### PR TITLE
Remove `ms` parameter from UpdateRegistry

### DIFF
--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -116,7 +116,7 @@ func Invoke(
 
 			// Add the Update.
 			// NOTE: UpdateWorkflowAction return value is ignored since ther Starter will always create a WFT.
-			updateReg := workflowLease.GetContext().UpdateRegistry(ctx, nil)
+			updateReg := workflowLease.GetContext().UpdateRegistry(ctx)
 			if _, err := updater.ApplyRequest(ctx, updateReg, ms); err != nil {
 				// Wrapping the error so Update and Start errors can be distinguished later.
 				return nil, updateError{err}
@@ -214,7 +214,7 @@ func updateWorkflow(
 		currentWorkflowLease,
 		func(lease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
 			ms := lease.GetMutableState()
-			updateReg := lease.GetContext().UpdateRegistry(ctx, ms)
+			updateReg := lease.GetContext().UpdateRegistry(ctx)
 			return updater.ApplyRequest(ctx, updateReg, ms)
 		},
 		nil,

--- a/service/history/api/pollupdate/api.go
+++ b/service/history/api/pollupdate/api.go
@@ -67,7 +67,7 @@ func Invoke(
 		release := workflowLease.GetReleaseFn()
 		defer release(nil)
 		wfCtx := workflowLease.GetContext()
-		upd := wfCtx.UpdateRegistry(ctx, nil).Find(ctx, updateRef.UpdateId)
+		upd := wfCtx.UpdateRegistry(ctx).Find(ctx, updateRef.UpdateId)
 		wfKey := wfCtx.GetWorkflowKey()
 		return &wfKey, upd, nil
 	}()

--- a/service/history/api/pollupdate/api_test.go
+++ b/service/history/api/pollupdate/api_test.go
@@ -117,7 +117,7 @@ func TestPollOutcome(t *testing.T) {
 
 	wfCtx := workflow.NewMockContext(mockController)
 	wfCtx.EXPECT().GetWorkflowKey().Return(definition.WorkflowKey{NamespaceID: namespaceId, WorkflowID: workflowId, RunID: runId}).AnyTimes()
-	wfCtx.EXPECT().UpdateRegistry(gomock.Any(), gomock.Any()).Return(reg).AnyTimes()
+	wfCtx.EXPECT().UpdateRegistry(gomock.Any()).Return(reg).AnyTimes()
 
 	apiCtx := mockWorkflowLeaseCtx{
 		GetReleaseFnFn: func() wcache.ReleaseCacheFunc { return func(error) {} },

--- a/service/history/api/reapplyevents/api.go
+++ b/service/history/api/reapplyevents/api.go
@@ -180,7 +180,7 @@ func Invoke(
 			reappliedEvents, err := eventsReapplier.ReapplyEvents(
 				ctx,
 				mutableState,
-				context.UpdateRegistry(ctx, nil),
+				context.UpdateRegistry(ctx),
 				toReapplyEvents,
 				runID,
 			)

--- a/service/history/api/recordworkflowtaskstarted/api.go
+++ b/service/history/api/recordworkflowtaskstarted/api.go
@@ -84,7 +84,7 @@ func Invoke(
 		),
 		func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
 			mutableState := workflowLease.GetMutableState()
-			updateRegistry := workflowLease.GetContext().UpdateRegistry(ctx, nil)
+			updateRegistry := workflowLease.GetContext().UpdateRegistry(ctx)
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, consts.ErrWorkflowCompleted
 			}

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -333,7 +333,7 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 		newMutableState             workflow.MutableState
 		responseMutations           []workflowTaskResponseMutation
 	)
-	updateRegistry := weContext.UpdateRegistry(ctx, nil)
+	updateRegistry := weContext.UpdateRegistry(ctx)
 	// hasBufferedEventsOrMessages indicates if there are any buffered events
 	// or admitted updates which should generate a new workflow task.
 

--- a/service/history/api/respondworkflowtaskcompleted/api_test.go
+++ b/service/history/api/respondworkflowtaskcompleted/api_test.go
@@ -613,7 +613,7 @@ func (s *WorkflowTaskCompletedHandlerSuite) createSentUpdate(tv *testvars.TestVa
 	s.NoError(err)
 
 	// 2. Create update.
-	upd, alreadyExisted, err := wfContext.UpdateRegistry(ctx, nil).FindOrCreate(ctx, tv.UpdateID(updateID))
+	upd, alreadyExisted, err := wfContext.UpdateRegistry(ctx).FindOrCreate(ctx, tv.UpdateID(updateID))
 	s.False(alreadyExisted)
 	s.NoError(err)
 

--- a/service/history/api/update_workflow_util.go
+++ b/service/history/api/update_workflow_util.go
@@ -143,7 +143,7 @@ func UpdateWorkflowWithNew(
 	}
 
 	if postActions.AbortUpdates {
-		workflowLease.GetContext().UpdateRegistry(ctx, nil).Abort(update.AbortReasonWorkflowCompleted)
+		workflowLease.GetContext().UpdateRegistry(ctx).Abort(update.AbortReasonWorkflowCompleted)
 	}
 
 	return nil

--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -108,7 +108,7 @@ func (u *Updater) Invoke(
 		wfKey,
 		func(lease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
 			ms := lease.GetMutableState()
-			updateReg := lease.GetContext().UpdateRegistry(ctx, ms)
+			updateReg := lease.GetContext().UpdateRegistry(ctx)
 			return u.ApplyRequest(ctx, updateReg, ms)
 		},
 		nil,

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -304,7 +304,7 @@ func (r *transactionMgrImpl) backfillWorkflowEventsReapply(
 			if _, err := r.eventsReapplier.ReapplyEvents(
 				ctx,
 				targetWorkflow.GetMutableState(),
-				targetWorkflow.GetContext().UpdateRegistry(ctx, nil),
+				targetWorkflow.GetContext().UpdateRegistry(ctx),
 				totalEvents,
 				targetWorkflow.GetMutableState().GetExecutionState().GetRunId(),
 			); err != nil {

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -181,7 +181,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Open()
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), s.mockShard, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, workflow.TransactionPolicyActive, (*workflow.TransactionPolicy)(nil),
 	).Return(nil)
-	weContext.EXPECT().UpdateRegistry(ctx, nil).Return(updateRegistry)
+	weContext.EXPECT().UpdateRegistry(ctx).Return(updateRegistry)
 	err := s.transactionMgr.BackfillWorkflow(ctx, targetWorkflow, workflowEvents)
 	s.NoError(err)
 	s.True(releaseCalled)

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -249,7 +249,7 @@ func (r *workflowResetterImpl) ResetWorkflow(
 		return err
 	}
 
-	currentWorkflow.GetContext().UpdateRegistry(ctx, nil).Abort(update.AbortReasonWorkflowCompleted)
+	currentWorkflow.GetContext().UpdateRegistry(ctx).Abort(update.AbortReasonWorkflowCompleted)
 
 	return nil
 }

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -664,7 +664,7 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowRunTimeoutTask(
 		if updateErr != nil {
 			return updateErr
 		}
-		weContext.UpdateRegistry(ctx, nil).Abort(update.AbortReasonWorkflowCompleted)
+		weContext.UpdateRegistry(ctx).Abort(update.AbortReasonWorkflowCompleted)
 		return nil
 	}
 
@@ -738,7 +738,7 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowRunTimeoutTask(
 	// A new run was created after the previous run timed out. Running Updates
 	// for this WF are aborted with a retryable error.
 	// Internal server retries will retry the API call, and the Update will be sent to the new run.
-	weContext.UpdateRegistry(ctx, nil).Abort(update.AbortReasonWorkflowContinuing)
+	weContext.UpdateRegistry(ctx).Abort(update.AbortReasonWorkflowContinuing)
 	return nil
 }
 
@@ -776,7 +776,7 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowExecutionTimeoutTask(
 		return updateErr
 	}
 
-	weContext.UpdateRegistry(ctx, nil).Abort(update.AbortReasonWorkflowCompleted)
+	weContext.UpdateRegistry(ctx).Abort(update.AbortReasonWorkflowCompleted)
 	return nil
 }
 

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -152,7 +152,7 @@ type (
 			transactionPolicy TransactionPolicy,
 		) error
 		// TODO (alex-update): move this from workflow context.
-		UpdateRegistry(ctx context.Context, ms MutableState) update.Registry
+		UpdateRegistry(ctx context.Context) update.Registry
 	}
 )
 
@@ -954,26 +954,17 @@ func (c *ContextImpl) RefreshTasks(
 	return c.UpdateWorkflowExecutionAsPassive(ctx, shardContext)
 }
 
-// TODO: remove `fallbackMutableState` parameter again (added since it's not possible to initialize a new Context with a specific MutableState)
-func (c *ContextImpl) UpdateRegistry(ctx context.Context, fallbackMutableState MutableState) update.Registry {
-	ms := c.MutableState
-	if ms == nil {
-		if fallbackMutableState == nil {
-			panic("both c.MutableState and fallbackMutableState are nil")
-		}
-		ms = fallbackMutableState
-	}
-
-	if c.updateRegistry != nil && c.updateRegistry.FailoverVersion() != ms.GetCurrentVersion() {
+func (c *ContextImpl) UpdateRegistry(ctx context.Context) update.Registry {
+	if c.updateRegistry != nil && c.updateRegistry.FailoverVersion() != c.MutableState.GetCurrentVersion() {
 		c.updateRegistry.Clear()
 		c.updateRegistry = nil
 	}
 
 	if c.updateRegistry == nil {
-		nsIDStr := ms.GetNamespaceEntry().ID().String()
+		nsIDStr := c.MutableState.GetNamespaceEntry().ID().String()
 
 		c.updateRegistry = update.NewRegistry(
-			ms,
+			c.MutableState,
 			update.WithLogger(c.logger),
 			update.WithMetrics(c.metricsHandler),
 			update.WithTracerProvider(trace.SpanFromContext(ctx).TracerProvider()),
@@ -1118,7 +1109,7 @@ func (c *ContextImpl) forceTerminateWorkflow(
 	// Abort updates before clearing context.
 	// MS is not persisted yet, but this code is executed only when something
 	// really bad happened with workflow, and it won't make any progress anyway.
-	c.UpdateRegistry(ctx, nil).Abort(update.AbortReasonWorkflowCompleted)
+	c.UpdateRegistry(ctx).Abort(update.AbortReasonWorkflowCompleted)
 
 	// Discard pending changes in MutableState so we can apply terminate state transition
 	c.Clear()

--- a/service/history/workflow/context_mock.go
+++ b/service/history/workflow/context_mock.go
@@ -270,17 +270,17 @@ func (mr *MockContextMockRecorder) Unlock() *gomock.Call {
 }
 
 // UpdateRegistry mocks base method.
-func (m *MockContext) UpdateRegistry(ctx context.Context, ms MutableState) update.Registry {
+func (m *MockContext) UpdateRegistry(ctx context.Context) update.Registry {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRegistry", ctx, ms)
+	ret := m.ctrl.Call(m, "UpdateRegistry", ctx)
 	ret0, _ := ret[0].(update.Registry)
 	return ret0
 }
 
 // UpdateRegistry indicates an expected call of UpdateRegistry.
-func (mr *MockContextMockRecorder) UpdateRegistry(ctx, ms any) *gomock.Call {
+func (mr *MockContextMockRecorder) UpdateRegistry(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRegistry", reflect.TypeOf((*MockContext)(nil).UpdateRegistry), ctx, ms)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRegistry", reflect.TypeOf((*MockContext)(nil).UpdateRegistry), ctx)
 }
 
 // UpdateWorkflowExecutionAsActive mocks base method.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Removes the `fallbackMutableState` from the workflow context's `UpdateRegistry` method.

## Why?
<!-- Tell your future self why have you made these changes -->

Not needed anymore. Once https://github.com/temporalio/temporal/pull/6858 is merged, the MutableState should always be present in the workflow context.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
