### PR TITLE
Adding history.TaskDLQUnexpectedErrorAttempts in dlq doc

### DIFF
--- a/docs/admin/dlq.md
+++ b/docs/admin/dlq.md
@@ -10,6 +10,8 @@ To enable the DLQ for history replication tasks, set `history.enableHistoryRepli
 
 ### History Tasks DLQ
 To enable the DLQ for non-replication history tasks, set `history.TaskDLQEnabled` to true.
+You can specify the maximum number of task execution attempts with unexpected errors using the dynamic config
+`history.TaskDLQUnexpectedErrorAttempts`. The task will be sent to DLQ after the specified number of attempts.
 
 ## Detection
 There is a metric `dlq_writes`, which is incremented each time a message is enqueued to the DLQ.


### PR DESCRIPTION
## What changed?
Adding history.TaskDLQUnexpectedErrorAttempts to DLQ documentation.

## Why?
This feature will be released in 1.23.

## How did you test it?

## Potential risks
None

## Documentation

## Is hotfix candidate?
No
