### PR TITLE
Fix check to create draft release notes in create-tag job

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -80,7 +80,7 @@ jobs:
           fi
 
       - name: Create draft release notes
-        if: ${{ github.event.inputs.release_notes }}
+        if: ${{ github.event.inputs.release_notes == 'true' }}
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           BASE_TAG: ${{ github.event.inputs.base_tag }}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix check to create draft release notes in create-tag GHA job

## Why?
<!-- Tell your future self why have you made these changes -->
Boolean inputs are actually strings with `'true'` of `'false'` values.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
