### PR TITLE
fix panic when replicationTask is nil

### DIFF
--- a/service/history/replication/raw_task_converter.go
+++ b/service/history/replication/raw_task_converter.go
@@ -108,11 +108,13 @@ func (c *SourceTaskConverterImpl) Convert(
 	if err != nil {
 		return nil, err
 	}
-	rawTaskInfo, err := c.serializer.ParseReplicationTaskInfo(task)
-	if err != nil {
-		return nil, err
+	if replicationTask != nil {
+		rawTaskInfo, err := c.serializer.ParseReplicationTaskInfo(task)
+		if err != nil {
+			return nil, err
+		}
+		replicationTask.RawTaskInfo = rawTaskInfo
 	}
-	replicationTask.RawTaskInfo = rawTaskInfo
 	return replicationTask, nil
 }
 


### PR DESCRIPTION
## What changed?
check replicationTask to avoid panic

## Why?
In some cases, ConvertReplicationTask may return nil replicationTask. We need to check that when setting RawTaskInfo.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
