### PR TITLE
Handle User Metadata in workflow start requests

### DIFF
--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -101,6 +101,11 @@ func Invoke(
 	executionInfo := mutableState.GetExecutionInfo()
 	executionState := mutableState.GetExecutionState()
 
+	// fetch the start event to get the associated user metadata.
+	startEvent, err := mutableState.GetStartEvent(ctx)
+	if err != nil {
+		return nil, err
+	}
 	result := &historyservice.DescribeWorkflowExecutionResponse{
 		ExecutionConfig: &workflowpb.WorkflowExecutionConfig{
 			TaskQueue: &taskqueuepb.TaskQueue{
@@ -110,6 +115,7 @@ func Invoke(
 			WorkflowExecutionTimeout:   executionInfo.WorkflowExecutionTimeout,
 			WorkflowRunTimeout:         executionInfo.WorkflowRunTimeout,
 			DefaultWorkflowTaskTimeout: executionInfo.DefaultWorkflowTaskTimeout,
+			UserMetadata:               startEvent.UserMetadata,
 		},
 		WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
 			Execution: &commonpb.WorkflowExecution{

--- a/service/history/api/signalwithstartworkflow/convert.go
+++ b/service/history/api/signalwithstartworkflow/convert.go
@@ -58,6 +58,7 @@ func ConvertToStartRequest(
 		SearchAttributes:         request.GetSearchAttributes(),
 		Header:                   request.GetHeader(),
 		WorkflowStartDelay:       request.GetWorkflowStartDelay(),
+		UserMetadata:             request.UserMetadata,
 	}
 
 	return common.CreateHistoryStartWorkflowRequest(namespaceID.String(), req, nil, nil, now)

--- a/service/history/historybuilder/history_builder.go
+++ b/service/history/historybuilder/history_builder.go
@@ -159,6 +159,9 @@ func (b *HistoryBuilder) AddWorkflowExecutionStartedEvent(
 		firstInChainRunID,
 		originalRunID,
 	)
+	if request.StartRequest.GetUserMetadata() != nil {
+		event.UserMetadata = request.StartRequest.GetUserMetadata()
+	}
 	event, _ = b.EventStore.add(event)
 	return event
 }

--- a/tests/user_metadata_test.go
+++ b/tests/user_metadata_test.go
@@ -1,3 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package tests
 
 import (

--- a/tests/user_metadata_test.go
+++ b/tests/user_metadata_test.go
@@ -3,128 +3,123 @@ package tests
 import (
 	"github.com/pborman/uuid"
 	commonpb "go.temporal.io/api/common/v1"
-	enumspb "go.temporal.io/api/enums/v1"
 	sdkpb "go.temporal.io/api/sdk/v1"
-	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/testing/testvars"
 )
 
-func getDescribeWorkflowExecutionInfo(engine FrontendClient, namespace string, workflowID string, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
-	return engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: namespace,
-		Execution: &commonpb.WorkflowExecution{
-			WorkflowId: workflowID,
-			RunId:      runID,
-		},
+func (s *FunctionalSuite) TestUserMetadata() {
+	getDescribeWorkflowExecutionInfo := func(engine FrontendClient, namespace string, workflowID string, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+		return engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: namespace,
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: workflowID,
+				RunId:      runID,
+			},
+		})
+	}
+	prepareTestUserMetadata := func() *sdkpb.UserMetadata {
+		return &sdkpb.UserMetadata{
+			Summary: &commonpb.Payload{
+				Metadata: map[string][]byte{"test_summary_key": []byte(`test_summary_val`)},
+				Data:     []byte(`Test summary Data`),
+			},
+			Details: &commonpb.Payload{
+				Metadata: map[string][]byte{"test_details_key": []byte(`test_details_val`)},
+				Data:     []byte(`Test Details Data`),
+			},
+		}
+	}
+
+	s.Run("StartWorkflowExecution records UserMetadata", func() {
+		tv := testvars.New(s.T().Name())
+		id := tv.WorkflowID("functional-user-metadata-StartWorkflowExecution")
+		metadata := prepareTestUserMetadata()
+		request := &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:    uuid.New(),
+			Namespace:    s.namespace,
+			WorkflowId:   id,
+			WorkflowType: tv.WorkflowType(),
+			TaskQueue:    tv.TaskQueue(),
+			UserMetadata: metadata,
+		}
+
+		we, err := s.engine.StartWorkflowExecution(NewContext(), request)
+		s.NoError(err)
+
+		// Verify that the UserMetadata associated with the start event is returned in the describe response.
+		describeInfo, err := getDescribeWorkflowExecutionInfo(s.engine, s.namespace, id, we.RunId)
+		s.NoError(err)
+		s.EqualExportedValues(metadata, describeInfo.ExecutionConfig.UserMetadata)
 	})
-}
 
-func prepareTestUserMetadata() *sdkpb.UserMetadata {
-	return &sdkpb.UserMetadata{
-		Summary: &commonpb.Payload{
-			Metadata: map[string][]byte{"test_summary_key": []byte(`test_summary_val`)},
-			Data:     []byte(`Test summary Data`),
-		},
-		Details: &commonpb.Payload{
-			Metadata: map[string][]byte{"test_details_key": []byte(`test_details_val`)},
-			Data:     []byte(`Test Details Data`),
-		},
-	}
-}
+	s.Run("SignalWithStartWorkflowExecution records UserMetadata", func() {
+		tv := testvars.New(s.T().Name())
+		id := tv.WorkflowID("functional-user-metadata-SignalWithStartWorkflowExecution")
+		metadata := prepareTestUserMetadata()
+		request := &workflowservice.SignalWithStartWorkflowExecutionRequest{
+			RequestId:    uuid.New(),
+			Namespace:    s.namespace,
+			WorkflowId:   id,
+			WorkflowType: tv.WorkflowType(),
+			TaskQueue:    tv.TaskQueue(),
+			SignalName:   "TEST-SIGNAL",
+			UserMetadata: metadata,
+		}
 
-// TestUserMetadataStartWorkflowExecution verifies that the user metadata passed in StartWorkflowExecution request
-// is correctly recorded and returned in the describe workflow response.
-func (s *FunctionalSuite) TestUserMetadataStartWorkflowExecution() {
-	id := "functional-user-metadata-StartWorkflowExecution"
-	metadata := prepareTestUserMetadata()
-	request := &workflowservice.StartWorkflowExecutionRequest{
-		RequestId:    uuid.New(),
-		Namespace:    s.namespace,
-		WorkflowId:   id,
-		WorkflowType: &commonpb.WorkflowType{Name: "functional-user-metadata-workflow-type"},
-		TaskQueue:    &taskqueuepb.TaskQueue{Name: "functional-user-metadata-taskqueue", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-		UserMetadata: metadata,
-	}
+		we, err := s.engine.SignalWithStartWorkflowExecution(NewContext(), request)
+		s.NoError(err)
 
-	we, err := s.engine.StartWorkflowExecution(NewContext(), request)
-	s.NoError(err)
+		// Verify that the UserMetadata associated with the start event is returned in the describe response.
+		describeInfo, err := getDescribeWorkflowExecutionInfo(s.engine, s.namespace, id, we.RunId)
+		s.NoError(err)
+		s.EqualExportedValues(metadata, describeInfo.ExecutionConfig.UserMetadata)
+	})
 
-	// Verify that the UserMetadata associated with the start event is returned in the describe response.
-	describeInfo, err := getDescribeWorkflowExecutionInfo(s.engine, s.namespace, id, we.RunId)
-	s.NoError(err)
-	s.NotNil(describeInfo.ExecutionConfig.UserMetadata)
-	s.EqualExportedValues(describeInfo.ExecutionConfig.UserMetadata, metadata)
-}
-
-// TestUserMetadataSignalWithStartWorkflowExecution verifies that the user metadata attached to SignalWithStartWorkflowExecution request
-// is correctly recorded and returned in the describe workflow response.
-func (s *FunctionalSuite) TestUserMetadataSignalWithStartWorkflowExecution() {
-	id := "functional-user-metadata-SignalWithStartWorkflowExecution"
-	metadata := prepareTestUserMetadata()
-	request := &workflowservice.SignalWithStartWorkflowExecutionRequest{
-		RequestId:    uuid.New(),
-		Namespace:    s.namespace,
-		WorkflowId:   id,
-		WorkflowType: &commonpb.WorkflowType{Name: "functional-user-metadata-workflow-type"},
-		TaskQueue:    &taskqueuepb.TaskQueue{Name: "functional-user-metadata-taskqueue", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-		SignalName:   "TEST-SIGNAL",
-		UserMetadata: metadata,
-	}
-
-	we, err := s.engine.SignalWithStartWorkflowExecution(NewContext(), request)
-	s.NoError(err)
-
-	// Verify that the UserMetadata associated with the start event is returned in the describe response.
-	describeInfo, err := getDescribeWorkflowExecutionInfo(s.engine, s.namespace, id, we.RunId)
-	s.NoError(err)
-	s.NotNil(describeInfo.ExecutionConfig.UserMetadata)
-	s.EqualExportedValues(describeInfo.ExecutionConfig.UserMetadata, metadata)
-}
-
-// TestUserMetadataExecuteMultiOperation issues a multi operation that includes start workflow with metadata attached.
-// It verifies that the sent metadata is correctly recorded and returned in the describe workflow response.
-func (s *FunctionalSuite) TestUserMetadataExecuteMultiOperation() {
-	id := "functional-user-metadata-ExecuteMultiOperation"
-	metadata := prepareTestUserMetadata()
-	startWorkflowRequest := &workflowservice.StartWorkflowExecutionRequest{
-		RequestId:    uuid.New(),
-		Namespace:    s.namespace,
-		WorkflowId:   id,
-		WorkflowType: &commonpb.WorkflowType{Name: "functional-user-metadata-workflow-type"},
-		TaskQueue:    &taskqueuepb.TaskQueue{Name: "functional-user-metadata-taskqueue", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-		UserMetadata: metadata,
-	}
-	updateWorkflowRequest := &workflowservice.UpdateWorkflowExecutionRequest{
-		Namespace:         s.namespace,
-		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: id},
-		Request: &updatepb.Request{
-			Meta:  &updatepb.Meta{UpdateId: "UPDATE_ID"},
-			Input: &updatepb.Input{Name: "NAME"},
-		},
-	}
-	request := &workflowservice.ExecuteMultiOperationRequest{
-		Namespace: s.namespace,
-		Operations: []*workflowservice.ExecuteMultiOperationRequest_Operation{
-			{ // start workflow operation
-				Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_StartWorkflow{
-					StartWorkflow: startWorkflowRequest,
+	s.Run("ExecuteMultiOperation records UserMetadata", func() {
+		tv := testvars.New(s.T().Name())
+		id := tv.WorkflowID("functional-user-metadata-ExecuteMultiOperation")
+		metadata := prepareTestUserMetadata()
+		startWorkflowRequest := &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:    uuid.New(),
+			Namespace:    s.namespace,
+			WorkflowId:   id,
+			WorkflowType: tv.WorkflowType(),
+			TaskQueue:    tv.TaskQueue(),
+			UserMetadata: metadata,
+		}
+		updateWorkflowRequest := &workflowservice.UpdateWorkflowExecutionRequest{
+			Namespace:         s.namespace,
+			WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: id},
+			Request: &updatepb.Request{
+				Meta:  &updatepb.Meta{UpdateId: "UPDATE_ID"},
+				Input: &updatepb.Input{Name: "NAME"},
+			},
+		}
+		request := &workflowservice.ExecuteMultiOperationRequest{
+			Namespace: s.namespace,
+			Operations: []*workflowservice.ExecuteMultiOperationRequest_Operation{
+				{ // start workflow operation
+					Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_StartWorkflow{
+						StartWorkflow: startWorkflowRequest,
+					},
+				},
+				{ // update workflow operation
+					Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_UpdateWorkflow{
+						UpdateWorkflow: updateWorkflowRequest,
+					},
 				},
 			},
-			{ // update workflow operation
-				Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_UpdateWorkflow{
-					UpdateWorkflow: updateWorkflowRequest,
-				},
-			},
-		},
-	}
+		}
 
-	_, err := s.engine.ExecuteMultiOperation(NewContext(), request)
-	s.NoError(err)
+		_, err := s.engine.ExecuteMultiOperation(NewContext(), request)
+		s.NoError(err)
 
-	// Verify that the UserMetadata associated with the start event is returned in the describe response.
-	describeInfo, err := getDescribeWorkflowExecutionInfo(s.engine, s.namespace, id, "")
-	s.NoError(err)
-	s.NotNil(describeInfo.ExecutionConfig.UserMetadata)
-	s.EqualExportedValues(describeInfo.ExecutionConfig.UserMetadata, metadata)
+		// Verify that the UserMetadata associated with the start event is returned in the describe response.
+		describeInfo, err := getDescribeWorkflowExecutionInfo(s.engine, s.namespace, id, "")
+		s.NoError(err)
+		s.EqualExportedValues(metadata, describeInfo.ExecutionConfig.UserMetadata)
+	})
+
 }

--- a/tests/user_metadata_test.go
+++ b/tests/user_metadata_test.go
@@ -1,0 +1,130 @@
+package tests
+
+import (
+	"github.com/pborman/uuid"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	sdkpb "go.temporal.io/api/sdk/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	updatepb "go.temporal.io/api/update/v1"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+func getDescribeWorkflowExecutionInfo(engine FrontendClient, namespace string, workflowID string, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+	return engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: namespace,
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: workflowID,
+			RunId:      runID,
+		},
+	})
+}
+
+func prepareTestUserMetadata() *sdkpb.UserMetadata {
+	return &sdkpb.UserMetadata{
+		Summary: &commonpb.Payload{
+			Metadata: map[string][]byte{"test_summary_key": []byte(`test_summary_val`)},
+			Data:     []byte(`Test summary Data`),
+		},
+		Details: &commonpb.Payload{
+			Metadata: map[string][]byte{"test_details_key": []byte(`test_details_val`)},
+			Data:     []byte(`Test Details Data`),
+		},
+	}
+}
+
+// TestUserMetadataStartWorkflowExecution verifies that the user metadata passed in StartWorkflowExecution request
+// is correctly recorded and returned in the describe workflow response.
+func (s *FunctionalSuite) TestUserMetadataStartWorkflowExecution() {
+	id := "functional-user-metadata-StartWorkflowExecution"
+	metadata := prepareTestUserMetadata()
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:    uuid.New(),
+		Namespace:    s.namespace,
+		WorkflowId:   id,
+		WorkflowType: &commonpb.WorkflowType{Name: "functional-user-metadata-workflow-type"},
+		TaskQueue:    &taskqueuepb.TaskQueue{Name: "functional-user-metadata-taskqueue", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		UserMetadata: metadata,
+	}
+
+	we, err := s.engine.StartWorkflowExecution(NewContext(), request)
+	s.NoError(err)
+
+	// Verify that the UserMetadata associated with the start event is returned in the describe response.
+	describeInfo, err := getDescribeWorkflowExecutionInfo(s.engine, s.namespace, id, we.RunId)
+	s.NoError(err)
+	s.NotNil(describeInfo.ExecutionConfig.UserMetadata)
+	s.EqualExportedValues(describeInfo.ExecutionConfig.UserMetadata, metadata)
+}
+
+// TestUserMetadataSignalWithStartWorkflowExecution verifies that the user metadata attached to SignalWithStartWorkflowExecution request
+// is correctly recorded and returned in the describe workflow response.
+func (s *FunctionalSuite) TestUserMetadataSignalWithStartWorkflowExecution() {
+	id := "functional-user-metadata-SignalWithStartWorkflowExecution"
+	metadata := prepareTestUserMetadata()
+	request := &workflowservice.SignalWithStartWorkflowExecutionRequest{
+		RequestId:    uuid.New(),
+		Namespace:    s.namespace,
+		WorkflowId:   id,
+		WorkflowType: &commonpb.WorkflowType{Name: "functional-user-metadata-workflow-type"},
+		TaskQueue:    &taskqueuepb.TaskQueue{Name: "functional-user-metadata-taskqueue", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		SignalName:   "TEST-SIGNAL",
+		UserMetadata: metadata,
+	}
+
+	we, err := s.engine.SignalWithStartWorkflowExecution(NewContext(), request)
+	s.NoError(err)
+
+	// Verify that the UserMetadata associated with the start event is returned in the describe response.
+	describeInfo, err := getDescribeWorkflowExecutionInfo(s.engine, s.namespace, id, we.RunId)
+	s.NoError(err)
+	s.NotNil(describeInfo.ExecutionConfig.UserMetadata)
+	s.EqualExportedValues(describeInfo.ExecutionConfig.UserMetadata, metadata)
+}
+
+// TestUserMetadataExecuteMultiOperation issues a multi operation that includes start workflow with metadata attached.
+// It verifies that the sent metadata is correctly recorded and returned in the describe workflow response.
+func (s *FunctionalSuite) TestUserMetadataExecuteMultiOperation() {
+	id := "functional-user-metadata-ExecuteMultiOperation"
+	metadata := prepareTestUserMetadata()
+	startWorkflowRequest := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:    uuid.New(),
+		Namespace:    s.namespace,
+		WorkflowId:   id,
+		WorkflowType: &commonpb.WorkflowType{Name: "functional-user-metadata-workflow-type"},
+		TaskQueue:    &taskqueuepb.TaskQueue{Name: "functional-user-metadata-taskqueue", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		UserMetadata: metadata,
+	}
+	updateWorkflowRequest := &workflowservice.UpdateWorkflowExecutionRequest{
+		Namespace:         s.namespace,
+		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: id},
+		Request: &updatepb.Request{
+			Meta:  &updatepb.Meta{UpdateId: "UPDATE_ID"},
+			Input: &updatepb.Input{Name: "NAME"},
+		},
+	}
+	request := &workflowservice.ExecuteMultiOperationRequest{
+		Namespace: s.namespace,
+		Operations: []*workflowservice.ExecuteMultiOperationRequest_Operation{
+			{ // start workflow operation
+				Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_StartWorkflow{
+					StartWorkflow: startWorkflowRequest,
+				},
+			},
+			{ // update workflow operation
+				Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_UpdateWorkflow{
+					UpdateWorkflow: updateWorkflowRequest,
+				},
+			},
+		},
+	}
+
+	_, err := s.engine.ExecuteMultiOperation(NewContext(), request)
+	s.NoError(err)
+
+	// Verify that the UserMetadata associated with the start event is returned in the describe response.
+	describeInfo, err := getDescribeWorkflowExecutionInfo(s.engine, s.namespace, id, "")
+	s.NoError(err)
+	s.NotNil(describeInfo.ExecutionConfig.UserMetadata)
+	s.EqualExportedValues(describeInfo.ExecutionConfig.UserMetadata, metadata)
+}


### PR DESCRIPTION
## What changed?
We are now handling the User Metadata attached in the start workflow requests.

## Why?
Users need a way to set arbitrary information on workflows and events. This would be later used in the clients to build custom tooling (ex: UI showing additional information about a timer event etc)

## How did you test it?
Added new functional tests

## Potential risks
N/A

## Documentation
N/A

## Is hotfix candidate?
No
