### PR TITLE
Separating LoadedTaskQueueGauge into separate metrics for increased visibility

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -42,6 +42,7 @@ const (
 	httpStatusTagName           = "http_status"
 	versionedTagName            = "versioned"
 	resourceExhaustedTag        = "resource_exhausted_cause"
+	PartitionTypeName           = "partition_type"
 )
 
 // This package should hold all the metrics and tags for temporal
@@ -956,7 +957,10 @@ var (
 	LocalToRemoteMatchPerTaskQueueCounter     = NewCounterDef("local_to_remote_matches")
 	RemoteToLocalMatchPerTaskQueueCounter     = NewCounterDef("remote_to_local_matches")
 	RemoteToRemoteMatchPerTaskQueueCounter    = NewCounterDef("remote_to_remote_matches")
-	LoadedTaskQueueGauge                      = NewGaugeDef("loaded_task_queue_count")
+	LoadedTaskQueueFamilyCounter              = NewGaugeDef("loaded_task_queue_family_count")
+	LoadedTaskQueueCounter                    = NewGaugeDef("loaded_task_queue_count")
+	LoadedTaskQueuePartitionCounter           = NewGaugeDef("loaded_task_queue_partition_count")
+	LoadedPhysicalTaskQueueCounter            = NewGaugeDef("loaded_physical_task_queue_count")
 	TaskQueueStartedCounter                   = NewCounterDef("task_queue_started")
 	TaskQueueStoppedCounter                   = NewCounterDef("task_queue_stopped")
 	TaskWriteThrottlePerTaskQueueCounter      = NewCounterDef("task_write_throttle_count")

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -224,6 +224,13 @@ func TaskTypeTag(value string) Tag {
 	return &tagImpl{key: TaskTypeTagName, value: value}
 }
 
+func PartitionTypeTag(value string) Tag {
+	if len(value) == 0 {
+		value = unknownValue
+	}
+	return &tagImpl{key: PartitionTypeName, value: value}
+}
+
 func TaskPriorityTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -1378,7 +1378,6 @@ func (e *matchingEngineImpl) unloadTaskQueuePartition(unloadPM taskQueuePartitio
 	delete(e.partitions, key)
 	e.partitionsLock.Unlock()
 	foundTQM.Stop()
-	e.updateTaskQueuePartitionGauge(unloadPM, -1)
 }
 
 // Responsible for emitting and updating loaded_physical_task_queue_count metric
@@ -1387,7 +1386,7 @@ func (e *matchingEngineImpl) updatePhysicalTaskQueueGauge(pm *physicalTaskQueueM
 	// calculating versioned to be one of: “unversioned” or "buildId” or “versionSet”
 	versioned := "unversioned"
 	if buildID := pm.queue.BuildId(); buildID != "" {
-		versioned = "buildID"
+		versioned = "buildId"
 	} else if versionSet := pm.queue.VersionSet(); versionSet != "" {
 		versioned = "versionSet"
 	}

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -99,10 +99,10 @@ type (
 	}
 
 	taskQueueCounterKey struct {
-		namespaceID namespace.ID
-		taskType    enumspb.TaskQueueType
-		kind        enumspb.TaskQueueKind
-		versioned   bool
+		namespaceID   namespace.ID
+		taskType      enumspb.TaskQueueType
+		partitionType enumspb.TaskQueueKind
+		versioned     string // one of these values: "unversioned", "versionSet", "buildId"
 	}
 
 	pollMetadata struct {
@@ -114,6 +114,14 @@ type (
 	namespaceUpdateLocks struct {
 		updateLock      sync.Mutex
 		replicationLock sync.Mutex
+	}
+
+	gaugeMetrics struct {
+		loadedTaskQueueFamilyCount    map[taskQueueCounterKey]int
+		loadedTaskQueueCount          map[taskQueueCounterKey]int
+		loadedTaskQueuePartitionCount map[taskQueueCounterKey]int
+		loadedPhysicalTaskQueueCount  map[taskQueueCounterKey]int
+		gaugeMetricCounterLock        sync.Mutex
 	}
 
 	// Implements matching.Engine
@@ -134,8 +142,7 @@ type (
 		metricsHandler       metrics.Handler
 		partitionsLock       sync.RWMutex // locks mutation of partitions
 		partitions           map[tqid.PartitionKey]taskQueuePartitionManager
-		taskQueueCountLock   sync.Mutex
-		taskQueueCount       map[taskQueueCounterKey]int // per-namespace task queue counter
+		gaugeMetricCounter   gaugeMetrics // per-namespace task queue counter
 		config               *Config
 		lockableQueryTaskMap lockableQueryTaskMap
 		// pollMap is needed to keep track of all outstanding pollers for a particular
@@ -199,7 +206,7 @@ func NewEngine(
 		visibilityManager:         visibilityManager,
 		metricsHandler:            metricsHandler.WithTags(metrics.OperationTag(metrics.MatchingEngineScope)),
 		partitions:                make(map[tqid.PartitionKey]taskQueuePartitionManager),
-		taskQueueCount:            make(map[taskQueueCounterKey]int),
+		gaugeMetricCounter:        gaugeMetrics{make(map[taskQueueCounterKey]int), make(map[taskQueueCounterKey]int), make(map[taskQueueCounterKey]int), make(map[taskQueueCounterKey]int), sync.Mutex{}},
 		config:                    config,
 		lockableQueryTaskMap:      lockableQueryTaskMap{queryTaskMap: make(map[string]chan *queryResult)},
 		pollMap:                   lockablePollMap{polls: make(map[string]context.CancelFunc)},
@@ -323,7 +330,6 @@ func (e *matchingEngineImpl) getTaskQueuePartitionManagerNoWait(
 
 		if !ok {
 			pm.Start()
-			e.updateTaskQueueGauge(pm, false, 1)
 		}
 	}
 	return pm, nil
@@ -1372,34 +1378,100 @@ func (e *matchingEngineImpl) unloadTaskQueuePartition(unloadPM taskQueuePartitio
 	delete(e.partitions, key)
 	e.partitionsLock.Unlock()
 	foundTQM.Stop()
-	e.updateTaskQueueGauge(foundTQM, false, -1)
+	e.updateTaskQueuePartitionGauge(unloadPM, -1)
 }
 
-func (e *matchingEngineImpl) updateTaskQueueGauge(pm taskQueuePartitionManager, versioned bool, delta int) {
-	countKey := taskQueueCounterKey{
+// Responsible for emitting and updating loaded_physical_task_queue_count metric
+func (e *matchingEngineImpl) updatePhysicalTaskQueueGauge(pm *physicalTaskQueueManagerImpl, delta int) {
+
+	// calculating versioned to be one of: “unversioned” or "buildId” or “versionSet”
+	versioned := "unversioned"
+	if buildID := pm.queue.BuildId(); buildID != "" {
+		versioned = "buildID"
+	} else if versionSet := pm.queue.VersionSet(); versionSet != "" {
+		versioned = "versionSet"
+	}
+
+	PhysicalTaskQueueParameters := taskQueueCounterKey{
+		namespaceID:   pm.partitionMgr.Partition().NamespaceId(),
+		taskType:      pm.partitionMgr.Partition().TaskType(),
+		partitionType: pm.partitionMgr.Partition().Kind(),
+		versioned:     versioned,
+	}
+
+	e.gaugeMetricCounter.gaugeMetricCounterLock.Lock()
+	e.gaugeMetricCounter.loadedPhysicalTaskQueueCount[PhysicalTaskQueueParameters] += delta
+	loadedPhysicalTaskQueueCounter := e.gaugeMetricCounter.loadedPhysicalTaskQueueCount[PhysicalTaskQueueParameters]
+	e.gaugeMetricCounter.gaugeMetricCounterLock.Unlock()
+
+	pmImpl := pm.partitionMgr
+
+	e.metricsHandler.Gauge(metrics.LoadedPhysicalTaskQueueCounter.Name()).Record(
+		float64(loadedPhysicalTaskQueueCounter),
+		metrics.NamespaceTag(pmImpl.ns.Name().String()),
+		metrics.TaskTypeTag(PhysicalTaskQueueParameters.taskType.String()),
+		metrics.PartitionTypeTag(PhysicalTaskQueueParameters.partitionType.String()),
+	)
+}
+
+// Responsible for emitting and updating loaded_task_queue_family_count, loaded_task_queue_count and
+// loaded_task_queue_partition_count metrics
+func (e *matchingEngineImpl) updateTaskQueuePartitionGauge(pm taskQueuePartitionManager, delta int) {
+
+	// each metric shall be accessed based on the mentioned parameters
+	TaskQueueFamilyParameters := taskQueueCounterKey{
+		namespaceID: pm.Partition().NamespaceId(),
+	}
+
+	TaskQueueParameters := taskQueueCounterKey{
 		namespaceID: pm.Partition().NamespaceId(),
 		taskType:    pm.Partition().TaskType(),
-		kind:        pm.Partition().Kind(),
-		versioned:   versioned,
 	}
 
-	e.taskQueueCountLock.Lock()
-	e.taskQueueCount[countKey] += delta
-	newCount := e.taskQueueCount[countKey]
-	e.taskQueueCountLock.Unlock()
-
-	nsEntry, err := e.namespaceRegistry.GetNamespaceByID(countKey.namespaceID)
-	ns := namespace.Name("unknown")
-	if err == nil {
-		ns = nsEntry.Name()
+	TaskQueuePartitionParameters := taskQueueCounterKey{
+		namespaceID:   pm.Partition().NamespaceId(),
+		taskType:      pm.Partition().TaskType(),
+		partitionType: pm.Partition().Kind(),
 	}
 
-	e.metricsHandler.Gauge(metrics.LoadedTaskQueueGauge.Name()).Record(
-		float64(newCount),
-		metrics.NamespaceTag(ns.String()),
-		metrics.TaskTypeTag(countKey.taskType.String()),
-		metrics.QueueTypeTag(countKey.kind.String()),
-		metrics.VersionedTag(countKey.versioned),
+	rootPartition := pm.Partition().IsRoot()
+	e.gaugeMetricCounter.gaugeMetricCounterLock.Lock()
+
+	loadedTaskQueueFamilyCounter, loadedTaskQueueCounter, loadedTaskQueuePartitionCounter :=
+		e.gaugeMetricCounter.loadedTaskQueueFamilyCount[TaskQueueFamilyParameters], e.gaugeMetricCounter.loadedTaskQueueCount[TaskQueueParameters],
+		e.gaugeMetricCounter.loadedTaskQueuePartitionCount[TaskQueuePartitionParameters]
+
+	loadedTaskQueuePartitionCounter += delta
+	e.gaugeMetricCounter.loadedTaskQueuePartitionCount[TaskQueuePartitionParameters] = loadedTaskQueuePartitionCounter
+	if rootPartition {
+		loadedTaskQueueCounter += delta
+		e.gaugeMetricCounter.loadedTaskQueueCount[TaskQueueParameters] = loadedTaskQueueCounter
+		if pm.Partition().TaskType() == enumspb.TASK_QUEUE_TYPE_WORKFLOW {
+			loadedTaskQueueFamilyCounter += delta
+			e.gaugeMetricCounter.loadedTaskQueueFamilyCount[TaskQueueFamilyParameters] = loadedTaskQueueFamilyCounter
+		}
+	}
+	e.gaugeMetricCounter.gaugeMetricCounterLock.Unlock()
+
+	pmImpl := pm.(*taskQueuePartitionManagerImpl)
+
+	// emitting all the three metrics, for now.
+	e.metricsHandler.Gauge(metrics.LoadedTaskQueueFamilyCounter.Name()).Record(
+		float64(loadedTaskQueueFamilyCounter),
+		metrics.NamespaceTag(pmImpl.ns.Name().String()),
+	)
+
+	e.metricsHandler.Gauge(metrics.LoadedTaskQueueCounter.Name()).Record(
+		float64(loadedTaskQueueCounter),
+		metrics.NamespaceTag(pmImpl.ns.Name().String()),
+		metrics.TaskTypeTag(TaskQueueParameters.taskType.String()),
+	)
+
+	e.metricsHandler.Gauge(metrics.LoadedTaskQueuePartitionCounter.Name()).Record(
+		float64(loadedTaskQueuePartitionCounter),
+		metrics.NamespaceTag(pmImpl.ns.Name().String()),
+		metrics.TaskTypeTag(TaskQueueParameters.taskType.String()),
+		metrics.PartitionTypeTag(TaskQueuePartitionParameters.partitionType.String()),
 	)
 }
 

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -33,6 +33,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/server/common/metrics/metricstest"
+
 	"github.com/emirpasic/gods/maps/treemap"
 	godsutils "github.com/emirpasic/gods/utils"
 	"github.com/golang/mock/gomock"
@@ -2501,6 +2504,221 @@ func (s *matchingEngineSuite) TestDemotedMatch() {
 	s.Equal("wf", task.event.Data.WorkflowId)
 	s.Equal(int64(123), task.event.Data.ScheduledEventId)
 	task.finish(nil)
+}
+
+func TaskQueueMetricValidator(T *testing.T, capture *metricstest.Capture, FamilyCounterLength int, FamilyCounter float64, QueueCounterLength int, QueueCounter float64, QueuePartitionCounterLength int, QueuePartitionCounter float64) {
+	// checks the metrics according to the values passed in the parameters
+
+	snapshot := capture.Snapshot()
+	FamilyCounterRecordings := snapshot[metrics.LoadedTaskQueueFamilyCounter.Name()]
+	assert.Len(T, FamilyCounterRecordings, FamilyCounterLength)
+	counter, ok := FamilyCounterRecordings[FamilyCounterLength-1].Value.(float64)
+	assert.True(T, ok)
+	assert.Equal(T, FamilyCounter, counter)
+
+	QueueCounterRecordings := snapshot[metrics.LoadedTaskQueueCounter.Name()]
+	assert.Len(T, QueueCounterRecordings, QueueCounterLength)
+	counter, ok = QueueCounterRecordings[QueueCounterLength-1].Value.(float64)
+	assert.True(T, ok)
+	assert.Equal(T, QueueCounter, counter)
+
+	QueuePartitionCounterRecordings := snapshot[metrics.LoadedTaskQueuePartitionCounter.Name()]
+	assert.Len(T, QueuePartitionCounterRecordings, QueuePartitionCounterLength)
+	counter, ok = QueuePartitionCounterRecordings[QueuePartitionCounterLength-1].Value.(float64)
+	assert.True(T, ok)
+	assert.Equal(T, QueuePartitionCounter, counter)
+}
+
+func PhysicalQueueMetricValidator(T *testing.T, capture *metricstest.Capture, PhysicalTaskQueueLength int, PhysicalTaskQueueCounter float64) {
+	// checks the metrics according to the values passed in the parameters
+
+	snapshot := capture.Snapshot()
+	PhysicalTaskQueueRecordings := snapshot[metrics.LoadedPhysicalTaskQueueCounter.Name()]
+	assert.Len(T, PhysicalTaskQueueRecordings, PhysicalTaskQueueLength)
+	counter, ok := PhysicalTaskQueueRecordings[PhysicalTaskQueueLength-1].Value.(float64)
+	assert.True(T, ok)
+	assert.Equal(T, PhysicalTaskQueueCounter, counter)
+
+}
+
+func (s *matchingEngineSuite) TestUpdateTaskQueuePartitionGauge_RootPartitionWorkflowType() {
+	// for getting snapshots of metrics
+	s.matchingEngine.metricsHandler = metricstest.NewCaptureHandler()
+	captureHandler, ok := s.matchingEngine.metricsHandler.(*metricstest.CaptureHandler)
+	s.True(ok)
+	capture := captureHandler.StartCapture()
+
+	prtn := newRootPartition(
+		uuid.New(),
+		"MetricTester",
+		enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+	tqm, err := s.matchingEngine.getTaskQueuePartitionManager(context.Background(), prtn, true)
+	s.Require().NoError(err)
+
+	TaskQueueMetricValidator(s.T(), capture, 1, 1, 1, 1, 1, 1)
+
+	// Calling the update gauge function should increase each of the metrics to 2
+	// since we are dealing with a root partition
+	s.matchingEngine.updateTaskQueuePartitionGauge(tqm, 1)
+	TaskQueueMetricValidator(s.T(), capture, 2, 2, 2, 2, 2, 2)
+
+}
+
+func (s *matchingEngineSuite) TestUpdateTaskQueuePartitionGauge_RootPartitionActivityType() {
+	// for getting snapshots of metrics
+	s.matchingEngine.metricsHandler = metricstest.NewCaptureHandler()
+	captureHandler, ok := s.matchingEngine.metricsHandler.(*metricstest.CaptureHandler)
+	s.True(ok)
+	capture := captureHandler.StartCapture()
+
+	prtn := newRootPartition(
+		uuid.New(),
+		"MetricTester",
+		enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+	tqm, err := s.matchingEngine.getTaskQueuePartitionManager(context.Background(), prtn, true)
+	s.Require().NoError(err)
+
+	// Creation of a new root partition, having an activity task queue, should not have
+	// increased FamilyCounter. Other metrics should be 1.
+	TaskQueueMetricValidator(s.T(), capture, 1, 0, 1, 1, 1, 1)
+
+	// Calling the update gauge function should increase each of the metrics to 2
+	// since we are dealing with a root partition
+	s.matchingEngine.updateTaskQueuePartitionGauge(tqm, 1)
+	TaskQueueMetricValidator(s.T(), capture, 2, 0, 2, 2, 2, 2)
+
+}
+
+func (s *matchingEngineSuite) TestUpdateTaskQueuePartitionGauge_NonRootPartition() {
+	s.matchingEngine.metricsHandler = metricstest.NewCaptureHandler()
+	captureHandler, ok := s.matchingEngine.metricsHandler.(*metricstest.CaptureHandler)
+	s.True(ok)
+	capture := captureHandler.StartCapture()
+
+	NonRootPrtn := newTestTaskQueue(
+		uuid.New(),
+		"MetricTester",
+		enumspb.TASK_QUEUE_TYPE_WORKFLOW).NormalPartition(31)
+	tqm, err := s.matchingEngine.getTaskQueuePartitionManager(context.Background(), NonRootPrtn, true)
+	s.Require().NoError(err)
+
+	// Creation of a non-root partition should only increase the Queue Partition counter
+	TaskQueueMetricValidator(s.T(), capture, 1, 0, 1, 0, 1, 1)
+
+	// Calling the update gauge function should increase each of the metrics to 2
+	// since we are dealing with a root partition
+	s.matchingEngine.updateTaskQueuePartitionGauge(tqm, 1)
+	TaskQueueMetricValidator(s.T(), capture, 2, 0, 2, 0, 2, 2)
+
+}
+
+func (s *matchingEngineSuite) TestUpdatePhysicalTaskQueueGauge_UnVersioned() {
+	s.matchingEngine.metricsHandler = metricstest.NewCaptureHandler()
+	captureHandler, ok := s.matchingEngine.metricsHandler.(*metricstest.CaptureHandler)
+	s.True(ok)
+	capture := captureHandler.StartCapture()
+
+	prtn := newRootPartition(
+		uuid.New(),
+		"MetricTester",
+		enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+	tqm, err := s.matchingEngine.getTaskQueuePartitionManager(context.Background(), prtn, true)
+	s.Require().NoError(err)
+
+	// Creating a TaskQueuePartitionManager results in creating a PhysicalTaskQueueManager which should increase
+	// the size of the map to 1 and it's counter to 1.
+	PhysicalQueueMetricValidator(s.T(), capture, 1, 1)
+
+	tlmImpl, ok := tqm.(*taskQueuePartitionManagerImpl).defaultQueue.(*physicalTaskQueueManagerImpl)
+	s.True(ok)
+
+	s.matchingEngine.updatePhysicalTaskQueueGauge(tlmImpl, 1)
+
+	PhysicalQueueMetricValidator(s.T(), capture, 2, 2)
+
+	// Validating if versioned has been set right for the respective parameters
+	PhysicalTaskQueueParameters := taskQueueCounterKey{
+		namespaceID:   prtn.NamespaceId(),
+		taskType:      prtn.TaskType(),
+		partitionType: prtn.Kind(),
+		versioned:     "unversioned",
+	}
+	assert.Equal(s.T(), s.matchingEngine.gaugeMetricCounter.loadedPhysicalTaskQueueCount[PhysicalTaskQueueParameters], 2)
+
+}
+
+func (s *matchingEngineSuite) TestUpdatePhysicalTaskQueueGauge_VersionSet() {
+	s.matchingEngine.metricsHandler = metricstest.NewCaptureHandler()
+	captureHandler, ok := s.matchingEngine.metricsHandler.(*metricstest.CaptureHandler)
+	s.True(ok)
+	capture := captureHandler.StartCapture()
+
+	namespaceId := uuid.New()
+	versionSet := uuid.New()
+	tl := "MetricTester"
+	dbq := VersionSetQueueKey(newTestTaskQueue(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY).RootPartition(), versionSet)
+	tqm, err := s.matchingEngine.getTaskQueuePartitionManager(context.Background(), dbq.Partition(), true)
+	s.Require().NoError(err)
+
+	// Creating a TaskQueuePartitionManager results in creating a PhysicalTaskQueueManager which should increase
+	// the size of the map to 1 and it's counter to 1.
+	PhysicalQueueMetricValidator(s.T(), capture, 1, 1)
+
+	Vqtpm, err := tqm.(*taskQueuePartitionManagerImpl).getVersionedQueueNoWait(versionSet, "", true)
+	s.Require().NoError(err)
+
+	// Creating a VersionedQueue results in increasing the size of the map to 2, due to 2 entries now,
+	// with it's counter to 1.
+	PhysicalQueueMetricValidator(s.T(), capture, 2, 1)
+	s.matchingEngine.updatePhysicalTaskQueueGauge(Vqtpm.(*physicalTaskQueueManagerImpl), 1)
+	PhysicalQueueMetricValidator(s.T(), capture, 3, 2)
+
+	// Validating if versioned has been set right for the specific parameters
+	PhysicalTaskQueueParameters := taskQueueCounterKey{
+		namespaceID:   dbq.Partition().NamespaceId(),
+		taskType:      dbq.Partition().TaskType(),
+		partitionType: dbq.Partition().Kind(),
+		versioned:     "versionSet",
+	}
+	assert.Equal(s.T(), s.matchingEngine.gaugeMetricCounter.loadedPhysicalTaskQueueCount[PhysicalTaskQueueParameters], 2)
+
+}
+
+func (s *matchingEngineSuite) TestUpdatePhysicalTaskQueueGauge_BuildID() {
+	s.matchingEngine.metricsHandler = metricstest.NewCaptureHandler()
+	captureHandler, ok := s.matchingEngine.metricsHandler.(*metricstest.CaptureHandler)
+	s.True(ok)
+	capture := captureHandler.StartCapture()
+
+	namespaceId := uuid.New()
+	buildID := uuid.New()
+	tl := "MetricTester"
+	dbq := BuildIdQueueKey(newTestTaskQueue(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY).RootPartition(), buildID)
+	tqm, err := s.matchingEngine.getTaskQueuePartitionManager(context.Background(), dbq.Partition(), true)
+	s.Require().NoError(err)
+
+	// Creating a TaskQueuePartitionManager results in creating a PhysicalTaskQueueManager which should increase
+	// the size of the map to 1 and it's counter to 1.
+	PhysicalQueueMetricValidator(s.T(), capture, 1, 1)
+
+	Vqtpm, err := tqm.(*taskQueuePartitionManagerImpl).getVersionedQueueNoWait("", buildID, true)
+	s.Require().NoError(err)
+
+	// Creating a VersionedQueue results in increasing the size of the map to 2, due to 2 entries now,
+	// with it's counter to 1.
+	PhysicalQueueMetricValidator(s.T(), capture, 2, 1)
+	s.matchingEngine.updatePhysicalTaskQueueGauge(Vqtpm.(*physicalTaskQueueManagerImpl), 1)
+	PhysicalQueueMetricValidator(s.T(), capture, 3, 2)
+
+	// Validating if versioned has been set right for the specific parameters
+	PhysicalTaskQueueParameters := taskQueueCounterKey{
+		namespaceID:   dbq.Partition().NamespaceId(),
+		taskType:      dbq.Partition().TaskType(),
+		partitionType: dbq.Partition().Kind(),
+		versioned:     "buildId",
+	}
+	assert.Equal(s.T(), s.matchingEngine.gaugeMetricCounter.loadedPhysicalTaskQueueCount[PhysicalTaskQueueParameters], 2)
+
 }
 
 func (s *matchingEngineSuite) setupRecordActivityTaskStartedMock(tlName string) {

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -180,7 +180,7 @@ func newMatchingEngine(
 		taskManager:          taskMgr,
 		historyClient:        mockHistoryClient,
 		partitions:           make(map[tqid.PartitionKey]taskQueuePartitionManager),
-		taskQueueCount:       make(map[taskQueueCounterKey]int),
+		gaugeMetricCounter:   gaugeMetrics{make(map[taskQueueCounterKey]int), make(map[taskQueueCounterKey]int), make(map[taskQueueCounterKey]int), make(map[taskQueueCounterKey]int), sync.Mutex{}},
 		lockableQueryTaskMap: lockableQueryTaskMap{queryTaskMap: make(map[string]chan *queryResult)},
 		logger:               logger,
 		throttledLogger:      log.ThrottledLogger(logger),

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -231,6 +231,7 @@ func newPhysicalTaskQueueManager(
 	for _, opt := range opts {
 		opt(tlMgr)
 	}
+	e.updatePhysicalTaskQueueGauge(tlMgr, 1)
 	return tlMgr, nil
 }
 

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -231,7 +231,6 @@ func newPhysicalTaskQueueManager(
 	for _, opt := range opts {
 		opt(tlMgr)
 	}
-	e.updatePhysicalTaskQueueGauge(tlMgr, 1)
 	return tlMgr, nil
 }
 
@@ -266,6 +265,7 @@ func (c *physicalTaskQueueManagerImpl) Start() {
 	c.taskReader.Start()
 	c.logger.Info("", tag.LifeCycleStarted)
 	c.taggedMetricsHandler.Counter(metrics.TaskQueueStartedCounter.Name()).Record(1)
+	c.partitionMgr.engine.updatePhysicalTaskQueueGauge(c, 1)
 }
 
 // Stop does not unload the queue from its partition. It is intended to be called by the partition manager when
@@ -297,6 +297,7 @@ func (c *physicalTaskQueueManagerImpl) Stop() {
 	c.taskReader.Stop()
 	c.logger.Info("", tag.LifeCycleStopped)
 	c.taggedMetricsHandler.Counter(metrics.TaskQueueStoppedCounter.Name()).Record(1)
+	c.partitionMgr.engine.updatePhysicalTaskQueueGauge(c, -1)
 }
 
 // managesSpecificVersionSet returns true if this is a tqm for a specific version set in the build-id-based versioning


### PR DESCRIPTION
## What changed?
Currently, `LoadedTaskQueueGauge` is a metric which counts the number of DB-level task queues (the total number of physicalTaskQueueManagers being created). Thus, there is not much visibility on the total number of other created instances, such as the total number of `taskQueuePartitionManagers`, the total number of `root` partitions and the total number of 'Workflow' based task queues. This PR aims to add these metrics for increased visibility.

## Why?
These changes are being made for increased visibility which would help us understand the scale of our fleet better.

## How did you test it?
- Tested it locally by ensuring no tests have broken.
- Github CI/CD

## Is hotfix candidate?
No
