### PR TITLE
Fix reset after timeout for workflow run timeout

### DIFF
--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -511,7 +511,7 @@ func GetMetricsHandlerFromContext(
 ) metrics.Handler {
 	handler, ok := ctx.Value(metricsCtxKey).(metrics.Handler)
 	if !ok {
-		logger.Error("unable to get metrics scope")
+		logger.Info("unable to get metrics scope")
 		return metrics.NoopMetricsHandler
 	}
 	return handler

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -511,7 +511,7 @@ func GetMetricsHandlerFromContext(
 ) metrics.Handler {
 	handler, ok := ctx.Value(metricsCtxKey).(metrics.Handler)
 	if !ok {
-		logger.Info("unable to get metrics scope")
+		logger.Error("unable to get metrics scope")
 		return metrics.NoopMetricsHandler
 	}
 	return handler

--- a/service/history/ndc/resetter.go
+++ b/service/history/ndc/resetter.go
@@ -153,6 +153,10 @@ func (r *resetterImpl) resetWorkflow(
 	}
 	rebuildMutableState.AddHistorySize(rebuiltHistorySize)
 
+	if err := rebuildMutableState.RefreshExpirationTimeoutTask(ctx); err != nil {
+		return nil, err
+	}
+
 	r.newContext.Clear()
 	return rebuildMutableState, nil
 }

--- a/service/history/ndc/resetter_test.go
+++ b/service/history/ndc/resetter_test.go
@@ -198,6 +198,8 @@ func (s *resetterSuite) TestResetWorkflow_NoError() {
 		NewRunID:        s.newRunID,
 	}).Return(&persistence.ForkHistoryBranchResponse{NewBranchToken: newBranchToken}, nil)
 
