### PR TITLE
Do not clear mutable state when query failed

### DIFF
--- a/service/history/api/queryworkflow/api.go
+++ b/service/history/api/queryworkflow/api.go
@@ -97,7 +97,11 @@ func Invoke(
 	if err != nil {
 		return nil, err
 	}
-	defer func() { workflowLease.GetReleaseFn()(retError) }()
+	defer func() {
+		// Do not clear mutable state when query failed. Clear mutable state will fail other buffered pending queries.
+		// Note: QueryWorkflow should not alter mutable state, so it is safe to ignore error and not clear ms.
+		workflowLease.GetReleaseFn()(nil)
+	}()
 
 	req := request.GetRequest()
 	_, mutableStateStatus := workflowLease.GetMutableState().GetWorkflowStateStatus()


### PR DESCRIPTION
## What changed?
Do not clear mutable state when query failed

## Why?
QueryWorkflow won't alter mutable state, so it is safe to not clear ms when query failed.
Exiting behavior would clear mutable state on failed query, which delete all pending buffered queries and is not desired.

## How did you test it?
Update existing tests to verify that buffered query still exists after a failed query.

## Potential risks
No

## Documentation
No change.

## Is hotfix candidate?
No.
