### PR TITLE
Fix flakey Nexus functional tests

### DIFF
--- a/common/nexus/incoming_service_registry.go
+++ b/common/nexus/incoming_service_registry.go
@@ -77,7 +77,7 @@ func NewIncomingServiceRegistryConfig(dc *dynamicconfig.Collection) *IncomingSer
 		nexusAPIsEnabled:       dc.GetBoolProperty(dynamicconfig.FrontendEnableNexusAPIs, false),
 		refreshLongPollTimeout: dc.GetDurationProperty(dynamicconfig.FrontendRefreshNexusIncomingServicesLongPollTimeout, 5*time.Minute),
 		refreshPageSize:        dc.GetIntProperty(dynamicconfig.NexusIncomingServiceListDefaultPageSize, 1000),
-		refreshMinWait:         dc.GetDurationProperty(dynamicconfig.FrontendRefreshNexusIncomingServicesLongPollTimeout, 1*time.Second),
+		refreshMinWait:         dc.GetDurationProperty(dynamicconfig.FrontendRefreshNexusIncomingServicesMinWait, 1*time.Second),
 	}
 	config.refreshRetryPolicy = backoff.NewExponentialRetryPolicy(config.refreshMinWait()).WithMaximumInterval(config.refreshLongPollTimeout())
 	return config

--- a/tests/client_suite.go
+++ b/tests/client_suite.go
@@ -51,10 +51,11 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
+	"go.uber.org/multierr"
+
 	"go.temporal.io/server/common/testing/historyrequire"
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/components/nexusoperations"
-	"go.uber.org/multierr"
 
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/common"
@@ -108,6 +109,7 @@ func (s *ClientFunctionalSuite) SetupSuite() {
 		nexusoperations.Enabled:                                       true,
 		dynamicconfig.OutboundProcessorEnabled:                        true,
 		dynamicconfig.EnableMutableStateTransitionHistory:             true,
+		dynamicconfig.FrontendRefreshNexusIncomingServicesMinWait:     1 * time.Millisecond,
 	}
 	s.setupSuite("testdata/client_cluster.yaml")
 }

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -690,9 +690,6 @@ func (s *ClientFunctionalSuite) versionedNexusTaskPoller(ctx context.Context, ta
 	if err != nil {
 		panic(err)
 	}
-	if res == nil {
-		return
-	}
 	response, handlerError := handler(res)
 	if handlerError != nil {
 		_, err = s.testCluster.GetFrontendClient().RespondNexusTaskFailed(ctx, &workflowservice.RespondNexusTaskFailedRequest{


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Switch to using `EventuallyWithT` instead of `time.Sleep` to make sure that Nexus incoming services are loaded into memory before executing tests.

## Why?
<!-- Tell your future self why have you made these changes -->
Flakey :(

