### PR TITLE
DRAFT: list schedule query should support "ScheduleId" fake search attribute

### DIFF
--- a/common/namespace/namespace.go
+++ b/common/namespace/namespace.go
@@ -381,7 +381,11 @@ func (m *CustomSearchAttributesMapper) GetAlias(fieldName string, namespace stri
 	return alias, nil
 }
 
-func (m *CustomSearchAttributesMapper) GetFieldName(alias string, namespace string) (string, error) {
+func (m *CustomSearchAttributesMapper) GetFieldName(alias string, namespace string, typeMap NameTypeMap) (string, error) {
+	if alias == "ScheduleId" && !typeMap.IsDefined("scheduleId") {
+		return "temporal-sys-scheduler:" + alias, nil
+	}
+
 	fieldName, ok := m.aliasToField[alias]
 	if !ok {
 		return "", serviceerror.NewInvalidArgument(

--- a/common/persistence/visibility/store/elasticsearch/query_interceptors.go
+++ b/common/persistence/visibility/store/elasticsearch/query_interceptors.go
@@ -85,7 +85,7 @@ func (ni *nameInterceptor) Name(name string, usage query.FieldNameUsage) (string
 			return "", err
 		}
 		if mapper != nil {
-			fieldName, err = mapper.GetFieldName(name, ni.namespace.String())
+			fieldName, err = mapper.GetFieldName(name, ni.namespace.String(), ni.searchAttributesTypeMap)
 			if err != nil {
 				return "", err
 			}

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -928,6 +928,7 @@ func (handler *workflowTaskCompletedHandler) handleCommandContinueAsNewWorkflow(
 	unaliasedSas, err := searchattribute.UnaliasFields(
 		handler.searchAttributesMapperProvider,
 		attr.GetSearchAttributes(),
+		saNameType,
 		namespaceName.String(),
 	)
 	if err != nil {
@@ -1045,6 +1046,7 @@ func (handler *workflowTaskCompletedHandler) handleCommandStartChildWorkflow(
 	unaliasedSas, err := searchattribute.UnaliasFields(
 		handler.searchAttributesMapperProvider,
 		attr.GetSearchAttributes(),
+		saTypeMap,
 		targetNamespace.String(),
 	)
 	if err != nil {
@@ -1192,6 +1194,7 @@ func (handler *workflowTaskCompletedHandler) handleCommandUpsertWorkflowSearchAt
 	unaliasedSas, err := searchattribute.UnaliasFields(
 		handler.searchAttributesMapperProvider,
 		attr.GetSearchAttributes(),
+		saTypeMap,
 		namespace.String(),
 	)
 	if err != nil {


### PR DESCRIPTION
If the user defines a custom search attribute with the name ScheduleId, a rewrite should not take place. Instead, we should query what the user supplied.
Otherwise, we should prepend the const value of temporal-sys-scheduler: and replace ScheduleId with WorkflowId.

## What changed?
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
