### PR TITLE
Allow up to 2 minutes for ES index to become yellow

### DIFF
--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -397,7 +397,7 @@ func setupIndex(esConfig *esclient.Config, logger log.Logger) error {
 }
 
 func waitForYellowStatus(esClient esclient.IntegrationTestsClient, index string) error {
-	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	status, err := esClient.WaitForYellowStatus(ctxWithTimeout, index)
 	if err != nil {


### PR DESCRIPTION
Should fix flaky tests