### PR TITLE
Improve dynamic config memory client removing overrides

### DIFF
--- a/common/dynamicconfig/memory_client_test.go
+++ b/common/dynamicconfig/memory_client_test.go
@@ -1,0 +1,67 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dynamicconfig_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+func TestMemoryClient(t *testing.T) {
+	c := dynamicconfig.NewMemoryClient()
+	k := dynamicconfig.Key("key")
+
+	// plain override
+	assert.Nil(t, c.GetValue(k))
+	remove := c.OverrideValue(k, 123)
+	assert.Equal(t, []dynamicconfig.ConstrainedValue{{Value: 123}}, c.GetValue(k))
+	remove()
+	assert.Nil(t, c.GetValue(k))
+
+	// two levels, pop in correct order
+	remove1 := c.OverrideValue(k, 123)
+	remove2 := c.OverrideValue(k, 456)
+	assert.Equal(t, []dynamicconfig.ConstrainedValue{{Value: 456}}, c.GetValue(k))
+	remove2()
+	assert.Equal(t, []dynamicconfig.ConstrainedValue{{Value: 123}}, c.GetValue(k))
+	remove1()
+	assert.Nil(t, c.GetValue(k))
+
+	// three levels, pop in wrong order
+	remove1 = c.OverrideValue(k, 123)
+	remove2 = c.OverrideValue(k, 456)
+	remove3 := c.OverrideValue(k, 789)
+	assert.Equal(t, []dynamicconfig.ConstrainedValue{{Value: 789}}, c.GetValue(k))
+	remove2()
+	assert.Equal(t, []dynamicconfig.ConstrainedValue{{Value: 789}}, c.GetValue(k))
+	remove3()
+	assert.Equal(t, []dynamicconfig.ConstrainedValue{{Value: 123}}, c.GetValue(k))
+	remove1()
+	remove3() // no-op
+	remove2() // no-op
+	assert.Nil(t, c.GetValue(k))
+}

--- a/tests/functional_test_base.go
+++ b/tests/functional_test_base.go
@@ -438,7 +438,7 @@ func (s *FunctionalTestBase) registerArchivalNamespace(archivalNamespace string)
 }
 
 func (s *FunctionalTestBase) OverrideDynamicConfig(setting dynamicconfig.GenericSetting, value any) (cleanup func()) {
-	return s.testCluster.host.overrideDynamicConfigByKey(s.T(), setting.Key(), value)
+	return s.testCluster.host.overrideDynamicConfig(s.T(), setting.Key(), value)
 }
 
 func (s *FunctionalTestBase) testWithMatchingBehavior(subtest func()) {

--- a/tests/functional_test_base.go
+++ b/tests/functional_test_base.go
@@ -437,8 +437,8 @@ func (s *FunctionalTestBase) registerArchivalNamespace(archivalNamespace string)
 	return err
 }
 
