### PR TITLE
Add lifecycle callbacks for workflow cache

### DIFF
--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -58,7 +58,7 @@ type Cache interface {
 	Size() int
 }
 
-// Options control the behavior of the cache
+// Options control the behavior of the cache.
 type Options struct {
 	// TTL controls the time-to-live for a given cache entry.  Cache entries that
 	// are older than the TTL will not be returned.
@@ -71,7 +71,7 @@ type Options struct {
 	TimeSource clock.TimeSource
 }
 
-// SimpleOptions provides options that can be used to configure SimpleCache
+// SimpleOptions provides options that can be used to configure SimpleCache.
 type SimpleOptions struct {
 	// RemovedFunc is an optional function called when an element
 	// is scheduled for deletion
@@ -84,7 +84,7 @@ type SimpleOptions struct {
 // deletion, Cache calls go f(i)
 type RemovedFunc func(interface{})
 
-// Iterator represents the interface for cache iterators
+// Iterator represents the interface for cache iterators.
 type Iterator interface {
 	// Close closes the iterator
 	// and releases any allocated resources
@@ -95,7 +95,7 @@ type Iterator interface {
 	Next() Entry
 }
 
-// Entry represents a key-value entry within the map
+// Entry represents a key-value entry within the map.
 type Entry interface {
 	// Key represents the key
 	Key() interface{}
@@ -103,4 +103,14 @@ type Entry interface {
 	Value() interface{}
 	// CreateTime represents the time when the entry is created
 	CreateTime() time.Time
+}
+
+// PutCallback has a callback that is invoked when being written to the cache.
+type PutCallback interface {
+	OnPut() error
+}
+
+// EvictCallback has a callback that is invoked when being evicted from the cache.
+type EvictCallback interface {
+	OnEvict() error
 }

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -32,6 +32,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
@@ -42,14 +44,25 @@ type (
 		dummyString string
 		dummyInt    int
 	}
-
 	testEntryWithCacheSize struct {
 		cacheSize int
+	}
+	valWithCallback struct {
+		onPut   func() error
+		onEvict func() error
 	}
 )
 
 func (c *testEntryWithCacheSize) CacheSize() int {
 	return c.cacheSize
+}
+
+func (v valWithCallback) OnPut() error {
+	return v.onPut()
+}
+
+func (v valWithCallback) OnEvict() error {
+	return v.onEvict()
 }
 
 func TestLRU(t *testing.T) {
@@ -720,4 +733,45 @@ func TestCache_ItemSizeChangeBeforeRelease(t *testing.T) {
 	cache.Release(key1)
 	// Cache should have evicted entry1 to bring cache size under max limit.
 	assert.Equal(t, 2, cache.Size())
+}
+
+func TestCache_InvokeLifecycleCallbacks(t *testing.T) {
+	t.Parallel()
+
+	ttl := time.Millisecond * 50
+	timeSource := clock.NewEventTimeSource()
+	cache := New(5,
+		&Options{
+			TTL:        ttl,
+			TimeSource: timeSource,
+		},
+	)
+
+	var onPut, onEvict int
+	val := valWithCallback{
+		onPut: func() error {
+			onPut++
+			return nil
+		},
+		onEvict: func() error {
+			onEvict++
+			return nil
+		},
+	}
+
+	cache.Put("key", val)
+	cache.Put("key", val)
+	require.Equal(t, 2, onPut, "expected OnPut callback to be invoked twice")
+
+	_, _ = cache.PutIfNotExist("key", val)
+	require.Equal(t, 2, onPut, "expected OnPut callback to *not* be invoked again")
+	require.Equal(t, 0, onEvict, "expected OnEvict callback to be *not* be invoked")
+
+	cache.Delete("key")
+	require.Equal(t, 1, onEvict, "expected OnEvict callback to be invoked")
+
+	cache.Put("key", val)
+	timeSource.Advance(2 * ttl)
+	assert.Nil(t, cache.Get("key"))
+	require.Equal(t, 2, onEvict, "expected OnEvict callback to be invoked")
 }

--- a/service/history/api/respondworkflowtaskcompleted/api_test.go
+++ b/service/history/api/respondworkflowtaskcompleted/api_test.go
@@ -141,7 +141,7 @@ func (s *WorkflowTaskCompletedHandlerSuite) SetupSubTest() {
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
 	s.logger = mockShard.GetLogger()
 
-	s.workflowCache = wcache.NewHostLevelCache(mockShard.GetConfig(), metrics.NoopMetricsHandler)
+	s.workflowCache = wcache.NewHostLevelCache(mockShard.GetConfig(), mockShard.GetLogger(), metrics.NoopMetricsHandler)
 	s.workflowTaskCompletedHandler = NewWorkflowTaskCompletedHandler(
 		mockShard,
 		common.NewProtoTaskTokenSerializer(),

--- a/service/history/api/verifyfirstworkflowtaskscheduled/api_test.go
+++ b/service/history/api/verifyfirstworkflowtaskscheduled/api_test.go
@@ -39,12 +39,13 @@ import (
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	workflowspb "go.temporal.io/server/api/workflow/v1"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/service/history/api"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
@@ -112,7 +113,7 @@ func (s *VerifyFirstWorkflowTaskScheduledSuite) SetupTest() {
 
 	s.workflowConsistencyChecker = api.NewWorkflowConsistencyChecker(
 		s.shardContext,
-		wcache.NewHostLevelCache(s.shardContext.GetConfig(), metrics.NoopMetricsHandler))
+		wcache.NewHostLevelCache(s.shardContext.GetConfig(), s.shardContext.GetLogger(), metrics.NoopMetricsHandler))
 	s.mockEventsCache = s.shardContext.MockEventsCache
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
 	s.logger = s.shardContext.GetLogger()

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -185,7 +185,7 @@ func (s *engine2Suite) SetupTest() {
 			},
 		).
 		AnyTimes()
-	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler)
+	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 	s.logger = log.NewMockLogger(s.controller)
 	s.logger.EXPECT().Debug(gomock.Any(), gomock.Any()).AnyTimes()
 	s.logger.EXPECT().Info(gomock.Any(), gomock.Any()).AnyTimes()

--- a/service/history/history_engine3_eventsv2_test.go
+++ b/service/history/history_engine3_eventsv2_test.go
@@ -145,7 +145,7 @@ func (s *engine3Suite) SetupTest() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(false, common.EmptyVersion).Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
-	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler)
+	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 	s.mockVisibilityManager.EXPECT().GetIndexName().Return("").AnyTimes()
 	s.mockVisibilityManager.EXPECT().
 		ValidateCustomSearchAttributes(gomock.Any()).

--- a/service/history/history_engine_factory.go
+++ b/service/history/history_engine_factory.go
@@ -80,7 +80,7 @@ func (f *historyEngineFactory) CreateEngine(
 	if shard.GetConfig().EnableHostLevelHistoryCache() {
 		wfCache = f.WorkflowCache
 	} else {
-		wfCache = f.NewCacheFn(shard.GetConfig(), shard.GetMetricsHandler())
+		wfCache = f.NewCacheFn(shard.GetConfig(), shard.GetLogger(), shard.GetMetricsHandler())
 	}
 
 	workflowConsistencyChecker := api.NewWorkflowConsistencyChecker(shard, wfCache)

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -182,7 +182,7 @@ func (s *engineSuite) SetupTest() {
 		},
 		s.config,
 	)
-	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler)
+	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 
 	s.eventsCache = events.NewHostLevelEventsCache(
 		s.mockShard.GetExecutionManager(),

--- a/service/history/ndc/activity_state_replicator_test.go
+++ b/service/history/ndc/activity_state_replicator_test.go
@@ -70,7 +70,7 @@ type (
 
 		mockExecutionMgr *persistence.MockExecutionManager
 
-		workflowCache *wcache.CacheImpl
+		workflowCache wcache.Cache
 		logger        log.Logger
 
 		nDCActivityStateReplicator *ActivityStateReplicatorImpl
@@ -103,7 +103,8 @@ func (s *activityReplicatorStateSuite) SetupTest() {
 		},
 		tests.NewDynamicConfig(),
 	)
-	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler).(*wcache.CacheImpl)
+
+	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 
 	s.mockNamespaceCache = s.mockShard.Resource.NamespaceCache
 	s.mockExecutionMgr = s.mockShard.Resource.ExecutionMgr
@@ -679,7 +680,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_WorkflowClosed() {
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
-	_, err := s.workflowCache.PutIfNotExist(key, weContext)
+	err := wcache.PutContextIfNotExist(s.workflowCache, key, weContext)
 	s.NoError(err)
 
 	request := &historyservice.SyncActivityRequest{
@@ -758,7 +759,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_WorkflowClosed() {
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
-	_, err := s.workflowCache.PutIfNotExist(key, weContext)
+	err := wcache.PutContextIfNotExist(s.workflowCache, key, weContext)
 	s.NoError(err)
 
 	request := &historyservice.SyncActivitiesRequest{
@@ -841,7 +842,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityNotFound() {
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
-	_, err := s.workflowCache.PutIfNotExist(key, weContext)
+	err := wcache.PutContextIfNotExist(s.workflowCache, key, weContext)
 	s.NoError(err)
 
 	request := &historyservice.SyncActivityRequest{
@@ -921,7 +922,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityNotFound() {
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
-	_, err := s.workflowCache.PutIfNotExist(key, weContext)
+	err := wcache.PutContextIfNotExist(s.workflowCache, key, weContext)
 	s.NoError(err)
 
 	request := &historyservice.SyncActivitiesRequest{
@@ -1005,7 +1006,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_Zombie() {
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
-	_, err := s.workflowCache.PutIfNotExist(key, weContext)
+	err := wcache.PutContextIfNotExist(s.workflowCache, key, weContext)
 	s.NoError(err)
 
 	now := time.Now()
@@ -1108,7 +1109,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityFound_Zombie()
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
-	_, err := s.workflowCache.PutIfNotExist(key, weContext)
+	err := wcache.PutContextIfNotExist(s.workflowCache, key, weContext)
 	s.NoError(err)
 
 	now := time.Now()
@@ -1214,7 +1215,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_NonZombie(
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
-	_, err := s.workflowCache.PutIfNotExist(key, weContext)
+	err := wcache.PutContextIfNotExist(s.workflowCache, key, weContext)
 	s.NoError(err)
 
 	now := time.Now()
@@ -1317,7 +1318,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityFound_NonZombi
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
 
-	_, err := s.workflowCache.PutIfNotExist(key, weContext)
+	err := wcache.PutContextIfNotExist(s.workflowCache, key, weContext)
 	s.NoError(err)
 
 	now := time.Now()

--- a/service/history/ndc/hsm_state_replicator_test.go
+++ b/service/history/ndc/hsm_state_replicator_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -65,7 +66,7 @@ type (
 
 		mockExecutionMgr *persistence.MockExecutionManager
 
-		workflowCache *wcache.CacheImpl
+		workflowCache wcache.Cache
 		logger        log.Logger
 
 		workflowKey     definition.WorkflowKey
@@ -109,9 +110,7 @@ func (s *hsmStateReplicatorSuite) SetupTest() {
 	err = stateMachineRegistry.RegisterTaskSerializer(hsmtest.TaskType, hsmtest.TaskSerializer{})
 	s.NoError(err)
 
-	var ok bool
-	s.workflowCache, ok = wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler).(*wcache.CacheImpl)
-	s.True(ok)
+	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 
 	s.namespaceEntry = tests.GlobalNamespaceEntry
 	s.workflowKey = definition.NewWorkflowKey(s.namespaceEntry.ID().String(), tests.WorkflowID, tests.RunID)

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -105,7 +105,7 @@ func (s *transactionMgrSuite) SetupTest() {
 
 	s.transactionMgr = NewTransactionManager(
 		s.mockShard,
-		wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler),
+		wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler),
 		s.mockEventsReapplier,
 		s.logger,
 		false,

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -116,7 +116,7 @@ func (s *workflowResetterSuite) SetupTest() {
 
 	s.workflowResetter = NewWorkflowResetter(
 		s.mockShard,
-		wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler),
+		wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler),
 		s.logger,
 	)
 	s.workflowResetter.stateRebuilder = s.mockStateRebuilder
@@ -718,7 +718,8 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithConti
 		WorkflowKey: definition.NewWorkflowKey(s.namespaceID.String(), s.workflowID, newRunID),
 		ShardUUID:   s.mockShard.GetOwner(),
 	}
-	_, _ = s.workflowResetter.workflowCache.(*wcache.CacheImpl).PutIfNotExist(resetContextCacheKey, resetContext)
+	err := wcache.PutContextIfNotExist(s.workflowResetter.workflowCache, resetContextCacheKey, resetContext)
+	s.NoError(err)
 
 	mutableState := workflow.NewMockMutableState(s.controller)
 	mutableState.EXPECT().VisitUpdates(gomock.Any()).Return()

--- a/service/history/replication/ack_manager_test.go
+++ b/service/history/replication/ack_manager_test.go
@@ -120,7 +120,7 @@ func (s *ackManagerSuite) SetupTest() {
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, gomock.Any()).Return(cluster.TestCurrentClusterName).AnyTimes()
 
 	s.logger = s.mockShard.GetLogger()
-	workflowCache := wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler)
+	workflowCache := wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 
 	s.replicationAckManager = NewAckManager(
 		s.mockShard, workflowCache, nil, s.mockExecutionMgr, s.logger,

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
+
 	"go.temporal.io/server/api/adminservice/v1"
 	clockspb "go.temporal.io/server/api/clock/v1"
 	"go.temporal.io/server/api/historyservice/v1"

--- a/service/history/statemachine_environment_test.go
+++ b/service/history/statemachine_environment_test.go
@@ -106,7 +106,7 @@ func newStateMachineEnvTestContext(t *testing.T, enableTransitionHistory bool) *
 	require.NoError(t, callbacks.RegisterStateMachine(reg))
 	require.NoError(t, callbacks.RegisterTaskSerializers(reg))
 	s.mockShard.SetStateMachineRegistry(reg)
-	s.workflowCache = cache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetMetricsHandler())
+	s.workflowCache = cache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), s.mockShard.GetMetricsHandler())
 
 	mockClusterMetadata := s.mockShard.Resource.ClusterMetadata
 	mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -173,7 +173,7 @@ func (s *timerQueueActiveTaskExecutorSuite) SetupTest() {
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(true).AnyTimes()
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(s.namespaceEntry.IsGlobalNamespace(), s.version).Return(s.mockClusterMetadata.GetCurrentClusterName()).AnyTimes()
-	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler)
+	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 	s.logger = s.mockShard.GetLogger()
 
 	s.mockDeleteManager = deletemanager.NewMockDeleteManager(s.controller)
@@ -1966,7 +1966,7 @@ func (s *timerQueueActiveTaskExecutorSuite) getMutableStateFromCache(
 		WorkflowKey: definition.NewWorkflowKey(namespaceID.String(), workflowID, runID),
 		ShardUUID:   s.mockShard.GetOwner(),
 	}
-	return s.workflowCache.(*wcache.CacheImpl).Get(key).(*workflow.ContextImpl).MutableState
+	return wcache.GetMutableState(s.workflowCache, key)
 }
 
 func (s *timerQueueActiveTaskExecutorSuite) newTaskExecutable(

--- a/service/history/timer_queue_standby_task_executor_test.go
+++ b/service/history/timer_queue_standby_task_executor_test.go
@@ -179,7 +179,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) SetupTest() {
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(true).AnyTimes()
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(s.namespaceEntry.IsGlobalNamespace(), s.version).Return(s.clusterName).AnyTimes()
-	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler)
+	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 	s.logger = s.mockShard.GetLogger()
 
 	s.mockDeleteManager = deletemanager.NewMockDeleteManager(s.controller)

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -217,7 +217,7 @@ func (s *transferQueueActiveTaskExecutorSuite) SetupTest() {
 	s.mockArchivalMetadata.SetHistoryEnabledByDefault()
 	s.mockArchivalMetadata.SetVisibilityEnabledByDefault()
 
-	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler)
+	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 	s.logger = s.mockShard.GetLogger()
 
 	h := &historyEngineImpl{

--- a/service/history/transfer_queue_standby_task_executor_test.go
+++ b/service/history/transfer_queue_standby_task_executor_test.go
@@ -190,7 +190,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) SetupTest() {
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(true).AnyTimes()
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(s.namespaceEntry.IsGlobalNamespace(), s.version).Return(s.clusterName).AnyTimes()
 
-	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler)
+	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 	s.logger = s.mockShard.GetLogger()
 
 	s.mockArchivalMetadata.SetHistoryEnabledByDefault()
@@ -1039,7 +1039,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessStartChildExecution_P
 	mutableState.FlushBufferedEvents()
 
 	// clear the cache
-	s.transferQueueStandbyTaskExecutor.cache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler)
+	s.transferQueueStandbyTaskExecutor.cache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 	persistenceMutableState = s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
@@ -1154,7 +1154,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessStartChildExecution_S
 	)
 	s.NoError(err)
 
-	s.transferQueueStandbyTaskExecutor.cache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler)
+	s.transferQueueStandbyTaskExecutor.cache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 	persistenceMutableState = s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockHistoryClient.EXPECT().VerifyFirstWorkflowTaskScheduled(gomock.Any(), gomock.Any()).Return(nil, nil)

--- a/service/history/visibility_queue_task_executor_test.go
+++ b/service/history/visibility_queue_task_executor_test.go
@@ -154,7 +154,7 @@ func (s *visibilityQueueTaskExecutorSuite) SetupTest() {
 	mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(true).AnyTimes()
 	mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, s.version).Return(mockClusterMetadata.GetCurrentClusterName()).AnyTimes()
 
-	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), metrics.NoopMetricsHandler)
+	s.workflowCache = wcache.NewHostLevelCache(s.mockShard.GetConfig(), s.mockShard.GetLogger(), metrics.NoopMetricsHandler)
 	s.logger = s.mockShard.GetLogger()
 
 	h := &historyEngineImpl{

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -84,13 +84,17 @@ type (
 		) (workflow.Context, ReleaseCacheFunc, error)
 	}
 
-	CacheImpl struct {
+	cacheImpl struct {
 		cache.Cache
 
+		logger                    log.Logger
 		nonUserContextLockTimeout time.Duration
 	}
+	cacheItem struct {
+		wfContext workflow.Context
+	}
 
-	NewCacheFn func(config *configs.Config, handler metrics.Handler) Cache
+	NewCacheFn func(config *configs.Config, logger log.Logger, handler metrics.Handler) Cache
 
 	Key struct {
 		// Those are exported because some unit tests uses the cache directly.
@@ -113,6 +117,7 @@ const (
 
 func NewHostLevelCache(
 	config *configs.Config,
+	logger log.Logger,
 	handler metrics.Handler,
 ) Cache {
 	maxSize := config.HistoryHostLevelCacheMaxSize()
@@ -123,12 +128,14 @@ func NewHostLevelCache(
 		maxSize,
 		config.HistoryCacheTTL(),
 		config.HistoryCacheNonUserContextLockTimeout(),
+		logger,
 		handler,
 	)
 }
 
 func NewShardLevelCache(
 	config *configs.Config,
+	logger log.Logger,
 	handler metrics.Handler,
 ) Cache {
 	maxSize := config.HistoryShardLevelCacheMaxSize()
@@ -139,6 +146,7 @@ func NewShardLevelCache(
 		maxSize,
 		config.HistoryCacheTTL(),
 		config.HistoryCacheNonUserContextLockTimeout(),
+		logger,
 		handler,
 	)
 }
@@ -147,19 +155,21 @@ func newCache(
 	size int,
 	ttl time.Duration,
 	nonUserContextLockTimeout time.Duration,
+	logger log.Logger,
 	handler metrics.Handler,
 ) Cache {
 	opts := &cache.Options{}
 	opts.TTL = ttl
 	opts.Pin = true
 
-	return &CacheImpl{
+	return &cacheImpl{
 		Cache:                     cache.NewWithMetrics(size, opts, handler.WithTags(metrics.CacheTypeTag(metrics.MutableStateCacheTypeTagValue))),
+		logger:                    logger,
 		nonUserContextLockTimeout: nonUserContextLockTimeout,
 	}
 }
 
-func (c *CacheImpl) GetOrCreateCurrentWorkflowExecution(
+func (c *cacheImpl) GetOrCreateCurrentWorkflowExecution(
 	ctx context.Context,
 	shardContext shard.Context,
 	namespaceID namespace.ID,
@@ -201,7 +211,7 @@ func (c *CacheImpl) GetOrCreateCurrentWorkflowExecution(
 	return weReleaseFn, err
 }
 
-func (c *CacheImpl) GetOrCreateWorkflowExecution(
+func (c *cacheImpl) GetOrCreateWorkflowExecution(
 	ctx context.Context,
 	shardContext shard.Context,
 	namespaceID namespace.ID,
@@ -237,7 +247,7 @@ func (c *CacheImpl) GetOrCreateWorkflowExecution(
 	return weCtx, weReleaseFunc, err
 }
 
-func (c *CacheImpl) Put(
+func (c *cacheImpl) Put(
 	shardContext shard.Context,
 	namespaceID namespace.ID,
 	execution *commonpb.WorkflowExecution,
@@ -245,16 +255,17 @@ func (c *CacheImpl) Put(
 	handler metrics.Handler,
 ) (workflow.Context, error) {
 	cacheKey := makeCacheKey(shardContext, namespaceID, execution)
-	existing, err := c.PutIfNotExist(cacheKey, workflowCtx)
+	item := &cacheItem{wfContext: workflowCtx}
+	existing, err := c.PutIfNotExist(cacheKey, item)
 	if err != nil {
 		metrics.CacheFailures.With(handler).Record(1)
 		return nil, err
 	}
 	//nolint:revive
-	return existing.(workflow.Context), nil
+	return existing.(*cacheItem).wfContext, nil
 }
 
-func (c *CacheImpl) getOrCreateWorkflowExecutionInternal(
+func (c *cacheImpl) getOrCreateWorkflowExecutionInternal(
 	ctx context.Context,
 	shardContext shard.Context,
 	namespaceID namespace.ID,
@@ -264,8 +275,12 @@ func (c *CacheImpl) getOrCreateWorkflowExecutionInternal(
 	lockPriority locks.Priority,
 ) (workflow.Context, ReleaseCacheFunc, error) {
 	cacheKey := makeCacheKey(shardContext, namespaceID, execution)
-	workflowCtx, cacheHit := c.Get(cacheKey).(workflow.Context)
-	if !cacheHit {
+	item, cacheHit := c.Get(cacheKey).(*cacheItem)
+
+	var workflowCtx workflow.Context
+	if cacheHit {
+		workflowCtx = item.wfContext
+	} else {
 		metrics.CacheMissCounter.With(handler).Record(1)
 		workflowCtx = workflow.NewContext(
 			shardContext.GetConfig(),
@@ -295,7 +310,7 @@ func (c *CacheImpl) getOrCreateWorkflowExecutionInternal(
 	return workflowCtx, releaseFunc, nil
 }
 
-func (c *CacheImpl) lockWorkflowExecution(
+func (c *cacheImpl) lockWorkflowExecution(
 	ctx context.Context,
 	workflowCtx workflow.Context,
 	cacheKey Key,
@@ -327,7 +342,7 @@ func (c *CacheImpl) lockWorkflowExecution(
 	return nil
 }
 
-func (c *CacheImpl) makeReleaseFunc(
+func (c *cacheImpl) makeReleaseFunc(
 	cacheKey Key,
 	shardContext shard.Context,
 	context workflow.Context,
@@ -370,7 +385,7 @@ func (c *CacheImpl) makeReleaseFunc(
 	}
 }
 
-func (c *CacheImpl) validateWorkflowExecutionInfo(
+func (c *cacheImpl) validateWorkflowExecutionInfo(
 	ctx context.Context,
 	shardContext shard.Context,
 	namespaceID namespace.ID,
@@ -403,7 +418,7 @@ func (c *CacheImpl) validateWorkflowExecutionInfo(
 	return nil
 }
 
-func (c *CacheImpl) validateWorkflowID(
+func (c *cacheImpl) validateWorkflowID(
 	workflowID string,
 ) error {
 	if workflowID == "" {
@@ -415,6 +430,23 @@ func (c *CacheImpl) validateWorkflowID(
 		return serviceerror.NewNotFound("Workflow not exists.")
 	}
 
+	return nil
+}
+
+func (c *cacheItem) CacheSize() int {
+	if sg, ok := c.wfContext.(cache.SizeGetter); ok {
+		return sg.CacheSize()
+	}
+	return 0
+}
+
+func (c *cacheItem) OnPut() error {
+	// TODO: will be used in follow-up PR
+	return nil
+}
+
+func (c *cacheItem) OnEvict() error {
+	// TODO: will be used in follow-up PR
 	return nil
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Adds two lifecycle callbacks for workflow cache: OnPut and OnEvict.

## Why?

Prerequisite for https://github.com/temporalio/temporal/pull/6090

tl;dr We need to track workflow contexts per shard in order to clear them when the shard closes. This is the first step towards that goal.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

No actual behavior change is introduced here yet. The callbacks have a new unit test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

No new behavior, therefore no risk expected.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
