### PR TITLE
Add and enforce dynamic config chain limit for redirect rules

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -205,6 +205,10 @@ const (
 	// in the versioning data for a task queue. Update requests which would cause the versioning data to exceed this
 	// number will fail with a FailedPrecondition error.
 	RedirectRuleLimitPerQueue = "limit.wv.RedirectRuleLimitPerQueue"
+	// RedirectRuleChainLimitPerQueue is the max number of compatible redirect rules allowed to be connected
+	// in one chain in the versioning data for a task queue. Update requests which would cause the versioning data
+	// to exceed this number will fail with a FailedPrecondition error.
+	RedirectRuleChainLimitPerQueue = "limit.wv.RedirectRuleChainLimitPerQueue"
 	// MatchingDeletedRuleRetentionTime is the length of time that deleted Version Assignment Rules and
 	// Deleted Redirect Rules will be kept in the DB (with DeleteTimestamp). After this time, the tombstones are deleted at the next time update of versioning data for the task queue.
 	MatchingDeletedRuleRetentionTime = "matching.wv.DeletedRuleRetentionTime"

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -69,6 +69,7 @@ type (
 		VersionBuildIdLimitPerQueue              dynamicconfig.IntPropertyFnWithNamespaceFilter
 		AssignmentRuleLimitPerQueue              dynamicconfig.IntPropertyFnWithNamespaceFilter
 		RedirectRuleLimitPerQueue                dynamicconfig.IntPropertyFnWithNamespaceFilter
+		RedirectRuleChainLimitPerQueue           dynamicconfig.IntPropertyFnWithNamespaceFilter
 		DeletedRuleRetentionTime                 dynamicconfig.DurationPropertyFnWithNamespaceFilter
 		ReachabilityBuildIdVisibilityGracePeriod dynamicconfig.DurationPropertyFnWithNamespaceFilter
 		TaskQueueLimitPerBuildId                 dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -197,6 +198,7 @@ func NewConfig(
 		VersionBuildIdLimitPerQueue:              dc.GetIntPropertyFilteredByNamespace(dynamicconfig.VersionBuildIdLimitPerQueue, 100),
 		AssignmentRuleLimitPerQueue:              dc.GetIntPropertyFilteredByNamespace(dynamicconfig.AssignmentRuleLimitPerQueue, 100),
 		RedirectRuleLimitPerQueue:                dc.GetIntPropertyFilteredByNamespace(dynamicconfig.RedirectRuleLimitPerQueue, 500),
+		RedirectRuleChainLimitPerQueue:           dc.GetIntPropertyFilteredByNamespace(dynamicconfig.RedirectRuleChainLimitPerQueue, 50),
 		DeletedRuleRetentionTime:                 dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.MatchingDeletedRuleRetentionTime, 14*24*time.Hour),
 		ReachabilityBuildIdVisibilityGracePeriod: dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.ReachabilityBuildIdVisibilityGracePeriod, 3*time.Minute),
 		TaskQueueLimitPerBuildId:                 dc.GetIntPropertyFilteredByNamespace(dynamicconfig.TaskQueuesPerBuildIdLimit, 20),

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -1044,12 +1044,14 @@ func (e *matchingEngineImpl) UpdateWorkerVersioningRules(
 				data.GetVersioningData(),
 				req.GetAddCompatibleRedirectRule(),
 				e.config.RedirectRuleLimitPerQueue(ns.Name().String()),
+				e.config.RedirectRuleChainLimitPerQueue(ns.Name().String()),
 			)
 		case *workflowservice.UpdateWorkerVersioningRulesRequest_ReplaceCompatibleRedirectRule:
 			versioningData, err = ReplaceCompatibleRedirectRule(
 				updatedClock,
 				data.GetVersioningData(),
 				req.GetReplaceCompatibleRedirectRule(),
+				e.config.RedirectRuleChainLimitPerQueue(ns.Name().String()),
 			)
 		case *workflowservice.UpdateWorkerVersioningRulesRequest_DeleteCompatibleRedirectRule:
 			versioningData, err = DeleteCompatibleRedirectRule(

--- a/service/matching/reachability.go
+++ b/service/matching/reachability.go
@@ -40,6 +40,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/common/worker_versioning"
 )
 
@@ -83,7 +84,7 @@ func (rc *reachabilityCalculator) run(ctx context.Context, buildId string) (enum
 	}
 
 	// Gather list of all build ids that could point to buildId
-	buildIdsOfInterest := rc.getBuildIdsOfInterest(buildId, false)
+	buildIdsOfInterest := rc.getBuildIdsOfInterest(buildId, nil)
 
 	// 2. Cases for REACHABLE
 	// 2a. If buildId is assignable to new tasks
@@ -103,7 +104,7 @@ func (rc *reachabilityCalculator) run(ctx context.Context, buildId string) (enum
 	// Note: The below cases are not applicable to activity-only task queues, since we don't record those in visibility
 
 	// Gather list of all build ids that could point to buildId, now including deleted rules to account for the delay in updating visibility
-	buildIdsOfInterest = rc.getBuildIdsOfInterest(buildId, true)
+	buildIdsOfInterest = rc.getBuildIdsOfInterest(buildId, &rc.buildIdVisibilityGracePeriod)
 
 	// 2c. If buildId is assignable to tasks from open workflows
 	existsOpenWFAssignedToBuildId, err := rc.existsWFAssignedToAny(ctx, rc.makeBuildIdCountRequest(buildIdsOfInterest, true))
@@ -129,56 +130,24 @@ func (rc *reachabilityCalculator) run(ctx context.Context, buildId string) (enum
 
 // getBuildIdsOfInterest returns a list of build ids that point to the given buildId in the graph
 // of redirect rules and adds the given build id to that list.
-// It considers rules if the deletion time is within versioningReachabilityDeletedRuleInclusionPeriod.
+// It considers rules if the deletion time is nil or within the given deletedRuleInclusionPeriod.
 func (rc *reachabilityCalculator) getBuildIdsOfInterest(
 	buildId string,
-	includeRecentlyDeleted bool) []string {
-	return append(rc.getUpstreamHelper(buildId, includeRecentlyDeleted, nil), buildId)
+	deletedRuleInclusionPeriod *time.Duration) []string {
+	includedRules := util.FilterSlice(slices.Clone(rc.redirectRules), func(rr *persistencespb.RedirectRule) bool {
+		return rr.DeleteTimestamp == nil || rc.withinRuleInclusionPeriod(rr.DeleteTimestamp, deletedRuleInclusionPeriod)
+	})
+	return append(getUpstreamBuildIds(buildId, includedRules), buildId)
 }
 
-func (rc *reachabilityCalculator) getUpstreamHelper(
-	buildId string,
-	includeRecentlyDeleted bool,
-	visited []string) []string {
-	var upstream []string
-	visited = append(visited, buildId)
-	directSources := rc.getSourcesForTarget(buildId, includeRecentlyDeleted)
-
-	for _, src := range directSources {
-		if !slices.Contains(visited, src) {
-			upstream = append(upstream, src)
-			upstream = append(upstream, rc.getUpstreamHelper(src, includeRecentlyDeleted, visited)...)
-		}
+func (rc *reachabilityCalculator) withinRuleInclusionPeriod(clk *clock.HybridLogicalClock, maxTimeSinceDeleted *time.Duration) bool {
+	if clk == nil {
+		return true
 	}
-
-	// dedupe
-	upstreamUnique := make(map[string]bool)
-	for _, bid := range upstream {
-		upstreamUnique[bid] = true
+	if maxTimeSinceDeleted == nil {
+		return false
 	}
-	upstream = make([]string, 0)
-	for k := range upstreamUnique {
-		upstream = append(upstream, k)
-	}
-	return upstream
-}
-
-// getSourcesForTarget gets the first-degree sources for any redirect rule targeting buildId
-func (rc *reachabilityCalculator) getSourcesForTarget(buildId string, includeRecentlyDeleted bool) []string {
-	var sources []string
-	for _, rr := range rc.redirectRules {
-		if rr.GetRule().GetTargetBuildId() == buildId &&
-			((!includeRecentlyDeleted && rr.GetDeleteTimestamp() == nil) ||
-				(includeRecentlyDeleted && rc.withinDeletedRuleInclusionPeriod(rr.GetDeleteTimestamp()))) {
-			sources = append(sources, rr.GetRule().GetSourceBuildId())
-		}
-	}
-
-	return sources
-}
-
-func (rc *reachabilityCalculator) withinDeletedRuleInclusionPeriod(clk *clock.HybridLogicalClock) bool {
-	return clk == nil || hlc.Since(clk) <= rc.buildIdVisibilityGracePeriod
+	return hlc.Since(clk) <= *maxTimeSinceDeleted
 }
 
 func (rc *reachabilityCalculator) existsBackloggedActivityOrWFTaskAssignedToAny(ctx context.Context, buildIdsOfInterest []string) (bool, error) {

--- a/service/matching/reachability_test.go
+++ b/service/matching/reachability_test.go
@@ -66,7 +66,7 @@ func TestGetBuildIdsOfInterest_NoCycle(t *testing.T) {
 	}
 
 	expectedUpstreamBuildIds := []string{"2", "5", "3", "4", "1"}
-	upstreamBuildIds := rc.getBuildIdsOfInterest("1", true)
+	upstreamBuildIds := rc.getBuildIdsOfInterest("1", nil)
 
 	for _, bid := range expectedUpstreamBuildIds {
 		assert.Contains(t, upstreamBuildIds, bid)
@@ -95,7 +95,7 @@ func TestGetBuildIdsOfInterest_WithCycle(t *testing.T) {
 		},
 	}
 	expectedUpstreamBuildIds := []string{"5", "3", "2", "1"}
-	upstreamBuildIds := rc.getBuildIdsOfInterest("1", true)
+	upstreamBuildIds := rc.getBuildIdsOfInterest("1", nil)
 	for _, bid := range expectedUpstreamBuildIds {
 		assert.Contains(t, upstreamBuildIds, bid)
 	}
@@ -119,7 +119,7 @@ func TestGetBuildIdsOfInterest_WithCycle(t *testing.T) {
 		},
 	}
 	expectedUpstreamBuildIds = []string{"5", "3", "2", "4", "1"}
-	upstreamBuildIds = rc.getBuildIdsOfInterest("1", true)
+	upstreamBuildIds = rc.getBuildIdsOfInterest("1", nil)
 	for _, bid := range expectedUpstreamBuildIds {
 		assert.Contains(t, upstreamBuildIds, bid)
 	}

--- a/service/matching/reachability_test.go
+++ b/service/matching/reachability_test.go
@@ -75,28 +75,28 @@ func TestGetBuildIdsOfInterest(t *testing.T) {
 	}
 
 	// getBuildIdsOfInterest(1, deletedRuleInclusionPeriod=nil)
-	buildIdsOfInterest := rc.getBuildIdsOfInterest("1", nil)
+	buildIdsOfInterest := rc.getBuildIdsOfInterest("1", time.Duration(0))
 	expectedBuildIdsOfInterest := []string{"2", "5", "3", "1"}
 	slices.Sort(expectedBuildIdsOfInterest)
 	slices.Sort(buildIdsOfInterest)
 	assert.Equal(t, expectedBuildIdsOfInterest, buildIdsOfInterest)
 
 	// getBuildIdsOfInterest(1, deletedRuleInclusionPeriod=rc.buildIdVisibilityGracePeriod)
-	buildIdsOfInterest = rc.getBuildIdsOfInterest("1", &rc.buildIdVisibilityGracePeriod)
+	buildIdsOfInterest = rc.getBuildIdsOfInterest("1", rc.buildIdVisibilityGracePeriod)
 	expectedBuildIdsOfInterest = []string{"2", "5", "3", "4", "1"}
 	slices.Sort(expectedBuildIdsOfInterest)
 	slices.Sort(buildIdsOfInterest)
 	assert.Equal(t, expectedBuildIdsOfInterest, buildIdsOfInterest)
 
 	// getBuildIdsOfInterest(6, deletedRuleInclusionPeriod=nil)
-	buildIdsOfInterest = rc.getBuildIdsOfInterest("6", nil)
+	buildIdsOfInterest = rc.getBuildIdsOfInterest("6", time.Duration(0))
 	expectedBuildIdsOfInterest = []string{"6"}
 	slices.Sort(expectedBuildIdsOfInterest)
 	slices.Sort(buildIdsOfInterest)
 	assert.Equal(t, expectedBuildIdsOfInterest, buildIdsOfInterest)
 
 	// getBuildIdsOfInterest(6, deletedRuleInclusionPeriod=rc.buildIdVisibilityGracePeriod)
-	buildIdsOfInterest = rc.getBuildIdsOfInterest("6", &rc.buildIdVisibilityGracePeriod)
+	buildIdsOfInterest = rc.getBuildIdsOfInterest("6", rc.buildIdVisibilityGracePeriod)
 	expectedBuildIdsOfInterest = []string{"7", "6"}
 	slices.Sort(expectedBuildIdsOfInterest)
 	slices.Sort(buildIdsOfInterest)

--- a/service/matching/reachability_test.go
+++ b/service/matching/reachability_test.go
@@ -26,6 +26,7 @@ package matching
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -41,8 +42,17 @@ import (
 
 const testBuildIdVisibilityGracePeriod = 2 * time.Minute
 
-func TestGetBuildIdsOfInterest_NoCycle(t *testing.T) {
+func TestGetBuildIdsOfInterest(t *testing.T) {
 	t.Parallel()
+	rc := mkTestReachabilityCalculator()
+
+	// start time 3x rc.buildIdVisibilityGracePeriod ago
+	timesource := commonclock.NewEventTimeSource().Update(time.Now().Add(-3*rc.buildIdVisibilityGracePeriod + time.Second))
+	createTs := hlc.Next(hlc.Zero(1), timesource)
+	timesource.Advance(rc.buildIdVisibilityGracePeriod)
+	oldDeleteTs := hlc.Next(createTs, timesource)
+	timesource.Advance(rc.buildIdVisibilityGracePeriod)
+	recentDeleteTs := hlc.Next(oldDeleteTs, timesource) // this should be within the grace period by 1s
 	/*
 		e.g.
 		Redirect Rules:
@@ -52,78 +62,45 @@ func TestGetBuildIdsOfInterest_NoCycle(t *testing.T) {
 		1 <------ 2
 		^
 		|
-		5 <------ 3 <------ 4
+		5 <------ 3 <------ 4 (recently-deleted) <------ 6 (old-deleted) <------ 7 (recently-deleted)
 	*/
-	createTs := hlc.Zero(1)
-	rc := &reachabilityCalculator{
-		redirectRules: []*persistencespb.RedirectRule{
-			mkRedirectRulePersistence(mkRedirectRule("1", "10"), createTs, nil),
-			mkRedirectRulePersistence(mkRedirectRule("2", "1"), createTs, nil),
-			mkRedirectRulePersistence(mkRedirectRule("3", "5"), createTs, nil),
-			mkRedirectRulePersistence(mkRedirectRule("4", "3"), createTs, nil),
-			mkRedirectRulePersistence(mkRedirectRule("5", "1"), createTs, nil),
-		},
+	rc.redirectRules = []*persistencespb.RedirectRule{
+		mkRedirectRulePersistence(mkRedirectRule("1", "10"), createTs, nil),
+		mkRedirectRulePersistence(mkRedirectRule("2", "1"), createTs, nil),
+		mkRedirectRulePersistence(mkRedirectRule("3", "5"), createTs, nil),
+		mkRedirectRulePersistence(mkRedirectRule("4", "3"), createTs, recentDeleteTs),
+		mkRedirectRulePersistence(mkRedirectRule("5", "1"), createTs, nil),
+		mkRedirectRulePersistence(mkRedirectRule("6", "4"), createTs, oldDeleteTs),
+		mkRedirectRulePersistence(mkRedirectRule("7", "6"), createTs, recentDeleteTs),
 	}
 
-	expectedUpstreamBuildIds := []string{"2", "5", "3", "4", "1"}
-	upstreamBuildIds := rc.getBuildIdsOfInterest("1", nil)
+	// getBuildIdsOfInterest(1, deletedRuleInclusionPeriod=nil)
+	buildIdsOfInterest := rc.getBuildIdsOfInterest("1", nil)
+	expectedBuildIdsOfInterest := []string{"2", "5", "3", "1"}
+	slices.Sort(expectedBuildIdsOfInterest)
+	slices.Sort(buildIdsOfInterest)
+	assert.Equal(t, expectedBuildIdsOfInterest, buildIdsOfInterest)
 
-	for _, bid := range expectedUpstreamBuildIds {
-		assert.Contains(t, upstreamBuildIds, bid)
-	}
-	assert.Equal(t, len(expectedUpstreamBuildIds), len(upstreamBuildIds))
-}
+	// getBuildIdsOfInterest(1, deletedRuleInclusionPeriod=rc.buildIdVisibilityGracePeriod)
+	buildIdsOfInterest = rc.getBuildIdsOfInterest("1", &rc.buildIdVisibilityGracePeriod)
+	expectedBuildIdsOfInterest = []string{"2", "5", "3", "4", "1"}
+	slices.Sort(expectedBuildIdsOfInterest)
+	slices.Sort(buildIdsOfInterest)
+	assert.Equal(t, expectedBuildIdsOfInterest, buildIdsOfInterest)
 
-func TestGetBuildIdsOfInterest_WithCycle(t *testing.T) {
-	t.Parallel()
-	/*
-		e.g.
-		Redirect Rules:
-		1 ------> 2
-		^         |
-		|         v
-		5 <------ 3 ------> 4
-	*/
-	createTs := hlc.Zero(1)
-	rc := &reachabilityCalculator{
-		redirectRules: []*persistencespb.RedirectRule{
-			mkRedirectRulePersistence(mkRedirectRule("1", "2"), createTs, nil),
-			mkRedirectRulePersistence(mkRedirectRule("2", "3"), createTs, nil),
-			mkRedirectRulePersistence(mkRedirectRule("3", "4"), createTs, nil),
-			mkRedirectRulePersistence(mkRedirectRule("3", "5"), createTs, nil),
-			mkRedirectRulePersistence(mkRedirectRule("5", "1"), createTs, nil),
-		},
-	}
-	expectedUpstreamBuildIds := []string{"5", "3", "2", "1"}
-	upstreamBuildIds := rc.getBuildIdsOfInterest("1", nil)
-	for _, bid := range expectedUpstreamBuildIds {
-		assert.Contains(t, upstreamBuildIds, bid)
-	}
-	assert.Equal(t, len(expectedUpstreamBuildIds), len(upstreamBuildIds))
+	// getBuildIdsOfInterest(6, deletedRuleInclusionPeriod=nil)
+	buildIdsOfInterest = rc.getBuildIdsOfInterest("6", nil)
+	expectedBuildIdsOfInterest = []string{"6"}
+	slices.Sort(expectedBuildIdsOfInterest)
+	slices.Sort(buildIdsOfInterest)
+	assert.Equal(t, expectedBuildIdsOfInterest, buildIdsOfInterest)
 
-	/*
-		e.g.
-		Redirect Rules:
-		1         2 <---
-		^         |     \
-		|         v      \
-		5 <------ 3 ------> 4
-	*/
-	rc = &reachabilityCalculator{
-		redirectRules: []*persistencespb.RedirectRule{
-			mkRedirectRulePersistence(mkRedirectRule("2", "3"), createTs, nil),
-			mkRedirectRulePersistence(mkRedirectRule("3", "4"), createTs, nil),
-			mkRedirectRulePersistence(mkRedirectRule("3", "5"), createTs, nil),
-			mkRedirectRulePersistence(mkRedirectRule("4", "2"), createTs, nil),
-			mkRedirectRulePersistence(mkRedirectRule("5", "1"), createTs, nil),
-		},
-	}
-	expectedUpstreamBuildIds = []string{"5", "3", "2", "4", "1"}
-	upstreamBuildIds = rc.getBuildIdsOfInterest("1", nil)
-	for _, bid := range expectedUpstreamBuildIds {
-		assert.Contains(t, upstreamBuildIds, bid)
-	}
-	assert.Equal(t, len(expectedUpstreamBuildIds), len(upstreamBuildIds))
+	// getBuildIdsOfInterest(6, deletedRuleInclusionPeriod=rc.buildIdVisibilityGracePeriod)
+	buildIdsOfInterest = rc.getBuildIdsOfInterest("6", &rc.buildIdVisibilityGracePeriod)
+	expectedBuildIdsOfInterest = []string{"7", "6"}
+	slices.Sort(expectedBuildIdsOfInterest)
+	slices.Sort(buildIdsOfInterest)
+	assert.Equal(t, expectedBuildIdsOfInterest, buildIdsOfInterest)
 }
 
 func TestExistsBackloggedActivityOrWFAssignedTo(t *testing.T) {

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -511,13 +511,16 @@ func getUpstreamBuildIds(buildId string, redirectRules []*persistencespb.Redirec
 func getUpstreamHelper(
 	buildId string,
 	redirectRules []*persistencespb.RedirectRule,
-	visited []string) []string {
+	visited map[string]bool) []string {
 	var upstream []string
-	visited = append(visited, buildId)
+	if visited == nil {
+		visited = make(map[string]bool)
+	}
+	visited[buildId] = true
 	directSources := getSourcesForTarget(buildId, redirectRules)
 
 	for _, src := range directSources {
-		if !slices.Contains(visited, src) {
+		if !visited[src] {
 			upstream = append(upstream, src)
 			upstream = append(upstream, getUpstreamHelper(src, redirectRules, visited)...)
 		}
@@ -528,9 +531,11 @@ func getUpstreamHelper(
 	for _, bid := range upstream {
 		upstreamUnique[bid] = true
 	}
-	upstream = make([]string, 0)
+	upstream = make([]string, len(upstreamUnique))
+	i := 0
 	for k := range upstreamUnique {
-		upstream = append(upstream, k)
+		upstream[i] = k
+		i++
 	}
 	return upstream
 }

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -511,7 +511,8 @@ func getUpstreamBuildIds(buildId string, redirectRules []*persistencespb.Redirec
 func getUpstreamHelper(
 	buildId string,
 	redirectRules []*persistencespb.RedirectRule,
-	visited map[string]bool) []string {
+	visited map[string]bool,
+) []string {
 	var upstream []string
 	if visited == nil {
 		visited = make(map[string]bool)

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -353,7 +353,7 @@ func checkRedirectConditions(g *persistencespb.VersioningData, maxRRs, maxChain 
 	}
 	for _, r := range activeRules {
 		upstream := getUpstreamBuildIds(r.GetRule().GetTargetBuildId(), activeRules)
-		if len(upstream) > maxChain {
+		if len(upstream)+1 > maxChain {
 			return serviceerror.NewFailedPrecondition(
 				fmt.Sprintf("update exceeds number of chained redirect rules permitted in namespace (%v/%v)", len(upstream), maxChain))
 		}

--- a/service/matching/version_rule_test.go
+++ b/service/matching/version_rule_test.go
@@ -41,6 +41,11 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+const (
+	ignoreMaxRules = 1000
+	ignoreMaxChain = 1000
+)
+
 func mkNewInsertAssignmentReq(rule *taskqueuepb.BuildIdAssignmentRule, ruleIdx int32) *workflowservice.UpdateWorkerVersioningRulesRequest_InsertBuildIdAssignmentRule {
 	return &workflowservice.UpdateWorkerVersioningRulesRequest_InsertBuildIdAssignmentRule{
 		RuleIndex: ruleIdx,
@@ -267,32 +272,30 @@ func TestInsertAssignmentRuleMaxRules(t *testing.T) {
 // Test requirement that target id isn't in a version set (success and failure)
 func TestInsertAssignmentRuleInVersionSet(t *testing.T) {
 	t.Parallel()
-	maxRules := 3
 	clock := hlc.Zero(1)
 	data := mkInitialData(1, clock)
 
 	// target 0 --> failure
-	_, err := insertAssignmentRule(mkAssignmentRule("0", nil), data, clock, 0, maxRules)
+	_, err := insertAssignmentRule(mkAssignmentRule("0", nil), data, clock, 0, ignoreMaxRules)
 	assert.Error(t, err)
 
 	// insert 1 --> success
-	_, err = insertAssignmentRule(mkAssignmentRule("1", nil), data, clock, 0, maxRules)
+	_, err = insertAssignmentRule(mkAssignmentRule("1", nil), data, clock, 0, ignoreMaxRules)
 	assert.NoError(t, err)
 }
 
 func TestInsertAssignmentRuleTerminalBuildID(t *testing.T) {
 	t.Parallel()
-	maxRules := 3
 	clock := hlc.Zero(1)
-	data, err := insertRedirectRule(mkRedirectRule("0", "1"), mkInitialData(0, clock), clock, maxRules, maxRules)
+	data, err := insertRedirectRule(mkRedirectRule("0", "1"), mkInitialData(0, clock), clock, ignoreMaxRules, ignoreMaxChain)
 	assert.NoError(t, err)
 
 	// insert 1 --> failure
-	_, err = insertAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(10)), data, clock, 0, maxRules)
+	_, err = insertAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(10)), data, clock, 0, ignoreMaxRules)
 	assert.Error(t, err)
 
 	// insert 2 --> success
-	_, err = insertAssignmentRule(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(10)), data, clock, 0, maxRules)
+	_, err = insertAssignmentRule(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(10)), data, clock, 0, ignoreMaxRules)
 	assert.NoError(t, err)
 }
 
@@ -395,7 +398,7 @@ func TestReplaceAssignmentRuleTerminalBuildID(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestReplaceAssignmentRuleTestrequireUnconditional(t *testing.T) {
+func TestReplaceAssignmentRuleTestRequireUnconditional(t *testing.T) {
 	t.Parallel()
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
@@ -498,13 +501,12 @@ func TestDeleteAssignmentRuleTestrequireUnconditional(t *testing.T) {
 
 func TestInsertRedirectRuleBasic(t *testing.T) {
 	t.Parallel()
-	maxRules := 10
 	clock := hlc.Zero(1)
 	initialData := mkInitialData(0, clock)
 	expectedSet := make([]*persistencepb.RedirectRule, 0)
 
 	rule1 := mkRedirectRule("1", "0")
-	data, err := insertRedirectRule(rule1, initialData, clock, maxRules, maxRules)
+	data, err := insertRedirectRule(rule1, initialData, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.NoError(t, err)
 	expectedSet = append(expectedSet, mkRedirectRulePersistence(rule1, clock, nil))
 	for _, r := range data.RedirectRules {
@@ -512,7 +514,7 @@ func TestInsertRedirectRuleBasic(t *testing.T) {
 	}
 
 	rule2 := mkRedirectRule("2", "0")
-	data, err = insertRedirectRule(rule2, data, clock, maxRules, maxRules)
+	data, err = insertRedirectRule(rule2, data, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.NoError(t, err)
 	expectedSet = append(expectedSet, mkRedirectRulePersistence(rule2, clock, nil))
 	for _, r := range data.RedirectRules {
@@ -520,7 +522,7 @@ func TestInsertRedirectRuleBasic(t *testing.T) {
 	}
 
 	rule3 := mkRedirectRule("3", "0")
-	data, err = insertRedirectRule(rule3, data, clock, maxRules, maxRules)
+	data, err = insertRedirectRule(rule3, data, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.NoError(t, err)
 	expectedSet = append(expectedSet, mkRedirectRulePersistence(rule3, clock, nil))
 	for _, r := range data.RedirectRules {
@@ -541,42 +543,40 @@ func TestInsertRedirectRuleMaxRules(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		src := fmt.Sprintf("%d", i)
 		dst := fmt.Sprintf("%d", i+1)
-		data, err = insertRedirectRule(mkRedirectRule(src, dst), data, clock, maxRules, maxRules)
+		data, err = insertRedirectRule(mkRedirectRule(src, dst), data, clock, maxRules, ignoreMaxChain)
 		assert.NoError(t, err)
 	}
 
 	// insert fourth --> error
-	_, err = insertRedirectRule(mkRedirectRule("10", "20"), data, clock, maxRules, maxRules)
+	_, err = insertRedirectRule(mkRedirectRule("10", "20"), data, clock, maxRules, ignoreMaxChain)
 	assert.Error(t, err)
 }
 
 func TestInsertRedirectRuleInVersionSet(t *testing.T) {
 	t.Parallel()
-	maxRules := 3
 	clock := hlc.Zero(1)
 	// make version set with build id "0" in it
 	initialData := mkInitialData(1, clock)
 
 	// insert with source build id "0" --> failure
-	_, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, maxRules, maxRules)
+	_, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.Error(t, err)
 
 	// insert with target build id "0" --> failure
-	_, err = insertRedirectRule(mkRedirectRule("1", "0"), initialData, clock, maxRules, maxRules)
+	_, err = insertRedirectRule(mkRedirectRule("1", "0"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.Error(t, err)
 
 	// insert with non-zero source build id --> success
-	_, err = insertRedirectRule(mkRedirectRule("1", "2"), initialData, clock, maxRules, maxRules)
+	_, err = insertRedirectRule(mkRedirectRule("1", "2"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.NoError(t, err)
 
 	// insert with non-zero target build id --> success
-	_, err = insertRedirectRule(mkRedirectRule("2", "1"), initialData, clock, maxRules, maxRules)
+	_, err = insertRedirectRule(mkRedirectRule("2", "1"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.NoError(t, err)
 }
 
 func TestInsertRedirectRuleSourceIsRampedAssignmentRuleTarget(t *testing.T) {
 	t.Parallel()
-	maxRules := 3
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
@@ -585,68 +585,65 @@ func TestInsertRedirectRuleSourceIsRampedAssignmentRuleTarget(t *testing.T) {
 	}
 
 	// insert redirect rule with target 1 --> failure
-	_, err := insertRedirectRule(mkRedirectRule("1", "0"), data, clock, maxRules, maxRules)
+	_, err := insertRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.Error(t, err)
 
 	// insert redirect rule with target 2 --> success
-	_, err = insertRedirectRule(mkRedirectRule("2", "0"), data, clock, maxRules, maxRules)
+	_, err = insertRedirectRule(mkRedirectRule("2", "0"), data, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.NoError(t, err)
 }
 
 func TestInsertRedirectRuleAlreadyExists(t *testing.T) {
 	t.Parallel()
-	maxRules := 10
 	clock := hlc.Zero(1)
 	initialData := mkInitialData(0, clock)
 
 	// insert with source build id "0"
-	data, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, maxRules, maxRules)
+	data, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.NoError(t, err)
 
 	// insert with source build id "0" --> failure
-	_, err = insertRedirectRule(mkRedirectRule("0", "6"), data, clock, maxRules, maxRules)
+	_, err = insertRedirectRule(mkRedirectRule("0", "6"), data, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.Error(t, err)
 }
 
 func TestInsertRedirectRuleCreateCycle(t *testing.T) {
 	t.Parallel()
-	maxRules := 3
 	clock := hlc.Zero(1)
 	initialData := mkInitialData(0, clock)
 
 	// insert with source -> target == "0" -> "0" --> failure
-	_, err := insertRedirectRule(mkRedirectRule("0", "0"), initialData, clock, maxRules, maxRules)
+	_, err := insertRedirectRule(mkRedirectRule("0", "0"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.Error(t, err)
 
 	// insert with source -> target == "0" -> "1" --> success
-	data, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, maxRules, maxRules)
+	data, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.NoError(t, err)
 
 	// insert with source build id "1" -> "0" --> failure
-	_, err = insertRedirectRule(mkRedirectRule("1", "0"), data, clock, maxRules, maxRules)
+	_, err = insertRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.Error(t, err)
 }
 
 func TestInsertRedirectRuleMaxChain(t *testing.T) {
 	t.Parallel()
-	maxRules := 10
 	maxChain := 3
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 
 	// insert (4->5)
 	// 4 ---> 5
-	data, err := insertRedirectRule(mkRedirectRule("4", "5"), data, clock, maxRules, maxChain)
+	data, err := insertRedirectRule(mkRedirectRule("4", "5"), data, clock, ignoreMaxRules, maxChain)
 	assert.NoError(t, err)
 
 	// insert (5->6)
 	// 4 ---> 5 ---> 6
-	data, err = insertRedirectRule(mkRedirectRule("5", "6"), data, clock, maxRules, maxChain)
+	data, err = insertRedirectRule(mkRedirectRule("5", "6"), data, clock, ignoreMaxRules, maxChain)
 	assert.NoError(t, err)
 
 	// insert (6->7)
 	// 4 ---> 5 ---> 6 ---> 7
-	_, err = insertRedirectRule(mkRedirectRule("6", "7"), data, clock, maxRules, maxChain)
+	_, err = insertRedirectRule(mkRedirectRule("6", "7"), data, clock, ignoreMaxRules, maxChain)
 	assert.Error(t, err)
 }
 
@@ -665,7 +662,7 @@ func TestReplaceRedirectRuleBasic(t *testing.T) {
 	replaceTest := func(source, target string) {
 		prevRule := getActiveRedirectRuleBySrc(source, data)
 		rule := mkRedirectRule(source, target)
-		data, err = replaceRedirectRule(rule, data, clock, len(data.GetRedirectRules()))
+		data, err = replaceRedirectRule(rule, data, clock, ignoreMaxChain)
 		assert.NoError(t, err)
 		newActive := getActiveRedirectRuleBySrc(source, data)
 		protoassert.ProtoEqual(t, newActive.GetRule(), rule)
@@ -695,11 +692,11 @@ func TestReplaceRedirectRuleInVersionSet(t *testing.T) {
 	var err error
 
 	// replace with target 0 --> failure
-	_, err = replaceRedirectRule(mkRedirectRule("1", "0"), data, clock, len(data.GetRedirectRules()))
+	_, err = replaceRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
 
 	// replace with non-zero target --> success
-	_, err = replaceRedirectRule(mkRedirectRule("1", "10"), data, clock, len(data.GetRedirectRules()))
+	_, err = replaceRedirectRule(mkRedirectRule("1", "10"), data, clock, ignoreMaxChain)
 	assert.NoError(t, err)
 }
 
@@ -714,39 +711,38 @@ func TestReplaceRedirectRuleCreateCycle(t *testing.T) {
 	}
 	var err error
 
-	_, err = replaceRedirectRule(mkRedirectRule("0", "0"), data, clock, len(data.GetRedirectRules()))
+	_, err = replaceRedirectRule(mkRedirectRule("0", "0"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
 
-	_, err = replaceRedirectRule(mkRedirectRule("2", "0"), data, clock, len(data.GetRedirectRules()))
+	_, err = replaceRedirectRule(mkRedirectRule("2", "0"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
 
-	_, err = replaceRedirectRule(mkRedirectRule("1", "0"), data, clock, len(data.GetRedirectRules()))
+	_, err = replaceRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
 
-	_, err = replaceRedirectRule(mkRedirectRule("2", "1"), data, clock, len(data.GetRedirectRules()))
+	_, err = replaceRedirectRule(mkRedirectRule("2", "1"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
 }
 
 func TestReplaceRedirectRuleMaxChain(t *testing.T) {
 	t.Parallel()
-	maxRules := 10
 	maxChain := 3
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 
 	// insert (2->3)
 	// 2 ---> 3
-	data, err := insertRedirectRule(mkRedirectRule("2", "3"), data, clock, maxRules, maxChain)
+	data, err := insertRedirectRule(mkRedirectRule("2", "3"), data, clock, ignoreMaxRules, maxChain)
 	assert.NoError(t, err)
 
 	// insert (4->5)
 	// 2 ---> 3, 4 ---> 5
-	data, err = insertRedirectRule(mkRedirectRule("4", "5"), data, clock, maxRules, maxChain)
+	data, err = insertRedirectRule(mkRedirectRule("4", "5"), data, clock, ignoreMaxRules, maxChain)
 	assert.NoError(t, err)
 
 	// insert (5->6)
 	// 2 ---> 3, 4 ---> 5 ---> 6
-	data, err = insertRedirectRule(mkRedirectRule("5", "6"), data, clock, maxRules, maxChain)
+	data, err = insertRedirectRule(mkRedirectRule("5", "6"), data, clock, ignoreMaxRules, maxChain)
 	assert.NoError(t, err)
 
 	// replace(2, new_target=1)
@@ -767,7 +763,7 @@ func TestReplaceRedirectRuleNotFound(t *testing.T) {
 	var err error
 
 	// fails because no rules to replace
-	_, err = replaceRedirectRule(mkRedirectRule("1", "100"), data, clock, len(data.GetRedirectRules()))
+	_, err = replaceRedirectRule(mkRedirectRule("1", "100"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
 
 	data.RedirectRules = []*persistencepb.RedirectRule{
@@ -775,7 +771,7 @@ func TestReplaceRedirectRuleNotFound(t *testing.T) {
 	}
 
 	// fails because source doesnt exist
-	_, err = replaceRedirectRule(mkRedirectRule("1", "100"), data, clock, len(data.GetRedirectRules()))
+	_, err = replaceRedirectRule(mkRedirectRule("1", "100"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
 }
 
@@ -900,7 +896,6 @@ func TestGetWorkerVersioningRules(t *testing.T) {
 
 func TestCleanupRedirectRuleTombstones(t *testing.T) {
 	t.Parallel()
-	maxRules := 10
 	clock := hlc.Zero(1)
 	initialData := mkInitialData(0, clock)
 
@@ -910,13 +905,13 @@ func TestCleanupRedirectRuleTombstones(t *testing.T) {
 	// insert 3x to get three rules in there
 	rule1 := mkRedirectRule("1", "10")
 	clock1 := hlc.Next(clock, timesource)
-	data, err := insertRedirectRule(rule1, initialData, clock1, maxRules, maxRules)
+	data, err := insertRedirectRule(rule1, initialData, clock1, ignoreMaxRules, ignoreMaxChain)
 	assert.NoError(t, err)
 	rule2 := mkRedirectRule("2", "10")
-	data, err = insertRedirectRule(rule2, data, clock1, maxRules, maxRules)
+	data, err = insertRedirectRule(rule2, data, clock1, ignoreMaxRules, ignoreMaxChain)
 	assert.NoError(t, err)
 	rule3 := mkRedirectRule("3", "10")
-	data, err = insertRedirectRule(rule3, data, clock1, maxRules, maxRules)
+	data, err = insertRedirectRule(rule3, data, clock1, ignoreMaxRules, ignoreMaxChain)
 	assert.NoError(t, err)
 
 	// delete "now," ~1 hour ago
@@ -957,7 +952,6 @@ func TestCleanupRedirectRuleTombstones(t *testing.T) {
 
 func TestCommitBuildIDBasic(t *testing.T) {
 	t.Parallel()
-	maxRules := 10
 	timesource := commonclock.NewRealTimeSource()
 	clock1 := hlc.Zero(1)
 	clock2 := hlc.Next(clock1, timesource)
@@ -978,7 +972,7 @@ func TestCommitBuildIDBasic(t *testing.T) {
 	}
 	var err error
 
-	data, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("10", false), true, maxRules)
+	data, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("10", false), true, ignoreMaxRules)
 	assert.NoError(t, err)
 	protoassert.ProtoEqual(t, expected, data)
 
@@ -993,7 +987,7 @@ func TestCommitBuildIDBasic(t *testing.T) {
 			mkAssignmentRulePersistence(mkAssignmentRule("10", nil), clock3, nil),
 		},
 	}
-	data, err = CommitBuildID(clock3, data, mkNewCommitBuildIdReq("10", false), true, maxRules)
+	data, err = CommitBuildID(clock3, data, mkNewCommitBuildIdReq("10", false), true, ignoreMaxRules)
 	assert.NoError(t, err)
 	protoassert.ProtoEqual(t, expected, data)
 }
@@ -1001,7 +995,6 @@ func TestCommitBuildIDBasic(t *testing.T) {
 func TestCommitBuildIDNoRecentPoller(t *testing.T) {
 	// note: correctly generating hasRecentPoller needs to be tested in the end-to-end tests
 	t.Parallel()
-	maxRules := 10
 	timesource := commonclock.NewRealTimeSource()
 	clock1 := hlc.Zero(1)
 	clock2 := hlc.Next(clock1, timesource)
@@ -1015,17 +1008,16 @@ func TestCommitBuildIDNoRecentPoller(t *testing.T) {
 	var err error
 
 	// without force --> fail
-	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("10", false), false, maxRules)
+	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("10", false), false, ignoreMaxRules)
 	assert.Error(t, err)
 
 	// with force --> success
-	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("10", true), false, maxRules)
+	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("10", true), false, ignoreMaxRules)
 	assert.NoError(t, err)
 }
 
 func TestCommitBuildIDInVersionSet(t *testing.T) {
 	t.Parallel()
-	maxRules := 10
 	timesource := commonclock.NewRealTimeSource()
 	clock1 := hlc.Zero(1)
 	clock2 := hlc.Next(clock1, timesource)
@@ -1038,11 +1030,11 @@ func TestCommitBuildIDInVersionSet(t *testing.T) {
 	var err error
 
 	// with target 0 --> fail
-	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("0", false), true, maxRules)
+	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("0", false), true, ignoreMaxRules)
 	assert.Error(t, err)
 
 	// with target 10 --> success
-	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("10", false), true, maxRules)
+	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("10", false), true, ignoreMaxRules)
 	assert.NoError(t, err)
 }
 

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -83,6 +83,7 @@ func (s *VersioningIntegSuite) SetupSuite() {
 
 		dynamicconfig.AssignmentRuleLimitPerQueue:              10,
 		dynamicconfig.RedirectRuleLimitPerQueue:                10,
+		dynamicconfig.RedirectRuleChainLimitPerQueue:           10,
 		dynamicconfig.MatchingDeletedRuleRetentionTime:         24 * time.Hour,
 		dynamicconfig.ReachabilityBuildIdVisibilityGracePeriod: 3 * time.Minute,
 


### PR DESCRIPTION
## What changed?
Add and enforce dynamic config chain limit for redirect rules

## Why?
To limit scope of visibility queries and ensure that task matching using redirect rules can complete quickly.

## How did you test it?
Unit tests

## Potential risks
None

## Documentation
Good error message is included

## Is hotfix candidate?
No
