### PR TITLE
Deprecate taskCategoryRegistry usage for DLQ Key on frontend

### DIFF
--- a/common/persistence/history_task_queue_manager.go
+++ b/common/persistence/history_task_queue_manager.go
@@ -251,6 +251,14 @@ func combineUnique(strs ...string) string {
 }
 
 func (k QueueKey) GetQueueName() string {
-	hash := combineUnique(k.SourceCluster, k.TargetCluster)[:clusterNamesHashSuffixLength]
-	return fmt.Sprintf("%d_%s_%s_%s", k.Category.ID(), k.SourceCluster, k.TargetCluster, hash)
+	return GetHistoryTaskQueueName(k.Category.ID(), k.SourceCluster, k.TargetCluster)
+}
+
+func GetHistoryTaskQueueName(
+	categoryID int,
+	sourceCluster string,
+	targetCluster string,
+) string {
+	hash := combineUnique(sourceCluster, targetCluster)[:clusterNamesHashSuffixLength]
+	return fmt.Sprintf("%d_%s_%s_%s", categoryID, sourceCluster, targetCluster, hash)
 }

--- a/service/frontend/admin_handler_test.go
+++ b/service/frontend/admin_handler_test.go
@@ -1283,11 +1283,11 @@ func (s *adminHandlerSuite) TestPurgeDLQTasks() {
 	}
 }
 
-func (s *adminHandlerSuite) TestPurgeDLQTasks_InvalidCategory() {
+func (s *adminHandlerSuite) TestPurgeDLQTasks_ClusterNotSet() {
 	_, err := s.handler.PurgeDLQTasks(context.Background(), &adminservice.PurgeDLQTasksRequest{
 		DlqKey: &commonspb.HistoryDLQKey{
-			TaskCategory:  -1,
-			SourceCluster: "test-source-cluster",
+			TaskCategory:  1,
+			SourceCluster: "",
 			TargetCluster: "test-target-cluster",
 		},
 		InclusiveMaxTaskMetadata: &commonspb.HistoryDLQTaskMetadata{
@@ -1296,8 +1296,7 @@ func (s *adminHandlerSuite) TestPurgeDLQTasks_InvalidCategory() {
 	})
 	s.Error(err)
 	s.Equal(codes.InvalidArgument, serviceerror.ToStatus(err).Code())
-	s.ErrorContains(err, "task category")
-	s.ErrorContains(err, "-1")
+	s.ErrorContains(err, errSourceClusterNotSet.Error())
 }
 
 func (s *adminHandlerSuite) TestDescribeDLQJob() {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Deprecate taskCategoryRegistry usage for DLQ Key on frontend

## Why?
<!-- Tell your future self why have you made these changes -->
- Frontend should not use task category registry. That component should be used only by history service.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
