### PR TITLE
Add GetFrontendHostPort() method to TestServer

### DIFF
--- a/temporaltest/server.go
+++ b/temporaltest/server.go
@@ -103,6 +103,14 @@ func (ts *TestServer) GetDefaultNamespace() string {
 	return ts.defaultTestNamespace
 }
 
+// GetFrontendHostPort returns the host:port for this server.
+//
+// When constructing a Temporal client from within the same process,
+// GetDefaultClient or NewClientWithOptions should be used instead.
+func (ts *TestServer) GetFrontendHostPort() string {
+	return ts.server.FrontendHostPort()
+}
+
 // NewClientWithOptions returns a new Temporal client configured for making requests to the server.
 //
 // If no namespace option is set it will use a pre-registered test namespace.


### PR DESCRIPTION
## What changed?
Added a `GetFrontendHostPort()` method to the TestServer

## Why?
For situations where you want to know the port that the test server is running on outside of typical use of client.Client

## How did you test it?
Tested locally

## Potential risks
None

## Documentation
there is currently no documentation for TestServer aside from inline comments

## Is hotfix candidate?
no
