### PR TITLE
Workflow Update: improve "update not found" error message

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -28,8 +28,9 @@ import (
 	"context"
 	"fmt"
 
-	"go.temporal.io/server/service/history/api/recordworkflowtaskstarted"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"go.temporal.io/server/service/history/api/recordworkflowtaskstarted"
 
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
@@ -39,6 +40,7 @@ import (
 	querypb "go.temporal.io/api/query/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
@@ -920,7 +922,7 @@ func failWorkflowTask(
 	wtFailedEvent, err := mutableState.AddWorkflowTaskFailedEvent(
 		workflowTask,
 		wtFailedCause.failedCause,
-		failure.NewServerFailure(wtFailedCause.Message(), true),
+		failure.NewServerFailure(wtFailedCause.Message(), false),
 		request.GetIdentity(),
 		nil,
 		request.GetBinaryChecksum(),

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -374,7 +374,7 @@ func (handler *workflowTaskCompletedHandler) handleMessage(
 		if upd == nil {
 			return handler.failWorkflowTask(
 				enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
-				serviceerror.NewNotFound(fmt.Sprintf("update %s wasn't found on server. It is, most likely, a transient error which is fixed by retries", message.ProtocolInstanceId)))
+				serviceerror.NewNotFound(fmt.Sprintf("update %s wasn't found on the server. This is most likely a transient error which will be resolved automatically by retries", message.ProtocolInstanceId)))
 		}
 
 		if err := upd.OnProtocolMessage(

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -374,7 +374,7 @@ func (handler *workflowTaskCompletedHandler) handleMessage(
 		if upd == nil {
 			return handler.failWorkflowTask(
 				enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
-				serviceerror.NewNotFound(fmt.Sprintf("update %s not found", message.ProtocolInstanceId)))
+				serviceerror.NewNotFound(fmt.Sprintf("update %s wasn't found on server. It is, most likely, a transient error which is fixed by retries", message.ProtocolInstanceId)))
 		}
 
 		if err := upd.OnProtocolMessage(

--- a/tests/update_workflow.go
+++ b/tests/update_workflow.go
@@ -938,7 +938,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ValidateWorkerMessages() {
 	}{
 		{
 			Name:                     "message-update-id-not-found",
-			RespondWorkflowTaskError: "not found",
+			RespondWorkflowTaskError: "wasn't found",
 			MessageFn: func(tv *testvars.TestVars, reqMsg *protocolpb.Message) []*protocolpb.Message {
 				updRequest := protoutils.UnmarshalAny[*updatepb.Request](s.T(), reqMsg.GetBody())
 				return []*protocolpb.Message{
@@ -2342,7 +2342,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_FailSpeculativeWorkflowTask() {
 	// Try to accept update in workflow: get malformed response.
 	_, err = poller.PollAndProcessWorkflowTask()
 	s.Error(err)
-	s.Contains(err.Error(), "not found")
+	s.Contains(err.Error(), "wasn't found")
 	// New normal (but transient) WT will be created but not returned.
 
 	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage, 1*time.Second)
@@ -3878,7 +3878,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalWorkflowTaskUpdateLost_B
 	_, err := poller.PollAndProcessWorkflowTask()
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err, "workflow task failure must be an InvalidArgument error")
-	s.ErrorContains(err, fmt.Sprintf("update %s not found", tv.UpdateID("1")))
+	s.ErrorContains(err, fmt.Sprintf("update %s wasn't found", tv.UpdateID("1")))
 
 	<-updateResultCh
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Improve "update not found" error message.

Also change `nonRetryable` flag on failure to `false` (meaning that failure is retryable). This failure is not used by the code, but just goes to the history and shows up in UI. Because WFT failures are retryable, setting it to `false` is more accurate.

## Why?
<!-- Tell your future self why have you made these changes -->
When update is not found while handling messages from worker, it is most likely means that update registry was cleared but retries on the caller side will recreate it. I am trying to phrase it in the way it clearly says that it is not an user error.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
N/A

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
Yes, to 1.24.0.