### PR TITLE
Allow any visibilityStore + secondaryVisibilityStore combination

### DIFF
--- a/common/config/persistence.go
+++ b/common/config/persistence.go
@@ -75,9 +75,7 @@ func (c *Persistence) Validate() error {
 	// - advancedVisibilityStore (es),    advancedVisibilityStore (es) [via elasticsearch.indices config]
 	//
 	// Invalid dual visibility combinations:
-	// - visibilityStore (advanced sql),  secondaryVisibilityStore (standard, es)
 	// - visibilityStore (advanced sql),  advancedVisibilityStore (es)
-	// - visibilityStore (es),            secondaryVisibilityStore (any)
 	// - visibilityStore (es),            advancedVisibilityStore (es)
 	// - advancedVisibilityStore (es),    secondaryVisibilityStore (any)
 	//
@@ -99,10 +97,9 @@ func (c *Persistence) Validate() error {
 			c.AdvancedVisibilityStore,
 		)
 	}
-	if c.DataStores[c.VisibilityStore].Elasticsearch != nil &&
-		(c.SecondaryVisibilityStore != "" || c.AdvancedVisibilityStore != "") {
+	if c.DataStores[c.VisibilityStore].Elasticsearch != nil && c.AdvancedVisibilityStore != "" {
 		return errors.New(
-			"persistence config: cannot set secondaryVisibilityStore or advancedVisibilityStore " +
+			"persistence config: cannot set advancedVisibilityStore " +
 				"when visibilityStore is setting elasticsearch datastore",
 		)
 	}

--- a/common/persistence/visibility/factory.go
+++ b/common/persistence/visibility/factory.go
@@ -30,9 +30,6 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"
-	"go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql"
-	"go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/persistence/visibility/store"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
@@ -117,21 +114,6 @@ func NewManager(
 	}
 
 	if secondaryVisibilityManager != nil {
-		isPrimaryAdvancedSQL := false
-		isSecondaryAdvancedSQL := false
-		switch visibilityManager.GetStoreNames()[0] {
-		case mysql.PluginName, postgresql.PluginName, postgresql.PluginNamePGX, sqlite.PluginName:
-			isPrimaryAdvancedSQL = true
-		}
-		switch secondaryVisibilityManager.GetStoreNames()[0] {
-		case mysql.PluginName, postgresql.PluginName, postgresql.PluginNamePGX, sqlite.PluginName:
-			isSecondaryAdvancedSQL = true
-		}
-		if isPrimaryAdvancedSQL && !isSecondaryAdvancedSQL {
-			logger.Fatal("invalid config: dual visibility combination not supported")
-			return nil, nil
-		}
-
 		managerSelector := newDefaultManagerSelector(
 			visibilityManager,
 			secondaryVisibilityManager,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Any pair of `visibilityStore` and `secondaryVisibilityStore` is now allowed.

## Why?
<!-- Tell your future self why have you made these changes -->
This change allows migration between Elasticsearch and SQL advanced visibility in both directions.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Checked in staging env.
[defaultManagerSelector](https://github.com/temporalio/temporal/blob/main/common/persistence/visibility/manager_selector.go) is not aware of the underlying datastore of its `visibilityManager` and `secondaryVisibilityManager`.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Different visibility backends may have different restrictions on the number of SearchAttributes and allowed queries. Therefore, additional validation may be required in `CreateSearchAttribute` and `ListWorkflowExecutions`.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
Current version of `How to migrate Visibility database` does not mention any restrictions on the primary and secondary visibility stores.
https://docs.temporal.io/self-hosted-guide/visibility#migrating-visibility-database

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No