### PR TITLE
Return StartOutcome from Workflow Start

### DIFF
--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -262,6 +262,8 @@ func startAndUpdateWorkflow(
 	}
 
 	switch startOutcome {
+	case startworkflow.NoStart:
+		panic("unreachable")
 	case startworkflow.StartNew:
 	case startworkflow.StartReused:
 		// The workflow was meant to be *started* - but was actually *not* started since it's already running.

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -399,7 +399,7 @@ func (e *historyEngineImpl) registerNamespaceStateChangeCallback() {
 func (e *historyEngineImpl) StartWorkflowExecution(
 	ctx context.Context,
 	startRequest *historyservice.StartWorkflowExecutionRequest,
-) (resp *historyservice.StartWorkflowExecutionResponse, retError error) {
+) (*historyservice.StartWorkflowExecutionResponse, error) {
 	starter, err := startworkflow.NewStarter(
 		e.shardContext,
 		e.workflowConsistencyChecker,
@@ -410,7 +410,9 @@ func (e *historyEngineImpl) StartWorkflowExecution(
 	if err != nil {
 		return nil, err
 	}
-	return starter.Invoke(ctx, startworkflow.BeforeCreateHookNoop)
+
+	resp, _, err := starter.Invoke(ctx, startworkflow.BeforeCreateHookNoop)
+	return resp, err
 }
 
 func (e *historyEngineImpl) ExecuteMultiOperation(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Introducing a new StartOutcome type. It signals the kind of start that was performed.

I considered various other options (like sentinel error types and adding a new field to the proto), but then decided on this.

## Why?
<!-- Tell your future self why have you made these changes -->

This is needed for making Terminate-Existing work, since there it's important to distinguish between "deduped" and "reused".

See https://github.com/temporalio/temporal/pull/6783

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
