### PR TITLE
terminate (instead of fail) workflows whose tasks fail to complete due to payload size limit breach

### DIFF
--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -103,9 +103,9 @@ func (ch *commandHandler) HandleScheduleCommand(
 
 	if !validator.IsValidPayloadSize(attrs.Input.Size()) {
 		return workflow.FailWorkflowTaskError{
-			Cause:        enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES,
-			Message:      "ScheduleNexusOperationCommandAttributes.Input exceeds size limit",
-			FailWorkflow: true,
+			Cause:             enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES,
+			Message:           "ScheduleNexusOperationCommandAttributes.Input exceeds size limit",
+			TerminateWorkflow: true,
 		}
 	}
 

--- a/components/nexusoperations/workflow/commands_test.go
+++ b/components/nexusoperations/workflow/commands_test.go
@@ -134,7 +134,7 @@ func TestHandleScheduleCommand(t *testing.T) {
 		err := tcx.scheduleHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 1, &commandpb.Command{})
 		var failWFTErr workflow.FailWorkflowTaskError
 		require.ErrorAs(t, err, &failWFTErr)
-		require.False(t, failWFTErr.FailWorkflow)
+		require.False(t, failWFTErr.TerminateWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_FEATURE_DISABLED, failWFTErr.Cause)
 		require.Equal(t, 0, len(tcx.history.Events))
 	})
@@ -144,7 +144,7 @@ func TestHandleScheduleCommand(t *testing.T) {
 		err := tcx.scheduleHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 1, &commandpb.Command{})
 		var failWFTErr workflow.FailWorkflowTaskError
 		require.ErrorAs(t, err, &failWFTErr)
-		require.False(t, failWFTErr.FailWorkflow)
+		require.False(t, failWFTErr.TerminateWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES, failWFTErr.Cause)
 		require.Equal(t, 0, len(tcx.history.Events))
 	})
@@ -162,7 +162,7 @@ func TestHandleScheduleCommand(t *testing.T) {
 		})
 		var failWFTErr workflow.FailWorkflowTaskError
 		require.ErrorAs(t, err, &failWFTErr)
-		require.False(t, failWFTErr.FailWorkflow)
+		require.False(t, failWFTErr.TerminateWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES, failWFTErr.Cause)
 		require.Equal(t, 0, len(tcx.history.Events))
 	})
@@ -180,7 +180,7 @@ func TestHandleScheduleCommand(t *testing.T) {
 		})
 		var failWFTErr workflow.FailWorkflowTaskError
 		require.ErrorAs(t, err, &failWFTErr)
-		require.False(t, failWFTErr.FailWorkflow)
+		require.False(t, failWFTErr.TerminateWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES, failWFTErr.Cause)
 		require.Equal(t, 0, len(tcx.history.Events))
 	})
@@ -198,7 +198,7 @@ func TestHandleScheduleCommand(t *testing.T) {
 		})
 		var failWFTErr workflow.FailWorkflowTaskError
 		require.ErrorAs(t, err, &failWFTErr)
-		require.False(t, failWFTErr.FailWorkflow)
+		require.False(t, failWFTErr.TerminateWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES, failWFTErr.Cause)
 		require.Equal(t, 0, len(tcx.history.Events))
 	})
@@ -219,7 +219,7 @@ func TestHandleScheduleCommand(t *testing.T) {
 		})
 		var failWFTErr workflow.FailWorkflowTaskError
 		require.ErrorAs(t, err, &failWFTErr)
-		require.True(t, failWFTErr.FailWorkflow)
+		require.True(t, failWFTErr.TerminateWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES, failWFTErr.Cause)
 		require.Equal(t, 0, len(tcx.history.Events))
 	})
@@ -249,7 +249,7 @@ func TestHandleScheduleCommand(t *testing.T) {
 		})
 		var failWFTErr workflow.FailWorkflowTaskError
 		require.ErrorAs(t, err, &failWFTErr)
-		require.False(t, failWFTErr.FailWorkflow)
+		require.False(t, failWFTErr.TerminateWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_PENDING_NEXUS_OPERATIONS_LIMIT_EXCEEDED, failWFTErr.Cause)
 		require.Equal(t, 2, len(tcx.history.Events))
 	})
@@ -397,7 +397,7 @@ func TestHandleCancelCommand(t *testing.T) {
 		err := tcx.cancelHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 1, &commandpb.Command{})
 		var failWFTErr workflow.FailWorkflowTaskError
 		require.ErrorAs(t, err, &failWFTErr)
