### PR TITLE
Rename RedirectRuleMaxChainLength to RedirectRuleMaxUpstreamBuildIDs

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -207,10 +207,10 @@ const (
 	// in the versioning data for a task queue. Update requests which would cause the versioning data to exceed this
 	// number will fail with a FailedPrecondition error.
 	RedirectRuleLimitPerQueue = "limit.wv.RedirectRuleLimitPerQueue"
-	// RedirectRuleChainLimitPerQueue is the max number of compatible redirect rules allowed to be connected
+	// RedirectRuleMaxUpstreamBuildIDsPerQueue is the max number of compatible redirect rules allowed to be connected
 	// in one chain in the versioning data for a task queue. Update requests which would cause the versioning data
 	// to exceed this number will fail with a FailedPrecondition error.
-	RedirectRuleChainLimitPerQueue = "limit.wv.RedirectRuleChainLimitPerQueue"
+	RedirectRuleMaxUpstreamBuildIDsPerQueue = "limit.wv.RedirectRuleMaxUpstreamBuildIDsPerQueue"
 	// MatchingDeletedRuleRetentionTime is the length of time that deleted Version Assignment Rules and
 	// Deleted Redirect Rules will be kept in the DB (with DeleteTimestamp). After this time, the tombstones are deleted at the next time update of versioning data for the task queue.
 	MatchingDeletedRuleRetentionTime = "matching.wv.DeletedRuleRetentionTime"

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -367,9 +367,9 @@ func WorkerVersioningRedirectRuleCount(redirectRuleCount int) ZapTag {
 	return NewInt("worker-versioning-redirect-rule-count", redirectRuleCount)
 }
 
-// WorkerVersioningMaxRedirectRuleChain returns tag for RedirectRuleCount
-func WorkerVersioningMaxRedirectRuleChain(maxChainLen int) ZapTag {
-	return NewInt("worker-versioning-max-redirect-rule-chain", maxChainLen)
+// WorkerVersioningMaxUpstreamBuildIDs returns tag for RedirectRuleCount
+func WorkerVersioningMaxUpstreamBuildIDs(maxUpstreamBuildIDs int) ZapTag {
+	return NewInt("worker-versioning-max-upstream-build-ids", maxUpstreamBuildIDs)
 }
 
 // ScheduleID returns tag for ScheduleID

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -70,7 +70,7 @@ type (
 		VersionBuildIdLimitPerQueue              dynamicconfig.IntPropertyFnWithNamespaceFilter
 		AssignmentRuleLimitPerQueue              dynamicconfig.IntPropertyFnWithNamespaceFilter
 		RedirectRuleLimitPerQueue                dynamicconfig.IntPropertyFnWithNamespaceFilter
-		RedirectRuleChainLimitPerQueue           dynamicconfig.IntPropertyFnWithNamespaceFilter
+		RedirectRuleMaxUpstreamBuildIDsPerQueue  dynamicconfig.IntPropertyFnWithNamespaceFilter
 		DeletedRuleRetentionTime                 dynamicconfig.DurationPropertyFnWithNamespaceFilter
 		ReachabilityBuildIdVisibilityGracePeriod dynamicconfig.DurationPropertyFnWithNamespaceFilter
 		ReachabilityCacheOpenWFsTTL              dynamicconfig.DurationPropertyFn
@@ -206,7 +206,7 @@ func NewConfig(
 		VersionBuildIdLimitPerQueue:              dc.GetIntPropertyFilteredByNamespace(dynamicconfig.VersionBuildIdLimitPerQueue, 100),
 		AssignmentRuleLimitPerQueue:              dc.GetIntPropertyFilteredByNamespace(dynamicconfig.AssignmentRuleLimitPerQueue, 100),
 		RedirectRuleLimitPerQueue:                dc.GetIntPropertyFilteredByNamespace(dynamicconfig.RedirectRuleLimitPerQueue, 500),
-		RedirectRuleChainLimitPerQueue:           dc.GetIntPropertyFilteredByNamespace(dynamicconfig.RedirectRuleChainLimitPerQueue, 50),
+		RedirectRuleMaxUpstreamBuildIDsPerQueue:  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.RedirectRuleMaxUpstreamBuildIDsPerQueue, 50),
 		DeletedRuleRetentionTime:                 dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.MatchingDeletedRuleRetentionTime, 14*24*time.Hour),
 		ReachabilityBuildIdVisibilityGracePeriod: dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.ReachabilityBuildIdVisibilityGracePeriod, 3*time.Minute),
 		ReachabilityCacheOpenWFsTTL:              dc.GetDurationProperty(dynamicconfig.ReachabilityCacheOpenWFsTTL, time.Minute),

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -73,9 +73,9 @@ var (
 	errExceedsMaxRedirectRules            = func(cnt, max int) error {
 		return serviceerror.NewFailedPrecondition(fmt.Sprintf("update exceeds number of redirect rules permitted in namespace (%v/%v)", cnt, max))
 	}
-	errIsCyclic            = serviceerror.NewFailedPrecondition("update would break acyclic requirement")
-	errExceedsMaxRuleChain = func(cnt, max int) error {
-		return serviceerror.NewFailedPrecondition(fmt.Sprintf("update exceeds number of chained redirect rules permitted in namespace (%v/%v)", cnt, max))
+	errIsCyclic                   = serviceerror.NewFailedPrecondition("update would break acyclic requirement")
+	errExceedsMaxUpstreamBuildIDs = func(cnt, max int) error {
+		return serviceerror.NewFailedPrecondition(fmt.Sprintf("update exceeds number of upstream build ids permitted in namespace (%v/%v)", cnt, max))
 	}
 	errUnversionedRedirectRuleTarget = serviceerror.NewInvalidArgument("the unversioned build id cannot be the target of a redirect rule")
 )
@@ -176,7 +176,7 @@ func AddCompatibleRedirectRule(timestamp *hlc.Clock,
 	data *persistencespb.VersioningData,
 	req *workflowservice.UpdateWorkerVersioningRulesRequest_AddCompatibleBuildIdRedirectRule,
 	maxRedirectRules,
-	maxRedirectRuleChain int) (*persistencespb.VersioningData, error) {
+	maxUpstreamBuildIds int) (*persistencespb.VersioningData, error) {
 	data = cloneOrMkData(data)
 	rule := req.GetRule()
 	source := rule.GetSourceBuildId()
@@ -204,13 +204,13 @@ func AddCompatibleRedirectRule(timestamp *hlc.Clock,
 		CreateTimestamp: timestamp,
 		DeleteTimestamp: nil,
 	})
-	return data, checkRedirectConditions(data, maxRedirectRules, maxRedirectRuleChain)
+	return data, checkRedirectConditions(data, maxRedirectRules, maxUpstreamBuildIds)
 }
 
 func ReplaceCompatibleRedirectRule(timestamp *hlc.Clock,
 	data *persistencespb.VersioningData,
 	req *workflowservice.UpdateWorkerVersioningRulesRequest_ReplaceCompatibleBuildIdRedirectRule,
-	maxRedirectRuleChain int,
+	maxUpstreamBuildIDs int,
 ) (*persistencespb.VersioningData, error) {
 	data = cloneOrMkData(data)
 	rule := req.GetRule()
@@ -234,7 +234,7 @@ func ReplaceCompatibleRedirectRule(timestamp *hlc.Clock,
 				CreateTimestamp: timestamp,
 				DeleteTimestamp: nil,
 			})
-			return data, checkRedirectConditions(data, 0, maxRedirectRuleChain)
+			return data, checkRedirectConditions(data, 0, maxUpstreamBuildIDs)
 		}
 	}
 	return nil, errSourceNotFound(source)
