### PR TITLE
Adding caching for Describe Task Queue Partition Requests

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -509,8 +509,8 @@ DescribeTaskQueue API with ReportTaskQueueReachability==true, or to the GetWorke
 		`ReachabilityCacheClosedWFsTTL is the TTL for the reachability closed workflows cache.`,
 	)
 	TaskQueueInternalInfoCacheTTL = NewGlobalDurationSetting(
-		"matching.wv.TaskQueueInternalInfoCacheTTL", // todo Shivam - what the heck is wv?
-		time.Minute,
+		"matching.wv.TaskQueueInternalInfoCacheTTL",
+		time.Second,
 		`TaskQueueInternalInfoCacheTTL is the TTL for the task queue internal info cache.`,
 	)
 	ReachabilityQuerySetDurationSinceDefault = NewGlobalDurationSetting(

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -508,10 +508,10 @@ DescribeTaskQueue API with ReportTaskQueueReachability==true, or to the GetWorke
 		10*time.Minute,
 		`ReachabilityCacheClosedWFsTTL is the TTL for the reachability closed workflows cache.`,
 	)
-	TaskQueueStatsCacheTTL = NewGlobalDurationSetting(
-		"matching.wv.taskQueueStatsCacheTTL", // todo Shivam - what the heck is wv?
+	TaskQueueInternalInfoCacheTTL = NewGlobalDurationSetting(
+		"matching.wv.TaskQueueInternalInfoCacheTTL", // todo Shivam - what the heck is wv?
 		time.Minute,
-		`taskQueueStatsCacheTTL is the TTL for the task queue statistics cache.`,
+		`TaskQueueInternalInfoCacheTTL is the TTL for the task queue internal info cache.`,
 	)
 	ReachabilityQuerySetDurationSinceDefault = NewGlobalDurationSetting(
 		"frontend.reachabilityQuerySetDurationSinceDefault",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -508,6 +508,11 @@ DescribeTaskQueue API with ReportTaskQueueReachability==true, or to the GetWorke
 		10*time.Minute,
 		`ReachabilityCacheClosedWFsTTL is the TTL for the reachability closed workflows cache.`,
 	)
+	TaskQueueStatsCacheTTL = NewGlobalDurationSetting(
+		"matching.wv.taskQueueStatsCacheTTL", // todo Shivam - what the heck is wv?
+		time.Minute,
+		`taskQueueStatsCacheTTL is the TTL for the task queue statistics cache.`,
+	)
 	ReachabilityQuerySetDurationSinceDefault = NewGlobalDurationSetting(
 		"frontend.reachabilityQuerySetDurationSinceDefault",
 		5*time.Minute,

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -85,7 +85,7 @@ type (
 		QueryPollerUnavailableWindow             dynamicconfig.DurationPropertyFn
 		QueryWorkflowTaskTimeoutLogRate          dynamicconfig.FloatPropertyFnWithTaskQueueFilter
 		MembershipUnloadDelay                    dynamicconfig.DurationPropertyFn
-		TaskQueueStatsCacheTTL                   dynamicconfig.DurationPropertyFn
+		TaskQueueInternalInfoCacheTTL            dynamicconfig.DurationPropertyFn
 
 		// Time to hold a poll request before returning an empty response if there are no tasks
 		LongPollExpirationInterval dynamicconfig.DurationPropertyFnWithTaskQueueFilter
@@ -246,7 +246,7 @@ func NewConfig(
 		QueryPollerUnavailableWindow:             dynamicconfig.QueryPollerUnavailableWindow.Get(dc),
 		QueryWorkflowTaskTimeoutLogRate:          dynamicconfig.MatchingQueryWorkflowTaskTimeoutLogRate.Get(dc),
 		MembershipUnloadDelay:                    dynamicconfig.MatchingMembershipUnloadDelay.Get(dc),
-		TaskQueueStatsCacheTTL:                   dynamicconfig.TaskQueueStatsCacheTTL.Get(dc),
+		TaskQueueInternalInfoCacheTTL:            dynamicconfig.TaskQueueInternalInfoCacheTTL.Get(dc),
 
 		AdminNamespaceToPartitionDispatchRate:          dynamicconfig.AdminMatchingNamespaceToPartitionDispatchRate.Get(dc),
 		AdminNamespaceTaskqueueToPartitionDispatchRate: dynamicconfig.AdminMatchingNamespaceTaskqueueToPartitionDispatchRate.Get(dc),

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -85,6 +85,7 @@ type (
 		QueryPollerUnavailableWindow             dynamicconfig.DurationPropertyFn
 		QueryWorkflowTaskTimeoutLogRate          dynamicconfig.FloatPropertyFnWithTaskQueueFilter
 		MembershipUnloadDelay                    dynamicconfig.DurationPropertyFn
+		TaskQueueStatsCacheTTL                   dynamicconfig.DurationPropertyFn
 
 		// Time to hold a poll request before returning an empty response if there are no tasks
 		LongPollExpirationInterval dynamicconfig.DurationPropertyFnWithTaskQueueFilter
@@ -245,6 +246,7 @@ func NewConfig(
 		QueryPollerUnavailableWindow:             dynamicconfig.QueryPollerUnavailableWindow.Get(dc),
 		QueryWorkflowTaskTimeoutLogRate:          dynamicconfig.MatchingQueryWorkflowTaskTimeoutLogRate.Get(dc),
 		MembershipUnloadDelay:                    dynamicconfig.MatchingMembershipUnloadDelay.Get(dc),
+		TaskQueueStatsCacheTTL:                   dynamicconfig.TaskQueueStatsCacheTTL.Get(dc),
 
 		AdminNamespaceToPartitionDispatchRate:          dynamicconfig.AdminMatchingNamespaceToPartitionDispatchRate.Get(dc),
 		AdminNamespaceTaskqueueToPartitionDispatchRate: dynamicconfig.AdminMatchingNamespaceTaskqueueToPartitionDispatchRate.Get(dc),

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -163,6 +163,8 @@ type (
 		namespaceUpdateLockMapLock sync.Mutex
 		// Stores results of reachability queries to visibility
 		reachabilityCache reachabilityCache
+		// Stores aggregated task-queue statistics
+		taskQueueStatsCache taskQueueStatsCache
 	}
 )
 
@@ -239,6 +241,7 @@ func NewEngine(
 		visibilityManager,
 		e.config.ReachabilityCacheOpenWFsTTL(),
 		e.config.ReachabilityCacheClosedWFsTTL())
+	e.taskQueueStatsCache = newTaskQueueStatsCache(metrics.NoopMetricsHandler, e.config.TaskQueueStatsCacheTTL())
 	return e
 }
 
@@ -939,6 +942,7 @@ func (e *matchingEngineImpl) DescribeTaskQueue(
 		numPartitions := max(tqConfig.NumWritePartitions(), tqConfig.NumReadPartitions())
 		for _, taskQueueType := range req.TaskQueueTypes {
 			for i := 0; i < numPartitions; i++ {
+				// todo Shivam - only call
 				partitionResp, err := e.matchingRawClient.DescribeTaskQueuePartition(ctx, &matchingservice.DescribeTaskQueuePartitionRequest{
 					NamespaceId: request.GetNamespaceId(),
 					TaskQueuePartition: &taskqueuespb.TaskQueuePartition{

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -991,7 +991,11 @@ func (e *matchingEngineImpl) DescribeTaskQueue(
 					}
 				}
 			}
+			fmt.Printf("Activity tasks are %d \n\n\n", physicalInfoByBuildId[""][enumspb.TASK_QUEUE_TYPE_ACTIVITY].TaskQueueStats.ApproximateBacklogCount)
 			e.taskQueueInternalInfoCache.Put(rootPartition.Key(), physicalInfoByBuildId)
+		} else {
+			fmt.Println("fetched from cache!!!!!")
+			fmt.Printf("Activity tasks are %d \n\n\n", physicalInfoByBuildId[""][enumspb.TASK_QUEUE_TYPE_ACTIVITY].TaskQueueStats.ApproximateBacklogCount)
 		}
 
 		// smush internal info into versions info

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -991,11 +991,7 @@ func (e *matchingEngineImpl) DescribeTaskQueue(
 					}
 				}
 			}
-			fmt.Printf("Activity tasks are %d \n\n\n", physicalInfoByBuildId[""][enumspb.TASK_QUEUE_TYPE_ACTIVITY].TaskQueueStats.ApproximateBacklogCount)
 			e.taskQueueInternalInfoCache.Put(rootPartition.Key(), physicalInfoByBuildId)
-		} else {
-			fmt.Println("fetched from cache!!!!!")
-			fmt.Printf("Activity tasks are %d \n\n\n", physicalInfoByBuildId[""][enumspb.TASK_QUEUE_TYPE_ACTIVITY].TaskQueueStats.ApproximateBacklogCount)
 		}
 
 		// smush internal info into versions info

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -243,7 +243,6 @@ func NewEngine(
 		e.config.ReachabilityCacheOpenWFsTTL(),
 		e.config.ReachabilityCacheClosedWFsTTL())
 	e.taskQueueInternalInfoCache = newTaskQueueInternalInfoCache(
-		metrics.NoopMetricsHandler, // todo Shivam - why noop
 		&cache.Options{TTL: e.config.TaskQueueInternalInfoCacheTTL()},
 	)
 	return e

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -340,6 +340,9 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 	// one rateLimiter for this entire task queue and as we get polls,
 	// we update the ratelimiter rps if it has changed from the last
 	// value. Last poller wins if different pollers provide different values
+
+	// todo Shivam - this shall be updated to now be a value set by customer from userData by checking a variable
+	// todo Shivam - if the variable is not set, we just simply use the current implementation
 	c.matcher.UpdateRatelimit(pollMetadata.ratePerSecond)
 
 	if !namespaceEntry.ActiveInCluster(c.clusterMeta.GetCurrentClusterName()) {

--- a/service/matching/task_queue_internal_info_cache.go
+++ b/service/matching/task_queue_internal_info_cache.go
@@ -28,7 +28,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/common/cache"
-	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/tqid"
 )
 
@@ -42,14 +41,12 @@ Stores key-value pairs as: PartitionKey -> physicalInfoByBuildId
 */
 
 type taskQueueInternalInfoCache struct {
-	cache          cache.Cache
-	metricsHandler metrics.Handler
+	cache cache.Cache
 }
 
-func newTaskQueueInternalInfoCache(handler metrics.Handler, opts *cache.Options) taskQueueInternalInfoCache {
+func newTaskQueueInternalInfoCache(opts *cache.Options) taskQueueInternalInfoCache {
 	return taskQueueInternalInfoCache{
-		cache:          cache.New(taskQueueInternalInfoCacheMaxSize, opts),
-		metricsHandler: handler,
+		cache: cache.New(taskQueueInternalInfoCacheMaxSize, opts),
 	}
 }
 

--- a/service/matching/task_queue_internal_info_cache_test.go
+++ b/service/matching/task_queue_internal_info_cache_test.go
@@ -1,0 +1,103 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
+	"go.temporal.io/server/common/cache"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/tqid"
+	"testing"
+	"time"
+)
+
+type (
+	taskQueueInternalInfoCacheSuite struct {
+		suite.Suite
+		*require.Assertions
+		taskQueueInternalInfoCache taskQueueInternalInfoCache
+		timeSource                 *clock.EventTimeSource
+	}
+)
+
+const taskQueueInternalInfoCacheTTL = 10 * time.Second
+
+func createTaskQueueInternalInfoCache(options *cache.Options) taskQueueInternalInfoCache {
+	return newTaskQueueInternalInfoCache(metrics.NoopMetricsHandler, options)
+}
+
+func TestTaskQueueInternalInfoSuite(t *testing.T) {
+	s := new(taskQueueInternalInfoCacheSuite)
+	suite.Run(t, s)
+}
+
+func (s *taskQueueInternalInfoCacheSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+	s.timeSource = clock.NewEventTimeSource()
+	currentTime := time.Now()
+	s.timeSource.Update(currentTime)
+
+	options := cache.Options{TTL: taskQueueInternalInfoCacheTTL, TimeSource: s.timeSource}
+	s.taskQueueInternalInfoCache = createTaskQueueInternalInfoCache(&options)
+}
+
+func (s *taskQueueInternalInfoCacheSuite) TearDownTest() {}
+
+// testing the put method
+func (s *taskQueueInternalInfoCacheSuite) TestGetPutWithTTL() {
+	physicalInfoByBuildId := make(map[string]map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo)
+
+	buildID := "buildID123"
+	taskQueueTypeMap := make(map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo)
+	physicalInfo := &taskqueuespb.PhysicalTaskQueueInfo{}
+	taskQueueTypeMap[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = physicalInfo
+	// Add the taskQueueTypeMap to the outer map using buildID as the key
+	physicalInfoByBuildId[buildID] = taskQueueTypeMap
+
+	nsid := "my-namespace"
+	normalName := "very-normal"
+	taskType := enumspb.TASK_QUEUE_TYPE_WORKFLOW
+	proto := &taskqueuepb.TaskQueue{
+		Name: normalName,
+	}
+
+	p, err := tqid.PartitionFromProto(proto, nsid, taskType)
+	s.NoError(err)
+
+	// adding it to our cache
+	s.taskQueueInternalInfoCache.Put(p.Key(), physicalInfoByBuildId)
+	cachedInternalInfo := s.taskQueueInternalInfoCache.Get(p.Key())
+	s.Equal(physicalInfoByBuildId, cachedInternalInfo)
+
+	// ensuring cache evicts after TTL has expired
+	s.timeSource.Advance(11 * time.Second)
+	cachedInternalInfo = s.taskQueueInternalInfoCache.Get(p.Key())
+	s.Nil(cachedInternalInfo)
+}

--- a/service/matching/task_queue_internal_info_cache_test.go
+++ b/service/matching/task_queue_internal_info_cache_test.go
@@ -25,6 +25,9 @@
 package matching
 
 import (
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -34,8 +37,6 @@ import (
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/tqid"
-	"testing"
-	"time"
 )
 
 type (
@@ -70,7 +71,6 @@ func (s *taskQueueInternalInfoCacheSuite) SetupTest() {
 
 func (s *taskQueueInternalInfoCacheSuite) TearDownTest() {}
 
-// testing the put method
 func (s *taskQueueInternalInfoCacheSuite) TestGetPutWithTTL() {
 	physicalInfoByBuildId := make(map[string]map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo)
 

--- a/service/matching/task_queue_internal_info_cache_test.go
+++ b/service/matching/task_queue_internal_info_cache_test.go
@@ -35,7 +35,6 @@ import (
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/common/cache"
 	"go.temporal.io/server/common/clock"
-	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/tqid"
 )
 
@@ -51,7 +50,7 @@ type (
 const taskQueueInternalInfoCacheTTL = 10 * time.Second
 
 func createTaskQueueInternalInfoCache(options *cache.Options) taskQueueInternalInfoCache {
-	return newTaskQueueInternalInfoCache(metrics.NoopMetricsHandler, options)
+	return newTaskQueueInternalInfoCache(options)
 }
 
 func TestTaskQueueInternalInfoSuite(t *testing.T) {

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -319,7 +319,7 @@ func (pm *taskQueuePartitionManagerImpl) PollTask(
 		defer dbq.UpdatePollerInfo(pollerIdentity(identity), pollMetadata)
 	}
 
-	task, err := dbq.PollTask(ctx, pollMetadata)
+	task, err := dbq.PollTask(ctx, pollMetadata) // todo Shivam - pass in an extra variable denoting if we
 	return task, versionSetUsed, err
 }
 

--- a/service/matching/task_queue_stats_cache.go
+++ b/service/matching/task_queue_stats_cache.go
@@ -1,0 +1,68 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/server/common/tqid"
+	"time"
+
+	"go.temporal.io/server/common/cache"
+	"go.temporal.io/server/common/metrics"
+)
+
+const (
+	taskQueueStatsCacheMaxSize = 10000
+)
+
+/*
+In-memory Cache for storing task queue stats from multiple child partitions
+*/
+
+// todo Shivam - cache will have PartitionType -> stats
+type taskQueueStatsCache struct {
+	cache          cache.Cache
+	metricsHandler metrics.Handler
+}
+
+func newTaskQueueStatsCache(handler metrics.Handler, taskQueueStatsCacheTTL time.Duration) taskQueueStatsCache {
+	return taskQueueStatsCache{
+		cache:          cache.New(taskQueueStatsCacheMaxSize, &cache.Options{TTL: taskQueueStatsCacheTTL}),
+		metricsHandler: handler,
+	}
+}
+
+// Get retrieves the backlog stats for the partition
+// NOTE: Should only be called by the root Partition
+func (tqCache *taskQueueStatsCache) Get() *taskqueuepb.TaskQueueStats {
+	return tqCache.Get()
+}
+
+// Put updates the backlog stats for the partition
+// NOTE: Should only be called by the root Partition
+func (tqCache *taskQueueStatsCache) Put(partitionKey tqid.PartitionKey, taskQueueStats *taskqueuepb.TaskQueueStats) {
+	tqCache.cache.Put(partitionKey, taskQueueStats)
+	return
+}

--- a/tests/describe_task_queue.go
+++ b/tests/describe_task_queue.go
@@ -24,7 +24,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -82,25 +81,12 @@ func (s *DescribeTaskQueueSuite) SetupSuite() {
 	}
 	s.DescribeTaskQueueSuiteBase.SetupSuite()
 }
-func (s *DescribeTaskQueueSuite) TearDownSuite() {
-	s.DescribeTaskQueueSuiteBase.TearDownSuite()
-}
 
 func (s *DescribeTaskQueueSuiteWithCache) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]any{
 		dynamicconfig.TaskQueueInternalInfoCacheTTL.Key(): largeTTL,
 	}
 	s.DescribeTaskQueueSuiteBase.SetupSuite()
-}
-func (s *DescribeTaskQueueSuiteWithCache) TearDownSuite() {
-	s.DescribeTaskQueueSuiteBase.TearDownSuite()
-}
-
-func (s *DescribeTaskQueueSuite) SetupTest() {
-	s.DescribeTaskQueueSuiteBase.SetupTest()
-}
-func (s *DescribeTaskQueueSuiteWithCache) SetupTest() {
-	s.DescribeTaskQueueSuiteBase.SetupTest()
 }
 
 /* Tests for DescribeTaskQueueSuite suite */
@@ -233,7 +219,6 @@ func (s *DescribeTaskQueueSuiteBase) PollActivityTasks(workflows int, tq *taskqu
 		)
 		s.NoError(err1)
 		if resp1 == nil || resp1.GetAttempt() < 1 {
-			fmt.Println("empty poll response")
 			continue // poll again on empty responses
 		}
 		i++
@@ -276,7 +261,6 @@ func (s *DescribeTaskQueueSuiteBase) validateDescribeTaskQueue(
 
 			wfStats := types[int32(enumspb.TASK_QUEUE_TYPE_WORKFLOW)].Stats
 			actStats := types[int32(enumspb.TASK_QUEUE_TYPE_ACTIVITY)].Stats
-			fmt.Printf("Activity tasks inside matching are %d and expected activity backlog count %d \n\n\n", actStats.ApproximateBacklogCount, expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY])
 
 			a := assert.New(t)
 
@@ -417,13 +401,11 @@ func (s *DescribeTaskQueueSuiteWithCache) publishConsumeWorkflowTasksValidateSta
 	time.Sleep(largeTTL + 30*time.Millisecond) // forcing cache evictions due to TTL
 
 	// fetches the latest stats by making per partition gRPC calls
-	fmt.Println("First DescribeTQ call")
 	s.validateDescribeTaskQueue(tqName, expectedBacklogCount, maxBacklogExtraTasks, expectedAddRate, expectedDispatchRate, isEnhancedMode)
 
 	// Poll the activity tasks
 	s.PollActivityTasks(workflows, tq, identity)
 
 	// validating with cached stats
-	fmt.Println("Second DescribeTQ call")
 	s.validateDescribeTaskQueue(tqName, expectedBacklogCount, maxBacklogExtraTasks, expectedAddRate, expectedDispatchRate, isEnhancedMode)
 }

--- a/tests/describe_task_queue.go
+++ b/tests/describe_task_queue.go
@@ -46,6 +46,9 @@ type (
 )
 
 func (s *DescribeTaskQueueSuite) SetupSuite() {
+	s.dynamicConfigOverrides = map[dynamicconfig.Key]any{
+		dynamicconfig.TaskQueueInternalInfoCacheTTL.Key(): time.Nanosecond, // small value since our tests require accurate data
+	}
 	s.setupSuite("testdata/es_cluster.yaml")
 }
 
@@ -55,7 +58,6 @@ func (s *DescribeTaskQueueSuite) TearDownSuite() {
 
 func (s *DescribeTaskQueueSuite) SetupTest() {
 	s.FunctionalTestBase.SetupTest()
-
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
 }

--- a/tests/describe_task_queue_test.go
+++ b/tests/describe_task_queue_test.go
@@ -33,3 +33,8 @@ func TestDescribeTaskQueueSuite(t *testing.T) {
 	flag.Parse()
 	suite.Run(t, new(DescribeTaskQueueSuite))
 }
+
+func TestDescribeTaskQueueSuiteWithCache(t *testing.T) {
+	flag.Parse()
+	suite.Run(t, new(DescribeTaskQueueSuiteWithCache))
+}

--- a/tests/versioning.go
+++ b/tests/versioning.go
@@ -111,6 +111,7 @@ func (s *VersioningIntegSuite) SetupSuite() {
 		// this is overridden for tests using testWithMatchingBehavior
 		dynamicconfig.MatchingNumTaskqueueReadPartitions.Key():  4,
 		dynamicconfig.MatchingNumTaskqueueWritePartitions.Key(): 4,
+		dynamicconfig.TaskQueueInternalInfoCacheTTL.Key():       time.Nanosecond,
 	}
 	s.setupSuite("testdata/es_cluster.yaml")
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- added a LRU cache, eviction policy being based on TTL's, which shall store results from the `DescribeTaskQueuePartition` gRPC calls.

## Why?
<!-- Tell your future self why have you made these changes -->
- #6539 reduced the restriction on `DescribeTaskQueue` requests which are not concerned with reachabilty.
- In order to prevent excessive gRPC calls, this protection (added by the cache) is needed. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- added a unit test specifically testing the workings of the cache
- added a functional test 
- *NOTE* : For better code organization, I have changed the structure found inside `tests/describe_task_queue.go` while adding the new test. 

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- just outdated information which will be resolved thanks to TTL's

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
nope
