### PR TITLE
Add oncemap collection

### DIFF
--- a/common/collection/oncemap.go
+++ b/common/collection/oncemap.go
@@ -1,0 +1,59 @@
+// The MIT License
+
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package collection
+
+import "sync"
+
+// OnceMap is a concurrent map which lazily constructs its values. Map values are initialized on-the-fly, using a
+// provided construction function only when a key is accessed for the first time.
+type OnceMap[K comparable, T any] struct {
+	mu        sync.RWMutex
+	pool      map[K]T
+	construct func(K) T
+}
+
+// NewOnceMap creates a [OnceMap] from a given construct function.
+// construct should be kept light as is called while holding a lock on the entire map.
+func NewOnceMap[K comparable, T any](construct func(K) T) *OnceMap[K, T] {
+	return &OnceMap[K, T]{
+		construct: construct,
+		pool:      make(map[K]T, 0),
+	}
+}
+
+func (p *OnceMap[K, T]) Get(key K) T {
+	p.mu.RLock()
+	value, ok := p.pool[key]
+	p.mu.RUnlock()
+	if !ok {
+		p.mu.Lock()
+		if value, ok = p.pool[key]; !ok {
+			value = p.construct(key)
+			p.pool[key] = value
+		}
+		p.mu.Unlock()
+	}
+
+	return value
+}

--- a/common/collection/oncemap_test.go
+++ b/common/collection/oncemap_test.go
@@ -1,0 +1,50 @@
+// The MIT License
+
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package collection
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnceMap(t *testing.T) {
+	counter := atomic.Int32{}
+	m := NewOnceMap(func(k string) int {
+		return int(counter.Add(1))
+	})
+
+	foo1 := m.Get("foo")
+	foo2 := m.Get("foo")
+
+	require.Equal(t, 1, foo1)
+	require.Equal(t, 1, foo2)
+
+	bar1 := m.Get("bar")
+	bar2 := m.Get("bar")
+
+	require.Equal(t, 2, bar1)
+	require.Equal(t, 2, bar2)
+}


### PR DESCRIPTION
## What changed?

Added a OnceMap collection to common.

> OnceMap is a concurrent map which lazily constructs its values. Map values are initialized on-the-fly, using a
> provided construction function only when a key is accessed for the first time.
## Why?

I have a couple of uses for it in the nexus branch.

## How did you test it?

Added unit tests