### PR TITLE
Revert "Revert change to default reapply type"

### DIFF
--- a/common/enums/defaults.go
+++ b/common/enums/defaults.go
@@ -75,7 +75,7 @@ func SetDefaultContinueAsNewInitiator(f *enumspb.ContinueAsNewInitiator) {
 
 func SetDefaultResetReapplyType(f *enumspb.ResetReapplyType) {
 	if *f == enumspb.RESET_REAPPLY_TYPE_UNSPECIFIED {
-		*f = enumspb.RESET_REAPPLY_TYPE_SIGNAL
+		*f = enumspb.RESET_REAPPLY_TYPE_ALL_ELIGIBLE
 	}
 }
 

--- a/tests/reset_workflow.go
+++ b/tests/reset_workflow.go
@@ -344,6 +344,14 @@ func (s *FunctionalSuite) TestResetWorkflowAfterTimeout() {
 	8 WorkflowExecutionCompleted`, events)
 }
 
+func (s *FunctionalSuite) TestResetWorkflow_ExcludeNoneReapplyDefault() {
+	t := resetTest{
+		FunctionalSuite: s,
+		tv:              testvars.New(s.T()),
+	}
+	t.run()
+}
+
 func (s *FunctionalSuite) TestResetWorkflow_ExcludeNoneReapplyAll() {
 	t := resetTest{
 		FunctionalSuite:     s,

--- a/tests/xdc/history_replication_signals_and_updates_test.go
+++ b/tests/xdc/history_replication_signals_and_updates_test.go
@@ -1015,7 +1015,6 @@ func (c *hrsuTestCluster) resetWorkflow(ctx context.Context, workflowTaskFinishE
 		WorkflowExecution:         c.t.tv.WorkflowExecution(),
 		Reason:                    "reset",
 		WorkflowTaskFinishEventId: workflowTaskFinishEventId,
-		ResetReapplyType:          enumspb.RESET_REAPPLY_TYPE_ALL_ELIGIBLE,
 	})
 	c.t.s.NoError(err)
 	return resp.RunId


### PR DESCRIPTION
## What changed?
Change default `ResetReapply` enum value to `ALL_ELIGIBLE`.

## Why?
Reverts temporalio/temporal#5688, i.e. after this PR we will have the behavior described in https://github.com/temporalio/temporal/pull/5360. This means both signals *and* updates will be reapplied by default during resets and coinflict resolution, which is the product behavior we want.

### Explanation
- #5360 attempted to introduce a new proto enum value and start using it as the default
- However, that is not a valid single-deploy change, since it can cause a frontend client on the new version to send a value that is unknown to a history node on the old version.
- Therefore #5688 reverted the change to the default, allowing the new proto enum value to be introduced to the codebase
- This PR is deployable iff all clusters that we deploy to have #5360 deployed


## How did you test it?
I didn't. Tests were added in the original PR https://github.com/temporalio/temporal/pull/5360.

## Potential risks
Could break reset or history conflict resolution.

## Is hotfix candidate?
1.25.1