### PR TITLE
Prevent reapplying an update with a conflicting ID

### DIFF
--- a/service/history/api/reapplyevents/api.go
+++ b/service/history/api/reapplyevents/api.go
@@ -177,6 +177,7 @@ func Invoke(
 			reappliedEvents, err := eventsReapplier.ReapplyEvents(
 				ctx,
 				mutableState,
+				context.UpdateRegistry(ctx, mutableState),
 				toReapplyEvents,
 				runID,
 			)

--- a/service/history/api/reapplyevents/api.go
+++ b/service/history/api/reapplyevents/api.go
@@ -177,7 +177,7 @@ func Invoke(
 			reappliedEvents, err := eventsReapplier.ReapplyEvents(
 				ctx,
 				mutableState,
-				context.UpdateRegistry(ctx, mutableState),
+				context.UpdateRegistry(ctx, nil),
 				toReapplyEvents,
 				runID,
 			)

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -5176,7 +5176,7 @@ func (s *engineSuite) TestReapplyEvents_ReturnSuccess() {
 	gceResponse := &persistence.GetCurrentExecutionResponse{RunID: tests.RunID}
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), gomock.Any()).Return(gceResponse, nil)
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
-	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 	err := s.mockHistoryEngine.ReapplyEvents(
 		context.Background(),
@@ -5220,7 +5220,7 @@ func (s *engineSuite) TestReapplyEvents_IgnoreSameVersionEvents() {
 	gceResponse := &persistence.GetCurrentExecutionResponse{RunID: tests.RunID}
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), gomock.Any()).Return(gceResponse, nil)
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
-	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	err := s.mockHistoryEngine.ReapplyEvents(
 		context.Background(),
@@ -5269,7 +5269,7 @@ func (s *engineSuite) TestReapplyEvents_ResetWorkflow() {
 	gceResponse := &persistence.GetCurrentExecutionResponse{RunID: tests.RunID}
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), gomock.Any()).Return(gceResponse, nil).AnyTimes()
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
-	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	s.mockEventsReapplier.EXPECT().ReapplyEvents(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	s.mockWorkflowResetter.EXPECT().ResetWorkflow(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),

--- a/service/history/ndc/events_reapplier.go
+++ b/service/history/ndc/events_reapplier.go
@@ -37,6 +37,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/service/history/workflow"
+	"go.temporal.io/server/service/history/workflow/update"
 )
 
 type (
@@ -44,6 +45,7 @@ type (
 		ReapplyEvents(
 			ctx context.Context,
 			ms workflow.MutableState,
+			updateRegistry update.Registry,
 			historyEvents []*historypb.HistoryEvent,
 			runID string,
 		) ([]*historypb.HistoryEvent, error)
@@ -69,6 +71,7 @@ func NewEventsReapplier(
 func (r *EventsReapplierImpl) ReapplyEvents(
 	ctx context.Context,
 	ms workflow.MutableState,
+	updateRegistry update.Registry,
 	historyEvents []*historypb.HistoryEvent,
 	runID string,
 ) ([]*historypb.HistoryEvent, error) {
@@ -76,7 +79,7 @@ func (r *EventsReapplierImpl) ReapplyEvents(
 	if !ms.IsWorkflowExecutionRunning() {
 		return nil, serviceerror.NewInternal("unable to reapply events to closed workflow.")
 	}
-	reappliedEvents, err := reapplyEvents(ms, historyEvents, nil, runID)
+	reappliedEvents, err := reapplyEvents(ms, &updateRegistry, historyEvents, nil, runID)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/ndc/events_reapplier.go
+++ b/service/history/ndc/events_reapplier.go
@@ -79,7 +79,7 @@ func (r *EventsReapplierImpl) ReapplyEvents(
 	if !ms.IsWorkflowExecutionRunning() {
 		return nil, serviceerror.NewInternal("unable to reapply events to closed workflow.")
 	}
-	reappliedEvents, err := reapplyEvents(ms, &updateRegistry, historyEvents, nil, runID)
+	reappliedEvents, err := reapplyEvents(ms, updateRegistry, historyEvents, nil, runID)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/ndc/events_reapplier_mock.go
+++ b/service/history/ndc/events_reapplier_mock.go
@@ -35,6 +35,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	history "go.temporal.io/api/history/v1"
 	workflow "go.temporal.io/server/service/history/workflow"
+	update "go.temporal.io/server/service/history/workflow/update"
 )
 
 // MockEventsReapplier is a mock of EventsReapplier interface.
@@ -61,16 +62,16 @@ func (m *MockEventsReapplier) EXPECT() *MockEventsReapplierMockRecorder {
 }
 
 // ReapplyEvents mocks base method.
-func (m *MockEventsReapplier) ReapplyEvents(ctx context.Context, ms workflow.MutableState, historyEvents []*history.HistoryEvent, runID string) ([]*history.HistoryEvent, error) {
+func (m *MockEventsReapplier) ReapplyEvents(ctx context.Context, ms workflow.MutableState, updateRegistry update.Registry, historyEvents []*history.HistoryEvent, runID string) ([]*history.HistoryEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReapplyEvents", ctx, ms, historyEvents, runID)
+	ret := m.ctrl.Call(m, "ReapplyEvents", ctx, ms, updateRegistry, historyEvents, runID)
 	ret0, _ := ret[0].([]*history.HistoryEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReapplyEvents indicates an expected call of ReapplyEvents.
-func (mr *MockEventsReapplierMockRecorder) ReapplyEvents(ctx, ms, historyEvents, runID interface{}) *gomock.Call {
+func (mr *MockEventsReapplierMockRecorder) ReapplyEvents(ctx, ms, updateRegistry, historyEvents, runID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReapplyEvents", reflect.TypeOf((*MockEventsReapplier)(nil).ReapplyEvents), ctx, ms, historyEvents, runID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReapplyEvents", reflect.TypeOf((*MockEventsReapplier)(nil).ReapplyEvents), ctx, ms, updateRegistry, historyEvents, runID)
 }

--- a/service/history/ndc/events_reapplier_test.go
+++ b/service/history/ndc/events_reapplier_test.go
@@ -36,7 +36,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
-	"go.temporal.io/api/update/v1"
+	updatepb "go.temporal.io/api/update/v1"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/definition"
@@ -44,6 +44,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/service/history/workflow"
+	"go.temporal.io/server/service/history/workflow/update"
 )
 
 type (
@@ -97,6 +98,8 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Signal() {
 	attr := event.GetWorkflowExecutionSignaledEventAttributes()
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
+	msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
+	updateRegistry := update.NewRegistry(msCurrent)
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 	msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
@@ -115,7 +118,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Signal() {
 		{EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED},
 		event,
 	}
-	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, events, runID)
+	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, updateRegistry, events, runID)
 	s.NoError(err)
 	s.Equal(1, len(appliedEvent))
 }
@@ -130,7 +133,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 			EventId:   105,
 			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED,
 			Attributes: &historypb.HistoryEvent_WorkflowExecutionUpdateAdmittedEventAttributes{WorkflowExecutionUpdateAdmittedEventAttributes: &historypb.WorkflowExecutionUpdateAdmittedEventAttributes{
-				Request: &update.Request{Input: &update.Input{Args: payloads.EncodeString("update-request-payload")}},
+				Request: &updatepb.Request{Input: &updatepb.Input{Args: payloads.EncodeString("update-request-payload")}},
 				Origin:  enumspb.UPDATE_ADMITTED_EVENT_ORIGIN_UNSPECIFIED,
 			}},
 		},
@@ -138,12 +141,14 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 			EventId:   105,
 			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
 			Attributes: &historypb.HistoryEvent_WorkflowExecutionUpdateAcceptedEventAttributes{WorkflowExecutionUpdateAcceptedEventAttributes: &historypb.WorkflowExecutionUpdateAcceptedEventAttributes{
-				AcceptedRequest: &update.Request{Input: &update.Input{Args: payloads.EncodeString("update-request-payload")}},
+				AcceptedRequest: &updatepb.Request{Input: &updatepb.Input{Args: payloads.EncodeString("update-request-payload")}},
 			}},
 		},
 	} {
 
 		msCurrent := workflow.NewMockMutableState(s.controller)
+		msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
+		updateRegistry := update.NewRegistry(msCurrent)
 		msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 		msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 		msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
@@ -169,7 +174,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 			{EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED},
 			event,
 		}
-		appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, events, runID)
+		appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, updateRegistry, events, runID)
 		s.NoError(err)
 		s.Equal(1, len(appliedEvent))
 	}
@@ -188,6 +193,8 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Noop() {
 	}
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
+	msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
+	updateRegistry := update.NewRegistry(msCurrent)
 	dedupResource := definition.NewEventReappliedID(runID, event.GetEventId(), event.GetVersion())
 	msCurrent.EXPECT().IsResourceDuplicated(dedupResource).Return(true)
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
@@ -195,7 +202,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Noop() {
 		{EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED},
 		event,
 	}
-	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, events, runID)
+	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, updateRegistry, events, runID)
 	s.NoError(err)
 	s.Equal(0, len(appliedEvent))
 }
