### PR TITLE
Add adaptive worker pool

### DIFF
--- a/common/clock/event_time_source.go
+++ b/common/clock/event_time_source.go
@@ -118,6 +118,14 @@ func (ts *EventTimeSource) Advance(d time.Duration) {
 	ts.fireTimers()
 }
 
+// NumTimers returns the number of outstanding timers.
+func (ts *EventTimeSource) NumTimers() int {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	return len(ts.timers)
+}
+
 // fireTimers fires all timers that are ready.
 func (ts *EventTimeSource) fireTimers() {
 	n := 0

--- a/common/clock/event_time_source.go
+++ b/common/clock/event_time_source.go
@@ -89,6 +89,15 @@ func (ts *EventTimeSource) AfterFunc(d time.Duration, f func()) Timer {
 	return t
 }
 
+// NewTimer creates a Timer that will send the current time on a channel after at least
+// duration d. It returns the channel and the Timer.
+func (ts *EventTimeSource) NewTimer(d time.Duration) (<-chan time.Time, Timer) {
+	c := make(chan time.Time, 1)
+	// we can't call ts.Now() from the callback so just calculate what it should be
+	target := ts.Now().Add(d)
+	return c, ts.AfterFunc(d, func() { c <- target })
+}
+
 // Update the fake current time. It returns the timeSource so that you can chain calls like this:
 // timeSource := NewEventTimeSource().Update(time.Now())
 func (ts *EventTimeSource) Update(now time.Time) *EventTimeSource {

--- a/common/clock/event_time_source_test.go
+++ b/common/clock/event_time_source_test.go
@@ -203,3 +203,25 @@ func TestEventTimeSource_Update(t *testing.T) {
 	ev1.AssertFiredOnce("Timer should fire after deadline")
 	ev2.AssertFiredOnce("Timer should fire after deadline")
 }
+
+func TestEventTimeSource_NewTimer(t *testing.T) {
+	t.Parallel()
+
+	source := clock.NewEventTimeSource()
+
+	ch, _ := source.NewTimer(time.Second)
+
+	select {
+	case <-ch:
+		t.Error("shouldn't fire yet")
+	default:
+	}
+
+	source.Advance(2 * time.Second)
+
+	select {
+	case <-ch:
+	default:
+		t.Error("should have fired")
+	}
+}

--- a/common/clock/time_source.go
+++ b/common/clock/time_source.go
@@ -34,6 +34,7 @@ type (
 	TimeSource interface {
 		Now() time.Time
 		AfterFunc(d time.Duration, f func()) Timer
+		NewTimer(d time.Duration) (<-chan time.Time, Timer)
 	}
 	// Timer is a timer returned by TimeSource.AfterFunc. Unlike the timers returned by [time.NewTimer] or time.Ticker,
 	// this timer does not have a channel. That is because the callback already reacts to the timer firing.
@@ -62,4 +63,10 @@ func (ts RealTimeSource) Now() time.Time {
 // AfterFunc is a pass-through to time.AfterFunc.
 func (ts RealTimeSource) AfterFunc(d time.Duration, f func()) Timer {
 	return time.AfterFunc(d, f)
+}
+
+// NewTimer is a pass-through to time.NewTimer.
+func (ts RealTimeSource) NewTimer(d time.Duration) (<-chan time.Time, Timer) {
+	t := time.NewTimer(d)
+	return t.C, t
 }

--- a/common/clock/time_source_test.go
+++ b/common/clock/time_source_test.go
@@ -26,6 +26,7 @@ package clock_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/server/common/clock"
@@ -50,4 +51,21 @@ func TestNewRealClock_AfterFunc(t *testing.T) {
 
 	<-ch
 	assert.False(t, timer.Stop())
+}
+
+func TestNewRealClock_NewTimer(t *testing.T) {
+	t.Parallel()
+
+	source := clock.NewRealTimeSource()
+	ch, timer := source.NewTimer(0)
+	<-ch
+	assert.False(t, timer.Stop())
+}
+
+func TestNewRealClock_NewTimer_Stop(t *testing.T) {
+	t.Parallel()
+
+	source := clock.NewRealTimeSource()
+	_, timer := source.NewTimer(time.Second)
+	assert.True(t, timer.Stop())
 }

--- a/internal/goro/adaptive_pool.go
+++ b/internal/goro/adaptive_pool.go
@@ -1,0 +1,122 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package goro
+
+import (
+	"math/rand"
+	"sync/atomic"
+	"time"
+)
+
+type (
+	// AdaptivePool manages a pool of goroutines to handle small items of work.
+	// The size of the pool starts with minWorkers but can grow if needed, up to maxWorkers,
+	// and can shrink back down to minWorkers.
+	AdaptivePool struct {
+		minWorkers   int
+		maxWorkers   int
+		targetDelay  time.Duration
+		shrinkFactor float64
+
+		ch      chan func()
+		workers atomic.Int64
+	}
+)
+
+func NewAdaptivePool(
+	minWorkers int,
+	maxWorkers int,
+	targetDelay time.Duration,
+	shrinkFactor float64,
+) *AdaptivePool {
+	p := &AdaptivePool{
+		minWorkers:   minWorkers,
+		maxWorkers:   maxWorkers,
+		targetDelay:  targetDelay,
+		shrinkFactor: shrinkFactor,
+		ch:           make(chan func()),
+	}
+	for i := 0; i < minWorkers; i++ {
+		go p.work()
+	}
+	p.workers.Store(int64(minWorkers))
+	return p
+}
+
+// Stops workers. Note that this does not wait for workers to exit.
+func (p *AdaptivePool) Stop() {
+	close(p.ch)
+}
+
+// Do calls f() on a worker. If the call can't be started within targetDelay, it adds another
+// worker.
+func (p *AdaptivePool) Do(f func()) {
+	have := p.workers.Load()
+	if have < int64(p.maxWorkers) {
+		// we might want to add a worker, send with timeout
+		timeout := time.NewTimer(p.targetDelay)
+		select {
+		case p.ch <- f:
+			timeout.Stop()
+			return
+		case <-timeout.C:
+		}
+
+		if p.workers.CompareAndSwap(have, have+1) {
+			go p.work()
+		}
+	}
+
+	// blocking send
+	p.ch <- f
+}
+
+func (p *AdaptivePool) work() {
+	for {
+		have := p.workers.Load()
+		if have > int64(p.minWorkers) {
+			// we might want to exit, receive with timeout
+			// jitter this so we shrink slower than we grow
+			timeout := time.NewTimer(time.Duration(float64(p.targetDelay) * (1 + p.shrinkFactor*rand.Float64())))
+			select {
+			case f, ok := <-p.ch:
+				if !ok {
+					return
+				}
+				f()
+				continue
+			case <-timeout.C:
+			}
+			if p.workers.CompareAndSwap(have, have-1) {
+				return
+			}
+		}
+
+		// blocking receive
+		f, ok := <-p.ch
+		if !ok {
+			return
+		}
+		f()
+	}
+}

--- a/internal/goro/adaptive_pool_test.go
+++ b/internal/goro/adaptive_pool_test.go
@@ -1,0 +1,123 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package goro_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.temporal.io/server/internal/goro"
+)
+
+func TestAdaptivePool_CallsF(t *testing.T) {
+	p := goro.NewAdaptivePool(1, 10, time.Millisecond, 10)
+	defer p.Stop()
+
+	start := time.Now()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	p.Do(wg.Done)
+	wg.Wait()
+	assert.Less(t, time.Since(start), time.Second)
+}
+
+func TestAdaptivePool_Grows(t *testing.T) {
+	p := goro.NewAdaptivePool(1, 10, time.Millisecond, 10)
+	defer p.Stop()
+
+	start := time.Now()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	// occupy five workers for 1s
+	p.Do(func() { time.Sleep(time.Second) })
+	p.Do(func() { time.Sleep(time.Second) })
+	p.Do(func() { time.Sleep(time.Second) })
+	p.Do(func() { time.Sleep(time.Second) })
+	p.Do(func() { time.Sleep(time.Second) })
+	// sixth call will start new worker and complete in < 1s
+	p.Do(wg.Done)
+	wg.Wait()
+
+	assert.Less(t, time.Since(start), time.Second)
+}
+
+func TestAdaptivePool_DoesntGrowPastMax(t *testing.T) {
+	p := goro.NewAdaptivePool(1, 5, time.Millisecond, 10)
+	defer p.Stop()
+
+	start := time.Now()
+	interruptCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	// occupy five workers, one is interruptible
+	p.Do(func() { time.Sleep(time.Second) })
+	p.Do(func() { time.Sleep(time.Second) })
+	p.Do(func() { interruptCh <- struct{}{} })
+	p.Do(func() { time.Sleep(time.Second) })
+	p.Do(func() { time.Sleep(time.Second) })
+	// sixth call will block
+	go func() {
+		p.Do(func() { time.Sleep(time.Second) })
+		doneCh <- struct{}{}
+	}()
+
+	// wait for done
+	select {
+	case <-doneCh:
+		t.Error("should not be done yet")
+		return
+	case <-time.After(10 * time.Millisecond):
+	}
+	// unblock fifth, allow sixth to run
+	<-interruptCh
+	// wait for sixth
+	<-doneCh
+
+	assert.Less(t, time.Since(start), time.Second)
+}
+
+func TestAdaptivePool_ShrinksAgain(t *testing.T) {
+	p := goro.NewAdaptivePool(1, 5, 10*time.Millisecond, 1)
+	defer p.Stop()
+
+	// make 3 calls to force it to grow to 3 workers
+	p.Do(func() { time.Sleep(time.Second) })
+	p.Do(func() { time.Sleep(time.Second) })
+	p.Do(func() {})
+
+	// now there are 3 workers with one free, another call or two should start immediately
+	start := time.Now()
+	p.Do(func() {})
+	p.Do(func() {})
+	assert.Less(t, time.Since(start), 10*time.Millisecond)
+
+	// after 10ms, it should shrink back to 2
+	time.Sleep(20 * time.Millisecond)
+
+	// next call will wait for targetDelay
+	start = time.Now()
+	p.Do(func() {})
+	assert.Greater(t, time.Since(start), 10*time.Millisecond)
+}


### PR DESCRIPTION
## What changed?
- Add a utility to manage a pool of goroutine workers.
- Add NewTimer to the TimeSource interface.

## Why?
To use this for dynamic config subscription callbacks. It can also be used in the deadlock detector (where the pattern was taken from and expanded).

## How did you test it?
unit tests
