### PR TITLE
Fix current workflow lock release

### DIFF
--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -439,7 +439,7 @@ func GetCurrentRunID(
 	if err != nil {
 		return "", err
 	}
-	defer currentRelease(retErr)
+	defer func() { currentRelease(retErr) }()
 
 	resp, err := shardContext.GetCurrentExecution(
 		ctx,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- "Fix" current workflow lock release

## Why?
<!-- Tell your future self why have you made these changes -->
- Just to follow the pattern for all other places.
- Doesn't really matter what value is passed in here since the error is just for determining if mutable state should be cleared or not. However, there's no mutable state for current workflow (we are just using it as a lock), so nothing to clear. As long as the lock is released, we are good.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- No
