### PR TITLE
Modify nexus endpoint name regexp to accept dashes instead of underscores

### DIFF
--- a/service/frontend/nexus_endpoint_client.go
+++ b/service/frontend/nexus_endpoint_client.go
@@ -48,7 +48,7 @@ import (
 )
 
 // EndpointNameRegex is the regular expression that endpoint names must match.
-var EndpointNameRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+var EndpointNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9]$`)
 
 type (
 	// NexusEndpointClient manages frontend CRUD requests for Nexus endpoints.

--- a/tests/functional_test_base.go
+++ b/tests/functional_test_base.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -488,4 +489,10 @@ func (s *FunctionalTestBase) testWithMatchingBehavior(subtest func()) {
 			}
 		}
 	}
+}
+
+func RandomizedNexusEndpoint(name string) string {
+	re := regexp.MustCompile("[/_]")
+	safeName := re.ReplaceAllString(name, "-")
+	return fmt.Sprintf("%v-%v", safeName, uuid.New())
 }

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -851,7 +851,6 @@ func getDispatchByNsAndTqURL(address string, namespace string, taskQueue string)
 }
 
 func (s *ClientFunctionalSuite) createNexusEndpoint(name string, taskQueue string) *nexuspb.Endpoint {
-	name = strings.ReplaceAll(name, "-", "_")
 	resp, err := s.operatorClient.CreateNexusEndpoint(NewContext(), &operatorservice.CreateNexusEndpointRequest{
 		Spec: &nexuspb.EndpointSpec{
 			Name: name,

--- a/tests/nexus_endpoint_test.go
+++ b/tests/nexus_endpoint_test.go
@@ -166,7 +166,7 @@ type MatchingSuite struct {
 }
 
 func (s *MatchingSuite) TestCreate() {
-	endpointName := "test_matching_create_endpoint_name"
+	endpointName := RandomizedNexusEndpoint(s.T().Name())
 	entry := s.createNexusEndpoint(endpointName)
 	s.Equal(int64(1), entry.Version)
 	s.NotNil(entry.Endpoint.Clock)
@@ -193,8 +193,8 @@ func (s *MatchingSuite) TestCreate() {
 }
 
 func (s *MatchingSuite) TestUpdate() {
-	endpointName := "test_update_endpoint_name"
-	updatedName := "updated_name"
+	endpointName := RandomizedNexusEndpoint(s.T().Name())
+	updatedName := RandomizedNexusEndpoint(s.T().Name() + "-updated")
 	endpoint := s.createNexusEndpoint(endpointName)
 	type testcase struct {
 		name      string
@@ -283,7 +283,7 @@ func (s *MatchingSuite) TestUpdate() {
 }
 
 func (s *MatchingSuite) TestDelete() {
-	endpointName := "test_delete_endpoint_name"
+	endpointName := RandomizedNexusEndpoint(s.T().Name())
 	endpoint := s.createNexusEndpoint(endpointName)
 	type testcase struct {
 		name       string
@@ -468,7 +468,7 @@ type OperatorSuite struct {
 }
 
 func (s *OperatorSuite) TestCreate() {
-	endpointName := "test_operator_create_endpoint_name"
+	endpointName := RandomizedNexusEndpoint(s.T().Name())
 	type testcase struct {
 		name      string
 		request   *operatorservice.CreateNexusEndpointRequest
@@ -767,8 +767,8 @@ func (s *OperatorSuite) TestCreate() {
 }
 
 func (s *OperatorSuite) TestUpdate() {
-	endpointName := "test_operator_update_endpoint_name"
-	updatedName := "updated_name"
+	endpointName := RandomizedNexusEndpoint(s.T().Name())
+	updatedName := RandomizedNexusEndpoint(s.T().Name() + "-updated")
 	endpoint := s.createNexusEndpoint(endpointName)
 	type testcase struct {
 		name      string
@@ -996,7 +996,7 @@ func (s *OperatorSuite) TestList() {
 }
 
 func (s *OperatorSuite) TestGet() {
-	endpointName := "test_operator_get_endpoint_name"
+	endpointName := RandomizedNexusEndpoint(s.T().Name())
 	endpoint := s.createNexusEndpoint(endpointName)
 
 	type testcase struct {

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -60,7 +60,7 @@ import (
 func (s *ClientFunctionalSuite) TestNexusOperationCancelation() {
 	ctx := NewContext()
 	taskQueue := s.randomizeStr(s.T().Name())
-	endpointName := "test_cancelation_endpoint_name"
+	endpointName := RandomizedNexusEndpoint(s.T().Name())
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
@@ -185,7 +185,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationCancelation() {
 func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion() {
 	ctx := NewContext()
 	taskQueue := s.randomizeStr(s.T().Name())
-	endpointName := "test_sync_completion_endpoint_name"
+	endpointName := RandomizedNexusEndpoint(s.T().Name())
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
@@ -285,7 +285,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion() {
 func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion_LargePayload() {
 	ctx := NewContext()
 	taskQueue := s.randomizeStr(s.T().Name())
-	endpointName := "test_sync_completion_large_payload_endpoint_name"
+	endpointName := RandomizedNexusEndpoint(s.T().Name())
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
@@ -388,7 +388,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationSyncCompletion_LargePayload() 
 func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {
 	ctx := NewContext()
 	taskQueue := s.randomizeStr(s.T().Name())
-	endpointName := "test_async_completion_endpoint_name"
+	endpointName := RandomizedNexusEndpoint(s.T().Name())
 
 	testClusterInfo, err := s.client.GetClusterInfo(ctx, &workflowservice.GetClusterInfoRequest{})
 	s.NoError(err)
@@ -629,7 +629,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletion() {
 func (s *ClientFunctionalSuite) TestNexusOperationAsyncFailure() {
 	ctx := NewContext()
 	taskQueue := s.randomizeStr(s.T().Name())
-	endpointName := "test_async_failure_endpoint_name"
+	endpointName := RandomizedNexusEndpoint(s.T().Name())
 
 	var callbackToken, publicCallbackUrl string
 
@@ -849,7 +849,7 @@ func (s *ClientFunctionalSuite) TestNexusOperationAsyncCompletionInternalAuth() 
 
 	ctx := NewContext()
 	taskQueue := s.randomizeStr(s.T().Name())
-	endpointName := "test_async_completion_internal_auth_endpoint_name"
+	endpointName := RandomizedNexusEndpoint(s.T().Name())
 
 	_, err := s.operatorClient.CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
 		Spec: &nexuspb.EndpointSpec{

--- a/tests/xdc/nexus_request_forwarding_test.go
+++ b/tests/xdc/nexus_request_forwarding_test.go
@@ -341,7 +341,7 @@ func (s *NexusRequestForwardingSuite) TestCompleteOperationForwardedFromStandbyT
 	ctx := tests.NewContext()
 	ns := s.createNexusRequestForwardingNamespace()
 	taskQueue := fmt.Sprintf("%v-%v", "test-task-queue", uuid.New())
-	endpointName := "test_complete_operation_forwarding_endpoint_name"
+	endpointName := tests.RandomizedNexusEndpoint(s.T().Name())
 
 	var callbackToken, publicCallbackUrl string
 


### PR DESCRIPTION
## Why?

We realized during pre-release that users expect dashes rather than underscores and the new regexp would allow using endpoint names as host names if that use case comes up.