### PR TITLE
Remove history queue reader registration logic

### DIFF
--- a/common/persistence/cassandra/mutable_state_task_store.go
+++ b/common/persistence/cassandra/mutable_state_task_store.go
@@ -203,28 +203,6 @@ func NewMutableStateTaskStore(
 	}
 }
 
-func (d *MutableStateTaskStore) RegisterHistoryTaskReader(
-	_ context.Context,
-	_ *p.RegisterHistoryTaskReaderRequest,
-) error {
-	// no-op
-	return nil
-}
-
-func (d *MutableStateTaskStore) UnregisterHistoryTaskReader(
-	_ context.Context,
-	_ *p.UnregisterHistoryTaskReaderRequest,
-) {
-	// no-op
-}
-
-func (d *MutableStateTaskStore) UpdateHistoryTaskReaderProgress(
-	_ context.Context,
-	_ *p.UpdateHistoryTaskReaderProgressRequest,
-) {
-	// no-op
-}
-
 func (d *MutableStateTaskStore) AddHistoryTasks(
 	ctx context.Context,
 	request *p.InternalAddHistoryTasksRequest,

--- a/common/persistence/client/fault_injection.go
+++ b/common/persistence/client/fault_injection.go
@@ -621,30 +621,6 @@ func (e *FaultInjectionExecutionStore) ListConcreteExecutions(
 	return e.baseExecutionStore.ListConcreteExecutions(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) RegisterHistoryTaskReader(
-	ctx context.Context,
-	request *persistence.RegisterHistoryTaskReaderRequest,
-) error {
-	// hint methods don't actually hint DB, so don't inject any failure
-	return e.baseExecutionStore.RegisterHistoryTaskReader(ctx, request)
-}
-
-func (e *FaultInjectionExecutionStore) UnregisterHistoryTaskReader(
-	ctx context.Context,
-	request *persistence.UnregisterHistoryTaskReaderRequest,
-) {
-	// hint methods don't actually hint DB, so don't inject any failure
-	e.baseExecutionStore.UnregisterHistoryTaskReader(ctx, request)
-}
-
-func (e *FaultInjectionExecutionStore) UpdateHistoryTaskReaderProgress(
-	ctx context.Context,
-	request *persistence.UpdateHistoryTaskReaderProgressRequest,
-) {
-	// hint methods don't actually hint DB, so don't inject any failure
-	e.baseExecutionStore.UpdateHistoryTaskReaderProgress(ctx, request)
-}
-
 func (e *FaultInjectionExecutionStore) AddHistoryTasks(
 	ctx context.Context,
 	request *persistence.InternalAddHistoryTasksRequest,

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -406,37 +406,12 @@ type (
 		RunID       string
 	}
 
-	// RegisterHistoryTaskReaderRequest is a hint for underlying persistence implementation
-	// that a new queue reader is created by queue processing logic
-	RegisterHistoryTaskReaderRequest struct {
-		ShardID      int32
-		ShardOwner   string
-		TaskCategory tasks.Category
-		ReaderID     int64
-	}
-
-	// UnregisterHistoryTaskReaderRequest is a hint for underlying persistence implementation
-	// that queue processing logic is done using an existing queue reader
-	UnregisterHistoryTaskReaderRequest RegisterHistoryTaskReaderRequest
-
-	// UpdateHistoryTaskReaderProgressRequest is a hint for underlying persistence implementation
-	// that a certain queue reader's process and the fact that it won't try to load tasks with
-	// key less than InclusiveMinPendingTaskKey
-	UpdateHistoryTaskReaderProgressRequest struct {
-		ShardID                    int32
-		ShardOwner                 string
-		TaskCategory               tasks.Category
-		ReaderID                   int64
-		InclusiveMinPendingTaskKey tasks.Key
-	}
-
 	// GetHistoryTasksRequest is used to get a range of history tasks
 	// Either max TaskID or FireTime is required depending on the
 	// task category type. Min TaskID or FireTime is optional.
 	GetHistoryTasksRequest struct {
 		ShardID             int32
 		TaskCategory        tasks.Category
-		ReaderID            int64
 		InclusiveMinTaskKey tasks.Key
 		ExclusiveMaxTaskKey tasks.Key
 		BatchSize           int
@@ -1093,11 +1068,6 @@ type (
 		ListConcreteExecutions(ctx context.Context, request *ListConcreteExecutionsRequest) (*ListConcreteExecutionsResponse, error)
 
 		// Tasks related APIs
-
-		// Hints for persistence implementation regarding history task readers
-		RegisterHistoryTaskReader(ctx context.Context, request *RegisterHistoryTaskReaderRequest) error
-		UnregisterHistoryTaskReader(ctx context.Context, request *UnregisterHistoryTaskReaderRequest)
-		UpdateHistoryTaskReaderProgress(ctx context.Context, request *UpdateHistoryTaskReaderProgressRequest)
 
 		AddHistoryTasks(ctx context.Context, request *AddHistoryTasksRequest) error
 		GetHistoryTasks(ctx context.Context, request *GetHistoryTasksRequest) (*GetHistoryTasksResponse, error)

--- a/common/persistence/data_interfaces_mock.go
+++ b/common/persistence/data_interfaces_mock.go
@@ -606,20 +606,6 @@ func (mr *MockExecutionManagerMockRecorder) ReadRawHistoryBranch(ctx, request in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadRawHistoryBranch", reflect.TypeOf((*MockExecutionManager)(nil).ReadRawHistoryBranch), ctx, request)
 }
 
-// RegisterHistoryTaskReader mocks base method.
-func (m *MockExecutionManager) RegisterHistoryTaskReader(ctx context.Context, request *RegisterHistoryTaskReaderRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterHistoryTaskReader", ctx, request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RegisterHistoryTaskReader indicates an expected call of RegisterHistoryTaskReader.
-func (mr *MockExecutionManagerMockRecorder) RegisterHistoryTaskReader(ctx, request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterHistoryTaskReader", reflect.TypeOf((*MockExecutionManager)(nil).RegisterHistoryTaskReader), ctx, request)
-}
-
 // SetWorkflowExecution mocks base method.
 func (m *MockExecutionManager) SetWorkflowExecution(ctx context.Context, request *SetWorkflowExecutionRequest) (*SetWorkflowExecutionResponse, error) {
 	m.ctrl.T.Helper()
@@ -648,30 +634,6 @@ func (m *MockExecutionManager) TrimHistoryBranch(ctx context.Context, request *T
 func (mr *MockExecutionManagerMockRecorder) TrimHistoryBranch(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrimHistoryBranch", reflect.TypeOf((*MockExecutionManager)(nil).TrimHistoryBranch), ctx, request)
-}
-
-// UnregisterHistoryTaskReader mocks base method.
-func (m *MockExecutionManager) UnregisterHistoryTaskReader(ctx context.Context, request *UnregisterHistoryTaskReaderRequest) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UnregisterHistoryTaskReader", ctx, request)
-}
-
-// UnregisterHistoryTaskReader indicates an expected call of UnregisterHistoryTaskReader.
-func (mr *MockExecutionManagerMockRecorder) UnregisterHistoryTaskReader(ctx, request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterHistoryTaskReader", reflect.TypeOf((*MockExecutionManager)(nil).UnregisterHistoryTaskReader), ctx, request)
-}
-
-// UpdateHistoryTaskReaderProgress mocks base method.
-func (m *MockExecutionManager) UpdateHistoryTaskReaderProgress(ctx context.Context, request *UpdateHistoryTaskReaderProgressRequest) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateHistoryTaskReaderProgress", ctx, request)
-}
-
-// UpdateHistoryTaskReaderProgress indicates an expected call of UpdateHistoryTaskReaderProgress.
-func (mr *MockExecutionManagerMockRecorder) UpdateHistoryTaskReaderProgress(ctx, request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHistoryTaskReaderProgress", reflect.TypeOf((*MockExecutionManager)(nil).UpdateHistoryTaskReaderProgress), ctx, request)
 }
 
 // UpdateWorkflowExecution mocks base method.

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -800,27 +800,6 @@ func (m *executionManagerImpl) ListConcreteExecutions(
 	return newResponse, nil
 }
 
-func (m *executionManagerImpl) RegisterHistoryTaskReader(
-	ctx context.Context,
-	request *RegisterHistoryTaskReaderRequest,
-) error {
-	return m.persistence.RegisterHistoryTaskReader(ctx, request)
-}
-
-func (m *executionManagerImpl) UnregisterHistoryTaskReader(
-	ctx context.Context,
-	request *UnregisterHistoryTaskReaderRequest,
-) {
-	m.persistence.UnregisterHistoryTaskReader(ctx, request)
-}
-
-func (m *executionManagerImpl) UpdateHistoryTaskReaderProgress(
-	ctx context.Context,
-	request *UpdateHistoryTaskReaderProgressRequest,
-) {
-	m.persistence.UpdateHistoryTaskReaderProgress(ctx, request)
-}
-
 func (m *executionManagerImpl) AddHistoryTasks(
 	ctx context.Context,
 	input *AddHistoryTasksRequest,

--- a/common/persistence/mock/store_mock.go
+++ b/common/persistence/mock/store_mock.go
@@ -1109,20 +1109,6 @@ func (mr *MockExecutionStoreMockRecorder) ReadHistoryBranch(ctx, request interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadHistoryBranch", reflect.TypeOf((*MockExecutionStore)(nil).ReadHistoryBranch), ctx, request)
 }
 
-// RegisterHistoryTaskReader mocks base method.
-func (m *MockExecutionStore) RegisterHistoryTaskReader(ctx context.Context, request *persistence.RegisterHistoryTaskReaderRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterHistoryTaskReader", ctx, request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RegisterHistoryTaskReader indicates an expected call of RegisterHistoryTaskReader.
-func (mr *MockExecutionStoreMockRecorder) RegisterHistoryTaskReader(ctx, request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterHistoryTaskReader", reflect.TypeOf((*MockExecutionStore)(nil).RegisterHistoryTaskReader), ctx, request)
-}
-
 // SetWorkflowExecution mocks base method.
 func (m *MockExecutionStore) SetWorkflowExecution(ctx context.Context, request *persistence.InternalSetWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()
@@ -1135,30 +1121,6 @@ func (m *MockExecutionStore) SetWorkflowExecution(ctx context.Context, request *
 func (mr *MockExecutionStoreMockRecorder) SetWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).SetWorkflowExecution), ctx, request)
-}
-
-// UnregisterHistoryTaskReader mocks base method.
-func (m *MockExecutionStore) UnregisterHistoryTaskReader(ctx context.Context, request *persistence.UnregisterHistoryTaskReaderRequest) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UnregisterHistoryTaskReader", ctx, request)
-}
-
-// UnregisterHistoryTaskReader indicates an expected call of UnregisterHistoryTaskReader.
-func (mr *MockExecutionStoreMockRecorder) UnregisterHistoryTaskReader(ctx, request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterHistoryTaskReader", reflect.TypeOf((*MockExecutionStore)(nil).UnregisterHistoryTaskReader), ctx, request)
-}
-
-// UpdateHistoryTaskReaderProgress mocks base method.
-func (m *MockExecutionStore) UpdateHistoryTaskReaderProgress(ctx context.Context, request *persistence.UpdateHistoryTaskReaderProgressRequest) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateHistoryTaskReaderProgress", ctx, request)
-}
-
-// UpdateHistoryTaskReaderProgress indicates an expected call of UpdateHistoryTaskReaderProgress.
-func (mr *MockExecutionStoreMockRecorder) UpdateHistoryTaskReaderProgress(ctx, request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHistoryTaskReaderProgress", reflect.TypeOf((*MockExecutionStore)(nil).UpdateHistoryTaskReaderProgress), ctx, request)
 }
 
 // UpdateWorkflowExecution mocks base method.

--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -132,11 +132,6 @@ type (
 
 		// Tasks related APIs
 
-		// Hints for persistence implementaion regarding hisotry task readers
-		RegisterHistoryTaskReader(ctx context.Context, request *RegisterHistoryTaskReaderRequest) error
-		UnregisterHistoryTaskReader(ctx context.Context, request *UnregisterHistoryTaskReaderRequest)
-		UpdateHistoryTaskReaderProgress(ctx context.Context, request *UpdateHistoryTaskReaderProgressRequest)
-
 		AddHistoryTasks(ctx context.Context, request *InternalAddHistoryTasksRequest) error
 		GetHistoryTasks(ctx context.Context, request *GetHistoryTasksRequest) (*InternalGetHistoryTasksResponse, error)
 		CompleteHistoryTask(ctx context.Context, request *CompleteHistoryTaskRequest) error

--- a/common/persistence/persistence_metric_clients.go
+++ b/common/persistence/persistence_metric_clients.go
@@ -333,33 +333,6 @@ func (p *executionPersistenceClient) ListConcreteExecutions(
 	return p.persistence.ListConcreteExecutions(ctx, request)
 }
 
-func (p *executionPersistenceClient) RegisterHistoryTaskReader(
-	ctx context.Context,
-	request *RegisterHistoryTaskReaderRequest,
-) error {
-	// hint methods won't go through persistence rate limiter
-	// so also not emitting any persistence request/error metrics
-	return p.persistence.RegisterHistoryTaskReader(ctx, request)
-}
-
-func (p *executionPersistenceClient) UnregisterHistoryTaskReader(
-	ctx context.Context,
-	request *UnregisterHistoryTaskReaderRequest,
-) {
-	// hint methods won't go through persistence rate limiter
-	// so also not emitting any persistence request/error metrics
-	p.persistence.UnregisterHistoryTaskReader(ctx, request)
-}
-
-func (p *executionPersistenceClient) UpdateHistoryTaskReaderProgress(
-	ctx context.Context,
-	request *UpdateHistoryTaskReaderProgressRequest,
-) {
-	// hint methods won't go through persistence rate limiter
-	// so also not emitting any persistence request/error metrics
-	p.persistence.UpdateHistoryTaskReaderProgress(ctx, request)
-}
-
 func (p *executionPersistenceClient) AddHistoryTasks(
 	ctx context.Context,
 	request *AddHistoryTasksRequest,

--- a/common/persistence/persistence_rate_limited_clients.go
+++ b/common/persistence/persistence_rate_limited_clients.go
@@ -302,30 +302,6 @@ func (p *executionRateLimitedPersistenceClient) ListConcreteExecutions(
 	return response, err
 }
 
-func (p *executionRateLimitedPersistenceClient) RegisterHistoryTaskReader(
-	ctx context.Context,
-	request *RegisterHistoryTaskReaderRequest,
-) error {
-	// hint methods don't actually hint DB, so don't go through persistence rate limiter
-	return p.persistence.RegisterHistoryTaskReader(ctx, request)
-}
-
-func (p *executionRateLimitedPersistenceClient) UnregisterHistoryTaskReader(
-	ctx context.Context,
-	request *UnregisterHistoryTaskReaderRequest,
-) {
-	// hint methods don't actually hint DB, so don't go through persistence rate limiter
-	p.persistence.UnregisterHistoryTaskReader(ctx, request)
-}
-
-func (p *executionRateLimitedPersistenceClient) UpdateHistoryTaskReaderProgress(
-	ctx context.Context,
-	request *UpdateHistoryTaskReaderProgressRequest,
-) {
-	// hint methods don't actually hint DB, so don't go through persistence rate limiter
-	p.persistence.UpdateHistoryTaskReaderProgress(ctx, request)
-}
-
 func (p *executionRateLimitedPersistenceClient) AddHistoryTasks(
 	ctx context.Context,
 	request *AddHistoryTasksRequest,

--- a/common/persistence/persistence_retryable_clients.go
+++ b/common/persistence/persistence_retryable_clients.go
@@ -335,30 +335,6 @@ func (p *executionRetryablePersistenceClient) ListConcreteExecutions(
 	return response, err
 }
 
-func (p *executionRetryablePersistenceClient) RegisterHistoryTaskReader(
-	ctx context.Context,
-	request *RegisterHistoryTaskReaderRequest,
-) error {
-	// hint methods don't actually hint DB, retry won't help
-	return p.persistence.RegisterHistoryTaskReader(ctx, request)
-}
-
-func (p *executionRetryablePersistenceClient) UnregisterHistoryTaskReader(
-	ctx context.Context,
-	request *UnregisterHistoryTaskReaderRequest,
-) {
-	// hint methods don't actually hint DB, retry won't help
-	p.persistence.UnregisterHistoryTaskReader(ctx, request)
-}
-
-func (p *executionRetryablePersistenceClient) UpdateHistoryTaskReaderProgress(
-	ctx context.Context,
-	request *UpdateHistoryTaskReaderProgressRequest,
-) {
-	// hint methods don't actually hint DB, retry won't help
-	p.persistence.UpdateHistoryTaskReaderProgress(ctx, request)
-}
-
 func (p *executionRetryablePersistenceClient) AddHistoryTasks(
 	ctx context.Context,
 	request *AddHistoryTasksRequest,

--- a/common/persistence/sql/execution_tasks.go
+++ b/common/persistence/sql/execution_tasks.go
@@ -41,28 +41,6 @@ import (
 	"go.temporal.io/server/service/history/tasks"
 )
 
-func (m *sqlExecutionStore) RegisterHistoryTaskReader(
-	_ context.Context,
-	_ *p.RegisterHistoryTaskReaderRequest,
-) error {
-	// no-op
-	return nil
-}
-
-func (m *sqlExecutionStore) UnregisterHistoryTaskReader(
-	_ context.Context,
-	_ *p.UnregisterHistoryTaskReaderRequest,
-) {
-	// no-op
-}
-
-func (m *sqlExecutionStore) UpdateHistoryTaskReaderProgress(
-	_ context.Context,
-	_ *p.UpdateHistoryTaskReaderProgressRequest,
-) {
-	// no-op
-}
-
 func (m *sqlExecutionStore) AddHistoryTasks(
 	ctx context.Context,
 	request *p.InternalAddHistoryTasksRequest,

--- a/common/persistence/tests/execution_mutable_state_task.go
+++ b/common/persistence/tests/execution_mutable_state_task.go
@@ -40,7 +40,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -142,16 +141,6 @@ func (s *ExecutionMutableStateTaskSuite) SetupTest() {
 		uuid.New().String(),
 		uuid.New().String(),
 	)
-
-	for _, category := range taskCategories {
-		err := s.ExecutionManager.RegisterHistoryTaskReader(s.Ctx, &p.RegisterHistoryTaskReaderRequest{
-			ShardID:      s.ShardID,
-			ShardOwner:   s.Owner,
-			TaskCategory: category,
-			ReaderID:     common.DefaultQueueReaderID,
-		})
-		s.NoError(err)
-	}
 }
 
 func (s *ExecutionMutableStateTaskSuite) TearDownTest() {
@@ -171,15 +160,6 @@ func (s *ExecutionMutableStateTaskSuite) TearDownTest() {
 		ExclusiveMaxTaskKey: tasks.NewKey(time.Unix(0, math.MaxInt64), 0),
 	})
 	s.NoError(err)
-
-	for _, category := range taskCategories {
-		s.ExecutionManager.UnregisterHistoryTaskReader(s.Ctx, &p.UnregisterHistoryTaskReaderRequest{
-			ShardID:      s.ShardID,
-			ShardOwner:   s.Owner,
-			TaskCategory: category,
-			ReaderID:     common.DefaultQueueReaderID,
-		})
-	}
 
 	s.Cancel()
 }
@@ -580,7 +560,6 @@ func (s *ExecutionMutableStateTaskSuite) TestGetScheduledTasksOrdered() {
 	response, err := s.ExecutionManager.GetHistoryTasks(s.Ctx, &p.GetHistoryTasksRequest{
 		ShardID:             s.ShardID,
 		TaskCategory:        fakeScheduledTaskCategory,
-		ReaderID:            common.DefaultQueueReaderID,
 		InclusiveMinTaskKey: tasks.NewKey(now, 0),
 		ExclusiveMaxTaskKey: tasks.NewKey(now.Add(time.Second), 0),
 		BatchSize:           10,
@@ -628,7 +607,6 @@ func (s *ExecutionMutableStateTaskSuite) PaginateTasks(
 	request := &p.GetHistoryTasksRequest{
 		ShardID:             s.ShardID,
 		TaskCategory:        category,
-		ReaderID:            common.DefaultQueueReaderID,
 		InclusiveMinTaskKey: inclusiveMinTaskKey,
 		ExclusiveMaxTaskKey: exclusiveMaxTaskKey,
 		BatchSize:           batchSize,

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -847,7 +847,6 @@ func (adh *AdminHandler) ListHistoryTasks(
 	resp, err := adh.persistenceExecutionManager.GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
 		ShardID:             request.ShardId,
 		TaskCategory:        taskCategory,
-		ReaderID:            common.DefaultQueueReaderID,
 		InclusiveMinTaskKey: minTaskKey,
 		ExclusiveMaxTaskKey: maxTaskKey,
 		BatchSize:           int(request.BatchSize),

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -333,9 +333,6 @@ func (e *historyEngineImpl) Stop() {
 		queueProcessor.Stop()
 	}
 	e.replicationProcessorMgr.Stop()
-	if e.replicationAckMgr != nil {
-		e.replicationAckMgr.Close()
-	}
 	// unset the failover callback
 	e.shardContext.GetNamespaceRegistry().UnregisterStateChangeCallback(e)
 }

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -29,8 +29,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/exp/slices"
-
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
@@ -352,8 +350,6 @@ func (p *queueBase) checkpoint() {
 	metrics.QueueSliceCountHistogram.With(p.metricsHandler).Record(int64(p.monitor.GetTotalSliceCount()))
 	metrics.PendingTasksCounter.With(p.metricsHandler).Record(int64(p.monitor.GetTotalPendingTaskCount()))
 
-	p.updateReaderProgress(readerScopes)
-
 	// NOTE: Must range-complete task first.
 	// Otherwise, if state is updated first, later deletion fails and the shard gets reloaded.
 	// Some tasks will never be deleted.
@@ -376,52 +372,6 @@ func (p *queueBase) checkpoint() {
 
 	err := p.updateQueueState(readerScopes)
 	p.resetCheckpointTimer(err)
-}
-
-func (p *queueBase) updateReaderProgress(
-	readerScopes map[int64][]Scope,
-) {
-	// NOTE: A reader has progress = X means that reader will
-	// never try to load/process tasks with key < X.
-	// If a reader's first slice has scope start from Y,
-	// it's possible that later a slice containing a key < Y gets moved into it.
-	// In general, the minKey of a reader's first slice's scope is not it's progress.
-
-	// However, since slices only move from reader with lower ID to higher ID,
-	// progress of reader with ID X = min(
-	//     progress of reader with ID < X if exists,
-	//     minKey of the first slice's scope,
-	// )
-	ctx, cancel := newQueueIOContext()
-	defer cancel()
-
-	readerIDs := make([]int64, 0, len(readerScopes))
-	for readerID := range readerScopes {
-		readerIDs = append(readerIDs, readerID)
-	}
-	slices.Sort(readerIDs)
-
-	progress := tasks.MaximumKey
-	for _, readerID := range readerIDs {
-		scopes := readerScopes[readerID]
-
-		var minKey tasks.Key
-		if len(scopes) == 0 {
-			// this should only happen to default reader
-			minKey = p.nonReadableScope.Range.InclusiveMin
-		} else {
-			minKey = scopes[0].Range.InclusiveMin
-		}
-
-		progress = tasks.MinKey(progress, minKey)
-		p.shard.GetExecutionManager().UpdateHistoryTaskReaderProgress(ctx, &persistence.UpdateHistoryTaskReaderProgressRequest{
-			ShardID:                    p.shard.GetShardID(),
-			ShardOwner:                 p.shard.GetOwner(),
-			TaskCategory:               p.category,
-			ReaderID:                   readerID,
-			InclusiveMinPendingTaskKey: progress,
-		})
-	}
 }
 
 func (p *queueBase) updateShardRangeID() bool {

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -26,7 +26,6 @@ package queues
 
 import (
 	"context"
-	"errors"
 	"math"
 	"math/rand"
 	"testing"
@@ -201,8 +200,6 @@ func (s *queueBaseSuite) TestNewProcessBase_WithPreviousState_RestoreSucceed() {
 		},
 		s.config,
 	)
-	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(2)
-
 	base := s.newQueueBase(mockShard, tasks.CategoryTransfer, nil)
 	readerScopes := make(map[int64][]Scope)
 	for id, reader := range base.readerGroup.Readers() {
@@ -216,66 +213,6 @@ func (s *queueBaseSuite) TestNewProcessBase_WithPreviousState_RestoreSucceed() {
 	s.ProtoEqual(persistenceState, ToPersistenceQueueState(queueState))
 }
 
-func (s *queueBaseSuite) TestNewProcessBase_WithPreviousState_RestoreFailed() {
-	persistenceState := &persistencespb.QueueState{
-		ReaderStates: map[int64]*persistencespb.QueueReaderState{
-			DefaultReaderId: {
-				Scopes: []*persistencespb.QueueSliceScope{
-					{
-						Range: &persistencespb.QueueSliceRange{
-							InclusiveMin: &persistencespb.TaskKey{FireTime: timestamppb.New(tasks.DefaultFireTime), TaskId: 1000},
-							ExclusiveMax: &persistencespb.TaskKey{FireTime: timestamppb.New(tasks.DefaultFireTime), TaskId: 2000},
-						},
-						Predicate: &persistencespb.Predicate{
-							PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-							Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-						},
-					},
-				},
-			},
-			DefaultReaderId + 1: {
-				Scopes: []*persistencespb.QueueSliceScope{
-					{
-						Range: &persistencespb.QueueSliceRange{
-							InclusiveMin: &persistencespb.TaskKey{FireTime: timestamppb.New(tasks.DefaultFireTime), TaskId: 500},
-							ExclusiveMax: &persistencespb.TaskKey{FireTime: timestamppb.New(tasks.DefaultFireTime), TaskId: 1000},
-						},
-						Predicate: &persistencespb.Predicate{
-							PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-							Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-						},
-					},
-				},
-			},
-		},
-		ExclusiveReaderHighWatermark: &persistencespb.TaskKey{FireTime: timestamppb.New(tasks.DefaultFireTime), TaskId: 4000},
-	}
-
-	mockShard := shard.NewTestContext(
-		s.controller,
-		&persistencespb.ShardInfo{
-			ShardId: 0,
-			RangeId: 10,
-			QueueStates: map[int32]*persistencespb.QueueState{
-				int32(tasks.CategoryIDTransfer): persistenceState,
-			},
-		},
-		s.config,
-	)
-	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(errors.New("some random error")).Times(2)
-
-	base := s.newQueueBase(mockShard, tasks.CategoryTransfer, nil)
-	s.Empty(base.readerGroup.Readers())
-	s.Equal(
-		NewScope(
-			// Range should start from the smallest key among all scopes
-			NewRange(tasks.NewImmediateKey(500), tasks.MaximumKey),
-			predicates.Universal[tasks.Task](),
-		),
-		base.nonReadableScope,
-	)
-}
-
 func (s *queueBaseSuite) TestStartStop() {
 	mockShard := shard.NewTestContext(
 		s.controller,
@@ -286,10 +223,8 @@ func (s *queueBaseSuite) TestStartStop() {
 		s.config,
 	)
 	mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
-	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-	mockShard.Resource.ExecutionMgr.EXPECT().UnregisterHistoryTaskReader(gomock.Any(), gomock.Any()).Times(1)
 
-	paginationFnProvider := func(_ int64, paginationRange Range) collection.PaginationFn[tasks.Task] {
+	paginationFnProvider := func(paginationRange Range) collection.PaginationFn[tasks.Task] {
 		return func(paginationToken []byte) ([]tasks.Task, []byte, error) {
 			mockTask := tasks.NewMockTask(s.controller)
 			key := NewRandomKeyInRange(paginationRange)
@@ -341,7 +276,6 @@ func (s *queueBaseSuite) TestProcessNewRange() {
 		s.config,
 	)
 	mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
-	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
 	s.True(base.nonReadableScope.Range.Equals(NewRange(tasks.MinimumKey, tasks.MaximumKey)))
@@ -387,7 +321,6 @@ func (s *queueBaseSuite) TestCheckPoint_WithPendingTasks_PerformRangeCompletion(
 	)
 	mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
-	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(len(readerIDs))
 
 	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
 	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
@@ -399,7 +332,6 @@ func (s *queueBaseSuite) TestCheckPoint_WithPendingTasks_PerformRangeCompletion(
 	base.exclusiveDeletionHighWatermark = currentLowWatermark
 
 	gomock.InOrder(
-		mockShard.Resource.ExecutionMgr.EXPECT().UpdateHistoryTaskReaderProgress(gomock.Any(), gomock.Any()).Times(len(readerIDs)),
 		mockShard.Resource.ExecutionMgr.EXPECT().RangeCompleteHistoryTasks(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(ctx context.Context, request *persistence.RangeCompleteHistoryTasksRequest) error {
 				s.Equal(mockShard.GetShardID(), request.ShardID)
@@ -458,7 +390,6 @@ func (s *queueBaseSuite) TestCheckPoint_WithPendingTasks_SkipRangeCompletion() {
 	)
 	mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
-	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(len(readerScopes))
 
 	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
 	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
@@ -469,15 +400,12 @@ func (s *queueBaseSuite) TestCheckPoint_WithPendingTasks_SkipRangeCompletion() {
 	currentLowWatermark := tasks.MinimumKey
 	base.exclusiveDeletionHighWatermark = currentLowWatermark
 
-	gomock.InOrder(
-		mockShard.Resource.ExecutionMgr.EXPECT().UpdateHistoryTaskReaderProgress(gomock.Any(), gomock.Any()).Times(len(readerScopes)),
-		mockShard.Resource.ShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(_ context.Context, request *persistence.UpdateShardRequest) error {
-				s.QueueStateEqual(persistenceState, request.ShardInfo.QueueStates[int32(tasks.CategoryIDTimer)])
-				return nil
-			},
-		).Times(1),
-	)
+	mockShard.Resource.ShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *persistence.UpdateShardRequest) error {
+			s.QueueStateEqual(persistenceState, request.ShardInfo.QueueStates[int32(tasks.CategoryIDTimer)])
+			return nil
+		},
+	).Times(1)
 
 	base.checkpoint()
 
@@ -580,7 +508,6 @@ func (s *queueBaseSuite) TestCheckPoint_MoveSlices() {
 	)
 	mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
-	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
 	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
@@ -593,7 +520,6 @@ func (s *queueBaseSuite) TestCheckPoint_MoveSlices() {
 	base.monitor.SetSlicePendingTaskCount(&SliceImpl{}, 2*moveSliceDefaultReaderMinPendingTaskCount)
 
 	gomock.InOrder(
-		mockShard.Resource.ExecutionMgr.EXPECT().UpdateHistoryTaskReaderProgress(gomock.Any(), gomock.Any()).Times(len(expectedQueueState.readerScopes)),
 		mockShard.Resource.ExecutionMgr.EXPECT().RangeCompleteHistoryTasks(gomock.Any(), gomock.Any()).Return(nil).Times(1),
 		mockShard.Resource.ShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ context.Context, request *persistence.UpdateShardRequest) error {
@@ -606,58 +532,6 @@ func (s *queueBaseSuite) TestCheckPoint_MoveSlices() {
 	base.checkpoint()
 
 	s.True(scopes[0].Range.InclusiveMin.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
-}
-
-func (s *queueBaseSuite) TestUpdateReaderProgress() {
-	queueState := &queueState{
-		readerScopes: map[int64][]Scope{
-			DefaultReaderId: {},
-			DefaultReaderId + 2: {
-				NewScope(NewRange(tasks.NewImmediateKey(25), tasks.NewImmediateKey(30)), predicates.Universal[tasks.Task]()),
-				NewScope(NewRange(tasks.NewImmediateKey(35), tasks.NewImmediateKey(50)), predicates.Universal[tasks.Task]()),
-			},
-			DefaultReaderId + 3: {
-				NewScope(NewRange(tasks.NewImmediateKey(75), tasks.NewImmediateKey(80)), predicates.Universal[tasks.Task]()),
-			},
-		},
-		exclusiveReaderHighWatermark: tasks.NewImmediateKey(100),
-	}
-	persistenceState := ToPersistenceQueueState(queueState)
-
-	mockShard := shard.NewTestContext(
-		s.controller,
-		&persistencespb.ShardInfo{
-			ShardId: 0,
-			RangeId: 10,
-			Owner:   "test-shard-owner",
-			QueueStates: map[int32]*persistencespb.QueueState{
-				int32(tasks.CategoryIDTransfer): persistenceState,
-			},
-		},
-		s.config,
-	)
-	mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
-	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
-	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(2)
-
-	base := s.newQueueBase(mockShard, tasks.CategoryTransfer, nil)
-	readerProgress := make(map[int64]tasks.Key)
-	mockShard.Resource.ExecutionMgr.EXPECT().UpdateHistoryTaskReaderProgress(gomock.Any(), gomock.Any()).Do(
-		func(_ context.Context, request *persistence.UpdateHistoryTaskReaderProgressRequest) {
-			s.Equal(mockShard.GetShardID(), request.ShardID)
-			s.Equal(mockShard.GetOwner(), request.ShardOwner)
-			s.Equal(tasks.CategoryTransfer, request.TaskCategory)
-			readerProgress[request.ReaderID] = request.InclusiveMinPendingTaskKey
-		},
-	).Times(len(queueState.readerScopes))
-
-	base.updateReaderProgress(queueState.readerScopes)
-
-	s.Equal(map[int64]tasks.Key{
-		DefaultReaderId:     tasks.NewImmediateKey(100),
-		DefaultReaderId + 2: tasks.NewImmediateKey(25),
-		DefaultReaderId + 3: tasks.NewImmediateKey(25),
-	}, readerProgress)
 }
 
 func (s *queueBaseSuite) QueueStateEqual(

--- a/service/history/queues/queue_immediate.go
+++ b/service/history/queues/queue_immediate.go
@@ -62,7 +62,7 @@ func NewImmediateQueue(
 	metricsHandler metrics.Handler,
 	factory ExecutableFactory,
 ) *immediateQueue {
-	paginationFnProvider := func(readerID int64, r Range) collection.PaginationFn[tasks.Task] {
+	paginationFnProvider := func(r Range) collection.PaginationFn[tasks.Task] {
 		return func(paginationToken []byte) ([]tasks.Task, []byte, error) {
 			ctx, cancel := newQueueIOContext()
 			defer cancel()
@@ -70,7 +70,6 @@ func NewImmediateQueue(
 			request := &persistence.GetHistoryTasksRequest{
 				ShardID:             shard.GetShardID(),
 				TaskCategory:        category,
-				ReaderID:            readerID,
 				InclusiveMinTaskKey: r.InclusiveMin,
 				ExclusiveMaxTaskKey: r.ExclusiveMax,
 				BatchSize:           options.BatchSize(),

--- a/service/history/queues/reader_group_test.go
+++ b/service/history/queues/reader_group_test.go
@@ -90,7 +90,6 @@ func (s *readerGroupSuite) TearDownTest() {
 
 func (s *readerGroupSuite) TestStartStop() {
 	readerID := DefaultReaderId
-	s.setupRegisterReaderMock(readerID)
 	r, err := s.readerGroup.NewReader(readerID)
 	s.NoError(err)
 	s.Equal(common.DaemonStatusInitialized, r.(*testReader).status)
@@ -99,14 +98,12 @@ func (s *readerGroupSuite) TestStartStop() {
 	s.Equal(common.DaemonStatusStarted, r.(*testReader).status)
 
 	readerID = DefaultReaderId + 1
-	s.setupRegisterReaderMock(readerID)
 	r, err = s.readerGroup.NewReader(readerID)
 	s.NoError(err)
 	s.Equal(common.DaemonStatusStarted, r.(*testReader).status)
 
 	var readers []*testReader
-	for readerID, reader := range s.readerGroup.Readers() {
-		s.setupUnRegisterReaderMock(readerID)
+	for _, reader := range s.readerGroup.Readers() {
 		readers = append(readers, reader.(*testReader))
 	}
 	s.readerGroup.Stop()
@@ -129,7 +126,6 @@ func (s *readerGroupSuite) TestAddGetReader() {
 	s.Nil(r)
 
 	for i := int64(0); i < 3; i++ {
-		s.setupRegisterReaderMock(i)
 		r, err := s.readerGroup.NewReader(i)
 		s.NoError(err)
 
@@ -153,11 +149,9 @@ func (s *readerGroupSuite) TestRemoveReader() {
 
 	readerID := DefaultReaderId
 
-	s.setupRegisterReaderMock(readerID)
 	r, err := s.readerGroup.NewReader(readerID)
 	s.NoError(err)
 
-	s.setupUnRegisterReaderMock(readerID)
 	s.readerGroup.RemoveReader(readerID)
 
 	s.Equal(common.DaemonStatusStopped, r.(*testReader).status)
@@ -167,7 +161,6 @@ func (s *readerGroupSuite) TestRemoveReader() {
 func (s *readerGroupSuite) TestForEach() {
 	readerIDs := []int64{1, 2, 3}
 	for _, readerID := range readerIDs {
-		s.setupRegisterReaderMock(readerID)
 		_, err := s.readerGroup.NewReader(readerID)
 		s.NoError(err)
 	}
@@ -178,32 +171,6 @@ func (s *readerGroupSuite) TestForEach() {
 	})
 
 	s.Equal(s.readerGroup.Readers(), forEachResult)
-}
-
-func (s *readerGroupSuite) setupRegisterReaderMock(
-	readerID int64,
-) {
-	request := &persistence.RegisterHistoryTaskReaderRequest{
-		ShardID:      s.shardID,
-		ShardOwner:   s.shardOwner,
-		TaskCategory: s.category,
-		ReaderID:     readerID,
-	}
-
-	s.mockExecutionManager.EXPECT().RegisterHistoryTaskReader(gomock.Any(), request).Return(nil).Times(1)
-}
-
-func (s *readerGroupSuite) setupUnRegisterReaderMock(
-	readerID int64,
-) {
-	request := &persistence.UnregisterHistoryTaskReaderRequest{
-		ShardID:      s.shardID,
-		ShardOwner:   s.shardOwner,
-		TaskCategory: s.category,
-		ReaderID:     readerID,
-	}
-
-	s.mockExecutionManager.EXPECT().UnregisterHistoryTaskReader(gomock.Any(), request).Times(1)
 }
 
 func newTestReader() Reader {

--- a/service/history/queues/reader_test.go
+++ b/service/history/queues/reader_test.go
@@ -106,7 +106,7 @@ func (s *readerSuite) TestStartLoadStop() {
 	r := NewRandomRange()
 	scopes := []Scope{NewScope(r, predicates.Universal[tasks.Task]())}
 
-	paginationFnProvider := func(_ int64, paginationRange Range) collection.PaginationFn[tasks.Task] {
+	paginationFnProvider := func(paginationRange Range) collection.PaginationFn[tasks.Task] {
 		s.Equal(r, paginationRange)
 		return func(paginationToken []byte) ([]tasks.Task, []byte, error) {
 			mockTask := tasks.NewMockTask(s.controller)
@@ -286,7 +286,7 @@ func (s *readerSuite) TestNotify() {
 func (s *readerSuite) TestPause() {
 	scopes := NewRandomScopes(1)
 
-	paginationFnProvider := func(_ int64, _ Range) collection.PaginationFn[tasks.Task] {
+	paginationFnProvider := func(_ Range) collection.PaginationFn[tasks.Task] {
 		return func(paginationToken []byte) ([]tasks.Task, []byte, error) {
 			mockTask := tasks.NewMockTask(s.controller)
 			mockTask.EXPECT().GetKey().Return(NewRandomKeyInRange(scopes[0].Range)).AnyTimes()
@@ -353,7 +353,7 @@ func (s *readerSuite) TestLoadAndSubmitTasks_TooManyPendingTasks() {
 func (s *readerSuite) TestLoadAndSubmitTasks_MoreTasks() {
 	scopes := NewRandomScopes(1)
 
-	paginationFnProvider := func(_ int64, _ Range) collection.PaginationFn[tasks.Task] {
+	paginationFnProvider := func(_ Range) collection.PaginationFn[tasks.Task] {
 		return func(paginationToken []byte) ([]tasks.Task, []byte, error) {
 			result := make([]tasks.Task, 0, 100)
 			for i := 0; i != 100; i++ {
@@ -390,7 +390,7 @@ func (s *readerSuite) TestLoadAndSubmitTasks_MoreTasks() {
 func (s *readerSuite) TestLoadAndSubmitTasks_NoMoreTasks_HasNextSlice() {
 	scopes := NewRandomScopes(2)
 
-	paginationFnProvider := func(_ int64, _ Range) collection.PaginationFn[tasks.Task] {
+	paginationFnProvider := func(_ Range) collection.PaginationFn[tasks.Task] {
 		return func(paginationToken []byte) ([]tasks.Task, []byte, error) {
 			mockTask := tasks.NewMockTask(s.controller)
 			mockTask.EXPECT().GetKey().Return(NewRandomKeyInRange(scopes[0].Range)).AnyTimes()
@@ -422,7 +422,7 @@ func (s *readerSuite) TestLoadAndSubmitTasks_NoMoreTasks_HasNextSlice() {
 func (s *readerSuite) TestLoadAndSubmitTasks_NoMoreTasks_NoNextSlice() {
 	scopes := NewRandomScopes(1)
 
-	paginationFnProvider := func(_ int64, _ Range) collection.PaginationFn[tasks.Task] {
+	paginationFnProvider := func(_ Range) collection.PaginationFn[tasks.Task] {
 		return func(paginationToken []byte) ([]tasks.Task, []byte, error) {
 			mockTask := tasks.NewMockTask(s.controller)
 			mockTask.EXPECT().GetKey().Return(NewRandomKeyInRange(scopes[0].Range)).AnyTimes()

--- a/service/history/queues/slice.go
+++ b/service/history/queues/slice.go
@@ -370,8 +370,8 @@ func (s *SliceImpl) SelectTasks(readerID int64, batchSize int) ([]Executable, er
 
 	executables := make([]Executable, 0, batchSize)
 	for len(executables) < batchSize && len(s.iterators) != 0 {
-		if s.iterators[0].HasNext(readerID) {
-			task, err := s.iterators[0].Next(readerID)
+		if s.iterators[0].HasNext() {
+			task, err := s.iterators[0].Next()
 			if err != nil {
 				s.iterators[0] = s.iterators[0].Remaining()
 				if len(executables) != 0 {

--- a/service/history/queues/slice_test.go
+++ b/service/history/queues/slice_test.go
@@ -437,7 +437,7 @@ func (s *sliceSuite) TestSelectTasks_NoError() {
 	predicate := tasks.NewNamespacePredicate(namespaceIDs)
 
 	numTasks := 20
-	paginationFnProvider := func(_ int64, paginationRange Range) collection.PaginationFn[tasks.Task] {
+	paginationFnProvider := func(paginationRange Range) collection.PaginationFn[tasks.Task] {
 		return func(paginationToken []byte) ([]tasks.Task, []byte, error) {
 
 			mockTasks := make([]tasks.Task, 0, numTasks)
@@ -487,7 +487,7 @@ func (s *sliceSuite) TestSelectTasks_Error_NoLoadedTasks() {
 
 	numTasks := 20
 	loadErr := true
-	paginationFnProvider := func(_ int64, paginationRange Range) collection.PaginationFn[tasks.Task] {
+	paginationFnProvider := func(paginationRange Range) collection.PaginationFn[tasks.Task] {
 		return func(paginationToken []byte) ([]tasks.Task, []byte, error) {
 			if loadErr {
 				loadErr = false
@@ -527,7 +527,7 @@ func (s *sliceSuite) TestSelectTasks_Error_WithLoadedTasks() {
 
 	numTasks := 20
 	loadErr := false
-	paginationFnProvider := func(_ int64, paginationRange Range) collection.PaginationFn[tasks.Task] {
+	paginationFnProvider := func(paginationRange Range) collection.PaginationFn[tasks.Task] {
 		return func(paginationToken []byte) ([]tasks.Task, []byte, error) {
 			defer func() {
 				loadErr = !loadErr

--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -28,7 +28,6 @@ package replication
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -39,12 +38,10 @@ import (
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/dynamicconfig"
-	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -63,7 +60,6 @@ type (
 		GetMaxTaskInfo() (int64, time.Time)
 		GetTasks(ctx context.Context, pollingCluster string, queryMessageID int64) (*replicationspb.ReplicationMessages, error)
 		GetTask(ctx context.Context, taskInfo *replicationspb.ReplicationTaskInfo) (*replicationspb.ReplicationTask, error)
-		Close()
 
 		SubscribeNotification() (<-chan struct{}, string)
 		UnsubscribeNotification(string)
@@ -98,7 +94,6 @@ type (
 		maxTaskID                  *int64
 		maxTaskVisibilityTimestamp time.Time
 		sanityCheckTime            time.Time
-		registeredQueueReaders     map[int64]struct{}
 
 		subscriberLock sync.Mutex
 		subscribers    map[string]chan struct{}
@@ -107,10 +102,6 @@ type (
 
 var (
 	errUnknownReplicationTask = serviceerror.NewInternal("unknown replication task")
-)
-
-var (
-	closeAckMangerTimeout = 10 * time.Second
 )
 
 func NewAckManager(
@@ -142,9 +133,8 @@ func NewAckManager(
 		pageSize:           config.ReplicatorProcessorFetchTasksBatchSize,
 		maxSkipTaskCount:   config.ReplicatorProcessorMaxSkipTaskCount,
 
-		maxTaskID:              nil,
-		sanityCheckTime:        time.Time{},
-		registeredQueueReaders: make(map[int64]struct{}),
+		maxTaskID:       nil,
+		sanityCheckTime: time.Time{},
 
 		subscribers: make(map[string]chan struct{}),
 	}
@@ -289,32 +279,6 @@ func (p *ackMgrImpl) GetTasks(
 	}, nil
 }
 
-func (p *ackMgrImpl) Close() {
-	p.Lock()
-	defer p.Unlock()
-
-	if p.registeredQueueReaders == nil {
-		// Close called multiple times
-		// should not happen
-		return
-	}
-
-	closeCtx, cancel := context.WithTimeout(context.Background(), closeAckMangerTimeout)
-	closeCtx = headers.SetCallerInfo(closeCtx, headers.SystemPreemptableCallerInfo)
-	defer cancel()
-
-	for readerID := range p.registeredQueueReaders {
-		p.executionMgr.UnregisterHistoryTaskReader(closeCtx, &persistence.UnregisterHistoryTaskReaderRequest{
-			ShardID:      p.shardContext.GetShardID(),
-			ShardOwner:   p.shardContext.GetOwner(),
-			TaskCategory: tasks.CategoryReplication,
-			ReaderID:     readerID,
-		})
-	}
-
-	p.registeredQueueReaders = nil
-}
-
 func (p *ackMgrImpl) getTasks(
 	ctx context.Context,
 	pollingCluster string,
@@ -327,15 +291,10 @@ func (p *ackMgrImpl) getTasks(
 		return nil, maxTaskID, nil
 	}
 
-	readerID, err := p.clusterToReaderID(ctx, pollingCluster)
-	if err != nil {
-		return nil, 0, err
-	}
-
 	replicationTasks := make([]*replicationspb.ReplicationTask, 0, p.pageSize())
 	skippedTaskCount := 0
 	lastTaskID := maxTaskID // If no tasks are returned, then it means there are no tasks bellow maxTaskID.
-	iter := collection.NewPagingIterator(p.getReplicationTasksFn(ctx, readerID, minTaskID, maxTaskID, p.pageSize()))
+	iter := collection.NewPagingIterator(p.getReplicationTasksFn(ctx, minTaskID, maxTaskID, p.pageSize()))
 	// iter.HasNext() should be the last check to avoid extra page read in case if replicationTasks is already full.
 	for len(replicationTasks) < p.pageSize() && skippedTaskCount <= p.maxSkipTaskCount() && iter.HasNext() {
 		task, err := iter.Next()
@@ -382,7 +341,6 @@ func (p *ackMgrImpl) getTasks(
 
 func (p *ackMgrImpl) getReplicationTasksFn(
 	ctx context.Context,
-	readerID int64,
 	minTaskID int64,
 	maxTaskID int64,
 	batchSize int,
@@ -391,7 +349,6 @@ func (p *ackMgrImpl) getReplicationTasksFn(
 		response, err := p.executionMgr.GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
 			ShardID:             p.shardContext.GetShardID(),
 			TaskCategory:        tasks.CategoryReplication,
-			ReaderID:            readerID,
 			InclusiveMinTaskKey: tasks.NewImmediateKey(minTaskID + 1),
 			ExclusiveMaxTaskKey: tasks.NewImmediateKey(maxTaskID + 1),
 			BatchSize:           batchSize,
@@ -441,37 +398,6 @@ func (p *ackMgrImpl) taskIDsRange(
 	}
 
 	return minTaskID, maxTaskID
-}
-
-func (p *ackMgrImpl) clusterToReaderID(
-	ctx context.Context,
-	pollingCluster string,
-) (int64, error) {
-	// TODO: need different readerID for different remote clusters
-	// e.g. use cluster's initial failover version
-	readerID := common.DefaultQueueReaderID
-
-	p.Lock()
-	defer p.Unlock()
-
-	if p.registeredQueueReaders == nil {
-		return readerID, errors.New("replication ack manager already closed")
-	}
-
-	if _, ok := p.registeredQueueReaders[readerID]; !ok {
-		err := p.executionMgr.RegisterHistoryTaskReader(ctx, &persistence.RegisterHistoryTaskReaderRequest{
-			ShardID:      p.shardContext.GetShardID(),
-			ShardOwner:   p.shardContext.GetOwner(),
-			TaskCategory: tasks.CategoryReplication,
-			ReaderID:     readerID,
-		})
-		if err != nil {
-			return readerID, err
-		}
-		p.registeredQueueReaders[readerID] = struct{}{}
-	}
-
-	return readerID, nil
 }
 
 // TODO split the ack manager into 2 components
@@ -553,15 +479,10 @@ func (p *ackMgrImpl) GetReplicationTasksIter(
 	minInclusiveTaskID int64,
 	maxExclusiveTaskID int64,
 ) (collection.Iterator[tasks.Task], error) {
-	readerID, err := p.clusterToReaderID(ctx, pollingCluster)
-	if err != nil {
-		return nil, err
-	}
 	return collection.NewPagingIterator(func(paginationToken []byte) ([]tasks.Task, []byte, error) {
 		response, err := p.executionMgr.GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
 			ShardID:             p.shardContext.GetShardID(),
 			TaskCategory:        tasks.CategoryReplication,
-			ReaderID:            readerID,
 			InclusiveMinTaskKey: tasks.NewImmediateKey(minInclusiveTaskID),
 			ExclusiveMaxTaskKey: tasks.NewImmediateKey(maxExclusiveTaskID),
 			BatchSize:           p.config.ReplicatorProcessorFetchTasksBatchSize(),

--- a/service/history/replication/ack_manager_mock.go
+++ b/service/history/replication/ack_manager_mock.go
@@ -62,18 +62,6 @@ func (m *MockAckManager) EXPECT() *MockAckManagerMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method.
-func (m *MockAckManager) Close() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Close")
-}
-
-// Close indicates an expected call of Close.
-func (mr *MockAckManagerMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAckManager)(nil).Close))
-}
-
 // ConvertTask mocks base method.
 func (m *MockAckManager) ConvertTask(ctx context.Context, task tasks.Task) (*repication.ReplicationTask, error) {
 	m.ctrl.T.Helper()

--- a/service/history/replication/ack_manager_test.go
+++ b/service/history/replication/ack_manager_test.go
@@ -39,7 +39,6 @@ import (
 
 	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
@@ -106,12 +105,6 @@ func (s *ackManagerSuite) SetupTest() {
 	s.mockNamespaceRegistry.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(tests.GlobalNamespaceEntry, nil).AnyTimes()
 
 	s.mockExecutionMgr = s.mockShard.Resource.ExecutionMgr
-	s.mockExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), &persistence.RegisterHistoryTaskReaderRequest{
-		ShardID:      s.mockShard.GetShardID(),
-		ShardOwner:   s.mockShard.GetOwner(),
-		TaskCategory: tasks.CategoryReplication,
-		ReaderID:     common.DefaultQueueReaderID,
-	}).Return(nil).MaxTimes(1)
 
 	s.mockClusterMetadata = s.mockShard.Resource.ClusterMetadata
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
@@ -245,7 +238,6 @@ func (s *ackManagerSuite) TestGetTasks_NoTasksInDB() {
 	s.mockExecutionMgr.EXPECT().GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
 		ShardID:             s.mockShard.GetShardID(),
 		TaskCategory:        tasks.CategoryReplication,
-		ReaderID:            common.DefaultQueueReaderID,
 		InclusiveMinTaskKey: tasks.NewImmediateKey(minTaskID + 1),
 		ExclusiveMaxTaskKey: tasks.NewImmediateKey(maxTaskID + 1),
 		BatchSize:           s.replicationAckManager.pageSize(),
@@ -267,7 +259,6 @@ func (s *ackManagerSuite) TestGetTasks_FirstPersistenceErrorReturnsErrorAndEmpty
 	s.mockExecutionMgr.EXPECT().GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
 		ShardID:             s.mockShard.GetShardID(),
 		TaskCategory:        tasks.CategoryReplication,
-		ReaderID:            common.DefaultQueueReaderID,
 		InclusiveMinTaskKey: tasks.NewImmediateKey(minTaskID + 1),
 		ExclusiveMaxTaskKey: tasks.NewImmediateKey(maxTaskID + 1),
 		BatchSize:           s.replicationAckManager.pageSize(),
@@ -298,7 +289,6 @@ func (s *ackManagerSuite) TestGetTasks_SecondPersistenceErrorReturnsPartialResul
 	s.mockExecutionMgr.EXPECT().GetHistoryTasks(ctx, &persistence.GetHistoryTasksRequest{
 		ShardID:             s.mockShard.GetShardID(),
 		TaskCategory:        tasks.CategoryReplication,
-		ReaderID:            common.DefaultQueueReaderID,
 		InclusiveMinTaskKey: tasks.NewImmediateKey(minTaskID + 1),
 		ExclusiveMaxTaskKey: tasks.NewImmediateKey(maxTaskID + 1),
 		BatchSize:           s.replicationAckManager.pageSize(),
@@ -347,7 +337,6 @@ func (s *ackManagerSuite) TestGetTasks_FullPage() {
 	s.mockExecutionMgr.EXPECT().GetHistoryTasks(gomock.Any(), &persistence.GetHistoryTasksRequest{
 		ShardID:             s.mockShard.GetShardID(),
 		TaskCategory:        tasks.CategoryReplication,
-		ReaderID:            common.DefaultQueueReaderID,
 		InclusiveMinTaskKey: tasks.NewImmediateKey(minTaskID + 1),
 		ExclusiveMaxTaskKey: tasks.NewImmediateKey(maxTaskID + 1),
 		BatchSize:           s.replicationAckManager.pageSize(),
@@ -396,7 +385,6 @@ func (s *ackManagerSuite) TestGetTasks_PartialPage() {
 	s.mockExecutionMgr.EXPECT().GetHistoryTasks(gomock.Any(), &persistence.GetHistoryTasksRequest{
 		ShardID:             s.mockShard.GetShardID(),
 		TaskCategory:        tasks.CategoryReplication,
-		ReaderID:            common.DefaultQueueReaderID,
 		InclusiveMinTaskKey: tasks.NewImmediateKey(minTaskID + 1),
 		ExclusiveMaxTaskKey: tasks.NewImmediateKey(maxTaskID + 1),
 		BatchSize:           s.replicationAckManager.pageSize(),
@@ -457,7 +445,6 @@ func (s *ackManagerSuite) TestGetTasks_FilterNamespace() {
 	s.mockExecutionMgr.EXPECT().GetHistoryTasks(gomock.Any(), &persistence.GetHistoryTasksRequest{
 		ShardID:             s.mockShard.GetShardID(),
 		TaskCategory:        tasks.CategoryReplication,
-		ReaderID:            common.DefaultQueueReaderID,
 		InclusiveMinTaskKey: tasks.NewImmediateKey(minTaskID + 1),
 		ExclusiveMaxTaskKey: tasks.NewImmediateKey(maxTaskID + 1),
 		BatchSize:           s.replicationAckManager.pageSize(),
@@ -471,7 +458,6 @@ func (s *ackManagerSuite) TestGetTasks_FilterNamespace() {
 	s.mockExecutionMgr.EXPECT().GetHistoryTasks(gomock.Any(), &persistence.GetHistoryTasksRequest{
 		ShardID:             s.mockShard.GetShardID(),
 		TaskCategory:        tasks.CategoryReplication,
-		ReaderID:            common.DefaultQueueReaderID,
 		InclusiveMinTaskKey: tasks.NewImmediateKey(minTaskID + 1),
 		ExclusiveMaxTaskKey: tasks.NewImmediateKey(maxTaskID + 1),
 		BatchSize:           s.replicationAckManager.pageSize(),
@@ -482,7 +468,6 @@ func (s *ackManagerSuite) TestGetTasks_FilterNamespace() {
 	s.mockExecutionMgr.EXPECT().GetHistoryTasks(gomock.Any(), &persistence.GetHistoryTasksRequest{
 		ShardID:             s.mockShard.GetShardID(),
 		TaskCategory:        tasks.CategoryReplication,
-		ReaderID:            common.DefaultQueueReaderID,
 		InclusiveMinTaskKey: tasks.NewImmediateKey(minTaskID + 1),
 		ExclusiveMaxTaskKey: tasks.NewImmediateKey(maxTaskID + 1),
 		BatchSize:           s.replicationAckManager.pageSize(),
@@ -522,30 +507,6 @@ func (s *ackManagerSuite) TestGetTasks_FilterNamespace() {
 	s.NotNil(replicationMessages)
 	s.Len(replicationMessages.ReplicationTasks, s.replicationAckManager.pageSize())
 	s.Equal(tasksResponse3.Tasks[len(tasksResponse3.Tasks)-1].GetTaskID(), replicationMessages.LastRetrievedMessageId)
-}
-
-func (s *ackManagerSuite) TestClose() {
-	readerIDs := []int64{0, 2, 3}
-
-	s.replicationAckManager.Lock()
-	s.replicationAckManager.registeredQueueReaders = make(map[int64]struct{})
-
-	for _, readerID := range readerIDs {
-		s.replicationAckManager.registeredQueueReaders[readerID] = struct{}{}
-		s.mockExecutionMgr.EXPECT().UnregisterHistoryTaskReader(gomock.Any(), &persistence.UnregisterHistoryTaskReaderRequest{
-			ShardID:      s.mockShard.GetShardID(),
-			ShardOwner:   s.mockShard.GetOwner(),
-			TaskCategory: tasks.CategoryReplication,
-			ReaderID:     readerID,
-		}).Times(1)
-	}
-	s.replicationAckManager.Unlock()
-
-	s.replicationAckManager.Close()
-
-	s.replicationAckManager.Lock()
-	s.Nil(s.replicationAckManager.registeredQueueReaders)
-	s.replicationAckManager.Unlock()
 }
 
 func (s *ackManagerSuite) getHistoryTasksResponse(size int) *persistence.GetHistoryTasksResponse {

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -37,7 +37,6 @@ import (
 	historyspb "go.temporal.io/server/api/history/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/client"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -284,7 +283,6 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 		GetHistoryTasksRequest: persistence.GetHistoryTasksRequest{
 			ShardID:             r.shard.GetShardID(),
 			TaskCategory:        tasks.CategoryReplication,
-			ReaderID:            common.DefaultQueueReaderID,
 			InclusiveMinTaskKey: tasks.NewImmediateKey(ackLevel + 1),
 			ExclusiveMaxTaskKey: tasks.NewImmediateKey(lastMessageID + 1),
 			BatchSize:           pageSize,

--- a/service/history/replication/dlq_handler_test.go
+++ b/service/history/replication/dlq_handler_test.go
@@ -41,7 +41,6 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/client"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/persistence"
@@ -189,7 +188,6 @@ func (s *dlqHandlerSuite) TestReadMessages_OK() {
 		GetHistoryTasksRequest: persistence.GetHistoryTasksRequest{
 			ShardID:             s.mockShard.GetShardID(),
 			TaskCategory:        tasks.CategoryReplication,
-			ReaderID:            common.DefaultQueueReaderID,
 			InclusiveMinTaskKey: tasks.NewImmediateKey(persistence.EmptyQueueMessageID + 1),
 			ExclusiveMaxTaskKey: tasks.NewImmediateKey(lastMessageID + 1),
 			BatchSize:           pageSize,
@@ -285,7 +283,6 @@ func (s *dlqHandlerSuite) TestMergeMessages() {
 		GetHistoryTasksRequest: persistence.GetHistoryTasksRequest{
 			ShardID:             s.mockShard.GetShardID(),
 			TaskCategory:        tasks.CategoryReplication,
-			ReaderID:            common.DefaultQueueReaderID,
 			InclusiveMinTaskKey: tasks.NewImmediateKey(persistence.EmptyQueueMessageID + 1),
 			ExclusiveMaxTaskKey: tasks.NewImmediateKey(lastMessageID + 1),
 			BatchSize:           pageSize,

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -344,21 +344,12 @@ func (r *taskProcessorManagerImpl) cleanupReplicationTasks() error {
 	ctx = headers.SetCallerInfo(ctx, headers.SystemPreemptableCallerInfo)
 	defer cancel()
 
-	inclusiveMinPendingTaskKey := tasks.NewImmediateKey(minAckedTaskID + 1)
-	r.shard.GetExecutionManager().UpdateHistoryTaskReaderProgress(ctx, &persistence.UpdateHistoryTaskReaderProgressRequest{
-		ShardID:                    r.shard.GetShardID(),
-		ShardOwner:                 r.shard.GetOwner(),
-		TaskCategory:               tasks.CategoryReplication,
-		ReaderID:                   common.DefaultQueueReaderID,
-		InclusiveMinPendingTaskKey: inclusiveMinPendingTaskKey,
-	})
-
 	err := r.shard.GetExecutionManager().RangeCompleteHistoryTasks(
 		ctx,
 		&persistence.RangeCompleteHistoryTasksRequest{
 			ShardID:             r.shard.GetShardID(),
 			TaskCategory:        tasks.CategoryReplication,
-			ExclusiveMaxTaskKey: inclusiveMinPendingTaskKey,
+			ExclusiveMaxTaskKey: tasks.NewImmediateKey(minAckedTaskID + 1),
 		},
 	)
 	if err == nil {

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -197,16 +197,6 @@ func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Cleanup() {
 		},
 	}, true)
 	s.taskProcessorManager.minTxAckedTaskID = ackedTaskID - 1
-	s.mockExecutionManager.EXPECT().UpdateHistoryTaskReaderProgress(
-		gomock.Any(),
-		&persistence.UpdateHistoryTaskReaderProgressRequest{
-			ShardID:                    s.shardID,
-			ShardOwner:                 s.shardOwner,
-			TaskCategory:               tasks.CategoryReplication,
-			ReaderID:                   common.DefaultQueueReaderID,
-			InclusiveMinPendingTaskKey: tasks.NewImmediateKey(ackedTaskID + 1),
-		},
-	).Times(1)
 	s.mockExecutionManager.EXPECT().RangeCompleteHistoryTasks(
 		gomock.Any(),
 		&persistence.RangeCompleteHistoryTasksRequest{

--- a/tests/ndc/replication_test.go
+++ b/tests/ndc/replication_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pborman/uuid"
 	historypb "go.temporal.io/api/history/v1"
 
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/persistence"
 	test "go.temporal.io/server/common/testing"
 	"go.temporal.io/server/service/history/tasks"
@@ -90,7 +89,6 @@ Loop:
 			GetHistoryTasksRequest: persistence.GetHistoryTasksRequest{
 				ShardID:             shardID,
 				TaskCategory:        tasks.CategoryReplication,
-				ReaderID:            common.DefaultQueueReaderID,
 				InclusiveMinTaskKey: tasks.NewImmediateKey(0),
 				ExclusiveMaxTaskKey: tasks.NewImmediateKey(math.MaxInt64),
 				BatchSize:           math.MaxInt64,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Remove unused persistence API for registering queue readers and updating it's progress.

## Why?
<!-- Tell your future self why have you made these changes -->
- Those APIs are adding for a deprecated design

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
