### PR TITLE
Moved max_read_level inside of db

### DIFF
--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -233,6 +233,8 @@ func (db *taskQueueDB) CreateTasks(
 			Tasks: tasks,
 		})
 
+	// Update the maxReadLevel after the writes are completed, but before we send the response,
+	// so that taskReader is guaranteed to see the new read level when SpoolTask wakes it up
 	atomic.StoreInt64(&db.maxReadLevel, maxReadLevel)
 	return resp, err
 }

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -54,7 +54,7 @@ type (
 		rangeID      int64
 		ackLevel     int64
 		store        persistence.TaskManager
-		maxReadLevel atomic.Int64
+		maxReadLevel atomic.Int64 // note that even though this is an atomic, it should only be written to while holding the db lock
 		logger       log.Logger
 	}
 	taskQueueState struct {

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -233,8 +233,6 @@ func (db *taskQueueDB) CreateTasks(
 			Tasks: tasks,
 		})
 
-	// Update the maxReadLevel after the writes are completed, but before we send the response,
-	// so that taskReader is guaranteed to see the new read level when SpoolTask wakes it up
 	atomic.StoreInt64(&db.maxReadLevel, maxReadLevel)
 	return resp, err
 }

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -29,7 +29,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1755,11 +1754,11 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch() {
 
 	// setReadLevel should NEVER be called without updating ackManager.outstandingTasks
 	// This is only for unit test purpose
-	tlMgr.backlogMgr.taskAckManager.setReadLevel(tlMgr.backlogMgr.taskWriter.GetMaxReadLevel())
+	tlMgr.backlogMgr.taskAckManager.setReadLevel(tlMgr.backlogMgr.db.GetMaxReadLevel())
 	batch, err := tlMgr.backlogMgr.taskReader.getTaskBatch(context.Background())
 	s.Nil(err)
 	s.EqualValues(0, len(batch.tasks))
-	s.EqualValues(tlMgr.backlogMgr.taskWriter.GetMaxReadLevel(), batch.readLevel)
+	s.EqualValues(tlMgr.backlogMgr.db.GetMaxReadLevel(), batch.readLevel)
 	s.True(batch.isReadBatchDone)
 
 	tlMgr.backlogMgr.taskAckManager.setReadLevel(0)
@@ -1824,7 +1823,7 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch_ReadBatchDone() {
 	time.Sleep(100 * time.Millisecond)
 
 	tlMgr.backlogMgr.taskAckManager.setReadLevel(0)
-	atomic.StoreInt64(&tlMgr.backlogMgr.taskWriter.maxReadLevel, maxReadLevel)
+	tlMgr.backlogMgr.db.SetMaxReadLevel(maxReadLevel)
 	batch, err := tlMgr.backlogMgr.taskReader.getTaskBatch(context.Background())
 	s.Empty(batch.tasks)
 	s.Equal(int64(rangeSize*10), batch.readLevel)

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -237,7 +237,7 @@ type getTasksBatchResponse struct {
 func (tr *taskReader) getTaskBatch(ctx context.Context) (*getTasksBatchResponse, error) {
 	var tasks []*persistencespb.AllocatedTaskInfo
 	readLevel := tr.backlogMgr.taskAckManager.getReadLevel()
-	maxReadLevel := tr.backlogMgr.taskWriter.GetMaxReadLevel()
+	maxReadLevel := tr.backlogMgr.db.GetMaxReadLevel()
 
 	// counter i is used to break and let caller check whether taskqueue is still alive and need resume read.
 	for i := 0; i < 10 && readLevel < maxReadLevel; i++ {
@@ -319,7 +319,7 @@ func (tr *taskReader) taggedMetricsHandler() metrics.Handler {
 func (tr *taskReader) emitTaskLagMetric(ackLevel int64) {
 	// note: this metric is only an estimation for the lag.
 	// taskID in DB may not be continuous, especially when task list ownership changes.
-	maxReadLevel := tr.backlogMgr.taskWriter.GetMaxReadLevel()
+	maxReadLevel := tr.backlogMgr.db.GetMaxReadLevel()
 	tr.taggedMetricsHandler().Gauge(metrics.TaskLagPerTaskQueueGauge.Name()).Record(float64(maxReadLevel - ackLevel))
 }
 

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -229,8 +229,6 @@ writerLoop:
 			}
 
 			resp, err := w.appendTasks(ctx, taskIDs, reqs)
-			// Update the maxReadLevel after the writes are completed, but before we send the response,
-			// so that taskReader is guaranteed to see the new read level when SpoolTask wakes it up.
 			w.sendWriteResponse(reqs, resp, err)
 
 		case <-ctx.Done():

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -62,15 +62,14 @@ type (
 
 	// taskWriter writes tasks sequentially to persistence
 	taskWriter struct {
-		status       int32
-		backlogMgr   *backlogManagerImpl
-		config       *taskQueueConfig
-		appendCh     chan *writeTaskRequest
-		taskIDBlock  taskIDBlock
-		maxReadLevel int64
-		logger       log.Logger
-		writeLoop    *goro.Handle
-		idAlloc      idBlockAllocator
+		status      int32
+		backlogMgr  *backlogManagerImpl
+		config      *taskQueueConfig
+		appendCh    chan *writeTaskRequest
+		taskIDBlock taskIDBlock
+		logger      log.Logger
+		writeLoop   *goro.Handle
+		idAlloc     idBlockAllocator
 	}
 )
 
@@ -86,14 +85,13 @@ func newTaskWriter(
 	backlogMgr *backlogManagerImpl,
 ) *taskWriter {
 	return &taskWriter{
-		status:       common.DaemonStatusInitialized,
-		backlogMgr:   backlogMgr,
-		config:       backlogMgr.config,
-		appendCh:     make(chan *writeTaskRequest, backlogMgr.config.OutstandingTaskAppendsThreshold()),
-		taskIDBlock:  noTaskIDs,
-		maxReadLevel: noTaskIDs.start - 1,
-		logger:       backlogMgr.logger,
-		idAlloc:      backlogMgr.db,
+		status:      common.DaemonStatusInitialized,
+		backlogMgr:  backlogMgr,
+		config:      backlogMgr.config,
+		appendCh:    make(chan *writeTaskRequest, backlogMgr.config.OutstandingTaskAppendsThreshold()),
+		taskIDBlock: noTaskIDs,
+		logger:      backlogMgr.logger,
+		idAlloc:     backlogMgr.db,
 	}
 }
 
@@ -133,7 +131,7 @@ func (w *taskWriter) initReadWriteState(ctx context.Context) error {
 		return err
 	}
 	w.taskIDBlock = rangeIDToTaskIDBlock(state.rangeID, w.config.RangeSize)
-	atomic.StoreInt64(&w.maxReadLevel, w.taskIDBlock.start-1)
+	w.backlogMgr.db.SetMaxReadLevel(w.taskIDBlock.start - 1)
 	w.backlogMgr.taskAckManager.setAckLevel(state.ackLevel)
 	return nil
 }
@@ -175,10 +173,6 @@ func (w *taskWriter) appendTask(
 	}
 }
 
-func (w *taskWriter) GetMaxReadLevel() int64 {
-	return atomic.LoadInt64(&w.maxReadLevel)
-}
-
 func (w *taskWriter) allocTaskIDs(ctx context.Context, count int) ([]int64, error) {
 	result := make([]int64, count)
 	for i := 0; i < count; i++ {
@@ -198,10 +192,11 @@ func (w *taskWriter) allocTaskIDs(ctx context.Context, count int) ([]int64, erro
 
 func (w *taskWriter) appendTasks(
 	ctx context.Context,
-	tasks []*persistencespb.AllocatedTaskInfo,
+	taskIDs []int64,
+	reqs []*writeTaskRequest,
 ) (*persistence.CreateTasksResponse, error) {
 
-	resp, err := w.backlogMgr.db.CreateTasks(ctx, tasks)
+	resp, err := w.backlogMgr.db.CreateTasks(ctx, taskIDs, reqs)
 	if err != nil {
 		w.backlogMgr.signalIfFatal(err)
 		w.logger.Error("Persistent store operation failure",
@@ -227,29 +222,15 @@ writerLoop:
 			reqs = w.getWriteBatch(reqs)
 			batchSize := len(reqs)
 
-			maxReadLevel := int64(0)
-
 			taskIDs, err := w.allocTaskIDs(ctx, batchSize)
 			if err != nil {
 				w.sendWriteResponse(reqs, nil, err)
 				continue writerLoop
 			}
 
-			var tasks []*persistencespb.AllocatedTaskInfo
-			for i, req := range reqs {
-				tasks = append(tasks, &persistencespb.AllocatedTaskInfo{
-					TaskId: taskIDs[i],
-					Data:   req.taskInfo,
-				})
-				maxReadLevel = taskIDs[i]
-			}
-
-			resp, err := w.appendTasks(ctx, tasks)
+			resp, err := w.appendTasks(ctx, taskIDs, reqs)
 			// Update the maxReadLevel after the writes are completed, but before we send the response,
 			// so that taskReader is guaranteed to see the new read level when SpoolTask wakes it up.
-			if maxReadLevel > 0 {
-				atomic.StoreInt64(&w.maxReadLevel, maxReadLevel)
-			}
 			w.sendWriteResponse(reqs, resp, err)
 
 		case <-ctx.Done():


### PR DESCRIPTION
## What changed?
This PR moves `max_read_level` inside of db so that `db` becomes the single source of truth for this variable. 

## Why?
While working on #5593, we realized there were concurrency issues, such as deadlock, which were spinning up when `db` tried to read `max_read_level` for resetting the `approximateBacklogCounter`. Thus, moving `max_read_level` inside of db will solve that issue and shall also serve towards the purpose of making `db` the single source of truth for most shared resources in the near future.

## How did you test it?
Current unit tests.

## Potential risks
None

## Is hotfix candidate?
No
