### PR TITLE
Rename api.WorkflowContext to api.WorkflowLease

### DIFF
--- a/service/history/api/consistency_checker.go
+++ b/service/history/api/consistency_checker.go
@@ -61,7 +61,7 @@ type (
 			consistencyPredicate MutableStateConsistencyPredicate,
 			workflowKey definition.WorkflowKey,
 			lockPriority workflow.LockPriority,
-		) (WorkflowContext, error)
+		) (WorkflowLease, error)
 	}
 
 	WorkflowConsistencyCheckerImpl struct {
@@ -113,7 +113,7 @@ func (c *WorkflowConsistencyCheckerImpl) GetWorkflowContext(
 	consistencyPredicate MutableStateConsistencyPredicate,
 	workflowKey definition.WorkflowKey,
 	lockPriority workflow.LockPriority,
-) (WorkflowContext, error) {
+) (WorkflowLease, error) {
 	if reqClock != nil {
 		currentClock := c.shardContext.CurrentVectorClock()
 		if vclock.Comparable(reqClock, currentClock) {
@@ -158,7 +158,7 @@ func (c *WorkflowConsistencyCheckerImpl) getWorkflowContextValidatedByClock(
 	currentClock *clockspb.VectorClock,
 	workflowKey definition.WorkflowKey,
 	lockPriority workflow.LockPriority,
-) (WorkflowContext, error) {
+) (WorkflowLease, error) {
 	cmpResult, err := vclock.Compare(reqClock, currentClock)
 	if err != nil {
 		return nil, err
@@ -191,7 +191,7 @@ func (c *WorkflowConsistencyCheckerImpl) getWorkflowContextValidatedByClock(
 		release(err)
 		return nil, err
 	}
-	return NewWorkflowContext(wfContext, release, mutableState), nil
+	return NewWorkflowLease(wfContext, release, mutableState), nil
 }
 
 func (c *WorkflowConsistencyCheckerImpl) getWorkflowContextValidatedByCheck(
@@ -200,7 +200,7 @@ func (c *WorkflowConsistencyCheckerImpl) getWorkflowContextValidatedByCheck(
 	consistencyPredicate MutableStateConsistencyPredicate,
 	workflowKey definition.WorkflowKey,
 	lockPriority workflow.LockPriority,
-) (WorkflowContext, error) {
+) (WorkflowLease, error) {
 	if len(workflowKey.RunID) == 0 {
 		return nil, serviceerror.NewInternal(fmt.Sprintf(
 			"loadWorkflowContext encountered empty run ID: %v", workflowKey,
@@ -225,7 +225,7 @@ func (c *WorkflowConsistencyCheckerImpl) getWorkflowContextValidatedByCheck(
 	switch err.(type) {
 	case nil:
 		if consistencyPredicate(mutableState) {
-			return NewWorkflowContext(wfContext, release, mutableState), nil
+			return NewWorkflowLease(wfContext, release, mutableState), nil
 		}
 		wfContext.Clear()
 
@@ -234,7 +234,7 @@ func (c *WorkflowConsistencyCheckerImpl) getWorkflowContextValidatedByCheck(
 			release(err)
 			return nil, err
 		}
-		return NewWorkflowContext(wfContext, release, mutableState), nil
+		return NewWorkflowLease(wfContext, release, mutableState), nil
 	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 		release(err)
 		if err := assertShardOwnership(
@@ -258,7 +258,7 @@ func (c *WorkflowConsistencyCheckerImpl) getCurrentWorkflowContext(
 	namespaceID string,
 	workflowID string,
 	lockPriority workflow.LockPriority,
-) (WorkflowContext, error) {
+) (WorkflowLease, error) {
 	runID, err := c.getCurrentRunID(
 		ctx,
 		shardOwnershipAsserted,

--- a/service/history/api/consistency_checker.go
+++ b/service/history/api/consistency_checker.go
@@ -55,7 +55,7 @@ type (
 			workflowID string,
 			lockPriority workflow.LockPriority,
 		) (string, error)
-		GetWorkflowContext(
+		GetWorkflowLease(
 			ctx context.Context,
 			reqClock *clockspb.VectorClock,
 			consistencyPredicate MutableStateConsistencyPredicate,
@@ -107,7 +107,7 @@ func (c *WorkflowConsistencyCheckerImpl) GetCurrentRunID(
 	return runID, nil
 }
 
-func (c *WorkflowConsistencyCheckerImpl) GetWorkflowContext(
+func (c *WorkflowConsistencyCheckerImpl) GetWorkflowLease(
 	ctx context.Context,
 	reqClock *clockspb.VectorClock,
 	consistencyPredicate MutableStateConsistencyPredicate,

--- a/service/history/api/create_workflow_util.go
+++ b/service/history/api/create_workflow_util.go
@@ -62,7 +62,7 @@ func NewWorkflowWithSignal(
 	runID string,
 	startRequest *historyservice.StartWorkflowExecutionRequest,
 	signalWithStartRequest *workflowservice.SignalWithStartWorkflowExecutionRequest,
-) (WorkflowContext, error) {
+) (WorkflowLease, error) {
 	newMutableState, err := CreateMutableState(
 		ctx,
 		shard,
@@ -137,7 +137,7 @@ func NewWorkflowWithSignal(
 		shard.GetThrottledLogger(),
 		shard.GetMetricsHandler(),
 	)
-	return NewWorkflowContext(newWorkflowContext, wcache.NoopReleaseFn, newMutableState), nil
+	return NewWorkflowLease(newWorkflowContext, wcache.NoopReleaseFn, newMutableState), nil
 }
 
 func CreateMutableState(

--- a/service/history/api/deleteworkflow/api.go
+++ b/service/history/api/deleteworkflow/api.go
@@ -87,8 +87,8 @@ func Invoke(
 				shard,
 				ctx,
 				weCtx,
-				func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-					mutableState := workflowContext.GetMutableState()
+				func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+					mutableState := workflowLease.GetMutableState()
 
 					return api.UpdateWorkflowWithoutWorkflowTask, workflow.TerminateWorkflow(
 						mutableState,

--- a/service/history/api/deleteworkflow/api.go
+++ b/service/history/api/deleteworkflow/api.go
@@ -46,7 +46,7 @@ func Invoke(
 	workflowConsistencyChecker api.WorkflowConsistencyChecker,
 	workflowDeleteManager deletemanager.DeleteManager,
 ) (_ *historyservice.DeleteWorkflowExecutionResponse, retError error) {
-	weCtx, err := workflowConsistencyChecker.GetWorkflowContext(
+	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
 		api.BypassMutableStateConsistencyPredicate,
@@ -60,7 +60,7 @@ func Invoke(
 	if err != nil {
 		return nil, err
 	}
-	defer func() { weCtx.GetReleaseFn()(retError) }()
+	defer func() { workflowLease.GetReleaseFn()(retError) }()
 
 	// Open and Close workflow executions are deleted differently.
 	// Open workflow execution is deleted by terminating with special flag `deleteAfterTerminate` set to true.
@@ -72,7 +72,7 @@ func Invoke(
 	// Although running workflows in active cluster are terminated first and the termination event might be replicated.
 	// In passive cluster, workflow executions are just deleted in regardless of its state.
 
-	if weCtx.GetMutableState().IsWorkflowExecutionRunning() {
+	if workflowLease.GetMutableState().IsWorkflowExecutionRunning() {
 		if request.GetClosedWorkflowOnly() {
 			// skip delete open workflow
 			return &historyservice.DeleteWorkflowExecutionResponse{}, nil
@@ -86,7 +86,7 @@ func Invoke(
 			if err := api.UpdateWorkflowWithNew(
 				shard,
 				ctx,
-				weCtx,
+				workflowLease,
 				func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
 					mutableState := workflowLease.GetMutableState()
 
@@ -114,7 +114,7 @@ func Invoke(
 			WorkflowId: request.GetWorkflowExecution().GetWorkflowId(),
 			RunId:      request.GetWorkflowExecution().GetRunId(),
 		},
-		weCtx.GetMutableState(),
+		workflowLease.GetMutableState(),
 		request.GetWorkflowVersion(),
 	); err != nil {
 		return nil, err

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -74,7 +74,7 @@ func Invoke(
 		return nil, err
 	}
 
-	weCtx, err := workflowConsistencyChecker.GetWorkflowContext(
+	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
 		api.BypassMutableStateConsistencyPredicate,
@@ -91,9 +91,9 @@ func Invoke(
 	// We release the lock on this workflow just before we return from this method, at which point mutable state might
 	// be mutated. Take extra care to clone all response methods as marshalling happens after we return and it is unsafe
 	// to mutate proto fields during marshalling.
-	defer func() { weCtx.GetReleaseFn()(retError) }()
+	defer func() { workflowLease.GetReleaseFn()(retError) }()
 
-	mutableState := weCtx.GetMutableState()
+	mutableState := workflowLease.GetMutableState()
 	executionInfo := mutableState.GetExecutionInfo()
 	executionState := mutableState.GetExecutionState()
 

--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -216,7 +216,7 @@ func GetMutableState(
 		))
 	}
 
-	weCtx, err := workflowConsistencyChecker.GetWorkflowContext(
+	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
 		BypassMutableStateConsistencyPredicate,
@@ -226,9 +226,9 @@ func GetMutableState(
 	if err != nil {
 		return nil, err
 	}
-	defer func() { weCtx.GetReleaseFn()(retError) }()
+	defer func() { workflowLease.GetReleaseFn()(retError) }()
 
-	mutableState, err := weCtx.GetContext().LoadMutableState(ctx, shardContext)
+	mutableState, err := workflowLease.GetContext().LoadMutableState(ctx, shardContext)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/api/isactivitytaskvalid/api.go
+++ b/service/history/api/isactivitytaskvalid/api.go
@@ -51,8 +51,8 @@ func Invoke(
 			req.Execution.WorkflowId,
 			req.Execution.RunId,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			isTaskValid, err := isActivityTaskValid(workflowContext, req.ScheduledEventId)
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			isTaskValid, err := isActivityTaskValid(workflowLease, req.ScheduledEventId)
 			if err != nil {
 				return nil, err
 			}
@@ -72,10 +72,10 @@ func Invoke(
 }
 
 func isActivityTaskValid(
-	workflowContext api.WorkflowContext,
+	workflowLease api.WorkflowLease,
 	scheduledEventID int64,
 ) (bool, error) {
-	mutableState := workflowContext.GetMutableState()
+	mutableState := workflowLease.GetMutableState()
 	if !mutableState.IsWorkflowExecutionRunning() {
 		return false, consts.ErrWorkflowCompleted
 	}

--- a/service/history/api/isworkflowtaskvalid/api.go
+++ b/service/history/api/isworkflowtaskvalid/api.go
@@ -51,8 +51,8 @@ func Invoke(
 			req.Execution.WorkflowId,
 			req.Execution.RunId,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			isTaskValid, err := isWorkflowTaskValid(workflowContext, req.ScheduledEventId)
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			isTaskValid, err := isWorkflowTaskValid(workflowLease, req.ScheduledEventId)
 			if err != nil {
 				return nil, err
 			}
@@ -72,10 +72,10 @@ func Invoke(
 }
 
 func isWorkflowTaskValid(
-	workflowContext api.WorkflowContext,
+	workflowLease api.WorkflowLease,
 	scheduledEventID int64,
 ) (bool, error) {
-	mutableState := workflowContext.GetMutableState()
+	mutableState := workflowLease.GetMutableState()
 	if !mutableState.IsWorkflowExecutionRunning() {
 		return false, consts.ErrWorkflowCompleted
 	}

--- a/service/history/api/pollupdate/api.go
+++ b/service/history/api/pollupdate/api.go
@@ -53,7 +53,7 @@ func Invoke(
 	updateRef := req.GetRequest().GetUpdateRef()
 	wfexec := updateRef.GetWorkflowExecution()
 	wfKey, upd, ok, err := func() (*definition.WorkflowKey, *update.Update, bool, error) {
-		wfctx, err := ctxLookup.GetWorkflowContext(
+		workflowLease, err := ctxLookup.GetWorkflowLease(
 			ctx,
 			nil,
 			api.BypassMutableStateConsistencyPredicate,
@@ -67,10 +67,10 @@ func Invoke(
 		if err != nil {
 			return nil, nil, false, err
 		}
-		release := wfctx.GetReleaseFn()
+		release := workflowLease.GetReleaseFn()
 		defer release(nil)
-		upd, found := wfctx.GetUpdateRegistry(ctx).Find(ctx, updateRef.UpdateId)
-		wfKey := wfctx.GetWorkflowKey()
+		upd, found := workflowLease.GetUpdateRegistry(ctx).Find(ctx, updateRef.UpdateId)
+		wfKey := workflowLease.GetWorkflowKey()
 		return &wfKey, upd, found, nil
 	}()
 	if err != nil {

--- a/service/history/api/pollupdate/api_test.go
+++ b/service/history/api/pollupdate/api_test.go
@@ -87,7 +87,7 @@ func (mockUpdateEventStore) OnAfterCommit(f func(context.Context))   { f(context
 func (mockUpdateEventStore) OnAfterRollback(f func(context.Context)) {}
 func (mockUpdateEventStore) CanAddEvent() bool                       { return true }
 
-func (m mockWFConsistencyChecker) GetWorkflowContext(
+func (m mockWFConsistencyChecker) GetWorkflowLease(
 	ctx context.Context,
 	clock *clockspb.VectorClock,
 	pred api.MutableStateConsistencyPredicate,

--- a/service/history/api/pollupdate/api_test.go
+++ b/service/history/api/pollupdate/api_test.go
@@ -63,11 +63,11 @@ type (
 			consistencyPredicate api.MutableStateConsistencyPredicate,
 			workflowKey definition.WorkflowKey,
 			lockPriority workflow.LockPriority,
-		) (api.WorkflowContext, error)
+		) (api.WorkflowLease, error)
 	}
 
 	mockAPICtx struct {
-		api.WorkflowContext
+		api.WorkflowLease
 		GetUpdateRegistryFunc func(context.Context) update.Registry
 		GetReleaseFnFunc      func() wcache.ReleaseCacheFunc
 		GetWorkflowKeyFunc    func() definition.WorkflowKey
@@ -93,7 +93,7 @@ func (m mockWFConsistencyChecker) GetWorkflowContext(
 	pred api.MutableStateConsistencyPredicate,
 	wfKey definition.WorkflowKey,
 	prio workflow.LockPriority,
-) (api.WorkflowContext, error) {
+) (api.WorkflowLease, error) {
 	return m.GetWorkflowContextFunc(ctx, clock, pred, wfKey, prio)
 }
 
@@ -135,7 +135,7 @@ func TestPollOutcome(t *testing.T) {
 			consistencyPredicate api.MutableStateConsistencyPredicate,
 			workflowKey definition.WorkflowKey,
 			lockPriority workflow.LockPriority,
-		) (api.WorkflowContext, error) {
+		) (api.WorkflowLease, error) {
 			return apiCtx, nil
 		},
 	}

--- a/service/history/api/reapplyevents/api.go
+++ b/service/history/api/reapplyevents/api.go
@@ -74,9 +74,9 @@ func Invoke(
 			workflowID,
 			"",
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			context := workflowContext.GetContext()
-			mutableState := workflowContext.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			context := workflowLease.GetContext()
+			mutableState := workflowLease.GetMutableState()
 			// Filter out reapply event from the same cluster
 			toReapplyEvents := make([]*historypb.HistoryEvent, 0, len(reapplyEvents))
 			lastWriteVersion, err := mutableState.GetLastWriteVersion()

--- a/service/history/api/recordactivitytaskheartbeat/api.go
+++ b/service/history/api/recordactivitytaskheartbeat/api.go
@@ -68,8 +68,8 @@ func Invoke(
 			token.WorkflowId,
 			token.RunId,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			mutableState := workflowContext.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, consts.ErrWorkflowCompleted
 			}

--- a/service/history/api/recordactivitytaskstarted/api.go
+++ b/service/history/api/recordactivitytaskstarted/api.go
@@ -62,8 +62,8 @@ func Invoke(
 			request.WorkflowExecution.WorkflowId,
 			request.WorkflowExecution.RunId,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			mutableState := workflowContext.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, consts.ErrWorkflowCompleted
 			}

--- a/service/history/api/recordchildworkflowcompleted/api.go
+++ b/service/history/api/recordchildworkflowcompleted/api.go
@@ -80,8 +80,8 @@ func Invoke(
 			request.GetParentExecution().WorkflowId,
 			request.GetParentExecution().RunId,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			mutableState := workflowContext.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, consts.ErrWorkflowCompleted
 			}

--- a/service/history/api/refreshworkflow/api.go
+++ b/service/history/api/refreshworkflow/api.go
@@ -46,7 +46,7 @@ func Invoke(
 		return err
 	}
 
-	wfContext, err := workflowConsistencyChecker.GetWorkflowContext(
+	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
 		api.BypassMutableStateConsistencyPredicate,
@@ -56,9 +56,9 @@ func Invoke(
 	if err != nil {
 		return err
 	}
-	defer func() { wfContext.GetReleaseFn()(retError) }()
+	defer func() { workflowLease.GetReleaseFn()(retError) }()
 
-	mutableState := wfContext.GetMutableState()
+	mutableState := workflowLease.GetMutableState()
 	mutableStateTaskRefresher := workflow.NewTaskRefresher(
 		shard,
 		shard.GetConfig(),

--- a/service/history/api/removesignalmutablestate/api.go
+++ b/service/history/api/removesignalmutablestate/api.go
@@ -55,8 +55,8 @@ func Invoke(
 			req.WorkflowExecution.WorkflowId,
 			req.WorkflowExecution.RunId,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			mutableState := workflowContext.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, consts.ErrWorkflowCompleted
 			}

--- a/service/history/api/replication/generate_task.go
+++ b/service/history/api/replication/generate_task.go
@@ -49,7 +49,7 @@ func GenerateTask(
 	}
 	namespaceID := namespaceEntry.ID()
 
-	wfContext, err := workflowConsistencyChecker.GetWorkflowContext(
+	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
 		api.BypassMutableStateConsistencyPredicate,
@@ -63,9 +63,9 @@ func GenerateTask(
 	if err != nil {
 		return nil, err
 	}
-	defer func() { wfContext.GetReleaseFn()(retError) }()
+	defer func() { workflowLease.GetReleaseFn()(retError) }()
 
-	mutableState := wfContext.GetMutableState()
+	mutableState := workflowLease.GetMutableState()
 	replicationTasks, stateTransitionCount, err := mutableState.GenerateMigrationTasks()
 	if err != nil {
 		return nil, err

--- a/service/history/api/requestcancelworkflow/api.go
+++ b/service/history/api/requestcancelworkflow/api.go
@@ -66,8 +66,8 @@ func Invoke(
 			workflowID,
 			runID,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			mutableState := workflowContext.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
 			if !mutableState.IsWorkflowExecutionRunning() {
 				// the request to cancel this workflow is a success even
 				// if the target workflow has already finished

--- a/service/history/api/resetstickytaskqueue/api.go
+++ b/service/history/api/resetstickytaskqueue/api.go
@@ -56,8 +56,8 @@ func Invoke(
 			resetRequest.Execution.WorkflowId,
 			resetRequest.Execution.RunId,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			mutableState := workflowContext.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, consts.ErrWorkflowCompleted
 			}

--- a/service/history/api/resetworkflow/api.go
+++ b/service/history/api/resetworkflow/api.go
@@ -94,7 +94,7 @@ func Invoke(
 		baseRunID = currentRunID
 	}
 
-	var currentWFContext api.WorkflowContext
+	var currentWFContext api.WorkflowLease
 	if currentRunID == baseRunID {
 		currentWFContext = baseWFContext
 	} else {

--- a/service/history/api/resetworkflow/api.go
+++ b/service/history/api/resetworkflow/api.go
@@ -58,7 +58,7 @@ func Invoke(
 	workflowID := request.WorkflowExecution.GetWorkflowId()
 	baseRunID := request.WorkflowExecution.GetRunId()
 
-	baseWFContext, err := workflowConsistencyChecker.GetWorkflowContext(
+	baseWorkflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
 		api.BypassMutableStateConsistencyPredicate,
@@ -72,9 +72,9 @@ func Invoke(
 	if err != nil {
 		return nil, err
 	}
-	defer func() { baseWFContext.GetReleaseFn()(retError) }()
+	defer func() { baseWorkflowLease.GetReleaseFn()(retError) }()
 
-	baseMutableState := baseWFContext.GetMutableState()
+	baseMutableState := baseWorkflowLease.GetMutableState()
 	if request.GetWorkflowTaskFinishEventId() <= common.FirstEventID ||
 		request.GetWorkflowTaskFinishEventId() >= baseMutableState.GetNextEventID() {
 		return nil, serviceerror.NewInvalidArgument("Workflow task finish ID must be > 1 && <= workflow last event ID.")
@@ -94,11 +94,11 @@ func Invoke(
 		baseRunID = currentRunID
 	}
 
-	var currentWFContext api.WorkflowLease
+	var currentWorkflowLease api.WorkflowLease
 	if currentRunID == baseRunID {
-		currentWFContext = baseWFContext
+		currentWorkflowLease = baseWorkflowLease
 	} else {
-		currentWFContext, err = workflowConsistencyChecker.GetWorkflowContext(
+		currentWorkflowLease, err = workflowConsistencyChecker.GetWorkflowLease(
 			ctx,
 			nil,
 			api.BypassMutableStateConsistencyPredicate,
@@ -112,11 +112,11 @@ func Invoke(
 		if err != nil {
 			return nil, err
 		}
-		defer func() { currentWFContext.GetReleaseFn()(retError) }()
+		defer func() { currentWorkflowLease.GetReleaseFn()(retError) }()
 	}
 
 	// dedup by requestID
-	if currentWFContext.GetMutableState().GetExecutionState().CreateRequestId == request.GetRequestId() {
+	if currentWorkflowLease.GetMutableState().GetExecutionState().CreateRequestId == request.GetRequestId() {
 		shard.GetLogger().Info("Duplicated reset request",
 			tag.WorkflowID(workflowID),
 			tag.WorkflowRunID(currentRunID),
@@ -157,9 +157,9 @@ func Invoke(
 		request.GetRequestId(),
 		ndc.NewWorkflow(
 			shard.GetClusterMetadata(),
-			currentWFContext.GetContext(),
-			currentWFContext.GetMutableState(),
-			currentWFContext.GetReleaseFn(),
+			currentWorkflowLease.GetContext(),
+			currentWorkflowLease.GetMutableState(),
+			currentWorkflowLease.GetReleaseFn(),
 		),
 		request.GetReason(),
 		nil,

--- a/service/history/api/respondactivitytaskcanceled/api.go
+++ b/service/history/api/respondactivitytaskcanceled/api.go
@@ -72,8 +72,8 @@ func Invoke(
 			token.WorkflowId,
 			token.RunId,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			mutableState := workflowContext.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
 			workflowTypeName = mutableState.GetWorkflowType().GetName()
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, consts.ErrWorkflowCompleted

--- a/service/history/api/respondactivitytaskcompleted/api.go
+++ b/service/history/api/respondactivitytaskcompleted/api.go
@@ -72,8 +72,8 @@ func Invoke(
 			token.WorkflowId,
 			token.RunId,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			mutableState := workflowContext.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
 			workflowTypeName = mutableState.GetWorkflowType().GetName()
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, consts.ErrWorkflowCompleted

--- a/service/history/api/respondactivitytaskfailed/api.go
+++ b/service/history/api/respondactivitytaskfailed/api.go
@@ -75,8 +75,8 @@ func Invoke(
 			token.WorkflowId,
 			token.RunId,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			mutableState := workflowContext.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
 			workflowTypeName = mutableState.GetWorkflowType().GetName()
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, consts.ErrWorkflowCompleted

--- a/service/history/api/signalwithstartworkflow/api.go
+++ b/service/history/api/signalwithstartworkflow/api.go
@@ -51,7 +51,7 @@ func Invoke(
 	namespaceID := namespaceEntry.ID()
 
 	var currentWorkflowLease api.WorkflowLease
-	currentWorkflowLease, err = workflowConsistencyChecker.GetWorkflowContext(
+	currentWorkflowLease, err = workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
 		api.BypassMutableStateConsistencyPredicate,

--- a/service/history/api/signalwithstartworkflow/api.go
+++ b/service/history/api/signalwithstartworkflow/api.go
@@ -50,8 +50,8 @@ func Invoke(
 	}
 	namespaceID := namespaceEntry.ID()
 
-	var currentWorkflowContext api.WorkflowContext
-	currentWorkflowContext, err = workflowConsistencyChecker.GetWorkflowContext(
+	var currentWorkflowLease api.WorkflowLease
+	currentWorkflowLease, err = workflowConsistencyChecker.GetWorkflowContext(
 		ctx,
 		nil,
 		api.BypassMutableStateConsistencyPredicate,
@@ -64,9 +64,9 @@ func Invoke(
 	)
 	switch err.(type) {
 	case nil:
-		defer func() { currentWorkflowContext.GetReleaseFn()(retError) }()
+		defer func() { currentWorkflowLease.GetReleaseFn()(retError) }()
 	case *serviceerror.NotFound:
-		currentWorkflowContext = nil
+		currentWorkflowLease = nil
 	default:
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func Invoke(
 		ctx,
 		shard,
 		namespaceEntry,
-		currentWorkflowContext,
+		currentWorkflowLease,
 		startRequest,
 		signalWithStartRequest.SignalWithStartRequest,
 	)

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow_test.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow_test.go
@@ -109,7 +109,7 @@ func (s *signalWithStartWorkflowSuite) TearDownTest() {
 
 func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_WorkflowCloseAttempted() {
 	ctx := context.Background()
-	currentWorkflowContext := api.NewWorkflowLease(
+	currentWorkflowLease := api.NewWorkflowLease(
 		s.currentContext,
 		wcache.NoopReleaseFn,
 		s.currentMutableState,
@@ -122,7 +122,7 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_WorkflowCloseAttempted
 	err := signalWorkflow(
 		ctx,
 		s.shardContext,
-		currentWorkflowContext,
+		currentWorkflowLease,
 		request,
 	)
 	s.Error(consts.ErrWorkflowClosing, err)
@@ -130,7 +130,7 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_WorkflowCloseAttempted
 
 func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_Dedup() {
 	ctx := context.Background()
-	currentWorkflowContext := api.NewWorkflowLease(
+	currentWorkflowLease := api.NewWorkflowLease(
 		s.currentContext,
 		wcache.NoopReleaseFn,
 		s.currentMutableState,
@@ -143,7 +143,7 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_Dedup() {
 	err := signalWorkflow(
 		ctx,
 		s.shardContext,
-		currentWorkflowContext,
+		currentWorkflowLease,
 		request,
 	)
 	s.NoError(err)
@@ -151,7 +151,7 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_Dedup() {
 
 func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_NewWorkflowTask() {
 	ctx := context.Background()
-	currentWorkflowContext := api.NewWorkflowLease(
+	currentWorkflowLease := api.NewWorkflowLease(
 		s.currentContext,
 		wcache.NoopReleaseFn,
 		s.currentMutableState,
@@ -176,7 +176,7 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_NewWorkflowTask() {
 	err := signalWorkflow(
 		ctx,
 		s.shardContext,
-		currentWorkflowContext,
+		currentWorkflowLease,
 		request,
 	)
 	s.NoError(err)
@@ -184,7 +184,7 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_NewWorkflowTask() {
 
 func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_NoNewWorkflowTask() {
 	ctx := context.Background()
-	currentWorkflowContext := api.NewWorkflowLease(
+	currentWorkflowLease := api.NewWorkflowLease(
 		s.currentContext,
 		wcache.NoopReleaseFn,
 		s.currentMutableState,
@@ -207,7 +207,7 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_NoNewWorkflowTask() {
 	err := signalWorkflow(
 		ctx,
 		s.shardContext,
-		currentWorkflowContext,
+		currentWorkflowLease,
 		request,
 	)
 	s.NoError(err)

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow_test.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow_test.go
@@ -109,7 +109,7 @@ func (s *signalWithStartWorkflowSuite) TearDownTest() {
 
 func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_WorkflowCloseAttempted() {
 	ctx := context.Background()
-	currentWorkflowContext := api.NewWorkflowContext(
+	currentWorkflowContext := api.NewWorkflowLease(
 		s.currentContext,
 		wcache.NoopReleaseFn,
 		s.currentMutableState,
@@ -130,7 +130,7 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_WorkflowCloseAttempted
 
 func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_Dedup() {
 	ctx := context.Background()
-	currentWorkflowContext := api.NewWorkflowContext(
+	currentWorkflowContext := api.NewWorkflowLease(
 		s.currentContext,
 		wcache.NoopReleaseFn,
 		s.currentMutableState,
@@ -151,7 +151,7 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_Dedup() {
 
 func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_NewWorkflowTask() {
 	ctx := context.Background()
-	currentWorkflowContext := api.NewWorkflowContext(
+	currentWorkflowContext := api.NewWorkflowLease(
 		s.currentContext,
 		wcache.NoopReleaseFn,
 		s.currentMutableState,
@@ -184,7 +184,7 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_NewWorkflowTask() {
 
 func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_NoNewWorkflowTask() {
 	ctx := context.Background()
-	currentWorkflowContext := api.NewWorkflowContext(
+	currentWorkflowContext := api.NewWorkflowLease(
 		s.currentContext,
 		wcache.NoopReleaseFn,
 		s.currentMutableState,

--- a/service/history/api/signalworkflow/api.go
+++ b/service/history/api/signalworkflow/api.go
@@ -60,8 +60,8 @@ func Invoke(
 			request.WorkflowExecution.WorkflowId,
 			request.WorkflowExecution.RunId,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			mutableState := workflowContext.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
 			if request.GetRequestId() != "" && mutableState.IsSignalRequested(request.GetRequestId()) {
 				return &api.UpdateWorkflowAction{
 					Noop:               true,
@@ -69,7 +69,7 @@ func Invoke(
 				}, nil
 			}
 
-			releaseFn := workflowContext.GetReleaseFn()
+			releaseFn := workflowLease.GetReleaseFn()
 			if !mutableState.IsWorkflowExecutionRunning() {
 				// in-memory mutable state is still clean, release the lock with nil error to prevent
 				// clearing and reloading mutable state

--- a/service/history/api/terminateworkflow/api.go
+++ b/service/history/api/terminateworkflow/api.go
@@ -67,8 +67,8 @@ func Invoke(
 			workflowID,
 			runID,
 		),
-		func(workflowContext api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
-			mutableState := workflowContext.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, consts.ErrWorkflowCompleted
 			}

--- a/service/history/api/update_workflow_util.go
+++ b/service/history/api/update_workflow_util.go
@@ -44,7 +44,7 @@ func GetAndUpdateWorkflowWithNew(
 	shard shard.Context,
 	workflowConsistencyChecker WorkflowConsistencyChecker,
 ) (retError error) {
-	workflowContext, err := workflowConsistencyChecker.GetWorkflowContext(
+	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		reqClock,
 		consistencyCheckFn,
@@ -54,9 +54,9 @@ func GetAndUpdateWorkflowWithNew(
 	if err != nil {
 		return err
 	}
-	defer func() { workflowContext.GetReleaseFn()(retError) }()
+	defer func() { workflowLease.GetReleaseFn()(retError) }()
 
-	return UpdateWorkflowWithNew(shard, ctx, workflowContext, action, newWorkflowFn)
+	return UpdateWorkflowWithNew(shard, ctx, workflowLease, action, newWorkflowFn)
 }
 
 func UpdateWorkflowWithNew(

--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -91,8 +91,8 @@ func Invoke(
 		nil,
 		api.BypassMutableStateConsistencyPredicate,
 		wfKey,
-		func(weCtx api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
-			ms := weCtx.GetMutableState()
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			ms := workflowLease.GetMutableState()
 			if !ms.IsWorkflowExecutionRunning() {
 				return nil, consts.ErrWorkflowCompleted
 			}
@@ -118,7 +118,7 @@ func Invoke(
 			}
 
 			updateID := req.GetRequest().GetRequest().GetMeta().GetUpdateId()
-			updateReg := weCtx.GetUpdateRegistry(ctx)
+			updateReg := workflowLease.GetUpdateRegistry(ctx)
 			var (
 				alreadyExisted bool
 				err            error

--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -91,7 +91,7 @@ func Invoke(
 		nil,
 		api.BypassMutableStateConsistencyPredicate,
 		wfKey,
-		func(weCtx api.WorkflowContext) (*api.UpdateWorkflowAction, error) {
+		func(weCtx api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
 			ms := weCtx.GetMutableState()
 			if !ms.IsWorkflowExecutionRunning() {
 				return nil, consts.ErrWorkflowCompleted

--- a/service/history/api/verifychildworkflowcompletionrecorded/api.go
+++ b/service/history/api/verifychildworkflowcompletionrecorded/api.go
@@ -49,7 +49,7 @@ func Invoke(
 		return nil, err
 	}
 
-	workflowContext, err := workflowConsistencyChecker.GetWorkflowContext(
+	workflowContext, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		request.Clock,
 		// it's ok we have stale state when doing verification,

--- a/service/history/api/workflow_context.go
+++ b/service/history/api/workflow_context.go
@@ -34,7 +34,7 @@ import (
 	"go.temporal.io/server/service/history/workflow/update"
 )
 
-type WorkflowContext interface {
+type WorkflowLease interface {
 	GetContext() workflow.Context
 	GetMutableState() workflow.MutableState
 	GetReleaseFn() wcache.ReleaseCacheFunc
@@ -44,7 +44,7 @@ type WorkflowContext interface {
 	GetUpdateRegistry(context.Context) update.Registry
 }
 
-type WorkflowContextImpl struct {
+type workflowLease struct {
 	context      workflow.Context
 	mutableState workflow.MutableState
 	releaseFn    wcache.ReleaseCacheFunc
@@ -64,43 +64,42 @@ var (
 	}
 )
 
-type UpdateWorkflowActionFunc func(WorkflowContext) (*UpdateWorkflowAction, error)
+type UpdateWorkflowActionFunc func(WorkflowLease) (*UpdateWorkflowAction, error)
 
-var _ WorkflowContext = (*WorkflowContextImpl)(nil)
+var _ WorkflowLease = (*workflowLease)(nil)
 
-func NewWorkflowContext(
+func NewWorkflowLease(
 	context workflow.Context,
 	releaseFn wcache.ReleaseCacheFunc,
 	mutableState workflow.MutableState,
-) *WorkflowContextImpl {
-
-	return &WorkflowContextImpl{
+) WorkflowLease {
+	return &workflowLease{
 		context:      context,
 		releaseFn:    releaseFn,
 		mutableState: mutableState,
 	}
 }
 
-func (w *WorkflowContextImpl) GetContext() workflow.Context {
+func (w *workflowLease) GetContext() workflow.Context {
 	return w.context
 }
 
-func (w *WorkflowContextImpl) GetMutableState() workflow.MutableState {
+func (w *workflowLease) GetMutableState() workflow.MutableState {
 	return w.mutableState
 }
 
-func (w *WorkflowContextImpl) GetReleaseFn() wcache.ReleaseCacheFunc {
+func (w *workflowLease) GetReleaseFn() wcache.ReleaseCacheFunc {
 	return w.releaseFn
 }
 
-func (w *WorkflowContextImpl) GetNamespaceEntry() *namespace.Namespace {
+func (w *workflowLease) GetNamespaceEntry() *namespace.Namespace {
 	return w.mutableState.GetNamespaceEntry()
 }
 
-func (w *WorkflowContextImpl) GetWorkflowKey() definition.WorkflowKey {
+func (w *workflowLease) GetWorkflowKey() definition.WorkflowKey {
 	return w.context.GetWorkflowKey()
 }
 
-func (w *WorkflowContextImpl) GetUpdateRegistry(ctx context.Context) update.Registry {
+func (w *workflowLease) GetUpdateRegistry(ctx context.Context) update.Registry {
 	return w.context.UpdateRegistry(ctx)
 }

--- a/service/history/api/workflow_id_reuse_policy.go
+++ b/service/history/api/workflow_id_reuse_policy.go
@@ -57,7 +57,7 @@ func ApplyWorkflowIDReusePolicy(
 	case enumsspb.WORKFLOW_EXECUTION_STATE_CREATED,
 		enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING:
 		if wfIDReusePolicy == enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING {
-			return func(workflowContext WorkflowContext) (*UpdateWorkflowAction, error) {
+			return func(workflowContext WorkflowLease) (*UpdateWorkflowAction, error) {
 				mutableState := workflowContext.GetMutableState()
 				if !mutableState.IsWorkflowExecutionRunning() {
 					return nil, consts.ErrWorkflowCompleted

--- a/service/history/api/workflow_id_reuse_policy.go
+++ b/service/history/api/workflow_id_reuse_policy.go
@@ -57,8 +57,8 @@ func ApplyWorkflowIDReusePolicy(
 	case enumsspb.WORKFLOW_EXECUTION_STATE_CREATED,
 		enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING:
 		if wfIDReusePolicy == enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING {
-			return func(workflowContext WorkflowLease) (*UpdateWorkflowAction, error) {
-				mutableState := workflowContext.GetMutableState()
+			return func(workflowLease WorkflowLease) (*UpdateWorkflowAction, error) {
+				mutableState := workflowLease.GetMutableState()
 				if !mutableState.IsWorkflowExecutionRunning() {
 					return nil, consts.ErrWorkflowCompleted
 				}

--- a/service/history/workflow_task_handler_callbacks.go
+++ b/service/history/workflow_task_handler_callbacks.go
@@ -398,7 +398,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		return nil, consts.ErrDeserializingToken
 	}
 
-	workflowContext, err := handler.workflowConsistencyChecker.GetWorkflowContext(
+	workflowContext, err := handler.workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		token.Clock,
 		func(mutableState workflow.MutableState) bool {
@@ -885,7 +885,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) verifyFirstWorkflowTaskSchedule
 		return err
 	}
 
-	workflowContext, err := handler.workflowConsistencyChecker.GetWorkflowContext(
+	workflowLease, err := handler.workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		req.Clock,
 		api.BypassMutableStateConsistencyPredicate,
@@ -899,9 +899,9 @@ func (handler *workflowTaskHandlerCallbacksImpl) verifyFirstWorkflowTaskSchedule
 	if err != nil {
 		return err
 	}
-	defer func() { workflowContext.GetReleaseFn()(retError) }()
+	defer func() { workflowLease.GetReleaseFn()(retError) }()
 
-	mutableState := workflowContext.GetMutableState()
+	mutableState := workflowLease.GetMutableState()
 	if !mutableState.IsWorkflowExecutionRunning() &&
 		mutableState.GetExecutionState().State != enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE {
 		return nil


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Renamed `api.WorkflowContext` to `api.WorkflowLease`.

## Why?

The name is confusing as there is already a `workflow.Context`. It keeps coming up for me and makes it unnecessarily harder to read/understand the code. The current name also doesn't _add_ anything but the entity _is_ different from `workflow.Context`. I believe it effectively acts as a "lease".

If that one doesn't work, I'm happy to find a better name than that together.

## How did you test it?

Compiler.

## Potential risks

N/A

## Is hotfix candidate?

No