### PR TITLE
Use wtFailedCause.Message() over causeErr directly

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -416,7 +416,7 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 			// Flush buffer event before terminating the workflow
 			ms.FlushBufferedEvents()
 
-			if err := workflow.TerminateWorkflow(ms, wtFailedCause.causeErr.Error(), nil,
+			if err := workflow.TerminateWorkflow(ms, wtFailedCause.Message(), nil,
 				consts.IdentityHistoryService, false); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## What changed?
Uses the `Message()` method over `causeErr` directly in the workflow task completion handler.

## Why?
`Message()` is used throughout, handles `nil` `causeErr`

## How did you test it?
`make test`

## Potential risks

## Documentation

## Is hotfix candidate?
