### PR TITLE
Limit nexus operation on a mutable state instance to 30

### DIFF
--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -37,7 +37,9 @@ var RequestTimeout = dynamicconfig.NewDestinationDurationSetting(
 
 var MaxConcurrentOperations = dynamicconfig.NewNamespaceIntSetting(
 	"component.nexusoperations.limit.operation.concurrency",
-	1000,
+	// Temporary limit due to a persistence limitation, this will be increased when we change persistence to accept
+	// partial sub state machine updates.
+	30,
 	`MaxConcurrentOperations limits the maximum allowed concurrent Nexus Operations for a given workflow execution.
 Once the limit is reached, ScheduleNexusOperation commands will be rejected.`,
 )


### PR DESCRIPTION
## Why?

We currently store sub state machines in mutable state's execution info which does not support partial updates.
The large update sizes are causing excess persistence load.
This restriction should be lifted when we change the persistence model.