### PR TITLE
Handle NextRetryDelay option in workflow failures

### DIFF
--- a/service/history/workflow/retry.go
+++ b/service/history/workflow/retry.go
@@ -75,6 +75,11 @@ func getBackoffInterval(
 		return backoff.NoBackoff, enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE
 	}
 
+	// Check if the remote worker sent an application failure indicating a custom backoff duration.
+	delayedRetryDuration := nextRetryDelayFrom(failure)
+	if delayedRetryDuration != nil {
+		return nextBackoffInterval(now, currentAttempt, maxAttempts, initInterval, maxInterval, expirationTime, backoffCoefficient, makeBackoffAlgorithm(delayedRetryDuration))
+	}
 	return nextBackoffInterval(now, currentAttempt, maxAttempts, initInterval, maxInterval, expirationTime, backoffCoefficient, ExponentialBackoffAlgorithm)
 }
 


### PR DESCRIPTION
## What changed?
Workflows can now return an application error with NextRetryDelay option to customize when the workflow will be retried again.
```
  return temporal.NewApplicationError(
    "some retryable error",
    "SomeType",
    temporal.ApplicationErrorOptions{NextRetryDelay: 2 * time.Minute},
  )
```

## Why?
Currently Activity tasks can customize the next retry time. This is bringing the same feature to workflow tasks as well.

## How did you test it?
Added unit tests.
Also added a test to assert next retry delay customization in activities.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
No
