### PR TITLE
Propagate links from all supported API requests to events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/sdk/metric v1.27.0
 	go.opentelemetry.io/otel/trace v1.27.0
-	go.temporal.io/api v1.39.1-0.20240910163028-b13574e18f3c
+	go.temporal.io/api v1.39.1-0.20241009002640-770fbc24a354
 	go.temporal.io/sdk v1.29.1
 	go.temporal.io/version v0.3.0
 	go.uber.org/atomic v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -321,8 +321,8 @@ go.opentelemetry.io/otel/trace v1.27.0 h1:IqYb813p7cmbHk0a5y6pD5JPakbVfftRXABGt5
 go.opentelemetry.io/otel/trace v1.27.0/go.mod h1:6RiD1hkAprV4/q+yd2ln1HG9GoPx39SuvvstaLBl+l4=
 go.opentelemetry.io/proto/otlp v1.2.0 h1:pVeZGk7nXDC9O2hncA6nHldxEjm6LByfA2aN8IOkz94=
 go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naRm/KDsgaHD8A=
-go.temporal.io/api v1.39.1-0.20240910163028-b13574e18f3c h1:1mORGBzFqhOn4I+Yg/KT07UQtHV59wptGxsPRB0rGIk=
-go.temporal.io/api v1.39.1-0.20240910163028-b13574e18f3c/go.mod h1:1WwYUMo6lao8yl0371xWUm13paHExN5ATYT/B7QtFis=
+go.temporal.io/api v1.39.1-0.20241009002640-770fbc24a354 h1:bHQwYbpodmJh6No1B3uUGR/cb6K/nfzVT+DD1bc9QY8=
+go.temporal.io/api v1.39.1-0.20241009002640-770fbc24a354/go.mod h1:1WwYUMo6lao8yl0371xWUm13paHExN5ATYT/B7QtFis=
 go.temporal.io/sdk v1.29.1 h1:y+sUMbUhTU9rj50mwIZAPmcXCtgUdOWS9xHDYRYSgZ0=
 go.temporal.io/sdk v1.29.1/go.mod h1:kp//DRvn3CqQVBCtjL51Oicp9wrZYB2s6row1UgzcKQ=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=

--- a/service/history/api/create_workflow_util.go
+++ b/service/history/api/create_workflow_util.go
@@ -124,6 +124,7 @@ func NewWorkflowWithSignal(
 			signalWithStartRequest.GetIdentity(),
 			signalWithStartRequest.GetHeader(),
 			signalWithStartRequest.GetSkipGenerateWorkflowTask(),
+			signalWithStartRequest.GetLinks(),
 		); err != nil {
 			return nil, err
 		}

--- a/service/history/api/deleteworkflow/api.go
+++ b/service/history/api/deleteworkflow/api.go
@@ -95,6 +95,8 @@ func Invoke(
 						nil,
 						consts.IdentityHistoryService,
 						true,
+						// TODO(bergundy): No links will be attached here for now, we may want to add support for this later though.
+						nil,
 					)
 				},
 				nil,

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -464,6 +464,7 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 				nil,
 				consts.IdentityHistoryService,
 				false,
+				nil, // No links necessary.
 			)
 			if err != nil {
 				return nil, err
@@ -614,6 +615,7 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 				payloads.EncodeString(updateErr.Error()),
 				consts.IdentityHistoryService,
 				false,
+				nil, // no links necessary.
 			); err != nil {
 				return nil, err
 			}

--- a/service/history/api/signalwithstartworkflow/convert.go
+++ b/service/history/api/signalwithstartworkflow/convert.go
@@ -58,6 +58,7 @@ func ConvertToStartRequest(
 		Header:                   request.GetHeader(),
 		WorkflowStartDelay:       request.GetWorkflowStartDelay(),
 		UserMetadata:             request.UserMetadata,
+		Links:                    request.GetLinks(),
 	}
 
 	return common.CreateHistoryStartWorkflowRequest(namespaceID.String(), req, nil, nil, now)

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -317,6 +317,7 @@ func signalWorkflow(
 		request.GetIdentity(),
 		request.GetHeader(),
 		request.GetSkipGenerateWorkflowTask(),
+		request.GetLinks(),
 	); err != nil {
 		return err
 	}

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow_test.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow_test.go
@@ -167,6 +167,7 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_NewWorkflowTask() {
 		request.GetIdentity(),
 		request.GetHeader(),
 		request.GetSkipGenerateWorkflowTask(),
+		request.GetLinks(),
 	).Return(&history.HistoryEvent{}, nil)
 	s.currentMutableState.EXPECT().HasPendingWorkflowTask().Return(false)
 	s.currentMutableState.EXPECT().HadOrHasWorkflowTask().Return(true)
