### PR TITLE
Ensure we don't open sqlite multiple times

### DIFF
--- a/common/persistence/sql/sqlplugin/sqlite/plugin.go
+++ b/common/persistence/sql/sqlplugin/sqlite/plugin.go
@@ -29,10 +29,12 @@ package sqlite
 import (
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/iancoleman/strcase"
 	"github.com/jmoiron/sqlx"
+	"golang.org/x/exp/maps"
 
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/persistence/sql"
@@ -185,9 +187,14 @@ func buildDSN(cfg *config.SQL) (string, error) {
 
 func buildDSNAttr(cfg *config.SQL) (url.Values, error) {
 	parameters := url.Values{}
-	for k, v := range cfg.ConnectAttributes {
+
+	// sort ConnectAttributes to get a deterministic order
+	keys := maps.Keys(cfg.ConnectAttributes)
+	sort.Strings(keys)
+
+	for _, k := range keys {
 		key := strings.TrimSpace(k)
-		value := strings.TrimSpace(v)
+		value := strings.TrimSpace(cfg.ConnectAttributes[k])
 		if parameters.Get(key) != "" {
 			return nil, fmt.Errorf("duplicate connection attr: %v:%v, %v:%v",
 				key,


### PR DESCRIPTION
## What changed?
Sort sqlite connect attributes to ensure a deterministic string so the sqlite pool logic works correctly.

## Why?
I noticed a lot of `database is locked (5) (SQLITE_BUSY)` errors when using a local dev server, and tracked it down to multiple services having separate connection to the db. The sqlite connection pool is supposed to prevent this, but it depends on the mapping from `ConnectAttributes` to a string being deterministic. The code that constructed the string was iterating over a `map[string]string` without sorting the keys making it nondeterministic.

## How did you test it?
local testing, saw no more SQLITE_BUSY errors