### PR TITLE
Nit: map<struct> instead of map<bool>

### DIFF
--- a/components/nexusoperations/events.go
+++ b/components/nexusoperations/events.go
@@ -51,7 +51,7 @@ func (d ScheduledEventDefinition) Apply(root *hsm.Node, event *historypb.History
 	return err
 }
 
-func (d ScheduledEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, _ map[enumspb.ResetReapplyExcludeType]bool) error {
+func (d ScheduledEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, _ map[enumspb.ResetReapplyExcludeType]struct{}) error {
 	// We never cherry pick command events, and instead allow user logic to reschedule those commands.
 	return hsm.ErrNotCherryPickable
 }
@@ -72,7 +72,7 @@ func (d CancelRequestedEventDefinition) Apply(root *hsm.Node, event *historypb.H
 	})
 }
 
-func (d CancelRequestedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, _ map[enumspb.ResetReapplyExcludeType]bool) error {
+func (d CancelRequestedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, _ map[enumspb.ResetReapplyExcludeType]struct{}) error {
 	// We never cherry pick command events, and instead allow user logic to reschedule those commands.
 	return hsm.ErrNotCherryPickable
 }
@@ -97,8 +97,8 @@ func (d StartedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEv
 	})
 }
 
-func (d StartedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]bool) error {
-	if excludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS] {
+func (d StartedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
+	if _, ok := excludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS]; ok {
 		return hsm.ErrNotCherryPickable
 	}
 	return d.Apply(root, event)
@@ -123,8 +123,8 @@ func (d CompletedEventDefinition) Type() enumspb.EventType {
 	return enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED
 }
 
-func (d CompletedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]bool) error {
-	if excludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS] {
+func (d CompletedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
+	if _, ok := excludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS]; ok {
 		return hsm.ErrNotCherryPickable
 	}
 	return d.Apply(root, event)
@@ -150,8 +150,8 @@ func (d FailedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEve
 	})
 }
 
-func (d FailedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]bool) error {
-	if excludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS] {
+func (d FailedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
+	if _, ok := excludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS]; ok {
 		return hsm.ErrNotCherryPickable
 	}
 	return d.Apply(root, event)
@@ -176,8 +176,8 @@ func (d CanceledEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryE
 	})
 }
 
-func (d CanceledEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]bool) error {
-	if excludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS] {
+func (d CanceledEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
+	if _, ok := excludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS]; ok {
 		return hsm.ErrNotCherryPickable
 	}
 	return d.Apply(root, event)
@@ -201,8 +201,8 @@ func (d TimedOutEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryE
 	})
 }
 
