### PR TITLE
Print actual events in HistoryRequire helper

### DIFF
--- a/common/testing/historyrequire/history_require.go
+++ b/common/testing/historyrequire/history_require.go
@@ -76,7 +76,9 @@ func (h HistoryRequire) EqualHistoryEvents(expectedHistory string, actualHistory
 
 	expectedHistoryEvents, expectedEventsAttributes := h.parseHistory(expectedHistory)
 
-	require.Equalf(h.t, len(expectedHistoryEvents), len(actualHistoryEvents), "Length of expected(%d) and actual(%d) histories is not equal", len(expectedHistoryEvents), len(actualHistoryEvents))
+	require.Equalf(h.t, len(expectedHistoryEvents), len(actualHistoryEvents),
+		"Length of expected(%d) and actual(%d) histories is not equal - actual history: \n%v",
+		len(expectedHistoryEvents), len(actualHistoryEvents), h.formatHistoryEvents(actualHistoryEvents, true))
 
 	h.equalHistoryEvents(expectedHistoryEvents, expectedEventsAttributes, actualHistoryEvents)
 }
@@ -88,7 +90,9 @@ func (h HistoryRequire) EqualHistoryEventsSuffix(expectedHistorySuffix string, a
 
 	expectedHistoryEvents, expectedEventsAttributes := h.parseHistory(expectedHistorySuffix)
 
-	require.GreaterOrEqualf(h.t, len(actualHistoryEvents), len(expectedHistoryEvents), "Length of actual history(%d) must be greater or equal to the length of expected history suffix(%d)", len(actualHistoryEvents), len(expectedHistoryEvents))
+	require.GreaterOrEqualf(h.t, len(actualHistoryEvents), len(expectedHistoryEvents),
+		"Length of actual history(%d) must be greater or equal to the length of expected history suffix(%d) - actual history: \n%v",
+		len(actualHistoryEvents), len(expectedHistoryEvents), h.formatHistoryEvents(actualHistoryEvents, true))
 
 	h.equalHistoryEvents(expectedHistoryEvents, expectedEventsAttributes, actualHistoryEvents[len(actualHistoryEvents)-len(expectedHistoryEvents):])
 }
@@ -100,7 +104,9 @@ func (h HistoryRequire) EqualHistoryEventsPrefix(expectedHistoryPrefix string, a
 
 	expectedHistoryEvents, expectedEventsAttributes := h.parseHistory(expectedHistoryPrefix)
 
-	require.GreaterOrEqualf(h.t, len(actualHistoryEvents), len(expectedHistoryEvents), "Length of actual history(%d) must be greater or equal to the length of expected history prefix(%d)", len(actualHistoryEvents), len(expectedHistoryEvents))
+	require.GreaterOrEqualf(h.t, len(actualHistoryEvents), len(expectedHistoryEvents),
+		"Length of actual history(%d) must be greater or equal to the length of expected history prefix(%d) - actual history: \n%v",
+		len(actualHistoryEvents), len(expectedHistoryEvents), h.formatHistoryEvents(actualHistoryEvents, true))
 
 	h.equalHistoryEvents(expectedHistoryEvents, expectedEventsAttributes, actualHistoryEvents[:len(expectedHistoryEvents)])
 }
@@ -114,7 +120,9 @@ func (h HistoryRequire) ContainsHistoryEvents(expectedHistorySegment string, act
 
 	expectedHistoryEvents, expectedEventsAttributes := h.parseHistory(expectedHistorySegment)
 
-	require.GreaterOrEqualf(h.t, len(actualHistoryEvents), len(expectedHistoryEvents), "Length of actual history(%d) must be greater or equal to the length of expected history segment(%d)", len(actualHistoryEvents), len(expectedHistoryEvents))
+	require.GreaterOrEqualf(h.t, len(actualHistoryEvents), len(expectedHistoryEvents),
+		"Length of actual history(%d) must be greater or equal to the length of expected history segment(%d) - actual history: \n%v",
+		len(actualHistoryEvents), len(expectedHistoryEvents), h.formatHistoryEvents(actualHistoryEvents, true))
 
 	h.containsHistoryEvents(expectedHistoryEvents, expectedEventsAttributes, actualHistoryEvents)
 }
