### PR TITLE
Workflow Update: remove quotes from error messages

### DIFF
--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -35,12 +35,12 @@ import (
 	protocolpb "go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
-	"go.temporal.io/server/common/metrics"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/future"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/utf8validator"
 	"go.temporal.io/server/internal/effect"
 )
@@ -358,11 +358,11 @@ func (u *Update) OnProtocolMessage(
 	eventStore EventStore,
 ) error {
 	if protocolMsg == nil {
-		return invalidArgf("Update %q received nil message", u.id)
+		return invalidArgf("Update %s received nil message", u.id)
 	}
 
 	if protocolMsg.Body == nil {
-		return invalidArgf("Update %q received message with nil body", u.id)
+		return invalidArgf("Update %s received message with nil body", u.id)
 	}
 
 	body, err := protocolMsg.Body.UnmarshalNew()
@@ -623,7 +623,7 @@ func (u *Update) checkStateSet(msg proto.Message, allowed stateSet) error {
 	}
 	u.instrumentation.invalidStateTransition(u.id, msg, u.state)
 	return invalidArgf("invalid state transition attempted for Update %s: "+
-		"received %T message while in state %q", u.id, msg, u.state)
+		"received %T message while in state %s", u.id, msg, u.state)
 }
 
 // setState assigns the current state to a new value returning the original value.

--- a/service/history/workflow_task_handler.go
+++ b/service/history/workflow_task_handler.go
@@ -370,7 +370,7 @@ func (handler *workflowTaskHandlerImpl) handleMessage(
 		if !ok {
 			return handler.failWorkflowTask(
 				enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
-				serviceerror.NewNotFound(fmt.Sprintf("update %q not found", message.ProtocolInstanceId)))
+				serviceerror.NewNotFound(fmt.Sprintf("update %s not found", message.ProtocolInstanceId)))
 		}
 
 		if err := upd.OnProtocolMessage(
@@ -383,7 +383,7 @@ func (handler *workflowTaskHandlerImpl) handleMessage(
 	default:
 		return handler.failWorkflowTask(
 			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
-			serviceerror.NewInvalidArgument(fmt.Sprintf("unsupported protocol type %q", protocolType)))
+			serviceerror.NewInvalidArgument(fmt.Sprintf("unsupported protocol type %s", protocolType)))
 	}
 
 	return nil
@@ -416,7 +416,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandProtocolMessage(
 	}
 	return handler.failWorkflowTask(
 		enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
-		serviceerror.NewInvalidArgument(fmt.Sprintf("ProtocolMessageCommand referenced absent message ID %q", attr.MessageId)),
+		serviceerror.NewInvalidArgument(fmt.Sprintf("ProtocolMessageCommand referenced absent message ID %s", attr.MessageId)),
 	)
 }
 

--- a/tests/update_workflow.go
+++ b/tests/update_workflow.go
@@ -3878,7 +3878,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalWorkflowTaskUpdateLost_B
 	_, err := poller.PollAndProcessWorkflowTask()
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err, "workflow task failure must be an InvalidArgument error")
-	s.ErrorContains(err, fmt.Sprintf("update %q not found", tv.UpdateID("1")))
+	s.ErrorContains(err, fmt.Sprintf("update %s not found", tv.UpdateID("1")))
 
 	<-updateResultCh
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Remove quotes from error messages.

## Why?
<!-- Tell your future self why have you made these changes -->
Error messages with quotes don't look good in UI:

![image](https://github.com/temporalio/temporal/assets/2232524/406e75a1-eda5-4124-8b91-2652ca760a4a)
![image](https://github.com/temporalio/temporal/assets/2232524/e4bd7e7e-491b-4d7c-a565-0a62bc01a323)


## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.