### PR TITLE
Changing log level for unexpected errors

### DIFF
--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -519,7 +519,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 	}
 	// Unexpected errors handled below
 	metrics.TaskFailures.With(e.taggedMetricsHandler).Record(1)
-	e.logger.Error("Fail to process task", tag.Error(err), tag.LifeCycleProcessingFailed)
+	e.logger.Warn("Fail to process task", tag.Error(err), tag.LifeCycleProcessingFailed)
 
 	if e.isUnexpectedNonRetryableError(err) {
 		// Terminal errors are likely due to data corruption.

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -519,7 +519,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 	}
 	// Unexpected errors handled below
 	metrics.TaskFailures.With(e.taggedMetricsHandler).Record(1)
-	e.logger.Warn("Fail to process task", tag.Error(err), tag.LifeCycleProcessingFailed)
+	e.logger.Warn("Fail to process task", tag.Error(err), tag.ErrorType(err), tag.UnexpectedErrorAttempts(int32(e.unexpectedErrorAttempts)), tag.LifeCycleProcessingFailed)
 
 	if e.isUnexpectedNonRetryableError(err) {
 		// Terminal errors are likely due to data corruption.
@@ -540,7 +540,6 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 	// Unexpected but retryable error
 	e.unexpectedErrorAttempts++
 	metrics.TaskFailures.With(e.taggedMetricsHandler).Record(1)
-	e.logger.Error("Fail to process task", tag.Error(err), tag.ErrorType(err), tag.UnexpectedErrorAttempts(int32(e.unexpectedErrorAttempts)), tag.LifeCycleProcessingFailed)
 
 	if e.unexpectedErrorAttempts >= e.maxUnexpectedErrorAttempts() && e.dlqEnabled() {
 		// Keep this message in sync with the log line mentioned in Investigation section of docs/admin/dlq.md

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -518,6 +518,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 		return rewrittenErr
 	}
 	// Unexpected errors handled below
+	e.unexpectedErrorAttempts++
 	metrics.TaskFailures.With(e.taggedMetricsHandler).Record(1)
 	e.logger.Warn("Fail to process task", tag.Error(err), tag.ErrorType(err), tag.UnexpectedErrorAttempts(int32(e.unexpectedErrorAttempts)), tag.LifeCycleProcessingFailed)
 
@@ -538,9 +539,6 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 	}
 
 	// Unexpected but retryable error
-	e.unexpectedErrorAttempts++
-	metrics.TaskFailures.With(e.taggedMetricsHandler).Record(1)
-
 	if e.unexpectedErrorAttempts >= e.maxUnexpectedErrorAttempts() && e.dlqEnabled() {
 		// Keep this message in sync with the log line mentioned in Investigation section of docs/admin/dlq.md
 		e.logger.Error("Marking task as terminally failed, will send to DLQ. Maximum number of attempts with unexpected errors",


### PR DESCRIPTION
## What changed?
Changing log level for unexpected errors to warning in task processing.
Sometimes errors like shard ownership lost fills log with stack traces, making it harder to read.
The stack trace printed in the log corresponds to this logging line rather than the actual stack where the error happened.
So this stack trace is not very useful anyways.

## Why?
Making the log easier to read.

## How did you test it?


## Potential risks
None

## Documentation

## Is hotfix candidate?
No
