### PR TITLE
Simplify and streamline GetWorkflowLease logic

### DIFF
--- a/service/history/api/consistency_checker.go
+++ b/service/history/api/consistency_checker.go
@@ -136,7 +136,7 @@ func (c *WorkflowConsistencyCheckerImpl) clockConsistencyCheck(
 	}
 	currentClock := c.shardContext.CurrentVectorClock()
 	if !vclock.Comparable(reqClock, currentClock) {
-		// request vector clock cannot is not comparable with current shard vector clock
+		// request vector clock is not comparable with current shard vector clock
 		return nil
 	}
 

--- a/service/history/api/consistency_checker.go
+++ b/service/history/api/consistency_checker.go
@@ -61,7 +61,7 @@ type (
 			lockPriority workflow.LockPriority,
 		) (WorkflowLease, error)
 
-		GetWorkflowLeaseWithConsistancyCheck(
+		GetWorkflowLeaseWithConsistencyCheck(
 			ctx context.Context,
 			reqClock *clockspb.VectorClock,
 			consistencyPredicate MutableStateConsistencyPredicate,

--- a/service/history/api/consistency_checker_test.go
+++ b/service/history/api/consistency_checker_test.go
@@ -36,13 +36,9 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 
-	historyspb "go.temporal.io/server/api/history/v1"
-	persistencespb "go.temporal.io/server/api/persistence/v1"
-
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/testing/protomock"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/shard"
@@ -124,9 +120,8 @@ func (s *workflowConsistencyCheckerSuite) TestGetWorkflowContextValidatedByCheck
 	).Return(wfContext, releaseFn, nil)
 	wfContext.EXPECT().LoadMutableState(ctx, s.shardContext).Return(mutableState, nil)
 
-	workflowLease, err := s.checker.getWorkflowLeaseValidatedByCheck(
+	workflowLease, err := s.checker.getWorkflowLease(
 		ctx,
-		BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(s.namespaceID, s.workflowID, s.currentRunID),
 		workflow.LockPriorityHigh,
 	)
@@ -134,73 +129,6 @@ func (s *workflowConsistencyCheckerSuite) TestGetWorkflowContextValidatedByCheck
 	s.Equal(mutableState, workflowLease.GetMutableState())
 	s.False(released)
 }
-
-func (s *workflowConsistencyCheckerSuite) TestGetWorkflowContextValidatedByCheck_Success_FailedCheck() {
-	ctx := context.Background()
-
-	wfContext := workflow.NewMockContext(s.controller)
-	mutableState1 := workflow.NewMockMutableState(s.controller)
-	mutableState2 := workflow.NewMockMutableState(s.controller)
-	released := false
-	releaseFn := func(err error) { released = true }
-
-	s.workflowCache.EXPECT().GetOrCreateWorkflowExecution(
-		ctx,
-		s.shardContext,
-		namespace.ID(s.namespaceID),
-		protomock.Eq(&commonpb.WorkflowExecution{
-			WorkflowId: s.workflowID,
-			RunId:      s.currentRunID,
-		}),
-		workflow.LockPriorityHigh,
-	).Return(wfContext, releaseFn, nil)
-	gomock.InOrder(
-		wfContext.EXPECT().LoadMutableState(ctx, s.shardContext).Return(mutableState1, nil),
-		wfContext.EXPECT().Clear(),
-		wfContext.EXPECT().LoadMutableState(ctx, s.shardContext).Return(mutableState2, nil),
-	)
-
-	workflowLease, err := s.checker.getWorkflowLeaseValidatedByCheck(
-		ctx,
-		FailMutableStateConsistencyPredicate,
-		definition.NewWorkflowKey(s.namespaceID, s.workflowID, s.currentRunID),
-		workflow.LockPriorityHigh,
-	)
-	s.NoError(err)
-	s.Equal(mutableState2, workflowLease.GetMutableState())
-	s.False(released)
-}
-
-func (s *workflowConsistencyCheckerSuite) TestGetWorkflowContextValidatedByCheck_Error() {
-	ctx := context.Background()
-
-	wfContext := workflow.NewMockContext(s.controller)
-	released := false
-	releaseFn := func(err error) { released = true }
-
-	s.workflowCache.EXPECT().GetOrCreateWorkflowExecution(
-		ctx,
-		s.shardContext,
-		namespace.ID(s.namespaceID),
-		protomock.Eq(&commonpb.WorkflowExecution{
-			WorkflowId: s.workflowID,
-			RunId:      s.currentRunID,
-		}),
-		workflow.LockPriorityHigh,
-	).Return(wfContext, releaseFn, nil)
-	wfContext.EXPECT().LoadMutableState(ctx, s.shardContext).Return(nil, serviceerror.NewUnavailable(""))
-
-	workflowLease, err := s.checker.getWorkflowLeaseValidatedByCheck(
-		ctx,
-		FailMutableStateConsistencyPredicate,
-		definition.NewWorkflowKey(s.namespaceID, s.workflowID, s.currentRunID),
-		workflow.LockPriorityHigh,
-	)
-	s.IsType(&serviceerror.Unavailable{}, err)
-	s.Nil(workflowLease)
-	s.True(released)
-}
-
 func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_Success() {
 	ctx := context.Background()
 
@@ -255,74 +183,4 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_Error() {
 	s.IsType(&serviceerror.Unavailable{}, err)
 	s.Empty(runID)
 	s.True(released)
-}
-
-func (s *workflowConsistencyCheckerSuite) TestHistoryEventConsistencyPredicate() {
-	eventID := int64(400)
-	eventVersion := int64(200)
-	predicate := HistoryEventConsistencyPredicate(eventID, eventVersion)
-
-	testCases := []struct {
-		name             string
-		versionHistories *historyspb.VersionHistories
-		pass             bool
-	}{
-		{
-			name: "Pass_OnCurrentBranch",
-			versionHistories: versionhistory.NewVersionHistories(
-				&historyspb.VersionHistory{
-					BranchToken: []byte{1, 2, 3},
-					Items: []*historyspb.VersionHistoryItem{
-						{EventId: 123, Version: 100},
-						{EventId: 456, Version: 200},
-					},
-				},
-			),
-			pass: true,
-		},
-		{
-			name: "Pass_OnNonCurrentBranch",
-			versionHistories: &historyspb.VersionHistories{
-				CurrentVersionHistoryIndex: 0,
-				Histories: []*historyspb.VersionHistory{
-					{
-						BranchToken: []byte{1, 2, 3},
-						Items: []*historyspb.VersionHistoryItem{
-							{EventId: 123, Version: 100},
-						},
-					},
-					{
-						BranchToken: []byte{4, 5, 6},
-						Items: []*historyspb.VersionHistoryItem{
-							{EventId: 123, Version: 100},
-							{EventId: 456, Version: 200},
-						},
-					},
-				},
-			},
-			pass: true,
-		},
-		{
-			name: "Fail_NotFound",
-			versionHistories: versionhistory.NewVersionHistories(
-				&historyspb.VersionHistory{
-					BranchToken: []byte{1, 2, 3},
-					Items: []*historyspb.VersionHistoryItem{
-						{EventId: 123, Version: 100},
-					},
-				},
-			),
-			pass: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		s.Run(tc.name, func() {
-			mockMutableState := workflow.NewMockMutableState(s.controller)
-			mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
-				VersionHistories: tc.versionHistories,
-			})
-			s.Equal(tc.pass, predicate(mockMutableState))
-		})
-	}
 }

--- a/service/history/api/consistency_checker_test.go
+++ b/service/history/api/consistency_checker_test.go
@@ -121,8 +121,8 @@ func (s *workflowConsistencyCheckerSuite) TestGetWorkflowContextValidatedByCheck
 	).Return(wfContext, releaseFn, nil)
 	wfContext.EXPECT().LoadMutableState(ctx, s.shardContext).Return(mutableState, nil)
 
