### PR TITLE
Fix SQL visibility root workflow fields in schema

### DIFF
--- a/schema/mysql/v8/version.go
+++ b/schema/mysql/v8/version.go
@@ -30,4 +30,4 @@ package v8
 const Version = "1.12"
 
 // VisibilityVersion is the MySQL visibility database release version
-const VisibilityVersion = "1.5"
+const VisibilityVersion = "1.6"

--- a/schema/mysql/v8/visibility/schema.sql
+++ b/schema/mysql/v8/visibility/schema.sql
@@ -17,8 +17,8 @@ CREATE TABLE executions_visibility (
   search_attributes       JSON          NULL,
   parent_workflow_id      VARCHAR(255)  NULL,
   parent_run_id           VARCHAR(255)  NULL,
-  root_workflow_id        VARCHAR(255)  NULL,
-  root_run_id             VARCHAR(255)  NULL,
+  root_workflow_id        VARCHAR(255)  NOT NULL DEFAULT '',
+  root_run_id             VARCHAR(255)  NOT NULL DEFAULT '',
 
   -- Each search attribute has its own generated column.
   -- For string types (keyword and text), we need to unquote the json string,

--- a/schema/mysql/v8/visibility/versioned/v1.6/fix_root_workflow_info.sql
+++ b/schema/mysql/v8/visibility/versioned/v1.6/fix_root_workflow_info.sql
@@ -1,0 +1,9 @@
+DROP INDEX by_root_workflow_id    ON executions_visibility;
+DROP INDEX by_root_run_id         ON executions_visibility;
+ALTER TABLE executions_visibility DROP COLUMN root_workflow_id;
+ALTER TABLE executions_visibility DROP COLUMN root_run_id;
+
+ALTER TABLE executions_visibility ADD COLUMN root_workflow_id VARCHAR(255) NOT NULL DEFAULT '';
+ALTER TABLE executions_visibility ADD COLUMN root_run_id      VARCHAR(255) NOT NULL DEFAULT '';
+CREATE INDEX by_root_workflow_id  ON executions_visibility (namespace_id, root_workflow_id, (COALESCE(close_time, CAST('9999-12-31 23:59:59' AS DATETIME))) DESC, start_time DESC, run_id);
+CREATE INDEX by_root_run_id       ON executions_visibility (namespace_id, root_run_id,      (COALESCE(close_time, CAST('9999-12-31 23:59:59' AS DATETIME))) DESC, start_time DESC, run_id);

--- a/schema/mysql/v8/visibility/versioned/v1.6/manifest.json
+++ b/schema/mysql/v8/visibility/versioned/v1.6/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.6",
+  "MinCompatibleVersion": "0.1",
+  "Description": "fix root workflow info columns",
+  "SchemaUpdateCqlFiles": [
+    "fix_root_workflow_info.sql"
+  ]
+}

--- a/schema/postgresql/v12/version.go
+++ b/schema/postgresql/v12/version.go
@@ -32,4 +32,4 @@ const Version = "1.12"
 
 // VisibilityVersion is the Postgres visibility database release version
 // Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres
-const VisibilityVersion = "1.5"
+const VisibilityVersion = "1.6"

--- a/schema/postgresql/v12/visibility/schema.sql
+++ b/schema/postgresql/v12/visibility/schema.sql
@@ -26,8 +26,8 @@ CREATE TABLE executions_visibility (
   search_attributes       JSONB         NULL,
   parent_workflow_id      VARCHAR(255)  NULL,
   parent_run_id           VARCHAR(255)  NULL,
-  root_workflow_id        VARCHAR(255)  NULL,
-  root_run_id             VARCHAR(255)  NULL,
+  root_workflow_id        VARCHAR(255)  NOT NULL DEFAULT '',
+  root_run_id             VARCHAR(255)  NOT NULL DEFAULT '',
 
   -- Each search attribute has its own generated column.
   -- Since PostgreSQL doesn't support virtual columns, all columns are stored.

--- a/schema/postgresql/v12/visibility/versioned/v1.6/fix_root_workflow_info.sql
+++ b/schema/postgresql/v12/visibility/versioned/v1.6/fix_root_workflow_info.sql
@@ -1,0 +1,9 @@
+DROP INDEX by_root_workflow_id;
+DROP INDEX by_root_run_id;
+ALTER TABLE executions_visibility DROP COLUMN root_workflow_id;
+ALTER TABLE executions_visibility DROP COLUMN root_run_id;
+
+ALTER TABLE executions_visibility ADD COLUMN root_workflow_id VARCHAR(255) NOT NULL DEFAULT '';
+ALTER TABLE executions_visibility ADD COLUMN root_run_id      VARCHAR(255) NOT NULL DEFAULT '';
+CREATE INDEX by_root_workflow_id  ON executions_visibility (namespace_id, root_workflow_id, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_root_run_id       ON executions_visibility (namespace_id, root_run_id,      (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);

--- a/schema/postgresql/v12/visibility/versioned/v1.6/manifest.json
+++ b/schema/postgresql/v12/visibility/versioned/v1.6/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.6",
+  "MinCompatibleVersion": "0.1",
+  "Description": "fix root workflow info columns",
+  "SchemaUpdateCqlFiles": [
+    "fix_root_workflow_info.sql"
+  ]
+}

--- a/schema/sqlite/v3/visibility/schema.sql
+++ b/schema/sqlite/v3/visibility/schema.sql
@@ -17,8 +17,8 @@ CREATE TABLE executions_visibility (
   search_attributes       TEXT          NULL,
   parent_workflow_id      VARCHAR(255)  NULL,
   parent_run_id           VARCHAR(255)  NULL,
-  root_workflow_id        VARCHAR(255)  NULL,
-  root_run_id             VARCHAR(255)  NULL,
+  root_workflow_id        VARCHAR(255)  NOT NULL DEFAULT '',
+  root_run_id             VARCHAR(255)  NOT NULL DEFAULT '',
 
   -- Predefined search attributes
   TemporalChangeVersion         TEXT          GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalChangeVersion")) STORED,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix SQL visibility root workflow fields in schema: they are supposed to be not null.

## Why?
<!-- Tell your future self why have you made these changes -->
The schema set the root workflow fields as nullable, but the code was assuming to be not null.
GH Issue: https://github.com/temporalio/temporal/issues/6050

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Start Temporal v1.23.1, create some workflows, update the schemas in v1.24.0, upgrade Temporal v1.24.0:
- reproduced the error
- applied this fix, and the error was gone.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
