### PR TITLE
Workflow Update: delay Update abortion with effects package

### DIFF
--- a/docs/architecture/workflow-update.md
+++ b/docs/architecture/workflow-update.md
@@ -180,6 +180,7 @@ Full "Update state" and "Abort reason" matrix is the following:
 | **ProvisionallyCompleted**              | `WorkflowUpdateAbortedErr` | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
 | **ProvisionallyCompletedAfterAccepted** | `WorkflowUpdateAbortedErr` | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
 | **Completed**                           | `nil`                      | `nil`                                    | `nil`                                    |
+| **ProvisionallyAborted**                | `nil`                      | `nil`                                    | `nil`                                    |
 | **Aborted**                             | `nil`                      | `nil`                                    | `nil`                                    |
 
 When the Workflow performs a final completion, all in-flight Updates are aborted: admitted Updates get
@@ -430,6 +431,14 @@ Sent -> ProvisionalyAccepted -> ProvisionalyCompleted -> ProvisionalyCompletedAf
 The `ProvisionalyCompletedAfterAccepted` in-between state is necessary to unblock `completed` future before
 `accepted`. This allows returning Update results to the API caller even it was waiting for `ACCEPTED`
 stage.
+
+If a Workflow Update is accepted and **Workflow** is completed in the same Workflow Task, it goes through the
+similar chain of state transitions:
+```
+Sent -> ProvisionalyAccepted -> ProvisionalyAborted -> ProvisionalyCompletedAfterAccepted -> Aborted
+```
+The `ProvisionalyCompletedAfterAccepted` state is reused here as `ProvisionalyAbortedAfterAccepted` because
+behavior is exactly the same.
 
 > #### NOTE
 > Because the `Cancel()` method is called in a `defer` block in case of error, the `Apply()` method

--- a/docs/architecture/workflow-update.md
+++ b/docs/architecture/workflow-update.md
@@ -426,18 +426,18 @@ rollback - the transition after successful persistence write. Check the
 If a Workflow Update is accepted and completed in the same Workflow Task, it goes through the
 following chain of state transitions:
 ```
-Sent -> ProvisionalyAccepted -> ProvisionalyCompleted -> ProvisionalyCompletedAfterAccepted -> Completed
+Sent -> ProvisionallyAccepted -> ProvisionallyCompleted -> ProvisionallyCompletedAfterAccepted -> Completed
 ```
-The `ProvisionalyCompletedAfterAccepted` in-between state is necessary to unblock `completed` future before
+The `ProvisionallyCompletedAfterAccepted` in-between state is necessary to unblock `completed` future before
 `accepted`. This allows returning Update results to the API caller even it was waiting for `ACCEPTED`
 stage.
 
-If a Workflow Update is accepted and **Workflow** is completed in the same Workflow Task, it goes through the
+If a Workflow Update is accepted and the **Workflow** is completed in the same Workflow Task, it goes through a
 similar chain of state transitions:
 ```
-Sent -> ProvisionalyAccepted -> ProvisionalyAborted -> ProvisionalyCompletedAfterAccepted -> Aborted
+Sent -> ProvisionallyAccepted -> ProvisionallyAborted -> ProvisionallyCompletedAfterAccepted -> Aborted
 ```
-The `ProvisionalyCompletedAfterAccepted` state is reused here as `ProvisionalyAbortedAfterAccepted` because
+The `ProvisionallyCompletedAfterAccepted` state is reused here as `ProvisionallyAbortedAfterAccepted` because
 behavior is exactly the same.
 
 > #### NOTE

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -414,6 +414,14 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 			request.GetIdentity(),
 		)
 
+		// If the Workflow completed itself, but there are still accepted
+		// (but not completed) Updates, they need to be aborted.
+		// Reason is always "WorkflowCompleted" because accepted Updates
+		// are not moving to continuing runs (if any).
+		if !ms.IsWorkflowExecutionRunning() {
+			updateRegistry.AbortAccepted(update.AbortReasonWorkflowCompleted, &effects)
+		}
+
 		// set the vars used by following logic
 		// further refactor should also clean up the vars used below
 		wtFailedCause = workflowTaskHandler.workflowTaskFailedCause
