### PR TITLE
Deprecate cluster information config

### DIFF
--- a/common/cluster/clustertest/test_metadata.go
+++ b/common/cluster/clustertest/test_metadata.go
@@ -31,12 +31,13 @@ import (
 func NewMetadataForTest(
 	config *cluster.Config,
 ) cluster.Metadata {
+	clusterMap := cluster.NewTestClusterMapConfig(config.EnableGlobalNamespace)
 	return cluster.NewMetadata(
 		config.EnableGlobalNamespace,
 		config.FailoverVersionIncrement,
 		config.MasterClusterName,
 		config.CurrentClusterName,
-		config.ClusterInformation,
+		clusterMap.ClusterInformation,
 		nil,
 		nil,
 		log.NewNoopLogger(),

--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -98,11 +98,22 @@ type (
 		// all clusters can do namespace failover.
 		MasterClusterName string `yaml:"masterClusterName"`
 		// CurrentClusterName is the name of the current cluster.
-		CurrentClusterName string `yaml:"currentClusterName"`
-		// ClusterInformation is a map from cluster name to corresponding information for each registered cluster.
-		ClusterInformation map[string]ClusterInformation `yaml:"clusterInformation"`
+		CurrentClusterName     string `yaml:"currentClusterName"`
+		InitialFailoverVersion int64  `yaml:"initialFailoverVersion"`
+		// RPCAddress indicate the remote service address(Host:Port). Host can be DNS name.
+		RPCAddress string `yaml:"rpcAddress"`
+		// HTTPAddress indicates the address of the [go.temporal.io/server/service/frontend.HTTPAPIServer].
+		// E.g. "localhost:7243".
+		HTTPAddress string `yaml:"httpAddress"`
+		// ClusterID allows to explicitly set the ID of the cluster. Optional.
+		ClusterID string `yaml:"-"`
 		// Tags contains customized tags for the current cluster.
 		Tags map[string]string `yaml:"tags"`
+	}
+
+	ClusterMap struct {
+		// ClusterInformation is a map from cluster name to corresponding information for each registered cluster.
+		ClusterInformation map[string]ClusterInformation `yaml:"clusterInformation"`
 	}
 
 	// ClusterInformation contains information for a single cluster.
@@ -208,6 +219,7 @@ func NewMetadata(
 
 func NewMetadataFromConfig(
 	config *Config,
+	clusterMap *ClusterMap,
 	clusterMetadataStore persistence.ClusterMetadataManager,
 	dynamicCollection *dynamicconfig.Collection,
 	logger log.Logger,
@@ -217,7 +229,7 @@ func NewMetadataFromConfig(
 		config.FailoverVersionIncrement,
 		config.MasterClusterName,
 		config.CurrentClusterName,
-		config.ClusterInformation,
+		clusterMap.ClusterInformation,
 		clusterMetadataStore,
 		dynamicconfig.ClusterMetadataRefreshInterval.Get(dynamicCollection),
 		logger,

--- a/common/cluster/metadata_test_config.go
+++ b/common/cluster/metadata_test_config.go
@@ -85,7 +85,6 @@ func NewTestClusterMetadataConfig(enableGlobalNamespace bool, isMasterCluster bo
 			FailoverVersionIncrement: TestFailoverVersionIncrement,
 			MasterClusterName:        masterClusterName,
 			CurrentClusterName:       TestCurrentClusterName,
-			ClusterInformation:       TestAllClusterInfo,
 		}
 	}
 
@@ -94,6 +93,14 @@ func NewTestClusterMetadataConfig(enableGlobalNamespace bool, isMasterCluster bo
 		FailoverVersionIncrement: TestFailoverVersionIncrement,
 		MasterClusterName:        TestCurrentClusterName,
 		CurrentClusterName:       TestCurrentClusterName,
-		ClusterInformation:       TestSingleDCClusterInfo,
 	}
+}
+
+// NewTestClusterMapConfig return an cluster metadata config
+func NewTestClusterMapConfig(enableGlobalNamespace bool) *ClusterMap {
+	if enableGlobalNamespace {
+		return &ClusterMap{ClusterInformation: TestAllClusterInfo}
+	}
+
+	return &ClusterMap{ClusterInformation: TestSingleDCClusterInfo}
 }

--- a/common/persistence/persistence-tests/persistence_test_base.go
+++ b/common/persistence/persistence-tests/persistence_test_base.go
@@ -202,6 +202,7 @@ func (s *TestBase) Setup(clusterMetadataConfig *cluster.Config) {
 	if clusterMetadataConfig == nil {
 		clusterMetadataConfig = cluster.NewTestClusterMetadataConfig(false, false)
 	}
+	clusterMap := cluster.NewTestClusterMapConfig(clusterMetadataConfig.EnableGlobalNamespace)
 	if s.PersistenceHealthSignals == nil {
 		s.PersistenceHealthSignals = persistence.NoopHealthSignalAggregator
 	}
@@ -227,7 +228,7 @@ func (s *TestBase) Setup(clusterMetadataConfig *cluster.Config) {
 	s.ClusterMetadataManager, err = factory.NewClusterMetadataManager()
 	s.fatalOnError("NewClusterMetadataManager", err)
 
-	s.ClusterMetadata = cluster.NewMetadataFromConfig(clusterMetadataConfig, s.ClusterMetadataManager, dynamicconfig.NewNoopCollection(), s.Logger)
+	s.ClusterMetadata = cluster.NewMetadataFromConfig(clusterMetadataConfig, clusterMap, s.ClusterMetadataManager, dynamicconfig.NewNoopCollection(), s.Logger)
 	s.SearchAttributesManager = searchattribute.NewManager(clock.NewRealTimeSource(), s.ClusterMetadataManager, dynamicconfig.GetBoolPropertyFn(true))
 
 	s.MetadataManager, err = factory.NewMetadataManager()

--- a/config/development-cluster-a.yaml
+++ b/config/development-cluster-a.yaml
@@ -65,12 +65,9 @@ clusterMetadata:
   failoverVersionIncrement: 100
   masterClusterName: "cluster-a"
   currentClusterName: "cluster-a"
-  clusterInformation:
-    cluster-a:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  rpcName: "frontend"
+  rpcAddress: "localhost:7233"
 # Use tctl --ad 127.0.0.1:7233 adm cl upsert-remote-cluster --frontend_address "127.0.0.1:8233"
 #    cluster-b:
 #      enabled: true

--- a/config/development-cluster-b.yaml
+++ b/config/development-cluster-b.yaml
@@ -62,19 +62,11 @@ services:
 clusterMetadata:
   enableGlobalNamespace: true
   failoverVersionIncrement: 100
-  masterClusterName: "cluster-a"
+  masterClusterName: "cluster-b"
   currentClusterName: "cluster-b"
-  clusterInformation:
-    cluster-a:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
-    cluster-b:
-      enabled: true
-      initialFailoverVersion: 2
-      rpcName: "frontend"
-      rpcAddress: "localhost:8233"
+  initialFailoverVersion: 2
+  rpcName: "frontend"
+  rpcAddress: "localhost:8233"
 # Use tctl --ad 127.0.0.1:8233 adm cl upsert-remote-cluster --frontend_address "127.0.0.1:7233"
 #    active:
 #      enabled: true

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	historypb "go.temporal.io/api/history/v1"
+
 	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/client"

--- a/temporal/cluster_metadata_loader_test.go
+++ b/temporal/cluster_metadata_loader_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
@@ -47,16 +48,8 @@ func TestNewClusterMetadataLoader(t *testing.T) {
 	svc := &config.Config{
 		ClusterMetadata: &cluster.Config{
 			CurrentClusterName: "current_cluster",
-			ClusterInformation: map[string]cluster.ClusterInformation{
-				"current_cluster": {
-					RPCAddress:  "rpc_old",
-					HTTPAddress: "http_old",
-				},
-				"remote_cluster1": {
-					RPCAddress:  "rpc_old",
-					HTTPAddress: "http_old",
-				},
-			},
+			RPCAddress:         "rpc_old",
+			HTTPAddress:        "http_old",
 		},
 	}
 
@@ -86,7 +79,7 @@ func TestNewClusterMetadataLoader(t *testing.T) {
 		},
 	}, nil)
 
-	err := loader.LoadAndMergeWithStaticConfig(ctx, svc)
+	clusterMap, err := loader.LoadAndMergeWithStaticConfig(ctx, svc)
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]cluster.ClusterInformation{
@@ -102,5 +95,5 @@ func TestNewClusterMetadataLoader(t *testing.T) {
 			RPCAddress:  "rpc_new",
 			HTTPAddress: "http_new",
 		},
-	}, svc.ClusterMetadata.ClusterInformation)
+	}, clusterMap.ClusterInformation)
 }

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -352,6 +352,7 @@ type (
 		fx.In
 
 		Cfg                        *config.Config
+		ClusterMapper              *cluster.ClusterMap
 		ServiceNames               resource.ServiceNames
 		Logger                     log.Logger
 		NamespaceLogger            resource.NamespaceLogger
@@ -399,6 +400,7 @@ func (params ServiceProviderParamsCommon) GetCommonServiceOptions(serviceName pr
 			params.PersistenceConfig,
 			params.ClusterMetadata,
 			params.Cfg,
+			params.ClusterMapper,
 			params.SpanExporters,
 		),
 		fx.Provide(
@@ -599,61 +601,54 @@ func WorkerServiceProvider(
 // TODO: move this to cluster.fx
 func ApplyClusterMetadataConfigProvider(
 	logger log.Logger,
-	svc *config.Config,
+	staticConfig *config.Config,
 	persistenceServiceResolver resolver.ServiceResolver,
 	persistenceFactoryProvider persistenceClient.FactoryProviderFn,
 	customDataStoreFactory persistenceClient.AbstractDataStoreFactory,
 	metricsHandler metrics.Handler,
-) (*cluster.Config, config.Persistence, error) {
+) (*cluster.Config, *cluster.ClusterMap, config.Persistence, error) {
 	ctx := context.TODO()
 	logger = log.With(logger, tag.ComponentMetadataInitializer)
 	metricsHandler = metricsHandler.WithTags(metrics.ServiceNameTag(primitives.ServerService))
-	clusterName := persistenceClient.ClusterName(svc.ClusterMetadata.CurrentClusterName)
+	clusterName := persistenceClient.ClusterName(staticConfig.ClusterMetadata.CurrentClusterName)
 	dataStoreFactory := persistenceClient.DataStoreFactoryProvider(
 		clusterName,
 		persistenceServiceResolver,
-		&svc.Persistence,
+		&staticConfig.Persistence,
 		customDataStoreFactory,
 		logger,
 		metricsHandler,
 	)
 	factory := persistenceFactoryProvider(persistenceClient.NewFactoryParams{
 		DataStoreFactory:           dataStoreFactory,
-		Cfg:                        &svc.Persistence,
+		Cfg:                        &staticConfig.Persistence,
 		PersistenceMaxQPS:          nil,
 		PersistenceNamespaceMaxQPS: nil,
-		ClusterName:                persistenceClient.ClusterName(svc.ClusterMetadata.CurrentClusterName),
+		ClusterName:                persistenceClient.ClusterName(staticConfig.ClusterMetadata.CurrentClusterName),
 		MetricsHandler:             metricsHandler,
 		Logger:                     logger,
 	})
 	defer factory.Close()
 
+	clusterMap := &cluster.ClusterMap{
+		ClusterInformation: make(map[string]cluster.ClusterInformation),
+	}
+
 	clusterMetadataManager, err := factory.NewClusterMetadataManager()
 	if err != nil {
-		return svc.ClusterMetadata, svc.Persistence, fmt.Errorf("error initializing cluster metadata manager: %w", err)
+		return staticConfig.ClusterMetadata, clusterMap, staticConfig.Persistence, fmt.Errorf("error initializing cluster metadata manager: %w", err)
 	}
 	defer clusterMetadataManager.Close()
 
 	initialIndexSearchAttributes := make(map[string]*persistencespb.IndexSearchAttributes)
-	if ds := svc.Persistence.GetVisibilityStoreConfig(); ds.SQL != nil {
+	if ds := staticConfig.Persistence.GetVisibilityStoreConfig(); ds.SQL != nil {
 		initialIndexSearchAttributes[ds.GetIndexName()] = searchattribute.GetSqlDbIndexSearchAttributes()
 	}
-	if ds := svc.Persistence.GetSecondaryVisibilityStoreConfig(); ds.SQL != nil {
+	if ds := staticConfig.Persistence.GetSecondaryVisibilityStoreConfig(); ds.SQL != nil {
 		initialIndexSearchAttributes[ds.GetIndexName()] = searchattribute.GetSqlDbIndexSearchAttributes()
 	}
 
-	clusterMetadata := svc.ClusterMetadata
-	if len(clusterMetadata.ClusterInformation) > 1 {
-		logger.Warn(
-			"All remote cluster settings under ClusterMetadata.ClusterInformation config will be ignored. "+
-				"Please use TCTL admin tool to configure remote cluster settings",
-			tag.Key("clusterInformation"))
-	}
-	if _, ok := clusterMetadata.ClusterInformation[clusterMetadata.CurrentClusterName]; !ok {
-		logger.Error("Current cluster setting is missing under clusterMetadata.ClusterInformation",
-			tag.ClusterName(clusterMetadata.CurrentClusterName))
-		return svc.ClusterMetadata, svc.Persistence, missingCurrentClusterMetadataErr
-	}
+	clusterMetadata := staticConfig.ClusterMetadata
 	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundCallerInfo)
 	resp, err := clusterMetadataManager.GetClusterMetadata(
 		ctx,
@@ -665,15 +660,15 @@ func ApplyClusterMetadataConfigProvider(
 		if updateErr := updateCurrentClusterMetadataRecord(
 			ctx,
 			clusterMetadataManager,
-			svc,
+			staticConfig,
 			initialIndexSearchAttributes,
 			resp,
 		); updateErr != nil {
-			return svc.ClusterMetadata, svc.Persistence, updateErr
+			return staticConfig.ClusterMetadata, clusterMap, staticConfig.Persistence, updateErr
 		}
 		// Ignore invalid cluster metadata
 		overwriteCurrentClusterMetadataWithDBRecord(
-			svc,
+			staticConfig,
 			resp,
 			logger,
 		)
@@ -682,22 +677,22 @@ func ApplyClusterMetadataConfigProvider(
 		if initErr := initCurrentClusterMetadataRecord(
 			ctx,
 			clusterMetadataManager,
-			svc,
+			staticConfig,
 			initialIndexSearchAttributes,
 			logger,
 		); initErr != nil {
-			return svc.ClusterMetadata, svc.Persistence, initErr
+			return staticConfig.ClusterMetadata, clusterMap, staticConfig.Persistence, initErr
 		}
 	default:
-		return svc.ClusterMetadata, svc.Persistence, fmt.Errorf("error while fetching cluster metadata: %w", err)
+		return staticConfig.ClusterMetadata, clusterMap, staticConfig.Persistence, fmt.Errorf("error while fetching cluster metadata: %w", err)
 	}
 
 	clusterLoader := NewClusterMetadataLoader(clusterMetadataManager, logger)
-	err = clusterLoader.LoadAndMergeWithStaticConfig(ctx, svc)
+	clusterMap, err = clusterLoader.LoadAndMergeWithStaticConfig(ctx, staticConfig)
 	if err != nil {
-		return svc.ClusterMetadata, svc.Persistence, fmt.Errorf("error while loading metadata from cluster: %w", err)
+		return staticConfig.ClusterMetadata, clusterMap, staticConfig.Persistence, fmt.Errorf("error while loading metadata from cluster: %w", err)
 	}
-	return svc.ClusterMetadata, svc.Persistence, nil
+	return staticConfig.ClusterMetadata, clusterMap, staticConfig.Persistence, nil
 }
 
 func initCurrentClusterMetadataRecord(
@@ -709,14 +704,13 @@ func initCurrentClusterMetadataRecord(
 ) error {
 	var clusterId string
 	currentClusterName := svc.ClusterMetadata.CurrentClusterName
-	currentClusterInfo := svc.ClusterMetadata.ClusterInformation[currentClusterName]
-	if uuid.Parse(currentClusterInfo.ClusterID) == nil {
-		if currentClusterInfo.ClusterID != "" {
+	if uuid.Parse(svc.ClusterMetadata.ClusterID) == nil {
+		if svc.ClusterMetadata.ClusterID != "" {
 			logger.Warn("Cluster Id in Cluster Metadata config is not a valid uuid. Generating a new Cluster Id")
 		}
 		clusterId = uuid.New()
 	} else {
-		clusterId = currentClusterInfo.ClusterID
+		clusterId = svc.ClusterMetadata.ClusterID
 	}
 
 	applied, err := clusterMetadataManager.SaveClusterMetadata(
@@ -726,12 +720,12 @@ func initCurrentClusterMetadataRecord(
 				HistoryShardCount:        svc.Persistence.NumHistoryShards,
 				ClusterName:              currentClusterName,
 				ClusterId:                clusterId,
-				ClusterAddress:           currentClusterInfo.RPCAddress,
-				HttpAddress:              currentClusterInfo.HTTPAddress,
+				ClusterAddress:           svc.ClusterMetadata.RPCAddress,
+				HttpAddress:              svc.ClusterMetadata.HTTPAddress,
 				FailoverVersionIncrement: svc.ClusterMetadata.FailoverVersionIncrement,
-				InitialFailoverVersion:   currentClusterInfo.InitialFailoverVersion,
+				InitialFailoverVersion:   svc.ClusterMetadata.InitialFailoverVersion,
 				IsGlobalNamespaceEnabled: svc.ClusterMetadata.EnableGlobalNamespace,
-				IsConnectionEnabled:      currentClusterInfo.Enabled,
+				IsConnectionEnabled:      true,
 				UseClusterIdMembership:   true, // Enable this for new cluster after 1.19. This is to prevent two clusters join into one ring.
 				IndexSearchAttributes:    initialIndexSearchAttributes,
 				Tags:                     svc.ClusterMetadata.Tags,
@@ -757,21 +751,19 @@ func updateCurrentClusterMetadataRecord(
 ) error {
 	updateDBRecord := false
 	currentClusterMetadata := svc.ClusterMetadata
-	currentClusterName := currentClusterMetadata.CurrentClusterName
-	currentCLusterInfo := currentClusterMetadata.ClusterInformation[currentClusterName]
 	// Allow updating cluster metadata if global namespace is disabled
 	if !currentClusterDBRecord.IsGlobalNamespaceEnabled && currentClusterMetadata.EnableGlobalNamespace {
 		currentClusterDBRecord.IsGlobalNamespaceEnabled = currentClusterMetadata.EnableGlobalNamespace
-		currentClusterDBRecord.InitialFailoverVersion = currentCLusterInfo.InitialFailoverVersion
+		currentClusterDBRecord.InitialFailoverVersion = currentClusterMetadata.InitialFailoverVersion
 		currentClusterDBRecord.FailoverVersionIncrement = currentClusterMetadata.FailoverVersionIncrement
 		updateDBRecord = true
 	}
-	if currentClusterDBRecord.ClusterAddress != currentCLusterInfo.RPCAddress {
-		currentClusterDBRecord.ClusterAddress = currentCLusterInfo.RPCAddress
+	if len(currentClusterMetadata.RPCAddress) != 0 && currentClusterDBRecord.ClusterAddress != currentClusterMetadata.RPCAddress {
+		currentClusterDBRecord.ClusterAddress = currentClusterMetadata.RPCAddress
 		updateDBRecord = true
 	}
-	if currentClusterDBRecord.HttpAddress != currentCLusterInfo.HTTPAddress {
-		currentClusterDBRecord.HttpAddress = currentCLusterInfo.HTTPAddress
+	if len(currentClusterMetadata.HTTPAddress) != 0 && currentClusterDBRecord.HttpAddress != currentClusterMetadata.HTTPAddress {
+		currentClusterDBRecord.HttpAddress = currentClusterMetadata.HTTPAddress
 		updateDBRecord = true
 	}
 	if !maps.Equal(currentClusterDBRecord.Tags, svc.ClusterMetadata.Tags) {

--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -188,13 +188,13 @@ func NewClusterWithPersistenceTestBaseFactory(t *testing.T, options *TestCluster
 		options.ClusterMetadata.EnableGlobalNamespace,
 		options.IsMasterCluster,
 	)
+	clusterMap := cluster.NewTestClusterMapConfig(options.ClusterMetadata.EnableGlobalNamespace)
 	if !options.IsMasterCluster && options.ClusterMetadata.MasterClusterName != "" { // xdc cluster metadata setup
 		clusterMetadataConfig = &cluster.Config{
 			EnableGlobalNamespace:    options.ClusterMetadata.EnableGlobalNamespace,
 			FailoverVersionIncrement: options.ClusterMetadata.FailoverVersionIncrement,
 			MasterClusterName:        options.ClusterMetadata.MasterClusterName,
 			CurrentClusterName:       options.ClusterMetadata.CurrentClusterName,
-			ClusterInformation:       options.ClusterMetadata.ClusterInformation,
 		}
 	}
 	options.Persistence.Logger = logger
@@ -239,7 +239,7 @@ func NewClusterWithPersistenceTestBaseFactory(t *testing.T, options *TestCluster
 	}
 
 	clusterInfoMap := make(map[string]cluster.ClusterInformation)
-	for clusterName, clusterInfo := range clusterMetadataConfig.ClusterInformation {
+	for clusterName, clusterInfo := range clusterMap.ClusterInformation {
 		clusterInfo.ShardCount = options.HistoryConfig.NumHistoryShards
 		clusterInfoMap[clusterName] = clusterInfo
 		_, err := testBase.ClusterMetadataManager.SaveClusterMetadata(context.Background(), &persistence.SaveClusterMetadataRequest{
@@ -258,7 +258,7 @@ func NewClusterWithPersistenceTestBaseFactory(t *testing.T, options *TestCluster
 			return nil, err
 		}
 	}
-	clusterMetadataConfig.ClusterInformation = clusterInfoMap
+	clusterMap.ClusterInformation = clusterInfoMap
 
 	// This will save custom test search attributes to cluster metadata.
 	// Actual Elasticsearch fields are created in setupIndex.


### PR DESCRIPTION
## What changed?
Deprecate cluster information config

## Why?
We don't need cluster information for remote clusters.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
