### PR TITLE
Add validation for links on StartWorkflowExecution request

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -888,6 +888,16 @@ used when the first cache layer has a miss. Requires server restart for change t
 		32,
 		`MaxCallbacksPerWorkflow is the maximum number of callbacks that can be attached to a workflow.`,
 	)
+	FrontendLinkMaxSize = NewNamespaceIntSetting(
+		"frontend.linkMaxSize",
+		4000, // Links may include a workflow ID and namespace name, both of which are limited to a length of 1000.
+		`Maximum size in bytes of temporal.api.common.v1.Link object in an API request.`,
+	)
+	FrontendMaxLinksPerRequest = NewNamespaceIntSetting(
+		"frontend.maxlinksPerRequest",
+		10,
+		`Maximum number of links allowed to be attached via a single API request.`,
+	)
 	FrontendMaxConcurrentBatchOperationPerNamespace = NewNamespaceIntSetting(
 		"frontend.MaxConcurrentBatchOperationPerNamespace",
 		1,

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -189,10 +189,14 @@ type Config struct {
 	// EnableNexusAPIs controls whether to allow invoking Nexus related APIs.
 	EnableNexusAPIs dynamicconfig.BoolPropertyFn
 
-	CallbackURLMaxLength        dynamicconfig.IntPropertyFnWithNamespaceFilter
-	CallbackHeaderMaxSize       dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxCallbacksPerWorkflow     dynamicconfig.IntPropertyFnWithNamespaceFilter
-	CallbackEndpointConfigs     dynamicconfig.TypedPropertyFnWithNamespaceFilter[[]callbacks.AddressMatchRule]
+	CallbackURLMaxLength    dynamicconfig.IntPropertyFnWithNamespaceFilter
+	CallbackHeaderMaxSize   dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxCallbacksPerWorkflow dynamicconfig.IntPropertyFnWithNamespaceFilter
+	CallbackEndpointConfigs dynamicconfig.TypedPropertyFnWithNamespaceFilter[[]callbacks.AddressMatchRule]
+
+	LinkMaxSize        dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxLinksPerRequest dynamicconfig.IntPropertyFnWithNamespaceFilter
+
 	AdminEnableListHistoryTasks dynamicconfig.BoolPropertyFn
 
 	MaskInternalErrorDetails dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -307,10 +311,14 @@ func NewConfig(
 		EnableWorkerVersioningWorkflow: dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs.Get(dc),
 		EnableWorkerVersioningRules:    dynamicconfig.FrontendEnableWorkerVersioningRuleAPIs.Get(dc),
 
-		EnableNexusAPIs:             dynamicconfig.EnableNexus.Get(dc),
-		CallbackURLMaxLength:        dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
-		CallbackHeaderMaxSize:       dynamicconfig.FrontendCallbackHeaderMaxSize.Get(dc),
-		MaxCallbacksPerWorkflow:     dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
+		EnableNexusAPIs:         dynamicconfig.EnableNexus.Get(dc),
+		CallbackURLMaxLength:    dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
+		CallbackHeaderMaxSize:   dynamicconfig.FrontendCallbackHeaderMaxSize.Get(dc),
+		MaxCallbacksPerWorkflow: dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
+
+		LinkMaxSize:        dynamicconfig.FrontendLinkMaxSize.Get(dc),
+		MaxLinksPerRequest: dynamicconfig.FrontendMaxLinksPerRequest.Get(dc),
+
 		CallbackEndpointConfigs:     callbacks.AllowedAddresses.Get(dc),
 		AdminEnableListHistoryTasks: dynamicconfig.AdminEnableListHistoryTasks.Get(dc),
 

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -31,7 +31,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pborman/uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -94,7 +94,7 @@ const (
 )
 
 type (
-	workflowHandlerSuite struct {
+	WorkflowHandlerSuite struct {
 		suite.Suite
 		*require.Assertions
 
@@ -126,17 +126,17 @@ type (
 var testNamespaceID = primitives.MustValidateUUID("deadbeef-c001-4567-890a-bcdef0123456")
 
 func TestWorkflowHandlerSuite(t *testing.T) {
-	s := new(workflowHandlerSuite)
+	s := new(WorkflowHandlerSuite)
 	suite.Run(t, s)
 }
 
-func (s *workflowHandlerSuite) SetupSuite() {
+func (s *WorkflowHandlerSuite) SetupSuite() {
 }
 
-func (s *workflowHandlerSuite) TearDownSuite() {
+func (s *WorkflowHandlerSuite) TearDownSuite() {
 }
 
-func (s *workflowHandlerSuite) SetupTest() {
+func (s *WorkflowHandlerSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 
 	s.testNamespace = "test-namespace"
@@ -166,11 +166,11 @@ func (s *workflowHandlerSuite) SetupTest() {
 	s.mockExecutionManager.EXPECT().GetName().Return("mock-execution-manager").AnyTimes()
 }
 
-func (s *workflowHandlerSuite) TearDownTest() {
+func (s *WorkflowHandlerSuite) TearDownTest() {
 	s.controller.Finish()
 }
 
-func (s *workflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandler {
+func (s *WorkflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandler {
 	s.mockVisibilityMgr.EXPECT().GetIndexName().Return(esIndexName).AnyTimes()
 	healthInterceptor := interceptor.NewHealthInterceptor()
 	healthInterceptor.SetHealthy(true)
@@ -200,9 +200,9 @@ func (s *workflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 	)
 }
 
-func (s *workflowHandlerSuite) TestDisableListVisibilityByFilter() {
+func (s *WorkflowHandlerSuite) TestDisableListVisibilityByFilter() {
 	testNamespace := namespace.Name("test-namespace")
-	namespaceID := namespace.ID(uuid.New())
+	namespaceID := namespace.ID(uuid.NewString())
 	config := s.newConfig()
 	config.DisableListVisibilityByFilter = dc.GetBoolPropertyFnFilteredByNamespace(true)
 
@@ -265,7 +265,7 @@ func (s *workflowHandlerSuite) TestDisableListVisibilityByFilter() {
 	s.Equal(errListNotAllowed, err)
 }
 
-func (s *workflowHandlerSuite) TestPollForTask_Failed_ContextTimeoutTooShort() {
+func (s *WorkflowHandlerSuite) TestPollForTask_Failed_ContextTimeoutTooShort() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 
@@ -290,7 +290,7 @@ func (s *workflowHandlerSuite) TestPollForTask_Failed_ContextTimeoutTooShort() {
 	s.Equal(common.ErrContextTimeoutTooShort, err)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_StartRequestNotSet() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_StartRequestNotSet() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
@@ -300,7 +300,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_StartRequestNot
 	s.Equal(errRequestNotSet, err)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_NamespaceNotSet() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_NamespaceNotSet() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
@@ -326,7 +326,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_NamespaceNotSet
 			MaximumInterval:    durationpb.New(2 * time.Second),
 			MaximumAttempts:    1,
 		},
-		RequestId: uuid.New(),
+		RequestId: uuid.NewString(),
 	}
 	_, err := wh.StartWorkflowExecution(context.Background(), startWorkflowExecutionRequest)
 	s.Error(err)
@@ -334,7 +334,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_NamespaceNotSet
 	s.ErrorAs(err, &notFound)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_WorkflowIdNotSet() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_WorkflowIdNotSet() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
@@ -356,14 +356,14 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_WorkflowIdNotSe
 			MaximumInterval:    durationpb.New(2 * time.Second),
 			MaximumAttempts:    1,
 		},
-		RequestId: uuid.New(),
+		RequestId: uuid.NewString(),
 	}
 	_, err := wh.StartWorkflowExecution(context.Background(), startWorkflowExecutionRequest)
 	s.Error(err)
 	s.Equal(errWorkflowIDNotSet, err)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_WorkflowTypeNotSet() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_WorkflowTypeNotSet() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
@@ -386,14 +386,14 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_WorkflowTypeNot
 			MaximumInterval:    durationpb.New(2 * time.Second),
 			MaximumAttempts:    1,
 		},
-		RequestId: uuid.New(),
+		RequestId: uuid.NewString(),
 	}
 	_, err := wh.StartWorkflowExecution(context.Background(), startWorkflowExecutionRequest)
 	s.Error(err)
 	s.Equal(errWorkflowTypeNotSet, err)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_TaskQueueNotSet() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_TaskQueueNotSet() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
@@ -413,14 +413,14 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_TaskQueueNotSet
 			MaximumInterval:    durationpb.New(2 * time.Second),
 			MaximumAttempts:    1,
 		},
-		RequestId: uuid.New(),
+		RequestId: uuid.NewString(),
 	}
 	_, err := wh.StartWorkflowExecution(context.Background(), startWorkflowExecutionRequest)
 	s.Error(err)
 	s.Equal(serviceerror.NewInvalidArgument("missing task queue name"), err)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidExecutionTimeout() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidExecutionTimeout() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
@@ -442,14 +442,14 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidExecutio
 			MaximumInterval:    durationpb.New(2 * time.Second),
 			MaximumAttempts:    1,
 		},
-		RequestId: uuid.New(),
+		RequestId: uuid.NewString(),
 	}
 	_, err := wh.StartWorkflowExecution(context.Background(), startWorkflowExecutionRequest)
 	s.Error(err)
 	s.Equal(errInvalidWorkflowExecutionTimeoutSeconds, err)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidRunTimeout() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidRunTimeout() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
@@ -471,14 +471,14 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidRunTimeo
 			MaximumInterval:    durationpb.New(2 * time.Second),
 			MaximumAttempts:    1,
 		},
-		RequestId: uuid.New(),
+		RequestId: uuid.NewString(),
 	}
 	_, err := wh.StartWorkflowExecution(context.Background(), startWorkflowExecutionRequest)
 	s.Error(err)
 	s.Equal(errInvalidWorkflowRunTimeoutSeconds, err)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_EnsureNonNilRetryPolicyInitialized() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_EnsureNonNilRetryPolicyInitialized() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
@@ -495,7 +495,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_EnsureNonNilRetryPolic
 		WorkflowExecutionTimeout: durationpb.New(1 * time.Second),
 		WorkflowRunTimeout:       durationpb.New(time.Duration(-1) * time.Second),
 		RetryPolicy:              &commonpb.RetryPolicy{},
-		RequestId:                uuid.New(),
+		RequestId:                uuid.NewString(),
 	}
 	_, err := wh.StartWorkflowExecution(context.Background(), startWorkflowExecutionRequest)
 	s.Error(err)
@@ -506,7 +506,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_EnsureNonNilRetryPolic
 	}, startWorkflowExecutionRequest.RetryPolicy)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_EnsureNilRetryPolicyNotInitialized() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_EnsureNilRetryPolicyNotInitialized() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
@@ -522,14 +522,14 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_EnsureNilRetryPolicyNo
 		},
 		WorkflowExecutionTimeout: durationpb.New(1 * time.Second),
 		WorkflowRunTimeout:       durationpb.New(time.Duration(-1) * time.Second),
-		RequestId:                uuid.New(),
+		RequestId:                uuid.NewString(),
 	}
 	_, err := wh.StartWorkflowExecution(context.Background(), startWorkflowExecutionRequest)
 	s.Error(err)
 	s.Nil(startWorkflowExecutionRequest.RetryPolicy)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidTaskTimeout() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidTaskTimeout() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
@@ -552,14 +552,14 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidTaskTime
 			MaximumInterval:    durationpb.New(2 * time.Second),
 			MaximumAttempts:    1,
 		},
-		RequestId: uuid.New(),
+		RequestId: uuid.NewString(),
 	}
 	_, err := wh.StartWorkflowExecution(context.Background(), startWorkflowExecutionRequest)
 	s.Error(err)
 	s.Equal(errInvalidWorkflowTaskTimeoutSeconds, err)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_CronAndStartDelaySet() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_CronAndStartDelaySet() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