-func (s *FunctionalTestBase) OverrideDynamicConfig(setting dynamicconfig.GenericSetting, value any) {
-	s.testCluster.host.overrideDynamicConfigByKey(s.T(), setting.Key(), value)
+func (s *FunctionalTestBase) OverrideDynamicConfig(setting dynamicconfig.GenericSetting, value any) (cleanup func()) {
+	return s.testCluster.host.overrideDynamicConfigByKey(s.T(), setting.Key(), value)
 }
 
 func (s *FunctionalTestBase) testWithMatchingBehavior(subtest func()) {

--- a/tests/namespace_delete.go
+++ b/tests/namespace_delete.go
@@ -214,7 +214,7 @@ func (s *namespaceTestSuite) Test_NamespaceDelete_OverrideDelay() {
 	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(10000 * time.Second)
 	defer cancel()
 
-	s.cluster.host.OverrideDCValue(s.T(), dynamicconfig.DeleteNamespaceNamespaceDeleteDelay, time.Hour)
+	s.cluster.OverrideDynamicConfig(s.T(), dynamicconfig.DeleteNamespaceNamespaceDeleteDelay, time.Hour)
 
 	retention := 24 * time.Hour
 	_, err := s.frontendClient.RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -247,10 +247,10 @@ func newTemporal(t *testing.T, params *TemporalParams) *temporalImpl {
 		taskCategoryRegistry:             params.TaskCategoryRegistry,
 	}
 	for k, v := range staticOverrides {
-		impl.overrideDynamicConfigByKey(t, k, v)
+		impl.overrideDynamicConfig(t, k, v)
 	}
 	for k, v := range params.DynamicConfigOverrides {
-		impl.overrideDynamicConfigByKey(t, k, v)
+		impl.overrideDynamicConfig(t, k, v)
 	}
 	impl.overrideHistoryDynamicConfig(t)
 	return impl
@@ -870,36 +870,36 @@ func (c *temporalImpl) frontendConfigProvider() *config.Config {
 
 func (c *temporalImpl) overrideHistoryDynamicConfig(t *testing.T) {
 	if c.esConfig != nil {
-		c.overrideDynamicConfigByKey(t, dynamicconfig.SecondaryVisibilityWritingMode.Key(), visibility.SecondaryVisibilityWritingModeDual)
+		c.overrideDynamicConfig(t, dynamicconfig.SecondaryVisibilityWritingMode.Key(), visibility.SecondaryVisibilityWritingModeDual)
 	}
 	if c.historyConfig.HistoryCountLimitWarn != 0 {
-		c.overrideDynamicConfigByKey(t, dynamicconfig.HistoryCountLimitWarn.Key(), c.historyConfig.HistoryCountLimitWarn)
+		c.overrideDynamicConfig(t, dynamicconfig.HistoryCountLimitWarn.Key(), c.historyConfig.HistoryCountLimitWarn)
 	}
 	if c.historyConfig.HistoryCountLimitError != 0 {
-		c.overrideDynamicConfigByKey(t, dynamicconfig.HistoryCountLimitError.Key(), c.historyConfig.HistoryCountLimitError)
+		c.overrideDynamicConfig(t, dynamicconfig.HistoryCountLimitError.Key(), c.historyConfig.HistoryCountLimitError)
 	}
 	if c.historyConfig.HistorySizeLimitWarn != 0 {
-		c.overrideDynamicConfigByKey(t, dynamicconfig.HistorySizeLimitWarn.Key(), c.historyConfig.HistorySizeLimitWarn)
+		c.overrideDynamicConfig(t, dynamicconfig.HistorySizeLimitWarn.Key(), c.historyConfig.HistorySizeLimitWarn)
 	}
 	if c.historyConfig.HistorySizeLimitError != 0 {
-		c.overrideDynamicConfigByKey(t, dynamicconfig.HistorySizeLimitError.Key(), c.historyConfig.HistorySizeLimitError)
+		c.overrideDynamicConfig(t, dynamicconfig.HistorySizeLimitError.Key(), c.historyConfig.HistorySizeLimitError)
 	}
 	if c.historyConfig.BlobSizeLimitError != 0 {
-		c.overrideDynamicConfigByKey(t, dynamicconfig.BlobSizeLimitError.Key(), c.historyConfig.BlobSizeLimitError)
+		c.overrideDynamicConfig(t, dynamicconfig.BlobSizeLimitError.Key(), c.historyConfig.BlobSizeLimitError)
 	}
 	if c.historyConfig.BlobSizeLimitWarn != 0 {
-		c.overrideDynamicConfigByKey(t, dynamicconfig.BlobSizeLimitWarn.Key(), c.historyConfig.BlobSizeLimitWarn)
+		c.overrideDynamicConfig(t, dynamicconfig.BlobSizeLimitWarn.Key(), c.historyConfig.BlobSizeLimitWarn)
 	}
 	if c.historyConfig.MutableStateSizeLimitError != 0 {
-		c.overrideDynamicConfigByKey(t, dynamicconfig.MutableStateSizeLimitError.Key(), c.historyConfig.MutableStateSizeLimitError)
+		c.overrideDynamicConfig(t, dynamicconfig.MutableStateSizeLimitError.Key(), c.historyConfig.MutableStateSizeLimitError)
 	}
 	if c.historyConfig.MutableStateSizeLimitWarn != 0 {
-		c.overrideDynamicConfigByKey(t, dynamicconfig.MutableStateSizeLimitWarn.Key(), c.historyConfig.MutableStateSizeLimitWarn)
+		c.overrideDynamicConfig(t, dynamicconfig.MutableStateSizeLimitWarn.Key(), c.historyConfig.MutableStateSizeLimitWarn)
 	}
 
 	// For DeleteWorkflowExecution tests
-	c.overrideDynamicConfigByKey(t, dynamicconfig.TransferProcessorUpdateAckInterval.Key(), 1*time.Second)
-	c.overrideDynamicConfigByKey(t, dynamicconfig.VisibilityProcessorUpdateAckInterval.Key(), 1*time.Second)
+	c.overrideDynamicConfig(t, dynamicconfig.TransferProcessorUpdateAckInterval.Key(), 1*time.Second)
+	c.overrideDynamicConfig(t, dynamicconfig.VisibilityProcessorUpdateAckInterval.Key(), 1*time.Second)
 }
 
 func (c *temporalImpl) newRPCFactory(
@@ -1022,7 +1022,7 @@ func sdkClientFactoryProvider(
 	)
 }
 
-func (c *temporalImpl) overrideDynamicConfigByKey(t *testing.T, name dynamicconfig.Key, value any) func() {
+func (c *temporalImpl) overrideDynamicConfig(t *testing.T, name dynamicconfig.Key, value any) func() {
 	cleanup := c.dcClient.OverrideValue(name, value)
 	t.Cleanup(cleanup)
 	return cleanup

--- a/tests/schedule.go
+++ b/tests/schedule.go
@@ -970,7 +970,7 @@ func (s *ScheduleFunctionalSuite) TestListBeforeRun() {
 	wt := "sched-test-list-before-run-wt"
 
 	// disable per-ns worker so that the schedule workflow never runs
-	s.OverrideDynamicConfig(dynamicconfig.WorkerPerNamespaceWorkerCount, 0)
+	removeWorkerCount := s.OverrideDynamicConfig(dynamicconfig.WorkerPerNamespaceWorkerCount, 0)
 	s.testCluster.host.workerService.RefreshPerNSWorkerManager()
 	time.Sleep(2 * time.Second)
 
@@ -1031,6 +1031,7 @@ func (s *ScheduleFunctionalSuite) TestListBeforeRun() {
 	})
 	s.NoError(err)
 
+	removeWorkerCount()
 	s.testCluster.host.workerService.RefreshPerNSWorkerManager()
 	time.Sleep(2 * time.Second)
 }
@@ -1044,11 +1045,11 @@ func (s *ScheduleFunctionalSuite) TestRateLimit() {
 	// waiting one minute) we have to cause the whole worker to be stopped and started. The
 	// sleeps are needed because the refresh is asynchronous, and there's no way to get access
 	// to the actual rate limiter object to refresh it directly.
-	s.OverrideDynamicConfig(dynamicconfig.SchedulerNamespaceStartWorkflowRPS, 1.0)
-	s.OverrideDynamicConfig(dynamicconfig.WorkerPerNamespaceWorkerCount, 0)
+	removeRPS := s.OverrideDynamicConfig(dynamicconfig.SchedulerNamespaceStartWorkflowRPS, 1.0)
+	removeWorkerCount := s.OverrideDynamicConfig(dynamicconfig.WorkerPerNamespaceWorkerCount, 0)
 	s.testCluster.host.workerService.RefreshPerNSWorkerManager()
 	time.Sleep(2 * time.Second)
-	s.testCluster.host.dcClient.RemoveOverride(dynamicconfig.WorkerPerNamespaceWorkerCount)
+	removeWorkerCount()
 	s.testCluster.host.workerService.RefreshPerNSWorkerManager()
 	time.Sleep(2 * time.Second)
 
@@ -1106,11 +1107,11 @@ func (s *ScheduleFunctionalSuite) TestRateLimit() {
 		s.NoError(err)
 	}
 
-	s.testCluster.host.dcClient.RemoveOverride(dynamicconfig.SchedulerNamespaceStartWorkflowRPS)
-	s.OverrideDynamicConfig(dynamicconfig.WorkerPerNamespaceWorkerCount, 0)
+	removeRPS()
+	removeWorkerCount = s.OverrideDynamicConfig(dynamicconfig.WorkerPerNamespaceWorkerCount, 0)
 	s.testCluster.host.workerService.RefreshPerNSWorkerManager()
 	time.Sleep(2 * time.Second)
-	s.testCluster.host.dcClient.RemoveOverride(dynamicconfig.WorkerPerNamespaceWorkerCount)
+	removeWorkerCount()
 	s.testCluster.host.workerService.RefreshPerNSWorkerManager()
 }
 

--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -540,8 +540,8 @@ func (tc *TestCluster) GetHost() *temporalImpl {
 	return tc.host
 }
 
-func (tc *TestCluster) OverrideDynamicConfig(t *testing.T, key dynamicconfig.GenericSetting, value any) {
-	tc.host.OverrideDCValue(t, key, value)
+func (tc *TestCluster) OverrideDynamicConfig(t *testing.T, key dynamicconfig.GenericSetting, value any) (cleanup func()) {
+	return tc.host.overrideDynamicConfigByKey(t, key.Key(), value)
 }
 
 var errCannotAddCACertToPool = errors.New("failed adding CA to pool")

--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -541,7 +541,7 @@ func (tc *TestCluster) GetHost() *temporalImpl {
 }
 
 func (tc *TestCluster) OverrideDynamicConfig(t *testing.T, key dynamicconfig.GenericSetting, value any) (cleanup func()) {
-	return tc.host.overrideDynamicConfigByKey(t, key.Key(), value)
+	return tc.host.overrideDynamicConfig(t, key.Key(), value)
 }
 
 var errCannotAddCACertToPool = errors.New("failed adding CA to pool")

--- a/tests/update_workflow.go
+++ b/tests/update_workflow.go
@@ -190,8 +190,8 @@ func (s *FunctionalSuite) clearUpdateRegistryAndAbortPendingUpdates(tv *testvars
 // Simulating an unexpected loss of the update registry due to a crash. The shard finalizer won't run,
 // therefore the workflow context is NOT cleared, pending update requests are NOT aborted and will time out.
 func (s *FunctionalSuite) loseUpdateRegistryAndAbandonPendingUpdates(tv *testvars.TestVars) {
-	s.OverrideDynamicConfig(dynamicconfig.ShardFinalizerTimeout, 0)
-	defer s.testCluster.host.dcClient.RemoveOverride(dynamicconfig.ShardFinalizerTimeout)
+	cleanup := s.OverrideDynamicConfig(dynamicconfig.ShardFinalizerTimeout, 0)
+	defer cleanup()
 	s.closeShard(tv.WorkflowID())
 }
 

--- a/tests/xdc/nexus_request_forwarding_test.go
+++ b/tests/xdc/nexus_request_forwarding_test.go
@@ -326,11 +326,11 @@ func (s *NexusRequestForwardingSuite) TestCancelOperationForwardedFromStandbyToA
 
 func (s *NexusRequestForwardingSuite) TestCompleteOperationForwardedFromStandbyToActive() {
 	// Override templates to always return passive cluster in callback URL
-	s.cluster1.GetHost().OverrideDCValue(
+	s.cluster1.OverrideDynamicConfig(
 		s.T(),
 		nexusoperations.CallbackURLTemplate,
 		"http://"+s.cluster2.GetHost().FrontendHTTPAddress()+"/namespaces/{{.NamespaceName}}/nexus/callback")
-	s.cluster2.GetHost().OverrideDCValue(
+	s.cluster2.OverrideDynamicConfig(
 		s.T(),
 		nexusoperations.CallbackURLTemplate,
 		"http://"+s.cluster2.GetHost().FrontendHTTPAddress()+"/namespaces/{{.NamespaceName}}/nexus/callback")


### PR DESCRIPTION
## What changed?
- dynamicconfig.MemoryClient.OverrideValue now returns a cleanup function to undo the override.
- There is no more RemoveOverride.
- Refactor some functional test code to use cleanup functions.

## Why?
temporalImpl.overrideDynamicConfigByKey tried to undo the override it made, but if other code called RemoveOverride, things would get confused. Also, it was annoying to remove overrides in the middle of a test.

The new implementation of overrides is a list of pairs instead of a map, so they're clearly ordered. Removing one clears just that one, but later ones would still take effect.

## How did you test it?
existing tests + new test