### PR TITLE
Fix iwrr scheduler UpdateWeight test

### DIFF
--- a/common/tasks/interleaved_weighted_round_robin.go
+++ b/common/tasks/interleaved_weighted_round_robin.go
@@ -289,7 +289,7 @@ func (s *InterleavedWeightedRoundRobinScheduler[T, K]) updateChannelWeightLocked
 }
 
 func (s *InterleavedWeightedRoundRobinScheduler[T, K]) dispatchTasksWithWeight() {
-	for s.hasRemainingTasks() {
+	for s.hasRemainingTasks() && !s.isStopped() {
 		if s.receiveWeightUpdateNotification() {
 			s.Lock()
 			s.updateChannelWeightLocked()

--- a/common/tasks/interleaved_weighted_round_robin.go
+++ b/common/tasks/interleaved_weighted_round_robin.go
@@ -289,7 +289,7 @@ func (s *InterleavedWeightedRoundRobinScheduler[T, K]) updateChannelWeightLocked
 }
 
 func (s *InterleavedWeightedRoundRobinScheduler[T, K]) dispatchTasksWithWeight() {
-	for s.hasRemainingTasks() && !s.isStopped() {
+	for s.hasRemainingTasks() {
 		if s.receiveWeightUpdateNotification() {
 			s.Lock()
 			s.updateChannelWeightLocked()

--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -391,6 +391,9 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestUpdateWeight() {
 
 	}
 	s.Equal([]int{8, 8, 8, 8, 5, 8, 5, 8, 5, 8, 5, 8, 5, 1, 1}, channelWeights)
+
+	// set the number of pending task back
+	atomic.AddInt64(&s.scheduler.numInflightTask, -1)
 }
 
 func newTestTask(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Reset inflight task count in UpdateWeight test. That test manually increase the inflight task count to test dispatch logic, but there's no actual task for it. So the shutdown logic will be blocked on the non-existing inflight task.

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- N/A

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- No
