### PR TITLE
Make service ShardOwnerShipLost Error non retryable for replication stream

### DIFF
--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -34,7 +34,7 @@ import (
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/shard"
 )
 
 type (
@@ -109,8 +109,11 @@ func IsStreamError(err error) bool {
 }
 
 func IsRetryableError(err error) bool {
+	if shard.IsShardOwnershipLostError(err) {
+		return false
+	}
 	switch err.(type) {
-	case *StreamError, *persistence.ShardOwnershipLostError:
+	case *StreamError:
 		return false
 	default:
 		return true


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Make service ShardOwnerShipLost Error non retryable for replication stream
## Why?
<!-- Tell your future self why have you made these changes -->
To include both service/persistence ShardOwnerShip lost error
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
n/a
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
yes