### PR TITLE
Fix lifecycle for dynamicconfig Collection

### DIFF
--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -56,12 +56,12 @@ type (
 
 		cancelClientSubscription func()
 
-		subscriptionLock sync.Mutex
+		subscriptionLock sync.Mutex          // protects subscriptions, subscriptionIdx, and callbackPool
 		subscriptions    map[Key]map[int]any // final "any" is *subscription[T]
 		subscriptionIdx  int
+		callbackPool     *goro.AdaptivePool
 
-		poller       goro.Group
-		callbackPool *goro.AdaptivePool
+		poller goro.Group
 	}
 
 	subscription[T any] struct {

--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -108,22 +108,27 @@ var (
 	errNoMatchingConstraint = errors.New("no matching constraint in key")
 )
 
-// NewCollection creates a new collection
+// NewCollection creates a new collection. For subscriptions to work, you must call Start/Stop.
+// Get will work without Start/Stop.
 func NewCollection(client Client, logger log.Logger) *Collection {
-	c := &Collection{
+	return &Collection{
 		client:        client,
 		logger:        logger,
 		errCount:      -1,
 		subscriptions: make(map[Key]map[int]any),
 	}
+}
+
+func (c *Collection) Start() {
 	s := DynamicConfigSubscriptionCallback.Get(c)()
+	c.subscriptionLock.Lock()
+	defer c.subscriptionLock.Unlock()
 	c.callbackPool = goro.NewAdaptivePool(clock.NewRealTimeSource(), s.MinWorkers, s.MaxWorkers, s.TargetDelay, s.ShrinkFactor)
-	if notifyingClient, ok := client.(NotifyingClient); ok {
+	if notifyingClient, ok := c.client.(NotifyingClient); ok {
 		c.cancelClientSubscription = notifyingClient.Subscribe(c.keysChanged)
 	} else {
 		c.poller.Go(c.pollForChanges)
 	}
-	return c
 }
 
 func (c *Collection) Stop() {
@@ -135,6 +140,7 @@ func (c *Collection) Stop() {
 	c.subscriptionLock.Lock()
 	defer c.subscriptionLock.Unlock()
 	c.callbackPool.Stop()
+	c.callbackPool = nil
 }
 
 // Implement pingable.Pingable
@@ -144,6 +150,11 @@ func (c *Collection) GetPingChecks() []pingable.Check {
 			Name:    "dynamic config callbacks",
 			Timeout: 5 * time.Second,
 			Ping: func() []pingable.Pingable {
+				c.subscriptionLock.Lock()
+				defer c.subscriptionLock.Unlock()
+				if c.callbackPool == nil {
+					return nil
+				}
 				var wg sync.WaitGroup
 				wg.Add(1)
 				c.callbackPool.Do(wg.Done)
@@ -166,6 +177,9 @@ func (c *Collection) pollForChanges(ctx context.Context) error {
 func (c *Collection) pollOnce(ctx context.Context) {
 	c.subscriptionLock.Lock()
 	defer c.subscriptionLock.Unlock()
+	if c.callbackPool == nil {
+		return
+	}
 
 	for key, subs := range c.subscriptions {
 		setting := queryRegistry(key)
@@ -182,6 +196,9 @@ func (c *Collection) pollOnce(ctx context.Context) {
 func (c *Collection) keysChanged(changed map[Key][]ConstrainedValue) {
 	c.subscriptionLock.Lock()
 	defer c.subscriptionLock.Unlock()
+	if c.callbackPool == nil {
+		return
+	}
 
 	for key, cvs := range changed {
 		setting := queryRegistry(key)

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -66,6 +66,7 @@ func (s *fileBasedClientSuite) SetupSuite() {
 	}, logger, s.doneCh)
 	s.Require().NoError(err)
 	s.collection = dynamicconfig.NewCollection(s.client, logger)
+	s.collection.Start()
 }
 
 func (s *fileBasedClientSuite) TearDownSuite() {
@@ -368,6 +369,7 @@ testGetBoolPropertyKey:
 	s.NoError(err)
 
 	c := dynamicconfig.NewCollection(client, mockLogger)
+	c.Start()
 	sub := setting.Subscribe(c)
 
 	val1 := make(chan bool, 1)

--- a/common/dynamicconfig/fx.go
+++ b/common/dynamicconfig/fx.go
@@ -27,11 +27,16 @@ package dynamicconfig
 import (
 	"go.uber.org/fx"
 
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/pingable"
 )
 
 var Module = fx.Options(
-	fx.Provide(NewCollection),
+	fx.Provide(func(client Client, logger log.Logger, lc fx.Lifecycle) *Collection {
+		col := NewCollection(client, logger)
+		lc.Append(fx.StartStopHook(col.Start, col.Stop))
+		return col
+	}),
 	fx.Provide(fx.Annotate(
 		func(c *Collection) pingable.Pingable { return c },
 		fx.ResultTags(`group:"deadlockDetectorRoots"`),

--- a/common/dynamicconfig/static_client.go
+++ b/common/dynamicconfig/static_client.go
@@ -29,6 +29,7 @@ import "go.temporal.io/server/common/log"
 type (
 	// StaticClient is a simple implementation of Client that just looks up in a map.
 	// Values can be either plain values or []ConstrainedValue for a constrained value.
+	// A StaticClient should never be mutated or you'll create race conditions!
 	StaticClient map[Key]any
 )
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -94,7 +94,7 @@ var Module = fx.Options(
 	// coverage to catch misconfiguration.
 	// A more robust approach would require using fx groups but we shouldn't overcomplicate until this becomes an issue.
 	fx.Provide(MuxRouterProvider),
-	fx.Provide(dynamicconfig.NewCollection),
+	fx.Provide(dynamicconfig.Module),
 	fx.Provide(ConfigProvider),
 	fx.Provide(NamespaceLogInterceptorProvider),
 	fx.Provide(RedirectionInterceptorProvider),

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -86,6 +86,7 @@ type (
 var Module = fx.Options(
 	resource.Module,
 	scheduler.Module,
+	dynamicconfig.Module,
 	// Note that with this approach routes may be registered in arbitrary order.
 	// This is okay because our routes don't have overlapping matches.
 	// The only important detail is that the PathPrefix("/") route registered in the HTTPAPIServerProvider comes last.
@@ -94,7 +95,6 @@ var Module = fx.Options(
 	// coverage to catch misconfiguration.
 	// A more robust approach would require using fx groups but we shouldn't overcomplicate until this becomes an issue.
 	fx.Provide(MuxRouterProvider),
-	fx.Provide(dynamicconfig.Module),
 	fx.Provide(ConfigProvider),
 	fx.Provide(NamespaceLogInterceptorProvider),
 	fx.Provide(RedirectionInterceptorProvider),

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2537,7 +2537,7 @@ func (s *workflowHandlerSuite) TestListBatchOperations_InvalidRerquest() {
 }
 
 func (s *workflowHandlerSuite) newConfig() *Config {
-	return NewConfig(dc.NewCollection(dc.NewNoopClient(), s.mockResource.GetLogger()), numHistoryShards)
+	return NewConfig(dc.NewNoopCollection(), numHistoryShards)
 }
 
 func updateRequest(

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler_test.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler_test.go
@@ -68,7 +68,6 @@ func TestCommandProtocolMessage(t *testing.T) {
 		ms      *workflow.MockMutableState
 		updates update.Registry
 		handler *workflowTaskCompletedHandler
-		conf    map[dynamicconfig.Key]any
 	}
 
 	const defaultBlobSizeLimit = 1 * 1024 * 1024
@@ -88,7 +87,6 @@ func TestCommandProtocolMessage(t *testing.T) {
 		shardCtx := shard.NewMockContext(gomock.NewController(t))
 		logger := log.NewNoopLogger()
 		metricsHandler := metrics.NoopMetricsHandler
-		out.conf = map[dynamicconfig.Key]any{}
 		out.ms = workflow.NewMockMutableState(gomock.NewController(t))
 		out.ms.EXPECT().VisitUpdates(gomock.Any())
 		out.ms.EXPECT().GetNamespaceEntry().Return(tests.LocalNamespaceEntry)
@@ -96,9 +94,8 @@ func TestCommandProtocolMessage(t *testing.T) {
 
 		out.updates = update.NewRegistry(out.ms)
 		var effects effect.Buffer
-		config := configs.NewConfig(
-			dynamicconfig.NewCollection(
-				dynamicconfig.StaticClient(out.conf), logger), 1)
+		col := dynamicconfig.NewCollection(dynamicconfig.StaticClient(nil), logger)
+		config := configs.NewConfig(col, 1)
 		mockMeta := persistence.NewMockMetadataManager(gomock.NewController(t))
 		nsReg := namespace.NewRegistry(
 			mockMeta,

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -78,7 +78,7 @@ var Module = fx.Options(
 	events.Module,
 	cache.Module,
 	archival.Module,
-	fx.Provide(dynamicconfig.Module),
+	dynamicconfig.Module,
 	fx.Provide(ConfigProvider), // might be worth just using provider for configs.Config directly
 	fx.Provide(workflow.NewCommandHandlerRegistry),
 	fx.Provide(RetryableInterceptorProvider),

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -78,7 +78,7 @@ var Module = fx.Options(
 	events.Module,
 	cache.Module,
 	archival.Module,
-	fx.Provide(dynamicconfig.NewCollection),
+	fx.Provide(dynamicconfig.Module),
 	fx.Provide(ConfigProvider), // might be worth just using provider for configs.Config directly
 	fx.Provide(workflow.NewCommandHandlerRegistry),
 	fx.Provide(RetryableInterceptorProvider),

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -51,7 +51,7 @@ import (
 
 var Module = fx.Options(
 	resource.Module,
-	fx.Provide(dynamicconfig.Module),
+	dynamicconfig.Module,
 	fx.Provide(ConfigProvider),
 	fx.Provide(PersistenceRateLimitingParamsProvider),
 	service.PersistenceLazyLoadedServiceResolverModule,

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -51,7 +51,7 @@ import (
 
 var Module = fx.Options(
 	resource.Module,
-	fx.Provide(dynamicconfig.NewCollection),
+	fx.Provide(dynamicconfig.Module),
 	fx.Provide(ConfigProvider),
 	fx.Provide(PersistenceRateLimitingParamsProvider),
 	service.PersistenceLazyLoadedServiceResolverModule,

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -63,6 +63,7 @@ var Module = fx.Options(
 	scheduler.Module,
 	batcher.Module,
 	dlq.Module,
+	dynamicconfig.Module,
 	fx.Provide(
 		func(c resource.HistoryClient) dlq.HistoryClient {
 			return c
@@ -86,7 +87,6 @@ var Module = fx.Options(
 		},
 	),
 	fx.Provide(VisibilityManagerProvider),
-	fx.Provide(dynamicconfig.Module),
 	fx.Provide(ThrottledLoggerRpsFnProvider),
 	fx.Provide(ConfigProvider),
 	fx.Provide(PersistenceRateLimitingParamsProvider),

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -86,7 +86,7 @@ var Module = fx.Options(
 		},
 	),
 	fx.Provide(VisibilityManagerProvider),
-	fx.Provide(dynamicconfig.NewCollection),
+	fx.Provide(dynamicconfig.Module),
 	fx.Provide(ThrottledLoggerRpsFnProvider),
 	fx.Provide(ConfigProvider),
 	fx.Provide(PersistenceRateLimitingParamsProvider),


### PR DESCRIPTION
## What changed?
- Use an explicit Start for dynamicconfig.Collection (in addition to Stop)
- Use fx hooks for Start/Stop
- Make it clear that StaticClient should be static
- Use thread-safe client in dynamic config unit tests

## Why?
Fix thread-safety and cleanup

## How did you test it?
existing tests
