### PR TITLE
Use generics in loadClusterInformationFromStore

### DIFF
--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -680,7 +680,7 @@ func ApplyClusterMetadataConfigProvider(
 
 // TODO: move this to cluster.fx
 func loadClusterInformationFromStore(ctx context.Context, svc *config.Config, clusterMsg persistence.ClusterMetadataManager, logger log.Logger) error {
-	iter := collection.NewPagingIterator(func(paginationToken []byte) ([]interface{}, []byte, error) {
+	iter := collection.NewPagingIterator(func(paginationToken []byte) ([]*persistence.GetClusterMetadataResponse, []byte, error) {
 		request := &persistence.ListClusterMetadataRequest{
 			PageSize:      100,
 			NextPageToken: nil,
@@ -689,19 +689,14 @@ func loadClusterInformationFromStore(ctx context.Context, svc *config.Config, cl
 		if err != nil {
 			return nil, nil, err
 		}
-		var pageItem []interface{}
-		for _, metadata := range resp.ClusterMetadata {
-			pageItem = append(pageItem, metadata)
-		}
-		return pageItem, resp.NextPageToken, nil
+		return resp.ClusterMetadata, resp.NextPageToken, nil
 	})
 
 	for iter.HasNext() {
-		item, err := iter.Next()
+		metadata, err := iter.Next()
 		if err != nil {
 			return err
 		}
-		metadata := item.(*persistence.GetClusterMetadataResponse)
 		shardCount := metadata.HistoryShardCount
 		if shardCount == 0 {
 			// This is to add backward compatibility to the svc based cluster connection.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
The `loadClusterInformationFromStore` function was written before we had generics, so it does some type-casting, and it also allocates a new slice to copy the `[]*persistence.GetClusterMetadataResponse` into a `[]interface{}`. We can now make this generic to be more readable and efficient.

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
