### PR TITLE
dlqv2: fix listing queues and correct docs

### DIFF
--- a/docs/admin/dlq.md
+++ b/docs/admin/dlq.md
@@ -47,13 +47,13 @@ cause them to be retried).
 ## Resolution
 
 ### Deleting Tasks
-To purge a message, execute the command `tdbg dlq --dlq-version v2 purge --dlq-type {type} --last_message_id {message_id}`. 
+To purge a message, execute the command `tdbg dlq --dlq-version v2 purge --dlq-type {type} --last-message-id {message_id}`. 
 Note that this command will purge all messages with an ID less than or equal to the specified `message_id`. 
 The output of this command will have a job token which can be used to manage the purge job.
 Before executing this command, you can list the messages in the queue using the command mentioned in step 6 above to make sure more messages are not purged by mistake.
 
 ### Retrying Tasks
-To merge a message, execute the command `tdbg dlq --dlq-version v2 merge --dlq-type {type} --last_message_id {message_id}`.
+To merge a message, execute the command `tdbg dlq --dlq-version v2 merge --dlq-type {type} --last-message-id {message_id}`.
 This command will merge all messages with an ID less than or equal to `message_id` back into the original queue for reprocessing.
 The output of this command will have a job token that can be used to manage the merge job.
 

--- a/tools/tdbg/util.go
+++ b/tools/tdbg/util.go
@@ -261,10 +261,12 @@ func printTable(items []interface{}, writer io.Writer) error {
 	}
 
 	var fields []string
+	var exportedFields []int
 	t := e.Type()
 	for i := 0; i < e.NumField(); i++ {
 		if exportRgx.MatchString(t.Field(i).Name) {
 			fields = append(fields, t.Field(i).Name)
+			exportedFields = append(exportedFields, i)
 		}
 	}
 
@@ -279,7 +281,7 @@ func printTable(items []interface{}, writer io.Writer) error {
 			item = item.Elem()
 		}
 		var columns []string
-		for j := 0; j < len(fields); j++ {
+		for _, j := range exportedFields {
 			col := item.Field(j)
 			columns = append(columns, fmt.Sprintf("%v", col.Interface()))
 		}


### PR DESCRIPTION
## What changed?

I fixed a bug I introduced into the `dlq list` command for v2 DLQs and corrected a typo in our DLQ docs

## Why?

Listing v2 DLQs panics since my protobuf changes, which means we don't have any automated tests for that functionality.

## How did you test it?
I tested it against a cluster with DLQs

## Potential risks
None

## Documentation
Yes

## Is hotfix candidate?
No?
