### PR TITLE
Remove unused GetNexusIncomingServicesTableVersion persistence method

### DIFF
--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -1194,7 +1194,6 @@ type (
 	NexusIncomingServiceManager interface {
 		Closeable
 		GetName() string
-		GetNexusIncomingServicesTableVersion(ctx context.Context) (int64, error)
 		GetNexusIncomingService(ctx context.Context, request *GetNexusIncomingServiceRequest) (*persistencespb.NexusIncomingServiceEntry, error)
 		ListNexusIncomingServices(ctx context.Context, request *ListNexusIncomingServicesRequest) (*ListNexusIncomingServicesResponse, error)
 		CreateOrUpdateNexusIncomingService(ctx context.Context, request *CreateOrUpdateNexusIncomingServiceRequest) (*CreateOrUpdateNexusIncomingServiceResponse, error)

--- a/common/persistence/data_interfaces_mock.go
+++ b/common/persistence/data_interfaces_mock.go
@@ -1317,21 +1317,6 @@ func (mr *MockNexusIncomingServiceManagerMockRecorder) GetNexusIncomingService(c
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNexusIncomingService", reflect.TypeOf((*MockNexusIncomingServiceManager)(nil).GetNexusIncomingService), ctx, request)
 }
 
-// GetNexusIncomingServicesTableVersion mocks base method.
-func (m *MockNexusIncomingServiceManager) GetNexusIncomingServicesTableVersion(ctx context.Context) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNexusIncomingServicesTableVersion", ctx)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNexusIncomingServicesTableVersion indicates an expected call of GetNexusIncomingServicesTableVersion.
-func (mr *MockNexusIncomingServiceManagerMockRecorder) GetNexusIncomingServicesTableVersion(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNexusIncomingServicesTableVersion", reflect.TypeOf((*MockNexusIncomingServiceManager)(nil).GetNexusIncomingServicesTableVersion), ctx)
-}
-
 // ListNexusIncomingServices mocks base method.
 func (m *MockNexusIncomingServiceManager) ListNexusIncomingServices(ctx context.Context, request *ListNexusIncomingServicesRequest) (*ListNexusIncomingServicesResponse, error) {
 	m.ctrl.T.Helper()

--- a/common/persistence/nexus_incoming_service_manager.go
+++ b/common/persistence/nexus_incoming_service_manager.go
@@ -77,20 +77,6 @@ func (m *nexusIncomingServiceManagerImpl) Close() {
 	m.persistence.Close()
 }
 
-// GetNexusIncomingServicesTableVersion is a convenience method for getting the current nexus_incoming_services table
-// version by calling ListNexusIncomingServices with LastKnownTableVersion=0 and PageSize=0
-func (m *nexusIncomingServiceManagerImpl) GetNexusIncomingServicesTableVersion(ctx context.Context) (int64, error) {
-	tableVersion := int64(0)
-	resp, err := m.ListNexusIncomingServices(ctx, &ListNexusIncomingServicesRequest{
-		LastKnownTableVersion: 0,
-		PageSize:              0,
-	})
-	if resp != nil {
-		tableVersion = resp.TableVersion
-	}
-	return tableVersion, err
-}
-
 func (m *nexusIncomingServiceManagerImpl) GetNexusIncomingService(
 	ctx context.Context,
 	request *GetNexusIncomingServiceRequest,

--- a/common/persistence/persistence_metric_clients.go
+++ b/common/persistence/persistence_metric_clients.go
@@ -1232,18 +1232,6 @@ func (p *nexusIncomingServicePersistenceClient) Close() {
 	p.persistence.Close()
 }
 
-func (p *nexusIncomingServicePersistenceClient) GetNexusIncomingServicesTableVersion(
-	ctx context.Context,
-) (_ int64, retErr error) {
-	caller := headers.GetCallerInfo(ctx).CallerName
-	startTime := time.Now().UTC()
-	defer func() {
-		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
-		p.recordRequestMetrics(metrics.PersistenceListNexusIncomingServicesScope, caller, time.Since(startTime), retErr)
-	}()
-	return p.persistence.GetNexusIncomingServicesTableVersion(ctx)
-}
-
 func (p *nexusIncomingServicePersistenceClient) GetNexusIncomingService(
 	ctx context.Context,
 	request *GetNexusIncomingServiceRequest,

--- a/common/persistence/persistence_rate_limited_clients.go
+++ b/common/persistence/persistence_rate_limited_clients.go
@@ -1055,15 +1055,6 @@ func (p *nexusIncomingServiceRateLimitedPersistenceClient) Close() {
 	p.persistence.Close()
 }
 
-func (p *nexusIncomingServiceRateLimitedPersistenceClient) GetNexusIncomingServicesTableVersion(
-	ctx context.Context,
-) (int64, error) {
-	if err := allow(ctx, "ListNexusIncomingServices", CallerSegmentMissing, p.systemRateLimiter, p.namespaceRateLimiter); err != nil {
-		return 0, err
-	}
-	return p.persistence.GetNexusIncomingServicesTableVersion(ctx)
-}
-
 func (p *nexusIncomingServiceRateLimitedPersistenceClient) GetNexusIncomingService(
 	ctx context.Context,
 	request *GetNexusIncomingServiceRequest,

--- a/common/persistence/persistence_retryable_clients.go
+++ b/common/persistence/persistence_retryable_clients.go
@@ -1220,19 +1220,6 @@ func (p *nexusIncomingServiceRetryablePersistenceClient) Close() {
 	p.persistence.Close()
 }
 
-func (p *nexusIncomingServiceRetryablePersistenceClient) GetNexusIncomingServicesTableVersion(
-	ctx context.Context,
-) (int64, error) {
-	var response int64
-	op := func(ctx context.Context) error {
-		var err error
-		response, err = p.persistence.GetNexusIncomingServicesTableVersion(ctx)
-		return err
-	}
-	err := backoff.ThrottleRetryContext(ctx, op, p.policy, p.isRetryable)
-	return response, err
-}
-
 func (p *nexusIncomingServiceRetryablePersistenceClient) GetNexusIncomingService(
 	ctx context.Context,
 	request *GetNexusIncomingServiceRequest,


### PR DESCRIPTION
We thought we'd use this in the operator service but ended up with a simpler solution.