### PR TITLE
Fixing flaky TestWorkflowReplicationTaskFailure

### DIFF
--- a/tests/xdc/history_replication_dlq_test.go
+++ b/tests/xdc/history_replication_dlq_test.go
@@ -237,7 +237,7 @@ func (s *historyReplicationDLQSuite) TestWorkflowReplicationTaskFailure() {
 	// replication, so we use a context with a timeout to ensure that the test doesn't hang forever when we try to
 	// receive from a channel.
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, testTimeout)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	// Register a namespace.


### PR DESCRIPTION
## What changed?
Fixing flaky TestWorkflowReplicationTaskFailure by increasing timeout.

## Why?
It looks like test timeout is not enough for the history events to get replicated and DLQed.
Increasing the timeout from 30s to 1m. 

## How did you test it?


## Potential risks


## Documentation

## Is hotfix candidate?
No
