### PR TITLE
Rename alias for tdbg history-host

### DIFF
--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -59,7 +59,7 @@ func getCommands(
 		},
 		{
 			Name:        "history-host",
-			Aliases:     []string{"his"},
+			Aliases:     []string{"hh"},
 			Usage:       "Run admin operation on history host",
 			Subcommands: newAdminHistoryHostCommands(clientFactory),
 		},

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -59,7 +59,7 @@ func getCommands(
 		},
 		{
 			Name:        "history-host",
-			Aliases:     []string{"h"},
+			Aliases:     []string{"his"},
 			Usage:       "Run admin operation on history host",
 			Subcommands: newAdminHistoryHostCommands(clientFactory),
 		},


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Rename alias for tdbg history-host from `h` to `his`

## Why?
<!-- Tell your future self why have you made these changes -->
- `h` is used by the built in help command
```
COMMANDS:
   workflow, w      Run admin operation on workflow
   shard, s         Run admin operation on specific shard
   history-host, h  Run admin operation on history host
   taskqueue, tq    Run admin operation on taskQueue
   membership, m    Run admin operation on membership
   dlq              Run admin operation on DLQ
   decode           Decode payload
   help, h          Shows a list of commands or help for one command
```
In the version of `"github.com/urfave/cli/v2"` we are using right now it's ok. But in the latest version  v2.27.5, this duplication will result in an error when running tdbg commands.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Tested locally.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- Technically a breaking change for tdbg users

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
