### PR TITLE
Add outbound queue specific pending task limits

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1407,8 +1407,8 @@ before discarding the task`,
 	QueuePendingTaskCriticalCount = NewGlobalIntSetting(
 		"history.queuePendingTaskCriticalCount",
 		9000,
-		`QueuePendingTaskCriticalCount is the max number of pending task in one queue
-before triggering queue slice splitting and unloading`,
+		`Max number of pending tasks in a history queue before triggering slice splitting and unloading.
+NOTE: The outbound queue has a separate configuration: outboundQueuePendingTaskCriticalCount.`,
 	)
 	QueueReaderStuckCriticalAttempts = NewGlobalIntSetting(
 		"history.queueReaderStuckCriticalAttempts",
@@ -1426,11 +1426,12 @@ before force compacting slices`,
 	QueuePendingTaskMaxCount = NewGlobalIntSetting(
 		"history.queuePendingTasksMaxCount",
 		10000,
-		`QueuePendingTaskMaxCount is the max number of task pending tasks in one queue before stop
-loading new tasks into memory. While QueuePendingTaskCriticalCount won't stop task loading
-for the entire queue but only trigger a queue action to unload tasks. Ideally this max count
-limit should not be hit and task unloading should happen once critical count is exceeded. But
-since queue action is async, we need this hard limit.`,
+		`The max number of task pending tasks in a history queue before stopping loading new tasks into memory. This
+limit is in addition to queuePendingTaskCriticalCount which controls when to unload already loaded tasks but doesn't
+prevent loading new tasks. Ideally this max count limit should not be hit and task unloading should happen once critical
+count is exceeded. But since queue action is async, we need this hard limit.
+NOTE: The outbound queue has a separate configuration: outboundQueuePendingTaskMaxCount.
+`,
 	)
 
 	TaskSchedulerEnableRateLimiter = NewGlobalBoolSetting(
@@ -1621,6 +1622,20 @@ If value less or equal to 0, will fall back to HistoryPersistenceNamespaceMaxQPS
 		"history.outboundTaskBatchSize",
 		100,
 		`OutboundTaskBatchSize is batch size for outboundQueueFactory`,
+	)
+	OutboundQueuePendingTaskMaxCount = NewGlobalIntSetting(
+		"history.outboundQueuePendingTasksMaxCount",
+		10000,
+		`The max number of task pending tasks in the outbound queue before stopping loading new tasks into memory. This
+limit is in addition to outboundQueuePendingTaskCriticalCount which controls when to unload already loaded tasks but
+doesn't prevent loading new tasks. Ideally this max count limit should not be hit and task unloading should happen once
+critical count is exceeded. But since queue action is async, we need this hard limit.
+`,
+	)
+	OutboundQueuePendingTaskCriticalCount = NewGlobalIntSetting(
+		"history.outboundQueuePendingTaskCriticalCount",
+		9000,
+		`Max number of pending tasks in the outbound queue before triggering slice splitting and unloading.`,
 	)
 	OutboundProcessorMaxPollRPS = NewGlobalIntSetting(
 		"history.outboundProcessorMaxPollRPS",

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -167,6 +167,8 @@ type Config struct {
 	OutboundProcessorUpdateAckInterval                  dynamicconfig.DurationPropertyFn
 	OutboundProcessorUpdateAckIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
 	OutboundProcessorPollBackoffInterval                dynamicconfig.DurationPropertyFn
+	OutboundQueuePendingTaskCriticalCount               dynamicconfig.IntPropertyFn
+	OutboundQueuePendingTaskMaxCount                    dynamicconfig.IntPropertyFn
 	OutboundQueueMaxReaderCount                         dynamicconfig.IntPropertyFn
 	OutboundQueueGroupLimiterBufferSize                 dynamicconfig.IntPropertyFnWithDestinationFilter
 	OutboundQueueGroupLimiterConcurrency                dynamicconfig.IntPropertyFnWithDestinationFilter
@@ -490,6 +492,8 @@ func NewConfig(
 		OutboundProcessorUpdateAckInterval:                  dynamicconfig.OutboundProcessorUpdateAckInterval.Get(dc),
 		OutboundProcessorUpdateAckIntervalJitterCoefficient: dynamicconfig.OutboundProcessorUpdateAckIntervalJitterCoefficient.Get(dc),
 		OutboundProcessorPollBackoffInterval:                dynamicconfig.OutboundProcessorPollBackoffInterval.Get(dc),
+		OutboundQueuePendingTaskCriticalCount:               dynamicconfig.OutboundQueuePendingTaskCriticalCount.Get(dc),
+		OutboundQueuePendingTaskMaxCount:                    dynamicconfig.OutboundQueuePendingTaskMaxCount.Get(dc),
 		OutboundQueueMaxReaderCount:                         dynamicconfig.OutboundQueueMaxReaderCount.Get(dc),
 		OutboundQueueGroupLimiterBufferSize:                 dynamicconfig.OutboundQueueGroupLimiterBufferSize.Get(dc),
 		OutboundQueueGroupLimiterConcurrency:                dynamicconfig.OutboundQueueGroupLimiterConcurrency.Get(dc),

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -308,11 +308,12 @@ func (f *outboundQueueFactory) CreateQueue(
 		&queues.Options{
 			ReaderOptions: queues.ReaderOptions{
 				BatchSize:            f.Config.OutboundTaskBatchSize,
-				MaxPendingTasksCount: f.Config.QueuePendingTaskMaxCount,
+				MaxPendingTasksCount: f.Config.OutboundQueuePendingTaskMaxCount,
 				PollBackoffInterval:  f.Config.OutboundProcessorPollBackoffInterval,
 			},
 			MonitorOptions: queues.MonitorOptions{
-				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,
+				PendingTasksCriticalCount: f.Config.OutboundQueuePendingTaskCriticalCount,
+				// Shared configuration with other queues.
 				ReaderStuckCriticalAttempts: f.Config.QueueReaderStuckCriticalAttempts,
 				SliceCountCriticalThreshold: f.Config.QueueCriticalSlicesCount,
 			},


### PR DESCRIPTION
## What changed?

Add `history.outboundQueuePendingTasksMaxCount` and `history.outboundQueuePendingTaskCriticalCount` dynamic configs.

## Why?

The outbound queue runs tasks for multiple destinations with varying latency and availability. We may need more control over the number of pending tasks to prevent situations where tasks for unavailable destinations block tasks that should be okay to process.