### PR TITLE
Improve historyrequire test helper

### DIFF
--- a/common/testing/historyrequire/history_require.go
+++ b/common/testing/historyrequire/history_require.go
@@ -507,6 +507,8 @@ func (h HistoryRequire) equalExpectedMapToActualAttributes(expectedMap map[strin
 }
 
 // parseHistory accept history in a formatHistoryEvents format and return slice of history events w/o attributes and maps of event attributes for every event.
+//
+//nolint:revive // cognitive complexity 29 (> max enabled 25)
 func (h HistoryRequire) parseHistory(history string) ([]*historypb.HistoryEvent, []map[string]any) {
 	if th, ok := h.t.(helper); ok {
 		th.Helper()

--- a/common/testing/historyrequire/history_require_test.go
+++ b/common/testing/historyrequire/history_require_test.go
@@ -1,0 +1,194 @@
+package historyrequire
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	historypb "go.temporal.io/api/history/v1"
+	test "go.temporal.io/server/common/testing"
+	"go.temporal.io/server/common/testing/testvars"
+)
+
+// sampleCompactHistory is used in almost every test.
+func sampleCompactHistory(t *testing.T) ([]*historypb.HistoryEvent, []map[string]any) {
+	hr := New(t)
+	hes, attrs := hr.parseHistory(`
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskFailed
+  5 v1 WorkflowTaskScheduled
+  6 v1 WorkflowTaskStarted
+  7 v1 WorkflowTaskCompleted
+  8 v1 ActivityTaskScheduled
+  9 v1 ActivityTaskStarted
+ 10 v1 ActivityTaskCompleted
+ 11 v1 WorkflowTaskScheduled
+ 12 v1 WorkflowTaskStarted
+ 13 v1 WorkflowTaskCompleted`)
+
+	require.Len(t, hes, 13)
+	require.Len(t, attrs, 13)
+	for _, attr := range attrs {
+		require.Nil(t, attr)
+	}
+	return hes, attrs
+}
+
+// Sanity check for history parser.
+func TestSampleCompactHistory(t *testing.T) {
+	sampleCompactHistory(t)
+}
+
+// Use this test to generate new sample history.
+func TestPrintHistoryEvents(t *testing.T) {
+	tv := testvars.New(t)
+
+	generator := test.InitializeHistoryEventGenerator(tv.NamespaceName(), tv.NamespaceID(), 0)
+
+	var historyEvents []*historypb.HistoryEvent
+	for generator.HasNextVertex() {
+		events := generator.GetNextVertices()
+		for _, event := range events {
+			historyEvent := event.GetData().(*historypb.HistoryEvent)
+			historyEvents = append(historyEvents, historyEvent)
+		}
+	}
+
+	hr := New(t)
+	hr.PrintHistoryEvents(historyEvents)
+	hr.PrintHistoryEventsCompact(historyEvents)
+}
+
+func TestEqualHistoryEventsWithVersion(t *testing.T) {
+	hr := New(t)
+	historyEvents, _ := sampleCompactHistory(t)
+
+	hr.EqualHistoryEvents(`
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskFailed
+  5 v1 WorkflowTaskScheduled
+  6 v1 WorkflowTaskStarted
+  7 v1 WorkflowTaskCompleted
+  8 v1 ActivityTaskScheduled
+  9 v1 ActivityTaskStarted
+ 10 v1 ActivityTaskCompleted
+ 11 v1 WorkflowTaskScheduled
+ 12 v1 WorkflowTaskStarted
+ 13 v1 WorkflowTaskCompleted`, historyEvents)
+}
+
+func TestEqualHistoryEventsWithoutVersion(t *testing.T) {
+	hr := New(t)
+	historyEvents, _ := sampleCompactHistory(t)
+
+	for _, event := range historyEvents {
+		event.Version = 0
+	}
+
+	hr.EqualHistoryEvents(`
+  1 WorkflowExecutionStarted
+  2 WorkflowTaskScheduled
+  3 WorkflowTaskStarted
+  4 WorkflowTaskFailed
+  5 WorkflowTaskScheduled
+  6 WorkflowTaskStarted
+  7 WorkflowTaskCompleted
+  8 ActivityTaskScheduled
+  9 ActivityTaskStarted
+ 10 ActivityTaskCompleted
+ 11 WorkflowTaskScheduled
+ 12 WorkflowTaskStarted
+ 13 WorkflowTaskCompleted`, historyEvents)
+}
+
+func TestEqualHistoryEventsWithoutEventID(t *testing.T) {
+	hr := New(t)
+
+	historyEvents, _ := sampleCompactHistory(t)
+
+	for _, event := range historyEvents {
+		event.EventId = 0
+		event.Version = 0
+	}
+
+	hr.EqualHistoryEvents(`
+WorkflowExecutionStarted
+WorkflowTaskScheduled
+WorkflowTaskStarted
+WorkflowTaskFailed
+WorkflowTaskScheduled
+WorkflowTaskStarted
+WorkflowTaskCompleted
+ActivityTaskScheduled
+ActivityTaskStarted
+ActivityTaskCompleted
+WorkflowTaskScheduled
+WorkflowTaskStarted
+WorkflowTaskCompleted`, historyEvents)
+}
+
+func TestEqualHistoryEventsSuffix(t *testing.T) {
+	hr := New(t)
+
+	historyEvents, _ := sampleCompactHistory(t)
+
+	for _, event := range historyEvents {
+		event.EventId = 0
+		event.Version = 0
+	}
+
+	hr.EqualHistoryEventsSuffix(`
+ActivityTaskCompleted
+WorkflowTaskScheduled
+WorkflowTaskStarted
+WorkflowTaskCompleted`, historyEvents)
+}
+
+func TestEqualHistoryEventsPrefix(t *testing.T) {
+	hr := New(t)
+	historyEvents, _ := sampleCompactHistory(t)
+
+	for _, event := range historyEvents {
+		event.EventId = 0
+		event.Version = 0
+	}
+
+	hr.EqualHistoryEventsPrefix(`
+WorkflowExecutionStarted
+WorkflowTaskScheduled
+WorkflowTaskStarted
+WorkflowTaskFailed
+WorkflowTaskScheduled`, historyEvents)
+}
+
+func TestParsePartialHistoryEvents(t *testing.T) {
+	hr := New(t)
+
+	historyEvents, attrs := hr.parseHistory(`
+  7 WorkflowTaskCompleted
+  8 ActivityTaskScheduled
+  9 ActivityTaskStarted
+ 10 ActivityTaskCompleted
+ 11 WorkflowTaskScheduled
+ 12 WorkflowTaskStarted
+ 13 WorkflowTaskCompleted`)
+
+	require.Len(t, historyEvents, 7)
+	require.Len(t, attrs, 7)
+
+	for i, event := range historyEvents {
+		require.Equal(t, int64(i+7), event.EventId)
+	}
+
+	hr.EqualHistoryEvents(`
+  7 WorkflowTaskCompleted
+  8 ActivityTaskScheduled
+  9 ActivityTaskStarted
+ 10 ActivityTaskCompleted
+ 11 WorkflowTaskScheduled
+ 12 WorkflowTaskStarted
+ 13 WorkflowTaskCompleted`, historyEvents)
+}

--- a/common/testing/historyrequire/history_require_test.go
+++ b/common/testing/historyrequire/history_require_test.go
@@ -192,3 +192,70 @@ func TestParsePartialHistoryEvents(t *testing.T) {
  12 WorkflowTaskStarted
  13 WorkflowTaskCompleted`, historyEvents)
 }
+
+func TestContainsHistoryEventsWithoutEventID(t *testing.T) {
+	hr := New(t)
+	historyEvents, _ := sampleCompactHistory(t)
+
+	historyEvents[3].Attributes = &historypb.HistoryEvent_WorkflowTaskFailedEventAttributes{
+		WorkflowTaskFailedEventAttributes: &historypb.WorkflowTaskFailedEventAttributes{
+			Identity: "Was wollen wir trinken",
+		},
+	}
+
+	hr.ContainsHistoryEvents(`
+WorkflowTaskFailed {"Identity": "Was wollen wir trinken"}
+WorkflowTaskScheduled
+WorkflowTaskStarted
+`, historyEvents)
+}
+
+func TestContainsHistoryEventsWithEventID(t *testing.T) {
+	hr := New(t)
+	historyEvents, _ := sampleCompactHistory(t)
+
+	historyEvents[4].Attributes = &historypb.HistoryEvent_WorkflowTaskScheduledEventAttributes{
+		WorkflowTaskScheduledEventAttributes: &historypb.WorkflowTaskScheduledEventAttributes{
+			Attempt: 2208,
+		},
+	}
+
+	hr.ContainsHistoryEvents(`
+4 WorkflowTaskFailed
+5 WorkflowTaskScheduled {"Attempt": 2208}
+6 WorkflowTaskStarted
+`, historyEvents)
+}
+
+func TestEmptyHistoryEvents(t *testing.T) {
+	hr := New(t)
+	emptyHistoryEvents := make([]*historypb.HistoryEvent, 0)
+
+	hr.EqualHistoryEvents(``, emptyHistoryEvents)
+	hr.EqualHistoryEvents(``, nil)
+	hr.EqualHistoryEvents(`
+`, emptyHistoryEvents)
+	hr.EqualHistoryEvents(`
+`, nil)
+
+	hr.EqualHistoryEventsPrefix(``, emptyHistoryEvents)
+	hr.EqualHistoryEventsPrefix(``, nil)
+	hr.EqualHistoryEventsPrefix(`
+`, emptyHistoryEvents)
+	hr.EqualHistoryEventsPrefix(`
+`, nil)
+
+	hr.EqualHistoryEventsSuffix(``, emptyHistoryEvents)
+	hr.EqualHistoryEventsSuffix(``, nil)
+	hr.EqualHistoryEventsSuffix(`
+`, emptyHistoryEvents)
+	hr.EqualHistoryEventsSuffix(`
+`, nil)
+
+	hr.ContainsHistoryEvents(``, emptyHistoryEvents)
+	hr.ContainsHistoryEvents(``, nil)
+	hr.ContainsHistoryEvents(`
+`, emptyHistoryEvents)
+	hr.ContainsHistoryEvents(`
+`, nil)
+}

--- a/common/testing/historyrequire/history_require_test.go
+++ b/common/testing/historyrequire/history_require_test.go
@@ -1,3 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package historyrequire
 
 import (

--- a/tests/update_workflow_sdk_test.go
+++ b/tests/update_workflow_sdk_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
+	historypb "go.temporal.io/api/history/v1"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -119,20 +120,14 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TimeoutWorkflowAfterUpdateAc
 	s.NoError(err)
 
 	// Wait for the first WFT to complete.
-	// TODO: replace with s.WaitForHistoryEvents when its ready.
-	s.Eventually(func() bool {
-		// Wait until the first WFT completes.
-		h := s.GetHistory(s.Namespace(), tv.WorkflowExecution())
-		if len(h) == 4 {
-			s.EqualHistoryEvents(`
+	s.WaitForHistoryEvents(`
   1 WorkflowExecutionStarted
   2 WorkflowTaskScheduled
   3 WorkflowTaskStarted
-  4 WorkflowTaskCompleted`, h)
-			return true
-		}
-		return false
-	}, 1*time.Second, 200*time.Millisecond)
+  4 WorkflowTaskCompleted`,
+		func() []*historypb.HistoryEvent {
+			return s.GetHistory(s.Namespace(), tv.WorkflowExecution())
+		}, 1*time.Second, 200*time.Millisecond)
 
 	updateHandle, err := s.updateWorkflowWaitAccepted(ctx, tv, "my-update-arg")
 	s.NoError(err)
@@ -179,20 +174,14 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TerminateWorkflowAfterUpdate
 	wfRun := s.startWorkflow(ctx, tv, workflowFn)
 
 	// Wait for the first WFT to complete.
-	// TODO: replace with s.WaitForHistoryEvents when its ready.
-	s.Eventually(func() bool {
-		// Wait until the first WFT completes.
-		h := s.GetHistory(s.Namespace(), tv.WorkflowExecution())
-		if len(h) == 4 {
-			s.EqualHistoryEvents(`
+	s.WaitForHistoryEvents(`
   1 WorkflowExecutionStarted
   2 WorkflowTaskScheduled
   3 WorkflowTaskStarted
-  4 WorkflowTaskCompleted`, h)
-			return true
-		}
-		return false
-	}, 1*time.Second, 200*time.Millisecond)
+  4 WorkflowTaskCompleted`,
+		func() []*historypb.HistoryEvent {
+			return s.GetHistory(s.Namespace(), tv.WorkflowExecution())
+		}, 1*time.Second, 200*time.Millisecond)
 
 	updateHandle, err := s.updateWorkflowWaitAccepted(ctx, tv, "my-update-arg")
 	s.NoError(err)

--- a/tests/update_workflow_sdk_test.go
+++ b/tests/update_workflow_sdk_test.go
@@ -30,8 +30,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
-	historypb "go.temporal.io/api/history/v1"
-
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
@@ -125,9 +123,8 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TimeoutWorkflowAfterUpdateAc
   2 WorkflowTaskScheduled
   3 WorkflowTaskStarted
   4 WorkflowTaskCompleted`,
