### PR TITLE
Add DC to limit schedule-to-close timeout of a Nexus operation

### DIFF
--- a/components/nexusoperations/workflow/commands_test.go
+++ b/components/nexusoperations/workflow/commands_test.go
@@ -58,6 +58,7 @@ func (v commandValidator) IsValidPayloadSize(size int) bool {
 }
 
 type testContext struct {
+	execInfo        *persistencespb.WorkflowExecutionInfo
 	ms              workflow.MutableState
 	scheduleHandler workflow.CommandHandler
 	cancelHandler   workflow.CommandHandler
@@ -65,10 +66,11 @@ type testContext struct {
 }
 
 var defaultConfig = &nexusoperations.Config{
-	Enabled:                 dynamicconfig.GetBoolPropertyFn(true),
-	MaxServiceNameLength:    dynamicconfig.GetIntPropertyFnFilteredByNamespace(len("service")),
-	MaxOperationNameLength:  dynamicconfig.GetIntPropertyFnFilteredByNamespace(len("op")),
-	MaxConcurrentOperations: dynamicconfig.GetIntPropertyFnFilteredByNamespace(2),
+	Enabled:                            dynamicconfig.GetBoolPropertyFn(true),
+	MaxServiceNameLength:               dynamicconfig.GetIntPropertyFnFilteredByNamespace(len("service")),
+	MaxOperationNameLength:             dynamicconfig.GetIntPropertyFnFilteredByNamespace(len("op")),
+	MaxConcurrentOperations:            dynamicconfig.GetIntPropertyFnFilteredByNamespace(2),
+	MaxOperationScheduleToCloseTimeout: dynamicconfig.GetDurationPropertyFnFilteredByNamespace(time.Hour * 24),
 }
 
 func newTestContext(t *testing.T, cfg *nexusoperations.Config) testContext {
@@ -104,8 +106,10 @@ func newTestContext(t *testing.T, cfg *nexusoperations.Config) testContext {
 		history.Events = append(history.Events, e)
 		return e
 	}).AnyTimes()
+
+	execInfo := &persistencespb.WorkflowExecutionInfo{}
 	ms.EXPECT().GetNamespaceEntry().Return(tests.GlobalNamespaceEntry).AnyTimes()
-	ms.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{}).AnyTimes()
+	ms.EXPECT().GetExecutionInfo().Return(execInfo).AnyTimes()
 	ms.EXPECT().GetCurrentVersion().Return(int64(1)).AnyTimes()
 	ms.EXPECT().TransitionCount().Return(int64(1)).AnyTimes()
 	scheduleHandler, ok := chReg.Handler(enumspb.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION)
@@ -114,6 +118,7 @@ func newTestContext(t *testing.T, cfg *nexusoperations.Config) testContext {
 	require.True(t, ok)
 
 	return testContext{
+		execInfo:        execInfo,
 		ms:              ms,
 		history:         history,
 		scheduleHandler: scheduleHandler,
@@ -247,6 +252,43 @@ func TestHandleScheduleCommand(t *testing.T) {
 		require.False(t, failWFTErr.FailWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_PENDING_NEXUS_OPERATIONS_LIMIT_EXCEEDED, failWFTErr.Cause)
 		require.Equal(t, 2, len(tcx.history.Events))
+	})
+
+	t.Run("schedule to close timeout capped by run timeout", func(t *testing.T) {
+		tcx := newTestContext(t, defaultConfig)
+		tcx.execInfo.WorkflowRunTimeout = durationpb.New(time.Hour)
+		err := tcx.scheduleHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 1, &commandpb.Command{
+			Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
+				ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
+					Endpoint:               "endpoint",
+					Service:                "service",
+					Operation:              "op",
+					ScheduleToCloseTimeout: durationpb.New(time.Hour * 2),
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(tcx.history.Events))
+		require.Equal(t, time.Hour, tcx.history.Events[0].GetNexusOperationScheduledEventAttributes().ScheduleToCloseTimeout.AsDuration())
+	})
+
+	t.Run("schedule to close timeout capped by dynamic config", func(t *testing.T) {
+		cfg := *defaultConfig
+		cfg.MaxOperationScheduleToCloseTimeout = dynamicconfig.GetDurationPropertyFnFilteredByNamespace(time.Minute)
+		tcx := newTestContext(t, &cfg)
+		err := tcx.scheduleHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 1, &commandpb.Command{
+			Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
+				ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
+					Endpoint:               "endpoint",
+					Service:                "service",
+					Operation:              "op",
+					ScheduleToCloseTimeout: durationpb.New(time.Hour),
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(tcx.history.Events))
+		require.Equal(t, time.Minute, tcx.history.Events[0].GetNexusOperationScheduledEventAttributes().ScheduleToCloseTimeout.AsDuration())
 	})
 
 	timeoutCases := []struct {


### PR DESCRIPTION
## Why?

Operational flexibility, allows deprecating callback URLs and tokens.
This will be even more important when we support callback token encryption and want to limit the lifetime of an encryption key.