### PR TITLE
Remove gocql.Batch interface

### DIFF
--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -312,7 +312,7 @@ func (h *HistoryStore) DeleteHistoryBranch(
 }
 
 func (h *HistoryStore) deleteBranchRangeNodes(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	treeID string,
 	branchID string,
 	beginNodeID int64,

--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -312,7 +312,7 @@ func (h *HistoryStore) DeleteHistoryBranch(
 }
 
 func (h *HistoryStore) deleteBranchRangeNodes(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	treeID string,
 	branchID string,
 	beginNodeID int64,

--- a/common/persistence/cassandra/metadata_store.go
+++ b/common/persistence/cassandra/metadata_store.go
@@ -489,7 +489,7 @@ func (m *MetadataStore) GetMetadata(
 }
 
 func (m *MetadataStore) updateMetadataBatch(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	notificationVersion int64,
 ) {
 	var nextVersion int64 = 1

--- a/common/persistence/cassandra/metadata_store.go
+++ b/common/persistence/cassandra/metadata_store.go
@@ -489,7 +489,7 @@ func (m *MetadataStore) GetMetadata(
 }
 
 func (m *MetadataStore) updateMetadataBatch(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	notificationVersion int64,
 ) {
 	var nextVersion int64 = 1

--- a/common/persistence/cassandra/util.go
+++ b/common/persistence/cassandra/util.go
@@ -36,7 +36,7 @@ import (
 )
 
 func applyWorkflowMutationBatch(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	shardID int32,
 	workflowMutation *p.InternalWorkflowMutation,
 ) error {
@@ -154,7 +154,7 @@ func applyWorkflowMutationBatch(
 }
 
 func applyWorkflowSnapshotBatchAsReset(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	shardID int32,
 	workflowSnapshot *p.InternalWorkflowSnapshot,
 ) error {
@@ -264,7 +264,7 @@ func applyWorkflowSnapshotBatchAsReset(
 }
 
 func applyWorkflowSnapshotBatchAsNew(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	shardID int32,
 	workflowSnapshot *p.InternalWorkflowSnapshot,
 ) error {
@@ -359,7 +359,7 @@ func applyWorkflowSnapshotBatchAsNew(
 }
 
 func createExecution(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	shardID int32,
 	snapshot *p.InternalWorkflowSnapshot,
 ) error {
@@ -393,7 +393,7 @@ func createExecution(
 }
 
 func updateExecution(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	shardID int32,
 	namespaceID string,
 	workflowID string,
@@ -458,7 +458,7 @@ func updateExecution(
 }
 
 func applyTasks(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	shardID int32,
 	insertTasks map[tasks.Category][]p.InternalHistoryTask,
 ) error {
@@ -487,7 +487,7 @@ func applyTasks(
 }
 
 func createTransferTasks(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	transferTasks []p.InternalHistoryTask,
 	shardID int32,
 ) error {
@@ -508,7 +508,7 @@ func createTransferTasks(
 }
 
 func createTimerTasks(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	timerTasks []p.InternalHistoryTask,
 	shardID int32,
 ) error {
@@ -529,7 +529,7 @@ func createTimerTasks(
 }
 
 func createReplicationTasks(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	replicationTasks []p.InternalHistoryTask,
 	shardID int32,
 ) error {
@@ -550,7 +550,7 @@ func createReplicationTasks(
 }
 
 func createVisibilityTasks(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	visibilityTasks []p.InternalHistoryTask,
 	shardID int32,
 ) error {
@@ -571,7 +571,7 @@ func createVisibilityTasks(
 }
 
 func createHistoryTasks(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	category tasks.Category,
 	historyTasks []p.InternalHistoryTask,
 	shardID int32,
@@ -598,7 +598,7 @@ func createHistoryTasks(
 }
 
 func updateActivityInfos(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	activityInfos map[int64]*commonpb.DataBlob,
 	deleteIDs map[int64]struct{},
 	shardID int32,
@@ -636,7 +636,7 @@ func updateActivityInfos(
 }
 
 func deleteBufferedEvents(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	shardID int32,
 	namespaceID string,
 	workflowID string,
@@ -654,7 +654,7 @@ func deleteBufferedEvents(
 }
 
 func resetActivityInfos(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	activityInfos map[int64]*commonpb.DataBlob,
 	shardID int32,
 	namespaceID string,
@@ -681,7 +681,7 @@ func resetActivityInfos(
 }
 
 func updateTimerInfos(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	timerInfos map[string]*commonpb.DataBlob,
 	deleteInfos map[string]struct{},
 	shardID int32,
@@ -719,7 +719,7 @@ func updateTimerInfos(
 }
 
 func resetTimerInfos(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	timerInfos map[string]*commonpb.DataBlob,
 	shardID int32,
 	namespaceID string,
@@ -747,7 +747,7 @@ func resetTimerInfos(
 }
 
 func updateChildExecutionInfos(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	childExecutionInfos map[int64]*commonpb.DataBlob,
 	deleteIDs map[int64]struct{},
 	shardID int32,
@@ -785,7 +785,7 @@ func updateChildExecutionInfos(
 }
 
 func resetChildExecutionInfos(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	childExecutionInfos map[int64]*commonpb.DataBlob,
 	shardID int32,
 	namespaceID string,
@@ -811,7 +811,7 @@ func resetChildExecutionInfos(
 }
 
 func updateRequestCancelInfos(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	requestCancelInfos map[int64]*commonpb.DataBlob,
 	deleteIDs map[int64]struct{},
 	shardID int32,
@@ -849,7 +849,7 @@ func updateRequestCancelInfos(
 }
 
 func resetRequestCancelInfos(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	requestCancelInfos map[int64]*commonpb.DataBlob,
 	shardID int32,
 	namespaceID string,
@@ -878,7 +878,7 @@ func resetRequestCancelInfos(
 }
 
 func updateSignalInfos(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	signalInfos map[int64]*commonpb.DataBlob,
 	deleteIDs map[int64]struct{},
 	shardID int32,
@@ -916,7 +916,7 @@ func updateSignalInfos(
 }
 
 func resetSignalInfos(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	signalInfos map[int64]*commonpb.DataBlob,
 	shardID int32,
 	namespaceID string,
@@ -944,7 +944,7 @@ func resetSignalInfos(
 }
 
 func updateSignalsRequested(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	signalReqIDs map[string]struct{},
 	deleteSignalReqIDs map[string]struct{},
 	shardID int32,
@@ -979,7 +979,7 @@ func updateSignalsRequested(
 }
 
 func resetSignalRequested(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	signalRequested map[string]struct{},
 	shardID int32,
 	namespaceID string,
@@ -999,7 +999,7 @@ func resetSignalRequested(
 }
 
 func updateBufferedEvents(
-	batch gocql.Batch_Deprecated,
+	batch *gocql.Batch,
 	newBufferedEvents *commonpb.DataBlob,
 	clearBufferedEvents bool,
 	shardID int32,

--- a/common/persistence/cassandra/util.go
+++ b/common/persistence/cassandra/util.go
@@ -36,7 +36,7 @@ import (
 )
 
 func applyWorkflowMutationBatch(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	shardID int32,
 	workflowMutation *p.InternalWorkflowMutation,
 ) error {
@@ -154,7 +154,7 @@ func applyWorkflowMutationBatch(
 }
 
 func applyWorkflowSnapshotBatchAsReset(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	shardID int32,
 	workflowSnapshot *p.InternalWorkflowSnapshot,
 ) error {
@@ -264,7 +264,7 @@ func applyWorkflowSnapshotBatchAsReset(
 }
 
 func applyWorkflowSnapshotBatchAsNew(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	shardID int32,
 	workflowSnapshot *p.InternalWorkflowSnapshot,
 ) error {
@@ -359,7 +359,7 @@ func applyWorkflowSnapshotBatchAsNew(
 }
 
 func createExecution(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	shardID int32,
 	snapshot *p.InternalWorkflowSnapshot,
 ) error {
@@ -393,7 +393,7 @@ func createExecution(
 }
 
 func updateExecution(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	shardID int32,
 	namespaceID string,
 	workflowID string,
@@ -458,7 +458,7 @@ func updateExecution(
 }
 
 func applyTasks(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	shardID int32,
 	insertTasks map[tasks.Category][]p.InternalHistoryTask,
 ) error {
@@ -487,7 +487,7 @@ func applyTasks(
 }
 
 func createTransferTasks(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	transferTasks []p.InternalHistoryTask,
 	shardID int32,
 ) error {
@@ -508,7 +508,7 @@ func createTransferTasks(
 }
 
 func createTimerTasks(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	timerTasks []p.InternalHistoryTask,
 	shardID int32,
 ) error {
@@ -529,7 +529,7 @@ func createTimerTasks(
 }
 
 func createReplicationTasks(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	replicationTasks []p.InternalHistoryTask,
 	shardID int32,
 ) error {
@@ -550,7 +550,7 @@ func createReplicationTasks(
 }
 
 func createVisibilityTasks(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	visibilityTasks []p.InternalHistoryTask,
 	shardID int32,
 ) error {
@@ -571,7 +571,7 @@ func createVisibilityTasks(
 }
 
 func createHistoryTasks(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	category tasks.Category,
 	historyTasks []p.InternalHistoryTask,
 	shardID int32,
@@ -598,7 +598,7 @@ func createHistoryTasks(
 }
 
 func updateActivityInfos(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	activityInfos map[int64]*commonpb.DataBlob,
 	deleteIDs map[int64]struct{},
 	shardID int32,
@@ -636,7 +636,7 @@ func updateActivityInfos(
 }
 
 func deleteBufferedEvents(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	shardID int32,
 	namespaceID string,
 	workflowID string,
@@ -654,7 +654,7 @@ func deleteBufferedEvents(
 }
 
 func resetActivityInfos(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	activityInfos map[int64]*commonpb.DataBlob,
 	shardID int32,
 	namespaceID string,
@@ -681,7 +681,7 @@ func resetActivityInfos(
 }
 
 func updateTimerInfos(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	timerInfos map[string]*commonpb.DataBlob,
 	deleteInfos map[string]struct{},
 	shardID int32,
@@ -719,7 +719,7 @@ func updateTimerInfos(
 }
 
 func resetTimerInfos(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	timerInfos map[string]*commonpb.DataBlob,
 	shardID int32,
 	namespaceID string,
@@ -747,7 +747,7 @@ func resetTimerInfos(
 }
 
 func updateChildExecutionInfos(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	childExecutionInfos map[int64]*commonpb.DataBlob,
 	deleteIDs map[int64]struct{},
 	shardID int32,
@@ -785,7 +785,7 @@ func updateChildExecutionInfos(
 }
 
 func resetChildExecutionInfos(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	childExecutionInfos map[int64]*commonpb.DataBlob,
 	shardID int32,
 	namespaceID string,
@@ -811,7 +811,7 @@ func resetChildExecutionInfos(
 }
 
 func updateRequestCancelInfos(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	requestCancelInfos map[int64]*commonpb.DataBlob,
 	deleteIDs map[int64]struct{},
 	shardID int32,
@@ -849,7 +849,7 @@ func updateRequestCancelInfos(
 }
 
 func resetRequestCancelInfos(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	requestCancelInfos map[int64]*commonpb.DataBlob,
 	shardID int32,
 	namespaceID string,
@@ -878,7 +878,7 @@ func resetRequestCancelInfos(
 }
 
 func updateSignalInfos(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	signalInfos map[int64]*commonpb.DataBlob,
 	deleteIDs map[int64]struct{},
 	shardID int32,
@@ -916,7 +916,7 @@ func updateSignalInfos(
 }
 
 func resetSignalInfos(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	signalInfos map[int64]*commonpb.DataBlob,
 	shardID int32,
 	namespaceID string,
@@ -944,7 +944,7 @@ func resetSignalInfos(
 }
 
 func updateSignalsRequested(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	signalReqIDs map[string]struct{},
 	deleteSignalReqIDs map[string]struct{},
 	shardID int32,
@@ -979,7 +979,7 @@ func updateSignalsRequested(
 }
 
 func resetSignalRequested(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	signalRequested map[string]struct{},
 	shardID int32,
 	namespaceID string,
@@ -999,7 +999,7 @@ func resetSignalRequested(
 }
 
 func updateBufferedEvents(
-	batch gocql.Batch,
+	batch gocql.Batch_Deprecated,
 	newBufferedEvents *commonpb.DataBlob,
 	clearBufferedEvents bool,
 	shardID int32,

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
@@ -31,10 +31,10 @@ import (
 	"github.com/gocql/gocql"
 )
 
-var _ Batch_Deprecated = (*batch)(nil)
+var _ Batch_Deprecated = (*Batch)(nil)
 
 type (
-	batch struct {
+	Batch struct {
 		session *session
 
 		gocqlBatch *gocql.Batch
@@ -51,22 +51,22 @@ const (
 func newBatch(
 	session *session,
 	gocqlBatch *gocql.Batch,
-) *batch {
-	return &batch{
+) *Batch {
+	return &Batch{
 		session:    session,
 		gocqlBatch: gocqlBatch,
 	}
 }
 
-func (b *batch) Query(stmt string, args ...interface{}) {
+func (b *Batch) Query(stmt string, args ...interface{}) {
 	b.gocqlBatch.Query(stmt, args...)
 }
 
-func (b *batch) WithContext(ctx context.Context) Batch_Deprecated {
+func (b *Batch) WithContext(ctx context.Context) Batch_Deprecated {
 	return newBatch(b.session, b.gocqlBatch.WithContext(ctx))
 }
 
-func (b *batch) WithTimestamp(timestamp int64) Batch_Deprecated {
+func (b *Batch) WithTimestamp(timestamp int64) Batch_Deprecated {
 	b.gocqlBatch.WithTimestamp(timestamp)
 	return newBatch(b.session, b.gocqlBatch)
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
@@ -31,8 +31,6 @@ import (
 	"github.com/gocql/gocql"
 )
 
-var _ Batch_Deprecated = (*Batch)(nil)
-
 type (
 	Batch struct {
 		session *session
@@ -62,11 +60,11 @@ func (b *Batch) Query(stmt string, args ...interface{}) {
 	b.gocqlBatch.Query(stmt, args...)
 }
 
-func (b *Batch) WithContext(ctx context.Context) Batch_Deprecated {
+func (b *Batch) WithContext(ctx context.Context) *Batch {
 	return newBatch(b.session, b.gocqlBatch.WithContext(ctx))
 }
 
-func (b *Batch) WithTimestamp(timestamp int64) Batch_Deprecated {
+func (b *Batch) WithTimestamp(timestamp int64) *Batch {
 	b.gocqlBatch.WithTimestamp(timestamp)
 	return newBatch(b.session, b.gocqlBatch)
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gocql/gocql"
 )
 
-var _ Batch = (*batch)(nil)
+var _ Batch_Deprecated = (*batch)(nil)
 
 type (
 	batch struct {
@@ -62,11 +62,11 @@ func (b *batch) Query(stmt string, args ...interface{}) {
 	b.gocqlBatch.Query(stmt, args...)
 }
 
-func (b *batch) WithContext(ctx context.Context) Batch {
+func (b *batch) WithContext(ctx context.Context) Batch_Deprecated {
 	return newBatch(b.session, b.gocqlBatch.WithContext(ctx))
 }
 
-func (b *batch) WithTimestamp(timestamp int64) Batch {
+func (b *batch) WithTimestamp(timestamp int64) Batch_Deprecated {
 	b.gocqlBatch.WithTimestamp(timestamp)
 	return newBatch(b.session, b.gocqlBatch)
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
@@ -37,9 +37,9 @@ type (
 	// Session is the interface for interacting with the database.
 	Session interface {
 		Query(string, ...interface{}) Query
-		NewBatch(BatchType) Batch_Deprecated
-		ExecuteBatch(Batch_Deprecated) error
-		MapExecuteBatchCAS(Batch_Deprecated, map[string]interface{}) (bool, Iter, error)
+		NewBatch(BatchType) *Batch
+		ExecuteBatch(*Batch) error
+		MapExecuteBatchCAS(*Batch, map[string]interface{}) (bool, Iter, error)
 		AwaitSchemaAgreement(ctx context.Context) error
 		Close()
 	}
@@ -58,13 +58,6 @@ type (
 		WithTimestamp(int64) Query
 		Consistency(Consistency) Query
 		Bind(...interface{}) Query
-	}
-
-	// Batch_Deprecated is the interface for batch operation.
-	Batch_Deprecated interface {
-		Query(string, ...interface{})
-		WithContext(context.Context) Batch_Deprecated
-		WithTimestamp(int64) Batch_Deprecated
 	}
 
 	// Iter is the interface for executing and iterating over all resulting rows.

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
@@ -37,9 +37,9 @@ type (
 	// Session is the interface for interacting with the database.
 	Session interface {
 		Query(string, ...interface{}) Query
-		NewBatch(BatchType) Batch
-		ExecuteBatch(Batch) error
-		MapExecuteBatchCAS(Batch, map[string]interface{}) (bool, Iter, error)
+		NewBatch(BatchType) Batch_Deprecated
+		ExecuteBatch(Batch_Deprecated) error
+		MapExecuteBatchCAS(Batch_Deprecated, map[string]interface{}) (bool, Iter, error)
 		AwaitSchemaAgreement(ctx context.Context) error
 		Close()
 	}
@@ -60,11 +60,11 @@ type (
 		Bind(...interface{}) Query
 	}
 
-	// Batch is the interface for batch operation.
-	Batch interface {
+	// Batch_Deprecated is the interface for batch operation.
+	Batch_Deprecated interface {
 		Query(string, ...interface{})
-		WithContext(context.Context) Batch
-		WithTimestamp(int64) Batch
+		WithContext(context.Context) Batch_Deprecated
+		WithTimestamp(int64) Batch_Deprecated
 	}
 
 	// Iter is the interface for executing and iterating over all resulting rows.

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
@@ -149,7 +149,7 @@ func (s *session) Query(
 
 func (s *session) NewBatch(
 	batchType BatchType,
-) Batch {
+) Batch_Deprecated {
 	b := s.Value.Load().(*gocql.Session).NewBatch(mustConvertBatchType(batchType))
 	if b == nil {
 		return nil
@@ -161,7 +161,7 @@ func (s *session) NewBatch(
 }
 
 func (s *session) ExecuteBatch(
-	b Batch,
+	b Batch_Deprecated,
 ) (retError error) {
 	defer func() { s.handleError(retError) }()
 
@@ -169,7 +169,7 @@ func (s *session) ExecuteBatch(
 }
 
 func (s *session) MapExecuteBatchCAS(
-	b Batch,
+	b Batch_Deprecated,
 	previous map[string]interface{},
 ) (_ bool, _ Iter, retError error) {
 	defer func() { s.handleError(retError) }()

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
@@ -154,7 +154,7 @@ func (s *session) NewBatch(
 	if b == nil {
 		return nil
 	}
-	return &batch{
+	return &Batch{
 		session:    s,
 		gocqlBatch: b,
 	}
@@ -165,7 +165,7 @@ func (s *session) ExecuteBatch(
 ) (retError error) {
 	defer func() { s.handleError(retError) }()
 
-	return s.Value.Load().(*gocql.Session).ExecuteBatch(b.(*batch).gocqlBatch)
+	return s.Value.Load().(*gocql.Session).ExecuteBatch(b.(*Batch).gocqlBatch)
 }
 
 func (s *session) MapExecuteBatchCAS(
@@ -174,7 +174,7 @@ func (s *session) MapExecuteBatchCAS(
 ) (_ bool, _ Iter, retError error) {
 	defer func() { s.handleError(retError) }()
 
-	applied, iter, err := s.Value.Load().(*gocql.Session).MapExecuteBatchCAS(b.(*batch).gocqlBatch, previous)
+	applied, iter, err := s.Value.Load().(*gocql.Session).MapExecuteBatchCAS(b.(*Batch).gocqlBatch, previous)
 	return applied, iter, err
 }
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
@@ -149,7 +149,7 @@ func (s *session) Query(
 
 func (s *session) NewBatch(
 	batchType BatchType,
-) Batch_Deprecated {
+) *Batch {
 	b := s.Value.Load().(*gocql.Session).NewBatch(mustConvertBatchType(batchType))
 	if b == nil {
 		return nil
@@ -161,7 +161,7 @@ func (s *session) NewBatch(
 }
 
 func (s *session) ExecuteBatch(
-	b Batch_Deprecated,
+	b *Batch,
 ) (retError error) {
 	defer func() { s.handleError(retError) }()
 
@@ -169,7 +169,7 @@ func (s *session) ExecuteBatch(
 }
 
 func (s *session) MapExecuteBatchCAS(
-	b Batch_Deprecated,
+	b *Batch,
 	previous map[string]interface{},
 ) (_ bool, _ Iter, retError error) {
 	defer func() { s.handleError(retError) }()

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
@@ -165,7 +165,7 @@ func (s *session) ExecuteBatch(
 ) (retError error) {
 	defer func() { s.handleError(retError) }()
 
-	return s.Value.Load().(*gocql.Session).ExecuteBatch(b.(*Batch).gocqlBatch)
+	return s.Value.Load().(*gocql.Session).ExecuteBatch(b.gocqlBatch)
 }
 
 func (s *session) MapExecuteBatchCAS(
@@ -174,7 +174,7 @@ func (s *session) MapExecuteBatchCAS(
 ) (_ bool, _ Iter, retError error) {
 	defer func() { s.handleError(retError) }()
 
-	applied, iter, err := s.Value.Load().(*gocql.Session).MapExecuteBatchCAS(b.(*Batch).gocqlBatch, previous)
+	applied, iter, err := s.Value.Load().(*gocql.Session).MapExecuteBatchCAS(b.gocqlBatch, previous)
 	return applied, iter, err
 }
 


### PR DESCRIPTION
## What changed?
 - Removed the existing unused interface `gocql.Batch`.
 - Exported `gocql.batch`. This was the only implementation of the above interface.
 - Fixed few references and types.

## Why?
This interface was unused. i.e there were no other implementations other than `gocql.batch`. 

## How did you test it?
Existing tests

## Potential risks
N/A

## Documentation
N/A

## Is hotfix candidate?
No