### PR TITLE
Ensure our logs for potential data loss can be easily found

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -934,3 +934,7 @@ func Endpoint(endpoint string) ZapTag {
 func BuildId(buildId string) ZapTag {
 	return NewStringTag("build-id", buildId)
 }
+
+func Cause(cause string) ZapTag {
+	return NewStringTag("cause", cause)
+}


### PR DESCRIPTION
## What changed?
Possible data loss is now logged similarly in both the frontend and history pod

## Why?
When investigating data loss alerts the frontend and history pod logged entirely different messages, making it difficult for the on-call engineer to find the information necessary to know whether the issue is transient or not.

In both recent cases they were transient read failures, but it took time to discover that because you needed to know about the persistence logs to diagnose it.

Now both will use the same terminology and casing, so a simple search for either "data loss" or the actual message will find both logs.

## How did you test it?
N/A

## Potential risks
None

## Documentation
None

## Is hotfix candidate?
No
