### PR TITLE
Move NewTaskGeneratorProvider back to HistoryServiceProvider

### DIFF
--- a/service/history/workflow/fx.go
+++ b/service/history/workflow/fx.go
@@ -29,7 +29,6 @@ import (
 )
 
 var Module = fx.Options(
-	fx.Provide(NewTaskGeneratorProvider),
 	fx.Populate(&taskGeneratorProvider),
 	fx.Provide(RelocatableAttributesFetcherProvider),
 	fx.Invoke(RegisterStateMachine),

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -74,6 +74,7 @@ import (
 	"go.temporal.io/server/service/history"
 	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/workflow"
 	"go.temporal.io/server/service/matching"
 	"go.temporal.io/server/service/worker"
 )
@@ -498,6 +499,7 @@ func HistoryServiceProvider(
 	}
 
 	app := fx.New(
+		fx.Provide(workflow.NewTaskGeneratorProvider),
 		params.GetCommonServiceOptions(serviceName),
 		history.QueueModule,
 		history.Module,

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -76,6 +76,7 @@ import (
 	"go.temporal.io/server/service/history"
 	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/workflow"
 	"go.temporal.io/server/service/matching"
 	"go.temporal.io/server/service/worker"
 	"go.temporal.io/server/temporal"
@@ -546,6 +547,7 @@ func (c *temporalImpl) startHistory(
 			fx.Provide(resource.DefaultSnTaggedLoggerProvider),
 			fx.Provide(func() *esclient.Config { return c.esConfig }),
 			fx.Provide(func() esclient.Client { return c.esClient }),
+			fx.Provide(workflow.NewTaskGeneratorProvider),
 			fx.Provide(c.GetTLSConfigProvider),
 			fx.Provide(c.GetTaskCategoryRegistry),
 			fx.Supply(c.spanExporters),


### PR DESCRIPTION
## Why?

To allow extending the task generator.