### PR TITLE
Dedupe HSM timers

### DIFF
--- a/service/history/workflow/state_machine_timers_test.go
+++ b/service/history/workflow/state_machine_timers_test.go
@@ -45,6 +45,8 @@ func TestTrackStateMachineTimer_MaintainsSortedSlice(t *testing.T) {
 	ms.EXPECT().NextTransitionCount().Return(int64(3)).AnyTimes()
 
 	workflow.TrackStateMachineTimer(ms, now, &persistencespb.StateMachineTaskInfo{Type: "0"})
+	// This should be deduped.
+	workflow.TrackStateMachineTimer(ms, now, &persistencespb.StateMachineTaskInfo{Type: "0"})
 	workflow.TrackStateMachineTimer(ms, now.Add(time.Hour), &persistencespb.StateMachineTaskInfo{Type: "1"})
 	workflow.TrackStateMachineTimer(ms, now.Add(time.Hour), &persistencespb.StateMachineTaskInfo{Type: "2"})
 	workflow.TrackStateMachineTimer(ms, now.Add(-time.Hour), &persistencespb.StateMachineTaskInfo{Type: "3"})

--- a/service/history/workflow/state_machine_timers_test.go
+++ b/service/history/workflow/state_machine_timers_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
 	"go.uber.org/mock/gomock"
@@ -44,16 +45,33 @@ func TestTrackStateMachineTimer_MaintainsSortedSlice(t *testing.T) {
 	ms.EXPECT().GetCurrentVersion().Return(int64(1)).AnyTimes()
 	ms.EXPECT().NextTransitionCount().Return(int64(3)).AnyTimes()
 
-	workflow.TrackStateMachineTimer(ms, now, &persistencespb.StateMachineTaskInfo{Type: "0"})
+	workflow.TrackStateMachineTimer(ms, now, &persistencespb.StateMachineTaskInfo{Type: "0", Ref: &persistencespb.StateMachineRef{
+		Path: []*persistencespb.StateMachineKey{{Type: "t", Id: "a"}},
+	}})
 	// This should be deduped.
-	workflow.TrackStateMachineTimer(ms, now, &persistencespb.StateMachineTaskInfo{Type: "0"})
+	workflow.TrackStateMachineTimer(ms, now, &persistencespb.StateMachineTaskInfo{Type: "0", Ref: &persistencespb.StateMachineRef{
+		Path: []*persistencespb.StateMachineKey{{Type: "t", Id: "a"}},
+	}})
+	// This should be deduped.
+	workflow.TrackStateMachineTimer(ms, now, &persistencespb.StateMachineTaskInfo{Type: "0", Ref: &persistencespb.StateMachineRef{
+		Path: []*persistencespb.StateMachineKey{{Type: "t", Id: "b"}},
+	}})
 	workflow.TrackStateMachineTimer(ms, now.Add(time.Hour), &persistencespb.StateMachineTaskInfo{Type: "1"})
 	workflow.TrackStateMachineTimer(ms, now.Add(time.Hour), &persistencespb.StateMachineTaskInfo{Type: "2"})
 	workflow.TrackStateMachineTimer(ms, now.Add(-time.Hour), &persistencespb.StateMachineTaskInfo{Type: "3"})
 
 	require.Equal(t, 3, len(execInfo.StateMachineTimers))
+
+	require.Equal(t, 1, len(execInfo.StateMachineTimers[0].Infos))
 	require.Equal(t, "3", execInfo.StateMachineTimers[0].Infos[0].Type)
+
+	require.Equal(t, 2, len(execInfo.StateMachineTimers[1].Infos))
 	require.Equal(t, "0", execInfo.StateMachineTimers[1].Infos[0].Type)
+	protorequire.ProtoSliceEqual(t, []*persistencespb.StateMachineKey{{Type: "t", Id: "a"}}, execInfo.StateMachineTimers[1].Infos[0].Ref.Path)
+	require.Equal(t, "0", execInfo.StateMachineTimers[1].Infos[1].Type)
+	protorequire.ProtoSliceEqual(t, []*persistencespb.StateMachineKey{{Type: "t", Id: "b"}}, execInfo.StateMachineTimers[1].Infos[1].Ref.Path)
+
+	require.Equal(t, 2, len(execInfo.StateMachineTimers[2].Infos))
 	require.Equal(t, "1", execInfo.StateMachineTimers[2].Infos[0].Type)
 	require.Equal(t, "2", execInfo.StateMachineTimers[2].Infos[1].Type)
 }


### PR DESCRIPTION
Deduplicate HSM timers if they come from the same state machine and have the same type to support regenerating tasks in the state based replication path.
Note, this can also be applied for the pre-state-replication path. I may follow up with a PR that changes how that path works but it's not critical since we're deprecating this framework.

Note that technically tasks can have a data field and there immediate tasks that can't be deduped this way but there aren't any uses where that's relevant and we're not expecting to expand usage.