### PR TITLE
Remove uninteresting and noisy warning about task queue kinds

### DIFF
--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2728,16 +2728,16 @@ func (s *workflowHandlerSuite) Test_ValidateTaskQueue() {
 	wh := s.getWorkflowHandler(s.newConfig())
 
 	tq := taskqueuepb.TaskQueue{Name: "\x87\x01"}
-	err := wh.validateTaskQueue(&tq, "default")
+	err := wh.validateTaskQueue(&tq)
 	s.Error(err)
 	s.Contains(err.Error(), "is not a valid UTF-8 string")
 
 	tq = taskqueuepb.TaskQueue{Name: "valid-tq-name"}
-	err = wh.validateTaskQueue(&tq, "default")
+	err = wh.validateTaskQueue(&tq)
 	s.NoError(err)
 
 	tq = taskqueuepb.TaskQueue{Name: "valid-tq-name", NormalName: "\x87\x01", Kind: enumspb.TASK_QUEUE_KIND_STICKY}
-	err = wh.validateTaskQueue(&tq, "default")
+	err = wh.validateTaskQueue(&tq)
 	s.Error(err)
 	s.Contains(err.Error(), "is not a valid UTF-8 string")
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

## Why?
Java SDK (and probably others) don't set the task queue kind when starting workflows. It makes no sense to, so that's eminently reasonable.

In fact, this warning is literally _only_ applicable to polls (maybe also list partitions? if so I can add it there too), but is blindly applied everywhere. 

This should reduce pointless logspam significantly.

## How did you test it?
Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
