### PR TITLE
Revert "Revert "Reenable flaky tests" (#6813)"

### DIFF
--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -420,7 +420,6 @@ func (t *MatcherTestSuite) TestAvoidForwardingWhenBacklogIsOldButReconsider() {
 }
 
 func (t *MatcherTestSuite) TestBacklogAge() {
-	t.T().Skip("flaky test")
 	t.Equal(emptyBacklogAge, t.rootMatcher.getBacklogAge())
 
 	youngBacklogTask := newInternalTaskFromBacklog(randomTaskInfoWithAge(time.Second), nil)

--- a/tests/describe_task_queue_test.go
+++ b/tests/describe_task_queue_test.go
@@ -91,7 +91,6 @@ func (s *DescribeTaskQueueSuite) TestAddNoTasks_ValidateStats() {
 }
 
 func (s *DescribeTaskQueueSuite) TestAddSingleTask_ValidateStats() {
-	s.T().Skip("flaky test")
 	s.OverrideDynamicConfig(dynamicconfig.MatchingUpdateAckInterval, 5*time.Second)
 	s.RunTestWithMatchingBehavior(func() { s.publishConsumeWorkflowTasksValidateStats(1, true) })
 }

--- a/tests/http_api_test.go
+++ b/tests/http_api_test.go
@@ -329,8 +329,6 @@ func (s *HttpApiTestSuite) TestHTTPHostValidation() {
 }
 
 func (s *HttpApiTestSuite) TestHTTPAPIHeaders() {
-	s.T().Skip("flaky test")
-
 	if s.HttpAPIAddress() == "" {
 		s.T().Skip("HTTP API server not enabled")
 	}

--- a/tests/max_buffered_event_test.go
+++ b/tests/max_buffered_event_test.go
@@ -138,8 +138,6 @@ func (s *MaxBufferedEventSuite) TestMaxBufferedEventsLimit() {
 }
 
 func (s *MaxBufferedEventSuite) TestBufferedEventsMutableStateSizeLimit() {
-	s.T().Skip("flaky test")
-
 	/*
 			This test starts a workflow, and block its workflow task, then sending
 			signals to it which will be buffered. The default max mutable state

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -1049,8 +1049,6 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSyncMatch() {
 }
 
 func (s *VersioningIntegSuite) TestIndependentActivityTaskAssignment_Spooled_VersionedWorkflow() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.independentActivityTaskAssignmentSpooled(true) })
 }
 
@@ -1241,8 +1239,6 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSpooled(versione
 }
 
 func (s *VersioningIntegSuite) TestIndependentActivityTaskAssignment_SyncMatch_VersionedWorkflow() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.independentActivityTaskAssignmentSyncMatch(true) })
 }
 
@@ -1423,8 +1419,6 @@ func (s *VersioningIntegSuite) independentActivityTaskAssignmentSyncMatch(versio
 }
 
 func (s *VersioningIntegSuite) TestWorkflowTaskRedirectInRetryFirstTask() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.testWorkflowTaskRedirectInRetry(true) })
 }
 
@@ -1734,8 +1728,6 @@ func (s *VersioningIntegSuite) TestDispatchUpgradeStopOld() {
 }
 
 func (s *VersioningIntegSuite) TestDispatchUpgradeWait() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.dispatchUpgrade(true, false) })
 }
 
@@ -1837,20 +1829,14 @@ const (
 )
 
 func (s *VersioningIntegSuite) TestDispatchActivityOld() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.dispatchActivity(dontFailActivity, false, false) })
 }
 
 func (s *VersioningIntegSuite) TestDispatchActivityFailOld() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.dispatchActivity(failActivity, false, false) })
 }
 
 func (s *VersioningIntegSuite) TestDispatchActivityTimeoutOld() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.dispatchActivity(timeoutActivity, false, false) })
 }
 
@@ -2604,14 +2590,10 @@ func (s *VersioningIntegSuite) TestDispatchActivityCrossTQFails() {
 }
 
 func (s *VersioningIntegSuite) TestDispatchChildWorkflowOld() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.dispatchChildWorkflow(false, false) })
 }
 
 func (s *VersioningIntegSuite) TestDispatchChildWorkflow() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.dispatchChildWorkflow(true, false) })
 }
 
@@ -3086,8 +3068,6 @@ func (s *VersioningIntegSuite) dispatchQuery(newVersioning bool) {
 }
 
 func (s *VersioningIntegSuite) TestDispatchContinueAsNewOld() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.dispatchContinueAsNew(false, false) })
 }
 
@@ -3250,8 +3230,6 @@ func (s *VersioningIntegSuite) dispatchContinueAsNew(newVersioning bool, crossTq
 }
 
 func (s *VersioningIntegSuite) TestDispatchContinueAsNewUpgradeOld() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.dispatchContinueAsNewUpgrade(false) })
 }
 
@@ -3511,8 +3489,6 @@ func (s *VersioningIntegSuite) dispatchRetryOld() {
 }
 
 func (s *VersioningIntegSuite) TestDispatchRetry() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(s.dispatchRetry)
 }
 
@@ -3604,14 +3580,10 @@ func (s *VersioningIntegSuite) dispatchRetry() {
 }
 
 func (s *VersioningIntegSuite) TestDispatchCronOld() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.dispatchCron(false) })
 }
 
 func (s *VersioningIntegSuite) TestDispatchCron() {
-	s.T().Skip("flaky test")
-
 	s.RunTestWithMatchingBehavior(func() { s.dispatchCron(true) })
 }
 

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -571,8 +571,6 @@ func (s *WorkflowTestSuite) TestCompleteWorkflowTaskAndCreateNewOne() {
 }
 
 func (s *WorkflowTestSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
-	s.T().Skip("flaky test")
-
 	id := "functional-timeouts-workflow-test"
 	wt := "functional-timeouts-workflow-test-type"
 	tl := "functional-timeouts-workflow-test-taskqueue"

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -1784,8 +1784,6 @@ func (s *FunctionalClustersTestSuite) TestTransientWorkflowTaskFailover() {
 }
 
 func (s *FunctionalClustersTestSuite) TestCronWorkflowStartAndFailover() {
-	s.T().Skip("flaky test")
-
 	namespace := "test-cron-workflow-start-and-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.FrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -1880,8 +1878,6 @@ func (s *FunctionalClustersTestSuite) TestCronWorkflowStartAndFailover() {
 }
 
 func (s *FunctionalClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
-	s.T().Skip("flaky test")
-
 	namespace := "test-cron-workflow-complete-and-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.FrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -98,8 +98,6 @@ func (s *NexusStateReplicationSuite) TearDownSuite() {
 // 9. Check that the operation completion triggers a workflow task when we poll on cluster1.
 // 10. Complete the workflow.
 func (s *NexusStateReplicationSuite) TestNexusOperationEventsReplicated() {
-	s.T().Skip("flaky test")
-
 	var callbackToken string
 	var publicCallbackUrl string
 


### PR DESCRIPTION
This reverts commit 5d793621dd40d518e18ae6058c3d3163ff1b63ce.

## Why?

Now that we can rerun failures automatically, we can enable these flaky tests.