### PR TITLE
Knob for logging all rpc errors for a namespace

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2486,4 +2486,10 @@ WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 		20000,
 		`MaxUserMetadataDetailsSize is the maximum size of user metadata details payloads in bytes.`,
 	)
+
+	LogAllErrors = NewNamespaceBoolSetting(
+		"system.logAllErrors",
+		false,
+		`When set to true, logs all error types for the namespace, not just unexpected ones.`,
+	)
 )

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2487,8 +2487,8 @@ WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 		`MaxUserMetadataDetailsSize is the maximum size of user metadata details payloads in bytes.`,
 	)
 
-	LogAllErrors = NewNamespaceBoolSetting(
-		"system.logAllErrors",
+	LogAllReqErrors = NewNamespaceBoolSetting(
+		"system.logAllReqErrors",
 		false,
 		`When set to true, logs all error types for the namespace, not just unexpected ones.`,
 	)

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2490,6 +2490,6 @@ WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 	LogAllReqErrors = NewNamespaceBoolSetting(
 		"system.logAllReqErrors",
 		false,
-		`When set to true, logs all error types for the namespace, not just unexpected ones.`,
+		`When set to true, logs all RPC/request errors for the namespace, not just unexpected ones.`,
 	)
 )

--- a/common/rpc/interceptor/namespace.go
+++ b/common/rpc/interceptor/namespace.go
@@ -45,7 +45,7 @@ type (
 )
 
 // MustGetNamespaceName returns request namespace name
