### PR TITLE
Bypass namespace rate limit interceptor if namespace name cannot be retrieved

### DIFF
--- a/common/rpc/interceptor/namespace_rate_limit.go
+++ b/common/rpc/interceptor/namespace_rate_limit.go
@@ -78,11 +78,13 @@ func (ni *NamespaceRateLimitInterceptor) Intercept(
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (interface{}, error) {
-	ns := MustGetNamespaceName(ni.namespaceRegistry, req)
-	md, _ := metadata.FromIncomingContext(ctx)
-	if err := ni.Allow(ns, info.FullMethod, headers.GRPCHeaderGetter{Metadata: md}); err != nil {
-		return nil, err
+	if ns := MustGetNamespaceName(ni.namespaceRegistry, req); ns != namespace.EmptyName {
+		md, _ := metadata.FromIncomingContext(ctx)
+		if err := ni.Allow(ns, info.FullMethod, headers.GRPCHeaderGetter{Metadata: md}); err != nil {
+			return nil, err
+		}
 	}
+
 	return handler(ctx, req)
 }
 

--- a/service/frontend/fx_test.go
+++ b/service/frontend/fx_test.go
@@ -583,8 +583,9 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			namespaceName := "test-namespace"
 			mockRegistry := namespace.NewMockRegistry(gomock.NewController(t))
-			mockRegistry.EXPECT().GetNamespace(namespace.Name("")).Return(&namespace.Namespace{}, nil).AnyTimes()
+			mockRegistry.EXPECT().GetNamespace(namespace.Name(namespaceName)).Return(&namespace.Namespace{}, nil).AnyTimes()
 			serviceResolver := membership.NewMockServiceResolver(gomock.NewController(t))
 			serviceResolver.EXPECT().MemberCount().Return(tc.frontendServiceCount).AnyTimes()
 
@@ -653,7 +654,9 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			for i := 0; i < tc.numRequests; i++ {
 				_, err = client.StartWorkflowExecution(
 					context.Background(),
-					&workflowservice.StartWorkflowExecutionRequest{},
+					&workflowservice.StartWorkflowExecutionRequest{
+						Namespace: namespaceName,
+					},
 					grpc.Header(&header),
 				)
 				if err != nil {
@@ -664,7 +667,9 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			for i := 0; i < tc.numVisibilityRequests; i++ {
 				_, err = client.ListWorkflowExecutions(
 					context.Background(),
-					&workflowservice.ListWorkflowExecutionsRequest{},
+					&workflowservice.ListWorkflowExecutionsRequest{
+						Namespace: namespaceName,
+					},
 					grpc.Header(&header),
 				)
 				if err != nil {
@@ -675,7 +680,9 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			for i := 0; i < tc.numReplicationInducingRequests; i++ {
 				_, err = client.RegisterNamespace(
 					context.Background(),
-					&workflowservice.RegisterNamespaceRequest{},
+					&workflowservice.RegisterNamespaceRequest{
+						Namespace: namespaceName,
+					},
 					grpc.Header(&header),
 				)
 				if err != nil {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Bypass namespace rate limit interceptor if namespace name cannot be retrieved

## Why?
<!-- Tell your future self why have you made these changes -->
- Calls like GetSystemInfo doesn't contain namespace name and today's logic will use empty string `""` as the namespace name and go through a rate limiter for that `""` namespace

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Run server locally

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
