### PR TITLE
Add history.enableMutableStateTransitionHistory feature flag

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -547,6 +547,10 @@ const (
 	HistoryCacheHostLevelMaxSizeBytes = "history.hostLevelCacheMaxSizeBytes"
 	// EnableAPIGetCurrentRunIDLock controls if a lock should be acquired before getting current run ID for API requests
 	EnableAPIGetCurrentRunIDLock = "history.enableAPIGetCurrentRunIDLock"
+	// EnableMutableStateTransitionHistory controls whether to record state transition history in mutable state records.
+	// The feature is used in the hierarchical state machine framework and is considered unstable as the structure may
+	// change with the pending replication design.
+	EnableMutableStateTransitionHistory = "history.enableMutableStateTransitionHistory"
 	// HistoryStartupMembershipJoinDelay is the duration a history instance waits
 	// before joining membership after starting.
 	HistoryStartupMembershipJoinDelay = "history.startupMembershipJoinDelay"

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -387,7 +387,7 @@ func NewConfig(
 		HistoryCacheNonUserContextLockTimeout: dc.GetDurationProperty(dynamicconfig.HistoryCacheNonUserContextLockTimeout, 500*time.Millisecond),
 		EnableHostLevelHistoryCache:           dc.GetBoolProperty(dynamicconfig.EnableHostHistoryCache, false),
 		EnableAPIGetCurrentRunIDLock:          dc.GetBoolProperty(dynamicconfig.EnableAPIGetCurrentRunIDLock, false),
-		EnableMutableStateTransitionHistory:   dc.GetBoolProperty(dynamicconfig.EnableAPIGetCurrentRunIDLock, false),
+		EnableMutableStateTransitionHistory:   dc.GetBoolProperty(dynamicconfig.EnableMutableStateTransitionHistory, false),
 
 		EventsShardLevelCacheMaxSizeBytes: dc.GetIntProperty(dynamicconfig.EventsCacheMaxSizeBytes, 512*1024),              // 512KB
 		EventsHostLevelCacheMaxSizeBytes:  dc.GetIntProperty(dynamicconfig.EventsHostLevelCacheMaxSizeBytes, 512*512*1024), // 256MB

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -80,6 +80,7 @@ type Config struct {
 	HistoryCacheNonUserContextLockTimeout dynamicconfig.DurationPropertyFn
 	EnableHostLevelHistoryCache           dynamicconfig.BoolPropertyFn
 	EnableAPIGetCurrentRunIDLock          dynamicconfig.BoolPropertyFn
+	EnableMutableStateTransitionHistory   dynamicconfig.BoolPropertyFn
 
 	// EventsCache settings
 	// Change of these configs require shard restart
@@ -386,6 +387,7 @@ func NewConfig(
 		HistoryCacheNonUserContextLockTimeout: dc.GetDurationProperty(dynamicconfig.HistoryCacheNonUserContextLockTimeout, 500*time.Millisecond),
 		EnableHostLevelHistoryCache:           dc.GetBoolProperty(dynamicconfig.EnableHostHistoryCache, false),
 		EnableAPIGetCurrentRunIDLock:          dc.GetBoolProperty(dynamicconfig.EnableAPIGetCurrentRunIDLock, false),
+		EnableMutableStateTransitionHistory:   dc.GetBoolProperty(dynamicconfig.EnableAPIGetCurrentRunIDLock, false),
 
 		EventsShardLevelCacheMaxSizeBytes: dc.GetIntProperty(dynamicconfig.EventsCacheMaxSizeBytes, 512*1024),              // 512KB
 		EventsHostLevelCacheMaxSizeBytes:  dc.GetIntProperty(dynamicconfig.EventsHostLevelCacheMaxSizeBytes, 512*512*1024), // 256MB

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -190,5 +190,6 @@ func NewDynamicConfig() *configs.Config {
 	config.NamespaceCacheRefreshInterval = dynamicconfig.GetDurationPropertyFn(time.Second)
 	config.EnableAPIGetCurrentRunIDLock = dynamicconfig.GetBoolPropertyFn(true)
 	config.FrontendAccessHistoryFraction = dynamicconfig.GetFloatPropertyFn(1.0)
+	config.EnableMutableStateTransitionHistory = dynamicconfig.GetBoolPropertyFn(true)
 	return config
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4790,11 +4790,13 @@ func (ms *MutableStateImpl) prepareCloseTransaction(
 
 	ms.executionInfo.StateTransitionCount += 1
 
-	ms.executionInfo.TransitionHistory = UpdatedTransitionHistory(
-		ms.executionInfo.TransitionHistory,
-		ms.currentTransactionNamespaceFailoverVersion,
-		ms.executionInfo.StateTransitionCount,
-	)
+	if ms.config.EnableMutableStateTransitionHistory() {
+		ms.executionInfo.TransitionHistory = UpdatedTransitionHistory(
+			ms.executionInfo.TransitionHistory,
+			ms.currentTransactionNamespaceFailoverVersion,
+			ms.executionInfo.StateTransitionCount,
+		)
+	}
 
 	// TODO(bergundy): Collapse timer tasks.
 	if err := ms.taskGenerator.GenerateDirtySubStateMachineTasks(ms.shard.StateMachineRegistry()); err != nil {

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -248,9 +248,14 @@ func (r *TaskGeneratorImpl) GenerateDirtySubStateMachineTasks(
 	stateMachineRegistry *hsm.Registry,
 ) error {
 	tree := r.mutableState.HSM()
+	// Early return here to avoid accessing the transition history. It may be disabled via dynamic config.
+	outputs := tree.Outputs()
+	if len(outputs) == 0 {
+		return nil
+	}
 	transitionHistory := r.mutableState.GetExecutionInfo().TransitionHistory
 	versionedTransition := transitionHistory[len(transitionHistory)-1]
-	for _, pao := range tree.Outputs() {
+	for _, pao := range outputs {
 		node, err := tree.Child(pao.Path)
 		if err != nil {
 			return err

--- a/tests/functional.go
+++ b/tests/functional.go
@@ -53,9 +53,10 @@ type (
 
 func (s *FunctionalSuite) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
-		dynamicconfig.RetentionTimerJitterDuration: time.Second,
-		dynamicconfig.EnableEagerWorkflowStart:     true,
-		dynamicconfig.OutboundProcessorEnabled:     true,
+		dynamicconfig.RetentionTimerJitterDuration:        time.Second,
+		dynamicconfig.EnableEagerWorkflowStart:            true,
+		dynamicconfig.EnableMutableStateTransitionHistory: true,
+		dynamicconfig.OutboundProcessorEnabled:            true,
 	}
 	s.setupSuite("testdata/es_cluster.yaml")
 }


### PR DESCRIPTION
## What changed and why?

> 	// EnableMutableStateTransitionHistory controls whether to record state transition history in mutable state records.
	// The feature is used in the hierarchical state machine framework and is considered unstable as the structure may
	// change with the pending replication design.