### PR TITLE
Fix replication issues with nexus operations and cancelation requests

### DIFF
--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -117,9 +117,20 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 		return fmt.Errorf("failed to get namespace by ID: %w", err)
 	}
 
-	args, err := e.loadOperationArgs(ctx, ns, env, ref)
+	args, err := e.loadOperationArgs(ctx, ns, env, ref, task)
 	if err != nil {
 		return fmt.Errorf("failed to load operation args: %w", err)
+	}
+
+	if args.cancelRequested {
+		// TODO(bergundy): Properly support cancel before started. We need to transmit this intent to cancel to the
+		// handler because we don't know for sure that the operation hasn't been started.
+		return e.saveResult(ctx, env, ref, nil, &nexus.UnsuccessfulOperationError{
+			State: nexus.OperationStateCanceled,
+			Failure: nexus.Failure{
+				Message: "operation canceled before it was started",
+			},
+		})
 	}
 
 	// This happens when we accept the ScheduleNexusOperation command when the endpoint is not found in the registry as
@@ -272,6 +283,7 @@ type startArgs struct {
 	payload                  *commonpb.Payload
 	workflowEventLink        *commonpb.Link_WorkflowEvent
 	namespaceFailoverVersion int64
+	cancelRequested          bool
 }
 
 func (e taskExecutor) loadOperationArgs(
@@ -279,13 +291,22 @@ func (e taskExecutor) loadOperationArgs(
 	ns *namespace.Namespace,
 	env hsm.Environment,
 	ref hsm.Ref,
+	task InvocationTask,
 ) (args startArgs, err error) {
 	var eventToken []byte
 	err = env.Access(ctx, ref, hsm.AccessRead, func(node *hsm.Node) error {
+		if err := task.Validate(node); err != nil {
+			return err
+		}
 		if err := node.CheckRunning(); err != nil {
 			return err
 		}
 		operation, err := hsm.MachineData[Operation](node)
+		if err != nil {
+			return err
+		}
+
+		args.cancelRequested, err = operation.cancelRequested(node)
 		if err != nil {
 			return err
 		}
@@ -445,6 +466,9 @@ func handleNonRetryableStartOperationError(env hsm.Environment, node *hsm.Node, 
 }
 
 func (e taskExecutor) executeBackoffTask(env hsm.Environment, node *hsm.Node, task BackoffTask) error {
+	if err := task.Validate(node); err != nil {
+		return err
+	}
 	if err := node.CheckRunning(); err != nil {
 		return err
 	}
@@ -583,6 +607,7 @@ func (e taskExecutor) loadArgsForCancelation(ctx context.Context, env hsm.Enviro
 			// Operation is already in a terminal state.
 			return fmt.Errorf("%w: operation already in terminal state", consts.ErrStaleReference)
 		}
+
 		args.service = op.Service
 		args.operation = op.Operation
 		args.operationID = op.OperationId

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -105,6 +105,7 @@ func TestProcessInvocationTask(t *testing.T) {
 		name                       string
 		endpointNotFound           bool
 		eventHasNoEndpointID       bool
+		operationIsCanceled        bool
 		checkStartOperationOptions func(t *testing.T, options nexus.StartOperationOptions)
 		onStartOperation           func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error)
 		expectedMetricOutcome      string
@@ -352,6 +353,22 @@ func TestProcessInvocationTask(t *testing.T) {
 				require.Equal(t, 1, len(events))
 			},
 		},
+		{
+			name:                "operation already canceled",
+			operationIsCanceled: true,
+			requestTimeout:      time.Hour,
+			destinationDown:     false,
+			onStartOperation:    nil, // This should not be called if the operation is already canceled.
+			checkOutcome: func(t *testing.T, op nexusoperations.Operation, events []*historypb.HistoryEvent) {
+				require.Equal(t, enumsspb.NEXUS_OPERATION_STATE_CANCELED, op.State())
+				require.Nil(t, op.LastAttemptFailure)
+				require.Equal(t, 1, len(events))
+				require.NotNil(t, events[0].GetNexusOperationCanceledEventAttributes().Failure.Cause.GetCanceledFailureInfo())
+				require.Equal(t,
+					"operation canceled before it was started",
+					events[0].GetNexusOperationCanceledEventAttributes().Failure.Cause.Message)
+			},
+		},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -381,6 +398,12 @@ func TestProcessInvocationTask(t *testing.T) {
 			backend := &hsmtest.NodeBackend{Events: []*historypb.HistoryEvent{event}}
 			node := newOperationNode(t, backend, backend.Events[0])
 			env := fakeEnv{node}
+			if tc.operationIsCanceled {
+				op, err := hsm.MachineData[nexusoperations.Operation](node)
+				require.NoError(t, err)
+				_, err = op.Cancel(node, time.Now())
+				require.NoError(t, err)
+			}
 			namespaceRegistry := namespace.NewMockRegistry(ctrl)
 			namespaceRegistry.EXPECT().GetNamespaceByID(namespace.ID("ns-id")).Return(
 				namespace.NewNamespaceForTest(&persistence.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0), nil)

--- a/components/nexusoperations/workflow/commands_test.go
+++ b/components/nexusoperations/workflow/commands_test.go
@@ -524,17 +524,12 @@ func TestHandleCancelCommand(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, child)
 
-		require.Equal(t, 3, len(tcx.history.Events))
+		require.Equal(t, 2, len(tcx.history.Events))
 		crAttrs := tcx.history.Events[1].GetNexusOperationCancelRequestedEventAttributes()
 		require.Equal(t, event.EventId, crAttrs.ScheduledEventId)
 		require.Equal(t, int64(1), crAttrs.WorkflowTaskCompletedEventId)
 		savedUserMetadata := tcx.history.Events[1].GetUserMetadata()
 		require.EqualExportedValues(t, userMetadata, savedUserMetadata)
-
-		cAttrs := tcx.history.Events[2].GetNexusOperationCanceledEventAttributes()
-		require.Equal(t, event.EventId, cAttrs.ScheduledEventId)
-		require.Equal(t, "operation canceled before started", cAttrs.Failure.Cause.Message)
-		require.NotNil(t, cAttrs.Failure.Cause.GetCanceledFailureInfo())
 
 		child, err = child.Child([]hsm.Key{nexusoperations.CancelationMachineKey})
 		require.NoError(t, err)


### PR DESCRIPTION
## What changed?

Changed the operation cancelation logic to not cancel the operation if the operation hasn't been started yet.
Before this change canceling an operation would add a NEXUS_OPERATION_CANCELED event and immediately transition to the `Canceled` state, which had issues with replication and buffered events. E.g. the `Started` event would be applied before the `CancelRequested` event on one cluster and then applied in reverse order when replicating to another cluster.

Example history batch taken from a test cluster contains these events:

```
EVENT_TYPE_WORKFLOW_TASK_COMPLETED
EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED
EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED
EVENT_TYPE_NEXUS_OPERATION_STARTED // <-- this had to be buffered
EVENT_TYPE_WORKFLOW_TASK_SCHEDULED
EVENT_TYPE_WORKFLOW_TASK_STARTED
```

The new code path simply creates the cancelation state machine but doesn't actually cancel it, instead it lets the task executor attempt to resolve the machine as canceled.

Eventually we'll want to properly support cancel-before-started. At the moment, we may end up starting an operation and leave it oblivious of the cancelation request.

## How did you test it?

I didn't test the replication issue but the new code path avoids ordering issues by not transitioning to canceled state.
Added unit tests for the executor changes and modified the state machine tests.

## Is hotfix candidate?

We should patch 120 and maybe even 119. The latter will be promoted to OSS 1.25.0 but since we explicitly state that Nexus in 1.25.0 isn't suited for multi cluster deployments, we could skip this patch.