### PR TITLE
Trim MultiOperation error message

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -539,6 +539,12 @@ func (wh *WorkflowHandler) ExecuteMultiOperation(
 
 	historyResp, err := wh.historyClient.ExecuteMultiOperation(ctx, historyReq)
 	if err != nil {
+		var multiErr *serviceerror.MultiOperationExecution
+		if errors.As(err, &multiErr) {
+			// Trim error message for end-users.
+			// The per-operation errors are embedded inside the error and unpacked by the SDK.
+			multiErr.Message = "MultiOperation could not be executed."
+		}
 		return nil, err
 	}
 

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -5180,7 +5180,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 			uwsCh := sendUpdateWithStart(testcore.NewContext(), startReq, updateReq)
 			uwsRes := <-uwsCh
 			s.Error(uwsRes.err)
-			s.Contains(uwsRes.err.Error(), "MultiOperation could not be executed")
+			s.Equal("MultiOperation could not be executed.", uwsRes.err.Error())
 			errs := uwsRes.err.(*serviceerror.MultiOperationExecution).OperationErrors()
 			s.Len(errs, 2)
 			s.Contains(errs[0].Error(), "Workflow execution is already running")


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Trim the user-facing MultiOperation error message.

## Why?
<!-- Tell your future self why have you made these changes -->

In https://github.com/temporalio/temporal/pull/6848 I added more error details; but decided while that's helpful for internal debugging (the error message is printed in the logs), I prefer not to expose the fairly noisy/verbose message to customers. They can still find the details inside the error and extract them (which is what the SDKs do).

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Adjusted test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
