### PR TITLE
remove linter goerr113 and nolint comments/annotations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@
 linters:
   disable-all: true
   enable:
-    - err113
     - errcheck
     - goimports
     # - paralleltest # missing the call to method parallel, but testify does not seem to work well with parallel test: https://github.com/stretchr/testify/issues/187
@@ -30,12 +29,8 @@ issues:
       text: "dot-imports"  # helpful in tests
       linters:
         - revive
-    - path: _test\.go|tests/.+\.go
-      linters:
-        - goerr113  # like err = errors.New("test error")
     - path: ^tools\/.+\.go
       linters:
-        - goerr113
         - revive
 linters-settings:
   godox:

--- a/common/testing/runtime/goroutine.go
+++ b/common/testing/runtime/goroutine.go
@@ -121,7 +121,6 @@ func numGoRoutinesWithFn(fnName string) (int, error) {
 	stackRecords := make([]runtime.StackRecord, runtime.NumGoroutine()+20)
 	stackRecordsLen, ok := runtime.GoroutineProfile(stackRecords)
 	if !ok {
-		// nolint:goerr113 // Error is just for logging.
 		return 0, errors.New(fmt.Sprintf("Size %d is too small for stack records. Need %d", len(stackRecords), stackRecordsLen))
 	}
 
@@ -151,7 +150,6 @@ func functionName(fn any) (string, error) {
 		return fnName, nil
 	}
 
-	// nolint:goerr113 // Error is just for logging.
 	return "", errors.New(fmt.Sprintf("Invalid function %#v", fn))
 }
 

