### PR TITLE
Separate version history Add and Switch

### DIFF
--- a/common/persistence/versionhistory/version_history_test.go
+++ b/common/persistence/versionhistory/version_history_test.go
@@ -522,7 +522,7 @@ func (s *versionHistoriesSuite) TestAddGetVersionHistory() {
 	histories := NewVersionHistories(versionHistory1)
 	s.Equal(int32(0), histories.CurrentVersionHistoryIndex)
 
-	currentBranchChanged, newVersionHistoryIndex, err := AddVersionHistory(histories, versionHistory2)
+	currentBranchChanged, newVersionHistoryIndex, err := AddAndSwitchVersionHistory(histories, versionHistory2)
 	s.Nil(err)
 	s.True(currentBranchChanged)
 	s.Equal(int32(1), newVersionHistoryIndex)
@@ -552,7 +552,7 @@ func (s *versionHistoriesSuite) TestFindLCAVersionHistoryIndexAndItem_LargerEven
 	})
 
 	histories := NewVersionHistories(versionHistory1)
-	_, _, err := AddVersionHistory(histories, versionHistory2)
+	_, _, err := AddAndSwitchVersionHistory(histories, versionHistory2)
 	s.Nil(err)
 
 	versionHistoryIncoming := NewVersionHistory([]byte("branch token incoming"), []*historyspb.VersionHistoryItem{
@@ -582,7 +582,7 @@ func (s *versionHistoriesSuite) TestFindLCAVersionHistoryIndexAndItem_SameEventI
 	})
 
 	histories := NewVersionHistories(versionHistory1)
