### PR TITLE
Fix local frontend HTTP client creation

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -521,7 +521,7 @@ type (
 		// HostPort is the host port to connect on. Host can be DNS name. See the above
 		// comment: in many situations you can leave this empty.
 		HostPort string `yaml:"hostPort"`
-		// HostPort is the HTTP host port to connect on. Host can be DNS name. See the above
+		// HTTPHostPort is the HTTP host port to connect on. Host can be DNS name. See the above
 		// comment: in many situations you can leave this empty.
 		HTTPHostPort string `yaml:"httpHostPort"`
 		// Force selection of either the "internode" or "frontend" TLS configs for these

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -521,6 +521,9 @@ type (
 		// HostPort is the host port to connect on. Host can be DNS name. See the above
 		// comment: in many situations you can leave this empty.
 		HostPort string `yaml:"hostPort"`
+		// HostPort is the HTTP host port to connect on. Host can be DNS name. See the above
+		// comment: in many situations you can leave this empty.
+		HTTPHostPort string `yaml:"httpHostPort"`
 		// Force selection of either the "internode" or "frontend" TLS configs for these
 		// connections (only those two strings are valid).
 		ForceTLSConfig string `yaml:"forceTLSConfig"`
@@ -607,7 +610,7 @@ func (c *Config) Validate() error {
 	}
 
 	_, hasIFE := c.Services[string(primitives.InternalFrontendService)]
-	if hasIFE && (c.PublicClient.HostPort != "" || c.PublicClient.ForceTLSConfig != "") {
+	if hasIFE && (c.PublicClient.HostPort != "" || c.PublicClient.ForceTLSConfig != "" || c.PublicClient.HTTPHostPort != "") {
 		return fmt.Errorf("when using internal-frontend, publicClient must be empty")
 	}
 

--- a/common/membership/grpc_resolver.go
+++ b/common/membership/grpc_resolver.go
@@ -61,7 +61,7 @@ func initializeBuilder(monitor Monitor) GRPCResolver {
 	return GRPCResolver{}
 }
 
-func (g *GRPCResolver) MakeURL(service primitives.ServiceName) string {
+func MakeResolverURL(service primitives.ServiceName) string {
 	return fmt.Sprintf("%s://%s", grpcResolverScheme, string(service))
 }
 

--- a/common/membership/grpc_resolver.go
+++ b/common/membership/grpc_resolver.go
@@ -36,8 +36,6 @@ import (
 	"go.temporal.io/server/common/primitives"
 )
 
-const grpcResolverScheme = "membership"
-
 // GRPCResolver is an empty type used to enforce a dependency using fx so that we're guaranteed to have initialized
 // the global builder before we use it.
 type GRPCResolver struct{}
@@ -61,16 +59,12 @@ func initializeBuilder(monitor Monitor) GRPCResolver {
 	return GRPCResolver{}
 }
 
-func MakeResolverURL(service primitives.ServiceName) string {
-	return fmt.Sprintf("%s://%s", grpcResolverScheme, string(service))
-}
-
 type grpcBuilder struct {
 	monitor atomic.Value // Monitor
 }
 
 func (m *grpcBuilder) Scheme() string {
-	return grpcResolverScheme
+	return ResolverScheme
 }
 
 func (m *grpcBuilder) Build(target resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions) (resolver.Resolver, error) {

--- a/common/membership/grpc_resolver_test.go
+++ b/common/membership/grpc_resolver_test.go
@@ -88,7 +88,7 @@ func TestGRPCBuilder(t *testing.T) {
 	resolverBuilder := &grpcBuilder{}
 	resolverBuilder.monitor.Store(monitor)
 
-	url := (&GRPCResolver{}).MakeURL(primitives.FrontendService)
+	url := MakeResolverURL(primitives.FrontendService)
 	assert.Equal(t, "membership://frontend", url)
 
 	// dialedAddress is the actual address that the gRPC framework dialed after resolving the URL using our resolver.

--- a/common/membership/resolver.go
+++ b/common/membership/resolver.go
@@ -1,0 +1,35 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package membership
+
+import (
+	"fmt"
+
+	"go.temporal.io/server/common/primitives"
+)
+
+const ResolverScheme = "membership"
+
+func MakeResolverURL(service primitives.ServiceName) string {
+	return fmt.Sprintf("%s://%s", ResolverScheme, string(service))
+}

--- a/common/rpc.go
+++ b/common/rpc.go
@@ -26,18 +26,31 @@ package common
 
 import (
 	"net"
+	"net/http"
 
 	"google.golang.org/grpc"
 )
 
-type (
-	// RPCFactory creates gRPC listener and connection.
-	RPCFactory interface {
-		GetFrontendGRPCServerOptions() ([]grpc.ServerOption, error)
-		GetInternodeGRPCServerOptions() ([]grpc.ServerOption, error)
-		GetGRPCListener() net.Listener
-		CreateRemoteFrontendGRPCConnection(rpcAddress string) *grpc.ClientConn
-		CreateLocalFrontendGRPCConnection() *grpc.ClientConn
-		CreateInternodeGRPCConnection(rpcAddress string) *grpc.ClientConn
-	}
-)
+// RPCFactory creates gRPC listeners and connections, and frontend HTTP clients.
+type RPCFactory interface {
+	GetFrontendGRPCServerOptions() ([]grpc.ServerOption, error)
+	GetInternodeGRPCServerOptions() ([]grpc.ServerOption, error)
+	GetGRPCListener() net.Listener
+	CreateRemoteFrontendGRPCConnection(rpcAddress string) *grpc.ClientConn
+	CreateLocalFrontendGRPCConnection() *grpc.ClientConn
+	CreateInternodeGRPCConnection(rpcAddress string) *grpc.ClientConn
+	CreateLocalFrontendHTTPClient() (*FrontendHTTPClient, error)
+}
+
+type FrontendHTTPClient struct {
+	http.Client
+	// Address is the host:port pair of this HTTP client.
+	Address string
+	// Scheme is the URL scheme of this HTTP client.
+	Scheme string
+}
+
+// BaseURL is the scheme and address of this HTTP client.
+func (c *FrontendHTTPClient) BaseURL() string {
+	return c.Scheme + "://" + c.Address
+}

--- a/common/rpc/rpc.go
+++ b/common/rpc/rpc.go
@@ -344,7 +344,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func extractServiceFromURL(ustr string) (primitives.ServiceName, error) {
-	if !strings.HasPrefix(ustr, "membership://") {
+	if !strings.HasPrefix(ustr, membership.ResolverScheme+"://") {
 		return "", nil
 	}
 	u, err := url.Parse(ustr)

--- a/common/rpc/rpc.go
+++ b/common/rpc/rpc.go
@@ -26,17 +26,25 @@ package rpc
 
 import (
 	"crypto/tls"
+	"fmt"
+	"math/rand"
 	"net"
+	"net/http"
+	"net/url"
+	"strings"
 	"sync"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/environment"
@@ -51,12 +59,16 @@ type RPCFactory struct {
 	logger      log.Logger
 
 	frontendURL       string
+	frontendHTTPURL   string
 	frontendTLSConfig *tls.Config
 
 	initListener       sync.Once
 	grpcListener       net.Listener
 	tlsFactory         encryption.TLSConfigProvider
 	clientInterceptors []grpc.UnaryClientInterceptor
+	monitor            membership.Monitor
+	// A OnceValues wrapper for createLocalFrontendHTTPClient.
+	localFrontendClient func() (*common.FrontendHTTPClient, error)
 }
 
 // NewFactory builds a new RPCFactory
@@ -67,18 +79,24 @@ func NewFactory(
 	logger log.Logger,
 	tlsProvider encryption.TLSConfigProvider,
 	frontendURL string,
+	frontendHTTPURL string,
 	frontendTLSConfig *tls.Config,
 	clientInterceptors []grpc.UnaryClientInterceptor,
+	monitor membership.Monitor,
 ) *RPCFactory {
-	return &RPCFactory{
+	f := &RPCFactory{
 		config:             cfg,
 		serviceName:        sName,
 		logger:             logger,
 		frontendURL:        frontendURL,
+		frontendHTTPURL:    frontendHTTPURL,
 		frontendTLSConfig:  frontendTLSConfig,
 		tlsFactory:         tlsProvider,
 		clientInterceptors: clientInterceptors,
+		monitor:            monitor,
 	}
+	f.localFrontendClient = sync.OnceValues(f.createLocalFrontendHTTPClient)
+	return f
 }
 
 func (d *RPCFactory) GetFrontendGRPCServerOptions() ([]grpc.ServerOption, error) {
@@ -234,4 +252,104 @@ func (d *RPCFactory) dial(hostName string, tlsClientConfig *tls.Config) *grpc.Cl
 
 func (d *RPCFactory) GetTLSConfigProvider() encryption.TLSConfigProvider {
 	return d.tlsFactory
+}
+
+// CreateLocalFrontendHTTPClient gets or creates a cached frontend client.
+func (d *RPCFactory) CreateLocalFrontendHTTPClient() (*common.FrontendHTTPClient, error) {
+	return d.localFrontendClient()
+}
+
+// createLocalFrontendHTTPClient creates an HTTP client for communicating with the frontend.
+// It uses either the provided frontendURL or membership to resolve the frontend address.
+func (d *RPCFactory) createLocalFrontendHTTPClient() (*common.FrontendHTTPClient, error) {
+	// dialer and transport field values copied from http.DefaultTransport.
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	client := http.Client{}
+
+	// Default to http unless TLS is configured.
+	scheme := "http"
+	if d.frontendTLSConfig != nil {
+		transport.TLSClientConfig = d.frontendTLSConfig
+		scheme = "https"
+	}
+
+	var address string
+	service, err := extractServiceFromURL(d.frontendHTTPURL)
+	if err != nil {
+		return nil, err
+	}
+	if service != "" {
+		// The URL instructs us to resolve via membership for frontend or internal-frontend.
+		r, err := d.monitor.GetResolver(primitives.ServiceName(service))
+		if err != nil {
+			return nil, err
+		}
+		client.Transport = &roundTripper{
+			resolver:   r,
+			underlying: transport,
+			config:     d.config,
+		}
+		address = "internal" // This will be replaced by the roundTripper
+	} else {
+		// Use the URL as-is and leave the transport unmodified.
+		client.Transport = transport
+		address = d.frontendHTTPURL
+	}
+
+	return &common.FrontendHTTPClient{
+		Client:  client,
+		Address: address,
+		Scheme:  scheme,
+	}, nil
+}
+
+type roundTripper struct {
+	resolver   membership.ServiceResolver
+	underlying http.RoundTripper
+	config     *config.RPC
+}
+
+func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Pick a frontend host at random.
+	members := rt.resolver.AvailableMembers()
+	if len(members) == 0 {
+		return nil, serviceerror.NewUnavailable("no frontend host to route request to")
+	}
+	idx := rand.Intn(len(members))
+	member := members[idx]
+
+	// Replace port with the HTTP port.
+	host, _, err := net.SplitHostPort(member.Identity())
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract port from frontend member: %w", err)
+	}
+	address := fmt.Sprintf("%s:%d", host, rt.config.HTTPPort)
+
+	// Replace request's host.
+	req.URL.Host = address
+	req.Host = address
+	return rt.underlying.RoundTrip(req)
+}
+
+func extractServiceFromURL(ustr string) (primitives.ServiceName, error) {
+	if !strings.HasPrefix(ustr, "membership://") {
+		return "", nil
+	}
+	u, err := url.Parse(ustr)
+	if err != nil {
+		return "", nil
+	}
+	return primitives.ServiceName(u.Host), nil
 }

--- a/common/rpc/test/http_test.go
+++ b/common/rpc/test/http_test.go
@@ -1,0 +1,136 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rpc
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/membership"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/rpc"
+	"google.golang.org/grpc"
+)
+
+func TestCreateLocalFrontendHTTPClient_UsingMembership(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	monitor := membership.NewMockMonitor(ctrl)
+	resolver := membership.NewMockServiceResolver(ctrl)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+	addr := srv.Listener.Addr()
+	_, portStr, err := net.SplitHostPort(addr.String())
+	require.NoError(t, err)
+	port, err := strconv.ParseInt(portStr, 10, 64)
+	require.NoError(t, err)
+	monitor.EXPECT().GetResolver(primitives.FrontendService).Return(resolver, nil)
+	resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{membership.NewHostInfoFromAddress(addr.String())})
+
+	fact := rpc.NewFactory(
+		&config.RPC{HTTPPort: int(port)},
+		primitives.HistoryService,
+		nil, // No logger
+		nil,
+		membership.MakeResolverURL(primitives.FrontendService),
+		membership.MakeResolverURL(primitives.FrontendService),
+		nil, // No TLS
+		[]grpc.UnaryClientInterceptor{},
+		monitor,
+	)
+
+	client, err := fact.CreateLocalFrontendHTTPClient()
+	require.NoError(t, err)
+	require.Equal(t, "internal", client.Address)
+	require.Equal(t, "http", client.Scheme)
+	res, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func TestCreateLocalFrontendHTTPClient_UsingFixedHostPort(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+	addr := srv.Listener.Addr()
+
+	fact := rpc.NewFactory(
+		nil, // unused
+		primitives.HistoryService,
+		nil, // No logger
+		nil,
+		membership.MakeResolverURL(primitives.FrontendService),
+		addr.String(),
+		nil, // No TLS
+		[]grpc.UnaryClientInterceptor{},
+		nil, // monitor should not be used
+	)
+
+	client, err := fact.CreateLocalFrontendHTTPClient()
+	require.NoError(t, err)
+	require.Equal(t, addr.String(), client.Address)
+	require.Equal(t, "http", client.Scheme)
+	res, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func TestCreateLocalFrontendHTTPClient_UsingFixedHostPort_AndTLS(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+	addr := srv.Listener.Addr()
+	tlsConfig := srv.Client().Transport.(*http.Transport).TLSClientConfig
+
+	fact := rpc.NewFactory(
+		nil, // unused
+		primitives.HistoryService,
+		nil, // No logger
+		nil,
+		membership.MakeResolverURL(primitives.FrontendService),
+		addr.String(),
+		tlsConfig,
+		[]grpc.UnaryClientInterceptor{},
+		nil, // monitor should not be used
+	)
+
+	client, err := fact.CreateLocalFrontendHTTPClient()
+	require.NoError(t, err)
+	require.Equal(t, addr.String(), client.Address)
+	require.Equal(t, "https", client.Scheme)
+	res, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+}

--- a/common/rpc/test/rpc_localstore_tls_test.go
+++ b/common/rpc/test/rpc_localstore_tls_test.go
@@ -52,6 +52,7 @@ const (
 
 var (
 	frontendURL         = "dummy://" // not needed for test
+	frontendHTTPURL         = "dummy://" // not needed for test
 	noExtraInterceptors = []grpc.UnaryClientInterceptor{}
 )
 
@@ -136,7 +137,7 @@ func (s *localStoreRPCSuite) SetupSuite() {
 
 	provider, err := encryption.NewTLSConfigProviderFromConfig(serverCfgInsecure.TLS, metrics.NoopMetricsHandler, s.logger, nil)
 	s.NoError(err)
-	insecureFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, nil, noExtraInterceptors)
+	insecureFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, frontendHTTPURL, nil, noExtraInterceptors, nil)
 	s.NotNil(insecureFactory)
 	s.insecureRPCFactory = i(insecureFactory)
 
@@ -346,26 +347,26 @@ func (s *localStoreRPCSuite) setupFrontend() {
 	s.NoError(err)
 	tlsConfig, err := provider.GetFrontendClientConfig()
 	s.NoError(err)
-	frontendMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, tlsConfig, noExtraInterceptors)
+	frontendMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, frontendHTTPURL, tlsConfig, noExtraInterceptors, nil)
 	s.NotNil(frontendMutualTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreServerTLS.TLS, metrics.NoopMetricsHandler, s.logger, nil)
 	s.NoError(err)
-	frontendServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, nil, noExtraInterceptors)
+	frontendServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, frontendHTTPURL, nil, noExtraInterceptors, nil)
 	s.NotNil(frontendServerTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSSystemWorker.TLS, metrics.NoopMetricsHandler, s.logger, nil)
 	s.NoError(err)
 	tlsConfig, err = provider.GetFrontendClientConfig()
 	s.NoError(err)
-	frontendSystemWorkerMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, tlsConfig, noExtraInterceptors)
+	frontendSystemWorkerMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, frontendHTTPURL, tlsConfig, noExtraInterceptors, nil)
 	s.NotNil(frontendSystemWorkerMutualTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSWithRefresh.TLS, metrics.NoopMetricsHandler, s.logger, nil)
 	s.NoError(err)
 	tlsConfig, err = provider.GetFrontendClientConfig()
 	s.NoError(err)
-	frontendMutualTLSRefreshFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, tlsConfig, noExtraInterceptors)
+	frontendMutualTLSRefreshFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, frontendHTTPURL, tlsConfig, noExtraInterceptors, nil)
 	s.NotNil(frontendMutualTLSRefreshFactory)
 
 	s.frontendMutualTLSRPCFactory = f(frontendMutualTLSFactory)
@@ -382,7 +383,7 @@ func (s *localStoreRPCSuite) setupFrontend() {
 	s.NoError(err)
 	tlsConfig, err = s.dynamicConfigProvider.GetFrontendClientConfig()
 	s.NoError(err)
-	dynamicServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, s.dynamicConfigProvider, frontendURL, tlsConfig, noExtraInterceptors)
+	dynamicServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, s.dynamicConfigProvider, frontendURL, frontendHTTPURL, tlsConfig, noExtraInterceptors, nil)
 	s.frontendDynamicTLSFactory = f(dynamicServerTLSFactory)
 	s.internodeDynamicTLSFactory = i(dynamicServerTLSFactory)
 
@@ -392,7 +393,7 @@ func (s *localStoreRPCSuite) setupFrontend() {
 	s.NoError(err)
 	tlsConfig, err = provider.GetFrontendClientConfig()
 	s.NoError(err)
-	frontendRootCAForceTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, tlsConfig, noExtraInterceptors)
+	frontendRootCAForceTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, frontendHTTPURL, tlsConfig, noExtraInterceptors, nil)
 	s.NotNil(frontendServerTLSFactory)
 	s.frontendConfigRootCAForceTLSFactory = f(frontendRootCAForceTLSFactory)
 
