### PR TITLE
Temporary disable xdc functional tests over SQL persistances

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -202,7 +202,8 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest]
-        name: [cass_es, cass_es8, mysql8, postgres12, postgres12_pgx]
+        name: [cass_es, cass_es8]
+#        name: [cass_es, cass_es8, mysql8, postgres12, postgres12_pgx]
         include:
           - name: cass_es
             persistence_type: nosql
@@ -212,18 +213,18 @@ jobs:
             persistence_type: nosql
             persistence_driver: elasticsearch
             containers: [cassandra, elasticsearch8]
-          - name: mysql8
-            persistence_type: sql
-            persistence_driver: mysql8
-            containers: [mysql]
-          - name: postgres12
-            persistence_type: sql
-            persistence_driver: postgres12
-            containers: [postgresql]
-          - name: postgres12_pgx
-            persistence_type: sql
-            persistence_driver: postgres12_pgx
-            containers: [postgresql]
+#          - name: mysql8
+#            persistence_type: sql
+#            persistence_driver: mysql8
+#            containers: [mysql]
+#          - name: postgres12
+#            persistence_type: sql
+#            persistence_driver: postgres12
+#            containers: [postgresql]
+#          - name: postgres12_pgx
+#            persistence_type: sql
+#            persistence_driver: postgres12_pgx
+#            containers: [postgresql]
     runs-on: ${{ matrix.runs-on }}
     env:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Temporary disable xdc functional tests over SQL persistances.

## Why?
<!-- Tell your future self why have you made these changes -->
xdc tests over SQL are constantly fails due to different connection errors such as

```
2024-04-30T16:51:34.847Z	error	Failed to get replication tasks	{"cluster-name": "active-adv-vis", "service": "worker", "component": "replicator", "component": "replication-task-processor", "xdc-source-cluster": "standby-adv-vis", "error": "last connection error: connection error: desc = \"transport: Error while dialing: dial tcp 127.0.0.1:10134: connect: connection refused\"", "logging-call-at": "namespace_replication_message_processor.go:169"}
```

These errors need to be investigated and tests should be enabled back.

Cassandra is also flaky but not that bad.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
GHA.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Replication over SQL is not tested in GHA.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.