### PR TITLE
Don't allow RunID in Update MultiOperation

### DIFF
--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -92,6 +92,8 @@ var (
 	errTaskQueuePartitionInvalid                          = serviceerror.NewInvalidArgument("Task Queue Partition invalid, use a different Task Queue or Task Queue Type")
 	errMultiOpWorkflowIdInconsistent                      = serviceerror.NewInvalidArgument("WorkflowId is not consistent with previous operation(s).")
 	errMultiOpStartCronSchedule                           = serviceerror.NewInvalidArgument("CronSchedule is not allowed.")
+	errMultiOpUpdateFirstExecutionRunId                   = serviceerror.NewInvalidArgument("FirstExecutionRunId is not allowed.")
+	errMultiOpUpdateExecutionRunId                        = serviceerror.NewInvalidArgument("RunId is not allowed.")
 	errMultiOpEagerWorkflow                               = serviceerror.NewInvalidArgument("RequestEagerExecution is not supported.")
 	errMultiOpNotStartAndUpdate                           = serviceerror.NewInvalidArgument("Operations have to be exactly [Start, Update].")
 	errMultiOpAborted                                     = serviceerror.NewMultiOperationAborted("Operation was aborted.")

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -599,6 +599,12 @@ func (wh *WorkflowHandler) convertToHistoryMultiOperationItem(
 		if err := wh.prepareUpdateWorkflowRequest(updateReq); err != nil {
 			return nil, "", err
 		}
+		if updateReq.FirstExecutionRunId != "" {
+			return nil, "", errMultiOpUpdateFirstExecutionRunId
+		}
+		if updateReq.WorkflowExecution.RunId != "" {
+			return nil, "", errMultiOpUpdateExecutionRunId
+		}
 
 		workflowId = updateReq.WorkflowExecution.WorkflowId
 		opReq = &historyservice.ExecuteMultiOperationRequest_Operation{


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Don't allow UpdateWorkflow request options `FirstExecutionRunId` and `WorkflowExecution.RunId` for MultiOperation.

## Why?
<!-- Tell your future self why have you made these changes -->

Those Update options `FirstExecutionRunId` and `WorkflowExecution.RunId` don't make sense for Update-with-Start, as the RunID cannot be known as the caller doesn't know if a Workflow is actually running or not.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

I intend to add a comment to the proto API, too.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
