### PR TITLE
Consistent tags for `task_schedule_to_start_latency` metric

### DIFF
--- a/common/metrics/metricstest/task_queues_test.go
+++ b/common/metrics/metricstest/task_queues_test.go
@@ -53,28 +53,46 @@ func TestPerTaskQueueScope(t *testing.T) {
 	)
 }
 
-func TestPerTaskQueuePartitionScope_Normal(t *testing.T) {
+func TestPerTaskQueuePartitionIDScope_Normal(t *testing.T) {
 	ns := "my_ns"
 	p := tqid.UnsafeTaskQueueFamily("ns_id", "my_tq").TaskQueue(enums.TASK_QUEUE_TYPE_WORKFLOW).NormalPartition(1)
 	verifyTags(t,
-		metrics.GetPerTaskQueuePartitionScope(NewCaptureHandler(), ns, p, true, false),
+		metrics.GetPerTaskQueuePartitionIDScope(NewCaptureHandler(), ns, p, true, false),
 		map[string]string{"namespace": ns, "taskqueue": p.TaskQueue().Name(), "task_type": "Workflow", "partition": normal},
 	)
 	verifyTags(t,
-		metrics.GetPerTaskQueuePartitionScope(NewCaptureHandler(), ns, p, true, true),
+		metrics.GetPerTaskQueuePartitionIDScope(NewCaptureHandler(), ns, p, true, true),
 		map[string]string{"namespace": ns, "taskqueue": p.TaskQueue().Name(), "task_type": "Workflow", "partition": "1"},
 	)
 }
 
-func TestPerTaskQueuePartitionScope_Sticky(t *testing.T) {
+func TestPerTaskQueuePartitionIDScope_Sticky(t *testing.T) {
 	ns := "my_ns"
 	p := tqid.UnsafeTaskQueueFamily("ns_id", "my_tq").TaskQueue(enums.TASK_QUEUE_TYPE_WORKFLOW).StickyPartition("abc")
 	verifyTags(t,
-		metrics.GetPerTaskQueuePartitionScope(NewCaptureHandler(), ns, p, true, false),
+		metrics.GetPerTaskQueuePartitionTypeScope(NewCaptureHandler(), ns, p, true),
+		map[string]string{"namespace": ns, "taskqueue": p.TaskQueue().Name(), "task_type": "Workflow", "partition": sticky},
+	)
+}
+
+func TestPerTaskQueuePartitionTypeScope_Normal(t *testing.T) {
+	ns := "my_ns"
+	p := tqid.UnsafeTaskQueueFamily("ns_id", "my_tq").TaskQueue(enums.TASK_QUEUE_TYPE_WORKFLOW).NormalPartition(1)
+	verifyTags(t,
+		metrics.GetPerTaskQueuePartitionTypeScope(NewCaptureHandler(), ns, p, true),
+		map[string]string{"namespace": ns, "taskqueue": p.TaskQueue().Name(), "task_type": "Workflow", "partition": normal},
+	)
+}
+
+func TestPerTaskQueuePartitionTypeScope_Sticky(t *testing.T) {
+	ns := "my_ns"
+	p := tqid.UnsafeTaskQueueFamily("ns_id", "my_tq").TaskQueue(enums.TASK_QUEUE_TYPE_WORKFLOW).StickyPartition("abc")
+	verifyTags(t,
+		metrics.GetPerTaskQueuePartitionIDScope(NewCaptureHandler(), ns, p, true, false),
 		map[string]string{"namespace": ns, "taskqueue": p.TaskQueue().Name(), "task_type": "Workflow", "partition": sticky},
 	)
 	verifyTags(t,
-		metrics.GetPerTaskQueuePartitionScope(NewCaptureHandler(), ns, p, true, true),
+		metrics.GetPerTaskQueuePartitionIDScope(NewCaptureHandler(), ns, p, true, true),
 		map[string]string{"namespace": ns, "taskqueue": p.TaskQueue().Name(), "task_type": "Workflow", "partition": sticky},
 	)
 }

--- a/common/metrics/metricstest/task_queues_test.go
+++ b/common/metrics/metricstest/task_queues_test.go
@@ -70,7 +70,11 @@ func TestPerTaskQueuePartitionIDScope_Sticky(t *testing.T) {
 	ns := "my_ns"
 	p := tqid.UnsafeTaskQueueFamily("ns_id", "my_tq").TaskQueue(enums.TASK_QUEUE_TYPE_WORKFLOW).StickyPartition("abc")
 	verifyTags(t,
-		metrics.GetPerTaskQueuePartitionTypeScope(NewCaptureHandler(), ns, p, true),
+		metrics.GetPerTaskQueuePartitionIDScope(NewCaptureHandler(), ns, p, true, false),
+		map[string]string{"namespace": ns, "taskqueue": p.TaskQueue().Name(), "task_type": "Workflow", "partition": sticky},
+	)
+	verifyTags(t,
+		metrics.GetPerTaskQueuePartitionIDScope(NewCaptureHandler(), ns, p, true, true),
 		map[string]string{"namespace": ns, "taskqueue": p.TaskQueue().Name(), "task_type": "Workflow", "partition": sticky},
 	)
 }
@@ -88,11 +92,7 @@ func TestPerTaskQueuePartitionTypeScope_Sticky(t *testing.T) {
 	ns := "my_ns"
 	p := tqid.UnsafeTaskQueueFamily("ns_id", "my_tq").TaskQueue(enums.TASK_QUEUE_TYPE_WORKFLOW).StickyPartition("abc")
 	verifyTags(t,
-		metrics.GetPerTaskQueuePartitionIDScope(NewCaptureHandler(), ns, p, true, false),
-		map[string]string{"namespace": ns, "taskqueue": p.TaskQueue().Name(), "task_type": "Workflow", "partition": sticky},
-	)
-	verifyTags(t,
-		metrics.GetPerTaskQueuePartitionIDScope(NewCaptureHandler(), ns, p, true, true),
+		metrics.GetPerTaskQueuePartitionTypeScope(NewCaptureHandler(), ns, p, true),
 		map[string]string{"namespace": ns, "taskqueue": p.TaskQueue().Name(), "task_type": "Workflow", "partition": sticky},
 	)
 }

--- a/common/metrics/task_queues.go
+++ b/common/metrics/task_queues.go
@@ -80,7 +80,11 @@ func GetPerTaskQueuePartitionIDScope(
 	if partition == nil {
 		value = unknownValue
 	} else if normalPartition, ok := partition.(*tqid.NormalPartition); ok {
-		value = strconv.Itoa(normalPartition.PartitionId())
+		if partitionIDBreakdown {
+			value = strconv.Itoa(normalPartition.PartitionId())
+		} else {
+			value = normal
+		}
 	} else {
 		value = sticky
 	}

--- a/common/metrics/task_queues.go
+++ b/common/metrics/task_queues.go
@@ -66,7 +66,7 @@ func GetPerTaskQueueScope(
 		append(tags, TaskQueueTypeTag(taskQueue.TaskType()))...)
 }
 
-// GetPerTaskQueuePartitionIDScope similar to GetPerTaskQueuePartitionTypeScope, except that the partition tag will
+// GetPerTaskQueuePartitionIDScope is similar to GetPerTaskQueuePartitionTypeScope, except that the partition tag will
 // hold the normal partition ID if partitionIDBreakdown is true.
 func GetPerTaskQueuePartitionIDScope(
 	handler Handler,

--- a/common/tqid/task_queue_id.go
+++ b/common/tqid/task_queue_id.go
@@ -136,7 +136,8 @@ func NewTaskQueueFamily(namespaceId string, name string) (*TaskQueueFamily, erro
 	}, nil
 }
 
-// UnsafeTaskQueueFamily should be avoided as much as possible. Use NewTaskQueueFamily instead as it validates the tq name.
+// UnsafeTaskQueueFamily returns a TaskQueueFamily object without validating the task queue name.
+// This method should only be used in logs/metrics, not in the server logic (use NewTaskQueueFamily instead).
 func UnsafeTaskQueueFamily(namespaceId string, name string) *TaskQueueFamily {
 	return &TaskQueueFamily{namespaceId, name}
 }

--- a/service/history/api/recordworkflowtaskstarted/api.go
+++ b/service/history/api/recordworkflowtaskstarted/api.go
@@ -173,12 +173,11 @@ func Invoke(
 			namespaceName := namespaceEntry.Name()
 			tqPartition := tqid.UnsafePartitionFromProto(workflowTask.TaskQueue, req.GetNamespaceId(), enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 			metrics.TaskScheduleToStartLatency.With(
-				metrics.GetPerTaskQueuePartitionScope(
+				metrics.GetPerTaskQueuePartitionTypeScope(
 					metricsScope,
 					namespaceName.String(),
 					tqPartition,
 					config.BreakdownMetricsByTaskQueue(namespaceName.String(), tqPartition.TaskQueue().Name(), enumspb.TASK_QUEUE_TYPE_WORKFLOW),
-					false, // we don't want breakdown by normal partition, only sticky vs normal breakdown.
 				),
 			).Record(workflowScheduleToStartLatency)
 

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -136,7 +136,7 @@ func (h *Handler) opMetricsHandler(
 ) metrics.Handler {
 	nsName := h.namespaceName(namespace.ID(namespaceID))
 	partition := tqid.UnsafePartitionFromProto(taskQueue, namespaceID, taskQueueType)
-	return metrics.GetPerTaskQueuePartitionScope(
+	return metrics.GetPerTaskQueuePartitionIDScope(
 		h.metricsHandler.WithTags(metrics.OperationTag(operation)),
 		nsName.String(),
 		partition,

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -1987,13 +1987,12 @@ func (e *matchingEngineImpl) updatePhysicalTaskQueueGauge(pqm *physicalTaskQueue
 
 	pm := pqm.partitionMgr
 	metrics.LoadedPhysicalTaskQueueGauge.With(
-		metrics.GetPerTaskQueuePartitionScope(
+		metrics.GetPerTaskQueuePartitionTypeScope(
 			e.metricsHandler,
 			pm.ns.Name().String(),
 			pm.Partition(),
 			// TODO: Track counters per TQ name so we can honor pm.config.BreakdownMetricsByTaskQueue(),
 			false,
-			false, // we don't want breakdown by partition ID, only sticky vs normal breakdown.
 		)).Record(
 		float64(loadedPhysicalTaskQueueCounter),
 		metrics.VersionedTag(versioned),
@@ -2051,13 +2050,12 @@ func (e *matchingEngineImpl) updateTaskQueuePartitionGauge(pm taskQueuePartition
 		metrics.TaskQueueTypeTag(taskQueueParameters.taskType),
 	)
 
-	taggedHandler := metrics.GetPerTaskQueuePartitionScope(
+	taggedHandler := metrics.GetPerTaskQueuePartitionTypeScope(
 		e.metricsHandler,
 		nsName,
 		pm.Partition(),
 		// TODO: Track counters per TQ name so we can honor pm.config.BreakdownMetricsByTaskQueue(),
 		false,
-		false, // we don't want breakdown by partition ID, only sticky vs normal breakdown.
 	)
 	metrics.LoadedTaskQueuePartitionGauge.With(taggedHandler).Record(float64(loadedTaskQueuePartitionCounter))
 }

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -97,7 +97,7 @@ func newTaskQueuePartitionManager(
 		tag.WorkflowTaskQueueName(partition.RpcName()),
 		tag.WorkflowTaskQueueType(partition.TaskType()),
 		tag.WorkflowNamespace(nsName))
-	taggedMetricsHandler := metrics.GetPerTaskQueuePartitionScope(
+	taggedMetricsHandler := metrics.GetPerTaskQueuePartitionIDScope(
 		e.metricsHandler,
 		nsName,
 		partition,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Refactored code to emit the same number of tags in the task_schedule_to_start_latency metric.

## Why?
<!-- Tell your future self why have you made these changes -->
Previously we were using both GetPerTaskQueueFamilyScope and GetPerTaskQueuePartitionScope for the same metric, now we only use GetPerTaskQueuePartitionTypeScope.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
None.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
None.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.