### PR TITLE
Fix recycleToken race with lock

### DIFF
--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -326,7 +326,7 @@ func (tm *TaskMatcher) MustOffer(ctx context.Context, task *internalTask, interr
 	// attach the rate limiter's RecycleToken func to the task
 	// so that if the task is later determined to be invalid,
 	// we can recycle the token it used.
-	task.recycleToken = tm.rateLimiter.RecycleToken
+	task.setRecycleToken(tm.rateLimiter.RecycleToken)
 
 	// attempt a match with local poller first. When that
 	// doesn't succeed, try both local match and remote match


### PR DESCRIPTION
## What changed?
Add recycleToken lock to internalTask

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
`go test ./service/matching -count 1 -race -run TestMatcherSuite` previously detected race and failed, now it passes

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
