### PR TITLE
Allow embedding dynamic config in static config

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -65,6 +65,10 @@ type (
 		// DynamicConfigClient is the config for setting up the file based dynamic config client
 		// Filepath should be relative to the root directory
 		DynamicConfigClient *dynamicconfig.FileBasedClientConfig `yaml:"dynamicConfigClient"`
+		// If DynamicConfig is present, it is used as the dynamic config for the server (and
+		// reloaded periodically if dynamicConfigClient.pollInterval is set). This conflicts
+		// with dynamicConfigClient.filepath.
+		DynamicConfig any `yaml:"dynamicConfig"`
 		// NamespaceDefaults is the default config for every namespace
 		NamespaceDefaults NamespaceDefaults `yaml:"namespaceDefaults"`
 		// ExporterConfig allows the specification of process-wide OTEL exporters

--- a/common/config/loader_test.go
+++ b/common/config/loader_test.go
@@ -40,15 +40,6 @@ type (
 		*require.Assertions
 		suite.Suite
 	}
-
-	itemsConfig struct {
-		Item1 string `yaml:"item1"`
-		Item2 string `yaml:"item2"`
-	}
-
-	testConfig struct {
-		Items itemsConfig `yaml:"items"`
-	}
 )
 
 func TestLoaderSuite(t *testing.T) {
@@ -71,11 +62,11 @@ func (s *LoaderSuite) TestBaseYaml() {
 
 	for _, env := range envs {
 		for _, zone := range zones {
-			var cfg testConfig
+			var cfg Config
 			err = Load(env, dir, zone, &cfg)
 			s.Nil(err)
-			s.Equal("hello__", cfg.Items.Item1)
-			s.Equal("world__", cfg.Items.Item2)
+			s.Equal("hello__", cfg.Log.Level)
+			s.Equal("world__", cfg.Log.Format)
 		}
 	}
 }
@@ -106,16 +97,16 @@ func (s *LoaderSuite) TestHierarchy() {
 	}
 
 	for _, tc := range testCases {
-		var cfg testConfig
+		var cfg Config
 		err := Load(tc.env, dir, tc.zone, &cfg)
 		s.Nil(err)
-		s.Equal(tc.item1, cfg.Items.Item1)
-		s.Equal(tc.item2, cfg.Items.Item2)
+		s.Equal(tc.item1, cfg.Log.Level)
+		s.Equal(tc.item2, cfg.Log.Format)
 	}
 }
 
 func (s *LoaderSuite) TestInvalidPath() {
-	var cfg testConfig
+	var cfg Config
 	err := Load("prod", "", "", &cfg)
 	s.NotNil(err)
 }
@@ -129,7 +120,12 @@ func buildConfig(env, zone string) string {
 	item1 := concat("hello", concat(env, zone))
 	item2 := concat("world", concat(env, zone))
 	return `
-    items:
-      item1: ` + item1 + `
-      item2: ` + item2
+    log:
+      level: ` + item1 + `
+      format: ` + item2 + `
+    # make validator happy:
+    persistence:
+      defaultStore: dummy
+      numHistoryShards: 10
+`
 }

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -102,7 +102,8 @@ func NewServerFxImpl(
 
 func (s *ServerImpl) Start(ctx context.Context) error {
 	s.logger.Info("Starting server for services", tag.Value(s.so.serviceNames))
-	s.logger.Debug(s.so.config.String())
+	// Using NewAnyTag on config (which is a fmt.Stringer) avoids marshaling unless it's needed.
+	s.logger.Debug("Using static config", tag.NewAnyTag("static-config", s.so.config))
 
 	if err := initSystemNamespaces(
 		ctx,


### PR DESCRIPTION
## What changed?
PoC for #6561:
- If static config has a key `dynamicConfig`, use the contents of that as dynamic config.
- `dynamicConfigClient.pollInterval` is allowed to be zero, meaning "do not reload".

This only works with configs loaded from yaml files, not generated by code and passed with WithConfig. Callers can use WithDynamicConfigClient with a StaticClient or MemoryClient.

## Why?
Simplify server configuration for dev/test servers.

## How did you test it?
unit tests, manual test of dev server (not cli)