### PR TITLE
Revert "Deprecate StartTime filed in WorkflowExecutionInfo (#6489)"

### DIFF
--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -333,7 +333,7 @@ func (p *visibilityManagerImpl) convertInternalWorkflowExecutionInfo(
 	// Remove this "if" block when ExecutionTime field has actual correct value (added 6/9/21).
 	// Affects only non-advanced visibility.
 	if !executionInfo.ExecutionTime.AsTime().After(time.Unix(0, 0)) {
-		executionInfo.ExecutionTime = timestamppb.New(internalExecution.StartTime)
+		executionInfo.ExecutionTime = executionInfo.StartTime
 	}
 
 	return executionInfo, nil

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -124,7 +124,7 @@ func Invoke(
 				RunId:      executionState.RunId,
 			},
 			Type:          &commonpb.WorkflowType{Name: executionInfo.WorkflowTypeName},
-			StartTime:     executionState.StartTime,
+			StartTime:     executionInfo.StartTime,
 			Status:        executionState.Status,
 			HistoryLength: mutableState.GetNextEventID() - common.FirstEventID,
 			ExecutionTime: executionInfo.ExecutionTime,

--- a/service/history/api/queryworkflow/api.go
+++ b/service/history/api/queryworkflow/api.go
@@ -256,7 +256,7 @@ func queryWillTimeoutsBeforeFirstWorkflowTaskStart(
 	startAttr := startEvent.GetWorkflowExecutionStartedEventAttributes()
 	workflowTaskBackoffDuration := timestamp.DurationValue(startAttr.GetFirstWorkflowTaskBackoff())
 
-	workflowStart := mutableState.GetExecutionState().StartTime.AsTime().UTC()
+	workflowStart := mutableState.GetExecutionInfo().StartTime.AsTime().UTC()
 	workflowTaskStart := workflowStart.Add(workflowTaskBackoffDuration)
 
 	deadline, ok := ctx.Deadline()

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -159,7 +159,7 @@ func createWorkflowMutationFunction(
 	}
 	currentMutableState := currentWorkflowLease.GetMutableState()
 	currentExecutionState := currentMutableState.GetExecutionState()
-	currentWorkflowStartTime := currentMutableState.GetExecutionState().StartTime.AsTime()
+	currentWorkflowStartTime := currentMutableState.GetExecutionInfo().StartTime.AsTime()
 
 	// It is unclear if currentExecutionState.RunId is the same as
 	// currentWorkflowLease.GetContext().GetWorkflowKey().RunID
@@ -325,8 +325,7 @@ func signalWorkflow(
 	if !mutableState.HasPendingWorkflowTask() && !request.GetSkipGenerateWorkflowTask() {
 
 		executionInfo := mutableState.GetExecutionInfo()
-		executionState := mutableState.GetExecutionState()
-		if !mutableState.HadOrHasWorkflowTask() && !executionInfo.ExecutionTime.AsTime().Equal(executionState.StartTime.AsTime()) {
+		if !mutableState.HadOrHasWorkflowTask() && !executionInfo.ExecutionTime.AsTime().Equal(executionInfo.StartTime.AsTime()) {
 			metrics.SignalWithStartSkipDelayCounter.With(shardContext.GetMetricsHandler()).Record(1, metrics.NamespaceTag(request.GetNamespace()))
 
 			workflowKey := workflowLease.GetContext().GetWorkflowKey()

--- a/service/history/archival_queue_task_executor.go
+++ b/service/history/archival_queue_task_executor.go
@@ -228,7 +228,7 @@ func (e *archivalQueueTaskExecutor) getArchiveTaskRequest(
 		HistoryURI:           historyURI,
 		VisibilityURI:        visibilityURI,
 		WorkflowTypeName:     executionInfo.GetWorkflowTypeName(),
-		StartTime:            executionState.GetStartTime(),
+		StartTime:            executionInfo.GetStartTime(),
 		ExecutionTime:        executionInfo.GetExecutionTime(),
 		CloseTime:            timestamppb.New(closeTime),
 		ExecutionDuration:    durationpb.New(executionDuration),

--- a/service/history/archival_queue_task_executor_test.go
+++ b/service/history/archival_queue_task_executor_test.go
@@ -429,15 +429,15 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 				).AnyTimes()
 				executionInfo := &persistence.WorkflowExecutionInfo{
 					NamespaceId:                  tests.NamespaceID.String(),
+					StartTime:                    timestamppb.New(p.StartTime),
 					ExecutionTime:                timestamppb.New(p.ExecutionTime),
 					CloseTime:                    timestamppb.New(p.CloseTime),
 					CloseVisibilityTaskCompleted: p.CloseVisibilityTaskCompleted,
 				}
 				mutableState.EXPECT().GetExecutionInfo().Return(executionInfo).AnyTimes()
 				executionState := &persistence.WorkflowExecutionState{
-					State:     0,
-					Status:    0,
-					StartTime: timestamppb.New(p.StartTime),
+					State:  0,
+					Status: 0,
 				}
 				mutableState.EXPECT().GetExecutionState().Return(executionState).AnyTimes()
 				if p.ExpectAddTask {

--- a/service/history/ndc/conflict_resolver.go
+++ b/service/history/ndc/conflict_resolver.go
@@ -166,7 +166,7 @@ func (r *ConflictResolverImpl) rebuild(
 
 	rebuildMutableState, _, err := r.stateRebuilder.Rebuild(
 		ctx,
-		timestamp.TimeValue(executionState.StartTime),
+		timestamp.TimeValue(executionInfo.StartTime),
 		workflowKey,
 		replayVersionHistory.GetBranchToken(),
 		lastItem.GetEventId(),

--- a/service/history/ndc/state_rebuilder_test.go
+++ b/service/history/ndc/state_rebuilder_test.go
@@ -375,6 +375,6 @@ func (s *stateRebuilderSuite) TestRebuild() {
 			[]*historyspb.VersionHistoryItem{versionhistory.NewVersionHistoryItem(lastEventID, version)},
 		),
 	), rebuildMutableState.GetExecutionInfo().GetVersionHistories())
-	s.Equal(timestamp.TimeValue(rebuildMutableState.GetExecutionState().StartTime), s.now)
+	s.Equal(timestamp.TimeValue(rebuildMutableState.GetExecutionInfo().StartTime), s.now)
 	s.Equal(expectedLastFirstTransactionID, rebuildExecutionInfo.LastFirstEventTxnId)
 }

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -310,7 +310,7 @@ func (r *workflowResetterImpl) prepareResetWorkflow(
 	}
 
 	if err := r.failInflightActivity(
-		resetMutableState.GetExecutionState().StartTime.AsTime(),
+		resetMutableState.GetExecutionInfo().StartTime.AsTime(),
 		resetMutableState,
 		resetReason,
 	); err != nil {

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -1599,8 +1599,9 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowRunTimeout_Cron() {
 		},
 	)
 	s.Nil(err)
-	mutableState.GetExecutionState().StartTime = timestamppb.New(s.now)
-	mutableState.GetExecutionInfo().CronSchedule = "* * * * *"
+	executionInfo := mutableState.GetExecutionInfo()
+	executionInfo.StartTime = timestamppb.New(s.now)
+	executionInfo.CronSchedule = "* * * * *"
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	startEvent := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1656,8 +1657,9 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowRunTimeout_WorkflowExpir
 		},
 	)
 	s.Nil(err)
-	mutableState.GetExecutionState().StartTime = timestamppb.New(s.now)
-	mutableState.GetExecutionInfo().CronSchedule = "* * * * *"
+	executionInfo := mutableState.GetExecutionInfo()
+	executionInfo.StartTime = timestamppb.New(s.now)
+	executionInfo.CronSchedule = "* * * * *"
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	startEvent := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())

--- a/service/history/visibility_queue_task_executor.go
+++ b/service/history/visibility_queue_task_executor.go
@@ -350,7 +350,7 @@ func (t *visibilityQueueTaskExecutor) getVisibilityRequestBase(
 ) *manager.VisibilityRequestBase {
 	var (
 		executionInfo    = mutableState.GetExecutionInfo()
-		startTime        = timestamp.TimeValue(mutableState.GetExecutionState().GetStartTime())
+		startTime        = timestamp.TimeValue(executionInfo.GetStartTime())
 		executionTime    = timestamp.TimeValue(executionInfo.GetExecutionTime())
 		visibilityMemo   = getWorkflowMemo(copyMapPayload(executionInfo.Memo))
 		searchAttributes = getSearchAttributes(copyMapPayload(executionInfo.SearchAttributes))

--- a/service/history/visibility_queue_task_executor_test.go
+++ b/service/history/visibility_queue_task_executor_test.go
@@ -614,7 +614,7 @@ func (s *visibilityQueueTaskExecutorSuite) createVisibilityRequestBase(
 		Namespace:        namespaceName,
 		Execution:        execution,
 		WorkflowTypeName: executionInfo.WorkflowTypeName,
-		StartTime:        timestamp.TimeValue(mutableState.GetExecutionState().GetStartTime()),
+		StartTime:        timestamp.TimeValue(executionInfo.GetStartTime()),
 		Status:           mutableState.GetExecutionState().GetStatus(),
 		ExecutionTime:    timestamp.TimeValue(executionInfo.GetExecutionTime()),
 		TaskID:           task.GetTaskID(),

--- a/service/history/workflow/context_test.go
+++ b/service/history/workflow/context_test.go
@@ -398,6 +398,7 @@ func (s *contextSuite) TestRefreshTask() {
 			NamespaceId:        tests.NamespaceID.String(),
 			WorkflowId:         tests.WorkflowID,
 			WorkflowRunTimeout: timestamp.DurationFromSeconds(200),
+			StartTime:          timestamppb.New(now),
 			ExecutionTime:      timestamppb.New(now),
 			VersionHistories: &historyspb.VersionHistories{
 				Histories: []*historyspb.VersionHistory{
@@ -420,10 +421,9 @@ func (s *contextSuite) TestRefreshTask() {
 			},
 		},
 		ExecutionState: &persistencespb.WorkflowExecutionState{
-			RunId:     tests.RunID,
-			State:     enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
-			Status:    enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-			StartTime: timestamppb.New(now),
+			RunId:  tests.RunID,
+			State:  enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+			Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
 		},
 		NextEventId: 2,
 	}

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -628,7 +628,7 @@ func (s *mutableStateSuite) TestContinueAsNewMinBackoff() {
 	s.True(minBackoff == backoff)
 
 	// set start time to be 3s ago
-	s.mutableState.executionState.StartTime = timestamppb.New(time.Now().Add(-time.Second * 3))
+	s.mutableState.executionInfo.StartTime = timestamppb.New(time.Now().Add(-time.Second * 3))
 	// with no backoff, verify min backoff is in [0, 2s]
 	minBackoff = s.mutableState.ContinueAsNewMinBackoff(nil).AsDuration()
 	s.NotNil(minBackoff)
@@ -641,7 +641,7 @@ func (s *mutableStateSuite) TestContinueAsNewMinBackoff() {
 	s.True(minBackoff == backoff)
 
 	// set start time to be 5s ago
-	s.mutableState.executionState.StartTime = timestamppb.New(time.Now().Add(-time.Second * 5))
+	s.mutableState.executionInfo.StartTime = timestamppb.New(time.Now().Add(-time.Second * 5))
 	// with no backoff, verify backoff unchanged (no backoff needed)
 	minBackoff = s.mutableState.ContinueAsNewMinBackoff(nil).AsDuration()
 	s.Zero(minBackoff)
@@ -1056,6 +1056,7 @@ func (s *mutableStateSuite) buildWorkflowMutableState() *persistencespb.Workflow
 		DefaultWorkflowTaskTimeout:              timestamp.DurationFromSeconds(100),
 		LastCompletedWorkflowTaskStartedEventId: int64(99),
 		LastUpdateTime:                          timestamp.TimeNowPtrUtc(),
+		StartTime:                               startTime,
 		ExecutionTime:                           startTime,
 		WorkflowTaskVersion:                     failoverVersion,
 		WorkflowTaskScheduledEventId:            101,
@@ -1084,10 +1085,9 @@ func (s *mutableStateSuite) buildWorkflowMutableState() *persistencespb.Workflow
 	}
 
 	state := &persistencespb.WorkflowExecutionState{
-		RunId:     we.GetRunId(),
-		State:     enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
-		Status:    enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		StartTime: startTime,
+		RunId:  we.GetRunId(),
+		State:  enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+		Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
 	}
 
 	activityInfos := map[int64]*persistencespb.ActivityInfo{

--- a/service/history/workflow/test_util.go
+++ b/service/history/workflow/test_util.go
@@ -54,7 +54,7 @@ func TestLocalMutableState(
 	ms.executionInfo.NamespaceId = string(ns.ID())
 	ms.executionInfo.WorkflowId = workflowID
 	ms.executionState.RunId = runID
-	ms.GetExecutionInfo().ExecutionTime = ms.GetExecutionState().StartTime
+	ms.GetExecutionInfo().ExecutionTime = ms.GetExecutionInfo().StartTime
 	_ = ms.SetHistoryTree(nil, nil, runID)
 
 	return ms
@@ -103,7 +103,7 @@ func TestGlobalMutableState(
 ) *MutableStateImpl {
 
 	ms := NewMutableState(shard, eventsCache, logger, tests.GlobalNamespaceEntry, workflowID, runID, time.Now().UTC())
-	ms.GetExecutionInfo().ExecutionTime = ms.GetExecutionState().StartTime
+	ms.GetExecutionInfo().ExecutionTime = ms.GetExecutionInfo().StartTime
 	_ = ms.UpdateCurrentVersion(version, false)
 	_ = ms.SetHistoryTree(nil, nil, runID)
 


### PR DESCRIPTION
## What changed?
This reverts commit f50a5908c211311a3c96c14e2ee0538f04f8e9f4  (#6489)

## Why?
Downgrade compatibility