### PR TITLE
Support for Activity tasks in TaskPoller

### DIFF
--- a/common/testing/taskpoller/taskpoller.go
+++ b/common/testing/taskpoller/taskpoller.go
@@ -35,6 +35,7 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/testing/testvars"
@@ -47,18 +48,39 @@ type (
 		namespace string
 	}
 	Options struct {
-		tv                  *testvars.TestVars
-		timeout             time.Duration
-		pollStickyTaskQueue bool
+		tv                      *testvars.TestVars
+		timeout                 time.Duration
+		pollActivityTaskRequest *workflowservice.PollActivityTaskQueueRequest
+		pollworkflowTaskRequest *workflowservice.PollWorkflowTaskQueueRequest
 	}
 	// OptionFunc is a function to change an Options instance
 	OptionFunc func(*Options)
 )
 
 var (
-	// DrainWorkflowTask returns an empty RespondWorkflowTaskCompletedRequest response
+	// DrainWorkflowTask returns an empty RespondWorkflowTaskCompletedRequest
 	DrainWorkflowTask = func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
 		return &workflowservice.RespondWorkflowTaskCompletedRequest{}, nil
+	}
+	// CompleteActivityTask returns a RespondActivityTaskCompletedRequest with an auto-generated `Result` from `tv.Any().Payloads()`.
+	CompleteActivityTask = func(tv *testvars.TestVars) func(task *workflowservice.PollActivityTaskQueueResponse) (*workflowservice.RespondActivityTaskCompletedRequest, error) {
+		return func(task *workflowservice.PollActivityTaskQueueResponse) (*workflowservice.RespondActivityTaskCompletedRequest, error) {
+			return &workflowservice.RespondActivityTaskCompletedRequest{
+				Result: tv.Any().Payloads(),
+			}, nil
+		}
+	}
+	// WithActivityTaskPollRequest defines the PollActivityTaskQueueRequest to use for polling
+	WithActivityTaskPollRequest = func(req *workflowservice.PollActivityTaskQueueRequest) OptionFunc {
+		return func(o *Options) {
+			o.pollActivityTaskRequest = req
+		}
+	}
+	// WithWorkflowTaskPollRequest defines the PollWorkflowTaskQueueRequest to use for polling
+	WithWorkflowTaskPollRequest = func(req *workflowservice.PollWorkflowTaskQueueRequest) OptionFunc {
+		return func(o *Options) {
+			o.pollworkflowTaskRequest = req
+		}
 	}
 	// WithTimeout defines a timeout for a task poller method (includes *all* RPC calls it has to make)
 	WithTimeout = func(timeout time.Duration) OptionFunc {
@@ -66,10 +88,7 @@ var (
 			o.timeout = timeout
 		}
 	}
-	// WithPollSticky will make the poller use the sticky task queue instead of the normal task queue
-	WithPollSticky OptionFunc = func(o *Options) {
-		o.pollStickyTaskQueue = true
-	}
+	NoTaskAvailable = errors.New("no task available")
 )
 
 func New(
@@ -84,20 +103,9 @@ func New(
 	}
 }
 
-// PollWorkflowTask issues PollWorkflowTaskQueueRequests to obtain a new workflow task.
-func (p *TaskPoller) PollWorkflowTask(
-	tv *testvars.TestVars,
-	funcs ...OptionFunc,
-) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
-	p.t.Helper()
-	options := newOptions(tv, funcs)
-	ctx, cancel := newContext(options)
-	defer cancel()
-	return p.pollWorkflowTask(ctx, options)
-}
-
-// PollAndHandleWorkflowTask issues PollWorkflowTaskQueueRequests to obtain a new workflow task,
+// PollAndHandleWorkflowTask issues a PollWorkflowTaskQueueRequest to obtain a new workflow task,
 // invokes the handler with the task, and completes/fails the task accordingly.
+// If no task is available, it returns NoTaskAvailable.
 func (p *TaskPoller) PollAndHandleWorkflowTask(
 	tv *testvars.TestVars,
 	handler func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error),
@@ -125,29 +133,59 @@ func (p *TaskPoller) HandleWorkflowTask(
 	return p.handleWorkflowTask(ctx, options, task, handler)
 }
 
