### PR TITLE
Allow all adminservice APIs for namespace in Deleted state

### DIFF
--- a/common/api/metadata.go
+++ b/common/api/metadata.go
@@ -175,11 +175,19 @@ func GetMethodMetadata(fullApiName string) MethodMetadata {
 	}
 }
 
-// BaseName returns just the method name from a fullly qualified name.
+// MethodName returns just the method name from a fully qualified name.
 func MethodName(fullApiName string) string {
 	index := strings.LastIndex(fullApiName, "/")
 	if index > -1 {
 		return fullApiName[index+1:]
 	}
 	return fullApiName
+}
+
+func ServiceName(fullApiName string) string {
+	index := strings.LastIndex(fullApiName, "/")
+	if index > -1 {
+		return fullApiName[:index+1]
+	}
+	return ""
 }

--- a/common/api/metadata_test.go
+++ b/common/api/metadata_test.go
@@ -125,3 +125,10 @@ func getMethodNames(tp reflect.Type) []string {
 	}
 	return out
 }
+
+func TestServiceName(t *testing.T) {
+	assert.Equal(t, WorkflowServicePrefix, ServiceName(WorkflowServicePrefix+"SomeAPI"))
+	assert.Equal(t, AdminServicePrefix, ServiceName(AdminServicePrefix+"SomeAPI"))
+	assert.Equal(t, "", ServiceName("SomeAPI"))
+	assert.Equal(t, "", ServiceName(""))
+}