@@ -400,7 +401,7 @@ func (s *localStoreRPCSuite) setupFrontend() {
 	s.NoError(err)
 	tlsConfig, err = provider.GetFrontendClientConfig()
 	s.NoError(err)
-	remoteClusterMutualTLSRPCFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, tlsConfig, noExtraInterceptors)
+	remoteClusterMutualTLSRPCFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, frontendHTTPURL, tlsConfig, noExtraInterceptors, nil)
 	s.NotNil(remoteClusterMutualTLSRPCFactory)
 	s.remoteClusterMutualTLSRPCFactory = r(remoteClusterMutualTLSRPCFactory)
 }
@@ -438,28 +439,28 @@ func (s *localStoreRPCSuite) setupInternode() {
 	s.NoError(err)
 	tlsConfig, err := provider.GetFrontendClientConfig()
 	s.NoError(err)
-	internodeMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, tlsConfig, noExtraInterceptors)
+	internodeMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, frontendHTTPURL, tlsConfig, noExtraInterceptors, nil)
 	s.NotNil(internodeMutualTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreServerTLS.TLS, metrics.NoopMetricsHandler, s.logger, nil)
 	s.NoError(err)
 	tlsConfig, err = provider.GetFrontendClientConfig()
 	s.NoError(err)
-	internodeServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, tlsConfig, noExtraInterceptors)
+	internodeServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, frontendHTTPURL, tlsConfig, noExtraInterceptors, nil)
 	s.NotNil(internodeServerTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreAltMutualTLS.TLS, metrics.NoopMetricsHandler, s.logger, nil)
 	s.NoError(err)
 	tlsConfig, err = provider.GetFrontendClientConfig()
 	s.NoError(err)
