### PR TITLE
Fix Update-with-Start poll of completed Update

### DIFF
--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -5035,6 +5035,221 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_ContinueAsNew_UpdateIsNotCarrie
   4 WorkflowTaskCompleted`, s.GetHistory(s.Namespace(), tv.WorkflowExecution()))
 }
 
+func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
+	// reset reuse minimal interval to allow workflow termination
+	s.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, 0)
+
+	runMultiOp := func(
+		tv *testvars.TestVars,
+		request *workflowservice.ExecuteMultiOperationRequest,
+	) (resp *workflowservice.ExecuteMultiOperationResponse, retErr error) {
+		capture := s.GetTestCluster().Host().CaptureMetricsHandler().StartCapture()
+		defer s.GetTestCluster().Host().CaptureMetricsHandler().StopCapture(capture)
+
+		msgHandlerCalls := 0
+		poller := &testcore.TaskPoller{
+			Client:    s.FrontendClient(),
+			Namespace: s.Namespace(),
+			TaskQueue: tv.TaskQueue(),
+			Identity:  tv.WorkerIdentity(),
+			WorkflowTaskHandler: func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
+				return nil, nil
+			},
+			MessageHandler: func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*protocolpb.Message, error) {
+				if len(task.Messages) > 0 {
+					updRequestMsg := task.Messages[0]
+					msgHandlerCalls += 1
+					switch msgHandlerCalls {
+					case 1:
+						return s.UpdateAcceptCompleteMessages(tv, updRequestMsg, "1"), nil
+					default:
+						s.Failf("msgHandler called too many times", "msgHandler shouldn't be called %d times", msgHandlerCalls)
+					}
+				}
+				return nil, nil
+			},
+			Logger: s.Logger,
+			T:      s.T(),
+		}
+
+		// issue multi operation request
+		done := make(chan struct{})
+		go func() {
+			resp, retErr = s.FrontendClient().ExecuteMultiOperation(testcore.NewContext(), request)
+			done <- struct{}{}
+		}()
+
+		_, err := poller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
+		s.NoError(err)
+
+		// wait for request to complete
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		select {
+		case <-ctx.Done():
+			s.Fail("timed out waiting for result of ExecuteMultiOperation")
+		case <-done:
+		}
+
+		// make sure there's no lock contention
+		s.Empty(capture.Snapshot()[metrics.TaskWorkflowBusyCounter.Name()])
+
+		return
+	}
+
+	runUpdateWithStart := func(
+		tv *testvars.TestVars,
+		startReq *workflowservice.StartWorkflowExecutionRequest,
+		updateReq *workflowservice.UpdateWorkflowExecutionRequest,
+	) (*workflowservice.ExecuteMultiOperationResponse, error) {
+		resp, err := runMultiOp(tv,
+			&workflowservice.ExecuteMultiOperationRequest{
+				Namespace: s.Namespace(),
+				Operations: []*workflowservice.ExecuteMultiOperationRequest_Operation{
+					{
+						Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_StartWorkflow{
+							StartWorkflow: startReq,
+						},
+					},
+					{
+						Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_UpdateWorkflow{
+							UpdateWorkflow: updateReq,
+						},
+					},
+				},
+			})
+
+		if err == nil {
+			s.Len(resp.Responses, 2)
+
+			startRes := resp.Responses[0].Response.(*workflowservice.ExecuteMultiOperationResponse_Response_StartWorkflow).StartWorkflow
+			s.NotZero(startRes.RunId)
+
+			updateRes := resp.Responses[1].Response.(*workflowservice.ExecuteMultiOperationResponse_Response_UpdateWorkflow).UpdateWorkflow
+			s.NotNil(updateRes.Outcome)
+			s.NotZero(updateRes.Outcome.String())
+		}
+
+		return resp, err
+	}
+
+	startWorkflowReq := func(tv *testvars.TestVars) *workflowservice.StartWorkflowExecutionRequest {
+		return &workflowservice.StartWorkflowExecutionRequest{
+			Namespace:    s.Namespace(),
+			WorkflowId:   tv.WorkflowID(),
+			WorkflowType: tv.WorkflowType(),
+			TaskQueue:    tv.TaskQueue(),
+			Identity:     tv.WorkerIdentity(),
+		}
+	}
+
+	updateWorkflowReq := func(tv *testvars.TestVars) *workflowservice.UpdateWorkflowExecutionRequest {
+		return &workflowservice.UpdateWorkflowExecutionRequest{
+			Namespace: s.Namespace(),
+			Request: &updatepb.Request{
+				Meta:  &updatepb.Meta{UpdateId: tv.UpdateID("1")},
+				Input: &updatepb.Input{Name: tv.Any().String(), Args: tv.Any().Payloads()},
+			},
+			WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID()},
+			WaitPolicy:        &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED},
+		}
+	}
+
+	s.Run("workflow is not running", func() {
+
+		s.Run("start workflow and send update", func() {
+			tv := testvars.New(s.T())
+
+			resp, err := runUpdateWithStart(tv, startWorkflowReq(tv), updateWorkflowReq(tv))
+			s.NoError(err)
+			s.True(resp.Responses[0].GetStartWorkflow().Started)
+		})
+
+		s.Run("poll update result after completion", func() {
+			tv := testvars.New(s.T())
+
+			_, err := runUpdateWithStart(tv, startWorkflowReq(tv), updateWorkflowReq(tv))
+			s.NoError(err)
+
+			_, err = s.pollUpdate(tv, "1",
+				&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
+			s.Nil(err)
+		})
+	})
+
+	s.Run("workflow is running", func() {
+
+		s.Run("workflow id conflict policy use-existing: only send update", func() {
+			tv := testvars.New(s.T())
+
+			_, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startWorkflowReq(tv))
+			s.NoError(err)
+
+			req := startWorkflowReq(tv)
+			req.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+			resp, err := runUpdateWithStart(tv, req, updateWorkflowReq(tv))
+			s.NoError(err)
+			s.False(resp.Responses[0].GetStartWorkflow().Started)
+		})
+
+		s.Run("workflow id conflict policy terminate-existing: terminate workflow first, then start and update", func() {
+			tv := testvars.New(s.T())
+
+			initReq := startWorkflowReq(tv)
+			initReq.TaskQueue.Name = initReq.TaskQueue.Name + "-init" // avoid race condition with poller
+			initWF, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), initReq)
+			s.NoError(err)
+
+			req := startWorkflowReq(tv)
+			req.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING
+			resp, err := runUpdateWithStart(tv, req, updateWorkflowReq(tv))
+			s.NoError(err)
+			s.True(resp.Responses[0].GetStartWorkflow().Started)
+
+			descResp, err := s.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(),
+				&workflowservice.DescribeWorkflowExecutionRequest{
+					Namespace: s.Namespace(),
+					Execution: &commonpb.WorkflowExecution{WorkflowId: req.WorkflowId, RunId: initWF.RunId},
+				})
+			s.NoError(err)
+			s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, descResp.WorkflowExecutionInfo.Status)
+		})
+
+		s.Run("workflow id conflict policy fail: abort multi operation", func() {
+			tv := testvars.New(s.T())
+
+			_, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startWorkflowReq(tv))
+			s.NoError(err)
+
+			req := startWorkflowReq(tv)
+			req.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL
+			_, err = runUpdateWithStart(tv, req, updateWorkflowReq(tv))
+			s.NotNil(err)
+			s.Equal(err.Error(), "MultiOperation could not be executed.")
+			errs := err.(*serviceerror.MultiOperationExecution).OperationErrors()
+			s.Len(errs, 2)
+			s.Contains(errs[0].Error(), "Workflow execution is already running")
+			s.Equal("Operation was aborted.", errs[1].Error())
+		})
+
+		s.Run("poll update result after completion", func() {
+			tv := testvars.New(s.T())
+
+			_, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startWorkflowReq(tv))
+			s.NoError(err)
+
+			req := startWorkflowReq(tv)
+			req.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+			_, err = runUpdateWithStart(tv, req, updateWorkflowReq(tv))
+			s.NoError(err)
+
+			_, err = s.pollUpdate(tv, "1",
+				&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
+			s.Nil(err)
+		})
+	})
+}
+
 func (s *UpdateWorkflowSuite) closeShard(wid string) {
 	s.T().Helper()
 

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -42,20 +42,16 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
-	protocolpb "go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
-	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log/tag"
-	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
-	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -991,184 +987,4 @@ func (s *WorkflowTestSuite) TestWorkflowRetryFailures() {
   3 WorkflowTaskStarted
   4 WorkflowTaskCompleted
   5 WorkflowExecutionFailed`, events)
