### PR TITLE
Fix flaky update test

### DIFF
--- a/common/testing/runtime/goroutine.go
+++ b/common/testing/runtime/goroutine.go
@@ -30,13 +30,14 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 // WaitGoRoutineWithFn waits for a go routine with the given function to appear within the duration.
-func WaitGoRoutineWithFn(t require.TestingT, fn any, maxDuration time.Duration) {
+func WaitGoRoutineWithFn(t testing.TB, fn any, maxDuration time.Duration) {
 	targetFnName, ok := functionNameForPC(reflect.ValueOf(fn).Pointer())
 	if !ok {
 		t.Errorf("Invalid function %#v", fn)
@@ -55,9 +56,8 @@ func WaitGoRoutineWithFn(t require.TestingT, fn any, maxDuration time.Duration) 
 				frames := runtime.CallersFrames(stackRecord.Stack())
 				for {
 					frame, more := frames.Next()
-					// fmt.Printf("%s\t%s:%d\n", frame.Function, frame.File, frame.Line)
 					if strings.Contains(frame.Function, targetFnName) {
-						// fmt.Printf("Found blocked %s function on %d attempt\n", frame.Function, attempt)
+						t.Logf("Found %s function on %d attempt\n", frame.Function, attempt)
 						return true
 					}
 					if !more {

--- a/common/testing/runtime/goroutine.go
+++ b/common/testing/runtime/goroutine.go
@@ -1,0 +1,89 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package runtime
+
+import (
+	"os"
+	"reflect"
+	"runtime"
+	"runtime/pprof"
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// WaitGoRoutineWithFn waits for a go routine with the given function to appear within the duration.
+func WaitGoRoutineWithFn(t require.TestingT, fn any, maxDuration time.Duration) {
+	targetFnName, ok := functionNameForPC(reflect.ValueOf(fn).Pointer())
+	if !ok {
+		t.Errorf("Invalid function %#v", fn)
+	}
+
+	attempt := 1
+	require.Eventually(t,
+		func() bool {
+			stackRecords := make([]runtime.StackRecord, runtime.NumGoroutine()+10)
+			stackRecordsLen, ok := runtime.GoroutineProfile(stackRecords)
+			if !ok {
+				t.Errorf("Size %d is too small for stack records. Need %d", len(stackRecords), stackRecordsLen)
+			}
+
+			for _, stackRecord := range stackRecords {
+				frames := runtime.CallersFrames(stackRecord.Stack())
+				for {
+					frame, more := frames.Next()
+					// fmt.Printf("%s\t%s:%d\n", frame.Function, frame.File, frame.Line)
+					if strings.Contains(frame.Function, targetFnName) {
+						// fmt.Printf("Found blocked %s function on %d attempt\n", frame.Function, attempt)
+						return true
+					}
+					if !more {
+						break
+					}
+				}
+			}
+			attempt++
+			return false
+		},
+		maxDuration,
+		1*time.Millisecond,
+		"Function %s didn't appear in any go routine call stack after %s", targetFnName, maxDuration.String())
+}
+
+// PrintGoRoutines prints all go routines.
+func PrintGoRoutines() {
+	_ = pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+}
+
+func functionNameForPC(pc uintptr) (string, bool) {
+	fn := runtime.FuncForPC(pc)
+	if fn == nil {
+		return "", false
+	}
+	elements := strings.Split(fn.Name(), ".")
+	shortName := elements[len(elements)-1]
+	return strings.TrimSuffix(shortName, "-fm"), true
+}

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -41,6 +41,8 @@ import (
 	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/testing/runtime"
+	"go.temporal.io/server/service/history/workflow/update"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"go.temporal.io/server/api/adminservice/v1"
@@ -723,6 +725,9 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NormalScheduledWorkflowTask_AcceptC
 			go func() {
 				updateResultCh <- s.sendUpdateNoError(tv, "1")
 			}()
+			// Signal creates WFT, and it is important to wait for update to get blocked,
+			// to make sure that poll bellow won't poll just for WFT from signal.
+			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
 
 			// Process update in workflow. It will be attached to existing WT.
 			res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
@@ -782,7 +787,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeFromStartedWorkflowTa
 				updateResultCh <- s.sendUpdateNoError(tv, "1")
 			}()
 			// To make sure that 1st update gets to the sever while WT1 is running.
-			time.Sleep(500 * time.Millisecond)
+			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
 			// Completes WT with empty command list to create next WT as speculative.
 			return nil, nil
 		case 2:
@@ -899,7 +904,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewNormalFromStartedWorkflowTask_Re
 				updateResultCh <- s.sendUpdateNoError(tv, "1")
 			}()
 			// To make sure that 1st update gets to the sever while WT1 is running.
-			time.Sleep(500 * time.Millisecond)
+			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
 			// Completes WT with update unrelated commands to prevent next WT to be speculative.
 			return []*commandpb.Command{{
 				CommandType: enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK,
@@ -1448,7 +1453,9 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_Ac
 
 			updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
 			go func() {
-				time.Sleep(500 * time.Millisecond) // This is to make sure that next sticky poller reach to server first.
+				// This is to make sure that next sticky poller reach to server first.
+				// And when update comes, stick poller is already available.
+				time.Sleep(500 * time.Millisecond)
 				updateResultCh <- s.sendUpdateNoError(tv, "1")
 			}()
 
@@ -2649,7 +2656,8 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ConvertScheduledSpeculativeWorkflow
 	go func() {
 		updateResultCh <- s.sendUpdateNoError(tv, "1")
 	}()
-	time.Sleep(500 * time.Millisecond) // This is to make sure that update gets to the server before the next Signal call.
+	// This is to make sure that update gets to the server before the next Signal call.
+	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
 
 	// Send signal which will NOT be buffered because speculative WT is not started yet (only scheduled).
 	// This will persist MS and speculative WT must be converted to normal.
@@ -2724,8 +2732,8 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartToCloseTimeoutSpeculativeWorkf
   5 WorkflowTaskScheduled // Speculative WT.
   6 WorkflowTaskStarted
 `, history)
-			// Emulate slow worker: sleep more than WT timeout.
-			time.Sleep(1*time.Second + 100*time.Millisecond)
+			// Emulate slow worker: sleep little more than WT timeout.
+			time.Sleep(request.WorkflowTaskTimeout.AsDuration() + 100*time.Millisecond)
 			// This doesn't matter because WT times out before update is applied.
 			return s.acceptCompleteUpdateCommands(tv, "1"), nil
 		case 3:
@@ -3257,7 +3265,8 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_Te
 		updateResultCh <- struct{}{}
 	}
 	go updateWorkflowFn()
-	time.Sleep(500 * time.Millisecond) // This is to make sure that update gets to the server before the next Terminate call.
+	// This is to make sure that update gets to the server before the next Terminate call.
+	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
 
 	// Terminate workflow after speculative WT is scheduled but not started.
 	_, err = s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
@@ -4040,6 +4049,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_De
 	go func() {
 		updateResultCh <- s.sendUpdateNoError(tv, "1")
 	}()
+	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
 
 	// Send second update with the same ID.
 	updateResultCh2 := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -4104,6 +4114,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Dedu
 			go func() {
 				updateResultCh2 <- s.sendUpdateNoError(tv, "1")
 			}()
+			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
 
 			s.EqualHistory(`
   1 WorkflowExecutionStarted
@@ -5121,7 +5132,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_WorkerSk
 				update2ResultCh <- s.sendUpdateNoError(tv, "2")
 			}()
 			// To make sure that gets to the sever while this WT is running.
-			time.Sleep(500 * time.Millisecond)
+			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
 			return nil, nil
 		case 3:
 			s.EqualHistory(`


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix flaky update test.

## Why?
<!-- Tell your future self why have you made these changes -->
Depending on how go runtime schedules different goroutines, there is a chance that WFT is dispatched to worker before update reached the server.

Instead of sleep for short duration, tests use helper function `WaitGoRoutineWithFn` introduced in this PR. This function searches over call stacks of all goroutines for specific call. As soon as internal update handler code reached `WaitOutcome` function, it means that update handler got to the point where it waits for update results.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run locally.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.