### PR TITLE
Replace base branch token with new branch token in fork request

### DIFF
--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -877,6 +877,8 @@ type (
 		ForkNodeID int64
 		// the info for clean up data in background
 		Info string
+		// the new run ID
+		NewRunID string
 	}
 
 	// ForkHistoryBranchResponse is the response to ForkHistoryBranchRequest

--- a/common/persistence/history_branch_util.go
+++ b/common/persistence/history_branch_util.go
@@ -66,15 +66,15 @@ type (
 )
 
 func (u *HistoryBranchUtilImpl) NewHistoryBranch(
-	namespaceID string,
-	workflowID string,
-	runID string,
+	_ string, // namespaceID
+	_ string, // workflowID
+	_ string, // runID
 	treeID string,
 	branchID *string,
 	ancestors []*persistencespb.HistoryBranchRange,
-	runTimeout time.Duration,
-	executionTimeout time.Duration,
-	retentionDuration time.Duration,
+	_ time.Duration, // runTimeout
+	_ time.Duration, // executionTimeout
+	_ time.Duration, // retentionDuration
 ) ([]byte, error) {
 	var id string
 	if branchID == nil {

--- a/common/persistence/history_branch_util.go
+++ b/common/persistence/history_branch_util.go
@@ -50,19 +50,31 @@ type (
 			retentionDuration time.Duration,
 		) ([]byte, error)
 		// ParseHistoryBranchInfo parses the history branch for branch information
-		ParseHistoryBranchInfo(branchToken []byte) (*persistencespb.HistoryBranch, error)
+		ParseHistoryBranchInfo(
+			branchToken []byte,
+		) (*persistencespb.HistoryBranch, error)
 		// UpdateHistoryBranchInfo updates the history branch with branch information
-		UpdateHistoryBranchInfo(branchToken []byte, branchInfo *persistencespb.HistoryBranch) ([]byte, error)
+		UpdateHistoryBranchInfo(
+			branchToken []byte,
+			branchInfo *persistencespb.HistoryBranch,
+			runID string,
+		) ([]byte, error)
 	}
 
 	HistoryBranchUtilImpl struct {
 	}
 )
 
