### PR TITLE
Clear sticky task queue on speculative WFT error

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -57,7 +58,10 @@ func Operation(operation string) ZapTag {
 
 // Error returns tag for Error
 func Error(err error) ZapTag {
-	return NewErrorTag(err)
+	return ZapTag{
+		// NOTE: zap already chosen "error" as key
+		field: zap.Error(err),
+	}
 }
 
 // ServiceErrorType returns tag for ServiceErrorType

--- a/common/log/tag/zap_tag.go
+++ b/common/log/tag/zap_tag.go
@@ -114,10 +114,9 @@ func NewBoolTag(key string, value bool) ZapTag {
 	}
 }
 
-func NewErrorTag(value error) ZapTag {
-	// NOTE: zap already chosen "error" as key
+func NewErrorTag(key string, value error) ZapTag {
 	return ZapTag{
-		field: zap.Error(value),
+		field: zap.NamedError(key, value),
 	}
 }
 

--- a/common/namespace/replication_task_executor.go
+++ b/common/namespace/replication_task_executor.go
@@ -204,7 +204,7 @@ func (h *namespaceReplicationTaskExecutorImpl) handleNamespaceCreationReplicatio
 					tag.WorkflowNamespaceID(resp.Namespace.Info.Id),
 					tag.NewStringTag("Task Namespace Id", task.GetId()),
 					tag.NewStringTag("Task Namepsace Info Id", task.Info.GetId()),
-					tag.NewErrorTag(err))
+					tag.Error(err))
 				return ErrNameUUIDCollision
 			}
 		case *serviceerror.NamespaceNotFound:
@@ -216,7 +216,7 @@ func (h *namespaceReplicationTaskExecutorImpl) handleNamespaceCreationReplicatio
 				"namespace replication encountered error during NamespaceCreationReplicationTask",
 				tag.WorkflowNamespace(task.Info.GetName()),
 				tag.WorkflowNamespaceID(task.Info.GetId()),
-				tag.NewErrorTag(err))
+				tag.Error(err))
 			return err
 		}
 
@@ -230,7 +230,7 @@ func (h *namespaceReplicationTaskExecutorImpl) handleNamespaceCreationReplicatio
 					"namespace replication encountered name collision during NamespaceCreationReplicationTask",
 					tag.WorkflowNamespace(resp.Namespace.Info.Name),
 					tag.NewStringTag("Task Namespace Name", task.Info.GetName()),
-					tag.NewErrorTag(err))
+					tag.Error(err))
 				return ErrNameUUIDCollision
 			}
 		case *serviceerror.NamespaceNotFound:

--- a/components/scheduler/executors.go
+++ b/components/scheduler/executors.go
@@ -33,12 +33,16 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	schedpb "go.temporal.io/api/schedule/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.uber.org/fx"
+
 	"go.temporal.io/server/api/historyservice/v1"
 	schedspb "go.temporal.io/server/api/schedule/v1"
