### PR TITLE
Fix data race in MultiOps API

### DIFF
--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -114,10 +114,9 @@ func Invoke(
 			// - but receive a new instance that won't have the in-memory Update registry.
 			workflowLease.GetContext().(*workflow.ContextImpl).MutableState = ms
 
-			updateReg := workflowLease.GetContext().UpdateRegistry(ctx, nil)
-
 			// Add the Update.
 			// NOTE: UpdateWorkflowAction return value is ignored since ther Starter will always create a WFT.
+			updateReg := workflowLease.GetContext().UpdateRegistry(ctx, nil)
 			if _, err := updater.ApplyRequest(ctx, updateReg, ms); err != nil {
 				// Wrapping the error so Update and Start errors can be distinguished later.
 				return nil, updateError{err}

--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -49,6 +49,10 @@ var (
 	multiOpAbortedErr = serviceerror.NewMultiOperationAborted("Operation was aborted.")
 )
 
+type (
+	updateError struct{ error }
+)
+
 func Invoke(
 	ctx context.Context,
 	req *historyservice.ExecuteMultiOperationRequest,
@@ -62,21 +66,6 @@ func Invoke(
 		return nil, serviceerror.NewInternal("expected exactly 2 operations")
 	}
 
-	startReq := req.Operations[0].GetStartWorkflow()
-	if startReq == nil {
-		return nil, serviceerror.NewInternal("expected first operation to be Start Workflow")
-	}
-	starter, err := startworkflow.NewStarter(
-		shardContext,
-		workflowConsistencyChecker,
-		tokenSerializer,
-		visibilityManager,
-		startReq,
-	)
-	if err != nil {
-		return nil, newMultiOpError(err, multiOpAbortedErr)
-	}
-
 	updateReq := req.Operations[1].GetUpdateWorkflow()
 	if updateReq == nil {
 		return nil, serviceerror.NewInternal("expected second operation to be Update Workflow")
@@ -87,6 +76,59 @@ func Invoke(
 		matchingClient,
 		updateReq,
 	)
+
+	startReq := req.Operations[0].GetStartWorkflow()
+	if startReq == nil {
+		return nil, serviceerror.NewInternal("expected first operation to be Start Workflow")
+	}
+	starter, err := startworkflow.NewStarter(
+		shardContext,
+		workflowConsistencyChecker,
+		tokenSerializer,
+		visibilityManager,
+		startReq,
+		func(
+			shardContext shard.Context,
+			ms workflow.MutableState,
+		) (api.WorkflowLease, error) {
+			// Create a new *locked* workflow context. This is important since without the lock, task processing
+			// would try to modify the mutable state concurrently. Once the Starter completes, it will release the lock.
+			//
+			// The cache write needs to happen *before* the persistence write because a failed cache write means an
+			// early error response that aborts the entire MultiOperation request. And it allows for a simple retry, too -
+			// whereas if the cache write happened and failed *after* a successful persistence write,
+			// it would leave behind a started workflow that will never receive the update.
+			workflowContext, releaseFunc, err := workflowConsistencyChecker.GetWorkflowCache().GetOrCreateWorkflowExecution(
+				ctx,
+				shardContext,
+				ms.GetNamespaceEntry().ID(),
+				&commonpb.WorkflowExecution{WorkflowId: ms.GetExecutionInfo().WorkflowId, RunId: ms.GetExecutionState().RunId},
+				locks.PriorityHigh,
+			)
+			if err != nil {
+				return nil, err
+			}
+			workflowLease := api.NewWorkflowLease(workflowContext, releaseFunc, ms)
+
+			// If MutableState isn't set here, the next request for it will load it from the database
+			// - but receive a new instance that won't have the in-memory Update registry.
+			workflowLease.GetContext().(*workflow.ContextImpl).MutableState = ms
+
+			updateReg := workflowLease.GetContext().UpdateRegistry(ctx, nil)
+
+			// Add the Update.
+			// NOTE: UpdateWorkflowAction return value is ignored since ther Starter will always create a WFT.
+			if _, err := updater.ApplyRequest(ctx, updateReg, ms); err != nil {
+				// Wrapping the error so Update and Start errors can be distinguished later.
+				return nil, updateError{err}
+			}
+
+			return workflowLease, nil
+		},
+	)
+	if err != nil {
+		return nil, newMultiOpError(err, multiOpAbortedErr)
+	}
 
 	// For workflow id conflict policy terminate-existing, always attempt a start
 	// since that works when the workflow is already running *and* when it's not running.
@@ -218,49 +260,11 @@ func startAndUpdateWorkflow(
 	starter *startworkflow.Starter,
 	updater *updateworkflow.Updater,
 ) (*historyservice.ExecuteMultiOperationResponse, startworkflow.StartOutcome, error) {
-	var updateErr error
-
-	// hook is invoked before workflow is persisted
-	applyUpdateFunc := func(lease api.WorkflowLease) error {
-		// workflowCtx is the response from the cache write: either it's the context from the currently held lease
-		// OR the already-existing, previously cached context (this happens when the workflow is being terminated;
-		// it re-uses the same context).
-		var workflowCtx workflow.Context
-
-		// It is crucial to put the Update registry (inside the workflow context) into the cache, as it needs to
-		// exist on the Matching call back to History when delivering a workflow task to a worker.
-		//
-		// The cache write needs to happen *before* the persistence write because a failed cache write means an
-		// early error response that aborts the entire MultiOperation request. And it allows for a simple retry, too -
-		// whereas if the cache write happened and failed *after* a successful persistence write,
-		// it would leave behind a started workflow that will never receive the update.
-		ms := lease.GetMutableState()
-		wfContext := lease.GetContext()
-		// if MutableState isn't set, the next request for it will load it from the database
-		// - but receive a new instance that is inconsistent with this one
-		wfContext.(*workflow.ContextImpl).MutableState = ms
-		workflowKey := wfContext.GetWorkflowKey()
-		workflowCtx, updateErr = workflowConsistencyChecker.GetWorkflowCache().Put(
-			shardContext,
-			ms.GetNamespaceEntry().ID(),
-			&commonpb.WorkflowExecution{WorkflowId: workflowKey.WorkflowID, RunId: workflowKey.RunID},
-			wfContext,
-			shardContext.GetMetricsHandler(),
-		)
-		if updateErr == nil {
-			// UpdateWorkflowAction return value is ignored since Start will always create WFT
-			updateReg := workflowCtx.UpdateRegistry(ctx, ms)
-			_, updateErr = updater.ApplyRequest(ctx, updateReg, ms)
-		}
-		return updateErr
-	}
-
-	// start workflow, using the hook to apply the update operation
-	startResp, startOutcome, err := starter.Invoke(ctx, applyUpdateFunc)
+	startResp, startOutcome, err := starter.Invoke(ctx)
 	if err != nil {
 		// an update error occurred
-		if updateErr != nil {
-			return nil, startOutcome, newMultiOpError(multiOpAbortedErr, updateErr)
+		if errors.As(err, &updateError{}) {
+			return nil, startOutcome, newMultiOpError(multiOpAbortedErr, err)
 		}
 
 		// a start error occurred

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -89,7 +89,7 @@ func startAndSignalWorkflow(
 	workflowID := signalWithStartRequest.GetWorkflowId()
 	runID := uuid.New().String()
 	// TODO(bergundy): Support eager workflow task
-	newWorkflowLease, err := api.NewWorkflowWithSignal(
+	newMutableState, err := api.NewWorkflowWithSignal(
 		shard,
 		namespaceEntry,
 		workflowID,
@@ -100,10 +100,16 @@ func startAndSignalWorkflow(
 	if err != nil {
 		return "", false, err
 	}
+
+	newWorkflowLease, err := api.NewWorkflowLeaseAndContext(shard, newMutableState)
+	if err != nil {
+		return "", false, err
+	}
+
 	if err = api.ValidateSignal(
 		ctx,
 		shard,
-		newWorkflowLease.GetMutableState(),
+		newMutableState,
 		signalWithStartRequest.GetSignalInput().Size(),
 		"SignalWithStartWorkflowExecution",
 	); err != nil {

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -396,8 +396,8 @@ func (s *Starter) resolveDuplicateWorkflowID(
 		currentWorkflowConditionFailed.RunID,
 	)
 
-	// Using a new RunID here to simplify locking. MultiOperation, that re-uses the Starter, is creating
-	// locked workflow contexts, and using a fresh RunID prevents a deadlock.
+	// Using a new RunID here to simplify locking: MultiOperation, that re-uses the Starter, is creating
+	// a locked workflow context for each new workflow. Using a fresh RunID prevents a deadlock.
 	newRunID := uuid.NewString()
 
 	currentExecutionUpdateAction, err := api.ResolveDuplicateWorkflowID(

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -397,7 +397,8 @@ func (s *Starter) resolveDuplicateWorkflowID(
 	)
 
 	// Using a new RunID here to simplify locking: MultiOperation, that re-uses the Starter, is creating
-	// a locked workflow context for each new workflow. Using a fresh RunID prevents a deadlock.
+	// a locked workflow context for each new workflow. Using a fresh RunID prevents a deadlock with the
+	// previously created workflow context.
 	newRunID := uuid.NewString()
 
 	currentExecutionUpdateAction, err := api.ResolveDuplicateWorkflowID(

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -72,10 +72,6 @@ const (
 	StartDeduped
 )
 
-var (
-	BeforeCreateHookNoop = func(lease api.WorkflowLease) error { return nil }
-)
-
 // Starter starts a new workflow execution.
 type Starter struct {
 	shardContext               shard.Context
@@ -84,7 +80,7 @@ type Starter struct {
 	visibilityManager          manager.VisibilityManager
 	request                    *historyservice.StartWorkflowExecutionRequest
 	namespace                  *namespace.Namespace
-	beforeCreateHook           BeforeCreateHookFunc
+	createLeaseForWorkflow     api.CreateLeaseForWorkflow
 }
 
 // creationParams is a container for all information obtained from creating the uncommitted execution.
@@ -113,6 +109,7 @@ func NewStarter(
 	tokenSerializer common.TaskTokenSerializer,
 	visibilityManager manager.VisibilityManager,
 	request *historyservice.StartWorkflowExecutionRequest,
+	createLeaseForWorkflow api.CreateLeaseForWorkflow,
 ) (*Starter, error) {
 	namespaceEntry, err := api.GetActiveNamespace(shardContext, namespace.ID(request.GetNamespaceId()))
 	if err != nil {
@@ -126,6 +123,7 @@ func NewStarter(
 		visibilityManager:          visibilityManager,
 		request:                    request,
 		namespace:                  namespaceEntry,
+		createLeaseForWorkflow:     createLeaseForWorkflow,
 	}, nil
 }
 
@@ -191,38 +189,37 @@ func (s *Starter) requestEagerStart() bool {
 // requires terminating the running workflow first; it is then invoked again on the newly started workflow.
 func (s *Starter) Invoke(
 	ctx context.Context,
-	beforeCreateHook BeforeCreateHookFunc,
 ) (resp *historyservice.StartWorkflowExecutionResponse, startOutcome StartOutcome, retError error) {
 	request := s.request.StartRequest
 	if err := s.prepare(ctx); err != nil {
-		return nil, startOutcome, err
+		return nil, NoStart, err
 	}
 
-	creationParams, err := s.createNewMutableState(request.GetWorkflowId())
+	creationParams, err := s.prepareNewWorkflow(request.GetWorkflowId())
 	if err != nil {
-		return nil, startOutcome, err
+		return nil, NoStart, err
 	}
+	defer func() {
+		creationParams.workflowLease.GetReleaseFn()(retError)
+	}()
 
-	// grab current workflow context as a lock so that user latency can be computed
-	currentRelease, err := s.lockCurrentWorkflowExecution(ctx)
+	currentExecutionLock, err := s.lockCurrentWorkflowExecution(ctx)
 	if err != nil {
-		return nil, startOutcome, err
+		return nil, NoStart, err
 	}
-	defer func() { currentRelease(retError) }()
-
-	if err = beforeCreateHook(creationParams.workflowLease); err != nil {
-		return nil, startOutcome, err
-	}
+	defer func() {
+		currentExecutionLock(retError)
+	}()
 
 	err = s.createBrandNew(ctx, creationParams)
 	if err != nil {
 		var currentWorkflowConditionFailedError *persistence.CurrentWorkflowConditionFailedError
 		if errors.As(err, &currentWorkflowConditionFailedError) && len(currentWorkflowConditionFailedError.RunID) > 0 {
 			// The history and mutable state generated above will be deleted by a background process.
-			return s.handleConflict(ctx, creationParams, beforeCreateHook, currentWorkflowConditionFailedError)
+			return s.handleConflict(ctx, creationParams, currentWorkflowConditionFailedError)
 		}
 
-		return nil, startOutcome, err
+		return nil, NoStart, err
 	}
 
 	resp, err = s.generateResponse(
@@ -249,11 +246,11 @@ func (s *Starter) lockCurrentWorkflowExecution(
 	return currentRelease, nil
 }
 
-// createNewMutableState creates a new workflow context, and closes its mutable state transaction as snapshot.
+// prepareNewWorkflow creates a new workflow context, and closes its mutable state transaction as snapshot.
 // It returns the creationContext which can later be used to insert into the executions table.
-func (s *Starter) createNewMutableState(workflowID string) (*creationParams, error) {
+func (s *Starter) prepareNewWorkflow(workflowID string) (*creationParams, error) {
 	runID := uuid.NewString()
-	workflowLease, err := api.NewWorkflowWithSignal(
+	mutableState, err := api.NewWorkflowWithSignal(
 		s.shardContext,
 		s.namespace,
 		workflowID,
@@ -265,7 +262,11 @@ func (s *Starter) createNewMutableState(workflowID string) (*creationParams, err
 		return nil, err
 	}
 
-	mutableState := workflowLease.GetMutableState()
+	workflowLease, err := s.createLeaseForWorkflow(s.shardContext, mutableState)
+	if err != nil {
+		return nil, err
+	}
+
 	workflowTaskInfo := mutableState.GetStartedWorkflowTask()
 	if s.requestEagerStart() && workflowTaskInfo == nil {
 		return nil, serviceerror.NewInternal("unexpected error: mutable state did not have a started workflow task")
@@ -290,7 +291,7 @@ func (s *Starter) createNewMutableState(workflowID string) (*creationParams, err
 	}, nil
 }
 
-// createBrandNew creates a new "brand new" execution in the executions table.
+// createBrandNew creates a "brand new" execution in the executions table.
 func (s *Starter) createBrandNew(ctx context.Context, creationParams *creationParams) error {
 	return creationParams.workflowLease.GetContext().CreateWorkflowExecution(
 		ctx,
@@ -310,7 +311,6 @@ func (s *Starter) createBrandNew(ctx context.Context, creationParams *creationPa
 func (s *Starter) handleConflict(
 	ctx context.Context,
 	creationParams *creationParams,
-	beforeCreateHook BeforeCreateHookFunc,
 	currentWorkflowConditionFailed *persistence.CurrentWorkflowConditionFailedError,
 ) (*historyservice.StartWorkflowExecutionResponse, StartOutcome, error) {
 	request := s.request.StartRequest
@@ -323,7 +323,7 @@ func (s *Starter) handleConflict(
 		return nil, NoStart, err
 	}
 
-	response, startOutcome, err := s.resolveDuplicateWorkflowID(ctx, creationParams, beforeCreateHook, currentWorkflowConditionFailed)
+	response, startOutcome, err := s.resolveDuplicateWorkflowID(ctx, currentWorkflowConditionFailed)
 	if err != nil {
 		return nil, NoStart, err
 	} else if response != nil {
@@ -380,8 +380,6 @@ func (s *Starter) verifyNamespaceActive(
 // Returns non-nil response if an action was required and completed successfully resulting in a newly created execution.
 func (s *Starter) resolveDuplicateWorkflowID(
 	ctx context.Context,
-	creationParams *creationParams,
-	beforeCreateHook BeforeCreateHookFunc,
 	currentWorkflowConditionFailed *persistence.CurrentWorkflowConditionFailedError,
 ) (*historyservice.StartWorkflowExecutionResponse, StartOutcome, error) {
 	workflowID := s.request.StartRequest.WorkflowId
@@ -398,11 +396,12 @@ func (s *Starter) resolveDuplicateWorkflowID(
 		currentWorkflowConditionFailed.RunID,
 	)
 
+	newRunID := uuid.NewString()
 	currentExecutionUpdateAction, err := api.ResolveDuplicateWorkflowID(
 		s.shardContext,
 		workflowKey,
 		s.namespace,
-		creationParams.runID,
+		newRunID,
 		currentWorkflowConditionFailed.State,
 		currentWorkflowConditionFailed.Status,
 		currentWorkflowConditionFailed.RequestID,
@@ -424,10 +423,11 @@ func (s *Starter) resolveDuplicateWorkflowID(
 		return nil, NoStart, nil
 	}
 
+	var workflowLease api.WorkflowLease
 	var mutableStateInfo *mutableStateInfo
-	// update current execution and create new execution in one transaction
-	// we already validated that currentWorkflowConditionFailed.RunID is not empty,
-	// so the following update won't try to lock current execution again.
+	// Update current execution and create new execution in one transaction.
+	// We already validated that currentWorkflowConditionFailed.RunID is not empty,
+	// so the following update won't try to lock the current execution again.
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		nil,
@@ -438,19 +438,19 @@ func (s *Starter) resolveDuplicateWorkflowID(
 		),
 		currentExecutionUpdateAction,
 		func() (workflow.Context, workflow.MutableState, error) {
-			workflowLease, err := api.NewWorkflowWithSignal(
+			newMutableState, err := api.NewWorkflowWithSignal(
 				s.shardContext,
 				s.namespace,
 				workflowID,
-				creationParams.runID,
+				newRunID,
 				s.request,
 				nil)
 			if err != nil {
 				return nil, nil, err
 			}
 
-			// apply hook again to new lease
-			if err = beforeCreateHook(workflowLease); err != nil {
+			workflowLease, err = s.createLeaseForWorkflow(s.shardContext, newMutableState)
+			if err != nil {
 				return nil, nil, err
 			}
 
@@ -466,11 +466,15 @@ func (s *Starter) resolveDuplicateWorkflowID(
 		s.shardContext,
 		s.workflowConsistencyChecker,
 	)
+	if workflowLease != nil {
+		workflowLease.GetReleaseFn()(err)
+	}
+
 	switch err {
 	case nil:
 		if !s.requestEagerStart() {
 			return &historyservice.StartWorkflowExecutionResponse{
-				RunId:   creationParams.runID,
+				RunId:   newRunID,
 				Started: true,
 			}, StartNew, nil
 		}
@@ -478,7 +482,7 @@ func (s *Starter) resolveDuplicateWorkflowID(
 		if err != nil {
 			return nil, NoStart, err
 		}
-		resp, err := s.generateResponse(creationParams.runID, mutableStateInfo.workflowTask, events)
+		resp, err := s.generateResponse(newRunID, mutableStateInfo.workflowTask, events)
 		return resp, StartNew, err
 	case consts.ErrWorkflowCompleted:
 		// current workflow already closed

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -406,12 +406,13 @@ func (e *historyEngineImpl) StartWorkflowExecution(
 		e.tokenSerializer,
 		e.persistenceVisibilityMgr,
 		startRequest,
+		api.NewWorkflowLeaseAndContext,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, _, err := starter.Invoke(ctx, startworkflow.BeforeCreateHookNoop)
+	resp, _, err := starter.Invoke(ctx)
 	return resp, err
 }
 

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -5113,7 +5113,6 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 		})
 
 		s.Run("workflow id conflict policy terminate-existing: terminate workflow first, then start and update", func() {
-			s.T().Skip()
 			tv := testvars.New(s.T())
 
 			// start workflow

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -5022,6 +5022,9 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 				_, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startWorkflowReq(tv))
 				s.NoError(err)
 
+				_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv, taskpoller.DrainWorkflowTask)
+				s.NoError(err)
+
 				// update-with-start
 				startReq := startWorkflowReq(tv)
 				startReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
@@ -5055,8 +5058,11 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 				  2 WorkflowTaskScheduled
 				  3 WorkflowTaskStarted
 				  4 WorkflowTaskCompleted
-				  5 WorkflowExecutionUpdateAccepted
-				  6 WorkflowExecutionUpdateCompleted`, s.GetHistory(s.Namespace(), tv.WorkflowExecution()))
+				  5 WorkflowTaskScheduled
+				  6 WorkflowTaskStarted
+				  7 WorkflowTaskCompleted
+				  8 WorkflowExecutionUpdateAccepted
+				  9 WorkflowExecutionUpdateCompleted`, s.GetHistory(s.Namespace(), tv.WorkflowExecution()))
 			})
 
 			s.Run("and reject", func() {
@@ -5064,6 +5070,9 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 
 				// start workflow
 				_, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startWorkflowReq(tv))
+				s.NoError(err)
+
+				_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv, taskpoller.DrainWorkflowTask)
 				s.NoError(err)
 
 				// update-with-start


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Changed how MultiOps integrates with the Workflow Starter.

Specifically, it creates a cached-based, locked workflow context for a workflow start now. The approach before was error-prone and difficult to understand.

## Why?
<!-- Tell your future self why have you made these changes -->

Data race.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
