### PR TITLE
Expose GetOutboundTaskTypeTagValue

### DIFF
--- a/service/history/outbound_queue_standby_task_executor.go
+++ b/service/history/outbound_queue_standby_task_executor.go
@@ -73,14 +73,7 @@ func (e *outboundQueueStandbyTaskExecutor) Execute(
 	executable queues.Executable,
 ) queues.ExecuteResponse {
 	task := executable.GetTask()
-	var taskType string
-	ref, smt, err := stateMachineTask(e.shardContext, task)
-	if err != nil {
-		taskType = "StandbyUnknownOutbound"
-	} else {
-		taskType = "Standby." + smt.Type()
-	}
-
+	taskType := queues.GetOutboundTaskTypeTagValue(task, false)
 	respond := func(err error) queues.ExecuteResponse {
 		metricsTags := []metrics.Tag{
 			getNamespaceTagByID(e.shardContext.GetNamespaceRegistry(), task.GetNamespaceID()),
@@ -94,6 +87,7 @@ func (e *outboundQueueStandbyTaskExecutor) Execute(
 		}
 	}
 
+	ref, smt, err := stateMachineTask(e.shardContext, task)
 	if err != nil {
 		return respond(err)
 	}

--- a/service/history/queues/metrics.go
+++ b/service/history/queues/metrics.go
@@ -170,6 +170,21 @@ func GetArchivalTaskTypeTagValue(
 	}
 }
 
+func GetOutboundTaskTypeTagValue(task tasks.Task, isActive bool) string {
+	var prefix string
+	if isActive {
+		prefix = "Active"
+	} else {
+		prefix = "Standby"
+	}
+
+	outbound, ok := task.(*tasks.StateMachineOutboundTask)
+	if !ok {
+		return prefix + "UnknownOutbound"
+	}
+	return prefix + "." + outbound.StateMachineTaskType()
+}
+
 func getTaskTypeTagValue(
 	executable Executable,
 	isActive bool,
@@ -190,6 +205,8 @@ func getTaskTypeTagValue(
 		return GetVisibilityTaskTypeTagValue(task)
 	case tasks.CategoryArchival:
 		return GetArchivalTaskTypeTagValue(task)
+	case tasks.CategoryOutbound:
+		return GetOutboundTaskTypeTagValue(task, isActive)
 	default:
 		return task.GetType().String()
 	}


### PR DESCRIPTION
## Why?

Needed in a few different scenarios. Specifically the executable needs a more accurate way to extract the tag.