### PR TITLE
Avoid allocation of dynamic config constraint precedence

### DIFF
--- a/cmd/tools/gendynamicconfig/main.go
+++ b/cmd/tools/gendynamicconfig/main.go
@@ -43,10 +43,10 @@ type (
 		IsGeneric bool
 	}
 	settingPrecedence struct {
-		Name       string
-		GoArgs     string
-		GoArgNames string
-		Index      int
+		Name   string
+		GoArgs string
+		Expr   string
+		Index  int
 	}
 )
 
@@ -86,30 +86,51 @@ var (
 		{
 			Name:   "Global",
 			GoArgs: "",
+			Expr:   "[]Constraints{{}}",
 		},
 		{
 			Name:   "Namespace",
 			GoArgs: "namespace string",
+			Expr:   "[]Constraints{{Namespace: namespace}, {}}",
 		},
 		{
 			Name:   "NamespaceID",
 			GoArgs: "namespaceID string",
+			Expr:   "[]Constraints{{NamespaceID: namespaceID}, {}}",
 		},
 		{
 			Name:   "TaskQueue",
 			GoArgs: "namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType",
+			// A task-queue-name-only filter applies to a single task queue name across all
+			// namespaces, with higher precedence than a namespace-only filter. This is intended to
+			// be used by the default partition count and is probably not useful otherwise.
+			Expr: `[]Constraints{
+			{Namespace: namespace, TaskQueueName: taskQueue, TaskQueueType: taskQueueType},
+			{Namespace: namespace, TaskQueueName: taskQueue},
+			{TaskQueueName: taskQueue},
+			{Namespace: namespace},
+			{},
+		}`,
 		},
 		{
 			Name:   "ShardID",
 			GoArgs: "shardID int32",
+			Expr:   "[]Constraints{{ShardID: shardID}, {}}",
 		},
 		{
 			Name:   "TaskType",
 			GoArgs: "taskType enumsspb.TaskType",
+			Expr:   "[]Constraints{{TaskType: taskType}, {}}",
 		},
 		{
 			Name:   "Destination",
 			GoArgs: "namespace string, destination string",
+			Expr: `[]Constraints{
+			{Namespace: namespace, Destination: destination},
+			{Destination: destination},
+			{Namespace: namespace},
+			{},
+		}`,
 		},
 	}
 )
