### PR TITLE
Batch Mutable State Metrics

### DIFF
--- a/common/metrics/metrics.go
+++ b/common/metrics/metrics.go
@@ -60,9 +60,14 @@ type (
 
 		Stop(log.Logger)
 
-		// BatchStart returns a Handler that where supported, can emit a series of metrics as a single "wide event".
+		// StartBatch returns a BatchHandler that can emit a series of metrics as a single "wide event".
 		// If wide events aren't supported in the underlying implementation, metrics can still be sent individually.
-		BatchStart(string) (Handler, io.Closer)
+		StartBatch(string) BatchHandler
+	}
+
+	BatchHandler interface {
+		Handler
+		io.Closer
 	}
 
 	// CounterIface is an ever-increasing counter.
@@ -71,7 +76,7 @@ type (
 		// Tags provided are merged with the source MetricsHandler
 		Record(int64, ...Tag)
 	}
-	// GaugeIface can be set to any float and repesents a latest value instrument.
+	// GaugeIface can be set to any float and represents a latest value instrument.
 	GaugeIface interface {
 		// Record updates the gauge value.
 		// Tags provided are merged with the source MetricsHandler

--- a/common/metrics/metrics.go
+++ b/common/metrics/metrics.go
@@ -27,6 +27,7 @@
 package metrics
 
 import (
+	"io"
 	"time"
 
 	"go.temporal.io/server/common/log"
@@ -58,6 +59,10 @@ type (
 		Histogram(string, MetricUnit) HistogramIface
 
 		Stop(log.Logger)
+
+		// BatchStart returns a Handler that where supported, can emit a series of metrics as a single "wide event".
+		// If wide events aren't supported in the underlying implementation, metrics can still be sent individually.
+		BatchStart(string) (Handler, io.Closer)
 	}
 
 	// CounterIface is an ever-increasing counter.

--- a/common/metrics/metrics_mock.go
+++ b/common/metrics/metrics_mock.go
@@ -34,6 +34,7 @@
 package metrics
 
 import (
+	io "io"
 	reflect "reflect"
 	time "time"
 
@@ -62,6 +63,21 @@ func NewMockHandler(ctrl *gomock.Controller) *MockHandler {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
+}
+
+// BatchStart mocks base method.
+func (m *MockHandler) BatchStart(arg0 string) (Handler, io.Closer) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchStart", arg0)
+	ret0, _ := ret[0].(Handler)
+	ret1, _ := ret[1].(io.Closer)
+	return ret0, ret1
+}
+
+// BatchStart indicates an expected call of BatchStart.
+func (mr *MockHandlerMockRecorder) BatchStart(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchStart", reflect.TypeOf((*MockHandler)(nil).BatchStart), arg0)
 }
 
 // Counter mocks base method.

--- a/common/metrics/metrics_mock.go
+++ b/common/metrics/metrics_mock.go
@@ -34,7 +34,6 @@
 package metrics
 
 import (
-	io "io"
 	reflect "reflect"
 	time "time"
 
@@ -63,21 +62,6 @@ func NewMockHandler(ctrl *gomock.Controller) *MockHandler {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
-}
-
-// BatchStart mocks base method.
-func (m *MockHandler) BatchStart(arg0 string) (Handler, io.Closer) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BatchStart", arg0)
-	ret0, _ := ret[0].(Handler)
-	ret1, _ := ret[1].(io.Closer)
-	return ret0, ret1
-}
-
-// BatchStart indicates an expected call of BatchStart.
-func (mr *MockHandlerMockRecorder) BatchStart(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchStart", reflect.TypeOf((*MockHandler)(nil).BatchStart), arg0)
 }
 
 // Counter mocks base method.
@@ -122,6 +106,20 @@ func (mr *MockHandlerMockRecorder) Histogram(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Histogram", reflect.TypeOf((*MockHandler)(nil).Histogram), arg0, arg1)
 }
 
+// StartBatch mocks base method.
+func (m *MockHandler) StartBatch(arg0 string) BatchHandler {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartBatch", arg0)
+	ret0, _ := ret[0].(BatchHandler)
+	return ret0
+}
+
+// StartBatch indicates an expected call of StartBatch.
+func (mr *MockHandlerMockRecorder) StartBatch(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartBatch", reflect.TypeOf((*MockHandler)(nil).StartBatch), arg0)
+}
+
 // Stop mocks base method.
 func (m *MockHandler) Stop(arg0 log.Logger) {
 	m.ctrl.T.Helper()
@@ -164,6 +162,143 @@ func (m *MockHandler) WithTags(arg0 ...Tag) Handler {
 func (mr *MockHandlerMockRecorder) WithTags(arg0 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithTags", reflect.TypeOf((*MockHandler)(nil).WithTags), arg0...)
+}
+
+// MockBatchHandler is a mock of BatchHandler interface.
+type MockBatchHandler struct {
+	ctrl     *gomock.Controller
+	recorder *MockBatchHandlerMockRecorder
+}
+
+// MockBatchHandlerMockRecorder is the mock recorder for MockBatchHandler.
+type MockBatchHandlerMockRecorder struct {
+	mock *MockBatchHandler
+}
+
+// NewMockBatchHandler creates a new mock instance.
+func NewMockBatchHandler(ctrl *gomock.Controller) *MockBatchHandler {
+	mock := &MockBatchHandler{ctrl: ctrl}
+	mock.recorder = &MockBatchHandlerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockBatchHandler) EXPECT() *MockBatchHandlerMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockBatchHandler) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockBatchHandlerMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockBatchHandler)(nil).Close))
+}
+
+// Counter mocks base method.
+func (m *MockBatchHandler) Counter(arg0 string) CounterIface {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Counter", arg0)
+	ret0, _ := ret[0].(CounterIface)
+	return ret0
+}
+
+// Counter indicates an expected call of Counter.
+func (mr *MockBatchHandlerMockRecorder) Counter(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Counter", reflect.TypeOf((*MockBatchHandler)(nil).Counter), arg0)
+}
+
+// Gauge mocks base method.
+func (m *MockBatchHandler) Gauge(arg0 string) GaugeIface {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Gauge", arg0)
+	ret0, _ := ret[0].(GaugeIface)
+	return ret0
+}
+
+// Gauge indicates an expected call of Gauge.
+func (mr *MockBatchHandlerMockRecorder) Gauge(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Gauge", reflect.TypeOf((*MockBatchHandler)(nil).Gauge), arg0)
+}
+
+// Histogram mocks base method.
+func (m *MockBatchHandler) Histogram(arg0 string, arg1 MetricUnit) HistogramIface {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Histogram", arg0, arg1)
+	ret0, _ := ret[0].(HistogramIface)
+	return ret0
+}
+
+// Histogram indicates an expected call of Histogram.
+func (mr *MockBatchHandlerMockRecorder) Histogram(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Histogram", reflect.TypeOf((*MockBatchHandler)(nil).Histogram), arg0, arg1)
+}
+
+// StartBatch mocks base method.
+func (m *MockBatchHandler) StartBatch(arg0 string) BatchHandler {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartBatch", arg0)
+	ret0, _ := ret[0].(BatchHandler)
+	return ret0
+}
+
+// StartBatch indicates an expected call of StartBatch.
+func (mr *MockBatchHandlerMockRecorder) StartBatch(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartBatch", reflect.TypeOf((*MockBatchHandler)(nil).StartBatch), arg0)
+}
+
+// Stop mocks base method.
+func (m *MockBatchHandler) Stop(arg0 log.Logger) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Stop", arg0)
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockBatchHandlerMockRecorder) Stop(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockBatchHandler)(nil).Stop), arg0)
+}
+
+// Timer mocks base method.
+func (m *MockBatchHandler) Timer(arg0 string) TimerIface {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Timer", arg0)
+	ret0, _ := ret[0].(TimerIface)
+	return ret0
+}
+
+// Timer indicates an expected call of Timer.
+func (mr *MockBatchHandlerMockRecorder) Timer(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Timer", reflect.TypeOf((*MockBatchHandler)(nil).Timer), arg0)
+}
+
+// WithTags mocks base method.
+func (m *MockBatchHandler) WithTags(arg0 ...Tag) Handler {
+	m.ctrl.T.Helper()
+	varargs := []any{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WithTags", varargs...)
+	ret0, _ := ret[0].(Handler)
+	return ret0
+}
+
+// WithTags indicates an expected call of WithTags.
+func (mr *MockBatchHandlerMockRecorder) WithTags(arg0 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithTags", reflect.TypeOf((*MockBatchHandler)(nil).WithTags), arg0...)
 }
 
 // MockCounterIface is a mock of CounterIface interface.

--- a/common/metrics/metricstest/capture_handler.go
+++ b/common/metrics/metricstest/capture_handler.go
@@ -25,6 +25,7 @@
 package metricstest
 
 import (
+	"io"
 	"sync"
 	"time"
 
@@ -140,6 +141,14 @@ func (c *CaptureHandler) Timer(name string) metrics.TimerIface {
 // Histogram implements [metrics.Handler.Histogram].
 func (c *CaptureHandler) Histogram(name string, unit metrics.MetricUnit) metrics.HistogramIface {
 	return metrics.HistogramFunc(func(v int64, tags ...metrics.Tag) { c.record(name, v, unit, tags...) })
+}
+
+func (c *CaptureHandler) Close() error {
+	return nil
+}
+
+func (c *CaptureHandler) BatchStart(_ string) (metrics.Handler, io.Closer) {
+	return c, c
 }
 
 // Stop implements [metrics.Handler.Stop].

--- a/common/metrics/metricstest/capture_handler.go
+++ b/common/metrics/metricstest/capture_handler.go
@@ -25,7 +25,6 @@
 package metricstest
 
 import (
-	"io"
 	"sync"
 	"time"
 
@@ -147,8 +146,8 @@ func (c *CaptureHandler) Close() error {
 	return nil
 }
 
-func (c *CaptureHandler) BatchStart(_ string) (metrics.Handler, io.Closer) {
-	return c, c
+func (c *CaptureHandler) StartBatch(_ string) metrics.BatchHandler {
+	return c
 }
 
 // Stop implements [metrics.Handler.Stop].

--- a/common/metrics/noop_impl.go
+++ b/common/metrics/noop_impl.go
@@ -25,6 +25,7 @@
 package metrics
 
 import (
+	"io"
 	"time"
 
 	"go.temporal.io/server/common/log"
@@ -67,6 +68,14 @@ func (*noopMetricsHandler) Histogram(string, MetricUnit) HistogramIface {
 }
 
 func (*noopMetricsHandler) Stop(log.Logger) {}
+
+func (*noopMetricsHandler) Close() error {
+	return nil
+}
+
+func (n *noopMetricsHandler) BatchStart(_ string) (Handler, io.Closer) {
+	return n, n
+}
 
 var NoopCounterMetricFunc = CounterFunc(func(i int64, t ...Tag) {})
 var NoopGaugeMetricFunc = GaugeFunc(func(f float64, t ...Tag) {})

--- a/common/metrics/noop_impl.go
+++ b/common/metrics/noop_impl.go
@@ -25,7 +25,6 @@
 package metrics
 
 import (
-	"io"
 	"time"
 
 	"go.temporal.io/server/common/log"
@@ -73,8 +72,8 @@ func (*noopMetricsHandler) Close() error {
 	return nil
 }
 
-func (n *noopMetricsHandler) BatchStart(_ string) (Handler, io.Closer) {
-	return n, n
+func (n *noopMetricsHandler) StartBatch(_ string) BatchHandler {
+	return n
 }
 
 var NoopCounterMetricFunc = CounterFunc(func(i int64, t ...Tag) {})

--- a/common/metrics/otel_metrics_handler.go
+++ b/common/metrics/otel_metrics_handler.go
@@ -27,6 +27,7 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
@@ -202,6 +203,14 @@ func (omp *otelMetricsHandler) Histogram(histogram string, unit MetricUnit) Hist
 
 func (omp *otelMetricsHandler) Stop(l log.Logger) {
 	omp.provider.Stop(l)
+}
+
+func (omp *otelMetricsHandler) Close() error {
+	return nil
+}
+
+func (omp *otelMetricsHandler) BatchStart(_ string) (Handler, io.Closer) {
+	return omp, omp
 }
 
 // makeSet returns an otel attribute.Set with the given tags merged with the

--- a/common/metrics/otel_metrics_handler.go
+++ b/common/metrics/otel_metrics_handler.go
@@ -27,7 +27,6 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"io"
 	"sync"
 	"time"
 
@@ -209,8 +208,8 @@ func (omp *otelMetricsHandler) Close() error {
 	return nil
 }
 
-func (omp *otelMetricsHandler) BatchStart(_ string) (Handler, io.Closer) {
-	return omp, omp
+func (omp *otelMetricsHandler) StartBatch(_ string) BatchHandler {
+	return omp
 }
 
 // makeSet returns an otel attribute.Set with the given tags merged with the

--- a/common/metrics/tally_metrics_handler.go
+++ b/common/metrics/tally_metrics_handler.go
@@ -25,7 +25,6 @@
 package metrics
 
 import (
-	"io"
 	"time"
 
 	"github.com/uber-go/tally/v4"
@@ -125,8 +124,8 @@ func (*tallyMetricsHandler) Close() error {
 	return nil
 }
 
-func (tmh *tallyMetricsHandler) BatchStart(_ string) (Handler, io.Closer) {
-	return tmh, tmh
+func (tmh *tallyMetricsHandler) StartBatch(_ string) BatchHandler {
+	return tmh
 }
 
 func tagsToMap(t1 []Tag, e excludeTags) map[string]string {

--- a/common/metrics/tally_metrics_handler.go
+++ b/common/metrics/tally_metrics_handler.go
@@ -25,6 +25,7 @@
 package metrics
 
 import (
+	"io"
 	"time"
 
 	"github.com/uber-go/tally/v4"
@@ -66,59 +67,67 @@ func NewTallyMetricsHandler(cfg ClientConfig, scope tally.Scope) *tallyMetricsHa
 
 // WithTags creates a new MetricProvder with provided []Tag
 // Tags are merged with registered Tags from the source MetricsHandler
-func (tmp *tallyMetricsHandler) WithTags(tags ...Tag) Handler {
+func (tmh *tallyMetricsHandler) WithTags(tags ...Tag) Handler {
 	return &tallyMetricsHandler{
-		scope:          tmp.scope.Tagged(tagsToMap(tags, tmp.excludeTags)),
-		perUnitBuckets: tmp.perUnitBuckets,
-		excludeTags:    tmp.excludeTags,
+		scope:          tmh.scope.Tagged(tagsToMap(tags, tmh.excludeTags)),
+		perUnitBuckets: tmh.perUnitBuckets,
+		excludeTags:    tmh.excludeTags,
 	}
 }
 
 // Counter obtains a counter for the given name.
-func (tmp *tallyMetricsHandler) Counter(counter string) CounterIface {
+func (tmh *tallyMetricsHandler) Counter(counter string) CounterIface {
 	return CounterFunc(func(i int64, t ...Tag) {
-		scope := tmp.scope
+		scope := tmh.scope
 		if len(t) > 0 {
-			scope = tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags))
+			scope = tmh.scope.Tagged(tagsToMap(t, tmh.excludeTags))
 		}
 		scope.Counter(counter).Inc(i)
 	})
 }
 
 // Gauge obtains a gauge for the given name.
-func (tmp *tallyMetricsHandler) Gauge(gauge string) GaugeIface {
+func (tmh *tallyMetricsHandler) Gauge(gauge string) GaugeIface {
 	return GaugeFunc(func(f float64, t ...Tag) {
-		scope := tmp.scope
+		scope := tmh.scope
 		if len(t) > 0 {
-			scope = tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags))
+			scope = tmh.scope.Tagged(tagsToMap(t, tmh.excludeTags))
 		}
 		scope.Gauge(gauge).Update(f)
 	})
 }
 
 // Timer obtains a timer for the given name.
-func (tmp *tallyMetricsHandler) Timer(timer string) TimerIface {
+func (tmh *tallyMetricsHandler) Timer(timer string) TimerIface {
 	return TimerFunc(func(d time.Duration, t ...Tag) {
-		scope := tmp.scope
+		scope := tmh.scope
 		if len(t) > 0 {
-			scope = tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags))
+			scope = tmh.scope.Tagged(tagsToMap(t, tmh.excludeTags))
 		}
 		scope.Timer(timer).Record(d)
 	})
 }
 
 // Histogram obtains a histogram for the given name.
-func (tmp *tallyMetricsHandler) Histogram(histogram string, unit MetricUnit) HistogramIface {
+func (tmh *tallyMetricsHandler) Histogram(histogram string, unit MetricUnit) HistogramIface {
 	return HistogramFunc(func(i int64, t ...Tag) {
-		scope := tmp.scope
+		scope := tmh.scope
 		if len(t) > 0 {
-			scope = tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags))
+			scope = tmh.scope.Tagged(tagsToMap(t, tmh.excludeTags))
 		}
-		scope.Histogram(histogram, tmp.perUnitBuckets[unit]).RecordValue(float64(i))
+		scope.Histogram(histogram, tmh.perUnitBuckets[unit]).RecordValue(float64(i))
 	})
 }
 
 func (*tallyMetricsHandler) Stop(log.Logger) {}
+
+func (*tallyMetricsHandler) Close() error {
+	return nil
+}
+
+func (tmh *tallyMetricsHandler) BatchStart(_ string) (Handler, io.Closer) {
+	return tmh, tmh
+}
 
 func tagsToMap(t1 []Tag, e excludeTags) map[string]string {
 	if len(t1) == 0 {

--- a/service/history/historybuilder/history_builder_categorization_test.go
+++ b/service/history/historybuilder/history_builder_categorization_test.go
@@ -25,7 +25,6 @@
 package historybuilder
 
 import (
-	"io"
 	"testing"
 	"time"
 
@@ -71,8 +70,8 @@ func (h StubHandler) Close() error {
 	return nil
 }
 
-func (h StubHandler) BatchStart(_ string) (metrics.Handler, io.Closer) {
-	return h, h
+func (h StubHandler) StartBatch(_ string) metrics.BatchHandler {
+	return h
 }
 
 func TestHistoryBuilder_IsDirty(t *testing.T) {

--- a/service/history/historybuilder/history_builder_categorization_test.go
+++ b/service/history/historybuilder/history_builder_categorization_test.go
@@ -25,6 +25,7 @@
 package historybuilder
 
 import (
+	"io"
 	"testing"
 	"time"
 
@@ -65,6 +66,14 @@ func (h StubHandler) Histogram(_ string, _ metrics.MetricUnit) metrics.Histogram
 }
 
 func (h StubHandler) Stop(_ log.Logger) {}
+
+func (h StubHandler) Close() error {
+	return nil
+}
+
+func (h StubHandler) BatchStart(_ string) (metrics.Handler, io.Closer) {
+	return h, h
+}
 
 func TestHistoryBuilder_IsDirty(t *testing.T) {
 	hb := HistoryBuilder{EventStore: EventStore{}}

--- a/service/history/workflow/metrics.go
+++ b/service/history/workflow/metrics.go
@@ -93,9 +93,7 @@ func emitMutableStateStatus(
 	}
 
 	for category, taskCount := range stats.TaskCountByCategory {
-		// We use the metricsHandler rather than the batchHandler here because the same metric is repeatedly sent
-		metrics.TaskCount.With(metricsHandler).
-			Record(int64(taskCount), metrics.TaskCategoryTag(category))
+		metrics.TaskCount.With(batchHandler).Record(int64(taskCount), metrics.TaskCategoryTag(category))
 	}
 }
 

--- a/service/history/workflow/metrics.go
+++ b/service/history/workflow/metrics.go
@@ -60,36 +60,40 @@ func emitMutableStateStatus(
 	if stats == nil {
 		return
 	}
-	metrics.MutableStateSize.With(metricsHandler).Record(int64(stats.TotalSize))
-	metrics.ExecutionInfoSize.With(metricsHandler).Record(int64(stats.ExecutionInfoSize))
-	metrics.ExecutionStateSize.With(metricsHandler).Record(int64(stats.ExecutionStateSize))
-	metrics.ActivityInfoSize.With(metricsHandler).Record(int64(stats.ActivityInfoSize))
-	metrics.ActivityInfoCount.With(metricsHandler).Record(int64(stats.ActivityInfoCount))
-	metrics.TotalActivityCount.With(metricsHandler).Record(stats.TotalActivityCount)
-	metrics.TimerInfoSize.With(metricsHandler).Record(int64(stats.TimerInfoSize))
-	metrics.TimerInfoCount.With(metricsHandler).Record(int64(stats.TimerInfoCount))
-	metrics.TotalUserTimerCount.With(metricsHandler).Record(stats.TotalUserTimerCount)
-	metrics.ChildInfoSize.With(metricsHandler).Record(int64(stats.ChildInfoSize))
-	metrics.ChildInfoCount.With(metricsHandler).Record(int64(stats.ChildInfoCount))
-	metrics.TotalChildExecutionCount.With(metricsHandler).Record(stats.TotalChildExecutionCount)
-	metrics.RequestCancelInfoSize.With(metricsHandler).Record(int64(stats.RequestCancelInfoSize))
-	metrics.RequestCancelInfoCount.With(metricsHandler).Record(int64(stats.RequestCancelInfoCount))
-	metrics.TotalRequestCancelExternalCount.With(metricsHandler).Record(stats.TotalRequestCancelExternalCount)
-	metrics.SignalInfoSize.With(metricsHandler).Record(int64(stats.SignalInfoSize))
-	metrics.SignalInfoCount.With(metricsHandler).Record(int64(stats.SignalInfoCount))
-	metrics.TotalSignalExternalCount.With(metricsHandler).Record(stats.TotalSignalExternalCount)
-	metrics.SignalRequestIDSize.With(metricsHandler).Record(int64(stats.SignalRequestIDSize))
-	metrics.SignalRequestIDCount.With(metricsHandler).Record(int64(stats.SignalRequestIDCount))
-	metrics.TotalSignalCount.With(metricsHandler).Record(stats.TotalSignalCount)
-	metrics.BufferedEventsSize.With(metricsHandler).Record(int64(stats.BufferedEventsSize))
-	metrics.BufferedEventsCount.With(metricsHandler).Record(int64(stats.BufferedEventsCount))
+
+	batchHandler, closer := metricsHandler.BatchStart("mutable_state_status")
+	defer closer.Close()
+	metrics.MutableStateSize.With(batchHandler).Record(int64(stats.TotalSize))
+	metrics.ExecutionInfoSize.With(batchHandler).Record(int64(stats.ExecutionInfoSize))
+	metrics.ExecutionStateSize.With(batchHandler).Record(int64(stats.ExecutionStateSize))
+	metrics.ActivityInfoSize.With(batchHandler).Record(int64(stats.ActivityInfoSize))
+	metrics.ActivityInfoCount.With(batchHandler).Record(int64(stats.ActivityInfoCount))
+	metrics.TotalActivityCount.With(batchHandler).Record(stats.TotalActivityCount)
+	metrics.TimerInfoSize.With(batchHandler).Record(int64(stats.TimerInfoSize))
+	metrics.TimerInfoCount.With(batchHandler).Record(int64(stats.TimerInfoCount))
+	metrics.TotalUserTimerCount.With(batchHandler).Record(stats.TotalUserTimerCount)
+	metrics.ChildInfoSize.With(batchHandler).Record(int64(stats.ChildInfoSize))
+	metrics.ChildInfoCount.With(batchHandler).Record(int64(stats.ChildInfoCount))
+	metrics.TotalChildExecutionCount.With(batchHandler).Record(stats.TotalChildExecutionCount)
+	metrics.RequestCancelInfoSize.With(batchHandler).Record(int64(stats.RequestCancelInfoSize))
+	metrics.RequestCancelInfoCount.With(batchHandler).Record(int64(stats.RequestCancelInfoCount))
+	metrics.TotalRequestCancelExternalCount.With(batchHandler).Record(stats.TotalRequestCancelExternalCount)
+	metrics.SignalInfoSize.With(batchHandler).Record(int64(stats.SignalInfoSize))
+	metrics.SignalInfoCount.With(batchHandler).Record(int64(stats.SignalInfoCount))
+	metrics.TotalSignalExternalCount.With(batchHandler).Record(stats.TotalSignalExternalCount)
+	metrics.SignalRequestIDSize.With(batchHandler).Record(int64(stats.SignalRequestIDSize))
+	metrics.SignalRequestIDCount.With(batchHandler).Record(int64(stats.SignalRequestIDCount))
+	metrics.TotalSignalCount.With(batchHandler).Record(stats.TotalSignalCount)
+	metrics.BufferedEventsSize.With(batchHandler).Record(int64(stats.BufferedEventsSize))
+	metrics.BufferedEventsCount.With(batchHandler).Record(int64(stats.BufferedEventsCount))
 
 	if stats.HistoryStatistics != nil {
-		metrics.HistorySize.With(metricsHandler).Record(int64(stats.HistoryStatistics.SizeDiff))
-		metrics.HistoryCount.With(metricsHandler).Record(int64(stats.HistoryStatistics.CountDiff))
+		metrics.HistorySize.With(batchHandler).Record(int64(stats.HistoryStatistics.SizeDiff))
+		metrics.HistoryCount.With(batchHandler).Record(int64(stats.HistoryStatistics.CountDiff))
 	}
 
 	for category, taskCount := range stats.TaskCountByCategory {
+		// We use the metricsHandler rather than the batchHandler here because the same metric is repeatedly sent
 		metrics.TaskCount.With(metricsHandler).
 			Record(int64(taskCount), metrics.TaskCategoryTag(category))
 	}

--- a/service/history/workflow/metrics.go
+++ b/service/history/workflow/metrics.go
@@ -61,8 +61,8 @@ func emitMutableStateStatus(
 		return
 	}
 
-	batchHandler, closer := metricsHandler.BatchStart("mutable_state_status")
-	defer closer.Close()
+	batchHandler := metricsHandler.StartBatch("mutable_state_status")
+	defer batchHandler.Close()
 	metrics.MutableStateSize.With(batchHandler).Record(int64(stats.TotalSize))
 	metrics.ExecutionInfoSize.With(batchHandler).Record(int64(stats.ExecutionInfoSize))
 	metrics.ExecutionStateSize.With(batchHandler).Record(int64(stats.ExecutionStateSize))


### PR DESCRIPTION
## What changed?
Extend metrics.Handler interface to include a batching feature which enables implementations to send "wide events". Batch the mutable state metrics.

## Why?
Send a single metrics "event" where possible rather than several.

## How did you test it?
Unit tests.

## Potential risks
None expected.

## Documentation
Nothing in `docs/` to update. Release notes to come.

## Is hotfix candidate?
No