### PR TITLE
IGNORE: Determine test coverage for reapplying signals in workflow.Context.ReapplyEvents

### DIFF
--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -785,7 +785,6 @@ func (c *ContextImpl) ReapplyEvents(
 			event := e
 			switch event.GetEventType() {
 			case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
-				reapplyEvents = append(reapplyEvents, event)
 			}
 		}
 	}


### PR DESCRIPTION
IGNORE: determining test coverage