### PR TITLE
Do not emit replication lag metrics for low priority tasks

### DIFF
--- a/service/history/replication/executable_activity_state_task.go
+++ b/service/history/replication/executable_activity_state_task.go
@@ -67,6 +67,7 @@ func NewExecutableActivityStateTask(
 	taskCreationTime time.Time,
 	task *replicationspb.SyncActivityTaskAttributes,
 	sourceClusterName string,
+	priority enumsspb.TaskPriority,
 ) *ExecutableActivityStateTask {
 	return &ExecutableActivityStateTask{
 		ProcessToolBox: processToolBox,
@@ -79,6 +80,7 @@ func NewExecutableActivityStateTask(
 			taskCreationTime,
 			time.Now().UTC(),
 			sourceClusterName,
+			priority,
 		),
 		req: &historyservice.SyncActivityRequest{
 			NamespaceId:                task.NamespaceId,

--- a/service/history/replication/executable_activity_state_task_test.go
+++ b/service/history/replication/executable_activity_state_task_test.go
@@ -145,6 +145,7 @@ func (s *executableActivityStateTaskSuite) SetupTest() {
 		time.Unix(0, rand.Int63()),
 		s.replicationTask,
 		s.sourceClusterName,
+		enumsspb.TASK_PRIORITY_HIGH,
 	)
 	s.task.ExecutableTask = s.executableTask
 	s.executableTask.EXPECT().TaskID().Return(s.taskID).AnyTimes()
@@ -372,6 +373,7 @@ func (s *executableActivityStateTaskSuite) TestBatchedTask_ShouldBatchTogether_A
 		time.Unix(0, rand.Int63()),
 		replicationAttribute1,
 		s.sourceClusterName,
+		enumsspb.TASK_PRIORITY_HIGH,
 	)
 	task1.ExecutableTask = s.executableTask
 
@@ -392,6 +394,7 @@ func (s *executableActivityStateTaskSuite) TestBatchedTask_ShouldBatchTogether_A
 		time.Unix(0, rand.Int63()),
 		replicationAttribute2,
 		s.sourceClusterName,
+		enumsspb.TASK_PRIORITY_HIGH,
 	)
 	task2.ExecutableTask = s.executableTask
 
@@ -444,6 +447,7 @@ func (s *executableActivityStateTaskSuite) TestBatchWith_InvalidBatchTask_Should
 		time.Unix(0, rand.Int63()),
 		replicationAttribute1,
 		s.sourceClusterName,
+		enumsspb.TASK_PRIORITY_HIGH,
 	)
 
 	replicationAttribute2 := s.generateReplicationAttribute(namespaceId, "wf_2", runId) //
@@ -463,6 +467,7 @@ func (s *executableActivityStateTaskSuite) TestBatchWith_InvalidBatchTask_Should
 		time.Unix(0, rand.Int63()),
 		replicationAttribute2,
 		s.sourceClusterName,
+		enumsspb.TASK_PRIORITY_HIGH,
 	)
 	batchResult, batched := task1.BatchWith(task2)
 	s.False(batched)

