### PR TITLE
Fix SyncHSM for buffered event case

### DIFF
--- a/service/history/replication/raw_task_converter.go
+++ b/service/history/replication/raw_task_converter.go
@@ -222,6 +222,12 @@ func convertSyncHSMReplicationTask(
 			// HSM can be updated after workflow is completed
 			// so no check on workflow state here.
 
+			if mutableState.HasBufferedEvents() {
+				// we can't sync HSM when there's buffered events
+				// as current state could depend on those buffered events
+				return nil, nil
+			}
+
 			versionHistories := mutableState.GetExecutionInfo().GetVersionHistories()
 			currentVersionHistory, err := versionhistory.GetCurrentVersionHistory(versionHistories)
 			if err != nil {

--- a/service/history/replication/raw_task_converter_test.go
+++ b/service/history/replication/raw_task_converter_test.go
@@ -963,6 +963,7 @@ func (s *rawTaskConverterSuite) TestConvertSyncHSMTask_WorkflowFound() {
 			},
 		},
 	}
+	s.mutableState.EXPECT().HasBufferedEvents().Return(false).AnyTimes()
 	s.mutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		VersionHistories: versionHistories,
 	}).AnyTimes()

--- a/service/history/replication/raw_task_converter_test.go
+++ b/service/history/replication/raw_task_converter_test.go
@@ -1008,3 +1008,51 @@ func (s *rawTaskConverterSuite) TestConvertSyncHSMTask_WorkflowFound() {
 	}, result)
 	s.True(s.lockReleased)
 }
