### PR TITLE
Don't emit schedule metrics if workflow already running

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1116,6 +1116,10 @@ var (
 		"schedule_action_success",
 		WithDescription("The number of schedule actions that were successfully taken by a schedule"),
 	)
+	ScheduleActionAttempt = NewCounterDef(
+		"schedule_action_attempt",
+		WithDescription("The number of schedule actions attempts"),
+	)
 	ScheduleActionErrors = NewCounterDef(
 		"schedule_action_errors",
 		WithDescription("The number of schedule actions that failed to start"),

--- a/service/worker/scheduler/activities.go
+++ b/service/worker/scheduler/activities.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go.temporal.io/server/common/util"
 	"reflect"
 	"time"
 
@@ -292,9 +293,11 @@ func translateError(err error, msgPrefix string) error {
 	}
 	message := fmt.Sprintf("%s: %s", msgPrefix, err.Error())
 	if common.IsServiceTransientError(err) || common.IsContextDeadlineExceededErr(err) {
-		return temporal.NewApplicationErrorWithCause(message, errType(err), err)
+		return temporal.NewApplicationErrorWithCause(message, errType(err), err, reflect.TypeOf(err))
 	}
-	return temporal.NewNonRetryableApplicationError(message, errType(err), err)
+
+	errorType := util.ErrorType(err)
+	return temporal.NewNonRetryableApplicationError(message, errorType, err)
 }
 
 type responseBuilder struct {

--- a/service/worker/scheduler/activities.go
+++ b/service/worker/scheduler/activities.go
@@ -293,7 +293,7 @@ func translateError(err error, msgPrefix string) error {
 	}
 	message := fmt.Sprintf("%s: %s", msgPrefix, err.Error())
 	if common.IsServiceTransientError(err) || common.IsContextDeadlineExceededErr(err) {
-		return temporal.NewApplicationErrorWithCause(message, errType(err), err, reflect.TypeOf(err))
+		return temporal.NewApplicationErrorWithCause(message, errType(err), err)
 	}
 
 	errorType := util.ErrorType(err)

--- a/service/worker/scheduler/activities.go
+++ b/service/worker/scheduler/activities.go
@@ -28,8 +28,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.temporal.io/server/common/util"
-	"reflect"
+
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -51,6 +50,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/util"
 )
 
 type (
@@ -283,20 +283,17 @@ func (a *activities) TerminateWorkflow(ctx context.Context, req *schedspb.Termin
 	return translateError(err, "TerminateWorkflowExecution")
 }
 
-func errType(err error) string {
-	return reflect.TypeOf(err).Name()
-}
-
 func translateError(err error, msgPrefix string) error {
 	if err == nil {
 		return nil
 	}
 	message := fmt.Sprintf("%s: %s", msgPrefix, err.Error())
+	errorType := util.ErrorType(err)
+
 	if common.IsServiceTransientError(err) || common.IsContextDeadlineExceededErr(err) {
-		return temporal.NewApplicationErrorWithCause(message, errType(err), err)
+		return temporal.NewApplicationErrorWithCause(message, errorType, err)
 	}
 
-	errorType := util.ErrorType(err)
 	return temporal.NewNonRetryableApplicationError(message, errorType, err)
 }
 

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -113,7 +113,7 @@ const (
 	maxListMatchingTimesCount = 1000
 
 	rateLimitedErrorType            = "RateLimited"
-	workflowExecutionAlreadyStarted = "WorkflowExecutionAlreadyStarted"
+	workflowExecutionAlreadyStarted = "serviceerror.WorkflowExecutionAlreadyStarted"
 
 	nextTimeCacheV1Size = 10
 
@@ -1563,11 +1563,8 @@ func GetListInfoFromStartArgs(args *schedspb.StartScheduleArgs, now time.Time, s
 
 func isUserScheduleError(err error) bool {
 	var appError *temporal.ApplicationError
-	if errors.As(err, &appError) {
-		var innerError *temporal.ApplicationError
-		if errors.As(appError.Unwrap(), &innerError) && innerError.Type() == workflowExecutionAlreadyStarted {
-			return true
-		}
+	if errors.As(err, &appError) && appError.Type() == workflowExecutionAlreadyStarted {
+		return true
 	}
 	return false
 }

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -29,7 +29,6 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
-	"go.temporal.io/api/serviceerror"
 	"time"
 
 	"github.com/google/uuid"
@@ -41,6 +40,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	schedpb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -2310,17 +2310,14 @@ func (s *workflowSuite) TestStartScheduledAction() {
 	_scheduler := &scheduler{
 		StartScheduleArgs: s.buildScheduleArgs(),
 	}
+	_scheduler.metrics = sdkclient.MetricsNopHandler
 
 	start := &schedspb.BufferedStart{
-		Manual: true,
+		Manual: false,
 	}
-
-	tryAgain := _scheduler.startScheduledAction(start,
-		_scheduler.Schedule.Action,
-		nil)
-	assert.True(s.T(), tryAgain)
-
-	_scheduler.metrics = sdkclient.MetricsNopHandler
-	start.Manual = false
-	tryAgain = _scheduler.startScheduledAction(start, nil, nil)
+	_scheduler.Schedule.State.Paused = true
+	
+	result, workflowStarted := _scheduler.startScheduledAction(start)
+	assert.False(s.T(), workflowStarted)
+	assert.Nil(s.T(), result)
 }

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -27,12 +27,12 @@ package scheduler
 import (
 	"context"
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -2316,7 +2316,7 @@ func (s *workflowSuite) TestStartScheduledAction() {
 		Manual: false,
 	}
 	_scheduler.Schedule.State.Paused = true
-	
+
 	result, workflowStarted := _scheduler.startScheduledAction(start)
 	assert.False(s.T(), workflowStarted)
 	assert.Nil(s.T(), result)

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -44,7 +43,6 @@ import (
 	schedpb "go.temporal.io/api/schedule/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
-	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 
@@ -2275,49 +2273,4 @@ func (s *workflowSuite) TestCANBySignal() {
 	}, 0) // 0 means use suggested
 	s.True(s.env.IsWorkflowCompleted())
 	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
-}
-
-func (s *workflowSuite) buildScheduleArgs() *schedspb.StartScheduleArgs {
-	startScheduleArgs := &schedspb.StartScheduleArgs{
-		Schedule: &schedpb.Schedule{
-			Spec: &schedpb.ScheduleSpec{
-				Calendar: []*schedpb.CalendarSpec{{
-					Minute: "17",
-					Hour:   "*",
-				}},
-			},
-			Action: s.defaultAction("myid"),
-			Policies: &schedpb.SchedulePolicies{
-				CatchupWindow: durationpb.New(1 * time.Hour),
-			},
-			State: &schedpb.ScheduleState{
-				Paused: true,
-			},
-		},
-		State: &schedspb.InternalState{
-			Namespace:     "myns",
-			NamespaceId:   "mynsid",
-			ScheduleId:    "myschedule",
-			ConflictToken: InitialConflictToken,
-			// workflow "woke up" after 6 hours
-			LastProcessedTime: timestamppb.New(time.Date(2022, 5, 31, 18, 0, 0, 0, time.UTC)),
-		},
-	}
-	return startScheduleArgs
-}
-
-func (s *workflowSuite) TestStartScheduledAction() {
-	_scheduler := &scheduler{
-		StartScheduleArgs: s.buildScheduleArgs(),
-	}
-	_scheduler.metrics = sdkclient.MetricsNopHandler
-
-	start := &schedspb.BufferedStart{
-		Manual: false,
-	}
-	_scheduler.Schedule.State.Paused = true
-
-	result, workflowStarted := _scheduler.startScheduledAction(start)
-	assert.False(s.T(), workflowStarted)
-	assert.Nil(s.T(), result)
 }


### PR DESCRIPTION
## What changed?
1. Add new metric ScheduleActionAttempt. Increment it every time schedule is trying to start workflow.
2. Increment ScheduleActionErrors metric only if it is not WorkflowExecutionAlreadyStarted error.

## Why?
If the user do multiple schedule starts for the same workflow, consecutive starts will fail because workflow already started. This is expected behavior. 
ScheduleActionErrors intention is to capture server error, and this is not a server error.
At the same time we may want to know how many actions user takes, thus new ScheduleActionAttempt metric was added.