### PR TITLE
Add sampled logging when workflow query task times out

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -480,6 +480,9 @@ const (
 	// MatchingMembershipUnloadDelay is how long to wait to re-confirm loss of ownership before unloading a task queue.
 	// Set to zero to disable proactive unload.
 	MatchingMembershipUnloadDelay = "matching.membershipUnloadDelay"
+	// MatchingQueryWorkflowTaskTimeoutLogRate defines the sampling rate for logs when a query workflow task times out. Since
+	// these log lines can be noisy, we want to be able to turn on and sample selectively for each affected namespace.
+	MatchingQueryWorkflowTaskTimeoutLogRate = "matching.queryWorkflowTaskTimeoutLogRate"
 
 	// for matching testing only:
 

--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -46,3 +46,5 @@ frontend.adminDeleteAccessHistoryFraction:
   - value: 1.0
 frontend.enableNexusHTTPHandler:
   - value: true
+matching.queryWorkflowTaskTimeoutLogRate:
+  - value: 1.0

--- a/config/dynamicconfig/development-sql.yaml
+++ b/config/dynamicconfig/development-sql.yaml
@@ -49,3 +49,5 @@ frontend.adminDeleteAccessHistoryFraction:
   - value: 1.0
 frontend.enableNexusHTTPHandler:
   - value: true
+matching.queryWorkflowTaskTimeoutLogRate:
+  - value: 1.0

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -101,7 +101,7 @@ type (
 		// FrontendAccessHistoryFraction is an interim flag across 2 minor releases and will be removed once fully enabled.
 		FrontendAccessHistoryFraction dynamicconfig.FloatPropertyFn
 
-		QueryWorkflowTaskTimeoutLogRate dynamicconfig.FloatPropertyFnWithNamespaceFilter
+		QueryWorkflowTaskTimeoutLogRate dynamicconfig.FloatPropertyFnWithTaskQueueInfoFilters
 	}
 
 	forwarderConfig struct {
@@ -221,7 +221,7 @@ func NewConfig(
 		ListNexusIncomingServicesLongPollTimeout: dc.GetDurationProperty(dynamicconfig.MatchingListNexusIncomingServicesLongPollTimeout, 5*time.Minute-10*time.Second), // Use -10 seconds so that we send back empty response instead of timeout
 
 		FrontendAccessHistoryFraction:   dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 0.0),
-		QueryWorkflowTaskTimeoutLogRate: dc.GetFloatPropertyFilteredByNamespace(dynamicconfig.MatchingQueryWorkflowTaskTimeoutLogRate, 0.0),
+		QueryWorkflowTaskTimeoutLogRate: dc.GetFloatPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingQueryWorkflowTaskTimeoutLogRate, 0.0),
 	}
 }
 

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -100,6 +100,8 @@ type (
 
 		// FrontendAccessHistoryFraction is an interim flag across 2 minor releases and will be removed once fully enabled.
 		FrontendAccessHistoryFraction dynamicconfig.FloatPropertyFn
+
+		QueryWorkflowTaskTimeoutLogRate dynamicconfig.FloatPropertyFnWithNamespaceFilter
 	}
 
 	forwarderConfig struct {
@@ -218,7 +220,8 @@ func NewConfig(
 
 		ListNexusIncomingServicesLongPollTimeout: dc.GetDurationProperty(dynamicconfig.MatchingListNexusIncomingServicesLongPollTimeout, 5*time.Minute-10*time.Second), // Use -10 seconds so that we send back empty response instead of timeout
 
-		FrontendAccessHistoryFraction: dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 0.0),
+		FrontendAccessHistoryFraction:   dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 0.0),
+		QueryWorkflowTaskTimeoutLogRate: dc.GetFloatPropertyFilteredByNamespace(dynamicconfig.MatchingQueryWorkflowTaskTimeoutLogRate, 0.0),
 	}
 }
 

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -72,6 +72,7 @@ type (
 		BacklogNegligibleAge              dynamicconfig.DurationPropertyFnWithTaskQueueInfoFilters
 		MaxWaitForPollerBeforeFwd         dynamicconfig.DurationPropertyFnWithTaskQueueInfoFilters
 		QueryPollerUnavailableWindow      dynamicconfig.DurationPropertyFn
+		QueryWorkflowTaskTimeoutLogRate   dynamicconfig.FloatPropertyFnWithTaskQueueInfoFilters
 		MembershipUnloadDelay             dynamicconfig.DurationPropertyFn
 
 		// Time to hold a poll request before returning an empty response if there are no tasks
@@ -100,8 +101,6 @@ type (
 
 		// FrontendAccessHistoryFraction is an interim flag across 2 minor releases and will be removed once fully enabled.
 		FrontendAccessHistoryFraction dynamicconfig.FloatPropertyFn
-
-		QueryWorkflowTaskTimeoutLogRate dynamicconfig.FloatPropertyFnWithTaskQueueInfoFilters
 	}
 
 	forwarderConfig struct {
@@ -207,6 +206,7 @@ func NewConfig(
 		BacklogNegligibleAge:                  dc.GetDurationPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingBacklogNegligibleAge, 24*365*10*time.Hour),
 		MaxWaitForPollerBeforeFwd:             dc.GetDurationPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingMaxWaitForPollerBeforeFwd, 200*time.Millisecond),
 		QueryPollerUnavailableWindow:          dc.GetDurationProperty(dynamicconfig.QueryPollerUnavailableWindow, 20*time.Second),
+		QueryWorkflowTaskTimeoutLogRate:       dc.GetFloatPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingQueryWorkflowTaskTimeoutLogRate, 0.0),
 		MembershipUnloadDelay:                 dc.GetDurationProperty(dynamicconfig.MatchingMembershipUnloadDelay, 500*time.Millisecond),
 
 		AdminNamespaceToPartitionDispatchRate:          dc.GetFloatPropertyFilteredByNamespace(dynamicconfig.AdminMatchingNamespaceToPartitionDispatchRate, 10000),
