### PR TITLE
Fix error handling on replication task

### DIFF
--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -61,10 +61,10 @@ const (
 
 var (
 	TaskRetryPolicy = backoff.NewExponentialRetryPolicy(1 * time.Second).
-		WithBackoffCoefficient(1.2).
-		WithMaximumInterval(5 * time.Second).
-		WithMaximumAttempts(80).
-		WithExpirationInterval(5 * time.Minute)
+			WithBackoffCoefficient(1.2).
+			WithMaximumInterval(5 * time.Second).
+			WithMaximumAttempts(80).
+			WithExpirationInterval(5 * time.Minute)
 	ErrResendAttemptExceeded = serviceerror.NewInternal("resend history attempts exceeded")
 )
 

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -33,8 +33,6 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
-	"go.temporal.io/server/service/history/shard"
-
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/definition"
@@ -63,10 +61,10 @@ const (
 
 var (
 	TaskRetryPolicy = backoff.NewExponentialRetryPolicy(1 * time.Second).
-			WithBackoffCoefficient(1.2).
-			WithMaximumInterval(5 * time.Second).
-			WithMaximumAttempts(80).
-			WithExpirationInterval(5 * time.Minute)
+		WithBackoffCoefficient(1.2).
+		WithMaximumInterval(5 * time.Second).
+		WithMaximumAttempts(80).
+		WithExpirationInterval(5 * time.Minute)
 	ErrResendAttemptExceeded = serviceerror.NewInternal("resend history attempts exceeded")
 )
 
@@ -236,9 +234,6 @@ func (e *ExecutableTaskImpl) Reschedule() {
 }
 
 func (e *ExecutableTaskImpl) IsRetryableError(err error) bool {
-	if shard.IsShardOwnershipLostError(err) {
-		return false
-	}
 	switch err.(type) {
 	case *serviceerror.InvalidArgument, *serviceerror.DataLoss:
 		return false


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Revert the change that mark shardonwership error as non retryable
## Why?
<!-- Tell your future self why have you made these changes -->
This is creating unnecessary DLQ messages
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
n/a
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
no
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
Yes