### PR TITLE
Extract RespondWorkflowTaskFailedRequest handler

### DIFF
--- a/service/history/api/respondworkflowtaskfailed/api.go
+++ b/service/history/api/respondworkflowtaskfailed/api.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package respondworkflowtaskfailedrequest
+package respondworkflowtaskfailed
 
 import (
 	"context"

--- a/service/history/api/respondworkflowtaskfailedrequest/api.go
+++ b/service/history/api/respondworkflowtaskfailedrequest/api.go
@@ -1,0 +1,111 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package respondworkflowtaskfailedrequest
+
+import (
+	"context"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/service/history/api"
+	"go.temporal.io/server/service/history/consts"
+	"go.temporal.io/server/service/history/shard"
+)
+
+func Invoke(
+	ctx context.Context,
+	req *historyservice.RespondWorkflowTaskFailedRequest,
+	shardContext shard.Context,
+	tokenSerializer common.TaskTokenSerializer,
+	workflowConsistencyChecker api.WorkflowConsistencyChecker,
+) (retError error) {
+	_, err := api.GetActiveNamespace(shardContext, namespace.ID(req.GetNamespaceId()))
+	if err != nil {
+		return err
+	}
+
+	request := req.FailedRequest
+	token, err := tokenSerializer.Deserialize(request.TaskToken)
+	if err != nil {
+		return consts.ErrDeserializingToken
+	}
+
+	return api.GetAndUpdateWorkflowWithNew(
+		ctx,
+		token.Clock,
+		api.BypassMutableStateConsistencyPredicate,
+		definition.NewWorkflowKey(
+			token.NamespaceId,
+			token.WorkflowId,
+			token.RunId,
+		),
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
+			if !mutableState.IsWorkflowExecutionRunning() {
+				return nil, consts.ErrWorkflowCompleted
+			}
+
+			scheduledEventID := token.GetScheduledEventId()
+			workflowTask := mutableState.GetWorkflowTaskByID(scheduledEventID)
+
+			if workflowTask == nil ||
+				workflowTask.StartedEventID == common.EmptyEventID ||
+				(token.StartedEventId != common.EmptyEventID && token.StartedEventId != workflowTask.StartedEventID) ||
+				(token.StartedTime != nil && !workflowTask.StartedTime.IsZero() && !token.StartedTime.AsTime().Equal(workflowTask.StartedTime)) ||
+				workflowTask.Attempt != token.Attempt ||
+				(workflowTask.Version != common.EmptyVersion && token.Version != workflowTask.Version) {
+				// we have not alter mutable state yet, so release with it with nil to avoid clear MS.
+				workflowLease.GetReleaseFn()(nil)
+				return nil, serviceerror.NewNotFound("Workflow task not found.")
+			}
+
+			if _, err := mutableState.AddWorkflowTaskFailedEvent(
+				workflowTask,
+				request.GetCause(),
+				request.GetFailure(),
+				request.GetIdentity(),
+				request.GetWorkerVersion(),
+				request.GetBinaryChecksum(),
+				"",
+				"",
+				0); err != nil {
+				return nil, err
+			}
+
+			// TODO (alex-update): if it was speculative WT that failed, and there is nothing but pending updates,
+			//  new WT also should be create as speculative (or not?). Currently, it will be recreated as normal WT.
+			return &api.UpdateWorkflowAction{
+				Noop:               false,
+				CreateWorkflowTask: true,
+			}, nil
+		},
+		nil,
+		shardContext,
+		workflowConsistencyChecker,
+	)
+}

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	commonpb "go.temporal.io/api/common/v1"
 	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/server/service/history/api/respondworkflowtaskfailedrequest"
 
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
@@ -538,7 +539,7 @@ func (e *historyEngineImpl) RespondWorkflowTaskFailed(
 	ctx context.Context,
 	req *historyservice.RespondWorkflowTaskFailedRequest,
 ) error {
-	return e.workflowTaskHandler.handleWorkflowTaskFailed(ctx, req)
+	return respondworkflowtaskfailedrequest.Invoke(ctx, req, e.shardContext, e.tokenSerializer, e.workflowConsistencyChecker)
 }
 
 // RespondActivityTaskCompleted completes an activity task.

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -32,7 +32,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	commonpb "go.temporal.io/api/common/v1"
 	historypb "go.temporal.io/api/history/v1"