@@ -634,11 +642,13 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 	effects.Apply(ctx)
 
 	if !ms.IsWorkflowExecutionRunning() {
-		// NOTE: It is important to call this *after* applying effects to be sure there are no pending effects.
+		// NOTE: It is important to call this *after* applying effects to be sure there are no
+		// Updates in ProvisionallyCompleted state.
 
-		// Because all unprocessed Updates were already rejected, the registry only has:
-		//   (1) Updates that were received while this WFT was running,
-		//   (2) Updates that were accepted but not yet completed.
+		// Because:
+		//  (1) all unprocessed Updates were already rejected
+		//  (2) all accepted Updates were aborted
+		// the registry only has: Updates received while this WFT was running (new Updates).
 		hasNewRun := newMutableState != nil
 		if hasNewRun {
 			// If a new run was created (e.g. ContinueAsNew, Retry, Cron), then Updates that were

--- a/service/history/workflow/update/abort_reason.go
+++ b/service/history/workflow/update/abort_reason.go
@@ -65,8 +65,9 @@ var reasonStateMatrix = map[reasonState]failureError{
 	reasonState{r: AbortReasonRegistryCleared, st: stateProvisionallyCompleted}:              {f: nil, err: registryClearedErr},
 	reasonState{r: AbortReasonRegistryCleared, st: stateProvisionallyCompletedAfterAccepted}: {f: nil, err: registryClearedErr},
 	// Completed Updates can't be aborted.
-	reasonState{r: AbortReasonRegistryCleared, st: stateCompleted}: {f: nil, err: nil},
-	reasonState{r: AbortReasonRegistryCleared, st: stateAborted}:   {f: nil, err: nil},
+	reasonState{r: AbortReasonRegistryCleared, st: stateCompleted}:            {f: nil, err: nil},
+	reasonState{r: AbortReasonRegistryCleared, st: stateProvisionallyAborted}: {f: nil, err: nil},
+	reasonState{r: AbortReasonRegistryCleared, st: stateAborted}:              {f: nil, err: nil},
 
 	// If the Workflow is completed, then pre-accepted Updates are aborted with non-retryable ErrWorkflowCompleted error.
 	reasonState{r: AbortReasonWorkflowCompleted, st: stateCreated}:               {f: nil, err: consts.ErrWorkflowCompleted},
@@ -83,8 +84,9 @@ var reasonStateMatrix = map[reasonState]failureError{
 	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyCompleted}:              {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
 	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyCompletedAfterAccepted}: {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
 	// Completed Updates can't be aborted.
-	reasonState{r: AbortReasonWorkflowCompleted, st: stateCompleted}: {f: nil, err: nil},
-	reasonState{r: AbortReasonWorkflowCompleted, st: stateAborted}:   {f: nil, err: nil},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateCompleted}:            {f: nil, err: nil},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyAborted}: {f: nil, err: nil},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateAborted}:              {f: nil, err: nil},
 
 	// If Workflow is starting new run, then all Updates are aborted with retryable ErrWorkflowClosing error.
 	// Internal retries will send them to the new run.
@@ -98,8 +100,9 @@ var reasonStateMatrix = map[reasonState]failureError{
 	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyCompleted}:              {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
 	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyCompletedAfterAccepted}: {f: acceptedUpdateCompletedWorkflowFailure, err: nil},
 	// Completed Updates can't be aborted.
-	reasonState{r: AbortReasonWorkflowContinuing, st: stateCompleted}: {f: nil, err: nil},
-	reasonState{r: AbortReasonWorkflowContinuing, st: stateAborted}:   {f: nil, err: nil},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateCompleted}:            {f: nil, err: nil},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyAborted}: {f: nil, err: nil},
+	reasonState{r: AbortReasonWorkflowContinuing, st: stateAborted}:              {f: nil, err: nil},
 }
 
 // FailureError returns failure or error which will be set on Update futures while aborting Update.
