### PR TITLE
fix version in activity task generation.

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4284,7 +4284,7 @@ func (ms *MutableStateImpl) RetryActivity(
 		return state, nil
 	}
 	nextAttempt := ai.Attempt + 1
-	if err := ms.taskGenerator.GenerateActivityRetryTasks(ai, nextAttempt); err != nil {
+	if err := ms.taskGenerator.GenerateActivityRetryTasks(ai.ScheduledEventId, activityVisitor.NextScheduledTime(), nextAttempt); err != nil {
 		return enumspb.RETRY_STATE_INTERNAL_SERVER_ERROR, err
 	}
 	// we need to store activity info size since pendingActivityInfoIDs holds pointers to activity

--- a/service/history/workflow/mutable_state_impl_restart_activity_test.go
+++ b/service/history/workflow/mutable_state_impl_restart_activity_test.go
@@ -163,12 +163,12 @@ func (s *retryActivitySuite) TestRetryActivity_when_activity_has_pending_cancel_
 }
 
 func (s *retryActivitySuite) TestRetryActivity_should_be_scheduled_when_next_backoff_interval_can_be_calculated() {
+	s.mutableState.timeSource = s.timeSource
 	taskGeneratorMock := NewMockTaskGenerator(s.controller)
 	nextAttempt := s.activity.Attempt + 1
-	taskGeneratorMock.EXPECT().GenerateActivityRetryTasks(s.activity, nextAttempt)
+	scheduledTime := s.timeSource.Now().Add(1 * time.Second).UTC()
+	taskGeneratorMock.EXPECT().GenerateActivityRetryTasks(s.activity.ScheduledEventId, scheduledTime, nextAttempt)
 	s.mutableState.taskGenerator = taskGeneratorMock
-
-	s.mutableState.timeSource = s.timeSource
 
 	// second := time.Second
 	_, err := s.mutableState.RetryActivity(s.activity, s.failure)
@@ -177,7 +177,7 @@ func (s *retryActivitySuite) TestRetryActivity_should_be_scheduled_when_next_bac
 	s.Equal(s.activity.Version, s.mutableState.currentVersion)
 	s.Equal(s.activity.Attempt, nextAttempt)
 
-	s.Equal(s.timeSource.Now().Add(1*time.Second).UTC(), s.activity.ScheduledTime.AsTime(), "Activity scheduled time is incorrect")
+	s.Equal(scheduledTime, s.activity.ScheduledTime.AsTime(), "Activity scheduled time is incorrect")
 	// s.Equal(s.nextBackoffStub.expected, s.nextBackoffStub.recorded)
 	s.assertTruncateFailureCalled()
 }
