### PR TITLE
Fix raw_task_converter lock

### DIFF
--- a/service/history/replication/raw_task_converter.go
+++ b/service/history/replication/raw_task_converter.go
@@ -395,7 +395,7 @@ func generateStateReplicationTask(
 	ms, err := wfContext.LoadMutableState(ctx, shardContext)
 	switch err.(type) {
 	case nil:
-		return action(ms, release)
+		return action(ms, release) // do not access mutable state after this point
 	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 		return nil, nil
 	default:

--- a/service/history/replication/raw_task_converter.go
+++ b/service/history/replication/raw_task_converter.go
@@ -141,7 +141,7 @@ func convertActivityStateReplicationTask(
 		shardContext,
 		definition.NewWorkflowKey(taskInfo.NamespaceID, taskInfo.WorkflowID, taskInfo.RunID),
 		workflowCache,
-		func(mutableState workflow.MutableState) (*replicationspb.ReplicationTask, error) {
+		func(mutableState workflow.MutableState, releaseFunc wcache.ReleaseCacheFunc) (*replicationspb.ReplicationTask, error) {
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, nil
 			}
@@ -212,7 +212,7 @@ func convertWorkflowStateReplicationTask(
 		shardContext,
 		definition.NewWorkflowKey(taskInfo.NamespaceID, taskInfo.WorkflowID, taskInfo.RunID),
 		workflowCache,
-		func(mutableState workflow.MutableState) (*replicationspb.ReplicationTask, error) {
+		func(mutableState workflow.MutableState, releaseFunc wcache.ReleaseCacheFunc) (*replicationspb.ReplicationTask, error) {
 			state, _ := mutableState.GetWorkflowStateStatus()
 			if state != enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
 				return nil, nil
@@ -250,7 +250,7 @@ func convertSyncHSMReplicationTask(
 		shardContext,
 		definition.NewWorkflowKey(taskInfo.NamespaceID, taskInfo.WorkflowID, taskInfo.RunID),
 		workflowCache,
-		func(mutableState workflow.MutableState) (*replicationspb.ReplicationTask, error) {
+		func(mutableState workflow.MutableState, releaseFunc wcache.ReleaseCacheFunc) (*replicationspb.ReplicationTask, error) {
 			// HSM can be updated after workflow is completed
 			// so no check on workflow state here.
 
@@ -301,8 +301,8 @@ func convertSyncVersionedTransitionTask(
 		converter.shardContext,
 		definition.NewWorkflowKey(taskInfo.NamespaceID, taskInfo.WorkflowID, taskInfo.RunID),
 		converter.workflowCache,
-		func(mutableState workflow.MutableState) (*replicationspb.ReplicationTask, error) {
-			return converter.convert(ctx, taskInfo, targetClusterID, mutableState)
+		func(mutableState workflow.MutableState, releaseFunc wcache.ReleaseCacheFunc) (*replicationspb.ReplicationTask, error) {
+			return converter.convert(ctx, taskInfo, targetClusterID, mutableState, releaseFunc)
 		},
 	)
 }
@@ -375,7 +375,7 @@ func generateStateReplicationTask(
 	shardContext shard.Context,
 	workflowKey definition.WorkflowKey,
 	workflowCache wcache.Cache,
-	action func(workflow.MutableState) (*replicationspb.ReplicationTask, error),
+	action func(mutableState workflow.MutableState, releaseFunc wcache.ReleaseCacheFunc) (*replicationspb.ReplicationTask, error),
 ) (retReplicationTask *replicationspb.ReplicationTask, retError error) {
 	wfContext, release, err := workflowCache.GetOrCreateWorkflowExecution(
 		ctx,
@@ -395,7 +395,7 @@ func generateStateReplicationTask(
 	ms, err := wfContext.LoadMutableState(ctx, shardContext)
 	switch err.(type) {
 	case nil:
-		return action(ms)
+		return action(ms, release)
 	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 		return nil, nil
 	default:
@@ -634,6 +634,7 @@ func (c *syncVersionedTransitionTaskConverter) convert(
 	taskInfo *tasks.SyncVersionedTransitionTask,
 	targetClusterID int32,
 	mutableState workflow.MutableState,
+	releaseFunc wcache.ReleaseCacheFunc,
 ) (*replicationspb.ReplicationTask, error) {
 	executionInfo := mutableState.GetExecutionInfo()
 
@@ -653,6 +654,7 @@ func (c *syncVersionedTransitionTaskConverter) convert(
 		if taskInfo.FirstEventID == common.EmptyEventID && taskInfo.NextEventID == common.EmptyEventID && len(taskInfo.NewRunID) == 0 {
 			return nil, nil
 		}
+		releaseFunc(nil) // release wf lock before retrieving history events
 		return c.generateBackfillHistoryTask(ctx, taskInfo, targetClusterID)
 	}
 
@@ -660,6 +662,11 @@ func (c *syncVersionedTransitionTaskConverter) convert(
 	if progress != nil {
 		targetHistoryItems = progress.eventVersionHistoryItems
 	}
+	currentHistory, err := versionhistory.GetCurrentVersionHistory(executionInfo.VersionHistories)
+	if err != nil {
+		return nil, err
+	}
+	currentHistoryCopy := versionhistory.CopyVersionHistory(currentHistory)
 
 	result, err := c.syncStateRetriever.GetSyncWorkflowStateArtifactFromMutableState(
 		ctx,
@@ -671,15 +678,14 @@ func (c *syncVersionedTransitionTaskConverter) convert(
 		mutableState,
 		progress.LastSyncedTransition(),
 		targetHistoryItems,
+		releaseFunc,
 	)
 	if err != nil {
 		return nil, err
 	}
-	currentHistory, err := versionhistory.GetCurrentVersionHistory(executionInfo.VersionHistories)
-	if err != nil {
-		return nil, err
-	}
-	err = c.replicationCache.Update(taskInfo.RunID, targetClusterID, executionInfo.TransitionHistory, currentHistory.Items)
+	// do not access mutable state after this point
+
+	err = c.replicationCache.Update(taskInfo.RunID, targetClusterID, result.VersionedTransitionHistory, currentHistoryCopy.Items)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/replication/raw_task_converter_test.go
+++ b/service/history/replication/raw_task_converter_test.go
@@ -1470,6 +1470,7 @@ func (s *rawTaskConverterSuite) TestConvertSyncVersionedTransitionTask_Mutation(
 				},
 			},
 		},
+		VersionedTransitionHistory: transitionHistory,
 	}
 	s.syncStateRetriever.EXPECT().GetSyncWorkflowStateArtifactFromMutableState(
 		ctx,
@@ -1481,6 +1482,7 @@ func (s *rawTaskConverterSuite) TestConvertSyncVersionedTransitionTask_Mutation(
 		s.mutableState,
 		nil,
 		nil,
+		gomock.Any(),
 	).Return(syncResult, nil)
 	converter := newSyncVersionedTransitionTaskConverter(s.shardContext, s.workflowCache, nil, s.progressCache, s.executionManager, s.syncStateRetriever, s.logger)
 	result, err := convertSyncVersionedTransitionTask(ctx, task, targetClusterID, converter)

--- a/service/history/replication/sync_state_retriever.go
+++ b/service/history/replication/sync_state_retriever.go
@@ -53,8 +53,6 @@ import (
 )
 
 const (
-	Mutation ResultType = iota
-	Snapshot
 	defaultPageSize = 32
 )
 
@@ -80,6 +78,7 @@ type (
 			mutableState workflow.MutableState,
 			targetVersionedTransition *persistencepb.VersionedTransition,
 			targetVersionHistories [][]*history.VersionHistoryItem,
+			releaseFunc wcache.ReleaseCacheFunc,
 		) (*SyncStateResult, error)
 	}
 
@@ -150,7 +149,7 @@ func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifact(
 		}
 	}
 
-	return s.getSyncStateResult(ctx, namespaceID, execution, mu, targetCurrentVersionedTransition, versionHistoriesItems, &releaseFunc)
+	return s.getSyncStateResult(ctx, namespaceID, execution, mu, targetCurrentVersionedTransition, versionHistoriesItems, releaseFunc)
 }
 
 func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifactFromMutableState(
@@ -160,8 +159,9 @@ func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifactFromMutableState(
 	mu workflow.MutableState,
 	targetCurrentVersionedTransition *persistencepb.VersionedTransition,
 	targetVersionHistories [][]*history.VersionHistoryItem,
+	releaseFunc wcache.ReleaseCacheFunc,
 ) (_ *SyncStateResult, retError error) {
-	return s.getSyncStateResult(ctx, namespaceID, execution, mu, targetCurrentVersionedTransition, targetVersionHistories, nil)
+	return s.getSyncStateResult(ctx, namespaceID, execution, mu, targetCurrentVersionedTransition, targetVersionHistories, releaseFunc)
 }
 
 func (s *SyncStateRetrieverImpl) getSyncStateResult(
@@ -171,7 +171,7 @@ func (s *SyncStateRetrieverImpl) getSyncStateResult(
 	mu workflow.MutableState,
 	targetCurrentVersionedTransition *persistencepb.VersionedTransition,
 	targetVersionHistories [][]*history.VersionHistoryItem,
-	cacheReleaseFunc *wcache.ReleaseCacheFunc,
+	cacheReleaseFunc wcache.ReleaseCacheFunc,
 ) (_ *SyncStateResult, retError error) {
 	shouldReturnMutation := func() bool {
 		if targetCurrentVersionedTransition == nil {
@@ -224,8 +224,8 @@ func (s *SyncStateRetrieverImpl) getSyncStateResult(
 	sourceVersionHistories := versionhistory.CopyVersionHistories(mu.GetExecutionInfo().VersionHistories)
 	sourceTransitionHistory := workflow.CopyVersionedTransitions(mu.GetExecutionInfo().TransitionHistory)
 	if cacheReleaseFunc != nil {
-		(*cacheReleaseFunc)(nil)
-		*cacheReleaseFunc = nil
+		(cacheReleaseFunc)(nil)
+		cacheReleaseFunc = nil
 	}
 
 	if len(newRunId) > 0 {

--- a/service/history/replication/sync_state_retriever.go
+++ b/service/history/replication/sync_state_retriever.go
@@ -224,8 +224,7 @@ func (s *SyncStateRetrieverImpl) getSyncStateResult(
 	sourceVersionHistories := versionhistory.CopyVersionHistories(mu.GetExecutionInfo().VersionHistories)
 	sourceTransitionHistory := workflow.CopyVersionedTransitions(mu.GetExecutionInfo().TransitionHistory)
 	if cacheReleaseFunc != nil {
-		(cacheReleaseFunc)(nil)
-		cacheReleaseFunc = nil
+		cacheReleaseFunc(nil)
 	}
 
 	if len(newRunId) > 0 {

--- a/service/history/replication/sync_state_retriever_mock.go
+++ b/service/history/replication/sync_state_retriever_mock.go
@@ -41,6 +41,7 @@ import (
 	history "go.temporal.io/server/api/history/v1"
 	persistence "go.temporal.io/server/api/persistence/v1"
 	workflow "go.temporal.io/server/service/history/workflow"
+	cache "go.temporal.io/server/service/history/workflow/cache"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -83,18 +84,18 @@ func (mr *MockSyncStateRetrieverMockRecorder) GetSyncWorkflowStateArtifact(ctx, 
 }
 
 // GetSyncWorkflowStateArtifactFromMutableState mocks base method.
-func (m *MockSyncStateRetriever) GetSyncWorkflowStateArtifactFromMutableState(ctx context.Context, namespaceID string, execution *common.WorkflowExecution, mutableState workflow.MutableState, targetVersionedTransition *persistence.VersionedTransition, targetVersionHistories [][]*history.VersionHistoryItem) (*SyncStateResult, error) {
+func (m *MockSyncStateRetriever) GetSyncWorkflowStateArtifactFromMutableState(ctx context.Context, namespaceID string, execution *common.WorkflowExecution, mutableState workflow.MutableState, targetVersionedTransition *persistence.VersionedTransition, targetVersionHistories [][]*history.VersionHistoryItem, releaseFunc cache.ReleaseCacheFunc) (*SyncStateResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSyncWorkflowStateArtifactFromMutableState", ctx, namespaceID, execution, mutableState, targetVersionedTransition, targetVersionHistories)
+	ret := m.ctrl.Call(m, "GetSyncWorkflowStateArtifactFromMutableState", ctx, namespaceID, execution, mutableState, targetVersionedTransition, targetVersionHistories, releaseFunc)
 	ret0, _ := ret[0].(*SyncStateResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSyncWorkflowStateArtifactFromMutableState indicates an expected call of GetSyncWorkflowStateArtifactFromMutableState.
-func (mr *MockSyncStateRetrieverMockRecorder) GetSyncWorkflowStateArtifactFromMutableState(ctx, namespaceID, execution, mutableState, targetVersionedTransition, targetVersionHistories any) *gomock.Call {
+func (mr *MockSyncStateRetrieverMockRecorder) GetSyncWorkflowStateArtifactFromMutableState(ctx, namespaceID, execution, mutableState, targetVersionedTransition, targetVersionHistories, releaseFunc any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyncWorkflowStateArtifactFromMutableState", reflect.TypeOf((*MockSyncStateRetriever)(nil).GetSyncWorkflowStateArtifactFromMutableState), ctx, namespaceID, execution, mutableState, targetVersionedTransition, targetVersionHistories)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyncWorkflowStateArtifactFromMutableState", reflect.TypeOf((*MockSyncStateRetriever)(nil).GetSyncWorkflowStateArtifactFromMutableState), ctx, namespaceID, execution, mutableState, targetVersionedTransition, targetVersionHistories, releaseFunc)
 }
 
 // MocklastUpdatedStateTransitionGetter is a mock of lastUpdatedStateTransitionGetter interface.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix raw_task_converter lock usage when converting sync versioned transition task
## Why?
<!-- Tell your future self why have you made these changes -->
Not holding the lock when doing io for reading history events from cache
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no risk. Feature not enabled.
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
no.
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
no