### PR TITLE
Add Max retry Attempts when putting replication task to DLQ

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -794,6 +794,9 @@ func SourceShardID(shardID int32) ZapTag {
 func TargetShardID(shardID int32) ZapTag {
 	return NewInt32("xdc-target-shard-id", shardID)
 }
+func ReplicationTask(replicationTask interface{}) ZapTag {
+	return NewAnyTag("xdc-replication-task", replicationTask)
+}
 
 // PrevActiveCluster returns tag for PrevActiveCluster
 func PrevActiveCluster(prevActiveCluster string) ZapTag {

--- a/service/history/replication/executable_activity_state_task_test.go
+++ b/service/history/replication/executable_activity_state_task_test.go
@@ -318,6 +318,35 @@ func (s *executableActivityStateTaskSuite) TestMarkPoisonPill() {
 	s.NoError(err)
 }
 
+func (s *executableActivityStateTaskSuite) TestMarkPoisonPill_MaxAttemptsReached() {
+	s.task.markPoisonPillAttempts = MarkPoisonPillMaxAttempts - 1
+	shardID := rand.Int31()
+	shardContext := shard.NewMockContext(s.controller)
+	s.shardController.EXPECT().GetShardByNamespaceWorkflow(
+		namespace.ID(s.task.NamespaceID),
+		s.task.WorkflowID,
+	).Return(shardContext, nil).AnyTimes()
+	shardContext.EXPECT().GetShardID().Return(shardID).AnyTimes()
+	s.mockExecutionManager.EXPECT().PutReplicationTaskToDLQ(gomock.Any(), &persistence.PutReplicationTaskToDLQRequest{
+		ShardID:           shardID,
+		SourceClusterName: s.sourceClusterName,
+		TaskInfo: &persistencespb.ReplicationTaskInfo{
+			NamespaceId:      s.task.NamespaceID,
+			WorkflowId:       s.task.WorkflowID,
+			RunId:            s.task.RunID,
+			TaskId:           s.task.ExecutableTask.TaskID(),
+			TaskType:         enumsspb.TASK_TYPE_REPLICATION_SYNC_ACTIVITY,
+			ScheduledEventId: s.task.req.ScheduledEventId,
+			Version:          s.task.req.Version,
+		},
+	}).Return(serviceerror.NewInternal("failed"))
+
+	err := s.task.MarkPoisonPill()
+	s.Error(err)
+	err = s.task.MarkPoisonPill()
+	s.NoError(err)
+}
+
 func (s *executableActivityStateTaskSuite) TestBatchedTask_ShouldBatchTogether_AndExecute() {
 	namespaceId := uuid.NewString()
 	workflowId := uuid.NewString()

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -32,6 +32,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/service/history/shard"
 
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common/backoff"
@@ -231,6 +232,9 @@ func (e *ExecutableTaskImpl) Reschedule() {
 }
 
 func (e *ExecutableTaskImpl) IsRetryableError(err error) bool {
+	if shard.IsShardOwnershipLostError(err) {
+		return false
+	}
 	switch err.(type) {
 	case *serviceerror.InvalidArgument, *serviceerror.DataLoss:
 		return false

--- a/service/history/replication/executable_task_tracker.go
+++ b/service/history/replication/executable_task_tracker.go
@@ -38,6 +38,8 @@ import (
 
 //go:generate mockgen -copyright_file ../../../LICENSE -package $GOPACKAGE -source $GOFILE -destination executable_task_tracker_mock.go
 
+const MarkPoisonPillMaxAttempts = 3
+
 type (
 	TrackableExecutableTask interface {
 		ctasks.Task

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -49,7 +49,8 @@ type (
 
 		definition.WorkflowKey
 		ExecutableTask
-		req *historyservice.ReplicateWorkflowStateRequest
+		req                    *historyservice.ReplicateWorkflowStateRequest
+		markPoisonPillAttempts int
 	}
 )
 
@@ -85,6 +86,7 @@ func NewExecutableWorkflowStateTask(
 			WorkflowState: task.GetWorkflowState(),
 			RemoteCluster: sourceClusterName,
 		},
+		markPoisonPillAttempts: 0,
 	}
 }
 
@@ -171,6 +173,22 @@ func (e *ExecutableWorkflowStateTask) HandleErr(err error) error {
 }
 
 func (e *ExecutableWorkflowStateTask) MarkPoisonPill() error {
+	if e.markPoisonPillAttempts >= MarkPoisonPillMaxAttempts {
+		replicationTaskInfo := &persistencespb.ReplicationTaskInfo{
+			NamespaceId: e.NamespaceID,
+			WorkflowId:  e.WorkflowID,
+			RunId:       e.RunID,
+			TaskId:      e.ExecutableTask.TaskID(),
+			TaskType:    enumsspb.TASK_TYPE_REPLICATION_SYNC_WORKFLOW_STATE,
+		}
+		e.Logger.Error("MarkPoisonPill reached max attempts",
+			tag.SourceCluster(e.SourceClusterName()),
+			tag.ReplicationTask(replicationTaskInfo),
+		)
+		return nil
+	}
+	e.markPoisonPillAttempts++
+
 	shardContext, err := e.ShardController.GetShardByNamespaceWorkflow(
 		namespace.ID(e.NamespaceID),
 		e.WorkflowID,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add Max retry Attempts when putting replication task to DLQ
## Why?
<!-- Tell your future self why have you made these changes -->
When failed to put task to DLQ, the task will stay at ExecutableTaskTracker and will block the ACK level. In a extreme case where DLQ component is down, the poison pill task will stay and accumulate in ExecutableTaskTracker.
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Unit test
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Nothing
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
Yes.