### PR TITLE
Fix flaky test: TestForwardingWhenBacklogIsYoung

### DIFF
--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -267,7 +267,7 @@ func (t *MatcherTestSuite) TestRejectSyncMatchWhenBacklog() {
 func (t *MatcherTestSuite) TestForwardingWhenBacklogIsYoung() {
 	historyTask := newInternalTaskForSyncMatch(randomTaskInfo().Data, nil)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	intruptC := make(chan struct{})
 
 	var wg sync.WaitGroup
@@ -280,7 +280,7 @@ func (t *MatcherTestSuite) TestForwardingWhenBacklogIsYoung() {
 	).Return(&matchingservice.PollWorkflowTaskQueueResponse{}, errMatchingHostThrottleTest)
 
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		// poll forwarding attempt happens when there is no backlog
 		_, err := t.childMatcher.Poll(ctx, &pollMetadata{})
 		t.Assert().NoError(err)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Fixes flaky `MatcherTestSuite/TestForwardingWhenBacklogIsYoung`
- I noticed this unit test was flaking by running the test about 3000 times.
- This was happening because it was not using proper synchronization to ensure that poller and consumer forwarding was done. (tldr - the existing `time.sleep` were not sufficient sometimes which is why the test was throwing errors)
<img width="872" alt="Screenshot 2024-10-06 at 8 44 17 PM" src="https://github.com/user-attachments/assets/8eb38387-cf19-4e97-be51-dd92673c8602">

## Why?
<!-- Tell your future self why have you made these changes -->
- To resolve flakiness. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- I ran the modified test 30000 times and it passed.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
None

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
I don't think so, since this is a unit test.
