### PR TITLE
Fix flaky TestHistoryReplicationSignalsAndUpdatesTestSuite

### DIFF
--- a/common/testing/testvars/test_vars.go
+++ b/common/testing/testvars/test_vars.go
@@ -171,9 +171,9 @@ func (tv *TestVars) WorkflowExecution(key ...string) *commonpb.WorkflowExecution
 	}
 }
 
-func (tv *TestVars) UpdateRef() *updatepb.UpdateRef {
+func (tv *TestVars) UpdateRef(key ...string) *updatepb.UpdateRef {
 	return &updatepb.UpdateRef{
-		UpdateId:          tv.UpdateID(),
+		UpdateId:          tv.UpdateID(key...),
 		WorkflowExecution: tv.WorkflowExecution(),
 	}
 }

--- a/tests/update_workflow_suite_base.go
+++ b/tests/update_workflow_suite_base.go
@@ -106,11 +106,8 @@ func (s *WorkflowUpdateBaseSuite) waitUpdateAdmitted(tv *testvars.TestVars, upda
 	s.T().Helper()
 	s.Eventuallyf(func() bool {
 		pollResp, pollErr := s.FrontendClient().PollWorkflowExecutionUpdate(testcore.NewContext(), &workflowservice.PollWorkflowExecutionUpdateRequest{
-			Namespace: s.Namespace(),
-			UpdateRef: &updatepb.UpdateRef{
-				WorkflowExecution: tv.WorkflowExecution(),
-				UpdateId:          tv.UpdateID(updateID),
-			},
+			Namespace:  s.Namespace(),
+			UpdateRef:  tv.UpdateRef(updateID),
 			WaitPolicy: &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED},
 		})
 
@@ -126,7 +123,7 @@ func (s *WorkflowUpdateBaseSuite) waitUpdateAdmitted(tv *testvars.TestVars, upda
 
 		// Poll beat send in race - poll again!
 		return false
-	}, 5*time.Second, 10*time.Millisecond, "update %s did not reach Admitted stage", updateID)
+	}, 5*time.Second, 10*time.Millisecond, "update %s did not reach Admitted stage", tv.UpdateID(updateID))
 }
 
 func (s *WorkflowUpdateBaseSuite) startWorkflow(tv *testvars.TestVars) *testvars.TestVars {

--- a/tests/update_workflow_suite_base.go
+++ b/tests/update_workflow_suite_base.go
@@ -26,9 +26,9 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	updatepb "go.temporal.io/api/update/v1"
@@ -104,25 +104,15 @@ func (s *WorkflowUpdateBaseSuite) sendUpdateInternal(
 
 func (s *WorkflowUpdateBaseSuite) waitUpdateAdmitted(tv *testvars.TestVars, updateID string) {
 	s.T().Helper()
-	s.Eventuallyf(func() bool {
+	s.EventuallyWithTf(func(collect *assert.CollectT) {
 		pollResp, pollErr := s.FrontendClient().PollWorkflowExecutionUpdate(testcore.NewContext(), &workflowservice.PollWorkflowExecutionUpdateRequest{
 			Namespace:  s.Namespace(),
 			UpdateRef:  tv.UpdateRef(updateID),
 			WaitPolicy: &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED},
 		})
 
-		if pollErr == nil {
-			// This is technically "at least Admitted".
-			s.GreaterOrEqual(pollResp.Stage, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED)
-			return true
-		}
-		if pollErr.Error() != fmt.Sprintf("update %q not found", tv.UpdateID(updateID)) {
-			s.T().Log("received error from Update poll: ", pollErr)
-			return true
-		}
-
-		// Poll beat send in race - poll again!
-		return false
+		assert.NoError(collect, pollErr)
+		assert.GreaterOrEqual(collect, pollResp.GetStage(), enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED)
 	}, 5*time.Second, 10*time.Millisecond, "update %s did not reach Admitted stage", tv.UpdateID(updateID))
 }
 

--- a/tests/xdc/history_replication_signals_and_updates_test.go
+++ b/tests/xdc/history_replication_signals_and_updates_test.go
@@ -207,8 +207,6 @@ func (t *hrsuTest) newHrsuTestCluster(ns string, name string, cluster *testcore.
 // TestAcceptedUpdateCanBeCompletedAfterFailoverAndFailback tests that an update can be accepted in one cluster, and completed in a
 // different cluster, after a failover.
 func (s *hrsuTestSuite) TestAcceptedUpdateCanBeCompletedAfterFailoverAndFailback() {
-	s.T().Skip("flaky test")
-
 	t, ctx, cancel := s.startHrsuTest()
 	defer cancel()
 	t.cluster1.startWorkflow(ctx, func(workflow.Context) error { return nil })
@@ -359,8 +357,6 @@ func (s *hrsuTestSuite) TestConflictResolutionReappliesUpdates() {
 // updates have the same update ID. The test confirms that when the conflict is resolved, we do not reapply the
 // UpdateAccepted event, since it has a conflicting ID.
 func (s *hrsuTestSuite) TestConflictResolutionDoesNotReapplyAcceptedUpdateWithConflictingId() {
-	s.T().Skip("flaky test")
-
 	t, ctx, cancel := s.startHrsuTest()
 	defer cancel()
 	t.cluster1.startWorkflow(ctx, func(workflow.Context) error { return nil })
@@ -785,33 +781,62 @@ func (task *hrsuTestExecutableTask) workflowId() string {
 
 // Update test utilities
 func (c *hrsuTestCluster) sendUpdateAndWaitUntilStage(ctx context.Context, updateId string, arg string, stage sdkclient.WorkflowUpdateStage) {
-	updateResponse := make(chan error)
-	processWorkflowTaskResponse := make(chan error)
+	updateErrCh := make(chan error)
 	go func() {
 		_, err := c.client.UpdateWorkflow(ctx, sdkclient.UpdateWorkflowOptions{
 			UpdateID:     updateId,
 			WorkflowID:   c.t.tv.WorkflowID(),
 			RunID:        c.t.tv.RunID(),
-			UpdateName:   "the-test-doesn't-use-this",
-			Args:         []interface{}{arg},
+			UpdateName:   c.t.tv.Any().String(),
+			Args:         []any{arg},
 			WaitForStage: stage,
 		})
+		updateErrCh <- err
+	}()
+
+	// Wait admitted to make sure that Update reached server, and added to registry.
+	// This guarantees following poll to get an Update request message.
+	c.waitUpdateAdmitted(c.t.tv, updateId)
+
+	// Blocks until the update request causes a WFT to be dispatched; then sends the update acceptance message
+	// required for the update request to return.
+	if stage == sdkclient.WorkflowUpdateStageCompleted {
+		err := c.pollAndAcceptCompleteUpdate(updateId)
 		c.t.s.NoError(err)
-		updateResponse <- err
-	}()
-	go func() {
-		// Blocks until the update request causes a WFT to be dispatched; then sends the update acceptance message
-		// required for the update request to return.
-		if stage == sdkclient.WorkflowUpdateStageCompleted {
-			processWorkflowTaskResponse <- c.pollAndAcceptCompleteUpdate(updateId)
-		} else if stage == sdkclient.WorkflowUpdateStageAccepted {
-			processWorkflowTaskResponse <- c.pollAndAcceptUpdate()
-		} else {
-			c.t.s.FailNow("invalid stage")
+	} else if stage == sdkclient.WorkflowUpdateStageAccepted {
+		err := c.pollAndAcceptUpdate()
+		c.t.s.NoError(err)
+	} else {
+		c.t.s.FailNow("invalid stage", stage)
+	}
+
+	c.t.s.NoError(<-updateErrCh)
+}
+
+func (c *hrsuTestCluster) waitUpdateAdmitted(tv *testvars.TestVars, updateID string) {
+	c.t.s.Eventuallyf(func() bool {
+		pollResp, pollErr := c.testCluster.FrontendClient().PollWorkflowExecutionUpdate(testcore.NewContext(), &workflowservice.PollWorkflowExecutionUpdateRequest{
+			Namespace: tv.NamespaceName().String(),
+			UpdateRef: &updatepb.UpdateRef{
+				WorkflowExecution: tv.WorkflowExecution(),
+				UpdateId:          updateID,
+			},
+			WaitPolicy: &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED},
+		})
+
+		if pollErr == nil {
+			// This is technically "at least Admitted".
+			c.t.s.GreaterOrEqual(pollResp.Stage, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED)
+			return true
 		}
-	}()
-	c.t.s.NoError(<-updateResponse)
-	c.t.s.NoError(<-processWorkflowTaskResponse)
+		if pollErr.Error() != fmt.Sprintf("update %q not found", updateID) {
+			c.t.s.T().Log("received error from Update poll: ", pollErr)
+			return true
+		}
+
+		// Poll beat send in race - poll again!
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "update %s did not reach Admitted stage", updateID)
 }
 
 func (c *hrsuTestCluster) pollAndAcceptUpdate() error {
@@ -890,7 +915,7 @@ func (t *hrsuTest) acceptUpdateMessageHandler(resp *workflowservice.PollWorkflow
 		attrs := updateAdmittedEvent.GetWorkflowExecutionUpdateAdmittedEventAttributes()
 		updateId = attrs.Request.Meta.UpdateId
 	} else {
-		t.s.Equal(1, len(resp.Messages))
+		t.s.Len(resp.Messages, 1)
 		msg := resp.Messages[0]
 		updateId = msg.ProtocolInstanceId
 	}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix flaky `TestHistoryReplicationSignalsAndUpdatesTestSuite`.

## Why?
<!-- Tell your future self why have you made these changes -->
Tests were flaky because WFT poller didn't wait for Update to reach the server and might poll for WFT w/o Update request message.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run. And they passed here 3 times. There might be some other flakes though.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.