### PR TITLE
Workflow Update: return outcome if available, even if accepted was requested

### DIFF
--- a/common/testing/testvars/any.go
+++ b/common/testing/testvars/any.go
@@ -25,6 +25,7 @@
 package testvars
 
 import (
+	"github.com/pborman/uuid"
 	commonpb "go.temporal.io/api/common/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/server/common/payload"
@@ -73,4 +74,8 @@ func (a Any) ApplicationFailure() *failurepb.Failure {
 			NonRetryable: false,
 		}},
 	}
+}
+
+func (a Any) RunID() string {
+	return uuid.New()
 }

--- a/common/testing/testvars/test_vars.go
+++ b/common/testing/testvars/test_vars.go
@@ -157,7 +157,7 @@ func (tv *TestVars) WithWorkflowID(workflowID string, key ...string) *TestVars {
 }
 
 func (tv *TestVars) RunID(key ...string) string {
-	return tv.getOrCreate("run_id", key, uuid.New()).(string)
+	return tv.getOrCreate("run_id", key, "").(string)
 }
 
 func (tv *TestVars) WithRunID(runID string, key ...string) *TestVars {

--- a/service/history/api/respondworkflowtaskcompleted/api_test.go
+++ b/service/history/api/respondworkflowtaskcompleted/api_test.go
@@ -182,6 +182,7 @@ func (s *WorkflowTaskCompletedHandlerSuite) TestUpdateWorkflow() {
 
 	s.Run("Accept Complete", func() {
 		tv := testvars.New(s.T())
+		tv = tv.WithRunID(tv.Any().RunID())
 		s.mockNamespaceCache.EXPECT().GetNamespaceByID(tv.NamespaceID()).Return(tv.Namespace(), nil).AnyTimes()
 		wfContext := s.createStartedWorkflow(tv)
 		writtenHistoryCh := createWrittenHistoryCh(1)
@@ -215,6 +216,7 @@ func (s *WorkflowTaskCompletedHandlerSuite) TestUpdateWorkflow() {
 
 	s.Run("Reject", func() {
 		tv := testvars.New(s.T())
+		tv = tv.WithRunID(tv.Any().RunID())
 		s.mockNamespaceCache.EXPECT().GetNamespaceByID(tv.NamespaceID()).Return(tv.Namespace(), nil).AnyTimes()
 		wfContext := s.createStartedWorkflow(tv)
 
@@ -239,6 +241,7 @@ func (s *WorkflowTaskCompletedHandlerSuite) TestUpdateWorkflow() {
 
 	s.Run("Write failed on normal task queue", func() {
 		tv := testvars.New(s.T())
+		tv = tv.WithRunID(tv.Any().RunID())
 		s.mockNamespaceCache.EXPECT().GetNamespaceByID(tv.NamespaceID()).Return(tv.Namespace(), nil).AnyTimes()
 		wfContext := s.createStartedWorkflow(tv)
 
@@ -264,6 +267,7 @@ func (s *WorkflowTaskCompletedHandlerSuite) TestUpdateWorkflow() {
 
 	s.Run("Write failed on sticky task queue", func() {
 		tv := testvars.New(s.T())
+		tv = tv.WithRunID(tv.Any().RunID())
 		s.mockNamespaceCache.EXPECT().GetNamespaceByID(tv.NamespaceID()).Return(tv.Namespace(), nil).AnyTimes()
 		wfContext := s.createStartedWorkflow(tv)
 
@@ -296,6 +300,7 @@ func (s *WorkflowTaskCompletedHandlerSuite) TestUpdateWorkflow() {
 
 	s.Run("GetHistory failed", func() {
 		tv := testvars.New(s.T())
+		tv = tv.WithRunID(tv.Any().RunID())
 		s.mockNamespaceCache.EXPECT().GetNamespaceByID(tv.NamespaceID()).Return(tv.Namespace(), nil).AnyTimes()
 		wfContext := s.createStartedWorkflow(tv)
 		writtenHistoryCh := createWrittenHistoryCh(1)

--- a/service/history/workflow/update/state.go
+++ b/service/history/workflow/update/state.go
@@ -39,6 +39,7 @@ const (
 	stateProvisionallyCompleted
 	stateCompleted
 	stateAborted
+	stateProvisionallyCompletedAfterAccepted
 )
 
 func (s state) String() string {
@@ -61,6 +62,8 @@ func (s state) String() string {
 		return "Completed"
 	case stateAborted:
 		return "Aborted"
+	case stateProvisionallyCompletedAfterAccepted:
+		return "ProvisionallyCompletedAfterAccepted"
 	}
 	return "unrecognized state"
 }

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -498,11 +498,11 @@ func (u *Update) onAcceptanceMsg(
 		// If the Update is accepted *and* completed in the same WFT, then its state has transitioned
 		// from ProvisionallyAccepted to ProvisionallyCompleted in onResponseMsg by the
 		// time we get here.
-		// 
+		//
 		// Now, to prevent a race condition in WaitLifecycleStage, the accepted future
 		// cannot be set here right now, as it must be set *after* the outcome future.
-		// 
-		// So instead, the state is set to ProvisionallyCompletedAfterAccepted here,  
+		//
+		// So instead, the state is set to ProvisionallyCompletedAfterAccepted here,
 		// and onResponseMsg's OnAfterCommit callback will set the futures in the correct order.
 		if u.state == stateProvisionallyCompleted {
 			u.state = stateProvisionallyCompletedAfterAccepted
@@ -598,9 +598,9 @@ func (u *Update) onResponseMsg(
 			// If the Update is accepted *and* completed in the same WFT, then its state is ProvisionallyCompletedAfterAccepted here, set by onAcceptance's OnAfterCommit.
 			//
 			// To prevent a race condition in WaitLifecycleStage, the accepted future
-		        // has not been set by OnAcceptance earlier, as it must be set *after* the outcome future.
-		        // Now is the time to set it.
-		        // 
+			// has not been set by OnAcceptance earlier, as it must be set *after* the outcome future.
+			// Now is the time to set it.
+			//
 			// Note that the Accepted state is skipped, and it transitions straight to Completed.
 			u.accepted.(*future.FutureImpl[*failurepb.Failure]).Set(nil, nil)
 		}

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -263,13 +263,13 @@ func (u *Update) WaitLifecycleStage(
 func (u *Update) abort(reason AbortReason) {
 	u.instrumentation.countAborted()
 
-	const preAcceptedStates = stateSet(stateCreated | stateAdmitted | stateSent)
-	if u.state.Matches(preAcceptedStates) {
+	const preAcceptedStates = stateSet(stateCreated | stateProvisionallyAdmitted | stateAdmitted | stateSent | stateProvisionallyAccepted)
+	if u.state.Matches(preAcceptedStates | stateSet(stateProvisionallyCompletedAfterAccepted)) {
 		u.accepted.(*future.FutureImpl[*failurepb.Failure]).Set(nil, reason.Error())
 		u.outcome.(*future.FutureImpl[*updatepb.Outcome]).Set(nil, reason.Error())
 	}
 
-	const preCompletedStates = stateSet(stateAccepted)
+	const preCompletedStates = stateSet(stateAccepted | stateProvisionallyCompleted)
 	if u.state.Matches(preCompletedStates) {
 		u.outcome.(*future.FutureImpl[*updatepb.Outcome]).Set(nil, reason.Error())
 	}

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -62,13 +62,13 @@ var (
 	immediateCtx, _  = context.WithTimeout(context.Background(), immedateTimeout)
 )
 
-type stateTest struct {
-	title        string
-	apply        func()
-	failOnEffect bool
-}
-
 func TestUpdateState(t *testing.T) {
+	type stateTest struct {
+		title        string
+		apply        func()
+		failOnEffect bool
+	}
+
 	var (
 		tv            = testvars.New(t)
 		completed     bool
@@ -505,8 +505,28 @@ func TestUpdateState(t *testing.T) {
 				// it is possible for the acceptance message and the completion message to
 				// be part of the same message batch, and thus they will be delivered without
 				// an intermediate call to apply pending effects
-				title: "transition to stateCompleted via stateAccepted in one step",
+				title: "transition to stateCompleted via stateAccepted in one WFT",
 				apply: func() {
+					// start waiters
+					accptCh := make(chan any, 1)
+					go func() {
+						status, err := upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, 100*time.Millisecond)
+						if err != nil {
+							accptCh <- err
+							return
+						}
+						accptCh <- status.Outcome
+					}()
+					complCh := make(chan any, 1)
+					go func() {
+						status, err := upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, 100*time.Millisecond)
+						if err != nil {
+							complCh <- err
+							return
+						}
+						complCh <- status.Outcome
+					}()
+
 					err := accept(t, store, upd)
 					require.NoError(t, err)
 
@@ -522,6 +542,12 @@ func TestUpdateState(t *testing.T) {
 					// apply pending effect
 					effects.Apply(context.Background())
 					require.True(t, completed, "update state should now be completed")
+
+					// ensure both waiter received completed response
+					accptWaiterRes := <-accptCh
+					complWaiterRes := <-complCh
+					require.EqualExportedValues(t, successOutcome, accptWaiterRes)
+					require.EqualExportedValues(t, successOutcome, complWaiterRes)
 
 					// new waiter receives same response
 					assertCompleted(t, upd, successOutcome)

--- a/tests/update_workflow.go
+++ b/tests/update_workflow.go
@@ -5009,7 +5009,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_WaitAccepted_GotCompleted() {
 	updateResult := <-updateResultCh
 	// but Update was accepted and completed on the same WFT, and outcome was returned.
 	s.Equal(enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, updateResult.GetStage())
-	s.EqualValues("success-result-of-"+tv.UpdateID("1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
+	s.EqualValues("success-result-of-"+tv.UpdateID("1"), decodeString(s.T(), updateResult.GetOutcome().GetSuccess()))
 
 	s.EqualHistoryEvents(`
 	1 WorkflowExecutionStarted

--- a/tests/update_workflow.go
+++ b/tests/update_workflow.go
@@ -4756,15 +4756,11 @@ func (s *FunctionalSuite) TestUpdateWorkflow_LastWorkflowTask_HasUpdateMessage()
 		T:      s.T(),
 	}
 
-	s.sendUpdateNoErrorWaitPolicyAccepted(tv, tv.UpdateID())
-	pollResponse := make(chan error)
-	go func() {
-		// Blocks until the update request causes a WFT to be dispatched; then sends the update complete message
-		// required for the update request to return.
-		_, err := poller.PollAndProcessWorkflowTask()
-		pollResponse <- err
-	}()
-	s.NoError(<-pollResponse)
+	updateResultCh := s.sendUpdateNoErrorWaitPolicyAccepted(tv, "1")
+	_, err := poller.PollAndProcessWorkflowTask(WithoutRetries)
+	s.NoError(err)
+	updateResult := <-updateResultCh
+	s.Equal(enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, updateResult.GetStage())
 
 	s.EqualHistoryEvents(`
 	1 WorkflowExecutionStarted
@@ -4985,4 +4981,42 @@ func (s *FunctionalSuite) TestUpdateWorkflow_UpdatesAreSentToWorkerInOrderOfAdmi
 
 	history := s.getHistory(s.namespace, tv.WorkflowExecution())
 	s.EqualHistoryEvents(expectedHistory, history)
+}
+
+func (s *FunctionalSuite) TestUpdateWorkflow_WaitAccepted_GotCompleted() {
+	tv := testvars.New(s.T())
+	tv = s.startWorkflow(tv)
+
+	poller := &TaskPoller{
+		Client:    s.client,
+		Namespace: s.namespace,
+		TaskQueue: tv.TaskQueue(),
+		Identity:  tv.WorkerIdentity(),
+		WorkflowTaskHandler: func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
+			return s.UpdateAcceptCompleteCommands(tv, "1"), nil
+		},
+		MessageHandler: func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*protocolpb.Message, error) {
+			return s.UpdateAcceptCompleteMessages(tv, task.Messages[0], "1"), nil
+		},
+		Logger: s.Logger,
+		T:      s.T(),
+	}
+
+	// Send Update with intent to wait for Accepted stage only,
+	updateResultCh := s.sendUpdateNoErrorWaitPolicyAccepted(tv, "1")
+	_, err := poller.PollAndProcessWorkflowTask(WithoutRetries)
+	s.NoError(err)
+	updateResult := <-updateResultCh
+	// but Update was accepted and completed on the same WFT, and outcome was returned.
+	s.Equal(enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, updateResult.GetStage())
+	s.EqualValues("success-result-of-"+tv.UpdateID("1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
+
+	s.EqualHistoryEvents(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowExecutionUpdateAccepted
+	6 WorkflowExecutionUpdateCompleted
+	`, s.getHistory(s.namespace, tv.WorkflowExecution()))
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Return Update outcome even if `ACCEPTED` stage was requested but Update was accepted and completed on the same WFT.

## Why?
<!-- Tell your future self why have you made these changes -->
To provide better DX and return the most advanced reached stage.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests + added functional test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
Server doc needs to be updated.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.