### PR TITLE
Fix ndc Resender when history event has empty version

### DIFF
--- a/common/xdc/ndc_history_resender_test.go
+++ b/common/xdc/ndc_history_resender_test.go
@@ -361,8 +361,8 @@ func (s *nDCHistoryResenderSuite) TestSendSingleWorkflowHistory_Batching_ApplyWi
 	s.config.ReplicationResendMaxBatchCount = dynamicconfig.GetIntPropertyFn(2)
 
 	eventBatch0 := []*historypb.HistoryEvent{
-		{EventId: 1, Version: 123},
-		{EventId: 2, Version: 123},
+		{EventId: 1},
+		{EventId: 2},
 	}
 	eventBatch1 := []*historypb.HistoryEvent{
 		{EventId: 3, Version: 124},
@@ -381,7 +381,7 @@ func (s *nDCHistoryResenderSuite) TestSendSingleWorkflowHistory_Batching_ApplyWi
 		{EventId: 10, Version: 127},
 	}
 	versionHistoryItems := []*historyspb.VersionHistoryItem{
-		{EventId: 2, Version: 123},
+		{EventId: 2},
 		{EventId: 4, Version: 124},
 		{EventId: 6, Version: 125},
 		{EventId: 8, Version: 126},

--- a/service/history/replication/eventhandler/resend_handler.go
+++ b/service/history/replication/eventhandler/resend_handler.go
@@ -249,7 +249,8 @@ func (r *resendHandlerImpl) replicateRemoteGeneratedEvents(
 	}
 	var eventsBatch [][]*historypb.HistoryEvent
 	var versionHistory []*historyspb.VersionHistoryItem
-	eventsVersion := common.EmptyVersion
+	const EmptyVersion = int64(-1) // 0 is a valid event version when namespace is local
+	eventsVersion := EmptyVersion
 	if headBatch != nil {
 		events, err := r.serializer.DeserializeEvents(headBatch.RawEventBatch)
 		if err != nil {
@@ -283,6 +284,7 @@ func (r *resendHandlerImpl) replicateRemoteGeneratedEvents(
 		}
 		eventsBatch = nil
 		versionHistory = nil
+		eventsVersion = EmptyVersion
 		return nil
 	}
 
@@ -305,7 +307,7 @@ func (r *resendHandlerImpl) replicateRemoteGeneratedEvents(
 		}
 		if len(eventsBatch) != 0 && len(versionHistory) != 0 {
 			if !versionhistory.IsEqualVersionHistoryItems(versionHistory, batch.VersionHistory.Items) ||
-				(eventsVersion != common.EmptyVersion && eventsVersion != events[0].Version) {
+				(eventsVersion != EmptyVersion && eventsVersion != events[0].Version) {
 				err := applyFn()
 				if err != nil {
 					return err


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix ndc resender batching logic when handling empty event version
## Why?
<!-- Tell your future self why have you made these changes -->
Without this, event with empty version will be batched with events with other version
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no risk.
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
yes