### PR TITLE
Add TokensAt method to quotas.RateLimiter interface

### DIFF
--- a/common/quotas/clocked_rate_limiter.go
+++ b/common/quotas/clocked_rate_limiter.go
@@ -147,3 +147,7 @@ func (l ClockedRateLimiter) SetLimitAt(t time.Time, newLimit rate.Limit) {
 func (l ClockedRateLimiter) SetBurstAt(t time.Time, newBurst int) {
 	l.rateLimiter.SetBurstAt(t, newBurst)
 }
+
+func (l ClockedRateLimiter) TokensAt(t time.Time) int {
+	return int(l.rateLimiter.TokensAt(t))
+}

--- a/common/quotas/dynamic_rate_limiter_impl.go
+++ b/common/quotas/dynamic_rate_limiter_impl.go
@@ -161,3 +161,7 @@ func (d *DynamicRateLimiterImpl) maybeRefresh() {
 		// noop
 	}
 }
+
+func (d *DynamicRateLimiterImpl) TokensAt(t time.Time) int {
+	return d.rateLimiter.TokensAt(t)
+}

--- a/common/quotas/multi_rate_limiter_impl.go
+++ b/common/quotas/multi_rate_limiter_impl.go
@@ -27,6 +27,7 @@ package quotas
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -181,4 +182,12 @@ func (rl *MultiRateLimiterImpl) Burst() int {
 		}
 	}
 	return result
+}
+
+func (rl *MultiRateLimiterImpl) TokensAt(t time.Time) int {
+	tokens := math.MaxInt
+	for _, rateLimiter := range rl.rateLimiters {
+		tokens = min(tokens, rateLimiter.TokensAt(t))
+	}
+	return tokens
 }

--- a/common/quotas/rate_limiter.go
+++ b/common/quotas/rate_limiter.go
@@ -65,5 +65,8 @@ type (
 
 		// Burst returns the burst for this rate limiter
 		Burst() int
+
+		// TokensAt returns the number of tokens that will be available at time t
+		TokensAt(t time.Time) int
 	}
 )

--- a/common/quotas/rate_limiter_impl.go
+++ b/common/quotas/rate_limiter_impl.go
@@ -99,6 +99,14 @@ func (rl *RateLimiterImpl) Burst() int {
 	return rl.burst
 }
 
+// TokensAt returns the number of tokens that will be available at time t
+func (rl *RateLimiterImpl) TokensAt(t time.Time) int {
+	rl.Lock()
+	defer rl.Unlock()
+
+	return rl.ClockedRateLimiter.TokensAt(t)
+}
+
 func (rl *RateLimiterImpl) refreshInternalRateLimiterImpl(
 	newRate *float64,
 	newBurst *int,

--- a/common/quotas/rate_limiter_mock.go
+++ b/common/quotas/rate_limiter_mock.go
@@ -143,6 +143,20 @@ func (mr *MockRateLimiterMockRecorder) ReserveN(now, numToken interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReserveN", reflect.TypeOf((*MockRateLimiter)(nil).ReserveN), now, numToken)
 }
 
+// TokensAt mocks base method.
+func (m *MockRateLimiter) TokensAt(t time.Time) int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TokensAt", t)
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// TokensAt indicates an expected call of TokensAt.
+func (mr *MockRateLimiterMockRecorder) TokensAt(t interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TokensAt", reflect.TypeOf((*MockRateLimiter)(nil).TokensAt), t)
+}
+
 // Wait mocks base method.
 func (m *MockRateLimiter) Wait(ctx context.Context) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## What changed?
Add TokensAt() method to quotas.RateLimiter interface.

## Why?
This method is useful to get the number of tokens that will be available at a future time point.
It is available in golang's rate.Limiter. We just have to expose it.

## How did you test it?
Unit tests

## Potential risks
None

## Documentation

## Is hotfix candidate?
No
