### PR TITLE
Consider rampPercentage=100 as 'fully-ramped' assignment rule

### DIFF
--- a/service/matching/reachability.go
+++ b/service/matching/reachability.go
@@ -221,18 +221,18 @@ func (rc *reachabilityCalculator) existsBackloggedActivityOrWFTaskAssignedToAny(
 }
 
 func (rc *reachabilityCalculator) isReachableActiveAssignmentRuleTargetOrDefault(buildId string) bool {
-	foundUnrampedRule := false
+	foundFullyRampedRule := false
 	for _, r := range getActiveAssignmentRules(rc.assignmentRules) {
 		if r.GetRule().GetTargetBuildId() == buildId {
 			return true
 		}
-		if r.GetRule().GetPercentageRamp() == nil {
-			// rules after an un-ramped rule will not be reached
-			foundUnrampedRule = true
+		if !isPartiallyRamped(r.GetRule()) {
+			// rules after a fully-ramped rule will not be reached
+			foundFullyRampedRule = true
 			break
 		}
 	}
-	if !foundUnrampedRule && buildId == "" {
+	if !foundFullyRampedRule && buildId == "" {
 		// unversioned is the default, and is reachable
 		return true
 	}
@@ -301,12 +301,12 @@ func (rc *reachabilityCalculator) makeBuildIdQuery(
 	return fmt.Sprintf("%s = %s AND %s%s", searchattribute.TaskQueue, escapedTaskQueue, buildIdsFilter, statusFilter)
 }
 
-// getDefaultBuildId gets the build ID mentioned in the first un-ramped Assignment Rule.
+// getDefaultBuildId gets the build ID mentioned in the first fully-ramped Assignment Rule.
 // If there is no default Build ID, the result for the unversioned queue will be returned.
 // This should only be called on the root.
 func getDefaultBuildId(assignmentRules []*persistencespb.AssignmentRule) string {
 	for _, ar := range getActiveAssignmentRules(assignmentRules) {
-		if !isRamped(ar.GetRule()) {
+		if !isPartiallyRamped(ar.GetRule()) {
 			return ar.GetRule().GetTargetBuildId()
 		}
 	}

--- a/service/matching/reachability.go
+++ b/service/matching/reachability.go
@@ -226,7 +226,7 @@ func (rc *reachabilityCalculator) isReachableActiveAssignmentRuleTargetOrDefault
 		if r.GetRule().GetTargetBuildId() == buildId {
 			return true
 		}
-		if !isPartiallyRamped(r.GetRule()) {
+		if isFullyRamped(r.GetRule()) {
 			// rules after a fully-ramped rule will not be reached
 			foundFullyRampedRule = true
 			break
@@ -306,7 +306,7 @@ func (rc *reachabilityCalculator) makeBuildIdQuery(
 // This should only be called on the root.
 func getDefaultBuildId(assignmentRules []*persistencespb.AssignmentRule) string {
 	for _, ar := range getActiveAssignmentRules(assignmentRules) {
-		if !isPartiallyRamped(ar.GetRule()) {
+		if isFullyRamped(ar.GetRule()) {
 			return ar.GetRule().GetTargetBuildId()
 		}
 	}

--- a/service/matching/reachability_test.go
+++ b/service/matching/reachability_test.go
@@ -126,7 +126,7 @@ func TestExistsBackloggedActivityOrWFAssignedTo(t *testing.T) {
 Assignment Rules:
 [ (3, 50%), (2, nil) (1, nil) ]
 
-Expect 3 and 2 are reachable, but not 1 since it is behind an unconditional rule.
+Expect 3 and 2 are reachable, but not 1 since it is behind an un-ramped rule.
 */
 func TestIsReachableAssignmentRuleTarget(t *testing.T) {
 	t.Parallel()

--- a/service/matching/reachability_test.go
+++ b/service/matching/reachability_test.go
@@ -126,7 +126,7 @@ func TestExistsBackloggedActivityOrWFAssignedTo(t *testing.T) {
 Assignment Rules:
 [ (3, 50%), (2, nil) (1, nil) ]
 
-Expect 3 and 2 are reachable, but not 1 since it is behind an un-ramped rule.
+Expect 3 and 2 are reachable, but not 1 since it is behind a fully-ramped rule.
 */
 func TestIsReachableAssignmentRuleTarget(t *testing.T) {
 	t.Parallel()

--- a/service/matching/reachability_test.go
+++ b/service/matching/reachability_test.go
@@ -134,10 +134,10 @@ func TestIsReachableAssignmentRuleTarget(t *testing.T) {
 	deleteTs := hlc.Next(createTs, commonclock.NewRealTimeSource())
 	rc := &reachabilityCalculator{
 		assignmentRules: []*persistencespb.AssignmentRule{
-			mkAssignmentRulePersistence(mkAssignmentRule("3", mkNewAssignmentPercentageRamp(50)), createTs, nil),
-			mkAssignmentRulePersistence(mkAssignmentRule("2.5", nil), createTs, deleteTs),
-			mkAssignmentRulePersistence(mkAssignmentRule("2", nil), createTs, nil),
-			mkAssignmentRulePersistence(mkAssignmentRule("1", nil), createTs, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("3", 50), createTs, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("2.5"), createTs, deleteTs),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("2"), createTs, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("1"), createTs, nil),
 		},
 	}
 
@@ -155,10 +155,10 @@ func TestGetDefaultBuildId(t *testing.T) {
 	createTs := hlc.Zero(1)
 	deleteTs := hlc.Next(createTs, commonclock.NewRealTimeSource())
 	assignmentRules := []*persistencespb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("3", mkNewAssignmentPercentageRamp(50)), createTs, nil),
-		mkAssignmentRulePersistence(mkAssignmentRule("2.5", nil), createTs, deleteTs),
-		mkAssignmentRulePersistence(mkAssignmentRule("2", nil), createTs, nil),
-		mkAssignmentRulePersistence(mkAssignmentRule("1", nil), createTs, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("3", 50), createTs, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("2.5"), createTs, deleteTs),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("2"), createTs, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("1"), createTs, nil),
 	}
 	assert.Equal(t, "2", getDefaultBuildId(assignmentRules))
 }
@@ -200,7 +200,7 @@ func TestGetReachability_WithVisibility_WithoutRules(t *testing.T) {
 	checkReachability(ctx, t, rc, "", enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE, checkedRuleTargetsForUpstream)
 
 	// reachability("") --> closed_workflows_only (now that "" is not default)
-	rc.assignmentRules = []*persistencespb.AssignmentRule{mkAssignmentRulePersistence(mkAssignmentRule("A", nil), nil, nil)}
+	rc.assignmentRules = []*persistencespb.AssignmentRule{mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("A"), nil, nil)}
 	setVisibilityExpect(t, rc, []string{""}, 0, 1)
 	checkReachability(ctx, t, rc, "", enumspb.BUILD_ID_TASK_REACHABILITY_CLOSED_WORKFLOWS_ONLY, checkedClosedWorkflowExecutionsForUpstreamMiss)
 	rc.assignmentRules = nil // remove rule for rest of test
@@ -223,8 +223,8 @@ func TestGetReachability_WithoutVisibility_WithRules(t *testing.T) {
 	trc := mkTestReachabilityCalculatorWithEmptyVisibility(t)
 	rc := trc.rc
 	rc.assignmentRules = []*persistencespb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("D", mkNewAssignmentPercentageRamp(50)), createTs, nil),
-		mkAssignmentRulePersistence(mkAssignmentRule("A", nil), createTs, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("D", 50), createTs, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("A"), createTs, nil),
 	}
 	rc.redirectRules = []*persistencespb.RedirectRule{
 		mkRedirectRulePersistence(mkRedirectRule("A", "B"), createTs, nil),

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -184,14 +184,14 @@ func (s *PartitionManagerTestSuite) TestRedirectRuleLoadUpstream() {
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_NoVersionDirective() {
 	buildId := "bld"
-	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(buildId)}}
+	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(buildId, 100)}}
 	s.validateAddTask("", false, versioningData, nil)
 	s.validatePollTask("", false)
 }
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_AssignedTask() {
 	ruleBld := "rule-bld"
-	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)}}
+	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(ruleBld, 100)}}
 	taskBld := "task-bld"
 	s.validateAddTask("", false, versioningData, worker_versioning.MakeBuildIdDirective(taskBld))
 	s.validatePollTask(taskBld, true)
@@ -199,14 +199,14 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_AssignedTask(
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_UnassignedTask() {
 	ruleBld := "rule-bld"
-	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)}}
+	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(ruleBld, 100)}}
 	s.validateAddTask(ruleBld, false, versioningData, worker_versioning.MakeUseAssignmentRulesDirective())
 	s.validatePollTask(ruleBld, true)
 }
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_UnassignedTask_SyncMatch() {
 	ruleBld := "rule-bld"
-	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)}}
+	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(ruleBld, 100)}}
 	s.validatePollTaskSyncMatch(ruleBld, true)
 	s.validateAddTask("", true, versioningData, worker_versioning.MakeUseAssignmentRulesDirective())
 }
@@ -215,7 +215,7 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRulesAndVersionSets
 	ruleBld := "rule-bld"
 	vs := createVersionSet("vs-bld")
 	versioningData := &persistence.VersioningData{
-		AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)},
+		AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(ruleBld, 100)},
 		VersionSets:     []*persistence.CompatibleVersionSet{vs},
 	}
 
@@ -229,7 +229,7 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRulesAndVersionSets
 	ruleBld := "rule-bld"
 	vs := createVersionSet("vs-bld")
 	versioningData := &persistence.VersioningData{
-		AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)},
+		AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(ruleBld, 100)},
 		VersionSets:     []*persistence.CompatibleVersionSet{vs},
 	}
 
@@ -250,7 +250,7 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRulesAndVersionSets
 	ruleBld := "rule-bld"
 	vs := createVersionSet("vs-bld")
 	versioningData := &persistence.VersioningData{
-		AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)},
+		AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(ruleBld, 100)},
 		VersionSets:     []*persistence.CompatibleVersionSet{vs},
 	}
 	s.validateAddTask(ruleBld, false, versioningData, worker_versioning.MakeUseAssignmentRulesDirective())

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -184,14 +184,14 @@ func (s *PartitionManagerTestSuite) TestRedirectRuleLoadUpstream() {
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_NoVersionDirective() {
 	buildId := "bld"
-	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(buildId, 100)}}
+	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(buildId)}}
 	s.validateAddTask("", false, versioningData, nil)
 	s.validatePollTask("", false)
 }
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_AssignedTask() {
 	ruleBld := "rule-bld"
-	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(ruleBld, 100)}}
+	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)}}
 	taskBld := "task-bld"
 	s.validateAddTask("", false, versioningData, worker_versioning.MakeBuildIdDirective(taskBld))
 	s.validatePollTask(taskBld, true)
@@ -199,14 +199,14 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_AssignedTask(
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_UnassignedTask() {
 	ruleBld := "rule-bld"
-	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(ruleBld, 100)}}
+	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)}}
 	s.validateAddTask(ruleBld, false, versioningData, worker_versioning.MakeUseAssignmentRulesDirective())
 	s.validatePollTask(ruleBld, true)
 }
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_UnassignedTask_SyncMatch() {
 	ruleBld := "rule-bld"
-	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(ruleBld, 100)}}
+	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)}}
 	s.validatePollTaskSyncMatch(ruleBld, true)
 	s.validateAddTask("", true, versioningData, worker_versioning.MakeUseAssignmentRulesDirective())
 }
@@ -215,7 +215,7 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRulesAndVersionSets
 	ruleBld := "rule-bld"
 	vs := createVersionSet("vs-bld")
 	versioningData := &persistence.VersioningData{
-		AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(ruleBld, 100)},
+		AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)},
 		VersionSets:     []*persistence.CompatibleVersionSet{vs},
 	}
 
@@ -229,7 +229,7 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRulesAndVersionSets
 	ruleBld := "rule-bld"
 	vs := createVersionSet("vs-bld")
 	versioningData := &persistence.VersioningData{
-		AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(ruleBld, 100)},
+		AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)},
 		VersionSets:     []*persistence.CompatibleVersionSet{vs},
 	}
 
