### PR TITLE
Add retry on replication sender for single replication task

### DIFF
--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -548,13 +548,13 @@ Loop:
 			return nil
 		}
 
-		TaskRetryPolicy = backoff.NewExponentialRetryPolicy(1 * time.Second).
+		retryPolicy := backoff.NewExponentialRetryPolicy(1 * time.Second).
 			WithBackoffCoefficient(1.2).
 			WithMaximumInterval(3 * time.Second).
 			WithMaximumAttempts(80).
 			WithExpirationInterval(3 * time.Minute)
 
-		if err := backoff.ThrottleRetry(operation, TaskRetryPolicy, IsRetryableError); err != nil {
+		if err := backoff.ThrottleRetry(operation, retryPolicy, IsRetryableError); err != nil {
 			return err
 		}
 	}

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -31,8 +31,10 @@ import (
 	"fmt"
 	"math"
 	"sync/atomic"
+	"time"
 
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/backoff"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -513,34 +515,48 @@ Loop:
 			priority != s.getTaskPriority(item) { // case: skip task with different priority than this loop
 			continue Loop
 		}
-		task, err := s.taskConverter.Convert(item)
-		if err != nil {
-			return err
-		}
-		if task == nil {
-			continue Loop
-		}
-		task.Priority = priority
-		s.logger.Debug("StreamSender send replication task", tag.TaskID(task.SourceTaskId))
-		if err := s.sendToStream(&historyservice.StreamWorkflowReplicationMessagesResponse{
-			Attributes: &historyservice.StreamWorkflowReplicationMessagesResponse_Messages{
-				Messages: &replicationspb.WorkflowReplicationMessages{
-					ReplicationTasks:           []*replicationspb.ReplicationTask{task},
-					ExclusiveHighWatermark:     task.SourceTaskId + 1,
-					ExclusiveHighWatermarkTime: task.VisibilityTime,
-					Priority:                   priority,
+
+		operation := func() error {
+			task, err := s.taskConverter.Convert(item)
+			if err != nil {
+				return err
+			}
+			if task == nil {
+				return nil
+			}
+			task.Priority = priority
+			s.logger.Debug("StreamSender send replication task", tag.TaskID(task.SourceTaskId))
+			if err := s.sendToStream(&historyservice.StreamWorkflowReplicationMessagesResponse{
+				Attributes: &historyservice.StreamWorkflowReplicationMessagesResponse_Messages{
+					Messages: &replicationspb.WorkflowReplicationMessages{
+						ReplicationTasks:           []*replicationspb.ReplicationTask{task},
+						ExclusiveHighWatermark:     task.SourceTaskId + 1,
+						ExclusiveHighWatermarkTime: task.VisibilityTime,
+						Priority:                   priority,
+					},
 				},
-			},
-		}); err != nil {
+			}); err != nil {
+				return err
+			}
+			skipCount = 0
+			metrics.ReplicationTasksSend.With(s.metrics).Record(
+				int64(1),
+				metrics.FromClusterIDTag(s.serverShardKey.ClusterID),
+				metrics.ToClusterIDTag(s.clientShardKey.ClusterID),
+				metrics.OperationTag(TaskOperationTag(task)),
+			)
+			return nil
+		}
+
+		TaskRetryPolicy = backoff.NewExponentialRetryPolicy(1 * time.Second).
+			WithBackoffCoefficient(1.2).
+			WithMaximumInterval(3 * time.Second).
+			WithMaximumAttempts(80).
+			WithExpirationInterval(3 * time.Minute)
+
+		if err := backoff.ThrottleRetry(operation, TaskRetryPolicy, IsRetryableError); err != nil {
 			return err
 		}
-		skipCount = 0
-		metrics.ReplicationTasksSend.With(s.metrics).Record(
-			int64(1),
-			metrics.FromClusterIDTag(s.serverShardKey.ClusterID),
-			metrics.ToClusterIDTag(s.clientShardKey.ClusterID),
-			metrics.OperationTag(TaskOperationTag(task)),
-		)
 	}
 	return s.sendToStream(&historyservice.StreamWorkflowReplicationMessagesResponse{
 		Attributes: &historyservice.StreamWorkflowReplicationMessagesResponse_Messages{


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add retry on replication sender for single replication task
## Why?
<!-- Tell your future self why have you made these changes -->
We should not rely on stream retry if there is error on DB throttling. Stream retry will re-send task from ACK level, if ACK level is left behind and progressing slow, we will repeat the resend process again and again. This is not a good use of resource.
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
relying on current test.
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
yes