### PR TITLE
Fix stale mutable state being captured in update registry

### DIFF
--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -916,13 +916,19 @@ func (c *ContextImpl) ReapplyEvents(
 // TODO: remove `ms` parameter again (added since it's not possible to initialize a new Context with a specific MutableState)
 func (c *ContextImpl) UpdateRegistry(ctx context.Context, ms MutableState) update.Registry {
 	if c.updateRegistry == nil {
-		if ms == nil {
-			ms = c.MutableState
+		var nsIDStr string
+		if c.MutableState != nil {
+			nsIDStr = c.MutableState.GetNamespaceEntry().ID().String()
+		} else {
+			nsIDStr = ms.GetNamespaceEntry().ID().String()
 		}
-
-		nsIDStr := ms.GetNamespaceEntry().ID().String()
 		c.updateRegistry = update.NewRegistry(
-			func() update.Store { return ms },
+			func() update.Store {
+				if c.MutableState != nil {
+					return c.MutableState
+				}
+				return ms
+			},
 			update.WithLogger(c.logger),
 			update.WithMetrics(c.metricsHandler),
 			update.WithTracerProvider(trace.SpanFromContext(ctx).TracerProvider()),


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Use `c.MutableState` every time when possible (when it is not `nil`), and use passed `ms` only when `c.MutableState` is `nil`, which is the case only for `UpdateWithStart` scenario.

## Why?
<!-- Tell your future self why have you made these changes -->
To prevent using of stale mutable state passed in `ms` parameter while creating update registry.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests and fault injection tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.