### PR TITLE
Fix parse ExecutionDuration value as quoted integer

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/query_interceptors_test.go
+++ b/common/persistence/visibility/store/elasticsearch/query_interceptors_test.go
@@ -161,7 +161,7 @@ func (s *QueryInterceptorSuite) TestDurationProcessFunc() {
 		value     interface{}
 		returnErr bool
 	}{
-		{value: nil, returnErr: true},
+		{value: int64(1), returnErr: false},
 		{value: int64(1), returnErr: false},
 		{value: int64(18180000000000), returnErr: false},
 		{value: int64(1000000000), returnErr: false},

--- a/common/persistence/visibility/store/query/util.go
+++ b/common/persistence/visibility/store/query/util.go
@@ -1,0 +1,46 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package query
+
+import (
+	"strconv"
+	"time"
+
+	"go.temporal.io/server/common/primitives/timestamp"
+)
+
+func ParseExecutionDurationStr(durationStr string) (time.Duration, error) {
+	if durationNanos, err := strconv.ParseInt(durationStr, 10, 64); err == nil {
+		return time.Duration(durationNanos), nil
+	}
+
+	// To support durations passed as golang durations such as "300ms", "-1.5h" or "2h45m".
+	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	// Custom timestamp.ParseDuration also supports "d" as additional unit for days.
+	if duration, err := timestamp.ParseDuration(durationStr); err == nil {
+		return duration, nil
+	}
+
+	// To support "hh:mm:ss" durations.
+	return timestamp.ParseHHMMSSDuration(durationStr)
+}

--- a/common/persistence/visibility/store/query/util_test.go
+++ b/common/persistence/visibility/store/query/util_test.go
@@ -1,0 +1,85 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package query
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseExecutionDurationStr(t *testing.T) {
+	s := assert.New(t)
+
+	testCases := []struct {
+		input         string
+		expectedValue time.Duration
+		expectedErr   error
+	}{
+		{
+			input:         "123",
+			expectedValue: time.Duration(123),
+		},
+		{
+			input:         "123s",
+			expectedValue: 123 * time.Second,
+		},
+		{
+			input:         "123m",
+			expectedValue: 123 * time.Minute,
+		},
+		{
+			input:         "123h",
+			expectedValue: 123 * time.Hour,
+		},
+		{
+			input:         "123d",
+			expectedValue: 123 * 24 * time.Hour,
+		},
+		{
+			input:         "01:02:03",
+			expectedValue: 1*time.Hour + 2*time.Minute + 3*time.Second,
+		},
+		{
+			input:       "01:60:03",
+			expectedErr: errors.New("invalid duration"),
+		},
+		{
+			input:       "123q",
+			expectedErr: errors.New("invalid duration"),
+		},
+	}
+
+	for _, tc := range testCases {
+		got, err := ParseExecutionDurationStr(tc.input)
+		if tc.expectedErr == nil {
+			s.Equal(tc.expectedValue, got)
+			s.NoError(err)
+		} else {
+			s.Error(err)
+			s.Contains(err.Error(), tc.expectedErr.Error())
+		}
+	}
+}

--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -37,7 +37,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
-	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
 )
 
@@ -643,20 +642,12 @@ func (c *QueryConverter) parseSQLVal(
 
 	if saName == searchattribute.ExecutionDuration {
 		if durationStr, isString := value.(string); isString {
-			// To support durations passed as golang durations such as "300ms", "-1.5h" or "2h45m".
-			// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-			// Custom timestamp.ParseDuration also supports "d" as additional unit for days.
-			if duration, err := timestamp.ParseDuration(durationStr); err == nil {
-				value = duration.Nanoseconds()
-			} else {
-				// To support "hh:mm:ss" durations.
-				duration, err := timestamp.ParseHHMMSSDuration(durationStr)
-				if err != nil {
-					return nil, query.NewConverterError(
-						"invalid value for search attribute %s: %v (%v)", saName, value, err)
-				}
-				value = duration.Nanoseconds()
+			duration, err := query.ParseExecutionDurationStr(durationStr)
+			if err != nil {
+				return nil, query.NewConverterError(
+					"invalid value for search attribute %s: %v (%v)", saName, value, err)
 			}
+			value = duration.Nanoseconds()
 		}
 	}
 

--- a/common/persistence/visibility/store/sql/query_converter_test.go
+++ b/common/persistence/visibility/store/sql/query_converter_test.go
@@ -860,15 +860,35 @@ func (s *queryConverterSuite) TestParseSQLVal() {
 			err:      nil,
 		},
 		{
-			name:  "invalid ExecutionDuration",
+			name:  "valid ExecutionDuration string nanos",
 			input: "'100'",
+			args: map[string]any{
+				"saName": "ExecutionDuration",
+				"saType": enumspb.INDEXED_VALUE_TYPE_INT,
+			},
+			retValue: int64(100),
+			err:      nil,
+		},
+		{
+			name:  "valid ExecutionDuration int nanos",
+			input: "100",
+			args: map[string]any{
+				"saName": "ExecutionDuration",
+				"saType": enumspb.INDEXED_VALUE_TYPE_INT,
+			},
+			retValue: int64(100),
+			err:      nil,
+		},
+		{
+			name:  "invalid ExecutionDuration",
+			input: "'100q'",
 			args: map[string]any{
 				"saName": "ExecutionDuration",
 				"saType": enumspb.INDEXED_VALUE_TYPE_INT,
 			},
 			retValue: nil,
 			err: query.NewConverterError(
-				"invalid value for search attribute ExecutionDuration: 100 (invalid duration)"),
+				"invalid value for search attribute ExecutionDuration: 100q (invalid duration)"),
 		},
 		{
 			name:  "invalid ExecutionDuration out of bounds",


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix parse ExecutionDuration value as quoted integer.

## Why?
<!-- Tell your future self why have you made these changes -->
It used to work when querying `ExecutionDuration='123'`.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
