### PR TITLE
Nexus: Better handling of nil and empty payloads

### DIFF
--- a/common/nexus/payload_serializer.go
+++ b/common/nexus/payload_serializer.go
@@ -129,11 +129,13 @@ func (payloadSerializer) Serialize(v any) (*nexus.Content, error) {
 		return nil, fmt.Errorf("%w: cannot serialize %v", errSerializer, v)
 	}
 
+	// Use the "nil" Nexus Content representation for nil Payloads.
 	if payload == nil {
-		return &nexus.Content{}, nil
+		// Use same structure as the nil serializer from the Nexus Go SDK.
+		return &nexus.Content{Header: nexus.Header{}}, nil
 	}
 
-	if payload.GetMetadata() == nil {
+	if len(payload.GetMetadata()) == 0 {
 		return xTemporalPayload(payload)
 	}
 

--- a/common/nexus/payload_serializer_test.go
+++ b/common/nexus/payload_serializer_test.go
@@ -65,6 +65,13 @@ func TestNexusPayloadSerializer(t *testing.T) {
 			header:       nexus.Header{},
 		},
 		{
+			// Empty payload is preserved.
+			name:            "empty",
+			inputPayload:    &commonpb.Payload{},
+			expectedPayload: &commonpb.Payload{},
+			header:          nexus.Header{"type": "application/x-temporal-payload"},
+		},
+		{
 			name:         "json proto",
 			inputPayload: mustToPayload(t, commonpb.RetryPolicy{}),
 			header: nexus.Header{
@@ -104,15 +111,16 @@ func TestNexusPayloadSerializer(t *testing.T) {
 					"encoding": []byte("binary/null"),
 				},
 			},
-			// Yes this is the default value, but this test should have an explicit expectation.
-			header: nil,
+			header: nexus.Header{},
 		},
 		{
-			name:         "nil metadata",
-			inputPayload: &commonpb.Payload{},
+			name: "nil metadata non-empty data",
+			inputPayload: &commonpb.Payload{
+				Data: []byte("not empty"),
+			},
 			expectedPayload: &commonpb.Payload{
 				Metadata: map[string][]byte{},
-				Data:     []byte{},
+				Data:     []byte("not empty"),
 			},
 			header: nexus.Header{"type": "application/x-temporal-payload"},
 		},

--- a/common/testing/mocksdk/worker_mock.go
+++ b/common/testing/mocksdk/worker_mock.go
@@ -36,6 +36,7 @@ package mocksdk
 import (
 	reflect "reflect"
 
+	nexus "github.com/nexus-rpc/sdk-go/nexus"
 	activity "go.temporal.io/sdk/activity"
 	workflow "go.temporal.io/sdk/workflow"
 	gomock "go.uber.org/mock/gomock"
@@ -86,6 +87,18 @@ func (m *MockWorker) RegisterActivityWithOptions(arg0 any, arg1 activity.Registe
 func (mr *MockWorkerMockRecorder) RegisterActivityWithOptions(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterActivityWithOptions", reflect.TypeOf((*MockWorker)(nil).RegisterActivityWithOptions), arg0, arg1)
+}
+
+// RegisterNexusService mocks base method.
+func (m *MockWorker) RegisterNexusService(arg0 *nexus.Service) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterNexusService", arg0)
+}
+
+// RegisterNexusService indicates an expected call of RegisterNexusService.
+func (mr *MockWorkerMockRecorder) RegisterNexusService(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterNexusService", reflect.TypeOf((*MockWorker)(nil).RegisterNexusService), arg0)
 }
 
 // RegisterWorkflow mocks base method.

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.27.0
 	go.opentelemetry.io/otel/trace v1.27.0
 	go.temporal.io/api v1.39.1-0.20240910163028-b13574e18f3c
-	go.temporal.io/sdk v1.27.0
+	go.temporal.io/sdk v1.29.1
 	go.temporal.io/version v0.3.0
 	go.uber.org/atomic v1.11.0
 	go.uber.org/automaxprocs v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ go.opentelemetry.io/proto/otlp v1.2.0 h1:pVeZGk7nXDC9O2hncA6nHldxEjm6LByfA2aN8IO
 go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naRm/KDsgaHD8A=
 go.temporal.io/api v1.39.1-0.20240910163028-b13574e18f3c h1:1mORGBzFqhOn4I+Yg/KT07UQtHV59wptGxsPRB0rGIk=
 go.temporal.io/api v1.39.1-0.20240910163028-b13574e18f3c/go.mod h1:1WwYUMo6lao8yl0371xWUm13paHExN5ATYT/B7QtFis=
-go.temporal.io/sdk v1.27.0 h1:C5oOE/IRyLcZaFoB13kEHsjvSHEnGcwT6bNys0HFFHk=
-go.temporal.io/sdk v1.27.0/go.mod h1:PnOq5f3dWuU2NAbY+yczXkIeycsIIdBtoCO62ZE0aak=
+go.temporal.io/sdk v1.29.1 h1:y+sUMbUhTU9rj50mwIZAPmcXCtgUdOWS9xHDYRYSgZ0=
+go.temporal.io/sdk v1.29.1/go.mod h1:kp//DRvn3CqQVBCtjL51Oicp9wrZYB2s6row1UgzcKQ=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
 go.temporal.io/version v0.3.0/go.mod h1:UA9S8/1LaKYae6TyD9NaPMJTZb911JcbqghI2CBSP78=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -575,14 +575,12 @@ func (ms *MutableStateImpl) GetNexusCompletion(ctx context.Context) (nexus.Opera
 	switch ce.GetEventType() {
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:
 		payloads := ce.GetWorkflowExecutionCompletedEventAttributes().GetResult().GetPayloads()
-		var p *commonpb.Payload
+		var p *commonpb.Payload // default to nil, the payload serializer converts nil to Nexus nil Content.
 		if len(payloads) > 0 {
 			// All of our SDKs support returning a single value from workflows, we can safely ignore the
 			// rest of the payloads. Additionally, even if a workflow could return more than a single value,
 			// Nexus does not support it.
 			p = payloads[0]
-		} else {
-			p = &commonpb.Payload{}
 		}
 		completion, err := nexus.NewOperationCompletionSuccessful(p, nexus.OperationCompletionSuccesfulOptions{
 			Serializer: commonnexus.PayloadSerializer,

--- a/tests/nexus/nexus_workflow_test.go
+++ b/tests/nexus/nexus_workflow_test.go
@@ -43,10 +43,13 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/operatorservice/v1"
-	"go.temporal.io/api/taskqueue/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/temporalnexus"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -110,7 +113,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation() {
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		pollResp, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.Namespace(),
-			TaskQueue: &taskqueue.TaskQueue{
+			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 				Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 			},
@@ -140,7 +143,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation() {
 	// Poll and wait for the "started" event to be recorded.
 	pollResp, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -228,7 +231,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion() {
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		pollResp, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.Namespace(),
-			TaskQueue: &taskqueue.TaskQueue{
+			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 				Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 			},
@@ -257,7 +260,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion() {
 
 	pollResp, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -330,7 +333,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion_LargePayload()
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		pollResp, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.Namespace(),
-			TaskQueue: &taskqueue.TaskQueue{
+			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 				Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 			},
@@ -359,7 +362,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion_LargePayload()
 
 	pollResp, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -489,7 +492,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion() {
 
 	pollResp, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -518,7 +521,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion() {
 	// Poll and verify that the "started" event was recorded.
 	pollResp, err = s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -633,7 +636,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion() {
 	// Poll again and verify the completion is recorded and triggers workflow progress.
 	pollResp, err = s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -730,7 +733,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure() {
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		pollResp, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.Namespace(),
-			TaskQueue: &taskqueue.TaskQueue{
+			TaskQueue: &taskqueuepb.TaskQueue{
 				Name: taskQueue,
 				Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 			},
@@ -760,7 +763,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure() {
 	// Poll and verify that the "started" event was recorded.
 	pollResp, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -793,7 +796,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure() {
 	// Poll again and verify the completion is recorded and triggers workflow progress.
 	pollResp, err = s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -943,7 +946,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionInternalAuth()
 		Namespace:          s.Namespace(),
 		WorkflowId:         testcore.RandomizeStr(s.T().Name()),
 		WorkflowType:       &commonpb.WorkflowType{Name: completionWFType},
-		TaskQueue:          &taskqueue.TaskQueue{Name: completionWFTaskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		TaskQueue:          &taskqueuepb.TaskQueue{Name: completionWFTaskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Input:              nil,
 		WorkflowRunTimeout: durationpb.New(100 * time.Second),
 		Identity:           "test",
@@ -982,7 +985,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionInternalAuth()
 
 	pollResp, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -1011,7 +1014,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionInternalAuth()
 	// Poll and verify that the "started" event was recorded.
 	pollResp, err = s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -1031,7 +1034,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionInternalAuth()
 	// Complete workflow containing callback
 	pollResp, err = s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: completionWFTaskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -1061,7 +1064,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionInternalAuth()
 	// Poll again and verify the completion is recorded and triggers workflow progress.
 	pollResp, err = s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -1144,7 +1147,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 
 	pollResp, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -1183,7 +1186,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 	// Poll and cancel the operation.
 	pollResp, err = s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -1260,7 +1263,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset() {
 
 	pollResp, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -1289,7 +1292,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset() {
 	// Poll and verify that the "started" event was recorded.
 	pollResp, err = s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -1343,7 +1346,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset() {
 	// Poll again and verify the completion is recorded and triggers workflow progress.
 	pollResp, err = s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.Namespace(),
-		TaskQueue: &taskqueue.TaskQueue{
+		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: taskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
@@ -1378,6 +1381,101 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset() {
 	run = s.SdkClient().GetWorkflow(ctx, run.GetID(), resetResp.RunId)
 	s.NoError(run.Get(ctx, &result))
 	s.Equal("result", result)
+}
+
+func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationWithNilIO() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	defer cancel()
+	callerTaskQueue := testcore.RandomizeStr("caller_" + s.T().Name())
+	handlerWorkflowTaskQueue := testcore.RandomizeStr("handler_" + s.T().Name())
+	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
+	handlerWorkflowID := testcore.RandomizeStr(s.T().Name())
+
+	_, err := s.SdkClient().OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpointName,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: s.Namespace(),
+						TaskQueue: callerTaskQueue,
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	w := worker.New(
+		s.SdkClient(),
+		callerTaskQueue,
+		worker.Options{},
+	)
+
+	svc := nexus.NewService("test")
+	wf := func(ctx workflow.Context, input nexus.NoValue) (nexus.NoValue, error) {
+		return nil, nil
+	}
+	op := temporalnexus.NewWorkflowRunOperation("op", wf, func(ctx context.Context, nv nexus.NoValue, opts nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+		return client.StartWorkflowOptions{
+			ID:        handlerWorkflowID,
+			TaskQueue: handlerWorkflowTaskQueue,
+		}, nil
+	})
+	svc.Register(op)
+
+	callerWF := func(ctx workflow.Context, input nexus.NoValue) (nexus.NoValue, error) {
+		c := workflow.NewNexusClient(endpointName, svc.Name)
+		fut := c.ExecuteOperation(ctx, op, nil, workflow.NexusOperationOptions{})
+		return nil, fut.Get(ctx, nil)
+	}
+
+	w.RegisterNexusService(svc)
+	w.RegisterWorkflow(wf)
+	w.RegisterWorkflow(callerWF)
+	w.Start()
+	defer w.Stop()
+
+	run, err := s.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue: callerTaskQueue,
+	}, callerWF, nil)
+	s.NoError(err)
+
+	pollRes, err := s.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+		Namespace: s.Namespace(),
+		TaskQueue: &taskqueuepb.TaskQueue{
+			Name: handlerWorkflowTaskQueue,
+		},
+		Identity: "test",
+	})
+	s.NoError(err)
+	_, err = s.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		Namespace: s.Namespace(),
+		TaskToken: pollRes.TaskToken,
+		Identity:  "test",
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+					CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+						Result: nil, // Return nil here to verify that the conversion to nexus content works as expected.
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	s.NoError(run.Get(ctx, nil))
+	history := s.SdkClient().GetWorkflowHistory(ctx, run.GetID(), "", false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	for history.HasNext() {
+		ev, err := history.Next()
+		s.NoError(err)
+		if attr := ev.GetNexusOperationCompletedEventAttributes(); attr != nil {
+			protorequire.ProtoEqual(s.T(), s.mustToPayload(nil), attr.GetResult())
+			break
+		}
+	}
 }
 
 func (s *NexusWorkflowTestSuite) sendNexusCompletionRequest(


### PR DESCRIPTION
## What changed?

Improve conversion of payloads with empty metadata and nil workflow results to Nexus Content.

NOTE: This also upgrades the Go SDK from 1.27.0 to 1.29.1 to test Nexus via the SDK.

## Why?

Handle a couple of edge cases that weren't properly handled before.
The fix in `mutable_state_impl.go` is the more critical one and may cause surprising behavior in the SDKs.

## How did you test it?

Added tests.