### PR TITLE
Add destination to dynamic config filter

### DIFF
--- a/common/dynamicconfig/client.go
+++ b/common/dynamicconfig/client.go
@@ -98,6 +98,7 @@ type (
 		TaskQueueType enumspb.TaskQueueType
 		ShardID       int32
 		TaskType      enumsspb.TaskType
+		Destination   string
 	}
 )
 

--- a/common/dynamicconfig/collection_test.go
+++ b/common/dynamicconfig/collection_test.go
@@ -54,6 +54,7 @@ const (
 	testGetBoolPropertyFilteredByNamespaceIDKey       = "testGetBoolPropertyFilteredByNamespaceIDKey"
 	testGetBoolPropertyFilteredByTaskQueueInfoKey     = "testGetBoolPropertyFilteredByTaskQueueInfoKey"
 	testGetStringPropertyFilteredByNamespaceIDKey     = "testGetStringPropertyFilteredByNamespaceIDKey"
+	testGetIntPropertyFilteredByDestinationKey        = "testGetIntPropertyFilteredByDestinationKey"
 )
 
 // Note: fileBasedClientSuite also heavily tests Collection, since some tests are easier with data
@@ -260,6 +261,46 @@ func (s *collectionSuite) TestGetMapProperty() {
 	s.client[testGetMapPropertyKey] = val
 	s.Equal(val, value())
 	s.Equal("321", value()["testKey"])
+}
+
+func (s *collectionSuite) TestGetIntPropertyFilteredByDestination() {
+	namespaceID := "testNamespaceID"
+	destination1 := "testDestination1"
+	destination2 := "testDestination2"
+	value := s.cln.GetIntPropertyFilteredByDestination(testGetIntPropertyFilteredByDestinationKey, 10)
+	s.Equal(10, value(namespaceID, destination1))
+	s.client[testGetIntPropertyFilteredByDestinationKey] = []ConstrainedValue{
+		{
+			Constraints: Constraints{
+				NamespaceID: namespaceID,
+				Destination: destination1,
+			},
+			Value: 50,
+		},
+		{
+			Constraints: Constraints{
+				NamespaceID: namespaceID,
+			},
+			Value: 75,
+		},
+		{
+			Constraints: Constraints{
+				Destination: destination1,
+			},
+			Value: 90,
+		},
+		{
+			Constraints: Constraints{
+				Destination: destination2,
+			},
+			Value: 100,
+		},
+	}
+	s.Equal(50, value(namespaceID, destination1))
+	s.Equal(75, value(namespaceID, "testAnotherDestination"))
+	s.Equal(90, value("testAnotherNamespaceID", destination1))
+	s.Equal(100, value(namespaceID, destination2)) // priority: destination >>> namespace
+	s.Equal(10, value("testAnotherNamespaceID", "testAnotherDestination"))
 }
 
 func (s *collectionSuite) TestFindMatch() {

--- a/common/dynamicconfig/config/testConfig.yaml
+++ b/common/dynamicconfig/config/testConfig.yaml
@@ -84,3 +84,19 @@ testGetDurationPropertyFilteredByTaskTypeKey:
   - value: 10s
     constraints:
       historytasktype: 1
+testGetIntPropertyFilteredByDestinationKey:
+  - value: 10
+    constraints: {}
+  - value: 20
+    constraints:
+      namespaceID: test-namespace-id
+      destination: test-destination-1
+  - value: 30
+    constraints:
+      namespaceID: test-namespace-id
+  - value: 40
+    constraints:
+      destination: test-destination-1
+  - value: 50
+    constraints:
+      destination: test-destination-2

--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -298,6 +298,9 @@ func (fc *fileBasedClient) appendConstrainedValue(logLine *strings.Builder, valu
 		if value.Constraints.TaskType != enumsspb.TASK_TYPE_UNSPECIFIED {
 			logLine.WriteString(fmt.Sprintf("{HistoryTaskType:%s}", value.Constraints.TaskType))
 		}
+		if value.Constraints.Destination != "" {
+			logLine.WriteString(fmt.Sprintf("{Destination:%s}", value.Constraints.Destination))
+		}
 		logLine.WriteString(fmt.Sprint("} value: ", value.Value, " }"))
 	}
 }
@@ -402,6 +405,12 @@ func convertYamlConstraints(m map[string]any) (Constraints, error) {
 				cs.ShardID = int32(v)
 			} else {
 				return cs, fmt.Errorf("shardID constraint must be integer")
+			}
+		case "destination":
+			if v, ok := v.(string); ok {
+				cs.Destination = v
+			} else {
+				return cs, fmt.Errorf("destination constraint must be string")
 			}
 		default:
 			return cs, fmt.Errorf("unknown constraint type %q", k)

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -167,6 +167,15 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilterByTQ_MatchFallback() {
 	s.Equal(v1, v2)
 }
 
+func (s *fileBasedClientSuite) TestGetIntValue_FilterByDestination() {
+	dc := s.collection.GetIntPropertyFilteredByDestination(testGetIntPropertyFilteredByDestinationKey, 5)
+	s.Equal(10, dc("foo", "bar"))
+	s.Equal(20, dc("test-namespace-id", "test-destination-1"))
+	s.Equal(30, dc("test-namespace-id", "random-destination"))
+	s.Equal(40, dc("random-namespace-id", "test-destination-1"))
+	s.Equal(50, dc("test-namespace-id", "test-destination-2"))
+}
+
 func (s *fileBasedClientSuite) TestGetFloatValue() {
 	v := s.collection.GetFloat64Property(testGetFloat64PropertyKey, 1)()
 	s.Equal(12.0, v)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add destination filter to dynamic config. It also filters by namespace ID instead of namespace name because of how the existing outbound task key is built.

## Why?
<!-- Tell your future self why have you made these changes -->
Be able to create specific dynamic configs by destination.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
