### PR TITLE
feat: export setuptask and updatetask

### DIFF
--- a/tools/common/schema/handler.go
+++ b/tools/common/schema/handler.go
@@ -41,7 +41,7 @@ func Setup(cli *cli.Context, db DB, logger log.Logger) error {
 	if err != nil {
 		return err
 	}
-	return newSetupSchemaTask(db, cfg, logger).Run()
+	return NewSetupSchemaTask(db, cfg, logger).Run()
 }
 
 // Update updates the schema for the specified database
@@ -50,7 +50,7 @@ func Update(cli *cli.Context, db DB, logger log.Logger) error {
 	if err != nil {
 		return err
 	}
-	return newUpdateSchemaTask(db, cfg, logger).Run()
+	return NewUpdateSchemaTask(db, cfg, logger).Run()
 }
 
 func newUpdateConfig(cli *cli.Context, db DB) (*UpdateConfig, error) {

--- a/tools/common/schema/setuptask.go
+++ b/tools/common/schema/setuptask.go
@@ -49,7 +49,8 @@ type SetupTask struct {
 	logger log.Logger
 }
 
-func newSetupSchemaTask(db DB, config *SetupConfig, logger log.Logger) *SetupTask {
+// NewSetupSchemaTask returns a new instance of SetupTask
+func NewSetupSchemaTask(db DB, config *SetupConfig, logger log.Logger) *SetupTask {
 	return &SetupTask{
 		db:     db,
 		config: config,

--- a/tools/common/schema/updatetask.go
+++ b/tools/common/schema/updatetask.go
@@ -42,6 +42,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
+
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/persistence"
@@ -89,7 +90,7 @@ var (
 )
 
 // NewUpdateSchemaTask returns a new instance of UpdateTask
-func newUpdateSchemaTask(db DB, config *UpdateConfig, logger log.Logger) *UpdateTask {
+func NewUpdateSchemaTask(db DB, config *UpdateConfig, logger log.Logger) *UpdateTask {
 	return &UpdateTask{
 		db:     db,
 		config: config,


### PR DESCRIPTION
## What changed?
Setup and Update schema tasks have been exported.

## Why?
These utilities are useful for setting up the database via code.

## How did you test it?
I've invoked these functions inside a host application.

## Potential risks
No risks. These are utility functions.

## Documentation
Yes.

## Is hotfix candidate?
No.
