### PR TITLE
Acquire workflow lock during backfill history

### DIFF
--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -285,9 +285,8 @@ func (r *WorkflowStateReplicatorImpl) backfillHistory(
 		if rec := recover(); rec != nil {
 			wfReleaseFn(errPanic)
 			panic(rec)
-		} else {
-			wfReleaseFn(retError)
 		}
+		wfReleaseFn(retError)
 	}()
 
 	// Get the last batch node id to check if the history data is already in DB.

--- a/service/history/ndc/workflow_state_replicator_test.go
+++ b/service/history/ndc/workflow_state_replicator_test.go
@@ -187,16 +187,13 @@ func (s *workflowReplicatorSuite) Test_ApplyWorkflowState_BrandNew() {
 		we,
 		workflow.LockPriorityLow,
 	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
-	currentRun := &commonpb.WorkflowExecution{
-		WorkflowId: s.workflowID,
-	}
-	s.mockWorkflowCache.EXPECT().GetOrCreateWorkflowExecution(
+	s.mockWorkflowCache.EXPECT().GetOrCreateCurrentWorkflowExecution(
 		gomock.Any(),
 		s.mockShard,
 		namespace.ID(namespaceID),
-		currentRun,
+		s.workflowID,
 		workflow.LockPriorityLow,
-	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
+	).Return(wcache.NoopReleaseFn, nil)
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(nil, serviceerror.NewNotFound("ms not found"))
 	mockWeCtx.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),
@@ -303,16 +300,13 @@ func (s *workflowReplicatorSuite) Test_ApplyWorkflowState_Ancestors() {
 		we,
 		workflow.LockPriorityLow,
 	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
-	currentRun := &commonpb.WorkflowExecution{
-		WorkflowId: s.workflowID,
-	}
-	s.mockWorkflowCache.EXPECT().GetOrCreateWorkflowExecution(
+	s.mockWorkflowCache.EXPECT().GetOrCreateCurrentWorkflowExecution(
 		gomock.Any(),
 		s.mockShard,
 		namespace.ID(namespaceID),
-		currentRun,
+		s.workflowID,
 		workflow.LockPriorityLow,
-	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
+	).Return(wcache.NoopReleaseFn, nil)
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(nil, serviceerror.NewNotFound("ms not found"))
 	mockWeCtx.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),

--- a/service/history/ndc/workflow_state_replicator_test.go
+++ b/service/history/ndc/workflow_state_replicator_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	historypb "go.temporal.io/api/history/v1"
+
 	"go.temporal.io/server/service/history/events"
 	"go.temporal.io/server/service/history/hsm"
 
@@ -186,6 +187,16 @@ func (s *workflowReplicatorSuite) Test_ApplyWorkflowState_BrandNew() {
 		we,
 		workflow.LockPriorityLow,
 	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
+	currentRun := &commonpb.WorkflowExecution{
+		WorkflowId: s.workflowID,
+	}
+	s.mockWorkflowCache.EXPECT().GetOrCreateWorkflowExecution(
+		gomock.Any(),
+		s.mockShard,
+		namespace.ID(namespaceID),
+		currentRun,
+		workflow.LockPriorityLow,
+	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(nil, serviceerror.NewNotFound("ms not found"))
 	mockWeCtx.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),
@@ -290,6 +301,16 @@ func (s *workflowReplicatorSuite) Test_ApplyWorkflowState_Ancestors() {
 		s.mockShard,
 		namespace.ID(namespaceID),
 		we,
+		workflow.LockPriorityLow,
+	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
+	currentRun := &commonpb.WorkflowExecution{
+		WorkflowId: s.workflowID,
+	}
+	s.mockWorkflowCache.EXPECT().GetOrCreateWorkflowExecution(
+		gomock.Any(),
+		s.mockShard,
+		namespace.ID(namespaceID),
+		currentRun,
 		workflow.LockPriorityLow,
 	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(nil, serviceerror.NewNotFound("ms not found"))


### PR DESCRIPTION
## What changed?
Acquire workflow lock during backfill history

## Why?
Stream replication processes WorkflowRun concurrently. This could lead to concurrent append history node on same node id and write dirty history node into the table.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