@@ -129,7 +137,9 @@ func (h HistoryRequire) WaitForHistoryEvents(expectedHistory string, actualHisto
 	var actualHistoryEvents []*historypb.HistoryEvent
 	require.EventuallyWithT(h.t, func(collect *assert.CollectT) {
 		actualHistoryEvents = actualHistoryEventsReader()
-		assert.Equalf(collect, len(expectedHistoryEvents), len(actualHistoryEvents), "Length of expected(%d) and actual(%d) histories is not equal", len(expectedHistoryEvents), len(actualHistoryEvents))
+		assert.Equalf(collect, len(expectedHistoryEvents), len(actualHistoryEvents),
+			"Length of expected(%d) and actual(%d) histories is not equal - actual history: \n%v",
+			len(expectedHistoryEvents), len(actualHistoryEvents), h.formatHistoryEvents(actualHistoryEvents, true))
 	}, waitFor, tick)
 
 	h.equalHistoryEvents(expectedHistoryEvents, expectedEventsAttributes, actualHistoryEvents)
@@ -148,7 +158,9 @@ func (h HistoryRequire) WaitForHistoryEventsSuffix(expectedHistorySuffix string,
 	require.EventuallyWithT(h.t, func(collect *assert.CollectT) {
 		actualHistoryEvents = actualHistoryEventsReader()
 
-		assert.GreaterOrEqualf(collect, len(actualHistoryEvents), len(expectedHistoryEvents), "Length of actual history(%d) must be greater or equal to the length of expected history suffix(%d)", len(actualHistoryEvents), len(expectedHistoryEvents))
+		assert.GreaterOrEqualf(collect, len(actualHistoryEvents), len(expectedHistoryEvents),
+			"Length of actual history(%d) must be greater or equal to the length of expected history suffix(%d) - actual history: \n%v",
+			len(actualHistoryEvents), len(expectedHistoryEvents), h.formatHistoryEvents(actualHistoryEvents, true))
 		if len(actualHistoryEvents) < len(expectedHistoryEvents) {
 			return
 		}
@@ -157,7 +169,9 @@ func (h HistoryRequire) WaitForHistoryEventsSuffix(expectedHistorySuffix string,
 		actualHistoryEvents = h.sanitizeActualHistoryEventsForEquals(expectedHistoryEvents, actualHistoryEvents)
 		actualCompactHistory := h.formatHistoryEvents(actualHistoryEvents, true)
 
-		assert.Equalf(collect, actualCompactHistory, expectedCompactHistory, "Expected history suffix is not found in actual history. Expected suffix:\n%s\nLast actual:\n%s", expectedCompactHistory, actualCompactHistory)
+		assert.Equalf(collect, actualCompactHistory, expectedCompactHistory,
+			"Expected history suffix is not found in actual history. Expected suffix:\n%s\nLast actual:\n%s",
+			expectedCompactHistory, actualCompactHistory)
 	}, waitFor, tick)
 
 	// TODO: Now if expected sequence of events is found, all attributes must match.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Before

```
Error:      	Not equal: 
        	            	expected: 4
        	            	actual  : 5
        	Test:       	TestResetWorkflowTestSuite/TestResetWorkflowAfterTimeout
        	Messages:   	Length of expected(4) and actual(5) histories is not equal
```

After

```
Error:      	Not equal: 
        	            	expected: 4
        	            	actual  : 5
        	Test:       	TestResetWorkflowTestSuite/TestResetWorkflowAfterTimeout
        	Messages:   	Length of expected(4) and actual(5) histories is not equal: 
        	            	  1 WorkflowExecutionStarted
        	            	  2 WorkflowTaskScheduled
        	            	  3 WorkflowTaskStarted
        	            	  4 WorkflowTaskCompleted
        	            	  5 WorkflowExecutionCompleted
```

## Why?
<!-- Tell your future self why have you made these changes -->

Help understand why the length was different; without firing up a debugger.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