@@ -368,9 +368,9 @@ func checkAssignmentConditions(g *persistencespb.VersioningData, maxARs int, req
 // It returns an error if the new set of redirect rules don't meet the following requirements:
 //   - No more rules than dynamicconfig.VersionRedirectRuleLimitPerQueue
 //   - The DAG of redirect rules must not contain a cycle
-//   - The DAG of redirect rules must not contain a chain of connected rules longer than dynamicconfig.VersionRedirectRuleChainLimitPerQueue
+//   - The DAG of redirect rules must not contain a chain of connected rules longer than dynamicconfig.VersionRedirectRuleMaxUpstreamBuildIDsPerQueue
 //     (Here, a "chain" counts the # of vertices, not the # of edges. So 3 ---> 4 ---> 5 has a chain length of 3)
-func checkRedirectConditions(g *persistencespb.VersioningData, maxRRs, maxChain int) error {
+func checkRedirectConditions(g *persistencespb.VersioningData, maxRRs, maxUpstreamBuildIds int) error {
 	activeRules := getActiveRedirectRules(g.GetRedirectRules())
 	if maxRRs > 0 && len(activeRules) > maxRRs {
 		return errExceedsMaxRedirectRules(len(activeRules), maxRRs)
@@ -380,8 +380,8 @@ func checkRedirectConditions(g *persistencespb.VersioningData, maxRRs, maxChain 
 	}
 	for _, r := range activeRules {
 		upstream := getUpstreamBuildIds(r.GetRule().GetTargetBuildId(), activeRules)
-		if len(upstream)+1 > maxChain {
-			return errExceedsMaxRuleChain(len(upstream)+1, maxChain)
+		if len(upstream) > maxUpstreamBuildIds {
+			return errExceedsMaxUpstreamBuildIDs(len(upstream), maxUpstreamBuildIds)
 		}
 	}
 	return nil

--- a/service/matching/version_rule_test.go
+++ b/service/matching/version_rule_test.go
@@ -42,8 +42,8 @@ import (
 )
 
 const (
-	ignoreMaxRules = 1000
-	ignoreMaxChain = 1000
+	ignoreMaxRules            = 1000
+	ignoreMaxUpstreamBuildIDs = 1000
 )
 
 func mkNewInsertAssignmentReq(rule *taskqueuepb.BuildIdAssignmentRule, ruleIdx int32) *workflowservice.UpdateWorkerVersioningRulesRequest_InsertBuildIdAssignmentRule {
@@ -150,9 +150,9 @@ func insertRedirectRule(rule *taskqueuepb.CompatibleBuildIdRedirectRule,
 	data *persistencepb.VersioningData,
 	clock *hlc.Clock,
 	maxRedirectRules,
-	maxRedirectRuleChain int,
+	maxUpstreamBuildIDs int,
 ) (*persistencepb.VersioningData, error) {
-	return AddCompatibleRedirectRule(clock, data, mkNewInsertRedirectReq(rule), maxRedirectRules, maxRedirectRuleChain)
+	return AddCompatibleRedirectRule(clock, data, mkNewInsertRedirectReq(rule), maxRedirectRules, maxUpstreamBuildIDs)
 }
 
 func replaceAssignmentRule(rule *taskqueuepb.BuildIdAssignmentRule,
@@ -167,9 +167,9 @@ func replaceAssignmentRule(rule *taskqueuepb.BuildIdAssignmentRule,
 func replaceRedirectRule(rule *taskqueuepb.CompatibleBuildIdRedirectRule,
 	data *persistencepb.VersioningData,
 	clock *hlc.Clock,
-	maxRedirectRuleChain int,
+	maxUpstreamBuildIDs int,
 ) (*persistencepb.VersioningData, error) {
-	return ReplaceCompatibleRedirectRule(clock, data, mkNewReplaceRedirectReq(rule), maxRedirectRuleChain)
+	return ReplaceCompatibleRedirectRule(clock, data, mkNewReplaceRedirectReq(rule), maxUpstreamBuildIDs)
 }
 
 func deleteAssignmentRule(data *persistencepb.VersioningData,
@@ -285,7 +285,7 @@ func TestInsertAssignmentRuleInVersionSet(t *testing.T) {
 func TestInsertAssignmentRuleRampedRuleIsRedirectSource(t *testing.T) {
 	t.Parallel()
 	clock := hlc.Zero(1)
-	data, err := insertRedirectRule(mkRedirectRule("0", "1"), mkInitialData(0, clock), clock, ignoreMaxRules, ignoreMaxChain)
+	data, err := insertRedirectRule(mkRedirectRule("0", "1"), mkInitialData(0, clock), clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.NoError(t, err)
 
 	// insert 1 --> failure
@@ -583,7 +583,7 @@ func TestAddRedirectRuleBasic(t *testing.T) {
 	expectedSet := make([]*persistencepb.RedirectRule, 0)
 
 	rule1 := mkRedirectRule("1", "0")
-	data, err := insertRedirectRule(rule1, initialData, clock, ignoreMaxRules, ignoreMaxChain)
+	data, err := insertRedirectRule(rule1, initialData, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.NoError(t, err)
 	expectedSet = append(expectedSet, mkRedirectRulePersistence(rule1, clock, nil))
 	for _, r := range data.RedirectRules {
@@ -591,7 +591,7 @@ func TestAddRedirectRuleBasic(t *testing.T) {
 	}
 
 	rule2 := mkRedirectRule("2", "0")
-	data, err = insertRedirectRule(rule2, data, clock, ignoreMaxRules, ignoreMaxChain)
+	data, err = insertRedirectRule(rule2, data, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.NoError(t, err)
 	expectedSet = append(expectedSet, mkRedirectRulePersistence(rule2, clock, nil))
 	for _, r := range data.RedirectRules {
@@ -599,7 +599,7 @@ func TestAddRedirectRuleBasic(t *testing.T) {
 	}
 
 	rule3 := mkRedirectRule("3", "0")
-	data, err = insertRedirectRule(rule3, data, clock, ignoreMaxRules, ignoreMaxChain)
+	data, err = insertRedirectRule(rule3, data, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.NoError(t, err)
 	expectedSet = append(expectedSet, mkRedirectRulePersistence(rule3, clock, nil))
 	for _, r := range data.RedirectRules {
@@ -620,12 +620,12 @@ func TestAddRedirectRuleMaxRules(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		src := fmt.Sprintf("%d", i)
 		dst := fmt.Sprintf("%d", i+1)
-		data, err = insertRedirectRule(mkRedirectRule(src, dst), data, clock, maxRules, ignoreMaxChain)
+		data, err = insertRedirectRule(mkRedirectRule(src, dst), data, clock, maxRules, ignoreMaxUpstreamBuildIDs)
 		assert.NoError(t, err)
 	}
 
 	// insert fourth --> error
-	_, err = insertRedirectRule(mkRedirectRule("10", "20"), data, clock, maxRules, ignoreMaxChain)
+	_, err = insertRedirectRule(mkRedirectRule("10", "20"), data, clock, maxRules, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errExceedsMaxRedirectRules(4, maxRules), err)
 }
@@ -637,12 +637,12 @@ func TestAddRedirectRuleInVersionSet(t *testing.T) {
 	initialData := mkInitialData(1, clock)
 
 	// insert with source build id "0" --> failure
-	_, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
+	_, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errSourceIsVersionSetMember, err)
 
 	// insert with target build id "0" --> failure
-	_, err = insertRedirectRule(mkRedirectRule("1", "0"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
+	_, err = insertRedirectRule(mkRedirectRule("1", "0"), initialData, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errTargetIsVersionSetMember, err)
 }
@@ -657,7 +657,7 @@ func TestAddRedirectRuleSourceIsConditionalAssignmentRuleTarget(t *testing.T) {
 	}
 
 	// insert redirect rule with target 1 --> failure
-	_, err := insertRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxRules, ignoreMaxChain)
+	_, err := insertRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errSourceIsConditionalAssignmentRuleTarget, err)
 }
@@ -668,11 +668,11 @@ func TestAddRedirectRuleAlreadyExists(t *testing.T) {
 	initialData := mkInitialData(0, clock)
 
 	// insert with source build id "0"
-	data, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
+	data, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.NoError(t, err)
 
 	// insert with source build id "0" --> failure
-	_, err = insertRedirectRule(mkRedirectRule("0", "6"), data, clock, ignoreMaxRules, ignoreMaxChain)
+	_, err = insertRedirectRule(mkRedirectRule("0", "6"), data, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errSourceAlreadyExists("0", "1"), err)
 }
@@ -683,41 +683,41 @@ func TestAddRedirectRuleCreateCycle(t *testing.T) {
 	initialData := mkInitialData(0, clock)
 
 	// insert with source -> target == "0" -> "0" --> failure
-	_, err := insertRedirectRule(mkRedirectRule("0", "0"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
+	_, err := insertRedirectRule(mkRedirectRule("0", "0"), initialData, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errIsCyclic, err)
 
 	// insert with source -> target == "0" -> "1" --> success
-	data, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, ignoreMaxRules, ignoreMaxChain)
+	data, err := insertRedirectRule(mkRedirectRule("0", "1"), initialData, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.NoError(t, err)
 
 	// insert with source build id "1" -> "0" --> failure
-	_, err = insertRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxRules, ignoreMaxChain)
+	_, err = insertRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errIsCyclic, err)
 }
 
-func TestAddRedirectRuleMaxChain(t *testing.T) {
+func TestAddRedirectRuleMaxUpstreamBuildIDs(t *testing.T) {
 	t.Parallel()
-	maxChain := 3
+	maxUpstreamBuildIDs := 2
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 
 	// insert (4->5)
 	// 4 ---> 5
-	data, err := insertRedirectRule(mkRedirectRule("4", "5"), data, clock, ignoreMaxRules, maxChain)
+	data, err := insertRedirectRule(mkRedirectRule("4", "5"), data, clock, ignoreMaxRules, maxUpstreamBuildIDs)
 	assert.NoError(t, err)
 
 	// insert (5->6)
 	// 4 ---> 5 ---> 6
-	data, err = insertRedirectRule(mkRedirectRule("5", "6"), data, clock, ignoreMaxRules, maxChain)
+	data, err = insertRedirectRule(mkRedirectRule("5", "6"), data, clock, ignoreMaxRules, maxUpstreamBuildIDs)
 	assert.NoError(t, err)
 
 	// insert (6->7)
 	// 4 ---> 5 ---> 6 ---> 7
-	_, err = insertRedirectRule(mkRedirectRule("6", "7"), data, clock, ignoreMaxRules, maxChain)
+	_, err = insertRedirectRule(mkRedirectRule("6", "7"), data, clock, ignoreMaxRules, maxUpstreamBuildIDs)
 	assert.Error(t, err)
-	assert.Equal(t, errExceedsMaxRuleChain(4, maxChain), err)
+	assert.Equal(t, errExceedsMaxUpstreamBuildIDs(3, maxUpstreamBuildIDs), err)
 }
 
 func TestAddRedirectRuleUnversionedTarget(t *testing.T) {
@@ -726,7 +726,7 @@ func TestAddRedirectRuleUnversionedTarget(t *testing.T) {
 	data := mkInitialData(0, clock)
 
 	// insert (1->"") errors
-	_, err := insertRedirectRule(mkRedirectRule("1", ""), data, clock, ignoreMaxRules, ignoreMaxChain)
+	_, err := insertRedirectRule(mkRedirectRule("1", ""), data, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.ErrorIs(t, err, errUnversionedRedirectRuleTarget)
 }
 
@@ -745,7 +745,7 @@ func TestReplaceRedirectRuleBasic(t *testing.T) {
 	replaceTest := func(source, target string) {
 		prevRule := getActiveRedirectRuleBySrc(source, data)
 		rule := mkRedirectRule(source, target)
-		data, err = replaceRedirectRule(rule, data, clock, ignoreMaxChain)
+		data, err = replaceRedirectRule(rule, data, clock, ignoreMaxUpstreamBuildIDs)
 		assert.NoError(t, err)
 		newActive := getActiveRedirectRuleBySrc(source, data)
 		protoassert.ProtoEqual(t, newActive.GetRule(), rule)
@@ -775,7 +775,7 @@ func TestReplaceRedirectRuleInVersionSet(t *testing.T) {
 	var err error
 
 	// replace with target 0 --> failure
-	_, err = replaceRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxChain)
+	_, err = replaceRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errTargetIsVersionSetMember, err)
 }
@@ -791,26 +791,26 @@ func TestReplaceRedirectRuleCreateCycle(t *testing.T) {
 	}
 	var err error
 
-	_, err = replaceRedirectRule(mkRedirectRule("0", "0"), data, clock, ignoreMaxChain)
+	_, err = replaceRedirectRule(mkRedirectRule("0", "0"), data, clock, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errIsCyclic, err)
 
-	_, err = replaceRedirectRule(mkRedirectRule("2", "0"), data, clock, ignoreMaxChain)
+	_, err = replaceRedirectRule(mkRedirectRule("2", "0"), data, clock, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errIsCyclic, err)
 
-	_, err = replaceRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxChain)
+	_, err = replaceRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errIsCyclic, err)
 
-	_, err = replaceRedirectRule(mkRedirectRule("2", "1"), data, clock, ignoreMaxChain)
+	_, err = replaceRedirectRule(mkRedirectRule("2", "1"), data, clock, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errIsCyclic, err)
 }
 
-func TestReplaceRedirectRuleMaxChain(t *testing.T) {
+func TestReplaceRedirectRuleMaxUpstreamBuildIDs(t *testing.T) {
 	t.Parallel()
-	maxChain := 3
+	maxUpstreamBuildIDs := 2
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 
@@ -823,14 +823,14 @@ func TestReplaceRedirectRuleMaxChain(t *testing.T) {
 
 	// replace(2, new_target=1)
 	// 2 ---> 1, 4 ---> 5 ---> 6
-	data, err := replaceRedirectRule(mkRedirectRule("2", "1"), data, clock, maxChain)
+	data, err := replaceRedirectRule(mkRedirectRule("2", "1"), data, clock, maxUpstreamBuildIDs)
 	assert.NoError(t, err)
 
 	// replace(2, new_target=4)
 	// 2 ---> 4 ---> 5 ---> 6
-	_, err = replaceRedirectRule(mkRedirectRule("2", "4"), data, clock, maxChain)
+	_, err = replaceRedirectRule(mkRedirectRule("2", "4"), data, clock, maxUpstreamBuildIDs)
 	assert.Error(t, err)
-	assert.Equal(t, errExceedsMaxRuleChain(4, maxChain), err)
+	assert.Equal(t, errExceedsMaxUpstreamBuildIDs(3, maxUpstreamBuildIDs), err)
 }
 
 func TestReplaceRedirectRuleUnversionedTarget(t *testing.T) {
@@ -839,11 +839,11 @@ func TestReplaceRedirectRuleUnversionedTarget(t *testing.T) {
 	data := mkInitialData(0, clock)
 
 	// insert (1->2) so that we can replace
-	data, err := insertRedirectRule(mkRedirectRule("1", "2"), data, clock, ignoreMaxRules, ignoreMaxChain)
+	data, err := insertRedirectRule(mkRedirectRule("1", "2"), data, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.NoError(t, err)
 
 	// replace (1->"") errors
-	_, err = replaceRedirectRule(mkRedirectRule("1", ""), data, clock, ignoreMaxChain)
+	_, err = replaceRedirectRule(mkRedirectRule("1", ""), data, clock, ignoreMaxUpstreamBuildIDs)
 	assert.ErrorIs(t, err, errUnversionedRedirectRuleTarget)
 }
 
@@ -854,7 +854,7 @@ func TestReplaceRedirectRuleNotFound(t *testing.T) {
 	var err error
 
 	// fails because no rules to replace
-	_, err = replaceRedirectRule(mkRedirectRule("1", "100"), data, clock, ignoreMaxChain)
+	_, err = replaceRedirectRule(mkRedirectRule("1", "100"), data, clock, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errSourceNotFound("1"), err)
 
@@ -863,7 +863,7 @@ func TestReplaceRedirectRuleNotFound(t *testing.T) {
 	}
 
 	// fails because source doesnt exist
-	_, err = replaceRedirectRule(mkRedirectRule("1", "100"), data, clock, ignoreMaxChain)
+	_, err = replaceRedirectRule(mkRedirectRule("1", "100"), data, clock, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
 	assert.Equal(t, errSourceNotFound("1"), err)
 }
@@ -1000,13 +1000,13 @@ func TestCleanupRedirectRuleTombstones(t *testing.T) {
 	// insert 3x to get three rules in there
 	rule1 := mkRedirectRule("1", "10")
 	clock1 := hlc.Next(clock, timesource)
-	data, err := insertRedirectRule(rule1, initialData, clock1, ignoreMaxRules, ignoreMaxChain)
+	data, err := insertRedirectRule(rule1, initialData, clock1, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.NoError(t, err)
 	rule2 := mkRedirectRule("2", "10")
-	data, err = insertRedirectRule(rule2, data, clock1, ignoreMaxRules, ignoreMaxChain)
+	data, err = insertRedirectRule(rule2, data, clock1, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.NoError(t, err)
 	rule3 := mkRedirectRule("3", "10")
-	data, err = insertRedirectRule(rule3, data, clock1, ignoreMaxRules, ignoreMaxChain)
+	data, err = insertRedirectRule(rule3, data, clock1, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.NoError(t, err)
 
 	// delete "now," ~1 hour ago

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -86,7 +86,7 @@ func (s *VersioningIntegSuite) SetupSuite() {
 
 		dynamicconfig.AssignmentRuleLimitPerQueue:              10,
 		dynamicconfig.RedirectRuleLimitPerQueue:                10,
-		dynamicconfig.RedirectRuleChainLimitPerQueue:           10,
+		dynamicconfig.RedirectRuleMaxUpstreamBuildIDsPerQueue:  10,
 		dynamicconfig.MatchingDeletedRuleRetentionTime:         24 * time.Hour,
 		dynamicconfig.ReachabilityBuildIdVisibilityGracePeriod: 3 * time.Minute,
 		dynamicconfig.ReachabilityQueryBuildIdLimit:            4,


### PR DESCRIPTION
## What changed?
Rename RedirectRuleMaxChainLength to RedirectRuleMaxUpstreamBuildIDs

## Why?
Because it is more clear than "chain"

## How did you test it?
Existing unit and functional tests

## Potential risks
None

## Documentation
See dynamic config comments

## Is hotfix candidate?
No