-	"go.uber.org/fx"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -48,8 +52,6 @@ import (
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/service/history/hsm"
 	"go.temporal.io/server/service/worker/scheduler"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type (
@@ -239,7 +241,7 @@ func (e taskExecutor) processBuffer(ctx context.Context,
 		result, err := e.startWorkflow(ctx, s, start, req)
 		metricsWithTag := e.MetricsHandler.WithTags(metrics.StringTag(metrics.ScheduleActionTypeTag, metrics.ScheduleActionStartWorkflow))
 		if err != nil {
-			e.Logger.Error("Failed to start workflow", tag.NewErrorTag(err))
+			e.Logger.Error("Failed to start workflow", tag.Error(err))
 			metricsWithTag.Counter(metrics.ScheduleActionErrors.Name()).Record(1)
 			// TODO: we could put this back in the buffer and retry (after a delay) up until
 			// the catchup window. of course, it's unlikely that this workflow would be making

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -30,8 +30,6 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"go.temporal.io/server/service/history/api/recordworkflowtaskstarted"
-
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
@@ -61,6 +59,7 @@ import (
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/internal/effect"
 	"go.temporal.io/server/service/history/api"
+	"go.temporal.io/server/service/history/api/recordworkflowtaskstarted"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/events"
@@ -126,6 +125,12 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 	ctx context.Context,
 	req *historyservice.RespondWorkflowTaskCompletedRequest,
 ) (_ *historyservice.RespondWorkflowTaskCompletedResponse, retError error) {
+	// By default, retError is passed to workflow lease release method in deferred function.
+	// If error is passed, then workflow context and mutable state are cleared.
+	// If no changes to mutable state are made or changes already persisted (in memory version corresponds to the database),
+	// then the lease is released without an error, i.e. workflow context and mutable state are NOT cleared.
+	releaseLeaseWithError := true
+
 	namespaceEntry, err := api.GetActiveNamespace(handler.shardContext, namespace.ID(req.GetNamespaceId()))
 	if err != nil {
 		return nil, err
@@ -162,8 +167,39 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 	}
 	weContext := workflowLease.GetContext()
 	ms := workflowLease.GetMutableState()
-
 	currentWorkflowTask := ms.GetWorkflowTaskByID(token.GetScheduledEventId())
+	defer func() {
+		if retError != nil && currentWorkflowTask != nil && currentWorkflowTask.Type == enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE && ms.IsStickyTaskQueueSet() {
+			// If, while completing WFT, error is occurred and returned to the worker then worker will clear its cache.
+			// New WFT will also be created on sticky task queue and sent to worker.
+			// Because worker doesn't have a workflow in cache, it needs to replay it from the beginning,
+			// but sticky WFT has only partial history. Worker will request full history using GetWorkflowExecutionHistory API.
+			// This history doesn't have speculative WFT events. If WFT is speculative,
+			// then worker will see inconsistency between history from it and full history, and will fail WFT.
+			//
+			// To prevent unexpected WFT failure, server clears stickiness for this workflow, next WFT will go to normal task queue,
+			// and will have full history attached to it.
+			// This is NOT 100% bulletproof solution because this write operation may also fail.
+			// TODO: remove this call when GetWorkflowExecutionHistory includes speculative WFT events.
+			if clearStickyErr := handler.clearStickyTaskQueue(ctx, workflowLease.GetContext()); clearStickyErr != nil {
+				handler.logger.Error("Failed to clear stickiness after speculative workflow task failed to complete.",
+					tag.NewErrorTag("clear-sticky-error", clearStickyErr),
+					tag.Error(retError),
+					tag.WorkflowID(token.GetWorkflowId()),
+					tag.WorkflowRunID(token.GetRunId()),
+					tag.WorkflowNamespaceID(namespaceEntry.ID().String()))
+			}
+		}
+
+		if releaseLeaseWithError {
+			// If the workflow context needs to be cleared, pass operation error (default).
+			workflowLease.GetReleaseFn()(retError)
+		} else {
+			// Otherwise, pass nil to avoid clearing the workflow context (but still return error to the caller).
+			workflowLease.GetReleaseFn()(nil)
+		}
+	}()
+
 	if !ms.IsWorkflowExecutionRunning() ||
 		currentWorkflowTask == nil ||
 		currentWorkflowTask.StartedEventID == common.EmptyEventID ||
@@ -171,8 +207,8 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 		(token.StartedTime != nil && !currentWorkflowTask.StartedTime.IsZero() && !token.StartedTime.AsTime().Equal(currentWorkflowTask.StartedTime)) ||
 		currentWorkflowTask.Attempt != token.Attempt ||
 		(token.Version != common.EmptyVersion && token.Version != currentWorkflowTask.Version) {
-		// we have not alter mutable state yet, so release with it with nil to avoid clear MS.
-		workflowLease.GetReleaseFn()(nil)
+		// Mutable state wasn't changed yet and doesn't have to be cleared.
+		releaseLeaseWithError = false
 		return nil, serviceerror.NewNotFound("Workflow task not found.")
 	}
 
@@ -184,12 +220,11 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 		// TODO: remove !ms.IsStickyTaskQueueSet() from above condition after old WV cleanup [cleanup-old-wv]
 		wftStartedBuildId := ms.GetExecutionInfo().GetWorkflowTaskBuildId()
 		if wftCompletedBuildId != wftStartedBuildId {
-			workflowLease.GetReleaseFn()(nil)
+			// Mutable state wasn't changed yet and doesn't have to be cleared.
+			releaseLeaseWithError = false
 			return nil, serviceerror.NewNotFound(fmt.Sprintf("this workflow task was dispatched to Build ID %s, not %s", wftStartedBuildId, wftCompletedBuildId))
 		}
 	}
-
-	defer func() { workflowLease.GetReleaseFn()(retError) }()
 
 	var effects effect.Buffer
 	defer func() {
@@ -212,6 +247,8 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 
 	// It's an error if the workflow has used versioning in the past but this task has no versioning info.
 	if ms.GetMostRecentWorkerVersionStamp().GetUseVersioning() && !request.GetWorkerVersionStamp().GetUseVersioning() {
+		// Mutable state wasn't changed yet and doesn't have to be cleared.
+		releaseLeaseWithError = false
 		return nil, serviceerror.NewInvalidArgument("Workflow using versioning must continue to use versioning.")
 	}
 
@@ -634,15 +671,14 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 	handler.handleBufferedQueries(ms, req.GetCompleteRequest().GetQueryResults(), newWorkflowTask != nil, namespaceEntry)
 
 	if wtHeartbeatTimedOut {
-		// at this point, update is successful, but we still return an error to client so that the worker will give up this workflow
-		// release workflow lock with nil error to prevent mutable state from being cleared and reloaded
-		workflowLease.GetReleaseFn()(nil)
+		// Mutable state was already persisted and doesn't need to be cleared although error is returned to the worker.
+		releaseLeaseWithError = false
 		return nil, serviceerror.NewNotFound("workflow task heartbeat timeout")
 	}
 
 	if wtFailedCause != nil {
-		// release workflow lock with nil error to prevent mutable state from being cleared and reloaded
-		workflowLease.GetReleaseFn()(nil)
+		// Mutable state was already persisted and doesn't need to be cleared although error is returned to the worker.
+		releaseLeaseWithError = false
 		return nil, serviceerror.NewInvalidArgument(wtFailedCause.Message())
 	}
 
@@ -974,6 +1010,23 @@ func failWorkflowTask(
 
 	// Return reloaded mutable state back to the caller for further updates.
 	return mutableState, wtFailedEventID, nil
+}
+
+func (handler *WorkflowTaskCompletedHandler) clearStickyTaskQueue(ctx context.Context, wfContext workflow.Context) error {
+
+	// Clear all changes in the workflow context that was made already.
+	wfContext.Clear()
+
+	ms, err := wfContext.LoadMutableState(ctx, handler.shardContext)
+	if err != nil {
+		return err
+	}
+	ms.ClearStickyTaskQueue()
+	err = wfContext.UpdateWorkflowExecutionAsActive(ctx, handler.shardContext)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Filter function to be passed to mutable_state.HasAnyBufferedEvent


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Clear sticky task queue on speculative WFT error.

## Why?
<!-- Tell your future self why have you made these changes -->
If, while completing WFT, error is occurred and returned to the worker then worker will clear its cache. New WFT will also be created on sticky task queue and sent to worker. Because worker doesn't have a workflow in cache, it needs to replay it from the beginning, but sticky WFT has only partial history. Worker will request full history using `GetWorkflowExecutionHistory` API. This history doesn't have speculative WFT events. If WFT is speculative, then worker will see inconsistency between history from it and full history, and will fail WFT.

![image](https://github.com/user-attachments/assets/7d8df668-ec82-4e90-a408-4266176f59bf)

To prevent unexpected WFT failure, server clears stickiness for this workflow, next WFT will go to normal task queue, and will have full history attached to it.
This is NOT 100% bulletproof solution because this write operation may also fail.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run in test environment with fault injection enabled.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Not 100% bulletproof solution. Future work to improve `GetWorkflowExecutionHistory` is needed.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.