### PR TITLE
Fix go-generate - provide goimports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -581,7 +581,7 @@ update-dependencies:
 	@go get -u -t $(PINNED_DEPENDENCIES) ./...
 	@go mod tidy
 
-go-generate: $(MOCKGEN)
+go-generate: $(MOCKGEN) $(GOIMPORTS)
 	@printf $(COLOR) "Process go:generate directives..."
 	@go generate ./...
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add goimports to go-generate in makefile
## Why?
<!-- Tell your future self why have you made these changes -->
$(GOIMPORTS) needs to be a dependency of go-generate, otherwise make go-generate fails.


## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
run it. make sure mocks are generated

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
N/A

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No