### PR TITLE
Use scheduled/initiated event Id for out_of_order_buffered_events metric

### DIFF
--- a/service/history/historybuilder/event_store.go
+++ b/service/history/historybuilder/event_store.go
@@ -465,33 +465,33 @@ func (b *EventStore) emitOutOfOrderBufferedEvents(bufferedEvents []*historypb.Hi
 		switch event.GetEventType() {
 		// Activity.
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_STARTED:
-			if completeEventType, seenCompleted := completedActivities[event.GetEventId()]; seenCompleted {
+			if completeEventType, seenCompleted := completedActivities[event.GetActivityTaskStartedEventAttributes().GetScheduledEventId()]; seenCompleted {
 				metrics.OutOfOrderBufferedEventsCounter.With(b.metricsHandler).Record(1, metrics.OperationTag(completeEventType.String()))
 			}
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED:
-			completedActivities[event.GetActivityTaskCompletedEventAttributes().GetStartedEventId()] = event.GetEventType()
+			completedActivities[event.GetActivityTaskCompletedEventAttributes().GetScheduledEventId()] = event.GetEventType()
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_FAILED:
-			completedActivities[event.GetActivityTaskFailedEventAttributes().GetStartedEventId()] = event.GetEventType()
+			completedActivities[event.GetActivityTaskFailedEventAttributes().GetScheduledEventId()] = event.GetEventType()
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT:
-			completedActivities[event.GetActivityTaskTimedOutEventAttributes().GetStartedEventId()] = event.GetEventType()
+			completedActivities[event.GetActivityTaskTimedOutEventAttributes().GetScheduledEventId()] = event.GetEventType()
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_CANCELED:
-			completedActivities[event.GetActivityTaskCanceledEventAttributes().GetStartedEventId()] = event.GetEventType()
+			completedActivities[event.GetActivityTaskCanceledEventAttributes().GetScheduledEventId()] = event.GetEventType()
 
 		// Child Workflow.
 		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED:
-			if completeEventType, seenCompleted := completedChildWorkflows[event.GetEventId()]; seenCompleted {
+			if completeEventType, seenCompleted := completedChildWorkflows[event.GetChildWorkflowExecutionStartedEventAttributes().GetInitiatedEventId()]; seenCompleted {
 				metrics.OutOfOrderBufferedEventsCounter.With(b.metricsHandler).Record(1, metrics.OperationTag(completeEventType.String()))
 			}
 		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED:
-			completedChildWorkflows[event.GetChildWorkflowExecutionCompletedEventAttributes().GetStartedEventId()] = event.GetEventType()
+			completedChildWorkflows[event.GetChildWorkflowExecutionCompletedEventAttributes().GetInitiatedEventId()] = event.GetEventType()
 		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED:
-			completedChildWorkflows[event.GetChildWorkflowExecutionFailedEventAttributes().GetStartedEventId()] = event.GetEventType()
+			completedChildWorkflows[event.GetChildWorkflowExecutionFailedEventAttributes().GetInitiatedEventId()] = event.GetEventType()
 		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TIMED_OUT:
-			completedChildWorkflows[event.GetChildWorkflowExecutionTimedOutEventAttributes().GetStartedEventId()] = event.GetEventType()
+			completedChildWorkflows[event.GetChildWorkflowExecutionTimedOutEventAttributes().GetInitiatedEventId()] = event.GetEventType()
 		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED:
-			completedChildWorkflows[event.GetChildWorkflowExecutionCanceledEventAttributes().GetStartedEventId()] = event.GetEventType()
+			completedChildWorkflows[event.GetChildWorkflowExecutionCanceledEventAttributes().GetInitiatedEventId()] = event.GetEventType()
 		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TERMINATED:
-			completedChildWorkflows[event.GetChildWorkflowExecutionTerminatedEventAttributes().GetStartedEventId()] = event.GetEventType()
+			completedChildWorkflows[event.GetChildWorkflowExecutionTerminatedEventAttributes().GetInitiatedEventId()] = event.GetEventType()
 
 		// Nexus Operation.
 		case enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED:


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Use scheduled/initiated event Id for `out_of_order_buffered_events` metric.

## Why?
<!-- Tell your future self why have you made these changes -->
In case if both started and completed events are buffered, `event.GetEventID()` always returns `-123` (buffered event Id) and it is incorrect to use it as a map key.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run in test environment.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.