-	workflowLease, err := s.checker.getWorkflowLease(
-		ctx,
+	workflowLease, err := s.checker.GetWorkflowLease(
+		ctx, nil,
 		definition.NewWorkflowKey(s.namespaceID, s.workflowID, s.currentRunID),
 		workflow.LockPriorityHigh,
 	)

--- a/service/history/api/deleteworkflow/api.go
+++ b/service/history/api/deleteworkflow/api.go
@@ -49,7 +49,6 @@ func Invoke(
 	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			request.NamespaceId,
 			request.WorkflowExecution.WorkflowId,

--- a/service/history/api/describemutablestate/api.go
+++ b/service/history/api/describemutablestate/api.go
@@ -50,7 +50,6 @@ func Invoke(
 	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			req.NamespaceId,
 			req.Execution.WorkflowId,

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -82,7 +82,6 @@ func Invoke(
 	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			req.NamespaceId,
 			req.Request.Execution.WorkflowId,

--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -219,7 +219,6 @@ func GetMutableState(
 	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
-		BypassMutableStateConsistencyPredicate,
 		workflowKey,
 		workflow.LockPriorityHigh,
 	)

--- a/service/history/api/isactivitytaskvalid/api.go
+++ b/service/history/api/isactivitytaskvalid/api.go
@@ -45,7 +45,6 @@ func Invoke(
 	err := api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		req.Clock,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			req.NamespaceId,
 			req.Execution.WorkflowId,

--- a/service/history/api/isworkflowtaskvalid/api.go
+++ b/service/history/api/isworkflowtaskvalid/api.go
@@ -45,7 +45,6 @@ func Invoke(
 	err := api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		req.Clock,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			req.NamespaceId,
 			req.Execution.WorkflowId,

--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -96,7 +96,6 @@ func Invoke(
 	currentWorkflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(req.NamespaceId, startReq.StartRequest.WorkflowId, ""),
 		workflow.LockPriorityHigh,
 	)

--- a/service/history/api/pollupdate/api.go
+++ b/service/history/api/pollupdate/api.go
@@ -55,7 +55,6 @@ func Invoke(
 		workflowLease, err := ctxLookup.GetWorkflowLease(
 			ctx,
 			nil,
-			api.BypassMutableStateConsistencyPredicate,
 			definition.NewWorkflowKey(
 				req.GetNamespaceId(),
 				wfexec.GetWorkflowId(),

--- a/service/history/api/pollupdate/api_test.go
+++ b/service/history/api/pollupdate/api_test.go
@@ -61,7 +61,6 @@ type (
 		GetWorkflowContextFunc func(
 			ctx context.Context,
 			reqClock *clockspb.VectorClock,
-			consistencyPredicate api.MutableStateConsistencyPredicate,
 			workflowKey definition.WorkflowKey,
 			lockPriority workflow.LockPriority,
 		) (api.WorkflowLease, error)
@@ -90,11 +89,10 @@ func (mockUpdateEventStore) CanAddEvent() bool                       { return tr
 func (m mockWFConsistencyChecker) GetWorkflowLease(
 	ctx context.Context,
 	clock *clockspb.VectorClock,
-	pred api.MutableStateConsistencyPredicate,
 	wfKey definition.WorkflowKey,
 	prio workflow.LockPriority,
 ) (api.WorkflowLease, error) {
-	return m.GetWorkflowContextFunc(ctx, clock, pred, wfKey, prio)
+	return m.GetWorkflowContextFunc(ctx, clock, wfKey, prio)
 }
 
 func (m mockWorkflowLeaseCtx) GetReleaseFn() wcache.ReleaseCacheFunc {
@@ -132,7 +130,6 @@ func TestPollOutcome(t *testing.T) {
 		GetWorkflowContextFunc: func(
 			ctx context.Context,
 			reqClock *clockspb.VectorClock,
-			consistencyPredicate api.MutableStateConsistencyPredicate,
 			workflowKey definition.WorkflowKey,
 			lockPriority workflow.LockPriority,
 		) (api.WorkflowLease, error) {

--- a/service/history/api/queryworkflow/api.go
+++ b/service/history/api/queryworkflow/api.go
@@ -92,7 +92,6 @@ func Invoke(
 	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		workflowKey,
 		workflow.LockPriorityHigh,
 	)

--- a/service/history/api/reapplyevents/api.go
+++ b/service/history/api/reapplyevents/api.go
@@ -68,7 +68,6 @@ func Invoke(
 	return api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			namespaceID.String(),
 			workflowID,

--- a/service/history/api/recordactivitytaskheartbeat/api.go
+++ b/service/history/api/recordactivitytaskheartbeat/api.go
@@ -62,7 +62,6 @@ func Invoke(
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		token.Clock,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			token.NamespaceId,
 			token.WorkflowId,

--- a/service/history/api/recordactivitytaskstarted/api.go
+++ b/service/history/api/recordactivitytaskstarted/api.go
@@ -56,7 +56,6 @@ func Invoke(
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		request.Clock,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			request.NamespaceId,
 			request.WorkflowExecution.WorkflowId,

--- a/service/history/api/recordchildworkflowcompleted/api.go
+++ b/service/history/api/recordchildworkflowcompleted/api.go
@@ -53,7 +53,7 @@ func Invoke(
 	parentInitiatedID := request.ParentInitiatedId
 	parentInitiatedVersion := request.ParentInitiatedVersion
 
-	err = api.GetAndUpdateWorkflowWithNew(
+	err = api.GetAndUpdateWorkflowWithConsistancyCheck(
 		ctx,
 		request.Clock,
 		func(mutableState workflow.MutableState) bool {

--- a/service/history/api/recordchildworkflowcompleted/api.go
+++ b/service/history/api/recordchildworkflowcompleted/api.go
@@ -53,7 +53,7 @@ func Invoke(
 	parentInitiatedID := request.ParentInitiatedId
 	parentInitiatedVersion := request.ParentInitiatedVersion
 
-	err = api.GetAndUpdateWorkflowWithConsistancyCheck(
+	err = api.GetAndUpdateWorkflowWithConsistencyCheck(
 		ctx,
 		request.Clock,
 		func(mutableState workflow.MutableState) bool {

--- a/service/history/api/recordworkflowtaskstarted/api.go
+++ b/service/history/api/recordworkflowtaskstarted/api.go
@@ -77,7 +77,6 @@ func Invoke(
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		req.Clock,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			req.NamespaceId,
 			req.WorkflowExecution.WorkflowId,

--- a/service/history/api/refreshworkflow/api.go
+++ b/service/history/api/refreshworkflow/api.go
@@ -49,7 +49,6 @@ func Invoke(
 	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		workflowKey,
 		workflow.LockPriorityLow,
 	)

--- a/service/history/api/removesignalmutablestate/api.go
+++ b/service/history/api/removesignalmutablestate/api.go
@@ -49,7 +49,6 @@ func Invoke(
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			req.NamespaceId,
 			req.WorkflowExecution.WorkflowId,

--- a/service/history/api/replication/generate_task.go
+++ b/service/history/api/replication/generate_task.go
@@ -52,7 +52,6 @@ func GenerateTask(
 	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			namespaceID.String(),
 			request.Execution.WorkflowId,

--- a/service/history/api/requestcancelworkflow/api.go
+++ b/service/history/api/requestcancelworkflow/api.go
@@ -60,7 +60,6 @@ func Invoke(
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			namespaceID.String(),
 			workflowID,

--- a/service/history/api/resetstickytaskqueue/api.go
+++ b/service/history/api/resetstickytaskqueue/api.go
@@ -50,7 +50,6 @@ func Invoke(
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			resetRequest.NamespaceId,
 			resetRequest.Execution.WorkflowId,

--- a/service/history/api/resetworkflow/api.go
+++ b/service/history/api/resetworkflow/api.go
@@ -62,7 +62,6 @@ func Invoke(
 	baseWorkflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			namespaceID.String(),
 			workflowID,
@@ -102,7 +101,6 @@ func Invoke(
 		currentWorkflowLease, err = workflowConsistencyChecker.GetWorkflowLease(
 			ctx,
 			nil,
-			api.BypassMutableStateConsistencyPredicate,
 			definition.NewWorkflowKey(
 				namespaceID.String(),
 				workflowID,

--- a/service/history/api/respondactivitytaskcanceled/api.go
+++ b/service/history/api/respondactivitytaskcanceled/api.go
@@ -66,7 +66,6 @@ func Invoke(
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		token.Clock,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			token.NamespaceId,
 			token.WorkflowId,

--- a/service/history/api/respondactivitytaskcompleted/api.go
+++ b/service/history/api/respondactivitytaskcompleted/api.go
@@ -67,7 +67,6 @@ func Invoke(
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		token.Clock,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			token.NamespaceId,
 			token.WorkflowId,

--- a/service/history/api/respondactivitytaskfailed/api.go
+++ b/service/history/api/respondactivitytaskfailed/api.go
@@ -69,7 +69,6 @@ func Invoke(
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		token.Clock,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			token.NamespaceId,
 			token.WorkflowId,

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -136,7 +136,7 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 		return nil, consts.ErrDeserializingToken
 	}
 
-	workflowLease, err := handler.workflowConsistencyChecker.GetWorkflowLeaseWithConsistancyCheck(
+	workflowLease, err := handler.workflowConsistencyChecker.GetWorkflowLeaseWithConsistencyCheck(
 		ctx,
 		token.Clock,
 		func(mutableState workflow.MutableState) bool {

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -136,7 +136,7 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 		return nil, consts.ErrDeserializingToken
 	}
 
-	workflowLease, err := handler.workflowConsistencyChecker.GetWorkflowLease(
+	workflowLease, err := handler.workflowConsistencyChecker.GetWorkflowLeaseWithConsistancyCheck(
 		ctx,
 		token.Clock,
 		func(mutableState workflow.MutableState) bool {

--- a/service/history/api/respondworkflowtaskfailed/api.go
+++ b/service/history/api/respondworkflowtaskfailed/api.go
@@ -58,7 +58,6 @@ func Invoke(
 	return api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		token.Clock,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			token.NamespaceId,
 			token.WorkflowId,

--- a/service/history/api/scheduleworkflowtask/api.go
+++ b/service/history/api/scheduleworkflowtask/api.go
@@ -50,7 +50,6 @@ func Invoke(
 	return api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		req.ChildClock,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			req.NamespaceId,
 			req.WorkflowExecution.WorkflowId,

--- a/service/history/api/signalwithstartworkflow/api.go
+++ b/service/history/api/signalwithstartworkflow/api.go
@@ -56,7 +56,6 @@ func Invoke(
 	currentWorkflowLease, err = workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			string(namespaceID),
 			signalWithStartRequest.SignalWithStartRequest.WorkflowId,

--- a/service/history/api/signalworkflow/api.go
+++ b/service/history/api/signalworkflow/api.go
@@ -54,7 +54,6 @@ func Invoke(
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			namespaceID.String(),
 			request.WorkflowExecution.WorkflowId,

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -417,7 +417,6 @@ func (s *Starter) resolveDuplicateWorkflowID(
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			s.namespace.ID().String(),
 			workflowID,

--- a/service/history/api/terminateworkflow/api.go
+++ b/service/history/api/terminateworkflow/api.go
@@ -61,7 +61,6 @@ func Invoke(
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			namespaceID.String(),
 			workflowID,

--- a/service/history/api/update_workflow_util.go
+++ b/service/history/api/update_workflow_util.go
@@ -65,7 +65,7 @@ func GetAndUpdateWorkflowWithConsistancyCheck(
 	workflowKey definition.WorkflowKey,
 	action UpdateWorkflowActionFunc,
 	newWorkflowFn func() (workflow.Context, workflow.MutableState, error),
-	shard shard.Context,
+	shardContext shard.Context,
 	workflowConsistencyChecker WorkflowConsistencyChecker,
 ) (retError error) {
 	workflowLease, err := workflowConsistencyChecker.GetWorkflowLeaseWithConsistancyCheck(
@@ -80,7 +80,7 @@ func GetAndUpdateWorkflowWithConsistancyCheck(
 	}
 	defer func() { workflowLease.GetReleaseFn()(retError) }()
 
-	return UpdateWorkflowWithNew(shard, ctx, workflowLease, action, newWorkflowFn)
+	return UpdateWorkflowWithNew(shardContext, ctx, workflowLease, action, newWorkflowFn)
 }
 
 func UpdateWorkflowWithNew(

--- a/service/history/api/update_workflow_util.go
+++ b/service/history/api/update_workflow_util.go
@@ -58,7 +58,7 @@ func GetAndUpdateWorkflowWithNew(
 	return UpdateWorkflowWithNew(shard, ctx, workflowLease, action, newWorkflowFn)
 }
 
-func GetAndUpdateWorkflowWithConsistancyCheck(
+func GetAndUpdateWorkflowWithConsistencyCheck(
 	ctx context.Context,
 	reqClock *clockspb.VectorClock,
 	consistencyCheckFn MutableStateConsistencyPredicate,

--- a/service/history/api/update_workflow_util.go
+++ b/service/history/api/update_workflow_util.go
@@ -68,7 +68,7 @@ func GetAndUpdateWorkflowWithConsistencyCheck(
 	shardContext shard.Context,
 	workflowConsistencyChecker WorkflowConsistencyChecker,
 ) (retError error) {
-	workflowLease, err := workflowConsistencyChecker.GetWorkflowLeaseWithConsistancyCheck(
+	workflowLease, err := workflowConsistencyChecker.GetWorkflowLeaseWithConsistencyCheck(
 		ctx,
 		reqClock,
 		consistencyCheckFn,

--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -109,7 +109,6 @@ func (u *Updater) Invoke(
 	err := api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		nil,
-		api.BypassMutableStateConsistencyPredicate,
 		wfKey,
 		func(lease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
 			ms := lease.GetMutableState()

--- a/service/history/api/verifychildworkflowcompletionrecorded/api.go
+++ b/service/history/api/verifychildworkflowcompletionrecorded/api.go
@@ -54,7 +54,6 @@ func Invoke(
 		// the logic will return WorkflowNotReady error and the caller will retry
 		// this can prevent keep reloading mutable state when there's a replication lag
 		// in parent shard.
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			request.NamespaceId,
 			request.ParentExecution.WorkflowId,

--- a/service/history/api/verifyfirstworkflowtaskscheduled/api.go
+++ b/service/history/api/verifyfirstworkflowtaskscheduled/api.go
@@ -49,7 +49,6 @@ func Invoke(
 	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		req.Clock,
-		api.BypassMutableStateConsistencyPredicate,
 		definition.NewWorkflowKey(
 			req.NamespaceId,
 			req.WorkflowExecution.WorkflowId,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Remove "consistency check" parameter from GetAndUpdateWorkflow and GetWorkflowLease
To support those cases where is was still used - old version is preserved with different function name.
Also remove dead code and dead tests.

## Why?
<!-- Tell your future self why have you made these changes -->


Current implementation has some issues.
a. It is hard to understand, which can (and does) lead to hard-to-detect bugs

b. Predicate (I'm not calling it "consistency check" because it is not) is used only in just 2 cases out of > 70. In all other cases “do nothing” check is provided.

c. Current implementation of predicate check introduce huge “side effect” (clear WF context) which (most likely) has little to do with loading mutable state. I'm still not sure it should be used in the way it is used.

d. It is hard to tell if current implementation do anything useful - it loads mutable state, and if predicate failed - clear context and load it again. That is all. It is not clear that clear WF context somehow affect mutable state loading at all…

e. Logic in one (or two) consistency check function is complicated and clearly out of boundaries for "consistency check"scope. It looks more like business logic. Thus introduce more side-effects.


## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test. add a bit more tests to cover clock related logic.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
This is core logic, and has side-effects. I try to minimize the risk by keeping the old version intact, but it still exist.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
