### PR TITLE
Make Retry Non-Recursive, Add Sleep Between Retries

### DIFF
--- a/service/history/replication/batchable_task.go
+++ b/service/history/replication/batchable_task.go
@@ -137,11 +137,10 @@ func (w *batchedTask) Nack(err error) {
 }
 
 func (w *batchedTask) Reschedule() {
-	if len(w.individualTasks) == 1 {
-		w.Reschedule()
-	} else {
-		w.handleIndividualTasks()
+	for len(w.individualTasks) == 1 {
+		time.Sleep(10 * time.Millisecond)
 	}
+	w.handleIndividualTasks()
 }
 
 func (w *batchedTask) State() ctasks.State {


### PR DESCRIPTION
## What changed?
Task resubmit implementation changed from recursive to loop.

## Why?
Recursive busy wait may eventually blow the stack.

## How did you test it?
Locally, run unittest.

## Potential risks
None

## Is hotfix candidate?
Yes