### PR TITLE
Summarize test results

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -263,6 +263,16 @@ jobs:
           TEST_ARGS: ${{ needs.set-up-single-test.outputs.single_test_args }}
           TEST_TIMEOUT: ${{ needs.set-up-single-test.outputs.test_timeout }}
 
+      - name: Generate test summary
+        uses: mikepenz/action-junit-report@v5.0.0-rc01
+        if: failure()
+        with:
+          report_paths: ./.testoutput/*.junit.xml
+          detailed_summary: true
+          check_annotations: false
+          annotate_only: true
+          skip_annotations: true
+
       - name: Upload test results
         # Can't pin to major because the action linter doesn't recognize the include-hidden-files flag.
         uses: actions/upload-artifact@v4.4.3
@@ -331,6 +341,16 @@ jobs:
       - name: Run integration test
         timeout-minutes: 15
         run: make integration-test-coverage
+
+      - name: Generate test summary
+        uses: mikepenz/action-junit-report@v5.0.0-rc01
+        if: failure()
+        with:
+          report_paths: ./.testoutput/*.junit.xml
+          detailed_summary: true
+          check_annotations: false
+          annotate_only: true
+          skip_annotations: true
 
       - name: Upload test results
         # Can't pin to major because the action linter doesn't recognize the include-hidden-files flag.
@@ -455,6 +475,16 @@ jobs:
         env:
           TEST_ARGS: ${{ needs.set-up-single-test.outputs.single_test_args }}
 
+      - name: Generate test summary
+        uses: mikepenz/action-junit-report@v5.0.0-rc01
+        if: failure()
+        with:
+          report_paths: ./.testoutput/*.junit.xml
+          detailed_summary: true
+          check_annotations: false
+          annotate_only: true
+          skip_annotations: true
+
       - name: Upload test results
         # Can't pin to major because the action linter doesn't recognize the include-hidden-files flag.
         uses: actions/upload-artifact@v4.4.3
@@ -551,6 +581,16 @@ jobs:
       - name: Run functional test xdc
         timeout-minutes: 25   # update this to TEST_TIMEOUT+5 if you update the Makefile
         run: make functional-test-xdc-coverage
+
+      - name: Generate test summary
+        uses: mikepenz/action-junit-report@v5.0.0-rc01
+        if: failure()
+        with:
+          report_paths: ./.testoutput/*.junit.xml
+          detailed_summary: true
+          check_annotations: false
+          annotate_only: true
+          skip_annotations: true
 
       - name: Upload test results
         # Can't pin to major because the action linter doesn't recognize the include-hidden-files flag.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Added GitHub Action to publish test summaries; using https://github.com/mikepenz/action-junit-report.

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/98571482-1efc-4695-878c-9610eedb75ef">


## Why?
<!-- Tell your future self why have you made these changes -->

Finding the failed tests in the GitHub Action logs is very tedious. This step prints a summary of the failed tests for quick consumption by the developer.

## How did you test it?

Example: https://github.com/temporalio/temporal/actions/runs/11636133070?pr=6594

_NOTE: the GHA attempts to write annotate but cannot do that successfully since the JUnit XML reports Go packages, no Go file paths. I filed an issue with the GHA asking for an option to disable them. But in the meantime, they are harmless - albeit a bit annoying._

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
