### PR TITLE
Invalid Shard Owner Lost error in streaming

### DIFF
--- a/client/history/client.go
+++ b/client/history/client.go
@@ -254,14 +254,22 @@ func (c *clientImpl) StreamWorkflowReplicationMessages(
 	if err != nil {
 		return nil, err
 	}
-	client, err := c.redirector.clientForShardID(targetClusterShardID.ShardID)
-	if err != nil {
+
+	var streamClient historyservice.HistoryService_StreamWorkflowReplicationMessagesClient
+	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
+		var err error
+		ctx, cancel := c.createContext(ctx)
+		defer cancel()
+		metadata.NewOutgoingContext(ctx, ctxMetadata)
+		streamClient, err = client.StreamWorkflowReplicationMessages(
+			metadata.NewOutgoingContext(ctx, ctxMetadata),
+			opts...)
+		return err
+	}
+	if err := c.executeWithRedirect(ctx, targetClusterShardID.ShardID, op); err != nil {
 		return nil, err
 	}
-	return client.StreamWorkflowReplicationMessages(
-		metadata.NewOutgoingContext(ctx, ctxMetadata),
-		opts...,
-	)
+	return streamClient, nil
 }
 
 // GetDLQTasks doesn't need redirects or routing because DLQ tasks are not sharded, so it just picks any available host

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -258,9 +258,6 @@ func (c *clientImpl) StreamWorkflowReplicationMessages(
 	var streamClient historyservice.HistoryService_StreamWorkflowReplicationMessagesClient
 	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
 		var err error
-		ctx, cancel := c.createContext(ctx)
-		defer cancel()
-		metadata.NewOutgoingContext(ctx, ctxMetadata)
 		streamClient, err = client.StreamWorkflowReplicationMessages(
 			metadata.NewOutgoingContext(ctx, ctxMetadata),
 			opts...)


### PR DESCRIPTION
## What changed?
Invalid Shard Owner Lost error in streaming

## Why?
When SOL error returned, we should invalid the history client in replication stream.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
