### PR TITLE
Disable ES track_total_hits

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7.go
@@ -160,7 +160,8 @@ func (c *clientImpl) Get(ctx context.Context, index string, docID string) (*elas
 func (c *clientImpl) Search(ctx context.Context, p *SearchParameters) (*elastic.SearchResult, error) {
 	searchSource := elastic.NewSearchSource().
 		Query(p.Query).
-		SortBy(p.Sorter...)
+		SortBy(p.Sorter...).
+		TrackTotalHits(false)
 
 	if p.PointInTime != nil {
 		searchSource.PointInTime(p.PointInTime)
@@ -192,6 +193,7 @@ func (c *clientImpl) OpenScroll(
 		Index(p.Index).
 		Query(p.Query).
 		SortBy(p.Sorter...).
+		TrackTotalHits(false).
 		KeepAlive(keepAliveInterval)
 	if p.PageSize != 0 {
 		scrollService.Size(p.PageSize)
@@ -263,6 +265,7 @@ func (c *clientImpl) CountGroupBy(
 	searchSource := elastic.NewSearchSource().
 		Query(query).
 		Size(0).
+		TrackTotalHits(false).
 		Aggregation(aggName, agg)
 	return c.esClient.Search(index).SearchSource(searchSource).Do(ctx)
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Set `track_total_hits = false` for all ES queries.

## Why?
<!-- Tell your future self why have you made these changes -->
We don't care about the total number of hits, and it makes queries faster.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
