### PR TITLE
Fix task generation validation

### DIFF
--- a/service/history/ndc_task_util.go
+++ b/service/history/ndc_task_util.go
@@ -166,8 +166,12 @@ func loadMutableStateForTask(
 		return nil, err
 	}
 
-	if err := validateTaskGeneration(mutableState, task.GetTaskID()); err != nil {
-		return nil, err
+	if task.GetRunID() == mutableState.GetExecutionState().GetRunId() {
+		// Task generation is scoped to a specific run, so only perform the validation if runID matches.
+		// Tasks targeting the current run (e.g. workflow execution timeout timer) should bypass the validation.
+		if err := validateTaskGeneration(mutableState, task.GetTaskID()); err != nil {
+			return nil, err
+		}
 	}
 
 	// TODO: With validateTaskByClock check above, we should never run into the situation where

--- a/service/history/ndc_task_util.go
+++ b/service/history/ndc_task_util.go
@@ -166,7 +166,7 @@ func loadMutableStateForTask(
 		return nil, err
 	}
 
-	if task.GetRunID() == mutableState.GetExecutionState().GetRunId() {
+	if task.GetRunID() == mutableState.GetWorkflowKey().RunID {
 		// Task generation is scoped to a specific run, so only perform the validation if runID matches.
 		// Tasks targeting the current run (e.g. workflow execution timeout timer) should bypass the validation.
 		if err := validateTaskGeneration(mutableState, task.GetTaskID()); err != nil {

--- a/service/history/timer_queue_task_executor_base_test.go
+++ b/service/history/timer_queue_task_executor_base_test.go
@@ -134,6 +134,7 @@ func (s *timerQueueTaskExecutorBaseSuite) Test_executeDeleteHistoryEventTask_NoE
 	s.mockCache.EXPECT().GetOrCreateWorkflowExecution(gomock.Any(), s.testShardContext, tests.NamespaceID, we, locks.PriorityLow).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
 
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.testShardContext).Return(mockMutableState, nil)
+	mockMutableState.EXPECT().GetWorkflowKey().Return(task.WorkflowKey).AnyTimes()
 	mockMutableState.EXPECT().GetCloseVersion().Return(int64(1), nil)
 	mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{}).AnyTimes()
 	mockMutableState.EXPECT().GetNextEventID().Return(int64(2))
@@ -179,6 +180,7 @@ func (s *timerQueueTaskExecutorBaseSuite) TestArchiveHistory_DeleteFailed() {
 	s.mockCache.EXPECT().GetOrCreateWorkflowExecution(gomock.Any(), s.testShardContext, tests.NamespaceID, we, locks.PriorityLow).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
 
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.testShardContext).Return(mockMutableState, nil)
+	mockMutableState.EXPECT().GetWorkflowKey().Return(task.WorkflowKey).AnyTimes()
 	mockMutableState.EXPECT().GetCloseVersion().Return(int64(1), nil)
 	mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{}).AnyTimes()
 	mockMutableState.EXPECT().GetNextEventID().Return(int64(2))

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -2455,6 +2455,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestPendingCloseExecutionTasks() 
 				closeTransferTaskId = 10
 			}
 			workflowKey := definition.NewWorkflowKey(uuid.New(), uuid.New(), uuid.New())
+			mockMutableState.EXPECT().GetWorkflowKey().Return(workflowKey).AnyTimes()
 			mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 				NamespaceId:         workflowKey.NamespaceID,
 				WorkflowId:          workflowKey.WorkflowID,

--- a/tests/continue_as_new.go
+++ b/tests/continue_as_new.go
@@ -29,6 +29,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -170,10 +171,10 @@ func (s *FunctionalSuite) TestContinueAsNewWorkflow() {
 	)
 }
 
