### PR TITLE
Use FrontendEnableWorkerVersioningRules flag

### DIFF
--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -182,6 +182,7 @@ type Config struct {
 
 	EnableWorkerVersioningData     dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableWorkerVersioningWorkflow dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableWorkerVersioningRules    dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
 	// AccessHistoryFraction is an interim flag across 2 minor releases and will be removed once fully enabled.
 	AccessHistoryFraction dynamicconfig.FloatPropertyFn
@@ -280,6 +281,7 @@ func NewConfig(
 
 		EnableWorkerVersioningData:     dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableWorkerVersioningDataAPIs, false),
 		EnableWorkerVersioningWorkflow: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs, false),
+		EnableWorkerVersioningRules:    dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableWorkerVersioningRuleAPIs, false),
 
 		AccessHistoryFraction: dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 0.0),
 	}

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3308,8 +3308,7 @@ func (wh *WorkflowHandler) UpdateWorkerVersioningRules(ctx context.Context, requ
 		return nil, errRequestNotSet
 	}
 
-	// todo carly: what about EnableWorkerVersioningWorkflow?
-	if !wh.config.EnableWorkerVersioningData(request.Namespace) {
+	if !wh.config.EnableWorkerVersioningRules(request.Namespace) {
 		return nil, errWorkerVersioningNotAllowed
 	}
 
@@ -3346,8 +3345,7 @@ func (wh *WorkflowHandler) ListWorkerVersioningRules(ctx context.Context, reques
 		return nil, errRequestNotSet
 	}
 
-	// todo carly: what about EnableWorkerVersioningWorkflow?
-	if !wh.config.EnableWorkerVersioningData(request.Namespace) {
+	if !wh.config.EnableWorkerVersioningRules(request.Namespace) {
 		return nil, errWorkerVersioningNotAllowed
 	}
 

--- a/tests/advanced_visibility.go
+++ b/tests/advanced_visibility.go
@@ -92,6 +92,7 @@ func (s *AdvancedVisibilitySuite) SetupSuite() {
 		dynamicconfig.VisibilityDisableOrderByClause:             false,
 		dynamicconfig.FrontendEnableWorkerVersioningDataAPIs:     true,
 		dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs: true,
+		dynamicconfig.FrontendEnableWorkerVersioningRuleAPIs:     true,
 		dynamicconfig.ReachabilityTaskQueueScanLimit:             2,
 		dynamicconfig.ReachabilityQueryBuildIdLimit:              1,
 		dynamicconfig.BuildIdScavengerEnabled:                    true,

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -75,6 +75,7 @@ func (s *VersioningIntegSuite) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]any{
 		dynamicconfig.FrontendEnableWorkerVersioningDataAPIs:     true,
 		dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs: true,
+		dynamicconfig.FrontendEnableWorkerVersioningRuleAPIs:     true,
 		dynamicconfig.MatchingForwarderMaxChildrenPerNode:        partitionTreeDegree,
 		dynamicconfig.TaskQueuesPerBuildIdLimit:                  3,
 

--- a/tests/xdc/user_data_replication_test.go
+++ b/tests/xdc/user_data_replication_test.go
@@ -78,6 +78,7 @@ func (s *UserDataReplicationTestSuite) SetupSuite() {
 		dynamicconfig.FrontendNamespaceReplicationInducingAPIsRPS:                          1000,
 		dynamicconfig.FrontendEnableWorkerVersioningDataAPIs:                               true,
 		dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs:                           true,
+		dynamicconfig.FrontendEnableWorkerVersioningRuleAPIs:                               true,
 		dynamicconfig.BuildIdScavengerEnabled:                                              true,
 		// Ensure the scavenger can immediately delete build ids that are not in use.
 		dynamicconfig.RemovableBuildIdDurationSinceDefault: time.Microsecond,


### PR DESCRIPTION
## What changed?
Use FrontendEnableWorkerVersioningRules flag for Versioning Rules API instead of previous FrontendEnableWorkerVersioningData flag

## Why?
Because it's a new feature, so it makes sense to have a separate flag.

## How did you test it?
Versioning integration tests pass

## Potential risks
None

## Documentation
There's a comment where the flag is defined

## Is hotfix candidate?
No