### PR TITLE
Reduce cassandra heap size in CI

### DIFF
--- a/develop/github/docker-compose.yml
+++ b/develop/github/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       - "9042:9042"
     environment:
       CASSANDRA_LISTEN_ADDRESS: 127.0.0.1
+      MAX_HEAP_SIZE: "2G"
+      HEAP_NEWSIZE: "200M"
 
   mysql:
     image: mysql:8.0.29-oracle


### PR DESCRIPTION
## What changed?
Run cassandra with smaller heap (2GB) in CI. Default (on standard GHA workers) comes out to 4GB, so this is 1/2 of what it was before.

## Why?
Try to reduce CI flakiness.