### PR TITLE
Fix force migration tests to start namespace disconnected

### DIFF
--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -2232,7 +2232,7 @@ func (s *FunctionalClustersTestSuite) TestWorkflowRetryFailAndFailover() {
 
 func (s *FunctionalClustersTestSuite) TestActivityHeartbeatFailover() {
 	namespace := "test-activity-heartbeat-workflow-failover-" + common.GenerateRandomString(5)
-	s.registerNamespace(namespace, true)
+	s.registerNamespace(namespace, true, true)
 
 	taskqueue := "functional-activity-heartbeat-workflow-failover-test-taskqueue"
 	client1, worker1 := s.newClientAndWorker(s.cluster1.Host().FrontendGRPCAddress(), namespace, taskqueue, "worker1")
@@ -2352,7 +2352,7 @@ func (s *FunctionalClustersTestSuite) TestLocalNamespaceMigration() {
 	defer cancel()
 
 	namespace := "local-ns-to-be-promote-" + common.GenerateRandomString(5)
-	s.registerNamespace(namespace, false)
+	s.registerNamespace(namespace, false, false)
 
 	taskqueue := "functional-local-ns-to-be-promote-taskqueue"
 	client1, worker1 := s.newClientAndWorker(s.cluster1.Host().FrontendGRPCAddress(), namespace, taskqueue, "worker1")
@@ -2708,7 +2708,7 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
 	defer cancel()
 
 	namespace := "force-replication" + common.GenerateRandomString(5)
-	s.registerNamespace(namespace, true)
+	s.registerNamespace(namespace, true, false)
 
 	taskqueue := "functional-local-force-replication-task-queue"
 	client1, worker1 := s.newClientAndWorker(s.cluster1.Host().FrontendGRPCAddress(), namespace, taskqueue, "worker1")
@@ -2834,7 +2834,7 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
 	defer cancel()
 
 	namespace := "force-replication" + common.GenerateRandomString(5)
-	s.registerNamespace(namespace, true)
+	s.registerNamespace(namespace, true, false)
 
 	taskqueue := "functional-force-replication-reset-task-queue"
 	client1, worker1 := s.newClientAndWorker(s.cluster1.Host().FrontendGRPCAddress(), namespace, taskqueue, "worker1")
@@ -2957,9 +2957,9 @@ func (s *FunctionalClustersTestSuite) getHistory(client workflowservice.Workflow
 	return events
 }
 
-func (s *FunctionalClustersTestSuite) registerNamespace(namespace string, isGlobalNamespace bool) {
+func (s *FunctionalClustersTestSuite) registerNamespace(namespace string, isGlobalNamespace, initialReplicated bool) {
 	clusters := s.clusterReplicationConfig()
-	if !isGlobalNamespace {
+	if !isGlobalNamespace || !initialReplicated {
 		clusters = s.clusterReplicationConfig()[0:1]
 	}
 	client1 := s.cluster1.FrontendClient() // active


### PR DESCRIPTION
## What changed?
TestForceMigration_* should create its namespace on one cluster and then update to cross clusters.

## Why?
More accurately tests the desired scenario.