### PR TITLE
Run go mod tidy in clean-proto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,8 +175,9 @@ ci-update-tools: update-goimports update-mockgen update-proto-plugins update-pro
 $(PROTO_OUT):
 	@mkdir -p $(PROTO_OUT)
 
-clean-proto:
-	@go mod tidy # Make sure go.mod is up to date before we delete the generated files in case protogen fails and we need to rerun it.
+# We depend on gomodtidy to ensure that go.mod is up to date before we delete the generated files
+# in case protogen fails, and we need to rerun it.
+clean-proto: gomodtidy
 	@rm -rf $(PROTO_OUT)/*
 
 update-proto-submodule:

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ $(PROTO_OUT):
 	@mkdir -p $(PROTO_OUT)
 
 clean-proto:
+	@go mod tidy # Make sure go.mod is up to date before we delete the generated files in case protogen fails and we need to rerun it.
 	@rm -rf $(PROTO_OUT)/*
 
 update-proto-submodule:


### PR DESCRIPTION
## What Changed?
### Summary
Fixed an issue where `make proto` fails due to untracked dependencies, leading to the deletion of generated code necessary for `go mod tidy`.

### Detailed Explanation
When `make proto` is executed, it invokes the `service-clients` target, which runs `go generate ./client/...`. This operation requires compiling code in the `.cmd/tools/rpcwrappers` package. If there is a missing dependency in `go.sum`, likely due to a recent dependency upgrade via `go get go.temporal.io/api@…`, the compilation and client generation fail. This failure occurs after the `clean-proto` target has already deleted the existing clients. Consequently, `go mod tidy` also fails because it cannot resolve dependencies on the now-missing `service-clients` output, such as `go.temporal.io/server/api/adminservicemock/v1`. 

A workaround is to restore the deleted generated code before running `go mod tidy` again, using:

```shell
git restore $(git ls-files --deleted)
go mod tidy # should now succeed
make proto # should now succeed with the updated go.sum
```

### Reproduction Steps
1. Checkout the `temporalio/temporal` repository and navigate to the appropriate commit:
   ```shell
   git checkout e53b26b8bb7f03105a8e3e66eab89d92b58b21a2
   ```
2. Update the dependency and attempt to regenerate the client code:
   ```shell
   go get go.temporal.io/api@3a595fbfce0ae8cc25da63a3bef1143861408cc2
   make proto # This will fail
   ```
3. Attempt to tidy the module:
   ```shell
   go mod tidy # This will also fail
   ```
4. Restore the deleted files, tidy the module, and regenerate the client code:
   ```shell
   git restore $(git ls-files --deleted)
   go mod tidy # Should now work
   make proto # Should now succeed
   ```

## Why?
To address and prevent the build failure caused by untracked dependencies during client code generation, ensuring a consistent and error-free build process.

## How Did You Test It?
- Local reproduction of the issue and verification of the fix.
- Ensured that both `go mod tidy` and `make proto` commands succeed after applying the workaround.

## Potential Risks

## Documentation

## Is Hotfix Candidate?
