### PR TITLE
Fix speculative WFT timeout task executor

### DIFF
--- a/service/history/ndc_task_util.go
+++ b/service/history/ndc_task_util.go
@@ -253,15 +253,16 @@ func transferTaskMutableStateStaleChecker(
 ) bool {
 
 	// Check to see if mutable state cache needs to be reloaded from a database.
-	// The exception is a transient workflow task that doesn't generate events.
+	// The exception is a transient workflow task that doesn't generate events
+	// (check only that it is still current WFT).
 
 	wt, isWt := transferTask.(*tasks.WorkflowTask)
 	if !isWt {
 		return true
 	}
 
-	transientWorkflowTask := executionInfo.WorkflowTaskAttempt > 1
-	if transientWorkflowTask && executionInfo.WorkflowTaskScheduledEventId == wt.ScheduledEventID {
+	isTransientWorkflowTask := executionInfo.WorkflowTaskAttempt > 1
+	if isTransientWorkflowTask && executionInfo.WorkflowTaskScheduledEventId == wt.ScheduledEventID {
 		return false
 	}
 
@@ -275,7 +276,7 @@ func timerTaskMutableStateStaleChecker(
 
 	// Check to see if mutable state cache needs to be reloaded from a database.
 	// Exceptions are:
-	// 1. Transient workflow task that doesn't generate events.
+	// 1. Transient workflow task that doesn't generate events (check only that it is still current WFT).
 	// 2. Speculative workflow task that doesn't generate events.
 
 	wttt, isWttt := timerTask.(*tasks.WorkflowTaskTimeoutTask)
@@ -283,12 +284,13 @@ func timerTaskMutableStateStaleChecker(
 		return true
 	}
 
-	if wttt.GetCategory() == tasks.CategoryMemoryTimer {
+	isSpeculativeWorkflowTask := wttt.GetCategory() == tasks.CategoryMemoryTimer
+	if isSpeculativeWorkflowTask {
 		return false
 	}
 
-	transientWorkflowTask := executionInfo.WorkflowTaskAttempt > 1
-	if transientWorkflowTask && executionInfo.WorkflowTaskScheduledEventId == wttt.EventID {
+	isTransientWorkflowTask := executionInfo.WorkflowTaskAttempt > 1
+	if isTransientWorkflowTask && executionInfo.WorkflowTaskScheduledEventId == wttt.EventID {
 		return false
 	}
 

--- a/service/history/ndc_task_util.go
+++ b/service/history/ndc_task_util.go
@@ -45,6 +45,11 @@ import (
 	"go.temporal.io/server/service/history/workflow"
 )
 
+type (
+	taskEventIDGetter        func(task tasks.Task) int64
+	mutableStateStaleChecker func(task tasks.Task, executionInfo *persistencespb.WorkflowExecutionInfo) bool
+)
+
 // CheckTaskVersion will return an error if task version check fails
 func CheckTaskVersion(
 	shard shard.Context,
@@ -87,7 +92,8 @@ func loadMutableStateForTransferTask(
 		shardContext,
 		wfContext,
 		transferTask,
-		getTransferTaskEventIDAndRetryable,
+		tasks.GetTransferTaskEventID,
+		transferTaskMutableStateStaleChecker,
 		metricsHandler.WithTags(metrics.OperationTag(metrics.OperationTransferQueueProcessorScope)),
 		logger,
 	)
@@ -133,7 +139,8 @@ func loadMutableStateForTimerTask(
 		shardContext,
 		wfContext,
 		timerTask,
-		getTimerTaskEventIDAndRetryable,
+		tasks.GetTimerTaskEventID,
+		timerTaskMutableStateStaleChecker,
 		metricsHandler.WithTags(metrics.OperationTag(metrics.OperationTimerQueueProcessorScope)),
 		logger,
 	)
@@ -144,7 +151,8 @@ func loadMutableStateForTask(
 	shardContext shard.Context,
 	wfContext workflow.Context,
 	task tasks.Task,
-	taskEventIDAndRetryable func(task tasks.Task, executionInfo *persistencespb.WorkflowExecutionInfo) (int64, bool),
+	getEventID taskEventIDGetter,
+	canMutableStateBeStale mutableStateStaleChecker,
 	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) (workflow.MutableState, error) {
@@ -169,14 +177,17 @@ func loadMutableStateForTask(
 
 	// Validation based on eventID is not good enough as certain operation does not generate events.
 	// For example, scheduling transient workflow task, or starting activities that have retry policy.
-
-	// check to see if cache needs to be refreshed as we could potentially have stale workflow execution
-	// the exception is workflow task consistently fail
-	// there will be no event generated, thus making the workflow task schedule ID == next event ID
-	eventID, retryable := taskEventIDAndRetryable(task, mutableState.GetExecutionInfo())
-	if eventID < mutableState.GetNextEventID() || !retryable {
+	eventID := getEventID(task)
+	if eventID < mutableState.GetNextEventID() {
 		return mutableState, nil
 	}
+
+	// Depending on task type, there are exceptions when mutable state can't be stale.
+	// If this is a case, it is safe to use cached mutable state.
+	if !canMutableStateBeStale(task, mutableState.GetExecutionInfo()) {
+		return mutableState, nil
+	}
+	// Otherwise, clear workflow context, reload mutable state from a database and try again.
 
 	metrics.StaleMutableStateCounter.With(metricsHandler).Record(1)
 	wfContext.Clear()
@@ -190,15 +201,16 @@ func loadMutableStateForTask(
 		return nil, err
 	}
 
-	// after refresh, still mutable state's next event ID <= task's event ID
-	if eventID >= mutableState.GetNextEventID() {
-		metrics.TaskSkipped.With(metricsHandler).Record(1)
-		logger.Info("Task Processor: task event ID >= MS NextEventID, skip.",
-			tag.WorkflowNextEventID(mutableState.GetNextEventID()),
-		)
-		return nil, nil
+	if eventID < mutableState.GetNextEventID() {
+		return mutableState, nil
 	}
-	return mutableState, nil
+	// After reloading mutable state from a database, task's event ID is still not valid,
+	// means that task is obsolete and can be safely skipped.
+	metrics.TaskSkipped.With(metricsHandler).Record(1)
+	logger.Info("Task processor skipping task: task event ID >= MS NextEventID.",
+		tag.WorkflowNextEventID(mutableState.GetNextEventID()),
+	)
+	return nil, nil
 }
 
 func validateTaskByClock(
@@ -235,33 +247,52 @@ func validateTaskGeneration(mutableState workflow.MutableState, taskID int64) er
 	return nil
 }
 
-func getTransferTaskEventIDAndRetryable(
+func transferTaskMutableStateStaleChecker(
 	transferTask tasks.Task,
 	executionInfo *persistencespb.WorkflowExecutionInfo,
-) (int64, bool) {
-	eventID := tasks.GetTransferTaskEventID(transferTask)
-	retryable := true
+) bool {
 
-	if task, ok := transferTask.(*tasks.WorkflowTask); ok {
-		retryable = !(executionInfo.WorkflowTaskScheduledEventId == task.ScheduledEventID && executionInfo.WorkflowTaskAttempt > 1)
+	// Check to see if mutable state cache needs to be reloaded from a database.
+	// The exception is a transient workflow task that doesn't generate events.
+
+	wt, isWt := transferTask.(*tasks.WorkflowTask)
+	if !isWt {
+		return true
 	}
 
-	return eventID, retryable
+	transientWorkflowTask := executionInfo.WorkflowTaskAttempt > 1
+	if transientWorkflowTask && executionInfo.WorkflowTaskScheduledEventId == wt.ScheduledEventID {
+		return false
+	}
+
+	return true
 }
 
-func getTimerTaskEventIDAndRetryable(
+func timerTaskMutableStateStaleChecker(
 	timerTask tasks.Task,
 	executionInfo *persistencespb.WorkflowExecutionInfo,
-) (int64, bool) {
-	eventID := tasks.GetTimerTaskEventID(timerTask)
-	retryable := true
+) bool {
 
-	if task, ok := timerTask.(*tasks.WorkflowTaskTimeoutTask); ok {
-		retryable = !(executionInfo.WorkflowTaskScheduledEventId == task.EventID && executionInfo.WorkflowTaskAttempt > 1) &&
-			executionInfo.WorkflowTaskType != enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE
+	// Check to see if mutable state cache needs to be reloaded from a database.
+	// Exceptions are:
+	// 1. Transient workflow task that doesn't generate events.
+	// 2. Speculative workflow task that doesn't generate events.
+
+	wttt, isWttt := timerTask.(*tasks.WorkflowTaskTimeoutTask)
+	if !isWttt {
+		return true
 	}
 
-	return eventID, retryable
+	if wttt.GetCategory() == tasks.CategoryMemoryTimer {
+		return false
+	}
+
+	transientWorkflowTask := executionInfo.WorkflowTaskAttempt > 1
+	if transientWorkflowTask && executionInfo.WorkflowTaskScheduledEventId == wttt.EventID {
+		return false
+	}
+
+	return true
 }
 
 func getNamespaceTagByID(

--- a/service/history/tasks/utils.go
+++ b/service/history/tasks/utils.go
@@ -37,12 +37,12 @@ func Tags(
 ) []tag.Tag {
 	// TODO: convert this to a method GetEventID on task interface
 	// or remove this tag as the value is visible in the Task tag value.
-	taskEventID := int64(0)
+	taskEventID := common.EmptyEventID
 	taskCategory := task.GetCategory()
 	switch taskCategory.ID() {
 	case CategoryIDTransfer:
 		taskEventID = GetTransferTaskEventID(task)
-	case CategoryIDTimer:
+	case CategoryIDTimer, CategoryIDMemoryTimer:
 		taskEventID = GetTimerTaskEventID(task)
 	default:
 		// no-op, other task categories don't have task eventID

--- a/service/history/tasks/workflow_task_timer.go
+++ b/service/history/tasks/workflow_task_timer.go
@@ -53,7 +53,9 @@ type (
 		ScheduleAttempt     int32
 		TimeoutType         enumspb.TimeoutType
 		Version             int64
-		InMemory            bool
+
+		// InMemory field is not persisted in the database.
+		InMemory bool
 
 		// state is used by speculative WT only.
 		state atomic.Uint32 // of type ctasks.State

--- a/service/history/workflow/cache/cache_test.go
+++ b/service/history/workflow/cache/cache_test.go
@@ -160,6 +160,7 @@ func (s *workflowCacheSuite) TestHistoryCachePanic() {
 	mockMS1 := workflow.NewMockMutableState(s.controller)
 	mockMS1.EXPECT().IsDirty().Return(true).AnyTimes()
 	mockMS1.EXPECT().GetQueryRegistry().Return(workflow.NewQueryRegistry()).AnyTimes()
+	mockMS1.EXPECT().RemoveSpeculativeWorkflowTaskTimeoutTask().AnyTimes()
 	ctx, release, err := s.cache.GetOrCreateWorkflowExecution(
 		context.Background(),
 		s.mockShard,
@@ -269,6 +270,7 @@ func (s *workflowCacheSuite) TestHistoryCacheClear() {
 	// all we need is a fake MutableState
 	mock := workflow.NewMockMutableState(s.controller)
 	mock.EXPECT().IsDirty().Return(false).AnyTimes()
+	mock.EXPECT().RemoveSpeculativeWorkflowTaskTimeoutTask().AnyTimes()
 	ctx.(*workflow.ContextImpl).MutableState = mock
 
 	release(nil)
@@ -340,6 +342,7 @@ func (s *workflowCacheSuite) TestHistoryCacheConcurrentAccess_Release() {
 		// all we need is a fake MutableState
 		mock := workflow.NewMockMutableState(s.controller)
 		mock.EXPECT().GetQueryRegistry().Return(workflow.NewQueryRegistry())
+		mock.EXPECT().RemoveSpeculativeWorkflowTaskTimeoutTask()
 		ctx.(*workflow.ContextImpl).MutableState = mock
 		release(errors.New("some random error message"))
 	}

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -217,6 +217,7 @@ func (c *ContextImpl) Clear() {
 	metrics.WorkflowContextCleared.With(c.metricsHandler).Record(1)
 	if c.MutableState != nil {
 		c.MutableState.GetQueryRegistry().Clear()
+		c.MutableState.RemoveSpeculativeWorkflowTaskTimeoutTask()
 		c.MutableState = nil
 	}
 	if c.updateRegistry != nil {

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5089,11 +5089,11 @@ func (ms *MutableStateImpl) GetUpdateCondition() (int64, int64) {
 func (ms *MutableStateImpl) SetSpeculativeWorkflowTaskTimeoutTask(
 	task *tasks.WorkflowTaskTimeoutTask,
 ) error {
-	taskID, err := ms.shard.GenerateTaskIDs(1)
+	taskID, err := ms.shard.GenerateTaskID()
 	if err != nil {
 		return err
 	}
-	task.TaskID = taskID[0]
+	task.TaskID = taskID
 	ms.speculativeWorkflowTaskTimeoutTask = task
 	return ms.shard.AddSpeculativeWorkflowTaskTimeoutTask(task)
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5089,6 +5089,11 @@ func (ms *MutableStateImpl) GetUpdateCondition() (int64, int64) {
 func (ms *MutableStateImpl) SetSpeculativeWorkflowTaskTimeoutTask(
 	task *tasks.WorkflowTaskTimeoutTask,
 ) error {
+	taskID, err := ms.shard.GenerateTaskIDs(1)
+	if err != nil {
+		return err
+	}
+	task.TaskID = taskID[0]
 	ms.speculativeWorkflowTaskTimeoutTask = task
 	return ms.shard.AddSpeculativeWorkflowTaskTimeoutTask(task)
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix speculative WFT timeout task executor.

## Why?
<!-- Tell your future self why have you made these changes -->
There was a bug when type of workflow task was determined from mutable state. This is wrong because when workflow context is cleared and mutable state is reloaded, speculative workflow task is lost but corresponding timeout timer task still can be executed. This PR fixes it twice:
1. on workflow context clear, in memory timeout task is also removed (if WFT is not there, there is nothing to timeout),
2. mutable state is never reloaded in timer task executor for speculative WFT.

Also fixed few minor logging issues found during investigation.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
Maybe.