### PR TITLE
Implement CompareState for Nexus and Callback machines

### DIFF
--- a/components/callbacks/statemachine.go
+++ b/components/callbacks/statemachine.go
@@ -40,8 +40,14 @@ import (
 	"go.temporal.io/server/service/history/hsm"
 )
 
-// StateMachineType is a unique type identifier for this state machine.
-var StateMachineType = "callbacks.Callback"
+const (
+	// StateMachineType is a unique type identifier for this state machine.
+	StateMachineType = "callbacks.Callback"
+
+	// A marker for the first return value from a progress() that indicates the machine is in a terminal state.
+	// TODO: Remove this once transition history is fully implemented.
+	terminalStage = 3
+)
 
 // MachineCollection creates a new typed [statemachines.Collection] for callbacks.
 func MachineCollection(tree *hsm.Node) hsm.Collection[Callback] {
@@ -114,6 +120,27 @@ func (c Callback) output() (hsm.TransitionOutput, error) {
 	return hsm.TransitionOutput{Tasks: tasks}, err
 }
 
+// TODO: Remove this implementation once transition history is fully implemented.
+func (c Callback) progress() (int, int32, error) {
+	switch c.State() {
+	case enumsspb.CALLBACK_STATE_UNSPECIFIED:
+		return 0, 0, serviceerror.NewInvalidArgument("uninitialized callback state")
+	case enumsspb.CALLBACK_STATE_STANDBY:
+		return 1, 0, nil
+	case enumsspb.CALLBACK_STATE_SCHEDULED:
+		return 2, c.GetAttempt() * 2, nil
+	case enumsspb.CALLBACK_STATE_BACKING_OFF:
+		// We've made slightly more progress if we transitioned from scheduled to backing off.
+		return 2, c.GetAttempt()*2 + 1, nil
+	case enumsspb.CALLBACK_STATE_FAILED, enumsspb.CALLBACK_STATE_SUCCEEDED:
+		// Consider any terminal state as "max progress", we'll rely on last update namespace failover version to break
+		// the tie when comparing two states.
+		return terminalStage, 0, nil
+	default:
+		return 0, 0, serviceerror.NewInvalidArgument("unknown callback state")
+	}
+}
+
 type stateMachineDefinition struct{}
 
 func (stateMachineDefinition) Type() string {
@@ -135,9 +162,34 @@ func (stateMachineDefinition) Serialize(state any) ([]byte, error) {
 	return nil, fmt.Errorf("invalid callback provided: %v", state) // nolint:goerr113
 }
 
+// CompareState compares the progress of two Callback state machines to determine whether to sync machine state while
+// processing a replication task.
+// TODO: Remove this implementation once transition history is fully implemented.
 func (stateMachineDefinition) CompareState(state1, state2 any) (int, error) {
-	// TODO: remove this implementation once transition history is fully implemented
-	return 0, serviceerror.NewUnimplemented("CompareState not implemented for callbacks")
+	cb1, ok := state1.(Callback)
+	if !ok {
+		return 0, fmt.Errorf("%w: expected state1 to be a Callback instance, got %v", hsm.ErrIncompatibleType, state1)
+	}
+	cb2, ok := state2.(Callback)
+	if !ok {
+		return 0, fmt.Errorf("%w: expected state2 to be a Callback instance, got %v", hsm.ErrIncompatibleType, state2)
+	}
+
+	stage1, attempts1, err := cb1.progress()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get progress for state1: %w", err)
+	}
+	stage2, attempts2, err := cb2.progress()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get progress for state2: %w", err)
+	}
+	if stage1 != stage2 {
+		return stage2 - stage1, nil
+	}
+	if stage1 == terminalStage && cb1.State() != cb2.State() {
+		return 0, serviceerror.NewInvalidArgument(fmt.Sprintf("cannot compare two distinct terminal states: %v, %v", cb1.State(), cb2.State()))
+	}
+	return int(attempts2 - attempts1), nil
 }
 
 func RegisterStateMachine(r *hsm.Registry) error {

--- a/components/nexusoperations/statemachine_test.go
+++ b/components/nexusoperations/statemachine_test.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/components/nexusoperations"
@@ -590,4 +591,153 @@ func TestCancelationValidTransitions(t *testing.T) {
 
 	// Assert no additional tasks are generated
 	require.Equal(t, 0, len(out.Tasks))
+}
+
+func TestOperationCompareState(t *testing.T) {
+	reg := hsm.NewRegistry()
+	require.NoError(t, nexusoperations.RegisterStateMachines(reg))
+	def, ok := reg.Machine(nexusoperations.OperationMachineType)
+	require.True(t, ok)
+
+	cases := []struct {
+		name                 string
+		s1, s2               enumsspb.NexusOperationState
+		attempts1, attempts2 int32
+		sign                 int
+		expectError          bool
+	}{
+		{
+			name:        "succeeded not comparable to failed",
+			s1:          enumsspb.NEXUS_OPERATION_STATE_SUCCEEDED,
+			s2:          enumsspb.NEXUS_OPERATION_STATE_FAILED,
+			expectError: true,
+		},
+		{
+			name: "started < succeeded",
+			s1:   enumsspb.NEXUS_OPERATION_STATE_STARTED,
+			s2:   enumsspb.NEXUS_OPERATION_STATE_SUCCEEDED,
+			sign: 1,
+		},
+		{
+			name: "backing off < failed",
+			s1:   enumsspb.NEXUS_OPERATION_STATE_BACKING_OFF,
+			s2:   enumsspb.NEXUS_OPERATION_STATE_FAILED,
+			sign: 1,
+		},
+		{
+			name: "backing off > scheduled",
+			s1:   enumsspb.NEXUS_OPERATION_STATE_BACKING_OFF,
+			s2:   enumsspb.NEXUS_OPERATION_STATE_SCHEDULED,
+			sign: -1,
+		},
+		{
+			name:      "backing off < scheduled with greater attempt",
+			s1:        enumsspb.NEXUS_OPERATION_STATE_BACKING_OFF,
+			s2:        enumsspb.NEXUS_OPERATION_STATE_SCHEDULED,
+			attempts2: 1,
+			sign:      1,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s1 := nexusoperations.Operation{
+				NexusOperationInfo: &persistencespb.NexusOperationInfo{
+					State:   tc.s1,
+					Attempt: tc.attempts1,
+				},
+			}
+			s2 := nexusoperations.Operation{
+				NexusOperationInfo: &persistencespb.NexusOperationInfo{
+					State:   tc.s2,
+					Attempt: tc.attempts2,
+				},
+			}
+			res, err := def.CompareState(s1, s2)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tc.sign == 0 {
+				require.Equal(t, 0, res)
+			} else if tc.sign > 0 {
+				require.Greater(t, res, 0)
+			} else {
+				require.Greater(t, 0, res)
+			}
+		})
+	}
+}
+
+func TestCancelationCompareState(t *testing.T) {
+	reg := hsm.NewRegistry()
+	require.NoError(t, nexusoperations.RegisterStateMachines(reg))
+	def, ok := reg.Machine(nexusoperations.CancelationMachineType)
+	require.True(t, ok)
+
+	cases := []struct {
+		name                 string
+		s1, s2               enumspb.NexusOperationCancellationState
+		attempts1, attempts2 int32
+		sign                 int
+		expectError          bool
+	}{
+		{
+			name:        "succeeded not comparable to failed",
+			s1:          enumspb.NEXUS_OPERATION_CANCELLATION_STATE_SUCCEEDED,
+			s2:          enumspb.NEXUS_OPERATION_CANCELLATION_STATE_FAILED,
+			expectError: true,
+		},
+		{
+			name: "backing off < failed",
+			s1:   enumspb.NEXUS_OPERATION_CANCELLATION_STATE_BACKING_OFF,
+			s2:   enumspb.NEXUS_OPERATION_CANCELLATION_STATE_FAILED,
+			sign: 1,
+		},
+		{
+			name: "backing off > scheduled",
+			s1:   enumspb.NEXUS_OPERATION_CANCELLATION_STATE_BACKING_OFF,
+			s2:   enumspb.NEXUS_OPERATION_CANCELLATION_STATE_SCHEDULED,
+			sign: -1,
+		},
+		{
+			name:      "backing off < scheduled with greater attempt",
+			s1:        enumspb.NEXUS_OPERATION_CANCELLATION_STATE_BACKING_OFF,
+			s2:        enumspb.NEXUS_OPERATION_CANCELLATION_STATE_SCHEDULED,
+			attempts2: 1,
+			sign:      1,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s1 := nexusoperations.Cancelation{
+				NexusOperationCancellationInfo: &persistencespb.NexusOperationCancellationInfo{
+					State:   tc.s1,
+					Attempt: tc.attempts1,
+				},
+			}
+			s2 := nexusoperations.Cancelation{
+				NexusOperationCancellationInfo: &persistencespb.NexusOperationCancellationInfo{
+					State:   tc.s2,
+					Attempt: tc.attempts2,
+				},
+			}
+			res, err := def.CompareState(s1, s2)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tc.sign == 0 {
+				require.Equal(t, 0, res)
+			} else if tc.sign > 0 {
+				require.Greater(t, res, 0)
+			} else {
+				require.Greater(t, 0, res)
+			}
+		})
+	}
 }

