### PR TITLE
Fix TQ dispatch rate for forwarded polls

### DIFF
--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -194,6 +194,10 @@ func (s *taskTracker) rate() float32 {
 	elapsedTime := min(currentTime.Sub(s.bucketStartTime)+s.totalIntervalSize,
 		currentTime.Sub(s.startTime))
 
+	if elapsedTime <= 0 {
+		return 0
+	}
+
 	// rate per second
 	return float32(totalTasks) / float32(elapsedTime.Seconds())
 }
@@ -364,8 +368,8 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 		task.namespace = c.partitionMgr.ns.Name()
 		task.backlogCountHint = c.backlogMgr.BacklogCountHint
 
-		if task.redirectInfo == nil && (!task.isStarted() || !task.started.hasEmptyResponse()) {
-			// only track the original polls, not forwarded ones.
+		if pollMetadata.forwardedFrom == "" && // only track the original polls, not forwarded ones.
+			(!task.isStarted() || !task.started.hasEmptyResponse()) { // Need to filter out the empty "started" ones
 			c.tasksDispatchedInIntervals.incrementTaskCount()
 		}
 		return task, nil

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -120,9 +120,13 @@ func TestAddTasksRate(t *testing.T) {
 	// mini windows will have the following format : (start time, end time)
 	// (0 - 4), (5 - 9), (10 - 14), (15 - 19), (20 - 24), (25 - 29), (30 - 34), ...
 
-	// tasks should be placed in the first mini-window
-	timeSource.Advance(1 * time.Second) // time: 1 second
+	// rate should be zero when no time is passed
+	require.Equal(t, float32(0), tr.rate()) // time: 0
 	trackTasksHelper(tr, 100)
+	require.Equal(t, float32(0), tr.rate()) // still zero because no time is passed
+
+	// tasks should be placed in the first mini-window
+	timeSource.Advance(1 * time.Second)                  // time: 1 second
 	require.InEpsilon(t, float32(100), tr.rate(), 0.001) // 100 tasks added in 1 second = 100 / 1 = 100
 
 	// tasks should be placed in the second mini-window with 6 total seconds elapsed

--- a/tests/describe_task_queue.go
+++ b/tests/describe_task_queue.go
@@ -72,9 +72,7 @@ func (s *DescribeTaskQueueSuite) TestAddNoTasks_ValidateStats() {
 
 func (s *DescribeTaskQueueSuite) TestAddSingleTask_ValidateStats() {
 	s.OverrideDynamicConfig(dynamicconfig.MatchingUpdateAckInterval, 5*time.Second)
-	for i := 0; i < 100; i++ {
-		s.testWithMatchingBehavior(func() { s.publishConsumeWorkflowTasksValidateStats(1, true) })
-	}
+	s.testWithMatchingBehavior(func() { s.publishConsumeWorkflowTasksValidateStats(1, true) })
 }
 
 func (s *DescribeTaskQueueSuite) TestAddMultipleTasksMultiplePartitions_ValidateStats() {

--- a/tests/describe_task_queue.go
+++ b/tests/describe_task_queue.go
@@ -70,7 +70,10 @@ func (s *DescribeTaskQueueSuite) TestAddNoTasks_ValidateStats() {
 }
 
 func (s *DescribeTaskQueueSuite) TestAddSingleTask_ValidateStats() {
-	s.testWithMatchingBehavior(func() { s.publishConsumeWorkflowTasksValidateStats(1, true) })
+	s.OverrideDynamicConfig(dynamicconfig.MatchingUpdateAckInterval, 5*time.Second)
+	for i := 0; i < 100; i++ {
+		s.testWithMatchingBehavior(func() { s.publishConsumeWorkflowTasksValidateStats(1, true) })
+	}
 }
 
 func (s *DescribeTaskQueueSuite) TestAddMultipleTasksMultiplePartitions_ValidateStats() {
@@ -261,7 +264,7 @@ func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(
 			s.Assert().Equal(expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY], actStats.TasksDispatchRate > 0)
 
 			return true
-		}, 3*time.Second, 50*time.Millisecond)
+		}, 10*time.Second, 50*time.Millisecond)
 
 	} else {
 		// Querying the Legacy API
@@ -275,6 +278,6 @@ func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(
 			s.NoError(err)
 			s.NotNil(resp)
 			return resp.TaskQueueStatus.GetBacklogCountHint() == expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW]
-		}, 3*time.Second, 50*time.Millisecond)
+		}, 10*time.Second, 50*time.Millisecond)
 	}
 }

