### PR TITLE
Fix task state change for state based replication

### DIFF
--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -243,8 +243,7 @@ func (t *timerQueueActiveTaskExecutor) executeActivityTimeoutTask(
 	isHeartBeatTask := task.TimeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT
 	activityInfo, heartbeatTimeoutVis, ok := mutableState.GetActivityInfoWithTimerHeartbeat(task.EventID)
 	if isHeartBeatTask && ok && queues.IsTimeExpired(task.GetVisibilityTime(), heartbeatTimeoutVis) {
-		activityInfo.TimerTaskStatus = activityInfo.TimerTaskStatus &^ workflow.TimerTaskStatusCreatedHeartbeat
-		if err := mutableState.UpdateActivity(activityInfo); err != nil {
+		if err := mutableState.UpdateActivityTimerTaskStatus(activityInfo.ScheduledEventId, activityInfo.TimerTaskStatus&^workflow.TimerTaskStatusCreatedHeartbeat); err != nil {
 			return err
 		}
 		updateMutableState = true

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -245,8 +245,7 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityTimeoutTask(
 		isHeartBeatTask := timerTask.TimeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT
 		activityInfo, heartbeatTimeoutVis, ok := mutableState.GetActivityInfoWithTimerHeartbeat(timerTask.EventID)
 		if isHeartBeatTask && ok && queues.IsTimeExpired(timerTask.GetVisibilityTime(), heartbeatTimeoutVis) {
-			activityInfo.TimerTaskStatus = activityInfo.TimerTaskStatus &^ workflow.TimerTaskStatusCreatedHeartbeat
-			if err := mutableState.UpdateActivity(activityInfo); err != nil {
+			if err := mutableState.UpdateActivityTimerTaskStatus(activityInfo.ScheduledEventId, activityInfo.TimerTaskStatus&^workflow.TimerTaskStatusCreatedHeartbeat); err != nil {
 				return nil, err
 			}
 			updateMutableState = true

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -362,8 +362,10 @@ type (
 		)
 		UpdateActivity(*persistencespb.ActivityInfo) error
 		UpdateActivityWithTimerHeartbeat(*persistencespb.ActivityInfo, time.Time) error
+		UpdateActivityTimerTaskStatus(activityId int64, status int32) error
 		UpdateActivityProgress(ai *persistencespb.ActivityInfo, request *workflowservice.RecordActivityTaskHeartbeatRequest)
 		UpdateUserTimer(*persistencespb.TimerInfo) error
+		UpdateUserTimerTaskStatus(timerId string, status int64) error
 		UpdateCurrentVersion(version int64, forceUpdate bool) error
 		UpdateWorkflowStateStatus(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) error
 		UpdateBuildIdAssignment(buildId string) error

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -299,7 +299,7 @@ func NewMutableState(
 		workflowTaskUpdated:                false,
 		updateInfoUpdated:                  make(map[string]struct{}),
 		updateTimerInfosUserDataUpdated:    make(map[string]struct{}),
-		updateActivityInfosUserDataUpdated: map[int64]struct{}{},
+		updateActivityInfosUserDataUpdated: make(map[int64]struct{}),
 
 		QueryRegistry: NewQueryRegistry(),
 

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -3739,11 +3739,11 @@ func (s *mutableStateSuite) TestApplySnapshot() {
 	// set updateXXX so LastUpdateVersionedTransition will be updated
 	targetMS.updateActivityInfos = targetMS.pendingActivityInfoIDs
 	for key := range targetMS.updateActivityInfos {
-		targetMS.updateActivityInfosUserDataUpdated[key] = struct{}{}
+		targetMS.activityInfosUserDataUpdated[key] = struct{}{}
 	}
 	targetMS.updateTimerInfos = targetMS.pendingTimerInfoIDs
 	for key := range targetMS.updateTimerInfos {
-		targetMS.updateTimerInfosUserDataUpdated[key] = struct{}{}
+		targetMS.timerInfosUserDataUpdated[key] = struct{}{}
 	}
 	targetMS.updateChildExecutionInfos = targetMS.pendingChildExecutionInfoIDs
 	targetMS.updateRequestCancelInfos = targetMS.pendingRequestCancelInfoIDs
@@ -3811,11 +3811,11 @@ func (s *mutableStateSuite) TestApplyMutation() {
 	// set updateXXX so LastUpdateVersionedTransition will be updated
 	targetMS.updateActivityInfos = targetMS.pendingActivityInfoIDs
 	for key := range targetMS.updateActivityInfos {
-		targetMS.updateActivityInfosUserDataUpdated[key] = struct{}{}
+		targetMS.activityInfosUserDataUpdated[key] = struct{}{}
 	}
 	targetMS.updateTimerInfos = targetMS.pendingTimerInfoIDs
 	for key := range targetMS.updateTimerInfos {
-		targetMS.updateTimerInfosUserDataUpdated[key] = struct{}{}
+		targetMS.timerInfosUserDataUpdated[key] = struct{}{}
 	}
 	targetMS.updateChildExecutionInfos = targetMS.pendingChildExecutionInfoIDs
 	targetMS.updateRequestCancelInfos = targetMS.pendingRequestCancelInfoIDs

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -3738,7 +3738,13 @@ func (s *mutableStateSuite) TestApplySnapshot() {
 
 	// set updateXXX so LastUpdateVersionedTransition will be updated
 	targetMS.updateActivityInfos = targetMS.pendingActivityInfoIDs
+	for key := range targetMS.updateActivityInfos {
+		targetMS.updateActivityInfosUserDataUpdated[key] = struct{}{}
+	}
 	targetMS.updateTimerInfos = targetMS.pendingTimerInfoIDs
+	for key := range targetMS.updateTimerInfos {
+		targetMS.updateTimerInfosUserDataUpdated[key] = struct{}{}
+	}
 	targetMS.updateChildExecutionInfos = targetMS.pendingChildExecutionInfoIDs
 	targetMS.updateRequestCancelInfos = targetMS.pendingRequestCancelInfoIDs
 	targetMS.updateSignalInfos = targetMS.pendingSignalInfoIDs
@@ -3804,7 +3810,13 @@ func (s *mutableStateSuite) TestApplyMutation() {
 
 	// set updateXXX so LastUpdateVersionedTransition will be updated
 	targetMS.updateActivityInfos = targetMS.pendingActivityInfoIDs
+	for key := range targetMS.updateActivityInfos {
+		targetMS.updateActivityInfosUserDataUpdated[key] = struct{}{}
+	}
 	targetMS.updateTimerInfos = targetMS.pendingTimerInfoIDs
+	for key := range targetMS.updateTimerInfos {
+		targetMS.updateTimerInfosUserDataUpdated[key] = struct{}{}
+	}
 	targetMS.updateChildExecutionInfos = targetMS.pendingChildExecutionInfoIDs
 	targetMS.updateRequestCancelInfos = targetMS.pendingRequestCancelInfoIDs
 	targetMS.updateSignalInfos = targetMS.pendingSignalInfoIDs

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -3107,6 +3107,20 @@ func (mr *MockMutableStateMockRecorder) UpdateActivityProgress(ai, request any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActivityProgress", reflect.TypeOf((*MockMutableState)(nil).UpdateActivityProgress), ai, request)
 }
 
+// UpdateActivityTimerTaskStatus mocks base method.
+func (m *MockMutableState) UpdateActivityTimerTaskStatus(activityId int64, status int32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateActivityTimerTaskStatus", activityId, status)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateActivityTimerTaskStatus indicates an expected call of UpdateActivityTimerTaskStatus.
+func (mr *MockMutableStateMockRecorder) UpdateActivityTimerTaskStatus(activityId, status any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActivityTimerTaskStatus", reflect.TypeOf((*MockMutableState)(nil).UpdateActivityTimerTaskStatus), activityId, status)
+}
+
 // UpdateActivityWithTimerHeartbeat mocks base method.
 func (m *MockMutableState) UpdateActivityWithTimerHeartbeat(arg0 *persistence.ActivityInfo, arg1 time.Time) error {
 	m.ctrl.T.Helper()
@@ -3185,6 +3199,20 @@ func (m *MockMutableState) UpdateUserTimer(arg0 *persistence.TimerInfo) error {
 func (mr *MockMutableStateMockRecorder) UpdateUserTimer(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserTimer", reflect.TypeOf((*MockMutableState)(nil).UpdateUserTimer), arg0)
+}
+
+// UpdateUserTimerTaskStatus mocks base method.
+func (m *MockMutableState) UpdateUserTimerTaskStatus(timerId string, status int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUserTimerTaskStatus", timerId, status)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateUserTimerTaskStatus indicates an expected call of UpdateUserTimerTaskStatus.
+func (mr *MockMutableStateMockRecorder) UpdateUserTimerTaskStatus(timerId, status any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserTimerTaskStatus", reflect.TypeOf((*MockMutableState)(nil).UpdateUserTimerTaskStatus), timerId, status)
 }
 
 // UpdateWorkflowStateStatus mocks base method.

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -389,12 +389,11 @@ func (r *TaskRefresherImpl) refreshTasksForActivity(
 		}
 
 		if CompareVersionedTransition(minVersionedTransition, EmptyVersionedTransition) == 0 { // Full refresh
-			// clear activity timer task mask for later activity timer task re-generation
-			activityInfo.TimerTaskStatus = TimerTaskStatusNone
 
 			// need to update activity timer task mask for which task is generated
-			if err := mutableState.UpdateActivity(
-				activityInfo,
+			if err := mutableState.UpdateActivityTimerTaskStatus(
+				activityInfo.ScheduledEventId,
+				TimerTaskStatusNone, // clear activity timer task mask for later activity timer task re-generation
 			); err != nil {
 				return err
 			}
@@ -449,13 +448,12 @@ func (r *TaskRefresherImpl) refreshTasksForTimer(
 			continue
 		}
 
-		// clear timer task mask for later timer task re-generation
 		refreshUserTimerTask = true
 
 		// need to update user timer task mask for which task is generated
 		if err := mutableState.UpdateUserTimerTaskStatus(
 			timerInfo.TimerId,
-			TimerTaskStatusNone,
+			TimerTaskStatusNone, // clear timer task mask for later timer task re-generation
 		); err != nil {
 			return err
 		}

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -450,12 +450,12 @@ func (r *TaskRefresherImpl) refreshTasksForTimer(
 		}
 
 		// clear timer task mask for later timer task re-generation
-		timerInfo.TaskStatus = TimerTaskStatusNone
 		refreshUserTimerTask = true
 
 		// need to update user timer task mask for which task is generated
-		if err := mutableState.UpdateUserTimer(
-			timerInfo,
+		if err := mutableState.UpdateUserTimerTaskStatus(
+			timerInfo.TimerId,
+			TimerTaskStatusNone,
 		); err != nil {
 			return err
 		}

--- a/service/history/workflow/timer_sequence.go
+++ b/service/history/workflow/timer_sequence.go
@@ -116,9 +116,9 @@ func (t *timerSequenceImpl) CreateNextUserTimer() (bool, error) {
 	}
 	// mark timer task mask as indication that timer task is generated
 	// here TaskID is misleading attr, should be called timer created flag or something
-	timerInfo.TaskStatus = TimerTaskStatusCreated
-	if err := t.mutableState.UpdateUserTimer(timerInfo); err != nil {
+	if err := t.mutableState.UpdateUserTimerTaskStatus(timerInfo.TimerId, TimerTaskStatusCreated); err != nil {
 		return false, err
+
 	}
 	t.mutableState.AddTasks(&tasks.UserTimerTask{
 		// TaskID is set by shard
@@ -160,7 +160,7 @@ func (t *timerSequenceImpl) CreateNextActivityTimer() (bool, error) {
 	if firstTimerTask.TimerType == enumspb.TIMEOUT_TYPE_HEARTBEAT {
 		err = t.mutableState.UpdateActivityWithTimerHeartbeat(activityInfo, firstTimerTask.Timestamp)
 	} else {
-		err = t.mutableState.UpdateActivity(activityInfo)
+		err = t.mutableState.UpdateActivityTimerTaskStatus(activityInfo.ScheduledEventId, activityInfo.TimerTaskStatus)
 	}
 
 	if err != nil {

--- a/service/history/workflow/timer_sequence_test.go
+++ b/service/history/workflow/timer_sequence_test.go
@@ -190,7 +190,7 @@ func (s *timerSequenceSuite) TestCreateNextUserTimer_NotCreated_BeforeWorkflowEx
 
 	var timerInfoUpdated = common.CloneProto(timerInfo) // make a copy
 	timerInfoUpdated.TaskStatus = TimerTaskStatusCreated
-	s.mockMutableState.EXPECT().UpdateUserTimer(protomock.Eq(timerInfoUpdated)).Return(nil)
+	s.mockMutableState.EXPECT().UpdateUserTimerTaskStatus(timerInfoUpdated.TimerId, timerInfoUpdated.TaskStatus).Return(nil)
 	s.mockMutableState.EXPECT().AddTasks(&tasks.UserTimerTask{
 		// TaskID is set by shard
 		WorkflowKey:         s.workflowKey,
@@ -222,7 +222,7 @@ func (s *timerSequenceSuite) TestCreateNextUserTimer_NotCreated_NoWorkflowExpiry
 
 	var timerInfoUpdated = common.CloneProto(timerInfo) // make a copy
 	timerInfoUpdated.TaskStatus = TimerTaskStatusCreated
-	s.mockMutableState.EXPECT().UpdateUserTimer(protomock.Eq(timerInfoUpdated)).Return(nil)
+	s.mockMutableState.EXPECT().UpdateUserTimerTaskStatus(timerInfoUpdated.TimerId, timerInfoUpdated.TaskStatus).Return(nil)
 	s.mockMutableState.EXPECT().AddTasks(&tasks.UserTimerTask{
 		// TaskID is set by shard
 		WorkflowKey:         s.workflowKey,
@@ -375,7 +375,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_NotCreated_BeforeWorkfl
 
 	var activityInfoUpdated = common.CloneProto(activityInfo) // make a copy
 	activityInfoUpdated.TimerTaskStatus = TimerTaskStatusCreatedScheduleToStart
-	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated)).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivityTimerTaskStatus(activityInfoUpdated.ScheduledEventId, activityInfoUpdated.TimerTaskStatus).Return(nil)
 	s.mockMutableState.EXPECT().AddTasks(&tasks.ActivityTimeoutTask{
 		// TaskID is set by shard
 		WorkflowKey:         s.workflowKey,
@@ -417,7 +417,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_NotCreated_NoWorkflowEx
 
 	var activityInfoUpdated = common.CloneProto(activityInfo) // make a copy
 	activityInfoUpdated.TimerTaskStatus = TimerTaskStatusCreatedScheduleToStart
-	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated)).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivityTimerTaskStatus(activityInfoUpdated.ScheduledEventId, activityInfoUpdated.TimerTaskStatus).Return(nil)
 	s.mockMutableState.EXPECT().AddTasks(&tasks.ActivityTimeoutTask{
 		// TaskID is set by shard
 		WorkflowKey:         s.workflowKey,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add new api for updating timer task status
## Why?
<!-- Tell your future self why have you made these changes -->
We need to distinguish the user data update and timer task status update because we don't need to update state transition when the change is task status update change. 
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
n/a
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
no