### PR TITLE
Add linter rule to grumble when time.Sleep is used in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,8 @@ linters-settings:
     fieldalignment: 0
   forbidigo:
     forbid:
+      - p: time.Sleep
+        msg: "Please use require.Eventually or assert.Eventually instead unless you've no other option"
       - p: ^time\.After$
         msg: "time.After may leak resources. Use time.NewTimer instead."
   revive:
@@ -107,6 +109,10 @@ linters-settings:
           - "strings.Builder.*"
 issues:
   exclude-rules:
+    - path-except: _test\.go|tests/.+\.go
+      text: "time.Sleep"
+      linters:
+        - forbidigo
     - path: _test\.go|tests/.+\.go
       text: "(cyclomatic|cognitive)"  # false positives when using subtests
       linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,11 +12,6 @@ linters:
     - forbidigo
     - exhaustive
     - godox
-run:
-  skip-dirs:
-    - ^api
-    - ^proto
-    - ^.git
 linters-settings:
   godox:
     keywords:
@@ -108,6 +103,10 @@ linters-settings:
           - "bytes.Buffer.*"
           - "strings.Builder.*"
 issues:
+  exclude-dirs:
+    - ^api
+    - ^proto
+    - ^.git
   exclude-rules:
     - path-except: _test\.go|tests/.+\.go
       text: "time.Sleep"


### PR DESCRIPTION
## What changed?
I updated our linter rules to forbid the usage of time.Sleep in new tests.
Note that our linters can be ignored but _please don't_ :(

## Why?

This has been a source of race conditions and flaky tests historically. If you've a good reason to use `time.Sleep` in your test (we have some) then you can override and/or ignore this, but you should otherwise default to using `require.Eventually` or `assert.Eventually`.

## How did you test it?
I applied the following diff:
```diff
diff --git a/service/fx.go b/service/fx.go
index 3b024069c..52cf3e4bf 100644
--- a/service/fx.go
+++ b/service/fx.go
@@ -26,6 +26,7 @@ package service

 import (
 	"sync/atomic"
+	"time"

 	"go.uber.org/fx"
 	"google.golang.org/grpc"
@@ -168,6 +169,8 @@ func getUnaryInterceptors(params GrpcServerOptionsParams) []grpc.UnaryServerInte

 	interceptors = append(interceptors, params.AdditionalInterceptors...)

+	time.Sleep(12 * time.Second)
+
 	return append(
 		interceptors,
 		params.RateLimitInterceptor.Intercept,
diff --git a/tests/dlq_test.go b/tests/dlq_test.go
index fd0546120..5c264b28f 100644
--- a/tests/dlq_test.go
+++ b/tests/dlq_test.go
@@ -27,6 +27,7 @@ package tests
 import (
 	"flag"
 	"testing"
+	"time"

 	"github.com/stretchr/testify/suite"
 )
@@ -34,4 +35,5 @@ import (
 func TestDLQSuite(t *testing.T) {
 	flag.Parse()
 	suite.Run(t, new(DLQSuite))
+	time.Sleep(1)
 }
```

Then ran our linters as follows to make sure it only complained about the time.Sleep I added in test code:

```
$ make GOLANGCI_LINT_FIX=false GOLANGCI_LINT_BASE_REV=HEAD~ lint-code
Linting code...
...
INFO [runner] linters took 730.646834ms with stages: goanalysis_metalinter: 338.380792ms
tests/dlq_test.go:38:2: use of `time.Sleep` forbidden because "Please use require.Eventually or assert.Eventually instead unless you've no other option" (forbidigo)
	time.Sleep(1)
	^
INFO File cache stats: 1 entries of total size 1.4KiB
INFO Memory: 23 samples, avg is 52.3MB, max is 89.1MB
INFO Execution took 2.124820459s
make: *** [Makefile:333: lint-code] Error 1
```
