### PR TITLE
Include full file path in logging-call-at field

### DIFF
--- a/common/log/slog_test.go
+++ b/common/log/slog_test.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -68,5 +69,5 @@ func TestSlogFromLayeredLogger(t *testing.T) {
 	require.Equal(t, "wp", record["hey.go.gg"])
 	require.Equal(t, "wow", record["msg"])
 	require.Equal(t, "corn", record["cluster-name"])
-	require.Equal(t, "slog_test.go:61", record["logging-call-at"])
+	require.True(t, strings.HasSuffix(record["logging-call-at"].(string), "slog_test.go:62"))
 }

--- a/common/log/zap_logger.go
+++ b/common/log/zap_logger.go
@@ -26,7 +26,6 @@ package log
 
 import (
 	"os"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -97,7 +96,7 @@ func caller(skip int) string {
 	if !ok {
 		return ""
 	}
-	return filepath.Base(path) + ":" + strconv.Itoa(line)
+	return path + ":" + strconv.Itoa(line)
 }
 
 func (l *zapLogger) buildFieldsWithCallAt(tags []tag.Tag) []zap.Field {

--- a/common/log/zap_logger_test.go
+++ b/common/log/zap_logger_test.go
@@ -126,8 +126,7 @@ func TestDefaultLogger(t *testing.T) {
 	par, err := strconv.Atoi(sps[1])
 	assert.Nil(t, err)
 	lineNum := fmt.Sprintf("%v", par+1)
-	fmt.Println(out, lineNum)
-	assert.Equal(t, `{"level":"info","msg":"test info","error":"test error","wf-action":"add-workflow-started-event","logging-call-at":"zap_logger_test.go:`+lineNum+`"}`+"\n", out)
+	assert.Regexp(t, `{"level":"info","msg":"test info","error":"test error","wf-action":"add-workflow-started-event","logging-call-at":".*zap_logger_test.go:`+lineNum+`"}`+"\n", out)
 }
 
 func TestThrottleLogger(t *testing.T) {
@@ -157,7 +156,7 @@ func TestThrottleLogger(t *testing.T) {
 	assert.Nil(t, err)
 	lineNum := fmt.Sprintf("%v", par+1)
 	fmt.Println(out, lineNum)
-	assert.Equal(t, `{"level":"info","msg":"test info","error":"test error","component":"shard-context","wf-action":"add-workflow-started-event","logging-call-at":"zap_logger_test.go:`+lineNum+`"}`+"\n", out)
+	assert.Regexp(t, `{"level":"info","msg":"test info","error":"test error","component":"shard-context","wf-action":"add-workflow-started-event","logging-call-at":".*zap_logger_test.go:`+lineNum+`"}`+"\n", out)
 }
 
 func TestEmptyMsg(t *testing.T) {
@@ -186,5 +185,5 @@ func TestEmptyMsg(t *testing.T) {
 	assert.Nil(t, err)
 	lineNum := fmt.Sprintf("%v", par+1)
 	fmt.Println(out, lineNum)
-	assert.Equal(t, `{"level":"info","msg":"`+defaultMsgForEmpty+`","error":"test error","wf-action":"add-workflow-started-event","logging-call-at":"zap_logger_test.go:`+lineNum+`"}`+"\n", out)
+	assert.Regexp(t, `{"level":"info","msg":"`+defaultMsgForEmpty+`","error":"test error","wf-action":"add-workflow-started-event","logging-call-at":".*zap_logger_test.go:`+lineNum+`"}`+"\n", out)
 }


### PR DESCRIPTION
## What changed?
We are now logging full file path in `logging-call-at` tags in log entries.

## Why?
Currently it records just the file name which is not sufficient to identify the exact location where the logging is happening. There could be multiple files with same name (ex: api.go)

## How did you test it?
Ran the server and observed the log lines in console
+
unit tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
No