@@ -250,7 +250,7 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRulesAndVersionSets
 	ruleBld := "rule-bld"
 	vs := createVersionSet("vs-bld")
 	versioningData := &persistence.VersioningData{
-		AssignmentRules: []*persistence.AssignmentRule{createAssignmentRule(ruleBld, 100)},
+		AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)},
 		VersionSets:     []*persistence.CompatibleVersionSet{vs},
 	}
 	s.validateAddTask(ruleBld, false, versioningData, worker_versioning.MakeUseAssignmentRulesDirective())

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -184,14 +184,14 @@ func (s *PartitionManagerTestSuite) TestRedirectRuleLoadUpstream() {
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_NoVersionDirective() {
 	buildId := "bld"
-	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(buildId)}}
+	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createAssignmentRuleWithoutRamp(buildId)}}
 	s.validateAddTask("", false, versioningData, nil)
 	s.validatePollTask("", false)
 }
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_AssignedTask() {
 	ruleBld := "rule-bld"
-	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)}}
+	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createAssignmentRuleWithoutRamp(ruleBld)}}
 	taskBld := "task-bld"
 	s.validateAddTask("", false, versioningData, worker_versioning.MakeBuildIdDirective(taskBld))
 	s.validatePollTask(taskBld, true)
@@ -199,14 +199,14 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_AssignedTask(
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_UnassignedTask() {
 	ruleBld := "rule-bld"
-	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)}}
+	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createAssignmentRuleWithoutRamp(ruleBld)}}
 	s.validateAddTask(ruleBld, false, versioningData, worker_versioning.MakeUseAssignmentRulesDirective())
 	s.validatePollTask(ruleBld, true)
 }
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_UnassignedTask_SyncMatch() {
 	ruleBld := "rule-bld"
-	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)}}
+	versioningData := &persistence.VersioningData{AssignmentRules: []*persistence.AssignmentRule{createAssignmentRuleWithoutRamp(ruleBld)}}
 	s.validatePollTaskSyncMatch(ruleBld, true)
 	s.validateAddTask("", true, versioningData, worker_versioning.MakeUseAssignmentRulesDirective())
 }
@@ -215,7 +215,7 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRulesAndVersionSets
 	ruleBld := "rule-bld"
 	vs := createVersionSet("vs-bld")
 	versioningData := &persistence.VersioningData{
-		AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)},
+		AssignmentRules: []*persistence.AssignmentRule{createAssignmentRuleWithoutRamp(ruleBld)},
 		VersionSets:     []*persistence.CompatibleVersionSet{vs},
 	}
 
@@ -229,7 +229,7 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRulesAndVersionSets
 	ruleBld := "rule-bld"
 	vs := createVersionSet("vs-bld")
 	versioningData := &persistence.VersioningData{
-		AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)},
+		AssignmentRules: []*persistence.AssignmentRule{createAssignmentRuleWithoutRamp(ruleBld)},
 		VersionSets:     []*persistence.CompatibleVersionSet{vs},
 	}
 
@@ -250,7 +250,7 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRulesAndVersionSets
 	ruleBld := "rule-bld"
 	vs := createVersionSet("vs-bld")
 	versioningData := &persistence.VersioningData{
-		AssignmentRules: []*persistence.AssignmentRule{createFullAssignmentRule(ruleBld)},
+		AssignmentRules: []*persistence.AssignmentRule{createAssignmentRuleWithoutRamp(ruleBld)},
 		VersionSets:     []*persistence.CompatibleVersionSet{vs},
 	}
 	s.validateAddTask(ruleBld, false, versioningData, worker_versioning.MakeUseAssignmentRulesDirective())

