### PR TITLE
Add Nexus incoming service registry

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -377,6 +377,10 @@ const (
 	FrontendEnableSchedules = "frontend.enableSchedules"
 	// FrontendEnableNexusHTTPHandler enables serving Nexus HTTP requests in the frontend.
 	FrontendEnableNexusHTTPHandler = "frontend.enableNexusHTTPHandler"
+	// FrontendRefreshNexusIncomingServicesLongPollTimeout is the maximum duration of background long poll requests to update Nexus incoming services.
+	FrontendRefreshNexusIncomingServicesLongPollTimeout = "frontend.refreshNexusIncomingServicesLongPollTimeout"
+	// FrontendRefreshNexusIncomingServicesMinWait is the minimum wait time between background long poll requests to update Nexus incoming services.
+	FrontendRefreshNexusIncomingServicesMinWait = "frontend.refreshNexusIncomingServicesMinWait"
 	// FrontendEnableCallbackAttachment enables attaching callbacks to workflows.
 	FrontendEnableCallbackAttachment = "frontend.enableCallbackAttachment"
 	// FrontendMaxConcurrentBatchOperationPerNamespace is the max concurrent batch operation job count per namespace

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -377,6 +377,8 @@ const (
 	FrontendEnableSchedules = "frontend.enableSchedules"
 	// FrontendEnableNexusHTTPHandler enables serving Nexus HTTP requests in the frontend.
 	FrontendEnableNexusHTTPHandler = "frontend.enableNexusHTTPHandler"
+	// FrontendInitializeNexusIncomingServicesTimeout is the maximum time allowed for initializing Nexus incoming services.
+	FrontendInitializeNexusIncomingServicesTimeout = "frontend.initializeNexusIncomingServicesTimeout"
 	// FrontendRefreshNexusIncomingServicesLongPollTimeout is the maximum duration of background long poll requests to update Nexus incoming services.
 	FrontendRefreshNexusIncomingServicesLongPollTimeout = "frontend.refreshNexusIncomingServicesLongPollTimeout"
 	// FrontendRefreshNexusIncomingServicesMinWait is the minimum wait time between background long poll requests to update Nexus incoming services.

--- a/common/nexus/incoming_service_registry.go
+++ b/common/nexus/incoming_service_registry.go
@@ -212,6 +212,7 @@ func (r *IncomingServiceRegistry) refreshServices(ctx context.Context) error {
 				// Indicates table was updated during paging, so reset and start from the beginning
 				currentTableVersion, services, err = r.getAllServicesMatching(ctx)
 				if err != nil {
+					r.logger.Error("error during background refresh of Nexus incoming services", tag.Error(err))
 					return err
 				}
 				break

--- a/common/nexus/incoming_service_registry.go
+++ b/common/nexus/incoming_service_registry.go
@@ -131,7 +131,7 @@ func (r *IncomingServiceRegistry) Get(ctx context.Context, id string) (*nexus.In
 
 	service, ok := r.services[id]
 	if !ok {
-		return nil, serviceerror.NewNotFound(fmt.Sprintf("could not find Nexus incoming service with ID: %v", id))
+		return nil, serviceerror.NewNotFound(fmt.Sprintf("could not find Nexus incoming service with ID: %v.", id))
 	}
 
 	return service, nil
@@ -258,7 +258,7 @@ func (r *IncomingServiceRegistry) refreshServices(ctx context.Context) error {
 				// Indicates table was updated during paging, so reset and start from the beginning.
 				currentTableVersion, services, err = r.getAllServicesMatching(ctx)
 				if err != nil {
-					r.logger.Error("error during background refresh of Nexus incoming services", tag.Error(err))
+					r.logger.Error("error during background refresh of Nexus incoming services.", tag.Error(err))
 					return err
 				}
 				break

--- a/common/nexus/incoming_service_registry.go
+++ b/common/nexus/incoming_service_registry.go
@@ -131,7 +131,7 @@ func (r *IncomingServiceRegistry) Get(ctx context.Context, id string) (*nexus.In
 
 	service, ok := r.services[id]
 	if !ok {
-		return nil, serviceerror.NewNotFound(fmt.Sprintf("could not find Nexus incoming service with ID: %v.", id))
+		return nil, serviceerror.NewNotFound(fmt.Sprintf("could not find Nexus incoming service with ID: %v", id))
 	}
 
 	return service, nil
@@ -172,7 +172,7 @@ func (r *IncomingServiceRegistry) initializeServicesLocked(ctx context.Context) 
 	tableVersion, services, err := r.getAllServicesMatching(ctx)
 	if err != nil {
 		// Fallback to persistence on matching error during initial load.
-		r.logger.Error("error from matching when initializing Nexus incoming service cache.", tag.Error(err))
+		r.logger.Error("error from matching when initializing Nexus incoming service cache", tag.Error(err))
 		tableVersion, services, err = r.getAllServicesPersistence(ctx)
 		if err != nil {
 			return err
@@ -258,7 +258,7 @@ func (r *IncomingServiceRegistry) refreshServices(ctx context.Context) error {
 				// Indicates table was updated during paging, so reset and start from the beginning.
 				currentTableVersion, services, err = r.getAllServicesMatching(ctx)
 				if err != nil {
-					r.logger.Error("error during background refresh of Nexus incoming services.", tag.Error(err))
+					r.logger.Error("error during background refresh of Nexus incoming services", tag.Error(err))
 					return err
 				}
 				break

--- a/common/nexus/incoming_service_registry.go
+++ b/common/nexus/incoming_service_registry.go
@@ -145,6 +145,7 @@ func (r *IncomingServiceRegistry) refreshServicesLoop(ctx context.Context) error
 
 	for ctx.Err() == nil {
 		start := time.Now()
+		// Ignoring errors here because they are logged where they occur and we never want to exit the refresh loop.
 		_ = backoff.ThrottleRetryContext(ctx, r.refreshServices, r.config.refreshRetryPolicy, nil)
 		elapsed := time.Since(start)
 

--- a/common/nexus/incoming_service_registry.go
+++ b/common/nexus/incoming_service_registry.go
@@ -99,7 +99,7 @@ func NewIncomingServiceRegistry(
 }
 
 // StartLifecycle starts this component. It should only be invoked by an fx lifecycle hook.
-// Should not be called concurrently with StopLifecycle()
+// Should not be called multiple times or concurrently with StopLifecycle()
 func (r *IncomingServiceRegistry) StartLifecycle() {
 	refreshCtx := headers.SetCallerInfo(
 		context.Background(),
@@ -109,7 +109,7 @@ func (r *IncomingServiceRegistry) StartLifecycle() {
 }
 
 // StopLifecycle stops this component. It should only be invoked by an fx lifecycle hook.
-// Should not be called concurrently with StartLifecycle()
+// Should not be called multiple times or concurrently with StartLifecycle()
 func (r *IncomingServiceRegistry) StopLifecycle() {
 	if r.refreshPoller != nil {
 		r.refreshPoller.Cancel()

--- a/common/nexus/incoming_service_registry.go
+++ b/common/nexus/incoming_service_registry.go
@@ -1,0 +1,353 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package nexus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/serviceerror"
+
+	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/future"
+	"go.temporal.io/server/common/headers"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	p "go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/internal/goro"
+)
+
+type (
+	IncomingServiceRegistryConfig struct {
+		refreshLongPollTimeout dynamicconfig.DurationPropertyFn
+		refreshPageSize        dynamicconfig.IntPropertyFn
+		refreshMinWait         dynamicconfig.DurationPropertyFn
+		refreshRetryPolicy     backoff.RetryPolicy
+	}
+
+	// IncomingServiceRegistry manages a cached view of incoming services.
+	// Services are lazily-loaded into memory on the first read. Thereafter, service data is kept up to date by
+	// long polling on matching service ListNexusIncomingServices.
+	IncomingServiceRegistry struct {
+		config *IncomingServiceRegistryConfig
+
+		status           int32
+		serviceDataReady *future.FutureImpl[struct{}]
+
+		dataLock     sync.RWMutex // protects tableVersion and services
+		tableVersion int64
+		services     map[string]*nexus.IncomingService // mapping of service ID -> service
+
+		refreshPoller *goro.Handle
+
+		matchingClient matchingservice.MatchingServiceClient
+		persistence    p.NexusIncomingServiceManager
+		logger         log.Logger
+	}
+)
+
+func NewIncomingServiceRegistryConfig(dc *dynamicconfig.Collection) *IncomingServiceRegistryConfig {
+	config := &IncomingServiceRegistryConfig{
+		refreshLongPollTimeout: dc.GetDurationProperty(dynamicconfig.FrontendRefreshNexusIncomingServicesLongPollTimeout, 5*time.Minute),
+		refreshPageSize:        dc.GetIntProperty(dynamicconfig.NexusIncomingServiceListDefaultPageSize, 1000),
+		refreshMinWait:         dc.GetDurationProperty(dynamicconfig.FrontendRefreshNexusIncomingServicesLongPollTimeout, 1*time.Second),
+	}
+	config.refreshRetryPolicy = backoff.NewExponentialRetryPolicy(config.refreshMinWait()).WithMaximumInterval(config.refreshLongPollTimeout())
+	return config
+}
+
+func NewIncomingServiceRegistry(
+	config *IncomingServiceRegistryConfig,
+	matchingClient matchingservice.MatchingServiceClient,
+	persistence p.NexusIncomingServiceManager,
+	logger log.Logger,
+) *IncomingServiceRegistry {
+	return &IncomingServiceRegistry{
+		status:           common.DaemonStatusInitialized,
+		config:           config,
+		serviceDataReady: future.NewFuture[struct{}](),
+		services:         make(map[string]*nexus.IncomingService),
+		matchingClient:   matchingClient,
+		persistence:      persistence,
+		logger:           logger,
+	}
+}
+
+func (r *IncomingServiceRegistry) Start() {
+	if !atomic.CompareAndSwapInt32(&r.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
+		return
+	}
+
+	refreshCtx := headers.SetCallerInfo(
+		context.Background(),
+		headers.SystemBackgroundCallerInfo,
+	)
+	r.refreshPoller = goro.NewHandle(refreshCtx).Go(r.refreshServicesLoop)
+}
+
+func (r *IncomingServiceRegistry) Stop() {
+	if !atomic.CompareAndSwapInt32(&r.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
+		return
+	}
+
+	r.refreshPoller.Cancel()
+	<-r.refreshPoller.Done()
+}
+
+func (r *IncomingServiceRegistry) Get(ctx context.Context, id string) (*nexus.IncomingService, error) {
+	if !r.serviceDataReady.Ready() {
+		if err := r.initializeServices(ctx); err != nil {
+			r.logger.Error("error loading Nexus incoming service cache.", tag.Error(err))
+			return nil, serviceerror.NewInternal("error loading Nexus incoming service data.")
+		}
+	}
+
+	r.dataLock.RLock()
+	defer r.dataLock.RUnlock()
+
+	service, ok := r.services[id]
+	if !ok {
+		return nil, serviceerror.NewNotFound(fmt.Sprintf("could not find Nexus incoming service with ID: %v", id))
+	}
+
+	return service, nil
+}
+
+func (r *IncomingServiceRegistry) refreshServicesLoop(ctx context.Context) error {
+	minWaitTime := r.config.refreshMinWait()
+
+	for ctx.Err() == nil {
+		start := time.Now()
+		_ = backoff.ThrottleRetryContext(ctx, r.refreshServices, r.config.refreshRetryPolicy, nil)
+		elapsed := time.Since(start)
+
+		// In general, we want to start a new call immediately on completion of the previous
+		// one. But if the remote is broken and returns success immediately, we might end up
+		// spinning. So enforce a minimum wait time that increases as long as we keep getting
+		// very fast replies.
+		if elapsed < minWaitTime {
+			common.InterruptibleSleep(ctx, minWaitTime-elapsed)
+			// Don't let this get near our call timeout, otherwise we can't tell the difference
+			// between a fast reply and a timeout.
+			minWaitTime = min(minWaitTime*2, r.config.refreshLongPollTimeout()/2)
+		} else {
+			minWaitTime = r.config.refreshMinWait()
+		}
+	}
+
+	return ctx.Err()
+}
+
+// refreshServices sends long-poll requests to matching to check for any updates to service data.
+// It waits to send any requests until service data has been initialized.
+func (r *IncomingServiceRegistry) refreshServices(ctx context.Context) error {
+	// Wait for service data to be initialized before long polling.
+	if _, err := r.serviceDataReady.Get(ctx); err != nil {
+		return err
+	}
+
+	// acquire read lock only to get last known table version, but do not lock during long poll
+	r.dataLock.RLock()
+	currentTableVersion := r.tableVersion
+	r.dataLock.RUnlock()
+
+	resp, err := r.matchingClient.ListNexusIncomingServices(ctx, &matchingservice.ListNexusIncomingServicesRequest{
+		NextPageToken:         nil,
+		PageSize:              int32(r.config.refreshPageSize()),
+		LastKnownTableVersion: currentTableVersion,
+		Wait:                  true,
+	})
+	if err != nil {
+		return err
+	}
+
+	if resp.TableVersion == currentTableVersion {
+		// long poll returned with no changes
+		return nil
+	}
+
+	// changes were returned by long poll so acquire write lock to prevent reads while updating
+	r.dataLock.Lock()
+	defer r.dataLock.Unlock()
+
+	if r.tableVersion >= resp.TableVersion {
+		// service data was updated while waiting for the write lock
+		return nil
+	}
+
+	currentTableVersion = resp.TableVersion
+	services := make(map[string]*nexus.IncomingService)
+	for _, service := range resp.Services {
+		services[service.Id] = service
+	}
+
+	currentPageToken := resp.NextPageToken
+	for currentPageToken != nil {
+		// iterate over remaining pages
+		resp, err = r.matchingClient.ListNexusIncomingServices(ctx, &matchingservice.ListNexusIncomingServicesRequest{
+			NextPageToken:         currentPageToken,
+			PageSize:              int32(r.config.refreshPageSize()),
+			LastKnownTableVersion: currentTableVersion,
+			Wait:                  false,
+		})
+
+		if err != nil {
+			if errors.Is(err, p.ErrNexusTableVersionConflict) {
+				// indicates table was updated during paging, so reset and start from the beginning
+				currentTableVersion, services, err = r.getAllServicesMatching(ctx)
+				if err != nil {
+					return err
+				}
+				break
+			}
+			return err
+		}
+
+		for _, service := range resp.Services {
+			services[service.Id] = service
+		}
+
+		currentPageToken = resp.NextPageToken
+	}
+
+	r.tableVersion = currentTableVersion
+	r.services = services
+	return nil
+}
+
+// initializeServices initializes the in-memory view of service data.
+// It first tries to load from matching service and falls back to querying persistence directly if matching is unavailable.
+func (r *IncomingServiceRegistry) initializeServices(ctx context.Context) error {
+	r.dataLock.Lock()
+	defer r.dataLock.Unlock()
+
+	if r.serviceDataReady.Ready() {
+		// Indicates service data was loaded by another thread while waiting for write lock.
+		return nil
+	}
+
+	tableVersion, services, err := r.getAllServicesMatching(ctx)
+	if err != nil {
+		// Fallback to persistence on matching error during initial load.
+		tableVersion, services, err = r.getAllServicesPersistence(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	r.tableVersion = tableVersion
+	r.services = services
+	if !r.serviceDataReady.Ready() {
+		r.serviceDataReady.Set(struct{}{}, nil)
+	}
+
+	return nil
+}
+
+// getAllServicesMatching paginates over all services returned by matching. It always does a simple get.
+func (r *IncomingServiceRegistry) getAllServicesMatching(ctx context.Context) (int64, map[string]*nexus.IncomingService, error) {
+	var currentPageToken []byte
+
+	currentTableVersion := int64(0)
+	services := make(map[string]*nexus.IncomingService)
+
+	for ctx.Err() == nil {
+		resp, err := r.matchingClient.ListNexusIncomingServices(ctx, &matchingservice.ListNexusIncomingServicesRequest{
+			NextPageToken:         currentPageToken,
+			PageSize:              int32(r.config.refreshPageSize()),
+			LastKnownTableVersion: currentTableVersion,
+			Wait:                  false,
+		})
+		if err != nil {
+			if errors.Is(err, p.ErrNexusTableVersionConflict) {
+				// indicates table was updated during paging, so reset and start from the beginning
+				currentPageToken = nil
+				currentTableVersion = 0
+				services = make(map[string]*nexus.IncomingService)
+				continue
+			}
+			return 0, nil, err
+		}
+
+		currentTableVersion = resp.TableVersion
+		for _, service := range resp.Services {
+			services[service.Id] = service
+		}
+
+		if resp.NextPageToken == nil {
+			return currentTableVersion, services, nil
+		}
+
+		currentPageToken = resp.NextPageToken
+	}
+
+	return 0, nil, ctx.Err()
+}
+
+// getAllServicesPersistence paginates over all services returned by persistence.
+// Should only be used as a fall-back if matching service is unavailable during initial load.
+func (r *IncomingServiceRegistry) getAllServicesPersistence(ctx context.Context) (int64, map[string]*nexus.IncomingService, error) {
+	var currentPageToken []byte
+
+	currentTableVersion := int64(0)
+	services := make(map[string]*nexus.IncomingService)
+
+	for ctx.Err() == nil {
+		resp, err := r.persistence.ListNexusIncomingServices(ctx, &p.ListNexusIncomingServicesRequest{
+			LastKnownTableVersion: currentTableVersion,
+			NextPageToken:         currentPageToken,
+			PageSize:              r.config.refreshPageSize(),
+		})
+		if err != nil {
+			if errors.Is(err, p.ErrNexusTableVersionConflict) {
+				// indicates table was updated during paging, so reset and start from the beginning
+				currentPageToken = nil
+				currentTableVersion = 0
+				services = make(map[string]*nexus.IncomingService)
+				continue
+			}
+			return 0, nil, err
+		}
+
+		currentTableVersion = resp.TableVersion
+		for _, entry := range resp.Entries {
+			services[entry.Id] = IncomingServicePersistedEntryToExternalAPI(entry)
+		}
+
+		if resp.NextPageToken == nil {
+			return currentTableVersion, services, nil
+		}
+
+		currentPageToken = resp.NextPageToken
+	}
+
+	return 0, nil, ctx.Err()
+}

--- a/common/nexus/incoming_service_registry.go
+++ b/common/nexus/incoming_service_registry.go
@@ -99,6 +99,7 @@ func NewIncomingServiceRegistry(
 }
 
 // StartLifecycle starts this component. It should only be invoked by an fx lifecycle hook.
+// Should not be called concurrently with StopLifecycle()
 func (r *IncomingServiceRegistry) StartLifecycle() {
 	refreshCtx := headers.SetCallerInfo(
 		context.Background(),
@@ -108,9 +109,12 @@ func (r *IncomingServiceRegistry) StartLifecycle() {
 }
 
 // StopLifecycle stops this component. It should only be invoked by an fx lifecycle hook.
+// Should not be called concurrently with StartLifecycle()
 func (r *IncomingServiceRegistry) StopLifecycle() {
-	r.refreshPoller.Cancel()
-	<-r.refreshPoller.Done()
+	if r.refreshPoller != nil {
+		r.refreshPoller.Cancel()
+		<-r.refreshPoller.Done()
+	}
 }
 
 func (r *IncomingServiceRegistry) Get(ctx context.Context, id string) (*nexus.IncomingService, error) {

--- a/common/nexus/incoming_service_registry_test.go
+++ b/common/nexus/incoming_service_registry_test.go
@@ -74,8 +74,8 @@ func TestGet(t *testing.T) {
 	}).MaxTimes(1)
 
 	reg := NewIncomingServiceRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger())
-	reg.Start()
-	defer reg.Stop()
+	reg.StartLifecycle()
+	defer reg.StopLifecycle()
 
 	service, err := reg.Get(context.Background(), testService.Id)
 	require.NoError(t, err)
@@ -110,8 +110,8 @@ func TestGetNotFound(t *testing.T) {
 	}).MaxTimes(1)
 
 	reg := NewIncomingServiceRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger())
-	reg.Start()
-	defer reg.Stop()
+	reg.StartLifecycle()
+	defer reg.StopLifecycle()
 
 	service, err := reg.Get(context.Background(), uuid.NewString())
 	var notFound *serviceerror.NotFound
@@ -138,8 +138,8 @@ func TestLazyLoadFallback(t *testing.T) {
 	}, nil)
 
 	reg := NewIncomingServiceRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger())
-	reg.Start()
-	defer reg.Stop()
+	reg.StartLifecycle()
+	defer reg.StopLifecycle()
 
 	service, err := reg.Get(context.Background(), testService.Id)
 	require.NoError(t, err)
@@ -212,8 +212,8 @@ func TestTableVersionErrorResetsMatchingPagination(t *testing.T) {
 	}).MaxTimes(1)
 
 	reg := NewIncomingServiceRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger())
-	reg.Start()
-	defer reg.Stop()
+	reg.StartLifecycle()
+	defer reg.StopLifecycle()
 
 	service, err := reg.Get(context.Background(), testService0.Id)
 	require.NoError(t, err)
@@ -279,8 +279,8 @@ func TestTableVersionErrorResetsPersistencePagination(t *testing.T) {
 	}, nil)
 
 	reg := NewIncomingServiceRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger())
-	reg.Start()
-	defer reg.Stop()
+	reg.StartLifecycle()
+	defer reg.StopLifecycle()
 
 	service, err := reg.Get(context.Background(), testService0.Id)
 	require.NoError(t, err)

--- a/common/nexus/incoming_service_registry_test.go
+++ b/common/nexus/incoming_service_registry_test.go
@@ -79,8 +79,11 @@ func TestGet(t *testing.T) {
 
 	service, err := reg.Get(context.Background(), testService.Id)
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), reg.tableVersion)
 	protoassert.ProtoEqual(t, testService, service)
+
+	reg.dataLock.RLock()
+	defer reg.dataLock.RUnlock()
+	assert.Equal(t, int64(1), reg.tableVersion)
 }
 
 func TestGetNotFound(t *testing.T) {
@@ -114,6 +117,9 @@ func TestGetNotFound(t *testing.T) {
 	var notFound *serviceerror.NotFound
 	assert.ErrorAs(t, err, &notFound)
 	assert.Nil(t, service)
+
+	reg.dataLock.RLock()
+	defer reg.dataLock.RUnlock()
 	assert.Equal(t, int64(1), reg.tableVersion)
 	assert.NotEmpty(t, reg.services)
 }
@@ -137,8 +143,11 @@ func TestLazyLoadFallback(t *testing.T) {
 
 	service, err := reg.Get(context.Background(), testService.Id)
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), reg.tableVersion)
 	protoassert.ProtoEqual(t, testService, service)
+
+	reg.dataLock.RLock()
+	defer reg.dataLock.RUnlock()
+	assert.Equal(t, int64(1), reg.tableVersion)
 }
 
 func TestTableVersionErrorResetsMatchingPagination(t *testing.T) {
@@ -214,6 +223,8 @@ func TestTableVersionErrorResetsMatchingPagination(t *testing.T) {
 	require.NoError(t, err)
 	protoassert.ProtoEqual(t, testService1, service)
 
+	reg.dataLock.RLock()
+	defer reg.dataLock.RUnlock()
 	assert.Equal(t, int64(3), reg.tableVersion)
 }
 
@@ -279,6 +290,8 @@ func TestTableVersionErrorResetsPersistencePagination(t *testing.T) {
 	require.NoError(t, err)
 	protoassert.ProtoEqual(t, testService1, service)
 
+	reg.dataLock.RLock()
+	defer reg.dataLock.RUnlock()
 	assert.Equal(t, int64(3), reg.tableVersion)
 }
 

--- a/common/nexus/incoming_service_registry_test.go
+++ b/common/nexus/incoming_service_registry_test.go
@@ -1,0 +1,315 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package nexus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/serviceerror"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/api/matchingservicemock/v1"
+	persistencepb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/testing/protoassert"
+)
+
+type testMocks struct {
+	config         *IncomingServiceRegistryConfig
+	matchingClient *matchingservicemock.MockMatchingServiceClient
+	persistence    *persistence.MockNexusIncomingServiceManager
+}
+
+func TestGet(t *testing.T) {
+	t.Parallel()
+
+	testService := newIncomingService(t.Name())
+	mocks := newTestMocks(t)
+
+	// lazy load
+	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), gomock.Any()).Return(&matchingservice.ListNexusIncomingServicesResponse{
+		Services:      []*nexus.IncomingService{testService},
+		TableVersion:  1,
+		NextPageToken: nil,
+	}, nil)
+
+	// first long poll
+	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), &matchingservice.ListNexusIncomingServicesRequest{
+		PageSize:              int32(1000),
+		LastKnownTableVersion: int64(1),
+		Wait:                  true,
+	}).DoAndReturn(func(context.Context, *matchingservice.ListNexusIncomingServicesRequest, ...interface{}) (*matchingservice.ListNexusIncomingServicesResponse, error) {
+		time.Sleep(20 * time.Millisecond)
+		return &matchingservice.ListNexusIncomingServicesResponse{TableVersion: int64(1)}, nil
+	}).MaxTimes(1)
+
+	reg := NewIncomingServiceRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger())
+	reg.Start()
+	defer reg.Stop()
+
+	service, err := reg.Get(context.Background(), testService.Id)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), reg.tableVersion)
+	protoassert.ProtoEqual(t, testService, service)
+}
+
+func TestGetNotFound(t *testing.T) {
+	t.Parallel()
+
+	testService := newIncomingService(t.Name())
+	mocks := newTestMocks(t)
+
+	// lazy load
+	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), gomock.Any()).Return(&matchingservice.ListNexusIncomingServicesResponse{
+		Services:      []*nexus.IncomingService{testService},
+		TableVersion:  1,
+		NextPageToken: nil,
+	}, nil)
+
+	// first long poll
+	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), &matchingservice.ListNexusIncomingServicesRequest{
+		PageSize:              int32(1000),
+		LastKnownTableVersion: int64(1),
+		Wait:                  true,
+	}).DoAndReturn(func(context.Context, *matchingservice.ListNexusIncomingServicesRequest, ...interface{}) (*matchingservice.ListNexusIncomingServicesResponse, error) {
+		time.Sleep(20 * time.Millisecond)
+		return &matchingservice.ListNexusIncomingServicesResponse{TableVersion: int64(1)}, nil
+	}).MaxTimes(1)
+
+	reg := NewIncomingServiceRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger())
+	reg.Start()
+	defer reg.Stop()
+
+	service, err := reg.Get(context.Background(), uuid.NewString())
+	var notFound *serviceerror.NotFound
+	assert.ErrorAs(t, err, &notFound)
+	assert.Nil(t, service)
+	assert.Equal(t, int64(1), reg.tableVersion)
+	assert.NotEmpty(t, reg.services)
+}
+
+func TestLazyLoadFallback(t *testing.T) {
+	t.Parallel()
+
+	testService := newIncomingService(t.Name())
+	mocks := newTestMocks(t)
+
+	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewUnavailable("matching unavailable test error")).MinTimes(1)
+	mocks.persistence.EXPECT().ListNexusIncomingServices(gomock.Any(), gomock.Any()).Return(&persistence.ListNexusIncomingServicesResponse{
+		TableVersion:  int64(1),
+		NextPageToken: nil,
+		Entries:       []*persistencepb.NexusIncomingServiceEntry{serviceToEntry(testService)},
+	}, nil)
+
+	reg := NewIncomingServiceRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger())
+	reg.Start()
+	defer reg.Stop()
+
+	service, err := reg.Get(context.Background(), testService.Id)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), reg.tableVersion)
+	protoassert.ProtoEqual(t, testService, service)
+}
+
+func TestTableVersionErrorResetsMatchingPagination(t *testing.T) {
+	t.Parallel()
+
+	testService0 := newIncomingService(t.Name() + "-0")
+	testService1 := newIncomingService(t.Name() + "-1")
+
+	mocks := newTestMocks(t)
+	mocks.config.refreshPageSize = dynamicconfig.GetIntPropertyFn(1)
+
+	// service data initialization mocks
+	// successfully get first page
+	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), &matchingservice.ListNexusIncomingServicesRequest{
+		NextPageToken:         nil,
+		PageSize:              int32(1),
+		LastKnownTableVersion: int64(0),
+		Wait:                  false,
+	}).Return(&matchingservice.ListNexusIncomingServicesResponse{
+		Services:      []*nexus.IncomingService{testService0},
+		TableVersion:  int64(2),
+		NextPageToken: []byte(testService0.Id),
+	}, nil)
+	// persistence.ErrNexusTableVersionConflict error on second page
+	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), &matchingservice.ListNexusIncomingServicesRequest{
+		NextPageToken:         []byte(testService0.Id),
+		PageSize:              int32(1),
+		LastKnownTableVersion: int64(2),
+		Wait:                  false,
+	}).Return(&matchingservice.ListNexusIncomingServicesResponse{TableVersion: int64(3)}, persistence.ErrNexusTableVersionConflict)
+	// request first page again
+	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), &matchingservice.ListNexusIncomingServicesRequest{
+		NextPageToken:         nil,
+		PageSize:              int32(1),
+		LastKnownTableVersion: int64(0),
+		Wait:                  false,
+	}).Return(&matchingservice.ListNexusIncomingServicesResponse{
+		Services:      []*nexus.IncomingService{testService0},
+		TableVersion:  int64(3),
+		NextPageToken: []byte(testService0.Id),
+	}, nil)
+	// successfully get second page
+	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), &matchingservice.ListNexusIncomingServicesRequest{
+		NextPageToken:         []byte(testService0.Id),
+		PageSize:              int32(1),
+		LastKnownTableVersion: int64(3),
+		Wait:                  false,
+	}).Return(&matchingservice.ListNexusIncomingServicesResponse{
+		Services:      []*nexus.IncomingService{testService1},
+		TableVersion:  int64(3),
+		NextPageToken: nil,
+	}, nil)
+
+	// mock first long poll
+	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), &matchingservice.ListNexusIncomingServicesRequest{
+		PageSize:              int32(1),
+		LastKnownTableVersion: int64(3),
+		Wait:                  true,
+	}).DoAndReturn(func(context.Context, *matchingservice.ListNexusIncomingServicesRequest, ...interface{}) (*matchingservice.ListNexusIncomingServicesResponse, error) {
+		time.Sleep(20 * time.Millisecond)
+		return &matchingservice.ListNexusIncomingServicesResponse{TableVersion: int64(1)}, nil
+	}).MaxTimes(1)
+
+	reg := NewIncomingServiceRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger())
+	reg.Start()
+	defer reg.Stop()
+
+	service, err := reg.Get(context.Background(), testService0.Id)
+	require.NoError(t, err)
+	protoassert.ProtoEqual(t, testService0, service)
+
+	service, err = reg.Get(context.Background(), testService1.Id)
+	require.NoError(t, err)
+	protoassert.ProtoEqual(t, testService1, service)
+
+	assert.Equal(t, int64(3), reg.tableVersion)
+}
+
+func TestTableVersionErrorResetsPersistencePagination(t *testing.T) {
+	t.Parallel()
+
+	testService0 := newIncomingService(t.Name() + "-0")
+	testService1 := newIncomingService(t.Name() + "-1")
+
+	mocks := newTestMocks(t)
+	mocks.config.refreshPageSize = dynamicconfig.GetIntPropertyFn(1)
+
+	// mock unavailable matching service
+	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewUnavailable("matching unavailable test error")).MinTimes(1)
+
+	// fallback service data initialization mocks
+	// successfully get first page
+	mocks.persistence.EXPECT().ListNexusIncomingServices(gomock.Any(), &persistence.ListNexusIncomingServicesRequest{
+		NextPageToken:         nil,
+		PageSize:              1,
+		LastKnownTableVersion: int64(0),
+	}).Return(&persistence.ListNexusIncomingServicesResponse{
+		Entries:       []*persistencepb.NexusIncomingServiceEntry{serviceToEntry(testService0)},
+		TableVersion:  int64(2),
+		NextPageToken: []byte(testService0.Id),
+	}, nil)
+	// persistence.ErrNexusTableVersionConflict error on second page
+	mocks.persistence.EXPECT().ListNexusIncomingServices(gomock.Any(), &persistence.ListNexusIncomingServicesRequest{
+		NextPageToken:         []byte(testService0.Id),
+		PageSize:              1,
+		LastKnownTableVersion: int64(2),
+	}).Return(&persistence.ListNexusIncomingServicesResponse{TableVersion: int64(3)}, persistence.ErrNexusTableVersionConflict)
+	// request first page again
+	mocks.persistence.EXPECT().ListNexusIncomingServices(gomock.Any(), &persistence.ListNexusIncomingServicesRequest{
+		NextPageToken:         nil,
+		PageSize:              1,
+		LastKnownTableVersion: int64(0),
+	}).Return(&persistence.ListNexusIncomingServicesResponse{
+		Entries:       []*persistencepb.NexusIncomingServiceEntry{serviceToEntry(testService0)},
+		TableVersion:  int64(3),
+		NextPageToken: []byte(testService0.Id),
+	}, nil)
+	// successfully get second page
+	mocks.persistence.EXPECT().ListNexusIncomingServices(gomock.Any(), &persistence.ListNexusIncomingServicesRequest{
+		NextPageToken:         []byte(testService0.Id),
+		PageSize:              1,
+		LastKnownTableVersion: int64(3),
+	}).Return(&persistence.ListNexusIncomingServicesResponse{
+		Entries:       []*persistencepb.NexusIncomingServiceEntry{serviceToEntry(testService1)},
+		TableVersion:  int64(3),
+		NextPageToken: nil,
+	}, nil)
+
+	reg := NewIncomingServiceRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger())
+	reg.Start()
+	defer reg.Stop()
+
+	service, err := reg.Get(context.Background(), testService0.Id)
+	require.NoError(t, err)
+	protoassert.ProtoEqual(t, testService0, service)
+
+	service, err = reg.Get(context.Background(), testService1.Id)
+	require.NoError(t, err)
+	protoassert.ProtoEqual(t, testService1, service)
+
+	assert.Equal(t, int64(3), reg.tableVersion)
+}
+
+func newTestMocks(t *testing.T) *testMocks {
+	ctrl := gomock.NewController(t)
+	return &testMocks{
+		config:         NewIncomingServiceRegistryConfig(dynamicconfig.NewNoopCollection()),
+		matchingClient: matchingservicemock.NewMockMatchingServiceClient(ctrl),
+		persistence:    persistence.NewMockNexusIncomingServiceManager(ctrl),
+	}
+}
+
+func newIncomingService(name string) *nexus.IncomingService {
+	id := uuid.NewString()
+	return &nexus.IncomingService{
+		Version:     1,
+		Id:          id,
+		CreatedTime: timestamppb.Now(),
+		UrlPrefix:   "/" + Routes().DispatchNexusTaskByService.Path(id),
+		Spec: &nexus.IncomingServiceSpec{
+			Name:      name,
+			Namespace: name + "-namespace",
+			TaskQueue: name + "-task-queue",
+		},
+	}
+}
+
+func serviceToEntry(service *nexus.IncomingService) *persistencepb.NexusIncomingServiceEntry {
+	return &persistencepb.NexusIncomingServiceEntry{
+		Version: service.Version,
+		Id:      service.Id,
+		Service: &persistencepb.NexusIncomingService{Spec: service.Spec, CreatedTime: service.CreatedTime},
+	}
+}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Added `nexus.IncomingServiceRegistry`
The registry is a wrapper for a cache of `serviceID->service` mappings. The cache is lazily loaded on first read and then kept up to date by a background thread that long polls on the matching service `ListNexusIncomingServices` API. On initial load only, if matching is unavailable, it falls back to reading directly from persistence.

## Why?
<!-- Tell your future self why have you made these changes -->
This will be used to resolve `serviceID -> namespace + task queue` to support dispatching Nexus tasks by service ID.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
New unit tests

