### PR TITLE
fix task_writer data race

### DIFF
--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -94,6 +94,7 @@ func newTaskWriter(
 		maxReadLevel: noTaskIDs.start - 1,
 		logger:       backlogMgr.logger,
 		idAlloc:      backlogMgr.db,
+		writeLoop: goro.NewHandle(backlogMgr.contextInfoProvider(context.Background())),
 	}
 }
 
@@ -106,7 +107,6 @@ func (w *taskWriter) Start() {
 		return
 	}
 
-	w.writeLoop = goro.NewHandle(w.backlogMgr.contextInfoProvider(context.Background()))
 	w.writeLoop.Go(w.taskWriterLoop)
 }
 

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -94,7 +94,7 @@ func newTaskWriter(
 		maxReadLevel: noTaskIDs.start - 1,
 		logger:       backlogMgr.logger,
 		idAlloc:      backlogMgr.db,
-		writeLoop: goro.NewHandle(backlogMgr.contextInfoProvider(context.Background())),
+		writeLoop:    goro.NewHandle(backlogMgr.contextInfoProvider(context.Background())),
 	}
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Eliminate data race in task_writer that caused some functional tests to fail. I believe the race did not impact the functionality, only that the runtime was not happy with it.

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
