### PR TITLE
Delete code for standard visibility from DeleteNamespace workflow

### DIFF
--- a/service/worker/deletenamespace/reclaimresources/activities_test.go
+++ b/service/worker/deletenamespace/reclaimresources/activities_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/server/common/log"
@@ -118,54 +117,4 @@ func Test_EnsureNoExecutionsAdvVisibilityActivity_NotDeletedExecutionsExist(t *t
 	var appErr *temporal.ApplicationError
 	require.ErrorAs(t, err, &appErr)
 	require.Equal(t, "NotDeletedExecutionsStillExist", appErr.Type())
-}
-
-func Test_EnsureNoExecutionsStdVisibilityActivity_NoExecutions(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	visibilityManager := manager.NewMockVisibilityManager(ctrl)
-
-	visibilityManager.EXPECT().ListWorkflowExecutions(gomock.Any(), &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: "namespace-id",
-		Namespace:   "namespace",
-		PageSize:    1,
-		Query:       searchattribute.QueryWithAnyNamespaceDivision(""),
-	}).Return(&manager.ListWorkflowExecutionsResponse{
-		Executions: []*workflowpb.WorkflowExecutionInfo{},
-	}, nil)
-
-	a := &Activities{
-		visibilityManager: visibilityManager,
-		metricsHandler:    metrics.NoopMetricsHandler,
-		logger:            log.NewNoopLogger(),
-	}
-
-	err := a.EnsureNoExecutionsStdVisibilityActivity(context.Background(), "namespace-id", "namespace")
-	require.NoError(t, err)
-}
-
-func Test_EnsureNoExecutionsStdVisibilityActivity_ExecutionsExist(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	visibilityManager := manager.NewMockVisibilityManager(ctrl)
-
-	visibilityManager.EXPECT().ListWorkflowExecutions(gomock.Any(), &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: "namespace-id",
-		Namespace:   "namespace",
-		PageSize:    1,
-		Query:       searchattribute.QueryWithAnyNamespaceDivision(""),
-	}).Return(&manager.ListWorkflowExecutionsResponse{
-		Executions: []*workflowpb.WorkflowExecutionInfo{{}},
-	}, nil)
-
-	a := &Activities{
-		visibilityManager: visibilityManager,
-		metricsHandler:    metrics.NoopMetricsHandler,
-		logger:            log.NewNoopLogger(),
-	}
-
-	err := a.EnsureNoExecutionsStdVisibilityActivity(context.Background(), "namespace-id", "namespace")
-
-	require.Error(t, err)
-	var appErr *temporal.ApplicationError
-	require.ErrorAs(t, err, &appErr)
-	require.Equal(t, "ExecutionsStillExist", appErr.Type())
 }

--- a/service/worker/deletenamespace/reclaimresources/workflow_test.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow_test.go
@@ -69,7 +69,6 @@ func Test_ReclaimResourcesWorkflow_Success(t *testing.T) {
 		ErrorCount:   0,
 	}, nil).Once()
 
-	env.OnActivity(la.IsAdvancedVisibilityActivity, mock.Anything, namespace.Name("namespace")).Return(true, nil).Once()
 	env.OnActivity(la.CountExecutionsAdvVisibilityActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace")).Return(int64(10), nil).Once()
 	env.OnActivity(a.EnsureNoExecutionsAdvVisibilityActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace"), 0).Return(nil).Once()
 
@@ -119,7 +118,6 @@ func Test_ReclaimResourcesWorkflow_EnsureNoExecutionsActivity_Error(t *testing.T
 		ErrorCount:   0,
 	}, nil).Once()
 
-	env.OnActivity(la.IsAdvancedVisibilityActivity, mock.Anything, namespace.Name("namespace")).Return(true, nil).Once()
 	env.OnActivity(la.CountExecutionsAdvVisibilityActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace")).Return(int64(10), nil).Once()
 	env.OnActivity(a.EnsureNoExecutionsAdvVisibilityActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace"), 0).
 		Return(stderrors.New("specific_error_from_activity")).
@@ -166,7 +164,6 @@ func Test_ReclaimResourcesWorkflow_EnsureNoExecutionsActivity_ExecutionsStillExi
 		ErrorCount:   0,
 	}, nil).Once()
 
-	env.OnActivity(la.IsAdvancedVisibilityActivity, mock.Anything, namespace.Name("namespace")).Return(true, nil).Once()
 	env.OnActivity(la.CountExecutionsAdvVisibilityActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace")).Return(int64(10), nil).Once()
 	env.OnActivity(a.EnsureNoExecutionsAdvVisibilityActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace"), 0).
 		Return(errors.NewExecutionsStillExistError(1)).
@@ -195,7 +192,6 @@ func Test_ReclaimResourcesWorkflow_NoActivityMocks_Success(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	visibilityManager := manager.NewMockVisibilityManager(ctrl)
-	visibilityManager.EXPECT().GetReadStoreName(namespace.Name("namespace")).Return("elasticsearch")
 
 	// For CountExecutionsAdvVisibilityActivity.
 	visibilityManager.EXPECT().CountWorkflowExecutions(gomock.Any(), &manager.CountWorkflowExecutionsRequest{
@@ -242,7 +238,6 @@ func Test_ReclaimResourcesWorkflow_NoActivityMocks_Success(t *testing.T) {
 		logger:            log.NewNoopLogger(),
 	}
 
-	env.RegisterActivity(la.IsAdvancedVisibilityActivity)
 	env.RegisterActivity(la.CountExecutionsAdvVisibilityActivity)
 	env.RegisterActivity(a.EnsureNoExecutionsAdvVisibilityActivity)
 	env.RegisterActivity(la.DeleteNamespaceActivity)
@@ -289,7 +284,6 @@ func Test_ReclaimResourcesWorkflow_NoActivityMocks_NoProgressMade(t *testing.T) 
 
 	ctrl := gomock.NewController(t)
 	visibilityManager := manager.NewMockVisibilityManager(ctrl)
-	visibilityManager.EXPECT().GetReadStoreName(namespace.Name("namespace")).Return("elasticsearch")
 
 	// For CountExecutionsAdvVisibilityActivity.
 	visibilityManager.EXPECT().CountWorkflowExecutions(gomock.Any(), &manager.CountWorkflowExecutionsRequest{
@@ -321,7 +315,6 @@ func Test_ReclaimResourcesWorkflow_NoActivityMocks_NoProgressMade(t *testing.T) 
 		logger:            log.NewNoopLogger(),
 	}
 
-	env.RegisterActivity(la.IsAdvancedVisibilityActivity)
 	env.RegisterActivity(la.CountExecutionsAdvVisibilityActivity)
 	env.RegisterActivity(a.EnsureNoExecutionsAdvVisibilityActivity)
 


### PR DESCRIPTION
## What changed?
Standard visibility was removed from server in v1.24 release. This is to clear dead code.

## Why?
Less is better.

## How did you test it?
eye_ball

## Potential risks
NDE on replay

## Documentation
No

## Is hotfix candidate?
No
