### PR TITLE
Workflow Update: fix functional tests flakiness

### DIFF
--- a/tests/update_workflow_sdk_test.go
+++ b/tests/update_workflow_sdk_test.go
@@ -287,7 +287,7 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_ContinueAsNewAfterUpdateAdmi
   4 WorkflowTaskCompleted
   5 MarkerRecorded
   6 WorkflowExecutionContinuedAsNew`, s.GetHistory(s.Namespace(), tv.WithRunID(firstRun.GetRunID()).WorkflowExecution()))
-	// TODO: This might have different history if 1st WFT completes before Update is retired. Then
+	// TODO: This might have different history if 1st WFT completes before Update is retried. Then
 	//  there will be another 3 WFT events before Event 5. This needs to be replaced with s.EqualHistorySuffix once available.
 	s.EqualHistoryEvents(`
   1 WorkflowExecutionStarted

--- a/tests/update_workflow_sdk_test.go
+++ b/tests/update_workflow_sdk_test.go
@@ -116,6 +116,17 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TimeoutWorkflowAfterUpdateAc
 	}, workflowFn)
 	s.NoError(err)
 
+	s.Eventually(func() bool {
+		// Wait until the first WFT completes.
+		return len(s.GetHistory(s.Namespace(), tv.WorkflowExecution())) == 4
+	}, 1*time.Second, 200*time.Millisecond)
+
+	s.EqualHistoryEvents(`
+  1 WorkflowExecutionStarted
+  2 WorkflowTaskScheduled
+  3 WorkflowTaskStarted
+  4 WorkflowTaskCompleted`, s.GetHistory(s.Namespace(), tv.WorkflowExecution()))
+
 	updateHandle, err := s.updateWorkflowWaitAccepted(ctx, tv, "my-update-arg")
 	s.NoError(err)
 
@@ -133,8 +144,11 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TimeoutWorkflowAfterUpdateAc
   2 WorkflowTaskScheduled
   3 WorkflowTaskStarted
   4 WorkflowTaskCompleted
-  5 WorkflowExecutionUpdateAccepted
-  6 WorkflowExecutionTimedOut`, s.GetHistory(s.Namespace(), tv.WorkflowExecution()))
+  5 WorkflowTaskScheduled
+  6 WorkflowTaskStarted
+  7 WorkflowTaskCompleted
+  8 WorkflowExecutionUpdateAccepted
+  9 WorkflowExecutionTimedOut`, s.GetHistory(s.Namespace(), tv.WorkflowExecution()))
 }
 
 // TestUpdateWorkflow_TerminateWorkflowAfterUpdateAccepted executes an update, and while WF awaits
@@ -157,6 +171,17 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TerminateWorkflowAfterUpdate
 	s.Worker().RegisterWorkflow(workflowFn)
 	wfRun := s.startWorkflow(ctx, tv, workflowFn)
 
+	s.Eventually(func() bool {
+		// Wait until the first WFT completes.
+		return len(s.GetHistory(s.Namespace(), tv.WorkflowExecution())) == 4
+	}, 1*time.Second, 200*time.Millisecond)
+
+	s.EqualHistoryEvents(`
+  1 WorkflowExecutionStarted
+  2 WorkflowTaskScheduled
+  3 WorkflowTaskStarted
+  4 WorkflowTaskCompleted`, s.GetHistory(s.Namespace(), tv.WorkflowExecution()))
+
 	updateHandle, err := s.updateWorkflowWaitAccepted(ctx, tv, "my-update-arg")
 	s.NoError(err)
 
@@ -171,21 +196,19 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TerminateWorkflowAfterUpdate
 	var wee *temporal.WorkflowExecutionError
 	s.ErrorAs(wfRun.Get(ctx, nil), &wee)
 
-	hist := s.GetHistory(s.Namespace(), tv.WorkflowExecution())
-	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED, hist[len(hist)-1].GetEventType())
-	// Not EqualHistoryEvents because there is a race and Update might be on first WFT and might be on second.
-	// TODO: Use s.EqualHistorySuffix when it is implemented.
-	// s.EqualHistoryEvents(`
-	// 1 WorkflowExecutionStarted
-	// 2 WorkflowTaskScheduled
-	// 3 WorkflowTaskStarted
-	// 4 WorkflowTaskCompleted
-	// 5 WorkflowExecutionUpdateAccepted
-	// 6 WorkflowExecutionTerminated`, s.GetHistory(s.Namespace(), tv.WorkflowExecution()))
+	s.EqualHistoryEvents(`
+	1 WorkflowExecutionStarted
+	2 WorkflowTaskScheduled
+	3 WorkflowTaskStarted
+	4 WorkflowTaskCompleted
+	5 WorkflowTaskScheduled
+	6 WorkflowTaskStarted
+	7 WorkflowTaskCompleted
+	8 WorkflowExecutionUpdateAccepted
+	9 WorkflowExecutionTerminated`, s.GetHistory(s.Namespace(), tv.WorkflowExecution()))
 }
 
 func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_ContinueAsNewAfterUpdateAdmitted() {
-	s.T().Skip("flaky test")
 	/*
 		Start Workflow and send Update to itself from LA to make sure it is admitted
 		by server while WFT is running. This WFT does CAN. For test simplicity,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix functional tests flakiness by waiting for history to get to specific state before moving forward.

## Why?
<!-- Tell your future self why have you made these changes -->
Flakiness is bad. Follow up to #6621.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run tests 100 times with
```
go test -run ^TestUpdateWorkflowSdkSuite$ -count=100
```

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Some flakiness sources are still there. `historyrequire` package needs to be improvement to address it.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.