### PR TITLE
tdbg: fallback to encode history to text if JSON encoding failed

### DIFF
--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -48,6 +48,7 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/service/history/tasks"
+	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -111,22 +112,39 @@ func AdminShowWorkflow(c *cli.Context, clientFactory ClientFactory) error {
 
 	var historyBatches []*historypb.History
 	totalSize := 0
+	var errs []error
 	for idx, b := range histories {
 		totalSize += len(b.Data)
 		fmt.Fprintf(c.App.Writer, "======== batch %v, blob len: %v ======\n", idx+1, len(b.Data))
 		historyBatch, err := serializer.DeserializeEvents(b)
 		if err != nil {
-			return fmt.Errorf("unable to deserialize Events: %s", err)
+			err := fmt.Errorf("unable to deserialize Events: %s", err)
+			fmt.Fprintln(c.App.Writer, err)
+			errs = append(errs, err)
+			continue
 		}
 		historyBatches = append(historyBatches, &historypb.History{Events: historyBatch})
 		encoder := codec.NewJSONPBEncoder()
 		data, err := encoder.EncodeHistoryEvents(historyBatch)
 		if err != nil {
-			return fmt.Errorf("unable to encode History Events: %s", err)
+			err := fmt.Errorf("unable to encode History Events: %s", err)
+			fmt.Fprintln(c.App.Writer, err)
+			text, terr := prototext.Marshal(&historypb.History{Events: historyBatch})
+			if terr == nil {
+				fmt.Fprintln(c.App.Writer, "marshal to text:")
+				fmt.Fprintln(c.App.Writer, string(text))
+			}
+			errs = append(errs, err)
+			continue
 		}
 		fmt.Fprintln(c.App.Writer, string(data))
 	}
 	fmt.Fprintf(c.App.Writer, "======== total batches %v, total blob len: %v ======\n", len(histories), totalSize)
+
+	err = errors.Join(errs...)
+	if err != nil {
+		return err
+	}
 
 	if outputFileName != "" {
 		encoder := codec.NewJSONPBEncoder()

--- a/tools/tdbg/decode_commands.go
+++ b/tools/tdbg/decode_commands.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/codec"
+	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -96,9 +97,15 @@ func AdminDecodeProto(c *cli.Context) error {
 	encoder := codec.NewJSONPBIndentEncoder(" ")
 	json, err := encoder.Encode(message)
 	if err != nil {
-		return fmt.Errorf("unable to encode to JSON: %s", err)
+		err := fmt.Errorf("unable to encode to JSON: %s", err)
+		text, terr := prototext.Marshal(message)
+		if terr != nil {
+			return err
+		}
+		fmt.Fprintln(c.App.Writer, err)
+		fmt.Fprintln(c.App.Writer, "marshal to text:")
+		json = text
 	}
-	fmt.Fprintln(c.App.Writer)
 	fmt.Fprintln(c.App.Writer, string(json))
 	return nil
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
`tdbg`: fallback to encode history to text if JSON encoding failed.

## Why?
<!-- Tell your future self why have you made these changes -->
Under some weird circumstances JSON encoding might not work but it is still useful to see as much data as we can. Text marshaling seems always work.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run `tdbg` for problematic blobs with wrong durations.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.