### PR TITLE
Accept strings for bool in dynamic config

### DIFF
--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -289,10 +290,14 @@ func convertString(val any) (string, error) {
 }
 
 func convertBool(val any) (bool, error) {
-	if boolVal, ok := val.(bool); ok {
-		return boolVal, nil
+	switch v := val.(type) {
+	case bool:
+		return v, nil
+	case string:
+		return strconv.ParseBool(v)
+	default:
+		return false, errors.New("value type is not bool")
 	}
-	return false, errors.New("value type is not bool")
 }
 
 func convertMap(val any) (map[string]any, error) {

--- a/common/dynamicconfig/collection_test.go
+++ b/common/dynamicconfig/collection_test.go
@@ -143,6 +143,8 @@ func (s *collectionSuite) TestGetBoolProperty() {
 	s.Equal(true, value())
 	s.client[testGetBoolPropertyKey] = false
 	s.Equal(false, value())
+	s.client[testGetBoolPropertyKey] = "false"
+	s.Equal(false, value())
 }
 
 func (s *collectionSuite) TestGetBoolPropertyFilteredByNamespaceID() {


### PR DESCRIPTION
## What changed?
Use strconv.ParseBool to convert strings to bools in dynamic config.

## Why?
Be more flexible in case someone quotes a bool.

## How did you test it?
unit test