### PR TITLE
MultiOperation: set vector clock

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -637,7 +637,18 @@ func (h *Handler) ExecuteMultiOperation(
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	// TODO: shardContext.NewVectorClock()
+
+	for _, opResp := range response.Responses {
+		if startResp := opResp.GetStartWorkflow(); startResp != nil {
+			if startResp.Clock == nil {
+				startResp.Clock, err = shardContext.NewVectorClock()
+				if err != nil {
+					return nil, h.convertError(err)
+				}
+			}
+		}
+	}
+
 	return response, nil
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Setting the vector clock on any `StartWorkflowExecutionResponse` inside the MultiOperation response.
(NOTE: there can only ever be one Start Workflow)

## Why?
<!-- Tell your future self why have you made these changes -->

Vector clock needs to be set.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

To be honest, I'm not sure how to.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
