### PR TITLE
Fix root workflow execution fields in SQL visibility

### DIFF
--- a/common/persistence/sql/sqlplugin/visibility.go
+++ b/common/persistence/sql/sqlplugin/visibility.go
@@ -71,8 +71,8 @@ type (
 		SearchAttributes     *VisibilitySearchAttributes
 		ParentWorkflowID     *string
 		ParentRunID          *string
-		RootWorkflowID       string
-		RootRunID            string
+		RootWorkflowID       *string
+		RootRunID            *string
 	}
 
 	// VisibilitySelectFilter contains the column names within executions_visibility table that

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -391,8 +391,8 @@ func (s *VisibilityStore) generateVisibilityRow(
 		SearchAttributes: searchAttributes,
 		ParentWorkflowID: request.ParentWorkflowID,
 		ParentRunID:      request.ParentRunID,
-		RootWorkflowID:   request.RootWorkflowID,
-		RootRunID:        request.RootRunID,
+		RootWorkflowID:   &request.RootWorkflowID,
+		RootRunID:        &request.RootRunID,
 	}, nil
 }
 
@@ -459,8 +459,6 @@ func (s *VisibilityStore) rowToInfo(
 		ExecutionTime:  row.ExecutionTime,
 		Status:         enumspb.WorkflowExecutionStatus(row.Status),
 		TaskQueue:      row.TaskQueue,
-		RootWorkflowID: row.RootWorkflowID,
-		RootRunID:      row.RootRunID,
 		Memo:           persistence.NewDataBlob(row.Memo, row.Encoding),
 	}
 	if row.SearchAttributes != nil && len(*row.SearchAttributes) > 0 {
@@ -490,6 +488,12 @@ func (s *VisibilityStore) rowToInfo(
 	}
 	if row.ParentRunID != nil {
 		info.ParentRunID = *row.ParentRunID
+	}
+	if row.RootWorkflowID != nil {
+		info.RootWorkflowID = *row.RootWorkflowID
+	}
+	if row.RootRunID != nil {
+		info.RootRunID = *row.RootRunID
 	}
 	return info, nil
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix root workflow execution fields in SQL visibility

## Why?
<!-- Tell your future self why have you made these changes -->
The schema set the root workflow fields as nullable, but the code was assuming to be not null.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Start Temporal v1.23.1, create some workflows, update the schemas in v1.24.0, upgrade Temporal v1.24.0:
- reproduced the error
- applied this fix, and the error was gone.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