-		func() []*historypb.HistoryEvent {
-			return s.GetHistory(s.Namespace(), tv.WorkflowExecution())
-		}, 1*time.Second, 200*time.Millisecond)
+		s.GetHistoryFunc(tv.NamespaceName().String(), tv.WorkflowExecution()),
+		1*time.Second, 200*time.Millisecond)
 
 	updateHandle, err := s.updateWorkflowWaitAccepted(ctx, tv, "my-update-arg")
 	s.NoError(err)
@@ -179,9 +176,8 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TerminateWorkflowAfterUpdate
   2 WorkflowTaskScheduled
   3 WorkflowTaskStarted
   4 WorkflowTaskCompleted`,
-		func() []*historypb.HistoryEvent {
-			return s.GetHistory(s.Namespace(), tv.WorkflowExecution())
-		}, 1*time.Second, 200*time.Millisecond)
+		s.GetHistoryFunc(tv.NamespaceName().String(), tv.WorkflowExecution()),
+		1*time.Second, 200*time.Millisecond)
 
 	updateHandle, err := s.updateWorkflowWaitAccepted(ctx, tv, "my-update-arg")
 	s.NoError(err)

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -38,6 +38,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	filterpb "go.temporal.io/api/filter/v1"
+	historypb "go.temporal.io/api/history/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
 	replicationpb "go.temporal.io/api/replication/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -388,62 +389,41 @@ func (s *AdvVisCrossDCTestSuite) TestSearchAttributes() {
 	s.NoError(err)
 
 	// check terminate done
-	executionTerminated := false
 	getHistoryReq := &workflowservice.GetWorkflowExecutionHistoryRequest{
 		Namespace: namespace,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: id,
 		},
 	}
-GetHistoryLoop:
-	for i := 0; i < 10; i++ {
-		historyResponse, err := client1.GetWorkflowExecutionHistory(testcore.NewContext(), getHistoryReq)
-		s.NoError(err)
-		history := historyResponse.History
 
-		lastEvent := history.Events[len(history.Events)-1]
-		if lastEvent.EventType != enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED {
-			s.logger.Warn("Execution not terminated yet")
-			time.Sleep(100 * time.Millisecond)
-			continue GetHistoryLoop
-		}
-		s.EqualHistory(`
+	s.WaitForHistory(`
   1 v1 WorkflowExecutionStarted
   2 v1 WorkflowTaskScheduled
   3 v1 WorkflowTaskStarted
   4 v1 WorkflowTaskCompleted
   5 v1 UpsertWorkflowSearchAttributes
-  6 v1 WorkflowExecutionTerminated {"Details":{"Payloads":[{"Data":"\"terminate details\""}]},"Identity":"worker1","Reason":"force terminate to make sure standby process tasks"}`, history)
-		executionTerminated = true
-		break GetHistoryLoop
-	}
-	s.True(executionTerminated)
+  6 v1 WorkflowExecutionTerminated {"Details":{"Payloads":[{"Data":"\"terminate details\""}]},"Identity":"worker1","Reason":"force terminate to make sure standby process tasks"}`,
+		func() *historypb.History {
+			historyResponse, err := client1.GetWorkflowExecutionHistory(testcore.NewContext(), getHistoryReq)
+			s.NoError(err)
+			return historyResponse.History
+		}, 1*time.Second, 100*time.Millisecond)
 
 	// check history replicated to the other cluster
-	var historyResponse *workflowservice.GetWorkflowExecutionHistoryResponse
-	eventsReplicated := false
-GetHistoryLoop2:
-	for i := 0; i < numOfRetry; i++ {
-		historyResponse, err = client2.GetWorkflowExecutionHistory(testcore.NewContext(), getHistoryReq)
-		if err == nil {
-			history := historyResponse.History
-			lastEvent := history.Events[len(history.Events)-1]
-			if lastEvent.EventType == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED {
-				s.EqualHistory(`
+	s.WaitForHistory(`
   1 v1 WorkflowExecutionStarted
   2 v1 WorkflowTaskScheduled
   3 v1 WorkflowTaskStarted
   4 v1 WorkflowTaskCompleted
   5 v1 UpsertWorkflowSearchAttributes
-  6 v1 WorkflowExecutionTerminated {"Details":{"Payloads":[{"Data":"\"terminate details\""}]},"Identity":"worker1","Reason":"force terminate to make sure standby process tasks"}`, history)
-				eventsReplicated = true
-				break GetHistoryLoop2
+  6 v1 WorkflowExecutionTerminated {"Details":{"Payloads":[{"Data":"\"terminate details\""}]},"Identity":"worker1","Reason":"force terminate to make sure standby process tasks"}`,
+		func() *historypb.History {
+			historyResponse, err := client2.GetWorkflowExecutionHistory(testcore.NewContext(), getHistoryReq)
+			if err != nil {
+				return nil
 			}
-		}
-		time.Sleep(waitTimeInMs * time.Millisecond)
-	}
-	s.NoError(err)
-	s.True(eventsReplicated)
+			return historyResponse.History
+		}, waitTimeInMs*numOfRetry*time.Millisecond, waitTimeInMs*time.Millisecond)
 
 	terminatedListRequest := &workflowservice.ListWorkflowExecutionsRequest{
 		Namespace: namespace,

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -408,12 +408,12 @@ GetHistoryLoop:
 			continue GetHistoryLoop
 		}
 		s.EqualHistory(`
