### PR TITLE
Fix flakiness in TestRedirectWithConcurrentActivities

### DIFF
--- a/common/serviceerror/obsolete_dispatch_build_id.go
+++ b/common/serviceerror/obsolete_dispatch_build_id.go
@@ -41,9 +41,9 @@ type (
 	}
 )
 
-func NewObsoleteDispatchBuildId() error {
+func NewObsoleteDispatchBuildId(msg string) error {
 	return &ObsoleteDispatchBuildId{
-		Message: "dispatch build ID is not the workflow's current build ID",
+		Message: msg,
 	}
 }
 

--- a/common/worker_versioning/worker_versioning.go
+++ b/common/worker_versioning/worker_versioning.go
@@ -166,3 +166,7 @@ func StampFromCapabilities(cap *commonpb.WorkerVersionCapabilities) *commonpb.Wo
 	}
 	return nil
 }
+
+func StampForBuildId(buildId string) *commonpb.WorkerVersionStamp {
+	return &commonpb.WorkerVersionStamp{UseVersioning: true, BuildId: buildId}
+}

--- a/components/nexusoperations/tasks.go
+++ b/components/nexusoperations/tasks.go
@@ -31,10 +31,10 @@ import (
 )
 
 const (
-	TaskTypeTimeout = "nexusoperations.Timeout"
-	TaskTypeInvocation = "nexusoperations.Invocation"
-	TaskTypeBackoff = "nexusoperations.Backoff"
-	TaskTypeCancelation = "nexusoperations.Cancelation"
+	TaskTypeTimeout            = "nexusoperations.Timeout"
+	TaskTypeInvocation         = "nexusoperations.Invocation"
+	TaskTypeBackoff            = "nexusoperations.Backoff"
+	TaskTypeCancelation        = "nexusoperations.Cancelation"
 	TaskTypeCancelationBackoff = "nexusoperations.CancelationBackoff"
 )
 

