### PR TITLE
Logged Quota Calculator

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -382,6 +382,12 @@ func shardupdate(shardupdate string) ZapTag {
 	return NewStringTag("shard-update", shardupdate)
 }
 
+// scope returns a tag for scope
+// Pre-defined scope tags are in values.go.
+func scope(scope string) ZapTag {
+	return NewStringTag("scope", scope)
+}
+
 // general
 
 // Service returns tag for Service

--- a/common/log/tag/values.go
+++ b/common/log/tag/values.go
@@ -138,7 +138,19 @@ var (
 	ComponentServiceResolver          = component("service-resolver")
 	ComponentMetadataInitializer      = component("metadata-initializer")
 	ComponentAddSearchAttributes      = component("add-search-attributes")
+	ComponentRPCHandler               = component("rpc-handler")
+	ComponentLongPollHandler          = component("long-poll-handler")
+	ComponentVisibilityHandler        = component("visibility-handler")
+	ComponentNamespaceReplication     = component("namespace-replication")
+	ComponentPersistence              = component("persistence")
+	ComponentTaskScheduler            = component("task-scheduler")
 	VersionChecker                    = component("version-checker")
+)
+
+// Pre-defined values for scope tag
+var (
+	ScopeHost      = scope("host")
+	ScopeNamespace = scope("namespace")
 )
 
 // Pre-defined values for TagSysLifecycle

--- a/common/quotas/calculator/calculator.go
+++ b/common/quotas/calculator/calculator.go
@@ -1,0 +1,35 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package calculator
+
+type (
+	Calculator interface {
+		GetQuota() float64
+	}
+
+	NamespaceCalculator interface {
+		GetQuota(namespace string) float64
+	}
+)

