### PR TITLE
Dump only the type of request when we fail to find Namespace info

### DIFF
--- a/common/rpc/interceptor/namespace.go
+++ b/common/rpc/interceptor/namespace.go
@@ -84,6 +84,6 @@ func GetNamespaceName(
 		return namespaceName, nil
 
 	default:
-		return namespace.EmptyName, serviceerror.NewInternal(fmt.Sprintf("unable to extract namespace info from request: %+v", req))
+		return namespace.EmptyName, serviceerror.NewInternal(fmt.Sprintf("unable to extract namespace info from request of type %T", req))
 	}
 }


### PR DESCRIPTION
## What changed?

We now only log the type of the request we failed to find namespace details on rather than the contents of the request, which required expensive reflection.

## Why?
This is an expensive error path otherwise. We discovered we spent more time in this error path than in our actual logic when running an experiment

## How did you test it?


## Potential risks
None

## Documentation

## Is hotfix candidate?
No
