### PR TITLE
Remove makefile targets for the cli, tctl, and ui

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,6 @@ This doc is for contributors to Temporal Server (hopefully that's you!)
   - Download all other versions from [protoc release page](https://github.com/protocolbuffers/protobuf/releases).
 * [Temporal CLI](https://github.com/temporalio/cli)
   - Homebrew `brew install temporal`
-  - Go install `make update-cli`
   - Or download it from here https://github.com/temporalio/cli
 
 

--- a/Makefile
+++ b/Makefile
@@ -201,18 +201,6 @@ $(STAMPDIR)/protoc-gen-go-helpers-$(GO_API_VER): | $(STAMPDIR) $(LOCALBIN)
 	@touch $@
 $(PROTOC_GEN_GO_HELPERS): $(STAMPDIR)/protoc-gen-go-helpers-$(GO_API_VER)
 
-update-tctl:
-	@printf $(COLOR) "Install/update tctl..."
-	@go install github.com/temporalio/tctl/cmd/tctl@latest
-
-update-cli:
-	@printf $(COLOR) "Install/update cli..."
-	curl -sSf https://temporal.download/cli.sh | sh
-
-update-ui:
-	@printf $(COLOR) "Install/update temporal ui-server..."
-	@go install github.com/temporalio/ui-server/cmd/server@latest
-
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)
 # $2 - package url which can be installed


### PR DESCRIPTION
## What changed?
I removed the makefile targets for installing and updating our CLI, `tctl`, and our UI as they're no longer used for development.

If you need these, we recommend installing them through other means.

## Why?
These are unused and, in the case of update-cli, insecure.