### PR TITLE
Deprecation proposal: Block build-id as a search attribute

### DIFF
--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -27,6 +27,7 @@ package searchattribute
 import (
 	"errors"
 	"fmt"
+	"go.temporal.io/server/common/log"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
@@ -52,6 +53,7 @@ type (
 		// suppressErrorSetSystemSearchAttribute suppresses errors when the user
 		// attempts to set values in system search attributes.
 		suppressErrorSetSystemSearchAttribute dynamicconfig.BoolPropertyFnWithNamespaceFilter
+		logger                                log.Logger
 	}
 )
 
@@ -65,6 +67,7 @@ func NewValidator(
 	visibilityManager manager.VisibilityManager,
 	allowList dynamicconfig.BoolPropertyFnWithNamespaceFilter,
 	suppressErrorSetSystemSearchAttribute dynamicconfig.BoolPropertyFnWithNamespaceFilter,
+	logger log.Logger,
 ) *Validator {
 	return &Validator{
 		searchAttributesProvider:              searchAttributesProvider,
@@ -75,6 +78,7 @@ func NewValidator(
 		visibilityManager:                     visibilityManager,
 		allowList:                             allowList,
 		suppressErrorSetSystemSearchAttribute: suppressErrorSetSystemSearchAttribute,
+		logger:                                logger,
 	}
 }
 
@@ -119,6 +123,7 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 			)
 		}
 		if saFieldName == BuildIds {
+			v.logger.Warn("Setting BuildIDs as a SearchAttribute is invalid and should be avoided.")
 			return serviceerror.NewInvalidArgument(
 				fmt.Sprintf("%s attribute can't be set in SearchAttributes", saFieldName),
 			)

--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -118,7 +118,11 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 				fmt.Sprintf("%s attribute can't be set in SearchAttributes", saFieldName),
 			)
 		}
-
+		if saFieldName == BuildIds {
+			return serviceerror.NewInvalidArgument(
+				fmt.Sprintf("%s buildID attribute can't be set in SearchAttributes", saFieldName),
+			)
+		}
 		saType, err := saTypeMap.getType(saFieldName, customCategory|predefinedCategory)
 		if err != nil {
 			if errors.Is(err, ErrInvalidName) {

--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -27,6 +27,7 @@ package searchattribute
 import (
 	"errors"
 	"fmt"
+
 	"go.temporal.io/server/common/log"
 
 	commonpb "go.temporal.io/api/common/v1"

--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -120,7 +120,7 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 		}
 		if saFieldName == BuildIds {
 			return serviceerror.NewInvalidArgument(
-				fmt.Sprintf("%s buildID attribute can't be set in SearchAttributes", saFieldName),
+				fmt.Sprintf("%s attribute can't be set in SearchAttributes", saFieldName),
 			)
 		}
 		saType, err := saTypeMap.getType(saFieldName, customCategory|predefinedCategory)

--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -124,9 +124,6 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 		}
 		if saFieldName == BuildIds {
 			v.logger.Warn("Setting BuildIDs as a SearchAttribute is invalid and should be avoided.")
-			return serviceerror.NewInvalidArgument(
-				fmt.Sprintf("%s attribute can't be set in SearchAttributes", saFieldName),
-			)
 		}
 		saType, err := saTypeMap.getType(saFieldName, customCategory|predefinedCategory)
 		if err != nil {
@@ -224,4 +221,8 @@ func (v *Validator) getAlias(saFieldName string, namespaceName string) (string, 
 		}
 	}
 	return saFieldName, nil
+}
+
+func (v *Validator) GetLogger() log.Logger {
+	return v.logger
 }

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/persistence/visibility/manager"

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -134,6 +134,14 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 	err = saValidator.Validate(attr, namespace)
 	s.Error(err)
 	s.Equal("StartTime attribute can't be set in SearchAttributes", err.Error())
