### PR TITLE
Do not retry namespace level resource exhausted error in service clients

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -337,13 +337,12 @@ func IsServiceClientTransientError(err error) bool {
 
 	switch err := err.(type) {
 	case *serviceerror.ResourceExhausted:
-		if err.Cause != enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW {
-			return true
-		}
+		return err.Scope != enumspb.RESOURCE_EXHAUSTED_SCOPE_NAMESPACE
 	case *serviceerrors.ShardOwnershipLost:
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 func IsServiceHandlerRetryableError(err error) bool {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Do not retry namespace level resource exhausted error in service clients

## Why?
<!-- Tell your future self why have you made these changes -->
- Backoff & retry will increase API latency and trigger alerts.
- Namespace level resource exhausted error even if returned won't count against SLA.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- Yes.
