### PR TITLE
Basic E2E done for callback processor

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -345,6 +345,8 @@ const (
 	FrontendEnableSchedules = "frontend.enableSchedules"
 	// FrontendEnableNexusHTTPHandler enables serving Nexus HTTP requests in the frontend.
 	FrontendEnableNexusHTTPHandler = "frontend.enableNexusHTTPHandler"
+	// FrontendEnableCallbackAttachment enables attaching callbacks to workflows.
+	FrontendEnableCallbackAttachment = "frontend.enableCallbackAttachment"
 	// FrontendMaxConcurrentBatchOperationPerNamespace is the max concurrent batch operation job count per namespace
 	FrontendMaxConcurrentBatchOperationPerNamespace = "frontend.MaxConcurrentBatchOperationPerNamespace"
 	// FrontendMaxExecutionCountBatchOperationPerNamespace is the max execution count batch operation supports per namespace
@@ -667,6 +669,8 @@ const (
 	// TransferQueueMaxReaderCount is the max number of readers in one multi-cursor transfer queue
 	TransferQueueMaxReaderCount = "history.transferQueueMaxReaderCount"
 
+	// CallbackProcessorEnabled enables starting the callback queue processor.
+	CallbackProcessorEnabled = "history.callbackProcessorEnabled"
 	// CallbackTaskBatchSize is batch size for callbackQueueFactory
 	CallbackTaskBatchSize = "history.callbackTaskBatchSize"
 	// CallbackProcessorMaxPollRPS is max poll rate per second for callbackQueueFactory

--- a/common/log/tag/values.go
+++ b/common/log/tag/values.go
@@ -112,6 +112,7 @@ var (
 	ComponentHistoryCache             = component("history-cache")
 	ComponentEventsCache              = component("events-cache")
 	ComponentTransferQueue            = component("transfer-queue-processor")
+	ComponentCallbackQueue            = component("callback-queue-processor")
 	ComponentVisibilityQueue          = component("visibility-queue-processor")
 	ComponentArchivalQueue            = component("archival-queue-processor")
 	ComponentTimerQueue               = component("timer-queue-processor")

--- a/common/persistence/persistence_metric_clients.go
+++ b/common/persistence/persistence_metric_clients.go
@@ -409,6 +409,8 @@ func (p *executionPersistenceClient) GetHistoryTasks(
 		operation = metrics.PersistenceGetReplicationTasksScope
 	case tasks.CategoryIDArchival:
 		operation = metrics.PersistenceGetArchivalTasksScope
+	case tasks.CategoryIDCallback:
+		operation = metrics.PersistenceGetCallbackTasksScope
 	default:
 		return nil, serviceerror.NewInternal(fmt.Sprintf("unknown task category type: %v", request.TaskCategory))
 	}
@@ -438,6 +440,8 @@ func (p *executionPersistenceClient) CompleteHistoryTask(
 		operation = metrics.PersistenceCompleteReplicationTaskScope
 	case tasks.CategoryIDArchival:
 		operation = metrics.PersistenceCompleteArchivalTaskScope
+	case tasks.CategoryIDCallback:
+		operation = metrics.PersistenceCompleteCallbackTasksScope
 	default:
 		return serviceerror.NewInternal(fmt.Sprintf("unknown task category type: %v", request.TaskCategory))
 	}
@@ -467,6 +471,8 @@ func (p *executionPersistenceClient) RangeCompleteHistoryTasks(
 		operation = metrics.PersistenceRangeCompleteReplicationTasksScope
 	case tasks.CategoryIDArchival:
 		operation = metrics.PersistenceRangeCompleteArchivalTasksScope
+	case tasks.CategoryIDCallback:
+		operation = metrics.PersistenceRangeCompleteCallbackTasksScope
 	default:
 		return serviceerror.NewInternal(fmt.Sprintf("unknown task category type: %v", request.TaskCategory))
 	}

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -33,6 +33,8 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/api"
@@ -331,12 +333,27 @@ func (ti *TelemetryInterceptor) handleError(
 	case *serviceerror.ResourceExhausted:
 		metricsHandler.Counter(metrics.ServiceErrResourceExhaustedCounter.Name()).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
 
-	// Any other errors are treated as ServiceFailures against SLA.
+	// Any other errors are treated as ServiceFailures against SLA unless constructed with the standard
+	// `status.Error` (or Errorf) constructors, in which case the status code is checked below.
 	// Including below known errors and any other unknown errors.
 	//  *serviceerror.DataLoss,
 	//  *serviceerror.Internal
 	//	*serviceerror.Unavailable:
 	default:
+		// Also skip emitting ServiceFailures for non serviceerrors returned from handlers for certain error
+		// codes.
+		if st, ok := status.FromError(err); ok {
+			switch st.Code() {
+			case codes.InvalidArgument,
+				codes.AlreadyExists,
+				codes.FailedPrecondition,
+				codes.OutOfRange,
+				codes.PermissionDenied,
+				codes.Unauthenticated,
+				codes.NotFound:
+				return
+			}
+		}
 		metricsHandler.Counter(metrics.ServiceFailures.Name()).Record(1)
 		ti.logger.Error("service failures", append(logTags, tag.Error(err))...)
 	}

--- a/common/tasks/dynamic_worker_pool_scheduler.go
+++ b/common/tasks/dynamic_worker_pool_scheduler.go
@@ -103,11 +103,10 @@ func (pool *DynamicWorkerPoolScheduler) TrySubmit(task Runnable) bool {
 		pool.mu.Unlock()
 		pool.wg.Done()
 		return enqueued
-	} else {
-		pool.runningGoroutines++
-		pool.mu.Unlock()
-		go pool.executeUntilBufferEmpty(task)
 	}
+	pool.runningGoroutines++
+	pool.mu.Unlock()
+	go pool.executeUntilBufferEmpty(task)
 	return true
 }
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -190,6 +190,9 @@ type Config struct {
 
 	// EnableNexusHTTPHandler controls whether to register a handler for Nexus HTTP requests.
 	EnableNexusHTTPHandler dynamicconfig.BoolPropertyFn
+
+	// EnableCallbackAttachment enables attaching callbacks to workflows.
+	EnableCallbackAttachment dynamicconfig.BoolPropertyFnWithNamespaceFilter
 }
 
 // NewConfig returns new service config with default values
@@ -288,7 +291,8 @@ func NewConfig(
 		AccessHistoryFraction:            dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 0.0),
 		AdminDeleteAccessHistoryFraction: dc.GetFloat64Property(dynamicconfig.FrontendAdminDeleteAccessHistoryFraction, 0.0),
 
-		EnableNexusHTTPHandler: dc.GetBoolProperty(dynamicconfig.FrontendEnableNexusHTTPHandler, false),
+		EnableNexusHTTPHandler:   dc.GetBoolProperty(dynamicconfig.FrontendEnableNexusHTTPHandler, false),
+		EnableCallbackAttachment: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableCallbackAttachment, false),
 	}
 }
 

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -228,6 +228,10 @@ func Invoke(
 	result.WorkflowExecutionInfo.SearchAttributes = &commonpb.SearchAttributes{
 		IndexedFields: clonePayloadMap(relocatableAttributes.SearchAttributes.GetIndexedFields()),
 	}
+	result.Callbacks = make([]*workflowpb.CallbackInfo, 0, len(mutableState.GetExecutionInfo().GetCallbacks()))
+	for _, callback := range mutableState.GetExecutionInfo().GetCallbacks() {
+		result.Callbacks = append(result.Callbacks, common.CloneProto(callback.PublicInfo))
+	}
 
 	return result, nil
 }

