### PR TITLE
Fix metrics tag inconsistency in replication task executor

### DIFF
--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -332,15 +332,24 @@ func (e *ExecutableTaskImpl) Resend(
 		return false, ErrResendAttemptExceeded
 	}
 
+	var namespaceName string
+	item := e.namespace.Load()
+	if item != nil {
+		namespaceName = item.(namespace.Name).String()
+	}
 	metrics.ClientRequests.With(e.MetricsHandler).Record(
 		1,
 		metrics.OperationTag(e.metricsTag+"Resend"),
+		metrics.NamespaceTag(namespaceName),
+		metrics.ServiceRoleTag(metrics.HistoryRoleTagValue),
 	)
 	startTime := time.Now().UTC()
 	defer func() {
 		metrics.ClientLatency.With(e.MetricsHandler).Record(
 			time.Since(startTime),
 			metrics.OperationTag(e.metricsTag+"Resend"),
+			metrics.NamespaceTag(namespaceName),
+			metrics.ServiceRoleTag(metrics.HistoryRoleTagValue),
 		)
 	}()
 	var resendErr error


### PR DESCRIPTION
## What changed?
Add NamespaceTag and ServiceRoleTag when emitting ClientRequests and ClientLatency from replication task executor. We include these tags when we emit these metrics from other places. Prometheus does not support this tag inconsistency.

## Why?
To fix tag inconsistency.

## How did you test it?

## Potential risks

## Documentation

## Is hotfix candidate?
No
