### PR TITLE
Return InvalidArgument error for invalid search attributes

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -925,7 +925,7 @@ func (s *VisibilityStore) GenerateESDoc(
 	// If it's only invalid values error, then silently continue without them.
 	searchAttributes, err = s.ValidateCustomSearchAttributes(searchAttributes)
 	if err != nil {
-		if _, ok := err.(*store.VisibilityStoreInvalidValuesError); !ok {
+		if _, ok := err.(*serviceerror.InvalidArgument); !ok {
 			return nil, err
 		}
 	}
@@ -1453,7 +1453,7 @@ func parsePageTokenValue(
 func validateDatetime(value time.Time) error {
 	if value.Before(minTime) || value.After(maxTime) {
 		return serviceerror.NewInvalidArgument(
-			fmt.Sprintf("Date not supported in Elasticsearch: %v", value),
+			fmt.Sprintf("invalid search attribute date: %v, supported range: [%v, %v]", value, minTime, maxTime),
 		)
 	}
 	return nil
@@ -1463,7 +1463,7 @@ func validateString(value string) error {
 	if len(value) > maxStringLength {
 		return serviceerror.NewInvalidArgument(
 			fmt.Sprintf(
-				"strings with more than %d bytes are not supported in Elasticsearch (got string of len %d)",
+				"strings with more than %d bytes are not supported (got string of len %d)",
 				maxStringLength,
 				len(value),
 			),

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_validation_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_validation_test.go
@@ -1,0 +1,28 @@
+package elasticsearch
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/api/serviceerror"
+)
+
+func TestValidationDatetime(t *testing.T) {
+	store := VisibilityStore{}
+
+	// valid datetime
+	_, err := store.ValidateCustomSearchAttributes(map[string]any{
+		"CustomDatetimeField": time.Now(),
+	})
+	assert.NoError(t, err)
+
+	// invalid out of range datetime
+	_, err = store.ValidateCustomSearchAttributes(map[string]any{
+		"CustomDatetimeField": time.Unix(0, math.MaxInt64).Add(time.Hour),
+	})
+	assert.Error(t, err)
+	assert.IsType(t, &serviceerror.InvalidArgument{}, err)
+	assert.Contains(t, err.Error(), "Visibility store validation errors")
+}

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_validation_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_validation_test.go
@@ -1,3 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package elasticsearch
 
 import (

--- a/common/persistence/visibility/store/errors.go
+++ b/common/persistence/visibility/store/errors.go
@@ -30,28 +30,22 @@ import (
 	"go.temporal.io/api/serviceerror"
 )
 
-type (
-	VisibilityStoreInvalidValuesError struct {
-		errs []error
-	}
-)
-
 var (
 	// OperationNotSupportedErr is returned when visibility operation in not supported.
 	OperationNotSupportedErr = serviceerror.NewInvalidArgument("Operation not supported. Please use on Elasticsearch")
 )
 
-func (e *VisibilityStoreInvalidValuesError) Error() string {
+func NewVisibilityStoreInvalidValuesError(errs []error) error {
 	var sb strings.Builder
-	sb.WriteString("Visibility store invalid values errors: ")
-	for _, err := range e.errs {
+	sb.WriteString("Visibility store validation errors: ")
+	for i, err := range errs {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
 		sb.WriteString("[")
 		sb.WriteString(err.Error())
 		sb.WriteString("]")
 	}
-	return sb.String()
-}
 
-func NewVisibilityStoreInvalidValuesError(errs []error) error {
-	return &VisibilityStoreInvalidValuesError{errs: errs}
+	return serviceerror.NewInvalidArgument(sb.String())
 }

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -420,7 +420,7 @@ func (s *VisibilityStore) prepareSearchAttributesForDb(
 	// If it's only invalid values error, then silently continue without them.
 	searchAttributes, err = s.ValidateCustomSearchAttributes(searchAttributes)
 	if err != nil {
-		if _, ok := err.(*store.VisibilityStoreInvalidValuesError); !ok {
+		if _, ok := err.(*serviceerror.InvalidArgument); !ok {
 			return nil, err
 		}
 	}

--- a/common/persistence/visibility/store/visibility_store.go
+++ b/common/persistence/visibility/store/visibility_store.go
@@ -45,8 +45,8 @@ type (
 		GetIndexName() string
 
 		// Validate search attributes based on the store constraints. It returns a new map containing
-		// only search attributes with valid values. If there are invalid values, an error of type
-		// VisibilityStoreInvalidValuesError wraps all invalid values errors.
+		// only search attributes with valid values. If there are invalid values, it returns error of type
+		// serviceerror.InvalidArgument.
 		ValidateCustomSearchAttributes(searchAttributes map[string]any) (map[string]any, error)
 
 		// Write APIs.


### PR DESCRIPTION
## What changed?
Return InvalidArgument error for invalid search attribute input

## Why?
Existing error is converted into errors.errorString is convert to grpc Unknown code.

## How did you test it?
Added new unit test

## Potential risks
No

## Documentation
No

## Is hotfix candidate?
No
