### PR TITLE
Disable frontend error masking in functional tests

### DIFF
--- a/tests/dynamicconfig.go
+++ b/tests/dynamicconfig.go
@@ -61,6 +61,7 @@ var (
 		dynamicconfig.ValidateUTF8FailRPCResponse.Key():                         true,
 		dynamicconfig.ValidateUTF8FailPersistence.Key():                         true,
 		dynamicconfig.EnableWorkflowExecutionTimeoutTimer.Key():                 true,
+		dynamicconfig.FrontendMaskInternalErrorDetails.Key():                    false,
 	}
 )
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Disable frontend error masking in functional tests.

## Why?
<!-- Tell your future self why have you made these changes -->
When test fails it is easier to debug if original error is logged/returned.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run with some broken functionality and got original message.
