### PR TITLE
Fix GHA tests job result to fail when individual tests are cancelled or skipped

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -330,10 +330,11 @@ jobs:
       - functional-test-ndc
     runs-on: ubuntu-latest
     if: always()
+    env:
+      RESULTS: ${{ toJSON(needs.*.result) }}
     steps:
-      - name: Success
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
-        run: exit 0
-      - name: Failure
-        if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
+      - name: Check results
+        run: |
+          if [[ -n $(echo "$RESULTS" | jq '.[] | select (. != "success")') ]]; then
+            exit 1
+          fi


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix GHA tests results jobs to fail when tests are cancelled or skipped

## Why?
<!-- Tell your future self why have you made these changes -->
When a indirect dependency fails, and tests are cancelled or skipped, the test result should fail, not pass.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Cancelled the `misc-checks` and checked the final result was a failure: https://github.com/temporalio/temporal/actions/runs/8511400629

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
