### PR TITLE
Allow more numeric types in dynamic config

### DIFF
--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -220,17 +220,43 @@ func precedenceTaskType(taskType enumsspb.TaskType) []Constraints {
 }
 
 func convertInt(val any) (int, error) {
-	if intVal, ok := val.(int); ok {
-		return intVal, nil
+	switch val := val.(type) {
+	case int:
+		return int(val), nil
+	case int8:
+		return int(val), nil
+	case int16:
+		return int(val), nil
+	case int32:
+		return int(val), nil
+	case int64:
+		return int(val), nil
+	case uint:
+		return int(val), nil
+	case uint8:
+		return int(val), nil
+	case uint16:
+		return int(val), nil
+	case uint32:
+		return int(val), nil
+	case uint64:
+		return int(val), nil
+	case uintptr:
+		return int(val), nil
+	default:
+		return 0, errors.New("value type is not int")
 	}
-	return 0, errors.New("value type is not int")
 }
 
 func convertFloat(val any) (float64, error) {
-	if floatVal, ok := val.(float64); ok {
-		return floatVal, nil
-	} else if intVal, ok := val.(int); ok {
-		return float64(intVal), nil
+	switch val := val.(type) {
+	case float32:
+		return float64(val), nil
+	case float64:
+		return float64(val), nil
+	}
+	if ival, err := convertInt(val); err == nil {
+		return float64(ival), nil
 	}
 	return 0, errors.New("value type is not float64")
 }
@@ -239,15 +265,18 @@ func convertDuration(val any) (time.Duration, error) {
 	switch v := val.(type) {
 	case time.Duration:
 		return v, nil
-	case int:
-		// treat plain int as seconds
-		return time.Duration(v) * time.Second, nil
 	case string:
 		d, err := timestamp.ParseDurationDefaultSeconds(v)
 		if err != nil {
 			return 0, fmt.Errorf("failed to parse duration: %v", err)
 		}
 		return d, nil
+	}
+	// treat numeric values as seconds
+	if ival, err := convertInt(val); err == nil {
+		return time.Duration(ival) * time.Second, nil
+	} else if fval, err := convertFloat(val); err == nil {
+		return time.Duration(fval * float64(time.Second)), nil
 	}
 	return 0, errors.New("value not convertible to Duration")
 }

--- a/common/dynamicconfig/collection_test.go
+++ b/common/dynamicconfig/collection_test.go
@@ -86,6 +86,8 @@ func (s *collectionSuite) TestGetIntProperty() {
 	s.Equal(10, value())
 	s.client[testGetIntPropertyKey] = 50
 	s.Equal(50, value())
+	s.client[testGetIntPropertyKey] = uint32(50000)
+	s.Equal(50000, value())
 }
 
 func (s *collectionSuite) TestGetIntPropertyFilteredByNamespace() {
@@ -128,9 +130,11 @@ func (s *collectionSuite) TestGetIntPropertyFilteredByTaskQueueInfo() {
 func (s *collectionSuite) TestGetFloat64Property() {
 	setting := dynamicconfig.NewGlobalFloatSetting(testGetFloat64PropertyKey, 0.1, "")
 	value := setting.Get(s.cln)
-	s.Equal(0.1, value())
+	s.InEpsilon(0.1, value(), 1e-10)
 	s.client[testGetFloat64PropertyKey] = 0.01
-	s.Equal(0.01, value())
+	s.InEpsilon(0.01, value(), 1e-10)
+	s.client[testGetFloat64PropertyKey] = int64(123456789)
+	s.InEpsilon(float64(123456789), value(), 1e-10)
 }
 
 func (s *collectionSuite) TestGetBoolProperty() {
@@ -168,8 +172,14 @@ func (s *collectionSuite) TestGetDurationProperty() {
 	s.Equal(time.Minute, value())
 	s.client[testGetDurationPropertyKey] = 33
 	s.Equal(33*time.Second, value())
+	s.client[testGetDurationPropertyKey] = int16(33)
+	s.Equal(33*time.Second, value())
 	s.client[testGetDurationPropertyKey] = "33"
 	s.Equal(33*time.Second, value())
+	s.client[testGetDurationPropertyKey] = "33h"
+	s.Equal(33*time.Hour, value())
+	s.client[testGetDurationPropertyKey] = float32(33.5)
+	s.Equal(33*time.Second+500*time.Millisecond, value())
 }
 
 func (s *collectionSuite) TestGetDurationPropertyFilteredByNamespace() {


### PR DESCRIPTION
## What changed?
Convert more numerical types in dynamic config.

## Why?
Types besides `int` and `float64` generally won't show up using the default yaml-based dynamic config client, but other clients (e.g. static clients for test or dev server) might use different concrete types.

## How did you test it?
Added a few more unit tests

## Potential risks
This may make some configurations work where they didn't work before, but shouldn't change the behavior of any working configuration.