+
+	fields = map[string]*commonpb.Payload{
+		"BuildIds": payload.EncodeString("1"),
+	}
+	attr.IndexedFields = fields
+	err = saValidator.Validate(attr, namespace)
+	s.Error(err)
+	s.Equal("BuildIds attribute can't be set in SearchAttributes", err.Error())
 }
 
 func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_SuppressError() {

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -138,13 +138,17 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 	s.Error(err)
 	s.Equal("StartTime attribute can't be set in SearchAttributes", err.Error())
 
-	mockLogger := saValidator.logger.(*log.MockLogger)
+	mockLogger, ok := saValidator.logger.(*log.MockLogger)
+	s.True(ok)
 	mockLogger.EXPECT().Warn("Setting BuildIDs as a SearchAttribute is invalid and should be avoided.").Times(1)
-	fields = map[string]*commonpb.Payload{
-		"BuildIds": payload.EncodeString("1"),
+
+	saPayload, err := EncodeValue([]string{"a"}, enumspb.INDEXED_VALUE_TYPE_TEXT)
+	s.NoError(err)
+	attr.IndexedFields = map[string]*commonpb.Payload{
+		"BuildIds": saPayload,
 	}
-	attr.IndexedFields = fields
 	err = saValidator.Validate(attr, namespace)
+	s.NoError(err)
 }
 
 func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_SuppressError() {

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -73,7 +73,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 		s.mockVisibilityManager,
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
-		log.NewTestLogger(),
+		log.NewMockLogger(gomock.NewController(s.T())),
 	)
 
 	namespace := "namespace"
@@ -137,13 +137,13 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 	s.Error(err)
 	s.Equal("StartTime attribute can't be set in SearchAttributes", err.Error())
 
+	mockLogger := saValidator.logger.(*log.MockLogger)
+	mockLogger.EXPECT().Warn("Setting BuildIDs as a SearchAttribute is invalid and should be avoided.").Times(1)
 	fields = map[string]*commonpb.Payload{
 		"BuildIds": payload.EncodeString("1"),
 	}
 	attr.IndexedFields = fields
 	err = saValidator.Validate(attr, namespace)
-	s.Error(err)
-	s.Equal("BuildIds attribute can't be set in SearchAttributes", err.Error())
 }
 
 func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_SuppressError() {
@@ -160,7 +160,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_SuppressEr
 		s.mockVisibilityManager,
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
-		log.NewTestLogger(),
+		log.NewMockLogger(gomock.NewController(s.T())),
 	)
 
 	namespace := "namespace"
@@ -188,7 +188,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 		s.mockVisibilityManager,
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
-		log.NewTestLogger(),
+		log.NewMockLogger(gomock.NewController(s.T())),
 	)
 
 	namespace := "test-namespace"
@@ -253,7 +253,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {
 		s.mockVisibilityManager,
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
-		log.NewTestLogger(),
+		log.NewMockLogger(gomock.NewController(s.T())),
 	)
 
 	namespace := "namespace"
@@ -294,7 +294,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize_Mapper
 		s.mockVisibilityManager,
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
-		log.NewTestLogger(),
+		log.NewMockLogger(gomock.NewController(s.T())),
 	)
 
 	namespace := "test-namespace"

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -25,6 +25,7 @@
 package searchattribute
 
 import (
+	"go.temporal.io/server/common/log"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -72,6 +73,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 		s.mockVisibilityManager,
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		log.NewTestLogger(),
 	)
 
 	namespace := "namespace"
@@ -158,6 +160,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_SuppressEr
 		s.mockVisibilityManager,
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+		log.NewTestLogger(),
 	)
 
 	namespace := "namespace"
@@ -185,6 +188,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 		s.mockVisibilityManager,
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		log.NewTestLogger(),
 	)
 
 	namespace := "test-namespace"
@@ -249,6 +253,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {
 		s.mockVisibilityManager,
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		log.NewTestLogger(),
 	)
 
 	namespace := "namespace"
