### PR TITLE
Restoring legacy backlog hint

### DIFF
--- a/service/matching/ack_manager.go
+++ b/service/matching/ack_manager.go
@@ -27,6 +27,8 @@ package matching
 import (
 	"sync"
 
+	"go.uber.org/atomic"
+
 	"github.com/emirpasic/gods/maps/treemap"
 	godsutils "github.com/emirpasic/gods/utils"
 	"go.temporal.io/server/common/log"
@@ -40,6 +42,7 @@ type ackManager struct {
 	outstandingTasks *treemap.Map        // TaskID->acked
 	readLevel        int64               // Maximum TaskID inserted into outstandingTasks
 	ackLevel         int64               // Maximum TaskID below which all tasks are acked
+	backlogCounter   atomic.Int64
 	logger           log.Logger
 }
 
@@ -66,6 +69,7 @@ func (m *ackManager) addTask(taskID int64) {
 		m.logger.Fatal("Already present in outstanding tasks", tag.TaskID(taskID))
 	}
 	m.outstandingTasks.Put(taskID, false)
+	m.backlogCounter.Inc()
 }
 
 func (m *ackManager) getReadLevel() int64 {
@@ -132,6 +136,7 @@ func (m *ackManager) completeTask(taskID int64) int64 {
 	// TODO the ack level management should be done by a dedicated coroutine
 	//  this is only a temporarily solution
 	m.outstandingTasks.Put(taskID, true)
+	m.backlogCounter.Dec()
 
 	// Adjust the ack level as far as we can
 	for {
@@ -145,4 +150,8 @@ func (m *ackManager) completeTask(taskID int64) int64 {
 		m.backlogMgr.db.updateApproximateBacklogCount(int64(-1))
 	}
 
+}
+
+func (m *ackManager) getBacklogCountHint() int64 {
+	return m.backlogCounter.Load()
 }

--- a/service/matching/ack_manager_test.go
+++ b/service/matching/ack_manager_test.go
@@ -33,6 +33,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAckManager_AddingTasksIncreasesBacklogCounter(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	backlogMgr := newBacklogMgr(controller)
+
+	t.Parallel()
+	backlogMgr.taskAckManager.addTask(1)
+	require.Equal(t, backlogMgr.taskAckManager.getBacklogCountHint(), int64(1))
+	backlogMgr.taskAckManager.addTask(12)
+	require.Equal(t, backlogMgr.taskAckManager.getBacklogCountHint(), int64(2))
+}
+
 func TestAckManager_CompleteTaskMovesAckLevelUpToGap(t *testing.T) {
 	t.Parallel()
 	controller := gomock.NewController(t)

--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -207,7 +207,7 @@ func (c *backlogManagerImpl) BacklogStatus() *taskqueuepb.TaskQueueStatus {
 	return &taskqueuepb.TaskQueueStatus{
 		ReadLevel:        c.taskAckManager.getReadLevel(),
 		AckLevel:         c.taskAckManager.getAckLevel(),
-		BacklogCountHint: c.BacklogCountHint(),
+		BacklogCountHint: c.db.getApproximateBacklogCount(),
 		TaskIdBlock: &taskqueuepb.TaskIdBlock{
 			StartId: taskIDBlock.start,
 			EndId:   taskIDBlock.end,

--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -207,7 +207,7 @@ func (c *backlogManagerImpl) BacklogStatus() *taskqueuepb.TaskQueueStatus {
 	return &taskqueuepb.TaskQueueStatus{
 		ReadLevel:        c.taskAckManager.getReadLevel(),
 		AckLevel:         c.taskAckManager.getAckLevel(),
-		BacklogCountHint: c.db.getApproximateBacklogCount(),
+		BacklogCountHint: c.db.getApproximateBacklogCount(), // replacing with a more accurate value of the backlog counter
 		TaskIdBlock: &taskqueuepb.TaskIdBlock{
 			StartId: taskIDBlock.start,
 			EndId:   taskIDBlock.end,

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -321,7 +321,7 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 	}
 
 	task.namespace = c.partitionMgr.ns.Name()
-	task.backlogCountHint = c.backlogMgr.db.getApproximateBacklogCount
+	task.backlogCountHint = c.backlogMgr.BacklogCountHint
 	return task, nil
 }
 


### PR DESCRIPTION
## What changed?
Conversation from @dnr and @ShahabT, over [here](https://github.com/temporalio/temporal/pull/5934#discussion_r1610692023), made me realize that the legacy backlog hint is required. Since the updated backlog counter is an overestimate, it could result in a case where a worker keeps on polling a sticky queue even when there are no tasks in the backlog. Thus, it is better and safer to restore this.

## How did you test it?
- Existing suite of tests.

## Potential risks
No, merging to feature and restoring previously pushed changes.

## Is hotfix candidate?
No
