### PR TITLE
Change runner image to ubuntu-20.04

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest]
+        runs-on: [ubuntu-20.04]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest]
+        runs-on: [ubuntu-20.04]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: ScribeMD/docker-cache@0.3.7
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest]
+        runs-on: [ubuntu-20.04]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest]
+        runs-on: [ubuntu-20.04]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: ScribeMD/docker-cache@0.3.7
@@ -133,7 +133,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest]
+        runs-on: [ubuntu-20.04]
         name: [cass_es, cass_es8, sqlite, mysql8, postgres12, postgres12_pgx]
         shard_index: [0, 1, 2]
         include:
@@ -202,7 +202,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest]
+        runs-on: [ubuntu-20.04]
         name: [cass_es]
 #        name: [cass_es, cass_es8, mysql8, postgres12, postgres12_pgx]
         include:
@@ -265,7 +265,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest]
+        runs-on: [ubuntu-20.04]
         name: [cass_es, cass_es8, mysql8, postgres12, postgres12_pgx]
         include:
           - name: cass_es
@@ -329,7 +329,7 @@ jobs:
       - functional-test
       - functional-test-xdc
       - functional-test-ndc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: always()
     env:
       RESULTS: ${{ toJSON(needs.*.result) }}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Downgrading Github `All Tests` actions to use `ubuntu-20.04` instead of `ubuntu-latest`

## Why?
<!-- Tell your future self why have you made these changes -->
It seems we started hitting an issue with Github's action runners. These errors seem to appear most often when runners are killed because they are using too much CPU or memory, but we have been unable to conclusively say what might have caused an increase in resource usage.

Downgrading the ubuntu version worked for others and seems to be working for us.

For more info:
* https://github.com/actions/runner-images/issues/6709
* https://github.com/actions/runner-images/discussions/7188
* Users reported a similar issue with ubuntu-24.04 runners (not yet GA): https://github.com/actions/runner-images/issues/9848

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Reran all PR check jobs several times

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
