### PR TITLE
Subscription for schedulerNamespaceStartWorkflowRPS

### DIFF
--- a/service/worker/batcher/fx.go
+++ b/service/worker/batcher/fx.go
@@ -89,9 +89,10 @@ func (s *workerComponent) DedicatedWorkerOptions(ns *namespace.Namespace) *worke
 	}
 }
 
-func (s *workerComponent) Register(registry sdkworker.Registry, ns *namespace.Namespace, _ workercommon.RegistrationDetails) {
+func (s *workerComponent) Register(registry sdkworker.Registry, ns *namespace.Namespace, _ workercommon.RegistrationDetails) func() {
 	registry.RegisterWorkflowWithOptions(BatchWorkflow, workflow.RegisterOptions{Name: BatchWFTypeName})
 	registry.RegisterActivity(s.activities(ns.Name(), ns.ID()))
+	return nil
 }
 
 func (s *workerComponent) activities(name namespace.Name, id namespace.ID) *activities {

--- a/service/worker/common/interface.go
+++ b/service/worker/common/interface.go
@@ -61,7 +61,9 @@ type (
 	PerNSWorkerComponent interface {
 		// Register registers Workflow and Activity types provided by this worker component.
 		// The namespace that this worker is running in is also provided.
-		Register(sdkworker.Registry, *namespace.Namespace, RegistrationDetails)
+		// If Register returns a function, that function will be called when the worker is
+		// stopped. This can be used to clean up any state.
+		Register(sdkworker.Registry, *namespace.Namespace, RegistrationDetails) func()
 		// DedicatedWorkerOptions returns a PerNSDedicatedWorkerOptions for this worker component.
 		DedicatedWorkerOptions(*namespace.Namespace) *PerNSDedicatedWorkerOptions
 	}

--- a/service/worker/common/interface_mock.go
+++ b/service/worker/common/interface_mock.go
@@ -154,9 +154,11 @@ func (mr *MockPerNSWorkerComponentMockRecorder) DedicatedWorkerOptions(arg0 any)
 }
 
 // Register mocks base method.
-func (m *MockPerNSWorkerComponent) Register(arg0 worker.Registry, arg1 *namespace.Namespace, arg2 RegistrationDetails) {
+func (m *MockPerNSWorkerComponent) Register(arg0 worker.Registry, arg1 *namespace.Namespace, arg2 RegistrationDetails) func() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Register", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Register", arg0, arg1, arg2)
+	ret0, _ := ret[0].(func())
+	return ret0
 }
 
 // Register indicates an expected call of Register.


### PR DESCRIPTION
## What changed?
- Use dynamic config subscription for `schedulerNamespaceStartWorkflowRPS`.
- Simplify test that uses it.

## Why?
Faster reaction to changing rate limit and can simplify test.

## How did you test it?
updated functional test