### PR TITLE
Specify Go compiler minor version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.temporal.io/server
 
-go 1.22
+go 1.22.3
 
 require (
 	cloud.google.com/go/storage v1.40.0


### PR DESCRIPTION
## What changed?
Specify minor version of Go compiler

## Why?
It's now required. See https://github.com/golang/go/issues/65568

## How did you test it?
`go mod tidy && make bins`

## Potential risks
None

## Is hotfix candidate?
No