### PR TITLE
Workflow Update: allow transition from stateAdmitted to stateAccepted

### DIFF
--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -38,8 +38,6 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	"go.temporal.io/server/common/metrics"
-
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/future"
 	"go.temporal.io/server/common/metrics"

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -347,17 +347,7 @@ func TestAdmitAcceptOrReject(t *testing.T) {
 		effects = effect.Immediate(ctx)
 		meta    = updatepb.Meta{UpdateId: t.Name() + "-update-id"}
 		req     = updatepb.Request{Meta: &meta, Input: &updatepb.Input{Name: t.Name()}}
-		acpt    = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
-			AcceptedRequestMessageId:         "random",
-			AcceptedRequestSequencingEventId: 2208,
-		})}
-		acceptedEventData = struct {
-			updateID                         string
-			acceptedRequestMessageId         string
-			acceptedRequestSequencingEventId int64
-			acceptedRequest                  *updatepb.Request
-		}{}
-		store = mockEventStore{
+		store   = mockEventStore{
 			Controller: effects,
 			AddWorkflowExecutionUpdateAcceptedEventFunc: func(
 				updateID string,
@@ -365,10 +355,6 @@ func TestAdmitAcceptOrReject(t *testing.T) {
 				acceptedRequestSequencingEventId int64,
 				acceptedRequest *updatepb.Request,
 			) (*historypb.HistoryEvent, error) {
-				acceptedEventData.updateID = updateID
-				acceptedEventData.acceptedRequestMessageId = acceptedRequestMessageId
-				acceptedEventData.acceptedRequestSequencingEventId = acceptedRequestSequencingEventId
-				acceptedEventData.acceptedRequest = acceptedRequest
 				return &historypb.HistoryEvent{EventId: testAcceptedEventID}, nil
 			},
 		}
@@ -381,6 +367,10 @@ func TestAdmitAcceptOrReject(t *testing.T) {
 
 		// Note: no upd.Send call.
 
+		acpt := protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
+			AcceptedRequestMessageId:         "random",
+			AcceptedRequestSequencingEventId: 2208,
+		})}
 		err = upd.OnProtocolMessage(ctx, &acpt, store)
 		require.NoError(t, err)
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Allow transition from `stateAdmitted` to `stateAccepted`.

## Why?
<!-- Tell your future self why have you made these changes -->
See comment in the code:

> 	// Normally update goes from stateAdmitted to stateSent and then to stateAccepted,
	// therefore the only valid state here is stateSent.
	// But if update registry is cleared after update was sent to the worker,
	// it will be recreated by retries in stateAdmitted, and then worker can accept previous (cleared) update
	// with the same UpdateId. Because it is, in fact, the same update, server should process this accept message w/o error.
	// Therefore, stateAdmitted is also a valid state.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added new unit test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.