--- a/service/history/replication/executable_history_task.go
+++ b/service/history/replication/executable_history_task.go
@@ -83,6 +83,7 @@ func NewExecutableHistoryTask(
 	taskCreationTime time.Time,
 	task *replicationspb.HistoryTaskAttributes,
 	sourceClusterName string,
+	priority enumsspb.TaskPriority,
 ) *ExecutableHistoryTask {
 	return &ExecutableHistoryTask{
 		ProcessToolBox: processToolBox,
@@ -95,6 +96,7 @@ func NewExecutableHistoryTask(
 			taskCreationTime,
 			time.Now().UTC(),
 			sourceClusterName,
+			priority,
 		),
 
 		baseExecutionInfo:      task.BaseExecutionInfo,

--- a/service/history/replication/executable_history_task_test.go
+++ b/service/history/replication/executable_history_task_test.go
@@ -167,6 +167,7 @@ func (s *executableHistoryTaskSuite) SetupTest() {
 		time.Unix(0, rand.Int63()),
 		s.replicationTask,
 		s.sourceClusterName,
+		enumsspb.TASK_PRIORITY_HIGH,
 	)
 	s.task.ExecutableTask = s.executableTask
 	s.executableTask.EXPECT().TaskID().Return(s.taskID).AnyTimes()
@@ -581,6 +582,7 @@ func (s *executableHistoryTaskSuite) buildExecutableHistoryTask(
 		time.Unix(0, rand.Int63()),
 		replicationTaskAttribute,
 		sourceCluster,
+		enumsspb.TASK_PRIORITY_HIGH,
 	)
 	executableHistoryTask.ExecutableTask = executableTask
 	return executableHistoryTask

--- a/service/history/replication/executable_noop_task.go
+++ b/service/history/replication/executable_noop_task.go
@@ -27,6 +27,7 @@ package replication
 import (
 	"time"
 
+	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/metrics"
 	ctasks "go.temporal.io/server/common/tasks"
 )
@@ -58,6 +59,7 @@ func NewExecutableNoopTask(
 			taskCreationTime,
 			time.Now().UTC(),
 			sourceClusterName,
+			enumsspb.TASK_PRIORITY_UNSPECIFIED,
 		),
 	}
 }

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -32,6 +32,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
+	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/service/history/shard"
 
 	"go.temporal.io/server/api/historyservice/v1"
