### PR TITLE
Use pagination token in loadClusterInformationFromStore

### DIFF
--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -683,7 +683,7 @@ func loadClusterInformationFromStore(ctx context.Context, svc *config.Config, cl
 	iter := collection.NewPagingIterator(func(paginationToken []byte) ([]interface{}, []byte, error) {
 		request := &persistence.ListClusterMetadataRequest{
 			PageSize:      100,
-			NextPageToken: nil,
+			NextPageToken: paginationToken,
 		}
 		resp, err := clusterMsg.ListClusterMetadata(ctx, request)
 		if err != nil {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
We forgot to use the next page token when loading all clusters in the cluster metadata loader during startup. This probably doesn't matter because most people don't have more than 100 clusters, but it looks like this code would trigger an infinite loop if that were the case.

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
You can see the infinite loop in action if you set the page size to 1 for the xdc cluster setup by running `make install-schema-xdc && make start-xdc-cluster-a` because it has 3 clusters, which means 2 remote clusters, so a page size of 1 will not get all clusters, causing the paginating iterator to call the func again. <img width="945" alt="image" src="https://github.com/temporalio/temporal/assets/5942963/11bb683c-588c-476f-9163-46405452755f">

If I actually use the paginationToken, you can see that the issue goes away.
<img width="1082" alt="image" src="https://github.com/temporalio/temporal/assets/5942963/3ce37d7b-aaeb-464b-a8d7-db6413176391">



## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
