### PR TITLE
Send update requests to worker in admission order 

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -912,7 +912,7 @@ func (ms *MutableStateImpl) VisitUpdates(visitor func(updID string, updInfo *upd
 		updInfo *updatespb.UpdateInfo
 		eventId int64
 	}
-	updateEvents := []updateEvent{}
+	var updateEvents []updateEvent
 	for updID, updInfo := range ms.executionInfo.GetUpdateInfos() {
 		u := updateEvent{
 			updId:   updID,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -25,6 +25,7 @@
 package workflow
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"math/rand"
@@ -902,9 +903,34 @@ func (ms *MutableStateImpl) GetQueryRegistry() QueryRegistry {
 	return ms.QueryRegistry
 }
 
+// VisitUpdates visits mutable state update entries, ordered by the ID of the history event pointed to by the mutable
+// state entry. Thus, for example, updates entries in Admitted state will be visited in the order that their Admitted
+// events were added to history.
 func (ms *MutableStateImpl) VisitUpdates(visitor func(updID string, updInfo *updatespb.UpdateInfo)) {
+	type updateEvent struct {
+		updId   string
+		updInfo *updatespb.UpdateInfo
+		eventId int64
+	}
+	updateEvents := []updateEvent{}
 	for updID, updInfo := range ms.executionInfo.GetUpdateInfos() {
-		visitor(updID, updInfo)
+		u := updateEvent{
+			updId:   updID,
+			updInfo: updInfo,
+		}
+		if adm := updInfo.GetAdmission(); adm != nil {
+			u.eventId = adm.GetHistoryPointer().EventId
+		} else if acc := updInfo.GetAcceptance(); acc != nil {
+			u.eventId = acc.EventId
+		} else if com := updInfo.GetCompletion(); com != nil {
+			u.eventId = com.EventId
+		}
+		updateEvents = append(updateEvents, u)
+	}
+	slices.SortFunc(updateEvents, func(u1, u2 updateEvent) int { return cmp.Compare(u1.eventId, u2.eventId) })
+
+	for _, u := range updateEvents {
+		visitor(u.updId, u.updInfo)
 	}
 }
 

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -305,7 +305,7 @@ func (r *registry) Send(
 	for _, upd := range r.updates {
 		updates = append(updates, upd)
 	}
-	slices.SortFunc(updates, func(u1, u2 *Update) int { return u1.admittedTime.Compare(u2.admittedTime) })
+	slices.SortStableFunc(updates, func(u1, u2 *Update) int { return u1.admittedTime.Compare(u2.admittedTime) })
 
 	for _, upd := range updates {
 		outgoingMessage := upd.Send(ctx, includeAlreadySent, sequencingEventID)

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -301,13 +301,13 @@ func (r *registry) Send(
 
 	var outgoingMessages []*protocolpb.Message
 
-	var updates []*Update
+	var sortedUpdates []*Update
 	for _, upd := range r.updates {
-		updates = append(updates, upd)
+		sortedUpdates = append(sortedUpdates, upd)
 	}
-	slices.SortStableFunc(updates, func(u1, u2 *Update) int { return u1.admittedTime.Compare(u2.admittedTime) })
+	slices.SortStableFunc(sortedUpdates, func(u1, u2 *Update) int { return u1.admittedTime.Compare(u2.admittedTime) })
 
-	for _, upd := range updates {
+	for _, upd := range sortedUpdates {
 		outgoingMessage := upd.Send(ctx, includeAlreadySent, sequencingEventID)
 		if outgoingMessage != nil {
 			outgoingMessages = append(outgoingMessages, outgoingMessage)

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -92,6 +92,7 @@ type (
 		acceptedEventID int64
 		onComplete      func()
 		instrumentation *instrumentation
+		admittedTime    time.Time
 
 		// these fields might be accessed while not holding the workflow lock
 		accepted future.Future[*failurepb.Failure]
@@ -143,6 +144,7 @@ func newAdmitted(id string, request *anypb.Any, opts ...updateOpt) *Update {
 		instrumentation: &noopInstrumentation,
 		accepted:        future.NewFuture[*failurepb.Failure](),
 		outcome:         future.NewFuture[*updatepb.Outcome](),
+		admittedTime:    time.Now(),
 	}
 	for _, opt := range opts {
 		opt(upd)
@@ -324,12 +326,15 @@ func (u *Update) Admit(
 			return
 		}
 		u.setState(stateAdmitted)
+		u.admittedTime = time.Now()
 	})
 	eventStore.OnAfterRollback(func(context.Context) {
 		if u.state != stateProvisionallyAdmitted {
 			return
 		}
 		u.setState(prevState)
+		var timeZero time.Time
+		u.admittedTime = timeZero
 	})
 	return nil
 }

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -144,7 +144,7 @@ func newAdmitted(id string, request *anypb.Any, opts ...updateOpt) *Update {
 		instrumentation: &noopInstrumentation,
 		accepted:        future.NewFuture[*failurepb.Failure](),
 		outcome:         future.NewFuture[*updatepb.Outcome](),
-		admittedTime:    time.Now(),
+		admittedTime:    time.Now().UTC(),
 	}
 	for _, opt := range opts {
 		opt(upd)
@@ -326,7 +326,7 @@ func (u *Update) Admit(
 			return
 		}
 		u.setState(stateAdmitted)
-		u.admittedTime = time.Now()
+		u.admittedTime = time.Now().UTC()
 	})
 	eventStore.OnAfterRollback(func(context.Context) {
 		if u.state != stateProvisionallyAdmitted {

--- a/tests/update_workflow.go
+++ b/tests/update_workflow.go
@@ -5380,7 +5380,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_AdmittedUpdatesAreSentToWorkerInOrd
 	tv = s.startWorkflow(tv)
 	for i := 0; i < nUpdates; i++ {
 		updateId := fmt.Sprint(i)
-		go s.sendUpdate(tv, updateId)
+		go func() { _, _ = s.sendUpdate(tv, updateId) }()
 		for {
 			resp, err := s.pollUpdate(tv, updateId, &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED})
 			if err == nil {


### PR DESCRIPTION
## What changed?
Sort update requests by order of admission when sending to worker.

## Why?
The order in which updates are sent to the worker affects execution semantics (consider the initial, synchronous portion of the handler: for this section of code, update B can see changes made to workflow state by update A iff update B is executed after A by the worker).

Furthermore, it is possible for a user to know in which order the server has received the updates (the client can poll for admitted status), and even without polling, if they are re-using the same client they will expect admission order to match send order. Thus, the user may reasonably have expectations for the order of execution by the worker based on happens-before relations among their update requests.

## How did you test it?
Test in PR

## Potential risks
The test in the PR has a non-zero false negative rate. However, it is not high... `1/20! = 1/2432902008176640000` in the case where our code is incorrectly ordering updates randomly.

## Is hotfix candidate?
No