### PR TITLE
Remove GetHistoryTree from persistence manager

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -125,9 +125,7 @@ const (
 	PersistenceDeleteHistoryBranchScope = "DeleteHistoryBranch"
 	// PersistenceTrimHistoryBranchScope tracks TrimHistoryBranch calls made by service to persistence layer
 	PersistenceTrimHistoryBranchScope = "TrimHistoryBranch"
-	// PersistenceGetHistoryTreeScope tracks GetHistoryTree calls made by service to persistence layer
-	PersistenceGetHistoryTreeScope = "GetHistoryTree"
-	// PersistenceGetAllHistoryTreeBranchesScope tracks GetHistoryTree calls made by service to persistence layer
+	// PersistenceGetAllHistoryTreeBranchesScope tracks GetAllHistoryTreeBranches calls made by service to persistence layer
 	PersistenceGetAllHistoryTreeBranchesScope = "GetAllHistoryTreeBranches"
 	// PersistenceNamespaceReplicationQueueScope is the metrics scope for namespace replication queue
 	PersistenceNamespaceReplicationQueueScope = "NamespaceReplicationQueue"

--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -374,7 +374,7 @@ func (h *HistoryStore) GetAllHistoryTreeBranches(
 // GetHistoryTree returns all branch information of a tree
 func (h *HistoryStore) GetHistoryTree(
 	ctx context.Context,
-	request *p.GetHistoryTreeRequest,
+	request *p.InternalGetHistoryTreeRequest,
 ) (*p.InternalGetHistoryTreeResponse, error) {
 
 	treeID, err := primitives.ValidateUUID(request.TreeID)

--- a/common/persistence/client/fault_injection.go
+++ b/common/persistence/client/fault_injection.go
@@ -790,7 +790,7 @@ func (e *FaultInjectionExecutionStore) DeleteHistoryBranch(
 
 func (e *FaultInjectionExecutionStore) GetHistoryTree(
 	ctx context.Context,
-	request *persistence.GetHistoryTreeRequest,
+	request *persistence.InternalGetHistoryTreeRequest,
 ) (*persistence.InternalGetHistoryTreeResponse, error) {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return nil, err

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -944,24 +944,11 @@ type (
 	TrimHistoryBranchResponse struct {
 	}
 
-	// GetHistoryTreeRequest is used to retrieve branch info of a history tree
-	GetHistoryTreeRequest struct {
-		// A UUID of a tree
-		TreeID string
-		// Get data from this shard
-		ShardID int32
-	}
-
 	// HistoryBranchDetail contains detailed information of a branch
 	HistoryBranchDetail struct {
 		BranchInfo *persistencespb.HistoryBranch
 		ForkTime   *timestamppb.Timestamp
 		Info       string
-	}
-
-	// GetHistoryTreeResponse is a response to GetHistoryTreeRequest
-	GetHistoryTreeResponse struct {
-		BranchInfos []*persistencespb.HistoryBranch
 	}
 
 	// GetAllHistoryTreeBranchesRequest is a request of GetAllHistoryTreeBranches
@@ -1134,8 +1121,6 @@ type (
 		DeleteHistoryBranch(ctx context.Context, request *DeleteHistoryBranchRequest) error
 		// TrimHistoryBranch validate & trim a history branch
 		TrimHistoryBranch(ctx context.Context, request *TrimHistoryBranchRequest) (*TrimHistoryBranchResponse, error)
-		// GetHistoryTree returns all branch information of a tree
-		GetHistoryTree(ctx context.Context, request *GetHistoryTreeRequest) (*GetHistoryTreeResponse, error)
 		// GetAllHistoryTreeBranches returns all branches of all trees
 		GetAllHistoryTreeBranches(ctx context.Context, request *GetAllHistoryTreeBranchesRequest) (*GetAllHistoryTreeBranchesResponse, error)
 	}

--- a/common/persistence/data_interfaces_mock.go
+++ b/common/persistence/data_interfaces_mock.go
@@ -415,21 +415,6 @@ func (mr *MockExecutionManagerMockRecorder) GetHistoryTasks(ctx, request interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTasks", reflect.TypeOf((*MockExecutionManager)(nil).GetHistoryTasks), ctx, request)
 }
 
-// GetHistoryTree mocks base method.
-func (m *MockExecutionManager) GetHistoryTree(ctx context.Context, request *GetHistoryTreeRequest) (*GetHistoryTreeResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHistoryTree", ctx, request)
-	ret0, _ := ret[0].(*GetHistoryTreeResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHistoryTree indicates an expected call of GetHistoryTree.
-func (mr *MockExecutionManagerMockRecorder) GetHistoryTree(ctx, request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTree", reflect.TypeOf((*MockExecutionManager)(nil).GetHistoryTree), ctx, request)
-}
-
 // GetName mocks base method.
 func (m *MockExecutionManager) GetName() string {
 	m.ctrl.T.Helper()

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -455,7 +455,7 @@ func (m *executionManagerImpl) serializeWorkflowEventBatches(
 	xdcKVs := make(map[XDCCacheKey]XDCCacheValue, len(eventBatches))
 	workflowNewEvents := make([]*InternalAppendHistoryNodesRequest, 0, len(eventBatches))
 	for _, workflowEvents := range eventBatches {
-		newEvents, err := m.serializeWorkflowEvents(ctx, shardID, workflowEvents)
+		newEvents, err := m.serializeWorkflowEvents(shardID, workflowEvents)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -518,7 +518,6 @@ func (m *executionManagerImpl) DeserializeBufferedEvents( // unexport
 }
 
 func (m *executionManagerImpl) serializeWorkflowEvents(
-	ctx context.Context,
 	shardID int32,
 	workflowEvents *WorkflowEvents,
 ) (*InternalAppendHistoryNodesRequest, error) {
@@ -539,7 +538,7 @@ func (m *executionManagerImpl) serializeWorkflowEvents(
 		request.Info = BuildHistoryGarbageCleanupInfo(workflowEvents.NamespaceID, workflowEvents.WorkflowID, workflowEvents.RunID)
 	}
 
-	return m.serializeAppendHistoryNodesRequest(ctx, request)
+	return m.serializeAppendHistoryNodesRequest(request)
 }
 
 func (m *executionManagerImpl) SerializeWorkflowMutation( // unexport

--- a/common/persistence/mock/store_mock.go
+++ b/common/persistence/mock/store_mock.go
@@ -964,7 +964,7 @@ func (mr *MockExecutionStoreMockRecorder) GetHistoryTasks(ctx, request interface
 }
 
 // GetHistoryTree mocks base method.
-func (m *MockExecutionStore) GetHistoryTree(ctx context.Context, request *persistence.GetHistoryTreeRequest) (*persistence.InternalGetHistoryTreeResponse, error) {
+func (m *MockExecutionStore) GetHistoryTree(ctx context.Context, request *persistence.InternalGetHistoryTreeRequest) (*persistence.InternalGetHistoryTreeResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHistoryTree", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetHistoryTreeResponse)

--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -162,7 +162,7 @@ type (
 		// DeleteHistoryBranch removes a branch
 		DeleteHistoryBranch(ctx context.Context, request *InternalDeleteHistoryBranchRequest) error
 		// GetHistoryTree returns all branch information of a tree
-		GetHistoryTree(ctx context.Context, request *GetHistoryTreeRequest) (*InternalGetHistoryTreeResponse, error)
+		GetHistoryTree(ctx context.Context, request *InternalGetHistoryTreeRequest) (*InternalGetHistoryTreeResponse, error)
 		// GetAllHistoryTreeBranches returns all branches of all trees.
 		// Note that branches may be skipped or duplicated across pages if there are branches created or deleted while
 		// paginating through results.
@@ -638,6 +638,14 @@ type (
 		BranchID string
 		Encoding string
 		Data     []byte // HistoryTreeInfo blob
+	}
+
+	// InternalGetHistoryTreeRequest is used to retrieve branch info of a history tree
+	InternalGetHistoryTreeRequest struct {
+		// A UUID of a tree
+		TreeID string
+		// Get data from this shard
+		ShardID int32
 	}
 
 	// InternalGetHistoryTreeResponse is response to GetHistoryTree

--- a/common/persistence/persistence_metric_clients.go
+++ b/common/persistence/persistence_metric_clients.go
@@ -956,20 +956,6 @@ func (p *executionPersistenceClient) GetAllHistoryTreeBranches(
 	return p.persistence.GetAllHistoryTreeBranches(ctx, request)
 }
 
-// GetHistoryTree returns all branch information of a tree
-func (p *executionPersistenceClient) GetHistoryTree(
-	ctx context.Context,
-	request *GetHistoryTreeRequest,
-) (_ *GetHistoryTreeResponse, retErr error) {
-	caller := headers.GetCallerInfo(ctx).CallerName
-	startTime := time.Now().UTC()
-	defer func() {
-		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetHistoryTreeScope, caller, time.Since(startTime), retErr)
-	}()
-	return p.persistence.GetHistoryTree(ctx, request)
-}
-
 func (p *queuePersistenceClient) Init(
 	ctx context.Context,
 	blob *commonpb.DataBlob,

--- a/common/persistence/persistence_rate_limited_clients.go
+++ b/common/persistence/persistence_rate_limited_clients.go
@@ -806,18 +806,6 @@ func (p *executionRateLimitedPersistenceClient) TrimHistoryBranch(
 	return resp, err
 }
 
-// GetHistoryTree returns all branch information of a tree
-func (p *executionRateLimitedPersistenceClient) GetHistoryTree(
-	ctx context.Context,
-	request *GetHistoryTreeRequest,
-) (*GetHistoryTreeResponse, error) {
-	if ok := allow(ctx, "GetHistoryTree", request.ShardID, p.rateLimiter); !ok {
-		return nil, ErrPersistenceLimitExceeded
-	}
-	response, err := p.persistence.GetHistoryTree(ctx, request)
-	return response, err
-}
-
 func (p *executionRateLimitedPersistenceClient) GetAllHistoryTreeBranches(
 	ctx context.Context,
 	request *GetAllHistoryTreeBranchesRequest,

--- a/common/persistence/persistence_retryable_clients.go
+++ b/common/persistence/persistence_retryable_clients.go
@@ -610,22 +610,6 @@ func (p *executionRetryablePersistenceClient) TrimHistoryBranch(
 	return response, err
 }
 
-// GetHistoryTree returns all branch information of a tree
-func (p *executionRetryablePersistenceClient) GetHistoryTree(
-	ctx context.Context,
-	request *GetHistoryTreeRequest,
-) (*GetHistoryTreeResponse, error) {
-	var response *GetHistoryTreeResponse
-	op := func(ctx context.Context) error {
-		var err error
-		response, err = p.persistence.GetHistoryTree(ctx, request)
-		return err
-	}
-
-	err := backoff.ThrottleRetryContext(ctx, op, p.policy, p.isRetryable)
-	return response, err
-}
-
 func (p *executionRetryablePersistenceClient) GetAllHistoryTreeBranches(
 	ctx context.Context,
 	request *GetAllHistoryTreeBranchesRequest,

--- a/common/persistence/sql/history_store.go
+++ b/common/persistence/sql/history_store.go
@@ -466,7 +466,7 @@ func (m *sqlExecutionStore) GetAllHistoryTreeBranches(
 // GetHistoryTree returns all branch information of a tree
 func (m *sqlExecutionStore) GetHistoryTree(
 	ctx context.Context,
-	request *p.GetHistoryTreeRequest,
+	request *p.InternalGetHistoryTreeRequest,
 ) (*p.InternalGetHistoryTreeResponse, error) {
 	treeID, err := primitives.ParseUUID(request.TreeID)
 	if err != nil {

--- a/tests/archival.go
+++ b/tests/archival.go
@@ -43,14 +43,17 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/testing/protoassert"
 )
 
 const (
@@ -58,10 +61,17 @@ const (
 	retryBackoffTime = 500 * time.Millisecond
 )
 
-type ArchivalSuite struct {
-	*require.Assertions
-	FunctionalTestBase
-}
+type (
+	ArchivalSuite struct {
+		*require.Assertions
+		FunctionalTestBase
+	}
+
+	archivalWorkflowInfo struct {
+		execution   *commonpb.WorkflowExecution
+		branchToken []byte
+	}
+)
 
 func (s *ArchivalSuite) SetupSuite() {
 	s.setupSuite("testdata/es_cluster.yaml")
@@ -85,15 +95,11 @@ func (s *ArchivalSuite) TestArchival_TimerQueueProcessor() {
 	taskQueue := "archival-timer-queue-processor-task-queue"
 	numActivities := 1
 	numRuns := 1
-	runID := s.startAndFinishWorkflow(workflowID, workflowType, taskQueue, s.archivalNamespace, namespaceID, numActivities, numRuns)[0]
+	workflowInfo := s.startAndFinishWorkflow(workflowID, workflowType, taskQueue, s.archivalNamespace, namespaceID, numActivities, numRuns)[0]
 
-	execution := &commonpb.WorkflowExecution{
-		WorkflowId: workflowID,
-		RunId:      runID,
-	}
-	s.True(s.isArchived(s.archivalNamespace, execution))
-	s.True(s.isHistoryDeleted(execution))
-	s.True(s.isMutableStateDeleted(namespaceID, execution))
+	s.True(s.isArchived(s.archivalNamespace, workflowInfo.execution))
+	s.True(s.isHistoryDeleted(workflowInfo))
+	s.True(s.isMutableStateDeleted(namespaceID, workflowInfo.execution))
 }
 
 func (s *ArchivalSuite) TestArchival_ContinueAsNew() {
@@ -105,16 +111,12 @@ func (s *ArchivalSuite) TestArchival_ContinueAsNew() {
 	taskQueue := "archival-continueAsNew-task-queue"
 	numActivities := 1
 	numRuns := 5
-	runIDs := s.startAndFinishWorkflow(workflowID, workflowType, taskQueue, s.archivalNamespace, namespaceID, numActivities, numRuns)
+	workflowInfos := s.startAndFinishWorkflow(workflowID, workflowType, taskQueue, s.archivalNamespace, namespaceID, numActivities, numRuns)
 
-	for _, runID := range runIDs {
-		execution := &commonpb.WorkflowExecution{
-			WorkflowId: workflowID,
-			RunId:      runID,
-		}
-		s.True(s.isArchived(s.archivalNamespace, execution))
-		s.True(s.isHistoryDeleted(execution))
-		s.True(s.isMutableStateDeleted(namespaceID, execution))
+	for _, workflowInfo := range workflowInfos {
+		s.True(s.isArchived(s.archivalNamespace, workflowInfo.execution))
+		s.True(s.isHistoryDeleted(workflowInfo))
+		s.True(s.isMutableStateDeleted(namespaceID, workflowInfo.execution))
 	}
 }
 
@@ -128,15 +130,11 @@ func (s *ArchivalSuite) TestArchival_ArchiverWorker() {
 	workflowType := "archival-archiver-worker-workflow-type"
 	taskQueue := "archival-archiver-worker-task-queue"
 	numActivities := 10
-	runID := s.startAndFinishWorkflow(workflowID, workflowType, taskQueue, s.archivalNamespace, namespaceID, numActivities, 1)[0]
+	workflowInfo := s.startAndFinishWorkflow(workflowID, workflowType, taskQueue, s.archivalNamespace, namespaceID, numActivities, 1)[0]
 
-	execution := &commonpb.WorkflowExecution{
-		WorkflowId: workflowID,
-		RunId:      runID,
-	}
-	s.True(s.isArchived(s.archivalNamespace, execution))
-	s.True(s.isHistoryDeleted(execution))
-	s.True(s.isMutableStateDeleted(namespaceID, execution))
+	s.True(s.isArchived(s.archivalNamespace, workflowInfo.execution))
+	s.True(s.isHistoryDeleted(workflowInfo))
+	s.True(s.isMutableStateDeleted(namespaceID, workflowInfo.execution))
 }
 
 func (s *ArchivalSuite) TestVisibilityArchival() {
@@ -258,20 +256,33 @@ func (s *ArchivalSuite) isArchived(namespace string, execution *commonpb.Workflo
 	return false
 }
 
-func (s *ArchivalSuite) isHistoryDeleted(execution *commonpb.WorkflowExecution) bool {
+func (s *ArchivalSuite) isHistoryDeleted(
+	workflowInfo archivalWorkflowInfo,
+) bool {
 	namespaceID := s.getNamespaceID(s.archivalNamespace)
-	shardID := common.WorkflowIDToHistoryShard(namespaceID, execution.GetWorkflowId(),
-		s.testClusterConfig.HistoryConfig.NumHistoryShards)
-	request := &persistence.GetHistoryTreeRequest{
-		TreeID:  execution.GetRunId(),
-		ShardID: shardID,
-	}
+	shardID := common.WorkflowIDToHistoryShard(
+		namespaceID,
+		workflowInfo.execution.WorkflowId,
+		s.testClusterConfig.HistoryConfig.NumHistoryShards,
+	)
+
 	for i := 0; i < retryLimit; i++ {
-		resp, err := s.testCluster.testBase.ExecutionManager.GetHistoryTree(NewContext(), request)
-		s.NoError(err)
-		if len(resp.BranchInfos) == 0 {
+		_, err := s.testCluster.testBase.ExecutionManager.ReadHistoryBranch(
+			NewContext(),
+			&persistence.ReadHistoryBranchRequest{
+				ShardID:       shardID,
+				BranchToken:   workflowInfo.branchToken,
+				MinEventID:    common.FirstEventID,
+				MaxEventID:    common.EndEventID,
+				PageSize:      1,
+				NextPageToken: nil,
+			},
+		)
+		if common.IsNotFoundError(err) {
 			return true
 		}
+
+		s.NoError(err)
 		time.Sleep(retryBackoffTime)
 	}
 	return false
@@ -297,7 +308,10 @@ func (s *ArchivalSuite) isMutableStateDeleted(namespaceID string, execution *com
 	return false
 }
 
-func (s *ArchivalSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceID string, numActivities, numRuns int) []string {
+func (s *ArchivalSuite) startAndFinishWorkflow(
+	id, wt, tq, namespace, namespaceID string,
+	numActivities, numRuns int,
+) []archivalWorkflowInfo {
 	identity := "worker1"
 	activityName := "activity_type1"
 	workflowType := &commonpb.WorkflowType{Name: wt}
@@ -313,10 +327,10 @@ func (s *ArchivalSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceI
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we, err := s.engine.StartWorkflowExecution(NewContext(), request)
+	startResp, err := s.engine.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err)
-	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
-	runIDs := make([]string, numRuns)
+	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(startResp.RunId))
+	workflowInfos := make([]archivalWorkflowInfo, numRuns)
 
 	workflowComplete := false
 	activityCount := int32(numActivities)
@@ -331,7 +345,14 @@ func (s *ArchivalSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceI
 		startedEventID int64,
 		history *historypb.History,
 	) ([]*commandpb.Command, error) {
-		runIDs[runCounter-1] = execution.GetRunId()
+		branchToken, err := s.getBranchToken(namespace, execution)
+		s.NoError(err)
+
+		workflowInfos[runCounter-1] = archivalWorkflowInfo{
+			execution:   execution,
+			branchToken: branchToken,
+		}
+
 		if activityCounter < activityCount {
 			activityCounter++
 			buf := new(bytes.Buffer)
@@ -383,8 +404,7 @@ func (s *ArchivalSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceI
 		input *commonpb.Payloads,
 		taskToken []byte,
 	) (*commonpb.Payloads, bool, error) {
-		s.Equal(id, execution.GetWorkflowId())
-		s.Equal(runIDs[runCounter-1], execution.GetRunId())
+		protoassert.ProtoEqual(s.T(), workflowInfos[runCounter-1].execution, execution)
 		s.Equal(activityName, activityType.Name)
 		currentActivityId, _ := strconv.Atoi(activityID)
 		s.Equal(int(expectedActivityID), currentActivityId)
@@ -423,7 +443,30 @@ func (s *ArchivalSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceI
 
 	s.True(workflowComplete)
 	for run := 1; run < numRuns; run++ {
-		s.NotEqual(runIDs[run-1], runIDs[run])
+		s.NotEqual(workflowInfos[run-1].execution, workflowInfos[run].execution)
+		s.NotEqual(workflowInfos[run-1].branchToken, workflowInfos[run].branchToken)
 	}
-	return runIDs
+	return workflowInfos
+}
+
+func (s *ArchivalSuite) getBranchToken(
+	namespace string,
+	execution *commonpb.WorkflowExecution,
+) ([]byte, error) {
+
+	descResp, err := s.adminClient.DescribeMutableState(NewContext(), &adminservice.DescribeMutableStateRequest{
+		Namespace: namespace,
+		Execution: execution,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	versionHistories := descResp.CacheMutableState.ExecutionInfo.VersionHistories
+	currentVersionHistory, err := versionhistory.GetCurrentVersionHistory(versionHistories)
+	if err != nil {
+		return nil, err
+	}
+
+	return currentVersionHistory.GetBranchToken(), nil
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Remove GetHistoryTree from persistence manager
- Prepare for the next change for store layer GetHistoryTree. https://github.com/temporalio/temporal/pull/5411

## Why?
<!-- Tell your future self why have you made these changes -->
- Not used by application layer. 
- Not supported by the new history store implementation

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
