### PR TITLE
fix flaky xdc stream based replication test

### DIFF
--- a/tests/xdc/stream_based_replication_test.go
+++ b/tests/xdc/stream_based_replication_test.go
@@ -77,18 +77,17 @@ type (
 )
 
 func TestStreamBasedReplicationTestSuite(t *testing.T) {
-	t.SkipNow() // flaky test (EnableTransitionHistory)
 	for _, tc := range []struct {
 		name                    string
 		enableTransitionHistory bool
 	}{
 		{
-			name:                    "EnableTransitionHistory",
-			enableTransitionHistory: true,
-		},
-		{
 			name:                    "DisableTransitionHistory",
 			enableTransitionHistory: false,
+		},
+		{
+			name:                    "EnableTransitionHistory",
+			enableTransitionHistory: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -171,7 +170,8 @@ func (s *streamBasedReplicationTestSuite) TestReplicateHistoryEvents_ForceReplic
 	var versions []int64
 	if s.enableTransitionHistory {
 		// Use versions for cluster1 (active) so we can update workflows
-		versions = []int64{1, 31, 21, 61, 41, 101, 91, 71, 81}
+		// Use same versions to prevent workflow tasks from being failed due to WORKFLOW_TASK_FAILED_CAUSE_FAILOVER_CLOSE_COMMAND
+		versions = []int64{1, 1, 1, 1, 1, 1, 1, 1, 1}
 	} else {
 		versions = []int64{2, 12, 22, 32, 2, 1, 5, 8, 9}
 	}

--- a/tests/xdc/stream_based_replication_test.go
+++ b/tests/xdc/stream_based_replication_test.go
@@ -38,7 +38,6 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
-	replicationpb "go.temporal.io/api/replication/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -196,39 +195,6 @@ func (s *streamBasedReplicationTestSuite) TestReplicateHistoryEvents_ForceReplic
 	}
 }
 
-func (s *streamBasedReplicationTestSuite) updateNamespace(version int64) error {
-	client1 := s.cluster1.FrontendClient() // active
-	nsResp, err := client1.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
-		Namespace: s.namespaceName,
-	})
-	s.NoError(err)
-
-	for nsResp.GetFailoverVersion() < version {
-		_, err = client1.UpdateNamespace(context.Background(), &workflowservice.UpdateNamespaceRequest{
-			Namespace: s.namespaceName,
-			ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
-				ActiveClusterName: s.clusterNames[1],
-			},
-		})
-		s.NoError(err)
-
-		_, err = client1.UpdateNamespace(context.Background(), &workflowservice.UpdateNamespaceRequest{
-			Namespace: s.namespaceName,
-			ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
-				ActiveClusterName: s.clusterNames[0],
-			},
-		})
-		s.NoError(err)
-
-		nsResp, err = client1.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
-			Namespace: s.namespaceName,
-		})
-		s.NoError(err)
-	}
-
-	return nil
-}
-
 func (s *streamBasedReplicationTestSuite) importTestEvents(
 	historyClient historyservice.HistoryServiceClient,
 	namespaceName namespace.Name,
@@ -251,11 +217,6 @@ func (s *streamBasedReplicationTestSuite) importTestEvents(
 	}
 	var runID string
 	for _, version := range versions {
-		if s.enableTransitionHistory {
-			err := s.updateNamespace(version)
-			s.NoError(err)
-		}
-
 		workflowID := "xdc-stream-replication-test-" + uuid.New()
 		runID = uuid.New()
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix flaky xdc stream based replication test and re-enable it.

## Why?
<!-- Tell your future self why have you made these changes -->
When state-based replication is enabled, if there are workflow tasks in fly and namespace failover version changes, these workflow tasks will be failed. This will generate events and replication tasks.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Unit test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
