### PR TITLE
Use scheduled membership changes in matching and drop unload delay

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,6 +82,8 @@ linters-settings:
         disabled: true
       - name: flag-parameter
         disabled: true
+      - name: unnecessary-stmt
+        disabled: true
 
       # Rule tuning
       - name: cognitive-complexity

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -454,6 +454,9 @@ const (
 	MatchingForwarderMaxRatePerSecond = "matching.forwarderMaxRatePerSecond"
 	// MatchingForwarderMaxChildrenPerNode is the max number of children per node in the task queue partition tree
 	MatchingForwarderMaxChildrenPerNode = "matching.forwarderMaxChildrenPerNode"
+	// MatchingAlignMembershipChange is a duration to align matching's membership changes to.
+	// This can help reduce effects of task queue movement.
+	MatchingAlignMembershipChange = "matching.alignMembershipChange"
 	// MatchingShutdownDrainDuration is the duration of traffic drain during shutdown
 	MatchingShutdownDrainDuration = "matching.shutdownDrainDuration"
 	// MatchingGetUserDataLongPollTimeout is the max length of long polls for GetUserData calls between partitions.

--- a/common/membership/ringpop/monitor.go
+++ b/common/membership/ringpop/monitor.go
@@ -448,7 +448,6 @@ func (rpo *monitor) EvictSelfAt(asOf time.Time) (time.Duration, error) {
 		rpo.logger.Error("unable to set ringpop label", tag.Error(err), tag.Key(stopAtKey))
 		return 0, err
 	}
-	rpo.logger.Info("evicting self at time", tag.Timestamp(asOf))
 	// Wait a couple more seconds after the stopAt time before actually leaving.
 	// The jitter doesn't really matter, but if two nodes join/leave at the same aligned time,
 	// it just spreads out the membership gossip traffic a little bit.

--- a/common/util/util.go
+++ b/common/util/util.go
@@ -50,6 +50,12 @@ func MaxTime(a, b time.Time) time.Time {
 	return b
 }
 
+// NextAlignedTime returns the time after `t` that is aligned to an integer multiple of `align`
+// since the unix epoch.
+func NextAlignedTime(t time.Time, align time.Duration) time.Time {
+	return time.Unix(0, (t.UnixNano()/int64(align)+1)*int64(align))
+}
+
 // SortSlice sorts the given slice of an ordered type.
 // Sort is not guaranteed to be stable.
 func SortSlice[S ~[]E, E constraints.Ordered](slice S) {

--- a/common/util/util.go
+++ b/common/util/util.go
@@ -50,8 +50,8 @@ func MaxTime(a, b time.Time) time.Time {
 	return b
 }
 
-// NextAlignedTime returns the time after `t` that is aligned to an integer multiple of `align`
-// since the unix epoch.
+// NextAlignedTime returns the earliest time after `t` that is aligned to an integer multiple
+// of `align` since the unix epoch.
 func NextAlignedTime(t time.Time, align time.Duration) time.Time {
 	return time.Unix(0, (t.UnixNano()/int64(align)+1)*int64(align))
 }

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -49,6 +49,7 @@ type (
 		TestDisableSyncMatch                  dynamicconfig.BoolPropertyFn
 		RPS                                   dynamicconfig.IntPropertyFn
 		OperatorRPSRatio                      dynamicconfig.FloatPropertyFn
+		AlignMembershipChange                 dynamicconfig.DurationPropertyFn
 		ShutdownDrainDuration                 dynamicconfig.DurationPropertyFn
 		HistoryMaxPageSize                    dynamicconfig.IntPropertyFnWithNamespaceFilter
 
@@ -193,6 +194,7 @@ func NewConfig(
 		ForwarderMaxOutstandingTasks:          dc.GetIntPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingForwarderMaxOutstandingTasks, 1),
 		ForwarderMaxRatePerSecond:             dc.GetIntPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingForwarderMaxRatePerSecond, 10),
 		ForwarderMaxChildrenPerNode:           dc.GetIntPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingForwarderMaxChildrenPerNode, 20),
+		AlignMembershipChange:                 dc.GetDurationProperty(dynamicconfig.MatchingAlignMembershipChange, 0*time.Second),
 		ShutdownDrainDuration:                 dc.GetDurationProperty(dynamicconfig.MatchingShutdownDrainDuration, 0*time.Second),
 		VersionCompatibleSetLimitPerQueue:     dc.GetIntPropertyFilteredByNamespace(dynamicconfig.VersionCompatibleSetLimitPerQueue, 10),
 		VersionBuildIdLimitPerQueue:           dc.GetIntPropertyFilteredByNamespace(dynamicconfig.VersionBuildIdLimitPerQueue, 100),
@@ -201,7 +203,7 @@ func NewConfig(
 		BacklogNegligibleAge:                  dc.GetDurationPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingBacklogNegligibleAge, 24*365*10*time.Hour),
 		MaxWaitForPollerBeforeFwd:             dc.GetDurationPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingMaxWaitForPollerBeforeFwd, 200*time.Millisecond),
 		QueryPollerUnavailableWindow:          dc.GetDurationProperty(dynamicconfig.QueryPollerUnavailableWindow, 20*time.Second),
