### PR TITLE
Add readthrough cache for nexus endpoints by ID

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -834,6 +834,18 @@ server hosts for it to take effect.`,
 		1*time.Second,
 		`RefreshNexusEndpointsMinWait is the minimum wait time between background long poll requests to update Nexus endpoints.`,
 	)
+	NexusReadThroughCacheSize = NewGlobalIntSetting(
+		"system.nexusReadThroughCacheSize",
+		100,
+		`The size of the Nexus endpoint registry's readthrough LRU cache - the cache is a secondary cache and is only
+used when the first cache layer has a miss. Requires server restart for change to be applied.`,
+	)
+	NexusReadThroughCacheTTL = NewGlobalDurationSetting(
+		"system.nexusReadThroughCacheTTL",
+		30*time.Second,
+		`The TTL of the Nexus endpoint registry's readthrough LRU cache - the cache is a secondary cache and is only
+used when the first cache layer has a miss. Requires server restart for change to be applied.`,
+	)
 	FrontendCallbackURLMaxLength = NewNamespaceIntSetting(
 		"frontend.callbackURLMaxLength",
 		1000,

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -59,8 +59,9 @@ const (
 	DCRedirectionRoleTagValue = "dc_redirection"
 	BlobstoreRoleTagValue     = "blobstore"
 
-	MutableStateCacheTypeTagValue = "mutablestate"
-	EventsCacheTypeTagValue       = "events"
+	MutableStateCacheTypeTagValue                     = "mutablestate"
+	EventsCacheTypeTagValue                           = "events"
+	NexusEndpointRegistryReadThroughCacheTypeTagValue = "nexus_endpoint_registry_readthrough"
 
 	InvalidHistoryURITagValue    = "invalid_history_uri"
 	InvalidVisibilityURITagValue = "invalid_visibility_uri"

--- a/components/nexusoperations/fx.go
+++ b/components/nexusoperations/fx.go
@@ -37,6 +37,7 @@ import (
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/persistence"
@@ -62,8 +63,9 @@ const NexusCallbackSourceHeader = "Nexus-Callback-Source"
 func EndpointRegistryProvider(
 	matchingClient resource.MatchingClient,
 	endpointManager persistence.NexusEndpointManager,
-	logger log.Logger,
 	dc *dynamicconfig.Collection,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
 ) commonnexus.EndpointRegistry {
 	registryConfig := commonnexus.NewEndpointRegistryConfig(dc)
 	return commonnexus.NewEndpointRegistry(
@@ -71,6 +73,7 @@ func EndpointRegistryProvider(
 		matchingClient,
 		endpointManager,
 		logger,
+		metricsHandler,
 	)
 }
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -840,8 +840,9 @@ func NexusEndpointClientProvider(
 func NexusEndpointRegistryProvider(
 	matchingClient resource.MatchingClient,
 	nexusEndpointManager persistence.NexusEndpointManager,
-	logger log.Logger,
 	dc *dynamicconfig.Collection,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
 ) nexus.EndpointRegistry {
 	registryConfig := nexus.NewEndpointRegistryConfig(dc)
 	return nexus.NewEndpointRegistry(
@@ -849,6 +850,7 @@ func NexusEndpointRegistryProvider(
 		matchingClient,
 		nexusEndpointManager,
 		logger,
+		metricsHandler,
 	)
 }
 


### PR DESCRIPTION
## What changed?

Add read-through cache for nexus endpoints by ID.
Note that this isn't done for getting an endpoint by name yet as it because that API is only used during command validation, where a cache miss it will fail a workflow task to automatically retried later.

## Why?

Better testing experience.

## How did you test it?

Added a unit test.