### PR TITLE
Fix: Don't cache buffered events in MutableStateImpl.AddHistoryEvent

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -809,7 +809,9 @@ func (ms *MutableStateImpl) GetNamespaceEntry() *namespace.Namespace {
 // The provided setAttributes function should be used to set the attributes on the event.
 func (ms *MutableStateImpl) AddHistoryEvent(t enumspb.EventType, setAttributes func(*history.HistoryEvent)) *history.HistoryEvent {
 	event := ms.hBuilder.AddHistoryEvent(t, setAttributes)
-	ms.writeEventToCache(event)
+	if event.EventId != common.BufferedEventID {
+		ms.writeEventToCache(event)
+	}
 	ms.currentTransactionAddedStateMachineEventTypes = append(ms.currentTransactionAddedStateMachineEventTypes, t)
 	return event
 }


### PR DESCRIPTION
I was seeing these warnings in logs and figured out that buffered events shouldn't be cached:

```
one or more ids is invalid in event cache	{"shard-id": 4, "address": "127.0.0.1:7231", "wf-id": "c98130b3-fa2a-45ce-bb59-99ad9319fd68", "wf-run-id": "dfe3b762-a12e-403f-950b-73fe8f37ae47", "wf-namespace-id": "d845a676-2988-47a3-aee8-f495e09ef65c", "wf-history-event-id": -123, "logging-call-at": "cache.go:124"}
```