### PR TITLE
Persistence store GetHistoryTreeContainingBranch

### DIFF
--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -372,12 +372,17 @@ func (h *HistoryStore) GetAllHistoryTreeBranches(
 }
 
 // GetHistoryTree returns all branch information of a tree
-func (h *HistoryStore) GetHistoryTree(
+func (h *HistoryStore) GetHistoryTreeContainingBranch(
 	ctx context.Context,
-	request *p.InternalGetHistoryTreeRequest,
-) (*p.InternalGetHistoryTreeResponse, error) {
+	request *p.InternalGetHistoryTreeContainingBranchRequest,
+) (*p.InternalGetHistoryTreeContainingBranchResponse, error) {
 
-	treeID, err := primitives.ValidateUUID(request.TreeID)
+	branch, err := h.GetHistoryBranchUtil().ParseHistoryBranchInfo(request.BranchToken)
+	if err != nil {
+		return nil, err
+	}
+
+	treeID, err := primitives.ValidateUUID(branch.TreeId)
 	if err != nil {
 		return nil, serviceerror.NewInternal(fmt.Sprintf("ReadHistoryBranch. Gocql TreeId UUID cast failed. Error: %v", err))
 	}
@@ -412,7 +417,7 @@ func (h *HistoryStore) GetHistoryTree(
 		}
 	}
 
-	return &p.InternalGetHistoryTreeResponse{
+	return &p.InternalGetHistoryTreeContainingBranchResponse{
 		TreeInfos: treeInfos,
 	}, nil
 }

--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -371,7 +371,7 @@ func (h *HistoryStore) GetAllHistoryTreeBranches(
 	return response, nil
 }
 
-// GetHistoryTree returns all branch information of a tree
+// GetHistoryTreeContainingBranch returns all branch information of a tree
 func (h *HistoryStore) GetHistoryTreeContainingBranch(
 	ctx context.Context,
 	request *p.InternalGetHistoryTreeContainingBranchRequest,

--- a/common/persistence/client/fault_injection.go
+++ b/common/persistence/client/fault_injection.go
@@ -788,14 +788,14 @@ func (e *FaultInjectionExecutionStore) DeleteHistoryBranch(
 	return e.baseExecutionStore.DeleteHistoryBranch(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) GetHistoryTree(
+func (e *FaultInjectionExecutionStore) GetHistoryTreeContainingBranch(
 	ctx context.Context,
-	request *persistence.InternalGetHistoryTreeRequest,
-) (*persistence.InternalGetHistoryTreeResponse, error) {
+	request *persistence.InternalGetHistoryTreeContainingBranchRequest,
+) (*persistence.InternalGetHistoryTreeContainingBranchResponse, error) {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return e.baseExecutionStore.GetHistoryTree(ctx, request)
+	return e.baseExecutionStore.GetHistoryTreeContainingBranch(ctx, request)
 }
 
 func (e *FaultInjectionExecutionStore) GetAllHistoryTreeBranches(

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -159,7 +159,8 @@ func (m *executionManagerImpl) DeleteHistoryBranch(
 		BeginNodeId: GetBeginNodeID(branch),
 	})
 
-	// Get the entire history tree, so we know if any part of the target branch is referenced by other branches.
+	// Get the history tree containing the branch to be delelted,
+	// so we know if any part of the target branch is referenced by other branches.
 	historyTreeResp, err := m.persistence.GetHistoryTreeContainingBranch(ctx, &InternalGetHistoryTreeContainingBranchRequest{
 		BranchToken: request.BranchToken,
 		ShardID:     request.ShardID,

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -160,9 +160,9 @@ func (m *executionManagerImpl) DeleteHistoryBranch(
 	})
 
 	// Get the entire history tree, so we know if any part of the target branch is referenced by other branches.
-	historyTreeResp, err := m.persistence.GetHistoryTree(ctx, &InternalGetHistoryTreeRequest{
-		TreeID:  branch.TreeId,
-		ShardID: request.ShardID,
+	historyTreeResp, err := m.persistence.GetHistoryTreeContainingBranch(ctx, &InternalGetHistoryTreeContainingBranchRequest{
+		BranchToken: request.BranchToken,
+		ShardID:     request.ShardID,
 	})
 	if err != nil {
 		return err
@@ -320,7 +320,7 @@ func (m *executionManagerImpl) TrimHistoryBranch(
 }
 
 func (m *executionManagerImpl) deserializeBranchInfos(
-	historyTreeResp *InternalGetHistoryTreeResponse,
+	historyTreeResp *InternalGetHistoryTreeContainingBranchResponse,
 ) ([]*persistencespb.HistoryBranch, error) {
 	branchInfos := make([]*persistencespb.HistoryBranch, 0, len(historyTreeResp.TreeInfos))
 	for _, blob := range historyTreeResp.TreeInfos {

--- a/common/persistence/mock/store_mock.go
+++ b/common/persistence/mock/store_mock.go
@@ -963,19 +963,19 @@ func (mr *MockExecutionStoreMockRecorder) GetHistoryTasks(ctx, request interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTasks", reflect.TypeOf((*MockExecutionStore)(nil).GetHistoryTasks), ctx, request)
 }
 
-// GetHistoryTree mocks base method.
-func (m *MockExecutionStore) GetHistoryTree(ctx context.Context, request *persistence.InternalGetHistoryTreeRequest) (*persistence.InternalGetHistoryTreeResponse, error) {
+// GetHistoryTreeContainingBranch mocks base method.
+func (m *MockExecutionStore) GetHistoryTreeContainingBranch(ctx context.Context, request *persistence.InternalGetHistoryTreeContainingBranchRequest) (*persistence.InternalGetHistoryTreeContainingBranchResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHistoryTree", ctx, request)
-	ret0, _ := ret[0].(*persistence.InternalGetHistoryTreeResponse)
+	ret := m.ctrl.Call(m, "GetHistoryTreeContainingBranch", ctx, request)
+	ret0, _ := ret[0].(*persistence.InternalGetHistoryTreeContainingBranchResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetHistoryTree indicates an expected call of GetHistoryTree.
-func (mr *MockExecutionStoreMockRecorder) GetHistoryTree(ctx, request interface{}) *gomock.Call {
+// GetHistoryTreeContainingBranch indicates an expected call of GetHistoryTreeContainingBranch.
+func (mr *MockExecutionStoreMockRecorder) GetHistoryTreeContainingBranch(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTree", reflect.TypeOf((*MockExecutionStore)(nil).GetHistoryTree), ctx, request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTreeContainingBranch", reflect.TypeOf((*MockExecutionStore)(nil).GetHistoryTreeContainingBranch), ctx, request)
 }
 
 // GetName mocks base method.

--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -161,7 +161,7 @@ type (
 		ForkHistoryBranch(ctx context.Context, request *InternalForkHistoryBranchRequest) error
 		// DeleteHistoryBranch removes a branch
 		DeleteHistoryBranch(ctx context.Context, request *InternalDeleteHistoryBranchRequest) error
-		// GetHistoryTreeContainingBranch returns all branch information of a tree containing the requested branch
+		// GetHistoryTreeContainingBranch returns all branch information of the tree containing the specified branch
 		GetHistoryTreeContainingBranch(ctx context.Context, request *InternalGetHistoryTreeContainingBranchRequest) (*InternalGetHistoryTreeContainingBranchResponse, error)
 		// GetAllHistoryTreeBranches returns all branches of all trees.
 		// Note that branches may be skipped or duplicated across pages if there are branches created or deleted while

--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -161,8 +161,8 @@ type (
 		ForkHistoryBranch(ctx context.Context, request *InternalForkHistoryBranchRequest) error
 		// DeleteHistoryBranch removes a branch
 		DeleteHistoryBranch(ctx context.Context, request *InternalDeleteHistoryBranchRequest) error
-		// GetHistoryTree returns all branch information of a tree
-		GetHistoryTree(ctx context.Context, request *InternalGetHistoryTreeRequest) (*InternalGetHistoryTreeResponse, error)
+		// GetHistoryTreeContainingBranch returns all branch information of a tree containing the requested branch
+		GetHistoryTreeContainingBranch(ctx context.Context, request *InternalGetHistoryTreeContainingBranchRequest) (*InternalGetHistoryTreeContainingBranchResponse, error)
 		// GetAllHistoryTreeBranches returns all branches of all trees.
 		// Note that branches may be skipped or duplicated across pages if there are branches created or deleted while
 		// paginating through results.
@@ -640,17 +640,17 @@ type (
 		Data     []byte // HistoryTreeInfo blob
 	}
 
-	// InternalGetHistoryTreeRequest is used to retrieve branch info of a history tree
-	InternalGetHistoryTreeRequest struct {
-		// A UUID of a tree
-		TreeID string
+	// InternalGetHistoryTreeContainingBranchRequest is used to retrieve branch info of a history tree
+	InternalGetHistoryTreeContainingBranchRequest struct {
+		// The raw branch token
+		BranchToken []byte
 		// Get data from this shard
 		ShardID int32
 	}
 
-	// InternalGetHistoryTreeResponse is response to GetHistoryTree
+	// InternalGetHistoryTreeContainingBranchResponse is response to GetHistoryTreeContainingBranch
 	// Only used by persistence layer
-	InternalGetHistoryTreeResponse struct {
+	InternalGetHistoryTreeContainingBranchResponse struct {
 		// TreeInfos
 		TreeInfos []*commonpb.DataBlob
 	}

--- a/common/persistence/sql/history_store.go
+++ b/common/persistence/sql/history_store.go
@@ -463,7 +463,7 @@ func (m *sqlExecutionStore) GetAllHistoryTreeBranches(
 	return response, nil
 }
 
-// GetHistoryTree returns all branch information of a tree
+// GetHistoryTreeContainingBranch returns all branch information of a tree
 func (m *sqlExecutionStore) GetHistoryTreeContainingBranch(
 	ctx context.Context,
 	request *p.InternalGetHistoryTreeContainingBranchRequest,

--- a/common/persistence/sql/history_store.go
+++ b/common/persistence/sql/history_store.go
@@ -464,11 +464,16 @@ func (m *sqlExecutionStore) GetAllHistoryTreeBranches(
 }
 
 // GetHistoryTree returns all branch information of a tree
-func (m *sqlExecutionStore) GetHistoryTree(
+func (m *sqlExecutionStore) GetHistoryTreeContainingBranch(
 	ctx context.Context,
-	request *p.InternalGetHistoryTreeRequest,
-) (*p.InternalGetHistoryTreeResponse, error) {
-	treeID, err := primitives.ParseUUID(request.TreeID)
+	request *p.InternalGetHistoryTreeContainingBranchRequest,
+) (*p.InternalGetHistoryTreeContainingBranchResponse, error) {
+	branch, err := m.GetHistoryBranchUtil().ParseHistoryBranchInfo(request.BranchToken)
+	if err != nil {
+		return nil, err
+	}
+
+	treeID, err := primitives.ParseUUID(branch.TreeId)
 	if err != nil {
 		return nil, err
 	}
@@ -478,14 +483,14 @@ func (m *sqlExecutionStore) GetHistoryTree(
 		ShardID: request.ShardID,
 	})
 	if err == sql.ErrNoRows || (err == nil && len(rows) == 0) {
-		return &p.InternalGetHistoryTreeResponse{}, nil
+		return &p.InternalGetHistoryTreeContainingBranchResponse{}, nil
 	}
 	treeInfos := make([]*commonpb.DataBlob, 0, len(rows))
 	for _, row := range rows {
 		treeInfos = append(treeInfos, p.NewDataBlob(row.Data, row.DataEncoding))
 	}
 
-	return &p.InternalGetHistoryTreeResponse{
+	return &p.InternalGetHistoryTreeContainingBranchResponse{
 		TreeInfos: treeInfos,
 	}, nil
 }

--- a/common/persistence/tests/history_store.go
+++ b/common/persistence/tests/history_store.go
@@ -50,7 +50,7 @@ import (
 
 // TODO add UT for the following
 //  * DeleteHistoryBranch
-//  * GetHistoryTree
+//  * GetHistoryTreeContainingBranch
 //  * GetAllHistoryTreeBranches
 
 type (


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Get history tree using branchToken instead of treeID in store layer.
- This change is based on https://github.com/temporalio/temporal/pull/5410

## Why?
<!-- Tell your future self why have you made these changes -->
- TreeID does not contain enough information in the new history store impl.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing impl

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
