### PR TITLE
Fix task executable metrics tags

### DIFF
--- a/service/history/archival_queue_factory_test.go
+++ b/service/history/archival_queue_factory_test.go
@@ -46,12 +46,15 @@ func TestArchivalQueueFactory(t *testing.T) {
 	defer ctrl.Finish()
 
 	metricsHandler := metrics.NewMockHandler(ctrl)
-	metricsHandler.EXPECT().WithTags(gomock.Any()).Do(func(tags ...metrics.Tag) metrics.Handler {
-		require.Len(t, tags, 1)
-		assert.Equal(t, metrics.OperationTagName, tags[0].Key())
-		assert.Equal(t, "ArchivalQueueProcessor", tags[0].Value())
-		return metricsHandler
-	}).Times(1)
+	metricsHandler.EXPECT().WithTags(gomock.Any()).DoAndReturn(
+		func(tags ...metrics.Tag) metrics.Handler {
+			require.Len(t, tags, 1)
+			assert.Equal(t, metrics.OperationTagName, tags[0].Key())
+			assert.Equal(t, "ArchivalQueueProcessor", tags[0].Value())
+			return metricsHandler
+		},
+	).Times(1)
+	metricsHandler.EXPECT().WithTags(gomock.Any()).Return(metricsHandler).Times(1)
 
 	mockShard := shard.NewTestContext(
 		ctrl,

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -104,7 +104,7 @@ var (
 	dependencyTaskNotCompletedReschedulePolicy = common.CreateDependencyTaskNotCompletedReschedulePolicy()
 )
 
-var defaultTaskMetricsTags = []metrics.Tag{
+var defaultExecutableMetricsTags = []metrics.Tag{
 	metrics.NamespaceUnknownTag(),
 	metrics.TaskTypeTag("__unknown__"),
 	metrics.OperationTag("__unknown__"),
@@ -240,7 +240,7 @@ func NewExecutable(
 				return tasks.Tags(task)
 			},
 		),
-		metricsHandler:             metricsHandler.WithTags(defaultTaskMetricsTags...),
+		metricsHandler:             metricsHandler,
 		dlqWriter:                  params.DLQWriter,
 		dlqEnabled:                 params.DLQEnabled,
 		maxUnexpectedErrorAttempts: params.MaxUnexpectedErrorAttempts,

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -104,6 +104,12 @@ var (
 	dependencyTaskNotCompletedReschedulePolicy = common.CreateDependencyTaskNotCompletedReschedulePolicy()
 )
 
+var defaultTaskMetricsTags = []metrics.Tag{
+	metrics.NamespaceUnknownTag(),
+	metrics.TaskTypeTag("__unknown__"),
+	metrics.OperationTag("__unknown__"),
+}
+
 const (
 	// resubmitMaxAttempts is the max number of attempts we may skip rescheduler when a task is Nacked.
 	// check the comment in shouldResubmitOnNack() for more details
@@ -234,13 +240,7 @@ func NewExecutable(
 				return tasks.Tags(task)
 			},
 		),
-		metricsHandler: metricsHandler.WithTags(
-			estimateTaskMetricTag(
-				task,
-				namespaceRegistry,
-				clusterMetadata.GetCurrentClusterName(),
-			)...,
-		),
+		metricsHandler:             metricsHandler.WithTags(defaultTaskMetricsTags...),
 		dlqWriter:                  params.DLQWriter,
 		dlqEnabled:                 params.DLQEnabled,
 		maxUnexpectedErrorAttempts: params.MaxUnexpectedErrorAttempts,

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -166,7 +166,6 @@ type (
 		inMemoryNoUserLatency      time.Duration
 		lastActiveness             bool
 		resourceExhaustedCount     int // does NOT include consts.ErrResourceExhaustedBusyWorkflow
-		taggedMetricsHandler       metrics.Handler
 		dlqEnabled                 dynamicconfig.BoolPropertyFn
 		terminalFailureCause       error
 		unexpectedErrorAttempts    int
@@ -235,8 +234,13 @@ func NewExecutable(
 				return tasks.Tags(task)
 			},
 		),
-		metricsHandler:             metricsHandler,
-		taggedMetricsHandler:       metricsHandler,
+		metricsHandler: metricsHandler.WithTags(
+			estimateTaskMetricTag(
+				task,
+				namespaceRegistry,
+				clusterMetadata.GetCurrentClusterName(),
+			)...,
+		),
 		dlqWriter:                  params.DLQWriter,
 		dlqEnabled:                 params.DLQEnabled,
 		maxUnexpectedErrorAttempts: params.MaxUnexpectedErrorAttempts,
@@ -285,7 +289,12 @@ func (e *executableImpl) Execute() (retErr error) {
 
 			// we need to guess the metrics tags here as we don't know which execution logic
 			// is actually used which is upto the executor implementation
-			e.taggedMetricsHandler = e.metricsHandler.WithTags(EstimateTaskMetricTag(e, e.namespaceRegistry, e.clusterMetadata.GetCurrentClusterName())...)
+			e.metricsHandler = e.metricsHandler.WithTags(
+				estimateTaskMetricTag(
+					e.GetTask(),
+					e.namespaceRegistry,
+					e.clusterMetadata.GetCurrentClusterName(),
+				)...)
 		}
 
 		attemptUserLatency := time.Duration(0)
@@ -296,9 +305,9 @@ func (e *executableImpl) Execute() (retErr error) {
 		attemptLatency := e.timeSource.Now().Sub(startTime)
 		e.attemptNoUserLatency = attemptLatency - attemptUserLatency
 		// emit total attempt latency so that we know how much time a task will occpy a worker goroutine
-		metrics.TaskProcessingLatency.With(e.taggedMetricsHandler).Record(attemptLatency)
+		metrics.TaskProcessingLatency.With(e.metricsHandler).Record(attemptLatency)
 
-		priorityTaggedProvider := e.taggedMetricsHandler.WithTags(metrics.TaskPriorityTag(e.priority.String()))
+		priorityTaggedProvider := e.metricsHandler.WithTags(metrics.TaskPriorityTag(e.priority.String()))
 		metrics.TaskRequests.With(priorityTaggedProvider).Record(1)
 		metrics.TaskScheduleLatency.With(priorityTaggedProvider).Record(e.scheduleLatency)
 
@@ -327,7 +336,7 @@ func (e *executableImpl) Execute() (retErr error) {
 	}
 
 	resp := e.executor.Execute(ctx, e)
-	e.taggedMetricsHandler = e.metricsHandler.WithTags(resp.ExecutionMetricTags...)
+	e.metricsHandler = e.metricsHandler.WithTags(resp.ExecutionMetricTags...)
 
 	if resp.ExecutedAsActive != e.lastActiveness {
 		// namespace did a failover,
@@ -353,10 +362,10 @@ func (e *executableImpl) writeToDLQ(ctx context.Context) error {
 		e.GetTask(),
 	)
 	if err != nil {
-		metrics.TaskDLQFailures.With(e.taggedMetricsHandler).Record(1)
+		metrics.TaskDLQFailures.With(e.metricsHandler).Record(1)
 		e.logger.Error("Failed to write task to DLQ", tag.Error(err))
 	}
-	metrics.TaskDLQSendLatency.With(e.taggedMetricsHandler).Record(e.timeSource.Now().Sub(start))
+	metrics.TaskDLQSendLatency.With(e.metricsHandler).Record(e.timeSource.Now().Sub(start))
 	return err
 }
 
@@ -365,7 +374,7 @@ func (e *executableImpl) isSafeToDropError(err error) bool {
 		// The task is stale and is safe to be dropped.
 		// Even though ErrStaleReference is castable to serviceerror.NotFound, we give this error special treatment
 		// because we're interested in the metric.
-		metrics.TaskSkipped.With(e.taggedMetricsHandler).Record(1)
+		metrics.TaskSkipped.With(e.metricsHandler).Record(1)
 		e.logger.Info("Skipped task due to stale reference", tag.Error(err))
 		return true
 	}
@@ -380,12 +389,12 @@ func (e *executableImpl) isSafeToDropError(err error) bool {
 	}
 
 	if err == consts.ErrTaskDiscarded {
-		metrics.TaskDiscarded.With(e.taggedMetricsHandler).Record(1)
+		metrics.TaskDiscarded.With(e.metricsHandler).Record(1)
 		return true
 	}
 
 	if err == consts.ErrTaskVersionMismatch {
-		metrics.TaskVersionMisMatch.With(e.taggedMetricsHandler).Record(1)
+		metrics.TaskVersionMisMatch.With(e.metricsHandler).Record(1)
 		return true
 	}
 
@@ -414,7 +423,7 @@ func (e *executableImpl) isExpectedRetryableError(err error) (isRetryable bool, 
 			e.resourceExhaustedCount++
 		}
 
-		metrics.TaskThrottledCounter.With(e.taggedMetricsHandler).Record(
+		metrics.TaskThrottledCounter.With(e.metricsHandler).Record(
 			1, metrics.ResourceExhaustedCauseTag(resourceExhaustedErr.Cause))
 		return true, err
 	}
@@ -423,22 +432,22 @@ func (e *executableImpl) isExpectedRetryableError(err error) (isRetryable bool, 
 	if _, ok := err.(*serviceerror.NamespaceNotActive); ok {
 		// error is expected when there's namespace failover,
 		// so don't count it into task failures.
-		metrics.TaskNotActiveCounter.With(e.taggedMetricsHandler).Record(1)
+		metrics.TaskNotActiveCounter.With(e.metricsHandler).Record(1)
 		return true, err
 	}
 
 	if err == consts.ErrDependencyTaskNotCompleted {
-		metrics.TasksDependencyTaskNotCompleted.With(e.taggedMetricsHandler).Record(1)
+		metrics.TasksDependencyTaskNotCompleted.With(e.metricsHandler).Record(1)
 		return true, err
 	}
 
 	if err == consts.ErrTaskRetry {
-		metrics.TaskStandbyRetryCounter.With(e.taggedMetricsHandler).Record(1)
+		metrics.TaskStandbyRetryCounter.With(e.metricsHandler).Record(1)
 		return true, err
 	}
 
 	if err.Error() == consts.ErrNamespaceHandover.Error() {
-		metrics.TaskNamespaceHandoverCounter.With(e.taggedMetricsHandler).Record(1)
+		metrics.TaskNamespaceHandoverCounter.With(e.metricsHandler).Record(1)
 		return true, consts.ErrNamespaceHandover
 	}
 
@@ -457,7 +466,7 @@ func (e *executableImpl) isUnexpectedNonRetryableError(err error) bool {
 
 	isInternalError := common.IsInternalError(err)
 	if isInternalError {
-		metrics.TaskInternalErrorCounter.With(e.taggedMetricsHandler).Record(1)
+		metrics.TaskInternalErrorCounter.With(e.metricsHandler).Record(1)
 		// Only DQL/drop when configured to
 		return e.dlqInternalErrors()
 	}
@@ -486,7 +495,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 
 			e.attempt++
 			if e.attempt > taskCriticalLogMetricAttempts {
-				metrics.TaskAttempt.With(e.taggedMetricsHandler).Record(int64(e.attempt))
+				metrics.TaskAttempt.With(e.metricsHandler).Record(int64(e.attempt))
 				e.logger.Error("Critical error processing task, retrying.",
 					tag.Attempt(int32(e.attempt)),
 					tag.UnexpectedErrorAttempts(int32(e.unexpectedErrorAttempts)),
@@ -507,7 +516,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 				tag.Error(err),
 				tag.ErrorType(err))
 			e.terminalFailureCause = err
-			metrics.TaskTerminalFailures.With(e.taggedMetricsHandler).Record(1)
+			metrics.TaskTerminalFailures.With(e.metricsHandler).Record(1)
 			return fmt.Errorf("%w: %v", ErrTerminalTaskFailure, err)
 		}
 	}
@@ -522,19 +531,19 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 
 	// Unexpected errors handled below
 	e.unexpectedErrorAttempts++
-	metrics.TaskFailures.With(e.taggedMetricsHandler).Record(1)
+	metrics.TaskFailures.With(e.metricsHandler).Record(1)
 	e.logger.Warn("Fail to process task", tag.Error(err), tag.ErrorType(err), tag.UnexpectedErrorAttempts(int32(e.unexpectedErrorAttempts)), tag.LifeCycleProcessingFailed)
 
 	if e.isUnexpectedNonRetryableError(err) {
 		// Terminal errors are likely due to data corruption.
 		// Drop the task by returning nil so that task will be marked as completed,
 		// or send it to the DLQ if that is enabled.
-		metrics.TaskCorruptionCounter.With(e.taggedMetricsHandler).Record(1)
+		metrics.TaskCorruptionCounter.With(e.metricsHandler).Record(1)
 		if e.dlqEnabled() {
 			// Keep this message in sync with the log line mentioned in Investigation section of docs/admin/dlq.md
 			e.logger.Error("Marking task as terminally failed, will send to DLQ", tag.Error(err), tag.ErrorType(err))
 			e.terminalFailureCause = err // <- Execute() examines this attribute on the next attempt.
-			metrics.TaskTerminalFailures.With(e.taggedMetricsHandler).Record(1)
+			metrics.TaskTerminalFailures.With(e.metricsHandler).Record(1)
 			return fmt.Errorf("%w: %v", ErrTerminalTaskFailure, err)
 		}
 		e.logger.Error("Dropping task due to terminal error", tag.Error(err), tag.ErrorType(err))
@@ -547,7 +556,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 		e.logger.Error("Marking task as terminally failed, will send to DLQ. Maximum number of attempts with unexpected errors",
 			tag.UnexpectedErrorAttempts(int32(e.unexpectedErrorAttempts)), tag.Error(err))
 		e.terminalFailureCause = err // <- Execute() examines this attribute on the next attempt.
-		metrics.TaskTerminalFailures.With(e.taggedMetricsHandler).Record(1)
+		metrics.TaskTerminalFailures.With(e.metricsHandler).Record(1)
 		return fmt.Errorf("%w: %w", ErrTerminalTaskFailure, e.terminalFailureCause)
 	}
 
@@ -597,13 +606,13 @@ func (e *executableImpl) Ack() {
 
 	e.state = ctasks.TaskStateAcked
 
-	metrics.TaskLoadLatency.With(e.taggedMetricsHandler).Record(
+	metrics.TaskLoadLatency.With(e.metricsHandler).Record(
 		e.loadTime.Sub(e.GetVisibilityTime()),
 		metrics.QueueReaderIDTag(e.readerID),
 	)
-	metrics.TaskAttempt.With(e.taggedMetricsHandler).Record(int64(e.attempt))
+	metrics.TaskAttempt.With(e.metricsHandler).Record(int64(e.attempt))
 
-	priorityTaggedProvider := e.taggedMetricsHandler.WithTags(metrics.TaskPriorityTag(e.lowestPriority.String()))
+	priorityTaggedProvider := e.metricsHandler.WithTags(metrics.TaskPriorityTag(e.lowestPriority.String()))
 	metrics.TaskLatency.With(priorityTaggedProvider).Record(e.inMemoryNoUserLatency)
 	metrics.TaskQueueLatency.With(priorityTaggedProvider.WithTags(metrics.QueueReaderIDTag(e.readerID))).
 		Record(time.Since(e.GetVisibilityTime()))
@@ -775,21 +784,21 @@ func (e *executableImpl) resetAttempt() {
 	e.attempt = 1
 }
 
-func EstimateTaskMetricTag(
-	e Executable,
+func estimateTaskMetricTag(
+	task tasks.Task,
 	namespaceRegistry namespace.Registry,
 	currentClusterName string,
 ) []metrics.Tag {
 	namespaceTag := metrics.NamespaceUnknownTag()
 	isActive := true
 
-	ns, err := namespaceRegistry.GetNamespaceByID(namespace.ID(e.GetNamespaceID()))
+	ns, err := namespaceRegistry.GetNamespaceByID(namespace.ID(task.GetNamespaceID()))
 	if err == nil {
 		namespaceTag = metrics.NamespaceTag(ns.Name().String())
 		isActive = ns.ActiveInCluster(currentClusterName)
 	}
 
-	taskType := getTaskTypeTagValue(e, isActive)
+	taskType := getTaskTypeTagValue(task, isActive)
 	return []metrics.Tag{
 		namespaceTag,
 		metrics.TaskTypeTag(taskType),

--- a/service/history/queues/executable_factory.go
+++ b/service/history/queues/executable_factory.go
@@ -89,7 +89,7 @@ func NewExecutableFactory(
 		namespaceRegistry:          namespaceRegistry,
 		clusterMetadata:            clusterMetadata,
 		logger:                     logger,
-		metricsHandler:             metricsHandler,
+		metricsHandler:             metricsHandler.WithTags(defaultExecutableMetricsTags...),
 		dlqWriter:                  dlqWriter,
 		dlqEnabled:                 dlqEnabled,
 		attemptsBeforeSendingToDlq: attemptsBeforeSendingToDlq,

--- a/service/history/queues/metrics.go
+++ b/service/history/queues/metrics.go
@@ -194,10 +194,9 @@ func GetTimerStateMachineTaskTypeTagValue(taskType string, isActive bool) string
 }
 
 func getTaskTypeTagValue(
-	executable Executable,
+	task tasks.Task,
 	isActive bool,
 ) string {
-	task := executable.GetTask()
 	switch task.GetCategory() {
 	case tasks.CategoryTransfer:
 		if isActive {

--- a/service/history/queues/scheduler.go
+++ b/service/history/queues/scheduler.go
@@ -236,7 +236,7 @@ func NewRateLimitedScheduler(
 		return quotas.NewRequest("", taskSchedulerToken, namespaceName.String(), tasks.PriorityName[e.GetPriority()], 0, "")
 	}
 	taskMetricsTagsFn := func(e Executable) []metrics.Tag {
-		return append(EstimateTaskMetricTag(e, namespaceRegistry, currentClusterName), metrics.TaskPriorityTag(e.GetPriority().String()))
+		return append(estimateTaskMetricTag(e.GetTask(), namespaceRegistry, currentClusterName), metrics.TaskPriorityTag(e.GetPriority().String()))
 	}
 
 	rateLimitedScheduler := tasks.NewRateLimitedScheduler[Executable](

--- a/service/history/queues/speculative_workflow_task_timeout_queue.go
+++ b/service/history/queues/speculative_workflow_task_timeout_queue.go
@@ -57,7 +57,6 @@ func NewSpeculativeWorkflowTaskTimeoutQueue(
 	timeSource clock.TimeSource,
 	metricsHandler metrics.Handler,
 	logger log.SnTaggedLogger,
-
 ) *SpeculativeWorkflowTaskTimeoutQueue {
 
 	timeoutQueue := newMemoryScheduledQueue(
@@ -105,7 +104,7 @@ func (q SpeculativeWorkflowTaskTimeoutQueue) NotifyNewTasks(ts []tasks.Task) {
 				q.namespaceRegistry,
 				q.clusterMetadata,
 				q.logger,
-				q.metricsHandler,
+				q.metricsHandler.WithTags(defaultExecutableMetricsTags...),
 			), wttt)
 			q.timeoutQueue.Add(executable)
 		}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Remove executable.taggedMetricsHandler. 
- Always init executable.metricsHandler with the full set of metric tags needed to prevent tag mismatch issue.

## Why?
<!-- Tell your future self why have you made these changes -->
- Prevent tag mismatch issue.
- It looks like the task_errors_throttled metric could be emitted before taggedMetricsHandler is really tagged with the right set of tags.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Run server locally.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
