### PR TITLE
added backlog head create time metric + unit and integration test

### DIFF
--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -635,6 +635,8 @@ func (tm *TaskMatcher) unregisterBacklogTask(task *internalTask) {
 	}
 }
 
+// getBacklogAge is the latest age across all backlogs re-directing to this matcher; may momentarily
+// be 0 cause of race conditions when no reader pushes a task into the matcher at this moment
 func (tm *TaskMatcher) getBacklogAge() time.Duration {
 	tm.backlogTasksLock.Lock()
 	defer tm.backlogTasksLock.Unlock()

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -29,12 +29,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"google.golang.org/protobuf/types/known/durationpb"
 	"math"
 	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/pborman/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3134,6 +3134,16 @@ func (s *matchingEngineSuite) TestMultipleWorkersLesserNumberOfPollersThanTasksD
 	s.concurrentPublishAndConsumeValidateBacklogCounter(5, 500, 200)
 }
 
+func (s *matchingEngineSuite) TestLargerBacklogAge() {
+	firstAge := durationpb.New(100 * time.Second)
+	secondAge := durationpb.New(1 * time.Millisecond)
+	s.Same(firstAge, s.matchingEngine.largerBacklogAge(firstAge, secondAge))
+
+	thirdAge := durationpb.New(5 * time.Minute)
+	s.Same(thirdAge, s.matchingEngine.largerBacklogAge(firstAge, thirdAge))
+	s.Same(thirdAge, s.matchingEngine.largerBacklogAge(secondAge, thirdAge))
+}
+
 func (s *matchingEngineSuite) setupRecordActivityTaskStartedMock(tlName string) {
 	activityTypeName := "activity1"
 	activityID := "activityId1"

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -108,7 +108,6 @@ type (
 		UnloadFromPartitionManager()
 		String() string
 		QueueKey() *PhysicalTaskQueueKey
-		Matcher() *TaskMatcher
 	}
 
 	// physicalTaskQueueManagerImpl manages a single DB-level (aka physical) task queue in memory
@@ -484,10 +483,6 @@ func newChildContext(
 
 func (c *physicalTaskQueueManagerImpl) QueueKey() *PhysicalTaskQueueKey {
 	return c.queue
-}
-
-func (c *physicalTaskQueueManagerImpl) Matcher() *TaskMatcher {
-	return c.matcher
 }
 
 func (c *physicalTaskQueueManagerImpl) newIOContext() (context.Context, context.CancelFunc) {

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -29,9 +29,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"google.golang.org/protobuf/types/known/durationpb"
 	"sync/atomic"
 	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"

--- a/service/matching/physical_task_queue_manager_mock.go
+++ b/service/matching/physical_task_queue_manager_mock.go
@@ -189,6 +189,20 @@ func (mr *MockphysicalTaskQueueManagerMockRecorder) MarkAlive() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkAlive", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).MarkAlive))
 }
 
+// Matcher mocks base method.
+func (m *MockphysicalTaskQueueManager) Matcher() *TaskMatcher {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Matcher")
+	ret0, _ := ret[0].(*TaskMatcher)
+	return ret0
+}
+
+// Matcher indicates an expected call of Matcher.
+func (mr *MockphysicalTaskQueueManagerMockRecorder) Matcher() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Matcher", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).Matcher))
+}
+
 // PollTask mocks base method.
 func (m *MockphysicalTaskQueueManager) PollTask(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, error) {
 	m.ctrl.T.Helper()

--- a/service/matching/physical_task_queue_manager_mock.go
+++ b/service/matching/physical_task_queue_manager_mock.go
@@ -189,20 +189,6 @@ func (mr *MockphysicalTaskQueueManagerMockRecorder) MarkAlive() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkAlive", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).MarkAlive))
 }
 
-// Matcher mocks base method.
-func (m *MockphysicalTaskQueueManager) Matcher() *TaskMatcher {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Matcher")
-	ret0, _ := ret[0].(*TaskMatcher)
-	return ret0
-}
-
-// Matcher indicates an expected call of Matcher.
-func (mr *MockphysicalTaskQueueManagerMockRecorder) Matcher() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Matcher", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).Matcher))
-}
-
 // PollTask mocks base method.
 func (m *MockphysicalTaskQueueManager) PollTask(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, error) {
 	m.ctrl.T.Helper()

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -27,6 +27,7 @@ package matching
 import (
 	"context"
 	"errors"
+	"go.temporal.io/server/common/primitives/timestamp"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -54,14 +55,15 @@ type (
 		backlogMgr *backlogManagerImpl
 		gorogrp    goro.Group
 
-		backoffTimerLock sync.Mutex
-		backoffTimer     *time.Timer
-		retrier          backoff.Retrier
+		backoffTimerLock      sync.Mutex
+		backoffTimer          *time.Timer
+		retrier               backoff.Retrier
+		backlogHeadCreateTime atomic.Int64
 	}
 )
 
 func newTaskReader(backlogMgr *backlogManagerImpl) *taskReader {
-	return &taskReader{
+	tr := &taskReader{
 		status:     common.DaemonStatusInitialized,
 		backlogMgr: backlogMgr,
 		notifyC:    make(chan struct{}, 1),
@@ -73,6 +75,8 @@ func newTaskReader(backlogMgr *backlogManagerImpl) *taskReader {
 			backoff.SystemClock,
 		),
 	}
+	tr.backlogHeadCreateTime.Store(-1)
+	return tr
 }
 
 // Start reading pump for the given task queue.
@@ -111,11 +115,31 @@ func (tr *taskReader) Signal() {
 	}
 }
 
+func (tr *taskReader) updateBacklogAge(task *internalTask) {
+	if task.event.Data.CreateTime == nil {
+		return // should not happen but for safety
+	}
+	ts := timestamp.TimeValue(task.event.Data.CreateTime).UnixNano()
+	// updating the backlogAge value
+	tr.backlogHeadCreateTime.Store(ts)
+}
+
+func (tr *taskReader) getBacklogHeadCreateTime() time.Duration {
+	if tr.backlogHeadCreateTime.Load() == -1 {
+		return time.Duration(0)
+	}
+	return time.Since(time.Unix(0, tr.backlogHeadCreateTime.Load()))
+}
+
 func (tr *taskReader) dispatchBufferedTasks(ctx context.Context) error {
 	ctx = tr.backlogMgr.contextInfoProvider(ctx)
 
 dispatchLoop:
 	for ctx.Err() == nil {
+		if len(tr.taskBuffer) == 0 {
+			// resetting the atomic since we have no tasks from the backlog
+			tr.backlogHeadCreateTime.Store(-1)
+		}
 		select {
 		case taskInfo, ok := <-tr.taskBuffer:
 			if !ok { // Task queue getTasks pump is shutdown
@@ -123,6 +147,7 @@ dispatchLoop:
 			}
 			task := newInternalTask(taskInfo, tr.backlogMgr.completeTask, enumsspb.TASK_SOURCE_DB_BACKLOG, "", false)
 			for ctx.Err() == nil {
+				tr.updateBacklogAge(task)
 				taskCtx, cancel := context.WithTimeout(ctx, taskReaderOfferTimeout)
 				err := tr.backlogMgr.processSpooledTask(taskCtx, task)
 				cancel()

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -27,10 +27,11 @@ package matching
 import (
 	"context"
 	"errors"
-	"go.temporal.io/server/common/primitives/timestamp"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"go.temporal.io/server/common/primitives/timestamp"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"

--- a/tests/describe_task_queue.go
+++ b/tests/describe_task_queue.go
@@ -86,6 +86,7 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateBacklogInfo(
 
 	expectedBacklogCount := make(map[enumspb.TaskQueueType]int64)
 	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = 0
+	nullBacklogHeadCreateTime := true
 
 	tl := "backlog-counter-task-queue"
 	tq := &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
@@ -113,7 +114,10 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateBacklogInfo(
 	}
 
 	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = int64(workflows)
-	s.validateDescribeTaskQueue(tl, expectedBacklogCount, isEnhancedMode)
+	if workflows > 0 {
+		nullBacklogHeadCreateTime = false
+	}
+	s.validateDescribeTaskQueue(tl, expectedBacklogCount, isEnhancedMode, nullBacklogHeadCreateTime)
 
 	// Polling the tasks
 	for i := 0; i < workflows; {
@@ -131,11 +135,11 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateBacklogInfo(
 
 	// call describeTaskQueue to verify if the backlog decreased
 	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = int64(0)
-	s.validateDescribeTaskQueue(tl, expectedBacklogCount, isEnhancedMode)
+	s.validateDescribeTaskQueue(tl, expectedBacklogCount, isEnhancedMode, true)
 }
 
 func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(tl string, expectedBacklogCount map[enumspb.TaskQueueType]int64,
-	isEnhancedMode bool) {
+	isEnhancedMode bool, nullBacklogHeadCreateTime bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -165,8 +169,24 @@ func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(tl string, expectedBa
 			validator := true
 			for qT, t := range types {
 				queueType := enumspb.TaskQueueType(qT)
+				backlogHeadCreateTime := t.BacklogInfo.ApproximateBacklogAge.AsDuration()
+
 				if t.BacklogInfo.ApproximateBacklogCount != expectedBacklogCount[queueType] {
 					validator = false
+				}
+
+				if queueType != enumspb.TASK_QUEUE_TYPE_WORKFLOW {
+					if backlogHeadCreateTime != time.Duration(0) {
+						validator = false
+					}
+				} else if nullBacklogHeadCreateTime {
+					if backlogHeadCreateTime != time.Duration(0) {
+						validator = false
+					}
+				} else {
+					if backlogHeadCreateTime == time.Duration(0) {
+						validator = false
+					}
 				}
 			}
 			return validator == true


### PR DESCRIPTION
## What changed?
Added functionality to emit the create time, from now, of a given backlog via the `DescribeTaskQueue` API.

## How did you test it?
- Unit test
- Integration test

## Potential risks
None, merging to feature.

## Is hotfix candidate?
No
