### PR TITLE
Speed up long poll tests

### DIFF
--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -183,8 +183,6 @@ var (
 func NewDynamicConfig() *configs.Config {
 	dc := dynamicconfig.NewNoopCollection()
 	config := configs.NewConfig(dc, 1)
-	// reduce the duration of long poll to increase test speed
-	config.LongPollExpirationInterval = dynamicconfig.HistoryLongPollExpirationInterval.Get(dc)
 	config.EnableActivityEagerExecution = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.EnableEagerWorkflowStart = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.NamespaceCacheRefreshInterval = dynamicconfig.GetDurationPropertyFn(time.Second)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Speed up long poll tests

Before
```
--- PASS: TestEngineSuite (42.01s)
    --- PASS: TestEngineSuite/TestGetMutableStateLongPoll (2.00s)
    --- PASS: TestEngineSuite/TestGetMutableStateLongPollTimeout (20.00s)
    --- PASS: TestEngineSuite/TestGetMutableStateLongPoll_CurrentBranchChanged (20.00s)
```
After
```
--- PASS: TestEngineSuite (3.01s)
    --- PASS: TestEngineSuite/TestGetMutableStateLongPoll (1.00s)
    --- PASS: TestEngineSuite/TestGetMutableStateLongPollTimeout (1.00s)
    --- PASS: TestEngineSuite/TestGetMutableStateLongPoll_CurrentBranchChanged (1.01s)
```

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
