### PR TITLE
Modified elasticsearch to use term query for keyword matching

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/converter.go
+++ b/common/persistence/visibility/store/elasticsearch/converter.go
@@ -49,7 +49,7 @@ var allowedComparisonOperators = map[string]struct{}{
 func NewQueryConverter(
 	fnInterceptor query.FieldNameInterceptor,
 	fvInterceptor query.FieldValuesInterceptor,
-	nameType searchattribute.NameTypeMap,
+	saNameType searchattribute.NameTypeMap,
 ) *query.Converter {
 	if fnInterceptor == nil {
 		fnInterceptor = &query.NopFieldNameInterceptor{}
@@ -60,7 +60,7 @@ func NewQueryConverter(
 	}
 
 	rangeCond := query.NewRangeCondConverter(fnInterceptor, fvInterceptor, true)
-	comparisonExpr := query.NewComparisonExprConverter(fnInterceptor, fvInterceptor, allowedComparisonOperators, nameType)
+	comparisonExpr := query.NewComparisonExprConverter(fnInterceptor, fvInterceptor, allowedComparisonOperators, saNameType)
 	is := query.NewIsConverter(fnInterceptor)
 
 	whereConverter := &query.WhereConverter{

--- a/common/persistence/visibility/store/elasticsearch/converter.go
+++ b/common/persistence/visibility/store/elasticsearch/converter.go
@@ -30,6 +30,7 @@ import (
 	"github.com/temporalio/sqlparser"
 
 	"go.temporal.io/server/common/persistence/visibility/store/query"
+	"go.temporal.io/server/common/searchattribute"
 )
 
 var allowedComparisonOperators = map[string]struct{}{
@@ -48,6 +49,7 @@ var allowedComparisonOperators = map[string]struct{}{
 func NewQueryConverter(
 	fnInterceptor query.FieldNameInterceptor,
 	fvInterceptor query.FieldValuesInterceptor,
+	nameType searchattribute.NameTypeMap,
 ) *query.Converter {
 	if fnInterceptor == nil {
 		fnInterceptor = &query.NopFieldNameInterceptor{}
@@ -58,7 +60,7 @@ func NewQueryConverter(
 	}
 
 	rangeCond := query.NewRangeCondConverter(fnInterceptor, fvInterceptor, true)
-	comparisonExpr := query.NewComparisonExprConverter(fnInterceptor, fvInterceptor, allowedComparisonOperators)
+	comparisonExpr := query.NewComparisonExprConverter(fnInterceptor, fvInterceptor, allowedComparisonOperators, nameType)
 	is := query.NewIsConverter(fnInterceptor)
 
 	whereConverter := &query.WhereConverter{

--- a/common/persistence/visibility/store/elasticsearch/converter_test.go
+++ b/common/persistence/visibility/store/elasticsearch/converter_test.go
@@ -33,7 +33,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
+	"go.temporal.io/server/common/searchattribute"
 )
 
 var errorCases = map[string]string{
@@ -56,27 +58,27 @@ var errorCases = map[string]string{
 }
 
 var supportedWhereCases = map[string]string{
-	"process_id= 1":                 `{"bool":{"filter":{"match":{"process_id":{"query":1}}}}}`,
-	"(process_id= 1)":               `{"bool":{"filter":{"match":{"process_id":{"query":1}}}}}`,
-	"((process_id= 1))":             `{"bool":{"filter":{"match":{"process_id":{"query":1}}}}}`,
-	"(process_id = 1 and status=1)": `{"bool":{"filter":[{"match":{"process_id":{"query":1}}},{"match":{"status":{"query":1}}}]}}`,
-	"`status`=1":                    `{"bool":{"filter":{"match":{"status":{"query":1}}}}}`,
+	"process_id= 1":                 `{"bool":{"filter":{"term":{"process_id":1}}}}`,
+	"(process_id= 1)":               `{"bool":{"filter":{"term":{"process_id":1}}}}`,
+	"((process_id= 1))":             `{"bool":{"filter":{"term":{"process_id":1}}}}`,
+	"(process_id = 1 and status=1)": `{"bool":{"filter":[{"term":{"process_id":1}},{"term":{"status":1}}]}}`,
+	"`status`=1":                    `{"bool":{"filter":{"term":{"status":1}}}}`,
 	"process_id > 1":                `{"bool":{"filter":{"range":{"process_id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}}}}`,
 	"process_id < 1":                `{"bool":{"filter":{"range":{"process_id":{"from":null,"include_lower":true,"include_upper":false,"to":1}}}}}`,
 	"process_id <= 1":               `{"bool":{"filter":{"range":{"process_id":{"from":null,"include_lower":true,"include_upper":true,"to":1}}}}}`,
 	"process_id >= 1":               `{"bool":{"filter":{"range":{"process_id":{"from":1,"include_lower":true,"include_upper":true,"to":null}}}}}`,
-	"process_id != 1":               `{"bool":{"must_not":{"match":{"process_id":{"query":1}}}}}`,
-	"process_id = 0 and status= 1 and channel = 4": `{"bool":{"filter":[{"match":{"process_id":{"query":0}}},{"match":{"status":{"query":1}}},{"match":{"channel":{"query":4}}}]}}`,
-	"process_id > 1 and status = 1":                `{"bool":{"filter":[{"range":{"process_id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}},{"match":{"status":{"query":1}}}]}}`,
-	"id > 1 or process_id = 0":                     `{"bool":{"should":[{"range":{"id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}},{"match":{"process_id":{"query":0}}}]}}`,
-	"id > 1 and d = 1 or process_id = 0 and x = 2": `{"bool":{"should":[{"bool":{"filter":[{"range":{"id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}},{"match":{"d":{"query":1}}}]}},{"bool":{"filter":[{"match":{"process_id":{"query":0}}},{"match":{"x":{"query":2}}}]}}]}}`,
-	"(id > 1 and d = 1)":                           `{"bool":{"filter":[{"range":{"id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}},{"match":{"d":{"query":1}}}]}}`,
-	"(id > 1 and d = 1) or (c=1)":                  `{"bool":{"should":[{"bool":{"filter":[{"range":{"id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}},{"match":{"d":{"query":1}}}]}},{"match":{"c":{"query":1}}}]}}`,
-	"nid=1 and (cif = 1 or cif = 2)":               `{"bool":{"filter":[{"match":{"nid":{"query":1}}},{"bool":{"should":[{"match":{"cif":{"query":1}}},{"match":{"cif":{"query":2}}}]}}]}}`,
-	"id > 1 or (process_id = 0)":                   `{"bool":{"should":[{"range":{"id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}},{"match":{"process_id":{"query":0}}}]}}`,
+	"process_id != 1":               `{"bool":{"must_not":{"term":{"process_id":1}}}}`,
+	"process_id = 0 and status= 1 and channel = 4": `{"bool":{"filter":[{"term":{"process_id":0}},{"term":{"status":1}},{"term":{"channel":4}}]}}`,
+	"process_id > 1 and status = 1":                `{"bool":{"filter":[{"range":{"process_id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}},{"term":{"status":1}}]}}`,
+	"id > 1 or process_id = 0":                     `{"bool":{"should":[{"range":{"id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}},{"term":{"process_id":0}}]}}`,
+	"id > 1 and d = 1 or process_id = 0 and x = 2": `{"bool":{"should":[{"bool":{"filter":[{"range":{"id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}},{"term":{"d":1}}]}},{"bool":{"filter":[{"term":{"process_id":0}},{"term":{"x":2}}]}}]}}`,
+	"(id > 1 and d = 1)":                           `{"bool":{"filter":[{"range":{"id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}},{"term":{"d":1}}]}}`,
+	"(id > 1 and d = 1) or (c=1)":                  `{"bool":{"should":[{"bool":{"filter":[{"range":{"id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}},{"term":{"d":1}}]}},{"term":{"c":1}}]}}`,
+	"nid=1 and (cif = 1 or cif = 2)":               `{"bool":{"filter":[{"term":{"nid":1}},{"bool":{"should":[{"term":{"cif":1}},{"term":{"cif":2}}]}}]}}`,
+	"id > 1 or (process_id = 0)":                   `{"bool":{"should":[{"range":{"id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}},{"term":{"process_id":0}}]}}`,
 	"id in (1,2,3,4)":                              `{"bool":{"filter":{"terms":{"id":[1,2,3,4]}}}}`,
-	"a = 'text'":                                   `{"bool":{"filter":{"match":{"a":{"query":"text"}}}}}`,
-	"`by` = 1":                                     `{"bool":{"filter":{"match":{"by":{"query":1}}}}}`,
+	"a = 'text'":                                   `{"bool":{"filter":{"term":{"a":"text"}}}}`,
+	"`by` = 1":                                     `{"bool":{"filter":{"term":{"by":1}}}}`,
 	"id not IN (1, 2,3)":                           `{"bool":{"must_not":{"terms":{"id":[1,2,3]}}}}`,
 	"id iS not null":                               `{"bool":{"filter":{"exists":{"field":"id"}}}}`,
 	"id is NULL":                                   `{"bool":{"must_not":{"exists":{"field":"id"}}}}`,
@@ -92,7 +94,7 @@ var supportedWhereCases = map[string]string{
 	"id in (\"text1\",'text2') and content = 'aaaa'":                          `{"bool":{"filter":[{"terms":{"id":["text1","text2"]}},{"match":{"content":{"query":"aaaa"}}}]}}`,
 	"create_time BETWEEN '2015-01-01 00:00:00' and '2016-02-02 00:00:00'":     `{"bool":{"filter":{"range":{"create_time":{"from":"2015-01-01 00:00:00","include_lower":true,"include_upper":true,"to":"2016-02-02 00:00:00"}}}}}`,
 	"create_time nOt between '2015-01-01 00:00:00' and '2016-02-02 00:00:00'": `{"bool":{"must_not":{"range":{"create_time":{"from":"2015-01-01 00:00:00","include_lower":true,"include_upper":true,"to":"2016-02-02 00:00:00"}}}}}`,
-	"create_time between '2015-01-01T00:00:00+0800' and '2017-01-01T00:00:00+0800' and process_id = 0 and status >= 1 and content = '三个男人' and phone = '15810324322'": `{"bool":{"filter":[{"range":{"create_time":{"from":"2015-01-01T00:00:00+0800","include_lower":true,"include_upper":true,"to":"2017-01-01T00:00:00+0800"}}},{"match":{"process_id":{"query":0}}},{"range":{"status":{"from":1,"include_lower":true,"include_upper":true,"to":null}}},{"match":{"content":{"query":"三个男人"}}},{"match":{"phone":{"query":"15810324322"}}}]}}`,
+	"create_time between '2015-01-01T00:00:00+0800' and '2017-01-01T00:00:00+0800' and process_id = 0 and status >= 1 and content = '三个男人' and phone = '15810324322'": `{"bool":{"filter":[{"range":{"create_time":{"from":"2015-01-01T00:00:00+0800","include_lower":true,"include_upper":true,"to":"2017-01-01T00:00:00+0800"}}},{"term":{"process_id":0}},{"range":{"status":{"from":1,"include_lower":true,"include_upper":true,"to":null}}},{"match":{"content":{"query":"三个男人"}}},{"match":{"phone":{"query":"15810324322"}}}]}}`,
 	"value starts_with 'prefix'":     `{"bool":{"filter":{"prefix":{"value":"prefix"}}}}`,
 	"value not starts_with 'prefix'": `{"bool":{"must_not":{"prefix":{"value":"prefix"}}}}`,
 }
@@ -124,13 +126,34 @@ var supportedWhereGroupByCases = map[string]struct {
 		groupBy: []string{"status"},
 	},
 	"id = 1 group by status": {
-		query:   `{"bool":{"filter":{"match":{"id":{"query":1}}}}}`,
+		query:   `{"bool":{"filter":{"term":{"id":1}}}}`,
 		groupBy: []string{"status"},
 	},
 }
 
+var testNameTypeMap = searchattribute.NewNameTypeMapStub(
+	map[string]enumspb.IndexedValueType{
+		"process_id":  enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"status":      enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"channel":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"id":          enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"nid":         enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"a":           enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"b":           enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"c":           enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"d":           enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"x":           enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"by":          enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"value":       enumspb.INDEXED_VALUE_TYPE_TEXT,
+		"cif":         enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"content":     enumspb.INDEXED_VALUE_TYPE_TEXT,
+		"create_time": enumspb.INDEXED_VALUE_TYPE_DATETIME,
+		"phone":       enumspb.INDEXED_VALUE_TYPE_TEXT,
+	},
+)
+
 func TestSupportedSelectWhere(t *testing.T) {
-	c := NewQueryConverter(nil, nil)
+	c := NewQueryConverter(nil, nil, testNameTypeMap)
 
 	for sql, expectedJson := range supportedWhereCases {
 		queryParams, err := c.ConvertWhereOrderBy(sql)
@@ -144,7 +167,7 @@ func TestSupportedSelectWhere(t *testing.T) {
 }
 
 func TestEmptySelectWhere(t *testing.T) {
-	c := NewQueryConverter(nil, nil)
+	c := NewQueryConverter(nil, nil, testNameTypeMap)
 
 	queryParams, err := c.ConvertWhereOrderBy("")
 	assert.NoError(t, err)
@@ -161,7 +184,7 @@ func TestEmptySelectWhere(t *testing.T) {
 }
 
 func TestSupportedSelectWhereOrder(t *testing.T) {
-	c := NewQueryConverter(nil, nil)
+	c := NewQueryConverter(nil, nil, testNameTypeMap)
 
 	for sql, expectedJson := range supportedWhereOrderCases {
 		queryParams, err := c.ConvertWhereOrderBy(sql)
@@ -182,7 +205,7 @@ func TestSupportedSelectWhereOrder(t *testing.T) {
 }
 
 func TestSupportedSelectWhereGroupBy(t *testing.T) {
-	c := NewQueryConverter(nil, nil)
+	c := NewQueryConverter(nil, nil, testNameTypeMap)
 
 	for sql, expectedJson := range supportedWhereGroupByCases {
 		queryParams, err := c.ConvertWhereOrderBy(sql)
@@ -200,7 +223,7 @@ func TestSupportedSelectWhereGroupBy(t *testing.T) {
 }
 
 func TestErrors(t *testing.T) {
-	c := NewQueryConverter(nil, nil)
+	c := NewQueryConverter(nil, nil, testNameTypeMap)
 	for sql, expectedErrMessage := range errorCases {
 		_, err := c.ConvertSql(sql)
 		assert.Contains(t, err.Error(), expectedErrMessage, sql)

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -736,6 +736,7 @@ func (s *visibilityStore) convertQuery(
 	queryConverter := NewQueryConverter(
 		nameInterceptor,
 		NewValuesInterceptor(namespace, saTypeMap, s.searchAttributesMapperProvider),
+		saTypeMap,
 	)
 	queryParams, err := queryConverter.ConvertWhereOrderBy(requestQueryStr)
 	if err != nil {

--- a/common/persistence/visibility/store/query/converter.go
+++ b/common/persistence/visibility/store/query/converter.go
@@ -75,7 +75,7 @@ type (
 		fnInterceptor    FieldNameInterceptor
 		fvInterceptor    FieldValuesInterceptor
 		allowedOperators map[string]struct{}
-		nameType         searchattribute.NameTypeMap
+		saNameType       searchattribute.NameTypeMap
 	}
 
 	isConverter struct {
@@ -170,7 +170,7 @@ func NewComparisonExprConverter(
 	fnInterceptor FieldNameInterceptor,
 	fvInterceptor FieldValuesInterceptor,
 	allowedOperators map[string]struct{},
-	nameType searchattribute.NameTypeMap,
+	saNameType searchattribute.NameTypeMap,
 ) ExprConverter {
 	if fnInterceptor == nil {
 		fnInterceptor = &NopFieldNameInterceptor{}
@@ -182,7 +182,7 @@ func NewComparisonExprConverter(
 		fnInterceptor:    fnInterceptor,
 		fvInterceptor:    fvInterceptor,
 		allowedOperators: allowedOperators,
-		nameType:         nameType,
+		saNameType:       saNameType,
 	}
 }
 
@@ -475,7 +475,7 @@ func (c *comparisonExprConverter) Convert(expr sqlparser.Expr) (elastic.Query, e
 		return nil, NewConverterError("operator '%v' not allowed in comparison expression", comparisonExpr.Operator)
 	}
 
-	tp, err := c.nameType.GetType(colName)
+	tp, err := c.saNameType.GetType(colName)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/visibility/store/query/interceptors_test.go
+++ b/common/persistence/visibility/store/query/interceptors_test.go
@@ -31,6 +31,8 @@ import (
 	"testing"
 
 	"github.com/temporalio/sqlparser"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/searchattribute"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -74,7 +76,7 @@ func TestNameInterceptor(t *testing.T) {
 	assert.NoError(t, err)
 	actualQueryMap, _ := queryParams.Query.Source()
 	actualQueryJson, _ := json.Marshal(actualQueryMap)
-	assert.Equal(t, `{"bool":{"filter":{"match":{"ExecutionStatus1":{"query":"Running"}}}}}`, string(actualQueryJson))
+	assert.Equal(t, `{"bool":{"filter":{"term":{"ExecutionStatus1":"Running"}}}}`, string(actualQueryJson))
 	var actualSorterMaps []interface{}
 	for _, sorter := range queryParams.Sorter {
 		actualSorterMap, _ := sorter.Source()
@@ -94,7 +96,7 @@ func TestValuesInterceptor(t *testing.T) {
 	assert.NoError(t, err)
 	actualQueryMap, _ := queryParams.Query.Source()
 	actualQueryJson, _ := json.Marshal(actualQueryMap)
-	assert.Equal(t, `{"bool":{"filter":{"match":{"ExecutionStatus":{"query":"Status1"}}}}}`, string(actualQueryJson))
+	assert.Equal(t, `{"bool":{"filter":{"term":{"ExecutionStatus":"Status1"}}}}`, string(actualQueryJson))
 
 	queryParams, err = c.ConvertWhereOrderBy("ExecutionStatus in (1,2)")
 	assert.NoError(t, err)
@@ -114,11 +116,17 @@ func TestValuesInterceptor(t *testing.T) {
 }
 
 func getTestConverter(fnInterceptor FieldNameInterceptor, fvInterceptor FieldValuesInterceptor) *Converter {
+	testNameTypeMap := searchattribute.NewNameTypeMapStub(
+		map[string]enumspb.IndexedValueType{
+			"ExecutionStatus1": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"StartTime1":       enumspb.INDEXED_VALUE_TYPE_DATETIME,
+		},
+	)
 	whereConverter := NewWhereConverter(
 		nil,
 		nil,
 		NewRangeCondConverter(fnInterceptor, fvInterceptor, false),
-		NewComparisonExprConverter(fnInterceptor, fvInterceptor, map[string]struct{}{sqlparser.EqualStr: {}, sqlparser.InStr: {}}),
+		NewComparisonExprConverter(fnInterceptor, fvInterceptor, map[string]struct{}{sqlparser.EqualStr: {}, sqlparser.InStr: {}}, testNameTypeMap),
 		nil)
 	return NewConverter(fnInterceptor, whereConverter)
 }

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3531,7 +3531,11 @@ func (wh *WorkflowHandler) ListSchedules(
 
 	query := ""
 	if strings.TrimSpace(request.Query) != "" {
-		if err := scheduler.ValidateVisibilityQuery(request.Query); err != nil {
+		saNameType, err := wh.saProvider.GetSearchAttributes(wh.visibilityMgr.GetIndexName(), false)
+		if err != nil {
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
+		}
+		if err := scheduler.ValidateVisibilityQuery(request.Query, saNameType); err != nil {
 			return nil, err
 		}
 		query = fmt.Sprintf("%s AND (%s)", scheduler.VisibilityBaseListQuery, request.Query)

--- a/service/worker/scheduler/query.go
+++ b/service/worker/scheduler/query.go
@@ -53,8 +53,8 @@ func newFieldNameAggInterceptor() *fieldNameAggInterceptor {
 	}
 }
 
-func ValidateVisibilityQuery(queryString string, nameType searchattribute.NameTypeMap) error {
-	fields, err := getQueryFields(queryString, nameType)
+func ValidateVisibilityQuery(queryString string, saNameType searchattribute.NameTypeMap) error {
+	fields, err := getQueryFields(queryString, saNameType)
 	if err != nil {
 		return err
 	}
@@ -68,9 +68,9 @@ func ValidateVisibilityQuery(queryString string, nameType searchattribute.NameTy
 	return nil
 }
 
-func getQueryFields(queryString string, nameType searchattribute.NameTypeMap) ([]string, error) {
+func getQueryFields(queryString string, saNameType searchattribute.NameTypeMap) ([]string, error) {
 	fnInterceptor := newFieldNameAggInterceptor()
-	queryConverter := elasticsearch.NewQueryConverter(fnInterceptor, nil, nameType)
+	queryConverter := elasticsearch.NewQueryConverter(fnInterceptor, nil, saNameType)
 	_, err := queryConverter.ConvertWhereOrderBy(queryString)
 	if err != nil {
 		var converterErr *query.ConverterError

--- a/service/worker/scheduler/query.go
+++ b/service/worker/scheduler/query.go
@@ -53,8 +53,8 @@ func newFieldNameAggInterceptor() *fieldNameAggInterceptor {
 	}
 }
 
-func ValidateVisibilityQuery(queryString string) error {
-	fields, err := getQueryFields(queryString)
+func ValidateVisibilityQuery(queryString string, nameType searchattribute.NameTypeMap) error {
+	fields, err := getQueryFields(queryString, nameType)
 	if err != nil {
 		return err
 	}
@@ -68,9 +68,9 @@ func ValidateVisibilityQuery(queryString string) error {
 	return nil
 }
 
-func getQueryFields(queryString string) ([]string, error) {
+func getQueryFields(queryString string, nameType searchattribute.NameTypeMap) ([]string, error) {
 	fnInterceptor := newFieldNameAggInterceptor()
-	queryConverter := elasticsearch.NewQueryConverter(fnInterceptor, nil)
+	queryConverter := elasticsearch.NewQueryConverter(fnInterceptor, nil, nameType)
 	_, err := queryConverter.ConvertWhereOrderBy(queryString)
 	if err != nil {
 		var converterErr *query.ConverterError

--- a/service/worker/scheduler/query_test.go
+++ b/service/worker/scheduler/query_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
+	"go.temporal.io/server/common/searchattribute"
 )
 
 func TestFieldNameAggInterceptor(t *testing.T) {
@@ -109,7 +110,7 @@ func TestGetQueryFields(t *testing.T) {
 			tc.name,
 			func(t *testing.T) {
 				s := require.New(t)
-				fields, err := getQueryFields(tc.input)
+				fields, err := getQueryFields(tc.input, searchattribute.TestNameTypeMap)
 				if tc.expectedErrMsg == "" {
 					s.NoError(err)
 					s.Equal(len(tc.expectedFields), len(fields))
@@ -179,7 +180,7 @@ func TestValidateVisibilityQuery(t *testing.T) {
 			tc.name,
 			func(t *testing.T) {
 				s := require.New(t)
-				err := ValidateVisibilityQuery(tc.input)
+				err := ValidateVisibilityQuery(tc.input, searchattribute.TestNameTypeMap)
 				if tc.expectedErrMsg == "" {
 					s.NoError(err)
 				} else {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- ElasticSearch query converter now uses term query if the search attribute is of type KEYWORD or KEYWORD_LIST 
- otherwise, it uses match query to support type TEXT matching in custom search attribute
- added `searchattribute.NameTypeMap` in `comparisonExprConverter` to support this

## Why?
<!-- Tell your future self why have you made these changes -->
- Improvement in performance: term query is generally faster than match query

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- modified converter and elasticsearch unit tests accordingly to use term query

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
