### PR TITLE
Changed unit test to now use InDelta instead of InEpsilon

### DIFF
--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -325,18 +325,19 @@ func (t *MatcherTestSuite) TestBacklogAge() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 
 	go t.rootMatcher.MustOffer(ctx, youngBacklogTask, intruptC) //nolint:errcheck
+
 	time.Sleep(time.Millisecond)
-	t.InEpsilon(t.rootMatcher.getBacklogAge(), time.Second, float64(10*time.Millisecond))
+	t.InDelta(t.rootMatcher.getBacklogAge(), time.Second, float64(10*time.Millisecond))
 
 	// offering the same task twice to make sure of correct counting
 	go t.rootMatcher.MustOffer(ctx, youngBacklogTask, intruptC) //nolint:errcheck
 	time.Sleep(time.Millisecond)
-	t.InEpsilon(t.rootMatcher.getBacklogAge(), time.Second, float64(10*time.Millisecond))
+	t.InDelta(t.rootMatcher.getBacklogAge(), time.Second, float64(10*time.Millisecond))
 
 	oldBacklogTask := newInternalTaskFromBacklog(randomTaskInfoWithAge(time.Minute), nil)
 	go t.rootMatcher.MustOffer(ctx, oldBacklogTask, intruptC) //nolint:errcheck
 	time.Sleep(time.Millisecond)
-	t.InEpsilon(t.rootMatcher.getBacklogAge(), time.Minute, float64(10*time.Millisecond))
+	t.InDelta(t.rootMatcher.getBacklogAge(), time.Minute, float64(10*time.Millisecond))
 
 	task, _ := t.rootMatcher.Poll(ctx, &pollMetadata{})
 	time.Sleep(time.Millisecond)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- `matcher_test.go` consisted of a test which intended on checking if the actual value of the backlog age differs from the expected by a delta 
- However, the test was using `InEpsilon` instead of `InDelta`. This fixes that.

## Why?
<!-- Tell your future self why have you made these changes -->
- For correct functionality.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- None


## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
