### PR TITLE
fix xdc test timeout failures

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -205,29 +205,28 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-20.04]
-        name: [cass_es]
-#        name: [cass_es, cass_es8, mysql8, postgres12, postgres12_pgx]
+        name: [cass_es, cass_es8, mysql8, postgres12, postgres12_pgx]
         include:
           - name: cass_es
             persistence_type: nosql
             persistence_driver: elasticsearch
             containers: [cassandra, elasticsearch]
-#          - name: cass_es8
-#            persistence_type: nosql
-#            persistence_driver: elasticsearch
-#            containers: [cassandra, elasticsearch8]
-#          - name: mysql8
-#            persistence_type: sql
-#            persistence_driver: mysql8
-#            containers: [mysql]
-#          - name: postgres12
-#            persistence_type: sql
-#            persistence_driver: postgres12
-#            containers: [postgresql]
-#          - name: postgres12_pgx
-#            persistence_type: sql
-#            persistence_driver: postgres12_pgx
-#            containers: [postgresql]
+          - name: cass_es8
+            persistence_type: nosql
+            persistence_driver: elasticsearch
+            containers: [cassandra, elasticsearch8]
+          - name: mysql8
+            persistence_type: sql
+            persistence_driver: mysql8
+            containers: [mysql]
+          - name: postgres12
+            persistence_type: sql
+            persistence_driver: postgres12
+            containers: [postgresql]
+          - name: postgres12_pgx
+            persistence_type: sql
+            persistence_driver: postgres12_pgx
+            containers: [postgresql]
     runs-on: ${{ matrix.runs-on }}
     env:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -30,6 +30,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -80,6 +81,9 @@ type AdvVisCrossDCTestSuite struct {
 
 	testSearchAttributeKey string
 	testSearchAttributeVal string
+
+	startTime          time.Time
+	onceClusterConnect sync.Once
 }
 
 func TestAdvVisCrossDCTestSuite(t *testing.T) {
@@ -136,6 +140,8 @@ func (s *AdvVisCrossDCTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 	s.cluster2 = c
 
+	s.startTime = time.Now()
+
 	cluster1Address := clusterConfigs[0].ClusterMetadata.ClusterInformation[clusterConfigs[0].ClusterMetadata.CurrentClusterName].RPCAddress
 	cluster2Address := clusterConfigs[1].ClusterMetadata.ClusterInformation[clusterConfigs[1].ClusterMetadata.CurrentClusterName].RPCAddress
 	_, err = s.cluster1.GetAdminClient().AddOrUpdateRemoteCluster(tests.NewContext(), &adminservice.AddOrUpdateRemoteClusterRequest{
@@ -161,6 +167,11 @@ func (s *AdvVisCrossDCTestSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
 	s.HistoryRequire = historyrequire.New(s.T())
+
+	s.onceClusterConnect.Do(func() {
+		waitForClusterConnected(s.Assertions, s.logger, s.cluster1, clusterNameAdvVis[0], clusterNameAdvVis[1], s.startTime)
+		waitForClusterConnected(s.Assertions, s.logger, s.cluster2, clusterNameAdvVis[1], clusterNameAdvVis[0], s.startTime)
+	})
 }
 
 func (s *AdvVisCrossDCTestSuite) TearDownSuite() {

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -32,6 +32,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -75,7 +76,8 @@ type (
 		logger                 log.Logger
 		dynamicConfigOverrides map[dynamicconfig.Key]interface{}
 
-		startTime time.Time
+		startTime          time.Time
+		onceClusterConnect sync.Once
 	}
 )
 
@@ -101,6 +103,7 @@ func (s *xdcBaseSuite) setupSuite(clusterNames []string, opts ...tests.Option) {
 	if s.dynamicConfigOverrides == nil {
 		s.dynamicConfigOverrides = make(map[dynamicconfig.Key]interface{})
 	}
+	s.dynamicConfigOverrides[dynamicconfig.ClusterMetadataRefreshInterval.Key()] = time.Second * 5
 
 	fileName := "../testdata/xdc_clusters.yaml"
 	if tests.TestFlags.TestClusterConfigFile != "" {
@@ -166,11 +169,18 @@ func (s *xdcBaseSuite) setupSuite(clusterNames []string, opts ...tests.Option) {
 	time.Sleep(time.Millisecond * 200)
 }
 
-func (s *xdcBaseSuite) waitForClusterConnected() {
-	s.logger.Info("wait for cluster to be connected")
+func waitForClusterConnected(
+	s *require.Assertions,
+	logger log.Logger,
+	sourceCluster *tests.TestCluster,
+	source string,
+	target string,
+	startTime time.Time,
+) {
+	logger.Info("wait for clusters to be synced", tag.SourceCluster(source), tag.TargetCluster(target))
 	s.EventuallyWithT(func(c *assert.CollectT) {
-		s.logger.Info("check if stream is established")
-		resp, err := s.cluster1.GetHistoryClient().GetReplicationStatus(context.Background(), &historyservice.GetReplicationStatusRequest{})
+		logger.Info("check if clusters are synced", tag.SourceCluster(source), tag.TargetCluster(target))
+		resp, err := sourceCluster.GetHistoryClient().GetReplicationStatus(context.Background(), &historyservice.GetReplicationStatusRequest{})
 		if !assert.NoError(c, err) {
 			return
 		}
@@ -182,17 +192,18 @@ func (s *xdcBaseSuite) waitForClusterConnected() {
 		}
 		assert.Greater(c, shard.MaxReplicationTaskId, int64(0))
 		assert.NotNil(c, shard.ShardLocalTime)
-		assert.WithinRange(c, shard.ShardLocalTime.AsTime(), s.startTime, time.Now())
+		assert.WithinRange(c, shard.ShardLocalTime.AsTime(), startTime, time.Now())
 		assert.NotNil(c, shard.RemoteClusters)
 
-		standbyAckInfo, ok := shard.RemoteClusters[s.clusterNames[1]]
+		standbyAckInfo, ok := shard.RemoteClusters[target]
 		if !assert.True(c, ok) || !assert.NotNil(c, standbyAckInfo) {
 			return
 		}
+		assert.LessOrEqual(c, shard.MaxReplicationTaskId, standbyAckInfo.AckedTaskId)
 		assert.NotNil(c, standbyAckInfo.AckedTaskVisibilityTime)
-		assert.WithinRange(c, standbyAckInfo.AckedTaskVisibilityTime.AsTime(), s.startTime, time.Now())
-	}, 60*time.Second, 1*time.Second)
-	s.logger.Info("cluster connected")
+		assert.WithinRange(c, standbyAckInfo.AckedTaskVisibilityTime.AsTime(), startTime, time.Now())
+	}, 90*time.Second, 1*time.Second)
+	logger.Info("clusters synced", tag.SourceCluster(source), tag.TargetCluster(target))
 }
 
 func (s *xdcBaseSuite) tearDownSuite() {
@@ -206,7 +217,10 @@ func (s *xdcBaseSuite) setupTest() {
 	s.ProtoAssertions = protorequire.New(s.T())
 	s.HistoryRequire = historyrequire.New(s.T())
 
-	s.waitForClusterConnected()
+	s.onceClusterConnect.Do(func() {
+		waitForClusterConnected(s.Assertions, s.logger, s.cluster1, s.clusterNames[0], s.clusterNames[1], s.startTime)
+		waitForClusterConnected(s.Assertions, s.logger, s.cluster2, s.clusterNames[1], s.clusterNames[0], s.startTime)
+	})
 }
 
 func (s *xdcBaseSuite) createGlobalNamespace() string {


### PR DESCRIPTION
## What changed?
Fix xdc test timeout failures by ensure test clusters are connected and synced before operations.

## Why?
If clusters are not connected or not synced yet, replication tasks will not be synced to target cluster. So if there is any check waiting for the specific replication task, the check will stuck.

## How did you test it?
reran tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
