### PR TITLE
Deprecate GetCurrentRunIDLock flag

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -573,8 +573,6 @@ const (
 	// HistoryCacheHostLevelMaxSizeBytes is the maximum size of the host level history cache. This is only used if
 	// HistoryCacheSizeBasedLimit is set to true.
 	HistoryCacheHostLevelMaxSizeBytes = "history.hostLevelCacheMaxSizeBytes"
-	// EnableAPIGetCurrentRunIDLock controls if a lock should be acquired before getting current run ID for API requests
-	EnableAPIGetCurrentRunIDLock = "history.enableAPIGetCurrentRunIDLock"
 	// EnableMutableStateTransitionHistory controls whether to record state transition history in mutable state records.
 	// The feature is used in the hierarchical state machine framework and is considered unstable as the structure may
 	// change with the pending replication design.

--- a/service/history/api/consistency_checker.go
+++ b/service/history/api/consistency_checker.go
@@ -309,19 +309,17 @@ func (c *WorkflowConsistencyCheckerImpl) getCurrentRunID(
 	workflowID string,
 	lockPriority workflow.LockPriority,
 ) (runID string, retErr error) {
-	if c.shardContext.GetConfig().EnableAPIGetCurrentRunIDLock() {
-		currentRelease, err := c.workflowCache.GetOrCreateCurrentWorkflowExecution(
-			ctx,
-			c.shardContext,
-			namespace.ID(namespaceID),
-			workflowID,
-			lockPriority,
-		)
-		if err != nil {
-			return "", err
-		}
-		defer currentRelease(retErr)
+	currentRelease, err := c.workflowCache.GetOrCreateCurrentWorkflowExecution(
+		ctx,
+		c.shardContext,
+		namespace.ID(namespaceID),
+		workflowID,
+		lockPriority,
+	)
+	if err != nil {
+		return "", err
 	}
+	defer currentRelease(retErr)
 
 	resp, err := c.shardContext.GetCurrentExecution(
 		ctx,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -80,7 +80,6 @@ type Config struct {
 	HistoryCacheTTL                       dynamicconfig.DurationPropertyFn
 	HistoryCacheNonUserContextLockTimeout dynamicconfig.DurationPropertyFn
 	EnableHostLevelHistoryCache           dynamicconfig.BoolPropertyFn
-	EnableAPIGetCurrentRunIDLock          dynamicconfig.BoolPropertyFn
 	EnableMutableStateTransitionHistory   dynamicconfig.BoolPropertyFn
 
 	// EventsCache settings
@@ -390,7 +389,6 @@ func NewConfig(
 		HistoryCacheTTL:                       dc.GetDurationProperty(dynamicconfig.HistoryCacheTTL, time.Hour),
 		HistoryCacheNonUserContextLockTimeout: dc.GetDurationProperty(dynamicconfig.HistoryCacheNonUserContextLockTimeout, 500*time.Millisecond),
 		EnableHostLevelHistoryCache:           dc.GetBoolProperty(dynamicconfig.EnableHostHistoryCache, false),
-		EnableAPIGetCurrentRunIDLock:          dc.GetBoolProperty(dynamicconfig.EnableAPIGetCurrentRunIDLock, false),
 		EnableMutableStateTransitionHistory:   dc.GetBoolProperty(dynamicconfig.EnableMutableStateTransitionHistory, false),
 
 		EventsShardLevelCacheMaxSizeBytes: dc.GetIntProperty(dynamicconfig.EventsCacheMaxSizeBytes, 512*1024),              // 512KB

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -188,7 +188,6 @@ func NewDynamicConfig() *configs.Config {
 	config.EnableActivityEagerExecution = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.EnableEagerWorkflowStart = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.NamespaceCacheRefreshInterval = dynamicconfig.GetDurationPropertyFn(time.Second)
-	config.EnableAPIGetCurrentRunIDLock = dynamicconfig.GetBoolPropertyFn(true)
 	config.FrontendAccessHistoryFraction = dynamicconfig.GetFloatPropertyFn(1.0)
 	config.EnableMutableStateTransitionHistory = dynamicconfig.GetBoolPropertyFn(true)
 	config.ReplicationEnableUpdateWithNewTaskMerge = dynamicconfig.GetBoolPropertyFn(true)

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -832,8 +832,6 @@ func (c *temporalImpl) overrideHistoryDynamicConfig(t *testing.T, client *dcClie
 	// For DeleteWorkflowExecution tests
 	client.OverrideValue(t, dynamicconfig.TransferProcessorUpdateAckInterval, 1*time.Second)
 	client.OverrideValue(t, dynamicconfig.VisibilityProcessorUpdateAckInterval, 1*time.Second)
-
-	client.OverrideValue(t, dynamicconfig.EnableAPIGetCurrentRunIDLock, true)
 }
 
 func (c *temporalImpl) newRPCFactory(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Deprecate EnableAPIGetCurrentRunIDLock flag and always perform the locking.

## Why?
<!-- Tell your future self why have you made these changes -->
- Flag already enabled in prod for a long time and believe to be safe to always enable the locking logic.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- N/A

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- N/A

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
- No changed required for OSS user.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- No.
