### PR TITLE
Fix workflow not found error message

### DIFF
--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -769,7 +769,7 @@ func (m *executionManagerImpl) GetCurrentExecution(
 	var notFound *serviceerror.NotFound
 	if errors.As(respErr, &notFound) {
 		// strip persistence-specific error message
-		respErr = serviceerror.NewNotFound("workflow not found")
+		respErr = serviceerror.NewNotFound("current workflow execution not found")
 	}
 	if respErr != nil && response == nil {
 		// try to utilize resp as much as possible, for RebuildMutableState API

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -1771,7 +1771,7 @@ func (s *ExecutionMutableStateSuite) TestDeleteCurrent_IsCurrent() {
 		WorkflowID:  s.WorkflowID,
 	})
 	s.IsType(&serviceerror.NotFound{}, err)
-	s.EqualError(err, "workflow not found")
+	s.EqualError(err, "current workflow execution not found")
 
 	s.AssertMSEqualWithDB(newSnapshot)
 	s.AssertHEEqualWithDB(branchToken, newEvents)
@@ -1818,7 +1818,7 @@ func (s *ExecutionMutableStateSuite) TestDeleteCurrent_NotCurrent() {
 		WorkflowID:  s.WorkflowID,
 	})
 	s.IsType(&serviceerror.NotFound{}, err)
-	s.EqualError(err, "workflow not found")
+	s.EqualError(err, "current workflow execution not found")
 
 	s.AssertMSEqualWithDB(newSnapshot)
 	s.AssertHEEqualWithDB(branchToken, newEvents)

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -1771,6 +1771,7 @@ func (s *ExecutionMutableStateSuite) TestDeleteCurrent_IsCurrent() {
 		WorkflowID:  s.WorkflowID,
 	})
 	s.IsType(&serviceerror.NotFound{}, err)
+	s.EqualError(err, "workflow not found")
 
 	s.AssertMSEqualWithDB(newSnapshot)
 	s.AssertHEEqualWithDB(branchToken, newEvents)
@@ -1817,6 +1818,7 @@ func (s *ExecutionMutableStateSuite) TestDeleteCurrent_NotCurrent() {
 		WorkflowID:  s.WorkflowID,
 	})
 	s.IsType(&serviceerror.NotFound{}, err)
+	s.EqualError(err, "workflow not found")
 
 	s.AssertMSEqualWithDB(newSnapshot)
 	s.AssertHEEqualWithDB(branchToken, newEvents)

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -26,6 +26,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"math/rand"
 	"testing"
@@ -1771,7 +1772,7 @@ func (s *ExecutionMutableStateSuite) TestDeleteCurrent_IsCurrent() {
 		WorkflowID:  s.WorkflowID,
 	})
 	s.IsType(&serviceerror.NotFound{}, err)
-	s.EqualError(err, "current workflow execution not found")
+	s.EqualError(err, "workflow not found for ID: "+s.WorkflowID)
 
 	s.AssertMSEqualWithDB(newSnapshot)
 	s.AssertHEEqualWithDB(branchToken, newEvents)
@@ -1818,7 +1819,7 @@ func (s *ExecutionMutableStateSuite) TestDeleteCurrent_NotCurrent() {
 		WorkflowID:  s.WorkflowID,
 	})
 	s.IsType(&serviceerror.NotFound{}, err)
-	s.EqualError(err, "current workflow execution not found")
+	s.EqualError(err, "workflow not found for ID: "+s.WorkflowID)
 
 	s.AssertMSEqualWithDB(newSnapshot)
 	s.AssertHEEqualWithDB(branchToken, newEvents)
@@ -1919,6 +1920,7 @@ func (s *ExecutionMutableStateSuite) AssertMissingFromDB(
 		RunID:       runID,
 	})
 	s.IsType(&serviceerror.NotFound{}, err)
+	s.EqualError(err, fmt.Sprintf("workflow execution not found for workflow ID %q and run ID %q", workflowID, runID))
 }
 
 func (s *ExecutionMutableStateSuite) AssertHEEqualWithDB(branchToken []byte, events ...[]*p.WorkflowEvents) {

--- a/tests/cancel_workflow.go
+++ b/tests/cancel_workflow.go
@@ -72,8 +72,8 @@ func (s *FunctionalSuite) TestExternalRequestCancelWorkflowExecution() {
 			WorkflowId: id,
 		},
 	})
-	s.Error(err)
 	s.IsType(&serviceerror.NotFound{}, err)
+	s.EqualError(err, "workflow not found")
 
 	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)

--- a/tests/cancel_workflow.go
+++ b/tests/cancel_workflow.go
@@ -73,7 +73,7 @@ func (s *FunctionalSuite) TestExternalRequestCancelWorkflowExecution() {
 		},
 	})
 	s.IsType(&serviceerror.NotFound{}, err)
-	s.EqualError(err, "workflow not found")
+	s.EqualError(err, "current workflow execution not found")
 
 	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)

--- a/tests/cancel_workflow.go
+++ b/tests/cancel_workflow.go
@@ -73,7 +73,7 @@ func (s *FunctionalSuite) TestExternalRequestCancelWorkflowExecution() {
 		},
 	})
 	s.IsType(&serviceerror.NotFound{}, err)
-	s.EqualError(err, "current workflow execution not found")
+	s.EqualError(err, "workflow not found for ID: "+id)
 
 	we, err0 := s.client.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err0)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Don't pass the `GetCurrentExecution` not found error up to non-persistence caller; use a custom error message instead.

## Why?
<!-- Tell your future self why have you made these changes -->

Fixes https://github.com/temporalio/temporal/issues/4118

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Added tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

Breaks anyone checking for that exact string (which they shouldn't do).

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
