### PR TITLE
Make link to CONTRIBUTING.md slightly more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ This repository contains the source code of the Temporal server. To implement Wo
 
 ## Contributing
 
-We'd love your help in making Temporal great. Please review the [internal architecture docs](./docs/architecture/README.md) and our [contribution guide](CONTRIBUTING.md).
+We'd love your help in making Temporal great. Please review the [internal architecture docs](./docs/architecture/README.md).
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to build and run the server locally, run tests, etc.
 
 If you'd like to work on or propose a new feature, first peruse [feature requests](https://community.temporal.io/c/feature-requests/6) and our [proposals repo](https://github.com/temporalio/proposals) to discover existing active and accepted proposals.
 


### PR DESCRIPTION
## What changed?
Make link to CONTRIBUTING.md in the README slightly more explicit.

## Why?
People outside server team sometimes need to run the server against `main` and it's not obvious how to.
