### PR TITLE
Fix state machine timer task metrics

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -855,6 +855,7 @@ var (
 	ScheduleToCloseTimeoutCounter                 = NewCounterDef("schedule_to_close_timeout")
 	NewTimerNotifyCounter                         = NewCounterDef("new_timer_notifications")
 	StateMachineTimerProcessingFailuresCounter    = NewCounterDef("state_machine_timer_processing_failures")
+	StateMachineTimerSkipsCounter                 = NewCounterDef("state_machine_timer_skips")
 	AcquireShardsCounter                          = NewCounterDef("acquire_shards_count")
 	AcquireShardsLatency                          = NewTimerDef("acquire_shards_latency")
 	MembershipChangedCounter                      = NewCounterDef("membership_changed_count")

--- a/service/history/queues/metrics.go
+++ b/service/history/queues/metrics.go
@@ -183,6 +183,17 @@ func GetOutboundTaskTypeTagValue(task tasks.Task, isActive bool) string {
 	return prefix + "." + outbound.StateMachineTaskType()
 }
 
+func GetTimerStateMachineTaskTypeTagValue(taskType string, isActive bool) string {
+	var prefix string
+	if isActive {
+		prefix = "TimerActive"
+	} else {
+		prefix = "TimerStandby"
+	}
+
+	return prefix + "." + taskType
+}
+
 func getTaskTypeTagValue(
 	executable Executable,
 	isActive bool,

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -84,6 +84,7 @@ func newTimerQueueActiveTaskExecutor(
 			logger,
 			metricProvider,
 			config,
+			true,
 		),
 	}
 }

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -86,6 +86,7 @@ func newTimerQueueStandbyTaskExecutor(
 			logger,
 			metricProvider,
 			config,
+			false,
 		),
 		clusterName:        clusterName,
 		nDCHistoryResender: nDCHistoryResender,

--- a/service/history/timer_queue_task_executor_base.go
+++ b/service/history/timer_queue_task_executor_base.go
@@ -66,6 +66,7 @@ type (
 		matchingRawClient  resource.MatchingRawClient
 		config             *configs.Config
 		metricHandler      metrics.Handler
+		isActive           bool
 	}
 )
 
@@ -77,6 +78,7 @@ func newTimerQueueTaskExecutorBase(
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 	config *configs.Config,
+	isActive bool,
 ) *timerQueueTaskExecutorBase {
 	return &timerQueueTaskExecutorBase{
 		stateMachineEnvironment: stateMachineEnvironment{
@@ -91,6 +93,7 @@ func newTimerQueueTaskExecutorBase(
 		matchingRawClient:  matchingRawClient,
 		config:             config,
 		metricHandler:      metricsHandler,
+		isActive:           isActive,
 	}
 }
 
@@ -264,12 +267,20 @@ func (t *timerQueueTaskExecutorBase) executeStateMachineTimers(
 			err := t.executeSingleStateMachineTimer(ms, group.Deadline.AsTime(), timer, execute)
 			if err != nil {
 				if !errors.As(err, new(*serviceerror.NotFound)) {
+					metrics.StateMachineTimerProcessingFailuresCounter.With(t.metricHandler).Record(
+						1,
+						metrics.OperationTag(queues.GetTimerStateMachineTaskTypeTagValue(timer.GetType(), t.isActive)),
+						metrics.ServiceErrorTypeTag(err),
+					)
 					// Return on first error as we don't want to duplicate the Executable's error handling logic.
 					// This implies that a single bad task in the mutable state timer sequence will cause all other
 					// tasks to be stuck. We'll accept this limitation for now.
 					return 0, err
 				}
-				metrics.StateMachineTimerProcessingFailuresCounter.With(t.metricHandler).Record(1, metrics.OperationTag(timer.GetType()))
+				metrics.StateMachineTimerSkipsCounter.With(t.metricHandler).Record(
+					1,
+					metrics.OperationTag(queues.GetTimerStateMachineTaskTypeTagValue(timer.GetType(), t.isActive)),
+				)
 				t.logger.Warn("Skipped state machine timer", tag.Error(err))
 			}
 		}

--- a/service/history/timer_queue_task_executor_base_test.go
+++ b/service/history/timer_queue_task_executor_base_test.go
@@ -104,6 +104,7 @@ func (s *timerQueueTaskExecutorBaseSuite) SetupTest() {
 		s.testShardContext.GetLogger(),
 		metrics.NoopMetricsHandler,
 		config,
+		true, // isActive (irelevant for test)
 	)
 }
 


### PR DESCRIPTION
## What changed?

- Add `state_machine_timer_skips` metrics
- Fix `state_machine_timer_processing_failures` to be emitted on failures instead of skips