### PR TITLE
Add dynamic config to control allowed Host headers

### DIFF
--- a/common/dynamicconfig/cachedvalue.go
+++ b/common/dynamicconfig/cachedvalue.go
@@ -1,3 +1,25 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package dynamicconfig
 
 import (
@@ -10,7 +32,7 @@ import (
 // GlobalCachedTypedValue holds a cached value of a GlobalTypedSetting after applying a supplied convert function.
 // This type should be deleted after dynamicconfig handles conversion more efficiently.
 type GlobalCachedTypedValue[T any] struct {
-	ptr    *atomic.Pointer[T]
+	ptr    atomic.Pointer[T]
 	cancel func()
 }
 
@@ -19,7 +41,7 @@ type GlobalCachedTypedValue[T any] struct {
 // If convert returns an error the old value will be preserved. If convert never succeeds, Get() will return the zero
 // value of T.
 func NewGlobalCachedTypedValue[T, I any](c *Collection, setting GlobalTypedSetting[I], convert func(I) (T, error)) *GlobalCachedTypedValue[T] {
-	ptr := &atomic.Pointer[T]{}
+	cachedValue := new(GlobalCachedTypedValue[T])
 	initial, cancel := setting.Subscribe(c)(func(i I) {
 		converted, err := convert(i)
 		if err != nil {
@@ -27,20 +49,19 @@ func NewGlobalCachedTypedValue[T, I any](c *Collection, setting GlobalTypedSetti
 			return
 		}
 		// Make sure to only store the value on successful conversion.
-		ptr.Store(&converted)
+		cachedValue.ptr.Store(&converted)
 	})
+	cachedValue.cancel = cancel
+
 	converted, err := convert(initial)
 	if err != nil {
 		c.logger.Warn(fmt.Sprintf("Failed to convert %q attribute", setting.Key().String()), tag.Value(initial), tag.Error(err))
 	} else {
 		// Make sure to only store the value on successful conversion.
-		ptr.Store(&converted)
+		cachedValue.ptr.Store(&converted)
 	}
 
-	return &GlobalCachedTypedValue[T]{
-		ptr:    ptr,
-		cancel: cancel,
-	}
+	return cachedValue
 }
 
 // Get the last successfully converted cached value or the zero value if convert has never succeeded.

--- a/common/dynamicconfig/cachedvalue.go
+++ b/common/dynamicconfig/cachedvalue.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GlobalCachedTypedValue holds a cached value of a GlobalTypedSetting after applying a supplied convert function.
-// This type should be deleted after caching is added to GlobalTypedSettingWithConverter.
+// This type should be deleted after dynamicconfig handles conversion more efficiently.
 type GlobalCachedTypedValue[T any] struct {
 	ptr    *atomic.Pointer[T]
 	cancel func()

--- a/common/dynamicconfig/cachedvalue.go
+++ b/common/dynamicconfig/cachedvalue.go
@@ -1,0 +1,59 @@
+package dynamicconfig
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"go.temporal.io/server/common/log/tag"
+)
+
+// GlobalCachedTypedValue holds a cached value of a GlobalTypedSetting after applying a supplied convert function.
+// This type should be deleted after caching is added to GlobalTypedSettingWithConverter.
+type GlobalCachedTypedValue[T any] struct {
+	ptr    *atomic.Pointer[T]
+	cancel func()
+}
+
+// NewGlobalCachedTypedValue returns a new [GlobalCachedTypedValue] for the given setting, applying the given convert
+// function on change.
+// If convert returns an error the old value will be preserved. If convert never succeeds, Get() will return the zero
+// value of T.
+func NewGlobalCachedTypedValue[T, I any](c *Collection, setting GlobalTypedSetting[I], convert func(I) (T, error)) *GlobalCachedTypedValue[T] {
+	ptr := &atomic.Pointer[T]{}
+	initial, cancel := setting.Subscribe(c)(func(i I) {
+		converted, err := convert(i)
+		if err != nil {
+			c.logger.Warn(fmt.Sprintf("Failed to convert %q attribute", setting.Key().String()), tag.Value(i), tag.Error(err))
+			return
+		}
+		// Make sure to only store the value on successful conversion.
+		ptr.Store(&converted)
+	})
+	converted, err := convert(initial)
+	if err != nil {
+		c.logger.Warn(fmt.Sprintf("Failed to convert %q attribute", setting.Key().String()), tag.Value(initial), tag.Error(err))
+	} else {
+		// Make sure to only store the value on successful conversion.
+		ptr.Store(&converted)
+	}
+
+	return &GlobalCachedTypedValue[T]{
+		ptr:    ptr,
+		cancel: cancel,
+	}
+}
+
+// Get the last successfully converted cached value or the zero value if convert has never succeeded.
+func (s *GlobalCachedTypedValue[T]) Get() T {
+	v := s.ptr.Load()
+	if v == nil {
+		var t T
+		return t
+	}
+	return *v
+}
+
+func (s *GlobalCachedTypedValue[T]) Close() error {
+	s.cancel()
+	return nil
+}

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -570,7 +570,12 @@ is currently processing a task.
 	)
 
 	// keys for frontend
-
+	FrontendHTTPAllowedHosts = NewGlobalTypedSetting(
+		"frontend.httpAllowedHosts",
+		[]string(nil),
+		`HTTP API Requests with "Host" header matching the allowed hosts will be processed, otherwise rejected.
+Wildcards (*) are expanded to allow any substring.`,
+	)
 	FrontendPersistenceMaxQPS = NewGlobalIntSetting(
 		"frontend.persistenceMaxQPS",
 		2000,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -572,9 +572,9 @@ is currently processing a task.
 	// keys for frontend
 	FrontendHTTPAllowedHosts = NewGlobalTypedSetting(
 		"frontend.httpAllowedHosts",
-		[]string(nil),
-		`HTTP API Requests with "Host" header matching the allowed hosts will be processed, otherwise rejected.
-Wildcards (*) are expanded to allow any substring.`,
+		[]string{"*"},
+		`HTTP API Requests with a "Host" header matching the allowed hosts will be processed, otherwise rejected.
+Wildcards (*) are expanded to allow any substring. By default any Host header is allowed.`,
 	)
 	FrontendPersistenceMaxQPS = NewGlobalIntSetting(
 		"frontend.persistenceMaxQPS",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -572,7 +572,7 @@ is currently processing a task.
 	// keys for frontend
 	FrontendHTTPAllowedHosts = NewGlobalTypedSetting(
 		"frontend.httpAllowedHosts",
-		[]string{"*"},
+		[]string(nil),
 		`HTTP API Requests with a "Host" header matching the allowed hosts will be processed, otherwise rejected.
 Wildcards (*) are expanded to allow any substring. By default any Host header is allowed.`,
 	)

--- a/common/wildcard.go
+++ b/common/wildcard.go
@@ -1,3 +1,25 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package common
 
 import (

--- a/common/wildcard.go
+++ b/common/wildcard.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+// WildCardStringToRegexp converts a given string pattern to a regular expression matching wildcards (*) with any
+// substring.
+func WildCardStringToRegexp(pattern string) (*regexp.Regexp, error) {
+	if pattern == "" {
+		return nil, errors.New("pattern cannot be empty")
+	}
+	var result strings.Builder
+	result.WriteString("^")
+	for i, literal := range strings.Split(pattern, "*") {
+		if i > 0 {
+			// Replace * with .*
+			result.WriteString(".*")
+		}
+		result.WriteString(regexp.QuoteMeta(literal))
+	}
+	result.WriteString("$")
+	return regexp.Compile(result.String())
+}
+
+// WildCardStringToRegexps converts a given slices of string patterns to a slice of regular expressions matching
+// wildcards (*) with any substring.
+func WildCardStringsToRegexps(patterns []string) ([]*regexp.Regexp, error) {
+	var errs []error
+	regexps := make([]*regexp.Regexp, len(patterns))
+	for i, pattern := range patterns {
+		re, err := WildCardStringToRegexp(pattern)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		regexps[i] = re
+	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	return regexps, nil
+}

--- a/service/frontend/http_api_server.go
+++ b/service/frontend/http_api_server.go
@@ -32,6 +32,7 @@ import (
 	"net"
 	"net/http"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -41,6 +42,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -67,6 +69,7 @@ type HTTPAPIServer struct {
 	logger                        log.Logger
 	serveMux                      *runtime.ServeMux
 	stopped                       chan struct{}
+	allowedHosts                  *dynamicconfig.GlobalCachedTypedValue[[]*regexp.Regexp]
 	matchAdditionalHeaders        map[string]bool
 	matchAdditionalHeaderPrefixes []string
 }
@@ -131,9 +134,10 @@ func NewHTTPAPIServer(
 	}
 
 	h := &HTTPAPIServer{
-		listener: listener,
-		logger:   logger,
-		stopped:  make(chan struct{}),
+		listener:     listener,
+		logger:       logger,
+		stopped:      make(chan struct{}),
+		allowedHosts: serviceConfig.HTTPAllowedHosts,
 	}
 
 	// Build 4 possible marshalers in order based on content type
@@ -160,6 +164,7 @@ func NewHTTPAPIServer(
 		}
 	}
 
+	opts = append(opts, runtime.WithMiddlewares(h.allowedHostsMiddleware))
 	opts = append(opts, runtime.WithIncomingHeaderMatcher(h.incomingHeaderMatcher))
 
 	// Create inline client connection
@@ -289,6 +294,21 @@ func (h *HTTPAPIServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Call gRPC gateway mux
 	h.serveMux.ServeHTTP(w, r)
+}
+
+func (h *HTTPAPIServer) allowedHostsMiddleware(hf runtime.HandlerFunc) runtime.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+		allowedHosts := h.allowedHosts.Get()
+		for _, allowedHost := range allowedHosts {
+			if allowedHost.MatchString(r.Host) {
+				hf(w, r, pathParams)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusForbidden)
+		// PermissionDenied gRPC code is 7.
+		_, _ = w.Write([]byte(`{"code": 7, "message": "Host not allowed"}`))
+	}
 }
 
 func (h *HTTPAPIServer) errorHandler(

--- a/service/frontend/http_api_server.go
+++ b/service/frontend/http_api_server.go
@@ -69,7 +69,7 @@ type HTTPAPIServer struct {
 	logger                        log.Logger
 	serveMux                      *runtime.ServeMux
 	stopped                       chan struct{}
-	allowedHosts                  *dynamicconfig.GlobalCachedTypedValue[[]*regexp.Regexp]
+	allowedHosts                  *dynamicconfig.GlobalCachedTypedValue[*regexp.Regexp]
 	matchAdditionalHeaders        map[string]bool
 	matchAdditionalHeaderPrefixes []string
 }
@@ -299,11 +299,9 @@ func (h *HTTPAPIServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *HTTPAPIServer) allowedHostsMiddleware(hf runtime.HandlerFunc) runtime.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
 		allowedHosts := h.allowedHosts.Get()
-		for _, allowedHost := range allowedHosts {
-			if allowedHost.MatchString(r.Host) {
-				hf(w, r, pathParams)
-				return
-			}
+		if allowedHost.MatchString(r.Host) {
+			hf(w, r, pathParams)
+			return
 		}
 		w.WriteHeader(http.StatusForbidden)
 		// PermissionDenied gRPC code is 7.

--- a/service/frontend/http_api_server.go
+++ b/service/frontend/http_api_server.go
@@ -299,7 +299,7 @@ func (h *HTTPAPIServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *HTTPAPIServer) allowedHostsMiddleware(hf runtime.HandlerFunc) runtime.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
 		allowedHosts := h.allowedHosts.Get()
-		if allowedHost.MatchString(r.Host) {
+		if allowedHosts.MatchString(r.Host) {
 			hf(w, r, pathParams)
 			return
 		}

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -35,7 +35,6 @@ import (
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -43,6 +42,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/retrypolicy"
+	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/components/callbacks"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
@@ -214,7 +214,7 @@ type Config struct {
 
 	ActivityAPIsEnabled dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
-	HTTPAllowedHosts *dynamicconfig.GlobalCachedTypedValue[[]*regexp.Regexp]
+	HTTPAllowedHosts *dynamicconfig.GlobalCachedTypedValue[*regexp.Regexp]
 }
 
 // NewConfig returns new service config with default values
@@ -335,7 +335,7 @@ func NewConfig(
 		EnableEagerWorkflowStart:   dynamicconfig.EnableEagerWorkflowStart.Get(dc),
 		ActivityAPIsEnabled:        dynamicconfig.ActivityAPIsEnabled.Get(dc),
 
-		HTTPAllowedHosts: dynamicconfig.NewGlobalCachedTypedValue(dc, dynamicconfig.FrontendHTTPAllowedHosts, common.WildCardStringsToRegexps),
+		HTTPAllowedHosts: dynamicconfig.NewGlobalCachedTypedValue(dc, dynamicconfig.FrontendHTTPAllowedHosts, util.WildCardStringsToRegexp),
 	}
 }
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -50,6 +50,8 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
+var matchAny = regexp.MustCompile(".*")
+
 // Config represents configuration for frontend service
 type Config struct {
 	NumHistoryShards                     int32
@@ -335,7 +337,12 @@ func NewConfig(
 		EnableEagerWorkflowStart:   dynamicconfig.EnableEagerWorkflowStart.Get(dc),
 		ActivityAPIsEnabled:        dynamicconfig.ActivityAPIsEnabled.Get(dc),
 
-		HTTPAllowedHosts: dynamicconfig.NewGlobalCachedTypedValue(dc, dynamicconfig.FrontendHTTPAllowedHosts, util.WildCardStringsToRegexp),
+		HTTPAllowedHosts: dynamicconfig.NewGlobalCachedTypedValue(dc, dynamicconfig.FrontendHTTPAllowedHosts, func(patterns []string) (*regexp.Regexp, error) {
+			if len(patterns) == 0 {
+				return matchAny, nil
+			}
+			return util.WildCardStringsToRegexp(patterns)
+		}),
 	}
 }
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -28,12 +28,14 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"sync"
 	"time"
 
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -211,6 +213,8 @@ type Config struct {
 	EnableEagerWorkflowStart dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
 	ActivityAPIsEnabled dynamicconfig.BoolPropertyFnWithNamespaceFilter
+
+	HTTPAllowedHosts *dynamicconfig.GlobalCachedTypedValue[[]*regexp.Regexp]
 }
 
 // NewConfig returns new service config with default values
@@ -330,6 +334,8 @@ func NewConfig(
 		LogAllReqErrors:            dynamicconfig.LogAllReqErrors.Get(dc),
 		EnableEagerWorkflowStart:   dynamicconfig.EnableEagerWorkflowStart.Get(dc),
 		ActivityAPIsEnabled:        dynamicconfig.ActivityAPIsEnabled.Get(dc),
+
+		HTTPAllowedHosts: dynamicconfig.NewGlobalCachedTypedValue(dc, dynamicconfig.FrontendHTTPAllowedHosts, common.WildCardStringsToRegexps),
 	}
 }
 

--- a/tests/http_api_test.go
+++ b/tests/http_api_test.go
@@ -42,6 +42,7 @@ import (
 	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/common/authorization"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/tests/testcore"
@@ -305,6 +306,26 @@ func (s *HttpApiTestSuite) runHTTPAPIBasicsTest_Shorthand(contentType string, pr
 		)
 	}
 	s.runHTTPAPIBasicsTest(contentType, reqBody, queryBody, signalBody, verifyQueryResult, verifyHistory)
+}
+
+func (s *HttpApiTestSuite) TestHTTPHostValidation() {
+	s.GetTestCluster().OverrideDynamicConfig(s.T(), dynamicconfig.FrontendHTTPAllowedHosts, []string{"allowed"})
+	{
+		req, err := http.NewRequest("GET", "/system-info", nil)
+		s.Require().NoError(err)
+		req.Host = "allowed"
+		req.Header.Add("Accept", "application/json")
+		req.Header.Add("Content-Type", "application/json")
+		s.httpRequest(http.StatusOK, req)
+	}
+	{
+		req, err := http.NewRequest("GET", "/system-info", nil)
+		s.Require().NoError(err)
+		req.Host = "not-allowed"
+		req.Header.Add("Accept", "application/json")
+		req.Header.Add("Content-Type", "application/json")
+		s.httpRequest(http.StatusForbidden, req)
+	}
 }
 
 func (s *HttpApiTestSuite) TestHTTPAPIHeaders() {


### PR DESCRIPTION
## What changed?

Add a dynamic config to restrict which HTTP `Host` header values are allowed in HTTP API requests.

## Why?

Prevent DNS rebinding attacks.

## How did you test it?

Added a functional test.