### PR TITLE
Fix scheduled task rescheduling on failover

### DIFF
--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -529,7 +529,8 @@ func (r *ReaderImpl) submit(
 	now := r.timeSource.Now()
 	// Persistence layer may lose precision when persisting the task, which essentially moves
 	// task fire time forward. Need to account for that when submitting the task.
-	if fireTime := executable.GetKey().FireTime.Add(persistence.ScheduledTaskMinPrecision); now.Before(fireTime) {
+	fireTime := executable.GetKey().FireTime.Add(persistence.ScheduledTaskMinPrecision)
+	if now.Before(fireTime) {
 		r.rescheduler.Add(executable, fireTime)
 		return
 	}

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -528,7 +528,7 @@ func (r *ReaderImpl) submit(
 ) {
 	now := r.timeSource.Now()
 	// Persistence layer may lose precision when persisting the task, which essentially moves
-	// task fire time forward. Need to account for that when submitting the task.
+	// task fire time backward. Need to account for that when submitting the task.
 	fireTime := executable.GetKey().FireTime.Add(persistence.ScheduledTaskMinPrecision)
 	if now.Before(fireTime) {
 		r.rescheduler.Add(executable, fireTime)

--- a/service/history/queues/rescheduler.go
+++ b/service/history/queues/rescheduler.go
@@ -38,8 +38,10 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
 	ctasks "go.temporal.io/server/common/tasks"
 	"go.temporal.io/server/common/timer"
+	"go.temporal.io/server/common/util"
 )
 
 const (
@@ -177,7 +179,12 @@ func (r *reschedulerImpl) Reschedule(
 		items := make([]rescheduledExecuable, 0, pq.Len())
 		for !pq.IsEmpty() {
 			rescheduled := pq.Remove()
-			rescheduled.rescheduleTime = now
+			// scheduled queue pre-fetches tasks,
+			// so we need to make sure the reschedule time is not before the task scheduled time
+			rescheduled.rescheduleTime = util.MaxTime(
+				rescheduled.executable.GetKey().FireTime.Add(persistence.ScheduledTaskMinPrecision),
+				now,
+			)
 			items = append(items, rescheduled)
 		}
 		r.pqMap[key] = r.newPriorityQueue(items)

--- a/service/history/queues/rescheduler_test.go
+++ b/service/history/queues/rescheduler_test.go
@@ -38,6 +38,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	ctasks "go.temporal.io/server/common/tasks"
+	"go.temporal.io/server/service/history/tasks"
 )
 
 type (
@@ -221,7 +222,7 @@ func (s *rescheudulerSuite) TestReschedule_DropCancelled() {
 	s.Equal(0, s.rescheduler.Len())
 }
 
-func (s *rescheudulerSuite) TestImmdiateReschedule() {
+func (s *rescheudulerSuite) TestForceReschedule_ImmediateTask() {
 	now := time.Now()
 	s.timeSource.Update(now)
 	namespaceID := s.mockScheduler.TaskChannelKeyFn()(nil).NamespaceID
@@ -234,8 +235,9 @@ func (s *rescheudulerSuite) TestImmdiateReschedule() {
 	taskWG.Add(numTask)
 	for i := 0; i != numTask; i++ {
 		mockTask := NewMockExecutable(s.controller)
-		mockTask.EXPECT().State().Return(ctasks.TaskStatePending).Times(1)
+		mockTask.EXPECT().State().Return(ctasks.TaskStatePending).AnyTimes()
 		mockTask.EXPECT().SetScheduledTime(gomock.Any()).AnyTimes()
+		mockTask.EXPECT().GetKey().Return(tasks.NewImmediateKey(int64(i))).AnyTimes()
 		s.rescheduler.Add(
 			mockTask,
 			now.Add(time.Minute+time.Duration(rand.Int63n(time.Minute.Nanoseconds()))),
@@ -250,4 +252,45 @@ func (s *rescheudulerSuite) TestImmdiateReschedule() {
 	s.rescheduler.Reschedule(namespaceID)
 	taskWG.Wait()
 	s.Equal(0, s.rescheduler.Len())
+}
+
+func (s *rescheudulerSuite) TestForceReschedule_ScheduledTask() {
+	now := time.Now()
+	s.timeSource.Update(now)
+	namespaceID := s.mockScheduler.TaskChannelKeyFn()(nil).NamespaceID
+
+	s.rescheduler.Start()
+	defer s.rescheduler.Stop()
+
+	taskWG := &sync.WaitGroup{}
+	taskWG.Add(1)
+
+	retryingTask := NewMockExecutable(s.controller)
+	retryingTask.EXPECT().State().Return(ctasks.TaskStatePending).AnyTimes()
+	retryingTask.EXPECT().SetScheduledTime(gomock.Any()).AnyTimes()
+	retryingTask.EXPECT().GetKey().Return(tasks.NewKey(now.Add(-time.Minute), int64(1))).AnyTimes()
+	s.rescheduler.Add(
+		retryingTask,
+		now.Add(time.Minute),
+	)
+
+	// schedule queue pre-fetches tasks
+	futureTaskTimestamp := now.Add(time.Second)
+	futureTask := NewMockExecutable(s.controller)
+	futureTask.EXPECT().State().Return(ctasks.TaskStatePending).AnyTimes()
+	futureTask.EXPECT().SetScheduledTime(gomock.Any()).AnyTimes()
+	futureTask.EXPECT().GetKey().Return(tasks.NewKey(futureTaskTimestamp, int64(2))).AnyTimes()
+	s.rescheduler.Add(
+		futureTask,
+		futureTaskTimestamp,
+	)
+
+	s.mockScheduler.EXPECT().TrySubmit(gomock.Any()).DoAndReturn(func(_ Executable) bool {
+		taskWG.Done()
+		return true
+	}).Times(1)
+
+	s.rescheduler.Reschedule(namespaceID)
+	taskWG.Wait()
+	s.Equal(1, s.rescheduler.Len())
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Do not set reschedule time for a scheduled task before it's fire time.

## Why?
<!-- Tell your future self why have you made these changes -->
- Task can not be processed before it's scheduled time
- On failover however we need to immediately reschedule "all" tasks for the failover namespace since those tasks may have been retrying for a long time when running standby logic and backoff interval is too long. But if a task is not supposed to be processed yet, it should not be rescheduled.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- YES