### PR TITLE
Update updateShardInfo to use the injected time source and test SetQueueState

### DIFF
--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1206,7 +1206,7 @@ func (s *ContextImpl) updateShardInfo(
 	updateFnLocked()
 	s.shardInfo.StolenSinceRenew = 0
 
-	now := cclock.NewRealTimeSource().Now()
+	now := s.timeSource.Now()
 	if s.lastUpdated.Add(s.config.ShardUpdateMinInterval()).After(now) {
 		s.wUnlock()
 		return nil


### PR DESCRIPTION
## What changed?
`ContextImpl.updateShardInfo` now uses the `timeSource` already present on the `ContextImpl` struct.

While here I added tests for `updateShardInfo` as I'm going to change our shard update logic soon.

## Why?
This let's us manipulate time when testing shard update scenarios (the behavior will change)

## How did you test it?
New unit tests

## Potential risks
None

## Is hotfix candidate?
No
