### PR TITLE
Improve error type extraction for logs

### DIFF
--- a/client/admin/metric_client.go
+++ b/client/admin/metric_client.go
@@ -85,7 +85,7 @@ func (c *metricClient) finishMetricsRecording(
 			*serviceerror.WorkflowExecutionAlreadyStarted:
 			// noop - not interest and too many logs
 		default:
-			c.throttledLogger.Info("admin client encountered error", tag.Error(err), tag.ErrorType(err))
+			c.throttledLogger.Info("admin client encountered error", tag.Error(err), tag.ServiceErrorType(err))
 		}
 		metrics.ClientFailures.With(metricsHandler).Record(1, metrics.ServiceErrorTypeTag(err))
 	}

--- a/client/frontend/metric_client.go
+++ b/client/frontend/metric_client.go
@@ -84,7 +84,7 @@ func (c *metricClient) finishMetricsRecording(
 			*serviceerror.WorkflowExecutionAlreadyStarted:
 			// noop - not interest and too many logs
 		default:
-			c.throttledLogger.Info("frontend client encountered error", tag.Error(err), tag.ErrorType(err))
+			c.throttledLogger.Info("frontend client encountered error", tag.Error(err), tag.ServiceErrorType(err))
 		}
 		metrics.ClientFailures.With(handler).Record(1, metrics.ServiceErrorTypeTag(err))
 	}

--- a/client/history/metric_client.go
+++ b/client/history/metric_client.go
@@ -101,7 +101,7 @@ func (c *metricClient) finishMetricsRecording(
 			*serviceerror.WorkflowExecutionAlreadyStarted:
 			// noop - not interest and too many logs
 		default:
-			c.throttledLogger.Info("history client encountered error", tag.Error(err), tag.ErrorType(err))
+			c.throttledLogger.Info("history client encountered error", tag.Error(err), tag.ServiceErrorType(err))
 		}
 		metrics.ClientFailures.With(metricsHandler).Record(1, metrics.ServiceErrorTypeTag(err))
 	}

--- a/client/matching/metric_client.go
+++ b/client/matching/metric_client.go
@@ -216,7 +216,7 @@ func (c *metricClient) finishMetricsRecording(
 			*serviceerror.WorkflowExecutionAlreadyStarted:
 			// noop - not interest and too many logs
 		default:
-			c.throttledLogger.Info("matching client encountered error", tag.Error(err), tag.ErrorType(err))
+			c.throttledLogger.Info("matching client encountered error", tag.Error(err), tag.ServiceErrorType(err))
 		}
 		metrics.ClientFailures.With(metricsHandler).Record(1, metrics.ServiceErrorTypeTag(err))
 	}

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -26,7 +26,6 @@ package tag
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
@@ -34,6 +33,7 @@ import (
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/util"
 )
 
 // All logging tags are defined in this file.
