### PR TITLE
Include API name in fault injection error message

### DIFF
--- a/common/persistence/client/targeted_fault_injection.go
+++ b/common/persistence/client/targeted_fault_injection.go
@@ -47,7 +47,7 @@ func NewTargetedDataStoreErrorGenerator(cfg *config.FaultInjectionDataStoreConfi
 		var faultWeights []FaultWeight
 		methodErrRate := 0.0
 		for errName, errRate := range methodConfig.Errors {
-			err := newError(errName, errRate)
+			err := newError(errName, errRate, methodName)
 			faultWeights = append(faultWeights, FaultWeight{
 				errFactory: func(data string) error {
 					return err
@@ -100,18 +100,19 @@ func (d *dataStoreErrorGenerator) Generate() error {
 
 // newError returns an error based on the provided name. If the name is not recognized, then this method will
 // panic.
-func newError(errName string, errRate float64) error {
+func newError(errName string, errRate float64, methodName string) error {
+	header := fmt.Sprintf("fault injection error at %s with %.2f rate", methodName, errRate)
 	switch errName {
 	case "ShardOwnershipLost":
-		return &persistence.ShardOwnershipLostError{Msg: fmt.Sprintf("fault injection error (%f): persistence.ShardOwnershipLostError", errRate)}
+		return &persistence.ShardOwnershipLostError{Msg: fmt.Sprintf("%s: persistence.ShardOwnershipLostError", header)}
 	case "DeadlineExceeded":
-		return fmt.Errorf("fault injection error (%f): %w", errRate, context.DeadlineExceeded)
+		return fmt.Errorf("%s: %w", header, context.DeadlineExceeded)
 	case "ResourceExhausted":
-		return serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED, fmt.Sprintf("fault injection error (%f): serviceerror.ResourceExhausted", errRate))
+		return serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED, fmt.Sprintf("%s: serviceerror.ResourceExhausted", header))
 	case "Unavailable":
-		return serviceerror.NewUnavailable(fmt.Sprintf("fault injection error (%f): serviceerror.Unavailable", errRate))
+		return serviceerror.NewUnavailable(fmt.Sprintf("%s: serviceerror.Unavailable", header))
 	default:
-		panic(fmt.Sprintf("unknown error type: %v", errName))
+		panic(fmt.Sprintf("unsupported error type: %v", errName))
 	}
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Include API name in fault injection error message. Instead of 

`fault injection error (0.050000): context deadline exceeded`

it will say 

`fault injection error at ReadHistoryBranch with 0.05 rate: context deadline exceeded`.

## Why?
<!-- Tell your future self why have you made these changes -->
Simplify debugging.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.