### PR TITLE
Only pre-build functional tests and use per-build cache

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -127,13 +127,6 @@ jobs:
           path: ~/go/pkg/mod
           key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
 
-      - name: Restore build outputs
-        id: restore-build
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.cache/go-build
-          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
-
       - run: make pre-build-functional-test-coverage
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
 
@@ -147,7 +140,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ~/.cache/go-build
-          key: ${{ steps.restore-build.outputs.cache-primary-key }}
+          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
   misc-checks:
     name: Misc checks

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -118,7 +118,6 @@ jobs:
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
         with:
           go-version-file: "go.mod"
-          check-latest: true
 
       - run: make pre-build-functional-test-coverage
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
@@ -143,7 +142,6 @@ jobs:
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
         with:
           go-version-file: "go.mod"
-          check-latest: true
 
       - uses: arduino/setup-protoc@v3
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
@@ -181,7 +179,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          check-latest: true
 
       - name: Run unit tests
         if: ${{ !cancelled() && !inputs.run_single_unit_test }}
@@ -217,7 +214,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          check-latest: true
 
       - name: Start containerized dependencies
         uses: hoverkraft-tech/compose-action@v2.0.1
@@ -312,7 +308,6 @@ jobs:
         if: ${{ inputs.run_single_functional_test != true || (inputs.run_single_functional_test == true && contains(fromJSON(needs.set-up-single-test.outputs.dbs), env.PERSISTENCE_DRIVER)) }}
         with:
           go-version-file: "go.mod"
-          check-latest: true
 
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' && (inputs.run_single_functional_test != true || (inputs.run_single_functional_test == true && contains(fromJSON(needs.set-up-single-test.outputs.dbs), env.PERSISTENCE_DRIVER))) }}
@@ -381,7 +376,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          check-latest: true
 
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' }}
@@ -450,7 +444,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          check-latest: true
 
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -118,9 +118,36 @@ jobs:
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
         with:
           go-version-file: "go.mod"
+          cache: false  # do our own caching
+
+      - name: restore dependencies
+        id: restore-deps
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
+
+      - name: restore build outputs
+        id: restore-build
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-${{ runner.os }}-build-${{ github.sha }}
 
       - run: make pre-build-functional-test-coverage
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
+
+      - name: save dependencies
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ steps.restore-deps.outputs.cache-primary-key }}
+
+      - name: save build outputs
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ steps.restore-build.outputs.cache-primary-key }}
 
   misc-checks:
     name: Misc checks
@@ -142,6 +169,19 @@ jobs:
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
         with:
           go-version-file: "go.mod"
+          cache: false  # do our own caching
+
+      - name: restore dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
+
+      - name: restore build outputs
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-${{ runner.os }}-build-${{ github.sha }}
 
       - uses: arduino/setup-protoc@v3
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
@@ -179,6 +219,19 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
+          cache: false  # do our own caching
+
+      - name: restore dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
+
+      - name: restore build outputs
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-${{ runner.os }}-build-${{ github.sha }}
 
       - name: Run unit tests
         if: ${{ !cancelled() && !inputs.run_single_unit_test }}
@@ -214,6 +267,19 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
+          cache: false  # do our own caching
+
+      - name: restore dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
+
+      - name: restore build outputs
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-${{ runner.os }}-build-${{ github.sha }}
 
       - name: Start containerized dependencies
         uses: hoverkraft-tech/compose-action@v2.0.1
@@ -308,6 +374,19 @@ jobs:
         if: ${{ inputs.run_single_functional_test != true || (inputs.run_single_functional_test == true && contains(fromJSON(needs.set-up-single-test.outputs.dbs), env.PERSISTENCE_DRIVER)) }}
         with:
           go-version-file: "go.mod"
