### PR TITLE
Keep history cache dynamic config backward compatible

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -511,8 +511,8 @@ const (
 	HistoryCacheNonUserContextLockTimeout = "history.cacheNonUserContextLockTimeout"
 	// EnableHostHistoryCache controls if the history cache is host level
 	EnableHostHistoryCache = "history.enableHostHistoryCache"
-	// HistoryCacheShardLevelMaxSize is max size of history shard level cache
-	HistoryCacheShardLevelMaxSize = "history.shardLevelCacheMaxSize"
+	// HistoryCacheHostLevelMaxSize is max size of history host level cache
+	HistoryCacheHostLevelMaxSize = "history.hostLevelCacheMaxSize"
 	// EnableAPIGetCurrentRunIDLock controls if a lock should be acquired before getting current run ID for API requests
 	EnableAPIGetCurrentRunIDLock = "history.enableAPIGetCurrentRunIDLock"
 	// HistoryStartupMembershipJoinDelay is the duration a history instance waits

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -71,11 +71,11 @@ type Config struct {
 	// HistoryCache settings
 	// Change of these configs require shard restart
 	HistoryCacheInitialSize               dynamicconfig.IntPropertyFn
-	HistoryCacheMaxSize                   dynamicconfig.IntPropertyFn
+	HistoryShardLevelCacheMaxSize         dynamicconfig.IntPropertyFn
+	HistoryHostLevelCacheMaxSize          dynamicconfig.IntPropertyFn
 	HistoryCacheTTL                       dynamicconfig.DurationPropertyFn
 	HistoryCacheNonUserContextLockTimeout dynamicconfig.DurationPropertyFn
 	EnableHostLevelHistoryCache           dynamicconfig.BoolPropertyFn
-	HistoryShardLevelCacheMaxSize         dynamicconfig.IntPropertyFn
 	EnableAPIGetCurrentRunIDLock          dynamicconfig.BoolPropertyFn
 
 	// EventsCache settings
@@ -356,11 +356,11 @@ func NewConfig(
 
 		EmitShardLagLog:                       dc.GetBoolProperty(dynamicconfig.EmitShardLagLog, false),
 		HistoryCacheInitialSize:               dc.GetIntProperty(dynamicconfig.HistoryCacheInitialSize, 128),
-		HistoryCacheMaxSize:                   dc.GetIntProperty(dynamicconfig.HistoryCacheMaxSize, 256000),
+		HistoryShardLevelCacheMaxSize:         dc.GetIntProperty(dynamicconfig.HistoryCacheMaxSize, 512),
+		HistoryHostLevelCacheMaxSize:          dc.GetIntProperty(dynamicconfig.HistoryCacheHostLevelMaxSize, 256000),
 		HistoryCacheTTL:                       dc.GetDurationProperty(dynamicconfig.HistoryCacheTTL, time.Hour),
 		HistoryCacheNonUserContextLockTimeout: dc.GetDurationProperty(dynamicconfig.HistoryCacheNonUserContextLockTimeout, 500*time.Millisecond),
 		EnableHostLevelHistoryCache:           dc.GetBoolProperty(dynamicconfig.EnableHostHistoryCache, false),
-		HistoryShardLevelCacheMaxSize:         dc.GetIntProperty(dynamicconfig.HistoryCacheShardLevelMaxSize, 512),
 		EnableAPIGetCurrentRunIDLock:          dc.GetBoolProperty(dynamicconfig.EnableAPIGetCurrentRunIDLock, false),
 
 		EventsCacheMaxSizeBytes: dc.GetIntProperty(dynamicconfig.EventsCacheMaxSizeBytes, 512*1024), // 512KB

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -106,7 +106,7 @@ func NewHostLevelCache(
 	config *configs.Config,
 ) Cache {
 	return newCache(
-		config.HistoryCacheMaxSize(),
+		config.HistoryHostLevelCacheMaxSize(),
 		config.HistoryCacheTTL(),
 		config.HistoryCacheNonUserContextLockTimeout(),
 	)

--- a/service/history/workflow/cache/cache_test.go
+++ b/service/history/workflow/cache/cache_test.go
@@ -183,7 +183,7 @@ func (s *workflowCacheSuite) TestHistoryCachePanic() {
 }
 
 func (s *workflowCacheSuite) TestHistoryCachePinning() {
-	s.mockShard.GetConfig().HistoryCacheMaxSize = dynamicconfig.GetIntPropertyFn(1)
+	s.mockShard.GetConfig().HistoryHostLevelCacheMaxSize = dynamicconfig.GetIntPropertyFn(1)
 	namespaceID := namespace.ID("test_namespace_id")
 	s.cache = NewHostLevelCache(s.mockShard.GetConfig())
 	we := commonpb.WorkflowExecution{
@@ -242,7 +242,7 @@ func (s *workflowCacheSuite) TestHistoryCachePinning() {
 }
 
 func (s *workflowCacheSuite) TestHistoryCacheClear() {
-	s.mockShard.GetConfig().HistoryCacheMaxSize = dynamicconfig.GetIntPropertyFn(20)
+	s.mockShard.GetConfig().HistoryHostLevelCacheMaxSize = dynamicconfig.GetIntPropertyFn(20)
 	namespaceID := namespace.ID("test_namespace_id")
 	s.cache = NewHostLevelCache(s.mockShard.GetConfig())
 	we := commonpb.WorkflowExecution{
@@ -299,7 +299,7 @@ func (s *workflowCacheSuite) TestHistoryCacheConcurrentAccess_Release() {
 	cacheMaxSize := 16
 	coroutineCount := 50
 
-	s.mockShard.GetConfig().HistoryCacheMaxSize = dynamicconfig.GetIntPropertyFn(cacheMaxSize)
+	s.mockShard.GetConfig().HistoryHostLevelCacheMaxSize = dynamicconfig.GetIntPropertyFn(cacheMaxSize)
 	s.cache = NewHostLevelCache(s.mockShard.GetConfig())
 
 	startGroup := &sync.WaitGroup{}
@@ -364,7 +364,7 @@ func (s *workflowCacheSuite) TestHistoryCacheConcurrentAccess_Pin() {
 	runIDCount := cacheMaxSize * 4
 	coroutineCount := runIDCount * 64
 
-	s.mockShard.GetConfig().HistoryCacheMaxSize = dynamicconfig.GetIntPropertyFn(cacheMaxSize)
+	s.mockShard.GetConfig().HistoryHostLevelCacheMaxSize = dynamicconfig.GetIntPropertyFn(cacheMaxSize)
 	s.mockShard.GetConfig().HistoryCacheTTL = dynamicconfig.GetDurationPropertyFn(time.Nanosecond)
 	s.cache = NewHostLevelCache(s.mockShard.GetConfig())
 


### PR DESCRIPTION
## What changed?
Keep history cache dynamic config backward compatible

## Why?
Reuse the old dynamic config for shard level cache.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
