### PR TITLE
Apply Nexus history events during replication

### DIFF
--- a/components/callbacks/config.go
+++ b/components/callbacks/config.go
@@ -43,7 +43,7 @@ var RetryPolicyInitialInterval = dynamicconfig.NewGlobalDurationSetting(
 
 var RetryPolicyMaximumInterval = dynamicconfig.NewGlobalDurationSetting(
 	"component.callbacks.retryPolicy.maxInterval",
-	time.Second,
+	time.Hour,
 	`The maximum backoff interval between every callback request attempt for a given callback.`,
 )
 

--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -74,7 +74,7 @@ var RetryPolicyInitialInterval = dynamicconfig.NewGlobalDurationSetting(
 
 var RetryPolicyMaximumInterval = dynamicconfig.NewGlobalDurationSetting(
 	"component.nexusoperations.retryPolicy.maxInterval",
-	time.Second,
+	time.Hour,
 	`The maximum backoff interval between every nexus StartOperation or CancelOperation request for a given operation.`,
 )
 

--- a/components/nexusoperations/events.go
+++ b/components/nexusoperations/events.go
@@ -23,7 +23,6 @@
 package nexusoperations
 
 import (
-	"fmt"
 	"reflect"
 	"strconv"
 
@@ -190,7 +189,7 @@ func transitionOperation(root *hsm.Node, event *historypb.HistoryEvent, fn func(
 
 	// Attributes is always a struct with a single field (e.g: HistoryEvent_NexusOperationScheduledEventAttributes)
 	if attrs.Kind() != reflect.Struct || attrs.NumField() != 1 {
-		panic("invalid event, expected Attributes field to a single field struct")
+		panic("invalid event, expected Attributes field with a single field struct")
 	}
 
 	f := attrs.Field(0).Interface()
@@ -203,7 +202,7 @@ func transitionOperation(root *hsm.Node, event *historypb.HistoryEvent, fn func(
 	nodeID := strconv.FormatInt(getter.GetScheduledEventId(), 10)
 	node, err := coll.Node(nodeID)
 	if err != nil {
-		return fmt.Errorf("TODO: %w", err)
+		return err
 	}
 	return coll.Transition(nodeID, func(o Operation) (hsm.TransitionOutput, error) {
 		return fn(node, o)

--- a/components/nexusoperations/events.go
+++ b/components/nexusoperations/events.go
@@ -23,78 +23,144 @@
 package nexusoperations
 
 import (
+	"fmt"
+	"reflect"
+	"strconv"
+
 	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/server/service/history/hsm"
 )
 
 type ScheduledEventDefinition struct{}
 
-func (n ScheduledEventDefinition) IsWorkflowTaskTrigger() bool {
+func (d ScheduledEventDefinition) IsWorkflowTaskTrigger() bool {
 	return false
 }
 
-func (n ScheduledEventDefinition) Type() enumspb.EventType {
+func (d ScheduledEventDefinition) Type() enumspb.EventType {
 	return enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED
+}
+
+func (d ScheduledEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
+	token, err := hsm.GenerateEventLoadToken(event)
+	if err != nil {
+		return err
+	}
+	_, err = AddChild(root, strconv.FormatInt(event.EventId, 10), event, token, true)
+	return err
 }
 
 type CancelRequestedEventDefinition struct{}
 
-func (n CancelRequestedEventDefinition) IsWorkflowTaskTrigger() bool {
+func (d CancelRequestedEventDefinition) IsWorkflowTaskTrigger() bool {
 	return false
 }
 
-func (n CancelRequestedEventDefinition) Type() enumspb.EventType {
+func (d CancelRequestedEventDefinition) Type() enumspb.EventType {
 	return enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED
+}
+
+func (d CancelRequestedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
+	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+		return o.Cancel(node, event.EventTime.AsTime())
+	})
 }
 
 type StartedEventDefinition struct{}
 
-func (n StartedEventDefinition) IsWorkflowTaskTrigger() bool {
+func (d StartedEventDefinition) IsWorkflowTaskTrigger() bool {
 	return true
 }
 
-func (n StartedEventDefinition) Type() enumspb.EventType {
+func (d StartedEventDefinition) Type() enumspb.EventType {
 	return enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED
+}
+
+func (d StartedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
+	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+		return TransitionStarted.Apply(o, EventStarted{
+			Time:       event.EventTime.AsTime(),
+			Node:       node,
+			Attributes: event.GetNexusOperationStartedEventAttributes(),
+		})
+	})
 }
 
 type CompletedEventDefinition struct{}
 
-func (n CompletedEventDefinition) IsWorkflowTaskTrigger() bool {
+func (d CompletedEventDefinition) IsWorkflowTaskTrigger() bool {
 	return true
 }
 
-func (n CompletedEventDefinition) Type() enumspb.EventType {
+func (d CompletedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
+	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+		return TransitionSucceeded.Apply(o, EventSucceeded{
+			Time: event.EventTime.AsTime(),
+			Node: node,
+		})
+	})
+}
+
+func (d CompletedEventDefinition) Type() enumspb.EventType {
 	return enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED
 }
 
 type FailedEventDefinition struct{}
 
-func (n FailedEventDefinition) IsWorkflowTaskTrigger() bool {
+func (d FailedEventDefinition) IsWorkflowTaskTrigger() bool {
 	return true
 }
 
-func (n FailedEventDefinition) Type() enumspb.EventType {
+func (d FailedEventDefinition) Type() enumspb.EventType {
 	return enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED
+}
+
+func (d FailedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
+	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+		return TransitionFailed.Apply(o, EventFailed{
+			Time:       event.EventTime.AsTime(),
+			Attributes: event.GetNexusOperationFailedEventAttributes(),
+			Node:       node,
+		})
+	})
 }
 
 type CanceledEventDefinition struct{}
 
-func (n CanceledEventDefinition) IsWorkflowTaskTrigger() bool {
+func (d CanceledEventDefinition) IsWorkflowTaskTrigger() bool {
 	return true
 }
 
-func (n CanceledEventDefinition) Type() enumspb.EventType {
+func (d CanceledEventDefinition) Type() enumspb.EventType {
 	return enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED
+}
+
+func (d CanceledEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
+	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+		return TransitionCanceled.Apply(o, EventCanceled{
+			Time: event.EventTime.AsTime(),
+			Node: node,
+		})
+	})
 }
 
 type TimedOutEventDefinition struct{}
 
-func (n TimedOutEventDefinition) IsWorkflowTaskTrigger() bool {
+func (d TimedOutEventDefinition) IsWorkflowTaskTrigger() bool {
 	return true
 }
 
-func (n TimedOutEventDefinition) Type() enumspb.EventType {
+func (d TimedOutEventDefinition) Type() enumspb.EventType {
 	return enumspb.EVENT_TYPE_NEXUS_OPERATION_TIMED_OUT
+}
+
+func (d TimedOutEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
+	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+		return TransitionTimedOut.Apply(o, EventTimedOut{
+			Node: node,
+		})
+	})
 }
 
 func RegisterEventDefinitions(reg *hsm.Registry) error {
@@ -117,4 +183,29 @@ func RegisterEventDefinitions(reg *hsm.Registry) error {
 		return err
 	}
 	return reg.RegisterEventDefinition(TimedOutEventDefinition{})
+}
+
+func transitionOperation(root *hsm.Node, event *historypb.HistoryEvent, fn func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error)) error {
+	attrs := reflect.ValueOf(event.Attributes).Elem()
+
+	// Attributes is always a struct with a single field (e.g: HistoryEvent_NexusOperationScheduledEventAttributes)
+	if attrs.Kind() != reflect.Struct || attrs.NumField() != 1 {
+		panic("invalid event, expected Attributes field to a single field struct")
+	}
+
+	f := attrs.Field(0).Interface()
+
+	getter, ok := f.(interface{ GetScheduledEventId() int64 })
+	if !ok {
+		panic("Event does not have a ScheduledEventId field")
+	}
+	coll := MachineCollection(root)
+	nodeID := strconv.FormatInt(getter.GetScheduledEventId(), 10)
+	node, err := coll.Node(nodeID)
+	if err != nil {
+		return fmt.Errorf("TODO: %w", err)
+	}
+	return coll.Transition(nodeID, func(o Operation) (hsm.TransitionOutput, error) {
+		return fn(node, o)
+	})
 }

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -285,7 +285,7 @@ func (e taskExecutor) saveResult(ctx context.Context, env hsm.Environment, ref h
 				// Handler has indicated that the operation will complete asynchronously. Mark the operation as started
 				// to allow it to complete via callback.
 				event := node.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED, func(e *historypb.HistoryEvent) {
-					// nolint:revive
+					// nolint:revive // We must mutate here even if the linter doesn't like it.
 					e.Attributes = &historypb.HistoryEvent_NexusOperationStartedEventAttributes{
 						NexusOperationStartedEventAttributes: &historypb.NexusOperationStartedEventAttributes{
 							ScheduledEventId: eventID,
@@ -352,7 +352,7 @@ func handleNonRetryableStartOperationError(env hsm.Environment, node *hsm.Node, 
 		ScheduledEventId: eventID,
 	}
 	node.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED, func(e *historypb.HistoryEvent) {
-		// nolint:revive
+		// nolint:revive // We must mutate here even if the linter doesn't like it.
 		e.Attributes = &historypb.HistoryEvent_NexusOperationFailedEventAttributes{
 			NexusOperationFailedEventAttributes: attrs,
 		}
@@ -390,7 +390,7 @@ func (e taskExecutor) executeTimeoutTask(env hsm.Environment, node *hsm.Node, ta
 			return hsm.TransitionOutput{}, err
 		}
 		node.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_TIMED_OUT, func(e *historypb.HistoryEvent) {
-			// nolint:revive
+			// nolint:revive // We must mutate here even if the linter doesn't like it.
 			e.Attributes = &historypb.HistoryEvent_NexusOperationTimedOutEventAttributes{
 				NexusOperationTimedOutEventAttributes: &historypb.NexusOperationTimedOutEventAttributes{
 					Failure: nexusOperationFailure(

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -362,11 +362,9 @@ func TestProcessBackoffTask(t *testing.T) {
 	require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{}))
 	err := hsm.MachineTransition(node, func(op nexusoperations.Operation) (hsm.TransitionOutput, error) {
 		return nexusoperations.TransitionAttemptFailed.Apply(op, nexusoperations.EventAttemptFailed{
-			Node: node,
-			AttemptFailure: nexusoperations.AttemptFailure{
-				Time: time.Now(),
-				Err:  errors.New("test"),
-			},
+			Node:        node,
+			Time:        time.Now(),
+			Err:         errors.New("test"),
 			RetryPolicy: backoff.NewExponentialRetryPolicy(time.Second),
 		})
 	})

--- a/components/nexusoperations/helpers_test.go
+++ b/components/nexusoperations/helpers_test.go
@@ -78,7 +78,7 @@ func newOperationNode(t *testing.T, backend *hsmtest.NodeBackend, event *history
 	root := newRoot(t, backend)
 	token, err := hsm.GenerateEventLoadToken(event)
 	require.NoError(t, err)
-	node, err := nexusoperations.AddChild(root, "test-id", event, "endpoint-id", token, false)
+	node, err := nexusoperations.AddChild(root, "test-id", event, token, false)
 	require.NoError(t, err)
 	return node
 }
@@ -102,6 +102,7 @@ func mustNewScheduledEvent(schedTime time.Time, timeout time.Duration) *historyp
 		EventTime: timestamppb.New(schedTime),
 		Attributes: &historypb.HistoryEvent_NexusOperationScheduledEventAttributes{
 			NexusOperationScheduledEventAttributes: &historypb.NexusOperationScheduledEventAttributes{
+				EndpointId:             "endpoint-id",
 				Endpoint:               "endpoint",
 				Service:                "service",
 				Operation:              "operation",

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -67,12 +67,12 @@ type Operation struct {
 }
 
 // AddChild adds a new operation child machine to the given node and transitions it to the SCHEDULED state.
-func AddChild(node *hsm.Node, id string, event *historypb.HistoryEvent, endpointID string, eventToken []byte, deleteOnCompletion bool) (*hsm.Node, error) {
+func AddChild(node *hsm.Node, id string, event *historypb.HistoryEvent, eventToken []byte, deleteOnCompletion bool) (*hsm.Node, error) {
 	attrs := event.GetNexusOperationScheduledEventAttributes()
 
 	node, err := node.AddChild(hsm.Key{Type: OperationMachineType.ID, ID: id}, Operation{
 		&persistencespb.NexusOperationInfo{
-			EndpointId:             endpointID,
+			EndpointId:             attrs.EndpointId,
 			Endpoint:               attrs.Endpoint,
 			Service:                attrs.Service,
 			Operation:              attrs.Operation,

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -213,11 +213,21 @@ func RegisterStateMachines(r *hsm.Registry) error {
 	return r.RegisterMachine(cancelationMachineDefinition{})
 }
 
-// AttemptFailure carries failure information of an invocation attempt.
-type AttemptFailure struct {
-	Time time.Time
-	Err  error
-}
+// CompletionSource is an enum specifying where an operation completion originated from.
+type CompletionSource int
+
+const (
+	// CompletionSourceUnspecified indicates that the source is unspecified (e.g. when reapplying a history event that
+	// doesn't record this information).
+	CompletionSourceUnspecified CompletionSource = iota
+	// CompletionSourceResponse indicates that a completion came synchronously from a response to a StartOperation
+	// request.
+	CompletionSourceResponse CompletionSource = iota
+	// CompletionSourceResponse indicates that a completion came asynchronously from a callback.
+	CompletionSourceCallback CompletionSource = iota
+	// CompletionSourceCancelRequested indicates that the operation was canceled due to workflow cancelation request.
+	CompletionSourceCancelRequested CompletionSource = iota
+)
 
 // EventScheduled is triggered when the operation is meant to be scheduled - immediately after initialization.
 type EventScheduled struct {
@@ -249,7 +259,8 @@ var TransitionRescheduled = hsm.NewTransition(
 
 // EventAttemptFailed is triggered when an invocation attempt is failed with a retryable error.
 type EventAttemptFailed struct {
-	AttemptFailure
+	Time        time.Time
+	Err         error
 	Node        *hsm.Node
 	RetryPolicy backoff.RetryPolicy
 }
@@ -277,9 +288,10 @@ var TransitionAttemptFailed = hsm.NewTransition(
 
 // EventFailed is triggered when an invocation attempt is failed with a non retryable error.
 type EventFailed struct {
-	// Only set if the operation completed synchronously, as a response to a StartOperation RPC.
-	AttemptFailure *AttemptFailure
-	Node           *hsm.Node
+	Time             time.Time
+	Node             *hsm.Node
+	Attributes       *historypb.NexusOperationFailedEventAttributes
+	CompletionSource CompletionSource
 }
 
 var TransitionFailed = hsm.NewTransition(
@@ -290,10 +302,15 @@ var TransitionFailed = hsm.NewTransition(
 	},
 	enumsspb.NEXUS_OPERATION_STATE_FAILED,
 	func(op Operation, event EventFailed) (hsm.TransitionOutput, error) {
-		if event.AttemptFailure != nil {
-			op.recordAttempt(event.AttemptFailure.Time)
+		// When reapplying history, assume that if we transition from the SCHEDULED state the completion comes from a
+		// response to a StartOpration request.  This may not be the case if a completion comes in before a response to
+		// the request but we ignore that detail for simplicity.
+		if event.CompletionSource == CompletionSourceResponse ||
+			event.CompletionSource == CompletionSourceUnspecified && op.State() == enumsspb.NEXUS_OPERATION_STATE_SCHEDULED {
+			op.recordAttempt(event.Time)
 			op.LastAttemptFailure = &failurepb.Failure{
-				Message: event.AttemptFailure.Err.Error(),
+				// The top level failure in the event is just a wrapper for the actual cause.
+				Message: event.Attributes.GetFailure().GetCause().GetMessage(),
 				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
 					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
 						NonRetryable: true,
@@ -310,8 +327,9 @@ var TransitionFailed = hsm.NewTransition(
 // EventSucceeded is triggered when an invocation attempt succeeds.
 type EventSucceeded struct {
 	// Only set if the operation completed synchronously, as a response to a StartOperation RPC.
-	AttemptTime *time.Time
-	Node        *hsm.Node
+	Time             time.Time
+	Node             *hsm.Node
+	CompletionSource CompletionSource
 }
 
 var TransitionSucceeded = hsm.NewTransition(
@@ -322,8 +340,12 @@ var TransitionSucceeded = hsm.NewTransition(
 	},
 	enumsspb.NEXUS_OPERATION_STATE_SUCCEEDED,
 	func(op Operation, event EventSucceeded) (hsm.TransitionOutput, error) {
-		if event.AttemptTime != nil {
-			op.recordAttempt(*event.AttemptTime)
+		// When reapplying history, assume that if we transition from the SCHEDULED state the completion comes from a
+		// response to a StartOpration request.  This may not be the case if a completion comes in before a response to
+		// the request but we ignore that detail for simplicity.
+		if event.CompletionSource == CompletionSourceResponse ||
+			event.CompletionSource == CompletionSourceUnspecified && op.State() == enumsspb.NEXUS_OPERATION_STATE_SCHEDULED {
+			op.recordAttempt(event.Time)
 		}
 		// Keep last attempt information as-is for debuggability when completed asynchronously.
 		// When used in a workflow, this machine node will be deleted from the tree after this transition.
@@ -333,9 +355,9 @@ var TransitionSucceeded = hsm.NewTransition(
 
 // EventCanceled is triggered when an invocation attempt succeeds.
 type EventCanceled struct {
-	// Only set if the operation completed synchronously, as a response to a StartOperation RPC.
-	AttemptFailure *AttemptFailure
-	Node           *hsm.Node
+	Time             time.Time
+	Node             *hsm.Node
+	CompletionSource CompletionSource
 }
 
 var TransitionCanceled = hsm.NewTransition(
@@ -346,14 +368,13 @@ var TransitionCanceled = hsm.NewTransition(
 	},
 	enumsspb.NEXUS_OPERATION_STATE_CANCELED,
 	func(op Operation, event EventCanceled) (hsm.TransitionOutput, error) {
-		if event.AttemptFailure != nil {
-			op.recordAttempt(event.AttemptFailure.Time)
-			op.LastAttemptFailure = &failurepb.Failure{
-				Message: event.AttemptFailure.Err.Error(),
-				FailureInfo: &failurepb.Failure_CanceledFailureInfo{
-					CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
-				},
-			}
+		// When reapplying history, assume that if we transition from the SCHEDULED state the completion comes from a
+		// response to a StartOpration request.  This may not be the case if a completion comes in before a response to
+		// the request but we ignore that detail for simplicity.
+		if event.CompletionSource == CompletionSourceResponse ||
+			event.CompletionSource == CompletionSourceUnspecified && op.State() == enumsspb.NEXUS_OPERATION_STATE_SCHEDULED {
+			op.recordAttempt(event.Time)
+			op.LastAttemptFailure = nil
 		}
 		// Keep last attempt information as-is for debuggability when completed asynchronously.
 		// When used in a workflow, this machine node will be deleted from the tree after this transition.
@@ -414,7 +435,7 @@ func (o Operation) Cancel(node *hsm.Node, t time.Time) (hsm.TransitionOutput, er
 		return handleUnsuccessfulOperationError(node, o, &nexus.UnsuccessfulOperationError{
 			State:   nexus.OperationStateCanceled,
 			Failure: nexus.Failure{Message: "operation canceled before started"},
-		}, nil)
+		}, CompletionSourceCancelRequested)
 	}
 	return hsm.TransitionOutput{}, hsm.MachineTransition(child, func(c Cancelation) (hsm.TransitionOutput, error) {
 		return TranstionCancelationScheduled.Apply(c, EventCancelationScheduled{

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -219,14 +219,14 @@ type CompletionSource int
 const (
 	// CompletionSourceUnspecified indicates that the source is unspecified (e.g. when reapplying a history event that
 	// doesn't record this information).
-	CompletionSourceUnspecified CompletionSource = iota
+	CompletionSourceUnspecified = CompletionSource(iota)
 	// CompletionSourceResponse indicates that a completion came synchronously from a response to a StartOperation
 	// request.
-	CompletionSourceResponse CompletionSource = iota
+	CompletionSourceResponse
 	// CompletionSourceResponse indicates that a completion came asynchronously from a callback.
-	CompletionSourceCallback CompletionSource = iota
+	CompletionSourceCallback
 	// CompletionSourceCancelRequested indicates that the operation was canceled due to workflow cancelation request.
-	CompletionSourceCancelRequested CompletionSource = iota
+	CompletionSourceCancelRequested
 )
 
 // EventScheduled is triggered when the operation is meant to be scheduled - immediately after initialization.

--- a/components/nexusoperations/statemachine_test.go
+++ b/components/nexusoperations/statemachine_test.go
@@ -74,6 +74,7 @@ func TestAddChild(t *testing.T) {
 				EventTime: schedTime,
 				Attributes: &historypb.HistoryEvent_NexusOperationScheduledEventAttributes{
 					NexusOperationScheduledEventAttributes: &historypb.NexusOperationScheduledEventAttributes{
+						EndpointId:             "endpoint-id",
 						Endpoint:               "endpoint",
 						Service:                "service",
 						Operation:              "operation",
@@ -82,7 +83,7 @@ func TestAddChild(t *testing.T) {
 					},
 				},
 			}
-			child, err := nexusoperations.AddChild(root, "test-id", event, "endpoint-id", []byte("token"), false)
+			child, err := nexusoperations.AddChild(root, "test-id", event, []byte("token"), false)
 			require.NoError(t, err)
 			oap := root.Outputs()
 			require.Equal(t, 1, len(oap))

--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -129,6 +129,7 @@ func (ch *commandHandler) HandleScheduleCommand(
 		he.Attributes = &historypb.HistoryEvent_NexusOperationScheduledEventAttributes{
 			NexusOperationScheduledEventAttributes: &historypb.NexusOperationScheduledEventAttributes{
 				Endpoint:                     attrs.Endpoint,
+				EndpointId:                   endpoint.Id,
 				Service:                      attrs.Service,
 				Operation:                    attrs.Operation,
 				Input:                        attrs.Input,
@@ -211,6 +212,10 @@ func (ch *commandHandler) HandleCancelCommand(
 			Message: fmt.Sprintf("cancelation was already requested for an operation with scheduled event ID of %d", attrs.ScheduledEventId),
 		}
 	}
+
+	// TODO(bergundy): When we support machine deletion, this err may be an hsm.ErrStateMachineNotFound.
+	// We'll need to check buffered events and verify that there aren't any terminal events in there.
+	// Ideally the framework can abstract that for us though.
 	return err
 }
 

--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -140,8 +140,8 @@ func (ch *commandHandler) HandleScheduleCommand(
 		}
 		he.UserMetadata = command.UserMetadata
 	})
-	// TODO: make this prettier
-	return nexusoperations.ScheduledEventDefinition.Apply(nexusoperations.ScheduledEventDefinition{}, root, event)
+
+	return nexusoperations.ScheduledEventDefinition{}.Apply(root, event)
 }
 
 func (ch *commandHandler) HandleCancelCommand(
@@ -202,7 +202,7 @@ func (ch *commandHandler) HandleCancelCommand(
 		he.UserMetadata = command.UserMetadata
 	})
 
-	err = nexusoperations.CancelRequestedEventDefinition.Apply(nexusoperations.CancelRequestedEventDefinition{}, ms.HSM(), event)
+	err = nexusoperations.CancelRequestedEventDefinition{}.Apply(ms.HSM(), event)
 
 	// Cancel spawns a child Cancelation machine, if that machine already exists we got a duplicate cancelation request.
 	if errors.Is(err, hsm.ErrStateMachineAlreadyExists) {

--- a/service/history/hsm/events.go
+++ b/service/history/hsm/events.go
@@ -22,12 +22,16 @@
 
 package hsm
 
-import enumspb "go.temporal.io/api/enums/v1"
+import (
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+)
 
 // EventDefinition is a definition for a history event for a given event type.
 type EventDefinition interface {
 	Type() enumspb.EventType
 	// IsWorkflowTaskTrigger returns a boolean indicating whether this event type should trigger a workflow task.
 	IsWorkflowTaskTrigger() bool
-	// More methods will be added here once replication is implemented.
+	// Apply a history event to the state machine. Triggered during replication and workflow reset.
+	Apply(root *Node, event *historypb.HistoryEvent) error
 }

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -112,11 +112,10 @@ func (b *MutableStateRebuilderImpl) ApplyEvents(
 	if err != nil {
 		return nil, err
 	}
-	// must generate the activity timer / user timer at the very end
+	// TODO: There doesn't seem to be a good reason to generate tasks here since they'll be generated eventually when we
+	// close the transaction.
+	// Previously this comment was here: must generate the activity timer / user timer at the very end
 	taskGenerator := taskGeneratorProvider.NewTaskGenerator(b.shard, b.mutableState)
-	if err := taskGenerator.GenerateDirtySubStateMachineTasks(b.shard.StateMachineRegistry()); err != nil {
-		return nil, err
-	}
 	if err := taskGenerator.GenerateActivityTimerTasks(); err != nil {
 		return nil, err
 	}

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -2151,6 +2151,7 @@ func (s *stateBuilderSuite) TestApplyEvents_HSMRegistry() {
 		EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED,
 		Attributes: &historypb.HistoryEvent_NexusOperationScheduledEventAttributes{
 			NexusOperationScheduledEventAttributes: &historypb.NexusOperationScheduledEventAttributes{
+				EndpointId:                   "endpoint-id",
 				Endpoint:                     "endpoint",
 				Service:                      "service",
 				Operation:                    "operation",
@@ -2159,17 +2160,13 @@ func (s *stateBuilderSuite) TestApplyEvents_HSMRegistry() {
 			},
 		},
 	}
-	root, err := hsm.NewRoot(s.stateMachineRegistry, StateMachineType.ID, nil, make(map[int32]*persistencespb.StateMachineMap), s.mockMutableState)
-	s.NoError(err)
-	s.mockMutableState.EXPECT().HSM().Return(root).AnyTimes()
-	s.mockMutableState.HSM()
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 	s.mockUpdateVersion(event)
 
-	_, err = s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
+	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.NoError(err)
 	// Verify the event was applied.
-	sm, err := nexusoperations.MachineCollection(root).Data("5")
+	sm, err := nexusoperations.MachineCollection(s.mockMutableState.HSM()).Data("5")
 	s.NoError(err)
 	s.Equal(enumsspb.NEXUS_OPERATION_STATE_SCHEDULED, sm.State())
 }

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -145,6 +145,8 @@ func (s *stateBuilderSuite) SetupTest() {
 		WorkflowExecutionTimerTaskStatus: TimerTaskStatusCreated,
 	}
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(s.executionInfo).AnyTimes()
+	s.mockMutableState.EXPECT().GetCurrentVersion().Return(int64(1)).AnyTimes()
+	s.mockMutableState.EXPECT().TransitionCount().Return(int64(1)).AnyTimes()
 
 	taskGeneratorProvider = &testTaskGeneratorProvider{
 		mockMutableState:  s.mockMutableState,
@@ -170,6 +172,7 @@ func (s *stateBuilderSuite) mockUpdateVersion(events ...*historypb.HistoryEvent)
 	}
 	s.mockTaskGenerator.EXPECT().GenerateActivityTimerTasks().Return(nil)
 	s.mockTaskGenerator.EXPECT().GenerateUserTimerTasks().Return(nil)
+	s.mockTaskGenerator.EXPECT().GenerateDirtySubStateMachineTasks(s.stateMachineRegistry).Return(nil).AnyTimes()
 	s.mockMutableState.EXPECT().SetHistoryBuilder(historybuilder.NewImmutable(events))
 }
 
@@ -2162,7 +2165,6 @@ func (s *stateBuilderSuite) TestApplyEvents_HSMRegistry() {
 	s.mockMutableState.HSM()
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 	s.mockUpdateVersion(event)
-	s.mockTaskGenerator.EXPECT().GenerateDirtySubStateMachineTasks(s.stateMachineRegistry).Return(nil).AnyTimes()
 
 	_, err = s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.NoError(err)

--- a/service/history/workflow/task_generator_test.go
+++ b/service/history/workflow/task_generator_test.go
@@ -467,12 +467,14 @@ func TestTaskGenerator_GenerateDirtySubStateMachineTasks(t *testing.T) {
 		EventTime: timestamppb.Now(),
 		Attributes: &historypb.HistoryEvent_NexusOperationScheduledEventAttributes{
 			NexusOperationScheduledEventAttributes: &historypb.NexusOperationScheduledEventAttributes{
+				Endpoint:               "endpoint",
+				EndpointId:             "endpoint-id",
 				Service:                "some-service",
 				Operation:              "some-op",
 				ScheduleToCloseTimeout: durationpb.New(time.Hour),
 			},
 		},
-	}, "endpoint-id", []byte("token"), false)
+	}, []byte("token"), false)
 	require.NoError(t, err)
 	err = taskGenerator.GenerateDirtySubStateMachineTasks(reg)
 	require.NoError(t, err)

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -379,7 +379,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion_LargePayload() 
 
 	var result string
 	s.NoError(run.Get(ctx, &result))
-	s.Equal("result of StartOperation exceeds size limit", result)
+	s.Equal("http: response body too large", result)
 }
 
 func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {

--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -513,6 +513,10 @@ func (tc *TestCluster) GetHost() *temporalImpl {
 	return tc.host
 }
 
+func (tc *TestCluster) OverrideDynamicConfig(t *testing.T, key dynamicconfig.GenericSetting, value any) {
+	tc.host.dcClient.OverrideValue(t, key, value)
+}
+
 var errCannotAddCACertToPool = errors.New("failed adding CA to pool")
 
 func createFixedTLSConfigProvider() (*encryption.FixedTLSConfigProvider, error) {

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -34,12 +34,18 @@ import (
 	"os"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
 	replicationpb "go.temporal.io/api/replication/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/converter"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"gopkg.in/yaml.v3"
 
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/testing/historyrequire"
 
 	"go.temporal.io/server/api/adminservice/v1"
@@ -203,4 +209,59 @@ func (s *xdcBaseSuite) setupTest() {
 	s.HistoryRequire = historyrequire.New(s.T())
 
 	s.waitForClusterConnected()
+}
+
+func (s *xdcBaseSuite) createGlobalNamespace() string {
+	ctx := tests.NewContext()
+	ns := "test-namespace-" + uuid.NewString()
+
+	regReq := &workflowservice.RegisterNamespaceRequest{
+		Namespace:                        ns,
+		IsGlobalNamespace:                true,
+		Clusters:                         s.clusterReplicationConfig(),
+		ActiveClusterName:                s.clusterNames[0],
+		WorkflowExecutionRetentionPeriod: durationpb.New(7 * time.Hour * 24),
+	}
+	_, err := s.cluster1.GetFrontendClient().RegisterNamespace(ctx, regReq)
+	s.NoError(err)
+
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		// Wait for namespace record to be replicated and loaded into memory.
+		_, err := s.cluster2.GetHost().GetFrontendNamespaceRegistry().GetNamespace(namespace.Name(ns))
+		assert.NoError(t, err)
+	}, 15*time.Second, 500*time.Millisecond)
+
+	return ns
+}
+
+func (s *xdcBaseSuite) failover(
+	namespace string,
+	targetCluster string,
+	targetFailoverVersion int64,
+	client tests.FrontendClient,
+) {
+	// wait for replication task propagation
+	time.Sleep(4 * time.Second)
+
+	// update namespace to fail over
+	updateReq := &workflowservice.UpdateNamespaceRequest{
+		Namespace: namespace,
+		ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
+			ActiveClusterName: targetCluster,
+		},
+	}
+	updateResp, err := client.UpdateNamespace(tests.NewContext(), updateReq)
+	s.NoError(err)
+	s.Equal(targetCluster, updateResp.ReplicationConfig.GetActiveClusterName())
+	s.Equal(targetFailoverVersion, updateResp.GetFailoverVersion())
+
+	// wait till failover completed
+	time.Sleep(cacheRefreshInterval)
+}
+
+func (s *xdcBaseSuite) mustToPayload(v any) *commonpb.Payload {
+	conv := converter.GetDefaultDataConverter()
+	payload, err := conv.ToPayload(v)
+	s.NoError(err)
+	return payload
 }

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -3025,31 +3025,6 @@ func (s *FunctionalClustersTestSuite) getHistory(client tests.FrontendClient, na
 	return events
 }
 
-func (s *FunctionalClustersTestSuite) failover(
-	namespace string,
-	targetCluster string,
-	targetFailoverVersion int64,
-	client tests.FrontendClient,
-) {
-	// wait for replication task propagation
-	time.Sleep(4 * time.Second)
-
-	// update namespace to fail over
-	updateReq := &workflowservice.UpdateNamespaceRequest{
-		Namespace: namespace,
-		ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
-			ActiveClusterName: targetCluster,
-		},
-	}
-	updateResp, err := client.UpdateNamespace(tests.NewContext(), updateReq)
-	s.NoError(err)
-	s.Equal(targetCluster, updateResp.ReplicationConfig.GetActiveClusterName())
-	s.Equal(targetFailoverVersion, updateResp.GetFailoverVersion())
-
-	// wait till failover completed
-	time.Sleep(cacheRefreshInterval)
-}
-
 func (s *FunctionalClustersTestSuite) registerNamespace(namespace string, isGlobalNamespace bool) {
 	clusters := s.clusterReplicationConfig()
 	if !isGlobalNamespace {

--- a/tests/xdc/nexus_request_forwarding_test.go
+++ b/tests/xdc/nexus_request_forwarding_test.go
@@ -33,19 +33,16 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
-	"go.temporal.io/server/common/namespace"
 	cnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/tests"
 )
@@ -82,7 +79,7 @@ func (s *NexusRequestForwardingSuite) TearDownSuite() {
 // Only tests dispatch by namespace+task_queue.
 // TODO: Add test cases for dispatch by endpoint ID once endpoints support replication.
 func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToActive() {
-	ns := s.createNexusRequestForwardingNamespace()
+	ns := s.createGlobalNamespace()
 
 	testCases := []struct {
 		name      string
@@ -218,7 +215,7 @@ func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToAc
 // Only tests dispatch by namespace+task_queue.
 // TODO: Add test cases for dispatch by endpoint ID once endpoints support replication.
 func (s *NexusRequestForwardingSuite) TestCancelOperationForwardedFromStandbyToActive() {
-	ns := s.createNexusRequestForwardingNamespace()
+	ns := s.createGlobalNamespace()
 
 	testCases := []struct {
 		name      string
@@ -348,29 +345,6 @@ func (s *NexusRequestForwardingSuite) nexusTaskPoller(ctx context.Context, front
 	}
 
 	s.NoError(err)
-}
-
-func (s *NexusRequestForwardingSuite) createNexusRequestForwardingNamespace() string {
-	ctx := tests.NewContext()
-	ns := fmt.Sprintf("%v-%v", "test-namespace", uuid.New())
-
-	regReq := &workflowservice.RegisterNamespaceRequest{
-		Namespace:                        ns,
-		IsGlobalNamespace:                true,
-		Clusters:                         s.clusterReplicationConfig(),
-		ActiveClusterName:                s.clusterNames[0],
-		WorkflowExecutionRetentionPeriod: durationpb.New(7 * time.Hour * 24),
-	}
-	_, err := s.cluster1.GetFrontendClient().RegisterNamespace(ctx, regReq)
-	s.NoError(err)
-
-	s.EventuallyWithT(func(t *assert.CollectT) {
-		// Wait for namespace record to be replicated and loaded into memory.
-		_, err := s.cluster2.GetHost().GetFrontendNamespaceRegistry().GetNamespace(namespace.Name(ns))
-		assert.NoError(t, err)
-	}, 15*time.Second, 500*time.Millisecond)
-
-	return ns
 }
 
 func requireExpectedMetricsCaptured(t *testing.T, snap map[string][]*metricstest.CapturedRecording, ns string, method string, expectedOutcome string) {

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -1,0 +1,257 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xdc
+
+import (
+	"context"
+	"flag"
+	"io"
+	"net/http"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/suite"
+	commandpb "go.temporal.io/api/command/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/operatorservice/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	sdkclient "go.temporal.io/sdk/client"
+
+	"go.temporal.io/server/common/dynamicconfig"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexustest"
+	"go.temporal.io/server/components/nexusoperations"
+	"go.temporal.io/server/tests"
+)
+
+type NexusStateReplicationSuite struct {
+	xdcBaseSuite
+}
+
+func TestNexusStateReplicationTestSuite(t *testing.T) {
+	flag.Parse()
+	suite.Run(t, new(NexusStateReplicationSuite))
+}
+
+func (s *NexusStateReplicationSuite) SetupSuite() {
+	s.dynamicConfigOverrides = map[dynamicconfig.Key]any{
+		// Make sure we don't hit the rate limiter in tests
+		dynamicconfig.FrontendGlobalNamespaceNamespaceReplicationInducingAPIsRPS.Key(): 1000,
+		dynamicconfig.EnableNexus.Key():                  true,
+		dynamicconfig.RefreshNexusEndpointsMinWait.Key(): 1 * time.Millisecond,
+	}
+	s.setupSuite([]string{"nexus_state_replication_active", "nexus_state_replication_standby"})
+}
+
+func (s *NexusStateReplicationSuite) SetupTest() {
+	s.setupTest()
+}
+
+func (s *NexusStateReplicationSuite) TearDownSuite() {
+	s.tearDownSuite()
+}
+
+// TestNexusOperationEventsReplicated tests that nexus related operation events are replicated across clusters and that
+// the operation machinary functions as expected when failover happens.
+// General outline:
+// 1. Start two clusters, cluster1 set to active, cluster2 set to standby.
+// 2. Start a workflow on cluster1.
+// 3. Schedule a nexus operation on cluster1. The request is expected to fail due to missing dynamic config for the callback URL template.
+// 4. Failover to cluster2.
+// 5. Wait for the operation to be started on cluster2.
+// 6. Fail back to cluster1.
+// 7. Complete the operation via callback on cluster1.
+// 8. Check that the operation completion triggers a workflow task when we poll on cluster1.
+// 9. Complete the workflow.
+func (s *NexusStateReplicationSuite) TestNexusOperationEventsReplicated() {
+	var callbackToken string
+	var publicCallbackUrl string
+
+	h := nexustest.Handler{
+		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+			callbackToken = options.CallbackHeader.Get(commonnexus.CallbackTokenHeader)
+			publicCallbackUrl = options.CallbackURL
+			return &nexus.HandlerStartOperationResultAsync{OperationID: "test"}, nil
+		},
+	}
+	listenAddr := nexustest.AllocListenAddress(s.T())
+	nexustest.NewNexusServer(s.T(), listenAddr, h)
+
+	ctx := tests.NewContext()
+	ns := s.createGlobalNamespace()
+
+	// Set URL template after httpAPAddress is set, see commonnexus.RouteCompletionCallback.
+	// But only on cluster2, this will prevent the operation request from starting in cluster1, we expect the operation
+	// to be executed in cluster2 after failover is complete.
+	s.cluster2.OverrideDynamicConfig(
+		s.T(),
+		nexusoperations.CallbackURLTemplate,
+		// We'll send the callback to cluster1, when we fail back to it.
+		"http://"+s.cluster1.GetHost().FrontendHTTPAddress()+"/namespaces/{{.NamespaceName}}/nexus/callback")
+
+	// Nexus endpoints registry isn't replicated yet, manually create the same endpoint in both clusters.
+	for _, cl := range []operatorservice.OperatorServiceClient{s.cluster1.GetOperatorClient(), s.cluster2.GetOperatorClient()} {
+		_, err := cl.CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+			Spec: &nexuspb.EndpointSpec{
+				Name: "endpoint",
+				Target: &nexuspb.EndpointTarget{
+					Variant: &nexuspb.EndpointTarget_External_{
+						External: &nexuspb.EndpointTarget_External{
+							Url: "http://" + listenAddr,
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+	}
+
+	sdkClient1, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  s.cluster1.GetHost().FrontendGRPCAddress(),
+		Namespace: ns,
+	})
+	s.NoError(err)
+	sdkClient2, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  s.cluster2.GetHost().FrontendGRPCAddress(),
+		Namespace: ns,
+	})
+	s.NoError(err)
+
+	run, err := sdkClient1.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+		TaskQueue: "tq",
+		ID:        "test",
+	}, "workflow")
+	s.NoError(err)
+
+	pollRes := s.pollWorkflowTask(ctx, s.cluster1.GetFrontendClient(), ns)
+	_, err = s.cluster1.GetFrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		TaskToken: pollRes.TaskToken,
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION,
+				Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
+					ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
+						Endpoint:  "endpoint",
+						Service:   "service",
+						Operation: "operation",
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	// Ensure the scheduled event is replicated.
+	s.waitEvent(ctx, sdkClient2, run, enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED)
+
+	// Now failover, and let cluster2 be the active.
+	s.failover(ns, s.clusterNames[1], 2, s.cluster1.GetFrontendClient())
+
+	// Poll in cluster2 (previously standby) and verify the operation was started.
+	pollRes = s.pollWorkflowTask(ctx, s.cluster2.GetFrontendClient(), ns)
+	_, err = s.cluster2.GetFrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		TaskToken: pollRes.TaskToken,
+		Commands:  []*commandpb.Command{}, // No need to generate other commands, this "workflow" just waits for the operation to complete.
+	})
+	s.NoError(err)
+
+	// Ensure the started event is replicated back to cluster1.
+	s.waitEvent(ctx, sdkClient1, run, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
+
+	// Fail back to cluster1.
+	s.failover(ns, s.clusterNames[0], 11, s.cluster2.GetFrontendClient())
+
+	s.completeNexusOperation(ctx, "result", publicCallbackUrl, callbackToken)
+
+	// Verify completion triggers a new workflow task and that the workflow completes.
+	pollRes = s.pollWorkflowTask(ctx, s.cluster1.GetFrontendClient(), ns)
+	_, err = s.cluster1.GetFrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		TaskToken: pollRes.TaskToken,
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+					CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+	idx := slices.IndexFunc(pollRes.History.Events, func(ev *historypb.HistoryEvent) bool {
+		return ev.EventType == enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED
+	})
+	s.Greater(idx, -1)
+
+	s.NoError(run.Get(ctx, nil))
+}
+
+func (s *NexusStateReplicationSuite) waitEvent(ctx context.Context, sdkClient sdkclient.Client, run sdkclient.WorkflowRun, eventType enumspb.EventType) {
+	s.Eventually(func() bool {
+		history := sdkClient.GetWorkflowHistory(ctx, run.GetID(), run.GetRunID(), false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+		for history.HasNext() {
+			event, err := history.Next()
+			s.NoError(err)
+			if event.EventType == eventType {
+				return true
+			}
+		}
+		return false
+	}, time.Second*10, time.Millisecond*100)
+}
+
+func (s *NexusStateReplicationSuite) pollWorkflowTask(ctx context.Context, client tests.FrontendClient, ns string) *workflowservice.PollWorkflowTaskQueueResponse {
+	pollRes, err := client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+		Namespace: ns,
+		TaskQueue: &taskqueuepb.TaskQueue{
+			Name: "tq",
+			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+		},
+		Identity: "test",
+	})
+	s.NoError(err)
+	return pollRes
+}
+
+func (s *NexusStateReplicationSuite) completeNexusOperation(ctx context.Context, result any, callbackUrl, callbackToken string) {
+	completion, err := nexus.NewOperationCompletionSuccessful(s.mustToPayload(result), nexus.OperationCompletionSuccesfulOptions{
+		Serializer: commonnexus.PayloadSerializer,
+	})
+	s.NoError(err)
+	req, err := nexus.NewCompletionHTTPRequest(ctx, callbackUrl, completion)
+	s.NoError(err)
+	if callbackToken != "" {
+		req.Header.Add(commonnexus.CallbackTokenHeader, callbackToken)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	s.NoError(err)
+	defer res.Body.Close()
+	_, err = io.ReadAll(res.Body)
+	s.NoError(err)
+	s.Equal(http.StatusOK, res.StatusCode)
+}


### PR DESCRIPTION
## What changed?

- Added hooks to apply Nexus events during replication
- [Fix max retry interval for operations and callbacks](https://github.com/temporalio/temporal/commit/f6c15221c8640897b76fda5471b301d097572c8d)
- Added unit test and XDC test