### PR TITLE
Send non-reachability DescribeTaskQueue requests through frontend rate limiter

### DIFF
--- a/common/rpc/interceptor/rate_limit.go
+++ b/common/rpc/interceptor/rate_limit.go
@@ -26,11 +26,11 @@ package interceptor
 
 import (
 	"context"
-	"go.temporal.io/api/workflowservice/v1"
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/quotas"
 	"google.golang.org/grpc"

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -163,7 +163,7 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkerTaskReachability":         1,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListSchedules":                     1,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListBatchOperations":               1,
-		"/temporal.api.workflowservice.v1.WorkflowService/DescribeTaskQueueWithReachability": 1,
+		"/temporal.api.workflowservice.v1.WorkflowService/DescribeTaskQueueWithReachability": 1, // note this isn't a real method name
 	}
 
 	VisibilityAPIPrioritiesOrdered = []int{0, 1}

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -110,6 +110,7 @@ var (
 
 		// P3: Status Querying APIs
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorkflowExecution":     3,
+		"/temporal.api.workflowservice.v1.WorkflowService/DescribeTaskQueue":             3,
 		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkerBuildIdCompatibility": 3,
 		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkerVersioningRules":      3,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListTaskQueuePartitions":       3,
@@ -159,10 +160,10 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/ListArchivedWorkflowExecutions": 1,
 
 		// APIs that rely on visibility
-		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkerTaskReachability": 1,
-		"/temporal.api.workflowservice.v1.WorkflowService/ListSchedules":             1,
-		"/temporal.api.workflowservice.v1.WorkflowService/ListBatchOperations":       1,
-		"/temporal.api.workflowservice.v1.WorkflowService/DescribeTaskQueue":         1,
+		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkerTaskReachability":         1,
+		"/temporal.api.workflowservice.v1.WorkflowService/ListSchedules":                     1,
+		"/temporal.api.workflowservice.v1.WorkflowService/ListBatchOperations":               1,
+		"/temporal.api.workflowservice.v1.WorkflowService/DescribeTaskQueueWithReachability": 1,
 	}
 
 	VisibilityAPIPrioritiesOrdered = []int{0, 1}

--- a/service/frontend/configs/quotas_test.go
+++ b/service/frontend/configs/quotas_test.go
@@ -117,10 +117,10 @@ func (s *quotasSuite) TestVisibilityAPIs() {
 		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkflowExecutions":         {},
 		"/temporal.api.workflowservice.v1.WorkflowService/ListArchivedWorkflowExecutions": {},
 
-		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkerTaskReachability": {},
-		"/temporal.api.workflowservice.v1.WorkflowService/ListSchedules":             {},
-		"/temporal.api.workflowservice.v1.WorkflowService/ListBatchOperations":       {},
-		"/temporal.api.workflowservice.v1.WorkflowService/DescribeTaskQueue":         {},
+		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkerTaskReachability":         {},
+		"/temporal.api.workflowservice.v1.WorkflowService/ListSchedules":                     {},
+		"/temporal.api.workflowservice.v1.WorkflowService/ListBatchOperations":               {},
+		"/temporal.api.workflowservice.v1.WorkflowService/DescribeTaskQueueWithReachability": {},
 	}
 
 	var service workflowservice.WorkflowServiceServer
@@ -128,6 +128,9 @@ func (s *quotasSuite) TestVisibilityAPIs() {
 	apiToPriority := make(map[string]int, t.NumMethod())
 	for i := 0; i < t.NumMethod(); i++ {
 		apiName := "/temporal.api.workflowservice.v1.WorkflowService/" + t.Method(i).Name
+		if t.Method(i).Name == "DescribeTaskQueue" {
+			apiName += "WithReachability"
+		}
 		if _, ok := apis[apiName]; ok {
 			apiToPriority[apiName] = VisibilityAPIToPriority[apiName]
 		}


### PR DESCRIPTION
## What changed?
Previously, all DescribeTaskQueue requests use visibility rate limiter, which is too restrictive for non-reachability requests. Fix that by checking in the interceptor.

## Why?
So that people interested in only the backlog data don't have to be rate-limited as if they are querying reachability when they are not.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
