### PR TITLE
Workflow Update: return reached stage if requested stage is not reached

### DIFF
--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -125,8 +125,8 @@ var (
 
 	errWorkflowIdConflictPolicyNotAllowed             = serviceerror.NewPermissionDenied("WorkflowIdConflictPolicy option is disabled on this namespace.", "")
 	errUpdateWorkflowExecutionAPINotAllowed           = serviceerror.NewPermissionDenied("UpdateWorkflowExecution operation is disabled on this namespace.", "")
-	errUpdateWorkflowExecutionAsyncAcceptedNotAllowed = serviceerror.NewPermissionDenied("UpdateWorkflowExecution issued asynchronously and waiting on update accepted is disabled on this namespace", "")
-	errUpdateWorkflowExecutionAsyncAdmittedNotAllowed = serviceerror.NewPermissionDenied("UpdateWorkflowExecution issued asynchronously and waiting on update admitted is disabled on this namespace", "")
+	errUpdateWorkflowExecutionAsyncAcceptedNotAllowed = serviceerror.NewPermissionDenied("UpdateWorkflowExecution issued asynchronously and waiting on update accepted is disabled on this namespace.", "")
+	errUpdateWorkflowExecutionAsyncAdmittedNotAllowed = serviceerror.NewPermissionDenied("UpdateWorkflowExecution issued asynchronously and waiting on update admitted is not supported.", "")
 	errMultiOperationAPINotAllowed                    = serviceerror.NewPermissionDenied("ExecuteMultiOperation API is disabled on this namespace.", "")
 
 	errWorkerVersioningNotAllowed = serviceerror.NewPermissionDenied("Worker versioning is disabled on this namespace.", "")

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3306,7 +3306,6 @@ func (wh *WorkflowHandler) UpdateWorkflowExecution(
 	if request.GetWaitPolicy() == nil {
 		request.WaitPolicy = &updatepb.WaitPolicy{}
 	}
-	enums.SetDefaultUpdateWorkflowExecutionLifecycleStage(&request.GetWaitPolicy().LifecycleStage)
 
 	nsID, err := wh.namespaceRegistry.GetNamespaceID(namespace.Name(request.GetNamespace()))
 	if err != nil {
@@ -3315,6 +3314,12 @@ func (wh *WorkflowHandler) UpdateWorkflowExecution(
 
 	if !wh.config.EnableUpdateWorkflowExecution(request.Namespace) {
 		return nil, errUpdateWorkflowExecutionAPINotAllowed
+	}
+
+	enums.SetDefaultUpdateWorkflowExecutionLifecycleStage(&request.GetWaitPolicy().LifecycleStage)
+
+	if request.WaitPolicy.LifecycleStage == enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED {
+		return nil, errUpdateWorkflowExecutionAsyncAdmittedNotAllowed
 	}
 
 	if request.WaitPolicy.LifecycleStage == enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED &&

--- a/service/history/api/pollupdate/api.go
+++ b/service/history/api/pollupdate/api.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
-	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 
@@ -81,29 +80,19 @@ func Invoke(
 		return nil, serviceerror.NewNotFound(fmt.Sprintf("update %q not found", updateRef.GetUpdateId()))
 	}
 
-	var status update.UpdateStatus
-
-	switch waitStage {
-	case enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED:
-		status, err = upd.Status()
-		if err != nil {
-			return nil, err
-		}
-	case enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED:
-		namespaceID := namespace.ID(req.GetNamespaceId())
-		ns, err := shardContext.GetNamespaceRegistry().GetNamespaceByID(namespaceID)
-		if err != nil {
-			return nil, err
-		}
-		serverTimeout := shardContext.GetConfig().LongPollExpirationInterval(ns.Name().String())
-		// If the long-poll times out due to serverTimeout then return a non-error empty response.
-		status, err = upd.WaitLifecycleStage(ctx, waitStage, serverTimeout)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("support for LifecycleStage=%v is not implemented", waitStage))
+	namespaceID := namespace.ID(req.GetNamespaceId())
+	ns, err := shardContext.GetNamespaceRegistry().GetNamespaceByID(namespaceID)
+	if err != nil {
+		return nil, err
 	}
+	softTimeout := shardContext.GetConfig().LongPollExpirationInterval(ns.Name().String())
+	// If the long-poll times out due to softTimeout
+	// then return a non-error empty response with actual reached stage.
+	status, err := upd.WaitLifecycleStage(ctx, waitStage, softTimeout)
+	if err != nil {
+		return nil, err
+	}
+
 	return &historyservice.PollWorkflowExecutionUpdateResponse{
 		Response: &workflowservice.PollWorkflowExecutionUpdateResponse{
 			Outcome: status.Outcome,

--- a/service/history/api/pollupdate/api_test.go
+++ b/service/history/api/pollupdate/api_test.go
@@ -189,7 +189,7 @@ func TestPollOutcome(t *testing.T) {
 		resp, err := pollupdate.Invoke(ctx, &req, shardContext, wfcc)
 		require.NoError(t, err)
 		require.Nil(t, resp.GetResponse().Outcome)
-		require.Equal(t, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, resp.Response.GetStage())
+		require.Equal(t, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED, resp.Response.GetStage())
 	})
 	t.Run("non-blocking poll with omitted/unspecified wait policy", func(t *testing.T) {
 		for _, req := range []*historyservice.PollWorkflowExecutionUpdateRequest{{

--- a/service/history/workflow/update/status.go
+++ b/service/history/workflow/update/status.go
@@ -1,0 +1,69 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package update
+
+import (
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	updatepb "go.temporal.io/api/update/v1"
+)
+
+type (
+	// Status describes current status of update from registry.
+	Status struct {
+		// The most advanced stage reached by update.
+		Stage enumspb.UpdateWorkflowExecutionLifecycleStage
+		// Outcome of update if it is completed or rejected.
+		Outcome *updatepb.Outcome
+	}
+)
+
+func statusAdmitted() *Status {
+	return &Status{
+		Stage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED,
+	}
+}
+
+func statusAccepted() *Status {
+	return &Status{
+		Stage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+	}
+}
+
+func statusRejected(rejection *failurepb.Failure) *Status {
+	return &Status{
+		Stage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+		Outcome: &updatepb.Outcome{
+			Value: &updatepb.Outcome_Failure{Failure: rejection},
+		},
+	}
+}
+
+func statusCompleted(outcome *updatepb.Outcome) *Status {
+	return &Status{
+		Stage:   enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+		Outcome: outcome,
+	}
+}

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -26,14 +26,12 @@ package update
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
 	protocolpb "go.temporal.io/api/protocol/v1"
-	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -99,11 +97,6 @@ type (
 	}
 
 	updateOpt func(*Update)
-
-	UpdateStatus struct {
-		Stage   enumspb.UpdateWorkflowExecutionLifecycleStage
-		Outcome *updatepb.Outcome
-	}
 )
 
 // New creates a new Update instance with the provided ID that will call the
@@ -170,100 +163,72 @@ func newCompleted(
 	return upd
 }
 
-// WaitLifecycleStage waits until the Update has reached at least `waitStage` or
-// a timeout. If the Update reaches `waitStage` with no timeout, the most
-// advanced stage known to have been reached is returned, along with the outcome
-// if any. If there is a timeout due to the supplied soft timeout, then
-// unspecified stage and nil outcome are returned, without an error. If there is
-// a timeout due to context deadline expiry, then the error is returned as usual.
+// WaitLifecycleStage waits until the Update has reached waitStage or a timeout.
+// If the Update reaches waitStage with no timeout, outcome (if any) is returned.
+// If there is a timeout due to the supplied soft timeout,
+// then the most advanced stage known to have been reached is returned together with empty outcome.
+// If there is a timeout due to supplied context deadline expiry,
+// then the error is returned.
+// If waitStage is UNSPECIFIED, current reached Status is returned immediately (even if ctx is expired).
 func (u *Update) WaitLifecycleStage(
 	ctx context.Context,
 	waitStage enumspb.UpdateWorkflowExecutionLifecycleStage,
-	softTimeout time.Duration) (UpdateStatus, error) {
+	softTimeout time.Duration,
+) (*Status, error) {
 
-	switch waitStage {
-	case enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED:
-		return u.waitLifecycleStage(ctx, u.WaitAccepted, softTimeout)
-	case enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED:
-		return u.waitLifecycleStage(ctx, u.WaitOutcome, softTimeout)
-	default:
-		err := serviceerror.NewInvalidArgument(fmt.Sprintf("%v is not implemented", waitStage))
-		return UpdateStatus{enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, nil}, err
-	}
-}
+	stCtx, stCancel := context.WithTimeout(ctx, softTimeout)
+	defer stCancel()
 
-func (u *Update) waitLifecycleStage(
-	ctx context.Context,
-	waitFn func(ctx context.Context) (UpdateStatus, error),
-	softTimeout time.Duration) (UpdateStatus, error) {
-
-	innerCtx, cancel := context.WithTimeout(context.Background(), softTimeout)
-	defer cancel()
-	status, err := waitFn(innerCtx)
-	if ctx.Err() != nil {
-		// Handle a context deadline expiry as usual.
-		return UpdateStatus{enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, nil}, ctx.Err()
-	}
-	if innerCtx.Err() != nil {
-		// Handle the deadline expiry as a violation of a soft deadline:
-		// return non-error empty response.
-		return UpdateStatus{enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, nil}, nil
-	}
-	return status, err
-}
-
-// Status returns an UpdateStatus containing the
-// enumspb.UpdateWorkflowExecutionLifecycleStage corresponding to the current
-// state of this Update, and the Outcome if it has one.
-func (u *Update) Status() (UpdateStatus, error) {
-	stage, err := u.state.LifecycleStage()
-	if err != nil {
-		return UpdateStatus{enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, nil}, err
-	}
-	var outcome *updatepb.Outcome
-	if u.outcome.Ready() {
-		outcome, err = u.outcome.Get(context.Background())
-	}
-	if err != nil {
-		return UpdateStatus{enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, nil}, err
-	}
-	return UpdateStatus{stage, outcome}, err
-}
-
-// WaitOutcome observes this Update's completion, returning when the Outcome is
-// available. This call will block until the Outcome is known or the provided
-// context.Context expires. It is safe to call this method outside of workflow
-// lock.
-func (u *Update) WaitOutcome(ctx context.Context) (UpdateStatus, error) {
-	outcome, err := u.outcome.Get(ctx)
-	if err != nil {
-		return UpdateStatus{enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, outcome}, err
-	}
-	return UpdateStatus{enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, outcome}, nil
-}
-
-// WaitAccepted blocks on the acceptance of this update, returning nil if it has
-// been accepted but not yet completed, or the overall Outcome if the update has
-// been completed (including completed by rejection). This call will block until
-// the acceptance occurs or the provided context.Context expires.
-// It is safe to call this method outside of workflow lock.
-func (u *Update) WaitAccepted(ctx context.Context) (UpdateStatus, error) {
-	if u.outcome.Ready() {
-		// Being complete implies being accepted; return the completed outcome
-		// here because we can.
-		return u.WaitOutcome(ctx)
-	}
-	fail, err := u.accepted.Get(ctx)
-	if err != nil {
-		return UpdateStatus{enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, nil}, err
-	}
-	if fail != nil {
-		outcome := &updatepb.Outcome{
-			Value: &updatepb.Outcome_Failure{Failure: fail},
+	if u.outcome.Ready() || waitStage == enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED {
+		outcome, err := u.outcome.Get(stCtx)
+		if err == nil {
+			return statusCompleted(outcome), nil
 		}
-		return UpdateStatus{enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, outcome}, nil
+
+		// If err is not nil, and is not coming from context, then it means that the error is from the future itself.
+		// Update doesn't set error to future, therefore this should never happen.
+		if ctx.Err() == nil && stCtx.Err() == nil {
+			return nil, err
+		}
+
+		if ctx.Err() != nil {
+			// Handle root context deadline expiry as normal error which is returned to the caller.
+			return nil, ctx.Err()
+		}
 	}
-	return UpdateStatus{enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, nil}, nil
+
+	// Update is not completed but maybe it is accepted.
+	if u.accepted.Ready() || waitStage == enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED {
+		// Using same context which might be already expired, but if accepted future is ready
+		// then it will return immediately without checking context deadline.
+		rejection, err := u.accepted.Get(stCtx)
+		if err == nil {
+			if rejection != nil {
+				return statusRejected(rejection), nil
+			}
+			return statusAccepted(), nil
+		}
+
+		// See comment for the same check in "completed" branch.
+		if ctx.Err() == nil && stCtx.Err() == nil {
+			return nil, err
+		}
+
+		if ctx.Err() != nil {
+			// Handle root context deadline expiry as normal error which is returned to the caller.
+			return nil, ctx.Err()
+		}
+	}
+
+	// Only get here:
+	//   if stCtx.Err() is not nil, which means that soft timeout (but not user timeout)
+	//     waiting for ACCEPTED/COMPLETED has expired,
+	//   or
+	//     waitStage is ADMITTED,
+	//   or
+	//     waitStage is UNSPECIFIED and neither ACCEPTED nor COMPLETED are reached.
+	// In all cases behavior is the same: return ADMITTED (as the most reached state) and empty outcome.
+	return statusAdmitted(), nil
 }
 
 // Request works if the Update is in any state but if the state is anything

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -198,9 +198,8 @@ func (u *Update) WaitLifecycleStage(
 			return nil, ctx.Err()
 		}
 
-		if stCtx.Err() != nil {
-			// Noop because if softTimeout has expired then check if ACCEPTED is reached.
-		}
+		// Only get here if there is an error and this error is stCtx.Err().
+		// Which means that softTimeout has expired => check if update has reached ACCEPTED state.
 	}
 
 	// Update is not completed but maybe it is accepted.

--- a/service/history/workflow_task_handler_callbacks_update_test.go
+++ b/service/history/workflow_task_handler_callbacks_update_test.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -198,7 +199,7 @@ func (s *WorkflowTaskHandlerCallbacksUpdateSuite) TestAcceptComplete() {
 	})
 	s.NoError(err)
 
-	updStatus, err := upd.Status()
+	updStatus, err := upd.WaitLifecycleStage(context.Background(), enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, time.Duration(0))
 	s.NoError(err)
 	s.Equal(enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED.String(), updStatus.Stage.String())
 	s.ProtoEqual(payloads.EncodeString("success-result-of-"+tv.UpdateID("1")), updStatus.Outcome.GetSuccess())
@@ -232,7 +233,7 @@ func (s *WorkflowTaskHandlerCallbacksUpdateSuite) TestReject() {
 	})
 	s.NoError(err)
 
-	updStatus, err := upd.Status()
+	updStatus, err := upd.WaitLifecycleStage(context.Background(), enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, time.Duration(0))
 	s.NoError(err)
 	s.Equal(enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED.String(), updStatus.Stage.String())
 	s.Equal("rejection-of-"+tv.UpdateID("1"), updStatus.Outcome.GetFailure().GetMessage())
@@ -266,7 +267,7 @@ func (s *WorkflowTaskHandlerCallbacksUpdateSuite) TestWriteFailed() {
 	})
 	s.ErrorIs(err, writeErr)
 
-	updStatus, err := upd.Status()
+	updStatus, err := upd.WaitLifecycleStage(context.Background(), enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, time.Duration(0))
 	s.NoError(err)
 	s.Equal(enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED.String(), updStatus.Stage.String())
 	s.Nil(updStatus.Outcome.GetSuccess())
@@ -301,7 +302,7 @@ func (s *WorkflowTaskHandlerCallbacksUpdateSuite) TestGetHistoryFailed() {
 	})
 	s.ErrorIs(err, readHistoryErr)
 
-	updStatus, err := upd.Status()
+	updStatus, err := upd.WaitLifecycleStage(context.Background(), enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, time.Duration(0))
 	s.NoError(err)
 	s.Equal(enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED.String(), updStatus.Stage.String())
 	s.ProtoEqual(payloads.EncodeString("success-result-of-"+tv.UpdateID("1")), updStatus.Outcome.GetSuccess())

--- a/tests/update_workflow.go
+++ b/tests/update_workflow.go
@@ -634,7 +634,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NormalScheduledWorkflowTask_AcceptC
 			}()
 			// Signal creates WFT, and it is important to wait for update to get blocked,
 			// to make sure that poll bellow won't poll just for WFT from signal.
-			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
+			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage, 1*time.Second)
 
 			// Process update in workflow. It will be attached to existing WT.
 			res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
@@ -694,7 +694,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeFromStartedWorkflowTa
 				updateResultCh <- s.sendUpdateNoError(tv, "1")
 			}()
 			// To make sure that 1st update gets to the sever while WT1 is running.
-			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
+			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage, 1*time.Second)
 			// Completes WT with empty command list to create next WT as speculative.
 			return nil, nil
 		case 2:
@@ -811,7 +811,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewNormalFromStartedWorkflowTask_Re
 				updateResultCh <- s.sendUpdateNoError(tv, "1")
 			}()
 			// To make sure that 1st update gets to the sever while WT1 is running.