-	internodeMutualAltTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, tlsConfig, noExtraInterceptors)
+	internodeMutualAltTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, frontendHTTPURL, tlsConfig, noExtraInterceptors, nil)
 	s.NotNil(internodeMutualAltTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSWithRefresh.TLS, metrics.NoopMetricsHandler, s.logger, nil)
 	s.NoError(err)
 	tlsConfig, err = provider.GetFrontendClientConfig()
 	s.NoError(err)
-	internodeMutualTLSRefreshFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, tlsConfig, noExtraInterceptors)
+	internodeMutualTLSRefreshFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, frontendURL, frontendHTTPURL, tlsConfig, noExtraInterceptors, nil)
 	s.NotNil(internodeMutualTLSRefreshFactory)
 
 	s.internodeMutualTLSRPCFactory = i(internodeMutualTLSFactory)

--- a/internal/nettest/rpc_factory.go
+++ b/internal/nettest/rpc_factory.go
@@ -81,6 +81,10 @@ func (f *RPCFactory) CreateLocalFrontendGRPCConnection() *grpc.ClientConn {
 	return f.dial(f.listener.Addr().String())
 }
 
+func (f *RPCFactory) CreateLocalFrontendHTTPClient() (*common.FrontendHTTPClient, error) {
+	panic("unimplemented in the nettest package")
+}
+
 func (f *RPCFactory) CreateInternodeGRPCConnection(rpcAddress string) *grpc.ClientConn {
 	return f.dial(rpcAddress)
 }


### PR DESCRIPTION
## What changed?

Fixed the mechanism to get a local frontend HTTP client to use a similar approach to getting a gRPC client.
Now we'll use a dedicated user provided config or default to membership lookup.

## How did you test it?

Added unit tests and ran existing functional tests.