### PR TITLE
Drop scheduled tasks if duration too long

### DIFF
--- a/common/timer/validation.go
+++ b/common/timer/validation.go
@@ -45,6 +45,7 @@ var (
 	maxNanos   = int32(MaxAllowedTimer.Nanoseconds() - maxSeconds*1e9)
 )
 
+// TODO: remove this logic, rely on scheduled task dropping logic in mutableState for long duration timers
 func ValidateAndCapTimer(delay *durationpb.Duration) error {
 	duration := timestamp.DurationValue(delay)
 	if duration < 0 {

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -99,6 +99,13 @@ const (
 )
 
 var (
+	// Scheduled tasks with timestamp after this will not be created.
+	// Those tasks are too far in the future and pratically never fire and just consume storage space.
+	// NOTE: this value is less than timer.MaxAllowedTimer so that no capped timers will be created.
+	maxScheduledTaskDuration = time.Hour * 24 * 365 * 99
+)
+
+var (
 	// ErrWorkflowFinished indicates trying to mutate mutable state after workflow finished
 	ErrWorkflowFinished = serviceerror.NewInternal("invalid mutable state action: mutation after finish")
 	// ErrMissingTimerInfo indicates missing timer info
@@ -4916,15 +4923,18 @@ func (ms *MutableStateImpl) processCloseCallbacks() error {
 // TODO mutable state should generate corresponding transfer / timer tasks according to
 //  updates accumulated, while currently all transfer / timer tasks are managed manually
 
-// TODO convert AddTasks to prepareTasks
-
-// AddTasks append transfer tasks
 func (ms *MutableStateImpl) AddTasks(
-	tasks ...tasks.Task,
+	newTasks ...tasks.Task,
 ) {
 
-	for _, task := range tasks {
+	now := ms.timeSource.Now()
+	for _, task := range newTasks {
 		category := task.GetCategory()
+		if category.Type() == tasks.CategoryTypeScheduled &&
+			task.GetVisibilityTime().Sub(now) > maxScheduledTaskDuration {
+			ms.logger.Info("Dropped long duration scheduled task.", tasks.Tags(task)...)
+			continue
+		}
 		ms.InsertTasks[category] = append(ms.InsertTasks[category], task)
 	}
 }

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -86,9 +86,10 @@ type (
 		mockShard       *shard.ContextTest
 		mockEventsCache *events.MockCache
 
-		mutableState *MutableStateImpl
-		logger       log.Logger
-		testScope    tally.TestScope
+		namespaceEntry *namespace.Namespace
+		mutableState   *MutableStateImpl
+		logger         log.Logger
+		testScope      tally.TestScope
 
 		replicationMultipleBatches bool
 	}
@@ -161,14 +162,14 @@ func (s *mutableStateSuite) SetupTest() {
 	s.mockConfig.MutableStateActivityFailureSizeLimitError = func(namespace string) int { return 2 * 1024 }
 	s.mockShard.SetEventsCacheForTesting(s.mockEventsCache)
 
-	namespaceEntry := tests.GlobalNamespaceEntry
-	s.mockShard.Resource.NamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(namespaceEntry, nil).AnyTimes()
-	s.mockShard.Resource.ClusterMetadata.EXPECT().ClusterNameForFailoverVersion(namespaceEntry.IsGlobalNamespace(), namespaceEntry.FailoverVersion()).Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.namespaceEntry = tests.GlobalNamespaceEntry
+	s.mockShard.Resource.NamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(s.namespaceEntry, nil).AnyTimes()
+	s.mockShard.Resource.ClusterMetadata.EXPECT().ClusterNameForFailoverVersion(s.namespaceEntry.IsGlobalNamespace(), s.namespaceEntry.FailoverVersion()).Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.testScope = s.mockShard.Resource.MetricsScope.(tally.TestScope)
 	s.logger = s.mockShard.GetLogger()
 
-	s.mutableState = NewMutableState(s.mockShard, s.mockEventsCache, s.logger, namespaceEntry, tests.WorkflowID, tests.RunID, time.Now().UTC())
+	s.mutableState = NewMutableState(s.mockShard, s.mockEventsCache, s.logger, s.namespaceEntry, tests.WorkflowID, tests.RunID, time.Now().UTC())
 }
 
 func (s *mutableStateSuite) TearDownTest() {
@@ -1944,5 +1945,65 @@ func (s *mutableStateSuite) TestCloseTransactionPrepareReplicationTasks() {
 				}
 			},
 		)
+	}
+}
+
+func (s *mutableStateSuite) TestMaxAllowedTimer() {
+	testCases := []struct {
+		name                   string
+		runTimeout             time.Duration
+		runTimeoutTimerDropped bool
+	}{
+		{
+			name:                   "run timeout timer preserved",
+			runTimeout:             time.Hour * 24 * 365,
+			runTimeoutTimerDropped: false,
+		},
+		{
+			name:                   "run timeout timer dropped",
+			runTimeout:             time.Hour * 24 * 365 * 100,
+			runTimeoutTimerDropped: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).Times(1)
+			s.mutableState = NewMutableState(s.mockShard, s.mockEventsCache, s.logger, s.namespaceEntry, tests.WorkflowID, tests.RunID, time.Now().UTC())
+
+			workflowKey := s.mutableState.GetWorkflowKey()
+			_, err := s.mutableState.AddWorkflowExecutionStartedEvent(
+				&commonpb.WorkflowExecution{
+					WorkflowId: workflowKey.WorkflowID,
+					RunId:      workflowKey.RunID,
+				},
+				&historyservice.StartWorkflowExecutionRequest{
+					NamespaceId: workflowKey.NamespaceID,
+					StartRequest: &workflowservice.StartWorkflowExecutionRequest{
+						Namespace:  s.mutableState.GetNamespaceEntry().Name().String(),
+						WorkflowId: workflowKey.WorkflowID,
+						WorkflowType: &commonpb.WorkflowType{
+							Name: "test-workflow-type",
+						},
+						TaskQueue: &taskqueuepb.TaskQueue{
+							Name: "test-task-queue",
+						},
+						WorkflowRunTimeout: durationpb.New(tc.runTimeout),
+					},
+				},
+			)
+			s.NoError(err)
+
+			snapshot, _, err := s.mutableState.CloseTransactionAsSnapshot(TransactionPolicyActive)
+			s.NoError(err)
+
+			timerTasks := snapshot.Tasks[tasks.CategoryTimer]
+			if tc.runTimeoutTimerDropped {
+				s.Empty(timerTasks)
+			} else {
+				s.Len(timerTasks, 1)
+				s.Equal(enumsspb.TASK_TYPE_WORKFLOW_RUN_TIMEOUT, timerTasks[0].GetType())
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Drop scheduled tasks if it's scheduled to run far in the future ( duration > 99 year )
- What if we want to recover those timers? 
  - Do a namespace migration, that will re-create all the timers. 

## Why?
<!-- Tell your future self why have you made these changes -->
- There's no point creating those timers. They just consume storage spaces. Persistence implementations also don't have a good way for handling them. 
- https://github.com/temporalio/temporal/pull/4775 capped all timer settings to MaxAllowTimer for new workflows. But if workflows are created before that check is added, we may still create timers for those large durations. E.g. the new logic added for creating workflow execution timeout timer based on the persisted workflow execution expiration time.
- NOTE: all capped timers will be dropped as well.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Added unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- Yes
