### PR TITLE
Handling concurrent stale reads

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -2023,7 +2023,6 @@ func (e *matchingEngineImpl) updatePhysicalTaskQueueGauge(pqm *physicalTaskQueue
 	e.gaugeMetrics.lock.Lock()
 	e.gaugeMetrics.loadedPhysicalTaskQueueCount[physicalTaskQueueParameters] += delta
 	loadedPhysicalTaskQueueCounter := e.gaugeMetrics.loadedPhysicalTaskQueueCount[physicalTaskQueueParameters]
-	e.gaugeMetrics.lock.Unlock()
 
 	pm := pqm.partitionMgr
 	metrics.LoadedPhysicalTaskQueueGauge.With(
@@ -2038,6 +2037,7 @@ func (e *matchingEngineImpl) updatePhysicalTaskQueueGauge(pqm *physicalTaskQueue
 		float64(loadedPhysicalTaskQueueCounter),
 		metrics.VersionedTag(versioned),
 	)
+	e.gaugeMetrics.lock.Unlock()
 }
 
 // Responsible for emitting and updating loaded_task_queue_family_count, loaded_task_queue_count and
@@ -2060,6 +2060,8 @@ func (e *matchingEngineImpl) updateTaskQueuePartitionGauge(pm taskQueuePartition
 	}
 
 	rootPartition := pm.Partition().IsRoot()
+	nsName := pm.Namespace().Name().String()
+
 	e.gaugeMetrics.lock.Lock()
 
 	loadedTaskQueueFamilyCounter, loadedTaskQueueCounter, loadedTaskQueuePartitionCounter :=
@@ -2076,9 +2078,6 @@ func (e *matchingEngineImpl) updateTaskQueuePartitionGauge(pm taskQueuePartition
 			e.gaugeMetrics.loadedTaskQueueFamilyCount[taskQueueFamilyParameters] = loadedTaskQueueFamilyCounter
 		}
 	}
-	e.gaugeMetrics.lock.Unlock()
-
-	nsName := pm.Namespace().Name().String()
 
 	e.metricsHandler.Gauge(metrics.LoadedTaskQueueFamilyGauge.Name()).Record(
 		float64(loadedTaskQueueFamilyCounter),
@@ -2100,6 +2099,7 @@ func (e *matchingEngineImpl) updateTaskQueuePartitionGauge(pm taskQueuePartition
 		false, // we don't want breakdown by partition ID, only sticky vs normal breakdown.
 	)
 	metrics.LoadedTaskQueuePartitionGauge.With(taggedHandler).Record(float64(loadedTaskQueuePartitionCounter))
+	e.gaugeMetrics.lock.Unlock()
 }
 
 // Populate the workflow task response based on context and scheduled/started events.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- While emitting TQ based metrics, I noticed that there was a `Lock` being held while writing to variables inside a shared structure. However, the lock was being released before these variables were being emitted as metrics.
- **NOTE**: I considered replacing the current mutex with a `RWMutex`. However, I decided against it due to its larger overhead + writes being prominent. (imo, when we have less writes and frequent reads, we should go ahead with a `RWMutex`)

## Why?
<!-- Tell your future self why have you made these changes -->
- My intuition is that releasing the lock before emitting the metrics could result in stale reads.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- None, if anything it should resolve a weird case of negative task queue metrics.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
nope
