### PR TITLE
Removing metrics handler from lru.New()

### DIFF
--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -151,7 +151,13 @@ func (entry *entryImpl) CreateTime() time.Time {
 }
 
 // New creates a new cache with the given options
-func New(maxSize int, opts *Options, handler metrics.Handler) Cache {
+func New(maxSize int, opts *Options) Cache {
+	return NewWithMetrics(maxSize, opts, metrics.NoopMetricsHandler)
+}
+
+// NewWithMetrics creates a new cache that will emit capacity and ttl metrics.
+// handler should be tagged with metrics.CacheTypeTag.
+func NewWithMetrics(maxSize int, opts *Options, handler metrics.Handler) Cache {
 	if opts == nil {
 		opts = &Options{}
 	}
@@ -177,7 +183,7 @@ func New(maxSize int, opts *Options, handler metrics.Handler) Cache {
 // NewLRU creates a new LRU cache of the given size, setting initial capacity
 // to the max size
 func NewLRU(maxSize int, handler metrics.Handler) Cache {
-	return New(maxSize, nil, handler)
+	return New(maxSize, nil)
 }
 
 // Get retrieves the value stored under the given key

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -57,7 +57,7 @@ func TestLRU(t *testing.T) {
 	metricsHandler := metricstest.NewCaptureHandler()
 	capture := metricsHandler.StartCapture()
 
-	cache := NewLRU(4, metricsHandler)
+	cache := NewWithMetrics(4, nil, metricsHandler)
 
 	cache.Put("A", "Foo")
 	assert.Equal(t, "Foo", cache.Get("A"))
@@ -142,7 +142,7 @@ func TestLRUWithTTL(t *testing.T) {
 	timeSource := clock.NewEventTimeSource()
 	metricsHandler := metricstest.NewCaptureHandler()
 	capture := metricsHandler.StartCapture()
-	cache := New(5,
+	cache := NewWithMetrics(5,
 		&Options{
 			TTL:        time.Millisecond * 100,
 			TimeSource: timeSource,
@@ -229,7 +229,6 @@ func TestTTL(t *testing.T) {
 			TTL:        time.Millisecond * 50,
 			TimeSource: timeSource,
 		},
-		metrics.NoopMetricsHandler,
 	)
 
 	cache.Put("A", t)
@@ -243,7 +242,7 @@ func TestTTLWithPin(t *testing.T) {
 
 	timeSource := clock.NewEventTimeSource()
 	metricsHandler := metricstest.NewCaptureHandler()
-	cache := New(5,
+	cache := NewWithMetrics(5,
 		&Options{
 			TTL:        time.Millisecond * 50,
 			Pin:        true,
@@ -287,7 +286,6 @@ func TestMaxSizeWithPin_MidItem(t *testing.T) {
 			Pin:        true,
 			TimeSource: timeSource,
 		},
-		metrics.NoopMetricsHandler,
 	)
 
 	_, err := cache.PutIfNotExist("A", t)
@@ -336,7 +334,6 @@ func TestMaxSizeWithPin_LastItem(t *testing.T) {
 			Pin:        true,
 			TimeSource: timeSource,
 		},
-		metrics.NoopMetricsHandler,
 	)
 
 	_, err := cache.PutIfNotExist("A", t)
@@ -627,7 +624,7 @@ func TestCache_PutIfNotExistWithNewKeys_Pin(t *testing.T) {
 	t.Parallel()
 
 	maxTotalBytes := 10
-	cache := New(maxTotalBytes, &Options{Pin: true}, metrics.NoopMetricsHandler)
+	cache := New(maxTotalBytes, &Options{Pin: true})
 
 	val, err := cache.PutIfNotExist(uuid.New(), &testEntryWithCacheSize{15})
 	assert.Equal(t, ErrCacheItemTooLarge, err)
@@ -654,7 +651,7 @@ func TestCache_PutIfNotExistWithSameKeys_Pin(t *testing.T) {
 	t.Parallel()
 
 	maxTotalBytes := 10
-	cache := New(maxTotalBytes, &Options{Pin: true}, metrics.NoopMetricsHandler)
+	cache := New(maxTotalBytes, &Options{Pin: true})
 
 	key := uuid.New()
 	val, err := cache.PutIfNotExist(key, &testEntryWithCacheSize{15})
@@ -683,7 +680,6 @@ func TestCache_ItemSizeChangeBeforeRelease(t *testing.T) {
 			Pin:        true,
 			TimeSource: nil,
 		},
-		metrics.NoopMetricsHandler,
 	)
 
 	entry1 := &testEntryWithCacheSize{

--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -208,11 +208,11 @@ func NewRegistry(
 		clock:                    clock.NewRealTimeSource(),
 		metricsHandler:           metricsHandler.WithTags(metrics.OperationTag(metrics.NamespaceCacheScope)),
 		logger:                   logger,
-		cacheNameToID:            cache.New(cacheMaxSize, &cacheOpts, metrics.NoopMetricsHandler),
-		cacheByID:                cache.New(cacheMaxSize, &cacheOpts, metrics.NoopMetricsHandler),
+		cacheNameToID:            cache.New(cacheMaxSize, &cacheOpts),
+		cacheByID:                cache.New(cacheMaxSize, &cacheOpts),
 		refreshInterval:          refreshInterval,
 		stateChangeCallbacks:     make(map[any]StateChangeCallbackFn),
-		readthroughNotFoundCache: cache.New(cacheMaxSize, &readthroughNotFoundCacheOpts, metrics.NoopMetricsHandler),
+		readthroughNotFoundCache: cache.New(cacheMaxSize, &readthroughNotFoundCacheOpts),
 
 		forceSearchAttributesCacheRefreshOnRead: forceSearchAttributesCacheRefreshOnRead,
 	}
@@ -465,8 +465,8 @@ func (r *registry) refreshNamespaces(ctx context.Context) error {
 	}
 
 	// Make a copy of the existing namespace cache (excluding deleted), so we can calculate diff and do "compare and swap".
-	newCacheNameToID := cache.New(cacheMaxSize, &cacheOpts, metrics.NoopMetricsHandler)
-	newCacheByID := cache.New(cacheMaxSize, &cacheOpts, metrics.NoopMetricsHandler)
+	newCacheNameToID := cache.New(cacheMaxSize, &cacheOpts)
+	newCacheByID := cache.New(cacheMaxSize, &cacheOpts)
 	var deletedEntries []*Namespace
 	for _, namespace := range r.getAllNamespace() {
 		if _, namespaceExistsDb := namespaceIDsDb[namespace.ID()]; !namespaceExistsDb {

--- a/common/persistence/xdc_cache.go
+++ b/common/persistence/xdc_cache.go
@@ -34,7 +34,6 @@ import (
 	workflowspb "go.temporal.io/server/api/workflow/v1"
 	"go.temporal.io/server/common/cache"
 	"go.temporal.io/server/common/definition"
-	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/versionhistory"
 )
 
@@ -113,7 +112,6 @@ func NewEventsBlobCache(
 				TTL: ttl,
 				Pin: false,
 			},
-			metrics.NoopMetricsHandler,
 		),
 	}
 }

--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -108,9 +108,9 @@ func newEventsCache(
 	opts := &cache.Options{}
 	opts.TTL = ttl
 
-	taggedMetricHandler := metricsHandler.WithTags(metrics.StringTag(metrics.CacheTypeTagName, metrics.EventsCacheTypeTagValue))
+	taggedMetricHandler := metricsHandler.WithTags(metrics.CacheTypeTag(metrics.EventsCacheTypeTagValue))
 	return &CacheImpl{
-		Cache:            cache.New(maxSize, opts, taggedMetricHandler),
+		Cache:            cache.NewWithMetrics(maxSize, opts, taggedMetricHandler),
 		executionManager: executionManager,
 		metricsHandler:   taggedMetricHandler,
 		logger:           logger,

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -153,7 +153,7 @@ func newCache(
 	opts.Pin = true
 
 	return &CacheImpl{
-		Cache:                     cache.New(size, opts, handler.WithTags(metrics.CacheTypeTag(metrics.MutableStateCacheTypeTagValue))),
+		Cache:                     cache.NewWithMetrics(size, opts, handler.WithTags(metrics.CacheTypeTag(metrics.MutableStateCacheTypeTagValue))),
 		nonUserContextLockTimeout: nonUserContextLockTimeout,
 	}
 }

--- a/service/matching/poller_history.go
+++ b/service/matching/poller_history.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.temporal.io/server/common/cache"
-	"go.temporal.io/server/common/metrics"
 )
 
 const (
@@ -60,7 +59,7 @@ func newPollerHistory() *pollerHistory {
 	}
 
 	return &pollerHistory{
-		history: cache.New(pollerHistoryInitMaxSize, opts, metrics.NoopMetricsHandler),
+		history: cache.New(pollerHistoryInitMaxSize, opts),
 	}
 }
 

--- a/service/matching/reachability.go
+++ b/service/matching/reachability.go
@@ -329,8 +329,8 @@ func newReachabilityCache(
 	reachabilityCacheClosedWFExecutionTTL time.Duration,
 ) reachabilityCache {
 	return reachabilityCache{
-		openWFCache:    cache.New(reachabilityCacheMaxSize, &cache.Options{TTL: reachabilityCacheOpenWFExecutionTTL}, handler),
-		closedWFCache:  cache.New(reachabilityCacheMaxSize, &cache.Options{TTL: reachabilityCacheClosedWFExecutionTTL}, handler),
+		openWFCache:    cache.New(reachabilityCacheMaxSize, &cache.Options{TTL: reachabilityCacheOpenWFExecutionTTL}),
+		closedWFCache:  cache.New(reachabilityCacheMaxSize, &cache.Options{TTL: reachabilityCacheClosedWFExecutionTTL}),
 		metricsHandler: handler,
 		visibilityMgr:  visibilityMgr,
 	}

--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -36,7 +36,6 @@ import (
 
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cache"
-	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives/timestamp"
 )
 
@@ -74,7 +73,6 @@ func NewSpecBuilder() *SpecBuilder {
 			&cache.Options{
 				TTL: 24 * time.Hour,
 			},
-			metrics.NoopMetricsHandler,
 		),
 	}
 }


### PR DESCRIPTION
## What changed?
We had added metrics handler in LRU cache for more visibility into its size and eviction times.
But for this to work, we had to provide a metrics handler with cache type tag. This is confusing as it is not obvious to provide this tag when passing a metrics handler. This has created some issues recently.
Most users of this cache object do not need metrics. Removing metrics handler from lru.New() function and adding a separate function lru.NewWithMetrics() for consumers who need metrics.

## Why?
To remove confusion in LRU creation.

## How did you test it?
Unit tests

## Potential risks
None

## Documentation

## Is hotfix candidate?
No
