### PR TITLE
Replace test setup panics with t.Fatalf

### DIFF
--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -429,6 +429,7 @@ func (s *ExecutionMutableStateSuite) TestUpdate_NotZombie() {
 	)
 
 	currentMutation, currentEvents := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -465,6 +466,7 @@ func (s *ExecutionMutableStateSuite) TestUpdate_NotZombie_CurrentConflict() {
 	)
 
 	currentMutation, currentEvents := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		uuid.New().String(),
@@ -504,6 +506,7 @@ func (s *ExecutionMutableStateSuite) TestUpdate_NotZombie_Conflict() {
 	)
 
 	currentMutation, currentEvents := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -539,6 +542,7 @@ func (s *ExecutionMutableStateSuite) TestUpdate_NotZombie_WithNew() {
 	)
 
 	updateMutation, updateEvents := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -614,6 +618,7 @@ func (s *ExecutionMutableStateSuite) TestUpdate_Zombie() {
 	s.NoError(err)
 
 	zombieMutation, zombieEvents2 := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		runID,
@@ -650,6 +655,7 @@ func (s *ExecutionMutableStateSuite) TestUpdate_Zombie_CurrentConflict() {
 	)
 
 	currentMutation, currentEvents := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -709,6 +715,7 @@ func (s *ExecutionMutableStateSuite) TestUpdate_Zombie_Conflict() {
 	s.NoError(err)
 
 	zombieMutation, zombieEvents := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		runID,
@@ -769,6 +776,7 @@ func (s *ExecutionMutableStateSuite) TestUpdate_Zombie_WithNew() {
 	s.NoError(err)
 
 	zombieMutation, zombieEvents2 := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		runID,
@@ -857,6 +865,7 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent() {
 		baseBranchToken,
 	)
 	currentMutation, currentEvents2 := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -937,6 +946,7 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_Current
 	currentRunID := uuid.New().String()
 	currentBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, currentRunID, s.historyBranchUtil)
 	currentMutation, currentEvents := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		currentRunID,
@@ -1013,6 +1023,7 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_Conflic
 		baseBranchToken,
 	)
 	currentMutation, currentEvents2 := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -1089,6 +1100,7 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_Conflic
 		baseBranchToken,
 	)
 	currentMutation, currentEvents2 := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -1178,6 +1190,7 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_WithNew
 		newBranchToken,
 	)
 	currentMutation, currentEvents2 := RandomMutation(
+		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,

--- a/common/persistence/tests/mysql_test.go
+++ b/common/persistence/tests/mysql_test.go
@@ -130,7 +130,7 @@ func TestMySQLTaskQueueSuite(t *testing.T) {
 	}
 	defer func() {
 		testData.Factory.Close()
-		TearDownMySQLDatabase(testData.Cfg)
+		TearDownMySQLDatabase(t, testData.Cfg)
 	}()
 
 	s := NewTaskQueueSuite(t, taskQueueStore, testData.Logger)
@@ -191,15 +191,15 @@ func TestMySQLClusterMetadataPersistence(t *testing.T) {
 
 func TestMySQLNamespaceSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewNamespaceSuite(t, store)
@@ -208,15 +208,15 @@ func TestMySQLNamespaceSuite(t *testing.T) {
 
 func TestMySQLQueueMessageSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewQueueMessageSuite(t, store)
@@ -225,15 +225,15 @@ func TestMySQLQueueMessageSuite(t *testing.T) {
 
 func TestMySQLQueueMetadataSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewQueueMetadataSuite(t, store)
@@ -242,15 +242,15 @@ func TestMySQLQueueMetadataSuite(t *testing.T) {
 
 func TestMySQLMatchingTaskSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewMatchingTaskSuite(t, store)
@@ -259,15 +259,15 @@ func TestMySQLMatchingTaskSuite(t *testing.T) {
 
 func TestMySQLMatchingTaskQueueSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewMatchingTaskQueueSuite(t, store)
@@ -276,15 +276,15 @@ func TestMySQLMatchingTaskQueueSuite(t *testing.T) {
 
 func TestMySQLHistoryShardSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryShardSuite(t, store)
@@ -293,15 +293,15 @@ func TestMySQLHistoryShardSuite(t *testing.T) {
 
 func TestMySQLHistoryNodeSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryNodeSuite(t, store)
@@ -310,15 +310,15 @@ func TestMySQLHistoryNodeSuite(t *testing.T) {
 
 func TestMySQLHistoryTreeSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryTreeSuite(t, store)
@@ -327,15 +327,15 @@ func TestMySQLHistoryTreeSuite(t *testing.T) {
 
 func TestMySQLHistoryCurrentExecutionSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryCurrentExecutionSuite(t, store)
@@ -344,15 +344,15 @@ func TestMySQLHistoryCurrentExecutionSuite(t *testing.T) {
 
 func TestMySQLHistoryExecutionSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionSuite(t, store)
@@ -361,15 +361,15 @@ func TestMySQLHistoryExecutionSuite(t *testing.T) {
 
 func TestMySQLHistoryTransferTaskSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryTransferTaskSuite(t, store)
@@ -378,15 +378,15 @@ func TestMySQLHistoryTransferTaskSuite(t *testing.T) {
 
 func TestMySQLHistoryTimerTaskSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryTimerTaskSuite(t, store)
@@ -395,15 +395,15 @@ func TestMySQLHistoryTimerTaskSuite(t *testing.T) {
 
 func TestMySQLHistoryReplicationTaskSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryReplicationTaskSuite(t, store)
@@ -412,15 +412,15 @@ func TestMySQLHistoryReplicationTaskSuite(t *testing.T) {
 
 func TestMySQLHistoryVisibilityTaskSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryVisibilityTaskSuite(t, store)
@@ -429,15 +429,15 @@ func TestMySQLHistoryVisibilityTaskSuite(t *testing.T) {
 
 func TestMySQLHistoryReplicationDLQTaskSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryReplicationDLQTaskSuite(t, store)
@@ -446,15 +446,15 @@ func TestMySQLHistoryReplicationDLQTaskSuite(t *testing.T) {
 
 func TestMySQLHistoryExecutionBufferSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionBufferSuite(t, store)
@@ -463,15 +463,15 @@ func TestMySQLHistoryExecutionBufferSuite(t *testing.T) {
 
 func TestMySQLHistoryExecutionActivitySuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionActivitySuite(t, store)
@@ -480,15 +480,15 @@ func TestMySQLHistoryExecutionActivitySuite(t *testing.T) {
 
 func TestMySQLHistoryExecutionChildWorkflowSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionChildWorkflowSuite(t, store)
@@ -497,15 +497,15 @@ func TestMySQLHistoryExecutionChildWorkflowSuite(t *testing.T) {
 
 func TestMySQLHistoryExecutionTimerSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionTimerSuite(t, store)
@@ -514,15 +514,15 @@ func TestMySQLHistoryExecutionTimerSuite(t *testing.T) {
 
 func TestMySQLHistoryExecutionRequestCancelSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionRequestCancelSuite(t, store)
@@ -531,15 +531,15 @@ func TestMySQLHistoryExecutionRequestCancelSuite(t *testing.T) {
 
 func TestMySQLHistoryExecutionSignalSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionSignalSuite(t, store)
@@ -548,15 +548,15 @@ func TestMySQLHistoryExecutionSignalSuite(t *testing.T) {
 
 func TestMySQLHistoryExecutionSignalRequestSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionSignalRequestSuite(t, store)
@@ -565,15 +565,15 @@ func TestMySQLHistoryExecutionSignalRequestSuite(t *testing.T) {
 
 func TestMySQLVisibilitySuite(t *testing.T) {
 	cfg := NewMySQLConfig()
-	SetupMySQLDatabase(cfg)
-	SetupMySQLSchema(cfg)
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindVisibility, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownMySQLDatabase(cfg)
+		TearDownMySQLDatabase(t, cfg)
 	}()
 
 	s := sqltests.NewVisibilitySuite(t, store)

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -191,15 +191,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLQueuePersistence() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLNamespaceSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewNamespaceSuite(p.T(), store)
@@ -208,15 +208,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLNamespaceSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLQueueMessageSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewQueueMessageSuite(p.T(), store)
@@ -225,15 +225,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLQueueMessageSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLQueueMetadataSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewQueueMetadataSuite(p.T(), store)
@@ -242,15 +242,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLQueueMetadataSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewMatchingTaskSuite(p.T(), store)
@@ -259,15 +259,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskQueueSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewMatchingTaskQueueSuite(p.T(), store)
@@ -276,15 +276,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskQueueSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryShardSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryShardSuite(p.T(), store)
@@ -293,15 +293,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryShardSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryNodeSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryNodeSuite(p.T(), store)
@@ -310,15 +310,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryNodeSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryTreeSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryTreeSuite(p.T(), store)
@@ -327,15 +327,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryTreeSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryCurrentExecutionSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryCurrentExecutionSuite(p.T(), store)
@@ -344,15 +344,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryCurrentExecutionSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionSuite(p.T(), store)
@@ -361,15 +361,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryTransferTaskSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryTransferTaskSuite(p.T(), store)
@@ -378,15 +378,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryTransferTaskSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryTimerTaskSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryTimerTaskSuite(p.T(), store)
@@ -395,15 +395,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryTimerTaskSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryReplicationTaskSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryReplicationTaskSuite(p.T(), store)
@@ -412,15 +412,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryReplicationTaskSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryVisibilityTaskSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryVisibilityTaskSuite(p.T(), store)
@@ -429,15 +429,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryVisibilityTaskSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryReplicationDLQTaskSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryReplicationDLQTaskSuite(p.T(), store)
@@ -446,15 +446,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryReplicationDLQTaskSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionBufferSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionBufferSuite(p.T(), store)
@@ -463,15 +463,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionBufferSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionActivitySuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionActivitySuite(p.T(), store)
@@ -480,15 +480,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionActivitySuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionChildWorkflowSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionChildWorkflowSuite(p.T(), store)
@@ -497,15 +497,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionChildWorkflowSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionTimerSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionTimerSuite(p.T(), store)
@@ -514,15 +514,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionTimerSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionRequestCancelSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionRequestCancelSuite(p.T(), store)
@@ -531,15 +531,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionRequestCancelSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSignalSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionSignalSuite(p.T(), store)
@@ -548,15 +548,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSignalSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSignalRequestSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewHistoryExecutionSignalRequestSuite(p.T(), store)
@@ -565,15 +565,15 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionSignalRequestSuite() {
 
 func (p *PostgreSQLSuite) TestPostgreSQLVisibilitySuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
-	SetupPostgreSQLDatabase(cfg)
-	SetupPostgreSQLSchema(cfg)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
 	store, err := sql.NewSQLDB(sqlplugin.DbKindVisibility, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
 	if err != nil {
 		p.T().Fatalf("unable to create MySQL DB: %v", err)
 	}
 	defer func() {
 		_ = store.Close()
-		TearDownPostgreSQLDatabase(cfg)
+		TearDownPostgreSQLDatabase(p.T(), cfg)
 	}()
 
 	s := sqltests.NewVisibilitySuite(p.T(), store)

--- a/common/persistence/tests/util.go
+++ b/common/persistence/tests/util.go
@@ -26,6 +26,7 @@ package tests
 
 import (
 	"math/rand"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -102,6 +103,7 @@ func RandomSnapshot(
 }
 
 func RandomMutation(
+	t *testing.T,
 	namespaceID string,
 	workflowID string,
 	runID string,


### PR DESCRIPTION
## What changed?
I replaced all panics in the persistence tests with calls to `testing.T.Fatalf` so they're easier to find.

I also updated the SQLite setup to log the error itself and not `%+v` of the error tag wrapper

## Why?

To make these failures easier to find and/or possible to diagnose. We ate the error in https://github.com/temporalio/temporal/actions/runs/9199422279/job/25304258612 so I don't know why it flaked

## How did you test it?


## Potential risks

## Documentation

## Is hotfix candidate?
No
