### PR TITLE
Remove runID from persistence addTasks request

### DIFF
--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -204,7 +204,6 @@ type (
 
 		NamespaceID string
 		WorkflowID  string
-		RunID       string
 
 		Tasks map[tasks.Category][]tasks.Task
 	}

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -814,7 +814,6 @@ func (m *executionManagerImpl) AddHistoryTasks(
 
 		NamespaceID: input.NamespaceID,
 		WorkflowID:  input.WorkflowID,
-		RunID:       input.RunID,
 
 		Tasks: tasks,
 	})

--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -406,7 +406,6 @@ type (
 
 		NamespaceID string
 		WorkflowID  string
-		RunID       string
 
 		Tasks map[tasks.Category][]InternalHistoryTask
 	}

--- a/common/persistence/tests/execution_mutable_state_task.go
+++ b/common/persistence/tests/execution_mutable_state_task.go
@@ -488,7 +488,6 @@ func (s *ExecutionMutableStateTaskSuite) TestGetTimerTasksOrdered() {
 		RangeID:     s.RangeID,
 		NamespaceID: s.WorkflowKey.NamespaceID,
 		WorkflowID:  s.WorkflowKey.WorkflowID,
-		RunID:       s.WorkflowKey.RunID,
 		Tasks: map[tasks.Category][]tasks.Task{
 			tasks.CategoryTimer: timerTasks,
 		},
@@ -530,7 +529,6 @@ func (s *ExecutionMutableStateTaskSuite) TestGetScheduledTasksOrdered() {
 		RangeID:     s.RangeID,
 		NamespaceID: s.WorkflowKey.NamespaceID,
 		WorkflowID:  s.WorkflowKey.WorkflowID,
-		RunID:       s.WorkflowKey.RunID,
 		Tasks: map[tasks.Category][]tasks.Task{
 			fakeScheduledTaskCategory: scheduledTasks,
 		},
@@ -588,7 +586,6 @@ func (s *ExecutionMutableStateTaskSuite) AddRandomTasks(
 		RangeID:     s.RangeID,
 		NamespaceID: s.WorkflowKey.NamespaceID,
 		WorkflowID:  s.WorkflowKey.WorkflowID,
-		RunID:       s.WorkflowKey.RunID,
 		Tasks: map[tasks.Category][]tasks.Task{
 			category: randomTasks,
 		},

--- a/service/history/api/addtasks/api.go
+++ b/service/history/api/addtasks/api.go
@@ -110,10 +110,11 @@ func Invoke(
 			))
 		}
 
+		// group by namespaceID + workflowID
 		workflowKey := definition.NewWorkflowKey(
 			deserializedTask.GetNamespaceID(),
 			deserializedTask.GetWorkflowID(),
-			deserializedTask.GetRunID(),
+			"",
 		)
 		if _, ok := taskBatches[workflowKey]; !ok {
 			taskBatches[workflowKey] = make(map[tasks.Category][]tasks.Task, 1)
@@ -128,7 +129,6 @@ func Invoke(
 			RangeID:     shardContext.GetRangeID(),
 			NamespaceID: workflowKey.NamespaceID,
 			WorkflowID:  workflowKey.WorkflowID,
-			RunID:       workflowKey.RunID,
 			Tasks:       taskBatch,
 		})
 		if err != nil {

--- a/service/history/api/addtasks/api_test.go
+++ b/service/history/api/addtasks/api_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
@@ -108,8 +109,8 @@ func TestInvoke(t *testing.T) {
 				for i := 0; i < numWorkflows; i++ {
 					workflowKey := definition.NewWorkflowKey(
 						string(tests.NamespaceID),
-						tests.WorkflowID,
 						strconv.Itoa(i),
+						uuid.New(),
 					)
 					// each workflow has two transfer tasks and one timer task
 					for _, task := range []tasks.Task{
@@ -136,9 +137,9 @@ func TestInvoke(t *testing.T) {
 					require.NoError(t, err)
 					assert.NotNil(t, resp)
 					require.Len(t, requests, numWorkflows, "We should send one request for each workflow")
-					runIDs := make([]string, numWorkflows)
+					workflowIDs := make([]string, numWorkflows)
 					for i, request := range requests {
-						runIDs[i] = request.RunID
+						workflowIDs[i] = request.WorkflowID
 						assert.Len(t, request.Tasks[tasks.CategoryTransfer], 2,
 							"There were two transfer tasks for each workflow")
 						assert.Len(t, request.Tasks[tasks.CategoryTimer], 1,
@@ -146,8 +147,8 @@ func TestInvoke(t *testing.T) {
 					}
 					// The requests could go in any order because we do map iteration, so compare the elements while
 					// ignoring their order.
-					assert.ElementsMatch(t, []string{"0", "1"}, runIDs,
-						"The requests should be for the expected run IDs")
+					assert.ElementsMatch(t, []string{"0", "1"}, workflowIDs,
+						"The requests should be for the expected workflowIDs")
 				}
 			},
 		},

--- a/service/history/api/refreshworkflow/api.go
+++ b/service/history/api/refreshworkflow/api.go
@@ -76,7 +76,6 @@ func Invoke(
 		// RangeID is set by shard
 		NamespaceID: workflowKey.NamespaceID,
 		WorkflowID:  workflowKey.WorkflowID,
-		RunID:       workflowKey.RunID,
 		Tasks:       mutableState.PopTasks(),
 	})
 }

--- a/service/history/api/replication/generate_task.go
+++ b/service/history/api/replication/generate_task.go
@@ -76,7 +76,6 @@ func GenerateTask(
 		// RangeID is set by shard
 		NamespaceID: string(namespaceID),
 		WorkflowID:  request.Execution.WorkflowId,
-		RunID:       request.Execution.RunId,
 		Tasks: map[tasks.Category][]tasks.Task{
 			tasks.CategoryReplication: replicationTasks,
 		},

--- a/service/history/archival_queue_task_executor.go
+++ b/service/history/archival_queue_task_executor.go
@@ -266,7 +266,6 @@ func (e *archivalQueueTaskExecutor) addDeletionTask(
 		ShardID:     e.shardContext.GetShardID(),
 		NamespaceID: task.GetNamespaceID(),
 		WorkflowID:  task.WorkflowID,
-		RunID:       task.RunID,
 		Tasks:       mutableState.PopTasks(),
 	})
 	return err

--- a/service/history/archival_queue_task_executor_test.go
+++ b/service/history/archival_queue_task_executor_test.go
@@ -447,7 +447,6 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 							ShardID:     shardID,
 							NamespaceID: tests.NamespaceID.String(),
 							WorkflowID:  task.WorkflowID,
-							RunID:       task.RunID,
 							Tasks:       popTasks,
 						})
 					})

