### PR TITLE
Drop unknown fields when replicating workflow state

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -41,6 +41,9 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protopath"
+	"google.golang.org/protobuf/reflect/protorange"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -699,4 +702,15 @@ func ValidateUTF8String(fieldName string, strValue string) error {
 		return serviceerror.NewInvalidArgument(fmt.Sprintf("%s %v is not a valid UTF-8 string", fieldName, strValue))
 	}
 	return nil
+}
+
+// DiscardUnknownProto discards unknown fields in a proto message.
+func DiscardUnknownProto(m proto.Message) error {
+	return protorange.Range(m.ProtoReflect(), func(values protopath.Values) error {
+		m, ok := values.Index(-1).Value.Interface().(protoreflect.Message)
+		if ok && len(m.GetUnknown()) > 0 {
+			m.SetUnknown(nil)
+		}
+		return nil
+	})
 }

--- a/service/history/replication/raw_task_converter.go
+++ b/service/history/replication/raw_task_converter.go
@@ -209,6 +209,9 @@ func convertWorkflowStateReplicationTask(
 			if err := workflow.SanitizeMutableState(workflowMutableState); err != nil {
 				return nil, err
 			}
+			if err := common.DiscardUnknownProto(workflowMutableState); err != nil {
+				return nil, err
+			}
 			return &replicationspb.ReplicationTask{
 				TaskType:     enumsspb.REPLICATION_TASK_TYPE_SYNC_WORKFLOW_STATE_TASK,
 				SourceTaskId: taskInfo.TaskID,
@@ -253,6 +256,9 @@ func convertSyncHSMReplicationTask(
 
 			stateMachineNode := common.CloneProto(mutableState.HSM().InternalRepr())
 			workflow.SanitizeStateMachineNode(stateMachineNode)
+			if err := common.DiscardUnknownProto(stateMachineNode); err != nil {
+				return nil, err
+			}
 
 			return &replicationspb.ReplicationTask{
 				TaskType:     enumsspb.REPLICATION_TASK_TYPE_SYNC_HSM_TASK,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -466,9 +466,13 @@ func NewSanitizedMutableState(
 	lastFirstEventTxnID int64,
 	lastWriteVersion int64,
 ) (*MutableStateImpl, error) {
-	// TODO:  The source cluster will perform the sanitization starting from 1.25 release.
-	// Remove the sanitization here in 1.26 release.
+	// Although new versions of temporal server will perform state sanitization,
+	// we have to keep the sanitization logic here as well for backward compatibility in case
+	// source cluster is running an old version and doesn't do the sanitization.
 	if err := SanitizeMutableState(mutableStateRecord); err != nil {
+		return nil, err
+	}
+	if err := common.DiscardUnknownProto(mutableStateRecord); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Drop unknown fields when replicating workflow state

## Why?
<!-- Tell your future self why have you made these changes -->
- This is to prevent a newly introduced, cell specific field got accidentally replicated to the target cluster after source cluster rolling back. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
