### PR TITLE
Enforce dc.ReachabilityQueryBuildIdLimit for DescribeTaskQueue with ReportTaskReachability==true

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -219,7 +219,7 @@ const (
 	// GetWorkerTaskReachability query.
 	ReachabilityTaskQueueScanLimit = "limit.reachabilityTaskQueueScan"
 	// ReachabilityQueryBuildIdLimit limits the number of build ids that can be requested in a single call to the
-	// GetWorkerTaskReachability API.
+	// DescribeTaskQueue API with ReportTaskQueueReachability==true, or to the GetWorkerTaskReachability API.
 	ReachabilityQueryBuildIdLimit = "limit.reachabilityQueryBuildIds"
 	// ReachabilityQuerySetDurationSinceDefault is the minimum period since a version set was demoted from being the
 	// queue default before it is considered unreachable by new workflows.

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2429,6 +2429,12 @@ func (wh *WorkflowHandler) DescribeTaskQueue(ctx context.Context, request *workf
 		request.TaskQueueTypes = []enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW, enumspb.TASK_QUEUE_TYPE_ACTIVITY}
 	}
 
+	if request.GetReportTaskReachability() &&
+		len(request.GetVersions().GetBuildIds()) > wh.config.ReachabilityQueryBuildIdLimit() {
+		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
+			"Too many build ids queried at once with ReportTaskReachability==true, limit: %d", wh.config.ReachabilityQueryBuildIdLimit()))
+	}
+
 	if request.ApiMode == enumspb.DESCRIBE_TASK_QUEUE_MODE_ENHANCED {
 		if request.TaskQueue.Kind == enumspb.TASK_QUEUE_KIND_STICKY {
 			return nil, errUseEnhancedDescribeOnStickyQueue


### PR DESCRIPTION
## What changed?
Enforce dc.ReachabilityQueryBuildIdLimit for DescribeTaskQueue with ReportTaskReachability==true.

## Why?
This is enforced in the frontend, because we have the information to enforce it there, so if we do it there we can return an error quickly without putting additional load on matching.

Optionally we could _also_ enforce it at the matching engine level to prevent attacks from any callers that use the API without going through the frontend, but I believe that that isn't necessary, since the main protection for overloading visibility will come from the rate limit not the build id limit. The length of the list of "active versions" could well exceed this limit, so we can't rely on this limit to strictly guarantee a short visibility query anyways, it just limits a portion of the queries from being too big.

## How did you test it?
Functional test.

## Potential risks
If implemented incorrectly, this could fail to reduce load on visibility. However, as discussed above, this is not the main mechanism for reducing load on visibility anyways.

## Documentation
Error message is clear