### PR TITLE
Propagate Nexus request timeout to workers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/lib/pq v1.10.9
-	github.com/nexus-rpc/sdk-go v0.0.7
+	github.com/nexus-rpc/sdk-go v0.0.8-0.20240416165501-deaa711b224e
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/olivere/elastic/v7 v7.0.32
 	github.com/pborman/uuid v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/nexus-rpc/sdk-go v0.0.7 h1:pWtQnc7Vui/y05dqHlvTX1EgMYYeXpIk0xfngD4haEc=
-github.com/nexus-rpc/sdk-go v0.0.7/go.mod h1:uBe8fX151zUW9DhXxwHjji19d6YfnNUqJ81tR3JbwHY=
+github.com/nexus-rpc/sdk-go v0.0.8-0.20240416165501-deaa711b224e h1:JrDYxSHype+PbRXMHcjTAQwnozkl/7VhxzWyf741oz4=
+github.com/nexus-rpc/sdk-go v0.0.8-0.20240416165501-deaa711b224e/go.mod h1:uBe8fX151zUW9DhXxwHjji19d6YfnNUqJ81tR3JbwHY=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -35,6 +35,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/pborman/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -1653,10 +1654,14 @@ pollLoop:
 			TaskId:      task.nexus.taskID,
 		}
 		serializedToken, _ := e.tokenSerializer.SerializeNexusTaskToken(taskToken)
+
+		nexusReq := task.nexus.request.GetRequest()
+		nexusReq.Header[nexus.HeaderRequestTimeout] = time.Until(task.nexus.deadline).String()
+
 		return &matchingservice.PollNexusTaskQueueResponse{
 			Response: &workflowservice.PollNexusTaskQueueResponse{
 				TaskToken: serializedToken,
-				Request:   task.nexus.request.GetRequest(),
+				Request:   nexusReq,
 			},
 		}, nil
 	}

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -340,7 +340,8 @@ func (c *physicalTaskQueueManagerImpl) DispatchNexusTask(
 	taskId string,
 	request *matchingservice.DispatchNexusTaskRequest,
 ) (*matchingservice.DispatchNexusTaskResponse, error) {
-	task := newInternalNexusTask(taskId, request)
+	deadline, _ := ctx.Deadline() // If not set by user, our client will set a default.
+	task := newInternalNexusTask(taskId, deadline, request)
 	return c.matcher.OfferNexusTask(ctx, task)
 }
 

--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -25,6 +25,8 @@
 package matching
 
 import (
+	"time"
+
 	commonpb "go.temporal.io/api/common/v1"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -46,8 +48,9 @@ type (
 	}
 	// nexusTaskInfo contains the info for a nexus task
 	nexusTaskInfo struct {
-		taskID  string
-		request *matchingservice.DispatchNexusTaskRequest
+		taskID   string
+		deadline time.Time
+		request  *matchingservice.DispatchNexusTaskRequest
 	}
 	// startedTaskInfo contains info for any task received from
 	// another matching host. This type of task is already marked as started
@@ -109,12 +112,14 @@ func newInternalQueryTask(
 
 func newInternalNexusTask(
 	taskID string,
+	deadline time.Time,
 	request *matchingservice.DispatchNexusTaskRequest,
 ) *internalTask {
 	return &internalTask{
 		nexus: &nexusTaskInfo{
-			taskID:  taskID,
-			request: request,
+			taskID:   taskID,
+			deadline: deadline,
+			request:  request,
 		},
 		forwardedFrom: request.GetForwardedSource(),
 		responseC:     make(chan error, 1),


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Propagating the timeout value from Nexus request headers to a matching task deadline.

## Why?
<!-- Tell your future self why have you made these changes -->
So workers polling for Nexus tasks know how long they have to complete an operation.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
New functional tests
