### PR TITLE
refactor ES constructor: moved ES processor/client initialization to visiblity store ctor

### DIFF
--- a/common/persistence/tests/visibility_persistence_suite.go
+++ b/common/persistence/tests/visibility_persistence_suite.go
@@ -85,7 +85,6 @@ func (s *VisibilityPersistenceSuite) SetupSuite() {
 		resolver.NewNoopResolver(),
 		s.CustomVisibilityStoreFactory,
 		nil,
-		nil,
 		s.SearchAttributesProvider,
 		s.SearchAttributesMapperProvider,
 		dynamicconfig.GetIntPropertyFn(1000),

--- a/common/persistence/visibility/factory.go
+++ b/common/persistence/visibility/factory.go
@@ -25,6 +25,8 @@
 package visibility
 
 import (
+	"net/http"
+
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -36,7 +38,6 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/persistence/visibility/store"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
-	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/persistence/visibility/store/sql"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/searchattribute"
@@ -56,7 +57,7 @@ func NewManager(
 	persistenceResolver resolver.ServiceResolver,
 	customVisibilityStoreFactory VisibilityStoreFactory,
 
-	esClient esclient.Client,
+	esHttpClient *http.Client,
 	esProcessorConfig *elasticsearch.ProcessorConfig,
 	searchAttributesProvider searchattribute.Provider,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
@@ -77,7 +78,7 @@ func NewManager(
 		persistenceCfg.GetVisibilityStoreConfig(),
 		persistenceResolver,
 		customVisibilityStoreFactory,
-		esClient,
+		esHttpClient,
 		esProcessorConfig,
 		searchAttributesProvider,
 		searchAttributesMapperProvider,
@@ -101,7 +102,7 @@ func NewManager(
 		persistenceCfg.GetSecondaryVisibilityStoreConfig(),
 		persistenceResolver,
 		customVisibilityStoreFactory,
-		esClient,
+		esHttpClient,
 		esProcessorConfig,
 		searchAttributesProvider,
 		searchAttributesMapperProvider,
@@ -192,7 +193,7 @@ func newVisibilityManagerFromDataStoreConfig(
 	persistenceResolver resolver.ServiceResolver,
 	customVisibilityStoreFactory VisibilityStoreFactory,
 
-	esClient esclient.Client,
+	esHttpClient *http.Client,
 	esProcessorConfig *elasticsearch.ProcessorConfig,
 	searchAttributesProvider searchattribute.Provider,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
@@ -210,7 +211,7 @@ func newVisibilityManagerFromDataStoreConfig(
 		dsConfig,
 		persistenceResolver,
 		customVisibilityStoreFactory,
-		esClient,
+		esHttpClient,
 		esProcessorConfig,
 		searchAttributesProvider,
 		searchAttributesMapperProvider,
@@ -241,7 +242,7 @@ func newVisibilityStoreFromDataStoreConfig(
 	persistenceResolver resolver.ServiceResolver,
 	customVisibilityStoreFactory VisibilityStoreFactory,
 
-	esClient esclient.Client,
+	esHttpClient *http.Client,
 	esProcessorConfig *elasticsearch.ProcessorConfig,
 	searchAttributesProvider searchattribute.Provider,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
@@ -266,8 +267,8 @@ func newVisibilityStoreFromDataStoreConfig(
 		)
 	} else if dsConfig.Elasticsearch != nil {
 		visStore = elasticsearch.NewVisibilityStore(
-			esClient,
-			dsConfig.Elasticsearch.GetVisibilityIndex(),
+			esHttpClient,
+			dsConfig.Elasticsearch,
 			esProcessorConfig,
 			searchAttributesProvider,
 			searchAttributesMapperProvider,

--- a/common/persistence/visibility/factory.go
+++ b/common/persistence/visibility/factory.go
@@ -298,28 +298,15 @@ func newElasticsearchVisibilityStore(
 	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) store.VisibilityStore {
-	if esClient == nil {
-		return nil
-	}
-
-	var (
-		esProcessor           elasticsearch.Processor
-		esProcessorAckTimeout dynamicconfig.DurationPropertyFn
-	)
-	if esProcessorConfig != nil {
-		esProcessor = elasticsearch.NewProcessor(esProcessorConfig, esClient, logger, metricsHandler)
-		esProcessor.Start()
-		esProcessorAckTimeout = esProcessorConfig.ESProcessorAckTimeout
-	}
 	s := elasticsearch.NewVisibilityStore(
 		esClient,
 		defaultIndexName,
+		esProcessorConfig,
 		searchAttributesProvider,
 		searchAttributesMapperProvider,
-		esProcessor,
-		esProcessorAckTimeout,
 		visibilityDisableOrderByClause,
 		visibilityEnableManualPagination,
-		metricsHandler)
+		metricsHandler,
+		logger)
 	return s
 }

--- a/common/persistence/visibility/factory.go
+++ b/common/persistence/visibility/factory.go
@@ -265,9 +265,9 @@ func newVisibilityStoreFromDataStoreConfig(
 			metricsHandler,
 		)
 	} else if dsConfig.Elasticsearch != nil {
-		visStore = newElasticsearchVisibilityStore(
-			dsConfig.Elasticsearch.GetVisibilityIndex(),
+		visStore = elasticsearch.NewVisibilityStore(
 			esClient,
+			dsConfig.Elasticsearch.GetVisibilityIndex(),
 			esProcessorConfig,
 			searchAttributesProvider,
 			searchAttributesMapperProvider,
@@ -285,28 +285,4 @@ func newVisibilityStoreFromDataStoreConfig(
 		)
 	}
 	return visStore, err
-}
-
-func newElasticsearchVisibilityStore(
-	defaultIndexName string,
-	esClient esclient.Client,
-	esProcessorConfig *elasticsearch.ProcessorConfig,
-	searchAttributesProvider searchattribute.Provider,
-	searchAttributesMapperProvider searchattribute.MapperProvider,
-	visibilityDisableOrderByClause dynamicconfig.BoolPropertyFnWithNamespaceFilter,
-	visibilityEnableManualPagination dynamicconfig.BoolPropertyFnWithNamespaceFilter,
-	metricsHandler metrics.Handler,
-	logger log.Logger,
-) store.VisibilityStore {
-	s := elasticsearch.NewVisibilityStore(
-		esClient,
-		defaultIndexName,
-		esProcessorConfig,
-		searchAttributesProvider,
-		searchAttributesMapperProvider,
-		visibilityDisableOrderByClause,
-		visibilityEnableManualPagination,
-		metricsHandler,
-		logger)
-	return s
 }

--- a/common/persistence/visibility/factory.go
+++ b/common/persistence/visibility/factory.go
@@ -25,8 +25,6 @@
 package visibility
 
 import (
-	"net/http"
-
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -57,7 +55,6 @@ func NewManager(
 	persistenceResolver resolver.ServiceResolver,
 	customVisibilityStoreFactory VisibilityStoreFactory,
 
-	esHttpClient *http.Client,
 	esProcessorConfig *elasticsearch.ProcessorConfig,
 	searchAttributesProvider searchattribute.Provider,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
@@ -78,7 +75,6 @@ func NewManager(
 		persistenceCfg.GetVisibilityStoreConfig(),
 		persistenceResolver,
 		customVisibilityStoreFactory,
-		esHttpClient,
 		esProcessorConfig,
 		searchAttributesProvider,
 		searchAttributesMapperProvider,
@@ -102,7 +98,6 @@ func NewManager(
 		persistenceCfg.GetSecondaryVisibilityStoreConfig(),
 		persistenceResolver,
 		customVisibilityStoreFactory,
-		esHttpClient,
 		esProcessorConfig,
 		searchAttributesProvider,
 		searchAttributesMapperProvider,
@@ -193,7 +188,6 @@ func newVisibilityManagerFromDataStoreConfig(
 	persistenceResolver resolver.ServiceResolver,
 	customVisibilityStoreFactory VisibilityStoreFactory,
 
-	esHttpClient *http.Client,
 	esProcessorConfig *elasticsearch.ProcessorConfig,
 	searchAttributesProvider searchattribute.Provider,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
@@ -211,7 +205,6 @@ func newVisibilityManagerFromDataStoreConfig(
 		dsConfig,
 		persistenceResolver,
 		customVisibilityStoreFactory,
-		esHttpClient,
 		esProcessorConfig,
 		searchAttributesProvider,
 		searchAttributesMapperProvider,
@@ -242,7 +235,6 @@ func newVisibilityStoreFromDataStoreConfig(
 	persistenceResolver resolver.ServiceResolver,
 	customVisibilityStoreFactory VisibilityStoreFactory,
 
-	esHttpClient *http.Client,
 	esProcessorConfig *elasticsearch.ProcessorConfig,
 	searchAttributesProvider searchattribute.Provider,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
@@ -266,8 +258,7 @@ func newVisibilityStoreFromDataStoreConfig(
 			metricsHandler,
 		)
 	} else if dsConfig.Elasticsearch != nil {
-		visStore = elasticsearch.NewVisibilityStore(
-			esHttpClient,
+		visStore, err = elasticsearch.NewVisibilityStore(
 			dsConfig.Elasticsearch,
 			esProcessorConfig,
 			searchAttributesProvider,

--- a/common/persistence/visibility/store/elasticsearch/client/config.go
+++ b/common/persistence/visibility/store/elasticsearch/client/config.go
@@ -27,6 +27,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -54,6 +55,8 @@ type (
 		EnableSniff                  bool                      `yaml:"enableSniff"`
 		EnableHealthcheck            bool                      `yaml:"enableHealthcheck"`
 		TLS                          *auth.TLS                 `yaml:"tls"`
+		// httpClient is the awsHttpClient to be used for creating esClient
+		httpClient *http.Client
 	}
 
 	// ESAWSRequestSigningConfig represents configuration for signing ES requests to AWS
@@ -97,6 +100,17 @@ func (cfg *Config) GetSecondaryVisibilityIndex() string {
 		return ""
 	}
 	return cfg.Indices[SecondaryVisibilityAppName]
+}
+
+func (cfg *Config) SetHttpClient(httpClient *http.Client) {
+	cfg.httpClient = httpClient
+}
+
+func (cfg *Config) GetHttpClient() *http.Client {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.httpClient
 }
 
 func (cfg *Config) Validate() error {

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -143,11 +143,11 @@ func NewVisibilityStore(
 ) (*visibilityStore, error) {
 	esHttpClient := cfg.GetHttpClient()
 	if esHttpClient == nil {
-		esHttpClient, err := client.NewAwsHttpClient(cfg.AWSRequestSigning)
+		var err error
+		esHttpClient, err = client.NewAwsHttpClient(cfg.AWSRequestSigning)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create AWS HTTP client for Elasticsearch: %w", err)
 		}
-		cfg.SetHttpClient(esHttpClient)
 	}
 	esClient, err := client.NewClient(cfg, esHttpClient, logger)
 	if err != nil {

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -52,7 +52,6 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/persistence/visibility/store"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
-	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/searchattribute"
 )
@@ -144,7 +143,7 @@ func NewVisibilityStore(
 	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *visibilityStore {
-	esClient, err := esclient.NewClient(cfg, esHttpClient, logger)
+	esClient, err := client.NewClient(cfg, esHttpClient, logger)
 	if esClient == nil || err != nil {
 		return nil
 	}

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -134,7 +134,7 @@ var (
 func NewVisibilityStore(
 	esClient client.Client,
 	index string,
-	esProcessorConfig *ProcessorConfig,
+	processorConfig *ProcessorConfig,
 	searchAttributesProvider searchattribute.Provider,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
 	disableOrderByClause dynamicconfig.BoolPropertyFnWithNamespaceFilter,
@@ -146,21 +146,21 @@ func NewVisibilityStore(
 		return nil
 	}
 	var (
-		esProcessor           Processor
-		esProcessorAckTimeout dynamicconfig.DurationPropertyFn
+		processor           Processor
+		processorAckTimeout dynamicconfig.DurationPropertyFn
 	)
-	if esProcessorConfig != nil {
-		esProcessor = NewProcessor(esProcessorConfig, esClient, logger, metricsHandler)
-		esProcessor.Start()
-		esProcessorAckTimeout = esProcessorConfig.ESProcessorAckTimeout
+	if processorConfig != nil {
+		processor = NewProcessor(processorConfig, esClient, logger, metricsHandler)
+		processor.Start()
+		processorAckTimeout = processorConfig.ESProcessorAckTimeout
 	}
 	return &visibilityStore{
 		esClient:                       esClient,
 		index:                          index,
 		searchAttributesProvider:       searchAttributesProvider,
 		searchAttributesMapperProvider: searchAttributesMapperProvider,
-		processor:                      esProcessor,
-		processorAckTimeout:            esProcessorAckTimeout,
+		processor:                      processor,
+		processorAckTimeout:            processorAckTimeout,
 		disableOrderByClause:           disableOrderByClause,
 		enableManualPagination:         enableManualPagination,
 		metricsHandler:                 metricsHandler.WithTags(metrics.OperationTag(metrics.ElasticsearchVisibility)),
@@ -168,7 +168,6 @@ func NewVisibilityStore(
 }
 
 func (s *visibilityStore) Close() {
-	// TODO (alex): visibilityStore shouldn't Stop processor. Processor should be stopped where it is created.
 	if s.processor != nil {
 		s.processor.Stop()
 	}

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -142,15 +142,15 @@ func (s *ESVisibilitySuite) SetupTest() {
 	s.mockESClient = client.NewMockClient(s.controller)
 	s.mockSearchAttributesMapperProvider = searchattribute.NewMockMapperProvider(s.controller)
 	s.visibilityStore = &visibilityStore{
-		s.mockESClient,
-		testIndex,
-		searchattribute.NewTestProvider(),
-		searchattribute.NewTestMapperProvider(nil),
-		s.mockProcessor,
-		esProcessorAckTimeout,
-		visibilityDisableOrderByClause,
-		visibilityEnableManualPagination,
-		s.mockMetricsHandler,
+		esClient:                       s.mockESClient,
+		index:                          testIndex,
+		searchAttributesProvider:       searchattribute.NewTestProvider(),
+		searchAttributesMapperProvider: searchattribute.NewTestMapperProvider(nil),
+		processor:                      s.mockProcessor,
+		processorAckTimeout:            esProcessorAckTimeout,
+		disableOrderByClause:           visibilityDisableOrderByClause,
+		enableManualPagination:         visibilityEnableManualPagination,
+		metricsHandler:                 s.mockMetricsHandler,
 	}
 }
 
@@ -1784,15 +1784,15 @@ func (s *ESVisibilitySuite) TestProcessPageToken() {
 	for _, tc := range testCases {
 		s.T().Run(tc.name, func(t *testing.T) {
 			visibilityStore := &visibilityStore{
-				s.mockESClient,
-				testIndex,
-				searchattribute.NewTestProvider(),
-				searchattribute.NewTestMapperProvider(nil),
-				s.mockProcessor,
-				dynamicconfig.GetDurationPropertyFn(1 * time.Minute * debug.TimeoutMultiplier),
-				dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
-				dynamicconfig.GetBoolPropertyFnFilteredByNamespace(tc.manualPagination),
-				s.mockMetricsHandler,
+				esClient:                       s.mockESClient,
+				index:                          testIndex,
+				searchAttributesProvider:       searchattribute.NewTestProvider(),
+				searchAttributesMapperProvider: searchattribute.NewTestMapperProvider(nil),
+				processor:                      s.mockProcessor,
+				processorAckTimeout:            dynamicconfig.GetDurationPropertyFn(1 * time.Minute * debug.TimeoutMultiplier),
+				disableOrderByClause:           dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+				enableManualPagination:         dynamicconfig.GetBoolPropertyFnFilteredByNamespace(tc.manualPagination),
+				metricsHandler:                 s.mockMetricsHandler,
 			}
 			params := &client.SearchParameters{
 				Index:  testIndex,

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -141,7 +141,7 @@ func (s *ESVisibilitySuite) SetupTest() {
 	s.mockProcessor = NewMockProcessor(s.controller)
 	s.mockESClient = client.NewMockClient(s.controller)
 	s.mockSearchAttributesMapperProvider = searchattribute.NewMockMapperProvider(s.controller)
-	s.visibilityStore = NewVisibilityStore(
+	s.visibilityStore = &visibilityStore{
 		s.mockESClient,
 		testIndex,
 		searchattribute.NewTestProvider(),
@@ -151,7 +151,7 @@ func (s *ESVisibilitySuite) SetupTest() {
 		visibilityDisableOrderByClause,
 		visibilityEnableManualPagination,
 		s.mockMetricsHandler,
-	)
+	}
 }
 
 func (s *ESVisibilitySuite) TearDownTest() {
@@ -1783,17 +1783,17 @@ func (s *ESVisibilitySuite) TestProcessPageToken() {
 
 	for _, tc := range testCases {
 		s.T().Run(tc.name, func(t *testing.T) {
-			visibilityStore := NewVisibilityStore(
+			visibilityStore := &visibilityStore{
 				s.mockESClient,
 				testIndex,
 				searchattribute.NewTestProvider(),
 				searchattribute.NewTestMapperProvider(nil),
 				s.mockProcessor,
-				dynamicconfig.GetDurationPropertyFn(1*time.Minute*debug.TimeoutMultiplier),
+				dynamicconfig.GetDurationPropertyFn(1 * time.Minute * debug.TimeoutMultiplier),
 				dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 				dynamicconfig.GetBoolPropertyFnFilteredByNamespace(tc.manualPagination),
 				s.mockMetricsHandler,
-			)
+			}
 			params := &client.SearchParameters{
 				Index:  testIndex,
 				Query:  baseQuery,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -27,6 +27,7 @@ package frontend
 import (
 	"fmt"
 	"net"
+	"net/http"
 
 	"github.com/gorilla/mux"
 	"go.uber.org/fx"
@@ -530,7 +531,7 @@ func VisibilityManagerProvider(
 	customVisibilityStoreFactory visibility.VisibilityStoreFactory,
 	metricsHandler metrics.Handler,
 	serviceConfig *Config,
-	esClient esclient.Client,
+	esHttpClient *http.Client,
 	persistenceServiceResolver resolver.ServiceResolver,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
 	saProvider searchattribute.Provider,
@@ -539,7 +540,7 @@ func VisibilityManagerProvider(
 		*persistenceConfig,
 		persistenceServiceResolver,
 		customVisibilityStoreFactory,
-		esClient,
+		esHttpClient,
 		nil, // frontend visibility never write
 		saProvider,
 		searchAttributesMapperProvider,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -27,7 +27,6 @@ package frontend
 import (
 	"fmt"
 	"net"
-	"net/http"
 
 	"github.com/gorilla/mux"
 	"go.uber.org/fx"
@@ -531,7 +530,6 @@ func VisibilityManagerProvider(
 	customVisibilityStoreFactory visibility.VisibilityStoreFactory,
 	metricsHandler metrics.Handler,
 	serviceConfig *Config,
-	esHttpClient *http.Client,
 	persistenceServiceResolver resolver.ServiceResolver,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
 	saProvider searchattribute.Provider,
@@ -540,7 +538,6 @@ func VisibilityManagerProvider(
 		*persistenceConfig,
 		persistenceServiceResolver,
 		customVisibilityStoreFactory,
-		esHttpClient,
 		nil, // frontend visibility never write
 		saProvider,
 		searchAttributesMapperProvider,

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -26,6 +26,7 @@ package history
 
 import (
 	"net"
+	"net/http"
 
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
@@ -273,7 +274,7 @@ func VisibilityManagerProvider(
 	customVisibilityStoreFactory visibility.VisibilityStoreFactory,
 	esProcessorConfig *elasticsearch.ProcessorConfig,
 	serviceConfig *configs.Config,
-	esClient esclient.Client,
+	esHttpClient *http.Client,
 	persistenceServiceResolver resolver.ServiceResolver,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
 	saProvider searchattribute.Provider,
@@ -282,7 +283,7 @@ func VisibilityManagerProvider(
 		*persistenceConfig,
 		persistenceServiceResolver,
 		customVisibilityStoreFactory,
-		esClient,
+		esHttpClient,
 		esProcessorConfig,
 		saProvider,
 		searchAttributesMapperProvider,

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -26,7 +26,6 @@ package history
 
 import (
 	"net"
-	"net/http"
 
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
@@ -274,7 +273,6 @@ func VisibilityManagerProvider(
 	customVisibilityStoreFactory visibility.VisibilityStoreFactory,
 	esProcessorConfig *elasticsearch.ProcessorConfig,
 	serviceConfig *configs.Config,
-	esHttpClient *http.Client,
 	persistenceServiceResolver resolver.ServiceResolver,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
 	saProvider searchattribute.Provider,
@@ -283,7 +281,6 @@ func VisibilityManagerProvider(
 		*persistenceConfig,
 		persistenceServiceResolver,
 		customVisibilityStoreFactory,
-		esHttpClient,
 		esProcessorConfig,
 		saProvider,
 		searchAttributesMapperProvider,

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -25,8 +25,6 @@
 package matching
 
 import (
-	"net/http"
-
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/common"
@@ -155,7 +153,6 @@ func VisibilityManagerProvider(
 	customVisibilityStoreFactory visibility.VisibilityStoreFactory,
 	metricsHandler metrics.Handler,
 	serviceConfig *Config,
-	esHttpClient *http.Client,
 	persistenceServiceResolver resolver.ServiceResolver,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
 	saProvider searchattribute.Provider,
@@ -164,7 +161,6 @@ func VisibilityManagerProvider(
 		*persistenceConfig,
 		persistenceServiceResolver,
 		customVisibilityStoreFactory,
-		esHttpClient,
 		nil, // matching visibility never writes
 		saProvider,
 		searchAttributesMapperProvider,

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -25,6 +25,8 @@
 package matching
 
 import (
+	"net/http"
+
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/common"
@@ -38,7 +40,6 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/visibility"
 	"go.temporal.io/server/common/persistence/visibility/manager"
-	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/resource"
@@ -154,7 +155,7 @@ func VisibilityManagerProvider(
 	customVisibilityStoreFactory visibility.VisibilityStoreFactory,
 	metricsHandler metrics.Handler,
 	serviceConfig *Config,
-	esClient esclient.Client,
+	esHttpClient *http.Client,
 	persistenceServiceResolver resolver.ServiceResolver,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
 	saProvider searchattribute.Provider,
@@ -163,7 +164,7 @@ func VisibilityManagerProvider(
 		*persistenceConfig,
 		persistenceServiceResolver,
 		customVisibilityStoreFactory,
-		esClient,
+		esHttpClient,
 		nil, // matching visibility never writes
 		saProvider,
 		searchAttributesMapperProvider,

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -26,6 +26,7 @@ package worker
 
 import (
 	"context"
+	"net/http"
 
 	"go.uber.org/fx"
 
@@ -41,7 +42,6 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/visibility"
 	"go.temporal.io/server/common/persistence/visibility/manager"
-	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/resource"
@@ -155,7 +155,7 @@ func VisibilityManagerProvider(
 	persistenceConfig *config.Persistence,
 	customVisibilityStoreFactory visibility.VisibilityStoreFactory,
 	serviceConfig *Config,
-	esClient esclient.Client,
+	esHttpClient *http.Client,
 	persistenceServiceResolver resolver.ServiceResolver,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
 	saProvider searchattribute.Provider,
@@ -164,7 +164,7 @@ func VisibilityManagerProvider(
 		*persistenceConfig,
 		persistenceServiceResolver,
 		customVisibilityStoreFactory,
-		esClient,
+		esHttpClient,
 		nil, // worker visibility never write
 		saProvider,
 		searchAttributesMapperProvider,

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -26,7 +26,6 @@ package worker
 
 import (
 	"context"
-	"net/http"
 
 	"go.uber.org/fx"
 
@@ -155,7 +154,6 @@ func VisibilityManagerProvider(
 	persistenceConfig *config.Persistence,
 	customVisibilityStoreFactory visibility.VisibilityStoreFactory,
 	serviceConfig *Config,
-	esHttpClient *http.Client,
 	persistenceServiceResolver resolver.ServiceResolver,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
 	saProvider searchattribute.Provider,
@@ -164,7 +162,6 @@ func VisibilityManagerProvider(
 		*persistenceConfig,
 		persistenceServiceResolver,
 		customVisibilityStoreFactory,
-		esHttpClient,
 		nil, // worker visibility never write
 		saProvider,
 		searchAttributesMapperProvider,

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -259,6 +259,19 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 	if esConfig != nil {
 		esHttpClient := so.elasticsearchHttpClient
 		esConfig.SetHttpClient(esHttpClient)
+		if esHttpClient == nil {
+			var err error
+			esHttpClient, err = esclient.NewAwsHttpClient(esConfig.AWSRequestSigning)
+			if err != nil {
+				return serverOptionsProvider{}, fmt.Errorf("unable to create AWS HTTP client for Elasticsearch: %w", err)
+			}
+		}
+
+		esClient, err = esclient.NewClient(esConfig, esHttpClient, logger)
+		if err != nil {
+			return serverOptionsProvider{}, fmt.Errorf("unable to create Elasticsearch client (URL = %v, username = %q): %w",
+				esConfig.URL.Redacted(), esConfig.Username, err)
+		}
 	}
 
 	// check that when static hosts are defined, they are defined for all required hosts

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -396,7 +396,6 @@ func (params ServiceProviderParamsCommon) GetCommonServiceOptions(serviceName pr
 		fx.Supply(
 			serviceName,
 			params.EsConfig,
-			params.EsHttpClient,
 			params.PersistenceConfig,
 			params.ClusterMetadata,
 			params.Cfg,
@@ -443,6 +442,9 @@ func (params ServiceProviderParamsCommon) GetCommonServiceOptions(serviceName pr
 			},
 			func() esclient.Client {
 				return params.EsClient
+			},
+			func() *http.Client {
+				return params.EsHttpClient
 			},
 			func() resource.NamespaceLogger {
 				return params.NamespaceLogger

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -30,6 +30,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"strconv"
 	"sync"
 	"testing"
@@ -126,6 +127,7 @@ type (
 		historyConfig                    *HistoryConfig
 		esConfig                         *esclient.Config
 		esClient                         esclient.Client
+		esHttpClient                     *http.Client
 		workerConfig                     *WorkerConfig
 		mockAdminClient                  map[string]adminservice.AdminServiceClient
 		namespaceReplicationTaskExecutor namespace.ReplicationTaskExecutor
@@ -174,6 +176,7 @@ type (
 		HistoryConfig                    *HistoryConfig
 		ESConfig                         *esclient.Config
 		ESClient                         esclient.Client
+		ESHttpClient                     *http.Client
 		WorkerConfig                     *WorkerConfig
 		MockAdminClient                  map[string]adminservice.AdminServiceClient
 		NamespaceReplicationTaskExecutor namespace.ReplicationTaskExecutor
@@ -211,6 +214,7 @@ func newTemporal(t *testing.T, params *TemporalParams) *temporalImpl {
 		clusterNo:                        params.ClusterNo,
 		esConfig:                         params.ESConfig,
 		esClient:                         params.ESClient,
+		esHttpClient:                     params.ESHttpClient,
 		archiverMetadata:                 params.ArchiverMetadata,
 		archiverProvider:                 params.ArchiverProvider,
 		historyConfig:                    params.HistoryConfig,
@@ -459,6 +463,7 @@ func (c *temporalImpl) startFrontend(
 		fx.Provide(resource.DefaultSnTaggedLoggerProvider),
 		fx.Provide(func() *esclient.Config { return c.esConfig }),
 		fx.Provide(func() esclient.Client { return c.esClient }),
+		fx.Provide(func() *http.Client { return c.esHttpClient }),
 		fx.Provide(c.GetTLSConfigProvider),
 		fx.Provide(c.GetTaskCategoryRegistry),
 		fx.Supply(c.spanExporters),
@@ -553,6 +558,7 @@ func (c *temporalImpl) startHistory(
 			fx.Provide(resource.DefaultSnTaggedLoggerProvider),
 			fx.Provide(func() *esclient.Config { return c.esConfig }),
 			fx.Provide(func() esclient.Client { return c.esClient }),
+			fx.Provide(func() *http.Client { return c.esHttpClient }),
 			fx.Provide(workflow.NewTaskGeneratorProvider),
 			fx.Provide(c.GetTLSConfigProvider),
 			fx.Provide(c.GetTaskCategoryRegistry),
@@ -646,6 +652,7 @@ func (c *temporalImpl) startMatching(
 		fx.Provide(func() dynamicconfig.Client { return c.dcClient }),
 		fx.Provide(func() *esclient.Config { return c.esConfig }),
 		fx.Provide(func() esclient.Client { return c.esClient }),
+		fx.Provide(func() *http.Client { return c.esHttpClient }),
 		fx.Provide(c.GetTLSConfigProvider),
 		fx.Provide(func() log.Logger { return c.logger }),
 		fx.Provide(resource.DefaultSnTaggedLoggerProvider),
@@ -743,6 +750,7 @@ func (c *temporalImpl) startWorker(
 		fx.Provide(func() log.Logger { return c.logger }),
 		fx.Provide(resource.DefaultSnTaggedLoggerProvider),
 		fx.Provide(func() esclient.Client { return c.esClient }),
+		fx.Provide(func() *http.Client { return c.esHttpClient }),
 		fx.Provide(func() *esclient.Config { return c.esConfig }),
 		fx.Provide(c.GetTLSConfigProvider),
 		fx.Provide(c.GetTaskCategoryRegistry),

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -30,7 +30,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"net/http"
 	"strconv"
 	"sync"
 	"testing"
@@ -127,7 +126,6 @@ type (
 		historyConfig                    *HistoryConfig
 		esConfig                         *esclient.Config
 		esClient                         esclient.Client
-		esHttpClient                     *http.Client
 		workerConfig                     *WorkerConfig
 		mockAdminClient                  map[string]adminservice.AdminServiceClient
 		namespaceReplicationTaskExecutor namespace.ReplicationTaskExecutor
@@ -176,7 +174,6 @@ type (
 		HistoryConfig                    *HistoryConfig
 		ESConfig                         *esclient.Config
 		ESClient                         esclient.Client
-		ESHttpClient                     *http.Client
 		WorkerConfig                     *WorkerConfig
 		MockAdminClient                  map[string]adminservice.AdminServiceClient
 		NamespaceReplicationTaskExecutor namespace.ReplicationTaskExecutor
@@ -214,7 +211,6 @@ func newTemporal(t *testing.T, params *TemporalParams) *temporalImpl {
 		clusterNo:                        params.ClusterNo,
 		esConfig:                         params.ESConfig,
 		esClient:                         params.ESClient,
-		esHttpClient:                     params.ESHttpClient,
 		archiverMetadata:                 params.ArchiverMetadata,
 		archiverProvider:                 params.ArchiverProvider,
 		historyConfig:                    params.HistoryConfig,
@@ -463,7 +459,6 @@ func (c *temporalImpl) startFrontend(
 		fx.Provide(resource.DefaultSnTaggedLoggerProvider),
 		fx.Provide(func() *esclient.Config { return c.esConfig }),
 		fx.Provide(func() esclient.Client { return c.esClient }),
-		fx.Provide(func() *http.Client { return c.esHttpClient }),
 		fx.Provide(c.GetTLSConfigProvider),
 		fx.Provide(c.GetTaskCategoryRegistry),
 		fx.Supply(c.spanExporters),
@@ -558,7 +553,6 @@ func (c *temporalImpl) startHistory(
 			fx.Provide(resource.DefaultSnTaggedLoggerProvider),
 			fx.Provide(func() *esclient.Config { return c.esConfig }),
 			fx.Provide(func() esclient.Client { return c.esClient }),
-			fx.Provide(func() *http.Client { return c.esHttpClient }),
 			fx.Provide(workflow.NewTaskGeneratorProvider),
 			fx.Provide(c.GetTLSConfigProvider),
 			fx.Provide(c.GetTaskCategoryRegistry),
@@ -652,7 +646,6 @@ func (c *temporalImpl) startMatching(
 		fx.Provide(func() dynamicconfig.Client { return c.dcClient }),
 		fx.Provide(func() *esclient.Config { return c.esConfig }),
 		fx.Provide(func() esclient.Client { return c.esClient }),
-		fx.Provide(func() *http.Client { return c.esHttpClient }),
 		fx.Provide(c.GetTLSConfigProvider),
 		fx.Provide(func() log.Logger { return c.logger }),
 		fx.Provide(resource.DefaultSnTaggedLoggerProvider),
@@ -750,7 +743,6 @@ func (c *temporalImpl) startWorker(
 		fx.Provide(func() log.Logger { return c.logger }),
 		fx.Provide(resource.DefaultSnTaggedLoggerProvider),
 		fx.Provide(func() esclient.Client { return c.esClient }),
-		fx.Provide(func() *http.Client { return c.esHttpClient }),
 		fx.Provide(func() *esclient.Config { return c.esConfig }),
 		fx.Provide(c.GetTLSConfigProvider),
 		fx.Provide(c.GetTaskCategoryRegistry),


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- moved ES processor initialization to visiblity store constructor
- create ES client in ES visibility store constructor
    - add private field `httpClient` in elasticsearch config and use config to create `esClient` directly in visibility store 
    - this will enable creating separate esClients for primary/secondary visibility store

## Why?
<!-- Tell your future self why have you made these changes -->
- not optimal to initialize the ES processor/client outside of the Elasticsearch visibility store

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- verified that ES processor is being initialized within ES visibility store locally

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
