### PR TITLE
Clean up buffered signal test

### DIFF
--- a/tests/client_suite.go
+++ b/tests/client_suite.go
@@ -1217,39 +1217,30 @@ func (s *ClientFunctionalSuite) Test_ActivityTimeouts() {
 //	Workflow runs the local activity again and drain the signal chan (with one signal) and complete workflow.
 //	Server complete workflow as requested.
 func (s *ClientFunctionalSuite) Test_BufferedSignalCausesUnhandledCommandAndSchedulesNewTask() {
-	sigReadyToSendChan := make(chan struct{}, 1)
-	sigSendDoneChan := make(chan struct{})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	tv := testvars.New(s.T().Name()).WithTaskQueue(s.taskQueue)
+
+	sigReadyToSendChan := make(chan bool, 1)
+	sigSendDoneChan := make(chan bool)
 	localActivityFn := func(ctx context.Context) error {
-		// to unblock signal sending, so signal is send after first workflow task started.
-		select {
-		case sigReadyToSendChan <- struct{}{}:
-		default:
-		}
-
-		// this will block workflow task and cause the signal to become buffered event
-		select {
-		case <-sigSendDoneChan:
-		case <-ctx.Done():
-		}
-
+		// Unblock signal sending, so it is sent after first workflow task started.
+		sigReadyToSendChan <- true
+		// Block workflow task and cause the signal to become buffered event.
+		<-sigSendDoneChan
 		return nil
 	}
 
-	var err1 error
 	var receivedSig string
 	workflowFn := func(ctx workflow.Context) error {
 		ctx1 := workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{
 			StartToCloseTimeout: 10 * time.Second,
 			RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
 		})
-		f1 := workflow.ExecuteLocalActivity(ctx1, localActivityFn)
-		err1 = f1.Get(ctx1, nil)
-		if err1 != nil {
-			return err1
+		if err := workflow.ExecuteLocalActivity(ctx1, localActivityFn).Get(ctx1, nil); err != nil {
+			return err
 		}
-
-		sigCh := workflow.GetSignalChannel(ctx, "signal-name")
-
+		sigCh := workflow.GetSignalChannel(ctx, tv.HandlerName())
 		for {
 			var sigVal string
 			ok := sigCh.ReceiveAsync(&sigVal)
@@ -1258,23 +1249,19 @@ func (s *ClientFunctionalSuite) Test_BufferedSignalCausesUnhandledCommandAndSche
 			}
 			receivedSig = sigVal
 		}
-
 		return nil
 	}
 
 	s.worker.RegisterWorkflow(workflowFn)
 
-	id := "functional-test-unhandled-command-new-task"
 	workflowOptions := sdkclient.StartWorkflowOptions{
-		ID:        id,
-		TaskQueue: s.taskQueue,
+		ID:        tv.WorkflowID(),
+		TaskQueue: tv.TaskQueue().Name,
 		// Intentionally use same timeout for WorkflowTaskTimeout and WorkflowRunTimeout so if workflow task is not
 		// correctly dispatched, it would time out which would fail the workflow and cause test to fail.
 		WorkflowTaskTimeout: 10 * time.Second,
 		WorkflowRunTimeout:  10 * time.Second,
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 	workflowRun, err := s.sdkClient.ExecuteWorkflow(ctx, workflowOptions, workflowFn)
 	if err != nil {
 		s.Logger.Fatal("Start workflow failed with err", tag.Error(err))
@@ -1282,14 +1269,12 @@ func (s *ClientFunctionalSuite) Test_BufferedSignalCausesUnhandledCommandAndSche
 
 	s.NotNil(workflowRun)
 	s.True(workflowRun.GetRunID() != "")
+	tv = tv.WithRunID(workflowRun.GetRunID())
 
 	// block until first workflow task started
-	select {
-	case <-sigReadyToSendChan:
-	case <-ctx.Done():
-	}
+	<-sigReadyToSendChan
 
-	err = s.sdkClient.SignalWorkflow(ctx, id, workflowRun.GetRunID(), "signal-name", "signal-value")
+	err = s.sdkClient.SignalWorkflow(ctx, tv.WorkflowID(), tv.RunID(), tv.HandlerName(), "signal-value")
 	s.NoError(err)
 
 	close(sigSendDoneChan)
@@ -1298,20 +1283,18 @@ func (s *ClientFunctionalSuite) Test_BufferedSignalCausesUnhandledCommandAndSche
 	s.NoError(err) // if new workflow task is not correctly dispatched, it would cause timeout error here
 	s.Equal("signal-value", receivedSig)
 
-	// verify event sequence
-	expectedHistory := []enumspb.EventType{
-		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
-		enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED,
-		enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED,
-		enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED,        // due to unhandled signal
-		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED, // this is the buffered signal
-		enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED,
-		enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED,
-		enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
-		enumspb.EVENT_TYPE_MARKER_RECORDED,
-		enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
-	}
-	s.assertHistory(id, workflowRun.GetRunID(), expectedHistory)
+	s.HistoryRequire.EqualHistoryEvents(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskFailed        // Unhandled signal prevented workflow completion
+	5 WorkflowExecutionSignaled // This is the buffered signal
+	6 WorkflowTaskScheduled
+	7 WorkflowTaskStarted
+	8 WorkflowTaskCompleted
+	9 MarkerRecorded
+	10 WorkflowExecutionCompleted`,
+		s.getHistory(s.namespace, tv.WorkflowExecution()))
 }
 
 // Analogous to Test_BufferedSignalCausesUnhandledCommandAndSchedulesNewTask


### PR DESCRIPTION
Clean up a test, similar to https://github.com/temporalio/temporal/pull/5794. No functional changes.