### PR TITLE
Don't reapply an update with a conflicting ID

### DIFF
--- a/service/history/api/reapplyevents/api.go
+++ b/service/history/api/reapplyevents/api.go
@@ -177,6 +177,7 @@ func Invoke(
 			reappliedEvents, err := eventsReapplier.ReapplyEvents(
 				ctx,
 				mutableState,
+				context.UpdateRegistry(ctx, mutableState),
 				toReapplyEvents,
 				runID,
 			)

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -5176,7 +5176,7 @@ func (s *engineSuite) TestReapplyEvents_ReturnSuccess() {
 	gceResponse := &persistence.GetCurrentExecutionResponse{RunID: tests.RunID}
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), gomock.Any()).Return(gceResponse, nil)
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
-	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 	err := s.mockHistoryEngine.ReapplyEvents(
 		context.Background(),
@@ -5220,7 +5220,7 @@ func (s *engineSuite) TestReapplyEvents_IgnoreSameVersionEvents() {
 	gceResponse := &persistence.GetCurrentExecutionResponse{RunID: tests.RunID}
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), gomock.Any()).Return(gceResponse, nil)
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
-	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	err := s.mockHistoryEngine.ReapplyEvents(
 		context.Background(),
@@ -5269,7 +5269,7 @@ func (s *engineSuite) TestReapplyEvents_ResetWorkflow() {
 	gceResponse := &persistence.GetCurrentExecutionResponse{RunID: tests.RunID}
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), gomock.Any()).Return(gceResponse, nil).AnyTimes()
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
-	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	s.mockWorkflowResetter.EXPECT().ResetWorkflow(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),

