### PR TITLE
Support having secondary visibility store through `secondaryVisibilityStore` config key

### DIFF
--- a/common/config/persistence.go
+++ b/common/config/persistence.go
@@ -41,7 +41,7 @@ const (
 	StoreTypeNoSQL = "nosql"
 )
 
-var ErrPersistenceConfig = errors.New("persistence config")
+var ErrPersistenceConfig = errors.New("persistence config error")
 
 // DefaultStoreType returns the storeType for the default persistence store
 func (c *Persistence) DefaultStoreType() string {
@@ -101,15 +101,17 @@ func (c *Persistence) Validate() error {
 		}
 		// ElasticSearch config for visibilityStore and secondaryVisibilityStore must be the same except for
 		// `indices.visibility` config key and private fields - this is a restriction due to global ES client
-		esConfig := *c.DataStores[c.VisibilityStore].Elasticsearch
-		secEsConfig := *c.DataStores[c.SecondaryVisibilityStore].Elasticsearch
-		esConfig.Indices = nil
-		secEsConfig.Indices = nil
-		if !reflect.DeepEqual(esConfig, secEsConfig) {
-			return fmt.Errorf(
-				"%w: config mismatch for visibilityStore and secondaryVisibilityStore",
-				ErrPersistenceConfig,
-			)
+		if isPrimaryEs && isSecondaryEs {
+			esConfig := *c.DataStores[c.VisibilityStore].Elasticsearch
+			secEsConfig := *c.DataStores[c.SecondaryVisibilityStore].Elasticsearch
+			esConfig.Indices = nil
+			secEsConfig.Indices = nil
+			if !reflect.DeepEqual(esConfig, secEsConfig) {
+				return fmt.Errorf(
+					"%w: config mismatch for visibilityStore and secondaryVisibilityStore",
+					ErrPersistenceConfig,
+				)
+			}
 		}
 	}
 

--- a/common/config/persistence.go
+++ b/common/config/persistence.go
@@ -99,9 +99,9 @@ func (c *Persistence) Validate() error {
 				ErrPersistenceConfig,
 				c.SecondaryVisibilityStore)
 		}
-		// ElasticSearch config for visibilityStore and secondaryVisibilityStore must be the same except for
-		// `indices.visibility` config key and private fields - this is a restriction due to global ES client
 		if isPrimaryEs && isSecondaryEs {
+			// ElasticSearch config for visibilityStore and secondaryVisibilityStore must be the same except for
+			// `indices.visibility` config key and private fields - this is a restriction due to global ES client
 			esConfig := *c.DataStores[c.VisibilityStore].Elasticsearch
 			secEsConfig := *c.DataStores[c.SecondaryVisibilityStore].Elasticsearch
 			esConfig.Indices = nil


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- modified persistence validation to support having secondary visibility store through `secondaryVisibilityStore` config key
- user can set dual ES visibility via 
   1. the existing indices.secondary_visibility key (backwards compatibility); or
   2. using the secondaryVisibilityStore and setting another data store config
- restrictions:
    - they must be mutually exclusive
    - ES config must be same except for `indices.visibility` in case of using secondaryVisibilityStore config (this is because we still have the global ES client)

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
