### PR TITLE
Add NexusEndpointName to authorizer CallTarget

### DIFF
--- a/common/authorization/authorizer.go
+++ b/common/authorization/authorizer.go
@@ -50,6 +50,8 @@ type CallTarget struct {
 	APIName string
 	// If a Namespace is not being targeted this be set to an empty string.
 	Namespace string
+	// The nexus endpoint name being targeted (if any).
+	NexusEndpointName string
 	// Request contains a deserialized copy of the API request object
 	Request interface{}
 }

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -118,6 +118,7 @@ func (c *operationContext) interceptRequest(ctx context.Context, request *matchi
 	err := c.auth.Authorize(ctx, c.claims, &authorization.CallTarget{
 		APIName:   c.apiName,
 		Namespace: c.namespaceName,
+		NexusEndpointName: c.endpointName,
 		Request:   request,
 	})
 	if err != nil {

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -302,6 +302,9 @@ func (s *ClientFunctionalSuite) TestNexusStartOperation_Forbidden() {
 					return authorization.Result{Decision: authorization.DecisionDeny, Reason: "unauthorized in test"}, nil
 				}
 				if ct.APIName == configs.DispatchNexusTaskByEndpointAPIName {
+					if ct.NexusEndpointName != testEndpoint.Spec.Name {
+						panic("expected nexus endpoint name")
+					}
 					return authorization.Result{Decision: authorization.DecisionDeny, Reason: "unauthorized in test"}, nil
 				}
 				return authorization.Result{Decision: authorization.DecisionAllow}, nil
@@ -315,6 +318,9 @@ func (s *ClientFunctionalSuite) TestNexusStartOperation_Forbidden() {
 					return authorization.Result{Decision: authorization.DecisionDeny}, nil
 				}
 				if ct.APIName == configs.DispatchNexusTaskByEndpointAPIName {
+					if ct.NexusEndpointName != testEndpoint.Spec.Name {
+						panic("expected nexus endpoint name")
+					}
 					return authorization.Result{Decision: authorization.DecisionDeny}, nil
 				}
 				return authorization.Result{Decision: authorization.DecisionAllow}, nil
@@ -328,6 +334,9 @@ func (s *ClientFunctionalSuite) TestNexusStartOperation_Forbidden() {
 					return authorization.Result{}, errors.New("some generic error")
 				}
 				if ct.APIName == configs.DispatchNexusTaskByEndpointAPIName {
+					if ct.NexusEndpointName != testEndpoint.Spec.Name {
+						panic("expected nexus endpoint name")
+					}
 					return authorization.Result{}, errors.New("some generic error")
 				}
 				return authorization.Result{Decision: authorization.DecisionAllow}, nil


### PR DESCRIPTION
When dispatching Nexus requests, the endpoint name should be taken into consideration for auth purposes along with the namespace.