### PR TITLE
Fix Nexus endpoint storage schemas

### DIFF
--- a/schema/cassandra/temporal/versioned/v1.10/manifest.json
+++ b/schema/cassandra/temporal/versioned/v1.10/manifest.json
@@ -1,6 +1,6 @@
 {
   "CurrVersion": "1.10",
   "MinCompatibleVersion": "1.0",
-  "Description": "create nexus_endpoints table",
-  "SchemaUpdateCqlFiles": ["nexus_endpoints.cql"]
+  "Description": "create nexus_incoming_services table",
+  "SchemaUpdateCqlFiles": ["nexus_incoming_services.cql"]
 }

--- a/schema/cassandra/temporal/versioned/v1.10/nexus_incoming_services.cql
+++ b/schema/cassandra/temporal/versioned/v1.10/nexus_incoming_services.cql
@@ -1,0 +1,15 @@
+CREATE TABLE nexus_incoming_services
+(
+    partition       int, -- constant for all rows (using a single partition for efficient list queries)
+    type            int, -- enum RowType { PartitionStatus, NexusIncomingService }
+    service_id      uuid,
+    data            blob,
+    data_encoding   text,
+    -- When type=PartitionStatus contains the partition version.
+    --      Partition version is used to guarantee latest versions when listing all services.
+    -- When type=NexusIncomingService contains the service version used for optimistic concurrency
+    version         bigint,
+    PRIMARY KEY ((partition), type, service_id)
+) WITH COMPACTION = {
+    'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
+    };

--- a/schema/cassandra/temporal/versioned/v1.11/manifest.json
+++ b/schema/cassandra/temporal/versioned/v1.11/manifest.json
@@ -1,0 +1,6 @@
+{
+  "CurrVersion": "1.11",
+  "MinCompatibleVersion": "1.0",
+  "Description": "Replace nexus_incoming_services table with nexus_endpoints table",
+  "SchemaUpdateCqlFiles": ["nexus_endpoints.cql"]
+}

--- a/schema/cassandra/temporal/versioned/v1.11/nexus_endpoints.cql
+++ b/schema/cassandra/temporal/versioned/v1.11/nexus_endpoints.cql
@@ -1,3 +1,5 @@
+DROP TABLE nexus_incoming_services;
+
 CREATE TABLE nexus_endpoints
 (
     partition       int, -- constant for all rows (using a single partition for efficient list queries)

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -27,4 +27,4 @@ package cassandra
 // NOTE: whenever there is a new database schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "1.10"
+const Version = "1.11"

--- a/schema/mysql/v8/temporal/versioned/v1.12/manifest.json
+++ b/schema/mysql/v8/temporal/versioned/v1.12/manifest.json
@@ -1,8 +1,8 @@
 {
   "CurrVersion": "1.12",
   "MinCompatibleVersion": "1.0",
-  "Description": "Create nexus_endpoints and nexus_endpoints_partition_status tables",
+  "Description": "add storage for Nexus incoming service records and create nexus_incoming_services and nexus_incoming_services_partition_status tables",
   "SchemaUpdateCqlFiles": [
-    "nexus_endpoints.sql"
+    "nexus_incoming_services.sql"
   ]
 }

--- a/schema/mysql/v8/temporal/versioned/v1.12/nexus_incoming_services.sql
+++ b/schema/mysql/v8/temporal/versioned/v1.12/nexus_incoming_services.sql
@@ -1,0 +1,15 @@
+-- Stores information about Nexus incoming services
+CREATE TABLE nexus_incoming_services (
+    service_id      BINARY(16) NOT NULL,
+    data            MEDIUMBLOB NOT NULL,  -- temporal.server.api.persistence.v1.NexusIncomingService
+    data_encoding   VARCHAR(16) NOT NULL, -- Encoding type used for serialization, in practice this should always be proto3
+    version         BIGINT NOT NULL,      -- Version of this row, used for optimistic concurrency
+    PRIMARY KEY (service_id)
+);
+
+-- Stores the version of Nexus incoming services table as a whole
+CREATE TABLE nexus_incoming_services_partition_status (
+    id      INT NOT NULL DEFAULT 0 CHECK (id = 0),  -- Restrict the table to a single row since it will only be used for incoming services
+    version BIGINT NOT NULL,                        -- Version of the nexus_incoming_services table
+    PRIMARY KEY (id)
+);

--- a/schema/mysql/v8/temporal/versioned/v1.13/manifest.json
+++ b/schema/mysql/v8/temporal/versioned/v1.13/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.13",
+  "MinCompatibleVersion": "1.0",
+  "Description": "Replace nexus_incoming_services and nexus_incoming_services_partition_status tables with nexus_endpoints and nexus_endpoints_partition_status tables",
+  "SchemaUpdateCqlFiles": [
+    "nexus_endpoints.sql"
+  ]
+}

