### PR TITLE
Do not retry tasks that result in wrapped NotFound errors

### DIFF
--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -366,7 +366,7 @@ func (e *executableImpl) isSafeToDropError(err error) bool {
 		return true
 	}
 
-	if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
+	if errors.As(err, new(*serviceerror.NotFound)) {
 		return true
 	}
 

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -167,6 +167,13 @@ func (s *executableSuite) TestExecute_InMemoryNoUserLatency_SingleAttempt() {
 			expectBackoff:                false,
 		},
 		{
+			name:                         "NotFoundErrorWrapped",
+			taskErr:                      fmt.Errorf("%w: some reason", consts.ErrWorkflowCompleted),
+			expectError:                  false,
+			expectedAttemptNoUserLatency: attemptNoUserLatency,
+			expectBackoff:                false,
+		},
+		{
 			name:                         "ResourceExhaustedError",
 			taskErr:                      consts.ErrResourceExhaustedBusyWorkflow,
 			expectError:                  true,


### PR DESCRIPTION
We have use cases (e.g. nexus) where we wrap errors to provide more context and we expect those errors to be non-retryable.

Using `errors.As` is also more idiomatic in Go.