@@ -206,7 +206,7 @@ func (s *retryActivitySuite) moveClockBeyondActivityExpirationTime() {
 func (s *retryActivitySuite) TestRetryActivity_when_task_can_not_be_generated_should_fail() {
 	e := errors.New("can't generate task")
 	taskGeneratorMock := NewMockTaskGenerator(s.controller)
-	taskGeneratorMock.EXPECT().GenerateActivityRetryTasks(s.activity, s.activity.Attempt+1).Return(e)
+	taskGeneratorMock.EXPECT().GenerateActivityRetryTasks(s.activity.ScheduledEventId, gomock.Any(), s.activity.Attempt+1).Return(e)
 	s.mutableState.taskGenerator = taskGeneratorMock
 
 	s.nextBackoffStub.onNextCallReturn(time.Second, enumspb.RETRY_STATE_IN_PROGRESS)

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -470,7 +470,7 @@ func (r *TaskGeneratorImpl) GenerateActivityRetryTasks(
 	r.mutableState.AddTasks(&tasks.ActivityRetryTimerTask{
 		// TaskID is set by shard
 		WorkflowKey:         r.mutableState.GetWorkflowKey(),
-		Version:             activity.Version,
+		Version:             r.mutableState.GetCurrentVersion(),
 		VisibilityTimestamp: activity.ScheduledTime.AsTime(),
 		EventID:             activity.ScheduledEventId,
 		Attempt:             nextAttempt,

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -35,7 +35,6 @@ import (
 	"go.temporal.io/api/serviceerror"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
-	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/namespace"
@@ -76,10 +75,7 @@ type (
 		GenerateActivityTasks(
 			event *historypb.HistoryEvent,
 		) error
-		GenerateActivityRetryTasks(
-			activity *persistencespb.ActivityInfo,
-			nextAttempt int32,
-		) error
+		GenerateActivityRetryTasks(eventID int64, visibilityTimestamp time.Time, nextAttempt int32) error
 		GenerateChildWorkflowTasks(
 			event *historypb.HistoryEvent,
 		) error
@@ -463,16 +459,13 @@ func (r *TaskGeneratorImpl) GenerateActivityTasks(
 	return nil
 }
 
-func (r *TaskGeneratorImpl) GenerateActivityRetryTasks(
-	activity *persistencespb.ActivityInfo,
-	nextAttempt int32,
-) error {
+func (r *TaskGeneratorImpl) GenerateActivityRetryTasks(eventID int64, visibilityTimestamp time.Time, nextAttempt int32) error {
 	r.mutableState.AddTasks(&tasks.ActivityRetryTimerTask{
 		// TaskID is set by shard
 		WorkflowKey:         r.mutableState.GetWorkflowKey(),
 		Version:             r.mutableState.GetCurrentVersion(),
-		VisibilityTimestamp: activity.ScheduledTime.AsTime(),
-		EventID:             activity.ScheduledEventId,
+		VisibilityTimestamp: visibilityTimestamp,
+		EventID:             eventID,
 		Attempt:             nextAttempt,
 	})
 	return nil

--- a/service/history/workflow/task_generator_mock.go
+++ b/service/history/workflow/task_generator_mock.go
@@ -34,7 +34,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "go.temporal.io/api/history/v1"
-	v10 "go.temporal.io/server/api/persistence/v1"
 	tasks "go.temporal.io/server/service/history/tasks"
 )
 
@@ -62,17 +61,17 @@ func (m *MockTaskGenerator) EXPECT() *MockTaskGeneratorMockRecorder {
 }
 
 // GenerateActivityRetryTasks mocks base method.
-func (m *MockTaskGenerator) GenerateActivityRetryTasks(activity *v10.ActivityInfo, nextAttempt int32) error {
+func (m *MockTaskGenerator) GenerateActivityRetryTasks(eventID int64, visibilityTimestamp time.Time, nextAttempt int32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateActivityRetryTasks", activity, nextAttempt)
+	ret := m.ctrl.Call(m, "GenerateActivityRetryTasks", eventID, visibilityTimestamp, nextAttempt)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateActivityRetryTasks indicates an expected call of GenerateActivityRetryTasks.
-func (mr *MockTaskGeneratorMockRecorder) GenerateActivityRetryTasks(activity, nextAttempt interface{}) *gomock.Call {
+func (mr *MockTaskGeneratorMockRecorder) GenerateActivityRetryTasks(eventID, visibilityTimestamp, nextAttempt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateActivityRetryTasks", reflect.TypeOf((*MockTaskGenerator)(nil).GenerateActivityRetryTasks), activity, nextAttempt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateActivityRetryTasks", reflect.TypeOf((*MockTaskGenerator)(nil).GenerateActivityRetryTasks), eventID, visibilityTimestamp, nextAttempt)
 }
 
 // GenerateActivityTasks mocks base method.


### PR DESCRIPTION
## What changed?
When scheduling activity task version from mutable state (which is the source of truth) used instead of activity

## Why?
There is temporal coupling between task generation and activity update. The activity received in the function is actually an alias of the activity stored in the mutable state. If we update activity MS size will change and cause incorrect update size calculation. On other hand if we do not update activity, created task will have incorrect version.

## How did you test it?
Run tests.

## Potential risks
Unknown.

## Documentation
No.

## Is hotfix candidate?
Yes
