### PR TITLE
Fix custom frontend interceptor injection

### DIFF
--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -123,11 +123,11 @@ type (
 		CustomDataStoreFactory persistenceClient.AbstractDataStoreFactory
 		CustomVisibilityStore  visibility.VisibilityStoreFactory
 
-		SearchAttributesMapper searchattribute.Mapper
-		CustomInterceptors     []grpc.UnaryServerInterceptor
-		Authorizer             authorization.Authorizer
-		ClaimMapper            authorization.ClaimMapper
-		AudienceGetter         authorization.JWTAudienceMapper
+		SearchAttributesMapper     searchattribute.Mapper
+		CustomFrontendInterceptors []grpc.UnaryServerInterceptor
+		Authorizer                 authorization.Authorizer
+		ClaimMapper                authorization.ClaimMapper
+		AudienceGetter             authorization.JWTAudienceMapper
 
 		// below are things that could be over write by server options or may have default if not supplied by serverOptions.
 		Logger                log.Logger
@@ -284,11 +284,11 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 		CustomDataStoreFactory: so.customDataStoreFactory,
 		CustomVisibilityStore:  so.customVisibilityStoreFactory,
 
-		SearchAttributesMapper: so.searchAttributesMapper,
-		CustomInterceptors:     so.customInterceptors,
-		Authorizer:             so.authorizer,
-		ClaimMapper:            so.claimMapper,
-		AudienceGetter:         so.audienceGetter,
+		SearchAttributesMapper:     so.searchAttributesMapper,
+		CustomFrontendInterceptors: so.customFrontendInterceptors,
+		Authorizer:                 so.authorizer,
+		ClaimMapper:                so.claimMapper,
+		AudienceGetter:             so.audienceGetter,
 
 		Logger:                logger,
 		ClientFactoryProvider: clientFactoryProvider,
@@ -352,7 +352,7 @@ type (
 		PersistenceServiceResolver resolver.ServiceResolver
 		PersistenceFactoryProvider persistenceClient.FactoryProviderFn
 		SearchAttributesMapper     searchattribute.Mapper
-		CustomInterceptors         []grpc.UnaryServerInterceptor
+		CustomFrontendInterceptors []grpc.UnaryServerInterceptor
 		Authorizer                 authorization.Authorizer
 		ClaimMapper                authorization.ClaimMapper
 		DataStoreFactory           persistenceClient.AbstractDataStoreFactory
@@ -523,7 +523,7 @@ func genericFrontendServiceProvider(
 
 	app := fx.New(
 		params.GetCommonServiceOptions(serviceName),
-		fx.Supply(params.CustomInterceptors),
+		fx.Supply(params.CustomFrontendInterceptors),
 		fx.Decorate(func() authorization.ClaimMapper {
 			switch serviceName {
 			case primitives.FrontendService:

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -124,7 +124,7 @@ type (
 		CustomVisibilityStore  visibility.VisibilityStoreFactory
 
 		SearchAttributesMapper searchattribute.Mapper
-		CustomInterceptors     []grpc.UnaryServerInterceptor `group:"frontendInterceptors"`
+		CustomInterceptors     []grpc.UnaryServerInterceptor
 		Authorizer             authorization.Authorizer
 		ClaimMapper            authorization.ClaimMapper
 		AudienceGetter         authorization.JWTAudienceMapper
@@ -352,7 +352,7 @@ type (
 		PersistenceServiceResolver resolver.ServiceResolver
 		PersistenceFactoryProvider persistenceClient.FactoryProviderFn
 		SearchAttributesMapper     searchattribute.Mapper
-		CustomInterceptors         []grpc.UnaryServerInterceptor `group:"frontendInterceptors"`
+		CustomInterceptors         []grpc.UnaryServerInterceptor
 		Authorizer                 authorization.Authorizer
 		ClaimMapper                authorization.ClaimMapper
 		DataStoreFactory           persistenceClient.AbstractDataStoreFactory
@@ -523,9 +523,7 @@ func genericFrontendServiceProvider(
 
 	app := fx.New(
 		params.GetCommonServiceOptions(serviceName),
-		fx.Provide(fx.Annotate(
-			func() []grpc.UnaryServerInterceptor { return params.CustomInterceptors },
-			fx.ParamTags(`group:"frontendInterceptors"`))),
+		fx.Supply(params.CustomInterceptors),
 		fx.Decorate(func() authorization.ClaimMapper {
 			switch serviceName {
 			case primitives.FrontendService:

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -185,7 +185,7 @@ func WithChainedFrontendGrpcInterceptors(
 	interceptors ...grpc.UnaryServerInterceptor,
 ) ServerOption {
 	return applyFunc(func(s *serverOptions) {
-		s.customInterceptors = interceptors
+		s.customFrontendInterceptors = interceptors
 	})
 }
 

--- a/temporal/server_options.go
+++ b/temporal/server_options.go
@@ -74,7 +74,7 @@ type (
 		customVisibilityStoreFactory visibility.VisibilityStoreFactory
 		clientFactoryProvider        client.FactoryProvider
 		searchAttributesMapper       searchattribute.Mapper
-		customInterceptors           []grpc.UnaryServerInterceptor
+		customFrontendInterceptors   []grpc.UnaryServerInterceptor
 		metricHandler                metrics.Handler
 	}
 )

--- a/temporal/server_test.go
+++ b/temporal/server_test.go
@@ -108,10 +108,12 @@ func setTestPorts(cfg *config.Config) {
 
 func getFrontendInterceptors() func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
-		if _, ok := info.Server.(*frontend.Handler); !ok {
+		switch info.Server.(type) {
+		case *frontend.Handler, *frontend.OperatorHandler, *frontend.AdminHandler, *frontend.WorkflowHandler:
+			return handler(ctx, req)
+		default:
 			panic("Frontend gRPC interceptor provided to non-frontend handler")
 		}
-		return handler(ctx, req)
 	}
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Removed the `group:"frontendInterceptors"` fx tag from custom frontend interceptor parameter and result structs. Instead custom frontend interceptors are provided directly to the frontend fx app using `fx.Supply`

## Why?
<!-- Tell your future self why have you made these changes -->
fx was not correctly injecting these and the value group was unnecessary

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Manually

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
None

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
