### PR TITLE
Circuit breaker with dynamic settings

### DIFF
--- a/common/circuitbreaker/circuitbreaker.go
+++ b/common/circuitbreaker/circuitbreaker.go
@@ -1,0 +1,204 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package circuitbreaker
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sony/gobreaker"
+	"go.temporal.io/server/common/number"
+)
+
+type (
+	TwoStepCircuitBreaker interface {
+		Name() string
+		State() gobreaker.State
+		Counts() gobreaker.Counts
+		Allow() (done func(success bool), err error)
+	}
+
+	// TwoStepCircuitBreakerWithDynamicSettings is a wrapper of gobreaker.TwoStepCircuitBreaker
+	// that calls the settingsFn everytime the Allow function is called and replaces the circuit
+	// breaker if there is a change in the settings object. Note that in this case, the previous
+	// state of the circuit breaker is lost.
+	TwoStepCircuitBreakerWithDynamicSettings struct {
+		settingsFn           func() map[string]any
+		settingsEvalInterval time.Duration
+		settingsLastCheck    atomic.Pointer[time.Time]
+
+		name          string
+		readyToTrip   func(counts gobreaker.Counts) bool
+		onStateChange func(name string, from gobreaker.State, to gobreaker.State)
+
+		cb              *gobreaker.TwoStepCircuitBreaker
+		cbLock          *sync.RWMutex
+		dynamicSettings dynamicSettings
+	}
+
+	dynamicSettings struct {
+		MaxRequests uint32
+		Interval    time.Duration
+		Timeout     time.Duration
+	}
+
+	Settings struct {
+		// Function to get the dynamic settings. Accepted keys:
+		// - maxRequests: Maximum number of requests allowed to pass through when
+		//   it is in half-open state (default 1).
+		// - interval (seconds): Cyclic period in closed state to clear the internal counts;
+		//   if interval is 0, then it never clears the internal counts (default 0).
+		// - timeout (seconds): Period of open state before changing to half-open state (default 60).`
+		SettingsFn func() map[string]any
+		// Min interval time between calls to SettingsFn. If not set or zero, then it defaults
+		// to 1 minute.
+		SettingsEvalInterval time.Duration
+
+		// For the following options, check gobreaker docs for details.
+
+		Name          string
+		ReadyToTrip   func(counts gobreaker.Counts) bool
+		OnStateChange func(name string, from gobreaker.State, to gobreaker.State)
+	}
+)
+
+var _ TwoStepCircuitBreaker = (*TwoStepCircuitBreakerWithDynamicSettings)(nil)
+
+const (
+	maxRequestsKey = "maxRequests"
+	intervalKey    = "interval"
+	timeoutKey     = "timeout"
+
+	// Zero values indicate to use the default values from gobreaker.Settings.
+	defaultMaxRequests = uint32(0)
+	defaultInterval    = 0 * time.Second
+	defaultTimeout     = 0 * time.Second
+
+	defaultSettingsEvalInterval = 1 * time.Minute
+)
+
+func NewTwoStepCircuitBreakerWithDynamicSettings(
+	settings Settings,
+) *TwoStepCircuitBreakerWithDynamicSettings {
+	c := &TwoStepCircuitBreakerWithDynamicSettings{
+		settingsEvalInterval: settings.SettingsEvalInterval,
+
+		name:          settings.Name,
+		settingsFn:    settings.SettingsFn,
+		readyToTrip:   settings.ReadyToTrip,
+		onStateChange: settings.OnStateChange,
+
+		cbLock: &sync.RWMutex{},
+	}
+	if c.settingsEvalInterval <= 0 {
+		c.settingsEvalInterval = defaultSettingsEvalInterval
+	}
+	c.settingsLastCheck.Store(&time.Time{})
+	_ = c.getInternalCircuitBreaker()
+	return c
+}
+
+func (c *TwoStepCircuitBreakerWithDynamicSettings) Name() string {
+	return c.cb.Name()
+}
+
+func (c *TwoStepCircuitBreakerWithDynamicSettings) State() gobreaker.State {
+	return c.cb.State()
+}
+
+func (c *TwoStepCircuitBreakerWithDynamicSettings) Counts() gobreaker.Counts {
+	return c.cb.Counts()
+}
+
+func (c *TwoStepCircuitBreakerWithDynamicSettings) Allow() (done func(success bool), err error) {
+	cb := c.getInternalCircuitBreaker()
+	return cb.Allow()
+}
+
+func (c *TwoStepCircuitBreakerWithDynamicSettings) getDynamicSettings() dynamicSettings {
+	settingsMap := c.settingsFn()
+	settings := dynamicSettings{
+		MaxRequests: defaultMaxRequests,
+		Interval:    defaultInterval,
+		Timeout:     defaultTimeout,
+	}
+
+	if maxRequests, ok := settingsMap[maxRequestsKey]; ok {
+		settings.MaxRequests = uint32(
+			number.NewNumber(maxRequests).GetUintOrDefault(uint(defaultMaxRequests)),
+		)
+	}
+	if interval, ok := settingsMap[intervalKey]; ok {
+		settings.Interval = time.Duration(
+			number.NewNumber(interval).GetIntOrDefault(int(defaultInterval.Seconds())),
+		) * time.Second
+	}
+	if timeout, ok := settingsMap[timeoutKey]; ok {
+		settings.Timeout = time.Duration(
+			number.NewNumber(timeout).GetIntOrDefault(int(defaultTimeout.Seconds())),
+		) * time.Second
+	}
+
+	return settings
+}
+
+// getInternalCircuitBreaker checks if the dynamic settings changed, updating
+// the cirbuit breaker if necessary, and returns the up-to-date reference to
+// the circuit breaker.
+func (c *TwoStepCircuitBreakerWithDynamicSettings) getInternalCircuitBreaker() *gobreaker.TwoStepCircuitBreaker {
+	c.cbLock.RLock()
+	currentCb := c.cb
+	currentDs := c.dynamicSettings
+	c.cbLock.RUnlock()
+
+	now := time.Now()
+	lastCheck := c.settingsLastCheck.Load()
+	if now.Sub(*lastCheck) < c.settingsEvalInterval {
+		return currentCb
+	}
+	if !c.settingsLastCheck.CompareAndSwap(lastCheck, &now) {
+		return currentCb
+	}
+
+	ds := c.getDynamicSettings()
+	if currentCb != nil && ds == currentDs {
+		return currentCb
+	}
+
+	c.cbLock.Lock()
+	defer c.cbLock.Unlock()
+	if c.cb != nil && ds == c.dynamicSettings {
+		return c.cb
+	}
+	c.dynamicSettings = ds
+	c.cb = gobreaker.NewTwoStepCircuitBreaker(gobreaker.Settings{
+		Name:          c.name,
+		MaxRequests:   ds.MaxRequests,
+		Interval:      ds.Interval,
+		Timeout:       ds.Timeout,
+		ReadyToTrip:   c.readyToTrip,
+		OnStateChange: c.onStateChange,
+	})
+	return c.cb
+}

