### PR TITLE
Record SM task transition count on transition

### DIFF
--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -414,7 +414,7 @@ type EventStarted struct {
 }
 
 var TransitionStarted = hsm.NewTransition(
-	[]enumsspb.NexusOperationState{enumsspb.NEXUS_OPERATION_STATE_SCHEDULED},
+	[]enumsspb.NexusOperationState{enumsspb.NEXUS_OPERATION_STATE_SCHEDULED, enumsspb.NEXUS_OPERATION_STATE_BACKING_OFF},
 	enumsspb.NEXUS_OPERATION_STATE_STARTED,
 	func(op Operation, event EventStarted) (hsm.TransitionOutput, error) {
 		op.recordAttempt(event.Time)

--- a/service/history/hsm/tree.go
+++ b/service/history/hsm/tree.go
@@ -84,7 +84,7 @@ type cachedMachine struct {
 	// A flag that indicates the cached machine is dirty.
 	dirty bool
 	// Outputs of all transitions in the current transaction.
-	outputs []TransitionOutput
+	outputs []TransitionOutputWithCount
 }
 
 // NodeBackend is a concrete implementation to support interacting with the underlying platform.
@@ -168,9 +168,13 @@ func (n *Node) Dirty() bool {
 	return false
 }
 
+type TransitionOutputWithCount struct {
+	TransitionOutput
+	TransitionCount int64
+}
 type PathAndOutputs struct {
 	Path    []Key
-	Outputs []TransitionOutput
+	Outputs []TransitionOutputWithCount
 }
 
 func (n *Node) Path() []Key {
@@ -490,7 +494,11 @@ func MachineTransition[T any](n *Node, transitionFn func(T) (TransitionOutput, e
 	}
 	n.persistence.Data = serialized
 	n.cache.dirty = true
-	n.cache.outputs = append(n.cache.outputs, output)
+	outputWithCount := TransitionOutputWithCount{
+		TransitionOutput: output,
+		TransitionCount:  n.persistence.TransitionCount,
+	}
+	n.cache.outputs = append(n.cache.outputs, outputWithCount)
 	return nil
 }
 

--- a/service/history/hsm/tree_test.go
+++ b/service/history/hsm/tree_test.go
@@ -144,6 +144,7 @@ func TestNode_MaintainsChildCache(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, root.Dirty()) // Should now be dirty again.
 	require.Equal(t, 1, len(root.Outputs()))
+	require.Equal(t, int64(1), root.Outputs()[0].Outputs[0].TransitionCount)
 	require.Equal(t, []hsm.Key{key}, root.Outputs()[0].Path)
 
 	// Cache when loaded from persistence.

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -504,6 +504,7 @@ func (r *TaskRefresherImpl) refreshTasksForSubStateMachines(
 				r.shard.StateMachineRegistry(),
 				node,
 				node.Path(),
+				node.InternalRepr().GetTransitionCount(),
 				task,
 			); err != nil {
 				return err


### PR DESCRIPTION
## What changed?

- Record SM task transition count on transition
- [Accept operation transition from backing off to started](https://github.com/temporalio/temporal/pull/6216/commits/bb1156ce8768fc4aa7523faacef7c9f523d4dd5a)

## Why?

During replication, multiple event batches may be applied at a time, generating non-concurrent tasks with an invalid transition count.

Also accept the transition because state replication is lossy and we can't rely on the machine to transition to scheduled before started.

## Is hotfix candidate?

Yes.