### PR TITLE
Workflow Update: abort updates with failure if update was accepted but workflow completes

### DIFF
--- a/docs/architecture/workflow-update.md
+++ b/docs/architecture/workflow-update.md
@@ -131,15 +131,6 @@ via `newAccepted()`. Similarly, when an Update is resurrected (see "Update Resur
 also has state `Admitted`. But when an Update cannot be found in the Registry, yet it exists in
 `EventStore` because it is already completed, it is created with state `Completed`.
 
-### Aborting an Update
-An Update is aborted when:
-1. The Workflow is completed or completes itself. Then, a non-retryable `ErrWorkflowCompleted` error 
-is returned to the API caller.
-2. The Update Registry is cleared. Then, a retryable `WorkflowUpdateAbortedErr` error is returned
-(see "Update Registry Lifecycle" below).
-
-An in-flight Update can be aborted at any time. `Aborted` is a terminal state.
-
 ### Update Registry Lifecycle
 Every time the Workflow context is cleared, its Update Registry is cleared as well. Because the
 Workflow context is cleared on every error, a significant effort was - originally - made to keep the
@@ -155,14 +146,61 @@ Update Registry intact. But it proved to be too error-prone.
 
 Instead, the Workflow Update feature relies on internal retries by the history gRPC handler,
 history gRPC client (on the frontend side), and frontend gRPC handler. So if an Update is removed from
-the Registry due to non-related error, a retryable error is returned to the `UpdateWorkflowExecution`
-API caller and subsequent internal retries recreate the Update in the Registry.
+the Registry due to non-related error, a retryable `WorkflowUpdateAbortedErr` error is returned to
+the `UpdateWorkflowExecution` API caller and subsequent internal retries recreate the Update
+in the Registry (see "Aborting an Update" below).
 
 Also, it is important to note that the Workflow context itself is stored in the Workflow cache
 and might be evicted any time. Therefore, the Workflow Update feature relies on a properly
 configured cache size. If the cache is too small, it will evict Workflow contexts too soon and their
 Update Registry will be cleared. Note that in that case, all in-flight Updates are aborted with a
 retryable error; and the frontend will retry the `UpdateWorkflowExecution` call.
+
+### Aborting an Update
+An Update is aborted when:
+1. The Update Registry is cleared. Then, a retryable `WorkflowUpdateAbortedErr` error is returned
+   (see "Update Registry Lifecycle" below).
+2. The Workflow completes itself (i.g. with `COMPLETE_WORKFLOW_EXECUTION` command) or completed externally
+   (i.g. terminated or timed out). Then, a non-retryable `ErrWorkflowCompleted` error or failure is returned
+   to the API caller depending on an Update state.
+3. The Workflow is continuing (i.g. with `CONTINUE_AS_NEW_WORKFLOW_EXECUTION` command) or is retried after
+   failure or timeout. Then, a retryable `ErrWorkflowClosing` error or failure is returned to the API caller
+   depending on an Update state.
+
+Full "Update state" and "Abort reason" matrix is the following:
+
+| Update State / Abort Reason             | RegistryCleared            | WorkflowCompleted                        | WorkflowContinuing                       |
+|-----------------------------------------|----------------------------|------------------------------------------|------------------------------------------|
+| **Created**                             | `WorkflowUpdateAbortedErr` | `ErrWorkflowCompleted`                   | `ErrWorkflowClosing`                     |
+| **ProvisionallyAdmitted**               | `WorkflowUpdateAbortedErr` | `ErrWorkflowCompleted`                   | `ErrWorkflowClosing`                     |
+| **Admitted**                            | `WorkflowUpdateAbortedErr` | `ErrWorkflowCompleted`                   | `ErrWorkflowClosing`                     |
+| **Sent**                                | `WorkflowUpdateAbortedErr` | `ErrWorkflowCompleted`                   | `ErrWorkflowClosing`                     |
+| **ProvisionallyAccepted**               | `WorkflowUpdateAbortedErr` | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
+| **Accepted**                            | `WorkflowUpdateAbortedErr` | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
+| **ProvisionallyCompleted**              | `WorkflowUpdateAbortedErr` | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
+| **ProvisionallyCompletedAfterAccepted** | `WorkflowUpdateAbortedErr` | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
+| **Completed**                           | `nil`                      | `nil`                                    | `nil`                                    |
+| **Aborted**                             | `nil`                      | `nil`                                    | `nil`                                    |
+
+When the Workflow performs a final completion, all in-flight Updates are aborted: admitted Updates get
+`ErrWorkflowCompleted` error on both `accepted` and `completed` futures. Accepted Updates
+are failed with special server `acceptedUpdateCompletedWorkflowFailure` failure because if a client
+knows that Update has been accepted, it expects any following requests to return an Update result
+(or failure) but not an error. This failure is set on the `completed` future only. 
+
+When a Workflow completion command creates a new run, accepted Updates are failed in the same way:
+with the `acceptedUpdateCompletedWorkflowFailure` failure on the `completed` future. Admitted Updates,
+though, are aborted with the retryable `ErrWorkflowClosing` error. Server internally retries this error
+and new attempt should land on the new run. Because Updates received while the Workflow Task
+was running haven't been seen by the Workflow yet can be safely retried on the new run.
+It also provides a better experience for API callers since they will not notice that the Workflow
+started a new run.
+
+`WorkflowUpdateAbortedErr` is also retried internally by the server providing a better experience
+to the API caller: they will not notice that the Update was lost.
+
+`Aborted` is a terminal state. Updates remain in the `Aborted` state in the Registry even after
+the Update Registry is reconstructed from the history.
 
 ## `UpdateWorkflowExecutions` and `PollWorkflowExecutionUpdate` APIs
 The Workflow Update feature exposes two APIs: `UpdateWorkflowExecution` to send Update requests
@@ -188,42 +226,65 @@ API call is returned. Currently, it can only be `ACCEPTED` or `COMPLETED`.
 > also allow using an Update as a "fire-and-forget" (just like Signal).
 
 ### Waiters
+Server performs few checks before blocking on corresponding future:  
+```mermaid
+flowchart TD
+    updateWorkflowExecution[UpdateWorkflowExecution / PollWorkflowExecutionUpdate] --> wfExists{Workflow exists?}
+    wfExists --> |yes| wfRunning{Workflow running?}
+    wfExists --> |no| notFound(((NotFound)))
+    wfRunning --> |no| updateExists{Update exists?}
+    wfRunning --> |yes| waitFor{Wait stage}
+    updateExists --> |yes| success1(((Update result)))
+    updateExists --> |no| wfCompleted(((ErrWorkflowCompleted)))
+
+    waitFor --> |ACCEPTED| blockAccepted[block on `accepted` future]
+    waitFor --> |COMPLETED| blockCompleted[block on `completed` future]
+```
 When the wait stage is `ACCEPTED`, the API caller waits for the `accepted` future to complete
-(type `*failurepb.Failure`). The following results can be returned:
+(type `*failurepb.Failure`). The future can be resolved with the following results:
 
 ```mermaid
 stateDiagram-v2
-    accepted: accepted=(nil,nil)
-    rejected: rejected=(rejectionFailure,nil)
-    notFound: (nil, NotFoundError)
-    unavailable: (nil, UnavailableError)
+    blockAccepted: block on `accepted` future
+    accepted: nil,nil
+    rejected: rejectionFailure,nil
+    notFoundError: nil, NotFoundError
+    wfContinuingError: nil, ErrWorkflowClosing
+    updateAbortedError: nil, WorkflowUpdateAbortedErr
     
-    [*] --> accepted: onAcceptanceMsg()
-    [*] --> rejected: onRejectionMsg()
-    [*] --> rejected: RejectUnprocessed()
-    [*] --> notFound: abort(reason=WorkflowCompleted)
-    [*] --> unavailable: abort(reason=RegistryCleared)
+    blockAccepted --> accepted: onAcceptanceMsg()
+    blockAccepted --> rejected: onRejectionMsg()
+    blockAccepted --> rejected: RejectUnprocessed()
+    blockAccepted --> notFoundError: Workflow completed
+    blockAccepted --> wfContinuingError: Workflow continuing
+    blockAccepted --> updateAbortedError: Registry cleared
 ```
-
 If the wait stage is `COMPLETED`, the API caller waits for the `outcome` future to complete
-(type `*updatepb.Outcome`). The following results can be returned:
+(type `*updatepb.Outcome`). The future can be resolved with the following results:
 
 ```mermaid
 stateDiagram-v2
-    completed: completed=(outcome{payload},nil)
-    failed: failed=(outcome{failure},nil)
-    rejected: failed=(outcome{rejectionFailure},nil)
-    notFound: (nil, NotFoundError)
-    unavailable: (nil, UnavailableError)
+    blockCompleted: block on `completed` future
+    completed: outcome{payload},nil
+    failed: outcome{failure},nil
+    rejected: outcome{rejectionFailure},nil
+    notFoundError: nil, NotFoundError
+    wfContinuingError: nil, ErrWorkflowClosing
+    wfCompletedFailure: workflowCompletedFailure, nil
+    updateAbortedError: nil, WorkflowUpdateAbortedErr
     
-    [*] --> completed: onResponseMsg()
-    [*] --> failed: onResponseMsg()
-    [*] --> rejected: onRejectionMsg()
-    [*] --> rejected: RejectUnprocessed()
-    [*] --> notFound: abort(reason=WorkflowCompleted)
-    [*] --> unavailable: abort(reason=RegistryCleared)
+    blockCompleted --> completed: onResponseMsg()
+    blockCompleted --> failed: onResponseMsg()
+    blockCompleted --> rejected: onRejectionMsg()
+    blockCompleted --> rejected: RejectUnprocessed()
+    blockCompleted --> notFoundError: Workflow completed
+    blockCompleted --> wfContinuingError: Workflow continuing before Update accepted
+    blockCompleted --> wfCompletedFailure: Workflow completed/continuing after Update accepted
+    blockCompleted --> updateAbortedError: Registry cleared
 ```
- 
+`ErrWorkflowClosing` and `WorkflowUpdateAbortedErr` are retryable errors. Even they are set on futures,
+they will not be returned to the API caller but will be retried internally.
+
 ### Timeouts
 The API caller can specify the time it is willing to wait before the specified stage is reached.
 If the timeout expires and the Update has not reached the desired stage yet, a 
@@ -241,7 +302,7 @@ the client should retry the `UpdateWorkflowExecution` API call.
 start polling for the Update result using the `PollWorkflowExecutionUpdate` API.
 
 > #### NOTE
-> When the registry is cleared, though, the behavior is slightly different: Instead of returning
+> When the Registry is cleared, though, the behavior is slightly different: Instead of returning
 > an empty response, the server returns a retryable `Unavailable` error. This error *should* not
 > reach the client, actually, as it is retried internally on the server. But if it does, the client 
 > should behave the same way as for the empty response with `ADMITTED` stage: 
@@ -318,30 +379,10 @@ trying to recreate the Update.
 > #### TODO
 > This might be possible in the future when "Durable Admitted" Update is implemented.
 
-There are two Workflow completion scenarios:
-- final completion, when no new run is created (e.g., with `COMPLETE_WORKFLOW_EXECUTION` command),
-- continued completion, when new run is created (e.g., `CONTINUE_AS_NEW_WORKFLOW_EXECUTION` command).
-
-When the Workflow performs a final completion, all in-flight Updates are aborted: admitted Updates get
-`ErrWorkflowCompleted` error on both `accepted` and `completed` futures, and accepted Updates get
-the same error on the `completed` future only. It is the Workflow's responsibility to complete
-accepted Updates. This behavior is similar to Activities which also can be left abandoned after 
-the Workflow is completed.
-
-When a Workflow completion command creates a new run, accepted Updates are aborted in the same way:
-with the `ErrWorkflowCompleted` error on the `completed` future. Admitted Updates, though, are aborted
-with the retryable `ErrWorkflowClosing` error. The SDK client retries this error and new attempt should
-land on the new run. Because Updates received while the Workflow Task was running haven't
-been seen by the Workflow yet can be safely retried on the new run. It also provides a better
-experience for API callers since they will not notice that the Workflow started a new run.
-
-Aborted accepted (but not completed) Updates remain in the `Aborted` state in the registry even after
-the Update registry is reconstructed from the history.
-
 Update results are available after the Workflow is completed. They can be accessed using the
 `PollWorkflowExecutionUpdate` API. Note that the `UpdateWorkflowExecution` API will return the
 result, too. This provides a consistent experience for API caller: no matter at what stage the 
-Workflow is, the API caller will always get the `ErrWorkflowCompleted` error, when the Update wasn't
+Workflow is, the API caller will always get the error or failure, when the Update wasn't
 processed by the Workflow, or the Update outcome when it was.
 
 > #### NOTE
@@ -402,7 +443,7 @@ exposes methods with exact the same name: `UpdateWorkflowExecution` (which write
 to the database). The method name is also used in the `operation` tag in various metrics.
 
 > #### TODO
-> Because it is unresonable and impossible to rename the `UpdateWorkflowExecution` API,
+> Because it is unreasonable and impossible to rename the `UpdateWorkflowExecution` API,
 > the persistence operation should be renamed to `SaveWorkflowExecution`, `WriteWorkflowExecution`, 
 > `PersistWorkflowExecution`, or something similar.
 

--- a/service/history/workflow/update/abort_reason.go
+++ b/service/history/workflow/update/abort_reason.go
@@ -25,29 +25,102 @@
 package update
 
 import (
+	"fmt"
+
+	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/server/service/history/consts"
 )
 
 type (
 	AbortReason uint32
+
+	reasonState struct {
+		r  AbortReason
+		st state
+	}
+
+	failureError struct {
+		f   *failurepb.Failure
+		err error
+	}
 )
 
 const (
 	AbortReasonRegistryCleared AbortReason = iota + 1
 	AbortReasonWorkflowCompleted
 	AbortReasonWorkflowContinuing
+	lastAbortReason
 )
 
-// Error returns an error which will be set to Update futures while aborting Update.
-func (r AbortReason) Error() error {
+// Matrix of "abort reason/Update state" to "failure/error" pair. Only one value (failure or error) is allowed per pair.
+var reasonStateMatrix = map[reasonState]failureError{
+	// If the registry is cleared, then all Updates (no matter what state they are)
+	// are aborted with retryable registryClearedErr error.
+	reasonState{r: AbortReasonRegistryCleared, st: stateCreated}:                             {f: nil, err: registryClearedErr},
+	reasonState{r: AbortReasonRegistryCleared, st: stateProvisionallyAdmitted}:               {f: nil, err: registryClearedErr},
+	reasonState{r: AbortReasonRegistryCleared, st: stateAdmitted}:                            {f: nil, err: registryClearedErr},
+	reasonState{r: AbortReasonRegistryCleared, st: stateSent}:                                {f: nil, err: registryClearedErr},
+	reasonState{r: AbortReasonRegistryCleared, st: stateProvisionallyAccepted}:               {f: nil, err: registryClearedErr},
+	reasonState{r: AbortReasonRegistryCleared, st: stateAccepted}:                            {f: nil, err: registryClearedErr},
+	reasonState{r: AbortReasonRegistryCleared, st: stateProvisionallyCompleted}:              {f: nil, err: registryClearedErr},
+	reasonState{r: AbortReasonRegistryCleared, st: stateCompleted}:                           {f: nil, err: registryClearedErr},
+	reasonState{r: AbortReasonRegistryCleared, st: stateAborted}:                             {f: nil, err: registryClearedErr},
+	reasonState{r: AbortReasonRegistryCleared, st: stateProvisionallyCompletedAfterAccepted}: {f: nil, err: registryClearedErr},
+
+	// If the Workflow is completed, then pre-accepted Updates are aborted with non-retryable ErrWorkflowCompleted error.
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateCreated}:               {f: nil, err: consts.ErrWorkflowCompleted},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyAdmitted}: {f: nil, err: consts.ErrWorkflowCompleted},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateAdmitted}:              {f: nil, err: consts.ErrWorkflowCompleted},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateSent}:                  {f: nil, err: consts.ErrWorkflowCompleted},
+	// Accepted Updates are failed with special server failure because if a client knows that Update has been accepted,
+	// it expects any following requests to return an Update result (or failure) but not an error.
+	// There can be different types of Update failures coming from worker and a client must handle them anyway.
+	// It is easier and less error-prone for a client to handle only Update failures instead of both failures and
+	// not obvious NotFound errors in case if the Workflow completes before the Update completes.
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyAccepted}: {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateAccepted}:              {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
+	// Completed Updates can't be aborted. These cases are just to fill the matrix.
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyCompleted}:              {f: nil, err: consts.ErrWorkflowCompleted},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateCompleted}:                           {f: nil, err: consts.ErrWorkflowCompleted},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateAborted}:                             {f: nil, err: consts.ErrWorkflowCompleted},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyCompletedAfterAccepted}: {f: nil, err: consts.ErrWorkflowCompleted},
+
+	// If Workflow is starting new run, then all Updates are aborted with retryable ErrWorkflowClosing error.
+	// Internal retries will send them to the new run.
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateCreated}:               {f: nil, err: consts.ErrWorkflowClosing},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyAdmitted}: {f: nil, err: consts.ErrWorkflowClosing},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateAdmitted}:              {f: nil, err: consts.ErrWorkflowClosing},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateSent}:                  {f: nil, err: consts.ErrWorkflowClosing},
+	// Accepted Update can't be applied to the new run, and must be failed same way as if Workflow is completed.
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyAccepted}: {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateAccepted}:              {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
+	// Completed Updates can't be aborted. These cases are just to fill the matrix.
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyCompleted}:              {f: nil, err: consts.ErrWorkflowCompleted},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateCompleted}:                           {f: nil, err: consts.ErrWorkflowCompleted},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateAborted}:                             {f: nil, err: consts.ErrWorkflowCompleted},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyCompletedAfterAccepted}: {f: nil, err: consts.ErrWorkflowCompleted},
+}
+
+// FailureError returns failure or error which will be set to Update futures while aborting Update.
+// Only one of the return values will be non-nil.
+func (r AbortReason) FailureError(st state) (*failurepb.Failure, error) {
+	fe, ok := reasonStateMatrix[reasonState{r: r, st: st}]
+	if !ok {
+		panic("unknown workflow update abort reason or update state")
+	}
+	return fe.f, fe.err
+}
+
+func (r AbortReason) String() string {
 	switch r {
 	case AbortReasonRegistryCleared:
-		return registryClearedErr
+		return "RegistryCleared"
 	case AbortReasonWorkflowCompleted:
-		return consts.ErrWorkflowCompleted
+		return "WorkflowCompleted"
 	case AbortReasonWorkflowContinuing:
-		return consts.ErrWorkflowClosing
-	default:
-		panic("unknown workflow update abort reason")
+		return "WorkflowContinuing"
+	case lastAbortReason:
+		return fmt.Sprintf("invalid reason %d", r)
 	}
+	return fmt.Sprintf("unrecognized reason %d", r)
 }

