### PR TITLE
OTEL span attributes

### DIFF
--- a/common/telemetry/attributes.go
+++ b/common/telemetry/attributes.go
@@ -1,0 +1,31 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package telemetry
+
+import "go.opentelemetry.io/otel/attribute"
+
+func WorkflowIdAttr(id string) attribute.KeyValue {
+	return attribute.String("temporal.workflow.id", id)
+}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Adds an OpenTelemetry (OTEL) span attribute:

- `temporal.workflow.id` annotates a span with the workflow id

PS: Note that only the top-most span is annotated with the workflow id. That's sufficient since the child spans do not need to be annotated again. That's why almost all annotations were added to the frontend handler; plus a few internal RPC calls.

PPS: Attributes were added _after_ the request validation. IMO this is good-enough for now and simplifies this change. Later, it could be moved higher up (with its own validation to ensure it doesn't crash) to include invalid requests, too.

## Why?
<!-- Tell your future self why have you made these changes -->

The workflow id allows to correlate traces (which spans are part of) that belong to the same workflow id.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Ran an internal OTEL tool I'm co-authoring; and it generates the expected output.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

(1) Existing functional tests are exercising the new code. However, it _could_ happen that an NPE slips through.

(2) OTEL is off by default, and so the performance impact is expected to be negligible (the span's method call is a noop).

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
