### PR TITLE
Fix schedule workflow to CAN after signals

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -79,6 +79,8 @@ const (
 	IncrementalBackfill = 5
 	// update from previous action instead of current time
 	UpdateFromPrevious = 6
+	// do continue-as-new after pending signals
+	CANAfterSignals = 7
 )
 
 const (
@@ -324,6 +326,13 @@ func (s *scheduler) run() error {
 		// if schedule is not paused and out of actions or do not have anything scheduled, exit the schedule workflow after retention period has passed
 		if exp := s.getRetentionExpiration(nextWakeup); !exp.IsZero() && !exp.After(s.now()) {
 			return nil
+		}
+		if suggestContinueAsNew && s.pendingUpdate == nil && s.pendingPatch == nil && s.hasMinVersion(CANAfterSignals) {
+			// If suggestContinueAsNew was true but we had a pending update or patch, we would
+			// not break above, but process the update/patch. Now that we're done, we should
+			// break here to do CAN. (pendingUpdate and pendingPatch should always nil here,
+			// the check check above is just being defensive.)
+			break
 		}
 
 		// sleep returns on any of:

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -2041,7 +2041,7 @@ func (s *workflowSuite) TestCANBySuggested() {
 }
 
 func (s *workflowSuite) TestCANBySuggestedWithSignals() {
-	// TODO: remove once default version is UpdateFromPrevious
+	// TODO: remove once default version is CANAfterSignals
 	prevTweakables := currentTweakablePolicies
 	currentTweakablePolicies.Version = CANAfterSignals
 	defer func() { currentTweakablePolicies = prevTweakables }()


### PR DESCRIPTION
## What changed and why?
If a schedule was paused and received a large number of signals (trigger, backfill, etc.), it wouldn't be able to continue-as-new and history size could grow past the suggested limit.

For various reasons the main loop receives and processes signals across iterations, with checking for CAN in between, so a wakeup due to a signal (instead of a timer) would prevent CAN. Refactoring is hard due to the determinism requirement, so the simplest fix is to do a second check.

## How did you test it?
New unit test
