### PR TITLE
Move common.InterruptibleSleep to util

### DIFF
--- a/common/nexus/endpoint_registry.go
+++ b/common/nexus/endpoint_registry.go
@@ -33,13 +33,13 @@ import (
 
 	"go.temporal.io/server/api/matchingservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	p "go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/internal/goro"
 )
 
@@ -178,7 +178,7 @@ func (r *EndpointRegistryImpl) refreshEndpointsLoop(ctx context.Context) error {
 				r.dataReady = make(chan struct{})
 			}
 			hasLoadedEndpointData = false
-			common.InterruptibleSleep(ctx, r.config.refreshMinWait())
+			util.InterruptibleSleep(ctx, r.config.refreshMinWait())
 			continue
 		}
 
@@ -204,7 +204,7 @@ func (r *EndpointRegistryImpl) refreshEndpointsLoop(ctx context.Context) error {
 		// spinning. So enforce a minimum wait time that increases as long as we keep getting
 		// very fast replies.
 		if elapsed < minWaitTime {
-			common.InterruptibleSleep(ctx, minWaitTime-elapsed)
+			util.InterruptibleSleep(ctx, minWaitTime-elapsed)
 			// Don't let this get near our call timeout, otherwise we can't tell the difference
 			// between a fast reply and a timeout.
 			minWaitTime = min(minWaitTime*2, r.config.refreshLongPollTimeout()/2)

--- a/common/util.go
+++ b/common/util.go
@@ -173,16 +173,6 @@ func BlockWithTimeout(fn func(), timeout time.Duration) bool {
 	}
 }
 
-// InterruptibleSleep is like time.Sleep but can be interrupted by a context.
-func InterruptibleSleep(ctx context.Context, timeout time.Duration) {
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case <-timer.C:
-	case <-ctx.Done():
-	}
-}
-
 // CreatePersistenceClientRetryPolicy creates a retry policy for calls to persistence
 func CreatePersistenceClientRetryPolicy() backoff.RetryPolicy {
 	return backoff.NewExponentialRetryPolicy(persistenceClientRetryInitialInterval).

--- a/common/util/util.go
+++ b/common/util/util.go
@@ -27,6 +27,7 @@
 package util
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -171,4 +172,14 @@ func RepeatSlice[T any](xs []T, n int) []T {
 // Ptr returns a pointer to a copy of v.
 func Ptr[T any](v T) *T {
 	return &v
+}
+
+// InterruptibleSleep is like time.Sleep but can be interrupted by a context.
+func InterruptibleSleep(ctx context.Context, timeout time.Duration) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+	}
 }

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/internal/goro"
 )
 
@@ -160,7 +161,7 @@ dispatchLoop:
 					// Don't log here if encounters missing user data error when dispatch a versioned task.
 					tr.throttledLogger().Error("taskReader: unexpected error dispatching task", tag.Error(err))
 				}
-				common.InterruptibleSleep(ctx, taskReaderOfferThrottleWait)
+				util.InterruptibleSleep(ctx, taskReaderOfferThrottleWait)
 			}
 			return ctx.Err()
 		case <-ctx.Done():

--- a/service/matching/user_data_manager.go
+++ b/service/matching/user_data_manager.go
@@ -44,6 +44,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/tqid"
+	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/internal/goro"
 )
 
@@ -309,7 +310,7 @@ func (m *userDataManagerImpl) fetchUserData(ctx context.Context) error {
 		// spinning. So enforce a minimum wait time that increases as long as we keep getting
 		// very fast replies.
 		if elapsed < minWaitTime {
-			common.InterruptibleSleep(ctx, minWaitTime-elapsed)
+			util.InterruptibleSleep(ctx, minWaitTime-elapsed)
 			// Don't let this get near our call timeout, otherwise we can't tell the difference
 			// between a fast reply and a timeout.
 			minWaitTime = min(minWaitTime*2, m.config.GetUserDataLongPollTimeout()/2)


### PR DESCRIPTION
## What changed?
Move this utility function.

## Why?
`common` has too many dependencies and this doesn't need any. Avoids import cycles.

## How did you test it?
Just moving code