-  1 1 WorkflowExecutionStarted
-  2 1 WorkflowTaskScheduled
-  3 1 WorkflowTaskStarted
-  4 1 WorkflowTaskCompleted
-  5 1 UpsertWorkflowSearchAttributes
-  6 1 WorkflowExecutionTerminated {"Details":{"Payloads":[{"Data":"\"terminate details\""}]},"Identity":"worker1","Reason":"force terminate to make sure standby process tasks"}`, history)
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskCompleted
+  5 v1 UpsertWorkflowSearchAttributes
+  6 v1 WorkflowExecutionTerminated {"Details":{"Payloads":[{"Data":"\"terminate details\""}]},"Identity":"worker1","Reason":"force terminate to make sure standby process tasks"}`, history)
 		executionTerminated = true
 		break GetHistoryLoop
 	}
@@ -430,12 +430,12 @@ GetHistoryLoop2:
 			lastEvent := history.Events[len(history.Events)-1]
 			if lastEvent.EventType == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED {
 				s.EqualHistory(`
-  1 1 WorkflowExecutionStarted
-  2 1 WorkflowTaskScheduled
-  3 1 WorkflowTaskStarted
-  4 1 WorkflowTaskCompleted
-  5 1 UpsertWorkflowSearchAttributes
-  6 1 WorkflowExecutionTerminated {"Details":{"Payloads":[{"Data":"\"terminate details\""}]},"Identity":"worker1","Reason":"force terminate to make sure standby process tasks"}`, history)
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskCompleted
+  5 v1 UpsertWorkflowSearchAttributes
+  6 v1 WorkflowExecutionTerminated {"Details":{"Payloads":[{"Data":"\"terminate details\""}]},"Identity":"worker1","Reason":"force terminate to make sure standby process tasks"}`, history)
 				eventsReplicated = true
 				break GetHistoryLoop2
 			}

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -375,11 +375,11 @@ func (s *FunctionalClustersTestSuite) TestSimpleWorkflowFailover() {
 		if err == nil && len(historyResponse.History.Events) == 5 {
 			eventsReplicated = true
 			s.EqualHistory(`
-  1 1 WorkflowExecutionStarted
-  2 1 WorkflowTaskScheduled
-  3 1 WorkflowTaskStarted
-  4 1 WorkflowTaskCompleted
-  5 1 ActivityTaskScheduled`, historyResponse.History)
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskCompleted
+  5 v1 ActivityTaskScheduled`, historyResponse.History)
 			break
 		}
 		time.Sleep(1 * time.Second)
