### PR TITLE
Fix metrics tag inconsistency in nexus handler

### DIFF
--- a/components/nexusoperations/frontend/handler.go
+++ b/components/nexusoperations/frontend/handler.go
@@ -422,6 +422,7 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexus.Co
 			c.forwarded = true
 			var forwardStartTime time.Time
 			c.metricsHandlerForInterceptors, forwardStartTime = c.RedirectionInterceptor.BeforeCall(methodNameForMetrics)
+			c.metricsHandlerForInterceptors = c.metricsHandlerForInterceptors.WithTags(metrics.NamespaceTag(c.namespace.Name().String()))
 			c.cleanupFunctions = append(c.cleanupFunctions, func(retErr error) {
 				c.RedirectionInterceptor.AfterCall(c.metricsHandlerForInterceptors, forwardStartTime, c.namespace.ActiveClusterName(), retErr)
 			})

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -173,6 +173,7 @@ func (c *operationContext) interceptRequest(ctx context.Context, request *matchi
 			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("request_forwarded"))
 			var forwardStartTime time.Time
 			c.metricsHandlerForInterceptors, forwardStartTime = c.redirectionInterceptor.BeforeCall(c.apiName)
+			c.metricsHandlerForInterceptors = c.metricsHandlerForInterceptors.WithTags(metrics.NamespaceTag(c.namespaceName))
 			c.cleanupFunctions = append(c.cleanupFunctions, func(retErr error) {
 				c.redirectionInterceptor.AfterCall(c.metricsHandlerForInterceptors, forwardStartTime, c.namespace.ActiveClusterName(), retErr)
 			})


### PR DESCRIPTION
## What changed?
Add namespace tag to metricsHandlerForInterceptors in nexus operationContext and requestContext.

## Why?
TelemetryInterceptor.RecordLatencyMetrics() is called with this metrics handler. In all other places, metrics handler passed to this function has namespace tag.

## How did you test it?

## Potential risks

## Documentation

## Is hotfix candidate?
No
