### PR TITLE
Always use speculative workflow task for updates

### DIFF
--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -189,22 +189,6 @@ func (u *Updater) ApplyRequest(
 		}, nil
 	}
 
-	// Speculative WT can be created only if there are no events which worker has not yet seen,
-	// i.e. last event in the history is WTCompleted event.
-	// It is guaranteed that WTStarted event is followed by WTCompleted event and history tail might look like:
-	//   WTStarted
-	//   WTCompleted
-	//   --> NextEventID points here
-	// In this case difference between NextEventID and LastCompletedWorkflowTaskStartedEventId is 2.
-	// If there are other events after WTCompleted event, then difference is > 2 and speculative WT can't be created.
-	canCreateSpeculativeWT := ms.GetNextEventID() == ms.GetLastCompletedWorkflowTaskStartedEventId()+2
-	if !canCreateSpeculativeWT {
-		return &api.UpdateWorkflowAction{
-			Noop:               false,
-			CreateWorkflowTask: true,
-		}, nil
-	}
-
 	// This will try not to add an event but will create speculative WT in mutable state.
 	newWorkflowTask, err := ms.AddWorkflowTaskScheduledEvent(false, enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE)
 	if err != nil {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Always use speculative workflow task for updates.

## Why?
<!-- Tell your future self why have you made these changes -->
Always use speculative workflow task for updates and make decision on dropping it to `RespondWorkflowTaskCompleted` handler. In future, this will allow to introduce SDK capability to handle case when WFT can disappear even if it carried events to SDK. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
At first, I thought that there is minimal risk of WFT being scheduled and completed on different hosts during deployment, but even this minimal risk doesn't exist because speculative WFT stays only in the host memory and can't be scheduled and completed on different hosts. So "No risks".
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.