### PR TITLE
redo #5707: define versioning rule errors and improve unit test coverage

### DIFF
--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -43,6 +43,38 @@ import (
 	"go.temporal.io/server/common/util"
 )
 
+var (
+	errInvalidNegativeIndex                     = serviceerror.NewInvalidArgument("rule index cannot be negative")
+	errInvalidRampPercentage                    = serviceerror.NewInvalidArgument("ramp percentage must be in range [0, 100)")
+	errTargetIsVersionSetMember                 = serviceerror.NewFailedPrecondition("update breaks requirement, target build id is already a member of a version set")
+	errSourceIsVersionSetMember                 = serviceerror.NewFailedPrecondition("update breaks requirement, source build id is already a member of a version set")
+	errRampedAssignmentRuleIsRedirectRuleSource = serviceerror.NewFailedPrecondition("update breaks requirement, this target build id cannot have a ramp because it is the source of a redirect rule")
+	errAssignmentRuleIndexOutOfBounds           = func(idx, length int) error {
+		return serviceerror.NewInvalidArgument(fmt.Sprintf("rule index %d is out of bounds for assignment rule list of length %d", idx, length))
+	}
+	errSourceIsConditionalAssignmentRuleTarget = serviceerror.NewFailedPrecondition("redirect rule source build ID cannot be the target of any assignment rule with non-nil ramp")
+	errSourceAlreadyExists                     = func(source, target string) error {
+		return serviceerror.NewAlreadyExist(fmt.Sprintf("source %s already redirects to target %s", source, target))
+	}
+	errSourceNotFound = func(source string) error {
+		return serviceerror.NewNotFound(fmt.Sprintf("no redirect rule found with source ID %s", source))
+	}
+	errNoRecentPollerOnCommitVersion = func(target string) error {
+		return serviceerror.NewFailedPrecondition(fmt.Sprintf("no versioned poller with build ID '%s' seen within the last %s, use force=true to commit anyways", target, versioningPollerSeenWindow.String()))
+	}
+	errExceedsMaxAssignmentRules = func(cnt, max int) error {
+		return serviceerror.NewFailedPrecondition(fmt.Sprintf("update exceeds number of assignment rules permitted in namespace (%v/%v)", cnt, max))
+	}
+	errRequireUnconditionalAssignmentRule = serviceerror.NewFailedPrecondition("there must exist at least one fully-ramped 'unconditional' assignment rule, use force=true to bypass this requirement")
+	errExceedsMaxRedirectRules            = func(cnt, max int) error {
+		return serviceerror.NewFailedPrecondition(fmt.Sprintf("update exceeds number of redirect rules permitted in namespace (%v/%v)", cnt, max))
+	}
+	errIsCyclic            = serviceerror.NewFailedPrecondition("update would break acyclic requirement")
+	errExceedsMaxRuleChain = func(cnt, max int) error {
+		return serviceerror.NewFailedPrecondition(fmt.Sprintf("update exceeds number of chained redirect rules permitted in namespace (%v/%v)", cnt, max))
+	}
+)
+
 func cloneOrMkData(data *persistencespb.VersioningData) *persistencespb.VersioningData {
 	if data == nil {
 		return &persistencespb.VersioningData{
@@ -58,20 +90,18 @@ func InsertAssignmentRule(timestamp *hlc.Clock,
 	req *workflowservice.UpdateWorkerVersioningRulesRequest_InsertBuildIdAssignmentRule,
 	maxAssignmentRules int) (*persistencespb.VersioningData, error) {
 	if req.GetRuleIndex() < 0 {
-		return nil, serviceerror.NewInvalidArgument("rule index cannot be negative")
+		return nil, errInvalidNegativeIndex
 	}
 	rule := req.GetRule()
 	if ramp := rule.GetPercentageRamp(); !validRamp(ramp) {
-		return nil, serviceerror.NewInvalidArgument("ramp percentage must be in range [0, 100)")
+		return nil, errInvalidRampPercentage
 	}
 	target := rule.GetTargetBuildId()
 	if isInVersionSets(target, data.GetVersionSets()) {
-		return nil, serviceerror.NewFailedPrecondition(
-			"update breaks requirement, target build id is already a member of a version set")
+		return nil, errTargetIsVersionSetMember
 	}
 	if rule.GetRamp() != nil && isActiveRedirectRuleSource(target, data.GetRedirectRules()) {
-		return nil, serviceerror.NewFailedPrecondition(
-			"update breaks requirement, this target build id cannot have a ramp because it is the source of a redirect rule")
+		return nil, errRampedAssignmentRuleIsRedirectRuleSource
 	}
 	data = cloneOrMkData(data)
 	rules := data.GetAssignmentRules()
@@ -96,24 +126,21 @@ func ReplaceAssignmentRule(timestamp *hlc.Clock,
 	data = cloneOrMkData(data)
 	rule := req.GetRule()
 	if ramp := rule.GetPercentageRamp(); !validRamp(ramp) {
-		return nil, serviceerror.NewInvalidArgument("ramp percentage must be in range [0, 100)")
+		return nil, errInvalidRampPercentage
 	}
 	target := rule.GetTargetBuildId()
 	if isInVersionSets(target, data.GetVersionSets()) {
-		return nil, serviceerror.NewFailedPrecondition(
-			"update breaks requirement, target build id is already a member of a version set")
+		return nil, errTargetIsVersionSetMember
 	}
 	if rule.GetRamp() != nil && isActiveRedirectRuleSource(target, data.GetRedirectRules()) {
-		return nil, serviceerror.NewFailedPrecondition(
-			"update breaks requirement, this target build id cannot have a ramp because it is the source of a redirect rule")
+		return nil, errRampedAssignmentRuleIsRedirectRuleSource
 	}
 	rules := data.GetAssignmentRules()
 	hadUnconditional := containsUnconditional(rules)
 	idx := req.GetRuleIndex()
 	actualIdx := given2ActualIdx(idx, rules)
 	if actualIdx < 0 {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
-			"rule index %d is out of bounds for assignment rule list of length %d", idx, len(getActiveAssignmentRules(rules))))
+		return nil, errAssignmentRuleIndexOutOfBounds(int(idx), len(getActiveAssignmentRules(rules)))
 	}
 	rules[actualIdx].DeleteTimestamp = timestamp
 	data.AssignmentRules = slices.Insert(rules, actualIdx, &persistencespb.AssignmentRule{
@@ -134,8 +161,7 @@ func DeleteAssignmentRule(timestamp *hlc.Clock,
 	idx := req.GetRuleIndex()
 	actualIdx := given2ActualIdx(idx, rules)
 	if actualIdx < 0 || actualIdx > len(rules)-1 {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
-			"rule index %d is out of bounds for assignment rule list of length %d", idx, len(getActiveAssignmentRules(rules))))
+		return nil, errAssignmentRuleIndexOutOfBounds(int(idx), len(getActiveAssignmentRules(rules)))
 	}
 	rules[actualIdx].DeleteTimestamp = timestamp
 	return data, checkAssignmentConditions(data, 0, hadUnconditional && !req.GetForce())
@@ -150,25 +176,19 @@ func AddCompatibleRedirectRule(timestamp *hlc.Clock,
 	rule := req.GetRule()
 	source := rule.GetSourceBuildId()
 	if isInVersionSets(source, data.GetVersionSets()) {
-		return nil, serviceerror.NewFailedPrecondition(
-			"update breaks requirement, resource build ID is already a member of a version set")
+		return nil, errSourceIsVersionSetMember
 	}
 	target := rule.GetTargetBuildId()
 	if isInVersionSets(target, data.GetVersionSets()) {
-		return nil, serviceerror.NewFailedPrecondition(
-			"update breaks requirement, target build ID is already a member of a version set")
+		return nil, errTargetIsVersionSetMember
 	}
 	if isConditionalAssignmentRuleTarget(source, data.GetAssignmentRules()) {
-		return nil, serviceerror.NewFailedPrecondition(
-			"redirect rule source build ID cannot be the target of any assignment rule with non-nil ramp")
+		return nil, errSourceIsConditionalAssignmentRuleTarget
 	}
 	rules := data.GetRedirectRules()
 	for _, r := range rules {
 		if r.GetDeleteTimestamp() == nil && r.GetRule().GetSourceBuildId() == source {
-			return nil, serviceerror.NewAlreadyExist(fmt.Sprintf(
-				"cannot insert: source %s already redirects to target %s",
-				source, r.GetRule().GetTargetBuildId(),
-			))
+			return nil, errSourceAlreadyExists(source, r.GetRule().GetTargetBuildId())
 		}
 	}
 	data.RedirectRules = slices.Insert(rules, 0, &persistencespb.RedirectRule{
@@ -188,13 +208,11 @@ func ReplaceCompatibleRedirectRule(timestamp *hlc.Clock,
 	rule := req.GetRule()
 	source := rule.GetSourceBuildId()
 	if isInVersionSets(source, data.GetVersionSets()) {
-		return nil, serviceerror.NewFailedPrecondition(
-			"update breaks requirement, resource build ID is already a member of a version set")
+		return nil, errSourceIsVersionSetMember
 	}
 	target := rule.GetTargetBuildId()
 	if isInVersionSets(target, data.GetVersionSets()) {
-		return nil, serviceerror.NewFailedPrecondition(
-			"update breaks requirement, target build ID is already a member of a version set")
+		return nil, errTargetIsVersionSetMember
 	}
 	rules := data.GetRedirectRules()
 	for _, r := range rules {
@@ -208,7 +226,7 @@ func ReplaceCompatibleRedirectRule(timestamp *hlc.Clock,
 			return data, checkRedirectConditions(data, 0, maxRedirectRuleChain)
 		}
 	}
-	return nil, serviceerror.NewNotFound(fmt.Sprintf("cannot replace: no redirect rule found with source ID %s", source))
+	return nil, errSourceNotFound(source)
 }
 
 func DeleteCompatibleRedirectRule(timestamp *hlc.Clock,
@@ -223,7 +241,7 @@ func DeleteCompatibleRedirectRule(timestamp *hlc.Clock,
 			return data, nil // no need to check cycle or chain because removing a node cannot create a cycle or create a link
 		}
 	}
-	return nil, serviceerror.NewNotFound(fmt.Sprintf("cannot delete: no redirect rule found with source ID %s", source))
+	return nil, errSourceNotFound(source)
 }
 
 // CleanupRuleTombstones clears all deleted rules from versioning data if the rule was deleted more than
@@ -259,13 +277,10 @@ func CommitBuildID(timestamp *hlc.Clock,
 	data = cloneOrMkData(data)
 	target := req.GetTargetBuildId()
 	if !hasRecentPoller && !req.GetForce() {
-		return nil, serviceerror.NewFailedPrecondition(
-			fmt.Sprintf("no versioned poller with build ID '%s' seen within the last %s, use force=true to commit anyways",
-				target, versioningPollerSeenWindow.String()))
+		return nil, errNoRecentPollerOnCommitVersion(target)
 	}
 	if isInVersionSets(target, data.GetVersionSets()) {
-		return nil, serviceerror.NewFailedPrecondition(
-			fmt.Sprintf("update breaks requirement, build id %s is already a member of version set", target))
+		return nil, errTargetIsVersionSetMember
 	}
 
 	for _, ar := range getActiveAssignmentRules(data.GetAssignmentRules()) {
@@ -330,10 +345,10 @@ func GetTimestampedWorkerVersioningRules(
 func checkAssignmentConditions(g *persistencespb.VersioningData, maxARs int, requireUnconditional bool) error {
 	activeRules := getActiveAssignmentRules(g.GetAssignmentRules())
 	if cnt := len(activeRules); maxARs > 0 && cnt > maxARs {
-		return serviceerror.NewFailedPrecondition(fmt.Sprintf("update exceeds number of assignment rules permitted in namespace (%v/%v)", cnt, maxARs))
+		return errExceedsMaxAssignmentRules(cnt, maxARs)
 	}
 	if requireUnconditional && !containsUnconditional(activeRules) {
-		return serviceerror.NewFailedPrecondition("there must exist at least one fully-ramped 'unconditional' assignment rule, use force=true to bypass this requirement")
+		return errRequireUnconditionalAssignmentRule
 	}
 	return nil
 }
@@ -346,17 +361,15 @@ func checkAssignmentConditions(g *persistencespb.VersioningData, maxARs int, req
 func checkRedirectConditions(g *persistencespb.VersioningData, maxRRs, maxChain int) error {
 	activeRules := getActiveRedirectRules(g.GetRedirectRules())
 	if maxRRs > 0 && len(activeRules) > maxRRs {
-		return serviceerror.NewFailedPrecondition(
-			fmt.Sprintf("update exceeds number of redirect rules permitted in namespace (%v/%v)", len(activeRules), maxRRs))
+		return errExceedsMaxRedirectRules(len(activeRules), maxRRs)
 	}
 	if isCyclic(activeRules) {
-		return serviceerror.NewFailedPrecondition("update would break acyclic requirement")
+		return errIsCyclic
 	}
 	for _, r := range activeRules {
 		upstream := getUpstreamBuildIds(r.GetRule().GetTargetBuildId(), activeRules)
 		if len(upstream)+1 > maxChain {
-			return serviceerror.NewFailedPrecondition(
-				fmt.Sprintf("update exceeds number of chained redirect rules permitted in namespace (%v/%v)", len(upstream), maxChain))
+			return errExceedsMaxRuleChain(len(upstream)+1, maxChain)
 		}
 	}
 	return nil

--- a/service/matching/version_rule_test.go
+++ b/service/matching/version_rule_test.go
@@ -267,9 +267,10 @@ func TestInsertAssignmentRuleMaxRules(t *testing.T) {
 	// insert fourth --> error
 	_, err = insertAssignmentRule(mkAssignmentRule("1", nil), data, clock, 0, maxRules)
 	assert.Error(t, err)
+	assert.Equal(t, errExceedsMaxAssignmentRules(4, maxRules), err)
 }
 
-// Test requirement that target id isn't in a version set (success and failure)
+// Test requirement that target id isn't in a version set
 func TestInsertAssignmentRuleInVersionSet(t *testing.T) {
 	t.Parallel()
 	clock := hlc.Zero(1)
@@ -278,13 +279,10 @@ func TestInsertAssignmentRuleInVersionSet(t *testing.T) {
 	// target 0 --> failure
 	_, err := insertAssignmentRule(mkAssignmentRule("0", nil), data, clock, 0, ignoreMaxRules)
 	assert.Error(t, err)
-
-	// insert 1 --> success
-	_, err = insertAssignmentRule(mkAssignmentRule("1", nil), data, clock, 0, ignoreMaxRules)
-	assert.NoError(t, err)
+	assert.Equal(t, errTargetIsVersionSetMember, err)
 }
 
-func TestInsertAssignmentRuleTerminalBuildID(t *testing.T) {
+func TestInsertAssignmentRuleRampedRuleIsRedirectSource(t *testing.T) {
 	t.Parallel()
 	clock := hlc.Zero(1)
 	data, err := insertRedirectRule(mkRedirectRule("0", "1"), mkInitialData(0, clock), clock, ignoreMaxRules, ignoreMaxChain)
@@ -293,10 +291,39 @@ func TestInsertAssignmentRuleTerminalBuildID(t *testing.T) {
 	// insert 1 --> failure
 	_, err = insertAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(10)), data, clock, 0, ignoreMaxRules)
 	assert.Error(t, err)
+	assert.Equal(t, errRampedAssignmentRuleIsRedirectRuleSource, err)
+}
 
-	// insert 2 --> success
-	_, err = insertAssignmentRule(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(10)), data, clock, 0, ignoreMaxRules)
-	assert.NoError(t, err)
+func TestInsertAssignmentRuleInvalidNegativeIndex(t *testing.T) {
+	t.Parallel()
+	clock := hlc.Zero(1)
+	data := mkInitialData(0, clock)
+
+	// insert @ -1 --> failure
+	_, err := insertAssignmentRule(mkAssignmentRule("0", nil), data, clock, -1, ignoreMaxRules)
+	assert.Error(t, err)
+	assert.Equal(t, errInvalidNegativeIndex, err)
+}
+
+func TestInsertAssignmentRuleInvalidRampPercentage(t *testing.T) {
+	t.Parallel()
+	clock := hlc.Zero(1)
+	data := mkInitialData(0, clock)
+
+	// insert with ramp percent < 0 --> failure
+	_, err := insertAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(-1)), data, clock, 0, ignoreMaxRules)
+	assert.Error(t, err)
+	assert.Equal(t, errInvalidRampPercentage, err)
+
+	// insert with ramp percent == 100 --> failure
+	_, err = insertAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(100)), data, clock, 0, ignoreMaxRules)
+	assert.Error(t, err)
+	assert.Equal(t, errInvalidRampPercentage, err)
+
+	// insert with ramp percent > 100 --> failure
+	_, err = insertAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(101)), data, clock, 0, ignoreMaxRules)
+	assert.Error(t, err)
+	assert.Equal(t, errInvalidRampPercentage, err)
 }
 
 func TestReplaceAssignmentRuleBasic(t *testing.T) {
@@ -370,13 +397,10 @@ func TestReplaceAssignmentRuleInVersionSet(t *testing.T) {
 	// replace 0 --> failure
 	_, err = replaceAssignmentRule(mkAssignmentRule("0", nil), data, clock, 0, false)
 	assert.Error(t, err)
-
-	// replace 3 --> success
-	_, err = replaceAssignmentRule(mkAssignmentRule("3", nil), data, clock, 0, false)
-	assert.NoError(t, err)
+	assert.Equal(t, errTargetIsVersionSetMember, err)
 }
 
-func TestReplaceAssignmentRuleTerminalBuildID(t *testing.T) {
+func TestReplaceAssignmentRuleRampedRuleIsRedirectSource(t *testing.T) {
 	t.Parallel()
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
@@ -392,10 +416,7 @@ func TestReplaceAssignmentRuleTerminalBuildID(t *testing.T) {
 	_, err := replaceAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(10)), data, clock, 0, false)
 	t.Log(err)
 	assert.Error(t, err)
-
-	// replace with target isSource and ramp == nil --> success
-	_, err = replaceAssignmentRule(mkAssignmentRule("0", nil), data, clock, 0, false)
-	assert.NoError(t, err)
+	assert.Equal(t, errRampedAssignmentRuleIsRedirectRuleSource, err)
 }
 
 func TestReplaceAssignmentRuleTestRequireUnconditional(t *testing.T) {
@@ -403,13 +424,9 @@ func TestReplaceAssignmentRuleTestRequireUnconditional(t *testing.T) {
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 	var err error
-
-	// replace filtered rule with filtered rule --> success
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
 		mkAssignmentRulePersistence(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(10)), clock, nil),
 	}
-	data, err = replaceAssignmentRule(mkAssignmentRule("2", mkNewAssignmentPercentageRamp(20)), data, clock, 0, false)
-	assert.NoError(t, err)
 
 	// replace unfiltered rule with filtered rule --> failure
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
@@ -417,10 +434,54 @@ func TestReplaceAssignmentRuleTestRequireUnconditional(t *testing.T) {
 	}
 	_, err = replaceAssignmentRule(mkAssignmentRule("2", mkNewAssignmentPercentageRamp(20)), data, clock, 0, false)
 	assert.Error(t, err)
+	assert.Equal(t, errRequireUnconditionalAssignmentRule, err)
 
 	// same as above but with force --> success
 	_, err = replaceAssignmentRule(mkAssignmentRule("4", mkNewAssignmentPercentageRamp(20)), data, clock, 0, true)
 	assert.NoError(t, err)
+}
+
+func TestReplaceAssignmentRuleIndexOutOfBounds(t *testing.T) {
+	t.Parallel()
+	clock := hlc.Zero(1)
+	data := mkInitialData(0, clock)
+	data.AssignmentRules = []*persistencepb.AssignmentRule{
+		mkAssignmentRulePersistence(mkAssignmentRule("1", nil), clock, nil),
+	}
+
+	// replace @ -1 --> failure
+	_, err := replaceAssignmentRule(mkAssignmentRule("0", nil), data, clock, -1, false)
+	assert.Error(t, err)
+	assert.Equal(t, errAssignmentRuleIndexOutOfBounds(-1, len(data.AssignmentRules)), err)
+
+	// replace @ 1 --> failure
+	_, err = replaceAssignmentRule(mkAssignmentRule("0", nil), data, clock, 1, false)
+	assert.Error(t, err)
+	assert.Equal(t, errAssignmentRuleIndexOutOfBounds(1, len(data.AssignmentRules)), err)
+}
+
+func TestReplaceAssignmentRuleInvalidRampPercentage(t *testing.T) {
+	t.Parallel()
+	clock := hlc.Zero(1)
+	data := mkInitialData(0, clock)
+	data.AssignmentRules = []*persistencepb.AssignmentRule{
+		mkAssignmentRulePersistence(mkAssignmentRule("1", nil), clock, nil),
+	}
+
+	// replace with ramp percent < 0 --> failure
+	_, err := replaceAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(-1)), data, clock, 0, false)
+	assert.Error(t, err)
+	assert.Equal(t, errInvalidRampPercentage, err)
+
+	// replace with ramp percent == 100 --> failure
+	_, err = replaceAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(100)), data, clock, 0, false)
+	assert.Error(t, err)
+	assert.Equal(t, errInvalidRampPercentage, err)
+
+	// replace with ramp percent > 100 --> failure
+	_, err = replaceAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(101)), data, clock, 0, false)
+	assert.Error(t, err)
+	assert.Equal(t, errInvalidRampPercentage, err)
 }
 
 func TestDeleteAssignmentRuleBasic(t *testing.T) {
@@ -466,18 +527,14 @@ func TestDeleteAssignmentRuleBasic(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestDeleteAssignmentRuleTestrequireUnconditional(t *testing.T) {
+func TestDeleteAssignmentRuleTestRequireUnconditional(t *testing.T) {
 	t.Parallel()
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 	var err error
-
-	// delete filtered rule --> success
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
 		mkAssignmentRulePersistence(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(10)), clock, nil),
 	}
-	_, err = deleteAssignmentRule(data, clock, 0, false)
-	assert.NoError(t, err)
 
 	// delete only unfiltered rule --> failure
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
@@ -485,6 +542,7 @@ func TestDeleteAssignmentRuleTestrequireUnconditional(t *testing.T) {
 	}
 	_, err = deleteAssignmentRule(data, clock, 0, false)
 	assert.Error(t, err)
+	assert.Equal(t, errRequireUnconditionalAssignmentRule, err)
 
 	// same as above but with force --> success
 	_, err = deleteAssignmentRule(data, clock, 0, true)
@@ -497,6 +555,25 @@ func TestDeleteAssignmentRuleTestrequireUnconditional(t *testing.T) {
 	}
 	_, err = deleteAssignmentRule(data, clock, 0, false)
 	assert.NoError(t, err)
+}
+
+func TestDeleteAssignmentRuleIndexOutOfBounds(t *testing.T) {
+	t.Parallel()
+	clock := hlc.Zero(1)
+	data := mkInitialData(0, clock)
+	data.AssignmentRules = []*persistencepb.AssignmentRule{
+		mkAssignmentRulePersistence(mkAssignmentRule("1", nil), clock, nil),
+	}
+
+	// delete @ -1 --> failure
+	_, err := deleteAssignmentRule(data, clock, -1, false)
+	assert.Error(t, err)
+	assert.Equal(t, errAssignmentRuleIndexOutOfBounds(-1, len(data.AssignmentRules)), err)
+
+	// delete @ 1 --> failure
+	_, err = deleteAssignmentRule(data, clock, 1, false)
+	assert.Error(t, err)
+	assert.Equal(t, errAssignmentRuleIndexOutOfBounds(1, len(data.AssignmentRules)), err)
 }
 
 func TestInsertRedirectRuleBasic(t *testing.T) {
@@ -550,6 +627,7 @@ func TestInsertRedirectRuleMaxRules(t *testing.T) {
 	// insert fourth --> error
 	_, err = insertRedirectRule(mkRedirectRule("10", "20"), data, clock, maxRules, ignoreMaxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errExceedsMaxRedirectRules(4, maxRules), err)
 }
 
 func TestInsertRedirectRuleInVersionSet(t *testing.T) {
@@ -561,21 +639,15 @@ func TestInsertRedirectRuleInVersionSet(t *testing.T) {
 	// insert with source build id "0" --> failure
 	_, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errSourceIsVersionSetMember, err)
 
 	// insert with target build id "0" --> failure
 	_, err = insertRedirectRule(mkRedirectRule("1", "0"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.Error(t, err)
-
-	// insert with non-zero source build id --> success
-	_, err = insertRedirectRule(mkRedirectRule("1", "2"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
-	assert.NoError(t, err)
-
-	// insert with non-zero target build id --> success
-	_, err = insertRedirectRule(mkRedirectRule("2", "1"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
-	assert.NoError(t, err)
+	assert.Equal(t, errTargetIsVersionSetMember, err)
 }
 
-func TestInsertRedirectRuleSourceIsRampedAssignmentRuleTarget(t *testing.T) {
+func TestInsertRedirectRuleSourceIsConditionalAssignmentRuleTarget(t *testing.T) {
 	t.Parallel()
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
@@ -587,10 +659,7 @@ func TestInsertRedirectRuleSourceIsRampedAssignmentRuleTarget(t *testing.T) {
 	// insert redirect rule with target 1 --> failure
 	_, err := insertRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.Error(t, err)
-
-	// insert redirect rule with target 2 --> success
-	_, err = insertRedirectRule(mkRedirectRule("2", "0"), data, clock, ignoreMaxRules, ignoreMaxChain)
-	assert.NoError(t, err)
+	assert.Equal(t, errSourceIsConditionalAssignmentRuleTarget, err)
 }
 
 func TestInsertRedirectRuleAlreadyExists(t *testing.T) {
@@ -605,6 +674,7 @@ func TestInsertRedirectRuleAlreadyExists(t *testing.T) {
 	// insert with source build id "0" --> failure
 	_, err = insertRedirectRule(mkRedirectRule("0", "6"), data, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errSourceAlreadyExists("0", "1"), err)
 }
 
 func TestInsertRedirectRuleCreateCycle(t *testing.T) {
@@ -615,6 +685,7 @@ func TestInsertRedirectRuleCreateCycle(t *testing.T) {
 	// insert with source -> target == "0" -> "0" --> failure
 	_, err := insertRedirectRule(mkRedirectRule("0", "0"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errIsCyclic, err)
 
 	// insert with source -> target == "0" -> "1" --> success
 	data, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
@@ -623,6 +694,7 @@ func TestInsertRedirectRuleCreateCycle(t *testing.T) {
 	// insert with source build id "1" -> "0" --> failure
 	_, err = insertRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxRules, ignoreMaxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errIsCyclic, err)
 }
 
 func TestInsertRedirectRuleMaxChain(t *testing.T) {
@@ -645,6 +717,7 @@ func TestInsertRedirectRuleMaxChain(t *testing.T) {
 	// 4 ---> 5 ---> 6 ---> 7
 	_, err = insertRedirectRule(mkRedirectRule("6", "7"), data, clock, ignoreMaxRules, maxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errExceedsMaxRuleChain(4, maxChain), err)
 }
 
 func TestReplaceRedirectRuleBasic(t *testing.T) {
@@ -694,10 +767,7 @@ func TestReplaceRedirectRuleInVersionSet(t *testing.T) {
 	// replace with target 0 --> failure
 	_, err = replaceRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
-
-	// replace with non-zero target --> success
-	_, err = replaceRedirectRule(mkRedirectRule("1", "10"), data, clock, ignoreMaxChain)
-	assert.NoError(t, err)
+	assert.Equal(t, errTargetIsVersionSetMember, err)
 }
 
 func TestReplaceRedirectRuleCreateCycle(t *testing.T) {
@@ -713,15 +783,19 @@ func TestReplaceRedirectRuleCreateCycle(t *testing.T) {
 
 	_, err = replaceRedirectRule(mkRedirectRule("0", "0"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errIsCyclic, err)
 
 	_, err = replaceRedirectRule(mkRedirectRule("2", "0"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errIsCyclic, err)
 
 	_, err = replaceRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errIsCyclic, err)
 
 	_, err = replaceRedirectRule(mkRedirectRule("2", "1"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errIsCyclic, err)
 }
 
 func TestReplaceRedirectRuleMaxChain(t *testing.T) {
@@ -730,30 +804,23 @@ func TestReplaceRedirectRuleMaxChain(t *testing.T) {
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 
-	// insert (2->3)
-	// 2 ---> 3
-	data, err := insertRedirectRule(mkRedirectRule("2", "3"), data, clock, ignoreMaxRules, maxChain)
-	assert.NoError(t, err)
-
-	// insert (4->5)
-	// 2 ---> 3, 4 ---> 5
-	data, err = insertRedirectRule(mkRedirectRule("4", "5"), data, clock, ignoreMaxRules, maxChain)
-	assert.NoError(t, err)
-
-	// insert (5->6)
 	// 2 ---> 3, 4 ---> 5 ---> 6
-	data, err = insertRedirectRule(mkRedirectRule("5", "6"), data, clock, ignoreMaxRules, maxChain)
-	assert.NoError(t, err)
+	data.RedirectRules = []*persistencepb.RedirectRule{
+		mkRedirectRulePersistence(mkRedirectRule("2", "3"), clock, nil),
+		mkRedirectRulePersistence(mkRedirectRule("4", "5"), clock, nil),
+		mkRedirectRulePersistence(mkRedirectRule("5", "6"), clock, nil),
+	}
 
 	// replace(2, new_target=1)
 	// 2 ---> 1, 4 ---> 5 ---> 6
-	data, err = replaceRedirectRule(mkRedirectRule("2", "1"), data, clock, maxChain)
+	data, err := replaceRedirectRule(mkRedirectRule("2", "1"), data, clock, maxChain)
 	assert.NoError(t, err)
 
 	// replace(2, new_target=4)
 	// 2 ---> 4 ---> 5 ---> 6
 	_, err = replaceRedirectRule(mkRedirectRule("2", "4"), data, clock, maxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errExceedsMaxRuleChain(4, maxChain), err)
 }
 
 func TestReplaceRedirectRuleNotFound(t *testing.T) {
@@ -765,6 +832,7 @@ func TestReplaceRedirectRuleNotFound(t *testing.T) {
 	// fails because no rules to replace
 	_, err = replaceRedirectRule(mkRedirectRule("1", "100"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errSourceNotFound("1"), err)
 
 	data.RedirectRules = []*persistencepb.RedirectRule{
 		mkRedirectRulePersistence(mkRedirectRule("0", "1"), clock, nil),
@@ -773,6 +841,7 @@ func TestReplaceRedirectRuleNotFound(t *testing.T) {
 	// fails because source doesnt exist
 	_, err = replaceRedirectRule(mkRedirectRule("1", "100"), data, clock, ignoreMaxChain)
 	assert.Error(t, err)
+	assert.Equal(t, errSourceNotFound("1"), err)
 }
 
 func TestDeleteRedirectRuleBasic(t *testing.T) {
@@ -814,6 +883,7 @@ func TestDeleteRedirectRuleNotFound(t *testing.T) {
 	// fails because no rules to delete
 	_, err := deleteRedirectRule("1", data, clock)
 	assert.Error(t, err)
+	assert.Equal(t, errSourceNotFound("1"), err)
 
 	// insert a rule to replace
 	data.RedirectRules = []*persistencepb.RedirectRule{
@@ -823,6 +893,7 @@ func TestDeleteRedirectRuleNotFound(t *testing.T) {
 	// fails because no rule with that source
 	_, err = deleteRedirectRule("1", data, clock)
 	assert.Error(t, err)
+	assert.Equal(t, errSourceNotFound("1"), err)
 }
 
 func TestGetWorkerVersioningRules(t *testing.T) {
@@ -1010,6 +1081,7 @@ func TestCommitBuildIDNoRecentPoller(t *testing.T) {
 	// without force --> fail
 	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("10", false), false, ignoreMaxRules)
 	assert.Error(t, err)
+	assert.Equal(t, errNoRecentPollerOnCommitVersion("10"), err)
 
 	// with force --> success
 	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("10", true), false, ignoreMaxRules)
@@ -1032,10 +1104,7 @@ func TestCommitBuildIDInVersionSet(t *testing.T) {
 	// with target 0 --> fail
 	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("0", false), true, ignoreMaxRules)
 	assert.Error(t, err)
-
-	// with target 10 --> success
-	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("10", false), true, ignoreMaxRules)
-	assert.NoError(t, err)
+	assert.Equal(t, errTargetIsVersionSetMember, err)
 }
 
 func TestCommitBuildIDMaxAssignmentRules(t *testing.T) {
@@ -1054,8 +1123,9 @@ func TestCommitBuildIDMaxAssignmentRules(t *testing.T) {
 	var err error
 
 	// commit a new target, no rules to be deleted --> fail
-	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("1000", false), false, maxRules)
+	_, err = CommitBuildID(clock2, data, mkNewCommitBuildIdReq("1000", false), true, maxRules)
 	assert.Error(t, err)
+	assert.Equal(t, errExceedsMaxAssignmentRules(4, maxRules), err)
 }
 
 /*


### PR DESCRIPTION
## What changed?
- Define named version rule errors
- Add unit tests for errors that were previously untested

## Why?
So that the error messages can be standardized when they are used repeatedly, and so that it is easier to tell whether all errors are covered by the unit tests

## How did you test it?
Unit tests