### PR TITLE
Add "beforeCreateHook" hook to Start Workflow 

### DIFF
--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -52,8 +52,10 @@ import (
 	"go.temporal.io/server/service/history/workflow/cache"
 )
 
-type eagerStartDeniedReason metrics.ReasonString
-type WithStartFunc func(lease api.WorkflowLease) error
+type (
+	eagerStartDeniedReason metrics.ReasonString
+	WithStartFunc          func(lease api.WorkflowLease) error
+)
 
 const (
 	eagerStartDeniedReasonDynamicConfigDisabled    eagerStartDeniedReason = "dynamic_config_disabled"
@@ -166,7 +168,8 @@ func (s *Starter) Invoke(
 	return s.invoke(ctx, nil)
 }
 
-// InvokeWithStart starts a new workflow execution; and allows to perform additional .
+// InvokeWithStart starts a new workflow execution;
+// and allows to run additional steps before the new execution is persisted.
 func (s *Starter) InvokeWithStart(
 	ctx context.Context,
 	withStart WithStartFunc,

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -169,7 +169,7 @@ func (s *Starter) Invoke(
 }
 
 // InvokeWithStart starts a new workflow execution;
-// and allows to run additional steps before the new execution is persisted.
+// allowing to run additional steps before the execution is started.
 func (s *Starter) InvokeWithStart(
 	ctx context.Context,
 	withStart WithStartFunc,
@@ -186,9 +186,7 @@ func (s *Starter) invoke(
 		return nil, err
 	}
 
-	runID := uuid.NewString()
-
-	creationParams, err := s.createNewMutableState(ctx, request.GetWorkflowId(), runID)
+	creationParams, err := s.createNewMutableState(ctx, request.GetWorkflowId())
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +236,8 @@ func (s *Starter) lockCurrentWorkflowExecution(
 
 // createNewMutableState creates a new workflow context, and closes its mutable state transaction as snapshot.
 // It returns the creationContext which can later be used to insert into the executions table.
-func (s *Starter) createNewMutableState(ctx context.Context, workflowID string, runID string) (*creationParams, error) {
+func (s *Starter) createNewMutableState(ctx context.Context, workflowID string) (*creationParams, error) {
+	runID := uuid.NewString()
 	workflowLease, err := api.NewWorkflowWithSignal(
 		s.shardContext,
 		s.namespace,

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -376,7 +376,7 @@ func (e *historyEngineImpl) StartWorkflowExecution(
 	if err != nil {
 		return nil, err
 	}
-	return starter.Invoke(ctx)
+	return starter.Invoke(ctx, nil)
 }
 
 // GetMutableState retrieves the mutable state of the workflow execution


### PR DESCRIPTION
## What changed?

Add a hook to Start Workflow, in-between Workflow Execution creation and its persistence.

## Why?

In preparation of upcoming Update-with-Start changes.

## How did you test it?

The new `withStart` path will be used and tested in subsequent PRs.

The existing path is covered by existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
