### PR TITLE
Fix TestRetryActivity_when_task_can_not_be_generated_should_fail to not assert on size changes

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4881,14 +4881,13 @@ func (ms *MutableStateImpl) RetryActivity(
 		ms.truncateRetryableActivityFailure(failure),
 		timestamppb.New(nextScheduledTime),
 	)
-	if err := ms.taskGenerator.GenerateActivityRetryTasks(ai); err != nil {
-		return enumspb.RETRY_STATE_INTERNAL_SERVER_ERROR, err
-	}
-
 	ms.approximateSize += ai.Size() - originalSize
 	ms.updateActivityInfos[ai.ScheduledEventId] = ai
 	ms.syncActivityTasks[ai.ScheduledEventId] = struct{}{}
 
+	if err := ms.taskGenerator.GenerateActivityRetryTasks(ai); err != nil {
+		return enumspb.RETRY_STATE_INTERNAL_SERVER_ERROR, err
+	}
 	return enumspb.RETRY_STATE_IN_PROGRESS, nil
 }
 

--- a/service/history/workflow/mutable_state_impl_restart_activity_test.go
+++ b/service/history/workflow/mutable_state_impl_restart_activity_test.go
@@ -263,7 +263,6 @@ func (s *retryActivitySuite) TestRetryActivity_when_task_can_not_be_generated_sh
 		"failure to generate task should produce RETRY_STATE_INTERNAL_SERVER_ERROR got %v",
 		state,
 	)
-	s.assertActivityWasNotScheduled(s.activity, "with failing task generator")
 }
 
 func (s *retryActivitySuite) TestRetryActivity_when_workflow_is_not_mutable_should_fail() {


### PR DESCRIPTION
## What changed?
Fixed a test and changed where we are creating retry activity task.

## Why?
Followup from https://github.com/temporalio/temporal/pull/6129

## How did you test it?
Modified the test.

## Potential risks
N/A

## Documentation
N/A

## Is hotfix candidate?
No