### PR TITLE
Treat serviceerror.Internal as non-retryable

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2167,12 +2167,6 @@ Do not turn this on if you aren't using Cassandra as the history task DLQ is not
 		70, // 70 attempts takes about an hour
 		`HistoryTaskDLQUnexpectedErrorAttempts is the number of task execution attempts before sending the task to DLQ.`,
 	)
-	HistoryTaskDLQInternalErrors = NewGlobalBoolSetting(
-		"history.TaskDLQInternalErrors",
-		false,
-		`HistoryTaskDLQInternalErrors causes history task processing to send tasks failing with serviceerror.Internal to
-the dlq (or will drop them if not enabled)`,
-	)
 	HistoryTaskDLQErrorPattern = NewGlobalStringSetting(
 		"history.TaskDLQErrorPattern",
 		"",

--- a/common/util.go
+++ b/common/util.go
@@ -343,8 +343,7 @@ func IsServiceHandlerRetryableError(err error) bool {
 	}
 
 	switch err.(type) {
-	case *serviceerror.Internal,
-		*serviceerror.Unavailable:
+	case *serviceerror.Unavailable:
 		return true
 	}
 

--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -184,7 +184,6 @@ func (f *archivalQueueFactory) newScheduledQueue(shard shard.Context, executor q
 		f.DLQWriter,
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
-		f.Config.TaskDLQInternalErrors,
 		f.Config.TaskDLQErrorPattern,
 	)
 	return queues.NewScheduledQueue(

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -115,7 +115,6 @@ type Config struct {
 
 	TaskDLQEnabled                 dynamicconfig.BoolPropertyFn
 	TaskDLQUnexpectedErrorAttempts dynamicconfig.IntPropertyFn
-	TaskDLQInternalErrors          dynamicconfig.BoolPropertyFn
 	TaskDLQErrorPattern            dynamicconfig.StringPropertyFn
 
 	TaskSchedulerEnableRateLimiter           dynamicconfig.BoolPropertyFn
@@ -452,7 +451,6 @@ func NewConfig(
 
 		TaskDLQEnabled:                 dynamicconfig.HistoryTaskDLQEnabled.Get(dc),
 		TaskDLQUnexpectedErrorAttempts: dynamicconfig.HistoryTaskDLQUnexpectedErrorAttempts.Get(dc),
-		TaskDLQInternalErrors:          dynamicconfig.HistoryTaskDLQInternalErrors.Get(dc),
 		TaskDLQErrorPattern:            dynamicconfig.HistoryTaskDLQErrorPattern.Get(dc),
 
 		TaskSchedulerEnableRateLimiter:           dynamicconfig.TaskSchedulerEnableRateLimiter.Get(dc),

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -294,7 +294,6 @@ func (f *outboundQueueFactory) CreateQueue(
 		f.DLQWriter,
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
-		f.Config.TaskDLQInternalErrors,
 		f.Config.TaskDLQErrorPattern,
 	)
 	return queues.NewImmediateQueue(

--- a/service/history/queues/executable_factory.go
+++ b/service/history/queues/executable_factory.go
@@ -77,7 +77,6 @@ func NewExecutableFactory(
 	dlqWriter *DLQWriter,
 	dlqEnabled dynamicconfig.BoolPropertyFn,
 	attemptsBeforeSendingToDlq dynamicconfig.IntPropertyFn,
-	dlqInternalErrors dynamicconfig.BoolPropertyFn,
 	dlqErrorPattern dynamicconfig.StringPropertyFn,
 ) *executableFactoryImpl {
 	return &executableFactoryImpl{
@@ -93,7 +92,6 @@ func NewExecutableFactory(
 		dlqWriter:                  dlqWriter,
 		dlqEnabled:                 dlqEnabled,
 		attemptsBeforeSendingToDlq: attemptsBeforeSendingToDlq,
-		dlqInternalErrors:          dlqInternalErrors,
 		dlqErrorPattern:            dlqErrorPattern,
 	}
 }
@@ -115,7 +113,6 @@ func (f *executableFactoryImpl) NewExecutable(task tasks.Task, readerID int64) E
 			params.DLQEnabled = f.dlqEnabled
 			params.DLQWriter = f.dlqWriter
 			params.MaxUnexpectedErrorAttempts = f.attemptsBeforeSendingToDlq
-			params.DLQInternalErrors = f.dlqInternalErrors
 			params.DLQErrorPattern = f.dlqErrorPattern
 		},
 	)

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -574,9 +574,6 @@ func (s *queueBaseSuite) newQueueBase(
 		func() int {
 			return math.MaxInt
 		},
-		func() bool {
-			return false
-		},
 		func() string {
 			return ""
 		},

--- a/service/history/queues/queue_scheduled_test.go
+++ b/service/history/queues/queue_scheduled_test.go
@@ -146,9 +146,6 @@ func (s *scheduledQueueSuite) SetupTest() {
 		func() int {
 			return math.MaxInt
 		},
-		func() bool {
-			return false
-		},
 		func() string {
 			return ""
 		},

--- a/service/history/timer_queue_factory.go
+++ b/service/history/timer_queue_factory.go
@@ -242,7 +242,6 @@ func (f *timerQueueFactory) CreateQueue(
 		f.DLQWriter,
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
-		f.Config.TaskDLQInternalErrors,
 		f.Config.TaskDLQErrorPattern,
 	)
 	return queues.NewScheduledQueue(

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -236,7 +236,6 @@ func (f *transferQueueFactory) CreateQueue(
 		f.DLQWriter,
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
-		f.Config.TaskDLQInternalErrors,
 		f.Config.TaskDLQErrorPattern,
 	)
 	return queues.NewImmediateQueue(

--- a/service/history/visibility_queue_factory.go
+++ b/service/history/visibility_queue_factory.go
@@ -141,7 +141,6 @@ func (f *visibilityQueueFactory) CreateQueue(
 		f.DLQWriter,
 		f.Config.TaskDLQEnabled,
 		f.Config.TaskDLQUnexpectedErrorAttempts,
-		f.Config.TaskDLQInternalErrors,
 		f.Config.TaskDLQErrorPattern,
 	)
 	return queues.NewImmediateQueue(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Treat serviceerror.Internal as non-retryable
- Deprecate `history.TaskDLQInternalErrors` and always DLQ history tasks when internal error is returned. 

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
