### PR TITLE
Size based cache limit for Workflow cache

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -510,6 +510,10 @@ const (
 	HistoryPersistenceDynamicRateLimitingParams = "history.persistenceDynamicRateLimitingParams"
 	// HistoryLongPollExpirationInterval is the long poll expiration interval in the history service
 	HistoryLongPollExpirationInterval = "history.longPollExpirationInterval"
+	// HistoryCacheSizeBasedLimit if true, HistoryCacheMaxSize and HistoryCacheHostLevelMaxSize are the total size of
+	// the objects in history cache. Otherwise, HistoryCacheMaxSize and HistoryCacheHostLevelMaxSize are the number of
+	// entries in the history cache.
+	HistoryCacheSizeBasedLimit = "history.cacheSizeBasedLimit"
 	// HistoryCacheInitialSize is initial size of history cache
 	HistoryCacheInitialSize = "history.cacheInitialSize"
 	// HistoryCacheMaxSize is max size of history cache

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -72,6 +72,7 @@ type Config struct {
 	// Change of these configs require shard restart
 	HistoryCacheInitialSize               dynamicconfig.IntPropertyFn
 	HistoryShardLevelCacheMaxSize         dynamicconfig.IntPropertyFn
+	HistoryCacheLimitSizeBased            dynamicconfig.BoolPropertyFn
 	HistoryHostLevelCacheMaxSize          dynamicconfig.IntPropertyFn
 	HistoryCacheTTL                       dynamicconfig.DurationPropertyFn
 	HistoryCacheNonUserContextLockTimeout dynamicconfig.DurationPropertyFn
@@ -362,6 +363,7 @@ func NewConfig(
 
 		EmitShardLagLog:                       dc.GetBoolProperty(dynamicconfig.EmitShardLagLog, false),
 		HistoryCacheInitialSize:               dc.GetIntProperty(dynamicconfig.HistoryCacheInitialSize, 128),
+		HistoryCacheLimitSizeBased:            dc.GetBoolProperty(dynamicconfig.HistoryCacheSizeBasedLimit, false),
 		HistoryShardLevelCacheMaxSize:         dc.GetIntProperty(dynamicconfig.HistoryCacheMaxSize, 512),
 		HistoryHostLevelCacheMaxSize:          dc.GetIntProperty(dynamicconfig.HistoryCacheHostLevelMaxSize, 256000),
 		HistoryCacheTTL:                       dc.GetDurationProperty(dynamicconfig.HistoryCacheTTL, time.Hour),

--- a/service/history/workflow/cache/cache_test.go
+++ b/service/history/workflow/cache/cache_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/server/common/cache"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/definition"
@@ -529,4 +530,216 @@ func (s *workflowCacheSuite) TestCacheImpl_lockWorkflowExecution() {
 
 		})
 	}
+}
+
+func (s *workflowCacheSuite) TestCacheImpl_SizeBasedCacheBasic() {
+	config := tests.NewDynamicConfig()
+	config.HistoryCacheLimitSizeBased = dynamicconfig.GetBoolPropertyFn(true)
+	config.HistoryHostLevelCacheMaxSize = dynamicconfig.GetIntPropertyFn(1000)
+	s.cache = NewHostLevelCache(config, metrics.NoopMetricsHandler)
+	mockShard := shard.NewTestContext(
+		s.controller,
+		&persistencespb.ShardInfo{
+			ShardId: 0,
+			RangeId: 1,
+		},
+		config,
+	)
+
+	namespaceID := namespace.ID("test_namespace_id")
+	execution1 := commonpb.WorkflowExecution{
+		WorkflowId: "some random workflow ID",
+		RunId:      uuid.New(),
+	}
+	mockMS1 := workflow.NewMockMutableState(s.controller)
+	mockMS1.EXPECT().IsDirty().Return(false).AnyTimes()
+	ctx, release1, err := s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		mockShard,
+		namespaceID,
+		&execution1,
+		workflow.LockPriorityHigh,
+	)
+	s.NoError(err)
+	ctx.(*workflow.ContextImpl).MutableState = mockMS1
+	// MockMS1 should fill the entire cache. The total size of the context object will be the size of MutableState
+	// plus the size of commonpb.WorkflowExecution in this case. Even though we are returning a size 900 from
+	// MutableState, the size of workflow.Context object in the cache will be slightly higher (~972bytes).
+	mockMS1.EXPECT().GetApproximatePersistedSize().Return(900).Times(1)
+	release1(nil)
+	ctx, release1, err = s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		mockShard,
+		namespaceID,
+		&execution1,
+		workflow.LockPriorityHigh,
+	)
+	s.NoError(err)
+	s.Equal(mockMS1, ctx.(*workflow.ContextImpl).MutableState)
+
+	// Try to insert another entry before releasing previous.
+	execution2 := commonpb.WorkflowExecution{
+		WorkflowId: "some random workflow ID",
+		RunId:      uuid.New(),
+	}
+	ctx, _, err = s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		mockShard,
+		namespaceID,
+		&execution2,
+		workflow.LockPriorityHigh,
+	)
+	s.Error(err)
+	s.ErrorIs(err, cache.ErrCacheFull)
+
+	// Now try inserting three 400byte entries to cache.
+	// Make mockMS1's size 400.
+	mockMS1.EXPECT().GetApproximatePersistedSize().Return(400).Times(1)
+	release1(nil)
+	// Fill 40 bytes in cache with mockMS1.
+	ctx, release1, err = s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		mockShard,
+		namespaceID,
+		&execution1,
+		workflow.LockPriorityHigh,
+	)
+	s.NoError(err)
+	s.Equal(mockMS1, ctx.(*workflow.ContextImpl).MutableState)
+
+	// Insert another 400byte entry.
+	execution2 = commonpb.WorkflowExecution{
+		WorkflowId: "some random workflow ID",
+		RunId:      uuid.New(),
+	}
+	mockMS2 := workflow.NewMockMutableState(s.controller)
+	mockMS2.EXPECT().IsDirty().Return(false).AnyTimes()
+	ctx, release2, err := s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		mockShard,
+		namespaceID,
+		&execution2,
+		workflow.LockPriorityHigh,
+	)
+	s.NoError(err)
+	ctx.(*workflow.ContextImpl).MutableState = mockMS2
+	mockMS2.EXPECT().GetApproximatePersistedSize().Return(400).Times(1)
+	release2(nil)
+	ctx, release2, err = s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		mockShard,
+		namespaceID,
+		&execution2,
+		workflow.LockPriorityHigh,
+	)
+	s.NoError(err)
+	s.Equal(mockMS2, ctx.(*workflow.ContextImpl).MutableState)
+
+	// Insert another entry. This should fail as cache has ~800bytes pinned.
+	execution3 := commonpb.WorkflowExecution{
+		WorkflowId: "some random workflow ID",
+		RunId:      uuid.New(),
+	}
+	mockMS3 := workflow.NewMockMutableState(s.controller)
+	mockMS3.EXPECT().IsDirty().Return(false).AnyTimes()
+	_, _, err = s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		mockShard,
+		namespaceID,
+		&execution3,
+		workflow.LockPriorityHigh,
+	)
+	s.Error(err)
+	s.ErrorIs(err, cache.ErrCacheFull)
+
+	// Now there are two entries pinned in the cache. Their total size is 800bytes.
+	// Make mockMS1 grow to 1000 bytes. Cache should be able to handle this. Now the cache size will be more than its
+	// limit. Cache will evict this entry and make more size.
+	mockMS1.EXPECT().GetApproximatePersistedSize().Return(1000).Times(1)
+	release1(nil)
+	ctx, release1, err = s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		mockShard,
+		namespaceID,
+		&execution1,
+		workflow.LockPriorityHigh,
+	)
+	s.NoError(err)
+	// Make sure execution 3 was evicted by checking if mutable state is nil.
+	s.Nil(ctx.(*workflow.ContextImpl).MutableState, nil)
+	release1(nil)
+
+	// Insert execution3 again.
+	ctx, release3, err := s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		mockShard,
+		namespaceID,
+		&execution3,
+		workflow.LockPriorityHigh,
+	)
+	s.NoError(err)
+	ctx.(*workflow.ContextImpl).MutableState = mockMS3
+
+	mockMS3.EXPECT().GetApproximatePersistedSize().Return(400).Times(1)
+	release3(nil)
+	ctx, release3, err = s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		mockShard,
+		namespaceID,
+		&execution3,
+		workflow.LockPriorityHigh,
+	)
+	s.NoError(err)
+	s.Equal(mockMS3, ctx.(*workflow.ContextImpl).MutableState)
+
+	// Release all remaining entries.
+	mockMS2.EXPECT().GetApproximatePersistedSize().Return(400).Times(1)
+	release2(nil)
+	mockMS3.EXPECT().GetApproximatePersistedSize().Return(400).Times(1)
+	release3(nil)
+}
+
+func (s *workflowCacheSuite) TestCacheImpl_CheckCacheLimitSizeBasedFlag() {
+	config := tests.NewDynamicConfig()
+	// HistoryCacheLimitSizeBased is set to false. Cache limit should be based on entry count.
+	config.HistoryCacheLimitSizeBased = dynamicconfig.GetBoolPropertyFn(false)
+	config.HistoryHostLevelCacheMaxSize = dynamicconfig.GetIntPropertyFn(1)
+	s.cache = NewHostLevelCache(config, metrics.NoopMetricsHandler)
+	mockShard := shard.NewTestContext(
+		s.controller,
+		&persistencespb.ShardInfo{
+			ShardId: 0,
+			RangeId: 1,
+		},
+		config,
+	)
+
+	namespaceID := namespace.ID("test_namespace_id")
+	execution1 := commonpb.WorkflowExecution{
+		WorkflowId: "some random workflow ID",
+		RunId:      uuid.New(),
+	}
+	mockMS1 := workflow.NewMockMutableState(s.controller)
+	mockMS1.EXPECT().IsDirty().Return(false).AnyTimes()
+	ctx, release1, err := s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		mockShard,
+		namespaceID,
+		&execution1,
+		workflow.LockPriorityHigh,
+	)
+	s.NoError(err)
+	ctx.(*workflow.ContextImpl).MutableState = mockMS1
+	// GetApproximatePersistedSize() should not be called, since we disabled HistoryHostLevelCacheMaxSize flag.
+	mockMS1.EXPECT().GetApproximatePersistedSize().Times(0)
+	release1(nil)
+	ctx, release1, err = s.cache.GetOrCreateWorkflowExecution(
+		context.Background(),
+		mockShard,
+		namespaceID,
+		&execution1,
+		workflow.LockPriorityHigh,
+	)
+	s.NoError(err)
+	s.Equal(mockMS1, ctx.(*workflow.ContextImpl).MutableState)
 }

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -1032,6 +1032,20 @@ func (c *ContextImpl) forceTerminateWorkflow(
 	)
 }
 
