### PR TITLE
Update namespace replication queue retry policy

### DIFF
--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	retryPolicy               = common.CreatePersistenceClientRetryPolicy()
-	namespaceQueueRetryPolicy = backoff.NewConstantDelayRetryPolicy(time.Millisecond * 100).WithMaximumAttempts(5)
+	namespaceQueueRetryPolicy = backoff.NewConstantDelayRetryPolicy(time.Millisecond * 50).WithMaximumAttempts(10)
 )
 
 type (

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -25,6 +25,8 @@
 package client
 
 import (
+	"time"
+
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
@@ -34,7 +36,6 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/quotas"
-	"time"
 )
 
 var (


### PR DESCRIPTION
## What changed?
Update namespace replication queue retry policy

## Why?
The condition failure is due to concurrent write to namespace replication queue and we should retry on this one.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
