### PR TITLE
Clone payloads in CreateHistoryStartWorkflowRequest to avoid losing payloads on retry

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -529,9 +529,6 @@ func CreateMatchingPollWorkflowTaskQueueResponse(historyResponse *historyservice
 }
 
 // CreateHistoryStartWorkflowRequest create a start workflow request for history.
-// Note: this mutates startRequest by unsetting the fields ContinuedFailure and
-// LastCompletionResult (these should only be set on workflows created by the scheduler
-// worker).
 // Assumes startRequest is valid. See frontend workflow_handler for detailed validation logic.
 func CreateHistoryStartWorkflowRequest(
 	namespaceID string,
@@ -540,6 +537,12 @@ func CreateHistoryStartWorkflowRequest(
 	rootExecutionInfo *workflowspb.RootExecutionInfo,
 	now time.Time,
 ) *historyservice.StartWorkflowExecutionRequest {
+	// We include the original startRequest in the forwarded request to History, but
+	// we don't want to send workflow payloads twice. We deep copy to a new struct,
+	// rather than mutate the request, to accommodate internal retries.
+	if startRequest.ContinuedFailure != nil || startRequest.LastCompletionResult != nil {
+		startRequest = CloneProto(startRequest)
+	}
 	histRequest := &historyservice.StartWorkflowExecutionRequest{
 		NamespaceId:              namespaceID,
 		StartRequest:             startRequest,

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -33,12 +33,15 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"google.golang.org/protobuf/testing/protopack"
 )
@@ -561,4 +564,29 @@ func TestMergeProtoExcludingFields(t *testing.T) {
 
 	require.NotEqual(t, source.WorkflowTaskVersion, target.WorkflowTaskVersion)
 	require.Equal(t, source.WorkflowId, target.WorkflowId)
+}
+
+// Tests that CreateHistoryStartWorkflowRequest doesn't mutate the request
+// parameter when creating a history request with payloads set.
+func TestCreateHistoryStartWorkflowRequestPayloads(t *testing.T) {
+	failurePayload := &failure.Failure{}
+	resultPayload := payloads.EncodeString("result")
+	startRequest := &workflowservice.StartWorkflowExecutionRequest{
+		Namespace:            uuid.New(),
+		WorkflowId:           uuid.New(),
+		ContinuedFailure:     failurePayload,
+		LastCompletionResult: resultPayload,
+	}
+	startRequestClone := CloneProto(startRequest)
+
+	histRequest := CreateHistoryStartWorkflowRequest(startRequest.Namespace, startRequest, nil, nil, time.Now())
+
+	// ensure we aren't copying the payloads into the history request twice
+	require.Equal(t, failurePayload, histRequest.ContinuedFailure)
+	require.Equal(t, resultPayload, histRequest.LastCompletionResult)
+	require.Nil(t, histRequest.StartRequest.ContinuedFailure)
+	require.Nil(t, histRequest.StartRequest.LastCompletionResult)
+
+	// ensure the original request object is unmodified
+	require.Equal(t, startRequestClone, startRequest)
 }


### PR DESCRIPTION
## What changed?
- `CreateHistoryStartWorkflowRequest` will now deep copy the `request` structure when `LastCompletionResult` or `ContinuedFailure` are set. 

## Why?
To avoid sending those payloads twice, `CreateHistoryStartWorkflowRequest` unsets those fields on the internal forwarded request struct. This is done by directly mutating the `request` parameter. When the workflow handler calls into `CreateHistoryStartWorkflowRequest` and fails, the internal retry handler will retry the request, but the fields have already been unset on the reused `request` object. Subsequent retries from the internal handler will therefore be missing these fields without additional consideration. 

## How did you test it?
- New test

## Potential risks
- A minimal performance difference because of the deep copy.

## Documentation
- No 

## Is hotfix candidate?
- No

