### PR TITLE
WorkflowStartDelay is invalid for MultiOperation

### DIFF
--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -95,6 +95,7 @@ var (
 	errMultiOpUpdateFirstExecutionRunId                   = serviceerror.NewInvalidArgument("FirstExecutionRunId is not allowed.")
 	errMultiOpUpdateExecutionRunId                        = serviceerror.NewInvalidArgument("RunId is not allowed.")
 	errMultiOpEagerWorkflow                               = serviceerror.NewInvalidArgument("RequestEagerExecution is not supported.")
+	errMultiOpStartDelay                                  = serviceerror.NewInvalidArgument("WorkflowStartDelay is not supported.")
 	errMultiOpNotStartAndUpdate                           = serviceerror.NewInvalidArgument("Operations have to be exactly [Start, Update].")
 	errMultiOpAborted                                     = serviceerror.NewMultiOperationAborted("Operation was aborted.")
 

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -83,6 +83,7 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/persistence/visibility/store"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/retrypolicy"
 	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/rpc/interceptor"
@@ -604,6 +605,9 @@ func (wh *WorkflowHandler) convertToHistoryMultiOperationItem(
 		}
 		if startReq.RequestEagerExecution {
 			return nil, "", errMultiOpEagerWorkflow
+		}
+		if timestamp.DurationValue(startReq.WorkflowStartDelay) > 0 {
+			return nil, "", errMultiOpStartDelay
 		}
 
 		workflowId = startReq.WorkflowId

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2924,6 +2924,23 @@ func (s *workflowHandlerSuite) TestExecuteMultiOperation() {
 			s.Nil(resp)
 			assertMultiOpsErr([]error{errMultiOpEagerWorkflow, errMultiOpAborted}, err)
 		})
+
+		// unique to MultiOperation:
+		s.Run("`workflow_start_delay` is invalid", func() {
+			startReq := validStartReq()
+			startReq.WorkflowStartDelay = durationpb.New(1 * time.Second)
+
+			resp, err := wh.ExecuteMultiOperation(ctx, &workflowservice.ExecuteMultiOperationRequest{
+				Namespace: s.testNamespace.String(),
+				Operations: []*workflowservice.ExecuteMultiOperationRequest_Operation{
+					newStartOp(startReq),
+					newUpdateOp(validUpdateReq()),
+				},
+			})
+
+			s.Nil(resp)
+			assertMultiOpsErr([]error{errMultiOpStartDelay, errMultiOpAborted}, err)
+		})
 	})
 
 	s.Run("Update operation is validated", func() {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Return a validation error when using `WorkflowStartDelay` option in MultiOperation Start.

## Why?
<!-- Tell your future self why have you made these changes -->

The option is incompatible (ignored right now); this makes it explicit.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Added unit test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
