### PR TITLE
Fix flaky update.TestClear test

### DIFF
--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -614,7 +614,8 @@ func TestClear(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, err := upd.WaitLifecycleStage(context.Background(), 0, 2*time.Second)
+		_, err := upd.WaitLifecycleStage(
+			context.Background(), enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, 2*time.Second)
 		require.Equal(t, update.WorkflowUpdateAbortedErr, err)
 	}()
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

I think the problem was that it didn't wait long enough to receive the abort (from `Clear()`). Now with the wait stage, I expect this to be fixed.

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
