### PR TITLE
Move static membership out of tests

### DIFF
--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -49,7 +49,6 @@ var ErrListenerAlreadyExist = errors.New("listener already exist for the service
 var ErrIncorrectAddressFormat = errors.New("incorrect address format")
 
 type (
-
 	// ChangedEvent describes a change in membership
 	ChangedEvent struct {
 		HostsAdded   []HostInfo

--- a/common/membership/static/fx.go
+++ b/common/membership/static/fx.go
@@ -1,0 +1,46 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package static
+
+import (
+	"go.temporal.io/server/common/primitives"
+	"go.uber.org/fx"
+
+	"go.temporal.io/server/common/membership"
+)
+
+func MembershipModule(
+	hosts map[primitives.ServiceName][]string,
+) fx.Option {
+	return fx.Options(
+		fx.Provide(func() membership.Monitor {
+			return newStaticMonitor(hosts)
+		}),
+		fx.Provide(func(serviceName primitives.ServiceName) membership.HostInfoProvider {
+			hostInfo := membership.NewHostInfoFromAddress(hosts[serviceName][0])
+			return membership.NewHostInfoProvider(hostInfo)
+		}),
+	)
+}

--- a/common/membership/static/monitor.go
+++ b/common/membership/static/monitor.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tests
+package static
 
 import (
 	"context"
@@ -32,39 +32,38 @@ import (
 	"go.temporal.io/server/common/primitives"
 )
 
-type simpleMonitor struct {
+type staticMonitor struct {
 	hosts     map[primitives.ServiceName][]string
-	resolvers map[primitives.ServiceName]*simpleResolver
+	resolvers map[primitives.ServiceName]*staticResolver
 }
 
-// NewSimpleMonitor returns a simple monitor interface
-func newSimpleMonitor(hosts map[primitives.ServiceName][]string) *simpleMonitor {
-	resolvers := make(map[primitives.ServiceName]*simpleResolver, len(hosts))
+func newStaticMonitor(hosts map[primitives.ServiceName][]string) membership.Monitor {
+	resolvers := make(map[primitives.ServiceName]*staticResolver, len(hosts))
 	for service, hostList := range hosts {
-		resolvers[service] = newSimpleResolver(service, hostList)
+		resolvers[service] = newStaticResolver(service, hostList)
 	}
 
-	return &simpleMonitor{
+	return &staticMonitor{
 		hosts:     hosts,
 		resolvers: resolvers,
 	}
 }
 
-func (s *simpleMonitor) Start() {
+func (s *staticMonitor) Start() {
 	for service, r := range s.resolvers {
 		r.start(s.hosts[service])
 	}
 }
 
-func (s *simpleMonitor) EvictSelf() error {
+func (s *staticMonitor) EvictSelf() error {
 	return nil
 }
 
-func (s *simpleMonitor) EvictSelfAt(asOf time.Time) (time.Duration, error) {
+func (s *staticMonitor) EvictSelfAt(asOf time.Time) (time.Duration, error) {
 	return 0, nil
 }
 
-func (s *simpleMonitor) GetResolver(service primitives.ServiceName) (membership.ServiceResolver, error) {
+func (s *staticMonitor) GetResolver(service primitives.ServiceName) (membership.ServiceResolver, error) {
 	resolver, ok := s.resolvers[service]
 	if !ok {
 		return nil, membership.ErrUnknownService
@@ -72,18 +71,18 @@ func (s *simpleMonitor) GetResolver(service primitives.ServiceName) (membership.
 	return resolver, nil
 }
 
-func (s *simpleMonitor) GetReachableMembers() ([]string, error) {
+func (s *staticMonitor) GetReachableMembers() ([]string, error) {
 	return nil, nil
 }
 
-func (s *simpleMonitor) WaitUntilInitialized(_ context.Context) error {
+func (s *staticMonitor) WaitUntilInitialized(_ context.Context) error {
 	return nil
 }
 
-func (s *simpleMonitor) SetDraining(draining bool) error {
+func (s *staticMonitor) SetDraining(draining bool) error {
 	return nil
 }
 
-func (s *simpleMonitor) ApproximateMaxPropagationTime() time.Duration {
+func (s *staticMonitor) ApproximateMaxPropagationTime() time.Duration {
 	return 0
 }

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	otelsdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.temporal.io/server/common/membership/static"
 	"go.uber.org/fx"
 	"go.uber.org/multierr"
 	"golang.org/x/exp/maps"
@@ -426,12 +427,7 @@ func (c *temporalImpl) startFrontend(hosts map[primitives.ServiceName][]string, 
 		fx.Provide(func() log.ThrottledLogger { return c.logger }),
 		fx.Provide(func() resource.NamespaceLogger { return c.logger }),
 		fx.Provide(c.newRPCFactory),
-		fx.Provide(func() membership.Monitor {
-			return newSimpleMonitor(hosts)
-		}),
-		fx.Provide(func() membership.HostInfoProvider {
-			return newSimpleHostInfoProvider(serviceName, hosts)
-		}),
+		static.MembershipModule(hosts),
 		fx.Provide(func() *cluster.Config { return c.clusterMetadataConfig }),
 		fx.Provide(func() carchiver.ArchivalMetadata { return c.archiverMetadata }),
 		fx.Provide(func() provider.ArchiverProvider { return c.archiverProvider }),
@@ -524,12 +520,7 @@ func (c *temporalImpl) startHistory(
 			fx.Provide(func() config.DCRedirectionPolicy { return config.DCRedirectionPolicy{} }),
 			fx.Provide(func() log.ThrottledLogger { return c.logger }),
 			fx.Provide(c.newRPCFactory),
-			fx.Provide(func() membership.Monitor {
-				return newSimpleMonitor(hosts)
-			}),
-			fx.Provide(func() membership.HostInfoProvider {
-				return newSimpleHostInfoProvider(serviceName, hosts)
-			}),
+			static.MembershipModule(hosts),
 			fx.Provide(func() *cluster.Config { return c.clusterMetadataConfig }),
 			fx.Provide(func() carchiver.ArchivalMetadata { return c.archiverMetadata }),
 			fx.Provide(func() provider.ArchiverProvider { return c.archiverProvider }),
@@ -623,12 +614,7 @@ func (c *temporalImpl) startMatching(hosts map[primitives.ServiceName][]string, 
 		fx.Provide(func() listenHostPort { return listenHostPort(c.MatchingGRPCServiceAddress()) }),
 		fx.Provide(func() log.ThrottledLogger { return c.logger }),
 		fx.Provide(c.newRPCFactory),
-		fx.Provide(func() membership.Monitor {
-			return newSimpleMonitor(hosts)
-		}),
-		fx.Provide(func() membership.HostInfoProvider {
-			return newSimpleHostInfoProvider(serviceName, hosts)
-		}),
+		static.MembershipModule(hosts),
 		fx.Provide(func() *cluster.Config { return c.clusterMetadataConfig }),
 		fx.Provide(func() carchiver.ArchivalMetadata { return c.archiverMetadata }),
 		fx.Provide(func() provider.ArchiverProvider { return c.archiverProvider }),
@@ -720,12 +706,7 @@ func (c *temporalImpl) startWorker(hosts map[primitives.ServiceName][]string, st
 		fx.Provide(func() config.DCRedirectionPolicy { return config.DCRedirectionPolicy{} }),
 		fx.Provide(func() log.ThrottledLogger { return c.logger }),
 		fx.Provide(c.newRPCFactory),
-		fx.Provide(func() membership.Monitor {
-			return newSimpleMonitor(hosts)
-		}),
-		fx.Provide(func() membership.HostInfoProvider {
-			return newSimpleHostInfoProvider(serviceName, hosts)
-		}),
+		static.MembershipModule(hosts),
 		fx.Provide(func() *cluster.Config { return &clusterConfigCopy }),
 		fx.Provide(func() carchiver.ArchivalMetadata { return c.archiverMetadata }),
 		fx.Provide(func() provider.ArchiverProvider { return c.archiverProvider }),


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Moved the non-ringpop, static membership implementation into its own package.

## Why?
<!-- Tell your future self why have you made these changes -->

First step in making it available to the Temporal dev server. I believe that'll make the dev server less flaky ("Not enough hosts to serve the request").

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Is tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
