### PR TITLE
Decrease Elasticsearch bulk processor write timeout to 15s

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2279,7 +2279,7 @@ See DynamicRateLimitingParams comments for more details.`,
 	)
 	WorkerESProcessorAckTimeout = NewGlobalDurationSetting(
 		"worker.ESProcessorAckTimeout",
-		30*time.Second,
+		15*time.Second,
 		`WorkerESProcessorAckTimeout is the timeout that store will wait to get ack signal from ES processor.
 Should be at least WorkerESProcessorFlushInterval+<time to process request>.`,
 	)

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -341,8 +341,8 @@ func (s *VisibilityStore) AddBulkRequestAndWait(
 	ackF := s.processor.Add(bulkRequest, visibilityTaskKey)
 
 	// processorAckTimeout is a maximum duration for bulk processor to commit the bulk and unblock the `ackF`.
-	// Default value is 30s and this timeout should never have happened,
-	// because Elasticsearch must process a bulk within 30s.
+	// Default value is 15s and this timeout should never have happened,
+	// because Elasticsearch must process a bulk within 15s.
 	// Parent context is not respected here because it has shorter timeout (3s),
 	// which might already expired here due to wait at Add method above.
 	ctx, cancel := context.WithTimeout(context.Background(), s.processorAckTimeout())


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Decrease Elasticsearch bulk processor write timeout from 30s to 15s.

## Why?
<!-- Tell your future self why have you made these changes -->
15 second should be enough to complete request and 30s is too high to detect transient gateway failures.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Didn't test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Long requests will start to time out earlier.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.