### PR TITLE
Add dynamic config registry and validation

### DIFF
--- a/cmd/tools/gendynamicconfig/main.go
+++ b/cmd/tools/gendynamicconfig/main.go
@@ -169,6 +169,7 @@ func New{{.P.Name}}TypedSettingWithConstrainedDefault[T any](key Key, convert fu
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -182,6 +183,7 @@ func (s {{.P.Name}}TypedSetting[T]) Validate(v any) error {
 func (s {{.P.Name}}TypedSetting[T]) WithDefault(v T) {{.P.Name}}TypedSetting[T] {
 	newS := s
 	newS.def = v
+	{{/* The base setting should be registered so we do not register the return value here */ -}}
 	return newS
 }
 

--- a/common/dynamicconfig/collection_test.go
+++ b/common/dynamicconfig/collection_test.go
@@ -80,6 +80,10 @@ func (s *collectionSuite) SetupSuite() {
 	s.cln = dynamicconfig.NewCollection(s.client, logger)
 }
 
+func (s *collectionSuite) SetupTest() {
+	dynamicconfig.ResetRegistryForTest()
+}
+
 func (s *collectionSuite) TestGetIntProperty() {
 	setting := dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 10, "")
 	value := setting.Get(s.cln)

--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -77,23 +77,24 @@ type (
 
 	osReader struct {
 	}
+
+	// Results of processing and loading dynamic config file contents.
+	// Warnings should be reported but not block using the new values.
+	// Errors should abort the loading process.
+	LoadResult struct {
+		Warnings []error
+		Errors   []error
+	}
 )
+
+func ValidateFile(contents []byte) *LoadResult {
+	_, lr := loadFile(contents)
+	return lr
+}
 
 // NewFileBasedClient creates a file based client.
 func NewFileBasedClient(config *FileBasedClientConfig, logger log.Logger, doneCh <-chan interface{}) (*fileBasedClient, error) {
-	client := &fileBasedClient{
-		logger: logger,
-		reader: &osReader{},
-		config: config,
-		doneCh: doneCh,
-	}
-
-	err := client.init()
-	if err != nil {
-		return nil, err
-	}
-
-	return client, nil
+	return NewFileBasedClientWithReader(&osReader{}, config, logger, doneCh)
 }
 
 func NewFileBasedClientWithReader(reader fileReader, config *FileBasedClientConfig, logger log.Logger, doneCh <-chan interface{}) (*fileBasedClient, error) {
@@ -118,7 +119,7 @@ func (fc *fileBasedClient) GetValue(key Key) []ConstrainedValue {
 }
 
 func (fc *fileBasedClient) init() error {
-	if err := fc.validateConfig(fc.config); err != nil {
+	if err := fc.validateStaticConfig(fc.config); err != nil {
 		return fmt.Errorf("unable to validate dynamic config: %w", err)
 	}
 
@@ -148,10 +149,6 @@ func (fc *fileBasedClient) init() error {
 // This is public mainly for testing. The update loop will call this periodically, you don't
 // have to call it explicitly.
 func (fc *fileBasedClient) Update() error {
-	defer func() {
-		fc.lastUpdatedTime = time.Now().UTC()
-	}()
-
 	info, err := fc.reader.Stat(fc.config.Filepath)
 	if err != nil {
 		return fmt.Errorf("dynamic config file: %s: %w", fc.config.Filepath, err)
@@ -159,36 +156,23 @@ func (fc *fileBasedClient) Update() error {
 	if !info.ModTime().After(fc.lastUpdatedTime) {
 		return nil
 	}
+	fc.lastUpdatedTime = info.ModTime()
 
-	confContent, err := fc.reader.ReadFile(fc.config.Filepath)
+	contents, err := fc.reader.ReadFile(fc.config.Filepath)
 	if err != nil {
 		return fmt.Errorf("dynamic config file: %s: %w", fc.config.Filepath, err)
 	}
 
-	var yamlValues map[string][]struct {
-		Constraints map[string]any
-		Value       any
+	newValues, lr := loadFile(contents)
+	for _, e := range lr.Errors {
+		fc.logger.Warn("dynamic config error", tag.Error(e))
 	}
-	if err = yaml.Unmarshal(confContent, &yamlValues); err != nil {
-		return fmt.Errorf("unable to decode dynamic config: %w", err)
+	for _, w := range lr.Warnings {
+		fc.logger.Warn("dynamic config warning", tag.Error(w))
 	}
-
-	newValues := make(configValueMap, len(yamlValues))
-	for key, yamlCV := range yamlValues {
-		cvs := make([]ConstrainedValue, len(yamlCV))
-		for i, cv := range yamlCV {
-			// yaml will unmarshal map into map[interface{}]interface{} instead of map[string]interface{}
-			// manually convert key type to string for all values here
-			cvs[i].Value, err = convertKeyTypeToString(cv.Value)
-			if err != nil {
-				return err
-			}
-			cvs[i].Constraints, err = convertYamlConstraints(cv.Constraints)
-			if err != nil {
-				return err
-			}
-		}
-		newValues[strings.ToLower(key)] = cvs
+	if len(lr.Errors) > 0 {
+		return fmt.Errorf("loading dynamic config failed: %d errors, %d warnings",
+			len(lr.Errors), len(lr.Warnings))
 	}
 
 	prev := fc.values.Swap(newValues)
@@ -199,7 +183,55 @@ func (fc *fileBasedClient) Update() error {
 	return nil
 }
 
-func (fc *fileBasedClient) validateConfig(config *FileBasedClientConfig) error {
+func loadFile(contents []byte) (configValueMap, *LoadResult) {
+	lr := &LoadResult{}
+
+	var yamlValues map[string][]struct {
+		Constraints map[string]any
+		Value       any
+	}
+	if err := yaml.Unmarshal(contents, &yamlValues); err != nil {
+		return nil, lr.errorf("decode error: %w", err)
+	}
+
+	newValues := make(configValueMap, len(yamlValues))
+	for key, yamlCV := range yamlValues {
+		precedence := PrecedenceUnknown
+		setting := queryRegistry(Key(key))
+		if setting == nil {
+			lr.warnf("unregistered key %q", key)
+		} else {
+			precedence = setting.Precedence()
+		}
+
+		cvs := make([]ConstrainedValue, len(yamlCV))
+		for i, cv := range yamlCV {
+			// yaml will unmarshal map into map[interface{}]interface{} instead of map[string]interface{}
+			// manually convert key type to string for all values here
+			val, err := convertKeyTypeToString(cv.Value)
+			if err != nil {
+				lr.error(err)
+				continue
+			}
+
+			// try validating if known setting
+			if setting != nil {
+				if valErr := setting.Validate(val); valErr != nil {
+					// TODO: raise this to error level
+					lr.warnf("validation failed: key %q value %v: %w", key, cv.Value, valErr)
+				}
+			}
+
+			cvs[i].Value = val
+			cvs[i].Constraints = convertYamlConstraints(key, cv.Constraints, precedence, lr)
+		}
+		newValues[strings.ToLower(key)] = cvs
+	}
+
+	return newValues, lr
+}
+
+func (fc *fileBasedClient) validateStaticConfig(config *FileBasedClientConfig) error {
 	if config == nil {
 		return errors.New("configuration for dynamic config client is nil")
 	}
@@ -346,79 +378,94 @@ func convertKeyTypeToStringSlice(s []interface{}) ([]interface{}, error) {
 	return stringKeySlice, nil
 }
 
-func convertYamlConstraints(m map[string]any) (Constraints, error) {
+func convertYamlConstraints(key string, m map[string]any, precedence Precedence, lr *LoadResult) Constraints {
 	var cs Constraints
 	for k, v := range m {
+		validConstraint := true
 		switch strings.ToLower(k) {
 		case "namespace":
 			if v, ok := v.(string); ok {
 				cs.Namespace = v
 			} else {
-				return cs, fmt.Errorf("namespace constraint must be string")
+				lr.errorf("namespace constraint must be string")
 			}
+			validConstraint = precedence == PrecedenceNamespace || precedence == PrecedenceTaskQueue || precedence == PrecedenceDestination
 		case "namespaceid":
 			if v, ok := v.(string); ok {
 				cs.NamespaceID = v
 			} else {
-				return cs, fmt.Errorf("namespaceID constraint must be string")
+				lr.errorf("namespaceID constraint must be string")
 			}
+			validConstraint = precedence == PrecedenceNamespaceID
 		case "taskqueuename":
 			if v, ok := v.(string); ok {
 				cs.TaskQueueName = v
 			} else {
-				return cs, fmt.Errorf("taskQueueName constraint must be string")
+				lr.errorf("taskQueueName constraint must be string")
 			}
+			validConstraint = precedence == PrecedenceTaskQueue
 		case "tasktype":
 			switch v := v.(type) {
 			case string:
 				i, err := enumspb.TaskQueueTypeFromString(v)
 				if err != nil {
-					return cs, fmt.Errorf("invalid value for taskType: %w", err)
+					lr.errorf("invalid value for taskType: %w", err)
 				} else if i <= enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
-					return cs, fmt.Errorf("taskType constraint must be Workflow/Activity")
+					lr.errorf("taskType constraint must be Workflow/Activity")
 				}
 				cs.TaskQueueType = i
 			case int:
 				if v > int(enumspb.TASK_QUEUE_TYPE_UNSPECIFIED) {
 					cs.TaskQueueType = enumspb.TaskQueueType(v)
 				} else {
-					return cs, fmt.Errorf("taskType constraint must be Workflow/Activity")
+					lr.errorf("taskType constraint must be Workflow/Activity")
 				}
 			default:
-				return cs, fmt.Errorf("taskType constraint must be Workflow/Activity")
+				lr.errorf("taskType constraint must be Workflow/Activity")
 			}
+			validConstraint = precedence == PrecedenceTaskQueue
 		case "historytasktype":
 			switch v := v.(type) {
 			case string:
 				tt, err := enumsspb.TaskTypeFromString(v)
 				if err != nil {
-					return cs, fmt.Errorf("invalid value for historytasktype constraint: %w", err)
+					lr.errorf("invalid value for historytasktype constraint: %w", err)
 				} else if tt <= enumsspb.TASK_TYPE_UNSPECIFIED {
-					return cs, fmt.Errorf("historytasktype %s constraint is not supported", v)
+					lr.errorf("historytasktype %s constraint is not supported", v)
 				}
 				cs.TaskType = tt
 			case int:
 				cs.TaskType = enumsspb.TaskType(v)
 			default:
-				return cs, fmt.Errorf("historytasktype %T constraint is not supported", v)
+				lr.errorf("historytasktype %T constraint is not supported", v)
 			}
+			validConstraint = precedence == PrecedenceTaskType
 		case "shardid":
 			if v, ok := v.(int); ok {
 				cs.ShardID = int32(v)
 			} else {
-				return cs, fmt.Errorf("shardID constraint must be integer")
+				lr.errorf("shardID constraint must be integer")
 			}
+			validConstraint = precedence == PrecedenceShardID
 		case "destination":
 			if v, ok := v.(string); ok {
 				cs.Destination = v
 			} else {
-				return cs, fmt.Errorf("destination constraint must be string")
+				lr.errorf("destination constraint must be string")
 			}
+			validConstraint = precedence == PrecedenceDestination
 		default:
-			return cs, fmt.Errorf("unknown constraint type %q", k)
+			lr.errorf("unknown constraint type %q", k)
+		}
+
+		// don't log error for PrecedenceUnknown, we would already have logged for an
+		// unregistered key above
+		// TODO: raise this to error level
+		if !validConstraint && precedence != PrecedenceUnknown {
+			lr.warnf("constraint %q isn't valid for dynamic config key %q", k, key)
 		}
 	}
-	return cs, nil
+	return cs
 }
 
 func (r *osReader) ReadFile(src string) ([]byte, error) {
@@ -427,4 +474,22 @@ func (r *osReader) ReadFile(src string) ([]byte, error) {
 
 func (r *osReader) Stat(src string) (os.FileInfo, error) {
 	return os.Stat(src)
+}
+
+func (lr *LoadResult) warn(err error) *LoadResult {
+	lr.Warnings = append(lr.Warnings, err)
+	return lr
+}
+
+func (lr *LoadResult) warnf(format string, args ...any) *LoadResult {
+	return lr.warn(fmt.Errorf(format, args...))
+}
+
+func (lr *LoadResult) error(err error) *LoadResult {
+	lr.Errors = append(lr.Errors, err)
+	return lr
+}
+
+func (lr *LoadResult) errorf(format string, args ...any) *LoadResult {
+	return lr.error(fmt.Errorf(format, args...))
 }

--- a/common/dynamicconfig/setting_gen.go
+++ b/common/dynamicconfig/setting_gen.go
@@ -33,19 +33,21 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 )
 
-const PrecedenceGlobal Precedence = 0
+const PrecedenceUnknown Precedence = 0
 
-const PrecedenceNamespace Precedence = 1
+const PrecedenceGlobal Precedence = 1
 
-const PrecedenceNamespaceID Precedence = 2
+const PrecedenceNamespace Precedence = 2
 
-const PrecedenceTaskQueue Precedence = 3
+const PrecedenceNamespaceID Precedence = 3
 
-const PrecedenceShardID Precedence = 4
+const PrecedenceTaskQueue Precedence = 4
 
-const PrecedenceTaskType Precedence = 5
+const PrecedenceShardID Precedence = 5
 
-const PrecedenceDestination Precedence = 6
+const PrecedenceTaskType Precedence = 6
+
+const PrecedenceDestination Precedence = 7
 
 type GlobalBoolSetting = GlobalTypedSetting[bool]
 
@@ -731,6 +733,7 @@ func NewGlobalTypedSetting[T any](key Key, def T, description string) GlobalType
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -742,6 +745,7 @@ func NewGlobalTypedSettingWithConverter[T any](key Key, convert func(any) (T, er
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -758,6 +762,10 @@ func NewGlobalTypedSettingWithConstrainedDefault[T any](key Key, convert func(an
 
 func (s GlobalTypedSetting[T]) Key() Key               { return s.key }
 func (s GlobalTypedSetting[T]) Precedence() Precedence { return PrecedenceGlobal }
+func (s GlobalTypedSetting[T]) Validate(v any) error {
+	_, err := s.convert(v)
+	return err
+}
 
 func (s GlobalTypedSetting[T]) WithDefault(v T) GlobalTypedSetting[T] {
 	newS := s
@@ -798,6 +806,7 @@ func NewNamespaceTypedSetting[T any](key Key, def T, description string) Namespa
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -809,6 +818,7 @@ func NewNamespaceTypedSettingWithConverter[T any](key Key, convert func(any) (T,
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -825,6 +835,10 @@ func NewNamespaceTypedSettingWithConstrainedDefault[T any](key Key, convert func
 
 func (s NamespaceTypedSetting[T]) Key() Key               { return s.key }
 func (s NamespaceTypedSetting[T]) Precedence() Precedence { return PrecedenceNamespace }
+func (s NamespaceTypedSetting[T]) Validate(v any) error {
+	_, err := s.convert(v)
+	return err
+}
 
 func (s NamespaceTypedSetting[T]) WithDefault(v T) NamespaceTypedSetting[T] {
 	newS := s
@@ -865,6 +879,7 @@ func NewNamespaceIDTypedSetting[T any](key Key, def T, description string) Names
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -876,6 +891,7 @@ func NewNamespaceIDTypedSettingWithConverter[T any](key Key, convert func(any) (
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -892,6 +908,10 @@ func NewNamespaceIDTypedSettingWithConstrainedDefault[T any](key Key, convert fu
 
 func (s NamespaceIDTypedSetting[T]) Key() Key               { return s.key }
 func (s NamespaceIDTypedSetting[T]) Precedence() Precedence { return PrecedenceNamespaceID }
+func (s NamespaceIDTypedSetting[T]) Validate(v any) error {
+	_, err := s.convert(v)
+	return err
+}
 
 func (s NamespaceIDTypedSetting[T]) WithDefault(v T) NamespaceIDTypedSetting[T] {
 	newS := s
@@ -932,6 +952,7 @@ func NewTaskQueueTypedSetting[T any](key Key, def T, description string) TaskQue
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -943,6 +964,7 @@ func NewTaskQueueTypedSettingWithConverter[T any](key Key, convert func(any) (T,
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -959,6 +981,10 @@ func NewTaskQueueTypedSettingWithConstrainedDefault[T any](key Key, convert func
 
 func (s TaskQueueTypedSetting[T]) Key() Key               { return s.key }
 func (s TaskQueueTypedSetting[T]) Precedence() Precedence { return PrecedenceTaskQueue }
+func (s TaskQueueTypedSetting[T]) Validate(v any) error {
+	_, err := s.convert(v)
+	return err
+}
 
 func (s TaskQueueTypedSetting[T]) WithDefault(v T) TaskQueueTypedSetting[T] {
 	newS := s
@@ -999,6 +1025,7 @@ func NewShardIDTypedSetting[T any](key Key, def T, description string) ShardIDTy
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -1010,6 +1037,7 @@ func NewShardIDTypedSettingWithConverter[T any](key Key, convert func(any) (T, e
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -1026,6 +1054,10 @@ func NewShardIDTypedSettingWithConstrainedDefault[T any](key Key, convert func(a
 
 func (s ShardIDTypedSetting[T]) Key() Key               { return s.key }
 func (s ShardIDTypedSetting[T]) Precedence() Precedence { return PrecedenceShardID }
+func (s ShardIDTypedSetting[T]) Validate(v any) error {
+	_, err := s.convert(v)
+	return err
+}
 
 func (s ShardIDTypedSetting[T]) WithDefault(v T) ShardIDTypedSetting[T] {
 	newS := s
@@ -1066,6 +1098,7 @@ func NewTaskTypeTypedSetting[T any](key Key, def T, description string) TaskType
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -1077,6 +1110,7 @@ func NewTaskTypeTypedSettingWithConverter[T any](key Key, convert func(any) (T, 
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -1093,6 +1127,10 @@ func NewTaskTypeTypedSettingWithConstrainedDefault[T any](key Key, convert func(
 
 func (s TaskTypeTypedSetting[T]) Key() Key               { return s.key }
 func (s TaskTypeTypedSetting[T]) Precedence() Precedence { return PrecedenceTaskType }
+func (s TaskTypeTypedSetting[T]) Validate(v any) error {
+	_, err := s.convert(v)
+	return err
+}
 
 func (s TaskTypeTypedSetting[T]) WithDefault(v T) TaskTypeTypedSetting[T] {
 	newS := s
@@ -1133,6 +1171,7 @@ func NewDestinationTypedSetting[T any](key Key, def T, description string) Desti
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -1144,6 +1183,7 @@ func NewDestinationTypedSettingWithConverter[T any](key Key, convert func(any) (
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -1160,6 +1200,10 @@ func NewDestinationTypedSettingWithConstrainedDefault[T any](key Key, convert fu
 
 func (s DestinationTypedSetting[T]) Key() Key               { return s.key }
 func (s DestinationTypedSetting[T]) Precedence() Precedence { return PrecedenceDestination }
+func (s DestinationTypedSetting[T]) Validate(v any) error {
+	_, err := s.convert(v)
+	return err
+}
 
 func (s DestinationTypedSetting[T]) WithDefault(v T) DestinationTypedSetting[T] {
 	newS := s

--- a/common/dynamicconfig/setting_gen.go
+++ b/common/dynamicconfig/setting_gen.go
@@ -757,6 +757,7 @@ func NewGlobalTypedSettingWithConstrainedDefault[T any](key Key, convert func(an
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -830,6 +831,7 @@ func NewNamespaceTypedSettingWithConstrainedDefault[T any](key Key, convert func
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -903,6 +905,7 @@ func NewNamespaceIDTypedSettingWithConstrainedDefault[T any](key Key, convert fu
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -976,6 +979,7 @@ func NewTaskQueueTypedSettingWithConstrainedDefault[T any](key Key, convert func
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -1049,6 +1053,7 @@ func NewShardIDTypedSettingWithConstrainedDefault[T any](key Key, convert func(a
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -1122,6 +1127,7 @@ func NewTaskTypeTypedSettingWithConstrainedDefault[T any](key Key, convert func(
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 
@@ -1195,6 +1201,7 @@ func NewDestinationTypedSettingWithConstrainedDefault[T any](key Key, convert fu
 		convert:     convert,
 		description: description,
 	}
+	register(s)
 	return s
 }
 


### PR DESCRIPTION
## What changed?
Added a process-wide registry for dynamic config settings and perform more validation on file load. Files that were successfully loaded before will still be loaded (for now), but more warnings may be logged. Eventually we can make some of the checks stricter.

Added a top-level CLI command to validate dynamic config files.

## Why?
Catch more errors, set up structure for doc generation and user-defined validation.

## How did you test it?
unit tests
