### PR TITLE
Move pingable interface to separate package

### DIFF
--- a/common/cluster/fx.go
+++ b/common/cluster/fx.go
@@ -29,14 +29,14 @@ import (
 
 	"go.uber.org/fx"
 
-	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/pingable"
 )
 
 var MetadataLifetimeHooksModule = fx.Options(
 	fx.Provide(NewMetadataFromConfig),
 	fx.Invoke(MetadataLifetimeHooks),
 	fx.Provide(fx.Annotate(
-		func(p Metadata) common.Pingable { return p },
+		func(p Metadata) pingable.Pingable { return p },
 		fx.ResultTags(`group:"deadlockDetectorRoots"`),
 	)),
 )

--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -45,6 +45,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/pingable"
 	"go.temporal.io/server/internal/goro"
 )
 
@@ -58,7 +59,7 @@ const (
 type (
 	// Metadata provides information about the current cluster and other registered remote clusters.
 	Metadata interface {
-		common.Pingable
+		pingable.Pingable
 
 		// IsGlobalNamespaceEnabled whether the global namespace is enabled,
 		// this attr should be discarded when cross DC is made public
@@ -250,13 +251,13 @@ func (m *metadataImpl) Stop() {
 	<-m.refresher.Done()
 }
 
-func (m *metadataImpl) GetPingChecks() []common.PingCheck {
-	return []common.PingCheck{
+func (m *metadataImpl) GetPingChecks() []pingable.Check {
+	return []pingable.Check{
 		{
 			Name: "cluster metadata lock",
 			// we don't do any persistence ops under clusterLock, use a short timeout
 			Timeout: 10 * time.Second,
-			Ping: func() []common.Pingable {
+			Ping: func() []pingable.Pingable {
 				m.clusterLock.Lock()
 				//lint:ignore SA2001 just checking if we can acquire the lock
 				m.clusterLock.Unlock()
@@ -269,7 +270,7 @@ func (m *metadataImpl) GetPingChecks() []common.PingCheck {
 			// listeners get called under clusterCallbackLock, they may do some more work, but
 			// not persistence ops.
 			Timeout: 10 * time.Second,
-			Ping: func() []common.Pingable {
+			Ping: func() []pingable.Pingable {
 				m.clusterCallbackLock.Lock()
 				//lint:ignore SA2001 just checking if we can acquire the lock
 				m.clusterCallbackLock.Unlock()

--- a/common/cluster/metadata_mock.go
+++ b/common/cluster/metadata_mock.go
@@ -32,7 +32,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	common "go.temporal.io/server/common"
+	pingable "go.temporal.io/server/common/pingable"
 )
 
 // MockMetadata is a mock of Metadata interface.
@@ -157,10 +157,10 @@ func (mr *MockMetadataMockRecorder) GetNextFailoverVersion(arg0, arg1 interface{
 }
 
 // GetPingChecks mocks base method.
-func (m *MockMetadata) GetPingChecks() []common.PingCheck {
+func (m *MockMetadata) GetPingChecks() []pingable.Check {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPingChecks")
-	ret0, _ := ret[0].([]common.PingCheck)
+	ret0, _ := ret[0].([]pingable.Check)
 	return ret0
 }
 

--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -35,7 +35,6 @@ import (
 	"golang.org/x/exp/maps"
 
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cache"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -44,6 +43,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/pingable"
 	"go.temporal.io/server/internal/goro"
 )
 
@@ -131,7 +131,7 @@ type (
 
 	// Registry provides access to Namespace objects by name or by ID.
 	Registry interface {
-		common.Pingable
+		pingable.Pingable
 		GetNamespace(name Name) (*Namespace, error)
 		GetNamespaceWithOptions(name Name, opts GetNamespaceOptions) (*Namespace, error)
 		GetNamespaceByID(id ID) (*Namespace, error)
@@ -257,13 +257,13 @@ func (r *registry) Stop() {
 	<-r.refresher.Done()
 }
 
-func (r *registry) GetPingChecks() []common.PingCheck {
-	return []common.PingCheck{
+func (r *registry) GetPingChecks() []pingable.Check {
+	return []pingable.Check{
 		{
 			Name: "namespace registry lock",
 			// we don't do any persistence ops, this shouldn't be blocked
 			Timeout: 10 * time.Second,
-			Ping: func() []common.Pingable {
+			Ping: func() []pingable.Pingable {
 				r.cacheLock.Lock()
 				//lint:ignore SA2001 just checking if we can acquire the lock
 				r.cacheLock.Unlock()

--- a/common/namespace/registry_mock.go
+++ b/common/namespace/registry_mock.go
@@ -34,8 +34,8 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	common "go.temporal.io/server/common"
 	persistence "go.temporal.io/server/common/persistence"
+	pingable "go.temporal.io/server/common/pingable"
 )
 
 // MockClock is a mock of Clock interface.
@@ -287,10 +287,10 @@ func (mr *MockRegistryMockRecorder) GetNamespaceWithOptions(name, opts interface
 }
 
 // GetPingChecks mocks base method.
-func (m *MockRegistry) GetPingChecks() []common.PingCheck {
+func (m *MockRegistry) GetPingChecks() []pingable.Check {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPingChecks")
-	ret0, _ := ret[0].([]common.PingCheck)
+	ret0, _ := ret[0].([]pingable.Check)
 	return ret0
 }
 

--- a/common/pingable/pingable.go
+++ b/common/pingable/pingable.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package common
+package pingable
 
 import "time"
 
@@ -30,10 +30,10 @@ type (
 	// Pingable is interface to check for liveness of a component, to detect deadlocks.
 	// This call should not block.
 	Pingable interface {
-		GetPingChecks() []PingCheck
+		GetPingChecks() []Check
 	}
 
-	PingCheck struct {
+	Check struct {
 		// Name of this component.
 		Name string
 		// The longest time that Ping can take. If it doesn't return in that much time, that's

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -59,6 +59,7 @@ import (
 	"go.temporal.io/server/common/persistence"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/pingable"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/rpc"
@@ -105,7 +106,7 @@ var Module = fx.Options(
 	fx.Provide(NamespaceRegistryProvider),
 	namespace.RegistryLifetimeHooksModule,
 	fx.Provide(fx.Annotate(
-		func(p namespace.Registry) common.Pingable { return p },
+		func(p namespace.Registry) pingable.Pingable { return p },
 		fx.ResultTags(`group:"deadlockDetectorRoots"`),
 	)),
 	fx.Provide(serialization.NewSerializer),

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -33,7 +33,6 @@ import (
 	clockspb "go.temporal.io/server/api/clock/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
@@ -43,6 +42,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/pingable"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/events"
@@ -126,7 +126,7 @@ type (
 	// the Controller.
 	ControllableContext interface {
 		Context
-		common.Pingable
+		pingable.Pingable
 
 		IsValid() bool
 		FinishStop()

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -39,7 +39,6 @@ import (
 	v11 "go.temporal.io/server/api/clock/v1"
 	v12 "go.temporal.io/server/api/historyservice/v1"
 	v13 "go.temporal.io/server/api/persistence/v1"
-	common "go.temporal.io/server/common"
 	archiver "go.temporal.io/server/common/archiver"
 	clock "go.temporal.io/server/common/clock"
 	cluster "go.temporal.io/server/common/cluster"
@@ -49,6 +48,7 @@ import (
 	namespace "go.temporal.io/server/common/namespace"
 	persistence "go.temporal.io/server/common/persistence"
 	serialization "go.temporal.io/server/common/persistence/serialization"
+	pingable "go.temporal.io/server/common/pingable"
 	searchattribute "go.temporal.io/server/common/searchattribute"
 	configs "go.temporal.io/server/service/history/configs"
 	events "go.temporal.io/server/service/history/events"
@@ -1137,10 +1137,10 @@ func (mr *MockControllableContextMockRecorder) GetPayloadSerializer() *gomock.Ca
 }
 
 // GetPingChecks mocks base method.
-func (m *MockControllableContext) GetPingChecks() []common.PingCheck {
+func (m *MockControllableContext) GetPingChecks() []pingable.Check {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPingChecks")
-	ret0, _ := ret[0].([]common.PingCheck)
+	ret0, _ := ret[0].([]pingable.Check)
 	return ret0
 }
 

--- a/service/history/shard/controller.go
+++ b/service/history/shard/controller.go
@@ -25,15 +25,15 @@
 package shard
 
 import (
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/pingable"
 )
 
 //go:generate mockgen -copyright_file ../../../LICENSE -package $GOPACKAGE -source $GOFILE -destination controller_mock.go
 
 type (
 	Controller interface {
-		common.Pingable
+		pingable.Pingable
 
 		GetShardByID(shardID int32) (Context, error)
 		GetShardByNamespaceWorkflow(namespaceID namespace.ID, workflowID string) (Context, error)

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -44,6 +44,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/pingable"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/configs"
 )
@@ -151,15 +152,15 @@ func (c *ControllerImpl) Stop() {
 	c.contextTaggedLogger.Info("", tag.LifeCycleStopped)
 }
 
-func (c *ControllerImpl) GetPingChecks() []common.PingCheck {
-	return []common.PingCheck{{
+func (c *ControllerImpl) GetPingChecks() []pingable.Check {
+	return []pingable.Check{{
 		Name:    "shard controller",
 		Timeout: 10 * time.Second,
-		Ping: func() []common.Pingable {
+		Ping: func() []pingable.Pingable {
 			// we only need to read but get write lock to make sure we can
 			c.Lock()
 			defer c.Unlock()
-			out := make([]common.Pingable, 0, len(c.historyShards))
+			out := make([]pingable.Pingable, 0, len(c.historyShards))
 			for _, shard := range c.historyShards {
 				out = append(out, shard)
 			}

--- a/service/history/shard/controller_mock.go
+++ b/service/history/shard/controller_mock.go
@@ -32,8 +32,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	common "go.temporal.io/server/common"
 	namespace "go.temporal.io/server/common/namespace"
+	pingable "go.temporal.io/server/common/pingable"
 )
 
 // MockController is a mock of Controller interface.
@@ -72,10 +72,10 @@ func (mr *MockControllerMockRecorder) CloseShardByID(shardID interface{}) *gomoc
 }
 
 // GetPingChecks mocks base method.
-func (m *MockController) GetPingChecks() []common.PingCheck {
+func (m *MockController) GetPingChecks() []pingable.Check {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPingChecks")
-	ret0, _ := ret[0].([]common.PingCheck)
+	ret0, _ := ret[0].([]pingable.Check)
 	return ret0
 }
 

--- a/service/history/shard/fx.go
+++ b/service/history/shard/fx.go
@@ -30,9 +30,9 @@ import (
 
 	"go.uber.org/fx"
 
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/pingable"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/service/history/configs"
 )
@@ -43,7 +43,7 @@ var Module = fx.Options(
 		func(impl *ControllerImpl) Controller { return impl },
 		ContextFactoryProvider,
 		fx.Annotate(
-			func(p Controller) common.Pingable { return p },
+			func(p Controller) pingable.Pingable { return p },
 			fx.ResultTags(`group:"deadlockDetectorRoots"`),
 		),
 	),


### PR DESCRIPTION
## What changed?
Moving an interface.

## Why?
Avoid import cycles: I want to use this from dynamicconfig which can't depend on common.