@@ -220,8 +220,7 @@ func NewConfig(
 
 		ListNexusIncomingServicesLongPollTimeout: dc.GetDurationProperty(dynamicconfig.MatchingListNexusIncomingServicesLongPollTimeout, 5*time.Minute-10*time.Second), // Use -10 seconds so that we send back empty response instead of timeout
 
-		FrontendAccessHistoryFraction:   dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 0.0),
-		QueryWorkflowTaskTimeoutLogRate: dc.GetFloatPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingQueryWorkflowTaskTimeoutLogRate, 0.0),
+		FrontendAccessHistoryFraction: dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 0.0),
 	}
 }
 

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -878,6 +878,7 @@ func (e *matchingEngineImpl) QueryWorkflow(
 					tag.WorkflowNamespaceID(ns.ID().String()),
 					tag.WorkflowNamespace(ns.Name().String()),
 					tag.WorkflowID(queryRequest.GetQueryRequest().GetExecution().GetWorkflowId()),
+					tag.WorkflowRunID(queryRequest.GetQueryRequest().GetExecution().GetRunId()),
 					tag.WorkflowTaskRequestId(taskID),
 					tag.WorkflowTaskQueueName(taskQueueName))
 			}

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -872,7 +872,7 @@ func (e *matchingEngineImpl) QueryWorkflow(
 				tag.WorkflowNamespaceID(string(namespaceID)),
 				tag.Error(err))
 		} else {
-			sampleRate := e.config.QueryWorkflowTaskTimeoutLogRate(ns.Name().String())
+			sampleRate := e.config.QueryWorkflowTaskTimeoutLogRate(ns.Name().String(), taskQueueName, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 			if rand.Float64() < sampleRate {
 				e.logger.Info("Workflow Query Task timed out",
 					tag.WorkflowNamespaceID(ns.ID().String()),


### PR DESCRIPTION
## What changed?
Adding a sampled logging when a workflow query task times out.

## Why?
Need this to be able to debug issues in the future when workflow queries timeout. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Ran it locally with the sampling rate set to 1 and simulated a timeout. Observed that the data is logged.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
