### PR TITLE
Workflow Update: replace getStoreFn() with store

### DIFF
--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -103,10 +103,10 @@ type (
 	registry struct {
 		mu              sync.RWMutex
 		updates         map[string]*Update
-		getStoreFn      func() Store // TODO: revert it back to Store
-		instrumentation instrumentation
-		maxInFlight     func() int
-		maxTotal        func() int
+		store            Store
+		instrumentation  instrumentation
+		maxInFlight      func() int
+		maxTotal         func() int
 		completedCount  int
 		failoverVersion int64
 	}
@@ -156,22 +156,22 @@ func WithTracerProvider(t trace.TracerProvider) Option {
 var _ Registry = (*registry)(nil)
 
 func NewRegistry(
-	getStoreFn func() Store,
+	store Store,
 	opts ...Option,
 ) Registry {
 	r := &registry{
 		updates:         make(map[string]*Update),
-		getStoreFn:      getStoreFn,
+		store:            store,
 		instrumentation: noopInstrumentation,
 		maxInFlight:     func() int { return math.MaxInt },
 		maxTotal:        func() int { return math.MaxInt },
-		failoverVersion: getStoreFn().GetCurrentVersion(),
+		failoverVersion: store.GetCurrentVersion(),
 	}
 	for _, opt := range opts {
 		opt(r)
 	}
 
-	r.getStoreFn().VisitUpdates(func(updID string, updInfo *updatespb.UpdateInfo) {
+	r.store.VisitUpdates(func(updID string, updInfo *updatespb.UpdateInfo) {
 		if updInfo.GetAdmission() != nil {
 			// An update entry in the registry may have a request payload: we use this to write the payload to an
 			// UpdateAccepted event, in the event that the update is accepted. However, when populating the registry
@@ -361,7 +361,7 @@ func (r *registry) findLocked(ctx context.Context, id string) (*Update, bool) {
 
 	// update not found in ephemeral state, but could have already completed so
 	// check in registry storage
-	updOutcome, err := r.getStoreFn().GetUpdateOutcome(ctx, id)
+	updOutcome, err := r.store.GetUpdateOutcome(ctx, id)
 
 	// Swallow NotFound error because it means that update doesn't exist.
 	var notFound *serviceerror.NotFound

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -103,10 +103,10 @@ type (
 	registry struct {
 		mu              sync.RWMutex
 		updates         map[string]*Update
-		store            Store
-		instrumentation  instrumentation
-		maxInFlight      func() int
-		maxTotal         func() int
+		store           Store
+		instrumentation instrumentation
+		maxInFlight     func() int
+		maxTotal        func() int
 		completedCount  int
 		failoverVersion int64
 	}
@@ -161,7 +161,7 @@ func NewRegistry(
 ) Registry {
 	r := &registry{
 		updates:         make(map[string]*Update),
-		store:            store,
+		store:           store,
 		instrumentation: noopInstrumentation,
 		maxInFlight:     func() int { return math.MaxInt },
 		maxTotal:        func() int { return math.MaxInt },

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -89,7 +89,7 @@ func TestFind(t *testing.T) {
 				return nil, serviceerror.NewNotFound("not found")
 			},
 		}
-		reg = update.NewRegistry(func() update.Store { return store })
+		reg = update.NewRegistry(store)
 	)
 	_, ok := reg.Find(ctx, updateID)
 	require.False(t, ok)
@@ -114,7 +114,7 @@ func TestHasOutgoingMessages(t *testing.T) {
 				return nil, serviceerror.NewNotFound("not found")
 			},
 		}
-		reg     = update.NewRegistry(func() update.Store { return store })
+		reg     = update.NewRegistry(store)
 		evStore = mockEventStore{Controller: effect.Immediate(ctx)}
 	)
 
@@ -187,7 +187,7 @@ func TestFindOrCreate(t *testing.T) {
 				return nil, serviceerror.NewNotFound("not found")
 			},
 		}
-		reg = update.NewRegistry(func() update.Store { return store })
+		reg = update.NewRegistry(store)
 	)
 
 	t.Run("new update", func(t *testing.T) {
@@ -243,7 +243,7 @@ func TestUpdateRemovalFromRegistry(t *testing.T) {
 				visitor(storedAcceptedUpdateID, storedAcceptedUpdateInfo)
 			},
 		}
-		reg     = update.NewRegistry(func() update.Store { return regStore })
+		reg     = update.NewRegistry(regStore)
 		effects = effect.Buffer{}
 		evStore = mockEventStore{Controller: &effects}
 	)
@@ -272,7 +272,7 @@ func TestSendMessageGathering(t *testing.T) {
 	var (
 		ctx     = context.Background()
 		evStore = mockEventStore{Controller: effect.Immediate(ctx)}
-		reg     = update.NewRegistry(func() update.Store { return emptyUpdateStore })
+		reg     = update.NewRegistry(emptyUpdateStore)
 	)
 	updateID1, updateID2 := t.Name()+"-update-id-1", t.Name()+"-update-id-2"
 	upd1, _, err := reg.FindOrCreate(ctx, updateID1)
@@ -339,7 +339,7 @@ func TestInFlightLimit(t *testing.T) {
 		ctx   = context.Background()
 		limit = 1
 		reg   = update.NewRegistry(
-			func() update.Store { return emptyUpdateStore },
+			emptyUpdateStore,
 			update.WithInFlightLimit(
 				func() int { return limit },
 			),
@@ -419,7 +419,7 @@ func TestTotalLimit(t *testing.T) {
 		ctx   = context.Background()
 		limit = 1
 		reg   = update.NewRegistry(
-			func() update.Store { return emptyUpdateStore },
+			emptyUpdateStore,
 			update.WithTotalLimit(
 				func() int { return limit },
 			),
@@ -513,7 +513,7 @@ func TestStorageErrorWhenLookingUpCompletedOutcome(t *testing.T) {
 				return nil, expectError
 			},
 		}
-		reg = update.NewRegistry(func() update.Store { return regStore })
+		reg = update.NewRegistry(regStore)
 	)
 
 	upd, found := reg.Find(ctx, completedUpdateID)
@@ -527,7 +527,7 @@ func TestRejectUnprocessed(t *testing.T) {
 	var (
 		ctx          = context.Background()
 		evStore      = mockEventStore{Controller: effect.Immediate(ctx)}
-		reg          = update.NewRegistry(func() update.Store { return emptyUpdateStore })
+		reg          = update.NewRegistry(emptyUpdateStore)
 		sequencingID = &protocolpb.Message_EventId{EventId: testSequencingEventID}
 	)
 	updateID1, updateID2, updateID3 := t.Name()+"-update-id-1", t.Name()+"-update-id-2", t.Name()+"-update-id-3"
@@ -584,7 +584,7 @@ func TestCancelIncomplete(t *testing.T) {
 	var (
 		ctx          = context.Background()
 		evStore      = mockEventStore{Controller: effect.Immediate(ctx)}
-		reg          = update.NewRegistry(func() update.Store { return emptyUpdateStore })
+		reg          = update.NewRegistry(emptyUpdateStore)
 		sequencingID = &protocolpb.Message_EventId{EventId: testSequencingEventID}
 	)
 	updateID1, updateID2, updateID3, updateID4, updateID5 := t.Name()+"-update-id-1", t.Name()+"-update-id-2", t.Name()+"-update-id-3", t.Name()+"-update-id-4", t.Name()+"-update-id-5"

--- a/service/history/workflow_task_handler_test.go
+++ b/service/history/workflow_task_handler_test.go
@@ -89,7 +89,7 @@ func TestCommandProtocolMessage(t *testing.T) {
 		out.ms.EXPECT().GetNamespaceEntry().Return(tests.LocalNamespaceEntry)
 		out.ms.EXPECT().GetCurrentVersion().Return(tests.LocalNamespaceEntry.FailoverVersion())
 
-		out.updates = update.NewRegistry(func() update.Store { return out.ms })
+		out.updates = update.NewRegistry(out.ms)
 		var effects effect.Buffer
 		config := configs.NewConfig(
 			dynamicconfig.NewCollection(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Replace `getStoreFn()` with `store`.

## Why?
<!-- Tell your future self why have you made these changes -->
After #5792 there is no need for call back function because update registry is always using up to date WF context.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests and nightly pipelines.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.