### PR TITLE
add log line for DeleteWorkflowExecution when request hits HistoryService

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -1136,11 +1136,6 @@ func (h *Handler) DeleteWorkflowExecution(ctx context.Context, request *historys
 
 	workflowExecution := request.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	h.logger.Debug("DeleteWorkflowExecution requested",
-		tag.WorkflowNamespaceID(request.GetNamespaceId()),
-		tag.WorkflowID(workflowExecution.GetWorkflowId()),
-		tag.WorkflowRunID(workflowExecution.GetRunId()))
-
 	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
@@ -1149,6 +1144,11 @@ func (h *Handler) DeleteWorkflowExecution(ctx context.Context, request *historys
 	if err != nil {
 		return nil, h.convertError(err)
 	}
+
+	h.logger.Info("DeleteWorkflowExecution requested",
+		tag.WorkflowNamespaceID(request.GetNamespaceId()),
+		tag.WorkflowID(workflowExecution.GetWorkflowId()),
+		tag.WorkflowRunID(workflowExecution.GetRunId()))
 
 	resp, err := engine.DeleteWorkflowExecution(ctx, request)
 	if err != nil {

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2204,6 +2204,13 @@ func (h *Handler) ForceDeleteWorkflowExecution(
 		request.Request.Execution.WorkflowId,
 		h.config.NumberOfShards,
 	)
+
+	workflowExecution := request.GetRequest().GetExecution()
+	h.logger.Info("ForceDeleteWorkflowExecution requested",
+		tag.WorkflowNamespaceID(request.GetNamespaceId()),
+		tag.WorkflowID(workflowExecution.GetWorkflowId()),
+		tag.WorkflowRunID(workflowExecution.GetRunId()))
+
 	return forcedeleteworkflowexecution.Invoke(
 		ctx,
 		request,

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -1136,6 +1136,11 @@ func (h *Handler) DeleteWorkflowExecution(ctx context.Context, request *historys
 
 	workflowExecution := request.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
+	h.logger.Debug("DeleteWorkflowExecution requested",
+		tag.WorkflowNamespaceID(request.GetNamespaceId()),
+		tag.WorkflowID(workflowExecution.GetWorkflowId()),
+		tag.WorkflowRunID(workflowExecution.GetRunId()))
+
 	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Adds logging for when the history service recieves the DeleteWorkflowExecution request. Previously, these were logged as part of the retention timer firing from the timer queue processor.

## Why?
<!-- Tell your future self why have you made these changes -->
Gives us more visibility on DeleteWorkflowExecution up-front, instead of when the task is processed later. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

```
$ TEST_ARGS="-v -run TestFunctionalSuite -testify.m TestDeleteWorkflowExecution_CompetedWorkflow" make functional-test
=== RUN   TestFunctionalSuite
2024-06-13T12:33:58.519-0700	info	created database	{"database": "test_0613193358_rge", "logging-call-at": "test.go:182"}
2024-06-13T12:33:59.371-0700	info	loaded schema	{"logging-call-at": "test.go:205"}
=== RUN   TestFunctionalSuite/TestDeleteWorkflowExecution_CompetedWorkflow
==========================================================================
Send commands to server using RespondWorkflowTaskCompleted:
--------------------------------------------------------------------------
command_type:COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION  complete_workflow_execution_command_attributes:{}
==========================================================================
Send commands to server using RespondWorkflowTaskCompleted:
--------------------------------------------------------------------------
command_type:COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION  complete_workflow_execution_command_attributes:{}
==========================================================================
Send commands to server using RespondWorkflowTaskCompleted:
--------------------------------------------------------------------------
command_type:COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION  complete_workflow_execution_command_attributes:{}
==========================================================================
Send commands to server using RespondWorkflowTaskCompleted:
--------------------------------------------------------------------------
command_type:COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION  complete_workflow_execution_command_attributes:{}
==========================================================================
Send commands to server using RespondWorkflowTaskCompleted:
--------------------------------------------------------------------------
command_type:COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION  complete_workflow_execution_command_attributes:{}
2024-06-13T12:34:06.701-0700	info	dropped database	{"database": "test_0613193358_rge", "logging-call-at": "test.go:191"}
--- PASS: TestFunctionalSuite (8.28s)
    --- PASS: TestFunctionalSuite/TestDeleteWorkflowExecution_CompetedWorkflow (4.45s)
PASS
ok  	go.temporal.io/server/tests	8.874s
```

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