--- a/service/matching/version_rule_helper_test.go
+++ b/service/matching/version_rule_helper_test.go
@@ -41,7 +41,7 @@ func TestFindAssignmentBuildId_NoRules(t *testing.T) {
 
 func TestFindAssignmentBuildId_OneFullRule(t *testing.T) {
 	buildId := "bld"
-	b := FindAssignmentBuildId([]*persistencespb.AssignmentRule{createFullAssignmentRule(buildId)}, "")
+	b := FindAssignmentBuildId([]*persistencespb.AssignmentRule{createAssignmentRuleWithoutRamp(buildId)}, "")
 	assert.Equal(t, buildId, b)
 }
 
@@ -50,8 +50,8 @@ func TestFindAssignmentBuildId_TwoFullRules(t *testing.T) {
 	buildId2 := "bld2"
 	b := FindAssignmentBuildId(
 		[]*persistencespb.AssignmentRule{
-			createFullAssignmentRule(buildId),
-			createFullAssignmentRule(buildId2),
+			createAssignmentRuleWithoutRamp(buildId),
+			createAssignmentRuleWithoutRamp(buildId2),
 		},
 		"",
 	)
@@ -66,11 +66,11 @@ func TestFindAssignmentBuildId_WithRamp(t *testing.T) {
 	buildId5 := "bld5"
 
 	rules := []*persistencespb.AssignmentRule{
-		createAssignmentRule(buildId1, 0),
-		createAssignmentRule(buildId2, 20),
-		createAssignmentRule(buildId3, 70),
-		createFullAssignmentRule(buildId4),
-		createAssignmentRule(buildId5, 90),
+		createAssignmentRuleWithRamp(buildId1, 0),
+		createAssignmentRuleWithRamp(buildId2, 20),
+		createAssignmentRuleWithRamp(buildId3, 70),
+		createAssignmentRuleWithoutRamp(buildId4),
+		createAssignmentRuleWithRamp(buildId5, 90),
 	}
 
 	histogram := make(map[string]int)
@@ -109,11 +109,11 @@ func TestCalcRampThresholdDeterministic(t *testing.T) {
 	assert.NotEqual(t, calcRampThreshold(""), calcRampThreshold(""))
 }
 
-func createFullAssignmentRule(buildId string) *persistencespb.AssignmentRule {
+func createAssignmentRuleWithoutRamp(buildId string) *persistencespb.AssignmentRule {
 	return &persistencespb.AssignmentRule{Rule: &taskqueuepb.BuildIdAssignmentRule{TargetBuildId: buildId}}
 }
 
-func createAssignmentRule(buildId string, ramp float32) *persistencespb.AssignmentRule {
+func createAssignmentRuleWithRamp(buildId string, ramp float32) *persistencespb.AssignmentRule {
 	return &persistencespb.AssignmentRule{Rule: &taskqueuepb.BuildIdAssignmentRule{
 		TargetBuildId: buildId,
 		Ramp:          mkNewAssignmentPercentageRamp(ramp),

--- a/service/matching/version_rule_helper_test.go
+++ b/service/matching/version_rule_helper_test.go
@@ -41,7 +41,7 @@ func TestFindAssignmentBuildId_NoRules(t *testing.T) {
 
 func TestFindAssignmentBuildId_OneFullRule(t *testing.T) {
 	buildId := "bld"
-	b := FindAssignmentBuildId([]*persistencespb.AssignmentRule{createAssignmentRule(buildId, 100)}, "")
+	b := FindAssignmentBuildId([]*persistencespb.AssignmentRule{createFullAssignmentRule(buildId)}, "")
 	assert.Equal(t, buildId, b)
 }
 
@@ -50,8 +50,8 @@ func TestFindAssignmentBuildId_TwoFullRules(t *testing.T) {
 	buildId2 := "bld2"
 	b := FindAssignmentBuildId(
 		[]*persistencespb.AssignmentRule{
-			createAssignmentRule(buildId, 100),
-			createAssignmentRule(buildId2, 100),
+			createFullAssignmentRule(buildId),
+			createFullAssignmentRule(buildId2),
 		},
 		"",
 	)
@@ -69,7 +69,7 @@ func TestFindAssignmentBuildId_WithRamp(t *testing.T) {
 		createAssignmentRule(buildId1, 0),
 		createAssignmentRule(buildId2, 20),
 		createAssignmentRule(buildId3, 70),
-		createAssignmentRule(buildId4, 100),
+		createFullAssignmentRule(buildId4),
 		createAssignmentRule(buildId5, 90),
 	}
 
@@ -107,6 +107,10 @@ func TestCalcRampThresholdDeterministic(t *testing.T) {
 
 	// unless it's an empty string which maps randomly each time
 	assert.NotEqual(t, calcRampThreshold(""), calcRampThreshold(""))
+}
+
+func createFullAssignmentRule(buildId string) *persistencespb.AssignmentRule {
+	return &persistencespb.AssignmentRule{Rule: &taskqueuepb.BuildIdAssignmentRule{TargetBuildId: buildId}}
 }
 
 func createAssignmentRule(buildId string, ramp float32) *persistencespb.AssignmentRule {

--- a/service/matching/version_rule_helper_test.go
+++ b/service/matching/version_rule_helper_test.go
@@ -41,7 +41,7 @@ func TestFindAssignmentBuildId_NoRules(t *testing.T) {
 
 func TestFindAssignmentBuildId_OneFullRule(t *testing.T) {
 	buildId := "bld"
-	b := FindAssignmentBuildId([]*persistencespb.AssignmentRule{createFullAssignmentRule(buildId)}, "")
+	b := FindAssignmentBuildId([]*persistencespb.AssignmentRule{createAssignmentRule(buildId, 100)}, "")
 	assert.Equal(t, buildId, b)
 }
 
@@ -50,8 +50,8 @@ func TestFindAssignmentBuildId_TwoFullRules(t *testing.T) {
 	buildId2 := "bld2"
 	b := FindAssignmentBuildId(
 		[]*persistencespb.AssignmentRule{
-			createFullAssignmentRule(buildId),
-			createFullAssignmentRule(buildId2),
+			createAssignmentRule(buildId, 100),
+			createAssignmentRule(buildId2, 100),
 		},
 		"",
 	)
@@ -66,11 +66,11 @@ func TestFindAssignmentBuildId_WithRamp(t *testing.T) {
 	buildId5 := "bld5"
 
 	rules := []*persistencespb.AssignmentRule{
-		createAssignmentRuleWithRamp(buildId1, 0),
-		createAssignmentRuleWithRamp(buildId2, 20),
-		createAssignmentRuleWithRamp(buildId3, 70),
-		createFullAssignmentRule(buildId4),
-		createAssignmentRuleWithRamp(buildId5, 90),
+		createAssignmentRule(buildId1, 0),
+		createAssignmentRule(buildId2, 20),
+		createAssignmentRule(buildId3, 70),
+		createAssignmentRule(buildId4, 100),
+		createAssignmentRule(buildId5, 90),
 	}
 
 	histogram := make(map[string]int)
@@ -109,11 +109,7 @@ func TestCalcRampThresholdDeterministic(t *testing.T) {
 	assert.NotEqual(t, calcRampThreshold(""), calcRampThreshold(""))
 }
 
-func createFullAssignmentRule(buildId string) *persistencespb.AssignmentRule {
-	return &persistencespb.AssignmentRule{Rule: &taskqueuepb.BuildIdAssignmentRule{TargetBuildId: buildId}}
-}
-
-func createAssignmentRuleWithRamp(buildId string, ramp float32) *persistencespb.AssignmentRule {
+func createAssignmentRule(buildId string, ramp float32) *persistencespb.AssignmentRule {
 	return &persistencespb.AssignmentRule{Rule: &taskqueuepb.BuildIdAssignmentRule{
 		TargetBuildId: buildId,
 		Ramp:          mkNewAssignmentPercentageRamp(ramp),

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -77,7 +77,7 @@ var (
 	// default queue. It's important that users do not accidentally make the unversioned queue the default after the
 	// unversioned worker has already been decommissioned, so we throw this error. If you are intentionally reverting from
 	// a versioned default Build ID to an unversioned default Build ID, use force=true to bypass this requirement.
-	errRequireFullyRampedAssignmentRule = serviceerror.NewFailedPrecondition("there must exist at least one fully-ramped assignment rule, use force=true to bypass this requirement and make the unversioned queue the default")
+	errRequireFullyRampedAssignmentRule = serviceerror.NewFailedPrecondition("at least one fully-ramped assignment rule must exist (use force=true to bypass this requirement and set the unversioned queue as the default)")
 	errExceedsMaxRedirectRules          = func(cnt, max int) error {
 		return serviceerror.NewFailedPrecondition(fmt.Sprintf("update exceeds number of redirect rules permitted in namespace (%v/%v)", cnt, max))
 	}

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -312,7 +312,10 @@ func CommitBuildID(timestamp *hlc.Clock,
 	}
 
 	data.AssignmentRules = append(data.GetAssignmentRules(), &persistencespb.AssignmentRule{
-		Rule:            &taskqueue.BuildIdAssignmentRule{TargetBuildId: target},
+		Rule: &taskqueue.BuildIdAssignmentRule{
+			TargetBuildId: target,
+			Ramp:          &taskqueue.BuildIdAssignmentRule_PercentageRamp{PercentageRamp: &taskqueue.RampByPercentage{RampPercentage: 100}},
+		},
 		CreateTimestamp: timestamp,
 	})
 	if err := checkAssignmentConditions(data, maxAssignmentRules, false); err != nil {

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -495,14 +495,16 @@ func given2ActualIdx(idx int32, rules []*persistencespb.AssignmentRule) int {
 	return -1
 }
 
-// handleAssignmentRuleNilRamp converts a rule with nil ramp to have 100% ramp and returns the same rule object
+// handleAssignmentRuleNilRamp returns a new rule object. If the ramp was nil, it is converted to 100%
 func handleAssignmentRuleNilRamp(rule *taskqueue.BuildIdAssignmentRule) *taskqueue.BuildIdAssignmentRule {
-	if rule.GetRamp() == nil {
-		rule.Ramp = &taskqueue.BuildIdAssignmentRule_PercentageRamp{
-			PercentageRamp: &taskqueue.RampByPercentage{RampPercentage: 100},
-		}
+	rampPercentage := float32(100)
+	if rule.GetRamp() != nil {
+		rampPercentage = rule.GetPercentageRamp().GetRampPercentage()
 	}
-	return rule
+	return &taskqueue.BuildIdAssignmentRule{
+		TargetBuildId: rule.GetTargetBuildId(),
+		Ramp:          &taskqueue.BuildIdAssignmentRule_PercentageRamp{PercentageRamp: &taskqueue.RampByPercentage{RampPercentage: rampPercentage}},
+	}
 }
 
 // isValidRamp returns true if the percentage ramp is within [0, 100]

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -281,10 +281,8 @@ func CleanupRuleTombstones(versioningData *persistencespb.VersioningData,
 // CommitBuildID makes the following changes. If no worker that can accept tasks for the
 // target build ID has been seen recently, the operation will fail.
 // To override this check, set the force flag:
-//  1. Adds a fully-ramped assignment rule for the target Build ID at the
-//     end of the list. A fully-ramped assignment rule:
-//     - Has no hint filter
-//     - Has a ramp percentage of 100
+//  1. Adds a fully-ramped assignment rule for the target Build ID at the end of the list.
+//     A fully-ramped assignment rule has a ramp percentage of 100 or a ramp of nil.
 //  2. Removes all previously added assignment rules to the given target
 //     Build ID (if any).
 //  3. Removes any *fully-ramped* assignment rule for other Build IDs.

--- a/service/matching/version_rule_test.go
+++ b/service/matching/version_rule_test.go
@@ -84,6 +84,8 @@ func mkAssignmentRule(target string, ramp *taskqueuepb.BuildIdAssignmentRule_Per
 	// because casting Rule to (*BuildIdAssignmentRule_WorkerRatioRamp) succeeds
 	if ramp != nil {
 		ret.Ramp = ramp
+	} else {
+		ret.Ramp = mkNewAssignmentPercentageRamp(100)
 	}
 	return ret
 }

--- a/service/matching/version_rule_test.go
+++ b/service/matching/version_rule_test.go
@@ -211,7 +211,7 @@ func TestInsertAssignmentRuleBasic(t *testing.T) {
 	maxRules := 10
 	clock := hlc.Zero(1)
 	initialData := mkInitialData(0, clock)
-	assert.False(t, containsUnconditional(initialData.GetAssignmentRules()))
+	assert.False(t, containsUnramped(initialData.GetAssignmentRules()))
 	expected := &persistencepb.VersioningData{AssignmentRules: []*persistencepb.AssignmentRule{}}
 
 	// insert at index 0
@@ -419,7 +419,7 @@ func TestReplaceAssignmentRuleRampedRuleIsRedirectSource(t *testing.T) {
 	assert.Equal(t, errRampedAssignmentRuleIsRedirectRuleSource, err)
 }
 
-func TestReplaceAssignmentRuleTestRequireUnconditional(t *testing.T) {
+func TestReplaceAssignmentRuleTestRequireUnramped(t *testing.T) {
 	t.Parallel()
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
@@ -434,7 +434,7 @@ func TestReplaceAssignmentRuleTestRequireUnconditional(t *testing.T) {
 	}
 	_, err = replaceAssignmentRule(mkAssignmentRule("2", mkNewAssignmentPercentageRamp(20)), data, clock, 0, false)
 	assert.Error(t, err)
-	assert.Equal(t, errRequireUnconditionalAssignmentRule, err)
+	assert.Equal(t, errRequireUnrampedAssignmentRule, err)
 
 	// same as above but with force --> success
 	_, err = replaceAssignmentRule(mkAssignmentRule("4", mkNewAssignmentPercentageRamp(20)), data, clock, 0, true)
@@ -527,7 +527,7 @@ func TestDeleteAssignmentRuleBasic(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestDeleteAssignmentRuleTestRequireUnconditional(t *testing.T) {
+func TestDeleteAssignmentRuleTestRequireUnramped(t *testing.T) {
 	t.Parallel()
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
@@ -542,7 +542,7 @@ func TestDeleteAssignmentRuleTestRequireUnconditional(t *testing.T) {
 	}
 	_, err = deleteAssignmentRule(data, clock, 0, false)
 	assert.Error(t, err)
-	assert.Equal(t, errRequireUnconditionalAssignmentRule, err)
+	assert.Equal(t, errRequireUnrampedAssignmentRule, err)
 
 	// same as above but with force --> success
 	_, err = deleteAssignmentRule(data, clock, 0, true)
@@ -647,7 +647,7 @@ func TestAddRedirectRuleInVersionSet(t *testing.T) {
 	assert.Equal(t, errTargetIsVersionSetMember, err)
 }
 
-func TestAddRedirectRuleSourceIsConditionalAssignmentRuleTarget(t *testing.T) {
+func TestAddRedirectRuleSourceIsRampedAssignmentRuleTarget(t *testing.T) {
 	t.Parallel()
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
@@ -659,7 +659,7 @@ func TestAddRedirectRuleSourceIsConditionalAssignmentRuleTarget(t *testing.T) {
 	// insert redirect rule with target 1 --> failure
 	_, err := insertRedirectRule(mkRedirectRule("1", "0"), data, clock, ignoreMaxRules, ignoreMaxUpstreamBuildIDs)
 	assert.Error(t, err)
-	assert.Equal(t, errSourceIsConditionalAssignmentRuleTarget, err)
+	assert.Equal(t, errSourceIsRampedAssignmentRuleTarget, err)
 }
 
 func TestAddRedirectRuleAlreadyExists(t *testing.T) {

--- a/service/matching/version_rule_test.go
+++ b/service/matching/version_rule_test.go
@@ -76,14 +76,17 @@ func mkAssignmentRulePersistence(rule *taskqueuepb.BuildIdAssignmentRule, create
 	}
 }
 
-func mkAssignmentRule(target string, ramp *taskqueuepb.BuildIdAssignmentRule_PercentageRamp) *taskqueuepb.BuildIdAssignmentRule {
+func mkAssignmentRuleWithoutRamp(target string) *taskqueuepb.BuildIdAssignmentRule {
 	ret := &taskqueuepb.BuildIdAssignmentRule{
 		TargetBuildId: target,
 	}
-	// if ramp == nil and is set above, there is a nil-pointer error in GetPercentageRamp()
-	// because casting Rule to (*BuildIdAssignmentRule_WorkerRatioRamp) succeeds
-	if ramp != nil {
-		ret.Ramp = ramp
+	return ret
+}
+
+func mkAssignmentRuleWithRamp(target string, rampPercentage float32) *taskqueuepb.BuildIdAssignmentRule {
+	ret := &taskqueuepb.BuildIdAssignmentRule{
+		TargetBuildId: target,
+		Ramp:          mkNewAssignmentPercentageRamp(rampPercentage),
 	}
 	return ret
 }
@@ -215,36 +218,36 @@ func TestInsertAssignmentRuleBasic(t *testing.T) {
 	expected := &persistencepb.VersioningData{AssignmentRules: []*persistencepb.AssignmentRule{}}
 
 	// insert at index 0
-	rule1 := mkAssignmentRule("1", nil)
+	rule1 := mkAssignmentRuleWithoutRamp("1")
 	data, err := insertAssignmentRule(rule1, initialData, clock, 0, maxRules)
 	assert.NoError(t, err)
-	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 0, mkAssignmentRulePersistence(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(100)), clock, nil))
+	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 0, mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("1", 100), clock, nil))
 	protoassert.ProtoEqual(t, expected, data)
 
-	rule2 := mkAssignmentRule("2", nil)
+	rule2 := mkAssignmentRuleWithoutRamp("2")
 	data, err = insertAssignmentRule(rule2, data, clock, 0, maxRules)
 	assert.NoError(t, err)
-	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 0, mkAssignmentRulePersistence(mkAssignmentRule("2", mkNewAssignmentPercentageRamp(100)), clock, nil))
+	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 0, mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("2", 100), clock, nil))
 	protoassert.ProtoEqual(t, expected, data)
 
-	rule3 := mkAssignmentRule("3", nil)
+	rule3 := mkAssignmentRuleWithoutRamp("3")
 	data, err = insertAssignmentRule(rule3, data, clock, 0, maxRules)
 	assert.NoError(t, err)
-	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 0, mkAssignmentRulePersistence(mkAssignmentRule("3", mkNewAssignmentPercentageRamp(100)), clock, nil))
+	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 0, mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("3", 100), clock, nil))
 	protoassert.ProtoEqual(t, expected, data)
 
 	// insert into the middle
-	rule4 := mkAssignmentRule("4", nil)
+	rule4 := mkAssignmentRuleWithoutRamp("4")
 	data, err = insertAssignmentRule(rule4, data, clock, 2, maxRules)
 	assert.NoError(t, err)
-	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 2, mkAssignmentRulePersistence(mkAssignmentRule("4", mkNewAssignmentPercentageRamp(100)), clock, nil))
+	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 2, mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("4", 100), clock, nil))
 	protoassert.ProtoEqual(t, expected, data)
 
 	// insert with a too-big index, it should be at the back
-	rule5 := mkAssignmentRule("5", nil)
+	rule5 := mkAssignmentRuleWithoutRamp("5")
 	data, err = insertAssignmentRule(rule5, data, clock, 100, maxRules)
 	assert.NoError(t, err)
-	expected.AssignmentRules = append(expected.AssignmentRules, mkAssignmentRulePersistence(mkAssignmentRule("5", mkNewAssignmentPercentageRamp(100)), clock, nil))
+	expected.AssignmentRules = append(expected.AssignmentRules, mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("5", 100), clock, nil))
 	protoassert.ProtoEqual(t, expected, data)
 
 	// initial data should be unmodified
@@ -260,12 +263,12 @@ func TestInsertAssignmentRuleMaxRules(t *testing.T) {
 
 	// insert 3x --> success
 	for i := 0; i < 3; i++ {
-		data, err = insertAssignmentRule(mkAssignmentRule("1", nil), data, clock, 0, maxRules)
+		data, err = insertAssignmentRule(mkAssignmentRuleWithoutRamp("1"), data, clock, 0, maxRules)
 		assert.NoError(t, err)
 	}
 
 	// insert fourth --> error
-	_, err = insertAssignmentRule(mkAssignmentRule("1", nil), data, clock, 0, maxRules)
+	_, err = insertAssignmentRule(mkAssignmentRuleWithoutRamp("1"), data, clock, 0, maxRules)
 	assert.Error(t, err)
 	assert.Equal(t, errExceedsMaxAssignmentRules(4, maxRules), err)
 }
@@ -277,7 +280,7 @@ func TestInsertAssignmentRuleInVersionSet(t *testing.T) {
 	data := mkInitialData(1, clock)
 
 	// target 0 --> failure
-	_, err := insertAssignmentRule(mkAssignmentRule("0", nil), data, clock, 0, ignoreMaxRules)
+	_, err := insertAssignmentRule(mkAssignmentRuleWithoutRamp("0"), data, clock, 0, ignoreMaxRules)
 	assert.Error(t, err)
 	assert.Equal(t, errTargetIsVersionSetMember, err)
 }
@@ -289,7 +292,7 @@ func TestInsertAssignmentRulePartiallyRampedRuleIsRedirectSource(t *testing.T) {
 	assert.NoError(t, err)
 
 	// insert 1 --> failure
-	_, err = insertAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(10)), data, clock, 0, ignoreMaxRules)
+	_, err = insertAssignmentRule(mkAssignmentRuleWithRamp("0", 10), data, clock, 0, ignoreMaxRules)
 	assert.Error(t, err)
 	assert.Equal(t, errPartiallyRampedAssignmentRuleIsRedirectRuleSource, err)
 }
@@ -300,7 +303,7 @@ func TestInsertAssignmentRuleInvalidNegativeIndex(t *testing.T) {
 	data := mkInitialData(0, clock)
 
 	// insert @ -1 --> failure
-	_, err := insertAssignmentRule(mkAssignmentRule("0", nil), data, clock, -1, ignoreMaxRules)
+	_, err := insertAssignmentRule(mkAssignmentRuleWithoutRamp("0"), data, clock, -1, ignoreMaxRules)
 	assert.Error(t, err)
 	assert.Equal(t, errInvalidNegativeIndex, err)
 }
@@ -311,12 +314,12 @@ func TestInsertAssignmentRuleInvalidRampPercentage(t *testing.T) {
 	data := mkInitialData(0, clock)
 
 	// insert with ramp percent < 0 --> failure
-	_, err := insertAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(-1)), data, clock, 0, ignoreMaxRules)
+	_, err := insertAssignmentRule(mkAssignmentRuleWithRamp("0", -1), data, clock, 0, ignoreMaxRules)
 	assert.Error(t, err)
 	assert.Equal(t, errInvalidRampPercentage, err)
 
 	// insert with ramp percent > 100 --> failure
-	_, err = insertAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(101)), data, clock, 0, ignoreMaxRules)
+	_, err = insertAssignmentRule(mkAssignmentRuleWithRamp("0", 101), data, clock, 0, ignoreMaxRules)
 	assert.Error(t, err)
 	assert.Equal(t, errInvalidRampPercentage, err)
 }
@@ -330,7 +333,7 @@ func TestReplaceAssignmentRuleBasic(t *testing.T) {
 	var err error
 
 	// start with three rules to replace
-	rule1 := mkAssignmentRule("1", nil)
+	rule1 := mkAssignmentRuleWithoutRamp("1")
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
 		mkAssignmentRulePersistence(rule1, clock, nil),
 		mkAssignmentRulePersistence(rule1, clock, nil),
@@ -344,32 +347,32 @@ func TestReplaceAssignmentRuleBasic(t *testing.T) {
 
 	// [1, 1, 1] --> [1, 1, 2]
 	// [1A, 1A, 1A] --> [1A, 1A, 2A, 1D]
-	rule2 := mkAssignmentRule("2", nil)
+	rule2 := mkAssignmentRuleWithoutRamp("2")
 	clock = hlc.Next(clock, timesource)
 	data, err = replaceAssignmentRule(rule2, data, clock, 2, false)
 	assert.NoError(t, err)
 	expected.AssignmentRules[2].DeleteTimestamp = clock
-	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 2, mkAssignmentRulePersistence(mkAssignmentRule("2", mkNewAssignmentPercentageRamp(100)), clock, nil))
+	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 2, mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("2", 100), clock, nil))
 	protoassert.ProtoEqual(t, expected, data)
 
 	// [1, 1, 2] --> [0, 1, 2]
 	// [1A, 1A, 2A, 1D] --> [0A, 1D, 1A, 2A, 1D]
-	rule0 := mkAssignmentRule("0", nil)
+	rule0 := mkAssignmentRuleWithoutRamp("0")
 	clock = hlc.Next(clock, timesource)
 	data, err = replaceAssignmentRule(rule0, data, clock, 0, false)
 	assert.NoError(t, err)
 	expected.AssignmentRules[0].DeleteTimestamp = clock
-	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 0, mkAssignmentRulePersistence(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(100)), clock, nil))
+	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 0, mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("0", 100), clock, nil))
 	protoassert.ProtoEqual(t, expected, data)
 
 	// [0, 1, 2] --> [0, 11, 2]
 	// [0A, 1D, 1A, 2A, 1D] --> [0A, 1D, 11A, 1D, 2A, 1D]
-	rule11 := mkAssignmentRule("11", nil)
+	rule11 := mkAssignmentRuleWithoutRamp("11")
 	clock = hlc.Next(clock, timesource)
 	data, err = replaceAssignmentRule(rule11, data, clock, 1, false)
 	assert.NoError(t, err)
 	expected.AssignmentRules[2].DeleteTimestamp = clock
-	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 2, mkAssignmentRulePersistence(mkAssignmentRule("11", mkNewAssignmentPercentageRamp(100)), clock, nil))
+	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 2, mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("11", 100), clock, nil))
 	protoassert.ProtoEqual(t, expected, data)
 
 	// out-of-bounds indices --> failure
@@ -386,11 +389,11 @@ func TestReplaceAssignmentRuleInVersionSet(t *testing.T) {
 	data := mkInitialData(1, clock)
 	var err error
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("1", nil), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("1"), clock, nil),
 	}
 
 	// replace 0 --> failure
-	_, err = replaceAssignmentRule(mkAssignmentRule("0", nil), data, clock, 0, false)
+	_, err = replaceAssignmentRule(mkAssignmentRuleWithoutRamp("0"), data, clock, 0, false)
 	assert.Error(t, err)
 	assert.Equal(t, errTargetIsVersionSetMember, err)
 }
@@ -400,15 +403,15 @@ func TestReplaceAssignmentRulePartiallyRampedRuleIsRedirectSource(t *testing.T) 
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("9", nil), clock, nil),
-		mkAssignmentRulePersistence(mkAssignmentRule("10", nil), clock, nil), // to avoid triggering "fully-ramped" error
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("9"), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("10"), clock, nil), // to avoid triggering "fully-ramped" error
 	}
 	data.RedirectRules = []*persistencepb.RedirectRule{
 		mkRedirectRulePersistence(mkRedirectRule("0", "1"), clock, nil),
 	}
 
 	// replace with target isSource and ramp < 100 --> failure
