### PR TITLE
Remove concept of concurrent HSM tasks

### DIFF
--- a/components/callbacks/tasks.go
+++ b/components/callbacks/tasks.go
@@ -25,6 +25,7 @@ package callbacks
 import (
 	"time"
 
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/service/history/hsm"
 )
 
@@ -57,8 +58,8 @@ func (t InvocationTask) Deadline() time.Time {
 	return hsm.Immediate
 }
 
-func (InvocationTask) Concurrent() bool {
-	return false
+func (InvocationTask) Validate(ref *persistencespb.StateMachineRef, node *hsm.Node) error {
+	return hsm.ValidateNotTransitioned(ref, node)
 }
 
 type InvocationTaskSerializer struct{}
@@ -81,16 +82,16 @@ func (BackoffTask) Type() string {
 	return TaskTypeBackoff
 }
 
-func (BackoffTask) Concurrent() bool {
-	return false
-}
-
 func (t BackoffTask) Deadline() time.Time {
 	return t.deadline
 }
 
 func (BackoffTask) Destination() string {
 	return ""
+}
+
+func (BackoffTask) Validate(ref *persistencespb.StateMachineRef, node *hsm.Node) error {
+	return hsm.ValidateNotTransitioned(ref, node)
 }
 
 type BackoffTaskSerializer struct{}

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -40,7 +40,6 @@ import (
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/api/token/v1"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -117,7 +116,7 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 		return fmt.Errorf("failed to get namespace by ID: %w", err)
 	}
 
-	args, err := e.loadOperationArgs(ctx, ns, env, ref, task)
+	args, err := e.loadOperationArgs(ctx, ns, env, ref)
 	if err != nil {
 		return fmt.Errorf("failed to load operation args: %w", err)
 	}
@@ -187,18 +186,11 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 		return fmt.Errorf("failed to get a client: %w", err)
 	}
 
