### PR TITLE
Return rules list in UpdateWorkerVersioningRules as in GetWorkerVersioningRules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.temporal.io/server
 
 go 1.21
 
-replace go.temporal.io/api => github.com/temporalio/api-go v1.26.1-0.20240322171941-24a485531a95
+replace go.temporal.io/api => ../api-go
 
 require (
 	cloud.google.com/go/storage v1.36.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.temporal.io/server
 
 go 1.21
 
-replace go.temporal.io/api => ../api-go
+replace go.temporal.io/api => github.com/temporalio/api-go v1.26.1-0.20240331082154-0f9414bcf5de
 
 require (
 	cloud.google.com/go/storage v1.36.0
@@ -138,8 +138,8 @@ require (
 	golang.org/x/tools v0.16.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240125205218-1f4bbc51befe // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20240325203815-454cdb8f5daa
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240325203815-454cdb8f5daa // indirect
 	google.golang.org/protobuf v1.33.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	lukechampine.com/uint128 v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/temporalio/api-go v1.26.1-0.20240331082154-0f9414bcf5de h1:bUYzy39KlRsOI5H6+i7k5jRk5CR76NOJUkT0sPKfBng=
+github.com/temporalio/api-go v1.26.1-0.20240331082154-0f9414bcf5de/go.mod h1:oAANNUHtK3EcEzPBj/mCavYt86dg+6/S9vZv+La1Cmg=
 github.com/temporalio/ringpop-go v0.0.0-20230606200434-b5c079f412d3 h1:V1U9fvhusDJ1pyAvQWg0+u6mQ+o5WtRfMbnnTIZe0Fo=
 github.com/temporalio/ringpop-go v0.0.0-20230606200434-b5c079f412d3/go.mod h1:LA2yFb94r5XoEnuMVHkCC/P5174whMy2Dd+cu+AEcQA=
 github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb h1:YzHH/U/dN7vMP+glybzcXRTczTrgfdRisNTzAj7La04=
@@ -570,10 +572,10 @@ google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20240125205218-1f4bbc51befe h1:USL2DhxfgRchafRvt/wYyyQNzwgL7ZiURcozOE/Pkvo=
 google.golang.org/genproto v0.0.0-20240125205218-1f4bbc51befe/go.mod h1:cc8bqMqtv9gMOr0zHg2Vzff5ULhhL2IXP4sbcn32Dro=
-google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 h1:RFiFrvy37/mpSpdySBDrUdipW/dHwsRwh3J3+A9VgT4=
-google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237/go.mod h1:Z5Iiy3jtmioajWHDGFk7CeugTyHtPvMHA4UTmUkyalE=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 h1:NnYq6UN9ReLM9/Y01KWNOWyI5xQ9kbIms5GGJVwS/Yc=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
+google.golang.org/genproto/googleapis/api v0.0.0-20240325203815-454cdb8f5daa h1:Jt1XW5PaLXF1/ePZrznsh/aAUvI7Adfc3LY1dAKlzRs=
+google.golang.org/genproto/googleapis/api v0.0.0-20240325203815-454cdb8f5daa/go.mod h1:K4kfzHtI0kqWA79gecJarFtDn/Mls+GxQcg3Zox91Ac=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240325203815-454cdb8f5daa h1:RBgMaUMP+6soRkik4VoN8ojR2nex2TqZwjSSogic+eo=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240325203815-454cdb8f5daa/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,6 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/temporalio/api-go v1.26.1-0.20240322171941-24a485531a95 h1:z/0MgbPM1htVcSk9ybRpGKglFu4pC9++6res6WInZdk=
-github.com/temporalio/api-go v1.26.1-0.20240322171941-24a485531a95/go.mod h1:xI9UdP3s07881dgWzG8idIBAnZq3/aop+O682EIDoT0=
 github.com/temporalio/ringpop-go v0.0.0-20230606200434-b5c079f412d3 h1:V1U9fvhusDJ1pyAvQWg0+u6mQ+o5WtRfMbnnTIZe0Fo=
 github.com/temporalio/ringpop-go v0.0.0-20230606200434-b5c079f412d3/go.mod h1:LA2yFb94r5XoEnuMVHkCC/P5174whMy2Dd+cu+AEcQA=
 github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb h1:YzHH/U/dN7vMP+glybzcXRTczTrgfdRisNTzAj7La04=

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -2747,6 +2747,9 @@ func (s *VersioningIntegSuite) deleteAssignmentRule(
 		Namespace: s.namespace,
 		TaskQueue: tq,
 	})
+	s.NoError(err)
+	s.NotNil(getResp)
+
 	var prevRule *taskqueuepb.BuildIdAssignmentRule
 	if expectSuccess {
 		prevRule = getResp.GetAssignmentRules()[idx].GetRule()

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -2699,6 +2699,7 @@ func (s *VersioningIntegSuite) insertAssignmentRule(
 	if expectSuccess {
 		s.NoError(err)
 		s.NotNil(res)
+		s.Assert().Equal(newBuildId, res.GetAssignmentRules()[idx].GetRule().GetTargetBuildId())
 		return res.GetConflictToken()
 	} else {
 		s.Error(err)
@@ -2728,6 +2729,7 @@ func (s *VersioningIntegSuite) replaceAssignmentRule(
 	if expectSuccess {
 		s.NoError(err)
 		s.NotNil(res)
+		s.Assert().Equal(newBuildId, res.GetAssignmentRules()[idx].GetRule().GetTargetBuildId())
 		return res.GetConflictToken()
 	} else {
 		s.Error(err)
@@ -2741,6 +2743,15 @@ func (s *VersioningIntegSuite) replaceAssignmentRule(
 func (s *VersioningIntegSuite) deleteAssignmentRule(
 	ctx context.Context, tq string,
 	idx int32, conflictToken []byte, expectSuccess bool) []byte {
+	getResp, err := s.engine.GetWorkerVersioningRules(ctx, &workflowservice.GetWorkerVersioningRulesRequest{
+		Namespace: s.namespace,
+		TaskQueue: tq,
+	})
+	var prevRule *taskqueuepb.BuildIdAssignmentRule
+	if expectSuccess {
+		prevRule = getResp.GetAssignmentRules()[idx].GetRule()
+	}
+
 	res, err := s.engine.UpdateWorkerVersioningRules(ctx, &workflowservice.UpdateWorkerVersioningRulesRequest{
 		Namespace:     s.namespace,
 		TaskQueue:     tq,
@@ -2754,6 +2765,14 @@ func (s *VersioningIntegSuite) deleteAssignmentRule(
 	if expectSuccess {
 		s.NoError(err)
 		s.NotNil(res)
+		found := false
+		for _, r := range res.GetAssignmentRules() {
+			if r.GetRule() == prevRule {
+				found = true
+				break
+			}
+		}
+		s.Assert().False(found)
 		return res.GetConflictToken()
 	} else {
 		s.Error(err)
@@ -2783,6 +2802,14 @@ func (s *VersioningIntegSuite) insertRedirectRule(
 	if expectSuccess {
 		s.NoError(err)
 		s.NotNil(res)
+		found := false
+		for _, r := range res.GetCompatibleRedirectRules() {
+			if r.GetRule().GetSourceBuildId() == sourceBuildId && r.GetRule().GetTargetBuildId() == targetBuildId {
+				found = true
+				break
+			}
+		}
+		s.Assert().True(found)
 		return res.GetConflictToken()
 	} else {
 		s.Error(err)
@@ -2812,6 +2839,14 @@ func (s *VersioningIntegSuite) replaceRedirectRule(
 	if expectSuccess {
 		s.NoError(err)
 		s.NotNil(res)
+		found := false
+		for _, r := range res.GetCompatibleRedirectRules() {
+			if r.GetRule().GetSourceBuildId() == sourceBuildId && r.GetRule().GetTargetBuildId() == targetBuildId {
+				found = true
+				break
+			}
+		}
+		s.Assert().True(found)
 		return res.GetConflictToken()
 	} else {
 		s.Error(err)
@@ -2838,6 +2873,14 @@ func (s *VersioningIntegSuite) deleteRedirectRule(
 	if expectSuccess {
 		s.NoError(err)
 		s.NotNil(res)
+		found := false
+		for _, r := range res.GetCompatibleRedirectRules() {
+			if r.GetRule().GetSourceBuildId() == sourceBuildId {
+				found = true
+				break
+			}
+		}
+		s.Assert().False(found)
 		return res.GetConflictToken()
 	} else {
 		s.Error(err)
@@ -2865,6 +2908,27 @@ func (s *VersioningIntegSuite) commitBuildId(
 	if expectSuccess {
 		s.NoError(err)
 		s.NotNil(res)
+		// 1. Adds an assignment rule (with full ramp) for the target Build ID at the end of the list.
+		endIdx := len(res.GetAssignmentRules()) - 1
+		addedRule := res.GetAssignmentRules()[endIdx].GetRule()
+		s.Assert().Equal(targetBuildId, addedRule.GetTargetBuildId())
+		s.Assert().Nil(addedRule.GetRamp())
+		s.Assert().Nil(addedRule.GetPercentageRamp())
+
+		foundOtherAssignmentRuleForTarget := false
+		foundFullyRampedAssignmentRuleForOtherTarget := false
+		for i, r := range res.GetAssignmentRules() {
+			if r.GetRule().GetTargetBuildId() == targetBuildId && i != endIdx {
+				foundOtherAssignmentRuleForTarget = true
+			}
+			if r.GetRule().GetRamp() == nil && r.GetRule().GetTargetBuildId() != targetBuildId {
+				foundFullyRampedAssignmentRuleForOtherTarget = true
+			}
+		}
+		// 2. Removes all previously added assignment rules to the given target Build ID (if any).
+		s.Assert().False(foundOtherAssignmentRuleForTarget)
+		// 3. Removes any fully-ramped assignment rule for other Build IDs.
+		s.Assert().False(foundFullyRampedAssignmentRuleForOtherTarget)
 		return res.GetConflictToken()
 	} else {
 		s.Error(err)


### PR DESCRIPTION
## What changed?
Return rules list in UpdateWorkerVersioningRules as in GetWorkerVersioningRules

## Why?
To make the responses consistent for a better SDK experience

## How did you test it?
Updated functional tests.

## Potential risks
None

## Documentation
Corresponding change in api has already landed

## Is hotfix candidate?
No