+          cache: false  # do our own caching
+
+      - name: restore dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
+
+      - name: restore build outputs
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-${{ runner.os }}-build-${{ github.sha }}
 
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' && (inputs.run_single_functional_test != true || (inputs.run_single_functional_test == true && contains(fromJSON(needs.set-up-single-test.outputs.dbs), env.PERSISTENCE_DRIVER))) }}
@@ -376,6 +455,19 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
+          cache: false  # do our own caching
+
+      - name: restore dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
+
+      - name: restore build outputs
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-${{ runner.os }}-build-${{ github.sha }}
 
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' }}
@@ -444,6 +536,19 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
+          cache: false  # do our own caching
+
+      - name: restore dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
+
+      - name: restore build outputs
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-${{ runner.os }}-build-${{ github.sha }}
 
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -78,7 +78,7 @@ jobs:
       - id: generate_output
         run: |
           shards=3
-          timeout=35   # update this to TEST_TIMEOUT if you update the Makefile
+          timeout=20   # update this to TEST_TIMEOUT if you update the Makefile
           runs_on='["ubuntu-20.04"]'
           if [[ "${{ inputs.run_single_functional_test }}" == "true" || "${{ inputs.run_single_unit_test }}" == "true" ]]; then
             shards=1
@@ -473,7 +473,7 @@ jobs:
           key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
       - name: Run functional test xdc
-        timeout-minutes: 40   # update this to TEST_TIMEOUT+5 if you update the Makefile
+        timeout-minutes: 25   # update this to TEST_TIMEOUT+5 if you update the Makefile
         run: make functional-test-xdc-coverage
 
       - name: Upload test results

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -132,7 +132,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/go-build
-          key: go-${{ runner.os }}-build-${{ github.sha }}
+          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
       - run: make pre-build-functional-test-coverage
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
@@ -182,7 +182,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/go-build
-          key: go-${{ runner.os }}-build-${{ github.sha }}
+          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
       - uses: arduino/setup-protoc@v3
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
@@ -232,7 +232,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/go-build
-          key: go-${{ runner.os }}-build-${{ github.sha }}
+          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
       - name: Run unit tests
         if: ${{ !cancelled() && !inputs.run_single_unit_test }}
@@ -280,7 +280,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/go-build
-          key: go-${{ runner.os }}-build-${{ github.sha }}
+          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
       - name: Start containerized dependencies
         uses: hoverkraft-tech/compose-action@v2.0.1
@@ -387,7 +387,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/go-build
-          key: go-${{ runner.os }}-build-${{ github.sha }}
+          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' && (inputs.run_single_functional_test != true || (inputs.run_single_functional_test == true && contains(fromJSON(needs.set-up-single-test.outputs.dbs), env.PERSISTENCE_DRIVER))) }}
@@ -468,7 +468,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/go-build
-          key: go-${{ runner.os }}-build-${{ github.sha }}
+          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' }}
@@ -549,7 +549,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/go-build
-          key: go-${{ runner.os }}-build-${{ github.sha }}
+          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -132,6 +132,7 @@ jobs:
 
       - name: Save dependencies
         uses: actions/cache/save@v4
+        if: ${{ steps.restore-deps.outputs.cache-hit != 'true' }}
         with:
           path: ~/go/pkg/mod
           key: ${{ steps.restore-deps.outputs.cache-primary-key }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -151,6 +151,7 @@ jobs:
 
   misc-checks:
     name: Misc checks
+    needs: pre-build
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -120,14 +120,14 @@ jobs:
           go-version-file: "go.mod"
           cache: false  # do our own caching
 
-      - name: restore dependencies
+      - name: Restore dependencies
         id: restore-deps
         uses: actions/cache/restore@v4
         with:
           path: ~/go/pkg/mod
           key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
 
-      - name: restore build outputs
+      - name: Restore build outputs
         id: restore-build
         uses: actions/cache/restore@v4
         with:
@@ -137,13 +137,13 @@ jobs:
       - run: make pre-build-functional-test-coverage
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
 
-      - name: save dependencies
+      - name: Save dependencies
         uses: actions/cache/save@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ steps.restore-deps.outputs.cache-primary-key }}
 
