### PR TITLE
[Outbound queue] Wrap retryable error from standby queue with DestinationDownError

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1664,6 +1664,13 @@ Fields (see gobreaker reference for more details):
 		`OutboundStandbyWrapErrTaskRetryWithDestionationDown enables wrapping ErrTaskRetry error when
 processing standby task with DestinationDownError`,
 	)
+	OutboundStandbyDiscardTaskMissingEvents = NewTaskTypeBoolSetting(
+		"history.outboundQueue.discardTaskMissingEvents",
+		false,
+		`OutboundStandbyDiscardTaskMissingEvents enables discarding outbound tasks after
+StandbyTaskMissingEventsDiscardDelay. In normal operation with multi-cursor enabled,
+it should not be necessary to discard tasks.`,
+	)
 
 	VisibilityTaskBatchSize = NewGlobalIntSetting(
 		"history.visibilityTaskBatchSize",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -25,6 +25,7 @@
 package dynamicconfig
 
 import (
+	"math"
 	"os"
 	"time"
 
@@ -1658,18 +1659,18 @@ Fields (see gobreaker reference for more details):
   if interval is 0, then it never clears the internal counts (default 0).
 - Timeout (duration): Period of open state before changing to half-open state (default 60s).`,
 	)
-	OutboundStandbyWrapErrTaskRetryWithDestionationDown = NewTaskTypeBoolSetting(
-		"history.outboundQueue.wrapErrTaskRetryWithDestionationDown",
-		true,
-		`OutboundStandbyWrapErrTaskRetryWithDestionationDown enables wrapping ErrTaskRetry error when
-processing standby task with DestinationDownError`,
+	OutboundStandbyTaskMissingEventsDiscardDelay = NewDestinationDurationSetting(
+		"history.outboundQueue.standbyTaskMissingEventsDiscardDelay",
+		// This is effectively equivalent to never discarding outbound tasks since it's 290+ years.
+		time.Duration(math.MaxInt64),
+		`OutboundStandbyTaskMissingEventsDiscardDelay is the equivalent of
+StandbyTaskMissingEventsDiscardDelay for outbound standby task processor.`,
 	)
-	OutboundStandbyDiscardTaskMissingEvents = NewTaskTypeBoolSetting(
-		"history.outboundQueue.discardTaskMissingEvents",
-		false,
-		`OutboundStandbyDiscardTaskMissingEvents enables discarding outbound tasks after
-StandbyTaskMissingEventsDiscardDelay. In normal operation with multi-cursor enabled,
-it should not be necessary to discard tasks.`,
+	OutboundStandbyTaskMissingEventsDestinationDownErr = NewDestinationBoolSetting(
+		"history.outboundQueue.standbyTaskMissingEventsDestinationDownErr",
+		true,
+		`OutboundStandbyTaskMissingEventsDestinationDownErr enables returning DestinationDownError when
+the outbound standby task failed to be processed due to missing events.`,
 	)
 
 	VisibilityTaskBatchSize = NewGlobalIntSetting(

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1658,6 +1658,12 @@ Fields (see gobreaker reference for more details):
   if interval is 0, then it never clears the internal counts (default 0).
 - Timeout (duration): Period of open state before changing to half-open state (default 60s).`,
 	)
+	OutboundStandbyWrapErrTaskRetryWithDestionationDown = NewTaskTypeBoolSetting(
+		"history.outboundQueue.wrapErrTaskRetryWithDestionationDown",
+		true,
+		`OutboundStandbyWrapErrTaskRetryWithDestionationDown enables wrapping ErrTaskRetry error when
+processing standby task with DestinationDownError`,
+	)
 
 	VisibilityTaskBatchSize = NewGlobalIntSetting(
 		"history.visibilityTaskBatchSize",

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -171,6 +171,7 @@ type Config struct {
 	OutboundQueueGroupLimiterConcurrency                dynamicconfig.IntPropertyFnWithDestinationFilter
 	OutboundQueueHostSchedulerMaxTaskRPS                dynamicconfig.FloatPropertyFnWithDestinationFilter
 	OutboundQueueCircuitBreakerSettings                 dynamicconfig.TypedPropertyFnWithDestinationFilter[dynamicconfig.CircuitBreakerSettings]
+	OutboundStandbyWrapErrTaskRetryWithDestionationDown dynamicconfig.BoolPropertyFnWithTaskTypeFilter
 
 	// ReplicatorQueueProcessor settings
 	ReplicatorProcessorMaxPollInterval                  dynamicconfig.DurationPropertyFn
@@ -488,6 +489,7 @@ func NewConfig(
 		OutboundQueueGroupLimiterConcurrency:                dynamicconfig.OutboundQueueGroupLimiterConcurrency.Get(dc),
 		OutboundQueueHostSchedulerMaxTaskRPS:                dynamicconfig.OutboundQueueHostSchedulerMaxTaskRPS.Get(dc),
 		OutboundQueueCircuitBreakerSettings:                 dynamicconfig.OutboundQueueCircuitBreakerSettings.Get(dc),
+		OutboundStandbyWrapErrTaskRetryWithDestionationDown: dynamicconfig.OutboundStandbyWrapErrTaskRetryWithDestionationDown.Get(dc),
 
 		ReplicatorProcessorMaxPollInterval:                  dynamicconfig.ReplicatorProcessorMaxPollInterval.Get(dc),
 		ReplicatorProcessorMaxPollIntervalJitterCoefficient: dynamicconfig.ReplicatorProcessorMaxPollIntervalJitterCoefficient.Get(dc),

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -172,6 +172,7 @@ type Config struct {
 	OutboundQueueHostSchedulerMaxTaskRPS                dynamicconfig.FloatPropertyFnWithDestinationFilter
 	OutboundQueueCircuitBreakerSettings                 dynamicconfig.TypedPropertyFnWithDestinationFilter[dynamicconfig.CircuitBreakerSettings]
 	OutboundStandbyWrapErrTaskRetryWithDestionationDown dynamicconfig.BoolPropertyFnWithTaskTypeFilter
+	OutboundStandbyDiscardTaskMissingEvents             dynamicconfig.BoolPropertyFnWithTaskTypeFilter
 
 	// ReplicatorQueueProcessor settings
 	ReplicatorProcessorMaxPollInterval                  dynamicconfig.DurationPropertyFn
@@ -490,6 +491,7 @@ func NewConfig(
 		OutboundQueueHostSchedulerMaxTaskRPS:                dynamicconfig.OutboundQueueHostSchedulerMaxTaskRPS.Get(dc),
 		OutboundQueueCircuitBreakerSettings:                 dynamicconfig.OutboundQueueCircuitBreakerSettings.Get(dc),
 		OutboundStandbyWrapErrTaskRetryWithDestionationDown: dynamicconfig.OutboundStandbyWrapErrTaskRetryWithDestionationDown.Get(dc),
+		OutboundStandbyDiscardTaskMissingEvents:             dynamicconfig.OutboundStandbyDiscardTaskMissingEvents.Get(dc),
 
 		ReplicatorProcessorMaxPollInterval:                  dynamicconfig.ReplicatorProcessorMaxPollInterval.Get(dc),
 		ReplicatorProcessorMaxPollIntervalJitterCoefficient: dynamicconfig.ReplicatorProcessorMaxPollIntervalJitterCoefficient.Get(dc),

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -171,8 +171,8 @@ type Config struct {
 	OutboundQueueGroupLimiterConcurrency                dynamicconfig.IntPropertyFnWithDestinationFilter
 	OutboundQueueHostSchedulerMaxTaskRPS                dynamicconfig.FloatPropertyFnWithDestinationFilter
 	OutboundQueueCircuitBreakerSettings                 dynamicconfig.TypedPropertyFnWithDestinationFilter[dynamicconfig.CircuitBreakerSettings]
-	OutboundStandbyWrapErrTaskRetryWithDestionationDown dynamicconfig.BoolPropertyFnWithTaskTypeFilter
-	OutboundStandbyDiscardTaskMissingEvents             dynamicconfig.BoolPropertyFnWithTaskTypeFilter
+	OutboundStandbyTaskMissingEventsDiscardDelay        dynamicconfig.DurationPropertyFnWithDestinationFilter
+	OutboundStandbyTaskMissingEventsDestinationDownErr  dynamicconfig.BoolPropertyFnWithDestinationFilter
 
 	// ReplicatorQueueProcessor settings
 	ReplicatorProcessorMaxPollInterval                  dynamicconfig.DurationPropertyFn
@@ -490,8 +490,8 @@ func NewConfig(
 		OutboundQueueGroupLimiterConcurrency:                dynamicconfig.OutboundQueueGroupLimiterConcurrency.Get(dc),
 		OutboundQueueHostSchedulerMaxTaskRPS:                dynamicconfig.OutboundQueueHostSchedulerMaxTaskRPS.Get(dc),
 		OutboundQueueCircuitBreakerSettings:                 dynamicconfig.OutboundQueueCircuitBreakerSettings.Get(dc),
-		OutboundStandbyWrapErrTaskRetryWithDestionationDown: dynamicconfig.OutboundStandbyWrapErrTaskRetryWithDestionationDown.Get(dc),
-		OutboundStandbyDiscardTaskMissingEvents:             dynamicconfig.OutboundStandbyDiscardTaskMissingEvents.Get(dc),
+		OutboundStandbyTaskMissingEventsDestinationDownErr:  dynamicconfig.OutboundStandbyTaskMissingEventsDestinationDownErr.Get(dc),
+		OutboundStandbyTaskMissingEventsDiscardDelay:        dynamicconfig.OutboundStandbyTaskMissingEventsDiscardDelay.Get(dc),
 
 		ReplicatorProcessorMaxPollInterval:                  dynamicconfig.ReplicatorProcessorMaxPollInterval.Get(dc),
 		ReplicatorProcessorMaxPollIntervalJitterCoefficient: dynamicconfig.ReplicatorProcessorMaxPollIntervalJitterCoefficient.Get(dc),


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Wrap retryable errors from the outbound standby queue tasks with `DestinationDownError`.

## Why?
<!-- Tell your future self why have you made these changes -->
`DestinationDownError` will trigger the circuit breaker, and minimizing discarding standby tasks prematurely.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
