### PR TITLE
Validate ListSchedulesRequest query field

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/converter.go
+++ b/common/persistence/visibility/store/elasticsearch/converter.go
@@ -45,7 +45,7 @@ var allowedComparisonOperators = map[string]struct{}{
 	sqlparser.NotStartsWithStr: {},
 }
 
-func newQueryConverter(
+func NewQueryConverter(
 	fnInterceptor query.FieldNameInterceptor,
 	fvInterceptor query.FieldValuesInterceptor,
 ) *query.Converter {

--- a/common/persistence/visibility/store/elasticsearch/converter_test.go
+++ b/common/persistence/visibility/store/elasticsearch/converter_test.go
@@ -130,7 +130,7 @@ var supportedWhereGroupByCases = map[string]struct {
 }
 
 func TestSupportedSelectWhere(t *testing.T) {
-	c := newQueryConverter(nil, nil)
+	c := NewQueryConverter(nil, nil)
 
 	for sql, expectedJson := range supportedWhereCases {
 		queryParams, err := c.ConvertWhereOrderBy(sql)
@@ -144,7 +144,7 @@ func TestSupportedSelectWhere(t *testing.T) {
 }
 
 func TestEmptySelectWhere(t *testing.T) {
-	c := newQueryConverter(nil, nil)
+	c := NewQueryConverter(nil, nil)
 
 	queryParams, err := c.ConvertWhereOrderBy("")
 	assert.NoError(t, err)
@@ -161,7 +161,7 @@ func TestEmptySelectWhere(t *testing.T) {
 }
 
 func TestSupportedSelectWhereOrder(t *testing.T) {
-	c := newQueryConverter(nil, nil)
+	c := NewQueryConverter(nil, nil)
 
 	for sql, expectedJson := range supportedWhereOrderCases {
 		queryParams, err := c.ConvertWhereOrderBy(sql)
@@ -182,7 +182,7 @@ func TestSupportedSelectWhereOrder(t *testing.T) {
 }
 
 func TestSupportedSelectWhereGroupBy(t *testing.T) {
-	c := newQueryConverter(nil, nil)
+	c := NewQueryConverter(nil, nil)
 
 	for sql, expectedJson := range supportedWhereGroupByCases {
 		queryParams, err := c.ConvertWhereOrderBy(sql)
@@ -200,7 +200,7 @@ func TestSupportedSelectWhereGroupBy(t *testing.T) {
 }
 
 func TestErrors(t *testing.T) {
-	c := newQueryConverter(nil, nil)
+	c := NewQueryConverter(nil, nil)
 	for sql, expectedErrMessage := range errorCases {
 		_, err := c.ConvertSql(sql)
 		assert.Contains(t, err.Error(), expectedErrMessage, sql)

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -886,7 +886,7 @@ func (s *visibilityStore) convertQuery(
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to read search attribute types: %v", err))
 	}
 	nameInterceptor := newNameInterceptor(namespace, s.index, saTypeMap, s.searchAttributesMapperProvider)
-	queryConverter := newQueryConverter(
+	queryConverter := NewQueryConverter(
 		nameInterceptor,
 		NewValuesInterceptor(namespace, saTypeMap, s.searchAttributesMapperProvider),
 	)

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3383,6 +3383,9 @@ func (wh *WorkflowHandler) ListSchedules(
 
 	query := ""
 	if strings.TrimSpace(request.Query) != "" {
+		if err := scheduler.ValidateVisibilityQuery(request.Query); err != nil {
+			return nil, err
+		}
 		query = fmt.Sprintf("%s AND (%s)", scheduler.VisibilityBaseListQuery, request.Query)
 	} else {
 		query = scheduler.VisibilityBaseListQuery

--- a/service/worker/scheduler/query.go
+++ b/service/worker/scheduler/query.go
@@ -1,0 +1,84 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package scheduler
+
+import (
+	"errors"
+	"fmt"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
+	"go.temporal.io/server/common/persistence/visibility/store/query"
+	"go.temporal.io/server/common/searchattribute"
+	"golang.org/x/exp/maps"
+)
+
+type (
+	fieldNameAggInterceptor struct {
+		names map[string]bool
+	}
+)
+
+var _ query.FieldNameInterceptor = (*fieldNameAggInterceptor)(nil)
+
+func (i *fieldNameAggInterceptor) Name(name string, _ query.FieldNameUsage) (string, error) {
+	if i != nil {
+		i.names[name] = true
+	}
+	return name, nil
+}
+
+func newFieldNameAggInterceptor() *fieldNameAggInterceptor {
+	return &fieldNameAggInterceptor{
+		names: make(map[string]bool),
+	}
+}
+
+func ValidateVisibilityQuery(queryString string) error {
+	fields, err := getQueryFields(queryString)
+	if err != nil {
+		return err
+	}
+	for _, field := range fields {
+		if searchattribute.IsReserved(field) && field != searchattribute.TemporalSchedulePaused {
+			return serviceerror.NewInvalidArgument(
+				fmt.Sprintf("invalid query filter for schedules: cannot filter on %q", field),
+			)
+		}
+	}
+	return nil
+}
+
+func getQueryFields(queryString string) ([]string, error) {
+	fnInterceptor := newFieldNameAggInterceptor()
+	queryConverter := elasticsearch.NewQueryConverter(fnInterceptor, nil)
+	_, err := queryConverter.ConvertWhereOrderBy(queryString)
+	if err != nil {
+		var converterErr *query.ConverterError
+		if errors.As(err, &converterErr) {
+			return nil, converterErr.ToInvalidArgument()
+		}
+		return nil, err
+	}
+	return maps.Keys(fnInterceptor.names), nil
+}

--- a/service/worker/scheduler/query.go
+++ b/service/worker/scheduler/query.go
@@ -27,10 +27,11 @@ import (
 	"fmt"
 
 	"go.temporal.io/api/serviceerror"
+	"golang.org/x/exp/maps"
+
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/searchattribute"
-	"golang.org/x/exp/maps"
 )
 
 type (
@@ -42,9 +43,7 @@ type (
 var _ query.FieldNameInterceptor = (*fieldNameAggInterceptor)(nil)
 
 func (i *fieldNameAggInterceptor) Name(name string, _ query.FieldNameUsage) (string, error) {
-	if i != nil {
-		i.names[name] = true
-	}
+	i.names[name] = true
 	return name, nil
 }
 

--- a/service/worker/scheduler/query_test.go
+++ b/service/worker/scheduler/query_test.go
@@ -1,0 +1,193 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/persistence/visibility/store/query"
+)
+
+func TestFieldNameAggInterceptor(t *testing.T) {
+	s := require.New(t)
+	fnInterceptor := newFieldNameAggInterceptor()
+
+	_, err := fnInterceptor.Name("foo", query.FieldNameFilter)
+	s.NoError(err)
+	s.Equal(map[string]bool{"foo": true}, fnInterceptor.names)
+
+	_, err = fnInterceptor.Name("bar", query.FieldNameFilter)
+	s.NoError(err)
+	s.Equal(map[string]bool{"foo": true, "bar": true}, fnInterceptor.names)
+
+	_, err = fnInterceptor.Name("foo", query.FieldNameFilter)
+	s.NoError(err)
+	s.Equal(map[string]bool{"foo": true, "bar": true}, fnInterceptor.names)
+}
+
+func TestGetQueryFields(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          string
+		expectedFields []string
+		expectedErrMsg string
+	}{
+		{
+			name:           "empty query string",
+			input:          "",
+			expectedFields: []string{},
+			expectedErrMsg: "",
+		},
+		{
+			name:           "filter custom search attribute",
+			input:          "CustomKeywordField = 'foo'",
+			expectedFields: []string{"CustomKeywordField"},
+			expectedErrMsg: "",
+		},
+		{
+			name:           "filter multiple custom search attribute",
+			input:          "(CustomKeywordField = 'foo' AND CustomIntField = 123) OR CustomKeywordField = 'bar'",
+			expectedFields: []string{"CustomKeywordField", "CustomIntField"},
+			expectedErrMsg: "",
+		},
+		{
+			name:           "filter TemporalSchedulePaused",
+			input:          "TemporalSchedulePaused = true",
+			expectedFields: []string{"TemporalSchedulePaused"},
+			expectedErrMsg: "",
+		},
+		{
+			name:           "filter TemporalSchedulePaused",
+			input:          "TemporalSchedulePaused = true",
+			expectedFields: []string{"TemporalSchedulePaused"},
+			expectedErrMsg: "",
+		},
+		{
+			name:           "filter TemporalSchedulePaused and custom search attribute",
+			input:          "TemporalSchedulePaused = true AND CustomKeywordField = 'foo'",
+			expectedFields: []string{"TemporalSchedulePaused", "CustomKeywordField"},
+			expectedErrMsg: "",
+		},
+		{
+			name:           "filter system search attribute",
+			input:          "ExecutionDuration > '1s'",
+			expectedFields: []string{"ExecutionDuration"},
+			expectedErrMsg: "",
+		},
+		{
+			name:           "invalid query filter",
+			input:          "CustomKeywordField = foo",
+			expectedFields: nil,
+			expectedErrMsg: "invalid query",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				s := require.New(t)
+				fields, err := getQueryFields(tc.input)
+				if tc.expectedErrMsg == "" {
+					s.NoError(err)
+					s.Equal(len(tc.expectedFields), len(fields))
+					for _, f := range fields {
+						s.Contains(tc.expectedFields, f)
+					}
+				} else {
+					var invalidArgErr *serviceerror.InvalidArgument
+					s.ErrorAs(err, &invalidArgErr)
+					s.ErrorContains(err, tc.expectedErrMsg)
+				}
+			},
+		)
+	}
+}
+
+func TestValidateVisibilityQuery(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          string
+		expectedErrMsg string
+	}{
+		{
+			name:           "empty query string",
+			input:          "",
+			expectedErrMsg: "",
+		},
+		{
+			name:           "filter custom search attribute",
+			input:          "CustomKeywordField = 'foo'",
+			expectedErrMsg: "",
+		},
+		{
+			name:           "filter multiple custom search attribute",
+			input:          "(CustomKeywordField = 'foo' AND CustomIntField = 123) OR CustomKeywordField = 'bar'",
+			expectedErrMsg: "",
+		},
+		{
+			name:           "filter TemporalSchedulePaused",
+			input:          "TemporalSchedulePaused = true",
+			expectedErrMsg: "",
+		},
+		{
+			name:           "filter TemporalSchedulePaused",
+			input:          "TemporalSchedulePaused = true",
+			expectedErrMsg: "",
+		},
+		{
+			name:           "filter TemporalSchedulePaused and custom search attribute",
+			input:          "TemporalSchedulePaused = true AND CustomKeywordField = 'foo'",
+			expectedErrMsg: "",
+		},
+		{
+			name:           "invalid filter system search attribute",
+			input:          "ExecutionDuration > '1s'",
+			expectedErrMsg: "invalid query filter for schedules: cannot filter on \"ExecutionDuration\"",
+		},
+		{
+			name:           "invalid query filter",
+			input:          "CustomKeywordField = foo",
+			expectedErrMsg: "invalid query",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				s := require.New(t)
+				err := ValidateVisibilityQuery(tc.input)
+				if tc.expectedErrMsg == "" {
+					s.NoError(err)
+				} else {
+					var invalidArgErr *serviceerror.InvalidArgument
+					s.ErrorAs(err, &invalidArgErr)
+					s.ErrorContains(err, tc.expectedErrMsg)
+				}
+			},
+		)
+	}
+}

--- a/tests/schedule.go
+++ b/tests/schedule.go
@@ -337,12 +337,21 @@ func (s *ScheduleFunctionalSuite) TestBasics() {
 	listResp, err := s.engine.ListSchedules(NewContext(), &workflowservice.ListSchedulesRequest{
 		Namespace:       s.namespace,
 		MaximumPageSize: 5,
-		Query:           "CustomKeywordField = 'schedule sa value'",
+		Query:           "CustomKeywordField = 'schedule sa value' AND TemporalSchedulePaused = false",
 	})
 	s.NoError(err)
 	s.Len(listResp.Schedules, 1)
 	entry := listResp.Schedules[0]
 	s.Equal(sid, entry.ScheduleId)
+
+	// list schedules with invalid search attribute filter
+
+	_, err = s.engine.ListSchedules(NewContext(), &workflowservice.ListSchedulesRequest{
+		Namespace:       s.namespace,
+		MaximumPageSize: 5,
+		Query:           "ExecutionDuration > '1s'",
+	})
+	s.Error(err)
 
 	// update
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Validate ListSchedulesRequest query field. It's only allowed to filter on custom search attributes and `TemporalSchedulePaused`.

## Why?
<!-- Tell your future self why have you made these changes -->
Schedules is implemented as workflow at this moment, but we don't want to expose all the system search attributes available since the implmenetion might change, and those system search attributes might not exist anymore for the schedule.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.