### PR TITLE
Unify event-reapply implementations

### DIFF
--- a/service/history/ndc/events_reapplier.go
+++ b/service/history/ndc/events_reapplier.go
@@ -34,7 +34,6 @@ import (
 	"go.temporal.io/api/serviceerror"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
-	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/service/history/workflow"
@@ -67,55 +66,22 @@ func NewEventsReapplier(
 	}
 }
 
-// TODO (dan) this function is almost identical to reapplyEvents in workflow_resetter.go: unify them.
 func (r *EventsReapplierImpl) ReapplyEvents(
 	ctx context.Context,
 	ms workflow.MutableState,
 	historyEvents []*historypb.HistoryEvent,
 	runID string,
 ) ([]*historypb.HistoryEvent, error) {
-	var reappliedEvents []*historypb.HistoryEvent
-	for _, event := range historyEvents {
-		switch event.GetEventType() {
-		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
-			dedupResource := definition.NewEventReappliedID(runID, event.GetEventId(), event.GetVersion())
-			if ms.IsResourceDuplicated(dedupResource) {
-				continue
-			}
-			reappliedEvents = append(reappliedEvents, event)
-		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED:
-			// Test coverage: TestNDCEventReapplicationSuite/TestReapplyEvents_AppliedEvent_Update
-			dedupResource := definition.NewEventReappliedID(runID, event.GetEventId(), event.GetVersion())
-			if ms.IsResourceDuplicated(dedupResource) {
-				continue
-			}
-			reappliedEvents = append(reappliedEvents, event)
-		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED:
-			attr := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
-			request := attr.GetAcceptedRequest()
-			if request == nil {
-				// An UpdateAccepted event lacks a request payload if and only if it is preceded by an UpdateAdmitted
-				// event (these always have the payload). If an UpdateAccepted event has no preceding UpdateAdmitted
-				// event then we reapply it (converting it to UpdateAdmitted on the new branch). But if there is a
-				// preceding UpdateAdmitted event then we do not reapply the UpdateAccepted event.
-				continue
-			}
-			// Test coverage: TestNDCEventReapplicationSuite/TestReapplyEvents_AppliedEvent_Update
-			dedupResource := definition.NewEventReappliedID(runID, event.GetEventId(), event.GetVersion())
-			if ms.IsResourceDuplicated(dedupResource) {
-				continue
-			}
-			reappliedEvents = append(reappliedEvents, event)
-		}
-	}
-
-	if len(reappliedEvents) == 0 {
-		return nil, nil
-	}
-
 	// sanity check workflow still running
 	if !ms.IsWorkflowExecutionRunning() {
 		return nil, serviceerror.NewInternal("unable to reapply events to closed workflow.")
+	}
+	reappliedEvents, err := reapplyEvents(ms, historyEvents, nil, runID)
+	if err != nil {
+		return nil, err
+	}
+	if len(reappliedEvents) == 0 {
+		return nil, nil
 	}
 
 	shouldScheduleWorkflowTask := false
@@ -124,36 +90,9 @@ func (r *EventsReapplierImpl) ReapplyEvents(
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
 			signal := event.GetWorkflowExecutionSignaledEventAttributes()
 			shouldScheduleWorkflowTask = shouldScheduleWorkflowTask || !signal.GetSkipGenerateWorkflowTask()
-			if _, err := ms.AddWorkflowExecutionSignaled(
-				signal.GetSignalName(),
-				signal.GetInput(),
-				signal.GetIdentity(),
-				signal.GetHeader(),
-				signal.GetSkipGenerateWorkflowTask(),
-			); err != nil {
-				return nil, err
-			}
-		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED:
-			attr := event.GetWorkflowExecutionUpdateAdmittedEventAttributes()
-			if _, err := ms.AddWorkflowExecutionUpdateAdmittedEvent(
-				attr.GetRequest(),
-				attr.Origin,
-			); err != nil {
-				return nil, err
-			}
-			shouldScheduleWorkflowTask = true
-		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED:
-			attr := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
-			if _, err := ms.AddWorkflowExecutionUpdateAdmittedEvent(
-				attr.GetAcceptedRequest(),
-				enumspb.UPDATE_ADMITTED_EVENT_ORIGIN_REAPPLY,
-			); err != nil {
-				return nil, err
-			}
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED:
 			shouldScheduleWorkflowTask = true
 		}
-		deDupResource := definition.NewEventReappliedID(runID, event.GetEventId(), event.GetVersion())
-		ms.UpdateDuplicatedResource(deDupResource)
 	}
 
 	// After reapply event, checking if we should schedule a workflow task

--- a/service/history/ndc/events_reapplier_test.go
+++ b/service/history/ndc/events_reapplier_test.go
@@ -190,6 +190,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Noop() {
 	msCurrent := workflow.NewMockMutableState(s.controller)
 	dedupResource := definition.NewEventReappliedID(runID, event.GetEventId(), event.GetVersion())
 	msCurrent.EXPECT().IsResourceDuplicated(dedupResource).Return(true)
+	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	events := []*historypb.HistoryEvent{
 		{EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED},
 		event,

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -714,12 +714,9 @@ func reapplyEvents(
 	excludeUpdate := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE]
 	reappliedEvents := []*historypb.HistoryEvent{}
 	for _, event := range events {
-		if isDuplicate(event) {
-			continue
-		}
 		switch event.GetEventType() {
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
-			if excludeSignal {
+			if excludeSignal || isDuplicate(event) {
 				continue
 			}
 			attr := event.GetWorkflowExecutionSignaledEventAttributes()
@@ -734,7 +731,7 @@ func reapplyEvents(
 			}
 			reappliedEvents = append(reappliedEvents, event)
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED:
-			if excludeUpdate {
+			if excludeUpdate || isDuplicate(event) {
 				continue
 			}
 			attr := event.GetWorkflowExecutionUpdateAdmittedEventAttributes()
@@ -746,7 +743,7 @@ func reapplyEvents(
 			}
 			reappliedEvents = append(reappliedEvents, event)
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED:
-			if excludeUpdate {
+			if excludeUpdate || isDuplicate(event) {
 				continue
 			}
 			attr := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
@@ -767,6 +764,7 @@ func reapplyEvents(
 			reappliedEvents = append(reappliedEvents, event)
 		default:
 			// Other event types are not reapplied.
+			continue
 		}
 		if runIdForDeduplication != "" {
 			deDupResource := definition.NewEventReappliedID(runIdForDeduplication, event.GetEventId(), event.GetVersion())

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -885,7 +885,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 		}
 	}
 
-	err := reapplyEvents(ms, events, nil)
+	_, err := reapplyEvents(ms, events, nil, "")
 	s.NoError(err)
 }
 


### PR DESCRIPTION
## What changed?
Unify two very similar implementations of event-reapply: one used when resetting, and the other used during history event replication conflict resolution.

## Why?
The duplication risked introducing bugs and made the codebase harder to understand and maintain.

## How did you test it?
Existing tests (including those being added in https://github.com/temporalio/temporal/pull/5595)

## Potential risks
History replication / conflict resolution and WorkflowReset

## Is hotfix candidate?
No