-// or EmptyName if there's error when retriving namespace name,
+// or EmptyName if there's error when retrieving namespace name,
 // e.g. unable to find namespace
 func MustGetNamespaceName(
 	namespaceRegistry namespace.Registry,

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -369,15 +369,15 @@ func (ti *TelemetryInterceptor) HandleError(req interface{},
 	logTags []tag.Tag,
 	err error,
 	nsName namespace.Name) {
-	if common.IsContextDeadlineExceededErr(err) || common.IsContextCanceledErr(err) {
-		return
-	}
-
 	statusCode := serviceerror.ToStatus(err).Code()
 
 	recordMetric(metricsHandler, err, statusCode)
 
 	logAllErrors := nsName != "" && ti.logAllReqErrors(nsName.String())
+	if !logAllErrors && (common.IsContextDeadlineExceededErr(err) || common.IsContextCanceledErr(err)) {
+		return
+	}
+
 	if !logAllErrors && isUserCaused(statusCode) {
 		return
 	}

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -382,7 +382,9 @@ func (ti *TelemetryInterceptor) HandleError(req interface{},
 		return
 	}
 
-	if statusCode == codes.Internal || statusCode == codes.Unknown || logAllErrors {
+	// We mask these two error types in MaskInternalErrorDetailsInterceptor, so we need the hash to find the actual
+	// error message.
+	if statusCode == codes.Internal || statusCode == codes.Unknown {
 		errorHash := common.ErrorHash(err)
 		logTags = append(logTags, tag.NewStringTag("hash", errorHash))
 	}

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -438,11 +438,9 @@ func recordMetric(metricsHandler metrics.Handler, err error, statusCode codes.Co
 		return
 	}
 
-	if isUserCaused(statusCode) {
-		return
+	if !isUserCaused(statusCode) {
+		metrics.ServiceFailures.With(metricsHandler).Record(1)
 	}
-
-	metrics.ServiceFailures.With(metricsHandler).Record(1)
 }
 
 func (ti *TelemetryInterceptor) getWorkflowTags(

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -404,9 +404,9 @@ func isUserCaused(statusCode codes.Code) bool {
 		codes.Unauthenticated,
 		codes.NotFound:
 		return true
-	default:
-		return false
 	}
+
+	return false
 }
 
 func recordMetric(metricsHandler metrics.Handler, err error, statusCode codes.Code) {

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -34,19 +34,19 @@ import (
 	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/anypb"
-
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/api"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 type (
@@ -57,6 +57,7 @@ type (
 		serializer        common.TaskTokenSerializer
 		metricsHandler    metrics.Handler
 		logger            log.Logger
+		logAllErrors      dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}
 	ExecutionGetter interface {
 		GetExecution() *commonpb.WorkflowExecution
@@ -126,12 +127,14 @@ func NewTelemetryInterceptor(
 	namespaceRegistry namespace.Registry,
 	metricsHandler metrics.Handler,
 	logger log.Logger,
+	logAllErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter,
 ) *TelemetryInterceptor {
 	return &TelemetryInterceptor{
 		namespaceRegistry: namespaceRegistry,
 		serializer:        common.NewProtoTaskTokenSerializer(),
 		metricsHandler:    metricsHandler,
 		logger:            logger,
+		logAllErrors:      logAllErrors,
 	}
 }
 
@@ -186,7 +189,9 @@ func (ti *TelemetryInterceptor) UnaryIntercept(
 	handler grpc.UnaryHandler,
 ) (interface{}, error) {
 	methodName := api.MethodName(info.FullMethod)
-	metricsHandler, logTags := ti.unaryMetricsHandlerLogTags(req, info.FullMethod, methodName)
+	nsName := MustGetNamespaceName(ti.namespaceRegistry, req)
+
+	metricsHandler, logTags := ti.unaryMetricsHandlerLogTags(req, info.FullMethod, methodName, nsName)
 
 	ctx = AddTelemetryContext(ctx, metricsHandler)
 	metrics.ServiceRequests.With(metricsHandler).Record(1)
@@ -199,7 +204,7 @@ func (ti *TelemetryInterceptor) UnaryIntercept(
 	resp, err := handler(ctx, req)
 
 	if err != nil {
-		ti.HandleError(req, metricsHandler, logTags, err)
+		ti.HandleError(req, metricsHandler, logTags, err, nsName)
 	} else {
 		// emit action metrics only after successful calls
 		ti.emitActionMetric(methodName, info.FullMethod, req, metricsHandler, resp)
@@ -237,7 +242,7 @@ func (ti *TelemetryInterceptor) StreamIntercept(
 
 	err := handler(service, serverStream)
 	if err != nil {
-		ti.HandleError(nil, metricsHandler, logTags, err)
+		ti.HandleError(nil, metricsHandler, logTags, err, "")
 		return err
 	}
 	return nil
@@ -334,14 +339,12 @@ func (ti *TelemetryInterceptor) emitActionMetric(
 	}
 }
 
-func (ti *TelemetryInterceptor) unaryMetricsHandlerLogTags(
-	req interface{},
+func (ti *TelemetryInterceptor) unaryMetricsHandlerLogTags(req interface{},
 	fullMethod string,
 	methodName string,
-) (metrics.Handler, []tag.Tag) {
+	nsName namespace.Name) (metrics.Handler, []tag.Tag) {
 	overridedMethodName := ti.unaryOverrideOperationTag(fullMethod, methodName, req)
 
-	nsName := MustGetNamespaceName(ti.namespaceRegistry, req)
 	if nsName == "" {
 		return ti.metricsHandler.WithTags(metrics.OperationTag(overridedMethodName), metrics.NamespaceUnknownTag()),
 			[]tag.Tag{tag.Operation(overridedMethodName)}
@@ -361,21 +364,57 @@ func (ti *TelemetryInterceptor) streamMetricsHandlerLogTags(
 	), []tag.Tag{tag.Operation(overridedMethodName)}
 }
 
-func (ti *TelemetryInterceptor) HandleError(
-	req interface{},
+func (ti *TelemetryInterceptor) HandleError(req interface{},
 	metricsHandler metrics.Handler,
 	logTags []tag.Tag,
 	err error,
-) {
-
+	nsName namespace.Name) {
 	metrics.ServiceErrorWithType.With(metricsHandler).Record(1, metrics.ServiceErrorTypeTag(err))
 
 	if common.IsContextDeadlineExceededErr(err) || common.IsContextCanceledErr(err) {
 		return
 	}
 
+	statusCode := serviceerror.ToStatus(err).Code()
+	logAllErrors := nsName != "" && ti.logAllErrors(nsName.String())
+	if !logAllErrors && isUserCaused(statusCode) {
+		return
+	}
+
+	if statusCode == codes.Internal || statusCode == codes.Unknown || logAllErrors {
+		errorHash := common.ErrorHash(err)
+		logTags = append(logTags, tag.NewStringTag("hash", errorHash))
+	}
+
+	logTags = append(logTags, tag.NewStringTag("grpc_code", statusCode.String()))
+	logTags = append(logTags, ti.getWorkflowTags(req)...)
+
+	ti.logger.Error("service failures", append(logTags, tag.Error(err))...)
+
+	recordMetric(metricsHandler, err, statusCode)
+}
+
+func isUserCaused(statusCode codes.Code) bool {
+	switch statusCode {
+	case codes.InvalidArgument,
+		codes.AlreadyExists,
+		codes.FailedPrecondition,
+		codes.OutOfRange,
+		codes.PermissionDenied,
+		codes.Unauthenticated,
+		codes.NotFound:
+		return true
+	default:
+		return false
+	}
+}
+
+func recordMetric(metricsHandler metrics.Handler, err error, statusCode codes.Code) {
 	switch err := err.(type) {
-	// we emit service_error_with_type metrics, no need to emit specific metric for these known error types.
+	case *serviceerror.ResourceExhausted:
+		metrics.ServiceErrResourceExhaustedCounter.With(metricsHandler).Record(
+			1, metrics.ResourceExhaustedCauseTag(err.Cause), metrics.ResourceExhaustedScopeTag(err.Scope))
+		return
 	case *serviceerror.AlreadyExists,
 		*serviceerror.CancellationAlreadyRequested,
 		*serviceerror.FailedPrecondition,
@@ -396,43 +435,14 @@ func (ti *TelemetryInterceptor) HandleError(
 		*serviceerrors.ShardOwnershipLost,
 		*serviceerrors.TaskAlreadyStarted,
 		*serviceerrors.RetryReplication:
-		// no-op
-
-	// specific metric for resource exhausted error with throttle reason
-	case *serviceerror.ResourceExhausted:
-		metrics.ServiceErrResourceExhaustedCounter.With(metricsHandler).Record(
-			1, metrics.ResourceExhaustedCauseTag(err.Cause), metrics.ResourceExhaustedScopeTag(err.Scope))
-	// Any other errors are treated as ServiceFailures against SLA unless constructed with the standard
-	// `status.Error` (or Errorf) constructors, in which case the status code is checked below.
-	// Including below known errors and any other unknown errors.
-	//  *serviceerror.DataLoss,
-	//  *serviceerror.Internal
-	//	*serviceerror.Unavailable:
-	default:
-		// Also skip emitting ServiceFailures for non serviceerrors returned from handlers for certain error
-		// codes.
-
-		if st, ok := status.FromError(err); ok {
-			switch st.Code() {
-			case codes.InvalidArgument,
-				codes.AlreadyExists,
-				codes.FailedPrecondition,
-				codes.OutOfRange,
-				codes.PermissionDenied,
-				codes.Unauthenticated,
-				codes.NotFound:
-				return
-			case codes.Internal,
-				codes.Unknown:
-				errorHash := common.ErrorHash(err)
-				logTags = append(logTags, tag.NewStringTag("hash", errorHash))
-			}
-		}
-
-		metrics.ServiceFailures.With(metricsHandler).Record(1)
-		logTags = append(logTags, ti.getWorkflowTags(req)...)
-		ti.logger.Error("service failures", append(logTags, tag.Error(err))...)
+		return
 	}
+
+	if isUserCaused(statusCode) {
+		return
+	}
+
+	metrics.ServiceFailures.With(metricsHandler).Record(1)
 }
 
 func (ti *TelemetryInterceptor) getWorkflowTags(

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -404,6 +404,17 @@ func isUserCaused(statusCode codes.Code) bool {
 		codes.Unauthenticated,
 		codes.NotFound:
 		return true
+	case codes.OK,
+		codes.Canceled,
+		codes.Unknown,
+		codes.DeadlineExceeded,
+		codes.ResourceExhausted,
+		codes.Aborted,
+		codes.Unimplemented,
+		codes.Internal,
+		codes.Unavailable,
+		codes.DataLoss:
+		return false
 	}
 
 	return false

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -29,6 +29,10 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -43,10 +47,6 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 type (

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -57,7 +57,7 @@ type (
 		serializer        common.TaskTokenSerializer
 		metricsHandler    metrics.Handler
 		logger            log.Logger
-		logAllErrors      dynamicconfig.BoolPropertyFnWithNamespaceFilter
+		logAllReqErrors   dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}
 	ExecutionGetter interface {
 		GetExecution() *commonpb.WorkflowExecution
@@ -127,14 +127,14 @@ func NewTelemetryInterceptor(
 	namespaceRegistry namespace.Registry,
 	metricsHandler metrics.Handler,
 	logger log.Logger,
-	logAllErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter,
+	logAllReqErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter,
 ) *TelemetryInterceptor {
 	return &TelemetryInterceptor{
 		namespaceRegistry: namespaceRegistry,
 		serializer:        common.NewProtoTaskTokenSerializer(),
 		metricsHandler:    metricsHandler,
 		logger:            logger,
-		logAllErrors:      logAllErrors,
+		logAllReqErrors:   logAllReqErrors,
 	}
 }
 
@@ -376,7 +376,7 @@ func (ti *TelemetryInterceptor) HandleError(req interface{},
 	}
 
 	statusCode := serviceerror.ToStatus(err).Code()
-	logAllErrors := nsName != "" && ti.logAllErrors(nsName.String())
+	logAllErrors := nsName != "" && ti.logAllReqErrors(nsName.String())
 	if !logAllErrors && isUserCaused(statusCode) {
 		return
 	}

--- a/common/rpc/interceptor/telemetry_test.go
+++ b/common/rpc/interceptor/telemetry_test.go
@@ -25,6 +25,8 @@
 package interceptor
 
 import (
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/dynamicconfig"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -57,7 +59,10 @@ func TestEmitActionMetric(t *testing.T) {
 	controller := gomock.NewController(t)
 	register := namespace.NewMockRegistry(controller)
 	metricsHandler := metrics.NewMockHandler(controller)
-	telemetry := NewTelemetryInterceptor(register, metricsHandler, log.NewNoopLogger())
+	telemetry := NewTelemetryInterceptor(register,
+		metricsHandler,
+		log.NewNoopLogger(),
+		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false))
 
 	testCases := []struct {
 		methodName        string
@@ -147,46 +152,133 @@ func TestEmitActionMetric(t *testing.T) {
 
 func TestHandleError(t *testing.T) {
 	controller := gomock.NewController(t)
+	mockLogger := log.NewMockLogger(controller)
 	registry := namespace.NewMockRegistry(controller)
 	metricsHandler := metrics.NewMockHandler(controller)
-	telemetry := NewTelemetryInterceptor(registry, metricsHandler, log.NewNoopLogger())
 
 	testCases := []struct {
-		name                 string
-		err                  error
-		expectServiceFailure bool
+		name                      string
+		err                       error
+		expectLogging             bool
+		ServiceFailuresCount      int
+		ServiceErrorWithTypeCount int
+		ResourceExhaustedCount    int
+		logAllErrors              dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}{
 		{
-			name:                 "serviceerror-invalid-argument",
-			err:                  serviceerror.NewInvalidArgument("invalid argument"),
-			expectServiceFailure: false,
+			name:                      "serviceerror-invalid-argument",
+			err:                       serviceerror.NewInvalidArgument("invalid argument"),
+			expectLogging:             false,
+			ServiceFailuresCount:      0,
+			ResourceExhaustedCount:    0,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		},
 		{
-			name:                 "statuserror-invalid-argument",
-			err:                  status.Error(codes.InvalidArgument, "invalid argument"),
-			expectServiceFailure: false,
+			name:                      "serviceerror-invalid-argument-log-all",
+			err:                       serviceerror.NewInvalidArgument("invalid argument"),
+			expectLogging:             true,
+			ServiceFailuresCount:      0,
+			ResourceExhaustedCount:    0,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
 		},
 		{
-			name:                 "serviceerror-internal",
-			err:                  serviceerror.NewInternal("internal"),
-			expectServiceFailure: true,
+			name:                      "statuserror-invalid-argument",
+			err:                       status.Error(codes.InvalidArgument, "invalid argument"),
+			expectLogging:             false,
+			ServiceFailuresCount:      0,
+			ResourceExhaustedCount:    0,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		},
 		{
-			name:                 "statuserror-internal",
-			err:                  status.Error(codes.Internal, "internal"),
-			expectServiceFailure: true,
+			name:                      "statuserror-invalid-argument-log-all",
+			err:                       status.Error(codes.InvalidArgument, "invalid argument"),
+			expectLogging:             true,
+			ServiceFailuresCount:      0,
+			ResourceExhaustedCount:    0,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+		},
+		{
+			name:                      "serviceerror-internal",
+			err:                       serviceerror.NewInternal("internal"),
+			expectLogging:             true,
+			ServiceFailuresCount:      1,
+			ResourceExhaustedCount:    0,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		},
+		{
+			name:                      "serviceerror-internal-log-all",
+			err:                       serviceerror.NewInternal("internal"),
+			expectLogging:             true,
+			ServiceFailuresCount:      1,
+			ResourceExhaustedCount:    0,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+		},
+		{
+			name:                      "statuserror-internal",
+			err:                       status.Error(codes.Internal, "internal"),
+			expectLogging:             true,
+			ServiceFailuresCount:      1,
+			ResourceExhaustedCount:    0,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		},
+		{
+			name:                      "statuserror-internal-log-all",
+			err:                       status.Error(codes.Internal, "internal"),
+			expectLogging:             true,
+			ServiceFailuresCount:      1,
+			ResourceExhaustedCount:    0,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+		},
+		{
+			name:                      "resource-exhausted",
+			err:                       serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_UNSPECIFIED, "resource exhausted"),
+			expectLogging:             true,
+			ServiceFailuresCount:      0,
+			ResourceExhaustedCount:    1,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		},
+		{
+			name:                      "resource-exhausted",
+			err:                       serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_UNSPECIFIED, "resource exhausted"),
+			expectLogging:             true,
+			ServiceFailuresCount:      0,
+			ResourceExhaustedCount:    1,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			metricsHandler.EXPECT().Counter(metrics.ServiceErrorWithType.Name()).Return(metrics.NoopCounterMetricFunc).Times(1)
-			times := 0
-			if tt.expectServiceFailure {
-				times = 1
+			metricsHandler.EXPECT().Counter(metrics.ServiceFailures.Name()).Return(metrics.NoopCounterMetricFunc).Times(tt.ServiceFailuresCount)
+			metricsHandler.EXPECT().Counter(metrics.ServiceErrorWithType.Name()).Return(metrics.NoopCounterMetricFunc).Times(tt.ServiceErrorWithTypeCount)
+			metricsHandler.EXPECT().Counter(metrics.ServiceErrResourceExhaustedCounter.Name()).Return(metrics.NoopCounterMetricFunc).Times(tt.ResourceExhaustedCount)
+
+			telemetry := NewTelemetryInterceptor(registry,
+				metricsHandler,
+				mockLogger,
+				tt.logAllErrors)
+
+			if tt.expectLogging {
+				mockLogger.EXPECT().Error(gomock.Eq("service failures"), gomock.Any()).Times(1)
+			} else {
+				mockLogger.EXPECT().Error(gomock.Eq("service failures"), gomock.Any()).Times(0)
 			}
-			metricsHandler.EXPECT().Counter(metrics.ServiceFailures.Name()).Return(metrics.NoopCounterMetricFunc).Times(times)
-			telemetry.HandleError(nil, metricsHandler, []tag.Tag{}, tt.err)
+
+			telemetry.HandleError(nil,
+				metricsHandler,
+				[]tag.Tag{},
+				tt.err,
+				"test")
 		})
 	}
 }
@@ -195,7 +287,10 @@ func TestOperationOverwrite(t *testing.T) {
 	controller := gomock.NewController(t)
 	register := namespace.NewMockRegistry(controller)
 	metricsHandler := metrics.NewMockHandler(controller)
-	telemetry := NewTelemetryInterceptor(register, metricsHandler, log.NewNoopLogger())
+	telemetry := NewTelemetryInterceptor(register,
+		metricsHandler,
+		log.NewNoopLogger(),
+		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false))
 
 	testCases := []struct {
 		methodName        string
@@ -232,7 +327,10 @@ func TestGetWorkflowTags(t *testing.T) {
 	registry := namespace.NewMockRegistry(controller)
 	metricsHandler := metrics.NewMockHandler(controller)
 	serializer := common.NewProtoTaskTokenSerializer()
-	telemetry := NewTelemetryInterceptor(registry, metricsHandler, log.NewTestLogger())
+	telemetry := NewTelemetryInterceptor(registry,
+		metricsHandler,
+		log.NewTestLogger(),
+		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false))
 
 	wid := "test_workflow_id"
 	rid := "test_run_id"
@@ -313,7 +411,9 @@ func TestOperationOverride(t *testing.T) {
 	controller := gomock.NewController(t)
 	register := namespace.NewMockRegistry(controller)
 	metricsHandler := metrics.NewMockHandler(controller)
-	telemetry := NewTelemetryInterceptor(register, metricsHandler, log.NewNoopLogger())
+	telemetry := NewTelemetryInterceptor(register, metricsHandler,
+		log.NewNoopLogger(),
+		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false))
 
 	wid := "test_workflow_id"
 	rid := "test_run_id"

--- a/common/rpc/interceptor/telemetry_test.go
+++ b/common/rpc/interceptor/telemetry_test.go
@@ -25,8 +25,6 @@
 package interceptor
 
 import (
-	enumspb "go.temporal.io/api/enums/v1"
-	"go.temporal.io/server/common/dynamicconfig"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -36,6 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	protocolpb "go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
@@ -44,6 +43,7 @@ import (
 	"go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/api"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"

--- a/components/nexusoperations/frontend/handler.go
+++ b/components/nexusoperations/frontend/handler.go
@@ -440,6 +440,7 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexus.Co
 				c.metricsHandlerForInterceptors,
 				[]tag.Tag{tag.Operation(methodNameForMetrics), tag.WorkflowNamespace(c.namespace.Name().String())},
 				retErr,
+				c.namespace.Name(),
 			)
 		}
 	})

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -355,11 +355,13 @@ func TelemetryInterceptorProvider(
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 	namespaceRegistry namespace.Registry,
+	serviceConfig *Config,
 ) *interceptor.TelemetryInterceptor {
 	return interceptor.NewTelemetryInterceptor(
 		namespaceRegistry,
 		metricsHandler,
 		logger,
+		serviceConfig.LogAllErrors,
 	)
 }
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -361,7 +361,7 @@ func TelemetryInterceptorProvider(
 		namespaceRegistry,
 		metricsHandler,
 		logger,
-		serviceConfig.LogAllErrors,
+		serviceConfig.LogAllReqErrors,
 	)
 }
 

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -190,6 +190,7 @@ func (c *operationContext) interceptRequest(ctx context.Context, request *matchi
 				c.metricsHandlerForInterceptors,
 				[]tag.Tag{tag.Operation(c.method), tag.WorkflowNamespace(c.namespaceName)},
 				retErr,
+				c.namespace.Name(),
 			)
 		}
 	})

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -201,6 +201,8 @@ type Config struct {
 
 	// Health check
 	HistoryHostErrorPercentage dynamicconfig.FloatPropertyFn
+
+	LogAllErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 }
 
 // NewConfig returns new service config with default values
@@ -313,6 +315,8 @@ func NewConfig(
 		MaskInternalErrorDetails: dynamicconfig.FrontendMaskInternalErrorDetails.Get(dc),
 
 		HistoryHostErrorPercentage: dynamicconfig.HistoryHostErrorPercentage.Get(dc),
+
+		LogAllErrors: dynamicconfig.LogAllErrors.Get(dc),
 	}
 }
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -202,7 +202,7 @@ type Config struct {
 	// Health check
 	HistoryHostErrorPercentage dynamicconfig.FloatPropertyFn
 
-	LogAllErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	LogAllReqErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 }
 
 // NewConfig returns new service config with default values
@@ -316,7 +316,7 @@ func NewConfig(
 
 		HistoryHostErrorPercentage: dynamicconfig.HistoryHostErrorPercentage.Get(dc),
 
-		LogAllErrors: dynamicconfig.LogAllErrors.Get(dc),
+		LogAllReqErrors: dynamicconfig.LogAllReqErrors.Get(dc),
 	}
 }
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -363,6 +363,8 @@ type Config struct {
 	HealthPersistenceErrorRatio     dynamicconfig.FloatPropertyFn
 
 	BreakdownMetricsByTaskQueue dynamicconfig.BoolPropertyFnWithTaskQueueFilter
+
+	LogAllErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 }
 
 // NewConfig returns new service config with default values
@@ -662,6 +664,8 @@ func NewConfig(
 		HealthPersistenceErrorRatio:     dynamicconfig.HealthPersistenceErrorRatio.Get(dc),
 
 		BreakdownMetricsByTaskQueue: dynamicconfig.MetricsBreakdownByTaskQueue.Get(dc),
+
+		LogAllErrors: dynamicconfig.LogAllErrors.Get(dc),
 	}
 
 	return cfg

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -364,7 +364,7 @@ type Config struct {
 
 	BreakdownMetricsByTaskQueue dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 
-	LogAllErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	LogAllReqErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 }
 
 // NewConfig returns new service config with default values
@@ -665,7 +665,7 @@ func NewConfig(
 
 		BreakdownMetricsByTaskQueue: dynamicconfig.MetricsBreakdownByTaskQueue.Get(dc),
 
-		LogAllErrors: dynamicconfig.LogAllErrors.Get(dc),
+		LogAllReqErrors: dynamicconfig.LogAllReqErrors.Get(dc),
 	}
 
 	return cfg

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -182,11 +182,13 @@ func TelemetryInterceptorProvider(
 	logger log.Logger,
 	namespaceRegistry namespace.Registry,
 	metricsHandler metrics.Handler,
+	configuration *configs.Config,
 ) *interceptor.TelemetryInterceptor {
 	return interceptor.NewTelemetryInterceptor(
 		namespaceRegistry,
 		metricsHandler,
 		logger,
+		configuration.LogAllErrors,
 	)
 }
 

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -188,7 +188,7 @@ func TelemetryInterceptorProvider(
 		namespaceRegistry,
 		metricsHandler,
 		logger,
-		configuration.LogAllReqErrors,
+		serviceConfig.LogAllReqErrors,
 	)
 }
 

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -188,7 +188,7 @@ func TelemetryInterceptorProvider(
 		namespaceRegistry,
 		metricsHandler,
 		logger,
-		configuration.LogAllErrors,
+		configuration.LogAllReqErrors,
 	)
 }
 

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -182,7 +182,7 @@ func TelemetryInterceptorProvider(
 	logger log.Logger,
 	namespaceRegistry namespace.Registry,
 	metricsHandler metrics.Handler,
-	configuration *configs.Config,
+	serviceConfig *configs.Config,
 ) *interceptor.TelemetryInterceptor {
 	return interceptor.NewTelemetryInterceptor(
 		namespaceRegistry,

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -5339,7 +5339,10 @@ func (s *engineSuite) TestEagerWorkflowStart_DoesNotCreateTransferTask() {
 		return &persistenceResponse, nil
 	})
 
-	i := interceptor.NewTelemetryInterceptor(s.mockShard.GetNamespaceRegistry(), s.mockShard.GetMetricsHandler(), s.mockShard.Resource.Logger)
+	i := interceptor.NewTelemetryInterceptor(s.mockShard.GetNamespaceRegistry(),
+		s.mockShard.GetMetricsHandler(),
+		s.mockShard.Resource.Logger,
+		s.config.LogAllErrors)
 	response, err := i.UnaryIntercept(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "StartWorkflowExecution"}, func(ctx context.Context, req interface{}) (interface{}, error) {
 		response, err := s.mockHistoryEngine.StartWorkflowExecution(ctx, &historyservice.StartWorkflowExecutionRequest{
 			NamespaceId: tests.NamespaceID.String(),
@@ -5373,7 +5376,10 @@ func (s *engineSuite) TestEagerWorkflowStart_FromCron_SkipsEager() {
 		return &persistenceResponse, nil
 	})
 
-	i := interceptor.NewTelemetryInterceptor(s.mockShard.GetNamespaceRegistry(), s.mockShard.GetMetricsHandler(), s.mockShard.Resource.Logger)
+	i := interceptor.NewTelemetryInterceptor(s.mockShard.GetNamespaceRegistry(),
+		s.mockShard.GetMetricsHandler(),
+		s.mockShard.Resource.Logger,
+		s.config.LogAllErrors)
 	response, err := i.UnaryIntercept(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "StartWorkflowExecution"}, func(ctx context.Context, req interface{}) (interface{}, error) {
 		firstWorkflowTaskBackoff := time.Second
 		response, err := s.mockHistoryEngine.StartWorkflowExecution(ctx, &historyservice.StartWorkflowExecutionRequest{

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -5342,7 +5342,7 @@ func (s *engineSuite) TestEagerWorkflowStart_DoesNotCreateTransferTask() {
 	i := interceptor.NewTelemetryInterceptor(s.mockShard.GetNamespaceRegistry(),
 		s.mockShard.GetMetricsHandler(),
 		s.mockShard.Resource.Logger,
-		s.config.LogAllErrors)
+		s.config.LogAllReqErrors)
 	response, err := i.UnaryIntercept(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "StartWorkflowExecution"}, func(ctx context.Context, req interface{}) (interface{}, error) {
 		response, err := s.mockHistoryEngine.StartWorkflowExecution(ctx, &historyservice.StartWorkflowExecutionRequest{
 			NamespaceId: tests.NamespaceID.String(),
@@ -5379,7 +5379,7 @@ func (s *engineSuite) TestEagerWorkflowStart_FromCron_SkipsEager() {
 	i := interceptor.NewTelemetryInterceptor(s.mockShard.GetNamespaceRegistry(),
 		s.mockShard.GetMetricsHandler(),
 		s.mockShard.Resource.Logger,
-		s.config.LogAllErrors)
+		s.config.LogAllReqErrors)
 	response, err := i.UnaryIntercept(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "StartWorkflowExecution"}, func(ctx context.Context, req interface{}) (interface{}, error) {
 		firstWorkflowTaskBackoff := time.Second
 		response, err := s.mockHistoryEngine.StartWorkflowExecution(ctx, &historyservice.StartWorkflowExecutionRequest{

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -110,6 +110,8 @@ type (
 		LoadUserData dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 
 		ListNexusEndpointsLongPollTimeout dynamicconfig.DurationPropertyFn
+
+		LogAllErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}
 
 	forwarderConfig struct {
@@ -253,6 +255,8 @@ func NewConfig(
 		VisibilityEnableManualPagination:  dynamicconfig.VisibilityEnableManualPagination.Get(dc),
 
 		ListNexusEndpointsLongPollTimeout: dynamicconfig.MatchingListNexusEndpointsLongPollTimeout.Get(dc),
+
+		LogAllErrors: dynamicconfig.LogAllErrors.Get(dc),
 	}
 }
 

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -111,7 +111,7 @@ type (
 
 		ListNexusEndpointsLongPollTimeout dynamicconfig.DurationPropertyFn
 
-		LogAllErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
+		LogAllReqErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}
 
 	forwarderConfig struct {
@@ -256,7 +256,7 @@ func NewConfig(
 
 		ListNexusEndpointsLongPollTimeout: dynamicconfig.MatchingListNexusEndpointsLongPollTimeout.Get(dc),
 
-		LogAllErrors: dynamicconfig.LogAllErrors.Get(dc),
+		LogAllReqErrors: dynamicconfig.LogAllReqErrors.Get(dc),
 	}
 }
 

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -98,7 +98,7 @@ func TelemetryInterceptorProvider(
 		namespaceRegistry,
 		metricsHandler,
 		logger,
-		serviceConfig.LogAllErrors,
+		serviceConfig.LogAllReqErrors,
 	)
 }
 

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -92,11 +92,13 @@ func TelemetryInterceptorProvider(
 	logger log.Logger,
 	namespaceRegistry namespace.Registry,
 	metricsHandler metrics.Handler,
+	serviceConfig *Config,
 ) *interceptor.TelemetryInterceptor {
 	return interceptor.NewTelemetryInterceptor(
 		namespaceRegistry,
 		metricsHandler,
 		logger,
+		serviceConfig.LogAllErrors,
 	)
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
 Added namespace-filtered dynamic configuration that allows us to enable additional error logging for a specific set of namespaces to aid in investigatory work.

## Why?
<!-- Tell your future self why have you made these changes -->
When investigating certain issues, additional request error logging is beneficial. Having the logging enabled at all times, however, is too noisy.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
