### PR TITLE
Config to specify error substrings to DLQ task processing errors

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -884,9 +884,12 @@ const (
 	HistoryTaskDLQEnabled = "history.TaskDLQEnabled"
 	// HistoryTaskDLQUnexpectedErrorAttempts is the number of task execution attempts before sending the task to DLQ.
 	HistoryTaskDLQUnexpectedErrorAttempts = "history.TaskDLQUnexpectedErrorAttempts"
-	// HistoryTaskDLQInteralErrors causes history task processing to send tasks failing with serviceerror.Internal to
+	// HistoryTaskDLQInternalErrors causes history task processing to send tasks failing with serviceerror.Internal to
 	// the dlq (or will drop them if not enabled)
 	HistoryTaskDLQInternalErrors = "history.TaskDLQInternalErrors"
+	// HistoryTaskDLQErrorSubStrings specifies a comma separated list of substring. If task processing error contains
+	// any of these strings, those tasks will be sent to DLQ.
+	HistoryTaskDLQErrorSubStrings = "history.DLQErrorSubStrings"
 
 	// ReplicationStreamSyncStatusDuration sync replication status duration
 	ReplicationStreamSyncStatusDuration = "history.ReplicationStreamSyncStatusDuration"

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -889,7 +889,7 @@ const (
 	HistoryTaskDLQInternalErrors = "history.TaskDLQInternalErrors"
 	// HistoryTaskDLQErrorPattern specifies a regular expression. If a task processing error matches with this regex,
 	// that task will be sent to DLQ.
-HistoryTaskDLQErrorPattern = "history.TaskDLQErrorPattern"
+	HistoryTaskDLQErrorPattern = "history.TaskDLQErrorPattern"
 
 	// ReplicationStreamSyncStatusDuration sync replication status duration
 	ReplicationStreamSyncStatusDuration = "history.ReplicationStreamSyncStatusDuration"

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -887,9 +887,9 @@ const (
 	// HistoryTaskDLQInternalErrors causes history task processing to send tasks failing with serviceerror.Internal to
 	// the dlq (or will drop them if not enabled)
 	HistoryTaskDLQInternalErrors = "history.TaskDLQInternalErrors"
-	// HistoryTaskDLQErrorSubStrings specifies a comma separated list of strings. If a task processing error contains
-	// any of these strings, that task will be sent to DLQ.
-	HistoryTaskDLQErrorSubStrings = "history.DLQErrorSubStrings"
+	// HistoryTaskDLQErrorPattern specifies a regular expression. If a task processing error matches with this regex,
+	// that task will be sent to DLQ.
+	HistoryTaskDLQErrorPattern = "history.DLQErrorPattern"
 
 	// ReplicationStreamSyncStatusDuration sync replication status duration
 	ReplicationStreamSyncStatusDuration = "history.ReplicationStreamSyncStatusDuration"

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -889,7 +889,7 @@ const (
 	HistoryTaskDLQInternalErrors = "history.TaskDLQInternalErrors"
 	// HistoryTaskDLQErrorPattern specifies a regular expression. If a task processing error matches with this regex,
 	// that task will be sent to DLQ.
-	HistoryTaskDLQErrorPattern = "history.DLQErrorPattern"
+HistoryTaskDLQErrorPattern = "history.TaskDLQErrorPattern"
 
 	// ReplicationStreamSyncStatusDuration sync replication status duration
 	ReplicationStreamSyncStatusDuration = "history.ReplicationStreamSyncStatusDuration"

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -887,8 +887,8 @@ const (
 	// HistoryTaskDLQInternalErrors causes history task processing to send tasks failing with serviceerror.Internal to
 	// the dlq (or will drop them if not enabled)
 	HistoryTaskDLQInternalErrors = "history.TaskDLQInternalErrors"
-	// HistoryTaskDLQErrorSubStrings specifies a comma separated list of substring. If task processing error contains
-	// any of these strings, those tasks will be sent to DLQ.
+	// HistoryTaskDLQErrorSubStrings specifies a comma separated list of strings. If a task processing error contains
+	// any of these strings, that task will be sent to DLQ.
 	HistoryTaskDLQErrorSubStrings = "history.DLQErrorSubStrings"
 
 	// ReplicationStreamSyncStatusDuration sync replication status duration

--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -186,7 +186,7 @@ func (f *archivalQueueFactory) newScheduledQueue(shard shard.Context, executor q
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
 		f.Config.TaskDLQInternalErrors,
-		f.Config.TaskDLQErrorSubStrings,
+		f.Config.TaskDLQErrorPattern,
 	)
 	return queues.NewScheduledQueue(
 		shard,

--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -186,6 +186,7 @@ func (f *archivalQueueFactory) newScheduledQueue(shard shard.Context, executor q
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
 		f.Config.TaskDLQInternalErrors,
+		f.Config.TaskDLQErrorSubStrings,
 	)
 	return queues.NewScheduledQueue(
 		shard,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -113,7 +113,7 @@ type Config struct {
 	TaskDLQEnabled                 dynamicconfig.BoolPropertyFn
 	TaskDLQUnexpectedErrorAttempts dynamicconfig.IntPropertyFn
 	TaskDLQInternalErrors          dynamicconfig.BoolPropertyFn
-	TaskDLQErrorSubStrings         dynamicconfig.StringPropertyFn
+	TaskDLQErrorPattern            dynamicconfig.StringPropertyFn
 
 	TaskSchedulerEnableRateLimiter           dynamicconfig.BoolPropertyFn
 	TaskSchedulerEnableRateLimiterShadowMode dynamicconfig.BoolPropertyFn
@@ -415,7 +415,7 @@ func NewConfig(
 		TaskDLQEnabled:                 dc.GetBoolProperty(dynamicconfig.HistoryTaskDLQEnabled, true),
 		TaskDLQUnexpectedErrorAttempts: dc.GetIntProperty(dynamicconfig.HistoryTaskDLQUnexpectedErrorAttempts, 100),
 		TaskDLQInternalErrors:          dc.GetBoolProperty(dynamicconfig.HistoryTaskDLQInternalErrors, false),
-		TaskDLQErrorSubStrings:         dc.GetStringProperty(dynamicconfig.HistoryTaskDLQErrorSubStrings, ""),
+		TaskDLQErrorPattern:            dc.GetStringProperty(dynamicconfig.HistoryTaskDLQErrorPattern, ""),
 
 		TaskSchedulerEnableRateLimiter:           dc.GetBoolProperty(dynamicconfig.TaskSchedulerEnableRateLimiter, false),
 		TaskSchedulerEnableRateLimiterShadowMode: dc.GetBoolProperty(dynamicconfig.TaskSchedulerEnableRateLimiterShadowMode, true),

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -113,6 +113,7 @@ type Config struct {
 	TaskDLQEnabled                 dynamicconfig.BoolPropertyFn
 	TaskDLQUnexpectedErrorAttempts dynamicconfig.IntPropertyFn
 	TaskDLQInternalErrors          dynamicconfig.BoolPropertyFn
+	TaskDLQErrorSubStrings         dynamicconfig.StringPropertyFn
 
 	TaskSchedulerEnableRateLimiter           dynamicconfig.BoolPropertyFn
 	TaskSchedulerEnableRateLimiterShadowMode dynamicconfig.BoolPropertyFn
@@ -414,6 +415,7 @@ func NewConfig(
 		TaskDLQEnabled:                 dc.GetBoolProperty(dynamicconfig.HistoryTaskDLQEnabled, true),
 		TaskDLQUnexpectedErrorAttempts: dc.GetIntProperty(dynamicconfig.HistoryTaskDLQUnexpectedErrorAttempts, 100),
 		TaskDLQInternalErrors:          dc.GetBoolProperty(dynamicconfig.HistoryTaskDLQInternalErrors, false),
+		TaskDLQErrorSubStrings:         dc.GetStringProperty(dynamicconfig.HistoryTaskDLQErrorSubStrings, ""),
 
 		TaskSchedulerEnableRateLimiter:           dc.GetBoolProperty(dynamicconfig.TaskSchedulerEnableRateLimiter, false),
 		TaskSchedulerEnableRateLimiterShadowMode: dc.GetBoolProperty(dynamicconfig.TaskSchedulerEnableRateLimiterShadowMode, true),

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -175,6 +175,7 @@ func (f *outboundQueueFactory) CreateQueue(
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
 		f.Config.TaskDLQInternalErrors,
+		f.Config.TaskDLQErrorSubStrings,
 	)
 	return queues.NewImmediateQueue(
 		shardContext,

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -175,7 +175,7 @@ func (f *outboundQueueFactory) CreateQueue(
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
 		f.Config.TaskDLQInternalErrors,
-		f.Config.TaskDLQErrorSubStrings,
+		f.Config.TaskDLQErrorPattern,
 	)
 	return queues.NewImmediateQueue(
 		shardContext,

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"math"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
@@ -198,12 +199,14 @@ type (
 		unexpectedErrorAttempts    int
 		maxUnexpectedErrorAttempts dynamicconfig.IntPropertyFn
 		dlqInternalErrors          dynamicconfig.BoolPropertyFn
+		dlqErrorSubStrings         dynamicconfig.StringPropertyFn
 	}
 	ExecutableParams struct {
 		DLQEnabled                 dynamicconfig.BoolPropertyFn
 		DLQWriter                  *DLQWriter
 		MaxUnexpectedErrorAttempts dynamicconfig.IntPropertyFn
 		DLQInternalErrors          dynamicconfig.BoolPropertyFn
+		DLQErrorSubStrings         dynamicconfig.StringPropertyFn
 	}
 	ExecutableOption func(*ExecutableParams)
 )
@@ -232,6 +235,9 @@ func NewExecutable(
 		},
 		DLQInternalErrors: func() bool {
 			return false
+		},
+		DLQErrorSubStrings: func() string {
+			return ""
 		},
 	}
 	for _, opt := range opts {
@@ -262,6 +268,7 @@ func NewExecutable(
 		dlqEnabled:                 params.DLQEnabled,
 		maxUnexpectedErrorAttempts: params.MaxUnexpectedErrorAttempts,
 		dlqInternalErrors:          params.DLQInternalErrors,
+		dlqErrorSubStrings:         params.DLQErrorSubStrings,
 	}
 	executable.updatePriority()
 	return executable
@@ -505,6 +512,23 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 			}
 		}
 	}()
+
+	dlqErrSubStrings := e.dlqErrorSubStrings()
+	if len(dlqErrSubStrings) > 0 {
+		subStrings := strings.Split(dlqErrSubStrings, ",")
+		for _, subStr := range subStrings {
+			if len(subStr) > 0 && strings.Contains(err.Error(), subStr) {
+				e.logger.Error(
+					fmt.Sprintf("Error matches with %s. Marking task as terminally failed, will send to DLQ",
+						dynamicconfig.HistoryTaskDLQErrorSubStrings),
+					tag.Error(err),
+					tag.ErrorType(err))
+				e.terminalFailureCause = err
+				metrics.TaskTerminalFailures.With(e.taggedMetricsHandler).Record(1)
+				return fmt.Errorf("%w: %v", ErrTerminalTaskFailure, err)
+			}
+		}
+	}
 
 	if e.isSafeToDropError(err) {
 		return nil

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -514,7 +514,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 	}()
 
 	if len(e.dlqErrorPattern()) > 0 {
-		match, mErr := regexp.Match(e.dlqErrorPattern(), []byte(err.Error()))
+		match, mErr := regexp.MatchString(e.dlqErrorPattern(), err.Error())
 		if mErr != nil {
 			e.logger.Error(fmt.Sprintf("Failed to match task processing error with %s", dynamicconfig.HistoryTaskDLQErrorPattern))
 		} else if match {

--- a/service/history/queues/executable_factory.go
+++ b/service/history/queues/executable_factory.go
@@ -56,6 +56,7 @@ type (
 		dlqEnabled                 dynamicconfig.BoolPropertyFn
 		attemptsBeforeSendingToDlq dynamicconfig.IntPropertyFn
 		dlqInternalErrors          dynamicconfig.BoolPropertyFn
+		dlqErrorSubStrings         dynamicconfig.StringPropertyFn
 	}
 )
 
@@ -77,6 +78,7 @@ func NewExecutableFactory(
 	dlqEnabled dynamicconfig.BoolPropertyFn,
 	attemptsBeforeSendingToDlq dynamicconfig.IntPropertyFn,
 	dlqInternalErrors dynamicconfig.BoolPropertyFn,
+	dlqErrorSubStrings dynamicconfig.StringPropertyFn,
 ) *executableFactoryImpl {
 	return &executableFactoryImpl{
 		executor:                   executor,
@@ -92,6 +94,7 @@ func NewExecutableFactory(
 		dlqEnabled:                 dlqEnabled,
 		attemptsBeforeSendingToDlq: attemptsBeforeSendingToDlq,
 		dlqInternalErrors:          dlqInternalErrors,
+		dlqErrorSubStrings:         dlqErrorSubStrings,
 	}
 }
 
@@ -113,6 +116,7 @@ func (f *executableFactoryImpl) NewExecutable(task tasks.Task, readerID int64) E
 			params.DLQWriter = f.dlqWriter
 			params.MaxUnexpectedErrorAttempts = f.attemptsBeforeSendingToDlq
 			params.DLQInternalErrors = f.dlqInternalErrors
+			params.DLQErrorSubStrings = f.dlqErrorSubStrings
 		},
 	)
 }

--- a/service/history/queues/executable_factory.go
+++ b/service/history/queues/executable_factory.go
@@ -56,7 +56,7 @@ type (
 		dlqEnabled                 dynamicconfig.BoolPropertyFn
 		attemptsBeforeSendingToDlq dynamicconfig.IntPropertyFn
 		dlqInternalErrors          dynamicconfig.BoolPropertyFn
-		dlqErrorSubStrings         dynamicconfig.StringPropertyFn
+		dlqErrorPattern            dynamicconfig.StringPropertyFn
 	}
 )
 
@@ -78,7 +78,7 @@ func NewExecutableFactory(
 	dlqEnabled dynamicconfig.BoolPropertyFn,
 	attemptsBeforeSendingToDlq dynamicconfig.IntPropertyFn,
 	dlqInternalErrors dynamicconfig.BoolPropertyFn,
-	dlqErrorSubStrings dynamicconfig.StringPropertyFn,
+	dlqErrorPattern dynamicconfig.StringPropertyFn,
 ) *executableFactoryImpl {
 	return &executableFactoryImpl{
 		executor:                   executor,
@@ -94,7 +94,7 @@ func NewExecutableFactory(
 		dlqEnabled:                 dlqEnabled,
 		attemptsBeforeSendingToDlq: attemptsBeforeSendingToDlq,
 		dlqInternalErrors:          dlqInternalErrors,
-		dlqErrorSubStrings:         dlqErrorSubStrings,
+		dlqErrorPattern:            dlqErrorPattern,
 	}
 }
 
@@ -116,7 +116,7 @@ func (f *executableFactoryImpl) NewExecutable(task tasks.Task, readerID int64) E
 			params.DLQWriter = f.dlqWriter
 			params.MaxUnexpectedErrorAttempts = f.attemptsBeforeSendingToDlq
 			params.DLQInternalErrors = f.dlqInternalErrors
-			params.DLQErrorSubStrings = f.dlqErrorSubStrings
+			params.DLQErrorPattern = f.dlqErrorPattern
 		},
 	)
 }

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -577,6 +577,9 @@ func (s *queueBaseSuite) newQueueBase(
 		func() bool {
 			return false
 		},
+		func() string {
+			return ""
+		},
 	)
 	return newQueueBase(
 		mockShard,

--- a/service/history/queues/queue_scheduled_test.go
+++ b/service/history/queues/queue_scheduled_test.go
@@ -150,6 +150,9 @@ func (s *scheduledQueueSuite) SetupTest() {
 		func() bool {
 			return false
 		},
+		func() string {
+			return ""
+		},
 	)
 	s.scheduledQueue = NewScheduledQueue(
 		s.mockShard,

--- a/service/history/timer_queue_factory.go
+++ b/service/history/timer_queue_factory.go
@@ -220,6 +220,7 @@ func (f *timerQueueFactory) CreateQueue(
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
 		f.Config.TaskDLQInternalErrors,
+		f.Config.TaskDLQErrorSubStrings,
 	)
 	return queues.NewScheduledQueue(
 		shard,

--- a/service/history/timer_queue_factory.go
+++ b/service/history/timer_queue_factory.go
@@ -220,7 +220,7 @@ func (f *timerQueueFactory) CreateQueue(
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
 		f.Config.TaskDLQInternalErrors,
-		f.Config.TaskDLQErrorSubStrings,
+		f.Config.TaskDLQErrorPattern,
 	)
 	return queues.NewScheduledQueue(
 		shard,

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -213,6 +213,7 @@ func (f *transferQueueFactory) CreateQueue(
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
 		f.Config.TaskDLQInternalErrors,
+		f.Config.TaskDLQErrorSubStrings,
 	)
 	return queues.NewImmediateQueue(
 		shard,

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -213,7 +213,7 @@ func (f *transferQueueFactory) CreateQueue(
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
 		f.Config.TaskDLQInternalErrors,
-		f.Config.TaskDLQErrorSubStrings,
+		f.Config.TaskDLQErrorPattern,
 	)
 	return queues.NewImmediateQueue(
 		shard,

--- a/service/history/visibility_queue_factory.go
+++ b/service/history/visibility_queue_factory.go
@@ -143,7 +143,7 @@ func (f *visibilityQueueFactory) CreateQueue(
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
 		f.Config.TaskDLQInternalErrors,
-		f.Config.TaskDLQErrorSubStrings,
+		f.Config.TaskDLQErrorPattern,
 	)
 	return queues.NewImmediateQueue(
 		shard,

--- a/service/history/visibility_queue_factory.go
+++ b/service/history/visibility_queue_factory.go
@@ -143,6 +143,7 @@ func (f *visibilityQueueFactory) CreateQueue(
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
 		f.Config.TaskDLQInternalErrors,
+		f.Config.TaskDLQErrorSubStrings,
 	)
 	return queues.NewImmediateQueue(
 		shard,


### PR DESCRIPTION
## What changed?
Adding a new config history.DLQErrorSubStrings to specify substrings in task processing error strings.
If the error contains this substring, this task will be enqueued to DLQ.

## Why?
Gives the ability to send tasks to DLQ based on errors.

## How did you test it?
Unit tests

## Potential risks
None

## Documentation
None

## Is hotfix candidate?
No
