### PR TITLE
Add GetRegisteredMetricsDefinitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ bins: temporal-server temporal-cassandra-tool temporal-sql-tool tdbg
 all: clean proto bins check test
 
 # Used in CI
-ci-build-misc: print-go-version proto bins shell-check copyright-check go-generate gomodtidy ensure-no-changes
+ci-build-misc: print-go-version proto bins temporal-server-debug shell-check copyright-check go-generate gomodtidy ensure-no-changes
 
 # Delete all build artifacts
 clean: clean-bins clean-test-results
@@ -249,6 +249,7 @@ update-go-api:
 clean-bins:
 	@printf $(COLOR) "Delete old binaries..."
 	@rm -f temporal-server
+	@rm -f temporal-server-debug
 	@rm -f temporal-cassandra-tool
 	@rm -f tdbg
 	@rm -f temporal-sql-tool

--- a/common/metrics/consts.go
+++ b/common/metrics/consts.go
@@ -24,33 +24,12 @@
 
 package metrics
 
-import (
-	"testing"
+type MetricUnit string
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+// MetricUnit supported values
+// Values are pulled from https://pkg.go.dev/golang.org/x/exp/event#Unit
+const (
+	Dimensionless = "1"
+	Milliseconds  = "ms"
+	Bytes         = "By"
 )
-
-func TestRegistryBuildCatalog_Ok(t *testing.T) {
-	t.Parallel()
-
-	r := registry{}
-	r.register(newMetricDefinition("foo", WithDescription("foo description")))
-	r.register(newMetricDefinition("bar", WithDescription("bar description")))
-	c, err := r.buildCatalog()
-	require.Nil(t, err)
-	require.Equal(t, 2, len(c))
-	require.Equal(t, "foo description", c["foo"].description)
-	require.Equal(t, "bar description", c["bar"].description)
-}
-
-func TestRegistryBuildCatalog_ErrMetricAlreadyExists(t *testing.T) {
-	t.Parallel()
-
-	b := registry{}
-	b.register(newMetricDefinition("foo", WithDescription("foo description")))
-	b.register(newMetricDefinition("foo", WithDescription("bar description")))
-	_, err := b.buildCatalog()
-	assert.ErrorIs(t, err, errMetricAlreadyExists)
-	assert.ErrorContains(t, err, "foo")
-}

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1,5 +1,4 @@
 // The MIT License
-
 //
 // Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
 //
@@ -27,15 +26,6 @@ package metrics
 
 // types used/defined by the package
 type (
-	MetricUnit string
-
-	// metricDefinition contains the definition for a metric
-	metricDefinition struct {
-		name        string
-		description string
-		unit        MetricUnit
-	}
-
 	histogramDefinition struct {
 		metricDefinition
 	}
@@ -53,54 +43,43 @@ type (
 	}
 )
 
-// MetricUnit supported values
-// Values are pulled from https://pkg.go.dev/golang.org/x/exp/event#Unit
-const (
-	Dimensionless = "1"
-	Milliseconds  = "ms"
-	Bytes         = "By"
-)
-
-func (md metricDefinition) Name() string {
-	return md.name
-}
-
-func (md metricDefinition) Unit() MetricUnit {
-	return md.unit
-}
-
 func NewTimerDef(name string, opts ...Option) timerDefinition {
 	// This line cannot be combined with others!
 	// This ensures the stack trace has information of the caller.
-	def := globalRegistry.register(name, append(opts, WithUnit(Milliseconds))...)
+	def := newMetricDefinition(name, append(opts, WithUnit(Milliseconds))...)
+	globalRegistry.register(def)
 	return timerDefinition{def}
 }
 
 func NewBytesHistogramDef(name string, opts ...Option) histogramDefinition {
 	// This line cannot be combined with others!
 	// This ensures the stack trace has information of the caller.
-	def := globalRegistry.register(name, append(opts, WithUnit(Bytes))...)
+	def := newMetricDefinition(name, append(opts, WithUnit(Bytes))...)
+	globalRegistry.register(def)
 	return histogramDefinition{def}
 }
 
 func NewDimensionlessHistogramDef(name string, opts ...Option) histogramDefinition {
 	// This line cannot be combined with others!
 	// This ensures the stack trace has information of the caller.
-	def := globalRegistry.register(name, append(opts, WithUnit(Dimensionless))...)
+	def := newMetricDefinition(name, append(opts, WithUnit(Dimensionless))...)
+	globalRegistry.register(def)
 	return histogramDefinition{def}
 }
 
 func NewCounterDef(name string, opts ...Option) counterDefinition {
 	// This line cannot be combined with others!
 	// This ensures the stack trace has information of the caller.
-	def := globalRegistry.register(name, opts...)
+	def := newMetricDefinition(name, opts...)
+	globalRegistry.register(def)
 	return counterDefinition{def}
 }
 
 func NewGaugeDef(name string, opts ...Option) gaugeDefinition {
 	// This line cannot be combined with others!
 	// This ensures the stack trace has information of the caller.
-	def := globalRegistry.register(name, opts...)
+	def := newMetricDefinition(name, opts...)
+	globalRegistry.register(def)
 	return gaugeDefinition{def}
 }
 

--- a/common/metrics/defs_base.go
+++ b/common/metrics/defs_base.go
@@ -22,35 +22,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build !TEMPORAL_DEBUG
+
 package metrics
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-)
-
-func TestRegistryBuildCatalog_Ok(t *testing.T) {
-	t.Parallel()
-
-	r := registry{}
-	r.register(newMetricDefinition("foo", WithDescription("foo description")))
-	r.register(newMetricDefinition("bar", WithDescription("bar description")))
-	c, err := r.buildCatalog()
-	require.Nil(t, err)
-	require.Equal(t, 2, len(c))
-	require.Equal(t, "foo description", c["foo"].description)
-	require.Equal(t, "bar description", c["bar"].description)
+// metricDefinition contains the definition for a metric
+type metricDefinition struct {
+	name        string
+	description string
+	unit        MetricUnit
 }
 
-func TestRegistryBuildCatalog_ErrMetricAlreadyExists(t *testing.T) {
-	t.Parallel()
+func newMetricDefinition(name string, opts ...Option) metricDefinition {
+	d := metricDefinition{
+		name:        name,
+		description: "",
+		unit:        "",
+	}
+	for _, opt := range opts {
+		opt.apply(&d)
+	}
+	return d
+}
 
-	b := registry{}
-	b.register(newMetricDefinition("foo", WithDescription("foo description")))
-	b.register(newMetricDefinition("foo", WithDescription("bar description")))
-	_, err := b.buildCatalog()
-	assert.ErrorIs(t, err, errMetricAlreadyExists)
-	assert.ErrorContains(t, err, "foo")
+func (md metricDefinition) Name() string {
+	return md.name
+}
+
+func (md metricDefinition) Unit() MetricUnit {
+	return md.unit
 }

--- a/common/metrics/registry.go
+++ b/common/metrics/registry.go
@@ -66,22 +66,10 @@ var (
 )
 
 // register adds a metric definition to the list of pending metric definitions. This method is thread-safe.
-func (c *registry) register(name string, opts ...Option) metricDefinition {
+func (c *registry) register(d metricDefinition) {
 	c.Lock()
 	defer c.Unlock()
-
-	d := metricDefinition{
-		name:        name,
-		description: "",
-		unit:        "",
-	}
-	for _, opt := range opts {
-		opt.apply(&d)
-	}
-
 	c.definitions = append(c.definitions, d)
-
-	return d
 }
 
 // buildCatalog builds a catalog from the list of pending metric definitions. It is safe to call this method multiple


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Added the build tag `debug` that builds the metric definition with the location of the metric definition.
Add `GetResisteredMetricsDefinitions` to the `debug` build tag to retrieve the metrics registry.

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
