### PR TITLE
Add Validation Of Search Attributes For The Scheduled Workflow

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2603,7 +2603,7 @@ func (wh *WorkflowHandler) CreateSchedule(ctx context.Context, request *workflow
 
 	err = wh.validateScheduledWorkflowSearchAttributes(request, namespaceName)
 	if err != nil {
-		return nil, fmt.Errorf("validating scheduled workflow search attributes:%v", err)
+		return nil, fmt.Errorf("validating scheduled workflow search attributes:%w", err)
 	}
 
 	inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(input)


### PR DESCRIPTION
## What changed?
Scheduled workflow search attributes validated on CreateSchedule request.

## Why?
User Request.

## How did you test it?
Run tests.

## Potential risks
Unknown.

## Is hotfix candidate?
No
