### PR TITLE
Tests - Fix how matching service client is accessed in functional tests

### DIFF
--- a/tests/functional_test_base.go
+++ b/tests/functional_test_base.go
@@ -49,6 +49,7 @@ import (
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
 
+	"go.temporal.io/server/api/matchingservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -72,6 +73,7 @@ type (
 		testClusterConfig      *TestClusterConfig
 		engine                 FrontendClient
 		adminClient            AdminClient
+		matchingServiceClient  matchingservice.MatchingServiceClient
 		operatorClient         operatorservice.OperatorServiceClient
 		httpAPIAddress         string
 		Logger                 log.Logger
@@ -152,6 +154,7 @@ func (s *FunctionalTestBase) setupSuite(defaultClusterConfigFile string, options
 		s.Require().NoError(err)
 		s.testCluster = cluster
 		s.engine = s.testCluster.GetFrontendClient()
+		s.matchingServiceClient = s.testCluster.GetMatchingClient()
 		s.adminClient = s.testCluster.GetAdminClient()
 		s.operatorClient = s.testCluster.GetOperatorClient()
 		s.httpAPIAddress = cluster.host.FrontendHTTPAddress()
@@ -414,4 +417,9 @@ func (s *FunctionalTestBase) registerArchivalNamespace(archivalNamespace string)
 		tag.WorkflowNamespaceID(response.ID),
 	)
 	return err
+}
+
+// MatchingServiceClient returns the matching service client setup for this functional test.
+func (s *FunctionalTestBase) MatchingServiceClient() matchingservice.MatchingServiceClient {
+	return s.matchingServiceClient
 }

--- a/tests/nexus_incoming_service_test.go
+++ b/tests/nexus_incoming_service_test.go
@@ -109,11 +109,10 @@ func (s *FunctionalSuite) TestCreateOrUpdateNexusIncomingService_Matching() {
 		},
 	}
 
-	matchingClient := s.testCluster.GetMatchingClient()
 	for _, tc := range testCases {
 		tc := tc
 		s.T().Run(tc.name, func(t *testing.T) {
-			resp, err := matchingClient.CreateOrUpdateNexusIncomingService(
+			resp, err := s.MatchingServiceClient().CreateOrUpdateNexusIncomingService(
 				NewContext(),
 				&matchingservice.CreateOrUpdateNexusIncomingServiceRequest{
 					Service: tc.service,
@@ -148,11 +147,10 @@ func (s *FunctionalSuite) TestDeleteNexusIncomingService_Matching() {
 	}
 
 	s.createNexusIncomingService("service-to-delete")
-	matchingClient := s.testCluster.GetMatchingClient()
 	for _, tc := range testCases {
 		tc := tc
 		s.T().Run(tc.name, func(t *testing.T) {
-			resp, err := matchingClient.DeleteNexusIncomingService(
+			resp, err := s.MatchingServiceClient().DeleteNexusIncomingService(
 				NewContext(),
 				&matchingservice.DeleteNexusIncomingServiceRequest{
 					Name: tc.serviceName,
@@ -169,8 +167,7 @@ func (s *FunctionalSuite) TestListNexusIncomingServices_Matching() {
 	s.createNexusIncomingService("list-test-service2")
 
 	// get expected table version and services for the course of the tests
-	matchingClient := s.testCluster.GetMatchingClient()
-	resp, err := matchingClient.ListNexusIncomingServices(
+	resp, err := s.MatchingServiceClient().ListNexusIncomingServices(
 		NewContext(),
 		&matchingservice.ListNexusIncomingServicesRequest{
 			PageSize:              100,
@@ -294,7 +291,7 @@ func (s *FunctionalSuite) TestListNexusIncomingServices_Matching() {
 			listReqDone := make(chan struct{})
 			go func() {
 				defer close(listReqDone)
-				resp, err := matchingClient.ListNexusIncomingServices(NewContext(), tc.request)
+				resp, err := s.MatchingServiceClient().ListNexusIncomingServices(NewContext(), tc.request)
 				tc.assertion(resp, err)
 			}()
 			if tc.request.Wait && tc.request.NextPageToken == nil && tc.request.LastKnownTableVersion != 0 {
@@ -307,7 +304,7 @@ func (s *FunctionalSuite) TestListNexusIncomingServices_Matching() {
 
 func (s *FunctionalSuite) TestListNexusIncomingServicesOrdering_Matching() {
 	// get initial table version since it has been modified by other tests
-	resp, err := s.testCluster.GetMatchingClient().ListNexusIncomingServices(NewContext(), &matchingservice.ListNexusIncomingServicesRequest{
+	resp, err := s.MatchingServiceClient().ListNexusIncomingServices(NewContext(), &matchingservice.ListNexusIncomingServicesRequest{
 		LastKnownTableVersion: 0,
 		PageSize:              0,
 	})
@@ -339,7 +336,7 @@ func (s *FunctionalSuite) TestListNexusIncomingServicesOrdering_Matching() {
 	s.Len(persistenceResp2.Entries, numServices/2)
 
 	// list from matching level
-	matchingClient := s.testCluster.GetMatchingClient()
+	matchingClient := s.MatchingServiceClient()
 	matchingResp1, err := matchingClient.ListNexusIncomingServices(NewContext(), &matchingservice.ListNexusIncomingServicesRequest{
 		LastKnownTableVersion: tableVersion,
 		PageSize:              int32(numServices / 2),
@@ -363,7 +360,7 @@ func (s *FunctionalSuite) TestListNexusIncomingServicesOrdering_Matching() {
 }
 
 func (s *FunctionalSuite) createNexusIncomingService(name string) *persistencepb.NexusIncomingServiceEntry {
-	resp, err := s.testCluster.GetMatchingClient().CreateOrUpdateNexusIncomingService(
+	resp, err := s.MatchingServiceClient().CreateOrUpdateNexusIncomingService(
 		NewContext(),
 		&matchingservice.CreateOrUpdateNexusIncomingServiceRequest{
 			Service: &nexus.IncomingService{

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -2098,7 +2098,7 @@ func (s *VersioningIntegSuite) waitForChan(ctx context.Context, ch chan struct{}
 }
 
 func (s *VersioningIntegSuite) unloadTaskQueue(ctx context.Context, tq string) {
-	_, err := s.testCluster.GetMatchingClient().ForceUnloadTaskQueue(ctx, &matchingservice.ForceUnloadTaskQueueRequest{
+	_, err := s.MatchingServiceClient().ForceUnloadTaskQueue(ctx, &matchingservice.ForceUnloadTaskQueueRequest{
 		NamespaceId:   s.getNamespaceID(s.namespace),
 		TaskQueue:     tq,
 		TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,


### PR DESCRIPTION
## What changed?
Functional tests now use the prepared Matching service client in the `FunctionalTestBase` object rather than reaching directly into `FunctionalTestBase.testCluster.xyz`.
Functional tests should not reach deep into the test suite object to get handles to dependencies.

## Why?
<!-- Tell your future self why have you made these changes -->
Functional tests should not reach deep into the test suite object to get handles to dependencies. Without this change, some of the tests assume that we have an inline testCluster setup. This will not be true if we want to run the functional tests against an already running service.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
N/A

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
