### PR TITLE
Removing frontend.namespaceBurst and adding frontend.namespaceBurstRatio

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -246,7 +246,7 @@ const (
 	// FrontendMaxNamespaceRPSPerInstance is workflow namespace rate limit per second
 	FrontendMaxNamespaceRPSPerInstance = "frontend.namespaceRPS"
 	// FrontendMaxNamespaceBurstRatioPerInstance is workflow namespace burst limit as a ratio of namespace RPS. The RPS
-	// used here will be the effective RPS from global and per-instance limits.
+	// used here will be the effective RPS from global and per-instance limits. The value must be 1 or higher.
 	FrontendMaxNamespaceBurstRatioPerInstance = "frontend.namespaceBurstRatio"
 	// FrontendMaxConcurrentLongRunningRequestsPerInstance limits concurrent long-running requests per-instance,
 	// per-API. Example requests include long-poll requests, and `Query` requests (which need to wait for WFTs). The
@@ -271,12 +271,13 @@ const (
 	FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance = "frontend.namespaceRPS.namespaceReplicationInducingAPIs"
 	// FrontendMaxNamespaceVisibilityBurstRatioPerInstance is namespace burst limit for visibility APIs as a ratio of
 	// namespace visibility RPS. The RPS used here will be the effective RPS from global and per-instance limits. This
-	// config is EXPERIMENTAL and may be changed or removed in a later release.
+	// config is EXPERIMENTAL and may be changed or removed in a later release. The value must be 1 or higher.
 	FrontendMaxNamespaceVisibilityBurstRatioPerInstance = "frontend.namespaceBurstRatio.visibility"
 	// FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance is a per host/per namespace burst limit for
 	// namespace replication inducing APIs (e.g. RegisterNamespace, UpdateNamespace, UpdateWorkerBuildIdCompatibility)
 	// as a ratio of namespace ReplicationInducingAPIs RPS. The RPS used here will be the effective RPS from global and
-	// per-instance limits. This config is EXPERIMENTAL and may be changed or removed in a later release.
+	// per-instance limits. This config is EXPERIMENTAL and may be changed or removed in a later release. The value must
+	// be 1 or higher.
 	FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance = "frontend.namespaceBurstRatio.namespaceReplicationInducingAPIs"
 	// FrontendGlobalNamespaceRPS is workflow namespace rate limit per second for the whole cluster.
 	// The limit is evenly distributed among available frontend service instances.

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -268,13 +268,14 @@ const (
 	// namespace replication inducing APIs (e.g. RegisterNamespace, UpdateNamespace, UpdateWorkerBuildIdCompatibility).
 	// This config is EXPERIMENTAL and may be changed or removed in a later release.
 	FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance = "frontend.namespaceRPS.namespaceReplicationInducingAPIs"
-	// FrontendMaxNamespaceVisibilityBurstPerInstance is namespace burst limit for visibility APIs.
-	// This config is EXPERIMENTAL and may be changed or removed in a later release.
-	FrontendMaxNamespaceVisibilityBurstPerInstance = "frontend.namespaceBurst.visibility"
-	// FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstPerInstance is a per host/per namespace burst limit for
-	// namespace replication inducing APIs (e.g. RegisterNamespace, UpdateNamespace, UpdateWorkerBuildIdCompatibility).
-	// This config is EXPERIMENTAL and may be changed or removed in a later release.
-	FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstPerInstance = "frontend.namespaceBurst.namespaceReplicationInducingAPIs"
+	// FrontendMaxNamespaceVisibilityBurstRatioPerInstance is namespace burst limit for visibility APIs as a ratio of
+	// frontend.namespaceRPS.visibility. This config is EXPERIMENTAL and may be changed or removed in a later release.
+	FrontendMaxNamespaceVisibilityBurstRatioPerInstance = "frontend.namespaceBurstRatio.visibility"
+	// FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance is a per host/per namespace burst limit for
+	// namespace replication inducing APIs (e.g. RegisterNamespace, UpdateNamespace, UpdateWorkerBuildIdCompatibility)
+	// as a ratio of frontend.namespaceRPS.namespaceReplicationInducingAPIs. This config is EXPERIMENTAL and may be
+	// changed or removed in a later release.
+	FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance = "frontend.namespaceBurstRatio.namespaceReplicationInducingAPIs"
 	// FrontendGlobalNamespaceRPS is workflow namespace rate limit per second for the whole cluster.
 	// The limit is evenly distributed among available frontend service instances.
 	// If this is set, it overwrites per instance limit "frontend.namespaceRPS".

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -245,8 +245,8 @@ const (
 	FrontendNamespaceReplicationInducingAPIsRPS = "frontend.rps.namespaceReplicationInducingAPIs"
 	// FrontendMaxNamespaceRPSPerInstance is workflow namespace rate limit per second
 	FrontendMaxNamespaceRPSPerInstance = "frontend.namespaceRPS"
-	// FrontendMaxNamespaceBurstPerInstance is workflow namespace burst limit
-	FrontendMaxNamespaceBurstPerInstance = "frontend.namespaceBurst"
+	// FrontendMaxNamespaceBurstRatioPerInstance is workflow namespace burst limit as fraction of frontend.namespaceRPS.
+	FrontendMaxNamespaceBurstRatioPerInstance = "frontend.namespaceBurstRatio"
 	// FrontendMaxConcurrentLongRunningRequestsPerInstance limits concurrent long-running requests per-instance,
 	// per-API. Example requests include long-poll requests, and `Query` requests (which need to wait for WFTs). The
 	// limit is applied individually to each API method. This value is ignored if

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -245,7 +245,8 @@ const (
 	FrontendNamespaceReplicationInducingAPIsRPS = "frontend.rps.namespaceReplicationInducingAPIs"
 	// FrontendMaxNamespaceRPSPerInstance is workflow namespace rate limit per second
 	FrontendMaxNamespaceRPSPerInstance = "frontend.namespaceRPS"
-	// FrontendMaxNamespaceBurstRatioPerInstance is workflow namespace burst limit as a ratio of frontend.namespaceRPS.
+	// FrontendMaxNamespaceBurstRatioPerInstance is workflow namespace burst limit as a ratio of namespace RPS. The RPS
+	// used here will be the effective RPS from global and per-instance limits.
 	FrontendMaxNamespaceBurstRatioPerInstance = "frontend.namespaceBurstRatio"
 	// FrontendMaxConcurrentLongRunningRequestsPerInstance limits concurrent long-running requests per-instance,
 	// per-API. Example requests include long-poll requests, and `Query` requests (which need to wait for WFTs). The
@@ -269,12 +270,13 @@ const (
 	// This config is EXPERIMENTAL and may be changed or removed in a later release.
 	FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance = "frontend.namespaceRPS.namespaceReplicationInducingAPIs"
 	// FrontendMaxNamespaceVisibilityBurstRatioPerInstance is namespace burst limit for visibility APIs as a ratio of
-	// frontend.namespaceRPS.visibility. This config is EXPERIMENTAL and may be changed or removed in a later release.
+	// namespace visibility RPS. The RPS used here will be the effective RPS from global and per-instance limits. This
+	// config is EXPERIMENTAL and may be changed or removed in a later release.
 	FrontendMaxNamespaceVisibilityBurstRatioPerInstance = "frontend.namespaceBurstRatio.visibility"
 	// FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance is a per host/per namespace burst limit for
 	// namespace replication inducing APIs (e.g. RegisterNamespace, UpdateNamespace, UpdateWorkerBuildIdCompatibility)
-	// as a ratio of frontend.namespaceRPS.namespaceReplicationInducingAPIs. This config is EXPERIMENTAL and may be
-	// changed or removed in a later release.
+	// as a ratio of namespace ReplicationInducingAPIs RPS. The RPS used here will be the effective RPS from global and
+	// per-instance limits. This config is EXPERIMENTAL and may be changed or removed in a later release.
 	FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance = "frontend.namespaceBurstRatio.namespaceReplicationInducingAPIs"
 	// FrontendGlobalNamespaceRPS is workflow namespace rate limit per second for the whole cluster.
 	// The limit is evenly distributed among available frontend service instances.

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -245,7 +245,7 @@ const (
 	FrontendNamespaceReplicationInducingAPIsRPS = "frontend.rps.namespaceReplicationInducingAPIs"
 	// FrontendMaxNamespaceRPSPerInstance is workflow namespace rate limit per second
 	FrontendMaxNamespaceRPSPerInstance = "frontend.namespaceRPS"
-	// FrontendMaxNamespaceBurstRatioPerInstance is workflow namespace burst limit as fraction of frontend.namespaceRPS.
+	// FrontendMaxNamespaceBurstRatioPerInstance is workflow namespace burst limit as a ratio of frontend.namespaceRPS.
 	FrontendMaxNamespaceBurstRatioPerInstance = "frontend.namespaceBurstRatio"
 	// FrontendMaxConcurrentLongRunningRequestsPerInstance limits concurrent long-running requests per-instance,
 	// per-API. Example requests include long-poll requests, and `Query` requests (which need to wait for WFTs). The

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -173,12 +173,14 @@ var _ quotas.RateBurst = (*operatorRateBurstImpl)(nil)
 func NewNamespaceRateBurst(
 	namespaceName string,
 	rateFn dynamicconfig.FloatPropertyFnWithNamespaceFilter,
-	burstFn dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	burstRatioFn dynamicconfig.FloatPropertyFnWithNamespaceFilter,
 ) *NamespaceRateBurstImpl {
 	return &NamespaceRateBurstImpl{
 		namespaceName: namespaceName,
 		rateFn:        rateFn,
-		burstFn:       burstFn,
+		burstFn: func(namespace string) int {
+			return int(rateFn(namespace) * burstRatioFn(namespace))
+		},
 	}
 }
 

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -25,6 +25,7 @@
 package configs
 
 import (
+	"math"
 	"time"
 
 	"go.temporal.io/server/common/dynamicconfig"
@@ -179,7 +180,7 @@ func NewNamespaceRateBurst(
 		namespaceName: namespaceName,
 		rateFn:        rateFn,
 		burstFn: func(namespace string) int {
-			return int(rateFn(namespace) * burstRatioFn(namespace))
+			return int(rateFn(namespace) * math.Max(1, burstRatioFn(namespace)))
 		},
 	}
 }

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -367,34 +367,22 @@ func NamespaceRateLimitInterceptorProvider(
 		PerInstanceQuota: serviceConfig.MaxNamespaceRPSPerInstance,
 		GlobalQuota:      globalNamespaceRPS,
 	}.GetQuota
-	namespaceBurstFn := func(ns string) int {
-		return int(namespaceRateFn(ns) *
-			serviceConfig.MaxNamespaceBurstRatioPerInstance(ns))
-	}
 	visibilityRateFn := quotas.ClusterAwareNamespaceSpecificQuotaCalculator{
 		MemberCounter:    frontendServiceResolver,
 		PerInstanceQuota: serviceConfig.MaxNamespaceVisibilityRPSPerInstance,
 		GlobalQuota:      globalNamespaceVisibilityRPS,
 	}.GetQuota
-	visibilityBurstFn := func(ns string) int {
-		return int(visibilityRateFn(ns) *
-			serviceConfig.MaxNamespaceVisibilityBurstRatioPerInstance(ns))
-	}
 	namespaceReplicationInducingRateFn := quotas.ClusterAwareNamespaceSpecificQuotaCalculator{
 		MemberCounter:    frontendServiceResolver,
 		PerInstanceQuota: serviceConfig.MaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance,
 		GlobalQuota:      globalNamespaceNamespaceReplicationInducingAPIsRPS,
 	}.GetQuota
-	namespaceReplicationInducingBurstFn := func(ns string) int {
-		return int(namespaceReplicationInducingRateFn(ns) *
-			serviceConfig.MaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance(ns))
-	}
 	namespaceRateLimiter := quotas.NewNamespaceRequestRateLimiter(
 		func(req quotas.Request) quotas.RequestRateLimiter {
 			return configs.NewRequestToRateLimiter(
-				configs.NewNamespaceRateBurst(req.Caller, namespaceRateFn, namespaceBurstFn),
-				configs.NewNamespaceRateBurst(req.Caller, visibilityRateFn, visibilityBurstFn),
-				configs.NewNamespaceRateBurst(req.Caller, namespaceReplicationInducingRateFn, namespaceReplicationInducingBurstFn),
+				configs.NewNamespaceRateBurst(req.Caller, namespaceRateFn, serviceConfig.MaxNamespaceBurstRatioPerInstance),
+				configs.NewNamespaceRateBurst(req.Caller, visibilityRateFn, serviceConfig.MaxNamespaceVisibilityBurstRatioPerInstance),
+				configs.NewNamespaceRateBurst(req.Caller, namespaceReplicationInducingRateFn, serviceConfig.MaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance),
 				serviceConfig.OperatorRPSRatio,
 			)
 		},

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -367,7 +367,7 @@ func NamespaceRateLimitInterceptorProvider(
 		PerInstanceQuota: serviceConfig.MaxNamespaceRPSPerInstance,
 		GlobalQuota:      globalNamespaceRPS,
 	}.GetQuota
-	burstFn := func(ns string) int {
+	namespaceBurstFn := func(ns string) int {
 		return int(float64(serviceConfig.MaxNamespaceRPSPerInstance(ns)) * serviceConfig.MaxNamespaceBurstRatioPerInstance(ns))
 	}
 	visibilityRateFn := quotas.ClusterAwareNamespaceSpecificQuotaCalculator{
@@ -383,7 +383,7 @@ func NamespaceRateLimitInterceptorProvider(
 	namespaceRateLimiter := quotas.NewNamespaceRequestRateLimiter(
 		func(req quotas.Request) quotas.RequestRateLimiter {
 			return configs.NewRequestToRateLimiter(
-				configs.NewNamespaceRateBurst(req.Caller, rateFn, burstFn),
+				configs.NewNamespaceRateBurst(req.Caller, rateFn, namespaceBurstFn),
 				configs.NewNamespaceRateBurst(req.Caller, visibilityRateFn, serviceConfig.MaxNamespaceVisibilityBurstPerInstance),
 				configs.NewNamespaceRateBurst(req.Caller, namespaceReplicationInducingRateFn, serviceConfig.MaxNamespaceNamespaceReplicationInducingAPIsBurstPerInstance),
 				serviceConfig.OperatorRPSRatio,

--- a/service/frontend/fx_test.go
+++ b/service/frontend/fx_test.go
@@ -346,11 +346,11 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			expectRateLimit:                   false,
 		},
 		{
-			name:                              "namespace burst hit when burst ratio is 0.5",
+			name:                              "namespace burst ratio does not apply for values < 1",
 			maxNamespaceRPSPerInstance:        10,
 			maxNamespaceBurstRatioPerInstance: 0.5,
-			numRequests:                       6,
-			expectRateLimit:                   true,
+			numRequests:                       10,
+			expectRateLimit:                   false,
 		},
 		{
 			name:                              "namespace burst allow when burst ratio is 1 and global limit is set",
@@ -424,11 +424,11 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			expectRateLimit:                             false,
 		},
 		{
-			name:                                 "visibility burst hit when burst ratio is 0.5",
+			name:                                 "visibility burst ratio does not apply for values < 1",
 			maxNamespaceVisibilityRPSPerInstance: 10,
 			maxNamespaceVisibilityBurstRatioPerInstance: 0.5,
-			numVisibilityRequests:                       6,
-			expectRateLimit:                             true,
+			numVisibilityRequests:                       10,
+			expectRateLimit:                             false,
 		},
 		{
 			name:                                 "visibility burst allow when burst ratio is 1 and global limit is set",
@@ -502,11 +502,11 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			expectRateLimit:                                                   false,
 		},
 		{
-			name: "replication inducing op burst hit when burst ratio is 0.5",
+			name: "replication inducing op burst ratio does not apply for values < 1",
 			maxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:        10,
 			maxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance: 0.5,
-			numReplicationInducingRequests:                                    6,
-			expectRateLimit:                                                   true,
+			numReplicationInducingRequests:                                    10,
+			expectRateLimit:                                                   false,
 		},
 		{
 			name:                 "replication inducing op burst allow when burst ratio is 1 and global limit is set",

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -76,7 +76,7 @@ type Config struct {
 	OperatorRPSRatio                                             dynamicconfig.FloatPropertyFn
 	NamespaceReplicationInducingAPIsRPS                          dynamicconfig.IntPropertyFn
 	MaxNamespaceRPSPerInstance                                   dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxNamespaceBurstPerInstance                                 dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxNamespaceBurstRatioPerInstance                            dynamicconfig.FloatPropertyFnWithNamespaceFilter
 	MaxConcurrentLongRunningRequestsPerInstance                  dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxGlobalConcurrentLongRunningRequests                       dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxNamespaceVisibilityRPSPerInstance                         dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -226,7 +226,7 @@ func NewConfig(
 		NamespaceReplicationInducingAPIsRPS: dc.GetIntProperty(dynamicconfig.FrontendNamespaceReplicationInducingAPIsRPS, 20),
 
 		MaxNamespaceRPSPerInstance:                                   dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceRPSPerInstance, 2400),
-		MaxNamespaceBurstPerInstance:                                 dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceBurstPerInstance, 4800),
+		MaxNamespaceBurstRatioPerInstance:                            dc.GetFloatPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceBurstRatioPerInstance, 1),
 		MaxConcurrentLongRunningRequestsPerInstance:                  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxConcurrentLongRunningRequestsPerInstance, 1200),
 		MaxGlobalConcurrentLongRunningRequests:                       dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendGlobalMaxConcurrentLongRunningRequests, 0),
 		MaxNamespaceVisibilityRPSPerInstance:                         dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceVisibilityRPSPerInstance, 10),

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -70,32 +70,32 @@ type Config struct {
 	VisibilityEnableManualPagination  dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	VisibilityAllowList               dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
-	HistoryMaxPageSize                                           dynamicconfig.IntPropertyFnWithNamespaceFilter
-	RPS                                                          dynamicconfig.IntPropertyFn
-	GlobalRPS                                                    dynamicconfig.IntPropertyFn
-	OperatorRPSRatio                                             dynamicconfig.FloatPropertyFn
-	NamespaceReplicationInducingAPIsRPS                          dynamicconfig.IntPropertyFn
-	MaxNamespaceRPSPerInstance                                   dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxNamespaceBurstRatioPerInstance                            dynamicconfig.FloatPropertyFnWithNamespaceFilter
-	MaxConcurrentLongRunningRequestsPerInstance                  dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxGlobalConcurrentLongRunningRequests                       dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxNamespaceVisibilityRPSPerInstance                         dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxNamespaceVisibilityBurstPerInstance                       dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance   dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxNamespaceNamespaceReplicationInducingAPIsBurstPerInstance dynamicconfig.IntPropertyFnWithNamespaceFilter
-	GlobalNamespaceRPS                                           dynamicconfig.IntPropertyFnWithNamespaceFilter
-	InternalFEGlobalNamespaceRPS                                 dynamicconfig.IntPropertyFnWithNamespaceFilter
-	GlobalNamespaceVisibilityRPS                                 dynamicconfig.IntPropertyFnWithNamespaceFilter
-	InternalFEGlobalNamespaceVisibilityRPS                       dynamicconfig.IntPropertyFnWithNamespaceFilter
-	GlobalNamespaceNamespaceReplicationInducingAPIsRPS           dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxIDLengthLimit                                             dynamicconfig.IntPropertyFn
-	WorkerBuildIdSizeLimit                                       dynamicconfig.IntPropertyFn
-	ReachabilityTaskQueueScanLimit                               dynamicconfig.IntPropertyFn
-	ReachabilityQueryBuildIdLimit                                dynamicconfig.IntPropertyFn
-	ReachabilityQuerySetDurationSinceDefault                     dynamicconfig.DurationPropertyFn
-	DisallowQuery                                                dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	ShutdownDrainDuration                                        dynamicconfig.DurationPropertyFn
-	ShutdownFailHealthCheckDuration                              dynamicconfig.DurationPropertyFn
+	HistoryMaxPageSize                                                dynamicconfig.IntPropertyFnWithNamespaceFilter
+	RPS                                                               dynamicconfig.IntPropertyFn
+	GlobalRPS                                                         dynamicconfig.IntPropertyFn
+	OperatorRPSRatio                                                  dynamicconfig.FloatPropertyFn
+	NamespaceReplicationInducingAPIsRPS                               dynamicconfig.IntPropertyFn
+	MaxNamespaceRPSPerInstance                                        dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxNamespaceBurstRatioPerInstance                                 dynamicconfig.FloatPropertyFnWithNamespaceFilter
+	MaxConcurrentLongRunningRequestsPerInstance                       dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxGlobalConcurrentLongRunningRequests                            dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxNamespaceVisibilityRPSPerInstance                              dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxNamespaceVisibilityBurstRatioPerInstance                       dynamicconfig.FloatPropertyFnWithNamespaceFilter
+	MaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance        dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance dynamicconfig.FloatPropertyFnWithNamespaceFilter
+	GlobalNamespaceRPS                                                dynamicconfig.IntPropertyFnWithNamespaceFilter
+	InternalFEGlobalNamespaceRPS                                      dynamicconfig.IntPropertyFnWithNamespaceFilter
+	GlobalNamespaceVisibilityRPS                                      dynamicconfig.IntPropertyFnWithNamespaceFilter
+	InternalFEGlobalNamespaceVisibilityRPS                            dynamicconfig.IntPropertyFnWithNamespaceFilter
+	GlobalNamespaceNamespaceReplicationInducingAPIsRPS                dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxIDLengthLimit                                                  dynamicconfig.IntPropertyFn
+	WorkerBuildIdSizeLimit                                            dynamicconfig.IntPropertyFn
+	ReachabilityTaskQueueScanLimit                                    dynamicconfig.IntPropertyFn
+	ReachabilityQueryBuildIdLimit                                     dynamicconfig.IntPropertyFn
+	ReachabilityQuerySetDurationSinceDefault                          dynamicconfig.DurationPropertyFn
+	DisallowQuery                                                     dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	ShutdownDrainDuration                                             dynamicconfig.DurationPropertyFn
+	ShutdownFailHealthCheckDuration                                   dynamicconfig.DurationPropertyFn
 
 	MaxBadBinaries dynamicconfig.IntPropertyFnWithNamespaceFilter
 
@@ -225,14 +225,14 @@ func NewConfig(
 		OperatorRPSRatio:                    dc.GetFloat64Property(dynamicconfig.OperatorRPSRatio, common.DefaultOperatorRPSRatio),
 		NamespaceReplicationInducingAPIsRPS: dc.GetIntProperty(dynamicconfig.FrontendNamespaceReplicationInducingAPIsRPS, 20),
 
-		MaxNamespaceRPSPerInstance:                                   dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceRPSPerInstance, 2400),
-		MaxNamespaceBurstRatioPerInstance:                            dc.GetFloatPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceBurstRatioPerInstance, 1),
-		MaxConcurrentLongRunningRequestsPerInstance:                  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxConcurrentLongRunningRequestsPerInstance, 1200),
-		MaxGlobalConcurrentLongRunningRequests:                       dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendGlobalMaxConcurrentLongRunningRequests, 0),
-		MaxNamespaceVisibilityRPSPerInstance:                         dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceVisibilityRPSPerInstance, 10),
-		MaxNamespaceVisibilityBurstPerInstance:                       dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceVisibilityBurstPerInstance, 10),
-		MaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:   dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance, 1),
-		MaxNamespaceNamespaceReplicationInducingAPIsBurstPerInstance: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstPerInstance, 10),
+		MaxNamespaceRPSPerInstance:                                        dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceRPSPerInstance, 2400),
+		MaxNamespaceBurstRatioPerInstance:                                 dc.GetFloatPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceBurstRatioPerInstance, 1),
+		MaxConcurrentLongRunningRequestsPerInstance:                       dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxConcurrentLongRunningRequestsPerInstance, 1200),
+		MaxGlobalConcurrentLongRunningRequests:                            dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendGlobalMaxConcurrentLongRunningRequests, 0),
+		MaxNamespaceVisibilityRPSPerInstance:                              dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceVisibilityRPSPerInstance, 10),
+		MaxNamespaceVisibilityBurstRatioPerInstance:                       dc.GetFloatPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceVisibilityBurstRatioPerInstance, 1),
+		MaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:        dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance, 1),
+		MaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance: dc.GetFloatPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance, 10),
 
 		GlobalNamespaceRPS:                     dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendGlobalNamespaceRPS, 0),
 		InternalFEGlobalNamespaceRPS:           dc.GetIntPropertyFilteredByNamespace(dynamicconfig.InternalFrontendGlobalNamespaceRPS, 0),