-      - name: save build outputs
+      - name: Save build outputs
         uses: actions/cache/save@v4
         with:
           path: ~/.cache/go-build
@@ -172,13 +172,13 @@ jobs:
           go-version-file: "go.mod"
           cache: false  # do our own caching
 
-      - name: restore dependencies
+      - name: Restore dependencies
         uses: actions/cache/restore@v4
         with:
           path: ~/go/pkg/mod
           key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
 
-      - name: restore build outputs
+      - name: Restore build outputs
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/go-build
@@ -222,13 +222,13 @@ jobs:
           go-version-file: "go.mod"
           cache: false  # do our own caching
 
-      - name: restore dependencies
+      - name: Restore dependencies
         uses: actions/cache/restore@v4
         with:
           path: ~/go/pkg/mod
           key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
 
-      - name: restore build outputs
+      - name: Restore build outputs
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/go-build
@@ -265,23 +265,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ env.COMMIT }}
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: "go.mod"
-          cache: false  # do our own caching
-
-      - name: restore dependencies
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
-
-      - name: restore build outputs
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.cache/go-build
-          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
-
       - name: Start containerized dependencies
         uses: hoverkraft-tech/compose-action@v2.0.1
         with:
@@ -291,6 +274,23 @@ jobs:
             mysql
             postgresql
           down-flags: -v
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: false  # do our own caching
+
+      - name: Restore dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
+
+      - name: Restore build outputs
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
       - name: Run integration test
         timeout-minutes: 15
@@ -371,24 +371,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ env.COMMIT }}
 
-      - uses: actions/setup-go@v5
-        if: ${{ inputs.run_single_functional_test != true || (inputs.run_single_functional_test == true && contains(fromJSON(needs.set-up-single-test.outputs.dbs), env.PERSISTENCE_DRIVER)) }}
-        with:
-          go-version-file: "go.mod"
-          cache: false  # do our own caching
-
-      - name: restore dependencies
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
-
-      - name: restore build outputs
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.cache/go-build
-          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
-
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' && (inputs.run_single_functional_test != true || (inputs.run_single_functional_test == true && contains(fromJSON(needs.set-up-single-test.outputs.dbs), env.PERSISTENCE_DRIVER))) }}
         uses: hoverkraft-tech/compose-action@v2.0.1
@@ -396,6 +378,24 @@ jobs:
           compose-file: ${{ env.DOCKER_COMPOSE_FILE }}
           services: "${{ join(matrix.containers, '\n') }}"
           down-flags: -v
+
+      - uses: actions/setup-go@v5
+        if: ${{ inputs.run_single_functional_test != true || (inputs.run_single_functional_test == true && contains(fromJSON(needs.set-up-single-test.outputs.dbs), env.PERSISTENCE_DRIVER)) }}
+        with:
+          go-version-file: "go.mod"
+          cache: false  # do our own caching
+
+      - name: Restore dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
+
+      - name: Restore build outputs
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
       - name: Run functional test
         if: ${{ inputs.run_single_functional_test != true || (inputs.run_single_functional_test == true && contains(fromJSON(needs.set-up-single-test.outputs.dbs), env.PERSISTENCE_DRIVER)) }}
@@ -453,23 +453,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ env.COMMIT }}
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: "go.mod"
-          cache: false  # do our own caching
-
-      - name: restore dependencies
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
-
-      - name: restore build outputs
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.cache/go-build
-          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
-
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' }}
         uses: hoverkraft-tech/compose-action@v2.0.1
@@ -477,6 +460,23 @@ jobs:
           compose-file: ${{ env.DOCKER_COMPOSE_FILE }}
           services: "${{ join(matrix.containers, '\n') }}"
           down-flags: -v
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: false  # do our own caching
+
+      - name: Restore dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
+
+      - name: Restore build outputs
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
       - name: Run functional test xdc
         timeout-minutes: 40   # update this to TEST_TIMEOUT+5 if you update the Makefile
