### PR TITLE
Validate normal TQ on sticky poll

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3841,6 +3841,11 @@ func (wh *WorkflowHandler) validateTaskQueue(t *taskqueuepb.TaskQueue, namespace
 	if err := common.ValidateUTF8String("TaskQueue", t.GetName()); err != nil {
 		return err
 	}
+	if t.GetKind() == enumspb.TASK_QUEUE_KIND_STICKY {
+		if err := common.ValidateUTF8String("TaskQueue", t.GetNormalName()); err != nil {
+			return err
+		}
+	}
 
 	if t.GetKind() == enumspb.TASK_QUEUE_KIND_UNSPECIFIED {
 		wh.logger.Warn("Unspecified task queue kind",


### PR DESCRIPTION
## What changed?
Validate normal TQ on sticky poll

## Why?
On sticky poll, we fetch normal TQ's UserData. So an invalid normal TQ on a sticky queue would still trigger a load for the invalid normal queue. 

## How did you test it?
Manual test with invalid TQ.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