--- a/service/history/ndc/events_reapplier.go
+++ b/service/history/ndc/events_reapplier.go
@@ -79,7 +79,7 @@ func (r *EventsReapplierImpl) ReapplyEvents(
 	if !ms.IsWorkflowExecutionRunning() {
 		return nil, serviceerror.NewInternal("unable to reapply events to closed workflow.")
 	}
-	reappliedEvents, err := reapplyEvents(ms, updateRegistry, historyEvents, nil, runID)
+	reappliedEvents, err := reapplyEvents(ms, &updateRegistry, historyEvents, nil, runID)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/ndc/events_reapplier.go
+++ b/service/history/ndc/events_reapplier.go
@@ -37,6 +37,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/service/history/workflow"
+	"go.temporal.io/server/service/history/workflow/update"
 )
 
 type (
@@ -44,6 +45,7 @@ type (
 		ReapplyEvents(
 			ctx context.Context,
 			ms workflow.MutableState,
+			updateRegistry update.Registry,
 			historyEvents []*historypb.HistoryEvent,
 			runID string,
 		) ([]*historypb.HistoryEvent, error)
@@ -69,6 +71,7 @@ func NewEventsReapplier(
 func (r *EventsReapplierImpl) ReapplyEvents(
 	ctx context.Context,
 	ms workflow.MutableState,
+	updateRegistry update.Registry,
 	historyEvents []*historypb.HistoryEvent,
 	runID string,
 ) ([]*historypb.HistoryEvent, error) {
@@ -76,7 +79,7 @@ func (r *EventsReapplierImpl) ReapplyEvents(
 	if !ms.IsWorkflowExecutionRunning() {
 		return nil, serviceerror.NewInternal("unable to reapply events to closed workflow.")
 	}
-	reappliedEvents, err := reapplyEvents(ms, historyEvents, nil, runID)
+	reappliedEvents, err := reapplyEvents(ms, updateRegistry, historyEvents, nil, runID)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/ndc/events_reapplier_mock.go
+++ b/service/history/ndc/events_reapplier_mock.go
@@ -35,6 +35,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	history "go.temporal.io/api/history/v1"
 	workflow "go.temporal.io/server/service/history/workflow"
+	update "go.temporal.io/server/service/history/workflow/update"
 )
 
 // MockEventsReapplier is a mock of EventsReapplier interface.
@@ -61,16 +62,16 @@ func (m *MockEventsReapplier) EXPECT() *MockEventsReapplierMockRecorder {
 }
 
 // ReapplyEvents mocks base method.
-func (m *MockEventsReapplier) ReapplyEvents(ctx context.Context, ms workflow.MutableState, historyEvents []*history.HistoryEvent, runID string) ([]*history.HistoryEvent, error) {
+func (m *MockEventsReapplier) ReapplyEvents(ctx context.Context, ms workflow.MutableState, updateRegistry update.Registry, historyEvents []*history.HistoryEvent, runID string) ([]*history.HistoryEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReapplyEvents", ctx, ms, historyEvents, runID)
+	ret := m.ctrl.Call(m, "ReapplyEvents", ctx, ms, updateRegistry, historyEvents, runID)
 	ret0, _ := ret[0].([]*history.HistoryEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReapplyEvents indicates an expected call of ReapplyEvents.
-func (mr *MockEventsReapplierMockRecorder) ReapplyEvents(ctx, ms, historyEvents, runID interface{}) *gomock.Call {
+func (mr *MockEventsReapplierMockRecorder) ReapplyEvents(ctx, ms, updateRegistry, historyEvents, runID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReapplyEvents", reflect.TypeOf((*MockEventsReapplier)(nil).ReapplyEvents), ctx, ms, historyEvents, runID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReapplyEvents", reflect.TypeOf((*MockEventsReapplier)(nil).ReapplyEvents), ctx, ms, updateRegistry, historyEvents, runID)
 }

--- a/service/history/ndc/events_reapplier_test.go
+++ b/service/history/ndc/events_reapplier_test.go
@@ -98,8 +98,8 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Signal() {
 	attr := event.GetWorkflowExecutionSignaledEventAttributes()
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
+	msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
 	updateRegistry := update.NewRegistry(func() update.Store { return msCurrent })
-
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 	msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
@@ -147,6 +147,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 	} {
 
 		msCurrent := workflow.NewMockMutableState(s.controller)
+		msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
 		updateRegistry := update.NewRegistry(func() update.Store { return msCurrent })
 		msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 		msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
@@ -192,6 +193,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Noop() {
 	}
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
+	msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
 	updateRegistry := update.NewRegistry(func() update.Store { return msCurrent })
 	dedupResource := definition.NewEventReappliedID(runID, event.GetEventId(), event.GetVersion())
 	msCurrent.EXPECT().IsResourceDuplicated(dedupResource).Return(true)
@@ -233,6 +235,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
 	attr1 := event1.GetWorkflowExecutionSignaledEventAttributes()
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
+	msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
 	updateRegistry := update.NewRegistry(func() update.Store { return msCurrent })
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
@@ -278,6 +281,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Error() {
 	attr := event.GetWorkflowExecutionSignaledEventAttributes()
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
+	msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
 	updateRegistry := update.NewRegistry(func() update.Store { return msCurrent })
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()

--- a/service/history/ndc/events_reapplier_test.go
+++ b/service/history/ndc/events_reapplier_test.go
@@ -36,7 +36,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
-	"go.temporal.io/api/update/v1"
+	updatepb "go.temporal.io/api/update/v1"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/definition"
@@ -44,6 +44,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/service/history/workflow"
+	"go.temporal.io/server/service/history/workflow/update"
 )
 
 type (
@@ -97,6 +98,8 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Signal() {
 	attr := event.GetWorkflowExecutionSignaledEventAttributes()
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
+	updateRegistry := update.NewRegistry(func() update.Store { return msCurrent })
+
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 	msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
@@ -115,7 +118,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Signal() {
 		{EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED},
 		event,
 	}
-	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, events, runID)
+	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, updateRegistry, events, runID)
 	s.NoError(err)
 	s.Equal(1, len(appliedEvent))
 }
@@ -130,7 +133,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 			EventId:   105,
 			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED,
 			Attributes: &historypb.HistoryEvent_WorkflowExecutionUpdateAdmittedEventAttributes{WorkflowExecutionUpdateAdmittedEventAttributes: &historypb.WorkflowExecutionUpdateAdmittedEventAttributes{
-				Request: &update.Request{Input: &update.Input{Args: payloads.EncodeString("update-request-payload")}},
+				Request: &updatepb.Request{Input: &updatepb.Input{Args: payloads.EncodeString("update-request-payload")}},
 				Origin:  enumspb.UPDATE_ADMITTED_EVENT_ORIGIN_UNSPECIFIED,
 			}},
 		},
@@ -138,12 +141,13 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 			EventId:   105,
 			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
 			Attributes: &historypb.HistoryEvent_WorkflowExecutionUpdateAcceptedEventAttributes{WorkflowExecutionUpdateAcceptedEventAttributes: &historypb.WorkflowExecutionUpdateAcceptedEventAttributes{
-				AcceptedRequest: &update.Request{Input: &update.Input{Args: payloads.EncodeString("update-request-payload")}},
+				AcceptedRequest: &updatepb.Request{Input: &updatepb.Input{Args: payloads.EncodeString("update-request-payload")}},
 			}},
 		},
 	} {
 
 		msCurrent := workflow.NewMockMutableState(s.controller)
+		updateRegistry := update.NewRegistry(func() update.Store { return msCurrent })
 		msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 		msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 		msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
@@ -169,7 +173,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 			{EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED},
 			event,
 		}
-		appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, events, runID)
+		appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, updateRegistry, events, runID)
 		s.NoError(err)
 		s.Equal(1, len(appliedEvent))
 	}
@@ -188,6 +192,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Noop() {
 	}
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
+	updateRegistry := update.NewRegistry(func() update.Store { return msCurrent })
 	dedupResource := definition.NewEventReappliedID(runID, event.GetEventId(), event.GetVersion())
 	msCurrent.EXPECT().IsResourceDuplicated(dedupResource).Return(true)
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
@@ -195,7 +200,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Noop() {
 		{EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED},
 		event,
 	}
-	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, events, runID)
+	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, updateRegistry, events, runID)
 	s.NoError(err)
 	s.Equal(0, len(appliedEvent))
 }
