### PR TITLE
Returning SerializationError when proto unmarshalling fails

### DIFF
--- a/common/nexus/payload_serializer.go
+++ b/common/nexus/payload_serializer.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/persistence/serialization"
 )
 
 type payloadSerializer struct{}
@@ -79,7 +81,7 @@ func (payloadSerializer) Deserialize(content *nexus.Content, v any) error {
 	case "application/x-temporal-payload":
 		err := payload.Unmarshal(content.Data)
 		if err != nil {
-			return err
+			return serialization.NewDeserializationError(enums.ENCODING_TYPE_PROTO3, err)
 		}
 	case "application/json":
 		if len(params) == 0 {

--- a/common/persistence/serialization/serializer.go
+++ b/common/persistence/serialization/serializer.go
@@ -170,7 +170,7 @@ func (t *serializerImpl) DeserializeEvents(data *commonpb.DataBlob) ([]*historyp
 		return nil, NewUnknownEncodingTypeError(data.EncodingType.String(), enumspb.ENCODING_TYPE_PROTO3)
 	}
 	if err != nil {
-		return nil, err
+		return nil, NewDeserializationError(enumspb.ENCODING_TYPE_PROTO3, err)
 	}
 	return events.Events, nil
 }
@@ -201,7 +201,7 @@ func (t *serializerImpl) DeserializeEvent(data *commonpb.DataBlob) (*historypb.H
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, NewDeserializationError(enumspb.ENCODING_TYPE_PROTO3, err)
 	}
 
 	return event, err
@@ -234,7 +234,7 @@ func (t *serializerImpl) DeserializeClusterMetadata(data *commonpb.DataBlob) (*p
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, NewSerializationError(enumspb.ENCODING_TYPE_PROTO3, err)
 	}
 
 	return cm, err

--- a/common/persistence/tests/execution_mutable_state_task.go
+++ b/common/persistence/tests/execution_mutable_state_task.go
@@ -730,7 +730,7 @@ func (s *testSerializer) DeserializeTask(
 
 	taskInfo := &persistencespb.TransferTaskInfo{}
 	if err := proto.Unmarshal(blob.Data, taskInfo); err != nil {
-		return nil, err
+		return nil, serialization.NewDeserializationError(enumspb.ENCODING_TYPE_PROTO3, err)
 	}
 
 	fakeTask := tasks.NewFakeTask(

--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -33,6 +33,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/server/common/persistence/serialization"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -422,11 +423,12 @@ func (p *visibilityManagerImpl) deserializeMemo(data *commonpb.DataBlob) (*commo
 		memo := &commonpb.Memo{}
 		err := proto.Unmarshal(data.Data, memo)
 		if err != nil {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to deserialize memo from data blob: %v", err))
+			return nil, serialization.NewDeserializationError(
+				enumspb.ENCODING_TYPE_PROTO3, fmt.Errorf("unable to deserialize memo from data blob: %w", err))
 		}
 		return memo, nil
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Invalid memo encoding in database: %s", data.GetEncodingType().String()))
+		return nil, serialization.NewUnknownEncodingTypeError(data.GetEncodingType().String(), enumspb.ENCODING_TYPE_PROTO3)
 	}
 }
 

--- a/plugins/callbacks/statemachine.go
+++ b/plugins/callbacks/statemachine.go
@@ -33,6 +33,7 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/service/history/hsm"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -124,7 +125,10 @@ func (stateMachineDefinition) Type() hsm.MachineType {
 
 func (stateMachineDefinition) Deserialize(d []byte) (any, error) {
 	info := &persistencespb.CallbackInfo{}
-	return Callback{info}, proto.Unmarshal(d, info)
+	if err := proto.Unmarshal(d, info); err != nil {
+		return nil, serialization.NewDeserializationError(enumspb.ENCODING_TYPE_PROTO3, err)
+	}
+	return Callback{info}, nil
 }
 
 func (stateMachineDefinition) Serialize(state any) ([]byte, error) {

--- a/service/history/ndc/mutable_state_initializer.go
+++ b/service/history/ndc/mutable_state_initializer.go
@@ -30,8 +30,10 @@ import (
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/persistence/serialization"
 	"google.golang.org/protobuf/proto"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -265,10 +267,10 @@ func (r *MutableStateInitializerImpl) deserializeBackfillToken(
 
 	historyBackfillToken := &MutableStateToken{}
 	if err := json.Unmarshal(token, historyBackfillToken); err != nil {
-		return nil, 0, 0, false, err
+		return nil, 0, 0, false, serialization.NewDeserializationError(enums.ENCODING_TYPE_JSON, err)
 	}
 	if err := proto.Unmarshal(historyBackfillToken.MutableStateRow, mutableState); err != nil {
-		return nil, 0, 0, false, err
+		return nil, 0, 0, false, serialization.NewDeserializationError(enums.ENCODING_TYPE_PROTO3, err)
 	}
 	return mutableState, historyBackfillToken.DBRecordVersion, historyBackfillToken.DBHistorySize, historyBackfillToken.ExistsInDB, nil
 }


### PR DESCRIPTION
## What changed?
Adding code to return DeserializationError when proto unmarshalling fails.

## Why?
If task processing see DeserializationError, it can DLQ the task. These errors cannot be handled with retries.
This can happen if there are any invalid UTF8 characters in any proto strings.

## How did you test it?
Unit tests

## Potential risks
None

## Documentation

## Is hotfix candidate?
No
