### PR TITLE
Fallback to endpoint name in task executor

### DIFF
--- a/components/callbacks/statemachine.go
+++ b/components/callbacks/statemachine.go
@@ -96,19 +96,19 @@ func (c Callback) RegenerateTasks(*hsm.Node) ([]hsm.Task, error) {
 	case enumsspb.CALLBACK_STATE_BACKING_OFF:
 		return []hsm.Task{BackoffTask{Deadline: c.NextAttemptScheduleTime.AsTime()}}, nil
 	case enumsspb.CALLBACK_STATE_SCHEDULED:
-		var destination string
+		var baseURL string
 		switch v := c.Callback.GetVariant().(type) {
 		case *persistencespb.Callback_Nexus_:
 			u, err := url.Parse(c.Callback.GetNexus().Url)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse URL: %v: %w", &c, err)
 			}
-			destination = u.Scheme + "://" + u.Host
+			baseURL = u.Scheme + "://" + u.Host
 		default:
 			return nil, fmt.Errorf("unsupported callback variant %v", v) // nolint:goerr113
 		}
 
-		return []hsm.Task{InvocationTask{Destination: destination}}, nil
+		return []hsm.Task{InvocationTask{Destination: baseURL}}, nil
 	}
 	return nil, nil
 }

--- a/components/callbacks/tasks.go
+++ b/components/callbacks/tasks.go
@@ -35,6 +35,8 @@ const (
 )
 
 type InvocationTask struct {
+	// The base URL for nexus callbacks.
+	// Will have other meanings as more callback use cases are added.
 	Destination string
 }
 

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -150,7 +150,7 @@ func (o Operation) transitionTasks(node *hsm.Node) ([]hsm.Task, error) {
 	case enumsspb.NEXUS_OPERATION_STATE_BACKING_OFF:
 		return []hsm.Task{BackoffTask{Deadline: o.NextAttemptScheduleTime.AsTime()}}, nil
 	case enumsspb.NEXUS_OPERATION_STATE_SCHEDULED:
-		return []hsm.Task{InvocationTask{Destination: o.EndpointId}}, nil
+		return []hsm.Task{InvocationTask{EndpointName: o.Endpoint}}, nil
 	default:
 		return nil, nil
 	}