-	_, _, err := AddVersionHistory(histories, versionHistory2)
+	_, _, err := AddAndSwitchVersionHistory(histories, versionHistory2)
 	s.Nil(err)
 
 	versionHistoryIncoming := NewVersionHistory([]byte("branch token incoming"), []*historyspb.VersionHistoryItem{
@@ -612,7 +612,7 @@ func (s *versionHistoriesSuite) TestFindFirstVersionHistoryIndexByItem() {
 	})
 
 	histories := NewVersionHistories(versionHistory1)
-	_, _, err := AddVersionHistory(histories, versionHistory2)
+	_, _, err := AddAndSwitchVersionHistory(histories, versionHistory2)
 	s.Nil(err)
 
 	index, err := FindFirstVersionHistoryIndexByVersionHistoryItem(histories, NewVersionHistoryItem(8, 10))
@@ -625,46 +625,6 @@ func (s *versionHistoriesSuite) TestFindFirstVersionHistoryIndexByItem() {
 
 	_, err = FindFirstVersionHistoryIndexByVersionHistoryItem(histories, NewVersionHistoryItem(41, 4))
 	s.Error(err)
-}
-
-func (s *versionHistoriesSuite) TestCurrentVersionHistoryIndexIsInReplay() {
-	versionHistory1 := NewVersionHistory([]byte("branch token 1"), []*historyspb.VersionHistoryItem{
-		{EventId: 3, Version: 0},
-		{EventId: 5, Version: 4},
-		{EventId: 7, Version: 6},
-		{EventId: 9, Version: 10},
-	})
-	versionHistory2 := NewVersionHistory([]byte("branch token 2"), []*historyspb.VersionHistoryItem{
-		{EventId: 3, Version: 0},
-		{EventId: 5, Version: 4},
-		{EventId: 6, Version: 6},
-		{EventId: 11, Version: 12},
-	})
-
-	histories := NewVersionHistories(versionHistory1)
-	s.Equal(int32(0), histories.CurrentVersionHistoryIndex)
-
-	currentBranchChanged, newVersionHistoryIndex, err := AddVersionHistory(histories, versionHistory2)
-	s.Nil(err)
-	s.True(currentBranchChanged)
-	s.Equal(int32(1), newVersionHistoryIndex)
-	s.Equal(int32(1), histories.CurrentVersionHistoryIndex)
-
-	isInReplay, err := IsVersionHistoriesRebuilt(histories)
-	s.NoError(err)
-	s.False(isInReplay)
-
-	err = SetCurrentVersionHistoryIndex(histories, 0)
-	s.NoError(err)
-	isInReplay, err = IsVersionHistoriesRebuilt(histories)
-	s.NoError(err)
-	s.True(isInReplay)
-
-	err = SetCurrentVersionHistoryIndex(histories, 1)
-	s.NoError(err)
-	isInReplay, err = IsVersionHistoriesRebuilt(histories)
-	s.NoError(err)
-	s.False(isInReplay)
 }
 
 func (s *versionHistoriesSuite) TestIsVersionHistoryItemsInSameBranch_Same_VersionItems_Return_True() {

--- a/service/history/api/getworkflowexecutionrawhistory/api_test.go
+++ b/service/history/api/getworkflowexecutionrawhistory/api_test.go
@@ -160,7 +160,7 @@ func Test_SetRequestDefaultValueAndGetTargetVersionHistory_NonCurrentBranch(t *t
 	item4 := versionhistory.NewVersionHistoryItem(int64(20), int64(51))
 	versionHistory2 := versionhistory.NewVersionHistory([]byte{}, []*historyspb.VersionHistoryItem{item1, item3, item4})
 	versionHistories := versionhistory.NewVersionHistories(versionHistory1)
-	_, _, err := versionhistory.AddVersionHistory(versionHistories, versionHistory2)
+	_, _, err := versionhistory.AddAndSwitchVersionHistory(versionHistories, versionHistory2)
 	assert.NoError(t, err)
 	request := &adminservice.GetWorkflowExecutionRawHistoryRequest{
 		NamespaceId: uuid.New(),

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -6224,7 +6224,7 @@ func (s *engineSuite) Test_SetRequestDefaultValueAndGetTargetVersionHistory_NonC
 	item4 := versionhistory.NewVersionHistoryItem(int64(20), int64(51))
 	versionHistory2 := versionhistory.NewVersionHistory([]byte{}, []*historyspb.VersionHistoryItem{item1, item3, item4})
 	versionHistories := versionhistory.NewVersionHistories(versionHistory1)
-	_, _, err := versionhistory.AddVersionHistory(versionHistories, versionHistory2)
+	_, _, err := versionhistory.AddAndSwitchVersionHistory(versionHistories, versionHistory2)
 	s.NoError(err)
 	namespaceID := namespace.ID(uuid.New())
 	request := &historyservice.GetWorkflowExecutionRawHistoryV2Request{

--- a/service/history/ndc/branch_manager.go
+++ b/service/history/ndc/branch_manager.go
@@ -237,7 +237,7 @@ func (r *BranchMgrImpl) createNewBranch(
 
 	versionhistory.SetVersionHistoryBranchToken(newVersionHistory, resp.NewBranchToken)
 
-	branchChanged, newIndex, err := versionhistory.AddVersionHistory(
+	branchChanged, newIndex, err := versionhistory.AddAndSwitchVersionHistory(
 		r.mutableState.GetExecutionInfo().GetVersionHistories(),
 		newVersionHistory,
 	)

--- a/service/history/ndc/conflict_resolver.go
+++ b/service/history/ndc/conflict_resolver.go
@@ -191,10 +191,6 @@ func (r *ConflictResolverImpl) rebuild(
 	}
 
 	// set the current branch index to target branch index
-	// set the version history back
-	//
-	// caller can use the IsVersionHistoriesRebuilt function in VersionHistories
-	// telling whether mutable state is rebuilt, before apply new history events
 	if err := versionhistory.SetCurrentVersionHistoryIndex(versionHistories, branchIndex); err != nil {
 		return nil, err
 	}

--- a/service/history/ndc/conflict_resolver_test.go
+++ b/service/history/ndc/conflict_resolver_test.go
@@ -127,7 +127,7 @@ func (s *conflictResolverSuite) TestRebuild() {
 		[]*historyspb.VersionHistoryItem{versionhistory.NewVersionHistoryItem(lastEventID1, version)},
 	)
 	versionHistories := versionhistory.NewVersionHistories(versionHistory0)
-	_, _, err := versionhistory.AddVersionHistory(versionHistories, versionHistory1)
+	_, _, err := versionhistory.AddAndSwitchVersionHistory(versionHistories, versionHistory1)
 	s.NoError(err)
 
 	s.mockMutableState.EXPECT().GetUpdateCondition().Return(updateCondition, dbVersion).AnyTimes()
@@ -197,7 +197,7 @@ func (s *conflictResolverSuite) TestGetOrRebuildCurrentMutableState_NoRebuild_No
 		[]*historyspb.VersionHistoryItem{versionHistoryItem0, versionHistoryItem1},
 	)
 	versionHistories := versionhistory.NewVersionHistories(versionHistory0)
-	_, _, err := versionhistory.AddVersionHistory(versionHistories, versionHistory1)
+	_, _, err := versionhistory.AddAndSwitchVersionHistory(versionHistories, versionHistory1)
 	s.Nil(err)
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{VersionHistories: versionHistories}).AnyTimes()
 
@@ -253,7 +253,7 @@ func (s *conflictResolverSuite) TestGetOrRebuildCurrentMutableState_Rebuild() {
 	)
 
 	versionHistories := versionhistory.NewVersionHistories(versionHistory0)
-	_, _, err := versionhistory.AddVersionHistory(versionHistories, versionHistory1)
+	_, _, err := versionhistory.AddAndSwitchVersionHistory(versionHistories, versionHistory1)
 	s.Nil(err)
 
 	s.mockMutableState.EXPECT().GetUpdateCondition().Return(updateCondition, dbVersion).AnyTimes()
@@ -350,7 +350,7 @@ func (s *conflictResolverSuite) TestGetOrRebuildMutableState_Rebuild() {
 	)
 
 	versionHistories := versionhistory.NewVersionHistories(versionHistory0)
-	_, _, err := versionhistory.AddVersionHistory(versionHistories, versionHistory1)
+	_, _, err := versionhistory.AddAndSwitchVersionHistory(versionHistories, versionHistory1)
 	s.Nil(err)
 
 	s.mockMutableState.EXPECT().GetUpdateCondition().Return(updateCondition, dbVersion).AnyTimes()

--- a/service/history/ndc/history_importer.go
+++ b/service/history/ndc/history_importer.go
@@ -413,7 +413,7 @@ func (r *HistoryImporterImpl) commit(
 
 	if cmpResult < 0 {
 		// imported events does not belong to current branch, update DB mutable state with new version history
-		updated, _, err := versionhistory.AddVersionHistory(
+		updated, _, err := versionhistory.AddAndSwitchVersionHistory(
 			dbNDCWorkflow.GetMutableState().GetExecutionInfo().GetVersionHistories(),
 			memCurrentVersionHistory,
 		)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Separate util func for version history Add and Switch

## Why?
<!-- Tell your future self why have you made these changes -->
- In state-based replication world, current history version history can have a smaller version than other history branches. This auto switch logic will break that and needs to be separated.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
