### PR TITLE
Source cluster mutable state sanitization

### DIFF
--- a/service/history/replication/raw_task_converter_test.go
+++ b/service/history/replication/raw_task_converter_test.go
@@ -558,7 +558,8 @@ func (s *rawTaskConverterSuite) TestConvertWorkflowStateReplicationTask_Workflow
 	s.NoError(err)
 
 	sanitizedMutableState := s.mutableState.CloneToProto()
-	workflow.SanitizeMutableState(sanitizedMutableState)
+	err = workflow.SanitizeMutableState(sanitizedMutableState)
+	s.NoError(err)
 	s.ProtoEqual(&replicationspb.ReplicationTask{
 		TaskType:     enumsspb.REPLICATION_TASK_TYPE_SYNC_WORKFLOW_STATE_TASK,
 		SourceTaskId: task.TaskID,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -463,37 +463,20 @@ func NewSanitizedMutableState(
 	lastFirstEventTxnID int64,
 	lastWriteVersion int64,
 ) (*MutableStateImpl, error) {
+	// TODO:  The source cluster will perform the sanitization starting from 1.25 release.
+	// Remove the sanitization here in 1.26 release.
+	if err := SanitizeMutableState(mutableStateRecord); err != nil {
+		return nil, err
+	}
+
 	mutableState, err := NewMutableStateFromDB(shard, eventsCache, logger, namespaceEntry, mutableStateRecord, 1)
 	if err != nil {
 		return nil, err
 	}
 
-	// sanitize data
-	// Some values stored in mutable state are cluster or shard specific.
-	// E.g task status (if task is created or not), taskID (derived from shard rangeID), txnID (derived from shard rangeID), etc.
-	// Those fields should not be replicated across clusters and should be sanitized.
-	mutableState.executionInfo.WorkflowExecutionTimerTaskStatus = TimerTaskStatusNone
 	mutableState.executionInfo.LastFirstEventTxnId = lastFirstEventTxnID
-	mutableState.executionInfo.CloseVisibilityTaskId = common.EmptyVersion
-	mutableState.executionInfo.CloseTransferTaskId = common.EmptyVersion
-	// TODO: after adding cluster to clock info, no need to reset clock here
-	mutableState.executionInfo.ParentClock = nil
-	for _, childExecutionInfo := range mutableState.pendingChildExecutionInfoIDs {
-		childExecutionInfo.Clock = nil
-	}
-	// Timer tasks are generated locally, do not sync them.
-	mutableState.executionInfo.StateMachineTimers = nil
-	mutableState.executionInfo.TaskGenerationShardClockTimestamp = 0
-	if err := mutableState.HSM().Walk(func(node *hsm.Node) error {
-		// Node TransitionCount is cluster local information used for detecting staleness.
-		// Reset it to 1 since we are creating a new mutable state.
-		node.InternalRepr().TransitionCount = 1
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-
 	mutableState.currentVersion = lastWriteVersion
+
 	return mutableState, nil
 }
 

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -836,7 +836,9 @@ func (s *mutableStateSuite) TestSanitizedMutableState() {
 	s.Equal(int32(TimerTaskStatusNone), sanitizedMutableState.executionInfo.WorkflowExecutionTimerTaskStatus)
 	s.Zero(sanitizedMutableState.executionInfo.TaskGenerationShardClockTimestamp)
 	err = sanitizedMutableState.HSM().Walk(func(node *hsm.Node) error {
-		s.Equal(int64(1), node.InternalRepr().TransitionCount)
+		if node.Parent != nil {
+			s.Equal(int64(1), node.InternalRepr().TransitionCount)
+		}
 		return nil
 	})
 	s.NoError(err)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Perform mutable state sanitization in source cluster during replication, instead in the target cluster.

## Why?
<!-- Tell your future self why have you made these changes -->
- Any new, cluster specific fields added to mutable state can't be sanitized by the target cluster if target cluster is running an old version. But those unknown fields will still be persisted and decoded properly later when target cluster got upgraded. Then those new, cluster specific fields essentially bypassed sanitization and will cause bugs since the value is only valid within the cluster that generates the value. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
