### PR TITLE
Revert change to default reapply type

### DIFF
--- a/common/enums/defaults.go
+++ b/common/enums/defaults.go
@@ -75,7 +75,7 @@ func SetDefaultContinueAsNewInitiator(f *enumspb.ContinueAsNewInitiator) {
 
 func SetDefaultResetReapplyType(f *enumspb.ResetReapplyType) {
 	if *f == enumspb.RESET_REAPPLY_TYPE_UNSPECIFIED {
-		*f = enumspb.RESET_REAPPLY_TYPE_ALL_ELIGIBLE
+		*f = enumspb.RESET_REAPPLY_TYPE_SIGNAL
 	}
 }
 


### PR DESCRIPTION
## What changed?
Revert change to default enum value made in #5360

## Why?
We cannot deploy a change that both introduces a new value and starts using it as the default, since during rollout it may cause a frontend client on the new version to send a value that is unknown to a history node on the old version.

## How did you test it?
I didn't

## Potential risks
No risk

## Is hotfix candidate?
This change should be cherry-picked onto current release candidates.
