### PR TITLE
fix flaky xdc test (TestWorkflowReplicationTaskFailure)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -202,29 +202,28 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest]
-        name: [cass_es]
-#        name: [cass_es, cass_es8, mysql8, postgres12, postgres12_pgx]
+        name: [cass_es, cass_es8, mysql8, postgres12, postgres12_pgx]
         include:
           - name: cass_es
             persistence_type: nosql
             persistence_driver: elasticsearch
             containers: [cassandra, elasticsearch]
-#          - name: cass_es8
-#            persistence_type: nosql
-#            persistence_driver: elasticsearch
-#            containers: [cassandra, elasticsearch8]
-#          - name: mysql8
-#            persistence_type: sql
-#            persistence_driver: mysql8
-#            containers: [mysql]
-#          - name: postgres12
-#            persistence_type: sql
-#            persistence_driver: postgres12
-#            containers: [postgresql]
-#          - name: postgres12_pgx
-#            persistence_type: sql
-#            persistence_driver: postgres12_pgx
-#            containers: [postgresql]
+          - name: cass_es8
+            persistence_type: nosql
+            persistence_driver: elasticsearch
+            containers: [cassandra, elasticsearch8]
+          - name: mysql8
+            persistence_type: sql
+            persistence_driver: mysql8
+            containers: [mysql]
+          - name: postgres12
+            persistence_type: sql
+            persistence_driver: postgres12
+            containers: [postgresql]
+          - name: postgres12_pgx
+            persistence_type: sql
+            persistence_driver: postgres12_pgx
+            containers: [postgresql]
     runs-on: ${{ matrix.runs-on }}
     env:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -202,28 +202,29 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest]
-        name: [cass_es, cass_es8, mysql8, postgres12, postgres12_pgx]
+        name: [cass_es]
+#        name: [cass_es, cass_es8, mysql8, postgres12, postgres12_pgx]
         include:
           - name: cass_es
             persistence_type: nosql
             persistence_driver: elasticsearch
             containers: [cassandra, elasticsearch]
-          - name: cass_es8
-            persistence_type: nosql
-            persistence_driver: elasticsearch
-            containers: [cassandra, elasticsearch8]
-          - name: mysql8
-            persistence_type: sql
-            persistence_driver: mysql8
-            containers: [mysql]
-          - name: postgres12
-            persistence_type: sql
-            persistence_driver: postgres12
-            containers: [postgresql]
-          - name: postgres12_pgx
-            persistence_type: sql
-            persistence_driver: postgres12_pgx
-            containers: [postgresql]
+#          - name: cass_es8
+#            persistence_type: nosql
+#            persistence_driver: elasticsearch
+#            containers: [cassandra, elasticsearch8]
+#          - name: mysql8
+#            persistence_type: sql
+#            persistence_driver: mysql8
+#            containers: [mysql]
+#          - name: postgres12
+#            persistence_type: sql
+#            persistence_driver: postgres12
+#            containers: [postgresql]
+#          - name: postgres12_pgx
+#            persistence_type: sql
+#            persistence_driver: postgres12_pgx
+#            containers: [postgresql]
     runs-on: ${{ matrix.runs-on }}
     env:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -166,8 +166,8 @@ func (s *AdvVisCrossDCTestSuite) SetupTest() {
 }
 
 func (s *AdvVisCrossDCTestSuite) TearDownSuite() {
-	s.cluster1.TearDownCluster()
-	s.cluster2.TearDownCluster()
+	s.NoError(s.cluster1.TearDownCluster())
+	s.NoError(s.cluster2.TearDownCluster())
 }
 
 func (s *AdvVisCrossDCTestSuite) TestSearchAttributes() {

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -29,10 +29,12 @@
 package xdc
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	replicationpb "go.temporal.io/api/replication/v1"
@@ -40,6 +42,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -65,6 +68,8 @@ type (
 		cluster2               *tests.TestCluster
 		logger                 log.Logger
 		dynamicConfigOverrides map[dynamicconfig.Key]interface{}
+
+		startTime time.Time
 	}
 )
 
