### PR TITLE
Fix panic in Nexus functional tests

### DIFF
--- a/service/history/hsm/tree.go
+++ b/service/history/hsm/tree.go
@@ -268,6 +268,10 @@ func (n *Node) AddChild(key Key, data any) (*Node, error) {
 	children, ok := n.persistence.Children[key.Type]
 	if !ok {
 		children = &persistencespb.StateMachineMap{MachinesById: make(map[string]*persistencespb.StateMachineNode)}
+		// Children may be nil if the map was empty and the proto message we serialized and deserialized.
+		if n.persistence.Children == nil {
+			n.persistence.Children = make(map[int32]*persistencespb.StateMachineMap, 1)
+		}
 		n.persistence.Children[key.Type] = children
 	}
 	children.MachinesById[key.ID] = node.persistence


### PR DESCRIPTION
## What changed?

Fixes a panic observed in functional tests:

```
    nexus_workflow_test.go:161: 
        	Error Trace:	/home/runner/work/temporal/temporal/tests/nexus_workflow_test.go:161
        	Error:      	Received unexpected error:
        	            	panic: Cache encountered dirty mutable state transaction
        	Test:       	TestClientFunctionalSuite/TestNexusOperationCancelation
```

I ran the tests in a loop with logging and found out the source.
Ran it again in a loop for a few minutes to verify the fix.