### PR TITLE
Remove deprecated metrics from history service commands

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -796,45 +796,15 @@ var (
 		"pending_tasks",
 		WithDescription("A histogram across history shards for the number of in-memory pending history tasks."),
 	)
-	TaskSchedulerThrottled      = NewCounterDef("task_scheduler_throttled")
-	QueueScheduleLatency        = NewTimerDef("queue_latency_schedule") // latency for scheduling 100 tasks in one task channel
-	QueueReaderCountHistogram   = NewDimensionlessHistogramDef("queue_reader_count")
-	QueueSliceCountHistogram    = NewDimensionlessHistogramDef("queue_slice_count")
-	QueueActionCounter          = NewCounterDef("queue_actions")
-	ActivityE2ELatency          = NewTimerDef("activity_end_to_end_latency")
-	AckLevelUpdateCounter       = NewCounterDef("ack_level_update")
-	AckLevelUpdateFailedCounter = NewCounterDef("ack_level_update_failed")
-	CommandCounter              = NewCounterDef("command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeScheduleActivityCounter = NewCounterDef("schedule_activity_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeCompleteWorkflowCounter = NewCounterDef("complete_workflow_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeFailWorkflowCounter = NewCounterDef("fail_workflow_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeCancelWorkflowCounter = NewCounterDef("cancel_workflow_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeStartTimerCounter = NewCounterDef("start_timer_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeCancelActivityCounter = NewCounterDef("cancel_activity_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeCancelTimerCounter = NewCounterDef("cancel_timer_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeRecordMarkerCounter = NewCounterDef("record_marker_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeCancelExternalWorkflowCounter = NewCounterDef("cancel_external_workflow_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeContinueAsNewCounter = NewCounterDef("continue_as_new_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeSignalExternalWorkflowCounter = NewCounterDef("signal_external_workflow_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeUpsertWorkflowSearchAttributesCounter = NewCounterDef("upsert_workflow_search_attributes_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeModifyWorkflowPropertiesCounter = NewCounterDef("modify_workflow_properties_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeChildWorkflowCounter = NewCounterDef("child_workflow_command")
-	// Deprecated: replaced by CommandCounter and will be removed in a future release
-	CommandTypeProtocolMessage                           = NewCounterDef("protocol_message_command")
+	TaskSchedulerThrottled                               = NewCounterDef("task_scheduler_throttled")
+	QueueScheduleLatency                                 = NewTimerDef("queue_latency_schedule") // latency for scheduling 100 tasks in one task channel
+	QueueReaderCountHistogram                            = NewDimensionlessHistogramDef("queue_reader_count")
+	QueueSliceCountHistogram                             = NewDimensionlessHistogramDef("queue_slice_count")
+	QueueActionCounter                                   = NewCounterDef("queue_actions")
+	ActivityE2ELatency                                   = NewTimerDef("activity_end_to_end_latency")
+	AckLevelUpdateCounter                                = NewCounterDef("ack_level_update")
+	AckLevelUpdateFailedCounter                          = NewCounterDef("ack_level_update_failed")
+	CommandCounter                                       = NewCounterDef("command")
 	MessageTypeRequestWorkflowExecutionUpdateCounter     = NewCounterDef("request_workflow_update_message")
 	MessageTypeAcceptWorkflowExecutionUpdateCounter      = NewCounterDef("accept_workflow_update_message")
 	MessageTypeRespondWorkflowExecutionUpdateCounter     = NewCounterDef("respond_workflow_update_message")

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -418,8 +418,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandProtocolMessage(
 	attr *commandpb.ProtocolMessageCommandAttributes,
 	msgs *collection.IndexedTakeList[string, *protocolpb.Message],
 ) error {
-	metrics.CommandTypeProtocolMessage.With(handler.metricsHandler).Record(1)
-
 	executionInfo := handler.mutableState.GetExecutionInfo()
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
 
@@ -448,8 +446,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandScheduleActivity(
 	_ context.Context,
 	attr *commandpb.ScheduleActivityTaskCommandAttributes,
 ) (*historypb.HistoryEvent, *handleCommandResponse, error) {
-	metrics.CommandTypeScheduleActivityCounter.With(handler.metricsHandler).Record(1)
-
 	executionInfo := handler.mutableState.GetExecutionInfo()
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
 
@@ -618,8 +614,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandRequestCancelActivity(
 	_ context.Context,
 	attr *commandpb.RequestCancelActivityTaskCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeCancelActivityCounter.With(handler.metricsHandler).Record(1)
-
 	if err := handler.validateCommandAttr(
 		func() (enumspb.WorkflowTaskFailedCause, error) {
 			return handler.attrValidator.validateActivityCancelAttributes(attr)
@@ -664,8 +658,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandStartTimer(
 	_ context.Context,
 	attr *commandpb.StartTimerCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeStartTimerCounter.With(handler.metricsHandler).Record(1)
-
 	if err := handler.validateCommandAttr(
 		func() (enumspb.WorkflowTaskFailedCause, error) {
 			return handler.attrValidator.validateTimerScheduleAttributes(attr)
@@ -685,8 +677,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandCompleteWorkflow(
 	ctx context.Context,
 	attr *commandpb.CompleteWorkflowExecutionCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeCompleteWorkflowCounter.With(handler.metricsHandler).Record(1)
-
 	if handler.hasBufferedEventsOrMessages {
 		return nil, handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
 	}
@@ -742,8 +732,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandFailWorkflow(
 	ctx context.Context,
 	attr *commandpb.FailWorkflowExecutionCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeFailWorkflowCounter.With(handler.metricsHandler).Record(1)
-
 	if handler.hasBufferedEventsOrMessages {
 		return nil, handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
 	}
@@ -814,8 +802,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandCancelTimer(
 	_ context.Context,
 	attr *commandpb.CancelTimerCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeCancelTimerCounter.With(handler.metricsHandler).Record(1)
-
 	if err := handler.validateCommandAttr(
 		func() (enumspb.WorkflowTaskFailedCause, error) {
 			return handler.attrValidator.validateTimerCancelAttributes(attr)
@@ -842,8 +828,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandCancelWorkflow(
 	ctx context.Context,
 	attr *commandpb.CancelWorkflowExecutionCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeCancelWorkflowCounter.With(handler.metricsHandler).Record(1)
-
 	if handler.hasBufferedEventsOrMessages {
 		return nil, handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
 	}
@@ -874,8 +858,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandRequestCancelExternalW
 	_ context.Context,
 	attr *commandpb.RequestCancelExternalWorkflowExecutionCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeCancelExternalWorkflowCounter.With(handler.metricsHandler).Record(1)
-
 	executionInfo := handler.mutableState.GetExecutionInfo()
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
 	targetNamespaceID := namespaceID
@@ -915,8 +897,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandRecordMarker(
 	_ context.Context,
 	attr *commandpb.RecordMarkerCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeRecordMarkerCounter.With(handler.metricsHandler).Record(1)
-
 	if err := handler.validateCommandAttr(
 		func() (enumspb.WorkflowTaskFailedCause, error) {
 			return handler.attrValidator.validateRecordMarkerAttributes(attr)
@@ -940,8 +920,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandContinueAsNewWorkflow(
 	ctx context.Context,
 	attr *commandpb.ContinueAsNewWorkflowExecutionCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeContinueAsNewCounter.With(handler.metricsHandler).Record(1)
-
 	if handler.hasBufferedEventsOrMessages {
 		return nil, handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
 	}
@@ -1049,8 +1027,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandStartChildWorkflow(
 	_ context.Context,
 	attr *commandpb.StartChildWorkflowExecutionCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeChildWorkflowCounter.With(handler.metricsHandler).Record(1)
-
 	parentNamespaceEntry := handler.mutableState.GetNamespaceEntry()
 	parentNamespaceID := parentNamespaceEntry.ID()
 	parentNamespace := parentNamespaceEntry.Name()
@@ -1160,8 +1136,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandSignalExternalWorkflow
 	_ context.Context,
 	attr *commandpb.SignalExternalWorkflowExecutionCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeSignalExternalWorkflowCounter.With(handler.metricsHandler).Record(1)
-
 	executionInfo := handler.mutableState.GetExecutionInfo()
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
 	targetNamespaceID := namespaceID
@@ -1207,8 +1181,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandUpsertWorkflowSearchAt
 	_ context.Context,
 	attr *commandpb.UpsertWorkflowSearchAttributesCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeUpsertWorkflowSearchAttributesCounter.With(handler.metricsHandler).Record(1)
-
 	// get namespace name
 	executionInfo := handler.mutableState.GetExecutionInfo()
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
@@ -1277,8 +1249,6 @@ func (handler *workflowTaskCompletedHandler) handleCommandModifyWorkflowProperti
 	_ context.Context,
 	attr *commandpb.ModifyWorkflowPropertiesCommandAttributes,
 ) (*historypb.HistoryEvent, error) {
-	metrics.CommandTypeModifyWorkflowPropertiesCounter.With(handler.metricsHandler).Record(1)
-
 	// get namespace name
 	executionInfo := handler.mutableState.GetExecutionInfo()
 	namespaceID := namespace.ID(executionInfo.NamespaceId)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
In #4995 we introduced a new unified metric covering all command types processed by the history service. The old individual command type metrics were deprecated at that time. This PR removes the deprecated metrics entirely.

## Why?
<!-- Tell your future self why have you made these changes -->
Migration to the new unified metric has been completed.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
`make unit-test`

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Missing a consumer/monitor/dashboard that had been making use of the deprecated metrics, thereby impairing observability

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
