### PR TITLE
history: ensure that activity run timeouts are non-nil

### DIFF
--- a/service/history/command_checker.go
+++ b/service/history/command_checker.go
@@ -345,6 +345,12 @@ func (v *commandAttrValidator) validateActivityScheduleAttributes(
 	ScheduleToStartSet := attributes.GetScheduleToStartTimeout().AsDuration() > 0
 	StartToCloseSet := attributes.GetStartToCloseTimeout().AsDuration() > 0
 
+	// The typescript SDK requires that the ScheduleToStart and/or the ScheduleToClose timeouts are non-nil.
+	// Since we override those using the potentially-nil run timeout we need to make sure it is always non-nil
+	if runTimeout == nil {
+		runTimeout = durationpb.New(0)
+	}
+
 	if ScheduleToCloseSet {
 		if ScheduleToStartSet {
 			attributes.ScheduleToStartTimeout = timestamp.MinDurationPtr(attributes.GetScheduleToStartTimeout(),


### PR DESCRIPTION
## What changed?
Run timeouts for schedule activity events events will always be valid.

## Why?
In 1.22 we always had a valid run timeout when checking schedule activity events; even though it was a `*time.Duration` in the proto message we converted it to a full `time.Duration` value before validating the command. With the proto rework in 1.23 that was dropped and we pass the `*durationpb.Duration` through without checking it's validity.

This causes the TypeScript SDK to crash as it assumes that the ScheduleToStart and ScheduleToClose timeouts are always valid.

Since we can't force all our users to upgrade their SDKs for obvious reasons, we're going to ensure we behave just like we did in 1.22

## How did you test it?

I've confirmed that this change fixes the bug uncovered by our [TypeScript Hello World sample](https://github.com/temporalio/samples-typescript/tree/main/hello-world) without the [matching patch](https://github.com/temporalio/temporal/pull/5444)

## Potential risks
None

## Documentation
No

## Is hotfix candidate?
Yes