-			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
+			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage, 1*time.Second)
 			// Completes WT with update unrelated commands to prevent next WT to be speculative.
 			return []*commandpb.Command{{
 				CommandType: enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK,
@@ -2564,7 +2564,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ConvertScheduledSpeculativeWorkflow
 		updateResultCh <- s.sendUpdateNoError(tv, "1")
 	}()
 	// This is to make sure that update gets to the server before the next Signal call.
-	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
+	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage, 1*time.Second)
 
 	// Send signal which will NOT be buffered because speculative WT is not started yet (only scheduled).
 	// This will persist MS and speculative WT must be converted to normal.
@@ -3173,7 +3173,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_Te
 	}
 	go updateWorkflowFn()
 	// This is to make sure that update gets to the server before the next Terminate call.
-	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
+	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage, 1*time.Second)
 
 	// Terminate workflow after speculative WT is scheduled but not started.
 	_, err = s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
@@ -3956,7 +3956,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_De
 	go func() {
 		updateResultCh <- s.sendUpdateNoError(tv, "1")
 	}()
-	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
+	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage, 1*time.Second)
 
 	// Send second update with the same ID.
 	updateResultCh2 := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -4021,7 +4021,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Dedu
 			go func() {
 				updateResultCh2 <- s.sendUpdateNoError(tv, "1")
 			}()
-			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
+			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage, 1*time.Second)
 
 			s.EqualHistory(`
   1 WorkflowExecutionStarted
@@ -5038,7 +5038,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_WorkerSk
 				update2ResultCh <- s.sendUpdateNoError(tv, "2")
 			}()
 			// To make sure that gets to the sever while this WT is running.
-			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitOutcome, 1*time.Second)
+			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage, 1*time.Second)
 			return nil, nil
 		case 3:
 			s.EqualHistory(`


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Previously, if update didn't reach requested stage within internal server timeout `UNSPECIFIED` was returned. Now actual reached stage `ADMITTED` or `ACCEPTED` is returned.

## Why?
<!-- Tell your future self why have you made these changes -->
Based on actual reached state caller can make a decision to retry `UpdateWorkflowExecution` API or start polling update result.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Add new unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.