### PR TITLE
Add history.alignMembershipChange setting

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1348,6 +1348,12 @@ This feature is still under development and should NOT be enabled.`,
 		`HistoryStartupMembershipJoinDelay is the duration a history instance waits
 before joining membership after starting.`,
 	)
+	HistoryAlignMembershipChange = NewGlobalDurationSetting(
+		"history.alignMembershipChange",
+		0*time.Second,
+		`HistoryAlignMembershipChange is a duration to align history's membership changes to.
+This can help reduce effects of shard movement.`,
+	)
 	HistoryShutdownDrainDuration = NewGlobalDurationSetting(
 		"history.shutdownDrainDuration",
 		0*time.Second,

--- a/common/membership/ringpop/factory.go
+++ b/common/membership/ringpop/factory.go
@@ -156,6 +156,8 @@ func (factory *factory) getJoinTime(maxPropagationTime time.Duration) time.Time 
 	switch factory.ServiceName {
 	case primitives.MatchingService:
 		alignTime = dynamicconfig.MatchingAlignMembershipChange.Get(factory.DC)()
+	case primitives.HistoryService:
+		alignTime = dynamicconfig.HistoryAlignMembershipChange.Get(factory.DC)()
 	}
 	if alignTime == 0 {
 		return time.Time{}

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	EmitShardLagLog            dynamicconfig.BoolPropertyFn
 	ThrottledLogRPS            dynamicconfig.IntPropertyFn
 	EnableStickyQuery          dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	AlignMembershipChange      dynamicconfig.DurationPropertyFn
 	ShutdownDrainDuration      dynamicconfig.DurationPropertyFn
 	StartupMembershipJoinDelay dynamicconfig.DurationPropertyFn
 
@@ -403,6 +404,7 @@ func NewConfig(
 		PersistencePerShardNamespaceMaxQPS:   dynamicconfig.HistoryPersistencePerShardNamespaceMaxQPS.Get(dc),
 		PersistenceDynamicRateLimitingParams: dynamicconfig.HistoryPersistenceDynamicRateLimitingParams.Get(dc),
 		PersistenceQPSBurstRatio:             dynamicconfig.PersistenceQPSBurstRatio.Get(dc),
+		AlignMembershipChange:                dynamicconfig.HistoryAlignMembershipChange.Get(dc),
 		ShutdownDrainDuration:                dynamicconfig.HistoryShutdownDrainDuration.Get(dc),
 		StartupMembershipJoinDelay:           dynamicconfig.HistoryStartupMembershipJoinDelay.Get(dc),
 		AllowResetWithPendingChildren:        dynamicconfig.AllowResetWithPendingChildren.Get(dc),

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -148,6 +148,8 @@ func (s *Service) Stop() {
 		time.Sleep(s.config.ShutdownDrainDuration())
 	}
 
+	// Stop shard controller. We should have waited long enough for all shards to realize they
+	// lost ownership and close, but if not, this will definitely close them.
 	s.logger.Info("ShutdownHandler: Initiating shardController shutdown")
 	s.handler.controller.Stop()
 


### PR DESCRIPTION
## What changed?
Add `history.alignMembershipChange` to allow history to use aligned membership changes also.

## Why?
Better behavior during restarts/deployments.

## How did you test it?
not yet