### PR TITLE
Remove build id from sticky recordWorkflowTaskStarted

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -176,8 +176,9 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 		return nil, serviceerror.NewNotFound("Workflow task not found.")
 	}
 
-	if assignedBuildId := ms.GetAssignedBuildId(); assignedBuildId != "" {
-		// worker versioning is used, make sure the task was completed by the right build ID
+	if assignedBuildId := ms.GetAssignedBuildId(); assignedBuildId != "" && !ms.IsStickyTaskQueueSet() {
+		// Worker versioning is used, make sure the task was completed by the right build ID, unless we're using a
+		// sticky queue in which case Matching will not send the build ID
 		wftStartedBuildId := ms.GetExecutionInfo().GetWorkflowTaskBuildId()
 		wftCompletedBuildId := request.GetWorkerVersionStamp().GetBuildId()
 		if wftCompletedBuildId != wftStartedBuildId {

--- a/service/matching/version_sets.go
+++ b/service/matching/version_sets.go
@@ -399,7 +399,11 @@ func checkVersionForStickyPoll(data *persistencespb.VersioningData, caps *common
 		// A poller is using a build ID, but we don't know about that build ID. See comments in
 		// lookupVersionSetForPoll. If we consider it the default for its set, then we should
 		// leave it on the sticky queue here.
-		return false, nil
+		// We set return true for all sticky tasks until old versioning is cleaned up.
+		// this value is used by matching_engine for deciding if it should pass the worker build ID
+		// to history in the recordStart call or not. We don't need to pass build ID for sticky
+		// tasks as no redirect happen in a sticky queue.
+		return true, nil
 	}
 	set := data.VersionSets[setIdx]
 	lastIndex := len(set.BuildIds) - 1


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Remove build id from RecordWorkflowTaskStarted calls for sticky queue tasks.
## Why?
<!-- Tell your future self why have you made these changes -->
- When old versioning is used, delay in UserData propagation to sticky queue may make the sticky WFT invalid when it wants to start. this will result in delay in workflow executions because the sticky WFT will be dropped and WF will be blocked until a new normal task gets scheduled (5secs). Note that this is still much better that the workflow getting stuck which happens in 1.24.0 and 1.24.1 fixed by https://github.com/temporalio/temporal/pull/6095.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Unit tests will be added.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
None.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
None.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.