### PR TITLE
Change Nexus request routes

### DIFF
--- a/common/nexus/routes.go
+++ b/common/nexus/routes.go
@@ -47,10 +47,11 @@ var routes = RouteSet{
 		StringVariable("namespace", func(params *NamespaceAndTaskQueue) *string { return &params.Namespace }).
 		Constant("task-queues").
 		StringVariable("task_queue", func(params *NamespaceAndTaskQueue) *string { return &params.TaskQueue }).
-		Constant("dispatch-nexus-task").
+		Constant("nexus-operations").
 		Build(),
 	DispatchNexusTaskByService: routing.NewBuilder[string]().
-		Constant("api", "v1", "services").
+		Constant("api", "v1", "nexus", "services").
 		StringVariable("service", func(service *string) *string { return service }).
+		Constant("operations").
 		Build(),
 }

--- a/common/nexus/routes_test.go
+++ b/common/nexus/routes_test.go
@@ -35,12 +35,12 @@ func ExampleRouteSet_DispatchNexusTaskByNamespaceAndTaskQueue() {
 			TaskQueue: "TEST-TASK-QUEUE",
 		})
 	fmt.Println(path)
-	// Output: api/v1/namespaces/TEST-NAMESPACE/task-queues/TEST-TASK-QUEUE/dispatch-nexus-task
+	// Output: api/v1/namespaces/TEST-NAMESPACE/task-queues/TEST-TASK-QUEUE/nexus-operations
 }
 
 func ExampleRouteSet_DispatchNexusTaskByService() {
 	path := nexus.Routes().DispatchNexusTaskByService.
 		Path("TEST-SERVICE")
 	fmt.Println(path)
-	// Output: api/v1/services/TEST-SERVICE
+	// Output: api/v1/nexus/services/TEST-SERVICE/operations
 }

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -41,9 +41,10 @@ const (
 const (
 	// These names do not map to an underlying gRPC service. This format is used for consistency with the
 	// gRPC API names on which the authorizer - the consumer of this string - may depend.
-	OpenAPIV3APIName         = "/temporal.api.openapi.v1.OpenAPIService/GetOpenAPIV3Docs"
-	OpenAPIV2APIName         = "/temporal.api.openapi.v1.OpenAPIService/GetOpenAPIV2Docs"
-	DispatchNexusTaskAPIName = "/temporal.api.nexusservice.v1.NexusService/DispatchNexusTask"
+	OpenAPIV3APIName                                = "/temporal.api.openapi.v1.OpenAPIService/GetOpenAPIV3Docs"
+	OpenAPIV2APIName                                = "/temporal.api.openapi.v1.OpenAPIService/GetOpenAPIV2Docs"
+	DispatchNexusTaskByNamespaceAndTaskQueueAPIName = "/temporal.api.nexusservice.v1.NexusService/DispatchByNamespaceAndTaskQueue"
+	DispatchNexusTaskByServiceAPIName               = "/temporal.api.nexusservice.v1.NexusService/DispatchByService"
 )
 
 var (
@@ -63,8 +64,9 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkflowExecutionHistory": 1,
 		"/temporal.api.workflowservice.v1.WorkflowService/PollNexusTaskQueue":          1,
 
-		// DispatchNexusTask is potentially long running, it's classified in the same bucket as QueryWorkflow.
-		DispatchNexusTaskAPIName: 1,
+		// Dispatching a Nexus task is a potentially long running RPC, it's classified in the same bucket as QueryWorkflow.
+		DispatchNexusTaskByNamespaceAndTaskQueueAPIName: 1,
+		DispatchNexusTaskByServiceAPIName:               1,
 	}
 
 	// APIToPriority determines common API priorities.
@@ -86,7 +88,7 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/UpdateWorkflowExecution":          1,
 		"/temporal.api.workflowservice.v1.WorkflowService/CreateSchedule":                   1,
 		"/temporal.api.workflowservice.v1.WorkflowService/StartBatchOperation":              1,
-		DispatchNexusTaskAPIName: 1,
+		DispatchNexusTaskByNamespaceAndTaskQueueAPIName:                                     1,
 
 		// P2: Change State APIs
 		"/temporal.api.workflowservice.v1.WorkflowService/RequestCancelWorkflowExecution": 2,

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -89,6 +89,7 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/CreateSchedule":                   1,
 		"/temporal.api.workflowservice.v1.WorkflowService/StartBatchOperation":              1,
 		DispatchNexusTaskByNamespaceAndTaskQueueAPIName:                                     1,
+		DispatchNexusTaskByServiceAPIName:                                                   1,
 
 		// P2: Change State APIs
 		"/temporal.api.workflowservice.v1.WorkflowService/RequestCancelWorkflowExecution": 2,

--- a/service/frontend/configs/quotas_test.go
+++ b/service/frontend/configs/quotas_test.go
@@ -170,8 +170,10 @@ func (s *quotasSuite) TestAllAPIs() {
 		_, ok := apisWithPriority["/temporal.api.workflowservice.v1.WorkflowService/"+m.Name]
 		s.True(ok, "missing priority for API: %v", m.Name)
 	})