@@ -582,7 +582,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_CronAndStartDel
 			MaximumInterval:    durationpb.New(2 * time.Second),
 			MaximumAttempts:    1,
 		},
-		RequestId:          uuid.New(),
+		RequestId:          uuid.NewString(),
 		CronSchedule:       "dummy-cron-schedule",
 		WorkflowStartDelay: durationpb.New(10 * time.Second),
 	}
@@ -590,7 +590,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_CronAndStartDel
 	s.ErrorIs(err, errCronAndStartDelaySet)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidStartDelay() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidStartDelay() {
 	config := s.newConfig()
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
@@ -613,7 +613,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidStartDel
 			MaximumInterval:    durationpb.New(2 * time.Second),
 			MaximumAttempts:    1,
 		},
-		RequestId:          uuid.New(),
+		RequestId:          uuid.NewString(),
 		WorkflowStartDelay: durationpb.New(-10 * time.Second),
 	}
 
@@ -622,7 +622,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidStartDel
 	s.ErrorIs(err, errInvalidWorkflowStartDelaySeconds)
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_InvalidWorkflowIdReusePolicy_TerminateIfRunning() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_InvalidWorkflowIdReusePolicy_TerminateIfRunning() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	req := &workflowservice.StartWorkflowExecutionRequest{
@@ -640,7 +640,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_InvalidWorkflowIdReuse
 		"Invalid WorkflowIDReusePolicy: WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING cannot be used together with a WorkflowIDConflictPolicy."))
 }
 
