### PR TITLE
Remove /api/v1 from development DC

### DIFF
--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -43,7 +43,7 @@ frontend.workerVersioningWorkflowAPIs:
 system.enableNexus:
   - value: true
 component.nexusoperations.callback.endpoint.template:
-  - value: http://localhost:7243/api/v1/namespaces/{{.NamespaceName}}/nexus/callback
+  - value: http://localhost:7243/namespaces/{{.NamespaceName}}/nexus/callback
 matching.queryWorkflowTaskTimeoutLogRate:
   - value: 1.0
 history.ReplicationEnableUpdateWithNewTaskMerge:

--- a/config/dynamicconfig/development-sql.yaml
+++ b/config/dynamicconfig/development-sql.yaml
@@ -46,7 +46,7 @@ frontend.enableUpdateWorkflowExecutionAsyncAccepted:
 system.enableNexus:
   - value: true
 component.nexusoperations.callback.endpoint.template:
-  - value: http://localhost:7243/api/v1/namespaces/{{.NamespaceName}}/nexus/callback
+  - value: http://localhost:7243/namespaces/{{.NamespaceName}}/nexus/callback
 matching.queryWorkflowTaskTimeoutLogRate:
   - value: 1.0
 history.ReplicationEnableUpdateWithNewTaskMerge:


### PR DESCRIPTION
We removed this prefix from all of the routes but forgot to modify the development configs.