### PR TITLE
Fix GHA upload-test-results

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -93,7 +93,7 @@ jobs:
         run: make unit-test-coverage
 
       - name: Upload test results
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: make upload-test-results
 
   integration-test:
@@ -128,7 +128,7 @@ jobs:
         run: make integration-test-coverage
 
       - name: Upload test results
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: make upload-test-results
 
       - name: Tear down docker compose
@@ -201,7 +201,7 @@ jobs:
         run: make functional-test-coverage
 
       - name: Upload test results
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: make upload-test-results
 
       - name: Tear down docker compose
@@ -268,7 +268,7 @@ jobs:
         run: make functional-test-xdc-coverage
 
       - name: Upload test results
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: make upload-test-results
 
       - name: Tear down docker compose

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,7 +90,11 @@ jobs:
 
       - name: Run unit test
         timeout-minutes: 15
-        run: make unit-test-coverage upload-test-results
+        run: make unit-test-coverage
+
+      - name: Upload test results
+        if: ${{ always() }}
+        run: make upload-test-results
 
   integration-test:
     name: Integration test
@@ -121,7 +125,11 @@ jobs:
 
       - name: Run integration test
         timeout-minutes: 15
-        run: make integration-test-coverage upload-test-results
+        run: make integration-test-coverage
+
+      - name: Upload test results
+        if: ${{ always() }}
+        run: make upload-test-results
 
       - name: Tear down docker compose
         if: ${{ always() }}
@@ -190,7 +198,11 @@ jobs:
 
       - name: Run functional test
         timeout-minutes: 25
-        run: make functional-test-coverage upload-test-results
+        run: make functional-test-coverage
+
+      - name: Upload test results
+        if: ${{ always() }}
+        run: make upload-test-results
 
       - name: Tear down docker compose
         if: ${{ always() }}
@@ -253,7 +265,11 @@ jobs:
 
       - name: Run functional test xdc
         timeout-minutes: 15
-        run: make functional-test-xdc-coverage upload-test-results
+        run: make functional-test-xdc-coverage
+
+      - name: Upload test results
+        if: ${{ always() }}
+        run: make upload-test-results
 
       - name: Tear down docker compose
         if: ${{ always() }}

--- a/develop/upload-test-results.sh
+++ b/develop/upload-test-results.sh
@@ -8,19 +8,18 @@ fi
 echo "uploading test results from $(pwd)"
 
 for file in *.junit.xml; do
-  if [ -e "$file" ]; then
-    echo "uploading ${file}"
+  [ -e "$file" ] || continue
+  echo "uploading ${file}"
 
-    curl -i -X POST \
-      -H "Authorization: Token token=${BUILDKITE_ANALYTICS_TOKEN}" \
-      -F "data=@${file}" \
-      -F "format=junit" \
-      -F "run_env[CI]=github_actions" \
-      -F "run_env[key]=${GITHUB_ACTION}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" \
-      -F "run_env[number]=${GITHUB_RUN_NUMBER}" \
-      -F "run_env[branch]=${GITHUB_REF}" \
-      -F "run_env[commit_sha]=${GITHUB_SHA}" \
-      -F "run_env[url]=https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-      https://analytics-api.buildkite.com/v1/uploads
-  fi
+  curl -i -X POST \
+    -H "Authorization: Token token=${BUILDKITE_ANALYTICS_TOKEN}" \
+    -F "data=@${file}" \
+    -F "format=junit" \
+    -F "run_env[CI]=github_actions" \
+    -F "run_env[key]=${GITHUB_ACTION}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" \
+    -F "run_env[number]=${GITHUB_RUN_NUMBER}" \
+    -F "run_env[branch]=${GITHUB_REF}" \
+    -F "run_env[commit_sha]=${GITHUB_SHA}" \
+    -F "run_env[url]=https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+    https://analytics-api.buildkite.com/v1/uploads
 done

--- a/develop/upload-test-results.sh
+++ b/develop/upload-test-results.sh
@@ -8,6 +8,7 @@ fi
 echo "uploading test results from $(pwd)"
 
 for file in *.junit.xml; do
+  if [ -e "$file" ]; then
     echo "uploading ${file}"
 
     curl -i -X POST \
@@ -21,4 +22,5 @@ for file in *.junit.xml; do
       -F "run_env[commit_sha]=${GITHUB_SHA}" \
       -F "run_env[url]=https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
       https://analytics-api.buildkite.com/v1/uploads
+  fi
 done


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Separate test execution and test result upload. And check XML file exists.

Previously introduced here https://github.com/temporalio/temporal/pull/6049

## Why?
<!-- Tell your future self why have you made these changes -->

make aborts execution when the previous target fails. Oops.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Scenarios:

- [x] no Buildkite secret set
- [x] make target has test errors
- [x] make target has no test errors
- [x] make target aborts (no XML file written)

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
