### PR TITLE
Workflow Update: always use speculative workflow task for updates from RespondWorkflowTaskCompleted handler

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -429,26 +429,26 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 			wtFailedShouldCreateNewTask ||
 			bufferedEventShouldCreateNewTask ||
 			activityNotStartedCancelled {
+
 			newWorkflowTaskType = enumsspb.WORKFLOW_TASK_TYPE_NORMAL
 
+		} else if updateRegistry.HasOutgoingMessages(true) {
 			// There shouldn't be any sent updates in the registry because
 			// all sent but not processed updates were rejected by server.
 			// Therefore, it doesn't matter if to includeAlreadySent or not.
-		} else if updateRegistry.HasOutgoingMessages(true) {
-			if completedEvent == nil || ms.GetNextEventID() == completedEvent.GetEventId()+1 {
-				newWorkflowTaskType = enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE
-			} else {
-				newWorkflowTaskType = enumsspb.WORKFLOW_TASK_TYPE_NORMAL
-			}
+
+			newWorkflowTaskType = enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE
 		}
 	}
 
 	bypassTaskGeneration := request.GetReturnNewWorkflowTask() && wtFailedCause == nil
-	// TODO (alex-update): Need to support case when ReturnNewWorkflowTask=false and WT.Type=Speculative.
-	// In this case WT needs to be added directly to matching.
-	// Current implementation will create normal WT.
+	// TODO (alex-update): All current SDKs always set ReturnNewWorkflowTask to true
+	//  which means that server always bypass task generation if WFT didn't fail.
+	//  ReturnNewWorkflowTask flag needs to be removed.
+
 	if newWorkflowTaskType == enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE && !bypassTaskGeneration {
-		// If task generation can't be bypassed workflow task must be of Normal type because Speculative workflow task always skip task generation.
+		// If task generation can't be bypassed (i.e. WFT has failed),
+		// WFT must be created as Normal because speculative WFT by nature skips task generation.
 		newWorkflowTaskType = enumsspb.WORKFLOW_TASK_TYPE_NORMAL
 	}
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Always use speculative workflow task for updates from `RespondWorkflowTaskCompleted` handler.

## Why?
<!-- Tell your future self why have you made these changes -->
Follow up to #5921.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks (see #5921).

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.