-	_, err := replaceAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(10)), data, clock, 0, false)
+	_, err := replaceAssignmentRule(mkAssignmentRuleWithRamp("0", 10), data, clock, 0, false)
 	assert.Error(t, err)
 	assert.Equal(t, errPartiallyRampedAssignmentRuleIsRedirectRuleSource, err)
 }
@@ -419,19 +422,19 @@ func TestReplaceAssignmentRuleTestRequireFullyRamped(t *testing.T) {
 	data := mkInitialData(0, clock)
 	var err error
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(10)), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("1", 10), clock, nil),
 	}
 
 	// replace fully-ramped rule with partially-ramped rule --> failure
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("1", nil), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("1"), clock, nil),
 	}
-	_, err = replaceAssignmentRule(mkAssignmentRule("2", mkNewAssignmentPercentageRamp(20)), data, clock, 0, false)
+	_, err = replaceAssignmentRule(mkAssignmentRuleWithRamp("2", 20), data, clock, 0, false)
 	assert.Error(t, err)
 	assert.Equal(t, errRequireFullyRampedAssignmentRule, err)
 
 	// same as above but with force --> success
-	_, err = replaceAssignmentRule(mkAssignmentRule("4", mkNewAssignmentPercentageRamp(20)), data, clock, 0, true)
+	_, err = replaceAssignmentRule(mkAssignmentRuleWithRamp("4", 20), data, clock, 0, true)
 	assert.NoError(t, err)
 }
 
@@ -440,16 +443,16 @@ func TestReplaceAssignmentRuleIndexOutOfBounds(t *testing.T) {
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("1", nil), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("1"), clock, nil),
 	}
 
 	// replace @ -1 --> failure
-	_, err := replaceAssignmentRule(mkAssignmentRule("0", nil), data, clock, -1, false)
+	_, err := replaceAssignmentRule(mkAssignmentRuleWithoutRamp("0"), data, clock, -1, false)
 	assert.Error(t, err)
 	assert.Equal(t, errAssignmentRuleIndexOutOfBounds(-1, len(data.AssignmentRules)), err)
 
 	// replace @ 1 --> failure
-	_, err = replaceAssignmentRule(mkAssignmentRule("0", nil), data, clock, 1, false)
+	_, err = replaceAssignmentRule(mkAssignmentRuleWithoutRamp("0"), data, clock, 1, false)
 	assert.Error(t, err)
 	assert.Equal(t, errAssignmentRuleIndexOutOfBounds(1, len(data.AssignmentRules)), err)
 }
@@ -459,16 +462,16 @@ func TestReplaceAssignmentRuleInvalidRampPercentage(t *testing.T) {
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("1", nil), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("1"), clock, nil),
 	}
 
 	// replace with ramp percent < 0 --> failure
-	_, err := replaceAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(-1)), data, clock, 0, false)
+	_, err := replaceAssignmentRule(mkAssignmentRuleWithRamp("0", -1), data, clock, 0, false)
 	assert.Error(t, err)
 	assert.Equal(t, errInvalidRampPercentage, err)
 
 	// replace with ramp percent > 100 --> failure
-	_, err = replaceAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(101)), data, clock, 0, false)
+	_, err = replaceAssignmentRule(mkAssignmentRuleWithRamp("0", 101), data, clock, 0, false)
 	assert.Error(t, err)
 	assert.Equal(t, errInvalidRampPercentage, err)
 }
@@ -489,7 +492,7 @@ func TestDeleteAssignmentRuleBasic(t *testing.T) {
 	}
 
 	// start with three rules inserted at different times
-	rule1 := mkAssignmentRule("1", nil)
+	rule1 := mkAssignmentRuleWithoutRamp("1")
 	data.AssignmentRules = slices.Insert(data.AssignmentRules, 0, mkAssignmentRulePersistence(rule1, clock, nil))
 	expected.AssignmentRules = slices.Insert(expected.AssignmentRules, 0, mkAssignmentRulePersistence(rule1, clock, nil))
 	data.AssignmentRules = slices.Insert(data.AssignmentRules, 0, mkAssignmentRulePersistence(rule1, nextClock(), nil))
@@ -522,12 +525,12 @@ func TestDeleteAssignmentRuleTestRequireFullyRamped(t *testing.T) {
 	data := mkInitialData(0, clock)
 	var err error
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(10)), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("1", 10), clock, nil),
 	}
 
 	// delete only fully-ramped rule --> failure
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("1", nil), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("1"), clock, nil),
 	}
 	_, err = deleteAssignmentRule(data, clock, 0, false)
 	assert.Error(t, err)
@@ -539,8 +542,8 @@ func TestDeleteAssignmentRuleTestRequireFullyRamped(t *testing.T) {
 
 	// delete one of two fully-ramped rules --> success
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("1", nil), clock, nil),
-		mkAssignmentRulePersistence(mkAssignmentRule("1", nil), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("1"), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("1"), clock, nil),
 	}
 	_, err = deleteAssignmentRule(data, clock, 0, false)
 	assert.NoError(t, err)
@@ -551,7 +554,7 @@ func TestDeleteAssignmentRuleIndexOutOfBounds(t *testing.T) {
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("1", nil), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("1"), clock, nil),
 	}
 
 	// delete @ -1 --> failure