@@ -200,6 +201,7 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_NoNewWorkflowTask() {
 		request.GetIdentity(),
 		request.GetHeader(),
 		request.GetSkipGenerateWorkflowTask(),
+		request.GetLinks(),
 	).Return(&history.HistoryEvent{}, nil)
 	s.currentMutableState.EXPECT().HasPendingWorkflowTask().Return(true)
 	s.currentContext.EXPECT().UpdateWorkflowExecutionAsActive(ctx, s.shardContext).Return(nil)

--- a/service/history/api/signalworkflow/api.go
+++ b/service/history/api/signalworkflow/api.go
@@ -112,6 +112,7 @@ func Invoke(
 				request.GetHeader(),
 				request.GetSkipGenerateWorkflowTask(),
 				externalWorkflowExecution,
+				request.GetLinks(),
 			)
 			if err != nil {
 				return nil, err

--- a/service/history/api/terminateworkflow/api.go
+++ b/service/history/api/terminateworkflow/api.go
@@ -94,6 +94,7 @@ func Invoke(
 				request.GetDetails(),
 				request.GetIdentity(),
 				false,
+				request.GetLinks(),
 			)
 		},
 		nil,

--- a/service/history/api/workflow_id_dedup.go
+++ b/service/history/api/workflow_id_dedup.go
@@ -161,6 +161,7 @@ func terminateWorkflowAction(
 			payloads.EncodeString(fmt.Sprintf("terminated by new runID: %s", newRunID)),
 			consts.IdentityHistoryService,
 			false,
+			nil, // No links necessary.
 		)
 	}, nil
 }

--- a/service/history/historybuilder/event_factory.go
+++ b/service/history/historybuilder/event_factory.go
@@ -374,6 +374,7 @@ func (b *EventFactory) CreateWorkflowExecutionTerminatedEvent(
 	reason string,
 	details *commonpb.Payloads,
 	identity string,
+	links []*commonpb.Link,
 ) *historypb.HistoryEvent {
 	event := b.createHistoryEvent(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED, b.timeSource.Now())
 	event.Attributes = &historypb.HistoryEvent_WorkflowExecutionTerminatedEventAttributes{
@@ -383,6 +384,7 @@ func (b *EventFactory) CreateWorkflowExecutionTerminatedEvent(
 			Identity: identity,
 		},
 	}
+	event.Links = links
 	return event
 }
 
@@ -547,6 +549,7 @@ func (b *EventFactory) CreateWorkflowExecutionCancelRequestedEvent(request *hist
 			ExternalWorkflowExecution: request.ExternalWorkflowExecution,
 		},
 	}
+	event.Links = request.CancelRequest.Links
 	return event
 }
 
@@ -777,6 +780,7 @@ func (b *EventFactory) CreateWorkflowExecutionSignaledEvent(
 	header *commonpb.Header,
 	skipGenerateWorkflowTask bool,
 	externalWorkflowExecution *commonpb.WorkflowExecution,
+	links []*commonpb.Link,
 ) *historypb.HistoryEvent {
 	event := b.createHistoryEvent(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED, b.timeSource.Now())
 	event.Attributes = &historypb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{
@@ -789,6 +793,7 @@ func (b *EventFactory) CreateWorkflowExecutionSignaledEvent(
 			ExternalWorkflowExecution: externalWorkflowExecution,
 		},
 	}
+	event.Links = links
 	return event
 }
 

