### PR TITLE
Add special handling for context.Canceled and context.DeadlineExceeded error types

### DIFF
--- a/common/persistence/persistence_metric_clients.go
+++ b/common/persistence/persistence_metric_clients.go
@@ -32,6 +32,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -1293,6 +1294,10 @@ func (p *metricEmitter) recordRequestMetrics(operation string, caller string, la
 func updateErrorMetric(handler metrics.Handler, logger log.Logger, operation string, err error) {
 	if err != nil {
 		metrics.PersistenceErrorWithType.With(handler).Record(1, metrics.ServiceErrorTypeTag(err))
+		if common.IsContextCanceledErr(err) {
+			// no-op
+			return
+		}
 		switch err := err.(type) {
 		case *ShardAlreadyExistError,
 			*ShardOwnershipLostError,

--- a/common/util/error_type.go
+++ b/common/util/error_type.go
@@ -25,6 +25,7 @@
 package util
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -55,6 +56,16 @@ func ErrorType(err error) string {
 	if errors.As(err, &typedErr) {
 		return typedErr.ErrorTypeName()
 	}
+
+	// Special case for context.Cancel error. It is of type errorString, which is not very useful.
+	if errors.Is(err, context.Canceled) {
+		return "context.Canceled"
+	}
+	// Special case for context.DeadlineExceeded error. It is of unexported type deadlineExceededError.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "context.DeadlineExceeded"
+	}
+
 	// Otherwise, do a DFS traversal of the error tree, ignoring wrapper errors.
 	q := []error{err}
 	for len(q) > 0 {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add special handling for `context.Canceled` and `context.DeadlineExceeded` error types.

## Why?
<!-- Tell your future self why have you made these changes -->
When logging or emitting metrics, `errors.errorString` error type is not useful. Changing `context.deadlineExceededError` to `context.DeadlineExceeded` also for consistency.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.