### PR TITLE
Remove queue reader registration error handling logic

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -783,7 +783,6 @@ var (
 	QueueReaderCountHistogram   = NewDimensionlessHistogramDef("queue_reader_count")
 	QueueSliceCountHistogram    = NewDimensionlessHistogramDef("queue_slice_count")
 	QueueActionCounter          = NewCounterDef("queue_actions")
-	QueueActionFailures         = NewCounterDef("queue_action_errors")
 	ActivityE2ELatency          = NewTimerDef("activity_end_to_end_latency")
 	AckLevelUpdateCounter       = NewCounterDef("ack_level_update")
 	AckLevelUpdateFailedCounter = NewCounterDef("ack_level_update_failed")

--- a/service/history/queues/action.go
+++ b/service/history/queues/action.go
@@ -29,6 +29,6 @@ type (
 	// It is created and run by Mitigator upon receiving an Alert.
 	Action interface {
 		Name() string
-		Run(*ReaderGroup) error
+		Run(*ReaderGroup)
 	}
 )

--- a/service/history/queues/action_reader_stuck.go
+++ b/service/history/queues/action_reader_stuck.go
@@ -53,11 +53,11 @@ func (a *actionReaderStuck) Name() string {
 	return "reader-stuck"
 }
 
-func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) error {
+func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) {
 	reader, ok := readerGroup.ReaderByID(a.attributes.ReaderID)
 	if !ok {
 		a.logger.Info("Failed to get queue with readerID for reader stuck action", tag.QueueReaderID(a.attributes.ReaderID))
-		return nil
+		return
 	}
 
 	stuckRange := NewRange(
@@ -101,16 +101,9 @@ func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) error {
 	})
 
 	if len(splitSlices) == 0 {
-		return nil
+		return
 	}
 
-	nextReader, err := readerGroup.GetOrCreateReader(a.attributes.ReaderID + 1)
-	if err != nil {
-		// unable to create new reader, merge split slices back to the original reader
-		reader.MergeSlices(splitSlices...)
-		return err
-	}
-
+	nextReader := readerGroup.GetOrCreateReader(a.attributes.ReaderID + 1)
 	nextReader.MergeSlices(splitSlices...)
-	return nil
 }

--- a/service/history/queues/action_slice_count.go
+++ b/service/history/queues/action_slice_count.go
@@ -58,10 +58,10 @@ func (a *actionSliceCount) Name() string {
 	return "slice-count"
 }
 
