### PR TITLE
Add lock when sending replication task to stream

### DIFF
--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -78,6 +79,7 @@ type (
 		config                  *configs.Config
 		isTieredStackEnabled    bool
 		flowController          SenderFlowController
+		sendLock                sync.Mutex
 	}
 )
 
@@ -588,6 +590,8 @@ Loop:
 }
 
 func (s *StreamSenderImpl) sendToStream(payload *historyservice.StreamWorkflowReplicationMessagesResponse) error {
+	s.sendLock.Lock()
+	defer s.sendLock.Unlock()
 	err := s.server.Send(payload)
 	if err != nil {
 		s.logger.Error("ReplicationStreamError Stream Sender unable to send", tag.Error(err))


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add lock when sending replication task to stream
## Why?
<!-- Tell your future self why have you made these changes -->
prevent concurrent send when multi-tiered processing stack enabled
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
n/a
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no risk. feature is not enabled by default
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
yes.