### PR TITLE
retract v1.26.0 and v1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module go.temporal.io/server
 
 go 1.22.6
 
+retract (
+    v1.26.0 // Published accidentally.
+    v1.26.1 // Contains retractions only.
+)
+
 require (
 	cloud.google.com/go/storage v1.41.0
 	github.com/aws/aws-sdk-go v1.53.15

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module go.temporal.io/server
 go 1.22.6
 
 retract (
-    v1.26.0 // Published accidentally.
-    v1.26.1 // Contains retractions only.
+	v1.26.1 // Contains retractions only.
+	v1.26.0 // Published accidentally.
 )
 
 require (


### PR DESCRIPTION
## What changed?
retract v1.26.0 and v1.26.1

## Why?
v1.26.0 was accidentally published. v1.26.1 retracts that version and itself.

## How did you test it?
N/A

## Potential risks
no

## Documentation
no

## Is hotfix candidate?
no