@@ -534,23 +534,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ env.COMMIT }}
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: "go.mod"
-          cache: false  # do our own caching
-
-      - name: restore dependencies
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
-
-      - name: restore build outputs
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.cache/go-build
-          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
-
       - name: Start containerized dependencies
         if: ${{ toJson(matrix.containers) != '[]' }}
         uses: hoverkraft-tech/compose-action@v2.0.1
@@ -558,6 +541,23 @@ jobs:
           compose-file: ${{ env.DOCKER_COMPOSE_FILE }}
           services: "${{ join(matrix.containers, '\n') }}"
           down-flags: -v
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: false  # do our own caching
+
+      - name: Restore dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ runner.os }}-deps-${{ hashFiles('go.sum') }}
+
+      - name: Restore build outputs
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-${{ runner.os }}-build-${{ env.COMMIT }}
 
       - name: Run functional test ndc
         timeout-minutes: 15

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -139,9 +139,7 @@ jobs:
     name: Pre-build for cache
     strategy:
       fail-fast: false
-      matrix:
-        runs-on: [ubuntu-20.04]
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
@@ -185,9 +183,7 @@ jobs:
     needs: pre-build
     strategy:
       fail-fast: false
-      matrix:
-        runs-on: [ubuntu-20.04]
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
@@ -235,9 +231,7 @@ jobs:
     needs: [pre-build, set-up-single-test]
     strategy:
       fail-fast: false
-      matrix:
-        runs-on: [ubuntu-20.04]
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-20.04
     env:
       BUILDKITE_MESSAGE: '{"job": "unit-test"}'
       SINGLE_TEST_ARGS: ${{ needs.set-up-single-test.outputs.single_test_args }}
@@ -294,9 +288,7 @@ jobs:
     needs: [pre-build, set-up-single-test]
     strategy:
       fail-fast: false
-      matrix:
-        runs-on: [ubuntu-20.04]
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-20.04
     env:
       BUILDKITE_MESSAGE: '{"job": "integration-test"}'
     steps:
@@ -466,7 +458,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-20.04]
         name: [cass_es, cass_es8, mysql8, postgres12, postgres12_pgx]
         include:
           - name: cass_es
@@ -494,7 +485,7 @@ jobs:
             persistence_driver: postgres12_pgx
             parallel_flags: "-parallel=2" # reduce parallelism for postgres
             containers: [postgresql]
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-20.04
     env:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}
@@ -553,7 +544,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-20.04]
         name:
           - cass_es
           - cass_es8
@@ -583,7 +573,7 @@ jobs:
             persistence_type: sql
             persistence_driver: postgres12_pgx
             containers: [postgresql]
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-20.04
     env:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -204,12 +204,14 @@ jobs:
           cache: false  # do our own caching
 
       - name: Restore dependencies
+        if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
         uses: actions/cache/restore@v4
         with:
           path: ~/go/pkg/mod
           key: go-${{ runner.os }}${{ runner.arch }}-deps-${{ hashFiles('go.sum') }}
 
       - name: Restore build outputs
+        if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/go-build
@@ -632,6 +634,7 @@ jobs:
     if: always()
     name: Test Status
     needs:
+      - misc-checks
       - unit-test
       - integration-test
       - functional-test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -100,6 +100,29 @@ jobs:
         run: |
           cat "$GITHUB_OUTPUT"
 
+  pre-build:
+    name: Pre-build for cache
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-20.04]
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ env.COMMIT }}
+
+      - uses: actions/setup-go@v5
+        if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
+        with:
+          go-version-file: "go.mod"
+          check-latest: true
+
+      - run: make pre-build-functional-test-coverage
+        if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
+
   misc-checks:
     name: Misc checks
     strategy:
@@ -134,13 +157,10 @@ jobs:
       - run: make clean-bins ci-build-misc
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
 
