### PR TITLE
Nexus service registry followups

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -377,8 +377,6 @@ const (
 	FrontendEnableSchedules = "frontend.enableSchedules"
 	// FrontendEnableNexusAPIs enables serving Nexus HTTP requests in the frontend.
 	FrontendEnableNexusAPIs = "frontend.enableNexusAPIs"
-	// FrontendInitializeNexusIncomingServicesTimeout is the maximum time allowed for initializing Nexus incoming services.
-	FrontendInitializeNexusIncomingServicesTimeout = "frontend.initializeNexusIncomingServicesTimeout"
 	// FrontendRefreshNexusIncomingServicesLongPollTimeout is the maximum duration of background long poll requests to update Nexus incoming services.
 	FrontendRefreshNexusIncomingServicesLongPollTimeout = "frontend.refreshNexusIncomingServicesLongPollTimeout"
 	// FrontendRefreshNexusIncomingServicesMinWait is the minimum wait time between background long poll requests to update Nexus incoming services.

--- a/common/nexus/incoming_service_registry.go
+++ b/common/nexus/incoming_service_registry.go
@@ -43,8 +43,6 @@ import (
 	"go.temporal.io/server/internal/goro"
 )
 
-var errNexusAPIsDisabled = serviceerror.NewNotFound("error Nexus APIs are disabled.")
-
 type (
 	IncomingServiceRegistryConfig struct {
 		nexusAPIsEnabled       dynamicconfig.BoolPropertyFn
@@ -121,10 +119,6 @@ func (r *IncomingServiceRegistry) StopLifecycle() {
 }
 
 func (r *IncomingServiceRegistry) Get(ctx context.Context, id string) (*nexus.IncomingService, error) {
-	if !r.config.nexusAPIsEnabled() {
-		return nil, errNexusAPIsDisabled
-	}
-
 	if err := r.waitUntilInitialized(ctx); err != nil {
 		return nil, err
 	}
@@ -176,8 +170,8 @@ func (r *IncomingServiceRegistry) refreshServicesLoop(ctx context.Context) error
 				close(r.serviceDataReady)
 			}
 		} else {
-			// Services have previously been loaded, so just keep them up to date by with long poll requests
-			// to matching, without fallback to persistence. Ignoring long poll errors since we will just retry
+			// Services have previously been loaded, so just keep them up to date with long poll requests to
+			// matching, without fallback to persistence. Ignoring long poll errors since we will just retry
 			// on next loop iteration.
 			_ = backoff.ThrottleRetryContext(ctx, r.refreshServices, r.config.refreshRetryPolicy, nil)
 		}

--- a/common/nexus/incoming_service_registry_test.go
+++ b/common/nexus/incoming_service_registry_test.go
@@ -56,7 +56,7 @@ func TestGet(t *testing.T) {
 	testService := newIncomingService(t.Name())
 	mocks := newTestMocks(t)
 
-	// lazy load
+	// initial load
 	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), gomock.Any()).Return(&matchingservice.ListNexusIncomingServicesResponse{
 		Services:      []*nexus.IncomingService{testService},
 		TableVersion:  1,
@@ -92,7 +92,7 @@ func TestGetNotFound(t *testing.T) {
 	testService := newIncomingService(t.Name())
 	mocks := newTestMocks(t)
 
-	// lazy load
+	// initial load
 	mocks.matchingClient.EXPECT().ListNexusIncomingServices(gomock.Any(), gomock.Any()).Return(&matchingservice.ListNexusIncomingServicesResponse{
 		Services:      []*nexus.IncomingService{testService},
 		TableVersion:  1,
@@ -124,7 +124,7 @@ func TestGetNotFound(t *testing.T) {
 	assert.NotEmpty(t, reg.services)
 }
 
-func TestLazyLoadFallback(t *testing.T) {
+func TestInitializationFallback(t *testing.T) {
 	t.Parallel()
 
 	testService := newIncomingService(t.Name())
@@ -297,8 +297,10 @@ func TestTableVersionErrorResetsPersistencePagination(t *testing.T) {
 
 func newTestMocks(t *testing.T) *testMocks {
 	ctrl := gomock.NewController(t)
+	testConfig := NewIncomingServiceRegistryConfig(dynamicconfig.NewNoopCollection())
+	testConfig.nexusAPIsEnabled = dynamicconfig.GetBoolPropertyFn(true)
 	return &testMocks{
-		config:         NewIncomingServiceRegistryConfig(dynamicconfig.NewNoopCollection()),
+		config:         testConfig,
 		matchingClient: matchingservicemock.NewMockMatchingServiceClient(ctrl),
 		persistence:    persistence.NewMockNexusIncomingServiceManager(ctrl),
 	}

--- a/common/nexus/outgoing_service_registry.go
+++ b/common/nexus/outgoing_service_registry.go
@@ -23,14 +23,17 @@
 package nexus
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/url"
 	"regexp"
-	"strings"
 
 	"go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/operatorservice/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/collection"
@@ -38,8 +41,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/rpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // OutgoingServiceRegistry manages the registration and retrieval of "outgoing" services from the namespace metadata in
@@ -73,7 +74,7 @@ func NewOutgoingServiceRegistry(
 		config:              config,
 		sortedSetManager: collection.NewSortedSetManager[[]*persistencespb.NexusOutgoingService, *persistencespb.NexusOutgoingService, string](
 			func(service *persistencespb.NexusOutgoingService, name string) int {
-				return strings.Compare(service.Name, name)
+				return bytes.Compare([]byte(service.Name), []byte(name))
 			},
 			func(service *persistencespb.NexusOutgoingService) string {
 				return service.Name


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
* Switched a few instances of `strings.Compare()` to `bytes.Compare()` because the strings utility is intentionally implemented in an inefficient way
* Renamed `matching.incomingNexusServiceManager` to `matching.nexusIncomingServiceClient` for symmetry with the naming of `frontend.nexusIncomingServiceClient` and to avoid confusion with the persistence-layer manager
* Added a test to make sure cassandra does not error when a service is deleted in the middle of paging
* Updated `nexus.incomingServiceRegistry` to respect the `frontend.enableNexusAPIs` dynamic config flag. Service data will only be initialized when this flag is true.

## Why?
<!-- Tell your future self why have you made these changes -->
To improve Nexus service registry functionality and maintainability

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests
