### PR TITLE
Fix execution timer status carryover upon continueAsNew

### DIFF
--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -47,6 +47,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/taskqueue/v1"
 	serviceerror2 "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/components/callbacks"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -1077,6 +1078,8 @@ func (s *mutableStateSuite) buildWorkflowMutableState() *persistencespb.Workflow
 				TransitionCount:          1024,
 			},
 		},
+		FirstExecutionRunId:              uuid.New(),
+		WorkflowExecutionTimerTaskStatus: TimerTaskStatusCreated,
 	}
 
 	state := &persistencespb.WorkflowExecutionState{
@@ -1305,6 +1308,73 @@ func (s *mutableStateSuite) TestApplyActivityTaskStartedEvent() {
 	s.Assert().Equal(now, ai.StartedTime.AsTime())
 	s.Assert().Equal(requestID, ai.RequestId)
 	s.Assert().Nil(ai.LastHeartbeatDetails)
+}
+
+func (s *mutableStateSuite) TestAddContinueAsNewEvent_Default() {
+	dbState := s.buildWorkflowMutableState()
+	dbState.BufferedEvents = nil
+
+	var err error
+	s.mutableState, err = NewMutableStateFromDB(s.mockShard, s.mockEventsCache, s.logger, tests.LocalNamespaceEntry, dbState, 123)
+	s.NoError(err)
+
+	workflowTaskInfo := s.mutableState.GetStartedWorkflowTask()
+	workflowTaskCompletedEvent, err := s.mutableState.AddWorkflowTaskCompletedEvent(
+		workflowTaskInfo,
+		&workflowservice.RespondWorkflowTaskCompletedRequest{},
+		WorkflowTaskCompletionLimits{
+			MaxResetPoints:              10,
+			MaxSearchAttributeValueSize: 1024,
+		},
+	)
+	s.NoError(err)
+
+	err = callbacks.RegisterStateMachine(s.mockShard.StateMachineRegistry())
+	s.NoError(err)
+	coll := callbacks.MachineCollection(s.mutableState.HSM())
+	_, err = coll.Add(
+		"test-callback-carryover",
+		callbacks.NewCallback(
+			timestamppb.Now(),
+			callbacks.NewWorkflowClosedTrigger(),
+			&persistencespb.Callback{
+				Variant: &persistencespb.Callback_Nexus_{
+					Nexus: &persistencespb.Callback_Nexus{
+						Url: "test-callback-carryover-url",
+					},
+				},
+			},
+		),
+	)
+	s.NoError(err)
+
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).Times(2)
+	_, newRunMutableState, err := s.mutableState.AddContinueAsNewEvent(
+		context.Background(),
+		workflowTaskCompletedEvent.GetEventId(),
+		workflowTaskCompletedEvent.GetEventId(),
+		"",
+		&commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
+			// All other fields will default to those in the current run.
+			WorkflowRunTimeout: s.mutableState.GetExecutionInfo().WorkflowRunTimeout,
+		},
+	)
+	s.NoError(err)
+
+	newColl := callbacks.MachineCollection(newRunMutableState.HSM())
+	s.Equal(1, newColl.Size())
+
+	currentRunExecutionInfo := s.mutableState.GetExecutionInfo()
+	newRunExecutionInfo := newRunMutableState.GetExecutionInfo()
+	s.Equal(currentRunExecutionInfo.TaskQueue, newRunExecutionInfo.TaskQueue)
+	s.Equal(currentRunExecutionInfo.WorkflowTypeName, newRunExecutionInfo.WorkflowTypeName)
+	protorequire.ProtoEqual(s.T(), currentRunExecutionInfo.DefaultWorkflowTaskTimeout, newRunExecutionInfo.DefaultWorkflowTaskTimeout)
+	protorequire.ProtoEqual(s.T(), currentRunExecutionInfo.WorkflowRunTimeout, newRunExecutionInfo.WorkflowRunTimeout)
+	protorequire.ProtoEqual(s.T(), currentRunExecutionInfo.WorkflowExecutionExpirationTime, newRunExecutionInfo.WorkflowExecutionExpirationTime)
+	s.Equal(currentRunExecutionInfo.WorkflowExecutionTimerTaskStatus, newRunExecutionInfo.WorkflowExecutionTimerTaskStatus)
+	s.Equal(currentRunExecutionInfo.FirstExecutionRunId, newRunExecutionInfo.FirstExecutionRunId)
+
+	// Add more checks here if needed.
 }
 
 func (s *mutableStateSuite) TestTotalEntitiesCount() {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Fix execution timer status carryover upon continueAsNew
- Basically use NewMutableStateInChain in AddContinutAsNewEvent

## Why?
<!-- Tell your future self why have you made these changes -->
- This code path was missed in https://github.com/temporalio/temporal/pull/5588

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- New unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- Yes.
