### PR TITLE
Workflow Update: add more test for different workflow completion commands

### DIFF
--- a/common/testing/testvars/any.go
+++ b/common/testing/testvars/any.go
@@ -26,6 +26,8 @@ package testvars
 
 import (
 	commonpb "go.temporal.io/api/common/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 )
@@ -62,4 +64,14 @@ func (a Any) Int() int {
 func (a Any) EventID() int64 {
 	// This produces EventID in XX0YY format, where XX is unique for every test and YY is a random number.
 	return int64(randInt(a.testHash, 2, 1, 2))
+}
+
+func (a Any) ApplicationFailure() *failurepb.Failure {
+	return &failurepb.Failure{
+		Message: a.String(),
+		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+			Type:         a.String(),
+			NonRetryable: false,
+		}},
+	}
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add more test for different workflow completion commands.

## Why?
<!-- Tell your future self why have you made these changes -->
Only `COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION` case was covered before. This PR adds `COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION` and `COMMAND_TYPE_FAIL_WORKFLOW_EXECUTION` cases which should behave exactly the same (in term of dealing with workflow updates). It also proves that besides very specific edge case described in #6375 workflow updates and "continue as new" work together as expected.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run locally.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.