@@ -46,9 +46,6 @@ import (
 // LoggingCallAtKey is reserved tag
 const (
 	LoggingCallAtKey = "logging-call-at"
-
-	getType     = "%T"
-	errorPrefix = "*"
 )
 
 // ==========  Common tags defined here ==========
@@ -63,9 +60,9 @@ func Error(err error) ZapTag {
 	return NewErrorTag(err)
 }
 
-// ErrorType returns tag for ErrorType
-func ErrorType(err error) ZapTag {
-	return NewStringTag("service-error-type", strings.TrimPrefix(fmt.Sprintf(getType, err), errorPrefix))
+// ServiceErrorType returns tag for ServiceErrorType
+func ServiceErrorType(err error) ZapTag {
+	return NewStringTag("service-error-type", util.ErrorType(err))
 }
 
 // IsRetryable returns tag for IsRetryable
@@ -366,6 +363,11 @@ func operationResult(operationResult string) ZapTag {
 }
 
 // ErrorType returns tag for ErrorType
+func ErrorType(err error) ZapTag {
+	return errorType(util.ErrorType(err))
+}
+
+// errorType returns tag for ErrorType given a string
 func errorType(errorType string) ZapTag {
 	return NewStringTag("error-type", errorType)
 }

--- a/common/log/tag/tags_test.go
+++ b/common/log/tag/tags_test.go
@@ -44,6 +44,6 @@ func TestErrorType(t *testing.T) {
 	}
 
 	for id, data := range testData {
-		assert.Equal(t, data.expectedResult, ErrorType(data.err).Value().(string), "Unexpected error type in index", id)
+		assert.Equal(t, data.expectedResult, ServiceErrorType(data.err).Value().(string), "Unexpected error type in index %d", id)
 	}
 }

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -32,6 +32,7 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/util"
 )
 
 const (
@@ -254,7 +255,7 @@ func VersionedTag(versioned bool) Tag {
 }
 
 func ServiceErrorTypeTag(err error) Tag {
-	return &tagImpl{key: ErrorTypeTagName, value: strings.TrimPrefix(errorType(err), errorPrefix)}
+	return &tagImpl{key: ErrorTypeTagName, value: strings.TrimPrefix(util.ErrorType(err), errorPrefix)}
 }
 
 // HttpStatusTag returns a new httpStatusTag.

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -410,7 +410,6 @@ func (e *executableImpl) isUnexpectedNonRetryableError(err error) bool {
 
 	isInternalError := common.IsInternalError(err)
 	if isInternalError {
-		e.logger.Error("Encountered internal error processing tasks", tag.Error(err))
 		metrics.TaskInternalErrorCounter.With(e.taggedMetricsHandler).Record(1)
 		// Only DQL/drop when configured to
 		return e.dlqInternalErrors()
@@ -464,18 +463,18 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 		metrics.TaskCorruptionCounter.With(e.taggedMetricsHandler).Record(1)
 		if e.dlqEnabled() {
 			// Keep this message in sync with the log line mentioned in Investigation section of develop/docs/dlq.md
-			e.logger.Error("Marking task as terminally failed, will send to DLQ", tag.Error(err))
+			e.logger.Error("Marking task as terminally failed, will send to DLQ", tag.Error(err), tag.ErrorType(err))
 			e.terminalFailureCause = err
 			return fmt.Errorf("%w: %v", ErrTerminalTaskFailure, err)
 		}
-		e.logger.Error("Dropping task due to terminal error", tag.Error(err))
+		e.logger.Error("Dropping task due to terminal error", tag.Error(err), tag.ErrorType(err))
 		return nil
 	}
 
 	// Unexpected but retryable error
 	e.unexpectedErrorAttempts++
 	metrics.TaskFailures.With(e.taggedMetricsHandler).Record(1)
-	e.logger.Error("Fail to process task", tag.Error(err), tag.UnexpectedErrorAttempts(int32(e.unexpectedErrorAttempts)), tag.LifeCycleProcessingFailed)
+	e.logger.Error("Fail to process task", tag.Error(err), tag.ErrorType(err), tag.UnexpectedErrorAttempts(int32(e.unexpectedErrorAttempts)), tag.LifeCycleProcessingFailed)
 
 	if e.unexpectedErrorAttempts >= e.maxUnexpectedErrorAttempts() && e.dlqEnabled() {
 		// Keep this message in sync with the log line mentioned in Investigation section of develop/docs/dlq.md

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -504,7 +504,7 @@ func (t *transferQueueActiveTaskExecutor) processCancelExecution(
 		case *serviceerror.NamespaceNotFound:
 			failedCause = enumspb.CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_NAMESPACE_NOT_FOUND
 		default:
-			t.logger.Error("Unexpected error type returned from RequestCancelWorkflowExecution API call.", tag.ErrorType(err), tag.Error(err))
+			t.logger.Error("Unexpected error type returned from RequestCancelWorkflowExecution API call.", tag.ServiceErrorType(err), tag.Error(err))
 			return err
 		}
 		return t.requestCancelExternalExecutionFailed(
@@ -637,7 +637,7 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 		case *serviceerror.InvalidArgument:
 			failedCause = enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_SIGNAL_COUNT_LIMIT_EXCEEDED
 		default:
-			t.logger.Error("Unexpected error type returned from SignalWorkflowExecution API call.", tag.ErrorType(err), tag.Error(err))
+			t.logger.Error("Unexpected error type returned from SignalWorkflowExecution API call.", tag.ServiceErrorType(err), tag.Error(err))
 			return err
 		}
 		return t.signalExternalExecutionFailed(
@@ -835,7 +835,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		case *serviceerror.NamespaceNotFound:
 			failedCause = enumspb.START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_NAMESPACE_NOT_FOUND
 		default:
-			t.logger.Error("Unexpected error type returned from StartWorkflowExecution API call for child workflow.", tag.ErrorType(err), tag.Error(err))
+			t.logger.Error("Unexpected error type returned from StartWorkflowExecution API call for child workflow.", tag.ServiceErrorType(err), tag.Error(err))
 			return err
 		}
 

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -898,7 +898,7 @@ var TraceExportModule = fx.Options(
 	fx.Invoke(func(log log.Logger) {
 		otel.SetErrorHandler(otel.ErrorHandlerFunc(
 			func(err error) {
-				log.Warn("OTEL error", tag.Error(err), tag.ErrorType(err))
+				log.Warn("OTEL error", tag.Error(err), tag.ServiceErrorType(err))
 			}),
 		)
 	}),


### PR DESCRIPTION
## What changed?

1. Port the type unwrapping code from our metrics to our util package and use it
2. Rename tag.ErrorType to tag.ServiceErrorType and create a new tag.ErrorType
3. Report the type for all task errors we log

## Why?

So that we know what type of unexpected errors we're encountering during task processing 

## How did you test it?


## Potential risks

## Is hotfix candidate?
