### PR TITLE
Fix flaky TestAvoidForwardingWhenBacklogIsOld and add new test

### DIFF
--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -644,9 +644,7 @@ func (tm *TaskMatcher) getBacklogAge() time.Duration {
 
 	oldest := int64(math.MaxInt64)
 	for createTime := range tm.backlogTasksCreateTime {
-		if createTime < oldest {
-			oldest = createTime
-		}
+		oldest = min(oldest, createTime)
 	}
 
 	return time.Since(time.Unix(0, oldest))

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -413,7 +413,8 @@ func (t *MatcherTestSuite) TestAvoidForwardingWhenBacklogIsOldButReconsider() {
 
 	select {
 	case fwdTime := <-forwardTask:
-		t.Greater(fwdTime.Sub(start), t.childConfig.MaxWaitForPollerBeforeFwd())
+		// check forward was after reconsider time. add a little buffer for last poller time calculation in MustOffer.
+		t.Greater(fwdTime.Sub(start), t.childConfig.MaxWaitForPollerBeforeFwd()*9/10)
 	case <-ctx.Done():
 		t.FailNow("timed out")
 	}


### PR DESCRIPTION
## What changed?
- Try to make TestAvoidForwardingWhenBacklogIsOld less flaky
- Add TestAvoidForwardingWhenBacklogIsOldButReconsider to check the "reconsider forwarding after waiting for a poll" behavior.

## Why?
Less flaky tests

## How did you test it?
ran them a lot