--- a/tests/dynamicconfig.go
+++ b/tests/dynamicconfig.go
@@ -40,19 +40,19 @@ const NamespaceCacheRefreshInterval = time.Second
 var (
 	// Override values for dynamic configs
 	staticOverrides = map[dynamicconfig.Key]any{
-		dynamicconfig.FrontendRPS:                                    3000,
-		dynamicconfig.FrontendMaxNamespaceVisibilityRPSPerInstance:   50,
-		dynamicconfig.FrontendMaxNamespaceVisibilityBurstPerInstance: 50,
-		dynamicconfig.ReplicationTaskProcessorErrorRetryMaxAttempts:  1,
-		dynamicconfig.SecondaryVisibilityWritingMode:                 visibility.SecondaryVisibilityWritingModeOff,
-		dynamicconfig.WorkflowTaskHeartbeatTimeout:                   5 * time.Second,
-		dynamicconfig.ReplicationTaskFetcherAggregationInterval:      200 * time.Millisecond,
-		dynamicconfig.ReplicationTaskFetcherErrorRetryWait:           50 * time.Millisecond,
-		dynamicconfig.ReplicationTaskProcessorErrorRetryWait:         time.Millisecond,
-		dynamicconfig.ClusterMetadataRefreshInterval:                 100 * time.Millisecond,
-		dynamicconfig.NamespaceCacheRefreshInterval:                  NamespaceCacheRefreshInterval,
-		dynamicconfig.FrontendEnableUpdateWorkflowExecution:          true,
-		dynamicconfig.FrontendAccessHistoryFraction:                  0.5,
+		dynamicconfig.FrontendRPS:                                         3000,
+		dynamicconfig.FrontendMaxNamespaceVisibilityRPSPerInstance:        50,
+		dynamicconfig.FrontendMaxNamespaceVisibilityBurstRatioPerInstance: 1,
+		dynamicconfig.ReplicationTaskProcessorErrorRetryMaxAttempts:       1,
+		dynamicconfig.SecondaryVisibilityWritingMode:                      visibility.SecondaryVisibilityWritingModeOff,
+		dynamicconfig.WorkflowTaskHeartbeatTimeout:                        5 * time.Second,
+		dynamicconfig.ReplicationTaskFetcherAggregationInterval:           200 * time.Millisecond,
+		dynamicconfig.ReplicationTaskFetcherErrorRetryWait:                50 * time.Millisecond,
+		dynamicconfig.ReplicationTaskProcessorErrorRetryWait:              time.Millisecond,
+		dynamicconfig.ClusterMetadataRefreshInterval:                      100 * time.Millisecond,
+		dynamicconfig.NamespaceCacheRefreshInterval:                       NamespaceCacheRefreshInterval,
+		dynamicconfig.FrontendEnableUpdateWorkflowExecution:               true,
+		dynamicconfig.FrontendAccessHistoryFraction:                       0.5,
 	}
 )
 

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -79,7 +79,7 @@ func (s *VersioningIntegSuite) SetupSuite() {
 		dynamicconfig.TaskQueuesPerBuildIdLimit:                  3,
 
 		// Make sure we don't hit the rate limiter in tests
-		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:        1000,
+		dynamicconfig.FrontendGlobalNamespaceNamespaceReplicationInducingAPIsRPS:                1000,
 		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance: 1,
 		dynamicconfig.FrontendNamespaceReplicationInducingAPIsRPS:                               1000,
 

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -79,9 +79,9 @@ func (s *VersioningIntegSuite) SetupSuite() {
 		dynamicconfig.TaskQueuesPerBuildIdLimit:                  3,
 
 		// Make sure we don't hit the rate limiter in tests
-		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:   1000,
-		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstPerInstance: 1000,
-		dynamicconfig.FrontendNamespaceReplicationInducingAPIsRPS:                          1000,
+		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:        1000,
+		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance: 1,
+		dynamicconfig.FrontendNamespaceReplicationInducingAPIsRPS:                               1000,
 
 		// The dispatch tests below rely on being able to see the effects of changing
 		// versioning data relatively quickly. In general we only promise to act on new

--- a/tests/xdc/user_data_replication_test.go
+++ b/tests/xdc/user_data_replication_test.go
@@ -73,12 +73,12 @@ func TestUserDataReplicationTestSuite(t *testing.T) {
 func (s *UserDataReplicationTestSuite) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
 		// Make sure we don't hit the rate limiter in tests
-		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:   1000,
-		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstPerInstance: 1000,
-		dynamicconfig.FrontendNamespaceReplicationInducingAPIsRPS:                          1000,
-		dynamicconfig.FrontendEnableWorkerVersioningDataAPIs:                               true,
-		dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs:                           true,
-		dynamicconfig.BuildIdScavengerEnabled:                                              true,
+		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:        1000,
+		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance: 1,
+		dynamicconfig.FrontendNamespaceReplicationInducingAPIsRPS:                               1000,
+		dynamicconfig.FrontendEnableWorkerVersioningDataAPIs:                                    true,
+		dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs:                                true,
+		dynamicconfig.BuildIdScavengerEnabled:                                                   true,
 		// Ensure the scavenger can immediately delete build ids that are not in use.
 		dynamicconfig.RemovableBuildIdDurationSinceDefault: time.Microsecond,
 	}

--- a/tests/xdc/user_data_replication_test.go
+++ b/tests/xdc/user_data_replication_test.go
@@ -73,7 +73,7 @@ func TestUserDataReplicationTestSuite(t *testing.T) {
 func (s *UserDataReplicationTestSuite) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
 		// Make sure we don't hit the rate limiter in tests
-		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:        1000,
+		dynamicconfig.FrontendGlobalNamespaceNamespaceReplicationInducingAPIsRPS:                1000,
 		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance: 1,
 		dynamicconfig.FrontendNamespaceReplicationInducingAPIsRPS:                               1000,
 		dynamicconfig.FrontendEnableWorkerVersioningDataAPIs:                                    true,


### PR DESCRIPTION
## What changed?
Removing `frontend.namespaceBurst` and adding `frontend.namespaceBurstRatio` config.
Similarly replacing `frontend.namespaceBurst.visibility` and `frontend.namespaceBurst.namespaceReplicationInducingAPIs` with `frontend.namespaceBurstRatio.visibility` and `frontend.namespaceBurstRatio.namespaceReplicationInducingAPIs`.

## Why?
With current configuration it is not possible to set a good default value for namespaceBurst.
If we don't want to allow burst, namespaceBurst should be equal to namespaceRPS. If the burst value is less than RPS, the effective RPS will be the value of burst.
This creates a problem when we need to change namespaceRPS for individual namespaces.  namespaceBurst should also be adjusted along with namespaceRPS.

Replacing namespaceBurst with namespaceBurstRatio will fix this problem. We can set the default value to 1 not allowing burst by default.

Similarly changing `frontend.namespaceBurst.visibility` and `frontend.namespaceBurst.namespaceReplicationInducingAPIs` to ratios.

## How did you test it?
Unit test

## Potential risks
None

## Documentation
Changes in dynamic config names should be documented in the next version's release notes.

## Is hotfix candidate?
No