-func (s *workflowHandlerSuite) TestStartWorkflowExecution_DefaultWorkflowIdDuplicationPolicies() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_DefaultWorkflowIdDuplicationPolicies() {
 	s.mockSearchAttributesMapperProvider.EXPECT().GetMapper(gomock.Any()).Return(nil, nil)
 	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(namespace.NewID(), nil)
 	s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), mock.MatchedBy(
@@ -663,7 +663,61 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_DefaultWorkflowIdDupli
 	s.True(resp.Started)
 }
 
-func (s *workflowHandlerSuite) TestSignalWithStartWorkflowExecution_InvalidWorkflowIdConflictPolicy() {
+func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidLinks() {
+	s.mockSearchAttributesMapperProvider.EXPECT().GetMapper(gomock.Any()).AnyTimes().Return(nil, nil)
+	config := s.newConfig()
+	config.RPS = dc.GetIntPropertyFn(10)
+	wh := s.getWorkflowHandler(config)
+
+	req := &workflowservice.StartWorkflowExecutionRequest{
+		Namespace:  "test-namespace",
+		WorkflowId: "workflow-id",
+		WorkflowType: &commonpb.WorkflowType{
+			Name: "workflow-type",
+		},
+		TaskQueue: &taskqueuepb.TaskQueue{
+			Name: "task-queue",
+		},
+		RequestId: uuid.NewString(),
+	}
+
+	req.Links = []*commonpb.Link{
+		{
+			Variant: &commonpb.Link_WorkflowEvent_{
+				WorkflowEvent: &commonpb.Link_WorkflowEvent{
+					Namespace:  "dont-care",
+					WorkflowId: strings.Repeat("X", 4000),
+					RunId:      uuid.NewString(),
+				},
+			},
+		},
+	}
+
+	_, err := wh.StartWorkflowExecution(context.Background(), req)
+	var invalidArgument *serviceerror.InvalidArgument
+	s.ErrorAs(err, &invalidArgument)
+	s.ErrorContains(err, "link exceeds allowed size of 4000")
+
+	req.Links = []*commonpb.Link{}
+	for i := 0; i < 11; i++ {
+		req.Links = append(req.Links, &commonpb.Link{
+			Variant: &commonpb.Link_WorkflowEvent_{
+				WorkflowEvent: &commonpb.Link_WorkflowEvent{
+					Namespace:  "dont-care",
+					WorkflowId: "dont-care",
+					RunId:      uuid.NewString(),
+				},
+			},
+		})
+	}
+
+	_, err = wh.StartWorkflowExecution(context.Background(), req)
+	s.ErrorAs(err, &invalidArgument)
+	s.ErrorContains(err, "cannot attach more than 10 links per request, got 11")
+
+}
+
+func (s *WorkflowHandlerSuite) TestSignalWithStartWorkflowExecution_InvalidWorkflowIdConflictPolicy() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	req := &workflowservice.SignalWithStartWorkflowExecutionRequest{
@@ -681,7 +735,7 @@ func (s *workflowHandlerSuite) TestSignalWithStartWorkflowExecution_InvalidWorkf
 		"Invalid WorkflowIDConflictPolicy: WORKFLOW_ID_CONFLICT_POLICY_FAIL is not supported for this operation."))
 }
 
-func (s *workflowHandlerSuite) TestSignalWithStartWorkflowExecution_InvalidWorkflowIdReusePolicy_TerminateIfRunning() {
+func (s *WorkflowHandlerSuite) TestSignalWithStartWorkflowExecution_InvalidWorkflowIdReusePolicy_TerminateIfRunning() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	req := &workflowservice.SignalWithStartWorkflowExecutionRequest{
@@ -700,7 +754,7 @@ func (s *workflowHandlerSuite) TestSignalWithStartWorkflowExecution_InvalidWorkf
 		"Invalid WorkflowIDReusePolicy: WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING cannot be used together with a WorkflowIDConflictPolicy."))
 }
 
-func (s *workflowHandlerSuite) TestSignalWithStartWorkflowExecution_DefaultWorkflowIdDuplicationPolicies() {
+func (s *WorkflowHandlerSuite) TestSignalWithStartWorkflowExecution_DefaultWorkflowIdDuplicationPolicies() {
 	s.mockSearchAttributesMapperProvider.EXPECT().GetMapper(gomock.Any()).Return(nil, nil)
 	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(namespace.NewID(), nil)
 	s.mockHistoryClient.EXPECT().SignalWithStartWorkflowExecution(gomock.Any(), mock.MatchedBy(
@@ -724,7 +778,7 @@ func (s *workflowHandlerSuite) TestSignalWithStartWorkflowExecution_DefaultWorkf
 	s.True(resp.Started)
 }
 
-func (s *workflowHandlerSuite) TestRegisterNamespace_Failure_InvalidArchivalURI() {
+func (s *WorkflowHandlerSuite) TestRegisterNamespace_Failure_InvalidArchivalURI() {
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false)
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "random URI"))
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "random URI"))
@@ -746,7 +800,7 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Failure_InvalidArchivalURI(
 	s.Error(err)
 }
 
