### PR TITLE
Fix stream_sender retry logic

### DIFF
--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -88,11 +88,11 @@ func WrapEventLoop(
 			return
 		}
 
-		if retryCount < 10 { // retry at most 10 times and then let the stream_receiver_monitor to restart it
-			retryCount++
-			time.Sleep(retryInterval)
-		} else {
+		if retryCount >= 10 { // retry at most 10 times and then let the stream_receiver_monitor to restart it
 			return
 		}
+
+		retryCount++
+		time.Sleep(retryInterval)
 	}
 }

--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -70,8 +70,8 @@ func WrapEventLoop(
 	retryInterval time.Duration,
 ) {
 	defer streamStopper()
-	retryCount := 0
-	for {
+
+	for retryCount := 0; retryCount < 11; retryCount++ {
 		err := originalEventLoop()
 
 		if err == nil { // shutdown case
@@ -92,7 +92,6 @@ func WrapEventLoop(
 			return
 		}
 
-		retryCount++
 		time.Sleep(retryInterval)
 	}
 }

--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -70,10 +70,11 @@ func WrapEventLoop(
 	retryInterval time.Duration,
 ) {
 	defer streamStopper()
+	retryCount := 0
 	for {
 		err := originalEventLoop()
 
-		if err == nil {
+		if err == nil { // shutdown case
 			return
 		}
 		// if it is stream error, we will not retry and terminate the stream, then let the stream_receiver_monitor to restart it
@@ -86,6 +87,12 @@ func WrapEventLoop(
 			)
 			return
 		}
-		time.Sleep(retryInterval)
+
+		if retryCount < 10 { // retry at most 10 times and then let the stream_receiver_monitor to restart it
+			retryCount++
+			time.Sleep(retryInterval)
+		} else {
+			return
+		}
 	}
 }

--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -87,11 +87,6 @@ func WrapEventLoop(
 			)
 			return
 		}
-
-		if retryCount >= 10 { // retry at most 10 times and then let the stream_receiver_monitor to restart it
-			return
-		}
-
 		time.Sleep(retryInterval)
 	}
 }

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -153,13 +153,11 @@ func (s *StreamSenderImpl) recvEventLoop() (retErr error) {
 
 	defer log.CapturePanic(s.logger, &panicErr)
 
-	defer s.Stop()
-
 	for !s.shutdownChan.IsShutdown() {
 		req, err := s.server.Recv()
 		if err != nil {
 			s.logger.Error("StreamSender exit recv loop", tag.Error(err))
-			return err
+			return NewStreamError("Stream recv error", err)
 		}
 		switch attr := req.GetAttributes().(type) {
 		case *historyservice.StreamWorkflowReplicationMessagesRequest_SyncReplicationState:
@@ -185,7 +183,6 @@ func (s *StreamSenderImpl) recvEventLoop() (retErr error) {
 }
 
 func (s *StreamSenderImpl) sendEventLoop() (retErr error) {
-	defer s.Stop()
 	var panicErr error
 	defer func() {
 		if panicErr != nil {
@@ -317,7 +314,7 @@ func (s *StreamSenderImpl) sendTasks(
 		return err
 	}
 	if beginInclusiveWatermark == endExclusiveWatermark {
-		return s.server.Send(&historyservice.StreamWorkflowReplicationMessagesResponse{
+		return s.sendToStream(&historyservice.StreamWorkflowReplicationMessagesResponse{
 			Attributes: &historyservice.StreamWorkflowReplicationMessagesResponse_Messages{
 				Messages: &replicationspb.WorkflowReplicationMessages{
 					ReplicationTasks:           nil,
@@ -357,7 +354,7 @@ Loop:
 		if task == nil {
 			continue Loop
 		}
-		if err := s.server.Send(&historyservice.StreamWorkflowReplicationMessagesResponse{
+		if err := s.sendToStream(&historyservice.StreamWorkflowReplicationMessagesResponse{
 			Attributes: &historyservice.StreamWorkflowReplicationMessagesResponse_Messages{
 				Messages: &replicationspb.WorkflowReplicationMessages{
 					ReplicationTasks:           []*replicationspb.ReplicationTask{task},
@@ -375,7 +372,7 @@ Loop:
 			metrics.OperationTag(TaskOperationTag(task)),
 		)
 	}
-	return s.server.Send(&historyservice.StreamWorkflowReplicationMessagesResponse{
+	return s.sendToStream(&historyservice.StreamWorkflowReplicationMessagesResponse{
 		Attributes: &historyservice.StreamWorkflowReplicationMessagesResponse_Messages{
 			Messages: &replicationspb.WorkflowReplicationMessages{
 				ReplicationTasks:           nil,
@@ -384,4 +381,12 @@ Loop:
 			},
 		},
 	})
+}
+
+func (s *StreamSenderImpl) sendToStream(payload *historyservice.StreamWorkflowReplicationMessagesResponse) error {
+	err := s.server.Send(payload)
+	if err != nil {
+		return NewStreamError("Stream send error", err)
+	}
+	return nil
 }

--- a/service/history/replication/stream_test.go
+++ b/service/history/replication/stream_test.go
@@ -40,7 +40,6 @@ func TestWrapEventLoopFn_ReturnStreamError_ShouldStopLoop(t *testing.T) {
 	done := make(chan bool)
 	timer := time.NewTimer(3 * time.Second)
 	go func() {
-		// Your original test code goes here
 		originalEventLoopCallCount := 0
 		originalEventLoop := func() error {
 			originalEventLoopCallCount++
@@ -72,7 +71,6 @@ func TestWrapEventLoopFn_ReturnServiceError_ShouldRetryUntilStreamError(t *testi
 	timer := time.NewTimer(3 * time.Second)
 
 	go func() {
-		// Your original test code goes here
 		originalEventLoopCallCount := 0
 		originalEventLoop := func() error {
 			originalEventLoopCallCount++
@@ -87,6 +85,37 @@ func TestWrapEventLoopFn_ReturnServiceError_ShouldRetryUntilStreamError(t *testi
 		}
 		WrapEventLoop(originalEventLoop, stopFunc, log.NewNoopLogger(), metrics.NoopMetricsHandler, NewClusterShardKey(1, 1), NewClusterShardKey(2, 1), 0)
 		assertion.Equal(3, originalEventLoopCallCount)
+		assertion.Equal(1, stopFuncCallCount)
+
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Test completed within the timeout
+	case <-timer.C:
+		t.Fatal("Test timed out after 5 seconds")
+	}
+}
+
+func TestWrapEventLoopFn_ReturnServiceError_ShouldRetry10Times(t *testing.T) {
+	assertion := require.New(t)
+
+	done := make(chan bool)
+	timer := time.NewTimer(3 * time.Second)
+
+	go func() {
+		originalEventLoopCallCount := 0
+		originalEventLoop := func() error {
+			originalEventLoopCallCount++
+			return errors.New("error")
+		}
+		stopFuncCallCount := 0
+		stopFunc := func() {
+			stopFuncCallCount++
+		}
+		WrapEventLoop(originalEventLoop, stopFunc, log.NewNoopLogger(), metrics.NoopMetricsHandler, NewClusterShardKey(1, 1), NewClusterShardKey(2, 1), 0)
+		assertion.Equal(11, originalEventLoopCallCount)
 		assertion.Equal(1, stopFuncCallCount)
 
 		done <- true


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
1. Fix stream_sender to return Stream error when there is error on stream
2. Avoid infinite retry on stream event loop wrapper
## Why?
<!-- Tell your future self why have you made these changes -->
1. stream_sender's send/recv error is not properly wrapped, so the eventloop wrapper is retrying infinitely on the "rpc error"
2. Avoid the infinitely retry
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Unit test
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risk.
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
Should only affecting 1.24.