### PR TITLE
upgrade golangci-lint to avoid panic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ $(LOCALBIN):
 .PHONY: golangci-lint
 GOLANGCI_LINT_BASE_REV ?= $(MAIN_BRANCH)
 GOLANGCI_LINT_FIX ?= true
-GOLANGCI_LINT_VERSION := v1.59.1
+GOLANGCI_LINT_VERSION := v1.60.3
 GOLANGCI_LINT := $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))


### PR DESCRIPTION
## What changed?
upgrade golangci-lint to v1.60.3

## Why?
Panic when `make check`:

```
make check
Check license header...
Downloading github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
Linting code...
INFO golangci-lint has version v1.59.1 built with go1.23.2 from (unknown, modified: ?, mod sum: "h1:CRRLu1JbhK5avLABFJ/OHVSQ0Ie5c4ulsOId1h3TTks=") on (unknown) 
INFO [config_reader] Used config file .golangci.yml 
WARN [lintersdb] The name "goerr113" is deprecated. The linter has been renamed to: err113. 
WARN [lintersdb] The name "vet" is deprecated. The linter has been renamed to: govet. 
INFO [lintersdb] Active 9 linters: [err113 errcheck exhaustive forbidigo godox goimports govet revive staticcheck] 
INFO [loader] Go packages loading at mode 575 (imports|deps|exports_file|files|name|types_sizes|compiled_files) took 1.222995125s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 90.026292ms 
ERRO [linters_context/goanalysis] fact_purity: panic during analysis: interface conversion: interface {} is nil, not *buildir.IR, goroutine 19045 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:105 +0x4c
panic({0x105faf400?, 0x140069d8690?})
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124
honnef.co/go/tools/analysis/facts/purity.purity(0x140069b60e0)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/analysis/facts/purity/purity.go:109 +0x270
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0x140057865d0)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:191 +0x8ac
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:113 +0x20
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0x140006eda90, {0x105bbd874, 0xb}, 0x14004f49f30)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0x105515c70?)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:112 +0x70
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0x140057865d0)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:80 +0xac
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 2167
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:75 +0x174 
ERRO [linters_context/goanalysis] nilness: panic during analysis: interface conversion: interface {} is nil, not *buildir.IR, goroutine 19047 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:105 +0x4c
panic({0x105faf400?, 0x14006074bd0?})
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124
honnef.co/go/tools/analysis/facts/nilness.run(0x1400607e000)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/analysis/facts/nilness/nilness.go:65 +0x244
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0x14005ab1500)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:191 +0x8ac
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:113 +0x20
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0x140006eda90, {0x105b6bc72, 0x7}, 0x14003e4bf30)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0x105515c70?)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:112 +0x70
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0x14005ab1500)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:80 +0xac
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 2167
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:75 +0x174 
ERRO [linters_context/goanalysis] typedness: panic during analysis: interface conversion: interface {} is nil, not *buildir.IR, goroutine 18576 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:105 +0x4c
panic({0x105faf400?, 0x14006e46270?})
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124
honnef.co/go/tools/analysis/facts/typedness.run(0x14006e40700)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/analysis/facts/typedness/typedness.go:59 +0x204
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0x14005aab8c0)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:191 +0x8ac
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:113 +0x20
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0x140006eda90, {0x105b91436, 0x9}, 0x14002972730)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0x105515c70?)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:112 +0x70
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0x14005aab8c0)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:80 +0xac
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 2167
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:75 +0x174 
ERRO [linters_context/goanalysis] buildir: panic during analysis: Cannot range over: func(yield func(K, V) bool), goroutine 18577 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:105 +0x4c
panic({0x105eff720?, 0x14006d39b90?})
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124
honnef.co/go/tools/go/ir.(*builder).rangeStmt(0x140061158d0, 0x14006e29900, 0x140063e8960, 0x0, {0x106131390, 0x140063e8960})
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2225 +0x6dc
honnef.co/go/tools/go/ir.(*builder).stmt(0x140061158d0, 0x14006e29900, {0x106135ce8?, 0x140063e8960?})
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2438 +0x1c0
honnef.co/go/tools/go/ir.(*builder).stmtList(...)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:859
honnef.co/go/tools/go/ir.(*builder).stmt(0x140061158d0, 0x14006e29900, {0x106135bf8?, 0x140063f1710?})
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2396 +0x10c4
honnef.co/go/tools/go/ir.(*builder).buildFunction(0x140061158d0, 0x14006e29900)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2508 +0x368
honnef.co/go/tools/go/ir.(*builder).buildFuncDecl(0x140061158d0, 0x140063a3440, 0x140063f1740)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2545 +0x1a4
honnef.co/go/tools/go/ir.(*Package).build(0x140063a3440)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2649 +0x934
sync.(*Once).doSlow(0x140063d2460?, 0x140063e8f60?)
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/sync/once.go:76 +0xf8
sync.(*Once).Do(...)
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/sync/once.go:67
honnef.co/go/tools/go/ir.(*Package).Build(...)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2567
honnef.co/go/tools/internal/passes/buildir.run(0x140063d2380)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/internal/passes/buildir/buildir.go:86 +0x134
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0x14005740280)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:191 +0x8ac
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:113 +0x20
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0x140006eda90, {0x105b73b75, 0x7}, 0x140035f7f30)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0x105515c70?)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:112 +0x70
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0x14005740280)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:80 +0xac
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 2167
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:75 +0x174 
ERRO [linters_context/goanalysis] SA5012: panic during analysis: interface conversion: interface {} is nil, not *buildir.IR, goroutine 19043 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:105 +0x4c
panic({0x105faf400?, 0x1400626a0c0?})
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124
honnef.co/go/tools/staticcheck.findSliceLenChecks(0x140002928c0)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/staticcheck/lint.go:4285 +0x718
honnef.co/go/tools/staticcheck.CheckEvenSliceLength(0x140002928c0)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/staticcheck/lint.go:4523 +0x20
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0x14005bf02e0)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:191 +0x8ac
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:113 +0x20
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0x140006eda90, {0x105b69872, 0x6}, 0x14002fa9f30)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0x105515c70?)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:112 +0x70
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0x14005bf02e0)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:80 +0xac
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 2167
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:75 +0x174 
ERRO [linters_context/goanalysis] buildir: panic during analysis: Cannot range over: func(yield func(E) bool), goroutine 19134 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:105 +0x4c
panic({0x105eff720?, 0x14007623ed0?})
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124
honnef.co/go/tools/go/ir.(*builder).rangeStmt(0x140039b78d0, 0x140028477c0, 0x14006c98fc0, 0x0, {0x106131390, 0x14006c98fc0})
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2225 +0x6dc
honnef.co/go/tools/go/ir.(*builder).stmt(0x140039b78d0, 0x140028477c0, {0x106135ce8?, 0x14006c98fc0?})
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2438 +0x1c0
honnef.co/go/tools/go/ir.(*builder).stmtList(...)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:859
honnef.co/go/tools/go/ir.(*builder).stmt(0x140039b78d0, 0x140028477c0, {0x106135bf8?, 0x14006ca8c30?})
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2396 +0x10c4
honnef.co/go/tools/go/ir.(*builder).buildFunction(0x140039b78d0, 0x140028477c0)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2508 +0x368
honnef.co/go/tools/go/ir.(*builder).buildFuncDecl(0x140039b78d0, 0x1400605d8c0, 0x14006ca8c60)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2545 +0x1a4
honnef.co/go/tools/go/ir.(*Package).build(0x1400605d8c0)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2649 +0x934
sync.(*Once).doSlow(0x140075aee00?, 0x14006dda300?)
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/sync/once.go:76 +0xf8
sync.(*Once).Do(...)
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/sync/once.go:67
honnef.co/go/tools/go/ir.(*Package).Build(...)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2567
honnef.co/go/tools/internal/passes/buildir.run(0x140075aed20)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/internal/passes/buildir/buildir.go:86 +0x134
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0x140057394d0)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:191 +0x8ac
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:113 +0x20
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0x140006eda90, {0x105b73b75, 0x7}, 0x14003903730)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0x105515c70?)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:112 +0x70
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0x140057394d0)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:80 +0xac
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 2479
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:75 +0x174 
ERRO [linters_context/goanalysis] nilness: panic during analysis: interface conversion: interface {} is nil, not *buildir.IR, goroutine 19132 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:105 +0x4c
panic({0x105faf400?, 0x14001579260?})
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124
honnef.co/go/tools/analysis/facts/nilness.run(0x1400163c000)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/analysis/facts/nilness/nilness.go:65 +0x244
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0x14005aa3d90)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:191 +0x8ac
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:113 +0x20
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0x140006eda90, {0x105b6bc72, 0x7}, 0x14004d01f30)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0x105515c70?)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:112 +0x70
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0x14005aa3d90)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:80 +0xac
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 2479
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:75 +0x174 
ERRO [linters_context/goanalysis] typedness: panic during analysis: interface conversion: interface {} is nil, not *buildir.IR, goroutine 19137 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:105 +0x4c
panic({0x105faf400?, 0x140032c9f20?})
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124
honnef.co/go/tools/analysis/facts/typedness.run(0x14001f56c40)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/analysis/facts/typedness/typedness.go:59 +0x204
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0x14005aa0820)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:191 +0x8ac
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:113 +0x20
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0x140006eda90, {0x105b91436, 0x9}, 0x14005f8e730)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0x105515c70?)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:112 +0x70
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0x14005aa0820)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:80 +0xac
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 2479
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:75 +0x174 
ERRO [linters_context/goanalysis] fact_purity: panic during analysis: interface conversion: interface {} is nil, not *buildir.IR, goroutine 19128 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:105 +0x4c
panic({0x105faf400?, 0x140017f1530?})
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124
honnef.co/go/tools/analysis/facts/purity.purity(0x14001f56d20)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/analysis/facts/purity/purity.go:109 +0x270
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0x1400577fdc0)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:191 +0x8ac
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:113 +0x20
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0x140006eda90, {0x105bbd874, 0xb}, 0x14003d2af30)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0x105515c70?)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:112 +0x70
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0x1400577fdc0)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:80 +0xac
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 2479
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:75 +0x174 
ERRO [linters_context/goanalysis] SA5012: panic during analysis: interface conversion: interface {} is nil, not *buildir.IR, goroutine 19136 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:105 +0x4c
panic({0x105faf400?, 0x140017ed8c0?})
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124
honnef.co/go/tools/staticcheck.findSliceLenChecks(0x140002927e0)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/staticcheck/lint.go:4285 +0x718
honnef.co/go/tools/staticcheck.CheckEvenSliceLength(0x140002927e0)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/staticcheck/lint.go:4523 +0x20
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0x14005bea070)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:191 +0x8ac
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:113 +0x20
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0x140006eda90, {0x105b69872, 0x6}, 0x1400393ff30)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0x105515c70?)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:112 +0x70
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0x14005bea070)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:80 +0xac
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 2479
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:75 +0x174 
ERRO [linters_context/goanalysis] nilness: panic during analysis: internal error: unhandled type *ir.ArrayConst, goroutine 24271 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:105 +0x4c
panic({0x105eff720?, 0x1400c535e30?})
        /opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124
honnef.co/go/tools/analysis/facts/nilness.impl.func1({0x12ef58950, 0x1400c5620c0})
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/analysis/facts/nilness/nilness.go:239 +0x920
honnef.co/go/tools/analysis/facts/nilness.impl.func1({0x106142598, 0x1400c553200})
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/analysis/facts/nilness/nilness.go:147 +0x958
honnef.co/go/tools/analysis/facts/nilness.impl(0x1400c5602a0, 0x1400c370b40, 0x140075bdc88)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/analysis/facts/nilness/nilness.go:246 +0x2bc
honnef.co/go/tools/analysis/facts/nilness.run(0x1400c5602a0)
        /Users/hai/go/pkg/mod/honnef.co/go/tools@v0.4.7/analysis/facts/nilness/nilness.go:66 +0xf4
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0x14005ab0810)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:191 +0x8ac
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:113 +0x20
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0x140006eda90, {0x105b6bc72, 0x7}, 0x1400427a730)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0x105515c70?)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_action.go:112 +0x70
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0x14005ab0810)
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:80 +0xac
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 997
        /Users/hai/go/pkg/mod/github.com/golangci/golangci-lint@v1.59.1/pkg/goanalysis/runner_loadingpackage.go:75 +0x174 
INFO [linters_context/goanalysis] analyzers took 4m13.782429933s with top 10 stages: buildir: 1m0.792702173s, goimports: 30.159507381s, the_only_name: 29.525520545s, nilness: 4.262889792s, forbidigo: 3.750209168s, fact_deprecated: 3.185376988s, exhaustive: 3.09331718s, printf: 2.843785062s, ctrlflow: 2.834569208s, typedness: 2.489390801s 
INFO [runner] fixer took 0s with no stages        
INFO [runner/skip_dirs] Skipped 19 issues from dir api/enums/v1 by pattern ^api 
INFO [runner] Issues before processing: 2562, after processing: 0 
INFO [runner] Processors filtering stat (out/in): filename_unadjuster: 2562/2562, autogenerated_exclude: 2531/2543, nolint: 1962/2365, skip_files: 2562/2562, exclude: 2531/2531, cgo: 2562/2562, path_prettifier: 2562/2562, skip_dirs: 2543/2562, identifier_marker: 2531/2531, invalid_issue: 2562/2562, exclude-rules: 2365/2531, uniq_by_line: 1926/1962, diff: 0/1926 
INFO [runner] processing took 487.079125ms with stages: nolint: 190.989249ms, diff: 118.008375ms, exclude-rules: 102.991917ms, autogenerated_exclude: 34.208041ms, identifier_marker: 31.944709ms, path_prettifier: 7.0265ms, skip_dirs: 1.327666ms, uniq_by_line: 227µs, cgo: 128.208µs, invalid_issue: 118.292µs, fixer: 60.333µs, filename_unadjuster: 46.541µs, max_same_issues: 1.084µs, max_per_file_from_linter: 250ns, sort_results: 209ns, exclude: 167ns, skip_files: 167ns, max_from_linter: 125ns, source_code: 124ns, path_prefixer: 84ns, severity-rules: 42ns, path_shortener: 42ns 
INFO [runner] linters took 14.959458958s with stages: goanalysis_metalinter: 14.472215583s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 160 samples, avg is 1618.5MB, max is 2625.5MB 
INFO Execution took 16.281830875s                 
make: *** [lint-code] Error 7
```

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