-	_, ok := apisWithPriority["/temporal.api.nexusservice.v1.NexusService/DispatchNexusTask"]
-	s.True(ok, "missing priority for API: /temporal.api.nexusservice.v1.NexusService/DispatchNexusTask")
+	_, ok := apisWithPriority[DispatchNexusTaskByNamespaceAndTaskQueueAPIName]
+	s.Truef(ok, "missing priority for API: %q", DispatchNexusTaskByNamespaceAndTaskQueueAPIName)
+	_, ok = apisWithPriority[DispatchNexusTaskByServiceAPIName]
+	s.Truef(ok, "missing priority for API: %q", DispatchNexusTaskByServiceAPIName)
 }
 
 func (s *quotasSuite) TestOperatorPriority_Execution() {

--- a/service/frontend/nexus_http_handler.go
+++ b/service/frontend/nexus_http_handler.go
@@ -140,7 +140,7 @@ func (h *NexusHTTPHandler) dispatchNexusTaskByNamespaceAndTaskQueue(w http.Respo
 		namespaceRateLimitInterceptor:        h.namespaceRateLimitInterceptor,
 		namespaceConcurrencyLimitInterceptor: h.namespaceConcurrencyLimitInterceptor,
 		rateLimitInterceptor:                 h.rateLimitInterceptor,
-		apiName:                              configs.DispatchNexusTaskAPIName,
+		apiName:                              configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName,
 	}
 
 	params := commonnexus.Routes().DispatchNexusTaskByNamespaceAndTaskQueue.Deserialize(vars)

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -48,6 +48,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	cnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/service/frontend/configs"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -262,7 +263,7 @@ func (s *ClientFunctionalSuite) TestNexusStartOperation_WithNamespaceAndTaskQueu
 		{
 			name: "deny with reason",
 			onAuthorize: func(ctx context.Context, c *authorization.Claims, ct *authorization.CallTarget) (authorization.Result, error) {
-				if ct.APIName == "/temporal.api.nexusservice.v1.NexusService/DispatchNexusTask" {
+				if ct.APIName == configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName {
 					return authorization.Result{Decision: authorization.DecisionDeny, Reason: "unauthorized in test"}, nil
 				}
 				return authorization.Result{Decision: authorization.DecisionAllow}, nil
@@ -272,7 +273,7 @@ func (s *ClientFunctionalSuite) TestNexusStartOperation_WithNamespaceAndTaskQueu
 		{
 			name: "deny without reason",
 			onAuthorize: func(ctx context.Context, c *authorization.Claims, ct *authorization.CallTarget) (authorization.Result, error) {
-				if ct.APIName == "/temporal.api.nexusservice.v1.NexusService/DispatchNexusTask" {
+				if ct.APIName == configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName {
 					return authorization.Result{Decision: authorization.DecisionDeny}, nil
 				}
 				return authorization.Result{Decision: authorization.DecisionAllow}, nil
@@ -282,7 +283,7 @@ func (s *ClientFunctionalSuite) TestNexusStartOperation_WithNamespaceAndTaskQueu
 		{
 			name: "deny with generic error",
 			onAuthorize: func(ctx context.Context, c *authorization.Claims, ct *authorization.CallTarget) (authorization.Result, error) {
-				if ct.APIName == "/temporal.api.nexusservice.v1.NexusService/DispatchNexusTask" {
+				if ct.APIName == configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName {
 					return authorization.Result{}, errors.New("some generic error")
 				}
 				return authorization.Result{Decision: authorization.DecisionAllow}, nil
@@ -364,7 +365,7 @@ func (s *ClientFunctionalSuite) TestNexusStartOperation_WithNamespaceAndTaskQueu
 	}
 
 	s.testCluster.host.SetOnAuthorize(func(ctx context.Context, c *authorization.Claims, ct *authorization.CallTarget) (authorization.Result, error) {
-		if ct.APIName == "/temporal.api.nexusservice.v1.NexusService/DispatchNexusTask" && (c == nil || c.Subject != "test") {
+		if ct.APIName == configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName && (c == nil || c.Subject != "test") {
 			return authorization.Result{Decision: authorization.DecisionDeny}, nil
 		}
 		return authorization.Result{Decision: authorization.DecisionAllow}, nil

--- a/tests/nexus_incoming_service_test.go
+++ b/tests/nexus_incoming_service_test.go
@@ -29,6 +29,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 
 	"go.temporal.io/server/api/matchingservice/v1"
+	commonnexus "go.temporal.io/server/common/nexus"
 	p "go.temporal.io/server/common/persistence"
 )
 
@@ -40,7 +41,7 @@ func (s *FunctionalSuite) TestCreateNexusIncomingService_Matching() {
 	s.NotEmpty(service.Id)
 	s.Equal(service.Spec.Name, s.T().Name())
 	s.Equal(service.Spec.Namespace, s.namespace)
-	s.Equal("/api/v1/services/"+service.Id, service.UrlPrefix)
+	s.Equal("/"+commonnexus.Routes().DispatchNexusTaskByService.Path(service.Id), service.UrlPrefix)
 
 	_, err := s.testCluster.GetMatchingClient().CreateNexusIncomingService(NewContext(), &matchingservice.CreateNexusIncomingServiceRequest{
 		Spec: &nexus.IncomingServiceSpec{
@@ -74,7 +75,7 @@ func (s *FunctionalSuite) TestUpdateNexusIncomingService_Matching() {
 			assertion: func(resp *matchingservice.UpdateNexusIncomingServiceResponse, err error) {
 				s.NoError(err)
 				s.NotNil(resp.Service)
-				s.Equal("/api/v1/services/"+service.Id, service.UrlPrefix)
+				s.Equal("/"+commonnexus.Routes().DispatchNexusTaskByService.Path(service.Id), service.UrlPrefix)
 				s.Equal(int64(2), resp.Service.Version)
 				s.Equal("updated name", resp.Service.Spec.Name)
 				s.NotNil(resp.Service.LastModifiedTime)


### PR DESCRIPTION
## What changed?

Changed Nexus HTTP routes from:

`/api/v1/namespaces/{namespace}/task-queues/{task_queue}/dispatch-nexus-task`

and

`/api/v1/services/{service}`

to:

`/api/v1/namespaces/{namespace}/task-queues/{task_queue}/nexus-operations`

and

`/api/v1/nexus/services/{service}/operations`

## Why?

- Use resource centric URLs for consistency with the rest of the HTTP API.
- The `nexus` prefix is an important annotation in the service API.

## How did you test it?

Existing tests.

## Potential risks

This is all experimental and never released, safe to change still.