### PR TITLE
Catch panic during gocel session creation

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
@@ -79,5 +79,5 @@ func TestPanicCapture(t *testing.T) {
 	}, metrics.NoopMetricsHandler)
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "panic: no valid connect address for host")
+	assert.Contains(t, err.Error(), "panic:")
 }


### PR DESCRIPTION
## What changed?
Catch gocql panic

## Why?
Gocql would panic when try to connect to 0.0.0.0

## How did you test it?
Added unit test

## Potential risks
No

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
No
