### PR TITLE
Fix metrics tag inconsistency in nexus handler

### DIFF
--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -171,10 +171,9 @@ func (c *operationContext) interceptRequest(ctx context.Context, request *matchi
 		if c.shouldForwardRequest(ctx, header) {
 			// Handler methods should have special logic to forward requests if this method returns a serviceerror.NamespaceNotActive error.
 			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("request_forwarded"))
-			var forwardStartTime time.Time
-			c.metricsHandlerForInterceptors, forwardStartTime = c.redirectionInterceptor.BeforeCall(c.apiName)
+			handler, forwardStartTime := c.redirectionInterceptor.BeforeCall(c.apiName)
 			c.cleanupFunctions = append(c.cleanupFunctions, func(retErr error) {
-				c.redirectionInterceptor.AfterCall(c.metricsHandlerForInterceptors, forwardStartTime, c.namespace.ActiveClusterName(), retErr)
+				c.redirectionInterceptor.AfterCall(handler, forwardStartTime, c.namespace.ActiveClusterName(), retErr)
 			})
 			return serviceerror.NewNamespaceNotActive(c.namespaceName, c.clusterMetadata.GetCurrentClusterName(), c.namespace.ActiveClusterName())
 		}


### PR DESCRIPTION
## What changed?
Fix metrics handler tag issue in nexus_handler.

## Why?
Replacing c.metricsHandlerForInterceptors is causing metrics tag inconsistency.

## How did you test it?

## Potential risks

## Documentation

## Is hotfix candidate?
No.
