### PR TITLE
Improve DLQ Logs

### DIFF
--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -416,7 +416,7 @@ func NewConfig(
 		QueuePendingTaskMaxCount:         dc.GetIntProperty(dynamicconfig.QueuePendingTaskMaxCount, 10000),
 
 		TaskDLQEnabled:                 dc.GetBoolProperty(dynamicconfig.HistoryTaskDLQEnabled, true),
-		TaskDLQUnexpectedErrorAttempts: dc.GetIntProperty(dynamicconfig.HistoryTaskDLQUnexpectedErrorAttempts, 100),
+		TaskDLQUnexpectedErrorAttempts: dc.GetIntProperty(dynamicconfig.HistoryTaskDLQUnexpectedErrorAttempts, 50),
 		TaskDLQInternalErrors:          dc.GetBoolProperty(dynamicconfig.HistoryTaskDLQInternalErrors, false),
 		TaskDLQErrorPattern:            dc.GetStringProperty(dynamicconfig.HistoryTaskDLQErrorPattern, ""),
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -416,7 +416,7 @@ func NewConfig(
 		QueuePendingTaskMaxCount:         dc.GetIntProperty(dynamicconfig.QueuePendingTaskMaxCount, 10000),
 
 		TaskDLQEnabled:                 dc.GetBoolProperty(dynamicconfig.HistoryTaskDLQEnabled, true),
-		TaskDLQUnexpectedErrorAttempts: dc.GetIntProperty(dynamicconfig.HistoryTaskDLQUnexpectedErrorAttempts, 50),
+		TaskDLQUnexpectedErrorAttempts: dc.GetIntProperty(dynamicconfig.HistoryTaskDLQUnexpectedErrorAttempts, 70), // 70 attempts takes about an hour
 		TaskDLQInternalErrors:          dc.GetBoolProperty(dynamicconfig.HistoryTaskDLQInternalErrors, false),
 		TaskDLQErrorPattern:            dc.GetStringProperty(dynamicconfig.HistoryTaskDLQErrorPattern, ""),
 

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -485,7 +485,11 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 			e.attempt++
 			if e.attempt > taskCriticalLogMetricAttempts {
 				metrics.TaskAttempt.With(e.taggedMetricsHandler).Record(int64(e.attempt))
-				e.logger.Error("Critical error processing task, retrying.", tag.Attempt(int32(e.attempt)), tag.Error(err), tag.OperationCritical)
+				e.logger.Error("Critical error processing task, retrying.",
+					tag.Attempt(int32(e.attempt)),
+					tag.UnexpectedErrorAttempts(int32(e.unexpectedErrorAttempts)),
+					tag.Error(err),
+					tag.OperationCritical)
 			}
 		}
 	}()
@@ -541,7 +545,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 	if e.unexpectedErrorAttempts >= e.maxUnexpectedErrorAttempts() && e.dlqEnabled() {
 		// Keep this message in sync with the log line mentioned in Investigation section of docs/admin/dlq.md
 		e.logger.Error("Marking task as terminally failed, will send to DLQ. Maximum number of attempts with unexpected errors",
-			tag.Attempt(int32(e.unexpectedErrorAttempts)), tag.Error(err))
+			tag.UnexpectedErrorAttempts(int32(e.unexpectedErrorAttempts)), tag.Error(err))
 		e.terminalFailureCause = err // <- Execute() examines this attribute on the next attempt.
 		metrics.TaskTerminalFailures.With(e.taggedMetricsHandler).Record(1)
 		return fmt.Errorf("%w: %w", ErrTerminalTaskFailure, e.terminalFailureCause)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Add UnexpectedErrorAttempts tag to some logs.
- Reduce default value for history.TaskDLQUnexpectedErrorAttempts to 70

## Why?
<!-- Tell your future self why have you made these changes -->
More consistent logs. Also 100 attempts take +2hrs which is to long. 50 attempts take about 16 minutes.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
None

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
none

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
none

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
no