@@ -289,6 +294,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize_Mapper
 		s.mockVisibilityManager,
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		log.NewTestLogger(),
 	)
 
 	namespace := "test-namespace"

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -25,8 +25,9 @@
 package searchattribute
 
 import (
-	"go.temporal.io/server/common/log"
 	"testing"
+
+	"go.temporal.io/server/common/log"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -145,4 +145,5 @@ var (
 	errWorkerVersioningNotAllowed = serviceerror.NewPermissionDenied("Worker versioning is disabled on this namespace.", "")
 
 	errListHistoryTasksNotAllowed = serviceerror.NewPermissionDenied("ListHistoryTasks feature is disabled on this cluster.", "")
+	errBuildIDAsSearchAttribute   = serviceerror.NewInvalidArgument("BuildIds attribute can't be set in SearchAttributes")
 )

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -212,6 +212,7 @@ func NewWorkflowHandler(
 				config.VisibilityAllowList,
 			),
 			config.SuppressErrorSetSystemSearchAttribute,
+			logger,
 		),
 		archivalMetadata:    archivalMetadata,
 		healthServer:        healthServer,

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -328,6 +328,8 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_NamespaceNotSet
 	}
 	_, err := wh.StartWorkflowExecution(context.Background(), startWorkflowExecutionRequest)
 	s.Error(err)
+	var notFound *serviceerror.NamespaceNotFound
+	s.ErrorAs(err, &notFound)
 }
 
 func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_WorkflowIdNotSet() {

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -298,64 +298,6 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_StartRequestNot
 	s.Equal(errRequestNotSet, err)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_BuildIDSearchAttribute() {
-	namespaceID := namespace.ID(uuid.New())
-
-	s.mockSearchAttributesMapperProvider.EXPECT().GetMapper(gomock.Any()).Return(nil, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil)
-	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(namespaceID, nil).AnyTimes()
-
-	wh := s.getWorkflowHandler(s.newConfig())
-	req := &workflowservice.StartWorkflowExecutionRequest{
-		Namespace:    namespaceID.String(),
-		WorkflowId:   testWorkflowID,
-		WorkflowType: &commonpb.WorkflowType{Name: "WORKFLOW"},
-		TaskQueue:    &taskqueuepb.TaskQueue{Name: "TASK_QUEUE", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-		SearchAttributes: &commonpb.SearchAttributes{
-			IndexedFields: map[string]*commonpb.Payload{
-				"BuildIds": &commonpb.Payload{
-					Metadata: nil,
-					Data:     nil,
-				},
-			},
-		},
-	}
-
-	_, err := wh.StartWorkflowExecution(context.Background(), req)
-	s.Error(err)
-	s.Equal(errBuildIDAsSearchAttribute, err)
-
-}
-
-func (s *workflowHandlerSuite) TestSignalWithStartWorkflowExecution_Failed_BuildIDSearchAttribute() {
-	namespaceID := namespace.ID(uuid.New())
-
-	s.mockSearchAttributesMapperProvider.EXPECT().GetMapper(gomock.Any()).Return(nil, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil)
-	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(namespaceID, nil).AnyTimes()
-
-	wh := s.getWorkflowHandler(s.newConfig())
-	req := &workflowservice.SignalWithStartWorkflowExecutionRequest{
-		Namespace:    namespaceID.String(),
-		WorkflowId:   testWorkflowID,
-		WorkflowType: &commonpb.WorkflowType{Name: "WORKFLOW"},
-		TaskQueue:    &taskqueuepb.TaskQueue{Name: "TASK_QUEUE", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-		SignalName:   "SIGNAL",
-		SearchAttributes: &commonpb.SearchAttributes{
-			IndexedFields: map[string]*commonpb.Payload{
-				"BuildIds": &commonpb.Payload{
-					Metadata: nil,
-					Data:     nil,
-				},
-			},
-		},
-	}
-
-	_, err := wh.SignalWithStartWorkflowExecution(context.Background(), req)
-	s.Error(err)
-	s.Equal(errBuildIDAsSearchAttribute, err)
-}
-
 func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_NamespaceNotSet() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)

--- a/service/history/api/respondworkflowtaskcompleted/command_checker_test.go
+++ b/service/history/api/respondworkflowtaskcompleted/command_checker_test.go
@@ -239,9 +239,10 @@ func (s *commandAttrValidatorSuite) TestValidateUpsertWorkflowSearchAttributes()
 	attributes.SearchAttributes.IndexedFields = map[string]*commonpb.Payload{
 		"BuildIds": saPayload,
 	}
-	mockedLogger := s.validator.searchAttributesValidator.GetLogger().(*log.MockLogger)
+	mockedLogger, ok := s.validator.searchAttributesValidator.GetLogger().(*log.MockLogger)
+	s.True(ok)
 	mockedLogger.EXPECT().Warn("Setting BuildIDs as a SearchAttribute is invalid and should be avoided.")
-	fc, err = s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes)
+	_, err = s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes)
 	s.NoError(err)
 }
 
