### PR TITLE
Clean up client bean + mock admin clients in functional tests

### DIFF
--- a/client/client_bean.go
+++ b/client/client_bean.go
@@ -107,27 +107,6 @@ func NewClientBean(factory Factory, clusterMetadata cluster.Metadata) (Bean, err
 		WorkflowServiceClient: client,
 	}
 
-	for clusterName, info := range clusterMetadata.GetAllClusterInfo() {
-		if !info.Enabled || clusterName == currentClusterName {
-			continue
-		}
-		adminClient = factory.NewRemoteAdminClientWithTimeout(
-			info.RPCAddress,
-			admin.DefaultTimeout,
-			admin.DefaultLargeTimeout,
-		)
-		conn, client = factory.NewRemoteFrontendClientWithTimeout(
-			info.RPCAddress,
-			frontend.DefaultTimeout,
-			frontend.DefaultLongPollTimeout,
-		)
-		adminClients[clusterName] = adminClient
-		frontendClients[clusterName] = frontendClient{
-			connection:            conn,
-			WorkflowServiceClient: client,
-		}
-	}
-
 	bean := &clientBeanImpl{
 		factory:         factory,
 		historyClient:   historyClient,

--- a/client/client_bean.go
+++ b/client/client_bean.go
@@ -51,7 +51,6 @@ type (
 		GetMatchingClient(namespaceIDToName NamespaceIDToNameFunc) (matchingservice.MatchingServiceClient, error)
 		GetFrontendClient() workflowservice.WorkflowServiceClient
 		GetRemoteAdminClient(string) (adminservice.AdminServiceClient, error)
-		SetRemoteAdminClient(string, adminservice.AdminServiceClient)
 		GetRemoteFrontendClient(string) (grpc.ClientConnInterface, workflowservice.WorkflowServiceClient, error)
 	}
 
@@ -191,16 +190,6 @@ func (h *clientBeanImpl) GetRemoteAdminClient(cluster string) (adminservice.Admi
 	return client, nil
 }
 
-func (h *clientBeanImpl) SetRemoteAdminClient(
-	cluster string,
-	client adminservice.AdminServiceClient,
-) {
-	h.adminClientsLock.Lock()
-	defer h.adminClientsLock.Unlock()
-
-	h.adminClients[cluster] = client
-}
-
 func (h *clientBeanImpl) GetRemoteFrontendClient(clusterName string) (grpc.ClientConnInterface, workflowservice.WorkflowServiceClient, error) {
 	h.frontendClientsLock.RLock()
 	client, ok := h.frontendClients[clusterName]
@@ -243,13 +232,6 @@ func (h *clientBeanImpl) GetRemoteFrontendClient(clusterName string) (grpc.Clien
 	}
 	h.frontendClients[clusterName] = client
 	return client.connection, client, nil
-}
-
-func (h *clientBeanImpl) setRemoteAdminClientLocked(
-	cluster string,
-	client adminservice.AdminServiceClient,
-) {
-	h.adminClients[cluster] = client
 }
 
 func (h *clientBeanImpl) lazyInitMatchingClient(namespaceIDToName NamespaceIDToNameFunc) (matchingservice.MatchingServiceClient, error) {

--- a/client/client_bean_mock.go
+++ b/client/client_bean_mock.go
@@ -140,15 +140,3 @@ func (mr *MockBeanMockRecorder) GetRemoteFrontendClient(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteFrontendClient", reflect.TypeOf((*MockBean)(nil).GetRemoteFrontendClient), arg0)
 }
-
-// SetRemoteAdminClient mocks base method.
-func (m *MockBean) SetRemoteAdminClient(arg0 string, arg1 adminservice.AdminServiceClient) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetRemoteAdminClient", arg0, arg1)
-}
-
-// SetRemoteAdminClient indicates an expected call of SetRemoteAdminClient.
-func (mr *MockBeanMockRecorder) SetRemoteAdminClient(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRemoteAdminClient", reflect.TypeOf((*MockBean)(nil).SetRemoteAdminClient), arg0, arg1)
-}


### PR DESCRIPTION
## What changed?
- ClientBean no longer eagerly establishes connections on creation. These connections get immediately deleted by the cluster metadata callback that's registered right after. They'll be created on-demand very soon anyway.
- Remove SetRemoteAdminClient and have functional tests interpose mock admin clients through the client factory instead of mutating maps in ClientBean. This is more reliable since connections get added/removed from the maps.

## Why?
More reliable tests

## How did you test it?
existing tests