+// PollAndHandleActivityTask issues a PollActivityTaskQueueRequest to obtain a new activity task,
+// invokes the handler with the task, and completes/fails the task accordingly.
+// If no task is available, it returns NoTaskAvailable.
+func (p *TaskPoller) PollAndHandleActivityTask(
+	tv *testvars.TestVars,
+	handler func(task *workflowservice.PollActivityTaskQueueResponse) (*workflowservice.RespondActivityTaskCompletedRequest, error),
+	funcs ...OptionFunc,
+) (*workflowservice.RespondActivityTaskCompletedResponse, error) {
+	p.t.Helper()
+	options := newOptions(tv, funcs)
+	ctx, cancel := newContext(options)
+	defer cancel()
+	return p.pollAndHandleActivityTask(ctx, options, handler)
+}
+
+// HandleActivityTask invokes the provided handler with the provided task,
+// and completes/fails the task accordingly.
+func (p *TaskPoller) HandleActivityTask(
+	tv *testvars.TestVars,
+	task *workflowservice.PollActivityTaskQueueResponse,
+	handler func(task *workflowservice.PollActivityTaskQueueResponse) (*workflowservice.RespondActivityTaskCompletedRequest, error),
+	funcs ...OptionFunc,
+) (*workflowservice.RespondActivityTaskCompletedResponse, error) {
+	p.t.Helper()
+	options := newOptions(tv, funcs)
+	ctx, cancel := newContext(options)
+	defer cancel()
+	return p.handleActivityTask(ctx, options, task, handler)
+}
+
 //revive:disable-next-line:cognitive-complexity
 func (p *TaskPoller) pollWorkflowTask(
 	ctx context.Context,
 	opts *Options,
 ) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
 	p.t.Helper()
-	taskQueue := opts.tv.TaskQueue()
-	if opts.pollStickyTaskQueue {
-		taskQueue = opts.tv.StickyTaskQueue()
-	}
 
