### PR TITLE
Keep redirect source queues loaded

### DIFF
--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -147,9 +147,13 @@ func newPhysicalTaskQueueManager(
 	config := partitionMgr.config
 	logger := log.With(partitionMgr.logger, tag.WorkerBuildId(queue.VersionSet()))
 	throttledLogger := log.With(partitionMgr.throttledLogger, tag.WorkerBuildId(queue.VersionSet()))
+	buildIdTagValue := queue.VersionSet()
+	if buildIdTagValue == "" {
+		buildIdTagValue = queue.BuildId()
+	}
 	taggedMetricsHandler := partitionMgr.taggedMetricsHandler.WithTags(
 		metrics.OperationTag(metrics.MatchingTaskQueueMgrScope),
-		metrics.WorkerBuildIdTag(queue.VersionSet()))
+		metrics.WorkerBuildIdTag(buildIdTagValue))
 	pqMgr := &physicalTaskQueueManagerImpl{
 		status:               common.DaemonStatusInitialized,
 		partitionMgr:         partitionMgr,

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -299,7 +299,7 @@ func (pm *taskQueuePartitionManagerImpl) PollTask(
 				versionSetUsed = true
 				dbq, err = pm.getVersionedQueue(ctx, versionSet, "", true)
 			} else {
-				activeRules := getActiveRedirectRules(versioningData.RedirectRules)
+				activeRules := getActiveRedirectRules(versioningData.GetRedirectRules())
 				terminalBuildId := findTerminalBuildId(buildId, activeRules)
 				if terminalBuildId != buildId {
 					return nil, false, serviceerror.NewNewerBuildExists(terminalBuildId)

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -526,7 +526,6 @@ func (pm *taskQueuePartitionManagerImpl) unloadPhysicalQueue(unloadedDbq physica
 	delete(pm.versionedQueues, version)
 	pm.versionedQueuesLock.Unlock()
 	unloadedDbq.Stop()
-
 }
 
 func (pm *taskQueuePartitionManagerImpl) unloadFromEngine() {

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -170,11 +170,8 @@ func (s *PartitionManagerTestSuite) TestRedirectRuleLoadUpstream() {
 	s.Assert().NoError(err)
 	s.Assert().NotNil(sourceQ)
 
-	// unload sourceQ and verify that
+	// unload sourceQ
 	s.partitionMgr.unloadPhysicalQueue(sourceQ)
-	sourceQ, err = s.partitionMgr.getVersionedQueue(ctx, "", source, false)
-	s.Assert().NoError(err)
-	s.Assert().Nil(sourceQ)
 
 	// poll from target
 	s.validatePollTask(target, true)

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -408,6 +408,20 @@ func isActiveRedirectRuleSource(buildID string, redirectRules []*persistencespb.
 	return false
 }
 
+// findTerminalBuildId follows redirect rules from the given build ID and returns the target of the last redirect rule.
+// Do not call on cyclic rule set.
+func findTerminalBuildId(buildID string, activeRedirectRules []*persistencespb.RedirectRule) string {
+	outer: for {
+		for _, r := range activeRedirectRules {
+			if r.GetRule().GetSourceBuildId() == buildID {
+				buildID = r.GetRule().GetTargetBuildId()
+				continue outer
+			}
+		}
+		return buildID
+	}
+}
+
 // isConditionalAssignmentRuleTarget checks whether the given buildID is the target of a conditional assignment rule
 // (one with a ramp). We check this for any buildID that is the source of a proposed redirect rule, because having a
 // ramped assignment rule target as the source for a redirect rule would lead to an unpredictable amount of traffic

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -411,7 +411,8 @@ func isActiveRedirectRuleSource(buildID string, redirectRules []*persistencespb.
 // findTerminalBuildId follows redirect rules from the given build ID and returns the target of the last redirect rule.
 // Do not call on cyclic rule set.
 func findTerminalBuildId(buildID string, activeRedirectRules []*persistencespb.RedirectRule) string {
-	outer: for {
+outer:
+	for {
 		for _, r := range activeRedirectRules {
 			if r.GetRule().GetSourceBuildId() == buildID {
 				buildID = r.GetRule().GetTargetBuildId()

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -409,10 +409,10 @@ func isActiveRedirectRuleSource(buildID string, redirectRules []*persistencespb.
 }
 
 // findTerminalBuildId follows redirect rules from the given build ID and returns the target of the last redirect rule.
-// Do not call on cyclic rule set.
+// Returns empty if a cycle is found.
 func findTerminalBuildId(buildID string, activeRedirectRules []*persistencespb.RedirectRule) string {
 outer:
-	for {
+	for i := 0; i <= len(activeRedirectRules); i++ { // limiting the cycles to protect against loops in the graph.
 		for _, r := range activeRedirectRules {
 			if r.GetRule().GetSourceBuildId() == buildID {
 				buildID = r.GetRule().GetTargetBuildId()
@@ -421,6 +421,7 @@ outer:
 		}
 		return buildID
 	}
+	return ""
 }
 
 // isConditionalAssignmentRuleTarget checks whether the given buildID is the target of a conditional assignment rule

--- a/service/matching/version_rule_test.go
+++ b/service/matching/version_rule_test.go
@@ -1185,6 +1185,37 @@ func TestIsCyclic(t *testing.T) {
 	}
 }
 
+func TestFindTerminalBuildId(t *testing.T) {
+	t.Parallel()
+	/*
+		e.g.
+		Redirect Rules:
+		10
+		^
+		|
+		1 <------ 2
+		^
+		|
+		5 <------ 3 <------ 4
+	*/
+	createTs := hlc.Zero(1)
+
+	redirectRules := []*persistencepb.RedirectRule{
+		mkRedirectRulePersistence(mkRedirectRule("1", "10"), createTs, nil),
+		mkRedirectRulePersistence(mkRedirectRule("2", "1"), createTs, nil),
+		mkRedirectRulePersistence(mkRedirectRule("3", "5"), createTs, nil),
+		mkRedirectRulePersistence(mkRedirectRule("4", "3"), createTs, nil),
+		mkRedirectRulePersistence(mkRedirectRule("5", "1"), createTs, nil),
+	}
+
+	assert.Equal(t, "10", findTerminalBuildId("1", redirectRules))
+	assert.Equal(t, "10", findTerminalBuildId("2", redirectRules))
+	assert.Equal(t, "10", findTerminalBuildId("3", redirectRules))
+	assert.Equal(t, "10", findTerminalBuildId("4", redirectRules))
+	assert.Equal(t, "10", findTerminalBuildId("5", redirectRules))
+	assert.Equal(t, "10", findTerminalBuildId("10", redirectRules))
+}
+
 func TestGetUpstreamBuildIds_NoCycle(t *testing.T) {
 	t.Parallel()
 	/*

--- a/service/matching/version_rule_test.go
+++ b/service/matching/version_rule_test.go
@@ -1214,6 +1214,24 @@ func TestFindTerminalBuildId(t *testing.T) {
 	assert.Equal(t, "10", findTerminalBuildId("4", redirectRules))
 	assert.Equal(t, "10", findTerminalBuildId("5", redirectRules))
 	assert.Equal(t, "10", findTerminalBuildId("10", redirectRules))
+
+	// empty rule set
+	assert.Equal(t, "11", findTerminalBuildId("11", []*persistencepb.RedirectRule{}))
+
+	// single rule
+	redirectRules = []*persistencepb.RedirectRule{
+		mkRedirectRulePersistence(mkRedirectRule("1", "2"), createTs, nil),
+	}
+	assert.Equal(t, "2", findTerminalBuildId("1", redirectRules))
+	assert.Equal(t, "2", findTerminalBuildId("2", redirectRules))
+
+	// cyclic rule set
+	redirectRules = []*persistencepb.RedirectRule{
+		mkRedirectRulePersistence(mkRedirectRule("1", "2"), createTs, nil),
+		mkRedirectRulePersistence(mkRedirectRule("2", "1"), createTs, nil),
+	}
+	assert.Equal(t, "", findTerminalBuildId("1", redirectRules))
+	assert.Equal(t, "", findTerminalBuildId("2", redirectRules))
 }
 
 func TestGetUpstreamBuildIds_NoCycle(t *testing.T) {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Make sure redirect rule source Build IDs are loaded as long as the terminal Build ID in that chain is being polled. Also, rejecting pollers of such source Build IDs with a `NewerBuildExists` error.

## Why?
<!-- Tell your future self why have you made these changes -->
So that user can safely stop old worker and their backlog keeps being processed no matter how old.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
If too many Build IDs are involved in a chain, all of them will be loaded all the time as long as the last one of them is getting pollers. We have a limit on the size of a redirect chain so this is controlled.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
None.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No. But candidate cherry-pick into 1.24.0 OS release.