### PR TITLE
Use timer instead of context for query no poller wait

### DIFF
--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -245,20 +245,21 @@ func syncOfferTask[T any](
 	}
 
 	fwdrTokenC := tm.fwdrAddReqTokenC()
-	var noPollerCtxC <-chan struct{}
-
-	if returnNoPollerErr {
-		if deadline, ok := ctx.Deadline(); ok && fwdrTokenC == nil {
-			// Reserving 1sec to customize the timeout error if user is querying a workflow
-			// without having started the workers.
-			noPollerTimeout := time.Until(deadline) - time.Second
-			noPollerCtx, cancel := context.WithTimeout(ctx, noPollerTimeout)
-			noPollerCtxC = noPollerCtx.Done()
-			defer cancel()
-		}
-	}
+	var noPollerC <-chan time.Time
 
 	for {
+		if returnNoPollerErr {
+			returnNoPollerErr = false // only do this once
+			if deadline, ok := ctx.Deadline(); ok && fwdrTokenC == nil {
+				// Reserving 1sec to customize the timeout error if user is querying a workflow
+				// without having started the workers.
+				noPollerTimeout := time.Until(deadline) - returnEmptyTaskTimeBudget
+				t := time.NewTimer(noPollerTimeout)
+				noPollerC = t.C
+				defer t.Stop()
+			}
+		}
+
 		select {
 		case taskChan <- task:
 			<-task.responseC
@@ -276,7 +277,7 @@ func syncOfferTask[T any](
 				continue
 			}
 			return t, err
-		case <-noPollerCtxC:
+		case <-noPollerC:
 			// only error if there has not been a recent poller. Otherwise, let it wait for the remaining time
 			// hopping for a match, or ultimately returning the default CDE error.
 			if tm.timeSinceLastPoll() > tm.config.QueryPollerUnavailableWindow() {


### PR DESCRIPTION
## What changed?
Tweak the "return special error if no recent poller when we're near the deadline" logic:
- Use a one-shot timer instead of a context.
- Move it into the loop so that it also can activate in the errForwarderSlowDown case.

## Why?
- Context Done channels are closed, so it becomes a busy loop after close. A timer is more efficient here anyway.
- Use the logic in more potential situations for better error messages.

## How did you test it?
Existing tests. The previous code had correct behavior besides the busy loop.