### PR TITLE
Skip namespace state validation based on the request type

### DIFF
--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -212,6 +212,11 @@ func (ni *NamespaceValidatorInterceptor) StateValidationIntercept(
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (interface{}, error) {
+
+	if !ni.shouldValidateNamespace(req) {
+		return handler(ctx, req)
+	}
+
 	namespaceEntry, err := ni.extractNamespace(req)
 	if err != nil {
 		return nil, err
@@ -222,6 +227,16 @@ func (ni *NamespaceValidatorInterceptor) StateValidationIntercept(
 	}
 
 	return handler(ctx, req)
+}
+
+// while most(all?) workflow related requests must have namespace field
+// admin request at most should
+func (ni *NamespaceValidatorInterceptor) shouldValidateNamespace(req interface{}) bool {
+	switch req.(type) {
+	case *adminservice.DescribeHistoryHostRequest:
+		return false
+	}
+	return true
 }
 
 // ValidateState validates:

--- a/common/rpc/interceptor/namespace_validator_test.go
+++ b/common/rpc/interceptor/namespace_validator_test.go
@@ -485,6 +485,31 @@ func (s *namespaceValidatorSuite) Test_Intercept_RegisterNamespace() {
 	s.False(handlerCalled)
 }
 
+func (s *namespaceValidatorSuite) Test_StateValidationIntercept_ShouldValidate() {
+	testCases := []struct {
+		req            any
+		shouldValidate bool
+	}{
+		{
+			req:            &adminservice.AddSearchAttributesRequest{},
+			shouldValidate: true,
+		},
+		{
+			req:            &workflowservice.RegisterNamespaceRequest{},
+			shouldValidate: true,
+		},
+		{
+			req:            &adminservice.DescribeHistoryHostRequest{},
+			shouldValidate: false,
+		},
+	}
+	nvi := NewNamespaceValidatorInterceptor(nil, nil, nil)
+	for _, testCase := range testCases {
+		result := nvi.shouldValidateNamespace(testCase.req)
+		s.Equal(testCase.shouldValidate, result)
+	}
+}
+
 func (s *namespaceValidatorSuite) Test_StateValidationIntercept_TokenNamespaceEnforcement() {
 	testCases := []struct {
 		tokenNamespaceID                namespace.ID


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add a logic to namespace state validator to select what request to process.

## Why?
<!-- Tell your future self why have you made these changes -->
Before the logic assumes that namespace should present and be valid in every request.
This is not the case at least for some admin requests. 

There is no conditional interceptors, so we need to add 'should we event check namespace' logic into validator code.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Add unit tests.


## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
None, logic is isolated.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
N/A
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
N/A