### PR TITLE
Unskip xdc tests expecting advanced visibility

### DIFF
--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -55,6 +55,8 @@ import (
 	"go.temporal.io/sdk/temporal"
 	sdkworker "go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/convert"
@@ -64,7 +66,6 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/service/worker/migration"
 	"go.temporal.io/server/tests"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type (
@@ -2403,10 +2404,6 @@ func (s *FunctionalClustersTestSuite) TestActivityHeartbeatFailover() {
 // }
 
 func (s *FunctionalClustersTestSuite) TestLocalNamespaceMigration() {
-	if !tests.UsingSQLAdvancedVisibility() {
-		s.T().Skip("Test requires advanced visibility")
-	}
-
 	testCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -2763,10 +2760,6 @@ func (s *FunctionalClustersTestSuite) TestLocalNamespaceMigration() {
 }
 
 func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
-	if !tests.UsingSQLAdvancedVisibility() {
-		s.T().Skip("Test requires advanced visibility")
-	}
-
 	testCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -2893,10 +2886,6 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
 }
 
 func (s *FunctionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
-	if !tests.UsingSQLAdvancedVisibility() {
-		s.T().Skip("Test requires advanced visibility")
-	}
-
 	testCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 

--- a/tests/xdc/user_data_replication_test.go
+++ b/tests/xdc/user_data_replication_test.go
@@ -42,6 +42,8 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
@@ -55,7 +57,6 @@ import (
 	"go.temporal.io/server/service/worker/migration"
 	"go.temporal.io/server/service/worker/scanner/build_ids"
 	"go.temporal.io/server/tests"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type (
@@ -175,10 +176,6 @@ func (s *UserDataReplicationTestSuite) TestUserDataIsReplicatedFromPassiveToActi
 }
 
 func (s *UserDataReplicationTestSuite) TestUserDataEntriesAreReplicatedOnDemand() {
-	if !tests.UsingSQLAdvancedVisibility() {
-		s.T().Skip("Test requires advanced visibility")
-	}
-
 	ctx := tests.NewContext()
 	namespace := s.T().Name() + "-" + common.GenerateRandomString(5)
 	activeFrontendClient := s.cluster1.GetFrontendClient()


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Removed some skips in xdc functional tests that were checking `UsingSQLAdvancedVisibility()`

We are always using advanced visibility now, so this flag is just for checking whether visibility persistence is SQL or ES, not for checking whether advanced visibility is being used at all.

XDC functional tests are only run using cass+es persistence, so these tests were never getting exercised.