### PR TITLE
change delimeter for paused info search attribute

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4990,7 +4990,7 @@ func (ms *MutableStateImpl) updatePauseInfoSearchAttribute() error {
 	}
 	pausedInfo := make([]string, 0, len(pausedInfoMap))
 	for activityType := range pausedInfoMap {
-		pausedInfo = append(pausedInfo, fmt.Sprintf("property.activityType=%s", activityType))
+		pausedInfo = append(pausedInfo, fmt.Sprintf("property:activityType=%s", activityType))
 	}
 
 	pauseInfoPayload, err := searchattribute.EncodeValue(pausedInfo, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Change delimiter for pause info search attribute from "." to ":
## Why?
<!-- Tell your future self why have you made these changes -->
This is what we agree on.