-}
-
-func (s *WorkflowTestSuite) TestExecuteMultiOperation() {
-	// reset reuse minimal interval to allow workflow termination
-	s.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, 0)
-
-	runMultiOp := func(
-		tv *testvars.TestVars,
-		request *workflowservice.ExecuteMultiOperationRequest,
-	) (resp *workflowservice.ExecuteMultiOperationResponse, retErr error) {
-		capture := s.GetTestCluster().Host().CaptureMetricsHandler().StartCapture()
-		defer s.GetTestCluster().Host().CaptureMetricsHandler().StopCapture(capture)
-
-		poller := &testcore.TaskPoller{
-			Client:    s.FrontendClient(),
-			Namespace: s.Namespace(),
-			TaskQueue: tv.TaskQueue(),
-			Identity:  tv.WorkerIdentity(),
-			WorkflowTaskHandler: func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
-				return nil, nil
-			},
-			MessageHandler: func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*protocolpb.Message, error) {
-				if len(task.Messages) > 0 {
-					updRequestMsg := task.Messages[0]
-					return s.UpdateAcceptCompleteMessages(tv, updRequestMsg, "1"), nil
-				}
-				return nil, nil
-			},
-			Logger: s.Logger,
-			T:      s.T(),
-		}
-
-		// issue multi operation request
-		done := make(chan struct{})
-		go func() {
-			resp, retErr = s.FrontendClient().ExecuteMultiOperation(testcore.NewContext(), request)
-			done <- struct{}{}
-		}()
-
-		_, err := poller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
-		s.NoError(err)
-
-		// wait for request to complete
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		select {
-		case <-ctx.Done():
-			s.Fail("timed out waiting for result of ExecuteMultiOperation")
-		case <-done:
-		}
-
-		// make sure there's no lock contention
-		s.Empty(capture.Snapshot()[metrics.TaskWorkflowBusyCounter.Name()])
-
-		return
-	}
-
-	s.Run("StartWorkflow + UpdateWorkflow", func() {
-		runUpdateWithStart := func(
-			tv *testvars.TestVars,
-			startReq *workflowservice.StartWorkflowExecutionRequest,
-			updateReq *workflowservice.UpdateWorkflowExecutionRequest,
-		) (*workflowservice.ExecuteMultiOperationResponse, error) {
-			resp, err := runMultiOp(tv,
-				&workflowservice.ExecuteMultiOperationRequest{
-					Namespace: s.Namespace(),
-					Operations: []*workflowservice.ExecuteMultiOperationRequest_Operation{
-						{
-							Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_StartWorkflow{
-								StartWorkflow: startReq,
-							},
-						},
-						{
-							Operation: &workflowservice.ExecuteMultiOperationRequest_Operation_UpdateWorkflow{
-								UpdateWorkflow: updateReq,
-							},
-						},
-					},
-				})
-
-			if err == nil {
-				s.Len(resp.Responses, 2)
-
-				startRes := resp.Responses[0].Response.(*workflowservice.ExecuteMultiOperationResponse_Response_StartWorkflow).StartWorkflow
-				s.NotZero(startRes.RunId)
-
-				updateRes := resp.Responses[1].Response.(*workflowservice.ExecuteMultiOperationResponse_Response_UpdateWorkflow).UpdateWorkflow
-				s.NotNil(updateRes.Outcome)
-				s.NotZero(updateRes.Outcome.String())
-			}
-
-			return resp, err
-		}
-
-		startWorkflowReq := func(tv *testvars.TestVars) *workflowservice.StartWorkflowExecutionRequest {
-			return &workflowservice.StartWorkflowExecutionRequest{
-				Namespace:    s.Namespace(),
-				WorkflowId:   tv.WorkflowID(),
-				WorkflowType: tv.WorkflowType(),
-				TaskQueue:    tv.TaskQueue(),
-				Identity:     tv.WorkerIdentity(),
-			}
-		}
-
-		updateWorkflowReq := func(tv *testvars.TestVars) *workflowservice.UpdateWorkflowExecutionRequest {
-			return &workflowservice.UpdateWorkflowExecutionRequest{
-				Namespace: s.Namespace(),
-				Request: &updatepb.Request{
-					Meta:  &updatepb.Meta{UpdateId: tv.UpdateID("1")},
-					Input: &updatepb.Input{Name: tv.Any().String(), Args: tv.Any().Payloads()},
-				},
-				WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: tv.WorkflowID()},
-				WaitPolicy:        &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED},
-			}
-		}
-
-		s.Run("workflow is not running", func() {
-			tv := testvars.New(s.T())
-
-			resp, err := runUpdateWithStart(tv, startWorkflowReq(tv), updateWorkflowReq(tv))
-			s.NoError(err)
-			s.True(resp.Responses[0].GetStartWorkflow().Started)
-		})
-
-		s.Run("workflow is running", func() {
-
-			s.Run("workflow id conflict policy use-existing: only send update", func() {
-				tv := testvars.New(s.T())
-
-				_, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startWorkflowReq(tv))
-				s.NoError(err)
-
-				req := startWorkflowReq(tv)
-				req.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
-				resp, err := runUpdateWithStart(tv, req, updateWorkflowReq(tv))
-				s.NoError(err)
-				s.False(resp.Responses[0].GetStartWorkflow().Started)
-			})
-
-			s.Run("workflow id conflict policy terminate-existing: terminate workflow first, then start and update", func() {
-				tv := testvars.New(s.T())
-
-				initReq := startWorkflowReq(tv)
-				initReq.TaskQueue.Name = initReq.TaskQueue.Name + "-init" // avoid race condition with poller
-				initWF, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), initReq)
-				s.NoError(err)
-
-				req := startWorkflowReq(tv)
-				req.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING
-				resp, err := runUpdateWithStart(tv, req, updateWorkflowReq(tv))
-				s.NoError(err)
-				s.True(resp.Responses[0].GetStartWorkflow().Started)
-
-				descResp, err := s.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(),
-					&workflowservice.DescribeWorkflowExecutionRequest{
-						Namespace: s.Namespace(),
-						Execution: &commonpb.WorkflowExecution{WorkflowId: req.WorkflowId, RunId: initWF.RunId},
-					})
-				s.NoError(err)
-				s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, descResp.WorkflowExecutionInfo.Status)
-			})
-
-			s.Run("workflow id conflict policy fail: abort multi operation", func() {
-				tv := testvars.New(s.T())
-
-				_, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startWorkflowReq(tv))
-				s.NoError(err)
-
-				req := startWorkflowReq(tv)
-				req.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL
-				_, err = runUpdateWithStart(tv, req, updateWorkflowReq(tv))
-				s.NotNil(err)
-				s.Equal(err.Error(), "MultiOperation could not be executed.")
-				errs := err.(*serviceerror.MultiOperationExecution).OperationErrors()
-				s.Len(errs, 2)
-				s.Contains(errs[0].Error(), "Workflow execution is already running")
-				s.Equal("Operation was aborted.", errs[1].Error())
-			})
-		})
-	})
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

MutableState is assigned to the workflow context to prevent it from re-initializing later in task processing.

## Why?
<!-- Tell your future self why have you made these changes -->

Polling for an Update result from an Update-with-Start returned a NotFound error.

This is due to inconsistent use of MutableState: the worker responses in task processing uses a different MutableState than the poll request from the user. There was no problem while the update was in the registry, but once it completed and is transferred to MS, the inconsistency was observable by the user when polling.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Added new tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->

Yes.