### PR TITLE
Allow DescribeHistoryHost requests without namespace set

### DIFF
--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -304,6 +304,9 @@ func (ni *NamespaceValidatorInterceptor) extractNamespaceFromRequest(req interfa
 			return ni.namespaceRegistry.GetNamespaceByID(namespaceID)
 		}
 		return ni.namespaceRegistry.GetNamespace(namespaceName)
+	case *adminservice.DescribeHistoryHostRequest:
+		// Special case for DescribeHistoryHost API which should run regardless of namespace state.
+		return nil, nil
 	case *adminservice.AddSearchAttributesRequest,
 		*adminservice.RemoveSearchAttributesRequest,
 		*adminservice.GetSearchAttributesRequest,

--- a/common/rpc/interceptor/namespace_validator_test.go
+++ b/common/rpc/interceptor/namespace_validator_test.go
@@ -600,6 +600,44 @@ func (s *namespaceValidatorSuite) Test_StateValidationIntercept_TokenNamespaceEn
 	}
 }
 
+func (s *namespaceValidatorSuite) Test_Intercept_DescribeHistoryHostRequests() {
+	// it's just a list of requests
+	testCases := []struct {
+		req any
+	}{
+		{
+			req: &adminservice.DescribeHistoryHostRequest{},
+		},
+		{
+			req: &adminservice.DescribeHistoryHostRequest{Namespace: "test-namespace"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		nvi := NewNamespaceValidatorInterceptor(
+			s.mockRegistry,
+			dynamicconfig.GetBoolPropertyFn(false),
+			dynamicconfig.GetIntPropertyFn(100),
+		)
+		serverInfo := &grpc.UnaryServerInfo{
+			FullMethod: "/temporal.api.workflowservice.v1.WorkflowService/random",
+		}
+
+		handlerCalled := false
+		_, err := nvi.StateValidationIntercept(
+			context.Background(),
+			testCase.req,
+			serverInfo,
+			func(ctx context.Context, req any) (any, error) {
+				handlerCalled = true
+				return nil, nil
+			},
+		)
+		s.NoError(err)
+		s.True(handlerCalled)
+	}
+}
+
 func (s *namespaceValidatorSuite) Test_Intercept_SearchAttributeRequests() {
 	// it's just a list of requests
 	testCases := []struct {


### PR DESCRIPTION
## What changed?
Exclude `DescribeHistoryHost` requests from namespace interceptor. Fixes #5933.

## Why?
`Namespace` field is optional on the request, and it should be processed regardless of presence or namespace state.

## How did you test it?
Tested with `tdbg history-host describe --history-address <history-host-ip:port>`

## Is hotfix candidate?
Probably not, I don't know how common or urgently the history host describe command is needed.