@@ -129,6 +134,8 @@ func (s *xdcBaseSuite) setupSuite(clusterNames []string, opts ...tests.Option) {
 	s.Require().NoError(err)
 	s.cluster2 = c
 
+	s.startTime = time.Now()
+
 	cluster1Info := clusterConfigs[0].ClusterMetadata.ClusterInformation[clusterConfigs[0].ClusterMetadata.CurrentClusterName]
 	cluster2Info := clusterConfigs[1].ClusterMetadata.ClusterInformation[clusterConfigs[1].ClusterMetadata.CurrentClusterName]
 	_, err = s.cluster1.GetAdminClient().AddOrUpdateRemoteCluster(
@@ -152,6 +159,36 @@ func (s *xdcBaseSuite) setupSuite(clusterNames []string, opts ...tests.Option) {
 	time.Sleep(time.Millisecond * 200)
 }
 
+func (s *xdcBaseSuite) waitForClusterConnected() {
+	s.logger.Debug("wait for cluster to be connected")
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		s.logger.Debug("check if stream is established")
+		resp, err := s.cluster1.GetHistoryClient().GetReplicationStatus(context.Background(), &historyservice.GetReplicationStatusRequest{})
+		if !(assert.NoError(c, err) &&
+			assert.Equal(c, 1, len(resp.Shards))) { // test cluster has only one history shard
+			return
+		}
+		shard := resp.Shards[0]
+		if !(assert.NotNil(c, shard) &&
+			assert.True(c, shard.MaxReplicationTaskId > 0) &&
+			assert.NotNil(c, shard.ShardLocalTime) &&
+			assert.True(c, shard.ShardLocalTime.AsTime().Before(time.Now())) &&
+			assert.True(c, shard.ShardLocalTime.AsTime().After(s.startTime)) &&
+			assert.NotNil(c, shard.RemoteClusters)) {
+			return
+		}
+		standbyAckInfo, ok := shard.RemoteClusters[s.clusterNames[1]]
+		if !(assert.True(c, ok) &&
+			assert.NotNil(c, standbyAckInfo) &&
+			assert.NotNil(c, standbyAckInfo.AckedTaskVisibilityTime) &&
+			assert.True(c, standbyAckInfo.AckedTaskVisibilityTime.AsTime().Before(time.Now())) &&
+			assert.True(c, standbyAckInfo.AckedTaskVisibilityTime.AsTime().After(s.startTime))) {
+			return
+		}
+		s.logger.Debug("cluster connected")
+	}, 60*time.Second, 1*time.Second)
+}
+
 func (s *xdcBaseSuite) tearDownSuite() {
 	s.NoError(s.cluster1.TearDownCluster())
 	s.NoError(s.cluster2.TearDownCluster())
@@ -162,4 +199,6 @@ func (s *xdcBaseSuite) setupTest() {
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
 	s.HistoryRequire = historyrequire.New(s.T())
+
+	s.waitForClusterConnected()
 }

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -2439,6 +2439,7 @@ func (s *FunctionalClustersTestSuite) TestLocalNamespaceMigration() {
 
 	worker1.RegisterWorkflow(testWorkflowFn)
 	s.NoError(worker1.Start())
+	defer worker1.Stop()
 
 	// Start wf1 (in local ns)
 	workflowID := "local-ns-wf-1"
@@ -2798,6 +2799,7 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
 
 	worker1.RegisterWorkflow(testWorkflowFn)
 	s.NoError(worker1.Start())
+	defer worker1.Stop()
 
 	// Start wf1
 	workflowID := "force-replication-test-wf-1"
@@ -2883,6 +2885,7 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
 
 	worker2.RegisterWorkflow(testWorkflowFn)
 	s.NoError(worker2.Start())
+	defer worker2.Stop()
 
 	// Test reset workflow in cluster 2
 	resetResp, err := client2.ResetWorkflowExecution(testCtx, &workflowservice.ResetWorkflowExecutionRequest{
@@ -2926,6 +2929,7 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
 
 	worker1.RegisterWorkflow(testWorkflowFn)
 	s.NoError(worker1.Start())
+	defer worker1.Stop()
 
 	// Start wf1
 	workflowID := "force-replication-test-reset-wf-1"


### PR DESCRIPTION
## What changed?
- Wait until test clusters are connected.
- Add worker stop() calls to reduce noisy "connection refused" logs.

## Why?
If workflows are executed before two test clusters are connected, the existing tasks will not be replicated to standby cluster.

## How did you test it?
Local test and github checks.

## Potential risks


## Documentation


## Is hotfix candidate?

