### PR TITLE
Fix ms rebuilder log version value

### DIFF
--- a/service/history/ndc/state_rebuilder.go
+++ b/service/history/ndc/state_rebuilder.go
@@ -179,7 +179,7 @@ func (r *StateRebuilderImpl) Rebuild(
 			return nil, 0, serviceerror.NewInvalidArgument(fmt.Sprintf(
 				"StateRebuilder unable to Rebuild mutable state to event ID: %v, version: %v, this event must be at the boundary",
 				baseLastEventID,
-				baseLastEventVersion,
+				*baseLastEventVersion,
 			))
 		}
 	}


### PR DESCRIPTION
## What changed?
Fix ms rebuilder log version value

## Why?
The log current print out the pointer address. we need to see the version number.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