@@ -228,6 +235,8 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
 	attr1 := event1.GetWorkflowExecutionSignaledEventAttributes()
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
+	msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
+	updateRegistry := update.NewRegistry(msCurrent)
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 	msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
@@ -249,7 +258,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
 		event1,
 		event2,
 	}
-	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, events, runID)
+	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, updateRegistry, events, runID)
 	s.NoError(err)
 	s.Equal(1, len(appliedEvent))
 }
@@ -272,6 +281,8 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Error() {
 	attr := event.GetWorkflowExecutionSignaledEventAttributes()
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
+	msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
+	updateRegistry := update.NewRegistry(msCurrent)
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 	msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
@@ -288,7 +299,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Error() {
 		{EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED},
 		event,
 	}
-	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, events, runID)
+	appliedEvent, err := s.nDCReapplication.ReapplyEvents(context.Background(), msCurrent, updateRegistry, events, runID)
 	s.Error(err)
 	s.Equal(0, len(appliedEvent))
 }

--- a/service/history/ndc/events_reapplier_test.go
+++ b/service/history/ndc/events_reapplier_test.go
@@ -99,6 +99,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Signal() {
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
 	msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
+	msCurrent.EXPECT().GetCurrentVersion().Return(int64(0))
 	updateRegistry := update.NewRegistry(msCurrent)
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
@@ -148,6 +149,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 
 		msCurrent := workflow.NewMockMutableState(s.controller)
 		msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
+		msCurrent.EXPECT().GetCurrentVersion().Return(int64(0))
 		updateRegistry := update.NewRegistry(msCurrent)
 		msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 		msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
@@ -194,6 +196,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Noop() {
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
 	msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
+	msCurrent.EXPECT().GetCurrentVersion().Return(int64(0))
 	updateRegistry := update.NewRegistry(msCurrent)
 	dedupResource := definition.NewEventReappliedID(runID, event.GetEventId(), event.GetVersion())
 	msCurrent.EXPECT().IsResourceDuplicated(dedupResource).Return(true)
@@ -236,6 +239,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
 	msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
+	msCurrent.EXPECT().GetCurrentVersion().Return(int64(0))
 	updateRegistry := update.NewRegistry(msCurrent)
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
@@ -282,6 +286,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Error() {
 
 	msCurrent := workflow.NewMockMutableState(s.controller)
 	msCurrent.EXPECT().VisitUpdates(gomock.Any()).Return()
+	msCurrent.EXPECT().GetCurrentVersion().Return(int64(0))
 	updateRegistry := update.NewRegistry(msCurrent)
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()

--- a/service/history/ndc/events_reapplier_test.go
+++ b/service/history/ndc/events_reapplier_test.go
@@ -133,7 +133,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 			EventId:   105,
 			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED,
 			Attributes: &historypb.HistoryEvent_WorkflowExecutionUpdateAdmittedEventAttributes{WorkflowExecutionUpdateAdmittedEventAttributes: &historypb.WorkflowExecutionUpdateAdmittedEventAttributes{
-				Request: &updatepb.Request{Input: &updatepb.Input{Args: payloads.EncodeString("update-request-payload")}},
+				Request: &updatepb.Request{Input: &updatepb.Input{Args: payloads.EncodeString("update-request-payload")}, Meta: &updatepb.Meta{UpdateId: "update-1"}},
 				Origin:  enumspb.UPDATE_ADMITTED_EVENT_ORIGIN_UNSPECIFIED,
 			}},
 		},
@@ -141,7 +141,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 			EventId:   105,
 			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
 			Attributes: &historypb.HistoryEvent_WorkflowExecutionUpdateAcceptedEventAttributes{WorkflowExecutionUpdateAcceptedEventAttributes: &historypb.WorkflowExecutionUpdateAcceptedEventAttributes{
-				AcceptedRequest: &updatepb.Request{Input: &updatepb.Input{Args: payloads.EncodeString("update-request-payload")}},
+				AcceptedRequest: &updatepb.Request{Input: &updatepb.Input{Args: payloads.EncodeString("update-request-payload")}, Meta: &updatepb.Meta{UpdateId: "update-2"}},
 			}},
 		},
 	} {

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -304,6 +304,7 @@ func (r *transactionMgrImpl) backfillWorkflowEventsReapply(
 			if _, err := r.eventsReapplier.ReapplyEvents(
 				ctx,
 				targetWorkflow.GetMutableState(),
+				targetWorkflow.GetContext().UpdateRegistry(ctx, targetWorkflow.GetMutableState()),
 				totalEvents,
 				targetWorkflow.GetMutableState().GetExecutionState().GetRunId(),
 			); err != nil {

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -304,7 +304,7 @@ func (r *transactionMgrImpl) backfillWorkflowEventsReapply(
 			if _, err := r.eventsReapplier.ReapplyEvents(
 				ctx,
 				targetWorkflow.GetMutableState(),
-				targetWorkflow.GetContext().UpdateRegistry(ctx, targetWorkflow.GetMutableState()),
+				targetWorkflow.GetContext().UpdateRegistry(ctx, nil),
 				totalEvents,
 				targetWorkflow.GetMutableState().GetExecutionState().GetRunId(),
 			); err != nil {

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -182,7 +182,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Open()
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), s.mockShard, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, workflow.TransactionPolicyActive, (*workflow.TransactionPolicy)(nil),
 	).Return(nil)
-	weContext.EXPECT().UpdateRegistry(ctx, mutableState).Return(updateRegistry)
+	weContext.EXPECT().UpdateRegistry(ctx, nil).Return(updateRegistry)
 	err := s.transactionMgr.BackfillWorkflow(ctx, targetWorkflow, workflowEvents)
 	s.NoError(err)
 	s.True(releaseCalled)

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -769,6 +769,9 @@ func reapplyEvents(
 				continue
 			}
 			attr := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
+			if targetBranchUpdateRegistry != nil && (*targetBranchUpdateRegistry).Contains(attr.ProtocolInstanceId) {
+				continue
+			}
 			request := attr.GetAcceptedRequest()
 			if request == nil {
 				// An UpdateAccepted event lacks a request payload if and only if it is preceded by an UpdateAdmitted

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -757,6 +757,9 @@ func reapplyEvents(
 				continue
 			}
 			attr := event.GetWorkflowExecutionUpdateAdmittedEventAttributes()
+			if targetBranchUpdateRegistry != nil && (*targetBranchUpdateRegistry).Contains(attr.Request.Meta.UpdateId) {
+				continue
+			}
 			if _, err := mutableState.AddWorkflowExecutionUpdateAdmittedEvent(
 				attr.GetRequest(),
 				attr.Origin,

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -222,7 +222,7 @@ func (r *workflowResetterImpl) ResetWorkflow(
 	if err := reapplyEventsFn(ctx, resetMS); err != nil {
 		return err
 	}
-	if _, err := reapplyEvents(resetMS, nil, additionalReapplyEvents, nil, ""); err != nil {
+	if _, err := r.reapplyEvents(resetMS, additionalReapplyEvents, nil); err != nil {
 		return err
 	}
 

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -583,7 +583,6 @@ func (r *workflowResetterImpl) reapplyContinueAsNewWorkflowEvents(
 	nextRunID, err := r.reapplyEventsFromBranch(
 		ctx,
 		resetMutableState,
-		currentUpdateRegistry,
 		baseRebuildNextEventID,
 		baseNextEventID,
 		baseBranchToken,
@@ -641,7 +640,6 @@ func (r *workflowResetterImpl) reapplyContinueAsNewWorkflowEvents(
 		nextRunID, err = r.reapplyEventsFromBranch(
 			ctx,
 			resetMutableState,
-			currentUpdateRegistry,
 			common.FirstEventID,
 			nextWorkflowNextEventID,
 			nextWorkflowBranchToken,
@@ -664,7 +662,6 @@ func (r *workflowResetterImpl) reapplyContinueAsNewWorkflowEvents(
 func (r *workflowResetterImpl) reapplyEventsFromBranch(
 	ctx context.Context,
 	mutableState workflow.MutableState,
-	currentUpdateRegistry update.Registry,
 	firstEventID int64,
 	nextEventID int64,
 	branchToken []byte,

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -718,7 +718,7 @@ func (r *workflowResetterImpl) reapplyEvents(
 
 func reapplyEvents(
 	mutableState workflow.MutableState,
-	targetBranchUpdateRegistry *update.Registry,
+	targetBranchUpdateRegistry update.Registry,
 	events []*historypb.HistoryEvent,
 	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
 	runIdForDeduplication string,
@@ -757,7 +757,7 @@ func reapplyEvents(
 				continue
 			}
 			attr := event.GetWorkflowExecutionUpdateAdmittedEventAttributes()
-			if targetBranchUpdateRegistry != nil && (*targetBranchUpdateRegistry).Contains(attr.Request.Meta.UpdateId) {
+			if targetBranchUpdateRegistry != nil && targetBranchUpdateRegistry.Contains(attr.Request.Meta.UpdateId) {
 				continue
 			}
 			if _, err := mutableState.AddWorkflowExecutionUpdateAdmittedEvent(
@@ -772,7 +772,7 @@ func reapplyEvents(
 				continue
 			}
 			attr := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
-			if targetBranchUpdateRegistry != nil && (*targetBranchUpdateRegistry).Contains(attr.ProtocolInstanceId) {
+			if targetBranchUpdateRegistry != nil && targetBranchUpdateRegistry.Contains(attr.ProtocolInstanceId) {
 				continue
 			}
 			request := attr.GetAcceptedRequest()

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -139,7 +139,7 @@ func (r *workflowResetterImpl) ResetWorkflow(
 	var currentWorkflowEventsSeq []*persistence.WorkflowEvents
 	var reapplyEventsFn workflowResetReapplyEventsFn
 	currentMutableState := currentWorkflow.GetMutableState()
-	currentUpdateRegistry := currentWorkflow.GetContext().UpdateRegistry(ctx, currentMutableState)
+	currentUpdateRegistry := currentWorkflow.GetContext().UpdateRegistry(ctx, nil)
 	if currentMutableState.IsWorkflowExecutionRunning() {
 		if err := r.terminateWorkflow(
 			currentMutableState,

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -37,7 +37,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
-	"go.temporal.io/api/update/v1"
+	updatepb "go.temporal.io/api/update/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	historyspb "go.temporal.io/server/api/history/v1"
@@ -58,6 +58,7 @@ import (
 	"go.temporal.io/server/service/history/tests"
 	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
+	"go.temporal.io/server/service/history/workflow/update"
 )
 
 type (
@@ -602,10 +603,13 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithOutCo
 	}, nil)
 
 	mutableState := workflow.NewMockMutableState(s.controller)
+	mutableState.EXPECT().VisitUpdates(gomock.Any()).Return()
+	updateRegistry := update.NewRegistry(mutableState)
 
 	lastVisitedRunID, err := s.workflowResetter.reapplyContinueAsNewWorkflowEvents(
 		ctx,
 		mutableState,
+		updateRegistry,
 		s.namespaceID,
 		s.workflowID,
 		s.baseRunID,
@@ -720,10 +724,13 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithConti
 	_, _ = s.workflowResetter.workflowCache.(*wcache.CacheImpl).PutIfNotExist(resetContextCacheKey, resetContext)
 
 	mutableState := workflow.NewMockMutableState(s.controller)
+	mutableState.EXPECT().VisitUpdates(gomock.Any()).Return()
+	updateRegistry := update.NewRegistry(mutableState)
 
 	lastVisitedRunID, err := s.workflowResetter.reapplyContinueAsNewWorkflowEvents(
 		ctx,
 		mutableState,
+		updateRegistry,
 		s.namespaceID,
 		s.workflowID,
 		s.baseRunID,
@@ -784,10 +791,13 @@ func (s *workflowResetterSuite) TestReapplyWorkflowEvents() {
 	}, nil)
 
 	mutableState := workflow.NewMockMutableState(s.controller)
+	mutableState.EXPECT().VisitUpdates(gomock.Any()).Return()
+	updateRegistry := update.NewRegistry(mutableState)
 
-	nextRunID, err := s.workflowResetter.reapplyWorkflowEvents(
+	nextRunID, err := s.workflowResetter.reapplyEventsFromBranch(
 		context.Background(),
 		mutableState,
+		updateRegistry,
 		firstEventID,
 		nextEventID,
 		branchToken,
@@ -833,7 +843,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED,
 		Attributes: &historypb.HistoryEvent_WorkflowExecutionUpdateAdmittedEventAttributes{
 			WorkflowExecutionUpdateAdmittedEventAttributes: &historypb.WorkflowExecutionUpdateAdmittedEventAttributes{
-				Request: &update.Request{Input: &update.Input{Args: payloads.EncodeString("update-request-payload-1")}},
+				Request: &updatepb.Request{Input: &updatepb.Input{Args: payloads.EncodeString("update-request-payload-1")}},
 				Origin:  enumspb.UPDATE_ADMITTED_EVENT_ORIGIN_UNSPECIFIED,
 			},
 		},
@@ -843,7 +853,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
 		Attributes: &historypb.HistoryEvent_WorkflowExecutionUpdateAcceptedEventAttributes{
 			WorkflowExecutionUpdateAcceptedEventAttributes: &historypb.WorkflowExecutionUpdateAcceptedEventAttributes{
-				AcceptedRequest: &update.Request{Input: &update.Input{Args: payloads.EncodeString("update-request-payload-1")}},
+				AcceptedRequest: &updatepb.Request{Input: &updatepb.Input{Args: payloads.EncodeString("update-request-payload-1")}},
 			},
 		},
 	}
@@ -885,7 +895,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 		}
 	}
 
-	_, err := reapplyEvents(ms, events, nil, "")
+	_, err := reapplyEvents(ms, nil, events, nil, "")
 	s.NoError(err)
 }
 

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -604,6 +604,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithOutCo
 
 	mutableState := workflow.NewMockMutableState(s.controller)
 	mutableState.EXPECT().VisitUpdates(gomock.Any()).Return()
+	mutableState.EXPECT().GetCurrentVersion().Return(int64(0))
 	updateRegistry := update.NewRegistry(mutableState)
 
 	lastVisitedRunID, err := s.workflowResetter.reapplyContinueAsNewWorkflowEvents(
@@ -725,6 +726,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithConti
 
 	mutableState := workflow.NewMockMutableState(s.controller)
 	mutableState.EXPECT().VisitUpdates(gomock.Any()).Return()
+	mutableState.EXPECT().GetCurrentVersion().Return(int64(0))
 	updateRegistry := update.NewRegistry(mutableState)
 
 	lastVisitedRunID, err := s.workflowResetter.reapplyContinueAsNewWorkflowEvents(
@@ -791,7 +793,6 @@ func (s *workflowResetterSuite) TestReapplyWorkflowEvents() {
 	}, nil)
 
 	mutableState := workflow.NewMockMutableState(s.controller)
-	mutableState.EXPECT().VisitUpdates(gomock.Any()).Return()
 
 	nextRunID, err := s.workflowResetter.reapplyEventsFromBranch(
 		context.Background(),

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -792,12 +792,10 @@ func (s *workflowResetterSuite) TestReapplyWorkflowEvents() {
 
 	mutableState := workflow.NewMockMutableState(s.controller)
 	mutableState.EXPECT().VisitUpdates(gomock.Any()).Return()
-	updateRegistry := update.NewRegistry(mutableState)
 
 	nextRunID, err := s.workflowResetter.reapplyEventsFromBranch(
 		context.Background(),
 		mutableState,
-		updateRegistry,
 		firstEventID,
 		nextEventID,
 		branchToken,

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -78,6 +78,8 @@ type (
 		// Abort all incomplete updates in the registry.
 		Abort(reason AbortReason)
 
+		Contains(protocolInstanceID string) bool
+
 		// Clear registry and abort all waiters.
 		Clear()
 
@@ -216,6 +218,11 @@ func (r *registry) Abort(reason AbortReason) {
 	for _, upd := range r.updates {
 		upd.abort(reason)
 	}
+}
+
+// Contains returns true iff the update ID exists in the registry.
+func (r *registry) Contains(id string) bool {
+	return r.updates[id] != nil
 }
 
 // RejectUnprocessed reject all updates that are waiting for workflow task to be completed.

--- a/tests/xdc/history_replication_signals_and_updates_test.go
+++ b/tests/xdc/history_replication_signals_and_updates_test.go
@@ -171,7 +171,7 @@ func (s *hrsuTestSuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *hrsuTestSuite) startHrsuTest() (hrsuTest, context.Context, context.CancelFunc) {
+func (s *hrsuTestSuite) startHrsuTest() (*hrsuTest, context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	tv := testvars.New(s.T().Name())
 	ns := tv.NamespaceName().String()
@@ -187,7 +187,7 @@ func (s *hrsuTestSuite) startHrsuTest() (hrsuTest, context.Context, context.Canc
 	t.cluster1 = t.newHrsuTestCluster(ns, s.clusterNames[0], s.cluster1)
 	t.cluster2 = t.newHrsuTestCluster(ns, s.clusterNames[1], s.cluster2)
 	t.registerMultiRegionNamespace(ctx)
-	return t, ctx, cancel
+	return &t, ctx, cancel
 }
 
 func (t *hrsuTest) newHrsuTestCluster(ns string, name string, cluster *tests.TestCluster) hrsuTestCluster {


### PR DESCRIPTION
## What changed?
Skip reapplying an `UpdateAdmitted` event if an update with that ID already exists.

## Why?
In a split-brain scenario it is possible for both clusters to accept an update with the same ID. Prior to this PR, conflict resolution would create an `UpdateAdmitted` event via a reapply, despite the fact that the update ID conflicts with the other update. This state would not be correct: the update registry can only hold one of them and it would not be possible to interact with both updates (i.e. the worker will not be able to accept/reject/complete both of them).

### Summary:
- We have a function that takes a slice of events and decides whether to "reapply" them.
- It is called during `WorkflowReset` (might need to reapply a signal/update in the portion of history being lost) and on conflict resolution (might need to reapply a signal/update accepted in another cluster during a split brain situation)
- In the conflict resolution case, there's a possibility that the incoming accepted request might have an ID that conflicts with one already in-flight
- But that's not possible in the reset case (the workflow state was consistent before reset)
- So we need to check for this in the conflict resolution case at least. That requires having access to a registry (representing the state of the receiving branch)
- The PR passes the registry down through the stack to the reapply function.
- Reset doesn't need the check, so we use a nil registry argument in that case.

## How did you test it?
Test in PR simulates a split-brain situation and performs a reset to generate the `UpdateAdmitted` event: `TestHistoryReplicationSignalsAndUpdatesTestSuite/TestConflictResolutionReappliesUpdatesSameIds `

## Potential risks
It could break workflow reset and history event conflict resolution if it is not correct.

## Is hotfix candidate?
Yes, it should be included in 1.24.

## Note to reviewers:

The first commit in the PR is noisy refactoring -- it is just passing the update registry down the stack: 4087447faf4e7926eaea60d98d44e6f004f19291. The following diff view shows the real changes after that refactoring: https://github.com/temporalio/temporal/compare/4087447faf4e7926eaea60d98d44e6f004f19291...OSS-2553-conflicting-update-ids