### PR TITLE
Wrap nexus task executor error for circuit breaker

### DIFF
--- a/components/callbacks/executors_test.go
+++ b/components/callbacks/executors_test.go
@@ -212,7 +212,8 @@ func TestProcessInvocationTask_Outcomes(t *testing.T) {
 			)
 
 			if tc.destinationDown {
-				require.IsType(t, &queues.DestinationDownError{}, err)
+				var destinationDownErr *queues.DestinationDownError
+				require.ErrorAs(t, err, &destinationDownErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -226,10 +226,20 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 		}
 	}
 
-	if err := e.saveResult(ctx, env, ref, result, callErr); err != nil {
-		return fmt.Errorf("failed to save result: %w", err)
+	err = e.saveResult(ctx, env, ref, result, callErr)
+
+	if callErr != nil {
+		var unexpectedErr *nexus.UnexpectedResponseError
+		if errors.As(callErr, &unexpectedErr) {
+			if isRetryableHTTPResponse(unexpectedErr.Response) {
+				err = queues.NewDestinationDownError(callErr.Error(), err)
+			}
+		} else if !errors.Is(callErr, ErrResponseBodyTooLarge) {
+			err = queues.NewDestinationDownError(callErr.Error(), err)
+		}
 	}
-	return nil
+
+	return err
 }
 
 type startArgs struct {
@@ -312,8 +322,7 @@ func (e taskExecutor) handleStartOperationError(env hsm.Environment, node *hsm.N
 	if errors.As(callErr, &opFailedError) {
 		return handleUnsuccessfulOperationError(node, operation, opFailedError, CompletionSourceResponse)
 	} else if errors.As(callErr, &unexpectedResponseError) {
-		response := unexpectedResponseError.Response
-		if response.StatusCode >= 400 && response.StatusCode < 500 && !slices.Contains(retryable4xxErrorTypes, response.StatusCode) {
+		if !isRetryableHTTPResponse(unexpectedResponseError.Response) {
 			// The StartOperation request got an unexpected response that is not retryable, fail the operation.
 			return handleNonRetryableStartOperationError(env, node, operation, unexpectedResponseError.Message)
 		}
@@ -471,7 +480,20 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 	e.MetricsHandler.Counter(OutboundRequestCounter.Name()).Record(1, namespaceTag, destTag, methodTag, statusCodeTag)
 	e.MetricsHandler.Timer(OutboundRequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, methodTag, statusCodeTag)
 
-	return e.saveCancelationResult(ctx, env, ref, callErr)
+	err = e.saveCancelationResult(ctx, env, ref, callErr)
+
+	if callErr != nil {
+		var unexpectedResponseErr *nexus.UnexpectedResponseError
+		if errors.As(callErr, &unexpectedResponseErr) {
+			if isRetryableHTTPResponse(unexpectedResponseErr.Response) {
+				err = queues.NewDestinationDownError(callErr.Error(), err)
+			}
+		} else {
+			err = queues.NewDestinationDownError(callErr.Error(), err)
+		}
+	}
+
+	return err
 }
 
 type cancelArgs struct {
@@ -510,8 +532,7 @@ func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environ
 			if callErr != nil {
 				var unexpectedResponseErr *nexus.UnexpectedResponseError
 				if errors.As(callErr, &unexpectedResponseErr) {
-					response := unexpectedResponseErr.Response
-					if response.StatusCode >= 400 && response.StatusCode < 500 && !slices.Contains(retryable4xxErrorTypes, response.StatusCode) {
+					if !isRetryableHTTPResponse(unexpectedResponseErr.Response) {
 						return TransitionCancelationFailed.Apply(c, EventCancelationFailed{
 							Time: env.Now(),
 							Err:  callErr,
@@ -597,4 +618,8 @@ func cancelCallOutcomeTag(callCtx context.Context, callErr error) string {
 		return "unknown-error"
 	}
 	return "successful"
+}
+
+func isRetryableHTTPResponse(response *http.Response) bool {
+	return response.StatusCode >= 500 || slices.Contains(retryable4xxErrorTypes, response.StatusCode)
 }

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -86,10 +86,12 @@ func TestProcessInvocationTask(t *testing.T) {
 		expectedMetricOutcome string
 		checkOutcome          func(t *testing.T, op nexusoperations.Operation, events []*historypb.HistoryEvent)
 		requestTimeout        time.Duration
+		destinationDown       bool
 	}{
 		{
-			name:           "async start",
-			requestTimeout: time.Hour,
+			name:            "async start",
+			requestTimeout:  time.Hour,
+			destinationDown: false,
 			onStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
 				return &nexus.HandlerStartOperationResultAsync{OperationID: "op-id"}, nil
 			},
@@ -105,8 +107,9 @@ func TestProcessInvocationTask(t *testing.T) {
 			},
 		},
 		{
-			name:           "sync start",
-			requestTimeout: time.Hour,
+			name:            "sync start",
+			requestTimeout:  time.Hour,
+			destinationDown: false,
 			onStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
 				// Also use this test case to check the input and options provided.
 				if service != "service" {
@@ -140,8 +143,9 @@ func TestProcessInvocationTask(t *testing.T) {
 			},
 		},
 		{
-			name:           "sync failed",
-			requestTimeout: time.Hour,
+			name:            "sync failed",
+			requestTimeout:  time.Hour,
+			destinationDown: true,
 			onStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
 				return nil, &nexus.UnsuccessfulOperationError{
 					Failure: nexus.Failure{Message: "operation failed from handler", Metadata: map[string]string{"encoding": "json/plain"}, Details: json.RawMessage("\"details\"")},
@@ -185,8 +189,9 @@ func TestProcessInvocationTask(t *testing.T) {
 			},
 		},
 		{
-			name:           "sync canceled",
-			requestTimeout: time.Hour,
+			name:            "sync canceled",
+			requestTimeout:  time.Hour,
+			destinationDown: true,
 			onStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
 				return nil, &nexus.UnsuccessfulOperationError{
 					Failure: nexus.Failure{Message: "operation canceled from handler", Metadata: map[string]string{"encoding": "json/plain"}, Details: json.RawMessage("\"details\"")},
@@ -228,8 +233,9 @@ func TestProcessInvocationTask(t *testing.T) {
 			},
 		},
 		{
-			name:           "transient error",
-			requestTimeout: time.Hour,
+			name:            "transient error",
+			requestTimeout:  time.Hour,
+			destinationDown: true,
 			onStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
 				return nil, nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "internal server error")
 			},
@@ -244,6 +250,7 @@ func TestProcessInvocationTask(t *testing.T) {
 		{
 			name:                  "invocation timeout",
 			requestTimeout:        time.Microsecond,
+			destinationDown:       true,
 			expectedMetricOutcome: "request-timeout",
 			onStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
 				time.Sleep(time.Millisecond * 100)
@@ -260,6 +267,7 @@ func TestProcessInvocationTask(t *testing.T) {
 			name:             "service not found",
 			endpointNotFound: true,
 			requestTimeout:   time.Hour,
+			destinationDown:  false,
 			onStartOperation: nil, // This should not be called if the service is not found.
 			checkOutcome: func(t *testing.T, op nexusoperations.Operation, events []*historypb.HistoryEvent) {
 				require.Equal(t, enumsspb.NEXUS_OPERATION_STATE_FAILED, op.State())
@@ -345,7 +353,11 @@ func TestProcessInvocationTask(t *testing.T) {
 				},
 				nexusoperations.InvocationTask{Destination: "endpoint-name"},
 			)
-			require.NoError(t, err)
+			if tc.destinationDown {
+				require.IsType(t, &queues.DestinationDownError{}, err)
+			} else {
+				require.NoError(t, err)
+			}
 			op, err := hsm.MachineData[nexusoperations.Operation](node)
 			require.NoError(t, err)
 			tc.checkOutcome(t, op, backend.Events[1:]) // Ignore the original scheduled event.
@@ -433,10 +445,12 @@ func TestProcessCancelationTask(t *testing.T) {
 		expectedMetricOutcome string
 		checkOutcome          func(t *testing.T, op nexusoperations.Cancelation)
 		requestTimeout        time.Duration
+		destinationDown       bool
 	}{
 		{
-			name:           "failure",
-			requestTimeout: time.Hour,
+			name:            "failure",
+			requestTimeout:  time.Hour,
+			destinationDown: false,
 			onCancelOperation: func(ctx context.Context, service, operation, operationID string, options nexus.CancelOperationOptions) error {
 				return nexus.HandlerErrorf(nexus.HandlerErrorTypeNotFound, "operation not found")
 			},
@@ -448,8 +462,9 @@ func TestProcessCancelationTask(t *testing.T) {
 			},
 		},
 		{
-			name:           "success",
-			requestTimeout: time.Hour,
+			name:            "success",
+			requestTimeout:  time.Hour,
+			destinationDown: false,
 			onCancelOperation: func(ctx context.Context, service, operation, operationID string, options nexus.CancelOperationOptions) error {
 				return nil
 			},
@@ -460,8 +475,9 @@ func TestProcessCancelationTask(t *testing.T) {
 			},
 		},
 		{
-			name:           "transient error",
-			requestTimeout: time.Hour,
+			name:            "transient error",
+			requestTimeout:  time.Hour,
+			destinationDown: true,
 			onCancelOperation: func(ctx context.Context, service, operation, operationID string, options nexus.CancelOperationOptions) error {
 				return nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "internal server error")
 			},
@@ -473,8 +489,9 @@ func TestProcessCancelationTask(t *testing.T) {
 			},
 		},
 		{
-			name:           "invocation timeout",
-			requestTimeout: time.Microsecond,
+			name:            "invocation timeout",
+			requestTimeout:  time.Microsecond,
+			destinationDown: true,
 			onCancelOperation: func(ctx context.Context, service, operation, operationID string, options nexus.CancelOperationOptions) error {
 				time.Sleep(time.Millisecond * 100)
 				return nil
@@ -490,6 +507,7 @@ func TestProcessCancelationTask(t *testing.T) {
 			name:              "service not found",
 			endpointNotFound:  true,
 			requestTimeout:    time.Hour,
+			destinationDown:   false,
 			onCancelOperation: nil, // This should not be called if the endpoint is not found.
 			checkOutcome: func(t *testing.T, c nexusoperations.Cancelation) {
 				require.Equal(t, enumspb.NEXUS_OPERATION_CANCELLATION_STATE_FAILED, c.State())
@@ -586,7 +604,11 @@ func TestProcessCancelationTask(t *testing.T) {
 				},
 				nexusoperations.CancelationTask{Destination: "endpoint-name"},
 			)
-			require.NoError(t, err)
+			if tc.destinationDown {
+				require.IsType(t, &queues.DestinationDownError{}, err)
+			} else {
+				require.NoError(t, err)
+			}
 			cancelation, err := hsm.MachineData[nexusoperations.Cancelation](node)
 			require.NoError(t, err)
 			tc.checkOutcome(t, cancelation)

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -145,7 +145,7 @@ func TestProcessInvocationTask(t *testing.T) {
 		{
 			name:            "sync failed",
 			requestTimeout:  time.Hour,
-			destinationDown: true,
+			destinationDown: false,
 			onStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
 				return nil, &nexus.UnsuccessfulOperationError{
 					Failure: nexus.Failure{Message: "operation failed from handler", Metadata: map[string]string{"encoding": "json/plain"}, Details: json.RawMessage("\"details\"")},
@@ -191,7 +191,7 @@ func TestProcessInvocationTask(t *testing.T) {
 		{
 			name:            "sync canceled",
 			requestTimeout:  time.Hour,
-			destinationDown: true,
+			destinationDown: false,
 			onStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
 				return nil, &nexus.UnsuccessfulOperationError{
 					Failure: nexus.Failure{Message: "operation canceled from handler", Metadata: map[string]string{"encoding": "json/plain"}, Details: json.RawMessage("\"details\"")},

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -354,7 +354,8 @@ func TestProcessInvocationTask(t *testing.T) {
 				nexusoperations.InvocationTask{Destination: "endpoint-name"},
 			)
 			if tc.destinationDown {
-				require.IsType(t, &queues.DestinationDownError{}, err)
+				var destinationDownErr *queues.DestinationDownError
+				require.ErrorAs(t, err, &destinationDownErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -830,12 +830,12 @@ func (e *CircuitBreakerExecutable) Execute() error {
 	}()
 
 	err = e.Executable.Execute()
-	destinationDownErr, destinationDown := err.(*DestinationDownError)
-	if destinationDown {
+	var destinationDownErr *DestinationDownError
+	if errors.As(err, &destinationDownErr) {
 		err = destinationDownErr.Unwrap()
 	}
 
-	doneCb(!destinationDown)
+	doneCb(destinationDownErr == nil)
 	return err
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Wrap nexus task executor error for circuit breaker: it needs to return `DestinationDownError` for the circuit breaker to trip.

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
