### PR TITLE
Ban the connect attr interpolateParams for MySQL 8 Vis dbs

### DIFF
--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -146,3 +146,14 @@ type (
 		PrepareNamedContext(ctx context.Context, query string) (*sqlx.NamedStmt, error)
 	}
 )
+
+func (k DbKind) String() string {
+	switch k {
+	case DbKindMain:
+		return "main"
+	case DbKindVisibility:
+		return "visibility"
+	default:
+		return "unknown"
+	}
+}

--- a/common/persistence/sql/sqlplugin/mysql/plugin.go
+++ b/common/persistence/sql/sqlplugin/mysql/plugin.go
@@ -67,7 +67,7 @@ func (p *plugin) CreateAdminDB(
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
 ) (sqlplugin.AdminDB, error) {
-	conn, err := p.createDBConnection(sqlplugin.DbKindMain, cfg, r)
+	conn, err := p.createDBConnection(dbKind, cfg, r)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/sql/sqlplugin/mysql/plugin.go
+++ b/common/persistence/sql/sqlplugin/mysql/plugin.go
@@ -53,7 +53,7 @@ func (p *plugin) CreateDB(
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
 ) (sqlplugin.DB, error) {
-	conn, err := p.createDBConnection(cfg, r)
+	conn, err := p.createDBConnection(session.MySQLVersion5_7, dbKind, cfg, r)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func (p *plugin) CreateAdminDB(
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
 ) (sqlplugin.AdminDB, error) {
-	conn, err := p.createDBConnection(cfg, r)
+	conn, err := p.createDBConnection(session.MySQLVersion5_7, sqlplugin.DbKindMain, cfg, r)
 	if err != nil {
 		return nil, err
 	}
@@ -80,10 +80,12 @@ func (p *plugin) CreateAdminDB(
 // SQL database and the object can be used to perform CRUD operations on
 // the tables in the database
 func (p *plugin) createDBConnection(
+	version session.MySQLVersion,
+	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	resolver resolver.ServiceResolver,
 ) (*sqlx.DB, error) {
-	mysqlSession, err := session.NewSession(cfg, resolver)
+	mysqlSession, err := session.NewSession(version, dbKind, cfg, resolver)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/sql/sqlplugin/mysql/plugin.go
+++ b/common/persistence/sql/sqlplugin/mysql/plugin.go
@@ -53,7 +53,7 @@ func (p *plugin) CreateDB(
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
 ) (sqlplugin.DB, error) {
-	conn, err := p.createDBConnection(session.MySQLVersion5_7, dbKind, cfg, r)
+	conn, err := p.createDBConnection(dbKind, cfg, r)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func (p *plugin) CreateAdminDB(
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
 ) (sqlplugin.AdminDB, error) {
-	conn, err := p.createDBConnection(session.MySQLVersion5_7, sqlplugin.DbKindMain, cfg, r)
+	conn, err := p.createDBConnection(sqlplugin.DbKindMain, cfg, r)
 	if err != nil {
 		return nil, err
 	}
@@ -80,12 +80,11 @@ func (p *plugin) CreateAdminDB(
 // SQL database and the object can be used to perform CRUD operations on
 // the tables in the database
 func (p *plugin) createDBConnection(
-	version session.MySQLVersion,
 	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	resolver resolver.ServiceResolver,
 ) (*sqlx.DB, error) {
-	mysqlSession, err := session.NewSession(version, dbKind, cfg, resolver)
+	mysqlSession, err := session.NewSession(dbKind, cfg, resolver)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/sql/sqlplugin/mysql/session/session.go
+++ b/common/persistence/sql/sqlplugin/mysql/session/session.go
@@ -47,7 +47,6 @@ type (
 		*sqlx.DB
 	}
 
-	// MySQLVersion specifies which of the distinct mysql versions we support
 	MySQLVersion int
 )
 
@@ -70,6 +69,7 @@ const (
 )
 
 var (
+	errUnspecifiedMySQLVersion                = errors.New("bug: mysql version left unspecified")
 	errMySQL8VisInterpolateParamsNotSupported = errors.New("interpolateParams is not supported for mysql8 visibility stores")
 	dsnAttrOverrides                          = map[string]string{
 		"parseTime":       "true",
@@ -95,7 +95,7 @@ func NewSession(
 	resolver resolver.ServiceResolver,
 ) (*Session, error) {
 	if version == MySQLVersionUnspecified {
-		return nil, fmt.Errorf("Bug: unspecified MySQL version provided to NewSession")
+		return nil, errUnspecifiedMySQLVersion
 	}
 
 	db, err := createConnection(version, dbKind, cfg, resolver)

--- a/common/persistence/sql/sqlplugin/mysql/session/session.go
+++ b/common/persistence/sql/sqlplugin/mysql/session/session.go
@@ -59,8 +59,8 @@ const (
 )
 
 var (
-	errMySQL8VisInterpolateParamsNotSupported = errors.New("interpolateParams is not supported for mysql8 visibility stores")
-	dsnAttrOverrides                          = map[string]string{
+	errVisInterpolateParamsNotSupported = errors.New("interpolateParams is not supported for mysql visibility stores")
+	dsnAttrOverrides                    = map[string]string{
 		"parseTime":       "true",
 		"clientFoundRows": "true",
 	}
@@ -169,7 +169,7 @@ func buildDSNAttrs(dbKind sqlplugin.DbKind, cfg *config.SQL) (map[string]string,
 
 	if dbKind == sqlplugin.DbKindVisibility {
 		if _, ok := attrs[interpolateParamsAttr]; ok {
-			return nil, errMySQL8VisInterpolateParamsNotSupported
+			return nil, errVisInterpolateParamsNotSupported
 		}
 	}
 

--- a/common/persistence/sql/sqlplugin/mysql/session/session_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/session/session_test.go
@@ -182,7 +182,7 @@ func (s *sessionTestSuite) Test_Visibility_DoesntSupport_interpolateParams() {
 	r := resolver.NewMockServiceResolver(s.controller)
 	r.EXPECT().Resolve(cfg.ConnectAddr).Return([]string{cfg.ConnectAddr})
 	_, err := buildDSN(sqlplugin.DbKindVisibility, &cfg, r)
-	s.Error(err, "We should return an error when a MySQL8 Visibility database is configured with interpolateParams")
+	s.Error(err, "We should return an error when a MySQL Visibility database is configured with interpolateParams")
 }
 
 func buildExpectedURLParams(attrs map[string]string, isolationKey string, isolationValue string) url.Values {

--- a/common/persistence/sql/sqlplugin/mysql/session/session_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/session/session_test.go
@@ -173,7 +173,7 @@ func (s *sessionTestSuite) TestBuildDSN() {
 }
 
 func (s *sessionTestSuite) Test_MySQL8_Visibility_DoesntSupport_interpolateParams() {
-	config := config.SQL{
+	cfg := config.SQL{
 		User:              "test",
 		Password:          "pass",
 		ConnectProtocol:   "tcp",
@@ -182,8 +182,8 @@ func (s *sessionTestSuite) Test_MySQL8_Visibility_DoesntSupport_interpolateParam
 		ConnectAttributes: map[string]string{"interpolateParams": "ignored"},
 	}
 	r := resolver.NewMockServiceResolver(s.controller)
-	r.EXPECT().Resolve(config.ConnectAddr).Return([]string{config.ConnectAddr})
-	_, err := buildDSN(MySQLVersion8_0, sqlplugin.DbKindVisibility, &config, r)
+	r.EXPECT().Resolve(cfg.ConnectAddr).Return([]string{cfg.ConnectAddr})
+	_, err := buildDSN(MySQLVersion8_0, sqlplugin.DbKindVisibility, &cfg, r)
 	s.Error(err, "We should return an error when a MySQL8 Visibility database is configured with interpolateParams")
 }
 

--- a/common/persistence/sql/sqlplugin/mysql/session/session_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/session/session_test.go
@@ -25,6 +25,7 @@
 package session
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 	"testing"
@@ -33,6 +34,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/resolver"
 )
 
@@ -66,12 +68,15 @@ func (s *sessionTestSuite) TearDownTest() {
 
 func (s *sessionTestSuite) TestBuildDSN() {
 	testCases := []struct {
-		in              config.SQL
-		outURLPath      string
-		outIsolationKey string
-		outIsolationVal string
+		name                string
+		in                  config.SQL
+		outURLPath          string
+		outIsolationKey     string
+		outIsolationVal     string
+		expectInvalidConfig bool
 	}{
 		{
+			name: "no connect attributes",
 			in: config.SQL{
 				User:            "test",
 				Password:        "pass",
@@ -84,6 +89,7 @@ func (s *sessionTestSuite) TestBuildDSN() {
 			outURLPath:      "test:pass@tcp(192.168.0.1:3306)/db1?",
 		},
 		{
+			name: "with connect attributes",
 			in: config.SQL{
 				User:              "test",
 				Password:          "pass",
@@ -97,6 +103,7 @@ func (s *sessionTestSuite) TestBuildDSN() {
 			outURLPath:      "test:pass@tcp(192.168.0.1:3306)/db1?",
 		},
 		{
+			name: "override isolation level (quoted, shorthand)",
 			in: config.SQL{
 				User:              "test",
 				Password:          "pass",
@@ -110,6 +117,7 @@ func (s *sessionTestSuite) TestBuildDSN() {
 			outURLPath:      "test:pass@tcp(192.168.0.1:3306)/db1?",
 		},
 		{
+			name: "override isolation level (unquoted, shorthand)",
 			in: config.SQL{
 				User:              "test",
 				Password:          "pass",
@@ -123,6 +131,7 @@ func (s *sessionTestSuite) TestBuildDSN() {
 			outURLPath:      "test:pass@tcp(192.168.0.1:3306)/db1?",
 		},
 		{
+			name: "override isolation level (unquoted, full name)",
 			in: config.SQL{
 				User:              "test",
 				Password:          "pass",
@@ -137,19 +146,45 @@ func (s *sessionTestSuite) TestBuildDSN() {
 		},
 	}
 
-	for _, tc := range testCases {
-		r := resolver.NewMockServiceResolver(s.controller)
-		r.EXPECT().Resolve(tc.in.ConnectAddr).Return([]string{tc.in.ConnectAddr})
+	for _, version := range []MySQLVersion{MySQLVersion5_7, MySQLVersion8_0} {
+		for _, dbKind := range []sqlplugin.DbKind{sqlplugin.DbKindMain, sqlplugin.DbKindVisibility} {
+			for _, tc := range testCases {
+				s.Run(fmt.Sprintf("%s %s: %s", version.String(), dbKind.String(), tc.name), func() {
+					r := resolver.NewMockServiceResolver(s.controller)
+					r.EXPECT().Resolve(tc.in.ConnectAddr).Return([]string{tc.in.ConnectAddr})
 
-		out := buildDSN(&tc.in, r)
-		s.True(strings.HasPrefix(out, tc.outURLPath), "invalid url path")
-		tokens := strings.Split(out, "?")
-		s.Equal(2, len(tokens), "invalid url")
-		qry, err := url.Parse("?" + tokens[1])
-		s.NoError(err)
-		wantAttrs := buildExpectedURLParams(tc.in.ConnectAttributes, tc.outIsolationKey, tc.outIsolationVal)
-		s.Equal(wantAttrs, qry.Query(), "invalid dsn url params")
+					out, err := buildDSN(version, dbKind, &tc.in, r)
+					if tc.expectInvalidConfig {
+						s.Error(err, "Expected an invalid configuration error")
+					} else {
+						s.NoError(err)
+					}
+					s.True(strings.HasPrefix(out, tc.outURLPath), "invalid url path")
+					tokens := strings.Split(out, "?")
+					s.Equal(2, len(tokens), "invalid url")
+					qry, err := url.Parse("?" + tokens[1])
+					s.NoError(err)
+					wantAttrs := buildExpectedURLParams(tc.in.ConnectAttributes, tc.outIsolationKey, tc.outIsolationVal)
+					s.Equal(wantAttrs, qry.Query(), "invalid dsn url params")
+				})
+			}
+		}
 	}
+}
+
+func (s *sessionTestSuite) Test_MySQL8_Visibility_DoesntSupport_interpolateParams() {
+	config := config.SQL{
+		User:              "test",
+		Password:          "pass",
+		ConnectProtocol:   "tcp",
+		ConnectAddr:       "192.168.0.1:3306",
+		DatabaseName:      "db1",
+		ConnectAttributes: map[string]string{"interpolateParams": "ignored"},
+	}
+	r := resolver.NewMockServiceResolver(s.controller)
+	r.EXPECT().Resolve(config.ConnectAddr).Return([]string{config.ConnectAddr})
+	_, err := buildDSN(MySQLVersion8_0, sqlplugin.DbKindVisibility, &config, r)
+	s.Error(err, "We should return an error when a MySQL8 Visibility database is configured with interpolateParams")
 }
 
 func buildExpectedURLParams(attrs map[string]string, isolationKey string, isolationValue string) url.Values {


### PR DESCRIPTION
## What changed?
Attempting to configure a MySQL 8 Visibility database with go-sql-driver/mysql's `interpolateParams` option will now fail.

## Why?

There are a number of reasons why this doesn't work right now so we're going to prevent it from happening while we discuss how much we should invest in fixing it. The current work to fix this is in https://github.com/temporalio/temporal/pull/5428

## How did you test it?
Added a new test

## Potential risks
There should be none. Any user who has currently set up their database this way will already have encountered exciting errors like `Cannot create a JSON value from a string with CHARACTER SET 'binary'` and `Unable to parse ExecutionStatus value from DB`.

## Is hotfix candidate?

That's up for discussion
