### PR TITLE
Skip all known flaky tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,9 @@ define NEWLINE
 
 endef
 
-TEST_TIMEOUT ?= 25m
+# 30 minutes is the upper bound defined for all tests, the longer running ones at the time of writing are XDC tests. The
+# 30 minute timeout is also defined in run-tests.yml
+TEST_TIMEOUT ?= 30m
 
 PROTO_ROOT := proto
 PROTO_FILES = $(shell find ./$(PROTO_ROOT)/internal -name "*.proto")

--- a/tests/acquire_shard_test.go
+++ b/tests/acquire_shard_test.go
@@ -227,6 +227,8 @@ func (s *EventualSuccessSuite) SetupSuite() {
 // TestEventuallySucceeds verifies that we eventually succeed in acquiring the shard when we get a deadline exceeded
 // error followed by a successful acquire shard call.
 func (s *EventualSuccessSuite) TestEventuallySucceeds() {
+	s.T().Skip("flaky test")
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 

--- a/tests/describe_task_queue_test.go
+++ b/tests/describe_task_queue_test.go
@@ -80,6 +80,8 @@ func (s *DescribeTaskQueueSuite) TestAddNoTasks_ValidateStats() {
 }
 
 func (s *DescribeTaskQueueSuite) TestAddSingleTask_ValidateStats() {
+	s.T().Skip("flaky test")
+
 	s.OverrideDynamicConfig(dynamicconfig.MatchingUpdateAckInterval, 5*time.Second)
 	s.RunTestWithMatchingBehavior(func() { s.publishConsumeWorkflowTasksValidateStats(1, true) })
 }

--- a/tests/http_api_test.go
+++ b/tests/http_api_test.go
@@ -308,6 +308,8 @@ func (s *HttpApiTestSuite) runHTTPAPIBasicsTest_Shorthand(contentType string, pr
 }
 
 func (s *HttpApiTestSuite) TestHTTPAPIHeaders() {
+	s.T().Skip("flaky test")
+
 	if s.HttpAPIAddress() == "" {
 		s.T().Skip("HTTP API server not enabled")
 	}

--- a/tests/max_buffered_event_test.go
+++ b/tests/max_buffered_event_test.go
@@ -138,6 +138,8 @@ func (s *MaxBufferedEventSuite) TestMaxBufferedEventsLimit() {
 }
 
 func (s *MaxBufferedEventSuite) TestBufferedEventsMutableStateSizeLimit() {
+	s.T().Skip("flaky test")
+
 	/*
 			This test starts a workflow, and block its workflow task, then sending
 			signals to it which will be buffered. The default max mutable state

--- a/tests/update_workflow_sdk_test.go
+++ b/tests/update_workflow_sdk_test.go
@@ -153,6 +153,8 @@ func (s *UpdateWorkflowClientSuite) TestUpdateWorkflow_TerminateWorkflowAfterUpd
 }
 
 func (s *UpdateWorkflowClientSuite) TestUpdateWorkflow_ContinueAsNewAfterUpdateAdmitted() {
+	s.T().Skip("flaky test")
+
 	/*
 		Start Workflow and send Update to itself from LA to make sure it is admitted
 		by server while WFT is running. This WFT does CAN. For test simplicity,

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -1237,6 +1237,8 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSpooled(versione
 }
 
 func (s *VersioningIntegSuite) TestIndependentActivityTaskAssignment_SyncMatch_VersionedWorkflow() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.independentActivityTaskAssignmentSyncMatch(true) })
 }
 
@@ -1417,6 +1419,8 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSyncMatch(versio
 }
 
 func (s *VersioningIntegSuite) TestWorkflowTaskRedirectInRetryFirstTask() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.testWorkflowTaskRedirectInRetry(true) })
 }
 
@@ -1726,6 +1730,8 @@ func (s *VersioningIntegSuite) TestDispatchUpgradeStopOld() {
 }
 
 func (s *VersioningIntegSuite) TestDispatchUpgradeWait() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.dispatchUpgrade(true, false) })
 }
 
@@ -1827,14 +1833,20 @@ const (
 )
 
 func (s *VersioningIntegSuite) TestDispatchActivityOld() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.dispatchActivity(dontFailActivity, false, false) })
 }
 
 func (s *VersioningIntegSuite) TestDispatchActivityFailOld() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.dispatchActivity(failActivity, false, false) })
 }
 
 func (s *VersioningIntegSuite) TestDispatchActivityTimeoutOld() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.dispatchActivity(timeoutActivity, false, false) })
 }
 
@@ -2592,6 +2604,8 @@ func (s *VersioningIntegSuite) TestDispatchChildWorkflowOld() {
 }
 
 func (s *VersioningIntegSuite) TestDispatchChildWorkflow() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.dispatchChildWorkflow(true, false) })
 }
 
@@ -3066,6 +3080,8 @@ func (s *VersioningIntegSuite) dispatchQuery(newVersioning bool) {
 }
 
 func (s *VersioningIntegSuite) TestDispatchContinueAsNewOld() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.dispatchContinueAsNew(false, false) })
 }
 
@@ -3228,6 +3244,8 @@ func (s *VersioningIntegSuite) dispatchContinueAsNew(newVersioning bool, crossTq
 }
 
 func (s *VersioningIntegSuite) TestDispatchContinueAsNewUpgradeOld() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.dispatchContinueAsNewUpgrade(false) })
 }
 
@@ -3578,10 +3596,14 @@ func (s *VersioningIntegSuite) dispatchRetry() {
 }
 
 func (s *VersioningIntegSuite) TestDispatchCronOld() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.dispatchCron(false) })
 }
 
 func (s *VersioningIntegSuite) TestDispatchCron() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.dispatchCron(true) })
 }
 

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -1047,6 +1047,8 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSyncMatch() {
 }
 
 func (s *VersioningIntegSuite) TestIndependentActivityTaskAssignment_Spooled_VersionedWorkflow() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.independentActivityTaskAssignmentSpooled(true) })
 }
 
@@ -2600,6 +2602,8 @@ func (s *VersioningIntegSuite) TestDispatchActivityCrossTQFails() {
 }
 
 func (s *VersioningIntegSuite) TestDispatchChildWorkflowOld() {
+	s.T().Skip("flaky test")
+
 	s.RunTestWithMatchingBehavior(func() { s.dispatchChildWorkflow(false, false) })
 }
 

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -1035,7 +1035,7 @@ func (s *WorkflowTestSuite) TestExecuteMultiOperation() {
 		s.NoError(err)
 
 		// wait for request to complete
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		select {
 		case <-ctx.Done():

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -575,6 +575,8 @@ func (s *WorkflowTestSuite) TestCompleteWorkflowTaskAndCreateNewOne() {
 }
 
 func (s *WorkflowTestSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
+	s.T().Skip("flaky test")
+
 	id := "functional-timeouts-workflow-test"
 	wt := "functional-timeouts-workflow-test-type"
 	tl := "functional-timeouts-workflow-test-taskqueue"

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -1857,6 +1857,8 @@ func (s *FunctionalClustersTestSuite) TestTransientWorkflowTaskFailover() {
 }
 
 func (s *FunctionalClustersTestSuite) TestCronWorkflowStartAndFailover() {
+	s.T().Skip("flaky test")
+
 	namespace := "test-cron-workflow-start-and-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.FrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -1951,6 +1953,8 @@ func (s *FunctionalClustersTestSuite) TestCronWorkflowStartAndFailover() {
 }
 
 func (s *FunctionalClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
+	s.T().Skip("flaky test")
+
 	namespace := "test-cron-workflow-complete-and-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.FrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{

--- a/tests/xdc/history_replication_signals_and_updates_test.go
+++ b/tests/xdc/history_replication_signals_and_updates_test.go
@@ -208,6 +208,8 @@ func (t *hrsuTest) newHrsuTestCluster(ns string, name string, cluster *testcore.
 // TestAcceptedUpdateCanBeCompletedAfterFailoverAndFailback tests that an update can be accepted in one cluster, and completed in a
 // different cluster, after a failover.
 func (s *hrsuTestSuite) TestAcceptedUpdateCanBeCompletedAfterFailoverAndFailback() {
+	s.T().Skip("flaky test")
+
 	t, ctx, cancel := s.startHrsuTest()
 	defer cancel()
 	t.cluster1.startWorkflow(ctx, func(workflow.Context) error { return nil })
@@ -358,6 +360,8 @@ func (s *hrsuTestSuite) TestConflictResolutionReappliesUpdates() {
 // updates have the same update ID. The test confirms that when the conflict is resolved, we do not reapply the
 // UpdateAccepted event, since it has a conflicting ID.
 func (s *hrsuTestSuite) TestConflictResolutionDoesNotReapplyAcceptedUpdateWithConflictingId() {
+	s.T().Skip("flaky test")
+
 	t, ctx, cancel := s.startHrsuTest()
 	defer cancel()
 	t.cluster1.startWorkflow(ctx, func(workflow.Context) error { return nil })

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -100,6 +100,8 @@ func (s *NexusStateReplicationSuite) TearDownSuite() {
 // 9. Check that the operation completion triggers a workflow task when we poll on cluster1.
 // 10. Complete the workflow.
 func (s *NexusStateReplicationSuite) TestNexusOperationEventsReplicated() {
+	s.T().Skip("flaky test")
+
 	var callbackToken string
 	var publicCallbackUrl string
 


### PR DESCRIPTION
## What changed?

Skipped all known flaky tests.

```
go.temporal.io/server/tests TestVersioningFunctionalSuite/TestDispatchChildWorkflow
go.temporal.io/server/tests TestWorkflowTestSuite/TestWorkflowTaskAndActivityTaskTimeoutsWorkflow
go.temporal.io/server/tests TestVersioningFunctionalSuite/TestDispatchCron
go.temporal.io/server/tests TestHttpApiTestSuite/TestHTTPAPIHeaders
go.temporal.io/server/tests TestVersioningFunctionalSuite/TestDispatchActivityFailOld
go.temporal.io/server/tests/xdc TestNexusStateReplicationTestSuite/TestNexusOperationEventsReplicated
go.temporal.io/server/tests TestVersioningFunctionalSuite/TestDispatchActivityTimeoutOld
go.temporal.io/server/tests TestVersioningFunctionalSuite/TestDispatchContinueAsNewUpgrade
go.temporal.io/server/tests TestMaxBufferedEventSuite/TestBufferedEventsMutableStateSizeLimit
go.temporal.io/server/tests TestVersioningFunctionalSuite/TestWorkflowTaskRedirectInRetryFirstTask
go.temporal.io/server/tests TestVersioningFunctionalSuite/TestDispatchActivityOld
go.temporal.io/server/tests TestVersioningFunctionalSuite/TestDispatchContinueAsNewOld
go.temporal.io/server/tests TestVersioningFunctionalSuite/estDispatchActivityFailOld/ForceTaskForwardNoPollForwardForceAsync
go.temporal.io/server/tests TestVersioningFunctionalSuite/TestDispatchCronOld
go.temporal.io/server/tests/xdc TestHistoryReplicationSignalsAndUpdatesTestSuite/TestAcceptedUpdateCanBeCompletedAfterFailoverAndFailback
go.temporal.io/server/tests TestDescribeTaskQueueSuite/TestAddSingleTask_ValidateStats
go.temporal.io/server/tests TestVersioningFunctionalSuite/TestIndependentActivityTaskAssignment_SyncMatch_VersionedWorkflow
go.temporal.io/server/tests/xdc TestFuncClustersTestSuite/TestCronWorkflowCompleteAndFailover
go.temporal.io/server/tests/xdc TestHistoryReplicationSignalsAndUpdatesTestSuite/TestConflictResolutionDoesNotReapplyAcceptedUpdateWithConflictingId
go.temporal.io/server/tests TestVersioningFunctionalSuite/TestDispatchUpgradeWait
go.temporal.io/server/tests/xdc TestFuncClustersTestSuite/TestCronWorkflowStartAndFailover
go.temporal.io/server/tests TestActivityTestSuite/TestUpdateWorkflow_ContinueAsNewAfterUpdateAdmitted
go.temporal.io/server/tests TestActivityTestSuite/TestClientDataConverter_WithChild
go.temporal.io/server/tests TestAcquireShard_EventualSuccess/TestEventuallySucceeds
TestVersioningFunctionalSuite/TestDispatchChildWorkflowOld
TestVersioningFunctionalSuite/TestIndependentActivityTaskAssignment_Spooled_VersionedWorkflow
```

Also increased `TEST_TIMEOUT` in the `Makefile` to `30m` to allow XDC tests to span the entire allowed time specified in `run-tests.yml`.

## Why?

Make CI stable again. We'll need to triage reenabling and fixing these tests over time.

## How did you test it?

How did _you_ test it?!