### PR TITLE
Record task generation clock only when Nexus is enabled

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -309,13 +309,16 @@ func NewMutableState(
 
 		LastCompletedWorkflowTaskStartedEventId: common.EmptyEventID,
 
-		StartTime:                         timestamppb.New(startTime),
-		VersionHistories:                  versionhistory.NewVersionHistories(&historyspb.VersionHistory{}),
-		ExecutionStats:                    &persistencespb.ExecutionStats{HistorySize: 0},
-		SubStateMachinesByType:            make(map[string]*persistencespb.StateMachineMap),
-		TaskGenerationShardClockTimestamp: shard.CurrentVectorClock().GetClock(),
+		StartTime:              timestamppb.New(startTime),
+		VersionHistories:       versionhistory.NewVersionHistories(&historyspb.VersionHistory{}),
+		ExecutionStats:         &persistencespb.ExecutionStats{HistorySize: 0},
+		SubStateMachinesByType: make(map[string]*persistencespb.StateMachineMap),
+	}
+	if s.config.EnableNexus() {
+		s.executionInfo.TaskGenerationShardClockTimestamp = shard.CurrentVectorClock().GetClock()
 	}
 	s.approximateSize += s.executionInfo.Size()
+
 	s.executionState = &persistencespb.WorkflowExecutionState{
 		RunId: runID,
 

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -89,8 +89,11 @@ func (r *TaskRefresherImpl) Refresh(
 	ctx context.Context,
 	mutableState MutableState,
 ) error {
-	// Invalidate all tasks generated for this mutable state before the refresh.
-	mutableState.GetExecutionInfo().TaskGenerationShardClockTimestamp = r.shard.CurrentVectorClock().GetClock()
+	if r.shard.GetConfig().EnableNexus() {
+		// Invalidate all tasks generated for this mutable state before the refresh.
+		mutableState.GetExecutionInfo().TaskGenerationShardClockTimestamp = r.shard.CurrentVectorClock().GetClock()
+	}
+
 	return r.PartialRefresh(ctx, mutableState, EmptyVersionedTransition)
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Record task generation clock only when Nexus is enabled

## Why?
<!-- Tell your future self why have you made these changes -->
- This is for preventing the task generation clock value get replication across clusters without being sanitized. 
   If source cluster is new and recorded the value, but target cluster is old but doesn't know about this field, this unknown field could (during migration) be replicated and persisted in the target cluster. Even if we perform sanitization in the source cluster, it's still possible that during the deployment shard moves to an old host in the source cluster.  
- This new field is mainly for making sure Nexus can work properly, so we don't have to use it when nexus is disabled.

Now the upgrade/downgrade story looks like the following:
(Assuming we perform source cluster sanitization: [PR](https://github.com/temporalio/temporal/pull/6373) )
Upgrade from 1.24 -> 1.25: deploy 1.25. After the deployment is done, enable Nexus if needed. 
Downgrade from 1.25 -> 1.24: If nexus was never enabled, just downgrade. Otherwise, disable nexus, **wait for all pending migrations to complete**, then downgrade. 

This PR can be reverted in 1.26 release, thus decoupling task generation clock with nexus.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