@@ -199,13 +220,14 @@ func (s {{.P.Name}}TypedSetting[T]) Get(c *Collection) TypedPropertyFn[T] {
 func (s {{.P.Name}}TypedSetting[T]) Get(c *Collection) TypedPropertyFnWith{{.P.Name}}Filter[T] {
 {{- end}}
 	return func({{.P.GoArgs}}) T {
+		prec := {{.P.Expr}}
 		return matchAndConvert(
 			c,
 			s.key,
 			s.def,
 			s.cdef,
 			s.convert,
-			precedence{{.P.Name}}({{.P.GoArgNames}}),
+			prec,
 		)
 	}
 }
@@ -263,13 +285,7 @@ import (
 const PrecedenceUnknown Precedence = 0
 `, nil)
 	for idx, prec := range precedences {
-		// fill in Index and GoArgNames
 		prec.Index = idx + 1
-		var argNames []string
-		for _, argAndType := range strings.Split(prec.GoArgs, ",") {
-			argNames = append(argNames, strings.Split(strings.TrimSpace(argAndType), " ")[0])
-		}
-		prec.GoArgNames = strings.Join(argNames, ", ")
 		generatePrecEnum(w, prec)
 	}
 	for _, tp := range types {

--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -34,9 +34,6 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	enumspb "go.temporal.io/api/enums/v1"
-
-	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -162,62 +159,6 @@ func matchAndConvert[T any](
 		// Return typedVal anyway since we have to return something.
 	}
 	return typedVal
-}
-
-func precedenceGlobal() []Constraints {
-	return []Constraints{
-		{},
-	}
-}
-
-func precedenceNamespace(namespace string) []Constraints {
-	return []Constraints{
-		{Namespace: namespace},
-		{},
-	}
-}
-
-func precedenceNamespaceID(namespaceID string) []Constraints {
-	return []Constraints{
-		{NamespaceID: namespaceID},
-		{},
-	}
-}
-
-func precedenceTaskQueue(namespace string, taskQueue string, taskType enumspb.TaskQueueType) []Constraints {
-	return []Constraints{
-		{Namespace: namespace, TaskQueueName: taskQueue, TaskQueueType: taskType},
-		{Namespace: namespace, TaskQueueName: taskQueue},
-		// A task-queue-name-only filter applies to a single task queue name across all
-		// namespaces, with higher precedence than a namespace-only filter. This is intended to
-		// be used by defaultNumTaskQueuePartitions and is probably not useful otherwise.
-		{TaskQueueName: taskQueue},
-		{Namespace: namespace},
-		{},
-	}
-}
-
-func precedenceDestination(namespace string, destination string) []Constraints {
-	return []Constraints{
-		{Namespace: namespace, Destination: destination},
-		{Destination: destination},
-		{Namespace: namespace},
-		{},
-	}
-}
-
-func precedenceShardID(shardID int32) []Constraints {
-	return []Constraints{
-		{ShardID: shardID},
-		{},
-	}
-}
-
-func precedenceTaskType(taskType enumsspb.TaskType) []Constraints {
-	return []Constraints{
-		{TaskType: taskType},
-		{},
-	}
 }
 
 func convertInt(val any) (int, error) {

--- a/common/dynamicconfig/setting_gen.go
+++ b/common/dynamicconfig/setting_gen.go
@@ -778,13 +778,14 @@ type TypedPropertyFn[T any] func() T
 
 func (s GlobalTypedSetting[T]) Get(c *Collection) TypedPropertyFn[T] {
 	return func() T {
+		prec := []Constraints{{}}
 		return matchAndConvert(
 			c,
 			s.key,
 			s.def,
 			s.cdef,
 			s.convert,
-			precedenceGlobal(),
+			prec,
 		)
 	}
 }
@@ -852,13 +853,14 @@ type TypedPropertyFnWithNamespaceFilter[T any] func(namespace string) T
 
 func (s NamespaceTypedSetting[T]) Get(c *Collection) TypedPropertyFnWithNamespaceFilter[T] {
 	return func(namespace string) T {
+		prec := []Constraints{{Namespace: namespace}, {}}
 		return matchAndConvert(
 			c,
 			s.key,
 			s.def,
 			s.cdef,
 			s.convert,
-			precedenceNamespace(namespace),
+			prec,
 		)
 	}
 }
@@ -926,13 +928,14 @@ type TypedPropertyFnWithNamespaceIDFilter[T any] func(namespaceID string) T
 
 func (s NamespaceIDTypedSetting[T]) Get(c *Collection) TypedPropertyFnWithNamespaceIDFilter[T] {
 	return func(namespaceID string) T {
+		prec := []Constraints{{NamespaceID: namespaceID}, {}}
 		return matchAndConvert(
 			c,
 			s.key,
 			s.def,
 			s.cdef,
 			s.convert,
-			precedenceNamespaceID(namespaceID),
+			prec,
 		)
 	}
 }
@@ -1000,13 +1003,20 @@ type TypedPropertyFnWithTaskQueueFilter[T any] func(namespace string, taskQueue 
 
 func (s TaskQueueTypedSetting[T]) Get(c *Collection) TypedPropertyFnWithTaskQueueFilter[T] {
 	return func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType) T {
+		prec := []Constraints{
+			{Namespace: namespace, TaskQueueName: taskQueue, TaskQueueType: taskQueueType},
+			{Namespace: namespace, TaskQueueName: taskQueue},
+			{TaskQueueName: taskQueue},
+			{Namespace: namespace},
+			{},
+		}
 		return matchAndConvert(
 			c,
 			s.key,
 			s.def,
 			s.cdef,
 			s.convert,
-			precedenceTaskQueue(namespace, taskQueue, taskQueueType),
+			prec,
 		)
 	}
 }
@@ -1074,13 +1084,14 @@ type TypedPropertyFnWithShardIDFilter[T any] func(shardID int32) T
 
 func (s ShardIDTypedSetting[T]) Get(c *Collection) TypedPropertyFnWithShardIDFilter[T] {
 	return func(shardID int32) T {
+		prec := []Constraints{{ShardID: shardID}, {}}
 		return matchAndConvert(
 			c,
 			s.key,
 			s.def,
 			s.cdef,
 			s.convert,
-			precedenceShardID(shardID),
+			prec,
 		)
 	}
 }
@@ -1148,13 +1159,14 @@ type TypedPropertyFnWithTaskTypeFilter[T any] func(taskType enumsspb.TaskType) T
 
 func (s TaskTypeTypedSetting[T]) Get(c *Collection) TypedPropertyFnWithTaskTypeFilter[T] {
 	return func(taskType enumsspb.TaskType) T {
+		prec := []Constraints{{TaskType: taskType}, {}}
 		return matchAndConvert(
 			c,
 			s.key,
 			s.def,
 			s.cdef,
 			s.convert,
-			precedenceTaskType(taskType),
+			prec,
 		)
 	}
 }
@@ -1222,13 +1234,19 @@ type TypedPropertyFnWithDestinationFilter[T any] func(namespace string, destinat
 
 func (s DestinationTypedSetting[T]) Get(c *Collection) TypedPropertyFnWithDestinationFilter[T] {
 	return func(namespace string, destination string) T {
+		prec := []Constraints{
+			{Namespace: namespace, Destination: destination},
+			{Destination: destination},
+			{Namespace: namespace},
+			{},
+		}
 		return matchAndConvert(
 			c,
 			s.key,
 			s.def,
 			s.cdef,
 			s.convert,
-			precedenceDestination(namespace, destination),
+			prec,
 		)
 	}
 }


### PR DESCRIPTION
## What changed?
Inline slices representation constraint precedence in generated code.

## Why?
This saves an allocation per dynamic config call.

## How did you test it?
Existing tests + bench.