### PR TITLE
Remove unused function

### DIFF
--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -950,8 +950,3 @@ func sdkClientFactoryProvider(
 		dc.GetIntProperty(dynamicconfig.WorkerStickyCacheSize, 0),
 	)
 }
-
-func newSimpleHostInfoProvider(serviceName primitives.ServiceName, hosts map[primitives.ServiceName][]string) membership.HostInfoProvider {
-	hostInfo := membership.NewHostInfoFromAddress(hosts[serviceName][0])
-	return membership.NewHostInfoProvider(hostInfo)
-}


### PR DESCRIPTION
## What changed?
Unused function `newSimpleHostInfoProvider` was removed.

## Why?
Unused. No references to it. 

## How did you test it?
compile check.

## Potential risks
N/A

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
No