--- a/service/history/callback_queue_active_task_executor.go
+++ b/service/history/callback_queue_active_task_executor.go
@@ -59,7 +59,7 @@ type callbackQueueActiveTaskExecutor struct {
 	config            *configs.Config
 	payloadSerializer commonnexus.PayloadSerializer
 	clusterName       string
-	callerProvider    func(namespaceID, destination string) HTTPCaller
+	callerProvider    func(queues.NamespaceIDAndDestination) HTTPCaller
 }
 
 var _ queues.Executor = &callbackQueueActiveTaskExecutor{}
@@ -70,7 +70,7 @@ func newCallbackQueueActiveTaskExecutor(
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 	config *configs.Config,
-	callerProvider func(namespaceID, destination string) HTTPCaller,
+	callerProvider func(queues.NamespaceIDAndDestination) HTTPCaller,
 ) *callbackQueueActiveTaskExecutor {
 	return &callbackQueueActiveTaskExecutor{
 		taskExecutor: taskExecutor{
@@ -221,7 +221,7 @@ func (t *callbackQueueActiveTaskExecutor) processNexusCallbackTask(ctx context.C
 		return serviceerror.NewInternal(fmt.Sprintf("failed to construct Nexus request: %v", err))
 	}
 
-	caller := t.callerProvider(task.NamespaceID, task.DestinationAddress)
+	caller := t.callerProvider(queues.NamespaceIDAndDestination{NamespaceID: task.NamespaceID, Destination: task.DestinationAddress})
 	response, callErr := caller(request)
 	var callback *persistencespb.CallbackInfo
 	wfCtx, release, ms, err := t.getValidatedMutableStateForTask(

--- a/service/history/callback_queue_active_task_executor_test.go
+++ b/service/history/callback_queue_active_task_executor_test.go
@@ -294,7 +294,7 @@ func (s *callbackQueueActiveTaskExecutorSuite) newExecutor(caller HTTPCaller) *c
 		s.mockShard.GetLogger(),
 		s.mockShard.GetMetricsHandler(),
 		s.mockShard.GetConfig(),
-		func(namespaceID, destination string) HTTPCaller {
+		func(queues.NamespaceIDAndDestination) HTTPCaller {
 			return caller
 		},
 	)

--- a/service/history/callback_queue_factory.go
+++ b/service/history/callback_queue_factory.go
@@ -1,0 +1,245 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	"net/http"
+	"sync"
+
+	"go.uber.org/fx"
+
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/quotas"
+	ctasks "go.temporal.io/server/common/tasks"
+	"go.temporal.io/server/service/history/queues"
+	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tasks"
+	wcache "go.temporal.io/server/service/history/workflow/cache"
+)
+
+const callbackQueuePersistenceMaxRPSRatio = 0.3
+
+type callbackQueueFactoryParams struct {
+	fx.In
+
+	QueueFactoryBaseParams
+}
+
+type groupPool[K comparable, T any] struct {
+	mu        sync.RWMutex
+	pool      map[K]T
+	construct func(K) T
+}
+
+func newGroupPool[K comparable, T any](construct func(K) T) *groupPool[K, T] {
+	return &groupPool[K, T]{
+		construct: construct,
+		pool:      make(map[K]T, 0),
+	}
+}
+
+func (p *groupPool[K, T]) getOrCreate(key K) T {
+	p.mu.RLock()
+	value, ok := p.pool[key]
+	p.mu.RUnlock()
+	if !ok {
+		p.mu.Lock()
+		if value, ok = p.pool[key]; !ok {
+			value = p.construct(key)
+		}
+		p.mu.Unlock()
+	}
+
+	return value
+}
+
+// TODO: get actual limits from dynamic config.
+type groupLimiter struct {
+	key queues.NamespaceIDAndDestination
+}
+
+func (groupLimiter) BufferSize() int {
+	return 100
+}
+
+func (groupLimiter) Concurrency() int {
+	return 100
+}
+
+var _ ctasks.DynamicWorkerPoolLimiter = groupLimiter{}
+
+type callbackQueueFactory struct {
+	callbackQueueFactoryParams
+	hostReaderRateLimiter quotas.RequestRateLimiter
+	// Shared client pool for all shards in the host.
+	completionCallerPool *groupPool[queues.NamespaceIDAndDestination, HTTPCaller]
+	// Shared rate limiter pool for all shards in the host.
+	rateLimiterPool *groupPool[queues.NamespaceIDAndDestination, quotas.RateLimiter]
+	// Shared scheduler across all shards in the host.
+	hostScheduler queues.Scheduler
+}
+
+func NewCallbackQueueFactory(params callbackQueueFactoryParams) QueueFactory {
+	rateLimiterPool := newGroupPool(func(queues.NamespaceIDAndDestination) quotas.RateLimiter {
+		// TODO: get this value from dynamic config.
+		return quotas.NewDefaultOutgoingRateLimiter(func() float64 { return 100.0 })
+	})
+	grouper := queues.GrouperNamespaceIDAndDestination{}
+	f := &callbackQueueFactory{
+		callbackQueueFactoryParams: params,
+		hostReaderRateLimiter: queues.NewReaderPriorityRateLimiter(
+			NewHostRateLimiterRateFn(
+				params.Config.CallbackProcessorMaxPollHostRPS,
+				params.Config.PersistenceMaxQPS,
+				callbackQueuePersistenceMaxRPSRatio,
+			),
+			int64(params.Config.CallbackQueueMaxReaderCount()),
+		),
+		completionCallerPool: newGroupPool(func(queues.NamespaceIDAndDestination) HTTPCaller {
+			// In the future, we'll want to support HTTP2 clients as well.
+			client := &http.Client{}
+			return client.Do
+		}),
+		hostScheduler: &queues.CommonSchedulerWrapper{
+			Scheduler: ctasks.NewGroupByScheduler[queues.NamespaceIDAndDestination, queues.Executable](
+				ctasks.GroupBySchedulerOptions[queues.NamespaceIDAndDestination, queues.Executable]{
+					Logger: params.Logger,
+					KeyFn:  func(e queues.Executable) queues.NamespaceIDAndDestination { return grouper.KeyTyped(e.GetTask()) },
+					RunnableFactory: func(e queues.Executable) ctasks.Runnable {
+						return ctasks.RateLimitedTaskRunnable{
+							Limiter:  rateLimiterPool.getOrCreate(grouper.KeyTyped(e.GetTask())),
+							Runnable: ctasks.RunnableTask{Task: e},
+						}
+					},
+					SchedulerFactory: func(key queues.NamespaceIDAndDestination) ctasks.RunnableScheduler {
+						return ctasks.NewDynamicWorkerPoolScheduler(groupLimiter{key})
+					},
+				},
+			),
+			TaskKeyFn: func(e queues.Executable) queues.TaskChannelKey {
+				// This key is used by the rescheduler and does not support destinations.
+				// Destination is intentionally ignored here.
+				return queues.TaskChannelKey{NamespaceID: e.GetNamespaceID(), Priority: e.GetPriority()}
+			},
+		},
+	}
+	return f
+}
+
+// Start implements QueueFactory.
+func (f *callbackQueueFactory) Start() {
+	f.hostScheduler.Start()
+}
+
+// Stop implements QueueFactory.
+func (f *callbackQueueFactory) Stop() {
+	f.hostScheduler.Stop()
+}
+
+func (f *callbackQueueFactory) CreateQueue(
+	shardContext shard.Context,
+	workflowCache wcache.Cache,
+) queues.Queue {
+	logger := log.With(shardContext.GetLogger(), tag.ComponentCallbackQueue)
+	metricsHandler := f.MetricsHandler.WithTags(metrics.OperationTag(metrics.OperationCallbackQueueProcessorScope))
+
+	currentClusterName := f.ClusterMetadata.GetCurrentClusterName()
+
+	rescheduler := queues.NewRescheduler(
+		f.hostScheduler,
+		shardContext.GetTimeSource(),
+		logger,
+		metricsHandler,
+	)
+
+	activeExecutor := newCallbackQueueActiveTaskExecutor(
+		shardContext,
+		workflowCache,
+		logger,
+		metricsHandler,
+		f.Config,
+		f.completionCallerPool.getOrCreate,
+	)
+
+	// not implemented yet
+	standbyExecutor := &callbackQueueStandbyTaskExecutor{}
+
+	executor := queues.NewActiveStandbyExecutor(
+		currentClusterName,
+		f.NamespaceRegistry,
+		activeExecutor,
+		standbyExecutor,
+		logger,
+	)
+
+	if f.ExecutorWrapper != nil {
+		executor = f.ExecutorWrapper.Wrap(executor)
+	}
+
+	factory := queues.NewExecutableFactory(
+		executor,
+		f.hostScheduler,
+		rescheduler,
+		queues.NewNoopPriorityAssigner(),
+		shardContext.GetTimeSource(),
+		shardContext.GetNamespaceRegistry(),
+		shardContext.GetClusterMetadata(),
+		logger,
+		metricsHandler,
+		f.DLQWriter,
+		f.Config.TaskDLQEnabled,
+		f.Config.TaskDLQUnexpectedErrorAttempts,
+		f.Config.TaskDLQInternalErrors,
+	)
+	return queues.NewImmediateQueue(
+		shardContext,
+		tasks.CategoryCallback,
+		f.hostScheduler,
+		rescheduler,
+		&queues.Options{
+			ReaderOptions: queues.ReaderOptions{
+				BatchSize:            f.Config.CallbackTaskBatchSize,
+				MaxPendingTasksCount: f.Config.QueuePendingTaskMaxCount,
+				PollBackoffInterval:  f.Config.CallbackProcessorPollBackoffInterval,
+			},
+			MonitorOptions: queues.MonitorOptions{
+				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,
+				ReaderStuckCriticalAttempts: f.Config.QueueReaderStuckCriticalAttempts,
+				SliceCountCriticalThreshold: f.Config.QueueCriticalSlicesCount,
+			},
+			MaxPollRPS:                          f.Config.CallbackProcessorMaxPollRPS,
+			MaxPollInterval:                     f.Config.CallbackProcessorMaxPollInterval,
+			MaxPollIntervalJitterCoefficient:    f.Config.CallbackProcessorMaxPollIntervalJitterCoefficient,
+			CheckpointInterval:                  f.Config.CallbackProcessorUpdateAckInterval,
+			CheckpointIntervalJitterCoefficient: f.Config.CallbackProcessorUpdateAckIntervalJitterCoefficient,
+			MaxReaderCount:                      f.Config.CallbackQueueMaxReaderCount,
+		},
+		f.hostReaderRateLimiter,
+		queues.GrouperNamespaceIDAndDestination{},
+		logger,
+		metricsHandler,
+		factory,
+	)
+}

--- a/service/history/callback_queue_standby_task_executor.go
+++ b/service/history/callback_queue_standby_task_executor.go
@@ -1,0 +1,38 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	"context"
+
+	"go.temporal.io/server/service/history/queues"
+)
+
+type callbackQueueStandbyTaskExecutor struct {
+}
+
+func (*callbackQueueStandbyTaskExecutor) Execute(context.Context, queues.Executable) queues.ExecuteResponse {
+	panic("unimplemented")
+}
+
+var _ queues.Executor = &callbackQueueStandbyTaskExecutor{}

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -153,6 +153,7 @@ type Config struct {
 	TransferQueueMaxReaderCount                         dynamicconfig.IntPropertyFn
 
 	// CallbackQueueProcessor settings
+	CallbackProcessorEnabled                            dynamicconfig.BoolPropertyFn
 	CallbackTaskBatchSize                               dynamicconfig.IntPropertyFn
 	CallbackProcessorMaxPollRPS                         dynamicconfig.IntPropertyFn
 	CallbackProcessorMaxPollHostRPS                     dynamicconfig.IntPropertyFn

--- a/service/history/queue_factory_base.go
+++ b/service/history/queue_factory_base.go
@@ -140,15 +140,19 @@ type additionalQueueFactories struct {
 // is why we must return a list here.
 func getOptionalQueueFactories(
 	registry tasks.TaskCategoryRegistry,
-	params ArchivalQueueFactoryParams,
+	archivalParams ArchivalQueueFactoryParams,
+	callbackParams callbackQueueFactoryParams,
+	config *configs.Config,
 ) additionalQueueFactories {
-	if _, ok := registry.GetCategoryByID(tasks.CategoryIDArchival); !ok {
-		return additionalQueueFactories{}
+	factories := []QueueFactory{}
+	if _, ok := registry.GetCategoryByID(tasks.CategoryIDArchival); ok {
+		factories = append(factories, NewArchivalQueueFactory(archivalParams))
+	}
+	if _, ok := registry.GetCategoryByID(tasks.CategoryIDCallback); ok {
+		factories = append(factories, NewCallbackQueueFactory(callbackParams))
 	}
 	return additionalQueueFactories{
-		Factories: []QueueFactory{
-			NewArchivalQueueFactory(params),
-		},
+		Factories: factories,
 	}
 }
 

--- a/service/history/queues/grouper.go
+++ b/service/history/queues/grouper.go
@@ -53,32 +53,36 @@ func (GrouperNamespaceID) Predicate(keys []any) tasks.Predicate {
 
 var _ Grouper = GrouperNamespaceID{}
 
-// namespaceIDAndDestination is the key for grouping tasks by namespace ID and destination.
-type namespaceIDAndDestination struct {
-	namespaceID string
-	destination string
+// NamespaceIDAndDestination is the key for grouping tasks by namespace ID and destination.
+type NamespaceIDAndDestination struct {
+	NamespaceID string
+	Destination string
 }
 
 type GrouperNamespaceIDAndDestination struct {
 }
 
-func (GrouperNamespaceIDAndDestination) Key(task tasks.Task) (key any) {
+func (g GrouperNamespaceIDAndDestination) Key(task tasks.Task) (key any) {
+	return g.KeyTyped(task)
+}
+
+func (GrouperNamespaceIDAndDestination) KeyTyped(task tasks.Task) (key NamespaceIDAndDestination) {
 	getter, ok := task.(tasks.HasDestination)
 	var dest string
 	if ok {
 		dest = getter.GetDestination()
 	}
-	return namespaceIDAndDestination{task.GetNamespaceID(), dest}
+	return NamespaceIDAndDestination{task.GetNamespaceID(), dest}
 }
 
 func (GrouperNamespaceIDAndDestination) Predicate(keys []any) tasks.Predicate {
 	pred := predicates.Empty[tasks.Task]()
 	for _, anyKey := range keys {
 		// Assume predicate is only called with keys returned from GrouperNamespaceID.Key()
-		key := anyKey.(namespaceIDAndDestination)
+		key := anyKey.(NamespaceIDAndDestination)
 		pred = predicates.Or(pred, predicates.And(
-			tasks.NewNamespacePredicate([]string{key.namespaceID}),
-			tasks.NewDestinationPredicate([]string{key.destination}),
+			tasks.NewNamespacePredicate([]string{key.NamespaceID}),
+			tasks.NewDestinationPredicate([]string{key.Destination}),
 		))
 	}
 	return pred

--- a/service/history/queues/grouper_test.go
+++ b/service/history/queues/grouper_test.go
@@ -51,12 +51,12 @@ func TestGrouperNamespaceIDAndDestination_Key(t *testing.T) {
 		Destination: "dest",
 	}
 	k := g.Key(task)
-	require.Equal(t, namespaceIDAndDestination{"nid", "dest"}, k)
+	require.Equal(t, NamespaceIDAndDestination{"nid", "dest"}, k)
 }
 
 func TestGrouperNamespaceIDAndDestination_Predicate(t *testing.T) {
 	g := GrouperNamespaceIDAndDestination{}
-	p := g.Predicate([]any{namespaceIDAndDestination{"n1", "d1"}, namespaceIDAndDestination{"n2", "d2"}})
+	p := g.Predicate([]any{NamespaceIDAndDestination{"n1", "d1"}, NamespaceIDAndDestination{"n2", "d2"}})
 	expected := predicates.Or(
 		predicates.And(
 			tasks.NewNamespacePredicate([]string{"n1"}),

--- a/service/history/queues/scheduler.go
+++ b/service/history/queues/scheduler.go
@@ -193,6 +193,17 @@ func (s *schedulerImpl) TaskChannelKeyFn() TaskChannelKeyFn {
 	return s.taskChannelKeyFn
 }
 
+// CommonSchedulerWrapper is an adapter that converts a common [task.Scheduler] to a [Scheduler] with an injectable
+// TaskChannelKeyFn.
+type CommonSchedulerWrapper struct {
+	tasks.Scheduler[Executable]
+	TaskKeyFn func(e Executable) TaskChannelKey
+}
+
+func (s *CommonSchedulerWrapper) TaskChannelKeyFn() TaskChannelKeyFn {
+	return s.TaskKeyFn
+}
+
 func NewRateLimitedScheduler(
 	baseScheduler Scheduler,
 	options RateLimitedSchedulerOptions,

--- a/service/history/task_executor_test.go
+++ b/service/history/task_executor_test.go
@@ -94,14 +94,12 @@ func (s *taskExecutorSuite) SetupTest() {
 		config,
 		s.timeSource,
 	)
-	s.mockShard.SetEventsCacheForTesting(events.NewEventsCache(
-		s.mockShard.GetShardID(),
-		s.mockShard.GetConfig().EventsCacheMaxSizeBytes(),
-		s.mockShard.GetConfig().EventsCacheTTL(),
+	s.mockShard.SetEventsCacheForTesting(events.NewHostLevelEventsCache(
 		s.mockShard.GetExecutionManager(),
-		false,
-		s.mockShard.GetLogger(),
+		s.mockShard.GetConfig(),
 		s.mockShard.GetMetricsHandler(),
+		s.mockShard.GetLogger(),
+		false,
 	))
 	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig())
 

--- a/service/history/tasks/task_category_registry.go
+++ b/service/history/tasks/task_category_registry.go
@@ -58,8 +58,6 @@ func NewDefaultTaskCategoryRegistry() *MutableTaskCategoryRegistry {
 			CategoryVisibility.ID():  CategoryVisibility,
 			CategoryReplication.ID(): CategoryReplication,
 			CategoryMemoryTimer.ID(): CategoryMemoryTimer,
-			// TODO: register this when processing is implemented:
-			// CategoryCallback.ID():    CategoryCallback,
 		},
 	}
 }

--- a/service/history/tasks/utils.go
+++ b/service/history/tasks/utils.go
@@ -120,8 +120,6 @@ func GetTimerTaskEventID(
 		eventID = common.FirstEventID
 	case *DeleteHistoryEventTask:
 		eventID = common.FirstEventID
-	case *CallbackBackoffTask:
-		eventID = common.FirstEventID
 	case *FakeTask:
 		// no-op
 	default:

--- a/temporal/fx_test.go
+++ b/temporal/fx_test.go
@@ -35,6 +35,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/tasks"
@@ -132,6 +133,7 @@ func TestTaskCategoryRegistryProvider(t *testing.T) {
 		historyState           archiver.ArchivalState
 		visibilityState        archiver.ArchivalState
 		expectArchivalCategory bool
+		expectCallbackCategory bool
 	}{
 		{
 			name:                   "both disabled",
@@ -157,6 +159,13 @@ func TestTaskCategoryRegistryProvider(t *testing.T) {
 			visibilityState:        archiver.ArchivalEnabled,
 			expectArchivalCategory: true,
 		},
+		{
+			name:                   "callbacks enabled, archival disabled",
+			historyState:           archiver.ArchivalDisabled,
+			visibilityState:        archiver.ArchivalDisabled,
+			expectArchivalCategory: false,
+			expectCallbackCategory: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
@@ -167,13 +176,17 @@ func TestTaskCategoryRegistryProvider(t *testing.T) {
 			visibilityArchivalConfig := archiver.NewMockArchivalConfig(ctrl)
 			visibilityArchivalConfig.EXPECT().StaticClusterState().Return(tc.visibilityState).AnyTimes()
 			archivalMetadata.EXPECT().GetVisibilityConfig().Return(visibilityArchivalConfig).AnyTimes()
-			registry := TaskCategoryRegistryProvider(archivalMetadata)
+			dcClient := dynamicconfig.StaticClient{dynamicconfig.CallbackProcessorEnabled: tc.expectCallbackCategory}
+			dcc := dynamicconfig.NewCollection(dcClient, log.NewNoopLogger())
+			registry := TaskCategoryRegistryProvider(archivalMetadata, dcc)
 			_, ok := registry.GetCategoryByID(tasks.CategoryIDArchival)
 			if tc.expectArchivalCategory {
 				require.True(t, ok)
 			} else {
 				require.False(t, ok)
 			}
+			_, ok = registry.GetCategoryByID(tasks.CategoryIDCallback)
+			require.Equal(t, tc.expectCallbackCategory, ok)
 		})
 	}
 }

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -1,0 +1,238 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/pborman/uuid"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/internal/temporalite"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type completionHandler struct {
+	requestCh         chan *nexus.CompletionRequest
+	requestCompleteCh chan error
+}
+
+func (h *completionHandler) CompleteOperation(ctx context.Context, request *nexus.CompletionRequest) error {
+	h.requestCh <- request
+	return <-h.requestCompleteCh
+}
+
+func (s *FunctionalSuite) runNexusCompletionHTTPServer(h *completionHandler, listenAddr string) func() error {
+	hh := nexus.NewCompletionHTTPHandler(nexus.CompletionHandlerOptions{Handler: h})
+	srv := &http.Server{Addr: listenAddr, Handler: hh}
+	listener, err := net.Listen("tcp", listenAddr)
+	s.NoError(err)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Serve(listener)
+	}()
+
+	return func() error {
+		// Graceful shutdown
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			return err
+		}
+		if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	}
+}
+
+func (s *FunctionalSuite) TestWorkflowCallbacks_InvalidArgument() {
+	ctx := NewContext()
+	taskQueue := s.randomizeStr(s.T().Name())
+	workflowType := "test"
+
+	cases := []struct {
+		name, url, message string
+		allow              bool
+	}{
+		{
+			name:    "disabled",
+			url:     "http://some-ignored-address",
+			allow:   false,
+			message: "attaching workflow callbacks is disabled for this namespace",
+		},
+		{
+			name:    "invalid-scheme",
+			url:     "invalid",
+			allow:   true,
+			message: "invalid url scheme for url: invalid",
+		},
+	}
+
+	dc := s.testCluster.host.dcClient
+	defer dc.RemoveOverride(dynamicconfig.FrontendEnableCallbackAttachment)
+
+	for _, tc := range cases {
+		tc := tc
+		// TODO: use sdkClient when callbacks are exposed
+		s.T().Run(tc.name, func(t *testing.T) {
+			dc.OverrideValue(s.T(), dynamicconfig.FrontendEnableCallbackAttachment, tc.allow)
+			request := &workflowservice.StartWorkflowExecutionRequest{
+				RequestId:          uuid.New(),
+				Namespace:          s.namespace,
+				WorkflowId:         s.randomizeStr(s.T().Name()),
+				WorkflowType:       &commonpb.WorkflowType{Name: workflowType},
+				TaskQueue:          &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				Input:              nil,
+				WorkflowRunTimeout: durationpb.New(100 * time.Second),
+				Identity:           s.T().Name(),
+				CompletionCallbacks: []*commonpb.Callback{
+					{
+						Variant: &commonpb.Callback_Nexus_{
+							Nexus: &commonpb.Callback_Nexus{
+								Url: tc.url,
+							},
+						},
+					},
+				},
+			}
+
+			_, err := s.engine.StartWorkflowExecution(ctx, request)
+			var invalidArgument *serviceerror.InvalidArgument
+			s.ErrorAs(err, &invalidArgument)
+			s.Equal(tc.message, err.Error())
+		})
+	}
+}
+
+func (s *FunctionalSuite) TestWorkflowNexusCallbacks_CarriedOverContinueAsNew() {
+	dc := s.testCluster.host.dcClient
+	dc.OverrideValue(s.T(), dynamicconfig.FrontendEnableCallbackAttachment, true)
+	defer dc.RemoveOverride(dynamicconfig.FrontendEnableCallbackAttachment)
+
+	ctx := NewContext()
+	sdkClient, err := client.Dial(client.Options{
+		HostPort:  s.testCluster.GetHost().FrontendGRPCAddress(),
+		Namespace: s.namespace,
+	})
+	s.NoError(err)
+	pp := temporalite.NewPortProvider()
+
+	taskQueue := s.randomizeStr(s.T().Name())
+	workflowType := "test"
+
+	w := worker.New(sdkClient, taskQueue, worker.Options{})
+	wf := func(ctx workflow.Context) (int, error) {
+		// Verify that the callback is carried over the CAN boundary.
+		if workflow.GetInfo(ctx).ContinuedExecutionRunID == "" {
+			return 0, workflow.NewContinueAsNewError(ctx, workflowType)
+		}
+		return 666, nil
+	}
+	ch := &completionHandler{
+		requestCh:         make(chan *nexus.CompletionRequest, 1),
+		requestCompleteCh: make(chan error, 1),
+	}
+	callbackAddress := fmt.Sprintf("localhost:%d", pp.MustGetFreePort())
+	s.NoError(pp.Close())
+	shutdownServer := s.runNexusCompletionHTTPServer(ch, callbackAddress)
+	defer shutdownServer() // Ignoring shutdown errors, they don't affect the test.
+	w.RegisterWorkflowWithOptions(wf, workflow.RegisterOptions{Name: workflowType})
+	s.NoError(w.Start())
+	defer w.Stop()
+
+	// TODO: use sdkClient instead of directly calling the history engine when callbacks are exposed
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:          uuid.New(),
+		Namespace:          s.namespace,
+		WorkflowId:         s.randomizeStr(s.T().Name()),
+		WorkflowType:       &commonpb.WorkflowType{Name: workflowType},
+		TaskQueue:          &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Input:              nil,
+		WorkflowRunTimeout: durationpb.New(100 * time.Second),
+		Identity:           s.T().Name(),
+		CompletionCallbacks: []*commonpb.Callback{
+			{
+				Variant: &commonpb.Callback_Nexus_{
+					Nexus: &commonpb.Callback_Nexus{
+						Url: "http://" + callbackAddress,
+					},
+				},
+			},
+		},
+	}
+
+	_, err = s.engine.StartWorkflowExecution(ctx, request)
+	s.NoError(err)
+
+	run := sdkClient.GetWorkflow(ctx, request.WorkflowId, "")
+	s.NoError(run.Get(ctx, nil))
+
+	numAttempts := 2
+	for attempt := 1; attempt <= numAttempts; attempt++ {
+		completion := <-ch.requestCh
+		s.Equal(nexus.OperationStateSucceeded, completion.State)
+		var result int
+		s.NoError(completion.Result.Consume(&result))
+		s.Equal(666, result)
+		var err error
+		if attempt < numAttempts {
+			// force retry
+			err = nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "intentional error")
+		}
+		ch.requestCompleteCh <- err
+		s.Eventually(func() bool {
+			description, err := sdkClient.DescribeWorkflowExecution(ctx, request.WorkflowId, "")
+			s.NoError(err)
+			s.Equal(1, len(description.Callbacks))
+			callbackInfo := description.Callbacks[0]
+			s.ProtoEqual(request.CompletionCallbacks[0], callbackInfo.Callback)
+			s.ProtoEqual(&workflowpb.CallbackInfo_Trigger{Variant: &workflowpb.CallbackInfo_Trigger_WorkflowClosed{WorkflowClosed: &workflowpb.CallbackInfo_WorkflowClosed{}}}, callbackInfo.Trigger)
+			s.Equal(int32(attempt), callbackInfo.Attempt)
+			if attempt < numAttempts {
+				s.Equal(enumspb.CALLBACK_STATE_BACKING_OFF, callbackInfo.State)
+				s.Equal("request failed with: 500 Internal Server Error", callbackInfo.LastAttemptFailure.Message)
+			} else {
+				s.Equal(enumspb.CALLBACK_STATE_SUCCEEDED, callbackInfo.State)
+				s.Nil(callbackInfo.LastAttemptFailure)
+			}
+			return true
+		}, time.Second, time.Millisecond*100)
+	}
+}

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -172,7 +172,12 @@ func (s *FunctionalSuite) TestWorkflowNexusCallbacks_CarriedOverContinueAsNew() 
 	callbackAddress := fmt.Sprintf("localhost:%d", pp.MustGetFreePort())
 	s.NoError(pp.Close())
 	shutdownServer := s.runNexusCompletionHTTPServer(ch, callbackAddress)
-	defer shutdownServer() // Ignoring shutdown errors, they don't affect the test.
+	defer func() {
+		err := shutdownServer()
+		if err != nil {
+			panic(err)
+		}
+	}()
 	w.RegisterWorkflowWithOptions(wf, workflow.RegisterOptions{Name: workflowType})
 	s.NoError(w.Start())
 	defer w.Stop()

--- a/tests/functional.go
+++ b/tests/functional.go
@@ -55,6 +55,7 @@ func (s *FunctionalSuite) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
 		dynamicconfig.RetentionTimerJitterDuration: time.Second,
 		dynamicconfig.EnableEagerWorkflowStart:     true,
+		dynamicconfig.CallbackProcessorEnabled:     true,
 	}
 	s.setupSuite("testdata/es_cluster.yaml")
 }

--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -290,7 +290,9 @@ func NewClusterWithPersistenceTestBaseFactory(t *testing.T, options *TestCluster
 		}
 	}
 
-	taskCategoryRegistry := temporal.TaskCategoryRegistryProvider(archiverBase.metadata)
+	dcClient := dynamicconfig.StaticClient(options.DynamicConfigOverrides)
+	dcc := dynamicconfig.NewCollection(dcClient, log.NewNoopLogger())
+	taskCategoryRegistry := temporal.TaskCategoryRegistryProvider(archiverBase.metadata, dcc)
 
 	temporalParams := &TemporalParams{
 		ClusterMetadataConfig:            clusterMetadataConfig,


### PR DESCRIPTION
## What changed?

- Add callback queue processor and missing boilerplate to allow callbacks to work E2E.
- Add dynamic configs to disable accepting callbacks on the frontend and starting the callback queue processor.

**Only review the last commit**, the rest is part of #5356 and #5362

## Why?

This completes the E2E callback flow, part of the effort for integrating Nexus into the server.

## How did you test it?

I added integration tests and @MichaelSnowden stress tested it locally (with a slightly different branch of the code).

## Potential risks

Not merging this into main just yet but we're close.
I don't see any risks as long we don't enable the new dynamic configs.