### PR TITLE
Enable balanced partitions by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1096,7 +1096,7 @@ This can help reduce effects of task queue movement.`,
 	)
 	MatchingBacklogNegligibleAge = NewTaskQueueDurationSetting(
 		"matching.backlogNegligibleAge",
-		24*365*10*time.Hour,
+		5*time.Second,
 		`MatchingBacklogNegligibleAge if the head of backlog gets older than this we stop sync match and
 forwarding to ensure more equal dispatch order among partitions.`,
 	)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Set `matching.backlogNegligibleAge` to five seconds by default to enable balanced partitions.

## Why?
<!-- Tell your future self why have you made these changes -->

This config stop forwarding tasks and pollers once the backlog age in the child partition exceeds 5 seconds. By doing so we ensure that all partitions are treated equally when the task queue starts to accumulate backlog. It's expected that the backlog age difference among all partitions should stay around this 5 seconds value.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Feature already tests in prod.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
None.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
None.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.