-func NewHistoryBranch(
+func (u *HistoryBranchUtilImpl) NewHistoryBranch(
+	namespaceID string,
+	workflowID string,
+	runID string,
 	treeID string,
 	branchID *string,
 	ancestors []*persistencespb.HistoryBranchRange,
+	runTimeout time.Duration,
+	executionTimeout time.Duration,
+	retentionDuration time.Duration,
 ) ([]byte, error) {
 	var id string
 	if branchID == nil {
@@ -82,25 +94,17 @@ func NewHistoryBranch(
 	return data.Data, nil
 }
 
-func (u *HistoryBranchUtilImpl) NewHistoryBranch(
-	namespaceID string,
-	workflowID string,
-	runID string,
-	treeID string,
-	branchID *string,
-	ancestors []*persistencespb.HistoryBranchRange,
-	runTimeout time.Duration,
-	executionTimeout time.Duration,
-	retentionDuration time.Duration,
-) ([]byte, error) {
-	return NewHistoryBranch(treeID, branchID, ancestors)
-}
-
-func (u *HistoryBranchUtilImpl) ParseHistoryBranchInfo(branchToken []byte) (*persistencespb.HistoryBranch, error) {
+func (u *HistoryBranchUtilImpl) ParseHistoryBranchInfo(
+	branchToken []byte,
+) (*persistencespb.HistoryBranch, error) {
 	return serialization.HistoryBranchFromBlob(branchToken, enumspb.ENCODING_TYPE_PROTO3.String())
 }
 
-func (u *HistoryBranchUtilImpl) UpdateHistoryBranchInfo(branchToken []byte, branchInfo *persistencespb.HistoryBranch) ([]byte, error) {
+func (u *HistoryBranchUtilImpl) UpdateHistoryBranchInfo(
+	branchToken []byte,
+	branchInfo *persistencespb.HistoryBranch,
+	runID string,
+) ([]byte, error) {
 	bi, err := serialization.HistoryBranchFromBlob(branchToken, enumspb.ENCODING_TYPE_PROTO3.String())
 	if err != nil {
 		return nil, err

--- a/common/persistence/history_branch_util_mock.go
+++ b/common/persistence/history_branch_util_mock.go
@@ -90,16 +90,16 @@ func (mr *MockHistoryBranchUtilMockRecorder) ParseHistoryBranchInfo(branchToken 
 }
 
 // UpdateHistoryBranchInfo mocks base method.
-func (m *MockHistoryBranchUtil) UpdateHistoryBranchInfo(branchToken []byte, branchInfo *persistence.HistoryBranch) ([]byte, error) {
+func (m *MockHistoryBranchUtil) UpdateHistoryBranchInfo(branchToken []byte, branchInfo *persistence.HistoryBranch, runID string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateHistoryBranchInfo", branchToken, branchInfo)
+	ret := m.ctrl.Call(m, "UpdateHistoryBranchInfo", branchToken, branchInfo, runID)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateHistoryBranchInfo indicates an expected call of UpdateHistoryBranchInfo.
-func (mr *MockHistoryBranchUtilMockRecorder) UpdateHistoryBranchInfo(branchToken, branchInfo interface{}) *gomock.Call {
+func (mr *MockHistoryBranchUtilMockRecorder) UpdateHistoryBranchInfo(branchToken, branchInfo, runID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHistoryBranchInfo", reflect.TypeOf((*MockHistoryBranchUtil)(nil).UpdateHistoryBranchInfo), branchToken, branchInfo)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHistoryBranchInfo", reflect.TypeOf((*MockHistoryBranchUtil)(nil).UpdateHistoryBranchInfo), branchToken, branchInfo, runID)
 }

--- a/common/persistence/history_branch_util_test.go
+++ b/common/persistence/history_branch_util_test.go
@@ -65,7 +65,17 @@ func (s *historyBranchUtilSuite) TestHistoryBranchUtil() {
 	treeID0 := primitives.NewUUID().String()
 	branchID0 := primitives.NewUUID().String()
 	ancestors := []*persistencespb.HistoryBranchRange(nil)
-	branchToken0, err := NewHistoryBranch(treeID0, &branchID0, ancestors)
+	branchToken0, err := historyBranchUtil.NewHistoryBranch(
+		primitives.NewUUID().String(),
+		primitives.NewUUID().String(),
+		primitives.NewUUID().String(),
+		treeID0,
+		&branchID0,
+		ancestors,
+		0,
+		0,
+		0,
+	)
 	s.NoError(err)
 
 	branchInfo0, err := historyBranchUtil.ParseHistoryBranchInfo(branchToken0)
@@ -82,7 +92,9 @@ func (s *historyBranchUtilSuite) TestHistoryBranchUtil() {
 			TreeId:    treeID1,
 			BranchId:  branchID1,
 			Ancestors: ancestors,
-		})
+		},
+		primitives.NewUUID().String(),
+	)
 	s.NoError(err)
 
 	branchInfo1, err := historyBranchUtil.ParseHistoryBranchInfo(branchToken1)

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -105,7 +105,11 @@ func (m *executionManagerImpl) ForkHistoryBranch(
 	// The above newBranchInfo is a lossy construction of the forked branch token from the original opaque branch token.
 	// It only initializes with the fields it understands, which may inadvertently discard other misc fields. The
 	// following is the replacement logic to correctly apply the updated fields into the original opaque branch token.
-	newBranchToken, err := m.GetHistoryBranchUtil().UpdateHistoryBranchInfo(request.ForkBranchToken, newBranchInfo)
+	newBranchToken, err := m.GetHistoryBranchUtil().UpdateHistoryBranchInfo(
+		request.ForkBranchToken,
+		newBranchInfo,
+		request.NewRunID,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -123,13 +127,13 @@ func (m *executionManagerImpl) ForkHistoryBranch(
 	}
 
 	req := &InternalForkHistoryBranchRequest{
-		ForkBranchToken: request.ForkBranchToken,
-		ForkBranchInfo:  forkBranch,
-		TreeInfo:        treeInfoBlob,
-		ForkNodeID:      request.ForkNodeID,
-		NewBranchID:     newBranchInfo.BranchId,
-		Info:            request.Info,
-		ShardID:         request.ShardID,
+		NewBranchToken: newBranchToken,
+		ForkBranchInfo: forkBranch,
+		TreeInfo:       treeInfoBlob,
+		ForkNodeID:     request.ForkNodeID,
+		NewBranchID:    newBranchInfo.BranchId,
+		Info:           request.Info,
+		ShardID:        request.ShardID,
 	}
 
 	err = m.persistence.ForkHistoryBranch(ctx, req)

--- a/common/persistence/persistence-tests/history_v2_persistence.go
+++ b/common/persistence/persistence-tests/history_v2_persistence.go
@@ -854,6 +854,7 @@ func (s *HistoryV2PersistenceSuite) fork(forkBranch []byte, forkNodeID int64) ([
 			Info:            testForkRunID,
 			ShardID:         s.ShardInfo.GetShardId(),
 			NamespaceID:     uuid.New(),
+			NewRunID:        uuid.New(),
 		})
 		if resp != nil {
 			bi = resp.NewBranchToken

--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -562,8 +562,8 @@ type (
 
 	// InternalForkHistoryBranchRequest is used to fork a history branch
 	InternalForkHistoryBranchRequest struct {
-		// The base branch token
-		ForkBranchToken []byte
+		// The new branch token to fork to
+		NewBranchToken []byte
 		// The base branch to fork from
 		ForkBranchInfo *persistencespb.HistoryBranch
 		// Serialized TreeInfo

--- a/common/persistence/tests/history_store.go
+++ b/common/persistence/tests/history_store.go
@@ -800,6 +800,7 @@ func (s *HistoryEventsSuite) forkHistoryBranch(
 		ForkBranchToken: branchToken,
 		ForkNodeID:      newNodeID,
 		Info:            "",
+		NewRunID:        uuid.New(),
 	})
 	s.NoError(err)
 	return resp.NewBranchToken

--- a/service/history/ndc/branch_manager.go
+++ b/service/history/ndc/branch_manager.go
@@ -223,13 +223,15 @@ func (r *BranchMgrImpl) createNewBranch(
 	executionInfo := r.mutableState.GetExecutionInfo()
 	namespaceID := executionInfo.NamespaceId
 	workflowID := executionInfo.WorkflowId
+	runID := uuid.New()
 
 	resp, err := r.executionMgr.ForkHistoryBranch(ctx, &persistence.ForkHistoryBranchRequest{
 		ForkBranchToken: baseBranchToken,
 		ForkNodeID:      baseBranchLastEventID + 1,
-		Info:            persistence.BuildHistoryGarbageCleanupInfo(namespaceID, workflowID, uuid.New()),
+		Info:            persistence.BuildHistoryGarbageCleanupInfo(namespaceID, workflowID, runID),
 		ShardID:         shardID,
 		NamespaceID:     namespaceID,
+		NewRunID:        runID,
 	})
 	if err != nil {
 		return 0, err

--- a/service/history/ndc/branch_manager.go
+++ b/service/history/ndc/branch_manager.go
@@ -29,7 +29,6 @@ package ndc
 import (
 	"context"
 
-	"github.com/pborman/uuid"
 	"go.temporal.io/api/serviceerror"
 
 	historyspb "go.temporal.io/server/api/history/v1"
@@ -223,7 +222,7 @@ func (r *BranchMgrImpl) createNewBranch(
 	executionInfo := r.mutableState.GetExecutionInfo()
 	namespaceID := executionInfo.NamespaceId
 	workflowID := executionInfo.WorkflowId
-	runID := uuid.New()
+	runID := r.mutableState.GetExecutionState().RunId
 
 	resp, err := r.executionMgr.ForkHistoryBranch(ctx, &persistence.ForkHistoryBranchRequest{
 		ForkBranchToken: baseBranchToken,

--- a/service/history/ndc/branch_manager_test.go
+++ b/service/history/ndc/branch_manager_test.go
@@ -141,13 +141,13 @@ func (s *branchMgrSuite) TestCreateNewBranch() {
 	shardID := s.mockShard.GetShardID()
 	s.mockExecutionManager.EXPECT().ForkHistoryBranch(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, input *persistence.ForkHistoryBranchRequest) (*persistence.ForkHistoryBranchResponse, error) {
-			input.Info = ""
 			s.Equal(&persistence.ForkHistoryBranchRequest{
 				ForkBranchToken: baseBranchToken,
 				ForkNodeID:      baseBranchLCAEventID + 1,
-				Info:            "",
+				Info:            input.Info,
 				ShardID:         shardID,
 				NamespaceID:     s.namespaceID,
+				NewRunID:        input.NewRunID,
 			}, input)
 			return &persistence.ForkHistoryBranchResponse{
 				NewBranchToken: newBranchToken,
@@ -270,13 +270,13 @@ func (s *branchMgrSuite) TestGetOrCreate_BranchNotAppendable_NoMissingEventInBet
 	shardID := s.mockShard.GetShardID()
 	s.mockExecutionManager.EXPECT().ForkHistoryBranch(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, input *persistence.ForkHistoryBranchRequest) (*persistence.ForkHistoryBranchResponse, error) {
-			input.Info = ""
 			s.Equal(&persistence.ForkHistoryBranchRequest{
 				ForkBranchToken: baseBranchToken,
 				ForkNodeID:      baseBranchLCAEventID + 1,
-				Info:            "",
+				Info:            input.Info,
 				ShardID:         shardID,
 				NamespaceID:     s.namespaceID,
+				NewRunID:        input.NewRunID,
 			}, input)
 			return &persistence.ForkHistoryBranchResponse{
 				NewBranchToken: newBranchToken,
@@ -366,13 +366,13 @@ func (s *branchMgrSuite) TestCreate_NoMissingEventInBetween() {
 	shardID := s.mockShard.GetShardID()
 	s.mockExecutionManager.EXPECT().ForkHistoryBranch(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, input *persistence.ForkHistoryBranchRequest) (*persistence.ForkHistoryBranchResponse, error) {
-			input.Info = ""
 			s.Equal(&persistence.ForkHistoryBranchRequest{
 				ForkBranchToken: baseBranchToken,
 				ForkNodeID:      baseBranchLCAEventID + 1,
-				Info:            "",
+				Info:            input.Info,
 				ShardID:         shardID,
 				NamespaceID:     s.namespaceID,
+				NewRunID:        input.NewRunID,
 			}, input)
 			return &persistence.ForkHistoryBranchResponse{
 				NewBranchToken: newBranchToken,

--- a/service/history/ndc/resetter.go
+++ b/service/history/ndc/resetter.go
@@ -234,6 +234,7 @@ func (r *resetterImpl) getResetBranchToken(
 		Info:            persistence.BuildHistoryGarbageCleanupInfo(r.namespaceID.String(), r.workflowID, r.newRunID),
 		ShardID:         shardID,
 		NamespaceID:     r.namespaceID.String(),
+		NewRunID:        r.newRunID,
 	})
 	if err != nil {
 		return nil, err

--- a/service/history/ndc/resetter_test.go
+++ b/service/history/ndc/resetter_test.go
@@ -196,6 +196,7 @@ func (s *resetterSuite) TestResetWorkflow_NoError() {
 		Info:            persistence.BuildHistoryGarbageCleanupInfo(s.namespaceID.String(), s.workflowID, s.newRunID),
 		ShardID:         shardID,
 		NamespaceID:     s.namespaceID.String(),
+		NewRunID:        s.newRunID,
 	}).Return(&persistence.ForkHistoryBranchResponse{NewBranchToken: newBranchToken}, nil)
 
 	rebuiltMutableState, err := s.workflowResetter.resetWorkflow(

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -546,6 +546,7 @@ func (r *workflowResetterImpl) forkAndGenerateBranchToken(
 		Info:            persistence.BuildHistoryGarbageCleanupInfo(namespaceID.String(), workflowID, resetRunID),
 		ShardID:         shardID,
 		NamespaceID:     namespaceID.String(),
+		NewRunID:        resetRunID,
 	})
 	if err != nil {
 		return nil, err

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -297,6 +297,7 @@ func (s *workflowResetterSuite) TestReplayResetWorkflow() {
 		Info:            persistence.BuildHistoryGarbageCleanupInfo(s.namespaceID.String(), s.workflowID, s.resetRunID),
 		ShardID:         shardID,
 		NamespaceID:     s.namespaceID.String(),
+		NewRunID:        s.resetRunID,
 	}).Return(&persistence.ForkHistoryBranchResponse{NewBranchToken: resetBranchToken}, nil)
 
 	s.mockStateRebuilder.EXPECT().Rebuild(
@@ -515,6 +516,7 @@ func (s *workflowResetterSuite) TestGenerateBranchToken() {
 		Info:            persistence.BuildHistoryGarbageCleanupInfo(s.namespaceID.String(), s.workflowID, s.resetRunID),
 		ShardID:         shardID,
 		NamespaceID:     s.namespaceID.String(),
+		NewRunID:        s.resetRunID,
 	}).Return(&persistence.ForkHistoryBranchResponse{NewBranchToken: resetBranchToken}, nil)
 
 	newBranchToken, err := s.workflowResetter.forkAndGenerateBranchToken(

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -356,6 +356,7 @@ BackfillLoop:
 				BranchId:  branchID,
 				Ancestors: ancestors,
 			},
+			runID,
 		)
 		if err != nil {
 			return common.EmptyEventTaskID, err

--- a/service/worker/scanner/history/scavenger_test.go
+++ b/service/worker/scanner/history/scavenger_test.go
@@ -70,6 +70,7 @@ type (
 		mockAdminClient      *adminservicemock.MockAdminServiceClient
 		mockRegistry         *namespace.MockRegistry
 		scavenger            *Scavenger
+		historyBranchUtil    persistence.HistoryBranchUtilImpl
 	}
 )
 
@@ -423,26 +424,25 @@ func (s *ScavengerTestSuite) TestDeletingBranchesTwoPages() {
 			RunId:      "runID4",
 		},
 	})).Return(nil, serviceerror.NewNotFound(""))
-
-	branchToken1, err := persistence.NewHistoryBranch(treeID1, &branchID1, []*persistencepb.HistoryBranchRange{})
+	branchToken1, err := s.historyBranchUtil.NewHistoryBranch(uuid.New(), uuid.New(), uuid.New(), treeID1, &branchID1, []*persistencepb.HistoryBranchRange{}, 0, 0, 0)
 	s.Nil(err)
 	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), protomock.Eq(&persistence.DeleteHistoryBranchRequest{
 		BranchToken: branchToken1,
 		ShardID:     common.WorkflowIDToHistoryShard("namespaceID1", "workflowID1", s.numShards),
 	})).Return(nil)
-	branchToken2, err := persistence.NewHistoryBranch(treeID2, &branchID2, []*persistencepb.HistoryBranchRange{})
+	branchToken2, err := s.historyBranchUtil.NewHistoryBranch(uuid.New(), uuid.New(), uuid.New(), treeID2, &branchID2, []*persistencepb.HistoryBranchRange{}, 0, 0, 0)
 	s.Nil(err)
 	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), protomock.Eq(&persistence.DeleteHistoryBranchRequest{
 		BranchToken: branchToken2,
 		ShardID:     common.WorkflowIDToHistoryShard("namespaceID2", "workflowID2", s.numShards),
 	})).Return(nil)
-	branchToken3, err := persistence.NewHistoryBranch(treeID3, &branchID3, []*persistencepb.HistoryBranchRange{})
+	branchToken3, err := s.historyBranchUtil.NewHistoryBranch(uuid.New(), uuid.New(), uuid.New(), treeID3, &branchID3, []*persistencepb.HistoryBranchRange{}, 0, 0, 0)
 	s.Nil(err)
 	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), protomock.Eq(&persistence.DeleteHistoryBranchRequest{
 		BranchToken: branchToken3,
 		ShardID:     common.WorkflowIDToHistoryShard("namespaceID3", "workflowID3", s.numShards),
 	})).Return(nil)
-	branchToken4, err := persistence.NewHistoryBranch(treeID4, &branchID4, []*persistencepb.HistoryBranchRange{})
+	branchToken4, err := s.historyBranchUtil.NewHistoryBranch(uuid.New(), uuid.New(), uuid.New(), treeID4, &branchID4, []*persistencepb.HistoryBranchRange{}, 0, 0, 0)
 	s.Nil(err)
 	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), protomock.Eq(&persistence.DeleteHistoryBranchRequest{
 		BranchToken: branchToken4,
@@ -557,14 +557,14 @@ func (s *ScavengerTestSuite) TestMixesTwoPages() {
 		},
 	})).Return(ms, nil)
 
-	branchToken3, err := persistence.NewHistoryBranch(treeID3, &branchID3, []*persistencepb.HistoryBranchRange{})
+	branchToken3, err := s.historyBranchUtil.NewHistoryBranch(uuid.New(), uuid.New(), uuid.New(), treeID3, &branchID3, []*persistencepb.HistoryBranchRange{}, 0, 0, 0)
 	s.Nil(err)
 	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), protomock.Eq(&persistence.DeleteHistoryBranchRequest{
 		BranchToken: branchToken3,
 		ShardID:     common.WorkflowIDToHistoryShard("namespaceID3", "workflowID3", s.numShards),
 	})).Return(nil)
 
-	branchToken4, err := persistence.NewHistoryBranch(treeID4, &branchID4, []*persistencepb.HistoryBranchRange{})
+	branchToken4, err := s.historyBranchUtil.NewHistoryBranch(uuid.New(), uuid.New(), uuid.New(), treeID4, &branchID4, []*persistencepb.HistoryBranchRange{}, 0, 0, 0)
 	s.Nil(err)
 	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), protomock.Eq(&persistence.DeleteHistoryBranchRequest{
 		BranchToken: branchToken4,


### PR DESCRIPTION
Pass new run ID into the new branch token initialization.

## What changed?
Replace ForkBranchToken with NewBranchToken in InternalForkHistoryBranchRequest. The new branch token is derived from the base branch token and contains the updated set of ancestors.