### PR TITLE
Add dynamic config to limit multi cursor predicate size

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1453,13 +1453,13 @@ count is exceeded. But since queue action is async, we need this hard limit.
 NOTE: The outbound queue has a separate configuration: outboundQueuePendingTaskMaxCount.
 `,
 	)
-	QueuePredicateMaxDepth = NewGlobalIntSetting(
-		"history.queuePredicateMaxDepth",
+	QueueMaxPredicateSize = NewGlobalIntSetting(
+		"history.queueMaxPredicateSize",
 		0,
-		`The max depth of the multi-cursor predicate structure stored in the shard info record. 0 is considered
-unlimited. When the predicate depth is surpassed for a given scope, the predicate is converted to a universal predicate,
+		`The max size of the multi-cursor predicate structure stored in the shard info record. 0 is considered
+unlimited. When the predicate size is surpassed for a given scope, the predicate is converted to a universal predicate,
 which causes all tasks in the scope's range to eventually be reprocessed without applying any filtering logic.
-NOTE: The outbound queue has a separate configuration: outboundQueuePredicateMaxDepth.
+NOTE: The outbound queue has a separate configuration: outboundQueueMaxPredicateSize.
 `,
 	)
 
@@ -1666,11 +1666,11 @@ critical count is exceeded. But since queue action is async, we need this hard l
 		9000,
 		`Max number of pending tasks in the outbound queue before triggering slice splitting and unloading.`,
 	)
-	OutboundQueuePredicateMaxDepth = NewGlobalIntSetting(
-		"history.outboundQueuePredicateMaxDepth",
-		5,
-		`The max depth of the multi-cursor predicate structure stored in the shard info record for the outbound queue. 0
-is considered unlimited. When the predicate depth is surpassed for a given scope, the predicate is converted to a
+	OutboundQueueMaxPredicateSize = NewGlobalIntSetting(
+		"history.outboundQueueMaxPredicateSize",
+		10*1024,
+		`The max size of the multi-cursor predicate structure stored in the shard info record for the outbound queue. 0
+is considered unlimited. When the predicate size is surpassed for a given scope, the predicate is converted to a
 universal predicate, which causes all tasks in the scope's range to eventually be reprocessed without applying any
 filtering logic.
 `,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1453,6 +1453,15 @@ count is exceeded. But since queue action is async, we need this hard limit.
 NOTE: The outbound queue has a separate configuration: outboundQueuePendingTaskMaxCount.
 `,
 	)
+	QueuePredicateMaxDepth = NewGlobalIntSetting(
+		"history.queuePredicateMaxDepth",
+		0,
+		`The max depth of the multi-cursor predicate structure stored in the shard info record. 0 is considered
+unlimited. When the predicate depth is surpassed for a given scope, the predicate is converted to a universal predicate,
+which causes all tasks in the scope's range to eventually be reprocessed without applying any filtering logic.
+NOTE: The outbound queue has a separate configuration: outboundQueuePredicateMaxDepth.
+`,
+	)
 
 	TaskSchedulerEnableRateLimiter = NewGlobalBoolSetting(
 		"history.taskSchedulerEnableRateLimiter",
@@ -1657,6 +1666,16 @@ critical count is exceeded. But since queue action is async, we need this hard l
 		9000,
 		`Max number of pending tasks in the outbound queue before triggering slice splitting and unloading.`,
 	)