-	resp, err := p.client.PollWorkflowTaskQueue(
-		ctx,
-		&workflowservice.PollWorkflowTaskQueueRequest{
-			Namespace: p.namespace,
-			TaskQueue: taskQueue,
-			Identity:  opts.tv.WorkerIdentity(),
-		})
+	req := common.CloneProto(opts.pollworkflowTaskRequest)
+	if req.Namespace == "" {
+		req.Namespace = p.namespace
+	}
+	if req.TaskQueue == nil {
+		req.TaskQueue = opts.tv.TaskQueue()
+	}
+	if req.Identity == "" {
+		req.Identity = opts.tv.WorkerIdentity()
+	}
+	resp, err := p.client.PollWorkflowTaskQueue(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	if resp == nil || len(resp.TaskToken) == 0 {
-		return nil, errors.New("no task available")
+		return nil, NoTaskAvailable
 	}
 
 	var events []*historypb.HistoryEvent
@@ -256,12 +294,116 @@ func (p *TaskPoller) respondWorkflowTaskFailed(
 	return err
 }
 
+func (p *TaskPoller) pollActivityTask(
+	ctx context.Context,
+	opts *Options,
+) (*workflowservice.PollActivityTaskQueueResponse, error) {
+	p.t.Helper()
+
+	req := common.CloneProto(opts.pollActivityTaskRequest)
+	if req.Namespace == "" {
+		req.Namespace = p.namespace
+	}
+	if req.TaskQueue == nil {
+		req.TaskQueue = opts.tv.TaskQueue()
+	}
+	if req.Identity == "" {
+		req.Identity = opts.tv.WorkerIdentity()
+	}
+	resp, err := p.client.PollActivityTaskQueue(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || len(resp.TaskToken) == 0 {
+		return nil, NoTaskAvailable
+	}
+
+	return resp, err
+}
+
+func (p *TaskPoller) pollAndHandleActivityTask(
+	ctx context.Context,
+	opts *Options,
+	handler func(task *workflowservice.PollActivityTaskQueueResponse) (*workflowservice.RespondActivityTaskCompletedRequest, error),
+) (*workflowservice.RespondActivityTaskCompletedResponse, error) {
+	p.t.Helper()
+	task, err := p.pollActivityTask(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to poll workflow task: %w", err)
+	}
+	return p.handleActivityTask(ctx, opts, task, handler)
+}
+
+// TODO: support cancelling activity task
+func (p *TaskPoller) handleActivityTask(
+	ctx context.Context,
+	opts *Options,
+	task *workflowservice.PollActivityTaskQueueResponse,
+	handler func(task *workflowservice.PollActivityTaskQueueResponse) (*workflowservice.RespondActivityTaskCompletedRequest, error),
+) (*workflowservice.RespondActivityTaskCompletedResponse, error) {
+	p.t.Helper()
+	reply, err := handler(task)
+	if err != nil {
+		return nil, p.respondActivityTaskFailed(ctx, opts, task, err)
+	}
+
+	resp, err := p.respondActivityTaskCompleted(ctx, opts, task, reply)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (p *TaskPoller) respondActivityTaskCompleted(
+	ctx context.Context,
+	opts *Options,
+	task *workflowservice.PollActivityTaskQueueResponse,
+	reply *workflowservice.RespondActivityTaskCompletedRequest,
+) (*workflowservice.RespondActivityTaskCompletedResponse, error) {
+	p.t.Helper()
+	if reply == nil {
+		return nil, errors.New("missing RespondActivityTaskCompletedRequest return")
+	}
+	if reply.Namespace == "" {
+		reply.Namespace = p.namespace
+	}
+	if len(reply.TaskToken) == 0 {
+		reply.TaskToken = task.TaskToken
+	}
+	if reply.Identity == "" {
+		reply.Identity = opts.tv.WorkerIdentity()
+	}
+
+	return p.client.RespondActivityTaskCompleted(ctx, reply)
+}
+
+func (p *TaskPoller) respondActivityTaskFailed(
+	ctx context.Context,
+	opts *Options,
+	task *workflowservice.PollActivityTaskQueueResponse,
+	taskErr error,
+) error {
+	p.t.Helper()
+	_, err := p.client.RespondActivityTaskFailed(
+		ctx,
+		&workflowservice.RespondActivityTaskFailedRequest{
+			Namespace: p.namespace,
+			TaskToken: task.TaskToken,
+			Failure:   temporal.GetDefaultFailureConverter().ErrorToFailure(taskErr),
+			Identity:  opts.tv.WorkerIdentity(),
+		})
+	return err
+}
+
 func newOptions(
 	tv *testvars.TestVars,
 	funcs []OptionFunc,
 ) *Options {
 	res := &Options{
-		tv: tv,
+		tv:                      tv,
+		pollActivityTaskRequest: &workflowservice.PollActivityTaskQueueRequest{},
+		pollworkflowTaskRequest: &workflowservice.PollWorkflowTaskQueueRequest{},
 	}
 
 	// default options

--- a/common/testing/taskpoller/taskpoller.go
+++ b/common/testing/taskpoller/taskpoller.go
@@ -33,7 +33,6 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
-	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/debug"
@@ -372,7 +371,7 @@ func (p *activityTaskPoller) pollAndHandleTask(
 	p.t.Helper()
 	task, err := p.pollActivityTask(ctx, opts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to poll workflow task: %w", err)
+		return nil, fmt.Errorf("failed to poll activity task: %w", err)
 	}
 	return p.handleTask(ctx, opts, task, handler)
 }

--- a/common/testing/taskpoller/taskpoller.go
+++ b/common/testing/taskpoller/taskpoller.go
@@ -33,6 +33,7 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/debug"
@@ -226,7 +227,7 @@ func (p *workflowTaskPoller) pollTask(
 	if err != nil {
 		return nil, err
 	}
-	if resp == nil || len(resp.TaskToken) == 0 {
+	if resp == nil {
 		return nil, NoTaskAvailable
 	}
 

--- a/common/testing/taskpoller/taskpoller.go
+++ b/common/testing/taskpoller/taskpoller.go
@@ -111,11 +111,11 @@ func (p *TaskPoller) PollWorkflowTask(
 func (p *TaskPoller) PollAndHandleWorkflowTask(
 	tv *testvars.TestVars,
 	handler func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error),
-	funcs ...optionFunc,
+	opts ...optionFunc,
 ) (*workflowservice.RespondWorkflowTaskCompletedResponse, error) {
 	return p.
 		PollWorkflowTask(&workflowservice.PollWorkflowTaskQueueRequest{}).
-		HandleTask(tv, handler, funcs...)
+		HandleTask(tv, handler, opts...)
 }
 
 // HandleTask invokes the provided handler with the task poll result, and completes/fails the task accordingly.
@@ -125,10 +125,10 @@ func (p *TaskPoller) PollAndHandleWorkflowTask(
 func (p *workflowTaskPoller) HandleTask(
 	tv *testvars.TestVars,
 	handler func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error),
-	funcs ...optionFunc,
+	opts ...optionFunc,
 ) (*workflowservice.RespondWorkflowTaskCompletedResponse, error) {
 	p.t.Helper()
-	options := newOptions(tv, funcs)
+	options := newOptions(tv, opts)
 	ctx, cancel := newContext(options)
 	defer cancel()
 	return p.pollAndHandleTask(ctx, options, handler)
@@ -141,10 +141,10 @@ func (p *TaskPoller) HandleWorkflowTask(
 	tv *testvars.TestVars,
 	task *workflowservice.PollWorkflowTaskQueueResponse,
 	handler func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error),
-	funcs ...optionFunc,
+	opts ...optionFunc,
 ) (*workflowservice.RespondWorkflowTaskCompletedResponse, error) {
 	p.t.Helper()
-	options := newOptions(tv, funcs)
+	options := newOptions(tv, opts)
 	ctx, cancel := newContext(options)
 	defer cancel()
 	wp := workflowTaskPoller{TaskPoller: p}
@@ -166,11 +166,11 @@ func (p *TaskPoller) PollActivityTask(
 func (p *TaskPoller) PollAndHandleActivityTask(
 	tv *testvars.TestVars,
 	handler func(task *workflowservice.PollActivityTaskQueueResponse) (*workflowservice.RespondActivityTaskCompletedRequest, error),
-	funcs ...optionFunc,
+	opts ...optionFunc,
 ) (*workflowservice.RespondActivityTaskCompletedResponse, error) {
 	return p.
 		PollActivityTask(&workflowservice.PollActivityTaskQueueRequest{}).
-		HandleTask(tv, handler, funcs...)
+		HandleTask(tv, handler, opts...)
 }
 
 // HandleActivityTask invokes the provided handler with the provided task, and completes/fails the task accordingly.
@@ -180,10 +180,10 @@ func (p *TaskPoller) HandleActivityTask(
 	tv *testvars.TestVars,
 	task *workflowservice.PollActivityTaskQueueResponse,
 	handler func(task *workflowservice.PollActivityTaskQueueResponse) (*workflowservice.RespondActivityTaskCompletedRequest, error),
-	funcs ...optionFunc,
+	opts ...optionFunc,
 ) (*workflowservice.RespondActivityTaskCompletedResponse, error) {
 	p.t.Helper()
-	options := newOptions(tv, funcs)
+	options := newOptions(tv, opts)
 	ctx, cancel := newContext(options)
 	defer cancel()
 	ap := activityTaskPoller{TaskPoller: p}
@@ -197,10 +197,10 @@ func (p *TaskPoller) HandleActivityTask(
 func (p *activityTaskPoller) HandleTask(
 	tv *testvars.TestVars,
 	handler func(task *workflowservice.PollActivityTaskQueueResponse) (*workflowservice.RespondActivityTaskCompletedRequest, error),
-	funcs ...optionFunc,
+	opts ...optionFunc,
 ) (*workflowservice.RespondActivityTaskCompletedResponse, error) {
 	p.t.Helper()
-	options := newOptions(tv, funcs)
+	options := newOptions(tv, opts)
 	ctx, cancel := newContext(options)
 	defer cancel()
 	return p.pollAndHandleTask(ctx, options, handler)
@@ -441,7 +441,7 @@ func (p *activityTaskPoller) respondTaskFailed(
 
 func newOptions(
 	tv *testvars.TestVars,
-	funcs []optionFunc,
+	opts []optionFunc,
 ) *options {
 	res := &options{tv: tv}
 
@@ -449,7 +449,7 @@ func newOptions(
 	WithTimeout(21 * time.Second)(res) // Server logs warning if long poll is less than 20s
 
 	// custom options
-	for _, f := range funcs {
+	for _, f := range opts {
 		f(res)
 	}
 

--- a/common/testing/taskpoller/taskpoller.go
+++ b/common/testing/taskpoller/taskpoller.go
@@ -81,7 +81,8 @@ var (
 			o.timeout = timeout
 		}
 	}
-	NoTaskAvailable = errors.New("no task available")
+	NoWorkflowTaskAvailable = errors.New("taskpoller test helper timed out while waiting for the PollWorkflowTaskQueue API response, meaning no workflow task was ever created")
+	NoActivityTaskAvailable = errors.New("taskpoller test helper timed out while waiting for the PollActivityTaskQueue API response, meaning no activity task was ever created")
 )
 
 func New(
@@ -228,7 +229,7 @@ func (p *workflowTaskPoller) pollTask(
 		return nil, err
 	}
 	if resp == nil {
-		return nil, NoTaskAvailable
+		return nil, NoWorkflowTaskAvailable
 	}
 
 	var events []*historypb.HistoryEvent
@@ -358,7 +359,7 @@ func (p *activityTaskPoller) pollActivityTask(
 		return nil, err
 	}
 	if resp == nil || len(resp.TaskToken) == 0 {
-		return nil, NoTaskAvailable
+		return nil, NoActivityTaskAvailable
 	}
 
 	return resp, err

--- a/tests/testcore/taskpoller.go
+++ b/tests/testcore/taskpoller.go
@@ -55,6 +55,7 @@ type (
 	QueryHandler        func(task *workflowservice.PollWorkflowTaskQueueResponse) (*commonpb.Payloads, error)
 	MessageHandler      func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*protocolpb.Message, error)
 
+	// Deprecated: TaskPoller is deprecated. Use taskpoller.TaskPoller instead.
 	// TaskPoller is used in functional tests to poll workflow or activity task queues.
 	TaskPoller struct {
 		Client                       workflowservice.WorkflowServiceClient

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -1379,70 +1379,39 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_StickySpeculativeWorkflowTask_A
 				tv = tv.WithRunID("")
 			}
 
-			wtHandlerCalls := 0
-			wtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
-				wtHandlerCalls++
-				switch wtHandlerCalls {
-				case 1:
-					// Completes first WT with empty command list.
-					return nil, nil
-				case 2:
-					// This WT contains partial history because sticky was enabled.
-					s.EqualHistory(`
-  4 WorkflowTaskCompleted
-  5 WorkflowTaskScheduled // Speculative WT.
-  6 WorkflowTaskStarted`, task.History)
-					return s.UpdateAcceptCompleteCommands(tv, "1"), nil
-				default:
-					s.Failf("wtHandler called too many times", "wtHandler shouldn't be called %d times", wtHandlerCalls)
-					return nil, nil
-				}
-			}
-
-			msgHandlerCalls := 0
-			msgHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*protocolpb.Message, error) {
-				msgHandlerCalls++
-				switch msgHandlerCalls {
-				case 1:
-					return nil, nil
-				case 2:
-					updRequestMsg := task.Messages[0]
-					updRequest := protoutils.UnmarshalAny[*updatepb.Request](s.T(), updRequestMsg.GetBody())
-
-					s.Equal("args-value-of-"+tv.UpdateID("1"), testcore.DecodeString(s.T(), updRequest.GetInput().GetArgs()))
-					s.Equal(tv.HandlerName(), updRequest.GetInput().GetName())
-					s.EqualValues(5, updRequestMsg.GetEventId())
-
-					return s.UpdateAcceptCompleteMessages(tv, updRequestMsg, "1"), nil
-				default:
-					s.Failf("msgHandler called too many times", "msgHandler shouldn't be called %d times", msgHandlerCalls)
-					return nil, nil
-				}
-			}
-
-			poller := &testcore.TaskPoller{
-				Client:                       s.FrontendClient(),
-				Namespace:                    s.Namespace(),
-				TaskQueue:                    tv.TaskQueue(),
-				StickyTaskQueue:              tv.StickyTaskQueue(),
-				StickyScheduleToStartTimeout: 3 * time.Second,
-				Identity:                     tv.WorkerIdentity(),
-				WorkflowTaskHandler:          wtHandler,
-				MessageHandler:               msgHandler,
-				Logger:                       s.Logger,
-				T:                            s.T(),
-			}
-
 			// Drain existing first WT from regular task queue, but respond with sticky queue enabled response, next WT will go to sticky queue.
-			_, err := poller.PollAndProcessWorkflowTask(testcore.WithRespondSticky)
+			_, err := s.TaskPoller.PollAndHandleWorkflowTask(tv,
+				func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+					return &workflowservice.RespondWorkflowTaskCompletedRequest{
+						StickyAttributes: tv.StickyExecutionAttributes(3 * time.Second),
+					}, nil
+				})
 			s.NoError(err)
 
 			go func() {
 				// Process update in workflow task (it is sticky).
-				res, err := poller.PollAndProcessWorkflowTask(testcore.WithPollSticky, testcore.WithoutRetries)
+				res, err := s.TaskPoller.PollAndHandleWorkflowTask(tv,
+					func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+						// This WT contains partial history because sticky was enabled.
+						s.EqualHistory(`
+						  4 WorkflowTaskCompleted
+						  5 WorkflowTaskScheduled // Speculative WT.
+						  6 WorkflowTaskStarted`, task.History)
+
+						updRequestMsg := task.Messages[0]
+						updRequest := protoutils.UnmarshalAny[*updatepb.Request](s.T(), updRequestMsg.GetBody())
+						s.Equal("args-value-of-"+tv.UpdateID("1"), testcore.DecodeString(s.T(), updRequest.GetInput().GetArgs()))
+						s.Equal(tv.HandlerName(), updRequest.GetInput().GetName())
+						s.EqualValues(5, updRequestMsg.GetEventId())
+
+						return &workflowservice.RespondWorkflowTaskCompletedRequest{
+							Commands: s.UpdateAcceptCompleteCommands(tv, "1"),
+							Messages: s.UpdateAcceptCompleteMessages(tv, updRequestMsg, "1"),
+						}, nil
+					}, taskpoller.WithWorkflowTaskPollRequest(&workflowservice.PollWorkflowTaskQueueRequest{TaskQueue: tv.StickyTaskQueue()}))
 				require.NoError(s.T(), err)
 				require.NotNil(s.T(), res)
-				require.EqualValues(s.T(), 0, res.NewTask.ResetHistoryEventId)
+				require.EqualValues(s.T(), 0, res.ResetHistoryEventId)
 			}()
 
 			// This is to make sure that sticky poller above reached server first.
@@ -1452,22 +1421,17 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_StickySpeculativeWorkflowTask_A
 
 			s.EqualValues("success-result-of-"+tv.UpdateID("1"), testcore.DecodeString(s.T(), updateResult.GetOutcome().GetSuccess()))
 
-			s.Equal(2, wtHandlerCalls)
-			s.Equal(2, msgHandlerCalls)
-
-			events := s.GetHistory(s.Namespace(), tv.WorkflowExecution())
-
 			s.EqualHistoryEvents(`
-  1 WorkflowExecutionStarted
-  2 WorkflowTaskScheduled
-  3 WorkflowTaskStarted
-  4 WorkflowTaskCompleted
-  5 WorkflowTaskScheduled
-  6 WorkflowTaskStarted
-  7 WorkflowTaskCompleted
-  8 WorkflowExecutionUpdateAccepted {"AcceptedRequestSequencingEventId": 5} // WTScheduled event which delivered update to the worker.
-  9 WorkflowExecutionUpdateCompleted {"AcceptedEventId": 8}
-`, events)
+			  1 WorkflowExecutionStarted
+			  2 WorkflowTaskScheduled
+			  3 WorkflowTaskStarted
+			  4 WorkflowTaskCompleted
+			  5 WorkflowTaskScheduled
+			  6 WorkflowTaskStarted
+			  7 WorkflowTaskCompleted
+			  8 WorkflowExecutionUpdateAccepted {"AcceptedRequestSequencingEventId": 5} // WTScheduled event which delivered update to the worker.
+			  9 WorkflowExecutionUpdateCompleted {"AcceptedEventId": 8}
+			`, s.GetHistory(s.Namespace(), tv.WorkflowExecution()))
 		})
 	}
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Added support for activity tasks in new TaskPoller.

Also, added support for providing a custom poll request (instead of various options).

Not Ported:

- activity task cancellation was not ported over; not a single existing test seems to be using it
- handling activity tasks by ID is only used twice across the entire codebase; not ported over for now

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Two existing tests have been ported over: one with a successful task response and one with a failure.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
