### PR TITLE
Account for state only changes in LastWriteVersion

### DIFF
--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -170,13 +170,15 @@ func createVersionedRunID(currentWorkflowLease api.WorkflowLease) (*api.Versione
 		return nil, nil
 	}
 	currentExecutionState := currentWorkflowLease.GetMutableState().GetExecutionState()
-	currentLastWriteVersion, err := currentWorkflowLease.GetMutableState().GetLastWriteVersion()
+	currentCloseVersion, err := currentWorkflowLease.GetMutableState().GetCloseVersion()
 	if err != nil {
 		return nil, err
 	}
 	id := api.VersionedRunID{
-		RunID:            currentExecutionState.RunId,
-		LastWriteVersion: currentLastWriteVersion,
+		RunID: currentExecutionState.RunId,
+		// we stop updating last write version in the current record after workflow is closed
+		// so workflow close version is the last write version for the current record
+		LastWriteVersion: currentCloseVersion,
 	}
 	return &id, nil
 }

--- a/service/history/api/update_workflow_util.go
+++ b/service/history/api/update_workflow_util.go
@@ -96,6 +96,9 @@ func UpdateWorkflowWithNew(
 		if err != nil {
 			return err
 		}
+		// if current workflow gets an update with a higher version than
+		// the version of the new workflow, it means failover has happened,
+		// and the new workflow creation should be failed
 		lastWriteVersion, err := mutableState.GetLastWriteVersion()
 		if err != nil {
 			return err

--- a/service/history/api/update_workflow_util.go
+++ b/service/history/api/update_workflow_util.go
@@ -96,9 +96,6 @@ func UpdateWorkflowWithNew(
 		if err != nil {
 			return err
 		}
-		// if current workflow gets an update with a higher version than
-		// the version of the new workflow, it means failover has happened,
-		// and the new workflow creation should be failed
 		lastWriteVersion, err := mutableState.GetLastWriteVersion()
 		if err != nil {
 			return err

--- a/service/history/archival_queue_task_executor.go
+++ b/service/history/archival_queue_task_executor.go
@@ -225,7 +225,7 @@ func (e *archivalQueueTaskExecutor) getArchiveTaskRequest(
 		RunID:                task.RunID,
 		BranchToken:          branchToken,
 		NextEventID:          nextEventID,
-		CloseFailoverVersion: mutableState.LastWriteVersion,
+		CloseFailoverVersion: mutableState.CloseVersion,
 		HistoryURI:           historyURI,
 		VisibilityURI:        visibilityURI,
 		WorkflowTypeName:     executionInfo.GetWorkflowTypeName(),
@@ -283,9 +283,9 @@ type lockedMutableState struct {
 	// MutableState is the mutable state that is being wrapped. You may call any method on this object safely since
 	// the state is locked.
 	workflow.MutableState
-	// LastWriteVersion is the last write version of the mutable state. We store this here so that we don't have to
-	// call GetLastWriteVersion() on the mutable state object again.
-	LastWriteVersion int64
+	// CloseVersion is the namespace failover when the workflow is closed. We store this here so that we don't have to
+	// call GetCloseVersion() on the mutable state object again.
+	CloseVersion int64
 	// Release is a function that releases the context of the mutable state. This function should be called when
 	// you are done with the mutable state.
 	Release cache.ReleaseCacheFunc
@@ -295,13 +295,13 @@ type lockedMutableState struct {
 // last write version and release function
 func newLockedMutableState(
 	mutableState workflow.MutableState,
-	version int64,
+	closeVersion int64,
 	releaseFunc cache.ReleaseCacheFunc,
 ) *lockedMutableState {
 	return &lockedMutableState{
-		MutableState:     mutableState,
-		LastWriteVersion: version,
-		Release:          releaseFunc,
+		MutableState: mutableState,
+		CloseVersion: closeVersion,
+		Release:      releaseFunc,
 	}
 }
 
@@ -344,7 +344,7 @@ func (e *archivalQueueTaskExecutor) loadAndVersionCheckMutableState(
 		logger.Warn("Dropping archival task because workflow is still running.")
 		return nil, ErrWorkflowExecutionIsStillRunning
 	}
-	lastWriteVersion, err := mutableState.GetLastWriteVersion()
+	closeVersion, err := mutableState.GetCloseVersion()
 	if err != nil {
 		return nil, err
 	}
@@ -353,12 +353,12 @@ func (e *archivalQueueTaskExecutor) loadAndVersionCheckMutableState(
 		e.shardContext,
 		logger,
 		namespaceEntry,
-		lastWriteVersion,
+		closeVersion,
 		task.GetVersion(),
 		task,
 	)
 	if err != nil {
 		return nil, err
 	}
-	return newLockedMutableState(mutableState, lastWriteVersion, release), nil
+	return newLockedMutableState(mutableState, closeVersion, release), nil
 }

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -5153,20 +5153,40 @@ func (s *engineSuite) TestReapplyEvents_ReturnSuccess() {
 	taskqueue := "testTaskQueue"
 	identity := "testIdentity"
 
+	eventVersion := int64(100)
 	history := []*historypb.HistoryEvent{
 		{
 			EventId:   1,
 			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED,
-			Version:   1,
+			Version:   eventVersion,
 		},
 	}
-	ms := workflow.TestLocalMutableState(
+	globalNamespaceID := uuid.New()
+	globalNamespaceName := "global-namespace-name"
+	namespaceEntry := namespace.NewGlobalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Id: globalNamespaceID, Name: globalNamespaceName},
+		&persistencespb.NamespaceConfig{},
+		&persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []string{
+				cluster.TestCurrentClusterName,
+				cluster.TestAlternativeClusterName,
+			},
+		},
+		tests.Version,
+	)
+	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespaceEntry.ID()).Return(namespaceEntry, nil).AnyTimes()
+	s.mockNamespaceCache.EXPECT().GetNamespace(namespaceEntry.Name()).Return(namespaceEntry, nil).AnyTimes()
+	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, eventVersion).Return(cluster.TestAlternativeClusterName).AnyTimes()
+	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, namespaceEntry.FailoverVersion()).Return(cluster.TestCurrentClusterName).AnyTimes()
+
+	ms := workflow.TestGlobalMutableState(
 		s.mockHistoryEngine.shardContext,
 		s.eventsCache,
-		tests.LocalNamespaceEntry,
+		log.NewTestLogger(),
+		namespaceEntry.FailoverVersion(),
 		workflowExecution.GetWorkflowId(),
 		workflowExecution.GetRunId(),
-		log.NewTestLogger(),
 	)
 	// Add dummy event
 	addWorkflowExecutionStartedEvent(ms, &workflowExecution, "wType", taskqueue, payloads.EncodeString("input"), 100*time.Second, 50*time.Second, 200*time.Second, identity)
@@ -5179,7 +5199,7 @@ func (s *engineSuite) TestReapplyEvents_ReturnSuccess() {
 
 	err := s.mockHistoryEngine.ReapplyEvents(
 		context.Background(),
-		tests.NamespaceID,
+		namespaceEntry.ID(),
 		workflowExecution.GetWorkflowId(),
 		workflowExecution.GetRunId(),
 		history,
@@ -5187,9 +5207,9 @@ func (s *engineSuite) TestReapplyEvents_ReturnSuccess() {
 	s.NoError(err)
 }
 
-func (s *engineSuite) TestReapplyEvents_IgnoreSameVersionEvents() {
+func (s *engineSuite) TestReapplyEvents_IgnoreSameClusterEvents() {
 	workflowExecution := commonpb.WorkflowExecution{
-		WorkflowId: "test-reapply-same-version",
+		WorkflowId: "test-reapply-same-cluster",
 		RunId:      tests.RunID,
 	}
 	taskqueue := "testTaskQueue"
@@ -5238,20 +5258,40 @@ func (s *engineSuite) TestReapplyEvents_ResetWorkflow() {
 	}
 	taskqueue := "testTaskQueue"
 	identity := "testIdentity"
+	eventVersion := int64(100)
 	history := []*historypb.HistoryEvent{
 		{
 			EventId:   1,
 			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED,
-			Version:   100,
+			Version:   eventVersion,
 		},
 	}
-	ms := workflow.TestLocalMutableState(
+	globalNamespaceID := uuid.New()
+	globalNamespaceName := "global-namespace-name"
+	namespaceEntry := namespace.NewGlobalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Id: globalNamespaceID, Name: globalNamespaceName},
+		&persistencespb.NamespaceConfig{},
+		&persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []string{
+				cluster.TestCurrentClusterName,
+				cluster.TestAlternativeClusterName,
+			},
+		},
+		tests.Version,
+	)
+	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespaceEntry.ID()).Return(namespaceEntry, nil).AnyTimes()
+	s.mockNamespaceCache.EXPECT().GetNamespace(namespaceEntry.Name()).Return(namespaceEntry, nil).AnyTimes()
+	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, eventVersion).Return(cluster.TestAlternativeClusterName).AnyTimes()
+	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, namespaceEntry.FailoverVersion()).Return(cluster.TestCurrentClusterName).AnyTimes()
+
+	ms := workflow.TestGlobalMutableState(
 		s.mockHistoryEngine.shardContext,
 		s.eventsCache,
-		tests.LocalNamespaceEntry,
+		log.NewTestLogger(),
+		namespaceEntry.FailoverVersion(),
 		workflowExecution.GetWorkflowId(),
 		workflowExecution.GetRunId(),
-		log.NewTestLogger(),
 	)
 	// Add dummy event
 	addWorkflowExecutionStartedEvent(ms, &workflowExecution, "wType", taskqueue, payloads.EncodeString("input"), 100*time.Second, 50*time.Second, 200*time.Second, identity)
@@ -5274,9 +5314,10 @@ func (s *engineSuite) TestReapplyEvents_ResetWorkflow() {
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 	).Return(nil)
+
 	err = s.mockHistoryEngine.ReapplyEvents(
 		context.Background(),
-		tests.NamespaceID,
+		namespaceEntry.ID(),
 		workflowExecution.GetWorkflowId(),
 		workflowExecution.GetRunId(),
 		history,

--- a/service/history/ndc/buffer_event_flusher_test.go
+++ b/service/history/ndc/buffer_event_flusher_test.go
@@ -143,7 +143,7 @@ func (s *bufferEventFlusherSuite) TestClearTransientWorkflowTask() {
 
 func (s *bufferEventFlusherSuite) TestFlushBufferedEvents() {
 
-	lastEventVersion := int64(300)
+	lastWriteVersion := int64(300)
 	versionHistory := versionhistory.NewVersionHistory([]byte("some random base branch token"), []*historyspb.VersionHistoryItem{
 		versionhistory.NewVersionHistoryItem(10, 0),
 		versionhistory.NewVersionHistoryItem(50, 100),
@@ -159,10 +159,10 @@ func (s *bufferEventFlusherSuite) TestFlushBufferedEvents() {
 	)
 	s.NoError(err)
 
-	s.mockMutableState.EXPECT().GetLastEventVersion().Return(lastEventVersion, nil).AnyTimes()
+	s.mockMutableState.EXPECT().GetLastWriteVersion().Return(lastWriteVersion, nil).AnyTimes()
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
-	s.mockMutableState.EXPECT().UpdateCurrentVersion(lastEventVersion, true).Return(nil)
+	s.mockMutableState.EXPECT().UpdateCurrentVersion(lastWriteVersion, true).Return(nil)
 	workflowTask := &workflow.WorkflowTaskInfo{
 		ScheduledEventID: 1234,
 		StartedEventID:   2345,
@@ -187,7 +187,7 @@ func (s *bufferEventFlusherSuite) TestFlushBufferedEvents() {
 		enumsspb.WORKFLOW_TASK_TYPE_NORMAL,
 	).Return(&workflow.WorkflowTaskInfo{}, nil)
 	s.mockMutableState.EXPECT().FlushBufferedEvents()
-	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, lastEventVersion).Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, lastWriteVersion).Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 
 	s.mockContext.EXPECT().UpdateWorkflowExecutionAsActive(gomock.Any(), s.mockShard).Return(nil)

--- a/service/history/ndc/events_reapplier_test.go
+++ b/service/history/ndc/events_reapplier_test.go
@@ -102,7 +102,6 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Signal() {
 	msCurrent.EXPECT().GetCurrentVersion().Return(int64(0))
 	updateRegistry := update.NewRegistry(msCurrent)
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
-	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 	msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
 	msCurrent.EXPECT().AddWorkflowExecutionSignaled(
 		attr.GetSignalName(),
@@ -152,7 +151,6 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 		msCurrent.EXPECT().GetCurrentVersion().Return(int64(0))
 		updateRegistry := update.NewRegistry(msCurrent)
 		msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
-		msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 		msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
 		switch event.EventType {
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED:
@@ -242,7 +240,6 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
 	msCurrent.EXPECT().GetCurrentVersion().Return(int64(0))
 	updateRegistry := update.NewRegistry(msCurrent)
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
-	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 	msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
 	msCurrent.EXPECT().AddWorkflowExecutionSignaled(
 		attr1.GetSignalName(),
@@ -289,7 +286,6 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Error() {
 	msCurrent.EXPECT().GetCurrentVersion().Return(int64(0))
 	updateRegistry := update.NewRegistry(msCurrent)
 	msCurrent.EXPECT().IsWorkflowExecutionRunning().Return(true)
-	msCurrent.EXPECT().GetLastWriteVersion().Return(int64(1), nil).AnyTimes()
 	msCurrent.EXPECT().GetExecutionInfo().Return(execution).AnyTimes()
 	msCurrent.EXPECT().AddWorkflowExecutionSignaled(
 		attr.GetSignalName(),

--- a/service/history/ndc/workflow.go
+++ b/service/history/ndc/workflow.go
@@ -227,7 +227,7 @@ func (r *WorkflowImpl) FlushBufferedEvents() error {
 	currentCluster := r.clusterMetadata.GetCurrentClusterName()
 
 	if lastWriteCluster != currentCluster {
-		return serviceerror.NewInternal("Workflow encountered workflow with buffered events but last event not from current cluster")
+		return serviceerror.NewInternal("Workflow encountered workflow with buffered events but last write not from current cluster")
 	}
 
 	if _, err = r.failWorkflowTask(lastWriteVersion); err != nil {

--- a/service/history/ndc/workflow.go
+++ b/service/history/ndc/workflow.go
@@ -214,7 +214,7 @@ func (r *WorkflowImpl) FlushBufferedEvents() error {
 		return nil
 	}
 
-	// Same as the reasoning in mutableState.startTransactionHandleWorkflowTaskFailover()
+	// TODO: Same as the reasoning in mutableState.startTransactionHandleWorkflowTaskFailover()
 	// LastWriteVersion is only correct when replication task processing logic flush buffered
 	// events for state only changes as well.
 	// Transition history is not enabled today so LastWriteVersion == LastEventVersion

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -362,8 +362,6 @@ func (r *workflowResetterImpl) persistToDB(
 		r.shardContext,
 		persistence.CreateWorkflowModeUpdateCurrent,
 		currentRunID,
-		// we stop updating last write version in the current record after workflow is closed
-		// so workflow close version is the last write version for the current record
 		currentCloseVersion,
 		resetWorkflow.GetMutableState(),
 		resetWorkflowSnapshot,

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -352,7 +352,7 @@ func (r *workflowResetterImpl) persistToDB(
 
 	currentMutableState := currentWorkflow.GetMutableState()
 	currentRunID := currentMutableState.GetExecutionState().GetRunId()
-	currentLastWriteVersion, err := currentMutableState.GetLastWriteVersion()
+	currentCloseVersion, err := currentMutableState.GetCloseVersion()
 	if err != nil {
 		return err
 	}
@@ -362,7 +362,9 @@ func (r *workflowResetterImpl) persistToDB(
 		r.shardContext,
 		persistence.CreateWorkflowModeUpdateCurrent,
 		currentRunID,
-		currentLastWriteVersion,
+		// we stop updating last write version in the current record after workflow is closed
+		// so workflow close version is the last write version for the current record
+		currentCloseVersion,
 		resetWorkflow.GetMutableState(),
 		resetWorkflowSnapshot,
 		resetWorkflowEventsSeq,

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -220,7 +220,7 @@ func (s *workflowResetterSuite) TestPersistToDB_CurrentTerminated() {
 }
 
 func (s *workflowResetterSuite) TestPersistToDB_CurrentNotTerminated() {
-	currentLastWriteVersion := int64(1234)
+	currentCloseVersion := int64(1234)
 
 	currentWorkflow := NewMockWorkflow(s.controller)
 	currentReleaseCalled := false
@@ -234,7 +234,7 @@ func (s *workflowResetterSuite) TestPersistToDB_CurrentNotTerminated() {
 		RunId: s.currentRunID,
 	}).AnyTimes()
 
-	currentMutableState.EXPECT().GetLastWriteVersion().Return(currentLastWriteVersion, nil).AnyTimes()
+	currentMutableState.EXPECT().GetCloseVersion().Return(currentCloseVersion, nil).AnyTimes()
 
 	resetWorkflow := NewMockWorkflow(s.controller)
 	resetReleaseCalled := false
@@ -265,7 +265,7 @@ func (s *workflowResetterSuite) TestPersistToDB_CurrentNotTerminated() {
 		s.mockShard,
 		persistence.CreateWorkflowModeUpdateCurrent,
 		s.currentRunID,
-		currentLastWriteVersion,
+		currentCloseVersion,
 		resetMutableState,
 		resetSnapshot,
 		resetEventsSeq,

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -217,11 +217,6 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityTimeoutTask(
 		// NOTE: this is the only place in the standby logic where mutable state can be updated
 
 		// need to clear the activity heartbeat timer task marks
-		lastWriteVersion, err := mutableState.GetLastWriteVersion()
-		if err != nil {
-			return nil, err
-		}
-
 		// NOTE: LastHeartbeatTimeoutVisibilityInSeconds is for deduping heartbeat timer creation as it's possible
 		// one heartbeat task was persisted multiple times with different taskIDs due to the retry logic
 		// for updating workflow execution. In that case, only one new heartbeat timeout task should be
@@ -247,9 +242,22 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityTimeoutTask(
 			return nil, nil
 		}
 
+		// TODO: why do we need to update the current version here?
+		// Neither UpdateActivity nor CreateNextActivityTimer uses the current version.
+		// Current version also not used when closing the transaction as passive
+		//
 		// we need to handcraft some of the variables
 		// since the job being done here is update the activity and possibly write a timer task to DB
 		// also need to reset the current version.
+		//
+		// change is safe here because
+		// 1. workflow is still running
+		// 2. state only change has no difference compared to change with new events from the activity POV
+		//    both versions could be anything.
+		lastWriteVersion, err := mutableState.GetLastWriteVersion()
+		if err != nil {
+			return nil, err
+		}
 		if err := mutableState.UpdateCurrentVersion(lastWriteVersion, true); err != nil {
 			return nil, err
 		}

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -249,11 +249,6 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityTimeoutTask(
 		// we need to handcraft some of the variables
 		// since the job being done here is update the activity and possibly write a timer task to DB
 		// also need to reset the current version.
-		//
-		// change is safe here because
-		// 1. workflow is still running
-		// 2. state only change has no difference compared to change with new events from the activity POV
-		//    both versions could be anything.
 		lastWriteVersion, err := mutableState.GetLastWriteVersion()
 		if err != nil {
 			return nil, err

--- a/service/history/timer_queue_task_executor_base.go
+++ b/service/history/timer_queue_task_executor_base.go
@@ -133,11 +133,11 @@ func (t *timerQueueTaskExecutorBase) executeDeleteHistoryEventTask(
 		return nil
 	}
 
-	lastWriteVersion, err := mutableState.GetLastWriteVersion()
+	closeVersion, err := mutableState.GetCloseVersion()
 	if err != nil {
 		return err
 	}
-	if err := CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), lastWriteVersion, task.Version, task); err != nil {
+	if err := CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), closeVersion, task.Version, task); err != nil {
 		return err
 	}
 

--- a/service/history/timer_queue_task_executor_base_test.go
+++ b/service/history/timer_queue_task_executor_base_test.go
@@ -131,7 +131,7 @@ func (s *timerQueueTaskExecutorBaseSuite) Test_executeDeleteHistoryEventTask_NoE
 	s.mockCache.EXPECT().GetOrCreateWorkflowExecution(gomock.Any(), s.testShardContext, tests.NamespaceID, we, workflow.LockPriorityLow).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
 
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.testShardContext).Return(mockMutableState, nil)
-	mockMutableState.EXPECT().GetLastWriteVersion().Return(int64(1), nil)
+	mockMutableState.EXPECT().GetCloseVersion().Return(int64(1), nil)
 	mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{})
 	mockMutableState.EXPECT().GetNextEventID().Return(int64(2))
 	mockMutableState.EXPECT().GetNamespaceEntry().Return(tests.LocalNamespaceEntry)
@@ -176,7 +176,7 @@ func (s *timerQueueTaskExecutorBaseSuite) TestArchiveHistory_DeleteFailed() {
 	s.mockCache.EXPECT().GetOrCreateWorkflowExecution(gomock.Any(), s.testShardContext, tests.NamespaceID, we, workflow.LockPriorityLow).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
 
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.testShardContext).Return(mockMutableState, nil)
-	mockMutableState.EXPECT().GetLastWriteVersion().Return(int64(1), nil)
+	mockMutableState.EXPECT().GetCloseVersion().Return(int64(1), nil)
 	mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{})
 	mockMutableState.EXPECT().GetNextEventID().Return(int64(2))
 	mockMutableState.EXPECT().GetNamespaceEntry().Return(tests.LocalNamespaceEntry)

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -327,11 +327,11 @@ func (t *transferQueueActiveTaskExecutor) processCloseExecution(
 	// DeleteAfterClose is set to true when this close execution task was generated as part of delete open workflow execution procedure.
 	// Delete workflow execution is started by user API call and should be done regardless of current workflow version.
 	if !task.DeleteAfterClose {
-		lastWriteVersion, err := mutableState.GetLastWriteVersion()
+		closeVersion, err := mutableState.GetCloseVersion()
 		if err != nil {
 			return err
 		}
-		err = CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), lastWriteVersion, task.Version, task)
+		err = CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), closeVersion, task.Version, task)
 		if err != nil {
 			return err
 		}
@@ -951,7 +951,7 @@ func (t *transferQueueActiveTaskExecutor) processResetWorkflow(
 		return nil
 	}
 
-	currentStartVersion, err := currentMutableState.GetStartVersion()
+	currentStartVersion, err := currentMutableState.GetStartVersion() // why??? GenerateWorkflowResetTasks uses currentVersion
 	if err != nil {
 		return err
 	}

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -951,7 +951,9 @@ func (t *transferQueueActiveTaskExecutor) processResetWorkflow(
 		return nil
 	}
 
-	currentStartVersion, err := currentMutableState.GetStartVersion() // why??? GenerateWorkflowResetTasks uses currentVersion
+	// TODO: why we are comparing task version to workflow start version here?
+	// GenerateWorkflowResetTasks uses currentVersion
+	currentStartVersion, err := currentMutableState.GetStartVersion()
 	if err != nil {
 		return err
 	}

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -1893,7 +1893,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Su
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), s.createChildWorkflowExecutionRequest(
-		s.namespace,
 		s.childNamespace,
 		transferTask,
 		mutableState,
@@ -2008,7 +2007,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Fa
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), s.createChildWorkflowExecutionRequest(
-		s.namespace,
 		s.childNamespace,
 		transferTask,
 		mutableState,
@@ -2493,7 +2491,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestPendingCloseExecutionTasks() 
 				},
 			}).AnyTimes()
 			mockShard.EXPECT().GetClusterMetadata().Return(mockClusterMetadata).AnyTimes()
-			mockMutableState.EXPECT().GetLastWriteVersion().Return(tests.Version, nil).AnyTimes()
+			mockMutableState.EXPECT().GetCloseVersion().Return(tests.Version, nil).AnyTimes()
 			mockNamespaceRegistry := namespace.NewMockRegistry(ctrl)
 			mockNamespaceRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(namespaceEntry, nil)
 			mockShard.EXPECT().GetNamespaceRegistry().Return(mockNamespaceRegistry)
@@ -2641,7 +2639,6 @@ func (s *transferQueueActiveTaskExecutorSuite) createSignalWorkflowExecutionRequ
 }
 
 func (s *transferQueueActiveTaskExecutorSuite) createChildWorkflowExecutionRequest(
-	namespace namespace.Name,
 	childNamespace namespace.Name,
 	task *tasks.StartChildExecutionTask,
 	mutableState workflow.MutableState,

--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -246,11 +246,11 @@ func (t *transferQueueStandbyTaskExecutor) processCloseExecution(
 
 		executionInfo := mutableState.GetExecutionInfo()
 
-		lastWriteVersion, err := mutableState.GetLastWriteVersion()
+		closeVersion, err := mutableState.GetCloseVersion()
 		if err != nil {
 			return nil, err
 		}
-		err = CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), lastWriteVersion, transferTask.Version, transferTask)
+		err = CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), closeVersion, transferTask.Version, transferTask)
 		if err != nil {
 			return nil, err
 		}

--- a/service/history/transfer_queue_task_executor_base.go
+++ b/service/history/transfer_queue_task_executor_base.go
@@ -279,11 +279,11 @@ func (t *transferQueueTaskExecutorBase) deleteExecution(
 	}
 
 	if taskVersion != common.EmptyVersion {
-		lastWriteVersion, err := mutableState.GetLastWriteVersion()
+		closeVersion, err := mutableState.GetCloseVersion()
 		if err != nil {
 			return err
 		}
-		err = CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), lastWriteVersion, taskVersion, task)
+		err = CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), closeVersion, taskVersion, task)
 		if err != nil {
 			return err
 		}

--- a/service/history/visibility_queue_task_executor.go
+++ b/service/history/visibility_queue_task_executor.go
@@ -257,11 +257,11 @@ func (t *visibilityQueueTaskExecutor) processCloseExecution(
 		return nil
 	}
 
-	lastWriteVersion, err := mutableState.GetLastWriteVersion()
+	closeVersion, err := mutableState.GetCloseVersion()
 	if err != nil {
 		return err
 	}
-	err = CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), lastWriteVersion, task.Version, task)
+	err = CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), closeVersion, task.Version, task)
 	if err != nil {
 		return err
 	}
