### PR TITLE
Timeout test run before GHA

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -197,7 +197,7 @@ jobs:
           docker compose -f ${{ env.DOCKER_COMPOSE_FILE }} up -d ${{ join(matrix.containers, ' ') }}
 
       - name: Run functional test
-        timeout-minutes: 25
+        timeout-minutes: 30 # make sure this is larger than the test timeout in the Makefile
         run: make functional-test-coverage
 
       - name: Upload test results

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ define NEWLINE
 
 endef
 
-TEST_TIMEOUT := 30m
+TEST_TIMEOUT := 25m
 
 PROTO_ROOT := proto
 PROTO_FILES = $(shell find ./$(PROTO_ROOT)/internal -name "*.proto")


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Before this change, if a test suite was stuck, the GHA would forcibly kill the test process. But that meant there was no insight into what it was stuck on.

<img width="798" alt="Screenshot 2024-06-18 at 11 40 31 AM" src="https://github.com/temporalio/temporal/assets/159852/4eecb1c9-7ab4-44e8-95a5-cb4e5bb6b916">

Now, by stopping the test run before the GHA times out, it will print the stuck tests.

## Why?
<!-- Tell your future self why have you made these changes -->

To allow debugging stuck tests.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
