### PR TITLE
Print test names on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,12 +343,12 @@ prepare-coverage-test: update-gotestsum $(TEST_OUTPUT_ROOT)
 
 unit-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run unit tests with coverage..."
-	@gotestsum --junitfile $(NEW_REPORT) -- \
+	@gotestsum --junitfile $(NEW_REPORT) --format testname -- \
 		$(UNIT_TEST_DIRS) -timeout=$(TEST_TIMEOUT) -race $(TEST_TAG_FLAG) -coverprofile=$(NEW_COVER_PROFILE)
 
 integration-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run integration tests with coverage..."
-	@gotestsum --junitfile $(NEW_REPORT) -- \
+	@gotestsum --junitfile $(NEW_REPORT) --format testname -- \
 		$(INTEGRATION_TEST_DIRS) -timeout=$(TEST_TIMEOUT) $(TEST_TAG_FLAG) $(INTEGRATION_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
 
 # This should use the same build flags as functional-test-coverage for best build caching.
@@ -357,17 +357,17 @@ pre-build-functional-test-coverage: prepare-coverage-test
 
 functional-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional tests with coverage with $(PERSISTENCE_DRIVER) driver..."
-	@gotestsum --junitfile $(NEW_REPORT) -- \
+	@gotestsum --junitfile $(NEW_REPORT) --format testname -- \
 		$(FUNCTIONAL_TEST_ROOT) -timeout=$(TEST_TIMEOUT) $(TEST_ARGS) $(TEST_TAG_FLAG) -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER) $(FUNCTIONAL_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
 
 functional-test-xdc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for cross DC with coverage with $(PERSISTENCE_DRIVER) driver..."
-	@gotestsum --junitfile $(NEW_REPORT) -- \
+	@gotestsum --junitfile $(NEW_REPORT) --format testname -- \
 		$(FUNCTIONAL_TEST_XDC_ROOT) -timeout=$(TEST_TIMEOUT) $(TEST_TAG_FLAG) -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER) $(FUNCTIONAL_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
 
 functional-test-ndc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for NDC with coverage with $(PERSISTENCE_DRIVER) driver..."
-	@gotestsum --junitfile $(NEW_REPORT) -- \
+	@gotestsum --junitfile $(NEW_REPORT) --format testname -- \
 		$(FUNCTIONAL_TEST_NDC_ROOT) -timeout=$(TEST_TIMEOUT) $(TEST_ARGS) $(TEST_TAG_FLAG) -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER) $(FUNCTIONAL_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
 
 .PHONY: $(SUMMARY_COVER_PROFILE)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Change test output default from `pkgname` to `testname` to see which test actually failed, ie more verbose.

Note that this is only for coverage tests which are _typically_ only executed on the CI. If there is a concern that this would flood test output when run locally, this could be switched on if the CI env var is set.

## Why?
<!-- Tell your future self why have you made these changes -->

When a unit test fails, it's not reported which test:

```
> make unit-test-coverage
Install/update gotestsum...
Run unit tests with coverage...
✓  client/matching (1.28s) (coverage: 5.6% of statements)
✓  common (1.497s) (coverage: 27.0% of statements)
✖  common/api (872ms)
```

Now atfer this change:

```
> make unit-test-coverage      
Install/update gotestsum...
Run unit tests with coverage...
PASS client/history.TestCachingRedirectorSuite/TestClientForTargetByShard (0.00s)
PASS common.TestValidateRetryPolicy/nil_policy_is_okay (0.00s)
PASS common.TestValidateRetryPolicy/maxAttempts_is_1,_coefficient_<_1 (0.00s)
PASS common.TestValidateRetryPolicy/initial_interval_negative (0.00s)
PASS common.TestValidateRetryPolicy/coefficient_<_1 (0.00s)
PASS common.TestValidateRetryPolicy/maximum_interval_in_seconds_is_negative (0.00s)
PASS common.TestValidateRetryPolicy/maximum_interval_in_less_than_initial_interval (0.00s)
```
