### PR TITLE
demo: Inline matching/history rpcs and local load balancing

### DIFF
--- a/client/history/client_test.go
+++ b/client/history/client_test.go
@@ -185,7 +185,7 @@ func (s *testHistoryService) DeleteDLQTasks(
 	return &historyservice.DeleteDLQTasksResponse{}, nil
 }
 
-func (t *testRPCFactory) CreateInternodeGRPCConnection(rpcAddress string) *grpc.ClientConn {
+func (t *testRPCFactory) CreateInternodeGRPCConnection(rpcAddress string) grpc.ClientConnInterface {
 	t.dialedAddresses = append(t.dialedAddresses, rpcAddress)
 	return t.base.CreateInternodeGRPCConnection(rpcAddress)
 }

--- a/client/history/connections.go
+++ b/client/history/connections.go
@@ -37,7 +37,7 @@ import (
 type (
 	clientConnection struct {
 		historyClient historyservice.HistoryServiceClient
-		grpcConn      *grpc.ClientConn
+		grpcConn      grpc.ClientConnInterface
 	}
 
 	rpcAddress string
@@ -54,7 +54,7 @@ type (
 
 	// RPCFactory is a subset of the [go.temporal.io/server/common/rpc.RPCFactory] interface to make testing easier.
 	RPCFactory interface {
-		CreateInternodeGRPCConnection(rpcAddress string) *grpc.ClientConn
+		CreateInternodeGRPCConnection(rpcAddress string) grpc.ClientConnInterface
 	}
 
 	connectionPool interface {
@@ -114,5 +114,7 @@ func (c *connectionPoolImpl) getAllClientConns() []clientConnection {
 }
 
 func (c *connectionPoolImpl) resetConnectBackoff(cc clientConnection) {
-	cc.grpcConn.ResetConnectBackoff()
+	if grpcc, ok := cc.grpcConn.(*grpc.ClientConn); ok {
+		grpcc.ResetConnectBackoff()
+	}
 }

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1203,6 +1203,25 @@ these log lines can be noisy, we want to be able to turn on and sample selective
 		time.Second,
 		`TaskQueueInfoByBuildIdTTL serves as a TTL for the cache holding DescribeTaskQueue partition results`,
 	)
+	MatchingSpreadPartitions = NewTaskQueueBoolSetting(
+		"matching.spreadPartitions",
+		false,
+		`Use LookupN instead of Lookup to spread partitions evenly across matching nodes.
+Note: Enabling on an active queue will cause temporarily disruption.`,
+	)
+	MatchingLocalBalancing = NewTaskQueueBoolSetting(
+		"matching.localBalancing",
+		false,
+		`Try to send tasks to matching nodes in the same process as history.
+This also requires matching.spreadPartitions to be set.`,
+	)
+	MatchingLocalBalancingCacheSize = NewGlobalIntSetting(
+		"matching.localBalancingCacheSize",
+		1000,
+		`Size of cache for matching.localBalancing. This should be more than the number of
+task queues using local balancing.`,
+	)
+
 	// for matching testing only:
 
 	TestMatchingDisableSyncMatch = NewGlobalBoolSetting(

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -675,6 +675,10 @@ var (
 		"http_service_requests",
 		WithDescription("The number of HTTP requests received by the service."),
 	)
+	InlineRequests = NewCounterDef(
+		"inline_requests",
+		WithDescription("The number of GRPC requests routed in-process."),
+	)
 	NexusRequests = NewCounterDef(
 		"nexus_requests",
 		WithDescription("The number of Nexus requests received by the service."),

--- a/common/namespace/namespacegetter/namespace.go
+++ b/common/namespace/namespacegetter/namespace.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package interceptor
+package namespacegetter
 
 import (
 	"fmt"

--- a/common/namespace/namespacegetter/namespace_test.go
+++ b/common/namespace/namespacegetter/namespace_test.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package interceptor
+package namespacegetter
 
 import (
 	"errors"

--- a/common/rpc.go
+++ b/common/rpc.go
@@ -37,10 +37,11 @@ import (
 type RPCFactory interface {
 	GetFrontendGRPCServerOptions() ([]grpc.ServerOption, error)
 	GetInternodeGRPCServerOptions() ([]grpc.ServerOption, error)
+	GetGRPCClientInterceptors() []grpc.UnaryClientInterceptor
 	GetGRPCListener() net.Listener
-	CreateRemoteFrontendGRPCConnection(rpcAddress string) *grpc.ClientConn
-	CreateLocalFrontendGRPCConnection() *grpc.ClientConn
-	CreateInternodeGRPCConnection(rpcAddress string) *grpc.ClientConn
+	CreateRemoteFrontendGRPCConnection(rpcAddress string) grpc.ClientConnInterface
+	CreateLocalFrontendGRPCConnection() grpc.ClientConnInterface
+	CreateInternodeGRPCConnection(rpcAddress string) grpc.ClientConnInterface
 	CreateLocalFrontendHTTPClient() (*FrontendHTTPClient, error)
 }
 

--- a/common/rpc/inline/inline.go
+++ b/common/rpc/inline/inline.go
@@ -7,7 +7,7 @@ import (
 
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/rpc/interceptor"
+	"go.temporal.io/server/common/namespace/namespacegetter"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -136,7 +136,7 @@ func (icc *inlineClientConn) Invoke(
 
 	// Add metric
 	var namespaceTag metrics.Tag
-	if namespaceName := interceptor.MustGetNamespaceName(serviceMethod.namespaceRegistry, args); namespaceName != "" {
+	if namespaceName := namespacegetter.MustGetNamespaceName(serviceMethod.namespaceRegistry, args); namespaceName != "" {
 		namespaceTag = metrics.NamespaceTag(namespaceName.String())
 	} else {
 		namespaceTag = metrics.NamespaceUnknownTag()

--- a/common/rpc/inline/inline.go
+++ b/common/rpc/inline/inline.go
@@ -1,0 +1,289 @@
+package inline
+
+import (
+	"context"
+	"errors"
+	"reflect"
+
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/rpc/interceptor"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	errGRPCStreamNotSupported = errors.New("stream not supported")
+)
+
+// inlineClientConn is a [grpc.ClientConnInterface] implementation that forwards
+// requests directly to gRPC via interceptors. This implementation moves all
+// outgoing metadata to incoming and takes resulting outgoing metadata and sets
+// as header. But which headers to use and TLS peer context and such are
+// expected to be handled by the caller.
+//
+// RegisterServer must not be called concurrently with itself or with Invoke,
+// but after all RegisterServer calls are done (in server initialization),
+// Invoke may be called concurrently.
+type inlineClientConn struct {
+	methods map[string]*serviceMethod
+}
+
+var _ grpc.ClientConnInterface = (*inlineClientConn)(nil)
+
+type serviceMethod struct {
+	info              grpc.UnaryServerInfo
+	handler           grpc.UnaryHandler
+	clientInterceptor grpc.UnaryClientInterceptor
+	serverInterceptor grpc.UnaryServerInterceptor
+	requestCounter    metrics.CounterIface
+	namespaceRegistry namespace.Registry
+	fakeClientConn    *grpc.ClientConn
+}
+
+var contextType = reflect.TypeOf((*context.Context)(nil)).Elem()
+var protoMessageType = reflect.TypeOf((*proto.Message)(nil)).Elem()
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+func init() {
+	// This must be done at static init time.
+	resolver.Register(inlineGrpcBuilder{})
+}
+
+func NewInlineClientConn() *inlineClientConn {
+	return &inlineClientConn{
+		methods: make(map[string]*serviceMethod),
+	}
+}
+
+// RegisterServer adds a server to the inlineClientConn. This must not be called concurrently.
+func (icc *inlineClientConn) RegisterServer(
+	qualifiedServerName string,
+	server any,
+	clientInterceptors []grpc.UnaryClientInterceptor,
+	serverInterceptors []grpc.UnaryServerInterceptor,
+	requestCounter metrics.CounterIface,
+	namespaceRegistry namespace.Registry,
+) {
+	// Create a fake "real" *grpc.ClientConn just for client interceptors, since the function
+	// signature requires one. Our interceptors don't refer to the cc parameter, but the
+	// otelgrpc interceptor does, it calls cc.Target(). This will cause that to return
+	// "internal://...". We register an actual grpc resolver builder for the "internal" scheme
+	// to prevent grpc from falling back to dns. (Note that even if it falls back to dns, it
+	// won't do a lookup until the ClientConn is actually used. But it's safer to do this.)
+	target := inlineScheme + "://" + qualifiedServerName
+	fakeClientConn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		panic(err)
+	}
+
+	// Create the set of methods via reflection. We currently accept the overhead
+	// of reflection compared to having to custom generate gateway code.
+	serverVal := reflect.ValueOf(server)
+	for i := 0; i < serverVal.Type().NumMethod(); i++ {
+		reflectMethod := serverVal.Type().Method(i)
+		// We intentionally look this up by name to not assume method indexes line
+		// up from type to value
+		methodVal := serverVal.MethodByName(reflectMethod.Name)
+		// We assume the methods we want only accept a context + request and only
+		// return a response + error. We also assume the method name matches the
+		// RPC name.
+		methodType := methodVal.Type()
+		validRPCMethod := methodType.Kind() == reflect.Func &&
+			methodType.NumIn() == 2 &&
+			methodType.NumOut() == 2 &&
+			methodType.In(0) == contextType &&
+			methodType.In(1).Implements(protoMessageType) &&
+			methodType.Out(0).Implements(protoMessageType) &&
+			methodType.Out(1) == errorType
+		if !validRPCMethod {
+			continue
+		}
+		fullMethod := "/" + qualifiedServerName + "/" + reflectMethod.Name
+		icc.methods[fullMethod] = &serviceMethod{
+			info: grpc.UnaryServerInfo{Server: server, FullMethod: fullMethod},
+			handler: func(ctx context.Context, req interface{}) (interface{}, error) {
+				ret := methodVal.Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(req)})
+				err, _ := ret[1].Interface().(error)
+				return ret[0].Interface(), err
+			},
+			clientInterceptor: chainUnaryClientInterceptors(clientInterceptors),
+			serverInterceptor: chainUnaryServerInterceptors(serverInterceptors),
+			requestCounter:    requestCounter,
+			namespaceRegistry: namespaceRegistry,
+			fakeClientConn:    fakeClientConn,
+		}
+	}
+}
+
+func (icc *inlineClientConn) Invoke(
+	ctx context.Context,
+	method string,
+	args any,
+	reply any,
+	opts ...grpc.CallOption,
+) error {
+	// Get the method. Should never fail, but we check anyways
+	serviceMethod := icc.methods[method]
+	if serviceMethod == nil {
+		return status.Error(codes.NotFound, "call not found")
+	}
+
+	// Add metric
+	var namespaceTag metrics.Tag
+	if namespaceName := interceptor.MustGetNamespaceName(serviceMethod.namespaceRegistry, args); namespaceName != "" {
+		namespaceTag = metrics.NamespaceTag(namespaceName.String())
+	} else {
+		namespaceTag = metrics.NamespaceUnknownTag()
+	}
+	serviceMethod.requestCounter.Record(1, metrics.OperationTag(method), namespaceTag)
+
+	// Invoke
+	invoker := func(ctx context.Context, method string, req, reply any, _ *grpc.ClientConn, opts ...grpc.CallOption) error {
+		// We are now after all client interceptors, and before all server interceptors.
+
+		// Add a fake ServerTransportStream to capture any headers or trailers set by server interceptors.
+		stream := fakeServerTransportStream{method: method}
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+
+		// Move outgoing metadata to incoming and set new outgoing metadata
+		md, _ := metadata.FromOutgoingContext(ctx)
+		ctx = metadata.NewIncomingContext(ctx, md)
+		outgoingMD := metadata.MD{}
+		ctx = metadata.NewOutgoingContext(ctx, outgoingMD)
+
+		resp, err := serviceMethod.serverInterceptor(ctx, args, &serviceMethod.info, serviceMethod.handler)
+
+		// Find the header/trailer call option and set response headers. We accept that if
+		// somewhere internally the metadata was replaced instead of appended to, this
+		// does not work.
+		for _, opt := range opts {
+			if callOpt, ok := opt.(grpc.HeaderCallOption); ok {
+				*callOpt.HeaderAddr = metadata.Join(outgoingMD, stream.header)
+			} else if trailerOpt, ok := opt.(grpc.TrailerCallOption); ok {
+				*trailerOpt.TrailerAddr = stream.trailer
+			}
+		}
+
+		// Merge the response proto onto the wanted reply if non-nil
+		// TODO: is there any way to optimize this to not call Merge and do a "move" instead?
+		if respProto, _ := resp.(proto.Message); respProto != nil {
+			proto.Merge(reply.(proto.Message), respProto)
+		}
+
+		return err
+	}
+
+	return serviceMethod.clientInterceptor(ctx, method, args, reply, serviceMethod.fakeClientConn, invoker, opts...)
+}
+
+func (*inlineClientConn) NewStream(
+	context.Context,
+	*grpc.StreamDesc,
+	string,
+	...grpc.CallOption,
+) (grpc.ClientStream, error) {
+	return nil, errGRPCStreamNotSupported
+}
+
+// Mostly taken from https://github.com/grpc/grpc-go/blob/v1.56.1/server.go#L1124-L1158
+// with slight modifications.
+func chainUnaryServerInterceptors(interceptors []grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
+	switch len(interceptors) {
+	case 0:
+		return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+			return handler(ctx, req)
+		}
+	case 1:
+		return interceptors[0]
+	default:
+		return chainUnaryInterceptors(interceptors)
+	}
+}
+
+func chainUnaryInterceptors(interceptors []grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		return interceptors[0](ctx, req, info, getChainUnaryHandler(interceptors, 0, info, handler))
+	}
+}
+
+func getChainUnaryHandler(
+	interceptors []grpc.UnaryServerInterceptor,
+	curr int,
+	info *grpc.UnaryServerInfo,
+	finalHandler grpc.UnaryHandler,
+) grpc.UnaryHandler {
+	if curr == len(interceptors)-1 {
+		return finalHandler
+	}
+	return func(ctx context.Context, req interface{}) (interface{}, error) {
+		return interceptors[curr+1](ctx, req, info, getChainUnaryHandler(interceptors, curr+1, info, finalHandler))
+	}
+}
+
+// Mostly taken from https://github.com/grpc/grpc-go/blob/v1.66.0/clientconn.go
+// with modifications.
+func chainUnaryClientInterceptors(interceptors []grpc.UnaryClientInterceptor) grpc.UnaryClientInterceptor {
+	if len(interceptors) == 0 {
+		return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
+	} else if len(interceptors) == 1 {
+		return interceptors[0]
+	} else {
+		return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+			return interceptors[0](ctx, method, req, reply, cc, getChainUnaryInvoker(interceptors, 0, invoker), opts...)
+		}
+	}
+}
+
+func getChainUnaryInvoker(interceptors []grpc.UnaryClientInterceptor, curr int, finalInvoker grpc.UnaryInvoker) grpc.UnaryInvoker {
+	if curr == len(interceptors)-1 {
+		return finalInvoker
+	}
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		return interceptors[curr+1](ctx, method, req, reply, cc, getChainUnaryInvoker(interceptors, curr+1, finalInvoker), opts...)
+	}
+}
+
+type fakeServerTransportStream struct {
+	method  string
+	header  metadata.MD
+	trailer metadata.MD
+}
+
+func (f *fakeServerTransportStream) Method() string {
+	return f.method
+}
+
+func (f *fakeServerTransportStream) SetHeader(md metadata.MD) error {
+	f.header = metadata.Join(f.header, md)
+	return nil
+}
+
+func (f *fakeServerTransportStream) SendHeader(md metadata.MD) error {
+	panic("not implemented")
+}
+
+func (f *fakeServerTransportStream) SetTrailer(md metadata.MD) error {
+	f.trailer = metadata.Join(f.trailer, md)
+	return nil
+}
+
+type inlineGrpcBuilder struct{}
+
+const inlineScheme = "inline"
+
+func (i inlineGrpcBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+	// This resolver is never actually used so we should not get here.
+	panic("not implemented")
+}
+
+func (i inlineGrpcBuilder) Scheme() string {
+	return inlineScheme
+}

--- a/common/rpc/inline/registry.go
+++ b/common/rpc/inline/registry.go
@@ -1,0 +1,32 @@
+package inline
+
+import (
+	"sync"
+
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"google.golang.org/grpc"
+)
+
+var inlineConns sync.Map
+
+func RegisterInlineServer(
+	selfHostName string,
+	qualifiedServerName string,
+	server any,
+	clientInterceptors []grpc.UnaryClientInterceptor,
+	serverInterceptors []grpc.UnaryServerInterceptor,
+	requestCounter metrics.CounterIface,
+	namespaceRegistry namespace.Registry,
+) {
+	v, _ := inlineConns.LoadOrStore(selfHostName, NewInlineClientConn())
+	cc := v.(*inlineClientConn)
+	cc.RegisterServer(qualifiedServerName, server, clientInterceptors, serverInterceptors, requestCounter, namespaceRegistry)
+}
+
+func GetInlineConn(hostName string) grpc.ClientConnInterface {
+	if v, ok := inlineConns.Load(hostName); ok {
+		return v.(grpc.ClientConnInterface)
+	}
+	return nil
+}

--- a/common/rpc/interceptor/caller_info.go
+++ b/common/rpc/interceptor/caller_info.go
@@ -30,6 +30,7 @@ import (
 	"go.temporal.io/server/common/api"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/namespace/namespacegetter"
 	"google.golang.org/grpc"
 )
 
@@ -57,7 +58,7 @@ func (i *CallerInfoInterceptor) Intercept(
 ) (interface{}, error) {
 	ctx = PopulateCallerInfo(
 		ctx,
-		func() string { return string(MustGetNamespaceName(i.namespaceRegistry, req)) },
+		func() string { return string(namespacegetter.MustGetNamespaceName(i.namespaceRegistry, req)) },
 		func() string { return api.MethodName(info.FullMethod) },
 	)
 

--- a/common/rpc/interceptor/concurrent_request_limit.go
+++ b/common/rpc/interceptor/concurrent_request_limit.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/namespace/namespacegetter"
 	"go.temporal.io/server/common/quotas/calculator"
 	"google.golang.org/grpc"
 )
@@ -96,7 +97,7 @@ func (ni *ConcurrentRequestLimitInterceptor) Intercept(
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (interface{}, error) {
-	nsName := MustGetNamespaceName(ni.namespaceRegistry, req)
+	nsName := namespacegetter.MustGetNamespaceName(ni.namespaceRegistry, req)
 	mh := GetMetricsHandlerFromContext(ctx, ni.logger)
 	cleanup, err := ni.Allow(nsName, info.FullMethod, mh, req)
 	defer cleanup()

--- a/common/rpc/interceptor/mask_internal_error.go
+++ b/common/rpc/interceptor/mask_internal_error.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/namespace/namespacegetter"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -71,7 +72,7 @@ func (i *MaskInternalErrorDetailsInterceptor) Intercept(
 }
 
 func (i *MaskInternalErrorDetailsInterceptor) shouldMaskErrors(req any) bool {
-	ns := MustGetNamespaceName(i.namespaceRegistry, req)
+	ns := namespacegetter.MustGetNamespaceName(i.namespaceRegistry, req)
 	if ns.IsEmpty() {
 		return false
 	}

--- a/common/rpc/interceptor/namespace_logger.go
+++ b/common/rpc/interceptor/namespace_logger.go
@@ -34,6 +34,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/namespace/namespacegetter"
 	"google.golang.org/grpc"
 )
 
@@ -63,7 +64,7 @@ func (nli *NamespaceLogInterceptor) Intercept(
 
 	if nli.logger != nil {
 		methodName := api.MethodName(info.FullMethod)
-		namespace := MustGetNamespaceName(nli.namespaceRegistry, req)
+		namespace := namespacegetter.MustGetNamespaceName(nli.namespaceRegistry, req)
 		tlsInfo := authorization.TLSInfoFromContext(ctx)
 		var serverName string
 		var certThumbprint string

--- a/common/rpc/interceptor/namespace_rate_limit.go
+++ b/common/rpc/interceptor/namespace_rate_limit.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/namespace/namespacegetter"
 	"go.temporal.io/server/common/quotas"
 	"google.golang.org/grpc"
 )
@@ -76,7 +77,7 @@ func (ni *NamespaceRateLimitInterceptor) Intercept(
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (interface{}, error) {
-	if ns := MustGetNamespaceName(ni.namespaceRegistry, req); ns != namespace.EmptyName {
+	if ns := namespacegetter.MustGetNamespaceName(ni.namespaceRegistry, req); ns != namespace.EmptyName {
 		if err := ni.Allow(ns, info.FullMethod, headers.NewGRPCHeaderGetter(ctx)); err != nil {
 			return nil, err
 		}

--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common/api"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/namespace/namespacegetter"
 	"google.golang.org/grpc"
 )
 
@@ -131,7 +132,7 @@ func (ni *NamespaceValidatorInterceptor) NamespaceValidateIntercept(
 	if err != nil {
 		return nil, err
 	}
-	reqWithNamespace, hasNamespace := req.(NamespaceNameGetter)
+	reqWithNamespace, hasNamespace := req.(namespacegetter.NamespaceNameGetter)
 	if hasNamespace {
 		if err := ni.ValidateName(reqWithNamespace.GetNamespace()); err != nil {
 			return nil, err
@@ -153,7 +154,7 @@ func (ni *NamespaceValidatorInterceptor) setNamespaceIfNotPresent(
 	req interface{},
 ) error {
 	switch request := req.(type) {
-	case NamespaceNameGetter:
+	case namespacegetter.NamespaceNameGetter:
 		if request.GetNamespace() == "" {
 			namespaceEntry, err := ni.extractNamespaceFromTaskToken(req)
 			if err != nil {
@@ -270,7 +271,7 @@ func (ni *NamespaceValidatorInterceptor) extractNamespace(req interface{}) (*nam
 }
 
 func (ni *NamespaceValidatorInterceptor) extractNamespaceFromRequest(req interface{}) (*namespace.Namespace, error) {
-	reqWithNamespace, hasNamespace := req.(NamespaceNameGetter)
+	reqWithNamespace, hasNamespace := req.(namespacegetter.NamespaceNameGetter)
 	if !hasNamespace {
 		return nil, nil
 	}

--- a/common/rpc/interceptor/redirection.go
+++ b/common/rpc/interceptor/redirection.go
@@ -41,6 +41,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/namespace/namespacegetter"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -197,7 +198,7 @@ func (i *Redirection) Intercept(
 		return i.handleLocalAPIInvocation(ctx, req, handler, methodName)
 	}
 	if raFn, ok := globalAPIResponses[methodName]; ok {
-		namespaceName, err := GetNamespaceName(i.namespaceCache, req)
+		namespaceName, err := namespacegetter.GetNamespaceName(i.namespaceCache, req)
 		if err != nil {
 			return nil, err
 		}

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -41,6 +41,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/namespace/namespacegetter"
 	"go.temporal.io/server/common/rpc/interceptor/logtags"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"google.golang.org/grpc"
@@ -179,7 +180,7 @@ func (ti *TelemetryInterceptor) UnaryIntercept(
 	handler grpc.UnaryHandler,
 ) (any, error) {
 	methodName := api.MethodName(info.FullMethod)
-	nsName := MustGetNamespaceName(ti.namespaceRegistry, req)
+	nsName := namespacegetter.MustGetNamespaceName(ti.namespaceRegistry, req)
 
 	metricsHandler, logTags := ti.unaryMetricsHandlerLogTags(req, info.FullMethod, methodName, nsName)
 

--- a/common/rpc_mock.go
+++ b/common/rpc_mock.go
@@ -65,10 +65,10 @@ func (m *MockRPCFactory) EXPECT() *MockRPCFactoryMockRecorder {
 }
 
 // CreateInternodeGRPCConnection mocks base method.
-func (m *MockRPCFactory) CreateInternodeGRPCConnection(rpcAddress string) *grpc.ClientConn {
+func (m *MockRPCFactory) CreateInternodeGRPCConnection(rpcAddress string) grpc.ClientConnInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInternodeGRPCConnection", rpcAddress)
-	ret0, _ := ret[0].(*grpc.ClientConn)
+	ret0, _ := ret[0].(grpc.ClientConnInterface)
 	return ret0
 }
 
@@ -79,10 +79,10 @@ func (mr *MockRPCFactoryMockRecorder) CreateInternodeGRPCConnection(rpcAddress a
 }
 
 // CreateLocalFrontendGRPCConnection mocks base method.
-func (m *MockRPCFactory) CreateLocalFrontendGRPCConnection() *grpc.ClientConn {
+func (m *MockRPCFactory) CreateLocalFrontendGRPCConnection() grpc.ClientConnInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLocalFrontendGRPCConnection")
-	ret0, _ := ret[0].(*grpc.ClientConn)
+	ret0, _ := ret[0].(grpc.ClientConnInterface)
 	return ret0
 }
 
@@ -108,10 +108,10 @@ func (mr *MockRPCFactoryMockRecorder) CreateLocalFrontendHTTPClient() *gomock.Ca
 }
 
 // CreateRemoteFrontendGRPCConnection mocks base method.
-func (m *MockRPCFactory) CreateRemoteFrontendGRPCConnection(rpcAddress string) *grpc.ClientConn {
+func (m *MockRPCFactory) CreateRemoteFrontendGRPCConnection(rpcAddress string) grpc.ClientConnInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRemoteFrontendGRPCConnection", rpcAddress)
-	ret0, _ := ret[0].(*grpc.ClientConn)
+	ret0, _ := ret[0].(grpc.ClientConnInterface)
 	return ret0
 }
 
@@ -134,6 +134,20 @@ func (m *MockRPCFactory) GetFrontendGRPCServerOptions() ([]grpc.ServerOption, er
 func (mr *MockRPCFactoryMockRecorder) GetFrontendGRPCServerOptions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFrontendGRPCServerOptions", reflect.TypeOf((*MockRPCFactory)(nil).GetFrontendGRPCServerOptions))
+}
+
+// GetGRPCClientInterceptors mocks base method.
+func (m *MockRPCFactory) GetGRPCClientInterceptors() []grpc.UnaryClientInterceptor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGRPCClientInterceptors")
+	ret0, _ := ret[0].([]grpc.UnaryClientInterceptor)
+	return ret0
+}
+
+// GetGRPCClientInterceptors indicates an expected call of GetGRPCClientInterceptors.
+func (mr *MockRPCFactoryMockRecorder) GetGRPCClientInterceptors() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGRPCClientInterceptors", reflect.TypeOf((*MockRPCFactory)(nil).GetGRPCClientInterceptors))
 }
 
 // GetGRPCListener mocks base method.

--- a/common/tqid/task_queue_id.go
+++ b/common/tqid/task_queue_id.go
@@ -340,7 +340,7 @@ func (p *NormalPartition) ParentPartition(degree int) (*NormalPartition, error) 
 
 func (p *NormalPartition) RpcName() string {
 	if p.IsRoot() {
-		return p.TaskQueue().family.Name()
+		return p.TaskQueue().Name()
 	}
 	return nonRootPartitionPrefix + p.TaskQueue().Name() + partitionDelimiter + strconv.Itoa(p.partitionId)
 }
@@ -356,6 +356,13 @@ func (p *NormalPartition) Key() PartitionKey {
 
 func (p *NormalPartition) RoutingKey() string {
 	return fmt.Sprintf("%s:%s:%d", p.NamespaceId(), p.RpcName(), p.TaskType())
+}
+
+func (p *NormalPartition) RoutingKeyWithoutPartition() string {
+	// We have to use the rpc name of the root partition here for compatibility, to match
+	// StickyPartition.RoutingKey, since we can't always tell if an rpc name is sticky or
+	// the root of a normal queue.
+	return fmt.Sprintf("%s:%s:%d", p.NamespaceId(), p.TaskQueue().Name(), p.TaskType())
 }
 
 // parseRpcName takes the rpc name of a task queue partition and returns a ParseTaskQueuePartition.

--- a/internal/nettest/rpc_factory.go
+++ b/internal/nettest/rpc_factory.go
@@ -58,15 +58,19 @@ func (f *RPCFactory) GetInternodeGRPCServerOptions() ([]grpc.ServerOption, error
 	return nil, nil
 }
 
+func (f *RPCFactory) GetGRPCClientInterceptors() []grpc.UnaryClientInterceptor {
+	return nil
+}
+
 func (f *RPCFactory) GetGRPCListener() net.Listener {
 	return f.listener
 }
 
-func (f *RPCFactory) CreateRemoteFrontendGRPCConnection(rpcAddress string) *grpc.ClientConn {
+func (f *RPCFactory) CreateRemoteFrontendGRPCConnection(rpcAddress string) grpc.ClientConnInterface {
 	return f.dial(rpcAddress)
 }
 
-func (f *RPCFactory) CreateLocalFrontendGRPCConnection() *grpc.ClientConn {
+func (f *RPCFactory) CreateLocalFrontendGRPCConnection() grpc.ClientConnInterface {
 	return f.dial(f.listener.Addr().String())
 }
 
@@ -74,11 +78,11 @@ func (f *RPCFactory) CreateLocalFrontendHTTPClient() (*common.FrontendHTTPClient
 	panic("unimplemented in the nettest package")
 }
 
-func (f *RPCFactory) CreateInternodeGRPCConnection(rpcAddress string) *grpc.ClientConn {
+func (f *RPCFactory) CreateInternodeGRPCConnection(rpcAddress string) grpc.ClientConnInterface {
 	return f.dial(rpcAddress)
 }
 
-func (f *RPCFactory) dial(rpcAddress string) *grpc.ClientConn {
+func (f *RPCFactory) dial(rpcAddress string) grpc.ClientConnInterface {
 	dialOptions := append(f.dialOptions,
 		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
 			return f.listener.Connect(ctx.Done())

--- a/internal/nettest/rpc_factory_test.go
+++ b/internal/nettest/rpc_factory_test.go
@@ -62,7 +62,7 @@ func TestRPCFactory_CreateInternodeGRPCConnection(t *testing.T) {
 func TestRPCFactory_CreateLocalFrontendGRPCConnection(t *testing.T) {
 	t.Parallel()
 
-	testDialer(t, ":0", func(rpcFactory *nettest.RPCFactory) *grpc.ClientConn {
+	testDialer(t, ":0", func(rpcFactory *nettest.RPCFactory) grpc.ClientConnInterface {
 		return rpcFactory.CreateLocalFrontendGRPCConnection()
 	})
 }
@@ -70,7 +70,7 @@ func TestRPCFactory_CreateLocalFrontendGRPCConnection(t *testing.T) {
 func TestRPCFactory_CreateRemoteFrontendGRPCConnection(t *testing.T) {
 	t.Parallel()
 
-	testDialer(t, "localhost", func(rpcFactory *nettest.RPCFactory) *grpc.ClientConn {
+	testDialer(t, "localhost", func(rpcFactory *nettest.RPCFactory) grpc.ClientConnInterface {
 		return rpcFactory.CreateRemoteFrontendGRPCConnection("localhost")
 	})
 }

--- a/service/frontend/http_api_server.go
+++ b/service/frontend/http_api_server.go
@@ -31,7 +31,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"reflect"
 	"strings"
 	"time"
 
@@ -48,15 +47,12 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/rpc/encryption"
-	"go.temporal.io/server/common/rpc/interceptor"
+	"go.temporal.io/server/common/rpc/inline"
 	"go.temporal.io/server/common/utf8validator"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 // HTTPAPIServer is an HTTP API server that forwards requests to gRPC via the
@@ -81,8 +77,7 @@ var defaultForwardedHeaders = []string{
 type httpRemoteAddrContextKey struct{}
 
 var (
-	errHTTPGRPCListenerNotTCP     = errors.New("must use TCP for gRPC listener to support HTTP API")
-	errHTTPGRPCStreamNotSupported = errors.New("stream not supported")
+	errHTTPGRPCListenerNotTCP = errors.New("must use TCP for gRPC listener to support HTTP API")
 )
 
 // NewHTTPAPIServer creates an [HTTPAPIServer].
@@ -95,7 +90,7 @@ func NewHTTPAPIServer(
 	tlsConfigProvider encryption.TLSConfigProvider,
 	handler Handler,
 	operatorHandler *OperatorHandlerImpl,
-	interceptors []grpc.UnaryServerInterceptor,
+	serverInterceptors []grpc.UnaryServerInterceptor,
 	metricsHandler metrics.Handler,
 	router *mux.Router,
 	namespaceRegistry namespace.Registry,
@@ -162,14 +157,25 @@ func NewHTTPAPIServer(
 
 	opts = append(opts, runtime.WithIncomingHeaderMatcher(h.incomingHeaderMatcher))
 
+	clientInterceptors := []grpc.UnaryClientInterceptor{setDefaultClientHeadersForHTTP}
+
 	// Create inline client connection
-	clientConn := newInlineClientConn(
-		map[string]any{
-			"temporal.api.workflowservice.v1.WorkflowService": handler,
-			"temporal.api.operatorservice.v1.OperatorService": operatorHandler,
-		},
-		interceptors,
-		metricsHandler,
+	counter := metrics.HTTPServiceRequests.With(metricsHandler)
+	clientConn := inline.NewInlineClientConn()
+	clientConn.RegisterServer(
+		"temporal.api.workflowservice.v1.WorkflowService",
+		handler,
+		clientInterceptors,
+		serverInterceptors,
+		counter,
+		namespaceRegistry,
+	)
+	clientConn.RegisterServer(
+		"temporal.api.operatorservice.v1.OperatorService",
+		operatorHandler,
+		clientInterceptors,
+		serverInterceptors,
+		counter,
 		namespaceRegistry,
 	)
 
@@ -341,178 +347,14 @@ func (h *HTTPAPIServer) incomingHeaderMatcher(headerName string) (string, bool) 
 	return runtime.DefaultHeaderMatcher(headerName)
 }
 
-// inlineClientConn is a [grpc.ClientConnInterface] implementation that forwards
-// requests directly to gRPC via interceptors. This implementation moves all
-// outgoing metadata to incoming and takes resulting outgoing metadata and sets
-// as header. But which headers to use and TLS peer context and such are
-// expected to be handled by the caller.
-type inlineClientConn struct {
-	methods           map[string]*serviceMethod
-	interceptor       grpc.UnaryServerInterceptor
-	requestsCounter   metrics.CounterIface
-	namespaceRegistry namespace.Registry
-}
-
-var _ grpc.ClientConnInterface = (*inlineClientConn)(nil)
-
-type serviceMethod struct {
-	info    grpc.UnaryServerInfo
-	handler grpc.UnaryHandler
-}
-
-var contextType = reflect.TypeOf((*context.Context)(nil)).Elem()
-var protoMessageType = reflect.TypeOf((*proto.Message)(nil)).Elem()
-var errorType = reflect.TypeOf((*error)(nil)).Elem()
-
-func newInlineClientConn(
-	servers map[string]any,
-	interceptors []grpc.UnaryServerInterceptor,
-	metricsHandler metrics.Handler,
-	namespaceRegistry namespace.Registry,
-) *inlineClientConn {
-	// Create the set of methods via reflection. We currently accept the overhead
-	// of reflection compared to having to custom generate gateway code.
-	methods := map[string]*serviceMethod{}
-	for qualifiedServerName, server := range servers {
-		serverVal := reflect.ValueOf(server)
-		for i := 0; i < serverVal.Type().NumMethod(); i++ {
-			reflectMethod := serverVal.Type().Method(i)
-			// We intentionally look this up by name to not assume method indexes line
-			// up from type to value
-			methodVal := serverVal.MethodByName(reflectMethod.Name)
-			// We assume the methods we want only accept a context + request and only
-			// return a response + error. We also assume the method name matches the
-			// RPC name.
-			methodType := methodVal.Type()
-			validRPCMethod := methodType.Kind() == reflect.Func &&
-				methodType.NumIn() == 2 &&
-				methodType.NumOut() == 2 &&
-				methodType.In(0) == contextType &&
-				methodType.In(1).Implements(protoMessageType) &&
-				methodType.Out(0).Implements(protoMessageType) &&
-				methodType.Out(1) == errorType
-			if !validRPCMethod {
-				continue
-			}
-			fullMethod := "/" + qualifiedServerName + "/" + reflectMethod.Name
-			methods[fullMethod] = &serviceMethod{
-				info: grpc.UnaryServerInfo{Server: server, FullMethod: fullMethod},
-				handler: func(ctx context.Context, req interface{}) (interface{}, error) {
-					ret := methodVal.Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(req)})
-					err, _ := ret[1].Interface().(error)
-					return ret[0].Interface(), err
-				},
-			}
-		}
-	}
-
-	return &inlineClientConn{
-		methods:           methods,
-		interceptor:       chainUnaryServerInterceptors(interceptors),
-		requestsCounter:   metrics.HTTPServiceRequests.With(metricsHandler),
-		namespaceRegistry: namespaceRegistry,
-	}
-}
-
-func (i *inlineClientConn) Invoke(
-	ctx context.Context,
-	method string,
-	args any,
-	reply any,
-	opts ...grpc.CallOption,
-) error {
-	// Move outgoing metadata to incoming and set new outgoing metadata
-	md, _ := metadata.FromOutgoingContext(ctx)
+func setDefaultClientHeadersForHTTP(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	// Set the client and version headers if not already set
+	md, _ := metadata.FromOutgoingContext(ctx)
 	if len(md[headers.ClientNameHeaderName]) == 0 {
-		md.Set(headers.ClientNameHeaderName, headers.ClientNameServerHTTP)
+		ctx = metadata.AppendToOutgoingContext(ctx, headers.ClientNameHeaderName, headers.ClientNameServerHTTP)
 	}
 	if len(md[headers.ClientVersionHeaderName]) == 0 {
-		md.Set(headers.ClientVersionHeaderName, headers.ServerVersion)
+		ctx = metadata.AppendToOutgoingContext(ctx, headers.ClientVersionHeaderName, headers.ServerVersion)
 	}
-	ctx = metadata.NewIncomingContext(ctx, md)
-	outgoingMD := metadata.MD{}
-	ctx = metadata.NewOutgoingContext(ctx, outgoingMD)
-
-	// Get the method. Should never fail, but we check anyways
-	serviceMethod := i.methods[method]
-	if serviceMethod == nil {
-		return status.Error(codes.NotFound, "call not found")
-	}
-
-	// Add metric
-	var namespaceTag metrics.Tag
-	if namespaceName := interceptor.MustGetNamespaceName(i.namespaceRegistry, args); namespaceName != "" {
-		namespaceTag = metrics.NamespaceTag(namespaceName.String())
-	} else {
-		namespaceTag = metrics.NamespaceUnknownTag()
-	}
-	i.requestsCounter.Record(1, metrics.OperationTag(method), namespaceTag)
-
-	// Invoke
-	var resp any
-	var err error
-	if i.interceptor == nil {
-		resp, err = serviceMethod.handler(ctx, args)
-	} else {
-		resp, err = i.interceptor(ctx, args, &serviceMethod.info, serviceMethod.handler)
-	}
-
-	// Find the header call option and set response headers. We accept that if
-	// somewhere internally the metadata was replaced instead of appended to, this
-	// does not work.
-	for _, opt := range opts {
-		if callOpt, ok := opt.(grpc.HeaderCallOption); ok {
-			*callOpt.HeaderAddr = outgoingMD
-		}
-	}
-
-	// Merge the response proto onto the wanted reply if non-nil
-	if respProto, _ := resp.(proto.Message); respProto != nil {
-		proto.Merge(reply.(proto.Message), respProto)
-	}
-
-	return err
-}
-
-func (*inlineClientConn) NewStream(
-	context.Context,
-	*grpc.StreamDesc,
-	string,
-	...grpc.CallOption,
-) (grpc.ClientStream, error) {
-	return nil, errHTTPGRPCStreamNotSupported
-}
-
-// Mostly taken from https://github.com/grpc/grpc-go/blob/v1.56.1/server.go#L1124-L1158
-// with slight modifications.
-func chainUnaryServerInterceptors(interceptors []grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
-	switch len(interceptors) {
-	case 0:
-		return nil
-	case 1:
-		return interceptors[0]
-	default:
-		return chainUnaryInterceptors(interceptors)
-	}
-}
-
-func chainUnaryInterceptors(interceptors []grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		return interceptors[0](ctx, req, info, getChainUnaryHandler(interceptors, 0, info, handler))
-	}
-}
-
-func getChainUnaryHandler(
-	interceptors []grpc.UnaryServerInterceptor,
-	curr int,
-	info *grpc.UnaryServerInfo,
-	finalHandler grpc.UnaryHandler,
-) grpc.UnaryHandler {
-	if curr == len(interceptors)-1 {
-		return finalHandler
-	}
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
-		return interceptors[curr+1](ctx, req, info, getChainUnaryHandler(interceptors, curr+1, info, finalHandler))
-	}
+	return invoker(ctx, method, req, reply, cc, opts...)
 }

--- a/service/fx.go
+++ b/service/fx.go
@@ -151,12 +151,16 @@ func GrpcServerOptionsProvider(
 
 	return append(
 		grpcServerOptions,
-		grpc.ChainUnaryInterceptor(getUnaryInterceptors(params)...),
+		grpc.ChainUnaryInterceptor(params.GetUnaryServerInterceptors()...),
 		grpc.ChainStreamInterceptor(params.TelemetryInterceptor.StreamIntercept),
 	)
 }
 
-func getUnaryInterceptors(params GrpcServerOptionsParams) []grpc.UnaryServerInterceptor {
+func (params GrpcServerOptionsParams) GetUnaryClientInterceptors() []grpc.UnaryClientInterceptor {
+	return params.RpcFactory.GetGRPCClientInterceptors()
+}
+
+func (params GrpcServerOptionsParams) GetUnaryServerInterceptors() []grpc.UnaryServerInterceptor {
 	interceptors := []grpc.UnaryServerInterceptor{
 		rpc.ServiceErrorInterceptor,
 		grpc.UnaryServerInterceptor(params.TracingInterceptor),

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -59,6 +59,7 @@ type (
 		startWG           sync.WaitGroup
 		throttledLogger   log.Logger
 		namespaceRegistry namespace.Registry
+		hostInfoProvider  membership.HostInfoProvider
 	}
 )
 
@@ -109,6 +110,7 @@ func NewHandler(
 			nexusEndpointManager,
 		),
 		namespaceRegistry: namespaceRegistry,
+		hostInfoProvider:  hostInfoProvider,
 	}
 
 	// prevent from serving requests before matching engine is started and ready

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -34,7 +34,9 @@ import (
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/rpc/inline"
 	"go.temporal.io/server/common/util"
+	"go.temporal.io/server/service"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -50,6 +52,7 @@ type Service struct {
 	logger                 log.SnTaggedLogger
 	membershipMonitor      membership.Monitor
 	grpcListener           net.Listener
+	grpcParams             service.GrpcServerOptionsParams
 	runtimeMetricsReporter *metrics.RuntimeMetricsReporter
 	metricsHandler         metrics.Handler
 	healthServer           *health.Server
@@ -62,6 +65,7 @@ func NewService(
 	logger log.SnTaggedLogger,
 	membershipMonitor membership.Monitor,
 	grpcListener net.Listener,
+	grpcParams service.GrpcServerOptionsParams,
 	runtimeMetricsReporter *metrics.RuntimeMetricsReporter,
 	handler *Handler,
 	metricsHandler metrics.Handler,
@@ -75,6 +79,7 @@ func NewService(
 		logger:                 logger,
 		membershipMonitor:      membershipMonitor,
 		grpcListener:           grpcListener,
+		grpcParams:             grpcParams,
 		runtimeMetricsReporter: runtimeMetricsReporter,
 		metricsHandler:         metricsHandler,
 		healthServer:           healthServer,
@@ -96,6 +101,16 @@ func (s *Service) Start() {
 	s.healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
 
 	reflection.Register(s.server)
+
+	inline.RegisterInlineServer(
+		s.handler.hostInfoProvider.HostInfo().GetAddress(),
+		"temporal.server.api.matchingservice.v1.MatchingService",
+		s.handler,
+		s.grpcParams.GetUnaryClientInterceptors(),
+		s.grpcParams.GetUnaryServerInterceptors(),
+		metrics.InlineRequests.With(s.metricsHandler),
+		s.handler.namespaceRegistry,
+	)
 
 	go func() {
 		s.logger.Info("Starting to serve on matching listener")


### PR DESCRIPTION
## What changed?
- Add mechanism for doing rpc calls within process without actual grpc
- Enable for matching and history
- Add option to use LookupN for matching task queue routing
- Add option for local load balancing for AddTask to pick the matching partition in the local process

## Why?
Optimization to save two rpcs for heavy task queues

## How did you test it?
only basic tests so far, needs more tests