### PR TITLE
Optimize locking on backfill history

### DIFF
--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -226,6 +226,7 @@ func (r *WorkflowStateReplicatorImpl) SyncWorkflowState(
 		namespaceID,
 		wid,
 		rid,
+		branchInfo.GetTreeId(),
 		lastEventItem.GetEventId(),
 		lastEventItem.GetVersion(),
 		newHistoryBranchToken,
@@ -279,29 +280,36 @@ func (r *WorkflowStateReplicatorImpl) backfillHistory(
 	namespaceID namespace.ID,
 	workflowID string,
 	runID string,
+	rootRunID string,
 	lastEventID int64,
 	lastEventVersion int64,
 	branchToken []byte,
 ) (taskID int64, retError error) {
 
-	// Get the current run lock to make sure no concurrent backfill history across multiple runs.
-	currentRunReleaseFn, err := r.workflowCache.GetOrCreateCurrentWorkflowExecution(
-		ctx,
-		r.shardContext,
-		namespaceID,
-		workflowID,
-		locks.PriorityLow,
-	)
-	if err != nil {
-		return common.EmptyEventTaskID, err
-	}
-	defer func() {
-		if rec := recover(); rec != nil {
-			currentRunReleaseFn(errPanic)
-			panic(rec)
+	if runID != rootRunID {
+		// At this point, it already acquired the workflow lock on the run ID.
+		// Get the lock of root run id to make sure no concurrent backfill history across multiple runs.
+		_, rootRunReleaseFn, err := r.workflowCache.GetOrCreateWorkflowExecution(
+			ctx,
+			r.shardContext,
+			namespaceID,
+			&commonpb.WorkflowExecution{
+				WorkflowId: workflowID,
+				RunId:      rootRunID,
+			},
+			locks.PriorityLow,
+		)
+		if err != nil {
+			return common.EmptyEventTaskID, err
 		}
-		currentRunReleaseFn(retError)
-	}()
+		defer func() {
+			if rec := recover(); rec != nil {
+				rootRunReleaseFn(errPanic)
+				panic(rec)
+			}
+			rootRunReleaseFn(retError)
+		}()
+	}
 
 	// Get the last batch node id to check if the history data is already in DB.
 	localHistoryIterator := collection.NewPagingIterator(r.getHistoryFromLocalPaginationFn(

--- a/service/history/ndc/workflow_state_replicator_test.go
+++ b/service/history/ndc/workflow_state_replicator_test.go
@@ -137,7 +137,7 @@ func (s *workflowReplicatorSuite) Test_ApplyWorkflowState_BrandNew() {
 	namespaceID := uuid.New()
 	namespaceName := "namespaceName"
 	branchInfo := &persistencespb.HistoryBranch{
-		TreeId:    uuid.New(),
+		TreeId:    s.runID,
 		BranchId:  uuid.New(),
 		Ancestors: nil,
 	}
@@ -187,14 +187,8 @@ func (s *workflowReplicatorSuite) Test_ApplyWorkflowState_BrandNew() {
 		namespace.ID(namespaceID),
 		we,
 		locks.PriorityLow,
-	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
-	s.mockWorkflowCache.EXPECT().GetOrCreateCurrentWorkflowExecution(
-		gomock.Any(),
-		s.mockShard,
-		namespace.ID(namespaceID),
-		s.workflowID,
-		locks.PriorityLow,
-	).Return(wcache.NoopReleaseFn, nil)
+	).Return(mockWeCtx, wcache.NoopReleaseFn, nil).Times(1)
+
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(nil, serviceerror.NewNotFound("ms not found"))
 	mockWeCtx.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),
@@ -300,14 +294,18 @@ func (s *workflowReplicatorSuite) Test_ApplyWorkflowState_Ancestors() {
 		namespace.ID(namespaceID),
 		we,
 		locks.PriorityLow,
-	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
-	s.mockWorkflowCache.EXPECT().GetOrCreateCurrentWorkflowExecution(
+	).Return(mockWeCtx, wcache.NoopReleaseFn, nil).Times(1)
+	s.mockWorkflowCache.EXPECT().GetOrCreateWorkflowExecution(
 		gomock.Any(),
 		s.mockShard,
 		namespace.ID(namespaceID),
-		s.workflowID,
+		&commonpb.WorkflowExecution{
+			WorkflowId: s.workflowID,
+			RunId:      branchInfo.GetTreeId(),
+		},
 		locks.PriorityLow,
-	).Return(wcache.NoopReleaseFn, nil)
+	).Return(mockWeCtx, wcache.NoopReleaseFn, nil).Times(1)
+
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(nil, serviceerror.NewNotFound("ms not found"))
 	mockWeCtx.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),


### PR DESCRIPTION
## What changed?
When backfill history via sync workflow state replication task, it acquires the current run id lock to make sure no concurrent backfill on history. Add the optimization to reduce the locking scope to the same history tree.

## Why?
We need this backfill history lock only for workflows share the same history tree. This only happens on reset workflows. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
