### PR TITLE
update-reapply 4: Functional tests of scenarios involving updates and history replication

### DIFF
--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -943,6 +943,8 @@ func (c *ContextImpl) UpdateRegistry(ctx context.Context, ms MutableState) updat
 				},
 			),
 		)
+	} else {
+		c.updateRegistry.UpdateFromStore()
 	}
 	return c.updateRegistry
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -3801,7 +3801,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionUpdateAdmittedEvent(event *his
 		},
 	}
 	if _, ok := ms.executionInfo.UpdateInfos[updateID]; ok {
-		return serviceerror.NewInternal(fmt.Sprintf("Update ID %s is already present in registry", updateID))
+		return serviceerror.NewInternal(fmt.Sprintf("Update ID %s is already present in mutable state", updateID))
 	}
 	ui := updatespb.UpdateInfo{Value: admission}
 	ms.executionInfo.UpdateInfos[updateID] = &ui

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -211,9 +211,7 @@ func (r *registry) UpdateFromStore() {
 			)
 		} else if updInfo.GetCompletion() != nil {
 			if upd := r.updates[updID]; upd != nil {
-				if err := upd.advanceTo(stateCompleted); err == nil {
-					upd.onComplete()
-				}
+				_ = upd.advanceTo(stateCompleted)
 				return
 			}
 			r.completedUpdates[updID] = true

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -104,7 +104,7 @@ type (
 		instrumentation  instrumentation
 		maxInFlight      func() int
 		maxTotal         func() int
-		completedUpdates map[string]bool
+		completedUpdates map[string]struct{}
 	}
 
 	Option func(*registry)
@@ -161,7 +161,7 @@ func NewRegistry(
 		instrumentation:  noopInstrumentation,
 		maxInFlight:      func() int { return math.MaxInt },
 		maxTotal:         func() int { return math.MaxInt },
-		completedUpdates: make(map[string]bool),
+		completedUpdates: make(map[string]struct{}),
 	}
 	for _, opt := range opts {
 		opt(r)
@@ -214,7 +214,7 @@ func (r *registry) UpdateFromStore() {
 				_ = upd.advanceTo(stateCompleted)
 				return
 			}
-			r.completedUpdates[updID] = true
+			r.completedUpdates[updID] = struct{}{}
 		}
 	})
 }
@@ -337,7 +337,7 @@ func (r *registry) remover(id string) updateOpt {
 			r.mu.Lock()
 			defer r.mu.Unlock()
 			delete(r.updates, id)
-			r.completedUpdates[id] = true
+			r.completedUpdates[id] = struct{}{}
 		},
 	)
 }

--- a/service/history/workflow/update/state.go
+++ b/service/history/workflow/update/state.go
@@ -103,3 +103,10 @@ func (s state) LifecycleStage() (enumspb.UpdateWorkflowExecutionLifecycleStage, 
 func (s state) Matches(mask stateSet) bool {
 	return uint32(s)&uint32(mask) == uint32(s)
 }
+
+// isStrictlyAncestralTo returns true if the target state can be reached from the source state, and they are not the
+// same state.
+func (s state) isStrictlyAncestralTo(t state) bool {
+	// Currently, the DAG is linear.
+	return s < t
+}

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -576,6 +576,14 @@ func (u *Update) setState(newState state) state {
 	return prevState
 }
 
+func (u *Update) advanceTo(newState state) error {
+	if !u.state.isStrictlyAncestralTo(newState) {
+		return invalidArgf("cannot advance to state %q from state %q", newState, u.state)
+	}
+	u.setState(newState)
+	return nil
+}
+
 func (u *Update) GetSize() int {
 	size := len(u.id)
 	size += proto.Size(u.request)

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -581,6 +581,10 @@ func (u *Update) advanceTo(newState state) error {
 		return invalidArgf("cannot advance to state %q from state %q", newState, u.state)
 	}
 	u.setState(newState)
+	if newState == stateCompleted {
+		u.onComplete()
+	}
+	// TODO: resolve the accepted / completed futures
 	return nil
 }
 

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -564,8 +564,8 @@ func (u *Update) checkStateSet(msg proto.Message, allowed stateSet) error {
 		return nil
 	}
 	u.instrumentation.CountInvalidStateTransition()
-	return invalidArgf("invalid state transition attempted: "+
-		"received %T message while in state %q", msg, u.state)
+	return invalidArgf("invalid state transition attempted for Update %s: "+
+		"received %T message while in state %q", u.id, msg, u.state)
 }
 
 // setState assigns the current state to a new value returning the original value.

--- a/tests/xdc/history_replication_signals_and_updates_test.go
+++ b/tests/xdc/history_replication_signals_and_updates_test.go
@@ -30,15 +30,20 @@ package xdc
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/suite"
+	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	protocolpb "go.temporal.io/api/protocol/v1"
 	replicationpb "go.temporal.io/api/replication/v1"
