### PR TITLE
Workflow Update: remove mutex from update registry

### DIFF
--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -213,8 +213,6 @@ func (r *registry) FindOrCreate(ctx context.Context, id string) (*Update, bool, 
 
 // Abort all incomplete updates in the registry.
 func (r *registry) Abort(reason AbortReason) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
 	for _, upd := range r.updates {
 		upd.abort(reason)
 	}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Remove mutex from update registry.

## Why?
<!-- Tell your future self why have you made these changes -->
All access to registry is done within WF lock and extra lock is not needed. There are accesses to updates outside of WF lock (like `WaitLifecycleState`) but registry lock doesn't protect these calls and they are thread safe.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run existing tests with race detector enabled and also fault injection pipeline.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.