### PR TITLE
Make admitted updates prevent workflow completion

### DIFF
--- a/common/testing/testvars/test_vars.go
+++ b/common/testing/testvars/test_vars.go
@@ -34,6 +34,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	updatepb "go.temporal.io/api/update/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -160,6 +161,13 @@ func (tv *TestVars) WorkflowExecution(key ...string) *commonpb.WorkflowExecution
 	return &commonpb.WorkflowExecution{
 		WorkflowId: tv.WorkflowID(key...),
 		RunId:      tv.RunID(key...),
+	}
+}
+
+func (tv *TestVars) UpdateRef() *updatepb.UpdateRef {
+	return &updatepb.UpdateRef{
+		UpdateId:          tv.UpdateID(),
+		WorkflowExecution: tv.WorkflowExecution(),
 	}
 }
 

--- a/service/history/workflow_task_handler_callbacks.go
+++ b/service/history/workflow_task_handler_callbacks.go
@@ -538,8 +538,10 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		newMutableState             workflow.MutableState
 		responseMutations           []workflowTaskResponseMutation
 	)
-	// hasBufferedEvents indicates if there are any buffered events which should generate a new workflow task
-	hasBufferedEvents := ms.HasBufferedEvents()
+	updateRegistry := weContext.UpdateRegistry(ctx, nil)
+	// hasBufferedEvents indicates if there are any buffered events or admitted updates which should generate a new
+	// workflow task.
+	hasBufferedEvents := ms.HasBufferedEvents() || updateRegistry.HasOutgoingMessages(false)
 	if err := namespaceEntry.VerifyBinaryChecksum(request.GetBinaryChecksum()); err != nil {
 		wtFailedCause = newWorkflowTaskFailedCause(
 			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_BINARY,
@@ -574,7 +576,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 			request.GetIdentity(),
 			completedEvent.GetEventId(), // If completedEvent is nil, then GetEventId() returns 0 and this value shouldn't be used in workflowTaskHandler.
 			ms,
-			weContext.UpdateRegistry(ctx, nil),
+			updateRegistry,
 			&effects,
 			handler.commandAttrValidator,
 			workflowSizeChecker,

--- a/service/history/workflow_task_handler_callbacks.go
+++ b/service/history/workflow_task_handler_callbacks.go
@@ -539,9 +539,9 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		responseMutations           []workflowTaskResponseMutation
 	)
 	updateRegistry := weContext.UpdateRegistry(ctx, nil)
-	// hasBufferedEvents indicates if there are any buffered events or admitted updates which should generate a new
+	// hasBufferedEventsOrMessages indicates if there are any buffered events or admitted updates which should generate a new
 	// workflow task.
-	hasBufferedEvents := ms.HasBufferedEvents() || updateRegistry.HasOutgoingMessages(false)
+	hasBufferedEventsOrMessages := ms.HasBufferedEvents() || updateRegistry.HasOutgoingMessages(false)
 	if err := namespaceEntry.VerifyBinaryChecksum(request.GetBinaryChecksum()); err != nil {
 		wtFailedCause = newWorkflowTaskFailedCause(
 			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_BINARY,
@@ -586,7 +586,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 			handler.config,
 			handler.shardContext,
 			handler.searchAttributesMapperProvider,
-			hasBufferedEvents,
+			hasBufferedEventsOrMessages,
 			handler.commandHandlerRegistry,
 		)
 
@@ -642,7 +642,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 
 		newMutableState = workflowTaskHandler.newMutableState
 
-		hasBufferedEvents = workflowTaskHandler.hasBufferedEvents
+		hasBufferedEventsOrMessages = workflowTaskHandler.hasBufferedEventsOrMessages
 	}
 
 	wtFailedShouldCreateNewTask := false
@@ -682,8 +682,8 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		}
 	}
 
-	bufferedEventShouldCreateNewTask := hasBufferedEvents && ms.HasAnyBufferedEvent(eventShouldGenerateNewTaskFilter)
-	if hasBufferedEvents && !bufferedEventShouldCreateNewTask {
+	bufferedEventShouldCreateNewTask := hasBufferedEventsOrMessages && ms.HasAnyBufferedEvent(eventShouldGenerateNewTaskFilter)
+	if hasBufferedEventsOrMessages && !bufferedEventShouldCreateNewTask {
 		// Make sure tasks that should not create a new event don't get stuck in ms forever
 		ms.FlushBufferedEvents()
 	}


### PR DESCRIPTION
## What changed?
Make admitted updates prevent workflow completion, similar to how "buffered" signal events prevent workflow completion.

## Why?
Product design decision: it should be possible to design workflows which continue-as-new without the risk of losing admitted updates. Also, makes behavior consistent with signal.

## How did you test it?
End-to-end test in PR using Go SDK.

## Potential risks
Could break workflows using update.

## Is hotfix candidate?
No