-func (d TimedOutEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]bool) error {
-	if excludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS] {
+func (d TimedOutEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
+	if _, ok := excludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS]; ok {
 		return hsm.ErrNotCherryPickable
 	}
 	return d.Apply(root, event)

--- a/components/nexusoperations/events_test.go
+++ b/components/nexusoperations/events_test.go
@@ -133,7 +133,7 @@ func TestCherryPick(t *testing.T) {
 			nexusoperations.TimedOutEventDefinition{},
 		}
 
-		excludeNexusOperation := map[enumspb.ResetReapplyExcludeType]bool{enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS: true}
+		excludeNexusOperation := map[enumspb.ResetReapplyExcludeType]struct{}{enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS: {}}
 		for _, nexusOperation := range nexusOperations {
 			err := nexusOperation.CherryPick(node.Parent, &historypb.HistoryEvent{}, excludeNexusOperation)
 			require.ErrorIs(t, err, hsm.ErrNotCherryPickable, "%T should not be cherrypickable when shouldExcludeNexusEvent=true", nexusOperation)

--- a/service/history/api/resetworkflow/api.go
+++ b/service/history/api/resetworkflow/api.go
@@ -177,23 +177,23 @@ func Invoke(
 func GetResetReapplyExcludeTypes(
 	excludeTypes []enumspb.ResetReapplyExcludeType,
 	includeType enumspb.ResetReapplyType,
-) map[enumspb.ResetReapplyExcludeType]bool {
+) map[enumspb.ResetReapplyExcludeType]struct{} {
 	// A client who wishes to have reapplication of all supported event types should omit the deprecated
 	// reset_reapply_type field (since its default value is RESET_REAPPLY_TYPE_ALL_ELIGIBLE).
-	exclude := map[enumspb.ResetReapplyExcludeType]bool{}
+	exclude := map[enumspb.ResetReapplyExcludeType]struct{}{}
 	switch includeType {
 	case enumspb.RESET_REAPPLY_TYPE_SIGNAL:
 		// A client sending this value of the deprecated reset_reapply_type field will not have any events other than
 		// signal reapplied.
-		exclude[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE] = true
+		exclude[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE] = struct{}{}
 	case enumspb.RESET_REAPPLY_TYPE_NONE:
-		exclude[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL] = true
-		exclude[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE] = true
+		exclude[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL] = struct{}{}
+		exclude[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE] = struct{}{}
 	case enumspb.RESET_REAPPLY_TYPE_UNSPECIFIED, enumspb.RESET_REAPPLY_TYPE_ALL_ELIGIBLE:
 		// Do nothing.
 	}
 	for _, e := range excludeTypes {
-		exclude[e] = true
+		exclude[e] = struct{}{}
 	}
 	return exclude
 }

--- a/service/history/api/resetworkflow/api_test.go
+++ b/service/history/api/resetworkflow/api_test.go
@@ -43,7 +43,7 @@ func TestResetWorkflowSuite(t *testing.T) {
 func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
 	// Include all with no exclusions => no exclusions
 	s.Equal(
-		map[enums.ResetReapplyExcludeType]bool{},
+		map[enums.ResetReapplyExcludeType]struct{}{},
 		GetResetReapplyExcludeTypes(
 			[]enums.ResetReapplyExcludeType{},
 			enums.RESET_REAPPLY_TYPE_ALL_ELIGIBLE,
@@ -51,7 +51,7 @@ func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
 	)
 	// Include all with one exclusion => one exclusion (honor exclude in presence of default value of deprecated option)
 	s.Equal(
-		map[enums.ResetReapplyExcludeType]bool{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: true},
+		map[enums.ResetReapplyExcludeType]struct{}{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: {}},
 		GetResetReapplyExcludeTypes(
 			[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
 			enums.RESET_REAPPLY_TYPE_ALL_ELIGIBLE,
@@ -60,7 +60,7 @@ func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
 	// Include signal with no exclusions => exclude updates
 	// (honor non-default value of deprecated option in presence of default value of non-deprecated option)
 	s.Equal(
-		map[enums.ResetReapplyExcludeType]bool{enums.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: true},
+		map[enums.ResetReapplyExcludeType]struct{}{enums.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: {}},
 		GetResetReapplyExcludeTypes(
 			[]enums.ResetReapplyExcludeType{},
 			enums.RESET_REAPPLY_TYPE_SIGNAL,
@@ -69,9 +69,9 @@ func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
 	// Include signal with exclude signal => include signal means they want to exclude updates, and then the explicit
 	// exclusion of signal trumps the deprecated inclusion
 	s.Equal(
-		map[enums.ResetReapplyExcludeType]bool{
-			enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: true,
-			enums.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: true,
+		map[enums.ResetReapplyExcludeType]struct{}{
+			enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: {},
+			enums.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: {},
 		},
 		GetResetReapplyExcludeTypes(
 			[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},
@@ -81,9 +81,9 @@ func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
 	// Include none with no exclusions => all excluded
 	// (honor non-default value of deprecated option in presence of default value of non-deprecated option)
 	s.Equal(
-		map[enums.ResetReapplyExcludeType]bool{
-			enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: true,
-			enums.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: true,
+		map[enums.ResetReapplyExcludeType]struct{}{
+			enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: {},
+			enums.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: {},
 		},
 		GetResetReapplyExcludeTypes(
 			[]enums.ResetReapplyExcludeType{},
@@ -92,9 +92,9 @@ func (s *resetWorkflowSuite) TestGetResetReapplyExcludeTypes() {
 	)
 	// Include none with exclude signal is all excluded
 	s.Equal(
-		map[enums.ResetReapplyExcludeType]bool{
-			enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: true,
-			enums.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: true,
+		map[enums.ResetReapplyExcludeType]struct{}{
+			enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: {},
+			enums.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: {},
 		},
 		GetResetReapplyExcludeTypes(
 			[]enums.ResetReapplyExcludeType{enums.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL},

--- a/service/history/hsm/events.go
+++ b/service/history/hsm/events.go
@@ -44,5 +44,5 @@ type EventDefinition interface {
 	// Command events should never be cherry picked as we rely on the workflow to reschedule them.
 	// Return [ErrNotCherryPickable], [ErrStateMachineNotFound], or [ErrInvalidTransition] to skip cherry picking. Any
 	// other error is considered fatal and will abort the cherry pick process.
-	CherryPick(root *Node, event *historypb.HistoryEvent, resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool) error
+	CherryPick(root *Node, event *historypb.HistoryEvent, resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error
 }

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -74,7 +74,7 @@ type (
 			currentWorkflow Workflow,
 			resetReason string,
 			additionalReapplyEvents []*historypb.HistoryEvent,
-			resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
+			resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]struct{},
 		) error
 	}
 
@@ -123,7 +123,7 @@ func (r *workflowResetterImpl) ResetWorkflow(
 	currentWorkflow Workflow,
 	resetReason string,
 	additionalReapplyEvents []*historypb.HistoryEvent,
-	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
+	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]struct{},
 ) (retError error) {
 
 	namespaceEntry, err := r.namespaceRegistry.GetNamespaceByID(namespaceID)
@@ -580,7 +580,7 @@ func (r *workflowResetterImpl) reapplyContinueAsNewWorkflowEvents(
 	baseBranchToken []byte,
 	baseRebuildNextEventID int64,
 	baseNextEventID int64,
-	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
+	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]struct{},
 ) (string, error) {
 
 	// TODO change this logic to fetching all workflow [baseWorkflow, currentWorkflow]
@@ -682,7 +682,7 @@ func (r *workflowResetterImpl) reapplyEventsFromBranch(
 	firstEventID int64,
 	nextEventID int64,
 	branchToken []byte,
-	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
+	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]struct{},
 ) (string, error) {
 
 	// TODO change this logic to fetching all workflow [baseWorkflow, currentWorkflow]
@@ -723,7 +723,7 @@ func (r *workflowResetterImpl) reapplyEvents(
 	ctx context.Context,
 	mutableState workflow.MutableState,
 	events []*historypb.HistoryEvent,
-	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
+	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]struct{},
 ) ([]*historypb.HistoryEvent, error) {
 	// When reapplying events during WorkflowReset, we do not check for conflicting update IDs (they are not possible,
 	// since the workflow was in a consistent state before reset), and we do not perform deduplication (because we never
@@ -737,7 +737,7 @@ func reapplyEvents(
 	targetBranchUpdateRegistry update.Registry,
 	stateMachineRegistry *hsm.Registry,
 	events []*historypb.HistoryEvent,
-	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]bool,
+	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]struct{},
 	runIdForDeduplication string,
 ) ([]*historypb.HistoryEvent, error) {
 	// TODO (dan): This implementation is the result of unifying two previous implementations, one of which did
@@ -749,8 +749,8 @@ func reapplyEvents(
 		resource := definition.NewEventReappliedID(runIdForDeduplication, event.GetEventId(), event.GetVersion())
 		return mutableState.IsResourceDuplicated(resource)
 	}
-	excludeSignal := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL]
-	excludeUpdate := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE]
+	_, excludeSignal := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL]
+	_, excludeUpdate := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE]
 	var reappliedEvents []*historypb.HistoryEvent
 	for _, event := range events {
 		switch event.GetEventType() {

--- a/service/history/ndc/workflow_resetter_mock.go
+++ b/service/history/ndc/workflow_resetter_mock.go
@@ -67,7 +67,7 @@ func (m *MockWorkflowResetter) EXPECT() *MockWorkflowResetterMockRecorder {
 }
 
 // ResetWorkflow mocks base method.
-func (m *MockWorkflowResetter) ResetWorkflow(ctx context.Context, namespaceID namespace.ID, workflowID, baseRunID string, baseBranchToken []byte, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID int64, resetRunID, resetRequestID string, currentWorkflow Workflow, resetReason string, additionalReapplyEvents []*history.HistoryEvent, resetReapplyExcludeTypes map[enums.ResetReapplyExcludeType]bool) error {
+func (m *MockWorkflowResetter) ResetWorkflow(ctx context.Context, namespaceID namespace.ID, workflowID, baseRunID string, baseBranchToken []byte, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID int64, resetRunID, resetRequestID string, currentWorkflow Workflow, resetReason string, additionalReapplyEvents []*history.HistoryEvent, resetReapplyExcludeTypes map[enums.ResetReapplyExcludeType]struct{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetWorkflow", ctx, namespaceID, workflowID, baseRunID, baseBranchToken, baseRebuildLastEventID, baseRebuildLastEventVersion, baseNextEventID, resetRunID, resetRequestID, currentWorkflow, resetReason, additionalReapplyEvents, resetReapplyExcludeTypes)
 	ret0, _ := ret[0].(error)

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -976,10 +976,10 @@ func (s *workflowResetterSuite) TestReapplyEvents_Excludes() {
 	s.NoError(err)
 	ms.EXPECT().HSM().Return(root).AnyTimes()
 
-	excludes := map[enumspb.ResetReapplyExcludeType]bool{
-		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: true,
-		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: true,
-		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS:  true,
+	excludes := map[enumspb.ResetReapplyExcludeType]struct{}{
+		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: {},
+		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: {},
+		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS:  {},
 	}
 	reappliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, events, excludes, "")
 	s.Empty(reappliedEvents)

--- a/tests/reset_workflow_test.go
+++ b/tests/reset_workflow_test.go
@@ -597,8 +597,8 @@ func (t *resetTest) run() {
 	events := t.GetHistory(t.Namespace(), t.tv.WorkflowExecution())
 
 	resetReapplyExcludeTypes := resetworkflow.GetResetReapplyExcludeTypes(t.reapplyExcludeTypes, t.reapplyType)
-	signals := !resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL]
-	updates := !resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE]
+	_, signals := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL]
+	_, updates := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE]
 
 	if !signals && !updates {
 		t.EqualHistoryEvents(`


### PR DESCRIPTION
## What changed?
replacing `map[enumspb.ResetReapplyExcludeType]bool` with `map[enumspb.ResetReapplyExcludeType]struct{}`

## Why?
- Small space saving
- More conventional Go.

## How did you test it?
Existing tests.

## Potential risks
N/A

## Documentation
N/A

## Is hotfix candidate?
No