### PR TITLE
MultiOperation update-only

### DIFF
--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -108,7 +108,7 @@ func Invoke(
 	)
 	if err != nil {
 		// TODO: send per-operation error details
-		return nil, fmt.Errorf("failed create workflow starter: %w", err)
+		return nil, serviceerror.NewUnavailable(fmt.Errorf("failed create workflow starter: %w", err).Error())
 	}
 	workflowCache := workflowConsistencyChecker.GetWorkflowCache()
 	return startAndUpdateWorkflow(ctx, shardContext, workflowCache, starter, updater)
@@ -151,7 +151,7 @@ func updateWorkflow(
 	updateResp, err := updater.OnSuccess(ctx)
 	if err != nil {
 		// TODO: send Update outcome failure instead
-		return nil, fmt.Errorf("failed to complete Workflow Update: %w", err)
+		return nil, serviceerror.NewUnavailable(fmt.Errorf("failed to complete Workflow Update: %w", err).Error())
 	}
 
 	return &historyservice.ExecuteMultiOperationResponse{
@@ -202,7 +202,7 @@ func startAndUpdateWorkflow(
 
 		// a start error occurred
 		// TODO: send per-operation error details
-		return nil, fmt.Errorf("failed to start workflow: %w", err)
+		return nil, serviceerror.NewUnavailable(fmt.Errorf("failed to start workflow: %w", err).Error())
 	}
 
 	// without this, there's no Update registry on the call from Matching back to History
@@ -221,7 +221,7 @@ func startAndUpdateWorkflow(
 	updateResp, err := updater.OnSuccess(ctx)
 	if err != nil {
 		// TODO: send Update outcome failure instead
-		return nil, fmt.Errorf("failed to complete Workflow Update: %w", err)
+		return nil, serviceerror.NewUnavailable(fmt.Errorf("failed to complete Workflow Update: %w", err).Error())
 	}
 
 	return &historyservice.ExecuteMultiOperationResponse{
@@ -256,5 +256,5 @@ func onUpdateError(
 	}
 
 	// TODO: send per-operation error details
-	return nil, fmt.Errorf("failed to update workflow: %w", updateErr)
+	return nil, serviceerror.NewUnavailable(fmt.Errorf("failed to update workflow: %w", updateErr).Error())
 }

--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -140,7 +140,7 @@ func updateWorkflow(
 		nil,
 	)
 
-	// release lock!
+	// release lock since all changes to Workflow have completed here now
 	currentWorkflowLease.GetReleaseFn()(err)
 
 	if err != nil {

--- a/tests/workflow.go
+++ b/tests/workflow.go
@@ -43,6 +43,7 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/testing/testvars"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -985,38 +986,9 @@ func (s *FunctionalSuite) TestWorkflowRetryFailures() {
 }
 
 func (s *FunctionalSuite) TestExecuteMultiOperation() {
-	s.Run("Start Workflow and send Update", func() {
-		tv := testvars.New(s.T().Name())
-
-		request := &workflowservice.ExecuteMultiOperationRequest{
-			Namespace: s.namespace,
-			Operations: []*workflowservice.ExecuteMultiOperationRequest_Operation{
-				{
-					Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_StartWorkflow{
-						StartWorkflow: &workflowservice.StartWorkflowExecutionRequest{
-							RequestId:    uuid.New(),
-							WorkflowId:   tv.WorkflowID(),
-							WorkflowType: tv.WorkflowType(),
-							TaskQueue:    tv.TaskQueue(),
-							Input:        nil,
-							Identity:     tv.WorkerIdentity(),
-						},
-					},
-				},
-				{
-					Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_UpdateWorkflow{
-						UpdateWorkflow: &workflowservice.UpdateWorkflowExecutionRequest{
-							Request: &updatepb.Request{
-								Meta:  &updatepb.Meta{UpdateId: "UPDATE_ID"},
-								Input: &updatepb.Input{Name: "UPDATE"},
-							},
-							WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID()},
-							WaitPolicy:        &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED},
-						},
-					},
-				},
-			},
-		}
+	run := func(tv *testvars.TestVars, request *workflowservice.ExecuteMultiOperationRequest) {
+		capture := s.testCluster.host.captureMetricsHandler.StartCapture()
+		defer s.testCluster.host.captureMetricsHandler.StopCapture(capture)
 
 		poller := &TaskPoller{
 			Engine:    s.engine,
@@ -1044,7 +1016,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 		_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 		s.NoError(err)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		select {
 		case <-ctx.Done():
@@ -1057,6 +1029,91 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 
 			updateRes := resp.Responses[1].Response.(*workflowservice.ExecuteMultiOperationResponse_Response_UpdateWorkflow).UpdateWorkflow
 			s.NotZero(updateRes.Outcome.String())
+
+			// make sure there's no lock contention
+			s.Empty(capture.Snapshot()[metrics.TaskWorkflowBusyCounter.Name()])
 		}
+	}
+
+	s.Run("StartWorkflow + UpdateWorkflow", func() {
+		s.Run("workflow is not running", func() {
+			tv := testvars.New(s.T().Name())
+
+			run(tv,
+				&workflowservice.ExecuteMultiOperationRequest{
+					Namespace: s.namespace,
+					Operations: []*workflowservice.ExecuteMultiOperationRequest_Operation{
+						{
+							Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_StartWorkflow{
+								StartWorkflow: &workflowservice.StartWorkflowExecutionRequest{
+									RequestId:    uuid.New(),
+									WorkflowId:   tv.WorkflowID(),
+									WorkflowType: tv.WorkflowType(),
+									TaskQueue:    tv.TaskQueue(),
+									Identity:     tv.WorkerIdentity(),
+								},
+							},
+						},
+						{
+							Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_UpdateWorkflow{
+								UpdateWorkflow: &workflowservice.UpdateWorkflowExecutionRequest{
+									Request: &updatepb.Request{
+										Meta:  &updatepb.Meta{UpdateId: "UPDATE_ID"},
+										Input: &updatepb.Input{Name: "UPDATE"},
+									},
+									WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID()},
+									WaitPolicy:        &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED},
+								},
+							},
+						},
+					},
+				})
+		})
+
+		s.Run("workflow is running", func() {
+			tv := testvars.New(s.T().Name())
+
+			// start Workflow first
+			startWorkflowReq := &workflowservice.StartWorkflowExecutionRequest{
+				Namespace:    s.namespace,
+				RequestId:    uuid.New(),
+				WorkflowId:   tv.WorkflowID(),
+				WorkflowType: tv.WorkflowType(),
+				TaskQueue:    tv.TaskQueue(),
+				Identity:     tv.WorkerIdentity(),
+			}
+			_, err := s.engine.StartWorkflowExecution(NewContext(), startWorkflowReq)
+			s.NoError(err)
+
+			run(tv,
+				&workflowservice.ExecuteMultiOperationRequest{
+					Namespace: s.namespace,
+					Operations: []*workflowservice.ExecuteMultiOperationRequest_Operation{
+						{
+							Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_StartWorkflow{
+								StartWorkflow: &workflowservice.StartWorkflowExecutionRequest{
+									RequestId:    uuid.New(),
+									WorkflowId:   tv.WorkflowID(),
+									WorkflowType: tv.WorkflowType(),
+									TaskQueue:    tv.TaskQueue(),
+									Identity:     tv.WorkerIdentity(),
+								},
+							},
+						},
+						{
+							Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_UpdateWorkflow{
+								UpdateWorkflow: &workflowservice.UpdateWorkflowExecutionRequest{
+									Request: &updatepb.Request{
+										Meta:  &updatepb.Meta{UpdateId: "UPDATE_ID"},
+										Input: &updatepb.Input{Name: "UPDATE"},
+									},
+									WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID()},
+									WaitPolicy:        &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED},
+								},
+							},
+						},
+					},
+				})
+		})
 	})
 }

--- a/tests/workflow.go
+++ b/tests/workflow.go
@@ -1058,8 +1058,11 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 							Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_UpdateWorkflow{
 								UpdateWorkflow: &workflowservice.UpdateWorkflowExecutionRequest{
 									Request: &updatepb.Request{
-										Meta:  &updatepb.Meta{UpdateId: "UPDATE_ID"},
-										Input: &updatepb.Input{Name: "UPDATE"},
+										Meta: &updatepb.Meta{UpdateId: tv.UpdateID("1")},
+										Input: &updatepb.Input{
+											Name: tv.Any().String(),
+											Args: tv.Any().Payloads(),
+										},
 									},
 									WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID()},
 									WaitPolicy:        &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED},


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Adds support to MultiOperation to _not start_ a Workflow when it's running already and instead just _update_ it.

_Note that the error handling is still incomplete and will be addressed in a follow-up PR_

## Why?
<!-- Tell your future self why have you made these changes -->

MultiOperation needs to update the workflow regardless of whether the workflow is running or not.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Added a new functional test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

Feature is still in development phase, ie behind feature flag.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
