### PR TITLE
Export more metrics from dynamic worker pool scheduler

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -961,6 +961,9 @@ var (
 	CircuitBreakerExecutableBlocked         = NewCounterDef("circuit_breaker_executable_blocked")
 	DynamicWorkerPoolSchedulerBufferSize    = NewCounterDef("dynamic_worker_pool_scheduler_buffer_size")
 	DynamicWorkerPoolSchedulerActiveWorkers = NewCounterDef("dynamic_worker_pool_scheduler_active_workers")
+	DynamicWorkerPoolSchedulerEnqueuedTasks = NewCounterDef("dynamic_worker_pool_scheduler_enqueued_tasks")
+	DynamicWorkerPoolSchedulerDequeuedTasks = NewCounterDef("dynamic_worker_pool_scheduler_dequeued_tasks")
+	DynamicWorkerPoolSchedulerRejectedTasks = NewCounterDef("dynamic_worker_pool_scheduler_rejected_tasks")
 
 	// Deadlock detector latency metrics
 	DDClusterMetadataLockLatency         = NewTimerDef("dd_cluster_metadata_lock_latency")

--- a/common/tasks/dynamic_worker_pool_scheduler.go
+++ b/common/tasks/dynamic_worker_pool_scheduler.go
@@ -116,6 +116,13 @@ func (pool *DynamicWorkerPoolScheduler) TrySubmit(task Runnable) bool {
 		enqueued := pool.tryEnqueueLocked(task)
 		pool.mu.Unlock()
 		pool.wg.Done()
+		if enqueued {
+			metrics.DynamicWorkerPoolSchedulerEnqueuedTasks.With(pool.metricsHandler).
+				Record(1)
+		} else {
+			metrics.DynamicWorkerPoolSchedulerRejectedTasks.With(pool.metricsHandler).
+				Record(1)
+		}
 		return enqueued
 	}
 	pool.runningGoroutines++
@@ -140,6 +147,8 @@ func (pool *DynamicWorkerPoolScheduler) executeUntilBufferEmpty(task Runnable) {
 		}
 		task = nextTask
 		pool.mu.Unlock()
+		metrics.DynamicWorkerPoolSchedulerDequeuedTasks.With(pool.metricsHandler).
+			Record(1)
 	}
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Export more metrics from dynamic worker pool scheduler:
- enqueued tasks
- dequeued tasks
- rejected tasks

Counters reseted between export intervals

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
