### PR TITLE
Track Start Workflow actions correctly

### DIFF
--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -66,17 +66,18 @@ var (
 var (
 	respondWorkflowTaskCompleted = "RespondWorkflowTaskCompleted"
 	pollActivityTaskQueue        = "PollActivityTaskQueue"
+	startWorkflowExecution       = "StartWorkflowExecution"
 
 	grpcActions = map[string]struct{}{
+		startWorkflowExecution:             {},
+		respondWorkflowTaskCompleted:       {},
+		pollActivityTaskQueue:              {},
 		"QueryWorkflow":                    {},
 		"RecordActivityTaskHeartbeat":      {},
 		"RecordActivityTaskHeartbeatById":  {},
 		"ResetWorkflowExecution":           {},
-		"StartWorkflowExecution":           {},
 		"SignalWorkflowExecution":          {},
 		"SignalWithStartWorkflowExecution": {},
-		"RespondWorkflowTaskCompleted":     {},
-		"PollActivityTaskQueue":            {},
 		"CreateSchedule":                   {},
 		"UpdateSchedule":                   {},
 		"DeleteSchedule":                   {},
@@ -214,6 +215,15 @@ func (ti *TelemetryInterceptor) emitActionMetric(
 	}
 
 	switch methodName {
+	case startWorkflowExecution:
+		resp, ok := result.(*workflowservice.StartWorkflowExecutionResponse)
+		if !ok {
+			return
+		}
+		if resp.Started {
+			metrics.ActionCounter.With(metricsHandler).Record(1, metrics.ActionType("grpc_"+methodName))
+		}
+
 	case respondWorkflowTaskCompleted:
 		// handle commands
 		completedRequest, ok := req.(*workflowservice.RespondWorkflowTaskCompletedRequest)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Adjust the Action metric for Start Workflow. This metric is used by OSS users to estimate their Cloud bill.

## Why?
<!-- Tell your future self why have you made these changes -->

After https://github.com/temporalio/api/pull/359 was merged, a successful gRPC response from Start Workflow doesn't always result in an Action.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Added tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

Low. It's only an internal metric.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
