### PR TITLE
Clear update registry when mutable state failover version changes

### DIFF
--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -92,12 +92,15 @@ type (
 
 		// GetSize returns the size of the update object
 		GetSize() int
+
+		FailoverVersion() int64
 	}
 
 	// Store represents the update package's requirements for reading updates from the store.
 	Store interface {
 		VisitUpdates(visitor func(updID string, updInfo *updatespb.UpdateInfo))
 		GetUpdateOutcome(ctx context.Context, updateID string) (*updatepb.Outcome, error)
+		GetCurrentVersion() int64
 	}
 
 	registry struct {
@@ -108,6 +111,7 @@ type (
 		maxInFlight      func() int
 		maxTotal         func() int
 		completedUpdates map[string]struct{}
+		failoverVersion  int64
 	}
 
 	Option func(*registry)
@@ -165,6 +169,7 @@ func NewRegistry(
 		maxInFlight:      func() int { return math.MaxInt },
 		maxTotal:         func() int { return math.MaxInt },
 		completedUpdates: make(map[string]struct{}),
+		failoverVersion:  getStoreFn().GetCurrentVersion(),
 	}
 	for _, opt := range opts {
 		opt(r)
@@ -427,4 +432,8 @@ func (r *registry) GetSize() int {
 		size += len(key) + update.GetSize()
 	}
 	return size
+}
+
+func (r *registry) FailoverVersion() int64 {
+	return r.failoverVersion
 }

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -93,6 +93,7 @@ type (
 		// GetSize returns the size of the update object
 		GetSize() int
 
+		// FailoverVersion of mutable state at the time of registry creation.
 		FailoverVersion() int64
 	}
 

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -44,8 +44,9 @@ import (
 
 type mockUpdateStore struct {
 	update.Store
-	VisitUpdatesFunc     func(visitor func(updID string, updInfo *updatespb.UpdateInfo))
-	GetUpdateOutcomeFunc func(context.Context, string) (*updatepb.Outcome, error)
+	VisitUpdatesFunc      func(visitor func(updID string, updInfo *updatespb.UpdateInfo))
+	GetUpdateOutcomeFunc  func(context.Context, string) (*updatepb.Outcome, error)
+	GetCurrentVersionFunc func() int64
 }
 
 func (m mockUpdateStore) VisitUpdates(
@@ -59,6 +60,13 @@ func (m mockUpdateStore) GetUpdateOutcome(
 	updateID string,
 ) (*updatepb.Outcome, error) {
 	return m.GetUpdateOutcomeFunc(ctx, updateID)
+}
+
+func (m mockUpdateStore) GetCurrentVersion() int64 {
+	if m.GetCurrentVersionFunc == nil {
+		return 0
+	}
+	return m.GetCurrentVersionFunc()
 }
 
 var emptyUpdateStore = mockUpdateStore{

--- a/service/history/workflow_task_handler_test.go
+++ b/service/history/workflow_task_handler_test.go
@@ -85,8 +85,10 @@ func TestCommandProtocolMessage(t *testing.T) {
 		metricsHandler := metrics.NoopMetricsHandler
 		out.conf = map[dynamicconfig.Key]any{}
 		out.ms = workflow.NewMockMutableState(gomock.NewController(t))
-		out.ms.EXPECT().VisitUpdates(gomock.Any()).Times(1)
-		out.ms.EXPECT().GetNamespaceEntry().Return(tests.LocalNamespaceEntry).Times(1)
+		out.ms.EXPECT().VisitUpdates(gomock.Any())
+		out.ms.EXPECT().GetNamespaceEntry().Return(tests.LocalNamespaceEntry)
+		out.ms.EXPECT().GetCurrentVersion().Return(tests.LocalNamespaceEntry.FailoverVersion())
+
 		out.updates = update.NewRegistry(func() update.Store { return out.ms })
 		var effects effect.Buffer
 		config := configs.NewConfig(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Clear update registry when mutable state failover version changes.

## Why?
<!-- Tell your future self why have you made these changes -->
Update registry must stay in sync with mutable state. If mutable state was changed because of fail over, update registry must be updated. The easiest way to do it, is clear registry and rebuild from new version of mutable state.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.