### PR TITLE
Fix data race in WeightedChannel

### DIFF
--- a/common/tasks/weighted_channel.go
+++ b/common/tasks/weighted_channel.go
@@ -70,7 +70,7 @@ func (c *WeightedChannel[T]) SetWeight(newWeight int) {
 }
 
 func (c *WeightedChannel[T]) LastActiveTime() time.Time {
-	return c.lastActiveTime.Load().(time.Time)
+	return c.lastActiveTime.Load().(time.Time) // nolint:revive
 }
 
 func (c *WeightedChannel[T]) UpdateLastActiveTime(now time.Time) {

--- a/common/tasks/weighted_channel.go
+++ b/common/tasks/weighted_channel.go
@@ -39,7 +39,7 @@ type (
 	WeightedChannel[T Task] struct {
 		weight         int
 		channel        chan T
-		lastActiveTime time.Time
+		lastActiveTime atomic.Value
 		refCount       atomic.Int32
 	}
 )
@@ -49,11 +49,12 @@ func NewWeightedChannel[T Task](
 	size int,
 	now time.Time,
 ) *WeightedChannel[T] {
-	return &WeightedChannel[T]{
-		weight:         weight,
-		channel:        make(chan T, size),
-		lastActiveTime: now,
+	c := &WeightedChannel[T]{
+		weight:  weight,
+		channel: make(chan T, size),
 	}
+	c.UpdateLastActiveTime(now)
+	return c
 }
 
 func (c *WeightedChannel[T]) Chan() chan T {
@@ -69,11 +70,11 @@ func (c *WeightedChannel[T]) SetWeight(newWeight int) {
 }
 
 func (c *WeightedChannel[T]) LastActiveTime() time.Time {
-	return c.lastActiveTime
+	return c.lastActiveTime.Load().(time.Time)
 }
 
 func (c *WeightedChannel[T]) UpdateLastActiveTime(now time.Time) {
-	c.lastActiveTime = now
+	c.lastActiveTime.Store(now)
 }
 
 func (c *WeightedChannel[T]) IncrementRefCount() {

--- a/common/tasks/weighted_channel.go
+++ b/common/tasks/weighted_channel.go
@@ -39,7 +39,7 @@ type (
 	WeightedChannel[T Task] struct {
 		weight         int
 		channel        chan T
-		lastActiveTime atomic.Value
+		lastActiveTime atomic.Value // time.Time
 		refCount       atomic.Int32
 	}
 )


### PR DESCRIPTION
## What changed?
There is a possible data race when last updated time is accessed by the cleanupLoop in InterleavedWeightedRoundRobinScheduler while another goroutine is updating that value. Fix this by making LastActiveTime an atomic variable.

## Why?

## How did you test it?
Unit tests.

## Potential risks

## Documentation

## Is hotfix candidate?
No