-	smRef := common.CloneProto(ref.StateMachineRef)
-	// Unset the machine last update versioned transition so it is ignored in the completion staleness check.
-	// This is to account for either the operation transitioning to STARTED state after a successful call but also to
-	// account for the task timing out before we get a successful result and a transition to BACKING_OFF.
-	smRef.MachineLastUpdateVersionedTransition = nil
-	smRef.MachineTransitionCount = 0
-
 	token, err := e.CallbackTokenGenerator.Tokenize(&token.NexusOperationCompletion{
 		NamespaceId: ref.WorkflowKey.NamespaceID,
 		WorkflowId:  ref.WorkflowKey.WorkflowID,
 		RunId:       ref.WorkflowKey.RunID,
-		Ref:         smRef,
+		Ref:         ref.StateMachineRef,
 		RequestId:   args.requestID,
 	})
 	if err != nil {
@@ -286,13 +278,9 @@ func (e taskExecutor) loadOperationArgs(
 	ns *namespace.Namespace,
 	env hsm.Environment,
 	ref hsm.Ref,
-	task InvocationTask,
 ) (args startArgs, err error) {
 	var eventToken []byte
 	err = env.Access(ctx, ref, hsm.AccessRead, func(node *hsm.Node) error {
-		if err := task.Validate(node); err != nil {
-			return err
-		}
 		operation, err := hsm.MachineData[Operation](node)
 		if err != nil {
 			return err
@@ -334,9 +322,6 @@ func (e taskExecutor) loadOperationArgs(
 
 func (e taskExecutor) saveResult(ctx context.Context, env hsm.Environment, ref hsm.Ref, result *nexus.ClientStartOperationResult[*commonpb.Payload], callErr error) error {
 	return env.Access(ctx, ref, hsm.AccessWrite, func(node *hsm.Node) error {
-		if err := node.CheckRunning(); err != nil {
-			return err
-		}
 		return hsm.MachineTransition(node, func(operation Operation) (hsm.TransitionOutput, error) {
 			if callErr != nil {
 				return e.handleStartOperationError(env, node, operation, callErr)
@@ -458,9 +443,6 @@ func handleNonRetryableStartOperationError(env hsm.Environment, node *hsm.Node, 
 }
 
 func (e taskExecutor) executeBackoffTask(env hsm.Environment, node *hsm.Node, task BackoffTask) error {
-	if err := task.Validate(node); err != nil {
-		return err
-	}
 	return hsm.MachineTransition(node, func(op Operation) (hsm.TransitionOutput, error) {
 		return TransitionRescheduled.Apply(op, EventRescheduled{
 			Node: node,
@@ -469,9 +451,6 @@ func (e taskExecutor) executeBackoffTask(env hsm.Environment, node *hsm.Node, ta
 }
 
 func (e taskExecutor) executeTimeoutTask(env hsm.Environment, node *hsm.Node, task TimeoutTask) error {
-	if err := task.Validate(node); err != nil {
-		return err
-	}
 	return hsm.MachineTransition(node, func(op Operation) (hsm.TransitionOutput, error) {
 		eventID, err := hsm.EventIDFromToken(op.ScheduledEventToken)
 		if err != nil {
@@ -582,9 +561,6 @@ type cancelArgs struct {
 // given reference is pointing to.
 func (e taskExecutor) loadArgsForCancelation(ctx context.Context, env hsm.Environment, ref hsm.Ref) (args cancelArgs, err error) {
 	err = env.Access(ctx, ref, hsm.AccessRead, func(n *hsm.Node) error {
-		if err := n.CheckRunning(); err != nil {
-			return err
-		}
 		op, err := hsm.MachineData[Operation](n.Parent)
 		if err != nil {
 			return err
@@ -606,9 +582,6 @@ func (e taskExecutor) loadArgsForCancelation(ctx context.Context, env hsm.Enviro
 
 func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environment, ref hsm.Ref, callErr error) error {
 	return env.Access(ctx, ref, hsm.AccessWrite, func(n *hsm.Node) error {
-		if err := n.CheckRunning(); err != nil {
-			return err
-		}
 		return hsm.MachineTransition(n, func(c Cancelation) (hsm.TransitionOutput, error) {
 			if callErr != nil {
 				var unexpectedResponseErr *nexus.UnexpectedResponseError
@@ -640,26 +613,11 @@ func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environ
 }
 
 func (e taskExecutor) executeCancelationBackoffTask(env hsm.Environment, node *hsm.Node, task CancelationBackoffTask) error {
-	if err := node.CheckRunning(); err != nil {
-		return err
-	}
 	return hsm.MachineTransition(node, func(c Cancelation) (hsm.TransitionOutput, error) {
 		return TransitionCancelationRescheduled.Apply(c, EventCancelationRescheduled{
 			Node: node,
 		})
 	})
-}
-
-func (e taskExecutor) extractEndpointNameFromOperation(ctx context.Context, env hsm.Environment, ref hsm.Ref, getOpNode func(*hsm.Node) *hsm.Node) (endpoint string, err error) {
-	err = env.Access(ctx, ref, hsm.AccessRead, func(n *hsm.Node) error {
-		op, err := hsm.MachineData[Operation](getOpNode(n))
-		if err != nil {
-			return err
-		}
-		endpoint = op.Endpoint
-		return nil
-	})
-	return
 }
 
 // lookupEndpint gets an endpoint from the registry, preferring to look up by ID and falling back to name lookup.

--- a/components/scheduler/executors.go
+++ b/components/scheduler/executors.go
@@ -109,9 +109,6 @@ func (e taskExecutor) executeSchedulerWaitTask(
 	node *hsm.Node,
 	task SchedulerWaitTask,
 ) error {
-	if err := node.CheckRunning(); err != nil {
-		return err
-	}
 	return hsm.MachineTransition(node, func(scheduler *Scheduler) (hsm.TransitionOutput, error) {
 		return TransitionSchedulerActivate.Apply(scheduler, EventSchedulerActivate{})
 	})
@@ -160,9 +157,6 @@ func (e taskExecutor) executeSchedulerRunTask(
 	var prevArgs *schedspb.HsmSchedulerState
 	var prevRunningWorkflows []*commonpb.WorkflowExecution
 	err = env.Access(ctx, ref, hsm.AccessRead, func(node *hsm.Node) error {
-		if err := node.CheckRunning(); err != nil {
-			return err
-		}
 		prevS, err := hsm.MachineData[*Scheduler](node)
 		if err != nil {
 			return err

--- a/components/scheduler/tasks.go
+++ b/components/scheduler/tasks.go
@@ -25,6 +25,7 @@ package scheduler
 import (
 	"time"
 
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/service/history/hsm"
 )
 
@@ -51,8 +52,12 @@ func (SchedulerWaitTask) Destination() string {
 	return ""
 }
 
-func (SchedulerWaitTask) Concurrent() bool {
-	return false
+func (SchedulerWaitTask) Validate(ref *persistencespb.StateMachineRef, node *hsm.Node) error {
+	// TODO: We should allow an RPC to transition the machine.
+	if err := hsm.ValidateNotTransitioned(ref, node); err != nil {
+		return err
+	}
+	return node.CheckRunning()
 }
 
 type ScheduleWaitTaskSerializer struct{}
@@ -81,8 +86,12 @@ func (t SchedulerActivateTask) Destination() string {
 	return "TODO(bergundy): make this an empty string when we support transfer tasks"
 }
 
-func (SchedulerActivateTask) Concurrent() bool {
-	return false
+func (SchedulerActivateTask) Validate(ref *persistencespb.StateMachineRef, node *hsm.Node) error {
+	// TODO: We should allow an RPC to transition the machine.
+	if err := hsm.ValidateNotTransitioned(ref, node); err != nil {
+		return err
+	}
+	return node.CheckRunning()
 }
 
 type ScheduleExecuteTaskSerializer struct{}

--- a/service/history/hsm/executor.go
+++ b/service/history/hsm/executor.go
@@ -40,6 +40,10 @@ type Ref struct {
 	// serves as an indicator whether this Ref can reference stale state. This should be set during task processing
 	// where we can validate the task that embeds this reference against shard clock.
 	TaskID int64
+
+	// An optional function to validate the ref is not stale.
+	// For tasks, this is copied from the task's Validate() implementation.
+	Validate func(ref *persistencespb.StateMachineRef, node *Node) error
 }
 
 // StateMachinePath gets the state machine path for from this reference.

--- a/service/history/hsm/hsmtest/task.go
+++ b/service/history/hsm/hsmtest/task.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"time"
 
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/service/history/hsm"
 )
 
@@ -63,8 +64,11 @@ func (t *Task) Destination() string {
 	return t.attrs.Destination
 }
 
-func (t *Task) Concurrent() bool {
-	return t.IsConcurrent
+func (t *Task) Validate(ref *persistencespb.StateMachineRef, node *hsm.Node) error {
+	if t.IsConcurrent {
+		return hsm.ValidateNotTransitioned(ref, node)
+	}
+	return nil
 }
 
 type TaskSerializer struct{}

--- a/service/history/hsm/registry.go
+++ b/service/history/hsm/registry.go
@@ -34,10 +34,6 @@ import (
 // ErrDuplicateRegistration is returned by a [Registry] when it detects duplicate registration.
 var ErrDuplicateRegistration = errors.New("duplicate registration")
 
-// ErrConcurrentTaskNotImplemented is returned by a [Registry] when trying to register a
-// concurrent task that did not implement the [ConcurrentTask] interface.
-var ErrConcurrentTaskNotImplemented = errors.New("concurrent task not implemented")
-
 // ErrNotRegistered is returned by a [Registry] when trying to get a type that is not registered.
 var ErrNotRegistered error = notRegisteredError{"not registered"}
 
@@ -130,16 +126,6 @@ func RegisterImmediateExecutor[T Task](r *Registry, executor ImmediateExecutor[T
 			existing,
 		)
 	}
-	// TODO(bergundy): Concurrent may be dependent on the task's state, this solution isn't failsafe.
-	if task.Concurrent() {
-		if _, ok := Task(task).(ConcurrentTask); !ok {
-			return fmt.Errorf(
-				"%w: %q does not implement ConcurrentTask interface",
-				ErrConcurrentTaskNotImplemented,
-				taskType,
-			)
-		}
-	}
 	r.immediateExecutors[taskType] = executor
 	return nil
 }
@@ -177,15 +163,6 @@ func RegisterTimerExecutor[T Task](r *Registry, executor TimerExecutor[T]) error
 			taskType,
 			existing,
 		)
-	}
-	if task.Concurrent() {
-		if _, ok := Task(task).(ConcurrentTask); !ok {
-			return fmt.Errorf(
-				"%w: concurrent task type %q does not implement ConcurrentTask interface",
-				ErrConcurrentTaskNotImplemented,
-				taskType,
-			)
-		}
 	}
 	r.timerExecutors[taskType] = executor
 	return nil

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -360,6 +360,7 @@ func stateMachineTask(shardContext shard.Context, task tasks.Task) (hsm.Ref, hsm
 		WorkflowKey:     taskWorkflowKey(task),
 		StateMachineRef: cbt.Info.Ref,
 		TaskID:          task.GetTaskID(),
+		Validate:        smt.Validate,
 	}, smt, nil
 }
 

--- a/service/history/outbound_queue_standby_task_executor.go
+++ b/service/history/outbound_queue_standby_task_executor.go
@@ -120,12 +120,7 @@ func (e *outboundQueueStandbyTaskExecutor) processTask(
 	}
 
 	err = e.Access(ctx, ref, hsm.AccessRead, func(node *hsm.Node) error {
-		if smt.Concurrent() {
-			//nolint:revive // concurrent tasks implements hsm.ConcurrentTask interface
-			concurrentSmt := smt.(hsm.ConcurrentTask)
-			return concurrentSmt.Validate(node)
-		}
-		return nil
+		return smt.Validate(ref.StateMachineRef, node)
 	})
 
 	if err != nil {

--- a/service/history/outbound_queue_standby_task_executor.go
+++ b/service/history/outbound_queue_standby_task_executor.go
@@ -114,13 +114,15 @@ func (e *outboundQueueStandbyTaskExecutor) processTask(
 		return err
 	}
 
-	ref, smt, err := stateMachineTask(e.shardContext, task)
+	ref, _, err := stateMachineTask(e.shardContext, task)
 	if err != nil {
 		return err
 	}
 
 	err = e.Access(ctx, ref, hsm.AccessRead, func(node *hsm.Node) error {
-		return smt.Validate(ref.StateMachineRef, node)
+		// If we managed to access the machine the task is still valid.
+		// The logic below will either discard it or retry.
+		return nil
 	})
 
 	if err != nil {

--- a/service/history/statemachine_environment.go
+++ b/service/history/statemachine_environment.go
@@ -356,6 +356,10 @@ func (e *stateMachineEnvironment) validateNotZombieWorkflow(
 func (e *stateMachineEnvironment) Access(ctx context.Context, ref hsm.Ref, accessType hsm.AccessType, accessor func(*hsm.Node) error) (retErr error) {
 	wfCtx, release, ms, err := e.getValidatedMutableState(
 		ctx, ref.WorkflowKey, func(workflowContext workflow.Context, ms workflow.MutableState, potentialStaleState bool) error {
+			// For task references we never want to access a zombie workflow, even if the machine is accessed for read.
+			if ref.TaskID != 0 {
+				accessType = hsm.AccessWrite
+			}
 			if err := e.validateNotZombieWorkflow(ms, accessType); err != nil {
 				return err
 			}

--- a/service/history/statemachine_environment_test.go
+++ b/service/history/statemachine_environment_test.go
@@ -241,21 +241,6 @@ func TestValidateStateMachineRef(t *testing.T) {
 			},
 		},
 		{
-			name:                    "WithTransitionHistory/MachineLastUpdateTransitionInequality",
-			enableTransitionHistory: true,
-			mutateRef: func(ref *hsm.Ref) {
-				machineLastUpdateVersionedTransition := ref.StateMachineRef.MachineLastUpdateVersionedTransition
-				ref.StateMachineRef.MachineLastUpdateVersionedTransition = &persistencespb.VersionedTransition{
-					NamespaceFailoverVersion: machineLastUpdateVersionedTransition.NamespaceFailoverVersion,
-					TransitionCount:          machineLastUpdateVersionedTransition.TransitionCount + 1,
-				}
-			},
-			mutateNode: func(node *hsm.Node) {},
-			assertOutcome: func(t *testing.T, err error) {
-				require.ErrorIs(t, err, consts.ErrStaleReference)
-			},
-		},
-		{
 			name:                    "WithoutTransitionHistory/MachineTransitionInequality",
 			enableTransitionHistory: false,
 			mutateRef: func(ref *hsm.Ref) {
@@ -339,11 +324,8 @@ func TestValidateStateMachineRef(t *testing.T) {
 				logger:         s.mockShard.GetLogger(),
 			}
 
-			cbt := task.(*tasks.StateMachineOutboundTask)
-			ref := hsm.Ref{
-				WorkflowKey:     taskWorkflowKey(task),
-				StateMachineRef: cbt.Info.Ref,
-			}
+			ref, _, err := stateMachineTask(s.mockShard, task)
+			require.NoError(t, err)
 			node, err := mutableState.HSM().Child(ref.StateMachinePath())
 			require.NoError(t, err)
 			tc.mutateNode(node)
@@ -459,11 +441,8 @@ func TestAccess(t *testing.T) {
 			}
 
 			task := snapshot.Tasks[tasks.CategoryOutbound][0]
-			cbt := task.(*tasks.StateMachineOutboundTask)
-			ref := hsm.Ref{
-				WorkflowKey:     taskWorkflowKey(task),
-				StateMachineRef: cbt.Info.Ref,
-			}
+			ref, _, err := stateMachineTask(s.mockShard, task)
+			require.NoError(t, err)
 			err = exec.Access(context.Background(), ref, tc.accessType, tc.accessor)
 			tc.assertOutcome(t, err)
 		})

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -520,15 +520,9 @@ func (t *timerQueueStandbyTaskExecutor) executeStateMachineTimerTask(
 			wfContext,
 			mutableState,
 			func(node *hsm.Node, task hsm.Task) error {
-				if task.Concurrent() {
-					//nolint:revive // concurrent tasks implements hsm.ConcurrentTask interface
-					concurrentTask := task.(hsm.ConcurrentTask)
-					if err := concurrentTask.Validate(node); err != nil {
-						return err
-					}
-				}
-				// If the timer fired and the task is still valid in the standby queue, wait for the active cluster to
-				// transition and invalidate the task.
+				// If this line of code is reached, the task's Validate() function returned no error, which indicates
+				// that it is still expected to run. Return ErrTaskRetry to wait the machine to transition on the active
+				// cluster.
 				return consts.ErrTaskRetry
 			},
 		)

--- a/service/history/timer_queue_standby_task_executor_test.go
+++ b/service/history/timer_queue_standby_task_executor_test.go
@@ -1819,7 +1819,6 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestExecuteStateMachineTimerTask_Va
 			},
 		},
 		Type: dummy.TaskTypeTimer,
-		Data: []byte{1}, // Mark the task as concurrent
 	})
 
 	wfCtx := workflow.NewMockContext(s.controller)

--- a/service/history/timer_queue_task_executor_base.go
+++ b/service/history/timer_queue_task_executor_base.go
@@ -247,7 +247,8 @@ func (t *timerQueueTaskExecutorBase) executeSingleStateMachineTimer(
 		StateMachineRef: timer.Ref,
 		Validate:        smt.Validate,
 	}
-	// TODO(bergundy): I think we never want to execute tasks on zombie workflows, not sure why we check write access.
+	// TODO(bergundy): Duplicated this logic from the Access method. We specify write access here because
+	// validateNotZombieWorkflow only blocks write access to zombie workflows.
 	if err := t.validateNotZombieWorkflow(ms, hsm.AccessWrite); err != nil {
 		return err
 	}
@@ -283,6 +284,7 @@ func (t *timerQueueTaskExecutorBase) executeStateMachineTimers(
 
 	timers := ms.GetExecutionInfo().StateMachineTimers
 	processedTimers := 0
+
 	// StateMachineTimers are sorted by Deadline, iterate through them as long as the deadline is expired.
 	for len(timers) > 0 {
 		group := timers[0]

--- a/service/history/workflow/task_generator_test.go
+++ b/service/history/workflow/task_generator_test.go
@@ -476,7 +476,7 @@ func TestTaskGenerator_GenerateDirtySubStateMachineTasks(t *testing.T) {
 		},
 	}, timers[0])
 
-	// Reset and test a concurrent task (nexusoperations.TimeoutTask)
+	// Reset and test another timer task (nexusoperations.TimeoutTask)
 	node.ClearTransactionState()
 	genTasks = nil
 	opNode, err := nexusoperations.AddChild(node, "ID", &historypb.HistoryEvent{
@@ -520,8 +520,11 @@ func TestTaskGenerator_GenerateDirtySubStateMachineTasks(t *testing.T) {
 				NamespaceFailoverVersion: 3,
 				TransitionCount:          3,
 			},
-			MachineLastUpdateVersionedTransition: nil,
-			MachineTransitionCount:               0, // concurrent tasks don't store the machine transition count.
+			MachineLastUpdateVersionedTransition: &persistencespb.VersionedTransition{
+				NamespaceFailoverVersion: 3,
+				TransitionCount:          3,
+			},
+			MachineTransitionCount: 1,
 		},
 		Type: nexusoperations.TaskTypeTimeout,
 		Data: nil,


### PR DESCRIPTION
## What changed?

Remove the `Concurrent` method from the `hsm.Task` interface in favor of a `Validate` function for every task.

## Why?

After gaining experience with the framework and internal discussions, we decided this approach is easier to grasp and makes eliminates the need to sanitize fields from the task when generating refs for RPCs.

## How did you test it?

Existing tests.