### PR TITLE
Refactor handler for workflowIdReusePolicy

### DIFF
--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -151,13 +151,13 @@ func createWorkflowMutationFunction(
 		return nil, nil
 	}
 	currentExecutionState := currentWorkflowLease.GetMutableState().GetExecutionState()
-	workflowMutationFunc, err := api.ApplyWorkflowIDReusePolicy(
-		currentExecutionState.CreateRequestId,
+	workflowMutationFunc, err := api.ResolveDuplicateWorkflowID(
+		currentWorkflowLease.GetContext().GetWorkflowKey().WorkflowID,
+		newRunID,
 		currentExecutionState.RunId,
 		currentExecutionState.State,
 		currentExecutionState.Status,
-		currentWorkflowLease.GetContext().GetWorkflowKey().WorkflowID,
-		newRunID,
+		currentExecutionState.CreateRequestId,
 		workflowIDReusePolicy,
 	)
 	return workflowMutationFunc, err


### PR DESCRIPTION
## What changed?

- clearer distinction between the behavior for closed and running workflows
- name that isn't particular to workflowIdReusePolicy, but the more general issue of an "ID duplication"

## Why?

Preparing for changes from https://github.com/temporalio/api/pull/359 by pulling this refactor in early, reducing the size of the change later.

## How did you test it?

Existing tests + added a test for Terminate-if-Running earlier in https://github.com/temporalio/temporal/pull/5483.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
