### PR TITLE
Evaluate versioning rules in parent partition for forwarded Queries and Nexus tasks

### DIFF
--- a/api/taskqueue/v1/message.pb.go
+++ b/api/taskqueue/v1/message.pb.go
@@ -394,8 +394,10 @@ func (x *BuildIdRedirectInfo) GetAssignedBuildId() string {
 	return ""
 }
 
-// Information about task forwarding from one partition to its parent. Versioning decisions are made
-// at the source partition and sent to the parent partition in this message.
+// Information about task forwarding from one partition to its parent. Versioning decisions for activity/workflow
+// tasks are made at the source partition and sent to the parent partition in this message so that parent partition
+// does not have to make versioning decision again. For Query/Nexus tasks, this works differently as the child's
+// versioning decision is ignored and the parent partition makes a fresh decision.
 type TaskForwardInfo struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -407,7 +409,7 @@ type TaskForwardInfo struct {
 	TaskSource      v12.TaskSource `protobuf:"varint,2,opt,name=task_source,json=taskSource,proto3,enum=temporal.server.api.enums.v1.TaskSource" json:"task_source,omitempty"`
 	// Redirect info is not present for Query and Nexus tasks.
 	RedirectInfo *BuildIdRedirectInfo `protobuf:"bytes,3,opt,name=redirect_info,json=redirectInfo,proto3" json:"redirect_info,omitempty"`
-	// Build ID that should be used to dispatch the task to.
+	// Build ID that should be used to dispatch the task to. Ignored in Query and Nexus tasks.
 	DispatchBuildId string `protobuf:"bytes,4,opt,name=dispatch_build_id,json=dispatchBuildId,proto3" json:"dispatch_build_id,omitempty"`
 	// Only used for old versioning. [cleanup-old-wv]
 	DispatchVersionSet string `protobuf:"bytes,5,opt,name=dispatch_version_set,json=dispatchVersionSet,proto3" json:"dispatch_version_set,omitempty"`

--- a/proto/internal/temporal/server/api/taskqueue/v1/message.proto
+++ b/proto/internal/temporal/server/api/taskqueue/v1/message.proto
@@ -80,8 +80,10 @@ message BuildIdRedirectInfo {
     string assigned_build_id = 1;
 }
 
-// Information about task forwarding from one partition to its parent. Versioning decisions are made
-// at the source partition and sent to the parent partition in this message.
+// Information about task forwarding from one partition to its parent. Versioning decisions for activity/workflow
+// tasks are made at the source partition and sent to the parent partition in this message so that parent partition
+// does not have to make versioning decision again. For Query/Nexus tasks, this works differently as the child's
+// versioning decision is ignored and the parent partition makes a fresh decision.
 message TaskForwardInfo {
     // RPC name of the partition forwarded the task.
     // In case of multiple hops, this is the source partition of the last hop.
@@ -89,7 +91,7 @@ message TaskForwardInfo {
     temporal.server.api.enums.v1.TaskSource task_source = 2;
     // Redirect info is not present for Query and Nexus tasks.
     BuildIdRedirectInfo redirect_info = 3;
-    // Build ID that should be used to dispatch the task to.
+    // Build ID that should be used to dispatch the task to. Ignored in Query and Nexus tasks.
     string dispatch_build_id = 4;
     // Only used for old versioning. [cleanup-old-wv]
     string dispatch_version_set = 5;

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -366,7 +366,12 @@ func (pm *taskQueuePartitionManagerImpl) DispatchQueryTask(
 	_, syncMatchQueue, _, err := pm.getPhysicalQueuesForAdd(
 		ctx,
 		request.VersionDirective,
-		request.GetForwardInfo(),
+		// We do not pass forwardInfo because we want the parent partition to make fresh versioning decision. Note that
+		// forwarded Query/Nexus task requests do not expire rapidly in contrast to forwarded activity/workflow tasks
+		// that only try up to 200ms sync-match. Therefore, to prevent blocking the request on the wrong build ID, its
+		// more important to allow the parent partition to make a fresh versioning decision in case the child partition
+		// did not have up-to-date User Data when selected a dispatch build ID.
+		nil,
 		request.GetQueryRequest().GetExecution().GetRunId(),
 	)
 	if err != nil {
@@ -389,7 +394,12 @@ func (pm *taskQueuePartitionManagerImpl) DispatchNexusTask(
 	_, syncMatchQueue, _, err := pm.getPhysicalQueuesForAdd(
 		ctx,
 		worker_versioning.MakeUseAssignmentRulesDirective(),
-		request.GetForwardInfo(),
+		// We do not pass forwardInfo because we want the parent partition to make fresh versioning decision. Note that
+		// forwarded Query/Nexus task requests do not expire rapidly in contrast to forwarded activity/workflow tasks
+		// that only try up to 200ms sync-match. Therefore, to prevent blocking the request on the wrong build ID, its
+		// more important to allow the parent partition to make a fresh versioning decision in case the child partition
+		// did not have up-to-date User Data when selected a dispatch build ID.
+		nil,
 		"",
 	)
 	if err != nil {

--- a/service/matching/user_data_manager.go
+++ b/service/matching/user_data_manager.go
@@ -309,7 +309,7 @@ func (m *userDataManagerImpl) fetchUserData(ctx context.Context) error {
 		// one. But if the remote is broken and returns success immediately, we might end up
 		// spinning. So enforce a minimum wait time that increases as long as we keep getting
 		// very fast replies.
-		if elapsed < minWaitTime {
+		if elapsed < m.config.GetUserDataMinWaitTime {
 			util.InterruptibleSleep(ctx, minWaitTime-elapsed)
 			// Don't let this get near our call timeout, otherwise we can't tell the difference
 			// between a fast reply and a timeout.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
When a query is forwarded to parent partition, allow the parent to chose build ID itself rather than using the one selected by child partition.

## Why?
<!-- Tell your future self why have you made these changes -->
This fixes a race condition in which query comes to the child right after User Data is updated but before the child partition has the latest User Data. In that case child may select a stale build ID that no longer has workers. When forwarding the request to parent, we want to give the parent a second chance to fix the child's mistake.

This fixes the flakes in the following SDK test: https://github.com/temporalio/sdk-go/blob/master/test/worker_versioning_test.go#L885

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Made sure the SDK test passes 10 consecutive times.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
None.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
None.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.