### PR TITLE
Fix replicationspb import name in tests

### DIFF
--- a/tests/ndc/ndc_test.go
+++ b/tests/ndc/ndc_test.go
@@ -51,7 +51,7 @@ import (
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/persistence/v1"
-	replicationpb "go.temporal.io/server/api/replication/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/client/history"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/failure"
@@ -95,7 +95,7 @@ type (
 		version                     int64
 		versionIncrement            int64
 		mockAdminClient             map[string]adminservice.AdminServiceClient
-		standByReplicationTasksChan chan *replicationpb.ReplicationTask
+		standByReplicationTasksChan chan *replicationspb.ReplicationTask
 		standByTaskID               int64
 	}
 )
@@ -130,8 +130,8 @@ func (s *NDCFunctionalTestSuite) SetupSuite() {
 	mockStreamClient.EXPECT().Send(gomock.Any()).Return(nil).AnyTimes()
 	mockStreamClient.EXPECT().Recv().Return(&adminservice.StreamWorkflowReplicationMessagesResponse{
 		Attributes: &adminservice.StreamWorkflowReplicationMessagesResponse_Messages{
-			Messages: &replicationpb.WorkflowReplicationMessages{
-				ReplicationTasks:           []*replicationpb.ReplicationTask{},
+			Messages: &replicationspb.WorkflowReplicationMessages{
+				ReplicationTasks:           []*replicationspb.ReplicationTask{},
 				ExclusiveHighWatermark:     100,
 				ExclusiveHighWatermarkTime: timestamppb.New(time.Unix(0, 100)),
 			},
@@ -139,7 +139,7 @@ func (s *NDCFunctionalTestSuite) SetupSuite() {
 	}, nil).AnyTimes()
 	mockStreamClient.EXPECT().CloseSend().Return(nil).AnyTimes()
 
-	s.standByReplicationTasksChan = make(chan *replicationpb.ReplicationTask, 100)
+	s.standByReplicationTasksChan = make(chan *replicationspb.ReplicationTask, 100)
 
 	s.standByTaskID = 0
 	mockStandbyClient := adminservicemock.NewMockAdminServiceClient(s.controller)
@@ -148,7 +148,7 @@ func (s *NDCFunctionalTestSuite) SetupSuite() {
 	mockOtherClient := adminservicemock.NewMockAdminServiceClient(s.controller)
 	mockOtherClient.EXPECT().GetReplicationMessages(gomock.Any(), gomock.Any()).Return(
 		&adminservice.GetReplicationMessagesResponse{
-			ShardMessages: make(map[int32]*replicationpb.ReplicationMessages),
+			ShardMessages: make(map[int32]*replicationspb.ReplicationMessages),
 		}, nil).AnyTimes()
 	mockOtherClient.EXPECT().StreamWorkflowReplicationMessages(gomock.Any()).Return(mockStreamClient, nil).AnyTimes()
 	s.mockAdminClient = map[string]adminservice.AdminServiceClient{
@@ -177,7 +177,7 @@ func (s *NDCFunctionalTestSuite) GetReplicationMessagesMock(
 	case task := <-s.standByReplicationTasksChan:
 		taskID := atomic.AddInt64(&s.standByTaskID, 1)
 		task.SourceTaskId = taskID
-		tasks := []*replicationpb.ReplicationTask{task}
+		tasks := []*replicationspb.ReplicationTask{task}
 		for len(s.standByReplicationTasksChan) > 0 {
 			task = <-s.standByReplicationTasksChan
 			taskID := atomic.AddInt64(&s.standByTaskID, 1)
@@ -185,18 +185,18 @@ func (s *NDCFunctionalTestSuite) GetReplicationMessagesMock(
 			tasks = append(tasks, task)
 		}
 
-		replicationMessage := &replicationpb.ReplicationMessages{
+		replicationMessage := &replicationspb.ReplicationMessages{
 			ReplicationTasks:       tasks,
 			LastRetrievedMessageId: tasks[len(tasks)-1].SourceTaskId,
 			HasMore:                true,
 		}
 
 		return &adminservice.GetReplicationMessagesResponse{
-			ShardMessages: map[int32]*replicationpb.ReplicationMessages{1: replicationMessage},
+			ShardMessages: map[int32]*replicationspb.ReplicationMessages{1: replicationMessage},
 		}, nil
 	default:
 		return &adminservice.GetReplicationMessagesResponse{
-			ShardMessages: make(map[int32]*replicationpb.ReplicationMessages),
+			ShardMessages: make(map[int32]*replicationspb.ReplicationMessages),
 		}, nil
 	}
 }
@@ -2288,11 +2288,11 @@ func (s *NDCFunctionalTestSuite) applyEventsThroughFetcher(
 		eventBlob, newRunEventBlob, newRunID := s.generateEventBlobs(workflowID, runID, workflowType, taskqueue, batch)
 
 		taskType := enumsspb.REPLICATION_TASK_TYPE_HISTORY_V2_TASK
-		replicationTask := &replicationpb.ReplicationTask{
+		replicationTask := &replicationspb.ReplicationTask{
 			TaskType:     taskType,
 			SourceTaskId: 1,
-			Attributes: &replicationpb.ReplicationTask_HistoryTaskAttributes{
-				HistoryTaskAttributes: &replicationpb.HistoryTaskAttributes{
+			Attributes: &replicationspb.ReplicationTask_HistoryTaskAttributes{
+				HistoryTaskAttributes: &replicationspb.HistoryTaskAttributes{
 					NamespaceId:         s.namespaceID.String(),
 					WorkflowId:          workflowID,
 					RunId:               runID,

--- a/tests/ndc/replication_task_batching_test.go
+++ b/tests/ndc/replication_task_batching_test.go
@@ -45,7 +45,7 @@ import (
 	"go.temporal.io/server/api/adminservicemock/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
-	repicationpb "go.temporal.io/server/api/replication/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -70,7 +70,7 @@ type (
 		suite.Suite
 
 		testClusterFactory          tests.TestClusterFactory
-		standByReplicationTasksChan chan *repicationpb.ReplicationTask
+		standByReplicationTasksChan chan *replicationspb.ReplicationTask
 		mockAdminClient             map[string]adminservice.AdminServiceClient
 		namespace                   namespace.Name
 		namespaceID                 namespace.ID
@@ -128,7 +128,7 @@ func (s *NDCReplicationTaskBatchingTestSuite) SetupSuite() {
 		return s.GetReplicationMessagesMock()
 	}).AnyTimes()
 	mockActiveStreamClient.EXPECT().CloseSend().Return(nil).AnyTimes()
-	s.standByReplicationTasksChan = make(chan *repicationpb.ReplicationTask, 100)
+	s.standByReplicationTasksChan = make(chan *replicationspb.ReplicationTask, 100)
 
 	mockActiveClient := adminservicemock.NewMockAdminServiceClient(s.controller)
 	mockActiveClient.EXPECT().StreamWorkflowReplicationMessages(gomock.Any()).Return(mockActiveStreamClient, nil).AnyTimes()
@@ -269,9 +269,9 @@ func (s *NDCReplicationTaskBatchingTestSuite) GetReplicationMessagesMock() (*adm
 	task := <-s.standByReplicationTasksChan
 	taskID := atomic.AddInt64(&s.standByTaskID, 1)
 	task.SourceTaskId = taskID
-	tasks := []*repicationpb.ReplicationTask{task}
+	tasks := []*replicationspb.ReplicationTask{task}
 
-	replicationMessage := &repicationpb.WorkflowReplicationMessages{
+	replicationMessage := &replicationspb.WorkflowReplicationMessages{
 		ReplicationTasks:       tasks,
 		ExclusiveHighWatermark: taskID + 1,
 	}
@@ -290,7 +290,7 @@ func (s *NDCReplicationTaskBatchingTestSuite) createHistoryEventReplicationTaskF
 	events []*historypb.HistoryEvent,
 	newRunEvents []*historypb.HistoryEvent,
 	versionHistoryItems []*historyspb.VersionHistoryItem,
-) *repicationpb.ReplicationTask {
+) *replicationspb.ReplicationTask {
 	eventBlob, err := s.serializer.SerializeEvents(events, enumspb.ENCODING_TYPE_PROTO3)
 	var newRunEventBlob *commonpb.DataBlob
 	if newRunEvents != nil {
@@ -299,10 +299,10 @@ func (s *NDCReplicationTaskBatchingTestSuite) createHistoryEventReplicationTaskF
 	}
 	s.NoError(err)
 	taskType := enumsspb.REPLICATION_TASK_TYPE_HISTORY_V2_TASK
-	replicationTask := &repicationpb.ReplicationTask{
+	replicationTask := &replicationspb.ReplicationTask{
 		TaskType: taskType,
-		Attributes: &repicationpb.ReplicationTask_HistoryTaskAttributes{
-			HistoryTaskAttributes: &repicationpb.HistoryTaskAttributes{
+		Attributes: &replicationspb.ReplicationTask_HistoryTaskAttributes{
+			HistoryTaskAttributes: &replicationspb.HistoryTaskAttributes{
 				NamespaceId:         namespaceId,
 				WorkflowId:          workflowId,
 				RunId:               runId,


### PR DESCRIPTION
## What changed?
Fix `replicationspb` import name in tests

## Why?
consistent naming