--- a/common/circuitbreaker/circuitbreaker_test.go
+++ b/common/circuitbreaker/circuitbreaker_test.go
@@ -1,0 +1,151 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package circuitbreaker
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type TSCBWithDynamicSettingsTestSuite struct {
+	suite.Suite
+}
+
+func TestTSCBWithDynamicSettings(t *testing.T) {
+	suite.Run(t, &TSCBWithDynamicSettingsTestSuite{})
+}
+
+func TestBasic(t *testing.T) {
+	s := assert.New(t)
+
+	name := "test-tscb"
+	tscb := NewTwoStepCircuitBreakerWithDynamicSettings(
+		Settings{
+			SettingsFn: func() map[string]any {
+				return map[string]any{}
+			},
+			Name: name,
+		},
+	)
+	s.Equal(name, tscb.Name())
+
+	doneFn, err := tscb.Allow()
+	s.NoError(err)
+	doneFn(true)
+}
+
+func TestDynamicSettings(t *testing.T) {
+	s := assert.New(t)
+
+	settingsCallCount := 0
+	tscb := NewTwoStepCircuitBreakerWithDynamicSettings(
+		Settings{
+			SettingsFn: func() map[string]any {
+				settingsCallCount += 1
+				if settingsCallCount > 2 {
+					return map[string]any{
+						maxRequestsKey: 2,
+						intervalKey:    3600,
+						timeoutKey:     30,
+					}
+				}
+				return map[string]any{}
+			},
+		},
+	)
+	s.Equal(1, settingsCallCount)
+
+	// settingsCallCount = 2
+	ds := tscb.getDynamicSettings()
+	s.Equal(2, settingsCallCount)
+	s.Equal(
+		dynamicSettings{
+			MaxRequests: defaultMaxRequests,
+			Interval:    defaultInterval,
+			Timeout:     defaultTimeout,
+		},
+		ds,
+	)
+
+	// settingsCallCount = 3
+	ds = tscb.getDynamicSettings()
+	s.Equal(3, settingsCallCount)
+	s.Equal(
+		dynamicSettings{
+			MaxRequests: 2,
+			Interval:    1 * time.Hour,
+			Timeout:     30 * time.Second,
+		},
+		ds,
+	)
+}
+
+func TestGetInternalCircuitBreaker(t *testing.T) {
+	s := assert.New(t)
+
+	settingsCallCount := 0
+	tscb := NewTwoStepCircuitBreakerWithDynamicSettings(
+		Settings{
+			SettingsFn: func() map[string]any {
+				settingsCallCount += 1
+				if settingsCallCount > 2 {
+					return map[string]any{
+						maxRequestsKey: 2,
+						intervalKey:    3600,
+						timeoutKey:     30,
+					}
+				}
+				return map[string]any{}
+			},
+			SettingsEvalInterval: 2 * time.Second,
+		},
+	)
+	s.Equal(1, settingsCallCount)
+
+	workerFn := func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		ticker := time.NewTicker(100 * time.Millisecond)
+		timer := time.NewTimer(9 * time.Second)
+		for {
+			select {
+			case <-ticker.C:
+				_ = tscb.getInternalCircuitBreaker()
+			case <-timer.C:
+				return
+			}
+		}
+	}
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go workerFn(wg)
+	}
+	wg.Wait()
+	// Only one thread updates the settings at regular intervals
+	s.Equal(5, settingsCallCount)
+}

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1659,6 +1659,16 @@ If value less or equal to 0, will fall back to HistoryPersistenceNamespaceMaxQPS
 		100.0,
 		`OutboundQueueHostSchedulerMaxTaskRPS is the host scheduler max task RPS`,
 	)