@@ -641,8 +644,8 @@ func TestAddRedirectRuleSourceIsPartiallyRampedAssignmentRuleTarget(t *testing.T
 	clock := hlc.Zero(1)
 	data := mkInitialData(0, clock)
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(10)), clock, nil),
-		mkAssignmentRulePersistence(mkAssignmentRule("2", nil), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("1", 10), clock, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("2"), clock, nil),
 	}
 
 	// insert redirect rule with target 1 --> failure
@@ -915,10 +918,10 @@ func TestGetWorkerVersioningRules(t *testing.T) {
 	clock2 := hlc.Next(clock1, commonclock.NewRealTimeSource())
 	data := &persistencepb.VersioningData{
 		AssignmentRules: []*persistencepb.AssignmentRule{
-			mkAssignmentRulePersistence(mkAssignmentRule("1", nil), clock1, nil),
-			mkAssignmentRulePersistence(mkAssignmentRule("10", nil), clock2, nil),
-			mkAssignmentRulePersistence(mkAssignmentRule("10", nil), clock1, clock2),
-			mkAssignmentRulePersistence(mkAssignmentRule("100", nil), clock2, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("1"), clock1, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("10"), clock2, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("10"), clock1, clock2),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("100"), clock2, nil),
 		},
 		RedirectRules: []*persistencepb.RedirectRule{
 			mkRedirectRulePersistence(mkRedirectRule("1", "2"), clock1, nil),
@@ -937,15 +940,15 @@ func TestGetWorkerVersioningRules(t *testing.T) {
 	assignmentRules := resp.GetResponse().GetAssignmentRules()
 	assert.Equal(t, 3, len(assignmentRules))
 	protoassert.ProtoEqual(t, &taskqueuepb.TimestampedBuildIdAssignmentRule{
-		Rule:       mkAssignmentRule("1", nil),
+		Rule:       mkAssignmentRuleWithoutRamp("1"),
 		CreateTime: hlc.ProtoTimestamp(clock1),
 	}, assignmentRules[0])
 	protoassert.ProtoEqual(t, &taskqueuepb.TimestampedBuildIdAssignmentRule{
-		Rule:       mkAssignmentRule("10", nil),
+		Rule:       mkAssignmentRuleWithoutRamp("10"),
 		CreateTime: hlc.ProtoTimestamp(clock2),
 	}, assignmentRules[1])
 	protoassert.ProtoEqual(t, &taskqueuepb.TimestampedBuildIdAssignmentRule{
-		Rule:       mkAssignmentRule("100", nil),
+		Rule:       mkAssignmentRuleWithoutRamp("100"),
 		CreateTime: hlc.ProtoTimestamp(clock2),
 	}, assignmentRules[2])
 
@@ -1041,17 +1044,17 @@ func TestCommitBuildIDBasic(t *testing.T) {
 	clock2 := hlc.Next(clock1, timesource)
 	data := &persistencepb.VersioningData{
 		AssignmentRules: []*persistencepb.AssignmentRule{
-			mkAssignmentRulePersistence(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(1)), clock1, nil),
-			mkAssignmentRulePersistence(mkAssignmentRule("10", mkNewAssignmentPercentageRamp(1)), clock1, nil),
-			mkAssignmentRulePersistence(mkAssignmentRule("100", mkNewAssignmentPercentageRamp(100)), clock1, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("1", 1), clock1, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("10", 1), clock1, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("100", 100), clock1, nil),
 		},
 	}
 	expected := &persistencepb.VersioningData{
 		AssignmentRules: []*persistencepb.AssignmentRule{
-			mkAssignmentRulePersistence(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(1)), clock1, nil),
-			mkAssignmentRulePersistence(mkAssignmentRule("10", mkNewAssignmentPercentageRamp(1)), clock1, clock2),
-			mkAssignmentRulePersistence(mkAssignmentRule("100", mkNewAssignmentPercentageRamp(100)), clock1, clock2),
-			mkAssignmentRulePersistence(mkAssignmentRule("10", mkNewAssignmentPercentageRamp(100)), clock2, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("1", 1), clock1, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("10", 1), clock1, clock2),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("100", 100), clock1, clock2),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("10", 100), clock2, nil),
 		},
 	}
 	var err error
@@ -1064,11 +1067,11 @@ func TestCommitBuildIDBasic(t *testing.T) {
 	clock3 := hlc.Next(clock2, timesource)
 	expected = &persistencepb.VersioningData{
 		AssignmentRules: []*persistencepb.AssignmentRule{
-			mkAssignmentRulePersistence(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(1)), clock1, nil),
-			mkAssignmentRulePersistence(mkAssignmentRule("10", mkNewAssignmentPercentageRamp(1)), clock1, clock2),
-			mkAssignmentRulePersistence(mkAssignmentRule("100", mkNewAssignmentPercentageRamp(100)), clock1, clock2),
-			mkAssignmentRulePersistence(mkAssignmentRule("10", mkNewAssignmentPercentageRamp(100)), clock2, clock3),
-			mkAssignmentRulePersistence(mkAssignmentRule("10", mkNewAssignmentPercentageRamp(100)), clock3, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("1", 1), clock1, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("10", 1), clock1, clock2),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("100", 100), clock1, clock2),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("10", 100), clock2, clock3),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("10", 100), clock3, nil),
 		},
 	}
 	data, err = CommitBuildID(clock3, data, mkNewCommitBuildIdReq("10", false), true, ignoreMaxRules)
@@ -1084,9 +1087,9 @@ func TestCommitBuildIDNoRecentPoller(t *testing.T) {
 	clock2 := hlc.Next(clock1, timesource)
 	data := &persistencepb.VersioningData{
 		AssignmentRules: []*persistencepb.AssignmentRule{
-			mkAssignmentRulePersistence(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(1)), clock1, nil),
-			mkAssignmentRulePersistence(mkAssignmentRule("10", mkNewAssignmentPercentageRamp(1)), clock1, nil),
-			mkAssignmentRulePersistence(mkAssignmentRule("100", mkNewAssignmentPercentageRamp(100)), clock1, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("1", 1), clock1, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("10", 1), clock1, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("100", 100), clock1, nil),
 		},
 	}
 	var err error
@@ -1108,9 +1111,9 @@ func TestCommitBuildIDInVersionSet(t *testing.T) {
 	clock2 := hlc.Next(clock1, timesource)
 	data := mkInitialData(1, clock1)
 	data.AssignmentRules = []*persistencepb.AssignmentRule{
-		mkAssignmentRulePersistence(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(1)), clock1, nil),
-		mkAssignmentRulePersistence(mkAssignmentRule("10", mkNewAssignmentPercentageRamp(1)), clock1, nil),
-		mkAssignmentRulePersistence(mkAssignmentRule("100", nil), clock1, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("0", 1), clock1, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("10", 1), clock1, nil),
+		mkAssignmentRulePersistence(mkAssignmentRuleWithoutRamp("100"), clock1, nil),
 	}
 	var err error
 
@@ -1128,9 +1131,9 @@ func TestCommitBuildIDMaxAssignmentRules(t *testing.T) {
 	clock2 := hlc.Next(clock1, timesource)
 	data := &persistencepb.VersioningData{
 		AssignmentRules: []*persistencepb.AssignmentRule{
-			mkAssignmentRulePersistence(mkAssignmentRule("1", mkNewAssignmentPercentageRamp(1)), clock1, nil),
-			mkAssignmentRulePersistence(mkAssignmentRule("10", mkNewAssignmentPercentageRamp(1)), clock1, nil),
-			mkAssignmentRulePersistence(mkAssignmentRule("100", mkNewAssignmentPercentageRamp(1)), clock1, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("1", 1), clock1, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("10", 1), clock1, nil),
+			mkAssignmentRulePersistence(mkAssignmentRuleWithRamp("100", 1), clock1, nil),
 		},
 	}
 	var err error

--- a/service/matching/version_rule_test.go
+++ b/service/matching/version_rule_test.go
@@ -317,11 +317,6 @@ func TestInsertAssignmentRuleInvalidRampPercentage(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, errInvalidRampPercentage, err)
 
-	// insert with ramp percent == 100 --> failure
-	_, err = insertAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(100)), data, clock, 0, ignoreMaxRules)
-	assert.Error(t, err)
-	assert.Equal(t, errInvalidRampPercentage, err)
-
 	// insert with ramp percent > 100 --> failure
 	_, err = insertAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(101)), data, clock, 0, ignoreMaxRules)
 	assert.Error(t, err)
@@ -416,7 +411,6 @@ func TestReplaceAssignmentRulePartiallyRampedRuleIsRedirectSource(t *testing.T) 
 
 	// replace with target isSource and ramp < 100 --> failure
 	_, err := replaceAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(10)), data, clock, 0, false)
-	t.Log(err)
 	assert.Error(t, err)
 	assert.Equal(t, errPartiallyRampedAssignmentRuleIsRedirectRuleSource, err)
 }
@@ -472,11 +466,6 @@ func TestReplaceAssignmentRuleInvalidRampPercentage(t *testing.T) {
 
 	// replace with ramp percent < 0 --> failure
 	_, err := replaceAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(-1)), data, clock, 0, false)
