### PR TITLE
Replication stack monitor to check both high priority and low priority queue

### DIFF
--- a/service/history/replication/stream_receiver_monitor.go
+++ b/service/history/replication/stream_receiver_monitor.go
@@ -315,14 +315,6 @@ func (m *StreamReceiverMonitorImpl) doReconcileOutboundStreams(
 }
 
 func (m *StreamReceiverMonitorImpl) statusMonitorLoop() {
-	var panicErr error
-	defer func() {
-		if panicErr != nil {
-			metrics.ReplicationStreamPanic.With(m.MetricsHandler).Record(1)
-		}
-	}()
-	defer log.CapturePanic(m.Logger, &panicErr)
-
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 
@@ -336,6 +328,14 @@ func (m *StreamReceiverMonitorImpl) statusMonitorLoop() {
 	}
 }
 func (m *StreamReceiverMonitorImpl) monitorStreamStatus() {
+	var panicErr error
+	defer func() {
+		if panicErr != nil {
+			metrics.ReplicationStreamPanic.With(m.MetricsHandler).Record(1)
+		}
+	}()
+	defer log.CapturePanic(m.Logger, &panicErr)
+
 	if m.shutdownOnce.IsShutdown() {
 		return
 	}
@@ -381,8 +381,9 @@ func (m *StreamReceiverMonitorImpl) evaluateSingleStreamConnection(key *ClusterS
 	if !current.isTieredStackEnabled {
 		return checkIfMakeProgress(enumspb.TASK_PRIORITY_UNSPECIFIED, current.defaultAckLevel, current.maxReplicationTaskId, previous.defaultAckLevel, previous.maxReplicationTaskId)
 	}
-	return checkIfMakeProgress(enumspb.TASK_PRIORITY_HIGH, current.highPriorityAckLevel, current.maxReplicationTaskId, previous.highPriorityAckLevel, previous.maxReplicationTaskId) &&
-		checkIfMakeProgress(enumspb.TASK_PRIORITY_LOW, current.lowPriorityAckLevel, current.maxReplicationTaskId, previous.lowPriorityAckLevel, previous.maxReplicationTaskId)
+	highPriorityResult := checkIfMakeProgress(enumspb.TASK_PRIORITY_HIGH, current.highPriorityAckLevel, current.maxReplicationTaskId, previous.highPriorityAckLevel, previous.maxReplicationTaskId)
+	lowPriorityResult := checkIfMakeProgress(enumspb.TASK_PRIORITY_LOW, current.lowPriorityAckLevel, current.maxReplicationTaskId, previous.lowPriorityAckLevel, previous.maxReplicationTaskId)
+	return highPriorityResult && lowPriorityResult
 }
 
 func (m *StreamReceiverMonitorImpl) generateStatusMap(inboundKeys map[ClusterShardKeyPair]struct{}) map[ClusterShardKeyPair]*streamStatus {

--- a/service/history/replication/stream_receiver_monitor.go
+++ b/service/history/replication/stream_receiver_monitor.go
@@ -330,11 +330,11 @@ func (m *StreamReceiverMonitorImpl) statusMonitorLoop() {
 func (m *StreamReceiverMonitorImpl) monitorStreamStatus() {
 	var panicErr error
 	defer func() {
+		log.CapturePanic(m.Logger, &panicErr)
 		if panicErr != nil {
 			metrics.ReplicationStreamPanic.With(m.MetricsHandler).Record(1)
 		}
 	}()
-	defer log.CapturePanic(m.Logger, &panicErr)
 
 	if m.shutdownOnce.IsShutdown() {
 		return


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
1. move panic capture to inside of monitor loop, so check can be retried after panic
2. Check low priority even if high priority stuck
## Why?
<!-- Tell your future self why have you made these changes -->
Improve stability of monitor loop
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
n/a
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
no