### PR TITLE
Fix flaky test in iwrr scheduler suite

### DIFF
--- a/common/tasks/interleaved_weighted_round_robin.go
+++ b/common/tasks/interleaved_weighted_round_robin.go
@@ -144,9 +144,11 @@ func (s *InterleavedWeightedRoundRobinScheduler[T, K]) Stop() {
 
 	s.fifoScheduler.Stop()
 
-	s.shutdownWG.Wait()
 	s.abortTasks()
 
+	if success := common.AwaitWaitGroup(&s.shutdownWG, time.Minute); !success {
+		s.logger.Warn("interleaved weighted round robin task scheduler timed out on shutdown.")
+	}
 	s.logger.Info("interleaved weighted round robin task scheduler stopped")
 }
 

--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -118,6 +118,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestTrySubmitSchedule_Succ
 	s.True(s.scheduler.TrySubmit(mockTask))
 
 	testWaitGroup.Wait()
+	s.scheduler.Stop()
 	s.Equal(int64(0), atomic.LoadInt64(&s.scheduler.numInflightTask))
 }
 
@@ -140,6 +141,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestTrySubmitSchedule_Fail
 	s.True(s.scheduler.TrySubmit(mockTask))
 
 	testWaitGroup.Wait()
+	s.scheduler.Stop()
 	s.Equal(int64(0), atomic.LoadInt64(&s.scheduler.numInflightTask))
 }
 
@@ -178,6 +180,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestSubmitSchedule_Success
 	s.scheduler.Submit(mockTask)
 
 	testWaitGroup.Wait()
+	s.scheduler.Stop()
 	s.Equal(int64(0), atomic.LoadInt64(&s.scheduler.numInflightTask))
 }
 
@@ -317,6 +320,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestParallelSubmitSchedule
 
 	testWaitGroup.Wait()
 
+	s.scheduler.Stop()
 	s.Equal(int64(0), atomic.LoadInt64(&s.scheduler.numInflightTask))
 	s.Len(submittedTasks, numSubmitter*numTasks)
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Flaky test: https://github.com/temporalio/temporal/actions/runs/7734357310/job/21088315026#step:4:162

The update to numInflightTask and the check in the test has race condition.
Added a wait step in scheduler shutdown logic to wait for the update before checking.

## Why?
<!-- Tell your future self why have you made these changes -->
- Fix flaky test

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- Longer task scheduler shutdown time upon service restart

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- No.
