### PR TITLE
Ignore RequestCancelNexusOperation commands if operation completion is buffered

### DIFF
--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -220,7 +220,11 @@ func (ch *commandHandler) HandleCancelCommand(
 	if err != nil {
 		return err
 	}
-	if !nexusoperations.TransitionCanceled.Possible(op) {
+	// The operation is already in a terminal state and the terminal NexusOperation event has not just been buffered.
+	// We allow the workflow to request canceling an operation that has just completed while a workflow task is in
+	// flight since it cannot know about the state of the operation.
+	// TODO(bergundy): When we support state machine deletion, this condition will have to change.
+	if !nexusoperations.TransitionCanceled.Possible(op) && !ms.HasAnyBufferedEvent(makeNexusOperationTerminalEventFilter(attrs.ScheduledEventId)) {
 		return workflow.FailWorkflowTaskError{
 			Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES,
 			Message: fmt.Sprintf("requested cancelation for an already complete operation with scheduled event ID of %d", attrs.ScheduledEventId),
@@ -247,9 +251,6 @@ func (ch *commandHandler) HandleCancelCommand(
 		}
 	}
 
-	// TODO(bergundy): When we support machine deletion, this err may be an hsm.ErrStateMachineNotFound.
-	// We'll need to check buffered events and verify that there aren't any terminal events in there.
-	// Ideally the framework can abstract that for us though.
 	return err
 }
 
@@ -259,4 +260,21 @@ func RegisterCommandHandlers(reg *workflow.CommandHandlerRegistry, endpointRegis
 		return err
 	}
 	return reg.Register(enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION, h.HandleCancelCommand)
+}
+
+func makeNexusOperationTerminalEventFilter(scheduledEventID int64) func(event *historypb.HistoryEvent) bool {
+	return func(event *historypb.HistoryEvent) bool {
+		switch event.EventType {
+		case enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED:
+			return event.GetNexusOperationCompletedEventAttributes().GetScheduledEventId() == scheduledEventID
+		case enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED:
+			return event.GetNexusOperationFailedEventAttributes().GetScheduledEventId() == scheduledEventID
+		case enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED:
+			return event.GetNexusOperationCanceledEventAttributes().GetScheduledEventId() == scheduledEventID
+		case enumspb.EVENT_TYPE_NEXUS_OPERATION_TIMED_OUT:
+			return event.GetNexusOperationTimedOutEventAttributes().GetScheduledEventId() == scheduledEventID
+		default:
+			return false
+		}
+	}
 }


### PR DESCRIPTION
## Why?

More intuitive experience and consistent with activities.

## How did you test it?

Unit test.