### PR TITLE
Fix broken tests from https://github.com/temporalio/temporal/pull/6639

### DIFF
--- a/tests/reset_workflow_test.go
+++ b/tests/reset_workflow_test.go
@@ -597,9 +597,11 @@ func (t *resetTest) run() {
 	events := t.GetHistory(t.Namespace(), t.tv.WorkflowExecution())
 
 	resetReapplyExcludeTypes := resetworkflow.GetResetReapplyExcludeTypes(t.reapplyExcludeTypes, t.reapplyType)
-	_, signals := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL]
-	_, updates := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE]
+	_, noSignals := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL]
+	_, noUpdates := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE]
 
+	signals := !noSignals
+	updates := !noUpdates
 	if !signals && !updates {
 		t.EqualHistoryEvents(`
   1 WorkflowExecutionStarted


### PR DESCRIPTION
## What changed?
Fixing the bug introduced in https://github.com/temporalio/temporal/pull/6639. I had missed the negations.

## Why?
Tests are broken.

## How did you test it?
Ran the tests in `tests/reset_workflow_test.go` locally and ensured they all run fine.

## Potential risks
N/A

