### PR TITLE
Wait for task writer write loop to stop

### DIFF
--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -122,6 +122,7 @@ func (w *taskWriter) Stop() {
 		return
 	}
 	w.writeLoop.Cancel()
+	<-w.writeLoop.Done()
 }
 
 func (w *taskWriter) initReadWriteState(ctx context.Context) error {


### PR DESCRIPTION
## What changed?
Wait for write loop to stop in task writer shutdown.

## Why?
Mostly to fix the flaky test TestTaskWriterShutdown

## How did you test it?
Ran test a few hundred thousand times