### PR TITLE
Adding task category to dlq_writes metric

### DIFF
--- a/service/history/queues/dlq_writer.go
+++ b/service/history/queues/dlq_writer.go
@@ -109,7 +109,7 @@ func (q *DLQWriter) WriteTaskToDLQ(ctx context.Context, sourceCluster, targetClu
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrSendTaskToDLQ, err)
 	}
-	metrics.DLQWrites.With(q.metricsHandler).Record(1)
+	metrics.DLQWrites.With(q.metricsHandler).Record(1, metrics.TaskCategoryTag(task.GetCategory().Name()))
 	ns, err := q.namespaceRegistry.GetNamespaceByID(namespace.ID(task.GetNamespaceID()))
 	var namespaceTag tag.Tag
 	if err != nil {

--- a/service/history/queues/dlq_writer_test.go
+++ b/service/history/queues/dlq_writer_test.go
@@ -126,6 +126,8 @@ func TestDLQWriter_ErrGetNamespaceName(t *testing.T) {
 	counter, ok := recordings[0].Value.(int64)
 	assert.True(t, ok)
 	assert.Equal(t, int64(1), counter)
+	assert.Len(t, recordings[0].Tags, 1)
+	assert.Equal(t, recordings[0].Tags[metrics.TaskCategoryTagName], task.GetCategory().Name())
 }
 
 func TestDLQWriter_Ok(t *testing.T) {
@@ -172,4 +174,6 @@ func TestDLQWriter_Ok(t *testing.T) {
 	counter, ok := recordings[0].Value.(int64)
 	assert.True(t, ok)
 	assert.Equal(t, int64(1), counter)
+	assert.Len(t, recordings[0].Tags, 1)
+	assert.Equal(t, recordings[0].Tags[metrics.TaskCategoryTagName], task.GetCategory().Name())
 }

--- a/service/history/queues/dlq_writer_test.go
+++ b/service/history/queues/dlq_writer_test.go
@@ -127,7 +127,7 @@ func TestDLQWriter_ErrGetNamespaceName(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, int64(1), counter)
 	assert.Len(t, recordings[0].Tags, 1)
-	assert.Equal(t, recordings[0].Tags[metrics.TaskCategoryTagName], task.GetCategory().Name())
+	assert.Equal(t, "transfer", recordings[0].Tags[metrics.TaskCategoryTagName])
 }
 
 func TestDLQWriter_Ok(t *testing.T) {
@@ -175,5 +175,5 @@ func TestDLQWriter_Ok(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, int64(1), counter)
 	assert.Len(t, recordings[0].Tags, 1)
-	assert.Equal(t, recordings[0].Tags[metrics.TaskCategoryTagName], task.GetCategory().Name())
+	assert.Equal(t, "transfer", recordings[0].Tags[metrics.TaskCategoryTagName])
 }


### PR DESCRIPTION
## What changed?
Adding task category to dlq_writes metric.

## Why?
To understand the category of task when it is enqueued to DLQ.

## How did you test it?
Unit tests.

## Potential risks
None

## Documentation

## Is hotfix candidate?
No
