### PR TITLE
Fix Nexus endpoint name validation regex

### DIFF
--- a/service/frontend/nexus_endpoint_client.go
+++ b/service/frontend/nexus_endpoint_client.go
@@ -48,7 +48,7 @@ import (
 )
 
 // EndpointNameRegex is the regular expression that endpoint names must match.
-var EndpointNameRegex = regexp.MustCompile(`[a-zA-Z_][a-zA-Z0-9_]*`)
+var EndpointNameRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
 type (
 	// NexusEndpointClient manages frontend CRUD requests for Nexus endpoints.

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -853,6 +853,7 @@ func getDispatchByNsAndTqURL(address string, namespace string, taskQueue string)
 }
 
 func (s *ClientFunctionalSuite) createNexusEndpoint(name string, taskQueue string) *nexuspb.Endpoint {
+	name = strings.ReplaceAll(name, "-", "_")
 	resp, err := s.operatorClient.CreateNexusEndpoint(NewContext(), &operatorservice.CreateNexusEndpointRequest{
 		Spec: &nexuspb.EndpointSpec{
 			Name: name,

--- a/tests/nexus_endpoint_test.go
+++ b/tests/nexus_endpoint_test.go
@@ -164,17 +164,18 @@ type MatchingSuite struct {
 }
 
 func (s *MatchingSuite) TestCreate() {
-	entry := s.createNexusEndpoint(s.T().Name())
+	endpointName := "test_matching_create_endpoint_name"
+	entry := s.createNexusEndpoint(endpointName)
 	s.Equal(int64(1), entry.Version)
 	s.NotNil(entry.Endpoint.Clock)
 	s.NotNil(entry.Endpoint.CreatedTime)
 	s.NotEmpty(entry.Id)
-	s.Equal(entry.Endpoint.Spec.Name, s.T().Name())
+	s.Equal(entry.Endpoint.Spec.Name, endpointName)
 	s.Equal(entry.Endpoint.Spec.Target.GetWorker().NamespaceId, s.getNamespaceID(s.namespace))
 
 	_, err := s.testCluster.GetMatchingClient().CreateNexusEndpoint(NewContext(), &matchingservice.CreateNexusEndpointRequest{
 		Spec: &persistencespb.NexusEndpointSpec{
-			Name: s.T().Name(),
+			Name: endpointName,
 			Target: &persistencespb.NexusEndpointTarget{
 				Variant: &persistencespb.NexusEndpointTarget_Worker_{
 					Worker: &persistencespb.NexusEndpointTarget_Worker{
@@ -190,7 +191,9 @@ func (s *MatchingSuite) TestCreate() {
 }
 
 func (s *MatchingSuite) TestUpdate() {
-	endpoint := s.createNexusEndpoint(s.T().Name())
+	endpointName := "test_update_endpoint_name"
+	updatedName := "updated_name"
+	endpoint := s.createNexusEndpoint(endpointName)
 	type testcase struct {
 		name      string
 		request   *matchingservice.UpdateNexusEndpointRequest
@@ -203,7 +206,7 @@ func (s *MatchingSuite) TestUpdate() {
 				Version: 1,
 				Id:      endpoint.Id,
 				Spec: &persistencespb.NexusEndpointSpec{
-					Name: "updated name",
+					Name: updatedName,
 					Target: &persistencespb.NexusEndpointTarget{
 						Variant: &persistencespb.NexusEndpointTarget_Worker_{
 							Worker: &persistencespb.NexusEndpointTarget_Worker{
@@ -218,7 +221,7 @@ func (s *MatchingSuite) TestUpdate() {
 				s.NoError(err)
 				s.NotNil(resp.Entry)
 				s.Equal(int64(2), resp.Entry.Version)
-				s.Equal("updated name", resp.Entry.Endpoint.Spec.Name)
+				s.Equal(updatedName, resp.Entry.Endpoint.Spec.Name)
 				s.NotNil(resp.Entry.Endpoint.Clock)
 			},
 		},
@@ -228,7 +231,7 @@ func (s *MatchingSuite) TestUpdate() {
 				Version: 1,
 				Id:      "not-found",
 				Spec: &persistencespb.NexusEndpointSpec{
-					Name: "updated name",
+					Name: updatedName,
 					Target: &persistencespb.NexusEndpointTarget{
 						Variant: &persistencespb.NexusEndpointTarget_Worker_{
 							Worker: &persistencespb.NexusEndpointTarget_Worker{
@@ -250,7 +253,7 @@ func (s *MatchingSuite) TestUpdate() {
 				Version: 1,
 				Id:      endpoint.Id,
 				Spec: &persistencespb.NexusEndpointSpec{
-					Name: "updated name",
+					Name: updatedName,
 					Target: &persistencespb.NexusEndpointTarget{
 						Variant: &persistencespb.NexusEndpointTarget_Worker_{
 							Worker: &persistencespb.NexusEndpointTarget_Worker{
@@ -278,7 +281,8 @@ func (s *MatchingSuite) TestUpdate() {
 }
 
 func (s *MatchingSuite) TestDelete() {
-	endpoint := s.createNexusEndpoint("endpoint-to-delete-matching")
+	endpointName := "test_delete_endpoint_name"
+	endpoint := s.createNexusEndpoint(endpointName)
 	type testcase struct {
 		name       string
 		endpointID string
@@ -462,6 +466,7 @@ type OperatorSuite struct {
 }
 
 func (s *OperatorSuite) TestCreate() {
+	endpointName := "test_operator_create_endpoint_name"
 	type testcase struct {
 		name      string
 		request   *operatorservice.CreateNexusEndpointRequest
@@ -472,7 +477,7 @@ func (s *OperatorSuite) TestCreate() {
 			name: "valid create",
 			request: &operatorservice.CreateNexusEndpointRequest{
 				Spec: &nexus.EndpointSpec{
-					Name: s.T().Name(),
+					Name: endpointName,
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_Worker_{
 							Worker: &nexus.EndpointTarget_Worker{
@@ -484,12 +489,13 @@ func (s *OperatorSuite) TestCreate() {
 				},
 			},
 			assertion: func(resp *operatorservice.CreateNexusEndpointResponse, err error) {
+				s.NoError(err)
 				s.NotNil(resp.Endpoint)
 				s.Equal(int64(1), resp.Endpoint.Version)
 				s.Nil(resp.Endpoint.LastModifiedTime)
 				s.NotNil(resp.Endpoint.CreatedTime)
 				s.NotEmpty(resp.Endpoint.Id)
-				s.Equal(resp.Endpoint.Spec.Name, s.T().Name())
+				s.Equal(resp.Endpoint.Spec.Name, endpointName)
 				s.Equal(resp.Endpoint.Spec.Target.GetWorker().Namespace, s.namespace)
 				s.Equal("/"+commonnexus.RouteDispatchNexusTaskByEndpoint.Path(resp.Endpoint.Id), resp.Endpoint.UrlPrefix)
 			},
@@ -498,7 +504,7 @@ func (s *OperatorSuite) TestCreate() {
 			name: "invalid: name already in use",
 			request: &operatorservice.CreateNexusEndpointRequest{
 				Spec: &nexus.EndpointSpec{
-					Name: s.T().Name(),
+					Name: endpointName,
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_Worker_{
 							Worker: &nexus.EndpointTarget_Worker{
@@ -577,7 +583,7 @@ func (s *OperatorSuite) TestCreate() {
 			name: "invalid: namespace unset",
 			request: &operatorservice.CreateNexusEndpointRequest{
 				Spec: &nexus.EndpointSpec{
-					Name: s.randomizeStr(s.T().Name()),
+					Name: s.randomizeStr(endpointName),
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_Worker_{
 							Worker: &nexus.EndpointTarget_Worker{
@@ -596,7 +602,7 @@ func (s *OperatorSuite) TestCreate() {
 			name: "invalid: namespace not found",
 			request: &operatorservice.CreateNexusEndpointRequest{
 				Spec: &nexus.EndpointSpec{
-					Name: s.randomizeStr(s.T().Name()),
+					Name: s.randomizeStr(endpointName),
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_Worker_{
 							Worker: &nexus.EndpointTarget_Worker{
@@ -616,7 +622,7 @@ func (s *OperatorSuite) TestCreate() {
 			name: "invalid: task queue unset",
 			request: &operatorservice.CreateNexusEndpointRequest{
 				Spec: &nexus.EndpointSpec{
-					Name: s.randomizeStr(s.T().Name()),
+					Name: s.randomizeStr(endpointName),
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_Worker_{
 							Worker: &nexus.EndpointTarget_Worker{
@@ -635,7 +641,7 @@ func (s *OperatorSuite) TestCreate() {
 			name: "invalid: task queue too long",
 			request: &operatorservice.CreateNexusEndpointRequest{
 				Spec: &nexus.EndpointSpec{
-					Name: s.randomizeStr(s.T().Name()),
+					Name: s.randomizeStr(endpointName),
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_Worker_{
 							Worker: &nexus.EndpointTarget_Worker{
@@ -655,7 +661,7 @@ func (s *OperatorSuite) TestCreate() {
 			name: "invalid: empty URL",
 			request: &operatorservice.CreateNexusEndpointRequest{
 				Spec: &nexus.EndpointSpec{
-					Name: s.randomizeStr(s.T().Name()),
+					Name: s.randomizeStr(endpointName),
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_External_{
 							External: &nexus.EndpointTarget_External{},
@@ -672,7 +678,7 @@ func (s *OperatorSuite) TestCreate() {
 			name: "invalid: URL too long",
 			request: &operatorservice.CreateNexusEndpointRequest{
 				Spec: &nexus.EndpointSpec{
-					Name: s.randomizeStr(s.T().Name()),
+					Name: s.randomizeStr(endpointName),
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_External_{
 							External: &nexus.EndpointTarget_External{
@@ -691,7 +697,7 @@ func (s *OperatorSuite) TestCreate() {
 			name: "invalid: URL invalid",
 			request: &operatorservice.CreateNexusEndpointRequest{
 				Spec: &nexus.EndpointSpec{
-					Name: s.randomizeStr(s.T().Name()),
+					Name: s.randomizeStr(endpointName),
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_External_{
 							External: &nexus.EndpointTarget_External{
@@ -710,7 +716,7 @@ func (s *OperatorSuite) TestCreate() {
 			name: "invalid: URL invalid scheme",
 			request: &operatorservice.CreateNexusEndpointRequest{
 				Spec: &nexus.EndpointSpec{
-					Name: s.randomizeStr(s.T().Name()),
+					Name: s.randomizeStr(endpointName),
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_External_{
 							External: &nexus.EndpointTarget_External{
@@ -729,7 +735,7 @@ func (s *OperatorSuite) TestCreate() {
 			name: "invalid: description too large",
 			request: &operatorservice.CreateNexusEndpointRequest{
 				Spec: &nexus.EndpointSpec{
-					Name: s.randomizeStr(s.T().Name()),
+					Name: s.randomizeStr(endpointName),
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_Worker_{
 							Worker: &nexus.EndpointTarget_Worker{
@@ -759,7 +765,9 @@ func (s *OperatorSuite) TestCreate() {
 }
 
 func (s *OperatorSuite) TestUpdate() {
-	endpoint := s.createNexusEndpoint(s.T().Name())
+	endpointName := "test_operator_update_endpoint_name"
+	updatedName := "updated_name"
+	endpoint := s.createNexusEndpoint(endpointName)
 	type testcase struct {
 		name      string
 		request   *operatorservice.UpdateNexusEndpointRequest
@@ -772,7 +780,7 @@ func (s *OperatorSuite) TestUpdate() {
 				Version: 1,
 				Id:      endpoint.Id,
 				Spec: &nexus.EndpointSpec{
-					Name: "updated name",
+					Name: updatedName,
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_Worker_{
 							Worker: &nexus.EndpointTarget_Worker{
@@ -787,7 +795,7 @@ func (s *OperatorSuite) TestUpdate() {
 				s.NoError(err)
 				s.NotNil(resp.Endpoint)
 				s.Equal(int64(2), resp.Endpoint.Version)
-				s.Equal("updated name", resp.Endpoint.Spec.Name)
+				s.Equal(updatedName, resp.Endpoint.Spec.Name)
 				s.NotNil(resp.Endpoint.LastModifiedTime)
 			},
 		},
@@ -797,7 +805,7 @@ func (s *OperatorSuite) TestUpdate() {
 				Version: 1,
 				Id:      "not-found",
 				Spec: &nexus.EndpointSpec{
-					Name: "updated name",
+					Name: updatedName,
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_Worker_{
 							Worker: &nexus.EndpointTarget_Worker{
@@ -819,7 +827,7 @@ func (s *OperatorSuite) TestUpdate() {
 				Version: 1,
 				Id:      endpoint.Id,
 				Spec: &nexus.EndpointSpec{
-					Name: "updated name",
+					Name: updatedName,
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_Worker_{
 							Worker: &nexus.EndpointTarget_Worker{
@@ -986,7 +994,8 @@ func (s *OperatorSuite) TestList() {
 }
 
 func (s *OperatorSuite) TestGet() {
-	endpoint := s.createNexusEndpoint(s.T().Name())
+	endpointName := "test_operator_get_endpoint_name"
+	endpoint := s.createNexusEndpoint(endpointName)
 
 	type testcase struct {
 		name      string

--- a/tests/nexus_endpoint_test.go
+++ b/tests/nexus_endpoint_test.go
@@ -563,7 +563,7 @@ func (s *OperatorSuite) TestCreate() {
 			name: "invalid: malformed name",
 			request: &operatorservice.CreateNexusEndpointRequest{
 				Spec: &nexus.EndpointSpec{
-					Name: "\n```\n",
+					Name: "test_\n```\n",
 					Target: &nexus.EndpointTarget{
 						Variant: &nexus.EndpointTarget_Worker_{
 							Worker: &nexus.EndpointTarget_Worker{

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -60,7 +60,7 @@ import (
 func (s *ClientFunctionalSuite) TestNexusOperationCancelation() {
 	ctx := NewContext()
 	taskQueue := s.randomizeStr(s.T().Name())
-	endpointName := s.randomizeStr(s.T().Name())
+	endpointName := "test_cancelation_endpoint_name"
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
@@ -184,7 +184,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationCancelation() {
 func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion() {
 	ctx := NewContext()
 	taskQueue := s.randomizeStr(s.T().Name())
-	endpointName := s.randomizeStr(s.T().Name())
+	endpointName := "test_sync_completion_endpoint_name"
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
@@ -284,7 +284,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion() {
 func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion_LargePayload() {
 	ctx := NewContext()
 	taskQueue := s.randomizeStr(s.T().Name())
-	endpointName := s.randomizeStr("test_endpoint")
+	endpointName := "test_sync_completion_large_payload_endpoint_name"
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
@@ -387,7 +387,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion_LargePayload() 
 func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {
 	ctx := NewContext()
 	taskQueue := s.randomizeStr(s.T().Name())
-	endpointName := s.randomizeStr(s.T().Name())
+	endpointName := "test_async_completion_endpoint_name"
 
 	testClusterInfo, err := s.engine.GetClusterInfo(ctx, &workflowservice.GetClusterInfoRequest{})
 	s.NoError(err)
@@ -602,7 +602,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {
 func (s *ClientFunctionalSuite) TestNexusOperationAsyncFailure() {
 	ctx := NewContext()
 	taskQueue := s.randomizeStr(s.T().Name())
-	endpointName := s.randomizeStr(s.T().Name())
+	endpointName := "test_async_failure_endpoint_name"
 
 	var callbackToken, publicCallbackUrl string
 
@@ -825,7 +825,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletionInternalAuth() 
 
 	ctx := NewContext()
 	taskQueue := s.randomizeStr(s.T().Name())
-	endpointName := s.randomizeStr(s.T().Name())
+	endpointName := "test_async_completion_internal_auth_endpoint_name"
 
 	_, err := s.operatorClient.CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
 		Spec: &nexuspb.EndpointSpec{

--- a/tests/xdc/nexus_request_forwarding_test.go
+++ b/tests/xdc/nexus_request_forwarding_test.go
@@ -198,7 +198,7 @@ func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToAc
 		tc := tc
 		s.T().Run(tc.name, func(t *testing.T) {
 			dispatchURL := fmt.Sprintf("http://%s/%s", s.cluster2.GetHost().FrontendHTTPAddress(), cnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Path(cnexus.NamespaceAndTaskQueue{Namespace: ns, TaskQueue: tc.taskQueue}))
-			nexusClient, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test-service"})
+			nexusClient, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test_service"})
 			s.NoError(err)
 
 			activeMetricsHandler, ok := s.cluster1.GetHost().GetMetricsHandler().(*metricstest.CaptureHandler)
@@ -299,7 +299,7 @@ func (s *NexusRequestForwardingSuite) TestCancelOperationForwardedFromStandbyToA
 		tc := tc
 		s.T().Run(tc.name, func(t *testing.T) {
 			dispatchURL := fmt.Sprintf("http://%s/%s", s.cluster2.GetHost().FrontendHTTPAddress(), cnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Path(cnexus.NamespaceAndTaskQueue{Namespace: ns, TaskQueue: tc.taskQueue}))
-			nexusClient, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test-service"})
+			nexusClient, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test_service"})
 			s.NoError(err)
 
 			activeMetricsHandler, ok := s.cluster1.GetHost().GetMetricsHandler().(*metricstest.CaptureHandler)
@@ -339,7 +339,7 @@ func (s *NexusRequestForwardingSuite) TestCompleteOperationForwardedFromStandbyT
 	ctx := tests.NewContext()
 	ns := s.createNexusRequestForwardingNamespace()
 	taskQueue := fmt.Sprintf("%v-%v", "test-task-queue", uuid.New())
-	endpointName := fmt.Sprintf("%v-%v", "test-endpoint", uuid.New())
+	endpointName := "test_complete_operation_forwarding_endpoint_name"
 
 	var callbackToken, publicCallbackUrl string
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Made the Nexus endpoint name validation regex more restrictive.

## Why?
<!-- Tell your future self why have you made these changes -->
Bug

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
