### PR TITLE
Add permission for staleness GitHub Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  pull-requests: write
+
 jobs:
   stale_prs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Following [the documentation](https://github.com/actions/stale?tab=readme-ov-file#recommended-permissions), adding permissions to this GitHub action.

## Why?
<!-- Tell your future self why have you made these changes -->

The "label stale PR" GitHub Action I've added doesn't work since it [doesn't have permissions](https://github.com/temporalio/temporal/actions/runs/9087827866/job/24976300438#step:2:2041):
```
Error: [#5265] Error when creating a comment: Resource not accessible by integration
```

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

I can't?

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
