### PR TITLE
Clean up schedule functional tests and extend timeouts

### DIFF
--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -290,7 +290,7 @@ func (s *ScheduleFunctionalSuite) TestBasics() {
 	// list
 
 	visibilityResponse := s.getScheduleEntryFomVisibility(sid, func(ent *schedulepb.ScheduleListEntry) bool {
-		return ent.GetInfo().GetRecentActions() >= 2
+		return len(ent.GetInfo().GetRecentActions()) >= 2
 	})
 	s.Equal(sid, visibilityResponse.ScheduleId)
 	s.Equal(schSAValue.Data, visibilityResponse.SearchAttributes.IndexedFields[csaKeyword].Data)


### PR DESCRIPTION
## What changed?
- Extend timeouts on some schedule functional tests
- Allow ListSchedules to return extra schedules instead of exactly 1
- Clean up with t.Cleanup()

## Why?
less flaky tests