--- a/tests/describe_task_queue.go
+++ b/tests/describe_task_queue.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
+	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -59,37 +60,50 @@ func (s *DescribeTaskQueueSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 }
 
-func (s *DescribeTaskQueueSuite) TestAddNoTasks_ValidateBacklogInfo() {
-	s.publishConsumeWorkflowTasksValidateBacklogInfo(4, 0, true)
-}
-
-func (s *DescribeTaskQueueSuite) TestAddSingleTask_ValidateBacklogInfo() {
-	s.publishConsumeWorkflowTasksValidateBacklogInfo(1, 1, true)
-}
-
-func (s *DescribeTaskQueueSuite) TestAddMultipleTasksMultiplePartitions_ValidateBacklogInfo() {
-	s.publishConsumeWorkflowTasksValidateBacklogInfo(4, 100, true)
-}
-
-func (s *DescribeTaskQueueSuite) TestAddSingleTask_ValidateBacklogInfoLegacyAPIMode() {
-	s.publishConsumeWorkflowTasksValidateBacklogInfo(1, 1, false)
-}
-
-func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateBacklogInfo(partitions int, workflows int, isEnhancedMode bool) {
+func (s *DescribeTaskQueueSuite) TestAddNoTasks_ValidateStats() {
 	// Override the ReadPartitions and WritePartitions
-	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, partitions)
-	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, partitions)
+	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 4)
+	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 4)
 	s.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
 
