### PR TITLE
Refactor: Remove redundant error check in task executor in executors.go

### DIFF
--- a/components/callbacks/executors.go
+++ b/components/callbacks/executors.go
@@ -159,9 +159,6 @@ func (e taskExecutor) loadInvocationArgs(
 				return err
 			}
 			invokable = hsmInvokable
-			if err != nil {
-				return err
-			}
 		default:
 			return queues.NewUnprocessableTaskError(
 				fmt.Sprintf("unprocessable callback variant: %v", variant),


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
This error check was redundant as it was already handled prior to the block, improving readability and maintaining clean, efficient error handling.

## Why?
<!-- Tell your future self why have you made these changes -->
This error check was redundant as it was already handled prior to the block, improving readability and maintaining clean, efficient error handling.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Tested locally with existing unit tests to ensure the task executor continues functioning as expected without introducing new errors.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
There is a minimal risk of breaking error handling logic in taskExecutor, though the changes are straightforward and should have no functional impact.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No updates required in documentation, as this is an internal refactor that does not affect behavior or interfaces.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No, this is not a hotfix candidate.
