### PR TITLE
Fix comments broken by bad refactor

### DIFF
--- a/common/nexus/routes.go
+++ b/common/nexus/routes.go
@@ -44,13 +44,13 @@ type NamespaceAndTaskQueue struct {
 var routes = RouteSet{
 	DispatchNexusTaskByNamespaceAndTaskQueue: routing.NewBuilder[NamespaceAndTaskQueue]().
 		Constant("api", "v1", "namespaces").
-		Variable("namespace", func(params *NamespaceAndTaskQueue) *string { return &params.Namespace }).
+		StringVariable("namespace", func(params *NamespaceAndTaskQueue) *string { return &params.Namespace }).
 		Constant("task-queues").
-		Variable("task_queue", func(params *NamespaceAndTaskQueue) *string { return &params.TaskQueue }).
+		StringVariable("task_queue", func(params *NamespaceAndTaskQueue) *string { return &params.TaskQueue }).
 		Constant("dispatch-nexus-task").
 		Build(),
 	DispatchNexusTaskByService: routing.NewBuilder[string]().
 		Constant("api", "v1", "services").
-		Variable("service", func(service *string) *string { return service }).
+		StringVariable("service", func(service *string) *string { return service }).
 		Build(),
 }

--- a/common/persistence/cassandra/execution_store.go
+++ b/common/persistence/cassandra/execution_store.go
@@ -42,19 +42,19 @@ import (
 const (
 	// Special Run IDs
 	permanentRunID = "30000000-0000-f000-f000-000000000001"
-	// Row Constant for Shard Row
+	// Row Constants for Shard Row
 	rowTypeShardNamespaceID = "10000000-1000-f000-f000-000000000000"
 	rowTypeShardWorkflowID  = "20000000-1000-f000-f000-000000000000"
 	rowTypeShardRunID       = "30000000-1000-f000-f000-000000000000"
-	// Row Constant for Transfer Task Row
+	// Row Constants for Transfer Task Row
 	rowTypeTransferNamespaceID = "10000000-3000-f000-f000-000000000000"
 	rowTypeTransferWorkflowID  = "20000000-3000-f000-f000-000000000000"
 	rowTypeTransferRunID       = "30000000-3000-f000-f000-000000000000"
-	// Row Constant for Timer Task Row
+	// Row Constants for Timer Task Row
 	rowTypeTimerNamespaceID = "10000000-4000-f000-f000-000000000000"
 	rowTypeTimerWorkflowID  = "20000000-4000-f000-f000-000000000000"
 	rowTypeTimerRunID       = "30000000-4000-f000-f000-000000000000"
-	// Row Constant for Replication Task Row
+	// Row Constants for Replication Task Row
 	rowTypeReplicationNamespaceID = "10000000-5000-f000-f000-000000000000"
 	rowTypeReplicationWorkflowID  = "20000000-5000-f000-f000-000000000000"
 	rowTypeReplicationRunID       = "30000000-5000-f000-f000-000000000000"
@@ -62,7 +62,7 @@ const (
 	rowTypeVisibilityTaskNamespaceID = "10000000-6000-f000-f000-000000000000"
 	rowTypeVisibilityTaskWorkflowID  = "20000000-6000-f000-f000-000000000000"
 	rowTypeVisibilityTaskRunID       = "30000000-6000-f000-f000-000000000000"
-	// Row Constant for Replication Task DLQ Row. Source cluster name will be used as WorkflowID.
+	// Row Constants for Replication Task DLQ Row. Source cluster name will be used as WorkflowID.
 	rowTypeDLQNamespaceID = "10000000-6000-f000-f000-000000000000"
 	rowTypeDLQRunID       = "30000000-6000-f000-f000-000000000000"
 	// Row constants for History task row.

--- a/common/routing/route.go
+++ b/common/routing/route.go
@@ -81,9 +81,9 @@ func (r *RouteBuilder[T]) Constant(values ...string) *RouteBuilder[T] {
 	return r.With(Constant[T](values...))
 }
 
-// Variable adds a [Variable] component to the [Route].
-func (r *RouteBuilder[T]) Variable(name string, getter func(*T) *string) *RouteBuilder[T] {
-	return r.With(Variable[T](name, getter))
+// StringVariable adds a [StringVariable] component to the [Route].
+func (r *RouteBuilder[T]) StringVariable(name string, getter func(*T) *string) *RouteBuilder[T] {
+	return r.With(StringVariable[T](name, getter))
 }
 
 // Build returns a read-only [Route].
@@ -131,24 +131,24 @@ func (r Route[T]) Deserialize(vars map[string]string) *T {
 
 // Constant returns a [Component] that represents a series of constant HTTP path components in a Route.
 // They will be joined via strings when used to construct a path or path representation.
-func Constant[T any](values ...string) constants[T] {
+func Constant[T any](values ...string) constant[T] {
 	return values
 }
 
-type constants[T any] []string
+type constant[T any] []string
 
-func (s constants[T]) Representation() string {
+func (s constant[T]) Representation() string {
 	return strings.Join(s, "/")
 }
 
-func (s constants[T]) Serialize(T) string {
+func (s constant[T]) Serialize(T) string {
 	return strings.Join(s, "/")
 }
 
-func (s constants[T]) Deserialize(map[string]string, *T) {}
+func (s constant[T]) Deserialize(map[string]string, *T) {}
 
-// Variable returns a [Component] that represents a string variable in a Route.
-func Variable[T any](name string, getter func(*T) *string) stringVariable[T] {
+// StringVariable returns a [Component] that represents a string variable in a Route.
+func StringVariable[T any](name string, getter func(*T) *string) stringVariable[T] {
 	return stringVariable[T]{name, getter}
 }
 

--- a/common/routing/route_test.go
+++ b/common/routing/route_test.go
@@ -41,18 +41,18 @@ type QualifiedWorkflow struct {
 func newWorkflowRoute() routing.Route[QualifiedWorkflow] {
 	return routing.NewBuilder[QualifiedWorkflow]().
 		Constant("api", "v1", "namespaces").
-		Variable("namespace", func(params *QualifiedWorkflow) *string { return &params.Namespace }).
+		StringVariable("namespace", func(params *QualifiedWorkflow) *string { return &params.Namespace }).
 		Constant("workflows").
-		Variable("workflowID", func(params *QualifiedWorkflow) *string { return &params.WorkflowID }).
+		StringVariable("workflowID", func(params *QualifiedWorkflow) *string { return &params.WorkflowID }).
 		Build()
 }
 
 func ExampleRoute() {
 	route := routing.NewBuilder[QualifiedWorkflow]().
 		Constant("api", "v1", "namespaces").
-		Variable("namespace", func(params *QualifiedWorkflow) *string { return &params.Namespace }).
+		StringVariable("namespace", func(params *QualifiedWorkflow) *string { return &params.Namespace }).
 		Constant("workflows").
-		Variable("workflowID", func(params *QualifiedWorkflow) *string { return &params.WorkflowID }).
+		StringVariable("workflowID", func(params *QualifiedWorkflow) *string { return &params.WorkflowID }).
 		Build()
 	router := mux.NewRouter()
 	router.HandleFunc("/"+route.Representation(), func(w http.ResponseWriter, r *http.Request) {
@@ -106,7 +106,7 @@ func ExampleConstant() {
 }
 
 func ExampleVariable() {
-	fmt.Println(routing.Variable("namespace", func(params *QualifiedWorkflow) *string { return &params.Namespace }).Representation())
+	fmt.Println(routing.StringVariable("namespace", func(params *QualifiedWorkflow) *string { return &params.Namespace }).Representation())
 	// Output: {namespace}
 }
 

--- a/service/history/hsm/tree_test.go
+++ b/service/history/hsm/tree_test.go
@@ -39,7 +39,7 @@ func (definition) Deserialize(b []byte) (any, error) {
 	return &data{state(string(b))}, nil
 }
 
-// Get implements hsm.StateMachineDefinition.
+// Serialize implements hsm.StateMachineDefinition.
 func (definition) Serialize(s any) ([]byte, error) {
 	t, ok := s.(*data)
 	if !ok {

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -1220,8 +1220,6 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 				resultToken, err := s.matchingEngine.tokenSerializer.Deserialize(result.TaskToken)
 				s.NoError(err)
 
-				// taskToken, _ := s.matchingEngine.tokenSerializer.Get(token)
-				// s.EqualValues(taskToken, result.Task, fmt.Sprintf("%v!=%v", string(taskToken)))
 				s.EqualValues(taskToken, resultToken, fmt.Sprintf("%v!=%v", taskToken, resultToken))
 				i++
 			}
@@ -1351,8 +1349,6 @@ func (s *matchingEngineSuite) TestConcurrentPublishConsumeWorkflowTasks() {
 					panic(err)
 				}
 
-				// taskToken, _ := s.matchingEngine.tokenSerializer.Get(token)
-				// s.EqualValues(taskToken, result.Task, fmt.Sprintf("%v!=%v", string(taskToken)))
 				s.EqualValues(taskToken, resultToken, fmt.Sprintf("%v!=%v", taskToken, resultToken))
 				i++
 			}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
I accidentally renamed some comments when doing a refactor in https://github.com/temporalio/temporal/pull/5539/files. This PR reverts those changes. However, in doing this revert, I found some unnecessary comments in matching_test which I removed.

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
