### PR TITLE
Add cloud/* branches to trigger-publish

### DIFF
--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - release/*
+      - cloud/*
 
 jobs:
   trigger:


### PR DESCRIPTION
## What changed?
I added cloud/* branches to the list of branches we sync to temporalio/docker-builds.

## Why?
We want these to be auto-built and kept in sync for testing