### PR TITLE
Fix buf-breaking script to account for already merged commit

### DIFF
--- a/develop/buf-breaking.sh
+++ b/develop/buf-breaking.sh
@@ -64,7 +64,7 @@ check_against_commit() {
   fi
 }
 
-if [ "$PR_BASE_COMMIT" != "$COMMIT" ]; then
+if [[ "$PR_BASE_COMMIT" != "$COMMIT" ]]; then
   # We're running in GHA, using shallow clone. Fetch some commits from the PR
   # base so we can try to find the merge base.
   color "Fetching more commits from $PR_BASE_COMMIT..."


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix buf-breaking script to account for already merged commit

## Why?
<!-- Tell your future self why have you made these changes -->
Re-running GHA run-tests for old commits can fail if there are changes to proto files in main branch after the commit you're trying to test.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