--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -62,15 +62,20 @@ var (
 	errTaskTokenNamespaceMismatch = serviceerror.NewInvalidArgument("Operation requested with a token from a different namespace.")
 	errDeserializingToken         = serviceerror.NewInvalidArgument("Error deserializing task token.")
 
-	allowedNamespaceStates = map[string][]enumspb.NamespaceState{
+	allowedNamespaceStatesPerAPI = map[string][]enumspb.NamespaceState{
 		api.WorkflowServicePrefix + "StartWorkflowExecution":           {enumspb.NAMESPACE_STATE_REGISTERED},
 		api.WorkflowServicePrefix + "SignalWithStartWorkflowExecution": {enumspb.NAMESPACE_STATE_REGISTERED},
 		api.OperatorServicePrefix + "DeleteNamespace":                  {enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED, enumspb.NAMESPACE_STATE_DELETED},
-		api.AdminServicePrefix + "DescribeMutableState":                {enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED, enumspb.NAMESPACE_STATE_DELETED},
 		api.NexusServicePrefix + "DispatchNexusTask":                   {enumspb.NAMESPACE_STATE_REGISTERED},
 	}
-	// If API name is not in the map above, these are allowed states for all APIs that have `namespace` or `task_token` field in the request object.
-	defaultAllowedNamespaceStates = []enumspb.NamespaceState{enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED}
+	// If API name is not in the map above, these are allowed states for all APIs of specific service
+	// that have `namespace` or `task_token` field in the request object.
+	allowedNamespaceStatesPerService = map[string][]enumspb.NamespaceState{
+		api.AdminServicePrefix: {enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED, enumspb.NAMESPACE_STATE_DELETED},
+	}
+	// If service name is not in the map above, these are allowed states for all APIs
+	// that have `namespace` or `task_token` field in the request object.
+	allowedNamespaceStatesDefault = []enumspb.NamespaceState{enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED}
 
 	allowedMethodsDuringHandover = map[string]struct{}{
 		"DescribeNamespace":                  {},
@@ -377,17 +382,20 @@ func (ni *NamespaceValidatorInterceptor) checkNamespaceState(namespaceEntry *nam
 		return nil
 	}
 
-	allowedStates, allowedStatesDefined := allowedNamespaceStates[fullMethod]
-	if !allowedStatesDefined {
-		allowedStates = defaultAllowedNamespaceStates
+	allowedStates, allowedStatesPerAPIDefined := allowedNamespaceStatesPerAPI[fullMethod]
+	if !allowedStatesPerAPIDefined {
+		serviceName := api.ServiceName(fullMethod)
+		var allowedStatesPerServiceDefined bool
+		allowedStates, allowedStatesPerServiceDefined = allowedNamespaceStatesPerService[serviceName]
+		if !allowedStatesPerServiceDefined {
+			allowedStates = allowedNamespaceStatesDefault
+		}
 	}
-
 	for _, allowedState := range allowedStates {
 		if allowedState == namespaceEntry.State() {
 			return nil
 		}
 	}
-
 	return serviceerror.NewNamespaceInvalidState(namespaceEntry.Name().String(), namespaceEntry.State(), allowedStates)
 }
 

--- a/common/rpc/interceptor/namespace_validator_test.go
+++ b/common/rpc/interceptor/namespace_validator_test.go
@@ -174,13 +174,19 @@ func (s *namespaceValidatorSuite) Test_StateValidationIntercept_NamespaceNotFoun
 	s.False(handlerCalled)
 }
 
+type nexusRequest struct{}
+
+func (*nexusRequest) GetNamespace() string {
+	return "test-namespace"
+}
 func (s *namespaceValidatorSuite) Test_StateValidationIntercept_StatusFromNamespace() {
+
 	testCases := []struct {
 		state            enumspb.NamespaceState
 		replicationState enumspb.ReplicationState
 		expectedErr      error
 		method           string
-		req              interface{}
+		req              any
 	}{
 		// StartWorkflowExecution
 		{
@@ -213,76 +219,94 @@ func (s *namespaceValidatorSuite) Test_StateValidationIntercept_StatusFromNamesp
 			state:       enumspb.NAMESPACE_STATE_REGISTERED,
 			expectedErr: nil,
 			method:      api.WorkflowServicePrefix + "SignalWithStartWorkflowExecution",
-			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+			req:         &workflowservice.SignalWithStartWorkflowExecutionRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
 			expectedErr: &serviceerror.NamespaceInvalidState{},
 			method:      api.WorkflowServicePrefix + "SignalWithStartWorkflowExecution",
-			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+			req:         &workflowservice.SignalWithStartWorkflowExecutionRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DELETED,
 			expectedErr: &serviceerror.NamespaceInvalidState{},
 			method:      api.WorkflowServicePrefix + "SignalWithStartWorkflowExecution",
-			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+			req:         &workflowservice.SignalWithStartWorkflowExecutionRequest{Namespace: "test-namespace"},
 		},
 		// DeleteNamespace
 		{
 			state:       enumspb.NAMESPACE_STATE_REGISTERED,
 			expectedErr: nil,
 			method:      api.OperatorServicePrefix + "DeleteNamespace",
-			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+			req:         &operatorservice.DeleteNamespaceRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
 			expectedErr: nil,
 			method:      api.OperatorServicePrefix + "DeleteNamespace",
-			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+			req:         &operatorservice.DeleteNamespaceRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DELETED,
 			expectedErr: nil,
 			method:      api.OperatorServicePrefix + "DeleteNamespace",
-			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+			req:         &operatorservice.DeleteNamespaceRequest{Namespace: "test-namespace"},
 		},
-		// DescribeMutableState
+		// AdminService APIs
 		{
 			state:       enumspb.NAMESPACE_STATE_REGISTERED,
 			expectedErr: nil,
 			method:      api.AdminServicePrefix + "DescribeMutableState",
-			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+			req:         &adminservice.DescribeMutableStateRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
 			expectedErr: nil,
 			method:      api.AdminServicePrefix + "DescribeMutableState",
-			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+			req:         &adminservice.DescribeMutableStateRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DELETED,
 			expectedErr: nil,
 			method:      api.AdminServicePrefix + "DescribeMutableState",
-			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+			req:         &adminservice.DescribeMutableStateRequest{Namespace: "test-namespace"},
+		},
+		{
+			state:       enumspb.NAMESPACE_STATE_REGISTERED,
+			expectedErr: nil,
+			method:      api.AdminServicePrefix + "DeleteWorkflowExecution",
+			req:         &adminservice.DeleteWorkflowExecutionRequest{Namespace: "test-namespace"},
+		},
+		{
+			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
+			expectedErr: nil,
+			method:      api.AdminServicePrefix + "DeleteWorkflowExecution",
+			req:         &adminservice.DeleteWorkflowExecutionRequest{Namespace: "test-namespace"},
+		},
+		{
+			state:       enumspb.NAMESPACE_STATE_DELETED,
+			expectedErr: nil,
+			method:      api.AdminServicePrefix + "DeleteWorkflowExecution",
+			req:         &adminservice.DeleteWorkflowExecutionRequest{Namespace: "test-namespace"},
 		},
 		// DispatchNexusTask
 		{
 			state:       enumspb.NAMESPACE_STATE_REGISTERED,
 			expectedErr: nil,
 			method:      api.NexusServicePrefix + "DispatchNexusTask",
-			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+			req:         &nexusRequest{},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
 			expectedErr: &serviceerror.NamespaceInvalidState{},
 			method:      api.NexusServicePrefix + "DispatchNexusTask",
-			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+			req:         &nexusRequest{},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DELETED,
 			expectedErr: &serviceerror.NamespaceInvalidState{},
 			method:      api.NexusServicePrefix + "DispatchNexusTask",
-			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+			req:         &nexusRequest{},
 		},
 
 		// =====================================================================
@@ -368,8 +392,8 @@ func (s *namespaceValidatorSuite) Test_StateValidationIntercept_StatusFromNamesp
 		},
 	}
 
-	for i, testCase := range testCases {
-		s.T().Run(fmt.Sprintf("test-case-%v", i), func(t *testing.T) {
+	for _, testCase := range testCases {
+		s.T().Run(fmt.Sprintf("%s-%s", testCase.method, testCase.state.String()), func(t *testing.T) {
 			_, isDescribeNamespace := testCase.req.(*workflowservice.DescribeNamespaceRequest)
 			_, isRegisterNamespace := testCase.req.(*workflowservice.RegisterNamespaceRequest)
 			if !isDescribeNamespace && !isRegisterNamespace {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Allow all `adminservice` APIs for namespace in `Deleted` state.

## Why?
<!-- Tell your future self why have you made these changes -->
`adminservice` APIs mostly are used but `tdbg` tool, which might be used even for namespaces in `Deleted` state. For example, when delete failed and manual intervention is needed.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added new unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.