### PR TITLE
DescribeTaskQueuePartition calls PartitionFromPartitionProto to corre…

### DIFF
--- a/client/matching/client_gen.go
+++ b/client/matching/client_gen.go
@@ -47,6 +47,7 @@ func (c *clientImpl) ApplyTaskQueueUserDataReplicationEvent(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -66,6 +67,7 @@ func (c *clientImpl) CancelOutstandingPoll(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -85,6 +87,7 @@ func (c *clientImpl) CreateNexusEndpoint(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -104,6 +107,7 @@ func (c *clientImpl) DeleteNexusEndpoint(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -123,6 +127,7 @@ func (c *clientImpl) DescribeTaskQueue(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -138,10 +143,8 @@ func (c *clientImpl) DescribeTaskQueuePartition(
 	opts ...grpc.CallOption,
 ) (*matchingservice.DescribeTaskQueuePartitionResponse, error) {
 
-	p, err := tqid.NormalPartitionFromRpcName(request.GetTaskQueuePartition().GetTaskQueue(), request.GetNamespaceId(), request.GetTaskQueuePartition().GetTaskQueueType())
-	if err != nil {
-		return nil, err
-	}
+	p := tqid.PartitionFromPartitionProto(request.GetTaskQueuePartition(), request.GetNamespaceId())
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -161,6 +164,7 @@ func (c *clientImpl) DispatchNexusTask(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -180,6 +184,7 @@ func (c *clientImpl) ForceUnloadTaskQueue(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -199,6 +204,7 @@ func (c *clientImpl) GetBuildIdTaskQueueMapping(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -218,6 +224,7 @@ func (c *clientImpl) GetTaskQueueUserData(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -237,6 +244,7 @@ func (c *clientImpl) GetWorkerBuildIdCompatibility(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -256,6 +264,7 @@ func (c *clientImpl) GetWorkerVersioningRules(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -275,6 +284,7 @@ func (c *clientImpl) ListNexusEndpoints(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -294,6 +304,7 @@ func (c *clientImpl) ListTaskQueuePartitions(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -313,6 +324,7 @@ func (c *clientImpl) PollNexusTaskQueue(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -332,6 +344,7 @@ func (c *clientImpl) ReplicateTaskQueueUserData(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -351,6 +364,7 @@ func (c *clientImpl) RespondNexusTaskCompleted(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -370,6 +384,7 @@ func (c *clientImpl) RespondNexusTaskFailed(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -389,6 +404,7 @@ func (c *clientImpl) RespondQueryTaskCompleted(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -408,6 +424,7 @@ func (c *clientImpl) UpdateNexusEndpoint(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -427,6 +444,7 @@ func (c *clientImpl) UpdateTaskQueueUserData(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -446,6 +464,7 @@ func (c *clientImpl) UpdateWorkerBuildIdCompatibility(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err
@@ -465,6 +484,7 @@ func (c *clientImpl) UpdateWorkerVersioningRules(
 	if err != nil {
 		return nil, err
 	}
+
 	client, err := c.getClientForTaskQueuePartition(p)
 	if err != nil {
 		return nil, err

--- a/cmd/tools/rpcwrappers/main.go
+++ b/cmd/tools/rpcwrappers/main.go
@@ -287,9 +287,9 @@ func makeGetMatchingClient(reqType reflect.Type) string {
 		"ListNexusEndpointsRequest",
 		"DeleteNexusEndpointRequest":
 		// Always route these requests to the same matching node for all namespaces.
-		tq = fieldWithPath{path: "\"not-applicable\""}
+		tq = fieldWithPath{path: `"not-applicable"`}
 		tqt = fieldWithPath{path: "enumspb.TASK_QUEUE_TYPE_UNSPECIFIED"}
-		nsID = fieldWithPath{path: "\"not-applicable\""}
+		nsID = fieldWithPath{path: `"not-applicable"`}
 	default:
 		tqp = tryFindOneNestedField(t, "TaskQueuePartition", "request", 1)
 		tq = findOneNestedField(t, "TaskQueue", "request", 2)


### PR DESCRIPTION
…ctly respect TaskQueuePartitionID

## What changed?
DescribeTaskQueuePartition calls PartitionFromPartitionProto to correctly handle TaskQueuePartitionID

## Why?
Because it wasn't handling the TaskQueuePartitionID, which likely means all calls were describing the root partition.

## How did you test it?
Fill up TaskQueuePartitions, Call DescribeTaskQueue

## Potential risks
DescribeTaskQueue may have been magically working before, with some clients incorrectly formatting their requests.

## Documentation
N/A

## Is hotfix candidate?
No.
