### PR TITLE
Run test-status always

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -439,7 +439,7 @@ jobs:
         run: make functional-test-ndc-coverage
 
   test-status:
-    if: ${{ inputs.run_single_functional_test != true && inputs.run_single_unit_test != true }}
+    if: always()
     name: Test Status
     needs:
       - unit-test


### PR DESCRIPTION
## What changed?
Run Test Status job always

## Why?
Our PRs are gated on this job passing. When it was not running always, it was possible to merge a PR with broken tests.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
