### PR TITLE
Always register outbound category, make outbound processor registration conditional

### DIFF
--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -828,7 +828,12 @@ func (e *historyEngineImpl) NotifyNewTasks(
 		}
 
 		if len(tasksByCategory) > 0 {
-			e.queueProcessors[category].NotifyNewTasks(tasksByCategory)
+			proc, ok := e.queueProcessors[category]
+			if !ok {
+				e.logger.Error("Skipping notification for new tasks, processor not registered", tag.TaskCategoryID(category.ID()))
+				continue
+			}
+			proc.NotifyNewTasks(tasksByCategory)
 		}
 	}
 }

--- a/service/history/queue_factory_base.go
+++ b/service/history/queue_factory_base.go
@@ -143,15 +143,15 @@ type additionalQueueFactories struct {
 func getOptionalQueueFactories(
 	registry tasks.TaskCategoryRegistry,
 	archivalParams ArchivalQueueFactoryParams,
-	callbackParams outboundQueueFactoryParams,
+	outboundParams outboundQueueFactoryParams,
 	config *configs.Config,
 ) additionalQueueFactories {
 	factories := []QueueFactory{}
 	if _, ok := registry.GetCategoryByID(tasks.CategoryIDArchival); ok {
 		factories = append(factories, NewArchivalQueueFactory(archivalParams))
 	}
-	if _, ok := registry.GetCategoryByID(tasks.CategoryIDOutbound); ok {
-		factories = append(factories, NewOutboundQueueFactory(callbackParams))
+	if config.EnableNexus() {
+		factories = append(factories, NewOutboundQueueFactory(outboundParams))
 	}
 	return additionalQueueFactories{
 		Factories: factories,

--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -145,7 +145,6 @@ func newTestContext(t *resourcetest.Test, eventsCache events.Cache, config Conte
 	}
 	taskCategoryRegistry := tasks.NewDefaultTaskCategoryRegistry()
 	taskCategoryRegistry.AddCategory(tasks.CategoryArchival)
-	taskCategoryRegistry.AddCategory(tasks.CategoryOutbound)
 
 	ctx := &ContextImpl{
 		shardID:             config.ShardInfo.GetShardId(),

--- a/service/history/tasks/task_category_registry.go
+++ b/service/history/tasks/task_category_registry.go
@@ -58,6 +58,7 @@ func NewDefaultTaskCategoryRegistry() *MutableTaskCategoryRegistry {
 			CategoryVisibility.ID():  CategoryVisibility,
 			CategoryReplication.ID(): CategoryReplication,
 			CategoryMemoryTimer.ID(): CategoryMemoryTimer,
+			CategoryOutbound.ID():    CategoryOutbound,
 		},
 	}
 }

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -469,11 +469,6 @@ func TaskCategoryRegistryProvider(archivalMetadata archiver.ArchivalMetadata, dc
 		archivalMetadata.GetVisibilityConfig().StaticClusterState() == archiver.ArchivalEnabled {
 		registry.AddCategory(tasks.CategoryArchival)
 	}
-	// Can't use history service configs.Config because this provider is applied to all services (see docstring for this
-	// function for more info).
-	if dynamicconfig.EnableNexus.Get(dc)() {
-		registry.AddCategory(tasks.CategoryOutbound)
-	}
 	return registry
 }
 

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -463,7 +463,7 @@ func (params ServiceProviderParamsCommon) GetCommonServiceOptions(serviceName pr
 // it, we also do validation on request task categories in the frontend service. As a result, we need to initialize the
 // registry in the server graph, and then propagate it to the service graphs. Otherwise, it would be isolated to the
 // history service's graph.
-func TaskCategoryRegistryProvider(archivalMetadata archiver.ArchivalMetadata, dc *dynamicconfig.Collection) tasks.TaskCategoryRegistry {
+func TaskCategoryRegistryProvider(archivalMetadata archiver.ArchivalMetadata) tasks.TaskCategoryRegistry {
 	registry := tasks.NewDefaultTaskCategoryRegistry()
 	if archivalMetadata.GetHistoryConfig().StaticClusterState() == archiver.ArchivalEnabled ||
 		archivalMetadata.GetVisibilityConfig().StaticClusterState() == archiver.ArchivalEnabled {

--- a/temporal/fx_test.go
+++ b/temporal/fx_test.go
@@ -35,7 +35,6 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/config"
-	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/tasks"
@@ -135,7 +134,6 @@ func TestTaskCategoryRegistryProvider(t *testing.T) {
 		historyState           archiver.ArchivalState
 		visibilityState        archiver.ArchivalState
 		expectArchivalCategory bool
-		expectCallbackCategory bool
 	}{
 		{
 			name:                   "both disabled",
@@ -166,7 +164,6 @@ func TestTaskCategoryRegistryProvider(t *testing.T) {
 			historyState:           archiver.ArchivalDisabled,
 			visibilityState:        archiver.ArchivalDisabled,
 			expectArchivalCategory: false,
-			expectCallbackCategory: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -178,17 +175,13 @@ func TestTaskCategoryRegistryProvider(t *testing.T) {
 			visibilityArchivalConfig := archiver.NewMockArchivalConfig(ctrl)
 			visibilityArchivalConfig.EXPECT().StaticClusterState().Return(tc.visibilityState).AnyTimes()
 			archivalMetadata.EXPECT().GetVisibilityConfig().Return(visibilityArchivalConfig).AnyTimes()
-			dcClient := dynamicconfig.StaticClient{dynamicconfig.EnableNexus.Key(): tc.expectCallbackCategory}
-			dcc := dynamicconfig.NewCollection(dcClient, log.NewNoopLogger())
-			registry := TaskCategoryRegistryProvider(archivalMetadata, dcc)
+			registry := TaskCategoryRegistryProvider(archivalMetadata)
 			_, ok := registry.GetCategoryByID(tasks.CategoryIDArchival)
 			if tc.expectArchivalCategory {
 				require.True(t, ok)
 			} else {
 				require.False(t, ok)
 			}
-			_, ok = registry.GetCategoryByID(tasks.CategoryIDOutbound)
-			require.Equal(t, tc.expectCallbackCategory, ok)
 		})
 	}
 }

--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -279,9 +279,7 @@ func NewClusterWithPersistenceTestBaseFactory(t *testing.T, options *TestCluster
 		}
 	}
 
-	dcClient := dynamicconfig.StaticClient(options.DynamicConfigOverrides)
-	dcc := dynamicconfig.NewCollection(dcClient, log.NewNoopLogger())
-	taskCategoryRegistry := temporal.TaskCategoryRegistryProvider(archiverBase.metadata, dcc)
+	taskCategoryRegistry := temporal.TaskCategoryRegistryProvider(archiverBase.metadata)
 
 	temporalParams := &TemporalParams{
 		ClusterMetadataConfig:            clusterMetadataConfig,


### PR DESCRIPTION
## Why?

There are some case when disabling nexus where outbound tasks will still be generated, we'd like to keep those tasks and avoid notifying the processor instead of the current behavior where the server would panic.
This also addresses a panic that could happen when enabling nexus on a running server.

## How did you test it?

Ran the server locally with continuous nexus load, disabled nexus via dynamic config, restarted the server, re-enabled nexus and checked that things are functioning properly.