### PR TITLE
Properly dispatch requests for Nexus Worker Endpoints

### DIFF
--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -111,8 +111,8 @@ type (
 		InitialFailoverVersion int64 `yaml:"initialFailoverVersion"`
 		// RPCAddress indicate the remote service address(Host:Port). Host can be DNS name.
 		RPCAddress string `yaml:"rpcAddress"`
-		// HTTPAddress indicates the address of the [go.temporal.io/server/service/frontend.HTTPAPIServer]. Optional.
-		// This should include the scheme, whether it be HTTP or HTTPS, e.g. "http://localhost:8088".
+		// HTTPAddress indicates the address of the [go.temporal.io/server/service/frontend.HTTPAPIServer].
+		// E.g. "localhost:7243".
 		HTTPAddress string `yaml:"httpAddress"`
 		// ClusterID allows to explicitly set the ID of the cluster. Optional.
 		ClusterID  string            `yaml:"-"`

--- a/components/nexusoperations/fx.go
+++ b/components/nexusoperations/fx.go
@@ -31,6 +31,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.uber.org/fx"
 
+	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -104,6 +105,8 @@ func ClientProviderFactory(
 	namespaceRegistry namespace.Registry,
 	endpointRegistry *commonnexus.EndpointRegistry,
 	httpTransportProvider NexusTransportProvider,
+	clusterMetadata cluster.Metadata,
+	httpClientCache *cluster.FrontendHTTPClientCache,
 ) ClientProvider {
 	// TODO(bergundy): This should use an LRU or other form of cache that supports eviction.
 	m := collection.NewFallibleOnceMap(func(key clientProviderCacheKey) (*http.Client, error) {
@@ -127,12 +130,12 @@ func ClientProviderFactory(
 				return nil, err
 			}
 		case *nexuspb.EndpointTarget_Worker_:
-			// TODO(bergundy): properly get frontend client
-			url = "http://localhost:7243/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Path(endpoint.Id)
-			httpClient, err = m.Get(clientProviderCacheKey{key, url})
+			cl, err := httpClientCache.Get(clusterMetadata.GetCurrentClusterName())
 			if err != nil {
 				return nil, err
 			}
+			url = cl.BaseURL() + "/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Path(endpoint.Id)
+			httpClient = &cl.Client
 		default:
 			return nil, serviceerror.NewInternal("got unexpected endpoint target")
 		}

--- a/config/development-sqlite-file.yaml
+++ b/config/development-sqlite-file.yaml
@@ -62,8 +62,8 @@ global:
     port: 7936
   metrics:
     prometheus:
-#      # specify framework to use new approach for initializing metrics and/or use opentelemetry
-#      framework: "opentelemetry"
+      #      # specify framework to use new approach for initializing metrics and/or use opentelemetry
+      #      framework: "opentelemetry"
       framework: "tally"
       timerType: "histogram"
       listenAddress: "127.0.0.1:8000"
@@ -105,6 +105,7 @@ clusterMetadata:
       initialFailoverVersion: 1
       rpcName: "frontend"
       rpcAddress: "localhost:7233"
+      httpAddres: "localhost:7243"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development-sqlite.yaml
+++ b/config/development-sqlite.yaml
@@ -101,6 +101,7 @@ clusterMetadata:
       initialFailoverVersion: 1
       rpcName: "frontend"
       rpcAddress: "localhost:7233"
+      httpAddress: "localhost:7243"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -263,13 +263,14 @@ global:
         claimMapper: {{ default .Env.TEMPORAL_AUTH_CLAIM_MAPPER "" }}
 
 {{- $temporalGrpcPort := default .Env.FRONTEND_GRPC_PORT "7233" }}
+{{- $temporalHTTPPort := default .Env.FRONTEND_HTTP_PORT "7243" }}
 services:
     frontend:
         rpc:
             grpcPort: {{ $temporalGrpcPort }}
             membershipPort: {{ default .Env.FRONTEND_MEMBERSHIP_PORT "6933" }}
             bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
-            httpPort: {{ default .Env.FRONTEND_HTTP_PORT "7243" }}
+            httpPort: {{ $temporalHTTPPort }}
 
     {{- if .Env.USE_INTERNAL_FRONTEND }}
     internal-frontend:
@@ -308,6 +309,7 @@ clusterMetadata:
             initialFailoverVersion: 1
             rpcName: "frontend"
             rpcAddress: {{ (print "127.0.0.1:" $temporalGrpcPort) }}
+            httpAddress: {{ (print "127.0.0.1:" $temporalHTTPPort) }}
 
 dcRedirectionPolicy:
     policy: "noop"

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -452,13 +452,13 @@ func (h *nexusHandler) nexusClientForActiveCluster(oc *operationContext, service
 	}
 
 	baseURL, err := url.JoinPath(
-		httpClient.Address,
+		httpClient.BaseURL(),
 		commonnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Path(commonnexus.NamespaceAndTaskQueue{
 			Namespace: oc.namespaceName,
 			TaskQueue: oc.taskQueue,
 		}))
 	if err != nil {
-		oc.logger.Error(fmt.Sprintf("failed to forward Nexus request. error constructing ServiceBaseURL. address=%s namespace=%s task_queue=%s", httpClient.Address, oc.namespaceName, oc.taskQueue), tag.Error(err))
+		oc.logger.Error(fmt.Sprintf("failed to forward Nexus request. error constructing ServiceBaseURL. baseURL=%s namespace=%s task_queue=%s", httpClient.BaseURL(), oc.namespaceName, oc.taskQueue), tag.Error(err))
 		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.NexusOutcomeTag("request_forwarding_failed"))
 		return nil, nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "request forwarding failed")
 	}

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -122,7 +122,7 @@ func (s *xdcBaseSuite) setupSuite(clusterNames []string, opts ...tests.Option) {
 			Enabled:                true,
 			InitialFailoverVersion: int64(i + 1),
 			RPCAddress:             fmt.Sprintf("127.0.0.1:%d134", 7+i),
-			HTTPAddress:            fmt.Sprintf("http://127.0.0.1:%d144", 7+i),
+			HTTPAddress:            fmt.Sprintf("127.0.0.1:%d144", 7+i),
 		}
 		clusterConfigs[i].ServiceFxOptions = params.ServiceOptions
 		clusterConfigs[i].EnableMetricsCapture = true


### PR DESCRIPTION
Also changed the semantics of cluster info's HTTPAddress to just be the address, and not include the scheme.
We now use the TLS configuration to derive the URL scheme.