### PR TITLE
fix panic during cluster-b start

### DIFF
--- a/common/cluster/frontend_http_client.go
+++ b/common/cluster/frontend_http_client.go
@@ -117,7 +117,7 @@ func (c *FrontendHTTPClientCache) evictionCallback(oldClusterMetadata map[string
 		}
 
 		newClusterInfo, exists := newClusterMetadata[oldClusterName]
-		if !exists || oldClusterInfo.HTTPAddress != newClusterInfo.HTTPAddress {
+		if !exists || newClusterInfo == nil || oldClusterInfo.HTTPAddress != newClusterInfo.HTTPAddress {
 			// Cluster was removed or had its HTTP address changed, so invalidate the cached client for that cluster.
 			client, ok := c.clients.Pop(oldClusterName)
 			if ok {


### PR DESCRIPTION
## What changed?
Fix panic during cluster-b start

## Why?
Should check nil pointer.

```
./temporal-server --env development-cluster-b --allow-no-auth start

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x104e3cd68]

goroutine 553 [running]:
go.temporal.io/server/common/cluster.(*FrontendHTTPClientCache).evictionCallback(0x140008a76e0, 0x14000b455e8?, 0x14000dae120)
	/Users/hai/dev/github.com/temporalio/temporal/common/cluster/frontend_http_client.go:120 +0xe8
go.temporal.io/server/common/cluster.(*metadataImpl).refreshClusterMetadata(0x14000b831e0, {0x106d2b1a0?, 0x14000944ba0?})
	/Users/hai/dev/github.com/temporalio/temporal/common/cluster/metadata.go:484 +0x79c
go.temporal.io/server/common/cluster.(*metadataImpl).Start(0x14000b831e0)
	/Users/hai/dev/github.com/temporalio/temporal/common/cluster/metadata.go:237 +0x234
go.temporal.io/server/common/cluster.MetadataLifetimeHooks.func1({0x106768180?, 0x106d05f80?})
	/Users/hai/dev/github.com/temporalio/temporal/common/cluster/fx.go:51 +0x28
go.uber.org/fx/internal/lifecycle.(*Lifecycle).runStartHook(0x14000b6c1c0, {0x106d2b248, 0x140008e0d20}, {0x14000ac9da0, 0x14000ac9db8, {0x0, 0x0}, {0x0, 0x0}, {{0x14000a31d00, ...}, ...}})
	/Users/hai/go/pkg/mod/go.uber.org/fx@v1.22.0/internal/lifecycle/lifecycle.go:256 +0x1b8
go.uber.org/fx/internal/lifecycle.(*Lifecycle).Start(0x14000b6c1c0, {0x106d2b248, 0x140008e0d20})
	/Users/hai/go/pkg/mod/go.uber.org/fx@v1.22.0/internal/lifecycle/lifecycle.go:216 +0x474
go.uber.org/fx.(*App).start-fm.(*App).start.func1({0x106d2b248, 0x140008e0d20})
	/Users/hai/go/pkg/mod/go.uber.org/fx@v1.22.0/app.go:704 +0x40
go.uber.org/fx.(*App).withRollback(0x140006e44b0, {0x106d2b248, 0x140008e0d20}, 0x0?)
	/Users/hai/go/pkg/mod/go.uber.org/fx@v1.22.0/app.go:686 +0x38
go.uber.org/fx.(*App).start(...)
	/Users/hai/go/pkg/mod/go.uber.org/fx@v1.22.0/app.go:703
go.uber.org/fx.withTimeout.func1()
	/Users/hai/go/pkg/mod/go.uber.org/fx@v1.22.0/app.go:802 +0x74
created by go.uber.org/fx.withTimeout in goroutine 315
	/Users/hai/go/pkg/mod/go.uber.org/fx@v1.22.0/app.go:790 +0xa4
make: *** [start-xdc-cluster-b] Error 2
```

## How did you test it?
Start cluster-b locally and verify no panic

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
