### PR TITLE
Avoid recreating gocql session on transient connection errors

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
@@ -28,7 +28,6 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/gocql/gocql"
@@ -203,9 +202,7 @@ func (s *session) handleError(
 ) {
 	switch err {
 	case gocql.ErrNoConnections,
-		gocql.ErrSessionClosed,
-		gocql.ErrConnectionClosed,
-		syscall.ECONNRESET:
+		gocql.ErrSessionClosed:
 		s.refresh()
 	default:
 		// noop


### PR DESCRIPTION
## What changed?
Modifies gocql error handling introduced in https://github.com/temporalio/temporal/pull/4132 to avoid recreating the gocql session on transient connection errors. 

## Why?
Recreating the session adds latency and isn't necessary when connections are closed or reset. 

## How did you test it?
Ran a prod-like workload and periodically restarted cassandra nodes. With the patch applied, we observed a reduction in p50 and p99 latency across persistence operations. For instance, here are p50 and p99 request latencies for `StartWorkflowExecution`. The patch was applied for cassandra restarts at 20:00 and then removed for cassandra restarts at 21:00. 

![image](https://github.com/temporalio/temporal/assets/198742/b5f5d752-78c7-4950-ad49-d304ab225603)
![image](https://github.com/temporalio/temporal/assets/198742/a745e59e-c108-4ad9-a0a5-ce3c70d29eb4)


## Potential risks
No

## Is hotfix candidate?
No
