### PR TITLE
Fix missing Workflow Execution on completed Update

### DIFF
--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -135,6 +135,7 @@ func (u *Updater) ApplyRequest(
 		return nil, consts.ErrWorkflowExecutionNotFound
 	}
 
+	u.wfKey = ms.GetWorkflowKey()
 	updateID := u.req.GetRequest().GetRequest().GetMeta().GetUpdateId()
 
 	if !ms.IsWorkflowExecutionRunning() {
@@ -145,8 +146,6 @@ func (u *Updater) ApplyRequest(
 		}
 		return nil, consts.ErrWorkflowCompleted
 	}
-
-	u.wfKey = ms.GetWorkflowKey()
 
 	if ms.GetExecutionInfo().WorkflowTaskAttempt >= failUpdateWorkflowTaskAttemptCount {
 		// If workflow task is constantly failing, the update to that workflow will also fail.

--- a/tests/update_workflow.go
+++ b/tests/update_workflow.go
@@ -1010,7 +1010,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_CompletedWorkflow() {
 		// Send same Update request again, receiving the same Update result.
 		updateResultCh = s.sendUpdateNoError(tv, "1")
 		updateResult2 := <-updateResultCh
-		s.EqualValues(updateResult1.GetOutcome(), updateResult2.GetOutcome())
+		s.EqualValues(updateResult1, updateResult2)
 	})
 
 	s.Run("receive error from accepted Update", func() {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Make sure that `WorkflowExecution` is set.

## Why?
<!-- Tell your future self why have you made these changes -->

If the user sends an Update request to a closed Workflow and that Update was already complete earlier, the response is missing the `WorkflowExecution`.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Updated existing test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->

Maybe.