### PR TITLE
Handle data corruption in history resend

### DIFF
--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -32,6 +32,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
@@ -234,7 +235,7 @@ func (e *ExecutableTaskImpl) Reschedule() {
 
 func (e *ExecutableTaskImpl) IsRetryableError(err error) bool {
 	switch err.(type) {
-	case *serviceerror.InvalidArgument:
+	case *serviceerror.InvalidArgument, *serviceerror.DataLoss:
 		return false
 	default:
 		return true
@@ -355,16 +356,30 @@ func (e *ExecutableTaskImpl) Resend(
 		//  c. attempt failed due to old workflow does not exist
 		//  d. return error to resend new workflow before the branching point
 
+		if resendErr.NamespaceId == retryErr.NamespaceId &&
+			resendErr.WorkflowId == retryErr.WorkflowId &&
+			resendErr.RunId == retryErr.RunId {
+			e.Logger.Error("error resend history on the same workflow run",
+				tag.WorkflowNamespaceID(retryErr.NamespaceId),
+				tag.WorkflowID(retryErr.WorkflowId),
+				tag.WorkflowRunID(retryErr.RunId),
+				tag.NewStringTag("first-resend-error", retryErr.Error()),
+				tag.NewStringTag("second-resend-error", resendErr.Error()),
+			)
+			return false, serviceerror.NewDataLoss("failed to get requested data while resending history")
+		}
 		// handle 2nd resend error, then 1st resend error
-		if _, err := e.Resend(ctx, remoteCluster, resendErr, remainingAttempt); err == nil {
+		_, err := e.Resend(ctx, remoteCluster, resendErr, remainingAttempt)
+		if err == nil {
 			return e.Resend(ctx, remoteCluster, retryErr, remainingAttempt)
 		}
-		e.Logger.Error("error resend history for history event",
-			tag.WorkflowNamespaceID(retryErr.NamespaceId),
-			tag.WorkflowID(retryErr.WorkflowId),
-			tag.WorkflowRunID(retryErr.RunId),
-			tag.Value(retryErr),
-			tag.Error(resendErr),
+		e.Logger.Error("error resend 2nd workflow history for history event",
+			tag.WorkflowNamespaceID(resendErr.NamespaceId),
+			tag.WorkflowID(resendErr.WorkflowId),
+			tag.WorkflowRunID(resendErr.RunId),
+			tag.NewStringTag("first-resend-error", retryErr.Error()),
+			tag.NewStringTag("second-resend-error", resendErr.Error()),
+			tag.Error(err),
 		)
 		return false, resendErr
 	default:
@@ -372,8 +387,8 @@ func (e *ExecutableTaskImpl) Resend(
 			tag.WorkflowNamespaceID(retryErr.NamespaceId),
 			tag.WorkflowID(retryErr.WorkflowId),
 			tag.WorkflowRunID(retryErr.RunId),
-			tag.Value(retryErr),
-			tag.Error(resendErr),
+			tag.NewStringTag("first-resend-error", retryErr.Error()),
+			tag.NewStringTag("second-resend-error", resendErr.Error()),
 		)
 		return false, resendErr
 	}


### PR DESCRIPTION
## What changed?
Handle data corruption in history resend.

## Why?
1. When source cluster has a data corruption issue, it can ship partial data in resend history. With the two layers of resending (this is to handle resend across different workflow runs), this will cause a chain reaction. 

## How did you test it?
Unit tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
