### PR TITLE
Revamp Update package's unit tests (1/2)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,6 +117,10 @@ issues:
       linters:
         - revive
     - path: _test\.go|tests/.+\.go
+      text: "dot-imports"  # false positives when using subtests
+      linters:
+        - revive
+    - path: _test\.go|tests/.+\.go
       linters:
         - goerr113  # like err = errors.New("test error")
     - path: ^tools\/.+\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,7 +117,7 @@ issues:
       linters:
         - revive
     - path: _test\.go|tests/.+\.go
-      text: "dot-imports"  # false positives when using subtests
+      text: "dot-imports"  # helpful in tests
       linters:
         - revive
     - path: _test\.go|tests/.+\.go

--- a/common/testing/testvars/test_vars.go
+++ b/common/testing/testvars/test_vars.go
@@ -35,10 +35,11 @@ import (
 	namespacepb "go.temporal.io/api/namespace/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	updatepb "go.temporal.io/api/update/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives/timestamp"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type (
@@ -48,9 +49,16 @@ type (
 		an       Any
 		kv       sync.Map
 	}
+	testNamer interface {
+		Name() string
+	}
 )
 
-func New(testName string) *TestVars {
+func New(testNamer testNamer) *TestVars {
+	return newFromName(testNamer.Name())
+}
+
+func newFromName(testName string) *TestVars {
 	th := hash(testName)
 	return &TestVars{
 		testName: testName,
@@ -88,7 +96,7 @@ func (tv *TestVars) set(typ string, key []string, val any) {
 }
 
 func (tv *TestVars) clone() *TestVars {
-	tv2 := New(tv.testName)
+	tv2 := newFromName(tv.testName)
 	tv.kv.Range(func(key, value any) bool {
 		tv2.kv.Store(key, value)
 		return true

--- a/service/history/api/respondworkflowtaskcompleted/api_test.go
+++ b/service/history/api/respondworkflowtaskcompleted/api_test.go
@@ -41,6 +41,9 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"golang.org/x/exp/maps"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
@@ -52,8 +55,6 @@ import (
 	"go.temporal.io/server/internal/effect"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
 	"go.temporal.io/server/service/history/workflow/update"
-	"golang.org/x/exp/maps"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
@@ -277,7 +278,7 @@ func (s *WorkflowTaskCompletedHandlerSuite) TestUpdateWorkflow() {
 	}
 
 	s.Run("Accept Complete", func() {
-		tv := testvars.New(s.T().Name())
+		tv := testvars.New(s.T())
 		mockNamespaceCache.EXPECT().GetNamespaceByID(tv.NamespaceID()).Return(tv.Namespace(), nil).AnyTimes()
 		_, serializedTaskToken := createStartedWorkflow(tv)
 		writtenHistoryCh := createWrittenHistoryCh(1)
@@ -308,7 +309,7 @@ func (s *WorkflowTaskCompletedHandlerSuite) TestUpdateWorkflow() {
 	})
 
 	s.Run("Reject", func() {
-		tv := testvars.New(s.T().Name())
+		tv := testvars.New(s.T())
 		mockNamespaceCache.EXPECT().GetNamespaceByID(tv.NamespaceID()).Return(tv.Namespace(), nil).AnyTimes()
 		_, serializedTaskToken := createStartedWorkflow(tv)
 		writtenHistoryCh := createWrittenHistoryCh(1)
@@ -336,7 +337,7 @@ func (s *WorkflowTaskCompletedHandlerSuite) TestUpdateWorkflow() {
 	})
 
 	s.Run("Write Failed", func() {
-		tv := testvars.New(s.T().Name())
+		tv := testvars.New(s.T())
 		mockNamespaceCache.EXPECT().GetNamespaceByID(tv.NamespaceID()).Return(tv.Namespace(), nil).AnyTimes()
 		_, serializedTaskToken := createStartedWorkflow(tv)
 
@@ -364,7 +365,7 @@ func (s *WorkflowTaskCompletedHandlerSuite) TestUpdateWorkflow() {
 	})
 
 	s.Run("GetHistory Failed", func() {
-		tv := testvars.New(s.T().Name())
+		tv := testvars.New(s.T())
 		mockNamespaceCache.EXPECT().GetNamespaceByID(tv.NamespaceID()).Return(tv.Namespace(), nil).AnyTimes()
 		_, serializedTaskToken := createStartedWorkflow(tv)
 		writtenHistoryCh := createWrittenHistoryCh(1)

--- a/service/history/workflow/update/export_test.go
+++ b/service/history/workflow/update/export_test.go
@@ -41,4 +41,6 @@ func (u *Update) NeedToSend(includeAlreadySent bool) bool { return u.needToSend(
 
 func (u *Update) IsSent() bool { return u.isSent() }
 
+func (u *Update) ID() string { return u.id }
+
 func CompletedCount(r Registry) int { return r.(*registry).completedCount }

--- a/service/history/workflow/update/export_test.go
+++ b/service/history/workflow/update/export_test.go
@@ -40,3 +40,5 @@ func ObserveCompletion(b *bool) updateOpt {
 func (u *Update) NeedToSend(includeAlreadySent bool) bool { return u.needToSend(includeAlreadySent) }
 
 func (u *Update) IsSent() bool { return u.isSent() }
+
+func CompletedCount(r Registry) int { return r.(*registry).completedCount }

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -101,14 +101,6 @@ type (
 		FailoverVersion() int64
 	}
 
-	// Store represents the update package's requirements for reading updates from the store.
-	Store interface {
-		VisitUpdates(visitor func(updID string, updInfo *persistencespb.UpdateInfo))
-		GetUpdateOutcome(ctx context.Context, updateID string) (*updatepb.Outcome, error)
-		GetCurrentVersion() int64
-		IsWorkflowExecutionRunning() bool
-	}
-
 	registry struct {
 		updates         map[string]*Update
 		store           Store

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -105,7 +105,7 @@ type (
 
 	registry struct {
 		updates         map[string]*Update
-		store           Store
+		store           UpdateStore
 		instrumentation instrumentation
 		maxInFlight     func() int
 		maxTotal        func() int
@@ -156,7 +156,7 @@ func WithTracerProvider(t trace.TracerProvider) Option {
 }
 
 func NewRegistry(
-	store Store,
+	store UpdateStore,
 	opts ...Option,
 ) Registry {
 	r := &registry{

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -234,16 +234,19 @@ func (r *registry) TryResurrect(ctx context.Context, acptOrRejMsg *protocolpb.Me
 	if err != nil {
 		return nil, invalidArgf("unable to unmarshal request: %v", err)
 	}
+
 	err = utf8validator.Validate(body, utf8validator.SourceRPCRequest)
 	if err != nil {
 		return nil, invalidArgf("unable to validate utf-8 request: %v", err)
 	}
+
 	var reqMsg *updatepb.Request
 	switch updMsg := body.(type) {
 	case *updatepb.Acceptance:
 		reqMsg = updMsg.GetAcceptedRequest()
 	case *updatepb.Rejection:
 		reqMsg = updMsg.GetRejectedRequest()
+	default:
 		// Ignore all other message types.
 	}
 	if reqMsg == nil {
@@ -251,7 +254,7 @@ func (r *registry) TryResurrect(ctx context.Context, acptOrRejMsg *protocolpb.Me
 	}
 	reqAny, err := anypb.New(reqMsg)
 	if err != nil {
-		return nil, invalidArgf("unable to unmarshal request body: %v", err)
+		return nil, invalidArgf("unable to marshal request: %v", err)
 	}
 
 	updateID := acptOrRejMsg.ProtocolInstanceId
@@ -262,6 +265,7 @@ func (r *registry) TryResurrect(ctx context.Context, acptOrRejMsg *protocolpb.Me
 		withInstrumentation(&r.instrumentation),
 	)
 	r.updates[updateID] = upd
+
 	return upd, nil
 }
 

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -46,8 +46,6 @@ import (
 	"go.temporal.io/server/internal/effect"
 )
 
-var _ Registry = (*registry)(nil)
-
 type (
 	// Registry maintains a set of updates that have been admitted to run
 	// against a workflow execution.
@@ -115,6 +113,8 @@ type (
 
 	Option func(*registry)
 )
+
+var _ Registry = (*registry)(nil)
 
 // WithInFlightLimit provides an optional limit to the number of incomplete
 // updates that a Registry instance will allow.

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -46,6 +46,8 @@ import (
 	"go.temporal.io/server/internal/effect"
 )
 
+var _ Registry = (*registry)(nil)
+
 type (
 	// Registry maintains a set of updates that have been admitted to run
 	// against a workflow execution.
@@ -152,8 +154,6 @@ func WithTracerProvider(t trace.TracerProvider) Option {
 		r.instrumentation.tracer = t.Tracer(libraryName)
 	}
 }
-
-var _ Registry = (*registry)(nil)
 
 func NewRegistry(
 	store Store,

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -322,6 +322,7 @@ func (r *registry) Send(
 	includeAlreadySent bool,
 	workflowTaskStartedEventID int64,
 ) []*protocolpb.Message {
+	var outgoingMessages []*protocolpb.Message
 
 	// TODO (alex-update): currently sequencing_id is simply pointing to the
 	//  event before WorkflowTaskStartedEvent. SDKs are supposed to respect this
@@ -332,8 +333,7 @@ func (r *registry) Send(
 	//  and events reordering in some SDKs.
 	sequencingEventID := &protocolpb.Message_EventId{EventId: workflowTaskStartedEventID - 1}
 
-	var outgoingMessages []*protocolpb.Message
-
+	// sort updates by the time they were admitted
 	var sortedUpdates []*Update
 	for _, upd := range r.updates {
 		sortedUpdates = append(sortedUpdates, upd)
@@ -346,6 +346,7 @@ func (r *registry) Send(
 			outgoingMessages = append(outgoingMessages, outgoingMessage)
 		}
 	}
+
 	return outgoingMessages
 }
 

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -156,7 +156,7 @@ func TestFindOrCreate(t *testing.T) {
 		t.Run("deny new update since it is exceeding the limit", func(t *testing.T) {
 			_, _, err = reg.FindOrCreate(context.Background(), tv.UpdateID("2"))
 			var resExh *serviceerror.ResourceExhausted
-			require.ErrorAs(t, err, &resExh, "creating update #2 should have been denied")
+			require.ErrorAs(t, err, &resExh, "creating update #2 should be denied")
 			require.Equal(t, 1, reg.Len())
 		})
 
@@ -168,11 +168,11 @@ func TestFindOrCreate(t *testing.T) {
 					Input: &updatepb.Input{Name: "not_empty"},
 				},
 				evStore)
-			require.NoError(t, err, "update #1 should have been admitted")
+			require.NoError(t, err, "update #1 should be admitted")
 
 			_, _, err = reg.FindOrCreate(context.Background(), tv.UpdateID("2"))
 			var resExh *serviceerror.ResourceExhausted
-			require.ErrorAs(t, err, &resExh, "creating update #2 should have been denied")
+			require.ErrorAs(t, err, &resExh, "creating update #2 should be denied")
 			require.Equal(t, 1, reg.Len())
 		})
 
@@ -182,7 +182,7 @@ func TestFindOrCreate(t *testing.T) {
 
 			_, _, err = reg.FindOrCreate(context.Background(), tv.UpdateID("2"))
 			var resExh *serviceerror.ResourceExhausted
-			require.ErrorAs(t, err, &resExh, "creating update #2 should have been denied")
+			require.ErrorAs(t, err, &resExh, "creating update #2 should be denied")
 			require.Equal(t, 1, reg.Len())
 		})
 
@@ -210,10 +210,10 @@ func TestFindOrCreate(t *testing.T) {
 				Failure: &failurepb.Failure{Message: "intentional failure in " + t.Name()},
 			})}
 			require.NoError(t, upd1.OnProtocolMessage(context.Background(), &rej, evStore))
-			require.Equal(t, 1, reg.Len(), "update #1 should have been removed from registry")
+			require.Equal(t, 1, reg.Len(), "update #1 should be removed from registry")
 
 			_, existed, err = reg.FindOrCreate(context.Background(), tv.UpdateID("3"))
-			require.NoError(t, err, "update #3 should have been created after #1 completed")
+			require.NoError(t, err, "update #3 should be created after #1 completed")
 			require.False(t, existed)
 			require.Equal(t, 2, reg.Len())
 		})
@@ -252,7 +252,7 @@ func TestFindOrCreate(t *testing.T) {
 					Input: &updatepb.Input{Name: "not_empty"},
 				},
 				evStore)
-			require.NoError(t, err, "update #1 should have been admitted")
+			require.NoError(t, err, "update #1 should be admitted")
 
 			err = upd1.OnProtocolMessage(
 				context.Background(),
@@ -267,7 +267,7 @@ func TestFindOrCreate(t *testing.T) {
 					},
 				})},
 				evStore)
-			require.NoError(t, err, "update #1 should have been completed")
+			require.NoError(t, err, "update #1 should be completed")
 
 			_, existed, err = reg.FindOrCreate(context.Background(), tv.UpdateID("2"))
 			var failedPrecon *serviceerror.FailedPrecondition
@@ -279,7 +279,7 @@ func TestFindOrCreate(t *testing.T) {
 			limit = 2
 
 			_, existed, err = reg.FindOrCreate(context.Background(), tv.UpdateID("2"))
-			require.NoError(t, err, "update #2 should have been created after the limit increase")
+			require.NoError(t, err, "update #2 should be created after the limit increase")
 			require.False(t, existed)
 			require.Equal(t, 1, reg.Len())
 		})
@@ -540,7 +540,7 @@ func TestRejectUnprocessed(t *testing.T) {
 		rejectedIDs, err := reg.RejectUnprocessed(context.Background(), evStore)
 		require.NoError(t, err)
 		require.Len(t, rejectedIDs, 1, "only update #1 in stateSent should be rejected")
-		require.Equal(t, rejectedIDs[0], tv.UpdateID("1"), "update #1 should have been rejected")
+		require.Equal(t, rejectedIDs[0], tv.UpdateID("1"), "update #1 should be rejected")
 
 		rejectedIDs, err = reg.RejectUnprocessed(context.Background(), evStore)
 		require.NoError(t, err)

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -50,7 +50,7 @@ import (
 
 func TestNewRegistry(t *testing.T) {
 	t.Parallel()
-	tv := testvars.New(t.Name())
+	tv := testvars.New(t)
 
 	t.Run("registry created from empty store has no updates", func(t *testing.T) {
 		reg := update.NewRegistry(emptyUpdateStore)
@@ -160,7 +160,7 @@ func TestNewRegistry(t *testing.T) {
 
 func TestFind(t *testing.T) {
 	t.Parallel()
-	tv := testvars.New(t.Name())
+	tv := testvars.New(t)
 
 	t.Run("return update when found in registry", func(t *testing.T) {
 		reg := update.NewRegistry(&mockUpdateStore{
@@ -214,7 +214,7 @@ func TestFind(t *testing.T) {
 
 func TestFindOrCreate(t *testing.T) {
 	t.Parallel()
-	tv := testvars.New(t.Name())
+	tv := testvars.New(t)
 
 	t.Run("find stored update", func(t *testing.T) {
 		reg := update.NewRegistry(&mockUpdateStore{
@@ -379,7 +379,7 @@ func TestHasOutgoingMessages(t *testing.T) {
 	t.Parallel()
 
 	var (
-		tv      = testvars.New(t.Name())
+		tv      = testvars.New(t)
 		upd     *update.Update
 		reg     = update.NewRegistry(emptyUpdateStore)
 		evStore = mockEventStore{Controller: effect.Immediate(context.Background())}
@@ -424,7 +424,7 @@ func TestSendMessages(t *testing.T) {
 	t.Parallel()
 
 	var (
-		tv         = testvars.New(t.Name())
+		tv         = testvars.New(t)
 		upd1, upd2 *update.Update
 		reg        = update.NewRegistry(emptyUpdateStore)
 		evStore    = mockEventStore{Controller: effect.Immediate(context.Background())}
@@ -499,7 +499,7 @@ func TestRejectUnprocessed(t *testing.T) {
 	t.Parallel()
 
 	var (
-		tv           = testvars.New(t.Name())
+		tv           = testvars.New(t)
 		upd1, upd2   *update.Update
 		reg          = update.NewRegistry(emptyUpdateStore)
 		evStore      = mockEventStore{Controller: effect.Immediate(context.Background())}
@@ -574,7 +574,7 @@ func TestRejectUnprocessed(t *testing.T) {
 // NOTE: tests for various update states can be found in the update tests
 func TestAbort(t *testing.T) {
 	t.Parallel()
-	tv := testvars.New(t.Name())
+	tv := testvars.New(t)
 
 	reg := update.NewRegistry(&mockUpdateStore{
 		VisitUpdatesFunc: func(visitor func(updID string, updInfo *persistencespb.UpdateInfo)) {
@@ -618,7 +618,7 @@ func TestAbort(t *testing.T) {
 
 func TestClear(t *testing.T) {
 	t.Parallel()
-	tv := testvars.New(t.Name())
+	tv := testvars.New(t)
 
 	reg := update.NewRegistry(&mockUpdateStore{
 		VisitUpdatesFunc: func(visitor func(updID string, updInfo *persistencespb.UpdateInfo)) {
@@ -673,7 +673,7 @@ func TestFailoverVersion(t *testing.T) {
 
 func TestTryResurrect(t *testing.T) {
 	t.Parallel()
-	tv := testvars.New(t.Name())
+	tv := testvars.New(t)
 
 	t.Run("add acceptance message as new update with stateAdmitted", func(t *testing.T) {
 		reg := update.NewRegistry(emptyUpdateStore)
@@ -835,7 +835,7 @@ func testAcceptUpdate(
 	upd *update.Update,
 ) {
 	t.Helper()
-	tv := testvars.New(t.Name())
+	tv := testvars.New(t)
 
 	err := upd.OnProtocolMessage(
 		context.Background(),

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -36,55 +36,13 @@ import (
 	protocolpb "go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
+
 	"go.temporal.io/server/service/history/consts"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/internal/effect"
 	"go.temporal.io/server/service/history/workflow/update"
 )
-
-type mockUpdateStore struct {
-	update.Store
-	VisitUpdatesFunc               func(visitor func(updID string, updInfo *persistencespb.UpdateInfo))
-	GetUpdateOutcomeFunc           func(context.Context, string) (*updatepb.Outcome, error)
-	GetCurrentVersionFunc          func() int64
-	IsWorkflowExecutionRunningFunc func() bool
-}
-
-func (m mockUpdateStore) VisitUpdates(
-	visitor func(updID string, updInfo *persistencespb.UpdateInfo),
-) {
-	m.VisitUpdatesFunc(visitor)
-}
-
-func (m mockUpdateStore) GetUpdateOutcome(
-	ctx context.Context,
-	updateID string,
-) (*updatepb.Outcome, error) {
-	return m.GetUpdateOutcomeFunc(ctx, updateID)
-}
-
-func (m mockUpdateStore) GetCurrentVersion() int64 {
-	if m.GetCurrentVersionFunc == nil {
-		return 0
-	}
-	return m.GetCurrentVersionFunc()
-}
-
-func (m mockUpdateStore) IsWorkflowExecutionRunning() bool {
-	if m.IsWorkflowExecutionRunningFunc == nil {
-		return true
-	}
-	return m.IsWorkflowExecutionRunningFunc()
-}
-
-var emptyUpdateStore = mockUpdateStore{
-	VisitUpdatesFunc: func(func(updID string, updInfo *persistencespb.UpdateInfo)) {
-	},
-	GetUpdateOutcomeFunc: func(context.Context, string) (*updatepb.Outcome, error) {
-		return nil, serviceerror.NewNotFound("not found")
-	},
-}
 
 func TestFind(t *testing.T) {
 	t.Parallel()

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -409,7 +409,7 @@ func TestHasOutgoingMessages(t *testing.T) {
 		require.False(t, reg.HasOutgoingMessages(false))
 	})
 
-	t.Run("registy with admitted update", func(t *testing.T) {
+	t.Run("registry with admitted update", func(t *testing.T) {
 		err := upd.Admit(
 			context.Background(),
 			&updatepb.Request{
@@ -522,7 +522,7 @@ func TestSendMessages(t *testing.T) {
 		require.False(t, upd2.IsSent())
 	})
 
-	t.Run("registy with 1 admitted update has 1 message to send", func(t *testing.T) {
+	t.Run("registry with 1 admitted update has 1 message to send", func(t *testing.T) {
 		err := upd1.Admit(
 			context.Background(),
 			&updatepb.Request{
@@ -552,7 +552,7 @@ func TestSendMessages(t *testing.T) {
 		require.False(t, upd2.IsSent())
 	})
 
-	t.Run("registy with 2 admitted updates returns messages sorted by admission time", func(t *testing.T) {
+	t.Run("registry with 2 admitted updates returns messages sorted by admission time", func(t *testing.T) {
 		err := upd2.Admit(
 			context.Background(),
 			&updatepb.Request{

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -605,7 +605,7 @@ func TestAbort(t *testing.T) {
 			upd := reg.Find(context.Background(), tv.UpdateID(fmt.Sprintf("%d", id)))
 			require.NotNil(t, upd)
 
-			_, err := upd.WaitLifecycleStage(context.Background(), 0, 1*time.Second)
+			_, err := upd.WaitLifecycleStage(context.Background(), 0, 2*time.Second)
 			require.Equal(t, consts.ErrWorkflowCompleted, err)
 		}(i)
 	}
@@ -639,7 +639,7 @@ func TestClear(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, err := upd.WaitLifecycleStage(context.Background(), 0, 1*time.Second)
+		_, err := upd.WaitLifecycleStage(context.Background(), 0, 2*time.Second)
 		require.Equal(t, update.WorkflowUpdateAbortedErr, err)
 	}()
 

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -660,3 +660,23 @@ func TestAbort(t *testing.T) {
 	require.Nil(t, status.Outcome.GetFailure())
 	require.NotNil(t, status.Outcome.GetSuccess())
 }
+
+func TestFailoverVersion(t *testing.T) {
+	t.Run("return version obtained from store", func(t *testing.T) {
+		reg := update.NewRegistry(&mockUpdateStore{
+			GetCurrentVersionFunc: func() int64 { return 42 },
+		})
+		require.Equal(t, int64(42), reg.FailoverVersion())
+	})
+
+	t.Run("returns same version obtained from store after store changes its version", func(t *testing.T) {
+		var failoverVersion int64 = 42
+		reg := update.NewRegistry(&mockUpdateStore{
+			GetCurrentVersionFunc: func() int64 { return failoverVersion },
+		})
+		failoverVersion = 1024
+
+		require.Equal(t, int64(42), reg.FailoverVersion(),
+			"should still be original failover version")
+	})
+}

--- a/service/history/workflow/update/store.go
+++ b/service/history/workflow/update/store.go
@@ -27,15 +27,48 @@ package update
 import (
 	"context"
 
+	historypb "go.temporal.io/api/history/v1"
 	updatepb "go.temporal.io/api/update/v1"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/internal/effect"
 )
 
-// Store represents the update package's requirements for reading updates from the store.
-type Store interface {
-	VisitUpdates(visitor func(updID string, updInfo *persistencespb.UpdateInfo))
-	GetUpdateOutcome(ctx context.Context, updateID string) (*updatepb.Outcome, error)
-	GetCurrentVersion() int64
-	IsWorkflowExecutionRunning() bool
-}
+type (
+	// UpdateStore represents the update package's requirements for reading updates from the store.
+	UpdateStore interface {
+		VisitUpdates(visitor func(updID string, updInfo *persistencespb.UpdateInfo))
+		GetUpdateOutcome(ctx context.Context, updateID string) (*updatepb.Outcome, error)
+		GetCurrentVersion() int64
+		IsWorkflowExecutionRunning() bool
+	}
+
+	// EventStore is the interface that an Update needs to read and write events
+	// and to be notified when buffered writes have been flushed. It is the
+	// expectation of this code that writes to EventStore will return before the
+	// data has been made durable. Callbacks attached to the EventStore via
+	// OnAfterCommit and OnAfterRollback *must* be called after the EventStore
+	// state is successfully written or is discarded.
+	EventStore interface {
+		effect.Controller
+
+		// AddWorkflowExecutionUpdateAcceptedEvent writes an update accepted
+		// event. The data may not be durable when this function returns.
+		AddWorkflowExecutionUpdateAcceptedEvent(
+			updateID string,
+			acceptedRequestMessageId string,
+			acceptedRequestSequencingEventId int64,
+			acceptedRequest *updatepb.Request,
+		) (*historypb.HistoryEvent, error)
+
+		// AddWorkflowExecutionUpdateCompletedEvent writes an update completed
+		// event. The data may not be durable when this function returns.
+		AddWorkflowExecutionUpdateCompletedEvent(
+			acceptedEventID int64,
+			resp *updatepb.Response,
+		) (*historypb.HistoryEvent, error)
+
+		// CanAddEvent returns true if an event can be added to the EventStore.
+		CanAddEvent() bool
+	}
+)

--- a/service/history/workflow/update/store.go
+++ b/service/history/workflow/update/store.go
@@ -1,0 +1,41 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package update
+
+import (
+	"context"
+
+	updatepb "go.temporal.io/api/update/v1"
+
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+)
+
+// Store represents the update package's requirements for reading updates from the store.
+type Store interface {
+	VisitUpdates(visitor func(updID string, updInfo *persistencespb.UpdateInfo))
+	GetUpdateOutcome(ctx context.Context, updateID string) (*updatepb.Outcome, error)
+	GetCurrentVersion() int64
+	IsWorkflowExecutionRunning() bool
+}

--- a/service/history/workflow/update/store_mock_test.go
+++ b/service/history/workflow/update/store_mock_test.go
@@ -27,22 +27,27 @@ package update_test
 import (
 	"context"
 
+	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/internal/effect"
 	"go.temporal.io/server/service/history/workflow/update"
 )
 
-var emptyUpdateStore = mockUpdateStore{
-	VisitUpdatesFunc: func(func(updID string, updInfo *persistencespb.UpdateInfo)) {},
-	GetUpdateOutcomeFunc: func(context.Context, string) (*updatepb.Outcome, error) {
-		return nil, serviceerror.NewNotFound("not found")
-	},
-}
+var (
+	emptyUpdateStore = mockUpdateStore{
+		VisitUpdatesFunc: func(func(updID string, updInfo *persistencespb.UpdateInfo)) {},
+		GetUpdateOutcomeFunc: func(context.Context, string) (*updatepb.Outcome, error) {
+			return nil, serviceerror.NewNotFound("not found")
+		},
+	}
+	eventStoreUnused update.EventStore
+)
 
 type mockUpdateStore struct {
-	update.Store
+	update.UpdateStore
 	VisitUpdatesFunc               func(visitor func(updID string, updInfo *persistencespb.UpdateInfo))
 	GetUpdateOutcomeFunc           func(context.Context, string) (*updatepb.Outcome, error)
 	GetCurrentVersionFunc          func() int64
@@ -76,4 +81,50 @@ func (m mockUpdateStore) IsWorkflowExecutionRunning() bool {
 		return true
 	}
 	return m.IsWorkflowExecutionRunningFunc()
+}
+
+type mockEventStore struct {
+	effect.Controller
+	AddWorkflowExecutionUpdateAcceptedEventFunc func(
+		updateID string,
+		acceptedRequestMessageId string,
+		acceptedRequestSequencingEventId int64,
+		acceptedRequest *updatepb.Request,
+	) (*historypb.HistoryEvent, error)
+
+	AddWorkflowExecutionUpdateCompletedEventFunc func(
+		acceptedEventID int64,
+		resp *updatepb.Response,
+	) (*historypb.HistoryEvent, error)
+
+	CanAddEventFunc func() bool
+}
+
+func (m mockEventStore) AddWorkflowExecutionUpdateAcceptedEvent(
+	updateID string,
+	acceptedRequestMessageId string,
+	acceptedRequestSequencingEventId int64,
+	acceptedRequest *updatepb.Request,
+) (*historypb.HistoryEvent, error) {
+	if m.AddWorkflowExecutionUpdateAcceptedEventFunc != nil {
+		return m.AddWorkflowExecutionUpdateAcceptedEventFunc(updateID, acceptedRequestMessageId, acceptedRequestSequencingEventId, acceptedRequest)
+	}
+	return &historypb.HistoryEvent{EventId: testAcceptedEventID}, nil
+}
+
+func (m mockEventStore) AddWorkflowExecutionUpdateCompletedEvent(
+	acceptedEventID int64,
+	resp *updatepb.Response,
+) (*historypb.HistoryEvent, error) {
+	if m.AddWorkflowExecutionUpdateCompletedEventFunc != nil {
+		return m.AddWorkflowExecutionUpdateCompletedEventFunc(acceptedEventID, resp)
+	}
+	return &historypb.HistoryEvent{}, nil
+}
+
+func (m mockEventStore) CanAddEvent() bool {
+	if m.CanAddEventFunc != nil {
+		return m.CanAddEventFunc()
+	}
+	return true
 }

--- a/service/history/workflow/update/store_mock_test.go
+++ b/service/history/workflow/update/store_mock_test.go
@@ -34,6 +34,13 @@ import (
 	"go.temporal.io/server/service/history/workflow/update"
 )
 
+var emptyUpdateStore = mockUpdateStore{
+	VisitUpdatesFunc: func(func(updID string, updInfo *persistencespb.UpdateInfo)) {},
+	GetUpdateOutcomeFunc: func(context.Context, string) (*updatepb.Outcome, error) {
+		return nil, serviceerror.NewNotFound("not found")
+	},
+}
+
 type mockUpdateStore struct {
 	update.Store
 	VisitUpdatesFunc               func(visitor func(updID string, updInfo *persistencespb.UpdateInfo))
@@ -69,12 +76,4 @@ func (m mockUpdateStore) IsWorkflowExecutionRunning() bool {
 		return true
 	}
 	return m.IsWorkflowExecutionRunningFunc()
-}
-
-var emptyUpdateStore = mockUpdateStore{
-	VisitUpdatesFunc: func(func(updID string, updInfo *persistencespb.UpdateInfo)) {
-	},
-	GetUpdateOutcomeFunc: func(context.Context, string) (*updatepb.Outcome, error) {
-		return nil, serviceerror.NewNotFound("not found")
-	},
 }

--- a/service/history/workflow/update/store_mock_test.go
+++ b/service/history/workflow/update/store_mock_test.go
@@ -45,7 +45,9 @@ type mockUpdateStore struct {
 func (m mockUpdateStore) VisitUpdates(
 	visitor func(updID string, updInfo *persistencespb.UpdateInfo),
 ) {
-	m.VisitUpdatesFunc(visitor)
+	if m.VisitUpdatesFunc != nil {
+		m.VisitUpdatesFunc(visitor)
+	}
 }
 
 func (m mockUpdateStore) GetUpdateOutcome(

--- a/service/history/workflow/update/store_mock_test.go
+++ b/service/history/workflow/update/store_mock_test.go
@@ -1,0 +1,78 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package update_test
+
+import (
+	"context"
+
+	"go.temporal.io/api/serviceerror"
+	updatepb "go.temporal.io/api/update/v1"
+
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/service/history/workflow/update"
+)
+
+type mockUpdateStore struct {
+	update.Store
+	VisitUpdatesFunc               func(visitor func(updID string, updInfo *persistencespb.UpdateInfo))
+	GetUpdateOutcomeFunc           func(context.Context, string) (*updatepb.Outcome, error)
+	GetCurrentVersionFunc          func() int64
+	IsWorkflowExecutionRunningFunc func() bool
+}
+
+func (m mockUpdateStore) VisitUpdates(
+	visitor func(updID string, updInfo *persistencespb.UpdateInfo),
+) {
+	m.VisitUpdatesFunc(visitor)
+}
+
+func (m mockUpdateStore) GetUpdateOutcome(
+	ctx context.Context,
+	updateID string,
+) (*updatepb.Outcome, error) {
+	return m.GetUpdateOutcomeFunc(ctx, updateID)
+}
+
+func (m mockUpdateStore) GetCurrentVersion() int64 {
+	if m.GetCurrentVersionFunc == nil {
+		return 0
+	}
+	return m.GetCurrentVersionFunc()
+}
+
+func (m mockUpdateStore) IsWorkflowExecutionRunning() bool {
+	if m.IsWorkflowExecutionRunningFunc == nil {
+		return true
+	}
+	return m.IsWorkflowExecutionRunningFunc()
+}
+
+var emptyUpdateStore = mockUpdateStore{
+	VisitUpdatesFunc: func(func(updID string, updInfo *persistencespb.UpdateInfo)) {
+	},
+	GetUpdateOutcomeFunc: func(context.Context, string) (*updatepb.Outcome, error) {
+		return nil, serviceerror.NewNotFound("not found")
+	},
+}

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -31,7 +31,6 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
-	historypb "go.temporal.io/api/history/v1"
 	protocolpb "go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
@@ -50,35 +49,6 @@ var (
 )
 
 type (
-	// EventStore is the interface that an Update needs to read and write events
-	// and to be notified when buffered writes have been flushed. It is the
-	// expectation of this code that writes to EventStore will return before the
-	// data has been made durable. Callbacks attached to the EventStore via
-	// OnAfterCommit and OnAfterRollback *must* be called after the EventStore
-	// state is successfully written or is discarded.
-	EventStore interface {
-		effect.Controller
-
-		// AddWorkflowExecutionUpdateAcceptedEvent writes an update accepted
-		// event. The data may not be durable when this function returns.
-		AddWorkflowExecutionUpdateAcceptedEvent(
-			updateID string,
-			acceptedRequestMessageId string,
-			acceptedRequestSequencingEventId int64,
-			acceptedRequest *updatepb.Request,
-		) (*historypb.HistoryEvent, error)
-
-		// AddWorkflowExecutionUpdateCompletedEvent writes an update completed
-		// event. The data may not be durable when this function returns.
-		AddWorkflowExecutionUpdateCompletedEvent(
-			acceptedEventID int64,
-			resp *updatepb.Response,
-		) (*historypb.HistoryEvent, error)
-
-		// CanAddEvent returns true if an event can be added to the EventStore.
-		CanAddEvent() bool
-	}
-
 	// Update is a state machine for the update protocol. It reads and writes
 	// messages from the go.temporal.io/api/update/v1 package. See the diagram
 	// in service/history/workflow/update/README.md. The update state machine is

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -45,6 +45,10 @@ import (
 	"go.temporal.io/server/internal/effect"
 )
 
+var (
+	WorkflowUpdateAbortedErr = serviceerror.NewUnavailable("Workflow Update was aborted.")
+)
+
 type (
 	// EventStore is the interface that an Update needs to read and write events
 	// and to be notified when buffered writes have been flushed. It is the
@@ -263,7 +267,7 @@ func (u *Update) WaitLifecycleStage(
 			if !errors.Is(err, registryClearedErr) {
 				return nil, err
 			}
-			return nil, serviceerror.NewUnavailable("Workflow Update was aborted.")
+			return nil, WorkflowUpdateAbortedErr
 		}
 
 		if ctx.Err() != nil {

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -52,14 +52,6 @@ const (
 	testSequencingEventID int64 = 2203
 )
 
-func successOutcome(t *testing.T, s string) *updatepb.Outcome {
-	return &updatepb.Outcome{
-		Value: &updatepb.Outcome_Success{
-			Success: payloads.EncodeString(t.Name() + s),
-		},
-	}
-}
-
 func TestNilMessage(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -1106,6 +1098,14 @@ func TestCompletedWorkflow(t *testing.T) {
 		require.ErrorIs(t, err, consts.ErrWorkflowCompleted)
 		require.Nil(t, status)
 	})
+}
+
+func successOutcome(t *testing.T, s string) *updatepb.Outcome {
+	return &updatepb.Outcome{
+		Value: &updatepb.Outcome_Success{
+			Success: payloads.EncodeString(t.Name() + s),
+		},
+	}
 }
 
 // TODO: test aborting an Update in various states

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -60,54 +60,6 @@ func successOutcome(t *testing.T, s string) *updatepb.Outcome {
 	}
 }
 
-var eventStoreUnused update.EventStore
-
-type mockEventStore struct {
-	effect.Controller
-	AddWorkflowExecutionUpdateAcceptedEventFunc func(
-		updateID string,
-		acceptedRequestMessageId string,
-		acceptedRequestSequencingEventId int64,
-		acceptedRequest *updatepb.Request,
-	) (*historypb.HistoryEvent, error)
-
-	AddWorkflowExecutionUpdateCompletedEventFunc func(
-		acceptedEventID int64,
-		resp *updatepb.Response,
-	) (*historypb.HistoryEvent, error)
-
-	CanAddEventFunc func() bool
-}
-
-func (m mockEventStore) AddWorkflowExecutionUpdateAcceptedEvent(
-	updateID string,
-	acceptedRequestMessageId string,
-	acceptedRequestSequencingEventId int64,
-	acceptedRequest *updatepb.Request,
-) (*historypb.HistoryEvent, error) {
-	if m.AddWorkflowExecutionUpdateAcceptedEventFunc != nil {
-		return m.AddWorkflowExecutionUpdateAcceptedEventFunc(updateID, acceptedRequestMessageId, acceptedRequestSequencingEventId, acceptedRequest)
-	}
-	return &historypb.HistoryEvent{EventId: testAcceptedEventID}, nil
-}
-
-func (m mockEventStore) AddWorkflowExecutionUpdateCompletedEvent(
-	acceptedEventID int64,
-	resp *updatepb.Response,
-) (*historypb.HistoryEvent, error) {
-	if m.AddWorkflowExecutionUpdateCompletedEventFunc != nil {
-		return m.AddWorkflowExecutionUpdateCompletedEventFunc(acceptedEventID, resp)
-	}
-	return &historypb.HistoryEvent{}, nil
-}
-
-func (m mockEventStore) CanAddEvent() bool {
-	if m.CanAddEventFunc != nil {
-		return m.CanAddEventFunc()
-	}
-	return true
-}
-
 func TestNilMessage(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -26,7 +26,6 @@ package update_test
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
@@ -37,15 +36,14 @@ import (
 	protocolpb "go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
-
-	"go.temporal.io/server/service/history/consts"
 
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/testing/protorequire"
+	. "go.temporal.io/server/common/testing/protoutils"
 	"go.temporal.io/server/internal/effect"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/workflow/update"
 )
 
@@ -134,7 +132,7 @@ func TestUnsupportedMessageType(t *testing.T) {
 	ctx := context.Background()
 	upd := update.New(t.Name() + "update-id")
 	msg := protocolpb.Message{}
-	msg.Body = mustMarshalAny(t, &historypb.HistoryEvent{})
+	msg.Body = MarshalAny(t, &historypb.HistoryEvent{})
 	err := upd.OnProtocolMessage(ctx, &msg, mockEventStore{})
 	var invalidArg *serviceerror.InvalidArgument
 	require.ErrorAs(t, err, &invalidArg)
@@ -151,11 +149,11 @@ func TestAdmitSendAcceptComplete(t *testing.T) {
 		invalidArg *serviceerror.InvalidArgument
 		meta       = updatepb.Meta{UpdateId: t.Name() + "-update-id"}
 		req        = updatepb.Request{Meta: &meta, Input: &updatepb.Input{Name: t.Name()}}
-		acpt       = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
+		acpt       = protocolpb.Message{Body: MarshalAny(t, &updatepb.Acceptance{
 			AcceptedRequestMessageId:         "random",
 			AcceptedRequestSequencingEventId: 2208,
 		})}
-		resp         = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")})}
+		resp         = protocolpb.Message{Body: MarshalAny(t, &updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")})}
 		sequencingID = &protocolpb.Message_EventId{EventId: testSequencingEventID}
 
 		completedEventData *updatepb.Response
@@ -259,13 +257,13 @@ func TestAdmitSendAcceptComplete(t *testing.T) {
 		status, err := upd.WaitLifecycleStage(ctx, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, 1*time.Second)
 		require.NoError(t, err)
 		require.Equal(t, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, status.Stage)
-		require.Equal(t, mustUnmarshalBody[*updatepb.Response](t, &resp).Outcome, status.Outcome)
+		require.Equal(t, UnmarshalAny[*updatepb.Response](t, resp.Body).Outcome, status.Outcome)
 		require.True(t, completed)
 	})
 
 	require.Equal(t, meta.UpdateId, acceptedEventData.updateID)
-	require.Equal(t, mustUnmarshalBody[*updatepb.Acceptance](t, &acpt).AcceptedRequestSequencingEventId, acceptedEventData.acceptedRequestSequencingEventId)
-	protorequire.ProtoEqual(t, mustUnmarshalBody[*updatepb.Response](t, &resp), completedEventData)
+	require.Equal(t, UnmarshalAny[*updatepb.Acceptance](t, acpt.Body).AcceptedRequestSequencingEventId, acceptedEventData.acceptedRequestSequencingEventId)
+	protorequire.ProtoEqual(t, UnmarshalAny[*updatepb.Response](t, resp.Body), completedEventData)
 }
 
 func TestAdmitSendReject(t *testing.T) {
@@ -297,7 +295,7 @@ func TestAdmitSendReject(t *testing.T) {
 	effects.Apply(ctx)
 
 	t.Run("reject", func(t *testing.T) {
-		rej := protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Rejection{
+		rej := protocolpb.Message{Body: MarshalAny(t, &updatepb.Rejection{
 			RejectedRequest: &req,
 			Failure:         &failurepb.Failure{Message: "An intentional failure"},
 		})}
@@ -326,12 +324,12 @@ func TestAdmitSendReject(t *testing.T) {
 		status, err := upd.WaitLifecycleStage(ctx, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, 1*time.Second)
 		require.NoError(t, err)
 		require.Equal(t, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, status.Stage)
-		require.Equal(t, mustUnmarshalBody[*updatepb.Rejection](t, &rej).Failure, status.Outcome.GetFailure())
+		require.Equal(t, UnmarshalAny[*updatepb.Rejection](t, rej.Body).Failure, status.Outcome.GetFailure())
 
 		status, err = upd.WaitLifecycleStage(ctx, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, 1*time.Second)
 		require.NoError(t, err)
 		require.Equal(t, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, status.Stage)
-		require.Equal(t, mustUnmarshalBody[*updatepb.Rejection](t, &rej).Failure, status.Outcome.GetFailure())
+		require.Equal(t, UnmarshalAny[*updatepb.Rejection](t, rej.Body).Failure, status.Outcome.GetFailure())
 
 		require.True(t, completed)
 	})
@@ -367,7 +365,7 @@ func TestAdmitAcceptOrReject(t *testing.T) {
 
 		// Note: no upd.Send call.
 
-		acpt := protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
+		acpt := protocolpb.Message{Body: MarshalAny(t, &updatepb.Acceptance{
 			AcceptedRequestMessageId:         "random",
 			AcceptedRequestSequencingEventId: 2208,
 		})}
@@ -388,7 +386,7 @@ func TestAdmitAcceptOrReject(t *testing.T) {
 
 		// Note: no upd.Send call.
 
-		rej := protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Rejection{
+		rej := protocolpb.Message{Body: MarshalAny(t, &updatepb.Rejection{
 			RejectedRequest: &req,
 			Failure:         &failurepb.Failure{Message: "An intentional failure"},
 		})}
@@ -398,7 +396,7 @@ func TestAdmitAcceptOrReject(t *testing.T) {
 		status, err := upd.WaitLifecycleStage(ctx, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, 1*time.Second)
 		require.NoError(t, err)
 		require.Equal(t, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, status.Stage)
-		require.Equal(t, mustUnmarshalBody[*updatepb.Rejection](t, &rej).Failure, status.Outcome.GetFailure())
+		require.Equal(t, UnmarshalAny[*updatepb.Rejection](t, rej.Body).Failure, status.Outcome.GetFailure())
 	})
 
 }
@@ -410,7 +408,7 @@ func TestWithProtocolMessage(t *testing.T) {
 		store    = mockEventStore{Controller: &effect.Buffer{}}
 		updateID = t.Name() + "-update-id"
 		upd      = update.NewAccepted(updateID, 2208)
-		resp     = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Response{
+		resp     = protocolpb.Message{Body: MarshalAny(t, &updatepb.Response{
 			Meta:    &updatepb.Meta{UpdateId: updateID},
 			Outcome: successOutcome(t, "success!"),
 		})}
@@ -500,7 +498,7 @@ func TestRejectAfterAcceptFails(t *testing.T) {
 
 	updateID := t.Name() + "-update-id"
 	upd := update.NewAccepted(updateID, testAcceptedEventID)
-	err := upd.OnProtocolMessage(ctx, &protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Rejection{})}, store)
+	err := upd.OnProtocolMessage(ctx, &protocolpb.Message{Body: MarshalAny(t, &updatepb.Rejection{})}, store)
 	var invalidArg *serviceerror.InvalidArgument
 	require.ErrorAs(t, err, &invalidArg)
 	require.ErrorContains(t, err, "state")
@@ -518,12 +516,12 @@ func TestAcceptanceAndResponseInSameMessageBatch(t *testing.T) {
 		store     = mockEventStore{Controller: &effects}
 		meta      = updatepb.Meta{UpdateId: t.Name() + "-update-id"}
 		req       = updatepb.Request{Meta: &meta, Input: &updatepb.Input{Name: t.Name()}}
-		acpt      = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
+		acpt      = protocolpb.Message{Body: MarshalAny(t, &updatepb.Acceptance{
 			AcceptedRequestMessageId:         "x",
 			AcceptedRequestSequencingEventId: testSequencingEventID,
 			AcceptedRequest:                  &req,
 		})}
-		resp         = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")})}
+		resp         = protocolpb.Message{Body: MarshalAny(t, &updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")})}
 		upd          = update.New(meta.UpdateId, update.ObserveCompletion(&completed))
 		sequencingID = &protocolpb.Message_EventId{EventId: testSequencingEventID}
 	)
@@ -585,7 +583,7 @@ func TestMessageValidation(t *testing.T) {
 
 		err = upd.OnProtocolMessage(
 			ctx,
-			&protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{})},
+			&protocolpb.Message{Body: MarshalAny(t, &updatepb.Acceptance{})},
 			store,
 		)
 		require.ErrorAs(t, err, &invalidArg)
@@ -593,7 +591,7 @@ func TestMessageValidation(t *testing.T) {
 
 		err = upd.OnProtocolMessage(
 			ctx,
-			&protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
+			&protocolpb.Message{Body: MarshalAny(t, &updatepb.Acceptance{
 				AcceptedRequestSequencingEventId: testSequencingEventID,
 			})},
 			store,
@@ -605,7 +603,7 @@ func TestMessageValidation(t *testing.T) {
 		upd := update.NewAccepted("", testAcceptedEventID)
 		err := upd.OnProtocolMessage(
 			ctx,
-			&protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Response{})},
+			&protocolpb.Message{Body: MarshalAny(t, &updatepb.Response{})},
 			store,
 		)
 		require.ErrorAs(t, err, &invalidArg)
@@ -626,11 +624,11 @@ func TestDoubleRollback(t *testing.T) {
 		reqMsgID  = t.Name() + "-req-msg-id"
 		meta      = updatepb.Meta{UpdateId: t.Name() + "-update-id"}
 		req       = updatepb.Request{Meta: &meta, Input: &updatepb.Input{Name: t.Name()}}
-		acpt      = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
+		acpt      = protocolpb.Message{Body: MarshalAny(t, &updatepb.Acceptance{
 			AcceptedRequestMessageId:         reqMsgID,
 			AcceptedRequestSequencingEventId: testSequencingEventID,
 		})}
-		resp         = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")})}
+		resp         = protocolpb.Message{Body: MarshalAny(t, &updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")})}
 		sequencingID = &protocolpb.Message_EventId{EventId: testSequencingEventID}
 	)
 
@@ -679,7 +677,7 @@ func TestRollbackCompletion(t *testing.T) {
 			testAcceptedEventID,
 			update.ObserveCompletion(&completed),
 		)
-		resp = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Response{
+		resp = protocolpb.Message{Body: MarshalAny(t, &updatepb.Response{
 			Meta:    &updatepb.Meta{UpdateId: updateID},
 			Outcome: successOutcome(t, "success!"),
 		})}
@@ -715,7 +713,7 @@ func TestRejectionWithAcceptanceWaiter(t *testing.T) {
 			Meta:  &updatepb.Meta{UpdateId: updateID},
 			Input: &updatepb.Input{Name: "not_empty"},
 		}
-		rej = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Rejection{
+		rej = protocolpb.Message{Body: MarshalAny(t, &updatepb.Rejection{
 			RejectedRequestMessageId: "not_empty",
 			RejectedRequest:          &req,
 			Failure: &failurepb.Failure{
@@ -746,7 +744,7 @@ func TestRejectionWithAcceptanceWaiter(t *testing.T) {
 	retVal := <-ch
 	outcome, ok := retVal.(*updatepb.Outcome)
 	require.Truef(t, ok, "WaitLifecycleStage returned an unexpected type: %T", retVal)
-	require.Equal(t, mustUnmarshalBody[*updatepb.Rejection](t, &rej).Failure, outcome.GetFailure())
+	require.Equal(t, UnmarshalAny[*updatepb.Rejection](t, rej.Body).Failure, outcome.GetFailure())
 }
 
 func TestAcceptEventIDInCompletedEvent(t *testing.T) {
@@ -761,12 +759,12 @@ func TestAcceptEventIDInCompletedEvent(t *testing.T) {
 			Meta:  &updatepb.Meta{UpdateId: updateID},
 			Input: &updatepb.Input{Name: "not_empty"},
 		}
-		acpt = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
+		acpt = protocolpb.Message{Body: MarshalAny(t, &updatepb.Acceptance{
 			AcceptedRequestMessageId:         "not empty",
 			AcceptedRequest:                  &req,
 			AcceptedRequestSequencingEventId: testSequencingEventID,
 		})}
-		resp = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Response{
+		resp = protocolpb.Message{Body: MarshalAny(t, &updatepb.Response{
 			Meta:    &updatepb.Meta{UpdateId: updateID},
 			Outcome: successOutcome(t, "success!"),
 		})}
@@ -813,15 +811,15 @@ func TestWaitLifecycleStage(t *testing.T) {
 		effects   = effect.Buffer{}
 		meta      = updatepb.Meta{UpdateId: t.Name() + "-update-id"}
 		req       = updatepb.Request{Meta: &meta, Input: &updatepb.Input{Name: t.Name()}}
-		acpt      = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
+		acpt      = protocolpb.Message{Body: MarshalAny(t, &updatepb.Acceptance{
 			AcceptedRequestMessageId:         "random",
 			AcceptedRequestSequencingEventId: 2208,
 		})}
-		rej = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Rejection{
+		rej = protocolpb.Message{Body: MarshalAny(t, &updatepb.Rejection{
 			RejectedRequest: &req,
 			Failure:         &failurepb.Failure{Message: "An intentional failure"},
 		})}
-		resp              = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")})}
+		resp              = protocolpb.Message{Body: MarshalAny(t, &updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")})}
 		acceptedEventData = struct {
 			updateID                         string
 			acceptedRequestMessageId         string
@@ -882,7 +880,7 @@ func TestWaitLifecycleStage(t *testing.T) {
 			require.Equal(t, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, status.Stage)
 			require.Nil(t, status.Outcome.GetFailure())
 			require.NotNil(t, status.Outcome.GetSuccess())
-			require.Equal(t, mustUnmarshalBody[*updatepb.Response](t, &resp).Outcome, status.Outcome)
+			require.Equal(t, UnmarshalAny[*updatepb.Response](t, resp.Body).Outcome, status.Outcome)
 		}
 		if alreadyInState {
 			status, err := upd.WaitLifecycleStage(ctx, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, time.Duration(0))
@@ -898,7 +896,7 @@ func TestWaitLifecycleStage(t *testing.T) {
 			require.Equal(t, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, status.Stage)
 			require.NotNil(t, status.Outcome.GetFailure())
 			require.Nil(t, status.Outcome.GetSuccess())
-			require.Equal(t, mustUnmarshalBody[*updatepb.Rejection](t, &rej).Failure, status.Outcome.GetFailure())
+			require.Equal(t, UnmarshalAny[*updatepb.Rejection](t, rej.Body).Failure, status.Outcome.GetFailure())
 		}
 		if alreadyInState {
 			status, err := upd.WaitLifecycleStage(ctx, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, time.Duration(0))
@@ -1114,7 +1112,7 @@ func TestCompletedWorkflow(t *testing.T) {
 		_ = upd.Admit(ctx, &req, store)
 		upd.Send(ctx, false, &protocolpb.Message_EventId{EventId: testSequencingEventID})
 
-		acpt := protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{AcceptedRequestSequencingEventId: 2208})}
+		acpt := protocolpb.Message{Body: MarshalAny(t, &updatepb.Acceptance{AcceptedRequestSequencingEventId: 2208})}
 		err := upd.OnProtocolMessage(ctx, &acpt, roStore)
 		require.NoError(t, err)
 
@@ -1129,7 +1127,7 @@ func TestCompletedWorkflow(t *testing.T) {
 		_ = upd.Admit(ctx, &req, store)
 		upd.Send(ctx, false, &protocolpb.Message_EventId{EventId: testSequencingEventID})
 
-		rej := protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Rejection{
+		rej := protocolpb.Message{Body: MarshalAny(t, &updatepb.Rejection{
 			RejectedRequest: &req,
 			Failure:         &failurepb.Failure{Message: "An intentional failure"},
 		})}
@@ -1147,7 +1145,7 @@ func TestCompletedWorkflow(t *testing.T) {
 	t.Run("accepted update is rejected if completed workflow completes it", func(t *testing.T) {
 		upd := update.NewAccepted(meta.UpdateId, testAcceptedEventID)
 
-		resp := protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")})}
+		resp := protocolpb.Message{Body: MarshalAny(t, &updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")})}
 		err := upd.OnProtocolMessage(ctx, &resp, roStore)
 		require.NoError(t, err)
 
@@ -1156,22 +1154,4 @@ func TestCompletedWorkflow(t *testing.T) {
 		require.ErrorIs(t, err, consts.ErrWorkflowCompleted)
 		require.Nil(t, status)
 	})
-}
-
-func mustMarshalAny(t *testing.T, pb proto.Message) *anypb.Any {
-	t.Helper()
-	var a anypb.Any
-	require.NoError(t, a.MarshalFrom(pb))
-	return &a
-}
-
-func mustUnmarshalBody[T proto.Message](t *testing.T, protocolMsg *protocolpb.Message) T {
-	t.Helper()
-	pb := new(T)
-	ppb := reflect.ValueOf(pb).Elem()
-	pbNew := reflect.New(reflect.TypeOf(pb).Elem().Elem())
-	ppb.Set(pbNew)
-
-	require.NoError(t, protocolMsg.Body.UnmarshalTo(*pb))
-	return *pb
 }

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -1155,3 +1155,5 @@ func TestCompletedWorkflow(t *testing.T) {
 		require.Nil(t, status)
 	})
 }
+
+// TODO: test aborting an Update in various states

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -1157,3 +1157,4 @@ func TestCompletedWorkflow(t *testing.T) {
 }
 
 // TODO: test aborting an Update in various states
+// TODO: test "should not be able to completed update for completed workflow"

--- a/tests/client_suite.go
+++ b/tests/client_suite.go
@@ -1224,7 +1224,7 @@ func (s *ClientFunctionalSuite) Test_ActivityTimeouts() {
 func (s *ClientFunctionalSuite) Test_BufferedSignalCausesUnhandledCommandAndSchedulesNewTask() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	tv := testvars.New(s.T().Name()).WithTaskQueue(s.taskQueue)
+	tv := testvars.New(s.T()).WithTaskQueue(s.taskQueue)
 
 	sigReadyToSendChan := make(chan struct{}, 1)
 	sigSendDoneChan := make(chan struct{})
@@ -1316,7 +1316,7 @@ func (s *ClientFunctionalSuite) Test_WorkflowCanBeCompletedDespiteAdmittedUpdate
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	tv := testvars.New(s.T().Name()).WithTaskQueue(s.taskQueue)
+	tv := testvars.New(s.T()).WithTaskQueue(s.taskQueue)
 
 	readyToSendUpdate := make(chan bool, 1)
 	updateHasBeenAdmitted := make(chan bool)

--- a/tests/reset_workflow.go
+++ b/tests/reset_workflow.go
@@ -42,6 +42,7 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
+
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/testing/protoutils"
@@ -206,7 +207,7 @@ func (s *FunctionalSuite) TestResetWorkflow() {
 func (s *FunctionalSuite) TestResetWorkflow_ExcludeNoneReapplyAll() {
 	t := resetTest{
 		FunctionalSuite:     s,
-		tv:                  testvars.New(s.T().Name()),
+		tv:                  testvars.New(s.T()),
 		reapplyExcludeTypes: []enumspb.ResetReapplyExcludeType{},
 		reapplyType:         enumspb.RESET_REAPPLY_TYPE_ALL_ELIGIBLE,
 	}
@@ -216,7 +217,7 @@ func (s *FunctionalSuite) TestResetWorkflow_ExcludeNoneReapplyAll() {
 func (s *FunctionalSuite) TestResetWorkflow_ExcludeNoneReapplySignal() {
 	t := resetTest{
 		FunctionalSuite:     s,
-		tv:                  testvars.New(s.T().Name()),
+		tv:                  testvars.New(s.T()),
 		reapplyExcludeTypes: []enumspb.ResetReapplyExcludeType{},
 		reapplyType:         enumspb.RESET_REAPPLY_TYPE_SIGNAL,
 	}
@@ -226,7 +227,7 @@ func (s *FunctionalSuite) TestResetWorkflow_ExcludeNoneReapplySignal() {
 func (s *FunctionalSuite) TestResetWorkflow_ExcludeNoneReapplyNone() {
 	t := resetTest{
 		FunctionalSuite:     s,
-		tv:                  testvars.New(s.T().Name()),
+		tv:                  testvars.New(s.T()),
 		reapplyExcludeTypes: []enumspb.ResetReapplyExcludeType{},
 		reapplyType:         enumspb.RESET_REAPPLY_TYPE_NONE,
 	}
@@ -236,7 +237,7 @@ func (s *FunctionalSuite) TestResetWorkflow_ExcludeNoneReapplyNone() {
 func (s *FunctionalSuite) TestResetWorkflow_ExcludeSignalReapplyAll() {
 	t := resetTest{
 		FunctionalSuite:     s,
-		tv:                  testvars.New(s.T().Name()),
+		tv:                  testvars.New(s.T()),
 		reapplyExcludeTypes: []enumspb.ResetReapplyExcludeType{enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
 		reapplyType:         enumspb.RESET_REAPPLY_TYPE_ALL_ELIGIBLE,
 	}
@@ -246,7 +247,7 @@ func (s *FunctionalSuite) TestResetWorkflow_ExcludeSignalReapplyAll() {
 func (s *FunctionalSuite) TestResetWorkflow_ExcludeSignalReapplySignal() {
 	t := resetTest{
 		FunctionalSuite:     s,
-		tv:                  testvars.New(s.T().Name()),
+		tv:                  testvars.New(s.T()),
 		reapplyExcludeTypes: []enumspb.ResetReapplyExcludeType{enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
 		reapplyType:         enumspb.RESET_REAPPLY_TYPE_SIGNAL,
 	}
@@ -256,7 +257,7 @@ func (s *FunctionalSuite) TestResetWorkflow_ExcludeSignalReapplySignal() {
 func (s *FunctionalSuite) TestResetWorkflow_ExcludeSignalReapplyNone() {
 	t := resetTest{
 		FunctionalSuite:     s,
-		tv:                  testvars.New(s.T().Name()),
+		tv:                  testvars.New(s.T()),
 		reapplyExcludeTypes: []enumspb.ResetReapplyExcludeType{enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
 		reapplyType:         enumspb.RESET_REAPPLY_TYPE_NONE,
 	}

--- a/tests/update_workflow.go
+++ b/tests/update_workflow.go
@@ -132,7 +132,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_AcceptCo
 
 	for _, tc := range testCases {
 		s.Run(tc.Name, func() {
-			tv := testvars.New(s.T().Name())
+			tv := testvars.New(s.T())
 
 			tv = s.startWorkflow(tv)
 			if !tc.UseRunID {
@@ -280,7 +280,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewNormalWorkflowTask_AcceptComplet
 
 	for _, tc := range testCases {
 		s.Run(tc.Name, func() {
-			tv := testvars.New(s.T().Name())
+			tv := testvars.New(s.T())
 
 			tv = s.startWorkflow(tv)
 			if !tc.UseRunID {
@@ -431,7 +431,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_Ac
 
 	for _, tc := range testCases {
 		s.Run(tc.Name, func() {
-			tv := testvars.New(s.T().Name())
+			tv := testvars.New(s.T())
 
 			tv = s.startWorkflow(tv)
 			if !tc.UseRunID {
@@ -557,7 +557,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NormalScheduledWorkflowTask_AcceptC
 
 	for _, tc := range testCases {
 		s.Run(tc.Name, func() {
-			tv := testvars.New(s.T().Name())
+			tv := testvars.New(s.T())
 
 			tv = s.startWorkflow(tv)
 			if !tc.UseRunID {
@@ -691,7 +691,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NormalScheduledWorkflowTask_AcceptC
 
 func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeFromStartedWorkflowTask_Rejected() {
 
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -808,7 +808,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeFromStartedWorkflowTa
 
 func (s *FunctionalSuite) TestUpdateWorkflow_NewNormalFromStartedWorkflowTask_Rejected() {
 
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -1232,7 +1232,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ValidateWorkerMessages() {
 
 	for _, tc := range testCases {
 		s.Run(tc.Name, func() {
-			tv := testvars.New(s.T().Name())
+			tv := testvars.New(s.T())
 
 			tv = s.startWorkflow(tv)
 
@@ -1321,7 +1321,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_Ac
 
 	for _, tc := range testCases {
 		s.Run(tc.Name, func() {
-			tv := testvars.New(s.T().Name())
+			tv := testvars.New(s.T())
 
 			tv = s.startWorkflow(tv)
 			if !tc.UseRunID {
@@ -1446,7 +1446,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_Ac
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_AcceptComplete_StickyWorkerUnavailable() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -1574,7 +1574,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_Ac
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_Reject() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -1672,7 +1672,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_Re
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_Reject() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -1788,7 +1788,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_Reject()
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_NewNormalWorkflowTask_Reject() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -1910,7 +1910,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewNormalWorkflowTask_Reject() {
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_1stAccept_2ndAccept_2ndComplete_1stComplete() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -2082,7 +2082,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_1stAccept_2ndAccept_2ndComplete_1st
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_1stAccept_2ndReject_1stComplete() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -2234,7 +2234,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_1stAccept_2ndReject_1stComplete() {
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_FailSpeculativeWorkflowTask() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -2412,7 +2412,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_FailSpeculativeWorkflowTask() {
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_ConvertStartedSpeculativeWorkflowTaskToNormal_BecauseOfBufferedSignal() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -2529,7 +2529,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ConvertStartedSpeculativeWorkflowTa
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_ConvertScheduledSpeculativeWorkflowTaskToNormal_BecauseOfSignal() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -2650,7 +2650,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ConvertScheduledSpeculativeWorkflow
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_StartToCloseTimeoutSpeculativeWorkflowTask() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           tv.Any().String(),
@@ -2790,7 +2790,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartToCloseTimeoutSpeculativeWorkf
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeWorkflowTask() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -2908,7 +2908,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeWo
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeWorkflowTask_NormalTaskQueue() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -3037,7 +3037,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeWo
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_TerminateWorkflow() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -3157,7 +3157,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Term
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_TerminateWorkflow() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -3311,7 +3311,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_CompleteWorkflow_AbortUpdates() {
 
 	for _, tc := range testCases {
 		s.Run(tc.Name, func() {
-			tv := testvars.New(s.T().Name())
+			tv := testvars.New(s.T())
 
 			tv = s.startWorkflow(tv)
 
@@ -3417,7 +3417,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_CompleteWorkflow_AbortUpdates() {
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Heartbeat() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -3547,7 +3547,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Heartbeat()
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_NewScheduledSpeculativeWorkflowTaskLost_BecauseOfShardMove() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -3675,7 +3675,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewScheduledSpeculativeWorkflowTask
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_NewStartedSpeculativeWorkflowTaskLost_BecauseOfShardMove() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -3813,7 +3813,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NewStartedSpeculativeWorkflowTaskLo
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalWorkflowTask_UpdateResurrectedAfterShardMove() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -3944,7 +3944,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalWorkflowTask_UpdateResur
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_DeduplicateID() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -4068,7 +4068,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_De
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_DeduplicateID() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -4208,7 +4208,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_CompletedSpeculativeWorkflowTask_De
 
 	for _, tc := range testCases {
 		s.Run(tc.Name, func() {
-			tv := testvars.New(s.T().Name())
+			tv := testvars.New(s.T())
 
 			tv = s.startWorkflow(tv)
 
@@ -4356,7 +4356,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_CloseS
 		The second speculative WT responds back and server completes it.
 	*/
 
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 	tv = s.startWorkflow(tv)
 
 	wtHandlerCalls := 0
@@ -4529,7 +4529,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_CloseS
 		The first speculative WT respond back, server reject it because startTime is different.
 		The second speculative WT respond back, server accept it.
 	*/
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 	tv = s.startWorkflow(tv)
 
 	wtHandlerCalls := 0
@@ -4699,7 +4699,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_ClearM
 		The second speculative WT responds back, server accepted it.
 	*/
 
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 	tv = s.startWorkflow(tv)
 
 	testCtx := NewContext()
@@ -4901,7 +4901,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_SameSt
 		The second speculative WT responds back, server reject it.
 	*/
 
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 	tv = s.startWorkflow(tv)
 
 	testCtx := NewContext()
@@ -5064,7 +5064,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_SameSt
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_WorkerSkippedProcessing_RejectByServer() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -5194,7 +5194,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_UpdateMessageInLastWFT() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]any{
 		dynamicconfig.FrontendEnableUpdateWorkflowExecutionAsyncAccepted.Key(): true,
 	}
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 	tv = s.startWorkflow(tv)
 
 	messageId := "my-message-id"
@@ -5248,7 +5248,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_UpdateMessageInLastWFT() {
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_QueryFailureClearsWFContext() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	tv = s.startWorkflow(tv)
 
@@ -5405,7 +5405,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_AdmittedUpdatesAreSentToWorkerInOrd
 	nUpdates := 20
 	s.testCluster.host.dcClient.OverrideValue(s.T(), dynamicconfig.WorkflowExecutionMaxInFlightUpdates, nUpdates)
 
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 	tv = s.startWorkflow(tv)
 	for i := 0; i < nUpdates; i++ {
 		updateId := fmt.Sprint(i)

--- a/tests/update_workflow_sdk.go
+++ b/tests/update_workflow_sdk.go
@@ -35,6 +35,7 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
+
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/testing/testvars"
 )
@@ -42,7 +43,7 @@ import (
 func (s *ClientFunctionalSuite) TestUpdateWorkflow_TerminateWorkflowAfterUpdateAdmitted() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	tv := testvars.New(s.T().Name()).WithTaskQueue(s.taskQueue).WithNamespaceName(namespace.Name(s.namespace))
+	tv := testvars.New(s.T()).WithTaskQueue(s.taskQueue).WithNamespaceName(namespace.Name(s.namespace))
 
 	activityDone := make(chan struct{})
 	activityFn := func(ctx context.Context) error {
@@ -88,7 +89,7 @@ func (s *ClientFunctionalSuite) TestUpdateWorkflow_TerminateWorkflowAfterUpdateA
 func (s *ClientFunctionalSuite) TestUpdateWorkflow_TerminateWorkflowAfterUpdateAccepted() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	tv := testvars.New(s.T().Name()).WithTaskQueue(s.taskQueue).WithNamespaceName(namespace.Name(s.namespace))
+	tv := testvars.New(s.T()).WithTaskQueue(s.taskQueue).WithNamespaceName(namespace.Name(s.namespace))
 
 	activityDone := make(chan struct{})
 	activityFn := func(ctx context.Context) error {

--- a/tests/user_metadata_test.go
+++ b/tests/user_metadata_test.go
@@ -30,6 +30,7 @@ import (
 	sdkpb "go.temporal.io/api/sdk/v1"
 	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
+
 	"go.temporal.io/server/common/testing/testvars"
 )
 
@@ -57,7 +58,7 @@ func (s *FunctionalSuite) TestUserMetadata() {
 	}
 
 	s.Run("StartWorkflowExecution records UserMetadata", func() {
-		tv := testvars.New(s.T().Name())
+		tv := testvars.New(s.T())
 		id := tv.WorkflowID("functional-user-metadata-StartWorkflowExecution")
 		metadata := prepareTestUserMetadata()
 		request := &workflowservice.StartWorkflowExecutionRequest{
@@ -79,7 +80,7 @@ func (s *FunctionalSuite) TestUserMetadata() {
 	})
 
 	s.Run("SignalWithStartWorkflowExecution records UserMetadata", func() {
-		tv := testvars.New(s.T().Name())
+		tv := testvars.New(s.T())
 		id := tv.WorkflowID("functional-user-metadata-SignalWithStartWorkflowExecution")
 		metadata := prepareTestUserMetadata()
 		request := &workflowservice.SignalWithStartWorkflowExecutionRequest{
@@ -102,7 +103,7 @@ func (s *FunctionalSuite) TestUserMetadata() {
 	})
 
 	s.Run("ExecuteMultiOperation records UserMetadata", func() {
-		tv := testvars.New(s.T().Name())
+		tv := testvars.New(s.T())
 		id := tv.WorkflowID("functional-user-metadata-ExecuteMultiOperation")
 		metadata := prepareTestUserMetadata()
 		startWorkflowRequest := &workflowservice.StartWorkflowExecutionRequest{

--- a/tests/workflow.go
+++ b/tests/workflow.go
@@ -43,9 +43,10 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/testing/testvars"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/failure"
@@ -1086,7 +1087,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 		}
 
 		s.Run("workflow is not running", func() {
-			tv := testvars.New(s.T().Name())
+			tv := testvars.New(s.T())
 
 			_, err := runUpdateWithStart(tv, startWorkflowReq(tv), updateWorkflowReq(tv))
 			s.NoError(err)
@@ -1095,7 +1096,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 		s.Run("workflow is running", func() {
 
 			s.Run("workflow id reuse policy use-existing: only send update", func() {
-				tv := testvars.New(s.T().Name())
+				tv := testvars.New(s.T())
 
 				_, err := s.engine.StartWorkflowExecution(NewContext(), startWorkflowReq(tv))
 				s.NoError(err)
@@ -1108,7 +1109,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 			})
 
 			s.Run("workflow id reuse policy terminate-existing: terminate workflow first, then start and update", func() {
-				tv := testvars.New(s.T().Name())
+				tv := testvars.New(s.T())
 
 				initReq := startWorkflowReq(tv)
 				initReq.TaskQueue.Name = initReq.TaskQueue.Name + "-init" // avoid race condition with poller
@@ -1132,7 +1133,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 			})
 
 			s.Run("workflow id reuse policy fail: abort multi operation", func() {
-				tv := testvars.New(s.T().Name())
+				tv := testvars.New(s.T())
 
 				_, err := s.engine.StartWorkflowExecution(NewContext(), startWorkflowReq(tv))
 				s.NoError(err)

--- a/tests/workflow_delete_execution.go
+++ b/tests/workflow_delete_execution.go
@@ -52,7 +52,7 @@ const (
 )
 
 func (s *FunctionalSuite) TestDeleteWorkflowExecution_CompetedWorkflow() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	const numExecutions = 5
 
@@ -196,7 +196,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_CompetedWorkflow() {
 }
 
 func (s *FunctionalSuite) TestDeleteWorkflowExecution_RunningWorkflow() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	const numExecutions = 5
 
@@ -311,7 +311,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_RunningWorkflow() {
 }
 
 func (s *FunctionalSuite) TestDeleteWorkflowExecution_JustTerminatedWorkflow() {
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 
 	const numExecutions = 3
 

--- a/tests/xdc/history_replication_signals_and_updates_test.go
+++ b/tests/xdc/history_replication_signals_and_updates_test.go
@@ -47,6 +47,9 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/workflow"
+	"go.uber.org/fx"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -59,8 +62,6 @@ import (
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/tests"
-	"go.uber.org/fx"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // This suite contains tests of scenarios in which conflicting histories arise during history replication. To do that we
@@ -173,7 +174,7 @@ func (s *hrsuTestSuite) TearDownSuite() {
 
 func (s *hrsuTestSuite) startHrsuTest() (*hrsuTest, context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
-	tv := testvars.New(s.T().Name())
+	tv := testvars.New(s.T())
 	ns := tv.NamespaceName().String()
 	t := hrsuTest{
 		tv:                        tv,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

- [x] move both stores (and their mocks) into own files
- [x] replace proto helpers with shared ones
- [x] rework Registry's Find() tests
- [x] rework Registry's HasOutgoingMessages() tests
- [x] rework Registry's FindOrCreate() tests
- [x] remove duplicate `TestStorageErrorWhenLookingUpCompletedOutcome` (already part of `Find` tests)
- [x] remove duplicate `TestUpdateRemovalFromRegistry` (already part of `FindOrCreate` tests) 
- [x] rework Registry's Send() tests
- [x] rework Registry's RejectUnprocessed() tests
- [x] add test for Registry's FailoverVersion()
- [x] add test for Registry's NewRegistry() 
- [x] remove `TestUpdateAccepted_WorkflowCompleted` (already covered) 
- [x] add test for Registry's TryResurrect()

## Why?
<!-- Tell your future self why have you made these changes -->

To make sure the update package tests are in tip top shape.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

All tests (and production code changes are purely cosmetic).

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
