### PR TITLE
Workflow Update: advance to more advanced state only from non-provisional state

### DIFF
--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -200,7 +200,9 @@ func (r *registry) UpdateFromStore() {
 			)
 		} else if acc := updInfo.GetAcceptance(); acc != nil {
 			if upd := r.updates[updID]; upd != nil {
-				_ = upd.advanceTo(stateAccepted)
+				if upd.state != stateProvisionallyAccepted {
+					_ = upd.advanceTo(stateAccepted)
+				}
 				return
 			}
 			r.updates[updID] = newAccepted(
@@ -211,7 +213,9 @@ func (r *registry) UpdateFromStore() {
 			)
 		} else if updInfo.GetCompletion() != nil {
 			if upd := r.updates[updID]; upd != nil {
-				_ = upd.advanceTo(stateCompleted)
+				if upd.state != stateProvisionallyCompleted {
+					_ = upd.advanceTo(stateCompleted)
+				}
 				return
 			}
 			r.completedUpdates[updID] = struct{}{}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Advance to more advanced state only from non-provisional state.

## Why?
<!-- Tell your future self why have you made these changes -->
Without this check any access to `UpdateRegistry()` updates it from possible non yet persisted MS and advances updates to the states which are not persisted yet.


## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Manually. Didn't add new test because I am about to remove `UpdateFromStore()` soon.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.