### PR TITLE
Use latest minor of actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -269,8 +269,8 @@ jobs:
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--unit-test
           path: .testoutput
-          retention-days: 14
           include-hidden-files: true
+          retention-days: 28
 
       # Ensure this doesn't contribute to the junit output.
       - name: Flaky Unit Test Detection
@@ -337,8 +337,8 @@ jobs:
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--integration-test
           path: .testoutput
-          retention-days: 14
           include-hidden-files: true
+          retention-days: 28
 
       # Ensure this doesn't contribute to the junit output.
       - name: Flaky Integration Test Detection
@@ -459,8 +459,8 @@ jobs:
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--${{matrix.runs-on}}--${{matrix.name}}--${{matrix.shard_index}}--functional-test
           path: .testoutput
-          retention-days: 14
           include-hidden-files: true
+          retention-days: 28
 
       # Ensure this doesn't contribute to the junit output.
       - name: Flaky Functional Test Detection
@@ -555,8 +555,8 @@ jobs:
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--${{matrix.name}}--functional-test-xdc
           path: .testoutput
-          retention-days: 14
           include-hidden-files: true
+          retention-days: 28
 
       # Ensure this doesn't contribute to the junit output.
       - name: Flaky Functional XDC Test Detection
@@ -652,8 +652,8 @@ jobs:
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--${{matrix.name}}--functional-test-ndc
           path: .testoutput
-          retention-days: 14
           include-hidden-files: true
+          retention-days: 28
 
       # Ensure this doesn't contribute to the junit output.
       - name: Flaky Functional NDC Test Detection

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -264,7 +264,7 @@ jobs:
           TEST_TIMEOUT: ${{ needs.set-up-single-test.outputs.test_timeout }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && !inputs.run_single_unit_test }}
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--unit-test
@@ -332,7 +332,7 @@ jobs:
         run: make integration-test-coverage
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--integration-test
@@ -454,7 +454,7 @@ jobs:
           TEST_ARGS: ${{ needs.set-up-single-test.outputs.single_test_args }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && !inputs.run_single_functional_test }}
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--${{matrix.runs-on}}--${{matrix.name}}--${{matrix.shard_index}}--functional-test
@@ -550,7 +550,7 @@ jobs:
         run: make functional-test-xdc-coverage
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--${{matrix.name}}--functional-test-xdc
@@ -647,7 +647,7 @@ jobs:
         run: make functional-test-ndc-coverage
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--${{matrix.name}}--functional-test-ndc


### PR DESCRIPTION
Also increased retention to 28 days.

## Why?

Avoid strict version pinning so we can get updates and bug fixes.