+	s.mockRebuiltMutableState.EXPECT().RefreshExpirationTimeoutTask(gomock.Any()).Return(nil)
+
 	rebuiltMutableState, err := s.workflowResetter.resetWorkflow(
 		ctx,
 		now,

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -569,6 +569,10 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowRunTimeoutTask(
 		return err
 	}
 
+	if !t.isValidWorkflowRunTimeoutTask(mutableState, task) {
+		return nil
+	}
+
 	timeoutFailure := failure.NewTimeoutFailure("workflow timeout", enumspb.TIMEOUT_TYPE_START_TO_CLOSE)
 	backoffInterval := backoff.NoBackoff
 	retryState := enumspb.RETRY_STATE_TIMEOUT
@@ -699,7 +703,7 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowExecutionTimeoutTask(
 		return nil
 	}
 
-	if !t.isValidExecutionTimeoutTask(mutableState, task) {
+	if !t.isValidWorkflowExecutionTimeoutTask(mutableState, task) {
 		return nil
 	}
 

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -569,7 +569,7 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowRunTimeoutTask(
 		return err
 	}
 
-	if !t.isValidWorkflowRunTimeoutTask(mutableState, task) {
+	if !t.isValidWorkflowRunTimeoutTask(mutableState) {
 		return nil
 	}
 

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -1459,7 +1459,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowRunTimeout_Fire() {
 	workflowType := "some random workflow type"
 	taskQueueName := "some random task queue"
 
-	expirationTime := time.Duration(10 * time.Second)
+	expirationTime := 10 * time.Second
 
 	mutableState := workflow.TestGlobalMutableState(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetWorkflowId(), execution.GetRunId())
 	_, err := mutableState.AddWorkflowExecutionStartedEvent(

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -26,7 +26,6 @@ package history
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -1517,9 +1516,6 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowRunTimeout_Retry() {
 
 	executionRunTimeout := time.Duration(10 * time.Second)
 	workflowRunTimeout := time.Duration(200 * time.Second)
-	// QQQQQQQQ
-	workflowRunExpirationTime := timestamppb.New(s.now.Add(executionRunTimeout))
-	println(fmt.Sprintf("workflowRunExpirationTime : %v", workflowRunExpirationTime.AsTime()))
 
 	mutableState := workflow.TestGlobalMutableState(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetWorkflowId(), execution.GetRunId())
 	_, err := mutableState.AddWorkflowExecutionStartedEvent(

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -442,11 +442,6 @@ func (t *timerQueueStandbyTaskExecutor) executeWorkflowRunTimeoutTask(
 			return nil, nil
 		}
 
-		if !mutableState.IsWorkflowExecutionRunning() {
-			// workflow already finished, no need to process the timer
-			return nil, nil
-		}
-
 		startVersion, err := mutableState.GetStartVersion()
 		if err != nil {
 			return nil, err

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -436,7 +436,12 @@ func (t *timerQueueStandbyTaskExecutor) executeWorkflowRunTimeoutTask(
 	ctx context.Context,
 	timerTask *tasks.WorkflowRunTimeoutTask,
 ) error {
+
 	actionFn := func(_ context.Context, wfContext workflow.Context, mutableState workflow.MutableState) (interface{}, error) {
+		if !t.isValidWorkflowRunTimeoutTask(mutableState, timerTask) {
+			return nil, nil
+		}
+
 		if !mutableState.IsWorkflowExecutionRunning() {
 			// workflow already finished, no need to process the timer
 			return nil, nil
@@ -478,7 +483,7 @@ func (t *timerQueueStandbyTaskExecutor) executeWorkflowExecutionTimeoutTask(
 		wfContext workflow.Context,
 		mutableState workflow.MutableState,
 	) (interface{}, error) {
-		if !t.isValidExecutionTimeoutTask(mutableState, timerTask) {
+		if !t.isValidWorkflowExecutionTimeoutTask(mutableState, timerTask) {
 			return nil, nil
 		}
 

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -438,7 +438,7 @@ func (t *timerQueueStandbyTaskExecutor) executeWorkflowRunTimeoutTask(
 ) error {
 
 	actionFn := func(_ context.Context, wfContext workflow.Context, mutableState workflow.MutableState) (interface{}, error) {
-		if !t.isValidWorkflowRunTimeoutTask(mutableState, timerTask) {
+		if !t.isValidWorkflowRunTimeoutTask(mutableState) {
 			return nil, nil
 		}
 

--- a/service/history/timer_queue_task_executor_base.go
+++ b/service/history/timer_queue_task_executor_base.go
@@ -186,8 +186,10 @@ func (t *timerQueueTaskExecutorBase) isValidExpirationTime(
 	}
 
 	now := t.shardContext.GetTimeSource().Now()
-	expired := queues.IsTimeExpired(now, expirationTime.AsTime())
-
+	taskTriggerAt := expirationTime.AsTime()
+	expired := queues.IsTimeExpired(now, taskTriggerAt)
+	println(fmt.Sprintf("expiration time: %v", taskTriggerAt))
+	println(fmt.Sprintf("now: %v", now))
 	return expired
 
 }
@@ -200,7 +202,7 @@ func (t *timerQueueTaskExecutorBase) isValidWorkflowRunTimeoutTask(
 
 	// Check if workflow execution timeout is not expired
 	// This can happen if the workflow is reset but old timer task is still fired.
-	return t.isValidExpirationTime(mutableState, executionInfo.WorkflowExecutionExpirationTime)
+	return t.isValidExpirationTime(mutableState, executionInfo.WorkflowRunExpirationTime)
 }
 
 func (t *timerQueueTaskExecutorBase) isValidWorkflowExecutionTimeoutTask(

--- a/service/history/timer_queue_task_executor_base.go
+++ b/service/history/timer_queue_task_executor_base.go
@@ -178,17 +178,15 @@ func (t *timerQueueTaskExecutorBase) isValidExpirationTime(
 	mutableState workflow.MutableState,
 	expirationTime *timestamppb.Timestamp,
 ) bool {
-	if expirationTime == nil {
-		return false
-	}
 	if !mutableState.IsWorkflowExecutionRunning() {
 		return false
 	}
 
 	now := t.shardContext.GetTimeSource().Now()
-	taskTriggerAt := expirationTime.AsTime()
-	expired := queues.IsTimeExpired(now, taskTriggerAt)
-	println(fmt.Sprintf("expiration time: %v", taskTriggerAt))
+	taskShouldTriggerAt := expirationTime.AsTime()
+	expired := queues.IsTimeExpired(now, taskShouldTriggerAt)
+	// QQQQQQQQQQ
+	println(fmt.Sprintf("expiration time: %v", taskShouldTriggerAt))
 	println(fmt.Sprintf("now: %v", now))
 	return expired
 

--- a/service/history/timer_queue_task_executor_base.go
+++ b/service/history/timer_queue_task_executor_base.go
@@ -185,9 +185,6 @@ func (t *timerQueueTaskExecutorBase) isValidExpirationTime(
 	now := t.shardContext.GetTimeSource().Now()
 	taskShouldTriggerAt := expirationTime.AsTime()
 	expired := queues.IsTimeExpired(now, taskShouldTriggerAt)
-	// QQQQQQQQQQ
-	println(fmt.Sprintf("expiration time: %v", taskShouldTriggerAt))
-	println(fmt.Sprintf("now: %v", now))
 	return expired
 
 }

--- a/service/history/timer_queue_task_executor_base.go
+++ b/service/history/timer_queue_task_executor_base.go
@@ -191,7 +191,6 @@ func (t *timerQueueTaskExecutorBase) isValidExpirationTime(
 
 func (t *timerQueueTaskExecutorBase) isValidWorkflowRunTimeoutTask(
 	mutableState workflow.MutableState,
-	task *tasks.WorkflowRunTimeoutTask,
 ) bool {
 	executionInfo := mutableState.GetExecutionInfo()
 

--- a/service/history/timer_queue_task_executor_base_test.go
+++ b/service/history/timer_queue_task_executor_base_test.go
@@ -249,7 +249,7 @@ func (s *timerQueueTaskExecutorBaseSuite) TestIsValidExecutionTimeoutTask() {
 			}).AnyTimes()
 			mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(tc.workflowRunning).AnyTimes()
 
-			isValid := s.timerQueueTaskExecutorBase.isValidExecutionTimeoutTask(mockMutableState, timerTask)
+			isValid := s.timerQueueTaskExecutorBase.isValidWorkflowExecutionTimeoutTask(mockMutableState, timerTask)
 			s.Equal(tc.isValid, isValid)
 		})
 	}
@@ -292,7 +292,7 @@ func (s *timerQueueTaskExecutorBaseSuite) TestIsValidExecutionTimeouts() {
 			FirstExecutionRunId:             timerTask.FirstRunID,
 			WorkflowExecutionExpirationTime: timestamppb.New(tc.expirationTime),
 		})
-		isValid := s.timerQueueTaskExecutorBase.isValidExecutionTimeoutTask(mockMutableState, timerTask)
+		isValid := s.timerQueueTaskExecutorBase.isValidWorkflowExecutionTimeoutTask(mockMutableState, timerTask)
 		s.Equal(tc.isValid, isValid)
 	}
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -6233,7 +6233,7 @@ func (ms *MutableStateImpl) RefreshExpirationTimeoutTask(ctx context.Context) er
 	}
 	wrTimeout := timestamp.DurationValue(executionInfo.WorkflowRunTimeout)
 	if wrTimeout != 0 {
-		executionInfo.WorkflowRunExpirationTime = timestamp.TimeNowPtrUtcAddDuration(weTimeout)
+		executionInfo.WorkflowRunExpirationTime = timestamp.TimeNowPtrUtcAddDuration(wrTimeout)
 
 		if weTimeout > 0 && executionInfo.WorkflowRunExpirationTime.AsTime().After(executionInfo.WorkflowExecutionExpirationTime.AsTime()) {
 			executionInfo.WorkflowRunExpirationTime = executionInfo.WorkflowExecutionExpirationTime

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -6231,6 +6231,14 @@ func (ms *MutableStateImpl) RefreshExpirationTimeoutTask(ctx context.Context) er
 	if weTimeout > 0 {
 		executionInfo.WorkflowExecutionExpirationTime = timestamp.TimeNowPtrUtcAddDuration(weTimeout)
 	}
+	wrTimeout := timestamp.DurationValue(executionInfo.WorkflowRunTimeout)
+	if wrTimeout != 0 {
+		executionInfo.WorkflowRunExpirationTime = timestamp.TimeNowPtrUtcAddDuration(weTimeout)
+
+		if weTimeout > 0 && executionInfo.WorkflowRunExpirationTime.AsTime().After(executionInfo.WorkflowExecutionExpirationTime.AsTime()) {
+			executionInfo.WorkflowRunExpirationTime = executionInfo.WorkflowExecutionExpirationTime
+		}
+	}
 
 	return RefreshTasksForWorkflowStart(ctx, ms, ms.taskGenerator, EmptyVersionedTransition)
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
* Add validation checks for workflow run timeout. 
* Add tests that will trigger workflow run timoeout to reprooduce "timeout after reset" problem

## Why?
<!-- Tell your future self why have you made these changes -->
* Previous fix fixed only "execution timeout", 
* test didn't capture the case when workflow immediately ends after reset by run timeout (as opposite to execution timeout)

## How did you test it?
Add a functional test that verifies that negative scenario is triggered without a fix (workflow times out either by execution timeout or by run timeout without a fix)

## Is hotfix candidate?
No (?)
