### PR TITLE
Tag inordered_buffered_events metric with completed event type

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -948,7 +948,7 @@ var (
 	MutableStateChecksumMismatch                   = NewCounterDef("mutable_state_checksum_mismatch")
 	MutableStateChecksumInvalidated                = NewCounterDef("mutable_state_checksum_invalidated")
 	ClosedWorkflowBufferEventCount                 = NewCounterDef("closed_workflow_buffer_event_counter")
-	InorderBufferedEventsCounter                   = NewCounterDef("inordered_buffered_events")
+	OutOfOrderBufferedEventsCounter                = NewCounterDef("out_of_order_buffered_events")
 	ShardLingerSuccess                             = NewTimerDef("shard_linger_success")
 	ShardLingerTimeouts                            = NewCounterDef("shard_linger_timeouts")
 	DynamicRateLimiterMultiplier                   = NewGaugeDef("dynamic_rate_limit_multiplier")

--- a/service/history/historybuilder/history_builder_test.go
+++ b/service/history/historybuilder/history_builder_test.go
@@ -2306,6 +2306,7 @@ func (s *historyBuilderSuite) TestBufferEvent() {
 }
 
 func (s *historyBuilderSuite) TestReorder() {
+	// Only completion events are reordered.
 	reorderEventTypes := map[enumspb.EventType]struct{}{
 		enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED:             {},
 		enumspb.EVENT_TYPE_ACTIVITY_TASK_FAILED:                {},
@@ -2316,7 +2317,6 @@ func (s *historyBuilderSuite) TestReorder() {
 		enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TIMED_OUT:  {},
 		enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED:   {},
 		enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TERMINATED: {},
-		enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED:             {},
 		enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED:           {},
 		enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED:              {},
 		enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED:            {},


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Tag `inordered_buffered_events` metric with completed event type. And also include Nexus events in the metric.

## Why?
<!-- Tell your future self why have you made these changes -->
To get better visibility on where in ordered events are coming from.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Didn't test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.