-	assert.Error(t, err)
-	assert.Equal(t, errInvalidRampPercentage, err)
-
-	// replace with ramp percent == 100 --> failure
-	_, err = replaceAssignmentRule(mkAssignmentRule("0", mkNewAssignmentPercentageRamp(100)), data, clock, 0, false)
 	assert.Error(t, err)
 	assert.Equal(t, errInvalidRampPercentage, err)
 

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -242,7 +242,7 @@ func (s *VersioningIntegSuite) TestAssignmentRuleDelete() {
 	res := s.getVersioningRules(ctx, tq)
 	s.Equal(1, len(res.GetAssignmentRules()))
 
-	// failure due to requirement that once an unconditional rule exists, at least one must always exist
+	// failure due to requirement that once an un-ramped rule exists, at least one must always exist
 	s.deleteAssignmentRule(ctx, tq, 0, cT, false)
 	s.Equal(res, s.getVersioningRules(ctx, tq))
 

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -592,7 +592,7 @@ func (s *VersioningIntegSuite) TestDispatchNewWorkflowWithRamp() {
 	defer cancel()
 
 	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
-	rule2 := s.addAssignmentRuleWithPartialRamp(ctx, tq, v2, 50)
+	rule2 := s.addAssignmentRule(ctx, tq, v2, 50)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule2)
 
@@ -4791,13 +4791,10 @@ func (s *VersioningIntegSuite) addNewDefaultBuildId(ctx context.Context, tq, new
 }
 
 func (s *VersioningIntegSuite) addAssignmentRuleWithFullRamp(ctx context.Context, tq, buildId string) *taskqueuepb.BuildIdAssignmentRule {
-	rule := &taskqueuepb.BuildIdAssignmentRule{
-		TargetBuildId: buildId,
-	}
-	return s.doAddAssignmentRule(ctx, tq, rule)
+	return s.addAssignmentRule(ctx, tq, buildId, 100)
 }
 
-func (s *VersioningIntegSuite) addAssignmentRuleWithPartialRamp(ctx context.Context, tq, buildId string, ramp float32) *taskqueuepb.BuildIdAssignmentRule {
+func (s *VersioningIntegSuite) addAssignmentRule(ctx context.Context, tq, buildId string, ramp float32) *taskqueuepb.BuildIdAssignmentRule {
 	rule := &taskqueuepb.BuildIdAssignmentRule{
 		TargetBuildId: buildId,
 		Ramp: &taskqueuepb.BuildIdAssignmentRule_PercentageRamp{
@@ -4823,9 +4820,6 @@ func (s *VersioningIntegSuite) doAddAssignmentRule(ctx context.Context, tq strin
 	})
 	s.NoError(err)
 	s.NotNil(res)
-	if rule.GetRamp() == nil {
-		rule.Ramp = &taskqueuepb.BuildIdAssignmentRule_PercentageRamp{PercentageRamp: &taskqueuepb.RampByPercentage{RampPercentage: 100}}
-	}
 	return rule
 }
 

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -546,7 +546,7 @@ func (s *VersioningIntegSuite) dispatchNewWorkflow(newVersioning bool) {
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+		rule := s.addAssignmentRule(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -591,7 +591,7 @@ func (s *VersioningIntegSuite) TestDispatchNewWorkflowWithRamp() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule := s.addAssignmentRule(ctx, tq, v1)
 	rule2 := s.addAssignmentRuleWithRampPercentage(ctx, tq, v2, 50)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule2)
@@ -673,7 +673,7 @@ func (s *VersioningIntegSuite) workflowStaysInBuildId() {
 		return "done!", nil
 	}
 
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule := s.addAssignmentRule(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	w1 := worker.New(s.sdkClient, tq, worker.Options{
@@ -694,7 +694,7 @@ func (s *VersioningIntegSuite) workflowStaysInBuildId() {
 	s.validateWorkflowBuildIds(ctx, run.GetID(), run.GetRunID(), v1, true, v1, "", nil)
 
 	// update rules with v2 as the default build
-	rule = s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
+	rule = s.addAssignmentRule(ctx, tq, v2)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	dw, err := s.sdkClient.DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
@@ -776,7 +776,7 @@ func (s *VersioningIntegSuite) unversionedWorkflowStaysUnversioned() {
 	s.validateWorkflowBuildIds(ctx, run.GetID(), run.GetRunID(), "", true, "binary-checksum", "", nil)
 
 	// update rules with v1 as the default build
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule := s.addAssignmentRule(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	dw, err := s.sdkClient.DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
@@ -805,7 +805,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSpooled() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule := s.addAssignmentRule(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	// start wf without worker
@@ -821,7 +821,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSpooled() {
 	s.validateWorkflowBuildIds(ctx, run.GetID(), run.GetRunID(), v1, true, "", "", nil)
 
 	// update latest build to v2
-	rule = s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
+	rule = s.addAssignmentRule(ctx, tq, v2)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	failedTask := make(chan struct{})
@@ -847,7 +847,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSpooled() {
 	s.validateWorkflowBuildIds(ctx, run.GetID(), run.GetRunID(), v2, true, "", "", []string{v1})
 
 	// update latest build to v3
-	rule = s.addAssignmentRuleWithFullRamp(ctx, tq, v3)
+	rule = s.addAssignmentRule(ctx, tq, v3)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	timedoutTask := make(chan struct{})
@@ -917,7 +917,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSyncMatch() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule := s.addAssignmentRule(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	// v1 fails the task
@@ -973,7 +973,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSyncMatch() {
 	defer w2.Stop()
 
 	// update latest build to v2
-	rule = s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
+	rule = s.addAssignmentRule(ctx, tq, v2)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	// wait for multiple timeouts to make sure more attempts do not generate more history events
@@ -1000,7 +1000,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSyncMatch() {
 	defer w3.Stop()
 
 	// update latest build to v3
-	rule = s.addAssignmentRuleWithFullRamp(ctx, tq, v3)
+	rule = s.addAssignmentRule(ctx, tq, v3)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	var out string
@@ -1035,10 +1035,10 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSpooled(versione
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRuleWithFullRamp(ctx, actTq, v1)
+	rule := s.addAssignmentRule(ctx, actTq, v1)
 	s.waitForAssignmentRulePropagation(ctx, actTq, rule)
 	if versionedWf {
-		rule = s.addAssignmentRuleWithFullRamp(ctx, wfTq, wfV1)
+		rule = s.addAssignmentRule(ctx, wfTq, wfV1)
 		s.waitForAssignmentRulePropagation(ctx, wfTq, rule)
 	}
 
@@ -1097,7 +1097,7 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSpooled(versione
 	)
 
 	// update latest build to v2
-	rule = s.addAssignmentRuleWithFullRamp(ctx, actTq, v2)
+	rule = s.addAssignmentRule(ctx, actTq, v2)
 	s.waitForAssignmentRulePropagation(ctx, actTq, rule)
 
 	failedTask := make(chan struct{})
@@ -1131,7 +1131,7 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSpooled(versione
 	)
 
 	// update latest build to v3
-	rule = s.addAssignmentRuleWithFullRamp(ctx, actTq, v3)
+	rule = s.addAssignmentRule(ctx, actTq, v3)
 	s.waitForAssignmentRulePropagation(ctx, actTq, rule)
 
 	timedoutTask := make(chan struct{})
@@ -1225,10 +1225,10 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSyncMatch(versio
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRuleWithFullRamp(ctx, actTq, v1)
+	rule := s.addAssignmentRule(ctx, actTq, v1)
 	s.waitForAssignmentRulePropagation(ctx, actTq, rule)
 	if versionedWf {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, wfTq, wfV1)
+		rule := s.addAssignmentRule(ctx, wfTq, wfV1)
 		s.waitForAssignmentRulePropagation(ctx, wfTq, rule)
 	}
 
@@ -1325,7 +1325,7 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSyncMatch(versio
 	defer w2.Stop()
 
 	// update latest build to v2
-	rule = s.addAssignmentRuleWithFullRamp(ctx, actTq, v2)
+	rule = s.addAssignmentRule(ctx, actTq, v2)
 	s.waitForAssignmentRulePropagation(ctx, actTq, rule)
 
 	s.waitForChan(ctx, timedoutTask)
@@ -1358,7 +1358,7 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSyncMatch(versio
 	defer w3.Stop()
 
 	// update latest build to v3
-	rule = s.addAssignmentRuleWithFullRamp(ctx, actTq, v3)
+	rule = s.addAssignmentRule(ctx, actTq, v3)
 	s.waitForAssignmentRulePropagation(ctx, actTq, rule)
 
 	var out string
@@ -1403,7 +1403,7 @@ func (s *VersioningIntegSuite) testWorkflowTaskRedirectInRetry(firstTask bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule := s.addAssignmentRule(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	act := func() error {
@@ -1568,7 +1568,7 @@ func (s *VersioningIntegSuite) dispatchNotUsingVersioning(newVersioning bool) {
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+		rule := s.addAssignmentRule(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -1722,7 +1722,7 @@ func (s *VersioningIntegSuite) dispatchUpgrade(newVersioning, stopOld bool) {
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+		rule := s.addAssignmentRule(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -1909,7 +1909,7 @@ func (s *VersioningIntegSuite) dispatchActivity(failMode activityFailMode, newVe
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+		rule := s.addAssignmentRule(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -1942,9 +1942,9 @@ func (s *VersioningIntegSuite) dispatchActivity(failMode activityFailMode, newVe
 
 	// now register v2 as default
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
+		rule := s.addAssignmentRule(ctx, tq, v2)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
-		rule = s.addAssignmentRuleWithFullRamp(ctx, actxTq, v2)
+		rule = s.addAssignmentRule(ctx, actxTq, v2)
 		s.waitForAssignmentRulePropagation(ctx, actxTq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v2)
@@ -2083,7 +2083,7 @@ func (s *VersioningIntegSuite) TestDispatchActivityUpgrade() {
 	s.NoError(w12.Start())
 	defer w12.Stop()
 
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule := s.addAssignmentRule(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	run, err := s.sdkClient.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{TaskQueue: tq}, "wf")
@@ -2164,7 +2164,7 @@ func (s *VersioningIntegSuite) TestRedirectWithConcurrentActivities() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule := s.addAssignmentRule(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	versions := []string{v1}
@@ -2655,9 +2655,9 @@ func (s *VersioningIntegSuite) dispatchChildWorkflow(newVersioning bool, crossTq
 	}
 
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+		rule := s.addAssignmentRule(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
-		rule = s.addAssignmentRuleWithFullRamp(ctx, childxTq, v1)
+		rule = s.addAssignmentRule(ctx, childxTq, v1)
 		s.waitForAssignmentRulePropagation(ctx, childxTq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -2690,9 +2690,9 @@ func (s *VersioningIntegSuite) dispatchChildWorkflow(newVersioning bool, crossTq
 
 	// now register v2 as default
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
+		rule := s.addAssignmentRule(ctx, tq, v2)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
-		rule = s.addAssignmentRuleWithFullRamp(ctx, childxTq, v2)
+		rule = s.addAssignmentRule(ctx, childxTq, v2)
 		s.waitForAssignmentRulePropagation(ctx, childxTq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v2)
@@ -2795,7 +2795,7 @@ func (s *VersioningIntegSuite) dispatchChildWorkflowUpgrade(newVersioning bool) 
 	}
 
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+		rule := s.addAssignmentRule(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -2944,7 +2944,7 @@ func (s *VersioningIntegSuite) dispatchQuery(newVersioning bool) {
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+		rule := s.addAssignmentRule(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -2966,7 +2966,7 @@ func (s *VersioningIntegSuite) dispatchQuery(newVersioning bool) {
 	s.waitForChan(ctx, started)
 
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
+		rule := s.addAssignmentRule(ctx, tq, v2)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 		rrule := s.addRedirectRule(ctx, tq, v1, v11)
 		s.waitForRedirectRulePropagation(ctx, tq, rrule)
@@ -3115,9 +3115,9 @@ func (s *VersioningIntegSuite) dispatchContinueAsNew(newVersioning bool, crossTq
 	}
 
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+		rule := s.addAssignmentRule(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
-		rule = s.addAssignmentRuleWithFullRamp(ctx, canxTq, v1)
+		rule = s.addAssignmentRule(ctx, canxTq, v1)
 		s.waitForAssignmentRulePropagation(ctx, canxTq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -3148,9 +3148,9 @@ func (s *VersioningIntegSuite) dispatchContinueAsNew(newVersioning bool, crossTq
 
 	// now make v2 as a new default
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
+		rule := s.addAssignmentRule(ctx, tq, v2)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
-		rule = s.addAssignmentRuleWithFullRamp(ctx, canxTq, v2)
+		rule = s.addAssignmentRule(ctx, canxTq, v2)
 		s.waitForAssignmentRulePropagation(ctx, canxTq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v2)
@@ -3255,7 +3255,7 @@ func (s *VersioningIntegSuite) dispatchContinueAsNewUpgrade(newVersioning bool) 
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+		rule := s.addAssignmentRule(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -3280,7 +3280,7 @@ func (s *VersioningIntegSuite) dispatchContinueAsNewUpgrade(newVersioning bool) 
 	if newVersioning {
 		rule := s.addRedirectRule(ctx, tq, v1, v11)
 		s.waitForRedirectRulePropagation(ctx, tq, rule)
-		rule2 := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
+		rule2 := s.addAssignmentRule(ctx, tq, v2)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule2)
 	} else {
 		s.addCompatibleBuildId(ctx, tq, v11, v1, false)
@@ -3494,7 +3494,7 @@ func (s *VersioningIntegSuite) dispatchRetry() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule := s.addAssignmentRule(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	w1 := worker.New(s.sdkClient, tq, worker.Options{
@@ -3517,7 +3517,7 @@ func (s *VersioningIntegSuite) dispatchRetry() {
 	s.waitForChan(ctx, started1)
 
 	// now register v2 as a new default
-	rule = s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
+	rule = s.addAssignmentRule(ctx, tq, v2)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	// add another 100ms to make sure it got to sticky queues also
 	time.Sleep(100 * time.Millisecond)
@@ -3588,7 +3588,7 @@ func (s *VersioningIntegSuite) dispatchCron(newVersioning bool) {
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+		rule := s.addAssignmentRule(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -3621,7 +3621,7 @@ func (s *VersioningIntegSuite) dispatchCron(newVersioning bool) {
 	)
 
 	if newVersioning {
-		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
+		rule := s.addAssignmentRule(ctx, tq, v2)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		// now register v11 as newer compatible with v1 AND v2 as a new default.
@@ -3696,7 +3696,7 @@ func (s *VersioningIntegSuite) TestResetWorkflowAssignsToCorrectBuildId() {
 		return "done!", nil
 	}
 
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule := s.addAssignmentRule(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	w1 := worker.New(
@@ -3779,7 +3779,7 @@ func (s *VersioningIntegSuite) resetWorkflowAssignsToCorrectBuildIdCan(inheritBu
 		}
 	}
 
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule := s.addAssignmentRule(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	w1 := worker.New(
@@ -3879,7 +3879,7 @@ func (s *VersioningIntegSuite) resetWorkflowAssignsToCorrectBuildIdChildWf(inher
 		return "parent done!", nil
 	}
 
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule := s.addAssignmentRule(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	w1 := worker.New(
@@ -3932,7 +3932,7 @@ func (s *VersioningIntegSuite) validateBuildIdAfterReset(ctx context.Context, wf
 	s.validateWorkflowBuildIds(ctx, run.GetID(), run.GetRunID(), v1, true, v1, inheritedBuildId, nil)
 
 	// update rules with v2 as the default build
-	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
+	rule := s.addAssignmentRule(ctx, tq, v2)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	// now reset the wf to first wf task
@@ -3986,7 +3986,7 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Versioned_Reachabil
 	defer cancel()
 
 	// 1. Add assignment rule A and start workflow with build id A
-	s.addAssignmentRuleWithFullRamp(ctx, tq, "A")
+	s.addAssignmentRule(ctx, tq, "A")
 	started := make(chan struct{}, 10)
 	wf := func(ctx workflow.Context) (string, error) {
 		started <- struct{}{}
@@ -4048,7 +4048,7 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Versioned_BasicReac
 		"": enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE, // reachable because unversioned is default
 	})
 
-	s.addAssignmentRuleWithFullRamp(ctx, tq, "A")
+	s.addAssignmentRule(ctx, tq, "A")
 	s.getBuildIdReachability(ctx, tq, &taskqueuepb.TaskQueueVersionSelection{BuildIds: []string{"", "A"}}, map[string]enumspb.BuildIdTaskReachability{
 		"A": enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE,   // reachable by default assignment rule
 		"":  enumspb.BUILD_ID_TASK_REACHABILITY_UNREACHABLE, // unreachable because no longer default
@@ -4790,7 +4790,7 @@ func (s *VersioningIntegSuite) addNewDefaultBuildId(ctx context.Context, tq, new
 	s.NotNil(res)
 }
 
-func (s *VersioningIntegSuite) addAssignmentRuleWithFullRamp(ctx context.Context, tq, buildId string) *taskqueuepb.BuildIdAssignmentRule {
+func (s *VersioningIntegSuite) addAssignmentRule(ctx context.Context, tq, buildId string) *taskqueuepb.BuildIdAssignmentRule {
 	return s.addAssignmentRuleWithRampPercentage(ctx, tq, buildId, 100)
 }
 

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -342,7 +342,7 @@ func (s *VersioningIntegSuite) TestCommitBuildID() {
 	s.Equal(1, len(res.GetAssignmentRules()))
 	s.Equal(0, len(res.GetCompatibleRedirectRules()))
 	s.Equal("1", res.GetAssignmentRules()[0].GetRule().GetTargetBuildId())
-	s.Equal(100, res.GetAssignmentRules()[0].GetRule().GetPercentageRamp().GetRampPercentage())
+	s.Equal(float32(100), res.GetAssignmentRules()[0].GetRule().GetPercentageRamp().GetRampPercentage())
 
 	// recent versioned poller on wrong build ID --> failure
 	s.registerWorkflowAndPollVersionedTaskQueue(tq, "3", true)
@@ -359,7 +359,7 @@ func (s *VersioningIntegSuite) TestCommitBuildID() {
 	s.Equal(1, len(res.GetAssignmentRules()))
 	s.Equal(0, len(res.GetCompatibleRedirectRules()))
 	s.Equal("2", res.GetAssignmentRules()[0].GetRule().GetTargetBuildId())
-	s.Equal(100, res.GetAssignmentRules()[0].GetRule().GetPercentageRamp().GetRampPercentage())
+	s.Equal(float32(100), res.GetAssignmentRules()[0].GetRule().GetPercentageRamp().GetRampPercentage())
 }
 
 func mkRedirectRulesMap(redirectRules []*taskqueuepb.TimestampedCompatibleBuildIdRedirectRule) map[string]string {
@@ -4680,8 +4680,7 @@ func (s *VersioningIntegSuite) commitBuildId(
 		endIdx := len(res.GetAssignmentRules()) - 1
 		addedRule := res.GetAssignmentRules()[endIdx].GetRule()
 		s.Assert().Equal(targetBuildId, addedRule.GetTargetBuildId())
-		s.Assert().Equal(100, addedRule.GetPercentageRamp().GetRampPercentage())
-		s.Assert().Nil(addedRule.GetPercentageRamp())
+		s.Assert().Equal(float32(100), addedRule.GetPercentageRamp().GetRampPercentage())
 
 		foundOtherAssignmentRuleForTarget := false
 		foundFullyRampedAssignmentRuleForOtherTarget := false

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -592,7 +592,7 @@ func (s *VersioningIntegSuite) TestDispatchNewWorkflowWithRamp() {
 	defer cancel()
 
 	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
-	rule2 := s.addAssignmentRule(ctx, tq, v2, 50)
+	rule2 := s.addAssignmentRuleWithRampPercentage(ctx, tq, v2, 50)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule2)
 
@@ -4791,10 +4791,10 @@ func (s *VersioningIntegSuite) addNewDefaultBuildId(ctx context.Context, tq, new
 }
 
 func (s *VersioningIntegSuite) addAssignmentRuleWithFullRamp(ctx context.Context, tq, buildId string) *taskqueuepb.BuildIdAssignmentRule {
-	return s.addAssignmentRule(ctx, tq, buildId, 100)
+	return s.addAssignmentRuleWithRampPercentage(ctx, tq, buildId, 100)
 }
 
-func (s *VersioningIntegSuite) addAssignmentRule(ctx context.Context, tq, buildId string, ramp float32) *taskqueuepb.BuildIdAssignmentRule {
+func (s *VersioningIntegSuite) addAssignmentRuleWithRampPercentage(ctx context.Context, tq, buildId string, ramp float32) *taskqueuepb.BuildIdAssignmentRule {
 	rule := &taskqueuepb.BuildIdAssignmentRule{
 		TargetBuildId: buildId,
 		Ramp: &taskqueuepb.BuildIdAssignmentRule_PercentageRamp{

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -592,7 +592,7 @@ func (s *VersioningIntegSuite) TestDispatchNewWorkflowWithRamp() {
 	defer cancel()
 
 	rule := s.addAssignmentRule(ctx, tq, v1)
-	rule2 := s.addAssignmentRuleWithRampPercentage(ctx, tq, v2, 50)
+	rule2 := s.addAssignmentRuleWithRamp(ctx, tq, v2, 50)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule2)
 
@@ -4791,10 +4791,10 @@ func (s *VersioningIntegSuite) addNewDefaultBuildId(ctx context.Context, tq, new
 }
 
 func (s *VersioningIntegSuite) addAssignmentRule(ctx context.Context, tq, buildId string) *taskqueuepb.BuildIdAssignmentRule {
-	return s.addAssignmentRuleWithRampPercentage(ctx, tq, buildId, 100)
+	return s.addAssignmentRuleWithRamp(ctx, tq, buildId, 100)
 }
 
-func (s *VersioningIntegSuite) addAssignmentRuleWithRampPercentage(ctx context.Context, tq, buildId string, ramp float32) *taskqueuepb.BuildIdAssignmentRule {
+func (s *VersioningIntegSuite) addAssignmentRuleWithRamp(ctx context.Context, tq, buildId string, ramp float32) *taskqueuepb.BuildIdAssignmentRule {
 	rule := &taskqueuepb.BuildIdAssignmentRule{
 		TargetBuildId: buildId,
 		Ramp: &taskqueuepb.BuildIdAssignmentRule_PercentageRamp{

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -242,7 +242,7 @@ func (s *VersioningIntegSuite) TestAssignmentRuleDelete() {
 	res := s.getVersioningRules(ctx, tq)
 	s.Equal(1, len(res.GetAssignmentRules()))
 
-	// failure due to requirement that once an un-ramped rule exists, at least one must always exist
+	// failure due to requirement that once a fully-ramped rule exists, at least one must always exist
 	s.deleteAssignmentRule(ctx, tq, 0, cT, false)
 	s.Equal(res, s.getVersioningRules(ctx, tq))
 
@@ -546,7 +546,7 @@ func (s *VersioningIntegSuite) dispatchNewWorkflow(newVersioning bool) {
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v1)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -591,8 +591,8 @@ func (s *VersioningIntegSuite) TestDispatchNewWorkflowWithRamp() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRule(ctx, tq, v1)
-	rule2 := s.addAssignmentRuleWithRamp(ctx, tq, v2, 50)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
+	rule2 := s.addAssignmentRuleWithPartialRamp(ctx, tq, v2, 50)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule2)
 
@@ -673,7 +673,7 @@ func (s *VersioningIntegSuite) workflowStaysInBuildId() {
 		return "done!", nil
 	}
 
-	rule := s.addAssignmentRule(ctx, tq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	w1 := worker.New(s.sdkClient, tq, worker.Options{
@@ -694,7 +694,7 @@ func (s *VersioningIntegSuite) workflowStaysInBuildId() {
 	s.validateWorkflowBuildIds(ctx, run.GetID(), run.GetRunID(), v1, true, v1, "", nil)
 
 	// update rules with v2 as the default build
-	rule = s.addAssignmentRule(ctx, tq, v2)
+	rule = s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	dw, err := s.sdkClient.DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
@@ -776,7 +776,7 @@ func (s *VersioningIntegSuite) unversionedWorkflowStaysUnversioned() {
 	s.validateWorkflowBuildIds(ctx, run.GetID(), run.GetRunID(), "", true, "binary-checksum", "", nil)
 
 	// update rules with v1 as the default build
-	rule := s.addAssignmentRule(ctx, tq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	dw, err := s.sdkClient.DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
@@ -805,7 +805,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSpooled() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRule(ctx, tq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	// start wf without worker
@@ -821,7 +821,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSpooled() {
 	s.validateWorkflowBuildIds(ctx, run.GetID(), run.GetRunID(), v1, true, "", "", nil)
 
 	// update latest build to v2
-	rule = s.addAssignmentRule(ctx, tq, v2)
+	rule = s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	failedTask := make(chan struct{})
@@ -847,7 +847,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSpooled() {
 	s.validateWorkflowBuildIds(ctx, run.GetID(), run.GetRunID(), v2, true, "", "", []string{v1})
 
 	// update latest build to v3
-	rule = s.addAssignmentRule(ctx, tq, v3)
+	rule = s.addAssignmentRuleWithFullRamp(ctx, tq, v3)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	timedoutTask := make(chan struct{})
@@ -917,7 +917,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSyncMatch() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRule(ctx, tq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	// v1 fails the task
@@ -973,7 +973,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSyncMatch() {
 	defer w2.Stop()
 
 	// update latest build to v2
-	rule = s.addAssignmentRule(ctx, tq, v2)
+	rule = s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	// wait for multiple timeouts to make sure more attempts do not generate more history events
@@ -1000,7 +1000,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSyncMatch() {
 	defer w3.Stop()
 
 	// update latest build to v3
-	rule = s.addAssignmentRule(ctx, tq, v3)
+	rule = s.addAssignmentRuleWithFullRamp(ctx, tq, v3)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	var out string
@@ -1035,10 +1035,10 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSpooled(versione
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRule(ctx, actTq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, actTq, v1)
 	s.waitForAssignmentRulePropagation(ctx, actTq, rule)
 	if versionedWf {
-		rule = s.addAssignmentRule(ctx, wfTq, wfV1)
+		rule = s.addAssignmentRuleWithFullRamp(ctx, wfTq, wfV1)
 		s.waitForAssignmentRulePropagation(ctx, wfTq, rule)
 	}
 
@@ -1097,7 +1097,7 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSpooled(versione
 	)
 
 	// update latest build to v2
-	rule = s.addAssignmentRule(ctx, actTq, v2)
+	rule = s.addAssignmentRuleWithFullRamp(ctx, actTq, v2)
 	s.waitForAssignmentRulePropagation(ctx, actTq, rule)
 
 	failedTask := make(chan struct{})
@@ -1131,7 +1131,7 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSpooled(versione
 	)
 
 	// update latest build to v3
-	rule = s.addAssignmentRule(ctx, actTq, v3)
+	rule = s.addAssignmentRuleWithFullRamp(ctx, actTq, v3)
 	s.waitForAssignmentRulePropagation(ctx, actTq, rule)
 
 	timedoutTask := make(chan struct{})
@@ -1225,10 +1225,10 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSyncMatch(versio
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRule(ctx, actTq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, actTq, v1)
 	s.waitForAssignmentRulePropagation(ctx, actTq, rule)
 	if versionedWf {
-		rule := s.addAssignmentRule(ctx, wfTq, wfV1)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, wfTq, wfV1)
 		s.waitForAssignmentRulePropagation(ctx, wfTq, rule)
 	}
 
@@ -1325,7 +1325,7 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSyncMatch(versio
 	defer w2.Stop()
 
 	// update latest build to v2
-	rule = s.addAssignmentRule(ctx, actTq, v2)
+	rule = s.addAssignmentRuleWithFullRamp(ctx, actTq, v2)
 	s.waitForAssignmentRulePropagation(ctx, actTq, rule)
 
 	s.waitForChan(ctx, timedoutTask)
@@ -1358,7 +1358,7 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSyncMatch(versio
 	defer w3.Stop()
 
 	// update latest build to v3
-	rule = s.addAssignmentRule(ctx, actTq, v3)
+	rule = s.addAssignmentRuleWithFullRamp(ctx, actTq, v3)
 	s.waitForAssignmentRulePropagation(ctx, actTq, rule)
 
 	var out string
@@ -1403,7 +1403,7 @@ func (s *VersioningIntegSuite) testWorkflowTaskRedirectInRetry(firstTask bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRule(ctx, tq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	act := func() error {
@@ -1568,7 +1568,7 @@ func (s *VersioningIntegSuite) dispatchNotUsingVersioning(newVersioning bool) {
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v1)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -1722,7 +1722,7 @@ func (s *VersioningIntegSuite) dispatchUpgrade(newVersioning, stopOld bool) {
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v1)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -1909,7 +1909,7 @@ func (s *VersioningIntegSuite) dispatchActivity(failMode activityFailMode, newVe
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v1)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -1942,9 +1942,9 @@ func (s *VersioningIntegSuite) dispatchActivity(failMode activityFailMode, newVe
 
 	// now register v2 as default
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v2)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
-		rule = s.addAssignmentRule(ctx, actxTq, v2)
+		rule = s.addAssignmentRuleWithFullRamp(ctx, actxTq, v2)
 		s.waitForAssignmentRulePropagation(ctx, actxTq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v2)
@@ -2083,7 +2083,7 @@ func (s *VersioningIntegSuite) TestDispatchActivityUpgrade() {
 	s.NoError(w12.Start())
 	defer w12.Stop()
 
-	rule := s.addAssignmentRule(ctx, tq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	run, err := s.sdkClient.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{TaskQueue: tq}, "wf")
@@ -2164,7 +2164,7 @@ func (s *VersioningIntegSuite) TestRedirectWithConcurrentActivities() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
-	rule := s.addAssignmentRule(ctx, tq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	versions := []string{v1}
@@ -2655,9 +2655,9 @@ func (s *VersioningIntegSuite) dispatchChildWorkflow(newVersioning bool, crossTq
 	}
 
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v1)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
-		rule = s.addAssignmentRule(ctx, childxTq, v1)
+		rule = s.addAssignmentRuleWithFullRamp(ctx, childxTq, v1)
 		s.waitForAssignmentRulePropagation(ctx, childxTq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -2690,9 +2690,9 @@ func (s *VersioningIntegSuite) dispatchChildWorkflow(newVersioning bool, crossTq
 
 	// now register v2 as default
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v2)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
-		rule = s.addAssignmentRule(ctx, childxTq, v2)
+		rule = s.addAssignmentRuleWithFullRamp(ctx, childxTq, v2)
 		s.waitForAssignmentRulePropagation(ctx, childxTq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v2)
@@ -2795,7 +2795,7 @@ func (s *VersioningIntegSuite) dispatchChildWorkflowUpgrade(newVersioning bool) 
 	}
 
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v1)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -2944,7 +2944,7 @@ func (s *VersioningIntegSuite) dispatchQuery(newVersioning bool) {
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v1)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -2966,7 +2966,7 @@ func (s *VersioningIntegSuite) dispatchQuery(newVersioning bool) {
 	s.waitForChan(ctx, started)
 
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v2)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 		rrule := s.addRedirectRule(ctx, tq, v1, v11)
 		s.waitForRedirectRulePropagation(ctx, tq, rrule)
@@ -3115,9 +3115,9 @@ func (s *VersioningIntegSuite) dispatchContinueAsNew(newVersioning bool, crossTq
 	}
 
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v1)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
-		rule = s.addAssignmentRule(ctx, canxTq, v1)
+		rule = s.addAssignmentRuleWithFullRamp(ctx, canxTq, v1)
 		s.waitForAssignmentRulePropagation(ctx, canxTq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -3148,9 +3148,9 @@ func (s *VersioningIntegSuite) dispatchContinueAsNew(newVersioning bool, crossTq
 
 	// now make v2 as a new default
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v2)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
-		rule = s.addAssignmentRule(ctx, canxTq, v2)
+		rule = s.addAssignmentRuleWithFullRamp(ctx, canxTq, v2)
 		s.waitForAssignmentRulePropagation(ctx, canxTq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v2)
@@ -3255,7 +3255,7 @@ func (s *VersioningIntegSuite) dispatchContinueAsNewUpgrade(newVersioning bool) 
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v1)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -3280,7 +3280,7 @@ func (s *VersioningIntegSuite) dispatchContinueAsNewUpgrade(newVersioning bool) 
 	if newVersioning {
 		rule := s.addRedirectRule(ctx, tq, v1, v11)
 		s.waitForRedirectRulePropagation(ctx, tq, rule)
-		rule2 := s.addAssignmentRule(ctx, tq, v2)
+		rule2 := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule2)
 	} else {
 		s.addCompatibleBuildId(ctx, tq, v11, v1, false)
@@ -3494,7 +3494,7 @@ func (s *VersioningIntegSuite) dispatchRetry() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rule := s.addAssignmentRule(ctx, tq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	w1 := worker.New(s.sdkClient, tq, worker.Options{
@@ -3517,7 +3517,7 @@ func (s *VersioningIntegSuite) dispatchRetry() {
 	s.waitForChan(ctx, started1)
 
 	// now register v2 as a new default
-	rule = s.addAssignmentRule(ctx, tq, v2)
+	rule = s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	// add another 100ms to make sure it got to sticky queues also
 	time.Sleep(100 * time.Millisecond)
@@ -3588,7 +3588,7 @@ func (s *VersioningIntegSuite) dispatchCron(newVersioning bool) {
 	defer cancel()
 
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v1)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		s.addNewDefaultBuildId(ctx, tq, v1)
@@ -3621,7 +3621,7 @@ func (s *VersioningIntegSuite) dispatchCron(newVersioning bool) {
 	)
 
 	if newVersioning {
-		rule := s.addAssignmentRule(ctx, tq, v2)
+		rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
 		s.waitForAssignmentRulePropagation(ctx, tq, rule)
 	} else {
 		// now register v11 as newer compatible with v1 AND v2 as a new default.
@@ -3696,7 +3696,7 @@ func (s *VersioningIntegSuite) TestResetWorkflowAssignsToCorrectBuildId() {
 		return "done!", nil
 	}
 
-	rule := s.addAssignmentRule(ctx, tq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	w1 := worker.New(
@@ -3779,7 +3779,7 @@ func (s *VersioningIntegSuite) resetWorkflowAssignsToCorrectBuildIdCan(inheritBu
 		}
 	}
 
-	rule := s.addAssignmentRule(ctx, tq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	w1 := worker.New(
@@ -3879,7 +3879,7 @@ func (s *VersioningIntegSuite) resetWorkflowAssignsToCorrectBuildIdChildWf(inher
 		return "parent done!", nil
 	}
 
-	rule := s.addAssignmentRule(ctx, tq, v1)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v1)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	w1 := worker.New(
@@ -3932,7 +3932,7 @@ func (s *VersioningIntegSuite) validateBuildIdAfterReset(ctx context.Context, wf
 	s.validateWorkflowBuildIds(ctx, run.GetID(), run.GetRunID(), v1, true, v1, inheritedBuildId, nil)
 
 	// update rules with v2 as the default build
-	rule := s.addAssignmentRule(ctx, tq, v2)
+	rule := s.addAssignmentRuleWithFullRamp(ctx, tq, v2)
 	s.waitForAssignmentRulePropagation(ctx, tq, rule)
 
 	// now reset the wf to first wf task
@@ -3986,7 +3986,7 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Versioned_Reachabil
 	defer cancel()
 
 	// 1. Add assignment rule A and start workflow with build id A
-	s.addAssignmentRule(ctx, tq, "A")
+	s.addAssignmentRuleWithFullRamp(ctx, tq, "A")
 	started := make(chan struct{}, 10)
 	wf := func(ctx workflow.Context) (string, error) {
 		started <- struct{}{}
@@ -4048,7 +4048,7 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Versioned_BasicReac
 		"": enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE, // reachable because unversioned is default
 	})
 
-	s.addAssignmentRule(ctx, tq, "A")
+	s.addAssignmentRuleWithFullRamp(ctx, tq, "A")
 	s.getBuildIdReachability(ctx, tq, &taskqueuepb.TaskQueueVersionSelection{BuildIds: []string{"", "A"}}, map[string]enumspb.BuildIdTaskReachability{
 		"A": enumspb.BUILD_ID_TASK_REACHABILITY_REACHABLE,   // reachable by default assignment rule
 		"":  enumspb.BUILD_ID_TASK_REACHABILITY_UNREACHABLE, // unreachable because no longer default
@@ -4676,7 +4676,7 @@ func (s *VersioningIntegSuite) commitBuildId(
 	if expectSuccess {
 		s.NoError(err)
 		s.NotNil(res)
-		// 1. Adds an assignment rule (with full ramp) for the target Build ID at the end of the list.
+		// 1. Adds a fully-ramped assignment rule for the target Build ID at the end of the list.
 		endIdx := len(res.GetAssignmentRules()) - 1
 		addedRule := res.GetAssignmentRules()[endIdx].GetRule()
 		s.Assert().Equal(targetBuildId, addedRule.GetTargetBuildId())
@@ -4791,14 +4791,14 @@ func (s *VersioningIntegSuite) addNewDefaultBuildId(ctx context.Context, tq, new
 	s.NotNil(res)
 }
 
-func (s *VersioningIntegSuite) addAssignmentRule(ctx context.Context, tq, buildId string) *taskqueuepb.BuildIdAssignmentRule {
+func (s *VersioningIntegSuite) addAssignmentRuleWithFullRamp(ctx context.Context, tq, buildId string) *taskqueuepb.BuildIdAssignmentRule {
 	rule := &taskqueuepb.BuildIdAssignmentRule{
 		TargetBuildId: buildId,
 	}
 	return s.doAddAssignmentRule(ctx, tq, rule)
 }
 
-func (s *VersioningIntegSuite) addAssignmentRuleWithRamp(ctx context.Context, tq, buildId string, ramp float32) *taskqueuepb.BuildIdAssignmentRule {
+func (s *VersioningIntegSuite) addAssignmentRuleWithPartialRamp(ctx context.Context, tq, buildId string, ramp float32) *taskqueuepb.BuildIdAssignmentRule {
 	rule := &taskqueuepb.BuildIdAssignmentRule{
 		TargetBuildId: buildId,
 		Ramp: &taskqueuepb.BuildIdAssignmentRule_PercentageRamp{


### PR DESCRIPTION
## What changed?
- treat both rampPercentage=100 and ramp=nil as 'fully-ramped' assignment rule
- convert ramp=nil to rampPercentage=100 on insert and replace
- remove the references to "unconditional" and "conditional" assignment rules and just use the terms fully-ramped vs partially-ramped everywhere

## Why?
- customers are confused by the requirement that a ramp percentage of 100 is not allowed
- having two terms for the same thing is confusing

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