@@ -445,17 +445,17 @@ func (s *FunctionalClustersTestSuite) TestSimpleWorkflowFailover() {
 		if err == nil && len(historyResponse.History.Events) == 11 {
 			eventsReplicated = true
 			s.EqualHistory(`
-  1 1 WorkflowExecutionStarted
-  2 1 WorkflowTaskScheduled
-  3 1 WorkflowTaskStarted
-  4 1 WorkflowTaskCompleted
-  5 1 ActivityTaskScheduled
-  6 2 ActivityTaskStarted
-  7 2 ActivityTaskCompleted
-  8 2 WorkflowTaskScheduled
-  9 2 WorkflowTaskStarted
- 10 2 WorkflowTaskCompleted
- 11 2 WorkflowExecutionCompleted`, historyResponse.History)
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskCompleted
+  5 v1 ActivityTaskScheduled
+  6 v2 ActivityTaskStarted
+  7 v2 ActivityTaskCompleted
+  8 v2 WorkflowTaskScheduled
+  9 v2 WorkflowTaskStarted
+ 10 v2 WorkflowTaskCompleted
+ 11 v2 WorkflowExecutionCompleted`, historyResponse.History)
 			break
 		}
 		time.Sleep(1 * time.Second)
@@ -872,14 +872,14 @@ GetHistoryLoop:
 		}
 
 		s.EqualHistory(`
-  1 1 WorkflowExecutionStarted
-  2 1 WorkflowTaskScheduled
-  3 1 WorkflowTaskStarted
-  4 1 WorkflowTaskCompleted
-  5 1 ActivityTaskScheduled
-  6 2 ActivityTaskTimedOut
-  7 2 WorkflowTaskScheduled
-  8 2 WorkflowExecutionTerminated  {"Details":{"Payloads":[{"Data":"\"terminate details\""}]},"Identity":"worker1","Reason":"terminate reason"}`, history)
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskCompleted
+  5 v1 ActivityTaskScheduled
+  6 v2 ActivityTaskTimedOut
+  7 v2 WorkflowTaskScheduled
+  8 v2 WorkflowExecutionTerminated  {"Details":{"Payloads":[{"Data":"\"terminate details\""}]},"Identity":"worker1","Reason":"terminate reason"}`, history)
 
 		executionTerminated = true
 		break GetHistoryLoop
@@ -897,14 +897,14 @@ GetHistoryLoop2:
 			lastEvent := history.Events[len(history.Events)-1]
 			if lastEvent.EventType == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED {
 				s.EqualHistory(`
-  1 1 WorkflowExecutionStarted
-  2 1 WorkflowTaskScheduled
-  3 1 WorkflowTaskStarted
-  4 1 WorkflowTaskCompleted
-  5 1 ActivityTaskScheduled
-  6 2 ActivityTaskTimedOut
-  7 2 WorkflowTaskScheduled
-  8 2 WorkflowExecutionTerminated  {"Details":{"Payloads":[{"Data":"\"terminate details\""}]},"Identity":"worker1","Reason":"terminate reason"}`, history)
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskCompleted
+  5 v1 ActivityTaskScheduled
+  6 v2 ActivityTaskTimedOut
+  7 v2 WorkflowTaskScheduled
+  8 v2 WorkflowExecutionTerminated  {"Details":{"Payloads":[{"Data":"\"terminate details\""}]},"Identity":"worker1","Reason":"terminate reason"}`, history)
 				eventsReplicated = true
 				break GetHistoryLoop2
 			}
@@ -1063,28 +1063,28 @@ func (s *FunctionalClustersTestSuite) TestResetWorkflowFailover() {
 	getHistoryResp, err := client1.GetWorkflowExecutionHistory(testcore.NewContext(), getHistoryReq)
 	s.NoError(err)
 	s.EqualHistory(`
-  1 1 WorkflowExecutionStarted
-  2 1 WorkflowTaskScheduled
-  3 1 WorkflowExecutionSignaled
-  4 1 WorkflowTaskStarted
-  5 1 WorkflowTaskFailed
-  6 1 WorkflowTaskScheduled
-  7 2 WorkflowTaskStarted
-  8 2 WorkflowTaskCompleted
-  9 2 WorkflowExecutionCompleted`, getHistoryResp.History)
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowExecutionSignaled
+  4 v1 WorkflowTaskStarted
+  5 v1 WorkflowTaskFailed
+  6 v1 WorkflowTaskScheduled
+  7 v2 WorkflowTaskStarted
+  8 v2 WorkflowTaskCompleted
+  9 v2 WorkflowExecutionCompleted`, getHistoryResp.History)
 
 	getHistoryResp, err = client2.GetWorkflowExecutionHistory(testcore.NewContext(), getHistoryReq)
 	s.NoError(err)
 	s.EqualHistory(`
-  1 1 WorkflowExecutionStarted
-  2 1 WorkflowTaskScheduled
-  3 1 WorkflowExecutionSignaled
-  4 1 WorkflowTaskStarted
-  5 1 WorkflowTaskFailed
-  6 1 WorkflowTaskScheduled
-  7 2 WorkflowTaskStarted
-  8 2 WorkflowTaskCompleted
-  9 2 WorkflowExecutionCompleted`, getHistoryResp.History)
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowExecutionSignaled
+  4 v1 WorkflowTaskStarted
+  5 v1 WorkflowTaskFailed
+  6 v1 WorkflowTaskScheduled
+  7 v2 WorkflowTaskStarted
+  8 v2 WorkflowTaskCompleted
+  9 v2 WorkflowExecutionCompleted`, getHistoryResp.History)
 }
 
 func (s *FunctionalClustersTestSuite) TestContinueAsNewFailover() {
@@ -1356,15 +1356,15 @@ func (s *FunctionalClustersTestSuite) TestSignalFailover() {
 		historyResponse, err = client2.GetWorkflowExecutionHistory(testcore.NewContext(), getHistoryReq)
 		if err == nil && len(historyResponse.History.Events) == 9 {
 			s.EqualHistory(`
-  1 1 WorkflowExecutionStarted
-  2 1 WorkflowTaskScheduled
-  3 1 WorkflowTaskStarted
-  4 1 WorkflowTaskCompleted
-  5 1 WorkflowExecutionSignaled
-  6 1 WorkflowExecutionSignaled
-  7 1 WorkflowTaskScheduled
-  8 1 WorkflowTaskStarted
-  9 1 WorkflowTaskCompleted`, historyResponse.History)
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskCompleted
+  5 v1 WorkflowExecutionSignaled
+  6 v1 WorkflowExecutionSignaled
+  7 v1 WorkflowTaskScheduled
+  8 v1 WorkflowTaskStarted
+  9 v1 WorkflowTaskCompleted`, historyResponse.History)
 			eventsReplicated = true
 			break
 		}
