### PR TITLE
Move versioned pollers into their own physicalTaskQueueManager

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -911,6 +911,11 @@ func (e *matchingEngineImpl) UpdateWorkerVersioningRules(
 				req.GetDeleteCompatibleRedirectRule(),
 			)
 		case *workflowservice.UpdateWorkerVersioningRulesRequest_CommitBuildId_:
+			hasRecentPoller := false
+			if ptqm := tqMgr.GetVersionedPhysicalTaskQueueManager(req.GetCommitBuildId().GetTargetBuildId()); ptqm != nil {
+				hasRecentPoller = ptqm.HasPollerAfter(time.Now().Add(-versioningPollerSeenWindow))
+				// --> doesn't detect poller when it should
+			}
 			versioningData, err = CommitBuildID(
 				updatedClock,
 				data.GetVersioningData(),

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -65,6 +65,8 @@ type (
 		// DispatchQueryTask will dispatch query to local or remote poller. If forwarded then result or error is returned,
 		// if dispatched to local poller then nil and nil is returned.
 		DispatchQueryTask(ctx context.Context, taskID string, request *matchingservice.QueryWorkflowRequest) (*matchingservice.QueryWorkflowResponse, error)
+		// GetVersionedPhysicalTaskQueueManager gets the physical task queue manager associated with the given buildID
+		GetVersionedPhysicalTaskQueueManager(buildID string) physicalTaskQueueManager
 		GetUserDataManager() userDataManager
 		// MarkAlive updates the liveness timer to keep this partition manager alive.
 		MarkAlive()
@@ -317,6 +319,14 @@ func (pm *taskQueuePartitionManagerImpl) DispatchQueryTask(
 
 func (pm *taskQueuePartitionManagerImpl) GetUserDataManager() userDataManager {
 	return pm.userDataManager
+}
+
+func (pm *taskQueuePartitionManagerImpl) GetVersionedPhysicalTaskQueueManager(buildID string) physicalTaskQueueManager {
+	ptqm, ok := pm.versionedQueues[buildID]
+	if !ok {
+		return nil
+	}
+	return ptqm
 }
 
 // GetAllPollerInfo returns all pollers that polled from this taskqueue in last few minutes


### PR DESCRIPTION
## What changed?
- Add `GetVersionedPhysicalTaskQueueManager(buildID string) physicalTaskQueueManager` to `task_queue_partition_manager.go` for future use by commit build id, instead of having to check all pollers of the default queue
- TODO: Correctly create physical task queues for versioned pollers and update `map[buildID]physicalTaskQueueManager`, so Commit Build ID tests pass

## Why?
So that versioned tasks are no longer mixed in with unversioned tasks in the same queues.
So that we can call HasPollerAfter on the right physicalTaskQueueManager, not on the defaultQueue all the time.

## How did you test it?
todo

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
No