### PR TITLE
Use AvailableMemberCount when computing member count for rate limits

### DIFF
--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -103,6 +103,8 @@ type (
 		RemoveListener(name string) error
 		// MemberCount returns the number of known hosts running this service.
 		MemberCount() int
+		// AvailableMemberCount returns the number of hosts running this service that are accepting requests (not draining).
+		AvailableMemberCount() int
 		// Members returns all known hosts available for this service.
 		Members() []HostInfo
 		// AvailableMembers returns all hosts available for this service that are accepting requests (not draining).

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -210,6 +210,20 @@ func (mr *MockServiceResolverMockRecorder) AddListener(name, notifyChannel inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddListener", reflect.TypeOf((*MockServiceResolver)(nil).AddListener), name, notifyChannel)
 }
 
+// AvailableMemberCount mocks base method.
+func (m *MockServiceResolver) AvailableMemberCount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailableMemberCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// AvailableMemberCount indicates an expected call of AvailableMemberCount.
+func (mr *MockServiceResolverMockRecorder) AvailableMemberCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableMemberCount", reflect.TypeOf((*MockServiceResolver)(nil).AvailableMemberCount))
+}
+
 // AvailableMembers mocks base method.
 func (m *MockServiceResolver) AvailableMembers() []HostInfo {
 	m.ctrl.T.Helper()

--- a/common/membership/ringpop/service_resolver.go
+++ b/common/membership/ringpop/service_resolver.go
@@ -234,6 +234,20 @@ func (r *serviceResolver) MemberCount() int {
 	return len(hosts)
 }
 
+func (r *serviceResolver) AvailableMemberCount() int {
+	_, hosts := r.ring()
+	n := 0
+	for _, host := range hosts {
+		if drainingStr, ok := host.Label(drainingKey); ok {
+			if draining, _ := strconv.ParseBool(drainingStr); draining {
+				continue
+			}
+		}
+		n++
+	}
+	return n
+}
+
 func (r *serviceResolver) Members() []membership.HostInfo {
 	_, hosts := r.ring()
 	servers := make([]membership.HostInfo, 0, len(hosts))

--- a/common/membership/ringpop/service_resolver.go
+++ b/common/membership/ringpop/service_resolver.go
@@ -238,12 +238,9 @@ func (r *serviceResolver) AvailableMemberCount() int {
 	_, hosts := r.ring()
 	n := 0
 	for _, host := range hosts {
-		if drainingStr, ok := host.Label(drainingKey); ok {
-			if draining, _ := strconv.ParseBool(drainingStr); draining {
-				continue
-			}
+		if !isDraining(host) {
+			n++
 		}
-		n++
 	}
 	return n
 }
@@ -261,12 +258,9 @@ func (r *serviceResolver) AvailableMembers() []membership.HostInfo {
 	_, hosts := r.ring()
 	var servers []membership.HostInfo
 	for _, host := range hosts {
-		if drainingStr, ok := host.Label(drainingKey); ok {
-			if draining, _ := strconv.ParseBool(drainingStr); draining {
-				continue
-			}
+		if !isDraining(host) {
+			servers = append(servers, host)
 		}
-		servers = append(servers, host)
 	}
 	return servers
 }
@@ -549,4 +543,13 @@ func parseIntLabel(member swim.Member, label string) (int64, error) {
 		return 0, errMissingLabel
 	}
 	return strconv.ParseInt(str, 10, 64)
+}
+
+func isDraining(host *hostInfo) bool {
+	if drainingStr, ok := host.Label(drainingKey); ok {
+		if draining, err := strconv.ParseBool(drainingStr); err == nil {
+			return draining
+		}
+	}
+	return false
 }

--- a/common/membership/static/service_resolver.go
+++ b/common/membership/static/service_resolver.go
@@ -121,6 +121,12 @@ func (s *staticResolver) MemberCount() int {
 	return len(s.hostInfos)
 }
 
+func (s *staticResolver) AvailableMemberCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.hostInfos)
+}
+
 func (s *staticResolver) Members() []membership.HostInfo {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/common/quotas/calculator/cluster_aware_quota_calculator.go
+++ b/common/quotas/calculator/cluster_aware_quota_calculator.go
@@ -32,7 +32,7 @@ var (
 type (
 	// MemberCounter returns the total number of instances there are for a given service.
 	MemberCounter interface {
-		MemberCount() int
+		AvailableMemberCount() int
 	}
 	// ClusterAwareQuotaCalculator calculates the available quota for the current host based on the per instance and per
 	// cluster quota. The quota could represent requests per second, total number of active requests, etc. It works by
@@ -57,7 +57,7 @@ type (
 // the memberCounter reports is greater than zero. Otherwise, the per-instance limit is used.
 func getQuota(memberCounter MemberCounter, instanceLimit, clusterLimit int) float64 {
 	if clusterLimit > 0 && memberCounter != nil {
-		if clusterSize := memberCounter.MemberCount(); clusterSize > 0 {
+		if clusterSize := memberCounter.AvailableMemberCount(); clusterSize > 0 {
 			return float64(clusterLimit) / float64(clusterSize)
 		}
 	}

--- a/common/quotas/quotastest/fake_instance_counter.go
+++ b/common/quotas/quotastest/fake_instance_counter.go
@@ -33,6 +33,6 @@ type memberCounter struct {
 	numInstances int
 }
 
-func (c memberCounter) MemberCount() int {
+func (c memberCounter) AvailableMemberCount() int {
 	return c.numInstances
 }

--- a/service/frontend/fx_test.go
+++ b/service/frontend/fx_test.go
@@ -207,7 +207,7 @@ func TestRateLimitInterceptorProvider(t *testing.T) {
 				tc.operatorRPSRatio = operatorRPSRatio
 				tc.expectRateLimit = false
 				serviceResolver := membership.NewMockServiceResolver(gomock.NewController(tc.t))
-				serviceResolver.EXPECT().MemberCount().Return(0).AnyTimes()
+				serviceResolver.EXPECT().AvailableMemberCount().Return(0).AnyTimes()
 				tc.serviceResolver = serviceResolver
 			},
 		},
@@ -225,7 +225,7 @@ func TestRateLimitInterceptorProvider(t *testing.T) {
 				// This may be overridden by the test case.
 				ctrl := gomock.NewController(t)
 				serviceResolver := membership.NewMockServiceResolver(ctrl)
-				serviceResolver.EXPECT().MemberCount().Return(numHosts).AnyTimes()
+				serviceResolver.EXPECT().AvailableMemberCount().Return(numHosts).AnyTimes()
 				tc.serviceResolver = serviceResolver
 			}
 			tc.configure(&tc)
@@ -586,7 +586,7 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			mockRegistry := namespace.NewMockRegistry(gomock.NewController(t))
 			mockRegistry.EXPECT().GetNamespace(namespace.Name("")).Return(&namespace.Namespace{}, nil).AnyTimes()
 			serviceResolver := membership.NewMockServiceResolver(gomock.NewController(t))
-			serviceResolver.EXPECT().MemberCount().Return(tc.frontendServiceCount).AnyTimes()
+			serviceResolver.EXPECT().AvailableMemberCount().Return(tc.frontendServiceCount).AnyTimes()
 
 			config := getTestConfig(tc)
 
@@ -754,7 +754,7 @@ func TestNamespaceRateLimitMetrics(t *testing.T) {
 			mockRegistry := namespace.NewMockRegistry(gomock.NewController(t))
 			mockRegistry.EXPECT().GetNamespace(namespace.Name(testNS)).Return(&namespace.Namespace{}, nil).AnyTimes()
 			serviceResolver := membership.NewMockServiceResolver(gomock.NewController(t))
-			serviceResolver.EXPECT().MemberCount().Return(tc.frontendServiceCount).AnyTimes()
+			serviceResolver.EXPECT().AvailableMemberCount().Return(tc.frontendServiceCount).AnyTimes()
 			metricsHandler := metricstest.NewCaptureHandler()
 			capture := metricsHandler.StartCapture()
 

--- a/service/fx.go
+++ b/service/fx.go
@@ -92,7 +92,7 @@ func initPersistenceLazyLoadedServiceResolver(
 	logger.Info("Initialized service resolver for persistence rate limiting", tag.Service(serviceName))
 }
 
-func (p PersistenceLazyLoadedServiceResolver) MemberCount() int {
+func (p PersistenceLazyLoadedServiceResolver) AvailableMemberCount() int {
 	if value := p.Load(); value != nil {
 		return value.(membership.ServiceResolver).AvailableMemberCount()
 	}

--- a/service/fx.go
+++ b/service/fx.go
@@ -94,7 +94,7 @@ func initPersistenceLazyLoadedServiceResolver(
 
 func (p PersistenceLazyLoadedServiceResolver) MemberCount() int {
 	if value := p.Load(); value != nil {
-		return value.(membership.ServiceResolver).MemberCount()
+		return value.(membership.ServiceResolver).AvailableMemberCount()
 	}
 	return 0
 }


### PR DESCRIPTION
## What changed?
Use `AvailableMemberCount` instead of  `MemberCount` when computing per-host rate limits.

## Why?
Frontend hosts that are draining shouldn't be counted for this purpose, otherwise we could overcount and set per-host rate limits too low.

## How did you test it?
existing tests, didn't test this specifically yet