### PR TITLE
move failed syncmatch tasks to the backlog

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -551,7 +551,6 @@ pollLoop:
 			}
 			return nil, err
 		}
-
 		if task.isStarted() {
 			// tasks received from remote are already started. So, simply forward the response
 			return task.pollWorkflowTaskQueueResponse(), nil

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -404,8 +404,6 @@ func (s *matchingEngineSuite) TestFailAddTaskWithHistoryError() {
 
 	stickyTaskQueue := &taskqueuepb.TaskQueue{Name: "STQ", Kind: enumspb.TASK_QUEUE_KIND_STICKY}
 
-	//s.matchingEngine.config.RangeSize = 2 // to test that range is not updated without tasks
-
 	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(5 * time.Second)
 
 	runID := uuid.NewRandom().String()
@@ -444,7 +442,7 @@ func (s *matchingEngineSuite) TestFailAddTaskWithHistoryError() {
 		}
 	}()
 	wg.Wait()
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond) //nolint:forbidigo
 	partition, err := tqid.PartitionFromProto(addRequest.TaskQueue, addRequest.NamespaceId, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	s.NoError(err)
 
@@ -469,10 +467,10 @@ func (s *matchingEngineSuite) TestFailAddTaskWithHistoryError() {
 		nil, expectedError)
 
 	_, syncMath, err := s.matchingEngine.AddWorkflowTask(context.Background(), &addRequest)
-	//now history still generate error, but in this case task should be moved to backlog queue
+
+	// now history still generate error, but in this case task should be moved to backlog queue
 	s.Nil(err)
 	s.False(syncMath)
-
 }
 
 func (s *matchingEngineSuite) TestPollWorkflowTaskQueues() {

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -28,17 +28,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.temporal.io/server/service/history/consts"
 	"math/rand"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
-	"go.temporal.io/server/common/metrics/metricstest"
-	"go.temporal.io/server/common/worker_versioning"
 
 	"github.com/emirpasic/gods/maps/treemap"
 	godsutils "github.com/emirpasic/gods/utils"
@@ -51,7 +46,11 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/common/cluster/clustertest"
+	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/worker_versioning"
+	"go.temporal.io/server/service/history/consts"
 
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -28,7 +28,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.temporal.io/server/service/history/consts"
 	"math/rand"
 	"sync"
 	"testing"
@@ -87,6 +86,7 @@ import (
 	"go.temporal.io/server/common/quotas"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tqid"
+	"go.temporal.io/server/service/history/consts"
 )
 
 type (

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -46,7 +46,6 @@ import (
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/worker_versioning"
-	"go.temporal.io/server/service/history/consts"
 )
 
 type (
@@ -260,10 +259,12 @@ func (pm *taskQueuePartitionManagerImpl) AddTask(
 }
 
 func (pm *taskQueuePartitionManagerImpl) shouldBacklogSyncMatchTaskOnError(err error) bool {
-	if err != nil && errors.Is(err, consts.ErrResourceExhaustedBusyWorkflow) {
-		return true
+	var resourceExhaustedErr *serviceerror.ResourceExhausted
+	if err != nil && errors.As(err, &resourceExhaustedErr) {
+		if resourceExhaustedErr.Cause == enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW {
+			return true
+		}
 	}
-
 	return false
 }
 


### PR DESCRIPTION
## What changed?
If, while adding tasks, poller with a sticky queue failed because history service return "resource exhausted" error - move this task to backlog queue.
“Workflow is busy” is an resource exhausted error returned from history service


## Why?
To reduce the pressure on history service if it is in busy state.

## How did you test it?
Add unit test to cover both cases.

## Potential risks
N/A

## Documentation
N/A

## Is hotfix candidate?
No
