### PR TITLE
Fix: RespondWorkflowTaskCompleted should the workflow termination event into the same event batch as the workflowtask failure event

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -405,7 +405,10 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 			// drop this workflow task if it keeps failing. This will cause the workflow task to timeout and get retried after timeout.
 			return nil, serviceerror.NewInvalidArgument(wtFailedCause.Message())
 		}
-		ms, _, err = failWorkflowTask(ctx, handler.shardContext, weContext, currentWorkflowTask, wtFailedCause, request)
+
+		// wtFailedEventID must be used as the event batch ID for any following workflow termination events
+		var wtFailedEventID int64
+		ms, wtFailedEventID, err = failWorkflowTask(ctx, handler.shardContext, weContext, currentWorkflowTask, wtFailedCause, request)
 		if err != nil {
 			return nil, err
 		}
@@ -416,8 +419,14 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 			// Flush buffer event before terminating the workflow
 			ms.FlushBufferedEvents()
 
-			if err := workflow.TerminateWorkflow(ms, wtFailedCause.Message(), nil,
-				consts.IdentityHistoryService, false); err != nil {
+			_, err := ms.AddWorkflowExecutionTerminatedEvent(
+				wtFailedEventID,
+				wtFailedCause.Message(),
+				nil,
+				consts.IdentityHistoryService,
+				false,
+			)
+			if err != nil {
 				return nil, err
 			}
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1328,7 +1328,8 @@ func (ms *MutableStateImpl) GetCompletionEvent(
 	}
 
 	// Completion EventID is always one less than NextEventID after workflow is completed
-	completionEventID := ms.hBuilder.NextEventID() - 1
+	nextEventID := ms.hBuilder.NextEventID()
+	completionEventID := nextEventID - 1
 	firstEventID := ms.executionInfo.CompletionEventBatchId
 
 	currentBranchToken, version, err := ms.getCurrentBranchTokenAndEventVersion(completionEventID)
@@ -1356,6 +1357,41 @@ func (ms *MutableStateImpl) GetCompletionEvent(
 			// can cause task processing side to fail silently
 			return nil, ErrMissingWorkflowCompletionEvent
 		}
+
+		// Certain terminated workflows have an incorrect completionEventBatchId recorded which
+		// prevents the completion event from being loaded outside of cache.
+		//
+		// If we get back an internal error, attempt to search history (most recent
+		// events first) to find the completion event. Event will be earlier than
+		// the recorded CompletionEventBatchID, and should be a part of the same batch.
+		//
+		// see #inc-791-2024-07-16-high-frontend-cpu-on-s-cd046
+		if common.IsInternalError(err) &&
+			ms.executionState.Status == enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED {
+			_, txID := ms.GetLastFirstEventIDTxnID()
+			resp, err := ms.shard.GetExecutionManager().ReadHistoryBranchReverse(ctx, &persistence.ReadHistoryBranchReverseRequest{
+				ShardID:                ms.shard.GetShardID(),
+				BranchToken:            currentBranchToken,
+				MaxEventID:             nextEventID, // looking for an event in the most recent batch
+				PageSize:               1,
+				LastFirstTransactionID: txID,
+				NextPageToken:          []byte{},
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			for _, event := range resp.HistoryEvents {
+				// this only applies to terminated workflows whose ultimate WFT had been failed
+				if event.EventType == enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED {
+					return event, nil
+				}
+			}
+
+			// event wasn't in most recent batch, so this is a different case
+			return nil, ErrMissingWorkflowCompletionEvent
+		}
+
 		return nil, err
 	}
 	return event, nil

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1365,7 +1365,9 @@ func (ms *MutableStateImpl) GetCompletionEvent(
 		// events first) to find the completion event. Event will be earlier than
 		// the recorded CompletionEventBatchID, and should be a part of the same batch.
 		//
-		// see #inc-791-2024-07-16-high-frontend-cpu-on-s-cd046
+		// See also: https://github.com/temporalio/temporal/pull/6180
+		//
+		// TODO: Remove 90 days after deployment (remove after 10/16/2024)
 		if common.IsInternalError(err) &&
 			ms.executionState.Status == enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED {
 			_, txID := ms.GetLastFirstEventIDTxnID()
@@ -1383,7 +1385,7 @@ func (ms *MutableStateImpl) GetCompletionEvent(
 
 			for _, event := range resp.HistoryEvents {
 				// this only applies to terminated workflows whose ultimate WFT had been failed
-				if event.EventType == enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED {
+				if event.EventType == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED {
 					return event, nil
 				}
 			}

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1351,7 +1351,9 @@ func (ms *MutableStateImpl) GetCompletionEvent(
 		currentBranchToken,
 	)
 	if err != nil {
-		if common.IsNotFoundError(err) {
+		if (common.IsNotFoundError(err) ||
+			common.IsInternalError(err)) &&
+			ms.executionState.Status == enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED {
 			// Certain terminated workflows have an incorrect completionEventBatchId recorded which
 			// prevents the completion event from being loaded outside of cache.
 			//
@@ -1362,28 +1364,28 @@ func (ms *MutableStateImpl) GetCompletionEvent(
 			// See also: https://github.com/temporalio/temporal/pull/6180
 			//
 			// TODO: Remove 90 days after deployment (remove after 10/16/2024)
-			if ms.executionState.Status == enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED {
-				_, txID := ms.GetLastFirstEventIDTxnID()
-				resp, err := ms.shard.GetExecutionManager().ReadHistoryBranchReverse(ctx, &persistence.ReadHistoryBranchReverseRequest{
-					ShardID:                ms.shard.GetShardID(),
-					BranchToken:            currentBranchToken,
-					MaxEventID:             nextEventID, // looking for an event in the most recent batch
-					PageSize:               1,
-					LastFirstTransactionID: txID,
-					NextPageToken:          []byte{},
-				})
-				if err != nil {
-					return nil, err
-				}
-
-				for _, event := range resp.HistoryEvents {
-					// this only applies to terminated workflows whose ultimate WFT had been failed
-					if event.EventType == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED {
-						return event, nil
-					}
-				}
+			_, txID := ms.GetLastFirstEventIDTxnID()
+			resp, err := ms.shard.GetExecutionManager().ReadHistoryBranchReverse(ctx, &persistence.ReadHistoryBranchReverseRequest{
+				ShardID:                ms.shard.GetShardID(),
+				BranchToken:            currentBranchToken,
+				MaxEventID:             nextEventID, // looking for an event in the most recent batch
+				PageSize:               1,
+				LastFirstTransactionID: txID,
+				NextPageToken:          []byte{},
+			})
+			if err != nil {
+				return nil, err
 			}
 
+			for _, event := range resp.HistoryEvents {
+				// this only applies to terminated workflows whose ultimate WFT had been failed
+				if event.EventType == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED {
+					return event, nil
+				}
+			}
+		}
+
+		if common.IsNotFoundError(err) {
 			// do not return the original error
 			// since original error of type NotFound
 			// can cause task processing side to fail silently

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -109,6 +109,10 @@ func TimeoutWorkflow(
 	return err
 }
 
+// TerminateWorkflow will write a WorkflowExecutionTerminated event with a fresh
+// batch ID. Do not use for situations where the WorkflowExecutionTerminated
+// event must fall within an existing event batch (for example, if you've already
+// failed a workflow task via `failWorkflowTask` and have an event batch ID).
 func TerminateWorkflow(
 	mutableState MutableState,
 	terminateReason string,


### PR DESCRIPTION
## What changed?
We [previously updated RespondWorkflowTaskCompleted](https://github.com/temporalio/temporal/pull/6180) to terminate on certain non-retryable errors (payload size exceeded) instead of fail. Termination indicates that the failure was sourced from the service, rather than the customer code/SDK. The change inadvertedly resulted in the wrong `CompletionEventBatchID` being written into mutable state, since both `failWorkflowTask` and `TerminateWorkflow` allocate a new event batch. `CompletionEventBatchID` should be set to the batch started in `failWorkflowTask`, but it was overridden from `TerminateWorkflow`. 

When replication to another cluster was involved, or the events cache is otherwise evicted, `MutableState.GetCompletionEvent()` was no longer able to load the failed event, as the `CompletionEventBatchID` used to load from persistence is past the WFT failure event. This caused active transfer tasks involving the terminated workflow to be sent to the DLQ on secondary/standby clusters.

This fix:
- correctly writes the right event batch ID into the workflow termination event by using `AddWorkflowExecutionTerminatedEvent` over `TerminateWorkflow`
- updates `GetCompletionEvent()` to handle internal errors for terminated workflows by iterating through the last batch of events via persistence

## How did you test it?
Set up a local temporal server, and a simple test worker/workflow. The test workflow simply launches a child workflow and awaits the result; the child workflow returns an output with a large (2MB) payload, to trigger termination. 

✅ Validating test case:
- start with unpatched temporal
- run test workflow, observe termination
- run `tdbg w d` and observe an incorrect `completionEventBatchId`
- restart server
- run `tdbg w rt` to refresh tasks
- observe `"error":"unable to get workflow completion event"` message in logs

✅  Validating backfill for corrupted `completionEventBatchId` workflows:
- (continue from "Validated test case" steps)
- stop unpatched temporal server
- start patched temporal server
- run `tdbg w rt` to refresh tasks
- observe server no longer shows error message/makes progress

✅  Validating newly-terminated workflows:
- start with patched temporal server
- run test workflow, observe termination
- run `tdbg w d` and observe the correct `completionEventBatchId`, ensures it matches the `WorkflowTaskFailed` event ID

## Potential risks
- introduces new reverse-history search logic into `GetCompletionEvent()` for edge cases which previously wasn't there; tried to mitigate impact by only requesting a single page + batch of results
- once again changes the `CompletionEventBatchID` for workflow termination events, which may cause transfer task errors if incorrect

## Documentation

## Is hotfix candidate?
Yes
