### PR TITLE
Recalculate schedule times from previous action on update

### DIFF
--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1670,7 +1670,9 @@ func (s *workflowSuite) TestUpdateNotRetroactive() {
 	)
 }
 
-func (s *workflowSuite) TestUpdateWithJitter() {
+// Tests that an update between a nominal time and jittered time for a start, that doesn't
+// modify that start, will still start it.
+func (s *workflowSuite) TestUpdateBetweenNominalAndJitter() {
 	// TODO: remove once default version is UpdateFromPrevious
 	prevTweakables := currentTweakablePolicies
 	currentTweakablePolicies.Version = UpdateFromPrevious

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -212,7 +212,7 @@ func (s *workflowSuite) setupMocksForWorkflows(runs []workflowRun, state *runAcr
 					s.Failf("multiple starts", "for %s at %s (prev %s)", req.Request.WorkflowId, s.now(), prev)
 				}
 				state.started[req.Request.WorkflowId] = s.now()
-				overhead := time.Duration(100*rand.Intn(1000)) * time.Millisecond
+				overhead := time.Duration(100+rand.Intn(100)) * time.Millisecond
 				return &schedspb.StartWorkflowResponse{
 					RunId:         uuid.NewString(),
 					RealStartTime: timestamppb.New(s.now().Add(overhead)),
@@ -320,7 +320,7 @@ func (s *workflowSuite) runAcrossContinue(
 			s.Require().NoError(payloads.Decode(canErr.Input, &startArgs))
 		}
 		// check starts that we actually got
-		s.Require().Equal(len(runs), len(state.started))
+		s.Require().Equalf(len(runs), len(state.started), "started %#v", state.started)
 		for _, run := range runs {
 			actual := state.started[run.id]
 			inRange := !actual.Before(run.start.Add(-run.startTolerance)) && !actual.After(run.start.Add(run.startTolerance))

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -212,9 +212,10 @@ func (s *workflowSuite) setupMocksForWorkflows(runs []workflowRun, state *runAcr
 					s.Failf("multiple starts", "for %s at %s (prev %s)", req.Request.WorkflowId, s.now(), prev)
 				}
 				state.started[req.Request.WorkflowId] = s.now()
+				overhead := time.Duration(100*rand.Intn(1000)) * time.Millisecond
 				return &schedspb.StartWorkflowResponse{
 					RunId:         uuid.NewString(),
-					RealStartTime: timestamppb.New(time.Now()),
+					RealStartTime: timestamppb.New(s.now().Add(overhead)),
 				}, nil
 			})
 		// set up short-poll watchers
@@ -1665,6 +1666,69 @@ func (s *workflowSuite) TestUpdateNotRetroactive() {
 					Interval: durationpb.New(1 * time.Hour),
 				}},
 			},
+		},
+	)
+}
+
+func (s *workflowSuite) TestUpdateWithJitter() {
+	// TODO: remove once default version is UpdateFromPrevious
+	prevTweakables := currentTweakablePolicies
+	currentTweakablePolicies.Version = UpdateFromPrevious
+	defer func() { currentTweakablePolicies = prevTweakables }()
+
+	spec := &schedpb.ScheduleSpec{
+		Interval: []*schedpb.IntervalSpec{{
+			Interval: durationpb.New(1 * time.Hour),
+		}},
+		Jitter: durationpb.New(1 * time.Hour),
+	}
+	s.runAcrossContinue(
+		[]workflowRun{
+			{
+				id:     "myid-2022-06-01T01:00:00Z",
+				start:  time.Date(2022, 6, 1, 1, 49, 22, 594000000, time.UTC),
+				end:    time.Date(2022, 6, 1, 1, 53, 0, 0, time.UTC),
+				result: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			},
+			{
+				id:     "myid-2022-06-01T02:00:00Z",
+				start:  time.Date(2022, 6, 1, 2, 2, 39, 204000000, time.UTC),
+				end:    time.Date(2022, 6, 1, 2, 11, 0, 0, time.UTC),
+				result: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			},
+			{
+				id:     "newid-2022-06-01T03:00:00Z",
+				start:  time.Date(2022, 6, 1, 3, 37, 29, 538000000, time.UTC),
+				end:    time.Date(2022, 6, 1, 3, 41, 0, 0, time.UTC),
+				result: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			},
+			{
+				id:     "newid-2022-06-01T04:00:00Z",
+				start:  time.Date(2022, 6, 1, 4, 23, 34, 755000000, time.UTC),
+				end:    time.Date(2022, 6, 1, 4, 27, 0, 0, time.UTC),
+				result: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			},
+		},
+		[]delayedCallback{
+			{
+				// update after nominal time 03:00:00 but before jittered time 03:37:29
+				at: time.Date(2022, 6, 1, 3, 22, 10, 0, time.UTC),
+				f: func() {
+					s.env.SignalWorkflow(SignalNameUpdate, &schedspb.FullUpdateRequest{
+						Schedule: &schedpb.Schedule{
+							Spec:   spec,
+							Action: s.defaultAction("newid"),
+						},
+					})
+				},
+			},
+			{
+				at:         time.Date(2022, 6, 1, 5, 0, 0, 0, time.UTC),
+				finishTest: true,
+			},
+		},
+		&schedpb.Schedule{
+			Spec: spec,
 		},
 	)
 }


### PR DESCRIPTION
## What changed?
After an update, the schedule workflow goes back to the previous action/update and recomputes next times from there, instead of from the current time.

## Why?
Fixes #4866. Fixes the situation where an update happens in between the nominal time and the jittered time of an action.

## How did you test it?
new unit test
