### PR TITLE
Refactoring: rename UpdateActivityWithCallback method on mutable state to UpdateActivity

### DIFF
--- a/service/history/api/pauseactivity/api_test.go
+++ b/service/history/api/pauseactivity/api_test.go
@@ -132,7 +132,7 @@ func (s *pauseActivitySuite) TestPauseActivityAcceptance() {
 
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	s.mockMutableState.EXPECT().GetActivityByActivityID(gomock.Any()).Return(activityInfo, true)
-	s.mockMutableState.EXPECT().UpdateActivityWithCallback(gomock.Any(), gomock.Any())
+	s.mockMutableState.EXPECT().UpdateActivity(gomock.Any(), gomock.Any())
 
 	err := workflow.PauseActivityById(s.mockMutableState, activityId)
 	s.NoError(err)

--- a/service/history/api/updateactivityoptions/api.go
+++ b/service/history/api/updateactivityoptions/api.go
@@ -142,7 +142,7 @@ func updateActivityOptions(
 		return nil, err
 	}
 
-	if err := mutableState.UpdateActivity(ai.ActivityId, func(activityInfo *persistencespb.ActivityInfo, _ workflow.MutableState) {
+	if err := mutableState.UpdateActivity(ai.ScheduledEventId, func(activityInfo *persistencespb.ActivityInfo, _ workflow.MutableState) {
 		// update activity info with new options
 		activityInfo.TaskQueue = adjustedOptions.TaskQueue.Name
 		activityInfo.ScheduleToCloseTimeout = adjustedOptions.ScheduleToCloseTimeout

--- a/service/history/api/updateactivityoptions/api_test.go
+++ b/service/history/api/updateactivityoptions/api_test.go
@@ -395,7 +395,7 @@ func (s *activityOptionsSuite) Test_updateActivityOptionsAcceptance() {
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true)
 	s.mockMutableState.EXPECT().GetActivityByActivityID(gomock.Any()).Return(fullActivityInfo, true)
 	s.mockMutableState.EXPECT().RegenerateActivityRetryTask(gomock.Any(), gomock.Any()).Return(nil)
-	s.mockMutableState.EXPECT().UpdateActivity(gomock.Any()).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivity(gomock.Any(), gomock.Any()).Return(nil)
 
 	request := &historyservice.UpdateActivityOptionsRequest{
 		UpdateRequest: &workflowservicepb.UpdateActivityOptionsByIdRequest{

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -551,7 +551,7 @@ func (r *workflowResetterImpl) failInflightActivity(
 		switch ai.StartedEventId {
 		case common.EmptyEventID:
 			// activity not started, noop
-			if err := mutableState.UpdateActivity(ai.ActivityId, func(activityInfo *persistencespb.ActivityInfo, _ workflow.MutableState) {
+			if err := mutableState.UpdateActivity(ai.ScheduledEventId, func(activityInfo *persistencespb.ActivityInfo, _ workflow.MutableState) {
 				// override the scheduled activity time to now
 				activityInfo.ScheduledTime = timestamppb.New(now)
 				activityInfo.FirstScheduledTime = timestamppb.New(now)

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -493,13 +493,7 @@ func (s *workflowResetterSuite) TestFailInflightActivity() {
 		activity1.LastWorkerVersionStamp,
 	).Return(&historypb.HistoryEvent{}, nil)
 
-	mutableState.EXPECT().UpdateActivity(&persistencespb.ActivityInfo{
-		Version:            activity2.Version,
-		ScheduledEventId:   activity2.ScheduledEventId,
-		ScheduledTime:      timestamppb.New(now),
-		FirstScheduledTime: timestamppb.New(now),
-		StartedEventId:     activity2.StartedEventId,
-	}).Return(nil)
+	mutableState.EXPECT().UpdateActivity(gomock.Any(), gomock.Any()).Return(nil)
 
 	err := s.workflowResetter.failInflightActivity(now, mutableState, terminateReason)
 	s.NoError(err)

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -243,7 +243,7 @@ func (t *timerQueueActiveTaskExecutor) executeActivityTimeoutTask(
 	isHeartBeatTask := task.TimeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT
 	ai, heartbeatTimeoutVis, ok := mutableState.GetActivityInfoWithTimerHeartbeat(task.EventID)
 	if isHeartBeatTask && ok && queues.IsTimeExpired(task.GetVisibilityTime(), heartbeatTimeoutVis) {
-		err := mutableState.UpdateActivity(ai.ActivityId, func(activityInfo *persistencespb.ActivityInfo, _ workflow.MutableState) {
+		err := mutableState.UpdateActivity(ai.ScheduledEventId, func(activityInfo *persistencespb.ActivityInfo, _ workflow.MutableState) {
 			activityInfo.TimerTaskStatus = activityInfo.TimerTaskStatus &^ workflow.TimerTaskStatusCreatedHeartbeat
 		})
 		if err != nil {

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -246,7 +246,7 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityTimeoutTask(
 		isHeartBeatTask := timerTask.TimeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT
 		ai, heartbeatTimeoutVis, ok := mutableState.GetActivityInfoWithTimerHeartbeat(timerTask.EventID)
 		if isHeartBeatTask && ok && queues.IsTimeExpired(timerTask.GetVisibilityTime(), heartbeatTimeoutVis) {
-			err := mutableState.UpdateActivity(ai.ActivityId, func(activityInfo *persistencespb.ActivityInfo, _ workflow.MutableState) {
+			err := mutableState.UpdateActivity(ai.ScheduledEventId, func(activityInfo *persistencespb.ActivityInfo, _ workflow.MutableState) {
 				activityInfo.TimerTaskStatus = activityInfo.TimerTaskStatus &^ workflow.TimerTaskStatusCreatedHeartbeat
 			})
 			if err != nil {

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -36,6 +36,7 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -243,10 +244,12 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityTimeoutTask(
 		// for updating workflow execution. In that case, only one new heartbeat timeout task should be
 		// created.
 		isHeartBeatTask := timerTask.TimeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT
-		activityInfo, heartbeatTimeoutVis, ok := mutableState.GetActivityInfoWithTimerHeartbeat(timerTask.EventID)
+		ai, heartbeatTimeoutVis, ok := mutableState.GetActivityInfoWithTimerHeartbeat(timerTask.EventID)
 		if isHeartBeatTask && ok && queues.IsTimeExpired(timerTask.GetVisibilityTime(), heartbeatTimeoutVis) {
-			activityInfo.TimerTaskStatus = activityInfo.TimerTaskStatus &^ workflow.TimerTaskStatusCreatedHeartbeat
-			if err := mutableState.UpdateActivity(activityInfo); err != nil {
+			err := mutableState.UpdateActivity(ai.ActivityId, func(activityInfo *persistencespb.ActivityInfo, _ workflow.MutableState) {
+				activityInfo.TimerTaskStatus = activityInfo.TimerTaskStatus &^ workflow.TimerTaskStatusCreatedHeartbeat
+			})
+			if err != nil {
 				return nil, err
 			}
 			updateMutableState = true

--- a/service/history/worker_versioning_util.go
+++ b/service/history/worker_versioning_util.go
@@ -119,8 +119,9 @@ func updateIndependentActivityBuildId(
 		return err
 	}
 
-	ai.BuildIdInfo = &persistencespb.ActivityInfo_LastIndependentlyAssignedBuildId{LastIndependentlyAssignedBuildId: buildId}
-	err = mutableState.UpdateActivity(ai)
+	err = mutableState.UpdateActivity(ai.ActivityId, func(activityInfo *persistencespb.ActivityInfo, _ workflow.MutableState) {
+		activityInfo.BuildIdInfo = &persistencespb.ActivityInfo_LastIndependentlyAssignedBuildId{LastIndependentlyAssignedBuildId: buildId}
+	})
 	if err != nil {
 		return err
 	}

--- a/service/history/worker_versioning_util.go
+++ b/service/history/worker_versioning_util.go
@@ -119,7 +119,7 @@ func updateIndependentActivityBuildId(
 		return err
 	}
 
-	err = mutableState.UpdateActivity(ai.ActivityId, func(activityInfo *persistencespb.ActivityInfo, _ workflow.MutableState) {
+	err = mutableState.UpdateActivity(ai.ScheduledEventId, func(activityInfo *persistencespb.ActivityInfo, _ workflow.MutableState) {
 		activityInfo.BuildIdInfo = &persistencespb.ActivityInfo_LastIndependentlyAssignedBuildId{LastIndependentlyAssignedBuildId: buildId}
 	})
 	if err != nil {

--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -210,7 +210,7 @@ func PauseActivityById(mutableState MutableState, activityId string) error {
 		return nil
 	}
 
-	return mutableState.UpdateActivityWithCallback(ai.ActivityId, func(activityInfo *persistence.ActivityInfo, _ MutableState) {
+	return mutableState.UpdateActivity(ai.ActivityId, func(activityInfo *persistence.ActivityInfo, _ MutableState) {
 		// note - we are not increasing the stamp of the activity if it is running.
 		// this is because if activity is actually running we should let it finish
 		if GetActivityState(activityInfo) == enumspb.PENDING_ACTIVITY_STATE_SCHEDULED {

--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -210,7 +210,7 @@ func PauseActivityById(mutableState MutableState, activityId string) error {
 		return nil
 	}
 
-	return mutableState.UpdateActivity(ai.ActivityId, func(activityInfo *persistence.ActivityInfo, _ MutableState) {
+	return mutableState.UpdateActivity(ai.ScheduledEventId, func(activityInfo *persistence.ActivityInfo, _ MutableState) {
 		// note - we are not increasing the stamp of the activity if it is running.
 		// this is because if activity is actually running we should let it finish
 		if GetActivityState(activityInfo) == enumspb.PENDING_ACTIVITY_STATE_SCHEDULED {

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -145,7 +145,7 @@ type (
 		MaxSearchAttributeValueSize int
 	}
 
-	UpdateActivityCallback func(*persistencespb.ActivityInfo, MutableState)
+	ActivityUpdater func(*persistencespb.ActivityInfo, MutableState)
 
 	MutableState interface {
 		callbacks.CanGetNexusCompletion
@@ -360,7 +360,7 @@ type (
 			baseRunLowestCommonAncestorEventID int64,
 			baseRunLowestCommonAncestorEventVersion int64,
 		)
-		UpdateActivity(string, UpdateActivityCallback) error
+		UpdateActivity(string, ActivityUpdater) error
 		UpdateActivityTimerHeartbeat(int64, time.Time)
 		UpdateActivityProgress(ai *persistencespb.ActivityInfo, request *workflowservice.RecordActivityTaskHeartbeatRequest)
 		UpdateUserTimer(*persistencespb.TimerInfo) error

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -360,7 +360,7 @@ type (
 			baseRunLowestCommonAncestorEventID int64,
 			baseRunLowestCommonAncestorEventVersion int64,
 		)
-		UpdateActivity(string, ActivityUpdater) error
+		UpdateActivity(int64, ActivityUpdater) error
 		UpdateActivityTimerHeartbeat(int64, time.Time)
 		UpdateActivityProgress(ai *persistencespb.ActivityInfo, request *workflowservice.RecordActivityTaskHeartbeatRequest)
 		UpdateUserTimer(*persistencespb.TimerInfo) error

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -360,9 +360,8 @@ type (
 			baseRunLowestCommonAncestorEventID int64,
 			baseRunLowestCommonAncestorEventVersion int64,
 		)
-		UpdateActivity(*persistencespb.ActivityInfo) error
-		UpdateActivityWithTimerHeartbeat(*persistencespb.ActivityInfo, time.Time) error
-		UpdateActivityWithCallback(string, UpdateActivityCallback) error
+		UpdateActivity(string, UpdateActivityCallback) error
+		UpdateActivityTimerHeartbeat(int64, time.Time)
 		UpdateActivityProgress(ai *persistencespb.ActivityInfo, request *workflowservice.RecordActivityTaskHeartbeatRequest)
 		UpdateUserTimer(*persistencespb.TimerInfo) error
 		UpdateCurrentVersion(version int64, forceUpdate bool) error

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4940,6 +4940,16 @@ func (ms *MutableStateImpl) updateActivityInfoForRetries(
 	})
 }
 
+/*
+UpdateActivity function updates the existing pending activity via the updater callback.
+To update an activity, we need to do the following steps:
+	* preserve the original size of the activity
+	* preserve the original state of the activity
+	* call the updater callback to update the activity
+	* calculate new size of the activity
+	* respond to the changes of the activity state (like changes to pause)
+*/
+
 func (ms *MutableStateImpl) UpdateActivity(activityId string, updater ActivityUpdater) error {
 	ai, activityFound := ms.GetActivityByActivityID(activityId)
 	if !activityFound {
@@ -4953,7 +4963,7 @@ func (ms *MutableStateImpl) UpdateActivity(activityId string, updater ActivityUp
 		prevPause = prev.Paused
 	}
 
-	updateCallback(ai, ms)
+	updater(ai, ms)
 
 	if prevPause != ai.Paused {
 		err := ms.updatePauseInfoSearchAttribute()

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4940,7 +4940,7 @@ func (ms *MutableStateImpl) updateActivityInfoForRetries(
 	})
 }
 
-func (ms *MutableStateImpl) UpdateActivity(activityId string, updateCallback UpdateActivityCallback) error {
+func (ms *MutableStateImpl) UpdateActivity(activityId string, updater ActivityUpdater) error {
 	ai, activityFound := ms.GetActivityByActivityID(activityId)
 	if !activityFound {
 		return consts.ErrActivityNotFound

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -3068,7 +3068,7 @@ func (mr *MockMutableStateMockRecorder) TaskQueueScheduleToStartTimeout(name any
 }
 
 // UpdateActivity mocks base method.
-func (m *MockMutableState) UpdateActivity(arg0 string, arg1 ActivityUpdater) error {
+func (m *MockMutableState) UpdateActivity(arg0 int64, arg1 ActivityUpdater) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateActivity", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -3068,17 +3068,17 @@ func (mr *MockMutableStateMockRecorder) TaskQueueScheduleToStartTimeout(name any
 }
 
 // UpdateActivity mocks base method.
-func (m *MockMutableState) UpdateActivity(arg0 *persistence.ActivityInfo) error {
+func (m *MockMutableState) UpdateActivity(arg0 string, arg1 UpdateActivityCallback) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateActivity", arg0)
+	ret := m.ctrl.Call(m, "UpdateActivity", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateActivity indicates an expected call of UpdateActivity.
-func (mr *MockMutableStateMockRecorder) UpdateActivity(arg0 any) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) UpdateActivity(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActivity", reflect.TypeOf((*MockMutableState)(nil).UpdateActivity), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActivity", reflect.TypeOf((*MockMutableState)(nil).UpdateActivity), arg0, arg1)
 }
 
 // UpdateActivityInfo mocks base method.
@@ -3107,32 +3107,16 @@ func (mr *MockMutableStateMockRecorder) UpdateActivityProgress(ai, request any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActivityProgress", reflect.TypeOf((*MockMutableState)(nil).UpdateActivityProgress), ai, request)
 }
 
-// UpdateActivityWithCallback mocks base method.
-func (m *MockMutableState) UpdateActivityWithCallback(arg0 string, arg1 UpdateActivityCallback) error {
+// UpdateActivityTimerHeartbeat mocks base method.
+func (m *MockMutableState) UpdateActivityTimerHeartbeat(arg0 int64, arg1 time.Time) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateActivityWithCallback", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "UpdateActivityTimerHeartbeat", arg0, arg1)
 }
 
-// UpdateActivityWithCallback indicates an expected call of UpdateActivityWithCallback.
-func (mr *MockMutableStateMockRecorder) UpdateActivityWithCallback(arg0, arg1 any) *gomock.Call {
+// UpdateActivityTimerHeartbeat indicates an expected call of UpdateActivityTimerHeartbeat.
+func (mr *MockMutableStateMockRecorder) UpdateActivityTimerHeartbeat(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActivityWithCallback", reflect.TypeOf((*MockMutableState)(nil).UpdateActivityWithCallback), arg0, arg1)
-}
-
-// UpdateActivityWithTimerHeartbeat mocks base method.
-func (m *MockMutableState) UpdateActivityWithTimerHeartbeat(arg0 *persistence.ActivityInfo, arg1 time.Time) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateActivityWithTimerHeartbeat", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateActivityWithTimerHeartbeat indicates an expected call of UpdateActivityWithTimerHeartbeat.
-func (mr *MockMutableStateMockRecorder) UpdateActivityWithTimerHeartbeat(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActivityWithTimerHeartbeat", reflect.TypeOf((*MockMutableState)(nil).UpdateActivityWithTimerHeartbeat), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActivityTimerHeartbeat", reflect.TypeOf((*MockMutableState)(nil).UpdateActivityTimerHeartbeat), arg0, arg1)
 }
 
 // UpdateBuildIdAssignment mocks base method.

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -3068,7 +3068,7 @@ func (mr *MockMutableStateMockRecorder) TaskQueueScheduleToStartTimeout(name any
 }
 
 // UpdateActivity mocks base method.
-func (m *MockMutableState) UpdateActivity(arg0 string, arg1 UpdateActivityCallback) error {
+func (m *MockMutableState) UpdateActivity(arg0 string, arg1 ActivityUpdater) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateActivity", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -392,7 +392,7 @@ func (r *TaskRefresherImpl) refreshTasksForActivity(
 
 			// need to update activity timer task mask for which task is generated
 			if err := mutableState.UpdateActivity(
-				activityInfo.ActivityId, func(ai *persistencespb.ActivityInfo, _ MutableState) {
+				activityInfo.ScheduledEventId, func(ai *persistencespb.ActivityInfo, _ MutableState) {
 					// clear activity timer task mask for later activity timer task re-generation
 					activityInfo.TimerTaskStatus = TimerTaskStatusNone
 				},

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -389,12 +389,13 @@ func (r *TaskRefresherImpl) refreshTasksForActivity(
 		}
 
 		if CompareVersionedTransition(minVersionedTransition, EmptyVersionedTransition) == 0 { // Full refresh
-			// clear activity timer task mask for later activity timer task re-generation
-			activityInfo.TimerTaskStatus = TimerTaskStatusNone
 
 			// need to update activity timer task mask for which task is generated
 			if err := mutableState.UpdateActivity(
-				activityInfo,
+				activityInfo.ActivityId, func(ai *persistencespb.ActivityInfo, _ MutableState) {
+					// clear activity timer task mask for later activity timer task re-generation
+					activityInfo.TimerTaskStatus = TimerTaskStatusNone
+				},
 			); err != nil {
 				return err
 			}

--- a/service/history/workflow/timer_sequence.go
+++ b/service/history/workflow/timer_sequence.go
@@ -153,15 +153,14 @@ func (t *timerSequenceImpl) CreateNextActivityTimer() (bool, error) {
 	if !ok {
 		return false, serviceerror.NewInternal(fmt.Sprintf("unable to load activity info %v", firstTimerTask.EventID))
 	}
-	// mark timer task mask as indication that timer task is generated
-	activityInfo.TimerTaskStatus |= timerTypeToTimerMask(firstTimerTask.TimerType)
 
-	var err error
-	if firstTimerTask.TimerType == enumspb.TIMEOUT_TYPE_HEARTBEAT {
-		err = t.mutableState.UpdateActivityWithTimerHeartbeat(activityInfo, firstTimerTask.Timestamp)
-	} else {
-		err = t.mutableState.UpdateActivity(activityInfo)
-	}
+	err := t.mutableState.UpdateActivity(activityInfo.ActivityId, func(ai *persistencespb.ActivityInfo, ms MutableState) {
+		// mark timer task mask as indication that timer task is generated
+		ai.TimerTaskStatus |= timerTypeToTimerMask(firstTimerTask.TimerType)
+		if firstTimerTask.TimerType == enumspb.TIMEOUT_TYPE_HEARTBEAT {
+			t.mutableState.UpdateActivityTimerHeartbeat(ai.ScheduledEventId, firstTimerTask.Timestamp)
+		}
+	})
 
 	if err != nil {
 		return false, err

--- a/service/history/workflow/timer_sequence.go
+++ b/service/history/workflow/timer_sequence.go
@@ -154,7 +154,7 @@ func (t *timerSequenceImpl) CreateNextActivityTimer() (bool, error) {
 		return false, serviceerror.NewInternal(fmt.Sprintf("unable to load activity info %v", firstTimerTask.EventID))
 	}
 
-	err := t.mutableState.UpdateActivity(activityInfo.ActivityId, func(ai *persistencespb.ActivityInfo, ms MutableState) {
+	err := t.mutableState.UpdateActivity(activityInfo.ScheduledEventId, func(ai *persistencespb.ActivityInfo, ms MutableState) {
 		// mark timer task mask as indication that timer task is generated
 		ai.TimerTaskStatus |= timerTypeToTimerMask(firstTimerTask.TimerType)
 		if firstTimerTask.TimerType == enumspb.TIMEOUT_TYPE_HEARTBEAT {

--- a/service/history/workflow/timer_sequence_test.go
+++ b/service/history/workflow/timer_sequence_test.go
@@ -375,7 +375,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_NotCreated_BeforeWorkfl
 
 	var activityInfoUpdated = common.CloneProto(activityInfo) // make a copy
 	activityInfoUpdated.TimerTaskStatus = TimerTaskStatusCreatedScheduleToStart
-	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated)).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated.ActivityId), gomock.Any()).Return(nil)
 	s.mockMutableState.EXPECT().AddTasks(&tasks.ActivityTimeoutTask{
 		// TaskID is set by shard
 		WorkflowKey:         s.workflowKey,
@@ -417,7 +417,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_NotCreated_NoWorkflowEx
 
 	var activityInfoUpdated = common.CloneProto(activityInfo) // make a copy
 	activityInfoUpdated.TimerTaskStatus = TimerTaskStatusCreatedScheduleToStart
-	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated)).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated.ActivityId), gomock.Any()).Return(nil)
 	s.mockMutableState.EXPECT().AddTasks(&tasks.ActivityTimeoutTask{
 		// TaskID is set by shard
 		WorkflowKey:         s.workflowKey,
@@ -490,7 +490,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_HeartbeatTimer_BeforeWo
 
 	var activityInfoUpdated = common.CloneProto(activityInfo) // make a copy
 	activityInfoUpdated.TimerTaskStatus = TimerTaskStatusCreatedHeartbeat
-	s.mockMutableState.EXPECT().UpdateActivityWithTimerHeartbeat(protomock.Eq(activityInfoUpdated), taskVisibilityTimestamp).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated.ActivityId), gomock.Any()).Return(nil)
 	s.mockMutableState.EXPECT().AddTasks(&tasks.ActivityTimeoutTask{
 		// TaskID is set by shard
 		WorkflowKey:         s.workflowKey,
@@ -534,7 +534,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_HeartbeatTimer_NoWorkfl
 
 	var activityInfoUpdated = common.CloneProto(activityInfo) // make a copy
 	activityInfoUpdated.TimerTaskStatus = TimerTaskStatusCreatedHeartbeat
-	s.mockMutableState.EXPECT().UpdateActivityWithTimerHeartbeat(protomock.Eq(activityInfoUpdated), taskVisibilityTimestamp).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated.ActivityId), gomock.Any()).Return(nil)
 	s.mockMutableState.EXPECT().AddTasks(&tasks.ActivityTimeoutTask{
 		// TaskID is set by shard
 		WorkflowKey:         s.workflowKey,

--- a/service/history/workflow/timer_sequence_test.go
+++ b/service/history/workflow/timer_sequence_test.go
@@ -375,7 +375,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_NotCreated_BeforeWorkfl
 
 	var activityInfoUpdated = common.CloneProto(activityInfo) // make a copy
 	activityInfoUpdated.TimerTaskStatus = TimerTaskStatusCreatedScheduleToStart
-	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated.ActivityId), gomock.Any()).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfo.ScheduledEventId), gomock.Any()).Return(nil)
 	s.mockMutableState.EXPECT().AddTasks(&tasks.ActivityTimeoutTask{
 		// TaskID is set by shard
 		WorkflowKey:         s.workflowKey,
@@ -417,7 +417,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_NotCreated_NoWorkflowEx
 
 	var activityInfoUpdated = common.CloneProto(activityInfo) // make a copy
 	activityInfoUpdated.TimerTaskStatus = TimerTaskStatusCreatedScheduleToStart
-	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated.ActivityId), gomock.Any()).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfo.ScheduledEventId), gomock.Any()).Return(nil)
 	s.mockMutableState.EXPECT().AddTasks(&tasks.ActivityTimeoutTask{
 		// TaskID is set by shard
 		WorkflowKey:         s.workflowKey,
@@ -490,7 +490,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_HeartbeatTimer_BeforeWo
 
 	var activityInfoUpdated = common.CloneProto(activityInfo) // make a copy
 	activityInfoUpdated.TimerTaskStatus = TimerTaskStatusCreatedHeartbeat
-	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated.ActivityId), gomock.Any()).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated.ScheduledEventId), gomock.Any()).Return(nil)
 	s.mockMutableState.EXPECT().AddTasks(&tasks.ActivityTimeoutTask{
 		// TaskID is set by shard
 		WorkflowKey:         s.workflowKey,
@@ -534,7 +534,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_HeartbeatTimer_NoWorkfl
 
 	var activityInfoUpdated = common.CloneProto(activityInfo) // make a copy
 	activityInfoUpdated.TimerTaskStatus = TimerTaskStatusCreatedHeartbeat
-	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated.ActivityId), gomock.Any()).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivity(protomock.Eq(activityInfoUpdated.ScheduledEventId), gomock.Any()).Return(nil)
 	s.mockMutableState.EXPECT().AddTasks(&tasks.ActivityTimeoutTask{
 		// TaskID is set by shard
 		WorkflowKey:         s.workflowKey,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
1. I change  every UpdateActivity to UpdateActivityWithCallback everywhere in the code.
2. I removed old UpdateActivity
3. I rename UpdateActivityWithCallback to UpdateActivity
4. Fix tests, etc.

## Why?
<!-- Tell your future self why have you made these changes -->
Old UpdateActivity was not actually working. ActivityInfo in pending activities is a pointer, so calculating size was wrong. Few other reasons.

## How did you test it?
unit tests

## Risks
With this change the size of mutable state is calculated properly. This means that in some cases it may change, thus becoming larger then before, and trigger some errors.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No