### PR TITLE
IGNORE: Determine test coverage for reapplying signals in EventsReapplier.ReapplyEvents

### DIFF
--- a/service/history/ndc/events_reapplier.go
+++ b/service/history/ndc/events_reapplier.go
@@ -83,7 +83,6 @@ func (r *EventsReapplierImpl) ReapplyEvents(
 				// skip already applied event
 				continue
 			}
-			reappliedEvents = append(reappliedEvents, event)
 		}
 	}
 


### PR DESCRIPTION
IGNORE: determining test coverage for signal reapplication