### PR TITLE
avoid allocation during precedenceGlobal

### DIFF
--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -77,6 +77,8 @@ const (
 var (
 	errKeyNotPresent        = errors.New("key not present")
 	errNoMatchingConstraint = errors.New("no matching constraint in key")
+
+	precedenceGlobalConstraints = []Constraints{{}}
 )
 
 // NewCollection creates a new collection
@@ -165,9 +167,8 @@ func matchAndConvert[T any](
 }
 
 func precedenceGlobal() []Constraints {
-	return []Constraints{
-		{},
-	}
+	// Return a common slice to avoid allocating.
+	return precedenceGlobalConstraints
 }
 
 func precedenceNamespace(namespace string) []Constraints {


### PR DESCRIPTION
## What changed?
Instead of allocating & returning a new slice in precedenceGlobal, return a package level variable.

## Why?
While looking at recent heap profiles, the allocation for this small slice in `precedenceGlobal` was high on the list of total allocations in the system.

## Is hotfix candidate?
No.