-      - run: make build-tests
-        if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
-
   unit-test:
     if: ${{ inputs.run_single_functional_test != true }}
     name: Unit test
-    needs: [misc-checks, set-up-single-test]
+    needs: [pre-build, set-up-single-test]
     strategy:
       fail-fast: false
       matrix:
@@ -180,7 +200,7 @@ jobs:
   integration-test:
     if: ${{ inputs.run_single_functional_test != true && inputs.run_single_unit_test != true }}
     name: Integration test
-    needs: misc-checks
+    needs: pre-build
     strategy:
       fail-fast: false
       matrix:
@@ -225,7 +245,7 @@ jobs:
   functional-test:
     if: ${{ inputs.run_single_unit_test != true }}
     name: Functional test
-    needs: [misc-checks, set-up-single-test]
+    needs: [pre-build, set-up-single-test]
     strategy:
       fail-fast: false
       matrix:
@@ -314,7 +334,7 @@ jobs:
   functional-test-xdc:
     if: ${{ inputs.run_single_functional_test != true && inputs.run_single_unit_test != true }}
     name: Functional test xdc
-    needs: misc-checks
+    needs: pre-build
     strategy:
       fail-fast: false
       matrix:
@@ -382,7 +402,7 @@ jobs:
   functional-test-ndc:
     if: ${{ inputs.run_single_functional_test != true && inputs.run_single_unit_test != true }}
     name: Functional test ndc
-    needs: misc-checks
+    needs: pre-build
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ bins: temporal-server temporal-cassandra-tool temporal-sql-tool tdbg
 all: clean proto bins check test
 
 # Used in CI
-ci-build-misc: print-go-version proto go-generate buf-breaking bins temporal-server-debug shell-check copyright-check goimports-all gomodtidy ensure-no-changes
+ci-build-misc: print-go-version proto go-generate buf-breaking shell-check copyright-check goimports-all gomodtidy ensure-no-changes
 
 # Delete all build artifacts
 clean: clean-bins clean-test-results
@@ -391,7 +391,7 @@ integration-test-coverage: prepare-coverage-test
 	$(GOTESTSUM) --junitfile $(NEW_REPORT) -- \
 		$(INTEGRATION_TEST_DIRS) -shuffle on -timeout=$(TEST_TIMEOUT) $(TEST_TAG_FLAG) $(INTEGRATION_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
 
-# This should use the same build flags as functional-test-coverage for best build caching.
+# This should use the same build flags as functional-test-coverage and functional-test-{xdc,ndc}-coverage for best build caching.
 pre-build-functional-test-coverage: prepare-coverage-test
 	go test -c -o /dev/null $(FUNCTIONAL_TEST_ROOT) $(TEST_ARGS) $(TEST_TAG_FLAG) $(FUNCTIONAL_TEST_COVERPKG)
 

--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,11 @@ define NEWLINE
 
 endef
 
-# 35 minutes is the upper bound defined for all tests, the longer running ones at the time of writing are XDC tests.
+# 20 minutes is the upper bound defined for all tests. (Tests in CI take up to about 12:30 now)
 # If you change this, also change .github/workflows/run-tests.yml!
 # The timeout in the GH workflow must be larger than this to avoid GH timing out the action,
 # which causes the a job run to not produce any logs and hurts the debugging experience.
-TEST_TIMEOUT ?= 35m
+TEST_TIMEOUT ?= 20m
 
 PROTO_ROOT := proto
 PROTO_FILES = $(shell find ./$(PROTO_ROOT)/internal -name "*.proto")


### PR DESCRIPTION
## What changed?
- Change CI order to pre-build in one step, and let other functional tests depend only on that (instead of all of misc checks)
- Do manual caching of Go dependencies and build products so later steps can share results of earlier steps, and the overall cache size is much smaller
- Start dependencies earlier in job to hopefully be more stable
- Make test timeout tighter since they run faster now

## Why?
Shorten critical path, speed up CI