-		require.False(t, failWFTErr.FailWorkflow)
+		require.False(t, failWFTErr.TerminateWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_FEATURE_DISABLED, failWFTErr.Cause)
 		require.Equal(t, 0, len(tcx.history.Events))
 	})
@@ -407,7 +407,7 @@ func TestHandleCancelCommand(t *testing.T) {
 		err := tcx.cancelHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 1, &commandpb.Command{})
 		var failWFTErr workflow.FailWorkflowTaskError
 		require.ErrorAs(t, err, &failWFTErr)
-		require.False(t, failWFTErr.FailWorkflow)
+		require.False(t, failWFTErr.TerminateWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES, failWFTErr.Cause)
 		require.Equal(t, 0, len(tcx.history.Events))
 	})
@@ -423,7 +423,7 @@ func TestHandleCancelCommand(t *testing.T) {
 		})
 		var failWFTErr workflow.FailWorkflowTaskError
 		require.ErrorAs(t, err, &failWFTErr)
-		require.False(t, failWFTErr.FailWorkflow)
+		require.False(t, failWFTErr.TerminateWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES, failWFTErr.Cause)
 		require.Equal(t, 0, len(tcx.history.Events))
 	})
@@ -462,7 +462,7 @@ func TestHandleCancelCommand(t *testing.T) {
 		})
 		var failWFTErr workflow.FailWorkflowTaskError
 		require.ErrorAs(t, err, &failWFTErr)
-		require.False(t, failWFTErr.FailWorkflow)
+		require.False(t, failWFTErr.TerminateWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES, failWFTErr.Cause)
 		require.Equal(t, 1, len(tcx.history.Events)) // Only scheduled event should be recorded.
 	})

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -303,7 +303,7 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 				fmt.Sprintf(
 					"binary %v is marked as bad deployment",
 					request.GetBinaryChecksum())),
-			nil)
+			false)
 	} else {
 		namespace := namespaceEntry.Name()
 		workflowSizeChecker := newWorkflowSizeChecker(
@@ -404,11 +404,11 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 		wtFailedShouldCreateNewTask = true
 		newMutableState = nil
 
-		if wtFailedCause.workflowTerminationReason != nil {
+		if wtFailedCause.terminateWorkflow {
 			// Flush buffer event before terminating the workflow
 			ms.FlushBufferedEvents()
 
-			if err := workflow.TerminateWorkflow(ms, wtFailedCause.workflowTerminationReason.Message, nil,
+			if err := workflow.TerminateWorkflow(ms, wtFailedCause.causeErr.Error(), nil,
 				consts.IdentityHistoryService, false); err != nil {
 				return nil, err
 			}

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -53,7 +53,6 @@ import (
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/enums"
-	"go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"

--- a/service/history/workflow/command_handler.go
+++ b/service/history/workflow/command_handler.go
@@ -35,12 +35,12 @@ import (
 var ErrDuplicateRegistration = errors.New("duplicate registration")
 
 // FailWorkflowTaskError is an error that can be returned from a [CommandHandler] to fail the current workflow task and
-// optionally the entire workflow.
+// optionally terminate the entire workflow.
 type FailWorkflowTaskError struct {
 	// The cause to set on the WorkflowTaskFailed event.
-	Cause        enumspb.WorkflowTaskFailedCause
-	Message      string
-	FailWorkflow bool
+	Cause             enumspb.WorkflowTaskFailedCause
+	Message           string
+	TerminateWorkflow bool
 }
 
 func (e FailWorkflowTaskError) Error() string {

--- a/tests/sizelimit.go
+++ b/tests/sizelimit.go
@@ -347,7 +347,7 @@ func (s *SizeLimitFunctionalSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
   3 WorkflowTaskStarted
   4 WorkflowTaskFailed
   5 WorkflowExecutionSignaled
-  6 WorkflowExecutionFailed`, historyEvents)
+  6 WorkflowExecutionTerminated`, historyEvents)
 }
 
 func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByMsSizeLimit() {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
When a workflow task is being acknowledged as completed by the history service, the payload size is validated. Previously, a payload size exceeding the limit would result in a workflow failure (usually indicating a failure from the application code). Now, payload size limit breaches result in workflow termination (indicating a failure originated from the service).

## Why?
<!-- Tell your future self why have you made these changes -->
This helps customers delineate between failures originating from their application (via SDK call) and failures originating from the Temporal service/backend. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
 - `make unit-test`. The [existing tests](https://github.com/temporalio/temporal/blob/main/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler_test.go#L264-L268), which validate the correct failure messages are set from the handler, continues to pass. 

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Temrination of workflows is unexpected in metrics or logs, given that it's a behavior change. Existing dashboards that don't surface workflow terminations may lose visibility. 

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