-func (a *actionSliceCount) Run(readerGroup *ReaderGroup) error {
+func (a *actionSliceCount) Run(readerGroup *ReaderGroup) {
 	// first check if the alert is still valid
 	if a.monitor.GetTotalSliceCount() <= a.attributes.CriticalSliceCount {
-		return nil
+		return
 	}
 
 	// then try to shrink existing slices, which may reduce slice count
@@ -71,7 +71,7 @@ func (a *actionSliceCount) Run(readerGroup *ReaderGroup) error {
 	}
 	currentSliceCount := a.monitor.GetTotalSliceCount()
 	if currentSliceCount <= a.attributes.CriticalSliceCount {
-		return nil
+		return
 	}
 
 	// have to compact (force merge) slices to reduce slice count
@@ -102,7 +102,7 @@ func (a *actionSliceCount) Run(readerGroup *ReaderGroup) error {
 		isNotUniversalPredicate,
 		preferredSliceCount,
 	) {
-		return nil
+		return
 	}
 
 	if a.findAndCompactCandidates(
@@ -111,7 +111,7 @@ func (a *actionSliceCount) Run(readerGroup *ReaderGroup) error {
 		isNotUniversalPredicate,
 		preferredSliceCount,
 	) {
-		return nil
+		return
 	}
 
 	if a.findAndCompactCandidates(
@@ -120,7 +120,7 @@ func (a *actionSliceCount) Run(readerGroup *ReaderGroup) error {
 		isUniversalPredicate,
 		a.attributes.CriticalSliceCount,
 	) {
-		return nil
+		return
 	}
 
 	a.findAndCompactCandidates(
@@ -129,7 +129,6 @@ func (a *actionSliceCount) Run(readerGroup *ReaderGroup) error {
 		isUniversalPredicate,
 		a.attributes.CriticalSliceCount,
 	)
-	return nil
 }
 
 func (a *actionSliceCount) findAndCompactCandidates(

--- a/service/history/queues/reader_group_test.go
+++ b/service/history/queues/reader_group_test.go
@@ -25,30 +25,19 @@
 package queues
 
 import (
-	"math/rand"
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/service/history/tasks"
 )
 
 type (
 	readerGroupSuite struct {
 		suite.Suite
 		*require.Assertions
-
-		controller           *gomock.Controller
-		mockExecutionManager *persistence.MockExecutionManager
-
-		shardID    int32
-		shardOwner string
-		category   tasks.Category
 
 		readerGroup *ReaderGroup
 	}
@@ -66,40 +55,23 @@ func TestReaderGroupSuite(t *testing.T) {
 func (s *readerGroupSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 
-	s.controller = gomock.NewController(s.T())
-	s.mockExecutionManager = persistence.NewMockExecutionManager(s.controller)
-
-	s.shardID = rand.Int31()
-	s.shardOwner = "test-shard-owner"
-	s.category = tasks.CategoryTransfer
-
 	s.readerGroup = NewReaderGroup(
-		s.shardID,
-		s.shardOwner,
-		s.category,
 		func(_ int64, _ []Slice) Reader {
 			return newTestReader()
 		},
-		s.mockExecutionManager,
 	)
-}
-
-func (s *readerGroupSuite) TearDownTest() {
-	s.controller.Finish()
 }
 
 func (s *readerGroupSuite) TestStartStop() {
 	readerID := DefaultReaderId
-	r, err := s.readerGroup.NewReader(readerID)
-	s.NoError(err)
+	r := s.readerGroup.NewReader(readerID)
 	s.Equal(common.DaemonStatusInitialized, r.(*testReader).status)
 
 	s.readerGroup.Start()
 	s.Equal(common.DaemonStatusStarted, r.(*testReader).status)
 
 	readerID = DefaultReaderId + 1
-	r, err = s.readerGroup.NewReader(readerID)
-	s.NoError(err)
+	r = s.readerGroup.NewReader(readerID)
 	s.Equal(common.DaemonStatusStarted, r.(*testReader).status)
 
 	var readers []*testReader
@@ -107,15 +79,14 @@ func (s *readerGroupSuite) TestStartStop() {
 		readers = append(readers, reader.(*testReader))
 	}
 	s.readerGroup.Stop()
-	s.Empty(s.readerGroup.Readers(), 2)
+	s.Len(readers, 2)
 	for _, r := range readers {
 		s.Equal(common.DaemonStatusStopped, r.status)
 	}
 
 	readerID = DefaultReaderId + 2
-	r, err = s.readerGroup.NewReader(readerID)
-	s.Nil(r)
-	s.Equal(errReaderGroupStopped, err)
+	r = s.readerGroup.NewReader(readerID)
+	s.Equal(common.DaemonStatusInitialized, r.(*testReader).status)
 }
 
 func (s *readerGroupSuite) TestAddGetReader() {
@@ -126,8 +97,7 @@ func (s *readerGroupSuite) TestAddGetReader() {
 	s.Nil(r)
 
 	for i := int64(0); i < 3; i++ {
-		r, err := s.readerGroup.NewReader(i)
-		s.NoError(err)
+		r := s.readerGroup.NewReader(i)
 
 		readers := s.readerGroup.Readers()
 		s.Len(readers, int(i)+1)
@@ -139,7 +109,7 @@ func (s *readerGroupSuite) TestAddGetReader() {
 	}
 
 	s.Panics(func() {
-		_, _ = s.readerGroup.NewReader(DefaultReaderId)
+		s.readerGroup.NewReader(DefaultReaderId)
 	})
 }
 
@@ -149,9 +119,7 @@ func (s *readerGroupSuite) TestRemoveReader() {
 
 	readerID := DefaultReaderId
 
-	r, err := s.readerGroup.NewReader(readerID)
-	s.NoError(err)
-
+	r := s.readerGroup.NewReader(readerID)
 	s.readerGroup.RemoveReader(readerID)
 
 	s.Equal(common.DaemonStatusStopped, r.(*testReader).status)
@@ -161,8 +129,7 @@ func (s *readerGroupSuite) TestRemoveReader() {
 func (s *readerGroupSuite) TestForEach() {
 	readerIDs := []int64{1, 2, 3}
 	for _, readerID := range readerIDs {
-		_, err := s.readerGroup.NewReader(readerID)
-		s.NoError(err)
+		_ = s.readerGroup.NewReader(readerID)
 	}
 
 	forEachResult := make(map[int64]Reader)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Remove queue reader registration error handling logic
- This PR is a follow up of https://github.com/temporalio/temporal/pull/5420

## Why?
<!-- Tell your future self why have you made these changes -->
- Queue reader creation is an in-memory operation and should always succeed. Those error handling logic was added for a deprecated design where upon creating a queue reader, the logic also needs to talk to persistence layer.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- Risk is low as those logic are never triggered. However, is a bug is introduced in this PR, task can be lost.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
- N/A

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- No