--- a/service/history/workflow/update/abort_reason.go
+++ b/service/history/workflow/update/abort_reason.go
@@ -63,9 +63,10 @@ var reasonStateMatrix = map[reasonState]failureError{
 	reasonState{r: AbortReasonRegistryCleared, st: stateProvisionallyAccepted}:               {f: nil, err: registryClearedErr},
 	reasonState{r: AbortReasonRegistryCleared, st: stateAccepted}:                            {f: nil, err: registryClearedErr},
 	reasonState{r: AbortReasonRegistryCleared, st: stateProvisionallyCompleted}:              {f: nil, err: registryClearedErr},
-	reasonState{r: AbortReasonRegistryCleared, st: stateCompleted}:                           {f: nil, err: registryClearedErr},
-	reasonState{r: AbortReasonRegistryCleared, st: stateAborted}:                             {f: nil, err: registryClearedErr},
 	reasonState{r: AbortReasonRegistryCleared, st: stateProvisionallyCompletedAfterAccepted}: {f: nil, err: registryClearedErr},
+	// Completed Updates can't be aborted.
+	reasonState{r: AbortReasonRegistryCleared, st: stateCompleted}: {f: nil, err: nil},
+	reasonState{r: AbortReasonRegistryCleared, st: stateAborted}:   {f: nil, err: nil},
 
 	// If the Workflow is completed, then pre-accepted Updates are aborted with non-retryable ErrWorkflowCompleted error.
 	reasonState{r: AbortReasonWorkflowCompleted, st: stateCreated}:               {f: nil, err: consts.ErrWorkflowCompleted},
@@ -77,13 +78,13 @@ var reasonStateMatrix = map[reasonState]failureError{
 	// There can be different types of Update failures coming from worker and a client must handle them anyway.
 	// It is easier and less error-prone for a client to handle only Update failures instead of both failures and
 	// not obvious NotFound errors in case if the Workflow completes before the Update completes.
-	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyAccepted}: {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
-	reasonState{r: AbortReasonWorkflowCompleted, st: stateAccepted}:              {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
-	// Completed Updates can't be aborted. These cases are just to fill the matrix.
-	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyCompleted}:              {f: nil, err: consts.ErrWorkflowCompleted},
-	reasonState{r: AbortReasonWorkflowCompleted, st: stateCompleted}:                           {f: nil, err: consts.ErrWorkflowCompleted},
-	reasonState{r: AbortReasonWorkflowCompleted, st: stateAborted}:                             {f: nil, err: consts.ErrWorkflowCompleted},
-	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyCompletedAfterAccepted}: {f: nil, err: consts.ErrWorkflowCompleted},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyAccepted}:               {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateAccepted}:                            {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyCompleted}:              {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyCompletedAfterAccepted}: {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
+	// Completed Updates can't be aborted.
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateCompleted}: {f: nil, err: nil},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateAborted}:   {f: nil, err: nil},
 
 	// If Workflow is starting new run, then all Updates are aborted with retryable ErrWorkflowClosing error.
 	// Internal retries will send them to the new run.
