### PR TITLE
Check ownership of nexus endpoints table in matching

### DIFF
--- a/common/nexus/endpoint_registry.go
+++ b/common/nexus/endpoint_registry.go
@@ -272,7 +272,7 @@ func (r *EndpointRegistryImpl) refreshEndpoints(ctx context.Context) error {
 	entries := resp.Entries
 
 	currentPageToken := resp.NextPageToken
-	for currentPageToken != nil {
+	for len(currentPageToken) != 0 {
 		resp, err = r.matchingClient.ListNexusEndpoints(ctx, &matchingservice.ListNexusEndpointsRequest{
 			NextPageToken:         currentPageToken,
 			PageSize:              int32(r.config.refreshPageSize()),

--- a/common/tqid/task_queue_id.go
+++ b/common/tqid/task_queue_id.go
@@ -187,6 +187,14 @@ func NormalPartitionFromRpcName(rpcName string, namespaceId string, taskType enu
 	return tq.NormalPartition(partition), nil
 }
 
+func MustNormalPartitionFromRpcName(rpcName string, namespaceId string, taskType enumspb.TaskQueueType) *NormalPartition {
+	p, err := NormalPartitionFromRpcName(rpcName, namespaceId, taskType)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
 func (n *TaskQueueFamily) Name() string {
 	return n.name
 }

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -120,27 +120,28 @@ type (
 
 	// Implements matching.Engine
 	matchingEngineImpl struct {
-		status              int32
-		taskManager         persistence.TaskManager
-		historyClient       resource.HistoryClient
-		matchingRawClient   resource.MatchingRawClient
-		tokenSerializer     common.TaskTokenSerializer
-		historySerializer   serialization.Serializer
-		logger              log.Logger
-		throttledLogger     log.ThrottledLogger
-		namespaceRegistry   namespace.Registry
-		hostInfoProvider    membership.HostInfoProvider
-		serviceResolver     membership.ServiceResolver
-		membershipChangedCh chan *membership.ChangedEvent
-		clusterMeta         cluster.Metadata
-		timeSource          clock.TimeSource
-		visibilityManager   manager.VisibilityManager
-		nexusEndpointClient *nexusEndpointClient
-		metricsHandler      metrics.Handler
-		partitionsLock      sync.RWMutex // locks mutation of partitions
-		partitions          map[tqid.PartitionKey]taskQueuePartitionManager
-		gaugeMetrics        gaugeMetrics // per-namespace task queue counters
-		config              *Config
+		status                        int32
+		taskManager                   persistence.TaskManager
+		historyClient                 resource.HistoryClient
+		matchingRawClient             resource.MatchingRawClient
+		tokenSerializer               common.TaskTokenSerializer
+		historySerializer             serialization.Serializer
+		logger                        log.Logger
+		throttledLogger               log.ThrottledLogger
+		namespaceRegistry             namespace.Registry
+		hostInfoProvider              membership.HostInfoProvider
+		serviceResolver               membership.ServiceResolver
+		membershipChangedCh           chan *membership.ChangedEvent
+		clusterMeta                   cluster.Metadata
+		timeSource                    clock.TimeSource
+		visibilityManager             manager.VisibilityManager
+		nexusEndpointClient           *nexusEndpointClient
+		nexusEndpointsOwnershipLostCh chan struct{}
+		metricsHandler                metrics.Handler
+		partitionsLock                sync.RWMutex // locks mutation of partitions
+		partitions                    map[tqid.PartitionKey]taskQueuePartitionManager
+		gaugeMetrics                  gaugeMetrics // per-namespace task queue counters
+		config                        *Config
 		// queryResults maps query TaskID (which is a UUID generated in QueryWorkflow() call) to a channel
 		// that QueryWorkflow() will block on. The channel is unblocked either by worker sending response through
 		// RespondQueryTaskCompleted() or through an internal service error causing temporal to be unable to dispatch
@@ -177,6 +178,9 @@ var (
 
 	pollerIDKey pollerIDCtxKey = "pollerID"
 	identityKey identityCtxKey = "identity"
+
+	// The routing key for the single partition used to route Nexus endpoints CRUD RPCs to.
+	nexusEndpointsTablePartitionRoutingKey = tqid.MustNormalPartitionFromRpcName("not-applicable", "not-applicable", enumspb.TASK_QUEUE_TYPE_UNSPECIFIED).RoutingKey()
 )
 
 var _ Engine = (*matchingEngineImpl)(nil) // Asserts that interface is indeed implemented
@@ -200,24 +204,25 @@ func NewEngine(
 ) Engine {
 	scopedMetricsHandler := metricsHandler.WithTags(metrics.OperationTag(metrics.MatchingEngineScope))
 	e := &matchingEngineImpl{
-		status:              common.DaemonStatusInitialized,
-		taskManager:         taskManager,
-		historyClient:       historyClient,
-		matchingRawClient:   matchingRawClient,
-		tokenSerializer:     common.NewProtoTaskTokenSerializer(),
-		historySerializer:   serialization.NewSerializer(),
-		logger:              log.With(logger, tag.ComponentMatchingEngine),
-		throttledLogger:     log.With(throttledLogger, tag.ComponentMatchingEngine),
-		namespaceRegistry:   namespaceRegistry,
-		hostInfoProvider:    hostInfoProvider,
-		serviceResolver:     resolver,
-		membershipChangedCh: make(chan *membership.ChangedEvent, 1), // allow one signal to be buffered while we're working
-		clusterMeta:         clusterMeta,
-		timeSource:          clock.NewRealTimeSource(), // No need to mock this at the moment
-		visibilityManager:   visibilityManager,
-		nexusEndpointClient: newEndpointClient(nexusEndpointManager),
-		metricsHandler:      scopedMetricsHandler,
-		partitions:          make(map[tqid.PartitionKey]taskQueuePartitionManager),
+		status:                        common.DaemonStatusInitialized,
+		taskManager:                   taskManager,
+		historyClient:                 historyClient,
+		matchingRawClient:             matchingRawClient,
+		tokenSerializer:               common.NewProtoTaskTokenSerializer(),
+		historySerializer:             serialization.NewSerializer(),
+		logger:                        log.With(logger, tag.ComponentMatchingEngine),
+		throttledLogger:               log.With(throttledLogger, tag.ComponentMatchingEngine),
+		namespaceRegistry:             namespaceRegistry,
+		hostInfoProvider:              hostInfoProvider,
+		serviceResolver:               resolver,
+		membershipChangedCh:           make(chan *membership.ChangedEvent, 1), // allow one signal to be buffered while we're working
+		clusterMeta:                   clusterMeta,
+		timeSource:                    clock.NewRealTimeSource(), // No need to mock this at the moment
+		visibilityManager:             visibilityManager,
+		nexusEndpointClient:           newEndpointClient(nexusEndpointManager),
+		nexusEndpointsOwnershipLostCh: make(chan struct{}),
+		metricsHandler:                scopedMetricsHandler,
+		partitions:                    make(map[tqid.PartitionKey]taskQueuePartitionManager),
 		gaugeMetrics: gaugeMetrics{
 			loadedTaskQueueFamilyCount:    make(map[taskQueueCounterKey]int),
 			loadedTaskQueueCount:          make(map[taskQueueCounterKey]int),
@@ -281,6 +286,8 @@ func (e *matchingEngineImpl) watchMembership() {
 		if delay == 0 {
 			continue
 		}
+
+		e.notifyIfNexusEndpointsOwnershipLost()
 
 		// Check all our loaded partitions to see if we lost ownership of any of them.
 		e.partitionsLock.RLock()
@@ -1747,7 +1754,7 @@ func (e *matchingEngineImpl) RespondNexusTaskCompleted(ctx context.Context, requ
 	resultCh, ok := e.nexusResults.Pop(request.GetTaskId())
 	if !ok {
 		opMetrics.Counter(metrics.RespondNexusTaskFailedPerTaskQueueCounter.Name()).Record(1)
-		return nil, serviceerror.NewNotFound("nexus task not found or already expired")
+		return nil, serviceerror.NewNotFound("Nexus task not found or already expired")
 	}
 	resultCh <- &nexusResult{
 		successfulWorkerResponse: request,
@@ -1760,7 +1767,7 @@ func (e *matchingEngineImpl) RespondNexusTaskFailed(ctx context.Context, request
 	resultCh, ok := e.nexusResults.Pop(request.GetTaskId())
 	if !ok {
 		opMetrics.Counter(metrics.RespondNexusTaskFailedPerTaskQueueCounter.Name()).Record(1)
-		return nil, serviceerror.NewNotFound("nexus task not found or already expired")
+		return nil, serviceerror.NewNotFound("Nexus task not found or already expired")
 	}
 	resultCh <- &nexusResult{
 		failedWorkerResponse: request,
@@ -1770,29 +1777,60 @@ func (e *matchingEngineImpl) RespondNexusTaskFailed(ctx context.Context, request
 }
 
 func (e *matchingEngineImpl) CreateNexusEndpoint(ctx context.Context, request *matchingservice.CreateNexusEndpointRequest) (*matchingservice.CreateNexusEndpointResponse, error) {
-	return e.nexusEndpointClient.CreateNexusEndpoint(ctx, &internalCreateNexusEndpointRequest{
+	// Write API, let persistence verify table ownership.
+	res, err := e.nexusEndpointClient.CreateNexusEndpoint(ctx, &internalCreateNexusEndpointRequest{
 		spec:       request.GetSpec(),
 		clusterID:  e.clusterMeta.GetClusterID(),
 		timeSource: e.timeSource,
 	})
+	if err != nil {
+		e.logger.Error("Failed to create Nexus endpoint", tag.Error(err), tag.Endpoint(request.GetSpec().GetName()))
+	} else {
+		e.logger.Info("Created Nexus endpoint", tag.Endpoint(request.GetSpec().GetName()))
+	}
+	return res, err
 }
 
 func (e *matchingEngineImpl) UpdateNexusEndpoint(ctx context.Context, request *matchingservice.UpdateNexusEndpointRequest) (*matchingservice.UpdateNexusEndpointResponse, error) {
-	return e.nexusEndpointClient.UpdateNexusEndpoint(ctx, &internalUpdateNexusEndpointRequest{
+	// Write API, let persistence verify table ownership.
+	res, err := e.nexusEndpointClient.UpdateNexusEndpoint(ctx, &internalUpdateNexusEndpointRequest{
 		endpointID: request.GetId(),
 		version:    request.GetVersion(),
 		spec:       request.GetSpec(),
 		clusterID:  e.clusterMeta.GetClusterID(),
 		timeSource: e.timeSource,
 	})
+	if err != nil {
+		e.logger.Error("Failed to update Nexus endpoint", tag.Error(err), tag.Endpoint(request.GetSpec().GetName()))
+	} else {
+		e.logger.Info("Updated Nexus endpoint", tag.Endpoint(request.GetSpec().GetName()))
+	}
+	return res, err
 }
 
 func (e *matchingEngineImpl) DeleteNexusEndpoint(ctx context.Context, request *matchingservice.DeleteNexusEndpointRequest) (*matchingservice.DeleteNexusEndpointResponse, error) {
-	return e.nexusEndpointClient.DeleteNexusEndpoint(ctx, request)
+	// Write API, let persistence verify table ownership.
+	res, err := e.nexusEndpointClient.DeleteNexusEndpoint(ctx, request)
+	if err != nil {
+		e.logger.Error("Failed to delete Nexus endpoint", tag.Error(err), tag.Endpoint(request.GetId()))
+	} else {
+		e.logger.Info("Deleted Nexus endpoint", tag.Endpoint(request.GetId()))
+	}
+	return res, err
 }
 
 func (e *matchingEngineImpl) ListNexusEndpoints(ctx context.Context, request *matchingservice.ListNexusEndpointsRequest) (*matchingservice.ListNexusEndpointsResponse, error) {
 	lastKnownVersion := request.LastKnownTableVersion
+	// Read API, verify table ownership via membership.
+	isOwner, err := e.checkNexusEndpointsOwnership()
+	if err != nil {
+		e.logger.Error("Failed to check Nexus endpoints ownerhip", tag.Error(err))
+		return nil, serviceerror.NewFailedPrecondition(fmt.Sprintf("cannot verify ownership of Nexus endpoints table: %v", err))
+	}
+	if !isOwner {
+		e.logger.Error("Matching node doesn't think it's the Nexus endpoints table owner", tag.Error(err))
+		return nil, serviceerror.NewFailedPrecondition("matching node doesn't think it's the Nexus endpoints table owner")
+	}
 
 	if request.Wait {
 		if request.NextPageToken != nil {
@@ -1816,6 +1854,8 @@ func (e *matchingEngineImpl) ListNexusEndpoints(ctx context.Context, request *ma
 		if request.Wait && lastKnownVersion == resp.TableVersion {
 			// long-poll: wait for data to change/appear
 			select {
+			case <-e.nexusEndpointsOwnershipLostCh:
+				return nil, serviceerror.NewFailedPrecondition("Nexus endpoints table ownership lost")
 			case <-ctx.Done():
 				return resp, nil
 			case <-tableVersionChanged:
@@ -1824,6 +1864,28 @@ func (e *matchingEngineImpl) ListNexusEndpoints(ctx context.Context, request *ma
 		}
 
 		return resp, err
+	}
+}
+
+func (e *matchingEngineImpl) checkNexusEndpointsOwnership() (bool, error) {
+	self := e.hostInfoProvider.HostInfo().Identity()
+	owner, err := e.serviceResolver.Lookup(nexusEndpointsTablePartitionRoutingKey)
+	if err != nil {
+		return false, fmt.Errorf("cannot resolve Nexus endpoints partition owner: %w", err)
+	}
+	return owner.Identity() == self, nil
+}
+
+func (e *matchingEngineImpl) notifyIfNexusEndpointsOwnershipLost() {
+	isOwner, err := e.checkNexusEndpointsOwnership()
+	if err != nil {
+		e.logger.Error("Failed to check Nexus endpoints ownerhip", tag.Error(err))
+		return
+	}
+	if !isOwner {
+		ch := e.nexusEndpointsOwnershipLostCh
+		e.nexusEndpointsOwnershipLostCh = make(chan struct{})
+		close(ch)
 	}
 }
 

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3100,11 +3100,11 @@ func (s *matchingEngineSuite) TestLargerBacklogAge() {
 }
 
 func (s *matchingEngineSuite) TestCheckNexusEndpointsOwnership() {
-	isOwner, err := s.matchingEngine.checkNexusEndpointsOwnership()
+	isOwner, _, err := s.matchingEngine.checkNexusEndpointsOwnership()
 	s.NoError(err)
 	s.True(isOwner)
 	s.hostInfoForResolver = membership.NewHostInfoFromAddress("other")
-	isOwner, err = s.matchingEngine.checkNexusEndpointsOwnership()
+	isOwner, _, err = s.matchingEngine.checkNexusEndpointsOwnership()
 	s.NoError(err)
 	s.False(isOwner)
 }

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -102,6 +102,7 @@ type (
 		mockVisibilityManager *manager.MockVisibilityManager
 		mockHostInfoProvider  *membership.MockHostInfoProvider
 		mockServiceResolver   *membership.MockServiceResolver
+		hostInfoForResolver   membership.HostInfo
 
 		matchingEngine *matchingEngineImpl
 		taskManager    *testTaskManager
@@ -118,7 +119,8 @@ func createTestMatchingEngine(
 	controller *gomock.Controller,
 	config *Config,
 	matchingClient matchingservice.MatchingServiceClient,
-	namespaceRegistry namespace.Registry) *matchingEngineImpl {
+	namespaceRegistry namespace.Registry,
+) *matchingEngineImpl {
 	logger := log.NewTestLogger()
 	tm := newTestTaskManager(logger)
 	mockVisibilityManager := manager.NewMockVisibilityManager(controller)
@@ -175,9 +177,12 @@ func (s *matchingEngineSuite) SetupTest() {
 	s.mockVisibilityManager.EXPECT().Close().AnyTimes()
 	s.mockHostInfoProvider = membership.NewMockHostInfoProvider(s.controller)
 	hostInfo := membership.NewHostInfoFromAddress("self")
+	s.hostInfoForResolver = hostInfo
 	s.mockHostInfoProvider.EXPECT().HostInfo().Return(hostInfo).AnyTimes()
 	s.mockServiceResolver = membership.NewMockServiceResolver(s.controller)
-	s.mockServiceResolver.EXPECT().Lookup(gomock.Any()).Return(hostInfo, nil).AnyTimes()
+	s.mockServiceResolver.EXPECT().Lookup(gomock.Any()).DoAndReturn(func(string) (membership.HostInfo, error) {
+		return s.hostInfoForResolver, nil
+	}).AnyTimes()
 	s.mockServiceResolver.EXPECT().AddListener(gomock.Any(), gomock.Any()).AnyTimes()
 	s.mockServiceResolver.EXPECT().RemoveListener(gomock.Any()).AnyTimes()
 
@@ -212,20 +217,21 @@ func newMatchingEngine(
 			loadedTaskQueuePartitionCount: make(map[taskQueueCounterKey]int),
 			loadedPhysicalTaskQueueCount:  make(map[taskQueueCounterKey]int),
 		},
-		queryResults:        collection.NewSyncMap[string, chan *queryResult](),
-		logger:              logger,
-		throttledLogger:     log.ThrottledLogger(logger),
-		metricsHandler:      metrics.NoopMetricsHandler,
-		matchingRawClient:   mockMatchingClient,
-		tokenSerializer:     common.NewProtoTaskTokenSerializer(),
-		config:              config,
-		namespaceRegistry:   mockNamespaceCache,
-		hostInfoProvider:    mockHostInfoProvider,
-		serviceResolver:     mockServiceResolver,
-		membershipChangedCh: make(chan *membership.ChangedEvent, 1),
-		clusterMeta:         clustertest.NewMetadataForTest(cluster.NewTestClusterMetadataConfig(false, true)),
-		timeSource:          clock.NewRealTimeSource(),
-		visibilityManager:   mockVisibilityManager,
+		queryResults:                  collection.NewSyncMap[string, chan *queryResult](),
+		logger:                        logger,
+		throttledLogger:               log.ThrottledLogger(logger),
+		metricsHandler:                metrics.NoopMetricsHandler,
+		matchingRawClient:             mockMatchingClient,
+		tokenSerializer:               common.NewProtoTaskTokenSerializer(),
+		config:                        config,
+		namespaceRegistry:             mockNamespaceCache,
+		hostInfoProvider:              mockHostInfoProvider,
+		serviceResolver:               mockServiceResolver,
+		membershipChangedCh:           make(chan *membership.ChangedEvent, 1),
+		clusterMeta:                   clustertest.NewMetadataForTest(cluster.NewTestClusterMetadataConfig(false, true)),
+		timeSource:                    clock.NewRealTimeSource(),
+		visibilityManager:             mockVisibilityManager,
+		nexusEndpointsOwnershipLostCh: make(chan struct{}),
 	}
 }
 
@@ -2527,6 +2533,8 @@ func (s *matchingEngineSuite) TestUnloadOnMembershipChange() {
 
 	s.Equal(2, len(e.getTaskQueuePartitions(1000)))
 
+	s.mockServiceResolver.EXPECT().Lookup(nexusEndpointsTablePartitionRoutingKey).Return(self, nil).AnyTimes()
+
 	// signal membership changed and give time for loop to wake up
 	s.mockServiceResolver.EXPECT().Lookup(p1.RoutingKey()).Return(self, nil)
 	s.mockServiceResolver.EXPECT().Lookup(p2.RoutingKey()).Return(self, nil)
@@ -3089,6 +3097,30 @@ func (s *matchingEngineSuite) TestLargerBacklogAge() {
 	thirdAge := durationpb.New(5 * time.Minute)
 	s.Same(thirdAge, largerBacklogAge(firstAge, thirdAge))
 	s.Same(thirdAge, largerBacklogAge(secondAge, thirdAge))
+}
+
+func (s *matchingEngineSuite) TestCheckNexusEndpointsOwnership() {
+	isOwner, err := s.matchingEngine.checkNexusEndpointsOwnership()
+	s.NoError(err)
+	s.True(isOwner)
+	s.hostInfoForResolver = membership.NewHostInfoFromAddress("other")
+	isOwner, err = s.matchingEngine.checkNexusEndpointsOwnership()
+	s.NoError(err)
+	s.False(isOwner)
+}
+
+func (s *matchingEngineSuite) TestNotifyNexusEndpointsOwnershipLost() {
+	ch := s.matchingEngine.nexusEndpointsOwnershipLostCh
+	s.matchingEngine.notifyIfNexusEndpointsOwnershipLost()
+	select {
+	case <-ch:
+		s.Fail("expected nexusEndpointsOwnershipLost channel to not have been closed")
+	default:
+	}
+	s.hostInfoForResolver = membership.NewHostInfoFromAddress("other")
+	s.matchingEngine.notifyIfNexusEndpointsOwnershipLost()
+	<-ch
+	// If the channel is unblocked the test passed.
 }
 
 func (s *matchingEngineSuite) setupRecordActivityTaskStartedMock(tlName string) {

--- a/service/matching/nexus_endpoint_client.go
+++ b/service/matching/nexus_endpoint_client.go
@@ -346,7 +346,7 @@ func (m *nexusEndpointClient) loadEndpoints(ctx context.Context) error {
 			m.endpointsByName[entry.Endpoint.Spec.Name] = entry
 		}
 
-		if pageToken == nil {
+		if len(pageToken) == 0 {
 			break
 		}
 	}


### PR DESCRIPTION
## What changed?

For ListNexusEndpoints, in matching, check if node is ownership of the nexus endpoints table when a request comes in and abort polls if ownership is lost.

## Why?

Faster feedback when membership changes.

## Testing

Added unit tests and fixed existing tests.