-		MembershipUnloadDelay:                 dc.GetDurationProperty(dynamicconfig.MatchingMembershipUnloadDelay, 3*time.Second),
+		MembershipUnloadDelay:                 dc.GetDurationProperty(dynamicconfig.MatchingMembershipUnloadDelay, 500*time.Millisecond),
 
 		AdminNamespaceToPartitionDispatchRate:          dc.GetFloatPropertyFilteredByNamespace(dynamicconfig.AdminMatchingNamespaceToPartitionDispatchRate, 10000),
 		AdminNamespaceTaskqueueToPartitionDispatchRate: dc.GetFloatPropertyFilteredByTaskQueueInfo(dynamicconfig.AdminMatchingNamespaceTaskqueueToPartitionDispatchRate, 1000),

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -276,7 +276,7 @@ func (e *matchingEngineImpl) watchMembership() {
 			// Note that we don't verify ownership at load time, so this is the only guard against a task
 			// queue bouncing back and forth due to long membership propagation time.
 			batch := ids[i:min(len(ids), i+batchSize)]
-			wait := backoff.Jitter(delay, 0.2)
+			wait := backoff.Jitter(delay, 0.1)
 			time.AfterFunc(wait, func() {
 				// maybe the whole engine stopped
 				if atomic.LoadInt32(&e.status) != common.DaemonStatusStarted {

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -137,8 +137,7 @@ func (s *Service) Stop() {
 	// the engine which stops all task queues).
 	s.handler.Stop()
 
-	// Now there should be no more open RPCs. We can give a second in case there are any
-	// somehow remaining.
+	// All grpc handlers should be cancelled now. Give them a little time to return.
 	t := time.AfterFunc(2*time.Second, func() {
 		s.logger.Info("ShutdownHandler: Drain time expired, stopping all traffic")
 		s.server.Stop()

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/util"
 )
 
 // Service represents the matching service
@@ -111,18 +112,39 @@ func (s *Service) Start() {
 // Stop stops the service
 func (s *Service) Stop() {
 	// remove self from membership ring and wait for traffic to drain
-	s.logger.Info("ShutdownHandler: Evicting self from membership ring")
-	if err := s.membershipMonitor.EvictSelf(); err != nil {
+	var err error
+	var waitTime time.Duration
+	if align := s.config.AlignMembershipChange(); align > 0 {
+		propagation := s.membershipMonitor.ApproximateMaxPropagationTime()
+		asOf := util.NextAlignedTime(time.Now().Add(propagation), align)
+		s.logger.Info("ShutdownHandler: Evicting self from membership ring as of", tag.Timestamp(asOf))
+		waitTime, err = s.membershipMonitor.EvictSelfAt(asOf)
+	} else {
+		s.logger.Info("ShutdownHandler: Evicting self from membership ring immediately")
+		err = s.membershipMonitor.EvictSelf()
+	}
+	if err != nil {
 		s.logger.Error("ShutdownHandler: Failed to evict self from membership ring", tag.Error(err))
 	}
 	s.healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_NOT_SERVING)
+
 	s.logger.Info("ShutdownHandler: Waiting for others to discover I am unhealthy")
-	time.Sleep(s.config.ShutdownDrainDuration())
+	time.Sleep(max(s.config.ShutdownDrainDuration(), waitTime))
 
-	// TODO: Change this to GracefulStop when integration tests are refactored.
-	s.server.Stop()
-
+	// At this point we should not get any new rpcs since we removed ourself from the ring.
+	// Additionally, the engine will notice the membership change and stop all task queues
+	// after a delay. However, we can do it immediately by stopping the handler (which stops
+	// the engine which stops all task queues).
 	s.handler.Stop()
+
+	// Now there should be no more open RPCs. We can give a second in case there are any
+	// somehow remaining.
+	t := time.AfterFunc(2*time.Second, func() {
+		s.logger.Info("ShutdownHandler: Drain time expired, stopping all traffic")
+		s.server.Stop()
+	})
+	s.server.GracefulStop()
+	t.Stop()
 
 	s.visibilityManager.Close()
 


### PR DESCRIPTION
## What changed?
Connect the changes in #5431 to dynamic config for matching.

## Why?
Be able to adjust to membership changes faster.

## How did you test it?
mostly local testing, will test in test clusters before release

## Potential risks
This dynamic config shouldn't be enabled before fully rolling out this release, otherwise some nodes will understand the new labels and some won't.
