### PR TITLE
Enforce max number of callbacks per workflow

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -409,6 +409,8 @@ const (
 	FrontendEnableCallbackAttachment = "frontend.enableCallbackAttachment"
 	// FrontendCallbackURLMaxLength is the maximum length of callback URL
 	FrontendCallbackURLMaxLength = "frontend.callbackURLMaxLength"
+	// FrontendMaxCallbacksPerWorkflow is the maximum number of callbacks that can be attached to a workflow.
+	FrontendMaxCallbacksPerWorkflow = "frontend.maxCallbacksPerWorkflow"
 	// FrontendMaxConcurrentBatchOperationPerNamespace is the max concurrent batch operation job count per namespace
 	FrontendMaxConcurrentBatchOperationPerNamespace = "frontend.MaxConcurrentBatchOperationPerNamespace"
 	// FrontendMaxExecutionCountBatchOperationPerNamespace is the max execution count batch operation supports per namespace

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -196,6 +196,7 @@ type Config struct {
 	// EnableCallbackAttachment enables attaching callbacks to workflows.
 	EnableCallbackAttachment    dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	CallbackURLMaxLength        dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxCallbacksPerWorkflow     dynamicconfig.IntPropertyFnWithNamespaceFilter
 	AdminEnableListHistoryTasks dynamicconfig.BoolPropertyFn
 }
 
@@ -299,6 +300,7 @@ func NewConfig(
 		EnableNexusAPIs:             dc.GetBoolProperty(dynamicconfig.FrontendEnableNexusAPIs, false),
 		EnableCallbackAttachment:    dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableCallbackAttachment, false),
 		CallbackURLMaxLength:        dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendCallbackURLMaxLength, 1000),
+		MaxCallbacksPerWorkflow:     dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxCallbacksPerWorkflow, 32),
 		AdminEnableListHistoryTasks: dc.GetBoolProperty(dynamicconfig.AdminEnableListHistoryTasks, true),
 	}
 }

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -4334,6 +4334,16 @@ func (wh *WorkflowHandler) validateWorkflowCompletionCallbacks(
 		)
 	}
 
+	if len(callbacks) > wh.config.MaxCallbacksPerWorkflow(ns.String()) {
+		return status.Error(
+			codes.InvalidArgument,
+			fmt.Sprintf(
+				"cannot attach more than %d callbacks to a workflow",
+				wh.config.MaxCallbacksPerWorkflow(ns.String()),
+			),
+		)
+	}
+
 	for _, callback := range callbacks {
 		switch cb := callback.GetVariant().(type) {
 		case *commonpb.Callback_Nexus_:


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Enforce max number of callbacks that can be attached to a workflow

## Why?
<!-- Tell your future self why have you made these changes -->
Prevent too many callbacks from making the mutable state size explode.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
