### PR TITLE
Match all namespace divisions in internal workflows

### DIFF
--- a/common/searchattribute/defs.go
+++ b/common/searchattribute/defs.go
@@ -25,6 +25,7 @@
 package searchattribute
 
 import (
+	"fmt"
 	"strings"
 
 	enumspb "go.temporal.io/api/enums/v1"
@@ -68,6 +69,10 @@ const (
 	TemporalSchedulePaused = "TemporalSchedulePaused"
 
 	ReservedPrefix = "Temporal"
+
+	// Query clause that mentions TemporalNamespaceDivision to disable special handling of that
+	// search attribute in visibility.
+	matchAnyNamespaceDivision = TemporalNamespaceDivision + ` != "__never_used__"`
 )
 
 var (
@@ -201,4 +206,15 @@ func GetSqlDbIndexSearchAttributes() *persistencespb.IndexSearchAttributes {
 	return &persistencespb.IndexSearchAttributes{
 		CustomSearchAttributes: sqlDbCustomSearchAttributes,
 	}
+}
+
+// QueryWithAnyNamespaceDivision returns a modified workflow visibility query that disables
+// special handling of namespace division and so matches workflows in all namespace divisions.
+// Normally a query that didn't explicitly mention TemporalNamespaceDivision would be limited
+// to the default (empty string) namespace division.
+func QueryWithAnyNamespaceDivision(query string) string {
+	if strings.TrimSpace(query) == "" {
+		return matchAnyNamespaceDivision
+	}
+	return fmt.Sprintf(`(%s) AND (%s)`, query, matchAnyNamespaceDivision)
 }

--- a/common/searchattribute/defs.go
+++ b/common/searchattribute/defs.go
@@ -72,7 +72,7 @@ const (
 
 	// Query clause that mentions TemporalNamespaceDivision to disable special handling of that
 	// search attribute in visibility.
-	matchAnyNamespaceDivision = TemporalNamespaceDivision + ` != "__never_used__"`
+	matchAnyNamespaceDivision = TemporalNamespaceDivision + ` IS NULL OR ` + TemporalNamespaceDivision + ` IS NOT NULL`
 )
 
 var (

--- a/service/worker/deletenamespace/deleteexecutions/activities.go
+++ b/service/worker/deletenamespace/deleteexecutions/activities.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/searchattribute"
 )
 
 type (
@@ -110,6 +111,7 @@ func (a *LocalActivities) GetNextPageTokenActivity(ctx context.Context, params G
 		Namespace:     params.Namespace,
 		PageSize:      params.PageSize,
 		NextPageToken: params.NextPageToken,
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}
 
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
@@ -134,6 +136,7 @@ func (a *Activities) DeleteExecutionsActivity(ctx context.Context, params Delete
 		Namespace:     params.Namespace,
 		PageSize:      params.ListPageSize,
 		NextPageToken: params.NextPageToken,
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {

--- a/service/worker/deletenamespace/deleteexecutions/workflow_test.go
+++ b/service/worker/deletenamespace/deleteexecutions/workflow_test.go
@@ -46,6 +46,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/searchattribute"
 )
 
 func Test_DeleteExecutionsWorkflow_Success(t *testing.T) {
@@ -97,6 +98,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_NoExecutions(t *testing.T) {
 		Namespace:     "namespace",
 		PageSize:      1000,
 		NextPageToken: nil,
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions:    nil,
 		NextPageToken: nil,
@@ -265,6 +267,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_ManyExecutions(t *testing.T) 
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: nil,
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{
@@ -291,6 +294,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_ManyExecutions(t *testing.T) 
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: []byte{22, 8, 78},
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{
@@ -364,6 +368,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_HistoryClientError(t *testing
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: nil,
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{
@@ -390,6 +395,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_HistoryClientError(t *testing
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: []byte{22, 8, 78},
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{

--- a/service/worker/deletenamespace/reclaimresources/activities.go
+++ b/service/worker/deletenamespace/reclaimresources/activities.go
@@ -40,6 +40,7 @@ import (
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
+	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/service/worker/deletenamespace/errors"
 )
 
@@ -174,6 +175,7 @@ func (a *Activities) EnsureNoExecutionsStdVisibilityActivity(ctx context.Context
 		NamespaceID: nsID,
 		Namespace:   nsName,
 		PageSize:    1,
+		Query:       searchattribute.QueryWithAnyNamespaceDivision(""),
 	}
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {

--- a/service/worker/deletenamespace/reclaimresources/activities_test.go
+++ b/service/worker/deletenamespace/reclaimresources/activities_test.go
@@ -38,6 +38,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/searchattribute"
 )
 
 func Test_EnsureNoExecutionsAdvVisibilityActivity_NoExecutions(t *testing.T) {
@@ -125,6 +126,7 @@ func Test_EnsureNoExecutionsStdVisibilityActivity_NoExecutions(t *testing.T) {
 		NamespaceID: "namespace-id",
 		Namespace:   "namespace",
 		PageSize:    1,
+		Query:       searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{},
 	}, nil)
@@ -147,6 +149,7 @@ func Test_EnsureNoExecutionsStdVisibilityActivity_ExecutionsExist(t *testing.T) 
 		NamespaceID: "namespace-id",
 		Namespace:   "namespace",
 		PageSize:    1,
+		Query:       searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{{}},
 	}, nil)

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -55,6 +55,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/searchattribute"
 )
 
 type (
@@ -400,6 +401,9 @@ func (a *activities) UpdateActiveCluster(ctx context.Context, req updateActiveCl
 
 func (a *activities) ListWorkflows(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*listWorkflowsResponse, error) {
 	ctx = headers.SetCallerInfo(ctx, headers.NewCallerInfo(request.Namespace, headers.CallerTypePreemptable, ""))
+
+	// modify query to include all namespace divisions
+	request.Query = searchattribute.QueryWithAnyNamespaceDivision(request.Query)
 
 	resp, err := a.frontendClient.ListWorkflowExecutions(ctx, request)
 	if err != nil {

--- a/tests/functional_test_base.go
+++ b/tests/functional_test_base.go
@@ -36,6 +36,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/dgryski/go-farm"
@@ -109,8 +110,9 @@ func WithFxOptionsForService(serviceName primitives.ServiceName, options ...fx.O
 }
 
 func (s *FunctionalTestBase) setupSuite(defaultClusterConfigFile string, options ...Option) {
+	checkTestShard(s.T())
+
 	s.testClusterFactory = NewTestClusterFactory()
-	s.checkTestShard()
 
 	params := ApplyTestClusterParams(options)
 
@@ -194,31 +196,32 @@ func (s *FunctionalTestBase) setupLogger() {
 }
 
 // checkTestShard supports test sharding based on environment variables.
-func (s *FunctionalTestBase) checkTestShard() {
+func checkTestShard(t *testing.T) {
 	totalStr := os.Getenv("TEST_TOTAL_SHARDS")
 	indexStr := os.Getenv("TEST_SHARD_INDEX")
 	if totalStr == "" || indexStr == "" {
 		return
 	}
 	total, err := strconv.Atoi(totalStr)
-	s.NoError(err)
-	s.GreaterOrEqual(total, 1)
+	if err != nil || total < 1 {
+		t.Fatal("Couldn't convert TEST_TOTAL_SHARDS")
+	}
 	index, err := strconv.Atoi(indexStr)
-	s.NoError(err)
-	s.GreaterOrEqual(index, 0)
-	s.Less(index, total)
+	if err != nil || index < 0 || index >= total {
+		t.Fatal("Couldn't convert TEST_SHARD_INDEX")
+	}
 
 	// This was determined empirically to distribute our existing test names + run times
 	// reasonably well. This can be adjusted from time to time.
 	// For parallelism 4, use 11. For 3, use 26. For 2, use 20.
 	const salt = "-salt-26"
 
-	nameToHash := s.T().Name() + salt
+	nameToHash := t.Name() + salt
 	testIndex := int(farm.Fingerprint32([]byte(nameToHash))) % total
 	if testIndex != index {
-		s.T().Skipf("Skipping %s in test shard %d/%d (it runs in %d)", s.T().Name(), index, total, testIndex)
+		t.Skipf("Skipping %s in test shard %d/%d (it runs in %d)", t.Name(), index, total, testIndex)
 	}
-	s.T().Logf("Running %s in test shard %d/%d", s.T().Name(), index, total)
+	t.Logf("Running %s in test shard %d/%d", t.Name(), index, total)
 }
 
 // GetTestClusterConfig return test cluster config

--- a/tests/functional_test_base.go
+++ b/tests/functional_test_base.go
@@ -219,9 +219,9 @@ func checkTestShard(t *testing.T) {
 	nameToHash := t.Name() + salt
 	testIndex := int(farm.Fingerprint32([]byte(nameToHash))) % total
 	if testIndex != index {
-		t.Skipf("Skipping %s in test shard %d/%d (it runs in %d)", t.Name(), index, total, testIndex)
+		t.Skipf("Skipping %s in test shard %d/%d (it runs in %d)", t.Name(), index+1, total, testIndex+1)
 	}
-	t.Logf("Running %s in test shard %d/%d", t.Name(), index, total)
+	t.Logf("Running %s in test shard %d/%d", t.Name(), index+1, total)
 }
 
 // GetTestClusterConfig return test cluster config

--- a/tests/namespace_delete.go
+++ b/tests/namespace_delete.go
@@ -73,6 +73,8 @@ func dynamicConfig() map[dynamicconfig.Key]interface{} {
 }
 
 func (s *namespaceTestSuite) SetupSuite() {
+	checkTestShard(s.T())
+
 	s.logger = log.NewTestLogger()
 	s.testClusterFactory = NewTestClusterFactory()
 

--- a/tests/namespace_delete.go
+++ b/tests/namespace_delete.go
@@ -66,12 +66,6 @@ type (
 	}
 )
 
-func dynamicConfig() map[dynamicconfig.Key]interface{} {
-	return map[dynamicconfig.Key]interface{}{
-		dynamicconfig.DeleteNamespaceDeleteActivityRPS: 1000,
-	}
-}
-
 func (s *namespaceTestSuite) SetupSuite() {
 	checkTestShard(s.T())
 
@@ -91,7 +85,9 @@ func (s *namespaceTestSuite) SetupSuite() {
 		s.logger.Info("Running delete namespace tests with Elasticsearch persistence")
 	}
 
-	s.clusterConfig.DynamicConfigOverrides = dynamicConfig()
+	s.clusterConfig.DynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
+		dynamicconfig.DeleteNamespaceDeleteActivityRPS: 1000,
+	}
 
 	cluster, err := s.testClusterFactory.NewCluster(s.T(), s.clusterConfig, s.logger)
 	s.Require().NoError(err)

--- a/tests/schedule.go
+++ b/tests/schedule.go
@@ -306,7 +306,23 @@ func (s *ScheduleFunctionalSuite) TestBasics() {
 	s.WithinRange(ex0StartTime, createTime, time.Now())
 	s.True(ex0StartTime.UnixNano()%int64(5*time.Second) == 0)
 
-	// list workflows with namespace division (implementation details here, not public api)
+	// list with QueryWithAnyNamespaceDivision, we should see the scheduler workflow
+
+	wfResp, err = s.engine.ListWorkflowExecutions(NewContext(), &workflowservice.ListWorkflowExecutionsRequest{
+		Namespace: s.namespace,
+		PageSize:  5,
+		Query:     searchattribute.QueryWithAnyNamespaceDivision(`ExecutionStatus = "Running"`),
+	})
+	s.NoError(err)
+	count := 0
+	for _, ex := range wfResp.Executions {
+		if ex.Type.Name == scheduler.WorkflowType {
+			count++
+		}
+	}
+	s.EqualValues(1, count, "should see scheduler workflow")
+
+	// list workflows with an exact match on namespace division (implementation details here, not public api)
 
 	wfResp, err = s.engine.ListWorkflowExecutions(NewContext(), &workflowservice.ListWorkflowExecutionsRequest{
 		Namespace: s.namespace,

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -2313,6 +2313,10 @@ func (s *FunctionalClustersTestSuite) TestActivityHeartbeatFailover() {
 // }
 
 func (s *FunctionalClustersTestSuite) TestLocalNamespaceMigration() {
+	if !tests.UsingSQLAdvancedVisibility() {
+		s.T().Skip("Test requires advanced visibility")
+	}
+
 	testCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -2668,6 +2672,10 @@ func (s *FunctionalClustersTestSuite) TestLocalNamespaceMigration() {
 }
 
 func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
+	if !tests.UsingSQLAdvancedVisibility() {
+		s.T().Skip("Test requires advanced visibility")
+	}
+
 	testCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -2792,6 +2800,10 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
 }
 
 func (s *FunctionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
+	if !tests.UsingSQLAdvancedVisibility() {
+		s.T().Skip("Test requires advanced visibility")
+	}
+
 	testCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 

--- a/tests/xdc/user_data_replication_test.go
+++ b/tests/xdc/user_data_replication_test.go
@@ -175,6 +175,10 @@ func (s *UserDataReplicationTestSuite) TestUserDataIsReplicatedFromPassiveToActi
 }
 
 func (s *UserDataReplicationTestSuite) TestUserDataEntriesAreReplicatedOnDemand() {
+	if !tests.UsingSQLAdvancedVisibility() {
+		s.T().Skip("Test requires advanced visibility")
+	}
+
 	ctx := tests.NewContext()
 	namespace := s.T().Name() + "-" + common.GenerateRandomString(5)
 	activeFrontendClient := s.cluster1.GetFrontendClient()


### PR DESCRIPTION
## What changed?
Replacement for #4060 (can't reopen that one anymore).

Tweak ListWorkflows query in force-replication and delete namespace workflow to include other namespace divisions.

## Why?
These workflows have to operate on all workflows in a namespace regardless of namespace division.

## How did you test it?
tested queries manually, added check in schedule integration test
