### PR TITLE
Support configuring gocql timeout and writetimeout

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -354,6 +354,10 @@ type (
 		MaxConns int `yaml:"maxConns"`
 		// ConnectTimeout is a timeout for initial dial to cassandra server (default: 600 milliseconds)
 		ConnectTimeout time.Duration `yaml:"connectTimeout"`
+		// Timeout is a timeout for reads and, unless otherwise specified, writes. If not specified, ConnectTimeout is used.
+		Timeout time.Duration `yaml:"timeout"`
+		// WriteTimeout is a timeout for writing a query. If not specified, Timeout is used.
+		WriteTimeout time.Duration `yaml:"writeTimeout"`
 		// TLS configuration
 		TLS *auth.TLS `yaml:"tls"`
 		// Consistency configuration (defaults to LOCAL_QUORUM / LOCAL_SERIAL for all stores if this field not set)

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -152,12 +152,19 @@ func ConfigureCassandraCluster(cfg config.Cassandra, cluster *gocql.ClusterConfi
 		cluster.NumConns = cfg.MaxConns
 	}
 
+	cluster.ConnectTimeout = 10 * time.Second * debug.TimeoutMultiplier
 	if cfg.ConnectTimeout > 0 {
-		cluster.Timeout = cfg.ConnectTimeout
 		cluster.ConnectTimeout = cfg.ConnectTimeout
-	} else {
-		cluster.Timeout = 10 * time.Second * debug.TimeoutMultiplier
-		cluster.ConnectTimeout = 10 * time.Second * debug.TimeoutMultiplier
+	}
+
+	cluster.Timeout = cluster.ConnectTimeout
+	if cfg.Timeout > 0 {
+		cluster.Timeout = cfg.Timeout
+	}
+
+	cluster.WriteTimeout = cluster.Timeout
+	if cfg.WriteTimeout > 0 {
+		cluster.WriteTimeout = cfg.WriteTimeout
 	}
 
 	cluster.ProtoVersion = 4

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -109,7 +109,6 @@ func newCQLClient(cfg *CQLClientConfig, logger log.Logger) (*cqlClient, error) {
 	var err error
 
 	cassandraConfig := cfg.toCassandraConfig()
-	cassandraConfig.ConnectTimeout = time.Duration(cfg.Timeout) * time.Second
 
 	logger.Info("Validating connection to cassandra cluster.")
 	session, err := commongocql.NewSession(
@@ -151,6 +150,7 @@ func (cfg *CQLClientConfig) toCassandraConfig() *config.Cassandra {
 			},
 		},
 		AddressTranslator: cfg.AddressTranslator,
+		ConnectTimeout:    time.Duration(cfg.Timeout) * time.Second,
 	}
 
 	return &cassandraConfig


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Exposes all gocql timeouts independently

## Why?
<!-- Tell your future self why have you made these changes -->

When database hosts cycle or become unavailable, we hypothesize that shorter timeouts will speed up recovery

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Unit test updates

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

Allows for more possible misconfigurations. However, current usage will remain unchanged.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

Added doc comments, but if there's anything else to update, let me know

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->

No