### PR TITLE
Disambiguate metrics for getting vs polling workflow execution history

### DIFF
--- a/common/api/metadata.go
+++ b/common/api/metadata.go
@@ -67,6 +67,7 @@ const (
 const (
 	WorkflowServicePrefix = "/temporal.api.workflowservice.v1.WorkflowService/"
 	OperatorServicePrefix = "/temporal.api.operatorservice.v1.OperatorService/"
+	HistoryServicePrefix  = "/temporal.server.api.historyservice.v1.HistoryService/"
 	AdminServicePrefix    = "/temporal.server.api.adminservice.v1.AdminService/"
 	// Technically not a gRPC service, but still using this format for metadata.
 	NexusServicePrefix = "/temporal.api.nexusservice.v1.NexusService/"

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -343,6 +343,10 @@ const (
 	HistoryRespondActivityTaskFailedScope = "RespondActivityTaskFailed"
 	// HistoryRespondActivityTaskCanceledScope tracks RespondActivityTaskCanceled API calls received by service
 	HistoryRespondActivityTaskCanceledScope = "RespondActivityTaskCanceled"
+	// HistoryGetWorkflowExecutionHistoryScope is the metric scope for non-long-poll frontend.GetWorkflowExecutionHistory
+	HistoryGetWorkflowExecutionHistoryScope = "GetWorkflowExecutionHistory"
+	// HistoryPollWorkflowExecutionHistoryScope is the metric scope for long poll case of frontend.GetWorkflowExecutionHistory
+	HistoryPollWorkflowExecutionHistoryScope = "PollWorkflowExecutionHistory"
 	// HistoryGetWorkflowExecutionRawHistoryScope tracks GetWorkflowExecutionRawHistoryV2Scope API calls received by service
 	HistoryGetWorkflowExecutionRawHistoryScope = "GetWorkflowExecutionRawHistory"
 	// HistoryGetWorkflowExecutionRawHistoryV2Scope tracks GetWorkflowExecutionRawHistoryV2Scope API calls received by service

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -146,6 +146,11 @@ func (ti *TelemetryInterceptor) unaryOverrideOperationTag(fullName, operation st
 			if request.GetWaitNewEvent() {
 				return metrics.FrontendPollWorkflowExecutionHistoryScope
 			}
+		} else if operation == metrics.HistoryGetWorkflowExecutionHistoryScope {
+			request := req.(*workflowservice.GetWorkflowExecutionHistoryRequest)
+			if request.GetWaitNewEvent() {
+				return metrics.HistoryPollWorkflowExecutionHistoryScope
+			}
 		}
 		return operation
 	}

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -143,9 +143,10 @@ func (ti *TelemetryInterceptor) unaryOverrideOperationTag(fullName, operation st
 		// Current plan is to eventually split GetWorkflowExecutionHistory into two APIs,
 		// remove this "if" case when that is done.
 		if operation == metrics.FrontendGetWorkflowExecutionHistoryScope {
-			request := req.(*workflowservice.GetWorkflowExecutionHistoryRequest)
-			if request.GetWaitNewEvent() {
-				return metrics.FrontendPollWorkflowExecutionHistoryScope
+			if request, ok := req.(*workflowservice.GetWorkflowExecutionHistoryRequest); ok {
+				if request.GetWaitNewEvent() {
+					return metrics.FrontendPollWorkflowExecutionHistoryScope
+				}
 			}
 		}
 		return operation
@@ -154,9 +155,10 @@ func (ti *TelemetryInterceptor) unaryOverrideOperationTag(fullName, operation st
 		// Current plan is to eventually split GetWorkflowExecutionHistory into two APIs,
 		// remove this "if" case when that is done.
 		if operation == metrics.HistoryGetWorkflowExecutionHistoryScope {
-			request := req.(*historyservice.GetWorkflowExecutionHistoryRequest)
-			if r := request.GetRequest(); r != nil && r.GetWaitNewEvent() {
-				return metrics.HistoryPollWorkflowExecutionHistoryScope
+			if request, ok := req.(*historyservice.GetWorkflowExecutionHistoryRequest); ok {
+				if r := request.GetRequest(); r != nil && r.GetWaitNewEvent() {
+					return metrics.HistoryPollWorkflowExecutionHistoryScope
+				}
 			}
 		}
 	}

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -39,6 +39,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/api"
 	"go.temporal.io/server/common/log"
@@ -146,13 +147,18 @@ func (ti *TelemetryInterceptor) unaryOverrideOperationTag(fullName, operation st
 			if request.GetWaitNewEvent() {
 				return metrics.FrontendPollWorkflowExecutionHistoryScope
 			}
-		} else if operation == metrics.HistoryGetWorkflowExecutionHistoryScope {
-			request := req.(*workflowservice.GetWorkflowExecutionHistoryRequest)
-			if request.GetWaitNewEvent() {
+		}
+		return operation
+	} else if strings.HasPrefix(fullName, api.HistoryServicePrefix) {
+		// GetWorkflowExecutionHistory method handles both long poll and regular calls.
+		// Current plan is to eventually split GetWorkflowExecutionHistory into two APIs,
+		// remove this "if" case when that is done.
+		if operation == metrics.HistoryGetWorkflowExecutionHistoryScope {
+			request := req.(*historyservice.GetWorkflowExecutionHistoryRequest)
+			if r := request.GetRequest(); r != nil && r.GetWaitNewEvent() {
 				return metrics.HistoryPollWorkflowExecutionHistoryScope
 			}
 		}
-		return operation
 	}
 	return ti.overrideOperationTag(fullName, operation)
 }

--- a/common/rpc/interceptor/telemetry_test.go
+++ b/common/rpc/interceptor/telemetry_test.go
@@ -27,12 +27,18 @@ package interceptor
 import (
 	"testing"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+
 	commonpb "go.temporal.io/api/common/v1"
 	protocolpb "go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+
+	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/api"
@@ -40,8 +46,6 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const (
@@ -301,6 +305,83 @@ func TestGetWorkflowTags(t *testing.T) {
 			if len(tt.runID) > 0 {
 				assert.Contains(t, tags, tag.WorkflowRunID(tt.runID))
 			}
+		})
+	}
+}
+
+func TestOperationOverride(t *testing.T) {
+	controller := gomock.NewController(t)
+	register := namespace.NewMockRegistry(controller)
+	metricsHandler := metrics.NewMockHandler(controller)
+	telemetry := NewTelemetryInterceptor(register, metricsHandler, log.NewNoopLogger())
+
+	wid := "test_workflow_id"
+	rid := "test_run_id"
+
+	testCases := []struct {
+		methodName        string
+		fullName          string
+		req               interface{}
+		expectedOperation string
+	}{
+		{
+			"GetWorkflowExecutionHistory",
+			api.WorkflowServicePrefix + "GetWorkflowExecutionHistory",
+			&workflowservice.GetWorkflowExecutionHistoryRequest{
+				Execution: &commonpb.WorkflowExecution{
+					WorkflowId: wid,
+					RunId:      rid,
+				},
+				WaitNewEvent: false,
+			},
+			"GetWorkflowExecutionHistory",
+		},
+		{
+			"GetWorkflowExecutionHistory",
+			api.WorkflowServicePrefix + "GetWorkflowExecutionHistory",
+			&workflowservice.GetWorkflowExecutionHistoryRequest{
+				Execution: &commonpb.WorkflowExecution{
+					WorkflowId: wid,
+					RunId:      rid,
+				},
+				WaitNewEvent: true,
+			},
+			"PollWorkflowExecutionHistory",
+		},
+		{
+			"GetWorkflowExecutionHistory",
+			api.HistoryServicePrefix + "GetWorkflowExecutionHistory",
+			&historyservice.GetWorkflowExecutionHistoryRequest{
+				Request: &workflowservice.GetWorkflowExecutionHistoryRequest{
+					Execution: &commonpb.WorkflowExecution{
+						WorkflowId: wid,
+						RunId:      rid,
+					},
+					WaitNewEvent: false,
+				},
+			},
+			"GetWorkflowExecutionHistory",
+		},
+		{
+			"GetWorkflowExecutionHistory",
+			api.HistoryServicePrefix + "GetWorkflowExecutionHistory",
+			&historyservice.GetWorkflowExecutionHistoryRequest{
+				Request: &workflowservice.GetWorkflowExecutionHistoryRequest{
+					Execution: &commonpb.WorkflowExecution{
+						WorkflowId: wid,
+						RunId:      rid,
+					},
+					WaitNewEvent: true,
+				},
+			},
+			"PollWorkflowExecutionHistory",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.methodName, func(t *testing.T) {
+			operation := telemetry.unaryOverrideOperationTag(tt.fullName, tt.methodName, tt.req)
+			assert.Equal(t, tt.expectedOperation, operation)
 		})
 	}
 }


### PR DESCRIPTION
## Why?
Polling for workflow execution history has significantly longer latency. Splitting the metrics for the bimodal behavior reflects latency metrics more accurately.