### PR TITLE
Support happy-path testing for tdbg dlq commands

### DIFF
--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -255,10 +255,10 @@ func AdminDescribeWorkflow(c *cli.Context, clientFactory ClientFactory) error {
 	if resp != nil {
 		fmt.Println(color.Green(c, "Cache mutable state:"))
 		if resp.GetCacheMutableState() != nil {
-			prettyPrintJSONObject(resp.GetCacheMutableState())
+			prettyPrintJSONObject(c, resp.GetCacheMutableState())
 		}
 		fmt.Println(color.Green(c, "Database mutable state:"))
-		prettyPrintJSONObject(resp.GetDatabaseMutableState())
+		prettyPrintJSONObject(c, resp.GetDatabaseMutableState())
 
 		fmt.Println(color.Green(c, "Current branch token:"))
 		versionHistories := resp.GetDatabaseMutableState().GetExecutionInfo().GetVersionHistories()
@@ -272,7 +272,7 @@ func AdminDescribeWorkflow(c *cli.Context, clientFactory ClientFactory) error {
 			if err != nil {
 				fmt.Println(color.Red(c, "Unable to unmarshal current branch token:"), err)
 			} else {
-				prettyPrintJSONObject(&currentBranchToken)
+				prettyPrintJSONObject(c, &currentBranchToken)
 			}
 		}
 
@@ -495,7 +495,7 @@ func AdminDescribeShard(c *cli.Context, clientFactory ClientFactory) error {
 		return fmt.Errorf("unable to initialize Shard Manager: %s", err)
 	}
 
-	prettyPrintJSONObject(response.ShardInfo)
+	prettyPrintJSONObject(c, response.ShardInfo)
 	return nil
 }
 
@@ -541,7 +541,7 @@ func AdminListGossipMembers(c *cli.Context, clientFactory ClientFactory) error {
 		}
 	}
 
-	prettyPrintJSONObject(members)
+	prettyPrintJSONObject(c, members)
 	return nil
 }
 
@@ -571,7 +571,7 @@ func AdminListClusterMembers(c *cli.Context, clientFactory ClientFactory) error 
 
 	members := resp.ActiveMembers
 
-	prettyPrintJSONObject(members)
+	prettyPrintJSONObject(c, members)
 	return nil
 }
 
@@ -620,7 +620,7 @@ func AdminDescribeHistoryHost(c *cli.Context, clientFactory ClientFactory) error
 	if !printFully {
 		resp.ShardIds = nil
 	}
-	prettyPrintJSONObject(resp)
+	prettyPrintJSONObject(c, resp)
 	return nil
 }
 

--- a/tools/tdbg/dlq_service_test.go
+++ b/tools/tdbg/dlq_service_test.go
@@ -117,6 +117,7 @@ func (tc *dlqTestCase) Run(t *testing.T, firstAppRun chan struct{}) {
 	// it at the same time. This workaround only protects the first call because it's ok if subsequent calls happen in
 	// parallel since the help command is already initialized.
 	_, isFirstRun := <-firstAppRun
+	t.Logf("Running %v", runArgs)
 	err := app.Run(runArgs)
 	if isFirstRun {
 		close(firstAppRun)

--- a/tools/tdbg/util.go
+++ b/tools/tdbg/util.go
@@ -29,7 +29,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -47,7 +46,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 )
 
-func prettyPrintJSONObject(o interface{}) {
+func prettyPrintJSONObject(c *cli.Context, o interface{}) {
 	var b []byte
 	var err error
 	if pb, ok := o.(proto.Message); ok {
@@ -61,8 +60,9 @@ func prettyPrintJSONObject(o interface{}) {
 		fmt.Printf("Error when try to print pretty: %v\n", err)
 		fmt.Println(o)
 	}
-	_, _ = os.Stdout.Write(b)
-	fmt.Println()
+
+	_, _ = c.App.Writer.Write(b)
+	c.App.Writer.Write([]byte("\n"))
 }
 
 func getRequiredOption(c *cli.Context, optionName string) (string, error) {
@@ -231,11 +231,11 @@ func paginate[V any](c *cli.Context, paginationFn collection.PaginationFn[V], pa
 		pageItems = append(pageItems, item)
 		if len(pageItems) == pageSize || !iter.HasNext() {
 			if isTableView {
-				if err := printTable(pageItems, os.Stdout); err != nil {
+				if err := printTable(pageItems, c.App.Writer); err != nil {
 					return err
 				}
 			} else {
-				prettyPrintJSONObject(pageItems)
+				prettyPrintJSONObject(c, pageItems)
 			}
 
 			if !more || !showNextPage() {


### PR DESCRIPTION
## What changed?
I added support for correctness tests for our DLQ admin commands.

While here I added two tests for `tdbg dlq list` that _should_ have caught the bug I fixed in #5744

## Why?

We had zero correctness tests before this, only tests for our error handling.

## How did you test it?
I added new tests, of course!

## Potential risks
None

## Documentation
None

## Is hotfix candidate?
No
