### PR TITLE
Remove 3 methods from WorkflowLease interface

### DIFF
--- a/service/history/api/consistency_checker.go
+++ b/service/history/api/consistency_checker.go
@@ -294,7 +294,7 @@ func (c *WorkflowConsistencyCheckerImpl) getCurrentWorkflowContext(
 		wfContext.GetReleaseFn()(err)
 		return nil, err
 	}
-	if currentRunID == wfContext.GetWorkflowKey().RunID {
+	if currentRunID == wfContext.GetContext().GetWorkflowKey().RunID {
 		return wfContext, nil
 	}
 

--- a/service/history/api/pollupdate/api.go
+++ b/service/history/api/pollupdate/api.go
@@ -69,8 +69,9 @@ func Invoke(
 		}
 		release := workflowLease.GetReleaseFn()
 		defer release(nil)
-		upd, found := workflowLease.GetUpdateRegistry(ctx).Find(ctx, updateRef.UpdateId)
-		wfKey := workflowLease.GetWorkflowKey()
+		wfCtx := workflowLease.GetContext()
+		upd, found := wfCtx.UpdateRegistry(ctx).Find(ctx, updateRef.UpdateId)
+		wfKey := wfCtx.GetWorkflowKey()
 		return &wfKey, upd, found, nil
 	}()
 	if err != nil {

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -64,7 +64,7 @@ func SignalWithStartWorkflow(
 		); err != nil {
 			return "", err
 		}
-		return currentWorkflowLease.GetWorkflowKey().RunID, nil
+		return currentWorkflowLease.GetContext().GetWorkflowKey().RunID, nil
 	}
 	// else, either workflow is not running or restart requested
 	return startAndSignalWorkflow(
@@ -157,7 +157,7 @@ func createWorkflowMutationFunction(
 		currentExecutionState.RunId,
 		currentExecutionState.State,
 		currentExecutionState.Status,
-		currentWorkflowLease.GetWorkflowKey().WorkflowID,
+		currentWorkflowLease.GetContext().GetWorkflowKey().WorkflowID,
 		newRunID,
 		workflowIDReusePolicy,
 	)
@@ -248,7 +248,7 @@ func startAndSignalWithoutCurrentWorkflow(
 	)
 	switch failedErr := err.(type) {
 	case nil:
-		return newWorkflowLease.GetWorkflowKey().RunID, nil
+		return newWorkflowLease.GetContext().GetWorkflowKey().RunID, nil
 	case *persistence.CurrentWorkflowConditionFailedError:
 		if failedErr.RequestID == requestID {
 			return failedErr.RunID, nil

--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -118,7 +118,7 @@ func Invoke(
 			}
 
 			updateID := req.GetRequest().GetRequest().GetMeta().GetUpdateId()
-			updateReg := workflowLease.GetUpdateRegistry(ctx)
+			updateReg := workflowLease.GetContext().UpdateRegistry(ctx)
 			var (
 				alreadyExisted bool
 				err            error

--- a/service/history/api/workflow_context.go
+++ b/service/history/api/workflow_context.go
@@ -25,23 +25,14 @@
 package api
 
 import (
-	"context"
-
-	"go.temporal.io/server/common/definition"
-	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
-	"go.temporal.io/server/service/history/workflow/update"
 )
 
 type WorkflowLease interface {
 	GetContext() workflow.Context
 	GetMutableState() workflow.MutableState
 	GetReleaseFn() wcache.ReleaseCacheFunc
-
-	GetNamespaceEntry() *namespace.Namespace
-	GetWorkflowKey() definition.WorkflowKey
-	GetUpdateRegistry(context.Context) update.Registry
 }
 
 type workflowLease struct {
@@ -90,16 +81,4 @@ func (w *workflowLease) GetMutableState() workflow.MutableState {
 
 func (w *workflowLease) GetReleaseFn() wcache.ReleaseCacheFunc {
 	return w.releaseFn
-}
-
-func (w *workflowLease) GetNamespaceEntry() *namespace.Namespace {
-	return w.mutableState.GetNamespaceEntry()
-}
-
-func (w *workflowLease) GetWorkflowKey() definition.WorkflowKey {
-	return w.context.GetWorkflowKey()
-}
-
-func (w *workflowLease) GetUpdateRegistry(ctx context.Context) update.Registry {
-	return w.context.UpdateRegistry(ctx)
 }

--- a/service/history/workflow_task_handler_callbacks.go
+++ b/service/history/workflow_task_handler_callbacks.go
@@ -231,7 +231,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 			if workflowTask.StartedEventID != common.EmptyEventID {
 				// If workflow task is started as part of the current request scope then return a positive response
 				if workflowTask.RequestID == requestID {
-					resp, err = handler.createRecordWorkflowTaskStartedResponse(ctx, mutableState, workflowLease.GetUpdateRegistry(ctx), workflowTask, req.PollRequest.GetIdentity(), false)
+					resp, err = handler.createRecordWorkflowTaskStartedResponse(ctx, mutableState, workflowLease.GetContext().UpdateRegistry(ctx), workflowTask, req.PollRequest.GetIdentity(), false)
 					if err != nil {
 						return nil, err
 					}
@@ -287,7 +287,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 				metrics.TaskQueueTypeTag(enumspb.TASK_QUEUE_TYPE_WORKFLOW),
 			)
 
-			resp, err = handler.createRecordWorkflowTaskStartedResponse(ctx, mutableState, workflowLease.GetUpdateRegistry(ctx), workflowTask, req.PollRequest.GetIdentity(), false)
+			resp, err = handler.createRecordWorkflowTaskStartedResponse(ctx, mutableState, workflowLease.GetContext().UpdateRegistry(ctx), workflowTask, req.PollRequest.GetIdentity(), false)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Remove 3 methods from `WorkflowLease` interface. Following amazing #5386 rename PR.

## Why?
<!-- Tell your future self why have you made these changes -->
Because they don't belong to `WorkflowLease` interface.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Build locally.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.