### PR TITLE
Use start time to dedup executions start

### DIFF
--- a/api/persistence/v1/executions.pb.go
+++ b/api/persistence/v1/executions.pb.go
@@ -158,23 +158,24 @@ type WorkflowExecutionInfo struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	NamespaceId                             string                 `protobuf:"bytes,1,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty"`
-	WorkflowId                              string                 `protobuf:"bytes,2,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`
-	ParentNamespaceId                       string                 `protobuf:"bytes,3,opt,name=parent_namespace_id,json=parentNamespaceId,proto3" json:"parent_namespace_id,omitempty"`
-	ParentWorkflowId                        string                 `protobuf:"bytes,4,opt,name=parent_workflow_id,json=parentWorkflowId,proto3" json:"parent_workflow_id,omitempty"`
-	ParentRunId                             string                 `protobuf:"bytes,5,opt,name=parent_run_id,json=parentRunId,proto3" json:"parent_run_id,omitempty"`
-	ParentInitiatedId                       int64                  `protobuf:"varint,6,opt,name=parent_initiated_id,json=parentInitiatedId,proto3" json:"parent_initiated_id,omitempty"`
-	CompletionEventBatchId                  int64                  `protobuf:"varint,7,opt,name=completion_event_batch_id,json=completionEventBatchId,proto3" json:"completion_event_batch_id,omitempty"`
-	TaskQueue                               string                 `protobuf:"bytes,9,opt,name=task_queue,json=taskQueue,proto3" json:"task_queue,omitempty"`
-	WorkflowTypeName                        string                 `protobuf:"bytes,10,opt,name=workflow_type_name,json=workflowTypeName,proto3" json:"workflow_type_name,omitempty"`
-	WorkflowExecutionTimeout                *durationpb.Duration   `protobuf:"bytes,11,opt,name=workflow_execution_timeout,json=workflowExecutionTimeout,proto3" json:"workflow_execution_timeout,omitempty"`
-	WorkflowRunTimeout                      *durationpb.Duration   `protobuf:"bytes,12,opt,name=workflow_run_timeout,json=workflowRunTimeout,proto3" json:"workflow_run_timeout,omitempty"`
-	DefaultWorkflowTaskTimeout              *durationpb.Duration   `protobuf:"bytes,13,opt,name=default_workflow_task_timeout,json=defaultWorkflowTaskTimeout,proto3" json:"default_workflow_task_timeout,omitempty"`
-	LastEventTaskId                         int64                  `protobuf:"varint,17,opt,name=last_event_task_id,json=lastEventTaskId,proto3" json:"last_event_task_id,omitempty"`
-	LastFirstEventId                        int64                  `protobuf:"varint,18,opt,name=last_first_event_id,json=lastFirstEventId,proto3" json:"last_first_event_id,omitempty"`
-	LastCompletedWorkflowTaskStartedEventId int64                  `protobuf:"varint,19,opt,name=last_completed_workflow_task_started_event_id,json=lastCompletedWorkflowTaskStartedEventId,proto3" json:"last_completed_workflow_task_started_event_id,omitempty"`
-	StartTime                               *timestamppb.Timestamp `protobuf:"bytes,20,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
-	LastUpdateTime                          *timestamppb.Timestamp `protobuf:"bytes,21,opt,name=last_update_time,json=lastUpdateTime,proto3" json:"last_update_time,omitempty"`
+	NamespaceId                             string               `protobuf:"bytes,1,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty"`
+	WorkflowId                              string               `protobuf:"bytes,2,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`
+	ParentNamespaceId                       string               `protobuf:"bytes,3,opt,name=parent_namespace_id,json=parentNamespaceId,proto3" json:"parent_namespace_id,omitempty"`
+	ParentWorkflowId                        string               `protobuf:"bytes,4,opt,name=parent_workflow_id,json=parentWorkflowId,proto3" json:"parent_workflow_id,omitempty"`
+	ParentRunId                             string               `protobuf:"bytes,5,opt,name=parent_run_id,json=parentRunId,proto3" json:"parent_run_id,omitempty"`
+	ParentInitiatedId                       int64                `protobuf:"varint,6,opt,name=parent_initiated_id,json=parentInitiatedId,proto3" json:"parent_initiated_id,omitempty"`
+	CompletionEventBatchId                  int64                `protobuf:"varint,7,opt,name=completion_event_batch_id,json=completionEventBatchId,proto3" json:"completion_event_batch_id,omitempty"`
+	TaskQueue                               string               `protobuf:"bytes,9,opt,name=task_queue,json=taskQueue,proto3" json:"task_queue,omitempty"`
+	WorkflowTypeName                        string               `protobuf:"bytes,10,opt,name=workflow_type_name,json=workflowTypeName,proto3" json:"workflow_type_name,omitempty"`
+	WorkflowExecutionTimeout                *durationpb.Duration `protobuf:"bytes,11,opt,name=workflow_execution_timeout,json=workflowExecutionTimeout,proto3" json:"workflow_execution_timeout,omitempty"`
+	WorkflowRunTimeout                      *durationpb.Duration `protobuf:"bytes,12,opt,name=workflow_run_timeout,json=workflowRunTimeout,proto3" json:"workflow_run_timeout,omitempty"`
+	DefaultWorkflowTaskTimeout              *durationpb.Duration `protobuf:"bytes,13,opt,name=default_workflow_task_timeout,json=defaultWorkflowTaskTimeout,proto3" json:"default_workflow_task_timeout,omitempty"`
+	LastEventTaskId                         int64                `protobuf:"varint,17,opt,name=last_event_task_id,json=lastEventTaskId,proto3" json:"last_event_task_id,omitempty"`
+	LastFirstEventId                        int64                `protobuf:"varint,18,opt,name=last_first_event_id,json=lastFirstEventId,proto3" json:"last_first_event_id,omitempty"`
+	LastCompletedWorkflowTaskStartedEventId int64                `protobuf:"varint,19,opt,name=last_completed_workflow_task_started_event_id,json=lastCompletedWorkflowTaskStartedEventId,proto3" json:"last_completed_workflow_task_started_event_id,omitempty"`
+	// Deprecated. use `WorkflowExecutionState.start_time`
+	StartTime      *timestamppb.Timestamp `protobuf:"bytes,20,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
+	LastUpdateTime *timestamppb.Timestamp `protobuf:"bytes,21,opt,name=last_update_time,json=lastUpdateTime,proto3" json:"last_update_time,omitempty"`
 	// Workflow task fields.
 	WorkflowTaskVersion               int64                  `protobuf:"varint,22,opt,name=workflow_task_version,json=workflowTaskVersion,proto3" json:"workflow_task_version,omitempty"`
 	WorkflowTaskScheduledEventId      int64                  `protobuf:"varint,23,opt,name=workflow_task_scheduled_event_id,json=workflowTaskScheduledEventId,proto3" json:"workflow_task_scheduled_event_id,omitempty"`

--- a/common/persistence/cassandra/errors.go
+++ b/common/persistence/cassandra/errors.go
@@ -35,6 +35,7 @@ import (
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/primitives/timestamp"
 )
 
 var (
@@ -248,6 +249,7 @@ func extractCurrentWorkflowConflictError(
 			State:            executionState.State,
 			Status:           executionState.Status,
 			LastWriteVersion: lastWriteVersion,
+			StartTime:        timestamp.TimeValuePtr(executionState.StartTime),
 		}
 	}
 	return nil

--- a/common/persistence/cassandra/mutable_state_store.go
+++ b/common/persistence/cassandra/mutable_state_store.go
@@ -725,6 +725,11 @@ func (d *MutableStateStore) ConflictResolveWorkflowExecution(
 
 	var currentRunID string
 
+	var startTime *time.Time
+	if currentWorkflow != nil && currentWorkflow.ExecutionState != nil {
+		startTime = timestamp.TimeValuePtr(currentWorkflow.ExecutionState.StartTime)
+	}
+
 	switch request.Mode {
 	case p.ConflictResolveWorkflowModeBypassCurrent:
 		if err := d.assertNotCurrentExecution(
@@ -733,7 +738,7 @@ func (d *MutableStateStore) ConflictResolveWorkflowExecution(
 			namespaceID,
 			workflowID,
 			resetWorkflow.ExecutionState.RunId,
-			timestamp.TimeValuePtr(currentWorkflow.ExecutionState.StartTime),
+			startTime,
 		); err != nil {
 			return err
 		}

--- a/common/persistence/cassandra/mutable_state_store.go
+++ b/common/persistence/cassandra/mutable_state_store.go
@@ -27,6 +27,7 @@ package cassandra
 import (
 	"context"
 	"fmt"
+	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -38,6 +39,7 @@ import (
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/primitives/timestamp"
 )
 
 const (
@@ -592,6 +594,7 @@ func (d *MutableStateStore) UpdateWorkflowExecution(
 			namespaceID,
 			workflowID,
 			runID,
+			timestamp.TimeValuePtr(updateWorkflow.ExecutionState.StartTime),
 		); err != nil {
 			return err
 		}
@@ -730,6 +733,7 @@ func (d *MutableStateStore) ConflictResolveWorkflowExecution(
 			namespaceID,
 			workflowID,
 			resetWorkflow.ExecutionState.RunId,
+			timestamp.TimeValuePtr(currentWorkflow.ExecutionState.StartTime),
 		); err != nil {
 			return err
 		}
@@ -872,6 +876,7 @@ func (d *MutableStateStore) assertNotCurrentExecution(
 	namespaceID string,
 	workflowID string,
 	runID string,
+	startTime *time.Time,
 ) error {
 
 	if resp, err := d.GetCurrentExecution(ctx, &p.GetCurrentExecutionRequest{
@@ -892,6 +897,7 @@ func (d *MutableStateStore) assertNotCurrentExecution(
 			State:            enumsspb.WORKFLOW_EXECUTION_STATE_UNSPECIFIED,
 			Status:           enumspb.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED,
 			LastWriteVersion: 0,
+			StartTime:        startTime,
 		}
 	}
 

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -130,6 +130,7 @@ type (
 		State            enumsspb.WorkflowExecutionState
 		Status           enumspb.WorkflowExecutionStatus
 		LastWriteVersion int64
+		StartTime        *time.Time
 	}
 
 	// WorkflowConditionFailedError represents a failed conditional update for workflow record

--- a/common/persistence/sql/errors.go
+++ b/common/persistence/sql/errors.go
@@ -26,7 +26,6 @@ package sql
 
 import (
 	enumspb "go.temporal.io/api/enums/v1"
-
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
@@ -44,6 +43,7 @@ func extractCurrentWorkflowConflictError(
 			State:            enumsspb.WORKFLOW_EXECUTION_STATE_UNSPECIFIED,
 			Status:           enumspb.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED,
 			LastWriteVersion: 0,
+			StartTime:        nil,
 		}
 	}
 
@@ -54,5 +54,6 @@ func extractCurrentWorkflowConflictError(
 		State:            currentRow.State,
 		Status:           currentRow.Status,
 		LastWriteVersion: currentRow.LastWriteVersion,
+		StartTime:        currentRow.StartTime,
 	}
 }

--- a/common/primitives/timestamp/time.go
+++ b/common/primitives/timestamp/time.go
@@ -42,6 +42,14 @@ func TimeValue(t *timestamppb.Timestamp) time.Time {
 	return t.AsTime()
 }
 
+func TimeValuePtr(t *timestamppb.Timestamp) *time.Time {
+	if t == nil {
+		return nil
+	}
+	result := t.AsTime()
+	return &result
+}
+
 func DurationValue(d *durationpb.Duration) time.Duration {
 	if d == nil {
 		return 0

--- a/proto/internal/temporal/server/api/persistence/v1/executions.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/executions.proto
@@ -90,6 +90,7 @@ message WorkflowExecutionInfo {
     int64 last_event_task_id = 17;
     int64 last_first_event_id = 18;
     int64 last_completed_workflow_task_started_event_id = 19;
+    // Deprecated. use `WorkflowExecutionState.start_time`
     google.protobuf.Timestamp start_time = 20;
     google.protobuf.Timestamp last_update_time = 21;
 

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -28,7 +28,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.temporal.io/server/common/testing/testvars"
 	"testing"
 	"time"
 
@@ -52,6 +51,7 @@ import (
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testvars"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go.temporal.io/server/common/testing/testvars"
 	"testing"
 	"time"
 
@@ -111,6 +112,7 @@ type (
 		config        *configs.Config
 		logger        *log.MockLogger
 		errorMessages []string
+		tv            *testvars.TestVars
 	}
 )
 
@@ -230,6 +232,17 @@ func (s *engine2Suite) SetupTest() {
 	s.mockShard.SetEngineForTesting(h)
 
 	s.historyEngine = h
+
+	s.tv = testvars.New(s.T())
+	s.tv = s.tv.
+		WithWorkflowID("WorkflowID").
+		WithRunID(uuid.New()).
+		WithWorkflowType("WorkflowType").
+		WithTaskQueue("TestTaskQueue").
+		WithClientIdentity("ClientIdentity").
+		WithNamespaceID(tests.NamespaceID).
+		WithString(uuid.New(), "PrevRunID")
+
 }
 
 func (s *engine2Suite) SetupSubTest() {
@@ -1239,6 +1252,168 @@ func (s *engine2Suite) TestStartWorkflowExecution_BrandNew_SearchAttributes() {
 	s.NotNil(resp.RunId)
 }
 
+func makeMockStartRequest(
+	tv *testvars.TestVars,
+	wfReusePolicy enumspb.WorkflowIdReusePolicy,
+	wfConflictPolicy enumspb.WorkflowIdConflictPolicy,
+) *historyservice.StartWorkflowExecutionRequest {
+	return &historyservice.StartWorkflowExecutionRequest{
+		Attempt:     1,
+		NamespaceId: tv.NamespaceID().String(),
+		StartRequest: &workflowservice.StartWorkflowExecutionRequest{
+			Namespace:                tv.NamespaceID().String(),
+			WorkflowId:               tv.WorkflowID(),
+			WorkflowType:             tv.WorkflowType(),
+			TaskQueue:                tv.TaskQueue("dedupTaskQueue"),
+			WorkflowExecutionTimeout: durationpb.New(1 * time.Second),
+			WorkflowTaskTimeout:      durationpb.New(2 * time.Second),
+			WorkflowIdReusePolicy:    wfReusePolicy,
+			WorkflowIdConflictPolicy: wfConflictPolicy,
+			Identity:                 tv.WorkerIdentity(),
+			RequestId:                tv.String("RequestID"),
+		},
+	}
+}
+
+func makeCurrentWorkflowConditionFailedError(
+	tv *testvars.TestVars,
+	startTime *timestamppb.Timestamp,
+) *persistence.CurrentWorkflowConditionFailedError {
+	lastWriteVersion := common.EmptyVersion
+	return &persistence.CurrentWorkflowConditionFailedError{
+		Msg:              "random message",
+		RequestID:        tv.String("PrevRequestID"),
+		RunID:            tv.RunID(),
+		State:            enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+		Status:           enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+		LastWriteVersion: lastWriteVersion,
+		StartTime:        timestamp.TimeValuePtr(startTime),
+	}
+}
+
+func (s *engine2Suite) setupStartWorkflowExecutionDedup(startTime *timestamppb.Timestamp) *workflow.MutableStateImpl {
+	brandNewExecutionRequest := mock.MatchedBy(func(request *persistence.CreateWorkflowExecutionRequest) bool {
+		return request.Mode == persistence.CreateWorkflowModeBrandNew
+	})
+	currentWorkflowConditionFailedError := makeCurrentWorkflowConditionFailedError(s.tv, startTime)
+	s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).
+		Return(nil, currentWorkflowConditionFailedError).AnyTimes()
+
+	ms := workflow.TestGlobalMutableState(
+		s.historyEngine.shardContext,
+		s.mockEventsCache,
+		log.NewTestLogger(),
+		tests.Version,
+		s.tv.WorkflowID(),
+		s.tv.RunID(),
+	)
+	ms.GetExecutionInfo().VersionHistories.Histories[0].Items = []*historyspb.VersionHistoryItem{{Version: 0, EventId: 0}}
+	ms.GetExecutionState().StartTime = startTime
+	return ms
+}
+
+func (s *engine2Suite) setupStartWorkflowExecutionForRunning() {
+	now := s.historyEngine.shardContext.GetTimeSource().Now()
+	startTime := timestamppb.New(now.Add(-100 * time.Millisecond))
+	s.setupStartWorkflowExecutionDedup(startTime)
+}
+
+func (s *engine2Suite) setupStartWorkflowExecutionForTerminate() {
+	now := s.historyEngine.shardContext.GetTimeSource().Now()
+	startTime := timestamppb.New(now.Add(-2 * time.Second))
+	ms := s.setupStartWorkflowExecutionDedup(startTime)
+
+	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(
+		gomock.Any(),
+		mock.MatchedBy(func(req *persistence.UpdateWorkflowExecutionRequest) bool {
+			return req.UpdateWorkflowMutation.ExecutionState.Status == enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED
+		}),
+	).Return(&persistence.UpdateWorkflowExecutionResponse{
+		UpdateMutableStateStats: persistence.MutableStateStatistics{
+			HistoryStatistics: &persistence.HistoryStatistics{SizeDiff: 1},
+		},
+	}, nil).AnyTimes()
+
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(&persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}, nil)
+}
+
+func (s *engine2Suite) TestStartWorkflowExecution_Dedup_Running_CalledTooSoon() {
+	// error when id reuse policy is WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING but called too soon
+	s.setupStartWorkflowExecutionForRunning()
+
+	startRequest := makeMockStartRequest(s.tv, enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED, enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING)
+
+	resp, err := s.historyEngine.StartWorkflowExecution(metrics.AddMetricsContext(context.Background()), startRequest)
+
+	var expectedErr *serviceerror.ResourceExhausted
+	s.ErrorAs(err, &expectedErr)
+	s.Nil(resp)
+}
+
+func (s *engine2Suite) TestStartWorkflowExecution_Dedup_Running_SameRequestID() {
+	// no error when request ID is the same
+	s.setupStartWorkflowExecutionForRunning()
+	startRequest := makeMockStartRequest(s.tv, enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED, enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING)
+	startRequest.StartRequest.RequestId = s.tv.String("PrevRequestID")
+
+	resp, err := s.historyEngine.StartWorkflowExecution(metrics.AddMetricsContext(context.Background()), startRequest)
+
+	s.NoError(err)
+	s.True(resp.Started)
+	s.Equal(s.tv.RunID(), resp.GetRunId())
+}
+
+func (s *engine2Suite) TestStartWorkflowExecution_Dedup_Running_PolicyFail() {
+	// error when id conflict policy is POLICY_FAIL
+	s.setupStartWorkflowExecutionForRunning()
+
+	startRequest := makeMockStartRequest(s.tv, enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED, enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL)
+
+	resp, err := s.historyEngine.StartWorkflowExecution(metrics.AddMetricsContext(context.Background()), startRequest)
+
+	var expectedErr *serviceerror.WorkflowExecutionAlreadyStarted
+	s.ErrorAs(err, &expectedErr)
+	s.Nil(resp)
+}
+
+func (s *engine2Suite) TestStartWorkflowExecution_Dedup_Running_UseExisting() {
+	// ignore error when id conflict policy is USE_EXISTING
+	s.setupStartWorkflowExecutionForRunning()
+
+	startRequest := makeMockStartRequest(s.tv, enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE, enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING)
+
+	resp, err := s.historyEngine.StartWorkflowExecution(metrics.AddMetricsContext(context.Background()), startRequest)
+
+	s.NoError(err)
+	s.False(resp.Started)
+	s.Equal(s.tv.RunID(), resp.GetRunId())
+}
+
+func (s *engine2Suite) TestStartWorkflowExecution_Terminate_Running() {
+	s.setupStartWorkflowExecutionForTerminate()
+
+	startRequest := makeMockStartRequest(s.tv, enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING, enumspb.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED)
+
+	resp, err := s.historyEngine.StartWorkflowExecution(metrics.AddMetricsContext(context.Background()), startRequest)
+
+	s.NoError(err)
+	s.True(resp.Started)
+	s.NotEqual(s.tv.RunID(), resp.GetRunId())
+}
+
+func (s *engine2Suite) TestStartWorkflowExecution_Terminate_Existing() {
+	s.setupStartWorkflowExecutionForTerminate()
+
+	startRequest := makeMockStartRequest(s.tv, enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED, enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING)
+
+	resp, err := s.historyEngine.StartWorkflowExecution(metrics.AddMetricsContext(context.Background()), startRequest)
+
+	s.NoError(err)
+	s.True(resp.Started)
+	s.NotEqual(s.tv.RunID(), resp.GetRunId())
+}
+
 func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 	namespaceID := tests.NamespaceID
 	workflowID := "workflowID"
@@ -1279,130 +1454,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 	now := s.historyEngine.shardContext.GetTimeSource().Now()
 	ms := workflow.TestGlobalMutableState(s.historyEngine.shardContext, s.mockEventsCache, log.NewTestLogger(), tests.Version, workflowID, prevRunID)
 	ms.GetExecutionInfo().VersionHistories.Histories[0].Items = []*historyspb.VersionHistoryItem{{Version: 0, EventId: 0}}
-	ms.GetExecutionInfo().StartTime = timestamppb.New(now.Add(-2 * time.Second))
-
-	s.Run("when workflow is running", func() {
-		makeCurrentWorkflowConditionFailedError := func(
-			requestID string,
-		) *persistence.CurrentWorkflowConditionFailedError {
-			return &persistence.CurrentWorkflowConditionFailedError{
-				Msg:              "random message",
-				RequestID:        requestID,
-				RunID:            prevRunID,
-				State:            enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
-				Status:           enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-				LastWriteVersion: lastWriteVersion,
-			}
-		}
-
-		s.Run("ignore error when request ID is the same", func() {
-			s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).
-				Return(nil, makeCurrentWorkflowConditionFailedError(requestID)) // *same* request ID!
-
-			resp, err := s.historyEngine.StartWorkflowExecution(
-				metrics.AddMetricsContext(context.Background()),
-				makeStartRequest(enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED, enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL))
-
-			s.NoError(err)
-			s.True(resp.Started)
-			s.Equal(prevRunID, resp.GetRunId())
-		})
-
-		s.Run("return error when id conflict policy is POLICY_FAIL", func() {
-			s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).
-				Return(nil, makeCurrentWorkflowConditionFailedError(prevRequestID))
-
-			s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
-				Return(&persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}, nil)
-
-			resp, err := s.historyEngine.StartWorkflowExecution(
-				metrics.AddMetricsContext(context.Background()),
-				makeStartRequest(enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED, enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL))
-
-			var expectedErr *serviceerror.WorkflowExecutionAlreadyStarted
-			s.ErrorAs(err, &expectedErr)
-			s.Nil(resp)
-		})
-
-		s.Run("return error when id reuse policy is TERMINATE_IF_RUNNING but called too soon", func() {
-			s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).
-				Return(nil, makeCurrentWorkflowConditionFailedError(prevRequestID))
-
-			subtest_now := s.historyEngine.shardContext.GetTimeSource().Now()
-			ms.GetExecutionInfo().StartTime = timestamppb.New(subtest_now)
-			s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
-				Return(&persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}, nil)
-
-			resp, err := s.historyEngine.StartWorkflowExecution(
-				metrics.AddMetricsContext(context.Background()),
-				makeStartRequest(enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED, enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING))
-			var expectedErr *serviceerror.ResourceExhausted
-			s.ErrorAs(err, &expectedErr)
-			s.Nil(resp)
-		})
-
-		s.Run("ignore error when id conflict policy is USE_EXISTING", func() {
-			s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).
-				Return(nil, makeCurrentWorkflowConditionFailedError(prevRequestID))
-
-			s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
-				Return(&persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}, nil)
-
-			resp, err := s.historyEngine.StartWorkflowExecution(
-				metrics.AddMetricsContext(context.Background()),
-				makeStartRequest(enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE, enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING))
-
-			s.NoError(err)
-			s.False(resp.Started)
-			s.Equal(prevRunID, resp.GetRunId())
-		})
-
-		s.Run("terminate workflow when", func() {
-			expectWorkflowTerminate := func() {
-				failedError := makeCurrentWorkflowConditionFailedError(prevRequestID)
-				failedError.RunID = uuid.New()
-				s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).
-					Return(nil, failedError)
-				ms.GetExecutionInfo().StartTime = timestamppb.New(now.Add(-2 * time.Second))
-				s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(&persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}, nil)
-				s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(
-					gomock.Any(),
-					mock.MatchedBy(func(req *persistence.UpdateWorkflowExecutionRequest) bool {
-						return req.UpdateWorkflowMutation.ExecutionState.Status == enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED
-					}),
-				).Return(&persistence.UpdateWorkflowExecutionResponse{
-					UpdateMutableStateStats: persistence.MutableStateStatistics{
-						HistoryStatistics: &persistence.HistoryStatistics{SizeDiff: 1},
-					},
-				}, nil)
-			}
-
-			s.Run("id conflict policy is TERMINATE_EXISTING", func() {
-				expectWorkflowTerminate()
-
-				resp, err := s.historyEngine.StartWorkflowExecution(
-					metrics.AddMetricsContext(context.Background()),
-					makeStartRequest(enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED, enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING))
-
-				s.NoError(err)
-				s.True(resp.Started)
-				s.NotEqual(prevRunID, resp.GetRunId())
-			})
-
-			s.Run("id reuse policy is TERMINATE_IF_RUNNING", func() {
-				expectWorkflowTerminate()
-
-				resp, err := s.historyEngine.StartWorkflowExecution(
-					metrics.AddMetricsContext(context.Background()),
-					makeStartRequest(enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING, enumspb.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED))
-
-				s.NoError(err)
-				s.True(resp.Started)
-				s.NotEqual(prevRunID, resp.GetRunId())
-			})
-		})
-	})
+	ms.GetExecutionState().StartTime = timestamppb.New(now.Add(-2 * time.Second))
 
 	s.Run("when workflow completed", func() {
 		makeCurrentWorkflowConditionFailedError := func(
@@ -1437,14 +1489,12 @@ func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 		})
 
 		s.Run("with success", func() {
+
 			s.Run("and id reuse policy is ALLOW_DUPLICATE", func() {
 				s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).
 					Return(nil, makeCurrentWorkflowConditionFailedError(prevRequestID))
 				s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), updateExecutionRequest).
 					Return(tests.CreateWorkflowExecutionResponse, nil)
-
-				s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(&persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}, nil)
 
 				resp, err := s.historyEngine.StartWorkflowExecution(
 					metrics.AddMetricsContext(context.Background()),
@@ -1460,8 +1510,6 @@ func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 					Return(nil, makeCurrentWorkflowConditionFailedError(prevRequestID))
 				s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), updateExecutionRequest).
 					Return(tests.CreateWorkflowExecutionResponse, nil)
-				s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(&persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}, nil)
 
 				resp, err := s.historyEngine.StartWorkflowExecution(
 					metrics.AddMetricsContext(context.Background()),
@@ -1475,8 +1523,6 @@ func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 			s.Run("and id reuse policy ALLOW_DUPLICATE_FAILED_ONLY", func() {
 				s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).
 					Return(nil, makeCurrentWorkflowConditionFailedError(prevRequestID))
-				s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(&persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}, nil)
 
 				resp, err := s.historyEngine.StartWorkflowExecution(
 					metrics.AddMetricsContext(context.Background()),
@@ -1490,8 +1536,6 @@ func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 			s.Run("and id reuse policy REJECT_DUPLICATE", func() {
 				s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).
 					Return(nil, makeCurrentWorkflowConditionFailedError(prevRequestID))
-				s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
-					Return(&persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}, nil)
 
 				resp, err := s.historyEngine.StartWorkflowExecution(
 					metrics.AddMetricsContext(context.Background()),
@@ -1530,9 +1574,6 @@ func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 						s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).
 							Return(nil, makeCurrentWorkflowConditionFailedError(prevRequestID))
 
-						s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
-							Return(&persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}, nil)
-
 						resp, err := s.historyEngine.StartWorkflowExecution(
 							metrics.AddMetricsContext(context.Background()),
 							makeStartRequest(enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE, enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL))
@@ -1547,8 +1588,6 @@ func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 							Return(nil, makeCurrentWorkflowConditionFailedError(prevRequestID))
 						s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), updateExecutionRequest).
 							Return(tests.CreateWorkflowExecutionResponse, nil)
-						s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
-							Return(&persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}, nil)
 
 						resp, err := s.historyEngine.StartWorkflowExecution(
 							metrics.AddMetricsContext(context.Background()),
@@ -1562,8 +1601,6 @@ func (s *engine2Suite) TestStartWorkflowExecution_Dedup() {
 					s.Run("and id reuse policy REJECT_DUPLICATE", func() {
 						s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).
 							Return(nil, makeCurrentWorkflowConditionFailedError(prevRequestID))
-						s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
-							Return(&persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}, nil)
 
 						resp, err := s.historyEngine.StartWorkflowExecution(
 							metrics.AddMetricsContext(context.Background()),

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -98,7 +98,7 @@ const (
 )
 
 // Scheduled tasks with timestamp after this will not be created.
-// Those tasks are too far in the future and pratically never fire and just consume storage space.
+// Those tasks are too far in the future and practically never fire and just consume storage space.
 // NOTE: this value is less than timer.MaxAllowedTimer so that no capped timers will be created.
 var maxScheduledTaskDuration = time.Hour * 24 * 365 * 99
 
@@ -349,10 +349,7 @@ func NewMutableStateFromDB(
 	dbRecord *persistencespb.WorkflowMutableState,
 	dbRecordVersion int64,
 ) (*MutableStateImpl, error) {
-	startTime := time.Time{}
-	if dbRecord.ExecutionState.StartTime != nil {
-		startTime = dbRecord.ExecutionState.StartTime.AsTime()
-	}
+	startTime := timestamp.TimeValue(dbRecord.ExecutionState.StartTime)
 	mutableState := NewMutableState(
 		shard,
 		eventsCache,

--- a/tests/admin.go
+++ b/tests/admin.go
@@ -34,6 +34,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/primitives/timestamp"
 )
 
 func (s *ClientFunctionalSuite) TestAdminRebuildMutableState() {
@@ -117,4 +118,12 @@ func (s *ClientFunctionalSuite) TestAdminRebuildMutableState() {
 	s.Equal(response1.DatabaseMutableState.ExecutionState.State, response2.DatabaseMutableState.ExecutionState.State)
 	s.Equal(response1.DatabaseMutableState.ExecutionState.Status, response2.DatabaseMutableState.ExecutionState.Status)
 	s.Equal(response1.DatabaseMutableState.ExecutionState.LastUpdateVersionedTransition, response2.DatabaseMutableState.ExecutionState.LastUpdateVersionedTransition)
+
+	s.NotNil(response1.DatabaseMutableState.ExecutionState.StartTime)
+	s.NotNil(response2.DatabaseMutableState.ExecutionState.StartTime)
+
+	timeBefore := timestamp.TimeValue(response1.DatabaseMutableState.ExecutionState.StartTime)
+	timeAfter := timestamp.TimeValue(response2.DatabaseMutableState.ExecutionState.StartTime)
+
+	s.False(timeAfter.Before(timeBefore))
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
1. Populate StartTime filed when CurrentWorkflowConditionFailedError error happens
2. Use workflow start time from WorfklowExecutionState/CurrentWorkflowConditionFailedError (so avoid loading mutable state)
3. Add tests to verify that StartTime field in WorfklowExecutionState is populated
4. Refactor some dedup tests.
5. Mark StartTime in ExecutionInfo as deprecated.

## Why?
To allow blocking frequent restarts without loading mutable state (and thus without latency increase)

## How did you test it?
Add some unit tests, modify existing unit tests.


## Is hotfix candidate?
No
