### PR TITLE
sqlplugins/mysql: default interpolateParams in DSN

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/session/session.go
+++ b/common/persistence/sql/sqlplugin/mysql/session/session.go
@@ -51,8 +51,9 @@ const (
 )
 
 var dsnAttrOverrides = map[string]string{
-	"parseTime":       "true",
-	"clientFoundRows": "true",
+	"parseTime":         "true",
+	"clientFoundRows":   "true",
+	"interpolateParams": "true",
 }
 
 type Session struct {


### PR DESCRIPTION
By default, the `go-sql-driver/mysql` driver wraps every query in a prepared statement, and this extra prepared statement means every single query is effectively two round trips. A request of ComPrepare to prepare the query, then ComStmtExecute with the statement id and the parameters.

In theory, this would be be fine if Temporal was explicitly aware of this and prepared their own statements explicitly and reused the prepared statements over and over through the lifetime.

Short of that, wrapping every query in a prepared statement just effectively doubles the queries and double the latency.

I had originally considered exposing this as a configuration knob, since this can be set through `connectAttributes` manually, but I don't think there's value in having this be configurable and we can provide a better default.

See: https://github.com/go-sql-driver/mysql#interpolateparams

## How did you test it?
I have tested locally, and we are starting to tell our customers (PlanetScale) to set this manually in their `connectAttributes`.

## Potential risks
There's a potential for some reason, the behavior to change and not work with client side interpolation, but it's unknown currently and I think would be considered a bug in the `go-sql-driver/mysql` library if anything is uncovered.

## Is hotfix candidate?
I'd say Yes, but I personally have little experience with the Temporal community. :)
