### PR TITLE
Add search attributes param to sqlite.NewNamespaceConfig

### DIFF
--- a/schema/sqlite/setup.go
+++ b/schema/sqlite/setup.go
@@ -44,6 +44,7 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/resolver"
+	"go.temporal.io/server/common/searchattribute"
 )
 
 var (
@@ -133,7 +134,37 @@ func CreateNamespaces(cfg *config.SQL, namespaces ...*NamespaceConfig) error {
 // the namespace via the CreateNamespaces function.
 //
 // Note: this function may receive breaking changes or be removed in the future.
-func NewNamespaceConfig(activeClusterName, namespace string, global bool) *NamespaceConfig {
+func NewNamespaceConfig(
+	activeClusterName string,
+	namespace string,
+	global bool,
+	customSearchAttributes map[string]enumspb.IndexedValueType,
+) (*NamespaceConfig, error) {
+	dbCustomSearchAttributes := searchattribute.GetSqlDbIndexSearchAttributes().CustomSearchAttributes
+	fieldToAliasMap := map[string]string{}
+	for saName, saType := range customSearchAttributes {
+		var targetFieldName string
+		var cntUsed int
+		for fieldName, fieldType := range dbCustomSearchAttributes {
+			if fieldType != saType {
+				continue
+			}
+			if _, ok := fieldToAliasMap[fieldName]; !ok {
+				targetFieldName = fieldName
+				break
+			}
+			cntUsed++
+		}
+		if targetFieldName == "" {
+			return nil, fmt.Errorf(
+				"cannot have more than %d search attributes of type %s",
+				cntUsed,
+				saType,
+			)
+		}
+		fieldToAliasMap[targetFieldName] = saName
+	}
+
 	detail := persistencespb.NamespaceDetail{
 		Info: &persistencespb.NamespaceInfo{
 			Id:    primitives.NewUUID().String(),
@@ -141,9 +172,10 @@ func NewNamespaceConfig(activeClusterName, namespace string, global bool) *Names
 			Name:  namespace,
 		},
 		Config: &persistencespb.NamespaceConfig{
-			Retention:               timestamp.DurationFromHours(24),
-			HistoryArchivalState:    enumspb.ARCHIVAL_STATE_DISABLED,
-			VisibilityArchivalState: enumspb.ARCHIVAL_STATE_DISABLED,
+			Retention:                    timestamp.DurationFromHours(24),
+			HistoryArchivalState:         enumspb.ARCHIVAL_STATE_DISABLED,
+			VisibilityArchivalState:      enumspb.ARCHIVAL_STATE_DISABLED,
+			CustomSearchAttributeAliases: fieldToAliasMap,
 		},
 		ReplicationConfig: &persistencespb.NamespaceReplicationConfig{
 			ActiveClusterName: activeClusterName,
@@ -155,7 +187,7 @@ func NewNamespaceConfig(activeClusterName, namespace string, global bool) *Names
 	return &NamespaceConfig{
 		Detail:   &detail,
 		IsGlobal: global,
-	}
+	}, nil
 }
 
 func createNamespaceIfNotExists(db sqlplugin.DB, namespace *NamespaceConfig) error {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add search attributes param to sqlite.NewNamespaceConfig.

## Why?
<!-- Tell your future self why have you made these changes -->
Ability to start Temporal from the CLI with custom search attributes.
Address https://github.com/temporalio/temporal/issues/6195

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Modified the CLI to not call `registerSearchAttributes`, pass it directly to `NewNamespaceConfig`.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
