### PR TITLE
Fix flaky TestUpdateWorkflow_TerminateWorkflowAfterUpdateAdmitted

### DIFF
--- a/tests/update_workflow_sdk_test.go
+++ b/tests/update_workflow_sdk_test.go
@@ -74,9 +74,9 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateWorkflow_TerminateWorkflowAfterUpdate
 	run := s.startWorkflow(ctx, tv, workflowFn)
 	s.updateWorkflowWaitAdmitted(ctx, tv, "update-arg")
 
-	s.Worker().RegisterWorkflow(workflowFn)
-
 	s.NoError(s.SdkClient().TerminateWorkflow(ctx, tv.WorkflowID(), run.GetRunID(), "reason"))
+
+	s.Worker().RegisterWorkflow(workflowFn)
 
 	_, err := s.pollUpdate(ctx, tv, &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED})
 	var notFound *serviceerror.NotFound


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Changed test execution order: terminate first, process Update later.

## Why?
<!-- Tell your future self why have you made these changes -->

Test `TestUpdateWorkflow_TerminateWorkflowAfterUpdateAdmitted` is flaky: 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
