### PR TITLE
Logging workflowID and runID in service failure log line

### DIFF
--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
@@ -50,8 +51,21 @@ type (
 
 	TelemetryInterceptor struct {
 		namespaceRegistry namespace.Registry
+		serializer        common.TaskTokenSerializer
 		metricsHandler    metrics.Handler
 		logger            log.Logger
+	}
+	ExecutionGetter interface {
+		GetExecution() *commonpb.WorkflowExecution
+	}
+	WorkflowExecutionGetter interface {
+		GetWorkflowExecution() *commonpb.WorkflowExecution
+	}
+	WorkflowIdGetter interface {
+		GetWorkflowId() string
+	}
+	RunIdGetter interface {
+		GetRunId() string
 	}
 )
 
@@ -99,11 +113,13 @@ var (
 
 func NewTelemetryInterceptor(
 	namespaceRegistry namespace.Registry,
+	serializer common.TaskTokenSerializer,
 	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *TelemetryInterceptor {
 	return &TelemetryInterceptor{
 		namespaceRegistry: namespaceRegistry,
+		serializer:        serializer,
 		metricsHandler:    metricsHandler,
 		logger:            logger,
 	}
@@ -174,7 +190,7 @@ func (ti *TelemetryInterceptor) UnaryIntercept(
 	}
 
 	if err != nil {
-		ti.handleError(metricsHandler, logTags, err)
+		ti.handleError(req, metricsHandler, logTags, err)
 		return nil, err
 	}
 
@@ -196,7 +212,7 @@ func (ti *TelemetryInterceptor) StreamIntercept(
 
 	err := handler(service, serverStream)
 	if err != nil {
-		ti.handleError(metricsHandler, logTags, err)
+		ti.handleError(nil, metricsHandler, logTags, err)
 		return err
 	}
 	return nil
@@ -304,6 +320,7 @@ func (ti *TelemetryInterceptor) streamMetricsHandlerLogTags(
 }
 
 func (ti *TelemetryInterceptor) handleError(
+	req interface{},
 	metricsHandler metrics.Handler,
 	logTags []tag.Tag,
 	err error,
@@ -364,8 +381,45 @@ func (ti *TelemetryInterceptor) handleError(
 			}
 		}
 		metrics.ServiceFailures.With(metricsHandler).Record(1)
+		logTags = append(logTags, ti.getWorkflowTags(req)...)
 		ti.logger.Error("service failures", append(logTags, tag.Error(err))...)
 	}
+}
+
+func (ti *TelemetryInterceptor) getWorkflowTags(
+	req interface{},
+) []tag.Tag {
+	if executionGetter, ok := req.(ExecutionGetter); ok {
+		execution := executionGetter.GetExecution()
+		return []tag.Tag{tag.WorkflowID(execution.WorkflowId), tag.WorkflowRunID(execution.RunId)}
+	}
+	if workflowExecutionGetter, ok := req.(WorkflowExecutionGetter); ok {
+		execution := workflowExecutionGetter.GetWorkflowExecution()
+		return []tag.Tag{tag.WorkflowID(execution.WorkflowId), tag.WorkflowRunID(execution.RunId)}
+	}
+	if taskTokenGetter, ok := req.(TaskTokenGetter); ok {
+		taskTokenBytes := taskTokenGetter.GetTaskToken()
+		if len(taskTokenBytes) == 0 {
+			return []tag.Tag{}
+		}
+		// Special case for avoiding deprecated RespondQueryTaskCompleted API token which does not have workflow id.
+		if _, ok := req.(*workflowservice.RespondQueryTaskCompletedRequest); !ok {
+			taskToken, err := ti.serializer.Deserialize(taskTokenBytes)
+			if err != nil {
+				ti.logger.Error("unable to deserialize task token", tag.Error(err))
+				return []tag.Tag{}
+			}
+			return []tag.Tag{tag.WorkflowID(taskToken.WorkflowId), tag.WorkflowRunID(taskToken.RunId)}
+		}
+	}
+	if workflowIdGetter, ok := req.(WorkflowIdGetter); ok {
+		workflowTags := []tag.Tag{tag.WorkflowID(workflowIdGetter.GetWorkflowId())}
+		if runIdGetter, ok := req.(RunIdGetter); ok {
+			workflowTags = append(workflowTags, tag.WorkflowRunID(runIdGetter.GetRunId()))
+		}
+		return workflowTags
+	}
+	return []tag.Tag{}
 }
 
 func GetMetricsHandlerFromContext(

--- a/common/rpc/interceptor/telemetry_test.go
+++ b/common/rpc/interceptor/telemetry_test.go
@@ -29,7 +29,10 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/common"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -50,7 +53,7 @@ func TestEmitActionMetric(t *testing.T) {
 	controller := gomock.NewController(t)
 	register := namespace.NewMockRegistry(controller)
 	metricsHandler := metrics.NewMockHandler(controller)
-	telemetry := NewTelemetryInterceptor(register, metricsHandler, log.NewNoopLogger())
+	telemetry := NewTelemetryInterceptor(register, common.NewProtoTaskTokenSerializer(), metricsHandler, log.NewNoopLogger())
 
 	testCases := []struct {
 		methodName        string
@@ -100,7 +103,7 @@ func TestHandleError(t *testing.T) {
 	controller := gomock.NewController(t)
 	registry := namespace.NewMockRegistry(controller)
 	metricsHandler := metrics.NewMockHandler(controller)
-	telemetry := NewTelemetryInterceptor(registry, metricsHandler, log.NewNoopLogger())
+	telemetry := NewTelemetryInterceptor(registry, common.NewProtoTaskTokenSerializer(), metricsHandler, log.NewNoopLogger())
 
 	testCases := []struct {
 		name                 string
@@ -137,7 +140,7 @@ func TestHandleError(t *testing.T) {
 				times = 1
 			}
 			metricsHandler.EXPECT().Counter(metrics.ServiceFailures.Name()).Return(metrics.NoopCounterMetricFunc).Times(times)
-			telemetry.handleError(metricsHandler, []tag.Tag{}, tt.err)
+			telemetry.handleError(metricsHandler, nil, []tag.Tag{}, tt.err)
 		})
 	}
 }
@@ -146,7 +149,7 @@ func TestOperationOverwrite(t *testing.T) {
 	controller := gomock.NewController(t)
 	register := namespace.NewMockRegistry(controller)
 	metricsHandler := metrics.NewMockHandler(controller)
-	telemetry := NewTelemetryInterceptor(register, metricsHandler, log.NewNoopLogger())
+	telemetry := NewTelemetryInterceptor(register, common.NewProtoTaskTokenSerializer(), metricsHandler, log.NewNoopLogger())
 
 	testCases := []struct {
 		methodName        string
@@ -174,6 +177,88 @@ func TestOperationOverwrite(t *testing.T) {
 		t.Run(tt.methodName, func(t *testing.T) {
 			operation := telemetry.overrideOperationTag(tt.fullName, tt.methodName)
 			assert.Equal(t, tt.expectedOperation, operation)
+		})
+	}
+}
+
+func TestGetWorkflowTags(t *testing.T) {
+	controller := gomock.NewController(t)
+	registry := namespace.NewMockRegistry(controller)
+	metricsHandler := metrics.NewMockHandler(controller)
+	serializer := common.NewProtoTaskTokenSerializer()
+	telemetry := NewTelemetryInterceptor(registry, serializer, metricsHandler, log.NewTestLogger())
+
+	wid := "test_workflow_id"
+	rid := "test_run_id"
+	taskToken := token.Task{
+		WorkflowId: wid,
+		RunId:      rid,
+	}
+	taskTokenBytes, err := serializer.Serialize(&taskToken)
+	assert.NoError(t, err)
+
+	testCases := []struct {
+		name       string
+		req        interface{}
+		workflowID string
+		runID      string
+	}{
+		{
+			name:       "Request with only workflowID",
+			req:        &workflowservice.StartWorkflowExecutionRequest{WorkflowId: wid},
+			workflowID: wid,
+		},
+		{
+			name:       "Request with workflowID and runID",
+			req:        &workflowservice.RecordActivityTaskHeartbeatByIdRequest{WorkflowId: wid, RunId: rid},
+			workflowID: wid,
+			runID:      rid,
+		},
+		{
+			name: "Request with execution",
+			req: &workflowservice.GetWorkflowExecutionHistoryRequest{
+				Execution: &commonpb.WorkflowExecution{
+					WorkflowId: wid,
+					RunId:      rid,
+				},
+			},
+			workflowID: wid,
+			runID:      rid,
+		},
+		{
+			name: "Request with workflow_execution",
+			req: &workflowservice.RequestCancelWorkflowExecutionRequest{
+				WorkflowExecution: &commonpb.WorkflowExecution{
+					WorkflowId: wid,
+					RunId:      rid,
+				},
+			},
+			workflowID: wid,
+			runID:      rid,
+		},
+		{
+			name: "Request with task_token",
+			req: &workflowservice.RespondActivityTaskCompletedRequest{
+				TaskToken: taskTokenBytes,
+			},
+			workflowID: wid,
+			runID:      rid,
+		},
+		{
+			name: "Nil request",
+			req:  nil,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			tags := telemetry.getWorkflowTags(tt.req)
+			if len(tt.workflowID) > 0 {
+				assert.Contains(t, tags, tag.WorkflowID(tt.workflowID))
+			}
+			if len(tt.runID) > 0 {
+				assert.Contains(t, tags, tag.WorkflowRunID(tt.runID))
+			}
 		})
 	}
 }

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -333,9 +333,11 @@ func TelemetryInterceptorProvider(
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 	namespaceRegistry namespace.Registry,
+	serializer common.TaskTokenSerializer,
 ) *interceptor.TelemetryInterceptor {
 	return interceptor.NewTelemetryInterceptor(
 		namespaceRegistry,
+		serializer,
 		metricsHandler,
 		logger,
 	)

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -193,9 +193,11 @@ func TelemetryInterceptorProvider(
 	logger log.Logger,
 	namespaceRegistry namespace.Registry,
 	metricsHandler metrics.Handler,
+	serializer common.TaskTokenSerializer,
 ) *interceptor.TelemetryInterceptor {
 	return interceptor.NewTelemetryInterceptor(
 		namespaceRegistry,
+		serializer,
 		metricsHandler,
 		logger,
 	)

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -5297,7 +5297,7 @@ func (s *engineSuite) TestEagerWorkflowStart_DoesNotCreateTransferTask() {
 		return &persistenceResponse, nil
 	})
 
-	i := interceptor.NewTelemetryInterceptor(s.mockShard.GetNamespaceRegistry(), s.mockShard.GetMetricsHandler(), s.mockShard.Resource.Logger)
+	i := interceptor.NewTelemetryInterceptor(s.mockShard.GetNamespaceRegistry(), common.NewProtoTaskTokenSerializer(), s.mockShard.GetMetricsHandler(), s.mockShard.Resource.Logger)
 	response, err := i.UnaryIntercept(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "StartWorkflowExecution"}, func(ctx context.Context, req interface{}) (interface{}, error) {
 		response, err := s.mockHistoryEngine.StartWorkflowExecution(ctx, &historyservice.StartWorkflowExecutionRequest{
 			NamespaceId: tests.NamespaceID.String(),
@@ -5331,7 +5331,7 @@ func (s *engineSuite) TestEagerWorkflowStart_FromCron_SkipsEager() {
 		return &persistenceResponse, nil
 	})
 
-	i := interceptor.NewTelemetryInterceptor(s.mockShard.GetNamespaceRegistry(), s.mockShard.GetMetricsHandler(), s.mockShard.Resource.Logger)
+	i := interceptor.NewTelemetryInterceptor(s.mockShard.GetNamespaceRegistry(), common.NewProtoTaskTokenSerializer(), s.mockShard.GetMetricsHandler(), s.mockShard.Resource.Logger)
 	response, err := i.UnaryIntercept(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "StartWorkflowExecution"}, func(ctx context.Context, req interface{}) (interface{}, error) {
 		firstWorkflowTaskBackoff := time.Second
 		response, err := s.mockHistoryEngine.StartWorkflowExecution(ctx, &historyservice.StartWorkflowExecutionRequest{

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -85,9 +85,11 @@ func TelemetryInterceptorProvider(
 	logger log.Logger,
 	namespaceRegistry namespace.Registry,
 	metricsHandler metrics.Handler,
+	serializer common.TaskTokenSerializer,
 ) *interceptor.TelemetryInterceptor {
 	return interceptor.NewTelemetryInterceptor(
 		namespaceRegistry,
+		serializer,
 		metricsHandler,
 		logger,
 	)


### PR DESCRIPTION
## What changed?
Adding workflow id and run id tags in service failures log line.

## Why?
To help understand which workflow is causing the error.

## How did you test it?
Unit test

## Potential risks


## Documentation

## Is hotfix candidate?
No
