### PR TITLE
Rename SQL table `nexus_incoming_services_table_version` to `nexus_incoming_services_partition_status`

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/nexus_incoming_services.go
+++ b/common/persistence/sql/sqlplugin/mysql/nexus_incoming_services.go
@@ -31,9 +31,9 @@ import (
 )
 
 const (
-	createIncomingServicesTableVersionQry    = `INSERT INTO nexus_incoming_services_table_version(version) VALUES(1)`
-	incrementIncomingServicesTableVersionQry = `UPDATE nexus_incoming_services_table_version SET version = ? WHERE version = ?`
-	getIncomingServicesTableVersionQry       = `SELECT version FROM nexus_incoming_services_table_version`
+	createIncomingServicesTableVersionQry    = `INSERT INTO nexus_incoming_services_partition_status(version) VALUES(1)`
+	incrementIncomingServicesTableVersionQry = `UPDATE nexus_incoming_services_partition_status SET version = ? WHERE version = ?`
+	getIncomingServicesTableVersionQry       = `SELECT version FROM nexus_incoming_services_partition_status`
 
 	createIncomingServiceQry = `INSERT INTO nexus_incoming_services(service_id, data, data_encoding, version) VALUES (?, ?, ?, 1)`
 	updateIncomingServiceQry = `UPDATE nexus_incoming_services SET data = ?, data_encoding = ?, version = ? WHERE service_id = ? AND version = ?`

--- a/common/persistence/sql/sqlplugin/postgresql/nexus_incoming_services.go
+++ b/common/persistence/sql/sqlplugin/postgresql/nexus_incoming_services.go
@@ -31,9 +31,9 @@ import (
 )
 
 const (
-	createIncomingServicesTableVersionQry    = `INSERT INTO nexus_incoming_services_table_version(version) VALUES(1)`
-	incrementIncomingServicesTableVersionQry = `UPDATE nexus_incoming_services_table_version SET version = $1 WHERE version = $2`
-	getIncomingServicesTableVersionQry       = `SELECT version FROM nexus_incoming_services_table_version`
+	createIncomingServicesTableVersionQry    = `INSERT INTO nexus_incoming_services_partition_status(version) VALUES(1)`
+	incrementIncomingServicesTableVersionQry = `UPDATE nexus_incoming_services_partition_status SET version = $1 WHERE version = $2`
+	getIncomingServicesTableVersionQry       = `SELECT version FROM nexus_incoming_services_partition_status`
 
 	createIncomingServiceQry = `INSERT INTO nexus_incoming_services(service_id, data, data_encoding, version) VALUES ($1, $2, $3, 1)`
 	updateIncomingServiceQry = `UPDATE nexus_incoming_services SET data = $1, data_encoding = $2, version = $3 WHERE service_id = $4 AND version = $5`

--- a/common/persistence/sql/sqlplugin/sqlite/nexus_incoming_services.go
+++ b/common/persistence/sql/sqlplugin/sqlite/nexus_incoming_services.go
@@ -31,9 +31,9 @@ import (
 )
 
 const (
-	createIncomingServicesTableVersionQry    = `INSERT INTO nexus_incoming_services_table_version(version) VALUES(1)`
-	incrementIncomingServicesTableVersionQry = `UPDATE nexus_incoming_services_table_version SET version = ? WHERE version = ?`
-	getIncomingServicesTableVersionQry       = `SELECT version FROM nexus_incoming_services_table_version`
+	createIncomingServicesTableVersionQry    = `INSERT INTO nexus_incoming_services_partition_status(version) VALUES(1)`
+	incrementIncomingServicesTableVersionQry = `UPDATE nexus_incoming_services_partition_status SET version = ? WHERE version = ?`
+	getIncomingServicesTableVersionQry       = `SELECT version FROM nexus_incoming_services_partition_status`
 
 	createIncomingServiceQry = `INSERT INTO nexus_incoming_services(service_id, data, data_encoding, version) VALUES (?, ?, ?, 1)`
 	updateIncomingServiceQry = `UPDATE nexus_incoming_services SET data = ?, data_encoding = ?, version = ? WHERE service_id = ? AND version = ?`

--- a/schema/mysql/v8/temporal/schema.sql
+++ b/schema/mysql/v8/temporal/schema.sql
@@ -347,7 +347,7 @@ CREATE TABLE nexus_incoming_services (
 );
 
 -- Stores the version of Nexus incoming services table as a whole
-CREATE TABLE nexus_incoming_services_table_version (
+CREATE TABLE nexus_incoming_services_partition_status (
     id      INT NOT NULL DEFAULT 0 CHECK (id = 0),  -- Restrict the table to a single row since it will only be used for incoming services
     version BIGINT NOT NULL,                        -- Version of the nexus_incoming_services table
     PRIMARY KEY (id)

--- a/schema/mysql/v8/temporal/versioned/v1.12/manifest.json
+++ b/schema/mysql/v8/temporal/versioned/v1.12/manifest.json
@@ -1,7 +1,7 @@
 {
   "CurrVersion": "1.12",
   "MinCompatibleVersion": "1.0",
-  "Description": "add storage for Nexus incoming service records and create nexus_incoming_services and nexus_incoming_services_table_version tables",
+  "Description": "add storage for Nexus incoming service records and create nexus_incoming_services and nexus_incoming_services_partition_status tables",
   "SchemaUpdateCqlFiles": [
     "nexus_incoming_services.sql"
   ]

--- a/schema/mysql/v8/temporal/versioned/v1.12/nexus_incoming_services.sql
+++ b/schema/mysql/v8/temporal/versioned/v1.12/nexus_incoming_services.sql
@@ -8,7 +8,7 @@ CREATE TABLE nexus_incoming_services (
 );
 
 -- Stores the version of Nexus incoming services table as a whole
-CREATE TABLE nexus_incoming_services_table_version (
+CREATE TABLE nexus_incoming_services_partition_status (
     id      INT NOT NULL DEFAULT 0 CHECK (id = 0),  -- Restrict the table to a single row since it will only be used for incoming services
     version BIGINT NOT NULL,                        -- Version of the nexus_incoming_services table
     PRIMARY KEY (id)

--- a/schema/postgresql/v12/temporal/schema.sql
+++ b/schema/postgresql/v12/temporal/schema.sql
@@ -343,7 +343,7 @@ CREATE TABLE nexus_incoming_services (
 );
 
 -- Stores the version of Nexus incoming services table as a whole
-CREATE TABLE nexus_incoming_services_table_version (
+CREATE TABLE nexus_incoming_services_partition_status (
     id      INT NOT NULL PRIMARY KEY DEFAULT 0,
     version BIGINT NOT NULL,                -- Version of the nexus_incoming_services table
     CONSTRAINT only_one_row CHECK (id = 0)  -- Restrict the table to a single row since it will only be used for incoming services

--- a/schema/postgresql/v12/temporal/versioned/v1.12/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.12/manifest.json
@@ -1,7 +1,7 @@
 {
   "CurrVersion": "1.12",
   "MinCompatibleVersion": "1.0",
-  "Description": "add storage for Nexus incoming service records and create nexus_incoming_services and nexus_incoming_services_table_version tables",
+  "Description": "add storage for Nexus incoming service records and create nexus_incoming_services and nexus_incoming_services_partition_status tables",
   "SchemaUpdateCqlFiles": [
     "nexus_incoming_services.sql"
   ]

--- a/schema/postgresql/v12/temporal/versioned/v1.12/nexus_incoming_services.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.12/nexus_incoming_services.sql
@@ -8,7 +8,7 @@ CREATE TABLE nexus_incoming_services (
 );
 
 -- Stores the version of Nexus incoming services table as a whole
-CREATE TABLE nexus_incoming_services_table_version (
+CREATE TABLE nexus_incoming_services_partition_status (
     id      INT NOT NULL PRIMARY KEY DEFAULT 0,
     version BIGINT NOT NULL,                -- Version of the nexus_incoming_services table
     CONSTRAINT only_one_row CHECK (id = 0)  -- Restrict the table to a single row since it will only be used for incoming services

--- a/schema/sqlite/v3/temporal/schema.sql
+++ b/schema/sqlite/v3/temporal/schema.sql
@@ -347,7 +347,7 @@ CREATE TABLE nexus_incoming_services (
 );
 
 -- Stores the version of Nexus incoming services table as a whole
-CREATE TABLE nexus_incoming_services_table_version (
+CREATE TABLE nexus_incoming_services_partition_status (
     id      INT NOT NULL DEFAULT 0 CHECK (id = 0),  -- Restrict the primary key to a single value since it will only be used for incoming services
     version BIGINT NOT NULL,                        -- Version of the nexus_incoming_services table
     PRIMARY KEY (id)

--- a/schema/sqlite/v3/temporal/versioned/v0.4/manifest.json
+++ b/schema/sqlite/v3/temporal/versioned/v0.4/manifest.json
@@ -1,7 +1,7 @@
 {
   "CurrVersion": "0.4",
   "MinCompatibleVersion": "0.1",
-  "Description": "add storage for Nexus incoming service records and create nexus_incoming_services and nexus_incoming_services_table_version tables",
+  "Description": "add storage for Nexus incoming service records and create nexus_incoming_services and nexus_incoming_services_partition_status tables",
   "SchemaUpdateCqlFiles": [
     "nexus_incoming_services.sql"
   ]

--- a/schema/sqlite/v3/temporal/versioned/v0.4/nexus_incoming_services.sql
+++ b/schema/sqlite/v3/temporal/versioned/v0.4/nexus_incoming_services.sql
@@ -8,7 +8,7 @@ CREATE TABLE nexus_incoming_services (
 );
 
 -- Stores the version of Nexus incoming services table as a whole
-CREATE TABLE nexus_incoming_services_table_version (
+CREATE TABLE nexus_incoming_services_partition_status (
     id      INT NOT NULL DEFAULT 0 CHECK (id = 0),  -- Restrict the primary key to a single value since it will only be used for incoming services
     version BIGINT NOT NULL,                        -- Version of the nexus_incoming_services table
     PRIMARY KEY (id)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Renaming the SQL nexus services table version table.

## Why?
<!-- Tell your future self why have you made these changes -->
To make it more generic in case it is used for other table metadata in the future.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
