### PR TITLE
Add first shard update interval

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1845,7 +1845,7 @@ state. The total size is determined by the sum of the size, in bytes, of each Hi
 		"history.shardFirstUpdateInterval",
 		10*time.Second,
 		`ShardFirstUpdateInterval is the time interval after which the first shard info update will happen.
-		It shouud be smaller then ShardUpdateMinInterfal`,
+		It shoukd be smaller than ShardUpdateMinInterval`,
 	)
 	ShardUpdateMinTasksCompleted = NewGlobalIntSetting(
 		"history.shardUpdateMinTasksCompleted",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1841,6 +1841,12 @@ state. The total size is determined by the sum of the size, in bytes, of each Hi
 		5*time.Minute,
 		`ShardUpdateMinInterval is the minimal time interval which the shard info can be updated`,
 	)
+	ShardFirstUpdateInterval = NewGlobalDurationSetting(
+		"history.shardFirstUpdateInterval",
+		10*time.Second,
+		`ShardFirstUpdateInterval is the time interval after which the first shard info update will happen.
+		It shouud be smaller then ShardUpdateMinInterfal`,
+	)
 	ShardUpdateMinTasksCompleted = NewGlobalIntSetting(
 		"history.shardUpdateMinTasksCompleted",
 		1000,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1845,7 +1845,7 @@ state. The total size is determined by the sum of the size, in bytes, of each Hi
 		"history.shardFirstUpdateInterval",
 		10*time.Second,
 		`ShardFirstUpdateInterval is the time interval after which the first shard info update will happen.
-		It shoukd be smaller than ShardUpdateMinInterval`,
+		It should be smaller than ShardUpdateMinInterval`,
 	)
 	ShardUpdateMinTasksCompleted = NewGlobalIntSetting(
 		"history.shardUpdateMinTasksCompleted",

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -185,6 +185,10 @@ type Config struct {
 
 	// ShardUpdateMinInterval is the minimum time interval within which the shard info can be updated.
 	ShardUpdateMinInterval dynamicconfig.DurationPropertyFn
+
+	// ShardFirstUpdateMinInterval defines how soon _first_ hard update should happen.
+	ShardFirstUpdateInterval dynamicconfig.DurationPropertyFn
+
 	// ShardUpdateMinTasksCompleted is the minimum number of tasks which must be completed before the shard info can be updated before
 	// history.shardUpdateMinInterval has passed
 	ShardUpdateMinTasksCompleted dynamicconfig.IntPropertyFn
@@ -513,6 +517,7 @@ func NewConfig(
 		MaximumBufferedEventsSizeInBytes: dynamicconfig.MaximumBufferedEventsSizeInBytes.Get(dc),
 		MaximumSignalsPerExecution:       dynamicconfig.MaximumSignalsPerExecution.Get(dc),
 		ShardUpdateMinInterval:           dynamicconfig.ShardUpdateMinInterval.Get(dc),
+		ShardFirstUpdateInterval:         dynamicconfig.ShardFirstUpdateInterval.Get(dc),
 		ShardUpdateMinTasksCompleted:     dynamicconfig.ShardUpdateMinTasksCompleted.Get(dc),
 		ShardSyncMinInterval:             dynamicconfig.ShardSyncMinInterval.Get(dc),
 		ShardSyncTimerJitterCoefficient:  dynamicconfig.TransferProcessorMaxPollIntervalJitterCoefficient.Get(dc),

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -2130,14 +2130,14 @@ func newContext(
 		)
 	}
 
-	// We need to set lastUpdate time to "now" + "wait between shard updates time" -  "first update interval"
-	// This is done to make sure that first shard update` will happen around "first update interval".
+	// We need to set lastUpdate time to "now" - "wait between shard updates time" +  "first update interval".
+	// This is done to make sure that first shard update` will happen around "first update interval" after "now".
 	// The idea is to allow queue to persist even in the case of (relativly) constantly
 	// moving shards between hosts.
 	// Note: it still may prevent queue from progressing if shard moving rate is too high
 	lastUpdated := shardContext.timeSource.Now()
-	lastUpdated = lastUpdated.Add(shardContext.config.ShardUpdateMinInterval())
-	lastUpdated = lastUpdated.Add(-1 * shardContext.config.ShardFirstUpdateInterval())
+	lastUpdated = lastUpdated.Add(-1 * shardContext.config.ShardUpdateMinInterval())
+	lastUpdated = lastUpdated.Add(shardContext.config.ShardFirstUpdateInterval())
 	shardContext.lastUpdated = lastUpdated
 	return shardContext, nil
 }

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -2129,17 +2129,20 @@ func newContext(
 			false,
 		)
 	}
+	shardContext.initLastUpdatesTime()
+	return shardContext, nil
+}
 
+func (s *ContextImpl) initLastUpdatesTime() {
 	// We need to set lastUpdate time to "now" - "wait between shard updates time" +  "first update interval".
 	// This is done to make sure that first shard update` will happen around "first update interval" after "now".
 	// The idea is to allow queue to persist even in the case of (relativly) constantly
 	// moving shards between hosts.
 	// Note: it still may prevent queue from progressing if shard moving rate is too high
-	lastUpdated := shardContext.timeSource.Now()
-	lastUpdated = lastUpdated.Add(-1 * shardContext.config.ShardUpdateMinInterval())
-	lastUpdated = lastUpdated.Add(shardContext.config.ShardFirstUpdateInterval())
-	shardContext.lastUpdated = lastUpdated
-	return shardContext, nil
+	lastUpdated := s.timeSource.Now()
+	lastUpdated = lastUpdated.Add(-1 * s.config.ShardUpdateMinInterval())
+	lastUpdated = lastUpdated.Add(s.config.ShardFirstUpdateInterval())
+	s.lastUpdated = lastUpdated
 }
 
 // TODO: why do we need a deep copy here?


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
1. Add ShardFirstUpdateInterval config setting
2. Initialize shard lastUpdated according to that setting
3. Slightly change the logic in updateShardInfo

## Why?
<!-- Tell your future self why have you made these changes -->
In a situations when shard is (re)created again and again shard update (and thus storing shard progress) can be delayed.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