@@ -108,6 +109,7 @@ type (
 		taskCreationTime  time.Time
 		taskReceivedTime  time.Time
 		sourceClusterName string
+		taskPriority      enumsspb.TaskPriority
 
 		// mutable data
 		taskState int32
@@ -123,6 +125,7 @@ func NewExecutableTask(
 	taskCreationTime time.Time,
 	taskReceivedTime time.Time,
 	sourceClusterName string,
+	priority enumsspb.TaskPriority,
 ) *ExecutableTaskImpl {
 	return &ExecutableTaskImpl{
 		ProcessToolBox:    processToolBox,
@@ -131,6 +134,7 @@ func NewExecutableTask(
 		taskCreationTime:  taskCreationTime,
 		taskReceivedTime:  taskReceivedTime,
 		sourceClusterName: sourceClusterName,
+		taskPriority:      priority,
 
 		taskState: taskStatePending,
 		attempt:   1,
@@ -273,16 +277,19 @@ func (e *ExecutableTaskImpl) emitFinishMetrics(
 		metrics.OperationTag(e.metricsTag),
 		nsTag,
 	)
-	metrics.ReplicationLatency.With(e.MetricsHandler).Record(
-		now.Sub(e.taskCreationTime),
-		metrics.OperationTag(e.metricsTag),
-		nsTag,
-	)
-	metrics.ReplicationTaskTransmissionLatency.With(e.MetricsHandler).Record(
-		e.taskReceivedTime.Sub(e.taskCreationTime),
-		metrics.OperationTag(e.metricsTag),
-		nsTag,
-	)
+	// replication lag is only meaningful for non-low priority tasks as for low priority task, we may delay processing
+	if e.taskPriority != enumsspb.TASK_PRIORITY_LOW {
+		metrics.ReplicationLatency.With(e.MetricsHandler).Record(
+			now.Sub(e.taskCreationTime),
+			metrics.OperationTag(e.metricsTag),
+			nsTag,
+		)
+		metrics.ReplicationTaskTransmissionLatency.With(e.MetricsHandler).Record(
+			e.taskReceivedTime.Sub(e.taskCreationTime),
+			metrics.OperationTag(e.metricsTag),
+			nsTag,
+		)
+	}
 	// TODO consider emit attempt metrics
 }
 

--- a/service/history/replication/executable_task_converter.go
+++ b/service/history/replication/executable_task_converter.go
@@ -108,6 +108,7 @@ func (e *executableTaskConverterImpl) convertOne(
 			taskCreationTime,
 			replicationTask.GetSyncActivityTaskAttributes(),
 			taskClusterName,
+			replicationTask.GetPriority(),
 		)
 	case enumsspb.REPLICATION_TASK_TYPE_SYNC_WORKFLOW_STATE_TASK:
 		return NewExecutableWorkflowStateTask(
@@ -116,6 +117,7 @@ func (e *executableTaskConverterImpl) convertOne(
 			taskCreationTime,
 			replicationTask.GetSyncWorkflowStateTaskAttributes(),
 			taskClusterName,
+			replicationTask.GetPriority(),
 		)
 	case enumsspb.REPLICATION_TASK_TYPE_HISTORY_V2_TASK:
 		return NewExecutableHistoryTask(
@@ -124,6 +126,7 @@ func (e *executableTaskConverterImpl) convertOne(
 			taskCreationTime,
 			replicationTask.GetHistoryTaskAttributes(),
 			taskClusterName,
+			replicationTask.GetPriority(),
 		)
 	default:
 		e.processToolBox.Logger.Error(fmt.Sprintf("unknown replication task: %v", replicationTask))

--- a/service/history/replication/executable_task_test.go
+++ b/service/history/replication/executable_task_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
+	enumsspb "go.temporal.io/server/api/enums/v1"
 
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/service/history/configs"
@@ -126,6 +127,7 @@ func (s *executableTaskSuite) SetupTest() {
 		creationTime,
 		receivedTime,
 		s.sourceCluster,
+		enumsspb.TASK_PRIORITY_UNSPECIFIED,
 	)
 }
 

--- a/service/history/replication/executable_unknown_task.go
+++ b/service/history/replication/executable_unknown_task.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"go.temporal.io/api/serviceerror"
+	enumsspb "go.temporal.io/server/api/enums/v1"
 
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -67,6 +68,7 @@ func NewExecutableUnknownTask(
 			taskCreationTime,
 			time.Now().UTC(),
 			"sourceCluster",
+			enumsspb.TASK_PRIORITY_UNSPECIFIED,
 		),
 		task: task,
 	}

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -65,6 +65,7 @@ func NewExecutableWorkflowStateTask(
 	taskCreationTime time.Time,
 	task *replicationspb.SyncWorkflowStateTaskAttributes,
 	sourceClusterName string,
+	priority enumsspb.TaskPriority,
 ) *ExecutableWorkflowStateTask {
 	namespaceID := task.GetWorkflowState().ExecutionInfo.NamespaceId
 	workflowID := task.GetWorkflowState().ExecutionInfo.WorkflowId
@@ -80,6 +81,7 @@ func NewExecutableWorkflowStateTask(
 			taskCreationTime,
 			time.Now().UTC(),
 			sourceClusterName,
+			priority,
 		),
 		req: &historyservice.ReplicateWorkflowStateRequest{
 			NamespaceId:   namespaceID,

--- a/service/history/replication/executable_workflow_state_task_test.go
+++ b/service/history/replication/executable_workflow_state_task_test.go
@@ -136,6 +136,7 @@ func (s *executableWorkflowStateTaskSuite) SetupTest() {
 		time.Unix(0, rand.Int63()),
 		s.replicationTask,
 		s.sourceClusterName,
+		enumsspb.TASK_PRIORITY_HIGH,
 	)
 	s.task.ExecutableTask = s.executableTask
 	s.executableTask.EXPECT().TaskID().Return(s.taskID).AnyTimes()


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Do not emit replication lag metrics for low priority tasks
## Why?
<!-- Tell your future self why have you made these changes -->
Low priority tasks processing maybe delayed, we should not emit replication lag metrics as it will create some unnecessary noise.
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test.
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
nothing.
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.