### PR TITLE
Require conflict token for all versioning rule updates

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -869,17 +869,18 @@ func (e *matchingEngineImpl) UpdateWorkerVersioningRules(
 		clk := data.GetClock()
 		if clk == nil {
 			clk = hlc.Zero(e.clusterMeta.GetClusterID())
-		} else if cT != nil {
-			prevCT, err := clk.Marshal()
-			if err != nil {
-				return nil, false, err
-			}
-			if !bytes.Equal(cT, prevCT) {
-				return nil, false, serviceerror.NewFailedPrecondition(
-					fmt.Sprintf("provided conflict token %v does not match existing one %v", cT, prevCT),
-				)
-			}
 		}
+
+		prevCT, err := clk.Marshal()
+		if err != nil {
+			return nil, false, err
+		}
+		if !bytes.Equal(cT, prevCT) {
+			return nil, false, serviceerror.NewFailedPrecondition(
+				fmt.Sprintf("provided conflict token '%v' does not match existing one '%v'", cT, prevCT),
+			)
+		}
+
 		updatedClock := hlc.Next(clk, e.timeSource)
 		var versioningData *persistencespb.VersioningData
 		switch req.GetOperation().(type) {


### PR DESCRIPTION
## What changed?
Require conflict token to always be correct, instead of accepting a nil conflict token as an "override"
Change the tests to reflect this

## Why?
For better user experience

## How did you test it?
Changed existing functional tests to test new behavior

## Potential risks
None

## Documentation
Update API Comments: https://github.com/temporalio/api/pull/375

## Is hotfix candidate?
No