-func (s *workflowHandlerSuite) TestRegisterNamespace_Success_EnabledWithNoArchivalURI() {
+func (s *WorkflowHandlerSuite) TestRegisterNamespace_Success_EnabledWithNoArchivalURI() {
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
@@ -768,7 +822,7 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Success_EnabledWithNoArchiv
 	s.NoError(err)
 }
 
-func (s *workflowHandlerSuite) TestRegisterNamespace_Success_EnabledWithArchivalURI() {
+func (s *WorkflowHandlerSuite) TestRegisterNamespace_Success_EnabledWithArchivalURI() {
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
@@ -795,7 +849,7 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Success_EnabledWithArchival
 	s.NoError(err)
 }
 
-func (s *workflowHandlerSuite) TestRegisterNamespace_Success_ClusterNotConfiguredForArchival() {
+func (s *WorkflowHandlerSuite) TestRegisterNamespace_Success_ClusterNotConfiguredForArchival() {
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
@@ -818,7 +872,7 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Success_ClusterNotConfigure
 	s.NoError(err)
 }
 
-func (s *workflowHandlerSuite) TestRegisterNamespace_Success_NotEnabled() {
+func (s *WorkflowHandlerSuite) TestRegisterNamespace_Success_NotEnabled() {
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
@@ -836,7 +890,7 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Success_NotEnabled() {
 	s.NoError(err)
 }
 
-func (s *workflowHandlerSuite) TestDeprecateNamespace_Success() {
+func (s *WorkflowHandlerSuite) TestDeprecateNamespace_Success() {
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
@@ -884,7 +938,7 @@ func (s *workflowHandlerSuite) TestDeprecateNamespace_Success() {
 	s.NotNil(respDeprecate)
 }
 
-func (s *workflowHandlerSuite) TestDeprecateNamespace_Error() {
+func (s *WorkflowHandlerSuite) TestDeprecateNamespace_Error() {
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
@@ -932,7 +986,7 @@ func (s *workflowHandlerSuite) TestDeprecateNamespace_Error() {
 	s.Nil(respDeprecate)
 }
 
-func (s *workflowHandlerSuite) TestDeleteNamespace_Success() {
+func (s *WorkflowHandlerSuite) TestDeleteNamespace_Success() {
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
@@ -980,7 +1034,7 @@ func (s *workflowHandlerSuite) TestDeleteNamespace_Success() {
 	s.NotNil(respDelete)
 }
 
-func (s *workflowHandlerSuite) TestDeleteNamespace_Error() {
+func (s *WorkflowHandlerSuite) TestDeleteNamespace_Error() {
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
@@ -1028,7 +1082,7 @@ func (s *workflowHandlerSuite) TestDeleteNamespace_Error() {
 	s.Nil(respDelete)
 }
 
-func (s *workflowHandlerSuite) TestDescribeNamespace_Success_ArchivalDisabled() {
+func (s *WorkflowHandlerSuite) TestDescribeNamespace_Success_ArchivalDisabled() {
 	getNamespaceResp := persistenceGetNamespaceResponse(
 		&namespace.ArchivalConfigState{State: enumspb.ARCHIVAL_STATE_DISABLED, URI: ""},
 		&namespace.ArchivalConfigState{State: enumspb.ARCHIVAL_STATE_DISABLED, URI: ""},
@@ -1051,7 +1105,7 @@ func (s *workflowHandlerSuite) TestDescribeNamespace_Success_ArchivalDisabled() 
 	s.Equal("", result.Config.GetVisibilityArchivalUri())
 }
 
-func (s *workflowHandlerSuite) TestDescribeNamespace_Success_ArchivalEnabled() {
+func (s *WorkflowHandlerSuite) TestDescribeNamespace_Success_ArchivalEnabled() {
 	getNamespaceResp := persistenceGetNamespaceResponse(
 		&namespace.ArchivalConfigState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: testHistoryArchivalURI},
 		&namespace.ArchivalConfigState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: testVisibilityArchivalURI},
@@ -1074,7 +1128,7 @@ func (s *workflowHandlerSuite) TestDescribeNamespace_Success_ArchivalEnabled() {
 	s.Equal(testVisibilityArchivalURI, result.Config.GetVisibilityArchivalUri())
 }
 
-func (s *workflowHandlerSuite) TestUpdateNamespace_Failure_UpdateExistingArchivalURI() {
+func (s *WorkflowHandlerSuite) TestUpdateNamespace_Failure_UpdateExistingArchivalURI() {
 	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
@@ -1100,7 +1154,7 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Failure_UpdateExistingArchiva
 	s.Error(err)
 }
 
-func (s *workflowHandlerSuite) TestUpdateNamespace_Failure_InvalidArchivalURI() {
+func (s *WorkflowHandlerSuite) TestUpdateNamespace_Failure_InvalidArchivalURI() {
 	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
@@ -1125,7 +1179,7 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Failure_InvalidArchivalURI() 
 	s.Error(err)
 }
 
-func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToArchivalDisabledWithoutSettingURI() {
+func (s *WorkflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToArchivalDisabledWithoutSettingURI() {
 	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
@@ -1162,7 +1216,7 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToArch
 	s.Equal(testVisibilityArchivalURI, result.Config.GetVisibilityArchivalUri())
 }
 
-func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ClusterNotConfiguredForArchival() {
+func (s *WorkflowHandlerSuite) TestUpdateNamespace_Success_ClusterNotConfiguredForArchival() {
 	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
@@ -1189,7 +1243,7 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ClusterNotConfiguredF
 	s.Equal("some random visibility URI", result.Config.GetVisibilityArchivalUri())
 }
 
-func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToArchivalDisabledWithSettingBucket() {
+func (s *WorkflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToArchivalDisabledWithSettingBucket() {
 	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
@@ -1226,7 +1280,7 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToArch
 	s.Equal(testVisibilityArchivalURI, result.Config.GetVisibilityArchivalUri())
 }
 
-func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToEnabled() {
+func (s *WorkflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToEnabled() {
 	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
@@ -1262,7 +1316,7 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToEnab
 	s.Equal(testVisibilityArchivalURI, result.Config.GetVisibilityArchivalUri())
 }
 
-func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalNeverEnabledToEnabled() {
+func (s *WorkflowHandlerSuite) TestUpdateNamespace_Success_ArchivalNeverEnabledToEnabled() {
 	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
@@ -1299,7 +1353,7 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalNeverEnabledT
 	s.Equal(testVisibilityArchivalURI, result.Config.GetVisibilityArchivalUri())
 }
 
-func (s *workflowHandlerSuite) TestHistoryArchived() {
+func (s *WorkflowHandlerSuite) TestHistoryArchived() {
 	wh := s.getWorkflowHandler(s.newConfig())
 
 	getHistoryRequest := &workflowservice.GetWorkflowExecutionHistoryRequest{}
@@ -1338,7 +1392,7 @@ func (s *workflowHandlerSuite) TestHistoryArchived() {
 	s.False(wh.historyArchived(context.Background(), getHistoryRequest, "test-namespace"))
 }
 
-func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_NamespaceCacheEntryError() {
+func (s *WorkflowHandlerSuite) TestGetArchivedHistory_Failure_NamespaceCacheEntryError() {
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(nil, errors.New("error getting namespace"))
 
 	wh := s.getWorkflowHandler(s.newConfig())
@@ -1348,7 +1402,7 @@ func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_NamespaceCacheEntr
 	s.Error(err)
 }
 
-func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_ArchivalURIEmpty() {
+func (s *WorkflowHandlerSuite) TestGetArchivedHistory_Failure_ArchivalURIEmpty() {
 	namespaceEntry := namespace.NewLocalNamespaceForTest(
 		&persistencespb.NamespaceInfo{Name: "test-namespace"},
 		&persistencespb.NamespaceConfig{
@@ -1367,7 +1421,7 @@ func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_ArchivalURIEmpty()
 	s.Error(err)
 }
 
-func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_InvalidURI() {
+func (s *WorkflowHandlerSuite) TestGetArchivedHistory_Failure_InvalidURI() {
 	namespaceEntry := namespace.NewLocalNamespaceForTest(
 		&persistencespb.NamespaceInfo{Name: "test-namespace"},
 		&persistencespb.NamespaceConfig{
@@ -1386,7 +1440,7 @@ func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_InvalidURI() {
 	s.Error(err)
 }
 
-func (s *workflowHandlerSuite) TestGetArchivedHistory_Success_GetFirstPage() {
+func (s *WorkflowHandlerSuite) TestGetArchivedHistory_Success_GetFirstPage() {
 	namespaceEntry := namespace.NewLocalNamespaceForTest(
 		&persistencespb.NamespaceInfo{Name: "test-namespace"},
 		&persistencespb.NamespaceConfig{
@@ -1432,7 +1486,7 @@ func (s *workflowHandlerSuite) TestGetArchivedHistory_Success_GetFirstPage() {
 	s.True(resp.GetArchived())
 }
 
-func (s *workflowHandlerSuite) TestListArchivedVisibility_Failure_InvalidRequest() {
+func (s *WorkflowHandlerSuite) TestListArchivedVisibility_Failure_InvalidRequest() {
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewDisabledArchvialConfig())
 
 	wh := s.getWorkflowHandler(s.newConfig())
@@ -1442,7 +1496,7 @@ func (s *workflowHandlerSuite) TestListArchivedVisibility_Failure_InvalidRequest
 	s.Error(err)
 }
 
-func (s *workflowHandlerSuite) TestListArchivedVisibility_Failure_ClusterNotConfiguredForArchival() {
+func (s *WorkflowHandlerSuite) TestListArchivedVisibility_Failure_ClusterNotConfiguredForArchival() {
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewDisabledArchvialConfig())
 
 	wh := s.getWorkflowHandler(s.newConfig())
@@ -1452,7 +1506,7 @@ func (s *workflowHandlerSuite) TestListArchivedVisibility_Failure_ClusterNotConf
 	s.Error(err)
 }
 
-func (s *workflowHandlerSuite) TestListArchivedVisibility_Failure_NamespaceCacheEntryError() {
+func (s *WorkflowHandlerSuite) TestListArchivedVisibility_Failure_NamespaceCacheEntryError() {
 	s.mockNamespaceCache.EXPECT().GetNamespace(gomock.Any()).Return(nil, errors.New("error getting namespace"))
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "random URI")).Times(2)
 
@@ -1463,7 +1517,7 @@ func (s *workflowHandlerSuite) TestListArchivedVisibility_Failure_NamespaceCache
 	s.Error(err)
 }
 
-func (s *workflowHandlerSuite) TestListArchivedVisibility_Failure_NamespaceNotConfiguredForArchival() {
+func (s *WorkflowHandlerSuite) TestListArchivedVisibility_Failure_NamespaceNotConfiguredForArchival() {
 	s.mockNamespaceCache.EXPECT().GetNamespace(gomock.Any()).Return(namespace.NewLocalNamespaceForTest(
 		nil,
 		&persistencespb.NamespaceConfig{
@@ -1480,7 +1534,7 @@ func (s *workflowHandlerSuite) TestListArchivedVisibility_Failure_NamespaceNotCo
 	s.Error(err)
 }
 
-func (s *workflowHandlerSuite) TestListArchivedVisibility_Failure_InvalidURI() {
+func (s *WorkflowHandlerSuite) TestListArchivedVisibility_Failure_InvalidURI() {
 	s.mockNamespaceCache.EXPECT().GetNamespace(gomock.Any()).Return(namespace.NewLocalNamespaceForTest(
 		&persistencespb.NamespaceInfo{Name: "test-namespace"},
 		&persistencespb.NamespaceConfig{
@@ -1498,7 +1552,7 @@ func (s *workflowHandlerSuite) TestListArchivedVisibility_Failure_InvalidURI() {
 	s.Error(err)
 }
 
-func (s *workflowHandlerSuite) TestListArchivedVisibility_Success() {
+func (s *WorkflowHandlerSuite) TestListArchivedVisibility_Success() {
 	s.mockNamespaceCache.EXPECT().GetNamespace(gomock.Any()).Return(namespace.NewLocalNamespaceForTest(
 		&persistencespb.NamespaceInfo{Name: "test-namespace"},
 		&persistencespb.NamespaceConfig{
@@ -1519,7 +1573,7 @@ func (s *workflowHandlerSuite) TestListArchivedVisibility_Success() {
 	s.NoError(err)
 }
 
-func (s *workflowHandlerSuite) TestGetSearchAttributes() {
+func (s *WorkflowHandlerSuite) TestGetSearchAttributes() {
 	wh := s.getWorkflowHandler(s.newConfig())
 
 	ctx := context.Background()
@@ -1529,7 +1583,7 @@ func (s *workflowHandlerSuite) TestGetSearchAttributes() {
 	s.NotNil(resp)
 }
 
-func (s *workflowHandlerSuite) TestDescribeWorkflowExecution_RunningStatus() {
+func (s *WorkflowHandlerSuite) TestDescribeWorkflowExecution_RunningStatus() {
 	wh := s.getWorkflowHandler(s.newConfig())
 	now := timestamppb.New(time.Now())
 
@@ -1565,7 +1619,7 @@ func (s *workflowHandlerSuite) TestDescribeWorkflowExecution_RunningStatus() {
 	s.NoError(err)
 }
 
-func (s *workflowHandlerSuite) TestDescribeWorkflowExecution_CompletedStatus() {
+func (s *WorkflowHandlerSuite) TestDescribeWorkflowExecution_CompletedStatus() {
 	wh := s.getWorkflowHandler(s.newConfig())
 	now := timestamppb.New(time.Now())
 
@@ -1601,7 +1655,7 @@ func (s *workflowHandlerSuite) TestDescribeWorkflowExecution_CompletedStatus() {
 	s.NoError(err)
 }
 
-func (s *workflowHandlerSuite) TestListWorkflowExecutions() {
+func (s *WorkflowHandlerSuite) TestListWorkflowExecutions() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	s.mockNamespaceCache.EXPECT().GetNamespaceID(s.testNamespace).Return(s.testNamespaceID, nil).AnyTimes()
@@ -1663,7 +1717,7 @@ func (s *workflowHandlerSuite) TestListWorkflowExecutions() {
 	s.Equal(query, listRequest.GetQuery())
 }
 
-func (s *workflowHandlerSuite) TestScanWorkflowExecutions() {
+func (s *WorkflowHandlerSuite) TestScanWorkflowExecutions() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	s.mockNamespaceCache.EXPECT().GetNamespaceID(s.testNamespace).Return(s.testNamespaceID, nil).AnyTimes()
@@ -1725,7 +1779,7 @@ func (s *workflowHandlerSuite) TestScanWorkflowExecutions() {
 	s.Equal(query, scanRequest.GetQuery())
 }
 
-func (s *workflowHandlerSuite) TestCountWorkflowExecutions() {
+func (s *WorkflowHandlerSuite) TestCountWorkflowExecutions() {
 	wh := s.getWorkflowHandler(s.newConfig())
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(s.testNamespaceID, nil).AnyTimes()
@@ -1743,7 +1797,7 @@ func (s *workflowHandlerSuite) TestCountWorkflowExecutions() {
 	s.Equal(int64(5), resp.Count)
 }
 
-func (s *workflowHandlerSuite) TestVerifyHistoryIsComplete() {
+func (s *WorkflowHandlerSuite) TestVerifyHistoryIsComplete() {
 	events := make([]*historypb.HistoryEvent, 50)
 	for i := 0; i < len(events); i++ {
 		events[i] = &historypb.HistoryEvent{EventId: int64(i + 1)}
@@ -1796,7 +1850,7 @@ func (s *workflowHandlerSuite) TestVerifyHistoryIsComplete() {
 	}
 }
 
-func (s *workflowHandlerSuite) TestGetSystemInfo() {
+func (s *WorkflowHandlerSuite) TestGetSystemInfo() {
 	wh := s.getWorkflowHandler(s.newConfig())
 
 	resp, err := wh.GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{})
@@ -1812,9 +1866,9 @@ func (s *workflowHandlerSuite) TestGetSystemInfo() {
 	s.False(resp.Capabilities.Nexus)
 }
 
-func (s *workflowHandlerSuite) TestStartBatchOperation_Terminate() {
+func (s *WorkflowHandlerSuite) TestStartBatchOperation_Terminate() {
 	testNamespace := namespace.Name("test-namespace")
-	namespaceID := namespace.ID(uuid.New())
+	namespaceID := namespace.ID(uuid.NewString())
 	inputString := "unit test"
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
@@ -1849,7 +1903,7 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_Terminate() {
 	s.mockVisibilityMgr.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&manager.CountWorkflowExecutionsResponse{Count: 0}, nil)
 	request := &workflowservice.StartBatchOperationRequest{
 		Namespace: testNamespace.String(),
-		JobId:     uuid.New(),
+		JobId:     uuid.NewString(),
 		Reason:    inputString,
 		Operation: &workflowservice.StartBatchOperationRequest_TerminationOperation{
 			TerminationOperation: &batchpb.BatchOperationTermination{
@@ -1863,9 +1917,9 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_Terminate() {
 	s.NoError(err)
 }
 
-func (s *workflowHandlerSuite) TestStartBatchOperation_Cancellation() {
+func (s *WorkflowHandlerSuite) TestStartBatchOperation_Cancellation() {
 	testNamespace := namespace.Name("test-namespace")
-	namespaceID := namespace.ID(uuid.New())
+	namespaceID := namespace.ID(uuid.NewString())
 	inputString := "unit test"
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
@@ -1900,7 +1954,7 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_Cancellation() {
 	s.mockVisibilityMgr.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&manager.CountWorkflowExecutionsResponse{Count: 0}, nil)
 	request := &workflowservice.StartBatchOperationRequest{
 		Namespace: testNamespace.String(),
-		JobId:     uuid.New(),
+		JobId:     uuid.NewString(),
 		Reason:    inputString,
 		Operation: &workflowservice.StartBatchOperationRequest_CancellationOperation{
 			CancellationOperation: &batchpb.BatchOperationCancellation{
@@ -1914,9 +1968,9 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_Cancellation() {
 	s.NoError(err)
 }
 
-func (s *workflowHandlerSuite) TestStartBatchOperation_Signal() {
+func (s *WorkflowHandlerSuite) TestStartBatchOperation_Signal() {
 	testNamespace := namespace.Name("test-namespace")
-	namespaceID := namespace.ID(uuid.New())
+	namespaceID := namespace.ID(uuid.NewString())
 	inputString := "unit test"
 	signalName := "signal name"
 	config := s.newConfig()
@@ -1956,7 +2010,7 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_Signal() {
 	s.mockVisibilityMgr.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&manager.CountWorkflowExecutionsResponse{Count: 0}, nil)
 	request := &workflowservice.StartBatchOperationRequest{
 		Namespace: testNamespace.String(),
-		JobId:     uuid.New(),
+		JobId:     uuid.NewString(),
 		Operation: &workflowservice.StartBatchOperationRequest_SignalOperation{
 			SignalOperation: &batchpb.BatchOperationSignal{
 				Signal:   signalName,
@@ -1972,13 +2026,13 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_Signal() {
 	s.NoError(err)
 }
 
-func (s *workflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Signal() {
+func (s *WorkflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Signal() {
 	testNamespace := namespace.Name("test-namespace")
-	namespaceID := namespace.ID(uuid.New())
+	namespaceID := namespace.ID(uuid.NewString())
 	executions := []*commonpb.WorkflowExecution{
 		{
-			WorkflowId: uuid.New(),
-			RunId:      uuid.New(),
+			WorkflowId: uuid.NewString(),
+			RunId:      uuid.NewString(),
 		},
 	}
 	reason := "reason"
@@ -2021,7 +2075,7 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Signal
 	s.mockVisibilityMgr.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&manager.CountWorkflowExecutionsResponse{Count: 0}, nil)
 	request := &workflowservice.StartBatchOperationRequest{
 		Namespace: testNamespace.String(),
-		JobId:     uuid.New(),
+		JobId:     uuid.NewString(),
 		Operation: &workflowservice.StartBatchOperationRequest_SignalOperation{
 			SignalOperation: &batchpb.BatchOperationSignal{
 				Signal:   signalName,
@@ -2037,13 +2091,13 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Signal
 	s.NoError(err)
 }
 
-func (s *workflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Reset() {
+func (s *WorkflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Reset() {
 	testNamespace := namespace.Name("test-namespace")
-	namespaceID := namespace.ID(uuid.New())
+	namespaceID := namespace.ID(uuid.NewString())
 	executions := []*commonpb.WorkflowExecution{
 		{
-			WorkflowId: uuid.New(),
-			RunId:      uuid.New(),
+			WorkflowId: uuid.NewString(),
+			RunId:      uuid.NewString(),
 		},
 	}
 	reason := "reason"
@@ -2084,7 +2138,7 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Reset(
 	s.mockVisibilityMgr.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&manager.CountWorkflowExecutionsResponse{Count: 0}, nil)
 	request := &workflowservice.StartBatchOperationRequest{
 		Namespace: testNamespace.String(),
-		JobId:     uuid.New(),
+		JobId:     uuid.NewString(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetOperation{
 			ResetOperation: &batchpb.BatchOperationReset{
 				ResetType:        enumspb.RESET_TYPE_LAST_WORKFLOW_TASK,
@@ -2099,13 +2153,13 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Reset(
 	_, err = wh.StartBatchOperation(context.Background(), request)
 	s.NoError(err)
 }
-func (s *workflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_TooMany() {
+func (s *WorkflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_TooMany() {
 	testNamespace := namespace.Name("test-namespace")
-	namespaceID := namespace.ID(uuid.New())
+	namespaceID := namespace.ID(uuid.NewString())
 	executions := []*commonpb.WorkflowExecution{
 		{
-			WorkflowId: uuid.New(),
-			RunId:      uuid.New(),
+			WorkflowId: uuid.NewString(),
+			RunId:      uuid.NewString(),
 		},
 	}
 	reason := "reason"
@@ -2144,7 +2198,7 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_TooMan
 
 	request := &workflowservice.StartBatchOperationRequest{
 		Namespace: testNamespace.String(),
-		JobId:     uuid.New(),
+		JobId:     uuid.NewString(),
 		Operation: &workflowservice.StartBatchOperationRequest_CancellationOperation{
 			CancellationOperation: &batchpb.BatchOperationCancellation{
 				Identity: identity,
@@ -2158,18 +2212,18 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_TooMan
 	s.EqualError(err, "Max concurrent batch operations is reached")
 }
 
-func (s *workflowHandlerSuite) TestStartBatchOperation_InvalidRequest() {
+func (s *WorkflowHandlerSuite) TestStartBatchOperation_InvalidRequest() {
 	request := &workflowservice.StartBatchOperationRequest{
 		Namespace: "",
-		JobId:     uuid.New(),
+		JobId:     uuid.NewString(),
 		Operation: &workflowservice.StartBatchOperationRequest_SignalOperation{
 			SignalOperation: &batchpb.BatchOperationSignal{
 				Signal:   "signalName",
 				Identity: "identity",
 			},
 		},
-		Reason:          uuid.New(),
-		VisibilityQuery: uuid.New(),
+		Reason:          uuid.NewString(),
+		VisibilityQuery: uuid.NewString(),
 	}
 
 	config := s.newConfig()
@@ -2178,12 +2232,12 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_InvalidRequest() {
 	_, err := wh.StartBatchOperation(context.Background(), request)
 	s.ErrorAs(err, &invalidArgumentErr)
 
-	request.Namespace = uuid.New()
+	request.Namespace = uuid.NewString()
 	request.JobId = ""
 	_, err = wh.StartBatchOperation(context.Background(), request)
 	s.ErrorAs(err, &invalidArgumentErr)
 
-	request.JobId = uuid.New()
+	request.JobId = uuid.NewString()
 	request.Operation = nil
 	_, err = wh.StartBatchOperation(context.Background(), request)
 	s.ErrorAs(err, &invalidArgumentErr)
@@ -2198,16 +2252,16 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_InvalidRequest() {
 	_, err = wh.StartBatchOperation(context.Background(), request)
 	s.ErrorAs(err, &invalidArgumentErr)
 
-	request.Reason = uuid.New()
+	request.Reason = uuid.NewString()
 	request.VisibilityQuery = ""
 	_, err = wh.StartBatchOperation(context.Background(), request)
 	s.ErrorAs(err, &invalidArgumentErr)
 }
 
-func (s *workflowHandlerSuite) TestStopBatchOperation() {
+func (s *WorkflowHandlerSuite) TestStopBatchOperation() {
 	testNamespace := namespace.Name("test-namespace")
-	namespaceID := namespace.ID(uuid.New())
-	jobID := uuid.New()
+	namespaceID := namespace.ID(uuid.NewString())
+	jobID := uuid.NewString()
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 
@@ -2234,12 +2288,12 @@ func (s *workflowHandlerSuite) TestStopBatchOperation() {
 	s.NoError(err)
 }
 
-func (s *workflowHandlerSuite) TestStopBatchOperation_InvalidRequest() {
+func (s *WorkflowHandlerSuite) TestStopBatchOperation_InvalidRequest() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	request := &workflowservice.StopBatchOperationRequest{
 		Namespace: "",
-		JobId:     uuid.New(),
+		JobId:     uuid.NewString(),
 		Reason:    "reason",
 	}
 
@@ -2247,21 +2301,21 @@ func (s *workflowHandlerSuite) TestStopBatchOperation_InvalidRequest() {
 	_, err := wh.StopBatchOperation(context.Background(), request)
 	s.ErrorAs(err, &invalidArgumentErr)
 
-	request.Namespace = uuid.New()
+	request.Namespace = uuid.NewString()
 	request.JobId = ""
 	_, err = wh.StopBatchOperation(context.Background(), request)
 	s.ErrorAs(err, &invalidArgumentErr)
 
-	request.JobId = uuid.New()
+	request.JobId = uuid.NewString()
 	request.Reason = ""
 	_, err = wh.StopBatchOperation(context.Background(), request)
 	s.ErrorAs(err, &invalidArgumentErr)
 }
 
-func (s *workflowHandlerSuite) TestDescribeBatchOperation_CompletedStatus() {
+func (s *WorkflowHandlerSuite) TestDescribeBatchOperation_CompletedStatus() {
 	testNamespace := namespace.Name("test-namespace")
-	namespaceID := namespace.ID(uuid.New())
-	jobID := uuid.New()
+	namespaceID := namespace.ID(uuid.NewString())
+	jobID := uuid.NewString()
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	now := timestamppb.New(time.Now())
@@ -2352,10 +2406,10 @@ func (s *workflowHandlerSuite) TestDescribeBatchOperation_CompletedStatus() {
 	})
 }
 
-func (s *workflowHandlerSuite) TestDescribeBatchOperation_RunningStatus() {
+func (s *WorkflowHandlerSuite) TestDescribeBatchOperation_RunningStatus() {
 	testNamespace := namespace.Name("test-namespace")
-	namespaceID := namespace.ID(uuid.New())
-	jobID := uuid.New()
+	namespaceID := namespace.ID(uuid.NewString())
+	jobID := uuid.NewString()
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	now := timestamppb.New(time.Now())
@@ -2413,10 +2467,10 @@ func (s *workflowHandlerSuite) TestDescribeBatchOperation_RunningStatus() {
 	s.Assert().Equal(int64(1), resp.FailureOperationCount)
 }
 
-func (s *workflowHandlerSuite) TestDescribeBatchOperation_FailedStatus() {
+func (s *WorkflowHandlerSuite) TestDescribeBatchOperation_FailedStatus() {
 	testNamespace := namespace.Name("test-namespace")
-	namespaceID := namespace.ID(uuid.New())
-	jobID := uuid.New()
+	namespaceID := namespace.ID(uuid.NewString())
+	jobID := uuid.NewString()
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	now := timestamppb.New(time.Now())
@@ -2461,27 +2515,27 @@ func (s *workflowHandlerSuite) TestDescribeBatchOperation_FailedStatus() {
 	s.Equal(enumspb.BATCH_OPERATION_STATE_FAILED, resp.GetState())
 }
 
-func (s *workflowHandlerSuite) TestDescribeBatchOperation_InvalidRequest() {
+func (s *WorkflowHandlerSuite) TestDescribeBatchOperation_InvalidRequest() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	request := &workflowservice.DescribeBatchOperationRequest{
 		Namespace: "",
-		JobId:     uuid.New(),
+		JobId:     uuid.NewString(),
 	}
 	var invalidArgumentErr *serviceerror.InvalidArgument
 	_, err := wh.DescribeBatchOperation(context.Background(), request)
 	s.ErrorAs(err, &invalidArgumentErr)
 
-	request.Namespace = uuid.New()
+	request.Namespace = uuid.NewString()
 	request.JobId = ""
 	_, err = wh.DescribeBatchOperation(context.Background(), request)
 	s.ErrorAs(err, &invalidArgumentErr)
 }
 
-func (s *workflowHandlerSuite) TestListBatchOperations() {
+func (s *WorkflowHandlerSuite) TestListBatchOperations() {
 	testNamespace := namespace.Name("test-namespace")
-	namespaceID := namespace.ID(uuid.New())
-	jobID := uuid.New()
+	namespaceID := namespace.ID(uuid.NewString())
+	jobID := uuid.NewString()
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	now := timestamppb.New(time.Now())
@@ -2525,7 +2579,7 @@ func (s *workflowHandlerSuite) TestListBatchOperations() {
 	s.Equal(enumspb.BATCH_OPERATION_STATE_FAILED, resp.OperationInfo[0].GetState())
 }
 
-func (s *workflowHandlerSuite) TestListBatchOperations_InvalidRerquest() {
+func (s *WorkflowHandlerSuite) TestListBatchOperations_InvalidRerquest() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 
@@ -2537,7 +2591,7 @@ func (s *workflowHandlerSuite) TestListBatchOperations_InvalidRerquest() {
 	s.ErrorAs(err, &invalidArgumentErr)
 }
 
-func (s *workflowHandlerSuite) newConfig() *Config {
+func (s *WorkflowHandlerSuite) newConfig() *Config {
 	return NewConfig(dc.NewNoopCollection(), numHistoryShards)
 }
 
@@ -2656,7 +2710,7 @@ func TestValidateRequestId(t *testing.T) {
 	assert.Contains(t, err.Error(), "not a valid UTF-8 string")
 }
 
-func (s *workflowHandlerSuite) Test_DeleteWorkflowExecution() {
+func (s *WorkflowHandlerSuite) Test_DeleteWorkflowExecution() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	ctx := context.Background()
@@ -2725,7 +2779,7 @@ func (s *workflowHandlerSuite) Test_DeleteWorkflowExecution() {
 	s.NotNil(resp)
 }
 
-func (s *workflowHandlerSuite) TestExecuteMultiOperation() {
+func (s *WorkflowHandlerSuite) TestExecuteMultiOperation() {
 	ctx := context.Background()
 	config := s.newConfig()
 	config.EnableExecuteMultiOperation = func(string) bool { return true }
@@ -2946,7 +3000,7 @@ func (s *workflowHandlerSuite) TestExecuteMultiOperation() {
 	})
 }
 
-func (s *workflowHandlerSuite) TestShutdownWorker() {
+func (s *WorkflowHandlerSuite) TestShutdownWorker() {
 	config := s.newConfig()
 	wh := s.getWorkflowHandler(config)
 	ctx := context.Background()


### PR DESCRIPTION
## What changed?

Add validation for both link size and number of links per request.
Also refactored `workflow_handler_test.go` so a single test can be executed at a time and removed the use of `pborman/uuid` in this file.

## Why?

Accepting unbounded inputs is a security risk.

## How did you test it?

Unit tests.