@@ -286,9 +287,10 @@ func (s *commandAttrValidatorSuite) TestValidateContinueAsNewWorkflowExecutionAt
 		"BuildIds": saPayload,
 	}
 
-	mockedLogger := s.validator.searchAttributesValidator.GetLogger().(*log.MockLogger)
+	mockedLogger, ok := s.validator.searchAttributesValidator.GetLogger().(*log.MockLogger)
+	s.True(ok)
 	mockedLogger.EXPECT().Warn("Setting BuildIDs as a SearchAttribute is invalid and should be avoided.")
-	fc, err = s.validator.validateContinueAsNewWorkflowExecutionAttributes(
+	_, err = s.validator.validateContinueAsNewWorkflowExecutionAttributes(
 		tests.Namespace,
 		attributes,
 		executionInfo,
@@ -329,7 +331,8 @@ func (s *commandAttrValidatorSuite) TestValidateCommandStartChildWorkflowSearchA
 		"BuildIds": saPayload,
 	}
 
-	mockedLogger := s.validator.searchAttributesValidator.GetLogger().(*log.MockLogger)
+	mockedLogger, ok := s.validator.searchAttributesValidator.GetLogger().(*log.MockLogger)
+	s.True(ok)
 	mockedLogger.EXPECT().Warn("Setting BuildIDs as a SearchAttribute is invalid and should be avoided.")
 	_, err = s.validator.validateStartChildExecutionAttributes(
 		s.testNamespaceID,

--- a/service/history/api/respondworkflowtaskcompleted/command_checker_test.go
+++ b/service/history/api/respondworkflowtaskcompleted/command_checker_test.go
@@ -25,10 +25,11 @@
 package respondworkflowtaskcompleted
 
 import (
-	"go.temporal.io/api/taskqueue/v1"
 	"math/rand"
 	"testing"
 	"time"
+
+	"go.temporal.io/api/taskqueue/v1"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -289,6 +289,7 @@ func NewEngineWithShardContext(
 			config.VisibilityAllowList,
 		),
 		config.SuppressErrorSetSystemSearchAttribute,
+		logger,
 	)
 
 	historyEngImpl.replicationDLQHandler = replication.NewLazyDLQHandler(

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -222,6 +222,7 @@ func (s *engine2Suite) SetupTest() {
 			s.mockVisibilityManager,
 			dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 			dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+			s.logger,
 		),
 		workflowConsistencyChecker: api.NewWorkflowConsistencyChecker(mockShard, s.workflowCache),
 		persistenceVisibilityMgr:   s.mockVisibilityManager,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Adds a log with the `WARN` level for Search Attributes having `BuildIds` set.
- Only a log statement has been added, for now, since rejecting such requests would mean breaking changes for current customers writing them. 
- Thus, for now, we should notify them that this change is going to take place and plan in which version we deprecate moving forward, to reject such requests.

## Why?
<!-- Tell your future self why have you made these changes -->
- `BuildIds` is a default SA and should not be set by the customer.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- added unit tests
- existing suite of tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
none, just a logging statement is being added for now.


## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
nope
