### PR TITLE
Delete unused retry implementations

### DIFF
--- a/common/backoff/retry.go
+++ b/common/backoff/retry.go
@@ -26,7 +26,6 @@ package backoff
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
@@ -54,62 +53,7 @@ type (
 
 	// IsRetryable handler can be used to exclude certain errors during retry
 	IsRetryable func(error) bool
-
-	// ConcurrentRetrier is used for client-side throttling. It determines whether to
-	// throttle outgoing traffic in case downstream backend server rejects
-	// requests due to out-of-quota or server busy errors.
-	ConcurrentRetrier struct {
-		sync.Mutex
-		retrier      Retrier // Backoff retrier
-		failureCount int64   // Number of consecutive failures seen
-	}
 )
-
-// Throttle Sleep if there were failures since the last success call.
-func (c *ConcurrentRetrier) Throttle() {
-	c.throttleInternal()
-}
-
-func (c *ConcurrentRetrier) throttleInternal() time.Duration {
-	next := done
-
-	// Check if we have failure count.
-	failureCount := c.failureCount
-	if failureCount > 0 {
-		defer c.Unlock()
-		c.Lock()
-		if c.failureCount > 0 {
-			next = c.retrier.NextBackOff()
-		}
-	}
-
-	if next != done {
-		time.Sleep(next)
-	}
-
-	return next
-}
-
-// Succeeded marks client request succeeded.
-func (c *ConcurrentRetrier) Succeeded() {
-	defer c.Unlock()
-	c.Lock()
-	c.failureCount = 0
-	c.retrier.Reset()
-}
-
-// Failed marks client request failed because backend is busy.
-func (c *ConcurrentRetrier) Failed() {
-	defer c.Unlock()
-	c.Lock()
-	c.failureCount++
-}
-
-// NewConcurrentRetrier returns an instance of concurrent backoff retrier.
-func NewConcurrentRetrier(retryPolicy RetryPolicy) *ConcurrentRetrier {
-	retrier := NewRetrier(retryPolicy, SystemClock)
-	return &ConcurrentRetrier{retrier: retrier}
-}
 
 // ThrottleRetry is a resource aware version of Retry.
 // Resource exhausted error will be retried using a different throttle retry policy, instead of the specified one.

--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -201,7 +201,7 @@ func (s *RetrySuite) TestThrottleRetryContext() {
 		return &someError{}
 	}
 
