### PR TITLE
Reconnect to SQL databases when connections fail

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1186,6 +1186,8 @@ var (
 	VisibilityPersistenceLatency           = NewTimerDef("visibility_persistence_latency")
 	CassandraInitSessionLatency            = NewTimerDef("cassandra_init_session_latency")
 	CassandraSessionRefreshFailures        = NewCounterDef("cassandra_session_refresh_failures")
+	PersistenceSessionRefreshFailures      = NewCounterDef("persistence_session_refresh_failures")
+	PersistenceSessionRefreshAttempts      = NewCounterDef("persistence_session_refresh_attempts")
 
 	// Common service base metrics
 	RestartCount         = NewCounterDef("restarts")

--- a/common/persistence/client/fx.go
+++ b/common/persistence/client/fx.go
@@ -181,7 +181,7 @@ func DataStoreFactoryProvider(
 	case defaultStoreCfg.Cassandra != nil:
 		dataStoreFactory = cassandra.NewFactory(*defaultStoreCfg.Cassandra, r, string(clusterName), logger, metricsHandler)
 	case defaultStoreCfg.SQL != nil:
-		dataStoreFactory = sql.NewFactory(*defaultStoreCfg.SQL, r, string(clusterName), logger)
+		dataStoreFactory = sql.NewFactory(*defaultStoreCfg.SQL, r, string(clusterName), logger, metricsHandler)
 	case defaultStoreCfg.CustomDataStoreConfig != nil:
 		dataStoreFactory = abstractDataStoreFactory.NewFactory(*defaultStoreCfg.CustomDataStoreConfig, r, string(clusterName), logger, metricsHandler)
 	default:

--- a/common/persistence/sql/factory.go
+++ b/common/persistence/sql/factory.go
@@ -30,6 +30,7 @@ import (
 
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/resolver"
@@ -51,6 +52,8 @@ type (
 		dbKind   sqlplugin.DbKind
 		cfg      *config.SQL
 		resolver resolver.ServiceResolver
+		logger   log.Logger
+		metrics  metrics.Handler
 
 		sqlplugin.DB
 
@@ -66,12 +69,13 @@ func NewFactory(
 	r resolver.ServiceResolver,
 	clusterName string,
 	logger log.Logger,
+	metricsHandler metrics.Handler,
 ) *Factory {
 	return &Factory{
 		cfg:         cfg,
 		clusterName: clusterName,
 		logger:      logger,
-		mainDBConn:  NewRefCountedDBConn(sqlplugin.DbKindMain, &cfg, r),
+		mainDBConn:  NewRefCountedDBConn(sqlplugin.DbKindMain, &cfg, r, logger, metricsHandler),
 	}
 }
 
@@ -170,11 +174,15 @@ func NewRefCountedDBConn(
 	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
 ) DbConn {
 	return DbConn{
 		dbKind:   dbKind,
 		cfg:      cfg,
 		resolver: r,
+		metrics:  metricsHandler,
+		logger:   logger,
 	}
 }
 
@@ -185,7 +193,7 @@ func (c *DbConn) Get() (sqlplugin.DB, error) {
 	c.Lock()
 	defer c.Unlock()
 	if c.refCnt == 0 {
-		conn, err := NewSQLDB(c.dbKind, c.cfg, c.resolver)
+		conn, err := NewSQLDB(c.dbKind, c.cfg, c.resolver, c.logger, c.metrics)
 		if err != nil {
 			return nil, err
 		}

--- a/common/persistence/sql/sqlplugin/db_handle.go
+++ b/common/persistence/sql/sqlplugin/db_handle.go
@@ -43,8 +43,8 @@ import (
 )
 
 const (
-	// TODO: this should be dynamic config. For now we reuse the same setting as our cassandra implementation
-	sessionRefreshMinInternal = 5 * time.Second
+	// TODO: this should be dynamic config.
+	sessionRefreshMinInternal = 1 * time.Second
 )
 
 var (

--- a/common/persistence/sql/sqlplugin/db_handle.go
+++ b/common/persistence/sql/sqlplugin/db_handle.go
@@ -1,3 +1,25 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package sqlplugin
 
 import (
@@ -39,12 +61,12 @@ func NewDatabaseHandle(
 	connect func() (*sqlx.DB, error),
 	needsRefresh func(error) bool,
 	logger log.Logger,
-	metrics metrics.Handler,
+	metricsHandler metrics.Handler,
 ) *DatabaseHandle {
 	handle := &DatabaseHandle{
 		connect:      connect,
 		needsRefresh: needsRefresh,
-		metrics:      metrics,
+		metrics:      metricsHandler,
 		logger:       logger,
 	}
 	handle.running.Store(true)

--- a/common/persistence/sql/sqlplugin/db_handle.go
+++ b/common/persistence/sql/sqlplugin/db_handle.go
@@ -64,7 +64,7 @@ type DatabaseHandle struct {
 	sync.Mutex
 }
 
-// An invalid connection returns `databaseUnavailable` for all operations
+// An invalid connection returns `DatabaseUnavailableError` for all operations
 type invalidConn struct{}
 
 func NewDatabaseHandle(

--- a/common/persistence/sql/sqlplugin/db_handle.go
+++ b/common/persistence/sql/sqlplugin/db_handle.go
@@ -1,0 +1,114 @@
+package sqlplugin
+
+import (
+	"database/sql/driver"
+	"errors"
+	"io"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	uberatomic "go.uber.org/atomic"
+
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+)
+
+const (
+	sessionRefreshMinInternal = 5 * time.Second
+)
+
+type DatabaseHandle struct {
+	running      atomic.Bool
+	db           uberatomic.Pointer[sqlx.DB]
+	connect      func() (*sqlx.DB, error)
+	needsRefresh func(error) bool
+
+	lastRefresh time.Time
+	metrics     metrics.Handler
+	logger      log.Logger
+	// Ensures only one refresh call happens at a time
+	sync.Mutex
+}
+
+func NewDatabaseHandle(
+	connect func() (*sqlx.DB, error),
+	needsRefresh func(error) bool,
+	logger log.Logger,
+	metrics metrics.Handler,
+) *DatabaseHandle {
+	handle := &DatabaseHandle{
+		connect:      connect,
+		needsRefresh: needsRefresh,
+		metrics:      metrics,
+		logger:       logger,
+	}
+	handle.running.Store(true)
+	handle.reconnect()
+	return handle
+}
+
+// Close and reopen the underlying database connection
+func (h *DatabaseHandle) reconnect() {
+	if !h.running.Load() {
+		return
+	}
+
+	h.Lock()
+	defer h.Unlock()
+
+	metrics.PersistenceSessionRefreshAttempts.With(h.metrics).Record(1)
+
+	if time.Now().UTC().Sub(h.lastRefresh) < sessionRefreshMinInternal {
+		h.logger.Warn("sql handle: did not refresh database connection pool because the last refresh was too close",
+			tag.NewDurationTag("min_refresh_interval_seconds", sessionRefreshMinInternal))
+		handler := h.metrics.WithTags(metrics.FailureTag("throttle"))
+		metrics.PersistenceSessionRefreshFailures.With(handler).Record(1)
+		return
+	}
+
+	newConn, err := h.connect()
+	if err != nil {
+		h.logger.Error("sql handle: unable to refresh database connection pool", tag.Error(err))
+		handler := h.metrics.WithTags(metrics.FailureTag("error"))
+		metrics.PersistenceSessionRefreshFailures.With(handler).Record(1)
+		return
+	}
+
+	h.lastRefresh = time.Now().UTC()
+	prevConn := h.db.Swap(newConn)
+	if prevConn != nil {
+		go prevConn.Close()
+	}
+}
+
+func (h *DatabaseHandle) Close() {
+	// Already stopped
+	if !h.running.Swap(true) {
+		return
+	}
+	h.db.Load().Close()
+}
+
+func (h *DatabaseHandle) DB() *sqlx.DB {
+	return h.db.Load()
+}
+
+func (h *DatabaseHandle) Conn() Conn {
+	return h.db.Load()
+}
+
+func (h *DatabaseHandle) HandleError(err error) {
+	if h.needsRefresh(err) ||
+		errors.Is(err, driver.ErrBadConn) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNABORTED) ||
+		errors.Is(err, syscall.ECONNREFUSED) {
+		h.reconnect()
+	}
+}

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -31,6 +31,8 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/resolver"
 )
 
@@ -53,8 +55,8 @@ type VersionedBlob struct {
 type (
 	// Plugin defines the interface for any SQL database that needs to implement
 	Plugin interface {
-		CreateDB(dbKind DbKind, cfg *config.SQL, r resolver.ServiceResolver) (DB, error)
-		CreateAdminDB(dbKind DbKind, cfg *config.SQL, r resolver.ServiceResolver) (AdminDB, error)
+		CreateDB(dbKind DbKind, cfg *config.SQL, r resolver.ServiceResolver, l log.Logger, mh metrics.Handler) (DB, error)
+		CreateAdminDB(dbKind DbKind, cfg *config.SQL, r resolver.ServiceResolver, l log.Logger, mh metrics.Handler) (AdminDB, error)
 	}
 
 	// TableCRUD defines the API for interacting with the database tables

--- a/common/persistence/sql/sqlplugin/mysql/admin.go
+++ b/common/persistence/sql/sqlplugin/mysql/admin.go
@@ -79,8 +79,7 @@ func (mdb *db) CreateSchemaVersionTables() error {
 func (mdb *db) ReadSchemaVersion(database string) (string, error) {
 	var version string
 	err := mdb.handle.DB().Get(&version, readSchemaVersionQuery, database)
-	mdb.handle.HandleError(err)
-	return version, err
+	return version, mdb.handle.ConvertError(err)
 }
 
 // UpdateSchemaVersion updates the schema version for the keyspace
@@ -97,16 +96,14 @@ func (mdb *db) WriteSchemaUpdateLog(oldVersion string, newVersion string, manife
 // Exec executes a sql statement
 func (mdb *db) Exec(stmt string, args ...interface{}) error {
 	_, err := mdb.handle.DB().Exec(stmt, args...)
-	mdb.handle.HandleError(err)
-	return err
+	return mdb.handle.ConvertError(err)
 }
 
 // ListTables returns a list of tables in this database
 func (mdb *db) ListTables(database string) ([]string, error) {
 	var tables []string
 	err := mdb.handle.DB().Select(&tables, fmt.Sprintf(listTablesQuery, database))
-	mdb.handle.HandleError(err)
-	return tables, err
+	return tables, mdb.handle.ConvertError(err)
 }
 
 // DropTable drops a given table from the database

--- a/common/persistence/sql/sqlplugin/mysql/admin.go
+++ b/common/persistence/sql/sqlplugin/mysql/admin.go
@@ -78,7 +78,8 @@ func (mdb *db) CreateSchemaVersionTables() error {
 // ReadSchemaVersion returns the current schema version for the keyspace
 func (mdb *db) ReadSchemaVersion(database string) (string, error) {
 	var version string
-	err := mdb.db.Get(&version, readSchemaVersionQuery, database)
+	err := mdb.handle.DB().Get(&version, readSchemaVersionQuery, database)
+	mdb.handle.HandleError(err)
 	return version, err
 }
 
@@ -95,14 +96,16 @@ func (mdb *db) WriteSchemaUpdateLog(oldVersion string, newVersion string, manife
 
 // Exec executes a sql statement
 func (mdb *db) Exec(stmt string, args ...interface{}) error {
-	_, err := mdb.db.Exec(stmt, args...)
+	_, err := mdb.handle.DB().Exec(stmt, args...)
+	mdb.handle.HandleError(err)
 	return err
 }
 
 // ListTables returns a list of tables in this database
 func (mdb *db) ListTables(database string) ([]string, error) {
 	var tables []string
-	err := mdb.db.Select(&tables, fmt.Sprintf(listTablesQuery, database))
+	err := mdb.handle.DB().Select(&tables, fmt.Sprintf(listTablesQuery, database))
+	mdb.handle.HandleError(err)
 	return tables, err
 }
 

--- a/common/persistence/sql/sqlplugin/mysql/admin.go
+++ b/common/persistence/sql/sqlplugin/mysql/admin.go
@@ -78,7 +78,11 @@ func (mdb *db) CreateSchemaVersionTables() error {
 // ReadSchemaVersion returns the current schema version for the keyspace
 func (mdb *db) ReadSchemaVersion(database string) (string, error) {
 	var version string
-	err := mdb.handle.DB().Get(&version, readSchemaVersionQuery, database)
+	db, err := mdb.handle.DB()
+	if err != nil {
+		return "", err
+	}
+	err = db.Get(&version, readSchemaVersionQuery, database)
 	return version, mdb.handle.ConvertError(err)
 }
 
@@ -95,14 +99,22 @@ func (mdb *db) WriteSchemaUpdateLog(oldVersion string, newVersion string, manife
 
 // Exec executes a sql statement
 func (mdb *db) Exec(stmt string, args ...interface{}) error {
-	_, err := mdb.handle.DB().Exec(stmt, args...)
+	db, err := mdb.handle.DB()
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(stmt, args...)
 	return mdb.handle.ConvertError(err)
 }
 
 // ListTables returns a list of tables in this database
 func (mdb *db) ListTables(database string) ([]string, error) {
 	var tables []string
-	err := mdb.handle.DB().Select(&tables, fmt.Sprintf(listTablesQuery, database))
+	db, err := mdb.handle.DB()
+	if err != nil {
+		return nil, err
+	}
+	err = db.Select(&tables, fmt.Sprintf(listTablesQuery, database))
 	return tables, mdb.handle.ConvertError(err)
 }
 

--- a/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
@@ -83,7 +83,7 @@ func (mdb *db) SaveClusterMetadata(
 	row *sqlplugin.ClusterMetadataRow,
 ) (sql.Result, error) {
 	if row.Version == 0 {
-		return mdb.conn.ExecContext(ctx,
+		return mdb.ExecContext(ctx,
 			insertClusterMetadataQry,
 			constMetadataPartition,
 			row.ClusterName,
@@ -92,7 +92,7 @@ func (mdb *db) SaveClusterMetadata(
 			1,
 		)
 	}
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		updateClusterMetadataQry,
 		row.Data,
 		row.DataEncoding,
@@ -110,7 +110,7 @@ func (mdb *db) ListClusterMetadata(
 	var rows []sqlplugin.ClusterMetadataRow
 	switch {
 	case len(filter.ClusterName) != 0:
-		err = mdb.conn.SelectContext(ctx,
+		err = mdb.SelectContext(ctx,
 			&rows,
 			listClusterMetadataRangeQry,
 			constMetadataPartition,
@@ -118,7 +118,7 @@ func (mdb *db) ListClusterMetadata(
 			filter.PageSize,
 		)
 	default:
-		err = mdb.conn.SelectContext(ctx,
+		err = mdb.SelectContext(ctx,
 			&rows,
 			listClusterMetadataQry,
 			constMetadataPartition,
@@ -133,7 +133,7 @@ func (mdb *db) GetClusterMetadata(
 	filter *sqlplugin.ClusterMetadataFilter,
 ) (*sqlplugin.ClusterMetadataRow, error) {
 	var row sqlplugin.ClusterMetadataRow
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&row,
 		getClusterMetadataQry,
 		constMetadataPartition,
@@ -150,7 +150,7 @@ func (mdb *db) DeleteClusterMetadata(
 	filter *sqlplugin.ClusterMetadataFilter,
 ) (sql.Result, error) {
 
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteClusterMetadataQry,
 		constMetadataPartition,
 		filter.ClusterName,
@@ -162,7 +162,7 @@ func (mdb *db) WriteLockGetClusterMetadata(
 	filter *sqlplugin.ClusterMetadataFilter,
 ) (*sqlplugin.ClusterMetadataRow, error) {
 	var row sqlplugin.ClusterMetadataRow
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&row,
 		writeLockGetClusterMetadataQry,
 		constMetadataPartition,
@@ -178,7 +178,7 @@ func (mdb *db) UpsertClusterMembership(
 	ctx context.Context,
 	row *sqlplugin.ClusterMembershipRow,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		templateUpsertActiveClusterMembership,
 		constMembershipPartition,
 		row.HostID,
@@ -244,7 +244,7 @@ func (mdb *db) GetClusterMembers(
 	compiledQryString := queryString.String()
 
 	var rows []sqlplugin.ClusterMembershipRow
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows,
 		compiledQryString,
 		operands...,
@@ -263,7 +263,7 @@ func (mdb *db) PruneClusterMembership(
 	ctx context.Context,
 	filter *sqlplugin.PruneClusterMembershipFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		templatePruneStaleClusterMembership,
 		constMembershipPartition,
 		mdb.converter.ToMySQLDateTime(filter.PruneRecordsBefore),

--- a/common/persistence/sql/sqlplugin/mysql/db.go
+++ b/common/persistence/sql/sqlplugin/mysql/db.go
@@ -26,6 +26,7 @@ package mysql
 
 import (
 	"context"
+	"database/sql"
 	"database/sql/driver"
 	"errors"
 	"fmt"
@@ -38,14 +39,27 @@ import (
 	mysqlschemaV8 "go.temporal.io/server/schema/mysql/v8"
 )
 
+// MySQL error codes
+const (
+	// ErrDupEntryCode MySQL Error 1062 indicates a duplicate primary key i.e. the row already exists,
+	// so we don't do the insert and return a ConditionalUpdate error.
+	ErrDupEntryCode = 1062
+
+	// Cannot execute statement in a READ ONLY transaction.
+	readOnlyTransactionCode = 1792
+	// Too many connections open
+	tooManyConnectionsCode = 1040
+	// Running in read-only mode
+	readOnlyModeCode = 1836
+)
+
 // db represents a logical connection to mysql database
 type db struct {
 	dbKind sqlplugin.DbKind
 	dbName string
 
-	db        *sqlx.DB
+	handle    *sqlplugin.DatabaseHandle
 	tx        *sqlx.Tx
-	conn      sqlplugin.Conn
 	converter DataConverter
 }
 
@@ -53,9 +67,13 @@ var _ sqlplugin.AdminDB = (*db)(nil)
 var _ sqlplugin.DB = (*db)(nil)
 var _ sqlplugin.Tx = (*db)(nil)
 
-// ErrDupEntryCode MySQL Error 1062 indicates a duplicate primary key i.e. the row already exists,
-// so we don't do the insert and return a ConditionalUpdate error.
-const ErrDupEntryCode = 1062
+func isConnNeedsRefreshError(err error) bool {
+	myErr, ok := err.(*mysql.MySQLError)
+	if !ok {
+		return false
+	}
+	return myErr.Number == readOnlyModeCode || myErr.Number == readOnlyTransactionCode || myErr.Number == tooManyConnectionsCode
+}
 
 func (mdb *db) IsDupEntryError(err error) bool {
 	sqlErr, ok := err.(*mysql.MySQLError)
@@ -72,30 +90,34 @@ func (mdb *db) isConnNeedsRefreshError(err error) bool {
 func newDB(
 	dbKind sqlplugin.DbKind,
 	dbName string,
-	xdb *sqlx.DB,
+	handle *sqlplugin.DatabaseHandle,
 	tx *sqlx.Tx,
 ) *db {
 	mdb := &db{
 		dbKind: dbKind,
 		dbName: dbName,
-		db:     xdb,
+		handle: handle,
 		tx:     tx,
-	}
-	mdb.conn = xdb
-	if tx != nil {
-		mdb.conn = tx
 	}
 	mdb.converter = &converter{}
 	return mdb
 }
 
+func (mdb *db) conn() sqlplugin.Conn {
+	if mdb.tx != nil {
+		return mdb.tx
+	}
+	return mdb.handle.Conn()
+}
+
 // BeginTx starts a new transaction and returns a reference to the Tx object
 func (mdb *db) BeginTx(ctx context.Context) (sqlplugin.Tx, error) {
-	xtx, err := mdb.db.BeginTxx(ctx, nil)
+	xtx, err := mdb.handle.DB().BeginTxx(ctx, nil)
 	if err != nil {
+		mdb.handle.HandleError(err)
 		return nil, err
 	}
-	return newDB(mdb.dbKind, mdb.dbName, mdb.db, xtx), nil
+	return newDB(mdb.dbKind, mdb.dbName, mdb.handle, xtx), nil
 }
 
 // Commit commits a previously started transaction
@@ -114,7 +136,8 @@ func (mdb *db) Refresh() error {
 
 // Close closes the connection to the mysql db
 func (mdb *db) Close() error {
-	return mdb.db.Close()
+	mdb.handle.Close()
+	return nil
 }
 
 // PluginName returns the name of the mysql plugin
@@ -143,4 +166,49 @@ func (mdb *db) ExpectedVersion() string {
 func (mdb *db) VerifyVersion() error {
 	expectedVersion := mdb.ExpectedVersion()
 	return schema.VerifyCompatibleVersion(mdb, mdb.dbName, expectedVersion)
+}
+
+// Helper methods to hide common error handling
+func (mdb *db) ExecContext(ctx context.Context, stmt string, args ...any) (sql.Result, error) {
+	res, err := mdb.conn().ExecContext(ctx, stmt, args...)
+	if err != nil {
+		mdb.handle.HandleError(err)
+	}
+	return res, err
+}
+
+func (mdb *db) GetContext(ctx context.Context, dest any, query string, args ...any) error {
+	err := mdb.conn().GetContext(ctx, dest, query, args...)
+	if err != nil {
+		mdb.handle.HandleError(err)
+	}
+	return err
+}
+
+func (mdb *db) SelectContext(ctx context.Context, dest any, query string, args ...any) error {
+	err := mdb.conn().SelectContext(ctx, dest, query, args...)
+	if err != nil {
+		mdb.handle.HandleError(err)
+	}
+	return err
+}
+
+func (mdb *db) NamedExecContext(ctx context.Context, query string, arg any) (sql.Result, error) {
+	res, err := mdb.conn().NamedExecContext(ctx, query, arg)
+	if err != nil {
+		mdb.handle.HandleError(err)
+	}
+	return res, err
+}
+
+func (mdb *db) PrepareNamedContext(ctx context.Context, query string) (*sqlx.NamedStmt, error) {
+	stmt, err := mdb.conn().PrepareNamedContext(ctx, query)
+	if err != nil {
+		mdb.handle.HandleError(err)
+	}
+	return stmt, err
+}
+
+func (mdb *db) Rebind(query string) string {
+	return mdb.conn().Rebind(query)
 }

--- a/common/persistence/sql/sqlplugin/mysql/db.go
+++ b/common/persistence/sql/sqlplugin/mysql/db.go
@@ -114,8 +114,7 @@ func (mdb *db) conn() sqlplugin.Conn {
 func (mdb *db) BeginTx(ctx context.Context) (sqlplugin.Tx, error) {
 	xtx, err := mdb.handle.DB().BeginTxx(ctx, nil)
 	if err != nil {
-		mdb.handle.HandleError(err)
-		return nil, err
+		return nil, mdb.handle.ConvertError(err)
 	}
 	return newDB(mdb.dbKind, mdb.dbName, mdb.handle, xtx), nil
 }
@@ -171,42 +170,27 @@ func (mdb *db) VerifyVersion() error {
 // Helper methods to hide common error handling
 func (mdb *db) ExecContext(ctx context.Context, stmt string, args ...any) (sql.Result, error) {
 	res, err := mdb.conn().ExecContext(ctx, stmt, args...)
-	if err != nil {
-		mdb.handle.HandleError(err)
-	}
-	return res, err
+	return res, mdb.handle.ConvertError(err)
 }
 
 func (mdb *db) GetContext(ctx context.Context, dest any, query string, args ...any) error {
 	err := mdb.conn().GetContext(ctx, dest, query, args...)
-	if err != nil {
-		mdb.handle.HandleError(err)
-	}
-	return err
+	return mdb.handle.ConvertError(err)
 }
 
 func (mdb *db) SelectContext(ctx context.Context, dest any, query string, args ...any) error {
 	err := mdb.conn().SelectContext(ctx, dest, query, args...)
-	if err != nil {
-		mdb.handle.HandleError(err)
-	}
-	return err
+	return mdb.handle.ConvertError(err)
 }
 
 func (mdb *db) NamedExecContext(ctx context.Context, query string, arg any) (sql.Result, error) {
 	res, err := mdb.conn().NamedExecContext(ctx, query, arg)
-	if err != nil {
-		mdb.handle.HandleError(err)
-	}
-	return res, err
+	return res, mdb.handle.ConvertError(err)
 }
 
 func (mdb *db) PrepareNamedContext(ctx context.Context, query string) (*sqlx.NamedStmt, error) {
 	stmt, err := mdb.conn().PrepareNamedContext(ctx, query)
-	if err != nil {
-		mdb.handle.HandleError(err)
-	}
-	return stmt, err
+	return stmt, mdb.handle.ConvertError(err)
 }
 
 func (mdb *db) Rebind(query string) string {

--- a/common/persistence/sql/sqlplugin/mysql/db.go
+++ b/common/persistence/sql/sqlplugin/mysql/db.go
@@ -27,8 +27,6 @@ package mysql
 import (
 	"context"
 	"database/sql"
-	"database/sql/driver"
-	"errors"
 	"fmt"
 
 	"github.com/go-sql-driver/mysql"
@@ -80,11 +78,6 @@ func (mdb *db) IsDupEntryError(err error) bool {
 	return ok && sqlErr.Number == ErrDupEntryCode
 }
 
-// Time to reset
-func (mdb *db) isConnNeedsRefreshError(err error) bool {
-	return errors.Is(err, driver.ErrBadConn)
-}
-
 // newDB returns an instance of DB, which is a logical
 // connection to the underlying mysql database
 func newDB(
@@ -131,10 +124,6 @@ func (mdb *db) Commit() error {
 // Rollback triggers rollback of a previously started transaction
 func (mdb *db) Rollback() error {
 	return mdb.tx.Rollback()
-}
-
-func (mdb *db) Refresh() error {
-	panic("unimplemented")
 }
 
 // Close closes the connection to the mysql db

--- a/common/persistence/sql/sqlplugin/mysql/db.go
+++ b/common/persistence/sql/sqlplugin/mysql/db.go
@@ -112,7 +112,11 @@ func (mdb *db) conn() sqlplugin.Conn {
 
 // BeginTx starts a new transaction and returns a reference to the Tx object
 func (mdb *db) BeginTx(ctx context.Context) (sqlplugin.Tx, error) {
-	xtx, err := mdb.handle.DB().BeginTxx(ctx, nil)
+	db, err := mdb.handle.DB()
+	if err != nil {
+		return nil, err
+	}
+	xtx, err := db.BeginTxx(ctx, nil)
 	if err != nil {
 		return nil, mdb.handle.ConvertError(err)
 	}

--- a/common/persistence/sql/sqlplugin/mysql/db.go
+++ b/common/persistence/sql/sqlplugin/mysql/db.go
@@ -26,6 +26,8 @@ package mysql
 
 import (
 	"context"
+	"database/sql/driver"
+	"errors"
 	"fmt"
 
 	"github.com/go-sql-driver/mysql"
@@ -58,6 +60,11 @@ const ErrDupEntryCode = 1062
 func (mdb *db) IsDupEntryError(err error) bool {
 	sqlErr, ok := err.(*mysql.MySQLError)
 	return ok && sqlErr.Number == ErrDupEntryCode
+}
+
+// Time to reset
+func (mdb *db) isConnNeedsRefreshError(err error) bool {
+	return errors.Is(err, driver.ErrBadConn)
 }
 
 // newDB returns an instance of DB, which is a logical
@@ -99,6 +106,10 @@ func (mdb *db) Commit() error {
 // Rollback triggers rollback of a previously started transaction
 func (mdb *db) Rollback() error {
 	return mdb.tx.Rollback()
+}
+
+func (mdb *db) Refresh() error {
+	panic("unimplemented")
 }
 
 // Close closes the connection to the mysql db

--- a/common/persistence/sql/sqlplugin/mysql/events.go
+++ b/common/persistence/sql/sqlplugin/mysql/events.go
@@ -82,7 +82,7 @@ func (mdb *db) InsertIntoHistoryNode(
 ) (sql.Result, error) {
 	// NOTE: txn_id is *= -1 within DB
 	row.TxnID = -row.TxnID
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		addHistoryNodesQuery,
 		row,
 	)
@@ -95,7 +95,7 @@ func (mdb *db) DeleteFromHistoryNode(
 ) (sql.Result, error) {
 	// NOTE: txn_id is *= -1 within DB
 	row.TxnID = -row.TxnID
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteHistoryNodeQuery,
 		row.ShardID,
 		row.TreeID,
@@ -145,7 +145,7 @@ func (mdb *db) RangeSelectFromHistoryNode(
 	}
 
 	var rows []sqlplugin.HistoryNodeRow
-	if err := mdb.conn.SelectContext(ctx, &rows, query, args...); err != nil {
+	if err := mdb.SelectContext(ctx, &rows, query, args...); err != nil {
 		return nil, err
 	}
 
@@ -161,7 +161,7 @@ func (mdb *db) RangeDeleteFromHistoryNode(
 	ctx context.Context,
 	filter sqlplugin.HistoryNodeDeleteFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteHistoryNodesQuery,
 		filter.ShardID,
 		filter.TreeID,
@@ -177,7 +177,7 @@ func (mdb *db) InsertIntoHistoryTree(
 	ctx context.Context,
 	row *sqlplugin.HistoryTreeRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		addHistoryTreeQuery,
 		row,
 	)
@@ -189,7 +189,7 @@ func (mdb *db) SelectFromHistoryTree(
 	filter sqlplugin.HistoryTreeSelectFilter,
 ) ([]sqlplugin.HistoryTreeRow, error) {
 	var rows []sqlplugin.HistoryTreeRow
-	err := mdb.conn.SelectContext(ctx,
+	err := mdb.SelectContext(ctx,
 		&rows,
 		getHistoryTreeQuery,
 		filter.ShardID,
@@ -205,7 +205,7 @@ func (mdb *db) PaginateBranchesFromHistoryTree(
 	page sqlplugin.HistoryTreeBranchPage,
 ) ([]sqlplugin.HistoryTreeRow, error) {
 	var rows []sqlplugin.HistoryTreeRow
-	err := mdb.conn.SelectContext(
+	err := mdb.SelectContext(
 		ctx,
 		&rows,
 		paginateBranchesQuery,
@@ -224,7 +224,7 @@ func (mdb *db) DeleteFromHistoryTree(
 	ctx context.Context,
 	filter sqlplugin.HistoryTreeDeleteFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteHistoryTreeQuery,
 		filter.ShardID,
 		filter.TreeID,

--- a/common/persistence/sql/sqlplugin/mysql/execution.go
+++ b/common/persistence/sql/sqlplugin/mysql/execution.go
@@ -191,7 +191,7 @@ func (mdb *db) InsertIntoExecutions(
 	ctx context.Context,
 	row *sqlplugin.ExecutionsRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		createExecutionQuery,
 		row,
 	)
@@ -202,7 +202,7 @@ func (mdb *db) UpdateExecutions(
 	ctx context.Context,
 	row *sqlplugin.ExecutionsRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		updateExecutionQuery,
 		row,
 	)
@@ -214,7 +214,7 @@ func (mdb *db) SelectFromExecutions(
 	filter sqlplugin.ExecutionsFilter,
 ) (*sqlplugin.ExecutionsRow, error) {
 	var row sqlplugin.ExecutionsRow
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&row, getExecutionQuery,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -232,7 +232,7 @@ func (mdb *db) DeleteFromExecutions(
 	ctx context.Context,
 	filter sqlplugin.ExecutionsFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteExecutionQuery,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -247,7 +247,7 @@ func (mdb *db) ReadLockExecutions(
 	filter sqlplugin.ExecutionsFilter,
 ) (int64, int64, error) {
 	var executionVersion sqlplugin.ExecutionVersion
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&executionVersion,
 		readLockExecutionQuery,
 		filter.ShardID,
@@ -264,7 +264,7 @@ func (mdb *db) WriteLockExecutions(
 	filter sqlplugin.ExecutionsFilter,
 ) (int64, int64, error) {
 	var executionVersion sqlplugin.ExecutionVersion
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&executionVersion,
 		writeLockExecutionQuery,
 		filter.ShardID,
@@ -280,7 +280,7 @@ func (mdb *db) InsertIntoCurrentExecutions(
 	ctx context.Context,
 	row *sqlplugin.CurrentExecutionsRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		createCurrentExecutionQuery,
 		row,
 	)
@@ -291,7 +291,7 @@ func (mdb *db) UpdateCurrentExecutions(
 	ctx context.Context,
 	row *sqlplugin.CurrentExecutionsRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		updateCurrentExecutionsQuery,
 		row,
 	)
@@ -303,7 +303,7 @@ func (mdb *db) SelectFromCurrentExecutions(
 	filter sqlplugin.CurrentExecutionsFilter,
 ) (*sqlplugin.CurrentExecutionsRow, error) {
 	var row sqlplugin.CurrentExecutionsRow
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&row,
 		getCurrentExecutionQuery,
 		filter.ShardID,
@@ -318,7 +318,7 @@ func (mdb *db) DeleteFromCurrentExecutions(
 	ctx context.Context,
 	filter sqlplugin.CurrentExecutionsFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteCurrentExecutionQuery,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -333,7 +333,7 @@ func (mdb *db) LockCurrentExecutions(
 	filter sqlplugin.CurrentExecutionsFilter,
 ) (*sqlplugin.CurrentExecutionsRow, error) {
 	var row sqlplugin.CurrentExecutionsRow
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&row,
 		lockCurrentExecutionQuery,
 		filter.ShardID,
@@ -350,7 +350,7 @@ func (mdb *db) LockCurrentExecutionsJoinExecutions(
 	filter sqlplugin.CurrentExecutionsFilter,
 ) ([]sqlplugin.CurrentExecutionsRow, error) {
 	var rows []sqlplugin.CurrentExecutionsRow
-	err := mdb.conn.SelectContext(ctx,
+	err := mdb.SelectContext(ctx,
 		&rows,
 		lockCurrentExecutionJoinExecutionsQuery,
 		filter.ShardID,
@@ -365,7 +365,7 @@ func (mdb *db) InsertIntoHistoryImmediateTasks(
 	ctx context.Context,
 	rows []sqlplugin.HistoryImmediateTasksRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		createHistoryImmediateTasksQuery,
 		rows,
 	)
@@ -377,7 +377,7 @@ func (mdb *db) RangeSelectFromHistoryImmediateTasks(
 	filter sqlplugin.HistoryImmediateTasksRangeFilter,
 ) ([]sqlplugin.HistoryImmediateTasksRow, error) {
 	var rows []sqlplugin.HistoryImmediateTasksRow
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows,
 		getHistoryImmediateTasksQuery,
 		filter.ShardID,
@@ -396,7 +396,7 @@ func (mdb *db) DeleteFromHistoryImmediateTasks(
 	ctx context.Context,
 	filter sqlplugin.HistoryImmediateTasksFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteHistoryImmediateTaskQuery,
 		filter.ShardID,
 		filter.CategoryID,
@@ -409,7 +409,7 @@ func (mdb *db) RangeDeleteFromHistoryImmediateTasks(
 	ctx context.Context,
 	filter sqlplugin.HistoryImmediateTasksRangeFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		rangeDeleteHistoryImmediateTasksQuery,
 		filter.ShardID,
 		filter.CategoryID,
@@ -426,7 +426,7 @@ func (mdb *db) InsertIntoHistoryScheduledTasks(
 	for i := range rows {
 		rows[i].VisibilityTimestamp = mdb.converter.ToMySQLDateTime(rows[i].VisibilityTimestamp)
 	}
-	return mdb.conn.NamedExecContext(
+	return mdb.NamedExecContext(
 		ctx,
 		createHistoryScheduledTasksQuery,
 		rows,
@@ -441,7 +441,7 @@ func (mdb *db) RangeSelectFromHistoryScheduledTasks(
 	var rows []sqlplugin.HistoryScheduledTasksRow
 	filter.InclusiveMinVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.InclusiveMinVisibilityTimestamp)
 	filter.ExclusiveMaxVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.ExclusiveMaxVisibilityTimestamp)
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows,
 		getHistoryScheduledTasksQuery,
 		filter.ShardID,
@@ -466,7 +466,7 @@ func (mdb *db) DeleteFromHistoryScheduledTasks(
 	filter sqlplugin.HistoryScheduledTasksFilter,
 ) (sql.Result, error) {
 	filter.VisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.VisibilityTimestamp)
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteHistoryScheduledTaskQuery,
 		filter.ShardID,
 		filter.CategoryID,
@@ -482,7 +482,7 @@ func (mdb *db) RangeDeleteFromHistoryScheduledTasks(
 ) (sql.Result, error) {
 	filter.InclusiveMinVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.InclusiveMinVisibilityTimestamp)
 	filter.ExclusiveMaxVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.ExclusiveMaxVisibilityTimestamp)
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		rangeDeleteHistoryScheduledTasksQuery,
 		filter.ShardID,
 		filter.CategoryID,
@@ -496,7 +496,7 @@ func (mdb *db) InsertIntoTransferTasks(
 	ctx context.Context,
 	rows []sqlplugin.TransferTasksRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		createTransferTasksQuery,
 		rows,
 	)
@@ -508,7 +508,7 @@ func (mdb *db) RangeSelectFromTransferTasks(
 	filter sqlplugin.TransferTasksRangeFilter,
 ) ([]sqlplugin.TransferTasksRow, error) {
 	var rows []sqlplugin.TransferTasksRow
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows,
 		getTransferTasksQuery,
 		filter.ShardID,
@@ -526,7 +526,7 @@ func (mdb *db) DeleteFromTransferTasks(
 	ctx context.Context,
 	filter sqlplugin.TransferTasksFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteTransferTaskQuery,
 		filter.ShardID,
 		filter.TaskID,
@@ -538,7 +538,7 @@ func (mdb *db) RangeDeleteFromTransferTasks(
 	ctx context.Context,
 	filter sqlplugin.TransferTasksRangeFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		rangeDeleteTransferTaskQuery,
 		filter.ShardID,
 		filter.InclusiveMinTaskID,
@@ -554,7 +554,7 @@ func (mdb *db) InsertIntoTimerTasks(
 	for i := range rows {
 		rows[i].VisibilityTimestamp = mdb.converter.ToMySQLDateTime(rows[i].VisibilityTimestamp)
 	}
-	return mdb.conn.NamedExecContext(
+	return mdb.NamedExecContext(
 		ctx,
 		createTimerTasksQuery,
 		rows,
@@ -569,7 +569,7 @@ func (mdb *db) RangeSelectFromTimerTasks(
 	var rows []sqlplugin.TimerTasksRow
 	filter.InclusiveMinVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.InclusiveMinVisibilityTimestamp)
 	filter.ExclusiveMaxVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.ExclusiveMaxVisibilityTimestamp)
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows,
 		getTimerTasksQuery,
 		filter.ShardID,
@@ -593,7 +593,7 @@ func (mdb *db) DeleteFromTimerTasks(
 	filter sqlplugin.TimerTasksFilter,
 ) (sql.Result, error) {
 	filter.VisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.VisibilityTimestamp)
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteTimerTaskQuery,
 		filter.ShardID,
 		filter.VisibilityTimestamp,
@@ -608,7 +608,7 @@ func (mdb *db) RangeDeleteFromTimerTasks(
 ) (sql.Result, error) {
 	filter.InclusiveMinVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.InclusiveMinVisibilityTimestamp)
 	filter.ExclusiveMaxVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.ExclusiveMaxVisibilityTimestamp)
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		rangeDeleteTimerTaskQuery,
 		filter.ShardID,
 		filter.InclusiveMinVisibilityTimestamp,
@@ -621,7 +621,7 @@ func (mdb *db) InsertIntoBufferedEvents(
 	ctx context.Context,
 	rows []sqlplugin.BufferedEventsRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		createBufferedEventsQuery,
 		rows,
 	)
@@ -633,7 +633,7 @@ func (mdb *db) SelectFromBufferedEvents(
 	filter sqlplugin.BufferedEventsFilter,
 ) ([]sqlplugin.BufferedEventsRow, error) {
 	var rows []sqlplugin.BufferedEventsRow
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows,
 		getBufferedEventsQuery,
 		filter.ShardID,
@@ -657,7 +657,7 @@ func (mdb *db) DeleteFromBufferedEvents(
 	ctx context.Context,
 	filter sqlplugin.BufferedEventsFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteBufferedEventsQuery,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -671,7 +671,7 @@ func (mdb *db) InsertIntoReplicationTasks(
 	ctx context.Context,
 	rows []sqlplugin.ReplicationTasksRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		createReplicationTasksQuery,
 		rows,
 	)
@@ -683,7 +683,7 @@ func (mdb *db) RangeSelectFromReplicationTasks(
 	filter sqlplugin.ReplicationTasksRangeFilter,
 ) ([]sqlplugin.ReplicationTasksRow, error) {
 	var rows []sqlplugin.ReplicationTasksRow
-	err := mdb.conn.SelectContext(ctx,
+	err := mdb.SelectContext(ctx,
 		&rows,
 		getReplicationTasksQuery,
 		filter.ShardID,
@@ -699,7 +699,7 @@ func (mdb *db) DeleteFromReplicationTasks(
 	ctx context.Context,
 	filter sqlplugin.ReplicationTasksFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteReplicationTaskQuery,
 		filter.ShardID,
 		filter.TaskID,
@@ -711,7 +711,7 @@ func (mdb *db) RangeDeleteFromReplicationTasks(
 	ctx context.Context,
 	filter sqlplugin.ReplicationTasksRangeFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		rangeDeleteReplicationTaskQuery,
 		filter.ShardID,
 		filter.InclusiveMinTaskID,
@@ -724,7 +724,7 @@ func (mdb *db) InsertIntoReplicationDLQTasks(
 	ctx context.Context,
 	rows []sqlplugin.ReplicationDLQTasksRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		insertReplicationTaskDLQQuery,
 		rows,
 	)
@@ -736,7 +736,7 @@ func (mdb *db) RangeSelectFromReplicationDLQTasks(
 	filter sqlplugin.ReplicationDLQTasksRangeFilter,
 ) ([]sqlplugin.ReplicationDLQTasksRow, error) {
 	var rows []sqlplugin.ReplicationDLQTasksRow
-	err := mdb.conn.SelectContext(ctx,
+	err := mdb.SelectContext(ctx,
 		&rows, getReplicationTasksDLQQuery,
 		filter.SourceClusterName,
 		filter.ShardID,
@@ -753,7 +753,7 @@ func (mdb *db) DeleteFromReplicationDLQTasks(
 	filter sqlplugin.ReplicationDLQTasksFilter,
 ) (sql.Result, error) {
 
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteReplicationTaskFromDLQQuery,
 		filter.SourceClusterName,
 		filter.ShardID,
@@ -767,7 +767,7 @@ func (mdb *db) RangeDeleteFromReplicationDLQTasks(
 	filter sqlplugin.ReplicationDLQTasksRangeFilter,
 ) (sql.Result, error) {
 
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		rangeDeleteReplicationTaskFromDLQQuery,
 		filter.SourceClusterName,
 		filter.ShardID,
@@ -781,7 +781,7 @@ func (mdb *db) InsertIntoVisibilityTasks(
 	ctx context.Context,
 	rows []sqlplugin.VisibilityTasksRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		createVisibilityTasksQuery,
 		rows,
 	)
@@ -793,7 +793,7 @@ func (mdb *db) RangeSelectFromVisibilityTasks(
 	filter sqlplugin.VisibilityTasksRangeFilter,
 ) ([]sqlplugin.VisibilityTasksRow, error) {
 	var rows []sqlplugin.VisibilityTasksRow
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows,
 		getVisibilityTasksQuery,
 		filter.ShardID,
@@ -811,7 +811,7 @@ func (mdb *db) DeleteFromVisibilityTasks(
 	ctx context.Context,
 	filter sqlplugin.VisibilityTasksFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteVisibilityTaskQuery,
 		filter.ShardID,
 		filter.TaskID,
@@ -823,7 +823,7 @@ func (mdb *db) RangeDeleteFromVisibilityTasks(
 	ctx context.Context,
 	filter sqlplugin.VisibilityTasksRangeFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		rangeDeleteVisibilityTaskQuery,
 		filter.ShardID,
 		filter.InclusiveMinTaskID,

--- a/common/persistence/sql/sqlplugin/mysql/execution_maps.go
+++ b/common/persistence/sql/sqlplugin/mysql/execution_maps.go
@@ -135,7 +135,7 @@ func (mdb *db) ReplaceIntoActivityInfoMaps(
 	ctx context.Context,
 	rows []sqlplugin.ActivityInfoMapsRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		setKeyInActivityInfoMapQry,
 		rows,
 	)
@@ -147,7 +147,7 @@ func (mdb *db) SelectAllFromActivityInfoMaps(
 	filter sqlplugin.ActivityInfoMapsAllFilter,
 ) ([]sqlplugin.ActivityInfoMapsRow, error) {
 	var rows []sqlplugin.ActivityInfoMapsRow
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows,
 		getActivityInfoMapQry,
 		filter.ShardID,
@@ -182,8 +182,8 @@ func (mdb *db) DeleteFromActivityInfoMaps(
 	if err != nil {
 		return nil, err
 	}
-	return mdb.conn.ExecContext(ctx,
-		mdb.conn.Rebind(query),
+	return mdb.ExecContext(ctx,
+		mdb.Rebind(query),
 		args...,
 	)
 }
@@ -193,7 +193,7 @@ func (mdb *db) DeleteAllFromActivityInfoMaps(
 	ctx context.Context,
 	filter sqlplugin.ActivityInfoMapsAllFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteActivityInfoMapQry,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -221,7 +221,7 @@ func (mdb *db) ReplaceIntoTimerInfoMaps(
 	ctx context.Context,
 	rows []sqlplugin.TimerInfoMapsRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		setKeyInTimerInfoMapSQLQuery,
 		rows,
 	)
@@ -233,7 +233,7 @@ func (mdb *db) SelectAllFromTimerInfoMaps(
 	filter sqlplugin.TimerInfoMapsAllFilter,
 ) ([]sqlplugin.TimerInfoMapsRow, error) {
 	var rows []sqlplugin.TimerInfoMapsRow
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows,
 		getTimerInfoMapSQLQuery,
 		filter.ShardID,
@@ -268,8 +268,8 @@ func (mdb *db) DeleteFromTimerInfoMaps(
 	if err != nil {
 		return nil, err
 	}
-	return mdb.conn.ExecContext(ctx,
-		mdb.conn.Rebind(query),
+	return mdb.ExecContext(ctx,
+		mdb.Rebind(query),
 		args...,
 	)
 }
@@ -279,7 +279,7 @@ func (mdb *db) DeleteAllFromTimerInfoMaps(
 	ctx context.Context,
 	filter sqlplugin.TimerInfoMapsAllFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteTimerInfoMapSQLQuery,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -307,7 +307,7 @@ func (mdb *db) ReplaceIntoChildExecutionInfoMaps(
 	ctx context.Context,
 	rows []sqlplugin.ChildExecutionInfoMapsRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		setKeyInChildExecutionInfoMapQry,
 		rows,
 	)
@@ -319,7 +319,7 @@ func (mdb *db) SelectAllFromChildExecutionInfoMaps(
 	filter sqlplugin.ChildExecutionInfoMapsAllFilter,
 ) ([]sqlplugin.ChildExecutionInfoMapsRow, error) {
 	var rows []sqlplugin.ChildExecutionInfoMapsRow
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows,
 		getChildExecutionInfoMapQry,
 		filter.ShardID,
@@ -354,8 +354,8 @@ func (mdb *db) DeleteFromChildExecutionInfoMaps(
 	if err != nil {
 		return nil, err
 	}
-	return mdb.conn.ExecContext(ctx,
-		mdb.conn.Rebind(query),
+	return mdb.ExecContext(ctx,
+		mdb.Rebind(query),
 		args...,
 	)
 }
@@ -365,7 +365,7 @@ func (mdb *db) DeleteAllFromChildExecutionInfoMaps(
 	ctx context.Context,
 	filter sqlplugin.ChildExecutionInfoMapsAllFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteChildExecutionInfoMapQry,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -393,7 +393,7 @@ func (mdb *db) ReplaceIntoRequestCancelInfoMaps(
 	ctx context.Context,
 	rows []sqlplugin.RequestCancelInfoMapsRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		setKeyInRequestCancelInfoMapQry,
 		rows,
 	)
@@ -405,7 +405,7 @@ func (mdb *db) SelectAllFromRequestCancelInfoMaps(
 	filter sqlplugin.RequestCancelInfoMapsAllFilter,
 ) ([]sqlplugin.RequestCancelInfoMapsRow, error) {
 	var rows []sqlplugin.RequestCancelInfoMapsRow
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows, getRequestCancelInfoMapQry,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -439,8 +439,8 @@ func (mdb *db) DeleteFromRequestCancelInfoMaps(
 	if err != nil {
 		return nil, err
 	}
-	return mdb.conn.ExecContext(ctx,
-		mdb.conn.Rebind(query),
+	return mdb.ExecContext(ctx,
+		mdb.Rebind(query),
 		args...,
 	)
 }
@@ -450,7 +450,7 @@ func (mdb *db) DeleteAllFromRequestCancelInfoMaps(
 	ctx context.Context,
 	filter sqlplugin.RequestCancelInfoMapsAllFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteRequestCancelInfoMapQry,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -478,7 +478,7 @@ func (mdb *db) ReplaceIntoSignalInfoMaps(
 	ctx context.Context,
 	rows []sqlplugin.SignalInfoMapsRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		setKeyInSignalInfoMapQry,
 		rows,
 	)
@@ -490,7 +490,7 @@ func (mdb *db) SelectAllFromSignalInfoMaps(
 	filter sqlplugin.SignalInfoMapsAllFilter,
 ) ([]sqlplugin.SignalInfoMapsRow, error) {
 	var rows []sqlplugin.SignalInfoMapsRow
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows,
 		getSignalInfoMapQry,
 		filter.ShardID,
@@ -525,8 +525,8 @@ func (mdb *db) DeleteFromSignalInfoMaps(
 	if err != nil {
 		return nil, err
 	}
-	return mdb.conn.ExecContext(ctx,
-		mdb.conn.Rebind(query),
+	return mdb.ExecContext(ctx,
+		mdb.Rebind(query),
 		args...,
 	)
 }
@@ -536,7 +536,7 @@ func (mdb *db) DeleteAllFromSignalInfoMaps(
 	ctx context.Context,
 	filter sqlplugin.SignalInfoMapsAllFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteSignalInfoMapQry,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -579,7 +579,7 @@ func (mdb *db) ReplaceIntoSignalsRequestedSets(
 	ctx context.Context,
 	rows []sqlplugin.SignalsRequestedSetsRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		createSignalsRequestedSetQry,
 		rows,
 	)
@@ -592,7 +592,7 @@ func (mdb *db) SelectAllFromSignalsRequestedSets(
 	filter sqlplugin.SignalsRequestedSetsAllFilter,
 ) ([]sqlplugin.SignalsRequestedSetsRow, error) {
 	var rows []sqlplugin.SignalsRequestedSetsRow
-	if err := mdb.conn.SelectContext(ctx,
+	if err := mdb.SelectContext(ctx,
 		&rows,
 		getSignalsRequestedSetQry,
 		filter.ShardID,
@@ -627,8 +627,8 @@ func (mdb *db) DeleteFromSignalsRequestedSets(
 	if err != nil {
 		return nil, err
 	}
-	return mdb.conn.ExecContext(ctx,
-		mdb.conn.Rebind(query),
+	return mdb.ExecContext(ctx,
+		mdb.Rebind(query),
 		args...,
 	)
 }
@@ -638,7 +638,7 @@ func (mdb *db) DeleteAllFromSignalsRequestedSets(
 	ctx context.Context,
 	filter sqlplugin.SignalsRequestedSetsAllFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteAllSignalsRequestedSetQry,
 		filter.ShardID,
 		filter.NamespaceID,

--- a/common/persistence/sql/sqlplugin/mysql/namespace.go
+++ b/common/persistence/sql/sqlplugin/mysql/namespace.go
@@ -70,7 +70,7 @@ func (mdb *db) InsertIntoNamespace(
 	ctx context.Context,
 	row *sqlplugin.NamespaceRow,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		createNamespaceQuery,
 		partitionID,
 		row.ID,
@@ -87,7 +87,7 @@ func (mdb *db) UpdateNamespace(
 	ctx context.Context,
 	row *sqlplugin.NamespaceRow,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		updateNamespaceQuery,
 		row.Name,
 		row.Data,
@@ -124,14 +124,14 @@ func (mdb *db) selectFromNamespace(
 	var row sqlplugin.NamespaceRow
 	switch {
 	case filter.ID != nil:
-		err = mdb.conn.GetContext(ctx,
+		err = mdb.GetContext(ctx,
 			&row,
 			getNamespaceByIDQuery,
 			partitionID,
 			*filter.ID,
 		)
 	case filter.Name != nil:
-		err = mdb.conn.GetContext(ctx,
+		err = mdb.GetContext(ctx,
 			&row,
 			getNamespaceByNameQuery,
 			partitionID,
@@ -152,7 +152,7 @@ func (mdb *db) selectAllFromNamespace(
 	var rows []sqlplugin.NamespaceRow
 	switch {
 	case filter.GreaterThanID != nil:
-		err = mdb.conn.SelectContext(ctx,
+		err = mdb.SelectContext(ctx,
 			&rows,
 			listNamespacesRangeQuery,
 			partitionID,
@@ -160,7 +160,7 @@ func (mdb *db) selectAllFromNamespace(
 			*filter.PageSize,
 		)
 	default:
-		err = mdb.conn.SelectContext(ctx,
+		err = mdb.SelectContext(ctx,
 			&rows,
 			listNamespacesQuery,
 			partitionID,
@@ -179,13 +179,13 @@ func (mdb *db) DeleteFromNamespace(
 	var result sql.Result
 	switch {
 	case filter.ID != nil:
-		result, err = mdb.conn.ExecContext(ctx,
+		result, err = mdb.ExecContext(ctx,
 			deleteNamespaceByIDQuery,
 			partitionID,
 			filter.ID,
 		)
 	default:
-		result, err = mdb.conn.ExecContext(ctx,
+		result, err = mdb.ExecContext(ctx,
 			deleteNamespaceByNameQuery,
 			partitionID,
 			filter.Name,
@@ -199,7 +199,7 @@ func (mdb *db) LockNamespaceMetadata(
 	ctx context.Context,
 ) (*sqlplugin.NamespaceMetadataRow, error) {
 	var row sqlplugin.NamespaceMetadataRow
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&row.NotificationVersion,
 		lockNamespaceMetadataQuery,
 	)
@@ -214,7 +214,7 @@ func (mdb *db) SelectFromNamespaceMetadata(
 	ctx context.Context,
 ) (*sqlplugin.NamespaceMetadataRow, error) {
 	var row sqlplugin.NamespaceMetadataRow
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&row.NotificationVersion,
 		getNamespaceMetadataQuery,
 	)
@@ -226,7 +226,7 @@ func (mdb *db) UpdateNamespaceMetadata(
 	ctx context.Context,
 	row *sqlplugin.NamespaceMetadataRow,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		updateNamespaceMetadataQuery,
 		row.NotificationVersion+1,
 		row.NotificationVersion,

--- a/common/persistence/sql/sqlplugin/mysql/nexus_endpoints.go
+++ b/common/persistence/sql/sqlplugin/mysql/nexus_endpoints.go
@@ -43,19 +43,19 @@ const (
 )
 
 func (mdb *db) InitializeNexusEndpointsTableVersion(ctx context.Context) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx, createEndpointsTableVersionQry)
+	return mdb.ExecContext(ctx, createEndpointsTableVersionQry)
 }
 
 func (mdb *db) IncrementNexusEndpointsTableVersion(
 	ctx context.Context,
 	lastKnownTableVersion int64,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx, incrementEndpointsTableVersionQry, lastKnownTableVersion+1, lastKnownTableVersion)
+	return mdb.ExecContext(ctx, incrementEndpointsTableVersionQry, lastKnownTableVersion+1, lastKnownTableVersion)
 }
 
 func (mdb *db) GetNexusEndpointsTableVersion(ctx context.Context) (int64, error) {
 	var version int64
-	err := mdb.conn.GetContext(ctx, &version, getEndpointsTableVersionQry)
+	err := mdb.GetContext(ctx, &version, getEndpointsTableVersionQry)
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil
 	}
@@ -66,7 +66,7 @@ func (mdb *db) InsertIntoNexusEndpoints(
 	ctx context.Context,
 	row *sqlplugin.NexusEndpointsRow,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(
+	return mdb.ExecContext(
 		ctx,
 		createEndpointQry,
 		row.ID,
@@ -78,7 +78,7 @@ func (mdb *db) UpdateNexusEndpoint(
 	ctx context.Context,
 	row *sqlplugin.NexusEndpointsRow,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(
+	return mdb.ExecContext(
 		ctx,
 		updateEndpointQry,
 		row.Data,
@@ -92,7 +92,7 @@ func (mdb *db) DeleteFromNexusEndpoints(
 	ctx context.Context,
 	id []byte,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx, deleteEndpointQry, id)
+	return mdb.ExecContext(ctx, deleteEndpointQry, id)
 }
 
 func (mdb *db) GetNexusEndpointByID(
@@ -100,7 +100,7 @@ func (mdb *db) GetNexusEndpointByID(
 	id []byte,
 ) (*sqlplugin.NexusEndpointsRow, error) {
 	var row sqlplugin.NexusEndpointsRow
-	err := mdb.conn.GetContext(ctx, &row, getEndpointByIdQry, id)
+	err := mdb.GetContext(ctx, &row, getEndpointByIdQry, id)
 	return &row, err
 }
 
@@ -109,6 +109,6 @@ func (mdb *db) ListNexusEndpoints(
 	request *sqlplugin.ListNexusEndpointsRequest,
 ) ([]sqlplugin.NexusEndpointsRow, error) {
 	var rows []sqlplugin.NexusEndpointsRow
-	err := mdb.conn.SelectContext(ctx, &rows, getEndpointsQry, request.LastID, request.Limit)
+	err := mdb.SelectContext(ctx, &rows, getEndpointsQry, request.LastID, request.Limit)
 	return rows, err
 }

--- a/common/persistence/sql/sqlplugin/mysql/plugin.go
+++ b/common/persistence/sql/sqlplugin/mysql/plugin.go
@@ -54,14 +54,14 @@ func (p *plugin) CreateDB(
 	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
-	_ log.Logger,
-	_ metrics.Handler,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
 ) (sqlplugin.DB, error) {
-	conn, err := p.createDBConnection(dbKind, cfg, r)
-	if err != nil {
-		return nil, err
+	connect := func() (*sqlx.DB, error) {
+		return p.createDBConnection(dbKind, cfg, r)
 	}
-	db := newDB(dbKind, cfg.DatabaseName, conn, nil)
+	handle := sqlplugin.NewDatabaseHandle(connect, isConnNeedsRefreshError, logger, metricsHandler)
+	db := newDB(dbKind, cfg.DatabaseName, handle, nil)
 	return db, nil
 }
 
@@ -70,14 +70,14 @@ func (p *plugin) CreateAdminDB(
 	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
-	_ log.Logger,
-	_ metrics.Handler,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
 ) (sqlplugin.AdminDB, error) {
-	conn, err := p.createDBConnection(dbKind, cfg, r)
-	if err != nil {
-		return nil, err
+	connect := func() (*sqlx.DB, error) {
+		return p.createDBConnection(dbKind, cfg, r)
 	}
-	db := newDB(dbKind, cfg.DatabaseName, conn, nil)
+	handle := sqlplugin.NewDatabaseHandle(connect, isConnNeedsRefreshError, logger, metricsHandler)
+	db := newDB(dbKind, cfg.DatabaseName, handle, nil)
 	return db, nil
 }
 

--- a/common/persistence/sql/sqlplugin/mysql/plugin.go
+++ b/common/persistence/sql/sqlplugin/mysql/plugin.go
@@ -28,6 +28,8 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/sql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/mysql/session"
@@ -52,6 +54,8 @@ func (p *plugin) CreateDB(
 	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
+	_ log.Logger,
+	_ metrics.Handler,
 ) (sqlplugin.DB, error) {
 	conn, err := p.createDBConnection(dbKind, cfg, r)
 	if err != nil {
@@ -66,6 +70,8 @@ func (p *plugin) CreateAdminDB(
 	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
+	_ log.Logger,
+	_ metrics.Handler,
 ) (sqlplugin.AdminDB, error) {
 	conn, err := p.createDBConnection(dbKind, cfg, r)
 	if err != nil {

--- a/common/persistence/sql/sqlplugin/mysql/queue.go
+++ b/common/persistence/sql/sqlplugin/mysql/queue.go
@@ -54,7 +54,7 @@ func (mdb *db) InsertIntoMessages(
 	ctx context.Context,
 	row []sqlplugin.QueueMessageRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		templateEnqueueMessageQuery,
 		row,
 	)
@@ -65,7 +65,7 @@ func (mdb *db) SelectFromMessages(
 	filter sqlplugin.QueueMessagesFilter,
 ) ([]sqlplugin.QueueMessageRow, error) {
 	var rows []sqlplugin.QueueMessageRow
-	err := mdb.conn.SelectContext(ctx,
+	err := mdb.SelectContext(ctx,
 		&rows,
 		templateGetMessageQuery,
 		filter.QueueType,
@@ -79,7 +79,7 @@ func (mdb *db) RangeSelectFromMessages(
 	filter sqlplugin.QueueMessagesRangeFilter,
 ) ([]sqlplugin.QueueMessageRow, error) {
 	var rows []sqlplugin.QueueMessageRow
-	err := mdb.conn.SelectContext(ctx,
+	err := mdb.SelectContext(ctx,
 		&rows,
 		templateGetMessagesQuery,
 		filter.QueueType,
@@ -95,7 +95,7 @@ func (mdb *db) DeleteFromMessages(
 	ctx context.Context,
 	filter sqlplugin.QueueMessagesFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		templateDeleteMessageQuery,
 		filter.QueueType,
 		filter.MessageID,
@@ -107,7 +107,7 @@ func (mdb *db) RangeDeleteFromMessages(
 	ctx context.Context,
 	filter sqlplugin.QueueMessagesRangeFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		templateRangeDeleteMessagesQuery,
 		filter.QueueType,
 		filter.MinMessageID,
@@ -121,7 +121,7 @@ func (mdb *db) GetLastEnqueuedMessageIDForUpdate(
 	queueType persistence.QueueType,
 ) (int64, error) {
 	var lastMessageID *int64
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&lastMessageID,
 		templateGetLastMessageIDQuery,
 		queueType,
@@ -139,7 +139,7 @@ func (mdb *db) InsertIntoQueueMetadata(
 	ctx context.Context,
 	row *sqlplugin.QueueMetadataRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		templateCreateQueueMetadataQuery,
 		row,
 	)
@@ -149,7 +149,7 @@ func (mdb *db) UpdateQueueMetadata(
 	ctx context.Context,
 	row *sqlplugin.QueueMetadataRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		templateUpdateQueueMetadataQuery,
 		row,
 	)
@@ -160,7 +160,7 @@ func (mdb *db) SelectFromQueueMetadata(
 	filter sqlplugin.QueueMetadataFilter,
 ) (*sqlplugin.QueueMetadataRow, error) {
 	var row sqlplugin.QueueMetadataRow
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&row,
 		templateGetQueueMetadataQuery,
 		filter.QueueType,
@@ -176,7 +176,7 @@ func (mdb *db) LockQueueMetadata(
 	filter sqlplugin.QueueMetadataFilter,
 ) (*sqlplugin.QueueMetadataRow, error) {
 	var row sqlplugin.QueueMetadataRow
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&row,
 		templateLockQueueMetadataQuery,
 		filter.QueueType,

--- a/common/persistence/sql/sqlplugin/mysql/queue_v2.go
+++ b/common/persistence/sql/sqlplugin/mysql/queue_v2.go
@@ -46,14 +46,14 @@ const (
 )
 
 func (mdb *db) InsertIntoQueueV2Metadata(ctx context.Context, row *sqlplugin.QueueV2MetadataRow) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		templateCreateQueueMetadataQueryV2,
 		row,
 	)
 }
 
 func (mdb *db) UpdateQueueV2Metadata(ctx context.Context, row *sqlplugin.QueueV2MetadataRow) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		templateUpdateQueueMetadataQueryV2,
 		row,
 	)
@@ -61,7 +61,7 @@ func (mdb *db) UpdateQueueV2Metadata(ctx context.Context, row *sqlplugin.QueueV2
 
 func (mdb *db) SelectFromQueueV2Metadata(ctx context.Context, filter sqlplugin.QueueV2MetadataFilter) (*sqlplugin.QueueV2MetadataRow, error) {
 	var row sqlplugin.QueueV2MetadataRow
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&row,
 		templateGetQueueMetadataQueryV2,
 		filter.QueueType,
@@ -75,7 +75,7 @@ func (mdb *db) SelectFromQueueV2Metadata(ctx context.Context, filter sqlplugin.Q
 
 func (mdb *db) SelectFromQueueV2MetadataForUpdate(ctx context.Context, filter sqlplugin.QueueV2MetadataFilter) (*sqlplugin.QueueV2MetadataRow, error) {
 	var row sqlplugin.QueueV2MetadataRow
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&row,
 		templateGetQueueMetadataQueryV2ForUpdate,
 		filter.QueueType,
@@ -89,7 +89,7 @@ func (mdb *db) SelectFromQueueV2MetadataForUpdate(ctx context.Context, filter sq
 
 func (mdb *db) SelectNameFromQueueV2Metadata(ctx context.Context, filter sqlplugin.QueueV2MetadataTypeFilter) ([]sqlplugin.QueueV2MetadataRow, error) {
 	var rows []sqlplugin.QueueV2MetadataRow
-	err := mdb.conn.SelectContext(ctx,
+	err := mdb.SelectContext(ctx,
 		&rows,
 		templateGetNameFromQueueMetadataV2,
 		filter.QueueType,
@@ -103,7 +103,7 @@ func (mdb *db) SelectNameFromQueueV2Metadata(ctx context.Context, filter sqlplug
 }
 
 func (mdb *db) InsertIntoQueueV2Messages(ctx context.Context, row []sqlplugin.QueueV2MessageRow) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		templateEnqueueMessageQueryV2,
 		row,
 	)
@@ -111,7 +111,7 @@ func (mdb *db) InsertIntoQueueV2Messages(ctx context.Context, row []sqlplugin.Qu
 
 func (mdb *db) RangeSelectFromQueueV2Messages(ctx context.Context, filter sqlplugin.QueueV2MessagesFilter) ([]sqlplugin.QueueV2MessageRow, error) {
 	var rows []sqlplugin.QueueV2MessageRow
-	err := mdb.conn.SelectContext(ctx,
+	err := mdb.SelectContext(ctx,
 		&rows,
 		templateGetMessagesQueryV2,
 		filter.QueueType,
@@ -124,7 +124,7 @@ func (mdb *db) RangeSelectFromQueueV2Messages(ctx context.Context, filter sqlplu
 }
 
 func (mdb *db) RangeDeleteFromQueueV2Messages(ctx context.Context, filter sqlplugin.QueueV2MessagesFilter) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		templateRangeDeleteMessagesQueryV2,
 		filter.QueueType,
 		filter.QueueName,
@@ -136,7 +136,7 @@ func (mdb *db) RangeDeleteFromQueueV2Messages(ctx context.Context, filter sqlplu
 
 func (mdb *db) GetLastEnqueuedMessageIDForUpdateV2(ctx context.Context, filter sqlplugin.QueueV2Filter) (int64, error) {
 	var lastMessageID *int64
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&lastMessageID,
 		templateGetLastMessageIDQueryV2,
 		filter.QueueType,

--- a/common/persistence/sql/sqlplugin/mysql/shard.go
+++ b/common/persistence/sql/sqlplugin/mysql/shard.go
@@ -52,7 +52,7 @@ func (mdb *db) InsertIntoShards(
 	ctx context.Context,
 	row *sqlplugin.ShardsRow,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		createShardQry,
 		row.ShardID,
 		row.RangeID,
@@ -66,7 +66,7 @@ func (mdb *db) UpdateShards(
 	ctx context.Context,
 	row *sqlplugin.ShardsRow,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		updateShardQry,
 		row.RangeID,
 		row.Data,
@@ -81,7 +81,7 @@ func (mdb *db) SelectFromShards(
 	filter sqlplugin.ShardsFilter,
 ) (*sqlplugin.ShardsRow, error) {
 	var row sqlplugin.ShardsRow
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&row,
 		getShardQry,
 		filter.ShardID,
@@ -98,7 +98,7 @@ func (mdb *db) ReadLockShards(
 	filter sqlplugin.ShardsFilter,
 ) (int64, error) {
 	var rangeID int64
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&rangeID,
 		readLockShardQry,
 		filter.ShardID,
@@ -112,7 +112,7 @@ func (mdb *db) WriteLockShards(
 	filter sqlplugin.ShardsFilter,
 ) (int64, error) {
 	var rangeID int64
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&rangeID,
 		lockShardQry,
 		filter.ShardID,

--- a/common/persistence/sql/sqlplugin/mysql/task.go
+++ b/common/persistence/sql/sqlplugin/mysql/task.go
@@ -117,7 +117,7 @@ func (mdb *db) InsertIntoTasks(
 	ctx context.Context,
 	rows []sqlplugin.TasksRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		createTaskQry,
 		rows,
 	)
@@ -132,7 +132,7 @@ func (mdb *db) SelectFromTasks(
 	var rows []sqlplugin.TasksRow
 	switch {
 	case filter.ExclusiveMaxTaskID != nil:
-		err = mdb.conn.SelectContext(ctx,
+		err = mdb.SelectContext(ctx,
 			&rows, getTaskMinMaxQry,
 			filter.RangeHash,
 			filter.TaskQueueID,
@@ -141,7 +141,7 @@ func (mdb *db) SelectFromTasks(
 			*filter.PageSize,
 		)
 	default:
-		err = mdb.conn.SelectContext(ctx,
+		err = mdb.SelectContext(ctx,
 			&rows, getTaskMinQry,
 			filter.RangeHash,
 			filter.TaskQueueID,
@@ -166,7 +166,7 @@ func (mdb *db) DeleteFromTasks(
 	if filter.Limit == nil || *filter.Limit == 0 {
 		return nil, serviceerror.NewInternal("missing limit parameter")
 	}
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		rangeDeleteTaskQry,
 		filter.RangeHash,
 		filter.TaskQueueID,
@@ -180,7 +180,7 @@ func (mdb *db) InsertIntoTaskQueues(
 	ctx context.Context,
 	row *sqlplugin.TaskQueuesRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		createTaskQueueQry,
 		row,
 	)
@@ -191,7 +191,7 @@ func (mdb *db) UpdateTaskQueues(
 	ctx context.Context,
 	row *sqlplugin.TaskQueuesRow,
 ) (sql.Result, error) {
-	return mdb.conn.NamedExecContext(ctx,
+	return mdb.NamedExecContext(ctx,
 		updateTaskQueueQry,
 		row,
 	)
@@ -226,7 +226,7 @@ func (mdb *db) selectFromTaskQueues(
 ) ([]sqlplugin.TaskQueuesRow, error) {
 	var err error
 	var row sqlplugin.TaskQueuesRow
-	err = mdb.conn.GetContext(ctx,
+	err = mdb.GetContext(ctx,
 		&row,
 		getTaskQueueQry,
 		filter.RangeHash,
@@ -246,7 +246,7 @@ func (mdb *db) rangeSelectFromTaskQueues(
 	var rows []sqlplugin.TaskQueuesRow
 
 	if filter.RangeHashLessThanEqualTo != 0 {
-		err = mdb.conn.SelectContext(ctx,
+		err = mdb.SelectContext(ctx,
 			&rows,
 			listTaskQueueWithHashRangeQry,
 			filter.RangeHashGreaterThanEqualTo,
@@ -255,7 +255,7 @@ func (mdb *db) rangeSelectFromTaskQueues(
 			*filter.PageSize,
 		)
 	} else {
-		err = mdb.conn.SelectContext(ctx,
+		err = mdb.SelectContext(ctx,
 			&rows,
 			listTaskQueueQry,
 			filter.RangeHash,
@@ -274,7 +274,7 @@ func (mdb *db) DeleteFromTaskQueues(
 	ctx context.Context,
 	filter sqlplugin.TaskQueuesFilter,
 ) (sql.Result, error) {
-	return mdb.conn.ExecContext(ctx,
+	return mdb.ExecContext(ctx,
 		deleteTaskQueueQry,
 		filter.RangeHash,
 		filter.TaskQueueID,
@@ -288,7 +288,7 @@ func (mdb *db) LockTaskQueues(
 	filter sqlplugin.TaskQueuesFilter,
 ) (int64, error) {
 	var rangeID int64
-	err := mdb.conn.GetContext(ctx,
+	err := mdb.GetContext(ctx,
 		&rangeID,
 		lockTaskQueueQry,
 		filter.RangeHash,
@@ -299,13 +299,13 @@ func (mdb *db) LockTaskQueues(
 
 func (mdb *db) GetTaskQueueUserData(ctx context.Context, request *sqlplugin.GetTaskQueueUserDataRequest) (*sqlplugin.VersionedBlob, error) {
 	var row sqlplugin.VersionedBlob
-	err := mdb.conn.GetContext(ctx, &row, getTaskQueueUserDataQry, request.NamespaceID, request.TaskQueueName)
+	err := mdb.GetContext(ctx, &row, getTaskQueueUserDataQry, request.NamespaceID, request.TaskQueueName)
 	return &row, err
 }
 
 func (mdb *db) UpdateTaskQueueUserData(ctx context.Context, request *sqlplugin.UpdateTaskQueueDataRequest) error {
 	if request.Version == 0 {
-		_, err := mdb.conn.ExecContext(
+		_, err := mdb.ExecContext(
 			ctx,
 			insertTaskQueueUserDataQry,
 			request.NamespaceID,
@@ -314,7 +314,7 @@ func (mdb *db) UpdateTaskQueueUserData(ctx context.Context, request *sqlplugin.U
 			request.DataEncoding)
 		return err
 	}
-	result, err := mdb.conn.ExecContext(
+	result, err := mdb.ExecContext(
 		ctx,
 		updateTaskQueueUserDataQry,
 		request.Data,
@@ -348,7 +348,7 @@ func (mdb *db) AddToBuildIdToTaskQueueMapping(ctx context.Context, request sqlpl
 		params = append(params, request.NamespaceID, buildId, request.TaskQueueName)
 	}
 
-	_, err := mdb.conn.ExecContext(ctx, query, params...)
+	_, err := mdb.ExecContext(ctx, query, params...)
 	return err
 }
 
@@ -362,13 +362,13 @@ func (mdb *db) RemoveFromBuildIdToTaskQueueMapping(ctx context.Context, request 
 		params[i+2] = buildId
 	}
 
-	_, err := mdb.conn.ExecContext(ctx, query, params...)
+	_, err := mdb.ExecContext(ctx, query, params...)
 	return err
 }
 
 func (mdb *db) ListTaskQueueUserDataEntries(ctx context.Context, request *sqlplugin.ListTaskQueueUserDataEntriesRequest) ([]sqlplugin.TaskQueueUserDataEntry, error) {
 	var rows []sqlplugin.TaskQueueUserDataEntry
-	err := mdb.conn.SelectContext(ctx, &rows, listTaskQueueUserDataQry, request.NamespaceID, request.LastTaskQueueName, request.Limit)
+	err := mdb.SelectContext(ctx, &rows, listTaskQueueUserDataQry, request.NamespaceID, request.LastTaskQueueName, request.Limit)
 	return rows, err
 }
 
@@ -377,7 +377,7 @@ func (mdb *db) GetTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.Ge
 		TaskQueueName string
 	}
 
-	err := mdb.conn.SelectContext(ctx, &rows, listTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
+	err := mdb.SelectContext(ctx, &rows, listTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
 	taskQueues := make([]string, len(rows))
 	for i, row := range rows {
 		taskQueues[i] = row.TaskQueueName
@@ -387,6 +387,6 @@ func (mdb *db) GetTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.Ge
 
 func (mdb *db) CountTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.CountTaskQueuesByBuildIdRequest) (int, error) {
 	var count int
-	err := mdb.conn.GetContext(ctx, &count, countTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
+	err := mdb.GetContext(ctx, &count, countTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
 	return count, err
 }

--- a/common/persistence/sql/sqlplugin/mysql/visibility.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility.go
@@ -97,7 +97,12 @@ func (mdb *db) InsertIntoVisibility(
 	defer func() {
 		retError = mdb.handle.ConvertError(retError)
 	}()
-	tx, err := mdb.handle.DB().BeginTxx(ctx, nil)
+	db, err := mdb.handle.DB()
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := db.BeginTxx(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +138,11 @@ func (mdb *db) ReplaceIntoVisibility(
 		retError = mdb.handle.ConvertError(retError)
 	}()
 	finalRow := mdb.prepareRowForDB(row)
-	tx, err := mdb.handle.DB().BeginTxx(ctx, nil)
+	db, err := mdb.handle.DB()
+	if err != nil {
+		return nil, err
+	}
+	tx, err := db.BeginTxx(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +177,12 @@ func (mdb *db) DeleteFromVisibility(
 	defer func() {
 		retError = mdb.handle.ConvertError(retError)
 	}()
-	tx, err := mdb.handle.DB().BeginTxx(ctx, nil)
+	db, err := mdb.handle.DB()
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := db.BeginTxx(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +276,11 @@ func (mdb *db) CountGroupByFromVisibility(
 	defer func() {
 		retError = mdb.handle.ConvertError(retError)
 	}()
-	rows, err := mdb.handle.DB().QueryContext(ctx, filter.Query, filter.QueryArgs...)
+	db, err := mdb.handle.DB()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := db.QueryContext(ctx, filter.Query, filter.QueryArgs...)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/sql/sqlplugin/mysql/visibility.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility.go
@@ -95,7 +95,7 @@ func (mdb *db) InsertIntoVisibility(
 ) (result sql.Result, retError error) {
 	finalRow := mdb.prepareRowForDB(row)
 	defer func() {
-		mdb.handle.HandleError(retError)
+		retError = mdb.handle.ConvertError(retError)
 	}()
 	tx, err := mdb.handle.DB().BeginTxx(ctx, nil)
 	if err != nil {
@@ -130,7 +130,7 @@ func (mdb *db) ReplaceIntoVisibility(
 	row *sqlplugin.VisibilityRow,
 ) (result sql.Result, retError error) {
 	defer func() {
-		mdb.handle.HandleError(retError)
+		retError = mdb.handle.ConvertError(retError)
 	}()
 	finalRow := mdb.prepareRowForDB(row)
 	tx, err := mdb.handle.DB().BeginTxx(ctx, nil)
@@ -166,7 +166,7 @@ func (mdb *db) DeleteFromVisibility(
 	filter sqlplugin.VisibilityDeleteFilter,
 ) (result sql.Result, retError error) {
 	defer func() {
-		mdb.handle.HandleError(retError)
+		retError = mdb.handle.ConvertError(retError)
 	}()
 	tx, err := mdb.handle.DB().BeginTxx(ctx, nil)
 	if err != nil {
@@ -260,7 +260,7 @@ func (mdb *db) CountGroupByFromVisibility(
 	filter sqlplugin.VisibilitySelectFilter,
 ) (_ []sqlplugin.VisibilityCountRow, retError error) {
 	defer func() {
-		mdb.handle.HandleError(retError)
+		retError = mdb.handle.ConvertError(retError)
 	}()
 	rows, err := mdb.handle.DB().QueryContext(ctx, filter.Query, filter.QueryArgs...)
 	if err != nil {

--- a/common/persistence/sql/sqlplugin/postgresql/admin.go
+++ b/common/persistence/sql/sqlplugin/postgresql/admin.go
@@ -73,7 +73,11 @@ const (
 
 // Exec executes a sql statement
 func (pdb *db) Exec(stmt string, args ...any) error {
-	_, err := pdb.DB().Exec(stmt, args...)
+	db, err := pdb.handle.DB()
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(stmt, args...)
 	return pdb.handle.ConvertError(err)
 }
 
@@ -88,7 +92,11 @@ func (pdb *db) CreateSchemaVersionTables() error {
 // ReadSchemaVersion returns the current schema version for the keyspace
 func (pdb *db) ReadSchemaVersion(database string) (string, error) {
 	var version string
-	err := pdb.DB().Get(&version, readSchemaVersionQuery, database)
+	db, err := pdb.handle.DB()
+	if err != nil {
+		return "", err
+	}
+	err = db.Get(&version, readSchemaVersionQuery, database)
 	return version, pdb.handle.ConvertError(err)
 }
 

--- a/common/persistence/sql/sqlplugin/postgresql/admin.go
+++ b/common/persistence/sql/sqlplugin/postgresql/admin.go
@@ -74,10 +74,7 @@ const (
 // Exec executes a sql statement
 func (pdb *db) Exec(stmt string, args ...any) error {
 	_, err := pdb.DB().Exec(stmt, args...)
-	if err != nil {
-		pdb.handleError(err)
-	}
-	return err
+	return pdb.handle.ConvertError(err)
 }
 
 // CreateSchemaVersionTables sets up the schema version tables
@@ -92,10 +89,7 @@ func (pdb *db) CreateSchemaVersionTables() error {
 func (pdb *db) ReadSchemaVersion(database string) (string, error) {
 	var version string
 	err := pdb.DB().Get(&version, readSchemaVersionQuery, database)
-	if err != nil {
-		pdb.handleError(err)
-	}
-	return version, err
+	return version, pdb.handle.ConvertError(err)
 }
 
 // UpdateSchemaVersion updates the schema version for the keyspace
@@ -107,20 +101,14 @@ func (pdb *db) UpdateSchemaVersion(database string, newVersion string, minCompat
 func (pdb *db) WriteSchemaUpdateLog(oldVersion string, newVersion string, manifestMD5 string, desc string) error {
 	now := time.Now().UTC()
 	err := pdb.Exec(writeSchemaUpdateHistoryQuery, now.Year(), int(now.Month()), now, oldVersion, newVersion, manifestMD5, desc)
-	if err != nil {
-		pdb.handleError(err)
-	}
-	return err
+	return pdb.handle.ConvertError(err)
 }
 
 // ListTables returns a list of tables in this database
 func (pdb *db) ListTables(database string) ([]string, error) {
 	var tables []string
 	err := pdb.Select(&tables, listTablesQuery)
-	if err != nil {
-		pdb.handleError(err)
-	}
-	return tables, err
+	return tables, pdb.handle.ConvertError(err)
 }
 
 // DropTable drops a given table from the database

--- a/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
@@ -87,7 +87,7 @@ func (pdb *db) SaveClusterMetadata(
 	row *sqlplugin.ClusterMetadataRow,
 ) (sql.Result, error) {
 	if row.Version == 0 {
-		return pdb.conn.ExecContext(ctx,
+		return pdb.ExecContext(ctx,
 			insertClusterMetadataQry,
 			constMetadataPartition,
 			row.ClusterName,
@@ -96,7 +96,7 @@ func (pdb *db) SaveClusterMetadata(
 			1,
 		)
 	}
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		updateClusterMetadataQry,
 		row.Data,
 		row.DataEncoding,
@@ -114,7 +114,7 @@ func (pdb *db) ListClusterMetadata(
 	var rows []sqlplugin.ClusterMetadataRow
 	switch {
 	case len(filter.ClusterName) != 0:
-		err = pdb.conn.SelectContext(ctx,
+		err = pdb.SelectContext(ctx,
 			&rows,
 			listClusterMetadataRangeQry,
 			constMetadataPartition,
@@ -122,7 +122,7 @@ func (pdb *db) ListClusterMetadata(
 			filter.PageSize,
 		)
 	default:
-		err = pdb.conn.SelectContext(ctx,
+		err = pdb.SelectContext(ctx,
 			&rows,
 			listClusterMetadataQry,
 			constMetadataPartition,
@@ -137,7 +137,7 @@ func (pdb *db) GetClusterMetadata(
 	filter *sqlplugin.ClusterMetadataFilter,
 ) (*sqlplugin.ClusterMetadataRow, error) {
 	var row sqlplugin.ClusterMetadataRow
-	err := pdb.conn.GetContext(ctx,
+	err := pdb.GetContext(ctx,
 		&row,
 		getClusterMetadataQry,
 		constMetadataPartition,
@@ -154,7 +154,7 @@ func (pdb *db) WriteLockGetClusterMetadata(
 	filter *sqlplugin.ClusterMetadataFilter,
 ) (*sqlplugin.ClusterMetadataRow, error) {
 	var row sqlplugin.ClusterMetadataRow
-	err := pdb.conn.GetContext(ctx,
+	err := pdb.GetContext(ctx,
 		&row,
 		writeLockGetClusterMetadataQry,
 		constMetadataPartition,
@@ -171,7 +171,7 @@ func (pdb *db) DeleteClusterMetadata(
 	filter *sqlplugin.ClusterMetadataFilter,
 ) (sql.Result, error) {
 
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteClusterMetadataQry,
 		constMetadataPartition,
 		filter.ClusterName,
@@ -182,7 +182,7 @@ func (pdb *db) UpsertClusterMembership(
 	ctx context.Context,
 	row *sqlplugin.ClusterMembershipRow,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		templateUpsertActiveClusterMembership,
 		constMembershipPartition,
 		row.HostID,
@@ -257,7 +257,7 @@ func (pdb *db) GetClusterMembers(
 	compiledQryString := queryString.String()
 
 	var rows []sqlplugin.ClusterMembershipRow
-	err := pdb.conn.SelectContext(ctx, &rows,
+	err := pdb.SelectContext(ctx, &rows,
 		compiledQryString,
 		operands...)
 	if err != nil {
@@ -275,7 +275,7 @@ func (pdb *db) PruneClusterMembership(
 	ctx context.Context,
 	filter *sqlplugin.PruneClusterMembershipFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		templatePruneStaleClusterMembership,
 		constMembershipPartition,
 		filter.PruneRecordsBefore,

--- a/common/persistence/sql/sqlplugin/postgresql/db.go
+++ b/common/persistence/sql/sqlplugin/postgresql/db.go
@@ -98,16 +98,11 @@ func (pdb *db) conn() sqlplugin.Conn {
 	return pdb.handle.Conn()
 }
 
-func (pdb *db) handleError(err error) {
-	pdb.handle.HandleError(err)
-}
-
 // BeginTx starts a new transaction and returns a reference to the Tx object
 func (pdb *db) BeginTx(ctx context.Context) (sqlplugin.Tx, error) {
 	tx, err := pdb.handle.DB().BeginTxx(ctx, nil)
 	if err != nil {
-		pdb.handle.HandleError(err)
-		return nil, err
+		return nil, pdb.handle.ConvertError(err)
 	}
 	return newDB(pdb.dbKind, pdb.dbName, pdb.dbDriver, pdb.handle, tx), nil
 }
@@ -159,58 +154,37 @@ func (pdb *db) Rollback() error {
 // Helper methods to hide common error handling
 func (pdb *db) ExecContext(ctx context.Context, stmt string, args ...any) (sql.Result, error) {
 	res, err := pdb.conn().ExecContext(ctx, stmt, args...)
-	if err != nil {
-		pdb.handleError(err)
-	}
-	return res, err
+	return res, pdb.handle.ConvertError(err)
 }
 
 func (pdb *db) GetContext(ctx context.Context, dest any, query string, args ...any) error {
 	err := pdb.conn().GetContext(ctx, dest, query, args...)
-	if err != nil {
-		pdb.handleError(err)
-	}
-	return err
+	return pdb.handle.ConvertError(err)
 }
 
 func (pdb *db) Select(dest any, query string, args ...any) error {
 	err := pdb.DB().Select(dest, query, args...)
-	if err != nil {
-		pdb.handleError(err)
-	}
-	return err
+	return pdb.handle.ConvertError(err)
 }
 
 func (pdb *db) SelectContext(ctx context.Context, dest any, query string, args ...any) error {
 	err := pdb.conn().SelectContext(ctx, dest, query, args...)
-	if err != nil {
-		pdb.handleError(err)
-	}
-	return err
+	return pdb.handle.ConvertError(err)
 }
 
 func (pdb *db) NamedExecContext(ctx context.Context, query string, arg any) (sql.Result, error) {
 	res, err := pdb.conn().NamedExecContext(ctx, query, arg)
-	if err != nil {
-		pdb.handleError(err)
-	}
-	return res, err
+	return res, pdb.handle.ConvertError(err)
 }
 
 func (pdb *db) PrepareNamedContext(ctx context.Context, query string) (*sqlx.NamedStmt, error) {
 	stmt, err := pdb.conn().PrepareNamedContext(ctx, query)
-	if err != nil {
-		pdb.handleError(err)
-	}
-	return stmt, err
+	return stmt, pdb.handle.ConvertError(err)
 }
 
 func (pdb *db) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
 	rows, err := pdb.DB().QueryContext(ctx, query, args...)
-	if err != nil {
-		pdb.handleError(err)
-	}
-	return rows, err
+	return rows, pdb.handle.ConvertError(err)
 }
 
 func (pdb *db) Rebind(query string) string {

--- a/common/persistence/sql/sqlplugin/postgresql/db.go
+++ b/common/persistence/sql/sqlplugin/postgresql/db.go
@@ -26,12 +26,16 @@ package postgresql
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence/schema"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql/driver"
+	"go.temporal.io/server/common/resolver"
 	postgresqlschemaV12 "go.temporal.io/server/schema/postgresql/v12"
 )
 
@@ -49,14 +53,16 @@ type db struct {
 	dbName   string
 	dbDriver driver.Driver
 
-	db        *sqlx.DB
-	tx        *sqlx.Tx
-	conn      sqlplugin.Conn
+	plugin    *plugin
+	cfg       *config.SQL
+	resolver  resolver.ServiceResolver
 	converter DataConverter
+
+	handle *sqlplugin.DatabaseHandle
+	tx     *sqlx.Tx
 }
 
 var _ sqlplugin.DB = (*db)(nil)
-var _ sqlplugin.Tx = (*db)(nil)
 
 // newDB returns an instance of DB, which is a logical
 // connection to the underlying postgresql database
@@ -64,46 +70,55 @@ func newDB(
 	dbKind sqlplugin.DbKind,
 	dbName string,
 	dbDriver driver.Driver,
-	xdb *sqlx.DB,
+	handle *sqlplugin.DatabaseHandle,
 	tx *sqlx.Tx,
 ) *db {
 	mdb := &db{
 		dbKind:   dbKind,
 		dbName:   dbName,
 		dbDriver: dbDriver,
-		db:       xdb,
+		handle:   handle,
 		tx:       tx,
-	}
-	mdb.conn = xdb
-	if tx != nil {
-		mdb.conn = tx
 	}
 	mdb.converter = &converter{}
 	return mdb
 }
 
+func (pdb *db) DB() *sqlx.DB {
+	if pdb.tx != nil {
+		panic("cannot use DB() in a transaction")
+	}
+
+	return pdb.handle.DB()
+}
+
+func (pdb *db) conn() sqlplugin.Conn {
+	if pdb.tx != nil {
+		return pdb.tx
+	}
+	return pdb.handle.Conn()
+}
+
+func (pdb *db) handleError(err error) {
+	pdb.handle.HandleError(err)
+}
+
 // BeginTx starts a new transaction and returns a reference to the Tx object
 func (pdb *db) BeginTx(ctx context.Context) (sqlplugin.Tx, error) {
-	xtx, err := pdb.db.BeginTxx(ctx, nil)
+	tx, err := pdb.handle.DB().BeginTxx(ctx, nil)
 	if err != nil {
+		pdb.handle.HandleError(err)
 		return nil, err
 	}
-	return newDB(pdb.dbKind, pdb.dbName, pdb.dbDriver, pdb.db, xtx), nil
-}
-
-// Commit commits a previously started transaction
-func (pdb *db) Commit() error {
-	return pdb.tx.Commit()
-}
-
-// Rollback triggers rollback of a previously started transaction
-func (pdb *db) Rollback() error {
-	return pdb.tx.Rollback()
+	logr := log.NewTestLogger()
+	logr.Error("Began transaction")
+	return newDB(pdb.dbKind, pdb.dbName, pdb.dbDriver, pdb.handle, tx), nil
 }
 
 // Close closes the connection to the mysql db
 func (pdb *db) Close() error {
-	return pdb.db.Close()
+	pdb.handle.Close()
+	return nil
 }
 
 // PluginName returns the name of the mysql plugin
@@ -132,4 +147,76 @@ func (pdb *db) ExpectedVersion() string {
 func (pdb *db) VerifyVersion() error {
 	expectedVersion := pdb.ExpectedVersion()
 	return schema.VerifyCompatibleVersion(pdb, pdb.dbName, expectedVersion)
+}
+
+// Commit commits a previously started transaction
+func (pdb *db) Commit() error {
+	return pdb.tx.Commit()
+}
+
+// Rollback triggers rollback of a previously started transaction
+func (pdb *db) Rollback() error {
+	return pdb.tx.Rollback()
+}
+
+// Helper methods to hide common error handling
+
+func (pdb *db) ExecContext(ctx context.Context, stmt string, args ...any) (sql.Result, error) {
+	res, err := pdb.conn().ExecContext(ctx, stmt, args...)
+	if err != nil {
+		pdb.handleError(err)
+	}
+	return res, err
+}
+
+func (pdb *db) GetContext(ctx context.Context, dest any, query string, args ...any) error {
+	err := pdb.conn().GetContext(ctx, dest, query, args...)
+	if err != nil {
+		pdb.handleError(err)
+	}
+	return err
+}
+
+func (pdb *db) Select(dest any, query string, args ...any) error {
+	err := pdb.DB().Select(dest, query, args...)
+	if err != nil {
+		pdb.handleError(err)
+	}
+	return err
+}
+
+func (pdb *db) SelectContext(ctx context.Context, dest any, query string, args ...any) error {
+	err := pdb.conn().SelectContext(ctx, dest, query, args...)
+	if err != nil {
+		pdb.handleError(err)
+	}
+	return err
+}
+
+func (pdb *db) NamedExecContext(ctx context.Context, query string, arg any) (sql.Result, error) {
+	res, err := pdb.conn().NamedExecContext(ctx, query, arg)
+	if err != nil {
+		pdb.handleError(err)
+	}
+	return res, err
+}
+
+func (pdb *db) PrepareNamedContext(ctx context.Context, query string) (*sqlx.NamedStmt, error) {
+	stmt, err := pdb.conn().PrepareNamedContext(ctx, query)
+	if err != nil {
+		pdb.handleError(err)
+	}
+	return stmt, err
+}
+
+func (pdb *db) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	rows, err := pdb.DB().QueryContext(ctx, query, args...)
+	if err != nil {
+		pdb.handleError(err)
+	}
+	return rows, err
+}
+
+func (pdb *db) Rebind(query string) string {
+	return pdb.handle.DB().Rebind(query)
 }

--- a/common/persistence/sql/sqlplugin/postgresql/db.go
+++ b/common/persistence/sql/sqlplugin/postgresql/db.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"go.temporal.io/server/common/config"
-	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence/schema"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql/driver"
@@ -110,8 +109,6 @@ func (pdb *db) BeginTx(ctx context.Context) (sqlplugin.Tx, error) {
 		pdb.handle.HandleError(err)
 		return nil, err
 	}
-	logr := log.NewTestLogger()
-	logr.Error("Began transaction")
 	return newDB(pdb.dbKind, pdb.dbName, pdb.dbDriver, pdb.handle, tx), nil
 }
 
@@ -160,7 +157,6 @@ func (pdb *db) Rollback() error {
 }
 
 // Helper methods to hide common error handling
-
 func (pdb *db) ExecContext(ctx context.Context, stmt string, args ...any) (sql.Result, error) {
 	res, err := pdb.conn().ExecContext(ctx, stmt, args...)
 	if err != nil {
@@ -218,5 +214,5 @@ func (pdb *db) QueryContext(ctx context.Context, query string, args ...any) (*sq
 }
 
 func (pdb *db) Rebind(query string) string {
-	return pdb.handle.DB().Rebind(query)
+	return pdb.conn().Rebind(query)
 }

--- a/common/persistence/sql/sqlplugin/postgresql/driver/interface.go
+++ b/common/persistence/sql/sqlplugin/postgresql/driver/interface.go
@@ -30,12 +30,29 @@ import (
 
 const (
 	// check http://www.postgresql.org/docs/9.3/static/errcodes-appendix.html
-	dupEntryCode    = "23505"
-	dupDatabaseCode = "42P04"
+	dupEntryCode            = "23505"
+	dupDatabaseCode         = "42P04"
+	readOnlyTransactionCode = "25006"
+	cannotConnectNowCode    = "57P03"
+	featureNotSupportedCode = "0A000"
+
+	// Unsupported "feature" messages to look for
+	cannotSetReadWriteModeDuringRecoveryMsg = "cannot set transaction read-write mode during recovery"
 )
 
 type Driver interface {
 	CreateConnection(dsn string) (*sqlx.DB, error)
 	IsDupEntryError(error) bool
 	IsDupDatabaseError(error) bool
+	IsConnNeedsRefreshError(error) bool
+}
+
+func isConnNeedsRefreshError(code, message string) bool {
+	if code == readOnlyTransactionCode || code == cannotConnectNowCode {
+		return true
+	}
+	if code == featureNotSupportedCode && message == cannotSetReadWriteModeDuringRecoveryMsg {
+		return true
+	}
+	return false
 }

--- a/common/persistence/sql/sqlplugin/postgresql/driver/pgx.go
+++ b/common/persistence/sql/sqlplugin/postgresql/driver/pgx.go
@@ -45,3 +45,11 @@ func (p *PGXDriver) IsDupDatabaseError(err error) bool {
 	pqErr, ok := err.(*pgconn.PgError)
 	return ok && pqErr.Code == dupDatabaseCode
 }
+
+func (p *PGXDriver) IsConnNeedsRefreshError(err error) bool {
+	pqErr, ok := err.(*pgconn.PgError)
+	if !ok {
+		return false
+	}
+	return isConnNeedsRefreshError(pqErr.Code, pqErr.Message)
+}

--- a/common/persistence/sql/sqlplugin/postgresql/driver/pq.go
+++ b/common/persistence/sql/sqlplugin/postgresql/driver/pq.go
@@ -44,3 +44,11 @@ func (p *PQDriver) IsDupDatabaseError(err error) bool {
 	pqErr, ok := err.(*pq.Error)
 	return ok && pqErr.Code == dupDatabaseCode
 }
+
+func (p *PQDriver) IsConnNeedsRefreshError(err error) bool {
+	pqErr, ok := err.(*pq.Error)
+	if !ok {
+		return false
+	}
+	return isConnNeedsRefreshError(string(pqErr.Code), pqErr.Message)
+}

--- a/common/persistence/sql/sqlplugin/postgresql/events.go
+++ b/common/persistence/sql/sqlplugin/postgresql/events.go
@@ -82,7 +82,7 @@ func (pdb *db) InsertIntoHistoryNode(
 ) (sql.Result, error) {
 	// NOTE: txn_id is *= -1 within DB
 	row.TxnID = -row.TxnID
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		addHistoryNodesQuery,
 		row,
 	)
@@ -95,7 +95,7 @@ func (pdb *db) DeleteFromHistoryNode(
 ) (sql.Result, error) {
 	// NOTE: txn_id is *= -1 within DB
 	row.TxnID = -row.TxnID
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteHistoryNodeQuery,
 		row.ShardID,
 		row.TreeID,
@@ -145,7 +145,7 @@ func (pdb *db) RangeSelectFromHistoryNode(
 	}
 
 	var rows []sqlplugin.HistoryNodeRow
-	err := pdb.conn.SelectContext(ctx, &rows, query, args...)
+	err := pdb.SelectContext(ctx, &rows, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (pdb *db) RangeDeleteFromHistoryNode(
 	ctx context.Context,
 	filter sqlplugin.HistoryNodeDeleteFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteHistoryNodesQuery,
 		filter.ShardID,
 		filter.TreeID,
@@ -177,7 +177,7 @@ func (pdb *db) InsertIntoHistoryTree(
 	ctx context.Context,
 	row *sqlplugin.HistoryTreeRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		addHistoryTreeQuery,
 		row,
 	)
@@ -189,7 +189,7 @@ func (pdb *db) SelectFromHistoryTree(
 	filter sqlplugin.HistoryTreeSelectFilter,
 ) ([]sqlplugin.HistoryTreeRow, error) {
 	var rows []sqlplugin.HistoryTreeRow
-	err := pdb.conn.SelectContext(ctx,
+	err := pdb.SelectContext(ctx,
 		&rows,
 		getHistoryTreeQuery,
 		filter.ShardID,
@@ -205,7 +205,7 @@ func (pdb *db) PaginateBranchesFromHistoryTree(
 	page sqlplugin.HistoryTreeBranchPage,
 ) ([]sqlplugin.HistoryTreeRow, error) {
 	var rows []sqlplugin.HistoryTreeRow
-	err := pdb.conn.SelectContext(ctx,
+	err := pdb.SelectContext(ctx,
 		&rows,
 		paginateBranchesQuery,
 		page.ShardID,
@@ -221,7 +221,7 @@ func (pdb *db) DeleteFromHistoryTree(
 	ctx context.Context,
 	filter sqlplugin.HistoryTreeDeleteFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteHistoryTreeQuery,
 		filter.ShardID,
 		filter.TreeID,

--- a/common/persistence/sql/sqlplugin/postgresql/execution.go
+++ b/common/persistence/sql/sqlplugin/postgresql/execution.go
@@ -190,7 +190,7 @@ func (pdb *db) InsertIntoExecutions(
 	ctx context.Context,
 	row *sqlplugin.ExecutionsRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		createExecutionQuery,
 		row,
 	)
@@ -201,7 +201,7 @@ func (pdb *db) UpdateExecutions(
 	ctx context.Context,
 	row *sqlplugin.ExecutionsRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		updateExecutionQuery,
 		row,
 	)
@@ -213,7 +213,7 @@ func (pdb *db) SelectFromExecutions(
 	filter sqlplugin.ExecutionsFilter,
 ) (*sqlplugin.ExecutionsRow, error) {
 	var row sqlplugin.ExecutionsRow
-	err := pdb.conn.GetContext(ctx,
+	err := pdb.GetContext(ctx,
 		&row,
 		getExecutionQuery,
 		filter.ShardID,
@@ -232,7 +232,7 @@ func (pdb *db) DeleteFromExecutions(
 	ctx context.Context,
 	filter sqlplugin.ExecutionsFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteExecutionQuery,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -247,7 +247,10 @@ func (pdb *db) ReadLockExecutions(
 	filter sqlplugin.ExecutionsFilter,
 ) (int64, int64, error) {
 	var executionVersion sqlplugin.ExecutionVersion
-	err := pdb.conn.GetContext(ctx,
+	if pdb.tx == nil {
+		panic("cannot acquire execution read lock without a transaction")
+	}
+	err := pdb.GetContext(ctx,
 		&executionVersion,
 		readLockExecutionQuery,
 		filter.ShardID,
@@ -264,7 +267,10 @@ func (pdb *db) WriteLockExecutions(
 	filter sqlplugin.ExecutionsFilter,
 ) (int64, int64, error) {
 	var executionVersion sqlplugin.ExecutionVersion
-	err := pdb.conn.GetContext(ctx,
+	if pdb.tx == nil {
+		panic("cannot acquire execution write lock without a transaction")
+	}
+	err := pdb.GetContext(ctx,
 		&executionVersion,
 		writeLockExecutionQuery,
 		filter.ShardID,
@@ -280,7 +286,7 @@ func (pdb *db) InsertIntoCurrentExecutions(
 	ctx context.Context,
 	row *sqlplugin.CurrentExecutionsRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		createCurrentExecutionQuery,
 		row,
 	)
@@ -291,7 +297,7 @@ func (pdb *db) UpdateCurrentExecutions(
 	ctx context.Context,
 	row *sqlplugin.CurrentExecutionsRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		updateCurrentExecutionsQuery,
 		row,
 	)
@@ -303,7 +309,7 @@ func (pdb *db) SelectFromCurrentExecutions(
 	filter sqlplugin.CurrentExecutionsFilter,
 ) (*sqlplugin.CurrentExecutionsRow, error) {
 	var row sqlplugin.CurrentExecutionsRow
-	err := pdb.conn.GetContext(ctx,
+	err := pdb.GetContext(ctx,
 		&row,
 		getCurrentExecutionQuery,
 		filter.ShardID,
@@ -318,7 +324,7 @@ func (pdb *db) DeleteFromCurrentExecutions(
 	ctx context.Context,
 	filter sqlplugin.CurrentExecutionsFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteCurrentExecutionQuery,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -333,7 +339,7 @@ func (pdb *db) LockCurrentExecutions(
 	filter sqlplugin.CurrentExecutionsFilter,
 ) (*sqlplugin.CurrentExecutionsRow, error) {
 	var row sqlplugin.CurrentExecutionsRow
-	err := pdb.conn.GetContext(ctx,
+	err := pdb.GetContext(ctx,
 		&row,
 		lockCurrentExecutionQuery,
 		filter.ShardID,
@@ -350,7 +356,7 @@ func (pdb *db) LockCurrentExecutionsJoinExecutions(
 	filter sqlplugin.CurrentExecutionsFilter,
 ) ([]sqlplugin.CurrentExecutionsRow, error) {
 	var rows []sqlplugin.CurrentExecutionsRow
-	err := pdb.conn.SelectContext(ctx,
+	err := pdb.SelectContext(ctx,
 		&rows,
 		lockCurrentExecutionJoinExecutionsQuery,
 		filter.ShardID,
@@ -365,7 +371,7 @@ func (pdb *db) InsertIntoHistoryImmediateTasks(
 	ctx context.Context,
 	rows []sqlplugin.HistoryImmediateTasksRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		createHistoryImmediateTasksQuery,
 		rows,
 	)
@@ -377,7 +383,7 @@ func (pdb *db) RangeSelectFromHistoryImmediateTasks(
 	filter sqlplugin.HistoryImmediateTasksRangeFilter,
 ) ([]sqlplugin.HistoryImmediateTasksRow, error) {
 	var rows []sqlplugin.HistoryImmediateTasksRow
-	if err := pdb.conn.SelectContext(ctx,
+	if err := pdb.SelectContext(ctx,
 		&rows,
 		getHistoryImmediateTasksQuery,
 		filter.ShardID,
@@ -396,7 +402,7 @@ func (pdb *db) DeleteFromHistoryImmediateTasks(
 	ctx context.Context,
 	filter sqlplugin.HistoryImmediateTasksFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteHistoryImmediateTaskQuery,
 		filter.ShardID,
 		filter.CategoryID,
@@ -409,7 +415,7 @@ func (pdb *db) RangeDeleteFromHistoryImmediateTasks(
 	ctx context.Context,
 	filter sqlplugin.HistoryImmediateTasksRangeFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		rangeDeleteHistoryImmediateTasksQuery,
 		filter.ShardID,
 		filter.CategoryID,
@@ -426,7 +432,7 @@ func (pdb *db) InsertIntoHistoryScheduledTasks(
 	for i := range rows {
 		rows[i].VisibilityTimestamp = pdb.converter.ToPostgreSQLDateTime(rows[i].VisibilityTimestamp)
 	}
-	return pdb.conn.NamedExecContext(
+	return pdb.NamedExecContext(
 		ctx,
 		createHistoryScheduledTasksQuery,
 		rows,
@@ -441,7 +447,7 @@ func (pdb *db) RangeSelectFromHistoryScheduledTasks(
 	var rows []sqlplugin.HistoryScheduledTasksRow
 	filter.InclusiveMinVisibilityTimestamp = pdb.converter.ToPostgreSQLDateTime(filter.InclusiveMinVisibilityTimestamp)
 	filter.ExclusiveMaxVisibilityTimestamp = pdb.converter.ToPostgreSQLDateTime(filter.ExclusiveMaxVisibilityTimestamp)
-	if err := pdb.conn.SelectContext(ctx,
+	if err := pdb.SelectContext(ctx,
 		&rows,
 		getHistoryScheduledTasksQuery,
 		filter.ShardID,
@@ -466,7 +472,7 @@ func (pdb *db) DeleteFromHistoryScheduledTasks(
 	filter sqlplugin.HistoryScheduledTasksFilter,
 ) (sql.Result, error) {
 	filter.VisibilityTimestamp = pdb.converter.ToPostgreSQLDateTime(filter.VisibilityTimestamp)
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteHistoryScheduledTaskQuery,
 		filter.ShardID,
 		filter.CategoryID,
@@ -482,7 +488,7 @@ func (pdb *db) RangeDeleteFromHistoryScheduledTasks(
 ) (sql.Result, error) {
 	filter.InclusiveMinVisibilityTimestamp = pdb.converter.ToPostgreSQLDateTime(filter.InclusiveMinVisibilityTimestamp)
 	filter.ExclusiveMaxVisibilityTimestamp = pdb.converter.ToPostgreSQLDateTime(filter.ExclusiveMaxVisibilityTimestamp)
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		rangeDeleteHistoryScheduledTasksQuery,
 		filter.ShardID,
 		filter.CategoryID,
@@ -496,7 +502,7 @@ func (pdb *db) InsertIntoTransferTasks(
 	ctx context.Context,
 	rows []sqlplugin.TransferTasksRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		createTransferTasksQuery,
 		rows,
 	)
@@ -508,7 +514,7 @@ func (pdb *db) RangeSelectFromTransferTasks(
 	filter sqlplugin.TransferTasksRangeFilter,
 ) ([]sqlplugin.TransferTasksRow, error) {
 	var rows []sqlplugin.TransferTasksRow
-	err := pdb.conn.SelectContext(ctx,
+	err := pdb.SelectContext(ctx,
 		&rows,
 		getTransferTasksQuery,
 		filter.ShardID,
@@ -527,7 +533,7 @@ func (pdb *db) DeleteFromTransferTasks(
 	ctx context.Context,
 	filter sqlplugin.TransferTasksFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteTransferTaskQuery,
 		filter.ShardID,
 		filter.TaskID,
@@ -539,7 +545,7 @@ func (pdb *db) RangeDeleteFromTransferTasks(
 	ctx context.Context,
 	filter sqlplugin.TransferTasksRangeFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		rangeDeleteTransferTaskQuery,
 		filter.ShardID,
 		filter.InclusiveMinTaskID,
@@ -555,7 +561,7 @@ func (pdb *db) InsertIntoTimerTasks(
 	for i := range rows {
 		rows[i].VisibilityTimestamp = pdb.converter.ToPostgreSQLDateTime(rows[i].VisibilityTimestamp)
 	}
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		createTimerTasksQuery,
 		rows,
 	)
@@ -569,7 +575,7 @@ func (pdb *db) RangeSelectFromTimerTasks(
 	var rows []sqlplugin.TimerTasksRow
 	filter.InclusiveMinVisibilityTimestamp = pdb.converter.ToPostgreSQLDateTime(filter.InclusiveMinVisibilityTimestamp)
 	filter.ExclusiveMaxVisibilityTimestamp = pdb.converter.ToPostgreSQLDateTime(filter.ExclusiveMaxVisibilityTimestamp)
-	err := pdb.conn.SelectContext(ctx,
+	err := pdb.SelectContext(ctx,
 		&rows,
 		getTimerTasksQuery,
 		filter.ShardID,
@@ -594,7 +600,7 @@ func (pdb *db) DeleteFromTimerTasks(
 	filter sqlplugin.TimerTasksFilter,
 ) (sql.Result, error) {
 	filter.VisibilityTimestamp = pdb.converter.ToPostgreSQLDateTime(filter.VisibilityTimestamp)
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteTimerTaskQuery,
 		filter.ShardID,
 		filter.VisibilityTimestamp,
@@ -609,7 +615,7 @@ func (pdb *db) RangeDeleteFromTimerTasks(
 ) (sql.Result, error) {
 	filter.InclusiveMinVisibilityTimestamp = pdb.converter.ToPostgreSQLDateTime(filter.InclusiveMinVisibilityTimestamp)
 	filter.ExclusiveMaxVisibilityTimestamp = pdb.converter.ToPostgreSQLDateTime(filter.ExclusiveMaxVisibilityTimestamp)
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		rangeDeleteTimerTaskQuery,
 		filter.ShardID,
 		filter.InclusiveMinVisibilityTimestamp,
@@ -622,7 +628,7 @@ func (pdb *db) InsertIntoBufferedEvents(
 	ctx context.Context,
 	rows []sqlplugin.BufferedEventsRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		createBufferedEventsQuery,
 		rows,
 	)
@@ -634,7 +640,7 @@ func (pdb *db) SelectFromBufferedEvents(
 	filter sqlplugin.BufferedEventsFilter,
 ) ([]sqlplugin.BufferedEventsRow, error) {
 	var rows []sqlplugin.BufferedEventsRow
-	if err := pdb.conn.SelectContext(ctx,
+	if err := pdb.SelectContext(ctx,
 		&rows,
 		getBufferedEventsQuery,
 		filter.ShardID,
@@ -658,7 +664,7 @@ func (pdb *db) DeleteFromBufferedEvents(
 	ctx context.Context,
 	filter sqlplugin.BufferedEventsFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteBufferedEventsQuery,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -672,7 +678,7 @@ func (pdb *db) InsertIntoReplicationTasks(
 	ctx context.Context,
 	rows []sqlplugin.ReplicationTasksRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		createReplicationTasksQuery,
 		rows,
 	)
@@ -684,7 +690,7 @@ func (pdb *db) RangeSelectFromReplicationTasks(
 	filter sqlplugin.ReplicationTasksRangeFilter,
 ) ([]sqlplugin.ReplicationTasksRow, error) {
 	var rows []sqlplugin.ReplicationTasksRow
-	err := pdb.conn.SelectContext(ctx,
+	err := pdb.SelectContext(ctx,
 		&rows,
 		getReplicationTasksQuery,
 		filter.ShardID,
@@ -700,7 +706,7 @@ func (pdb *db) DeleteFromReplicationTasks(
 	ctx context.Context,
 	filter sqlplugin.ReplicationTasksFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteReplicationTaskQuery,
 		filter.ShardID,
 		filter.TaskID,
@@ -712,7 +718,7 @@ func (pdb *db) RangeDeleteFromReplicationTasks(
 	ctx context.Context,
 	filter sqlplugin.ReplicationTasksRangeFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		rangeDeleteReplicationTaskQuery,
 		filter.ShardID,
 		filter.InclusiveMinTaskID,
@@ -725,7 +731,7 @@ func (pdb *db) InsertIntoReplicationDLQTasks(
 	ctx context.Context,
 	rows []sqlplugin.ReplicationDLQTasksRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		insertReplicationTaskDLQQuery,
 		rows,
 	)
@@ -737,7 +743,7 @@ func (pdb *db) RangeSelectFromReplicationDLQTasks(
 	filter sqlplugin.ReplicationDLQTasksRangeFilter,
 ) ([]sqlplugin.ReplicationDLQTasksRow, error) {
 	var rows []sqlplugin.ReplicationDLQTasksRow
-	err := pdb.conn.SelectContext(ctx,
+	err := pdb.SelectContext(ctx,
 		&rows, getReplicationTasksDLQQuery,
 		filter.SourceClusterName,
 		filter.ShardID,
@@ -754,7 +760,7 @@ func (pdb *db) DeleteFromReplicationDLQTasks(
 	filter sqlplugin.ReplicationDLQTasksFilter,
 ) (sql.Result, error) {
 
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteReplicationTaskFromDLQQuery,
 		filter.SourceClusterName,
 		filter.ShardID,
@@ -768,7 +774,7 @@ func (pdb *db) RangeDeleteFromReplicationDLQTasks(
 	filter sqlplugin.ReplicationDLQTasksRangeFilter,
 ) (sql.Result, error) {
 
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		rangeDeleteReplicationTaskFromDLQQuery,
 		filter.SourceClusterName,
 		filter.ShardID,
@@ -782,7 +788,7 @@ func (pdb *db) InsertIntoVisibilityTasks(
 	ctx context.Context,
 	rows []sqlplugin.VisibilityTasksRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		createVisibilityTasksQuery,
 		rows,
 	)
@@ -794,7 +800,7 @@ func (pdb *db) RangeSelectFromVisibilityTasks(
 	filter sqlplugin.VisibilityTasksRangeFilter,
 ) ([]sqlplugin.VisibilityTasksRow, error) {
 	var rows []sqlplugin.VisibilityTasksRow
-	err := pdb.conn.SelectContext(ctx,
+	err := pdb.SelectContext(ctx,
 		&rows,
 		getVisibilityTasksQuery,
 		filter.ShardID,
@@ -813,7 +819,7 @@ func (pdb *db) DeleteFromVisibilityTasks(
 	ctx context.Context,
 	filter sqlplugin.VisibilityTasksFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteVisibilityTaskQuery,
 		filter.ShardID,
 		filter.TaskID,
@@ -825,7 +831,7 @@ func (pdb *db) RangeDeleteFromVisibilityTasks(
 	ctx context.Context,
 	filter sqlplugin.VisibilityTasksRangeFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		rangeDeleteVisibilityTaskQuery,
 		filter.ShardID,
 		filter.InclusiveMinTaskID,

--- a/common/persistence/sql/sqlplugin/postgresql/execution.go
+++ b/common/persistence/sql/sqlplugin/postgresql/execution.go
@@ -247,9 +247,6 @@ func (pdb *db) ReadLockExecutions(
 	filter sqlplugin.ExecutionsFilter,
 ) (int64, int64, error) {
 	var executionVersion sqlplugin.ExecutionVersion
-	if pdb.tx == nil {
-		panic("cannot acquire execution read lock without a transaction")
-	}
 	err := pdb.GetContext(ctx,
 		&executionVersion,
 		readLockExecutionQuery,
@@ -267,9 +264,6 @@ func (pdb *db) WriteLockExecutions(
 	filter sqlplugin.ExecutionsFilter,
 ) (int64, int64, error) {
 	var executionVersion sqlplugin.ExecutionVersion
-	if pdb.tx == nil {
-		panic("cannot acquire execution write lock without a transaction")
-	}
 	err := pdb.GetContext(ctx,
 		&executionVersion,
 		writeLockExecutionQuery,

--- a/common/persistence/sql/sqlplugin/postgresql/execution_maps.go
+++ b/common/persistence/sql/sqlplugin/postgresql/execution_maps.go
@@ -168,7 +168,7 @@ func (pdb *db) ReplaceIntoActivityInfoMaps(
 	ctx context.Context,
 	rows []sqlplugin.ActivityInfoMapsRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		setKeyInActivityInfoMapQry,
 		rows,
 	)
@@ -180,7 +180,7 @@ func (pdb *db) SelectAllFromActivityInfoMaps(
 	filter sqlplugin.ActivityInfoMapsAllFilter,
 ) ([]sqlplugin.ActivityInfoMapsRow, error) {
 	var rows []sqlplugin.ActivityInfoMapsRow
-	if err := pdb.conn.SelectContext(ctx,
+	if err := pdb.SelectContext(ctx,
 		&rows, getActivityInfoMapQry,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -214,8 +214,8 @@ func (pdb *db) DeleteFromActivityInfoMaps(
 	if err != nil {
 		return nil, err
 	}
-	return pdb.conn.ExecContext(ctx,
-		pdb.conn.Rebind(query),
+	return pdb.ExecContext(ctx,
+		pdb.Rebind(query),
 		args...,
 	)
 }
@@ -225,7 +225,7 @@ func (pdb *db) DeleteAllFromActivityInfoMaps(
 	ctx context.Context,
 	filter sqlplugin.ActivityInfoMapsAllFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteActivityInfoMapQry,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -253,7 +253,7 @@ func (pdb *db) ReplaceIntoTimerInfoMaps(
 	ctx context.Context,
 	rows []sqlplugin.TimerInfoMapsRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		setKeyInTimerInfoMapSQLQuery,
 		rows,
 	)
@@ -265,7 +265,7 @@ func (pdb *db) SelectAllFromTimerInfoMaps(
 	filter sqlplugin.TimerInfoMapsAllFilter,
 ) ([]sqlplugin.TimerInfoMapsRow, error) {
 	var rows []sqlplugin.TimerInfoMapsRow
-	if err := pdb.conn.SelectContext(ctx,
+	if err := pdb.SelectContext(ctx,
 		&rows,
 		getTimerInfoMapSQLQuery,
 		filter.ShardID,
@@ -300,8 +300,8 @@ func (pdb *db) DeleteFromTimerInfoMaps(
 	if err != nil {
 		return nil, err
 	}
-	return pdb.conn.ExecContext(ctx,
-		pdb.conn.Rebind(query),
+	return pdb.ExecContext(ctx,
+		pdb.Rebind(query),
 		args...,
 	)
 }
@@ -311,7 +311,7 @@ func (pdb *db) DeleteAllFromTimerInfoMaps(
 	ctx context.Context,
 	filter sqlplugin.TimerInfoMapsAllFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteTimerInfoMapSQLQuery,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -339,7 +339,7 @@ func (pdb *db) ReplaceIntoChildExecutionInfoMaps(
 	ctx context.Context,
 	rows []sqlplugin.ChildExecutionInfoMapsRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		setKeyInChildExecutionInfoMapQry,
 		rows,
 	)
@@ -351,7 +351,7 @@ func (pdb *db) SelectAllFromChildExecutionInfoMaps(
 	filter sqlplugin.ChildExecutionInfoMapsAllFilter,
 ) ([]sqlplugin.ChildExecutionInfoMapsRow, error) {
 	var rows []sqlplugin.ChildExecutionInfoMapsRow
-	if err := pdb.conn.SelectContext(ctx,
+	if err := pdb.SelectContext(ctx,
 		&rows,
 		getChildExecutionInfoMapQry,
 		filter.ShardID,
@@ -386,8 +386,8 @@ func (pdb *db) DeleteFromChildExecutionInfoMaps(
 	if err != nil {
 		return nil, err
 	}
-	return pdb.conn.ExecContext(ctx,
-		pdb.conn.Rebind(query),
+	return pdb.ExecContext(ctx,
+		pdb.Rebind(query),
 		args...,
 	)
 }
@@ -397,7 +397,7 @@ func (pdb *db) DeleteAllFromChildExecutionInfoMaps(
 	ctx context.Context,
 	filter sqlplugin.ChildExecutionInfoMapsAllFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteChildExecutionInfoMapQry,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -425,7 +425,7 @@ func (pdb *db) ReplaceIntoRequestCancelInfoMaps(
 	ctx context.Context,
 	rows []sqlplugin.RequestCancelInfoMapsRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		setKeyInRequestCancelInfoMapQry,
 		rows,
 	)
@@ -437,7 +437,7 @@ func (pdb *db) SelectAllFromRequestCancelInfoMaps(
 	filter sqlplugin.RequestCancelInfoMapsAllFilter,
 ) ([]sqlplugin.RequestCancelInfoMapsRow, error) {
 	var rows []sqlplugin.RequestCancelInfoMapsRow
-	if err := pdb.conn.SelectContext(ctx,
+	if err := pdb.SelectContext(ctx,
 		&rows,
 		getRequestCancelInfoMapQry,
 		filter.ShardID,
@@ -472,8 +472,8 @@ func (pdb *db) DeleteFromRequestCancelInfoMaps(
 	if err != nil {
 		return nil, err
 	}
-	return pdb.conn.ExecContext(ctx,
-		pdb.conn.Rebind(query),
+	return pdb.ExecContext(ctx,
+		pdb.Rebind(query),
 		args...,
 	)
 }
@@ -483,7 +483,7 @@ func (pdb *db) DeleteAllFromRequestCancelInfoMaps(
 	ctx context.Context,
 	filter sqlplugin.RequestCancelInfoMapsAllFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteRequestCancelInfoMapQry,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -511,7 +511,7 @@ func (pdb *db) ReplaceIntoSignalInfoMaps(
 	ctx context.Context,
 	rows []sqlplugin.SignalInfoMapsRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		setKeyInSignalInfoMapQry,
 		rows,
 	)
@@ -523,7 +523,7 @@ func (pdb *db) SelectAllFromSignalInfoMaps(
 	filter sqlplugin.SignalInfoMapsAllFilter,
 ) ([]sqlplugin.SignalInfoMapsRow, error) {
 	var rows []sqlplugin.SignalInfoMapsRow
-	if err := pdb.conn.SelectContext(ctx,
+	if err := pdb.SelectContext(ctx,
 		&rows,
 		getSignalInfoMapQry,
 		filter.ShardID,
@@ -558,8 +558,8 @@ func (pdb *db) DeleteFromSignalInfoMaps(
 	if err != nil {
 		return nil, err
 	}
-	return pdb.conn.ExecContext(ctx,
-		pdb.conn.Rebind(query),
+	return pdb.ExecContext(ctx,
+		pdb.Rebind(query),
 		args...,
 	)
 }
@@ -569,7 +569,7 @@ func (pdb *db) DeleteAllFromSignalInfoMaps(
 	ctx context.Context,
 	filter sqlplugin.SignalInfoMapsAllFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteSignalInfoMapQry,
 		filter.ShardID,
 		filter.NamespaceID,
@@ -583,7 +583,7 @@ func (pdb *db) ReplaceIntoSignalsRequestedSets(
 	ctx context.Context,
 	rows []sqlplugin.SignalsRequestedSetsRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		createSignalsRequestedSetQuery,
 		rows,
 	)
@@ -595,7 +595,7 @@ func (pdb *db) SelectAllFromSignalsRequestedSets(
 	filter sqlplugin.SignalsRequestedSetsAllFilter,
 ) ([]sqlplugin.SignalsRequestedSetsRow, error) {
 	var rows []sqlplugin.SignalsRequestedSetsRow
-	if err := pdb.conn.SelectContext(ctx,
+	if err := pdb.SelectContext(ctx,
 		&rows,
 		getSignalsRequestedSetQuery,
 		filter.ShardID,
@@ -630,8 +630,8 @@ func (pdb *db) DeleteFromSignalsRequestedSets(
 	if err != nil {
 		return nil, err
 	}
-	return pdb.conn.ExecContext(ctx,
-		pdb.conn.Rebind(query),
+	return pdb.ExecContext(ctx,
+		pdb.Rebind(query),
 		args...,
 	)
 }
@@ -641,7 +641,7 @@ func (pdb *db) DeleteAllFromSignalsRequestedSets(
 	ctx context.Context,
 	filter sqlplugin.SignalsRequestedSetsAllFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		deleteAllSignalsRequestedSetQuery,
 		filter.ShardID,
 		filter.NamespaceID,

--- a/common/persistence/sql/sqlplugin/postgresql/namespace.go
+++ b/common/persistence/sql/sqlplugin/postgresql/namespace.go
@@ -70,7 +70,7 @@ func (pdb *db) InsertIntoNamespace(
 	ctx context.Context,
 	row *sqlplugin.NamespaceRow,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx, createNamespaceQuery, partitionID, row.ID, row.Name, row.IsGlobal, row.Data, row.DataEncoding, row.NotificationVersion)
+	return pdb.ExecContext(ctx, createNamespaceQuery, partitionID, row.ID, row.Name, row.IsGlobal, row.Data, row.DataEncoding, row.NotificationVersion)
 }
 
 // UpdateNamespace updates a single row in namespaces table
@@ -78,7 +78,7 @@ func (pdb *db) UpdateNamespace(
 	ctx context.Context,
 	row *sqlplugin.NamespaceRow,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx, updateNamespaceQuery, row.Name, row.Data, row.DataEncoding, row.IsGlobal, row.NotificationVersion, row.ID)
+	return pdb.ExecContext(ctx, updateNamespaceQuery, row.Name, row.Data, row.DataEncoding, row.IsGlobal, row.NotificationVersion, row.ID)
 }
 
 // SelectFromNamespace reads one or more rows from namespaces table
@@ -86,17 +86,21 @@ func (pdb *db) SelectFromNamespace(
 	ctx context.Context,
 	filter sqlplugin.NamespaceFilter,
 ) ([]sqlplugin.NamespaceRow, error) {
+	var res []sqlplugin.NamespaceRow
+	var err error
 	switch {
 	case filter.ID != nil || filter.Name != nil:
 		if filter.ID != nil && filter.Name != nil {
 			return nil, serviceerror.NewInternal("only ID or name filter can be specified for selection")
 		}
-		return pdb.selectFromNamespace(ctx, filter)
+		res, err = pdb.selectFromNamespace(ctx, filter)
 	case filter.PageSize != nil && *filter.PageSize > 0:
-		return pdb.selectAllFromNamespace(ctx, filter)
+		res, err = pdb.selectAllFromNamespace(ctx, filter)
 	default:
 		return nil, errMissingArgs
 	}
+
+	return res, err
 }
 
 func (pdb *db) selectFromNamespace(
@@ -107,14 +111,14 @@ func (pdb *db) selectFromNamespace(
 	var row sqlplugin.NamespaceRow
 	switch {
 	case filter.ID != nil:
-		err = pdb.conn.GetContext(ctx,
+		err = pdb.GetContext(ctx,
 			&row,
 			getNamespaceByIDQuery,
 			partitionID,
 			*filter.ID,
 		)
 	case filter.Name != nil:
-		err = pdb.conn.GetContext(ctx,
+		err = pdb.GetContext(ctx,
 			&row,
 			getNamespaceByNameQuery,
 			partitionID,
@@ -135,7 +139,7 @@ func (pdb *db) selectAllFromNamespace(
 	var rows []sqlplugin.NamespaceRow
 	switch {
 	case filter.GreaterThanID != nil:
-		err = pdb.conn.SelectContext(ctx,
+		err = pdb.SelectContext(ctx,
 			&rows,
 			listNamespacesRangeQuery,
 			partitionID,
@@ -143,7 +147,7 @@ func (pdb *db) selectAllFromNamespace(
 			*filter.PageSize,
 		)
 	default:
-		err = pdb.conn.SelectContext(ctx,
+		err = pdb.SelectContext(ctx,
 			&rows,
 			listNamespacesQuery,
 			partitionID,
@@ -162,13 +166,13 @@ func (pdb *db) DeleteFromNamespace(
 	var result sql.Result
 	switch {
 	case filter.ID != nil:
-		result, err = pdb.conn.ExecContext(ctx,
+		result, err = pdb.ExecContext(ctx,
 			deleteNamespaceByIDQuery,
 			partitionID,
 			filter.ID,
 		)
 	default:
-		result, err = pdb.conn.ExecContext(ctx,
+		result, err = pdb.ExecContext(ctx,
 			deleteNamespaceByNameQuery,
 			partitionID,
 			filter.Name,
@@ -182,7 +186,11 @@ func (pdb *db) LockNamespaceMetadata(
 	ctx context.Context,
 ) (*sqlplugin.NamespaceMetadataRow, error) {
 	var row sqlplugin.NamespaceMetadataRow
-	err := pdb.conn.GetContext(ctx,
+	if pdb.tx == nil {
+		panic("cannot call LockNamespaceMetadata unless in a transaction")
+	}
+
+	err := pdb.GetContext(ctx,
 		&row.NotificationVersion,
 		lockNamespaceMetadataQuery,
 		partitionID,
@@ -198,7 +206,7 @@ func (pdb *db) SelectFromNamespaceMetadata(
 	ctx context.Context,
 ) (*sqlplugin.NamespaceMetadataRow, error) {
 	var row sqlplugin.NamespaceMetadataRow
-	err := pdb.conn.GetContext(ctx,
+	err := pdb.GetContext(ctx,
 		&row.NotificationVersion,
 		getNamespaceMetadataQuery,
 		partitionID,
@@ -211,7 +219,7 @@ func (pdb *db) UpdateNamespaceMetadata(
 	ctx context.Context,
 	row *sqlplugin.NamespaceMetadataRow,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		updateNamespaceMetadataQuery,
 		row.NotificationVersion+1,
 		row.NotificationVersion,

--- a/common/persistence/sql/sqlplugin/postgresql/namespace.go
+++ b/common/persistence/sql/sqlplugin/postgresql/namespace.go
@@ -186,9 +186,6 @@ func (pdb *db) LockNamespaceMetadata(
 	ctx context.Context,
 ) (*sqlplugin.NamespaceMetadataRow, error) {
 	var row sqlplugin.NamespaceMetadataRow
-	if pdb.tx == nil {
-		panic("cannot call LockNamespaceMetadata unless in a transaction")
-	}
 
 	err := pdb.GetContext(ctx,
 		&row.NotificationVersion,

--- a/common/persistence/sql/sqlplugin/postgresql/nexus_endpoints.go
+++ b/common/persistence/sql/sqlplugin/postgresql/nexus_endpoints.go
@@ -43,21 +43,21 @@ const (
 )
 
 func (pdb *db) InitializeNexusEndpointsTableVersion(ctx context.Context) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx, createEndpointsTableVersionQry)
+	return pdb.ExecContext(ctx, createEndpointsTableVersionQry)
 }
 
 func (pdb *db) IncrementNexusEndpointsTableVersion(
 	ctx context.Context,
 	lastKnownTableVersion int64,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx, incrementEndpointsTableVersionQry, lastKnownTableVersion+1, lastKnownTableVersion)
+	return pdb.ExecContext(ctx, incrementEndpointsTableVersionQry, lastKnownTableVersion+1, lastKnownTableVersion)
 }
 
 func (pdb *db) GetNexusEndpointsTableVersion(
 	ctx context.Context,
 ) (int64, error) {
 	var version int64
-	err := pdb.conn.GetContext(ctx, &version, getEndpointsTableVersionQry)
+	err := pdb.GetContext(ctx, &version, getEndpointsTableVersionQry)
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil
 	}
@@ -68,7 +68,7 @@ func (pdb *db) InsertIntoNexusEndpoints(
 	ctx context.Context,
 	row *sqlplugin.NexusEndpointsRow,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(
+	return pdb.ExecContext(
 		ctx,
 		createEndpointQry,
 		row.ID,
@@ -80,7 +80,7 @@ func (pdb *db) UpdateNexusEndpoint(
 	ctx context.Context,
 	row *sqlplugin.NexusEndpointsRow,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(
+	return pdb.ExecContext(
 		ctx,
 		updateEndpointQry,
 		row.Data,
@@ -94,7 +94,7 @@ func (pdb *db) DeleteFromNexusEndpoints(
 	ctx context.Context,
 	id []byte,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx, deleteEndpointQry, id)
+	return pdb.ExecContext(ctx, deleteEndpointQry, id)
 }
 
 func (pdb *db) GetNexusEndpointByID(
@@ -102,7 +102,7 @@ func (pdb *db) GetNexusEndpointByID(
 	id []byte,
 ) (*sqlplugin.NexusEndpointsRow, error) {
 	var row sqlplugin.NexusEndpointsRow
-	err := pdb.conn.GetContext(ctx, &row, getEndpointByIdQry, id)
+	err := pdb.GetContext(ctx, &row, getEndpointByIdQry, id)
 	return &row, err
 }
 
@@ -111,6 +111,6 @@ func (pdb *db) ListNexusEndpoints(
 	request *sqlplugin.ListNexusEndpointsRequest,
 ) ([]sqlplugin.NexusEndpointsRow, error) {
 	var rows []sqlplugin.NexusEndpointsRow
-	err := pdb.conn.SelectContext(ctx, &rows, getEndpointsQry, request.LastID, request.Limit)
+	err := pdb.SelectContext(ctx, &rows, getEndpointsQry, request.LastID, request.Limit)
 	return rows, err
 }

--- a/common/persistence/sql/sqlplugin/postgresql/plugin.go
+++ b/common/persistence/sql/sqlplugin/postgresql/plugin.go
@@ -32,6 +32,8 @@ import (
 	"go.temporal.io/api/serviceerror"
 
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/sql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql/driver"
@@ -69,12 +71,15 @@ func (d *plugin) CreateDB(
 	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
+	logger log.Logger,
+	metrics metrics.Handler,
 ) (sqlplugin.DB, error) {
-	conn, err := d.createDBConnection(cfg, r)
-	if err != nil {
-		return nil, err
+	connect := func() (*sqlx.DB, error) {
+		return d.createDBConnection(cfg, r)
 	}
-	db := newDB(dbKind, cfg.DatabaseName, d.d, conn, nil)
+	needsRefresh := d.d.IsConnNeedsRefreshError
+	handle := sqlplugin.NewDatabaseHandle(connect, needsRefresh, logger, metrics)
+	db := newDB(dbKind, cfg.DatabaseName, d.d, handle, nil)
 	return db, nil
 }
 
@@ -83,12 +88,15 @@ func (d *plugin) CreateAdminDB(
 	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
+	logger log.Logger,
+	metrics metrics.Handler,
 ) (sqlplugin.AdminDB, error) {
-	conn, err := d.createDBConnection(cfg, r)
-	if err != nil {
-		return nil, err
+	connect := func() (*sqlx.DB, error) {
+		return d.createDBConnection(cfg, r)
 	}
-	db := newDB(dbKind, cfg.DatabaseName, d.d, conn, nil)
+	needsRefresh := d.d.IsConnNeedsRefreshError
+	handle := sqlplugin.NewDatabaseHandle(connect, needsRefresh, logger, metrics)
+	db := newDB(dbKind, cfg.DatabaseName, d.d, handle, nil)
 	return db, nil
 }
 

--- a/common/persistence/sql/sqlplugin/postgresql/plugin.go
+++ b/common/persistence/sql/sqlplugin/postgresql/plugin.go
@@ -72,13 +72,13 @@ func (d *plugin) CreateDB(
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
 	logger log.Logger,
-	metrics metrics.Handler,
+	metricsHandler metrics.Handler,
 ) (sqlplugin.DB, error) {
 	connect := func() (*sqlx.DB, error) {
 		return d.createDBConnection(cfg, r)
 	}
 	needsRefresh := d.d.IsConnNeedsRefreshError
-	handle := sqlplugin.NewDatabaseHandle(connect, needsRefresh, logger, metrics)
+	handle := sqlplugin.NewDatabaseHandle(connect, needsRefresh, logger, metricsHandler)
 	db := newDB(dbKind, cfg.DatabaseName, d.d, handle, nil)
 	return db, nil
 }
@@ -89,13 +89,13 @@ func (d *plugin) CreateAdminDB(
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
 	logger log.Logger,
-	metrics metrics.Handler,
+	metricsHandler metrics.Handler,
 ) (sqlplugin.AdminDB, error) {
 	connect := func() (*sqlx.DB, error) {
 		return d.createDBConnection(cfg, r)
 	}
 	needsRefresh := d.d.IsConnNeedsRefreshError
-	handle := sqlplugin.NewDatabaseHandle(connect, needsRefresh, logger, metrics)
+	handle := sqlplugin.NewDatabaseHandle(connect, needsRefresh, logger, metricsHandler)
 	db := newDB(dbKind, cfg.DatabaseName, d.d, handle, nil)
 	return db, nil
 }

--- a/common/persistence/sql/sqlplugin/postgresql/queue.go
+++ b/common/persistence/sql/sqlplugin/postgresql/queue.go
@@ -52,7 +52,7 @@ func (pdb *db) InsertIntoMessages(
 	ctx context.Context,
 	row []sqlplugin.QueueMessageRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		templateEnqueueMessageQuery,
 		row,
 	)
@@ -63,7 +63,7 @@ func (pdb *db) SelectFromMessages(
 	filter sqlplugin.QueueMessagesFilter,
 ) ([]sqlplugin.QueueMessageRow, error) {
 	var rows []sqlplugin.QueueMessageRow
-	err := pdb.conn.SelectContext(ctx,
+	err := pdb.SelectContext(ctx,
 		&rows,
 		templateGetMessageQuery,
 		filter.QueueType,
@@ -77,7 +77,7 @@ func (pdb *db) RangeSelectFromMessages(
 	filter sqlplugin.QueueMessagesRangeFilter,
 ) ([]sqlplugin.QueueMessageRow, error) {
 	var rows []sqlplugin.QueueMessageRow
-	err := pdb.conn.SelectContext(ctx,
+	err := pdb.SelectContext(ctx,
 		&rows,
 		templateGetMessagesQuery,
 		filter.QueueType,
@@ -93,7 +93,7 @@ func (pdb *db) DeleteFromMessages(
 	ctx context.Context,
 	filter sqlplugin.QueueMessagesFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		templateDeleteMessageQuery,
 		filter.QueueType,
 		filter.MessageID,
@@ -105,7 +105,7 @@ func (pdb *db) RangeDeleteFromMessages(
 	ctx context.Context,
 	filter sqlplugin.QueueMessagesRangeFilter,
 ) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		templateRangeDeleteMessagesQuery,
 		filter.QueueType,
 		filter.MinMessageID,
@@ -119,7 +119,7 @@ func (pdb *db) GetLastEnqueuedMessageIDForUpdate(
 	queueType persistence.QueueType,
 ) (int64, error) {
 	var lastMessageID int64
-	err := pdb.conn.GetContext(ctx,
+	err := pdb.GetContext(ctx,
 		&lastMessageID,
 		templateGetLastMessageIDQuery,
 		queueType,
@@ -131,7 +131,7 @@ func (pdb *db) InsertIntoQueueMetadata(
 	ctx context.Context,
 	row *sqlplugin.QueueMetadataRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		templateCreateQueueMetadataQuery,
 		row,
 	)
@@ -141,7 +141,7 @@ func (pdb *db) UpdateQueueMetadata(
 	ctx context.Context,
 	row *sqlplugin.QueueMetadataRow,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		templateUpdateQueueMetadataQuery,
 		row,
 	)
@@ -152,7 +152,7 @@ func (pdb *db) SelectFromQueueMetadata(
 	filter sqlplugin.QueueMetadataFilter,
 ) (*sqlplugin.QueueMetadataRow, error) {
 	var row sqlplugin.QueueMetadataRow
-	err := pdb.conn.GetContext(ctx,
+	err := pdb.GetContext(ctx,
 		&row,
 		templateGetQueueMetadataQuery,
 		filter.QueueType,
@@ -168,7 +168,7 @@ func (pdb *db) LockQueueMetadata(
 	filter sqlplugin.QueueMetadataFilter,
 ) (*sqlplugin.QueueMetadataRow, error) {
 	var row sqlplugin.QueueMetadataRow
-	err := pdb.conn.GetContext(ctx,
+	err := pdb.GetContext(ctx,
 		&row,
 		templateLockQueueMetadataQuery,
 		filter.QueueType,

--- a/common/persistence/sql/sqlplugin/postgresql/queue_v2.go
+++ b/common/persistence/sql/sqlplugin/postgresql/queue_v2.go
@@ -46,14 +46,14 @@ const (
 )
 
 func (pdb *db) InsertIntoQueueV2Metadata(ctx context.Context, row *sqlplugin.QueueV2MetadataRow) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		templateCreateQueueMetadataQueryV2,
 		row,
 	)
 }
 
 func (pdb *db) UpdateQueueV2Metadata(ctx context.Context, row *sqlplugin.QueueV2MetadataRow) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		templateUpdateQueueMetadataQueryV2,
 		row,
 	)
@@ -61,7 +61,7 @@ func (pdb *db) UpdateQueueV2Metadata(ctx context.Context, row *sqlplugin.QueueV2
 
 func (pdb *db) SelectFromQueueV2Metadata(ctx context.Context, filter sqlplugin.QueueV2MetadataFilter) (*sqlplugin.QueueV2MetadataRow, error) {
 	var row sqlplugin.QueueV2MetadataRow
-	err := pdb.conn.GetContext(ctx,
+	err := pdb.GetContext(ctx,
 		&row,
 		templateGetQueueMetadataQueryV2,
 		filter.QueueType,
@@ -75,7 +75,7 @@ func (pdb *db) SelectFromQueueV2Metadata(ctx context.Context, filter sqlplugin.Q
 
 func (pdb *db) SelectFromQueueV2MetadataForUpdate(ctx context.Context, filter sqlplugin.QueueV2MetadataFilter) (*sqlplugin.QueueV2MetadataRow, error) {
 	var row sqlplugin.QueueV2MetadataRow
-	err := pdb.conn.GetContext(ctx,
+	err := pdb.GetContext(ctx,
 		&row,
 		templateGetQueueMetadataQueryV2ForUpdate,
 		filter.QueueType,
@@ -89,7 +89,7 @@ func (pdb *db) SelectFromQueueV2MetadataForUpdate(ctx context.Context, filter sq
 
 func (pdb *db) SelectNameFromQueueV2Metadata(ctx context.Context, filter sqlplugin.QueueV2MetadataTypeFilter) ([]sqlplugin.QueueV2MetadataRow, error) {
 	var rows []sqlplugin.QueueV2MetadataRow
-	err := pdb.conn.SelectContext(ctx,
+	err := pdb.SelectContext(ctx,
 		&rows,
 		templateGetNameFromQueueMetadataV2,
 		filter.QueueType,
@@ -103,7 +103,7 @@ func (pdb *db) SelectNameFromQueueV2Metadata(ctx context.Context, filter sqlplug
 }
 
 func (pdb *db) InsertIntoQueueV2Messages(ctx context.Context, row []sqlplugin.QueueV2MessageRow) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx,
+	return pdb.NamedExecContext(ctx,
 		templateEnqueueMessageQueryV2,
 		row,
 	)
@@ -111,7 +111,7 @@ func (pdb *db) InsertIntoQueueV2Messages(ctx context.Context, row []sqlplugin.Qu
 
 func (pdb *db) RangeSelectFromQueueV2Messages(ctx context.Context, filter sqlplugin.QueueV2MessagesFilter) ([]sqlplugin.QueueV2MessageRow, error) {
 	var rows []sqlplugin.QueueV2MessageRow
-	err := pdb.conn.SelectContext(ctx,
+	err := pdb.SelectContext(ctx,
 		&rows,
 		templateGetMessagesQueryV2,
 		filter.QueueType,
@@ -124,7 +124,7 @@ func (pdb *db) RangeSelectFromQueueV2Messages(ctx context.Context, filter sqlplu
 }
 
 func (pdb *db) RangeDeleteFromQueueV2Messages(ctx context.Context, filter sqlplugin.QueueV2MessagesFilter) (sql.Result, error) {
-	return pdb.conn.ExecContext(ctx,
+	return pdb.ExecContext(ctx,
 		templateRangeDeleteMessagesQueryV2,
 		filter.QueueType,
 		filter.QueueName,
@@ -136,7 +136,7 @@ func (pdb *db) RangeDeleteFromQueueV2Messages(ctx context.Context, filter sqlplu
 
 func (pdb *db) GetLastEnqueuedMessageIDForUpdateV2(ctx context.Context, filter sqlplugin.QueueV2Filter) (int64, error) {
 	var lastMessageID int64
-	err := pdb.conn.GetContext(ctx,
+	err := pdb.GetContext(ctx,
 		&lastMessageID,
 		templateGetLastMessageIDQueryV2,
 		filter.QueueType,

--- a/common/persistence/sql/sqlplugin/postgresql/shard.go
+++ b/common/persistence/sql/sqlplugin/postgresql/shard.go
@@ -97,9 +97,6 @@ func (pdb *db) ReadLockShards(
 	ctx context.Context,
 	filter sqlplugin.ShardsFilter,
 ) (int64, error) {
-	if pdb.tx == nil {
-		panic("cannot acquire shard read lock without a transaction")
-	}
 	var rangeID int64
 	err := pdb.GetContext(ctx,
 		&rangeID,
@@ -115,9 +112,6 @@ func (pdb *db) WriteLockShards(
 	filter sqlplugin.ShardsFilter,
 ) (int64, error) {
 	var rangeID int64
-	if pdb.tx == nil {
-		panic("cannot acquire shard write lock without a transaction")
-	}
 	err := pdb.GetContext(ctx,
 		&rangeID,
 		lockShardQry,

--- a/common/persistence/sql/sqlplugin/postgresql/visibility.go
+++ b/common/persistence/sql/sqlplugin/postgresql/visibility.go
@@ -114,9 +114,13 @@ func (pdb *db) SelectFromVisibility(
 	}
 
 	// Rebind will replace default placeholder `?` with the right placeholder for PostgreSQL.
-	filter.Query = pdb.DB().Rebind(filter.Query)
+	db, err := pdb.handle.DB()
+	if err != nil {
+		return nil, err
+	}
+	filter.Query = db.Rebind(filter.Query)
 	var rows []sqlplugin.VisibilityRow
-	err := pdb.SelectContext(ctx, &rows, filter.Query, filter.QueryArgs...)
+	err = db.SelectContext(ctx, &rows, filter.Query, filter.QueryArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +159,7 @@ func (pdb *db) CountFromVisibility(
 	filter sqlplugin.VisibilitySelectFilter,
 ) (int64, error) {
 	var count int64
-	filter.Query = pdb.DB().Rebind(filter.Query)
+	filter.Query = pdb.Rebind(filter.Query)
 	err := pdb.GetContext(ctx, &count, filter.Query, filter.QueryArgs...)
 	if err != nil {
 		return 0, err
@@ -167,7 +171,7 @@ func (pdb *db) CountGroupByFromVisibility(
 	ctx context.Context,
 	filter sqlplugin.VisibilitySelectFilter,
 ) ([]sqlplugin.VisibilityCountRow, error) {
-	filter.Query = pdb.DB().Rebind(filter.Query)
+	filter.Query = pdb.Rebind(filter.Query)
 	rows, err := pdb.QueryContext(ctx, filter.Query, filter.QueryArgs...)
 	if err != nil {
 		return nil, err

--- a/common/persistence/sql/sqlplugin/postgresql/visibility.go
+++ b/common/persistence/sql/sqlplugin/postgresql/visibility.go
@@ -80,7 +80,7 @@ func (pdb *db) InsertIntoVisibility(
 	row *sqlplugin.VisibilityRow,
 ) (sql.Result, error) {
 	finalRow := pdb.prepareRowForDB(row)
-	return pdb.conn.NamedExecContext(ctx, templateInsertWorkflowExecution, finalRow)
+	return pdb.NamedExecContext(ctx, templateInsertWorkflowExecution, finalRow)
 }
 
 // ReplaceIntoVisibility replaces an existing row if it exist or creates a new row in visibility table
@@ -89,7 +89,7 @@ func (pdb *db) ReplaceIntoVisibility(
 	row *sqlplugin.VisibilityRow,
 ) (sql.Result, error) {
 	finalRow := pdb.prepareRowForDB(row)
-	return pdb.conn.NamedExecContext(ctx, templateUpsertWorkflowExecution, finalRow)
+	return pdb.NamedExecContext(ctx, templateUpsertWorkflowExecution, finalRow)
 }
 
 // DeleteFromVisibility deletes a row from visibility table if it exist
@@ -97,7 +97,7 @@ func (pdb *db) DeleteFromVisibility(
 	ctx context.Context,
 	filter sqlplugin.VisibilityDeleteFilter,
 ) (sql.Result, error) {
-	return pdb.conn.NamedExecContext(ctx, templateDeleteWorkflowExecution_v12, filter)
+	return pdb.NamedExecContext(ctx, templateDeleteWorkflowExecution_v12, filter)
 }
 
 // SelectFromVisibility reads one or more rows from visibility table
@@ -114,9 +114,9 @@ func (pdb *db) SelectFromVisibility(
 	}
 
 	// Rebind will replace default placeholder `?` with the right placeholder for PostgreSQL.
-	filter.Query = pdb.db.Rebind(filter.Query)
+	filter.Query = pdb.DB().Rebind(filter.Query)
 	var rows []sqlplugin.VisibilityRow
-	err := pdb.conn.SelectContext(ctx, &rows, filter.Query, filter.QueryArgs...)
+	err := pdb.SelectContext(ctx, &rows, filter.Query, filter.QueryArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (pdb *db) GetFromVisibility(
 	filter sqlplugin.VisibilityGetFilter,
 ) (*sqlplugin.VisibilityRow, error) {
 	var row sqlplugin.VisibilityRow
-	stmt, err := pdb.conn.PrepareNamedContext(ctx, templateGetWorkflowExecution_v12)
+	stmt, err := pdb.PrepareNamedContext(ctx, templateGetWorkflowExecution_v12)
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +155,8 @@ func (pdb *db) CountFromVisibility(
 	filter sqlplugin.VisibilitySelectFilter,
 ) (int64, error) {
 	var count int64
-	filter.Query = pdb.db.Rebind(filter.Query)
-	err := pdb.conn.GetContext(ctx, &count, filter.Query, filter.QueryArgs...)
+	filter.Query = pdb.DB().Rebind(filter.Query)
+	err := pdb.GetContext(ctx, &count, filter.Query, filter.QueryArgs...)
 	if err != nil {
 		return 0, err
 	}
@@ -167,8 +167,8 @@ func (pdb *db) CountGroupByFromVisibility(
 	ctx context.Context,
 	filter sqlplugin.VisibilitySelectFilter,
 ) ([]sqlplugin.VisibilityCountRow, error) {
-	filter.Query = pdb.db.Rebind(filter.Query)
-	rows, err := pdb.db.QueryContext(ctx, filter.Query, filter.QueryArgs...)
+	filter.Query = pdb.DB().Rebind(filter.Query)
+	rows, err := pdb.QueryContext(ctx, filter.Query, filter.QueryArgs...)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/sql/sqlplugin/sqlite/plugin.go
+++ b/common/persistence/sql/sqlplugin/sqlite/plugin.go
@@ -37,6 +37,8 @@ import (
 	"golang.org/x/exp/maps"
 
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/sql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/resolver"
@@ -77,6 +79,8 @@ func (p *plugin) CreateDB(
 	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
+	_ log.Logger,
+	_ metrics.Handler,
 ) (sqlplugin.DB, error) {
 	conn, err := p.connPool.Allocate(cfg, r, p.createDBConnection)
 	if err != nil {
@@ -94,6 +98,8 @@ func (p *plugin) CreateAdminDB(
 	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
+	_ log.Logger,
+	_ metrics.Handler,
 ) (sqlplugin.AdminDB, error) {
 	conn, err := p.connPool.Allocate(cfg, r, p.createDBConnection)
 	if err != nil {

--- a/common/persistence/sql/sqlplugin/tests/history_execution.go
+++ b/common/persistence/sql/sqlplugin/tests/history_execution.go
@@ -41,7 +41,7 @@ type (
 		suite.Suite
 		*require.Assertions
 
-		store sqlplugin.HistoryExecution
+		store sqlplugin.DB
 	}
 )
 
@@ -59,7 +59,7 @@ var (
 
 func NewHistoryExecutionSuite(
 	t *testing.T,
-	store sqlplugin.HistoryExecution,
+	store sqlplugin.DB,
 ) *historyExecutionSuite {
 	return &historyExecutionSuite{
 		Assertions: require.New(t),
@@ -285,16 +285,19 @@ func (s *historyExecutionSuite) TestReadLock() {
 	s.NoError(err)
 	s.Equal(1, int(rowsAffected))
 
+	tx, err := s.store.BeginTx(newExecutionContext())
+	s.NoError(err)
 	filter := sqlplugin.ExecutionsFilter{
 		ShardID:     shardID,
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}
-	rowDBVersion, rowNextEventID, err := s.store.ReadLockExecutions(newExecutionContext(), filter)
+	rowDBVersion, rowNextEventID, err := tx.ReadLockExecutions(newExecutionContext(), filter)
 	s.NoError(err)
 	s.Equal(execution.DBRecordVersion, rowDBVersion)
 	s.Equal(execution.NextEventID, rowNextEventID)
+	s.NoError(tx.Commit())
 }
 
 func (s *historyExecutionSuite) TestWriteLock() {
@@ -312,16 +315,19 @@ func (s *historyExecutionSuite) TestWriteLock() {
 	s.NoError(err)
 	s.Equal(1, int(rowsAffected))
 
+	tx, err := s.store.BeginTx(newExecutionContext())
+	s.NoError(err)
 	filter := sqlplugin.ExecutionsFilter{
 		ShardID:     shardID,
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}
-	rowDBVersion, rowNextEventID, err := s.store.WriteLockExecutions(newExecutionContext(), filter)
+	rowDBVersion, rowNextEventID, err := tx.WriteLockExecutions(newExecutionContext(), filter)
 	s.NoError(err)
 	s.Equal(execution.DBRecordVersion, rowDBVersion)
 	s.Equal(execution.NextEventID, rowNextEventID)
+	s.NoError(tx.Commit())
 }
 
 func (s *historyExecutionSuite) newRandomExecutionRow(

--- a/common/persistence/sql/sqlplugin/tests/history_shard.go
+++ b/common/persistence/sql/sqlplugin/tests/history_shard.go
@@ -40,7 +40,7 @@ type (
 		suite.Suite
 		*require.Assertions
 
-		store sqlplugin.HistoryShard
+		store sqlplugin.DB
 	}
 )
 
@@ -54,7 +54,7 @@ var (
 
 func NewHistoryShardSuite(
 	t *testing.T,
-	store sqlplugin.HistoryShard,
+	store sqlplugin.DB,
 ) *historyShardSuite {
 	return &historyShardSuite{
 		Assertions: require.New(t),
@@ -195,14 +195,15 @@ func (s *historyShardSuite) TestInsertReadLock() {
 	s.NoError(err)
 	s.Equal(1, int(rowsAffected))
 
-	// NOTE: lock without transaction is equivalent to select
-	//  this test only test the select functionality
+	tx, err := s.store.BeginTx(newExecutionContext())
+	s.NoError(err)
 	filter := sqlplugin.ShardsFilter{
 		ShardID: shardID,
 	}
-	shardRange, err := s.store.ReadLockShards(newExecutionContext(), filter)
+	shardRange, err := tx.ReadLockShards(newExecutionContext(), filter)
 	s.NoError(err)
 	s.Equal(rangeID, shardRange)
+	s.NoError(tx.Commit())
 }
 
 func (s *historyShardSuite) TestInsertWriteLock() {
@@ -216,14 +217,15 @@ func (s *historyShardSuite) TestInsertWriteLock() {
 	s.NoError(err)
 	s.Equal(1, int(rowsAffected))
 
-	// NOTE: lock without transaction is equivalent to select
-	//  this test only test the select functionality
+	tx, err := s.store.BeginTx(newExecutionContext())
+	s.NoError(err)
 	filter := sqlplugin.ShardsFilter{
 		ShardID: shardID,
 	}
-	shardRange, err := s.store.WriteLockShards(newExecutionContext(), filter)
+	shardRange, err := tx.WriteLockShards(newExecutionContext(), filter)
 	s.NoError(err)
 	s.Equal(rangeID, shardRange)
+	s.NoError(tx.Commit())
 }
 
 func (s *historyShardSuite) newRandomShardRow(

--- a/common/persistence/sql/sqlplugin/tests/namespace.go
+++ b/common/persistence/sql/sqlplugin/tests/namespace.go
@@ -51,13 +51,13 @@ type (
 		suite.Suite
 		*require.Assertions
 
-		store sqlplugin.Namespace
+		store sqlplugin.DB
 	}
 )
 
 func NewNamespaceSuite(
 	t *testing.T,
-	store sqlplugin.Namespace,
+	store sqlplugin.DB,
 ) *namespaceSuite {
 	return &namespaceSuite{
 		Assertions: require.New(t),
@@ -353,11 +353,12 @@ func (s *namespaceSuite) TestSelectLockMetadata() {
 	row, err := s.store.SelectFromNamespaceMetadata(newExecutionContext())
 	s.NoError(err)
 
-	// NOTE: lock without transaction is equivalent to select
-	//  this test only test the select functionality
-	metadata, err := s.store.LockNamespaceMetadata(newExecutionContext())
+	tx, err := s.store.BeginTx(newExecutionContext())
+	s.NoError(err)
+	metadata, err := tx.LockNamespaceMetadata(newExecutionContext())
 	s.NoError(err)
 	s.Equal(row, metadata)
+	s.NoError(tx.Commit())
 }
 
 func (s *namespaceSuite) TestSelectUpdateSelectMetadata_Success() {

--- a/common/persistence/sql/store.go
+++ b/common/persistence/sql/store.go
@@ -28,6 +28,8 @@ import (
 	"fmt"
 
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/resolver"
 )
@@ -50,6 +52,8 @@ func NewSQLDB(
 	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
+	logger log.Logger,
+	mh metrics.Handler,
 ) (sqlplugin.DB, error) {
 	plugin, ok := supportedPlugins[cfg.PluginName]
 
@@ -57,7 +61,7 @@ func NewSQLDB(
 		return nil, fmt.Errorf("not supported plugin %v, only supported: %v", cfg.PluginName, supportedPlugins)
 	}
 
-	return plugin.CreateDB(dbKind, cfg, r)
+	return plugin.CreateDB(dbKind, cfg, r, logger, mh)
 }
 
 // NewSQLAdminDB returns a AdminDB
@@ -65,11 +69,13 @@ func NewSQLAdminDB(
 	dbKind sqlplugin.DbKind,
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
+	logger log.Logger,
+	mh metrics.Handler,
 ) (sqlplugin.AdminDB, error) {
 	plugin, ok := supportedPlugins[cfg.PluginName]
 	if !ok {
 		return nil, fmt.Errorf("not supported plugin %v, only supported: %v", cfg.PluginName, supportedPlugins)
 	}
 
-	return plugin.CreateAdminDB(dbKind, cfg, r)
+	return plugin.CreateAdminDB(dbKind, cfg, r, logger, mh)
 }

--- a/common/persistence/sql/test_sql_persistence.go
+++ b/common/persistence/sql/test_sql_persistence.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/primitives"
@@ -138,7 +139,7 @@ func (s *TestCluster) CreateDatabase() {
 	var err error
 	err = backoff.ThrottleRetry(
 		func() error {
-			db, err = NewSQLAdminDB(sqlplugin.DbKindUnknown, &cfg2, resolver.NewNoopResolver())
+			db, err = NewSQLAdminDB(sqlplugin.DbKindUnknown, &cfg2, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 			return err
 		},
 		backoff.NewExponentialRetryPolicy(time.Second).WithExpirationInterval(time.Minute),
@@ -176,7 +177,7 @@ func (s *TestCluster) DropDatabase() {
 
 	// NOTE need to connect with empty name to drop the database
 	cfg2.DatabaseName = ""
-	db, err := NewSQLAdminDB(sqlplugin.DbKindUnknown, &cfg2, resolver.NewNoopResolver())
+	db, err := NewSQLAdminDB(sqlplugin.DbKindUnknown, &cfg2, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		panic(err)
 	}
@@ -203,7 +204,7 @@ func (s *TestCluster) LoadSchema(schemaFile string) {
 	var db sqlplugin.AdminDB
 	err = backoff.ThrottleRetry(
 		func() error {
-			db, err = NewSQLAdminDB(sqlplugin.DbKindUnknown, &s.cfg, resolver.NewNoopResolver())
+			db, err = NewSQLAdminDB(sqlplugin.DbKindUnknown, &s.cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 			return err
 		},
 		backoff.NewExponentialRetryPolicy(time.Second).WithExpirationInterval(time.Minute),

--- a/common/persistence/sql/version_checker.go
+++ b/common/persistence/sql/version_checker.go
@@ -26,6 +26,8 @@ package sql
 
 import (
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/resolver"
 )
@@ -73,7 +75,7 @@ func checkCompatibleVersion(
 	r resolver.ServiceResolver,
 	dbKind sqlplugin.DbKind,
 ) error {
-	db, err := NewSQLAdminDB(dbKind, cfg, r)
+	db, err := NewSQLAdminDB(dbKind, cfg, r, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		return err
 	}

--- a/common/persistence/tests/mysql_test.go
+++ b/common/persistence/tests/mysql_test.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
 	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
 	"go.temporal.io/server/common/persistence/serialization"
@@ -191,7 +193,7 @@ func TestMySQLNamespaceSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -208,7 +210,7 @@ func TestMySQLQueueMessageSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -225,7 +227,7 @@ func TestMySQLQueueMetadataSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -242,7 +244,7 @@ func TestMySQLMatchingTaskSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -259,7 +261,7 @@ func TestMySQLMatchingTaskQueueSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -276,7 +278,7 @@ func TestMySQLHistoryShardSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -293,7 +295,7 @@ func TestMySQLHistoryNodeSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -310,7 +312,7 @@ func TestMySQLHistoryTreeSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -327,7 +329,7 @@ func TestMySQLHistoryCurrentExecutionSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -344,7 +346,7 @@ func TestMySQLHistoryExecutionSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -361,7 +363,7 @@ func TestMySQLHistoryTransferTaskSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -378,7 +380,7 @@ func TestMySQLHistoryTimerTaskSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -395,7 +397,7 @@ func TestMySQLHistoryReplicationTaskSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -412,7 +414,7 @@ func TestMySQLHistoryVisibilityTaskSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -429,7 +431,7 @@ func TestMySQLHistoryReplicationDLQTaskSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -446,7 +448,7 @@ func TestMySQLHistoryExecutionBufferSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -463,7 +465,7 @@ func TestMySQLHistoryExecutionActivitySuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -480,7 +482,7 @@ func TestMySQLHistoryExecutionChildWorkflowSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -497,7 +499,7 @@ func TestMySQLHistoryExecutionTimerSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -514,7 +516,7 @@ func TestMySQLHistoryExecutionRequestCancelSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -531,7 +533,7 @@ func TestMySQLHistoryExecutionSignalSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -548,7 +550,7 @@ func TestMySQLHistoryExecutionSignalRequestSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -565,7 +567,7 @@ func TestMySQLVisibilitySuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(cfg)
 	SetupMySQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindVisibility, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindVisibility, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}

--- a/common/persistence/tests/persistence_connection_suite.go
+++ b/common/persistence/tests/persistence_connection_suite.go
@@ -35,6 +35,7 @@ import (
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/sql"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 )
 
 type (
@@ -95,6 +96,5 @@ func (s *connectionSuite) TestClosedConnectionError() {
 	})
 
 	s.Nil(resp)
-	s.Error(err)
-	s.ErrorContains(err, "closed")
+	s.ErrorContains(err, sqlplugin.DatabaseUnavailableError.Error())
 }

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
 	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
 	"go.temporal.io/server/common/persistence/serialization"
@@ -191,7 +193,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLNamespaceSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
 	}
@@ -208,7 +210,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLQueueMessageSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
 	}
@@ -225,7 +227,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLQueueMetadataSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
 	}
@@ -242,7 +244,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
 	}
@@ -259,7 +261,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskQueueSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
 	}
@@ -276,7 +278,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryShardSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -293,7 +295,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryNodeSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -310,7 +312,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryTreeSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -327,7 +329,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryCurrentExecutionSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -344,7 +346,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -361,7 +363,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryTransferTaskSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -378,7 +380,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryTimerTaskSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -395,7 +397,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryReplicationTaskSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -412,7 +414,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryVisibilityTaskSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -429,7 +431,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryReplicationDLQTaskSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -446,7 +448,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionBufferSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -463,7 +465,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionActivitySuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -480,7 +482,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionChildWorkflowSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -497,7 +499,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionTimerSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -514,7 +516,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionRequestCancelSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -531,7 +533,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSignalSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -548,7 +550,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSignalRequestSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
@@ -565,7 +567,7 @@ func (p *PostgreSQLSuite) TestPostgreSQLVisibilitySuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(cfg)
 	SetupPostgreSQLSchema(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindVisibility, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindVisibility, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
 	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
 	"go.temporal.io/server/common/persistence/serialization"
@@ -80,7 +81,7 @@ func NewSQLiteFileConfig() *config.SQL {
 }
 
 func SetupSQLiteDatabase(cfg *config.SQL) {
-	db, err := sql.NewSQLAdminDB(sqlplugin.DbKindUnknown, cfg, resolver.NewNoopResolver())
+	db, err := sql.NewSQLAdminDB(sqlplugin.DbKindUnknown, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		panic(fmt.Sprintf("unable to create SQLite admin DB: %v", err))
 	}
@@ -116,6 +117,7 @@ func TestSQLiteExecutionMutableStateStoreSuite(t *testing.T) {
 		resolver.NewNoopResolver(),
 		testSQLiteClusterName,
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	shardStore, err := factory.NewShardStore()
 	if err != nil {
@@ -148,6 +150,7 @@ func TestSQLiteExecutionMutableStateTaskStoreSuite(t *testing.T) {
 		resolver.NewNoopResolver(),
 		testSQLiteClusterName,
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	shardStore, err := factory.NewShardStore()
 	if err != nil {
@@ -179,6 +182,7 @@ func TestSQLiteHistoryStoreSuite(t *testing.T) {
 		resolver.NewNoopResolver(),
 		testSQLiteClusterName,
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	store, err := factory.NewExecutionStore()
 	if err != nil {
@@ -200,6 +204,7 @@ func TestSQLiteTaskQueueSuite(t *testing.T) {
 		resolver.NewNoopResolver(),
 		testSQLiteClusterName,
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	taskQueueStore, err := factory.NewTaskStore()
 	if err != nil {
@@ -221,6 +226,7 @@ func TestSQLiteTaskQueueTaskSuite(t *testing.T) {
 		resolver.NewNoopResolver(),
 		testSQLiteClusterName,
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	taskQueueStore, err := factory.NewTaskStore()
 	if err != nil {
@@ -246,6 +252,7 @@ func TestSQLiteFileExecutionMutableStateStoreSuite(t *testing.T) {
 		resolver.NewNoopResolver(),
 		testSQLiteClusterName,
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	shardStore, err := factory.NewShardStore()
 	if err != nil {
@@ -282,6 +289,7 @@ func TestSQLiteFileExecutionMutableStateTaskStoreSuite(t *testing.T) {
 		resolver.NewNoopResolver(),
 		testSQLiteClusterName,
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	shardStore, err := factory.NewShardStore()
 	if err != nil {
@@ -317,6 +325,7 @@ func TestSQLiteFileHistoryStoreSuite(t *testing.T) {
 		resolver.NewNoopResolver(),
 		testSQLiteClusterName,
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	store, err := factory.NewExecutionStore()
 	if err != nil {
@@ -342,6 +351,7 @@ func TestSQLiteFileTaskQueueSuite(t *testing.T) {
 		resolver.NewNoopResolver(),
 		testSQLiteClusterName,
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	taskQueueStore, err := factory.NewTaskStore()
 	if err != nil {
@@ -367,6 +377,7 @@ func TestSQLiteFileTaskQueueTaskSuite(t *testing.T) {
 		resolver.NewNoopResolver(),
 		testSQLiteClusterName,
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	taskQueueStore, err := factory.NewTaskStore()
 	if err != nil {
@@ -448,7 +459,7 @@ func TestSQLiteFileQueuePersistence(t *testing.T) {
 
 func TestSQLiteNamespaceSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -462,7 +473,7 @@ func TestSQLiteNamespaceSuite(t *testing.T) {
 
 func TestSQLiteQueueMessageSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -476,7 +487,7 @@ func TestSQLiteQueueMessageSuite(t *testing.T) {
 
 func TestSQLiteQueueMetadataSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -490,7 +501,7 @@ func TestSQLiteQueueMetadataSuite(t *testing.T) {
 
 func TestSQLiteMatchingTaskSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -504,7 +515,7 @@ func TestSQLiteMatchingTaskSuite(t *testing.T) {
 
 func TestSQLiteMatchingTaskQueueSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -518,7 +529,7 @@ func TestSQLiteMatchingTaskQueueSuite(t *testing.T) {
 
 func TestSQLiteHistoryShardSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -532,7 +543,7 @@ func TestSQLiteHistoryShardSuite(t *testing.T) {
 
 func TestSQLiteHistoryNodeSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -546,7 +557,7 @@ func TestSQLiteHistoryNodeSuite(t *testing.T) {
 
 func TestSQLiteHistoryTreeSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -560,7 +571,7 @@ func TestSQLiteHistoryTreeSuite(t *testing.T) {
 
 func TestSQLiteHistoryCurrentExecutionSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -574,7 +585,7 @@ func TestSQLiteHistoryCurrentExecutionSuite(t *testing.T) {
 
 func TestSQLiteHistoryExecutionSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -588,7 +599,7 @@ func TestSQLiteHistoryExecutionSuite(t *testing.T) {
 
 func TestSQLiteHistoryTransferTaskSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -602,7 +613,7 @@ func TestSQLiteHistoryTransferTaskSuite(t *testing.T) {
 
 func TestSQLiteHistoryTimerTaskSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -616,7 +627,7 @@ func TestSQLiteHistoryTimerTaskSuite(t *testing.T) {
 
 func TestSQLiteHistoryReplicationTaskSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -630,7 +641,7 @@ func TestSQLiteHistoryReplicationTaskSuite(t *testing.T) {
 
 func TestSQLiteHistoryVisibilityTaskSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -644,7 +655,7 @@ func TestSQLiteHistoryVisibilityTaskSuite(t *testing.T) {
 
 func TestSQLiteHistoryReplicationDLQTaskSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -658,7 +669,7 @@ func TestSQLiteHistoryReplicationDLQTaskSuite(t *testing.T) {
 
 func TestSQLiteHistoryExecutionBufferSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -672,7 +683,7 @@ func TestSQLiteHistoryExecutionBufferSuite(t *testing.T) {
 
 func TestSQLiteHistoryExecutionActivitySuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -686,7 +697,7 @@ func TestSQLiteHistoryExecutionActivitySuite(t *testing.T) {
 
 func TestSQLiteHistoryExecutionChildWorkflowSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -700,7 +711,7 @@ func TestSQLiteHistoryExecutionChildWorkflowSuite(t *testing.T) {
 
 func TestSQLiteHistoryExecutionTimerSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -714,7 +725,7 @@ func TestSQLiteHistoryExecutionTimerSuite(t *testing.T) {
 
 func TestSQLiteHistoryExecutionRequestCancelSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -728,7 +739,7 @@ func TestSQLiteHistoryExecutionRequestCancelSuite(t *testing.T) {
 
 func TestSQLiteHistoryExecutionSignalSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -742,7 +753,7 @@ func TestSQLiteHistoryExecutionSignalSuite(t *testing.T) {
 
 func TestSQLiteHistoryExecutionSignalRequestSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -756,7 +767,7 @@ func TestSQLiteHistoryExecutionSignalRequestSuite(t *testing.T) {
 
 func TestSQLiteVisibilitySuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
-	store, err := sql.NewSQLDB(sqlplugin.DbKindVisibility, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindVisibility, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -771,7 +782,7 @@ func TestSQLiteVisibilitySuite(t *testing.T) {
 func TestSQLiteFileNamespaceSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -784,7 +795,7 @@ func TestSQLiteFileNamespaceSuite(t *testing.T) {
 func TestSQLiteFileQueueMessageSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -797,7 +808,7 @@ func TestSQLiteFileQueueMessageSuite(t *testing.T) {
 func TestSQLiteFileQueueMetadataSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -810,7 +821,7 @@ func TestSQLiteFileQueueMetadataSuite(t *testing.T) {
 func TestSQLiteFileMatchingTaskSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -823,7 +834,7 @@ func TestSQLiteFileMatchingTaskSuite(t *testing.T) {
 func TestSQLiteFileMatchingTaskQueueSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -836,7 +847,7 @@ func TestSQLiteFileMatchingTaskQueueSuite(t *testing.T) {
 func TestSQLiteFileHistoryShardSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -849,7 +860,7 @@ func TestSQLiteFileHistoryShardSuite(t *testing.T) {
 func TestSQLiteFileHistoryNodeSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -862,7 +873,7 @@ func TestSQLiteFileHistoryNodeSuite(t *testing.T) {
 func TestSQLiteFileHistoryTreeSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -875,7 +886,7 @@ func TestSQLiteFileHistoryTreeSuite(t *testing.T) {
 func TestSQLiteFileHistoryCurrentExecutionSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -888,7 +899,7 @@ func TestSQLiteFileHistoryCurrentExecutionSuite(t *testing.T) {
 func TestSQLiteFileHistoryExecutionSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -901,7 +912,7 @@ func TestSQLiteFileHistoryExecutionSuite(t *testing.T) {
 func TestSQLiteFileHistoryTransferTaskSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -914,7 +925,7 @@ func TestSQLiteFileHistoryTransferTaskSuite(t *testing.T) {
 func TestSQLiteFileHistoryTimerTaskSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -927,7 +938,7 @@ func TestSQLiteFileHistoryTimerTaskSuite(t *testing.T) {
 func TestSQLiteFileHistoryReplicationTaskSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -940,7 +951,7 @@ func TestSQLiteFileHistoryReplicationTaskSuite(t *testing.T) {
 func TestSQLiteFileHistoryVisibilityTaskSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -953,7 +964,7 @@ func TestSQLiteFileHistoryVisibilityTaskSuite(t *testing.T) {
 func TestSQLiteFileHistoryReplicationDLQTaskSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -966,7 +977,7 @@ func TestSQLiteFileHistoryReplicationDLQTaskSuite(t *testing.T) {
 func TestSQLiteFileHistoryExecutionBufferSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -979,7 +990,7 @@ func TestSQLiteFileHistoryExecutionBufferSuite(t *testing.T) {
 func TestSQLiteFileHistoryExecutionActivitySuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -992,7 +1003,7 @@ func TestSQLiteFileHistoryExecutionActivitySuite(t *testing.T) {
 func TestSQLiteFileHistoryExecutionChildWorkflowSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -1005,7 +1016,7 @@ func TestSQLiteFileHistoryExecutionChildWorkflowSuite(t *testing.T) {
 func TestSQLiteFileHistoryExecutionTimerSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -1018,7 +1029,7 @@ func TestSQLiteFileHistoryExecutionTimerSuite(t *testing.T) {
 func TestSQLiteFileHistoryExecutionRequestCancelSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -1031,7 +1042,7 @@ func TestSQLiteFileHistoryExecutionRequestCancelSuite(t *testing.T) {
 func TestSQLiteFileHistoryExecutionSignalSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -1044,7 +1055,7 @@ func TestSQLiteFileHistoryExecutionSignalSuite(t *testing.T) {
 func TestSQLiteFileHistoryExecutionSignalRequestSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -1057,7 +1068,7 @@ func TestSQLiteFileHistoryExecutionSignalRequestSuite(t *testing.T) {
 func TestSQLiteFileVisibilitySuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	store, err := sql.NewSQLDB(sqlplugin.DbKindVisibility, cfg, resolver.NewNoopResolver())
+	store, err := sql.NewSQLDB(sqlplugin.DbKindVisibility, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create SQLite DB: %v", err)
 	}
@@ -1076,6 +1087,7 @@ func TestSQLiteQueueV2(t *testing.T) {
 		resolver.NewNoopResolver(),
 		testSQLiteClusterName,
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	t.Cleanup(func() {
 		factory.Close()
@@ -1093,6 +1105,7 @@ func TestSQLiteNexusEndpointPersistence(t *testing.T) {
 		resolver.NewNoopResolver(),
 		testSQLiteClusterName,
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	t.Cleanup(func() {
 		factory.Close()

--- a/common/persistence/visibility/factory.go
+++ b/common/persistence/visibility/factory.go
@@ -260,6 +260,7 @@ func newVisibilityStoreFromDataStoreConfig(
 			searchAttributesProvider,
 			searchAttributesMapperProvider,
 			logger,
+			metricsHandler,
 		)
 	} else if dsConfig.Elasticsearch != nil {
 		visStore = newElasticsearchVisibilityStore(

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -38,6 +38,7 @@ import (
 
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	persistencesql "go.temporal.io/server/common/persistence/sql"
@@ -68,8 +69,9 @@ func NewSQLVisibilityStore(
 	searchAttributesProvider searchattribute.Provider,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
 	logger log.Logger,
+	metricsHandler metrics.Handler,
 ) (*VisibilityStore, error) {
-	refDbConn := persistencesql.NewRefCountedDBConn(sqlplugin.DbKindVisibility, &cfg, r)
+	refDbConn := persistencesql.NewRefCountedDBConn(sqlplugin.DbKindVisibility, &cfg, r, logger, metricsHandler)
 	db, err := refDbConn.Get()
 	if err != nil {
 		return nil, err

--- a/schema/sqlite/setup.go
+++ b/schema/sqlite/setup.go
@@ -36,6 +36,8 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/sql"
@@ -56,7 +58,7 @@ var (
 //
 // Note: this function may receive breaking changes or be removed in the future.
 func SetupSchema(cfg *config.SQL) error {
-	db, err := sql.NewSQLAdminDB(sqlplugin.DbKindUnknown, cfg, resolver.NewNoopResolver())
+	db, err := sql.NewSQLAdminDB(sqlplugin.DbKindUnknown, cfg, resolver.NewNoopResolver(), log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		return fmt.Errorf("unable to create SQLite admin DB: %w", err)
 	}
@@ -113,7 +115,7 @@ type NamespaceConfig struct {
 //
 // Note: this function may receive breaking changes or be removed in the future.
 func CreateNamespaces(cfg *config.SQL, namespaces ...*NamespaceConfig) error {
-	db, err := sql.NewSQLDB(sqlplugin.DbKindUnknown, cfg, resolver.NewNoopResolver())
+	db, err := sql.NewSQLDB(sqlplugin.DbKindUnknown, cfg, resolver.NewNoopResolver(), log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		return fmt.Errorf("unable to create SQLite admin DB: %w", err)
 	}

--- a/tools/sql/clitest/conn_tests.go
+++ b/tools/sql/clitest/conn_tests.go
@@ -117,5 +117,5 @@ func newTestConn(
 		Password:     testPassword,
 		PluginName:   pluginName,
 		DatabaseName: database,
-	})
+	}, log.NewTestLogger())
 }

--- a/tools/sql/conn.go
+++ b/tools/sql/conn.go
@@ -26,6 +26,8 @@ package sql
 
 import (
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/sql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/resolver"
@@ -45,8 +47,8 @@ const dbType = "sql"
 var _ schema.DB = (*Connection)(nil)
 
 // NewConnection creates a new connection to database
-func NewConnection(cfg *config.SQL) (*Connection, error) {
-	db, err := sql.NewSQLAdminDB(sqlplugin.DbKindUnknown, cfg, resolver.NewNoopResolver())
+func NewConnection(cfg *config.SQL, logger log.Logger) (*Connection, error) {
+	db, err := sql.NewSQLAdminDB(sqlplugin.DbKindUnknown, cfg, resolver.NewNoopResolver(), logger, metrics.NoopMetricsHandler)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -47,7 +47,7 @@ func setupSchema(cli *cli.Context, logger log.Logger) error {
 		logger.Error("Unable to read config.", tag.Error(schema.NewConfigError(err.Error())))
 		return err
 	}
-	conn, err := NewConnection(cfg)
+	conn, err := NewConnection(cfg, logger)
 	if err != nil {
 		logger.Error("Unable to connect to SQL database.", tag.Error(err))
 		return err
@@ -68,7 +68,7 @@ func updateSchema(cli *cli.Context, logger log.Logger) error {
 		logger.Error("Unable to read config.", tag.Error(schema.NewConfigError(err.Error())))
 		return err
 	}
-	conn, err := NewConnection(cfg)
+	conn, err := NewConnection(cfg, logger)
 	if err != nil {
 		logger.Error("Unable to connect to SQL database.", tag.Error(err))
 		return err
@@ -89,7 +89,7 @@ func createDatabase(cli *cli.Context, logger log.Logger) error {
 		return err
 	}
 	defaultDb := cli.String(schema.CLIOptDefaultDb)
-	err = DoCreateDatabase(cfg, defaultDb)
+	err = DoCreateDatabase(cfg, defaultDb, logger)
 	if err != nil {
 		logger.Error("Unable to create SQL database.", tag.Error(err))
 		return err
@@ -97,10 +97,10 @@ func createDatabase(cli *cli.Context, logger log.Logger) error {
 	return nil
 }
 
-func DoCreateDatabase(cfg *config.SQL, defaultDb string) error {
+func DoCreateDatabase(cfg *config.SQL, defaultDb string, logger log.Logger) error {
 	dbToCreate := cfg.DatabaseName
 	cfg.DatabaseName = defaultDb
-	conn, err := NewConnection(cfg)
+	conn, err := NewConnection(cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func dropDatabase(cli *cli.Context, logger log.Logger) error {
 		return err
 	}
 	defaultDb := cli.String(schema.CLIOptDefaultDb)
-	err = DoDropDatabase(cfg, defaultDb)
+	err = DoDropDatabase(cfg, defaultDb, logger)
 	if err != nil {
 		logger.Error("Unable to drop SQL database.", tag.Error(err))
 		return err
@@ -124,10 +124,10 @@ func dropDatabase(cli *cli.Context, logger log.Logger) error {
 	return nil
 }
 
-func DoDropDatabase(cfg *config.SQL, defaultDb string) error {
+func DoDropDatabase(cfg *config.SQL, defaultDb string, logger log.Logger) error {
 	dbToDrop := cfg.DatabaseName
 	cfg.DatabaseName = defaultDb
-	conn, err := NewConnection(cfg)
+	conn, err := NewConnection(cfg, logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What changed?

Both our PostgreSQL and MySQL database backends will now automatically reconnect to the database when certain errors occur: all errors chosen have been experienced when testing this behavior through an AWS Aurora RDS failover of either MySQL or PostgreSQL. 

For both backends we will reconnect when we see:
- `ECONNRESET`
- `ECONNABORTED`
- `ECONNREFUSED`
- `io.EOF`
- `io.ErrUnexpectedEOF`
- `database/sql/driver.ErrBadConn`

for postgres we will also reconnect on the following SQLStates:
- `25006` read-only transaction
- `57P03` cannot connect now
- `0A000` feature not supported, but ONLY when the message is `cannot set transaction read-write mode during recovery`

for mysql we will also reconnect when we see the following error codes:
- `1040` too many connections 
- `1792` read-only transaction (SQLstate `25006`)
- `1836` running in read-only mode

This logic is easily extensible should we discover more failure modes over time

## Why?

We've had multiple community reports of Temporal problems during RDS failover. One part of this is the fact that we wouldn't necessarily reconnect; we were at the whims of our chosen SQL abstraction's connection pooling logic.

## How did you test it?

I manually tested this functionality in the presence of repeated RDS failovers.
I'm manually testing the following combinations:
- [x] postgres12 plugin with pq driver
- [x] postgres12 plugin with pgx driver
- [x] mysql plugin

Automated testing will be added to our regular testing pipelines once our infrastructure friends have added the support I need (it's in progress)

## Potential risks

We're concerned there's a correctness issue in our PostgreSQL backend that's related to our behavior during an RDS failover. If we merge this before I figure out what's going on, we could hide the issue and make it harder to reproduce.

## Documentation
N/A

## Is hotfix candidate?
Yes?
