### PR TITLE
Fix reset workflow case with force replication

### DIFF
--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -317,6 +317,12 @@ BackfillLoop:
 
 		if historyBlob.nodeID <= lastBatchNodeID {
 			// The history batch already in DB.
+			currentAncestor := sortedAncestors[sortedAncestorsIdx]
+			if historyBlob.nodeID >= currentAncestor.GetEndNodeId() {
+				// update ancestor
+				ancestors = append(ancestors, currentAncestor)
+				sortedAncestorsIdx++
+			}
 			continue BackfillLoop
 		}
 


### PR DESCRIPTION
## What changed?
Fix reset workflow case with force replication

## Why?
bug when force replication 2+ reset workflows

## How did you test it?
new integration test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
