### PR TITLE
disable cyclomatic/cognitive complexity for all tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,15 +99,14 @@ linters-settings:
           - "bytes.Buffer.*"
           - "strings.Builder.*"
 issues:
-  # Exclude cyclomatic and cognitive complexity rules for functional tests in the `tests` root directory.
   exclude-rules:
-    - path: ^tests\/.+\.go
-      text: "(cyclomatic|cognitive)"
+    - path: _test\.go|tests/.+\.go
+      text: "(cyclomatic|cognitive)"  # false positives when using subtests
       linters:
         - revive
-    - path: _test\.go|^common/persistence\/tests\/.+\.go # Ignore things like err = errors.New("test error") in tests
+    - path: _test\.go|tests/.+\.go
       linters:
-        - goerr113
+        - goerr113  # like err = errors.New("test error")
     - path: ^tools\/.+\.go
       linters:
         - goerr113

--- a/service/history/historybuilder/history_builder_categorization_test.go
+++ b/service/history/historybuilder/history_builder_categorization_test.go
@@ -139,7 +139,6 @@ func TestHistoryBuilder_AddWorkflowExecutionStartedEvent(t *testing.T) {
 	})
 }
 
-//nolint:revive
 func TestHistoryBuilder_FlushBufferToCurrentBatch(t *testing.T) {
 	t.Run("when no events in dbBufferBatch or meBufferBatch will return scheduledIDToStartedID", func(t *testing.T) {
 		hb := HistoryBuilder{
@@ -969,7 +968,6 @@ func TestHistoryBuilder_AddDifferentEvents_AssignmentEventId(t *testing.T) {
 	})
 }
 
-//nolint:revive
 func TestHistoryBuilder_FlushBufferToCurrentBatch_WiringEvents(t *testing.T) {
 	t.Run("should allocate event id for each buffered event", func(t *testing.T) {
 		sut := newSUTFromConfig(builderConfig{nextEventId: 98})


### PR DESCRIPTION
## What changed?

Expanded the lint exclusion rules to include not just functional tests but all tests.

## Why?

When using subtests, it's easy to get an unhelpful "cyclomatic complexity" error.

## How did you test it?

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