--- a/common/tqid/task_queue_id.go
+++ b/common/tqid/task_queue_id.go
@@ -368,7 +368,6 @@ func parseRpcName(rpcName string) (string, int, error) {
 		suffixOff := strings.LastIndex(rpcName, partitionDelimiter)
 		if suffixOff <= len(nonRootPartitionPrefix) {
 			return "", 0, serviceerror.NewInvalidArgument("invalid task queue partition name " + rpcName)
-			// nolint:goerr113
 		}
 		baseName = rpcName[len(nonRootPartitionPrefix):suffixOff]
 		suffix := rpcName[suffixOff+1:]

--- a/components/callbacks/hsm_invocation.go
+++ b/components/callbacks/hsm_invocation.go
@@ -81,7 +81,7 @@ func (s hsmInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e ta
 	// TODO(Tianyu): Will this ever be too big for an RPC call?
 	callbackArgSerialized, err := s.callbackArg.Marshal()
 	if err != nil {
-		return failed, fmt.Errorf("failed to serialize completion event: %v", err) //nolint:goerr113
+		return failed, fmt.Errorf("failed to serialize completion event: %v", err)
 	}
 
 	request := historyservice.InvokeStateMachineMethodRequest{

--- a/components/callbacks/nexus_invocation.go
+++ b/components/callbacks/nexus_invocation.go
@@ -123,7 +123,7 @@ func (n nexusInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e 
 	}
 
 	retryable := isRetryableHTTPResponse(response)
-	err = fmt.Errorf("request failed with: %v", response.Status) // nolint:goerr113
+	err = fmt.Errorf("request failed with: %v", response.Status)
 	e.Logger.Error("Callback request failed", tag.Error(err), tag.NewStringTag("status", response.Status), tag.NewBoolTag("retryable", retryable))
 	if retryable {
 		return retry, err

--- a/components/callbacks/statemachine.go
+++ b/components/callbacks/statemachine.go
@@ -107,7 +107,7 @@ func (c Callback) RegenerateTasks(*hsm.Node) ([]hsm.Task, error) {
 			return []hsm.Task{InvocationTask{"TODO(bergundy): make this empty"}}, nil
 
 		default:
-			return nil, fmt.Errorf("unsupported callback variant %v", v) // nolint:goerr113
+			return nil, fmt.Errorf("unsupported callback variant %v", v)
 		}
 	}
 	return nil, nil
@@ -159,7 +159,7 @@ func (stateMachineDefinition) Serialize(state any) ([]byte, error) {
 	if state, ok := state.(Callback); ok {
 		return proto.Marshal(state.CallbackInfo)
 	}
-	return nil, fmt.Errorf("invalid callback provided: %v", state) // nolint:goerr113
+	return nil, fmt.Errorf("invalid callback provided: %v", state)
 }
 
 // CompareState compares the progress of two Callback state machines to determine whether to sync machine state while

--- a/components/callbacks/statemachine_test.go
+++ b/components/callbacks/statemachine_test.go
@@ -54,7 +54,7 @@ func TestValidTransitions(t *testing.T) {
 	// AttemptFailed
 	out, err := callbacks.TransitionAttemptFailed.Apply(callback, callbacks.EventAttemptFailed{
 		Time:        currentTime,
-		Err:         fmt.Errorf("test"), // nolint:goerr113
+		Err:         fmt.Errorf("test"),
 		RetryPolicy: backoff.NewExponentialRetryPolicy(time.Second),
 	})
 	require.NoError(t, err)

--- a/components/nexusoperations/completion.go
+++ b/components/nexusoperations/completion.go
@@ -123,7 +123,7 @@ func handleUnsuccessfulOperationError(
 	default:
 		// Both the Nexus Client and CompletionHandler reject invalid states, but just in case, we return this as a
 		// transition error.
-		return hsm.TransitionOutput{}, fmt.Errorf("unexpected operation state: %v", opFailedError.State) // nolint:goerr113
+		return hsm.TransitionOutput{}, fmt.Errorf("unexpected operation state: %v", opFailedError.State)
 	}
 }
 

--- a/components/nexusoperations/frontend/handler.go
+++ b/components/nexusoperations/frontend/handler.go
@@ -339,7 +339,7 @@ func (c *requestContext) capturePanicAndRecordMetrics(ctxPtr *context.Context, e
 	if recovered != nil {
 		err, ok := recovered.(error)
 		if !ok {
-			err = fmt.Errorf("panic: %v", recovered) //nolint:goerr113
+			err = fmt.Errorf("panic: %v", recovered)
 		}
 
 		st := string(debug.Stack())

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -206,7 +206,7 @@ func (operationMachineDefinition) Serialize(state any) ([]byte, error) {
 	if state, ok := state.(Operation); ok {
 		return proto.Marshal(state.NexusOperationInfo)
 	}
-	return nil, fmt.Errorf("invalid operation provided: %v", state) // nolint:goerr113
+	return nil, fmt.Errorf("invalid operation provided: %v", state)
 }
 
 // CompareState compares the progress of two Operation state machines to determine whether to sync machine state while
@@ -519,7 +519,7 @@ func (cancelationMachineDefinition) Serialize(state any) ([]byte, error) {
 	if state, ok := state.(Cancelation); ok {
 		return proto.Marshal(state.NexusOperationCancellationInfo)
 	}
-	return nil, fmt.Errorf("invalid cancelation provided: %v", state) // nolint:goerr113
+	return nil, fmt.Errorf("invalid cancelation provided: %v", state)
 }
 
 func (cancelationMachineDefinition) Type() string {

--- a/components/nexusoperations/statemachine_test.go
+++ b/components/nexusoperations/statemachine_test.go
@@ -162,7 +162,7 @@ func TestRegenerateTasks(t *testing.T) {
 				require.NoError(t, hsm.MachineTransition(node, func(op nexusoperations.Operation) (hsm.TransitionOutput, error) {
 					return nexusoperations.TransitionAttemptFailed.Apply(op, nexusoperations.EventAttemptFailed{
 						Time:        time.Now(),
-						Err:         fmt.Errorf("test"), // nolint:goerr113
+						Err:         fmt.Errorf("test"),
 						Node:        node,
 						RetryPolicy: backoff.NewExponentialRetryPolicy(time.Second),
 					})
@@ -185,7 +185,7 @@ func TestRetry(t *testing.T) {
 	require.NoError(t, hsm.MachineTransition(node, func(op nexusoperations.Operation) (hsm.TransitionOutput, error) {
 		return nexusoperations.TransitionAttemptFailed.Apply(op, nexusoperations.EventAttemptFailed{
 			Time:        time.Now(),
-			Err:         fmt.Errorf("test"), // nolint:goerr113
+			Err:         fmt.Errorf("test"),
 			Node:        node,
 			RetryPolicy: backoff.NewExponentialRetryPolicy(time.Second),
 		})
@@ -345,7 +345,7 @@ func TestCompleteExternally(t *testing.T) {
 					return nexusoperations.TransitionAttemptFailed.Apply(op, nexusoperations.EventAttemptFailed{
 						Node:        node,
 						Time:        time.Now(),
-						Err:         fmt.Errorf("test"), // nolint:goerr113
+						Err:         fmt.Errorf("test"),
 						RetryPolicy: backoff.NewExponentialRetryPolicy(time.Second),
 					})
 				}))

--- a/components/scheduler/statemachine.go
+++ b/components/scheduler/statemachine.go
@@ -161,7 +161,7 @@ func (stateMachineDefinition) Serialize(state any) ([]byte, error) {
 	if state, ok := state.(*Scheduler); ok {
 		return proto.Marshal(state.HsmSchedulerState)
 	}
-	return nil, fmt.Errorf("invalid scheduler state provided: %v", state) // nolint:goerr113
+	return nil, fmt.Errorf("invalid scheduler state provided: %v", state)
 }
 
 // CompareState is required for the temporary state sync solution to work.

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -100,7 +100,7 @@ func (c *operationContext) capturePanicAndRecordMetrics(ctxPtr *context.Context,
 	if recovered != nil {
 		err, ok := recovered.(error)
 		if !ok {
-			err = fmt.Errorf("panic: %v", recovered) //nolint:goerr113
+			err = fmt.Errorf("panic: %v", recovered)
 		}
 
 		st := string(debug.Stack())
@@ -264,7 +264,7 @@ type nexusHandler struct {
 func (h *nexusHandler) getOperationContext(ctx context.Context, method string) (*operationContext, error) {
 	nc, ok := ctx.Value(nexusContextKey{}).(*nexusContext)
 	if !ok {
-		return nil, errors.New("no nexus context set on context") //nolint:goerr113
+		return nil, errors.New("no nexus context set on context")
 	}
 	oc := operationContext{
 		nexusContext:                  nc,

--- a/service/history/hsm/hsmtest/backend.go
+++ b/service/history/hsm/hsmtest/backend.go
@@ -71,7 +71,7 @@ func (n *NodeBackend) LoadHistoryEvent(ctx context.Context, tokenBytes []byte) (
 	})
 
 	if idx < 0 {
-		return nil, fmt.Errorf("event not found") // nolint:goerr113
+		return nil, fmt.Errorf("event not found")
 	}
 
 	return n.Events[idx], nil

--- a/service/history/hsm/tree_test.go
+++ b/service/history/hsm/tree_test.go
@@ -420,7 +420,7 @@ func TestMachineTransition(t *testing.T) {
 	err = hsm.MachineTransition(root, func(d *hsmtest.Data) (hsm.TransitionOutput, error) {
 		// Mutate state and make sure the cache is marked stale.
 		d.SetState(hsmtest.State2)
-		return hsm.TransitionOutput{}, fmt.Errorf("test") // nolint:goerr113
+		return hsm.TransitionOutput{}, fmt.Errorf("test")
 	})
 	require.ErrorContains(t, err, "test")
 	require.Equal(t, int64(0), root.InternalRepr().TransitionCount)

--- a/service/history/workflow/task_generator_test.go
+++ b/service/history/workflow/task_generator_test.go
@@ -377,7 +377,7 @@ func TestTaskGenerator_GenerateDirtySubStateMachineTasks(t *testing.T) {
 	err = coll.Transition("backoff", func(cb callbacks.Callback) (hsm.TransitionOutput, error) {
 		return callbacks.TransitionAttemptFailed.Apply(cb, callbacks.EventAttemptFailed{
 			Time:        time.Now(),
-			Err:         fmt.Errorf("test"), // nolint:goerr113
+			Err:         fmt.Errorf("test"),
 			RetryPolicy: backoff.NewExponentialRetryPolicy(time.Second),
 		})
 	})

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -341,7 +341,7 @@ func (pm *taskQueuePartitionManagerImpl) ProcessSpooledTask(
 			task.redirectInfo = nil
 		}
 		err = syncMatchQueue.DispatchSpooledTask(ctx, task, userDataChanged)
-		if err != errInterrupted { // nolint:goerr113
+		if err != errInterrupted {
 			return err
 		}
 	}

--- a/service/matching/user_data_manager.go
+++ b/service/matching/user_data_manager.go
@@ -226,7 +226,7 @@ func (m *userDataManagerImpl) userDataFetchSource() (*tqid.NormalPartition, erro
 		p = p.TaskQueue().Family().TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).NormalPartition(p.PartitionId())
 		degree := m.config.ForwarderMaxChildrenPerNode()
 		parent, err := p.ParentPartition(degree)
-		if err == tqid.ErrNoParent { // nolint:goerr113
+		if err == tqid.ErrNoParent {
 			// we're the root activity task queue, ask the root workflow task queue
 			return p, nil
 		} else if err != nil {
@@ -254,7 +254,7 @@ func (m *userDataManagerImpl) fetchUserData(ctx context.Context) error {
 	// fetch from parent partition
 	fetchSource, err := m.userDataFetchSource()
 	if err != nil {
-		if err == errMissingNormalQueueName { // nolint:goerr113
+		if err == errMissingNormalQueueName {
 			// pretend we have no user data. this is a sticky queue so the only effect is that we can't
 			// kick off versioned pollers.
 			m.setUserDataState(userDataEnabled, nil)

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -2287,7 +2287,7 @@ func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnRetry() {
 	buildIdv1 := s.T().Name() + "-v1"
 
 	wf := func(ctx workflow.Context) error {
-		return fmt.Errorf("fail") //nolint:goerr113
+		return fmt.Errorf("fail")
 	}
 
 	// Declare v1

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -747,7 +747,7 @@ func (s *ScheduleFunctionalSuite) TestLastCompletionAndError() {
 		case 2:
 			s.NoError(lastErr)
 			s.Equal("this one succeeds", lcr)
-			return "", errors.New("this one fails") //nolint:goerr113
+			return "", errors.New("this one fails")
 		case 3:
 			s.Equal("this one succeeds", lcr)
 			s.ErrorContains(lastErr, "this one fails")
@@ -822,7 +822,7 @@ func (s *ScheduleFunctionalSuite) TestExperimentalHsmLastCompletionAndError() {
 		case 2:
 			s.NoError(lastErr)
 			s.Equal("this one succeeds", lcr)
-			return "", errors.New("this one fails") //nolint:goerr113
+			return "", errors.New("this one fails")
 		case 3:
 			s.Equal("this one succeeds", lcr)
 			s.ErrorContains(lastErr, "this one fails")

--- a/tests/stickytq_test.go
+++ b/tests/stickytq_test.go
@@ -117,7 +117,7 @@ func (s *StickyTqTestSuite) TestStickyTimeout_NonTransientWorkflowTask() {
 				}
 			*/
 			failureCount--
-			return nil, errors.New("non deterministic error") //nolint:goerr113
+			return nil, errors.New("non deterministic error")
 		}
 
 		return []*commandpb.Command{{
@@ -298,7 +298,7 @@ func (s *StickyTqTestSuite) TestStickyTaskqueueResetThenTimeout() {
 
 		if failureCount > 0 {
 			failureCount--
-			return nil, errors.New("non deterministic error") //nolint:goerr113
+			return nil, errors.New("non deterministic error")
 		}
 
 		return []*commandpb.Command{{

--- a/tests/testcore/client_suite.go
+++ b/tests/testcore/client_suite.go
@@ -174,7 +174,6 @@ func (s *ClientFunctionalSuite) HistoryContainsFailureCausedBy(
 				}
 			}
 		}
-		// nolint:goerr113
 		return fmt.Errorf("did not find a failed task whose cause was %q", cause)
 	})
 }

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -2339,7 +2339,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Fail() 
 			wtHandlerCalls++ // because it won't be called for case 3 but counter should be in sync.
 			// Fail WT one more time. Although 2nd attempt is normal WT, it is also transient and shouldn't appear in the history.
 			// Returning error will cause the poller to fail WT.
-			return nil, errors.New("malformed request") //nolint:goerr113
+			return nil, errors.New("malformed request")
 		case 4:
 			// 3rd attempt UpdateWorkflowExecution call has timed out but the
 			// update is still running
@@ -2348,7 +2348,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Fail() 
 			wtHandlerCalls++ // because it won't be called for case 4 but counter should be in sync.
 			// Fail WT one more time. This is transient WT and shouldn't appear in the history.
 			// Returning error will cause the poller to fail WT.
-			return nil, errors.New("malformed request") //nolint:goerr113
+			return nil, errors.New("malformed request")
 		case 5:
 			return nil, nil
 		default:

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -1293,7 +1293,7 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSyncMatch(versio
 	failedTask := make(chan struct{})
 	act1 := func() (string, error) {
 		close(failedTask)
-		return "", errors.New("failing activity task intentionally") //nolint:goerr113
+		return "", errors.New("failing activity task intentionally")
 	}
 
 	w1 := worker.New(s.sdkClient, actTq, worker.Options{
@@ -1883,7 +1883,7 @@ func (s *VersioningIntegSuite) dispatchActivity(failMode activityFailMode, newVe
 		if state.Add(1) == 1 {
 			switch failMode {
 			case failActivity:
-				return "", errors.New("try again") //nolint:goerr113
+				return "", errors.New("try again")
 			case timeoutActivity:
 				time.Sleep(5 * time.Second) //nolint:forbidigo
 				return "ignored", nil
@@ -2227,7 +2227,7 @@ func (s *VersioningIntegSuite) TestRedirectWithConcurrentActivities() {
 			lastRedirectTarget.CompareAndSwap(version+" observed", version+" redirect cleaned")
 		}
 		if rand.Float64() < activityErrorRate {
-			return "", errors.New("intentionally failing activity") //nolint:goerr113
+			return "", errors.New("intentionally failing activity")
 		}
 		if triggerRedirectAtActivityRun.Load() == runId {
 			// When enough activities are run using the current version, add redirect rule to the next version.


### PR DESCRIPTION
## What changed?
turned off linter goerr113

## Why?
causing excessive linter errors and challanges

## How did you test it?
PR build

## Potential risks
fix messy error handling later

## Documentation
N/A

## Is hotfix candidate?
Nope