+	OutboundQueueCircuitBreakerSettings = NewDestinationMapSetting(
+		"history.outboundQueue.circuitBreakerSettings",
+		map[string]any{},
+		`OutboundQueueCircuitBreakerSettings are circuit breaker settings.
+Accepted config keys (see gobreaker reference for more details):
+- maxRequests: maximum number of requests allowed to pass through when it is half-open (default 1).
+- interval (seconds): cyclic period in closed state to clear the internal counts;
+  if interval is 0, then it never clears the internal counts (default 0).
+- timeout (seconds): period of open state before changing to half-open state (default 60).`,
+	)
 
 	VisibilityTaskBatchSize = NewGlobalIntSetting(
 		"history.visibilityTaskBatchSize",

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -167,6 +167,7 @@ type Config struct {
 	OutboundQueueGroupLimiterBufferSize                 dynamicconfig.IntPropertyFnWithDestinationFilter
 	OutboundQueueGroupLimiterConcurrency                dynamicconfig.IntPropertyFnWithDestinationFilter
 	OutboundQueueHostSchedulerMaxTaskRPS                dynamicconfig.FloatPropertyFnWithDestinationFilter
+	OutboundQueueCircuitBreakerSettings                 dynamicconfig.MapPropertyFnWithDestinationFilter
 
 	// ReplicatorQueueProcessor settings
 	ReplicatorProcessorMaxPollInterval                  dynamicconfig.DurationPropertyFn
@@ -468,6 +469,7 @@ func NewConfig(
 		OutboundQueueGroupLimiterBufferSize:                 dynamicconfig.OutboundQueueGroupLimiterBufferSize.Get(dc),
 		OutboundQueueGroupLimiterConcurrency:                dynamicconfig.OutboundQueueGroupLimiterConcurrency.Get(dc),
 		OutboundQueueHostSchedulerMaxTaskRPS:                dynamicconfig.OutboundQueueHostSchedulerMaxTaskRPS.Get(dc),
+		OutboundQueueCircuitBreakerSettings:                 dynamicconfig.OutboundQueueCircuitBreakerSettings.Get(dc),
 
 		ReplicatorProcessorMaxPollInterval:                  dynamicconfig.ReplicatorProcessorMaxPollInterval.Get(dc),
 		ReplicatorProcessorMaxPollIntervalJitterCoefficient: dynamicconfig.ReplicatorProcessorMaxPollIntervalJitterCoefficient.Get(dc),

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -36,12 +36,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sony/gobreaker"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/circuitbreaker"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -803,12 +803,12 @@ func EstimateTaskMetricTag(
 // of failure, and return the inner error.
 type CircuitBreakerExecutable struct {
 	Executable
-	cb *gobreaker.TwoStepCircuitBreaker
+	cb circuitbreaker.TwoStepCircuitBreaker
 }
 
 func NewCircuitBreakerExecutable(
 	e Executable,
-	cb *gobreaker.TwoStepCircuitBreaker,
+	cb circuitbreaker.TwoStepCircuitBreaker,
 ) *CircuitBreakerExecutable {
 	return &CircuitBreakerExecutable{
 		Executable: e,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Circuit breaker with dynamic settings: it takes a function that is evaluated whenever `Allow` is called, and if any change happened, then it replaces the circuit breaker with the updated changes (previous state is lost). This makes possible to have the circuit breaker automatically update after a dynamic config change.

Added dynamic config for outbound queue circuit breaker.

## Why?
<!-- Tell your future self why have you made these changes -->
Be able to config by destination.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