+	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/workflow"
@@ -47,9 +52,9 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/testing/protoutils"
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/tests"
@@ -63,27 +68,55 @@ import (
 // based on those in tests/xdc/history_replication_dlq_test.go.
 
 type (
-	historyReplicationConflictTestSuite struct {
+	// The suite creates two clusters. We use injection to create history and namespace replication task executors
+	// that push their tasks into test-specific (i.e. workflow-specific) buffers.
+	hrsuTestSuite struct {
 		xdcBaseSuite
+		namespaceTaskExecutor namespace.ReplicationTaskExecutor
+		// The injection is performed once, at the level of the test suite, but we need the modified executors to be
+		// able to route tasks to test-specific (i.e. workflow-specific) buffers. The following two maps serve that
+		// purpose (each test registers itself in these maps as it starts). Workflow ID and namespace name are both
+		// unique per test (due to the use of TestVars).
+		testsByWorkflowId    map[string]*hrsuTest
+		testsByNamespaceName map[string]*hrsuTest
+	}
+	// Each test starts its own workflow, in its own namespace.
+	hrsuTest struct {
+		runId string
+		tv    *testvars.TestVars
+		// Per-test buffer of namespace replication tasks.
+		// TODO (dan): buffer namespace replication tasks from each cluster separately, as we do for history replication
+		// tasks.
 		namespaceReplicationTasks chan *replicationspb.NamespaceTaskAttributes
-		namespaceTaskExecutor     namespace.ReplicationTaskExecutor
-		historyReplicationTasks   map[string]chan *hrcTestExecutableTask
-		tv                        *testvars.TestVars
+		cluster1                  hrsuTestCluster
+		cluster2                  hrsuTestCluster
+		s                         *hrsuTestSuite
 	}
-	hrcTestNamespaceReplicationTaskExecutor struct {
+	hrsuTestCluster struct {
+		name        string
+		testCluster *tests.TestCluster
+		client      sdkclient.Client
+		// Per-test, per-cluster buffer of history event replication tasks
+		outboundHistoryReplicationTasks chan *hrsuTestExecutableTask
+		t                               *hrsuTest
+	}
+	// Used to inject a modified namespace replication task executor.
+	hrsuTestNamespaceReplicationTaskExecutor struct {
 		replicationTaskExecutor namespace.ReplicationTaskExecutor
-		s                       *historyReplicationConflictTestSuite
+		s                       *hrsuTestSuite
 	}
-	hrcTestExecutableTaskConverter struct {
+	// Used to inject a modified history event replication task executor.
+	hrsuTestExecutableTaskConverter struct {
 		converter replication.ExecutableTaskConverter
-		s         *historyReplicationConflictTestSuite
+		s         *hrsuTestSuite
 	}
-	hrcTestExecutableTask struct {
-		s *historyReplicationConflictTestSuite
+	// Used to inject a modified history event replication task executor.
+	hrsuTestExecutableTask struct {
 		replication.TrackableExecutableTask
 		replicationTask *replicationspb.ReplicationTask
 		taskClusterName string
 		result          chan error
+		s               *hrsuTestSuite
 	}
 )
 
@@ -91,14 +124,15 @@ const (
 	taskBufferCapacity = 100
 )
 
-func TestHistoryReplicationConflictTestSuite(t *testing.T) {
+func TestHistoryReplicationSignalsAndUpdatesTestSuite(t *testing.T) {
 	flag.Parse()
-	suite.Run(t, new(historyReplicationConflictTestSuite))
+	suite.Run(t, new(hrsuTestSuite))
 }
 
-func (s *historyReplicationConflictTestSuite) SetupSuite() {
+func (s *hrsuTestSuite) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
-		dynamicconfig.EnableReplicationStream: true,
+		dynamicconfig.EnableReplicationStream:                            true,
+		dynamicconfig.FrontendEnableUpdateWorkflowExecutionAsyncAccepted: true,
 	}
 	s.logger = log.NewNoopLogger()
 	s.setupSuite(
@@ -107,7 +141,7 @@ func (s *historyReplicationConflictTestSuite) SetupSuite() {
 			fx.Decorate(
 				func(executor namespace.ReplicationTaskExecutor) namespace.ReplicationTaskExecutor {
 					s.namespaceTaskExecutor = executor
-					return &hrcTestNamespaceReplicationTaskExecutor{
+					return &hrsuTestNamespaceReplicationTaskExecutor{
 						replicationTaskExecutor: executor,
 						s:                       s,
 					}
@@ -117,7 +151,7 @@ func (s *historyReplicationConflictTestSuite) SetupSuite() {
 		tests.WithFxOptionsForService(primitives.HistoryService,
 			fx.Decorate(
 				func(converter replication.ExecutableTaskConverter) replication.ExecutableTaskConverter {
-					return &hrcTestExecutableTaskConverter{
+					return &hrsuTestExecutableTaskConverter{
 						converter: converter,
 						s:         s,
 					}
@@ -125,91 +159,365 @@ func (s *historyReplicationConflictTestSuite) SetupSuite() {
 			),
 		),
 	)
-	s.namespaceReplicationTasks = make(chan *replicationspb.NamespaceTaskAttributes, taskBufferCapacity)
-	s.historyReplicationTasks = map[string]chan *hrcTestExecutableTask{}
-	for _, c := range s.clusterNames {
-		s.historyReplicationTasks[c] = make(chan *hrcTestExecutableTask, taskBufferCapacity)
-	}
+	s.testsByWorkflowId = make(map[string]*hrsuTest)
+	s.testsByNamespaceName = make(map[string]*hrsuTest)
 }
 
-func (s *historyReplicationConflictTestSuite) SetupTest() {
+func (s *hrsuTestSuite) SetupTest() {
 	s.setupTest()
 }
 
-func (s *historyReplicationConflictTestSuite) TearDownSuite() {
+func (s *hrsuTestSuite) TearDownSuite() {
 	s.tearDownSuite()
+}
+
+func (s *hrsuTestSuite) startHrsuTest() (hrsuTest, context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	tv := testvars.New(s.T().Name())
+	ns := tv.NamespaceName().String()
+	t := hrsuTest{
+		tv:                        tv,
+		namespaceReplicationTasks: make(chan *replicationspb.NamespaceTaskAttributes, taskBufferCapacity),
+		s:                         s,
+	}
+	// Register test with the suite, so that globally modified task executors can push tasks to test-specific buffers.
+	s.testsByWorkflowId[tv.WorkflowID()] = &t
+	s.testsByNamespaceName[ns] = &t
+
+	t.cluster1 = t.newHrsuTestCluster(ns, s.clusterNames[0], s.cluster1)
+	t.cluster2 = t.newHrsuTestCluster(ns, s.clusterNames[1], s.cluster2)
+	t.registerMultiRegionNamespace(ctx)
+	t.runId = t.cluster1.startWorkflow(ctx)
+	return t, ctx, cancel
+}
+
+func (t *hrsuTest) newHrsuTestCluster(ns string, name string, cluster *tests.TestCluster) hrsuTestCluster {
+	sdkClient, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  cluster.GetHost().FrontendGRPCAddress(),
+		Namespace: ns,
+		Logger:    log.NewSdkLogger(t.s.logger),
+	})
+	t.s.NoError(err)
+	return hrsuTestCluster{
+		name:                            name,
+		testCluster:                     cluster,
+		client:                          sdkClient,
+		outboundHistoryReplicationTasks: make(chan *hrsuTestExecutableTask, taskBufferCapacity),
+		t:                               t,
+	}
+}
+
+// TestAcceptedUpdateCanBeCompletedAfterFailoverAndFailback tests that an update can be accepted in one cluster, and completed in a
+// different cluster, after a failover.
+func (s *hrsuTestSuite) TestAcceptedUpdateCanBeCompletedAfterFailoverAndFailback() {
+	t, ctx, cancel := s.startHrsuTest()
+	defer cancel()
+
+	// Cluster 1 is active initially. We start an update in cluster 1, run it through to acceptance, and replicate the
+	// history to cluster 2. Then we failover to cluster 2 (where the update registry is empty) and confirm that the update
+	// can be completed in the new active cluster.
+	t.startAndAcceptUpdateInCluster1ThenFailoverTo2AndCompleteUpdate(ctx)
+	// Finally, we start an update in cluster 2, run it through to acceptance, failover back to cluster 1 (which already
+	// has an update registry from before the failover), and confirm that the update can be completed in cluster 1.
+	t.startAndAcceptUpdateInCluster2ThenFailoverTo1AndCompleteUpdate(ctx)
+}
+
+// TODO test failover before replication
+
+func (s *hrsuTestSuite) TestUpdateCompletedAfterFailoverCannotBeCompletedAgainAfterFailback() {
+	t, ctx, cancel := s.startHrsuTest()
+	defer cancel()
+	// Cluster 1 is active initially. We start an update in cluster 1, run it through to acceptance, and replicate the
+	// history to cluster 2. Then we failover to cluster 2 (where the update registry is empty) and confirm that the update
+	// can be completed in the new active cluster.
+	t.startAndAcceptUpdateInCluster1ThenFailoverTo2AndCompleteUpdate(ctx)
+	// Now we fail back to cluster 1. When this cluster was last active this update was in accepted state but,
+	// nevertheless, it should not be possible to complete it, since it is already completed.
+	t.cluster2.executeHistoryReplicationTasksFromClusterUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED)
+	t.failover2To1(ctx)
+	s.NoError(t.cluster1.client.SignalWorkflow(ctx, t.tv.WorkflowID(), t.runId, "my-signal", "cluster1-signal"))
+	s.Error(t.cluster1.pollAndCompleteUpdate("cluster1-update-id"))
 }
 
 // TestConflictResolutionReappliesSignals creates a split-brain scenario in which both clusters believe they are active.
 // Both clusters then accept a signal and write it to their own history, and the test confirms that the signal is
 // reapplied during the resulting conflict resolution process.
-func (s *historyReplicationConflictTestSuite) TestConflictResolutionReappliesSignals() {
-	s.tv = testvars.New(s.T().Name())
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, testTimeout)
+func (s *hrsuTestSuite) TestConflictResolutionReappliesSignals() {
+	t, ctx, cancel := s.startHrsuTest()
 	defer cancel()
-	sdkClient1, sdkClient2 := s.createSdkClients()
 
-	s.registerMultiRegionNamespace(ctx)
-	runId := s.startWorkflow(ctx, sdkClient1)
-	s.enterSplitBrainState(ctx)
+	t.enterSplitBrainState(ctx)
 
 	// Both clusters now believe they are active and hence both will accept a signal.
 
 	// Send signals
-	s.NoError(sdkClient1.SignalWorkflow(ctx, s.tv.WorkflowID(), runId, "my-signal", "cluster1-signal"))
-	s.NoError(sdkClient2.SignalWorkflow(ctx, s.tv.WorkflowID(), runId, "my-signal", "cluster2-signal"))
+	s.NoError(t.cluster1.client.SignalWorkflow(ctx, t.tv.WorkflowID(), t.runId, "my-signal", "cluster1-signal"))
+	s.NoError(t.cluster2.client.SignalWorkflow(ctx, t.tv.WorkflowID(), t.runId, "my-signal", "cluster2-signal"))
 
 	// cluster1 has accepted a signal
 	s.HistoryRequire.EqualHistoryEventsAndVersions(`
 	1 WorkflowExecutionStarted
 	2 WorkflowTaskScheduled
 	3 WorkflowExecutionSignaled {"Input": {"Payloads": [{"Data": "\"cluster1-signal\""}]}}
-	`, []int{1, 1, 1}, s.getHistory(ctx, s.cluster1, runId))
+	`, []int{1, 1, 1}, t.cluster1.getHistory(ctx))
 
 	// cluster2 has also accepted a signal (with failover version 2 since it is endogenous to cluster 2)
 	s.HistoryRequire.EqualHistoryEventsAndVersions(`
 	1 WorkflowExecutionStarted
 	2 WorkflowTaskScheduled
 	3 WorkflowExecutionSignaled {"Input": {"Payloads": [{"Data": "\"cluster2-signal\""}]}}
-	`, []int{1, 1, 2}, s.getHistory(ctx, s.cluster2, runId))
+	`, []int{1, 1, 2}, t.cluster2.getHistory(ctx))
 
 	// Execute pending history replication tasks. Each cluster sends its signal to the other, but these have the same
 	// event ID; this conflict is resolved by reapplying one of the signals after the other.
 
 	// cluster2 sends its signal to cluster1. Since it has a higher failover version, it supersedes the endogenous
 	// signal in cluster1.
-	s.executeHistoryReplicationTasksFromClusterUntil("cluster2", enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED)
+	t.cluster2.executeHistoryReplicationTasksFromClusterUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED)
 	s.HistoryRequire.EqualHistoryEventsAndVersions(`
 	1 WorkflowExecutionStarted
 	2 WorkflowTaskScheduled
 	3 WorkflowExecutionSignaled {"Input": {"Payloads": [{"Data": "\"cluster2-signal\""}]}}
-	`, []int{1, 1, 2}, s.getHistory(ctx, s.cluster1, runId))
+	`, []int{1, 1, 2}, t.cluster1.getHistory(ctx))
 
 	// cluster1 sends its signal to cluster2. Since it has a lower failover version, it is reapplied after the
 	// endogenous cluster 2 signal.
-	s.executeHistoryReplicationTasksFromClusterUntil("cluster1", enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED)
+	t.cluster1.executeHistoryReplicationTasksFromClusterUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED)
 	s.HistoryRequire.EqualHistoryEventsAndVersions(`
 	1 WorkflowExecutionStarted
 	2 WorkflowTaskScheduled
 	3 WorkflowExecutionSignaled {"Input": {"Payloads": [{"Data": "\"cluster2-signal\""}]}}
 	4 WorkflowExecutionSignaled {"Input": {"Payloads": [{"Data": "\"cluster1-signal\""}]}}
-	`, []int{1, 1, 2, 2}, s.getHistory(ctx, s.cluster2, runId))
+	`, []int{1, 1, 2, 2}, t.cluster2.getHistory(ctx))
 
 	// Cluster2 sends the reapplied signal to cluster1, bringing the cluster histories into agreement.
-	s.executeHistoryReplicationTasksFromClusterUntil("cluster2", enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED)
-	s.EqualValues(
-		s.getHistory(ctx, s.cluster1, runId),
-		s.getHistory(ctx, s.cluster2, runId),
-	)
+	t.cluster2.executeHistoryReplicationTasksFromClusterUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED)
+	s.EqualValues(t.cluster1.getHistory(ctx), t.cluster2.getHistory(ctx))
 }
 
-func (s *historyReplicationConflictTestSuite) enterSplitBrainState(ctx context.Context) {
+// TestConflictResolutionReappliesUpdates creates a split-brain scenario in which both clusters believe they are active.
+// Both clusters then accept an update and write it to their own history, and the test confirms that the update is
+// reapplied during the resulting conflict resolution process.
+func (s *hrsuTestSuite) TestConflictResolutionReappliesUpdates() {
+	t, ctx, cancel := s.startHrsuTest()
+	defer cancel()
+
+	cluster1UpdateId := "cluster1-update-id"
+	cluster2UpdateId := "cluster2-update-id"
+	t.enterSplitBrainStateAndSendUpdatesToBothClusters(ctx, cluster1UpdateId, cluster2UpdateId)
+	// cluster1 has received an update with failover version 2 which superseded its own update.
+	s.HistoryRequire.EqualHistoryEventsAndVersions(fmt.Sprintf(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "%s", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster2-update-input\""}]}}}}
+	`, cluster2UpdateId), []int{1, 1, 2, 2, 2}, t.cluster1.getHistory(ctx))
+
+	// cluster2 has reapplied the accepted update from cluster 1 on top of its own update, changing it from state
+	// Accepted to state Admitted, since it must be submitted to the validator on the new branch.
+	s.HistoryRequire.EqualHistoryEventsAndVersions(fmt.Sprintf(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "%s", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster2-update-input\""}]}}}}
+	6 WorkflowExecutionUpdateAdmitted {"Request": {"Meta": {"UpdateId": "%s"}, "Input": {"Args": {"Payloads": [{"Data": "\"cluster1-update-input\""}]}}}}
+	7 WorkflowTaskScheduled
+	`, cluster2UpdateId, cluster1UpdateId), []int{1, 1, 2, 2, 2, 2, 2}, t.cluster2.getHistory(ctx))
+
+	// Cluster2 sends the reapplied update to cluster1, bringing the cluster histories into agreement.
+	t.cluster2.executeHistoryReplicationTasksFromClusterUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED)
+	s.EqualValues(t.cluster1.getHistory(ctx), t.cluster2.getHistory(ctx))
+
+	s.NoError(t.cluster2.pollAndCompleteUpdate(cluster2UpdateId))
+	s.HistoryRequire.EqualHistoryEventsAndVersions(fmt.Sprintf(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "%s", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster2-update-input\""}]}}}}
+	6 WorkflowExecutionUpdateAdmitted {"Request": {"Meta": {"UpdateId": "%s"}, "Input": {"Args": {"Payloads": [{"Data": "\"cluster1-update-input\""}]}}}}
+	7 WorkflowTaskScheduled
+	8 WorkflowTaskStarted
+	9 WorkflowTaskCompleted
+   10 WorkflowExecutionUpdateCompleted {"Meta": {"UpdateId": "%s"}}
+  `, cluster2UpdateId, cluster1UpdateId, cluster2UpdateId), []int{1, 1, 2, 2, 2, 2, 2, 2, 2, 2}, t.cluster2.getHistory(ctx))
+}
+
+// TestConflictResolutionReappliesUpdatesSameIds creates a split-brain scenario in which both clusters believe they are
+// active. Both clusters then accept an update and write it to their own history, but those updates have the same update
+// ID.
+func (s *hrsuTestSuite) TestConflictResolutionReappliesUpdatesSameIds() {
+	// TODO (dan) The event-reapply implementation should drop the update since its update ID conflicts with an
+	// in-flight update. Currently this is not done and hence replication fails with "Update ID update-id is already
+	// present in mutable state"
+	s.T().SkipNow()
+	t, ctx, cancel := s.startHrsuTest()
+	defer cancel()
+	t.enterSplitBrainStateAndSendUpdatesToBothClusters(ctx, "update-id", "update-id")
+}
+
+// Start update in cluster 1 and run it through to acceptance.
+func (t *hrsuTest) startAndAcceptUpdateInCluster1ThenFailoverTo2AndCompleteUpdate(ctx context.Context) {
+	t.cluster1.sendUpdateAndWaitUntilAccepted(ctx, "cluster1-update-id", "cluster1-update-input")
+	t.cluster1.executeHistoryReplicationTasksFromClusterUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED)
+
+	for _, c := range []hrsuTestCluster{t.cluster1, t.cluster2} {
+		t.s.HistoryRequire.EqualHistoryEventsAndVersions(`
+		1 WorkflowExecutionStarted
+		2 WorkflowTaskScheduled
+		3 WorkflowTaskStarted
+		4 WorkflowTaskCompleted
+		5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "cluster1-update-id", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster1-update-input\""}]}}}}
+		`, []int{1, 1, 1, 1, 1}, c.getHistory(ctx))
+	}
+
+	t.failover1To2(ctx)
+
+	// This test does not explicitly model the update handler, but since the update has been accepted yet not completed,
+	// the handler must have scheduled something (e.g. a timer, an activity, a child workflow), and we need to do
+	// something to create another WorkflowTaskScheduled event, so that the worker can send the update completion
+	// message. We use a signal for that purpose.
+	t.s.NoError(t.cluster2.client.SignalWorkflow(ctx, t.tv.WorkflowID(), t.runId, "my-signal", "cluster2-signal"))
+
+	// Complete the update in  cluster 2 after the failover.
+	t.s.NoError(t.cluster2.pollAndCompleteUpdate("cluster1-update-id"))
+
+	t.s.HistoryRequire.EqualHistoryEventsAndVersions(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "cluster1-update-id", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster1-update-input\""}]}}}}
+	6 WorkflowExecutionSignaled
+	7 WorkflowTaskScheduled
+	8 WorkflowTaskStarted
+	9 WorkflowTaskCompleted
+   10 WorkflowExecutionUpdateCompleted {"Meta": {"UpdateId": "cluster1-update-id"}}
+	`, []int{1, 1, 1, 1, 1, 2, 2, 2, 2, 2}, t.cluster2.getHistory(ctx))
+}
+
+// Run an update in cluster 2 to Accepted state, failover to cluster 1, and confirm that it can be completed in cluster 1.
+func (t *hrsuTest) startAndAcceptUpdateInCluster2ThenFailoverTo1AndCompleteUpdate(ctx context.Context) {
+	t.cluster2.sendUpdateAndWaitUntilAccepted(ctx, "cluster2-update-id", "cluster2-update-input")
+	t.cluster2.executeHistoryReplicationTasksFromClusterUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED)
+
+	for _, c := range []hrsuTestCluster{t.cluster1, t.cluster2} {
+		t.s.HistoryRequire.EqualHistoryEventsAndVersions(`
+		1 WorkflowExecutionStarted
+		2 WorkflowTaskScheduled
+		3 WorkflowTaskStarted
+		4 WorkflowTaskCompleted
+		5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "cluster1-update-id", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster1-update-input\""}]}}}}
+		6 WorkflowExecutionSignaled
+		7 WorkflowTaskScheduled
+		8 WorkflowTaskStarted
+		9 WorkflowTaskCompleted
+	   10 WorkflowExecutionUpdateCompleted {"Meta": {"UpdateId": "cluster1-update-id"}}
+	   11 WorkflowTaskScheduled
+	   12 WorkflowTaskStarted
+	   13 WorkflowTaskCompleted
+	   14 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "cluster2-update-id", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster2-update-input\""}]}}}}
+	   `, []int{1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2}, c.getHistory(ctx))
+	}
+
+	t.failover2To1(ctx)
+
+	// As above, send a signal to create a WorkflowTaskScheduled event.
+	t.s.NoError(t.cluster1.client.SignalWorkflow(ctx, t.tv.WorkflowID(), t.runId, "my-signal", "cluster1-signal"))
+	t.s.NoError(t.cluster1.pollAndCompleteUpdate("cluster2-update-id"))
+
+	t.s.HistoryRequire.EqualHistoryEventsAndVersions(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "cluster1-update-id", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster1-update-input\""}]}}}}
+	6 WorkflowExecutionSignaled
+	7 WorkflowTaskScheduled
+	8 WorkflowTaskStarted
+	9 WorkflowTaskCompleted
+   10 WorkflowExecutionUpdateCompleted {"Meta": {"UpdateId": "cluster1-update-id"}}
+   11 WorkflowTaskScheduled
+   12 WorkflowTaskStarted
+   13 WorkflowTaskCompleted
+   14 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "cluster2-update-id", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster2-update-input\""}]}}}}
+   15 WorkflowExecutionSignaled
+   16 WorkflowTaskScheduled
+   17 WorkflowTaskStarted
+   18 WorkflowTaskCompleted
+   19 WorkflowExecutionUpdateCompleted {"Meta": {"UpdateId": "cluster2-update-id"}}
+   `, []int{1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 11, 11, 11, 11, 11}, t.cluster1.getHistory(ctx))
+}
+
+func (t *hrsuTest) enterSplitBrainStateAndSendUpdatesToBothClusters(ctx context.Context, cluster1UpdateId, cluster2UpdateId string) {
+	t.enterSplitBrainState(ctx)
+
+	// Both clusters now believe they are active and hence both will accept an update.
+
+	// Send updates
+	t.cluster1.sendUpdateAndWaitUntilAccepted(ctx, cluster1UpdateId, "cluster1-update-input")
+	t.cluster2.sendUpdateAndWaitUntilAccepted(ctx, cluster2UpdateId, "cluster2-update-input")
+
+	// cluster1 has accepted an update
+	t.s.HistoryRequire.EqualHistoryEventsAndVersions(fmt.Sprintf(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "%s", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster1-update-input\""}]}}}}
+	`, cluster1UpdateId), []int{1, 1, 1, 1, 1}, t.cluster1.getHistory(ctx))
+
+	// cluster2 has also accepted an update (events have failover version 2 since they are endogenous to cluster 2)
+	t.s.HistoryRequire.EqualHistoryEventsAndVersions(fmt.Sprintf(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "%s", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster2-update-input\""}]}}}}
+	`, cluster2UpdateId), []int{1, 1, 2, 2, 2}, t.cluster2.getHistory(ctx))
+
+	// Execute pending history replication tasks. Each cluster sends its update to the other, triggering conflict
+	// resolution.
+	t.cluster1.executeHistoryReplicationTasksFromClusterUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED)
+	t.cluster2.executeHistoryReplicationTasksFromClusterUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED)
+}
+
+func (t *hrsuTest) failover1To2(ctx context.Context) {
+	t.s.Equal([]string{"cluster1", "cluster1"}, t.getActiveClusters(ctx))
+	t.cluster1.setActive(ctx, "cluster2")
+	t.s.Equal([]string{"cluster2", "cluster1"}, t.getActiveClusters(ctx))
+
+	time.Sleep(tests.NamespaceCacheRefreshInterval)
+
+	t.executeNamespaceReplicationTasksUntil(ctx, enumsspb.NAMESPACE_OPERATION_UPDATE)
+	// Wait for active cluster to be changed in namespace registry entry.
+	// TODO (dan) It would be nice to find a better approach.
+	time.Sleep(tests.NamespaceCacheRefreshInterval)
+	t.s.Equal([]string{"cluster2", "cluster2"}, t.getActiveClusters(ctx))
+}
+
+func (t *hrsuTest) failover2To1(ctx context.Context) {
+	t.s.Equal([]string{"cluster2", "cluster2"}, t.getActiveClusters(ctx))
+	t.cluster1.setActive(ctx, "cluster1")
+	t.s.Equal([]string{"cluster1", "cluster2"}, t.getActiveClusters(ctx))
+
+	time.Sleep(tests.NamespaceCacheRefreshInterval)
+
+	t.executeNamespaceReplicationTasksUntil(ctx, enumsspb.NAMESPACE_OPERATION_UPDATE)
+	// Wait for active cluster to be changed in namespace registry entry.
+	// TODO (dan) It would be nice to find a better approach.
+	time.Sleep(tests.NamespaceCacheRefreshInterval)
+	t.s.Equal([]string{"cluster1", "cluster1"}, t.getActiveClusters(ctx))
+}
+
+func (t *hrsuTest) enterSplitBrainState(ctx context.Context) {
 	// We now create a "split brain" state by setting cluster2 to active. We do not execute namespace replication tasks
 	// afterward, so cluster1 does not learn of the change.
-	s.Equal([]string{"cluster1", "cluster1"}, s.getActiveClusters(ctx))
-	s.setActive(ctx, s.cluster2, "cluster2")
-	s.Equal([]string{"cluster1", "cluster2"}, s.getActiveClusters(ctx))
+	t.s.Equal([]string{"cluster1", "cluster1"}, t.getActiveClusters(ctx))
+	t.cluster2.setActive(ctx, "cluster2")
+	t.s.Equal([]string{"cluster1", "cluster2"}, t.getActiveClusters(ctx))
 
 	// TODO (dan) Why do the tests still pass with this? Does this not remove the split-brain?
 	// s.executeNamespaceReplicationTasksUntil(ctx, enumsspb.NAMESPACE_OPERATION_UPDATE, 2)
@@ -221,26 +529,25 @@ func (s *historyReplicationConflictTestSuite) enterSplitBrainState(ctx context.C
 
 // executeNamespaceReplicationTasksUntil executes buffered namespace event replication tasks until the specified event
 // type is encountered with the specified failover version.
-func (s *historyReplicationConflictTestSuite) executeNamespaceReplicationTasksUntil(ctx context.Context, operation enumsspb.NamespaceOperation, version int64) {
+func (t *hrsuTest) executeNamespaceReplicationTasksUntil(ctx context.Context, operation enumsspb.NamespaceOperation) {
 	for {
-		task := <-s.namespaceReplicationTasks
-		err := s.namespaceTaskExecutor.Execute(ctx, task)
-		s.NoError(err)
-		if task.NamespaceOperation == operation && task.FailoverVersion == version {
+		task := <-t.namespaceReplicationTasks
+		err := t.s.namespaceTaskExecutor.Execute(ctx, task)
+		t.s.NoError(err)
+		if task.NamespaceOperation == operation {
 			return
 		}
 	}
 }
 
-// executeHistoryReplicationTasksFromClusterUntil executes buffered history event replication tasks until the specified event type
-// is encountered for the workflowId.
-func (s *historyReplicationConflictTestSuite) executeHistoryReplicationTasksFromClusterUntil(
-	sourceCluster string,
+// executeHistoryReplicationTasksFromClusterUntil executes buffered history event replication tasks until the specified
+// event type is encountered.
+func (c *hrsuTestCluster) executeHistoryReplicationTasksFromClusterUntil(
 	eventType enumspb.EventType,
 ) {
 	for {
-		t := <-s.historyReplicationTasks[sourceCluster]
-		events := s.executeHistoryReplicationTask(t)
+		task := <-c.outboundHistoryReplicationTasks
+		events := c.t.s.executeHistoryReplicationTask(task)
 		for _, event := range events {
 			if event.GetEventType() == eventType {
 				return
@@ -249,7 +556,7 @@ func (s *historyReplicationConflictTestSuite) executeHistoryReplicationTasksFrom
 	}
 }
 
-func (s *historyReplicationConflictTestSuite) executeHistoryReplicationTask(task *hrcTestExecutableTask) []*historypb.HistoryEvent {
+func (s *hrsuTestSuite) executeHistoryReplicationTask(task *hrsuTestExecutableTask) []*historypb.HistoryEvent {
 	serializer := serialization.NewSerializer()
 	trackableTask := (*task).TrackableExecutableTask
 	err := trackableTask.Execute()
@@ -257,20 +564,22 @@ func (s *historyReplicationConflictTestSuite) executeHistoryReplicationTask(task
 	task.result <- err
 	attrs := (*task).replicationTask.GetHistoryTaskAttributes()
 	s.NotNil(attrs)
-	s.Equal(s.tv.WorkflowID(), attrs.WorkflowId)
 	events, err := serializer.DeserializeEvents(attrs.Events)
 	s.NoError(err)
 	return events
 }
 
-func (c *hrcTestNamespaceReplicationTaskExecutor) Execute(ctx context.Context, task *replicationspb.NamespaceTaskAttributes) error {
-	c.s.namespaceReplicationTasks <- task
+func (e *hrsuTestNamespaceReplicationTaskExecutor) Execute(ctx context.Context, task *replicationspb.NamespaceTaskAttributes) error {
+	// TODO (dan) Use one channel per cluster, as we do for history replication tasks in this test suite. This is
+	// currently blocked by the fact that namespace tasks don't expose the current cluster name.
+	test := e.s.testsByNamespaceName[task.Info.Name]
+	test.namespaceReplicationTasks <- task
 	// Report success, although we have merely buffered the task and will execute it later.
 	return nil
 }
 
 // Convert the replication tasks using the base converter, and wrap them in our own executable tasks.
-func (t *hrcTestExecutableTaskConverter) Convert(
+func (t *hrsuTestExecutableTaskConverter) Convert(
 	taskClusterName string,
 	clientShardKey replication.ClusterShardKey,
 	serverShardKey replication.ClusterShardKey,
@@ -279,7 +588,7 @@ func (t *hrcTestExecutableTaskConverter) Convert(
 	convertedTasks := t.converter.Convert(taskClusterName, clientShardKey, serverShardKey, replicationTasks...)
 	testExecutableTasks := make([]replication.TrackableExecutableTask, len(convertedTasks))
 	for i, task := range convertedTasks {
-		testExecutableTasks[i] = &hrcTestExecutableTask{
+		testExecutableTasks[i] = &hrsuTestExecutableTask{
 			taskClusterName:         taskClusterName,
 			s:                       t.s,
 			TrackableExecutableTask: task,
@@ -291,105 +600,276 @@ func (t *hrcTestExecutableTaskConverter) Convert(
 }
 
 // Execute pushes the task to a buffer and waits for it to be executed.
-func (t *hrcTestExecutableTask) Execute() error {
-	t.s.historyReplicationTasks[t.taskClusterName] <- t
-	return <-t.result
+func (task *hrsuTestExecutableTask) Execute() error {
+	test := task.s.testsByWorkflowId[task.workflowId()]
+	switch task.taskClusterName {
+	case "cluster1":
+		test.cluster1.outboundHistoryReplicationTasks <- task
+	case "cluster2":
+		test.cluster2.outboundHistoryReplicationTasks <- task
+	default:
+		task.s.FailNow(fmt.Sprintf("invalid cluster name: %s", task.taskClusterName))
+	}
+	return <-task.result
+}
+
+func (task *hrsuTestExecutableTask) workflowId() string {
+	attrs := (*task).replicationTask.GetHistoryTaskAttributes()
+	task.s.NotNil(attrs)
+	return attrs.WorkflowId
+}
+
+// Update test utilities
+func (c *hrsuTestCluster) sendUpdateAndWaitUntilAccepted(ctx context.Context, updateId string, arg string) {
+	updateResponse := make(chan error)
+	processWorkflowTaskResponse := make(chan error)
+	go func() {
+		_, err := c.client.UpdateWorkflowWithOptions(ctx, &sdkclient.UpdateWorkflowWithOptionsRequest{
+			UpdateID:   updateId,
+			WorkflowID: c.t.tv.WorkflowID(),
+			RunID:      c.t.runId,
+			UpdateName: "the-test-doesn't-use-this",
+			Args:       []interface{}{arg},
+			WaitPolicy: &updatepb.WaitPolicy{
+				LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+			},
+		})
+		c.t.s.NoError(err)
+		updateResponse <- err
+	}()
+	go func() {
+		// Blocks until the update request causes a WFT to be dispatched; then sends the update acceptance message
+		// required for the update request to return.
+		processWorkflowTaskResponse <- c.pollAndAcceptUpdate()
+	}()
+	c.t.s.NoError(<-updateResponse)
+	c.t.s.NoError(<-processWorkflowTaskResponse)
+}
+
+func (c *hrsuTestCluster) sendUpdate(ctx context.Context, updateId string, arg string) {
+	updateResponse := make(chan error)
+	processWorkflowTaskResponse := make(chan error)
+	go func() {
+		_, err := c.client.UpdateWorkflowWithOptions(ctx, &sdkclient.UpdateWorkflowWithOptionsRequest{
+			UpdateID:   updateId,
+			WorkflowID: c.t.tv.WorkflowID(),
+			RunID:      c.t.runId,
+			UpdateName: "the-test-doesn't-use-this",
+			Args:       []interface{}{arg},
+			WaitPolicy: &updatepb.WaitPolicy{
+				LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+			},
+		})
+		c.t.s.NoError(err)
+		updateResponse <- err
+	}()
+	go func() {
+		// Blocks until the update request causes a WFT to be dispatched; then sends the update acceptance message
+		// required for the update request to return.
+		processWorkflowTaskResponse <- c.pollAndAcceptUpdate()
+	}()
+	c.t.s.NoError(<-updateResponse)
+	c.t.s.NoError(<-processWorkflowTaskResponse)
+}
+
+func (c *hrsuTestCluster) pollAndAcceptUpdate() error {
+	poller := &tests.TaskPoller{
+		Engine:              c.testCluster.GetFrontendClient(),
+		Namespace:           c.t.tv.NamespaceName().String(),
+		TaskQueue:           c.t.tv.TaskQueue(),
+		Identity:            c.t.tv.WorkerIdentity(),
+		WorkflowTaskHandler: c.t.acceptUpdateWFTHandler,
+		MessageHandler:      c.t.acceptUpdateMessageHandler,
+		Logger:              c.t.s.logger,
+		T:                   c.t.s.T(),
+	}
+	_, err := poller.PollAndProcessWorkflowTask(tests.WithDumpHistory)
+	return err
+}
+
+func (c *hrsuTestCluster) pollAndCompleteUpdate(updateId string) error {
+	poller := &tests.TaskPoller{
+		Engine:              c.testCluster.GetFrontendClient(),
+		Namespace:           c.t.tv.NamespaceName().String(),
+		TaskQueue:           c.t.tv.TaskQueue(),
+		Identity:            c.t.tv.WorkerIdentity(),
+		WorkflowTaskHandler: c.t.completeUpdateWFTHandler,
+		MessageHandler:      c.t.completeUpdateMessageHandler(updateId),
+		Logger:              c.t.s.logger,
+		T:                   c.t.s.T(),
+	}
+	_, err := poller.PollAndProcessWorkflowTask(tests.WithDumpHistory)
+	return err
+}
+
+func (c *hrsuTestCluster) pollAndErrorWhileProcessingWorkflowTask() error {
+	poller := &tests.TaskPoller{
+		Engine:              c.testCluster.GetFrontendClient(),
+		Namespace:           c.t.tv.NamespaceName().String(),
+		TaskQueue:           c.t.tv.TaskQueue(),
+		Identity:            c.t.tv.WorkerIdentity(),
+		WorkflowTaskHandler: c.t.respondWithErrorWFTHandler,
+		MessageHandler:      c.t.respondWithErrorMessageHandler,
+		Logger:              c.t.s.logger,
+		T:                   c.t.s.T(),
+	}
+	_, err := poller.PollAndProcessWorkflowTask(tests.WithDumpHistory)
+	return err
+}
+
+func (t *hrsuTest) acceptUpdateMessageHandler(resp *workflowservice.PollWorkflowTaskQueueResponse) ([]*protocolpb.Message, error) {
+	// The WFT contains the update request as a protocol message xor an UpdateAdmittedEvent: obtain the updateId from
+	// one or the other.
+	var updateAdmittedEvent *historypb.HistoryEvent
+	for _, e := range resp.History.Events {
+		if e.EventType == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED {
+			t.s.Nil(updateAdmittedEvent)
+			updateAdmittedEvent = e
+		}
+	}
+	updateId := ""
+	if updateAdmittedEvent != nil {
+		t.s.Empty(resp.Messages)
+		attrs := updateAdmittedEvent.GetWorkflowExecutionUpdateAdmittedEventAttributes()
+		updateId = attrs.Request.Meta.UpdateId
+	} else {
+		t.s.Equal(1, len(resp.Messages))
+		msg := resp.Messages[0]
+		updateId = msg.ProtocolInstanceId
+	}
+
+	return []*protocolpb.Message{
+		{
+			Id:                 "accept-msg-id",
+			ProtocolInstanceId: updateId,
+			Body: protoutils.MarshalAny(t.s.T(), &updatepb.Acceptance{
+				AcceptedRequestMessageId:         "request-msg-id",
+				AcceptedRequestSequencingEventId: int64(-1),
+			}),
+		},
+	}, nil
+}
+
+func (t *hrsuTest) acceptUpdateWFTHandler(_ *commonpb.WorkflowExecution, _ *commonpb.WorkflowType, _ int64, _ int64, _ *historypb.History) ([]*commandpb.Command, error) {
+	return []*commandpb.Command{{
+		CommandType: enumspb.COMMAND_TYPE_PROTOCOL_MESSAGE,
+		Attributes: &commandpb.Command_ProtocolMessageCommandAttributes{ProtocolMessageCommandAttributes: &commandpb.ProtocolMessageCommandAttributes{
+			MessageId: "accept-msg-id",
+		}},
+	}}, nil
+}
+
+func (t *hrsuTest) completeUpdateMessageHandler(updateId string) func(resp *workflowservice.PollWorkflowTaskQueueResponse) ([]*protocolpb.Message, error) {
+	return func(resp *workflowservice.PollWorkflowTaskQueueResponse) ([]*protocolpb.Message, error) {
+		return []*protocolpb.Message{
+			{
+				Id:                 "completion-msg-id",
+				ProtocolInstanceId: updateId,
+				SequencingId:       nil,
+				Body: protoutils.MarshalAny(t.s.T(), &updatepb.Response{
+					Meta: &updatepb.Meta{
+						UpdateId: updateId,
+						Identity: t.tv.WorkerIdentity(),
+					},
+					Outcome: &updatepb.Outcome{
+						Value: &updatepb.Outcome_Success{
+							Success: t.tv.Any().Payloads(),
+						},
+					},
+				}),
+			},
+		}, nil
+
+	}
+}
+
+func (t *hrsuTest) completeUpdateWFTHandler(_ *commonpb.WorkflowExecution, _ *commonpb.WorkflowType, _ int64, _ int64, _ *historypb.History) ([]*commandpb.Command, error) {
+	return []*commandpb.Command{{
+		CommandType: enumspb.COMMAND_TYPE_PROTOCOL_MESSAGE,
+		Attributes: &commandpb.Command_ProtocolMessageCommandAttributes{ProtocolMessageCommandAttributes: &commandpb.ProtocolMessageCommandAttributes{
+			MessageId: "completion-msg-id",
+		}},
+	}}, nil
+}
+
+func (t *hrsuTest) respondWithErrorMessageHandler(resp *workflowservice.PollWorkflowTaskQueueResponse) ([]*protocolpb.Message, error) {
+	return []*protocolpb.Message{}, errors.New("fake error while handling workflow task (message handler)")
+}
+
+func (t *hrsuTest) respondWithErrorWFTHandler(_ *commonpb.WorkflowExecution, _ *commonpb.WorkflowType, _ int64, _ int64, _ *historypb.History) ([]*commandpb.Command, error) {
+	return []*commandpb.Command{}, errors.New("fake error while handling workflow task (WFT handler)")
 }
 
 // gRPC utilities
 
-func (s *historyReplicationConflictTestSuite) createSdkClients() (sdkclient.Client, sdkclient.Client) {
-	c1, err := sdkclient.Dial(sdkclient.Options{
-		HostPort:  s.cluster1.GetHost().FrontendGRPCAddress(),
-		Namespace: s.tv.NamespaceName().String(),
-		Logger:    log.NewSdkLogger(s.logger),
+func (t *hrsuTest) registerMultiRegionNamespace(ctx context.Context) {
+	_, err := t.cluster1.testCluster.GetFrontendClient().RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{
+		Namespace:                        t.tv.NamespaceName().String(),
+		Clusters:                         t.s.clusterReplicationConfig(),
+		ActiveClusterName:                t.s.clusterNames[0],
+		IsGlobalNamespace:                true,                           // Needed so that the namespace is replicated
+		WorkflowExecutionRetentionPeriod: durationpb.New(time.Hour * 24), // Required parameter
 	})
-	s.NoError(err)
-	c2, err := sdkclient.Dial(sdkclient.Options{
-		HostPort:  s.cluster2.GetHost().FrontendGRPCAddress(),
-		Namespace: s.tv.NamespaceName().String(),
-		Logger:    log.NewSdkLogger(s.logger),
-	})
-	s.NoError(err)
-	return c1, c2
+	t.s.NoError(err)
+	// Namespace event replication tasks are being captured; we need to execute the pending ones now to propagate the
+	// new namespace to cluster 2.
+	t.executeNamespaceReplicationTasksUntil(ctx, enumsspb.NAMESPACE_OPERATION_CREATE)
+	t.s.Equal([]string{"cluster1", "cluster1"}, t.getActiveClusters(ctx))
 }
 
-func (s *historyReplicationConflictTestSuite) startWorkflow(ctx context.Context, cluster1Client sdkclient.Client) string {
+func (t *hrsuTest) getActiveClusters(ctx context.Context) []string {
+	return []string{t.cluster1.getActiveCluster(ctx), t.cluster2.getActiveCluster(ctx)}
+}
+
+func (c *hrsuTestCluster) startWorkflow(ctx context.Context) string {
 	myWorkflow := func(ctx workflow.Context) error { return nil }
-	run, err := cluster1Client.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
-		TaskQueue: s.tv.TaskQueue().Name,
-		ID:        s.tv.WorkflowID(),
+	run, err := c.client.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+		TaskQueue: c.t.tv.TaskQueue().Name,
+		ID:        c.t.tv.WorkflowID(),
 	}, myWorkflow)
-	s.NoError(err)
+	c.t.s.NoError(err)
 	runId := run.GetRunID()
 
 	// Process history replication tasks until a task from cluster1 => cluster2 containing the initial workflow events
 	// is encountered.
-	s.executeHistoryReplicationTasksFromClusterUntil("cluster1", enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED)
+	c.executeHistoryReplicationTasksFromClusterUntil(enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED)
 
-	s.HistoryRequire.EqualHistoryEventsAndVersions(`
+	c.t.s.HistoryRequire.EqualHistoryEventsAndVersions(`
 	1 WorkflowExecutionStarted
   	2 WorkflowTaskScheduled
-  	`, []int{1, 1}, s.getHistory(ctx, s.cluster1, runId))
-	s.HistoryRequire.EqualHistoryEventsAndVersions(`
+  	`, []int{1, 1}, c.t.cluster1.getHistory(ctx))
+	c.t.s.HistoryRequire.EqualHistoryEventsAndVersions(`
 	1 WorkflowExecutionStarted
 	2 WorkflowTaskScheduled
-	`, []int{1, 1}, s.getHistory(ctx, s.cluster2, runId))
+	`, []int{1, 1}, c.t.cluster2.getHistory(ctx))
 
 	return runId
 }
 
-func (s *historyReplicationConflictTestSuite) registerMultiRegionNamespace(ctx context.Context) {
-	_, err := s.cluster1.GetFrontendClient().RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{
-		Namespace:                        s.tv.NamespaceName().String(),
-		Clusters:                         s.clusterReplicationConfig(),
-		ActiveClusterName:                s.clusterNames[0],
-		IsGlobalNamespace:                true,                           // Needed so that the namespace is replicated
-		WorkflowExecutionRetentionPeriod: durationpb.New(time.Hour * 24), // Required parameter
-	})
-	s.NoError(err)
-	// Namespace event replication tasks are being captured; we need to execute the pending ones now to propagate the
-	// new namespace to cluster 2.
-	s.executeNamespaceReplicationTasksUntil(ctx, enumsspb.NAMESPACE_OPERATION_CREATE, 1)
-	s.Equal([]string{"cluster1", "cluster1"}, s.getActiveClusters(ctx))
-}
-
-func (s *historyReplicationConflictTestSuite) setActive(ctx context.Context, cluster *tests.TestCluster, clusterName string) {
-	_, err := cluster.GetFrontendClient().UpdateNamespace(ctx, &workflowservice.UpdateNamespaceRequest{
-		Namespace: s.tv.NamespaceName().String(),
+func (c *hrsuTestCluster) setActive(ctx context.Context, clusterName string) {
+	_, err := c.testCluster.GetFrontendClient().UpdateNamespace(ctx, &workflowservice.UpdateNamespaceRequest{
+		Namespace: c.t.tv.NamespaceName().String(),
 		ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
 			ActiveClusterName: clusterName,
 		},
 	})
-	s.NoError(err)
+	c.t.s.NoError(err)
 }
 
-func (s *historyReplicationConflictTestSuite) getHistory(ctx context.Context, cluster *tests.TestCluster, rid string) []*historypb.HistoryEvent {
-	historyResponse, err := cluster.GetFrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
-		Namespace: s.tv.NamespaceName().String(),
+func (c *hrsuTestCluster) getHistory(ctx context.Context) []*historypb.HistoryEvent {
+	historyResponse, err := c.testCluster.GetFrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: c.t.tv.NamespaceName().String(),
 		Execution: &commonpb.WorkflowExecution{
-			WorkflowId: s.tv.WorkflowID(),
-			RunId:      rid,
+			WorkflowId: c.t.tv.WorkflowID(),
+			RunId:      c.t.runId,
 		},
 	})
-	s.NoError(err)
+	c.t.s.NoError(err)
 	return historyResponse.History.Events
 }
 
-func (s *historyReplicationConflictTestSuite) getActiveClusters(ctx context.Context) []string {
-	return []string{
-		s.getActiveCluster(ctx, s.cluster1),
-		s.getActiveCluster(ctx, s.cluster2),
-	}
-}
-
-func (s *historyReplicationConflictTestSuite) getActiveCluster(ctx context.Context, cluster *tests.TestCluster) string {
-	resp, err := cluster.GetFrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{Namespace: s.tv.NamespaceName().String()})
-	s.NoError(err)
+func (c *hrsuTestCluster) getActiveCluster(ctx context.Context) string {
+	resp, err := c.testCluster.GetFrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{Namespace: c.t.tv.NamespaceName().String()})
+	c.t.s.NoError(err)
 	return resp.ReplicationConfig.ActiveClusterName
-}
-
-func (s *historyReplicationConflictTestSuite) decodePayloadsString(ps *commonpb.Payloads) (r string) {
-	s.NoError(payloads.Decode(ps, &r))
-	return
 }


### PR DESCRIPTION
This PR adds functional test coverage for various scenarios involving updates and history event replication:

**`TestConflictResolutionReappliesUpdates`**: this test passes without requiring further changes (the necessary work was done in the previous PRs addressing WorkflowReset and reapplying updates).

**`TestAcceptedUpdateCanBeCompletedAfterFailoverAndFailback`**, **`TestUpdateCompletedAfterFailoverCannotBeCompletedAgainAfterFailback`**: to make these tests pass, this PR modifies update registry mechanics: we now update the registry from mutable state every time we obtain the registry from the workflow context. This is needed because, when we failback to cluster 1 after a failover, cluster 1 already has a populated registry, which must be brought up to date with events in history received from cluster2 (and hence in mutable state).

@alexshtin and I are discussing an alternative solution based on dropping the registry instead of updating it, so a future PR may change the way that the tests introduced here are satisfied.

**`TestConflictResolutionReappliesUpdatesSameIds`**: this test fails and is skipped; it will be addressed in the next PR.


## Potential risks
If the update registry changes here are incorrect then update could be broken in various ways.

## Is hotfix candidate?
No