@@ -1414,20 +1414,20 @@ func (s *FunctionalClustersTestSuite) TestSignalFailover() {
 		historyResponse, err = client2.GetWorkflowExecutionHistory(testcore.NewContext(), getHistoryReq)
 		if err == nil && len(historyResponse.History.Events) == 14 {
 			s.EqualHistory(`
-  1 1 WorkflowExecutionStarted
-  2 1 WorkflowTaskScheduled
-  3 1 WorkflowTaskStarted
-  4 1 WorkflowTaskCompleted
-  5 1 WorkflowExecutionSignaled
-  6 1 WorkflowExecutionSignaled
-  7 1 WorkflowTaskScheduled
-  8 1 WorkflowTaskStarted
-  9 1 WorkflowTaskCompleted
- 10 2 WorkflowExecutionSignaled
- 11 2 WorkflowExecutionSignaled
- 12 2 WorkflowTaskScheduled
- 13 2 WorkflowTaskStarted
- 14 2 WorkflowTaskCompleted`, historyResponse.History)
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskCompleted
+  5 v1 WorkflowExecutionSignaled
+  6 v1 WorkflowExecutionSignaled
+  7 v1 WorkflowTaskScheduled
+  8 v1 WorkflowTaskStarted
+  9 v1 WorkflowTaskCompleted
+ 10 v2 WorkflowExecutionSignaled
+ 11 v2 WorkflowExecutionSignaled
+ 12 v2 WorkflowTaskScheduled
+ 13 v2 WorkflowTaskStarted
+ 14 v2 WorkflowTaskCompleted`, historyResponse.History)
 			eventsReplicated = true
 			break
 		}
@@ -1931,11 +1931,11 @@ func (s *FunctionalClustersTestSuite) TestCronWorkflowStartAndFailover() {
 	s.True(wfCompleted)
 	events := s.getHistory(client2, namespace, executions[0])
 	s.EqualHistoryEvents(`
-  1 1 WorkflowExecutionStarted
-  2 2 WorkflowTaskScheduled
-  3 2 WorkflowTaskStarted
-  4 2 WorkflowTaskCompleted
-  5 2 WorkflowExecutionCompleted`, events)
+  1 v1 WorkflowExecutionStarted
+  2 v2 WorkflowTaskScheduled
+  3 v2 WorkflowTaskStarted
+  4 v2 WorkflowTaskCompleted
+  5 v2 WorkflowExecutionCompleted`, events)
 
 	// terminate the remaining cron
 	_, err = client2.TerminateWorkflowExecution(testcore.NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
@@ -2035,11 +2035,11 @@ func (s *FunctionalClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
 	s.Equal(1, wfCompletionCount)
 	events := s.getHistory(client1, namespace, executions[0])
 	s.EqualHistoryEvents(`
-  1 1 WorkflowExecutionStarted
-  2 1 WorkflowTaskScheduled
-  3 1 WorkflowTaskStarted
-  4 1 WorkflowTaskCompleted
-  5 1 WorkflowExecutionCompleted`, events)
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskCompleted
+  5 v1 WorkflowExecutionCompleted`, events)
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
@@ -2048,11 +2048,11 @@ func (s *FunctionalClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
 	s.Equal(2, wfCompletionCount)
 	events = s.getHistory(client2, namespace, executions[1])
 	s.EqualHistoryEvents(`
-  1 1 WorkflowExecutionStarted
-  2 2 WorkflowTaskScheduled
-  3 2 WorkflowTaskStarted
-  4 2 WorkflowTaskCompleted
-  5 2 WorkflowExecutionCompleted`, events)
+  1 v1 WorkflowExecutionStarted
+  2 v2 WorkflowTaskScheduled
+  3 v2 WorkflowTaskStarted
+  4 v2 WorkflowTaskCompleted
+  5 v2 WorkflowExecutionCompleted`, events)
 
 	_, err = client2.TerminateWorkflowExecution(testcore.NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: namespace,
@@ -2145,22 +2145,22 @@ func (s *FunctionalClustersTestSuite) TestWorkflowRetryStartAndFailover() {
 	s.NoError(err)
 	events := s.getHistory(client2, namespace, executions[0])
 	s.EqualHistoryEvents(`
-  1 1 WorkflowExecutionStarted {"Attempt":1}
-  2 1 WorkflowTaskScheduled
-  3 2 WorkflowTaskStarted
-  4 2 WorkflowTaskCompleted
-  5 2 WorkflowExecutionFailed`, events)
+  1 v1 WorkflowExecutionStarted {"Attempt":1}
+  2 v1 WorkflowTaskScheduled
+  3 v2 WorkflowTaskStarted
+  4 v2 WorkflowTaskCompleted
+  5 v2 WorkflowExecutionFailed`, events)
 
 	// second attempt
 	_, err = poller2.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	events = s.getHistory(client2, namespace, executions[1])
 	s.EqualHistoryEvents(`
-  1 2 WorkflowExecutionStarted {"Attempt":2}
-  2 2 WorkflowTaskScheduled
-  3 2 WorkflowTaskStarted
-  4 2 WorkflowTaskCompleted
-  5 2 WorkflowExecutionFailed`, events)
+  1 v2 WorkflowExecutionStarted {"Attempt":2}
+  2 v2 WorkflowTaskScheduled
+  3 v2 WorkflowTaskStarted
+  4 v2 WorkflowTaskCompleted
+  5 v2 WorkflowExecutionFailed`, events)
 }
 
 func (s *FunctionalClustersTestSuite) TestWorkflowRetryFailAndFailover() {
@@ -2252,11 +2252,11 @@ func (s *FunctionalClustersTestSuite) TestWorkflowRetryFailAndFailover() {
 	s.NoError(err)
 	events := s.getHistory(client1, namespace, executions[0])
 	s.EqualHistoryEvents(`
-  1 1 WorkflowExecutionStarted {"Attempt":1}
-  2 1 WorkflowTaskScheduled
-  3 1 WorkflowTaskStarted
-  4 1 WorkflowTaskCompleted
-  5 1 WorkflowExecutionFailed`, events)
+  1 v1 WorkflowExecutionStarted {"Attempt":1}
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskCompleted
+  5 v1 WorkflowExecutionFailed`, events)
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
@@ -2264,11 +2264,11 @@ func (s *FunctionalClustersTestSuite) TestWorkflowRetryFailAndFailover() {
 	s.NoError(err)
 	events = s.getHistory(client2, namespace, executions[1])
 	s.EqualHistoryEvents(`
-  1 1 WorkflowExecutionStarted {"Attempt":2}
-  2 1 WorkflowTaskScheduled
-  3 2 WorkflowTaskStarted
-  4 2 WorkflowTaskCompleted
-  5 2 WorkflowExecutionFailed`, events)
+  1 v1 WorkflowExecutionStarted {"Attempt":2}
+  2 v1 WorkflowTaskScheduled
+  3 v2 WorkflowTaskStarted
+  4 v2 WorkflowTaskCompleted
+  5 v2 WorkflowExecutionFailed`, events)
 }
 
 func (s *FunctionalClustersTestSuite) TestActivityHeartbeatFailover() {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Improve `historyrequire` test helper. Added:
```go
EqualHistoryEventsSuffix()
EqualHistoryEventsPrefix()
ContainsHistoryEvents()
WaitForHistoryEvents()
WaitForHistoryEventsSuffix()
```
and corresponding `History` functions.

To support this (especially `*Suffix` functions), I had to make `EventID` field optional. And to differentiate between `EventID` and `Version` I had to prefix version with `v`. This are valid histories to require:
```
  1 v1 WorkflowExecutionStarted
  2 v1 WorkflowTaskScheduled
  3 v1 WorkflowTaskStarted

  v1 WorkflowExecutionStarted
  v1 WorkflowTaskScheduled
  v1 WorkflowTaskStarted

  1 WorkflowExecutionStarted
  2 WorkflowTaskScheduled
  3 WorkflowTaskStarted

  WorkflowExecutionStarted
  WorkflowTaskScheduled
  WorkflowTaskStarted
```

Also used it in few places to fight with test falkines.

## Why?
<!-- Tell your future self why have you made these changes -->
More test helpers is better!

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit test and run all tests that uses it.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks, but I had to change number of existing tests to support `vX` version format.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.