@@ -107,7 +110,7 @@ var reasonStateMatrix = map[reasonState]failureError{
 func (r AbortReason) FailureError(st state) (*failurepb.Failure, error) {
 	fe, ok := reasonStateMatrix[reasonState{r: r, st: st}]
 	if !ok {
-		panic("unknown workflow update abort reason or update state")
+		panic(fmt.Sprintf("unknown workflow update abort reason %s or update state %s", r, st))
 	}
 	return fe.f, fe.err
 }

--- a/service/history/workflow/update/export_test.go
+++ b/service/history/workflow/update/export_test.go
@@ -24,12 +24,17 @@
 
 package update
 
+import (
+	"go.temporal.io/server/internal/effect"
+)
+
 var (
 	// while we *could* write the unit test code to walk an Update through a
 	// series of message deliveries to get to the right state, it's much faster
 	// just to instantiate directly into the desired state.
 	NewAccepted  = newAccepted
 	NewCompleted = newCompleted
+	AbortFailure = acceptedUpdateCompletedWorkflowFailure
 )
 
 // ObserveCompletion exports withOnComplete to unit tests
@@ -42,3 +47,5 @@ func (u *Update) IsSent() bool { return u.isSent() }
 func (u *Update) ID() string { return u.id }
 
 func CompletedCount(r Registry) int { return r.(*registry).completedCount }
+
+func (u *Update) Abort(reason AbortReason, effects effect.Controller) { u.abort(reason, effects) }

--- a/service/history/workflow/update/state.go
+++ b/service/history/workflow/update/state.go
@@ -41,9 +41,10 @@ const (
 	stateProvisionallyAccepted
 	stateAccepted
 	stateProvisionallyCompleted
-	stateCompleted
-	stateAborted
 	stateProvisionallyCompletedAfterAccepted
+	stateCompleted
+	stateProvisionallyAborted
+	stateAborted
 	lastState
 )
 
@@ -63,12 +64,14 @@ func (s state) String() string {
 		return "Accepted"
 	case stateProvisionallyCompleted:
 		return "ProvisionallyCompleted"
-	case stateCompleted:
-		return "Completed"
-	case stateAborted:
-		return "Aborted"
 	case stateProvisionallyCompletedAfterAccepted:
 		return "ProvisionallyCompletedAfterAccepted"
+	case stateCompleted:
+		return "Completed"
+	case stateProvisionallyAborted:
+		return "ProvisionallyAborted"
+	case stateAborted:
+		return "Aborted"
 	case lastState:
 		return fmt.Sprintf("invalid state %d", s)
 	}

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -1184,10 +1184,12 @@ func assertNotCompletedYet(t *testing.T, upd *update.Update) {
 	require.NotEqual(t, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, status.Stage)
 	require.Nil(t, status.Outcome, "outcome should not be available yet")
 }
+
 func abort(t *testing.T, store mockEventStore, upd *update.Update, reason update.AbortReason) {
 	t.Helper()
 	upd.Abort(reason, store)
 }
+
 func assertAborted(t *testing.T, upd *update.Update, expectedErr error) {
 	t.Helper()
 

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -189,6 +189,7 @@ func TestUpdateState(t *testing.T) {
 
 					err := admit(t, readonlyStore, upd) // NOTE the store!
 					require.ErrorIs(t, consts.ErrWorkflowCompleted, err)
+					effects.Apply(context.Background())
 
 					// ensure waiter received response
 					waiterRes := <-ch
@@ -418,6 +419,7 @@ func TestUpdateState(t *testing.T) {
 					// accept update
 					err := accept(t, readonlyStore, upd) // NOTE the store!
 					require.NoError(t, err)
+					effects.Apply(context.Background())
 
 					status, err := upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, 100*time.Millisecond)
 					require.ErrorIs(t, err, consts.ErrWorkflowCompleted)
@@ -705,6 +707,7 @@ func TestUpdateState(t *testing.T) {
 				apply: func() {
 					err := respondSuccess(t, readonlyStore, upd) // NOTE the store!
 					require.NoError(t, err)
+					effects.Apply(context.Background())
 
 					status, err := upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, 100*time.Millisecond)
 					require.NoError(t, err)

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -58,6 +58,7 @@ var (
 	rejectionOutcome = &updatepb.Outcome{Value: &updatepb.Outcome_Failure{Failure: rejectionFailure}}
 	failureOutcome   = &updatepb.Outcome{Value: &updatepb.Outcome_Failure{Failure: &failurepb.Failure{Message: "outcome failure"}}}
 	successOutcome   = &updatepb.Outcome{Value: &updatepb.Outcome_Success{Success: payloads.EncodeString("success")}}
+	abortedOutcome   = &updatepb.Outcome{Value: &updatepb.Outcome_Failure{Failure: update.AbortFailure}}
 	immediateTimeout = time.Duration(0)
 	immediateCtx, _  = context.WithTimeout(context.Background(), immediateTimeout)
 )
@@ -196,7 +197,7 @@ func TestUpdateState(t *testing.T) {
 					require.EqualExportedValues(t, consts.ErrWorkflowCompleted, waiterRes)
 
 					// new waiter receives same response
-					_, err = upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, 100*time.Millisecond)
+					_, err = upd.WaitLifecycleStage(immediateCtx, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, immediateTimeout)
 					require.ErrorIs(t, err, consts.ErrWorkflowCompleted)
 				},
 			}, {
@@ -225,6 +226,27 @@ func TestUpdateState(t *testing.T) {
 				apply: func() {
 					err := respondSuccess(t, store, upd)
 					require.ErrorContains(t, err, "received *update.Response message while in state Created")
+				},
+			}, {
+				title: "aborted because registry is cleared",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonRegistryCleared)
+					effects.Apply(context.Background())
+					assertAborted(t, upd, update.WorkflowUpdateAbortedErr)
+				},
+			}, {
+				title: "aborted because Workflow completed",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonWorkflowCompleted)
+					effects.Apply(context.Background())
+					assertAborted(t, upd, consts.ErrWorkflowCompleted)
+				},
+			}, {
+				title: "aborted because Workflow completing",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonWorkflowContinuing)
+					effects.Apply(context.Background())
+					assertAborted(t, upd, consts.ErrWorkflowClosing)
 				},
 			},
 			})
