### PR TITLE
Enable FE>history for reading history

### DIFF
--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -301,8 +301,8 @@ func NewConfig(
 		EnableWorkerVersioningWorkflow: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs, false),
 		EnableWorkerVersioningRules:    dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableWorkerVersioningRuleAPIs, false),
 
-		AccessHistoryFraction:            dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 0.0),
-		AdminDeleteAccessHistoryFraction: dc.GetFloat64Property(dynamicconfig.FrontendAdminDeleteAccessHistoryFraction, 0.0),
+		AccessHistoryFraction:            dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 1.0),
+		AdminDeleteAccessHistoryFraction: dc.GetFloat64Property(dynamicconfig.FrontendAdminDeleteAccessHistoryFraction, 1.0),
 
 		EnableNexusAPIs:             dc.GetBoolProperty(dynamicconfig.FrontendEnableNexusAPIs, false),
 		EnableCallbackAttachment:    dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableCallbackAttachment, false),

--- a/service/frontend/workflow_handler_deprecated_test.go
+++ b/service/frontend/workflow_handler_deprecated_test.go
@@ -278,7 +278,9 @@ func (s *workflowHandlerSuite) TestGetWorkflowExecutionHistory() {
 	s.mockExecutionManager.EXPECT().TrimHistoryBranch(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
 
-	wh := s.getWorkflowHandler(s.newConfig())
+	config := s.newConfig()
+	config.AccessHistoryFraction = dc.GetFloatPropertyFn(0.0)
+	wh := s.getWorkflowHandler(config)
 
 	oldGoSDKVersion := "1.9.1"
 	newGoSDKVersion := "1.10.1"
@@ -318,6 +320,7 @@ func (s *workflowHandlerSuite) TestGetWorkflowExecutionHistory_RawHistoryWithTra
 	we := &commonpb.WorkflowExecution{WorkflowId: "wid1", RunId: uuid.New()}
 
 	config := s.newConfig()
+	config.AccessHistoryFraction = dc.GetFloatPropertyFn(0.0)
 	config.SendRawWorkflowHistory = dc.GetBoolPropertyFnFilteredByNamespace(true)
 	wh := s.getWorkflowHandler(config)
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -610,7 +610,7 @@ func NewConfig(
 
 		SendRawWorkflowHistory: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.SendRawWorkflowHistory, false),
 
-		FrontendAccessHistoryFraction: dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 0.0),
+		FrontendAccessHistoryFraction: dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 1.0),
 	}
 
 	return cfg

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -226,7 +226,7 @@ func NewConfig(
 
 		ListNexusIncomingServicesLongPollTimeout: dc.GetDurationProperty(dynamicconfig.MatchingListNexusIncomingServicesLongPollTimeout, 5*time.Minute-10*time.Second), // Use -10 seconds so that we send back empty response instead of timeout
 
-		FrontendAccessHistoryFraction: dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 0.0),
+		FrontendAccessHistoryFraction: dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 1.0),
 	}
 }
 


### PR DESCRIPTION
## What changed?
This enables frontend+matching reading history through history service

## Why?
This is the prereq for https://github.com/temporalio/temporal/pull/5797