### PR TITLE
Remove state machine task type from the outbound queue key type

### DIFF
--- a/service/history/queues/grouper_test.go
+++ b/service/history/queues/grouper_test.go
@@ -45,6 +45,40 @@ func TestGrouperNamespaceID_Predicate(t *testing.T) {
 	require.Equal(t, tasks.NewNamespacePredicate([]string{"n1", "n2"}), p)
 }
 
+func TestGrouperNamespaceIDAndDestination_Key(t *testing.T) {
+	g := GrouperNamespaceIDAndDestination{}
+	task := &tasks.StateMachineOutboundTask{
+		StateMachineTask: tasks.StateMachineTask{
+			WorkflowKey: definition.NewWorkflowKey("nid", "", ""),
+			Info: &persistence.StateMachineTaskInfo{
+				Type: 3,
+			},
+		},
+		Destination: "dest",
+	}
+	k := g.Key(task)
+	require.Equal(t, NamespaceIDAndDestination{"nid", "dest"}, k)
+}
+
+func TestGrouperNamespaceIDAndDestination_Predicate(t *testing.T) {
+	g := GrouperNamespaceIDAndDestination{}
+	p := g.Predicate([]any{
+		NamespaceIDAndDestination{"n1", "d1"},
+		NamespaceIDAndDestination{"n2", "d2"},
+	})
+	expected := predicates.Or(
+		predicates.And(
+			tasks.NewNamespacePredicate([]string{"n1"}),
+			tasks.NewDestinationPredicate([]string{"d1"}),
+		),
+		predicates.And(
+			tasks.NewNamespacePredicate([]string{"n2"}),
+			tasks.NewDestinationPredicate([]string{"d2"}),
+		),
+	)
+	require.Equal(t, expected, p)
+}
+
 func TestGrouperStateMachineNamespaceIDAndDestination_Key(t *testing.T) {
 	g := GrouperStateMachineNamespaceIDAndDestination{}
 	task := &tasks.StateMachineOutboundTask{


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Remove state machine task type from the outbound queue key type

## Why?
<!-- Tell your future self why have you made these changes -->
State machine task type is not being used, and dynamic configs don't have task type, so caching with state machine task type will result is unexpected results.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit tests for the grouper.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
