### PR TITLE
Fix interrupting poll on partition unload

### DIFF
--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -228,6 +228,7 @@ func (c *physicalTaskQueueManagerImpl) Stop() {
 		return
 	}
 	c.backlogMgr.Stop()
+	c.matcher.Stop()
 	c.liveness.Stop()
 	c.logger.Info("", tag.LifeCycleStopped)
 	c.taggedMetricsHandler.Counter(metrics.TaskQueueStoppedCounter.Name()).Record(1)


### PR DESCRIPTION
## What changed?
Restore behavior added in #5345, that got lost in merging.

## Why?
See #5345 

## How did you test it?
added unit test
