### PR TITLE
Tag resource exhausted error metrics with scope

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -45,6 +45,7 @@ const (
 	nexusOutcomeTagName         = "outcome"
 	versionedTagName            = "versioned"
 	resourceExhaustedTag        = "resource_exhausted_cause"
+	resourceExhaustedScopeTag   = "resource_exhausted_scope"
 	PartitionTypeName           = "partition_type"
 )
 

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -313,6 +313,10 @@ func ResourceExhaustedCauseTag(cause enumspb.ResourceExhaustedCause) Tag {
 	return &tagImpl{key: resourceExhaustedTag, value: cause.String()}
 }
 
+func ResourceExhaustedScopeTag(scope enumspb.ResourceExhaustedScope) Tag {
+	return &tagImpl{key: resourceExhaustedScopeTag, value: scope.String()}
+}
+
 func ServiceNameTag(value primitives.ServiceName) Tag {
 	return &tagImpl{key: serviceName, value: string(value)}
 }

--- a/common/persistence/persistence_metric_clients.go
+++ b/common/persistence/persistence_metric_clients.go
@@ -1309,7 +1309,8 @@ func updateErrorMetric(handler metrics.Handler, logger log.Logger, operation str
 			// no-op
 
 		case *serviceerror.ResourceExhausted:
-			metrics.PersistenceErrResourceExhaustedCounter.With(handler).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
+			metrics.PersistenceErrResourceExhaustedCounter.With(handler).Record(
+				1, metrics.ResourceExhaustedCauseTag(err.Cause), metrics.ResourceExhaustedScopeTag(err.Scope))
 		default:
 			logger.Error("Operation failed with internal error.", tag.Error(err), tag.ErrorType(err), tag.Operation(operation))
 			metrics.PersistenceFailures.With(handler).Record(1)

--- a/common/persistence/visibility/visiblity_manager_metrics.go
+++ b/common/persistence/visibility/visiblity_manager_metrics.go
@@ -189,7 +189,8 @@ func (m *visibilityManagerMetrics) updateErrorMetric(handler metrics.Handler, er
 		// no-op
 
 	case *serviceerror.ResourceExhausted:
-		metrics.VisibilityPersistenceResourceExhausted.With(handler).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
+		metrics.VisibilityPersistenceResourceExhausted.With(handler).Record(
+			1, metrics.ResourceExhaustedCauseTag(err.Cause), metrics.ResourceExhaustedScopeTag(err.Scope))
 	default:
 		m.logger.Error("Operation failed with an error.", tag.Error(err))
 		metrics.VisibilityPersistenceFailures.With(handler).Record(1)

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -400,7 +400,8 @@ func (ti *TelemetryInterceptor) HandleError(
 
 	// specific metric for resource exhausted error with throttle reason
 	case *serviceerror.ResourceExhausted:
-		metrics.ServiceErrResourceExhaustedCounter.With(metricsHandler).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
+		metrics.ServiceErrResourceExhaustedCounter.With(metricsHandler).Record(
+			1, metrics.ResourceExhaustedCauseTag(err.Cause), metrics.ResourceExhaustedScopeTag(err.Scope))
 	// Any other errors are treated as ServiceFailures against SLA unless constructed with the standard
 	// `status.Error` (or Errorf) constructors, in which case the status code is checked below.
 	// Including below known errors and any other unknown errors.

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -551,7 +551,8 @@ func (p *taskProcessorImpl) emitTaskMetrics(operation string, err error) {
 	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 		metrics.ServiceErrNotFoundCounter.With(metricsScope).Record(1)
 	case *serviceerror.ResourceExhausted:
-		metrics.ServiceErrResourceExhaustedCounter.With(metricsScope).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
+		metrics.ServiceErrResourceExhaustedCounter.With(metricsScope).Record(
+			1, metrics.ResourceExhaustedCauseTag(err.Cause), metrics.ResourceExhaustedScopeTag(err.Scope))
 	case *serviceerrors.RetryReplication:
 		metrics.ServiceErrRetryTaskCounter.With(metricsScope).Record(1)
 	default:


### PR DESCRIPTION
## What changed?
Add scope tag to resource exhausted error metric

## Why?
so we can tell if the resource exhaust is due to namespace quota or due to system limit

## How did you test it?
persistence_errors_resource_exhausted{namespace="system",operation="GetClusterMembers",resource_exhausted_cause="PersistenceLimit",resource_exhausted_scope="System",service_name="history"} 1

service_errors_resource_exhausted{namespace="temporal_system",operation="DescribeNamespace",resource_exhausted_cause="RpsLimit",resource_exhausted_scope="System",service_name="frontend"}

## Potential risks


## Documentation

## Is hotfix candidate?
