### PR TITLE
Enable the exhaustive and godox linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,12 +10,17 @@ linters:
     - staticcheck
     - vet
     - forbidigo
+    - exhaustive
+    - godox
 run:
   skip-dirs:
     - ^api
     - ^proto
     - ^.git
 linters-settings:
+  godox:
+    keywords:
+      - FIXME # marks TODOs that must be fixed before merging
   govet:
     fieldalignment: 0
   forbidigo:


### PR DESCRIPTION
## What changed?
Exhaustive will ensure that switches on enums are exhaustive

Godox is configured to fail when code contains FIXMEs. TODOs are allowed, but FIXMEs must be fixed prior to merge.

## Why?
We have lots of enums and missing a case for a newly added variant (or missing cases in new switches) is a common source of bugs. If we want `default` clauses to satisfy this linter then we can specify `default-signifies-exhaustive: true` in its config.

As for godox: I know that I personally use FIXMEs as a reminder for things to do before merge, and I prefer it when tools yell at me for not doing so before I merge.

## How did you test it?
I ran `make lint` locally and ensured that nothing failed.

## Potential risks
None

## Documentation
No

## Is hotfix candidate?
No
