### PR TITLE
[UserMetadata] Copy metadata when creating child workflow

### DIFF
--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -32,6 +32,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
@@ -852,6 +853,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		sourceVersionStamp,
 		rootExecutionInfo,
 		inheritedBuildId,
+		initiatedEvent.GetUserMetadata(),
 	)
 	if err != nil {
 		t.logger.Debug("Failed to start child workflow execution", tag.Error(err))
@@ -1340,6 +1342,7 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 	sourceVersionStamp *commonpb.WorkerVersionStamp,
 	rootExecutionInfo *workflowspb.RootExecutionInfo,
 	inheritedBuildId string,
+	userMetadata *sdkpb.UserMetadata,
 ) (string, *clockspb.VectorClock, error) {
 	request := common.CreateHistoryStartWorkflowRequest(
 		task.TargetNamespaceID,
@@ -1361,6 +1364,7 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 			CronSchedule:          attributes.CronSchedule,
 			Memo:                  attributes.Memo,
 			SearchAttributes:      attributes.SearchAttributes,
+			UserMetadata:          userMetadata,
 		},
 		&workflowspb.ParentExecutionInfo{
 			NamespaceId: task.NamespaceID,


### PR DESCRIPTION
## What changed?
Propagating usermetadata to child workflow. This is a fix for https://github.com/temporalio/temporal/issues/6412

## Why?
Currently the usermetadata is attached to the event that initiates the child workflow (`enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED`). But when we actually start the child workflow, we were not passing the user metadata object form this event in the parent to the child workflow. This is now fixed by passing the user metadata object in the child workflow creation request in the transfer task that creates child workflow.

## How did you test it?
Added unit test to ensure the user metadata object is passed in the start child workflow request.

## Potential risks
N/A

## Documentation
N/A

## Is hotfix candidate?
No