-	"go.temporal.io/server/service/history/api/respondworkflowtaskfailedrequest"
+	"go.temporal.io/server/service/history/api/respondworkflowtaskfailed"
 
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
@@ -539,7 +539,7 @@ func (e *historyEngineImpl) RespondWorkflowTaskFailed(
 	ctx context.Context,
 	req *historyservice.RespondWorkflowTaskFailedRequest,
 ) error {
-	return respondworkflowtaskfailedrequest.Invoke(ctx, req, e.shardContext, e.tokenSerializer, e.workflowConsistencyChecker)
+	return respondworkflowtaskfailed.Invoke(ctx, req, e.shardContext, e.tokenSerializer, e.workflowConsistencyChecker)
 }
 
 // RespondActivityTaskCompleted completes an activity task.

--- a/service/history/workflow_task_handler_callbacks.go
+++ b/service/history/workflow_task_handler_callbacks.go
@@ -78,8 +78,6 @@ type (
 		handleWorkflowTaskScheduled(context.Context, *historyservice.ScheduleWorkflowTaskRequest) error
 		handleWorkflowTaskStarted(context.Context,
 			*historyservice.RecordWorkflowTaskStartedRequest) (*historyservice.RecordWorkflowTaskStartedResponse, error)
-		handleWorkflowTaskFailed(context.Context,
-			*historyservice.RespondWorkflowTaskFailedRequest) error
 		handleWorkflowTaskCompleted(context.Context,
 			*historyservice.RespondWorkflowTaskCompletedRequest) (*historyservice.RespondWorkflowTaskCompletedResponse, error)
 		verifyFirstWorkflowTaskScheduled(context.Context, *historyservice.VerifyFirstWorkflowTaskScheduledRequest) error
@@ -315,77 +313,6 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 		return nil, err
 	}
 	return resp, nil
-}
-
-func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskFailed(
-	ctx context.Context,
-	req *historyservice.RespondWorkflowTaskFailedRequest,
-) (retError error) {
-
-	_, err := api.GetActiveNamespace(handler.shardContext, namespace.ID(req.GetNamespaceId()))
-	if err != nil {
-		return err
-	}
-
-	request := req.FailedRequest
-	token, err := handler.tokenSerializer.Deserialize(request.TaskToken)
-	if err != nil {
-		return consts.ErrDeserializingToken
-	}
-
-	return api.GetAndUpdateWorkflowWithNew(
-		ctx,
-		token.Clock,
-		api.BypassMutableStateConsistencyPredicate,
-		definition.NewWorkflowKey(
-			token.NamespaceId,
-			token.WorkflowId,
-			token.RunId,
-		),
-		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
-			mutableState := workflowLease.GetMutableState()
-			if !mutableState.IsWorkflowExecutionRunning() {
-				return nil, consts.ErrWorkflowCompleted
-			}
-
-			scheduledEventID := token.GetScheduledEventId()
-			workflowTask := mutableState.GetWorkflowTaskByID(scheduledEventID)
-
-			if workflowTask == nil ||
-				workflowTask.StartedEventID == common.EmptyEventID ||
-				(token.StartedEventId != common.EmptyEventID && token.StartedEventId != workflowTask.StartedEventID) ||
-				(token.StartedTime != nil && !workflowTask.StartedTime.IsZero() && !token.StartedTime.AsTime().Equal(workflowTask.StartedTime)) ||
-				workflowTask.Attempt != token.Attempt ||
-				(workflowTask.Version != common.EmptyVersion && token.Version != workflowTask.Version) {
-				// we have not alter mutable state yet, so release with it with nil to avoid clear MS.
-				workflowLease.GetReleaseFn()(nil)
-				return nil, serviceerror.NewNotFound("Workflow task not found.")
-			}
-
-			if _, err := mutableState.AddWorkflowTaskFailedEvent(
-				workflowTask,
-				request.GetCause(),
-				request.GetFailure(),
-				request.GetIdentity(),
-				request.GetWorkerVersion(),
-				request.GetBinaryChecksum(),
-				"",
-				"",
-				0); err != nil {
-				return nil, err
-			}
-
-			// TODO (alex-update): if it was speculative WT that failed, and there is nothing but pending updates,
-			//  new WT also should be create as speculative (or not?). Currently, it will be recreated as normal WT.
-			return &api.UpdateWorkflowAction{
-				Noop:               false,
-				CreateWorkflowTask: true,
-			}, nil
-		},
-		nil,
-		handler.shardContext,
-		handler.workflowConsistencyChecker,
-	)
 }
 
 func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Extracted handler for `RespondWorkflowTaskFailedRequest` out of `workflow_task_handler_callbacks.go` into its own file.

Remaining ones will be moved in follow-up PRs.

## Why?
<!-- Tell your future self why have you made these changes -->

There's no clear benefit to grouping the WFT API handlers all in the - poorly named - file. The PR makes this consistent with the existing API handlers now.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Pure refactoring, no behavior change.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
