### PR TITLE
WorkflowIdConflictPolicy default on History

### DIFF
--- a/service/history/api/signalwithstartworkflow/api.go
+++ b/service/history/api/signalwithstartworkflow/api.go
@@ -27,7 +27,9 @@ package signalwithstartworkflow
 import (
 	"context"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/enums"
 
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common/definition"
@@ -70,6 +72,11 @@ func Invoke(
 	default:
 		return nil, err
 	}
+
+	// TODO: remove this call in 1.25
+	enums.SetDefaultWorkflowIdConflictPolicy(
+		&signalWithStartRequest.SignalWithStartRequest.WorkflowIdConflictPolicy,
+		enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING)
 
 	api.MigrateWorkflowIdReusePolicyForRunningWorkflow(
 		&signalWithStartRequest.SignalWithStartRequest.WorkflowIdReusePolicy,

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -30,9 +30,11 @@ import (
 
 	"github.com/google/uuid"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/enums"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.temporal.io/server/api/historyservice/v1"
@@ -118,6 +120,11 @@ func NewStarter(
 func (s *Starter) prepare(ctx context.Context) error {
 	request := s.request.StartRequest
 	metricsHandler := s.shardContext.GetMetricsHandler()
+
+	// TODO: remove this call in 1.25
+	enums.SetDefaultWorkflowIdConflictPolicy(
+		&request.WorkflowIdConflictPolicy,
+		enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL)
 
 	api.MigrateWorkflowIdReusePolicyForRunningWorkflow(
 		&request.WorkflowIdReusePolicy,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Set default for `WorkflowIdConflictPolicy` in History as well.

## Why?
<!-- Tell your future self why have you made these changes -->

An issue can happen on downgrade where the Frontend is running a previous version that doesn't set the default but the newer History expects it.

## How did you test it?

Tested locally by commenting out the code in Frontend and History; ensuring it fails and then re-enabling the code in History to verify it fixes it.

## Potential risks

None; if there is a policy already, nothing happens.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
