### PR TITLE
Remove `ctx` from SetHistoryTree

### DIFF
--- a/service/history/api/create_workflow_util.go
+++ b/service/history/api/create_workflow_util.go
@@ -55,7 +55,6 @@ type (
 )
 
 func NewWorkflowWithSignal(
-	ctx context.Context,
 	shard shard.Context,
 	namespaceEntry *namespace.Namespace,
 	workflowID string,
@@ -64,7 +63,6 @@ func NewWorkflowWithSignal(
 	signalWithStartRequest *workflowservice.SignalWithStartWorkflowExecutionRequest,
 ) (WorkflowLease, error) {
 	newMutableState, err := CreateMutableState(
-		ctx,
 		shard,
 		namespaceEntry,
 		startRequest.StartRequest.WorkflowExecutionTimeout,
@@ -142,7 +140,6 @@ func NewWorkflowWithSignal(
 }
 
 func CreateMutableState(
-	ctx context.Context,
 	shard shard.Context,
 	namespaceEntry *namespace.Namespace,
 	executionTimeout *durationpb.Duration,
@@ -159,7 +156,7 @@ func CreateMutableState(
 		runID,
 		shard.GetTimeSource().Now(),
 	)
-	if err := newMutableState.SetHistoryTree(ctx, executionTimeout, runTimeout, runID); err != nil {
+	if err := newMutableState.SetHistoryTree(executionTimeout, runTimeout, runID); err != nil {
 		return nil, err
 	}
 	return newMutableState, nil

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -89,7 +89,6 @@ func startAndSignalWorkflow(
 	runID := uuid.New().String()
 	// TODO(bergundy): Support eager workflow task
 	newWorkflowLease, err := api.NewWorkflowWithSignal(
-		ctx,
 		shard,
 		namespaceEntry,
 		workflowID,

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -215,7 +215,6 @@ func (s *Starter) lockCurrentWorkflowExecution(
 // It returns the creationContext which can later be used to insert into the executions table.
 func (s *Starter) createNewMutableState(ctx context.Context, workflowID string, runID string) (*creationParams, error) {
 	workflowLease, err := api.NewWorkflowWithSignal(
-		ctx,
 		s.shardContext,
 		s.namespace,
 		workflowID,
@@ -367,7 +366,6 @@ func (s *Starter) applyWorkflowIDReusePolicy(
 		prevExecutionUpdateAction,
 		func() (workflow.Context, workflow.MutableState, error) {
 			workflowLease, err := api.NewWorkflowWithSignal(
-				ctx,
 				s.shardContext,
 				s.namespace,
 				workflowID,

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -926,7 +926,7 @@ func (s *engine2Suite) createExecutionStartedStateWithParent(we *commonpb.Workfl
 	if wt != nil && startWorkflowTask {
 		addWorkflowTaskStartedEvent(ms, wt.ScheduledEventID, tl, identity)
 	}
-	_ = ms.SetHistoryTree(context.Background(), nil, nil, we.GetRunId())
+	_ = ms.SetHistoryTree(nil, nil, we.GetRunId())
 	versionHistory, _ := versionhistory.GetCurrentVersionHistory(
 		ms.GetExecutionInfo().VersionHistories,
 	)

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -603,10 +603,10 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowTimeoutTask(
 	}
 
 	err = newMutableState.SetHistoryTree(
-		ctx,
 		newMutableState.GetExecutionInfo().WorkflowExecutionTimeout,
 		newMutableState.GetExecutionInfo().WorkflowRunTimeout,
-		newRunID)
+		newRunID,
+	)
 	if err != nil {
 		return err
 	}

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -289,7 +289,7 @@ type (
 		ApplyWorkflowExecutionUpdateCompletedEvent(event *historypb.HistoryEvent, batchID int64) error
 		SetCurrentBranchToken(branchToken []byte) error
 		SetHistoryBuilder(hBuilder *historybuilder.HistoryBuilder)
-		SetHistoryTree(ctx context.Context, executionTimeout *durationpb.Duration, runTimeout *durationpb.Duration, treeID string) error
+		SetHistoryTree(executionTimeout *durationpb.Duration, runTimeout *durationpb.Duration, treeID string) error
 		SetBaseWorkflow(
 			baseRunID string,
 			baseRunLowestCommonAncestorEventID int64,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -491,7 +491,6 @@ func (ms *MutableStateImpl) getCurrentBranchTokenAndEventVersion(eventID int64) 
 
 // SetHistoryTree set treeID/historyBranches
 func (ms *MutableStateImpl) SetHistoryTree(
-	ctx context.Context,
 	executionTimeout *durationpb.Duration,
 	runTimeout *durationpb.Duration,
 	treeID string,
@@ -3785,7 +3784,6 @@ func (ms *MutableStateImpl) AddContinueAsNewEvent(
 	}
 
 	if err = newMutableState.SetHistoryTree(
-		ctx,
 		newMutableState.executionInfo.WorkflowExecutionTimeout,
 		newMutableState.executionInfo.WorkflowRunTimeout,
 		newRunID,

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -2640,9 +2640,9 @@ func (mr *MockMutableStateMockRecorder) SetHistoryBuilder(hBuilder interface{}) 
 }
 
 // SetHistoryTree mocks base method.
-func (m *MockMutableState) SetHistoryTree(ctx context.Context, executionTimeout, runTimeout *durationpb.Duration, treeID string) error {
+func (m *MockMutableState) SetHistoryTree(executionTimeout *durationpb.Duration, runTimeout *durationpb.Duration, treeID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetHistoryTree", ctx, executionTimeout, runTimeout, treeID)
+	ret := m.ctrl.Call(m, "SetHistoryTree", executionTimeout, runTimeout, treeID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -2640,7 +2640,7 @@ func (mr *MockMutableStateMockRecorder) SetHistoryBuilder(hBuilder interface{}) 
 }
 
 // SetHistoryTree mocks base method.
-func (m *MockMutableState) SetHistoryTree(executionTimeout *durationpb.Duration, runTimeout *durationpb.Duration, treeID string) error {
+func (m *MockMutableState) SetHistoryTree(executionTimeout, runTimeout *durationpb.Duration, treeID string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetHistoryTree", executionTimeout, runTimeout, treeID)
 	ret0, _ := ret[0].(error)
@@ -2648,9 +2648,9 @@ func (m *MockMutableState) SetHistoryTree(executionTimeout *durationpb.Duration,
 }
 
 // SetHistoryTree indicates an expected call of SetHistoryTree.
-func (mr *MockMutableStateMockRecorder) SetHistoryTree(ctx, executionTimeout, runTimeout, treeID interface{}) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) SetHistoryTree(executionTimeout, runTimeout, treeID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHistoryTree", reflect.TypeOf((*MockMutableState)(nil).SetHistoryTree), ctx, executionTimeout, runTimeout, treeID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHistoryTree", reflect.TypeOf((*MockMutableState)(nil).SetHistoryTree), executionTimeout, runTimeout, treeID)
 }
 
 // SetSpeculativeWorkflowTaskTimeoutTask mocks base method.

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -205,7 +205,6 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 			if err := b.mutableState.SetHistoryTree(
-				ctx,
 				executionInfo.WorkflowExecutionTimeout,
 				executionInfo.WorkflowRunTimeout,
 				execution.GetRunId(),

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -203,7 +203,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_No
 		protomock.Eq(event),
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
-	s.mockMutableState.EXPECT().SetHistoryTree(gomock.Any(), nil, timestamp.DurationFromSeconds(100), tests.RunID).Return(nil)
+	s.mockMutableState.EXPECT().SetHistoryTree(nil, timestamp.DurationFromSeconds(100), tests.RunID).Return(nil)
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil)
 	s.Nil(err)
@@ -252,7 +252,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_Wi
 		protomock.Eq(event),
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
-	s.mockMutableState.EXPECT().SetHistoryTree(gomock.Any(), nil, timestamp.DurationFromSeconds(100), tests.RunID).Return(nil)
+	s.mockMutableState.EXPECT().SetHistoryTree(nil, timestamp.DurationFromSeconds(100), tests.RunID).Return(nil)
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil)
 	s.Nil(err)

--- a/service/history/workflow/test_util.go
+++ b/service/history/workflow/test_util.go
@@ -57,7 +57,7 @@ func TestLocalMutableState(
 	ms.executionInfo.WorkflowId = workflowID
 	ms.executionState.RunId = runID
 	ms.GetExecutionInfo().ExecutionTime = ms.GetExecutionInfo().StartTime
-	_ = ms.SetHistoryTree(context.Background(), nil, nil, runID)
+	_ = ms.SetHistoryTree(nil, nil, runID)
 
 	return ms
 }
@@ -107,7 +107,7 @@ func TestGlobalMutableState(
 	ms := NewMutableState(shard, eventsCache, logger, tests.GlobalNamespaceEntry, workflowID, runID, time.Now().UTC())
 	ms.GetExecutionInfo().ExecutionTime = ms.GetExecutionInfo().StartTime
 	_ = ms.UpdateCurrentVersion(version, false)
-	_ = ms.SetHistoryTree(context.Background(), nil, nil, runID)
+	_ = ms.SetHistoryTree(nil, nil, runID)
 
 	return ms
 }

--- a/service/history/workflow_task_handler.go
+++ b/service/history/workflow_task_handler.go
@@ -1332,7 +1332,6 @@ func (handler *workflowTaskHandlerImpl) handleRetry(
 	}
 
 	err = newMutableState.SetHistoryTree(
-		ctx,
 		newMutableState.GetExecutionInfo().WorkflowExecutionTimeout,
 		newMutableState.GetExecutionInfo().WorkflowRunTimeout,
 		newRunID,
@@ -1388,7 +1387,6 @@ func (handler *workflowTaskHandlerImpl) handleCron(
 	}
 
 	err = newMutableState.SetHistoryTree(
-		ctx,
 		newMutableState.GetExecutionInfo().WorkflowExecutionTimeout,
 		newMutableState.GetExecutionInfo().WorkflowRunTimeout,
 		newRunID,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

MutableState's `SetHistoryTree` has an unused parameter. (not used downstream either)

## Why?

`ctx` often implies "side effect", sort of like the IO Monad, but there is no side effect here. 

## How did you test it?

Compiler.

## Potential risks

I cannot see any. The change can easily be reverted if requirements change.

## Is hotfix candidate?

No