@@ -304,6 +326,27 @@ func TestUpdateState(t *testing.T) {
 				failOnEffect: true,
 				apply: func() {
 					require.NoError(t, admit(t, store, upd))
+				},
+			}, {
+				title: "aborted because registry is cleared",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonRegistryCleared)
+					effects.Apply(context.Background())
+					assertAborted(t, upd, update.WorkflowUpdateAbortedErr)
+				},
+			}, {
+				title: "aborted because Workflow completed",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonWorkflowCompleted)
+					effects.Apply(context.Background())
+					assertAborted(t, upd, consts.ErrWorkflowCompleted)
+				},
+			}, {
+				title: "aborted because Workflow completing",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonWorkflowContinuing)
+					effects.Apply(context.Background())
+					assertAborted(t, upd, consts.ErrWorkflowClosing)
 				},
 			},
 			})
@@ -421,7 +464,7 @@ func TestUpdateState(t *testing.T) {
 					require.NoError(t, err)
 					effects.Apply(context.Background())
 
-					status, err := upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, 100*time.Millisecond)
+					status, err := upd.WaitLifecycleStage(immediateCtx, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, immediateTimeout)
 					require.ErrorIs(t, err, consts.ErrWorkflowCompleted)
 					require.Nil(t, status)
 
@@ -430,7 +473,7 @@ func TestUpdateState(t *testing.T) {
 					require.EqualExportedValues(t, consts.ErrWorkflowCompleted, waiterRes)
 
 					// new waiter still sees same result
-					_, err = upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, 100*time.Millisecond)
+					_, err = upd.WaitLifecycleStage(immediateCtx, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, immediateTimeout)
 					require.EqualExportedValues(t, consts.ErrWorkflowCompleted, err)
 				},
 			}, {
@@ -555,11 +598,82 @@ func TestUpdateState(t *testing.T) {
 					assertCompleted(t, upd, successOutcome)
 				},
 			}, {
+				// it is possible for the acceptance message and the WF completion command to
+				// be part of the same message batch, and thus they will be delivered without
+				// an intermediate call to apply pending effects
+				title: "transition to stateAborted via stateAccepted in one WFT",
+				apply: func() {
+					// start waiters
+					accptCh := make(chan any, 1)
+					go func() {
+						status, err := upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, 100*time.Millisecond)
+						if err != nil {
+							accptCh <- err
+							return
+						}
+						accptCh <- status.Outcome
+					}()
+					complCh := make(chan any, 1)
+					go func() {
+						status, err := upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, 100*time.Millisecond)
+						if err != nil {
+							complCh <- err
+							return
+						}
+						complCh <- status.Outcome
+					}()
+
+					err := accept(t, store, upd)
+					require.NoError(t, err)
+
+					// NOTE: no call to apply pending effects between these messages!
+
+					abort(t, store, upd, update.AbortReasonWorkflowCompleted)
+					require.False(t, completed, "completed call back should not be called when aborted")
+
+					assertNotAcceptedYet(t, upd)
+					assertNotCompletedYet(t, upd)
+
+					// apply pending effect
+					effects.Apply(context.Background())
+					require.False(t, completed, "completed call back should not be called when aborted")
+
+					// ensure both waiter received completed response
+					accptWaiterRes := <-accptCh
+					complWaiterRes := <-complCh
+					require.EqualExportedValues(t, abortedOutcome, accptWaiterRes)
+					require.EqualExportedValues(t, abortedOutcome, complWaiterRes)
+
+					// new waiter receives same response
+					assertAborted(t, upd, nil)
+				},
+			}, {
 				title:        "ignore another send request; unless explicitly requested",
 				failOnEffect: true,
 				apply: func() {
 					require.Nil(t, send(t, upd, skipAlreadySent), "update should not be sent")
 					require.NotNil(t, send(t, upd, includeAlreadySent), "update should be sent")
+				},
+			}, {
+				title: "aborted because registry is cleared",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonRegistryCleared)
+					effects.Apply(context.Background())
+					assertAborted(t, upd, update.WorkflowUpdateAbortedErr)
+				},
+			}, {
+				title: "aborted because Workflow completed",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonWorkflowCompleted)
+					effects.Apply(context.Background())
+					assertAborted(t, upd, consts.ErrWorkflowCompleted)
+				},
+			}, {
+				title: "aborted because Workflow completing",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonWorkflowContinuing)
+					effects.Apply(context.Background())
+					assertAborted(t, upd, consts.ErrWorkflowClosing)
 				},
 			},
 			})
