### PR TITLE
Adding documentation for history.TaskDLQErrorPattern flag

### DIFF
--- a/docs/admin/dlq.md
+++ b/docs/admin/dlq.md
@@ -16,7 +16,7 @@ You can specify the maximum number of task execution attempts with unexpected er
 If you need to capture tasks that fail with specific errors, you can utilize the config flag `history.TaskDLQErrorPattern`. 
 This allows you to define a regular expression that will match one or more errors. However, exercise caution when 
 specifying the regular expression to avoid unintended matches. Once configured, all task processing errors will be 
-compared against this pattern, which could affect performance. Therefore, use this flag only when absolutely necessary.
+compared against this pattern, which could affect performance. Therefore, use this flag only when necessary.
 
 ## Detection
 There is a metric `dlq_writes`, which is incremented each time a message is enqueued to the DLQ.

--- a/docs/admin/dlq.md
+++ b/docs/admin/dlq.md
@@ -13,6 +13,11 @@ To enable the DLQ for non-replication history tasks, set `history.TaskDLQEnabled
 You can specify the maximum number of task execution attempts with unexpected errors using the dynamic config
 `history.TaskDLQUnexpectedErrorAttempts`. The task will be sent to DLQ after the specified number of attempts.
 
+If you need to capture tasks that fail with specific errors, you can utilize the config flag `history.TaskDLQErrorPattern`. 
+This allows you to define a regular expression that will match one or more errors. However, exercise caution when 
+specifying the regular expression to avoid unintended matches. Once configured, all task processing errors will be 
+compared against this pattern, which could affect performance. Therefore, use this flag only when absolutely necessary.
+
 ## Detection
 There is a metric `dlq_writes`, which is incremented each time a message is enqueued to the DLQ.
 You can use this to determine when a task encountered a terminal error and needs manual resolution.


### PR DESCRIPTION
## What changed?
Adding documentation for the config flag history.TaskDLQErrorPattern in docs/admin/dlq.md.

## Why?

## How did you test it?

## Potential risks

## Documentation

## Is hotfix candidate?
No