+func (c *ContextImpl) CacheSize() int {
+	if !c.config.HistoryCacheLimitSizeBased() {
+		return 1
+	}
+	size := len(c.workflowKey.WorkflowID) + len(c.workflowKey.RunID) + len(c.workflowKey.NamespaceID)
+	if c.MutableState != nil {
+		size += c.MutableState.GetApproximatePersistedSize()
+	}
+	if c.updateRegistry != nil {
+		size += c.updateRegistry.GetSize()
+	}
+	return size
+}
+
 func emitStateTransitionCount(
 	metricsHandler metrics.Handler,
 	clusterMetadata cluster.Metadata,

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -82,6 +82,9 @@ type (
 
 		// Len observes the number of incomplete updates in this Registry.
 		Len() int
+
+		// GetSize returns the size of the update object
+		GetSize() int
 	}
 
 	// Store represents the update package's requirements for reading updates from the store.
@@ -357,4 +360,12 @@ func (r *registry) filter(predicate func(u *Update) bool) []*Update {
 		}
 	}
 	return res
+}
+
+func (r *registry) GetSize() int {
+	var size int
+	for key, update := range r.updates {
+		size += len(key) + update.GetSize()
+	}
+	return size
 }

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -564,3 +564,17 @@ func (u *Update) setState(newState state) state {
 	u.instrumentation.StateChange(u.id, prevState, newState)
 	return prevState
 }
+
+func (u *Update) GetSize() int {
+	size := len(u.id)
+	size += proto.Size(u.request)
+	if u.accepted.Ready() {
+		res, _ := u.accepted.Get(context.Background())
+		size += res.Size()
+	}
+	if u.outcome.Ready() {
+		res, _ := u.outcome.Get(context.Background())
+		size += res.Size()
+	}
+	return size
+}


### PR DESCRIPTION
## What changed?
Adding code for limiting MutableState cache using total size of entries.
Currently MutableState cache limit is specified by entry count.

This PR adds a new config `history.cacheSizeBasedLimit`. If this is set to true, MutableState cache will limit entries using the total size of the entries.
When `history.cacheSizeBasedLimit` is set to true, values of the flags `history.cacheMaxSize` and `history.hostLevelCacheMaxSize` are the total size of the cache in bytes instead of entry count.

## Why?
It is easier to control the total cache size by specifying size in bytes rather than entry count. The size of mutable state varies largely and it makes difficult to set a size limit using entry count.

## How did you test it?
Unit tests

## Potential risks
None

## Documentation
N/A

## Is hotfix candidate?
No
