### PR TITLE
Only stop non-nil persistence managers

### DIFF
--- a/common/persistence/client/fx.go
+++ b/common/persistence/client/fx.go
@@ -206,7 +206,9 @@ func managerProvider[T persistence.Closeable](newManagerFn func(Factory) (T, err
 			var nilT T
 			return nilT, err
 		}
-		lc.Append(fx.StopHook(manager.Close))
+		if manager != nil {
+			lc.Append(fx.StopHook(manager.Close))
+		}
 		return manager, nil
 	}
 }

--- a/common/persistence/client/fx.go
+++ b/common/persistence/client/fx.go
@@ -25,7 +25,6 @@
 package client
 
 import (
-	"reflect"
 	"time"
 
 	"go.uber.org/fx"
@@ -43,6 +42,7 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/resolver"
+	"go.temporal.io/server/common/util"
 )
 
 type (
@@ -207,8 +207,7 @@ func managerProvider[T persistence.Closeable](newManagerFn func(Factory) (T, err
 			var nilT T
 			return nilT, err
 		}
-		v := reflect.ValueOf(manager)
-		if !v.IsNil() {
+		if !util.IsGenericNil(manager) {
 			lc.Append(fx.StopHook(manager.Close))
 		}
 		return manager, nil

--- a/common/persistence/client/fx.go
+++ b/common/persistence/client/fx.go
@@ -25,6 +25,7 @@
 package client
 
 import (
+	"reflect"
 	"time"
 
 	"go.uber.org/fx"
@@ -206,7 +207,8 @@ func managerProvider[T persistence.Closeable](newManagerFn func(Factory) (T, err
 			var nilT T
 			return nilT, err
 		}
-		if manager != nil {
+		v := reflect.ValueOf(manager)
+		if !v.IsNil() {
 			lc.Append(fx.StopHook(manager.Close))
 		}
 		return manager, nil

--- a/common/util/util.go
+++ b/common/util/util.go
@@ -27,6 +27,7 @@
 package util
 
 import (
+	"reflect"
 	"sort"
 	"time"
 
@@ -171,4 +172,15 @@ func RepeatSlice[T any](xs []T, n int) []T {
 // Ptr returns a pointer to a copy of v.
 func Ptr[T any](v T) *T {
 	return &v
+}
+
+func IsGenericNil[T any](val T) bool {
+	v := reflect.ValueOf(val)
+	return (v.Kind() == reflect.Ptr &&
+		v.Kind() == reflect.Interface ||
+		v.Kind() == reflect.Slice ||
+		v.Kind() == reflect.Map ||
+		v.Kind() == reflect.Chan ||
+		v.Kind() == reflect.Func) &&
+		v.IsNil()
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Changed the persistence client fx to only add the StopHook when the factory returns a non-nil manager

## Why?
<!-- Tell your future self why have you made these changes -->
To prevent NPEs

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