--- a/schema/mysql/v8/temporal/versioned/v1.13/nexus_endpoints.sql
+++ b/schema/mysql/v8/temporal/versioned/v1.13/nexus_endpoints.sql
@@ -1,3 +1,6 @@
+DROP TABLE nexus_incoming_services;
+DROP TABLE nexus_incoming_services_partition_status;
+
 -- Stores information about Nexus endpoints
 CREATE TABLE nexus_endpoints (
     id            BINARY(16) NOT NULL,

--- a/schema/mysql/v8/version.go
+++ b/schema/mysql/v8/version.go
@@ -27,7 +27,7 @@ package v8
 // NOTE: whenever there is a new database schema update, plz update the following versions
 
 // Version is the MySQL database release version
-const Version = "1.12"
+const Version = "1.13"
 
 // VisibilityVersion is the MySQL visibility database release version
 const VisibilityVersion = "1.6"

--- a/schema/postgresql/v12/temporal/versioned/v1.12/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.12/manifest.json
@@ -1,8 +1,8 @@
 {
   "CurrVersion": "1.12",
   "MinCompatibleVersion": "1.0",
-  "Description": "Create nexus_endpoints and nexus_endpoints_partition_status tables",
+  "Description": "add storage for Nexus incoming service records and create nexus_incoming_services and nexus_incoming_services_partition_status tables",
   "SchemaUpdateCqlFiles": [
-    "nexus_endpoints.sql"
+    "nexus_incoming_services.sql"
   ]
 }

--- a/schema/postgresql/v12/temporal/versioned/v1.12/nexus_incoming_services.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.12/nexus_incoming_services.sql
@@ -1,0 +1,15 @@
+-- Stores information about Nexus incoming services
+CREATE TABLE nexus_incoming_services (
+    service_id      BYTEA NOT NULL,
+    data            BYTEA NOT NULL,  -- temporal.server.api.persistence.v1.NexusIncomingService
+    data_encoding   VARCHAR(16) NOT NULL, -- Encoding type used for serialization, in practice this should always be proto3
+    version         BIGINT NOT NULL,      -- Version of this row, used for optimistic concurrency
+    PRIMARY KEY (service_id)
+);
+
+-- Stores the version of Nexus incoming services table as a whole
+CREATE TABLE nexus_incoming_services_partition_status (
+    id      INT NOT NULL PRIMARY KEY DEFAULT 0,
+    version BIGINT NOT NULL,                -- Version of the nexus_incoming_services table
+    CONSTRAINT only_one_row CHECK (id = 0)  -- Restrict the table to a single row since it will only be used for incoming services
+);

--- a/schema/postgresql/v12/temporal/versioned/v1.13/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.13/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.13",
+  "MinCompatibleVersion": "1.0",
+  "Description": "Replace nexus_incoming_services and nexus_incoming_services_partition_status tables with nexus_endpoints and nexus_endpoints_partition_status tables",
+  "SchemaUpdateCqlFiles": [
+    "nexus_endpoints.sql"
+  ]
+}

