### PR TITLE
Persistence Burst Ratio Config

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -116,6 +116,9 @@ const (
 	// OperatorRPSRatio is the percentage of the rate limit provided to priority rate limiters that should be used for
 	// operator API calls (highest priority). Should be >0.0 and <= 1.0 (defaults to 20% if not specified)
 	OperatorRPSRatio = "system.operatorRPSRatio"
+	// PersistenceQPSBurstRatio is the burst ratio for persistence QPS.
+	// This flag controls the burst ratio for all services.
+	PersistenceQPSBurstRatio = "system.persistenceQPSBurstRatio"
 
 	// Whether the deadlock detector should dump goroutines
 	DeadlockDumpGoroutines = "system.deadlock.DumpGoroutines"

--- a/common/persistence/client/fx.go
+++ b/common/persistence/client/fx.go
@@ -46,6 +46,7 @@ type (
 	PersistencePerShardNamespaceMaxQPS dynamicconfig.IntPropertyFnWithNamespaceFilter
 	EnablePriorityRateLimiting         dynamicconfig.BoolPropertyFn
 	OperatorRPSRatio                   dynamicconfig.FloatPropertyFn
+	PersistenceBurstRatio              dynamicconfig.FloatPropertyFn
 
 	DynamicRateLimitingParams dynamicconfig.MapPropertyFn
 
@@ -62,6 +63,7 @@ type (
 		PersistencePerShardNamespaceMaxQPS PersistencePerShardNamespaceMaxQPS
 		EnablePriorityRateLimiting         EnablePriorityRateLimiting
 		OperatorRPSRatio                   OperatorRPSRatio
+		PersistenceBurstRatio              PersistenceBurstRatio
 		ClusterName                        ClusterName
 		ServiceName                        primitives.ServiceName
 		MetricsHandler                     metrics.Handler
@@ -104,6 +106,7 @@ func FactoryProvider(
 				params.PersistenceMaxQPS,
 				RequestPriorityFn,
 				params.OperatorRPSRatio,
+				params.PersistenceBurstRatio,
 				params.HealthSignals,
 				params.DynamicRateLimitingParams,
 				params.MetricsHandler,
@@ -115,10 +118,11 @@ func FactoryProvider(
 				params.PersistencePerShardNamespaceMaxQPS,
 				RequestPriorityFn,
 				params.OperatorRPSRatio,
+				params.PersistenceBurstRatio,
 			)
 		} else {
-			systemRequestRateLimiter = NewNoopPriorityRateLimiter(params.PersistenceMaxQPS)
-			namespaceRequestRateLimiter = NewNoopPriorityRateLimiter(params.PersistenceMaxQPS)
+			systemRequestRateLimiter = NewNoopPriorityRateLimiter(params.PersistenceMaxQPS, params.PersistenceBurstRatio)
+			namespaceRequestRateLimiter = NewNoopPriorityRateLimiter(params.PersistenceMaxQPS, params.PersistenceBurstRatio)
 		}
 	}
 

--- a/common/persistence/client/health_request_rate_limiter.go
+++ b/common/persistence/client/health_request_rate_limiter.go
@@ -56,8 +56,7 @@ type (
 
 		refreshTimer *time.Ticker
 
-		rateFn           quotas.RateFn
-		rateToBurstRatio float64
+		rateBurst quotas.RateBurst
 
 		curRateMultiplier atomic.Pointer[float64]
 
@@ -91,19 +90,20 @@ func NewHealthRequestRateLimiterImpl(
 	healthSignals persistence.HealthSignalAggregator,
 	rateFn quotas.RateFn,
 	params DynamicRateLimitingParams,
+	burstRatio PersistenceBurstRatio,
 	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *HealthRequestRateLimiterImpl {
+	rateBurst := quotas.NewDefaultRateBurst(rateFn, quotas.BurstRatioFn(burstRatio))
 	limiter := &HealthRequestRateLimiterImpl{
-		enabled:          atomic.Bool{},
-		rateLimiter:      quotas.NewRateLimiter(rateFn(), int(DefaultRateBurstRatio*rateFn())),
-		healthSignals:    healthSignals,
-		rateFn:           rateFn,
-		params:           params,
-		refreshTimer:     time.NewTicker(DefaultRefreshInterval),
-		rateToBurstRatio: DefaultRateBurstRatio,
-		metricsHandler:   metricsHandler,
-		logger:           logger,
+		enabled:        atomic.Bool{},
+		rateLimiter:    quotas.NewRateLimiter(rateBurst.Rate(), rateBurst.Burst()),
+		healthSignals:  healthSignals,
+		rateBurst:      rateBurst,
+		params:         params,
+		refreshTimer:   time.NewTicker(DefaultRefreshInterval),
+		metricsHandler: metricsHandler,
+		logger:         logger,
 	}
 	curRateMultiplier := new(float64)
 	*curRateMultiplier = DefaultInitialRateMultiplier
@@ -178,8 +178,8 @@ func (rl *HealthRequestRateLimiterImpl) refreshRate() {
 	}
 	rl.curRateMultiplier.Store(&curRateMultiplier)
 	// Always set rate to pickup changes to underlying rate limit dynamic config
-	rl.rateLimiter.SetRPS(curRateMultiplier * rl.rateFn())
-	rl.rateLimiter.SetBurst(int(rl.rateToBurstRatio * rl.rateFn()))
+	rl.rateLimiter.SetRPS(curRateMultiplier * rl.rateBurst.Rate())
+	rl.rateLimiter.SetBurst(int(curRateMultiplier * float64(rl.rateBurst.Burst())))
 }
 
 func (rl *HealthRequestRateLimiterImpl) refreshDynamicParams() {

--- a/common/persistence/client/persistence_rate_limited_clients_test.go
+++ b/common/persistence/client/persistence_rate_limited_clients_test.go
@@ -126,12 +126,15 @@ func TestRateLimitedPersistenceClients(t *testing.T) {
 			taskStore.EXPECT().GetTasks(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
 			dataStoreFactory.EXPECT().NewTaskStore().AnyTimes().Return(taskStore, nil)
 
+			burstRatioFn := func() float64 {
+				return 1.0
+			}
 			systemRequestRateLimiter := client.NewNoopPriorityRateLimiter(func() int {
 				return tc.systemRPS
-			})
+			}, burstRatioFn)
 			namespaceRequestRateLimiter := client.NewNoopPriorityRateLimiter(func() int {
 				return tc.namespaceRPS
-			})
+			}, burstRatioFn)
 			factory := client.NewFactory(
 				dataStoreFactory,
 				&config.Persistence{

--- a/common/persistence/client/quotas.go
+++ b/common/persistence/client/quotas.go
@@ -87,6 +87,7 @@ func NewPriorityRateLimiter(
 	hostMaxQPS PersistenceMaxQps,
 	requestPriorityFn quotas.RequestPriorityFn,
 	operatorRPSRatio OperatorRPSRatio,
+	burstRatio PersistenceBurstRatio,
 	healthSignals p.HealthSignalAggregator,
 	dynamicParams DynamicRateLimitingParams,
 	metricsHandler metrics.Handler,
@@ -96,9 +97,23 @@ func NewPriorityRateLimiter(
 
 	return quotas.NewMultiRequestRateLimiter(
 		// host-level dynamic rate limiter
-		newPriorityDynamicRateLimiter(hostRateFn, requestPriorityFn, operatorRPSRatio, healthSignals, dynamicParams, metricsHandler, logger),
+		newPriorityDynamicRateLimiter(
+			hostRateFn,
+			requestPriorityFn,
+			operatorRPSRatio,
+			burstRatio,
+			healthSignals,
+			dynamicParams,
+			metricsHandler,
+			logger,
+		),
 		// basic host-level rate limiter
-		newPriorityRateLimiter(hostRateFn, requestPriorityFn, operatorRPSRatio),
+		newPriorityRateLimiter(
+			hostRateFn,
+			requestPriorityFn,
+			operatorRPSRatio,
+			burstRatio,
+		),
 	)
 }
 
@@ -108,13 +123,26 @@ func NewPriorityNamespaceRateLimiter(
 	perShardNamespaceMaxQPS PersistencePerShardNamespaceMaxQPS,
 	requestPriorityFn quotas.RequestPriorityFn,
 	operatorRPSRatio OperatorRPSRatio,
+	burstRatio PersistenceBurstRatio,
 ) quotas.RequestRateLimiter {
 
 	return quotas.NewMultiRequestRateLimiter(
 		// per shardID+namespaceID rate limiters
-		newPerShardPerNamespacePriorityRateLimiter(perShardNamespaceMaxQPS, hostMaxQPS, requestPriorityFn, operatorRPSRatio),
+		newPerShardPerNamespacePriorityRateLimiter(
+			perShardNamespaceMaxQPS,
+			hostMaxQPS,
+			requestPriorityFn,
+			operatorRPSRatio,
+			burstRatio,
+		),
 		// per namespaceID rate limiters
-		newPriorityNamespaceRateLimiter(namespaceMaxQPS, hostMaxQPS, requestPriorityFn, operatorRPSRatio),
+		newPriorityNamespaceRateLimiter(
+			namespaceMaxQPS,
+			hostMaxQPS,
+			requestPriorityFn,
+			operatorRPSRatio,
+			burstRatio,
+		),
 	)
 }
 
@@ -123,6 +151,7 @@ func newPerShardPerNamespacePriorityRateLimiter(
 	hostMaxQPS PersistenceMaxQps,
 	requestPriorityFn quotas.RequestPriorityFn,
 	operatorRPSRatio OperatorRPSRatio,
+	burstRatio PersistenceBurstRatio,
 ) quotas.RequestRateLimiter {
 	return quotas.NewMapRequestRateLimiter(func(req quotas.Request) quotas.RequestRateLimiter {
 		if hasCaller(req) && hasCallerSegment(req) {
@@ -134,6 +163,7 @@ func newPerShardPerNamespacePriorityRateLimiter(
 			},
 				requestPriorityFn,
 				operatorRPSRatio,
+				burstRatio,
 			)
 		}
 		return quotas.NoopRequestRateLimiter
@@ -154,6 +184,7 @@ func newPriorityNamespaceRateLimiter(
 	hostMaxQPS PersistenceMaxQps,
 	requestPriorityFn quotas.RequestPriorityFn,
 	operatorRPSRatio OperatorRPSRatio,
+	burstRatio PersistenceBurstRatio,
 ) quotas.RequestRateLimiter {
 	return quotas.NewNamespaceRequestRateLimiter(func(req quotas.Request) quotas.RequestRateLimiter {
 		if hasCaller(req) {
@@ -172,6 +203,7 @@ func newPriorityNamespaceRateLimiter(
 				},
 				requestPriorityFn,
 				operatorRPSRatio,
+				burstRatio,
 			)
 		}
 		return quotas.NoopRequestRateLimiter
@@ -182,13 +214,24 @@ func newPriorityRateLimiter(
 	rateFn quotas.RateFn,
 	requestPriorityFn quotas.RequestPriorityFn,
 	operatorRPSRatio OperatorRPSRatio,
+	burstRatio PersistenceBurstRatio,
 ) quotas.RequestRateLimiter {
 	rateLimiters := make(map[int]quotas.RequestRateLimiter)
 	for priority := range RequestPrioritiesOrdered {
 		if priority == CallerTypeDefaultPriority[headers.CallerTypeOperator] {
-			rateLimiters[priority] = quotas.NewRequestRateLimiterAdapter(quotas.NewDefaultOutgoingRateLimiter(operatorRateFn(rateFn, operatorRPSRatio)))
+			rateLimiters[priority] = quotas.NewRequestRateLimiterAdapter(
+				quotas.NewDefaultRateLimiter(
+					operatorRateFn(rateFn, operatorRPSRatio),
+					quotas.BurstRatioFn(burstRatio),
+				),
+			)
 		} else {
-			rateLimiters[priority] = quotas.NewRequestRateLimiterAdapter(quotas.NewDefaultOutgoingRateLimiter(rateFn))
+			rateLimiters[priority] = quotas.NewRequestRateLimiterAdapter(
+				quotas.NewDefaultRateLimiter(
+					rateFn,
+					quotas.BurstRatioFn(burstRatio),
+				),
+			)
 		}
 	}
 
@@ -202,6 +245,7 @@ func newPriorityDynamicRateLimiter(
 	rateFn quotas.RateFn,
 	requestPriorityFn quotas.RequestPriorityFn,
 	operatorRPSRatio OperatorRPSRatio,
+	burstRatio PersistenceBurstRatio,
 	healthSignals p.HealthSignalAggregator,
 	dynamicParams DynamicRateLimitingParams,
 	metricsHandler metrics.Handler,
@@ -211,9 +255,23 @@ func newPriorityDynamicRateLimiter(
 	for priority := range RequestPrioritiesOrdered {
 		// TODO: refactor this so dynamic rate adjustment is global for all priorities
 		if priority == CallerTypeDefaultPriority[headers.CallerTypeOperator] {
-			rateLimiters[priority] = NewHealthRequestRateLimiterImpl(healthSignals, operatorRateFn(rateFn, operatorRPSRatio), dynamicParams, metricsHandler, logger)
+			rateLimiters[priority] = NewHealthRequestRateLimiterImpl(
+				healthSignals,
+				operatorRateFn(rateFn, operatorRPSRatio),
+				dynamicParams,
+				burstRatio,
+				metricsHandler,
+				logger,
+			)
 		} else {
-			rateLimiters[priority] = NewHealthRequestRateLimiterImpl(healthSignals, rateFn, dynamicParams, metricsHandler, logger)
+			rateLimiters[priority] = NewHealthRequestRateLimiterImpl(
+				healthSignals,
+				rateFn,
+				dynamicParams,
+				burstRatio,
+				metricsHandler,
+				logger,
+			)
 		}
 	}
 
@@ -225,15 +283,19 @@ func newPriorityDynamicRateLimiter(
 
 func NewNoopPriorityRateLimiter(
 	maxQPS PersistenceMaxQps,
+	burstRatio PersistenceBurstRatio,
 ) quotas.RequestRateLimiter {
 	priority := RequestPrioritiesOrdered[0]
 
 	return quotas.NewPriorityRateLimiter(
 		func(_ quotas.Request) int { return priority },
 		map[int]quotas.RequestRateLimiter{
-			priority: quotas.NewRequestRateLimiterAdapter(quotas.NewDefaultOutgoingRateLimiter(
-				func() float64 { return float64(maxQPS()) },
-			)),
+			priority: quotas.NewRequestRateLimiterAdapter(
+				quotas.NewDefaultRateLimiter(
+					func() float64 { return float64(maxQPS()) },
+					quotas.BurstRatioFn(burstRatio),
+				),
+			),
 		},
 	)
 }

--- a/common/persistence/client/quotas_test.go
+++ b/common/persistence/client/quotas_test.go
@@ -108,8 +108,15 @@ func (s *quotasSuite) TestPriorityNamespaceRateLimiter_DoesLimit() {
 	namespaceMaxRPS := func(namespace string) int { return 1 }
 	hostMaxRPS := func() int { return 1 }
 	operatorRPSRatioFn := func() float64 { return 0.2 }
+	burstRatio := func() float64 { return 1 }
 
-	limiter := newPriorityNamespaceRateLimiter(namespaceMaxRPS, hostMaxRPS, RequestPriorityFn, operatorRPSRatioFn)
+	limiter := newPriorityNamespaceRateLimiter(
+		namespaceMaxRPS,
+		hostMaxRPS,
+		RequestPriorityFn,
+		operatorRPSRatioFn,
+		burstRatio,
+	)
 
 	request := quotas.NewRequest(
 		"test-api",
@@ -136,8 +143,15 @@ func (s *quotasSuite) TestPerShardNamespaceRateLimiter_DoesLimit() {
 	perShardNamespaceMaxRPS := func(namespace string) int { return 1 }
 	hostMaxRPS := func() int { return 1 }
 	operatorRPSRatioFn := func() float64 { return 0.2 }
+	burstRatio := func() float64 { return 1 }
 
-	limiter := newPerShardPerNamespacePriorityRateLimiter(perShardNamespaceMaxRPS, hostMaxRPS, RequestPriorityFn, operatorRPSRatioFn)
+	limiter := newPerShardPerNamespacePriorityRateLimiter(
+		perShardNamespaceMaxRPS,
+		hostMaxRPS,
+		RequestPriorityFn,
+		operatorRPSRatioFn,
+		burstRatio,
+	)
 
 	request := quotas.NewRequest(
 		"test-api",
@@ -163,7 +177,13 @@ func (s *quotasSuite) TestPerShardNamespaceRateLimiter_DoesLimit() {
 func (s *quotasSuite) TestOperatorPrioritized() {
 	rateFn := func() float64 { return 5 }
 	operatorRPSRatioFn := func() float64 { return 0.2 }
-	limiter := newPriorityRateLimiter(rateFn, RequestPriorityFn, operatorRPSRatioFn)
+	burstRatio := func() float64 { return 1 }
+	limiter := newPriorityRateLimiter(
+		rateFn,
+		RequestPriorityFn,
+		operatorRPSRatioFn,
+		burstRatio,
+	)
 
 	operatorRequest := quotas.NewRequest(
 		"DescribeWorkflowExecution",

--- a/common/quotas/dynamic_rate_limiter_impl.go
+++ b/common/quotas/dynamic_rate_limiter_impl.go
@@ -64,7 +64,8 @@ func NewDynamicRateLimiter(
 }
 
 // NewDefaultIncomingRateLimiter returns a default rate limiter
-// for incoming traffic
+// for incoming traffic, using fixed burst ratio of 2
+// and fixed 1 minute refresh interval
 func NewDefaultIncomingRateLimiter(
 	rateFn RateFn,
 ) *DynamicRateLimiterImpl {
@@ -75,12 +76,25 @@ func NewDefaultIncomingRateLimiter(
 }
 
 // NewDefaultOutgoingRateLimiter returns a default rate limiter
-// for outgoing traffic
+// for outgoing traffic, using fixed burst ratio of 2
+// and fixed 1 minute refresh interval
 func NewDefaultOutgoingRateLimiter(
 	rateFn RateFn,
 ) *DynamicRateLimiterImpl {
 	return NewDynamicRateLimiter(
 		NewDefaultOutgoingRateBurst(rateFn),
+		defaultRefreshInterval,
+	)
+}
+
+// NewDefaultRateLimiter returns a default rate limiter with a dynamic burst ratio
+// and fixed 1 minute refresh interval
+func NewDefaultRateLimiter(
+	rateFn RateFn,
+	burstRatioFn BurstRatioFn,
+) *DynamicRateLimiterImpl {
+	return NewDynamicRateLimiter(
+		NewDefaultRateBurst(rateFn, burstRatioFn),
 		defaultRefreshInterval,
 	)
 }

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -484,6 +484,7 @@ func PersistenceRateLimitingParamsProvider(
 		serviceConfig.PersistencePerShardNamespaceMaxQPS,
 		serviceConfig.EnablePersistencePriorityRateLimiting,
 		serviceConfig.OperatorRPSRatio,
+		serviceConfig.PersistenceQPSBurstRatio,
 		serviceConfig.PersistenceDynamicRateLimitingParams,
 		persistenceLazyLoadedServiceResolver,
 		logger,

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -61,6 +61,7 @@ type Config struct {
 	PersistencePerShardNamespaceMaxQPS    dynamicconfig.IntPropertyFnWithNamespaceFilter
 	EnablePersistencePriorityRateLimiting dynamicconfig.BoolPropertyFn
 	PersistenceDynamicRateLimitingParams  dynamicconfig.MapPropertyFn
+	PersistenceQPSBurstRatio              dynamicconfig.FloatPropertyFn
 
 	VisibilityPersistenceMaxReadQPS       dynamicconfig.IntPropertyFn
 	VisibilityPersistenceMaxWriteQPS      dynamicconfig.IntPropertyFn
@@ -216,6 +217,7 @@ func NewConfig(
 		PersistencePerShardNamespaceMaxQPS:    dynamicconfig.DefaultPerShardNamespaceRPSMax,
 		EnablePersistencePriorityRateLimiting: dc.GetBoolProperty(dynamicconfig.FrontendEnablePersistencePriorityRateLimiting, true),
 		PersistenceDynamicRateLimitingParams:  dc.GetMapProperty(dynamicconfig.FrontendPersistenceDynamicRateLimitingParams, dynamicconfig.DefaultDynamicRateLimitingParams),
+		PersistenceQPSBurstRatio:              dc.GetFloat64Property(dynamicconfig.PersistenceQPSBurstRatio, 1),
 
 		VisibilityPersistenceMaxReadQPS:       visibility.GetVisibilityPersistenceMaxReadQPS(dc),
 		VisibilityPersistenceMaxWriteQPS:      visibility.GetVisibilityPersistenceMaxWriteQPS(dc),

--- a/service/fx.go
+++ b/service/fx.go
@@ -57,6 +57,7 @@ type (
 		PersistencePerShardNamespaceMaxQPS persistenceClient.PersistencePerShardNamespaceMaxQPS
 		EnablePriorityRateLimiting         persistenceClient.EnablePriorityRateLimiting
 		OperatorRPSRatio                   persistenceClient.OperatorRPSRatio
+		PersistenceBurstRatio              persistenceClient.PersistenceBurstRatio
 		DynamicRateLimitingParams          persistenceClient.DynamicRateLimitingParams
 	}
 
@@ -107,6 +108,7 @@ func NewPersistenceRateLimitingParams(
 	perShardNamespaceMaxQps dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	enablePriorityRateLimiting dynamicconfig.BoolPropertyFn,
 	operatorRPSRatio dynamicconfig.FloatPropertyFn,
+	burstRatio dynamicconfig.FloatPropertyFn,
 	dynamicRateLimitingParams dynamicconfig.MapPropertyFn,
 	lazyLoadedServiceResolver PersistenceLazyLoadedServiceResolver,
 	logger log.Logger,
@@ -137,6 +139,7 @@ func NewPersistenceRateLimitingParams(
 		PersistencePerShardNamespaceMaxQPS: persistenceClient.PersistencePerShardNamespaceMaxQPS(perShardNamespaceMaxQps),
 		EnablePriorityRateLimiting:         persistenceClient.EnablePriorityRateLimiting(enablePriorityRateLimiting),
 		OperatorRPSRatio:                   persistenceClient.OperatorRPSRatio(operatorRPSRatio),
+		PersistenceBurstRatio:              persistenceClient.PersistenceBurstRatio(burstRatio),
 		DynamicRateLimitingParams:          persistenceClient.DynamicRateLimitingParams(dynamicRateLimitingParams),
 	}
 }

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	PersistencePerShardNamespaceMaxQPS    dynamicconfig.IntPropertyFnWithNamespaceFilter
 	EnablePersistencePriorityRateLimiting dynamicconfig.BoolPropertyFn
 	PersistenceDynamicRateLimitingParams  dynamicconfig.MapPropertyFn
+	PersistenceQPSBurstRatio              dynamicconfig.FloatPropertyFn
 
 	VisibilityPersistenceMaxReadQPS       dynamicconfig.IntPropertyFn
 	VisibilityPersistenceMaxWriteQPS      dynamicconfig.IntPropertyFn
@@ -363,6 +364,7 @@ func NewConfig(
 		PersistencePerShardNamespaceMaxQPS:    dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryPersistencePerShardNamespaceMaxQPS, 0),
 		EnablePersistencePriorityRateLimiting: dc.GetBoolProperty(dynamicconfig.HistoryEnablePersistencePriorityRateLimiting, true),
 		PersistenceDynamicRateLimitingParams:  dc.GetMapProperty(dynamicconfig.HistoryPersistenceDynamicRateLimitingParams, dynamicconfig.DefaultDynamicRateLimitingParams),
+		PersistenceQPSBurstRatio:              dc.GetFloat64Property(dynamicconfig.PersistenceQPSBurstRatio, 1.0),
 		ShutdownDrainDuration:                 dc.GetDurationProperty(dynamicconfig.HistoryShutdownDrainDuration, 0*time.Second),
 		StartupMembershipJoinDelay:            dc.GetDurationProperty(dynamicconfig.HistoryStartupMembershipJoinDelay, 0*time.Second),
 		MaxAutoResetPoints:                    dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryMaxAutoResetPoints, DefaultHistoryMaxAutoResetPoints),

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -259,6 +259,7 @@ func PersistenceRateLimitingParamsProvider(
 		PersistencePerShardNamespaceMaxQPS: persistenceClient.PersistencePerShardNamespaceMaxQPS(serviceConfig.PersistencePerShardNamespaceMaxQPS),
 		EnablePriorityRateLimiting:         persistenceClient.EnablePriorityRateLimiting(serviceConfig.EnablePersistencePriorityRateLimiting),
 		OperatorRPSRatio:                   persistenceClient.OperatorRPSRatio(serviceConfig.OperatorRPSRatio),
+		PersistenceBurstRatio:              persistenceClient.PersistenceBurstRatio(serviceConfig.PersistenceQPSBurstRatio),
 		DynamicRateLimitingParams:          persistenceClient.DynamicRateLimitingParams(serviceConfig.PersistenceDynamicRateLimitingParams),
 	}
 }

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -45,6 +45,7 @@ type (
 		PersistencePerShardNamespaceMaxQPS    dynamicconfig.IntPropertyFnWithNamespaceFilter
 		EnablePersistencePriorityRateLimiting dynamicconfig.BoolPropertyFn
 		PersistenceDynamicRateLimitingParams  dynamicconfig.MapPropertyFn
+		PersistenceQPSBurstRatio              dynamicconfig.FloatPropertyFn
 		SyncMatchWaitDuration                 dynamicconfig.DurationPropertyFnWithTaskQueueInfoFilters
 		TestDisableSyncMatch                  dynamicconfig.BoolPropertyFn
 		RPS                                   dynamicconfig.IntPropertyFn
@@ -175,6 +176,7 @@ func NewConfig(
 		PersistencePerShardNamespaceMaxQPS:    dynamicconfig.DefaultPerShardNamespaceRPSMax,
 		EnablePersistencePriorityRateLimiting: dc.GetBoolProperty(dynamicconfig.MatchingEnablePersistencePriorityRateLimiting, true),
 		PersistenceDynamicRateLimitingParams:  dc.GetMapProperty(dynamicconfig.MatchingPersistenceDynamicRateLimitingParams, dynamicconfig.DefaultDynamicRateLimitingParams),
+		PersistenceQPSBurstRatio:              dc.GetFloat64Property(dynamicconfig.PersistenceQPSBurstRatio, 1),
 		SyncMatchWaitDuration:                 dc.GetDurationPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingSyncMatchWaitDuration, 200*time.Millisecond),
 		TestDisableSyncMatch:                  dc.GetBoolProperty(dynamicconfig.TestMatchingDisableSyncMatch, false),
 		LoadUserData:                          dc.GetBoolPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingLoadUserData, true),

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -121,6 +121,7 @@ func PersistenceRateLimitingParamsProvider(
 		serviceConfig.PersistencePerShardNamespaceMaxQPS,
 		serviceConfig.EnablePersistencePriorityRateLimiting,
 		serviceConfig.OperatorRPSRatio,
+		serviceConfig.PersistenceQPSBurstRatio,
 		serviceConfig.PersistenceDynamicRateLimitingParams,
 		persistenceLazyLoadedServiceResolver,
 		logger,

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -127,6 +127,7 @@ func PersistenceRateLimitingParamsProvider(
 		serviceConfig.PersistencePerShardNamespaceMaxQPS,
 		serviceConfig.EnablePersistencePriorityRateLimiting,
 		serviceConfig.OperatorRPSRatio,
+		serviceConfig.PersistenceQPSBurstRatio,
 		serviceConfig.PersistenceDynamicRateLimitingParams,
 		persistenceLazyLoadedServiceResolver,
 		logger,

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -103,6 +103,7 @@ type (
 		PersistencePerShardNamespaceMaxQPS    dynamicconfig.IntPropertyFnWithNamespaceFilter
 		EnablePersistencePriorityRateLimiting dynamicconfig.BoolPropertyFn
 		PersistenceDynamicRateLimitingParams  dynamicconfig.MapPropertyFn
+		PersistenceQPSBurstRatio              dynamicconfig.FloatPropertyFn
 		OperatorRPSRatio                      dynamicconfig.FloatPropertyFn
 		EnableBatcher                         dynamicconfig.BoolPropertyFn
 		BatcherRPS                            dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -330,6 +331,7 @@ func NewConfig(
 			true,
 		),
 		PersistenceDynamicRateLimitingParams: dc.GetMapProperty(dynamicconfig.WorkerPersistenceDynamicRateLimitingParams, dynamicconfig.DefaultDynamicRateLimitingParams),
+		PersistenceQPSBurstRatio:             dc.GetFloat64Property(dynamicconfig.PersistenceQPSBurstRatio, 1),
 		OperatorRPSRatio:                     dc.GetFloat64Property(dynamicconfig.OperatorRPSRatio, common.DefaultOperatorRPSRatio),
 
 		VisibilityPersistenceMaxReadQPS:   visibility.GetVisibilityPersistenceMaxReadQPS(dc),


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
-  Allow configuring persistence rate limiter burst ratio, default is still 1, same as today.

## Why?
<!-- Tell your future self why have you made these changes -->
- It's hard to set rate limit value without burst support. We allow incoming traffic to burst, but call to persistence can't burst, which often lead to persistence rate limited errors. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- N/A, default burst is still 1, no behavior change by default.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
- N/A

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- No
