### PR TITLE
Extract ScheduleWorkflowTask handler

### DIFF
--- a/service/history/api/scheduleworkflowtask/api.go
+++ b/service/history/api/scheduleworkflowtask/api.go
@@ -1,0 +1,85 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package scheduleworkflowtask
+
+import (
+	"context"
+
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/service/history/api"
+	"go.temporal.io/server/service/history/consts"
+	"go.temporal.io/server/service/history/shard"
+)
+
+func Invoke(
+	ctx context.Context,
+	req *historyservice.ScheduleWorkflowTaskRequest,
+	shardContext shard.Context,
+	workflowConsistencyChecker api.WorkflowConsistencyChecker,
+) error {
+
+	_, err := api.GetActiveNamespace(shardContext, namespace.ID(req.GetNamespaceId()))
+	if err != nil {
+		return err
+	}
+
+	return api.GetAndUpdateWorkflowWithNew(
+		ctx,
+		req.ChildClock,
+		api.BypassMutableStateConsistencyPredicate,
+		definition.NewWorkflowKey(
+			req.NamespaceId,
+			req.WorkflowExecution.WorkflowId,
+			req.WorkflowExecution.RunId,
+		),
+		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
+			mutableState := workflowLease.GetMutableState()
+			if !mutableState.IsWorkflowExecutionRunning() {
+				return nil, consts.ErrWorkflowCompleted
+			}
+
+			if req.IsFirstWorkflowTask && mutableState.HadOrHasWorkflowTask() {
+				return &api.UpdateWorkflowAction{
+					Noop: true,
+				}, nil
+			}
+
+			startEvent, err := mutableState.GetStartEvent(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if _, err := mutableState.AddFirstWorkflowTaskScheduled(req.ParentClock, startEvent, false); err != nil {
+				return nil, err
+			}
+
+			return &api.UpdateWorkflowAction{}, nil
+		},
+		nil,
+		shardContext,
+		workflowConsistencyChecker,
+	)
+}

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -33,6 +33,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/server/service/history/api/respondworkflowtaskfailed"
+	"go.temporal.io/server/service/history/api/scheduleworkflowtask"
 
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
@@ -508,7 +509,7 @@ func (e *historyEngineImpl) ScheduleWorkflowTask(
 	ctx context.Context,
 	req *historyservice.ScheduleWorkflowTaskRequest,
 ) error {
-	return e.workflowTaskHandler.handleWorkflowTaskScheduled(ctx, req)
+	return scheduleworkflowtask.Invoke(ctx, req, e.shardContext, e.workflowConsistencyChecker)
 }
 
 func (e *historyEngineImpl) VerifyFirstWorkflowTaskScheduled(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Extracted handler for `ScheduleWorkflowTask` out of `workflow_task_handler_callbacks.go` into its own file.

## Why?
<!-- Tell your future self why have you made these changes -->

There's no clear benefit to grouping the WFT API handlers all in the - poorly named - file. The PR makes this consistent with the existing API handlers now.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Pure refactoring, no behavior change.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
