### PR TITLE
Refactor global taskGeneratorProvider to avoid races

### DIFF
--- a/service/history/deletemanager/delete_manager.go
+++ b/service/history/deletemanager/delete_manager.go
@@ -108,7 +108,7 @@ func (m *DeleteManagerImpl) AddDeleteWorkflowExecutionTask(
 	ms workflow.MutableState,
 ) error {
 
-	taskGenerator := workflow.NewTaskGeneratorProvider().NewTaskGenerator(m.shardContext, ms)
+	taskGenerator := workflow.GetTaskGeneratorProvider().NewTaskGenerator(m.shardContext, ms)
 
 	// We can make this task immediately because the task itself will keep rescheduling itself until the workflow is
 	// closed before actually deleting the workflow.

--- a/service/history/workflow/fx.go
+++ b/service/history/workflow/fx.go
@@ -29,7 +29,8 @@ import (
 )
 
 var Module = fx.Options(
-	fx.Populate(&taskGeneratorProvider),
+	fx.Provide(func() TaskGeneratorProvider { return defaultTaskGeneratorProvider }),
+	fx.Invoke(populateTaskGeneratorProvider),
 	fx.Provide(RelocatableAttributesFetcherProvider),
 	fx.Invoke(RegisterStateMachine),
 )

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -70,7 +70,6 @@ import (
 	"go.temporal.io/server/service/history"
 	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/tasks"
-	"go.temporal.io/server/service/history/workflow"
 	"go.temporal.io/server/service/matching"
 	"go.temporal.io/server/service/worker"
 	"go.uber.org/fx"
@@ -493,7 +492,6 @@ func HistoryServiceProvider(
 	}
 
 	app := fx.New(
-		fx.Provide(workflow.NewTaskGeneratorProvider),
 		params.GetCommonServiceOptions(serviceName),
 		history.QueueModule,
 		history.Module,

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -74,7 +74,6 @@ import (
 	"go.temporal.io/server/service/history"
 	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/tasks"
-	"go.temporal.io/server/service/history/workflow"
 	"go.temporal.io/server/service/matching"
 	"go.temporal.io/server/service/worker"
 	"go.temporal.io/server/temporal"
@@ -544,7 +543,6 @@ func (c *TemporalImpl) startHistory() {
 			fx.Provide(resource.DefaultSnTaggedLoggerProvider),
 			fx.Provide(func() *esclient.Config { return c.esConfig }),
 			fx.Provide(func() esclient.Client { return c.esClient }),
-			fx.Provide(workflow.NewTaskGeneratorProvider),
 			fx.Provide(c.GetTLSConfigProvider),
 			fx.Provide(c.GetTaskCategoryRegistry),
 			fx.Supply(c.spanExporters),


### PR DESCRIPTION
## What changed?
This is based on @yycptt's idea:
Only do write on global taskGeneratorProvider if non-default.
Provide the default TaskGeneratorProvider (it can be overridden with fx.Decorate).

## Why?
This allows multiple independent servers to run in the same process without tripping the race detector, e.g. for integration testing, as long as the implementation is not overridden.

## How did you test it?
existing tests