--- a/components/scheduler/statemachine.go
+++ b/components/scheduler/statemachine.go
@@ -28,7 +28,6 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
-
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	schedspb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/common/persistence/serialization"
@@ -102,9 +101,12 @@ func (stateMachineDefinition) Serialize(state any) ([]byte, error) {
 	return nil, fmt.Errorf("invalid scheduler state provided: %v", state) // nolint:goerr113
 }
 
-func (stateMachineDefinition) CompareState(s1, s2 any) (int, error) {
-	// TODO: remove this implementation once transition history is fully implemented
-	return 0, serviceerror.NewUnimplemented("CompareState not implemented for scheduler")
+// CompareState is required for the temporary state sync solution to work.
+// Once transition history based replication is implemented, we won't need this method any more.
+// That will likely come before we productionize the HSM based scheduler, but if it doesn't, this method will need to be
+// implemented.
+func (s stateMachineDefinition) CompareState(any, any) (int, error) {
+	return 0, serviceerror.NewUnimplemented("CompareState not implemented for the scheduler state machine")
 }
 
 func RegisterStateMachine(r *hsm.Registry) error {

--- a/service/history/hsm/hsmtest/sm.go
+++ b/service/history/hsm/hsmtest/sm.go
@@ -99,7 +99,12 @@ func (d Definition) Serialize(s any) ([]byte, error) {
 	return []byte(t.state), nil
 }
 
-func (d Definition) CompareState(s1, s2 any) (int, error) {
+// Type implements hsm.StateMachineDefinition.
+func (d Definition) Type() string {
+	return d.typeName
+}
+
+func (d Definition) CompareState(s1 any, s2 any) (int, error) {
 	t1, ok := s1.(*Data)
 	if !ok {
 		return 0, errInvalidStateType
@@ -111,9 +116,4 @@ func (d Definition) CompareState(s1, s2 any) (int, error) {
 	}
 
 	return strings.Compare(string(t1.State()), string(t2.State())), nil
-}
-
-// Type implements hsm.StateMachineDefinition.
-func (d Definition) Type() string {
-	return d.typeName
 }

--- a/service/history/hsm/tree.go
+++ b/service/history/hsm/tree.go
@@ -64,13 +64,11 @@ type StateMachineDefinition interface {
 	Serialize(any) ([]byte, error)
 	// Deserialize a state machine from bytes.
 	Deserialize([]byte) (any, error)
-	// CompareState compares two state objects.
-	// It should return 0 if the states are equal,
-	// 1 if the first state is considered newer,
-	// -1 if the second state is considered newer.
-	// TODO: Remove this method and implementations once transition history is fully implemented.
-	// For now, we have to rely on each component to tell the framework which state is newer and
-	// if sync state can overwrite the states in the standby cluster.
+	// CompareState compares two state objects. It should return 0 if the states are equal, a positive number if the
+	// first state is considered newer, a negative number if the second state is considered newer.
+	// TODO: Remove this method and implementations once transition history is fully implemented. For now, we have to
+	// rely on each component to tell the framework which state is newer and if sync state can overwrite the states in
+	// the standby cluster.
 	CompareState(any, any) (int, error)
 }
 

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -76,6 +76,11 @@ var emptyTasks = []tasks.Task{}
 
 type stateMachineDefinition struct{}
 
+// TODO: Remove this implementation once transition history is fully implemented.
+func (s stateMachineDefinition) CompareState(any, any) (int, error) {
+	return 0, serviceerror.NewUnimplemented("CompareState not implemented for workflow mutable state")
+}
+
 func (stateMachineDefinition) Deserialize([]byte) (any, error) {
 	return nil, serviceerror.NewUnimplemented("workflow mutable state persistence is not supported in the HSM framework")
 }
@@ -83,11 +88,6 @@ func (stateMachineDefinition) Deserialize([]byte) (any, error) {
 // Serialize is a noop as Deserialize is not supported.
 func (stateMachineDefinition) Serialize(any) ([]byte, error) {
 	return nil, nil
-}
-
-func (stateMachineDefinition) CompareState(_, _ any) (int, error) {
-	// TODO: remove this implementation once transition history is fully implemented
-	return 0, serviceerror.NewUnimplemented("CompareState not implemented for workflow mutable state")
 }
 
 func (stateMachineDefinition) Type() string {


### PR DESCRIPTION
## Why?

This will be used in the temporary sync HSM replication task to determine whether a state is "newer" and should be synced.

## How did you test it?

Unit tests.