### PR TITLE
UpdateWorkflow action metric on accept/reject

### DIFF
--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -288,6 +288,8 @@ func (ti *TelemetryInterceptor) emitActionMetric(
 				updates += 1
 			case *updatepb.Rejection:
 				updates += 1
+			case *updatepb.Response:
+				// not billed
 			}
 		}
 		if updates > 0 {

--- a/common/rpc/interceptor/telemetry_test.go
+++ b/common/rpc/interceptor/telemetry_test.go
@@ -31,20 +31,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	commonpb "go.temporal.io/api/common/v1"
 	protocolpb "go.temporal.io/api/protocol/v1"
-	updatepb "go.temporal.io/api/update/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/anypb"
-
-	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/api"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -57,15 +54,6 @@ func TestEmitActionMetric(t *testing.T) {
 	register := namespace.NewMockRegistry(controller)
 	metricsHandler := metrics.NewMockHandler(controller)
 	telemetry := NewTelemetryInterceptor(register, metricsHandler, log.NewNoopLogger())
-
-	var updateAcceptanceMessageBody anypb.Any
-	_ = updateAcceptanceMessageBody.MarshalFrom(&updatepb.Acceptance{})
-
-	var updateRejectionMessageBody anypb.Any
-	_ = updateRejectionMessageBody.MarshalFrom(&updatepb.Rejection{})
-
-	var updateResponseMessageBody anypb.Any
-	_ = updateResponseMessageBody.MarshalFrom(&updatepb.Response{})
 
 	testCases := []struct {
 		methodName        string

--- a/common/rpc/interceptor/telemetry_test.go
+++ b/common/rpc/interceptor/telemetry_test.go
@@ -64,8 +64,8 @@ func TestEmitActionMetric(t *testing.T) {
 	var updateRejectionMessageBody anypb.Any
 	_ = updateRejectionMessageBody.MarshalFrom(&updatepb.Rejection{})
 
-	var updateCompletionMessageBody anypb.Any
-	_ = updateCompletionMessageBody.MarshalFrom(&updatepb.Outcome{})
+	var updateResponseMessageBody anypb.Any
+	_ = updateResponseMessageBody.MarshalFrom(&updatepb.Response{})
 
 	testCases := []struct {
 		methodName        string
@@ -134,7 +134,7 @@ func TestEmitActionMetric(t *testing.T) {
 				Messages: []*protocolpb.Message{
 					{
 						Id:   "MESSAGE_ID",
-						Body: &updateCompletionMessageBody,
+						Body: &updateResponseMessageBody,
 					},
 				},
 			},


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

The `action` metric gives OSS users an estimate for the expected cost when moving to Cloud.

The metric is now tracking Update Workflow actions when receiving an accepted/rejected protocol message from the Worker - instead of the RPC request from the client.

_Additional context: When a Worker accepts or rejects an Update request, it sends back an Acceptance, Rejection or Outcome message._

## Why?
<!-- Tell your future self why have you made these changes -->

Reflects upcoming Cloud bill change.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Added test cases.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
