### PR TITLE
Fault Injection: execute operation while still returning an error to the caller

### DIFF
--- a/common/persistence/client/fault_injection.go
+++ b/common/persistence/client/fault_injection.go
@@ -97,24 +97,24 @@ type (
 // from errors.go ConvertError
 var defaultErrors = []FaultWeight{
 	{
-		errFactory: func(msg string) error {
-			return serviceerror.NewUnavailable(fmt.Sprintf("serviceerror.NewUnavailable: %s", msg))
+		errFactory: func(msg string) *fault {
+			return newFault(serviceerror.NewUnavailable(fmt.Sprintf("serviceerror.NewUnavailable: %s", msg)))
 		},
 		weight: 1,
 	},
 	{
-		errFactory: func(msg string) error {
-			return &persistence.TimeoutError{Msg: fmt.Sprintf("persistence.TimeoutError: %s", msg)}
+		errFactory: func(msg string) *fault {
+			return newFault(&persistence.TimeoutError{Msg: fmt.Sprintf("persistence.TimeoutError: %s", msg)})
 		},
 		weight: 1,
 	},
 	{
-		errFactory: func(msg string) error {
-			return &serviceerror.ResourceExhausted{
+		errFactory: func(msg string) *fault {
+			return newFault(&serviceerror.ResourceExhausted{
 				Cause:   enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED,
 				Scope:   enumspb.RESOURCE_EXHAUSTED_SCOPE_SYSTEM,
 				Message: fmt.Sprintf("serviceerror.NewResourceExhausted: %s", msg),
-			}
+			})
 		},
 		weight: 1,
 	},
@@ -132,7 +132,7 @@ func NewFaultInjectionDatastoreFactory(
 		config.Rate,
 		[]FaultWeight{
 			{
-				errFactory: func(data string) error { return fmt.Errorf("FaultInjectionDataStoreFactory: %s", data) },
+				errFactory: func(data string) *fault { return newFault(fmt.Errorf("FaultInjectionDataStoreFactory: %s", data)) },
 				weight:     1,
 			},
 		},
@@ -329,11 +329,11 @@ func NewFaultInjectionQueue(rate float64, baseQueue persistence.Queue) (*FaultIn
 	errorGenerator := newErrorGenerator(rate,
 		append(defaultErrors,
 			FaultWeight{
-				errFactory: func(msg string) error {
-					return &persistence.ShardOwnershipLostError{
+				errFactory: func(msg string) *fault {
+					return newFault(&persistence.ShardOwnershipLostError{
 						ShardID: -1,
 						Msg:     fmt.Sprintf("FaultInjectionQueue injected, %s", msg),
-					}
+					})
 				},
 				weight: 1,
 			},
@@ -355,20 +355,18 @@ func (q *FaultInjectionQueue) Init(
 	blob *commonpb.DataBlob,
 ) error {
 	// potentially Init can return golang errors from blob.go encode/decode.
-	if err := q.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return q.baseQueue.Init(ctx, blob)
+	return inject0(q.ErrorGenerator.Generate(), func() error {
+		return q.baseQueue.Init(ctx, blob)
+	})
 }
 
 func (q *FaultInjectionQueue) EnqueueMessage(
 	ctx context.Context,
 	blob *commonpb.DataBlob,
 ) error {
-	if err := q.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return q.baseQueue.EnqueueMessage(ctx, blob)
+	return inject0(q.ErrorGenerator.Generate(), func() error {
+		return q.baseQueue.EnqueueMessage(ctx, blob)
+	})
 }
 
 func (q *FaultInjectionQueue) ReadMessages(
@@ -376,49 +374,44 @@ func (q *FaultInjectionQueue) ReadMessages(
 	lastMessageID int64,
 	maxCount int,
 ) ([]*persistence.QueueMessage, error) {
-	if err := q.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return q.baseQueue.ReadMessages(ctx, lastMessageID, maxCount)
+	return inject1(q.ErrorGenerator.Generate(), func() ([]*persistence.QueueMessage, error) {
+		return q.baseQueue.ReadMessages(ctx, lastMessageID, maxCount)
+	})
 }
 
 func (q *FaultInjectionQueue) DeleteMessagesBefore(
 	ctx context.Context,
 	messageID int64,
 ) error {
-	if err := q.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return q.baseQueue.DeleteMessagesBefore(ctx, messageID)
+	return inject0(q.ErrorGenerator.Generate(), func() error {
+		return q.baseQueue.DeleteMessagesBefore(ctx, messageID)
+	})
 }
 
 func (q *FaultInjectionQueue) UpdateAckLevel(
 	ctx context.Context,
 	metadata *persistence.InternalQueueMetadata,
 ) error {
-	if err := q.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return q.baseQueue.UpdateAckLevel(ctx, metadata)
+	return inject0(q.ErrorGenerator.Generate(), func() error {
+		return q.baseQueue.UpdateAckLevel(ctx, metadata)
+	})
 }
 
 func (q *FaultInjectionQueue) GetAckLevels(
 	ctx context.Context,
 ) (*persistence.InternalQueueMetadata, error) {
-	if err := q.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return q.baseQueue.GetAckLevels(ctx)
+	return inject1(q.ErrorGenerator.Generate(), func() (*persistence.InternalQueueMetadata, error) {
+		return q.baseQueue.GetAckLevels(ctx)
+	})
 }
 
 func (q *FaultInjectionQueue) EnqueueMessageToDLQ(
 	ctx context.Context,
 	blob *commonpb.DataBlob,
 ) (int64, error) {
-	if err := q.ErrorGenerator.Generate(); err != nil {
-		return 0, err
-	}
-	return q.baseQueue.EnqueueMessageToDLQ(ctx, blob)
+	return inject1(q.ErrorGenerator.Generate(), func() (int64, error) {
+		return q.baseQueue.EnqueueMessageToDLQ(ctx, blob)
+	})
 }
 
 func (q *FaultInjectionQueue) ReadMessagesFromDLQ(
@@ -428,20 +421,18 @@ func (q *FaultInjectionQueue) ReadMessagesFromDLQ(
 	pageSize int,
 	pageToken []byte,
 ) ([]*persistence.QueueMessage, []byte, error) {
-	if err := q.ErrorGenerator.Generate(); err != nil {
-		return nil, nil, err
-	}
-	return q.baseQueue.ReadMessagesFromDLQ(ctx, firstMessageID, lastMessageID, pageSize, pageToken)
+	return inject2(q.ErrorGenerator.Generate(), func() ([]*persistence.QueueMessage, []byte, error) {
+		return q.baseQueue.ReadMessagesFromDLQ(ctx, firstMessageID, lastMessageID, pageSize, pageToken)
+	})
 }
 
 func (q *FaultInjectionQueue) DeleteMessageFromDLQ(
 	ctx context.Context,
 	messageID int64,
 ) error {
-	if err := q.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return q.baseQueue.DeleteMessageFromDLQ(ctx, messageID)
+	return inject0(q.ErrorGenerator.Generate(), func() error {
+		return q.baseQueue.DeleteMessageFromDLQ(ctx, messageID)
+	})
 }
 
 func (q *FaultInjectionQueue) RangeDeleteMessagesFromDLQ(
@@ -449,29 +440,26 @@ func (q *FaultInjectionQueue) RangeDeleteMessagesFromDLQ(
 	firstMessageID int64,
 	lastMessageID int64,
 ) error {
-	if err := q.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return q.baseQueue.RangeDeleteMessagesFromDLQ(ctx, firstMessageID, lastMessageID)
+	return inject0(q.ErrorGenerator.Generate(), func() error {
+		return q.baseQueue.RangeDeleteMessagesFromDLQ(ctx, firstMessageID, lastMessageID)
+	})
 }
 
 func (q *FaultInjectionQueue) UpdateDLQAckLevel(
 	ctx context.Context,
 	metadata *persistence.InternalQueueMetadata,
 ) error {
-	if err := q.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return q.baseQueue.UpdateDLQAckLevel(ctx, metadata)
+	return inject0(q.ErrorGenerator.Generate(), func() error {
+		return q.baseQueue.UpdateDLQAckLevel(ctx, metadata)
+	})
 }
 
 func (q *FaultInjectionQueue) GetDLQAckLevels(
 	ctx context.Context,
 ) (*persistence.InternalQueueMetadata, error) {
-	if err := q.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return q.baseQueue.GetDLQAckLevels(ctx)
+	return inject1(q.ErrorGenerator.Generate(), func() (*persistence.InternalQueueMetadata, error) {
+		return q.baseQueue.GetDLQAckLevels(ctx)
+	})
 }
 
 func (q *FaultInjectionQueue) UpdateRate(rate float64) {
@@ -491,50 +479,45 @@ func (f *FaultInjectionQueueV2) EnqueueMessage(
 	ctx context.Context,
 	request *persistence.InternalEnqueueMessageRequest,
 ) (*persistence.InternalEnqueueMessageResponse, error) {
-	if err := f.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return f.baseQueue.EnqueueMessage(ctx, request)
+	return inject1(f.ErrorGenerator.Generate(), func() (*persistence.InternalEnqueueMessageResponse, error) {
+		return f.baseQueue.EnqueueMessage(ctx, request)
+	})
 }
 
 func (f *FaultInjectionQueueV2) ReadMessages(
 	ctx context.Context,
 	request *persistence.InternalReadMessagesRequest,
 ) (*persistence.InternalReadMessagesResponse, error) {
-	if err := f.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return f.baseQueue.ReadMessages(ctx, request)
+	return inject1(f.ErrorGenerator.Generate(), func() (*persistence.InternalReadMessagesResponse, error) {
+		return f.baseQueue.ReadMessages(ctx, request)
+	})
 }
 
 func (f *FaultInjectionQueueV2) CreateQueue(
 	ctx context.Context,
 	request *persistence.InternalCreateQueueRequest,
 ) (*persistence.InternalCreateQueueResponse, error) {
-	if err := f.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return f.baseQueue.CreateQueue(ctx, request)
+	return inject1(f.ErrorGenerator.Generate(), func() (*persistence.InternalCreateQueueResponse, error) {
+		return f.baseQueue.CreateQueue(ctx, request)
+	})
 }
 
 func (f *FaultInjectionQueueV2) RangeDeleteMessages(
 	ctx context.Context,
 	request *persistence.InternalRangeDeleteMessagesRequest,
 ) (*persistence.InternalRangeDeleteMessagesResponse, error) {
-	if err := f.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return f.baseQueue.RangeDeleteMessages(ctx, request)
+	return inject1(f.ErrorGenerator.Generate(), func() (*persistence.InternalRangeDeleteMessagesResponse, error) {
+		return f.baseQueue.RangeDeleteMessages(ctx, request)
+	})
 }
 
 func (f *FaultInjectionQueueV2) ListQueues(
 	ctx context.Context,
 	request *persistence.InternalListQueuesRequest,
 ) (*persistence.InternalListQueuesResponse, error) {
-	if err := f.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return f.baseQueue.ListQueues(ctx, request)
+	return inject1(f.ErrorGenerator.Generate(), func() (*persistence.InternalListQueuesResponse, error) {
+		return f.baseQueue.ListQueues(ctx, request)
+	})
 }
 
 func NewFaultInjectionExecutionStore(
@@ -566,253 +549,225 @@ func (e *FaultInjectionExecutionStore) GetWorkflowExecution(
 	ctx context.Context,
 	request *persistence.GetWorkflowExecutionRequest,
 ) (*persistence.InternalGetWorkflowExecutionResponse, error) {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return e.baseExecutionStore.GetWorkflowExecution(ctx, request)
+	return inject1(e.ErrorGenerator.Generate(), func() (*persistence.InternalGetWorkflowExecutionResponse, error) {
+		return e.baseExecutionStore.GetWorkflowExecution(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) SetWorkflowExecution(
 	ctx context.Context,
 	request *persistence.InternalSetWorkflowExecutionRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.SetWorkflowExecution(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.SetWorkflowExecution(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) UpdateWorkflowExecution(
 	ctx context.Context,
 	request *persistence.InternalUpdateWorkflowExecutionRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.UpdateWorkflowExecution(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.UpdateWorkflowExecution(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) ConflictResolveWorkflowExecution(
 	ctx context.Context,
 	request *persistence.InternalConflictResolveWorkflowExecutionRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.ConflictResolveWorkflowExecution(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.ConflictResolveWorkflowExecution(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) CreateWorkflowExecution(
 	ctx context.Context,
 	request *persistence.InternalCreateWorkflowExecutionRequest,
 ) (*persistence.InternalCreateWorkflowExecutionResponse, error) {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return e.baseExecutionStore.CreateWorkflowExecution(ctx, request)
+	return inject1(e.ErrorGenerator.Generate(), func() (*persistence.InternalCreateWorkflowExecutionResponse, error) {
+		return e.baseExecutionStore.CreateWorkflowExecution(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) DeleteWorkflowExecution(
 	ctx context.Context,
 	request *persistence.DeleteWorkflowExecutionRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.DeleteWorkflowExecution(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.DeleteWorkflowExecution(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) DeleteCurrentWorkflowExecution(
 	ctx context.Context,
 	request *persistence.DeleteCurrentWorkflowExecutionRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.DeleteCurrentWorkflowExecution(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.DeleteCurrentWorkflowExecution(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) GetCurrentExecution(
 	ctx context.Context,
 	request *persistence.GetCurrentExecutionRequest,
 ) (*persistence.InternalGetCurrentExecutionResponse, error) {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return e.baseExecutionStore.GetCurrentExecution(ctx, request)
+	return inject1(e.ErrorGenerator.Generate(), func() (*persistence.InternalGetCurrentExecutionResponse, error) {
+		return e.baseExecutionStore.GetCurrentExecution(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) ListConcreteExecutions(
 	ctx context.Context,
 	request *persistence.ListConcreteExecutionsRequest,
 ) (*persistence.InternalListConcreteExecutionsResponse, error) {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return e.baseExecutionStore.ListConcreteExecutions(ctx, request)
+	return inject1(e.ErrorGenerator.Generate(), func() (*persistence.InternalListConcreteExecutionsResponse, error) {
+		return e.baseExecutionStore.ListConcreteExecutions(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) AddHistoryTasks(
 	ctx context.Context,
 	request *persistence.InternalAddHistoryTasksRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.AddHistoryTasks(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.AddHistoryTasks(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) GetHistoryTasks(
 	ctx context.Context,
 	request *persistence.GetHistoryTasksRequest,
 ) (*persistence.InternalGetHistoryTasksResponse, error) {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return e.baseExecutionStore.GetHistoryTasks(ctx, request)
+	return inject1(e.ErrorGenerator.Generate(), func() (*persistence.InternalGetHistoryTasksResponse, error) {
+		return e.baseExecutionStore.GetHistoryTasks(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) CompleteHistoryTask(
 	ctx context.Context,
 	request *persistence.CompleteHistoryTaskRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.CompleteHistoryTask(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.CompleteHistoryTask(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) RangeCompleteHistoryTasks(
 	ctx context.Context,
 	request *persistence.RangeCompleteHistoryTasksRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.RangeCompleteHistoryTasks(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.RangeCompleteHistoryTasks(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) PutReplicationTaskToDLQ(
 	ctx context.Context,
 	request *persistence.PutReplicationTaskToDLQRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.PutReplicationTaskToDLQ(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.PutReplicationTaskToDLQ(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) GetReplicationTasksFromDLQ(
 	ctx context.Context,
 	request *persistence.GetReplicationTasksFromDLQRequest,
-) (
-	*persistence.InternalGetHistoryTasksResponse,
-	error,
-) {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return e.baseExecutionStore.GetReplicationTasksFromDLQ(ctx, request)
+) (*persistence.InternalGetHistoryTasksResponse, error) {
+	return inject1(e.ErrorGenerator.Generate(), func() (*persistence.InternalGetHistoryTasksResponse, error) {
+		return e.baseExecutionStore.GetReplicationTasksFromDLQ(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) DeleteReplicationTaskFromDLQ(
 	ctx context.Context,
 	request *persistence.DeleteReplicationTaskFromDLQRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.DeleteReplicationTaskFromDLQ(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.DeleteReplicationTaskFromDLQ(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) RangeDeleteReplicationTaskFromDLQ(
 	ctx context.Context,
 	request *persistence.RangeDeleteReplicationTaskFromDLQRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.RangeDeleteReplicationTaskFromDLQ(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.RangeDeleteReplicationTaskFromDLQ(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) IsReplicationDLQEmpty(
 	ctx context.Context,
 	request *persistence.GetReplicationTasksFromDLQRequest,
 ) (bool, error) {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return true, err
-	}
-	return e.baseExecutionStore.IsReplicationDLQEmpty(ctx, request)
+	return inject1(e.ErrorGenerator.Generate(), func() (bool, error) {
+		return e.baseExecutionStore.IsReplicationDLQEmpty(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) AppendHistoryNodes(
 	ctx context.Context,
 	request *persistence.InternalAppendHistoryNodesRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.AppendHistoryNodes(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.AppendHistoryNodes(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) DeleteHistoryNodes(
 	ctx context.Context,
 	request *persistence.InternalDeleteHistoryNodesRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.DeleteHistoryNodes(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.DeleteHistoryNodes(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) ReadHistoryBranch(
 	ctx context.Context,
 	request *persistence.InternalReadHistoryBranchRequest,
 ) (*persistence.InternalReadHistoryBranchResponse, error) {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return e.baseExecutionStore.ReadHistoryBranch(ctx, request)
+	return inject1(e.ErrorGenerator.Generate(), func() (*persistence.InternalReadHistoryBranchResponse, error) {
+		return e.baseExecutionStore.ReadHistoryBranch(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) ForkHistoryBranch(
 	ctx context.Context,
 	request *persistence.InternalForkHistoryBranchRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.ForkHistoryBranch(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.ForkHistoryBranch(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) DeleteHistoryBranch(
 	ctx context.Context,
 	request *persistence.InternalDeleteHistoryBranchRequest,
 ) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.DeleteHistoryBranch(ctx, request)
+	return inject0(e.ErrorGenerator.Generate(), func() error {
+		return e.baseExecutionStore.DeleteHistoryBranch(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) GetHistoryTreeContainingBranch(
 	ctx context.Context,
 	request *persistence.InternalGetHistoryTreeContainingBranchRequest,
 ) (*persistence.InternalGetHistoryTreeContainingBranchResponse, error) {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return e.baseExecutionStore.GetHistoryTreeContainingBranch(ctx, request)
+	return inject1(e.ErrorGenerator.Generate(), func() (*persistence.InternalGetHistoryTreeContainingBranchResponse, error) {
+		return e.baseExecutionStore.GetHistoryTreeContainingBranch(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) GetAllHistoryTreeBranches(
 	ctx context.Context,
 	request *persistence.GetAllHistoryTreeBranchesRequest,
 ) (*persistence.InternalGetAllHistoryTreeBranchesResponse, error) {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return e.baseExecutionStore.GetAllHistoryTreeBranches(ctx, request)
+	return inject1(e.ErrorGenerator.Generate(), func() (*persistence.InternalGetAllHistoryTreeBranchesResponse, error) {
+		return e.baseExecutionStore.GetAllHistoryTreeBranches(ctx, request)
+	})
 }
 
 func (e *FaultInjectionExecutionStore) UpdateRate(rate float64) {
@@ -842,70 +797,63 @@ func (c *FaultInjectionClusterMetadataStore) ListClusterMetadata(
 	ctx context.Context,
 	request *persistence.InternalListClusterMetadataRequest,
 ) (*persistence.InternalListClusterMetadataResponse, error) {
-	if err := c.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return c.baseCMStore.ListClusterMetadata(ctx, request)
+	return inject1(c.ErrorGenerator.Generate(), func() (*persistence.InternalListClusterMetadataResponse, error) {
+		return c.baseCMStore.ListClusterMetadata(ctx, request)
+	})
 }
 
 func (c *FaultInjectionClusterMetadataStore) GetClusterMetadata(
 	ctx context.Context,
 	request *persistence.InternalGetClusterMetadataRequest,
 ) (*persistence.InternalGetClusterMetadataResponse, error) {
-	if err := c.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return c.baseCMStore.GetClusterMetadata(ctx, request)
+	return inject1(c.ErrorGenerator.Generate(), func() (*persistence.InternalGetClusterMetadataResponse, error) {
+		return c.baseCMStore.GetClusterMetadata(ctx, request)
+	})
 }
 
 func (c *FaultInjectionClusterMetadataStore) SaveClusterMetadata(
 	ctx context.Context,
 	request *persistence.InternalSaveClusterMetadataRequest,
 ) (bool, error) {
-	if err := c.ErrorGenerator.Generate(); err != nil {
-		return false, err
-	}
-	return c.baseCMStore.SaveClusterMetadata(ctx, request)
+	return inject1(c.ErrorGenerator.Generate(), func() (bool, error) {
+		return c.baseCMStore.SaveClusterMetadata(ctx, request)
+	})
 }
 
 func (c *FaultInjectionClusterMetadataStore) DeleteClusterMetadata(
 	ctx context.Context,
 	request *persistence.InternalDeleteClusterMetadataRequest,
 ) error {
-	if err := c.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return c.baseCMStore.DeleteClusterMetadata(ctx, request)
+	return inject0(c.ErrorGenerator.Generate(), func() error {
+		return c.baseCMStore.DeleteClusterMetadata(ctx, request)
+	})
 }
 
 func (c *FaultInjectionClusterMetadataStore) GetClusterMembers(
 	ctx context.Context,
 	request *persistence.GetClusterMembersRequest,
 ) (*persistence.GetClusterMembersResponse, error) {
-	if err := c.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return c.baseCMStore.GetClusterMembers(ctx, request)
+	return inject1(c.ErrorGenerator.Generate(), func() (*persistence.GetClusterMembersResponse, error) {
+		return c.baseCMStore.GetClusterMembers(ctx, request)
+	})
 }
 
 func (c *FaultInjectionClusterMetadataStore) UpsertClusterMembership(
 	ctx context.Context,
 	request *persistence.UpsertClusterMembershipRequest,
 ) error {
-	if err := c.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return c.baseCMStore.UpsertClusterMembership(ctx, request)
+	return inject0(c.ErrorGenerator.Generate(), func() error {
+		return c.baseCMStore.UpsertClusterMembership(ctx, request)
+	})
 }
 
 func (c *FaultInjectionClusterMetadataStore) PruneClusterMembership(
 	ctx context.Context,
 	request *persistence.PruneClusterMembershipRequest,
 ) error {
-	if err := c.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return c.baseCMStore.PruneClusterMembership(ctx, request)
+	return inject0(c.ErrorGenerator.Generate(), func() error {
+		return c.baseCMStore.PruneClusterMembership(ctx, request)
+	})
 }
 
 func (c *FaultInjectionClusterMetadataStore) UpdateRate(rate float64) {
@@ -935,79 +883,71 @@ func (m *FaultInjectionMetadataStore) CreateNamespace(
 	ctx context.Context,
 	request *persistence.InternalCreateNamespaceRequest,
 ) (*persistence.CreateNamespaceResponse, error) {
-	if err := m.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return m.baseMetadataStore.CreateNamespace(ctx, request)
+	return inject1(m.ErrorGenerator.Generate(), func() (*persistence.CreateNamespaceResponse, error) {
+		return m.baseMetadataStore.CreateNamespace(ctx, request)
+	})
 }
 
 func (m *FaultInjectionMetadataStore) GetNamespace(
 	ctx context.Context,
 	request *persistence.GetNamespaceRequest,
 ) (*persistence.InternalGetNamespaceResponse, error) {
-	if err := m.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return m.baseMetadataStore.GetNamespace(ctx, request)
+	return inject1(m.ErrorGenerator.Generate(), func() (*persistence.InternalGetNamespaceResponse, error) {
+		return m.baseMetadataStore.GetNamespace(ctx, request)
+	})
 }
 
 func (m *FaultInjectionMetadataStore) UpdateNamespace(
 	ctx context.Context,
 	request *persistence.InternalUpdateNamespaceRequest,
 ) error {
-	if err := m.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return m.baseMetadataStore.UpdateNamespace(ctx, request)
+	return inject0(m.ErrorGenerator.Generate(), func() error {
+		return m.baseMetadataStore.UpdateNamespace(ctx, request)
+	})
 }
 
 func (m *FaultInjectionMetadataStore) RenameNamespace(
 	ctx context.Context,
 	request *persistence.InternalRenameNamespaceRequest,
 ) error {
-	if err := m.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return m.baseMetadataStore.RenameNamespace(ctx, request)
+	return inject0(m.ErrorGenerator.Generate(), func() error {
+		return m.baseMetadataStore.RenameNamespace(ctx, request)
+	})
 }
 
 func (m *FaultInjectionMetadataStore) DeleteNamespace(
 	ctx context.Context,
 	request *persistence.DeleteNamespaceRequest,
 ) error {
-	if err := m.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return m.baseMetadataStore.DeleteNamespace(ctx, request)
+	return inject0(m.ErrorGenerator.Generate(), func() error {
+		return m.baseMetadataStore.DeleteNamespace(ctx, request)
+	})
 }
 
 func (m *FaultInjectionMetadataStore) DeleteNamespaceByName(
 	ctx context.Context,
 	request *persistence.DeleteNamespaceByNameRequest,
 ) error {
-	if err := m.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return m.baseMetadataStore.DeleteNamespaceByName(ctx, request)
+	return inject0(m.ErrorGenerator.Generate(), func() error {
+		return m.baseMetadataStore.DeleteNamespaceByName(ctx, request)
+	})
 }
 
 func (m *FaultInjectionMetadataStore) ListNamespaces(
 	ctx context.Context,
 	request *persistence.InternalListNamespacesRequest,
 ) (*persistence.InternalListNamespacesResponse, error) {
-	if err := m.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return m.baseMetadataStore.ListNamespaces(ctx, request)
+	return inject1(m.ErrorGenerator.Generate(), func() (*persistence.InternalListNamespacesResponse, error) {
+		return m.baseMetadataStore.ListNamespaces(ctx, request)
+	})
 }
 
 func (m *FaultInjectionMetadataStore) GetMetadata(
 	ctx context.Context,
 ) (*persistence.GetMetadataResponse, error) {
-	if err := m.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return m.baseMetadataStore.GetMetadata(ctx)
+	return inject1(m.ErrorGenerator.Generate(), func() (*persistence.GetMetadataResponse, error) {
+		return m.baseMetadataStore.GetMetadata(ctx)
+	})
 }
 
 func (m *FaultInjectionMetadataStore) UpdateRate(rate float64) {
@@ -1038,115 +978,102 @@ func (t *FaultInjectionTaskStore) CreateTaskQueue(
 	ctx context.Context,
 	request *persistence.InternalCreateTaskQueueRequest,
 ) error {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return t.baseTaskStore.CreateTaskQueue(ctx, request)
+	return inject0(t.ErrorGenerator.Generate(), func() error {
+		return t.baseTaskStore.CreateTaskQueue(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) GetTaskQueue(
 	ctx context.Context,
 	request *persistence.InternalGetTaskQueueRequest,
 ) (*persistence.InternalGetTaskQueueResponse, error) {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return t.baseTaskStore.GetTaskQueue(ctx, request)
+	return inject1(t.ErrorGenerator.Generate(), func() (*persistence.InternalGetTaskQueueResponse, error) {
+		return t.baseTaskStore.GetTaskQueue(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) UpdateTaskQueue(
 	ctx context.Context,
 	request *persistence.InternalUpdateTaskQueueRequest,
 ) (*persistence.UpdateTaskQueueResponse, error) {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return t.baseTaskStore.UpdateTaskQueue(ctx, request)
+	return inject1(t.ErrorGenerator.Generate(), func() (*persistence.UpdateTaskQueueResponse, error) {
+		return t.baseTaskStore.UpdateTaskQueue(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) ListTaskQueue(
 	ctx context.Context,
 	request *persistence.ListTaskQueueRequest,
 ) (*persistence.InternalListTaskQueueResponse, error) {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return t.baseTaskStore.ListTaskQueue(ctx, request)
+	return inject1(t.ErrorGenerator.Generate(), func() (*persistence.InternalListTaskQueueResponse, error) {
+		return t.baseTaskStore.ListTaskQueue(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) DeleteTaskQueue(
 	ctx context.Context,
 	request *persistence.DeleteTaskQueueRequest,
 ) error {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return t.baseTaskStore.DeleteTaskQueue(ctx, request)
+	return inject0(t.ErrorGenerator.Generate(), func() error {
+		return t.baseTaskStore.DeleteTaskQueue(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) CreateTasks(
 	ctx context.Context,
 	request *persistence.InternalCreateTasksRequest,
 ) (*persistence.CreateTasksResponse, error) {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return t.baseTaskStore.CreateTasks(ctx, request)
+	return inject1(t.ErrorGenerator.Generate(), func() (*persistence.CreateTasksResponse, error) {
+		return t.baseTaskStore.CreateTasks(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) GetTasks(
 	ctx context.Context,
 	request *persistence.GetTasksRequest,
 ) (*persistence.InternalGetTasksResponse, error) {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return t.baseTaskStore.GetTasks(ctx, request)
+	return inject1(t.ErrorGenerator.Generate(), func() (*persistence.InternalGetTasksResponse, error) {
+		return t.baseTaskStore.GetTasks(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) CompleteTasksLessThan(
 	ctx context.Context,
 	request *persistence.CompleteTasksLessThanRequest,
 ) (int, error) {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return 0, err
-	}
-	return t.baseTaskStore.CompleteTasksLessThan(ctx, request)
+	return inject1(t.ErrorGenerator.Generate(), func() (int, error) {
+		return t.baseTaskStore.CompleteTasksLessThan(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) GetTaskQueueUserData(ctx context.Context, request *persistence.GetTaskQueueUserDataRequest) (*persistence.InternalGetTaskQueueUserDataResponse, error) {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return t.baseTaskStore.GetTaskQueueUserData(ctx, request)
+	return inject1(t.ErrorGenerator.Generate(), func() (*persistence.InternalGetTaskQueueUserDataResponse, error) {
+		return t.baseTaskStore.GetTaskQueueUserData(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) UpdateTaskQueueUserData(ctx context.Context, request *persistence.InternalUpdateTaskQueueUserDataRequest) error {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return t.baseTaskStore.UpdateTaskQueueUserData(ctx, request)
+	return inject0(t.ErrorGenerator.Generate(), func() error {
+		return t.baseTaskStore.UpdateTaskQueueUserData(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) ListTaskQueueUserDataEntries(ctx context.Context, request *persistence.ListTaskQueueUserDataEntriesRequest) (*persistence.InternalListTaskQueueUserDataEntriesResponse, error) {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return t.baseTaskStore.ListTaskQueueUserDataEntries(ctx, request)
+	return inject1(t.ErrorGenerator.Generate(), func() (*persistence.InternalListTaskQueueUserDataEntriesResponse, error) {
+		return t.baseTaskStore.ListTaskQueueUserDataEntries(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) GetTaskQueuesByBuildId(ctx context.Context, request *persistence.GetTaskQueuesByBuildIdRequest) ([]string, error) {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return t.baseTaskStore.GetTaskQueuesByBuildId(ctx, request)
+	return inject1(t.ErrorGenerator.Generate(), func() ([]string, error) {
+		return t.baseTaskStore.GetTaskQueuesByBuildId(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) CountTaskQueuesByBuildId(ctx context.Context, request *persistence.CountTaskQueuesByBuildIdRequest) (int, error) {
-	if err := t.ErrorGenerator.Generate(); err != nil {
-		return 0, err
-	}
-	return t.baseTaskStore.CountTaskQueuesByBuildId(ctx, request)
+	return inject1(t.ErrorGenerator.Generate(), func() (int, error) {
+		return t.baseTaskStore.CountTaskQueuesByBuildId(ctx, request)
+	})
 }
 
 func (t *FaultInjectionTaskStore) UpdateRate(rate float64) {
@@ -1160,11 +1087,11 @@ func NewFaultInjectionShardStore(
 	errorWeights := append(
 		defaultErrors,
 		FaultWeight{
-			errFactory: func(msg string) error {
-				return &persistence.ShardOwnershipLostError{
+			errFactory: func(msg string) *fault {
+				return newFault(&persistence.ShardOwnershipLostError{
 					ShardID: -1,
 					Msg:     fmt.Sprintf("FaultInjectionShardStore injected, %s", msg),
-				}
+				})
 			},
 			weight: 1,
 		},
@@ -1192,30 +1119,27 @@ func (s *FaultInjectionShardStore) GetOrCreateShard(
 	ctx context.Context,
 	request *persistence.InternalGetOrCreateShardRequest,
 ) (*persistence.InternalGetOrCreateShardResponse, error) {
-	if err := s.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return s.baseShardStore.GetOrCreateShard(ctx, request)
+	return inject1(s.ErrorGenerator.Generate(), func() (*persistence.InternalGetOrCreateShardResponse, error) {
+		return s.baseShardStore.GetOrCreateShard(ctx, request)
+	})
 }
 
 func (s *FaultInjectionShardStore) UpdateShard(
 	ctx context.Context,
 	request *persistence.InternalUpdateShardRequest,
 ) error {
-	if err := s.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return s.baseShardStore.UpdateShard(ctx, request)
+	return inject0(s.ErrorGenerator.Generate(), func() error {
+		return s.baseShardStore.UpdateShard(ctx, request)
+	})
 }
 
 func (s *FaultInjectionShardStore) AssertShardOwnership(
 	ctx context.Context,
 	request *persistence.AssertShardOwnershipRequest,
 ) error {
-	if err := s.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return s.baseShardStore.AssertShardOwnership(ctx, request)
+	return inject0(s.ErrorGenerator.Generate(), func() error {
+		return s.baseShardStore.AssertShardOwnership(ctx, request)
+	})
 }
 
 func (s *FaultInjectionShardStore) UpdateRate(rate float64) {
@@ -1245,40 +1169,36 @@ func (n *FaultInjectionNexusIncomingServiceStore) GetNexusIncomingService(
 	ctx context.Context,
 	request *persistence.GetNexusIncomingServiceRequest,
 ) (*persistence.InternalNexusIncomingService, error) {
-	if err := n.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return n.baseNexusIncomingServiceStore.GetNexusIncomingService(ctx, request)
+	return inject1(n.ErrorGenerator.Generate(), func() (*persistence.InternalNexusIncomingService, error) {
+		return n.baseNexusIncomingServiceStore.GetNexusIncomingService(ctx, request)
+	})
 }
 
 func (n *FaultInjectionNexusIncomingServiceStore) ListNexusIncomingServices(
 	ctx context.Context,
 	request *persistence.ListNexusIncomingServicesRequest,
 ) (*persistence.InternalListNexusIncomingServicesResponse, error) {
-	if err := n.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return n.baseNexusIncomingServiceStore.ListNexusIncomingServices(ctx, request)
+	return inject1(n.ErrorGenerator.Generate(), func() (*persistence.InternalListNexusIncomingServicesResponse, error) {
+		return n.baseNexusIncomingServiceStore.ListNexusIncomingServices(ctx, request)
+	})
 }
 
 func (n *FaultInjectionNexusIncomingServiceStore) CreateOrUpdateNexusIncomingService(
 	ctx context.Context,
 	request *persistence.InternalCreateOrUpdateNexusIncomingServiceRequest,
 ) error {
-	if err := n.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return n.baseNexusIncomingServiceStore.CreateOrUpdateNexusIncomingService(ctx, request)
+	return inject0(n.ErrorGenerator.Generate(), func() error {
+		return n.baseNexusIncomingServiceStore.CreateOrUpdateNexusIncomingService(ctx, request)
+	})
 }
 
 func (n *FaultInjectionNexusIncomingServiceStore) DeleteNexusIncomingService(
 	ctx context.Context,
 	request *persistence.DeleteNexusIncomingServiceRequest,
 ) error {
-	if err := n.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return n.baseNexusIncomingServiceStore.DeleteNexusIncomingService(ctx, request)
+	return inject0(n.ErrorGenerator.Generate(), func() error {
+		return n.baseNexusIncomingServiceStore.DeleteNexusIncomingService(ctx, request)
+	})
 }
 
 func (n *FaultInjectionNexusIncomingServiceStore) UpdateRate(rate float64) {

--- a/common/persistence/client/fault_injection_errorgenerator.go
+++ b/common/persistence/client/fault_injection_errorgenerator.go
@@ -44,7 +44,7 @@ type (
 	}
 
 	ErrorGenerator interface {
-		Generate() error
+		Generate() *fault
 		UpdateRate(rate float64)
 		UpdateWeights(weights []FaultWeight)
 		Rate() float64
@@ -55,7 +55,7 @@ type (
 		weight     float64
 	}
 
-	ErrorFactory func(string) error
+	ErrorFactory func(string) *fault
 
 	FaultMetadata struct {
 		errFactory ErrorFactory
@@ -130,7 +130,7 @@ func NewDefaultErrorGenerator(rate float64, errorWeights []FaultWeight) *Default
 	return result
 }
 
-func (p *DefaultErrorGenerator) Generate() error {
+func (p *DefaultErrorGenerator) Generate() *fault {
 	if p.rate.Load() <= 0 {
 		return nil
 	}
@@ -139,7 +139,7 @@ func (p *DefaultErrorGenerator) Generate() error {
 	defer p.Unlock()
 
 	if roll := p.r.Float64(); roll < p.rate.Load() {
-		var result error
+		var result *fault
 		for _, fm := range p.faultMetadata {
 			if roll < fm.threshold {
 				msg := fmt.Sprintf(

--- a/common/persistence/client/targeted_fault_injection.go
+++ b/common/persistence/client/targeted_fault_injection.go
@@ -49,7 +49,7 @@ func NewTargetedDataStoreErrorGenerator(cfg *config.FaultInjectionDataStoreConfi
 		for errName, errRate := range methodConfig.Errors {
 			err := newError(errName, errRate, methodName)
 			faultWeights = append(faultWeights, FaultWeight{
-				errFactory: func(data string) error {
+				errFactory: func(data string) *fault {
 					return err
 				},
 				weight: errRate,
@@ -80,7 +80,7 @@ type dataStoreErrorGenerator struct {
 // If no errors are configured for the method, or if there are some errors configured for this method,
 // but no error is sampled, then this method returns nil.
 // When this method returns nil, this causes the persistence layer to use the real implementation.
-func (d *dataStoreErrorGenerator) Generate() error {
+func (d *dataStoreErrorGenerator) Generate() *fault {
 	pc, _, _, ok := runtime.Caller(1)
 	if !ok {
 		panic("failed to get caller info")
@@ -100,25 +100,85 @@ func (d *dataStoreErrorGenerator) Generate() error {
 
 // newError returns an error based on the provided name. If the name is not recognized, then this method will
 // panic.
-func newError(errName string, errRate float64, methodName string) error {
+
+type fault struct {
+	err error
+	// execOp indicates whether the operation should be executed before returning the error.
+	execOp bool
+}
+
+func newFault(err error) *fault {
+	return &fault{
+		err:    err,
+		execOp: false,
+	}
+}
+func inject0(f *fault, op func() error) error {
+	if f == nil {
+		return op()
+	}
+	if f.execOp {
+		err := op()
+		if err != nil {
+			return err
+		}
+	}
+	return f.err
+}
+
+func inject1[T1 any](f *fault, op func() (T1, error)) (T1, error) {
+	if f == nil {
+		return op()
+	}
+	if f.execOp {
+		r1, err := op()
+		if err != nil {
+			return r1, err
+		}
+	}
+	var nilT1 T1
+	return nilT1, f.err
+}
+func inject2[T1 any, T2 any](f *fault, op func() (T1, T2, error)) (T1, T2, error) {
+	if f == nil {
+		return op()
+	}
+	if f.execOp {
+		r1, r2, err := op()
+		if err != nil {
+			return r1, r2, err
+		}
+	}
+	var nilT1 T1
+	var nilT2 T2
+	return nilT1, nilT2, f.err
+}
+
+func newError(errName string, errRate float64, methodName string) *fault {
 	header := fmt.Sprintf("fault injection error at %s with %.2f rate", methodName, errRate)
 	switch errName {
 	case "ShardOwnershipLost":
-		return &persistence.ShardOwnershipLostError{Msg: fmt.Sprintf("%s: persistence.ShardOwnershipLostError", header)}
+		return newFault(&persistence.ShardOwnershipLostError{Msg: fmt.Sprintf("%s: persistence.ShardOwnershipLostError", header)})
 	case "DeadlineExceeded":
 		// Real persistence store never returns context.DeadlineExceeded error. It returns persistence.TimeoutError instead.
 		// Therefor "DeadlineExceeded" shouldn't be used with fault injection. Use "Timeout" instead.
-		return fmt.Errorf("%s: %w", header, context.DeadlineExceeded)
+		return newFault(fmt.Errorf("%s: %w", header, context.DeadlineExceeded))
 	case "Timeout":
-		return &persistence.TimeoutError{Msg: fmt.Sprintf("%s: persistence.TimeoutError", header)}
+		return newFault(&persistence.TimeoutError{Msg: fmt.Sprintf("%s: persistence.TimeoutError", header)})
+	case "ExecuteAndTimeout":
+		// Special error which emulates case, when client got a Timeout error,
+		// but operation actually reached persistence and was executed successfully.
+		f := newFault(&persistence.TimeoutError{Msg: fmt.Sprintf("%s: persistence.TimeoutError", header)})
+		f.execOp = true
+		return f
 	case "ResourceExhausted":
-		return &serviceerror.ResourceExhausted{
+		return newFault(&serviceerror.ResourceExhausted{
 			Cause:   enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED,
 			Scope:   enumspb.RESOURCE_EXHAUSTED_SCOPE_SYSTEM,
 			Message: fmt.Sprintf("%s: serviceerror.ResourceExhausted", header),
-		}
+		})
 	case "Unavailable":
-		return serviceerror.NewUnavailable(fmt.Sprintf("%s: serviceerror.Unavailable", header))
+		return newFault(serviceerror.NewUnavailable(fmt.Sprintf("%s: serviceerror.Unavailable", header)))
 	default:
 		panic(fmt.Sprintf("unsupported error type: %v", errName))
 	}

--- a/config/development-cass-es-fi.yaml
+++ b/config/development-cass-es-fi.yaml
@@ -17,10 +17,12 @@ persistence:
                   errors:
                     ResourceExhausted: 0.05
                     Timeout: 0.05
+                    ExecuteAndTimeout: 0.05
                 UpdateWorkflowExecution:
                   errors:
                     ResourceExhausted: 0.10
                     Timeout: 0.05
+                    ExecuteAndTimeout: 0.05
                 GetWorkflowExecution:
                   errors:
                     ResourceExhausted: 0.05
@@ -33,6 +35,7 @@ persistence:
                   errors:
                     ResourceExhausted: 0.05
                     Timeout: 0.05
+                    ExecuteAndTimeout: 0.05
                 ReadHistoryBranch:
                   errors:
                     ResourceExhausted: 0.05


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Added new fault injection error `ExecuteAndTimeout`.

While working on this, I also figured out that fault injection code required refactoring and renames. I will do it in separate PR.

## Why?
<!-- Tell your future self why have you made these changes -->
`ExecuteAndTimeout` is a special error which emulates case, when client got a `Timeout` error, but operation actually reached persistence and was executed successfully.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run locally.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.