### PR TITLE
Made approximateBacklogCounter available via legacy API

### DIFF
--- a/service/matching/ack_manager_test.go
+++ b/service/matching/ack_manager_test.go
@@ -33,18 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAckManager_AddingTasksIncreasesBacklogCounter(t *testing.T) {
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-	backlogMgr := newBacklogMgr(controller)
-
-	t.Parallel()
-	backlogMgr.taskAckManager.addTask(1)
-	require.Equal(t, backlogMgr.taskAckManager.getBacklogCountHint(), int64(1))
-	backlogMgr.taskAckManager.addTask(12)
-	require.Equal(t, backlogMgr.taskAckManager.getBacklogCountHint(), int64(2))
-}
-
 func TestAckManager_CompleteTaskMovesAckLevelUpToGap(t *testing.T) {
 	t.Parallel()
 	controller := gomock.NewController(t)

--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -67,7 +67,6 @@ type (
 		Stop()
 		WaitUntilInitialized(context.Context) error
 		SpoolTask(taskInfo *persistencespb.TaskInfo) error
-		BacklogCountHint() int64
 		BacklogStatus() *taskqueuepb.TaskQueueStatus
 		String() string
 	}
@@ -194,10 +193,6 @@ func (c *backlogManagerImpl) processSpooledTask(
 	task *internalTask,
 ) error {
 	return c.pqMgr.ProcessSpooledTask(ctx, task)
-}
-
-func (c *backlogManagerImpl) BacklogCountHint() int64 {
-	return c.taskAckManager.getBacklogCountHint()
 }
 
 func (c *backlogManagerImpl) BacklogStatus() *taskqueuepb.TaskQueueStatus {

--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -205,7 +205,7 @@ func (c *backlogManagerImpl) BacklogStatus() *taskqueuepb.TaskQueueStatus {
 	return &taskqueuepb.TaskQueueStatus{
 		ReadLevel:        c.taskAckManager.getReadLevel(),
 		AckLevel:         c.taskAckManager.getAckLevel(),
-		BacklogCountHint: c.BacklogCountHint(),
+		BacklogCountHint: c.db.getApproximateBacklogCount(), // replacing with a more accurate value of the backlog counter
 		TaskIdBlock: &taskqueuepb.TaskIdBlock{
 			StartId: taskIDBlock.start,
 			EndId:   taskIDBlock.end,

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -324,7 +324,7 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 	}
 
 	task.namespace = c.partitionMgr.ns.Name()
-	task.backlogCountHint = c.backlogMgr.BacklogCountHint
+	task.backlogCountHint = c.backlogMgr.db.getApproximateBacklogCount
 	return task, nil
 }
 

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -308,7 +308,6 @@ func TestLegacyDescribeTaskQueue(t *testing.T) {
 	require.NotNil(t, taskQueueStatus)
 	require.Zero(t, taskQueueStatus.GetAckLevel())
 	require.Equal(t, taskCount, taskQueueStatus.GetReadLevel())
-	require.Equal(t, taskCount, taskQueueStatus.GetBacklogCountHint())
 	taskIDBlock := taskQueueStatus.GetTaskIdBlock()
 	require.Equal(t, int64(1), taskIDBlock.GetStartId())
 	require.Equal(t, tlm.config.RangeSize, taskIDBlock.GetEndId())

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -312,6 +312,7 @@ func TestLegacyDescribeTaskQueue(t *testing.T) {
 	require.NotNil(t, taskQueueStatus)
 	require.Zero(t, taskQueueStatus.GetAckLevel())
 	require.Equal(t, taskCount, taskQueueStatus.GetReadLevel())
+	require.Equal(t, taskCount, taskQueueStatus.GetBacklogCountHint())
 	taskIDBlock := taskQueueStatus.GetTaskIdBlock()
 	require.Equal(t, int64(1), taskIDBlock.GetStartId())
 	require.Equal(t, tlm.config.RangeSize, taskIDBlock.GetEndId())

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -298,6 +298,10 @@ func TestLegacyDescribeTaskQueue(t *testing.T) {
 		tlm.backlogMgr.taskAckManager.addTask(startTaskID + i)
 	}
 
+	// Manually increasing the backlog counter since it does not get incremented by taskAckManager.addTask
+	// Only doing this for the purpose of this test
+	tlm.backlogMgr.db.updateApproximateBacklogCount(taskCount)
+
 	includeTaskStatus := false
 	descResp := tlm.LegacyDescribeTaskQueue(includeTaskStatus)
 	require.Equal(t, 0, len(descResp.DescResponse.GetPollers()))
@@ -333,7 +337,7 @@ func TestLegacyDescribeTaskQueue(t *testing.T) {
 	taskQueueStatus = descResp.DescResponse.GetTaskQueueStatus()
 	require.NotNil(t, taskQueueStatus)
 	require.Equal(t, taskCount, taskQueueStatus.GetAckLevel())
-	require.Zero(t, taskQueueStatus.GetBacklogCountHint())
+	require.Zero(t, taskQueueStatus.GetBacklogCountHint()) // should be 0 since AckManager.CompleteTask decrements the updated backlog counter
 }
 
 func TestCheckIdleTaskQueue(t *testing.T) {

--- a/tests/describe_task_queue.go
+++ b/tests/describe_task_queue.go
@@ -62,18 +62,22 @@ func (s *DescribeTaskQueueSuite) SetupTest() {
 }
 
 func (s *DescribeTaskQueueSuite) TestAddNoTasks_ValidateBacklogInfo() {
-	s.publishConsumeWorkflowTasksValidateBacklogInfo(4, 0)
+	s.publishConsumeWorkflowTasksValidateBacklogInfo(4, 0, true)
 }
 
 func (s *DescribeTaskQueueSuite) TestAddSingleTask_ValidateBacklogInfo() {
-	s.publishConsumeWorkflowTasksValidateBacklogInfo(1, 1)
+	s.publishConsumeWorkflowTasksValidateBacklogInfo(1, 1, true)
 }
 
 func (s *DescribeTaskQueueSuite) TestAddMultipleTasksMultiplePartitions_ValidateBacklogInfo() {
-	s.publishConsumeWorkflowTasksValidateBacklogInfo(4, 100)
+	s.publishConsumeWorkflowTasksValidateBacklogInfo(4, 100, true)
 }
 
-func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateBacklogInfo(partitions int, workflows int) {
+func (s *DescribeTaskQueueSuite) TestAddSingleTask_ValidateBacklogInfoLegacyAPIMode() {
+	s.publishConsumeWorkflowTasksValidateBacklogInfo(1, 1, false)
+}
+
+func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateBacklogInfo(partitions int, workflows int, isEnhancedMode bool) {
 	// overriding the ReadPartitions and WritePartitions
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, partitions)
@@ -109,7 +113,7 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateBacklogInfo(
 	}
 
 	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = int64(workflows)
-	s.validateDescribeTaskQueue(tl, expectedBacklogCount)
+	s.validateDescribeTaskQueue(tl, expectedBacklogCount, isEnhancedMode)
 
 	// Polling the tasks
 	for i := 0; i < workflows; {
@@ -127,42 +131,59 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateBacklogInfo(
 
 	// call describeTaskQueue to verify if the backlog decreased
 	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = int64(0)
-	s.validateDescribeTaskQueue(tl, expectedBacklogCount)
+	s.validateDescribeTaskQueue(tl, expectedBacklogCount, isEnhancedMode)
 }
 
-func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(tl string, expectedBacklogCount map[enumspb.TaskQueueType]int64) {
+func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(tl string, expectedBacklogCount map[enumspb.TaskQueueType]int64,
+	isEnhancedMode bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	var resp *workflowservice.DescribeTaskQueueResponse
 	var err error
 
-	s.Eventually(func() bool {
-		resp, err = s.engine.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
-			Namespace:              s.namespace,
-			TaskQueue:              &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			ApiMode:                enumspb.DESCRIBE_TASK_QUEUE_MODE_ENHANCED,
-			Versions:               nil, // default version, in this case unversioned queue
-			TaskQueueTypes:         nil, // both types
-			ReportPollers:          true,
-			ReportTaskReachability: true,
-			ReportBacklogInfo:      true,
-		})
-		s.NoError(err)
-		s.NotNil(resp)
-		s.Assert().Equal(1, len(resp.GetVersionsInfo()), "should be 1 because only default/unversioned queue")
-		versionInfo := resp.GetVersionsInfo()[""]
-		s.Assert().Equal(enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE, versionInfo.GetTaskReachability())
-		types := versionInfo.GetTypesInfo()
-		s.Assert().Equal(len(types), len(expectedBacklogCount))
+	if isEnhancedMode {
+		s.Eventually(func() bool {
+			resp, err = s.engine.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
+				Namespace:              s.namespace,
+				TaskQueue:              &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				ApiMode:                enumspb.DESCRIBE_TASK_QUEUE_MODE_ENHANCED,
+				Versions:               nil, // default version, in this case unversioned queue
+				TaskQueueTypes:         nil, // both types
+				ReportPollers:          true,
+				ReportTaskReachability: true,
+				ReportBacklogInfo:      true,
+			})
+			s.NoError(err)
+			s.NotNil(resp)
+			s.Assert().Equal(1, len(resp.GetVersionsInfo()), "should be 1 because only default/unversioned queue")
+			versionInfo := resp.GetVersionsInfo()[""]
+			s.Assert().Equal(enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE, versionInfo.GetTaskReachability())
+			types := versionInfo.GetTypesInfo()
+			s.Assert().Equal(len(types), len(expectedBacklogCount))
 
-		validator := true
-		for qT, t := range types {
-			queueType := enumspb.TaskQueueType(qT)
-			if t.BacklogInfo.ApproximateBacklogCount != expectedBacklogCount[queueType] {
-				validator = false
+			validator := true
+			for qT, t := range types {
+				queueType := enumspb.TaskQueueType(qT)
+				if t.BacklogInfo.ApproximateBacklogCount != expectedBacklogCount[queueType] {
+					validator = false
+				}
 			}
-		}
-		return validator == true
-	}, 3*time.Second, 50*time.Millisecond)
+			return validator == true
+		}, 3*time.Second, 50*time.Millisecond)
+
+	} else {
+		// Querying the Legacy API
+		s.Eventually(func() bool {
+			resp, err = s.engine.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
+				Namespace:              s.namespace,
+				TaskQueue:              &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				ApiMode:                enumspb.DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED,
+				IncludeTaskQueueStatus: true,
+			})
+			s.NoError(err)
+			s.NotNil(resp)
+			return resp.TaskQueueStatus.GetBacklogCountHint() == expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW]
+		}, 3*time.Second, 50*time.Millisecond)
+	}
 }


### PR DESCRIPTION
## What changed?
- `approximateBacklogCounter` to be available via legacy `DescribeTaskQueue` API
- Legacy `BacklogCountHint` is removed. I propose that the new `approximateBacklogCounter` is a better estimate for task backlog and has been replaced.
- Functional test checking if the in-memory backlog counter is updated as expected
- Updated unit tests which were dealing with the legacy API

## Why?
- It is better to emit the more accurate backlog counter, which in this case, would be `approximateBacklogCounter`.

## How did you test it?
- Current CI/CD tests
- Functional test added

## Potential risks
None since this is merging into my own feature branch.

## Is hotfix candidate?
No