+	s.publishConsumeWorkflowTasksValidateStats(0, true)
+}
+
+func (s *DescribeTaskQueueSuite) TestAddSingleTask_ValidateStats() {
+	s.testWithMatchingBehavior(func() { s.publishConsumeWorkflowTasksValidateStats(1, true) })
+}
+
+func (s *DescribeTaskQueueSuite) TestAddMultipleTasksMultiplePartitions_ValidateStats() {
+	// Override the ReadPartitions and WritePartitions
+	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 4)
+	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 4)
+	s.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
+
+	s.publishConsumeWorkflowTasksValidateStats(100, true)
+}
+
+func (s *DescribeTaskQueueSuite) TestAddSingleTask_ValidateStatsLegacyAPIMode() {
+	// Override the ReadPartitions and WritePartitions
+	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
+	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
+	s.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
+
+	s.publishConsumeWorkflowTasksValidateStats(1, false)
+}
+
+func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateStats(workflows int, isEnhancedMode bool) {
 	expectedBacklogCount := make(map[enumspb.TaskQueueType]int64)
+	expectedAddRate := make(map[enumspb.TaskQueueType]bool)
+	expectedDispatchRate := make(map[enumspb.TaskQueueType]bool)
+
 	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = 0
-	nullBacklogHeadCreateTime := true
+	expectedAddRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = false
+	expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = false
 
 	tl := s.randomizeStr("backlog-counter-task-queue")
 	tq := &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
 	identity := "worker-multiple-tasks"
 	for i := 0; i < workflows; i++ {
-
 		id := uuid.New()
 		wt := "functional-workflow-multiple-tasks"
 		workflowType := &commonpb.WorkflowType{Name: wt}
@@ -111,10 +125,10 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateBacklogInfo(
 	}
 
 	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = int64(workflows)
-	if workflows > 0 {
-		nullBacklogHeadCreateTime = false
-	}
-	s.validateDescribeTaskQueue(tl, expectedBacklogCount, isEnhancedMode, nullBacklogHeadCreateTime, false, workflows)
+	expectedAddRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = workflows > 0
+	expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = false
+
+	s.validateDescribeTaskQueue(tl, expectedBacklogCount, expectedAddRate, expectedDispatchRate, isEnhancedMode)
 
 	// Poll the tasks
 	for i := 0; i < workflows; {
@@ -128,55 +142,82 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateBacklogInfo(
 			continue // poll again on empty responses
 		}
 		i++
+		_, err := s.client.RespondWorkflowTaskCompleted(NewContext(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Namespace: s.namespace,
+			Identity:  identity,
+			TaskToken: resp1.TaskToken,
+			Commands: []*commandpb.Command{
+				{
+					CommandType: enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK,
+					Attributes: &commandpb.Command_ScheduleActivityTaskCommandAttributes{
+						ScheduleActivityTaskCommandAttributes: &commandpb.ScheduleActivityTaskCommandAttributes{
+							ActivityId:            "activity1",
+							ActivityType:          &commonpb.ActivityType{Name: "activity_type1"},
+							TaskQueue:             &taskqueuepb.TaskQueue{Name: tl},
+							StartToCloseTimeout:   durationpb.New(time.Minute),
+							RequestEagerExecution: false,
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
 	}
 
-	// call describeTaskQueue to verify if the backlog decreased
+	// call describeTaskQueue to verify if the WTF backlog decreased and activity backlog increased
 	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = int64(0)
-	s.validateDescribeTaskQueue(tl, expectedBacklogCount, isEnhancedMode, true, true, workflows)
-}
+	expectedAddRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = workflows > 0
+	expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = workflows > 0
 
-func (s *DescribeTaskQueueSuite) isBacklogHeadCreateTimeCorrect(queueType enumspb.TaskQueueType,
-	backlogHeadCreateTime time.Duration, nullBacklogHeadCreateTime bool) bool {
-	if queueType != enumspb.TASK_QUEUE_TYPE_WORKFLOW {
-		if backlogHeadCreateTime != time.Duration(0) {
-			return false
+	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = int64(workflows)
+	expectedAddRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = workflows > 0
+	expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = false
+
+	s.validateDescribeTaskQueue(tl, expectedBacklogCount, expectedAddRate, expectedDispatchRate, isEnhancedMode)
+
+	// Poll the tasks
+	for i := 0; i < workflows; {
+		resp1, err1 := s.client.PollActivityTaskQueue(
+			NewContext(), &workflowservice.PollActivityTaskQueueRequest{
+				Namespace: s.namespace,
+				TaskQueue: tq,
+				Identity:  identity,
+			},
+		)
+		s.NoError(err1)
+		if resp1 == nil || resp1.GetAttempt() < 1 {
+			continue // poll again on empty responses
 		}
-	} else if nullBacklogHeadCreateTime {
-		if backlogHeadCreateTime != time.Duration(0) {
-			return false
-		}
-	} else {
-		if backlogHeadCreateTime == time.Duration(0) {
-			return false
-		}
+		i++
 	}
-	return true
+
+	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = int64(0)
+	expectedAddRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = workflows > 0
+	expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = workflows > 0
+
+	s.validateDescribeTaskQueue(tl, expectedBacklogCount, expectedAddRate, expectedDispatchRate, isEnhancedMode)
 }
 
-func (s *DescribeTaskQueueSuite) isAddDispatchTasksRateCorrect(queueType enumspb.TaskQueueType, workflows int,
-	backlogAddTasksRate float32, backlogDispatchTasksRate float32, polled bool) bool {
-	if workflows == 0 || queueType != enumspb.TASK_QUEUE_TYPE_WORKFLOW {
-		if backlogAddTasksRate != 0 && backlogDispatchTasksRate != 0 {
-			return false
-		}
-	} else if polled && backlogDispatchTasksRate == 0 {
-		return false
-	} else if backlogAddTasksRate == 0 {
-		return false
-	}
-	return true
+func (s *DescribeTaskQueueSuite) isBacklogHeadCreateTimeCorrect(actualBacklogAge time.Duration, expectEmptyBacklog bool) bool {
+	return expectEmptyBacklog == (actualBacklogAge == time.Duration(0))
 }
 
-func (s *DescribeTaskQueueSuite) isBacklogCountCorrect(backlogCounter int64,
-	expectedBacklogCount map[enumspb.TaskQueueType]int64, queueType enumspb.TaskQueueType) bool {
-	if backlogCounter != expectedBacklogCount[queueType] {
-		return false
-	}
-	return true
+func (s *DescribeTaskQueueSuite) isAddDispatchTasksRateCorrect(
+	actualAddTasksRate float32, actualDispatchTasksRate float32, expectAddRate, expectDispatchRate bool) bool {
+	return expectDispatchRate == (actualDispatchTasksRate != 0) && (expectAddRate == (actualAddTasksRate != 0))
 }
 
-func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(tl string, expectedBacklogCount map[enumspb.TaskQueueType]int64,
-	isEnhancedMode bool, nullBacklogHeadCreateTime bool, polled bool, workflows int) {
+func (s *DescribeTaskQueueSuite) isBacklogCountCorrect(actualBacklogCounter int64, expectedBacklogCount int64) bool {
+	return actualBacklogCounter == expectedBacklogCount
+}
+
+func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(
+	tq string,
+	expectedBacklogCount map[enumspb.TaskQueueType]int64,
+	expectedAddRate map[enumspb.TaskQueueType]bool,
+	expectedDispatchRate map[enumspb.TaskQueueType]bool,
+	isEnhancedMode bool,
+) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -187,7 +228,7 @@ func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(tl string, expectedBa
 		s.Eventually(func() bool {
 			resp, err = s.client.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
 				Namespace:              s.namespace,
-				TaskQueue:              &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				TaskQueue:              &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				ApiMode:                enumspb.DESCRIBE_TASK_QUEUE_MODE_ENHANCED,
 				Versions:               nil, // default version, in this case unversioned queue
 				TaskQueueTypes:         nil, // both types
@@ -203,20 +244,23 @@ func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(tl string, expectedBa
 			types := versionInfo.GetTypesInfo()
 			s.Assert().Equal(len(types), len(expectedBacklogCount))
 
-			validator := true
-			for qT, t := range types {
-				queueType := enumspb.TaskQueueType(qT)
-				backlogCounter := t.Stats.ApproximateBacklogCount
-				backlogHeadCreateTime := t.Stats.ApproximateBacklogAge.AsDuration()
-				backlogAddTasksRate := t.Stats.TasksAddRate
-				backlogDispatchTasksRate := t.Stats.TasksDispatchRate
+			wfStats := types[int32(enumspb.TASK_QUEUE_TYPE_WORKFLOW)].Stats
+			actStats := types[int32(enumspb.TASK_QUEUE_TYPE_ACTIVITY)].Stats
 
-				validator = validator &&
-					s.isBacklogCountCorrect(backlogCounter, expectedBacklogCount, queueType) &&
-					s.isBacklogHeadCreateTimeCorrect(queueType, backlogHeadCreateTime, nullBacklogHeadCreateTime) &&
-					s.isAddDispatchTasksRateCorrect(queueType, workflows, backlogAddTasksRate, backlogDispatchTasksRate, polled)
+			// Waiting until the counts are as expected, then all other metrics must be consistent
+			if wfStats.ApproximateBacklogCount != expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW] ||
+				actStats.ApproximateBacklogCount != expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY] {
+				return false
 			}
-			return validator == true
+
+			s.Assert().Equal(expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW] == 0, wfStats.ApproximateBacklogAge.AsDuration() == time.Duration(0))
+			s.Assert().Equal(expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY] == 0, actStats.ApproximateBacklogAge.AsDuration() == time.Duration(0))
+			s.Assert().Equal(expectedAddRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW], wfStats.TasksAddRate > 0)
+			s.Assert().Equal(expectedAddRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY], actStats.TasksAddRate > 0)
+			s.Assert().Equal(expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW], wfStats.TasksDispatchRate > 0)
+			s.Assert().Equal(expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY], actStats.TasksDispatchRate > 0)
+
+			return true
 		}, 3*time.Second, 50*time.Millisecond)
 
 	} else {
@@ -224,7 +268,7 @@ func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(tl string, expectedBa
 		s.Eventually(func() bool {
 			resp, err = s.client.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
 				Namespace:              s.namespace,
-				TaskQueue:              &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				TaskQueue:              &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				ApiMode:                enumspb.DESCRIBE_TASK_QUEUE_MODE_UNSPECIFIED,
 				IncludeTaskQueueStatus: true,
 			})

--- a/tests/describe_task_queue.go
+++ b/tests/describe_task_queue.go
@@ -72,7 +72,7 @@ func (s *DescribeTaskQueueSuite) TestAddNoTasks_ValidateStats() {
 
 func (s *DescribeTaskQueueSuite) TestAddSingleTask_ValidateStats() {
 	s.OverrideDynamicConfig(dynamicconfig.MatchingUpdateAckInterval, 5*time.Second)
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100; i++ {
 		s.testWithMatchingBehavior(func() { s.publishConsumeWorkflowTasksValidateStats(1, true) })
 	}
 }
@@ -272,7 +272,7 @@ func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(
 			a.GreaterOrEqual(actStats.ApproximateBacklogCount, expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY])
 			a.LessOrEqual(actStats.ApproximateBacklogCount, expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY]+maxBacklogExtraTasks[enumspb.TASK_QUEUE_TYPE_ACTIVITY])
 			a.Equal(wfStats.ApproximateBacklogCount == 0, wfStats.ApproximateBacklogAge.AsDuration() == time.Duration(0))
-			a.Equal(expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY] == 0, actStats.ApproximateBacklogAge.AsDuration() == time.Duration(0))
+			a.Equal(actStats.ApproximateBacklogCount == 0, actStats.ApproximateBacklogAge.AsDuration() == time.Duration(0))
 			a.Equal(expectedAddRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW], wfStats.TasksAddRate > 0)
 			a.Equal(expectedAddRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY], actStats.TasksAddRate > 0)
 			a.Equal(expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW], wfStats.TasksDispatchRate > 0)

--- a/tests/functional_test_base.go
+++ b/tests/functional_test_base.go
@@ -441,3 +441,51 @@ func (s *FunctionalTestBase) registerArchivalNamespace(archivalNamespace string)
 func (s *FunctionalTestBase) OverrideDynamicConfig(setting dynamicconfig.GenericSetting, value any) {
 	s.testCluster.host.overrideDynamicConfigByKey(s.T(), setting.Key(), value)
 }
+
+func (s *FunctionalTestBase) testWithMatchingBehavior(subtest func()) {
+	for _, forcePollForward := range []bool{false, true} {
+		for _, forceTaskForward := range []bool{false, true} {
+			for _, forceAsync := range []bool{false, true} {
+				name := "NoTaskForward"
+				if forceTaskForward {
+					// force two levels of forwarding
+					name = "ForceTaskForward"
+				}
+				if forcePollForward {
+					name += "ForcePollForward"
+				} else {
+					name += "NoPollForward"
+				}
+				if forceAsync {
+					name += "ForceAsync"
+				} else {
+					name += "AllowSync"
+				}
+
+				s.Run(
+					name, func() {
+						if forceTaskForward {
+							s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 13)
+							s.OverrideDynamicConfig(dynamicconfig.TestMatchingLBForceWritePartition, 11)
+						} else {
+							s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
+						}
+						if forcePollForward {
+							s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 13)
+							s.OverrideDynamicConfig(dynamicconfig.TestMatchingLBForceReadPartition, 5)
+						} else {
+							s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
+						}
+						if forceAsync {
+							s.OverrideDynamicConfig(dynamicconfig.TestMatchingDisableSyncMatch, true)
+						} else {
+							s.OverrideDynamicConfig(dynamicconfig.TestMatchingDisableSyncMatch, false)
+						}
+
+						subtest()
+					},
+				)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix the condition that checks for forwarded polls when tracking dispatched tasks. Previously, it was checking if the task is forwarded instead of checking if the poll is forwarded.

## Why?
<!-- Tell your future self why have you made these changes -->
To calculate dispatch rate correctly.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Improved tests to validate stats for all combinations of poll and task being forwarded or not in combination with force or allow sync. Total 8 combinations.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
None.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
None.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No hotfix, but should be patched in 1.25 OSS release.