### PR TITLE
Don't compare an issueSet with nil

### DIFF
--- a/common/nexus/outgoing_service_registry.go
+++ b/common/nexus/outgoing_service_registry.go
@@ -101,8 +101,8 @@ func (h *OutgoingServiceRegistry) Get(
 	ctx context.Context,
 	req *operatorservice.GetNexusOutgoingServiceRequest,
 ) (*operatorservice.GetNexusOutgoingServiceResponse, error) {
-	if issues := findIssuesForCommonRequest(req); issues != nil {
-		return nil, issues.GetError()
+	if err := findIssuesForCommonRequest(req).GetError(); err != nil {
+		return nil, err
 	}
 	response, err := h.namespaceService.GetNamespace(ctx, &persistence.GetNamespaceRequest{
 		Name: req.Namespace,
@@ -213,8 +213,8 @@ func (h *OutgoingServiceRegistry) Delete(
 	ctx context.Context,
 	req *operatorservice.DeleteNexusOutgoingServiceRequest,
 ) (*operatorservice.DeleteNexusOutgoingServiceResponse, error) {
-	if errorMessageSet := findIssuesForCommonRequest(req); errorMessageSet != nil {
-		return nil, errorMessageSet.GetError()
+	if err := findIssuesForCommonRequest(req).GetError(); err != nil {
+		return nil, err
 	}
 	response, err := h.namespaceService.GetNamespace(ctx, &persistence.GetNamespaceRequest{
 		Name: req.Namespace,
@@ -374,7 +374,7 @@ type commonRequest interface {
 	GetName() string
 }
 
-func findIssuesForCommonRequest(req commonRequest) issueSet {
+func findIssuesForCommonRequest(req commonRequest) *issueSet {
 	var set issueSet
 	if req.GetNamespace() == "" {
 		set.Append(IssueNamespaceNotSet)
@@ -382,7 +382,7 @@ func findIssuesForCommonRequest(req commonRequest) issueSet {
 	if req.GetName() == "" {
 		set.Append(IssueNameNotSet)
 	}
-	return set
+	return &set
 }
 
 type upsertRequest interface {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
There was a small issue in #5523 where we check an "issue set" against nil in the outgoing service registry code. The issue set is supposed to track a list of request issues to form one big invalid argument error if its length is greater than zero. However, we had code that looked like this:

```go
if issues := getIssuesFromCommonRequest(req); issues != nil {
  return nil, issues.GetError()
}
```

Which works because we return a nil issues set if there's no issues, but, technically, we could have a non-nil issues set with no issues, so it should instead be something like this:

```go
if err := getIssuesFromCommonRequest(req).GetError(); err != nil {
  return nil, err
}
```

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
