### PR TITLE
Remove `Put` cache method

### DIFF
--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -59,14 +59,6 @@ type (
 	ReleaseCacheFunc func(err error)
 
 	Cache interface {
-		Put(
-			shardContext shard.Context,
-			namespaceID namespace.ID,
-			execution *commonpb.WorkflowExecution,
-			workflowCtx workflow.Context,
-			handler metrics.Handler,
-		) (workflow.Context, error)
-
 		GetOrCreateCurrentWorkflowExecution(
 			ctx context.Context,
 			shardContext shard.Context,
@@ -289,24 +281,6 @@ func (c *cacheImpl) GetOrCreateWorkflowExecution(
 	return weCtx, weReleaseFunc, err
 }
 
-func (c *cacheImpl) Put(
-	shardContext shard.Context,
-	namespaceID namespace.ID,
-	execution *commonpb.WorkflowExecution,
-	workflowCtx workflow.Context,
-	handler metrics.Handler,
-) (workflow.Context, error) {
-	cacheKey := makeCacheKey(shardContext, namespaceID, execution)
-	item := &cacheItem{shardId: shardContext.GetShardID(), wfContext: workflowCtx, finalizer: shardContext.GetFinalizer()}
-	existing, err := c.PutIfNotExist(cacheKey, item)
-	if err != nil {
-		metrics.CacheFailures.With(handler).Record(1)
-		return nil, err
-	}
-	//nolint:revive
-	return existing.(*cacheItem).wfContext, nil
-}
-
 func (c *cacheImpl) getOrCreateWorkflowExecutionInternal(
 	ctx context.Context,
 	shardContext shard.Context,
@@ -316,7 +290,10 @@ func (c *cacheImpl) getOrCreateWorkflowExecutionInternal(
 	forceClearContext bool,
 	lockPriority locks.Priority,
 ) (workflow.Context, ReleaseCacheFunc, error) {
-	cacheKey := makeCacheKey(shardContext, namespaceID, execution)
+	cacheKey := Key{
+		WorkflowKey: definition.NewWorkflowKey(namespaceID.String(), execution.GetWorkflowId(), execution.GetRunId()),
+		ShardUUID:   shardContext.GetOwner(),
+	}
 	item, cacheHit := c.Get(cacheKey).(*cacheItem)
 	var workflowCtx workflow.Context
 	if cacheHit {
@@ -332,10 +309,14 @@ func (c *cacheImpl) getOrCreateWorkflowExecutionInternal(
 		)
 
 		var err error
-		workflowCtx, err = c.Put(shardContext, namespaceID, execution, workflowCtx, handler)
+		value := &cacheItem{shardId: shardContext.GetShardID(), wfContext: workflowCtx, finalizer: shardContext.GetFinalizer()}
+		existing, err := c.PutIfNotExist(cacheKey, value)
 		if err != nil {
+			metrics.CacheFailures.With(handler).Record(1)
 			return nil, nil, err
 		}
+		//nolint:revive
+		workflowCtx = existing.(*cacheItem).wfContext
 	}
 
 	if err := c.lockWorkflowExecution(ctx, workflowCtx, cacheKey, lockPriority); err != nil {
@@ -511,17 +492,6 @@ func GetCurrentRunID(
 		return "", err
 	}
 	return resp.RunID, nil
-}
-
-func makeCacheKey(
-	shardContext shard.Context,
-	namespaceID namespace.ID,
-	execution *commonpb.WorkflowExecution,
-) Key {
-	return Key{
-		WorkflowKey: definition.NewWorkflowKey(namespaceID.String(), execution.GetWorkflowId(), execution.GetRunId()),
-		ShardUUID:   shardContext.GetOwner(),
-	}
 }
 
 func (c *cacheItem) CacheSize() int {

--- a/service/history/workflow/cache/cache_mock.go
+++ b/service/history/workflow/cache/cache_mock.go
@@ -39,7 +39,6 @@ import (
 
 	common "go.temporal.io/api/common/v1"
 	locks "go.temporal.io/server/common/locks"
-	metrics "go.temporal.io/server/common/metrics"
 	namespace "go.temporal.io/server/common/namespace"
 	shard "go.temporal.io/server/service/history/shard"
 	workflow "go.temporal.io/server/service/history/workflow"
@@ -98,19 +97,4 @@ func (m *MockCache) GetOrCreateWorkflowExecution(ctx context.Context, shardConte
 func (mr *MockCacheMockRecorder) GetOrCreateWorkflowExecution(ctx, shardContext, namespaceID, execution, lockPriority any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateWorkflowExecution", reflect.TypeOf((*MockCache)(nil).GetOrCreateWorkflowExecution), ctx, shardContext, namespaceID, execution, lockPriority)
-}
-
-// Put mocks base method.
-func (m *MockCache) Put(shardContext shard.Context, namespaceID namespace.ID, execution *common.WorkflowExecution, workflowCtx workflow.Context, handler metrics.Handler) (workflow.Context, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", shardContext, namespaceID, execution, workflowCtx, handler)
-	ret0, _ := ret[0].(workflow.Context)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Put indicates an expected call of Put.
-func (mr *MockCacheMockRecorder) Put(shardContext, namespaceID, execution, workflowCtx, handler any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockCache)(nil).Put), shardContext, namespaceID, execution, workflowCtx, handler)
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Remove `Put` method from workflow cache.

## Why?
<!-- Tell your future self why have you made these changes -->

Not needed anymore after https://github.com/temporalio/temporal/pull/6850.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
