### PR TITLE
Migrate to reset reapply event type exclusions instead of inclusions

### DIFF
--- a/common/enums/defaults.go
+++ b/common/enums/defaults.go
@@ -66,7 +66,7 @@ func SetDefaultContinueAsNewInitiator(f *enumspb.ContinueAsNewInitiator) {
 
 func SetDefaultResetReapplyType(f *enumspb.ResetReapplyType) {
 	if *f == enumspb.RESET_REAPPLY_TYPE_UNSPECIFIED {
-		*f = enumspb.RESET_REAPPLY_TYPE_SIGNAL
+		*f = enumspb.RESET_REAPPLY_TYPE_ALL_ELIGIBLE
 	}
 }
 

--- a/service/history/api/reapplyevents/api.go
+++ b/service/history/api/reapplyevents/api.go
@@ -28,7 +28,6 @@ import (
 	"context"
 
 	"github.com/google/uuid"
-	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 
@@ -158,7 +157,7 @@ func Invoke(
 					),
 					ndc.EventsReapplicationResetWorkflowReason,
 					toReapplyEvents,
-					enumspb.RESET_REAPPLY_TYPE_SIGNAL,
+					nil,
 				)
 				switch err.(type) {
 				case *serviceerror.InvalidArgument:

--- a/service/history/api/resetworkflow/api.go
+++ b/service/history/api/resetworkflow/api.go
@@ -179,10 +179,10 @@ func Invoke(
 // field (a specification of what to include).
 func GetResetReapplyExcludeTypes(
 	excludeTypes []enumspb.ResetReapplyExcludeType,
-	includeSpec enumspb.ResetReapplyType,
-) []enumspb.ResetReapplyExcludeType {
-	excludeSet := map[enumspb.ResetReapplyExcludeType]bool{}
-	switch includeSpec {
+	includeType enumspb.ResetReapplyType,
+) map[enumspb.ResetReapplyExcludeType]bool {
+	exclude := map[enumspb.ResetReapplyExcludeType]bool{}
+	switch includeType {
 	case enumspb.RESET_REAPPLY_TYPE_SIGNAL:
 		// A client sending this value of the deprecated reset_reapply_type
 		// field will not have any events other than signal reapplied. We may
@@ -195,15 +195,10 @@ func GetResetReapplyExcludeTypes(
 		// TODO (dan) exclude update
 	case enumspb.RESET_REAPPLY_TYPE_NONE:
 		// TODO (dan) exclude update
-		excludeSet[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL] = true
+		exclude[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL] = true
 	}
 	for _, e := range excludeTypes {
-		excludeSet[e] = true
-	}
-
-	exclude := []enumspb.ResetReapplyExcludeType{}
-	for e := range excludeSet {
-		exclude = append(exclude, e)
+		exclude[e] = true
 	}
 	return exclude
 }

--- a/service/history/api/resetworkflow/api.go
+++ b/service/history/api/resetworkflow/api.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/uuid"
 	"go.temporal.io/api/serviceerror"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
@@ -163,11 +164,46 @@ func Invoke(
 		),
 		request.GetReason(),
 		nil,
-		request.GetResetReapplyType(),
+		GetResetReapplyExcludeTypes(request.GetResetReapplyExcludeTypes(), request.GetResetReapplyType()),
 	); err != nil {
 		return nil, err
 	}
 	return &historyservice.ResetWorkflowExecutionResponse{
 		RunId: resetRunID,
 	}, nil
+}
+
+// GetResetReapplyExcludeTypes computes the set of requested exclude types. It
+// uses the reset_reapply_exclude_types request field (a set of event types to
+// exclude from reapply), as well as the deprecated reset_reapply_type request
+// field (a specification of what to include).
+func GetResetReapplyExcludeTypes(
+	excludeTypes []enumspb.ResetReapplyExcludeType,
+	includeSpec enumspb.ResetReapplyType,
+) []enumspb.ResetReapplyExcludeType {
+	excludeSet := map[enumspb.ResetReapplyExcludeType]bool{}
+	switch includeSpec {
+	case enumspb.RESET_REAPPLY_TYPE_SIGNAL:
+		// A client sending this value of the deprecated reset_reapply_type
+		// field will not have any events other than signal reapplied. We may
+		// implement reapplication of event types other than signal in the
+		// future; any such event type should be added as an exclusion to this
+		// switch case. A client who wishes to have reapplication of all
+		// supported event types should not send the deprecated
+		// reset_reapply_type field (since its default value is
+		// RESET_REAPPLY_TYPE_ALL_ELIGIBLE).
+		// TODO (dan) exclude update
+	case enumspb.RESET_REAPPLY_TYPE_NONE:
+		// TODO (dan) exclude update
+		excludeSet[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL] = true
+	}
+	for _, e := range excludeTypes {
+		excludeSet[e] = true
+	}
+
+	exclude := []enumspb.ResetReapplyExcludeType{}
+	for e := range excludeSet {
+		exclude = append(exclude, e)
+	}
+	return exclude
 }

--- a/service/history/api/resetworkflow/api_test.go
+++ b/service/history/api/resetworkflow/api_test.go
@@ -47,7 +47,7 @@ func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
 			[]enums.ResetReapplyExcludeType{},
 			enums.RESET_REAPPLY_TYPE_ALL_ELIGIBLE,
 		),
-		[]enums.ResetReapplyExcludeType{},
+		map[enums.ResetReapplyExcludeType]bool{},
 	)
 	// Include all with one exclusion is one exclusion
 	s.Equal(
@@ -55,7 +55,7 @@ func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
 			[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
 			enums.RESET_REAPPLY_TYPE_ALL_ELIGIBLE,
 		),
-		[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+		map[enums.ResetReapplyExcludeType]bool{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: true},
 	)
 	// Include signal with no exclusions is no exclusions
 	s.Equal(
@@ -63,7 +63,7 @@ func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
 			[]enums.ResetReapplyExcludeType{},
 			enums.RESET_REAPPLY_TYPE_SIGNAL,
 		),
-		[]enums.ResetReapplyExcludeType{},
+		map[enums.ResetReapplyExcludeType]bool{},
 	)
 	// Include signal with exclude signal: exclude trumps deprecated include
 	s.Equal(
@@ -71,7 +71,7 @@ func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
 			[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
 			enums.RESET_REAPPLY_TYPE_SIGNAL,
 		),
-		[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+		map[enums.ResetReapplyExcludeType]bool{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: true},
 	)
 	// Include none with no exclusions is all excluded
 	s.Equal(
@@ -79,7 +79,7 @@ func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
 			[]enums.ResetReapplyExcludeType{},
 			enums.RESET_REAPPLY_TYPE_NONE,
 		),
-		[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+		map[enums.ResetReapplyExcludeType]bool{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: true},
 	)
 	// Include none with exclude signal is all excluded
 	s.Equal(
@@ -87,6 +87,6 @@ func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
 			[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
 			enums.RESET_REAPPLY_TYPE_NONE,
 		),
-		[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+		map[enums.ResetReapplyExcludeType]bool{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: true},
 	)
 }

--- a/service/history/api/resetworkflow/api_test.go
+++ b/service/history/api/resetworkflow/api_test.go
@@ -1,0 +1,92 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package resetworkflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/api/enums/v1"
+)
+
+type (
+	resetWorkflowSuite struct {
+		suite.Suite
+	}
+)
+
+func TestResetWorkflowSuite(t *testing.T) {
+	s := new(resetWorkflowSuite)
+	suite.Run(t, s)
+}
+
+func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
+	// Include all with no exclusions is no exclusions
+	s.Equal(
+		GetResetReapplyExcludeTypes(
+			[]enums.ResetReapplyExcludeType{},
+			enums.RESET_REAPPLY_TYPE_ALL_ELIGIBLE,
+		),
+		[]enums.ResetReapplyExcludeType{},
+	)
+	// Include all with one exclusion is one exclusion
+	s.Equal(
+		GetResetReapplyExcludeTypes(
+			[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+			enums.RESET_REAPPLY_TYPE_ALL_ELIGIBLE,
+		),
+		[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+	)
+	// Include signal with no exclusions is no exclusions
+	s.Equal(
+		GetResetReapplyExcludeTypes(
+			[]enums.ResetReapplyExcludeType{},
+			enums.RESET_REAPPLY_TYPE_SIGNAL,
+		),
+		[]enums.ResetReapplyExcludeType{},
+	)
+	// Include signal with exclude signal: exclude trumps deprecated include
+	s.Equal(
+		GetResetReapplyExcludeTypes(
+			[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+			enums.RESET_REAPPLY_TYPE_SIGNAL,
+		),
+		[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+	)
+	// Include none with no exclusions is all excluded
+	s.Equal(
+		GetResetReapplyExcludeTypes(
+			[]enums.ResetReapplyExcludeType{},
+			enums.RESET_REAPPLY_TYPE_NONE,
+		),
+		[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+	)
+	// Include none with exclude signal is all excluded
+	s.Equal(
+		GetResetReapplyExcludeTypes(
+			[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+			enums.RESET_REAPPLY_TYPE_NONE,
+		),
+		[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+	)
+}

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/pborman/uuid"
 	commonpb "go.temporal.io/api/common/v1"
-	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 
@@ -348,7 +347,7 @@ func (r *transactionMgrImpl) backfillWorkflowEventsReapply(
 			targetWorkflow,
 			EventsReapplicationResetWorkflowReason,
 			totalEvents,
-			enumspb.RESET_REAPPLY_TYPE_SIGNAL,
+			nil,
 		)
 		switch err.(type) {
 		case *serviceerror.InvalidArgument:

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -243,7 +243,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Closed
 		targetWorkflow,
 		EventsReapplicationResetWorkflowReason,
 		workflowEvents.Events,
-		enumspb.RESET_REAPPLY_TYPE_SIGNAL,
+		nil,
 	).Return(nil)
 
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), &persistence.GetCurrentExecutionRequest{
@@ -322,7 +322,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Closed_ResetF
 		targetWorkflow,
 		EventsReapplicationResetWorkflowReason,
 		workflowEvents.Events,
-		enumspb.RESET_REAPPLY_TYPE_SIGNAL,
+		nil,
 	).Return(serviceerror.NewInvalidArgument("reset fail"))
 
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), &persistence.GetCurrentExecutionRequest{

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -1,5 +1,4 @@
 // The MIT License
-
 //
 // Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
 //

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -73,7 +73,7 @@ type (
 			currentWorkflow Workflow,
 			resetReason string,
 			additionalReapplyEvents []*historypb.HistoryEvent,
-			resetReapplyExcludeTypes []enumspb.ResetReapplyExcludeType,
+			resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
 		) error
 	}
 
@@ -126,7 +126,7 @@ func (r *workflowResetterImpl) ResetWorkflow(
 	currentWorkflow Workflow,
 	resetReason string,
 	additionalReapplyEvents []*historypb.HistoryEvent,
-	resetReapplyExcludeTypes []enumspb.ResetReapplyExcludeType,
+	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
 ) (retError error) {
 
 	namespaceEntry, err := r.namespaceRegistry.GetNamespaceByID(namespaceID)
@@ -562,7 +562,7 @@ func (r *workflowResetterImpl) reapplyContinueAsNewWorkflowEvents(
 	baseBranchToken []byte,
 	baseRebuildNextEventID int64,
 	baseNextEventID int64,
-	resetReapplyExcludeTypes []enumspb.ResetReapplyExcludeType,
+	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
 ) (string, error) {
 
 	// TODO change this logic to fetching all workflow [baseWorkflow, currentWorkflow]
@@ -656,7 +656,7 @@ func (r *workflowResetterImpl) reapplyWorkflowEvents(
 	firstEventID int64,
 	nextEventID int64,
 	branchToken []byte,
-	resetReapplyExcludeTypes []enumspb.ResetReapplyExcludeType,
+	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
 ) (string, error) {
 
 	// TODO change this logic to fetching all workflow [baseWorkflow, currentWorkflow]
@@ -696,15 +696,9 @@ func (r *workflowResetterImpl) reapplyWorkflowEvents(
 func reapplyEvents(
 	mutableState workflow.MutableState,
 	events []*historypb.HistoryEvent,
-	resetReapplyExcludeTypes []enumspb.ResetReapplyExcludeType,
+	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
 ) error {
-	excludeSignal := false
-	for _, e := range resetReapplyExcludeTypes {
-		if e == enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL {
-			excludeSignal = true
-		}
-	}
-
+	excludeSignal := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL]
 	for _, event := range events {
 		switch event.GetEventType() {
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:

--- a/service/history/ndc/workflow_resetter_mock.go
+++ b/service/history/ndc/workflow_resetter_mock.go
@@ -62,15 +62,15 @@ func (m *MockWorkflowResetter) EXPECT() *MockWorkflowResetterMockRecorder {
 }
 
 // ResetWorkflow mocks base method.
-func (m *MockWorkflowResetter) ResetWorkflow(ctx context.Context, namespaceID namespace.ID, workflowID, baseRunID string, baseBranchToken []byte, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID int64, resetRunID, resetRequestID string, currentWorkflow Workflow, resetReason string, additionalReapplyEvents []*v10.HistoryEvent, resetReapplyType v1.ResetReapplyType) error {
+func (m *MockWorkflowResetter) ResetWorkflow(ctx context.Context, namespaceID namespace.ID, workflowID, baseRunID string, baseBranchToken []byte, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID int64, resetRunID, resetRequestID string, currentWorkflow Workflow, resetReason string, additionalReapplyEvents []*v10.HistoryEvent, resetReapplyExcludeTypes []v1.ResetReapplyExcludeType) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResetWorkflow", ctx, namespaceID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, resetReapplyType)
+	ret := m.ctrl.Call(m, "ResetWorkflow", ctx, namespaceID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, resetReapplyExcludeTypes)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ResetWorkflow indicates an expected call of ResetWorkflow.
-func (mr *MockWorkflowResetterMockRecorder) ResetWorkflow(ctx, namespaceID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, resetReapplyType interface{}) *gomock.Call {
+func (mr *MockWorkflowResetterMockRecorder) ResetWorkflow(ctx, namespaceID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, resetReapplyExcludeTypes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetWorkflow", reflect.TypeOf((*MockWorkflowResetter)(nil).ResetWorkflow), ctx, namespaceID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, resetReapplyType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetWorkflow", reflect.TypeOf((*MockWorkflowResetter)(nil).ResetWorkflow), ctx, namespaceID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, resetReapplyExcludeTypes)
 }

--- a/service/history/ndc/workflow_resetter_mock.go
+++ b/service/history/ndc/workflow_resetter_mock.go
@@ -62,7 +62,7 @@ func (m *MockWorkflowResetter) EXPECT() *MockWorkflowResetterMockRecorder {
 }
 
 // ResetWorkflow mocks base method.
-func (m *MockWorkflowResetter) ResetWorkflow(ctx context.Context, namespaceID namespace.ID, workflowID, baseRunID string, baseBranchToken []byte, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID int64, resetRunID, resetRequestID string, currentWorkflow Workflow, resetReason string, additionalReapplyEvents []*v10.HistoryEvent, resetReapplyExcludeTypes []v1.ResetReapplyExcludeType) error {
+func (m *MockWorkflowResetter) ResetWorkflow(ctx context.Context, namespaceID namespace.ID, workflowID, baseRunID string, baseBranchToken []byte, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID int64, resetRunID, resetRequestID string, currentWorkflow Workflow, resetReason string, additionalReapplyEvents []*v10.HistoryEvent, resetReapplyExcludeTypes map[v1.ResetReapplyExcludeType]bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetWorkflow", ctx, namespaceID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, resetReapplyExcludeTypes)
 	ret0, _ := ret[0].(error)

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -606,6 +606,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithOutCo
 		baseBranchToken,
 		baseFirstEventID,
 		baseNextEventID,
+		nil,
 	)
 	s.NoError(err)
 	s.Equal(s.baseRunID, lastVisitedRunID)
@@ -723,6 +724,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithConti
 		baseBranchToken,
 		baseFirstEventID,
 		baseNextEventID,
+		nil,
 	)
 	s.NoError(err)
 	s.Equal(newRunID, lastVisitedRunID)
@@ -783,6 +785,7 @@ func (s *workflowResetterSuite) TestReapplyWorkflowEvents() {
 		firstEventID,
 		nextEventID,
 		branchToken,
+		nil,
 	)
 	s.NoError(err)
 	s.Equal(newRunID, nextRunID)
@@ -831,7 +834,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 		}
 	}
 
-	err := s.workflowResetter.reapplyEvents(mutableState, events)
+	err := reapplyEvents(mutableState, events, nil)
 	s.NoError(err)
 }
 

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -1403,7 +1403,7 @@ func (t *transferQueueActiveTaskExecutor) resetWorkflow(
 		),
 		reason,
 		nil,
-		enumspb.RESET_REAPPLY_TYPE_SIGNAL,
+		nil,
 	)
 
 	switch err.(type) {

--- a/tests/reset_workflow.go
+++ b/tests/reset_workflow.go
@@ -353,16 +353,11 @@ func (s *FunctionalSuite) testResetWorkflowReapply(
 		}
 	}
 
-	var shouldReapplySignals = true
-	for _, excludeType := range resetworkflow.GetResetReapplyExcludeTypes(reapplyExcludeTypes, reapplyType) {
-		if excludeType == enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL {
-			shouldReapplySignals = false
-		}
-	}
-	if shouldReapplySignals {
-		s.Equal(totalSignals, signalCount)
-	} else {
+	resetReapplyExcludeTypes := resetworkflow.GetResetReapplyExcludeTypes(reapplyExcludeTypes, reapplyType)
+	if resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL] {
 		s.Equal(0, signalCount)
+	} else {
+		s.Equal(totalSignals, signalCount)
 	}
 }
 

--- a/tests/reset_workflow.go
+++ b/tests/reset_workflow.go
@@ -32,16 +32,17 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
-	"google.golang.org/protobuf/types/known/durationpb"
-
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/service/history/api/resetworkflow"
 )
 
 func (s *FunctionalSuite) TestResetWorkflow() {
@@ -201,30 +202,65 @@ func (s *FunctionalSuite) TestResetWorkflow() {
 	s.True(workflowComplete)
 }
 
-func (s *FunctionalSuite) TestResetWorkflow_ReapplyAll() {
-	workflowID := "functional-reset-workflow-test-reapply-all"
-	workflowTypeName := "functional-reset-workflow-test-reapply-all-type"
-	taskQueueName := "functional-reset-workflow-test-reapply-all-taskqueue"
-
-	s.testResetWorkflowReapply(workflowID, workflowTypeName, taskQueueName, 4, 3, enumspb.RESET_REAPPLY_TYPE_SIGNAL)
+func (s *FunctionalSuite) TestResetWorkflow_ExcludeNoneReapplyAll() {
+	s.testResetWorkflowReapply(
+		"exclude-none-reapply-all",
+		[]enumspb.ResetReapplyExcludeType{},
+		enumspb.RESET_REAPPLY_TYPE_ALL_ELIGIBLE,
+	)
 }
 
-func (s *FunctionalSuite) TestResetWorkflow_ReapplyNone() {
-	workflowID := "functional-reset-workflow-test-reapply-none"
-	workflowTypeName := "functional-reset-workflow-test-reapply-none-type"
-	taskQueueName := "functional-reset-workflow-test-reapply-none-taskqueue"
+func (s *FunctionalSuite) TestResetWorkflow_ExcludeNoneReapplySignal() {
+	s.testResetWorkflowReapply(
+		"exclude-none-reapply-signal",
+		[]enumspb.ResetReapplyExcludeType{},
+		enumspb.RESET_REAPPLY_TYPE_SIGNAL,
+	)
+}
 
-	s.testResetWorkflowReapply(workflowID, workflowTypeName, taskQueueName, 4, 3, enumspb.RESET_REAPPLY_TYPE_NONE)
+func (s *FunctionalSuite) TestResetWorkflow_ExcludeNoneReapplyNone() {
+	s.testResetWorkflowReapply(
+		"exclude-none-reapply-none",
+		[]enumspb.ResetReapplyExcludeType{},
+		enumspb.RESET_REAPPLY_TYPE_NONE,
+	)
+}
+
+func (s *FunctionalSuite) TestResetWorkflow_ExcludeSignalReapplyAll() {
+	s.testResetWorkflowReapply(
+		"exclude-signal-reapply-all",
+		[]enumspb.ResetReapplyExcludeType{enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+		enumspb.RESET_REAPPLY_TYPE_ALL_ELIGIBLE,
+	)
+}
+
+func (s *FunctionalSuite) TestResetWorkflow_ExcludeSignalReapplySignal() {
+	s.testResetWorkflowReapply(
+		"exclude-signal-reapply-signal",
+		[]enumspb.ResetReapplyExcludeType{enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+		enumspb.RESET_REAPPLY_TYPE_SIGNAL,
+	)
+}
+
+func (s *FunctionalSuite) TestResetWorkflow_ExcludeSignalReapplyNone() {
+	s.testResetWorkflowReapply(
+		"exclude-signal-reapply-none",
+		[]enumspb.ResetReapplyExcludeType{enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
+		enumspb.RESET_REAPPLY_TYPE_NONE,
+	)
 }
 
 func (s *FunctionalSuite) testResetWorkflowReapply(
-	workflowID string,
-	workflowTypeName string,
-	taskQueueName string,
-	resetToEventID int64,
-	totalSignals int,
+	testName string,
+	reapplyExcludeTypes []enumspb.ResetReapplyExcludeType,
 	reapplyType enumspb.ResetReapplyType,
 ) {
+	totalSignals := 3
+	resetToEventID := int64(totalSignals + 1)
+
+	workflowID := fmt.Sprintf("functional-reset-workflow-test-%s", testName)
+	workflowTypeName := fmt.Sprintf("functional-reset-workflow-test-%s-type", testName)
+	taskQueueName := fmt.Sprintf("functional-reset-workflow-test-%s-taskqueue", testName)
 	identity := "worker1"
 
 	workflowType := &commonpb.WorkflowType{Name: workflowTypeName}
@@ -247,35 +283,22 @@ func (s *FunctionalSuite) testResetWorkflowReapply(
 	s.NoError(err0)
 	runID := we.RunId
 
-	signalRequest := &workflowservice.SignalWorkflowExecutionRequest{
-		Namespace: s.namespace,
-		WorkflowExecution: &commonpb.WorkflowExecution{
-			WorkflowId: workflowID,
-			RunId:      runID,
-		},
-		SignalName: "random signal name",
-		Input: &commonpb.Payloads{Payloads: []*commonpb.Payload{{
-			Data: []byte("random data"),
-		}}},
-		Identity: identity,
-	}
-
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
 	// workflow logic
 	invocation := 0
-	completed := false
+	commandsCompleted := false
 	wtHandler := func(execution *commonpb.WorkflowExecution, wt *commonpb.WorkflowType,
 		previousStartedEventID, startedEventID int64, history *historypb.History) ([]*commandpb.Command, error) {
 
 		invocation++
+
+		// First invocation is first workflow task; then come `totalSignals` signals.
 		if invocation <= totalSignals {
-			// fist invocation is first workflow task,
-			// next few are triggered by signals
 			return []*commandpb.Command{}, nil
 		}
 
-		completed = true
+		commandsCompleted = true
 		return []*commandpb.Command{{
 			CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
 			Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
@@ -300,17 +323,8 @@ func (s *FunctionalSuite) testResetWorkflowReapply(
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	for i := 0; i < totalSignals; i++ {
-		signalRequest.RequestId = uuid.New()
-		_, err = s.engine.SignalWorkflowExecution(NewContext(), signalRequest)
-		s.NoError(err)
-
-		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
-		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
-		s.NoError(err)
-	}
-
-	s.True(completed)
+	s.testResetWorkflowReapplySendSignals(totalSignals, workflowID, runID, identity, poller)
+	s.True(commandsCompleted)
 
 	// reset
 	resp, err := s.engine.ResetWorkflowExecution(NewContext(), &workflowservice.ResetWorkflowExecutionRequest{
@@ -323,6 +337,7 @@ func (s *FunctionalSuite) testResetWorkflowReapply(
 		WorkflowTaskFinishEventId: resetToEventID,
 		RequestId:                 uuid.New(),
 		ResetReapplyType:          reapplyType,
+		ResetReapplyExcludeTypes:  reapplyExcludeTypes,
 	})
 	s.NoError(err)
 
@@ -338,15 +353,46 @@ func (s *FunctionalSuite) testResetWorkflowReapply(
 		}
 	}
 
-	switch reapplyType {
-	case enumspb.RESET_REAPPLY_TYPE_SIGNAL:
+	var shouldReapplySignals = true
+	for _, excludeType := range resetworkflow.GetResetReapplyExcludeTypes(reapplyExcludeTypes, reapplyType) {
+		if excludeType == enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL {
+			shouldReapplySignals = false
+		}
+	}
+	if shouldReapplySignals {
 		s.Equal(totalSignals, signalCount)
-	case enumspb.RESET_REAPPLY_TYPE_NONE:
+	} else {
 		s.Equal(0, signalCount)
-	default:
-		panic(fmt.Sprintf("unknown reset reapply type: %v", reapplyType))
+	}
+}
+
+func (s *FunctionalSuite) testResetWorkflowReapplySendSignals(
+	totalSignals int,
+	workflowId, runId, identity string,
+	poller *TaskPoller,
+) {
+	signalRequest := &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace: s.namespace,
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: workflowId,
+			RunId:      runId,
+		},
+		SignalName: "signal-name",
+		Input: &commonpb.Payloads{Payloads: []*commonpb.Payload{{
+			Data: []byte("random data"),
+		}}},
+		Identity: identity,
 	}
 
+	for i := 0; i < totalSignals; i++ {
+		signalRequest.RequestId = uuid.New()
+		_, err := s.engine.SignalWorkflowExecution(NewContext(), signalRequest)
+		s.NoError(err)
+
+		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
+		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
+		s.NoError(err)
+	}
 }
 
 func (s *FunctionalSuite) TestResetWorkflow_ReapplyBufferAll() {


### PR DESCRIPTION
## What changed?
- Start honoring the new `reset_reapply_exclude_types` request field added in https://github.com/temporalio/api/pull/348 
- Change all reapply codepaths to specify excluded event types rather than included
- Pass the set of excluded types further down the stack
- Delete a pointless helper function


## Why?
- We must honor the new request field because it is in the API and it is how we are going to control update reapply when we implement that
- The previous code was not future-proof: there were various codepaths passing `enumspb.RESET_REAPPLY_TYPE_SIGNAL` to mean "reapply everything". This PR changes those codepaths to pass an empty set of exclusions, which is robust to future additions of new reappliable event types.
- The actual work is done by `reapplyEvents`, and the excluded types had to be pushed all the way down the stack to this function. The previous code was pretty fragile: it checked that the caller had requested reapplication of signals and then let the downstream code reapply everything.

## How did you test it?
- Unit tests

## Potential risks
- It could break replication, and reset

## Is hotfix candidate?
- No
