### PR TITLE
Fix flaky MultiOperation test

### DIFF
--- a/tests/workflow.go
+++ b/tests/workflow.go
@@ -1031,7 +1031,6 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 	}
 
 	s.Run("StartWorkflow + UpdateWorkflow", func() {
-
 		runUpdateWithStart := func(
 			tv *testvars.TestVars,
 			startReq *workflowservice.StartWorkflowExecutionRequest,
@@ -1061,6 +1060,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 				s.NotZero(startRes.RunId)
 
 				updateRes := resp.Responses[1].Response.(*workflowservice.ExecuteMultiOperationResponse_Response_UpdateWorkflow).UpdateWorkflow
+				s.NotNil(updateRes.Outcome)
 				s.NotZero(updateRes.Outcome.String())
 			}
 
@@ -1114,7 +1114,9 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 			s.Run("workflow id reuse policy terminate-existing: terminate workflow first, then start and update", func() {
 				tv := testvars.New(s.T().Name())
 
-				runningWF, err := s.engine.StartWorkflowExecution(NewContext(), startWorkflowReq(tv))
+				initReq := startWorkflowReq(tv)
+				initReq.TaskQueue.Name = initReq.TaskQueue.Name + "-init" // avoid race condition with poller
+				initWF, err := s.engine.StartWorkflowExecution(NewContext(), initReq)
 				s.NoError(err)
 
 				req := startWorkflowReq(tv)
@@ -1126,7 +1128,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 				descResp, err := s.engine.DescribeWorkflowExecution(NewContext(),
 					&workflowservice.DescribeWorkflowExecutionRequest{
 						Namespace: s.namespace,
-						Execution: &commonpb.WorkflowExecution{WorkflowId: req.WorkflowId, RunId: runningWF.RunId},
+						Execution: &commonpb.WorkflowExecution{WorkflowId: req.WorkflowId, RunId: initWF.RunId},
 					})
 
 				s.NoError(err)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Fixing flakiness of MultiOperation test where workflow id conflict policy is "terminate".

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
