### PR TITLE
Fix enable/disable in nexus endpoint registry

### DIFF
--- a/common/nexus/endpoint_registry_test.go
+++ b/common/nexus/endpoint_registry_test.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -175,6 +176,85 @@ func TestInitializationFallback(t *testing.T) {
 	reg.dataLock.RLock()
 	defer reg.dataLock.RUnlock()
 	assert.Equal(t, int64(1), reg.tableVersion)
+}
+
+func TestEnableDisableEnable(t *testing.T) {
+	t.Parallel()
+
+	testEntry := newEndpointEntry(t.Name())
+	mocks := newTestMocks(t)
+
+	mocks.config.refreshMinWait = dynamicconfig.GetDurationPropertyFn(time.Millisecond)
+	var callback func(bool) // capture callback to call later
+	mocks.config.refreshEnabled = func(cb func(bool)) (bool, func()) {
+		callback = cb
+		return false, func() {}
+	}
+
+	// start disabled
+	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	reg.StartLifecycle()
+	defer reg.StopLifecycle()
+
+	// check waitUntilInitialized
+	quickCtx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, reg.waitUntilInitialized(quickCtx), ErrNexusDisabled)
+
+	// mocks for initial load
+	inLongPoll := make(chan struct{})
+	closeOnce := sync.OnceFunc(func() { close(inLongPoll) })
+	mocks.matchingClient.EXPECT().ListNexusEndpoints(gomock.Any(), gomock.Any()).Return(&matchingservice.ListNexusEndpointsResponse{
+		Entries:       []*persistencepb.NexusEndpointEntry{testEntry},
+		TableVersion:  1,
+		NextPageToken: nil,
+	}, nil)
+	mocks.matchingClient.EXPECT().ListNexusEndpoints(gomock.Any(), &matchingservice.ListNexusEndpointsRequest{
+		PageSize:              int32(100),
+		LastKnownTableVersion: int64(1),
+		Wait:                  true,
+	}).DoAndReturn(func(context.Context, *matchingservice.ListNexusEndpointsRequest, ...interface{}) (*matchingservice.ListNexusEndpointsResponse, error) {
+		closeOnce()
+		time.Sleep(100 * time.Millisecond)
+		return &matchingservice.ListNexusEndpointsResponse{TableVersion: int64(1)}, nil
+	})
+
+	// enable
+	callback(true)
+	<-inLongPoll
+
+	// check waitUntilInitialized
+	quickCtx, cancel = context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	require.NoError(t, reg.waitUntilInitialized(quickCtx))
+
+	// now disable
+	callback(false)
+
+	quickCtx, cancel = context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, reg.waitUntilInitialized(quickCtx), ErrNexusDisabled)
+
+	// enable again, should not crash
+
+	inLongPoll = make(chan struct{})
+	closeOnce = sync.OnceFunc(func() { close(inLongPoll) })
+	mocks.matchingClient.EXPECT().ListNexusEndpoints(gomock.Any(), gomock.Any()).Return(&matchingservice.ListNexusEndpointsResponse{
+		Entries:       []*persistencepb.NexusEndpointEntry{testEntry},
+		TableVersion:  1,
+		NextPageToken: nil,
+	}, nil)
+	mocks.matchingClient.EXPECT().ListNexusEndpoints(gomock.Any(), &matchingservice.ListNexusEndpointsRequest{
+		PageSize:              int32(100),
+		LastKnownTableVersion: int64(1),
+		Wait:                  true,
+	}).DoAndReturn(func(context.Context, *matchingservice.ListNexusEndpointsRequest, ...interface{}) (*matchingservice.ListNexusEndpointsResponse, error) {
+		closeOnce()
+		time.Sleep(100 * time.Millisecond)
+		return &matchingservice.ListNexusEndpointsResponse{TableVersion: int64(1)}, nil
+	})
+	callback(true)
+	<-inLongPoll
 }
 
 func TestTableVersionErrorResetsMatchingPagination(t *testing.T) {


### PR DESCRIPTION
## What changed?
Correctly handle a sequence of enable, disable, enable in nexus endpoint registry without double-close on the ready channel.

## Why?
avoid crash

## How did you test it?
new unit test