### PR TITLE
Set proper ScheduleToStart timeout in matching for speculative WFT

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -905,10 +905,17 @@ func (ms *MutableStateImpl) TaskQueueScheduleToStartTimeout(name string) (*taskq
 			NormalName: ms.executionInfo.TaskQueue,
 		}, ms.executionInfo.StickyScheduleToStartTimeout
 	}
+	if ms.executionInfo.WorkflowTaskType == enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE {
+		// Speculative WFT has ScheduleToStartTimeout even on normal task queue.
+		return &taskqueuepb.TaskQueue{
+			Name: ms.executionInfo.TaskQueue,
+			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+		}, durationpb.New(tasks.SpeculativeWorkflowTaskScheduleToStartTimeout)
+	}
 	return &taskqueuepb.TaskQueue{
 		Name: ms.executionInfo.TaskQueue,
 		Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
-	}, ms.executionInfo.WorkflowRunTimeout // No WT ScheduleToStart timeout for normal task queue.
+	}, ms.executionInfo.WorkflowRunTimeout // No WT ScheduleToStart timeout for normal WFT on normal task queue.
 }
 
 func (ms *MutableStateImpl) GetWorkflowType() *commonpb.WorkflowType {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Set proper `ScheduleToStart` timeout in matching for speculative WFT.

## Why?
<!-- Tell your future self why have you made these changes -->
Speculative WFT has `ScheduleToStart` timeout even on nornal task queue. This timeout is enforces in history service but wasn't used when WFT is added to matching.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.