### PR TITLE
Fix callback last attempt complete time not being set on success

### DIFF
--- a/components/callbacks/executors.go
+++ b/components/callbacks/executors.go
@@ -183,7 +183,9 @@ func (e taskExecutor) saveResult(
 		return hsm.MachineTransition(node, func(callback Callback) (hsm.TransitionOutput, error) {
 			switch result {
 			case ok:
-				return TransitionSucceeded.Apply(callback, EventSucceeded{})
+				return TransitionSucceeded.Apply(callback, EventSucceeded{
+					Time: env.Now(),
+				})
 			case retry:
 				return TransitionAttemptFailed.Apply(callback, EventAttemptFailed{
 					Time:        env.Now(),

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -311,6 +311,8 @@ func (s *FunctionalSuite) TestWorkflowNexusCallbacks_CarriedOver() {
 				s.ProtoEqual(request.CompletionCallbacks[0], callbackInfo.Callback)
 				s.ProtoEqual(&workflowpb.CallbackInfo_Trigger{Variant: &workflowpb.CallbackInfo_Trigger_WorkflowClosed{WorkflowClosed: &workflowpb.CallbackInfo_WorkflowClosed{}}}, callbackInfo.Trigger)
 				s.Equal(int32(attempt), callbackInfo.Attempt)
+				// Loose check to see that this is set.
+				s.Greater(callbackInfo.LastAttemptCompleteTime.AsTime(), time.Now().Add(-time.Hour))
 				if attempt < numAttempts {
 					s.Equal(enumspb.CALLBACK_STATE_BACKING_OFF, callbackInfo.State)
 					s.Equal("request failed with: 500 Internal Server Error", callbackInfo.LastAttemptFailure.Message)


### PR DESCRIPTION
## What changed?

Callback last attempt complete time was not being set on success, this fixes that:

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/e17a982e-1ab1-492b-bc19-d0b669d2a602">