@@ -566,7 +566,7 @@ func (c Cancelation) RegenerateTasks(node *hsm.Node) ([]hsm.Task, error) {
 	}
 	switch c.State() { // nolint:exhaustive
 	case enumspb.NEXUS_OPERATION_CANCELLATION_STATE_SCHEDULED:
-		return []hsm.Task{CancelationTask{Destination: op.EndpointId}}, nil
+		return []hsm.Task{CancelationTask{EndpointName: op.Endpoint}}, nil
 	case enumspb.NEXUS_OPERATION_CANCELLATION_STATE_BACKING_OFF:
 		return []hsm.Task{CancelationBackoffTask{Deadline: c.NextAttemptScheduleTime.AsTime()}}, nil
 	default:

--- a/components/nexusoperations/statemachine_test.go
+++ b/components/nexusoperations/statemachine_test.go
@@ -120,7 +120,7 @@ func TestRegenerateTasks(t *testing.T) {
 			assertTasks: func(t *testing.T, tasks []hsm.Task) {
 				require.Equal(t, 2, len(tasks))
 				require.Equal(t, nexusoperations.TaskTypeInvocation, tasks[0].Type())
-				require.Equal(t, tasks[0].(nexusoperations.InvocationTask).Destination, "endpoint-id")
+				require.Equal(t, tasks[0].(nexusoperations.InvocationTask).EndpointName, "endpoint")
 				require.Equal(t, nexusoperations.TaskTypeTimeout, tasks[1].Type())
 			},
 		},
@@ -213,7 +213,7 @@ func TestRetry(t *testing.T) {
 	require.Equal(t, 1, len(oap[0].Outputs))
 	require.Equal(t, 1, len(oap[0].Outputs[0].Tasks))
 	invocationTask := oap[0].Outputs[0].Tasks[0].(nexusoperations.InvocationTask) // nolint:revive
-	require.Equal(t, "endpoint-id", invocationTask.Destination)
+	require.Equal(t, "endpoint", invocationTask.EndpointName)
 	op, err = hsm.MachineData[nexusoperations.Operation](node)
 	require.NoError(t, err)
 	require.Equal(t, enumsspb.NEXUS_OPERATION_STATE_SCHEDULED, op.State())
@@ -545,7 +545,7 @@ func TestCancelationValidTransitions(t *testing.T) {
 	// Assert cancelation task is generated
 	require.Equal(t, 1, len(out.Tasks))
 	cbTask := out.Tasks[0].(nexusoperations.CancelationTask) // nolint:revive
-	require.Equal(t, "endpoint-id", cbTask.Destination)
+	require.Equal(t, "endpoint", cbTask.EndpointName)
 
 	// Store the pre-succeeded state to test Failed later
 	dup := nexusoperations.Cancelation{common.CloneProto(cancelation.NexusOperationCancellationInfo)}

--- a/components/nexusoperations/tasks.go
+++ b/components/nexusoperations/tasks.go
@@ -87,7 +87,7 @@ func (TimeoutTaskSerializer) Serialize(hsm.Task) ([]byte, error) {
 }
 
 type InvocationTask struct {
-	Destination string
+	EndpointName string
 }
 
 var _ hsm.Task = InvocationTask{}
@@ -97,7 +97,7 @@ func (InvocationTask) Type() string {
 }
 
 func (t InvocationTask) Kind() hsm.TaskKind {
-	return hsm.TaskKindOutbound{Destination: t.Destination}
+	return hsm.TaskKindOutbound{Destination: t.EndpointName}
 }
 
 func (InvocationTask) Concurrent() bool {
@@ -108,7 +108,7 @@ type InvocationTaskSerializer struct{}
 
 func (InvocationTaskSerializer) Deserialize(data []byte, kind hsm.TaskKind) (hsm.Task, error) {
 	if kind, ok := kind.(hsm.TaskKindOutbound); ok {
-		return InvocationTask{Destination: kind.Destination}, nil
+		return InvocationTask{EndpointName: kind.Destination}, nil
 	}
 	return nil, fmt.Errorf("%w: expected outbound", hsm.ErrInvalidTaskKind)
 }
@@ -149,7 +149,7 @@ func (BackoffTaskSerializer) Serialize(hsm.Task) ([]byte, error) {
 }
 
 type CancelationTask struct {
-	Destination string
+	EndpointName string
 }
 
 var _ hsm.Task = CancelationTask{}
@@ -159,7 +159,7 @@ func (CancelationTask) Type() string {
 }
 
 func (t CancelationTask) Kind() hsm.TaskKind {
-	return hsm.TaskKindOutbound{Destination: t.Destination}
+	return hsm.TaskKindOutbound{Destination: t.EndpointName}
 }
 
 func (CancelationTask) Concurrent() bool {
@@ -170,7 +170,7 @@ type CancelationTaskSerializer struct{}
 
 func (CancelationTaskSerializer) Deserialize(data []byte, kind hsm.TaskKind) (hsm.Task, error) {
 	if kind, ok := kind.(hsm.TaskKindOutbound); ok {
-		return CancelationTask{Destination: kind.Destination}, nil
+		return CancelationTask{EndpointName: kind.Destination}, nil
 	}
 	return nil, fmt.Errorf("%w: expected outbound", hsm.ErrInvalidTaskKind)
 }

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -106,27 +106,30 @@ func (s *NexusStateReplicationSuite) TestNexusOperationEventsReplicated() {
 	ns := s.createGlobalNamespace()
 
 	// Set URL template after httpAPAddress is set, see commonnexus.RouteCompletionCallback.
-	// Only needed for cluster1 - where the start request will be sent from.
-	s.cluster1.OverrideDynamicConfig(
+	// But only on cluster2, this will prevent the operation request from starting in cluster1, we expect the operation
+	// to be executed in cluster2 after failover is complete.
+	s.cluster2.OverrideDynamicConfig(
 		s.T(),
 		nexusoperations.CallbackURLTemplate,
-		// We'll send the callback to cluster2 when we failover to it.
-		"http://"+s.cluster2.GetHost().FrontendHTTPAddress()+"/namespaces/{{.NamespaceName}}/nexus/callback")
+		// We'll send the callback to cluster1, when we fail back to it.
+		"http://"+s.cluster1.GetHost().FrontendHTTPAddress()+"/namespaces/{{.NamespaceName}}/nexus/callback")
 
-	// Create our Nexus endpoint on cluster1, where the start request will be sent from.
-	_, err := s.cluster1.GetOperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
-		Spec: &nexuspb.EndpointSpec{
-			Name: "endpoint",
-			Target: &nexuspb.EndpointTarget{
-				Variant: &nexuspb.EndpointTarget_External_{
-					External: &nexuspb.EndpointTarget_External{
-						Url: "http://" + listenAddr,
+	// Nexus endpoints registry isn't replicated yet, manually create the same endpoint in both clusters.
+	for _, cl := range []operatorservice.OperatorServiceClient{s.cluster1.GetOperatorClient(), s.cluster2.GetOperatorClient()} {
+		_, err := cl.CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+			Spec: &nexuspb.EndpointSpec{
+				Name: "endpoint",
+				Target: &nexuspb.EndpointTarget{
+					Variant: &nexuspb.EndpointTarget_External_{
+						External: &nexuspb.EndpointTarget_External{
+							Url: "http://" + listenAddr,
+						},
 					},
 				},
 			},
-		},
-	})
-	s.NoError(err)
+		})
+		s.NoError(err)
+	}
 
 	sdkClient1, err := sdkclient.Dial(sdkclient.Options{
 		HostPort:  s.cluster1.GetHost().FrontendGRPCAddress(),
@@ -163,8 +166,8 @@ func (s *NexusStateReplicationSuite) TestNexusOperationEventsReplicated() {
 	})
 	s.NoError(err)
 
-	// Ensure the started event is replicated to cluster2.
-	s.waitEvent(ctx, sdkClient2, run, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
+	// Ensure the scheduled event is replicated.
+	s.waitEvent(ctx, sdkClient2, run, enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED)
 
 	// Now failover, and let cluster2 be the active.
 	s.failover(ns, s.clusterNames[1], 2, s.cluster1.GetFrontendClient())
@@ -176,12 +179,22 @@ func (s *NexusStateReplicationSuite) TestNexusOperationEventsReplicated() {
 		Commands:  []*commandpb.Command{}, // No need to generate other commands, this "workflow" just waits for the operation to complete.
 	})
 	s.NoError(err)
+	idx := slices.IndexFunc(pollRes.History.Events, func(ev *historypb.HistoryEvent) bool {
+		return ev.EventType == enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED
+	})
+	s.Greater(idx, -1)
+
+	// Ensure the started event is replicated back to cluster1.
+	s.waitEvent(ctx, sdkClient1, run, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
+
+	// Fail back to cluster1.
+	s.failover(ns, s.clusterNames[0], 11, s.cluster2.GetFrontendClient())
 
 	s.completeNexusOperation(ctx, "result", publicCallbackUrl, callbackToken)
 
 	// Verify completion triggers a new workflow task and that the workflow completes.
-	pollRes = s.pollWorkflowTask(ctx, s.cluster2.GetFrontendClient(), ns)
-	_, err = s.cluster2.GetFrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	pollRes = s.pollWorkflowTask(ctx, s.cluster1.GetFrontendClient(), ns)
+	_, err = s.cluster1.GetFrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		TaskToken: pollRes.TaskToken,
 		Commands: []*commandpb.Command{
 			{
@@ -193,7 +206,7 @@ func (s *NexusStateReplicationSuite) TestNexusOperationEventsReplicated() {
 		},
 	})
 	s.NoError(err)
-	idx := slices.IndexFunc(pollRes.History.Events, func(ev *historypb.HistoryEvent) bool {
+	idx = slices.IndexFunc(pollRes.History.Events, func(ev *historypb.HistoryEvent) bool {
 		return ev.EventType == enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED
 	})
 	s.Greater(idx, -1)


### PR DESCRIPTION
## What changed?

- Fallback to endpoint name in task executor
- Fix metrics to use endpoint name instead of ID (regression from #6118)
- Signature of ClientProvider changed and no longer requires resolving the nexus endpoint
- Renamed `nexusoperations.InvocationTask.Destination` to `EndpointName`
- Renamed `nexusoperations.CancelationTask.Destination` to `EndpointName` 

## Why?

A temporary workaround for not implementing endpoint replication, and endpoint ID being a UUID set by
the system, try to get the endpoint by name to support cases where an operator manually created an
endpoint with the same name in two replicas.

This practice is not recommended in production use cases and when replication is implemented, if endpoints are defined with the same name and different IDs and two replicas, they'll need to nuke their endpoint registry.

## How did you test it?

Unit tests and XDC test.