### PR TITLE
Ensure PollActivityTaskQueueResponse.ScheduleToCloseTimeout is not nil

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -1489,6 +1489,13 @@ func (e *matchingEngineImpl) createPollActivityTaskQueueResponse(
 	)
 	serializedToken, _ := e.tokenSerializer.Serialize(taskToken)
 
+	// This is here to ensure that this field is never nil as expected by the TS SDK.
+	// This may happen if ScheduleActivityExecution was recorded in version 1.23.
+	scheduleToCloseTimeout := attributes.ScheduleToCloseTimeout
+	if scheduleToCloseTimeout == nil {
+		scheduleToCloseTimeout = timestamp.DurationPtr(0)
+	}
+
 	return &matchingservice.PollActivityTaskQueueResponse{
 		ActivityId:                  attributes.ActivityId,
 		ActivityType:                attributes.ActivityType,
@@ -1497,7 +1504,7 @@ func (e *matchingEngineImpl) createPollActivityTaskQueueResponse(
 		WorkflowExecution:           task.workflowExecution(),
 		CurrentAttemptScheduledTime: historyResponse.CurrentAttemptScheduledTime,
 		ScheduledTime:               scheduledEvent.EventTime,
-		ScheduleToCloseTimeout:      attributes.ScheduleToCloseTimeout,
+		ScheduleToCloseTimeout:      scheduleToCloseTimeout,
 		StartedTime:                 historyResponse.StartedTime,
 		StartToCloseTimeout:         attributes.StartToCloseTimeout,
 		HeartbeatTimeout:            attributes.HeartbeatTimeout,


### PR DESCRIPTION
## What changed?

In description.

## Why?

This field should never be nil as expected by the TS SDK.
This may happen if ScheduleActivityExecution was recorded in version 1.23 and the server was rolled back.