### PR TITLE
Fix closeTransactionTrackLastUpdateVersionedTransition

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5500,6 +5500,10 @@ func (ms *MutableStateImpl) closeTransactionTrackLastUpdateVersionedTransition(
 		// transition history is not enabled
 		return
 	}
+	// transaction closed without any state change
+	if len(ms.executionInfo.TransitionHistory) == 0 {
+		return
+	}
 
 	transitionHistory := ms.executionInfo.TransitionHistory
 	currentVersionedTransition := transitionHistory[len(transitionHistory)-1]


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix closeTransactionTrackLastUpdateVersionedTransition
## Why?
<!-- Tell your future self why have you made these changes -->
In a case where we closed transaction without changing mutable state, the state transition will not be updated.
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
n/a
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no risk
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
no
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
no