--- a/service/history/api/recordworkflowtaskstarted/api.go
+++ b/service/history/api/recordworkflowtaskstarted/api.go
@@ -139,6 +139,13 @@ func Invoke(
 			currentTaskQueue := mutableState.CurrentTaskQueue()
 			if currentTaskQueue.Kind == enumspb.TASK_QUEUE_KIND_STICKY &&
 				currentTaskQueue.GetName() != req.PollRequest.TaskQueue.GetName() {
+				// For versioned workflows we additionally check for the poller queue to not be a sticky queue itself.
+				// Although it's ideal to check this for unversioned workflows as well, we can't rely on older clients
+				// setting the poller TQ kind.
+				if mutableState.GetAssignedBuildId() != "" && req.PollRequest.TaskQueue.Kind == enumspb.TASK_QUEUE_KIND_STICKY {
+					return nil, serviceerrors.NewObsoleteDispatchBuildId("wrong sticky queue")
+				}
+				//
 				// req.PollRequest.TaskQueue.GetName() may include partition, but we only check when sticky is enabled,
 				// and sticky queue never has partition, so it does not matter.
 				mutableState.ClearStickyTaskQueue()

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -184,7 +184,7 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 		wftCompletedBuildId := request.GetWorkerVersionStamp().GetBuildId()
 		if wftCompletedBuildId != wftStartedBuildId {
 			workflowLease.GetReleaseFn()(nil)
-			return nil, serviceerror.NewNotFound("this workflow task was not dispatched to this Build ID")
+			return nil, serviceerror.NewNotFound(fmt.Sprintf("this workflow task was dispatched to Build ID %s, not %s", wftStartedBuildId, wftCompletedBuildId))
 		}
 	}
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2469,7 +2469,7 @@ func (ms *MutableStateImpl) validateBuildIdRedirectInfo(
 	if !startedWorkerStamp.GetUseVersioning() && assignedBuildId != "" && ms.HasCompletedAnyWorkflowTask() {
 		// We don't allow moving from versioned to unversioned once the wf has completed the first WFT.
 		// If this happens, it must be a stale task.
-		return 0, serviceerrors.NewObsoleteDispatchBuildId()
+		return 0, serviceerrors.NewObsoleteDispatchBuildId("versioned workflow's task cannot be dispatched to unversioned workers")
 	}
 
 	if startedWorkerStamp.GetBuildId() == assignedBuildId {
@@ -2482,7 +2482,7 @@ func (ms *MutableStateImpl) validateBuildIdRedirectInfo(
 		// Workflow hs already completed tasks but no redirect or a redirect based on a wrong assigned build ID is
 		// reported. This must be a task backlogged on an old build ID. rejecting this task, there should be another
 		// task scheduled on the right build ID.
-		return 0, serviceerrors.NewObsoleteDispatchBuildId()
+		return 0, serviceerrors.NewObsoleteDispatchBuildId("dispatch build ID is not the workflow's current build ID")
 	}
 
 	if assignedBuildId == "" && !ms.HasCompletedAnyWorkflowTask() {

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -438,7 +438,7 @@ func (s *mutableStateSuite) createVersionedMutableStateWithCompletedWFT(tq *task
 	s.Equal("b1", s.mutableState.GetAssignedBuildId())
 	s.Equal(int64(0), wft.BuildIdRedirectCounter)
 	s.Equal(int64(0), s.mutableState.GetExecutionInfo().GetBuildIdRedirectCounter())
-	e, err = s.mutableState.AddWorkflowTaskCompletedEvent(
+	_, err = s.mutableState.AddWorkflowTaskCompletedEvent(
 		wft,
 		&workflowservice.RespondWorkflowTaskCompletedRequest{},
 		WorkflowTaskCompletionLimits{

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -45,6 +45,8 @@ import (
 	updatepb "go.temporal.io/api/update/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/taskqueue/v1"
+	serviceerror2 "go.temporal.io/server/common/serviceerror"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -269,6 +271,182 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchApplied
 	)
 	s.NoError(err)
 	s.Equal(0, s.mutableState.hBuilder.NumBufferedEvents())
+}
+
+func (s *mutableStateSuite) TestRedirectInfoValidation_Valid() {
+	tq := &taskqueuepb.TaskQueue{Name: "tq"}
+	s.createVersionedMutableStateWithCompletedWFT(tq)
+
+	wft, err := s.mutableState.AddWorkflowTaskScheduledEvent(true, enumsspb.WORKFLOW_TASK_TYPE_NORMAL)
+	s.NoError(err)
+	e, wft, err := s.mutableState.AddWorkflowTaskStartedEvent(
+		wft.ScheduledEventID,
+		"",
+		tq,
+		"",
+		worker_versioning.StampForBuildId("b2"),
+		&taskqueue.BuildIdRedirectInfo{AssignedBuildId: "b1"},
+		false,
+	)
+	s.NoError(err)
+	s.Equal("b2", wft.BuildId)
+	s.Equal("b2", e.GetWorkflowTaskStartedEventAttributes().GetWorkerVersion().GetBuildId())
+	s.Equal("b2", s.mutableState.GetAssignedBuildId())
+	s.Equal(int64(1), wft.BuildIdRedirectCounter)
+	s.Equal(int64(1), s.mutableState.GetExecutionInfo().GetBuildIdRedirectCounter())
+}
+
+func (s *mutableStateSuite) TestRedirectInfoValidation_Invalid() {
+	tq := &taskqueuepb.TaskQueue{Name: "tq"}
+	s.createVersionedMutableStateWithCompletedWFT(tq)
+
+	wft, err := s.mutableState.AddWorkflowTaskScheduledEvent(true, enumsspb.WORKFLOW_TASK_TYPE_NORMAL)
+	s.NoError(err)
+	_, _, err = s.mutableState.AddWorkflowTaskStartedEvent(
+		wft.ScheduledEventID,
+		"",
+		tq,
+		"",
+		worker_versioning.StampForBuildId("b2"),
+		&taskqueue.BuildIdRedirectInfo{AssignedBuildId: "b0"},
+		false,
+	)
+	expectedErr := &serviceerror2.ObsoleteDispatchBuildId{}
+	s.ErrorAs(err, &expectedErr)
+	s.Equal("b1", s.mutableState.GetAssignedBuildId())
+	s.Equal(int64(0), s.mutableState.GetExecutionInfo().GetBuildIdRedirectCounter())
+}
+
+func (s *mutableStateSuite) TestRedirectInfoValidation_EmptyRedirectInfo() {
+	tq := &taskqueuepb.TaskQueue{Name: "tq"}
+	s.createVersionedMutableStateWithCompletedWFT(tq)
+
+	wft, err := s.mutableState.AddWorkflowTaskScheduledEvent(true, enumsspb.WORKFLOW_TASK_TYPE_NORMAL)
+	s.NoError(err)
+	_, _, err = s.mutableState.AddWorkflowTaskStartedEvent(
+		wft.ScheduledEventID,
+		"",
+		tq,
+		"",
+		worker_versioning.StampForBuildId("b2"),
+		nil,
+		false,
+	)
+	expectedErr := &serviceerror2.ObsoleteDispatchBuildId{}
+	s.ErrorAs(err, &expectedErr)
+	s.Equal("b1", s.mutableState.GetAssignedBuildId())
+	s.Equal(int64(0), s.mutableState.GetExecutionInfo().GetBuildIdRedirectCounter())
+}
+
+func (s *mutableStateSuite) TestRedirectInfoValidation_EmptyStamp() {
+	tq := &taskqueuepb.TaskQueue{Name: "tq"}
+	s.createVersionedMutableStateWithCompletedWFT(tq)
+
+	wft, err := s.mutableState.AddWorkflowTaskScheduledEvent(true, enumsspb.WORKFLOW_TASK_TYPE_NORMAL)
+	s.NoError(err)
+	_, _, err = s.mutableState.AddWorkflowTaskStartedEvent(
+		wft.ScheduledEventID,
+		"",
+		tq,
+		"",
+		nil,
+		&taskqueue.BuildIdRedirectInfo{AssignedBuildId: "b1"},
+		false,
+	)
+	expectedErr := &serviceerror2.ObsoleteDispatchBuildId{}
+	s.ErrorAs(err, &expectedErr)
+	s.Equal("b1", s.mutableState.GetAssignedBuildId())
+	s.Equal(int64(0), s.mutableState.GetExecutionInfo().GetBuildIdRedirectCounter())
+}
+
+func (s *mutableStateSuite) TestRedirectInfoValidation_Sticky() {
+	tq := &taskqueuepb.TaskQueue{Name: "tq"}
+	sticky := &taskqueuepb.TaskQueue{Name: "sticky-tq", Kind: enumspb.TASK_QUEUE_KIND_STICKY}
+	s.createVersionedMutableStateWithCompletedWFT(tq)
+
+	s.mutableState.SetStickyTaskQueue(sticky.Name, durationpb.New(time.Second))
+	wft, err := s.mutableState.AddWorkflowTaskScheduledEvent(true, enumsspb.WORKFLOW_TASK_TYPE_NORMAL)
+	s.NoError(err)
+	e, wft, err := s.mutableState.AddWorkflowTaskStartedEvent(
+		wft.ScheduledEventID,
+		"",
+		sticky,
+		"",
+		nil,
+		nil,
+		false,
+	)
+	s.NoError(err)
+	s.Equal("", wft.BuildId)
+	s.Equal("", e.GetWorkflowTaskStartedEventAttributes().GetWorkerVersion().GetBuildId())
+	s.Equal("b1", s.mutableState.GetAssignedBuildId())
+	s.Equal(int64(0), wft.BuildIdRedirectCounter)
+	s.Equal(int64(0), s.mutableState.GetExecutionInfo().GetBuildIdRedirectCounter())
+}
+
+func (s *mutableStateSuite) TestRedirectInfoValidation_StickyInvalid() {
+	tq := &taskqueuepb.TaskQueue{Name: "tq"}
+	sticky := &taskqueuepb.TaskQueue{Name: "sticky-tq", Kind: enumspb.TASK_QUEUE_KIND_STICKY}
+	s.createVersionedMutableStateWithCompletedWFT(tq)
+
+	s.mutableState.SetStickyTaskQueue(sticky.Name, durationpb.New(time.Second))
+	wft, err := s.mutableState.AddWorkflowTaskScheduledEvent(true, enumsspb.WORKFLOW_TASK_TYPE_NORMAL)
+	s.NoError(err)
+	_, _, err = s.mutableState.AddWorkflowTaskStartedEvent(
+		wft.ScheduledEventID,
+		"",
+		&taskqueuepb.TaskQueue{Name: "another-sticky-tq"},
+		"",
+		nil,
+		nil,
+		false,
+	)
+	expectedErr := &serviceerror2.ObsoleteDispatchBuildId{}
+	s.ErrorAs(err, &expectedErr)
+	s.Equal("b1", s.mutableState.GetAssignedBuildId())
+	s.Equal(int64(0), s.mutableState.GetExecutionInfo().GetBuildIdRedirectCounter())
+}
+
+// creates a mutable state with first WFT completed on Build ID "b1"
+func (s *mutableStateSuite) createVersionedMutableStateWithCompletedWFT(tq *taskqueuepb.TaskQueue) {
+	version := int64(12)
+	workflowID := "some random workflow ID"
+	runID := uuid.New()
+	s.mutableState = TestGlobalMutableState(
+		s.mockShard,
+		s.mockEventsCache,
+		s.logger,
+		version,
+		workflowID,
+		runID,
+	)
+
+	wft, err := s.mutableState.AddWorkflowTaskScheduledEvent(true, enumsspb.WORKFLOW_TASK_TYPE_NORMAL)
+	s.NoError(err)
+	e, wft, err := s.mutableState.AddWorkflowTaskStartedEvent(
+		wft.ScheduledEventID,
+		"",
+		tq,
+		"",
+		worker_versioning.StampForBuildId("b1"),
+		nil,
+		false,
+	)
+	s.NoError(err)
+	s.Equal("b1", wft.BuildId)
+	s.Equal("b1", e.GetWorkflowTaskStartedEventAttributes().GetWorkerVersion().GetBuildId())
+	s.Equal("b1", s.mutableState.GetAssignedBuildId())
+	s.Equal(int64(0), wft.BuildIdRedirectCounter)
+	s.Equal(int64(0), s.mutableState.GetExecutionInfo().GetBuildIdRedirectCounter())
+	e, err = s.mutableState.AddWorkflowTaskCompletedEvent(
+		wft,
+		&workflowservice.RespondWorkflowTaskCompletedRequest{},
+		WorkflowTaskCompletionLimits{
+			MaxResetPoints:              10,
+			MaxSearchAttributeValueSize: 1024,
+		},
+	)
+	s.NoError(err)
 }
 
 func (s *mutableStateSuite) TestChecksum() {

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -299,8 +299,8 @@ func (pm *taskQueuePartitionManagerImpl) PollTask(
 					return nil, false, serviceerror.NewNewerBuildExists(terminalBuildId)
 				}
 			}
-			// We set return true for all sticky tasks until old versioning is cleaned up.
-			// this value is used by matching_engine for deciding if it should pass the worker build ID
+			// We set versionSetUsed to true for all sticky tasks until old versioning is cleaned up.
+			// this value is used by matching_engine to decide if it should pass the worker build ID
 			// to history in the recordStart call or not. We don't need to pass build ID for sticky
 			// tasks as no redirect happen in a sticky queue.
 			versionSetUsed = true

--- a/service/matching/version_sets.go
+++ b/service/matching/version_sets.go
@@ -388,7 +388,7 @@ func lookupVersionSetForPoll(data *persistencespb.VersioningData, caps *commonpb
 // lookupVersionSetForPoll is that we never redirect, we just need to return an error or not.
 // Requires: caps is not nil
 // Returns:
-// - whether the build ID was found
+// - whether the build ID was found in version sets
 // - error (can only be nil or serviceerror.NewerBuildExists)
 func checkVersionForStickyPoll(data *persistencespb.VersioningData, caps *commonpb.WorkerVersionCapabilities) (bool, error) {
 	// For poll, only the latest version in the compatible set can get tasks.
@@ -399,11 +399,7 @@ func checkVersionForStickyPoll(data *persistencespb.VersioningData, caps *common
 		// A poller is using a build ID, but we don't know about that build ID. See comments in
 		// lookupVersionSetForPoll. If we consider it the default for its set, then we should
 		// leave it on the sticky queue here.
-		// We set return true for all sticky tasks until old versioning is cleaned up.
-		// this value is used by matching_engine for deciding if it should pass the worker build ID
-		// to history in the recordStart call or not. We don't need to pass build ID for sticky
-		// tasks as no redirect happen in a sticky queue.
-		return true, nil
+		return false, nil
 	}
 	set := data.VersionSets[setIdx]
 	lastIndex := len(set.BuildIds) - 1

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -2161,7 +2161,7 @@ func (s *VersioningIntegSuite) TestRedirectWithConcurrentActivities() {
 	tq := s.randomizeStr(s.T().Name())
 	v1 := s.prefixed("v1.0")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 	rule := s.addAssignmentRule(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Prevent setting MS sticky queue if it belongs to an obsolete build ID. (In case WF has moved to a new build ID since the last WFT started).
- Improve sticky queue check in `processBuildIdRedirectInfo` at WFT start time to compare the sticky TQ name and not only if the sticky queue is set in the MS.

## Why?
<!-- Tell your future self why have you made these changes -->
- Setting obsolete sticky queue can cause workflow tasks to go back to the previous build ID.
- The old code did not catch edge cases when a sticky queue of an older build ID wants to start a WFT when WF is already moved to a sticky queue on a newer build id.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
For this to work properly, I'm assuming all the SDK versions that support versioning will set the task queue kind in poll request.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
none.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.