### PR TITLE
Change WorkflowIdReuseMinimalInterval setting to be per namespace

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1391,12 +1391,6 @@ for the entire queue but only trigger a queue action to unload tasks. Ideally th
 limit should not be hit and task unloading should happen once critical count is exceeded. But
 since queue action is async, we need this hard limit.`,
 	)
-	ContinueAsNewMinInterval = NewNamespaceDurationSetting(
-		"history.continueAsNewMinInterval",
-		time.Second,
-		`ContinueAsNewMinInterval is the minimal interval between continue_as_new executions.
-This is needed to prevent tight loop continue_as_new spin. Default is 1s.`,
-	)
 
 	TaskSchedulerEnableRateLimiter = NewGlobalBoolSetting(
 		"history.taskSchedulerEnableRateLimiter",
@@ -2382,7 +2376,7 @@ WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 		20000,
 		`MaxUserMetadataDetailsSize is the maximum size of user metadata details payloads in bytes.`,
 	)
-	WorkflowIdReuseMinimalInterval = NewGlobalDurationSetting(
+	WorkflowIdReuseMinimalInterval = NewNamespaceDurationSetting(
 		"system.workflowIdReuseMinimalInterval",
 		1*time.Second,
 		`WorkflowIdReuseMinimalInterval is used for timing how soon users can create new workflow with the same workflow ID.`,

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -112,6 +112,7 @@ func startAndSignalWorkflow(
 	workflowMutationFn, err := createWorkflowMutationFunction(
 		shard,
 		currentWorkflowLease,
+		namespaceEntry,
 		runID,
 		signalWithStartRequest.GetWorkflowIdReusePolicy(),
 		signalWithStartRequest.GetWorkflowIdConflictPolicy(),
@@ -147,6 +148,7 @@ func startAndSignalWorkflow(
 func createWorkflowMutationFunction(
 	shardContext shard.Context,
 	currentWorkflowLease api.WorkflowLease,
+	namespaceEntry *namespace.Namespace,
 	newRunID string,
 	workflowIDReusePolicy enumspb.WorkflowIdReusePolicy,
 	workflowIDConflictPolicy enumspb.WorkflowIdConflictPolicy,
@@ -169,6 +171,7 @@ func createWorkflowMutationFunction(
 	workflowMutationFunc, err := api.ResolveDuplicateWorkflowID(
 		shardContext,
 		workflowKey,
+		namespaceEntry,
 		newRunID,
 		currentExecutionState.State,
 		currentExecutionState.Status,

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -388,6 +388,7 @@ func (s *Starter) resolveDuplicateWorkflowID(
 	currentExecutionUpdateAction, err := api.ResolveDuplicateWorkflowID(
 		s.shardContext,
 		workflowKey,
+		s.namespace,
 		creationParams.runID,
 		currentWorkflowConditionFailed.State,
 		currentWorkflowConditionFailed.Status,

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -379,11 +379,16 @@ func (s *Starter) resolveDuplicateWorkflowID(
 		return nil, err
 	}
 
+	workflowKey := definition.NewWorkflowKey(
+		s.namespace.ID().String(),
+		workflowID,
+		currentWorkflowConditionFailed.RunID,
+	)
+
 	currentExecutionUpdateAction, err := api.ResolveDuplicateWorkflowID(
 		s.shardContext,
-		workflowID,
+		workflowKey,
 		creationParams.runID,
-		currentWorkflowConditionFailed.RunID,
 		currentWorkflowConditionFailed.State,
 		currentWorkflowConditionFailed.Status,
 		currentWorkflowConditionFailed.RequestID,

--- a/service/history/api/workflow_id_dedup.go
+++ b/service/history/api/workflow_id_dedup.go
@@ -122,7 +122,6 @@ func resolveDuplicateWorkflowStart(
 	nsName := namespaceEntry.Name().String()
 	minimalReuseInterval := shardContext.GetConfig().WorkflowIdReuseMinimalInterval(nsName)
 
-	//minimalReuseInterval := shardContext.GetConfig().WorkflowIdReuseMinimalInterval()
 	now := shardContext.GetTimeSource().Now().UTC()
 	timeSinceStart := now.Sub(currentWorkflowStartTime.UTC())
 

--- a/service/history/api/workflow_id_dedup_test.go
+++ b/service/history/api/workflow_id_dedup_test.go
@@ -29,12 +29,15 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tests"
 )
@@ -66,6 +69,7 @@ func TestResolveDuplicateWorkflowStart(t *testing.T) {
 	}
 
 	config := tests.NewDynamicConfig()
+
 	mockShard := shard.NewTestContextWithTimeSource(
 		gomock.NewController(t),
 		&persistencespb.ShardInfo{RangeId: 1},
@@ -73,12 +77,25 @@ func TestResolveDuplicateWorkflowStart(t *testing.T) {
 		timeSource,
 	)
 
-	for _, tc := range testCases {
-		config.WorkflowIdReuseMinimalInterval = dynamicconfig.GetDurationPropertyFn(tc.gracePeriod)
+	namespaceEntry := namespace.NewLocalNamespaceForTest(
+		&persistencespb.NamespaceInfo{},
+		&persistencespb.NamespaceConfig{},
+		"target_cluster",
+	)
+	mockNamespaceCache := mockShard.Resource.NamespaceCache
+	mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(namespaceEntry, nil).AnyTimes()
 
-		_, err := resolveDuplicateWorkflowStart(
-			mockShard, tc.currentWorkflowStart, "newRunID", "workflowID",
-		)
+	mockClusterMetadata := mockShard.Resource.ClusterMetadata
+	mockClusterMetadata.EXPECT().GetCurrentClusterName().Return("target_cluster").AnyTimes()
+
+	for _, tc := range testCases {
+		config.WorkflowIdReuseMinimalInterval = dynamicconfig.GetDurationPropertyFnFilteredByNamespace(tc.gracePeriod)
+		workflowKey := definition.WorkflowKey{
+			NamespaceID: uuid.NewUUID().String(),
+			WorkflowID:  "workflowID",
+			RunID:       "oldRunID",
+		}
+		_, err := resolveDuplicateWorkflowStart(mockShard, tc.currentWorkflowStart, workflowKey, "newRunID")
 
 		if tc.expectError {
 			assert.Error(t, err)

--- a/service/history/api/workflow_id_dedup_test.go
+++ b/service/history/api/workflow_id_dedup_test.go
@@ -82,11 +82,6 @@ func TestResolveDuplicateWorkflowStart(t *testing.T) {
 		&persistencespb.NamespaceConfig{},
 		"target_cluster",
 	)
-	mockNamespaceCache := mockShard.Resource.NamespaceCache
-	mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(namespaceEntry, nil).AnyTimes()
-
-	mockClusterMetadata := mockShard.Resource.ClusterMetadata
-	mockClusterMetadata.EXPECT().GetCurrentClusterName().Return("target_cluster").AnyTimes()
 
 	for _, tc := range testCases {
 		config.WorkflowIdReuseMinimalInterval = dynamicconfig.GetDurationPropertyFnFilteredByNamespace(tc.gracePeriod)
@@ -95,7 +90,7 @@ func TestResolveDuplicateWorkflowStart(t *testing.T) {
 			WorkflowID:  "workflowID",
 			RunID:       "oldRunID",
 		}
-		_, err := resolveDuplicateWorkflowStart(mockShard, tc.currentWorkflowStart, workflowKey, "newRunID")
+		_, err := resolveDuplicateWorkflowStart(mockShard, tc.currentWorkflowStart, workflowKey, namespaceEntry, "newRunID")
 
 		if tc.expectError {
 			assert.Error(t, err)

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -250,9 +250,6 @@ type Config struct {
 	WorkflowTaskCriticalAttempts dynamicconfig.IntPropertyFn
 	WorkflowTaskRetryMaxInterval dynamicconfig.DurationPropertyFn
 
-	// ContinueAsNewMinInterval is the minimal interval between continue_as_new to prevent tight continue_as_new loop.
-	ContinueAsNewMinInterval dynamicconfig.DurationPropertyFnWithNamespaceFilter
-
 	// The following is used by the new RPC replication stack
 	ReplicationTaskApplyTimeout                          dynamicconfig.DurationPropertyFn
 	ReplicationTaskFetcherParallelism                    dynamicconfig.IntPropertyFn
@@ -351,7 +348,7 @@ type Config struct {
 
 	SendRawWorkflowHistory dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
-	WorkflowIdReuseMinimalInterval dynamicconfig.DurationPropertyFn
+	WorkflowIdReuseMinimalInterval dynamicconfig.DurationPropertyFnWithNamespaceFilter
 
 	UseExperimentalHsmScheduler dynamicconfig.BoolPropertyFnWithNamespaceFilter
 }
@@ -381,7 +378,6 @@ func NewConfig(
 		StartupMembershipJoinDelay:           dynamicconfig.HistoryStartupMembershipJoinDelay.Get(dc),
 		MaxAutoResetPoints:                   dynamicconfig.HistoryMaxAutoResetPoints.Get(dc),
 		DefaultWorkflowTaskTimeout:           dynamicconfig.DefaultWorkflowTaskTimeout.Get(dc),
-		ContinueAsNewMinInterval:             dynamicconfig.ContinueAsNewMinInterval.Get(dc),
 
 		VisibilityPersistenceMaxReadQPS:       dynamicconfig.VisibilityPersistenceMaxReadQPS.Get(dc),
 		VisibilityPersistenceMaxWriteQPS:      dynamicconfig.VisibilityPersistenceMaxWriteQPS.Get(dc),

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2061,7 +2061,7 @@ func (ms *MutableStateImpl) ContinueAsNewMinBackoff(backoffDuration *durationpb.
 		interval += backoffDuration.AsDuration()
 	}
 	// minimal interval for continue as new to prevent tight continue as new loop
-	minInterval := ms.config.ContinueAsNewMinInterval(ms.namespaceEntry.Name().String())
+	minInterval := ms.config.WorkflowIdReuseMinimalInterval(ms.namespaceEntry.Name().String())
 	if interval < minInterval {
 		// enforce a minimal backoff
 		return durationpb.New(minInterval - lifetime)

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -605,7 +605,7 @@ func (s *mutableStateSuite) TestChecksumShouldInvalidate() {
 
 func (s *mutableStateSuite) TestContinueAsNewMinBackoff() {
 	// set ContinueAsNew min interval to 5s
-	s.mockConfig.ContinueAsNewMinInterval = func(namespace string) time.Duration {
+	s.mockConfig.WorkflowIdReuseMinimalInterval = func(namespace string) time.Duration {
 		return 5 * time.Second
 	}
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Make WorkflowIdReuseMinimalInterval to be per-namespace, rather then single global setting.
Also remove ContinueAsNewMinInterval setting (by reusing WorkflowIdReuseMinimalInterval setting).
This effectively makes ContinueAsNewMinInterval setting be per-namespace as well

## Why?
<!-- Tell your future self why have you made these changes -->
To have more flexibility in configuring this setting.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Update unit-tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
