### PR TITLE
Prevent frontend burst value going below 1

### DIFF
--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -205,7 +205,7 @@ func NewNamespaceRateBurst(
 		namespaceName: namespaceName,
 		rateFn:        rateFn,
 		burstFn: func(namespace string) int {
-			return max(1, math.Ceil(rateFn(namespace)*burstRatioFn(namespace)))
+			return max(1, int(math.Ceil(rateFn(namespace)*burstRatioFn(namespace))))
 		},
 	}
 }

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -205,7 +205,7 @@ func NewNamespaceRateBurst(
 		namespaceName: namespaceName,
 		rateFn:        rateFn,
 		burstFn: func(namespace string) int {
-			return int(math.Max(1, rateFn(namespace)*burstRatioFn(namespace)))
+			return max(1, math.Ceil(rateFn(namespace)*burstRatioFn(namespace)))
 		},
 	}
 }

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -205,7 +205,7 @@ func NewNamespaceRateBurst(
 		namespaceName: namespaceName,
 		rateFn:        rateFn,
 		burstFn: func(namespace string) int {
-			return int(rateFn(namespace) * math.Max(1, burstRatioFn(namespace)))
+			return int(math.Max(1, rateFn(namespace)*burstRatioFn(namespace)))
 		},
 	}
 }

--- a/service/frontend/fx_test.go
+++ b/service/frontend/fx_test.go
@@ -381,11 +381,11 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			expectRateLimit:                   false,
 		},
 		{
-			name:                              "namespace burst ratio does not apply for values < 1",
+			name:                              "namespace burst hit when burst ratio is 0.5",
 			maxNamespaceRPSPerInstance:        10,
 			maxNamespaceBurstRatioPerInstance: 0.5,
-			numRequests:                       10,
-			expectRateLimit:                   false,
+			numRequests:                       6,
+			expectRateLimit:                   true,
 		},
 		{
 			name:                              "namespace burst allow when burst ratio is 1 and global limit is set",
@@ -420,7 +420,7 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			globalNamespaceRPS:                5,
 			maxNamespaceRPSPerInstance:        10,
 			maxNamespaceBurstRatioPerInstance: 1.5,
-			numRequests:                       8,
+			numRequests:                       9,
 			expectRateLimit:                   true,
 		},
 		{
@@ -459,11 +459,11 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			expectRateLimit:                             false,
 		},
 		{
-			name:                                 "visibility burst ratio does not apply for values < 1",
+			name:                                 "visibility burst hit when burst ratio is 0.5",
 			maxNamespaceVisibilityRPSPerInstance: 10,
 			maxNamespaceVisibilityBurstRatioPerInstance: 0.5,
-			numVisibilityRequests:                       10,
-			expectRateLimit:                             false,
+			numVisibilityRequests:                       6,
+			expectRateLimit:                             true,
 		},
 		{
 			name:                                 "visibility burst allow when burst ratio is 1 and global limit is set",
@@ -498,7 +498,7 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			globalNamespaceVisibilityRPS:         5,
 			maxNamespaceVisibilityRPSPerInstance: 10,
 			maxNamespaceVisibilityBurstRatioPerInstance: 1.5,
-			numVisibilityRequests:                       8,
+			numVisibilityRequests:                       9,
 			expectRateLimit:                             true,
 		},
 		{
@@ -537,11 +537,11 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			expectRateLimit:                                                   false,
 		},
 		{
-			name: "replication inducing op burst ratio does not apply for values < 1",
+			name: "replication inducing op burst hit when burst ratio is 0.5",
 			maxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:        10,
 			maxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance: 0.5,
-			numReplicationInducingRequests:                                    10,
-			expectRateLimit:                                                   false,
+			numReplicationInducingRequests:                                    6,
+			expectRateLimit:                                                   true,
 		},
 		{
 			name:                 "replication inducing op burst allow when burst ratio is 1 and global limit is set",
@@ -576,7 +576,7 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 			globalNamespaceNamespaceReplicationInducingAPIsRPS:                5,
 			maxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:        10,
 			maxNamespaceNamespaceReplicationInducingAPIsBurstRatioPerInstance: 1.5,
-			numReplicationInducingRequests:                                    8,
+			numReplicationInducingRequests:                                    9,
 			expectRateLimit:                                                   true,
 		},
 	}


### PR DESCRIPTION
## What changed?
Prevent frontend burst value going below 0 in NewNamespaceRateBurst()

## Why?
If the rate value is too small, the burst value can become 0. This will block all requests. This can happen for rate limiters with small global RPS values(eg. namespaceReplicationInducingAPIs rate limiter) in a cluster with large number of frontend instances.

## How did you test it?
Existing tests.

## Potential risks

## Documentation

## Is hotfix candidate?
No
