### PR TITLE
Workflow Update: return error if update is completed w/o accepted event

### DIFF
--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -921,9 +921,10 @@ func (s *mutableStateSuite) TestUpdateInfos() {
 
 	acceptedUpdateID := s.T().Name() + "-accepted-update-id"
 	acceptedMsgID := s.T().Name() + "-accepted-msg-id"
+	var acptEvents []*historypb.HistoryEvent
 	for i := 0; i < 2; i++ {
 		updateID := fmt.Sprintf("%s-%d", acceptedUpdateID, i)
-		_, err := s.mutableState.AddWorkflowExecutionUpdateAcceptedEvent(
+		acptEvent, err := s.mutableState.AddWorkflowExecutionUpdateAcceptedEvent(
 			updateID,
 			fmt.Sprintf("%s-%d", acceptedMsgID, i),
 			1,
@@ -932,25 +933,39 @@ func (s *mutableStateSuite) TestUpdateInfos() {
 			},
 		)
 		s.Require().NoError(err)
+		s.Require().NotNil(acptEvent)
+		acptEvents = append(acptEvents, acptEvent)
 	}
-	completedUpdateID := s.T().Name() + "-completed-update-id"
-	completedOutcome := &updatepb.Outcome{
-		Value: &updatepb.Outcome_Success{Success: testPayloads},
-	}
+	s.Require().Len(acptEvents, 2, "expected to create 2 UpdateAccepted events")
+
 	_, err = s.mutableState.AddWorkflowExecutionUpdateCompletedEvent(
 		1234,
 		&updatepb.Response{
-			Meta:    &updatepb.Meta{UpdateId: completedUpdateID},
-			Outcome: completedOutcome,
+			Meta: &updatepb.Meta{UpdateId: s.T().Name() + "-completed-update-without-accepted-event"},
+			Outcome: &updatepb.Outcome{
+				Value: &updatepb.Outcome_Success{Success: testPayloads},
+			},
+		},
+	)
+	s.Require().Error(err)
+
+	completedEvent, err := s.mutableState.AddWorkflowExecutionUpdateCompletedEvent(
+		acptEvents[0].EventId,
+		&updatepb.Response{
+			Meta: &updatepb.Meta{UpdateId: acptEvents[0].GetWorkflowExecutionUpdateAcceptedEventAttributes().GetProtocolInstanceId()},
+			Outcome: &updatepb.Outcome{
+				Value: &updatepb.Outcome_Success{Success: testPayloads},
+			},
 		},
 	)
 	s.Require().NoError(err)
+	s.Require().NotNil(completedEvent)
 
-	s.Require().Len(cacheStore, 3, "expected 1 completed update + 2 accepted in cache")
+	s.Require().Len(cacheStore, 3, "expected 1 UpdateCompleted event + 2 UpdateAccepted events in cache")
 
-	outcome, err := s.mutableState.GetUpdateOutcome(ctx, completedUpdateID)
+	outcome, err := s.mutableState.GetUpdateOutcome(ctx, completedEvent.GetWorkflowExecutionUpdateCompletedEventAttributes().GetMeta().GetUpdateId())
 	s.Require().NoError(err)
-	s.Require().Equal(completedOutcome, outcome)
+	s.Require().Equal(completedEvent.GetWorkflowExecutionUpdateCompletedEventAttributes().GetOutcome(), outcome)
 
 	_, err = s.mutableState.GetUpdateOutcome(ctx, "not_an_update_id")
 	s.Require().Error(err)
@@ -967,12 +982,12 @@ func (s *mutableStateSuite) TestUpdateInfos() {
 		}
 	})
 	s.Require().Equal(numCompleted, 1, "expected 1 completed")
-	s.Require().Equal(numAccepted, 2, "expected 2 accepted")
+	s.Require().Equal(numAccepted, 1, "expected 1 accepted")
 
 	mutation, _, err := s.mutableState.CloseTransactionAsMutation(TransactionPolicyPassive)
 	s.Require().NoError(err)
-	s.Require().Len(mutation.ExecutionInfo.UpdateInfos, 3,
-		"expected 1 completed update + 2 accepted in mutation")
+	s.Require().Len(mutation.ExecutionInfo.UpdateInfos, 2,
+		"expected 1 completed update + 1 accepted in mutation")
 }
 
 func (s *mutableStateSuite) TestApplyActivityTaskStartedEvent() {
@@ -1062,7 +1077,11 @@ func (s *mutableStateSuite) TestTotalEntitiesCount() {
 	)
 	s.NoError(err)
 
-	_, err = s.mutableState.AddWorkflowExecutionUpdateCompletedEvent(1234, &updatepb.Response{})
+	accptEvent, err := s.mutableState.AddWorkflowExecutionUpdateAcceptedEvent("random-updateId", "random", 0, &updatepb.Request{})
+	s.NoError(err)
+	s.NotNil(accptEvent)
+
+	_, err = s.mutableState.AddWorkflowExecutionUpdateCompletedEvent(accptEvent.EventId, &updatepb.Response{})
 	s.NoError(err)
 
 	_, err = s.mutableState.AddWorkflowExecutionSignaled(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Workflow Update: return error if update is completed w/o accepted event.

## Why?
<!-- Tell your future self why have you made these changes -->
`UpdateCompleted` event should always be preceded but `UpdateAccepted` event. Otherwise there is a bug in server or SDK. Error should be returned instead of swallowing error.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Modified existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.