### PR TITLE
Add generic typed settings

### DIFF
--- a/cmd/tools/gendynamicconfig/main.go
+++ b/cmd/tools/gendynamicconfig/main.go
@@ -135,7 +135,21 @@ func generateType(w io.Writer, tp *settingType, prec *settingPrecedence) {
 {{ if .T.IsGeneric -}}
 type {{.P.Name}}TypedSetting[T any] setting[T, func({{.P.GoArgs}})]
 
-func New{{.P.Name}}TypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) {{.P.Name}}TypedSetting[T] {
+// New{{.P.Name}}TypedSetting creates a setting that uses mapstructure to handle complex structured
+// values. The value from dynamic config will be copied over a shallow copy of 'def', which means
+// 'def' must not contain any non-nil slices, maps, or pointers.
+func New{{.P.Name}}TypedSetting[T any](key Key, def T, description string) {{.P.Name}}TypedSetting[T] {
+	s := {{.P.Name}}TypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     ConvertStructure[T](def),
+		description: description,
+	}
+	return s
+}
+
+// New{{.P.Name}}TypedSettingWithConverter creates a setting with a custom converter function.
+func New{{.P.Name}}TypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) {{.P.Name}}TypedSetting[T] {
 	s := {{.P.Name}}TypedSetting[T]{
 		key:         key,
 		def:         def,

--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -27,8 +27,11 @@ package dynamicconfig
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"sync/atomic"
 	"time"
+
+	"github.com/mitchellh/mapstructure"
 
 	enumspb "go.temporal.io/api/enums/v1"
 
@@ -119,40 +122,42 @@ func findMatch[T any](cvs []ConstrainedValue, defaultCVs []TypedConstrainedValue
 
 // matchAndConvert can't be a method of Collection because methods can't be generic, but we can
 // take a *Collection as an argument.
-func matchAndConvert[T any, P any](
+func matchAndConvert[T any](
 	c *Collection,
-	s setting[T, P],
+	key Key,
+	def T,
+	cdef []TypedConstrainedValue[T],
+	convert func(value any) (T, error),
 	precedence []Constraints,
-	converter func(value any) (T, error),
 ) T {
-	cvs := c.client.GetValue(s.key)
+	cvs := c.client.GetValue(key)
 
-	defaultCVs := s.cdef
+	defaultCVs := cdef
 	if defaultCVs == nil {
-		defaultCVs = []TypedConstrainedValue[T]{{Value: s.def}}
+		defaultCVs = []TypedConstrainedValue[T]{{Value: def}}
 	}
 
 	val, matchErr := findMatch(cvs, defaultCVs, precedence)
 	if matchErr != nil {
 		if c.throttleLog() {
-			c.logger.Debug("No such key in dynamic config, using default", tag.Key(s.key.String()), tag.Error(matchErr))
+			c.logger.Debug("No such key in dynamic config, using default", tag.Key(key.String()), tag.Error(matchErr))
 		}
 		// couldn't find a constrained match, use default
-		val = s.def
+		val = def
 	}
 
-	typedVal, convertErr := converter(val)
+	typedVal, convertErr := convert(val)
 	if convertErr != nil && matchErr == nil {
 		// We failed to convert the value to the desired type. Try converting the default. note
 		// that if matchErr != nil then val _is_ defaultValue and we don't have to try this again.
 		if c.throttleLog() {
-			c.logger.Warn("Failed to convert value, using default", tag.Key(s.key.String()), tag.IgnoredValue(val), tag.Error(convertErr))
+			c.logger.Warn("Failed to convert value, using default", tag.Key(key.String()), tag.IgnoredValue(val), tag.Error(convertErr))
 		}
-		typedVal, convertErr = converter(s.def)
+		typedVal, convertErr = convert(def)
 	}
 	if convertErr != nil {
 		// If we can't convert the default, that's a bug in our code, use Warn level.
-		c.logger.Warn("Can't convert default value (this is a bug; fix server code)", tag.Key(s.key.String()), tag.IgnoredValue(s.def), tag.Error(convertErr))
+		c.logger.Warn("Can't convert default value (this is a bug; fix server code)", tag.Key(key.String()), tag.IgnoredValue(def), tag.Error(convertErr))
 		// Return typedVal anyway since we have to return something.
 	}
 	return typedVal
@@ -266,4 +271,28 @@ func convertMap(val any) (map[string]any, error) {
 		return mapVal, nil
 	}
 	return nil, errors.New("value type is not map")
+}
+
+// ConvertStructure can be used as a conversion function for New*TypedSetting.
+func ConvertStructure[T any](v any) (T, error) {
+	var out T
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result: &out,
+		// If we want more than one hook in the future, combine them with mapstructure.OrComposeDecodeHookFunc
+		DecodeHook: mapstructureHookDuration,
+	})
+	if err != nil {
+		return out, err
+	}
+	err = dec.Decode(v)
+	return out, err
+}
+
+// Parses string into time.Duration. mapstructure has an implementation of this already but it
+// calls time.ParseDuration and we want to use our own method.
+func mapstructureHookDuration(f, t reflect.Type, data any) (any, error) {
+	if t != reflect.TypeOf(time.Duration(0)) {
+		return data, nil
+	}
+	return convertDuration(data)
 }

--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -289,6 +289,11 @@ func convertMap(val any) (map[string]any, error) {
 // as a group and default unset fields to zero).
 func ConvertStructure[T any](def T) func(v any) (T, error) {
 	return func(v any) (T, error) {
+		// if we already have the right type, no conversion is necessary
+		if typedV, ok := v.(T); ok {
+			return typedV, nil
+		}
+
 		out := def
 		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 			Result: &out,

--- a/common/dynamicconfig/collection_test.go
+++ b/common/dynamicconfig/collection_test.go
@@ -289,7 +289,7 @@ func (s *collectionSuite) TestGetTyped() {
 		Number int
 		Names  []string
 	}
-	setting := NewGlobalTypedSetting(
+	setting := NewGlobalTypedSettingWithConverter(
 		testGetTypedPropertyKey,
 		ConvertStructure(myFancyType{-3, nil}), // used if convert is called
 		myFancyType{28, []string{"global", "typed", "setting"}},
@@ -328,7 +328,7 @@ func (s *collectionSuite) TestGetTyped() {
 }
 
 func (s *collectionSuite) TestGetTypedSimpleList() {
-	setting := NewGlobalTypedSetting(
+	setting := NewGlobalTypedSettingWithConverter(
 		testGetTypedPropertyKey,
 		ConvertStructure([]float64(nil)),
 		[]float64{1.5, 1.1, 2.6, 3.7, 6.3},
@@ -353,7 +353,7 @@ func (s *collectionSuite) TestGetTypedSimpleList() {
 
 func (s *collectionSuite) TestGetTypedListOfStruct() {
 	type simple struct{ A, B int }
-	setting := NewGlobalTypedSetting(
+	setting := NewGlobalTypedSettingWithConverter(
 		testGetTypedPropertyKey,
 		ConvertStructure([]simple(nil)),
 		[]simple{{1, 5}, {2, 9}},

--- a/common/dynamicconfig/collection_test.go
+++ b/common/dynamicconfig/collection_test.go
@@ -46,6 +46,7 @@ const (
 	testGetBoolPropertyKey                            = "testGetBoolPropertyKey"
 	testGetStringPropertyKey                          = "testGetStringPropertyKey"
 	testGetMapPropertyKey                             = "testGetMapPropertyKey"
+	testGetTypedPropertyKey                           = "testGetTypedPropertyKey"
 	testGetIntPropertyFilteredByNamespaceKey          = "testGetIntPropertyFilteredByNamespaceKey"
 	testGetDurationPropertyFilteredByNamespaceKey     = "testGetDurationPropertyFilteredByNamespaceKey"
 	testGetIntPropertyFilteredByTaskQueueInfoKey      = "testGetIntPropertyFilteredByTaskQueueInfoKey"
@@ -78,10 +79,7 @@ func (s *collectionSuite) SetupSuite() {
 }
 
 func (s *collectionSuite) TestGetIntProperty() {
-	setting := GlobalIntSetting{
-		key: testGetIntPropertyKey,
-		def: 10,
-	}
+	setting := NewGlobalIntSetting(testGetIntPropertyKey, 10, "")
 	value := setting.Get(s.cln)
 	s.Equal(10, value())
 	s.client[testGetIntPropertyKey] = 50
@@ -89,10 +87,7 @@ func (s *collectionSuite) TestGetIntProperty() {
 }
 
 func (s *collectionSuite) TestGetIntPropertyFilteredByNamespace() {
-	setting := NamespaceIntSetting{
-		key: testGetIntPropertyFilteredByNamespaceKey,
-		def: 10,
-	}
+	setting := NewNamespaceIntSetting(testGetIntPropertyFilteredByNamespaceKey, 10, "")
 	namespace := "testNamespace"
 	value := setting.Get(s.cln)
 	s.Equal(10, value(namespace))
@@ -109,10 +104,7 @@ func (s *collectionSuite) TestGetStringPropertyFnFilteredByNamespace() {
 }
 
 func (s *collectionSuite) TestGetStringPropertyFnFilteredByNamespaceID() {
-	setting := NamespaceIDStringSetting{
-		key: testGetStringPropertyFilteredByNamespaceIDKey,
-		def: "abc",
-	}
+	setting := NewNamespaceIDStringSetting(testGetStringPropertyFilteredByNamespaceIDKey, "abc", "")
 	namespaceID := "testNamespaceID"
 	value := setting.Get(s.cln)
 	s.Equal("abc", value(namespaceID))
@@ -121,10 +113,7 @@ func (s *collectionSuite) TestGetStringPropertyFnFilteredByNamespaceID() {
 }
 
 func (s *collectionSuite) TestGetIntPropertyFilteredByTaskQueueInfo() {
-	setting := TaskQueueIntSetting{
-		key: testGetIntPropertyFilteredByTaskQueueInfoKey,
-		def: 10,
-	}
+	setting := NewTaskQueueIntSetting(testGetIntPropertyFilteredByTaskQueueInfoKey, 10, "")
 	namespace := "testNamespace"
 	taskQueue := "testTaskQueue"
 	value := setting.Get(s.cln)
@@ -134,10 +123,7 @@ func (s *collectionSuite) TestGetIntPropertyFilteredByTaskQueueInfo() {
 }
 
 func (s *collectionSuite) TestGetFloat64Property() {
-	setting := GlobalFloatSetting{
-		key: testGetFloat64PropertyKey,
-		def: 0.1,
-	}
+	setting := NewGlobalFloatSetting(testGetFloat64PropertyKey, 0.1, "")
 	value := setting.Get(s.cln)
 	s.Equal(0.1, value())
 	s.client[testGetFloat64PropertyKey] = 0.01
@@ -145,10 +131,7 @@ func (s *collectionSuite) TestGetFloat64Property() {
 }
 
 func (s *collectionSuite) TestGetBoolProperty() {
-	setting := GlobalBoolSetting{
-		key: testGetBoolPropertyKey,
-		def: true,
-	}
+	setting := NewGlobalBoolSetting(testGetBoolPropertyKey, true, "")
 	value := setting.Get(s.cln)
 	s.Equal(true, value())
 	s.client[testGetBoolPropertyKey] = false
@@ -156,10 +139,7 @@ func (s *collectionSuite) TestGetBoolProperty() {
 }
 
 func (s *collectionSuite) TestGetBoolPropertyFilteredByNamespaceID() {
-	setting := NamespaceIDBoolSetting{
-		key: testGetBoolPropertyFilteredByNamespaceIDKey,
-		def: true,
-	}
+	setting := NewNamespaceIDBoolSetting(testGetBoolPropertyFilteredByNamespaceIDKey, true, "")
 	namespaceID := "testNamespaceID"
 	value := setting.Get(s.cln)
 	s.Equal(true, value(namespaceID))
@@ -168,10 +148,7 @@ func (s *collectionSuite) TestGetBoolPropertyFilteredByNamespaceID() {
 }
 
 func (s *collectionSuite) TestGetBoolPropertyFilteredByTaskQueueInfo() {
-	setting := TaskQueueBoolSetting{
-		key: testGetBoolPropertyFilteredByTaskQueueInfoKey,
-		def: false,
-	}
+	setting := NewTaskQueueBoolSetting(testGetBoolPropertyFilteredByTaskQueueInfoKey, false, "")
 	namespace := "testNamespace"
 	taskQueue := "testTaskQueue"
 	value := setting.Get(s.cln)
@@ -181,10 +158,7 @@ func (s *collectionSuite) TestGetBoolPropertyFilteredByTaskQueueInfo() {
 }
 
 func (s *collectionSuite) TestGetDurationProperty() {
-	setting := GlobalDurationSetting{
-		key: testGetDurationPropertyKey,
-		def: 1 * time.Second,
-	}
+	setting := NewGlobalDurationSetting(testGetDurationPropertyKey, 1*time.Second, "")
 	value := setting.Get(s.cln)
 	s.Equal(time.Second, value())
 	s.client[testGetDurationPropertyKey] = time.Minute
@@ -196,10 +170,7 @@ func (s *collectionSuite) TestGetDurationProperty() {
 }
 
 func (s *collectionSuite) TestGetDurationPropertyFilteredByNamespace() {
-	setting := NamespaceDurationSetting{
-		key: testGetDurationPropertyFilteredByNamespaceKey,
-		def: time.Second,
-	}
+	setting := NewNamespaceDurationSetting(testGetDurationPropertyFilteredByNamespaceKey, time.Second, "")
 	namespace := "testNamespace"
 	value := setting.Get(s.cln)
 	s.Equal(time.Second, value(namespace))
@@ -208,10 +179,7 @@ func (s *collectionSuite) TestGetDurationPropertyFilteredByNamespace() {
 }
 
 func (s *collectionSuite) TestGetDurationPropertyFilteredByTaskQueueInfo() {
-	setting := TaskQueueDurationSetting{
-		key: testGetDurationPropertyFilteredByTaskQueueInfoKey,
-		def: time.Second,
-	}
+	setting := NewTaskQueueDurationSetting(testGetDurationPropertyFilteredByTaskQueueInfoKey, time.Second, "")
 	namespace := "testNamespace"
 	taskQueue := "testTaskQueue"
 	value := setting.Get(s.cln)
@@ -221,10 +189,7 @@ func (s *collectionSuite) TestGetDurationPropertyFilteredByTaskQueueInfo() {
 }
 
 func (s *collectionSuite) TestGetDurationPropertyFilteredByTaskType() {
-	setting := TaskTypeDurationSetting{
-		key: testGetDurationPropertyFilteredByTaskTypeKey,
-		def: time.Second,
-	}
+	setting := NewTaskTypeDurationSetting(testGetDurationPropertyFilteredByTaskTypeKey, time.Second, "")
 	taskType := enumsspb.TASK_TYPE_UNSPECIFIED
 	value := setting.Get(s.cln)
 	s.Equal(time.Second, value(taskType))
@@ -233,9 +198,9 @@ func (s *collectionSuite) TestGetDurationPropertyFilteredByTaskType() {
 }
 
 func (s *collectionSuite) TestGetDurationPropertyStructuredDefaults() {
-	setting := TaskQueueDurationSetting{
-		key: testGetDurationPropertyStructuredDefaults,
-		cdef: []TypedConstrainedValue[time.Duration]{
+	setting := NewTaskQueueDurationSettingWithConstrainedDefault(
+		testGetDurationPropertyStructuredDefaults,
+		[]TypedConstrainedValue[time.Duration]{
 			{
 				Constraints: Constraints{
 					Namespace:     "ns2",
@@ -253,7 +218,8 @@ func (s *collectionSuite) TestGetDurationPropertyStructuredDefaults() {
 				Value: 7 * time.Minute,
 			},
 		},
-	}
+		"",
+	)
 	value := setting.Get(s.cln)
 	s.Equal(7*time.Minute, value("ns1", "tq1", 0))
 	s.Equal(7*time.Minute, value("ns2", "tq1", 0))
@@ -304,12 +270,11 @@ func (s *collectionSuite) TestGetDurationPropertyStructuredDefaults() {
 }
 
 func (s *collectionSuite) TestGetMapProperty() {
-	setting := GlobalMapSetting{
-		key: testGetMapPropertyKey,
-		def: map[string]interface{}{
-			"testKey": 123,
-		},
-	}
+	setting := NewGlobalMapSetting(
+		testGetMapPropertyKey,
+		map[string]interface{}{"testKey": 123},
+		"",
+	)
 	value := setting.Get(s.cln)
 	s.Equal(setting.def, value())
 	val := maps.Clone(setting.def)
@@ -319,11 +284,106 @@ func (s *collectionSuite) TestGetMapProperty() {
 	s.Equal("321", value()["testKey"])
 }
 
-func (s *collectionSuite) TestGetIntPropertyFilteredByDestination() {
-	setting := DestinationIntSetting{
-		key: testGetIntPropertyFilteredByDestinationKey,
-		def: 10,
+func (s *collectionSuite) TestGetTyped() {
+	type myFancyType struct {
+		Number int
+		Names  []string
 	}
+	setting := NewGlobalTypedSetting(
+		testGetTypedPropertyKey,
+		ConvertStructure[myFancyType],
+		myFancyType{28, []string{"global", "typed", "setting"}},
+		"",
+	)
+	get := setting.Get(s.cln)
+
+	s.Run("Default", func() {
+		s.Equal(setting.def, get())
+	})
+
+	s.Run("Basic", func() {
+		// map[string]any is what the yaml library decodes arbitrary data into
+		s.client[testGetTypedPropertyKey] = map[string]any{
+			"Number": 39,
+			"Names":  []string{"new", "names"},
+		}
+		s.Equal(myFancyType{
+			Number: 39,
+			Names:  []string{"new", "names"},
+		}, get())
+	})
+
+	s.Run("CaseInsensitive", func() {
+		s.client[testGetTypedPropertyKey] = map[string]any{
+			"numBER": 999,
+		}
+		s.Equal(999, get().Number)
+		s.Zero(len(get().Names))
+	})
+
+	s.Run("WrongType", func() {
+		s.client[testGetTypedPropertyKey] = 200
+		s.Equal(setting.def, get())
+	})
+}
+
+func (s *collectionSuite) TestGetTypedSimpleList() {
+	setting := NewGlobalTypedSetting(
+		testGetTypedPropertyKey,
+		ConvertStructure[[]float64],
+		[]float64{1.5, 1.1, 2.6, 3.7, 6.3},
+		"",
+	)
+	get := setting.Get(s.cln)
+
+	s.Run("Default", func() {
+		s.Equal(setting.def, get())
+	})
+
+	s.Run("Basic", func() {
+		s.client[testGetTypedPropertyKey] = []any{19.0, -2.0}
+		s.Equal([]float64{19.0, -2.0}, get())
+	})
+
+	s.Run("WrongType", func() {
+		s.client[testGetTypedPropertyKey] = []any{88.8, false, -5, "oops"}
+		s.Equal(setting.def, get())
+	})
+}
+
+func (s *collectionSuite) TestGetTypedListOfStruct() {
+	type simple struct{ A, B int }
+	setting := NewGlobalTypedSetting(
+		testGetTypedPropertyKey,
+		ConvertStructure[[]simple],
+		[]simple{{1, 5}, {2, 9}},
+		"",
+	)
+	get := setting.Get(s.cln)
+
+	s.Run("Default", func() {
+		s.Equal(setting.def, get())
+	})
+
+	s.Run("Basic", func() {
+		s.client[testGetTypedPropertyKey] = []any{
+			map[string]any{"A": 12, "B": 6},
+			map[string]any{"A": -23, "B": 0},
+			map[string]any{"B": 555, "C": "ignored"},
+		}
+		s.Equal([]simple{{12, 6}, {-23, 0}, {0, 555}}, get())
+	})
+
+	s.Run("WrongType", func() {
+		s.client[testGetTypedPropertyKey] = []any{
+			map[string]any{"A": false, "B": true},
+		}
+		s.Equal(setting.def, get())
+	})
+}
+
+func (s *collectionSuite) TestGetIntPropertyFilteredByDestination() {
+	setting := NewDestinationIntSetting(testGetIntPropertyFilteredByDestinationKey, 10, "")
 	namespaceName := "testNamespace"
 	destination1 := "testDestination1"
 	destination2 := "testDestination2"

--- a/common/dynamicconfig/collection_test.go
+++ b/common/dynamicconfig/collection_test.go
@@ -291,7 +291,7 @@ func (s *collectionSuite) TestGetTyped() {
 	}
 	setting := NewGlobalTypedSetting(
 		testGetTypedPropertyKey,
-		ConvertStructure[myFancyType],
+		ConvertStructure(myFancyType{-3, nil}), // used if convert is called
 		myFancyType{28, []string{"global", "typed", "setting"}},
 		"",
 	)
@@ -315,10 +315,10 @@ func (s *collectionSuite) TestGetTyped() {
 
 	s.Run("CaseInsensitive", func() {
 		s.client[testGetTypedPropertyKey] = map[string]any{
-			"numBER": 999,
+			"naMES": []string{"case", "insensitive"},
 		}
-		s.Equal(999, get().Number)
-		s.Zero(len(get().Names))
+		s.Equal(-3, get().Number) // note the convert default is used here
+		s.Equal([]string{"case", "insensitive"}, get().Names)
 	})
 
 	s.Run("WrongType", func() {
@@ -330,7 +330,7 @@ func (s *collectionSuite) TestGetTyped() {
 func (s *collectionSuite) TestGetTypedSimpleList() {
 	setting := NewGlobalTypedSetting(
 		testGetTypedPropertyKey,
-		ConvertStructure[[]float64],
+		ConvertStructure([]float64(nil)),
 		[]float64{1.5, 1.1, 2.6, 3.7, 6.3},
 		"",
 	)
@@ -355,7 +355,7 @@ func (s *collectionSuite) TestGetTypedListOfStruct() {
 	type simple struct{ A, B int }
 	setting := NewGlobalTypedSetting(
 		testGetTypedPropertyKey,
-		ConvertStructure[[]simple],
+		ConvertStructure([]simple(nil)),
 		[]simple{{1, 5}, {2, 9}},
 		"",
 	)

--- a/common/dynamicconfig/config/testConfig.yaml
+++ b/common/dynamicconfig/config/testConfig.yaml
@@ -71,6 +71,13 @@ testGetMapPropertyKey:
 - value: "1"
   constraints:
     namespace: random-namespace
+testGetTypedPropertyKey:
+- value:
+    number: 23.2  # note field is int
+    days: "6d"
+    inner:
+      key1: 12345  # note field is float
+      key2: true
 testGetStringPropertyKey:
 - value: some random string
   constraints: {}

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -89,7 +89,7 @@ func (s *fileBasedClientSuite) TestGetValue_NonExistKey() {
 	s.Nil(cvs)
 
 	defaultValue := true
-	v := GlobalBoolSetting{key: unknownKey, def: defaultValue}.Get(s.collection)()
+	v := NewGlobalBoolSetting(unknownKey, defaultValue, "").Get(s.collection)()
 	s.Equal(defaultValue, v)
 }
 
@@ -97,36 +97,36 @@ func (s *fileBasedClientSuite) TestGetValue_CaseInsensitie() {
 	cvs := s.client.GetValue(testCaseInsensitivePropertyKey)
 	s.Equal(1, len(cvs))
 
-	v := GlobalBoolSetting{key: testCaseInsensitivePropertyKey, def: false}.Get(s.collection)()
+	v := NewGlobalBoolSetting(testCaseInsensitivePropertyKey, false, "").Get(s.collection)()
 	s.Equal(true, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue() {
-	v := GlobalIntSetting{key: testGetIntPropertyKey, def: 1}.Get(s.collection)()
+	v := NewGlobalIntSetting(testGetIntPropertyKey, 1, "").Get(s.collection)()
 	s.Equal(1000, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilterNotMatch() {
-	v := NamespaceIntSetting{key: testGetIntPropertyKey, def: 500}.Get(s.collection)("samples-namespace")
+	v := NewNamespaceIntSetting(testGetIntPropertyKey, 500, "").Get(s.collection)("samples-namespace")
 	s.Equal(1000, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_WrongType() {
 	defaultValue := 2000
-	v := NamespaceIntSetting{key: testGetIntPropertyKey, def: defaultValue}.Get(s.collection)("global-samples-namespace")
+	v := NewNamespaceIntSetting(testGetIntPropertyKey, defaultValue, "").Get(s.collection)("global-samples-namespace")
 	s.Equal(defaultValue, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByWorkflowTaskQueueInfo() {
 	expectedValue := 1001
-	v := TaskQueueIntSetting{key: testGetIntPropertyKey, def: 0}.Get(s.collection)(
+	v := NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		"global-samples-namespace", "test-tq", enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	s.Equal(expectedValue, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByNoTaskTypeQueueInfo() {
 	expectedValue := 1003
-	v := TaskQueueIntSetting{key: testGetIntPropertyKey, def: 0}.Get(s.collection)(
+	v := NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		// this is contrived, but simulates something that doesn't match workflow or activity
 		"global-samples-namespace", "test-tq", enumspb.TaskQueueType(3),
 	)
@@ -135,40 +135,40 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilteredByNoTaskTypeQueueInfo() {
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByActivityTaskQueueInfo() {
 	expectedValue := 1002
-	v := TaskQueueIntSetting{key: testGetIntPropertyKey, def: 0}.Get(s.collection)(
+	v := NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		"global-samples-namespace", "test-tq", enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 	s.Equal(expectedValue, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByTaskQueueNameOnly() {
 	expectedValue := 1005
-	v := TaskQueueIntSetting{key: testGetIntPropertyKey, def: 0}.Get(s.collection)(
+	v := NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		"some-other-namespace", "other-test-tq", enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	s.Equal(expectedValue, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilterByTQ_NamespaceOnly() {
 	expectedValue := 1004
-	v := TaskQueueIntSetting{key: testGetIntPropertyKey, def: 0}.Get(s.collection)(
+	v := NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		"another-namespace", "test-tq", 0)
 	s.Equal(expectedValue, v)
 	expectedValue = 1005
-	v = TaskQueueIntSetting{key: testGetIntPropertyKey, def: 0}.Get(s.collection)(
+	v = NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		"another-namespace", "other-test-tq", 0)
 	s.Equal(expectedValue, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilterByTQ_MatchFallback() {
 	// should return 1001 as the most specific match
-	v1 := TaskQueueIntSetting{key: testGetIntPropertyKey, def: 1001}.Get(s.collection)(
+	v1 := NewTaskQueueIntSetting(testGetIntPropertyKey, 1001, "").Get(s.collection)(
 		"global-samples-namespace", "test-tq", enumspb.TASK_QUEUE_TYPE_WORKFLOW)
-	v2 := TaskQueueIntSetting{key: testGetIntPropertyKey, def: 0}.Get(s.collection)(
+	v2 := NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		"global-samples-namespace", "test-tq", enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	s.Equal(v1, v2)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilterByDestination() {
-	dc := DestinationIntSetting{key: testGetIntPropertyFilteredByDestinationKey, def: 5}.Get(s.collection)
+	dc := NewDestinationIntSetting(testGetIntPropertyFilteredByDestinationKey, 5, "").Get(s.collection)
 	s.Equal(10, dc("foo", "bar"))
 	s.Equal(20, dc("test-namespace", "test-destination-1"))
 	s.Equal(30, dc("test-namespace", "random-destination"))
@@ -177,29 +177,29 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilterByDestination() {
 }
 
 func (s *fileBasedClientSuite) TestGetFloatValue() {
-	v := GlobalFloatSetting{key: testGetFloat64PropertyKey, def: 1}.Get(s.collection)()
+	v := NewGlobalFloatSetting(testGetFloat64PropertyKey, 1, "").Get(s.collection)()
 	s.Equal(12.0, v)
 }
 
 func (s *fileBasedClientSuite) TestGetFloatValue_WrongType() {
 	defaultValue := 1.0
-	v := NamespaceFloatSetting{key: testGetFloat64PropertyKey, def: defaultValue}.Get(s.collection)("samples-namespace")
+	v := NewNamespaceFloatSetting(testGetFloat64PropertyKey, defaultValue, "").Get(s.collection)("samples-namespace")
 	s.Equal(defaultValue, v)
 }
 
 func (s *fileBasedClientSuite) TestGetBoolValue() {
-	v := GlobalBoolSetting{key: testGetBoolPropertyKey, def: true}.Get(s.collection)()
+	v := NewGlobalBoolSetting(testGetBoolPropertyKey, true, "").Get(s.collection)()
 	s.Equal(false, v)
 }
 
 func (s *fileBasedClientSuite) TestGetStringValue() {
-	v := NamespaceStringSetting{key: testGetStringPropertyKey, def: "defaultString"}.Get(s.collection)("random-namespace")
+	v := NewNamespaceStringSetting(testGetStringPropertyKey, "defaultString", "").Get(s.collection)("random-namespace")
 	s.Equal("constrained-string", v)
 }
 
 func (s *fileBasedClientSuite) TestGetMapValue() {
 	var defaultVal map[string]interface{}
-	v := GlobalMapSetting{key: testGetMapPropertyKey, def: defaultVal}.Get(s.collection)()
+	v := NewGlobalMapSetting(testGetMapPropertyKey, defaultVal, "").Get(s.collection)()
 	expectedVal := map[string]interface{}{
 		"key1": "1",
 		"key2": 1,
@@ -214,40 +214,64 @@ func (s *fileBasedClientSuite) TestGetMapValue() {
 	s.Equal(expectedVal, v)
 }
 
+func (s *fileBasedClientSuite) TestGetTypedValue() {
+	type myStruct struct {
+		Number int
+		Days   time.Duration
+		Inner  struct {
+			Key1 float64
+			Key2 bool
+		}
+	}
+	v := NewGlobalTypedSetting(testGetTypedPropertyKey, ConvertStructure[myStruct], myStruct{}, "").Get(s.collection)()
+	expectedVal := myStruct{
+		Number: 23,
+		Days:   6 * 24 * time.Hour,
+		Inner: struct {
+			Key1 float64
+			Key2 bool
+		}{
+			Key1: 12345.0,
+			Key2: true,
+		},
+	}
+	s.Equal(expectedVal, v)
+}
+
 func (s *fileBasedClientSuite) TestGetMapValue_WrongType() {
 	var defaultVal map[string]interface{}
-	v := NamespaceMapSetting{key: testGetMapPropertyKey, def: defaultVal}.Get(s.collection)("random-namespace")
+	v := NewNamespaceMapSetting(testGetMapPropertyKey, defaultVal, "").Get(s.collection)("random-namespace")
 	s.Equal(defaultVal, v)
 }
 
 func (s *fileBasedClientSuite) TestGetDurationValue() {
-	v := GlobalDurationSetting{key: testGetDurationPropertyKey, def: time.Second}.Get(s.collection)()
+	v := NewGlobalDurationSetting(testGetDurationPropertyKey, time.Second, "").Get(s.collection)()
 	s.Equal(time.Minute, v)
 }
 
 func (s *fileBasedClientSuite) TestGetDurationValue_DefaultSeconds() {
-	v := NamespaceDurationSetting{key: testGetDurationPropertyKey, def: time.Second}.Get(s.collection)("samples-namespace")
+	v := NewNamespaceDurationSetting(testGetDurationPropertyKey, time.Second, "").Get(s.collection)("samples-namespace")
 	s.Equal(2*time.Second, v)
 }
 
 func (s *fileBasedClientSuite) TestGetDurationValue_NotStringRepresentation() {
-	v := NamespaceDurationSetting{key: testGetDurationPropertyKey, def: time.Second}.Get(s.collection)("broken-namespace")
+	v := NewNamespaceDurationSetting(testGetDurationPropertyKey, time.Second, "").Get(s.collection)("broken-namespace")
 	s.Equal(time.Second, v)
 }
 
 func (s *fileBasedClientSuite) TestGetDurationValue_ParseFailed() {
-	v := TaskQueueDurationSetting{key: testGetDurationPropertyKey, def: time.Second}.Get(s.collection)(
+	v := NewTaskQueueDurationSetting(testGetDurationPropertyKey, time.Second, "").Get(s.collection)(
 		"samples-namespace", "longIdleTimeTaskqueue", enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	s.Equal(time.Second, v)
 }
 
 func (s *fileBasedClientSuite) TestGetDurationValue_FilteredByTaskTypeQueue() {
 	expectedValue := time.Second * 10
-	v := TaskTypeDurationSetting{key: testGetDurationPropertyFilteredByTaskTypeKey, def: 0}.Get(s.collection)(
+	v := NewTaskTypeDurationSetting(testGetDurationPropertyFilteredByTaskTypeKey, 0, "").Get(s.collection)(
 		enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
 	)
 	s.Equal(expectedValue, v)
-	v = TaskTypeDurationSetting{key: testGetDurationPropertyFilteredByTaskTypeKey, def: 0}.Get(s.collection)(
+	v = NewTaskTypeDurationSetting(testGetDurationPropertyFilteredByTaskTypeKey, 0, "").Get(s.collection)(
 		enumsspb.TASK_TYPE_REPLICATION_HISTORY,
 	)
 	s.Equal(expectedValue, v)

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -223,7 +223,7 @@ func (s *fileBasedClientSuite) TestGetTypedValue() {
 			Key2 bool
 		}
 	}
-	v := NewGlobalTypedSetting(testGetTypedPropertyKey, ConvertStructure[myStruct], myStruct{}, "").Get(s.collection)()
+	v := NewGlobalTypedSetting(testGetTypedPropertyKey, ConvertStructure(myStruct{}), myStruct{}, "").Get(s.collection)()
 	expectedVal := myStruct{
 		Number: 23,
 		Days:   6 * 24 * time.Hour,

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -222,8 +222,9 @@ func (s *fileBasedClientSuite) TestGetTypedValue() {
 			Key1 float64
 			Key2 bool
 		}
+		UnsetInFile string
 	}
-	v := NewGlobalTypedSetting(testGetTypedPropertyKey, ConvertStructure(myStruct{}), myStruct{}, "").Get(s.collection)()
+	v := NewGlobalTypedSetting(testGetTypedPropertyKey, myStruct{UnsetInFile: "unset"}, "").Get(s.collection)()
 	expectedVal := myStruct{
 		Number: 23,
 		Days:   6 * 24 * time.Hour,
@@ -234,6 +235,7 @@ func (s *fileBasedClientSuite) TestGetTypedValue() {
 			Key1: 12345.0,
 			Key2: true,
 		},
+		UnsetInFile: "unset", // note this value comes from the default
 	}
 	s.Equal(expectedVal, v)
 }

--- a/common/dynamicconfig/setting.go
+++ b/common/dynamicconfig/setting.go
@@ -41,13 +41,11 @@ type (
 	// T is the data type of the setting. P is a go type representing the precedence, which is
 	// just used to make the types more unique.
 	setting[T any, P any] struct {
-		// string value of key. case-insensitive.
-		key Key
-		// default value. cdef is used in preference to def if non-nil.
-		def  T
-		cdef []TypedConstrainedValue[T]
-		// documentation
-		description string
+		key         Key // string value of key. case-insensitive.
+		def         T   // default value. cdef is used in preference to def if non-nil.
+		cdef        []TypedConstrainedValue[T]
+		convert     func(any) (T, error) // converter function
+		description string               // documentation
 	}
 
 	// GenericSetting is an interface that all instances of Setting implement (by generated

--- a/common/dynamicconfig/setting.go
+++ b/common/dynamicconfig/setting.go
@@ -53,7 +53,6 @@ type (
 	// them generically..
 	GenericSetting interface {
 		Key() Key
-		Type() Type
 		Precedence() Precedence
 	}
 )

--- a/common/dynamicconfig/setting_gen.go
+++ b/common/dynamicconfig/setting_gen.go
@@ -33,18 +33,6 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 )
 
-const TypeBool Type = 0 // go type: bool
-
-const TypeInt Type = 1 // go type: int
-
-const TypeFloat Type = 2 // go type: float64
-
-const TypeString Type = 3 // go type: string
-
-const TypeDuration Type = 4 // go type: time.Duration
-
-const TypeMap Type = 5 // go type: map[string]any
-
 const PrecedenceGlobal Precedence = 0
 
 const PrecedenceNamespace Precedence = 1
@@ -65,6 +53,7 @@ func NewGlobalBoolSetting(key Key, def bool, description string) GlobalBoolSetti
 	s := GlobalBoolSetting{
 		key:         key,
 		def:         def,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
@@ -74,13 +63,13 @@ func NewGlobalBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstrained
 	s := GlobalBoolSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
 }
 
 func (s GlobalBoolSetting) Key() Key               { return s.key }
-func (s GlobalBoolSetting) Type() Type             { return TypeBool }
 func (s GlobalBoolSetting) Precedence() Precedence { return PrecedenceGlobal }
 
 func (s GlobalBoolSetting) WithDefault(v bool) GlobalBoolSetting {
@@ -95,9 +84,11 @@ func (s GlobalBoolSetting) Get(c *Collection) BoolPropertyFn {
 	return func() bool {
 		return matchAndConvert(
 			c,
-			(setting[bool, func()])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceGlobal(),
-			convertBool,
 		)
 	}
 }
@@ -114,6 +105,7 @@ func NewNamespaceBoolSetting(key Key, def bool, description string) NamespaceBoo
 	s := NamespaceBoolSetting{
 		key:         key,
 		def:         def,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
@@ -123,13 +115,13 @@ func NewNamespaceBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstrai
 	s := NamespaceBoolSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
 }
 
 func (s NamespaceBoolSetting) Key() Key               { return s.key }
-func (s NamespaceBoolSetting) Type() Type             { return TypeBool }
 func (s NamespaceBoolSetting) Precedence() Precedence { return PrecedenceNamespace }
 
 func (s NamespaceBoolSetting) WithDefault(v bool) NamespaceBoolSetting {
@@ -144,9 +136,11 @@ func (s NamespaceBoolSetting) Get(c *Collection) BoolPropertyFnWithNamespaceFilt
 	return func(namespace string) bool {
 		return matchAndConvert(
 			c,
-			(setting[bool, func(namespace string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceNamespace(namespace),
-			convertBool,
 		)
 	}
 }
@@ -163,6 +157,7 @@ func NewNamespaceIDBoolSetting(key Key, def bool, description string) NamespaceI
 	s := NamespaceIDBoolSetting{
 		key:         key,
 		def:         def,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
@@ -172,13 +167,13 @@ func NewNamespaceIDBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstr
 	s := NamespaceIDBoolSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
 }
 
 func (s NamespaceIDBoolSetting) Key() Key               { return s.key }
-func (s NamespaceIDBoolSetting) Type() Type             { return TypeBool }
 func (s NamespaceIDBoolSetting) Precedence() Precedence { return PrecedenceNamespaceID }
 
 func (s NamespaceIDBoolSetting) WithDefault(v bool) NamespaceIDBoolSetting {
@@ -193,9 +188,11 @@ func (s NamespaceIDBoolSetting) Get(c *Collection) BoolPropertyFnWithNamespaceID
 	return func(namespaceID string) bool {
 		return matchAndConvert(
 			c,
-			(setting[bool, func(namespaceID string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceNamespaceID(namespaceID),
-			convertBool,
 		)
 	}
 }
@@ -212,6 +209,7 @@ func NewTaskQueueBoolSetting(key Key, def bool, description string) TaskQueueBoo
 	s := TaskQueueBoolSetting{
 		key:         key,
 		def:         def,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
@@ -221,13 +219,13 @@ func NewTaskQueueBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstrai
 	s := TaskQueueBoolSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
 }
 
 func (s TaskQueueBoolSetting) Key() Key               { return s.key }
-func (s TaskQueueBoolSetting) Type() Type             { return TypeBool }
 func (s TaskQueueBoolSetting) Precedence() Precedence { return PrecedenceTaskQueue }
 
 func (s TaskQueueBoolSetting) WithDefault(v bool) TaskQueueBoolSetting {
@@ -242,9 +240,11 @@ func (s TaskQueueBoolSetting) Get(c *Collection) BoolPropertyFnWithTaskQueueFilt
 	return func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType) bool {
 		return matchAndConvert(
 			c,
-			(setting[bool, func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceTaskQueue(namespace, taskQueue, taskQueueType),
-			convertBool,
 		)
 	}
 }
@@ -261,6 +261,7 @@ func NewShardIDBoolSetting(key Key, def bool, description string) ShardIDBoolSet
 	s := ShardIDBoolSetting{
 		key:         key,
 		def:         def,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
@@ -270,13 +271,13 @@ func NewShardIDBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstraine
 	s := ShardIDBoolSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
 }
 
 func (s ShardIDBoolSetting) Key() Key               { return s.key }
-func (s ShardIDBoolSetting) Type() Type             { return TypeBool }
 func (s ShardIDBoolSetting) Precedence() Precedence { return PrecedenceShardID }
 
 func (s ShardIDBoolSetting) WithDefault(v bool) ShardIDBoolSetting {
@@ -291,9 +292,11 @@ func (s ShardIDBoolSetting) Get(c *Collection) BoolPropertyFnWithShardIDFilter {
 	return func(shardID int32) bool {
 		return matchAndConvert(
 			c,
-			(setting[bool, func(shardID int32)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceShardID(shardID),
-			convertBool,
 		)
 	}
 }
@@ -310,6 +313,7 @@ func NewTaskTypeBoolSetting(key Key, def bool, description string) TaskTypeBoolS
 	s := TaskTypeBoolSetting{
 		key:         key,
 		def:         def,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
@@ -319,13 +323,13 @@ func NewTaskTypeBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstrain
 	s := TaskTypeBoolSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
 }
 
 func (s TaskTypeBoolSetting) Key() Key               { return s.key }
-func (s TaskTypeBoolSetting) Type() Type             { return TypeBool }
 func (s TaskTypeBoolSetting) Precedence() Precedence { return PrecedenceTaskType }
 
 func (s TaskTypeBoolSetting) WithDefault(v bool) TaskTypeBoolSetting {
@@ -340,9 +344,11 @@ func (s TaskTypeBoolSetting) Get(c *Collection) BoolPropertyFnWithTaskTypeFilter
 	return func(taskType enumsspb.TaskType) bool {
 		return matchAndConvert(
 			c,
-			(setting[bool, func(taskType enumsspb.TaskType)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceTaskType(taskType),
-			convertBool,
 		)
 	}
 }
@@ -359,6 +365,7 @@ func NewDestinationBoolSetting(key Key, def bool, description string) Destinatio
 	s := DestinationBoolSetting{
 		key:         key,
 		def:         def,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
@@ -368,13 +375,13 @@ func NewDestinationBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstr
 	s := DestinationBoolSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertBool,
 		description: description,
 	}
 	return s
 }
 
 func (s DestinationBoolSetting) Key() Key               { return s.key }
-func (s DestinationBoolSetting) Type() Type             { return TypeBool }
 func (s DestinationBoolSetting) Precedence() Precedence { return PrecedenceDestination }
 
 func (s DestinationBoolSetting) WithDefault(v bool) DestinationBoolSetting {
@@ -389,9 +396,11 @@ func (s DestinationBoolSetting) Get(c *Collection) BoolPropertyFnWithDestination
 	return func(namespace string, destination string) bool {
 		return matchAndConvert(
 			c,
-			(setting[bool, func(namespace string, destination string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceDestination(namespace, destination),
-			convertBool,
 		)
 	}
 }
@@ -408,6 +417,7 @@ func NewGlobalIntSetting(key Key, def int, description string) GlobalIntSetting 
 	s := GlobalIntSetting{
 		key:         key,
 		def:         def,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
@@ -417,13 +427,13 @@ func NewGlobalIntSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedV
 	s := GlobalIntSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
 }
 
 func (s GlobalIntSetting) Key() Key               { return s.key }
-func (s GlobalIntSetting) Type() Type             { return TypeInt }
 func (s GlobalIntSetting) Precedence() Precedence { return PrecedenceGlobal }
 
 func (s GlobalIntSetting) WithDefault(v int) GlobalIntSetting {
@@ -438,9 +448,11 @@ func (s GlobalIntSetting) Get(c *Collection) IntPropertyFn {
 	return func() int {
 		return matchAndConvert(
 			c,
-			(setting[int, func()])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceGlobal(),
-			convertInt,
 		)
 	}
 }
@@ -457,6 +469,7 @@ func NewNamespaceIntSetting(key Key, def int, description string) NamespaceIntSe
 	s := NamespaceIntSetting{
 		key:         key,
 		def:         def,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
@@ -466,13 +479,13 @@ func NewNamespaceIntSettingWithConstrainedDefault(key Key, cdef []TypedConstrain
 	s := NamespaceIntSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
 }
 
 func (s NamespaceIntSetting) Key() Key               { return s.key }
-func (s NamespaceIntSetting) Type() Type             { return TypeInt }
 func (s NamespaceIntSetting) Precedence() Precedence { return PrecedenceNamespace }
 
 func (s NamespaceIntSetting) WithDefault(v int) NamespaceIntSetting {
@@ -487,9 +500,11 @@ func (s NamespaceIntSetting) Get(c *Collection) IntPropertyFnWithNamespaceFilter
 	return func(namespace string) int {
 		return matchAndConvert(
 			c,
-			(setting[int, func(namespace string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceNamespace(namespace),
-			convertInt,
 		)
 	}
 }
@@ -506,6 +521,7 @@ func NewNamespaceIDIntSetting(key Key, def int, description string) NamespaceIDI
 	s := NamespaceIDIntSetting{
 		key:         key,
 		def:         def,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
@@ -515,13 +531,13 @@ func NewNamespaceIDIntSettingWithConstrainedDefault(key Key, cdef []TypedConstra
 	s := NamespaceIDIntSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
 }
 
 func (s NamespaceIDIntSetting) Key() Key               { return s.key }
-func (s NamespaceIDIntSetting) Type() Type             { return TypeInt }
 func (s NamespaceIDIntSetting) Precedence() Precedence { return PrecedenceNamespaceID }
 
 func (s NamespaceIDIntSetting) WithDefault(v int) NamespaceIDIntSetting {
@@ -536,9 +552,11 @@ func (s NamespaceIDIntSetting) Get(c *Collection) IntPropertyFnWithNamespaceIDFi
 	return func(namespaceID string) int {
 		return matchAndConvert(
 			c,
-			(setting[int, func(namespaceID string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceNamespaceID(namespaceID),
-			convertInt,
 		)
 	}
 }
@@ -555,6 +573,7 @@ func NewTaskQueueIntSetting(key Key, def int, description string) TaskQueueIntSe
 	s := TaskQueueIntSetting{
 		key:         key,
 		def:         def,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
@@ -564,13 +583,13 @@ func NewTaskQueueIntSettingWithConstrainedDefault(key Key, cdef []TypedConstrain
 	s := TaskQueueIntSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
 }
 
 func (s TaskQueueIntSetting) Key() Key               { return s.key }
-func (s TaskQueueIntSetting) Type() Type             { return TypeInt }
 func (s TaskQueueIntSetting) Precedence() Precedence { return PrecedenceTaskQueue }
 
 func (s TaskQueueIntSetting) WithDefault(v int) TaskQueueIntSetting {
@@ -585,9 +604,11 @@ func (s TaskQueueIntSetting) Get(c *Collection) IntPropertyFnWithTaskQueueFilter
 	return func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType) int {
 		return matchAndConvert(
 			c,
-			(setting[int, func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceTaskQueue(namespace, taskQueue, taskQueueType),
-			convertInt,
 		)
 	}
 }
@@ -604,6 +625,7 @@ func NewShardIDIntSetting(key Key, def int, description string) ShardIDIntSettin
 	s := ShardIDIntSetting{
 		key:         key,
 		def:         def,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
@@ -613,13 +635,13 @@ func NewShardIDIntSettingWithConstrainedDefault(key Key, cdef []TypedConstrained
 	s := ShardIDIntSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
 }
 
 func (s ShardIDIntSetting) Key() Key               { return s.key }
-func (s ShardIDIntSetting) Type() Type             { return TypeInt }
 func (s ShardIDIntSetting) Precedence() Precedence { return PrecedenceShardID }
 
 func (s ShardIDIntSetting) WithDefault(v int) ShardIDIntSetting {
@@ -634,9 +656,11 @@ func (s ShardIDIntSetting) Get(c *Collection) IntPropertyFnWithShardIDFilter {
 	return func(shardID int32) int {
 		return matchAndConvert(
 			c,
-			(setting[int, func(shardID int32)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceShardID(shardID),
-			convertInt,
 		)
 	}
 }
@@ -653,6 +677,7 @@ func NewTaskTypeIntSetting(key Key, def int, description string) TaskTypeIntSett
 	s := TaskTypeIntSetting{
 		key:         key,
 		def:         def,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
@@ -662,13 +687,13 @@ func NewTaskTypeIntSettingWithConstrainedDefault(key Key, cdef []TypedConstraine
 	s := TaskTypeIntSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
 }
 
 func (s TaskTypeIntSetting) Key() Key               { return s.key }
-func (s TaskTypeIntSetting) Type() Type             { return TypeInt }
 func (s TaskTypeIntSetting) Precedence() Precedence { return PrecedenceTaskType }
 
 func (s TaskTypeIntSetting) WithDefault(v int) TaskTypeIntSetting {
@@ -683,9 +708,11 @@ func (s TaskTypeIntSetting) Get(c *Collection) IntPropertyFnWithTaskTypeFilter {
 	return func(taskType enumsspb.TaskType) int {
 		return matchAndConvert(
 			c,
-			(setting[int, func(taskType enumsspb.TaskType)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceTaskType(taskType),
-			convertInt,
 		)
 	}
 }
@@ -702,6 +729,7 @@ func NewDestinationIntSetting(key Key, def int, description string) DestinationI
 	s := DestinationIntSetting{
 		key:         key,
 		def:         def,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
@@ -711,13 +739,13 @@ func NewDestinationIntSettingWithConstrainedDefault(key Key, cdef []TypedConstra
 	s := DestinationIntSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertInt,
 		description: description,
 	}
 	return s
 }
 
 func (s DestinationIntSetting) Key() Key               { return s.key }
-func (s DestinationIntSetting) Type() Type             { return TypeInt }
 func (s DestinationIntSetting) Precedence() Precedence { return PrecedenceDestination }
 
 func (s DestinationIntSetting) WithDefault(v int) DestinationIntSetting {
@@ -732,9 +760,11 @@ func (s DestinationIntSetting) Get(c *Collection) IntPropertyFnWithDestinationFi
 	return func(namespace string, destination string) int {
 		return matchAndConvert(
 			c,
-			(setting[int, func(namespace string, destination string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceDestination(namespace, destination),
-			convertInt,
 		)
 	}
 }
@@ -751,6 +781,7 @@ func NewGlobalFloatSetting(key Key, def float64, description string) GlobalFloat
 	s := GlobalFloatSetting{
 		key:         key,
 		def:         def,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
@@ -760,13 +791,13 @@ func NewGlobalFloatSettingWithConstrainedDefault(key Key, cdef []TypedConstraine
 	s := GlobalFloatSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
 }
 
 func (s GlobalFloatSetting) Key() Key               { return s.key }
-func (s GlobalFloatSetting) Type() Type             { return TypeFloat }
 func (s GlobalFloatSetting) Precedence() Precedence { return PrecedenceGlobal }
 
 func (s GlobalFloatSetting) WithDefault(v float64) GlobalFloatSetting {
@@ -781,9 +812,11 @@ func (s GlobalFloatSetting) Get(c *Collection) FloatPropertyFn {
 	return func() float64 {
 		return matchAndConvert(
 			c,
-			(setting[float64, func()])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceGlobal(),
-			convertFloat,
 		)
 	}
 }
@@ -800,6 +833,7 @@ func NewNamespaceFloatSetting(key Key, def float64, description string) Namespac
 	s := NamespaceFloatSetting{
 		key:         key,
 		def:         def,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
@@ -809,13 +843,13 @@ func NewNamespaceFloatSettingWithConstrainedDefault(key Key, cdef []TypedConstra
 	s := NamespaceFloatSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
 }
 
 func (s NamespaceFloatSetting) Key() Key               { return s.key }
-func (s NamespaceFloatSetting) Type() Type             { return TypeFloat }
 func (s NamespaceFloatSetting) Precedence() Precedence { return PrecedenceNamespace }
 
 func (s NamespaceFloatSetting) WithDefault(v float64) NamespaceFloatSetting {
@@ -830,9 +864,11 @@ func (s NamespaceFloatSetting) Get(c *Collection) FloatPropertyFnWithNamespaceFi
 	return func(namespace string) float64 {
 		return matchAndConvert(
 			c,
-			(setting[float64, func(namespace string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceNamespace(namespace),
-			convertFloat,
 		)
 	}
 }
@@ -849,6 +885,7 @@ func NewNamespaceIDFloatSetting(key Key, def float64, description string) Namesp
 	s := NamespaceIDFloatSetting{
 		key:         key,
 		def:         def,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
@@ -858,13 +895,13 @@ func NewNamespaceIDFloatSettingWithConstrainedDefault(key Key, cdef []TypedConst
 	s := NamespaceIDFloatSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
 }
 
 func (s NamespaceIDFloatSetting) Key() Key               { return s.key }
-func (s NamespaceIDFloatSetting) Type() Type             { return TypeFloat }
 func (s NamespaceIDFloatSetting) Precedence() Precedence { return PrecedenceNamespaceID }
 
 func (s NamespaceIDFloatSetting) WithDefault(v float64) NamespaceIDFloatSetting {
@@ -879,9 +916,11 @@ func (s NamespaceIDFloatSetting) Get(c *Collection) FloatPropertyFnWithNamespace
 	return func(namespaceID string) float64 {
 		return matchAndConvert(
 			c,
-			(setting[float64, func(namespaceID string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceNamespaceID(namespaceID),
-			convertFloat,
 		)
 	}
 }
@@ -898,6 +937,7 @@ func NewTaskQueueFloatSetting(key Key, def float64, description string) TaskQueu
 	s := TaskQueueFloatSetting{
 		key:         key,
 		def:         def,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
@@ -907,13 +947,13 @@ func NewTaskQueueFloatSettingWithConstrainedDefault(key Key, cdef []TypedConstra
 	s := TaskQueueFloatSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
 }
 
 func (s TaskQueueFloatSetting) Key() Key               { return s.key }
-func (s TaskQueueFloatSetting) Type() Type             { return TypeFloat }
 func (s TaskQueueFloatSetting) Precedence() Precedence { return PrecedenceTaskQueue }
 
 func (s TaskQueueFloatSetting) WithDefault(v float64) TaskQueueFloatSetting {
@@ -928,9 +968,11 @@ func (s TaskQueueFloatSetting) Get(c *Collection) FloatPropertyFnWithTaskQueueFi
 	return func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType) float64 {
 		return matchAndConvert(
 			c,
-			(setting[float64, func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceTaskQueue(namespace, taskQueue, taskQueueType),
-			convertFloat,
 		)
 	}
 }
@@ -947,6 +989,7 @@ func NewShardIDFloatSetting(key Key, def float64, description string) ShardIDFlo
 	s := ShardIDFloatSetting{
 		key:         key,
 		def:         def,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
@@ -956,13 +999,13 @@ func NewShardIDFloatSettingWithConstrainedDefault(key Key, cdef []TypedConstrain
 	s := ShardIDFloatSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
 }
 
 func (s ShardIDFloatSetting) Key() Key               { return s.key }
-func (s ShardIDFloatSetting) Type() Type             { return TypeFloat }
 func (s ShardIDFloatSetting) Precedence() Precedence { return PrecedenceShardID }
 
 func (s ShardIDFloatSetting) WithDefault(v float64) ShardIDFloatSetting {
@@ -977,9 +1020,11 @@ func (s ShardIDFloatSetting) Get(c *Collection) FloatPropertyFnWithShardIDFilter
 	return func(shardID int32) float64 {
 		return matchAndConvert(
 			c,
-			(setting[float64, func(shardID int32)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceShardID(shardID),
-			convertFloat,
 		)
 	}
 }
@@ -996,6 +1041,7 @@ func NewTaskTypeFloatSetting(key Key, def float64, description string) TaskTypeF
 	s := TaskTypeFloatSetting{
 		key:         key,
 		def:         def,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
@@ -1005,13 +1051,13 @@ func NewTaskTypeFloatSettingWithConstrainedDefault(key Key, cdef []TypedConstrai
 	s := TaskTypeFloatSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
 }
 
 func (s TaskTypeFloatSetting) Key() Key               { return s.key }
-func (s TaskTypeFloatSetting) Type() Type             { return TypeFloat }
 func (s TaskTypeFloatSetting) Precedence() Precedence { return PrecedenceTaskType }
 
 func (s TaskTypeFloatSetting) WithDefault(v float64) TaskTypeFloatSetting {
@@ -1026,9 +1072,11 @@ func (s TaskTypeFloatSetting) Get(c *Collection) FloatPropertyFnWithTaskTypeFilt
 	return func(taskType enumsspb.TaskType) float64 {
 		return matchAndConvert(
 			c,
-			(setting[float64, func(taskType enumsspb.TaskType)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceTaskType(taskType),
-			convertFloat,
 		)
 	}
 }
@@ -1045,6 +1093,7 @@ func NewDestinationFloatSetting(key Key, def float64, description string) Destin
 	s := DestinationFloatSetting{
 		key:         key,
 		def:         def,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
@@ -1054,13 +1103,13 @@ func NewDestinationFloatSettingWithConstrainedDefault(key Key, cdef []TypedConst
 	s := DestinationFloatSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertFloat,
 		description: description,
 	}
 	return s
 }
 
 func (s DestinationFloatSetting) Key() Key               { return s.key }
-func (s DestinationFloatSetting) Type() Type             { return TypeFloat }
 func (s DestinationFloatSetting) Precedence() Precedence { return PrecedenceDestination }
 
 func (s DestinationFloatSetting) WithDefault(v float64) DestinationFloatSetting {
@@ -1075,9 +1124,11 @@ func (s DestinationFloatSetting) Get(c *Collection) FloatPropertyFnWithDestinati
 	return func(namespace string, destination string) float64 {
 		return matchAndConvert(
 			c,
-			(setting[float64, func(namespace string, destination string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceDestination(namespace, destination),
-			convertFloat,
 		)
 	}
 }
@@ -1094,6 +1145,7 @@ func NewGlobalStringSetting(key Key, def string, description string) GlobalStrin
 	s := GlobalStringSetting{
 		key:         key,
 		def:         def,
+		convert:     convertString,
 		description: description,
 	}
 	return s
@@ -1103,13 +1155,13 @@ func NewGlobalStringSettingWithConstrainedDefault(key Key, cdef []TypedConstrain
 	s := GlobalStringSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertString,
 		description: description,
 	}
 	return s
 }
 
 func (s GlobalStringSetting) Key() Key               { return s.key }
-func (s GlobalStringSetting) Type() Type             { return TypeString }
 func (s GlobalStringSetting) Precedence() Precedence { return PrecedenceGlobal }
 
 func (s GlobalStringSetting) WithDefault(v string) GlobalStringSetting {
@@ -1124,9 +1176,11 @@ func (s GlobalStringSetting) Get(c *Collection) StringPropertyFn {
 	return func() string {
 		return matchAndConvert(
 			c,
-			(setting[string, func()])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceGlobal(),
-			convertString,
 		)
 	}
 }
@@ -1143,6 +1197,7 @@ func NewNamespaceStringSetting(key Key, def string, description string) Namespac
 	s := NamespaceStringSetting{
 		key:         key,
 		def:         def,
+		convert:     convertString,
 		description: description,
 	}
 	return s
@@ -1152,13 +1207,13 @@ func NewNamespaceStringSettingWithConstrainedDefault(key Key, cdef []TypedConstr
 	s := NamespaceStringSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertString,
 		description: description,
 	}
 	return s
 }
 
 func (s NamespaceStringSetting) Key() Key               { return s.key }
-func (s NamespaceStringSetting) Type() Type             { return TypeString }
 func (s NamespaceStringSetting) Precedence() Precedence { return PrecedenceNamespace }
 
 func (s NamespaceStringSetting) WithDefault(v string) NamespaceStringSetting {
@@ -1173,9 +1228,11 @@ func (s NamespaceStringSetting) Get(c *Collection) StringPropertyFnWithNamespace
 	return func(namespace string) string {
 		return matchAndConvert(
 			c,
-			(setting[string, func(namespace string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceNamespace(namespace),
-			convertString,
 		)
 	}
 }
@@ -1192,6 +1249,7 @@ func NewNamespaceIDStringSetting(key Key, def string, description string) Namesp
 	s := NamespaceIDStringSetting{
 		key:         key,
 		def:         def,
+		convert:     convertString,
 		description: description,
 	}
 	return s
@@ -1201,13 +1259,13 @@ func NewNamespaceIDStringSettingWithConstrainedDefault(key Key, cdef []TypedCons
 	s := NamespaceIDStringSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertString,
 		description: description,
 	}
 	return s
 }
 
 func (s NamespaceIDStringSetting) Key() Key               { return s.key }
-func (s NamespaceIDStringSetting) Type() Type             { return TypeString }
 func (s NamespaceIDStringSetting) Precedence() Precedence { return PrecedenceNamespaceID }
 
 func (s NamespaceIDStringSetting) WithDefault(v string) NamespaceIDStringSetting {
@@ -1222,9 +1280,11 @@ func (s NamespaceIDStringSetting) Get(c *Collection) StringPropertyFnWithNamespa
 	return func(namespaceID string) string {
 		return matchAndConvert(
 			c,
-			(setting[string, func(namespaceID string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceNamespaceID(namespaceID),
-			convertString,
 		)
 	}
 }
@@ -1241,6 +1301,7 @@ func NewTaskQueueStringSetting(key Key, def string, description string) TaskQueu
 	s := TaskQueueStringSetting{
 		key:         key,
 		def:         def,
+		convert:     convertString,
 		description: description,
 	}
 	return s
@@ -1250,13 +1311,13 @@ func NewTaskQueueStringSettingWithConstrainedDefault(key Key, cdef []TypedConstr
 	s := TaskQueueStringSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertString,
 		description: description,
 	}
 	return s
 }
 
 func (s TaskQueueStringSetting) Key() Key               { return s.key }
-func (s TaskQueueStringSetting) Type() Type             { return TypeString }
 func (s TaskQueueStringSetting) Precedence() Precedence { return PrecedenceTaskQueue }
 
 func (s TaskQueueStringSetting) WithDefault(v string) TaskQueueStringSetting {
@@ -1271,9 +1332,11 @@ func (s TaskQueueStringSetting) Get(c *Collection) StringPropertyFnWithTaskQueue
 	return func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType) string {
 		return matchAndConvert(
 			c,
-			(setting[string, func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceTaskQueue(namespace, taskQueue, taskQueueType),
-			convertString,
 		)
 	}
 }
@@ -1290,6 +1353,7 @@ func NewShardIDStringSetting(key Key, def string, description string) ShardIDStr
 	s := ShardIDStringSetting{
 		key:         key,
 		def:         def,
+		convert:     convertString,
 		description: description,
 	}
 	return s
@@ -1299,13 +1363,13 @@ func NewShardIDStringSettingWithConstrainedDefault(key Key, cdef []TypedConstrai
 	s := ShardIDStringSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertString,
 		description: description,
 	}
 	return s
 }
 
 func (s ShardIDStringSetting) Key() Key               { return s.key }
-func (s ShardIDStringSetting) Type() Type             { return TypeString }
 func (s ShardIDStringSetting) Precedence() Precedence { return PrecedenceShardID }
 
 func (s ShardIDStringSetting) WithDefault(v string) ShardIDStringSetting {
@@ -1320,9 +1384,11 @@ func (s ShardIDStringSetting) Get(c *Collection) StringPropertyFnWithShardIDFilt
 	return func(shardID int32) string {
 		return matchAndConvert(
 			c,
-			(setting[string, func(shardID int32)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceShardID(shardID),
-			convertString,
 		)
 	}
 }
@@ -1339,6 +1405,7 @@ func NewTaskTypeStringSetting(key Key, def string, description string) TaskTypeS
 	s := TaskTypeStringSetting{
 		key:         key,
 		def:         def,
+		convert:     convertString,
 		description: description,
 	}
 	return s
@@ -1348,13 +1415,13 @@ func NewTaskTypeStringSettingWithConstrainedDefault(key Key, cdef []TypedConstra
 	s := TaskTypeStringSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertString,
 		description: description,
 	}
 	return s
 }
 
 func (s TaskTypeStringSetting) Key() Key               { return s.key }
-func (s TaskTypeStringSetting) Type() Type             { return TypeString }
 func (s TaskTypeStringSetting) Precedence() Precedence { return PrecedenceTaskType }
 
 func (s TaskTypeStringSetting) WithDefault(v string) TaskTypeStringSetting {
@@ -1369,9 +1436,11 @@ func (s TaskTypeStringSetting) Get(c *Collection) StringPropertyFnWithTaskTypeFi
 	return func(taskType enumsspb.TaskType) string {
 		return matchAndConvert(
 			c,
-			(setting[string, func(taskType enumsspb.TaskType)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceTaskType(taskType),
-			convertString,
 		)
 	}
 }
@@ -1388,6 +1457,7 @@ func NewDestinationStringSetting(key Key, def string, description string) Destin
 	s := DestinationStringSetting{
 		key:         key,
 		def:         def,
+		convert:     convertString,
 		description: description,
 	}
 	return s
@@ -1397,13 +1467,13 @@ func NewDestinationStringSettingWithConstrainedDefault(key Key, cdef []TypedCons
 	s := DestinationStringSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertString,
 		description: description,
 	}
 	return s
 }
 
 func (s DestinationStringSetting) Key() Key               { return s.key }
-func (s DestinationStringSetting) Type() Type             { return TypeString }
 func (s DestinationStringSetting) Precedence() Precedence { return PrecedenceDestination }
 
 func (s DestinationStringSetting) WithDefault(v string) DestinationStringSetting {
@@ -1418,9 +1488,11 @@ func (s DestinationStringSetting) Get(c *Collection) StringPropertyFnWithDestina
 	return func(namespace string, destination string) string {
 		return matchAndConvert(
 			c,
-			(setting[string, func(namespace string, destination string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceDestination(namespace, destination),
-			convertString,
 		)
 	}
 }
@@ -1437,6 +1509,7 @@ func NewGlobalDurationSetting(key Key, def time.Duration, description string) Gl
 	s := GlobalDurationSetting{
 		key:         key,
 		def:         def,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
@@ -1446,13 +1519,13 @@ func NewGlobalDurationSettingWithConstrainedDefault(key Key, cdef []TypedConstra
 	s := GlobalDurationSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
 }
 
 func (s GlobalDurationSetting) Key() Key               { return s.key }
-func (s GlobalDurationSetting) Type() Type             { return TypeDuration }
 func (s GlobalDurationSetting) Precedence() Precedence { return PrecedenceGlobal }
 
 func (s GlobalDurationSetting) WithDefault(v time.Duration) GlobalDurationSetting {
@@ -1467,9 +1540,11 @@ func (s GlobalDurationSetting) Get(c *Collection) DurationPropertyFn {
 	return func() time.Duration {
 		return matchAndConvert(
 			c,
-			(setting[time.Duration, func()])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceGlobal(),
-			convertDuration,
 		)
 	}
 }
@@ -1486,6 +1561,7 @@ func NewNamespaceDurationSetting(key Key, def time.Duration, description string)
 	s := NamespaceDurationSetting{
 		key:         key,
 		def:         def,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
@@ -1495,13 +1571,13 @@ func NewNamespaceDurationSettingWithConstrainedDefault(key Key, cdef []TypedCons
 	s := NamespaceDurationSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
 }
 
 func (s NamespaceDurationSetting) Key() Key               { return s.key }
-func (s NamespaceDurationSetting) Type() Type             { return TypeDuration }
 func (s NamespaceDurationSetting) Precedence() Precedence { return PrecedenceNamespace }
 
 func (s NamespaceDurationSetting) WithDefault(v time.Duration) NamespaceDurationSetting {
@@ -1516,9 +1592,11 @@ func (s NamespaceDurationSetting) Get(c *Collection) DurationPropertyFnWithNames
 	return func(namespace string) time.Duration {
 		return matchAndConvert(
 			c,
-			(setting[time.Duration, func(namespace string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceNamespace(namespace),
-			convertDuration,
 		)
 	}
 }
@@ -1535,6 +1613,7 @@ func NewNamespaceIDDurationSetting(key Key, def time.Duration, description strin
 	s := NamespaceIDDurationSetting{
 		key:         key,
 		def:         def,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
@@ -1544,13 +1623,13 @@ func NewNamespaceIDDurationSettingWithConstrainedDefault(key Key, cdef []TypedCo
 	s := NamespaceIDDurationSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
 }
 
 func (s NamespaceIDDurationSetting) Key() Key               { return s.key }
-func (s NamespaceIDDurationSetting) Type() Type             { return TypeDuration }
 func (s NamespaceIDDurationSetting) Precedence() Precedence { return PrecedenceNamespaceID }
 
 func (s NamespaceIDDurationSetting) WithDefault(v time.Duration) NamespaceIDDurationSetting {
@@ -1565,9 +1644,11 @@ func (s NamespaceIDDurationSetting) Get(c *Collection) DurationPropertyFnWithNam
 	return func(namespaceID string) time.Duration {
 		return matchAndConvert(
 			c,
-			(setting[time.Duration, func(namespaceID string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceNamespaceID(namespaceID),
-			convertDuration,
 		)
 	}
 }
@@ -1584,6 +1665,7 @@ func NewTaskQueueDurationSetting(key Key, def time.Duration, description string)
 	s := TaskQueueDurationSetting{
 		key:         key,
 		def:         def,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
@@ -1593,13 +1675,13 @@ func NewTaskQueueDurationSettingWithConstrainedDefault(key Key, cdef []TypedCons
 	s := TaskQueueDurationSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
 }
 
 func (s TaskQueueDurationSetting) Key() Key               { return s.key }
-func (s TaskQueueDurationSetting) Type() Type             { return TypeDuration }
 func (s TaskQueueDurationSetting) Precedence() Precedence { return PrecedenceTaskQueue }
 
 func (s TaskQueueDurationSetting) WithDefault(v time.Duration) TaskQueueDurationSetting {
@@ -1614,9 +1696,11 @@ func (s TaskQueueDurationSetting) Get(c *Collection) DurationPropertyFnWithTaskQ
 	return func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType) time.Duration {
 		return matchAndConvert(
 			c,
-			(setting[time.Duration, func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceTaskQueue(namespace, taskQueue, taskQueueType),
-			convertDuration,
 		)
 	}
 }
@@ -1633,6 +1717,7 @@ func NewShardIDDurationSetting(key Key, def time.Duration, description string) S
 	s := ShardIDDurationSetting{
 		key:         key,
 		def:         def,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
@@ -1642,13 +1727,13 @@ func NewShardIDDurationSettingWithConstrainedDefault(key Key, cdef []TypedConstr
 	s := ShardIDDurationSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
 }
 
 func (s ShardIDDurationSetting) Key() Key               { return s.key }
-func (s ShardIDDurationSetting) Type() Type             { return TypeDuration }
 func (s ShardIDDurationSetting) Precedence() Precedence { return PrecedenceShardID }
 
 func (s ShardIDDurationSetting) WithDefault(v time.Duration) ShardIDDurationSetting {
@@ -1663,9 +1748,11 @@ func (s ShardIDDurationSetting) Get(c *Collection) DurationPropertyFnWithShardID
 	return func(shardID int32) time.Duration {
 		return matchAndConvert(
 			c,
-			(setting[time.Duration, func(shardID int32)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceShardID(shardID),
-			convertDuration,
 		)
 	}
 }
@@ -1682,6 +1769,7 @@ func NewTaskTypeDurationSetting(key Key, def time.Duration, description string) 
 	s := TaskTypeDurationSetting{
 		key:         key,
 		def:         def,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
@@ -1691,13 +1779,13 @@ func NewTaskTypeDurationSettingWithConstrainedDefault(key Key, cdef []TypedConst
 	s := TaskTypeDurationSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
 }
 
 func (s TaskTypeDurationSetting) Key() Key               { return s.key }
-func (s TaskTypeDurationSetting) Type() Type             { return TypeDuration }
 func (s TaskTypeDurationSetting) Precedence() Precedence { return PrecedenceTaskType }
 
 func (s TaskTypeDurationSetting) WithDefault(v time.Duration) TaskTypeDurationSetting {
@@ -1712,9 +1800,11 @@ func (s TaskTypeDurationSetting) Get(c *Collection) DurationPropertyFnWithTaskTy
 	return func(taskType enumsspb.TaskType) time.Duration {
 		return matchAndConvert(
 			c,
-			(setting[time.Duration, func(taskType enumsspb.TaskType)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceTaskType(taskType),
-			convertDuration,
 		)
 	}
 }
@@ -1731,6 +1821,7 @@ func NewDestinationDurationSetting(key Key, def time.Duration, description strin
 	s := DestinationDurationSetting{
 		key:         key,
 		def:         def,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
@@ -1740,13 +1831,13 @@ func NewDestinationDurationSettingWithConstrainedDefault(key Key, cdef []TypedCo
 	s := DestinationDurationSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertDuration,
 		description: description,
 	}
 	return s
 }
 
 func (s DestinationDurationSetting) Key() Key               { return s.key }
-func (s DestinationDurationSetting) Type() Type             { return TypeDuration }
 func (s DestinationDurationSetting) Precedence() Precedence { return PrecedenceDestination }
 
 func (s DestinationDurationSetting) WithDefault(v time.Duration) DestinationDurationSetting {
@@ -1761,9 +1852,11 @@ func (s DestinationDurationSetting) Get(c *Collection) DurationPropertyFnWithDes
 	return func(namespace string, destination string) time.Duration {
 		return matchAndConvert(
 			c,
-			(setting[time.Duration, func(namespace string, destination string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceDestination(namespace, destination),
-			convertDuration,
 		)
 	}
 }
@@ -1780,6 +1873,7 @@ func NewGlobalMapSetting(key Key, def map[string]any, description string) Global
 	s := GlobalMapSetting{
 		key:         key,
 		def:         def,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
@@ -1789,13 +1883,13 @@ func NewGlobalMapSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedV
 	s := GlobalMapSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
 }
 
 func (s GlobalMapSetting) Key() Key               { return s.key }
-func (s GlobalMapSetting) Type() Type             { return TypeMap }
 func (s GlobalMapSetting) Precedence() Precedence { return PrecedenceGlobal }
 
 func (s GlobalMapSetting) WithDefault(v map[string]any) GlobalMapSetting {
@@ -1810,9 +1904,11 @@ func (s GlobalMapSetting) Get(c *Collection) MapPropertyFn {
 	return func() map[string]any {
 		return matchAndConvert(
 			c,
-			(setting[map[string]any, func()])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceGlobal(),
-			convertMap,
 		)
 	}
 }
@@ -1829,6 +1925,7 @@ func NewNamespaceMapSetting(key Key, def map[string]any, description string) Nam
 	s := NamespaceMapSetting{
 		key:         key,
 		def:         def,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
@@ -1838,13 +1935,13 @@ func NewNamespaceMapSettingWithConstrainedDefault(key Key, cdef []TypedConstrain
 	s := NamespaceMapSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
 }
 
 func (s NamespaceMapSetting) Key() Key               { return s.key }
-func (s NamespaceMapSetting) Type() Type             { return TypeMap }
 func (s NamespaceMapSetting) Precedence() Precedence { return PrecedenceNamespace }
 
 func (s NamespaceMapSetting) WithDefault(v map[string]any) NamespaceMapSetting {
@@ -1859,9 +1956,11 @@ func (s NamespaceMapSetting) Get(c *Collection) MapPropertyFnWithNamespaceFilter
 	return func(namespace string) map[string]any {
 		return matchAndConvert(
 			c,
-			(setting[map[string]any, func(namespace string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceNamespace(namespace),
-			convertMap,
 		)
 	}
 }
@@ -1878,6 +1977,7 @@ func NewNamespaceIDMapSetting(key Key, def map[string]any, description string) N
 	s := NamespaceIDMapSetting{
 		key:         key,
 		def:         def,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
@@ -1887,13 +1987,13 @@ func NewNamespaceIDMapSettingWithConstrainedDefault(key Key, cdef []TypedConstra
 	s := NamespaceIDMapSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
 }
 
 func (s NamespaceIDMapSetting) Key() Key               { return s.key }
-func (s NamespaceIDMapSetting) Type() Type             { return TypeMap }
 func (s NamespaceIDMapSetting) Precedence() Precedence { return PrecedenceNamespaceID }
 
 func (s NamespaceIDMapSetting) WithDefault(v map[string]any) NamespaceIDMapSetting {
@@ -1908,9 +2008,11 @@ func (s NamespaceIDMapSetting) Get(c *Collection) MapPropertyFnWithNamespaceIDFi
 	return func(namespaceID string) map[string]any {
 		return matchAndConvert(
 			c,
-			(setting[map[string]any, func(namespaceID string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceNamespaceID(namespaceID),
-			convertMap,
 		)
 	}
 }
@@ -1927,6 +2029,7 @@ func NewTaskQueueMapSetting(key Key, def map[string]any, description string) Tas
 	s := TaskQueueMapSetting{
 		key:         key,
 		def:         def,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
@@ -1936,13 +2039,13 @@ func NewTaskQueueMapSettingWithConstrainedDefault(key Key, cdef []TypedConstrain
 	s := TaskQueueMapSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
 }
 
 func (s TaskQueueMapSetting) Key() Key               { return s.key }
-func (s TaskQueueMapSetting) Type() Type             { return TypeMap }
 func (s TaskQueueMapSetting) Precedence() Precedence { return PrecedenceTaskQueue }
 
 func (s TaskQueueMapSetting) WithDefault(v map[string]any) TaskQueueMapSetting {
@@ -1957,9 +2060,11 @@ func (s TaskQueueMapSetting) Get(c *Collection) MapPropertyFnWithTaskQueueFilter
 	return func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType) map[string]any {
 		return matchAndConvert(
 			c,
-			(setting[map[string]any, func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceTaskQueue(namespace, taskQueue, taskQueueType),
-			convertMap,
 		)
 	}
 }
@@ -1976,6 +2081,7 @@ func NewShardIDMapSetting(key Key, def map[string]any, description string) Shard
 	s := ShardIDMapSetting{
 		key:         key,
 		def:         def,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
@@ -1985,13 +2091,13 @@ func NewShardIDMapSettingWithConstrainedDefault(key Key, cdef []TypedConstrained
 	s := ShardIDMapSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
 }
 
 func (s ShardIDMapSetting) Key() Key               { return s.key }
-func (s ShardIDMapSetting) Type() Type             { return TypeMap }
 func (s ShardIDMapSetting) Precedence() Precedence { return PrecedenceShardID }
 
 func (s ShardIDMapSetting) WithDefault(v map[string]any) ShardIDMapSetting {
@@ -2006,9 +2112,11 @@ func (s ShardIDMapSetting) Get(c *Collection) MapPropertyFnWithShardIDFilter {
 	return func(shardID int32) map[string]any {
 		return matchAndConvert(
 			c,
-			(setting[map[string]any, func(shardID int32)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceShardID(shardID),
-			convertMap,
 		)
 	}
 }
@@ -2025,6 +2133,7 @@ func NewTaskTypeMapSetting(key Key, def map[string]any, description string) Task
 	s := TaskTypeMapSetting{
 		key:         key,
 		def:         def,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
@@ -2034,13 +2143,13 @@ func NewTaskTypeMapSettingWithConstrainedDefault(key Key, cdef []TypedConstraine
 	s := TaskTypeMapSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
 }
 
 func (s TaskTypeMapSetting) Key() Key               { return s.key }
-func (s TaskTypeMapSetting) Type() Type             { return TypeMap }
 func (s TaskTypeMapSetting) Precedence() Precedence { return PrecedenceTaskType }
 
 func (s TaskTypeMapSetting) WithDefault(v map[string]any) TaskTypeMapSetting {
@@ -2055,9 +2164,11 @@ func (s TaskTypeMapSetting) Get(c *Collection) MapPropertyFnWithTaskTypeFilter {
 	return func(taskType enumsspb.TaskType) map[string]any {
 		return matchAndConvert(
 			c,
-			(setting[map[string]any, func(taskType enumsspb.TaskType)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceTaskType(taskType),
-			convertMap,
 		)
 	}
 }
@@ -2074,6 +2185,7 @@ func NewDestinationMapSetting(key Key, def map[string]any, description string) D
 	s := DestinationMapSetting{
 		key:         key,
 		def:         def,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
@@ -2083,13 +2195,13 @@ func NewDestinationMapSettingWithConstrainedDefault(key Key, cdef []TypedConstra
 	s := DestinationMapSetting{
 		key:         key,
 		cdef:        cdef,
+		convert:     convertMap,
 		description: description,
 	}
 	return s
 }
 
 func (s DestinationMapSetting) Key() Key               { return s.key }
-func (s DestinationMapSetting) Type() Type             { return TypeMap }
 func (s DestinationMapSetting) Precedence() Precedence { return PrecedenceDestination }
 
 func (s DestinationMapSetting) WithDefault(v map[string]any) DestinationMapSetting {
@@ -2104,9 +2216,11 @@ func (s DestinationMapSetting) Get(c *Collection) MapPropertyFnWithDestinationFi
 	return func(namespace string, destination string) map[string]any {
 		return matchAndConvert(
 			c,
-			(setting[map[string]any, func(namespace string, destination string)])(s),
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
 			precedenceDestination(namespace, destination),
-			convertMap,
 		)
 	}
 }
@@ -2114,5 +2228,243 @@ func (s DestinationMapSetting) Get(c *Collection) MapPropertyFnWithDestinationFi
 func GetMapPropertyFnFilteredByDestination(value map[string]any) MapPropertyFnWithDestinationFilter {
 	return func(namespace string, destination string) map[string]any {
 		return value
+	}
+}
+
+type GlobalTypedSetting[T any] setting[T, func()]
+
+func NewGlobalTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) GlobalTypedSetting[T] {
+	s := GlobalTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     convert,
+		description: description,
+	}
+	return s
+}
+
+func (s GlobalTypedSetting[T]) Key() Key               { return s.key }
+func (s GlobalTypedSetting[T]) Precedence() Precedence { return PrecedenceGlobal }
+
+func (s GlobalTypedSetting[T]) WithDefault(v T) GlobalTypedSetting[T] {
+	newS := s
+	newS.def = v
+	return newS
+}
+
+func (s GlobalTypedSetting[T]) Get(c *Collection) func() T {
+	return func() T {
+		return matchAndConvert(
+			c,
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
+			precedenceGlobal(),
+		)
+	}
+}
+
+type NamespaceTypedSetting[T any] setting[T, func(namespace string)]
+
+func NewNamespaceTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) NamespaceTypedSetting[T] {
+	s := NamespaceTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     convert,
+		description: description,
+	}
+	return s
+}
+
+func (s NamespaceTypedSetting[T]) Key() Key               { return s.key }
+func (s NamespaceTypedSetting[T]) Precedence() Precedence { return PrecedenceNamespace }
+
+func (s NamespaceTypedSetting[T]) WithDefault(v T) NamespaceTypedSetting[T] {
+	newS := s
+	newS.def = v
+	return newS
+}
+
+func (s NamespaceTypedSetting[T]) Get(c *Collection) func(namespace string) T {
+	return func(namespace string) T {
+		return matchAndConvert(
+			c,
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
+			precedenceNamespace(namespace),
+		)
+	}
+}
+
+type NamespaceIDTypedSetting[T any] setting[T, func(namespaceID string)]
+
+func NewNamespaceIDTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) NamespaceIDTypedSetting[T] {
+	s := NamespaceIDTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     convert,
+		description: description,
+	}
+	return s
+}
+
+func (s NamespaceIDTypedSetting[T]) Key() Key               { return s.key }
+func (s NamespaceIDTypedSetting[T]) Precedence() Precedence { return PrecedenceNamespaceID }
+
+func (s NamespaceIDTypedSetting[T]) WithDefault(v T) NamespaceIDTypedSetting[T] {
+	newS := s
+	newS.def = v
+	return newS
+}
+
+func (s NamespaceIDTypedSetting[T]) Get(c *Collection) func(namespaceID string) T {
+	return func(namespaceID string) T {
+		return matchAndConvert(
+			c,
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
+			precedenceNamespaceID(namespaceID),
+		)
+	}
+}
+
+type TaskQueueTypedSetting[T any] setting[T, func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType)]
+
+func NewTaskQueueTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) TaskQueueTypedSetting[T] {
+	s := TaskQueueTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     convert,
+		description: description,
+	}
+	return s
+}
+
+func (s TaskQueueTypedSetting[T]) Key() Key               { return s.key }
+func (s TaskQueueTypedSetting[T]) Precedence() Precedence { return PrecedenceTaskQueue }
+
+func (s TaskQueueTypedSetting[T]) WithDefault(v T) TaskQueueTypedSetting[T] {
+	newS := s
+	newS.def = v
+	return newS
+}
+
+func (s TaskQueueTypedSetting[T]) Get(c *Collection) func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType) T {
+	return func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType) T {
+		return matchAndConvert(
+			c,
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
+			precedenceTaskQueue(namespace, taskQueue, taskQueueType),
+		)
+	}
+}
+
+type ShardIDTypedSetting[T any] setting[T, func(shardID int32)]
+
+func NewShardIDTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) ShardIDTypedSetting[T] {
+	s := ShardIDTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     convert,
+		description: description,
+	}
+	return s
+}
+
+func (s ShardIDTypedSetting[T]) Key() Key               { return s.key }
+func (s ShardIDTypedSetting[T]) Precedence() Precedence { return PrecedenceShardID }
+
+func (s ShardIDTypedSetting[T]) WithDefault(v T) ShardIDTypedSetting[T] {
+	newS := s
+	newS.def = v
+	return newS
+}
+
+func (s ShardIDTypedSetting[T]) Get(c *Collection) func(shardID int32) T {
+	return func(shardID int32) T {
+		return matchAndConvert(
+			c,
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
+			precedenceShardID(shardID),
+		)
+	}
+}
+
+type TaskTypeTypedSetting[T any] setting[T, func(taskType enumsspb.TaskType)]
+
+func NewTaskTypeTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) TaskTypeTypedSetting[T] {
+	s := TaskTypeTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     convert,
+		description: description,
+	}
+	return s
+}
+
+func (s TaskTypeTypedSetting[T]) Key() Key               { return s.key }
+func (s TaskTypeTypedSetting[T]) Precedence() Precedence { return PrecedenceTaskType }
+
+func (s TaskTypeTypedSetting[T]) WithDefault(v T) TaskTypeTypedSetting[T] {
+	newS := s
+	newS.def = v
+	return newS
+}
+
+func (s TaskTypeTypedSetting[T]) Get(c *Collection) func(taskType enumsspb.TaskType) T {
+	return func(taskType enumsspb.TaskType) T {
+		return matchAndConvert(
+			c,
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
+			precedenceTaskType(taskType),
+		)
+	}
+}
+
+type DestinationTypedSetting[T any] setting[T, func(namespace string, destination string)]
+
+func NewDestinationTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) DestinationTypedSetting[T] {
+	s := DestinationTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     convert,
+		description: description,
+	}
+	return s
+}
+
+func (s DestinationTypedSetting[T]) Key() Key               { return s.key }
+func (s DestinationTypedSetting[T]) Precedence() Precedence { return PrecedenceDestination }
+
+func (s DestinationTypedSetting[T]) WithDefault(v T) DestinationTypedSetting[T] {
+	newS := s
+	newS.def = v
+	return newS
+}
+
+func (s DestinationTypedSetting[T]) Get(c *Collection) func(namespace string, destination string) T {
+	return func(namespace string, destination string) T {
+		return matchAndConvert(
+			c,
+			s.key,
+			s.def,
+			s.cdef,
+			s.convert,
+			precedenceDestination(namespace, destination),
+		)
 	}
 }

--- a/common/dynamicconfig/setting_gen.go
+++ b/common/dynamicconfig/setting_gen.go
@@ -2233,7 +2233,21 @@ func GetMapPropertyFnFilteredByDestination(value map[string]any) MapPropertyFnWi
 
 type GlobalTypedSetting[T any] setting[T, func()]
 
-func NewGlobalTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) GlobalTypedSetting[T] {
+// NewGlobalTypedSetting creates a setting that uses mapstructure to handle complex structured
+// values. The value from dynamic config will be copied over a shallow copy of 'def', which means
+// 'def' must not contain any non-nil slices, maps, or pointers.
+func NewGlobalTypedSetting[T any](key Key, def T, description string) GlobalTypedSetting[T] {
+	s := GlobalTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     ConvertStructure[T](def),
+		description: description,
+	}
+	return s
+}
+
+// NewGlobalTypedSettingWithConverter creates a setting with a custom converter function.
+func NewGlobalTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) GlobalTypedSetting[T] {
 	s := GlobalTypedSetting[T]{
 		key:         key,
 		def:         def,
@@ -2267,7 +2281,21 @@ func (s GlobalTypedSetting[T]) Get(c *Collection) func() T {
 
 type NamespaceTypedSetting[T any] setting[T, func(namespace string)]
 
-func NewNamespaceTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) NamespaceTypedSetting[T] {
+// NewNamespaceTypedSetting creates a setting that uses mapstructure to handle complex structured
+// values. The value from dynamic config will be copied over a shallow copy of 'def', which means
+// 'def' must not contain any non-nil slices, maps, or pointers.
+func NewNamespaceTypedSetting[T any](key Key, def T, description string) NamespaceTypedSetting[T] {
+	s := NamespaceTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     ConvertStructure[T](def),
+		description: description,
+	}
+	return s
+}
+
+// NewNamespaceTypedSettingWithConverter creates a setting with a custom converter function.
+func NewNamespaceTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) NamespaceTypedSetting[T] {
 	s := NamespaceTypedSetting[T]{
 		key:         key,
 		def:         def,
@@ -2301,7 +2329,21 @@ func (s NamespaceTypedSetting[T]) Get(c *Collection) func(namespace string) T {
 
 type NamespaceIDTypedSetting[T any] setting[T, func(namespaceID string)]
 
-func NewNamespaceIDTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) NamespaceIDTypedSetting[T] {
+// NewNamespaceIDTypedSetting creates a setting that uses mapstructure to handle complex structured
+// values. The value from dynamic config will be copied over a shallow copy of 'def', which means
+// 'def' must not contain any non-nil slices, maps, or pointers.
+func NewNamespaceIDTypedSetting[T any](key Key, def T, description string) NamespaceIDTypedSetting[T] {
+	s := NamespaceIDTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     ConvertStructure[T](def),
+		description: description,
+	}
+	return s
+}
+
+// NewNamespaceIDTypedSettingWithConverter creates a setting with a custom converter function.
+func NewNamespaceIDTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) NamespaceIDTypedSetting[T] {
 	s := NamespaceIDTypedSetting[T]{
 		key:         key,
 		def:         def,
@@ -2335,7 +2377,21 @@ func (s NamespaceIDTypedSetting[T]) Get(c *Collection) func(namespaceID string) 
 
 type TaskQueueTypedSetting[T any] setting[T, func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType)]
 
-func NewTaskQueueTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) TaskQueueTypedSetting[T] {
+// NewTaskQueueTypedSetting creates a setting that uses mapstructure to handle complex structured
+// values. The value from dynamic config will be copied over a shallow copy of 'def', which means
+// 'def' must not contain any non-nil slices, maps, or pointers.
+func NewTaskQueueTypedSetting[T any](key Key, def T, description string) TaskQueueTypedSetting[T] {
+	s := TaskQueueTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     ConvertStructure[T](def),
+		description: description,
+	}
+	return s
+}
+
+// NewTaskQueueTypedSettingWithConverter creates a setting with a custom converter function.
+func NewTaskQueueTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) TaskQueueTypedSetting[T] {
 	s := TaskQueueTypedSetting[T]{
 		key:         key,
 		def:         def,
@@ -2369,7 +2425,21 @@ func (s TaskQueueTypedSetting[T]) Get(c *Collection) func(namespace string, task
 
 type ShardIDTypedSetting[T any] setting[T, func(shardID int32)]
 
-func NewShardIDTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) ShardIDTypedSetting[T] {
+// NewShardIDTypedSetting creates a setting that uses mapstructure to handle complex structured
+// values. The value from dynamic config will be copied over a shallow copy of 'def', which means
+// 'def' must not contain any non-nil slices, maps, or pointers.
+func NewShardIDTypedSetting[T any](key Key, def T, description string) ShardIDTypedSetting[T] {
+	s := ShardIDTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     ConvertStructure[T](def),
+		description: description,
+	}
+	return s
+}
+
+// NewShardIDTypedSettingWithConverter creates a setting with a custom converter function.
+func NewShardIDTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) ShardIDTypedSetting[T] {
 	s := ShardIDTypedSetting[T]{
 		key:         key,
 		def:         def,
@@ -2403,7 +2473,21 @@ func (s ShardIDTypedSetting[T]) Get(c *Collection) func(shardID int32) T {
 
 type TaskTypeTypedSetting[T any] setting[T, func(taskType enumsspb.TaskType)]
 
-func NewTaskTypeTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) TaskTypeTypedSetting[T] {
+// NewTaskTypeTypedSetting creates a setting that uses mapstructure to handle complex structured
+// values. The value from dynamic config will be copied over a shallow copy of 'def', which means
+// 'def' must not contain any non-nil slices, maps, or pointers.
+func NewTaskTypeTypedSetting[T any](key Key, def T, description string) TaskTypeTypedSetting[T] {
+	s := TaskTypeTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     ConvertStructure[T](def),
+		description: description,
+	}
+	return s
+}
+
+// NewTaskTypeTypedSettingWithConverter creates a setting with a custom converter function.
+func NewTaskTypeTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) TaskTypeTypedSetting[T] {
 	s := TaskTypeTypedSetting[T]{
 		key:         key,
 		def:         def,
@@ -2437,7 +2521,21 @@ func (s TaskTypeTypedSetting[T]) Get(c *Collection) func(taskType enumsspb.TaskT
 
 type DestinationTypedSetting[T any] setting[T, func(namespace string, destination string)]
 
-func NewDestinationTypedSetting[T any](key Key, convert func(any) (T, error), def T, description string) DestinationTypedSetting[T] {
+// NewDestinationTypedSetting creates a setting that uses mapstructure to handle complex structured
+// values. The value from dynamic config will be copied over a shallow copy of 'def', which means
+// 'def' must not contain any non-nil slices, maps, or pointers.
+func NewDestinationTypedSetting[T any](key Key, def T, description string) DestinationTypedSetting[T] {
+	s := DestinationTypedSetting[T]{
+		key:         key,
+		def:         def,
+		convert:     ConvertStructure[T](def),
+		description: description,
+	}
+	return s
+}
+
+// NewDestinationTypedSettingWithConverter creates a setting with a custom converter function.
+func NewDestinationTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) DestinationTypedSetting[T] {
 	s := DestinationTypedSetting[T]{
 		key:         key,
 		def:         def,

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/lib/pq v1.10.9
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nexus-rpc/sdk-go v0.0.8-0.20240502185337-2b47041a2cc2
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/olivere/elastic/v7 v7.0.32

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
 github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nexus-rpc/sdk-go v0.0.8-0.20240502185337-2b47041a2cc2 h1:NhCabJX4shhYcqtw52H5gFhLToXDhDKZy3KjB81UcTo=


### PR DESCRIPTION
## What changed?
Add more flexible generic typed dynamic config. This can be used to replace lists and maps in a convenient and safe way.
A lot of the work is done by https://pkg.go.dev/github.com/mitchellh/mapstructure to convert from the output of yaml.Unmarshal to arbitrary structs.
I'll follow up this PR with another one to convert most of our current uses of maps to structs.

## Why?
Support more data types and remove a bunch of boilerplate code.

## How did you test it?
unit tests