### PR TITLE
Tagged logger for Update registry

### DIFF
--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -178,10 +178,15 @@ func NewContext(
 	throttledLogger log.ThrottledLogger,
 	metricsHandler metrics.Handler,
 ) *ContextImpl {
+	tags := []tag.Tag{
+		tag.WorkflowNamespaceID(workflowKey.NamespaceID),
+		tag.WorkflowID(workflowKey.WorkflowID),
+		tag.WorkflowRunID(workflowKey.RunID),
+	}
 	return &ContextImpl{
 		workflowKey:     workflowKey,
-		logger:          logger,
-		throttledLogger: throttledLogger,
+		logger:          log.With(logger, tags...),
+		throttledLogger: log.With(throttledLogger, tags...),
 		metricsHandler:  metricsHandler.WithTags(metrics.OperationTag(metrics.WorkflowContextScope)),
 		config:          config,
 		lock:            locks.NewPrioritySemaphore(1),
@@ -708,18 +713,12 @@ func (c *ContextImpl) mergeUpdateWithNewReplicationTasks(
 	}
 	if numCurrentReplicationTasks == 0 {
 		c.logger.Info("Current workflow has no replication task, while new workflow has replication task",
-			tag.WorkflowNamespaceID(c.workflowKey.NamespaceID),
-			tag.WorkflowID(c.workflowKey.WorkflowID),
-			tag.WorkflowRunID(c.workflowKey.RunID),
 			tag.WorkflowNewRunID(newWorkflowSnapshot.ExecutionState.RunId),
 		)
 		return nil
 	}
 	if numNewReplicationTasks == 0 {
 		c.logger.Info("New workflow has no replication task, while current workflow has replication task",
-			tag.WorkflowNamespaceID(c.workflowKey.NamespaceID),
-			tag.WorkflowID(c.workflowKey.WorkflowID),
-			tag.WorkflowRunID(c.workflowKey.RunID),
 			tag.WorkflowNewRunID(newWorkflowSnapshot.ExecutionState.RunId),
 		)
 		return nil
@@ -728,9 +727,6 @@ func (c *ContextImpl) mergeUpdateWithNewReplicationTasks(
 		// This could happen when importing a workflow and current running workflow is being terminated.
 		// TODO: support more than one replication tasks (batch of events) in the new workflow
 		c.logger.Info("Skipped merging replication tasks because new run has more than one replication tasks",
-			tag.WorkflowNamespaceID(c.workflowKey.NamespaceID),
-			tag.WorkflowID(c.workflowKey.WorkflowID),
-			tag.WorkflowRunID(c.workflowKey.RunID),
 			tag.WorkflowNewRunID(newWorkflowSnapshot.ExecutionState.RunId),
 		)
 		return nil
@@ -958,9 +954,6 @@ func (c *ContextImpl) maxHistorySizeExceeded(shardContext shard.Context) bool {
 
 	if historySize > historySizeLimitError && c.MutableState.IsWorkflowExecutionRunning() {
 		c.logger.Warn("history size exceeds error limit.",
-			tag.WorkflowNamespaceID(c.workflowKey.NamespaceID),
-			tag.WorkflowID(c.workflowKey.WorkflowID),
-			tag.WorkflowRunID(c.workflowKey.RunID),
 			tag.WorkflowHistorySize(historySize))
 
 		return true
@@ -968,9 +961,6 @@ func (c *ContextImpl) maxHistorySizeExceeded(shardContext shard.Context) bool {
 
 	if historySize > historySizeLimitWarn {
 		c.throttledLogger.Warn("history size exceeds warn limit.",
-			tag.WorkflowNamespaceID(c.MutableState.GetExecutionInfo().NamespaceId),
-			tag.WorkflowID(c.MutableState.GetExecutionInfo().WorkflowId),
-			tag.WorkflowRunID(c.MutableState.GetExecutionState().RunId),
 			tag.WorkflowHistorySize(historySize))
 	}
 
@@ -1002,9 +992,6 @@ func (c *ContextImpl) maxHistoryCountExceeded(shardContext shard.Context) bool {
 
 	if historyCount > historyCountLimitError && c.MutableState.IsWorkflowExecutionRunning() {
 		c.logger.Warn("history count exceeds error limit.",
-			tag.WorkflowNamespaceID(c.workflowKey.NamespaceID),
-			tag.WorkflowID(c.workflowKey.WorkflowID),
-			tag.WorkflowRunID(c.workflowKey.RunID),
 			tag.WorkflowEventCount(historyCount))
 
 		return true
@@ -1012,9 +999,6 @@ func (c *ContextImpl) maxHistoryCountExceeded(shardContext shard.Context) bool {
 
 	if historyCount > historyCountLimitWarn {
 		c.throttledLogger.Warn("history count exceeds warn limit.",
-			tag.WorkflowNamespaceID(c.MutableState.GetExecutionInfo().NamespaceId),
-			tag.WorkflowID(c.MutableState.GetExecutionInfo().WorkflowId),
-			tag.WorkflowRunID(c.MutableState.GetExecutionState().RunId),
 			tag.WorkflowEventCount(historyCount))
 	}
 
@@ -1045,9 +1029,6 @@ func (c *ContextImpl) maxMutableStateSizeExceeded() bool {
 
 	if mutableStateSize > mutableStateSizeLimitError {
 		c.logger.Warn("mutable state size exceeds error limit.",
-			tag.WorkflowNamespaceID(c.workflowKey.NamespaceID),
-			tag.WorkflowID(c.workflowKey.WorkflowID),
-			tag.WorkflowRunID(c.workflowKey.RunID),
 			tag.WorkflowMutableStateSize(mutableStateSize))
 
 		return true
@@ -1055,9 +1036,6 @@ func (c *ContextImpl) maxMutableStateSizeExceeded() bool {
 
 	if mutableStateSize > mutableStateSizeLimitWarn {
 		c.throttledLogger.Warn("mutable state size exceeds warn limit.",
-			tag.WorkflowNamespaceID(c.MutableState.GetExecutionInfo().NamespaceId),
-			tag.WorkflowID(c.MutableState.GetExecutionInfo().WorkflowId),
-			tag.WorkflowRunID(c.MutableState.GetExecutionState().RunId),
 			tag.WorkflowMutableStateSize(mutableStateSize))
 	}
 

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -178,15 +178,17 @@ func NewContext(
 	throttledLogger log.ThrottledLogger,
 	metricsHandler metrics.Handler,
 ) *ContextImpl {
-	tags := []tag.Tag{
-		tag.WorkflowNamespaceID(workflowKey.NamespaceID),
-		tag.WorkflowID(workflowKey.WorkflowID),
-		tag.WorkflowRunID(workflowKey.RunID),
+	tags := func() []tag.Tag {
+		return []tag.Tag{
+			tag.WorkflowNamespaceID(workflowKey.NamespaceID),
+			tag.WorkflowID(workflowKey.WorkflowID),
+			tag.WorkflowRunID(workflowKey.RunID),
+		}
 	}
 	return &ContextImpl{
 		workflowKey:     workflowKey,
-		logger:          log.With(logger, tags...),
-		throttledLogger: log.With(throttledLogger, tags...),
+		logger:          log.NewLazyLogger(logger, tags),
+		throttledLogger: log.NewLazyLogger(throttledLogger, tags),
 		metricsHandler:  metricsHandler.WithTags(metrics.OperationTag(metrics.WorkflowContextScope)),
 		config:          config,
 		lock:            locks.NewPrioritySemaphore(1),


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Refactored use of individual logging calls to use tagged loggers instead.

## Why?
<!-- Tell your future self why have you made these changes -->

`logger` is passed down into the Update registry where we need every log line to be tagged with the Workflow ID, Run ID and Namespace ID.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Added test log lines and verified they are tagged correctly.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

That `c.MutableState.GetExecutionInfo()` does not equal the workflow key.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
