### PR TITLE
Mark HSM tree as dirty on AddChild

### DIFF
--- a/service/history/hsm/tree_test.go
+++ b/service/history/hsm/tree_test.go
@@ -117,6 +117,10 @@ func TestNode_MaintainsChildCache(t *testing.T) {
 	// Cache when a new child is added.
 	child, err := root.AddChild(key, hsmtest.NewData(hsmtest.State1))
 	require.NoError(t, err)
+
+	require.True(t, root.Dirty()) // As soon as we mutate the tree, it should be marked dirty.
+	root.ClearTransactionState()  // Reset and check later that we're dirty after applying the transition.
+
 	// Verify this doesn't panic and the backend is propagated to the new child.
 	child.AddHistoryEvent(enumspb.EVENT_TYPE_ACTIVITY_TASK_CANCELED, func(e *historypb.HistoryEvent) {})
 
@@ -129,7 +133,7 @@ func TestNode_MaintainsChildCache(t *testing.T) {
 		return hsm.TransitionOutput{}, nil
 	})
 	require.NoError(t, err)
-	require.True(t, root.Dirty())
+	require.True(t, root.Dirty()) // Should now be dirty again.
 	require.Equal(t, 1, len(root.Outputs()))
 	require.Equal(t, []hsm.Key{key}, root.Outputs()[0].Path)
 

--- a/service/history/workflow/task_refresher_test.go
+++ b/service/history/workflow/task_refresher_test.go
@@ -116,6 +116,8 @@ func (s *taskRefresherSuite) TestRefreshSubStateMachineTasks() {
 	s.NoError(err)
 	_, err = hsmRoot.AddChild(hsm.Key{Type: stateMachineDef.Type().ID, ID: "child_2"}, hsmtest.NewData(hsmtest.State3))
 	s.NoError(err)
+	// Clear the dirty flag so we can test it later.
+	hsmRoot.ClearTransactionState()
 
 	err = s.taskRefresher.refreshTasksForSubStateMachines(s.mutableState)
 	s.NoError(err)


### PR DESCRIPTION
Previously on transitions marked the tree as dirty.
This was okay because we never added a child without immediately transitioning but was technically incorrect.