@@ -427,11 +427,11 @@ func (t *visibilityQueueTaskExecutor) cleanupExecutionInfo(
 		return nil
 	}
 
-	lastWriteVersion, err := mutableState.GetLastWriteVersion()
+	closeVersion, err := mutableState.GetCloseVersion()
 	if err != nil {
 		return err
 	}
-	err = CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), lastWriteVersion, task.Version, task)
+	err = CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), closeVersion, task.Version, task)
 	if err != nil {
 		return err
 	}

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -240,6 +240,7 @@ type (
 		GetStartVersion() (int64, error)
 		GetCloseVersion() (int64, error)
 		GetLastWriteVersion() (int64, error)
+		GetLastEventVersion() (int64, error)
 		GetExecutionInfo() *persistencespb.WorkflowExecutionInfo
 		GetExecutionState() *persistencespb.WorkflowExecutionState
 		GetStartedWorkflowTask() *WorkflowTaskInfo

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5491,9 +5491,6 @@ func (ms *MutableStateImpl) startTransactionHandleNamespaceMigration(
 	// * flush buffered events as if namespace is still local
 	// * use updated namespace for actual call
 
-	// - we want to catch if namespace promotion happens, which applies to both
-	// events and state only changes
-	// - also ms only has started workflow task when it's still running
 	lastWriteVersion, err := ms.GetLastWriteVersion()
 	if err != nil {
 		return nil, err

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5518,7 +5518,8 @@ func (ms *MutableStateImpl) startTransactionHandleWorkflowTaskFailover() (bool, 
 
 	// Handling mutable state turn from standby to active, while having a workflow task on the fly
 	workflowTask := ms.GetStartedWorkflowTask()
-	if workflowTask == nil || workflowTask.Version >= ms.GetCurrentVersion() {
+	currentVersion := ms.GetCurrentVersion()
+	if workflowTask == nil || workflowTask.Version >= currentVersion {
 		// no pending workflow tasks, no buffered events
 		// or workflow task has higher / equal version
 		return false, nil
@@ -5532,8 +5533,6 @@ func (ms *MutableStateImpl) startTransactionHandleWorkflowTaskFailover() (bool, 
 		return false, serviceerror.NewInternal(fmt.Sprintf("MutableStateImpl encountered mismatch version, workflow task: %v, last event version %v", workflowTask.Version, lastEventVersion))
 	}
 
-	// workflow must be running, checked at the beginning of the func
-	currentVersion := ms.GetCurrentVersion()
 	// NOTE: if lastEventVersion is used here then the version transition history could decrecase
 	//
 	// TODO: Today's replication task processing logic won't flush buffered events when applying state only changes.

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -765,7 +765,7 @@ func (ms *MutableStateImpl) GetCloseVersion() (int64, error) {
 		return lastEventVersion, nil
 	}
 
-	return ms.GetLastWriteVersion()
+	return ms.GetLastEventVersion()
 }
 
 func (ms *MutableStateImpl) GetLastWriteVersion() (int64, error) {

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -1975,6 +1975,21 @@ func (mr *MockMutableStateMockRecorder) GetInheritedBuildId() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInheritedBuildId", reflect.TypeOf((*MockMutableState)(nil).GetInheritedBuildId))
 }
 
+// GetLastEventVersion mocks base method.
+func (m *MockMutableState) GetLastEventVersion() (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLastEventVersion")
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLastEventVersion indicates an expected call of GetLastEventVersion.
+func (mr *MockMutableStateMockRecorder) GetLastEventVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastEventVersion", reflect.TypeOf((*MockMutableState)(nil).GetLastEventVersion))
+}
+
 // GetLastFirstEventIDTxnID mocks base method.
 func (m *MockMutableState) GetLastFirstEventIDTxnID() (int64, int64) {
 	m.ctrl.T.Helper()

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -351,7 +351,6 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskScheduledEventAsHeartbeat(
 
 		// If failover happened during transient workflow task,
 		// then reset the attempt to 1, and not use transient workflow task.
-		// workflow must be running here
 		if m.ms.GetCurrentVersion() != lastEventVersion {
 			m.ms.executionInfo.WorkflowTaskAttempt = 1
 			workflowTaskType = enumsspb.WORKFLOW_TASK_TYPE_NORMAL

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -341,14 +341,18 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskScheduledEventAsHeartbeat(
 		m.ms.updatePendingEventIDs(m.ms.hBuilder.FlushBufferToCurrentBatch())
 	}
 	if m.ms.IsTransientWorkflowTask() {
-		lastWriteVersion, err := m.ms.GetLastWriteVersion()
+		// TODO: ideally this should be the version of the last started workflow task.
+		// but we are using the last event version here instead since there's no other
+		// events when there's a started workflow task.
+		lastEventVersion, err := m.ms.GetLastEventVersion()
 		if err != nil {
 			return nil, err
 		}
 
 		// If failover happened during transient workflow task,
 		// then reset the attempt to 1, and not use transient workflow task.
-		if m.ms.GetCurrentVersion() != lastWriteVersion {
+		// workflow must be running here
+		if m.ms.GetCurrentVersion() != lastEventVersion {
 			m.ms.executionInfo.WorkflowTaskAttempt = 1
 			workflowTaskType = enumsspb.WORKFLOW_TASK_TYPE_NORMAL
 			createWorkflowTaskScheduledEvent = true


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Account for state only changes in LastWriteVersion
- ^ also means LastWriteVersion could change after workflow is closed.
- NOTE: this PR is stacked on top of https://github.com/temporalio/temporal/pull/5860

## Why?
<!-- Tell your future self why have you made these changes -->
- Account for state only changes

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests & new unit tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
