### PR TITLE
Clone mutable state fields before returning them from GetMutableState internal API

### DIFF
--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -27,7 +27,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"slices"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -239,14 +238,15 @@ func GetMutableState(
 func MutableStateToGetResponse(
 	mutableState workflow.MutableState,
 ) (*historyservice.GetMutableStateResponse, error) {
-	// NOTE: fields of GetMutableStateResponse (returned value) are accessed outside of workflow lock
-	// and, therefore, MUST be copied by value from mutableState fields.
+	// NOTE: fields of GetMutableStateResponse (returned value of this func)
+	// are accessed outside of workflow lock, and, therefore,
+	// ***MUST*** be copied by value from mutableState fields.
+	// strings are immutable, []byte is also considered to be immutable.
 
 	currentBranchToken, err := mutableState.GetCurrentBranchToken()
 	if err != nil {
 		return nil, err
 	}
-	currentBranchToken = slices.Clone(currentBranchToken)
 
 	executionInfo := mutableState.GetExecutionInfo()
 	workflowState, workflowStatus := mutableState.GetWorkflowStateStatus()

--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -27,6 +27,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -241,13 +242,11 @@ func MutableStateToGetResponse(
 	// NOTE: fields of GetMutableStateResponse (returned value) are accessed outside of workflow lock
 	// and, therefore, MUST be copied by value from mutableState fields.
 
-	var currentBranchToken []byte
-	if cbt, err := mutableState.GetCurrentBranchToken(); err != nil {
+	currentBranchToken, err := mutableState.GetCurrentBranchToken()
+	if err != nil {
 		return nil, err
-	} else {
-		currentBranchToken = make([]byte, len(cbt))
-		copy(currentBranchToken, cbt)
 	}
+	currentBranchToken = slices.Clone(currentBranchToken)
 
 	executionInfo := mutableState.GetExecutionInfo()
 	workflowState, workflowStatus := mutableState.GetWorkflowStateStatus()

--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -238,14 +238,29 @@ func GetMutableState(
 func MutableStateToGetResponse(
 	mutableState workflow.MutableState,
 ) (*historyservice.GetMutableStateResponse, error) {
-	currentBranchToken, err := mutableState.GetCurrentBranchToken()
-	if err != nil {
+	// NOTE: fields of GetMutableStateResponse (returned value) are accessed outside of workflow lock
+	// and, therefore, MUST be copied by value from mutableState fields.
+
+	var currentBranchToken []byte
+	if cbt, err := mutableState.GetCurrentBranchToken(); err != nil {
 		return nil, err
+	} else {
+		currentBranchToken = make([]byte, len(cbt))
+		copy(currentBranchToken, cbt)
 	}
 
 	executionInfo := mutableState.GetExecutionInfo()
 	workflowState, workflowStatus := mutableState.GetWorkflowStateStatus()
 	lastFirstEventID, lastFirstEventTxnID := mutableState.GetLastFirstEventIDTxnID()
+
+	var mostRecentWorkerVersionStamp *commonpb.WorkerVersionStamp
+	if mrwvs := mutableState.GetExecutionInfo().GetMostRecentWorkerVersionStamp(); mrwvs != nil {
+		mostRecentWorkerVersionStamp = &commonpb.WorkerVersionStamp{
+			BuildId:       mrwvs.GetBuildId(),
+			UseVersioning: mrwvs.GetUseVersioning(),
+		}
+	}
+
 	return &historyservice.GetMutableStateResponse{
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: mutableState.GetExecutionInfo().WorkflowId,
@@ -276,6 +291,6 @@ func MutableStateToGetResponse(
 		FirstExecutionRunId:          executionInfo.FirstExecutionRunId,
 		AssignedBuildId:              mutableState.GetAssignedBuildId(),
 		InheritedBuildId:             mutableState.GetInheritedBuildId(),
-		MostRecentWorkerVersionStamp: executionInfo.GetMostRecentWorkerVersionStamp(),
+		MostRecentWorkerVersionStamp: mostRecentWorkerVersionStamp,
 	}, nil
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Clone mutable state fields before returning them from `GetMutableState` internal API.

## Why?
<!-- Tell your future self why have you made these changes -->
Result of `GetMutableState` is used outside of workflow lock and, therefore, all fields of it MUST be copied by value from `mutableState` fields.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.