### PR TITLE
add dynamic config for history.ReplicationTaskApplyTimeout

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1969,6 +1969,11 @@ the number of children greater than or equal to this threshold`,
 		`MutableStateChecksumInvalidateBefore is the epoch timestamp before which all checksums are to be discarded`,
 	)
 
+	ReplicationTaskApplyTimeout = NewGlobalDurationSetting(
+		"history.ReplicationTaskApplyTimeout",
+		20*time.Second,
+		`ReplicationTaskApplyTimeout is the context timeout for replication task apply`,
+	)
 	ReplicationTaskFetcherParallelism = NewGlobalIntSetting(
 		"history.ReplicationTaskFetcherParallelism",
 		4,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -247,6 +247,7 @@ type Config struct {
 	ContinueAsNewMinInterval dynamicconfig.DurationPropertyFnWithNamespaceFilter
 
 	// The following is used by the new RPC replication stack
+	ReplicationTaskApplyTimeout                          dynamicconfig.DurationPropertyFn
 	ReplicationTaskFetcherParallelism                    dynamicconfig.IntPropertyFn
 	ReplicationTaskFetcherAggregationInterval            dynamicconfig.DurationPropertyFn
 	ReplicationTaskFetcherTimerJitterCoefficient         dynamicconfig.FloatPropertyFn
@@ -539,6 +540,7 @@ func NewConfig(
 		WorkflowTaskCriticalAttempts: dynamicconfig.WorkflowTaskCriticalAttempts.Get(dc),
 		WorkflowTaskRetryMaxInterval: dynamicconfig.WorkflowTaskRetryMaxInterval.Get(dc),
 
+		ReplicationTaskApplyTimeout:                  dynamicconfig.ReplicationTaskApplyTimeout.Get(dc),
 		ReplicationTaskFetcherParallelism:            dynamicconfig.ReplicationTaskFetcherParallelism.Get(dc),
 		ReplicationTaskFetcherAggregationInterval:    dynamicconfig.ReplicationTaskFetcherAggregationInterval.Get(dc),
 		ReplicationTaskFetcherTimerJitterCoefficient: dynamicconfig.ReplicationTaskFetcherTimerJitterCoefficient.Get(dc),

--- a/service/history/replication/executable_activity_state_task.go
+++ b/service/history/replication/executable_activity_state_task.go
@@ -143,7 +143,7 @@ func (e *ExecutableActivityStateTask) Execute() error {
 		)
 		return nil
 	}
-	ctx, cancel := newTaskContext(namespaceName)
+	ctx, cancel := newTaskContext(namespaceName, e.Config.ReplicationTaskApplyTimeout())
 	defer cancel()
 
 	shardContext, err := e.ShardController.GetShardByNamespaceWorkflow(
@@ -181,7 +181,7 @@ func (e *ExecutableActivityStateTask) HandleErr(err error) error {
 		if nsError != nil {
 			return err
 		}
-		ctx, cancel := newTaskContext(namespaceName)
+		ctx, cancel := newTaskContext(namespaceName, e.Config.ReplicationTaskApplyTimeout())
 		defer cancel()
 
 		if doContinue, resendErr := e.Resend(
@@ -233,7 +233,7 @@ func (e *ExecutableActivityStateTask) MarkPoisonPill() error {
 		tag.TaskID(e.ExecutableTask.TaskID()),
 	)
 
-	ctx, cancel := newTaskContext(e.NamespaceID)
+	ctx, cancel := newTaskContext(e.NamespaceID, e.Config.ReplicationTaskApplyTimeout())
 	defer cancel()
 
 	return writeTaskToDLQ(ctx, e.DLQWriter, shardContext, e.SourceClusterName(), replicationTaskInfo)

--- a/service/history/replication/executable_history_task.go
+++ b/service/history/replication/executable_history_task.go
@@ -134,7 +134,7 @@ func (e *ExecutableHistoryTask) Execute() error {
 		)
 		return nil
 	}
-	ctx, cancel := newTaskContext(namespaceName)
+	ctx, cancel := newTaskContext(namespaceName, e.Config.ReplicationTaskApplyTimeout())
 	defer cancel()
 
 	shardContext, err := e.ShardController.GetShardByNamespaceWorkflow(
@@ -189,7 +189,7 @@ func (e *ExecutableHistoryTask) HandleErr(err error) error {
 		if nsError != nil {
 			return err
 		}
-		ctx, cancel := newTaskContext(namespaceName)
+		ctx, cancel := newTaskContext(namespaceName, e.Config.ReplicationTaskApplyTimeout())
 		defer cancel()
 
 		if doContinue, resendErr := e.Resend(
@@ -264,7 +264,7 @@ func (e *ExecutableHistoryTask) MarkPoisonPill() error {
 		tag.TaskID(e.ExecutableTask.TaskID()),
 	)
 
-	ctx, cancel := newTaskContext(e.NamespaceID)
+	ctx, cancel := newTaskContext(e.NamespaceID, e.Config.ReplicationTaskApplyTimeout())
 	defer cancel()
 
 	return writeTaskToDLQ(ctx, e.DLQWriter, shardContext, e.SourceClusterName(), taskInfo)

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -56,8 +56,6 @@ const (
 )
 
 const (
-	applyReplicationTimeout = 20 * time.Second
-
 	ResendAttempt = 2
 )
 
@@ -452,11 +450,12 @@ FilterLoop:
 
 func newTaskContext(
 	namespaceName string,
+	timeout time.Duration,
 ) (context.Context, context.CancelFunc) {
 	ctx := headers.SetCallerInfo(
 		context.Background(),
 		headers.SystemPreemptableCallerInfo,
 	)
 	ctx = headers.SetCallerName(ctx, namespaceName)
-	return context.WithTimeout(ctx, applyReplicationTimeout)
+	return context.WithTimeout(ctx, timeout)
 }

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -117,7 +117,7 @@ func (e *ExecutableWorkflowStateTask) Execute() error {
 		)
 		return nil
 	}
-	ctx, cancel := newTaskContext(namespaceName)
+	ctx, cancel := newTaskContext(namespaceName, e.Config.ReplicationTaskApplyTimeout())
 	defer cancel()
 
 	shardContext, err := e.ShardController.GetShardByNamespaceWorkflow(
@@ -146,7 +146,7 @@ func (e *ExecutableWorkflowStateTask) HandleErr(err error) error {
 		if nsError != nil {
 			return err
 		}
-		ctx, cancel := newTaskContext(namespaceName)
+		ctx, cancel := newTaskContext(namespaceName, e.Config.ReplicationTaskApplyTimeout())
 		defer cancel()
 
 		if doContinue, resendErr := e.Resend(
@@ -196,7 +196,7 @@ func (e *ExecutableWorkflowStateTask) MarkPoisonPill() error {
 		tag.TaskID(e.ExecutableTask.TaskID()),
 	)
 
-	ctx, cancel := newTaskContext(e.NamespaceID)
+	ctx, cancel := newTaskContext(e.NamespaceID, e.Config.ReplicationTaskApplyTimeout())
 	defer cancel()
 
 	return writeTaskToDLQ(ctx, e.DLQWriter, shardContext, e.SourceClusterName(), taskInfo)

--- a/service/history/replication/executable_workflow_state_task_test.go
+++ b/service/history/replication/executable_workflow_state_task_test.go
@@ -47,7 +47,9 @@ import (
 	"go.temporal.io/server/common/persistence"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/xdc"
+	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tests"
 )
 
 type (
@@ -66,6 +68,7 @@ type (
 		executableTask          *MockExecutableTask
 		eagerNamespaceRefresher *MockEagerNamespaceRefresher
 		mockExecutionManager    *persistence.MockExecutionManager
+		config                  *configs.Config
 
 		replicationTask   *replicationspb.SyncWorkflowStateTaskAttributes
 		sourceClusterName string
@@ -112,6 +115,7 @@ func (s *executableWorkflowStateTaskSuite) SetupTest() {
 	}
 	s.sourceClusterName = cluster.TestCurrentClusterName
 	s.mockExecutionManager = persistence.NewMockExecutionManager(s.controller)
+	s.config = tests.NewDynamicConfig()
 
 	s.taskID = rand.Int63()
 	s.task = NewExecutableWorkflowStateTask(
@@ -125,6 +129,7 @@ func (s *executableWorkflowStateTaskSuite) SetupTest() {
 			Logger:                  s.logger,
 			EagerNamespaceRefresher: s.eagerNamespaceRefresher,
 			DLQWriter:               NewExecutionManagerDLQWriter(s.mockExecutionManager),
+			Config:                  s.config,
 		},
 		s.taskID,
 		time.Unix(0, rand.Int63()),

--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -103,7 +103,9 @@ func eagerNamespaceRefresherProvider(
 	)
 }
 
-func replicationTaskConverterFactoryProvider() SourceTaskConverterProvider {
+func replicationTaskConverterFactoryProvider(
+	config *configs.Config,
+) SourceTaskConverterProvider {
 	return func(
 		historyEngine shard.Engine,
 		shardContext shard.Context,
@@ -116,7 +118,8 @@ func replicationTaskConverterFactoryProvider() SourceTaskConverterProvider {
 			shardContext.GetNamespaceRegistry(),
 			clientClusterShardCount,
 			clientClusterName,
-			clientShardKey)
+			clientShardKey,
+			config)
 	}
 }
 


### PR DESCRIPTION
## What changed?
add dynamic config for history.ReplicationTaskApplyTimeout

## Why?
We encountered "context deadline exceeded" when retrieving events from tiered storage. Make this timeout configurable to unblock migration.

## How did you test it?


## Potential risks


## Documentation


## Is hotfix candidate?