--- a/common/quotas/calculator/cluster_aware_quota_calculator.go
+++ b/common/quotas/calculator/cluster_aware_quota_calculator.go
@@ -22,7 +22,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package quotas
+package calculator
+
+var (
+	_ Calculator          = (*ClusterAwareQuotaCalculator)(nil)
+	_ NamespaceCalculator = (*ClusterAwareNamespaceQuotaCalculator)(nil)
+)
 
 type (
 	// MemberCounter returns the total number of instances there are for a given service.
@@ -33,9 +38,9 @@ type (
 	// cluster quota. The quota could represent requests per second, total number of active requests, etc. It works by
 	// dividing the per cluster quota by the total number of instances running the same service.
 	ClusterAwareQuotaCalculator quotaCalculator[func() int]
-	// ClusterAwareNamespaceSpecificQuotaCalculator is similar to ClusterAwareQuotaCalculator, but it uses quotas that
+	// ClusterAwareNamespaceQuotaCalculator is similar to ClusterAwareQuotaCalculator, but it uses quotas that
 	// are specific to a namespace.
-	ClusterAwareNamespaceSpecificQuotaCalculator quotaCalculator[func(namespace string) int]
+	ClusterAwareNamespaceQuotaCalculator quotaCalculator[func(namespace string) int]
 	// quotaCalculator is a generic type that we use because the quota functions could be namespace specific or not.
 	quotaCalculator[T any] struct {
 		MemberCounter MemberCounter
@@ -64,6 +69,6 @@ func (l ClusterAwareQuotaCalculator) GetQuota() float64 {
 	return getQuota(l.MemberCounter, l.PerInstanceQuota(), l.GlobalQuota())
 }
 
-func (l ClusterAwareNamespaceSpecificQuotaCalculator) GetQuota(namespace string) float64 {
+func (l ClusterAwareNamespaceQuotaCalculator) GetQuota(namespace string) float64 {
 	return getQuota(l.MemberCounter, l.PerInstanceQuota(namespace), l.GlobalQuota(namespace))
 }

--- a/common/quotas/calculator/cluster_aware_quota_calculator_test.go
+++ b/common/quotas/calculator/cluster_aware_quota_calculator_test.go
@@ -22,20 +22,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package quotas_test
+package calculator
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/server/common/dynamicconfig"
-	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/quotas/quotastest"
 )
 
 type quotaCalculatorTestCase struct {
 	name          string
-	memberCounter quotas.MemberCounter
+	memberCounter MemberCounter
 	instanceLimit int
 	clusterLimit  int
 	expected      float64
@@ -80,7 +79,7 @@ func TestClusterAwareQuotaCalculator_GetQuota(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tc.expected, quotas.ClusterAwareQuotaCalculator{
+			assert.Equal(t, tc.expected, ClusterAwareQuotaCalculator{
 				MemberCounter:    tc.memberCounter,
 				PerInstanceQuota: dynamicconfig.GetIntPropertyFn(tc.instanceLimit),
 				GlobalQuota:      dynamicconfig.GetIntPropertyFn(tc.clusterLimit),
@@ -114,7 +113,7 @@ func TestClusterAwareNamespaceSpecificQuotaCalculator_GetQuota(t *testing.T) {
 
 			clusterLimit := perNamespaceQuota{t: t, quota: tc.clusterLimit}
 
-			assert.Equal(t, tc.expected, quotas.ClusterAwareNamespaceSpecificQuotaCalculator{
+			assert.Equal(t, tc.expected, ClusterAwareNamespaceQuotaCalculator{
 				MemberCounter:    tc.memberCounter,
 				PerInstanceQuota: instanceLimit.getQuota,
 				GlobalQuota:      clusterLimit.getQuota,

--- a/common/quotas/calculator/logged_calculator.go
+++ b/common/quotas/calculator/logged_calculator.go
@@ -1,0 +1,128 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package calculator
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+)
+
+var (
+	_ Calculator          = (*LoggedCalculator)(nil)
+	_ NamespaceCalculator = (*LoggedNamespaceCalculator)(nil)
+)
+
+type (
+	LoggedCalculator struct {
+		calculator Calculator
+
+		quotaLogger *quotaLogger[float64]
+	}
+
+	LoggedNamespaceCalculator struct {
+		calculator NamespaceCalculator
+		logger     log.Logger
+
+		quotaLoggersLock sync.Mutex
+		quotaLoggers     map[string]*quotaLogger[float64]
+	}
+
+	quotaLogger[T comparable] struct {
+		logger       log.Logger
+		currentValue atomic.Value
+	}
+)
+
+func NewLoggedCalculator(
+	calculator Calculator,
+	logger log.Logger,
+) *LoggedCalculator {
+	return &LoggedCalculator{
+		quotaLogger: newQuotaLogger(logger),
+		calculator:  calculator,
+	}
+}
+
+func (c *LoggedCalculator) GetQuota() float64 {
+	quota := c.calculator.GetQuota()
+	c.quotaLogger.updateQuota(quota)
+	return quota
+}
+
+func NewLoggedNamespaceCalculator(
+	calculator NamespaceCalculator,
+	logger log.Logger,
+) *LoggedNamespaceCalculator {
+	return &LoggedNamespaceCalculator{
+		calculator:   calculator,
+		logger:       logger,
+		quotaLoggers: make(map[string]*quotaLogger[float64]),
+	}
+}
+
+func (c *LoggedNamespaceCalculator) GetQuota(namespace string) float64 {
+	quota := c.calculator.GetQuota(namespace)
+	c.getOrCreateQuotaLogger(namespace).updateQuota(quota)
+	return quota
+}
+
+func (c *LoggedNamespaceCalculator) getOrCreateQuotaLogger(
+	namespace string,
+) *quotaLogger[float64] {
+	c.quotaLoggersLock.Lock()
+	defer c.quotaLoggersLock.Unlock()
+
+	quotaLogger, ok := c.quotaLoggers[namespace]
+	if !ok {
+		quotaLogger = newQuotaLogger(c.logger)
+		c.quotaLoggers[namespace] = quotaLogger
+	}
+
+	return quotaLogger
+}
+
+func newQuotaLogger(
+	logger log.Logger,
+) *quotaLogger[float64] {
+	return &quotaLogger[float64]{
+		logger: logger,
+	}
+}
+
+func (l *quotaLogger[T]) updateQuota(newQutoa T) {
+	currentQuota := l.currentValue.Swap(newQutoa)
+
+	if currentQuota != nil && newQutoa == currentQuota.(T) {
+		return
+	}
+
+	l.logger.Info("Quota changed",
+		tag.NewAnyTag("current-quota", currentQuota),
+		tag.NewAnyTag("new-quota", newQutoa),
+	)
+}

--- a/common/quotas/calculator/logged_calculator_test.go
+++ b/common/quotas/calculator/logged_calculator_test.go
@@ -1,0 +1,145 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package calculator
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+)
+
+type (
+	testCalculator struct {
+		quota float64
+	}
+
+	testNamespaceCalculator struct {
+		namespaceQuota map[string]float64
+	}
+)
+
+func TestQuotaLogger(t *testing.T) {
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+
+	mockLogger := log.NewMockLogger(controller)
+
+	quotaLogger := newQuotaLogger(mockLogger)
+
+	mockLogger.EXPECT().Info(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	quotaLogger.updateQuota(1.0)
+
+	quotaLogger.updateQuota(1.0)
+
+	mockLogger.EXPECT().Info(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	quotaLogger.updateQuota(2.0)
+}
+
+func TestLoggedCalculator(t *testing.T) {
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+
+	mockLogger := log.NewMockLogger(controller)
+	mockCalculator := &testCalculator{}
+
+	quota := 1.0
+	mockCalculator.updateQuota(quota)
+
+	loggedCalculator := NewLoggedCalculator(mockCalculator, mockLogger)
+
+	mockLogger.EXPECT().Info(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	actualQuota := loggedCalculator.GetQuota()
+	require.Equal(t, quota, actualQuota)
+
+	actualQuota = loggedCalculator.GetQuota()
+	require.Equal(t, quota, actualQuota)
+
+	quota = 2.0
+	mockCalculator.updateQuota(quota)
+
+	mockLogger.EXPECT().Info(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	actualQuota = loggedCalculator.GetQuota()
+	require.Equal(t, quota, actualQuota)
+}
+
+func TestLoggedNamespaceCalculator(t *testing.T) {
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+
+	mockLogger := log.NewMockLogger(controller)
+	mockCalculator := &testNamespaceCalculator{}
+
+	namespace1 := "test-namespace-1"
+	quota1 := 1.0
+	mockCalculator.updateQuota(namespace1, quota1)
+
+	namespace2 := "test-namespace-2"
+	quota2 := 2.0
+	mockCalculator.updateQuota(namespace2, quota2)
+
+	loggedCalculator := NewLoggedNamespaceCalculator(mockCalculator, mockLogger)
+
+	mockLogger.EXPECT().Info(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	actualQuota := loggedCalculator.GetQuota(namespace1)
+	require.Equal(t, quota1, actualQuota)
+
+	mockLogger.EXPECT().Info(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	actualQuota = loggedCalculator.GetQuota(namespace2)
+	require.Equal(t, quota2, actualQuota)
+
+	quota2 = 3.0
+	mockCalculator.updateQuota(namespace2, quota2)
+
+	mockLogger.EXPECT().Info(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	actualQuota = loggedCalculator.GetQuota(namespace2)
+	require.Equal(t, quota2, actualQuota)
+
+	actualQuota = loggedCalculator.GetQuota(namespace1)
+	require.Equal(t, quota1, actualQuota)
+}
+
+func (c *testCalculator) GetQuota() float64 {
+	return c.quota
+}
+
+func (c *testCalculator) updateQuota(newQuota float64) {
+	c.quota = newQuota
+}
+
+func (c *testNamespaceCalculator) GetQuota(namespace string) float64 {
+	return c.namespaceQuota[namespace]
+}
+
+func (c *testNamespaceCalculator) updateQuota(namespace string, newQuota float64) {
+	if c.namespaceQuota == nil {
+		c.namespaceQuota = make(map[string]float64)
+	}
+	c.namespaceQuota[namespace] = newQuota
+}

--- a/common/rpc/interceptor/concurrent_request_limit_test.go
+++ b/common/rpc/interceptor/concurrent_request_limit_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/dynamicconfig"
-	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/quotas/calculator"
 	"go.temporal.io/server/common/quotas/quotastest"
 	"google.golang.org/grpc"
 
@@ -48,7 +48,7 @@ type nsCountLimitTestCase struct {
 	// numBlockedRequests is the number of pending requests that will be blocked including the final request.
 	numBlockedRequests int
 	// memberCounter returns the number of members in the namespace.
-	memberCounter quotas.MemberCounter
+	memberCounter calculator.MemberCounter
 	// perInstanceLimit is the limit on the number of pending requests per-instance.
 	perInstanceLimit int
 	// globalLimit is the limit on the number of pending requests across all instances.

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -58,6 +58,7 @@ import (
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/quotas/calculator"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/rpc"
@@ -346,12 +347,16 @@ func TelemetryInterceptorProvider(
 func RateLimitInterceptorProvider(
 	serviceConfig *Config,
 	frontendServiceResolver membership.ServiceResolver,
+	logger log.Logger,
 ) *interceptor.RateLimitInterceptor {
-	rateFn := quotas.ClusterAwareQuotaCalculator{
-		MemberCounter:    frontendServiceResolver,
-		PerInstanceQuota: serviceConfig.RPS,
-		GlobalQuota:      serviceConfig.GlobalRPS,
-	}.GetQuota
+	rateFn := calculator.NewLoggedCalculator(
+		calculator.ClusterAwareQuotaCalculator{
+			MemberCounter:    frontendServiceResolver,
+			PerInstanceQuota: serviceConfig.RPS,
+			GlobalQuota:      serviceConfig.GlobalRPS,
+		},
+		log.With(logger, tag.ComponentRPCHandler, tag.ScopeHost),
+	).GetQuota
 	namespaceReplicationInducingRateFn := func() float64 {
 		return float64(serviceConfig.NamespaceReplicationInducingAPIsRPS())
 	}
@@ -372,6 +377,7 @@ func NamespaceRateLimitInterceptorProvider(
 	serviceConfig *Config,
 	namespaceRegistry namespace.Registry,
 	frontendServiceResolver membership.ServiceResolver,
+	logger log.Logger,
 ) *interceptor.NamespaceRateLimitInterceptor {
 	var globalNamespaceRPS, globalNamespaceVisibilityRPS, globalNamespaceNamespaceReplicationInducingAPIsRPS dynamicconfig.IntPropertyFnWithNamespaceFilter
 
@@ -389,21 +395,30 @@ func NamespaceRateLimitInterceptorProvider(
 		panic("invalid service name")
 	}
 
-	namespaceRateFn := quotas.ClusterAwareNamespaceSpecificQuotaCalculator{
-		MemberCounter:    frontendServiceResolver,
-		PerInstanceQuota: serviceConfig.MaxNamespaceRPSPerInstance,
-		GlobalQuota:      globalNamespaceRPS,
-	}.GetQuota
-	visibilityRateFn := quotas.ClusterAwareNamespaceSpecificQuotaCalculator{
-		MemberCounter:    frontendServiceResolver,
-		PerInstanceQuota: serviceConfig.MaxNamespaceVisibilityRPSPerInstance,
-		GlobalQuota:      globalNamespaceVisibilityRPS,
-	}.GetQuota
-	namespaceReplicationInducingRateFn := quotas.ClusterAwareNamespaceSpecificQuotaCalculator{
-		MemberCounter:    frontendServiceResolver,
-		PerInstanceQuota: serviceConfig.MaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance,
-		GlobalQuota:      globalNamespaceNamespaceReplicationInducingAPIsRPS,
-	}.GetQuota
+	namespaceRateFn := calculator.NewLoggedNamespaceCalculator(
+		calculator.ClusterAwareNamespaceQuotaCalculator{
+			MemberCounter:    frontendServiceResolver,
+			PerInstanceQuota: serviceConfig.MaxNamespaceRPSPerInstance,
+			GlobalQuota:      globalNamespaceRPS,
+		},
+		log.With(logger, tag.ComponentRPCHandler, tag.ScopeNamespace),
+	).GetQuota
+	visibilityRateFn := calculator.NewLoggedNamespaceCalculator(
+		calculator.ClusterAwareNamespaceQuotaCalculator{
+			MemberCounter:    frontendServiceResolver,
+			PerInstanceQuota: serviceConfig.MaxNamespaceVisibilityRPSPerInstance,
+			GlobalQuota:      globalNamespaceVisibilityRPS,
+		},
+		log.With(logger, tag.ComponentVisibilityHandler, tag.ScopeNamespace),
+	).GetQuota
+	namespaceReplicationInducingRateFn := calculator.NewLoggedNamespaceCalculator(
+		calculator.ClusterAwareNamespaceQuotaCalculator{
+			MemberCounter:    frontendServiceResolver,
+			PerInstanceQuota: serviceConfig.MaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance,
+			GlobalQuota:      globalNamespaceNamespaceReplicationInducingAPIsRPS,
+		},
+		log.With(logger, tag.ComponentNamespaceReplication, tag.ScopeNamespace),
+	).GetQuota
 	namespaceRateLimiter := quotas.NewNamespaceRequestRateLimiter(
 		func(req quotas.Request) quotas.RequestRateLimiter {
 			return configs.NewRequestToRateLimiter(
@@ -457,6 +472,7 @@ func CallerInfoInterceptorProvider(
 func PersistenceRateLimitingParamsProvider(
 	serviceConfig *Config,
 	persistenceLazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
+	logger log.Logger,
 ) service.PersistenceRateLimitingParams {
 	return service.NewPersistenceRateLimitingParams(
 		serviceConfig.PersistenceMaxQPS,
@@ -468,6 +484,7 @@ func PersistenceRateLimitingParamsProvider(
 		serviceConfig.OperatorRPSRatio,
 		serviceConfig.PersistenceDynamicRateLimitingParams,
 		persistenceLazyLoadedServiceResolver,
+		logger,
 	)
 }
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -347,7 +347,7 @@ func TelemetryInterceptorProvider(
 func RateLimitInterceptorProvider(
 	serviceConfig *Config,
 	frontendServiceResolver membership.ServiceResolver,
-	logger log.Logger,
+	logger log.SnTaggedLogger,
 ) *interceptor.RateLimitInterceptor {
 	rateFn := calculator.NewLoggedCalculator(
 		calculator.ClusterAwareQuotaCalculator{
@@ -377,7 +377,7 @@ func NamespaceRateLimitInterceptorProvider(
 	serviceConfig *Config,
 	namespaceRegistry namespace.Registry,
 	frontendServiceResolver membership.ServiceResolver,
-	logger log.Logger,
+	logger log.SnTaggedLogger,
 ) *interceptor.NamespaceRateLimitInterceptor {
 	var globalNamespaceRPS, globalNamespaceVisibilityRPS, globalNamespaceNamespaceReplicationInducingAPIsRPS dynamicconfig.IntPropertyFnWithNamespaceFilter
 
@@ -472,7 +472,7 @@ func CallerInfoInterceptorProvider(
 func PersistenceRateLimitingParamsProvider(
 	serviceConfig *Config,
 	persistenceLazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
-	logger log.Logger,
+	logger log.SnTaggedLogger,
 ) service.PersistenceRateLimitingParams {
 	return service.NewPersistenceRateLimitingParams(
 		serviceConfig.PersistenceMaxQPS,

--- a/service/frontend/fx_test.go
+++ b/service/frontend/fx_test.go
@@ -37,6 +37,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives"
@@ -230,7 +231,7 @@ func TestRateLimitInterceptorProvider(t *testing.T) {
 				OperatorRPSRatio: func() float64 {
 					return tc.operatorRPSRatio
 				},
-			}, tc.serviceResolver)
+			}, tc.serviceResolver, log.NewTestLogger())
 
 			// Create a gRPC server for the fake workflow service.
 			svc := &testSvc{}
@@ -574,6 +575,7 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 				&config,
 				mockRegistry,
 				serviceResolver,
+				log.NewTestLogger(),
 			)
 
 			// Create a gRPC server for the fake workflow service.

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -229,7 +229,7 @@ func PersistenceRateLimitingParamsProvider(
 	serviceConfig *configs.Config,
 	persistenceLazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
 	ownershipBasedQuotaScaler shard.LazyLoadedOwnershipBasedQuotaScaler,
-	logger log.Logger,
+	logger log.SnTaggedLogger,
 ) service.PersistenceRateLimitingParams {
 	hostCalculator := calculator.NewLoggedCalculator(
 		shard.NewOwnershipAwareQuotaCalculator(

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -45,6 +46,7 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/quotas/calculator"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/rpc/interceptor"
@@ -227,22 +229,29 @@ func PersistenceRateLimitingParamsProvider(
 	serviceConfig *configs.Config,
 	persistenceLazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
 	ownershipBasedQuotaScaler shard.LazyLoadedOwnershipBasedQuotaScaler,
+	logger log.Logger,
 ) service.PersistenceRateLimitingParams {
-	calculator := shard.NewOwnershipAwareQuotaCalculator(
-		ownershipBasedQuotaScaler,
-		persistenceLazyLoadedServiceResolver,
-		serviceConfig.PersistenceMaxQPS,
-		serviceConfig.PersistenceGlobalMaxQPS,
+	hostCalculator := calculator.NewLoggedCalculator(
+		shard.NewOwnershipAwareQuotaCalculator(
+			ownershipBasedQuotaScaler,
+			persistenceLazyLoadedServiceResolver,
+			serviceConfig.PersistenceMaxQPS,
+			serviceConfig.PersistenceGlobalMaxQPS,
+		),
+		log.With(logger, tag.ComponentPersistence, tag.ScopeHost),
 	)
-	namespaceCalculator := shard.NewOwnershipAwareNamespaceQuotaCalculator(
-		ownershipBasedQuotaScaler,
-		persistenceLazyLoadedServiceResolver,
-		serviceConfig.PersistenceNamespaceMaxQPS,
-		serviceConfig.PersistenceGlobalNamespaceMaxQPS,
+	namespaceCalculator := calculator.NewLoggedNamespaceCalculator(
+		shard.NewOwnershipAwareNamespaceQuotaCalculator(
+			ownershipBasedQuotaScaler,
+			persistenceLazyLoadedServiceResolver,
+			serviceConfig.PersistenceNamespaceMaxQPS,
+			serviceConfig.PersistenceGlobalNamespaceMaxQPS,
+		),
+		log.With(logger, tag.ComponentPersistence, tag.ScopeNamespace),
 	)
 	return service.PersistenceRateLimitingParams{
 		PersistenceMaxQps: func() int {
-			return int(calculator.GetQuota())
+			return int(hostCalculator.GetQuota())
 		},
 		PersistenceNamespaceMaxQps: func(namespace string) int {
 			return int(namespaceCalculator.GetQuota(namespace))

--- a/service/history/queue_factory_base.go
+++ b/service/history/queue_factory_base.go
@@ -27,7 +27,9 @@ package history
 import (
 	"context"
 
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/quotas/calculator"
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/common/clock"
@@ -161,20 +163,28 @@ func QueueSchedulerRateLimiterProvider(
 	serviceResolver membership.ServiceResolver,
 	config *configs.Config,
 	timeSource clock.TimeSource,
+	logger log.Logger,
 ) (queues.SchedulerRateLimiter, error) {
 	return queues.NewPrioritySchedulerRateLimiter(
-		shard.NewOwnershipAwareNamespaceQuotaCalculator(
-			ownershipBasedQuotaScaler,
-			serviceResolver,
-			config.TaskSchedulerNamespaceMaxQPS,
-			config.TaskSchedulerGlobalNamespaceMaxQPS,
+		calculator.NewLoggedNamespaceCalculator(
+			shard.NewOwnershipAwareNamespaceQuotaCalculator(
+				ownershipBasedQuotaScaler,
+				serviceResolver,
+				config.TaskSchedulerNamespaceMaxQPS,
+				config.TaskSchedulerGlobalNamespaceMaxQPS,
+			),
+			log.With(logger, tag.ComponentTaskScheduler, tag.ScopeNamespace),
 		).GetQuota,
-		shard.NewOwnershipAwareQuotaCalculator(
-			ownershipBasedQuotaScaler,
-			serviceResolver,
-			config.TaskSchedulerMaxQPS,
-			config.TaskSchedulerGlobalMaxQPS,
+		calculator.NewLoggedCalculator(
+			shard.NewOwnershipAwareQuotaCalculator(
+				ownershipBasedQuotaScaler,
+				serviceResolver,
+				config.TaskSchedulerMaxQPS,
+				config.TaskSchedulerGlobalMaxQPS,
+			),
+			log.With(logger, tag.ComponentTaskScheduler, tag.ScopeHost),
 		).GetQuota,
+		// TODO: reuse persistence rate limit calculator in PersistenceRateLimitingParamsProvider
 		shard.NewOwnershipAwareNamespaceQuotaCalculator(
 			ownershipBasedQuotaScaler,
 			serviceResolver,
@@ -223,25 +233,13 @@ func (f *QueueFactoryBase) Stop() {
 	}
 }
 
-func NewQueueHostRateLimiter(
-	hostRPS dynamicconfig.IntPropertyFn,
-	persistenceMaxRPS dynamicconfig.IntPropertyFn,
-	persistenceMaxRPSRatio float64,
-) quotas.RateLimiter {
-	return quotas.NewDefaultOutgoingRateLimiter(
-		NewHostRateLimiterRateFn(
-			hostRPS,
-			persistenceMaxRPS,
-			persistenceMaxRPSRatio,
-		),
-	)
-}
-
 func NewHostRateLimiterRateFn(
 	hostRPS dynamicconfig.IntPropertyFn,
 	persistenceMaxRPS dynamicconfig.IntPropertyFn,
 	persistenceMaxRPSRatio float64,
 ) quotas.RateFn {
+	// TODO: reuse persistence rate limit calculator in PersistenceRateLimitingParamsProvider
+
 	return func() float64 {
 		if maxPollHostRps := hostRPS(); maxPollHostRps > 0 {
 			return float64(maxPollHostRps)

--- a/service/history/queue_factory_base.go
+++ b/service/history/queue_factory_base.go
@@ -163,7 +163,7 @@ func QueueSchedulerRateLimiterProvider(
 	serviceResolver membership.ServiceResolver,
 	config *configs.Config,
 	timeSource clock.TimeSource,
-	logger log.Logger,
+	logger log.SnTaggedLogger,
 ) (queues.SchedulerRateLimiter, error) {
 	return queues.NewPrioritySchedulerRateLimiter(
 		calculator.NewLoggedNamespaceCalculator(

--- a/service/history/queue_factory_base_test.go
+++ b/service/history/queue_factory_base_test.go
@@ -146,6 +146,7 @@ func getModuleDependencies(controller *gomock.Controller, c *moduleTestCase) fx.
 		cfg,
 		fx.Annotate(registry, fx.As(new(tasks.TaskCategoryRegistry))),
 		fx.Annotate(metrics.NoopMetricsHandler, fx.As(new(metrics.Handler))),
+		fx.Annotate(log.NewTestLogger(), fx.As(new(log.SnTaggedLogger))),
 		fx.Annotate(clusterMetadata, fx.As(new(cluster.Metadata))),
 		lazyLoadedOwnershipBasedQuotaScaler,
 	)
@@ -159,7 +160,6 @@ type unusedDependencies struct {
 	clock.TimeSource
 	membership.ServiceResolver
 	namespace.Registry
-	log.SnTaggedLogger
 	client.Bean
 	sdk.ClientFactory
 	resource.MatchingRawClient

--- a/service/history/shard/ownership_based_quota_calculator.go
+++ b/service/history/shard/ownership_based_quota_calculator.go
@@ -25,18 +25,18 @@
 package shard
 
 import (
-	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/quotas/calculator"
 )
 
 type (
 	OwnershipAwareQuotaCalculator struct {
-		quotas.ClusterAwareQuotaCalculator
+		calculator.ClusterAwareQuotaCalculator
 
 		scaler OwnershipBasedQuotaScaler
 	}
 
 	OwnershipAwareNamespaceQuotaCalculator struct {
-		quotas.ClusterAwareNamespaceSpecificQuotaCalculator
+		calculator.ClusterAwareNamespaceQuotaCalculator
 
 		scaler OwnershipBasedQuotaScaler
 	}
@@ -44,12 +44,12 @@ type (
 
 func NewOwnershipAwareQuotaCalculator(
 	scaler OwnershipBasedQuotaScaler,
-	memberCounter quotas.MemberCounter,
+	memberCounter calculator.MemberCounter,
 	perInstanceQuota func() int,
 	globalQuota func() int,
 ) *OwnershipAwareQuotaCalculator {
 	return &OwnershipAwareQuotaCalculator{
-		ClusterAwareQuotaCalculator: quotas.ClusterAwareQuotaCalculator{
+		ClusterAwareQuotaCalculator: calculator.ClusterAwareQuotaCalculator{
 			MemberCounter:    memberCounter,
 			PerInstanceQuota: perInstanceQuota,
 			GlobalQuota:      globalQuota,
@@ -67,12 +67,12 @@ func (c *OwnershipAwareQuotaCalculator) GetQuota() float64 {
 
 func NewOwnershipAwareNamespaceQuotaCalculator(
 	scaler OwnershipBasedQuotaScaler,
-	memberCounter quotas.MemberCounter,
+	memberCounter calculator.MemberCounter,
 	perInstanceQuota func(namespace string) int,
 	globalQuota func(namespace string) int,
 ) *OwnershipAwareNamespaceQuotaCalculator {
 	return &OwnershipAwareNamespaceQuotaCalculator{
-		ClusterAwareNamespaceSpecificQuotaCalculator: quotas.ClusterAwareNamespaceSpecificQuotaCalculator{
+		ClusterAwareNamespaceQuotaCalculator: calculator.ClusterAwareNamespaceQuotaCalculator{
 			MemberCounter:    memberCounter,
 			PerInstanceQuota: perInstanceQuota,
 			GlobalQuota:      globalQuota,
@@ -85,7 +85,7 @@ func (c *OwnershipAwareNamespaceQuotaCalculator) GetQuota(namespace string) floa
 	if quota, ok := getOwnershipScaledQuota(c.scaler, c.GlobalQuota(namespace)); ok {
 		return quota
 	}
-	return c.ClusterAwareNamespaceSpecificQuotaCalculator.GetQuota(namespace)
+	return c.ClusterAwareNamespaceQuotaCalculator.GetQuota(namespace)
 }
 
 func getOwnershipScaledQuota(

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -111,7 +111,7 @@ func RateLimitInterceptorProvider(
 func PersistenceRateLimitingParamsProvider(
 	serviceConfig *Config,
 	persistenceLazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
-	logger log.Logger,
+	logger log.SnTaggedLogger,
 ) service.PersistenceRateLimitingParams {
 	return service.NewPersistenceRateLimitingParams(
 		serviceConfig.PersistenceMaxQPS,

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -111,6 +111,7 @@ func RateLimitInterceptorProvider(
 func PersistenceRateLimitingParamsProvider(
 	serviceConfig *Config,
 	persistenceLazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
+	logger log.Logger,
 ) service.PersistenceRateLimitingParams {
 	return service.NewPersistenceRateLimitingParams(
 		serviceConfig.PersistenceMaxQPS,
@@ -122,6 +123,7 @@ func PersistenceRateLimitingParamsProvider(
 		serviceConfig.OperatorRPSRatio,
 		serviceConfig.PersistenceDynamicRateLimitingParams,
 		persistenceLazyLoadedServiceResolver,
+		logger,
 	)
 }
 

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -117,6 +117,7 @@ func ThrottledLoggerRpsFnProvider(serviceConfig *Config) resource.ThrottledLogge
 func PersistenceRateLimitingParamsProvider(
 	serviceConfig *Config,
 	persistenceLazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
+	logger log.Logger,
 ) service.PersistenceRateLimitingParams {
 	return service.NewPersistenceRateLimitingParams(
 		serviceConfig.PersistenceMaxQPS,
@@ -128,6 +129,7 @@ func PersistenceRateLimitingParamsProvider(
 		serviceConfig.OperatorRPSRatio,
 		serviceConfig.PersistenceDynamicRateLimitingParams,
 		persistenceLazyLoadedServiceResolver,
+		logger,
 	)
 }
 

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -117,7 +117,7 @@ func ThrottledLoggerRpsFnProvider(serviceConfig *Config) resource.ThrottledLogge
 func PersistenceRateLimitingParamsProvider(
 	serviceConfig *Config,
 	persistenceLazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
-	logger log.Logger,
+	logger log.SnTaggedLogger,
 ) service.PersistenceRateLimitingParams {
 	return service.NewPersistenceRateLimitingParams(
 		serviceConfig.PersistenceMaxQPS,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Log computed per pod rate limiting value. Logs are only emitted when the values changes.

## Why?
<!-- Tell your future self why have you made these changes -->
- Improve observability into the rate limiting value that's actually in use. 
- We previously set per pod value directly, but with global rate limit configs, the per pod value is calculated based on things like pod count, shard ownership etc. which means we don't know that the actual value that's applied. This PR logs those computed value to make validation and investigation a bit easier.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Add unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- N/A. GetQuota() may be slower due to the additional value comparison, but that function is only evaluated once per minute

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
- N/A

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- N/A
