### PR TITLE
Workflow Update: check completed Updates when reappyling Updates

### DIFF
--- a/common/testing/historyrequire/history_require.go
+++ b/common/testing/historyrequire/history_require.go
@@ -268,7 +268,7 @@ func (h HistoryRequire) parseHistory(expectedHistory string) (string, map[int64]
 	prevEventID := 0
 	for lineNum, eventLine := range strings.Split(expectedHistory, "\n") {
 		fields := strings.Fields(eventLine)
-		if len(fields) == 0 {
+		if len(fields) == 0 || fields[0] == "//" {
 			continue
 		}
 		if len(fields) < 2 {

--- a/service/history/ndc/events_reapplier.go
+++ b/service/history/ndc/events_reapplier.go
@@ -82,7 +82,7 @@ func (r *EventsReapplierImpl) ReapplyEvents(
 	if !ms.IsWorkflowExecutionRunning() {
 		return nil, serviceerror.NewInternal("unable to reapply events to closed workflow.")
 	}
-	reappliedEvents, err := reapplyEvents(ms, updateRegistry, r.stateMachineRegistry, historyEvents, nil, runID)
+	reappliedEvents, err := reapplyEvents(ctx, ms, updateRegistry, r.stateMachineRegistry, historyEvents, nil, runID)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/ndc/events_reapplier_test.go
+++ b/service/history/ndc/events_reapplier_test.go
@@ -35,6 +35,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/definition"
@@ -152,7 +153,8 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 			EventId:   105,
 			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
 			Attributes: &historypb.HistoryEvent_WorkflowExecutionUpdateAcceptedEventAttributes{WorkflowExecutionUpdateAcceptedEventAttributes: &historypb.WorkflowExecutionUpdateAcceptedEventAttributes{
-				AcceptedRequest: &updatepb.Request{Input: &updatepb.Input{Args: payloads.EncodeString("update-request-payload")}, Meta: &updatepb.Meta{UpdateId: "update-2"}},
+				AcceptedRequest:    &updatepb.Request{Input: &updatepb.Input{Args: payloads.EncodeString("update-request-payload")}, Meta: &updatepb.Meta{UpdateId: "update-2"}},
+				ProtocolInstanceId: "update-2",
 			}},
 		},
 	} {
@@ -170,12 +172,14 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 				attr.GetRequest(),
 				enumspb.UPDATE_ADMITTED_EVENT_ORIGIN_UNSPECIFIED,
 			).Return(event, nil)
+			msCurrent.EXPECT().GetUpdateOutcome(gomock.Any(), attr.GetRequest().GetMeta().GetUpdateId()).Return(nil, serviceerror.NewNotFound(""))
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED:
 			attr := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
 			msCurrent.EXPECT().AddWorkflowExecutionUpdateAdmittedEvent(
 				attr.GetAcceptedRequest(),
 				enumspb.UPDATE_ADMITTED_EVENT_ORIGIN_REAPPLY,
 			).Return(event, nil)
+			msCurrent.EXPECT().GetUpdateOutcome(gomock.Any(), attr.GetProtocolInstanceId()).Return(nil, serviceerror.NewNotFound(""))
 		}
 		msCurrent.EXPECT().HSM().Return(s.hsmNode).AnyTimes()
 		msCurrent.EXPECT().IsWorkflowPendingOnWorkflowTaskBackoff().Return(true)

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -776,6 +776,9 @@ func reapplyEvents(
 				continue
 			}
 			attr := event.GetWorkflowExecutionUpdateAdmittedEventAttributes()
+			// targetBranchUpdateRegistry is a nil in a Reset case, and not nil in a conflict resolution case.
+			// If the Update with the same UpdateId is already present in the target branch (Find returns non-nil),
+			// it is skipped and not reapplied.
 			if targetBranchUpdateRegistry != nil && targetBranchUpdateRegistry.Find(ctx, attr.Request.Meta.UpdateId) != nil {
 				continue
 			}
@@ -791,6 +794,9 @@ func reapplyEvents(
 				continue
 			}
 			attr := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
+			// targetBranchUpdateRegistry is a nil in a Reset case, and not nil in a conflict resolution case.
+			// If the Update with the same UpdateId is already present in the target branch (Find returns non-nil),
+			// it is skipped and not reapplied.
 			if targetBranchUpdateRegistry != nil && targetBranchUpdateRegistry.Find(ctx, attr.ProtocolInstanceId) != nil {
 				continue
 			}

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -918,7 +918,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 	s.NoError(err)
 	ms.EXPECT().HSM().Return(root).AnyTimes()
 
-	_, err = reapplyEvents(ms, nil, smReg, events, nil, "")
+	_, err = reapplyEvents(context.Background(), ms, nil, smReg, events, nil, "")
 	s.NoError(err)
 }
 

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -55,8 +55,8 @@ type (
 		// created (false).
 		FindOrCreate(ctx context.Context, updateID string) (_ *Update, alreadyExisted bool, _ error)
 
-		// Find finds an existing Update in this Registry but does not create a
-		// new Update if no Update is found.
+		// Find an existing Update in this Registry.
+		// Returns nil if Update doesn't exist.
 		Find(ctx context.Context, updateID string) *Update
 
 		// TryResurrect tries to resurrect the Update from the protocol message,
@@ -84,9 +84,6 @@ type (
 
 		// Abort all incomplete Updates in the Registry.
 		Abort(reason AbortReason)
-
-		// Contains returns true iff the Update exists in the Registry.
-		Contains(updateID string) bool
 
 		// Clear the Registry and abort all Updates.
 		Clear()
@@ -278,10 +275,6 @@ func (r *registry) Abort(reason AbortReason) {
 	}
 }
 
-func (r *registry) Contains(updateID string) bool {
-	return r.updates[updateID] != nil
-}
-
 func (r *registry) RejectUnprocessed(
 	_ context.Context,
 	effects effect.Controller,
@@ -389,7 +382,7 @@ func (r *registry) checkTotalLimit() error {
 }
 
 func (r *registry) Find(ctx context.Context, id string) *Update {
-	// Check the Admitted and Accepted Updates map first.
+	// Check the admitted and accepted Updates map first.
 	if upd, ok := r.updates[id]; ok {
 		return upd
 	}

--- a/tests/xdc/history_replication_signals_and_updates_test.go
+++ b/tests/xdc/history_replication_signals_and_updates_test.go
@@ -385,6 +385,40 @@ func (s *hrsuTestSuite) TestConflictResolutionDoesNotReapplyAcceptedUpdateWithCo
 	}
 }
 
+// TestConflictResolutionDoesNotReapplyCompletedUpdateWithConflictingId creates a split-brain scenario in which both
+// clusters believe they are active. Both clusters then accept and *complete* an update and write it to their own history, but those
+// updates have the same update ID. The test confirms that when the conflict is resolved, we do not reapply the
+// UpdateAccepted and UpdateCompleted event, since it has a conflicting ID.
+// Same as above but for completed Updates.
+func (s *hrsuTestSuite) TestConflictResolutionDoesNotReapplyCompletedUpdateWithConflictingId() {
+	t, ctx, cancel := s.startHrsuTest()
+	defer cancel()
+	t.cluster1.startWorkflow(ctx, func(workflow.Context) error { return nil })
+
+	// Both clusters accept and complete an update with the same ID.
+	t.enterSplitBrainStateAndCompletedUpdatesInBothClusters(ctx, "update-id", "update-id")
+	// Execute pending history replication tasks. Each cluster sends its update to the other, triggering conflict
+	// resolution.
+	t.cluster1.executeHistoryReplicationTasksUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED)
+	t.cluster2.executeHistoryReplicationTasksUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED)
+
+	// Cluster1 has received an accepted update with failover version 2, which superseded its own update. Cluster2 has
+	// received an accepted update from cluster 1 with a lower failover version. Normally, such an update would be
+	// reapplied. But since it has the same update ID as the cluster 1 update, and since that update is not completed,
+	// we must not reapply it. The result is that both clusters have the same history; the update accepted in cluster 1
+	// has been dropped.
+	for _, c := range []hrsuTestCluster{t.cluster1, t.cluster2} {
+		t.s.HistoryRequire.EqualHistoryEventsAndVersions(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "update-id", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster2-update-input\""}]}}}}
+	6 WorkflowExecutionUpdateCompleted
+		`, []int{1, 1, 2, 2, 2, 2}, c.getHistory(ctx))
+	}
+}
+
 // TestConflictResolutionDoesNotReapplyAdmittedUpdateWithConflictingId creates a split-brain scenario in which both
 // clusters believe they are active. Both clusters then accept an update and write it to their own history, but those
 // updates have the same update ID. This time however, we perform a WorkflowReset in one of the clusters, creating an
@@ -450,7 +484,7 @@ func (s *hrsuTestSuite) TestConflictResolutionDoesNotReapplyAdmittedUpdateWithCo
 // Start update in cluster 1, run it through to acceptance, replicate it to cluster 2, then failover to 2 and complete
 // the update there.
 func (t *hrsuTest) startAndAcceptUpdateInCluster1ThenFailoverTo2AndCompleteUpdate(ctx context.Context) {
-	t.cluster1.sendUpdateAndWaitUntilAccepted(ctx, "cluster1-update-id", "cluster1-update-input")
+	t.cluster1.sendUpdateAndWaitUntilStage(ctx, "cluster1-update-id", "cluster1-update-input", sdkclient.WorkflowUpdateStageAccepted)
 	t.cluster2.executeHistoryReplicationTasksUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED)
 
 	for _, c := range []hrsuTestCluster{t.cluster1, t.cluster2} {
@@ -490,7 +524,7 @@ func (t *hrsuTest) startAndAcceptUpdateInCluster1ThenFailoverTo2AndCompleteUpdat
 
 // Run an update in cluster 2 to Accepted state, failover to cluster 1, and confirm that it can be completed in cluster 1.
 func (t *hrsuTest) startAndAcceptUpdateInCluster2ThenFailoverTo1AndCompleteUpdate(ctx context.Context) {
-	t.cluster2.sendUpdateAndWaitUntilAccepted(ctx, "cluster2-update-id", "cluster2-update-input")
+	t.cluster2.sendUpdateAndWaitUntilStage(ctx, "cluster2-update-id", "cluster2-update-input", sdkclient.WorkflowUpdateStageAccepted)
 	t.cluster1.executeHistoryReplicationTasksUntil(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED)
 
 	for _, c := range []hrsuTestCluster{t.cluster1, t.cluster2} {
@@ -547,8 +581,8 @@ func (t *hrsuTest) enterSplitBrainStateAndAcceptUpdatesInBothClusters(ctx contex
 	// Both clusters now believe they are active and hence both will accept an update.
 
 	// Send updates
-	t.cluster1.sendUpdateAndWaitUntilAccepted(ctx, cluster1UpdateId, "cluster1-update-input")
-	t.cluster2.sendUpdateAndWaitUntilAccepted(ctx, cluster2UpdateId, "cluster2-update-input")
+	t.cluster1.sendUpdateAndWaitUntilStage(ctx, cluster1UpdateId, "cluster1-update-input", sdkclient.WorkflowUpdateStageAccepted)
+	t.cluster2.sendUpdateAndWaitUntilStage(ctx, cluster2UpdateId, "cluster2-update-input", sdkclient.WorkflowUpdateStageAccepted)
 
 	// cluster1 has accepted an update
 	t.s.HistoryRequire.EqualHistoryEvents(fmt.Sprintf(`
