### PR TITLE
Improve handling of terminal task errors

### DIFF
--- a/common/persistence/serialization/serializer.go
+++ b/common/persistence/serialization/serializer.go
@@ -297,7 +297,7 @@ func (e *UnknownEncodingTypeError) Error() string {
 
 // IsTerminalTaskError informs our task processing subsystem that it is impossible
 // to retry this error
-func (e *UnknownEncodingTypeError) IsTerminalTaskError() {}
+func (e *UnknownEncodingTypeError) IsTerminalTaskError() bool { return true }
 
 // NewSerializationError returns a SerializationError
 func NewSerializationError(
@@ -339,7 +339,7 @@ func (e *DeserializationError) Unwrap() error {
 
 // IsTerminalTaskError informs our task processing subsystem that it is impossible to
 // retry this error and that the task should be sent to a DLQ
-func (e *DeserializationError) IsTerminalTaskError() {}
+func (e *DeserializationError) IsTerminalTaskError() bool { return true }
 
 func (t *serializerImpl) ShardInfoToBlob(info *persistencespb.ShardInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
 	return ProtoEncodeBlob(info, encodingType)

--- a/service/history/queues/executable_mock.go
+++ b/service/history/queues/executable_mock.go
@@ -509,9 +509,11 @@ func (m *MockTerminalTaskError) EXPECT() *MockTerminalTaskErrorMockRecorder {
 }
 
 // IsTerminalTaskError mocks base method.
-func (m *MockTerminalTaskError) IsTerminalTaskError() {
+func (m *MockTerminalTaskError) IsTerminalTaskError() bool {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "IsTerminalTaskError")
+	ret := m.ctrl.Call(m, "IsTerminalTaskError")
+	ret0, _ := ret[0].(bool)
+	return ret0
 }
 
 // IsTerminalTaskError indicates an expected call of IsTerminalTaskError.

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -576,7 +576,8 @@ func (s *executableSuite) TestExecute_DoesntSendInternalErrorsToDLQ_WhenDisabled
 	s.Error(executable.HandleErr(err))
 
 	// Attempt 2
-	s.Error(executable.Execute())
+	err = executable.Execute()
+	s.Error(err)
 	s.Error(executable.HandleErr(err))
 	s.Empty(queueWriter.EnqueueTaskRequests)
 }


### PR DESCRIPTION
## What changed?

1. I refactored HandleErr so it's more obvious what processing is occurring
2. I updated the `TerminalTaskError.IsTerminalTaskError` interface to return a bool. When true, it's terminal and we'll send a task to the dlq
3. I added `serviceerror.DataLoss` to our list of unexpected, non-retryable service errors

## Why?

The two cleanups are self-explanatory, but the third (DataLoss handling) is because those errors are non-recoverable and we should not block task processing because of them.

## How did you test it?
Existing tests

## Potential risks
None

## Is hotfix candidate?
No
