### PR TITLE
Interrupt forwarded polls on task queue close

### DIFF
--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -532,11 +532,14 @@ func (tm *TaskMatcher) poll(
 			tm.metricsHandler.Counter(metrics.PollSuccessPerTaskQueueCounter.Name()).Record(1)
 			return task, false, nil
 		case token := <-tm.fwdrPollReqTokenC():
-			if task, err := tm.fwdr.ForwardPoll(ctx, pollMetadata); err == nil {
-				token.release()
+			// Arrange to cancel this request if closeC is closed
+			fwdCtx, cancel := contextWithCancelOnChannelClose(ctx, tm.closeC)
+			task, err := tm.fwdr.ForwardPoll(fwdCtx, pollMetadata)
+			cancel()
+			token.release()
+			if err == nil {
 				return task, true, nil
 			}
-			token.release()
 		}
 	}
 
@@ -657,4 +660,19 @@ func (tm *TaskMatcher) emitForwardedSourceStats(
 
 func (tm *TaskMatcher) timeSinceLastPoll() time.Duration {
 	return time.Since(time.Unix(0, tm.lastPoller.Load()))
+}
+
+// contextWithCancelOnChannelClose returns a child Context and CancelFunc just like
+// context.WithCancel, but additionally propagates cancellation from another channel (besides
+// the parent's cancellation channel).
+func contextWithCancelOnChannelClose(parent context.Context, closeC <-chan struct{}) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	go func() {
+		select {
+		case <-closeC:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
 }


### PR DESCRIPTION
## What changed?
Followup to #5345: In addition to interrupting polls blocked in this matcher, interrupt polls that have been forwarded too.

## Why?
When we unload a task queue we should interrupt all open requests on it. In practice it doesn't make a big difference (for stuck pollers) because if the parent also moves, it will interrupt the forwarded request, and if it doesn't, then the poll won't be stuck.

## How did you test it?
Local testing with matching restarts

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