@@ -228,6 +233,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
 	attr1 := event1.GetWorkflowExecutionSignaledEventAttributes()
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
+	updateRegistry := update.NewRegistry(func() update.Store { return msCurrent })
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 	msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
@@ -249,7 +255,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
 		event1,
 		event2,
 	}
-	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, events, runID)
+	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, updateRegistry, events, runID)
 	s.NoError(err)
 	s.Equal(1, len(appliedEvent))
 }
@@ -272,6 +278,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Error() {
 	attr := event.GetWorkflowExecutionSignaledEventAttributes()
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
+	updateRegistry := update.NewRegistry(func() update.Store { return msCurrent })
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 	msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
@@ -288,7 +295,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Error() {
 		{EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED},
 		event,
 	}
-	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, events, runID)
+	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, updateRegistry, events, runID)
 	s.Error(err)
 	s.Equal(0, len(appliedEvent))
 }

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -304,6 +304,7 @@ func (r *transactionMgrImpl) backfillWorkflowEventsReapply(
 			if _, err := r.eventsReapplier.ReapplyEvents(
 				ctx,
 				targetWorkflow.GetMutableState(),
+				targetWorkflow.GetContext().UpdateRegistry(ctx, targetWorkflow.GetMutableState()),
 				totalEvents,
 				targetWorkflow.GetMutableState().GetExecutionState().GetRunId(),
 			); err != nil {

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -154,6 +154,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Open()
 	targetWorkflow := NewMockWorkflow(s.controller)
 	weContext := workflow.NewMockContext(s.controller)
 	mutableState := workflow.NewMockMutableState(s.controller)
+	mutableState.EXPECT().VisitUpdates(gomock.Any()).Return()
 	updateRegistry := update.NewRegistry(func() update.Store { return mutableState })
 	var releaseFn wcache.ReleaseCacheFunc = func(error) { releaseCalled = true }
 

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -175,7 +175,7 @@ func (r *workflowResetterImpl) ResetWorkflow(
 
 			if lastVisitedRunID == currentMutableState.GetExecutionState().RunId {
 				for _, event := range currentWorkflowEventsSeq {
-					if _, err := reapplyEvents(resetMutableState, currentUpdateRegistry, event.Events, resetReapplyExcludeTypes, ""); err != nil {
+					if _, err := reapplyEvents(resetMutableState, nil, event.Events, resetReapplyExcludeTypes, ""); err != nil {
 						return err
 					}
 				}
@@ -222,7 +222,7 @@ func (r *workflowResetterImpl) ResetWorkflow(
 	if err := reapplyEventsFn(ctx, resetMS); err != nil {
 		return err
 	}
-	if _, err := reapplyEvents(resetMS, currentUpdateRegistry, additionalReapplyEvents, nil, ""); err != nil {
+	if _, err := reapplyEvents(resetMS, nil, additionalReapplyEvents, nil, ""); err != nil {
 		return err
 	}
 
@@ -689,7 +689,7 @@ func (r *workflowResetterImpl) reapplyWorkflowEvents(
 			return "", err
 		}
 		lastEvents = batch.Events
-		if _, err := reapplyEvents(mutableState, currentUpdateRegistry, lastEvents, resetReapplyExcludeTypes, ""); err != nil {
+		if _, err := reapplyEvents(mutableState, nil, lastEvents, resetReapplyExcludeTypes, ""); err != nil {
 			return "", err
 		}
 	}
@@ -705,7 +705,7 @@ func (r *workflowResetterImpl) reapplyWorkflowEvents(
 
 func reapplyEvents(
 	mutableState workflow.MutableState,
-	updateRegistry update.Registry,
+	targetBranchUpdateRegistry *update.Registry,
 	events []*historypb.HistoryEvent,
 	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
 	runIdForDeduplication string,
@@ -756,7 +756,7 @@ func reapplyEvents(
 				continue
 			}
 			attr := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
-			if updateRegistry.Contains(attr.ProtocolInstanceId) {
+			if targetBranchUpdateRegistry != nil && (*targetBranchUpdateRegistry).Contains(attr.ProtocolInstanceId) {
 				continue
 			}
 			request := attr.GetAcceptedRequest()

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -756,6 +756,9 @@ func reapplyEvents(
 				continue
 			}
 			attr := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
+			if updateRegistry.IsIncomplete(attr.ProtocolInstanceId) {
+				continue
+			}
 			request := attr.GetAcceptedRequest()
 			if request == nil {
 				// An UpdateAccepted event lacks a request payload if and only if it is preceded by an UpdateAdmitted

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -756,7 +756,7 @@ func reapplyEvents(
 				continue
 			}
 			attr := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
-			if updateRegistry.IsIncomplete(attr.ProtocolInstanceId) {
+			if updateRegistry.Contains(attr.ProtocolInstanceId) {
 				continue
 			}
 			request := attr.GetAcceptedRequest()

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -603,6 +603,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithOutCo
 	}, nil)
 
 	mutableState := workflow.NewMockMutableState(s.controller)
+	mutableState.EXPECT().VisitUpdates(gomock.Any()).Return()
 	updateRegistry := update.NewRegistry(func() update.Store { return mutableState })
 
 	lastVisitedRunID, err := s.workflowResetter.reapplyContinueAsNewWorkflowEvents(
@@ -723,6 +724,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithConti
 	_, _ = s.workflowResetter.workflowCache.(*wcache.CacheImpl).PutIfNotExist(resetContextCacheKey, resetContext)
 
 	mutableState := workflow.NewMockMutableState(s.controller)
+	mutableState.EXPECT().VisitUpdates(gomock.Any()).Return()
 	updateRegistry := update.NewRegistry(func() update.Store { return mutableState })
 
 	lastVisitedRunID, err := s.workflowResetter.reapplyContinueAsNewWorkflowEvents(
@@ -789,6 +791,7 @@ func (s *workflowResetterSuite) TestReapplyWorkflowEvents() {
 	}, nil)
 
 	mutableState := workflow.NewMockMutableState(s.controller)
+	mutableState.EXPECT().VisitUpdates(gomock.Any()).Return()
 	updateRegistry := update.NewRegistry(func() update.Store { return mutableState })
 
 	nextRunID, err := s.workflowResetter.reapplyWorkflowEvents(

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -868,7 +868,6 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 	events := []*historypb.HistoryEvent{event1, event2, event3, event4, event5, event6}
 
 	ms := workflow.NewMockMutableState(s.controller)
-	updateRegistry := update.NewRegistry(func() update.Store { return ms })
 
 	for _, event := range events {
 		switch event.GetEventType() {
@@ -896,7 +895,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 		}
 	}
 
-	_, err := reapplyEvents(ms, updateRegistry, events, nil, "")
+	_, err := reapplyEvents(ms, nil, events, nil, "")
 	s.NoError(err)
 }
 

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -81,7 +81,7 @@ type (
 		//   - updates in stateCompleted are ignored.
 		CancelIncomplete(ctx context.Context, reason CancelReason, eventStore EventStore) error
 
-		IsIncomplete(protocolInstanceID string) bool
+		Contains(protocolInstanceID string) bool
 
 		// UpdateFromStore adds updates to the registry from the update store.
 		UpdateFromStore()
@@ -255,12 +255,9 @@ func (r *registry) CancelIncomplete(ctx context.Context, reason CancelReason, ev
 	return nil
 }
 
-// IsIncomplete returns true iff the update ID exists in the registry and is incomplete.
-func (r *registry) IsIncomplete(id string) bool {
-	if upd := r.updates[id]; upd != nil {
-		return upd.isIncomplete()
-	}
-	return false
+// Contains returns true iff the update ID exists in the registry.
+func (r *registry) Contains(id string) bool {
+	return r.updates[id] != nil
 }
 
 // RejectUnprocessed reject all updates that are waiting for workflow task to be completed.

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -81,6 +81,8 @@ type (
 		//   - updates in stateCompleted are ignored.
 		CancelIncomplete(ctx context.Context, reason CancelReason, eventStore EventStore) error
 
+		IsIncomplete(protocolInstanceID string) bool
+
 		// UpdateFromStore adds updates to the registry from the update store.
 		UpdateFromStore()
 
@@ -251,6 +253,14 @@ func (r *registry) CancelIncomplete(ctx context.Context, reason CancelReason, ev
 		}
 	}
 	return nil
+}
+
+// IsIncomplete returns true iff the update ID exists in the registry and is incomplete.
+func (r *registry) IsIncomplete(id string) bool {
+	if upd := r.updates[id]; upd != nil {
+		return upd.isIncomplete()
+	}
+	return false
 }
 
 // RejectUnprocessed reject all updates that are waiting for workflow task to be completed.

--- a/tests/xdc/history_replication_signals_and_updates_test.go
+++ b/tests/xdc/history_replication_signals_and_updates_test.go
@@ -356,10 +356,6 @@ func (s *hrsuTestSuite) TestConflictResolutionReappliesUpdates() {
 // active. Both clusters then accept an update and write it to their own history, but those updates have the same update
 // ID.
 func (s *hrsuTestSuite) TestConflictResolutionReappliesUpdatesSameIds() {
-	// TODO (dan) The event-reapply implementation should drop the update since its update ID conflicts with an
-	// in-flight update. Currently this is not done and hence replication fails with "Update ID update-id is already
-	// present in mutable state"
-	s.T().SkipNow()
 	t, ctx, cancel := s.startHrsuTest()
 	defer cancel()
 
@@ -369,6 +365,21 @@ func (s *hrsuTestSuite) TestConflictResolutionReappliesUpdatesSameIds() {
 	// resolution.
 	t.cluster1.executeHistoryReplicationTasksUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED)
 	t.cluster2.executeHistoryReplicationTasksUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED)
+
+	// Cluster1 has received an update with failover version 2, which superseded its own update.
+	// Cluster2 has received an update from cluster 1 with a lower failover version. Normally, such an update would be
+	// reapplied. But since it has the same update ID as the cluster 1 update, and since that update is not completed,
+	// we must not reapply it.
+	// The result is that both clusters have the same history; the update accepted in cluster 1 has been dropped.
+	for _, c := range []hrsuTestCluster{t.cluster1, t.cluster2} {
+		t.s.HistoryRequire.EqualHistoryEventsAndVersions(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "update-id", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster2-update-input\""}]}}}}
+	`, []int{1, 1, 2, 2, 2}, c.getHistory(ctx))
+	}
 }
 
 // Start update in cluster 1, run it through to acceptance, replicate it to cluster 2, then failover to 2 and complete


### PR DESCRIPTION
## What changed?
- Bug fix: do not reapply an update if it already exists in the registry
- Pass `updateRegistry` down the stack to event-reapply code to make it possible to do the check for duplicates

## Why?
It would be a bug to do so: update IDs must be unique. The situation only arises in split-brain scenarios, when multiple clusters accept an update with the same ID.

## How did you test it?
Functional tests added in PR

## Potential risks
Could break update

## Is hotfix candidate?
No