-	start := SystemClock.Now()
+	start := time.Now()
 	err := ThrottleRetryContext(context.Background(), op, policy, retryEverything)
 	s.Equal(&someError{}, err)
 	s.GreaterOrEqual(
@@ -211,7 +211,7 @@ func (s *RetrySuite) TestThrottleRetryContext() {
 	)
 
 	// test if context timeout is respected
-	start = SystemClock.Now()
+	start = time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	err = ThrottleRetryContext(ctx, func(_ context.Context) error { return &serviceerror.ResourceExhausted{} }, policy, retryEverything)
 	s.Equal(&serviceerror.ResourceExhausted{}, err)

--- a/common/backoff/retrypolicy.go
+++ b/common/backoff/retrypolicy.go
@@ -77,14 +77,6 @@ type (
 		maximumAttempts    int
 	}
 
-	// TwoPhaseRetryPolicy implements a policy that first use one policy to get next delay,
-	// and once expired use the second policy for the following retry.
-	// It can achieve fast retries in first phase then slowly retires in second phase.
-	TwoPhaseRetryPolicy struct {
-		firstPolicy  RetryPolicy
-		secondPolicy RetryPolicy
-	}
-
 	disabledRetryPolicyImpl struct{}
 
 	systemClock struct{}
@@ -201,15 +193,6 @@ func (p *ExponentialRetryPolicy) ComputeNextDelay(elapsedTime time.Duration, num
 	nextInterval = nextInterval*0.8 + float64(rand.Intn(jitterPortion))
 
 	return time.Duration(nextInterval)
-}
-
-// ComputeNextDelay returns the next delay interval.
-func (tp *TwoPhaseRetryPolicy) ComputeNextDelay(elapsedTime time.Duration, numAttempts int) time.Duration {
-	nextInterval := tp.firstPolicy.ComputeNextDelay(elapsedTime, numAttempts)
-	if nextInterval == done {
-		nextInterval = tp.secondPolicy.ComputeNextDelay(elapsedTime, numAttempts-defaultFirstPhaseMaximumAttempts)
-	}
-	return nextInterval
 }
 
 func (r *disabledRetryPolicyImpl) ComputeNextDelay(_ time.Duration, _ int) time.Duration {

--- a/common/backoff/retrypolicy.go
+++ b/common/backoff/retrypolicy.go
@@ -28,6 +28,8 @@ import (
 	"math"
 	"math/rand"
 	"time"
+
+	"go.temporal.io/server/common/clock"
 )
 
 const (
@@ -61,11 +63,6 @@ type (
 		Reset()
 	}
 
-	// Clock used by ExponentialRetryPolicy implementation to get the current time.  Mainly used for unit testing
-	Clock interface {
-		Now() time.Time
-	}
-
 	// ExponentialRetryPolicy provides the implementation for retry policy using a coefficient to compute the next delay.
 	// Formula used to compute the next delay is:
 	// 	min(initialInterval * pow(backoffCoefficient, currentAttempt), maximumInterval)
@@ -79,18 +76,13 @@ type (
 
 	disabledRetryPolicyImpl struct{}
 
-	systemClock struct{}
-
 	retrierImpl struct {
 		policy         RetryPolicy
-		clock          Clock
+		timeSource     clock.TimeSource
 		currentAttempt int
 		startTime      time.Time
 	}
 )
-
-// SystemClock implements Clock interface that uses time.Now().UTC().
-var SystemClock = systemClock{}
 
 // NewExponentialRetryPolicy returns an instance of ExponentialRetryPolicy using the provided initialInterval
 func NewExponentialRetryPolicy(initialInterval time.Duration) *ExponentialRetryPolicy {
@@ -106,11 +98,11 @@ func NewExponentialRetryPolicy(initialInterval time.Duration) *ExponentialRetryP
 }
 
 // NewRetrier is used for creating a new instance of Retrier
-func NewRetrier(policy RetryPolicy, clock Clock) Retrier {
+func NewRetrier(policy RetryPolicy, timeSource clock.TimeSource) Retrier {
 	return &retrierImpl{
 		policy:         policy,
-		clock:          clock,
-		startTime:      clock.Now(),
+		timeSource:     timeSource,
+		startTime:      timeSource.Now(),
 		currentAttempt: 1,
 	}
 }
@@ -199,14 +191,9 @@ func (r *disabledRetryPolicyImpl) ComputeNextDelay(_ time.Duration, _ int) time.
 	return done
 }
 
-// Now returns the current time using the system clock
-func (t systemClock) Now() time.Time {
-	return time.Now().UTC()
-}
-
 // Reset will set the Retrier into initial state
 func (r *retrierImpl) Reset() {
-	r.startTime = r.clock.Now()
+	r.startTime = r.timeSource.Now()
 	r.currentAttempt = 1
 }
 
@@ -220,5 +207,5 @@ func (r *retrierImpl) NextBackOff() time.Duration {
 }
 
 func (r *retrierImpl) getElapsedTime() time.Duration {
-	return r.clock.Now().Sub(r.startTime)
+	return r.timeSource.Now().Sub(r.startTime)
 }

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -234,7 +234,7 @@ func newQueueBase(
 		// pollTimer and checkpointTimer are initialized on Start()
 		checkpointRetrier: backoff.NewRetrier(
 			createCheckpointRetryPolicy(),
-			backoff.SystemClock,
+			clock.NewRealTimeSource(),
 		),
 
 		alertCh: monitor.AlertCh(),

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -156,7 +156,7 @@ func NewReader(
 
 		retrier: backoff.NewRetrier(
 			common.CreateReadTaskRetryPolicy(),
-			backoff.SystemClock,
+			clock.NewRealTimeSource(),
 		),
 
 		rateLimitContext:       rateLimitContext,

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -35,6 +35,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -70,7 +71,7 @@ func newTaskReader(backlogMgr *backlogManagerImpl) *taskReader {
 		taskBuffer: make(chan *persistencespb.AllocatedTaskInfo, backlogMgr.config.GetTasksBatchSize()-1),
 		retrier: backoff.NewRetrier(
 			common.CreateReadTaskRetryPolicy(),
-			backoff.SystemClock,
+			clock.NewRealTimeSource(),
 		),
 	}
 }

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	sdkclient "go.temporal.io/sdk/client"
 	sdkworker "go.temporal.io/sdk/worker"
+	"go.temporal.io/server/common/clock"
 	"go.uber.org/fx"
 	"golang.org/x/exp/maps"
 
@@ -260,7 +261,7 @@ func (wm *perNamespaceWorkerManager) getWorkerByNamespace(ns *namespace.Namespac
 	worker := &perNamespaceWorker{
 		wm:      wm,
 		logger:  log.With(wm.logger, tag.WorkflowNamespace(ns.Name().String())),
-		retrier: backoff.NewRetrier(backoff.NewExponentialRetryPolicy(wm.initialRetry), backoff.SystemClock),
+		retrier: backoff.NewRetrier(backoff.NewExponentialRetryPolicy(wm.initialRetry), clock.NewRealTimeSource()),
 		ns:      ns,
 	}
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

- `ConcurrentRetrier`: deleted, not used anywhere
- `TwoPhaseRetryPolicy`: deleted, not used anywhere
- `SystemClock`: replaced with `clock.TimeSource`

## Why?
<!-- Tell your future self why have you made these changes -->

Less code is good.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Compiler.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
