### PR TITLE
Emitting metric for payload size in mutable state

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -841,6 +841,7 @@ var (
 		"mutable_state_size",
 		WithDescription("The size of an individual Workflow Execution's state, emitted each time a workflow execution is retrieved or updated."),
 	)
+	MutableStatePayloadSize               = NewBytesHistogramDef("mutable_state_payload_size")
 	ExecutionInfoSize                     = NewBytesHistogramDef("execution_info_size")
 	ExecutionStateSize                    = NewBytesHistogramDef("execution_state_size")
 	ActivityInfoSize                      = NewBytesHistogramDef("activity_info_size")

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -717,6 +717,7 @@ type (
 	// MutableStateStatistics is the size stats for MutableState
 	MutableStateStatistics struct {
 		TotalSize         int
+		PayloadSize       int
 		HistoryStatistics *HistoryStatistics
 
 		// Breakdown of size into more granular stats

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -141,6 +141,7 @@ func (m *executionManagerImpl) CreateWorkflowExecution(
 	return &CreateWorkflowExecutionResponse{
 		NewMutableStateStats: *statusOfInternalWorkflowSnapshot(
 			serializedNewWorkflowSnapshot,
+			&newSnapshot,
 			newHistoryDiff,
 		),
 	}, nil
@@ -227,10 +228,12 @@ func (m *executionManagerImpl) UpdateWorkflowExecution(
 		return &UpdateWorkflowExecutionResponse{
 			UpdateMutableStateStats: *statusOfInternalWorkflowMutation(
 				&newRequest.UpdateWorkflowMutation,
+				&updateMutation,
 				updateWorkflowHistoryDiff,
 			),
 			NewMutableStateStats: statusOfInternalWorkflowSnapshot(
 				newRequest.NewWorkflowSnapshot,
+				newSnapshot,
 				newWorkflowHistoryDiff,
 			),
 		}, nil
@@ -355,14 +358,17 @@ func (m *executionManagerImpl) ConflictResolveWorkflowExecution(
 		return &ConflictResolveWorkflowExecutionResponse{
 			ResetMutableStateStats: *statusOfInternalWorkflowSnapshot(
 				&newRequest.ResetWorkflowSnapshot,
+				&resetSnapshot,
 				resetWorkflowHistoryDiff,
 			),
 			NewMutableStateStats: statusOfInternalWorkflowSnapshot(
 				newRequest.NewWorkflowSnapshot,
+				newSnapshot,
 				newWorkflowHistoryDiff,
 			),
 			CurrentMutableStateStats: statusOfInternalWorkflowMutation(
 				newRequest.CurrentWorkflowMutation,
+				currentMutation,
 				currentWorkflowHistoryDiff,
 			),
 		}, nil

--- a/common/persistence/size.go
+++ b/common/persistence/size.go
@@ -74,6 +74,7 @@ func statusOfInternalWorkflow(
 	payloadSize := sizeOfStringPayloadMap(state.ExecutionInfo.Memo)
 	payloadSize += sizeOfStringPayloadMap(state.ExecutionInfo.SearchAttributes)
 	payloadSize += getActivityPayloadSize(state.ActivityInfos)
+	payloadSize += sizeOfBlobSlice(internalState.BufferedEvents)
 
 	totalSize := executionInfoSize
 	totalSize += executionStateSize
@@ -188,6 +189,7 @@ func statusOfInternalWorkflowMutation(
 	payloadSize := sizeOfStringPayloadMap(internalMutation.ExecutionInfo.Memo)
 	payloadSize += sizeOfStringPayloadMap(internalMutation.ExecutionInfo.SearchAttributes)
 	payloadSize += getActivityPayloadSize(mutation.UpsertActivityInfos)
+	payloadSize += sizeOfBlob(internalMutation.NewBufferedEvents)
 
 	// TODO what about checksum?
 

--- a/common/persistence/size_util.go
+++ b/common/persistence/size_util.go
@@ -92,3 +92,14 @@ func sizeOfBlobSlice(
 	}
 	return size
 }
+
+func sizeOfStringPayloadMap(
+	kvBlob map[string]*commonpb.Payload,
+) int {
+	size := 0
+	for id, blob := range kvBlob {
+		// 8 == 64 bit / 8 bit per byte
+		size += len(id) + blob.Size()
+	}
+	return size
+}

--- a/common/persistence/size_util.go
+++ b/common/persistence/size_util.go
@@ -94,11 +94,10 @@ func sizeOfBlobSlice(
 }
 
 func sizeOfStringPayloadMap(
-	kvBlob map[string]*commonpb.Payload,
+	kvPayload map[string]*commonpb.Payload,
 ) int {
 	size := 0
-	for id, blob := range kvBlob {
-		// 8 == 64 bit / 8 bit per byte
+	for id, blob := range kvPayload {
 		size += len(id) + blob.Size()
 	}
 	return size

--- a/service/history/workflow/metrics.go
+++ b/service/history/workflow/metrics.go
@@ -61,6 +61,7 @@ func emitMutableStateStatus(
 	}
 
 	metricsHandler.Histogram(metrics.MutableStateSize.Name(), metrics.MutableStateSize.Unit()).Record(int64(stats.TotalSize))
+	metricsHandler.Histogram(metrics.MutableStatePayloadSize.Name(), metrics.MutableStatePayloadSize.Unit()).Record(int64(stats.PayloadSize))
 	metricsHandler.Histogram(metrics.ExecutionInfoSize.Name(), metrics.ExecutionInfoSize.Unit()).Record(int64(stats.ExecutionInfoSize))
 	metricsHandler.Histogram(metrics.ExecutionStateSize.Name(), metrics.ExecutionStateSize.Unit()).Record(int64(stats.ExecutionStateSize))
 	metricsHandler.Histogram(metrics.ActivityInfoSize.Name(), metrics.ActivityInfoSize.Unit()).Record(int64(stats.ActivityInfoSize))


### PR DESCRIPTION
## What changed?
Adding code to emit payload size in mutable state.

## Why?
To get a better understanding of how much space in mutable state is taken up by payloads.

## How did you test it?

## Potential risks

## Is hotfix candidate?