--- a/service/history/deletemanager/delete_manager.go
+++ b/service/history/deletemanager/delete_manager.go
@@ -126,7 +126,6 @@ func (m *DeleteManagerImpl) AddDeleteWorkflowExecutionTask(
 		// RangeID is set by shardContext
 		NamespaceID: nsID.String(),
 		WorkflowID:  we.GetWorkflowId(),
-		RunID:       we.GetRunId(),
 		Tasks: map[tasks.Category][]tasks.Task{
 			tasks.CategoryTransfer: {deleteTask},
 		},

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1026,7 +1026,6 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 					ShardID:     s.shardID,
 					NamespaceID: key.NamespaceID,
 					WorkflowID:  key.WorkflowID,
-					RunID:       key.RunID,
 
 					Tasks: newTasks,
 				}

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -165,7 +165,6 @@ func (s *contextSuite) TestOverwriteScheduledTaskTimestamp() {
 				ShardID:     s.mockShard.GetShardID(),
 				NamespaceID: workflowKey.NamespaceID,
 				WorkflowID:  workflowKey.WorkflowID,
-				RunID:       workflowKey.RunID,
 				Tasks:       testTasks,
 			},
 		)
@@ -190,7 +189,6 @@ func (s *contextSuite) TestAddTasks_Success() {
 		ShardID:     s.mockShard.GetShardID(),
 		NamespaceID: tests.NamespaceID.String(),
 		WorkflowID:  tests.WorkflowID,
-		RunID:       tests.RunID,
 
 		Tasks: testTasks,
 	}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Remove runID from persistence addTasks request

## Why?
<!-- Tell your future self why have you made these changes -->
- Not used. NamespaceID and workflowID could be used by some persistence implementation.
- A task may target a workflowID (a workflow chain) instead of an specific run of the workflow

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- N/A, the field is not used.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
- N/A

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- No.
