### PR TITLE
Add history deep health check into admin api

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -744,6 +744,11 @@ This config is EXPERIMENTAL and may be changed or removed in a later release.`,
 		true,
 		`MaskInternalOrUnknownErrors is whether to replace internal/unknown errors with default error`,
 	)
+	HistoryHostErrorPercentage = NewGlobalFloatSetting(
+		"frontend.historyHostErrorPercentage",
+		50,
+		`HistoryHostErrorPercentage is the percentage to mark history service as unhealthy`,
+	)
 	SendRawWorkflowHistory = NewNamespaceBoolSetting(
 		"frontend.sendRawWorkflowHistory",
 		false,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -747,7 +747,7 @@ This config is EXPERIMENTAL and may be changed or removed in a later release.`,
 	HistoryHostErrorPercentage = NewGlobalFloatSetting(
 		"frontend.historyHostErrorPercentage",
 		50,
-		`HistoryHostErrorPercentage is the percentage to mark history service as unhealthy`,
+		`HistoryHostErrorPercentage is the percentage of hosts that are unhealthy`,
 	)
 	SendRawWorkflowHistory = NewNamespaceBoolSetting(
 		"frontend.sendRawWorkflowHistory",

--- a/service/frontend/health_check.go
+++ b/service/frontend/health_check.go
@@ -1,0 +1,102 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package frontend
+
+import (
+	"context"
+
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/membership"
+	"go.temporal.io/server/common/primitives"
+)
+
+type (
+	HealthChecker interface {
+		Check(ctx context.Context) (enumsspb.HealthState, error)
+	}
+
+	healthCheckerImpl struct {
+		serviceName           primitives.ServiceName
+		membershipMonitor     membership.Monitor
+		hostFailurePercentage dynamicconfig.FloatPropertyFn
+		healthCheckFn         func(ctx context.Context, hostAddress string) (enumsspb.HealthState, error)
+		logger                log.Logger
+	}
+)
+
+func NewHealthChecker(
+	serviceName primitives.ServiceName,
+	membershipMonitor membership.Monitor,
+	hostFailurePercentage dynamicconfig.FloatPropertyFn,
+	healthCheckFn func(ctx context.Context, hostAddress string) (enumsspb.HealthState, error),
+	logger log.Logger,
+) HealthChecker {
+	return &healthCheckerImpl{
+		serviceName:           serviceName,
+		membershipMonitor:     membershipMonitor,
+		hostFailurePercentage: hostFailurePercentage,
+		healthCheckFn:         healthCheckFn,
+		logger:                logger,
+	}
+}
+
+func (h *healthCheckerImpl) Check(ctx context.Context) (enumsspb.HealthState, error) {
+	resolver, err := h.membershipMonitor.GetResolver(h.serviceName)
+	if err != nil {
+		return enumsspb.HEALTH_STATE_UNSPECIFIED, err
+	}
+	hosts := resolver.AvailableMembers()
+	receiveCh := make(chan enumsspb.HealthState, len(hosts))
+	for _, host := range hosts {
+		go func(hostAddress string) {
+			resp, err := h.healthCheckFn(
+				ctx,
+				hostAddress,
+			)
+			if err != nil {
+				h.logger.Warn("Failed to ping deep health check", tag.Error(err), tag.ServerName(string(h.serviceName)))
+			}
+			receiveCh <- resp
+		}(host.GetAddress())
+	}
+
+	var failedHostCount float64
+	for i := 0; i < len(hosts); i++ {
+		healthState := <-receiveCh
+		if healthState == enumsspb.HEALTH_STATE_NOT_SERVING {
+			failedHostCount++
+		}
+	}
+	close(receiveCh)
+
+	if (failedHostCount / float64(len(hosts))) > h.hostFailurePercentage() {
+		return enumsspb.HEALTH_STATE_NOT_SERVING, nil
+	}
+
+	return enumsspb.HEALTH_STATE_SERVING, nil
+}

--- a/service/frontend/health_check.go
+++ b/service/frontend/health_check.go
@@ -70,7 +70,12 @@ func (h *healthCheckerImpl) Check(ctx context.Context) (enumsspb.HealthState, er
 	if err != nil {
 		return enumsspb.HEALTH_STATE_UNSPECIFIED, err
 	}
+
 	hosts := resolver.AvailableMembers()
+	if len(hosts) == 0 {
+		return enumsspb.HEALTH_STATE_SERVING, nil
+	}
+
 	receiveCh := make(chan enumsspb.HealthState, len(hosts))
 	for _, host := range hosts {
 		go func(hostAddress string) {
@@ -79,7 +84,7 @@ func (h *healthCheckerImpl) Check(ctx context.Context) (enumsspb.HealthState, er
 				hostAddress,
 			)
 			if err != nil {
-				h.logger.Warn("Failed to ping deep health check", tag.Error(err), tag.ServerName(string(h.serviceName)))
+				h.logger.Warn("failed to ping deep health check", tag.Error(err), tag.ServerName(string(h.serviceName)))
 			}
 			receiveCh <- resp
 		}(host.GetAddress())

--- a/service/frontend/health_check_test.go
+++ b/service/frontend/health_check_test.go
@@ -61,7 +61,7 @@ func (s *healthCheckerSuite) SetupTest() {
 	s.resolver = membership.NewMockServiceResolver(s.controller)
 	s.membershipMonitor.EXPECT().GetResolver(gomock.Any()).Return(s.resolver, nil).AnyTimes()
 
-	s.checker = NewHealthChecker(
+	checker := NewHealthChecker(
 		primitives.HistoryService,
 		s.membershipMonitor,
 		func() float64 {
@@ -78,7 +78,12 @@ func (s *healthCheckerSuite) SetupTest() {
 			}
 		},
 		log.NewNoopLogger(),
-	).(*healthCheckerImpl)
+	)
+	healthChecker, ok := checker.(*healthCheckerImpl)
+	if !ok {
+		s.Fail("The constructor did not return correct type")
+	}
+	s.checker = healthChecker
 }
 
 func (s *healthCheckerSuite) TearDownTest() {

--- a/service/frontend/health_check_test.go
+++ b/service/frontend/health_check_test.go
@@ -1,0 +1,113 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package frontend
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/suite"
+
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/membership"
+	"go.temporal.io/server/common/primitives"
+)
+
+type (
+	healthCheckerSuite struct {
+		suite.Suite
+		controller *gomock.Controller
+
+		membershipMonitor *membership.MockMonitor
+		resolver          *membership.MockServiceResolver
+
+		checker *healthCheckerImpl
+	}
+)
+
+func TestHealthCheckerSuite(t *testing.T) {
+	s := new(healthCheckerSuite)
+	suite.Run(t, s)
+}
+
+func (s *healthCheckerSuite) SetupTest() {
+	s.controller = gomock.NewController(s.T())
+	s.membershipMonitor = membership.NewMockMonitor(s.controller)
+	s.resolver = membership.NewMockServiceResolver(s.controller)
+	s.membershipMonitor.EXPECT().GetResolver(gomock.Any()).Return(s.resolver, nil).AnyTimes()
+
+	s.checker = NewHealthChecker(
+		primitives.HistoryService,
+		s.membershipMonitor,
+		func() float64 {
+			return 0.25
+		},
+		func(ctx context.Context, hostAddress string) (enumsspb.HealthState, error) {
+			switch hostAddress {
+			case "1", "3":
+				return enumsspb.HEALTH_STATE_SERVING, nil
+			case "2":
+				return enumsspb.HEALTH_STATE_UNSPECIFIED, fmt.Errorf("test")
+			default:
+				return enumsspb.HEALTH_STATE_NOT_SERVING, nil
+			}
+		},
+		log.NewNoopLogger(),
+	).(*healthCheckerImpl)
+}
+
+func (s *healthCheckerSuite) TearDownTest() {
+	s.controller.Finish()
+}
+
+func (s *healthCheckerSuite) Test_Check_Serving() {
+	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
+		membership.NewHostInfoFromAddress("1"),
+		membership.NewHostInfoFromAddress("2"),
+		membership.NewHostInfoFromAddress("3"),
+		membership.NewHostInfoFromAddress("4"),
+	})
+
+	state, err := s.checker.Check(context.Background())
+	s.NoError(err)
+	s.Equal(enumsspb.HEALTH_STATE_SERVING, state)
+}
+
+func (s *healthCheckerSuite) Test_Check_Not_Serving() {
+	s.resolver.EXPECT().AvailableMembers().Return([]membership.HostInfo{
+		membership.NewHostInfoFromAddress("1"),
+		membership.NewHostInfoFromAddress("2"),
+		membership.NewHostInfoFromAddress("3"),
+		membership.NewHostInfoFromAddress("4"),
+		membership.NewHostInfoFromAddress("5"),
+	})
+
+	state, err := s.checker.Check(context.Background())
+	s.NoError(err)
+	s.Equal(enumsspb.HEALTH_STATE_NOT_SERVING, state)
+}

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -198,6 +198,9 @@ type Config struct {
 	AdminEnableListHistoryTasks dynamicconfig.BoolPropertyFn
 
 	MaskInternalErrorDetails dynamicconfig.BoolPropertyFnWithNamespaceFilter
+
+	// Health check
+	HistoryHostErrorPercentage dynamicconfig.FloatPropertyFn
 }
 
 // NewConfig returns new service config with default values
@@ -308,6 +311,8 @@ func NewConfig(
 		AdminEnableListHistoryTasks: dynamicconfig.AdminEnableListHistoryTasks.Get(dc),
 
 		MaskInternalErrorDetails: dynamicconfig.FrontendMaskInternalErrorDetails.Get(dc),
+
+		HistoryHostErrorPercentage: dynamicconfig.HistoryHostErrorPercentage.Get(dc),
 	}
 }
 


### PR DESCRIPTION
## What changed?
Add history deep health check into admin api

## Why?
wire up admin deep health check with history deep health check

## How did you test it?
unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
