### PR TITLE
docs(archival): Adds permissions for s3 archival

### DIFF
--- a/common/archiver/s3store/README.md
+++ b/common/archiver/s3store/README.md
@@ -83,6 +83,14 @@ Enable AWS SDK Logging with config parameter `logLevel`. For example enable debu
 * LogDebugWithDeprecated = 4128 = 0x1020
 
 
+## Permissions
+
+Your s3 user must have at least the following permissions:
+
+* s3:ListBucket
+* s3:GetObject
+* s3:PutObject
+
 ## Using localstack for local development
 1. Install awscli from [here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 2. Install localstack from [here](https://github.com/localstack/localstack#installing)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Added permissions for s3 user on self-hosted archival configuration

## Why?
<!-- Tell your future self why have you made these changes -->
I struggled to find any information about it. And managed to find it only in the source code.
I did not want to grant any unnecessary permissions to user that will only archive workflows.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
I did not test these changes. Because, I changed only README file.
However, things that I wrote in documentation helped me to configure archival

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
-

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
-

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
