### PR TITLE
When querying workflows during backoff, check if query can wait

### DIFF
--- a/common/testing/testvars/test_vars.go
+++ b/common/testing/testvars/test_vars.go
@@ -279,6 +279,14 @@ func (tv *TestVars) WithTimerID(timerID string, key ...string) *TestVars {
 	return tv.cloneSet("timer_id", key, timerID)
 }
 
+func (tv *TestVars) QueryType(key ...string) string {
+	return tv.getOrCreate("query_type", key).(string)
+}
+
+func (tv *TestVars) WithQueryType(queryTypeID string, key ...string) *TestVars {
+	return tv.cloneSet("query_type", key, queryTypeID)
+}
+
 // ----------- Generic methods ------------
 
 func (tv *TestVars) InfiniteTimeout() *durationpb.Duration {

--- a/service/history/api/queryworkflow/api.go
+++ b/service/history/api/queryworkflow/api.go
@@ -262,7 +262,8 @@ func queryWillTimeoutsBeforeTaskStart(
 	workflowTaskStart := workflowStart.Add(workflowTaskBackoffDuration)
 
 	deadline, _ := ctx.Deadline()
-	if workflowTaskStart.After(deadline.UTC()) {
+	deadline = deadline.UTC()
+	if workflowTaskStart.After(deadline) {
 		return true, nil
 	}
 	return false, nil

--- a/service/history/api/queryworkflow/api.go
+++ b/service/history/api/queryworkflow/api.go
@@ -124,9 +124,16 @@ func Invoke(
 	}
 
 	if !mutableState.HadOrHasWorkflowTask() {
-		// workflow has no workflow task ever scheduled, this usually is due to firstWorkflowTaskBackoff (cron / retry)
-		// in this case, don't buffer the query, because it is almost certain the query will time out.
-		return nil, consts.ErrWorkflowTaskNotScheduled
+		// Workflow has no workflow task scheduled.
+		// This can be due to firstWorkflowTaskBackoff (cron / retry)
+		// In this case, check if query can wait.
+		queryWillTimeout, err := queryWillTimeoutsBeforeTaskStart(ctx, shardContext, mutableState)
+		if err != nil {
+			return nil, err
+		}
+		if queryWillTimeout {
+			return nil, consts.ErrWorkflowTaskNotScheduled
+		}
 	}
 
 	if mutableState.GetExecutionInfo().WorkflowTaskAttempt >= failQueryWorkflowTaskAttemptCount {
@@ -239,6 +246,26 @@ func Invoke(
 		metrics.ConsistentQueryTimeoutCount.With(scope).Record(1)
 		return nil, ctx.Err()
 	}
+}
+
+func queryWillTimeoutsBeforeTaskStart(
+	ctx context.Context, shardContext shard.Context, mutableState workflow.MutableState,
+) (bool, error) {
+	startEvent, err := mutableState.GetStartEvent(ctx)
+	if err != nil {
+		return false, err
+	}
+	startAttr := startEvent.GetWorkflowExecutionStartedEventAttributes()
+	workflowTaskBackoffDuration := timestamp.DurationValue(startAttr.GetFirstWorkflowTaskBackoff())
+
+	workflowStart := mutableState.GetExecutionInfo().StartTime.AsTime().UTC()
+	workflowTaskStart := workflowStart.Add(workflowTaskBackoffDuration)
+
+	deadline, _ := ctx.Deadline()
+	if workflowTaskStart.After(deadline.UTC()) {
+		return true, nil
+	}
+	return false, nil
 }
 
 func queryDirectlyThroughMatching(

--- a/tests/query_workflow.go
+++ b/tests/query_workflow.go
@@ -170,8 +170,8 @@ func (s *ClientFunctionalSuite) TestQueryWorkflow_QueryWhileBackoff() {
 		testname       string
 	}{
 		{
-			contextTimeout: time.Duration(10) * time.Second,
-			startDelay:     time.Duration(5) * time.Second,
+			contextTimeout: 10 * time.Second,
+			startDelay:     5 * time.Second,
 			expectError:    false,
 			workflowFn:     workflowFnFail,
 			testname:       testnameFail,

--- a/tests/query_workflow.go
+++ b/tests/query_workflow.go
@@ -145,7 +145,7 @@ func (s *ClientFunctionalSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 	s.Equal("pauseabc", queryResultStr)
 }
 
-func (s *ClientFunctionalSuite) queryWorkflow_QueryWhileBackoff(contextTimeout int, retryTimeout int, expectError bool) {
+func (s *ClientFunctionalSuite) queryWorkflow_QueryWhileBackoff(contextTimeout int, expectError bool) {
 	testname := s.T().Name()
 	workflowFn := func(ctx workflow.Context) (string, error) {
 		workflow.SetQueryHandler(ctx, testname, func() (string, error) {
@@ -162,7 +162,7 @@ func (s *ClientFunctionalSuite) queryWorkflow_QueryWhileBackoff(contextTimeout i
 		TaskQueue:          s.taskQueue,
 		WorkflowRunTimeout: 20 * time.Second,
 		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval: time.Duration(retryTimeout) * time.Second,
+			InitialInterval: 4 * time.Second,
 		},
 	}
 
@@ -210,16 +210,14 @@ func (s *ClientFunctionalSuite) queryWorkflow_QueryWhileBackoff(contextTimeout i
 
 func (s *ClientFunctionalSuite) TestQueryWorkflow_QueryWhileBackoff_Pass() {
 	contextTimeout := 5
-	retryTimeout := 4
 	expectError := false
-	s.queryWorkflow_QueryWhileBackoff(contextTimeout, retryTimeout, expectError)
+	s.queryWorkflow_QueryWhileBackoff(contextTimeout, expectError)
 }
 
 func (s *ClientFunctionalSuite) TestQueryWorkflow_QueryWhileBackoff_Fail() {
 	contextTimeout := 2
-	retryTimeout := 4
 	expectError := true
-	s.queryWorkflow_QueryWhileBackoff(contextTimeout, retryTimeout, expectError)
+	s.queryWorkflow_QueryWhileBackoff(contextTimeout, expectError)
 }
 
 func (s *ClientFunctionalSuite) TestQueryWorkflow_QueryBeforeStart() {

--- a/tests/query_workflow.go
+++ b/tests/query_workflow.go
@@ -150,13 +150,13 @@ func (s *ClientFunctionalSuite) TestQueryWorkflow_QueryWhileBackoff() {
 	testnamePass := "backoff_query_pass"
 
 	workflowFnFail := func(ctx workflow.Context) (string, error) {
-		workflow.SetQueryHandler(ctx, testnameFail, func() (string, error) {
+		_ = workflow.SetQueryHandler(ctx, testnameFail, func() (string, error) {
 			return "should-reach-here", nil
 		})
 		return "", nil
 	}
 	workflowFnPass := func(ctx workflow.Context) (string, error) {
-		workflow.SetQueryHandler(ctx, testnamePass, func() (string, error) {
+		_ = workflow.SetQueryHandler(ctx, testnamePass, func() (string, error) {
 			return "should-reach-here", nil
 		})
 		return "", nil

--- a/tests/query_workflow.go
+++ b/tests/query_workflow.go
@@ -162,7 +162,7 @@ func (s *ClientFunctionalSuite) queryWorkflow_QueryWhileBackoff(contextTimeout i
 		TaskQueue:          s.taskQueue,
 		WorkflowRunTimeout: 20 * time.Second,
 		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval: 4 * time.Second,
+			InitialInterval: 10 * time.Second,
 		},
 	}
 
@@ -187,7 +187,7 @@ func (s *ClientFunctionalSuite) queryWorkflow_QueryWhileBackoff(contextTimeout i
 		})
 		if len(historyEvents) == 1 {
 			s.EqualHistoryEvents(`
-  1 WorkflowExecutionStarted {"FirstWorkflowTaskBackoff":{"Seconds":4}}`, historyEvents)
+  1 WorkflowExecutionStarted {"FirstWorkflowTaskBackoff":{"Seconds":10}}`, historyEvents)
 			findBackoffWorkflow = true
 			break
 		}
@@ -209,13 +209,13 @@ func (s *ClientFunctionalSuite) queryWorkflow_QueryWhileBackoff(contextTimeout i
 }
 
 func (s *ClientFunctionalSuite) TestQueryWorkflow_QueryWhileBackoff_Pass() {
-	contextTimeout := 5
+	contextTimeout := 30
 	expectError := false
 	s.queryWorkflow_QueryWhileBackoff(contextTimeout, expectError)
 }
 
 func (s *ClientFunctionalSuite) TestQueryWorkflow_QueryWhileBackoff_Fail() {
-	contextTimeout := 2
+	contextTimeout := 9
 	expectError := true
 	s.queryWorkflow_QueryWhileBackoff(contextTimeout, expectError)
 }

--- a/tests/query_workflow.go
+++ b/tests/query_workflow.go
@@ -186,47 +186,35 @@ func (s *ClientFunctionalSuite) TestQueryWorkflow_QueryWhileBackoff() {
 	}
 
 	for _, tc := range testCases {
-		s.testQueryWorkflow_QueryWhileBackoff(
-			tc.contextTimeout, tc.startDelay, tc.expectError, tc.workflowFn, tc.testname,
-		)
-	}
-}
+		s.worker.RegisterWorkflow(tc.workflowFn)
 
-func (s *ClientFunctionalSuite) testQueryWorkflow_QueryWhileBackoff(
-	contextTimeout time.Duration,
-	startDelay time.Duration,
-	expectError bool,
-	workflowFn any,
-	testname string,
-) {
-	s.worker.RegisterWorkflow(workflowFn)
+		id := fmt.Sprintf("test-query-before-backoff-%s", tc.testname)
+		workflowOptions := sdkclient.StartWorkflowOptions{
+			ID:         id,
+			TaskQueue:  s.taskQueue,
+			StartDelay: tc.startDelay,
+		}
 
-	id := fmt.Sprintf("test-query-before-backoff-%s", testname)
-	workflowOptions := sdkclient.StartWorkflowOptions{
-		ID:         id,
-		TaskQueue:  s.taskQueue,
-		StartDelay: startDelay,
-	}
+		//  context timeout is not going to be the provided timeout.
+		// It is going to be timeout / 2. See newGRPCContext implementation.
+		ctx, cancel := context.WithTimeout(context.Background(), 2*tc.contextTimeout)
+		defer cancel()
+		workflowRun, err := s.sdkClient.ExecuteWorkflow(ctx, workflowOptions, tc.workflowFn)
+		if err != nil {
+			s.Logger.Fatal("Start workflow failed with err", tag.Error(err))
+		}
 
-	//  context timeout is not going to be the provided timeout.
-	// It is going to be timeout / 2. See newGRPCContext implementation.
-	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout*2)
-	defer cancel()
-	workflowRun, err := s.sdkClient.ExecuteWorkflow(ctx, workflowOptions, workflowFn)
-	if err != nil {
-		s.Logger.Fatal("Start workflow failed with err", tag.Error(err))
-	}
+		s.NotNil(workflowRun)
+		s.True(workflowRun.GetRunID() != "")
 
-	s.NotNil(workflowRun)
-	s.True(workflowRun.GetRunID() != "")
+		_, err = s.sdkClient.QueryWorkflow(ctx, id, "", tc.testname)
 
-	_, err = s.sdkClient.QueryWorkflow(ctx, id, "", testname)
-
-	if expectError {
-		s.Error(err)
-		s.ErrorContains(err, consts.ErrWorkflowTaskNotScheduled.Error())
-	} else {
-		s.NoError(err)
+		if tc.expectError {
+			s.Error(err)
+			s.ErrorContains(err, consts.ErrWorkflowTaskNotScheduled.Error())
+		} else {
+			s.NoError(err)
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed?
Before: if there was not workflow task scheduled just fail.
After: check if query will actually time out while waiting, and if it will not - wait.

## Why?
To reduce avoidable failures. 
Query shouldn't fail if it can wait until successful conditions will be met.

## How did you test it?
Extend existing functional test to cover both situations.

## Potential risks
N/A

## Documentation
N/A

## Is hotfix candidate?
No