### PR TITLE
Add consistency check on mutable state when long poll history

### DIFF
--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -147,6 +147,7 @@ func GetOrPollMutableState(
 		if err != nil {
 			return nil, err
 		}
+		// TODO: update to use transition version history
 		if !versionhistory.ContainsVersionHistoryItem(currentVersionHistory, request.VersionHistoryItem) {
 			logItem, err := versionhistory.GetLastVersionHistoryItem(currentVersionHistory)
 			if err != nil {
@@ -189,6 +190,7 @@ func GetOrPollMutableState(
 				}
 				response.CurrentBranchToken = latestVersionHistory.GetBranchToken()
 				response.VersionHistories = event.VersionHistories
+				// TODO: update to use transition version history
 				if !versionhistory.ContainsVersionHistoryItem(latestVersionHistory, request.VersionHistoryItem) {
 					logItem, err := versionhistory.GetLastVersionHistoryItem(latestVersionHistory)
 					if err != nil {

--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -280,7 +280,7 @@ func GetMutableStateWithConsistencyCheck(
 			if currentVersion == lastVersionHistoryItem.GetVersion() {
 				return currentEventID <= lastVersionHistoryItem.GetEventId()
 			}
-			return currentVersion <= lastVersionHistoryItem.GetVersion()
+			return currentVersion < lastVersionHistoryItem.GetVersion()
 		},
 		workflowKey,
 		locks.PriorityHigh,


### PR DESCRIPTION
## What changed?
Add consistency check on mutable state when long poll history

## Why?
The long pull request can reach a stale shard and the version history won't be compatible.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
