### PR TITLE
Replace bogus test branch tokens with properly initialized ones

### DIFF
--- a/common/persistence/tests/cassandra_test.go
+++ b/common/persistence/tests/cassandra_test.go
@@ -180,6 +180,7 @@ func TestCassandraExecutionMutableStateStoreSuite(t *testing.T) {
 		shardStore,
 		executionStore,
 		serialization.NewSerializer(),
+		&persistence.HistoryBranchUtilImpl{},
 		testData.Logger,
 	)
 	suite.Run(t, s)

--- a/common/persistence/tests/mysql_test.go
+++ b/common/persistence/tests/mysql_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"go.temporal.io/server/common/persistence"
 	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/sql"
@@ -75,6 +76,7 @@ func TestMySQLExecutionMutableStateStoreSuite(t *testing.T) {
 		shardStore,
 		executionStore,
 		serialization.NewSerializer(),
+		&persistence.HistoryBranchUtilImpl{},
 		testData.Logger,
 	)
 	suite.Run(t, s)

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"go.temporal.io/server/common/persistence"
 	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/sql"
@@ -79,6 +80,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLExecutionMutableStateStoreSuite() {
 		shardStore,
 		executionStore,
 		serialization.NewSerializer(),
+		&persistence.HistoryBranchUtilImpl{},
 		testData.Logger,
 	)
 	suite.Run(p.T(), s)

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -134,6 +134,7 @@ func TestSQLiteExecutionMutableStateStoreSuite(t *testing.T) {
 		shardStore,
 		executionStore,
 		serialization.NewSerializer(),
+		&persistence.HistoryBranchUtilImpl{},
 		logger,
 	)
 	suite.Run(t, s)
@@ -263,6 +264,7 @@ func TestSQLiteFileExecutionMutableStateStoreSuite(t *testing.T) {
 		shardStore,
 		executionStore,
 		serialization.NewSerializer(),
+		&persistence.HistoryBranchUtilImpl{},
 		logger,
 	)
 	suite.Run(t, s)


### PR DESCRIPTION
## Why?
Tests have been using bogus branch token bytes as oppose to properly initialized ones.