@@ -92,13 +93,13 @@ var reasonStateMatrix = map[reasonState]failureError{
 	reasonState{r: AbortReasonWorkflowContinuing, st: stateAdmitted}:              {f: nil, err: consts.ErrWorkflowClosing},
 	reasonState{r: AbortReasonWorkflowContinuing, st: stateSent}:                  {f: nil, err: consts.ErrWorkflowClosing},
 	// Accepted Update can't be applied to the new run, and must be failed same way as if Workflow is completed.
-	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyAccepted}: {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
-	reasonState{r: AbortReasonWorkflowContinuing, st: stateAccepted}:              {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
-	// Completed Updates can't be aborted. These cases are just to fill the matrix.
-	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyCompleted}:              {f: nil, err: consts.ErrWorkflowCompleted},
-	reasonState{r: AbortReasonWorkflowContinuing, st: stateCompleted}:                           {f: nil, err: consts.ErrWorkflowCompleted},
-	reasonState{r: AbortReasonWorkflowContinuing, st: stateAborted}:                             {f: nil, err: consts.ErrWorkflowCompleted},
-	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyCompletedAfterAccepted}: {f: nil, err: consts.ErrWorkflowCompleted},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyAccepted}:               {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateAccepted}:                            {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyCompleted}:              {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyCompletedAfterAccepted}: {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
+	// Completed Updates can't be aborted.
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateCompleted}: {f: nil, err: nil},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateAborted}:   {f: nil, err: nil},
 }
 
 // FailureError returns failure or error which will be set to Update futures while aborting Update.

