### PR TITLE
added a flag when dropping non-retryable matching tasks

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1203,6 +1203,11 @@ these log lines can be noisy, we want to be able to turn on and sample selective
 		time.Second,
 		`TaskQueueInfoByBuildIdTTL serves as a TTL for the cache holding DescribeTaskQueue partition results`,
 	)
+	MatchingDropNonRetryableTasks = NewGlobalBoolSetting(
+		"matching.dropNonRetryableTasks",
+		false,
+		`MatchingDropNonRetryableTasks states if we should drop matching tasks with Internal/Dataloss errors`,
+	)
 	// for matching testing only:
 
 	TestMatchingDisableSyncMatch = NewGlobalBoolSetting(

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -53,6 +53,7 @@ type (
 		AlignMembershipChange                dynamicconfig.DurationPropertyFn
 		ShutdownDrainDuration                dynamicconfig.DurationPropertyFn
 		HistoryMaxPageSize                   dynamicconfig.IntPropertyFnWithNamespaceFilter
+		MatchingDropNonRetryableTasks        dynamicconfig.BoolPropertyFn
 
 		// task queue configuration
 
@@ -250,6 +251,7 @@ func NewConfig(
 		QueryWorkflowTaskTimeoutLogRate:          dynamicconfig.MatchingQueryWorkflowTaskTimeoutLogRate.Get(dc),
 		MembershipUnloadDelay:                    dynamicconfig.MatchingMembershipUnloadDelay.Get(dc),
 		TaskQueueInfoByBuildIdTTL:                dynamicconfig.TaskQueueInfoByBuildIdTTL.Get(dc),
+		MatchingDropNonRetryableTasks:            dynamicconfig.MatchingDropNonRetryableTasks.Get(dc),
 
 		AdminNamespaceToPartitionDispatchRate:          dynamicconfig.AdminMatchingNamespaceToPartitionDispatchRate.Get(dc),
 		AdminNamespaceTaskqueueToPartitionDispatchRate: dynamicconfig.AdminMatchingNamespaceTaskqueueToPartitionDispatchRate.Get(dc),

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -617,9 +617,19 @@ pollLoop:
 		if err != nil {
 			switch err.(type) {
 			case *serviceerror.Internal, *serviceerror.DataLoss:
-				e.nonRetryableErrorsDropTask(task, taskQueueName, err)
-				// drop the task as otherwise task would be stuck in a retry-loop
-				task.finish(nil, false)
+				if e.config.MatchingDropNonRetryableTasks() {
+					e.nonRetryableErrorsDropTask(task, taskQueueName, err)
+					// drop the task as otherwise task would be stuck in a retry-loop
+					task.finish(nil, false)
+				} else {
+					// default case
+					task.finish(err, false)
+					if err.Error() == common.ErrNamespaceHandover.Error() {
+						// do not keep polling new tasks when namespace is in handover state
+						// as record start request will be rejected by history service
+						return nil, err
+					}
+				}
 			case *serviceerror.NotFound: // mutable state not found, workflow not running or workflow task not found
 				e.logger.Info("Workflow task not found",
 					tag.WorkflowTaskQueueName(taskQueueName),
@@ -782,9 +792,19 @@ pollLoop:
 		if err != nil {
 			switch err.(type) {
 			case *serviceerror.Internal, *serviceerror.DataLoss:
-				e.nonRetryableErrorsDropTask(task, taskQueueName, err)
-				// drop the task as otherwise task would be stuck in a retry-loop
-				task.finish(nil, false)
+				if e.config.MatchingDropNonRetryableTasks() {
+					e.nonRetryableErrorsDropTask(task, taskQueueName, err)
+					// drop the task as otherwise task would be stuck in a retry-loop
+					task.finish(nil, false)
+				} else {
+					// default case
+					task.finish(err, false)
+					if err.Error() == common.ErrNamespaceHandover.Error() {
+						// do not keep polling new tasks when namespace is in handover state
+						// as record start request will be rejected by history service
+						return nil, err
+					}
+				}
 			case *serviceerror.NotFound: // mutable state not found, workflow not running or activity info not found
 				e.logger.Info("Activity task not found",
 					tag.WorkflowNamespaceID(task.event.Data.GetNamespaceId()),

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -624,11 +624,6 @@ pollLoop:
 				} else {
 					// default case
 					task.finish(err, false)
-					if err.Error() == common.ErrNamespaceHandover.Error() {
-						// do not keep polling new tasks when namespace is in handover state
-						// as record start request will be rejected by history service
-						return nil, err
-					}
 				}
 			case *serviceerror.NotFound: // mutable state not found, workflow not running or workflow task not found
 				e.logger.Info("Workflow task not found",
@@ -799,11 +794,6 @@ pollLoop:
 				} else {
 					// default case
 					task.finish(err, false)
-					if err.Error() == common.ErrNamespaceHandover.Error() {
-						// do not keep polling new tasks when namespace is in handover state
-						// as record start request will be rejected by history service
-						return nil, err
-					}
 				}
 			case *serviceerror.NotFound: // mutable state not found, workflow not running or activity info not found
 				e.logger.Info("Activity task not found",

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -471,6 +471,7 @@ func (s *matchingEngineSuite) TestFailAddTaskWithHistoryExhausted() {
 }
 
 func (s *matchingEngineSuite) TestFailAddTaskWithHistoryError() {
+	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
 	historyError := serviceerror.NewInternal("nothing to start")
 	tqName := "testFailAddTaskWithHistoryError"
 	s.testFailAddTaskWithHistoryError(tqName, true, historyError, nil) // expectedError shall be nil since history drops the task

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -691,6 +691,7 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_NamespaceHandover() {
 }
 
 func (s *matchingEngineSuite) TestPollActivityTaskQueues_InternalError() {
+	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
 	namespaceId := uuid.New()
 	tl := "queue"
 	taskQueue := &taskqueuepb.TaskQueue{Name: "queue", Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
@@ -723,6 +724,8 @@ func (s *matchingEngineSuite) TestPollActivityTaskQueues_InternalError() {
 }
 
 func (s *matchingEngineSuite) TestPollActivityTaskQueues_DataLossError() {
+	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
+
 	namespaceId := uuid.New()
 	tl := "queue"
 	taskQueue := &taskqueuepb.TaskQueue{Name: "queue", Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
@@ -756,6 +759,8 @@ func (s *matchingEngineSuite) TestPollActivityTaskQueues_DataLossError() {
 }
 
 func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_InternalError() {
+	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
+
 	tqName := "queue"
 	taskQueue := &taskqueuepb.TaskQueue{Name: tqName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
 	wfExecution := &commonpb.WorkflowExecution{WorkflowId: "workflowID", RunId: uuid.NewRandom().String()}
@@ -780,6 +785,8 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_InternalError() {
 }
 
 func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_DataLossError() {
+	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
+
 	tqName := "queue"
 	taskQueue := &taskqueuepb.TaskQueue{Name: tqName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
 	wfExecution := &commonpb.WorkflowExecution{WorkflowId: "workflowID", RunId: uuid.NewRandom().String()}
@@ -3927,7 +3934,7 @@ func defaultTestConfig() *Config {
 	config := NewConfig(dynamicconfig.NewNoopCollection())
 	config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(100 * time.Millisecond)
 	config.MaxTaskDeleteBatchSize = dynamicconfig.GetIntPropertyFnFilteredByTaskQueue(1)
-	config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true) // for tests testing matching non-retryable tasks being dropped
+	// config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true) // for tests testing matching non-retryable tasks being dropped
 	return config
 }
 

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3934,7 +3934,6 @@ func defaultTestConfig() *Config {
 	config := NewConfig(dynamicconfig.NewNoopCollection())
 	config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(100 * time.Millisecond)
 	config.MaxTaskDeleteBatchSize = dynamicconfig.GetIntPropertyFnFilteredByTaskQueue(1)
-	// config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true) // for tests testing matching non-retryable tasks being dropped
 	return config
 }
 

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3927,6 +3927,7 @@ func defaultTestConfig() *Config {
 	config := NewConfig(dynamicconfig.NewNoopCollection())
 	config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(100 * time.Millisecond)
 	config.MaxTaskDeleteBatchSize = dynamicconfig.GetIntPropertyFnFilteredByTaskQueue(1)
+	config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true) // for tests testing matching non-retryable tasks being dropped
 	return config
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Added a flag before we drop matching tasks with `Internal/DataLoss` errors.

## Why?
<!-- Tell your future self why have you made these changes -->
- CDS sometimes returns “Internal” error instead of “Unavailable”
- This could pose to be a problem since matching currently drops tasks with `Internal` Errors. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing suite of tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- None since there were no previously emitted metrics verifying the dropping of any matching tasks due to internal/dataloss error.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
