### PR TITLE
Fix TestDeleteInactiveChannels flakiness

### DIFF
--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -429,6 +429,10 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestDeleteInactiveChannels
 	s.scheduler.Submit(mockTask3)
 	taskWG.Wait()
 
+	// Sleeping for a small duration for the current dispatch loop to finish.
+	// We read ts.Now() before the dispatch loop begins and reuse it in the loop.
+	time.Sleep(100 * time.Millisecond) //nolint:forbidigo
+
 	var channelWeights []int
 	for _, channel := range s.scheduler.channels() {
 		channelWeights = append(channelWeights, channel.Weight())
@@ -436,6 +440,10 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestDeleteInactiveChannels
 	s.Equal([]int{5, 5, 5, 3, 5, 3, 2, 5, 3, 2, 1}, channelWeights)
 
 	s.ts.Advance(30 * time.Minute)
+
+	// Sleeping for a small duration for the current event loop to finish.
+	// We read ts.Now() before the loop begins and reuse it in the loop.
+	time.Sleep(100 * time.Millisecond) //nolint:forbidigo
 
 	// Only add tasks to first two channels.
 	taskWG.Add(2)

--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -429,10 +429,6 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestDeleteInactiveChannels
 	s.scheduler.Submit(mockTask3)
 	taskWG.Wait()
 
-	// Sleeping for a small duration for the current dispatch loop to finish.
-	// We read ts.Now() before the dispatch loop begins and reuse it in the loop.
-	time.Sleep(100 * time.Millisecond) //nolint:forbidigo
-
 	var channelWeights []int
 	for _, channel := range s.scheduler.channels() {
 		channelWeights = append(channelWeights, channel.Weight())
@@ -513,6 +509,10 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestInactiveChannelDeletio
 	s.Equal([]int{5, 5, 5, 3, 5, 3, 2, 5, 3, 2, 1}, channelWeights)
 
 	s.ts.Advance(30 * time.Minute)
+
+	// Sleeping for a small duration for the current event loop to finish.
+	// We read ts.Now() before the loop begins and reuse it in the loop.
+	time.Sleep(100 * time.Millisecond) //nolint:forbidigo
 
 	// Only add tasks to first two channels.
 	taskWG.Add(2)

--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -438,7 +438,8 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestDeleteInactiveChannels
 	s.ts.Advance(30 * time.Minute)
 
 	// Sleeping for a small duration for the current event loop to finish.
-	// We read ts.Now() before the loop begins and reuse it in the loop.
+	// doDispatchTasksWithWeight reads the current time before entering the loop. We have to wait for that loop to finish.
+	// Otherwise, the tasks added below will have old lastActiveTime. We don't have any other way to know if the loop has finished.
 	time.Sleep(100 * time.Millisecond) //nolint:forbidigo
 
 	// Only add tasks to first two channels.


### PR DESCRIPTION
## What changed?
Fix TestDeleteInactiveChannels flakiness.
We read the current time before the despatch loop and resue it. Added a small wait in the test for the dispatch loop to finish after advancing the time.
This will make sure that a dispatch loop has finished before next set of tasks are processed. Otherwise dispatch loop might set old lastActive time for channels.

## Why?

## How did you test it?

## Potential risks

## Documentation

## Is hotfix candidate?
No
