### PR TITLE
Bump Go to 1.23.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.temporal.io/server
 
-go 1.22.6
+go 1.23.2
 
 retract (
 	v1.26.1 // Contains retractions only.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

WISOTT

PS: base-builder is already 1.23.2 (see [link](https://github.com/temporalio/docker-builds/blob/ca17b250c72eb42018855c13d59588fb7229c4f4/docker/base-images/base-builder.Dockerfile#L4))

PPS: other docker-build jobs use this project's `go.mod` to install the correct Go version (see [search](https://github.com/search?q=repo%3Atemporalio%2Fdocker-builds%20go.mod&type=code))

PPPS: same for goreleaser (see [link](https://github.com/temporalio/temporal/blob/main/.github/workflows/goreleaser.yml#L23))


## Why?
<!-- Tell your future self why have you made these changes -->

Security.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