@@ -709,7 +823,7 @@ func TestUpdateState(t *testing.T) {
 					require.NoError(t, err)
 					effects.Apply(context.Background())
 
-					status, err := upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, 100*time.Millisecond)
+					status, err := upd.WaitLifecycleStage(immediateCtx, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, immediateTimeout)
 					require.NoError(t, err)
 					require.NotNil(t, status)
 					require.Equal(t, "Workflow Update failed because the Workflow completed before the Update completed.", status.Outcome.GetFailure().Message)
@@ -742,6 +856,34 @@ func TestUpdateState(t *testing.T) {
 					require.Nil(t, send(t, upd, skipAlreadySent), "update should not be sent")
 					require.Nil(t, send(t, upd, includeAlreadySent), "update should not be sent")
 				},
+			}, {
+				title: "aborted because registry is cleared",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonRegistryCleared)
+					effects.Apply(context.Background())
+					// Because Update was already accepted, clear registry doesn't require retry.
+					assertAccepted(t, upd)
+
+					// And even completed stage returns accepted status (as most advanced status reached).
+					status, err := upd.WaitLifecycleStage(immediateCtx, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, immediateTimeout)
+					require.NoError(t, err)
+					require.Equal(t, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, status.Stage)
+					require.Nil(t, status.Outcome)
+				},
+			}, {
+				title: "aborted because Workflow completed",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonWorkflowCompleted)
+					effects.Apply(context.Background())
+					assertAborted(t, upd, nil)
+				},
+			}, {
+				title: "aborted because Workflow completing",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonWorkflowContinuing)
+					effects.Apply(context.Background())
+					assertAborted(t, upd, nil)
+				},
 			},
 			})
 	})
@@ -760,6 +902,27 @@ func TestUpdateState(t *testing.T) {
 			[]*stateTest{{
 				title: "send back status completed to waiters immediately for any stage",
 				apply: func() {
+					assertCompleted(t, upd, rejectionOutcome)
+				},
+			}, {
+				title: "aborted because registry is cleared",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonRegistryCleared)
+					effects.Apply(context.Background())
+					assertCompleted(t, upd, rejectionOutcome)
+				},
+			}, {
+				title: "aborted because Workflow completed",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonWorkflowCompleted)
+					effects.Apply(context.Background())
+					assertCompleted(t, upd, rejectionOutcome)
+				},
+			}, {
+				title: "aborted because Workflow completing",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonWorkflowContinuing)
+					effects.Apply(context.Background())
 					assertCompleted(t, upd, rejectionOutcome)
 				},
 			},
@@ -801,6 +964,27 @@ func TestUpdateState(t *testing.T) {
 				apply: func() {
 					require.Nil(t, send(t, upd, skipAlreadySent), "update should not be sent")
 					require.Nil(t, send(t, upd, includeAlreadySent), "update should not be sent")
+				},
+			}, {
+				title: "aborted because registry is cleared",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonRegistryCleared)
+					effects.Apply(context.Background())
+					assertCompleted(t, upd, successOutcome)
+				},
+			}, {
+				title: "aborted because Workflow completed",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonWorkflowCompleted)
+					effects.Apply(context.Background())
+					assertCompleted(t, upd, successOutcome)
+				},
+			}, {
+				title: "aborted because Workflow completing",
+				apply: func() {
+					abort(t, store, upd, update.AbortReasonWorkflowContinuing)
+					effects.Apply(context.Background())
+					assertCompleted(t, upd, successOutcome)
 				},
 			},
 			})
