### PR TITLE
Util function to get SearchAttributeKey inferred from the payload metadata

### DIFF
--- a/common/searchattribute/encode_value.go
+++ b/common/searchattribute/encode_value.go
@@ -60,9 +60,9 @@ func DecodeValue(
 ) (any, error) {
 	if t == enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED {
 		var err error
-		t, err = enumspb.IndexedValueTypeFromString(string(value.Metadata[MetadataType]))
+		t, err = getMetadataType(value)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrInvalidType, t)
+			return nil, err
 		}
 	}
 

--- a/common/searchattribute/stringify_test.go
+++ b/common/searchattribute/stringify_test.go
@@ -25,7 +25,6 @@
 package searchattribute
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -89,8 +88,7 @@ func (s *StringifySuite) Test_Stringify() {
 
 	// Even w/o typeMap error is returned but string values are set with  raw JSON from GetData().
 	saStr, err = Stringify(sa, nil)
-	s.Error(err)
-	s.True(errors.Is(err, ErrInvalidType))
+	s.ErrorIs(err, ErrInvalidType)
 	s.Len(saStr, 3)
 	s.Equal(`"val1"`, saStr["key1"])
 	s.Equal("2", saStr["key2"])
@@ -134,8 +132,7 @@ func (s *StringifySuite) Test_Stringify_Array() {
 
 	// Even w/o typeMap error is returned but string values are set with  raw JSON from GetData().
 	saStr, err = Stringify(sa, nil)
-	s.Error(err)
-	s.True(errors.Is(err, ErrInvalidType))
+	s.ErrorIs(err, ErrInvalidType)
 	s.Len(saStr, 3)
 	s.Equal(`["val1","val2"]`, saStr["key1"])
 	s.Equal("[2,3,4]", saStr["key2"])


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Added `GetSearchAttributeKeyFromPayloadMetadata` util function to create `SearchAttributeKey` object inferred from the payload metadata type.

## Why?
<!-- Tell your future self why have you made these changes -->


## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.