+	OutboundQueuePredicateMaxDepth = NewGlobalIntSetting(
+		"history.outboundQueuePredicateMaxDepth",
+		5,
+		`The max depth of the multi-cursor predicate structure stored in the shard info record for the outbound queue. 0
+is considered unlimited. When the predicate depth is surpassed for a given scope, the predicate is converted to a
+universal predicate, which causes all tasks in the scope's range to eventually be reprocessed without applying any
+filtering logic.
+`,
+	)
+
 	OutboundProcessorMaxPollRPS = NewGlobalIntSetting(
 		"history.outboundProcessorMaxPollRPS",
 		20,

--- a/common/predicates/and.go
+++ b/common/predicates/and.go
@@ -89,6 +89,15 @@ func (a *AndImpl[T]) Equals(
 	return predicatesEqual(a.Predicates, andPredicate.Predicates)
 }
 
+func (o *AndImpl[T]) Depth() int {
+	depth := 0
+	for _, p := range o.Predicates {
+		depth = max(depth, p.Depth())
+	}
+
+	return depth + 1
+}
+
 // appendPredicates adds new predicates to the slice of existing predicates
 // dropping any duplicated predicates where duplication is determined by Predicate.Equals.
 // appendPredicates assumes that there's no duplication in new predicates.

--- a/common/predicates/and.go
+++ b/common/predicates/and.go
@@ -89,9 +89,9 @@ func (a *AndImpl[T]) Equals(
 	return predicatesEqual(a.Predicates, andPredicate.Predicates)
 }
 
-func (o *AndImpl[T]) Size() int {
+func (a *AndImpl[T]) Size() int {
 	size := EmptyPredicateProtoSize
-	for _, p := range o.Predicates {
+	for _, p := range a.Predicates {
 		size += p.Size()
 	}
 

--- a/common/predicates/and.go
+++ b/common/predicates/and.go
@@ -89,13 +89,13 @@ func (a *AndImpl[T]) Equals(
 	return predicatesEqual(a.Predicates, andPredicate.Predicates)
 }
 
-func (o *AndImpl[T]) Depth() int {
-	depth := 0
+func (o *AndImpl[T]) Size() int {
+	size := EmptyPredicateProtoSize
 	for _, p := range o.Predicates {
-		depth = max(depth, p.Depth())
+		size += p.Size()
 	}
 
-	return depth + 1
+	return size
 }
 
 // appendPredicates adds new predicates to the slice of existing predicates

--- a/common/predicates/and_test.go
+++ b/common/predicates/and_test.go
@@ -142,3 +142,13 @@ func (s *andSuite) TestAnd_Equals() {
 	s.False(p.Equals(Empty[int]()))
 	s.False(p.Equals(Universal[int]()))
 }
+
+func (s *andSuite) TestAnd_Depth() {
+	p1 := newTestPredicate(1, 2, 3)
+	p2 := newTestPredicate(2, 3, 4)
+	p := And(p1, p2)
+
+	s.Equal(2, p.Depth())
+	p = And(Or(p1, p2), p1)
+	s.Equal(3, p.Depth())
+}

--- a/common/predicates/and_test.go
+++ b/common/predicates/and_test.go
@@ -143,12 +143,10 @@ func (s *andSuite) TestAnd_Equals() {
 	s.False(p.Equals(Universal[int]()))
 }
 
-func (s *andSuite) TestAnd_Depth() {
+func (s *andSuite) TestAnd_Size() {
 	p1 := newTestPredicate(1, 2, 3)
 	p2 := newTestPredicate(2, 3, 4)
 	p := And(p1, p2)
 
-	s.Equal(2, p.Depth())
-	p = And(Or(p1, p2), p1)
-	s.Equal(3, p.Depth())
+	s.Equal(52, p.Size()) // 8 bytes per int64 * 6 ints + 4 bytes of overhead.
 }

--- a/common/predicates/empty.go
+++ b/common/predicates/empty.go
@@ -55,6 +55,6 @@ func (n *EmptyImpl[T]) Equals(
 	return ok
 }
 
-func (o *EmptyImpl[T]) Size() int {
+func (*EmptyImpl[T]) Size() int {
 	return EmptyPredicateProtoSize
 }

--- a/common/predicates/empty.go
+++ b/common/predicates/empty.go
@@ -24,9 +24,21 @@
 
 package predicates
 
+import (
+	"go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+)
+
 type (
 	EmptyImpl[T any] struct{}
 )
+
+var EmptyPredicateProtoSize = (&persistencespb.Predicate{
+	PredicateType: enums.PREDICATE_TYPE_EMPTY,
+	Attributes: &persistencespb.Predicate_EmptyPredicateAttributes{
+		EmptyPredicateAttributes: &persistencespb.EmptyPredicateAttributes{},
+	},
+}).Size()
 
 func Empty[T any]() Predicate[T] {
 	return &EmptyImpl[T]{}
@@ -43,6 +55,6 @@ func (n *EmptyImpl[T]) Equals(
 	return ok
 }
 
-func (o *EmptyImpl[T]) Depth() int {
-	return 1
+func (o *EmptyImpl[T]) Size() int {
+	return EmptyPredicateProtoSize
 }

--- a/common/predicates/empty.go
+++ b/common/predicates/empty.go
@@ -42,3 +42,7 @@ func (n *EmptyImpl[T]) Equals(
 	_, ok := predicate.(*EmptyImpl[T])
 	return ok
 }
+
+func (o *EmptyImpl[T]) Depth() int {
+	return 1
+}

--- a/common/predicates/not.go
+++ b/common/predicates/not.go
@@ -61,6 +61,6 @@ func (n *NotImpl[T]) Equals(
 	return n.Predicate.Equals(notPredicate.Predicate)
 }
 
-func (n *NotImpl[T]) Depth() int {
-	return n.Predicate.Depth() + 1
+func (n *NotImpl[T]) Size() int {
+	return n.Predicate.Size() + EmptyPredicateProtoSize
 }

--- a/common/predicates/not.go
+++ b/common/predicates/not.go
@@ -60,3 +60,7 @@ func (n *NotImpl[T]) Equals(
 	}
 	return n.Predicate.Equals(notPredicate.Predicate)
 }
+
+func (n *NotImpl[T]) Depth() int {
+	return n.Predicate.Depth() + 1
+}

--- a/common/predicates/not_test.go
+++ b/common/predicates/not_test.go
@@ -99,8 +99,9 @@ func (s *notSuite) TestNot_Equals() {
 	s.False(p.Equals(Universal[int]()))
 }
 
-func (s *notSuite) TestNot_Depth() {
+func (s *notSuite) TestNot_Size() {
 	p1 := newTestPredicate(1, 2, 3)
-	p := Not[int](p1)
-	s.Equal(2, p.Depth())
+	p := Not(p1)
+
+	s.Equal(28, p.Size()) // 8 bytes per int64 * 3 ints + 4 bytes of overhead.
 }

--- a/common/predicates/not_test.go
+++ b/common/predicates/not_test.go
@@ -98,3 +98,9 @@ func (s *notSuite) TestNot_Equals() {
 	s.False(p.Equals(Empty[int]()))
 	s.False(p.Equals(Universal[int]()))
 }
+
+func (s *notSuite) TestNot_Depth() {
+	p1 := newTestPredicate(1, 2, 3)
+	p := Not[int](p1)
+	s.Equal(2, p.Depth())
+}

--- a/common/predicates/or.go
+++ b/common/predicates/or.go
@@ -88,3 +88,12 @@ func (o *OrImpl[T]) Equals(
 
 	return predicatesEqual(o.Predicates, orPredicate.Predicates)
 }
+
+func (o *OrImpl[T]) Depth() int {
+	depth := 0
+	for _, p := range o.Predicates {
+		depth = max(depth, p.Depth())
+	}
+
+	return depth + 1
+}

--- a/common/predicates/or.go
+++ b/common/predicates/or.go
@@ -89,11 +89,11 @@ func (o *OrImpl[T]) Equals(
 	return predicatesEqual(o.Predicates, orPredicate.Predicates)
 }
 
-func (o *OrImpl[T]) Depth() int {
-	depth := 0
+func (o *OrImpl[T]) Size() int {
+	size := EmptyPredicateProtoSize
 	for _, p := range o.Predicates {
-		depth = max(depth, p.Depth())
+		size += p.Size()
 	}
 
-	return depth + 1
+	return size
 }

--- a/common/predicates/or_test.go
+++ b/common/predicates/or_test.go
@@ -143,12 +143,10 @@ func (s *orSuite) TestOr_Equals() {
 	s.False(p.Equals(Universal[int]()))
 }
 
-func (s *orSuite) TestOr_Depth() {
+func (s *orSuite) TestOr_Size() {
 	p1 := newTestPredicate(1, 2, 3)
 	p2 := newTestPredicate(2, 3, 4)
 	p := Or(p1, p2)
 
-	s.Equal(2, p.Depth())
-	p = Or(And(p1, p2), p1)
-	s.Equal(3, p.Depth())
+	s.Equal(52, p.Size()) // 8 bytes per int64 * 6 ints + 4 bytes of overhead.
 }

--- a/common/predicates/or_test.go
+++ b/common/predicates/or_test.go
@@ -142,3 +142,13 @@ func (s *orSuite) TestOr_Equals() {
 	s.False(p.Equals(Empty[int]()))
 	s.False(p.Equals(Universal[int]()))
 }
+
+func (s *orSuite) TestOr_Depth() {
+	p1 := newTestPredicate(1, 2, 3)
+	p2 := newTestPredicate(2, 3, 4)
+	p := Or(p1, p2)
+
+	s.Equal(2, p.Depth())
+	p = Or(And(p1, p2), p1)
+	s.Equal(3, p.Depth())
+}

--- a/common/predicates/predicates.go
+++ b/common/predicates/predicates.go
@@ -35,5 +35,7 @@ type (
 		// two predicates are mathmatically equivalent, Equals may still
 		// return false.
 		Equals(Predicate[T]) bool
+
+		Depth() int
 	}
 )

--- a/common/predicates/predicates.go
+++ b/common/predicates/predicates.go
@@ -36,6 +36,9 @@ type (
 		// return false.
 		Equals(Predicate[T]) bool
 
-		Depth() int
+		// Size gets the estimated size in bytes of this predicate.
+		// Implementation may keep this estimate rough and mostly account for elements that may take up considerable
+		// space such as strings and slices.
+		Size() int
 	}
 )

--- a/common/predicates/predicates_test.go
+++ b/common/predicates/predicates_test.go
@@ -59,3 +59,7 @@ func (p *testPredicate) Equals(predicate Predicate[int]) bool {
 
 	return maps.Equal(p.nums, testPrediate.nums)
 }
+
+func (p *testPredicate) Depth() int {
+	return 1
+}

--- a/common/predicates/predicates_test.go
+++ b/common/predicates/predicates_test.go
@@ -26,6 +26,7 @@ package predicates
 
 import (
 	"maps"
+	"strconv"
 )
 
 var _ Predicate[int] = (*testPredicate)(nil)
@@ -60,6 +61,6 @@ func (p *testPredicate) Equals(predicate Predicate[int]) bool {
 	return maps.Equal(p.nums, testPrediate.nums)
 }
 
-func (p *testPredicate) Depth() int {
-	return 1
+func (p *testPredicate) Size() int {
+	return strconv.IntSize / 8 * len(p.nums)
 }

--- a/common/predicates/universal.go
+++ b/common/predicates/universal.go
@@ -43,6 +43,6 @@ func (a *UniversalImpl[T]) Equals(
 	return ok
 }
 
-func (a *UniversalImpl[T]) Depth() int {
-	return 1
+func (a *UniversalImpl[T]) Size() int {
+	return EmptyPredicateProtoSize
 }

--- a/common/predicates/universal.go
+++ b/common/predicates/universal.go
@@ -42,3 +42,7 @@ func (a *UniversalImpl[T]) Equals(
 	_, ok := predicate.(*UniversalImpl[T])
 	return ok
 }
+
+func (a *UniversalImpl[T]) Depth() int {
+	return 1
+}

--- a/common/predicates/universal.go
+++ b/common/predicates/universal.go
@@ -43,6 +43,6 @@ func (a *UniversalImpl[T]) Equals(
 	return ok
 }
 
-func (a *UniversalImpl[T]) Size() int {
+func (*UniversalImpl[T]) Size() int {
 	return EmptyPredicateProtoSize
 }

--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -198,7 +198,7 @@ func (f *archivalQueueFactory) newScheduledQueue(shard shard.Context, executor q
 				BatchSize:            f.Config.ArchivalTaskBatchSize,
 				MaxPendingTasksCount: f.Config.QueuePendingTaskMaxCount,
 				PollBackoffInterval:  f.Config.ArchivalProcessorPollBackoffInterval,
-				MaxPredicateDepth:    f.Config.QueuePredicateMaxDepth,
+				MaxPredicateSize:     f.Config.QueueMaxPredicateSize,
 			},
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,

--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -198,6 +198,7 @@ func (f *archivalQueueFactory) newScheduledQueue(shard shard.Context, executor q
 				BatchSize:            f.Config.ArchivalTaskBatchSize,
 				MaxPendingTasksCount: f.Config.QueuePendingTaskMaxCount,
 				PollBackoffInterval:  f.Config.ArchivalProcessorPollBackoffInterval,
+				MaxPredicateDepth:    f.Config.QueuePredicateMaxDepth,
 			},
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -111,6 +111,7 @@ type Config struct {
 	QueueReaderStuckCriticalAttempts dynamicconfig.IntPropertyFn
 	QueueCriticalSlicesCount         dynamicconfig.IntPropertyFn
 	QueuePendingTaskMaxCount         dynamicconfig.IntPropertyFn
+	QueuePredicateMaxDepth           dynamicconfig.IntPropertyFn
 
 	TaskDLQEnabled                 dynamicconfig.BoolPropertyFn
 	TaskDLQUnexpectedErrorAttempts dynamicconfig.IntPropertyFn
@@ -169,6 +170,7 @@ type Config struct {
 	OutboundProcessorPollBackoffInterval                dynamicconfig.DurationPropertyFn
 	OutboundQueuePendingTaskCriticalCount               dynamicconfig.IntPropertyFn
 	OutboundQueuePendingTaskMaxCount                    dynamicconfig.IntPropertyFn
+	OutboundQueuePredicateMaxDepth                      dynamicconfig.IntPropertyFn
 	OutboundQueueMaxReaderCount                         dynamicconfig.IntPropertyFn
 	OutboundQueueGroupLimiterBufferSize                 dynamicconfig.IntPropertyFnWithDestinationFilter
 	OutboundQueueGroupLimiterConcurrency                dynamicconfig.IntPropertyFnWithDestinationFilter
@@ -445,6 +447,7 @@ func NewConfig(
 		QueueReaderStuckCriticalAttempts: dynamicconfig.QueueReaderStuckCriticalAttempts.Get(dc),
 		QueueCriticalSlicesCount:         dynamicconfig.QueueCriticalSlicesCount.Get(dc),
 		QueuePendingTaskMaxCount:         dynamicconfig.QueuePendingTaskMaxCount.Get(dc),
+		QueuePredicateMaxDepth:           dynamicconfig.QueuePredicateMaxDepth.Get(dc),
 
 		TaskDLQEnabled:                 dynamicconfig.HistoryTaskDLQEnabled.Get(dc),
 		TaskDLQUnexpectedErrorAttempts: dynamicconfig.HistoryTaskDLQUnexpectedErrorAttempts.Get(dc),
@@ -500,6 +503,7 @@ func NewConfig(
 		OutboundProcessorPollBackoffInterval:                dynamicconfig.OutboundProcessorPollBackoffInterval.Get(dc),
 		OutboundQueuePendingTaskCriticalCount:               dynamicconfig.OutboundQueuePendingTaskCriticalCount.Get(dc),
 		OutboundQueuePendingTaskMaxCount:                    dynamicconfig.OutboundQueuePendingTaskMaxCount.Get(dc),
+		OutboundQueuePredicateMaxDepth:                      dynamicconfig.OutboundQueuePredicateMaxDepth.Get(dc),
 		OutboundQueueMaxReaderCount:                         dynamicconfig.OutboundQueueMaxReaderCount.Get(dc),
 		OutboundQueueGroupLimiterBufferSize:                 dynamicconfig.OutboundQueueGroupLimiterBufferSize.Get(dc),
 		OutboundQueueGroupLimiterConcurrency:                dynamicconfig.OutboundQueueGroupLimiterConcurrency.Get(dc),

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -111,7 +111,7 @@ type Config struct {
 	QueueReaderStuckCriticalAttempts dynamicconfig.IntPropertyFn
 	QueueCriticalSlicesCount         dynamicconfig.IntPropertyFn
 	QueuePendingTaskMaxCount         dynamicconfig.IntPropertyFn
-	QueuePredicateMaxDepth           dynamicconfig.IntPropertyFn
+	QueueMaxPredicateSize            dynamicconfig.IntPropertyFn
 
 	TaskDLQEnabled                 dynamicconfig.BoolPropertyFn
 	TaskDLQUnexpectedErrorAttempts dynamicconfig.IntPropertyFn
@@ -170,7 +170,7 @@ type Config struct {
 	OutboundProcessorPollBackoffInterval                dynamicconfig.DurationPropertyFn
 	OutboundQueuePendingTaskCriticalCount               dynamicconfig.IntPropertyFn
 	OutboundQueuePendingTaskMaxCount                    dynamicconfig.IntPropertyFn
-	OutboundQueuePredicateMaxDepth                      dynamicconfig.IntPropertyFn
+	OutboundQueueMaxPredicateSize                       dynamicconfig.IntPropertyFn
 	OutboundQueueMaxReaderCount                         dynamicconfig.IntPropertyFn
 	OutboundQueueGroupLimiterBufferSize                 dynamicconfig.IntPropertyFnWithDestinationFilter
 	OutboundQueueGroupLimiterConcurrency                dynamicconfig.IntPropertyFnWithDestinationFilter
@@ -447,7 +447,7 @@ func NewConfig(
 		QueueReaderStuckCriticalAttempts: dynamicconfig.QueueReaderStuckCriticalAttempts.Get(dc),
 		QueueCriticalSlicesCount:         dynamicconfig.QueueCriticalSlicesCount.Get(dc),
 		QueuePendingTaskMaxCount:         dynamicconfig.QueuePendingTaskMaxCount.Get(dc),
-		QueuePredicateMaxDepth:           dynamicconfig.QueuePredicateMaxDepth.Get(dc),
+		QueueMaxPredicateSize:            dynamicconfig.QueueMaxPredicateSize.Get(dc),
 
 		TaskDLQEnabled:                 dynamicconfig.HistoryTaskDLQEnabled.Get(dc),
 		TaskDLQUnexpectedErrorAttempts: dynamicconfig.HistoryTaskDLQUnexpectedErrorAttempts.Get(dc),
@@ -503,7 +503,7 @@ func NewConfig(
 		OutboundProcessorPollBackoffInterval:                dynamicconfig.OutboundProcessorPollBackoffInterval.Get(dc),
 		OutboundQueuePendingTaskCriticalCount:               dynamicconfig.OutboundQueuePendingTaskCriticalCount.Get(dc),
 		OutboundQueuePendingTaskMaxCount:                    dynamicconfig.OutboundQueuePendingTaskMaxCount.Get(dc),
-		OutboundQueuePredicateMaxDepth:                      dynamicconfig.OutboundQueuePredicateMaxDepth.Get(dc),
+		OutboundQueueMaxPredicateSize:                       dynamicconfig.OutboundQueueMaxPredicateSize.Get(dc),
 		OutboundQueueMaxReaderCount:                         dynamicconfig.OutboundQueueMaxReaderCount.Get(dc),
 		OutboundQueueGroupLimiterBufferSize:                 dynamicconfig.OutboundQueueGroupLimiterBufferSize.Get(dc),
 		OutboundQueueGroupLimiterConcurrency:                dynamicconfig.OutboundQueueGroupLimiterConcurrency.Get(dc),

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -307,7 +307,7 @@ func (f *outboundQueueFactory) CreateQueue(
 				BatchSize:            f.Config.OutboundTaskBatchSize,
 				MaxPendingTasksCount: f.Config.OutboundQueuePendingTaskMaxCount,
 				PollBackoffInterval:  f.Config.OutboundProcessorPollBackoffInterval,
-				MaxPredicateDepth:    f.Config.OutboundQueuePredicateMaxDepth,
+				MaxPredicateSize:     f.Config.OutboundQueueMaxPredicateSize,
 			},
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount: f.Config.OutboundQueuePendingTaskCriticalCount,

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -307,6 +307,7 @@ func (f *outboundQueueFactory) CreateQueue(
 				BatchSize:            f.Config.OutboundTaskBatchSize,
 				MaxPendingTasksCount: f.Config.OutboundQueuePendingTaskMaxCount,
 				PollBackoffInterval:  f.Config.OutboundProcessorPollBackoffInterval,
+				MaxPredicateDepth:    f.Config.OutboundQueuePredicateMaxDepth,
 			},
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount: f.Config.OutboundQueuePendingTaskCriticalCount,

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -193,7 +193,7 @@ func newQueueBase(
 
 		slices := make([]Slice, 0, len(scopes))
 		for _, scope := range scopes {
-			slices = append(slices, NewSlice(paginationFnProvider, executableFactory, monitor, scope, grouper))
+			slices = append(slices, NewSlice(paginationFnProvider, executableFactory, monitor, scope, grouper, options.ReaderOptions.MaxPredicateSize))
 		}
 		readerGroup.NewReader(readerID, slices...)
 
@@ -281,6 +281,7 @@ func (p *queueBase) processNewRange() {
 			p.monitor,
 			newReadScope,
 			p.grouper,
+			p.options.ReaderOptions.MaxPredicateSize,
 		))
 	}
 

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -77,6 +77,7 @@ var testQueueOptions = &Options{
 		BatchSize:            dynamicconfig.GetIntPropertyFn(10),
 		MaxPendingTasksCount: dynamicconfig.GetIntPropertyFn(100),
 		PollBackoffInterval:  dynamicconfig.GetDurationPropertyFn(200 * time.Millisecond),
+		MaxPredicateDepth:    dynamicconfig.GetIntPropertyFn(10),
 	},
 	MonitorOptions: MonitorOptions{
 		PendingTasksCriticalCount:   dynamicconfig.GetIntPropertyFn(1000),

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -77,7 +77,7 @@ var testQueueOptions = &Options{
 		BatchSize:            dynamicconfig.GetIntPropertyFn(10),
 		MaxPendingTasksCount: dynamicconfig.GetIntPropertyFn(100),
 		PollBackoffInterval:  dynamicconfig.GetDurationPropertyFn(200 * time.Millisecond),
-		MaxPredicateDepth:    dynamicconfig.GetIntPropertyFn(10),
+		MaxPredicateSize:     dynamicconfig.GetIntPropertyFn(0),
 	},
 	MonitorOptions: MonitorOptions{
 		PendingTasksCriticalCount:   dynamicconfig.GetIntPropertyFn(1000),

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -269,19 +269,19 @@ func (r *ReaderImpl) MergeSlices(incomingSlices ...Slice) {
 		incomingSlice := incomingSlices[incomingSliceIdx]
 
 		if currentSlice.Scope().Range.InclusiveMin.CompareTo(incomingSlice.Scope().Range.InclusiveMin) < 0 {
-			mergeOrAppendSlice(mergedSlices, currentSlice, r.options.MaxPredicateSize())
+			mergeOrAppendSlice(mergedSlices, currentSlice)
 			currentSliceElement = currentSliceElement.Next()
 		} else {
-			mergeOrAppendSlice(mergedSlices, incomingSlice, r.options.MaxPredicateSize())
+			mergeOrAppendSlice(mergedSlices, incomingSlice)
 			incomingSliceIdx++
 		}
 	}
 
 	for ; currentSliceElement != nil; currentSliceElement = currentSliceElement.Next() {
-		mergeOrAppendSlice(mergedSlices, currentSliceElement.Value.(Slice), r.options.MaxPredicateSize())
+		mergeOrAppendSlice(mergedSlices, currentSliceElement.Value.(Slice))
 	}
 	for _, slice := range incomingSlices[incomingSliceIdx:] {
-		mergeOrAppendSlice(mergedSlices, slice, r.options.MaxPredicateSize())
+		mergeOrAppendSlice(mergedSlices, slice)
 	}
 
 	// clear existing list
@@ -552,7 +552,6 @@ func (r *ReaderImpl) verifyPendingTaskSize() bool {
 func mergeOrAppendSlice(
 	slices *list.List,
 	incomingSlice Slice,
-	maxPredicateDepth int,
 ) {
 	if slices.Len() == 0 {
 		slices.PushBack(incomingSlice)

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -69,7 +69,7 @@ type (
 		BatchSize            dynamicconfig.IntPropertyFn
 		MaxPendingTasksCount dynamicconfig.IntPropertyFn
 		PollBackoffInterval  dynamicconfig.DurationPropertyFn
-		MaxPredicateDepth    dynamicconfig.IntPropertyFn
+		MaxPredicateSize     dynamicconfig.IntPropertyFn
 	}
 
 	SliceIterator func(s Slice)
@@ -269,19 +269,19 @@ func (r *ReaderImpl) MergeSlices(incomingSlices ...Slice) {
 		incomingSlice := incomingSlices[incomingSliceIdx]
 
 		if currentSlice.Scope().Range.InclusiveMin.CompareTo(incomingSlice.Scope().Range.InclusiveMin) < 0 {
-			mergeOrAppendSlice(mergedSlices, currentSlice, r.options.MaxPredicateDepth())
+			mergeOrAppendSlice(mergedSlices, currentSlice, r.options.MaxPredicateSize())
 			currentSliceElement = currentSliceElement.Next()
 		} else {
-			mergeOrAppendSlice(mergedSlices, incomingSlice, r.options.MaxPredicateDepth())
+			mergeOrAppendSlice(mergedSlices, incomingSlice, r.options.MaxPredicateSize())
 			incomingSliceIdx++
 		}
 	}
 
 	for ; currentSliceElement != nil; currentSliceElement = currentSliceElement.Next() {
-		mergeOrAppendSlice(mergedSlices, currentSliceElement.Value.(Slice), r.options.MaxPredicateDepth())
+		mergeOrAppendSlice(mergedSlices, currentSliceElement.Value.(Slice), r.options.MaxPredicateSize())
 	}
 	for _, slice := range incomingSlices[incomingSliceIdx:] {
-		mergeOrAppendSlice(mergedSlices, slice, r.options.MaxPredicateDepth())
+		mergeOrAppendSlice(mergedSlices, slice, r.options.MaxPredicateSize())
 	}
 
 	// clear existing list
@@ -566,7 +566,7 @@ func mergeOrAppendSlice(
 		return
 	}
 
-	mergedSlices := lastSlice.MergeWithSlice(incomingSlice, maxPredicateDepth)
+	mergedSlices := lastSlice.MergeWithSlice(incomingSlice)
 	slices.Remove(lastElement)
 	for _, mergedSlice := range mergedSlices {
 		slices.PushBack(mergedSlice)

--- a/service/history/queues/reader_test.go
+++ b/service/history/queues/reader_test.go
@@ -512,6 +512,7 @@ func (s *readerSuite) newTestReader(
 			BatchSize:            dynamicconfig.GetIntPropertyFn(10),
 			MaxPendingTasksCount: dynamicconfig.GetIntPropertyFn(100),
 			PollBackoffInterval:  dynamicconfig.GetDurationPropertyFn(200 * time.Millisecond),
+			MaxPredicateDepth:    dynamicconfig.GetIntPropertyFn(10),
 		},
 		s.mockScheduler,
 		s.mockRescheduler,

--- a/service/history/queues/reader_test.go
+++ b/service/history/queues/reader_test.go
@@ -190,7 +190,7 @@ func (s *readerSuite) TestMergeSlices() {
 	incomingScopes := NewRandomScopes(rand.Intn(10))
 	incomingSlices := make([]Slice, 0, len(incomingScopes))
 	for _, incomingScope := range incomingScopes {
-		incomingSlices = append(incomingSlices, NewSlice(nil, s.executableFactory, s.monitor, incomingScope, GrouperNamespaceID{}))
+		incomingSlices = append(incomingSlices, NewSlice(nil, s.executableFactory, s.monitor, incomingScope, GrouperNamespaceID{}, noPredicateSizeLimit))
 	}
 
 	reader.MergeSlices(incomingSlices...)
@@ -217,7 +217,7 @@ func (s *readerSuite) TestAppendSlices() {
 	incomingScopes := scopes[totalScopes/2:]
 	incomingSlices := make([]Slice, 0, len(incomingScopes))
 	for _, incomingScope := range incomingScopes {
-		incomingSlices = append(incomingSlices, NewSlice(nil, s.executableFactory, s.monitor, incomingScope, GrouperNamespaceID{}))
+		incomingSlices = append(incomingSlices, NewSlice(nil, s.executableFactory, s.monitor, incomingScope, GrouperNamespaceID{}, noPredicateSizeLimit))
 	}
 
 	reader.AppendSlices(incomingSlices...)
@@ -501,7 +501,7 @@ func (s *readerSuite) newTestReader(
 ) *ReaderImpl {
 	slices := make([]Slice, 0, len(scopes))
 	for _, scope := range scopes {
-		slice := NewSlice(paginationFnProvider, s.executableFactory, s.monitor, scope, GrouperNamespaceID{})
+		slice := NewSlice(paginationFnProvider, s.executableFactory, s.monitor, scope, GrouperNamespaceID{}, noPredicateSizeLimit)
 		slices = append(slices, slice)
 	}
 
@@ -512,7 +512,7 @@ func (s *readerSuite) newTestReader(
 			BatchSize:            dynamicconfig.GetIntPropertyFn(10),
 			MaxPendingTasksCount: dynamicconfig.GetIntPropertyFn(100),
 			PollBackoffInterval:  dynamicconfig.GetDurationPropertyFn(200 * time.Millisecond),
-			MaxPredicateDepth:    dynamicconfig.GetIntPropertyFn(10),
+			MaxPredicateSize:     dynamicconfig.GetIntPropertyFn(10),
 		},
 		s.mockScheduler,
 		s.mockRescheduler,

--- a/service/history/queues/scope.go
+++ b/service/history/queues/scope.go
@@ -112,19 +112,12 @@ func (s *Scope) CanMergeByPredicate(
 
 func (s *Scope) MergeByPredicate(
 	incomingScope Scope,
-	maxPredicateDepth int,
 ) Scope {
 	if !s.CanMergeByPredicate(incomingScope) {
 		panic(fmt.Sprintf("Unable to merge scope with range %v with range %v by predicate", s.Range, incomingScope.Range))
 	}
 
 	merged := tasks.OrPredicates(s.Predicate, incomingScope.Predicate)
-	// 0 == unlimited
-	if maxPredicateDepth > 0 && merged.Depth() > maxPredicateDepth {
-		// Due to the limitations in predicate merging logic, the predicate depth can easily grow unbounded.
-		// The simplest mitigation is to stop merging and replace with the univeral predicate.
-		merged = predicates.Universal[tasks.Task]()
-	}
 	return NewScope(s.Range, merged)
 }
 

--- a/service/history/queues/scope.go
+++ b/service/history/queues/scope.go
@@ -117,8 +117,7 @@ func (s *Scope) MergeByPredicate(
 		panic(fmt.Sprintf("Unable to merge scope with range %v with range %v by predicate", s.Range, incomingScope.Range))
 	}
 
-	merged := tasks.OrPredicates(s.Predicate, incomingScope.Predicate)
-	return NewScope(s.Range, merged)
+	return NewScope(s.Range, tasks.OrPredicates(s.Predicate, incomingScope.Predicate))
 }
 
 func (s *Scope) IsEmpty() bool {

--- a/service/history/queues/scope_test.go
+++ b/service/history/queues/scope_test.go
@@ -322,7 +322,7 @@ func (s *scopeSuite) TestMergeByPredicate_SamePredicateType() {
 
 	mergeNamespaceIDs := append(slices.Clone(namespaceIDs[:rand.Intn(len(namespaceIDs))]), uuid.New(), uuid.New())
 	mergePredicate := tasks.NewNamespacePredicate(mergeNamespaceIDs)
-	mergedScope := scope.MergeByPredicate(NewScope(r, mergePredicate), 10)
+	mergedScope := scope.MergeByPredicate(NewScope(r, mergePredicate))
 	s.Equal(r, mergedScope.Range)
 
 	for _, namespaceID := range namespaceIDs {
@@ -359,7 +359,7 @@ func (s *scopeSuite) TestMergeByPredicate_DifferentPredicateType() {
 		enumsspb.TaskType(rand.Intn(10)),
 	}
 	mergePredicate := tasks.NewTypePredicate(mergeTaskTypes)
-	mergedScope := scope.MergeByPredicate(NewScope(r, mergePredicate), 10)
+	mergedScope := scope.MergeByPredicate(NewScope(r, mergePredicate))
 	s.Equal(r, mergedScope.Range)
 
 	for _, namespaceID := range namespaceIDs {

--- a/service/history/queues/scope_test.go
+++ b/service/history/queues/scope_test.go
@@ -322,7 +322,7 @@ func (s *scopeSuite) TestMergeByPredicate_SamePredicateType() {
 
 	mergeNamespaceIDs := append(slices.Clone(namespaceIDs[:rand.Intn(len(namespaceIDs))]), uuid.New(), uuid.New())
 	mergePredicate := tasks.NewNamespacePredicate(mergeNamespaceIDs)
-	mergedScope := scope.MergeByPredicate(NewScope(r, mergePredicate))
+	mergedScope := scope.MergeByPredicate(NewScope(r, mergePredicate), 10)
 	s.Equal(r, mergedScope.Range)
 
 	for _, namespaceID := range namespaceIDs {
@@ -359,7 +359,7 @@ func (s *scopeSuite) TestMergeByPredicate_DifferentPredicateType() {
 		enumsspb.TaskType(rand.Intn(10)),
 	}
 	mergePredicate := tasks.NewTypePredicate(mergeTaskTypes)
-	mergedScope := scope.MergeByPredicate(NewScope(r, mergePredicate))
+	mergedScope := scope.MergeByPredicate(NewScope(r, mergePredicate), 10)
 	s.Equal(r, mergedScope.Range)
 
 	for _, namespaceID := range namespaceIDs {

--- a/service/history/queues/slice_test.go
+++ b/service/history/queues/slice_test.go
@@ -57,6 +57,10 @@ type (
 	}
 )
 
+func noPredicateSizeLimit() int {
+	return 0
+}
+
 func TestSliceSuite(t *testing.T) {
 	s := new(sliceSuite)
 	suite.Run(t, s)
@@ -97,7 +101,7 @@ func (s *sliceSuite) TestCanSplitByRange() {
 	r := NewRandomRange()
 	scope := NewScope(r, predicates.Universal[tasks.Task]())
 
-	slice := NewSlice(nil, s.executableFactory, s.monitor, scope, GrouperNamespaceID{})
+	slice := NewSlice(nil, s.executableFactory, s.monitor, scope, GrouperNamespaceID{}, noPredicateSizeLimit)
 	s.Equal(scope, slice.Scope())
 
 	s.True(slice.CanSplitByRange(r.InclusiveMin))
@@ -158,7 +162,7 @@ func (s *sliceSuite) TestCanMergeWithSlice() {
 	r := NewRandomRange()
 	namespaceIDs := []string{uuid.New(), uuid.New(), uuid.New(), uuid.New()}
 	predicate := tasks.NewNamespacePredicate(namespaceIDs)
-	slice := NewSlice(nil, nil, s.monitor, NewScope(r, predicate), GrouperNamespaceID{})
+	slice := NewSlice(nil, nil, s.monitor, NewScope(r, predicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 
 	testPredicates := []tasks.Predicate{
 		predicate,
@@ -170,22 +174,22 @@ func (s *sliceSuite) TestCanMergeWithSlice() {
 	s.False(predicate.Equals(testPredicates[2]))
 
 	for _, mergePredicate := range testPredicates {
-		testSlice := NewSlice(nil, nil, s.monitor, NewScope(r, mergePredicate), GrouperNamespaceID{})
+		testSlice := NewSlice(nil, nil, s.monitor, NewScope(r, mergePredicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 		s.True(slice.CanMergeWithSlice(testSlice))
 
-		testSlice = NewSlice(nil, nil, s.monitor, NewScope(NewRange(tasks.MinimumKey, r.InclusiveMin), mergePredicate), GrouperNamespaceID{})
+		testSlice = NewSlice(nil, nil, s.monitor, NewScope(NewRange(tasks.MinimumKey, r.InclusiveMin), mergePredicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 		s.True(slice.CanMergeWithSlice(testSlice))
 
-		testSlice = NewSlice(nil, nil, s.monitor, NewScope(NewRange(r.ExclusiveMax, tasks.MaximumKey), mergePredicate), GrouperNamespaceID{})
+		testSlice = NewSlice(nil, nil, s.monitor, NewScope(NewRange(r.ExclusiveMax, tasks.MaximumKey), mergePredicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 		s.True(slice.CanMergeWithSlice(testSlice))
 
-		testSlice = NewSlice(nil, nil, s.monitor, NewScope(NewRange(tasks.MinimumKey, NewRandomKeyInRange(r)), mergePredicate), GrouperNamespaceID{})
+		testSlice = NewSlice(nil, nil, s.monitor, NewScope(NewRange(tasks.MinimumKey, NewRandomKeyInRange(r)), mergePredicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 		s.True(slice.CanMergeWithSlice(testSlice))
 
-		testSlice = NewSlice(nil, nil, s.monitor, NewScope(NewRange(NewRandomKeyInRange(r), tasks.MaximumKey), mergePredicate), GrouperNamespaceID{})
+		testSlice = NewSlice(nil, nil, s.monitor, NewScope(NewRange(NewRandomKeyInRange(r), tasks.MaximumKey), mergePredicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 		s.True(slice.CanMergeWithSlice(testSlice))
 
-		testSlice = NewSlice(nil, nil, s.monitor, NewScope(NewRange(tasks.MinimumKey, tasks.MaximumKey), mergePredicate), GrouperNamespaceID{})
+		testSlice = NewSlice(nil, nil, s.monitor, NewScope(NewRange(tasks.MinimumKey, tasks.MaximumKey), mergePredicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 		s.True(slice.CanMergeWithSlice(testSlice))
 	}
 
@@ -194,13 +198,13 @@ func (s *sliceSuite) TestCanMergeWithSlice() {
 	testSlice := NewSlice(nil, nil, s.monitor, NewScope(NewRange(
 		tasks.MinimumKey,
 		tasks.NewKey(r.InclusiveMin.FireTime, r.InclusiveMin.TaskID-1),
-	), predicate), GrouperNamespaceID{})
+	), predicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 	s.False(slice.CanMergeWithSlice(testSlice))
 
 	testSlice = NewSlice(nil, nil, s.monitor, NewScope(NewRange(
 		tasks.NewKey(r.ExclusiveMax.FireTime, r.ExclusiveMax.TaskID+1),
 		tasks.MaximumKey,
-	), predicate), GrouperNamespaceID{})
+	), predicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 	s.False(slice.CanMergeWithSlice(testSlice))
 }
 
@@ -213,7 +217,7 @@ func (s *sliceSuite) TestMergeWithSlice_SamePredicate() {
 	incomingSlice := s.newTestSlice(incomingRange, nil, nil)
 	totalExecutables += len(incomingSlice.pendingExecutables)
 
-	mergedSlices := slice.MergeWithSlice(incomingSlice, 10)
+	mergedSlices := slice.MergeWithSlice(incomingSlice)
 	s.Len(mergedSlices, 1)
 
 	s.validateMergedSlice(slice, incomingSlice, mergedSlices, totalExecutables)
@@ -232,16 +236,17 @@ func (s *sliceSuite) TestMergeWithSlice_SameRange() {
 	incomingSlice := s.newTestSlice(r, nil, taskTypes)
 	totalExecutables += len(incomingSlice.pendingExecutables)
 
-	mergedSlices := slice.MergeWithSlice(incomingSlice, 10)
+	mergedSlices := slice.MergeWithSlice(incomingSlice)
 	s.Len(mergedSlices, 1)
 
 	s.validateMergedSlice(slice, incomingSlice, mergedSlices, totalExecutables)
 }
 
-func (s *sliceSuite) TestMergeWithSlice_MaxPredicateDepthApplied() {
+func (s *sliceSuite) TestMergeWithSlice_MaxPredicateSizeApplied() {
 	r := NewRandomRange()
 	namespaceIDs := []string{uuid.New(), uuid.New(), uuid.New(), uuid.New()}
 	slice := s.newTestSlice(r, namespaceIDs, nil)
+	slice.maxPredicateSizeFn = func() int { return 4 }
 	totalExecutables := len(slice.pendingExecutables)
 
 	taskTypes := []enumsspb.TaskType{
@@ -251,7 +256,7 @@ func (s *sliceSuite) TestMergeWithSlice_MaxPredicateDepthApplied() {
 	incomingSlice := s.newTestSlice(r, nil, taskTypes)
 	totalExecutables += len(incomingSlice.pendingExecutables)
 
-	mergedSlices := slice.MergeWithSlice(incomingSlice, 1)
+	mergedSlices := slice.MergeWithSlice(incomingSlice)
 	s.Len(mergedSlices, 1)
 
 	s.True(mergedSlices[0].Scope().Predicate.Equals(predicates.Universal[tasks.Task]()))
@@ -271,7 +276,7 @@ func (s *sliceSuite) TestMergeWithSlice_SameMinKey() {
 	incomingSlice := s.newTestSlice(incomingRange, incomingNamespaceIDs, nil)
 	totalExecutables += len(incomingSlice.pendingExecutables)
 
-	mergedSlices := slice.MergeWithSlice(incomingSlice, 10)
+	mergedSlices := slice.MergeWithSlice(incomingSlice)
 	s.Len(mergedSlices, 2)
 
 	s.validateMergedSlice(slice, incomingSlice, mergedSlices, totalExecutables)
@@ -291,7 +296,7 @@ func (s *sliceSuite) TestMergeWithSlice_SameMaxKey() {
 	incomingSlice := s.newTestSlice(incomingRange, incomingNamespaceIDs, nil)
 	totalExecutables += len(incomingSlice.pendingExecutables)
 
-	mergedSlices := slice.MergeWithSlice(incomingSlice, 10)
+	mergedSlices := slice.MergeWithSlice(incomingSlice)
 	s.Len(mergedSlices, 2)
 
 	s.validateMergedSlice(slice, incomingSlice, mergedSlices, totalExecutables)
@@ -315,7 +320,7 @@ func (s *sliceSuite) TestMergeWithSlice_DifferentMinMaxKey() {
 	s.validateSliceState(slice)
 	s.validateSliceState(incomingSlice)
 
-	mergedSlices := slice.MergeWithSlice(incomingSlice, 10)
+	mergedSlices := slice.MergeWithSlice(incomingSlice)
 	s.Len(mergedSlices, 3)
 
 	s.validateMergedSlice(slice, incomingSlice, mergedSlices, totalExecutables)
@@ -363,7 +368,7 @@ func (s *sliceSuite) TestShrinkScope_ShrinkRange() {
 	r := NewRandomRange()
 	predicate := predicates.Universal[tasks.Task]()
 
-	slice := NewSlice(nil, s.executableFactory, s.monitor, NewScope(r, predicate), GrouperNamespaceID{})
+	slice := NewSlice(nil, s.executableFactory, s.monitor, NewScope(r, predicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 	slice.iterators = s.randomIteratorsInRange(r, rand.Intn(2), nil)
 
 	executables := s.randomExecutablesInRange(r, 5)
@@ -412,7 +417,7 @@ func (s *sliceSuite) TestShrinkScope_ShrinkPredicate() {
 	r := NewRandomRange()
 	predicate := predicates.Universal[tasks.Task]()
 
-	slice := NewSlice(nil, s.executableFactory, s.monitor, NewScope(r, predicate), GrouperNamespaceID{})
+	slice := NewSlice(nil, s.executableFactory, s.monitor, NewScope(r, predicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 	slice.iterators = []Iterator{} // manually set iterators to be empty to trigger predicate update
 
 	executables := s.randomExecutablesInRange(r, 100)
@@ -481,7 +486,7 @@ func (s *sliceSuite) TestSelectTasks_NoError() {
 	}
 
 	for _, batchSize := range []int{1, 2, 5, 10, 20, 100} {
-		slice := NewSlice(paginationFnProvider, s.executableFactory, s.monitor, NewScope(r, predicate), GrouperNamespaceID{})
+		slice := NewSlice(paginationFnProvider, s.executableFactory, s.monitor, NewScope(r, predicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 
 		executables := make([]Executable, 0, numTasks)
 		for {
@@ -529,7 +534,7 @@ func (s *sliceSuite) TestSelectTasks_Error_NoLoadedTasks() {
 		}
 	}
 
-	slice := NewSlice(paginationFnProvider, s.executableFactory, s.monitor, NewScope(r, predicate), GrouperNamespaceID{})
+	slice := NewSlice(paginationFnProvider, s.executableFactory, s.monitor, NewScope(r, predicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 	_, err := slice.SelectTasks(DefaultReaderId, 100)
 	s.Error(err)
 
@@ -572,7 +577,7 @@ func (s *sliceSuite) TestSelectTasks_Error_WithLoadedTasks() {
 		}
 	}
 
-	slice := NewSlice(paginationFnProvider, s.executableFactory, s.monitor, NewScope(r, predicate), GrouperNamespaceID{})
+	slice := NewSlice(paginationFnProvider, s.executableFactory, s.monitor, NewScope(r, predicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 	executables, err := slice.SelectTasks(DefaultReaderId, 100)
 	s.NoError(err)
 	s.Len(executables, numTasks)
@@ -631,7 +636,7 @@ func (s *sliceSuite) newTestSlice(
 		taskTypes = []enumsspb.TaskType{enumsspb.TASK_TYPE_TRANSFER_CLOSE_EXECUTION}
 	}
 
-	slice := NewSlice(nil, s.executableFactory, s.monitor, NewScope(r, predicate), GrouperNamespaceID{})
+	slice := NewSlice(nil, s.executableFactory, s.monitor, NewScope(r, predicate), GrouperNamespaceID{}, noPredicateSizeLimit)
 	for _, executable := range s.randomExecutablesInRange(r, rand.Intn(20)) {
 		slice.pendingExecutables[executable.GetKey()] = executable
 

--- a/service/history/tasks/predicates.go
+++ b/service/history/tasks/predicates.go
@@ -85,8 +85,12 @@ func (n *NamespacePredicate) Equals(predicate Predicate) bool {
 	return maps.Equal(n.NamespaceIDs, nsPredicate.NamespaceIDs)
 }
 
-func (n *NamespacePredicate) Depth() int {
-	return 1
+func (n *NamespacePredicate) Size() int {
+	size := predicates.EmptyPredicateProtoSize
+	for g := range n.NamespaceIDs {
+		size += len(g)
+	}
+	return size
 }
 
 func NewDestinationPredicate(
@@ -120,8 +124,12 @@ func (n *DestinationPredicate) Equals(predicate Predicate) bool {
 	return maps.Equal(n.Destinations, dPredicate.Destinations)
 }
 
-func (n *DestinationPredicate) Depth() int {
-	return 1
+func (n *DestinationPredicate) Size() int {
+	size := predicates.EmptyPredicateProtoSize
+	for g := range n.Destinations {
+		size += len(g)
+	}
+	return size
 }
 
 func NewOutboundTaskGroupPredicate(
@@ -155,8 +163,12 @@ func (n *OutboundTaskGroupPredicate) Equals(predicate Predicate) bool {
 	return maps.Equal(n.Groups, smPredicate.Groups)
 }
 
-func (n *OutboundTaskGroupPredicate) Depth() int {
-	return 1
+func (n *OutboundTaskGroupPredicate) Size() int {
+	size := predicates.EmptyPredicateProtoSize
+	for g := range n.Groups {
+		size += len(g)
+	}
+	return size
 }
 
 func NewTypePredicate(
@@ -186,8 +198,8 @@ func (t *TypePredicate) Equals(predicate Predicate) bool {
 	return maps.Equal(t.Types, typePrediate.Types)
 }
 
-func (n *TypePredicate) Depth() int {
-	return 1
+func (n *TypePredicate) Size() int {
+	return predicates.EmptyPredicateProtoSize + 4*len(n.Types) // Type is enum which is an int32
 }
 
 // TaskGroupNamespaceIDAndDestination is the key for grouping tasks by task type namespace ID and destination.
@@ -236,8 +248,12 @@ func (t *OutboundTaskPredicate) Equals(predicate Predicate) bool {
 	return maps.Equal(t.Groups, outboundPredicate.Groups)
 }
 
-func (n *OutboundTaskPredicate) Depth() int {
-	return 1
+func (n *OutboundTaskPredicate) Size() int {
+	size := predicates.EmptyPredicateProtoSize
+	for g := range n.Groups {
+		size += len(g.TaskGroup) + len(g.NamespaceID) + len(g.Destination)
+	}
+	return size
 }
 
 func AndPredicates(a Predicate, b Predicate) Predicate {

--- a/service/history/tasks/predicates.go
+++ b/service/history/tasks/predicates.go
@@ -85,6 +85,10 @@ func (n *NamespacePredicate) Equals(predicate Predicate) bool {
 	return maps.Equal(n.NamespaceIDs, nsPredicate.NamespaceIDs)
 }
 
+func (n *NamespacePredicate) Depth() int {
+	return 1
+}
+
 func NewDestinationPredicate(
 	destinations []string,
 ) *DestinationPredicate {
@@ -114,6 +118,10 @@ func (n *DestinationPredicate) Equals(predicate Predicate) bool {
 	}
 
 	return maps.Equal(n.Destinations, dPredicate.Destinations)
+}
+
+func (n *DestinationPredicate) Depth() int {
+	return 1
 }
 
 func NewOutboundTaskGroupPredicate(
@@ -147,6 +155,10 @@ func (n *OutboundTaskGroupPredicate) Equals(predicate Predicate) bool {
 	return maps.Equal(n.Groups, smPredicate.Groups)
 }
 
+func (n *OutboundTaskGroupPredicate) Depth() int {
+	return 1
+}
+
 func NewTypePredicate(
 	types []enumsspb.TaskType,
 ) *TypePredicate {
@@ -172,6 +184,10 @@ func (t *TypePredicate) Equals(predicate Predicate) bool {
 	}
 
 	return maps.Equal(t.Types, typePrediate.Types)
+}
+
+func (n *TypePredicate) Depth() int {
+	return 1
 }
 
 // TaskGroupNamespaceIDAndDestination is the key for grouping tasks by task type namespace ID and destination.
@@ -218,6 +234,10 @@ func (t *OutboundTaskPredicate) Equals(predicate Predicate) bool {
 	}
 
 	return maps.Equal(t.Groups, outboundPredicate.Groups)
+}
+
+func (n *OutboundTaskPredicate) Depth() int {
+	return 1
 }
 
 func AndPredicates(a Predicate, b Predicate) Predicate {

--- a/service/history/tasks/predicates.go
+++ b/service/history/tasks/predicates.go
@@ -198,8 +198,8 @@ func (t *TypePredicate) Equals(predicate Predicate) bool {
 	return maps.Equal(t.Types, typePrediate.Types)
 }
 
-func (n *TypePredicate) Size() int {
-	return predicates.EmptyPredicateProtoSize + 4*len(n.Types) // Type is enum which is an int32
+func (t *TypePredicate) Size() int {
+	return predicates.EmptyPredicateProtoSize + 4*len(t.Types) // Type is enum which is an int32
 }
 
 // TaskGroupNamespaceIDAndDestination is the key for grouping tasks by task type namespace ID and destination.
@@ -248,9 +248,9 @@ func (t *OutboundTaskPredicate) Equals(predicate Predicate) bool {
 	return maps.Equal(t.Groups, outboundPredicate.Groups)
 }
 
-func (n *OutboundTaskPredicate) Size() int {
+func (t *OutboundTaskPredicate) Size() int {
 	size := predicates.EmptyPredicateProtoSize
-	for g := range n.Groups {
+	for g := range t.Groups {
 		size += len(g.TaskGroup) + len(g.NamespaceID) + len(g.Destination)
 	}
 	return size

--- a/service/history/tasks/predicates_test.go
+++ b/service/history/tasks/predicates_test.go
@@ -94,6 +94,15 @@ func (s *predicatesSuite) TestNamespacePredicate_Equals() {
 	s.False(p.Equals(predicates.Universal[Task]()))
 }
 
+func (s *predicatesSuite) TestNamespacePredicate_Size() {
+	namespaceIDs := []string{uuid.New(), uuid.New()}
+
+	p := NewNamespacePredicate(namespaceIDs)
+
+	// UUID length is 36 and 4 bytes accounted for proto overhead.
+	s.Equal(76, p.Size())
+}
+
 func (s *predicatesSuite) TestTypePredicate_Test() {
 	types := []enumsspb.TaskType{
 		enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
@@ -150,6 +159,17 @@ func (s *predicatesSuite) TestTypePredicate_Equals() {
 	s.False(p.Equals(predicates.Universal[Task]()))
 }
 
+func (s *predicatesSuite) TestTypePredicate_Size() {
+	types := []enumsspb.TaskType{
+		enumsspb.TASK_TYPE_TRANSFER_ACTIVITY_TASK,
+		enumsspb.TASK_TYPE_VISIBILITY_CLOSE_EXECUTION,
+	}
+	p := NewTypePredicate(types)
+
+	// enum size is 4 and 4 bytes accounted for proto overhead.
+	s.Equal(12, p.Size())
+}
+
 func (s *predicatesSuite) TestDestinationPredicate_Test() {
 	destinations := []string{uuid.New(), uuid.New()}
 
@@ -183,6 +203,15 @@ func (s *predicatesSuite) TestDestinationPredicate_Equals() {
 	s.False(p.Equals(predicates.Universal[Task]()))
 }
 
+func (s *predicatesSuite) TestDestinationPredicate_Size() {
+	destinations := []string{uuid.New(), uuid.New()}
+
+	p := NewDestinationPredicate(destinations)
+
+	// UUID length is 36 and 4 bytes accounted for proto overhead.
+	s.Equal(76, p.Size())
+}
+
 func (s *predicatesSuite) TestOutboundTaskGroupPredicate_Test() {
 	groups := []string{"1", "2"}
 
@@ -214,6 +243,15 @@ func (s *predicatesSuite) TestOutboundTaskGroupPredicate_Equals() {
 	s.False(p.Equals(NewOutboundTaskGroupPredicate([]string{"3", "4"})))
 	s.False(p.Equals(NewTypePredicate([]enumsspb.TaskType{enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER})))
 	s.False(p.Equals(predicates.Universal[Task]()))
+}
+
+func (s *predicatesSuite) TestOutboundTaskGroupPredicate_Size() {
+	groups := []string{uuid.New(), uuid.New()}
+
+	p := NewOutboundTaskGroupPredicate(groups)
+
+	// UUID length is 36 and 4 bytes accounted for proto overhead.
+	s.Equal(76, p.Size())
 }
 
 func (s *predicatesSuite) TestOutboundTaskPredicate_Test() {
@@ -285,6 +323,16 @@ func (s *predicatesSuite) TestOutboundTaskPredicate_Equals() {
 	})))
 	s.False(p.Equals(NewTypePredicate([]enumsspb.TaskType{enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER})))
 	s.False(p.Equals(predicates.Universal[Task]()))
+}
+
+func (s *predicatesSuite) TestOutboundTaskPredicate_Size() {
+	groups := []TaskGroupNamespaceIDAndDestination{
+		{"g1", "n1", "d1"},
+		{"g2", "n2", "d2"},
+	}
+	p := NewOutboundTaskPredicate(groups)
+
+	s.Equal(16, p.Size())
 }
 
 func (s *predicatesSuite) TestAndPredicates() {

--- a/service/history/timer_queue_factory.go
+++ b/service/history/timer_queue_factory.go
@@ -256,7 +256,7 @@ func (f *timerQueueFactory) CreateQueue(
 				BatchSize:            f.Config.TimerTaskBatchSize,
 				MaxPendingTasksCount: f.Config.QueuePendingTaskMaxCount,
 				PollBackoffInterval:  f.Config.TimerProcessorPollBackoffInterval,
-				MaxPredicateDepth:    f.Config.QueuePredicateMaxDepth,
+				MaxPredicateSize:     f.Config.QueueMaxPredicateSize,
 			},
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,

--- a/service/history/timer_queue_factory.go
+++ b/service/history/timer_queue_factory.go
@@ -256,6 +256,7 @@ func (f *timerQueueFactory) CreateQueue(
 				BatchSize:            f.Config.TimerTaskBatchSize,
 				MaxPendingTasksCount: f.Config.QueuePendingTaskMaxCount,
 				PollBackoffInterval:  f.Config.TimerProcessorPollBackoffInterval,
+				MaxPredicateDepth:    f.Config.QueuePredicateMaxDepth,
 			},
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -249,6 +249,7 @@ func (f *transferQueueFactory) CreateQueue(
 				BatchSize:            f.Config.TransferTaskBatchSize,
 				MaxPendingTasksCount: f.Config.QueuePendingTaskMaxCount,
 				PollBackoffInterval:  f.Config.TransferProcessorPollBackoffInterval,
+				MaxPredicateDepth:    f.Config.QueuePredicateMaxDepth,
 			},
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -249,7 +249,7 @@ func (f *transferQueueFactory) CreateQueue(
 				BatchSize:            f.Config.TransferTaskBatchSize,
 				MaxPendingTasksCount: f.Config.QueuePendingTaskMaxCount,
 				PollBackoffInterval:  f.Config.TransferProcessorPollBackoffInterval,
-				MaxPredicateDepth:    f.Config.QueuePredicateMaxDepth,
+				MaxPredicateSize:     f.Config.QueueMaxPredicateSize,
 			},
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,

--- a/service/history/visibility_queue_factory.go
+++ b/service/history/visibility_queue_factory.go
@@ -154,6 +154,7 @@ func (f *visibilityQueueFactory) CreateQueue(
 				BatchSize:            f.Config.VisibilityTaskBatchSize,
 				MaxPendingTasksCount: f.Config.QueuePendingTaskMaxCount,
 				PollBackoffInterval:  f.Config.VisibilityProcessorPollBackoffInterval,
+				MaxPredicateDepth:    f.Config.QueuePredicateMaxDepth,
 			},
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,

--- a/service/history/visibility_queue_factory.go
+++ b/service/history/visibility_queue_factory.go
@@ -154,7 +154,7 @@ func (f *visibilityQueueFactory) CreateQueue(
 				BatchSize:            f.Config.VisibilityTaskBatchSize,
 				MaxPendingTasksCount: f.Config.QueuePendingTaskMaxCount,
 				PollBackoffInterval:  f.Config.VisibilityProcessorPollBackoffInterval,
-				MaxPredicateDepth:    f.Config.QueuePredicateMaxDepth,
+				MaxPredicateSize:     f.Config.QueueMaxPredicateSize,
 			},
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,


### PR DESCRIPTION
## What changed?

Add dynamic config to limit multi-cursor predicate size.
There are two separate configs:
- `history.queueMaxPredicateSize` for all history queues except for the outbound queue - set to unlimited by default to avoid changing behavior
- `history.outboundQueueMaxPredicateSize` for the outbound queue - set to 10K by default

## Why?

Limit the size of the shard info record. In stress test scenarios we've seen this record grow to over 10MB.

## How did you test it?

Added unit tests.

## Is hotfix candidate?

This should be applied to any server deployments enabling Nexus workloads.