@@ -865,18 +1049,19 @@ func mustAdmit(t *testing.T, store mockEventStore, upd *update.Update) {
 func assertAdmitted(t *testing.T, upd *update.Update) {
 	t.Helper()
 
-	status, err := upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, immediateTimeout)
+	status, err := upd.WaitLifecycleStage(immediateCtx, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, immediateTimeout)
 	require.NoError(t, err)
 	require.Equal(t, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED, status.Stage)
 	require.Nil(t, status.Outcome, "outcome should not be available yet")
 
-	status, err = upd.WaitLifecycleStage(context.Background(), UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED, immediateTimeout)
+	status, err = upd.WaitLifecycleStage(immediateCtx, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED, immediateTimeout)
 	require.NoError(t, err)
 	require.Equal(t, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED, status.Stage)
 	require.Nil(t, status.Outcome, "outcome should not be available yet")
 }
 
 func admit(t *testing.T, store mockEventStore, upd *update.Update) error {
+	t.Helper()
 	return upd.Admit(&updatepb.Request{
 		Meta:  &updatepb.Meta{UpdateId: upd.ID()},
 		Input: &updatepb.Input{Name: "not_empty"},
@@ -889,6 +1074,7 @@ func send(t *testing.T, upd *update.Update, includeAlreadySent bool) *protocolpb
 }
 
 func reject(t *testing.T, store mockEventStore, upd *update.Update) error {
+	t.Helper()
 	return upd.OnProtocolMessage(&protocolpb.Message{
 		Body: MarshalAny(t, &updatepb.Rejection{
 			RejectedRequestMessageId: "update1/request",
@@ -949,6 +1135,7 @@ func assertNotAcceptedYet(t *testing.T, upd *update.Update) {
 }
 
 func respondSuccess(t *testing.T, store mockEventStore, upd *update.Update) error {
+	t.Helper()
 	return upd.OnProtocolMessage(&protocolpb.Message{
 		Body: MarshalAny(t, &updatepb.Response{
 			Meta:    &updatepb.Meta{UpdateId: upd.ID()},
@@ -957,6 +1144,7 @@ func respondSuccess(t *testing.T, store mockEventStore, upd *update.Update) erro
 }
 
 func respondFailure(t *testing.T, store mockEventStore, upd *update.Update) error {
+	t.Helper()
 	return upd.OnProtocolMessage(&protocolpb.Message{
 		Body: MarshalAny(t, &updatepb.Response{
 			Meta:    &updatepb.Meta{UpdateId: upd.ID()},
@@ -995,4 +1183,30 @@ func assertNotCompletedYet(t *testing.T, upd *update.Update) {
 	require.NoError(t, err)
 	require.NotEqual(t, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, status.Stage)
 	require.Nil(t, status.Outcome, "outcome should not be available yet")
+}
+func abort(t *testing.T, store mockEventStore, upd *update.Update, reason update.AbortReason) {
+	t.Helper()
+	upd.Abort(reason, store)
+}
+func assertAborted(t *testing.T, upd *update.Update, expectedErr error) {
+	t.Helper()
+
+	for _, stage := range []UpdateWorkflowExecutionLifecycleStage{
+		UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED,
+		UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ADMITTED,
+		UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+		UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+	} {
+		t.Logf("testing stage %v", UpdateWorkflowExecutionLifecycleStage.String(stage))
+		status, err := upd.WaitLifecycleStage(immediateCtx, stage, immediateTimeout)
+		if expectedErr == nil {
+			// expectedErr == nil means update was aborted with failure instead of error.
+			require.NoError(t, err)
+			require.Equal(t, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, status.Stage)
+			require.EqualExportedValues(t, abortedOutcome, status.Outcome)
+		} else {
+			require.Error(t, err)
+			require.ErrorIs(t, err, expectedErr)
+		}
+	}
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Delay Update abortion with effects package.

## Why?
<!-- Tell your future self why have you made these changes -->
To address race condition case when Update is accepted and WF is completed on the same WFT. In this scenario Update result waiters should have similar experience as if Update was failed with error on the same WFT, meaning that even waiters for `Accepted` stage should get Update result (which is abort failure). Previous implementation had race condition and those waiter might get Update failure, or "Update is accepted" response.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
Yes, updated.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.
