### PR TITLE
Fix Update-with-Start deduping

### DIFF
--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -88,10 +88,9 @@ func Invoke(
 		updateReq,
 	)
 
-	// If the workflow id conflict policy is to terminate, it doesn't matter if the workflow is actually running or not:
-	// always attempt to start and update. The start will take care of terminating the workflow, if necessary.
+	// TODO
 	if startReq.StartRequest.WorkflowIdConflictPolicy == enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING {
-		return startAndUpdateWorkflow(ctx, shardContext, workflowConsistencyChecker, starter, updater)
+		return nil, serviceerror.NewInvalidArgument("workflow id conflict policy terminate-existing is not supported yet")
 	}
 
 	currentWorkflowLease, err := workflowConsistencyChecker.GetWorkflowLease(

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -5173,6 +5173,15 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 				&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
 			s.Nil(err)
 		})
+
+		s.Run("workflow id conflict policy terminate-existing: not supported yet", func() {
+			tv := testvars.New(s.T())
+
+			req := startWorkflowReq(tv)
+			req.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING
+			_, err := runUpdateWithStart(tv, req, updateWorkflowReq(tv))
+			s.Error(err)
+		})
 	})
 
 	s.Run("workflow is running", func() {
@@ -5191,6 +5200,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 		})
 
 		s.Run("workflow id conflict policy terminate-existing: terminate workflow first, then start and update", func() {
+			s.T().Skip("TODO")
 			tv := testvars.New(s.T())
 
 			initReq := startWorkflowReq(tv)

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -5039,10 +5039,15 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 	// reset reuse minimal interval to allow workflow termination
 	s.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, 0)
 
+	type multiopsResponseErr struct {
+		response *workflowservice.ExecuteMultiOperationResponse
+		err      error
+	}
+
 	runMultiOp := func(
 		tv *testvars.TestVars,
 		request *workflowservice.ExecuteMultiOperationRequest,
-	) (resp *workflowservice.ExecuteMultiOperationResponse, retErr error) {
+	) (*workflowservice.ExecuteMultiOperationResponse, error) {
 		capture := s.GetTestCluster().Host().CaptureMetricsHandler().StartCapture()
 		defer s.GetTestCluster().Host().CaptureMetricsHandler().StopCapture(capture)
 
@@ -5072,29 +5077,22 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 			T:      s.T(),
 		}
 
-		// issue multi operation request
-		done := make(chan struct{})
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		retCh := make(chan multiopsResponseErr)
 		go func() {
-			resp, retErr = s.FrontendClient().ExecuteMultiOperation(testcore.NewContext(), request)
-			done <- struct{}{}
+			resp, err := s.FrontendClient().ExecuteMultiOperation(ctx, request)
+			retCh <- multiopsResponseErr{resp, err}
 		}()
 
-		_, err := poller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
-		s.NoError(err)
+		go func() {
+			// TODO: handle error
+			_, _ = poller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
+		}()
 
-		// wait for request to complete
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		select {
-		case <-ctx.Done():
-			s.Fail("timed out waiting for result of ExecuteMultiOperation")
-		case <-done:
-		}
-
-		// make sure there's no lock contention
-		s.Empty(capture.Snapshot()[metrics.TaskWorkflowBusyCounter.Name()])
-
-		return
+		ret := <-retCh
+		return ret.response, ret.err
 	}
 
 	runUpdateWithStart := func(
@@ -5224,7 +5222,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 			req := startWorkflowReq(tv)
 			req.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL
 			_, err = runUpdateWithStart(tv, req, updateWorkflowReq(tv))
-			s.NotNil(err)
+			s.Error(err)
 			s.Equal(err.Error(), "MultiOperation could not be executed.")
 			errs := err.(*serviceerror.MultiOperationExecution).OperationErrors()
 			s.Len(errs, 2)
@@ -5246,6 +5244,64 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 			_, err = s.pollUpdate(tv, "1",
 				&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
 			s.Nil(err)
+		})
+	})
+
+	s.Run("dedupes both operations", func() {
+
+		s.Run("for workflow id conflict policy fail", func() {
+			tv := testvars.New(s.T())
+
+			startReq := startWorkflowReq(tv)
+			startReq.RequestId = "request_id"
+			startReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL
+			updReq := updateWorkflowReq(tv)
+
+			resp1, err := runUpdateWithStart(tv, startReq, updReq)
+			s.NoError(err)
+
+			resp2, err := runUpdateWithStart(tv, startReq, updReq)
+			s.NoError(err)
+
+			s.Equal(resp1.Responses[0].GetStartWorkflow().RunId, resp2.Responses[0].GetStartWorkflow().RunId)
+			s.Equal(resp1.Responses[1].GetUpdateWorkflow().Outcome.GetSuccess(), resp2.Responses[1].GetUpdateWorkflow().Outcome.GetSuccess())
+		})
+
+		s.Run("for workflow id conflict policy use existing", func() {
+			tv := testvars.New(s.T())
+
+			startReq := startWorkflowReq(tv)
+			startReq.RequestId = "request_id"
+			startReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+			updReq := updateWorkflowReq(tv)
+
+			resp1, err := runUpdateWithStart(tv, startReq, updReq)
+			s.NoError(err)
+
+			resp2, err := runUpdateWithStart(tv, startReq, updReq)
+			s.NoError(err)
+
+			s.Equal(resp1.Responses[0].GetStartWorkflow().RunId, resp2.Responses[0].GetStartWorkflow().RunId)
+			s.Equal(resp1.Responses[1].GetUpdateWorkflow().Outcome.GetSuccess(), resp2.Responses[1].GetUpdateWorkflow().Outcome.GetSuccess())
+		})
+
+		s.Run("for workflow id conflict policy terminate", func() {
+			s.T().Skip("TODO")
+			tv := testvars.New(s.T())
+
+			startReq := startWorkflowReq(tv)
+			startReq.RequestId = "request_id"
+			startReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING
+			updReq := updateWorkflowReq(tv)
+
+			resp1, err := runUpdateWithStart(tv, startReq, updReq)
+			s.NoError(err)
+
+			resp2, err := runUpdateWithStart(tv, startReq, updReq)
+			s.NoError(err)
+
+			s.Equal(resp1.Responses[0].GetStartWorkflow().RunId, resp2.Responses[0].GetStartWorkflow().RunId)
+			s.Equal(resp1.Responses[1].GetUpdateWorkflow().Outcome.GetSuccess(), resp2.Responses[1].GetUpdateWorkflow().Outcome.GetSuccess())
 		})
 	})
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Fixes Update-with-Start deduping behavior for `FAIL`.

## Why?
<!-- Tell your future self why have you made these changes -->

For `FAIL`, the behavior was not correct in that it didn't attempt to dedup the request; it just failed immediately.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Added new tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
