### PR TITLE
Mark PRs as stale after 6mo

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: Stale Pull Requests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale_prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: label stale pull requests
+        uses: actions/stale@v9
+        with:
+          days-before-close: -1  # ie disabled
+          days-before-stale: 120
+          days-before-issue-stale: -1  # ie disabled
+          stale-pr-label: stale
+          stale-pr-message: 'This PR was marked as stale. Please update or close it.'


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Mark Pull Requests - but not Issues - as stale after 120 days.

## Why?

Nudge author to either close or resurrect their PR from its slumber.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks

None. The "stale" label simply can be removed by the author; no PR is closed automatically.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
