### PR TITLE
Improve tooling management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .tmp/
+.bin/
+.stamp/
 
 .idea/
 .vscode/settings.json

--- a/Makefile
+++ b/Makefile
@@ -144,11 +144,6 @@ GOLANGCI_LINT := $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
-GOIMPORTS_VER := v0.20.0
-GOIMPORTS := $(LOCALBIN)/goimports-$(GOIMPORTS_VER)
-$(GOIMPORTS): | $(LOCALBIN)
-	$(call go-install-tool,$(GOIMPORTS),golang.org/x/tools/cmd/goimports,$(GOIMPORTS_VER))
-
 GOTESTSUM_VER := v1.11
 GOTESTSUM := $(LOCALBIN)/gotestsum-$(GOTESTSUM_VER)
 $(GOTESTSUM): | $(LOCALBIN)
@@ -169,32 +164,39 @@ PROTOGEN := $(LOCALBIN)/protogen-$(GO_API_VER)
 $(PROTOGEN): | $(LOCALBIN)
 	$(call go-install-tool,$(PROTOGEN),go.temporal.io/api/cmd/protogen,$(GO_API_VER))
 
+
+# The following tools need to have a consistent name, so we use a versioned stamp file to ensure the version we want is installed
+# while installing to an unversioned binary name.
+GOIMPORTS_VER := v0.20.0
+GOIMPORTS := $(LOCALBIN)/goimports
+$(STAMPDIR)/goimports-$(GOIMPORTS_VER): | $(STAMPDIR) $(LOCALBIN)
+	$(call go-install-tool,$(GOIMPORTS),golang.org/x/tools/cmd/goimports,$(GOIMPORTS_VER))
+	@touch $@
+$(GOIMPORTS): $(STAMPDIR)/goimports-$(GOIMPORTS_VER)
+
 # Mockgen is called by name throughout the codebase, so we need to keep the binary name consistent
 MOCKGEN_VER := v1.7.0-rc.1
 MOCKGEN := $(LOCALBIN)/mockgen
-$(STAMPDIR)/mockgen-$(MOCKGEN_VER): | $(STAMPDIR)
+$(STAMPDIR)/mockgen-$(MOCKGEN_VER): | $(STAMPDIR) $(LOCALBIN)
 	$(call go-install-tool,$(MOCKGEN),github.com/golang/mock/mockgen,$(MOCKGEN_VER))
 	@touch $@
 $(MOCKGEN): $(STAMPDIR)/mockgen-$(MOCKGEN_VER)
-
-# protoc needs these to have a consistent name, so we use a versioned stamp file to ensure the true actual version is installed
-# while installing an unversioned binary
 PROTOC_GEN_GO_VER := v1.33.0
 PROTOC_GEN_GO := $(LOCALBIN)/protoc-gen-go
-$(STAMPDIR)/protoc-gen-go-$(PROTOC_GEN_GO_VER): | $(STAMPDIR)
+$(STAMPDIR)/protoc-gen-go-$(PROTOC_GEN_GO_VER): | $(STAMPDIR) $(LOCALBIN)
 	$(call go-install-tool,$(PROTOC_GEN_GO),google.golang.org/protobuf/cmd/protoc-gen-go,$(PROTOC_GEN_GO_VER))
 	@touch $@
 $(PROTOC_GEN_GO): $(STAMPDIR)/protoc-gen-go-$(PROTOC_GEN_GO_VER)
 
 PROTOC_GEN_GO_GRPC_VER := v1.3.0
 PROTOC_GEN_GO_GRPC := $(LOCALBIN)/protoc-gen-go-grpc
-$(STAMPDIR)/protoc-gen-go-grpc-$(PROTOC_GEN_GO_GRPC_VER): | $(STAMPDIR)
+$(STAMPDIR)/protoc-gen-go-grpc-$(PROTOC_GEN_GO_GRPC_VER): | $(STAMPDIR) $(LOCALBIN)
 	$(call go-install-tool,$(PROTOC_GEN_GO_GRPC),google.golang.org/grpc/cmd/protoc-gen-go-grpc,$(PROTOC_GEN_GO_GRPC_VER))
 	@touch $@
 $(PROTOC_GEN_GO_GRPC): $(STAMPDIR)/protoc-gen-go-grpc-$(PROTOC_GEN_GO_GRPC_VER)
 
 PROTOC_GEN_GO_HELPERS := $(LOCALBIN)/protoc-gen-go-helpers
-$(STAMPDIR)/protoc-gen-go-helpers-$(GO_API_VER): | $(STAMPDIR)
+$(STAMPDIR)/protoc-gen-go-helpers-$(GO_API_VER): | $(STAMPDIR) $(LOCALBIN)
 	$(call go-install-tool,$(PROTOC_GEN_GO_HELPERS),go.temporal.io/api/cmd/protoc-gen-go-helpers,$(GO_API_VER))
 	@touch $@
 $(PROTOC_GEN_GO_HELPERS): $(STAMPDIR)/protoc-gen-go-helpers-$(GO_API_VER)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean: clean-bins clean-test-results
 	rm -rf $(STAMPDIR)
 	rm -rf $(TEST_OUTPUT_ROOT)
 	rm -rf $(PROTO_OUT)
