### PR TITLE
Fix sqlite connection closed issue

### DIFF
--- a/common/persistence/sql/sqlplugin/sqlite/driver.go
+++ b/common/persistence/sql/sqlplugin/sqlite/driver.go
@@ -43,8 +43,9 @@ const (
 	sqlTableExistsPattern = "SQL logic error: table .* already exists \\(1\\)"
 )
 
-// Driver implements a sql driver that return a custom connection which implements ResetSession() and IsValid().
-// In which case sql library will not close the connection when a transaction context times out.
+// Driver implements a SQL driver that returns a custom connection.
+// The custom connection provides ResetSession() and IsValid() methods,
+// preventing the SQL library from closing the connection when a transaction context is canceled.
 type Driver struct {
 	sqlite.Driver
 }

--- a/common/persistence/sql/sqlplugin/sqlite/driver.go
+++ b/common/persistence/sql/sqlplugin/sqlite/driver.go
@@ -46,6 +46,7 @@ const (
 // Driver implements a SQL driver that returns a custom connection.
 // The custom connection provides ResetSession() and IsValid() methods,
 // preventing the SQL library from closing the connection when a transaction context is canceled.
+// TODO prathyushpv: Remove this if connection in modernc.org/sqlite implement ResetSession() and IsValid() methods.
 type Driver struct {
 	sqlite.Driver
 }
@@ -66,7 +67,9 @@ type conn struct {
 	driver.Conn
 }
 
-// ResetSession does nothing.
+// ResetSession does nothing. If the connection is not valid for some reason, we must have lost the database already.
+// And there is nothing we can do to create a new connection. Because of this it is safe to return valid in all cases.
+// We can let the next database operation fail if connection is not valid.
 func (c *conn) ResetSession(ctx context.Context) error {
 	return nil
 }

--- a/common/persistence/sql/sqlplugin/sqlite/driver.go
+++ b/common/persistence/sql/sqlplugin/sqlite/driver.go
@@ -59,7 +59,10 @@ func newDriver() driver.Driver {
 
 func (d *Driver) Open(name string) (driver.Conn, error) {
 	c, err := d.Driver.Open(name)
-	return &conn{c}, err
+	if err != nil {
+		return nil, err
+	}
+	return &conn{c}, nil
 }
 
 // ResetSession does nothing.

--- a/common/persistence/sql/sqlplugin/sqlite/driver.go
+++ b/common/persistence/sql/sqlplugin/sqlite/driver.go
@@ -49,10 +49,6 @@ type Driver struct {
 	sqlite.Driver
 }
 
-type conn struct {
-	driver.Conn
-}
-
 func newDriver() driver.Driver {
 	return &Driver{sqlite.Driver{}}
 }
@@ -63,6 +59,10 @@ func (d *Driver) Open(name string) (driver.Conn, error) {
 		return nil, err
 	}
 	return &conn{c}, nil
+}
+
+type conn struct {
+	driver.Conn
 }
 
 // ResetSession does nothing.

--- a/common/persistence/sql/sqlplugin/sqlite/driver.go
+++ b/common/persistence/sql/sqlplugin/sqlite/driver.go
@@ -43,8 +43,8 @@ const (
 	sqlTableExistsPattern = "SQL logic error: table .* already exists \\(1\\)"
 )
 
-// Driver implements a sql driver that return a custom connection conn. conn implements ResetSession() and IsValid()
-// so that the sql library does not close the connection when a transaction context times out.
+// Driver implements a sql driver that return a custom connection which implements ResetSession() and IsValid().
+// In which case sql library will not close the connection when a transaction context times out.
 type Driver struct {
 	sqlite.Driver
 }

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -26,11 +26,10 @@ package tests
 
 import (
 	"context"
+	gosql "database/sql"
 	"os"
 	"path"
 	"testing"
-
-	gosql "database/sql"
 
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -25,9 +25,12 @@
 package tests
 
 import (
+	"context"
 	"os"
 	"path"
 	"testing"
+
+	gosql "database/sql"
 
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
@@ -1110,4 +1113,40 @@ func TestSQLiteNexusEndpointPersistence(t *testing.T) {
 		assert.NoError(t, os.Remove(cfg.DatabaseName))
 	})
 	RunNexusEndpointTestSuiteForSQL(t, factory)
+}
+
+// Go sql library will close the connection when a context is cancelled during a transaction. Since we only have one
+// connection to the sqlite database, we will lose the db in this case. We fixed this by extending the driver in
+// modernc.org/sqlite. This test verifies that fix.
+func TestSQLiteTransactionContextCancellation(t *testing.T) {
+	cfg := NewSQLiteMemoryConfig()
+	db, err := sql.NewSQLDB(sqlplugin.DbKindVisibility, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+	if err != nil {
+		t.Fatalf("unable to create SQLite DB: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tx, err := db.BeginTx(ctx)
+	assert.NoError(t, err)
+	_, err = tx.InsertIntoTaskQueues(ctx, &sqlplugin.TaskQueuesRow{
+		RangeHash:   0,
+		TaskQueueID: []byte("test-queue"),
+		RangeID:     0,
+		Data:        []byte("test-data"),
+	})
+	assert.NoError(t, err)
+
+	// Cancel the context before the transaction has finished.
+	cancel()
+
+	err = tx.Commit()
+	assert.ErrorAs(t, err, &context.Canceled)
+
+	// Check if we still have a connection to the db.
+	_, err = db.LockTaskQueues(context.Background(), sqlplugin.TaskQueuesFilter{
+		RangeHash:   0,
+		TaskQueueID: []byte("test-queue"),
+	})
+	assert.NotContains(t, err.Error(), "no such table")
+	assert.ErrorAs(t, err, &gosql.ErrNoRows)
 }


### PR DESCRIPTION
## What changed?
Use an sqlite connection that has ResetSession() and IsValid() implemented.

## Why?
If these methods are not implemented, sql library will close the connection when the context is cancelled during a transaction. We will lose the database if this happens.
IsValid() will always return true in this case. We should always have a valid database connection, otherwise we would have already lost the database. Similarly ResetSession() does nothing.

## How did you test it?
Tried to reproduce the issue by cancelling a transaction context.

## Potential risks
None

## Documentation

## Is hotfix candidate?
No
