### PR TITLE
rename flag tdbg decode task --task-type to --task-category

### DIFF
--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -390,7 +390,7 @@ func getCategory(registry tasks.TaskCategoryRegistry, key string) (tasks.Categor
 // AdminListShardTasks outputs a list of a tasks for given Shard and Task Category
 func AdminListShardTasks(c *cli.Context, clientFactory ClientFactory, registry tasks.TaskCategoryRegistry) error {
 	sid := int32(c.Int(FlagShardID))
-	categoryStr := c.String(FlagTaskType)
+	categoryStr := c.String(FlagTaskCategory)
 	category, err := getCategory(registry, categoryStr)
 	if err != nil {
 		return err
@@ -457,7 +457,7 @@ func AdminRemoveTask(
 	adminClient := clientFactory.AdminClient(c)
 	shardID := c.Int(FlagShardID)
 	taskID := c.Int64(FlagTaskID)
-	category, err := getCategory(taskCategoryRegistry, c.String(FlagTaskType))
+	category, err := getCategory(taskCategoryRegistry, c.String(FlagTaskCategory))
 	if err != nil {
 		return err
 	}

--- a/tools/tdbg/flags.go
+++ b/tools/tdbg/flags.go
@@ -55,7 +55,7 @@ var (
 	FlagClusterMembershipRole      = "role"
 	FlagSkipErrorMode              = "skip-errors"
 	FlagTaskID                     = "task-id"
-	FlagTaskType                   = "task-type"
+	FlagTaskCategory               = "task-category"
 	FlagTaskVisibilityTimestamp    = "task-timestamp"
 	FlagMinVisibilityTimestamp     = "min-visibility-ts"
 	FlagMaxVisibilityTimestamp     = "max-visibility-ts"

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -242,13 +242,14 @@ func newAdminWorkflowCommands(clientFactory ClientFactory, prompterFactory Promp
 }
 
 func newAdminShardManagementCommands(clientFactory ClientFactory, taskCategoryRegistry tasks.TaskCategoryRegistry) []*cli.Command {
-	// There are two different flags for the task type, and they have slightly different semantics. The first is the
-	// task type for the list-tasks command, which is required and does not have a default. The second is the task type
+	// There are two different categories for the task type, and they have slightly
+	// different semantics. The first is the task category for the list-tasks command,
+	// which is required and does not have a default. The second is the task category
 	// for the remove-task command, which is optional and defaults to transfer.
-	taskTypeFlag := getTaskTypeFlag(taskCategoryRegistry)
-	listTasksCategory := *taskTypeFlag
+	taskCategoryFlag := getTaskCategoryFlag(taskCategoryRegistry)
+	listTasksCategory := *taskCategoryFlag
 	listTasksCategory.Required = true
-	removeTaskCategory := *taskTypeFlag
+	removeTaskCategory := *taskCategoryFlag
 	removeTaskCategory.Value = tasks.CategoryTransfer.Name()
 
 	return []*cli.Command{
@@ -356,14 +357,14 @@ func newAdminShardManagementCommands(clientFactory ClientFactory, taskCategoryRe
 	}
 }
 
-func getTaskTypeFlag(taskCategoryRegistry tasks.TaskCategoryRegistry) *cli.StringFlag {
+func getTaskCategoryFlag(taskCategoryRegistry tasks.TaskCategoryRegistry) *cli.StringFlag {
 	categories := taskCategoryRegistry.GetCategories()
 	options := make([]string, 0, len(categories))
 	for _, category := range categories {
 		options = append(options, category.Name())
 	}
 	flag := &cli.StringFlag{
-		Name:  FlagTaskType,
+		Name:  FlagTaskCategory,
 		Usage: "Task type: " + strings.Join(options, ", "),
 	}
 	return flag


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Renamed `tdbg decode task` flag from `--task-type` to `--task-category`

## Why?
<!-- Tell your future self why have you made these changes -->
The value has always been plumbed through to the category fields; this aligns the flag's name to where the value's been used. No functional change. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

- make bins
- 
```
$ go run cmd/tools/tdbg/main.go decode task -h                                                                                                                                                                                 tdbg_cli_flag_taskcat * ] 11:12 AM
NAME:
   tdbg decode task - Decode a history task blob into a JSON message.

USAGE:
   tdbg decode task [command options] [arguments...]

OPTIONS:
   --binary-file value       file with data in binary format.
   --task-category-id value  Task category ID (see the history/tasks package) (default: 0)
  ....
```

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Out-of-date runbooks

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
I've searched across `org:temporalio`, and I believe that all references are within this repo alone.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