-	rm -rf ./.bin
+	rm -rf $(LOCALBIN)
 
 # Recompile proto files.
 proto: clean-proto buf-lint api-linter protoc service-clients goimports-proto proto-mocks copyright-proto

--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,8 @@ update-ui:
 	@printf $(COLOR) "Install/update temporal ui-server..."
 	@go install github.com/temporalio/ui-server/cmd/server@latest
 
+$(TEMPDIR) := $(shell mktemp -d)
+
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)
 # $2 - package url which can be installed
@@ -219,7 +221,7 @@ define go-install-tool
 set -e; \
 package=$(2)@$(3) ;\
 printf $(COLOR) "Downloading $${package}" ;\
-GOBIN=$(shell pwd)/$(LOCALBIN) go install $${package} ;\
+GOBIN=$(shell pwd)/$(TEMPDIR) go install $${package} ;\
 mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ TEST_TAG_FLAG := -tags $(ALL_TEST_TAGS)
 ROOT := $(shell git rev-parse --show-toplevel)
 LOCALBIN := .bin
 STAMPDIR := .stamp
-PATH := $(LOCALBIN):$(PATH)
+export PATH := $(ROOT)/$(LOCALBIN):$(PATH)
 GOINSTALL := GOBIN=$(ROOT)/$(LOCALBIN) go install
 
 MODULE_ROOT := $(lastword $(shell grep -e "^module " go.mod))
@@ -149,11 +149,6 @@ GOIMPORTS := $(LOCALBIN)/goimports-$(GOIMPORTS_VER)
 $(GOIMPORTS): | $(LOCALBIN)
 	$(call go-install-tool,$(GOIMPORTS),golang.org/x/tools/cmd/goimports,$(GOIMPORTS_VER))
 
-MOCKGEN_VER := v1.7.0-rc.1
-MOCKGEN := $(LOCALBIN)/mockgen-$(MOCKGEN_VER)
-$(MOCKGEN): | $(LOCALBIN)
-	$(call go-install-tool,$(MOCKGEN),github.com/golang/mock/mockgen,$(MOCKGEN_VER))
-
 GOTESTSUM_VER := v1.11
 GOTESTSUM := $(LOCALBIN)/gotestsum-$(GOTESTSUM_VER)
 $(GOTESTSUM): | $(LOCALBIN)
@@ -173,6 +168,14 @@ GO_API_VER := v1.29.0
 PROTOGEN := $(LOCALBIN)/protogen-$(GO_API_VER)
 $(PROTOGEN): | $(LOCALBIN)
 	$(call go-install-tool,$(PROTOGEN),go.temporal.io/api/cmd/protogen,$(GO_API_VER))
+
+# Mockgen is called by name throughout the codebase, so we need to keep the binary name consistent
+MOCKGEN_VER := v1.7.0-rc.1
+MOCKGEN := $(LOCALBIN)/mockgen
+$(STAMPDIR)/mockgen-$(MOCKGEN_VER): | $(STAMPDIR)
+	$(call go-install-tool,$(MOCKGEN),github.com/golang/mock/mockgen,$(MOCKGEN_VER))
+	@touch $@
+$(MOCKGEN): $(STAMPDIR)/mockgen-$(MOCKGEN_VER)
 
 # protoc needs these to have a consistent name, so we use a versioned stamp file to ensure the true actual version is installed
 # while installing an unversioned binary

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ install-proto-submodule:
 	git submodule update --init $(PROTO_ROOT)/api
 
 protoc: clean-proto $(PROTO_OUT) $(PROTOGEN) $(PROTOC_GEN_GO) $(PROTOC_GEN_GO_GRPC) $(PROTOC_GEN_GO_HELPERS)
-	@protogen \
+	@$(PROTOGEN) \
 		-I=proto/api \
 		-I=proto/dependencies \
 		--root=proto/internal \


### PR DESCRIPTION
## What changed?
All tooling is now installed to and used from a local binary directory. After these changes you'll never need to run `make install` or `make update-BLAH` to keep our tools up to date; Make will do that for you.

## Why?
Keeping tool versions in sync across repos is a nightmare when each repo installs its tooling globally. To fix that we're going to install all our tools into a local bin directory and use those versions for everything.

This is set up using two directories: a local binary directory (.bin) and a stamp directory for state-tracking. The stamp directory is used for protoc plugins that need to be named a certain way; the stampfile is how we know if we've installed the right version.

## How did you test it?
I ran through our common makefile uses locally

## Potential risks
None that I'm aware of

## Documentation
No

## Is hotfix candidate?
No