@@ -567,6 +601,36 @@ func (t *hrsuTest) enterSplitBrainStateAndAcceptUpdatesInBothClusters(ctx contex
 	4 2 WorkflowTaskCompleted
 	5 2 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "%s", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster2-update-input\""}]}}}}
 	`, cluster2UpdateId), t.cluster2.getHistory(ctx))
+}
+
+func (t *hrsuTest) enterSplitBrainStateAndCompletedUpdatesInBothClusters(ctx context.Context, cluster1UpdateId, cluster2UpdateId string) {
+	t.enterSplitBrainState(ctx)
+
+	// Both clusters now believe they are active and hence both will accept and complete an update.
+
+	// Send updates
+	t.cluster1.sendUpdateAndWaitUntilStage(ctx, cluster1UpdateId, "cluster1-update-input", sdkclient.WorkflowUpdateStageCompleted)
+	t.cluster2.sendUpdateAndWaitUntilStage(ctx, cluster2UpdateId, "cluster2-update-input", sdkclient.WorkflowUpdateStageCompleted)
+
+	// cluster1 has completed an update
+	t.s.HistoryRequire.EqualHistoryEventsAndVersions(fmt.Sprintf(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "%s", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster1-update-input\""}]}}}}
+	6 WorkflowExecutionUpdateCompleted {"Meta":{"UpdateId":"%[1]s"}}
+	`, cluster1UpdateId), []int{1, 1, 1, 1, 1, 1}, t.cluster1.getHistory(ctx))
+
+	// cluster2 has also completed an update (events have failover version 2 since they are endogenous to cluster 2)
+	t.s.HistoryRequire.EqualHistoryEventsAndVersions(fmt.Sprintf(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowExecutionUpdateAccepted {"ProtocolInstanceId": "%s", "AcceptedRequest": {"Input": {"Args": {"Payloads": [{"Data": "\"cluster2-update-input\""}]}}}}
+	6 WorkflowExecutionUpdateCompleted {"Meta":{"UpdateId":"%[1]s"}}
+	`, cluster2UpdateId), []int{1, 1, 2, 2, 2, 2}, t.cluster2.getHistory(ctx))
 }
 
 func (t *hrsuTest) failover1To2(ctx context.Context) {
@@ -713,7 +777,7 @@ func (task *hrsuTestExecutableTask) workflowId() string {
 }
 
 // Update test utilities
-func (c *hrsuTestCluster) sendUpdateAndWaitUntilAccepted(ctx context.Context, updateId string, arg string) {
+func (c *hrsuTestCluster) sendUpdateAndWaitUntilStage(ctx context.Context, updateId string, arg string, stage sdkclient.WorkflowUpdateStage) {
 	updateResponse := make(chan error)
 	processWorkflowTaskResponse := make(chan error)
 	go func() {
@@ -723,7 +787,7 @@ func (c *hrsuTestCluster) sendUpdateAndWaitUntilAccepted(ctx context.Context, up
 			RunID:        c.t.tv.RunID(),
 			UpdateName:   "the-test-doesn't-use-this",
 			Args:         []interface{}{arg},
-			WaitForStage: sdkclient.WorkflowUpdateStageAccepted,
+			WaitForStage: stage,
 		})
 		c.t.s.NoError(err)
 		updateResponse <- err
@@ -731,7 +795,13 @@ func (c *hrsuTestCluster) sendUpdateAndWaitUntilAccepted(ctx context.Context, up
 	go func() {
 		// Blocks until the update request causes a WFT to be dispatched; then sends the update acceptance message
 		// required for the update request to return.
-		processWorkflowTaskResponse <- c.pollAndAcceptUpdate()
+		if stage == sdkclient.WorkflowUpdateStageCompleted {
+			processWorkflowTaskResponse <- c.pollAndAcceptCompleteUpdate(updateId)
+		} else if stage == sdkclient.WorkflowUpdateStageAccepted {
+			processWorkflowTaskResponse <- c.pollAndAcceptUpdate()
+		} else {
+			c.t.s.FailNow("invalid stage")
+		}
 	}()
 	c.t.s.NoError(<-updateResponse)
 	c.t.s.NoError(<-processWorkflowTaskResponse)
@@ -760,6 +830,21 @@ func (c *hrsuTestCluster) pollAndCompleteUpdate(updateId string) error {
 		Identity:            c.t.tv.WorkerIdentity(),
 		WorkflowTaskHandler: c.t.completeUpdateWFTHandler,
 		MessageHandler:      c.completeUpdateMessageHandler(updateId),
+		Logger:              c.t.s.logger,
+		T:                   c.t.s.T(),
+	}
+	_, err := poller.PollAndProcessWorkflowTask()
+	return err
+}
+
+func (c *hrsuTestCluster) pollAndAcceptCompleteUpdate(updateId string) error {
+	poller := &tests.TaskPoller{
+		Client:              c.testCluster.GetFrontendClient(),
+		Namespace:           c.t.tv.NamespaceName().String(),
+		TaskQueue:           c.t.tv.TaskQueue(),
+		Identity:            c.t.tv.WorkerIdentity(),
+		WorkflowTaskHandler: joinResponses(c.t.acceptUpdateWFTHandler, c.t.completeUpdateWFTHandler),
+		MessageHandler:      joinResponses(c.t.acceptUpdateMessageHandler, c.completeUpdateMessageHandler(updateId)),
 		Logger:              c.t.s.logger,
 		T:                   c.t.s.T(),
 	}
@@ -966,4 +1051,18 @@ func (c *hrsuTestCluster) getActiveCluster(ctx context.Context) string {
 	resp, err := c.testCluster.GetFrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{Namespace: c.t.tv.NamespaceName().String()})
 	c.t.s.NoError(err)
 	return resp.ReplicationConfig.ActiveClusterName
+}
+
+func joinResponses[T any](fns ...func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*T, error)) func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*T, error) {
+	return func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*T, error) {
+		var ret []*T
+		for _, fn := range fns {
+			fnRes, err := fn(task)
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, fnRes...)
+		}
+		return ret, nil
+	}
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Check completed Updates when reapplying Updates. Bug fix for #5833.

## Why?
<!-- Tell your future self why have you made these changes -->
Internal Update registry map contains only admitted and accepted but not completed Updates. Previously `Contains` method (which btw breaks `update.Registry` abstraction) didn't check completed Updates.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added functional test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.