### PR TITLE
return an error if mutable state can't be loaded

### DIFF
--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -516,7 +516,7 @@ func (s *Starter) getMutableStateInfo(ctx context.Context, runID string) (*mutab
 	return extractMutableStateInfo(mutableState)
 }
 
-func (s *Starter) getMutableState(ctx context.Context, runID string) (workflow.MutableState, error) {
+func (s *Starter) getMutableState(ctx context.Context, runID string) (mutableState workflow.MutableState, retErr error) {
 	// We technically never want to create a new execution but in practice this should not happen.
 	workflowContext, releaseFn, err := s.workflowConsistencyChecker.GetWorkflowCache().GetOrCreateWorkflowExecution(
 		ctx,
@@ -529,14 +529,10 @@ func (s *Starter) getMutableState(ctx context.Context, runID string) (workflow.M
 		return nil, err
 	}
 
-	var releaseErr error
-	defer func() {
-		releaseFn(releaseErr)
-	}()
+	defer func() { releaseFn(retErr) }()
 
-	var mutableState workflow.MutableState
-	mutableState, releaseErr = workflowContext.LoadMutableState(ctx, s.shardContext)
-	return mutableState, nil
+	mutableState, retErr = workflowContext.LoadMutableState(ctx, s.shardContext)
+	return
 }
 
 // extractMutableStateInfo extracts the relevant information to generate a start response with an eager workflow task.

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -508,13 +508,13 @@ func (s *Starter) respondToRetriedRequest(
 }
 
 func (s *Starter) getWorkflowStartTime(ctx context.Context, runID string) (time.Time, error) {
-	mutableState, releaseFn, retError := s.getMutableState(ctx, runID)
+	mutableState, releaseFn, err := s.getMutableState(ctx, runID)
 	var workflowStartTime time.Time
-	if retError != nil {
-		return workflowStartTime, retError
+	if err != nil {
+		return workflowStartTime, err
 	}
 
-	defer func() { releaseFn(retError) }()
+	defer func() { releaseFn(err) }()
 
 	workflowStartTime = mutableState.GetExecutionInfo().StartTime.AsTime()
 	return workflowStartTime, nil
@@ -522,13 +522,13 @@ func (s *Starter) getWorkflowStartTime(ctx context.Context, runID string) (time.
 
 // getMutableStateInfo gets the relevant mutable state information while getting the state for the given run from the
 // workflow cache and managing the cache lease.
-func (s *Starter) getMutableStateInfo(ctx context.Context, runID string) (mutableSateInfo *mutableStateInfo, retError error) {
-	mutableState, releaseFn, retError := s.getMutableState(ctx, runID)
+func (s *Starter) getMutableStateInfo(ctx context.Context, runID string) (*mutableStateInfo, error) {
+	mutableState, releaseFn, err := s.getMutableState(ctx, runID)
 
-	if retError != nil {
-		return nil, retError
+	if err != nil {
+		return nil, err
 	}
-	defer func() { releaseFn(retError) }()
+	defer func() { releaseFn(err) }()
 
 	return extractMutableStateInfo(mutableState)
 }

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -517,10 +517,6 @@ func (s *Starter) getWorkflowStartTime(ctx context.Context, runID string) (time.
 
 	defer func() { releaseFn(retError) }()
 
-	if mutableState == nil {
-		return workflowStartTime, serviceerror.NewInternal("Can't load mutable state")
-	}
-
 	workflowStartTime = mutableState.GetExecutionInfo().StartTime.AsTime()
 	return workflowStartTime, nil
 }

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -508,7 +508,6 @@ func (s *Starter) respondToRetriedRequest(
 }
 
 func (s *Starter) getWorkflowStartTime(ctx context.Context, runID string) (time.Time, error) {
-
 	mutableState, releaseFn, retError := s.getMutableState(ctx, runID)
 	var workflowStartTime time.Time
 	if retError != nil {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Return an error if mutable state can't be loaded.

## Why?
<!-- Tell your future self why have you made these changes -->
To prevent using invalid mutable state, which can lead to panic.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
N/A

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
Yes(?)