### PR TITLE
Printing actual error when interceptor fails to add headers to response

### DIFF
--- a/common/rpc/grpc.go
+++ b/common/rpc/grpc.go
@@ -203,7 +203,7 @@ func addHeadersForResourceExhausted(ctx context.Context, logger log.Logger, err 
 			ResourceExhaustedScopeHeader, reErr.Scope.String(),
 		))
 		if headerErr != nil {
-			logger.Error("Failed to add Resource-Exhausted headers to response", tag.Error(err))
+			logger.Error("Failed to add Resource-Exhausted headers to response", tag.Error(headerErr))
 		}
 	}
 }


### PR DESCRIPTION
## What changed?
Printing the actual error when interceptor fails to add resource exhausted error cause to grpc headers.

## Why?
We were priting the resource exhausted error in this case. This is not useful to find why this operation failed.

## How did you test it?
Unit test

## Potential risks

## Documentation

## Is hotfix candidate?
No
