### PR TITLE
sql: Only update last refresh time when we refresh

### DIFF
--- a/common/persistence/sql/sqlplugin/db_handle.go
+++ b/common/persistence/sql/sqlplugin/db_handle.go
@@ -110,7 +110,6 @@ func (h *DatabaseHandle) reconnect(force bool) *sqlx.DB {
 
 	now := time.Now()
 	lastRefresh := h.lastRefresh
-	h.lastRefresh = now
 	if now.Sub(lastRefresh) < sessionRefreshMinInternal {
 		h.logger.Warn("sql handle: did not refresh database connection pool because the last refresh was too close",
 			tag.NewDurationTag("min_refresh_interval_seconds", sessionRefreshMinInternal))
@@ -119,6 +118,7 @@ func (h *DatabaseHandle) reconnect(force bool) *sqlx.DB {
 		return nil
 	}
 
+	h.lastRefresh = now
 	newConn, err := h.connect()
 	if err != nil {
 		h.logger.Error("sql handle: unable to refresh database connection pool", tag.Error(err))


### PR DESCRIPTION
Fixes #6514 

## What changed?
I fixed a bug in our sql `DBHandle` that could cause us to never reconnect to the database when an issue occurs.

## Why?
We should only update the last refresh time when we actually refresh. As written we always update the last refresh time even when we don't refresh.

If _every_ attempt to reconnect happens within
`sessionRefreshMinInterval` of the last attempt, the server will _never_ actually reconnect as it will just keep bumping the last refresh...

## How did you test it?
Existing tests

## Potential risks
None

## Documentation
No changes

## Is hotfix candidate?
Absolutely (cc @yiminc)
