### PR TITLE
Fix check that redirect rule source is not the target of a ramped assignment rule

### DIFF
--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -154,7 +154,7 @@ func InsertCompatibleRedirectRule(timestamp *hlc.Clock,
 		return nil, serviceerror.NewFailedPrecondition(
 			"update breaks requirement, target build ID is already a member of a version set")
 	}
-	if isUnfilteredAssignmentRuleTarget(source, data.GetAssignmentRules()) {
+	if isConditionalAssignmentRuleTarget(source, data.GetAssignmentRules()) {
 		return nil, serviceerror.NewFailedPrecondition(
 			"redirect rule source build ID cannot be the target of any assignment rule with non-nil ramp")
 	}
@@ -370,9 +370,22 @@ func isRedirectRuleSource(buildID string, redirectRules []*persistencepb.Redirec
 	return false
 }
 
-func isUnfilteredAssignmentRuleTarget(buildID string, assignmentRules []*persistencepb.AssignmentRule) bool {
+// isConditionalAssignmentRuleTarget checks whether the given buildID is the target of a conditional assignment rule (one with a ramp).
+// We check this for any buildID that is the source of a proposed redirect rule, because having a ramped assignment rule
+// target as the source for a redirect rule would lead to an unpredictable amount of traffic being redirected, and the rest of the
+// traffic being passed through to the next assignment rule in the chain. This would not be a sensible use of redirect
+// rules or assignment rule ramps, so it is prohibited.
+//
+// e.g. Scenario in which a conditional assignment rule target is the source for a redirect rule
+//
+//	Assignment rules: [{target: 1, ramp: 50%}, {target: 2, ramp: nil}, {target: 3, ramp: nil}]
+//	  Redirect rules: [{1->4}]
+//			 Outcome: 50% of tasks that start with buildID 1 would be sent on to buildID 2 per assignment rules, and the
+//					  remaining 50% that "stay" on buildID 1 would be redirected to buildID 4 per the redirect rules.
+//					  This doesn't make sense, so we prohibit it.
+func isConditionalAssignmentRuleTarget(buildID string, assignmentRules []*persistencepb.AssignmentRule) bool {
 	for _, r := range getActiveAssignmentRules(assignmentRules) {
-		if buildID == r.GetRule().GetTargetBuildId() {
+		if !isUnconditional(r.GetRule()) && buildID == r.GetRule().GetTargetBuildId() {
 			return true
 		}
 	}

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -376,13 +376,13 @@ func isRedirectRuleSource(buildID string, redirectRules []*persistencepb.Redirec
 // traffic being passed through to the next assignment rule in the chain. This would not be a sensible use of redirect
 // rules or assignment rule ramps, so it is prohibited.
 //
-// e.g. Scenario in which a conditional assignment rule target is the source for a redirect rule
+// e.g. Scenario in which a conditional assignment rule target is the source for a redirect rule.
 //
 //	Assignment rules: [{target: 1, ramp: 50%}, {target: 2, ramp: nil}, {target: 3, ramp: nil}]
 //	  Redirect rules: [{1->4}]
-//			 Outcome: 50% of tasks that start with buildID 1 would be sent on to buildID 2 per assignment rules, and the
-//					  remaining 50% that "stay" on buildID 1 would be redirected to buildID 4 per the redirect rules.
-//					  This doesn't make sense, so we prohibit it.
+//	50% of tasks that start with buildID 1 would be sent on to buildID 2 per assignment rules, and the
+//	remaining 50% that "stay" on buildID 1 would be redirected to buildID 4 per the redirect rules.
+//	This doesn't make sense, so we prohibit it.
 func isConditionalAssignmentRuleTarget(buildID string, assignmentRules []*persistencepb.AssignmentRule) bool {
 	for _, r := range getActiveAssignmentRules(assignmentRules) {
 		if !isUnconditional(r.GetRule()) && buildID == r.GetRule().GetTargetBuildId() {

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -370,11 +370,11 @@ func isRedirectRuleSource(buildID string, redirectRules []*persistencepb.Redirec
 	return false
 }
 
-// isConditionalAssignmentRuleTarget checks whether the given buildID is the target of a conditional assignment rule (one with a ramp).
-// We check this for any buildID that is the source of a proposed redirect rule, because having a ramped assignment rule
-// target as the source for a redirect rule would lead to an unpredictable amount of traffic being redirected, and the rest of the
-// traffic being passed through to the next assignment rule in the chain. This would not be a sensible use of redirect
-// rules or assignment rule ramps, so it is prohibited.
+// isConditionalAssignmentRuleTarget checks whether the given buildID is the target of a conditional assignment rule
+// (one with a ramp). We check this for any buildID that is the source of a proposed redirect rule, because having a
+// ramped assignment rule target as the source for a redirect rule would lead to an unpredictable amount of traffic
+// being redirected vs being passed through to the next assignment rule in the chain. This would not be a sensible use
+// of redirect rules or assignment rule ramps, so it is prohibited.
 //
 // e.g. Scenario in which a conditional assignment rule target is the source for a redirect rule.
 //

--- a/service/matching/version_rule_test.go
+++ b/service/matching/version_rule_test.go
@@ -571,18 +571,23 @@ func TestInsertRedirectRuleInVersionSet(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestInsertRedirectRuleTerminalBuildID(t *testing.T) {
+func TestInsertRedirectRuleSourceIsRampedAssignmentRuleTarget(t *testing.T) {
 	t.Parallel()
 	maxRules := 3
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
 		mkAssignmentRulePersistence(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(10)), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRule("2", nil), clock, nil),
 	}
 
 	// insert redirect rule with target 1 --> failure
 	_, err := insertRedirectRule(mkRedirectRule("1", "0"), data, clock, maxRules)
 	assert.Error(t, err)
+
+	// insert redirect rule with target 2 --> success
+	_, err = insertRedirectRule(mkRedirectRule("2", "0"), data, clock, maxRules)
+	assert.NoError(t, err)
 }
 
 func TestInsertRedirectRuleAlreadyExists(t *testing.T) {


### PR DESCRIPTION
## What changed?
Check that ramp is set instead of not checking.
Rename function for better clarity, and add comment explaining reason.
Add test to catch this issue.

## Why?
Because the broken check was causing valid redirect rule inserts to fail.

## How did you test it?
Added a unit test. Made sure it failed with the old code and succeeded with the new code.

## Potential risks
None

## Documentation
Commented

## Is hotfix candidate?
No
