### PR TITLE
Add persistence.TimeoutError support to fault injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,6 +502,9 @@ start: temporal-server
 start-es: temporal-server
 	./temporal-server --env development-cass-es --allow-no-auth start
 
+start-es-fi: temporal-server
+	./temporal-server --env development-cass-es-fi --allow-no-auth start
+
 start-mysql: temporal-server
 	./temporal-server --env development-mysql --allow-no-auth start
 

--- a/common/persistence/client/targeted_fault_injection.go
+++ b/common/persistence/client/targeted_fault_injection.go
@@ -106,7 +106,11 @@ func newError(errName string, errRate float64, methodName string) error {
 	case "ShardOwnershipLost":
 		return &persistence.ShardOwnershipLostError{Msg: fmt.Sprintf("%s: persistence.ShardOwnershipLostError", header)}
 	case "DeadlineExceeded":
+		// Real persistence store never returns context.DeadlineExceeded error. It returns persistence.TimeoutError instead.
+		// Therefor "DeadlineExceeded" shouldn't be used with fault injection. Use "Timeout" instead.
 		return fmt.Errorf("%s: %w", header, context.DeadlineExceeded)
+	case "Timeout":
+		return &persistence.TimeoutError{Msg: fmt.Sprintf("%s: persistence.TimeoutError", header)}
 	case "ResourceExhausted":
 		return serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED, fmt.Sprintf("%s: serviceerror.ResourceExhausted", header))
 	case "Unavailable":

--- a/config/development-cass-es-fi.yaml
+++ b/config/development-cass-es-fi.yaml
@@ -1,0 +1,138 @@
+log:
+  stdout: true
+  level: info
+
+persistence:
+  defaultStore: cass-default
+  visibilityStore: es-visibility
+  numHistoryShards: 4
+  datastores:
+    cass-default:
+      faultInjection:
+        targets:
+          dataStores:
+            ExecutionStore:
+              methods:
+                CreateWorkflowExecution:
+                  errors:
+                    ResourceExhausted: 0.05
+                    Timeout: 0.05
+                UpdateWorkflowExecution:
+                  errors:
+                    ResourceExhausted: 0.10
+                    Timeout: 0.05
+                GetWorkflowExecution:
+                  errors:
+                    ResourceExhausted: 0.05
+                    Timeout: 0.05
+                GetCurrentExecution:
+                  errors:
+                    ResourceExhausted: 0.05
+                    Timeout: 0.05
+                AppendHistoryNodes:
+                  errors:
+                    ResourceExhausted: 0.05
+                    Timeout: 0.05
+                ReadHistoryBranch:
+                  errors:
+                    ResourceExhausted: 0.05
+                    Timeout: 0.10
+      cassandra:
+        hosts: "127.0.0.1"
+        keyspace: "temporal"
+    es-visibility:
+      elasticsearch:
+        version: "v7"
+        logLevel: "error"
+        url:
+          scheme: "http"
+          host: "127.0.0.1:9200"
+        indices:
+          visibility: temporal_visibility_v1_dev
+          # secondary_visibility: temporal_visibility_v2_dev
+        closeIdleConnectionsInterval: 15s
+global:
+  membership:
+    maxJoinDuration: 30s
+    broadcastAddress: "127.0.0.1"
+  pprof:
+    port: 7936
+  metrics:
+    prometheus:
+#      # specify framework to use new approach for initializing metrics and/or use opentelemetry
+#      framework: "opentelemetry"
+      framework: "tally"
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
+
+services:
+  frontend:
+    rpc:
+      grpcPort: 7233
+      membershipPort: 6933
+      bindOnLocalHost: true
+      httpPort: 7243
+
+  matching:
+    rpc:
+      grpcPort: 7235
+      membershipPort: 6935
+      bindOnLocalHost: true
+
+  history:
+    rpc:
+      grpcPort: 7234
+      membershipPort: 6934
+      bindOnLocalHost: true
+
+  worker:
+    rpc:
+      grpcPort: 7239
+      membershipPort: 6939
+      bindOnLocalHost: true
+
+clusterMetadata:
+  enableGlobalNamespace: false
+  failoverVersionIncrement: 10
+  masterClusterName: "active"
+  currentClusterName: "active"
+  clusterInformation:
+    active:
+      enabled: true
+      initialFailoverVersion: 1
+      rpcName: "frontend"
+      rpcAddress: "localhost:7233"
+
+dcRedirectionPolicy:
+  policy: "noop"
+
+archival:
+  history:
+    state: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+      gstorage:
+        credentialsPath: "/tmp/gcloud/keyfile.json"
+  visibility:
+    state: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+
+namespaceDefaults:
+  archival:
+    history:
+      state: "disabled"
+      URI: "file:///tmp/temporal_archival/development"
+    visibility:
+      state: "disabled"
+      URI: "file:///tmp/temporal_vis_archival/development"
+
+dynamicConfigClient:
+  filepath: "config/dynamicconfig/development-cass.yaml"
+  pollInterval: "10s"


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add `persistence.TimeoutError` support to fault injection.

## Why?
<!-- Tell your future self why have you made these changes -->
Real persistence store never returns `context.DeadlineExceeded` error but returns `persistence.TimeoutError` instead.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run locally.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.