### PR TITLE
Remove deprecated advancedVisibilityStore config key

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -244,9 +244,6 @@ type (
 		VisibilityStore string `yaml:"visibilityStore"`
 		// SecondaryVisibilityStore is the name of the secondary datastore to be used for visibility records
 		SecondaryVisibilityStore string `yaml:"secondaryVisibilityStore"`
-		// DEPRECATED: use VisibilityStore key instead of AdvancedVisibilityStore
-		// AdvancedVisibilityStore is the name of the datastore to be used for visibility records
-		AdvancedVisibilityStore string `yaml:"advancedVisibilityStore"`
 		// NumHistoryShards is the desired number of history shards. This config doesn't
 		// belong here, needs refactoring
 		NumHistoryShards int32 `yaml:"numHistoryShards" validate:"nonzero"`

--- a/common/config/persistence.go
+++ b/common/config/persistence.go
@@ -58,51 +58,27 @@ func (c *Persistence) Validate() error {
 	if c.SecondaryVisibilityStore != "" {
 		stores = append(stores, c.SecondaryVisibilityStore)
 	}
-	if c.AdvancedVisibilityStore != "" {
-		stores = append(stores, c.AdvancedVisibilityStore)
-	}
 
 	// There are 3 config keys:
 	// - visibilityStore: can set any data store
 	// - secondaryVisibilityStore: can set any data store
-	// - advancedVisibilityStore: can only set elasticsearch data store
 	// If visibilityStore is set, then it's always the primary.
 	// If secondaryVisibilityStore is set, it's always the secondary.
 	//
 	// Valid dual visibility combinations (order: primary, secondary):
 	// - visibilityStore (advanced sql),  secondaryVisibilityStore (advanced sql)
 	// - visibilityStore (es),            visibilityStore (es) [via elasticsearch.indices config]
-	// - advancedVisibilityStore (es),    advancedVisibilityStore (es) [via elasticsearch.indices config]
 	//
 	// Invalid dual visibility combinations:
-	// - visibilityStore (advanced sql),  secondaryVisibilityStore (standard, es)
-	// - visibilityStore (advanced sql),  advancedVisibilityStore (es)
+	// - visibilityStore (advanced sql),  secondaryVisibilityStore (es)
 	// - visibilityStore (es),            secondaryVisibilityStore (any)
-	// - visibilityStore (es),            advancedVisibilityStore (es)
-	// - advancedVisibilityStore (es),    secondaryVisibilityStore (any)
-	//
-	// The validation for dual visibility pair (advanced sql, advanced sql) is in visibility factory
-	// due to circular dependency. This will be better after standard visibility is removed.
 
-	if c.VisibilityStore == "" && c.AdvancedVisibilityStore == "" {
+	if c.VisibilityStore == "" {
 		return errors.New("persistence config: visibilityStore must be specified")
 	}
-	if c.SecondaryVisibilityStore != "" && c.AdvancedVisibilityStore != "" {
+	if c.DataStores[c.VisibilityStore].Elasticsearch != nil && c.SecondaryVisibilityStore != "" {
 		return errors.New(
-			"persistence config: cannot specify both secondaryVisibilityStore and " +
-				"advancedVisibilityStore",
-		)
-	}
-	if c.AdvancedVisibilityStore != "" && c.DataStores[c.AdvancedVisibilityStore].Elasticsearch == nil {
-		return fmt.Errorf(
-			"persistence config: advanced visibility datastore %q: missing elasticsearch config",
-			c.AdvancedVisibilityStore,
-		)
-	}
-	if c.DataStores[c.VisibilityStore].Elasticsearch != nil &&
-		(c.SecondaryVisibilityStore != "" || c.AdvancedVisibilityStore != "") {
-		return errors.New(
-			"persistence config: cannot set secondaryVisibilityStore or advancedVisibilityStore " +
+			"persistence config: cannot set secondaryVisibilityStore " +
 				"when visibilityStore is setting elasticsearch datastore",
 		)
 	}
@@ -149,25 +125,13 @@ func (c *Persistence) SecondaryVisibilityConfigExist() bool {
 	return c.SecondaryVisibilityStore != ""
 }
 
-// AdvancedVisibilityConfigExist returns whether user specified advancedVisibilityStore in config
-func (c *Persistence) AdvancedVisibilityConfigExist() bool {
-	return c.AdvancedVisibilityStore != ""
-}
-
 func (c *Persistence) IsSQLVisibilityStore() bool {
 	return (c.VisibilityConfigExist() && c.DataStores[c.VisibilityStore].SQL != nil) ||
 		(c.SecondaryVisibilityConfigExist() && c.DataStores[c.SecondaryVisibilityStore].SQL != nil)
 }
 
 func (c *Persistence) GetVisibilityStoreConfig() DataStore {
-	if c.VisibilityStore != "" {
-		return c.DataStores[c.VisibilityStore]
-	}
-	if c.AdvancedVisibilityStore != "" {
-		return c.DataStores[c.AdvancedVisibilityStore]
-	}
-	// Based on validation above, this should never happen.
-	return DataStore{}
+	return c.DataStores[c.VisibilityStore]
 }
 
 func (c *Persistence) GetSecondaryVisibilityStoreConfig() DataStore {
@@ -175,21 +139,7 @@ func (c *Persistence) GetSecondaryVisibilityStoreConfig() DataStore {
 		return c.DataStores[c.SecondaryVisibilityStore]
 	}
 	if c.VisibilityStore != "" {
-		if c.AdvancedVisibilityStore != "" {
-			return c.DataStores[c.AdvancedVisibilityStore]
-		}
 		ds := c.DataStores[c.VisibilityStore]
-		if ds.Elasticsearch != nil && ds.Elasticsearch.GetSecondaryVisibilityIndex() != "" {
-			esConfig := *ds.Elasticsearch
-			esConfig.Indices = map[string]string{
-				client.VisibilityAppName: ds.Elasticsearch.GetSecondaryVisibilityIndex(),
-			}
-			ds.Elasticsearch = &esConfig
-			return ds
-		}
-	}
-	if c.AdvancedVisibilityStore != "" {
-		ds := c.DataStores[c.AdvancedVisibilityStore]
 		if ds.Elasticsearch != nil && ds.Elasticsearch.GetSecondaryVisibilityIndex() != "" {
 			esConfig := *ds.Elasticsearch
 			esConfig.Indices = map[string]string{

--- a/common/persistence/visibility/factory.go
+++ b/common/persistence/visibility/factory.go
@@ -30,9 +30,6 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"
-	"go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql"
-	"go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/persistence/visibility/store"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
@@ -118,21 +115,6 @@ func NewManager(
 	}
 
 	if secondaryVisibilityManager != nil {
-		isPrimaryAdvancedSQL := false
-		isSecondaryAdvancedSQL := false
-		switch visibilityManager.GetStoreNames()[0] {
-		case mysql.PluginName, postgresql.PluginName, postgresql.PluginNamePGX, sqlite.PluginName:
-			isPrimaryAdvancedSQL = true
-		}
-		switch secondaryVisibilityManager.GetStoreNames()[0] {
-		case mysql.PluginName, postgresql.PluginName, postgresql.PluginNamePGX, sqlite.PluginName:
-			isSecondaryAdvancedSQL = true
-		}
-		if isPrimaryAdvancedSQL && !isSecondaryAdvancedSQL {
-			logger.Fatal("invalid config: dual visibility combination not supported")
-			return nil, nil
-		}
-
 		managerSelector := newDefaultManagerSelector(
 			visibilityManager,
 			secondaryVisibilityManager,

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -252,8 +252,6 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 	} else if persistenceConfig.SecondaryVisibilityConfigExist() &&
 		persistenceConfig.DataStores[persistenceConfig.SecondaryVisibilityStore].Elasticsearch != nil {
 		esConfig = persistenceConfig.DataStores[persistenceConfig.SecondaryVisibilityStore].Elasticsearch
-	} else if persistenceConfig.AdvancedVisibilityConfigExist() {
-		esConfig = persistenceConfig.DataStores[persistenceConfig.AdvancedVisibilityStore].Elasticsearch
 	}
 
 	if esConfig != nil {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Remove deprecated `advancedVisibilityStore` config key.
Undoing the PR https://github.com/temporalio/temporal/pull/5549.

## Why?
<!-- Tell your future self why have you made these changes -->
It's deprecated, and replaced with `secondaryVisibilityStore`.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
