### PR TITLE
GetTaskQueueUserData returns success on task queue closing

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -1113,7 +1113,7 @@ func (e *matchingEngineImpl) GetTaskQueueUserData(
 	for {
 		resp := &matchingservice.GetTaskQueueUserDataResponse{}
 		userData, userDataChanged, err := tqMgr.GetUserData()
-		if err == errTaskQueueClosed {
+		if errors.Is(err, errTaskQueueClosed) {
 			// If we're closing, return a success with no data, as if the request expired. We shouldn't
 			// close due to idleness (because of the MarkAlive above), so we're probably closing due to a
 			// change of ownership. The caller will retry and be redirected to the new owner.

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -2335,14 +2335,14 @@ func (s *matchingEngineSuite) TestGetTaskQueueUserData_LongPoll_Closes() {
 		})
 	}()
 
-	_, err := s.matchingEngine.GetTaskQueueUserData(ctx, &matchingservice.GetTaskQueueUserDataRequest{
+	res, err := s.matchingEngine.GetTaskQueueUserData(ctx, &matchingservice.GetTaskQueueUserDataRequest{
 		NamespaceId:   namespaceID.String(),
 		TaskQueue:     tq,
 		TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
 		WaitNewData:   true,
 	})
-	s.ErrorAs(err, new(*serviceerror.Unavailable))
-
+	s.NoError(err)
+	s.Nil(res.UserData)
 }
 
 func (s *matchingEngineSuite) TestUpdateUserData_FailsOnKnownVersionMismatch() {


### PR DESCRIPTION
## What changed?
GetTaskQueueUserData returns a successful "no change" when the task queue is closing, instead of an Unavailable error.

## Why?
1. The caller will retry on both success and failure, so it doesn't really matter.
2. Returning success avoids misleading logs about errors (this was improved in #5227 but still happens on service deployment/restart).
3. More subtly, an unavailable error is actually retried by the server interceptor, which causes the task queue to be reloaded again. This can cause extra bouncing of task queues during deployment and increase latency. A success is not retried.

## How did you test it?
changed unit test, tested locally with matching restarts

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
