### PR TITLE
Translate NamespaceNotActive error in nexus completion API to retryable unavailable error

### DIFF
--- a/components/nexusoperations/frontend/handler.go
+++ b/components/nexusoperations/frontend/handler.go
@@ -207,6 +207,10 @@ func (h *completionHandler) CompleteOperation(ctx context.Context, r *nexus.Comp
 	_, err = h.HistoryClient.CompleteNexusOperation(ctx, hr)
 	if err != nil {
 		logger.Error("failed to process nexus completion request", tag.Error(err))
+		var namespaceInactiveErr *serviceerror.NamespaceNotActive
+		if errors.As(err, &namespaceInactiveErr) {
+			return nexus.HandlerErrorf(nexus.HandlerErrorTypeUnavailable, "cluster inactive")
+		}
 		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
 			return nexus.HandlerErrorf(nexus.HandlerErrorTypeNotFound, "operation not found")
 		}

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -169,7 +169,6 @@ func (c *operationContext) interceptRequest(ctx context.Context, request *matchi
 	}
 
 	if !c.namespace.ActiveInCluster(c.clusterMetadata.GetCurrentClusterName()) {
-		notActiveErr := serviceerror.NewNamespaceNotActive(c.namespaceName, c.clusterMetadata.GetCurrentClusterName(), c.namespace.ActiveClusterName())
 		if c.shouldForwardRequest(ctx, header) {
 			// Handler methods should have special logic to forward requests if this method returns a serviceerror.NamespaceNotActive error.
 			c.metricsHandler = c.metricsHandler.WithTags(metrics.NexusOutcomeTag("request_forwarded"))
@@ -178,7 +177,7 @@ func (c *operationContext) interceptRequest(ctx context.Context, request *matchi
 			c.cleanupFunctions = append(c.cleanupFunctions, func(retErr error) {
 				c.redirectionInterceptor.AfterCall(c.metricsHandlerForInterceptors, forwardStartTime, c.namespace.ActiveClusterName(), retErr)
 			})
-			return notActiveErr
+			return serviceerror.NewNamespaceNotActive(c.namespaceName, c.clusterMetadata.GetCurrentClusterName(), c.namespace.ActiveClusterName())
 		}
 		c.metricsHandler = c.metricsHandler.WithTags(metrics.NexusOutcomeTag("namespace_inactive_forwarding_disabled"))
 		return nexus.HandlerErrorf(nexus.HandlerErrorTypeUnavailable, "cluster inactive")


### PR DESCRIPTION
## Why?

This is considered transient recoverable state and should only happen when there's race when resolving the namespace before forwarding the request.