### PR TITLE
Move most dynamicconfig tests to external package

### DIFF
--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -273,8 +273,8 @@ func convertMap(val any) (map[string]any, error) {
 	return nil, errors.New("value type is not map")
 }
 
-// ConvertStructure can be used as a conversion function for New*TypedSetting. The value from
-// dynamic config will be converted to T, on top of the given default.
+// ConvertStructure can be used as a conversion function for New*TypedSettingWithConverter.
+// The value from dynamic config will be converted to T, on top of the given default.
 //
 // Note that any failure in conversion of _any_ field will result in the overall default being used,
 // ignoring the fields that successfully converted.

--- a/common/dynamicconfig/collection_test.go
+++ b/common/dynamicconfig/collection_test.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package dynamicconfig
+package dynamicconfig_test
 
 import (
 	"maps"
@@ -31,7 +31,9 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 )
 
@@ -63,8 +65,8 @@ const (
 // provided from a file.
 type collectionSuite struct {
 	suite.Suite
-	client StaticClient
-	cln    *Collection
+	client dynamicconfig.StaticClient
+	cln    *dynamicconfig.Collection
 }
 
 func TestCollectionSuite(t *testing.T) {
@@ -73,13 +75,13 @@ func TestCollectionSuite(t *testing.T) {
 }
 
 func (s *collectionSuite) SetupSuite() {
-	s.client = make(StaticClient)
+	s.client = make(dynamicconfig.StaticClient)
 	logger := log.NewNoopLogger()
-	s.cln = NewCollection(s.client, logger)
+	s.cln = dynamicconfig.NewCollection(s.client, logger)
 }
 
 func (s *collectionSuite) TestGetIntProperty() {
-	setting := NewGlobalIntSetting(testGetIntPropertyKey, 10, "")
+	setting := dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 10, "")
 	value := setting.Get(s.cln)
 	s.Equal(10, value())
 	s.client[testGetIntPropertyKey] = 50
@@ -87,7 +89,7 @@ func (s *collectionSuite) TestGetIntProperty() {
 }
 
 func (s *collectionSuite) TestGetIntPropertyFilteredByNamespace() {
-	setting := NewNamespaceIntSetting(testGetIntPropertyFilteredByNamespaceKey, 10, "")
+	setting := dynamicconfig.NewNamespaceIntSetting(testGetIntPropertyFilteredByNamespaceKey, 10, "")
 	namespace := "testNamespace"
 	value := setting.Get(s.cln)
 	s.Equal(10, value(namespace))
@@ -97,14 +99,15 @@ func (s *collectionSuite) TestGetIntPropertyFilteredByNamespace() {
 
 func (s *collectionSuite) TestGetStringPropertyFnFilteredByNamespace() {
 	namespace := "testNamespace"
-	value := DefaultEventEncoding.Get(s.cln)
-	s.Equal(DefaultEventEncoding.def, value(namespace))
-	s.client[DefaultEventEncoding.key] = "efg"
+	value := dynamicconfig.DefaultEventEncoding.Get(s.cln)
+	// copied default value, change this if it changes
+	s.Equal(enumspb.ENCODING_TYPE_PROTO3.String(), value(namespace))
+	s.client[dynamicconfig.DefaultEventEncoding.Key()] = "efg"
 	s.Equal("efg", value(namespace))
 }
 
 func (s *collectionSuite) TestGetStringPropertyFnFilteredByNamespaceID() {
-	setting := NewNamespaceIDStringSetting(testGetStringPropertyFilteredByNamespaceIDKey, "abc", "")
+	setting := dynamicconfig.NewNamespaceIDStringSetting(testGetStringPropertyFilteredByNamespaceIDKey, "abc", "")
 	namespaceID := "testNamespaceID"
 	value := setting.Get(s.cln)
 	s.Equal("abc", value(namespaceID))
@@ -113,7 +116,7 @@ func (s *collectionSuite) TestGetStringPropertyFnFilteredByNamespaceID() {
 }
 
 func (s *collectionSuite) TestGetIntPropertyFilteredByTaskQueueInfo() {
-	setting := NewTaskQueueIntSetting(testGetIntPropertyFilteredByTaskQueueInfoKey, 10, "")
+	setting := dynamicconfig.NewTaskQueueIntSetting(testGetIntPropertyFilteredByTaskQueueInfoKey, 10, "")
 	namespace := "testNamespace"
 	taskQueue := "testTaskQueue"
 	value := setting.Get(s.cln)
@@ -123,7 +126,7 @@ func (s *collectionSuite) TestGetIntPropertyFilteredByTaskQueueInfo() {
 }
 
 func (s *collectionSuite) TestGetFloat64Property() {
-	setting := NewGlobalFloatSetting(testGetFloat64PropertyKey, 0.1, "")
+	setting := dynamicconfig.NewGlobalFloatSetting(testGetFloat64PropertyKey, 0.1, "")
 	value := setting.Get(s.cln)
 	s.Equal(0.1, value())
 	s.client[testGetFloat64PropertyKey] = 0.01
@@ -131,7 +134,7 @@ func (s *collectionSuite) TestGetFloat64Property() {
 }
 
 func (s *collectionSuite) TestGetBoolProperty() {
-	setting := NewGlobalBoolSetting(testGetBoolPropertyKey, true, "")
+	setting := dynamicconfig.NewGlobalBoolSetting(testGetBoolPropertyKey, true, "")
 	value := setting.Get(s.cln)
 	s.Equal(true, value())
 	s.client[testGetBoolPropertyKey] = false
@@ -139,7 +142,7 @@ func (s *collectionSuite) TestGetBoolProperty() {
 }
 
 func (s *collectionSuite) TestGetBoolPropertyFilteredByNamespaceID() {
-	setting := NewNamespaceIDBoolSetting(testGetBoolPropertyFilteredByNamespaceIDKey, true, "")
+	setting := dynamicconfig.NewNamespaceIDBoolSetting(testGetBoolPropertyFilteredByNamespaceIDKey, true, "")
 	namespaceID := "testNamespaceID"
 	value := setting.Get(s.cln)
 	s.Equal(true, value(namespaceID))
@@ -148,7 +151,7 @@ func (s *collectionSuite) TestGetBoolPropertyFilteredByNamespaceID() {
 }
 
 func (s *collectionSuite) TestGetBoolPropertyFilteredByTaskQueueInfo() {
-	setting := NewTaskQueueBoolSetting(testGetBoolPropertyFilteredByTaskQueueInfoKey, false, "")
+	setting := dynamicconfig.NewTaskQueueBoolSetting(testGetBoolPropertyFilteredByTaskQueueInfoKey, false, "")
 	namespace := "testNamespace"
 	taskQueue := "testTaskQueue"
 	value := setting.Get(s.cln)
@@ -158,7 +161,7 @@ func (s *collectionSuite) TestGetBoolPropertyFilteredByTaskQueueInfo() {
 }
 
 func (s *collectionSuite) TestGetDurationProperty() {
-	setting := NewGlobalDurationSetting(testGetDurationPropertyKey, 1*time.Second, "")
+	setting := dynamicconfig.NewGlobalDurationSetting(testGetDurationPropertyKey, 1*time.Second, "")
 	value := setting.Get(s.cln)
 	s.Equal(time.Second, value())
 	s.client[testGetDurationPropertyKey] = time.Minute
@@ -170,7 +173,7 @@ func (s *collectionSuite) TestGetDurationProperty() {
 }
 
 func (s *collectionSuite) TestGetDurationPropertyFilteredByNamespace() {
-	setting := NewNamespaceDurationSetting(testGetDurationPropertyFilteredByNamespaceKey, time.Second, "")
+	setting := dynamicconfig.NewNamespaceDurationSetting(testGetDurationPropertyFilteredByNamespaceKey, time.Second, "")
 	namespace := "testNamespace"
 	value := setting.Get(s.cln)
 	s.Equal(time.Second, value(namespace))
@@ -179,7 +182,7 @@ func (s *collectionSuite) TestGetDurationPropertyFilteredByNamespace() {
 }
 
 func (s *collectionSuite) TestGetDurationPropertyFilteredByTaskQueueInfo() {
-	setting := NewTaskQueueDurationSetting(testGetDurationPropertyFilteredByTaskQueueInfoKey, time.Second, "")
+	setting := dynamicconfig.NewTaskQueueDurationSetting(testGetDurationPropertyFilteredByTaskQueueInfoKey, time.Second, "")
 	namespace := "testNamespace"
 	taskQueue := "testTaskQueue"
 	value := setting.Get(s.cln)
@@ -189,7 +192,7 @@ func (s *collectionSuite) TestGetDurationPropertyFilteredByTaskQueueInfo() {
 }
 
 func (s *collectionSuite) TestGetDurationPropertyFilteredByTaskType() {
-	setting := NewTaskTypeDurationSetting(testGetDurationPropertyFilteredByTaskTypeKey, time.Second, "")
+	setting := dynamicconfig.NewTaskTypeDurationSetting(testGetDurationPropertyFilteredByTaskTypeKey, time.Second, "")
 	taskType := enumsspb.TASK_TYPE_UNSPECIFIED
 	value := setting.Get(s.cln)
 	s.Equal(time.Second, value(taskType))
@@ -198,18 +201,18 @@ func (s *collectionSuite) TestGetDurationPropertyFilteredByTaskType() {
 }
 
 func (s *collectionSuite) TestGetDurationPropertyStructuredDefaults() {
-	setting := NewTaskQueueDurationSettingWithConstrainedDefault(
+	setting := dynamicconfig.NewTaskQueueDurationSettingWithConstrainedDefault(
 		testGetDurationPropertyStructuredDefaults,
-		[]TypedConstrainedValue[time.Duration]{
+		[]dynamicconfig.TypedConstrainedValue[time.Duration]{
 			{
-				Constraints: Constraints{
+				Constraints: dynamicconfig.Constraints{
 					Namespace:     "ns2",
 					TaskQueueName: "tq2",
 				},
 				Value: 2 * time.Minute,
 			},
 			{
-				Constraints: Constraints{
+				Constraints: dynamicconfig.Constraints{
 					TaskQueueName: "tq2",
 				},
 				Value: 5 * time.Minute,
@@ -228,9 +231,9 @@ func (s *collectionSuite) TestGetDurationPropertyStructuredDefaults() {
 
 	// user-set values should take precedence. defaults are included below in the interleaved
 	// precedence order to make the test easier to read
-	s.client[testGetDurationPropertyStructuredDefaults] = []ConstrainedValue{
+	s.client[testGetDurationPropertyStructuredDefaults] = []dynamicconfig.ConstrainedValue{
 		{
-			Constraints: Constraints{
+			Constraints: dynamicconfig.Constraints{
 				Namespace:     "ns2",
 				TaskQueueName: "tq2",
 			},
@@ -250,7 +253,7 @@ func (s *collectionSuite) TestGetDurationPropertyStructuredDefaults() {
 		//   Value: 5 * time.Minute,
 		// },
 		{
-			Constraints: Constraints{
+			Constraints: dynamicconfig.Constraints{
 				Namespace: "ns1",
 			},
 			Value: 5 * time.Second,
@@ -270,14 +273,15 @@ func (s *collectionSuite) TestGetDurationPropertyStructuredDefaults() {
 }
 
 func (s *collectionSuite) TestGetMapProperty() {
-	setting := NewGlobalMapSetting(
+	def := map[string]interface{}{"testKey": 123}
+	setting := dynamicconfig.NewGlobalMapSetting(
 		testGetMapPropertyKey,
-		map[string]interface{}{"testKey": 123},
+		def,
 		"",
 	)
 	value := setting.Get(s.cln)
-	s.Equal(setting.def, value())
-	val := maps.Clone(setting.def)
+	s.Equal(def, value())
+	val := maps.Clone(def)
 	val["testKey"] = "321"
 	s.client[testGetMapPropertyKey] = val
 	s.Equal(val, value())
@@ -289,16 +293,17 @@ func (s *collectionSuite) TestGetTyped() {
 		Number int
 		Names  []string
 	}
-	setting := NewGlobalTypedSettingWithConverter(
+	def := myFancyType{28, []string{"global", "typed", "setting"}}
+	setting := dynamicconfig.NewGlobalTypedSettingWithConverter(
 		testGetTypedPropertyKey,
-		ConvertStructure(myFancyType{-3, nil}), // used if convert is called
-		myFancyType{28, []string{"global", "typed", "setting"}},
+		dynamicconfig.ConvertStructure(myFancyType{-3, nil}), // used if convert is called
+		def,
 		"",
 	)
 	get := setting.Get(s.cln)
 
 	s.Run("Default", func() {
-		s.Equal(setting.def, get())
+		s.Equal(def, get())
 	})
 
 	s.Run("Basic", func() {
@@ -323,21 +328,22 @@ func (s *collectionSuite) TestGetTyped() {
 
 	s.Run("WrongType", func() {
 		s.client[testGetTypedPropertyKey] = 200
-		s.Equal(setting.def, get())
+		s.Equal(def, get())
 	})
 }
 
 func (s *collectionSuite) TestGetTypedSimpleList() {
-	setting := NewGlobalTypedSettingWithConverter(
+	def := []float64{1.5, 1.1, 2.6, 3.7, 6.3}
+	setting := dynamicconfig.NewGlobalTypedSettingWithConverter(
 		testGetTypedPropertyKey,
-		ConvertStructure([]float64(nil)),
-		[]float64{1.5, 1.1, 2.6, 3.7, 6.3},
+		dynamicconfig.ConvertStructure([]float64(nil)),
+		def,
 		"",
 	)
 	get := setting.Get(s.cln)
 
 	s.Run("Default", func() {
-		s.Equal(setting.def, get())
+		s.Equal(def, get())
 	})
 
 	s.Run("Basic", func() {
@@ -347,22 +353,23 @@ func (s *collectionSuite) TestGetTypedSimpleList() {
 
 	s.Run("WrongType", func() {
 		s.client[testGetTypedPropertyKey] = []any{88.8, false, -5, "oops"}
-		s.Equal(setting.def, get())
+		s.Equal(def, get())
 	})
 }
 
 func (s *collectionSuite) TestGetTypedListOfStruct() {
 	type simple struct{ A, B int }
-	setting := NewGlobalTypedSettingWithConverter(
+	def := []simple{{1, 5}, {2, 9}}
+	setting := dynamicconfig.NewGlobalTypedSettingWithConverter(
 		testGetTypedPropertyKey,
-		ConvertStructure([]simple(nil)),
-		[]simple{{1, 5}, {2, 9}},
+		dynamicconfig.ConvertStructure([]simple(nil)),
+		def,
 		"",
 	)
 	get := setting.Get(s.cln)
 
 	s.Run("Default", func() {
-		s.Equal(setting.def, get())
+		s.Equal(def, get())
 	})
 
 	s.Run("Basic", func() {
@@ -378,39 +385,39 @@ func (s *collectionSuite) TestGetTypedListOfStruct() {
 		s.client[testGetTypedPropertyKey] = []any{
 			map[string]any{"A": false, "B": true},
 		}
-		s.Equal(setting.def, get())
+		s.Equal(def, get())
 	})
 }
 
 func (s *collectionSuite) TestGetIntPropertyFilteredByDestination() {
-	setting := NewDestinationIntSetting(testGetIntPropertyFilteredByDestinationKey, 10, "")
+	setting := dynamicconfig.NewDestinationIntSetting(testGetIntPropertyFilteredByDestinationKey, 10, "")
 	namespaceName := "testNamespace"
 	destination1 := "testDestination1"
 	destination2 := "testDestination2"
 	value := setting.Get(s.cln)
 	s.Equal(10, value(namespaceName, destination1))
-	s.client[testGetIntPropertyFilteredByDestinationKey] = []ConstrainedValue{
+	s.client[testGetIntPropertyFilteredByDestinationKey] = []dynamicconfig.ConstrainedValue{
 		{
-			Constraints: Constraints{
+			Constraints: dynamicconfig.Constraints{
 				Namespace:   namespaceName,
 				Destination: destination1,
 			},
 			Value: 50,
 		},
 		{
-			Constraints: Constraints{
+			Constraints: dynamicconfig.Constraints{
 				Namespace: namespaceName,
 			},
 			Value: 75,
 		},
 		{
-			Constraints: Constraints{
+			Constraints: dynamicconfig.Constraints{
 				Destination: destination1,
 			},
 			Value: 90,
 		},
 		{
-			Constraints: Constraints{
+			Constraints: dynamicconfig.Constraints{
 				Destination: destination2,
 			},
 			Value: 100,
@@ -423,181 +430,81 @@ func (s *collectionSuite) TestGetIntPropertyFilteredByDestination() {
 	s.Equal(10, value("testAnotherNamespace", "testAnotherDestination"))
 }
 
-func (s *collectionSuite) TestFindMatch() {
-	testCases := []struct {
-		v       []ConstrainedValue
-		filters []Constraints
-		matched bool
-	}{
-		{
-			v: []ConstrainedValue{
-				{Constraints: Constraints{}},
-			},
-			filters: []Constraints{
-				{Namespace: "some random namespace"},
-			},
-			matched: false,
-		},
-		{
-			v: []ConstrainedValue{
-				{Constraints: Constraints{Namespace: "samples-namespace"}},
-			},
-			filters: []Constraints{
-				{Namespace: "some random namespace"},
-			},
-			matched: false,
-		},
-		{
-			v: []ConstrainedValue{
-				{Constraints: Constraints{Namespace: "samples-namespace", TaskQueueName: "sample-task-queue"}},
-			},
-			filters: []Constraints{
-				{Namespace: "samples-namespace", TaskQueueName: "sample-task-queue"},
-			},
-			matched: true,
-		},
-		{
-			v: []ConstrainedValue{
-				{Constraints: Constraints{Namespace: "samples-namespace"}},
-			},
-			filters: []Constraints{
-				{TaskQueueName: "sample-task-queue"},
-			},
-			matched: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		_, err := findMatch[struct{}](tc.v, nil, tc.filters)
-		s.Equal(tc.matched, err == nil)
-	}
-}
-
-func (s *collectionSuite) TestFindMatchWithTyped() {
-	testCases := []struct {
-		tv      []TypedConstrainedValue[struct{}]
-		filters []Constraints
-		matched bool
-	}{
-		{
-			tv: []TypedConstrainedValue[struct{}]{
-				{Constraints: Constraints{}},
-			},
-			filters: []Constraints{
-				{Namespace: "some random namespace"},
-			},
-			matched: false,
-		},
-		{
-			tv: []TypedConstrainedValue[struct{}]{
-				{Constraints: Constraints{Namespace: "samples-namespace"}},
-			},
-			filters: []Constraints{
-				{Namespace: "some random namespace"},
-			},
-			matched: false,
-		},
-		{
-			tv: []TypedConstrainedValue[struct{}]{
-				{Constraints: Constraints{Namespace: "samples-namespace", TaskQueueName: "sample-task-queue"}},
-			},
-			filters: []Constraints{
-				{Namespace: "samples-namespace", TaskQueueName: "sample-task-queue"},
-			},
-			matched: true,
-		},
-		{
-			tv: []TypedConstrainedValue[struct{}]{
-				{Constraints: Constraints{Namespace: "samples-namespace"}},
-			},
-			filters: []Constraints{
-				{TaskQueueName: "sample-task-queue"},
-			},
-			matched: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		_, err := findMatch(nil, tc.tv, tc.filters)
-		s.Equal(tc.matched, err == nil)
-	}
-}
-
 func BenchmarkCollection(b *testing.B) {
 	// client with just one value
-	client1 := StaticClient(map[Key]any{
-		MatchingMaxTaskBatchSize.Key(): []ConstrainedValue{{Value: 12}},
-	})
-	cln1 := NewCollection(client1, log.NewNoopLogger())
+	client1 := dynamicconfig.StaticClient{
+		dynamicconfig.MatchingMaxTaskBatchSize.Key(): []dynamicconfig.ConstrainedValue{{Value: 12}},
+	}
+	cln1 := dynamicconfig.NewCollection(client1, log.NewNoopLogger())
 	b.Run("global int", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N/2; i++ {
-			size := MatchingThrottledLogRPS.Get(cln1)
+			size := dynamicconfig.MatchingThrottledLogRPS.Get(cln1)
 			_ = size()
-			size = MatchingThrottledLogRPS.Get(cln1)
+			size = dynamicconfig.MatchingThrottledLogRPS.Get(cln1)
 			_ = size()
 		}
 	})
 	b.Run("namespace int", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N/2; i++ {
-			size := HistoryMaxPageSize.Get(cln1)
+			size := dynamicconfig.HistoryMaxPageSize.Get(cln1)
 			_ = size("my-namespace")
-			size = WorkflowExecutionMaxInFlightUpdates.Get(cln1)
+			size = dynamicconfig.WorkflowExecutionMaxInFlightUpdates.Get(cln1)
 			_ = size("my-namespace")
 		}
 	})
 	b.Run("taskqueue int", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N/2; i++ {
-			size := MatchingMaxTaskBatchSize.Get(cln1)
+			size := dynamicconfig.MatchingMaxTaskBatchSize.Get(cln1)
 			_ = size("my-namespace", "my-task-queue", 1)
-			size = MatchingGetTasksBatchSize.Get(cln1)
+			size = dynamicconfig.MatchingGetTasksBatchSize.Get(cln1)
 			_ = size("my-namespace", "my-task-queue", 1)
 		}
 	})
 
 	// client with more constrained values
-	client2 := StaticClient(map[Key]any{
-		MatchingMaxTaskBatchSize.Key(): []ConstrainedValue{
+	client2 := dynamicconfig.StaticClient{
+		dynamicconfig.MatchingMaxTaskBatchSize.Key(): []dynamicconfig.ConstrainedValue{
 			{
-				Constraints: Constraints{
+				Constraints: dynamicconfig.Constraints{
 					TaskQueueName: "other-tq",
 				},
 				Value: 18,
 			},
 			{
-				Constraints: Constraints{
+				Constraints: dynamicconfig.Constraints{
 					Namespace: "other-ns",
 				},
 				Value: 15,
 			},
 		},
-	})
-	cln2 := NewCollection(client2, log.NewNoopLogger())
+	}
+	cln2 := dynamicconfig.NewCollection(client2, log.NewNoopLogger())
 	b.Run("single default", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N/4; i++ {
-			size := MatchingMaxTaskBatchSize.Get(cln2)
+			size := dynamicconfig.MatchingMaxTaskBatchSize.Get(cln2)
 			_ = size("my-namespace", "my-task-queue", 1)
-			size = MatchingMaxTaskBatchSize.Get(cln2)
+			size = dynamicconfig.MatchingMaxTaskBatchSize.Get(cln2)
 			_ = size("my-namespace", "other-tq", 1)
-			size = MatchingMaxTaskBatchSize.Get(cln2)
+			size = dynamicconfig.MatchingMaxTaskBatchSize.Get(cln2)
 			_ = size("other-ns", "my-task-queue", 1)
-			size = MatchingMaxTaskBatchSize.Get(cln2)
+			size = dynamicconfig.MatchingMaxTaskBatchSize.Get(cln2)
 			_ = size("other-ns", "other-tq", 1)
 		}
 	})
 	b.Run("structured default", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N/4; i++ {
-			size := MatchingNumTaskqueueWritePartitions.Get(cln2)
+			size := dynamicconfig.MatchingNumTaskqueueWritePartitions.Get(cln2)
 			_ = size("my-namespace", "my-task-queue", 1)
-			size = MatchingNumTaskqueueWritePartitions.Get(cln2)
+			size = dynamicconfig.MatchingNumTaskqueueWritePartitions.Get(cln2)
 			_ = size("my-namespace", "other-tq", 1)
-			size = MatchingNumTaskqueueWritePartitions.Get(cln2)
+			size = dynamicconfig.MatchingNumTaskqueueWritePartitions.Get(cln2)
 			_ = size("other-ns", "my-task-queue", 1)
-			size = MatchingNumTaskqueueWritePartitions.Get(cln2)
+			size = dynamicconfig.MatchingNumTaskqueueWritePartitions.Get(cln2)
 			_ = size("other-ns", "other-tq", 1)
 		}
 	})

--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -122,7 +122,7 @@ func (fc *fileBasedClient) init() error {
 		return fmt.Errorf("unable to validate dynamic config: %w", err)
 	}
 
-	if err := fc.update(); err != nil {
+	if err := fc.Update(); err != nil {
 		return fmt.Errorf("unable to read dynamic config: %w", err)
 	}
 
@@ -131,7 +131,7 @@ func (fc *fileBasedClient) init() error {
 		for {
 			select {
 			case <-ticker.C:
-				err := fc.update()
+				err := fc.Update()
 				if err != nil {
 					fc.logger.Error("Unable to update dynamic config.", tag.Error(err))
 				}
@@ -145,7 +145,9 @@ func (fc *fileBasedClient) init() error {
 	return nil
 }
 
-func (fc *fileBasedClient) update() error {
+// This is public mainly for testing. The update loop will call this periodically, you don't
+// have to call it explicitly.
+func (fc *fileBasedClient) Update() error {
 	defer func() {
 		fc.lastUpdatedTime = time.Now().UTC()
 	}()

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package dynamicconfig
+package dynamicconfig_test
 
 import (
 	"os"
@@ -36,6 +36,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 )
 
@@ -44,8 +45,8 @@ import (
 type fileBasedClientSuite struct {
 	suite.Suite
 	*require.Assertions
-	client     Client
-	collection *Collection
+	client     dynamicconfig.Client
+	collection *dynamicconfig.Collection
 	doneCh     chan interface{}
 }
 
@@ -58,11 +59,11 @@ func (s *fileBasedClientSuite) SetupSuite() {
 	var err error
 	s.doneCh = make(chan interface{})
 	logger := log.NewNoopLogger()
-	s.client, err = NewFileBasedClient(&FileBasedClientConfig{
+	s.client, err = dynamicconfig.NewFileBasedClient(&dynamicconfig.FileBasedClientConfig{
 		Filepath:     "config/testConfig.yaml",
 		PollInterval: time.Second * 5,
 	}, logger, s.doneCh)
-	s.collection = NewCollection(s.client, logger)
+	s.collection = dynamicconfig.NewCollection(s.client, logger)
 	s.Require().NoError(err)
 }
 
@@ -77,10 +78,10 @@ func (s *fileBasedClientSuite) SetupTest() {
 func (s *fileBasedClientSuite) TestGetValue() {
 	cvs := s.client.GetValue(testGetBoolPropertyKey)
 	s.Equal(3, len(cvs))
-	s.ElementsMatch([]ConstrainedValue{
-		{Constraints: Constraints{}, Value: false},
-		{Constraints: Constraints{Namespace: "global-samples-namespace"}, Value: true},
-		{Constraints: Constraints{Namespace: "samples-namespace"}, Value: true},
+	s.ElementsMatch([]dynamicconfig.ConstrainedValue{
+		{Constraints: dynamicconfig.Constraints{}, Value: false},
+		{Constraints: dynamicconfig.Constraints{Namespace: "global-samples-namespace"}, Value: true},
+		{Constraints: dynamicconfig.Constraints{Namespace: "samples-namespace"}, Value: true},
 	}, cvs)
 }
 
@@ -89,7 +90,7 @@ func (s *fileBasedClientSuite) TestGetValue_NonExistKey() {
 	s.Nil(cvs)
 
 	defaultValue := true
-	v := NewGlobalBoolSetting(unknownKey, defaultValue, "").Get(s.collection)()
+	v := dynamicconfig.NewGlobalBoolSetting(unknownKey, defaultValue, "").Get(s.collection)()
 	s.Equal(defaultValue, v)
 }
 
@@ -97,36 +98,36 @@ func (s *fileBasedClientSuite) TestGetValue_CaseInsensitie() {
 	cvs := s.client.GetValue(testCaseInsensitivePropertyKey)
 	s.Equal(1, len(cvs))
 
-	v := NewGlobalBoolSetting(testCaseInsensitivePropertyKey, false, "").Get(s.collection)()
+	v := dynamicconfig.NewGlobalBoolSetting(testCaseInsensitivePropertyKey, false, "").Get(s.collection)()
 	s.Equal(true, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue() {
-	v := NewGlobalIntSetting(testGetIntPropertyKey, 1, "").Get(s.collection)()
+	v := dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 1, "").Get(s.collection)()
 	s.Equal(1000, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilterNotMatch() {
-	v := NewNamespaceIntSetting(testGetIntPropertyKey, 500, "").Get(s.collection)("samples-namespace")
+	v := dynamicconfig.NewNamespaceIntSetting(testGetIntPropertyKey, 500, "").Get(s.collection)("samples-namespace")
 	s.Equal(1000, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_WrongType() {
 	defaultValue := 2000
-	v := NewNamespaceIntSetting(testGetIntPropertyKey, defaultValue, "").Get(s.collection)("global-samples-namespace")
+	v := dynamicconfig.NewNamespaceIntSetting(testGetIntPropertyKey, defaultValue, "").Get(s.collection)("global-samples-namespace")
 	s.Equal(defaultValue, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByWorkflowTaskQueueInfo() {
 	expectedValue := 1001
-	v := NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
+	v := dynamicconfig.NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		"global-samples-namespace", "test-tq", enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	s.Equal(expectedValue, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByNoTaskTypeQueueInfo() {
 	expectedValue := 1003
-	v := NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
+	v := dynamicconfig.NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		// this is contrived, but simulates something that doesn't match workflow or activity
 		"global-samples-namespace", "test-tq", enumspb.TaskQueueType(3),
 	)
@@ -135,40 +136,40 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilteredByNoTaskTypeQueueInfo() {
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByActivityTaskQueueInfo() {
 	expectedValue := 1002
-	v := NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
+	v := dynamicconfig.NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		"global-samples-namespace", "test-tq", enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 	s.Equal(expectedValue, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByTaskQueueNameOnly() {
 	expectedValue := 1005
-	v := NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
+	v := dynamicconfig.NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		"some-other-namespace", "other-test-tq", enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	s.Equal(expectedValue, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilterByTQ_NamespaceOnly() {
 	expectedValue := 1004
-	v := NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
+	v := dynamicconfig.NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		"another-namespace", "test-tq", 0)
 	s.Equal(expectedValue, v)
 	expectedValue = 1005
-	v = NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
+	v = dynamicconfig.NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		"another-namespace", "other-test-tq", 0)
 	s.Equal(expectedValue, v)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilterByTQ_MatchFallback() {
 	// should return 1001 as the most specific match
-	v1 := NewTaskQueueIntSetting(testGetIntPropertyKey, 1001, "").Get(s.collection)(
+	v1 := dynamicconfig.NewTaskQueueIntSetting(testGetIntPropertyKey, 1001, "").Get(s.collection)(
 		"global-samples-namespace", "test-tq", enumspb.TASK_QUEUE_TYPE_WORKFLOW)
-	v2 := NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
+	v2 := dynamicconfig.NewTaskQueueIntSetting(testGetIntPropertyKey, 0, "").Get(s.collection)(
 		"global-samples-namespace", "test-tq", enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	s.Equal(v1, v2)
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilterByDestination() {
-	dc := NewDestinationIntSetting(testGetIntPropertyFilteredByDestinationKey, 5, "").Get(s.collection)
+	dc := dynamicconfig.NewDestinationIntSetting(testGetIntPropertyFilteredByDestinationKey, 5, "").Get(s.collection)
 	s.Equal(10, dc("foo", "bar"))
 	s.Equal(20, dc("test-namespace", "test-destination-1"))
 	s.Equal(30, dc("test-namespace", "random-destination"))
@@ -177,29 +178,29 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilterByDestination() {
 }
 
 func (s *fileBasedClientSuite) TestGetFloatValue() {
-	v := NewGlobalFloatSetting(testGetFloat64PropertyKey, 1, "").Get(s.collection)()
+	v := dynamicconfig.NewGlobalFloatSetting(testGetFloat64PropertyKey, 1, "").Get(s.collection)()
 	s.Equal(12.0, v)
 }
 
 func (s *fileBasedClientSuite) TestGetFloatValue_WrongType() {
 	defaultValue := 1.0
-	v := NewNamespaceFloatSetting(testGetFloat64PropertyKey, defaultValue, "").Get(s.collection)("samples-namespace")
+	v := dynamicconfig.NewNamespaceFloatSetting(testGetFloat64PropertyKey, defaultValue, "").Get(s.collection)("samples-namespace")
 	s.Equal(defaultValue, v)
 }
 
 func (s *fileBasedClientSuite) TestGetBoolValue() {
-	v := NewGlobalBoolSetting(testGetBoolPropertyKey, true, "").Get(s.collection)()
+	v := dynamicconfig.NewGlobalBoolSetting(testGetBoolPropertyKey, true, "").Get(s.collection)()
 	s.Equal(false, v)
 }
 
 func (s *fileBasedClientSuite) TestGetStringValue() {
-	v := NewNamespaceStringSetting(testGetStringPropertyKey, "defaultString", "").Get(s.collection)("random-namespace")
+	v := dynamicconfig.NewNamespaceStringSetting(testGetStringPropertyKey, "defaultString", "").Get(s.collection)("random-namespace")
 	s.Equal("constrained-string", v)
 }
 
 func (s *fileBasedClientSuite) TestGetMapValue() {
 	var defaultVal map[string]interface{}
-	v := NewGlobalMapSetting(testGetMapPropertyKey, defaultVal, "").Get(s.collection)()
+	v := dynamicconfig.NewGlobalMapSetting(testGetMapPropertyKey, defaultVal, "").Get(s.collection)()
 	expectedVal := map[string]interface{}{
 		"key1": "1",
 		"key2": 1,
@@ -224,7 +225,7 @@ func (s *fileBasedClientSuite) TestGetTypedValue() {
 		}
 		UnsetInFile string
 	}
-	v := NewGlobalTypedSetting(testGetTypedPropertyKey, myStruct{UnsetInFile: "unset"}, "").Get(s.collection)()
+	v := dynamicconfig.NewGlobalTypedSetting(testGetTypedPropertyKey, myStruct{UnsetInFile: "unset"}, "").Get(s.collection)()
 	expectedVal := myStruct{
 		Number: 23,
 		Days:   6 * 24 * time.Hour,
@@ -242,50 +243,50 @@ func (s *fileBasedClientSuite) TestGetTypedValue() {
 
 func (s *fileBasedClientSuite) TestGetMapValue_WrongType() {
 	var defaultVal map[string]interface{}
-	v := NewNamespaceMapSetting(testGetMapPropertyKey, defaultVal, "").Get(s.collection)("random-namespace")
+	v := dynamicconfig.NewNamespaceMapSetting(testGetMapPropertyKey, defaultVal, "").Get(s.collection)("random-namespace")
 	s.Equal(defaultVal, v)
 }
 
 func (s *fileBasedClientSuite) TestGetDurationValue() {
-	v := NewGlobalDurationSetting(testGetDurationPropertyKey, time.Second, "").Get(s.collection)()
+	v := dynamicconfig.NewGlobalDurationSetting(testGetDurationPropertyKey, time.Second, "").Get(s.collection)()
 	s.Equal(time.Minute, v)
 }
 
 func (s *fileBasedClientSuite) TestGetDurationValue_DefaultSeconds() {
-	v := NewNamespaceDurationSetting(testGetDurationPropertyKey, time.Second, "").Get(s.collection)("samples-namespace")
+	v := dynamicconfig.NewNamespaceDurationSetting(testGetDurationPropertyKey, time.Second, "").Get(s.collection)("samples-namespace")
 	s.Equal(2*time.Second, v)
 }
 
 func (s *fileBasedClientSuite) TestGetDurationValue_NotStringRepresentation() {
-	v := NewNamespaceDurationSetting(testGetDurationPropertyKey, time.Second, "").Get(s.collection)("broken-namespace")
+	v := dynamicconfig.NewNamespaceDurationSetting(testGetDurationPropertyKey, time.Second, "").Get(s.collection)("broken-namespace")
 	s.Equal(time.Second, v)
 }
 
 func (s *fileBasedClientSuite) TestGetDurationValue_ParseFailed() {
-	v := NewTaskQueueDurationSetting(testGetDurationPropertyKey, time.Second, "").Get(s.collection)(
+	v := dynamicconfig.NewTaskQueueDurationSetting(testGetDurationPropertyKey, time.Second, "").Get(s.collection)(
 		"samples-namespace", "longIdleTimeTaskqueue", enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	s.Equal(time.Second, v)
 }
 
 func (s *fileBasedClientSuite) TestGetDurationValue_FilteredByTaskTypeQueue() {
 	expectedValue := time.Second * 10
-	v := NewTaskTypeDurationSetting(testGetDurationPropertyFilteredByTaskTypeKey, 0, "").Get(s.collection)(
+	v := dynamicconfig.NewTaskTypeDurationSetting(testGetDurationPropertyFilteredByTaskTypeKey, 0, "").Get(s.collection)(
 		enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
 	)
 	s.Equal(expectedValue, v)
-	v = NewTaskTypeDurationSetting(testGetDurationPropertyFilteredByTaskTypeKey, 0, "").Get(s.collection)(
+	v = dynamicconfig.NewTaskTypeDurationSetting(testGetDurationPropertyFilteredByTaskTypeKey, 0, "").Get(s.collection)(
 		enumsspb.TASK_TYPE_REPLICATION_HISTORY,
 	)
 	s.Equal(expectedValue, v)
 }
 
 func (s *fileBasedClientSuite) TestValidateConfig_ConfigNotExist() {
-	_, err := NewFileBasedClient(nil, nil, nil)
+	_, err := dynamicconfig.NewFileBasedClient(nil, nil, nil)
 	s.Error(err)
 }
 
 func (s *fileBasedClientSuite) TestValidateConfig_FileNotExist() {
-	_, err := NewFileBasedClient(&FileBasedClientConfig{
+	_, err := dynamicconfig.NewFileBasedClient(&dynamicconfig.FileBasedClientConfig{
 		Filepath:     "file/not/exist.yaml",
 		PollInterval: time.Second * 10,
 	}, nil, nil)
@@ -293,7 +294,7 @@ func (s *fileBasedClientSuite) TestValidateConfig_FileNotExist() {
 }
 
 func (s *fileBasedClientSuite) TestValidateConfig_ShortPollInterval() {
-	_, err := NewFileBasedClient(&FileBasedClientConfig{
+	_, err := dynamicconfig.NewFileBasedClient(&dynamicconfig.FileBasedClientConfig{
 		Filepath:     "config/testConfig.yaml",
 		PollInterval: time.Second,
 	}, nil, nil)
@@ -318,7 +319,7 @@ func (s *fileBasedClientSuite) TestUpdate_ChangedValue() {
 	defer ctrl.Finish()
 
 	doneCh := make(chan interface{})
-	reader := NewMockfileReader(ctrl)
+	reader := dynamicconfig.NewMockfileReader(ctrl)
 	mockLogger := log.NewMockLogger(ctrl)
 
 	updateInterval := time.Minute * 5
@@ -368,8 +369,8 @@ testGetBoolPropertyKey:
 	reader.EXPECT().ReadFile(gomock.Any()).Return(originFileData, nil)
 
 	mockLogger.EXPECT().Info(gomock.Any()).Times(6)
-	client, err := NewFileBasedClientWithReader(reader,
-		&FileBasedClientConfig{
+	client, err := dynamicconfig.NewFileBasedClientWithReader(reader,
+		&dynamicconfig.FileBasedClientConfig{
 			Filepath:     "anyValue",
 			PollInterval: updateInterval,
 		}, mockLogger, s.doneCh)
@@ -383,7 +384,7 @@ testGetBoolPropertyKey:
 	mockLogger.EXPECT().Info("dynamic config changed for the key: testgetboolpropertykey oldValue: { constraints: {} value: false } newValue: { constraints: {} value: true }", gomock.Any())
 	mockLogger.EXPECT().Info("dynamic config changed for the key: testgetboolpropertykey oldValue: { constraints: {{Namespace:global-samples-namespace}} value: true } newValue: { constraints: {{Namespace:global-samples-namespace}} value: false }", gomock.Any())
 	mockLogger.EXPECT().Info(gomock.Any())
-	s.NoError(client.update())
+	s.NoError(client.Update())
 	s.NoError(err)
 	close(doneCh)
 }
@@ -393,7 +394,7 @@ func (s *fileBasedClientSuite) TestUpdate_ChangedMapValue() {
 	defer ctrl.Finish()
 
 	doneCh := make(chan interface{})
-	reader := NewMockfileReader(ctrl)
+	reader := dynamicconfig.NewMockfileReader(ctrl)
 	mockLogger := log.NewMockLogger(ctrl)
 
 	updateInterval := time.Minute * 5
@@ -421,8 +422,8 @@ history.defaultActivityRetryPolicy:
 	reader.EXPECT().ReadFile(gomock.Any()).Return(originFileData, nil)
 
 	mockLogger.EXPECT().Info(gomock.Any()).Times(2)
-	client, err := NewFileBasedClientWithReader(reader,
-		&FileBasedClientConfig{
+	client, err := dynamicconfig.NewFileBasedClientWithReader(reader,
+		&dynamicconfig.FileBasedClientConfig{
 			Filepath:     "anyValue",
 			PollInterval: updateInterval,
 		}, mockLogger, s.doneCh)
@@ -433,7 +434,7 @@ history.defaultActivityRetryPolicy:
 
 	mockLogger.EXPECT().Info("dynamic config changed for the key: history.defaultactivityretrypolicy oldValue: { constraints: {} value: map[BackoffCoefficient:3 InitialIntervalInSeconds:1 MaximumAttempts:0 MaximumIntervalCoefficient:100] } newValue: { constraints: {} value: map[BackoffCoefficient:2 InitialIntervalInSeconds:3 MaximumAttempts:0 MaximumIntervalCoefficient:100] }", gomock.Any())
 	mockLogger.EXPECT().Info(gomock.Any())
-	s.NoError(client.update())
+	s.NoError(client.Update())
 	s.NoError(err)
 	close(doneCh)
 }
@@ -443,7 +444,7 @@ func (s *fileBasedClientSuite) TestUpdate_NewEntry() {
 	defer ctrl.Finish()
 
 	doneCh := make(chan interface{})
-	reader := NewMockfileReader(ctrl)
+	reader := dynamicconfig.NewMockfileReader(ctrl)
 	mockLogger := log.NewMockLogger(ctrl)
 
 	updateInterval := time.Minute * 5
@@ -473,8 +474,8 @@ testGetIntPropertyKey:
 
 	mockLogger.EXPECT().Info("dynamic config changed for the key: testgetfloat64propertykey oldValue: nil newValue: { constraints: {} value: 12 }", gomock.Any())
 	mockLogger.EXPECT().Info(gomock.Any())
-	client, err := NewFileBasedClientWithReader(reader,
-		&FileBasedClientConfig{
+	client, err := dynamicconfig.NewFileBasedClientWithReader(reader,
+		&dynamicconfig.FileBasedClientConfig{
 			Filepath:     "anyValue",
 			PollInterval: updateInterval,
 		}, mockLogger, s.doneCh)
@@ -486,7 +487,7 @@ testGetIntPropertyKey:
 	mockLogger.EXPECT().Info("dynamic config changed for the key: testgetfloat64propertykey oldValue: nil newValue: { constraints: {{Namespace:samples-namespace}} value: 22 }", gomock.Any())
 	mockLogger.EXPECT().Info("dynamic config changed for the key: testgetintpropertykey oldValue: nil newValue: { constraints: {} value: 2000 }", gomock.Any())
 	mockLogger.EXPECT().Info(gomock.Any())
-	s.NoError(client.update())
+	s.NoError(client.Update())
 	s.NoError(err)
 	close(doneCh)
 }
@@ -496,7 +497,7 @@ func (s *fileBasedClientSuite) TestUpdate_ChangeOrder_ShouldNotWriteLog() {
 	defer ctrl.Finish()
 
 	doneCh := make(chan interface{})
-	reader := NewMockfileReader(ctrl)
+	reader := dynamicconfig.NewMockfileReader(ctrl)
 	mockLogger := log.NewMockLogger(ctrl)
 
 	updateInterval := time.Minute * 5
@@ -532,8 +533,8 @@ testGetFloat64PropertyKey:
 	reader.EXPECT().ReadFile(gomock.Any()).Return(originFileData, nil)
 
 	mockLogger.EXPECT().Info(gomock.Any()).Times(4)
-	client, err := NewFileBasedClientWithReader(reader,
-		&FileBasedClientConfig{
+	client, err := dynamicconfig.NewFileBasedClientWithReader(reader,
+		&dynamicconfig.FileBasedClientConfig{
 			Filepath:     "anyValue",
 			PollInterval: updateInterval,
 		}, mockLogger, s.doneCh)
@@ -543,7 +544,7 @@ testGetFloat64PropertyKey:
 	reader.EXPECT().ReadFile(gomock.Any()).Return(updatedFileData, nil)
 
 	mockLogger.EXPECT().Info(gomock.Any()).Times(1)
-	s.NoError(client.update())
+	s.NoError(client.Update())
 	s.NoError(err)
 	close(doneCh)
 }

--- a/common/dynamicconfig/find_match_test.go
+++ b/common/dynamicconfig/find_match_test.go
@@ -1,0 +1,134 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dynamicconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// These two tests are in a separate file in the 'dynamicconfig' package to access the private
+// findMatch function. Most other tests should be in 'dynamicconfig_test' to test things as a
+// client.
+func TestFindMatch(t *testing.T) {
+	testCases := []struct {
+		v       []ConstrainedValue
+		filters []Constraints
+		matched bool
+	}{
+		{
+			v: []ConstrainedValue{
+				{Constraints: Constraints{}},
+			},
+			filters: []Constraints{
+				{Namespace: "some random namespace"},
+			},
+			matched: false,
+		},
+		{
+			v: []ConstrainedValue{
+				{Constraints: Constraints{Namespace: "samples-namespace"}},
+			},
+			filters: []Constraints{
+				{Namespace: "some random namespace"},
+			},
+			matched: false,
+		},
+		{
+			v: []ConstrainedValue{
+				{Constraints: Constraints{Namespace: "samples-namespace", TaskQueueName: "sample-task-queue"}},
+			},
+			filters: []Constraints{
+				{Namespace: "samples-namespace", TaskQueueName: "sample-task-queue"},
+			},
+			matched: true,
+		},
+		{
+			v: []ConstrainedValue{
+				{Constraints: Constraints{Namespace: "samples-namespace"}},
+			},
+			filters: []Constraints{
+				{TaskQueueName: "sample-task-queue"},
+			},
+			matched: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := findMatch[struct{}](tc.v, nil, tc.filters)
+		assert.Equal(t, tc.matched, err == nil)
+	}
+}
+
+func TestFindMatchWithTyped(t *testing.T) {
+	testCases := []struct {
+		tv      []TypedConstrainedValue[struct{}]
+		filters []Constraints
+		matched bool
+	}{
+		{
+			tv: []TypedConstrainedValue[struct{}]{
+				{Constraints: Constraints{}},
+			},
+			filters: []Constraints{
+				{Namespace: "some random namespace"},
+			},
+			matched: false,
+		},
+		{
+			tv: []TypedConstrainedValue[struct{}]{
+				{Constraints: Constraints{Namespace: "samples-namespace"}},
+			},
+			filters: []Constraints{
+				{Namespace: "some random namespace"},
+			},
+			matched: false,
+		},
+		{
+			tv: []TypedConstrainedValue[struct{}]{
+				{Constraints: Constraints{Namespace: "samples-namespace", TaskQueueName: "sample-task-queue"}},
+			},
+			filters: []Constraints{
+				{Namespace: "samples-namespace", TaskQueueName: "sample-task-queue"},
+			},
+			matched: true,
+		},
+		{
+			tv: []TypedConstrainedValue[struct{}]{
+				{Constraints: Constraints{Namespace: "samples-namespace"}},
+			},
+			filters: []Constraints{
+				{TaskQueueName: "sample-task-queue"},
+			},
+			matched: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := findMatch(nil, tc.tv, tc.filters)
+		assert.Equal(t, tc.matched, err == nil)
+	}
+}


### PR DESCRIPTION
## What changed?
Move most unit tests to external package, except two for an internal helper function.

## Why?
To write tests as an client to the package would use it, which usually produces better tests.

## How did you test it?
is tests