+
+func (s *rawTaskConverterSuite) TestConvertSyncHSMTask_BufferedEvents() {
+	ctx := context.Background()
+	taskID := int64(1444)
+	version := int64(288)
+	task := &tasks.SyncHSMTask{
+		WorkflowKey: definition.NewWorkflowKey(
+			s.namespaceID,
+			s.workflowID,
+			s.runID,
+		),
+		VisibilityTimestamp: time.Now().UTC(),
+		TaskID:              taskID,
+	}
+	s.workflowCache.EXPECT().GetOrCreateWorkflowExecution(
+		gomock.Any(),
+		s.shardContext,
+		namespace.ID(s.namespaceID),
+		&commonpb.WorkflowExecution{
+			WorkflowId: s.workflowID,
+			RunId:      s.runID,
+		},
+		workflow.LockPriorityLow,
+	).Return(s.workflowContext, s.releaseFn, nil)
+	s.workflowContext.EXPECT().LoadMutableState(gomock.Any(), s.shardContext).Return(s.mutableState, nil)
+
+	s.mutableState.EXPECT().HasBufferedEvents().Return(true).AnyTimes()
+	s.mutableState.EXPECT().GetCurrentVersion().Return(version).AnyTimes()
+	s.mutableState.EXPECT().NextTransitionCount().Return(int64(0)).AnyTimes()
+
+	reg := s.shardContext.StateMachineRegistry()
+	err := workflow.RegisterStateMachine(reg)
+	s.NoError(err)
+	stateMachineDef := hsmtest.NewDefinition("test")
+	err = reg.RegisterMachine(stateMachineDef)
+	s.NoError(err)
+
+	root, err := hsm.NewRoot(reg, workflow.StateMachineType, s.mutableState, make(map[string]*persistencespb.StateMachineMap), s.mutableState)
+	s.NoError(err)
+	_, err = root.AddChild(hsm.Key{Type: stateMachineDef.Type(), ID: "child_1"}, hsmtest.NewData(hsmtest.State1))
+	s.NoError(err)
+	s.mutableState.EXPECT().HSM().Return(root).AnyTimes()
+
+	result, err := convertSyncHSMReplicationTask(ctx, s.shardContext, task, s.workflowCache)
+	s.NoError(err)
+	s.Nil(result)
+	s.True(s.lockReleased)
+}

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5242,6 +5242,7 @@ func (ms *MutableStateImpl) closeTransaction(
 	if err := ms.closeTransactionPrepareTasks(
 		transactionPolicy,
 		eventBatches,
+		clearBuffer,
 	); err != nil {
 		return closeTransactionResult{}, err
 	}
@@ -5370,6 +5371,7 @@ func (ms *MutableStateImpl) closeTransactionUpdateTransitionHistory(
 func (ms *MutableStateImpl) closeTransactionPrepareTasks(
 	transactionPolicy TransactionPolicy,
 	eventBatches [][]*historypb.HistoryEvent,
+	clearBufferEvents bool,
 ) error {
 	if err := ms.closeTransactionHandleWorkflowResetTask(
 		transactionPolicy,
@@ -5392,12 +5394,13 @@ func (ms *MutableStateImpl) closeTransactionPrepareTasks(
 		return err
 	}
 
-	return ms.closeTransactionPrepareReplicationTasks(transactionPolicy, eventBatches)
+	return ms.closeTransactionPrepareReplicationTasks(transactionPolicy, eventBatches, clearBufferEvents)
 }
 
 func (ms *MutableStateImpl) closeTransactionPrepareReplicationTasks(
 	transactionPolicy TransactionPolicy,
 	eventBatches [][]*historypb.HistoryEvent,
+	clearBufferEvents bool,
 ) error {
 
 	if ms.config.ReplicationMultipleBatches() {
@@ -5419,7 +5422,7 @@ func (ms *MutableStateImpl) closeTransactionPrepareReplicationTasks(
 
 	ms.InsertTasks[tasks.CategoryReplication] = append(
 		ms.InsertTasks[tasks.CategoryReplication],
-		ms.dirtyHSMToReplicationTask(transactionPolicy, eventBatches)...,
+		ms.dirtyHSMToReplicationTask(transactionPolicy, eventBatches, clearBufferEvents)...,
 	)
 
 	if transactionPolicy == TransactionPolicyPassive &&
@@ -5571,14 +5574,29 @@ func (ms *MutableStateImpl) syncActivityToReplicationTask(
 func (ms *MutableStateImpl) dirtyHSMToReplicationTask(
 	transactionPolicy TransactionPolicy,
 	eventBatches [][]*historypb.HistoryEvent,
+	clearBufferEvents bool,
 ) []tasks.Task {
 	switch transactionPolicy {
 	case TransactionPolicyActive:
-		// HSM().Dirty() implies Nexus is enabled
+		if !ms.generateReplicationTask() {
+			return emptyTasks
+		}
+
+		// HSM() contains children also implies Nexus is enabled
+		if len(ms.HSM().InternalRepr().Children) == 0 {
+			return emptyTasks
+		}
+
 		// We also assume that - for the time being - if events were generated in a transaction,
 		// all HSM node updates are a result of applying those events.
 		// The passive cluster will transition the HSM when applying the events.
-		if ms.HSM().Dirty() && len(eventBatches) == 0 && ms.generateReplicationTask() {
+		//
+		// When mutable state contains buffered events, SyncHSM task will be dropped as
+		// the state for **some** HSM nodes may depend on those buffered events.
+		// But there might be some other nodes whose state do not depend on buffered events.
+		// For those nodes, we need to make sure their states will be synced as well.
+		// So when clearing buffered events, generate another SyncHSM task.
+		if clearBufferEvents || (ms.HSM().Dirty() && len(eventBatches) == 0) {
 			return []tasks.Task{
 				&tasks.SyncHSMTask{
 					WorkflowKey: ms.GetWorkflowKey(),
@@ -5586,6 +5604,7 @@ func (ms *MutableStateImpl) dirtyHSMToReplicationTask(
 				},
 			}
 		}
+
 		return emptyTasks
 	case TransactionPolicyPassive:
 		return emptyTasks

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -2156,7 +2156,7 @@ func (s *mutableStateSuite) TestCloseTransactionPrepareReplicationTasks_HistoryT
 					return
 				}
 				ms.InsertTasks[tasks.CategoryReplication] = []tasks.Task{}
-				err := ms.closeTransactionPrepareReplicationTasks(TransactionPolicyActive, eventBatches)
+				err := ms.closeTransactionPrepareReplicationTasks(TransactionPolicyActive, eventBatches, false)
 				if err != nil {
 					s.Fail("closeTransactionPrepareReplicationTasks failed", err)
 				}
@@ -2238,12 +2238,15 @@ func (s *mutableStateSuite) TestCloseTransactionPrepareReplicationTasks_SyncHSMT
 
 	testCases := []struct {
 		name                    string
+		hsmEmpty                bool
 		hsmDirty                bool
 		eventBatches            [][]*historypb.HistoryEvent
+		clearBufferEvents       bool
 		expectedReplicationTask tasks.Task
 	}{
 		{
-			name:     "with events",
+			name:     "WithEvents",
+			hsmEmpty: false,
 			hsmDirty: true,
 			eventBatches: [][]*historypb.HistoryEvent{
 				{
@@ -2258,6 +2261,7 @@ func (s *mutableStateSuite) TestCloseTransactionPrepareReplicationTasks_SyncHSMT
 					},
 				},
 			},
+			clearBufferEvents: false,
 			expectedReplicationTask: &tasks.HistoryReplicationTask{
 				WorkflowKey:  s.mutableState.GetWorkflowKey(),
 				FirstEventID: 5,
@@ -2266,16 +2270,46 @@ func (s *mutableStateSuite) TestCloseTransactionPrepareReplicationTasks_SyncHSMT
 			},
 		},
 		{
-			name:     "without events",
-			hsmDirty: true,
+			name:              "NoEvents",
+			hsmEmpty:          false,
+			hsmDirty:          true,
+			eventBatches:      nil,
+			clearBufferEvents: false,
 			expectedReplicationTask: &tasks.SyncHSMTask{
 				WorkflowKey: s.mutableState.GetWorkflowKey(),
 			},
 		},
 		{
-			name:                    "no dirty hsm",
+			name:                    "NoChildren/ClearBufferFalse",
+			hsmEmpty:                true,
 			hsmDirty:                false,
+			eventBatches:            nil,
+			clearBufferEvents:       false,
 			expectedReplicationTask: nil,
+		},
+		{
+			name:                    "NoChildren/ClearBufferTrue",
+			hsmEmpty:                true,
+			hsmDirty:                false,
+			eventBatches:            nil,
+			clearBufferEvents:       true,
+			expectedReplicationTask: nil,
+		},
+		{
+			name:                    "CleanChildren/ClearBufferFalse",
+			hsmEmpty:                false,
+			hsmDirty:                false,
+			clearBufferEvents:       false,
+			expectedReplicationTask: nil,
+		},
+		{
+			name:              "CleanChildren/ClearBufferTrue",
+			hsmEmpty:          false,
+			hsmDirty:          false,
+			clearBufferEvents: true,
+			expectedReplicationTask: &tasks.SyncHSMTask{
+				WorkflowKey: s.mutableState.GetWorkflowKey(),
+			},
 		},
 	}
 
@@ -2283,15 +2317,19 @@ func (s *mutableStateSuite) TestCloseTransactionPrepareReplicationTasks_SyncHSMT
 		s.Run(
 			tc.name,
 			func() {
-				if tc.hsmDirty {
+				if !tc.hsmEmpty {
 					_, err = s.mutableState.HSM().AddChild(
 						hsm.Key{Type: stateMachineDef.Type(), ID: "child_1"},
 						hsmtest.NewData(hsmtest.State1),
 					)
 					s.NoError(err)
+
+					if !tc.hsmDirty {
+						s.mutableState.HSM().ClearTransactionState()
+					}
 				}
 
-				err := s.mutableState.closeTransactionPrepareReplicationTasks(TransactionPolicyActive, tc.eventBatches)
+				err := s.mutableState.closeTransactionPrepareReplicationTasks(TransactionPolicyActive, tc.eventBatches, tc.clearBufferEvents)
 				s.NoError(err)
 
 				repicationTasks := s.mutableState.PopTasks()[tasks.CategoryReplication]

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -189,8 +189,26 @@ func (s *NexusStateReplicationSuite) TestNexusOperationEventsReplicated() {
 	// Now failover, and let cluster2 be the active.
 	s.failover(ns, s.clusterNames[1], 2, s.cluster1.GetFrontendClient())
 
+	s.NoError(sdkClient2.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "dont-care", nil))
+
+	pollRes = s.pollWorkflowTask(ctx, s.cluster2.GetFrontendClient(), ns)
+
 	// Unblock nexus operation start after failover.
 	failStartOperation.Store(false)
+
+	s.Eventually(func() bool {
+		describeRes, err := sdkClient2.DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
+		s.NoError(err)
+		s.Equal(1, len(describeRes.PendingNexusOperations))
+		op := describeRes.PendingNexusOperations[0]
+		return op.State == enumspb.PENDING_NEXUS_OPERATION_STATE_STARTED
+	}, time.Second*10, time.Millisecond*100)
+
+	_, err = s.cluster2.GetFrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		TaskToken: pollRes.TaskToken,
+		Commands:  []*commandpb.Command{}, // No need to generate other commands, this "workflow" just waits for the operation to complete.
+	})
+	s.NoError(err)
 
 	// Poll in cluster2 (previously standby) and verify the operation was started.
 	pollRes = s.pollWorkflowTask(ctx, s.cluster2.GetFrontendClient(), ns)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Drop SyncHSM task on conversion if there are buffered events
- Generate syncHSM task when clearing buffered events

## Why?
<!-- Tell your future self why have you made these changes -->
- Can't sync HSM state when there are buffered events as states may depend on those events. Otherwise, later when those events are flushed and replicated, they can't be applied in the target cluster as the state has already been updated.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit tests
- Functional test from @bergundy 

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
