### PR TITLE
Refactor reapply signal on reset test

### DIFF
--- a/tests/reset_workflow.go
+++ b/tests/reset_workflow.go
@@ -494,12 +494,12 @@ func (t *resetTest) run() {
 	}
 }
 
-func (s *FunctionalSuite) TestResetWorkflow_Signal_ReapplyBufferAll() {
+func (s *FunctionalSuite) TestBufferedSignalIsReappliedOnReset() {
 	tv := testvars.New(s.T())
 	s.testResetWorkflowSignalReapplyBuffer(tv, enumspb.RESET_REAPPLY_TYPE_SIGNAL)
 }
 
-func (s *FunctionalSuite) TestResetWorkflow_Signal_ReapplyBufferNone() {
+func (s *FunctionalSuite) TestBufferedSignalIsDroppedOnReset() {
 	tv := testvars.New(s.T())
 	s.testResetWorkflowSignalReapplyBuffer(tv, enumspb.RESET_REAPPLY_TYPE_NONE)
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Refactored `testResetWorkflowSignalReapplyBuffer`. Using a few of the newer helper functions.

No behavior change.

## Why?
<!-- Tell your future self why have you made these changes -->

Done as part of another PR that's not merged yet; might as well merge this now.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
