### PR TITLE
Fix flaky TestUpdateWorkflow_ValidateWorkerMessages test

### DIFF
--- a/tests/update_workflow.go
+++ b/tests/update_workflow.go
@@ -1223,6 +1223,8 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ValidateWorkerMessages() {
 			}
 			go updateWorkflowFn(tc.RespondWorkflowTaskError != "")
 
+			runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage)
+
 			// Process update in workflow.
 			_, err := poller.PollAndProcessWorkflowTask()
 			if tc.RespondWorkflowTaskError != "" {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix flaky `TestUpdateWorkflow_ValidateWorkerMessages` test.

## Why?
<!-- Tell your future self why have you made these changes -->
Falkiness is bad.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run it. Only once though.