--- a/service/history/historybuilder/history_builder.go
+++ b/service/history/historybuilder/history_builder.go
@@ -398,8 +398,9 @@ func (b *HistoryBuilder) AddWorkflowExecutionTerminatedEvent(
 	reason string,
 	details *commonpb.Payloads,
 	identity string,
+	links []*commonpb.Link,
 ) *historypb.HistoryEvent {
-	event := b.EventFactory.CreateWorkflowExecutionTerminatedEvent(reason, details, identity)
+	event := b.EventFactory.CreateWorkflowExecutionTerminatedEvent(reason, details, identity, links)
 
 	event, _ = b.EventStore.add(event)
 	return event
@@ -669,6 +670,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionSignaledEvent(
 	header *commonpb.Header,
 	skipGenerateWorkflowTask bool,
 	externalWorkflowExecution *commonpb.WorkflowExecution,
+	links []*commonpb.Link,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateWorkflowExecutionSignaledEvent(
 		signalName,
@@ -677,6 +679,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionSignaledEvent(
 		header,
 		skipGenerateWorkflowTask,
 		externalWorkflowExecution,
+		links,
 	)
 	event, _ = b.EventStore.add(event)
 	return event

--- a/service/history/historybuilder/history_builder_categorization_test.go
+++ b/service/history/historybuilder/history_builder_categorization_test.go
@@ -1314,7 +1314,7 @@ func (s *sutTestingAdapter) AddTimeoutWorkflowEvent(_ ...eventConfig) *historypb
 }
 
 func (s *sutTestingAdapter) AddWorkflowExecutionTerminatedEvent(_ ...eventConfig) *historypb.HistoryEvent {
-	return s.HistoryBuilder.AddWorkflowExecutionTerminatedEvent("no reason to terminate", nil, "identity-secret")
+	return s.HistoryBuilder.AddWorkflowExecutionTerminatedEvent("no reason to terminate", nil, "identity-secret", nil)
 }
 
 func (s *sutTestingAdapter) AddWorkflowExecutionUpdateAcceptedEvent(_ ...eventConfig) *historypb.HistoryEvent {
@@ -1452,6 +1452,7 @@ func (s *sutTestingAdapter) AddWorkflowExecutionSignaledEvent(_ ...eventConfig) 
 		"identity-1",
 		nil,
 		false,
+		nil,
 		nil,
 	)
 }

--- a/service/history/historybuilder/history_builder_test.go
+++ b/service/history/historybuilder/history_builder_test.go
@@ -353,7 +353,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionCancelRequested() {
 func (s *historyBuilderSuite) TestWorkflowExecutionSignaled() {
 	signalName := "random signal name"
 	event := s.historyBuilder.AddWorkflowExecutionSignaledEvent(
-		signalName, testPayloads, testIdentity, testHeader, false, nil,
+		signalName, testPayloads, testIdentity, testHeader, false, nil, nil,
 	)
 	s.Equal(event, s.flush())
 	s.Equal(&historypb.HistoryEvent{
@@ -564,6 +564,7 @@ func (s *historyBuilderSuite) TestWorkflowExecutionTerminated() {
 		reason,
 		testPayloads,
 		testIdentity,
+		nil,
 	)
 	s.Equal(event, s.flush())
 	s.Equal(&historypb.HistoryEvent{
@@ -2371,6 +2372,7 @@ func (s *historyBuilderSuite) TestBufferSize_Memory() {
 		"identity",
 		&commonpb.Header{},
 		false,
+		nil,
 		nil,
 	)
 	s.Assert().Equal(1, s.historyBuilder.NumBufferedEvents())

--- a/service/history/ndc/events_reapplier_test.go
+++ b/service/history/ndc/events_reapplier_test.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pborman/uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
@@ -92,9 +92,9 @@ func (s *nDCEventReapplicationSuite) TearDownTest() {
 }
 
 func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Signal() {
-	runID := uuid.New()
+	runID := uuid.NewString()
 	execution := &persistencespb.WorkflowExecutionInfo{
-		NamespaceId: uuid.New(),
+		NamespaceId: uuid.NewString(),
 	}
 	event := &historypb.HistoryEvent{
 		EventId:   1,
@@ -105,6 +105,17 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Signal() {
 			Input:      payloads.EncodeBytes([]byte{}),
 			Header:     &commonpb.Header{Fields: map[string]*commonpb.Payload{"myheader": {Data: []byte("myheader")}}},
 		}},
+		Links: []*commonpb.Link{
+			{
+				Variant: &commonpb.Link_WorkflowEvent_{
+					WorkflowEvent: &commonpb.Link_WorkflowEvent{
+						Namespace:  "whatever",
+						WorkflowId: "abc",
+						RunId:      uuid.NewString(),
+					},
+				},
+			},
+		},
 	}
 	attr := event.GetWorkflowExecutionSignaledEventAttributes()
 
@@ -120,6 +131,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Signal() {
 		attr.GetIdentity(),
 		attr.GetHeader(),
 		attr.GetSkipGenerateWorkflowTask(),
+		event.Links,
 	).Return(event, nil)
 	msCurrent.EXPECT().HSM().Return(s.hsmNode).AnyTimes()
 	msCurrent.EXPECT().IsWorkflowPendingOnWorkflowTaskBackoff().Return(true)
@@ -136,9 +148,9 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Signal() {
 }
 
 func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
-	runID := uuid.New()
+	runID := uuid.NewString()
 	execution := &persistencespb.WorkflowExecutionInfo{
-		NamespaceId: uuid.New(),
+		NamespaceId: uuid.NewString(),
 	}
 	for _, event := range []*historypb.HistoryEvent{
 		{
@@ -197,7 +209,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent_Update() {
 }
 
 func (s *nDCEventReapplicationSuite) TestReapplyEvents_Noop() {
-	runID := uuid.New()
+	runID := uuid.NewString()
 	event := &historypb.HistoryEvent{
 		EventId:   1,
 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED,
@@ -226,9 +238,9 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Noop() {
 }
 
 func (s *nDCEventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
-	runID := uuid.New()
+	runID := uuid.NewString()
 	execution := &persistencespb.WorkflowExecutionInfo{
-		NamespaceId: uuid.New(),
+		NamespaceId: uuid.NewString(),
 	}
 	event1 := &historypb.HistoryEvent{
 		EventId:   1,
@@ -264,6 +276,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
 		attr1.GetIdentity(),
 		attr1.GetHeader(),
 		attr1.GetSkipGenerateWorkflowTask(),
+		event1.Links,
 	).Return(event1, nil)
 	msCurrent.EXPECT().IsWorkflowPendingOnWorkflowTaskBackoff().Return(true)
 	dedupResource1 := definition.NewEventReappliedID(runID, event1.GetEventId(), event1.GetVersion())
@@ -283,9 +296,9 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
 }
 
 func (s *nDCEventReapplicationSuite) TestReapplyEvents_Error() {
-	runID := uuid.New()
+	runID := uuid.NewString()
 	execution := &persistencespb.WorkflowExecutionInfo{
-		NamespaceId: uuid.New(),
+		NamespaceId: uuid.NewString(),
 	}
 	event := &historypb.HistoryEvent{
 		EventId:   1,
@@ -311,6 +324,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Error() {
 		attr.GetIdentity(),
 		attr.GetHeader(),
 		attr.GetSkipGenerateWorkflowTask(),
+		event.Links,
 	).Return(nil, fmt.Errorf("test"))
 	dedupResource := definition.NewEventReappliedID(runID, event.GetEventId(), event.GetVersion())
 	msCurrent.EXPECT().IsResourceDuplicated(dedupResource).Return(false)

--- a/service/history/ndc/workflow.go
+++ b/service/history/ndc/workflow.go
@@ -300,6 +300,7 @@ func (r *WorkflowImpl) terminateWorkflow(
 		payloads.EncodeString(fmt.Sprintf("terminated by version: %v", incomingLastWriteVersion)),
 		WorkflowTerminationIdentity,
 		false,
+		nil, // No links necessary.
 	)
 
 	// Don't abort updates here for a few reasons:

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -566,6 +566,7 @@ func (r *workflowResetterImpl) terminateWorkflow(
 		nil,
 		consts.IdentityResetter,
 		false,
+		nil, // No links necessary.
 	)
 }
 
@@ -764,6 +765,7 @@ func reapplyEvents(
 				attr.GetIdentity(),
 				attr.GetHeader(),
 				attr.GetSkipGenerateWorkflowTask(),
+				event.Links,
 			); err != nil {
 				return reappliedEvents, err
 			}

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -553,6 +553,7 @@ func (s *workflowResetterSuite) TestTerminateWorkflow() {
 		nil,
 		consts.IdentityResetter,
 		false,
+		nil,
 	).Return(&historypb.HistoryEvent{}, nil)
 
 	err := s.workflowResetter.terminateWorkflow(mutableState, terminateReason)
@@ -890,6 +891,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 				attr.GetIdentity(),
 				attr.GetHeader(),
 				attr.GetSkipGenerateWorkflowTask(),
+				event.Links,
 			).Return(&historypb.HistoryEvent{}, nil)
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED:
 			attr := event.GetWorkflowExecutionUpdateAdmittedEventAttributes()

--- a/service/history/ndc/workflow_test.go
+++ b/service/history/ndc/workflow_test.go
@@ -288,7 +288,7 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 	s.mockMutableState.EXPECT().FlushBufferedEvents()
 
 	s.mockMutableState.EXPECT().AddWorkflowExecutionTerminatedEvent(
-		wtFailedEventID, WorkflowTerminationReason, gomock.Any(), WorkflowTerminationIdentity, false,
+		wtFailedEventID, WorkflowTerminationReason, gomock.Any(), WorkflowTerminationIdentity, false, nil,
 	).Return(&historypb.HistoryEvent{}, nil)
 
 	// if workflow is in zombie or finished state, keep as is

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -1096,6 +1096,7 @@ func (c *ContextImpl) forceTerminateWorkflow(
 		nil,
 		consts.IdentityHistoryService,
 		false,
+		nil, // No links necessary.
 	)
 }
 

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -192,7 +192,14 @@ type (
 		AddWorkflowPropertiesModifiedEvent(int64, *commandpb.ModifyWorkflowPropertiesCommandAttributes) (*historypb.HistoryEvent, error)
 		AddWorkflowExecutionCancelRequestedEvent(*historyservice.RequestCancelWorkflowExecutionRequest) (*historypb.HistoryEvent, error)
 		AddWorkflowExecutionCanceledEvent(int64, *commandpb.CancelWorkflowExecutionCommandAttributes) (*historypb.HistoryEvent, error)
-		AddWorkflowExecutionSignaled(signalName string, input *commonpb.Payloads, identity string, header *commonpb.Header, skipGenerateWorkflowTask bool) (*historypb.HistoryEvent, error)
+		AddWorkflowExecutionSignaled(
+			signalName string,
+			input *commonpb.Payloads,
+			identity string,
+			header *commonpb.Header,
+			skipGenerateWorkflowTask bool,
+			links []*commonpb.Link,
+		) (*historypb.HistoryEvent, error)
 		AddWorkflowExecutionSignaledEvent(
 			signalName string,
 			input *commonpb.Payloads,
@@ -200,10 +207,11 @@ type (
 			header *commonpb.Header,
 			skipGenerateWorkflowTask bool,
 			externalWorkflowExecution *commonpb.WorkflowExecution,
+			links []*commonpb.Link,
 		) (*historypb.HistoryEvent, error)
 		AddWorkflowExecutionStartedEvent(*commonpb.WorkflowExecution, *historyservice.StartWorkflowExecutionRequest) (*historypb.HistoryEvent, error)
 		AddWorkflowExecutionStartedEventWithOptions(*commonpb.WorkflowExecution, *historyservice.StartWorkflowExecutionRequest, *workflowpb.ResetPoints, string, string) (*historypb.HistoryEvent, error)
-		AddWorkflowExecutionTerminatedEvent(firstEventID int64, reason string, details *commonpb.Payloads, identity string, deleteAfterTerminate bool) (*historypb.HistoryEvent, error)
+		AddWorkflowExecutionTerminatedEvent(firstEventID int64, reason string, details *commonpb.Payloads, identity string, deleteAfterTerminate bool, links []*commonpb.Link) (*historypb.HistoryEvent, error)
 
 		AddWorkflowExecutionUpdateAcceptedEvent(protocolInstanceID string, acceptedRequestMessageId string, acceptedRequestSequencingEventId int64, acceptedRequest *updatepb.Request) (*historypb.HistoryEvent, error)
 		AddWorkflowExecutionUpdateCompletedEvent(acceptedEventID int64, updResp *updatepb.Response) (*historypb.HistoryEvent, error)

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4057,13 +4057,14 @@ func (ms *MutableStateImpl) AddWorkflowExecutionTerminatedEvent(
 	details *commonpb.Payloads,
 	identity string,
 	deleteAfterTerminate bool,
+	links []*commonpb.Link,
 ) (*historypb.HistoryEvent, error) {
 	opTag := tag.WorkflowActionWorkflowTerminated
 	if err := ms.checkMutability(opTag); err != nil {
 		return nil, err
 	}
 
-	event := ms.hBuilder.AddWorkflowExecutionTerminatedEvent(reason, details, identity)
+	event := ms.hBuilder.AddWorkflowExecutionTerminatedEvent(reason, details, identity, links)
 	if err := ms.ApplyWorkflowExecutionTerminatedEvent(firstEventID, event); err != nil {
 		return nil, err
 	}
@@ -4248,6 +4249,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionSignaled(
 	identity string,
 	header *commonpb.Header,
 	skipGenerateWorkflowTask bool,
+	links []*commonpb.Link,
 ) (*historypb.HistoryEvent, error) {
 	return ms.AddWorkflowExecutionSignaledEvent(
 		signalName,
@@ -4256,6 +4258,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionSignaled(
 		header,
 		skipGenerateWorkflowTask,
 		nil,
+		links,
 	)
 }
 
@@ -4266,6 +4269,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionSignaledEvent(
 	header *commonpb.Header,
 	skipGenerateWorkflowTask bool,
 	externalWorkflowExecution *commonpb.WorkflowExecution,
+	links []*commonpb.Link,
 ) (*historypb.HistoryEvent, error) {
 	opTag := tag.WorkflowActionWorkflowSignaled
 	if err := ms.checkMutability(opTag); err != nil {
@@ -4279,6 +4283,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionSignaledEvent(
 		header,
 		skipGenerateWorkflowTask,
 		externalWorkflowExecution,
+		links,
 	)
 	if err := ms.ApplyWorkflowExecutionSignaled(event); err != nil {
 		return nil, err

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -1442,6 +1442,7 @@ func (s *mutableStateSuite) TestTotalEntitiesCount() {
 		"identity",
 		&commonpb.Header{},
 		false,
+		nil,
 	)
 	s.NoError(err)
 

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -646,33 +646,33 @@ func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionCanceledEvent(arg0, 
 }
 
 // AddWorkflowExecutionSignaled mocks base method.
-func (m *MockMutableState) AddWorkflowExecutionSignaled(signalName string, input *common.Payloads, identity string, header *common.Header, skipGenerateWorkflowTask bool) (*history.HistoryEvent, error) {
+func (m *MockMutableState) AddWorkflowExecutionSignaled(signalName string, input *common.Payloads, identity string, header *common.Header, skipGenerateWorkflowTask bool, links []*common.Link) (*history.HistoryEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddWorkflowExecutionSignaled", signalName, input, identity, header, skipGenerateWorkflowTask)
+	ret := m.ctrl.Call(m, "AddWorkflowExecutionSignaled", signalName, input, identity, header, skipGenerateWorkflowTask, links)
 	ret0, _ := ret[0].(*history.HistoryEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddWorkflowExecutionSignaled indicates an expected call of AddWorkflowExecutionSignaled.
-func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionSignaled(signalName, input, identity, header, skipGenerateWorkflowTask any) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionSignaled(signalName, input, identity, header, skipGenerateWorkflowTask, links any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowExecutionSignaled", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowExecutionSignaled), signalName, input, identity, header, skipGenerateWorkflowTask)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowExecutionSignaled", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowExecutionSignaled), signalName, input, identity, header, skipGenerateWorkflowTask, links)
 }
 
 // AddWorkflowExecutionSignaledEvent mocks base method.
-func (m *MockMutableState) AddWorkflowExecutionSignaledEvent(signalName string, input *common.Payloads, identity string, header *common.Header, skipGenerateWorkflowTask bool, externalWorkflowExecution *common.WorkflowExecution) (*history.HistoryEvent, error) {
+func (m *MockMutableState) AddWorkflowExecutionSignaledEvent(signalName string, input *common.Payloads, identity string, header *common.Header, skipGenerateWorkflowTask bool, externalWorkflowExecution *common.WorkflowExecution, links []*common.Link) (*history.HistoryEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddWorkflowExecutionSignaledEvent", signalName, input, identity, header, skipGenerateWorkflowTask, externalWorkflowExecution)
+	ret := m.ctrl.Call(m, "AddWorkflowExecutionSignaledEvent", signalName, input, identity, header, skipGenerateWorkflowTask, externalWorkflowExecution, links)
 	ret0, _ := ret[0].(*history.HistoryEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddWorkflowExecutionSignaledEvent indicates an expected call of AddWorkflowExecutionSignaledEvent.
-func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionSignaledEvent(signalName, input, identity, header, skipGenerateWorkflowTask, externalWorkflowExecution any) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionSignaledEvent(signalName, input, identity, header, skipGenerateWorkflowTask, externalWorkflowExecution, links any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowExecutionSignaledEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowExecutionSignaledEvent), signalName, input, identity, header, skipGenerateWorkflowTask, externalWorkflowExecution)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowExecutionSignaledEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowExecutionSignaledEvent), signalName, input, identity, header, skipGenerateWorkflowTask, externalWorkflowExecution, links)
 }
 
 // AddWorkflowExecutionStartedEvent mocks base method.
@@ -706,18 +706,18 @@ func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionStartedEventWithOpti
 }
 
 // AddWorkflowExecutionTerminatedEvent mocks base method.
-func (m *MockMutableState) AddWorkflowExecutionTerminatedEvent(firstEventID int64, reason string, details *common.Payloads, identity string, deleteAfterTerminate bool) (*history.HistoryEvent, error) {
+func (m *MockMutableState) AddWorkflowExecutionTerminatedEvent(firstEventID int64, reason string, details *common.Payloads, identity string, deleteAfterTerminate bool, links []*common.Link) (*history.HistoryEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddWorkflowExecutionTerminatedEvent", firstEventID, reason, details, identity, deleteAfterTerminate)
+	ret := m.ctrl.Call(m, "AddWorkflowExecutionTerminatedEvent", firstEventID, reason, details, identity, deleteAfterTerminate, links)
 	ret0, _ := ret[0].(*history.HistoryEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddWorkflowExecutionTerminatedEvent indicates an expected call of AddWorkflowExecutionTerminatedEvent.
-func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionTerminatedEvent(firstEventID, reason, details, identity, deleteAfterTerminate any) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) AddWorkflowExecutionTerminatedEvent(firstEventID, reason, details, identity, deleteAfterTerminate, links any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowExecutionTerminatedEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowExecutionTerminatedEvent), firstEventID, reason, details, identity, deleteAfterTerminate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowExecutionTerminatedEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowExecutionTerminatedEvent), firstEventID, reason, details, identity, deleteAfterTerminate, links)
 }
 
 // AddWorkflowExecutionUpdateAcceptedEvent mocks base method.

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -118,6 +118,7 @@ func TerminateWorkflow(
 	terminateDetails *commonpb.Payloads,
 	terminateIdentity string,
 	deleteAfterTerminate bool,
+	links []*commonpb.Link,
 ) error {
 
 	// Terminate workflow is written as a separate batch and might result in more than one event
@@ -149,6 +150,7 @@ func TerminateWorkflow(
 		terminateDetails,
 		terminateIdentity,
 		deleteAfterTerminate,
+		links,
 	)
 
 	return err

--- a/service/history/workflow/workflow_test/mutable_state_impl_test.go
+++ b/service/history/workflow/workflow_test/mutable_state_impl_test.go
@@ -206,6 +206,7 @@ func addWorkflowExecutionSignaled(t *testing.T, i int, ms *workflow.MutableState
 		identity,
 		header,
 		false,
+		nil,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -427,7 +428,7 @@ func TestGetNexusCompletion(t *testing.T) {
 		{
 			name: "termination",
 			mutateState: func(mutableState workflow.MutableState) (*historypb.HistoryEvent, error) {
-				return mutableState.AddWorkflowExecutionTerminatedEvent(mutableState.GetNextEventID(), "dont care", nil, "identity", false)
+				return mutableState.AddWorkflowExecutionTerminatedEvent(mutableState.GetNextEventID(), "dont care", nil, "identity", false, nil)
 			},
 			verifyCompletion: func(t *testing.T, completion nexus.OperationCompletion) {
 				failure, ok := completion.(*nexus.OperationCompletionUnsuccessful)

--- a/tests/links_test.go
+++ b/tests/links_test.go
@@ -1,0 +1,218 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/tests/testcore"
+)
+
+type LinksSuite struct {
+	testcore.ClientFunctionalSuite
+}
+
+func TestLinksTestSuite(t *testing.T) {
+	suite.Run(t, new(LinksSuite))
+}
+
+var links = []*commonpb.Link{
+	{
+		Variant: &commonpb.Link_WorkflowEvent_{
+			WorkflowEvent: &commonpb.Link_WorkflowEvent{
+				Namespace:  "dont-care",
+				WorkflowId: "whatever",
+				RunId:      uuid.NewString(),
+			},
+		},
+	},
+}
+
+func (s *LinksSuite) TestTerminateWorkflow_LinksAttachedToEvent() {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	run, err := s.SdkClient().ExecuteWorkflow(
+		ctx,
+		client.StartWorkflowOptions{
+			TaskQueue: "dont-care",
+		},
+		"test-workflow-type",
+	)
+	s.NoError(err)
+
+	// TODO(bergundy): Use SdkClient if and when it exposes links on TerminateWorkflow.
+	_, err = s.FrontendClient().TerminateWorkflowExecution(ctx, &workflowservice.TerminateWorkflowExecutionRequest{
+		Namespace: s.Namespace(),
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: run.GetID(),
+		},
+		Reason: "test",
+		Links:  links,
+	})
+	s.NoError(err)
+
+	history := s.SdkClient().GetWorkflowHistory(ctx, run.GetID(), "", false, enumspb.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT)
+	event, err := history.Next()
+	s.NoError(err)
+	protorequire.ProtoSliceEqual(s.T(), links, event.Links)
+}
+
+func (s *LinksSuite) TestRequestCancelWorkflow_LinksAttachedToEvent() {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	run, err := s.SdkClient().ExecuteWorkflow(
+		ctx,
+		client.StartWorkflowOptions{
+			TaskQueue: "dont-care",
+		},
+		"test-workflow-type",
+	)
+	s.NoError(err)
+
+	// TODO(bergundy): Use SdkClient if and when it exposes links on CancelWorkflow.
+	_, err = s.FrontendClient().RequestCancelWorkflowExecution(ctx, &workflowservice.RequestCancelWorkflowExecutionRequest{
+		Namespace: s.Namespace(),
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: run.GetID(),
+		},
+		Reason: "test",
+		Links:  links,
+	})
+	s.NoError(err)
+
+	history := s.SdkClient().GetWorkflowHistory(ctx, run.GetID(), "", false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	foundEvent := false
+	for history.HasNext() {
+		event, err := history.Next()
+		s.NoError(err)
+		if event.EventType != enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED {
+			continue
+		}
+		foundEvent = true
+		protorequire.ProtoSliceEqual(s.T(), links, event.Links)
+	}
+	s.True(foundEvent)
+}
+
+func (s *LinksSuite) TestSignalWorkflowExecution_LinksAttachedToEvent() {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	run, err := s.SdkClient().ExecuteWorkflow(
+		ctx,
+		client.StartWorkflowOptions{
+			TaskQueue: "dont-care",
+		},
+		"test-workflow-type",
+	)
+	s.NoError(err)
+
+	// TODO(bergundy): Use SdkClient if and when it exposes links on SignalWorkflow.
+	_, err = s.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace: s.Namespace(),
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: run.GetID(),
+		},
+		SignalName: "dont-care",
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+		Links:      links,
+	})
+	s.NoError(err)
+
+	history := s.SdkClient().GetWorkflowHistory(ctx, run.GetID(), "", false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	foundEvent := false
+	for history.HasNext() {
+		event, err := history.Next()
+		s.NoError(err)
+		if event.EventType != enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED {
+			continue
+		}
+		foundEvent = true
+		protorequire.ProtoSliceEqual(s.T(), links, event.Links)
+	}
+	s.True(foundEvent)
+}
+
+func (s *LinksSuite) TestSignalWithStartWorkflowExecution_LinksAttachedToRelevantEvents() {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	workflowID := testcore.RandomizeStr(s.T().Name())
+
+	// TODO(bergundy): Use SdkClient if and when it exposes links on SignalWithStartWorkflow.
+	request := &workflowservice.SignalWithStartWorkflowExecutionRequest{
+		Namespace:  s.Namespace(),
+		WorkflowId: workflowID,
+		WorkflowType: &commonpb.WorkflowType{
+			Name: "dont-care",
+		},
+		SignalName: "dont-care",
+		Identity:   "test",
+		TaskQueue: &taskqueue.TaskQueue{
+			Name: "dont-care",
+		},
+		RequestId: uuid.NewString(),
+		Links:     links,
+	}
+	_, err := s.FrontendClient().SignalWithStartWorkflowExecution(ctx, request)
+	s.NoError(err)
+
+	// Send a second request and verify that the new signal has links attached to it too.
+	request.RequestId = uuid.NewString()
+	_, err = s.FrontendClient().SignalWithStartWorkflowExecution(ctx, request)
+	s.NoError(err)
+
+	history := s.SdkClient().GetWorkflowHistory(ctx, workflowID, "", false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	foundStartEvent := false
+	foundFirstSignal := false
+	foundSecondSignal := false
+	for history.HasNext() {
+		event, err := history.Next()
+		s.NoError(err)
+		if event.EventType == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED {
+			if foundFirstSignal {
+				foundSecondSignal = true
+			} else {
+				foundFirstSignal = true
+			}
+			protorequire.ProtoSliceEqual(s.T(), links, event.Links)
+		}
+		if event.EventType == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED {
+			foundStartEvent = true
+			protorequire.ProtoSliceEqual(s.T(), links, event.Links)
+		}
+	}
+	s.True(foundStartEvent)
+	s.True(foundFirstSignal)
+	s.True(foundSecondSignal)
+}

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -61,7 +61,6 @@ type NexusApiTestSuite struct {
 
 func TestNexusApiTestSuite(t *testing.T) {
 	suite.Run(t, new(NexusApiTestSuite))
-
 }
 
 func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes() {


### PR DESCRIPTION
## What changed?

Implement the server side for https://github.com/temporalio/api/pull/455 (later fixed by https://github.com/temporalio/api/pull/460).
Also improved link validation.

Note that batch jobs still don't attach links at the moment, I'll probably do that in a follow up PR.

## Why?

Support links in various places.

## How did you test it?

Added both unit and functional test coverage.