### PR TITLE
Refactor hsm CheckRunning

### DIFF
--- a/components/scheduler/executors.go
+++ b/components/scheduler/executors.go
@@ -57,7 +57,7 @@ func (e activeExecutor) executeScheduleTask(
 	node *hsm.Node,
 	task ScheduleTask,
 ) error {
-	if err := node.CheckParentIsRunning(); err != nil {
+	if err := node.CheckRunning(); err != nil {
 		return err
 	}
 	// TODO(Tianyu): Perform scheduler logic before scheduling self again


### PR DESCRIPTION
## What changed?

Renamed and refactored `Node.CheckIsParentRunning` to `CheckRunning`.

## Why?

Leaks a bit less details about state machine being embedded in a workflow. This same check will later also be used to validate run state for top level machines.