### PR TITLE
Rename "engine" to "client" in tests

### DIFF
--- a/tests/activity.go
+++ b/tests/activity.go
@@ -86,7 +86,7 @@ func (s *FunctionalSuite) TestActivityHeartBeatWorkflow_Success() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -132,7 +132,7 @@ func (s *FunctionalSuite) TestActivityHeartBeatWorkflow_Success() {
 		s.Equal(activityName, task.ActivityType.GetName())
 		for i := 0; i < 10; i++ {
 			s.Logger.Info("Heartbeating for activity", tag.WorkflowActivityID(task.ActivityId), tag.Counter(i))
-			_, err := s.engine.RecordActivityTaskHeartbeat(NewContext(), &workflowservice.RecordActivityTaskHeartbeatRequest{
+			_, err := s.client.RecordActivityTaskHeartbeat(NewContext(), &workflowservice.RecordActivityTaskHeartbeatRequest{
 				Namespace: s.namespace,
 				TaskToken: task.TaskToken,
 				Details:   payloads.EncodeString("details"),
@@ -145,7 +145,7 @@ func (s *FunctionalSuite) TestActivityHeartBeatWorkflow_Success() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -214,7 +214,7 @@ func (s *FunctionalSuite) TestActivityRetry() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -313,7 +313,7 @@ func (s *FunctionalSuite) TestActivityRetry() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -324,7 +324,7 @@ func (s *FunctionalSuite) TestActivityRetry() {
 	}
 
 	poller2 := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -335,7 +335,7 @@ func (s *FunctionalSuite) TestActivityRetry() {
 	}
 
 	describeWorkflowExecution := func() (*workflowservice.DescribeWorkflowExecutionResponse, error) {
-		return s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+		return s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: id,
@@ -423,7 +423,7 @@ func (s *FunctionalSuite) TestActivityRetry_Infinite() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -480,7 +480,7 @@ func (s *FunctionalSuite) TestActivityRetry_Infinite() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -526,7 +526,7 @@ func (s *FunctionalSuite) TestActivityHeartBeatWorkflow_Timeout() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -579,7 +579,7 @@ func (s *FunctionalSuite) TestActivityHeartBeatWorkflow_Timeout() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -628,7 +628,7 @@ func (s *FunctionalSuite) TestTryActivityCancellationFromWorkflow() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution: response", tag.WorkflowRunID(we.GetRunId()))
@@ -685,7 +685,7 @@ func (s *FunctionalSuite) TestTryActivityCancellationFromWorkflow() {
 		s.Equal(activityName, task.ActivityType.GetName())
 		for i := 0; i < 10; i++ {
 			s.Logger.Info("Heartbeating for activity", tag.WorkflowActivityID(task.ActivityId), tag.Counter(i))
-			response, err := s.engine.RecordActivityTaskHeartbeat(NewContext(),
+			response, err := s.client.RecordActivityTaskHeartbeat(NewContext(),
 				&workflowservice.RecordActivityTaskHeartbeatRequest{
 					Namespace: s.namespace,
 					TaskToken: task.TaskToken,
@@ -702,7 +702,7 @@ func (s *FunctionalSuite) TestTryActivityCancellationFromWorkflow() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -719,7 +719,7 @@ func (s *FunctionalSuite) TestTryActivityCancellationFromWorkflow() {
 	go func() {
 		s.Logger.Info("Trying to cancel the task in a different thread")
 		// Send signal so that worker can send an activity cancel
-		_, err1 := s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+		_, err1 := s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			WorkflowExecution: &commonpb.WorkflowExecution{
 				WorkflowId: id,
@@ -771,7 +771,7 @@ func (s *FunctionalSuite) TestActivityCancellationNotStarted() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecutionn", tag.WorkflowRunID(we.GetRunId()))
@@ -829,7 +829,7 @@ func (s *FunctionalSuite) TestActivityCancellationNotStarted() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -845,7 +845,7 @@ func (s *FunctionalSuite) TestActivityCancellationNotStarted() {
 	// Send signal so that worker can send an activity cancel
 	signalName := "my signal"
 	signalInput := payloads.EncodeString("my signal input")
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -951,7 +951,7 @@ func (s *ClientFunctionalSuite) TestActivityHeartbeatDetailsDuringRetry() {
 	runId := workflowRun.GetRunID()
 
 	describeWorkflowExecution := func() (*workflowservice.DescribeWorkflowExecutionResponse, error) {
-		return s.engine.DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+		return s.client.DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: wfId,
@@ -1008,7 +1008,7 @@ func (s *FunctionalSuite) TestActivityHeartBeat_RecordIdentity() {
 		Identity:            workerIdentity,
 	}
 
-	we, err := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err)
 
 	workflowComplete := false
@@ -1049,7 +1049,7 @@ func (s *FunctionalSuite) TestActivityHeartBeat_RecordIdentity() {
 	atHandler := func(task *workflowservice.PollActivityTaskQueueResponse) (*commonpb.Payloads, bool, error) {
 		activityStartedSignal <- true // signal the start of activity task.
 		<-heartbeatSignalChan         // wait for signal before sending heartbeat.
-		_, err := s.engine.RecordActivityTaskHeartbeat(NewContext(), &workflowservice.RecordActivityTaskHeartbeatRequest{
+		_, err := s.client.RecordActivityTaskHeartbeat(NewContext(), &workflowservice.RecordActivityTaskHeartbeatRequest{
 			Namespace: s.namespace,
 			TaskToken: task.TaskToken,
 			Details:   payloads.EncodeString("details"),
@@ -1063,7 +1063,7 @@ func (s *FunctionalSuite) TestActivityHeartBeat_RecordIdentity() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            "", // Do not send the worker identity.
@@ -1084,7 +1084,7 @@ func (s *FunctionalSuite) TestActivityHeartBeat_RecordIdentity() {
 	}()
 
 	describeWorkflowExecution := func() (*workflowservice.DescribeWorkflowExecutionResponse, error) {
-		return s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+		return s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: id,

--- a/tests/archival.go
+++ b/tests/archival.go
@@ -160,7 +160,7 @@ func (s *ArchivalSuite) TestVisibilityArchival() {
 			Query:     fmt.Sprintf("CloseTime >= %v and CloseTime <= %v and WorkflowType = '%s'", startTime, endTime, workflowType),
 		}
 		for len(executions) == 0 || request.NextPageToken != nil {
-			response, err := s.engine.ListArchivedWorkflowExecutions(NewContext(), request)
+			response, err := s.client.ListArchivedWorkflowExecutions(NewContext(), request)
 			s.NoError(err)
 			s.NotNil(response)
 			executions = append(executions, response.GetExecutions()...)
@@ -187,7 +187,7 @@ func (s *ArchivalSuite) TestVisibilityArchival() {
 }
 
 func (s *FunctionalTestBase) getNamespaceID(namespace string) string {
-	namespaceResp, err := s.engine.DescribeNamespace(NewContext(), &workflowservice.DescribeNamespaceRequest{
+	namespaceResp, err := s.client.DescribeNamespace(NewContext(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
 	})
 	s.NoError(err)
@@ -331,7 +331,7 @@ func (s *ArchivalSuite) startAndFinishWorkflow(
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	startResp, err := s.engine.StartWorkflowExecution(NewContext(), request)
+	startResp, err := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(startResp.RunId))
 	workflowInfos := make([]archivalWorkflowInfo, numRuns)
@@ -406,7 +406,7 @@ func (s *ArchivalSuite) startAndFinishWorkflow(
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -178,7 +178,7 @@ func (s *FunctionalSuite) TestWorkflowCallbacks_InvalidArgument() {
 				CompletionCallbacks: cbs,
 			}
 
-			_, err := s.engine.StartWorkflowExecution(ctx, request)
+			_, err := s.client.StartWorkflowExecution(ctx, request)
 			var invalidArgument *serviceerror.InvalidArgument
 			s.ErrorAs(err, &invalidArgument)
 			s.Equal(tc.message, err.Error())
@@ -288,7 +288,7 @@ func (s *FunctionalSuite) TestWorkflowNexusCallbacks_CarriedOver() {
 				},
 			}
 
-			_, err = s.engine.StartWorkflowExecution(ctx, request)
+			_, err = s.client.StartWorkflowExecution(ctx, request)
 			s.NoError(err)
 
 			run := sdkClient.GetWorkflow(ctx, request.WorkflowId, "")

--- a/tests/cancel_workflow.go
+++ b/tests/cancel_workflow.go
@@ -66,7 +66,7 @@ func (s *FunctionalSuite) TestExternalRequestCancelWorkflowExecution() {
 	}
 
 	// cancellation to non exist workflow will lead to error
-	_, err := s.engine.RequestCancelWorkflowExecution(NewContext(), &workflowservice.RequestCancelWorkflowExecutionRequest{
+	_, err := s.client.RequestCancelWorkflowExecution(NewContext(), &workflowservice.RequestCancelWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -75,7 +75,7 @@ func (s *FunctionalSuite) TestExternalRequestCancelWorkflowExecution() {
 	s.Error(err)
 	s.IsType(&serviceerror.NotFound{}, err)
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -91,7 +91,7 @@ func (s *FunctionalSuite) TestExternalRequestCancelWorkflowExecution() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -100,7 +100,7 @@ func (s *FunctionalSuite) TestExternalRequestCancelWorkflowExecution() {
 		T:                   s.T(),
 	}
 
-	_, err = s.engine.RequestCancelWorkflowExecution(NewContext(), &workflowservice.RequestCancelWorkflowExecutionRequest{
+	_, err = s.client.RequestCancelWorkflowExecution(NewContext(), &workflowservice.RequestCancelWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -109,7 +109,7 @@ func (s *FunctionalSuite) TestExternalRequestCancelWorkflowExecution() {
 	})
 	s.NoError(err)
 
-	_, err = s.engine.RequestCancelWorkflowExecution(NewContext(), &workflowservice.RequestCancelWorkflowExecutionRequest{
+	_, err = s.client.RequestCancelWorkflowExecution(NewContext(), &workflowservice.RequestCancelWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -156,7 +156,7 @@ func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetRunnin
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -171,7 +171,7 @@ func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetRunnin
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we2, err0 := s.engine.StartWorkflowExecution(NewContext(), foreignRequest)
+	we2, err0 := s.client.StartWorkflowExecution(NewContext(), foreignRequest)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution on foreign namespace", tag.WorkflowNamespace(s.foreignNamespace), tag.WorkflowRunID(we2.RunId))
 
@@ -208,7 +208,7 @@ func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetRunnin
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -242,7 +242,7 @@ func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetRunnin
 	}
 
 	foreignPoller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.foreignNamespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -290,7 +290,7 @@ func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetFinish
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -305,7 +305,7 @@ func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetFinish
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we2, err0 := s.engine.StartWorkflowExecution(NewContext(), foreignRequest)
+	we2, err0 := s.client.StartWorkflowExecution(NewContext(), foreignRequest)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution on foreign namespace", tag.WorkflowNamespace(s.foreignNamespace), tag.WorkflowRunID(we2.RunId))
 
@@ -342,7 +342,7 @@ func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetFinish
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -372,7 +372,7 @@ func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetFinish
 	}
 
 	foreignPoller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.foreignNamespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -420,7 +420,7 @@ func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetNotFou
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -456,7 +456,7 @@ func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetNotFou
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -501,11 +501,11 @@ func (s *FunctionalSuite) TestImmediateChildCancellation_WorkflowTaskFailed() {
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
-	_, err := s.engine.RequestCancelWorkflowExecution(NewContext(),
+	_, err := s.client.RequestCancelWorkflowExecution(NewContext(),
 		&workflowservice.RequestCancelWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			WorkflowExecution: &commonpb.WorkflowExecution{
@@ -603,7 +603,7 @@ func (s *FunctionalSuite) TestImmediateChildCancellation_WorkflowTaskFailed() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -644,7 +644,7 @@ func (s *FunctionalSuite) TestImmediateChildCancellation_WorkflowTaskFailed() {
 		WorkflowId: id,
 	}))
 
-	_, err = s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+	_, err = s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: childWorkflowID,

--- a/tests/child_workflow.go
+++ b/tests/child_workflow.go
@@ -87,7 +87,7 @@ func (s *FunctionalSuite) TestChildWorkflowExecution() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -241,7 +241,7 @@ func (s *FunctionalSuite) TestChildWorkflowExecution() {
 	}
 
 	pollerParent := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueueParent,
 		Identity:            identity,
@@ -251,7 +251,7 @@ func (s *FunctionalSuite) TestChildWorkflowExecution() {
 	}
 
 	pollerChild := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueueChild,
 		Identity:            identity,
@@ -261,7 +261,7 @@ func (s *FunctionalSuite) TestChildWorkflowExecution() {
 	}
 
 	pollerGrandchild := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueueGrandchild,
 		Identity:            identity,
@@ -403,7 +403,7 @@ func (s *FunctionalSuite) TestCronChildWorkflowExecution() {
 	}
 
 	startParentWorkflowTS := time.Now().UTC()
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -467,7 +467,7 @@ func (s *FunctionalSuite) TestCronChildWorkflowExecution() {
 	}
 
 	pollerParent := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueueParent,
 		Identity:            identity,
@@ -477,7 +477,7 @@ func (s *FunctionalSuite) TestCronChildWorkflowExecution() {
 	}
 
 	pollerChild := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueueChild,
 		Identity:            identity,
@@ -517,7 +517,7 @@ func (s *FunctionalSuite) TestCronChildWorkflowExecution() {
 	}
 
 	// terminate the child workflow
-	_, terminateErr := s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, terminateErr := s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: childID,
@@ -539,7 +539,7 @@ func (s *FunctionalSuite) TestCronChildWorkflowExecution() {
 	startFilter.LatestTime = timestamppb.New(time.Now().UTC())
 	var closedExecutions []*workflowpb.WorkflowExecutionInfo
 	for i := 0; i < 10; i++ {
-		resp, err := s.engine.ListClosedWorkflowExecutions(NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
+		resp, err := s.client.ListClosedWorkflowExecutions(NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
 			Namespace:       s.namespace,
 			MaximumPageSize: 100,
 			StartTimeFilter: startFilter,
@@ -599,7 +599,7 @@ func (s *FunctionalSuite) TestRetryChildWorkflowExecution() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -696,7 +696,7 @@ func (s *FunctionalSuite) TestRetryChildWorkflowExecution() {
 	}
 
 	pollerParent := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueueParent,
 		Identity:            identity,
@@ -706,7 +706,7 @@ func (s *FunctionalSuite) TestRetryChildWorkflowExecution() {
 	}
 
 	pollerChild := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueueChild,
 		Identity:            identity,
@@ -815,7 +815,7 @@ func (s *FunctionalSuite) TestRetryFailChildWorkflowExecution() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -900,7 +900,7 @@ func (s *FunctionalSuite) TestRetryFailChildWorkflowExecution() {
 	}
 
 	pollerParent := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueueParent,
 		Identity:            identity,
@@ -910,7 +910,7 @@ func (s *FunctionalSuite) TestRetryFailChildWorkflowExecution() {
 	}
 
 	pollerChild := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueueChild,
 		Identity:            identity,

--- a/tests/client_suite.go
+++ b/tests/client_suite.go
@@ -859,7 +859,7 @@ func (s *ClientFunctionalSuite) TestStickyAutoReset() {
 	// stop worker
 	s.worker.Stop()
 	time.Sleep(time.Second * 11) // wait 11s (longer than 10s timeout), after this time, matching will detect StickyWorkerUnavailable
-	resp, err := s.engine.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
+	resp, err := s.client.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
 		Namespace:     s.namespace,
 		TaskQueue:     &taskqueuepb.TaskQueue{Name: stickyQueue, Kind: enumspb.TASK_QUEUE_KIND_STICKY, NormalName: s.taskQueue},
 		TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
@@ -888,7 +888,7 @@ func (s *ClientFunctionalSuite) TestStickyAutoReset() {
 	s.Equal(stickyQueue, ms.DatabaseMutableState.ExecutionInfo.StickyTaskQueue)
 
 	// now poll from normal queue, and it should see the full history.
-	task, err := s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	task, err := s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueuepb.TaskQueue{Name: s.taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 	})
@@ -1891,7 +1891,7 @@ func (s *ClientFunctionalSuite) TestBatchResetByBuildId() {
 		searchattribute.ExecutionStatus, "Running",
 		searchattribute.BuildIds, worker_versioning.UnversionedBuildIdSearchAttribute(v2))
 	s.Eventually(func() bool {
-		resp, err := s.engine.ListWorkflowExecutions(ctx, &workflowservice.ListWorkflowExecutionsRequest{
+		resp, err := s.client.ListWorkflowExecutions(ctx, &workflowservice.ListWorkflowExecutionsRequest{
 			Namespace: s.namespace,
 			Query:     query,
 		})
@@ -1899,7 +1899,7 @@ func (s *ClientFunctionalSuite) TestBatchResetByBuildId() {
 	}, 10*time.Second, 500*time.Millisecond)
 
 	// reset it using v2 as the bad build ID
-	_, err = s.engine.StartBatchOperation(context.Background(), &workflowservice.StartBatchOperationRequest{
+	_, err = s.client.StartBatchOperation(context.Background(), &workflowservice.StartBatchOperationRequest{
 		Namespace:       s.namespace,
 		VisibilityQuery: query,
 		JobId:           uuid.New(),

--- a/tests/continue_as_new.go
+++ b/tests/continue_as_new.go
@@ -85,7 +85,7 @@ func (s *FunctionalSuite) TestContinueAsNewWorkflow() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -132,7 +132,7 @@ func (s *FunctionalSuite) TestContinueAsNewWorkflow() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -192,7 +192,7 @@ func (s *FunctionalSuite) TestContinueAsNewRun_Timeout() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -232,7 +232,7 @@ func (s *FunctionalSuite) TestContinueAsNewRun_Timeout() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -294,7 +294,7 @@ func (s *FunctionalSuite) TestWorkflowContinueAsNew_TaskID() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -333,7 +333,7 @@ func (s *FunctionalSuite) TestWorkflowContinueAsNew_TaskID() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -527,12 +527,12 @@ func (s *FunctionalSuite) TestChildWorkflowWithContinueAsNew() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -641,12 +641,12 @@ func (s *FunctionalSuite) TestChildWorkflowWithContinueAsNewParentTerminate() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -673,7 +673,7 @@ func (s *FunctionalSuite) TestChildWorkflowWithContinueAsNewParentTerminate() {
 	s.NotNil(definition.startedEvent)
 
 	// Terminate parent workflow execution which should also trigger terminate of child due to parent close policy
-	_, err = s.engine.TerminateWorkflowExecution(
+	_, err = s.client.TerminateWorkflowExecution(
 		NewContext(),
 		&workflowservice.TerminateWorkflowExecutionRequest{
 			Namespace: s.namespace,
@@ -684,7 +684,7 @@ func (s *FunctionalSuite) TestChildWorkflowWithContinueAsNewParentTerminate() {
 	)
 	s.NoError(err)
 
-	parentDescribeResp, err := s.engine.DescribeWorkflowExecution(
+	parentDescribeResp, err := s.client.DescribeWorkflowExecution(
 		NewContext(),
 		&workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: s.namespace,
@@ -701,7 +701,7 @@ func (s *FunctionalSuite) TestChildWorkflowWithContinueAsNewParentTerminate() {
 	var childDescribeResp *workflowservice.DescribeWorkflowExecutionResponse
 	// Retry 10 times to wait for child to be terminated due to transfer task processing to enforce parent close policy
 	for i := 0; i < 10; i++ {
-		childDescribeResp, err = s.engine.DescribeWorkflowExecution(
+		childDescribeResp, err = s.client.DescribeWorkflowExecution(
 			NewContext(),
 			&workflowservice.DescribeWorkflowExecutionRequest{
 				Namespace: s.namespace,

--- a/tests/cron.go
+++ b/tests/cron.go
@@ -77,7 +77,7 @@ func (s *FunctionalSuite) TestCronWorkflow_Failed_Infinite() {
 		},
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -112,7 +112,7 @@ func (s *FunctionalSuite) TestCronWorkflow_Failed_Infinite() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -175,7 +175,7 @@ func (s *FunctionalSuite) TestCronWorkflow() {
 	}
 
 	startWorkflowTS := time.Now().UTC()
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -219,7 +219,7 @@ func (s *FunctionalSuite) TestCronWorkflow() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -235,7 +235,7 @@ func (s *FunctionalSuite) TestCronWorkflow() {
 	// Sleep some time before checking the open executions.
 	// This will not cost extra time as the polling for first workflow task will be blocked for 3 seconds.
 	time.Sleep(2 * time.Second)
-	resp, err := s.engine.ListOpenWorkflowExecutions(NewContext(), &workflowservice.ListOpenWorkflowExecutionsRequest{
+	resp, err := s.client.ListOpenWorkflowExecutions(NewContext(), &workflowservice.ListOpenWorkflowExecutionsRequest{
 		Namespace:       s.namespace,
 		MaximumPageSize: 100,
 		StartTimeFilter: startFilter,
@@ -265,7 +265,7 @@ func (s *FunctionalSuite) TestCronWorkflow() {
 
 	s.Equal(3, len(executions))
 
-	_, terminateErr := s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, terminateErr := s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -298,7 +298,7 @@ func (s *FunctionalSuite) TestCronWorkflow() {
 	startFilter.LatestTime = timestamppb.New(time.Now().UTC())
 	var closedExecutions []*workflowpb.WorkflowExecutionInfo
 	for i := 0; i < 10; i++ {
-		resp, err := s.engine.ListClosedWorkflowExecutions(NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
+		resp, err := s.client.ListClosedWorkflowExecutions(NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
 			Namespace:       s.namespace,
 			MaximumPageSize: 100,
 			StartTimeFilter: startFilter,
@@ -314,7 +314,7 @@ func (s *FunctionalSuite) TestCronWorkflow() {
 		time.Sleep(200 * time.Millisecond)
 	}
 	s.NotNil(closedExecutions)
-	dweResponse, err := s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+	dweResponse, err := s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: id,

--- a/tests/describe.go
+++ b/tests/describe.go
@@ -62,13 +62,13 @@ func (s *FunctionalSuite) TestDescribeWorkflowExecution() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
 	describeWorkflowExecution := func() (*workflowservice.DescribeWorkflowExecutionResponse, error) {
-		return s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+		return s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: id,
@@ -128,7 +128,7 @@ func (s *FunctionalSuite) TestDescribeWorkflowExecution() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -202,7 +202,7 @@ func (s *FunctionalSuite) TestDescribeTaskQueue() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -245,7 +245,7 @@ func (s *FunctionalSuite) TestDescribeTaskQueue() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -257,7 +257,7 @@ func (s *FunctionalSuite) TestDescribeTaskQueue() {
 
 	// this function poll events from history side
 	testDescribeTaskQueue := func(namespace string, taskqueue *taskqueuepb.TaskQueue, taskqueueType enumspb.TaskQueueType) []*taskqueuepb.PollerInfo {
-		responseInner, errInner := s.engine.DescribeTaskQueue(NewContext(), &workflowservice.DescribeTaskQueueRequest{
+		responseInner, errInner := s.client.DescribeTaskQueue(NewContext(), &workflowservice.DescribeTaskQueueRequest{
 			Namespace:     namespace,
 			TaskQueue:     taskqueue,
 			TaskQueueType: taskqueueType,

--- a/tests/describe_task_queue.go
+++ b/tests/describe_task_queue.go
@@ -32,8 +32,9 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
-	"go.temporal.io/server/common/dynamicconfig"
 	"google.golang.org/protobuf/types/known/durationpb"
+
+	"go.temporal.io/server/common/dynamicconfig"
 )
 
 type (
@@ -104,7 +105,7 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateBacklogInfo(
 			Identity:            identity,
 		}
 
-		_, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+		_, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 		s.NoError(err0)
 	}
 
@@ -116,7 +117,7 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateBacklogInfo(
 
 	// Poll the tasks
 	for i := 0; i < workflows; {
-		resp1, err1 := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+		resp1, err1 := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.namespace,
 			TaskQueue: tq,
 			Identity:  identity,
@@ -183,7 +184,7 @@ func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(tl string, expectedBa
 
 	if isEnhancedMode {
 		s.Eventually(func() bool {
-			resp, err = s.engine.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
+			resp, err = s.client.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
 				Namespace:              s.namespace,
 				TaskQueue:              &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				ApiMode:                enumspb.DESCRIBE_TASK_QUEUE_MODE_ENHANCED,
@@ -220,7 +221,7 @@ func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(tl string, expectedBa
 	} else {
 		// Querying the Legacy API
 		s.Eventually(func() bool {
-			resp, err = s.engine.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
+			resp, err = s.client.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
 				Namespace:              s.namespace,
 				TaskQueue:              &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				ApiMode:                enumspb.DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED,

--- a/tests/eager_workflow_start.go
+++ b/tests/eager_workflow_start.go
@@ -36,9 +36,10 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
-	"go.temporal.io/server/common/dynamicconfig"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
+
+	"go.temporal.io/server/common/dynamicconfig"
 )
 
 func (s *FunctionalSuite) defaultWorkflowID() string {
@@ -73,7 +74,7 @@ func (s *FunctionalSuite) startEagerWorkflow(baseOptions *workflowservice.StartW
 		options.RequestId = uuid.New()
 	}
 
-	response, err := s.engine.StartWorkflowExecution(NewContext(), options)
+	response, err := s.client.StartWorkflowExecution(NewContext(), options)
 	s.Require().NoError(err)
 
 	return response
@@ -93,12 +94,12 @@ func (s *FunctionalSuite) respondWorkflowTaskCompleted(task *workflowservice.Pol
 			},
 		}}},
 	}
-	_, err = s.engine.RespondWorkflowTaskCompleted(NewContext(), &completion)
+	_, err = s.client.RespondWorkflowTaskCompleted(NewContext(), &completion)
 	s.Require().NoError(err)
 }
 
 func (s *FunctionalSuite) pollWorkflowTaskQueue() *workflowservice.PollWorkflowTaskQueueResponse {
-	task, err := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	task, err := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: s.defaultTaskQueue(),
 		Identity:  "test",

--- a/tests/functional.go
+++ b/tests/functional.go
@@ -84,7 +84,7 @@ func (s *FunctionalSuite) TearDownTest() {
 
 func (s *FunctionalSuite) sendSignal(namespace string, execution *commonpb.WorkflowExecution, signalName string,
 	input *commonpb.Payloads, identity string) error {
-	_, err := s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err := s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         namespace,
 		WorkflowExecution: execution,
 		SignalName:        signalName,
@@ -98,7 +98,7 @@ func (s *FunctionalSuite) sendSignal(namespace string, execution *commonpb.Workf
 func (s *FunctionalSuite) closeShard(wid string) {
 	s.T().Helper()
 
-	resp, err := s.engine.DescribeNamespace(NewContext(), &workflowservice.DescribeNamespaceRequest{
+	resp, err := s.client.DescribeNamespace(NewContext(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: s.namespace,
 	})
 	s.NoError(err)

--- a/tests/gethistory.go
+++ b/tests/gethistory.go
@@ -33,8 +33,9 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
-	"go.temporal.io/server/common/testing/historyrequire"
 	"google.golang.org/protobuf/types/known/durationpb"
+
+	"go.temporal.io/server/common/testing/historyrequire"
 
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
@@ -98,7 +99,7 @@ func (s *FunctionalSuite) TestGetWorkflowExecutionHistory_All() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -143,7 +144,7 @@ func (s *FunctionalSuite) TestGetWorkflowExecutionHistory_All() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -155,7 +156,7 @@ func (s *FunctionalSuite) TestGetWorkflowExecutionHistory_All() {
 
 	// this function poll events from history side
 	getHistory := func(namespace string, workflowID string, token []byte, isLongPoll bool) ([]*historypb.HistoryEvent, []byte) {
-		responseInner, err := s.engine.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
+		responseInner, err := s.client.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
 			Namespace: namespace,
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: workflowID,
@@ -271,7 +272,7 @@ func (s *FunctionalSuite) TestGetWorkflowExecutionHistory_Close() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -316,7 +317,7 @@ func (s *FunctionalSuite) TestGetWorkflowExecutionHistory_Close() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -329,7 +330,7 @@ func (s *FunctionalSuite) TestGetWorkflowExecutionHistory_Close() {
 	// this function poll events from history side
 	getHistory := func(namespace string, workflowID string, token []byte, isLongPoll bool) ([]*historypb.HistoryEvent, []byte) {
 		closeEventOnly := enumspb.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT
-		responseInner, err := s.engine.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
+		responseInner, err := s.client.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
 			Namespace: namespace,
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: workflowID,
@@ -427,7 +428,7 @@ func (s *RawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.Nil(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -476,7 +477,7 @@ func (s *RawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -488,7 +489,7 @@ func (s *RawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 
 	// this function poll events from history side
 	getHistoryWithLongPoll := func(namespace string, workflowID string, token []byte, isLongPoll bool) ([]*commonpb.DataBlob, []byte) {
-		responseInner, err := s.engine.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
+		responseInner, err := s.client.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
 			Namespace: namespace,
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: workflowID,
@@ -504,7 +505,7 @@ func (s *RawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 	}
 
 	getHistory := func(namespace string, workflowID string, token []byte) ([]*commonpb.DataBlob, []byte) {
-		responseInner, err := s.engine.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
+		responseInner, err := s.client.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
 			Namespace: namespace,
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: workflowID,
@@ -783,7 +784,7 @@ func reverseSlice(events []*historypb.HistoryEvent) []*historypb.HistoryEvent {
 }
 
 func (s *FunctionalTestBase) getHistoryReverse(namespace string, execution *commonpb.WorkflowExecution, pageSize int32) []*historypb.HistoryEvent {
-	historyResponse, err := s.engine.GetWorkflowExecutionHistoryReverse(NewContext(), &workflowservice.GetWorkflowExecutionHistoryReverseRequest{
+	historyResponse, err := s.client.GetWorkflowExecutionHistoryReverse(NewContext(), &workflowservice.GetWorkflowExecutionHistoryReverseRequest{
 		Namespace:       namespace,
 		Execution:       execution,
 		NextPageToken:   nil,
@@ -793,7 +794,7 @@ func (s *FunctionalTestBase) getHistoryReverse(namespace string, execution *comm
 
 	events := historyResponse.History.Events
 	for historyResponse.NextPageToken != nil {
-		historyResponse, err = s.engine.GetWorkflowExecutionHistoryReverse(NewContext(), &workflowservice.GetWorkflowExecutionHistoryReverseRequest{
+		historyResponse, err = s.client.GetWorkflowExecutionHistoryReverse(NewContext(), &workflowservice.GetWorkflowExecutionHistoryReverseRequest{
 			Namespace:       namespace,
 			Execution:       execution,
 			NextPageToken:   historyResponse.NextPageToken,

--- a/tests/namespace_interceptor.go
+++ b/tests/namespace_interceptor.go
@@ -28,14 +28,16 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	"go.temporal.io/server/common/namespace"
 	"google.golang.org/protobuf/types/known/durationpb"
+
+	"go.temporal.io/server/common/namespace"
 
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
+
 	"go.temporal.io/server/common/payloads"
 )
 
@@ -81,13 +83,13 @@ func newSystemUnderTestConnector(s *FunctionalSuite) *sutConnector {
 func (b *sutConnector) startWorkflowExecution(ns namespace.Name) error {
 	request := newStartWorkflowExecutionRequest(ns, b.id, b.identity, b.taskQueue)
 
-	_, err := b.suite.engine.StartWorkflowExecution(NewContext(), request)
+	_, err := b.suite.client.StartWorkflowExecution(NewContext(), request)
 	return err
 }
 
 func (b *sutConnector) pollWorkflowTaskQueue(ns namespace.Name) ([]byte, error) {
 	request := newPollWorkflowTaskQueueRequest(ns, b.identity, b.taskQueue)
-	resp, err := b.suite.engine.PollWorkflowTaskQueue(NewContext(), request)
+	resp, err := b.suite.client.PollWorkflowTaskQueue(NewContext(), request)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +99,7 @@ func (b *sutConnector) pollWorkflowTaskQueue(ns namespace.Name) ([]byte, error) 
 
 func (b *sutConnector) respondWorkflowTaskCompleted(token []byte, ns namespace.Name) error {
 	request := newRespondWorkflowTaskCompletedRequest(ns, b.stickyTaskQueue, token)
-	_, err := b.suite.engine.RespondWorkflowTaskCompleted(NewContext(), request)
+	_, err := b.suite.client.RespondWorkflowTaskCompleted(NewContext(), request)
 	return err
 }
 

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -97,7 +97,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationCancelation() {
 	s.NoError(err)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		pollResp, err := s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+		pollResp, err := s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.namespace,
 			TaskQueue: &taskqueue.TaskQueue{
 				Name: taskQueue,
@@ -106,7 +106,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationCancelation() {
 			Identity: "test",
 		})
 		require.NoError(t, err)
-		_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 			Identity:  "test",
 			TaskToken: pollResp.TaskToken,
 			Commands: []*commandpb.Command{
@@ -127,7 +127,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationCancelation() {
 	}, time.Second*20, time.Millisecond*200)
 
 	// Poll and wait for the "started" event to be recorded.
-	pollResp, err := s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err := s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueue.TaskQueue{
 			Name: taskQueue,
@@ -148,7 +148,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationCancelation() {
 	})
 	s.Greater(scheduledEventIdx, 0)
 
-	_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 		Commands: []*commandpb.Command{
@@ -214,7 +214,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion() {
 	s.NoError(err)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		pollResp, err := s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+		pollResp, err := s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.namespace,
 			TaskQueue: &taskqueue.TaskQueue{
 				Name: taskQueue,
@@ -223,7 +223,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion() {
 			Identity: "test",
 		})
 		require.NoError(t, err)
-		_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 			Identity:  "test",
 			TaskToken: pollResp.TaskToken,
 			Commands: []*commandpb.Command{
@@ -243,7 +243,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion() {
 		assert.NoError(t, err)
 	}, time.Second*20, time.Millisecond*200)
 
-	pollResp, err := s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err := s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueue.TaskQueue{
 			Name: taskQueue,
@@ -257,7 +257,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion() {
 	})
 	s.Greater(completedEventIdx, 0)
 
-	_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 		Commands: []*commandpb.Command{
@@ -316,7 +316,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion_LargePayload() 
 	s.NoError(err)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		pollResp, err := s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+		pollResp, err := s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.namespace,
 			TaskQueue: &taskqueue.TaskQueue{
 				Name: taskQueue,
@@ -325,7 +325,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion_LargePayload() 
 			Identity: "test",
 		})
 		require.NoError(t, err)
-		_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 			Identity:  "test",
 			TaskToken: pollResp.TaskToken,
 			Commands: []*commandpb.Command{
@@ -345,7 +345,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion_LargePayload() 
 		assert.NoError(t, err)
 	}, time.Second*20, time.Millisecond*200)
 
-	pollResp, err := s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err := s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueue.TaskQueue{
 			Name: taskQueue,
@@ -359,7 +359,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion_LargePayload() 
 	})
 	s.Greater(failedEventIdx, 0)
 
-	_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 		Commands: []*commandpb.Command{
@@ -389,7 +389,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {
 	taskQueue := s.randomizeStr(s.T().Name())
 	endpointName := "test_async_completion_endpoint_name"
 
-	testClusterInfo, err := s.engine.GetClusterInfo(ctx, &workflowservice.GetClusterInfoRequest{})
+	testClusterInfo, err := s.client.GetClusterInfo(ctx, &workflowservice.GetClusterInfoRequest{})
 	s.NoError(err)
 
 	var callbackToken, publicCallbackUrl string
@@ -424,7 +424,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {
 	}, "workflow")
 	s.NoError(err)
 
-	pollResp, err := s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err := s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueue.TaskQueue{
 			Name: taskQueue,
@@ -433,7 +433,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {
 		Identity: "test",
 	})
 	s.NoError(err)
-	_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 		Commands: []*commandpb.Command{
@@ -453,7 +453,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {
 	s.NoError(err)
 
 	// Poll and verify that the "started" event was recorded.
-	pollResp, err = s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err = s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueue.TaskQueue{
 			Name: taskQueue,
@@ -462,7 +462,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {
 		Identity: "test",
 	})
 	s.NoError(err)
-	_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 	})
@@ -492,7 +492,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {
 	s.NoError(err)
 
 	invalidNamespace := s.randomizeStr("ns")
-	_, err = s.engine.RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{
+	_, err = s.client.RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{
 		Namespace:                        invalidNamespace,
 		WorkflowExecutionRetentionPeriod: durationpb.New(time.Hour * 24),
 	})
@@ -561,7 +561,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {
 	s.Subset(snap["nexus_completion_requests"][0].Tags, map[string]string{"namespace": s.namespace, "outcome": "error_not_found"})
 
 	// Poll again and verify the completion is recorded and triggers workflow progress.
-	pollResp, err = s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err = s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueue.TaskQueue{
 			Name: taskQueue,
@@ -575,7 +575,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {
 	})
 	s.Greater(completedEventIdx, 0)
 
-	_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 		Commands: []*commandpb.Command{
@@ -636,7 +636,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncFailure() {
 	s.NoError(err)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
-		pollResp, err := s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+		pollResp, err := s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.namespace,
 			TaskQueue: &taskqueue.TaskQueue{
 				Name: taskQueue,
@@ -645,7 +645,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncFailure() {
 			Identity: "test",
 		})
 		require.NoError(t, err)
-		_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 			Identity:  "test",
 			TaskToken: pollResp.TaskToken,
 			Commands: []*commandpb.Command{
@@ -666,7 +666,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncFailure() {
 	}, time.Second*20, time.Millisecond*200)
 
 	// Poll and verify that the "started" event was recorded.
-	pollResp, err := s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err := s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueue.TaskQueue{
 			Name: taskQueue,
@@ -675,7 +675,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncFailure() {
 		Identity: "test",
 	})
 	s.NoError(err)
-	_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 	})
@@ -699,7 +699,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncFailure() {
 	s.Subset(snap["nexus_completion_requests"][0].Tags, map[string]string{"namespace": s.namespace, "outcome": "success"})
 
 	// Poll again and verify the completion is recorded and triggers workflow progress.
-	pollResp, err = s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err = s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueue.TaskQueue{
 			Name: taskQueue,
@@ -713,7 +713,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncFailure() {
 	})
 	s.Greater(completedEventIdx, 0)
 
-	_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 		Commands: []*commandpb.Command{
@@ -875,7 +875,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletionInternalAuth() 
 			},
 		}
 
-		_, err := s.engine.StartWorkflowExecution(ctx, completionWFStartReq)
+		_, err := s.client.StartWorkflowExecution(ctx, completionWFStartReq)
 		s.NoError(err)
 
 		return &nexuspb.Response{
@@ -891,7 +891,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletionInternalAuth() 
 		}, nil
 	})
 
-	pollResp, err := s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err := s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueue.TaskQueue{
 			Name: taskQueue,
@@ -900,7 +900,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletionInternalAuth() 
 		Identity: "test",
 	})
 	s.NoError(err)
-	_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 		Commands: []*commandpb.Command{
@@ -920,7 +920,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletionInternalAuth() 
 	s.NoError(err)
 
 	// Poll and verify that the "started" event was recorded.
-	pollResp, err = s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err = s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueue.TaskQueue{
 			Name: taskQueue,
@@ -929,7 +929,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletionInternalAuth() 
 		Identity: "test",
 	})
 	s.NoError(err)
-	_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 	})
@@ -940,7 +940,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletionInternalAuth() 
 	s.Greater(startedEventIdx, 0)
 
 	// Complete workflow containing callback
-	pollResp, err = s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err = s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueue.TaskQueue{
 			Name: completionWFTaskQueue,
@@ -949,7 +949,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletionInternalAuth() 
 		Identity: "test",
 	})
 	s.NoError(err)
-	_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 		Commands: []*commandpb.Command{
@@ -970,7 +970,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletionInternalAuth() 
 	s.NoError(err)
 
 	// Poll again and verify the completion is recorded and triggers workflow progress.
-	pollResp, err = s.engine.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResp, err = s.client.PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: &taskqueue.TaskQueue{
 			Name: taskQueue,
@@ -984,7 +984,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletionInternalAuth() 
 	})
 	s.Greater(completedEventIdx, 0)
 
-	_, err = s.engine.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Identity:  "test",
 		TaskToken: pollResp.TaskToken,
 		Commands: []*commandpb.Command{

--- a/tests/relay_task.go
+++ b/tests/relay_task.go
@@ -57,7 +57,7 @@ func (s *FunctionalSuite) TestRelayWorkflowTaskTimeout() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -84,7 +84,7 @@ func (s *FunctionalSuite) TestRelayWorkflowTaskTimeout() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,

--- a/tests/reset_workflow.go
+++ b/tests/reset_workflow.go
@@ -72,7 +72,7 @@ func (s *FunctionalSuite) TestResetWorkflow() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -138,7 +138,7 @@ func (s *FunctionalSuite) TestResetWorkflow() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -176,7 +176,7 @@ func (s *FunctionalSuite) TestResetWorkflow() {
 	}
 
 	// Reset workflow execution
-	_, err = s.engine.ResetWorkflowExecution(NewContext(), &workflowservice.ResetWorkflowExecutionRequest{
+	_, err = s.client.ResetWorkflowExecution(NewContext(), &workflowservice.ResetWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -285,7 +285,7 @@ func (t resetTest) sendSignalAndProcessWFT(poller *TaskPoller) {
 		Input:             t.tv.Any().Payloads(),
 		Identity:          t.tv.WorkerIdentity(),
 	}
-	_, err := t.engine.SignalWorkflowExecution(NewContext(), signalRequest)
+	_, err := t.client.SignalWorkflowExecution(NewContext(), signalRequest)
 	t.NoError(err)
 	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	t.NoError(err)
@@ -364,7 +364,7 @@ func (t *resetTest) wftHandler(task *workflowservice.PollWorkflowTaskQueueRespon
 }
 
 func (t resetTest) reset(eventId int64) string {
-	resp, err := t.engine.ResetWorkflowExecution(NewContext(), &workflowservice.ResetWorkflowExecutionRequest{
+	resp, err := t.client.ResetWorkflowExecution(NewContext(), &workflowservice.ResetWorkflowExecutionRequest{
 		Namespace:                 t.namespace,
 		WorkflowExecution:         t.tv.WorkflowExecution(),
 		Reason:                    "reset execution from test",
@@ -383,7 +383,7 @@ func (t *resetTest) run() {
 	t.tv = t.FunctionalSuite.startWorkflow(t.tv)
 
 	poller := &TaskPoller{
-		Engine:              t.engine,
+		Client:              t.client,
 		Namespace:           t.namespace,
 		TaskQueue:           t.tv.TaskQueue(),
 		Identity:            t.tv.WorkerIdentity(),
@@ -543,7 +543,7 @@ func (s *FunctionalSuite) testResetWorkflowReapplyBuffer(
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	runID := we.RunId
 
@@ -568,7 +568,7 @@ func (s *FunctionalSuite) testResetWorkflowReapplyBuffer(
 	wtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
 		if len(resetRunID) == 0 {
 			signalRequest.RequestId = uuid.New()
-			_, err := s.engine.SignalWorkflowExecution(NewContext(), signalRequest)
+			_, err := s.client.SignalWorkflowExecution(NewContext(), signalRequest)
 			s.NoError(err)
 
 			// events layout
@@ -577,7 +577,7 @@ func (s *FunctionalSuite) testResetWorkflowReapplyBuffer(
 			//  3. WorkflowTaskStarted
 			//  x. WorkflowExecutionSignaled
 
-			resp, err := s.engine.ResetWorkflowExecution(NewContext(), &workflowservice.ResetWorkflowExecutionRequest{
+			resp, err := s.client.ResetWorkflowExecution(NewContext(), &workflowservice.ResetWorkflowExecutionRequest{
 				Namespace: s.namespace,
 				WorkflowExecution: &commonpb.WorkflowExecution{
 					WorkflowId: workflowID,
@@ -606,7 +606,7 @@ func (s *FunctionalSuite) testResetWorkflowReapplyBuffer(
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -691,10 +691,10 @@ func (s *FunctionalSuite) testResetWorkflowRangeScheduleToStart(
 		Identity:            identity,
 	}
 
-	we, err := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err)
 
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: workflowID,
@@ -730,7 +730,7 @@ func (s *FunctionalSuite) testResetWorkflowRangeScheduleToStart(
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -752,7 +752,7 @@ func (s *FunctionalSuite) testResetWorkflowRangeScheduleToStart(
 	//  5. WorkflowTaskCompleted
 
 	// Reset workflow execution
-	_, err = s.engine.ResetWorkflowExecution(NewContext(), &workflowservice.ResetWorkflowExecutionRequest{
+	_, err = s.client.ResetWorkflowExecution(NewContext(), &workflowservice.ResetWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: workflowID,

--- a/tests/signal_workflow.go
+++ b/tests/signal_workflow.go
@@ -68,7 +68,7 @@ func (s *FunctionalSuite) TestSignalWorkflow() {
 	header := &commonpb.Header{
 		Fields: map[string]*commonpb.Payload{"signal header key": payload.EncodeString("signal header value")},
 	}
-	_, err0 := s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err0 := s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -95,7 +95,7 @@ func (s *FunctionalSuite) TestSignalWorkflow() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -150,7 +150,7 @@ func (s *FunctionalSuite) TestSignalWorkflow() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -168,7 +168,7 @@ func (s *FunctionalSuite) TestSignalWorkflow() {
 	// Send first signal using RunID
 	signalName := "my signal"
 	signalInput := payloads.EncodeString("my signal input")
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -196,7 +196,7 @@ func (s *FunctionalSuite) TestSignalWorkflow() {
 	// Send another signal without RunID
 	signalName = "another signal"
 	signalInput = payloads.EncodeString("another signal input")
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -219,7 +219,7 @@ func (s *FunctionalSuite) TestSignalWorkflow() {
 	s.Equal(identity, signalEvent.GetWorkflowExecutionSignaledEventAttributes().Identity)
 
 	// Terminate workflow execution
-	_, err = s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -231,7 +231,7 @@ func (s *FunctionalSuite) TestSignalWorkflow() {
 	s.NoError(err)
 
 	// Send signal to terminated workflow
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -269,7 +269,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_DuplicateRequest() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -326,7 +326,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_DuplicateRequest() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -356,7 +356,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_DuplicateRequest() {
 		Identity:   identity,
 		RequestId:  requestID,
 	}
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), signalReqest)
+	_, err = s.client.SignalWorkflowExecution(NewContext(), signalReqest)
 	s.NoError(err)
 
 	// Process signal in workflow
@@ -372,7 +372,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_DuplicateRequest() {
 	s.Equal(1, numOfSignaledEvent)
 
 	// Send another signal with same request id
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), signalReqest)
+	_, err = s.client.SignalWorkflowExecution(NewContext(), signalReqest)
 	s.NoError(err)
 
 	// Process signal in workflow
@@ -408,7 +408,7 @@ func (s *FunctionalSuite) TestSignalExternalWorkflowCommand() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -423,7 +423,7 @@ func (s *FunctionalSuite) TestSignalExternalWorkflowCommand() {
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we2, err0 := s.engine.StartWorkflowExecution(NewContext(), foreignRequest)
+	we2, err0 := s.client.StartWorkflowExecution(NewContext(), foreignRequest)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution on foreign Namespace", tag.WorkflowNamespace(s.foreignNamespace), tag.WorkflowRunID(we2.RunId))
 
@@ -475,7 +475,7 @@ func (s *FunctionalSuite) TestSignalExternalWorkflowCommand() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -527,7 +527,7 @@ func (s *FunctionalSuite) TestSignalExternalWorkflowCommand() {
 	}
 
 	foreignPoller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.foreignNamespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -626,7 +626,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_Cron_NoWorkflowTaskCreated() {
 	}
 	now := time.Now().UTC()
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -634,7 +634,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_Cron_NoWorkflowTaskCreated() {
 	// Send first signal using RunID
 	signalName := "my signal"
 	signalInput := payloads.EncodeString("my signal input")
-	_, err := s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err := s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -660,7 +660,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_Cron_NoWorkflowTaskCreated() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -699,7 +699,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_NoWorkflowTaskCreated() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -721,7 +721,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_NoWorkflowTaskCreated() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -736,7 +736,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_NoWorkflowTaskCreated() {
 	s.NoError(err)
 
 	// Send first signal which should NOT generate a new wft
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -750,7 +750,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_NoWorkflowTaskCreated() {
 	s.NoError(err)
 
 	// Send second signal which should generate a new wft
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -793,7 +793,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_WorkflowCloseAttempted() {
 	workflowType := &commonpb.WorkflowType{Name: wt}
 	taskQueue := &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
 
-	we, err := s.engine.StartWorkflowExecution(NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+	we, err := s.client.StartWorkflowExecution(NewContext(), &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.New(),
 		Namespace:           s.namespace,
 		WorkflowId:          id,
@@ -809,7 +809,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_WorkflowCloseAttempted() {
 	attemptCount := 1
 	wtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
 		if attemptCount == 1 {
-			_, err := s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+			_, err := s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 				Namespace: s.namespace,
 				WorkflowExecution: &commonpb.WorkflowExecution{
 					WorkflowId: id,
@@ -824,7 +824,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_WorkflowCloseAttempted() {
 
 		if attemptCount == 2 {
 			ctx, _ := rpc.NewContextWithTimeoutAndVersionHeaders(time.Second)
-			_, err := s.engine.SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+			_, err := s.client.SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
 				Namespace: s.namespace,
 				WorkflowExecution: &commonpb.WorkflowExecution{
 					WorkflowId: id,
@@ -848,7 +848,7 @@ func (s *FunctionalSuite) TestSignalWorkflow_WorkflowCloseAttempted() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -889,7 +889,7 @@ func (s *FunctionalSuite) TestSignalExternalWorkflowCommand_WithoutRunID() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -904,7 +904,7 @@ func (s *FunctionalSuite) TestSignalExternalWorkflowCommand_WithoutRunID() {
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we2, err0 := s.engine.StartWorkflowExecution(NewContext(), foreignRequest)
+	we2, err0 := s.client.StartWorkflowExecution(NewContext(), foreignRequest)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution on foreign Namespace", tag.WorkflowNamespace(s.foreignNamespace), tag.WorkflowRunID(we2.RunId))
 
@@ -952,7 +952,7 @@ func (s *FunctionalSuite) TestSignalExternalWorkflowCommand_WithoutRunID() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1004,7 +1004,7 @@ func (s *FunctionalSuite) TestSignalExternalWorkflowCommand_WithoutRunID() {
 	}
 
 	foreignPoller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.foreignNamespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1099,7 +1099,7 @@ func (s *FunctionalSuite) TestSignalExternalWorkflowCommand_UnKnownTarget() {
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -1147,7 +1147,7 @@ func (s *FunctionalSuite) TestSignalExternalWorkflowCommand_UnKnownTarget() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1221,7 +1221,7 @@ func (s *FunctionalSuite) TestSignalExternalWorkflowCommand_SignalSelf() {
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -1269,7 +1269,7 @@ func (s *FunctionalSuite) TestSignalExternalWorkflowCommand_SignalSelf() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1349,7 +1349,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -1420,7 +1420,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1454,7 +1454,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow() {
 		Identity:              identity,
 		WorkflowIdReusePolicy: wfIDReusePolicy,
 	}
-	resp, err := s.engine.SignalWithStartWorkflowExecution(NewContext(), sRequest)
+	resp, err := s.client.SignalWithStartWorkflowExecution(NewContext(), sRequest)
 	s.NoError(err)
 	s.False(resp.Started)
 	s.Equal(we.GetRunId(), resp.GetRunId())
@@ -1471,7 +1471,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow() {
 	s.Equal(identity, signalEvent.GetWorkflowExecutionSignaledEventAttributes().Identity)
 
 	// Terminate workflow execution
-	_, err = s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -1489,7 +1489,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow() {
 	sRequest.SignalInput = signalInput
 	sRequest.WorkflowId = id
 
-	resp, err = s.engine.SignalWithStartWorkflowExecution(NewContext(), sRequest)
+	resp, err = s.client.SignalWithStartWorkflowExecution(NewContext(), sRequest)
 	s.NoError(err)
 	s.True(resp.Started)
 	s.NotNil(resp.GetRunId())
@@ -1516,7 +1516,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow() {
 	sRequest.SignalName = signalName
 	sRequest.SignalInput = signalInput
 	sRequest.WorkflowId = id
-	resp, err = s.engine.SignalWithStartWorkflowExecution(NewContext(), sRequest)
+	resp, err = s.client.SignalWithStartWorkflowExecution(NewContext(), sRequest)
 	s.NoError(err)
 	s.NotNil(resp.GetRunId())
 	s.True(resp.Started)
@@ -1550,7 +1550,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow() {
 	// Assert visibility is correct
 	s.Eventually(
 		func() bool {
-			listResp, err := s.engine.ListOpenWorkflowExecutions(NewContext(), listOpenRequest)
+			listResp, err := s.client.ListOpenWorkflowExecutions(NewContext(), listOpenRequest)
 			s.NoError(err)
 			return len(listResp.Executions) == 1
 		},
@@ -1559,7 +1559,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow() {
 	)
 
 	// Terminate workflow execution and assert visibility is correct
-	_, err = s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -1572,7 +1572,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow() {
 
 	s.Eventually(
 		func() bool {
-			listResp, err := s.engine.ListOpenWorkflowExecutions(NewContext(), listOpenRequest)
+			listResp, err := s.client.ListOpenWorkflowExecutions(NewContext(), listOpenRequest)
 			s.NoError(err)
 			return len(listResp.Executions) == 0
 		},
@@ -1591,7 +1591,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow() {
 			WorkflowId: id,
 		}},
 	}
-	listClosedResp, err := s.engine.ListClosedWorkflowExecutions(NewContext(), listClosedRequest)
+	listClosedResp, err := s.client.ListClosedWorkflowExecutions(NewContext(), listClosedRequest)
 	s.NoError(err)
 	s.Equal(1, len(listClosedResp.Executions))
 }
@@ -1624,7 +1624,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_ResolveIDDeduplication() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -1667,7 +1667,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_ResolveIDDeduplication() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1704,7 +1704,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_ResolveIDDeduplication() {
 		WorkflowIdReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
 	}
 	ctx, _ := rpc.NewContextWithTimeoutAndVersionHeaders(5 * time.Second)
-	resp, err := s.engine.SignalWithStartWorkflowExecution(ctx, sRequest)
+	resp, err := s.client.SignalWithStartWorkflowExecution(ctx, sRequest)
 	s.Nil(resp)
 	s.Error(err)
 	s.True(strings.Contains(err.Error(), "reject duplicate workflow Id"))
@@ -1713,7 +1713,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_ResolveIDDeduplication() {
 	// test WorkflowIdReusePolicy: AllowDuplicateFailedOnly
 	sRequest.WorkflowIdReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY
 	ctx, _ = rpc.NewContextWithTimeoutAndVersionHeaders(5 * time.Second)
-	resp, err = s.engine.SignalWithStartWorkflowExecution(ctx, sRequest)
+	resp, err = s.client.SignalWithStartWorkflowExecution(ctx, sRequest)
 	s.Nil(resp)
 	s.Error(err)
 	s.True(strings.Contains(err.Error(), "allow duplicate workflow Id if last run failed"))
@@ -1722,13 +1722,13 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_ResolveIDDeduplication() {
 	// test WorkflowIdReusePolicy: AllowDuplicate
 	sRequest.WorkflowIdReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
 	ctx, _ = rpc.NewContextWithTimeoutAndVersionHeaders(5 * time.Second)
-	resp, err = s.engine.SignalWithStartWorkflowExecution(ctx, sRequest)
+	resp, err = s.client.SignalWithStartWorkflowExecution(ctx, sRequest)
 	s.NoError(err)
 	s.NotEmpty(resp.GetRunId())
 	s.True(resp.Started)
 
 	// Terminate workflow execution
-	_, err = s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -1741,7 +1741,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_ResolveIDDeduplication() {
 
 	// test WorkflowIdReusePolicy: AllowDuplicateFailedOnly
 	sRequest.WorkflowIdReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY
-	resp, err = s.engine.SignalWithStartWorkflowExecution(NewContext(), sRequest)
+	resp, err = s.client.SignalWithStartWorkflowExecution(NewContext(), sRequest)
 	s.NoError(err)
 	s.NotEmpty(resp.GetRunId())
 	s.True(resp.Started)
@@ -1749,13 +1749,13 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_ResolveIDDeduplication() {
 	// test WorkflowIdReusePolicy: TerminateIfRunning (for backwards compatibility)
 	prevRunID := resp.RunId
 	sRequest.WorkflowIdReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING
-	resp, err = s.engine.SignalWithStartWorkflowExecution(NewContext(), sRequest)
+	resp, err = s.client.SignalWithStartWorkflowExecution(NewContext(), sRequest)
 	s.NoError(err)
 	s.NotEmpty(resp.GetRunId())
 	s.NotEqual(prevRunID, resp.GetRunId())
 	s.True(resp.Started)
 
-	descResp, err := s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+	descResp, err := s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		Execution: &commonpb.WorkflowExecution{WorkflowId: id, RunId: prevRunID},
 	})
@@ -1766,20 +1766,20 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_ResolveIDDeduplication() {
 	prevRunID = resp.RunId
 	sRequest.WorkflowIdReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
 	sRequest.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING
-	resp, err = s.engine.SignalWithStartWorkflowExecution(NewContext(), sRequest)
+	resp, err = s.client.SignalWithStartWorkflowExecution(NewContext(), sRequest)
 	s.NoError(err)
 	s.NotEmpty(resp.GetRunId())
 	s.NotEqual(prevRunID, resp.GetRunId())
 	s.True(resp.Started)
 
-	descResp, err = s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+	descResp, err = s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		Execution: &commonpb.WorkflowExecution{WorkflowId: id, RunId: prevRunID},
 	})
 	s.NoError(err)
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, descResp.WorkflowExecutionInfo.Status)
 
-	descResp, err = s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+	descResp, err = s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -1818,7 +1818,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_StartDelay() {
 	}
 
 	reqStartTime := time.Now()
-	we0, startErr := s.engine.SignalWithStartWorkflowExecution(NewContext(), sRequest)
+	we0, startErr := s.client.SignalWithStartWorkflowExecution(NewContext(), sRequest)
 	s.NoError(startErr)
 
 	var signalEvent *historypb.HistoryEvent
@@ -1843,7 +1843,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_StartDelay() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		StickyTaskQueue:     &taskqueuepb.TaskQueue{Name: stickyTq, Kind: enumspb.TASK_QUEUE_KIND_STICKY, NormalName: tl},
@@ -1861,7 +1861,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_StartDelay() {
 	s.ProtoEqual(signalInput, signalEvent.GetWorkflowExecutionSignaledEventAttributes().Input)
 	s.Equal(identity, signalEvent.GetWorkflowExecutionSignaledEventAttributes().Identity)
 
-	descResp, descErr := s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+	descResp, descErr := s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -1893,7 +1893,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_NoWorkflowTaskCreated() {
 		Identity:            identity,
 	}
 
-	we0, err := s.engine.StartWorkflowExecution(NewContext(), request)
+	we0, err := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we0.RunId))
 
@@ -1914,7 +1914,7 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_NoWorkflowTaskCreated() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		StickyTaskQueue:     taskQueue,
@@ -1946,11 +1946,11 @@ func (s *FunctionalSuite) TestSignalWithStartWorkflow_NoWorkflowTaskCreated() {
 		Identity:                 identity,
 	}
 
-	we1, err := s.engine.SignalWithStartWorkflowExecution(NewContext(), sRequest)
+	we1, err := s.client.SignalWithStartWorkflowExecution(NewContext(), sRequest)
 	s.NoError(err)
 
 	// Send second signal which should generate a new wft
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,

--- a/tests/sizelimit.go
+++ b/tests/sizelimit.go
@@ -39,14 +39,15 @@ import (
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/testing/historyrequire"
 	"go.temporal.io/server/service/history/consts"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type SizeLimitFunctionalSuite struct {
@@ -95,7 +96,7 @@ func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByHistoryCountLimi
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -137,7 +138,7 @@ func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByHistoryCountLimi
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -148,7 +149,7 @@ func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByHistoryCountLimi
 	}
 
 	for i := int32(0); i < activityCount-1; i++ {
-		dwResp, err := s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+		dwResp, err := s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: id,
@@ -176,7 +177,7 @@ SignalLoop:
 		// Send another signal without RunID
 		signalName := "another signal"
 		signalInput := payloads.EncodeString("another signal input")
-		_, signalErr = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+		_, signalErr = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			WorkflowExecution: &commonpb.WorkflowExecution{
 				WorkflowId: id,
@@ -226,7 +227,7 @@ SignalLoop:
 	// verify visibility is correctly processed from open to close
 	s.Eventually(
 		func() bool {
-			resp, err1 := s.engine.ListClosedWorkflowExecutions(
+			resp, err1 := s.client.ListClosedWorkflowExecutions(
 				NewContext(),
 				&workflowservice.ListClosedWorkflowExecutionsRequest{
 					Namespace:       s.namespace,
@@ -288,7 +289,7 @@ func (s *SizeLimitFunctionalSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 		}, nil
 	}
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -309,7 +310,7 @@ func (s *SizeLimitFunctionalSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 		Identity:            identity,
 	}
 
-	we, err := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err)
 
 	go func() {
@@ -321,7 +322,7 @@ func (s *SizeLimitFunctionalSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 	case <-sigReadyToSendChan:
 	}
 
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: id, RunId: we.GetRunId()},
 		SignalName:        "signal-name",
@@ -373,7 +374,7 @@ func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -416,7 +417,7 @@ func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -426,7 +427,7 @@ func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 		T:                   s.T(),
 	}
 
-	dwResp, err := s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+	dwResp, err := s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -445,7 +446,7 @@ func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 	}
 
 	// Send another signal without RunID
-	_, signalErr := s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, signalErr := s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -472,7 +473,7 @@ func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 	// verify visibility is correctly processed from open to close
 	s.Eventually(
 		func() bool {
-			resp, err1 := s.engine.ListClosedWorkflowExecutions(
+			resp, err1 := s.client.ListClosedWorkflowExecutions(
 				NewContext(),
 				&workflowservice.ListClosedWorkflowExecutionsRequest{
 					Namespace:       s.namespace,
@@ -519,7 +520,7 @@ func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByHistorySizeLimit
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -533,7 +534,7 @@ SignalLoop:
 		signalName := "another signal"
 		signalInput, err := payloads.Encode(largePayload)
 		s.NoError(err)
-		_, signalErr = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+		_, signalErr = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			WorkflowExecution: &commonpb.WorkflowExecution{
 				WorkflowId: id,
@@ -573,7 +574,7 @@ SignalLoop:
 	// verify visibility is correctly processed from open to close
 	s.Eventually(
 		func() bool {
-			resp, err1 := s.engine.ListClosedWorkflowExecutions(
+			resp, err1 := s.client.ListClosedWorkflowExecutions(
 				NewContext(),
 				&workflowservice.ListClosedWorkflowExecutionsRequest{
 					Namespace:       s.namespace,

--- a/tests/stickytq.go
+++ b/tests/stickytq.go
@@ -63,7 +63,7 @@ func (s *FunctionalSuite) TestStickyTimeout_NonTransientWorkflowTask() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -93,7 +93,7 @@ func (s *FunctionalSuite) TestStickyTimeout_NonTransientWorkflowTask() {
 		if failureCount > 0 {
 			// send a signal on third failure to be buffered, forcing a non-transient workflow task when buffer is flushed
 			/*if failureCount == 3 {
-				err := s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+				err := s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 					Namespace:            s.namespace,
 					WorkflowExecution: workflowExecution,
 					SignalName:        "signalB",
@@ -116,7 +116,7 @@ func (s *FunctionalSuite) TestStickyTimeout_NonTransientWorkflowTask() {
 	}
 
 	poller := &TaskPoller{
-		Engine:                       s.engine,
+		Client:                       s.client,
 		Namespace:                    s.namespace,
 		TaskQueue:                    &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:                     identity,
@@ -131,7 +131,7 @@ func (s *FunctionalSuite) TestStickyTimeout_NonTransientWorkflowTask() {
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: workflowExecution,
 		SignalName:        "signalA",
@@ -172,7 +172,7 @@ WaitForStickyTimeoutLoop:
 		s.NoError(err)
 	}
 
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: workflowExecution,
 		SignalName:        "signalB",
@@ -256,7 +256,7 @@ func (s *FunctionalSuite) TestStickyTaskqueueResetThenTimeout() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -297,7 +297,7 @@ func (s *FunctionalSuite) TestStickyTaskqueueResetThenTimeout() {
 	}
 
 	poller := &TaskPoller{
-		Engine:                       s.engine,
+		Client:                       s.client,
 		Namespace:                    s.namespace,
 		TaskQueue:                    &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:                     identity,
@@ -312,7 +312,7 @@ func (s *FunctionalSuite) TestStickyTaskqueueResetThenTimeout() {
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: workflowExecution,
 		SignalName:        "signalA",
@@ -323,7 +323,7 @@ func (s *FunctionalSuite) TestStickyTaskqueueResetThenTimeout() {
 	s.NoError(err)
 
 	// Reset sticky taskqueue before sticky workflow task starts
-	_, err = s.engine.ResetStickyTaskQueue(NewContext(), &workflowservice.ResetStickyTaskQueueRequest{
+	_, err = s.client.ResetStickyTaskQueue(NewContext(), &workflowservice.ResetStickyTaskQueueRequest{
 		Namespace: s.namespace,
 		Execution: workflowExecution,
 	})
@@ -360,7 +360,7 @@ WaitForStickyTimeoutLoop:
 		s.NoError(err)
 	}
 
-	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: workflowExecution,
 		SignalName:        "signalB",

--- a/tests/transient_task.go
+++ b/tests/transient_task.go
@@ -62,7 +62,7 @@ func (s *FunctionalSuite) TestTransientWorkflowTaskTimeout() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -99,7 +99,7 @@ func (s *FunctionalSuite) TestTransientWorkflowTaskTimeout() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -151,7 +151,7 @@ func (s *FunctionalSuite) TestTransientWorkflowTaskHistorySize() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -246,7 +246,7 @@ func (s *FunctionalSuite) TestTransientWorkflowTaskHistorySize() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -354,7 +354,7 @@ func (s *FunctionalSuite) TestNoTransientWorkflowTaskAfterFlushBufferedEvents() 
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -366,7 +366,7 @@ func (s *FunctionalSuite) TestNoTransientWorkflowTaskAfterFlushBufferedEvents() 
 		if !continueAsNewAndSignal {
 			continueAsNewAndSignal = true
 			// this will create new event when there is in-flight workflow task, and the new event will be buffered
-			_, err := s.engine.SignalWorkflowExecution(NewContext(),
+			_, err := s.client.SignalWorkflowExecution(NewContext(),
 				&workflowservice.SignalWorkflowExecutionRequest{
 					Namespace: s.namespace,
 					WorkflowExecution: &commonpb.WorkflowExecution{
@@ -400,7 +400,7 @@ func (s *FunctionalSuite) TestNoTransientWorkflowTaskAfterFlushBufferedEvents() 
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,

--- a/tests/update_workflow.go
+++ b/tests/update_workflow.go
@@ -67,7 +67,7 @@ func (s *FunctionalSuite) startWorkflow(tv *testvars.TestVars) *testvars.TestVar
 		TaskQueue:    tv.TaskQueue(),
 	}
 
-	startResp, err := s.engine.StartWorkflowExecution(NewContext(), request)
+	startResp, err := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err)
 
 	return tv.WithRunID(startResp.GetRunId())
@@ -91,7 +91,7 @@ func (s *FunctionalSuite) sendUpdateWaitPolicyAccepted(tv *testvars.TestVars, up
 
 func (s *FunctionalSuite) sendUpdateWithWaitPolicy(tv *testvars.TestVars, updateID string, waitPolicy *updatepb.WaitPolicy) (*workflowservice.UpdateWorkflowExecutionResponse, error) {
 	s.T().Helper()
-	return s.engine.UpdateWorkflowExecution(NewContext(), &workflowservice.UpdateWorkflowExecutionRequest{
+	return s.client.UpdateWorkflowExecution(NewContext(), &workflowservice.UpdateWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: tv.WorkflowExecution(),
 		WaitPolicy:        waitPolicy,
@@ -107,7 +107,7 @@ func (s *FunctionalSuite) sendUpdateWithWaitPolicy(tv *testvars.TestVars, update
 
 func (s *FunctionalSuite) pollUpdate(tv *testvars.TestVars, updateID string, waitPolicy *updatepb.WaitPolicy) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
 	s.T().Helper()
-	return s.engine.PollWorkflowExecutionUpdate(NewContext(), &workflowservice.PollWorkflowExecutionUpdateRequest{
+	return s.client.PollWorkflowExecutionUpdate(NewContext(), &workflowservice.PollWorkflowExecutionUpdateRequest{
 		Namespace: s.namespace,
 		UpdateRef: &updatepb.UpdateRef{
 			WorkflowExecution: tv.WorkflowExecution(),
@@ -188,7 +188,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_EmptySpeculativeWorkflowTask_Accept
 			}
 
 			poller := &TaskPoller{
-				Engine:              s.engine,
+				Client:              s.client,
 				Namespace:           s.namespace,
 				TaskQueue:           tv.TaskQueue(),
 				WorkflowTaskHandler: wtHandler,
@@ -322,7 +322,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NotEmptySpeculativeWorkflowTask_Acc
 			}
 
 			poller := &TaskPoller{
-				Engine:              s.engine,
+				Client:              s.client,
 				Namespace:           s.namespace,
 				TaskQueue:           tv.TaskQueue(),
 				Identity:            tv.WorkerIdentity(),
@@ -432,7 +432,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_Ac
 			}
 
 			poller := &TaskPoller{
-				Engine:              s.engine,
+				Client:              s.client,
 				Namespace:           s.namespace,
 				TaskQueue:           tv.TaskQueue(),
 				Identity:            tv.WorkerIdentity(),
@@ -546,7 +546,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NormalScheduledWorkflowTask_AcceptC
 			}
 
 			poller := &TaskPoller{
-				Engine:              s.engine,
+				Client:              s.client,
 				Namespace:           s.namespace,
 				TaskQueue:           tv.TaskQueue(),
 				Identity:            tv.WorkerIdentity(),
@@ -670,7 +670,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_RunningWorkflowTask_NewEmptySpecula
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -807,7 +807,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_RunningWorkflowTask_NewNotEmptySpec
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -1186,7 +1186,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ValidateWorkerMessages() {
 			}
 
 			poller := &TaskPoller{
-				Engine:              s.engine,
+				Client:              s.client,
 				Namespace:           s.namespace,
 				TaskQueue:           tv.TaskQueue(),
 				Identity:            tv.WorkerIdentity(),
@@ -1201,7 +1201,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ValidateWorkerMessages() {
 				halfSecondTimeoutCtx, cancel := context.WithTimeout(NewContext(), 500*time.Millisecond)
 				defer cancel()
 
-				updateResponse, err1 := s.engine.UpdateWorkflowExecution(halfSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
+				updateResponse, err1 := s.client.UpdateWorkflowExecution(halfSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
 					Namespace:         s.namespace,
 					WorkflowExecution: tv.WorkflowExecution(),
 					Request: &updatepb.Request{
@@ -1308,7 +1308,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StickySpeculativeWorkflowTask_Accep
 			}
 
 			poller := &TaskPoller{
-				Engine:                       s.engine,
+				Client:                       s.client,
 				Namespace:                    s.namespace,
 				TaskQueue:                    tv.TaskQueue(),
 				StickyTaskQueue:              tv.StickyTaskQueue(),
@@ -1411,7 +1411,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StickySpeculativeWorkflowTask_Accep
 	}
 
 	poller := &TaskPoller{
-		Engine:                       s.engine,
+		Client:                       s.client,
 		Namespace:                    s.namespace,
 		TaskQueue:                    tv.TaskQueue(),
 		StickyTaskQueue:              tv.StickyTaskQueue(),
@@ -1506,7 +1506,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_Re
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -1607,7 +1607,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_EmptySpeculativeWorkflowTask_Reject
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		WorkflowTaskHandler: wtHandler,
@@ -1742,7 +1742,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_NotEmptySpeculativeWorkflowTask_Rej
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -1926,7 +1926,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_1stAccept_2ndAccept_2ndComplete_1st
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -2102,7 +2102,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_1stAccept_2ndReject_1stComplete() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -2270,7 +2270,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Fail() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -2288,7 +2288,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Fail() {
 	updateWorkflowFn := func() {
 		ctx1, cancel := context.WithTimeout(NewContext(), 2*time.Second)
 		defer cancel()
-		updateResponse, err1 := s.engine.UpdateWorkflowExecution(ctx1, &workflowservice.UpdateWorkflowExecutionRequest{
+		updateResponse, err1 := s.client.UpdateWorkflowExecution(ctx1, &workflowservice.UpdateWorkflowExecutionRequest{
 			Namespace:         s.namespace,
 			WorkflowExecution: tv.WorkflowExecution(),
 			Request: &updatepb.Request{
@@ -2413,7 +2413,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Conv
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -2516,7 +2516,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_Co
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -2582,7 +2582,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_StartToClos
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second), // Important!
 	}
 
-	startResp, err := s.engine.StartWorkflowExecution(NewContext(), request)
+	startResp, err := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err)
 
 	tv = tv.WithRunID(startResp.GetRunId())
@@ -2655,7 +2655,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_StartToClos
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -2776,7 +2776,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_ScheduleToS
 	}
 
 	poller := &TaskPoller{
-		Engine:                       s.engine,
+		Client:                       s.client,
 		Namespace:                    s.namespace,
 		TaskQueue:                    tv.TaskQueue(),
 		StickyTaskQueue:              tv.StickyTaskQueue(),
@@ -2879,7 +2879,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_ScheduleToS
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -2949,7 +2949,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Term
 			return nil, nil
 		case 2:
 			// Terminate workflow while speculative WT is running.
-			_, err := s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+			_, err := s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 				Namespace:         s.namespace,
 				WorkflowExecution: tv.WorkflowExecution(),
 				Reason:            tv.Any().String(),
@@ -2986,7 +2986,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Term
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -3005,7 +3005,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Term
 		oneSecondTimeoutCtx, cancel := context.WithTimeout(NewContext(), 1*time.Second)
 		defer cancel()
 
-		updateResponse, err1 := s.engine.UpdateWorkflowExecution(oneSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
+		updateResponse, err1 := s.client.UpdateWorkflowExecution(oneSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
 			Namespace:         s.namespace,
 			WorkflowExecution: tv.WorkflowExecution(),
 			Request: &updatepb.Request{
@@ -3086,7 +3086,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_Te
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -3105,7 +3105,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_Te
 		oneSecondTimeoutCtx, cancel := context.WithTimeout(NewContext(), 1*time.Second)
 		defer cancel()
 
-		updateResponse, err1 := s.engine.UpdateWorkflowExecution(oneSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
+		updateResponse, err1 := s.client.UpdateWorkflowExecution(oneSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
 			Namespace:         s.namespace,
 			WorkflowExecution: tv.WorkflowExecution(),
 			Request: &updatepb.Request{
@@ -3128,7 +3128,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_Te
 	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage)
 
 	// Terminate workflow after speculative WT is scheduled but not started.
-	_, err = s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: tv.WorkflowExecution(),
 		Reason:            tv.Any().String(),
@@ -3248,7 +3248,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_CompleteWorkflow_AbortUpdates() {
 			}
 
 			poller := &TaskPoller{
-				Engine:              s.engine,
+				Client:              s.client,
 				Namespace:           s.namespace,
 				TaskQueue:           tv.TaskQueue(),
 				Identity:            tv.WorkerIdentity(),
@@ -3267,7 +3267,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_CompleteWorkflow_AbortUpdates() {
 				halfSecondTimeoutCtx, cancel := context.WithTimeout(NewContext(), 500*time.Millisecond)
 				defer cancel()
 
-				resp, err1 := s.engine.UpdateWorkflowExecution(halfSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
+				resp, err1 := s.client.UpdateWorkflowExecution(halfSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
 					Namespace:         s.namespace,
 					WorkflowExecution: tv.WorkflowExecution(),
 					Request: &updatepb.Request{
@@ -3302,7 +3302,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_CompleteWorkflow_AbortUpdates() {
 			<-updateResultCh
 
 			// Check that update didn't block workflow completion.
-			descResp, err := s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+			descResp, err := s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 				Namespace: s.namespace,
 				Execution: tv.WorkflowExecution(),
 			})
@@ -3374,7 +3374,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Heartbeat()
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -3472,7 +3472,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_Lo
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -3489,7 +3489,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_Lo
 	halfSecondTimeoutCtx, cancel := context.WithTimeout(NewContext(), 500*time.Millisecond)
 	defer cancel()
 
-	updateResponse, err1 := s.engine.UpdateWorkflowExecution(halfSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
+	updateResponse, err1 := s.client.UpdateWorkflowExecution(halfSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: tv.WorkflowExecution(),
 		Request: &updatepb.Request{
@@ -3510,7 +3510,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_Lo
 	// Ensure, there is no WFT.
 	pollCtx, cancel := context.WithTimeout(NewContext(), common.MinLongPollTimeout*2)
 	defer cancel()
-	pollResponse, err := s.engine.PollWorkflowTaskQueue(pollCtx, &workflowservice.PollWorkflowTaskQueueRequest{
+	pollResponse, err := s.client.PollWorkflowTaskQueue(pollCtx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: tv.TaskQueue(),
 		Identity:  tv.WorkerIdentity(),
@@ -3610,7 +3610,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Lost
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -3629,7 +3629,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Lost
 		halfSecondTimeoutCtx, cancel := context.WithTimeout(NewContext(), 500*time.Millisecond)
 		defer cancel()
 
-		updateResponse, err1 := s.engine.UpdateWorkflowExecution(halfSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
+		updateResponse, err1 := s.client.UpdateWorkflowExecution(halfSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
 			Namespace:         s.namespace,
 			WorkflowExecution: tv.WorkflowExecution(),
 			Request: &updatepb.Request{
@@ -3741,7 +3741,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalWorkflowTask_UpdateResur
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -3756,7 +3756,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalWorkflowTask_UpdateResur
 		halfSecondTimeoutCtx, cancel := context.WithTimeout(NewContext(), 500*time.Millisecond)
 		defer cancel()
 
-		updateResponse, err1 := s.engine.UpdateWorkflowExecution(halfSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
+		updateResponse, err1 := s.client.UpdateWorkflowExecution(halfSecondTimeoutCtx, &workflowservice.UpdateWorkflowExecutionRequest{
 			Namespace:         s.namespace,
 			WorkflowExecution: tv.WorkflowExecution(),
 			Request: &updatepb.Request{
@@ -3867,7 +3867,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_De
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -3974,7 +3974,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Dedu
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		WorkflowTaskHandler: wtHandler,
@@ -4089,7 +4089,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_CompletedSpeculativeWorkflowTask_De
 			}
 
 			poller := &TaskPoller{
-				Engine:              s.engine,
+				Client:              s.client,
 				Namespace:           s.namespace,
 				TaskQueue:           tv.TaskQueue(),
 				Identity:            tv.WorkerIdentity(),
@@ -4125,7 +4125,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_CompletedSpeculativeWorkflowTask_De
 			// Ensure, there is no new WT.
 			pollCtx, cancel := context.WithTimeout(NewContext(), common.MinLongPollTimeout*2)
 			defer cancel()
-			pollResponse, err := s.engine.PollWorkflowTaskQueue(pollCtx, &workflowservice.PollWorkflowTaskQueueRequest{
+			pollResponse, err := s.client.PollWorkflowTaskQueue(pollCtx, &workflowservice.PollWorkflowTaskQueueRequest{
 				Namespace: s.namespace,
 				TaskQueue: tv.TaskQueue(),
 				Identity:  tv.WorkerIdentity(),
@@ -4212,7 +4212,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_B
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		WorkflowTaskHandler: wtHandler,
@@ -4232,7 +4232,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_B
 	}()
 
 	// Poll 2nd speculative WT with 1st update.
-	wt2, err := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	wt2, err := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: tv.TaskQueue(),
 	})
@@ -4266,7 +4266,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_B
 	s.NoError(err)
 
 	// Poll the 3rd WFT (not speculative anymore) but must have 2nd update.
-	wt3, err := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	wt3, err := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: tv.TaskQueue(),
 	})
@@ -4288,7 +4288,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_B
 	  9 WorkflowTaskStarted`, wt3.History)
 
 	// Now try to complete 2nd WT (speculative). It should fail because WorkflowTaskStarted event Id is mismatched.
-	_, err = s.engine.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: s.namespace,
 		TaskToken: wt2.TaskToken,
 		Commands:  s.UpdateAcceptCompleteCommands(tv, "1"),
@@ -4299,7 +4299,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_B
 	s.Contains(err.Error(), "Workflow task not found")
 
 	// Complete 3rd WT. It should succeed.
-	_, err = s.engine.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: s.namespace,
 		TaskToken: wt3.TaskToken,
 		Commands:  s.UpdateAcceptCompleteCommands(tv, "1"),
@@ -4349,7 +4349,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_B
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		WorkflowTaskHandler: wtHandler,
@@ -4368,7 +4368,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_B
 	}()
 
 	// Poll 2nd speculative WT with 1st update.
-	wt2, err := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	wt2, err := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: tv.TaskQueue(),
 	})
@@ -4397,7 +4397,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_B
 	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage)
 
 	// Poll for the 3rd speculative WT.
-	wt3, err := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	wt3, err := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: tv.TaskQueue(),
 	})
@@ -4416,7 +4416,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_B
 	  6 WorkflowTaskStarted`, wt3.History)
 
 	// Now try to complete 2nd (speculative) WT, it should fail.
-	_, err = s.engine.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: s.namespace,
 		TaskToken: wt2.TaskToken,
 		Commands:  s.UpdateAcceptCompleteCommands(tv, "1"),
@@ -4427,7 +4427,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_B
 	s.Contains(err.Error(), "Workflow task not found")
 
 	// Try to complete 3rd WT, it should succeed
-	_, err = s.engine.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: s.namespace,
 		TaskToken: wt3.TaskToken,
 		Commands:  s.UpdateAcceptCompleteCommands(tv, "1"),
@@ -4465,13 +4465,13 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_N
 	testCtx := NewContext()
 
 	// Drain first WFT.
-	wt1, err := s.engine.PollWorkflowTaskQueue(testCtx, &workflowservice.PollWorkflowTaskQueueRequest{
+	wt1, err := s.client.PollWorkflowTaskQueue(testCtx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: tv.TaskQueue(),
 	})
 	s.NoError(err)
 	s.NotNil(wt1)
-	_, err = s.engine.RespondWorkflowTaskCompleted(testCtx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(testCtx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: s.namespace,
 		TaskToken: wt1.TaskToken,
 	})
@@ -4483,7 +4483,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_N
 	}()
 
 	// Poll 2nd speculative WFT with 1st update.
-	wt2, err := s.engine.PollWorkflowTaskQueue(testCtx, &workflowservice.PollWorkflowTaskQueueRequest{
+	wt2, err := s.client.PollWorkflowTaskQueue(testCtx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: tv.TaskQueue(),
 	})
@@ -4520,7 +4520,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_N
 	runtime.WaitGoRoutineWithFn(s.T(), ((*update.Update)(nil)).WaitLifecycleStage, runtime.WithNumGoRoutines(2))
 
 	// Poll the 3rd speculative WFT.
-	wt3, err := s.engine.PollWorkflowTaskQueue(testCtx, &workflowservice.PollWorkflowTaskQueueRequest{
+	wt3, err := s.client.PollWorkflowTaskQueue(testCtx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: tv.TaskQueue(),
 	})
@@ -4540,7 +4540,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_N
 	  6 WorkflowTaskStarted`, wt3.History)
 
 	// Now try to complete 2nd speculative WT, it should fail because start time does not match.
-	_, err = s.engine.RespondWorkflowTaskCompleted(testCtx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	_, err = s.client.RespondWorkflowTaskCompleted(testCtx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace:             s.namespace,
 		TaskToken:             wt2.TaskToken,
 		Commands:              s.UpdateAcceptCompleteCommands(tv, "1"),
@@ -4552,7 +4552,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Fail_N
 	s.IsType(&serviceerror.NotFound{}, err)
 
 	// Complete of the 3rd WT should succeed. It must accept both updates.
-	wt4Resp, err := s.engine.RespondWorkflowTaskCompleted(testCtx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+	wt4Resp, err := s.client.RespondWorkflowTaskCompleted(testCtx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: s.namespace,
 		TaskToken: wt3.TaskToken,
 		Commands: append(
@@ -4658,7 +4658,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_WorkerSkipp
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		WorkflowTaskHandler: wtHandler,
@@ -4717,7 +4717,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_LastWorkflowTask_HasUpdateMessage()
 	tv = s.startWorkflow(tv)
 
 	poller := &TaskPoller{
-		Engine:    s.engine,
+		Client:    s.client,
 		Namespace: s.namespace,
 		TaskQueue: tv.TaskQueue(),
 		Identity:  tv.WorkerIdentity(),
@@ -4814,7 +4814,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_QueryFailur
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		WorkflowTaskHandler: wtHandler,
@@ -4846,7 +4846,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_QueryFailur
 		// which leads to clearing of WF context.
 		shortCtx, cancel := context.WithTimeout(NewContext(), 100*time.Millisecond)
 		defer cancel()
-		queryResp, err := s.engine.QueryWorkflow(shortCtx, &workflowservice.QueryWorkflowRequest{
+		queryResp, err := s.client.QueryWorkflow(shortCtx, &workflowservice.QueryWorkflowRequest{
 			Namespace: s.namespace,
 			Execution: tv.WorkflowExecution(),
 			Query: &querypb.WorkflowQuery{
@@ -4935,7 +4935,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_UpdatesAreSentToWorkerInOrderOfAdmi
 	wtHandlerCalls := 0
 	msgHandlerCalls := 0
 	poller := &TaskPoller{
-		Engine:    s.engine,
+		Client:    s.client,
 		Namespace: s.namespace,
 		TaskQueue: tv.TaskQueue(),
 		Identity:  tv.WorkerIdentity(),

--- a/tests/user_metadata_test.go
+++ b/tests/user_metadata_test.go
@@ -35,8 +35,8 @@ import (
 )
 
 func (s *FunctionalSuite) TestUserMetadata() {
-	getDescribeWorkflowExecutionInfo := func(engine FrontendClient, namespace string, workflowID string, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
-		return engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+	getDescribeWorkflowExecutionInfo := func(client FrontendClient, namespace string, workflowID string, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+		return client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: namespace,
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: workflowID,
@@ -70,11 +70,11 @@ func (s *FunctionalSuite) TestUserMetadata() {
 			UserMetadata: metadata,
 		}
 
-		we, err := s.engine.StartWorkflowExecution(NewContext(), request)
+		we, err := s.client.StartWorkflowExecution(NewContext(), request)
 		s.NoError(err)
 
 		// Verify that the UserMetadata associated with the start event is returned in the describe response.
-		describeInfo, err := getDescribeWorkflowExecutionInfo(s.engine, s.namespace, id, we.RunId)
+		describeInfo, err := getDescribeWorkflowExecutionInfo(s.client, s.namespace, id, we.RunId)
 		s.NoError(err)
 		s.EqualExportedValues(metadata, describeInfo.ExecutionConfig.UserMetadata)
 	})
@@ -93,11 +93,11 @@ func (s *FunctionalSuite) TestUserMetadata() {
 			UserMetadata: metadata,
 		}
 
-		we, err := s.engine.SignalWithStartWorkflowExecution(NewContext(), request)
+		we, err := s.client.SignalWithStartWorkflowExecution(NewContext(), request)
 		s.NoError(err)
 
 		// Verify that the UserMetadata associated with the start event is returned in the describe response.
-		describeInfo, err := getDescribeWorkflowExecutionInfo(s.engine, s.namespace, id, we.RunId)
+		describeInfo, err := getDescribeWorkflowExecutionInfo(s.client, s.namespace, id, we.RunId)
 		s.NoError(err)
 		s.EqualExportedValues(metadata, describeInfo.ExecutionConfig.UserMetadata)
 	})
@@ -138,11 +138,11 @@ func (s *FunctionalSuite) TestUserMetadata() {
 			},
 		}
 
-		_, err := s.engine.ExecuteMultiOperation(NewContext(), request)
+		_, err := s.client.ExecuteMultiOperation(NewContext(), request)
 		s.NoError(err)
 
 		// Verify that the UserMetadata associated with the start event is returned in the describe response.
-		describeInfo, err := getDescribeWorkflowExecutionInfo(s.engine, s.namespace, id, "")
+		describeInfo, err := getDescribeWorkflowExecutionInfo(s.client, s.namespace, id, "")
 		s.NoError(err)
 		s.EqualExportedValues(metadata, describeInfo.ExecutionConfig.UserMetadata)
 	})

--- a/tests/user_timers.go
+++ b/tests/user_timers.go
@@ -62,7 +62,7 @@ func (s *FunctionalSuite) TestUserTimers_Sequential() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -94,7 +94,7 @@ func (s *FunctionalSuite) TestUserTimers_Sequential() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -134,10 +134,10 @@ func (s *FunctionalSuite) TestUserTimers_CapDuration() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
-	descResp, err := s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+	descResp, err := s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -161,7 +161,7 @@ func (s *FunctionalSuite) TestUserTimers_CapDuration() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -188,7 +188,7 @@ func (s *FunctionalSuite) TestUserTimers_CapDuration() {
 	s.Len(timerInfos, 1)
 	s.True(timerInfos[timerID].ExpiryTime.AsTime().Before(time.Now().Add(timer.MaxAllowedTimer)))
 
-	_, err = s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,

--- a/tests/workflow.go
+++ b/tests/workflow.go
@@ -76,7 +76,7 @@ func (s *FunctionalSuite) TestStartWorkflowExecution() {
 
 	s.Run("start", func() {
 		request := makeRequest()
-		we, err := s.engine.StartWorkflowExecution(NewContext(), request)
+		we, err := s.client.StartWorkflowExecution(NewContext(), request)
 		s.NoError(err)
 		s.True(we.Started)
 
@@ -93,11 +93,11 @@ func (s *FunctionalSuite) TestStartWorkflowExecution() {
 	s.Run("start twice - same request", func() {
 		request := makeRequest()
 
-		we0, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+		we0, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 		s.NoError(err0)
 		s.True(we0.Started)
 
-		we1, err1 := s.engine.StartWorkflowExecution(NewContext(), request)
+		we1, err1 := s.client.StartWorkflowExecution(NewContext(), request)
 		s.NoError(err1)
 		s.True(we1.Started)
 
@@ -106,13 +106,13 @@ func (s *FunctionalSuite) TestStartWorkflowExecution() {
 
 	s.Run("fail when already started", func() {
 		request := makeRequest()
-		we, err := s.engine.StartWorkflowExecution(NewContext(), request)
+		we, err := s.client.StartWorkflowExecution(NewContext(), request)
 		s.NoError(err)
 		s.True(we.Started)
 
 		request.RequestId = uuid.New()
 
-		we2, err := s.engine.StartWorkflowExecution(NewContext(), request)
+		we2, err := s.client.StartWorkflowExecution(NewContext(), request)
 		s.Error(err)
 		var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
 		s.ErrorAs(err, &alreadyStarted)
@@ -157,17 +157,17 @@ func (s *FunctionalSuite) TestStartWorkflowExecution_Terminate() {
 				Identity:           "worker1",
 			}
 
-			we0, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+			we0, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 			s.NoError(err0)
 
 			request.RequestId = uuid.New()
 			request.WorkflowIdReusePolicy = tc.WorkflowIdReusePolicy
 			request.WorkflowIdConflictPolicy = tc.WorkflowIdConflictPolicy
-			we1, err1 := s.engine.StartWorkflowExecution(NewContext(), request)
+			we1, err1 := s.client.StartWorkflowExecution(NewContext(), request)
 			s.NoError(err1)
 			s.NotEqual(we0.RunId, we1.RunId)
 
-			descResp, err := s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+			descResp, err := s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 				Namespace: s.namespace,
 				Execution: &commonpb.WorkflowExecution{
 					WorkflowId: id,
@@ -177,7 +177,7 @@ func (s *FunctionalSuite) TestStartWorkflowExecution_Terminate() {
 			s.NoError(err)
 			s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, descResp.WorkflowExecutionInfo.Status)
 
-			descResp, err = s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+			descResp, err = s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 				Namespace: s.namespace,
 				Execution: &commonpb.WorkflowExecution{
 					WorkflowId: id,
@@ -212,7 +212,7 @@ func (s *FunctionalSuite) TestStartWorkflowExecutionWithDelay() {
 	}
 
 	reqStartTime := time.Now()
-	we0, startErr := s.engine.StartWorkflowExecution(NewContext(), request)
+	we0, startErr := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(startErr)
 
 	delayEndTime := time.Now()
@@ -227,7 +227,7 @@ func (s *FunctionalSuite) TestStartWorkflowExecutionWithDelay() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		StickyTaskQueue:     &taskqueuepb.TaskQueue{Name: stickyTq, Kind: enumspb.TASK_QUEUE_KIND_STICKY, NormalName: tl},
@@ -241,7 +241,7 @@ func (s *FunctionalSuite) TestStartWorkflowExecutionWithDelay() {
 	s.NoError(pollErr)
 	s.GreaterOrEqual(delayEndTime.Sub(reqStartTime), startDelay)
 
-	descResp, descErr := s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+	descResp, descErr := s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -271,7 +271,7 @@ func (s *FunctionalSuite) TestTerminateWorkflow() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -313,7 +313,7 @@ func (s *FunctionalSuite) TestTerminateWorkflow() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl},
 		Identity:            identity,
@@ -327,7 +327,7 @@ func (s *FunctionalSuite) TestTerminateWorkflow() {
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err = s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
@@ -379,7 +379,7 @@ StartNewExecutionLoop:
 			Identity:            identity,
 		}
 
-		newExecution, err := s.engine.StartWorkflowExecution(NewContext(), request)
+		newExecution, err := s.client.StartWorkflowExecution(NewContext(), request)
 		if err != nil {
 			s.Logger.Warn("Start New Execution failed. Error", tag.Error(err))
 			time.Sleep(100 * time.Millisecond)
@@ -414,7 +414,7 @@ func (s *FunctionalSuite) TestSequentialWorkflow() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -465,7 +465,7 @@ func (s *FunctionalSuite) TestSequentialWorkflow() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -512,7 +512,7 @@ func (s *FunctionalSuite) TestCompleteWorkflowTaskAndCreateNewOne() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -539,7 +539,7 @@ func (s *FunctionalSuite) TestCompleteWorkflowTaskAndCreateNewOne() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -582,7 +582,7 @@ func (s *FunctionalSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -631,7 +631,7 @@ func (s *FunctionalSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -700,7 +700,7 @@ func (s *FunctionalSuite) TestWorkflowRetry() {
 		},
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -731,7 +731,7 @@ func (s *FunctionalSuite) TestWorkflowRetry() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -741,7 +741,7 @@ func (s *FunctionalSuite) TestWorkflowRetry() {
 	}
 
 	describeWorkflowExecution := func(execution *commonpb.WorkflowExecution) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
-		return s.engine.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
+		return s.client.DescribeWorkflowExecution(NewContext(), &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			Execution: execution,
 		})
@@ -812,7 +812,7 @@ func (s *FunctionalSuite) TestWorkflowRetry() {
 		// See comment in workflowHandler.go:GetWorkflowExecutionHistory
 		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 		oldSDKCtx := headers.SetVersionsForTests(ctx, "1.3.1", headers.ClientNameJavaSDK, headers.SupportedServerVersions, "")
-		resp, err := s.engine.GetWorkflowExecutionHistory(oldSDKCtx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+		resp, err := s.client.GetWorkflowExecutionHistory(oldSDKCtx, &workflowservice.GetWorkflowExecutionHistoryRequest{
 			Namespace:              s.namespace,
 			Execution:              executions[i],
 			MaximumPageSize:        5,
@@ -885,7 +885,7 @@ func (s *FunctionalSuite) TestWorkflowRetryFailures() {
 		},
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -893,7 +893,7 @@ func (s *FunctionalSuite) TestWorkflowRetryFailures() {
 	var executions []*commonpb.WorkflowExecution
 	wtHandler := workflowImpl(5, "retryable-error", false, &executions)
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -952,7 +952,7 @@ func (s *FunctionalSuite) TestWorkflowRetryFailures() {
 		},
 	}
 
-	we, err0 = s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 = s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -960,7 +960,7 @@ func (s *FunctionalSuite) TestWorkflowRetryFailures() {
 	executions = []*commonpb.WorkflowExecution{}
 	wtHandler = workflowImpl(5, "bad-bug", true, &executions)
 	poller = &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -992,7 +992,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 		defer s.testCluster.host.captureMetricsHandler.StopCapture(capture)
 
 		poller := &TaskPoller{
-			Engine:    s.engine,
+			Client:    s.client,
 			Namespace: s.namespace,
 			TaskQueue: tv.TaskQueue(),
 			Identity:  tv.WorkerIdentity(),
@@ -1013,7 +1013,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 		// issue multi operation request
 		done := make(chan struct{})
 		go func() {
-			resp, retErr = s.engine.ExecuteMultiOperation(NewContext(), request)
+			resp, retErr = s.client.ExecuteMultiOperation(NewContext(), request)
 			done <- struct{}{}
 		}()
 
@@ -1106,7 +1106,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 			s.Run("workflow id reuse policy use-existing: only send update", func() {
 				tv := testvars.New(s.T())
 
-				_, err := s.engine.StartWorkflowExecution(NewContext(), startWorkflowReq(tv))
+				_, err := s.client.StartWorkflowExecution(NewContext(), startWorkflowReq(tv))
 				s.NoError(err)
 
 				req := startWorkflowReq(tv)
@@ -1121,7 +1121,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 
 				initReq := startWorkflowReq(tv)
 				initReq.TaskQueue.Name = initReq.TaskQueue.Name + "-init" // avoid race condition with poller
-				initWF, err := s.engine.StartWorkflowExecution(NewContext(), initReq)
+				initWF, err := s.client.StartWorkflowExecution(NewContext(), initReq)
 				s.NoError(err)
 
 				req := startWorkflowReq(tv)
@@ -1130,7 +1130,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 
 				s.NoError(err)
 
-				descResp, err := s.engine.DescribeWorkflowExecution(NewContext(),
+				descResp, err := s.client.DescribeWorkflowExecution(NewContext(),
 					&workflowservice.DescribeWorkflowExecutionRequest{
 						Namespace: s.namespace,
 						Execution: &commonpb.WorkflowExecution{WorkflowId: req.WorkflowId, RunId: initWF.RunId},
@@ -1143,7 +1143,7 @@ func (s *FunctionalSuite) TestExecuteMultiOperation() {
 			s.Run("workflow id reuse policy fail: abort multi operation", func() {
 				tv := testvars.New(s.T())
 
-				_, err := s.engine.StartWorkflowExecution(NewContext(), startWorkflowReq(tv))
+				_, err := s.client.StartWorkflowExecution(NewContext(), startWorkflowReq(tv))
 				s.NoError(err)
 
 				req := startWorkflowReq(tv)

--- a/tests/workflow_buffered_events.go
+++ b/tests/workflow_buffered_events.go
@@ -62,7 +62,7 @@ func (s *FunctionalSuite) TestRateLimitBufferedEvents() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -114,7 +114,7 @@ func (s *FunctionalSuite) TestRateLimitBufferedEvents() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -160,7 +160,7 @@ func (s *FunctionalSuite) TestBufferedEvents() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -174,7 +174,7 @@ func (s *FunctionalSuite) TestBufferedEvents() {
 			signalSent = true
 
 			// this will create new event when there is in-flight workflow task, and the new event will be buffered
-			_, err := s.engine.SignalWorkflowExecution(NewContext(),
+			_, err := s.client.SignalWorkflowExecution(NewContext(),
 				&workflowservice.SignalWorkflowExecutionRequest{
 					Namespace: s.namespace,
 					WorkflowExecution: &commonpb.WorkflowExecution{
@@ -216,7 +216,7 @@ func (s *FunctionalSuite) TestBufferedEvents() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -275,7 +275,7 @@ func (s *FunctionalSuite) TestBufferedEventsOutOfOrder() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -337,7 +337,7 @@ func (s *FunctionalSuite) TestBufferedEventsOutOfOrder() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,

--- a/tests/workflow_delete_execution.go
+++ b/tests/workflow_delete_execution.go
@@ -59,7 +59,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_CompetedWorkflow() {
 	var wes []*commonpb.WorkflowExecution
 	// Start numExecutions workflow executions.
 	for i := 0; i < numExecutions; i++ {
-		we, err := s.engine.StartWorkflowExecution(NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+		we, err := s.client.StartWorkflowExecution(NewContext(), &workflowservice.StartWorkflowExecutionRequest{
 			RequestId:    uuid.New(),
 			Namespace:    s.namespace,
 			WorkflowId:   tv.WorkflowID(strconv.Itoa(i)),
@@ -83,7 +83,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_CompetedWorkflow() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           tv.TaskQueue(),
 		Identity:            tv.WorkerIdentity(),
@@ -101,7 +101,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_CompetedWorkflow() {
 	for _, we := range wes {
 		s.Eventually(
 			func() bool {
-				visibilityResponse, err := s.engine.ListWorkflowExecutions(
+				visibilityResponse, err := s.client.ListWorkflowExecutions(
 					NewContext(),
 					&workflowservice.ListWorkflowExecutionsRequest{
 						Namespace:     s.namespace,
@@ -124,7 +124,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_CompetedWorkflow() {
 
 	// Delete workflow executions.
 	for _, we := range wes {
-		_, err := s.engine.DeleteWorkflowExecution(NewContext(), &workflowservice.DeleteWorkflowExecutionRequest{
+		_, err := s.client.DeleteWorkflowExecution(NewContext(), &workflowservice.DeleteWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			WorkflowExecution: &commonpb.WorkflowExecution{
 				WorkflowId: we.WorkflowId,
@@ -138,7 +138,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_CompetedWorkflow() {
 		s.Eventually(
 			func() bool {
 				// Check execution is deleted.
-				describeResponse, err := s.engine.DescribeWorkflowExecution(
+				describeResponse, err := s.client.DescribeWorkflowExecution(
 					NewContext(),
 					&workflowservice.DescribeWorkflowExecutionRequest{
 						Namespace: s.namespace,
@@ -159,7 +159,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_CompetedWorkflow() {
 		)
 
 		// Check history is deleted.
-		historyResponse, err := s.engine.GetWorkflowExecutionHistory(
+		historyResponse, err := s.client.GetWorkflowExecutionHistory(
 			NewContext(),
 			&workflowservice.GetWorkflowExecutionHistoryRequest{
 				Namespace: s.namespace,
@@ -173,7 +173,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_CompetedWorkflow() {
 		s.Eventually(
 			func() bool {
 				// Check visibility is updated.
-				visibilityResponse, err := s.engine.ListWorkflowExecutions(
+				visibilityResponse, err := s.client.ListWorkflowExecutions(
 					NewContext(),
 					&workflowservice.ListWorkflowExecutionsRequest{
 						Namespace:     s.namespace,
@@ -203,7 +203,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_RunningWorkflow() {
 	var wes []*commonpb.WorkflowExecution
 	// Start numExecutions workflow executions.
 	for i := 0; i < numExecutions; i++ {
-		we, err := s.engine.StartWorkflowExecution(NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+		we, err := s.client.StartWorkflowExecution(NewContext(), &workflowservice.StartWorkflowExecutionRequest{
 			RequestId:    uuid.New(),
 			Namespace:    s.namespace,
 			WorkflowId:   tv.WorkflowID(strconv.Itoa(i)),
@@ -222,7 +222,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_RunningWorkflow() {
 	for _, we := range wes {
 		s.Eventually(
 			func() bool {
-				visibilityResponse, err := s.engine.ListWorkflowExecutions(
+				visibilityResponse, err := s.client.ListWorkflowExecutions(
 					NewContext(),
 					&workflowservice.ListWorkflowExecutionsRequest{
 						Namespace:     s.namespace,
@@ -242,7 +242,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_RunningWorkflow() {
 
 	// Delete workflow executions.
 	for _, we := range wes {
-		_, err := s.engine.DeleteWorkflowExecution(NewContext(), &workflowservice.DeleteWorkflowExecutionRequest{
+		_, err := s.client.DeleteWorkflowExecution(NewContext(), &workflowservice.DeleteWorkflowExecutionRequest{
 			Namespace:         s.namespace,
 			WorkflowExecution: we,
 		})
@@ -253,7 +253,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_RunningWorkflow() {
 		s.Eventually(
 			func() bool {
 				// Check execution is deleted.
-				describeResponse, err := s.engine.DescribeWorkflowExecution(
+				describeResponse, err := s.client.DescribeWorkflowExecution(
 					NewContext(),
 					&workflowservice.DescribeWorkflowExecutionRequest{
 						Namespace: s.namespace,
@@ -274,7 +274,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_RunningWorkflow() {
 		)
 
 		// Check history is deleted.
-		historyResponse, err := s.engine.GetWorkflowExecutionHistory(
+		historyResponse, err := s.client.GetWorkflowExecutionHistory(
 			NewContext(),
 			&workflowservice.GetWorkflowExecutionHistoryRequest{
 				Namespace: s.namespace,
@@ -288,7 +288,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_RunningWorkflow() {
 		s.Eventually(
 			func() bool {
 				// Check visibility is updated.
-				visibilityResponse, err := s.engine.ListWorkflowExecutions(
+				visibilityResponse, err := s.client.ListWorkflowExecutions(
 					NewContext(),
 					&workflowservice.ListWorkflowExecutionsRequest{
 						Namespace:     s.namespace,
@@ -318,7 +318,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_JustTerminatedWorkflow() {
 	var wes []*commonpb.WorkflowExecution
 	// Start numExecutions workflow executions.
 	for i := 0; i < numExecutions; i++ {
-		we, err := s.engine.StartWorkflowExecution(NewContext(), &workflowservice.StartWorkflowExecutionRequest{
+		we, err := s.client.StartWorkflowExecution(NewContext(), &workflowservice.StartWorkflowExecutionRequest{
 			RequestId:    uuid.New(),
 			Namespace:    s.namespace,
 			WorkflowId:   tv.WorkflowID(strconv.Itoa(i)),
@@ -337,7 +337,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_JustTerminatedWorkflow() {
 	for _, we := range wes {
 		s.Eventually(
 			func() bool {
-				visibilityResponse, err := s.engine.ListWorkflowExecutions(
+				visibilityResponse, err := s.client.ListWorkflowExecutions(
 					NewContext(),
 					&workflowservice.ListWorkflowExecutionsRequest{
 						Namespace:     s.namespace,
@@ -364,13 +364,13 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_JustTerminatedWorkflow() {
 	// two types of tasks and make sure that they are executed in correct order.
 
 	for i, we := range wes {
-		_, err := s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+		_, err := s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 			Namespace:         s.namespace,
 			WorkflowExecution: we,
 		})
 		s.NoError(err)
 		s.Logger.Warn("Execution is terminated", tag.NewInt("number", i), tag.WorkflowID(we.WorkflowId), tag.WorkflowRunID(we.RunId))
-		_, err = s.engine.DeleteWorkflowExecution(NewContext(), &workflowservice.DeleteWorkflowExecutionRequest{
+		_, err = s.client.DeleteWorkflowExecution(NewContext(), &workflowservice.DeleteWorkflowExecutionRequest{
 			Namespace:         s.namespace,
 			WorkflowExecution: we,
 		})
@@ -382,7 +382,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_JustTerminatedWorkflow() {
 		s.Eventually(
 			func() bool {
 				// Check execution is deleted.
-				describeResponse, err := s.engine.DescribeWorkflowExecution(
+				describeResponse, err := s.client.DescribeWorkflowExecution(
 					NewContext(),
 					&workflowservice.DescribeWorkflowExecutionRequest{
 						Namespace: s.namespace,
@@ -403,7 +403,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_JustTerminatedWorkflow() {
 		)
 
 		// Check history is deleted.
-		historyResponse, err := s.engine.GetWorkflowExecutionHistory(
+		historyResponse, err := s.client.GetWorkflowExecutionHistory(
 			NewContext(),
 			&workflowservice.GetWorkflowExecutionHistoryRequest{
 				Namespace: s.namespace,
@@ -417,7 +417,7 @@ func (s *FunctionalSuite) TestDeleteWorkflowExecution_JustTerminatedWorkflow() {
 		s.Eventually(
 			func() bool {
 				// Check visibility is updated.
-				visibilityResponse, err := s.engine.ListWorkflowExecutions(
+				visibilityResponse, err := s.client.ListWorkflowExecutions(
 					NewContext(),
 					&workflowservice.ListWorkflowExecutionsRequest{
 						Namespace:     s.namespace,

--- a/tests/workflow_failures.go
+++ b/tests/workflow_failures.go
@@ -68,7 +68,7 @@ func (s *FunctionalSuite) TestWorkflowTimeout() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
@@ -105,7 +105,7 @@ GetHistoryLoop:
 	closedCount := 0
 ListClosedLoop:
 	for i := 0; i < 10; i++ {
-		resp, err3 := s.engine.ListClosedWorkflowExecutions(NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
+		resp, err3 := s.client.ListClosedWorkflowExecutions(NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
 			Namespace:       s.namespace,
 			MaximumPageSize: 100,
 			StartTimeFilter: startFilter,
@@ -145,7 +145,7 @@ func (s *FunctionalSuite) TestWorkflowTaskFailed() {
 		Identity:            identity,
 	}
 
-	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
@@ -229,7 +229,7 @@ func (s *FunctionalSuite) TestWorkflowTaskFailed() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -349,7 +349,7 @@ func (s *FunctionalSuite) TestRespondWorkflowTaskCompleted_ReturnsErrorIfInvalid
 		Identity:           identity,
 	}
 
-	we0, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	we0, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	s.NotNil(we0)
 
@@ -368,7 +368,7 @@ func (s *FunctionalSuite) TestRespondWorkflowTaskCompleted_ReturnsErrorIfInvalid
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,

--- a/tests/workflow_memo.go
+++ b/tests/workflow_memo.go
@@ -74,7 +74,7 @@ func (s *FunctionalSuite) TestStartWithMemo() {
 	}
 
 	fn := func() (RunIdGetter, error) {
-		return s.engine.StartWorkflowExecution(NewContext(), request)
+		return s.client.StartWorkflowExecution(NewContext(), request)
 	}
 	s.startWithMemoHelper(fn, id, &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}, memo, `
   1 WorkflowExecutionStarted {"Memo":{"Fields":{"Info":{"Data":"\"memo-value\""}}}}
@@ -114,7 +114,7 @@ func (s *FunctionalSuite) TestSignalWithStartWithMemo() {
 	}
 
 	fn := func() (RunIdGetter, error) {
-		return s.engine.SignalWithStartWorkflowExecution(NewContext(), request)
+		return s.client.SignalWithStartWorkflowExecution(NewContext(), request)
 	}
 	s.startWithMemoHelper(fn, id, &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}, memo, `
   1 WorkflowExecutionStarted {"Memo":{"Fields":{"Info":{"Data":"\"memo-value\""}}}}
@@ -144,7 +144,7 @@ func (s *FunctionalSuite) startWithMemoHelper(startFn startFunc, id string, task
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -157,7 +157,7 @@ func (s *FunctionalSuite) startWithMemoHelper(startFn startFunc, id string, task
 	var openExecutionInfo *workflowpb.WorkflowExecutionInfo
 	s.Eventually(
 		func() bool {
-			resp, err1 := s.engine.ListOpenWorkflowExecutions(NewContext(), &workflowservice.ListOpenWorkflowExecutionsRequest{
+			resp, err1 := s.client.ListOpenWorkflowExecutions(NewContext(), &workflowservice.ListOpenWorkflowExecutionsRequest{
 				Namespace:       s.namespace,
 				MaximumPageSize: 100,
 				StartTimeFilter: &filterpb.StartTimeFilter{
@@ -192,7 +192,7 @@ func (s *FunctionalSuite) startWithMemoHelper(startFn startFunc, id string, task
 		Namespace: s.namespace,
 		Execution: execution,
 	}
-	descResp, err := s.engine.DescribeWorkflowExecution(NewContext(), descRequest)
+	descResp, err := s.client.DescribeWorkflowExecution(NewContext(), descRequest)
 	s.NoError(err)
 	s.ProtoEqual(memo, descResp.WorkflowExecutionInfo.Memo)
 
@@ -206,7 +206,7 @@ func (s *FunctionalSuite) startWithMemoHelper(startFn startFunc, id string, task
 	s.EqualHistoryEvents(expectedHistory, historyEvents)
 
 	// verify DescribeWorkflowExecution result: workflow closed, but close visibility task not completed
-	descResp, err = s.engine.DescribeWorkflowExecution(NewContext(), descRequest)
+	descResp, err = s.client.DescribeWorkflowExecution(NewContext(), descRequest)
 	s.NoError(err)
 	s.ProtoEqual(memo, descResp.WorkflowExecutionInfo.Memo)
 
@@ -214,7 +214,7 @@ func (s *FunctionalSuite) startWithMemoHelper(startFn startFunc, id string, task
 	var closedExecutionInfo *workflowpb.WorkflowExecutionInfo
 	s.Eventually(
 		func() bool {
-			resp, err1 := s.engine.ListClosedWorkflowExecutions(NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
+			resp, err1 := s.client.ListClosedWorkflowExecutions(NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
 				Namespace:       s.namespace,
 				MaximumPageSize: 100,
 				StartTimeFilter: &filterpb.StartTimeFilter{
@@ -240,7 +240,7 @@ func (s *FunctionalSuite) startWithMemoHelper(startFn startFunc, id string, task
 	s.ProtoEqual(memo, closedExecutionInfo.Memo)
 
 	// verify DescribeWorkflowExecution result: workflow closed and close visibility task completed
-	descResp, err = s.engine.DescribeWorkflowExecution(NewContext(), descRequest)
+	descResp, err = s.client.DescribeWorkflowExecution(NewContext(), descRequest)
 	s.NoError(err)
 	s.ProtoEqual(memo, descResp.WorkflowExecutionInfo.Memo)
 }

--- a/tests/workflow_task.go
+++ b/tests/workflow_task.go
@@ -62,7 +62,7 @@ func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithEmptyResult() {
 		Identity:            identity,
 	}
 
-	resp0, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	resp0, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	we := &commonpb.WorkflowExecution{
@@ -75,7 +75,7 @@ func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithEmptyResult() {
   2 WorkflowTaskScheduled`, s.getHistory(s.namespace, we))
 
 	// start workflow task
-	resp1, err1 := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	resp1, err1 := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: taskQueue,
 		Identity:  identity,
@@ -91,7 +91,7 @@ func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithEmptyResult() {
 	taskToken := resp1.GetTaskToken()
 	hbTimeout := 0
 	for i := 0; i < 12; i++ {
-		resp2, err2 := s.engine.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+		resp2, err2 := s.client.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 			Namespace: s.namespace,
 			TaskToken: taskToken,
 			Commands:  []*commandpb.Command{},
@@ -106,7 +106,7 @@ func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithEmptyResult() {
 			hbTimeout++
 			s.IsType(&workflowservice.RespondWorkflowTaskCompletedResponse{}, resp2)
 
-			resp, err := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+			resp, err := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 				Namespace: s.namespace,
 				TaskQueue: taskQueue,
 				Identity:  identity,
@@ -122,7 +122,7 @@ func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithEmptyResult() {
 
 	s.Equal(2, hbTimeout)
 
-	resp5, err5 := s.engine.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	resp5, err5 := s.client.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: s.namespace,
 		TaskToken: taskToken,
 		Commands: []*commandpb.Command{
@@ -216,7 +216,7 @@ func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithLocalActivitiesResult(
 		Identity:            identity,
 	}
 
-	resp0, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	resp0, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	we := &commonpb.WorkflowExecution{
@@ -229,7 +229,7 @@ func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithLocalActivitiesResult(
   2 WorkflowTaskScheduled`, s.getHistory(s.namespace, we))
 
 	// start workflow task
-	resp1, err1 := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	resp1, err1 := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: taskQueue,
 		Identity:  identity,
@@ -242,7 +242,7 @@ func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithLocalActivitiesResult(
   2 WorkflowTaskScheduled
   3 WorkflowTaskStarted`, s.getHistory(s.namespace, we))
 
-	resp2, err2 := s.engine.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	resp2, err2 := s.client.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: s.namespace,
 		TaskToken: resp1.GetTaskToken(),
 		Commands:  []*commandpb.Command{},
@@ -255,7 +255,7 @@ func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithLocalActivitiesResult(
 	})
 	s.NoError(err2)
 
-	resp3, err3 := s.engine.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	resp3, err3 := s.client.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: s.namespace,
 		TaskToken: resp2.WorkflowTask.GetTaskToken(),
 		Commands: []*commandpb.Command{
@@ -277,7 +277,7 @@ func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithLocalActivitiesResult(
 	})
 	s.NoError(err3)
 
-	resp4, err4 := s.engine.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	resp4, err4 := s.client.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: s.namespace,
 		TaskToken: resp3.WorkflowTask.GetTaskToken(),
 		Commands: []*commandpb.Command{
@@ -299,7 +299,7 @@ func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithLocalActivitiesResult(
 	})
 	s.NoError(err4)
 
-	resp5, err5 := s.engine.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+	resp5, err5 := s.client.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
 		Namespace: s.namespace,
 		TaskToken: resp4.WorkflowTask.GetTaskToken(),
 		Commands: []*commandpb.Command{
@@ -362,7 +362,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalBeforeRegularWorkflowTask
 		Identity:            identity,
 	}
 
-	resp0, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	resp0, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	we := &commonpb.WorkflowExecution{
@@ -374,7 +374,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalBeforeRegularWorkflowTask
   1 WorkflowExecutionStarted
   2 WorkflowTaskScheduled`, s.getHistory(s.namespace, we))
 
-	_, err0 = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err0 = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		SignalName:        "sig-for-integ-test",
@@ -389,7 +389,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalBeforeRegularWorkflowTask
   3 WorkflowExecutionSignaled`, s.getHistory(s.namespace, we))
 
 	// start this transient workflow task, the attempt should be cleared and it becomes again a regular workflow task
-	resp1, err1 := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	resp1, err1 := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: taskQueue,
 		Identity:  identity,
@@ -404,7 +404,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalBeforeRegularWorkflowTask
   4 WorkflowTaskStarted`, s.getHistory(s.namespace, we))
 
 	// then terminate the workflow
-	_, err := s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err := s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		Reason:            "test-reason",
@@ -442,7 +442,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskS
 		Identity:            identity,
 	}
 
-	resp0, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	resp0, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	we := &commonpb.WorkflowExecution{
@@ -455,7 +455,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskS
   2 WorkflowTaskScheduled`, s.getHistory(s.namespace, we))
 
 	// start workflow task to make signals into bufferedEvents
-	_, err1 := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	_, err1 := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: taskQueue,
 		Identity:  identity,
@@ -468,7 +468,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskS
   3 WorkflowTaskStarted`, s.getHistory(s.namespace, we))
 
 	// this signal should be buffered
-	_, err0 = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err0 = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		SignalName:        "sig-for-integ-test",
@@ -483,7 +483,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskS
   3 WorkflowTaskStarted`, s.getHistory(s.namespace, we))
 
 	// then terminate the workflow
-	_, err := s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err := s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		Reason:            "test-reason",
@@ -522,7 +522,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskS
 		Identity:            identity,
 	}
 
-	resp0, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	resp0, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	we := &commonpb.WorkflowExecution{
@@ -537,7 +537,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskS
 	cause := enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE
 
 	// start workflow task to make signals into bufferedEvents
-	resp1, err1 := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	resp1, err1 := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: taskQueue,
 		Identity:  identity,
@@ -550,7 +550,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskS
   3 WorkflowTaskStarted`, s.getHistory(s.namespace, we))
 
 	// this signal should be buffered
-	_, err0 = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err0 = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		SignalName:        "sig-for-integ-test",
@@ -565,7 +565,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskS
   3 WorkflowTaskStarted`, s.getHistory(s.namespace, we))
 
 	// fail this workflow task to flush buffer, and then another workflow task will be scheduled
-	_, err2 := s.engine.RespondWorkflowTaskFailed(NewContext(), &workflowservice.RespondWorkflowTaskFailedRequest{
+	_, err2 := s.client.RespondWorkflowTaskFailed(NewContext(), &workflowservice.RespondWorkflowTaskFailedRequest{
 		Namespace: s.namespace,
 		TaskToken: resp1.GetTaskToken(),
 		Cause:     cause,
@@ -581,7 +581,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskS
   6 WorkflowTaskScheduled`, s.getHistory(s.namespace, we))
 
 	// then terminate the workflow
-	_, err := s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err := s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		Reason:            "test-reason",
@@ -620,7 +620,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalBeforeTransientWorkflowTa
 		Identity:            identity,
 	}
 
-	resp0, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	resp0, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	we := &commonpb.WorkflowExecution{
@@ -634,7 +634,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalBeforeTransientWorkflowTa
 
 	cause := enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE
 	for i := 0; i < 10; i++ {
-		resp1, err1 := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+		resp1, err1 := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.namespace,
 			TaskQueue: taskQueue,
 			Identity:  identity,
@@ -649,7 +649,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalBeforeTransientWorkflowTa
 			s.Equal(int64(6), resp1.GetStartedEventId())
 		}
 
-		_, err2 := s.engine.RespondWorkflowTaskFailed(NewContext(), &workflowservice.RespondWorkflowTaskFailedRequest{
+		_, err2 := s.client.RespondWorkflowTaskFailed(NewContext(), &workflowservice.RespondWorkflowTaskFailedRequest{
 			Namespace: s.namespace,
 			TaskToken: resp1.GetTaskToken(),
 			Cause:     cause,
@@ -664,7 +664,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalBeforeTransientWorkflowTa
   3 WorkflowTaskStarted
   4 WorkflowTaskFailed`, s.getHistory(s.namespace, we))
 
-	_, err0 = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err0 = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		SignalName:        "sig-for-integ-test",
@@ -681,7 +681,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalBeforeTransientWorkflowTa
   5 WorkflowExecutionSignaled`, s.getHistory(s.namespace, we))
 
 	// start this transient workflow task, the attempt should be cleared and it becomes again a regular workflow task
-	resp1, err1 := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	resp1, err1 := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: taskQueue,
 		Identity:  identity,
@@ -699,7 +699,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalBeforeTransientWorkflowTa
   7 WorkflowTaskStarted`, s.getHistory(s.namespace, we))
 
 	// then terminate the workflow
-	_, err := s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err := s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		Reason:            "test-reason",
@@ -740,7 +740,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
 		Identity:            identity,
 	}
 
-	resp0, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	resp0, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	we := &commonpb.WorkflowExecution{
@@ -754,7 +754,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
 
 	cause := enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE
 	for i := 0; i < 10; i++ {
-		resp1, err1 := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+		resp1, err1 := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.namespace,
 			TaskQueue: taskQueue,
 			Identity:  identity,
@@ -769,7 +769,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
 			s.Equal(int64(6), resp1.GetStartedEventId())
 		}
 
-		_, err2 := s.engine.RespondWorkflowTaskFailed(NewContext(), &workflowservice.RespondWorkflowTaskFailedRequest{
+		_, err2 := s.client.RespondWorkflowTaskFailed(NewContext(), &workflowservice.RespondWorkflowTaskFailedRequest{
 			Namespace: s.namespace,
 			TaskToken: resp1.GetTaskToken(),
 			Cause:     cause,
@@ -785,7 +785,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
   4 WorkflowTaskFailed`, s.getHistory(s.namespace, we))
 
 	// start workflow task to make signals into bufferedEvents
-	_, err1 := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	_, err1 := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: taskQueue,
 		Identity:  identity,
@@ -799,7 +799,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
   4 WorkflowTaskFailed`, s.getHistory(s.namespace, we))
 
 	// this signal should be buffered
-	_, err0 = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err0 = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		SignalName:        "sig-for-integ-test",
@@ -815,7 +815,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
   4 WorkflowTaskFailed`, s.getHistory(s.namespace, we))
 
 	// then terminate the workflow
-	_, err := s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err := s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		Reason:            "test-reason",
@@ -853,7 +853,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
 		Identity:            identity,
 	}
 
-	resp0, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	resp0, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 
 	we := &commonpb.WorkflowExecution{
@@ -867,7 +867,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
 
 	cause := enumspb.WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE
 	for i := 0; i < 10; i++ {
-		resp1, err1 := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+		resp1, err1 := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.namespace,
 			TaskQueue: taskQueue,
 			Identity:  identity,
@@ -882,7 +882,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
 			s.Equal(int64(6), resp1.GetStartedEventId())
 		}
 
-		_, err2 := s.engine.RespondWorkflowTaskFailed(NewContext(), &workflowservice.RespondWorkflowTaskFailedRequest{
+		_, err2 := s.client.RespondWorkflowTaskFailed(NewContext(), &workflowservice.RespondWorkflowTaskFailedRequest{
 			Namespace: s.namespace,
 			TaskToken: resp1.GetTaskToken(),
 			Cause:     cause,
@@ -898,7 +898,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
   4 WorkflowTaskFailed`, s.getHistory(s.namespace, we))
 
 	// start workflow task to make signals into bufferedEvents
-	resp1, err1 := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
+	resp1, err1 := s.client.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: taskQueue,
 		Identity:  identity,
@@ -912,7 +912,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
   4 WorkflowTaskFailed`, s.getHistory(s.namespace, we))
 
 	// this signal should be buffered
-	_, err0 = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+	_, err0 = s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		SignalName:        "sig-for-integ-test",
@@ -928,7 +928,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
   4 WorkflowTaskFailed`, s.getHistory(s.namespace, we))
 
 	// fail this workflow task to flush buffer
-	_, err2 := s.engine.RespondWorkflowTaskFailed(NewContext(), &workflowservice.RespondWorkflowTaskFailedRequest{
+	_, err2 := s.client.RespondWorkflowTaskFailed(NewContext(), &workflowservice.RespondWorkflowTaskFailedRequest{
 		Namespace: s.namespace,
 		TaskToken: resp1.GetTaskToken(),
 		Cause:     cause,
@@ -944,7 +944,7 @@ func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
   6 WorkflowTaskScheduled`, s.getHistory(s.namespace, we))
 
 	// then terminate the workflow
-	_, err := s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
+	_, err := s.client.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		Reason:            "test-reason",

--- a/tests/workflow_timer.go
+++ b/tests/workflow_timer.go
@@ -57,7 +57,7 @@ func (s *FunctionalSuite) TestCancelTimer() {
 		Identity:            identity,
 	}
 
-	creatResp, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	creatResp, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	workflowExecution := &commonpb.WorkflowExecution{
 		WorkflowId: id,
@@ -113,7 +113,7 @@ func (s *FunctionalSuite) TestCancelTimer() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -179,7 +179,7 @@ func (s *FunctionalSuite) TestCancelTimer_CancelFiredAndBuffered() {
 		Identity:            identity,
 	}
 
-	creatResp, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	creatResp, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)
 	workflowExecution := &commonpb.WorkflowExecution{
 		WorkflowId: id,
@@ -236,7 +236,7 @@ func (s *FunctionalSuite) TestCancelTimer_CancelFiredAndBuffered() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,

--- a/tests/workflow_visibility.go
+++ b/tests/workflow_visibility.go
@@ -62,7 +62,7 @@ func (s *FunctionalSuite) TestVisibility() {
 		Identity:            identity,
 	}
 
-	startResponse, err0 := s.engine.StartWorkflowExecution(NewContext(), startRequest)
+	startResponse, err0 := s.client.StartWorkflowExecution(NewContext(), startRequest)
 	s.NoError(err0)
 
 	// Now complete one of the executions
@@ -76,7 +76,7 @@ func (s *FunctionalSuite) TestVisibility() {
 	}
 
 	poller := &TaskPoller{
-		Engine:              s.engine,
+		Client:              s.client,
 		Namespace:           s.namespace,
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
@@ -93,7 +93,7 @@ func (s *FunctionalSuite) TestVisibility() {
 	var nextToken []byte
 	historyEventFilterType := enumspb.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT
 	for {
-		historyResponse, historyErr := s.engine.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
+		historyResponse, historyErr := s.client.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
 			Namespace: startRequest.Namespace,
 			Execution: &commonpb.WorkflowExecution{
 				WorkflowId: startRequest.WorkflowId,
@@ -123,7 +123,7 @@ func (s *FunctionalSuite) TestVisibility() {
 		Identity:            identity,
 	}
 
-	_, err2 := s.engine.StartWorkflowExecution(NewContext(), startRequest)
+	_, err2 := s.client.StartWorkflowExecution(NewContext(), startRequest)
 	s.NoError(err2)
 
 	startFilter := &filterpb.StartTimeFilter{}
@@ -136,7 +136,7 @@ func (s *FunctionalSuite) TestVisibility() {
 	var historyLength int64
 	s.Eventually(
 		func() bool {
-			resp, err3 := s.engine.ListClosedWorkflowExecutions(NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
+			resp, err3 := s.client.ListClosedWorkflowExecutions(NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
 				Namespace:       s.namespace,
 				MaximumPageSize: 100,
 				StartTimeFilter: startFilter,
@@ -164,7 +164,7 @@ func (s *FunctionalSuite) TestVisibility() {
 
 	s.Eventually(
 		func() bool {
-			resp, err4 := s.engine.ListOpenWorkflowExecutions(NewContext(), &workflowservice.ListOpenWorkflowExecutionsRequest{
+			resp, err4 := s.client.ListOpenWorkflowExecutions(NewContext(), &workflowservice.ListOpenWorkflowExecutionsRequest{
 				Namespace:       s.namespace,
 				MaximumPageSize: 100,
 				StartTimeFilter: startFilter,

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -45,10 +45,11 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
-	"go.temporal.io/server/common/testing/historyrequire"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v3"
+
+	"go.temporal.io/server/common/testing/historyrequire"
 
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/common"
@@ -298,7 +299,7 @@ func (s *AdvVisCrossDCTestSuite) TestSearchAttributes() {
 	}
 
 	poller := tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -275,7 +275,7 @@ func (s *FunctionalClustersTestSuite) TestSimpleWorkflowFailover() {
 	}
 
 	poller := tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           namespaceName,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -287,7 +287,7 @@ func (s *FunctionalClustersTestSuite) TestSimpleWorkflowFailover() {
 	}
 
 	poller2 := tests.TaskPoller{
-		Engine:              client2,
+		Client:              client2,
 		Namespace:           namespaceName,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -548,7 +548,7 @@ func (s *FunctionalClustersTestSuite) TestStickyWorkflowTaskFailover() {
 	}
 
 	poller1 := &tests.TaskPoller{
-		Engine:                       client1,
+		Client:                       client1,
 		Namespace:                    namespace,
 		TaskQueue:                    taskQueue,
 		StickyTaskQueue:              stickyTaskQueue1,
@@ -560,7 +560,7 @@ func (s *FunctionalClustersTestSuite) TestStickyWorkflowTaskFailover() {
 	}
 
 	poller2 := &tests.TaskPoller{
-		Engine:                       client2,
+		Client:                       client2,
 		Namespace:                    namespace,
 		TaskQueue:                    taskQueue,
 		StickyTaskQueue:              stickyTaskQueue2,
@@ -683,7 +683,7 @@ func (s *FunctionalClustersTestSuite) TestStartWorkflowExecution_Failover_Workfl
 	}
 
 	poller := tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           namespaceName,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -694,7 +694,7 @@ func (s *FunctionalClustersTestSuite) TestStartWorkflowExecution_Failover_Workfl
 	}
 
 	poller2 := tests.TaskPoller{
-		Engine:              client2,
+		Client:              client2,
 		Namespace:           namespaceName,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -824,7 +824,7 @@ func (s *FunctionalClustersTestSuite) TestTerminateFailover() {
 	}
 
 	poller := &tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1003,7 +1003,7 @@ func (s *FunctionalClustersTestSuite) TestResetWorkflowFailover() {
 	}
 
 	poller := tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1014,7 +1014,7 @@ func (s *FunctionalClustersTestSuite) TestResetWorkflowFailover() {
 	}
 
 	poller2 := tests.TaskPoller{
-		Engine:              client2,
+		Client:              client2,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1173,7 +1173,7 @@ func (s *FunctionalClustersTestSuite) TestContinueAsNewFailover() {
 	}
 
 	poller := &tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1183,7 +1183,7 @@ func (s *FunctionalClustersTestSuite) TestContinueAsNewFailover() {
 	}
 
 	poller2 := tests.TaskPoller{
-		Engine:              client2,
+		Client:              client2,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1286,7 +1286,7 @@ func (s *FunctionalClustersTestSuite) TestSignalFailover() {
 	}
 
 	poller := &tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1296,7 +1296,7 @@ func (s *FunctionalClustersTestSuite) TestSignalFailover() {
 	}
 
 	poller2 := &tests.TaskPoller{
-		Engine:              client2,
+		Client:              client2,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1557,7 +1557,7 @@ func (s *FunctionalClustersTestSuite) TestUserTimerFailover() {
 	}
 
 	poller1 := &tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1567,7 +1567,7 @@ func (s *FunctionalClustersTestSuite) TestUserTimerFailover() {
 	}
 
 	poller2 := &tests.TaskPoller{
-		Engine:              client2,
+		Client:              client2,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1665,7 +1665,7 @@ func (s *FunctionalClustersTestSuite) TestForceWorkflowTaskClose_WithClusterReco
 	}
 
 	poller1 := &tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1823,7 +1823,7 @@ func (s *FunctionalClustersTestSuite) TestTransientWorkflowTaskFailover() {
 	}
 
 	poller1 := &tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1833,7 +1833,7 @@ func (s *FunctionalClustersTestSuite) TestTransientWorkflowTaskFailover() {
 	}
 
 	poller2 := &tests.TaskPoller{
-		Engine:              client2,
+		Client:              client2,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -1918,7 +1918,7 @@ func (s *FunctionalClustersTestSuite) TestCronWorkflowStartAndFailover() {
 	}
 
 	poller2 := tests.TaskPoller{
-		Engine:              client2,
+		Client:              client2,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -2013,7 +2013,7 @@ func (s *FunctionalClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
 	}
 
 	poller1 := tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -2023,7 +2023,7 @@ func (s *FunctionalClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
 	}
 
 	poller2 := tests.TaskPoller{
-		Engine:              client2,
+		Client:              client2,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -2136,7 +2136,7 @@ func (s *FunctionalClustersTestSuite) TestWorkflowRetryStartAndFailover() {
 	}
 
 	poller2 := tests.TaskPoller{
-		Engine:              client2,
+		Client:              client2,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -2240,7 +2240,7 @@ func (s *FunctionalClustersTestSuite) TestWorkflowRetryFailAndFailover() {
 	}
 
 	poller1 := tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -2250,7 +2250,7 @@ func (s *FunctionalClustersTestSuite) TestWorkflowRetryFailAndFailover() {
 	}
 
 	poller2 := tests.TaskPoller{
-		Engine:              client2,
+		Client:              client2,
 		Namespace:           namespace,
 		TaskQueue:           taskQueue,
 		Identity:            identity,

--- a/tests/xdc/history_replication_signals_and_updates_test.go
+++ b/tests/xdc/history_replication_signals_and_updates_test.go
@@ -745,7 +745,7 @@ func (c *hrsuTestCluster) sendUpdateAndWaitUntilAccepted(ctx context.Context, up
 
 func (c *hrsuTestCluster) pollAndAcceptUpdate() error {
 	poller := &tests.TaskPoller{
-		Engine:              c.testCluster.GetFrontendClient(),
+		Client:              c.testCluster.GetFrontendClient(),
 		Namespace:           c.t.tv.NamespaceName().String(),
 		TaskQueue:           c.t.tv.TaskQueue(),
 		Identity:            c.t.tv.WorkerIdentity(),
@@ -760,7 +760,7 @@ func (c *hrsuTestCluster) pollAndAcceptUpdate() error {
 
 func (c *hrsuTestCluster) pollAndCompleteUpdate(updateId string) error {
 	poller := &tests.TaskPoller{
-		Engine:              c.testCluster.GetFrontendClient(),
+		Client:              c.testCluster.GetFrontendClient(),
 		Namespace:           c.t.tv.NamespaceName().String(),
 		TaskQueue:           c.t.tv.TaskQueue(),
 		Identity:            c.t.tv.WorkerIdentity(),
@@ -775,7 +775,7 @@ func (c *hrsuTestCluster) pollAndCompleteUpdate(updateId string) error {
 
 func (c *hrsuTestCluster) pollAndErrorWhileProcessingWorkflowTask() error {
 	poller := &tests.TaskPoller{
-		Engine:              c.testCluster.GetFrontendClient(),
+		Client:              c.testCluster.GetFrontendClient(),
 		Namespace:           c.t.tv.NamespaceName().String(),
 		TaskQueue:           c.t.tv.TaskQueue(),
 		Identity:            c.t.tv.WorkerIdentity(),

--- a/tests/xdc/stream_based_replication_test.go
+++ b/tests/xdc/stream_based_replication_test.go
@@ -384,7 +384,7 @@ func (s *streamBasedReplicationTestSuite) TestForceReplicateResetWorkflow_BaseWo
 	}
 
 	poller := &tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           ns,
 		TaskQueue:           taskQueue,
 		Identity:            identity,
@@ -532,7 +532,7 @@ func (s *streamBasedReplicationTestSuite) TestResetWorkflow_SyncWorkflowState() 
 	}
 
 	poller := &tests.TaskPoller{
-		Engine:              client1,
+		Client:              client1,
 		Namespace:           ns,
 		TaskQueue:           taskQueue,
 		Identity:            identity,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Renamed fields of type `FrontendClient` from `engine` to `client`.

PS: using `frontendClient` seemed unnecessarily specific/verbose

## Why?
<!-- Tell your future self why have you made these changes -->

There is a `shard.Engine` and `matching.Engine` etc. which makes using this identifier for a frontend client misleading. Due to its name, more than once have I thought that a History Service test was calling the History Service directly, only to learn/remember that it's actually going through the Frontend Service.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Only touches tests. Refactoring was done via IDE.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
