### PR TITLE
excluding workflow metadata query types from actions history

### DIFF
--- a/common/rpc/interceptor/telemetry_test.go
+++ b/common/rpc/interceptor/telemetry_test.go
@@ -25,6 +25,7 @@
 package interceptor
 
 import (
+	"go.temporal.io/api/query/v1"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,7 +49,6 @@ import (
 
 const (
 	startWorkflow = "StartWorkflowExecution"
-	queryWorkflow = "QueryWorkflow"
 )
 
 func TestEmitActionMetric(t *testing.T) {
@@ -76,11 +76,6 @@ func TestEmitActionMetric(t *testing.T) {
 			methodName:        startWorkflow,
 			fullName:          api.WorkflowServicePrefix + startWorkflow,
 			resp:              &workflowservice.StartWorkflowExecutionResponse{Started: true},
-			expectEmitMetrics: true,
-		},
-		{
-			methodName:        queryWorkflow,
-			fullName:          api.WorkflowServicePrefix + queryWorkflow,
 			expectEmitMetrics: true,
 		},
 		{
@@ -141,6 +136,25 @@ func TestEmitActionMetric(t *testing.T) {
 						Id:   "MESSAGE_ID",
 						Body: &updateResponseMessageBody,
 					},
+				},
+			},
+		},
+		{
+			methodName: queryWorkflow,
+			fullName:   api.WorkflowServicePrefix + queryWorkflow,
+			req: &workflowservice.QueryWorkflowRequest{
+				Query: &query.WorkflowQuery{
+					QueryType: "some_type",
+				},
+			},
+			expectEmitMetrics: true,
+		},
+		{
+			methodName: queryWorkflow,
+			fullName:   api.WorkflowServicePrefix + queryWorkflow,
+			req: &workflowservice.QueryWorkflowRequest{
+				Query: &query.WorkflowQuery{
+					QueryType: "__temporal_workflow_metadata",
 				},
 			},
 		},


### PR DESCRIPTION
## What changed?
We are excluding `__temporal_workflow_metadata` actions from metrics emission.

## Why?
The pricing committee has decided to not charge for [`__temporal_workflow_metadata`](https://www.notion.so/temporalio/Do-not-charge-for-built-in-metadata-query-10c8fc5677388033845ffb1aa504e4d4?pvs=4) for billable actions.

## How did you test it?
unit tests

## Potential risks
Potential to expose a workaround for query types to be supplied at the client level to bypass metrics for billing purposes.
