### PR TITLE
Only update shard info when enough tasks are acked or time has passed

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -749,8 +749,6 @@ const (
 	// Note that once history.shardUpdateMinInterval amount of time has passed we'll update the shard info regardless of the number of tasks completed.
 	// When the this config is zero or lower we will only update shard info at most once every history.shardUpdateMinInterval.
 	ShardUpdateMinTasksCompleted = "history.shardUpdateMinTasksCompleted"
-	// ShardUpdateQueueMetricsInterval is the minimum amount of time between updates to a shard's queue metrics
-	ShardUpdateQueueMetricsInterval = "history.shardUpdateQueueMetricsInterval"
 	// ShardSyncMinInterval is the minimal time interval which the shard info should be sync to remote
 	ShardSyncMinInterval = "history.shardSyncMinInterval"
 	// EmitShardLagLog whether emit the shard lag log

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -745,6 +745,9 @@ const (
 	MaximumSignalsPerExecution = "history.maximumSignalsPerExecution"
 	// ShardUpdateMinInterval is the minimal time interval which the shard info can be updated
 	ShardUpdateMinInterval = "history.shardUpdateMinInterval"
+	// ShardUpdateMinTasksCompleted is the minimum number of tasks which must be completed before the shard info can be updated before
+	// history.shardUpdateMinInterval has passed
+	ShardUpdateMinTasksCompleted = "history.shardUpdateMinTasksCompleted"
 	// ShardSyncMinInterval is the minimal time interval which the shard info should be sync to remote
 	ShardSyncMinInterval = "history.shardSyncMinInterval"
 	// EmitShardLagLog whether emit the shard lag log

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -745,8 +745,9 @@ const (
 	MaximumSignalsPerExecution = "history.maximumSignalsPerExecution"
 	// ShardUpdateMinInterval is the minimal time interval which the shard info can be updated
 	ShardUpdateMinInterval = "history.shardUpdateMinInterval"
-	// ShardUpdateMinTasksCompleted is the minimum number of tasks which must be completed before the shard info can be updated before
-	// history.shardUpdateMinInterval has passed
+	// ShardUpdateMinTasksCompleted is the minimum number of tasks which must be completed (across all queues) before the shard info can be updated.
+	// Note that once history.shardUpdateMinInterval amount of time has passed we'll update the shard info regardless of the number of tasks completed.
+	// When the this config is zero or lower we will only update shard info at most once every history.shardUpdateMinInterval.
 	ShardUpdateMinTasksCompleted = "history.shardUpdateMinTasksCompleted"
 	// ShardSyncMinInterval is the minimal time interval which the shard info should be sync to remote
 	ShardSyncMinInterval = "history.shardSyncMinInterval"

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -749,6 +749,8 @@ const (
 	// Note that once history.shardUpdateMinInterval amount of time has passed we'll update the shard info regardless of the number of tasks completed.
 	// When the this config is zero or lower we will only update shard info at most once every history.shardUpdateMinInterval.
 	ShardUpdateMinTasksCompleted = "history.shardUpdateMinTasksCompleted"
+	// ShardUpdateQueueMetricsInterval is the minimum amount of time between updates to a shard's queue metrics
+	ShardUpdateQueueMetricsInterval = "history.shardUpdateQueueMetricsInterval"
 	// ShardSyncMinInterval is the minimal time interval which the shard info should be sync to remote
 	ShardSyncMinInterval = "history.shardSyncMinInterval"
 	// EmitShardLagLog whether emit the shard lag log

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -77,10 +77,6 @@ func NewBytesHistogramDef(name string, opts ...Option) histogramDefinition {
 	return histogramDefinition{globalRegistry.register(name, append(opts, WithUnit(Bytes))...)}
 }
 
-func NewMillisecondsHistogramDef(name string, opts ...Option) histogramDefinition {
-	return histogramDefinition{globalRegistry.register(name, append(opts, WithUnit(Milliseconds))...)}
-}
-
 func NewDimensionlessHistogramDef(name string, opts ...Option) histogramDefinition {
 	return histogramDefinition{globalRegistry.register(name, append(opts, WithUnit(Dimensionless))...)}
 }

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -77,6 +77,10 @@ func NewBytesHistogramDef(name string, opts ...Option) histogramDefinition {
 	return histogramDefinition{globalRegistry.register(name, append(opts, WithUnit(Bytes))...)}
 }
 
+func NewMillisecondsHistogramDef(name string, opts ...Option) histogramDefinition {
+	return histogramDefinition{globalRegistry.register(name, append(opts, WithUnit(Milliseconds))...)}
+}
+
 func NewDimensionlessHistogramDef(name string, opts ...Option) histogramDefinition {
 	return histogramDefinition{globalRegistry.register(name, append(opts, WithUnit(Dimensionless))...)}
 }

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -622,7 +622,7 @@ var (
 	HistorySize                      = NewBytesHistogramDef("history_size")
 	HistoryCount                     = NewDimensionlessHistogramDef("history_count")
 	TasksCompletedPerShardInfoUpdate = NewDimensionlessHistogramDef("tasks_per_shardinfo_update")
-	TimeBetweenShardInfoUpdates      = NewMillisecondsHistogramDef("time_between_shardinfo_update")
+	TimeBetweenShardInfoUpdates      = NewTimerDef("time_between_shardinfo_update")
 	SearchAttributesSize             = NewBytesHistogramDef("search_attributes_size")
 	MemoSize                         = NewBytesHistogramDef("memo_size")
 	TooManyPendingChildWorkflows     = NewCounterDef(

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -613,17 +613,19 @@ var (
 		"client_requests",
 		WithDescription("The number of requests sent by the client to an individual service, keyed by `service_role` and `operation`."),
 	)
-	ClientFailures               = NewCounterDef("client_errors")
-	ClientLatency                = NewTimerDef("client_latency")
-	ClientRedirectionRequests    = NewCounterDef("client_redirection_requests")
-	ClientRedirectionFailures    = NewCounterDef("client_redirection_errors")
-	ClientRedirectionLatency     = NewTimerDef("client_redirection_latency")
-	StateTransitionCount         = NewDimensionlessHistogramDef("state_transition_count")
-	HistorySize                  = NewBytesHistogramDef("history_size")
-	HistoryCount                 = NewDimensionlessHistogramDef("history_count")
-	SearchAttributesSize         = NewBytesHistogramDef("search_attributes_size")
-	MemoSize                     = NewBytesHistogramDef("memo_size")
-	TooManyPendingChildWorkflows = NewCounterDef(
+	ClientFailures                   = NewCounterDef("client_errors")
+	ClientLatency                    = NewTimerDef("client_latency")
+	ClientRedirectionRequests        = NewCounterDef("client_redirection_requests")
+	ClientRedirectionFailures        = NewCounterDef("client_redirection_errors")
+	ClientRedirectionLatency         = NewTimerDef("client_redirection_latency")
+	StateTransitionCount             = NewDimensionlessHistogramDef("state_transition_count")
+	HistorySize                      = NewBytesHistogramDef("history_size")
+	HistoryCount                     = NewDimensionlessHistogramDef("history_count")
+	TasksCompletedPerShardInfoUpdate = NewDimensionlessHistogramDef("tasks_per_shardinfo_update")
+	TimeBetweenShardInfoUpdates      = NewMillisecondsHistogramDef("time_between_shardinfo_update")
+	SearchAttributesSize             = NewBytesHistogramDef("search_attributes_size")
+	MemoSize                         = NewBytesHistogramDef("memo_size")
+	TooManyPendingChildWorkflows     = NewCounterDef(
 		"wf_too_many_pending_child_workflows",
 		WithDescription("The number of Workflow Tasks failed because they would cause the limit on the number of pending child workflows to be exceeded. See https://t.mp/limits for more information."),
 	)

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -165,6 +165,9 @@ type Config struct {
 
 	// ShardUpdateMinInterval is the minimum time interval within which the shard info can be updated.
 	ShardUpdateMinInterval dynamicconfig.DurationPropertyFn
+	// ShardUpdateMinTasksCompleted is the minimum number of tasks which must be completed before the shard info can be updated before
+	// history.shardUpdateMinInterval has passed
+	ShardUpdateMinTasksCompleted dynamicconfig.IntPropertyFn
 	// ShardSyncMinInterval is the minimum time interval within which the shard info can be synced to the remote.
 	ShardSyncMinInterval            dynamicconfig.DurationPropertyFn
 	ShardSyncTimerJitterCoefficient dynamicconfig.FloatPropertyFn
@@ -452,6 +455,7 @@ func NewConfig(
 		MaximumBufferedEventsSizeInBytes: dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsSizeInBytes, 2*1024*1024),
 		MaximumSignalsPerExecution:       dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MaximumSignalsPerExecution, 10000),
 		ShardUpdateMinInterval:           dc.GetDurationProperty(dynamicconfig.ShardUpdateMinInterval, 5*time.Minute),
+		ShardUpdateMinTasksCompleted:     dc.GetIntProperty(dynamicconfig.ShardUpdateMinTasksCompleted, 1000),
 		ShardSyncMinInterval:             dc.GetDurationProperty(dynamicconfig.ShardSyncMinInterval, 5*time.Minute),
 		ShardSyncTimerJitterCoefficient:  dc.GetFloat64Property(dynamicconfig.TransferProcessorMaxPollIntervalJitterCoefficient, 0.15),
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -168,8 +168,6 @@ type Config struct {
 	// ShardUpdateMinTasksCompleted is the minimum number of tasks which must be completed before the shard info can be updated before
 	// history.shardUpdateMinInterval has passed
 	ShardUpdateMinTasksCompleted dynamicconfig.IntPropertyFn
-	// ShardUpdateQueueMetricsInterval is the minimum amount of time between updates to a shard's queue metrics
-	ShardUpdateQueueMetricsInterval dynamicconfig.DurationPropertyFn
 	// ShardSyncMinInterval is the minimum time interval within which the shard info can be synced to the remote.
 	ShardSyncMinInterval            dynamicconfig.DurationPropertyFn
 	ShardSyncTimerJitterCoefficient dynamicconfig.FloatPropertyFn
@@ -458,7 +456,6 @@ func NewConfig(
 		MaximumSignalsPerExecution:       dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MaximumSignalsPerExecution, 10000),
 		ShardUpdateMinInterval:           dc.GetDurationProperty(dynamicconfig.ShardUpdateMinInterval, 5*time.Minute),
 		ShardUpdateMinTasksCompleted:     dc.GetIntProperty(dynamicconfig.ShardUpdateMinTasksCompleted, 1000),
-		ShardUpdateQueueMetricsInterval:  dc.GetDurationProperty(dynamicconfig.ShardUpdateQueueMetricsInterval, 5*time.Minute),
 		ShardSyncMinInterval:             dc.GetDurationProperty(dynamicconfig.ShardSyncMinInterval, 5*time.Minute),
 		ShardSyncTimerJitterCoefficient:  dc.GetFloat64Property(dynamicconfig.TransferProcessorMaxPollIntervalJitterCoefficient, 0.15),
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -168,6 +168,8 @@ type Config struct {
 	// ShardUpdateMinTasksCompleted is the minimum number of tasks which must be completed before the shard info can be updated before
 	// history.shardUpdateMinInterval has passed
 	ShardUpdateMinTasksCompleted dynamicconfig.IntPropertyFn
+	// ShardUpdateQueueMetricsInterval is the minimum amount of time between updates to a shard's queue metrics
+	ShardUpdateQueueMetricsInterval dynamicconfig.DurationPropertyFn
 	// ShardSyncMinInterval is the minimum time interval within which the shard info can be synced to the remote.
 	ShardSyncMinInterval            dynamicconfig.DurationPropertyFn
 	ShardSyncTimerJitterCoefficient dynamicconfig.FloatPropertyFn
@@ -456,6 +458,7 @@ func NewConfig(
 		MaximumSignalsPerExecution:       dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MaximumSignalsPerExecution, 10000),
 		ShardUpdateMinInterval:           dc.GetDurationProperty(dynamicconfig.ShardUpdateMinInterval, 5*time.Minute),
 		ShardUpdateMinTasksCompleted:     dc.GetIntProperty(dynamicconfig.ShardUpdateMinTasksCompleted, 1000),
+		ShardUpdateQueueMetricsInterval:  dc.GetDurationProperty(dynamicconfig.ShardUpdateQueueMetricsInterval, 5*time.Minute),
 		ShardSyncMinInterval:             dc.GetDurationProperty(dynamicconfig.ShardSyncMinInterval, 5*time.Minute),
 		ShardSyncTimerJitterCoefficient:  dc.GetFloat64Property(dynamicconfig.TransferProcessorMaxPollIntervalJitterCoefficient, 0.15),
 

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -57,7 +57,7 @@ type (
 		AppendSlices(...Slice)
 		ClearSlices(SlicePredicate)
 		CompactSlices(SlicePredicate)
-		ShrinkSlices()
+		ShrinkSlices() int
 
 		Notify()
 		Pause(time.Duration)
@@ -364,16 +364,18 @@ func (r *ReaderImpl) CompactSlices(predicate SlicePredicate) {
 	r.monitor.SetSliceCount(r.readerID, r.slices.Len())
 }
 
-func (r *ReaderImpl) ShrinkSlices() {
+// Shrink all queue slices, returning the number of tasks removed (completed)
+func (r *ReaderImpl) ShrinkSlices() int {
 	r.Lock()
 	defer r.Unlock()
 
+	var tasksCompleted int
 	var next *list.Element
 	for element := r.slices.Front(); element != nil; element = next {
 		next = element.Next()
 
 		slice := element.Value.(Slice)
-		slice.ShrinkScope()
+		tasksCompleted += slice.ShrinkScope()
 		if scope := slice.Scope(); scope.IsEmpty() {
 			r.monitor.RemoveSlice(slice)
 			r.slices.Remove(element)
@@ -381,6 +383,7 @@ func (r *ReaderImpl) ShrinkSlices() {
 	}
 
 	r.monitor.SetSliceCount(r.readerID, r.slices.Len())
+	return tasksCompleted
 }
 
 func (r *ReaderImpl) Notify() {

--- a/service/history/queues/reader_group_test.go
+++ b/service/history/queues/reader_group_test.go
@@ -221,6 +221,6 @@ func (r *testReader) MergeSlices(...Slice)         { panic("not implemented") }
 func (r *testReader) AppendSlices(...Slice)        { panic("not implemented") }
 func (r *testReader) ClearSlices(SlicePredicate)   { panic("not implemented") }
 func (r *testReader) CompactSlices(SlicePredicate) { panic("not implemented") }
-func (r *testReader) ShrinkSlices()                { panic("not implemented") }
+func (r *testReader) ShrinkSlices() int            { panic("not implemented") }
 func (r *testReader) Notify()                      { panic("not implemented") }
 func (r *testReader) Pause(time.Duration)          { panic("not implemented") }

--- a/service/history/queues/reader_test.go
+++ b/service/history/queues/reader_test.go
@@ -248,7 +248,8 @@ func (s *readerSuite) TestShrinkSlices() {
 	}
 
 	reader := s.newTestReader(scopes, nil, NoopReaderCompletionFn)
-	reader.ShrinkSlices()
+	completed := reader.ShrinkSlices()
+	s.Equal(0, completed)
 
 	actualScopes := reader.Scopes()
 	s.Len(actualScopes, numScopes-len(emptyIdx))

--- a/service/history/queues/slice.go
+++ b/service/history/queues/slice.go
@@ -49,7 +49,7 @@ type (
 		CanMergeWithSlice(Slice) bool
 		MergeWithSlice(Slice) []Slice
 		CompactWithSlice(Slice) Slice
-		ShrinkScope()
+		ShrinkScope() int
 		SelectTasks(readerID int64, batchSize int) ([]Executable, error)
 		MoreTasks() bool
 		TaskStats() TaskStats
@@ -309,19 +309,21 @@ func (s *SliceImpl) CompactWithSlice(slice Slice) Slice {
 	)
 }
 
-func (s *SliceImpl) ShrinkScope() {
+func (s *SliceImpl) ShrinkScope() int {
 	s.stateSanityCheck()
 
-	s.shrinkRange()
+	tasksCompleted := s.shrinkRange()
 	s.shrinkPredicate()
 
 	// shrinkRange shrinks the executableTracker, which may remove tracked pending executables. Set the
 	// pending task count to reflect that.
 	s.monitor.SetSlicePendingTaskCount(s, len(s.executableTracker.pendingExecutables))
+
+	return tasksCompleted
 }
 
-func (s *SliceImpl) shrinkRange() {
-	minPendingTaskKey := s.executableTracker.shrink()
+func (s *SliceImpl) shrinkRange() int {
+	minPendingTaskKey, tasksCompleted := s.executableTracker.shrink()
 
 	minIteratorKey := tasks.MaximumKey
 	if len(s.iterators) != 0 {
@@ -337,6 +339,8 @@ func (s *SliceImpl) shrinkRange() {
 	}
 
 	s.scope.Range.InclusiveMin = newRangeMin
+
+	return tasksCompleted
 }
 
 func (s *SliceImpl) shrinkPredicate() {

--- a/service/history/queues/slice_test.go
+++ b/service/history/queues/slice_test.go
@@ -374,7 +374,7 @@ func (s *sliceSuite) TestShrinkScope_ShrinkRange() {
 		slice.pendingExecutables[executable.GetKey()] = executable
 	}
 
-	slice.ShrinkScope()
+	s.Equal(numAcked, slice.ShrinkScope())
 	s.Len(slice.pendingExecutables, len(executables)-numAcked)
 	s.validateSliceState(slice)
 

--- a/service/history/queues/tracker.go
+++ b/service/history/queues/tracker.go
@@ -106,12 +106,14 @@ func (t *executableTracker) add(
 	t.pendingPerKey[key]++
 }
 
-func (t *executableTracker) shrink() tasks.Key {
+func (t *executableTracker) shrink() (tasks.Key, int) {
+	var tasksCompleted int
 	minPendingTaskKey := tasks.MaximumKey
 	for key, executable := range t.pendingExecutables {
 		if executable.State() == ctasks.TaskStateAcked {
 			t.pendingPerKey[t.grouper.Key(executable)]--
 			delete(t.pendingExecutables, key)
+			tasksCompleted++
 			continue
 		}
 
@@ -124,7 +126,7 @@ func (t *executableTracker) shrink() tasks.Key {
 		}
 	}
 
-	return minPendingTaskKey
+	return minPendingTaskKey, tasksCompleted
 }
 
 func (t *executableTracker) clear() {

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -87,7 +87,7 @@ type (
 
 		GetQueueExclusiveHighReadWatermark(category tasks.Category) tasks.Key
 		GetQueueState(category tasks.Category) (*persistencespb.QueueState, bool)
-		SetQueueState(category tasks.Category, state *persistencespb.QueueState) error
+		SetQueueState(category tasks.Category, tasksCompleted int, state *persistencespb.QueueState) error
 		UpdateReplicationQueueReaderState(readerID int64, readerState *persistencespb.QueueReaderState) error
 
 		GetReplicatorDLQAckLevel(sourceCluster string) int64

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1225,6 +1225,9 @@ func (s *ContextImpl) updateShardInfo(
 
 	// update lastUpdate here so that we don't have to grab shard lock again if UpdateShard is successful
 	previousLastUpdate := s.lastUpdated
+	metrics.TasksCompletedPerShardInfoUpdate.With(s.metricsHandler).Record(int64(s.tasksCompletedSinceLastUpdate))
+	metrics.TimeBetweenShardInfoUpdates.With(s.metricsHandler).Record(now.Sub(previousLastUpdate).Milliseconds())
+
 	s.lastUpdated = now
 	s.tasksCompletedSinceLastUpdate = 0
 

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1226,7 +1226,7 @@ func (s *ContextImpl) updateShardInfo(
 	// update lastUpdate here so that we don't have to grab shard lock again if UpdateShard is successful
 	previousLastUpdate := s.lastUpdated
 	metrics.TasksCompletedPerShardInfoUpdate.With(s.metricsHandler).Record(int64(s.tasksCompletedSinceLastUpdate))
-	metrics.TimeBetweenShardInfoUpdates.With(s.metricsHandler).Record(now.Sub(previousLastUpdate).Milliseconds())
+	metrics.TimeBetweenShardInfoUpdates.With(s.metricsHandler).Record(now.Sub(previousLastUpdate))
 
 	s.lastUpdated = now
 	s.tasksCompletedSinceLastUpdate = 0

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -622,17 +622,17 @@ func (mr *MockContextMockRecorder) SetCurrentTime(cluster, currentTime interface
 }
 
 // SetQueueState mocks base method.
-func (m *MockContext) SetQueueState(category tasks.Category, state *v13.QueueState) error {
+func (m *MockContext) SetQueueState(category tasks.Category, tasksCompleted int, state *v13.QueueState) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetQueueState", category, state)
+	ret := m.ctrl.Call(m, "SetQueueState", category, tasksCompleted, state)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetQueueState indicates an expected call of SetQueueState.
-func (mr *MockContextMockRecorder) SetQueueState(category, state interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) SetQueueState(category, tasksCompleted, state interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetQueueState", reflect.TypeOf((*MockContext)(nil).SetQueueState), category, state)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetQueueState", reflect.TypeOf((*MockContext)(nil).SetQueueState), category, tasksCompleted, state)
 }
 
 // SetWorkflowExecution mocks base method.
@@ -1350,17 +1350,17 @@ func (mr *MockControllableContextMockRecorder) SetCurrentTime(cluster, currentTi
 }
 
 // SetQueueState mocks base method.
-func (m *MockControllableContext) SetQueueState(category tasks.Category, state *v13.QueueState) error {
+func (m *MockControllableContext) SetQueueState(category tasks.Category, tasksCompleted int, state *v13.QueueState) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetQueueState", category, state)
+	ret := m.ctrl.Call(m, "SetQueueState", category, tasksCompleted, state)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetQueueState indicates an expected call of SetQueueState.
-func (mr *MockControllableContextMockRecorder) SetQueueState(category, state interface{}) *gomock.Call {
+func (mr *MockControllableContextMockRecorder) SetQueueState(category, tasksCompleted, state interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetQueueState", reflect.TypeOf((*MockControllableContext)(nil).SetQueueState), category, state)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetQueueState", reflect.TypeOf((*MockControllableContext)(nil).SetQueueState), category, tasksCompleted, state)
 }
 
 // SetWorkflowExecution mocks base method.

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -722,19 +722,19 @@ func (s *contextSuite) TestUpdateShardInfo_CallbackIsInvoked_EvenWhenNotPersiste
 
 	s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).
 		Return(nil).Times(1)
-	err := s.mockShard.updateShardInfo(callback)
+	err := s.mockShard.updateShardInfo(0, callback)
 	s.NoError(err)
 
 	// No time has passed. This shouldn't touch the db
 	s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).
 		Return(nil).Times(0)
-	err = s.mockShard.updateShardInfo(callback)
+	err = s.mockShard.updateShardInfo(0, callback)
 	s.NoError(err)
 
 	s.Equal(2, timesCalled)
 }
 
-func (s *contextSuite) TestUpdateShardInfo_PersistsAfterInterval() {
+func (s *contextSuite) TestUpdateShardInfo_PersistsAfterInterval_RegardlessOfTasksCompleted() {
 	s.mockShard.state = contextStateAcquired
 
 	// We only expect the first and third calls to updateShardInfo to hit the database
@@ -746,19 +746,41 @@ func (s *contextSuite) TestUpdateShardInfo_PersistsAfterInterval() {
 
 	s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).
 		Return(nil).Times(1)
-	err := s.mockShard.updateShardInfo(callback)
+	err := s.mockShard.updateShardInfo(0, callback)
 	s.NoError(err)
 
 	// No time has passed: shouldn't update the database.
 	s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).
 		Return(nil).Times(0)
-	err = s.mockShard.updateShardInfo(callback)
+	err = s.mockShard.updateShardInfo(0, callback)
 	s.NoError(err)
 
 	s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).
 		Return(nil).Times(1)
 	s.timeSource.Update(time.Now().Add(s.mockShard.config.ShardUpdateMinInterval()))
-	err = s.mockShard.updateShardInfo(callback)
+	err = s.mockShard.updateShardInfo(0, callback)
+	s.NoError(err)
+	s.Equal(3, timesCalled)
+}
+
+func (s *contextSuite) TestUpdateShardInfo_PersistsBeforeInterval_WhenEnoughTasksCompleted() {
+	s.mockShard.state = contextStateAcquired
+	s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).
+		Return(nil).Times(2)
+
+	var timesCalled int
+	callback := func() {
+		timesCalled++
+	}
+	tasksNecessaryForUpdate := s.mockShard.config.ShardUpdateMinTasksCompleted()
+	err := s.mockShard.updateShardInfo(tasksNecessaryForUpdate, callback)
+	s.NoError(err)
+
+	// No time has passed and too few tasks completed: shouldn't update
+	err = s.mockShard.updateShardInfo(tasksNecessaryForUpdate-1, callback)
+	s.NoError(err)
+
+	err = s.mockShard.updateShardInfo(1, callback)
 	s.NoError(err)
 	s.Equal(3, timesCalled)
 }
@@ -768,7 +790,7 @@ func (s *contextSuite) TestUpdateShardInfo_FailsUnlessShardAcquired() {
 		contextStateInitialized, contextStateAcquiring, contextStateStopping, contextStateStopped,
 	} {
 		s.mockShard.state = state
-		s.Error(s.mockShard.updateShardInfo(func() {
+		s.Error(s.mockShard.updateShardInfo(0, func() {
 			s.Fail("Should not have called update callback when in state %v", state)
 		}))
 
@@ -778,7 +800,7 @@ func (s *contextSuite) TestUpdateShardInfo_FailsUnlessShardAcquired() {
 	s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).
 		Return(nil).Times(1)
 	var called bool
-	s.NoError(s.mockShard.updateShardInfo(func() {
+	s.NoError(s.mockShard.updateShardInfo(0, func() {
 		called = true
 	}))
 	s.True(called)

--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -27,7 +27,7 @@ package shard
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
+	"sync"
 
 	"github.com/golang/mock/gomock"
 	"golang.org/x/sync/semaphore"
@@ -144,18 +144,18 @@ func newTestContext(t *resourcetest.Test, eventsCache events.Cache, config Conte
 	}
 
 	ctx := &ContextImpl{
-		shardID:              config.ShardInfo.GetShardId(),
-		owner:                config.ShardInfo.GetOwner(),
-		stringRepr:           fmt.Sprintf("Shard(%d)", config.ShardInfo.GetShardId()),
-		executionManager:     executionManager,
-		metricsHandler:       t.MetricsHandler,
-		eventsCache:          eventsCache,
-		config:               config.Config,
-		contextTaggedLogger:  t.GetLogger(),
-		throttledLogger:      t.GetThrottledLogger(),
-		lifecycleCtx:         lifecycleCtx,
-		lifecycleCancel:      lifecycleCancel,
-		emittingQueueMetrics: &atomic.Bool{},
+		shardID:             config.ShardInfo.GetShardId(),
+		owner:               config.ShardInfo.GetOwner(),
+		stringRepr:          fmt.Sprintf("Shard(%d)", config.ShardInfo.GetShardId()),
+		executionManager:    executionManager,
+		metricsHandler:      t.MetricsHandler,
+		eventsCache:         eventsCache,
+		config:              config.Config,
+		contextTaggedLogger: t.GetLogger(),
+		throttledLogger:     t.GetThrottledLogger(),
+		lifecycleCtx:        lifecycleCtx,
+		lifecycleCancel:     lifecycleCancel,
+		queueMetricEmitter:  sync.Once{},
 
 		state:              contextStateAcquired,
 		engineFuture:       future.NewFuture[Engine](),

--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -27,6 +27,7 @@ package shard
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/golang/mock/gomock"
 	"golang.org/x/sync/semaphore"
@@ -143,17 +144,18 @@ func newTestContext(t *resourcetest.Test, eventsCache events.Cache, config Conte
 	}
 
 	ctx := &ContextImpl{
-		shardID:             config.ShardInfo.GetShardId(),
-		owner:               config.ShardInfo.GetOwner(),
-		stringRepr:          fmt.Sprintf("Shard(%d)", config.ShardInfo.GetShardId()),
-		executionManager:    executionManager,
-		metricsHandler:      t.MetricsHandler,
-		eventsCache:         eventsCache,
-		config:              config.Config,
-		contextTaggedLogger: t.GetLogger(),
-		throttledLogger:     t.GetThrottledLogger(),
-		lifecycleCtx:        lifecycleCtx,
-		lifecycleCancel:     lifecycleCancel,
+		shardID:              config.ShardInfo.GetShardId(),
+		owner:                config.ShardInfo.GetOwner(),
+		stringRepr:           fmt.Sprintf("Shard(%d)", config.ShardInfo.GetShardId()),
+		executionManager:     executionManager,
+		metricsHandler:       t.MetricsHandler,
+		eventsCache:          eventsCache,
+		config:               config.Config,
+		contextTaggedLogger:  t.GetLogger(),
+		throttledLogger:      t.GetThrottledLogger(),
+		lifecycleCtx:         lifecycleCtx,
+		lifecycleCancel:      lifecycleCancel,
+		emittingQueueMetrics: &atomic.Bool{},
 
 		state:              contextStateAcquired,
 		engineFuture:       future.NewFuture[Engine](),

--- a/service/history/visibility_queue_task_executor_test.go
+++ b/service/history/visibility_queue_task_executor_test.go
@@ -532,7 +532,7 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessorDeleteExecution() {
 	})
 	s.Run("MultiCursorQueue", func() {
 		const highWatermark int64 = 5
-		s.NoError(s.mockShard.SetQueueState(tasks.CategoryVisibility, &persistencespb.QueueState{
+		s.NoError(s.mockShard.SetQueueState(tasks.CategoryVisibility, 1, &persistencespb.QueueState{
 			ReaderStates: nil,
 			ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
 				TaskId:   highWatermark,


### PR DESCRIPTION
## What changed?

Our shard info update logic now monitors how many tasks have been completed across all queues. If enough changes have occurred it will persist changes to our database even if `ShardUpdateMinInterval` time hasn't elapsed since the last change. The time between updates and the number of tasks completed per update can be monitored using `tasks_per_shardinfo_update` and `time_between_shardinfo_updates` metrics.

While here I extracted the metric calculation from the updateShardInfo function.
In the previous code we'd stop updating metrics if we stopped updating shard info
which isn't the behavior we want. Now it's handled by a separate goroutine that
grabs the shard's read lock as needed.

Follow-up work will handle updating shard info based on replication task completion if it makes sense to.

## Why?

When we have a large number of shards updating shard info every five minutes (the default) can be costly. If we persist after enough changes have occurred we can increase this interval and reduce the load on our DB.

## How did you test it?

I added a handful of new unit tests to verify the behavior

## Potential risks

None

## Is hotfix candidate?

No
