### PR TITLE
Allow UpdateWorkflowExecution against completed workflow

### DIFF
--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -133,8 +133,8 @@ func (u *Updater) ApplyRequest(
 	updateReg update.Registry,
 	ms workflow.MutableState,
 ) (*api.UpdateWorkflowAction, error) {
-	if !ms.IsWorkflowExecutionRunning() {
-		return nil, consts.ErrWorkflowCompleted
+	if !(ms.IsWorkflowExecutionRunning() || ms.GetExecutionState().State == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED) {
+		return nil, serviceerror.NewNotFound("invalid workflow execution state for update request")
 	}
 	u.wfKey = ms.GetWorkflowKey()
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -192,7 +192,6 @@ type Config struct {
 	ShardSyncTimerJitterCoefficient dynamicconfig.FloatPropertyFn
 
 	// Time to hold a poll request before returning an empty response
-	// right now only used by GetMutableState
 	LongPollExpirationInterval dynamicconfig.DurationPropertyFnWithNamespaceFilter
 
 	// encoding the history events


### PR DESCRIPTION
## Current behavior

<img width="306" alt="image" src="https://github.com/temporalio/temporal/assets/52205/b76ae9be-56fe-41c1-b7e6-cb2f530a228a">


## Proposed behavior

<img width="547" alt="image" src="https://github.com/temporalio/temporal/assets/52205/4e5b978a-d13a-4e4e-912a-e2b19bd58cdf">


## What changed?
Allow update requests against completed workflows.

**TODO**
- Prevent update creation for completed workflow
- Return error if update not already at requested stage, or return error if not requested-complete and at-complete.





## Why?
UpdateWorkflowExecution permits the submitted update ID to exist
already; in this situation it returns information on the state of the
existing update. Clients are encouraged to make use of this behavior
by submitting the request repeatedly until the response indicates
that the update has reached a durable stage. Therefore, we must allow
the request to be submitted against completed updates since, otherwise,
there would be a race condition:

1. client submits request 1; response indicates update not yet durable
2. update becomes durable and workflow completes
3. client submits request 2; receives WorkflowNotFound error

The above sequence is incorrect: the client's second request should be
a success response indicating that the update is complete and
containing the update outcome.

## How did you test it?
I set `history.longPollExpirationInterval=0.1` and observed that `sdk-typescript` tests fail, and are fixed by this commit.

## Potential risks
Could permit update requests that should not be permitted, if the above reasoning is flawed.

## Is hotfix candidate?
Yes, should be included in Update Public Preview.
