### PR TITLE
Escape BIND_ON_IP values for IPv6

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -274,7 +274,7 @@ services:
         rpc:
             grpcPort: {{ $temporalGrpcPort }}
             membershipPort: {{ default .Env.FRONTEND_MEMBERSHIP_PORT "6933" }}
-            bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
+            bindOnIP: "{{ default .Env.BIND_ON_IP "127.0.0.1" }}"
             httpPort: {{ $temporalHTTPPort }}
 
     {{- if .Env.USE_INTERNAL_FRONTEND }}
@@ -282,26 +282,26 @@ services:
         rpc:
             grpcPort: {{ default .Env.INTERNAL_FRONTEND_GRPC_PORT "7236" }}
             membershipPort: {{ default .Env.INTERNAL_FRONTEND_MEMBERSHIP_PORT "6936" }}
-            bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
+            bindOnIP: "{{ default .Env.BIND_ON_IP "127.0.0.1" }}"
     {{- end }}
 
     matching:
         rpc:
             grpcPort: {{ default .Env.MATCHING_GRPC_PORT "7235" }}
             membershipPort: {{ default .Env.MATCHING_MEMBERSHIP_PORT "6935" }}
-            bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
+            bindOnIP: "{{ default .Env.BIND_ON_IP "127.0.0.1" }}"
 
     history:
         rpc:
             grpcPort: {{ default .Env.HISTORY_GRPC_PORT "7234" }}
             membershipPort: {{ default .Env.HISTORY_MEMBERSHIP_PORT "6934" }}
-            bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
+            bindOnIP: "{{ default .Env.BIND_ON_IP "127.0.0.1" }}"
 
     worker:
         rpc:
             grpcPort: {{ default .Env.WORKER_GRPC_PORT "7239" }}
             membershipPort: {{ default .Env.WORKER_MEMBERSHIP_PORT "6939" }}
-            bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
+            bindOnIP: "{{ default .Env.BIND_ON_IP "127.0.0.1" }}"
 
 clusterMetadata:
     enableGlobalNamespace: false


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
The bindOnIP values in the docker configuration template is wrapped with a string.

## Why?
<!-- Tell your future self why have you made these changes -->
When attempting to listen on IPv6 in Docker without this change present, the colons in the IP address are interpreted as part of the YAML. The strings added allow IPv6 bind addresses to work properly.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
I have not verified this change but I came across this issue when trying to configure Temporal for IPv6, and this fix is similar as for other projects I've come across.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
The Temporal server docker image would be broken.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
N/A

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
Yes
