### PR TITLE
Fix prometheus warning message

### DIFF
--- a/service/history/api/recordworkflowtaskstarted/api.go
+++ b/service/history/api/recordworkflowtaskstarted/api.go
@@ -32,6 +32,8 @@ import (
 	querypb "go.temporal.io/api/query/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
@@ -50,7 +52,6 @@ import (
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
 	"go.temporal.io/server/service/history/workflow/update"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 //nolint:revive // cyclomatic complexity
@@ -195,7 +196,7 @@ func Invoke(
 		return nil, err
 	}
 
-	if dynamicconfig.AccessHistory(config.FrontendAccessHistoryFraction, shardContext.GetMetricsHandler().WithTags(metrics.OperationTag(metrics.HistoryHandleWorkflowTaskStartedTag))) {
+	if dynamicconfig.AccessHistory(config.FrontendAccessHistoryFraction, shardContext.GetMetricsHandler().WithTags(metrics.NamespaceTag(namespaceEntry.Name().String()), metrics.OperationTag(metrics.HistoryHandleWorkflowTaskStartedTag))) {
 		maxHistoryPageSize := int32(config.HistoryMaxPageSize(namespaceEntry.Name().String()))
 		err = setHistoryForRecordWfTaskStartedResp(
 			ctx,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix prometheus warning message by adding `namespace` tag.

```
{"level":"warn","ts":"2024-05-14T15:14:32.598-0700","msg":"error in prometheus reporter","error":"a previously registered descriptor with the same fully-qualified name as Desc{fqName: \"AccessHistoryNew\", help: \"AccessHistoryNew counter\", constLabels: {}, variableLabels: {operation,namespace,service_name}} has different label names or a different help string","logging-call-at":"config.go:432"}
```

Note: code will be removed very soon.

## Why?
<!-- Tell your future self why have you made these changes -->
Set of tags must be the same on the same metric. I hope it fixes #5897.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run it locally and checked logs with eyeballing.
