### PR TITLE
Add config for scheduler local activity sleep limit

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2306,6 +2306,12 @@ If the service configures with archival feature enabled, update worker.historySc
 		30.0,
 		`SchedulerNamespaceStartWorkflowRPS is the per-namespace limit for starting workflows by schedules`,
 	)
+	SchedulerLocalActivitySleepLimit = NewNamespaceDurationSetting(
+		"worker.schedulerLocalActivitySleepLimit",
+		1*time.Second,
+		`How long to sleep within a local activity before pushing to workflow level sleep (don't make this
+close to or more than the workflow task timeout)`,
+	)
 	WorkerDeleteNamespaceActivityLimitsConfig = NewGlobalMapSetting(
 		"worker.deleteNamespaceActivityLimitsConfig",
 		map[string]any{},


### PR DESCRIPTION
## What changed?
Add a config for the "1 second" limit on local activity sleep due to rate limit.
Also rename some stuff to be more readable.

## Why?
We want to adjust this to tune rate limiting behavior.

## How did you test it?
will test manually