### PR TITLE
Fix Nexus xdc test flakiness

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -252,7 +252,7 @@ jobs:
           down-flags: -v
 
       - name: Run functional test xdc
-        timeout-minutes: 15
+        timeout-minutes: 30
         run: make functional-test-xdc-coverage
 
       - name: Upload test results

--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ functional-test-coverage: prepare-coverage-test
 functional-test-xdc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for cross DC with coverage with $(PERSISTENCE_DRIVER) driver..."
 	@$(GOTESTSUM) --junitfile $(NEW_REPORT) -- \
-		$(FUNCTIONAL_TEST_XDC_ROOT) -shuffle=1725994791135537251 -timeout=$(TEST_TIMEOUT) $(TEST_TAG_FLAG) -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER) $(FUNCTIONAL_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
+		$(FUNCTIONAL_TEST_XDC_ROOT) -shuffle on -timeout=$(TEST_TIMEOUT) $(TEST_TAG_FLAG) -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER) $(FUNCTIONAL_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
 
 functional-test-ndc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for NDC with coverage with $(PERSISTENCE_DRIVER) driver..."

--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ functional-test-coverage: prepare-coverage-test
 functional-test-xdc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for cross DC with coverage with $(PERSISTENCE_DRIVER) driver..."
 	@$(GOTESTSUM) --junitfile $(NEW_REPORT) -- \
-		$(FUNCTIONAL_TEST_XDC_ROOT) -shuffle on -timeout=$(TEST_TIMEOUT) $(TEST_TAG_FLAG) -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER) $(FUNCTIONAL_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
+		$(FUNCTIONAL_TEST_XDC_ROOT) -shuffle=1725994791135537251 -timeout=$(TEST_TIMEOUT) $(TEST_TAG_FLAG) -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER) $(FUNCTIONAL_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
 
 functional-test-ndc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for NDC with coverage with $(PERSISTENCE_DRIVER) driver..."

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -182,8 +182,7 @@ func (s *xdcBaseSuite) waitForClusterConnected() {
 		}
 		assert.Greater(c, shard.MaxReplicationTaskId, int64(0))
 		assert.NotNil(c, shard.ShardLocalTime)
-		assert.Less(c, shard.ShardLocalTime.AsTime(), time.Now())
-		assert.Greater(c, shard.ShardLocalTime.AsTime(), s.startTime)
+		assert.WithinRange(c, shard.ShardLocalTime.AsTime(), s.startTime, time.Now())
 		assert.NotNil(c, shard.RemoteClusters)
 
 		standbyAckInfo, ok := shard.RemoteClusters[s.clusterNames[1]]
@@ -191,8 +190,7 @@ func (s *xdcBaseSuite) waitForClusterConnected() {
 			return
 		}
 		assert.NotNil(c, standbyAckInfo.AckedTaskVisibilityTime)
-		assert.Less(c, standbyAckInfo.AckedTaskVisibilityTime.AsTime(), time.Now())
-		assert.Greater(c, standbyAckInfo.AckedTaskVisibilityTime.AsTime(), s.startTime)
+		assert.WithinRange(c, standbyAckInfo.AckedTaskVisibilityTime.AsTime(), s.startTime, time.Now())
 	}, 60*time.Second, 1*time.Second)
 	s.logger.Info("cluster connected")
 }

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -171,11 +171,15 @@ func (s *xdcBaseSuite) waitForClusterConnected() {
 	s.EventuallyWithT(func(c *assert.CollectT) {
 		s.logger.Info("check if stream is established")
 		resp, err := s.cluster1.GetHistoryClient().GetReplicationStatus(context.Background(), &historyservice.GetReplicationStatusRequest{})
-		assert.NoError(c, err)
+		if !assert.NoError(c, err) {
+			return
+		}
 		assert.Lenf(c, resp.Shards, 1, "test cluster has only one history shard")
 
 		shard := resp.Shards[0]
-		assert.NotNil(c, shard)
+		if !assert.NotNil(c, shard) {
+			return
+		}
 		assert.Greater(c, shard.MaxReplicationTaskId, int64(0))
 		assert.NotNil(c, shard.ShardLocalTime)
 		assert.Less(c, shard.ShardLocalTime.AsTime(), time.Now())
@@ -183,8 +187,9 @@ func (s *xdcBaseSuite) waitForClusterConnected() {
 		assert.NotNil(c, shard.RemoteClusters)
 
 		standbyAckInfo, ok := shard.RemoteClusters[s.clusterNames[1]]
-		assert.True(c, ok)
-		assert.NotNil(c, standbyAckInfo)
+		if !assert.True(c, ok) || !assert.NotNil(c, standbyAckInfo) {
+			return
+		}
 		assert.NotNil(c, standbyAckInfo.AckedTaskVisibilityTime)
 		assert.Less(c, standbyAckInfo.AckedTaskVisibilityTime.AsTime(), time.Now())
 		assert.Greater(c, standbyAckInfo.AckedTaskVisibilityTime.AsTime(), s.startTime)

--- a/tests/xdc/nexus_request_forwarding_test.go
+++ b/tests/xdc/nexus_request_forwarding_test.go
@@ -197,7 +197,7 @@ func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToAc
 		tc := tc
 		s.T().Run(tc.name, func(t *testing.T) {
 			dispatchURL := fmt.Sprintf("http://%s/%s", s.cluster2.GetHost().FrontendHTTPAddress(), cnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Path(cnexus.NamespaceAndTaskQueue{Namespace: ns, TaskQueue: tc.taskQueue}))
-			nexusClient, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test_service"})
+			nexusClient, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test-service"})
 			s.NoError(err)
 
 			activeMetricsHandler, ok := s.cluster1.GetHost().GetMetricsHandler().(*metricstest.CaptureHandler)
@@ -298,7 +298,7 @@ func (s *NexusRequestForwardingSuite) TestCancelOperationForwardedFromStandbyToA
 		tc := tc
 		s.T().Run(tc.name, func(t *testing.T) {
 			dispatchURL := fmt.Sprintf("http://%s/%s", s.cluster2.GetHost().FrontendHTTPAddress(), cnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Path(cnexus.NamespaceAndTaskQueue{Namespace: ns, TaskQueue: tc.taskQueue}))
-			nexusClient, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test_service"})
+			nexusClient, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test-service"})
 			s.NoError(err)
 
 			activeMetricsHandler, ok := s.cluster1.GetHost().GetMetricsHandler().(*metricstest.CaptureHandler)
@@ -545,7 +545,9 @@ func (s *NexusRequestForwardingSuite) nexusTaskPoller(ctx context.Context, front
 		})
 	}
 
-	s.NoError(err)
+	if err != nil && ctx.Err() == nil {
+		s.FailNow("received unexpected error responding to Nexus task", err)
+	}
 }
 
 func (s *NexusRequestForwardingSuite) sendNexusCompletionRequest(

--- a/tests/xdc/nexus_request_forwarding_test.go
+++ b/tests/xdc/nexus_request_forwarding_test.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commandpb "go.temporal.io/api/command/v1"
@@ -48,17 +47,16 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
+
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
-	"go.temporal.io/server/common/namespace"
 	cnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexustest"
 	"go.temporal.io/server/components/callbacks"
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/tests"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 var op = nexus.NewOperationReference[string, string]("my-operation")
@@ -94,7 +92,7 @@ func (s *NexusRequestForwardingSuite) TearDownSuite() {
 // Only tests dispatch by namespace+task_queue.
 // TODO: Add test cases for dispatch by endpoint ID once endpoints support replication.
 func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToActive() {
-	ns := s.createNexusRequestForwardingNamespace()
+	ns := s.createGlobalNamespace()
 
 	testCases := []struct {
 		name      string
@@ -230,7 +228,7 @@ func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToAc
 // Only tests dispatch by namespace+task_queue.
 // TODO: Add test cases for dispatch by endpoint ID once endpoints support replication.
 func (s *NexusRequestForwardingSuite) TestCancelOperationForwardedFromStandbyToActive() {
-	ns := s.createNexusRequestForwardingNamespace()
+	ns := s.createGlobalNamespace()
 
 	testCases := []struct {
 		name      string
@@ -338,7 +336,7 @@ func (s *NexusRequestForwardingSuite) TestCompleteOperationForwardedFromStandbyT
 		"http://"+s.cluster2.GetHost().FrontendHTTPAddress()+"/namespaces/{{.NamespaceName}}/nexus/callback")
 
 	ctx := tests.NewContext()
-	ns := s.createNexusRequestForwardingNamespace()
+	ns := s.createGlobalNamespace()
 	taskQueue := fmt.Sprintf("%v-%v", "test-task-queue", uuid.New())
 	endpointName := tests.RandomizedNexusEndpoint(s.T().Name())
 
@@ -548,29 +546,6 @@ func (s *NexusRequestForwardingSuite) nexusTaskPoller(ctx context.Context, front
 	}
 
 	s.NoError(err)
-}
-
-func (s *NexusRequestForwardingSuite) createNexusRequestForwardingNamespace() string {
-	ctx := tests.NewContext()
-	ns := fmt.Sprintf("%v-%v", "test-namespace", uuid.New())
-
-	regReq := &workflowservice.RegisterNamespaceRequest{
-		Namespace:                        ns,
-		IsGlobalNamespace:                true,
-		Clusters:                         s.clusterReplicationConfig(),
-		ActiveClusterName:                s.clusterNames[0],
-		WorkflowExecutionRetentionPeriod: durationpb.New(7 * time.Hour * 24),
-	}
-	_, err := s.cluster1.GetFrontendClient().RegisterNamespace(ctx, regReq)
-	s.NoError(err)
-
-	s.EventuallyWithT(func(t *assert.CollectT) {
-		// Wait for namespace record to be replicated and loaded into memory.
-		_, err := s.cluster2.GetHost().GetFrontendNamespaceRegistry().GetNamespace(namespace.Name(ns))
-		assert.NoError(t, err)
-	}, 15*time.Second, 500*time.Millisecond)
-
-	return ns
 }
 
 func (s *NexusRequestForwardingSuite) sendNexusCompletionRequest(

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -47,6 +47,8 @@ import (
 	"go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
+	"go.uber.org/atomic"
+
 	"go.temporal.io/server/common/dynamicconfig"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexustest"
@@ -54,7 +56,6 @@ import (
 	"go.temporal.io/server/components/callbacks"
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/tests"
-	"go.uber.org/atomic"
 )
 
 type NexusStateReplicationSuite struct {
@@ -204,7 +205,7 @@ func (s *NexusStateReplicationSuite) TestNexusOperationEventsReplicated() {
 		s.Equal(1, len(describeRes.PendingNexusOperations))
 		op := describeRes.PendingNexusOperations[0]
 		return op.State == enumspb.PENDING_NEXUS_OPERATION_STATE_STARTED
-	}, time.Second*10, time.Millisecond*100)
+	}, time.Second*20, time.Millisecond*100)
 
 	_, err = s.cluster2.GetFrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
 		TaskToken: pollRes.TaskToken,
@@ -507,7 +508,7 @@ func (s *NexusStateReplicationSuite) waitCallback(
 		s.NoError(err)
 		s.Len(descResp.GetCallbacks(), 1)
 		return condition(descResp.GetCallbacks()[0])
-	}, time.Second*10, time.Millisecond*100)
+	}, time.Second*20, time.Millisecond*100)
 }
 
 func (s *NexusStateReplicationSuite) completeNexusOperation(ctx context.Context, result any, callbackUrl, callbackToken string) {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
* Increased eventually condition max wait times in `nexus_request_forwarding_test`
* Refactored the assertions in `waitForClusterConnected` to make sure it is not returning early
* Increased xdc test GHA timeout to 30 minutes to avoid GHA timeouts and to see which tests are taking too long (test timeout is 25m but if GHA times out first, we don't get any results)

## Why?
<!-- Tell your future self why have you made these changes -->
To make the suite less flakey

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Reran CI tests multiple times
Reran CI tests with shuffle seed that failed previously: `1725994791135537251`