-func (s *FunctionalSuite) TestContinueAsNewRun_Timeout() {
-	id := "functional-continue-as-new-workflow-timeout-test"
-	wt := "functional-continue-as-new-workflow-timeout-test-type"
-	tl := "functional-continue-as-new-workflow-timeout-test-taskqueue"
+func (s *FunctionalSuite) TestContinueAsNewRun_RunTimeout() {
+	id := "functional-continue-as-new-workflow-run-timeout-test"
+	wt := "functional-continue-as-new-workflow-run-timeout-test-type"
+	tl := "functional-continue-as-new-workflow-run-timeout-test-taskqueue"
 	identity := "worker1"
 
 	workflowType := &commonpb.WorkflowType{Name: wt}
@@ -270,6 +271,100 @@ func (s *FunctionalSuite) TestContinueAsNewRun_Timeout() {
   1 WorkflowExecutionStarted
   2 WorkflowTaskScheduled
   3 WorkflowExecutionTimedOut`, historyEvents)
+}
+
+func (s *FunctionalSuite) TestContinueAsNewRun_ExecutionTimeout() {
+	id := "functional-continue-as-new-workflow-execution-timeout-test"
+	wt := "functional-continue-as-new-workflow-execution-timeout-test-type"
+	tl := "functional-continue-as-new-workflow-execution-timeout-test-taskqueue"
+	identity := "worker1"
+
+	workflowType := &commonpb.WorkflowType{Name: wt}
+
+	taskQueue := &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
+
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:                uuid.New(),
+		Namespace:                s.namespace,
+		WorkflowId:               id,
+		WorkflowType:             workflowType,
+		TaskQueue:                taskQueue,
+		Input:                    nil,
+		WorkflowExecutionTimeout: durationpb.New(3 * time.Second),
+		WorkflowTaskTimeout:      durationpb.New(10 * time.Second),
+		Identity:                 identity,
+	}
+
+	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
+	s.NoError(err0)
+
+	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
+
+	wtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
+		return []*commandpb.Command{{
+			CommandType: enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION,
+			Attributes: &commandpb.Command_ContinueAsNewWorkflowExecutionCommandAttributes{
+				ContinueAsNewWorkflowExecutionCommandAttributes: &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
+					WorkflowType:        workflowType,
+					TaskQueue:           taskQueue,
+					WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+				},
+			},
+		}}, nil
+	}
+
+	poller := &TaskPoller{
+		Client:              s.client,
+		Namespace:           s.namespace,
+		TaskQueue:           taskQueue,
+		Identity:            identity,
+		WorkflowTaskHandler: wtHandler,
+		Logger:              s.Logger,
+		T:                   s.T(),
+	}
+
+	testCompleted := make(chan struct{})
+	var workerWG sync.WaitGroup
+	workerWG.Add(1)
+	go func() {
+		defer workerWG.Done()
+
+		for {
+			select {
+			case <-testCompleted:
+				return
+			default:
+				// process the workflow task and continue as new
+				_, err := poller.PollAndProcessWorkflowTask()
+				s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
+			}
+
+			// introduce some delay to the workflow
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+
+	s.Eventually(
+		func() bool {
+			descResp, err := s.client.DescribeWorkflowExecution(
+				NewContext(),
+				&workflowservice.DescribeWorkflowExecutionRequest{
+					Namespace: s.namespace,
+					Execution: &commonpb.WorkflowExecution{
+						WorkflowId: id,
+					},
+				},
+			)
+			s.NoError(err)
+			return descResp.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT &&
+				descResp.GetWorkflowExecutionInfo().Execution.GetRunId() != we.RunId // validate that workflow did continue as new
+		},
+		time.Second*10,
+		time.Millisecond*50,
+	)
+
+	close(testCompleted)
+	workerWG.Wait()
 }
 
 func (s *FunctionalSuite) TestWorkflowContinueAsNew_TaskID() {

--- a/tests/dynamicconfig.go
+++ b/tests/dynamicconfig.go
@@ -62,6 +62,7 @@ var (
 		dynamicconfig.ValidateUTF8FailPersistence.Key():                         true,
 		dynamicconfig.EnableWorkflowExecutionTimeoutTimer.Key():                 true,
 		dynamicconfig.FrontendMaskInternalErrorDetails.Key():                    false,
+		dynamicconfig.WorkflowIdReuseMinimalInterval.Key():                      100 * time.Millisecond,
 	}
 )
 

--- a/tests/dynamicconfig.go
+++ b/tests/dynamicconfig.go
@@ -62,7 +62,6 @@ var (
 		dynamicconfig.ValidateUTF8FailPersistence.Key():                         true,
 		dynamicconfig.EnableWorkflowExecutionTimeoutTimer.Key():                 true,
 		dynamicconfig.FrontendMaskInternalErrorDetails.Key():                    false,
-		dynamicconfig.WorkflowIdReuseMinimalInterval.Key():                      100 * time.Millisecond,
 	}
 )
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Fix task generation validation: make sure runID matches before doing the validation 
- Note this is a stacked PR on top of https://github.com/temporalio/temporal/pull/6325

## Why?
<!-- Tell your future self why have you made these changes -->
- Task generation is scoped to a run, while tasks can be across runs.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Tested locally
- New functional test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- Yes
