### PR TITLE
Fix metrics defs to unhide stack trace of caller

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -70,23 +70,38 @@ func (md metricDefinition) Unit() MetricUnit {
 }
 
 func NewTimerDef(name string, opts ...Option) timerDefinition {
-	return timerDefinition{globalRegistry.register(name, append(opts, WithUnit(Milliseconds))...)}
+	// This line cannot be combined with others!
+	// This ensures the stack trace has information of the caller.
+	def := globalRegistry.register(name, append(opts, WithUnit(Milliseconds))...)
+	return timerDefinition{def}
 }
 
 func NewBytesHistogramDef(name string, opts ...Option) histogramDefinition {
-	return histogramDefinition{globalRegistry.register(name, append(opts, WithUnit(Bytes))...)}
+	// This line cannot be combined with others!
+	// This ensures the stack trace has information of the caller.
+	def := globalRegistry.register(name, append(opts, WithUnit(Bytes))...)
+	return histogramDefinition{def}
 }
 
 func NewDimensionlessHistogramDef(name string, opts ...Option) histogramDefinition {
-	return histogramDefinition{globalRegistry.register(name, append(opts, WithUnit(Dimensionless))...)}
+	// This line cannot be combined with others!
+	// This ensures the stack trace has information of the caller.
+	def := globalRegistry.register(name, append(opts, WithUnit(Dimensionless))...)
+	return histogramDefinition{def}
 }
 
 func NewCounterDef(name string, opts ...Option) counterDefinition {
-	return counterDefinition{globalRegistry.register(name, opts...)}
+	// This line cannot be combined with others!
+	// This ensures the stack trace has information of the caller.
+	def := globalRegistry.register(name, opts...)
+	return counterDefinition{def}
 }
 
 func NewGaugeDef(name string, opts ...Option) gaugeDefinition {
-	return gaugeDefinition{globalRegistry.register(name, opts...)}
+	// This line cannot be combined with others!
+	// This ensures the stack trace has information of the caller.
+	def := globalRegistry.register(name, opts...)
+	return gaugeDefinition{def}
 }
 
 func (d histogramDefinition) With(handler Handler) HistogramIface {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix metrics defs to unhide stack trace of caller

## Why?
<!-- Tell your future self why have you made these changes -->
This way, we can see in the stack trace where the metric is defined.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
