### PR TITLE
Should disconnect stream when shard is closed

### DIFF
--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -78,7 +78,7 @@ func WrapEventLoop(
 		if err == nil { // shutdown case
 			return
 		}
-		// if it is stream error, we will not retry and terminate the stream, then let the stream_receiver_monitor to restart it
+
 		if streamError, ok := err.(*StreamError); ok {
 			metrics.ReplicationStreamError.With(metricsHandler).Record(
 				int64(1),
@@ -94,6 +94,7 @@ func WrapEventLoop(
 				metrics.ToClusterIDTag(toClusterKey.ClusterID),
 			)
 		}
+		// if it is not a retryable error, we will not retry and terminate the stream, then let the stream_receiver_monitor to restart it
 		if !IsRetryableError(err) {
 			return
 		}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Disconnect stream when shard is closed.
## Why?
<!-- Tell your future self why have you made these changes -->
When shard is closed, replication stream should not retry on that
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
n/a
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
Yes