### PR TITLE
Copy over completion callbacks when creating a new mutable state in a chain

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -1315,7 +1315,7 @@ func (handler *workflowTaskCompletedHandler) handleRetry(
 	}
 	startAttr := startEvent.GetWorkflowExecutionStartedEventAttributes()
 
-	newMutableState := workflow.NewMutableStateInChain(
+	newMutableState, err := workflow.NewMutableStateInChain(
 		handler.shard,
 		handler.shard.GetEventsCache(),
 		handler.shard.GetLogger(),
@@ -1325,6 +1325,9 @@ func (handler *workflowTaskCompletedHandler) handleRetry(
 		handler.shard.GetTimeSource().Now(),
 		handler.mutableState,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = workflow.SetupNewWorkflowForRetryOrCron(
 		ctx,
@@ -1371,7 +1374,7 @@ func (handler *workflowTaskCompletedHandler) handleCron(
 		lastCompletionResult = startAttr.LastCompletionResult
 	}
 
-	newMutableState := workflow.NewMutableStateInChain(
+	newMutableState, err := workflow.NewMutableStateInChain(
 		handler.shard,
 		handler.shard.GetEventsCache(),
 		handler.shard.GetLogger(),
@@ -1381,6 +1384,9 @@ func (handler *workflowTaskCompletedHandler) handleCron(
 		handler.shard.GetTimeSource().Now(),
 		handler.mutableState,
 	)
+	if err != nil {
+		return err
+	}
 
 	err = workflow.SetupNewWorkflowForRetryOrCron(
 		ctx,

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -612,7 +612,7 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowRunTimeoutTask(
 	}
 	startAttr := startEvent.GetWorkflowExecutionStartedEventAttributes()
 
-	newMutableState := workflow.NewMutableStateInChain(
+	newMutableState, err := workflow.NewMutableStateInChain(
 		t.shardContext,
 		t.shardContext.GetEventsCache(),
 		t.shardContext.GetLogger(),
@@ -622,6 +622,10 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowRunTimeoutTask(
 		t.shardContext.GetTimeSource().Now(),
 		mutableState,
 	)
+	if err != nil {
+		return err
+	}
+
 	err = workflow.SetupNewWorkflowForRetryOrCron(
 		ctx,
 		mutableState,

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -542,7 +542,7 @@ func (s *mutableStateSuite) TestNewMutableStateInChain() {
 				)
 				currentMutableState.GetExecutionInfo().WorkflowExecutionTimerTaskStatus = taskStatus
 
-				newMutableState := NewMutableStateInChain(
+				newMutableState, err := NewMutableStateInChain(
 					s.mockShard,
 					s.mockEventsCache,
 					s.logger,
@@ -552,6 +552,7 @@ func (s *mutableStateSuite) TestNewMutableStateInChain() {
 					s.mockShard.GetTimeSource().Now(),
 					currentMutableState,
 				)
+				s.NoError(err)
 				s.Equal(taskStatus, newMutableState.GetExecutionInfo().WorkflowExecutionTimerTaskStatus)
 			},
 		)

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -716,9 +716,10 @@ func (b *MutableStateRebuilderImpl) applyNewRunHistory(
 		sameWorkflowChain = newRunFirstRunID == b.mutableState.GetExecutionInfo().FirstExecutionRunId
 	}
 
+	var err error
 	var newRunMutableState MutableState
 	if sameWorkflowChain {
-		newRunMutableState = NewMutableStateInChain(
+		newRunMutableState, err = NewMutableStateInChain(
 			b.shard,
 			b.shard.GetEventsCache(),
 			b.logger,
@@ -728,6 +729,9 @@ func (b *MutableStateRebuilderImpl) applyNewRunHistory(
 			timestamp.TimeValue(newRunHistory[0].GetEventTime()),
 			b.mutableState,
 		)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		newRunMutableState = NewMutableState(
 			b.shard,
@@ -742,7 +746,7 @@ func (b *MutableStateRebuilderImpl) applyNewRunHistory(
 
 	newRunStateBuilder := NewMutableStateRebuilder(b.shard, b.logger, newRunMutableState)
 
-	_, err := newRunStateBuilder.ApplyEvents(
+	_, err = newRunStateBuilder.ApplyEvents(
 		ctx,
 		namespaceID,
 		uuid.New(),

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -121,6 +121,10 @@ func (s *stateBuilderSuite) SetupTest() {
 	s.NoError(err)
 	s.mockShard.SetStateMachineRegistry(reg)
 
+	root, err := hsm.NewRoot(reg, StateMachineType.ID, s.mockMutableState, make(map[int32]*persistencespb.StateMachineMap), s.mockMutableState)
+	s.NoError(err)
+	s.mockMutableState.EXPECT().HSM().Return(root).AnyTimes()
+
 	s.mockNamespaceCache = s.mockShard.Resource.NamespaceCache
 	s.mockClusterMetadata = s.mockShard.Resource.ClusterMetadata
 	s.mockEventsCache = s.mockShard.MockEventsCache

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -42,9 +43,10 @@ import (
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/internal/temporalite"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type completionHandler struct {
@@ -169,100 +171,146 @@ func (s *FunctionalSuite) TestWorkflowCallbacks_InvalidArgument() {
 	}
 }
 
-func (s *FunctionalSuite) TestWorkflowNexusCallbacks_CarriedOverContinueAsNew() {
+func (s *FunctionalSuite) TestWorkflowNexusCallbacks_CarriedOver() {
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.EnableNexus, true)
 	defer dc.RemoveOverride(dynamicconfig.EnableNexus)
 
-	ctx := NewContext()
-	sdkClient, err := client.Dial(client.Options{
-		HostPort:  s.testCluster.GetHost().FrontendGRPCAddress(),
-		Namespace: s.namespace,
-	})
-	s.NoError(err)
-	pp := temporalite.NewPortProvider()
-
-	taskQueue := s.randomizeStr(s.T().Name())
-	workflowType := "test"
-
-	w := worker.New(sdkClient, taskQueue, worker.Options{})
-	wf := func(ctx workflow.Context) (int, error) {
-		// Verify that the callback is carried over the CAN boundary.
-		if workflow.GetInfo(ctx).ContinuedExecutionRunID == "" {
-			return 0, workflow.NewContinueAsNewError(ctx, workflowType)
-		}
-		return 666, nil
-	}
-	ch := &completionHandler{
-		requestCh:         make(chan *nexus.CompletionRequest, 1),
-		requestCompleteCh: make(chan error, 1),
-	}
-	callbackAddress := fmt.Sprintf("localhost:%d", pp.MustGetFreePort())
-	s.NoError(pp.Close())
-	shutdownServer := s.runNexusCompletionHTTPServer(ch, callbackAddress)
-	defer func() {
-		err := shutdownServer()
-		if err != nil {
-			panic(err)
-		}
-	}()
-	w.RegisterWorkflowWithOptions(wf, workflow.RegisterOptions{Name: workflowType})
-	s.NoError(w.Start())
-	defer w.Stop()
-
-	// TODO: use sdkClient instead of directly calling the history engine when callbacks are exposed
-	request := &workflowservice.StartWorkflowExecutionRequest{
-		RequestId:          uuid.New(),
-		Namespace:          s.namespace,
-		WorkflowId:         s.randomizeStr(s.T().Name()),
-		WorkflowType:       &commonpb.WorkflowType{Name: workflowType},
-		TaskQueue:          &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-		Input:              nil,
-		WorkflowRunTimeout: durationpb.New(100 * time.Second),
-		Identity:           s.T().Name(),
-		CompletionCallbacks: []*commonpb.Callback{
-			{
-				Variant: &commonpb.Callback_Nexus_{
-					Nexus: &commonpb.Callback_Nexus{
-						Url: "http://" + callbackAddress,
-					},
-				},
+	cases := []struct {
+		name       string
+		wf         func(workflow.Context) (int, error)
+		runTimeout time.Duration
+	}{
+		{
+			name: "ContinueAsNew",
+			wf: func(ctx workflow.Context) (int, error) {
+				// Verify that the callback is carried over the CAN boundary.
+				if workflow.GetInfo(ctx).ContinuedExecutionRunID == "" {
+					return 0, workflow.NewContinueAsNewError(ctx, "test")
+				}
+				return 666, nil
 			},
+			runTimeout: 100 * time.Second,
+		},
+		{
+			name: "WorkflowRunTimeout",
+			wf: func(ctx workflow.Context) (int, error) {
+				// Verify that the callback is carried over the retry on run timeout boundary.
+				info := workflow.GetInfo(ctx)
+				if info.FirstRunID == info.WorkflowExecution.RunID {
+					return 0, workflow.Sleep(ctx, 1*time.Second)
+				}
+				s.Greater(info.Attempt, int32(1))
+				return 666, nil
+			},
+			runTimeout: 100 * time.Millisecond,
+		},
+		{
+			name: "WorkflowFailureRetry",
+			wf: func(ctx workflow.Context) (int, error) {
+				// Verify that the callback is carried over the retry on failure boundary.
+				info := workflow.GetInfo(ctx)
+				if info.FirstRunID == info.WorkflowExecution.RunID {
+					return 0, errors.New("intentional workflow failure")
+				}
+				s.Greater(info.Attempt, int32(1))
+				return 666, nil
+			},
+			runTimeout: 100 * time.Second,
 		},
 	}
 
-	_, err = s.engine.StartWorkflowExecution(ctx, request)
-	s.NoError(err)
+	for _, tc := range cases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			ctx := NewContext()
+			sdkClient, err := client.Dial(client.Options{
+				HostPort:  s.testCluster.GetHost().FrontendGRPCAddress(),
+				Namespace: s.namespace,
+			})
+			s.NoError(err)
+			pp := temporalite.NewPortProvider()
 
-	run := sdkClient.GetWorkflow(ctx, request.WorkflowId, "")
-	s.NoError(run.Get(ctx, nil))
+			taskQueue := s.randomizeStr(s.T().Name())
+			workflowType := "test"
 
-	numAttempts := 2
-	for attempt := 1; attempt <= numAttempts; attempt++ {
-		completion := <-ch.requestCh
-		s.Equal(nexus.OperationStateSucceeded, completion.State)
-		var result int
-		s.NoError(completion.Result.Consume(&result))
-		s.Equal(666, result)
-		var err error
-		if attempt < numAttempts {
-			// force retry
-			err = nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "intentional error")
-		}
-		ch.requestCompleteCh <- err
-		description, err := sdkClient.DescribeWorkflowExecution(ctx, request.WorkflowId, "")
-		s.NoError(err)
-		s.Equal(1, len(description.Callbacks))
-		callbackInfo := description.Callbacks[0]
-		s.ProtoEqual(request.CompletionCallbacks[0], callbackInfo.Callback)
-		s.ProtoEqual(&workflowpb.CallbackInfo_Trigger{Variant: &workflowpb.CallbackInfo_Trigger_WorkflowClosed{WorkflowClosed: &workflowpb.CallbackInfo_WorkflowClosed{}}}, callbackInfo.Trigger)
-		s.Equal(int32(attempt), callbackInfo.Attempt)
-		if attempt < numAttempts {
-			s.Equal(enumspb.CALLBACK_STATE_BACKING_OFF, callbackInfo.State)
-			s.Equal("request failed with: 500 Internal Server Error", callbackInfo.LastAttemptFailure.Message)
-		} else {
-			s.Equal(enumspb.CALLBACK_STATE_SUCCEEDED, callbackInfo.State)
-			s.Nil(callbackInfo.LastAttemptFailure)
-		}
+			w := worker.New(sdkClient, taskQueue, worker.Options{})
+
+			ch := &completionHandler{
+				requestCh:         make(chan *nexus.CompletionRequest, 1),
+				requestCompleteCh: make(chan error, 1),
+			}
+			callbackAddress := fmt.Sprintf("localhost:%d", pp.MustGetFreePort())
+			s.NoError(pp.Close())
+			shutdownServer := s.runNexusCompletionHTTPServer(ch, callbackAddress)
+			defer func() {
+				require.NoError(t, shutdownServer())
+			}()
+			w.RegisterWorkflowWithOptions(tc.wf, workflow.RegisterOptions{Name: workflowType})
+			s.NoError(w.Start())
+			defer w.Stop()
+
+			// TODO: use sdkClient instead of directly calling the history engine when callbacks are exposed
+			request := &workflowservice.StartWorkflowExecutionRequest{
+				RequestId:          uuid.New(),
+				Namespace:          s.namespace,
+				WorkflowId:         s.randomizeStr(s.T().Name()),
+				WorkflowType:       &commonpb.WorkflowType{Name: workflowType},
+				TaskQueue:          &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				Input:              nil,
+				WorkflowRunTimeout: durationpb.New(tc.runTimeout),
+				Identity:           s.T().Name(),
+				RetryPolicy: &commonpb.RetryPolicy{
+					InitialInterval:        durationpb.New(1 * time.Second),
+					MaximumAttempts:        3,
+					MaximumInterval:        durationpb.New(1 * time.Second),
+					NonRetryableErrorTypes: []string{"bad-bug"},
+					BackoffCoefficient:     1,
+				},
+				CompletionCallbacks: []*commonpb.Callback{
+					{
+						Variant: &commonpb.Callback_Nexus_{
+							Nexus: &commonpb.Callback_Nexus{
+								Url: "http://" + callbackAddress,
+							},
+						},
+					},
+				},
+			}
+
+			_, err = s.engine.StartWorkflowExecution(ctx, request)
+			s.NoError(err)
+
+			run := sdkClient.GetWorkflow(ctx, request.WorkflowId, "")
+			s.NoError(run.Get(ctx, nil))
+
+			numAttempts := 2
+			for attempt := 1; attempt <= numAttempts; attempt++ {
+				completion := <-ch.requestCh
+				s.Equal(nexus.OperationStateSucceeded, completion.State)
+				var result int
+				s.NoError(completion.Result.Consume(&result))
+				s.Equal(666, result)
+				var err error
+				if attempt < numAttempts {
+					// force retry
+					err = nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "intentional error")
+				}
+				ch.requestCompleteCh <- err
+				description, err := sdkClient.DescribeWorkflowExecution(ctx, request.WorkflowId, "")
+				s.NoError(err)
+				s.Equal(1, len(description.Callbacks))
+				callbackInfo := description.Callbacks[0]
+				s.ProtoEqual(request.CompletionCallbacks[0], callbackInfo.Callback)
+				s.ProtoEqual(&workflowpb.CallbackInfo_Trigger{Variant: &workflowpb.CallbackInfo_Trigger_WorkflowClosed{WorkflowClosed: &workflowpb.CallbackInfo_WorkflowClosed{}}}, callbackInfo.Trigger)
+				s.Equal(int32(attempt), callbackInfo.Attempt)
+				if attempt < numAttempts {
+					s.Equal(enumspb.CALLBACK_STATE_BACKING_OFF, callbackInfo.State)
+					s.Equal("request failed with: 500 Internal Server Error", callbackInfo.LastAttemptFailure.Message)
+				} else {
+					s.Equal(enumspb.CALLBACK_STATE_SUCCEEDED, callbackInfo.State)
+					s.Nil(callbackInfo.LastAttemptFailure)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Updated `NewMutableStateInChain` so that workflow close callbacks are copied over to the new run. This function now also returns an error to indicate whether there was an issue creating the new mutable state.

## Why?
<!-- Tell your future self why have you made these changes -->
This ensures callbacks will be available on workflow runs that are the result of retries (run timeout or retryable failure) and when rebuilding a mutable state with a new history.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
New functional test cases

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
