### PR TITLE
Revert "Use previous state in hsm RegenerateTasks (#6710)"

### DIFF
--- a/components/callbacks/statemachine.go
+++ b/components/callbacks/statemachine.go
@@ -90,7 +90,7 @@ func (c Callback) recordAttempt(ts time.Time) {
 	c.CallbackInfo.LastAttemptCompleteTime = timestamppb.New(ts)
 }
 
-func (c Callback) RegenerateTasks(any, *hsm.Node) ([]hsm.Task, error) {
+func (c Callback) RegenerateTasks(*hsm.Node) ([]hsm.Task, error) {
 	switch c.CallbackInfo.State {
 	case enumsspb.CALLBACK_STATE_BACKING_OFF:
 		return []hsm.Task{BackoffTask{deadline: c.NextAttemptScheduleTime.AsTime()}}, nil
@@ -116,7 +116,7 @@ func (c Callback) RegenerateTasks(any, *hsm.Node) ([]hsm.Task, error) {
 func (c Callback) output() (hsm.TransitionOutput, error) {
 	// Task logic is the same when regenerating tasks for a given state and when transitioning to that state.
 	// Node is ignored here.
-	tasks, err := c.RegenerateTasks(nil, nil)
+	tasks, err := c.RegenerateTasks(nil)
 	return hsm.TransitionOutput{Tasks: tasks}, err
 }
 

--- a/components/dummy/statemachine.go
+++ b/components/dummy/statemachine.go
@@ -65,7 +65,7 @@ func (sm *Dummy) SetState(state State) {
 	sm.CurrentState = state
 }
 
-func (sm Dummy) RegenerateTasks(any, *hsm.Node) ([]hsm.Task, error) {
+func (sm Dummy) RegenerateTasks(*hsm.Node) ([]hsm.Task, error) {
 	return []hsm.Task{}, nil
 }
 

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -171,19 +171,16 @@ func (o Operation) creationTasks(node *hsm.Node) ([]hsm.Task, error) {
 	return nil, nil
 }
 
-func (o Operation) RegenerateTasks(prevData any, node *hsm.Node) ([]hsm.Task, error) {
-	tasks, err := o.transitionTasks()
+func (o Operation) RegenerateTasks(node *hsm.Node) ([]hsm.Task, error) {
+	transitionTasks, err := o.transitionTasks()
 	if err != nil {
 		return nil, err
 	}
-	if prevData == nil {
-		creationTasks, err := o.creationTasks(node)
-		if err != nil {
-			return nil, err
-		}
-		tasks = append(tasks, creationTasks...)
+	creationTasks, err := o.creationTasks(node)
+	if err != nil {
+		return nil, err
 	}
-	return tasks, nil
+	return append(transitionTasks, creationTasks...), nil
 }
 
 func (o Operation) output() (hsm.TransitionOutput, error) {
@@ -578,7 +575,7 @@ func (c Cancelation) recordAttempt(ts time.Time) {
 	c.NexusOperationCancellationInfo.LastAttemptFailure = nil
 }
 
-func (c Cancelation) RegenerateTasks(_ any, node *hsm.Node) ([]hsm.Task, error) {
+func (c Cancelation) RegenerateTasks(node *hsm.Node) ([]hsm.Task, error) {
 	op, err := hsm.MachineData[Operation](node.Parent)
 	if err != nil {
 		return nil, err
@@ -594,7 +591,7 @@ func (c Cancelation) RegenerateTasks(_ any, node *hsm.Node) ([]hsm.Task, error) 
 }
 
 func (c Cancelation) output(node *hsm.Node) (hsm.TransitionOutput, error) {
-	tasks, err := c.RegenerateTasks(nil, node)
+	tasks, err := c.RegenerateTasks(node)
 	if err != nil {
 		return hsm.TransitionOutput{}, err
 	}

--- a/components/nexusoperations/statemachine_test.go
+++ b/components/nexusoperations/statemachine_test.go
@@ -171,33 +171,11 @@ func TestRegenerateTasks(t *testing.T) {
 
 			op, err := hsm.MachineData[nexusoperations.Operation](node)
 			require.NoError(t, err)
-			tasks, err := op.RegenerateTasks(nil, node)
+			tasks, err := op.RegenerateTasks(node)
 			require.NoError(t, err)
 			tc.assertTasks(t, tasks)
 		})
 	}
-}
-
-func TestRegenerateTasksFromPreviousState(t *testing.T) {
-	node := newOperationNode(t, &hsmtest.NodeBackend{}, mustNewScheduledEvent(time.Now(), time.Hour))
-	prevOp, err := hsm.MachineData[nexusoperations.Operation](node)
-	require.NoError(t, err)
-
-	require.NoError(t, hsm.MachineTransition(node, func(op nexusoperations.Operation) (hsm.TransitionOutput, error) {
-		return nexusoperations.TransitionAttemptFailed.Apply(op, nexusoperations.EventAttemptFailed{
-			Time:        time.Now(),
-			Err:         fmt.Errorf("test"), // nolint:goerr113
-			Node:        node,
-			RetryPolicy: backoff.NewExponentialRetryPolicy(time.Second),
-		})
-	}))
-
-	op, err := hsm.MachineData[nexusoperations.Operation](node)
-	require.NoError(t, err)
-	tasks, err := op.RegenerateTasks(prevOp, node)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(tasks))
-	require.Equal(t, nexusoperations.TaskTypeBackoff, tasks[0].Type())
 }
 
 func TestRetry(t *testing.T) {

--- a/components/scheduler/statemachine.go
+++ b/components/scheduler/statemachine.go
@@ -130,7 +130,7 @@ func (s *Scheduler) SetState(state enumsspb.SchedulerState) {
 	s.HsmSchedulerState.HsmState = state
 }
 
-func (s *Scheduler) RegenerateTasks(any, *hsm.Node) ([]hsm.Task, error) {
+func (s *Scheduler) RegenerateTasks(*hsm.Node) ([]hsm.Task, error) {
 	switch s.HsmState { // nolint:exhaustive
 	case enumsspb.SCHEDULER_STATE_WAITING:
 		return []hsm.Task{SchedulerWaitTask{deadline: s.NextInvocationTime.AsTime()}}, nil
@@ -183,7 +183,7 @@ var TransitionSchedulerActivate = hsm.NewTransition(
 	[]enumsspb.SchedulerState{enumsspb.SCHEDULER_STATE_WAITING},
 	enumsspb.SCHEDULER_STATE_EXECUTING,
 	func(scheduler *Scheduler, event EventSchedulerActivate) (hsm.TransitionOutput, error) {
-		tasks, err := scheduler.RegenerateTasks(nil, nil)
+		tasks, err := scheduler.RegenerateTasks(nil)
 		return hsm.TransitionOutput{Tasks: tasks}, err
 	})
 
@@ -194,6 +194,6 @@ var TransitionSchedulerWait = hsm.NewTransition(
 	[]enumsspb.SchedulerState{enumsspb.SCHEDULER_STATE_EXECUTING},
 	enumsspb.SCHEDULER_STATE_WAITING,
 	func(scheduler *Scheduler, event EventSchedulerWait) (hsm.TransitionOutput, error) {
-		tasks, err := scheduler.RegenerateTasks(nil, nil)
+		tasks, err := scheduler.RegenerateTasks(nil)
 		return hsm.TransitionOutput{Tasks: tasks}, err
 	})

--- a/service/history/hsm/hsmtest/sm.go
+++ b/service/history/hsm/hsmtest/sm.go
@@ -63,7 +63,7 @@ func (d *Data) SetState(s State) {
 	d.state = s
 }
 
-func (d *Data) RegenerateTasks(any, *hsm.Node) ([]hsm.Task, error) {
+func (d *Data) RegenerateTasks(node *hsm.Node) ([]hsm.Task, error) {
 	return []hsm.Task{
 		NewTask(
 			hsm.TaskAttributes{Deadline: time.Now().Add(time.Hour)},

--- a/service/history/hsm/sm.go
+++ b/service/history/hsm/sm.go
@@ -34,7 +34,7 @@ var ErrInvalidTransition = errors.New("invalid transition")
 // A TaskRegenerator is invoked to regenerate tasks post state-based replication or when refreshing all tasks for a
 // workflow.
 type TaskRegenerator interface {
-	RegenerateTasks(any, *Node) ([]Task, error)
+	RegenerateTasks(*Node) ([]Task, error)
 }
 
 // A StateMachine is anything that can get and set a comparable state S and re-generate tasks based on current state.

--- a/service/history/hsm/tree.go
+++ b/service/history/hsm/tree.go
@@ -415,10 +415,6 @@ func (n *Node) CompareState(incomingNode *Node) (int, error) {
 // Sync updates the state of the current node to that of the incoming node.
 // Meant to be used by the framework, **not** by components.
 func (n *Node) Sync(incomingNode *Node) error {
-	prevData, err := MachineData[any](n)
-	if err != nil {
-		return err
-	}
 	incomingInternalRepr := incomingNode.InternalRepr()
 
 	currentInitialVersionedTransition := n.InternalRepr().InitialVersionedTransition
@@ -446,7 +442,7 @@ func (n *Node) Sync(incomingNode *Node) error {
 	// - generate transition outputs (tasks)
 	// - update transition count
 	if err := MachineTransition(n, func(taskRegenerator TaskRegenerator) (TransitionOutput, error) {
-		tasks, err := taskRegenerator.RegenerateTasks(prevData, n)
+		tasks, err := taskRegenerator.RegenerateTasks(n)
 		return TransitionOutput{
 			Tasks: tasks,
 		}, err

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -6609,7 +6609,6 @@ func (ms *MutableStateImpl) applyUpdatesToStateMachineNodes(
 		internalNode.InitialVersionedTransition = nodeMutation.InitialVersionedTransition
 		internalNode.LastUpdateVersionedTransition = nodeMutation.LastUpdateVersionedTransition
 		internalNode.TransitionCount++
-		// TODO: Cache invalidation. This must be fixed before state based replication is enabled.
 	}
 	return nil
 }

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -667,8 +667,7 @@ func (r *TaskRefresherImpl) refreshTasksForSubStateMachines(
 			return err
 		}
 
-		// TODO: This may generate redundant tasks, needs to be fixed before enabling state replication.
-		tasks, err := taskRegenerator.RegenerateTasks(nil, node)
+		tasks, err := taskRegenerator.RegenerateTasks(node)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This reverts commit 2bfca0d9a1bdf16200594c38146e2b1a005005f8.

## Why?

The approach taken in #6728 made this change obsolete.