--- a/schema/postgresql/v12/temporal/versioned/v1.13/nexus_endpoints.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.13/nexus_endpoints.sql
@@ -1,3 +1,6 @@
+DROP TABLE nexus_incoming_services;
+DROP TABLE nexus_incoming_services_partition_status;
+
 -- Stores information about Nexus endpoints
 CREATE TABLE nexus_endpoints (
     id            BYTEA NOT NULL,

--- a/schema/postgresql/v12/version.go
+++ b/schema/postgresql/v12/version.go
@@ -28,7 +28,7 @@ package v12
 
 // Version is the Postgres database release version
 // Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres
-const Version = "1.12"
+const Version = "1.13"
 
 // VisibilityVersion is the Postgres visibility database release version
 // Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres

--- a/schema/sqlite/v3/temporal/versioned/v0.4/manifest.json
+++ b/schema/sqlite/v3/temporal/versioned/v0.4/manifest.json
@@ -1,8 +1,8 @@
 {
   "CurrVersion": "0.4",
   "MinCompatibleVersion": "0.1",
-  "Description": "Create nexus_endpoints and nexus_endpoints_partition_status tables",
+  "Description": "add storage for Nexus incoming service records and create nexus_incoming_services and nexus_incoming_services_partition_status tables",
   "SchemaUpdateCqlFiles": [
-    "nexus_endpoints.sql"
+    "nexus_incoming_services.sql"
   ]
 }

--- a/schema/sqlite/v3/temporal/versioned/v0.4/nexus_incoming_services.sql
+++ b/schema/sqlite/v3/temporal/versioned/v0.4/nexus_incoming_services.sql
@@ -1,0 +1,15 @@
+-- Stores information about Nexus incoming services
+CREATE TABLE nexus_incoming_services (
+    service_id      BINARY(16) NOT NULL,
+    data            MEDIUMBLOB NOT NULL,  -- temporal.server.api.persistence.v1.NexusIncomingService
+    data_encoding   VARCHAR(16) NOT NULL, -- Encoding type used for serialization, in practice this should always be proto3
+    version         BIGINT NOT NULL,      -- Version of this row, used for optimistic concurrency
+    PRIMARY KEY (service_id)
+);
+
+-- Stores the version of Nexus incoming services table as a whole
+CREATE TABLE nexus_incoming_services_partition_status (
+    id      INT NOT NULL DEFAULT 0 CHECK (id = 0),  -- Restrict the primary key to a single value since it will only be used for incoming services
+    version BIGINT NOT NULL,                        -- Version of the nexus_incoming_services table
+    PRIMARY KEY (id)
+);

--- a/schema/sqlite/v3/temporal/versioned/v0.5/manifest.json
+++ b/schema/sqlite/v3/temporal/versioned/v0.5/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.5",
+  "MinCompatibleVersion": "0.1",
+  "Description": "Replace nexus_incoming_services and nexus_incoming_services_partition_status tables with nexus_endpoints and nexus_endpoints_partition_status tables",
+  "SchemaUpdateCqlFiles": [
+    "nexus_endpoints.sql"
+  ]
+}

--- a/schema/sqlite/v3/temporal/versioned/v0.5/nexus_endpoints.sql
+++ b/schema/sqlite/v3/temporal/versioned/v0.5/nexus_endpoints.sql
@@ -1,3 +1,6 @@
+DROP TABLE nexus_incoming_services;
+DROP TABLE nexus_incoming_services_partition_status;
+
 -- Stores information about Nexus endpoints
 CREATE TABLE nexus_endpoints (
     id             BINARY(16) NOT NULL,

--- a/schema/sqlite/version.go
+++ b/schema/sqlite/version.go
@@ -27,7 +27,7 @@
 package sqlite
 
 // Version is the SQLite database release version
-const Version = "0.4"
+const Version = "0.5"
 
 // VisibilityVersion is the SQLite visibility database release version
 const VisibilityVersion = "0.1"


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Restored schema scripts for `nexus_incoming_services`
Added new schema revisions to drop `nexus_incoming_services` tables and create `nexus_endpoint` tables

## Why?
<!-- Tell your future self why have you made these changes -->
OSS v1.24 was released using an older schema change from before incoming services were renamed to endpoints, so we need to keep that to avoid breaking schema upgrades
