### PR TITLE
Reduce sensitivity of deadlock detector

### DIFF
--- a/common/deadlock/fx.go
+++ b/common/deadlock/fx.go
@@ -25,21 +25,12 @@
 package deadlock
 
 import (
-	"context"
-
 	"go.uber.org/fx"
 )
 
 var Module = fx.Options(
 	fx.Provide(NewDeadlockDetector),
 	fx.Invoke(func(lc fx.Lifecycle, dd *deadlockDetector) {
-		lc.Append(fx.Hook{
-			OnStart: func(ctx context.Context) error {
-				return dd.Start()
-			},
-			OnStop: func(ctx context.Context) error {
-				return dd.Stop()
-			},
-		})
+		lc.Append(fx.StartStopHook(dd.Start, dd.Stop))
 	}),
 )

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -275,7 +275,7 @@ operator API calls (highest priority). Should be >0.0 and <= 1.0 (defaults to 20
 	)
 	DeadlockInterval = NewGlobalDurationSetting(
 		"system.deadlock.Interval",
-		30*time.Second,
+		60*time.Second,
 		`How often the detector checks each root.`,
 	)
 	DeadlockMaxWorkersPerRoot = NewGlobalIntSetting(

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -250,8 +250,8 @@ func (s *ContextImpl) GetPingChecks() []pingable.Check {
 		{
 			Name: s.String() + "-shard-lock",
 			// rwLock may be held for the duration of renewing shard rangeID, which are called with a
-			// timeout of shardIOTimeout. add a few more seconds for reliability.
-			Timeout: s.config.ShardIOTimeout() + 5*time.Second,
+			// timeout of shardIOTimeout.
+			Timeout: s.config.ShardIOTimeout() + 30*time.Second,
 			Ping: func() []pingable.Pingable {
 				// call rwLock.Lock directly to bypass metrics since this isn't a real request
 				s.rwLock.Lock()
@@ -265,7 +265,7 @@ func (s *ContextImpl) GetPingChecks() []pingable.Check {
 			Name: s.String() + "-io-semaphore",
 			// ioSemaphore is for the duration of a persistence op which has a persistence connection timeout
 			// of 10 sec.
-			Timeout: 10 * time.Second,
+			Timeout: 10*time.Second + 30*time.Second,
 			Ping: func() []pingable.Pingable {
 				_ = s.ioSemaphore.Acquire(context.Background(), locks.PriorityHigh, 1)
 				s.ioSemaphore.Release(1)


### PR DESCRIPTION
## What changed?
- Run checks every 60s instead of 30s.
- Increase grace period for shard lock and shard io semaphore checks.

## Why?
These are a little too sensitive and can fire when persistence is slow for an extended time. The longer timeouts will still catch true deadlocks in a reasonable amount of time.

## How did you test it?
didn't