--- a/service/history/workflow/update/abort_reason.go
+++ b/service/history/workflow/update/abort_reason.go
@@ -102,7 +102,7 @@ var reasonStateMatrix = map[reasonState]failureError{
 	reasonState{r: AbortReasonWorkflowContinuing, st: stateAborted}:   {f: nil, err: nil},
 }
 
-// FailureError returns failure or error which will be set to Update futures while aborting Update.
+// FailureError returns failure or error which will be set on Update futures while aborting Update.
 // Only one of the return values will be non-nil.
 func (r AbortReason) FailureError(st state) (*failurepb.Failure, error) {
 	fe, ok := reasonStateMatrix[reasonState{r: r, st: st}]

--- a/service/history/workflow/update/abort_reason_test.go
+++ b/service/history/workflow/update/abort_reason_test.go
@@ -25,7 +25,6 @@
 package update
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,7 +34,9 @@ func TestAbortReasonUpdateStateMatrix(t *testing.T) {
 	for r := AbortReasonRegistryCleared; r < lastAbortReason; r++ {
 		for st := stateCreated; st < lastState; st <<= 1 {
 			fe, ok := reasonStateMatrix[reasonState{r: r, st: st}]
-			require.True(t, ok, fmt.Sprintf("missing combination: %v, %v", r, st))
+			// If new abort reason or state is added, this test will fail.
+			// Do not modify the test but make sure to update the reasonStateMatrix.
+			require.True(t, ok, "Missing combination: %v, %v. If new abort reason or state is added make sure to update the reasonStateMatrix", r, st)
 			if fe.f != nil {
 				require.Nil(t, fe.err)
 			}

--- a/service/history/workflow/update/abort_reason_test.go
+++ b/service/history/workflow/update/abort_reason_test.go
@@ -26,55 +26,22 @@ package update
 
 import (
 	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-type (
-	state    uint32
-	stateSet uint32
-)
-
-const (
-	stateCreated state = 1 << iota
-	stateProvisionallyAdmitted
-	stateAdmitted
-	stateSent
-	stateProvisionallyAccepted
-	stateAccepted
-	stateProvisionallyCompleted
-	stateCompleted
-	stateAborted
-	stateProvisionallyCompletedAfterAccepted
-	lastState
-)
-
-func (s state) String() string {
-	switch s {
-	case stateCreated:
-		return "Created"
-	case stateProvisionallyAdmitted:
-		return "ProvisionallyAdmitted"
-	case stateAdmitted:
-		return "Admitted"
-	case stateSent:
-		return "Sent"
-	case stateProvisionallyAccepted:
-		return "ProvisionallyAccepted"
-	case stateAccepted:
-		return "Accepted"
-	case stateProvisionallyCompleted:
-		return "ProvisionallyCompleted"
-	case stateCompleted:
-		return "Completed"
-	case stateAborted:
-		return "Aborted"
-	case stateProvisionallyCompletedAfterAccepted:
-		return "ProvisionallyCompletedAfterAccepted"
-	case lastState:
-		return fmt.Sprintf("invalid state %d", s)
+func TestAbortReasonUpdateStateMatrix(t *testing.T) {
+	for r := AbortReasonRegistryCleared; r < lastAbortReason; r++ {
+		for st := stateCreated; st < lastState; st <<= 1 {
+			fe, ok := reasonStateMatrix[reasonState{r: r, st: st}]
+			require.True(t, ok, fmt.Sprintf("missing combination: %v, %v", r, st))
+			if fe.f != nil {
+				require.Nil(t, fe.err)
+			}
+			if fe.err != nil {
+				require.Nil(t, fe.f)
+			}
+		}
 	}
-	return fmt.Sprintf("unrecognized state %d", s)
-}
-
-func (s state) Matches(mask stateSet) bool {
-	return uint32(s)&uint32(mask) == uint32(s)
 }

--- a/service/history/workflow/update/errors_failures.go
+++ b/service/history/workflow/update/errors_failures.go
@@ -43,4 +43,13 @@ var (
 			NonRetryable: true,
 		}},
 	}
+
+	acceptedUpdateCompletedWorkflowFailure = &failurepb.Failure{
+		Message: "Workflow Update is failed because it was accepted by Workflow but then Workflow completed.",
+		Source:  "Server",
+		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+			Type:         "AcceptedUpdateCompletedWorkflow",
+			NonRetryable: true,
+		}},
+	}
 )

--- a/service/history/workflow/update/errors_failures.go
+++ b/service/history/workflow/update/errors_failures.go
@@ -45,7 +45,7 @@ var (
 	}
 
 	acceptedUpdateCompletedWorkflowFailure = &failurepb.Failure{
-		Message: "Workflow Update is failed because it was accepted by Workflow but then Workflow completed.",
+		Message: "Workflow Update failed because the Workflow completed before the Update completed.",
 		Source:  "Server",
 		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
 			Type:         "AcceptedUpdateCompletedWorkflow",

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -134,7 +134,7 @@ func TestNewRegistry(t *testing.T) {
 		status, err := upd.WaitLifecycleStage(context.Background(), 0, 100*time.Millisecond)
 		require.NoError(t, err)
 		require.NotNil(t, status)
-		require.Equal(t, "Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", status.Outcome.GetFailure().Message)
+		require.Equal(t, "Workflow Update failed because the Workflow completed before the Update completed.", status.Outcome.GetFailure().Message)
 	})
 
 	t.Run("registry created from store with update in stateCompleted has no updates but increased completed count", func(t *testing.T) {
@@ -592,7 +592,7 @@ func TestAbort(t *testing.T) {
 	status2, err := upd2.WaitLifecycleStage(context.Background(), 0, 2*time.Second)
 	require.NoError(t, err)
 	require.NotNil(t, status2)
-	require.Equal(t, "Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", status2.Outcome.GetFailure().Message)
+	require.Equal(t, "Workflow Update failed because the Workflow completed before the Update completed.", status2.Outcome.GetFailure().Message)
 
 	require.Equal(t, 2, reg.Len(), "registry should still contain both updates")
 }

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -26,7 +26,6 @@ package update_test
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -132,8 +131,10 @@ func TestNewRegistry(t *testing.T) {
 		upd := reg.Find(context.Background(), tv.UpdateID())
 		require.NotNil(t, upd)
 
-		_, err := upd.WaitLifecycleStage(context.Background(), 0, 100*time.Millisecond)
-		require.Equal(t, err, consts.ErrWorkflowCompleted)
+		status, err := upd.WaitLifecycleStage(context.Background(), 0, 100*time.Millisecond)
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		require.Equal(t, "Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", status.Outcome.GetFailure().Message)
 	})
 
 	t.Run("registry created from store with update in stateCompleted has no updates but increased completed count", func(t *testing.T) {
@@ -580,13 +581,19 @@ func TestAbort(t *testing.T) {
 	// abort both updates
 	reg.Abort(update.AbortReasonWorkflowCompleted)
 
-	for i := 1; i <= 2; i++ {
-		upd := reg.Find(context.Background(), tv.UpdateID(fmt.Sprintf("%d", i)))
-		require.NotNil(t, upd)
+	upd1 := reg.Find(context.Background(), tv.UpdateID("1"))
+	require.NotNil(t, upd1)
+	status1, err := upd1.WaitLifecycleStage(context.Background(), 0, 2*time.Second)
+	require.Equal(t, consts.ErrWorkflowCompleted, err)
+	require.Nil(t, status1)
 
-		_, err := upd.WaitLifecycleStage(context.Background(), 0, 2*time.Second)
-		require.Equal(t, consts.ErrWorkflowCompleted, err)
-	}
+	upd2 := reg.Find(context.Background(), tv.UpdateID("2"))
+	require.NotNil(t, upd2)
+	status2, err := upd2.WaitLifecycleStage(context.Background(), 0, 2*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, status2)
+	require.Equal(t, "Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", status2.Outcome.GetFailure().Message)
+
 	require.Equal(t, 2, reg.Len(), "registry should still contain both updates")
 }
 

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -258,9 +258,14 @@ func (u *Update) WaitLifecycleStage(
 	return statusAdmitted(), nil
 }
 
-// abort fails Update futures with reason.Error() error (which will notify all waiters with error)
+// abort set Update futures with error or failure (which is passed to all waiters)
 // and set state to stateAborted. It is a terminal state. Update can't be changed after it is aborted.
 func (u *Update) abort(reason AbortReason) {
+	const terminalStates = stateSet(stateCompleted | stateAborted)
+	if u.state.Matches(terminalStates) {
+		return
+	}
+
 	u.instrumentation.countAborted()
 
 	abortFailure, abortErr := reason.FailureError(u.state)

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -709,7 +709,7 @@ func TestUpdateState(t *testing.T) {
 					status, err := upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, 100*time.Millisecond)
 					require.NoError(t, err)
 					require.NotNil(t, status)
-					require.Equal(t, "Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", status.Outcome.GetFailure().Message)
+					require.Equal(t, "Workflow Update failed because the Workflow completed before the Update completed.", status.Outcome.GetFailure().Message)
 				},
 			}, {
 				title: "fail to transition to stateCompleted on store write failure",

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -707,8 +707,9 @@ func TestUpdateState(t *testing.T) {
 					require.NoError(t, err)
 
 					status, err := upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, 100*time.Millisecond)
-					require.ErrorIs(t, err, consts.ErrWorkflowCompleted)
-					require.Nil(t, status)
+					require.NoError(t, err)
+					require.NotNil(t, status)
+					require.Equal(t, "Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", status.Outcome.GetFailure().Message)
 				},
 			}, {
 				title: "fail to transition to stateCompleted on store write failure",

--- a/tests/update_workflow_sdk_test.go
+++ b/tests/update_workflow_sdk_test.go
@@ -132,11 +132,11 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TimeoutWorkflowAfterUpdateAc
 	err = updateHandle.Get(ctx, nil)
 	var appErr *temporal.ApplicationError
 	s.ErrorAs(err, &appErr)
-	s.Contains("Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", appErr.Message())
+	s.Contains("Workflow Update failed because the Workflow completed before the Update completed.", appErr.Message())
 
 	pollFailure, pollErr := s.pollUpdate(ctx, tv, &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
 	s.NoError(pollErr)
-	s.Equal("Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", pollFailure.GetOutcome().GetFailure().GetMessage())
+	s.Equal("Workflow Update failed because the Workflow completed before the Update completed.", pollFailure.GetOutcome().GetFailure().GetMessage())
 
 	var wee *temporal.WorkflowExecutionError
 	s.ErrorAs(wfRun.Get(ctx, nil), &wee)
@@ -190,11 +190,11 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TerminateWorkflowAfterUpdate
 	err = updateHandle.Get(ctx, nil)
 	var appErr *temporal.ApplicationError
 	s.ErrorAs(err, &appErr)
-	s.Contains("Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", appErr.Message())
+	s.Contains("Workflow Update failed because the Workflow completed before the Update completed.", appErr.Message())
 
 	pollFailure, pollErr := s.pollUpdate(ctx, tv, &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
 	s.NoError(pollErr)
-	s.Equal("Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", pollFailure.GetOutcome().GetFailure().GetMessage())
+	s.Equal("Workflow Update failed because the Workflow completed before the Update completed.", pollFailure.GetOutcome().GetFailure().GetMessage())
 
 	var wee *temporal.WorkflowExecutionError
 	s.ErrorAs(wfRun.Get(ctx, nil), &wee)

--- a/tests/update_workflow_sdk_test.go
+++ b/tests/update_workflow_sdk_test.go
@@ -129,11 +129,14 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TimeoutWorkflowAfterUpdateAc
 	updateHandle, err := s.updateWorkflowWaitAccepted(ctx, tv, "my-update-arg")
 	s.NoError(err)
 
-	var notFound *serviceerror.NotFound
-	s.ErrorAs(updateHandle.Get(ctx, nil), &notFound)
+	err = updateHandle.Get(ctx, nil)
+	var appErr *temporal.ApplicationError
+	s.ErrorAs(err, &appErr)
+	s.Contains("Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", appErr.Message())
 
-	_, pollErr := s.pollUpdate(ctx, tv, &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
-	s.ErrorAs(pollErr, &notFound)
+	pollFailure, pollErr := s.pollUpdate(ctx, tv, &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
+	s.NoError(pollErr)
+	s.Equal("Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", pollFailure.GetOutcome().GetFailure().GetMessage())
 
 	var wee *temporal.WorkflowExecutionError
 	s.ErrorAs(wfRun.Get(ctx, nil), &wee)
@@ -184,11 +187,14 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TerminateWorkflowAfterUpdate
 
 	s.NoError(s.SdkClient().TerminateWorkflow(ctx, tv.WorkflowID(), wfRun.GetRunID(), "reason"))
 
-	var notFound *serviceerror.NotFound
-	s.ErrorAs(updateHandle.Get(ctx, nil), &notFound)
+	err = updateHandle.Get(ctx, nil)
+	var appErr *temporal.ApplicationError
+	s.ErrorAs(err, &appErr)
+	s.Contains("Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", appErr.Message())
 
-	_, pollErr := s.pollUpdate(ctx, tv, &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
-	s.ErrorAs(pollErr, &notFound)
+	pollFailure, pollErr := s.pollUpdate(ctx, tv, &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
+	s.NoError(pollErr)
+	s.Equal("Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", pollFailure.GetOutcome().GetFailure().GetMessage())
 
 	var wee *temporal.WorkflowExecutionError
 	s.ErrorAs(wfRun.Get(ctx, nil), &wee)
@@ -318,7 +324,6 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TimeoutWithRetryAfterUpdateA
 		TaskQueue:          tv.TaskQueue().Name,
 		WorkflowRunTimeout: 1 * time.Second,
 		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval: time.Nanosecond,
 			MaximumAttempts: 2,
 		},
 	}, workflowFn)

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -988,13 +988,13 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_CompletedWorkflow() {
 		// Receive Update result.
 		updateResult1 := <-updateResultCh
 		s.NoError(updateResult1.err)
-		s.Equal("Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", updateResult1.response.GetOutcome().GetFailure().GetMessage())
+		s.Equal("Workflow Update failed because the Workflow completed before the Update completed.", updateResult1.response.GetOutcome().GetFailure().GetMessage())
 
 		// Send same Update request again, receiving the same failure.
 		updateResultCh = s.sendUpdate(testcore.NewContext(), tv, "1")
 		updateResult2 := <-updateResultCh
 		s.NoError(updateResult2.err)
-		s.Equal("Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", updateResult2.response.GetOutcome().GetFailure().GetMessage())
+		s.Equal("Workflow Update failed because the Workflow completed before the Update completed.", updateResult2.response.GetOutcome().GetFailure().GetMessage())
 	})
 }
 
@@ -3205,7 +3205,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_CompleteWorkflow_AbortUpdates()
 			name:          "update accepted",
 			description:   "update in stateAccepted must get an update failure",
 			updateErr:     map[string]string{"*": ""},
-			updateFailure: "Workflow Update is failed because it was accepted by Workflow but then Workflow completed.",
+			updateFailure: "Workflow Update failed because the Workflow completed before the Update completed.",
 			commands:      func(tv *testvars.TestVars) []*commandpb.Command { return s.UpdateAcceptCommands(tv, "1") },
 			messages: func(tv *testvars.TestVars, updRequestMsg *protocolpb.Message) []*protocolpb.Message {
 				return s.UpdateAcceptMessages(tv, updRequestMsg, "1")
@@ -4684,7 +4684,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_LastWorkflowTask_HasUpdateMessa
 	s.NoError(err)
 	updateResult := <-updateResultCh
 	s.Equal(enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, updateResult.GetStage())
-	s.Equal("Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", updateResult.GetOutcome().GetFailure().GetMessage())
+	s.Equal("Workflow Update failed because the Workflow completed before the Update completed.", updateResult.GetOutcome().GetFailure().GetMessage())
 
 	s.EqualHistoryEvents(`
 	1 WorkflowExecutionStarted
@@ -5012,7 +5012,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_ContinueAsNew_UpdateIsNotCarrie
 
 	update1Response := <-update1ResponseCh
 	s.NoError(update1Response.err)
-	s.Equal("Workflow Update is failed because it was accepted by Workflow but then Workflow completed.", update1Response.response.GetOutcome().GetFailure().GetMessage())
+	s.Equal("Workflow Update failed because the Workflow completed before the Update completed.", update1Response.response.GetOutcome().GetFailure().GetMessage())
 
 	update2Response := <-update2ResponseCh
 	s.Error(update2Response.err)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Abort updates with failure if update was accepted but workflow completes.

## Why?
<!-- Tell your future self why have you made these changes -->
Accepted Updates are failed with special server failure because if a client knows that Update has been accepted, it expects any following requests to return an Update result (or failure) but not an error. There can be different types of Update failures coming from worker and a client must handle them anyway. It is easier and less error-prone for a client to handle only Update failures instead of both failures and not obvious `NotFound` errors in case if the Workflow completes before the Update completes.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Modified existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
It is some sort of breaking change for very narrow case though.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
TBD

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.