### PR TITLE
Use NewInvalidArgument consistently for deserializing task token

### DIFF
--- a/client/history/client_gen.go
+++ b/client/history/client_gen.go
@@ -605,7 +605,7 @@ func (c *clientImpl) RecordActivityTaskHeartbeat(
 ) (*historyservice.RecordActivityTaskHeartbeatResponse, error) {
 	taskToken, err := c.tokenSerializer.Deserialize(request.GetHeartbeatRequest().GetTaskToken())
 	if err != nil {
-		return nil, err
+		return nil, serviceerror.NewInvalidArgument("error deserializing task token")
 	}
 	shardID := c.shardIDFromWorkflowID(request.NamespaceId, taskToken.GetWorkflowId())
 
@@ -850,7 +850,7 @@ func (c *clientImpl) RespondActivityTaskCanceled(
 ) (*historyservice.RespondActivityTaskCanceledResponse, error) {
 	taskToken, err := c.tokenSerializer.Deserialize(request.GetCancelRequest().GetTaskToken())
 	if err != nil {
-		return nil, err
+		return nil, serviceerror.NewInvalidArgument("error deserializing task token")
 	}
 	shardID := c.shardIDFromWorkflowID(request.NamespaceId, taskToken.GetWorkflowId())
 
@@ -875,7 +875,7 @@ func (c *clientImpl) RespondActivityTaskCompleted(
 ) (*historyservice.RespondActivityTaskCompletedResponse, error) {
 	taskToken, err := c.tokenSerializer.Deserialize(request.GetCompleteRequest().GetTaskToken())
 	if err != nil {
-		return nil, err
+		return nil, serviceerror.NewInvalidArgument("error deserializing task token")
 	}
 	shardID := c.shardIDFromWorkflowID(request.NamespaceId, taskToken.GetWorkflowId())
 
@@ -900,7 +900,7 @@ func (c *clientImpl) RespondActivityTaskFailed(
 ) (*historyservice.RespondActivityTaskFailedResponse, error) {
 	taskToken, err := c.tokenSerializer.Deserialize(request.GetFailedRequest().GetTaskToken())
 	if err != nil {
-		return nil, err
+		return nil, serviceerror.NewInvalidArgument("error deserializing task token")
 	}
 	shardID := c.shardIDFromWorkflowID(request.NamespaceId, taskToken.GetWorkflowId())
 
@@ -925,7 +925,7 @@ func (c *clientImpl) RespondWorkflowTaskCompleted(
 ) (*historyservice.RespondWorkflowTaskCompletedResponse, error) {
 	taskToken, err := c.tokenSerializer.Deserialize(request.GetCompleteRequest().GetTaskToken())
 	if err != nil {
-		return nil, err
+		return nil, serviceerror.NewInvalidArgument("error deserializing task token")
 	}
 	shardID := c.shardIDFromWorkflowID(request.NamespaceId, taskToken.GetWorkflowId())
 
@@ -950,7 +950,7 @@ func (c *clientImpl) RespondWorkflowTaskFailed(
 ) (*historyservice.RespondWorkflowTaskFailedResponse, error) {
 	taskToken, err := c.tokenSerializer.Deserialize(request.GetFailedRequest().GetTaskToken())
 	if err != nil {
-		return nil, err
+		return nil, serviceerror.NewInvalidArgument("error deserializing task token")
 	}
 	shardID := c.shardIDFromWorkflowID(request.NamespaceId, taskToken.GetWorkflowId())
 

--- a/cmd/tools/rpcwrappers/main.go
+++ b/cmd/tools/rpcwrappers/main.go
@@ -214,7 +214,7 @@ func makeGetHistoryClient(reqType reflect.Type) string {
 	case len(taskTokenField) == 1:
 		return fmt.Sprintf(`taskToken, err := c.tokenSerializer.Deserialize(%s)
 	if err != nil {
-		return nil, err
+		return nil, serviceerror.NewInvalidArgument("error deserializing task token")
 	}
 	shardID := c.shardIDFromWorkflowID(request.NamespaceId, taskToken.GetWorkflowId())
 `, taskTokenField[0].path)

--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -60,6 +60,7 @@ var (
 	errNamespaceTooLong           = serviceerror.NewInvalidArgument("Namespace length exceeds limit.")
 	errTaskTokenNotSet            = serviceerror.NewInvalidArgument("Task token not set on request.")
 	errTaskTokenNamespaceMismatch = serviceerror.NewInvalidArgument("Operation requested with a token from a different namespace.")
+	errDeserializingToken         = serviceerror.NewInvalidArgument("Error deserializing task token.")
 
 	allowedNamespaceStates = map[string][]enumspb.NamespaceState{
 		"/temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution":           {enumspb.NAMESPACE_STATE_REGISTERED},
@@ -348,7 +349,7 @@ func (ni *NamespaceValidatorInterceptor) extractNamespaceFromTaskToken(req inter
 	} else {
 		taskToken, err := ni.tokenSerializer.Deserialize(taskTokenBytes)
 		if err != nil {
-			return nil, err
+			return nil, errDeserializingToken
 		}
 		namespaceID = namespace.ID(taskToken.GetNamespaceId())
 	}

--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -343,7 +343,7 @@ func (ni *NamespaceValidatorInterceptor) extractNamespaceFromTaskToken(req inter
 	if _, ok := req.(*workflowservice.RespondQueryTaskCompletedRequest); ok {
 		taskToken, err := ni.tokenSerializer.DeserializeQueryTaskToken(taskTokenBytes)
 		if err != nil {
-			return nil, err
+			return nil, errDeserializingToken
 		}
 		namespaceID = namespace.ID(taskToken.GetNamespaceId())
 	} else {

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -30,6 +30,7 @@ import (
 
 var (
 	errInvalidTaskToken                                   = serviceerror.NewInvalidArgument("Invalid TaskToken.")
+	errDeserializingToken                                 = serviceerror.NewInvalidArgument("Error deserializing task token.")
 	errTaskQueueNotSet                                    = serviceerror.NewInvalidArgument("TaskQueue is not set on request.")
 	errExecutionNotSet                                    = serviceerror.NewInvalidArgument("Execution is not set on request.")
 	errWorkflowIDNotSet                                   = serviceerror.NewInvalidArgument("WorkflowId is not set on request.")

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -929,7 +929,7 @@ func (wh *WorkflowHandler) RespondWorkflowTaskFailed(
 
 	taskToken, err := wh.tokenSerializer.Deserialize(request.TaskToken)
 	if err != nil {
-		return nil, err
+		return nil, errDeserializingToken
 	}
 	namespaceId := namespace.ID(taskToken.GetNamespaceId())
 	namespaceEntry, err := wh.namespaceRegistry.GetNamespaceByID(namespaceId)
@@ -1096,7 +1096,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(ctx context.Context, requ
 	wh.logger.Debug("Received RecordActivityTaskHeartbeat")
 	taskToken, err := wh.tokenSerializer.Deserialize(request.TaskToken)
 	if err != nil {
-		return nil, err
+		return nil, errDeserializingToken
 	}
 	namespaceId := namespace.ID(taskToken.GetNamespaceId())
 	namespaceEntry, err := wh.namespaceRegistry.GetNamespaceByID(namespaceId)
@@ -1257,7 +1257,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 	}
 	taskToken, err := wh.tokenSerializer.Deserialize(request.TaskToken)
 	if err != nil {
-		return nil, err
+		return nil, errDeserializingToken
 	}
 	namespaceId := namespace.ID(taskToken.GetNamespaceId())
 	namespaceEntry, err := wh.namespaceRegistry.GetNamespaceByID(namespaceId)
@@ -1425,7 +1425,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 
 	taskToken, err := wh.tokenSerializer.Deserialize(request.TaskToken)
 	if err != nil {
-		return nil, err
+		return nil, errDeserializingToken
 	}
 	namespaceID := namespace.ID(taskToken.GetNamespaceId())
 	namespaceEntry, err := wh.namespaceRegistry.GetNamespaceByID(namespaceID)
@@ -1618,7 +1618,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(ctx context.Context, requ
 
 	taskToken, err := wh.tokenSerializer.Deserialize(request.TaskToken)
 	if err != nil {
-		return nil, err
+		return nil, errDeserializingToken
 	}
 	namespaceID := namespace.ID(taskToken.GetNamespaceId())
 	namespaceEntry, err := wh.namespaceRegistry.GetNamespaceByID(namespaceID)

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2488,7 +2488,7 @@ func (wh *WorkflowHandler) RespondQueryTaskCompleted(
 
 	queryTaskToken, err := wh.tokenSerializer.DeserializeQueryTaskToken(request.TaskToken)
 	if err != nil {
-		return nil, err
+		return nil, errDeserializingToken
 	}
 	if queryTaskToken.GetTaskQueue() == "" || queryTaskToken.GetTaskId() == "" {
 		return nil, errInvalidTaskToken
@@ -4382,7 +4382,7 @@ func (wh *WorkflowHandler) RespondNexusTaskCompleted(ctx context.Context, reques
 	// NamespaceValidatorInterceptor does this for us.
 	tt, err := wh.tokenSerializer.DeserializeNexusTaskToken(request.GetTaskToken())
 	if err != nil {
-		return nil, err
+		return nil, errDeserializingToken
 	}
 	if tt.GetTaskQueue() == "" || tt.GetTaskId() == "" {
 		return nil, errInvalidTaskToken
@@ -4423,7 +4423,7 @@ func (wh *WorkflowHandler) RespondNexusTaskFailed(ctx context.Context, request *
 	// NamespaceValidatorInterceptor does this for us.
 	tt, err := wh.tokenSerializer.DeserializeNexusTaskToken(request.GetTaskToken())
 	if err != nil {
-		return nil, err
+		return nil, errDeserializingToken
 	}
 	if tt.GetTaskQueue() == "" || tt.GetTaskId() == "" {
 		return nil, errInvalidTaskToken

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -793,7 +793,7 @@ func (handler *WorkflowTaskCompletedHandler) withNewWorkflowTask(
 ) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
 	taskToken, err := handler.tokenSerializer.Deserialize(request.CompleteRequest.TaskToken)
 	if err != nil {
-		return nil, err
+		return nil, consts.ErrDeserializingToken
 	}
 
 	taskToken = tasktoken.NewWorkflowTaskToken(

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -70,6 +70,7 @@ import (
 	"go.temporal.io/server/service/history/api/getdlqtasks"
 	"go.temporal.io/server/service/history/api/listqueues"
 	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/events"
 	"go.temporal.io/server/service/history/hsm"
 	"go.temporal.io/server/service/history/replication"
@@ -160,8 +161,6 @@ var (
 	errSourceClusterNotSet     = serviceerror.NewInvalidArgument("Source Cluster not set on request.")
 	errShardIDNotSet           = serviceerror.NewInvalidArgument("ShardId not set on request.")
 	errTimestampNotSet         = serviceerror.NewInvalidArgument("Timestamp not set on request.")
-
-	errDeserializeTaskTokenMessage = "Error to deserialize task token. Error: %v."
 
 	errShuttingDown = serviceerror.NewUnavailable("Shutting down")
 )
@@ -273,7 +272,7 @@ func (h *Handler) RecordActivityTaskHeartbeat(ctx context.Context, request *hist
 	heartbeatRequest := request.HeartbeatRequest
 	taskToken, err0 := h.tokenSerializer.Deserialize(heartbeatRequest.TaskToken)
 	if err0 != nil {
-		return nil, h.convertError(serviceerror.NewInvalidArgument(fmt.Sprintf(errDeserializeTaskTokenMessage, err0)))
+		return nil, consts.ErrDeserializingToken
 	}
 
 	err0 = validateTaskToken(taskToken)
@@ -386,7 +385,7 @@ func (h *Handler) RespondActivityTaskCompleted(ctx context.Context, request *his
 	completeRequest := request.CompleteRequest
 	taskToken, err0 := h.tokenSerializer.Deserialize(completeRequest.TaskToken)
 	if err0 != nil {
-		return nil, h.convertError(serviceerror.NewInvalidArgument(fmt.Sprintf(errDeserializeTaskTokenMessage, err0)))
+		return nil, consts.ErrDeserializingToken
 	}
 
 	err0 = validateTaskToken(taskToken)
@@ -425,7 +424,7 @@ func (h *Handler) RespondActivityTaskFailed(ctx context.Context, request *histor
 	failRequest := request.FailedRequest
 	taskToken, err0 := h.tokenSerializer.Deserialize(failRequest.TaskToken)
 	if err0 != nil {
-		return nil, h.convertError(serviceerror.NewInvalidArgument(fmt.Sprintf(errDeserializeTaskTokenMessage, err0)))
+		return nil, consts.ErrDeserializingToken
 	}
 
 	err0 = validateTaskToken(taskToken)
@@ -464,7 +463,7 @@ func (h *Handler) RespondActivityTaskCanceled(ctx context.Context, request *hist
 	cancelRequest := request.CancelRequest
 	taskToken, err0 := h.tokenSerializer.Deserialize(cancelRequest.TaskToken)
 	if err0 != nil {
-		return nil, h.convertError(serviceerror.NewInvalidArgument(fmt.Sprintf(errDeserializeTaskTokenMessage, err0)))
+		return nil, consts.ErrDeserializingToken
 	}
 
 	err0 = validateTaskToken(taskToken)
@@ -503,7 +502,7 @@ func (h *Handler) RespondWorkflowTaskCompleted(ctx context.Context, request *his
 	completeRequest := request.CompleteRequest
 	token, err0 := h.tokenSerializer.Deserialize(completeRequest.TaskToken)
 	if err0 != nil {
-		return nil, h.convertError(serviceerror.NewInvalidArgument(fmt.Sprintf(errDeserializeTaskTokenMessage, err0)))
+		return nil, consts.ErrDeserializingToken
 	}
 
 	h.logger.Debug("RespondWorkflowTaskCompleted",
@@ -548,7 +547,7 @@ func (h *Handler) RespondWorkflowTaskFailed(ctx context.Context, request *histor
 	failedRequest := request.FailedRequest
 	token, err0 := h.tokenSerializer.Deserialize(failedRequest.TaskToken)
 	if err0 != nil {
-		return nil, h.convertError(serviceerror.NewInvalidArgument(fmt.Sprintf(errDeserializeTaskTokenMessage, err0)))
+		return nil, consts.ErrDeserializingToken
 	}
 
 	h.logger.Debug("RespondWorkflowTaskFailed",


### PR DESCRIPTION
## What changed?
Convert deserialization errors on task tokens to serviceerror.InvalidArgument. The error returned by the serializer is a raw proto error and should be translated before returning from rpc handlers.

## Why?
more accurate metrics

## How did you test it?
didn't