### PR TITLE
Disable gotestsum rerun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ TEST_TIMEOUT ?= 20m
 # Number of retries for *-coverage targets.
 # NOTE: This is incompatible with TEST_ARGS which specify the `-run` flag due to how gotestsum selects which tests to
 # retry.
-FAILED_TEST_RETRIES ?= 2
+# *WARNING*: This is disabled for now; see https://github.com/gotestyourself/gotestsum/issues/423
+FAILED_TEST_RETRIES ?= 0
 
 # Whether or not to test with the race detector. All of (1 on y yes t true) are true values.
 TEST_RACE_FLAG ?= on


### PR DESCRIPTION
## What changed?

Disable `gotestsum` re-runs.

## Why?
`gotestsum` has a bug that reports test failures with exit code 0, making the GHA job succeed.

See https://github.com/gotestyourself/gotestsum/issues/423

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Test failure results in GHA job failure.

<img width="611" alt="Screenshot 2024-11-13 at 11 19 27 AM" src="https://github.com/user-attachments/assets/e7c8bd00-845c-4001-9f3c-c960d15097c4">

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
