### PR TITLE
ShutdownWorker frontend implementation

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2608,6 +2608,25 @@ func (wh *WorkflowHandler) ResetStickyTaskQueue(ctx context.Context, request *wo
 func (wh *WorkflowHandler) ShutdownWorker(ctx context.Context, request *workflowservice.ShutdownWorkerRequest) (_ *workflowservice.ShutdownWorkerResponse, retError error) {
 	defer log.CapturePanic(wh.logger, &retError)
 
+	if request == nil {
+		return nil, errRequestNotSet
+	}
+
+	namespaceId, err := wh.namespaceRegistry.GetNamespaceID(namespace.Name(request.GetNamespace()))
+	if err != nil {
+		return nil, err
+	}
+	
+	// TODO: update poller info to indicate poller was shut down (pass identity/reason along)
+	_, err = wh.matchingClient.ForceUnloadTaskQueue(ctx, &matchingservice.ForceUnloadTaskQueueRequest{
+		NamespaceId:   namespaceId.String(),
+		TaskQueue:     request.GetStickyTaskQueue(),
+		TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW, // sticky task queues are always workflow queues
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	return &workflowservice.ShutdownWorkerResponse{}, nil
 }
 

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2616,7 +2616,7 @@ func (wh *WorkflowHandler) ShutdownWorker(ctx context.Context, request *workflow
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// TODO: update poller info to indicate poller was shut down (pass identity/reason along)
 	_, err = wh.matchingClient.ForceUnloadTaskQueue(ctx, &matchingservice.ForceUnloadTaskQueueRequest{
 		NamespaceId:   namespaceId.String(),

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -50,6 +50,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/api/matchingservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
@@ -2941,5 +2942,29 @@ func (s *workflowHandlerSuite) TestExecuteMultiOperation() {
 			s.Nil(resp)
 			assertMultiOpsErr([]error{errMultiOpAborted, errUpdateInputNotSet}, err)
 		})
+	})
+}
+
+func (s *workflowHandlerSuite) TestShutdownWorker() {
+	config := s.newConfig()
+	wh := s.getWorkflowHandler(config)
+	ctx := context.Background()
+
+	stickyTaskQueue := "sticky-task-queue"
+
+	expectedMatchingRequest := &matchingservice.ForceUnloadTaskQueueRequest{
+		NamespaceId:   s.testNamespaceID.String(),
+		TaskQueue:     stickyTaskQueue,
+		TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+	}
+
+	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Eq(s.testNamespace)).Return(s.testNamespaceID, nil).AnyTimes()
+	s.mockMatchingClient.EXPECT().ForceUnloadTaskQueue(gomock.Any(), gomock.Eq(expectedMatchingRequest)).Return(&matchingservice.ForceUnloadTaskQueueResponse{}, nil)
+
+	wh.ShutdownWorker(ctx, &workflowservice.ShutdownWorkerRequest{
+		Namespace:       s.testNamespace.String(),
+		StickyTaskQueue: stickyTaskQueue,
+		Identity:        "worker",
+		Reason:          "graceful shutdown",
 	})
 }

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2961,10 +2961,13 @@ func (s *workflowHandlerSuite) TestShutdownWorker() {
 	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Eq(s.testNamespace)).Return(s.testNamespaceID, nil).AnyTimes()
 	s.mockMatchingClient.EXPECT().ForceUnloadTaskQueue(gomock.Any(), gomock.Eq(expectedMatchingRequest)).Return(&matchingservice.ForceUnloadTaskQueueResponse{}, nil)
 
-	wh.ShutdownWorker(ctx, &workflowservice.ShutdownWorkerRequest{
+	err, _ := wh.ShutdownWorker(ctx, &workflowservice.ShutdownWorkerRequest{
 		Namespace:       s.testNamespace.String(),
 		StickyTaskQueue: stickyTaskQueue,
 		Identity:        "worker",
 		Reason:          "graceful shutdown",
 	})
+	if err != nil {
+		s.Fail("ShutdownWorker failed:", err)
+	}
 }

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2961,7 +2961,7 @@ func (s *workflowHandlerSuite) TestShutdownWorker() {
 	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Eq(s.testNamespace)).Return(s.testNamespaceID, nil).AnyTimes()
 	s.mockMatchingClient.EXPECT().ForceUnloadTaskQueue(gomock.Any(), gomock.Eq(expectedMatchingRequest)).Return(&matchingservice.ForceUnloadTaskQueueResponse{}, nil)
 
-	err, _ := wh.ShutdownWorker(ctx, &workflowservice.ShutdownWorkerRequest{
+	_, err := wh.ShutdownWorker(ctx, &workflowservice.ShutdownWorkerRequest{
 		Namespace:       s.testNamespace.String(),
 		StickyTaskQueue: stickyTaskQueue,
 		Identity:        "worker",

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -1489,6 +1489,52 @@ func (s *matchingEngineSuite) TestPollWithExpiredContext() {
 	s.Equal(emptyPollActivityTaskQueueResponse, resp)
 }
 
+func (s *matchingEngineSuite) TestForceUnloadTaskQueue() {
+	ctx := context.Background()
+	namespaceId := uuid.New()
+	identity := "nobody"
+
+	// We unload a sticky queue so that we can verify the unload took effect by
+	// attempting to add a task to it
+	stickyQueue := &taskqueuepb.TaskQueue{Name: "sticky-queue", Kind: enumspb.TASK_QUEUE_KIND_STICKY}
+
+	addTaskRequest := matchingservice.AddWorkflowTaskRequest{
+		NamespaceId:      namespaceId,
+		Execution:        &commonpb.WorkflowExecution{WorkflowId: "workflowID", RunId: uuid.NewRandom().String()},
+		ScheduledEventId: int64(0),
+		TaskQueue:        stickyQueue,
+	}
+
+	// Poll to create the queue
+	pollResp, err := s.matchingEngine.PollWorkflowTaskQueue(ctx, &matchingservice.PollWorkflowTaskQueueRequest{
+		NamespaceId: namespaceId,
+		PollRequest: &workflowservice.PollWorkflowTaskQueueRequest{
+			TaskQueue: stickyQueue,
+			Identity:  identity,
+		}},
+		metrics.NoopMetricsHandler)
+	s.Nil(err)
+	s.NotNil(pollResp)
+
+	// Sanity check: adding a task should succeed with the queue loaded
+	_, _, err = s.matchingEngine.AddWorkflowTask(ctx, &addTaskRequest)
+	s.NoError(err)
+
+	// Force unload the sticky queue
+	unloadResp, err := s.matchingEngine.ForceUnloadTaskQueue(ctx, &matchingservice.ForceUnloadTaskQueueRequest{
+		NamespaceId:   namespaceId,
+		TaskQueue:     stickyQueue.Name,
+		TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+	})
+	s.NoError(err)
+	s.NotNil(unloadResp)
+	s.True(unloadResp.WasLoaded)
+
+	// Adding a task should now fast fail
+	_, _, err = s.matchingEngine.AddWorkflowTask(ctx, &addTaskRequest)
+	s.ErrorAs(err, new(*serviceerrors.StickyWorkerUnavailable))
+}
+
 func (s *matchingEngineSuite) TestMultipleEnginesActivitiesRangeStealing() {
 	runID := uuid.NewRandom().String()
 	workflowID := "workflow1"


### PR DESCRIPTION
## What changed?
- ShutdownWorker is implemented in FrontendService by forwarding to `ForceUnloadTaskQueue` in Matching.

## Why?
- Will be used by workers to indicate their sticky queue is no longer being polled

## How did you test it?
- new test

## Potential risks
- new API that exposes `ForceUnloadTaskQueue`. If callers were to abuse the operation, they could force history being reloaded as the sticky queue is cleared.

## Documentation
- New docs on the API

## Is hotfix candidate?
- No 
