### PR TITLE
Do not log resource exhausted error by default

### DIFF
--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -391,7 +391,7 @@ func (ti *TelemetryInterceptor) logErrors(
 		return
 	}
 
-	if !logAllErrors && isUserCaused(statusCode) {
+	if !logAllErrors && isRecordingNeeded(statusCode) {
 		return
 	}
 
@@ -408,7 +408,7 @@ func (ti *TelemetryInterceptor) logErrors(
 	ti.logger.Error("service failures", append(logTags, tag.Error(err))...)
 }
 
-func isUserCaused(statusCode codes.Code) bool {
+func isRecordingNeeded(statusCode codes.Code) bool {
 	switch statusCode {
 	case codes.InvalidArgument,
 		codes.AlreadyExists,
@@ -465,7 +465,7 @@ func recordMetrics(metricsHandler metrics.Handler, err error, statusCode codes.C
 		return
 	}
 
-	if !isUserCaused(statusCode) {
+	if !isRecordingNeeded(statusCode) {
 		metrics.ServiceFailures.With(metricsHandler).Record(1)
 	}
 }

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -416,13 +416,13 @@ func isUserCaused(statusCode codes.Code) bool {
 		codes.OutOfRange,
 		codes.PermissionDenied,
 		codes.Unauthenticated,
-		codes.NotFound:
+		codes.NotFound,
+		codes.ResourceExhausted:
 		return true
 	case codes.OK,
 		codes.Canceled,
 		codes.Unknown,
 		codes.DeadlineExceeded,
-		codes.ResourceExhausted,
 		codes.Aborted,
 		codes.Unimplemented,
 		codes.Internal,

--- a/common/rpc/interceptor/telemetry_test.go
+++ b/common/rpc/interceptor/telemetry_test.go
@@ -262,7 +262,7 @@ func TestHandleError(t *testing.T) {
 		{
 			name:                      "resource-exhausted",
 			err:                       serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_UNSPECIFIED, "resource exhausted"),
-			expectLogging:             true,
+			expectLogging:             false,
 			ServiceFailuresCount:      0,
 			ResourceExhaustedCount:    1,
 			ServiceErrorWithTypeCount: 1,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Do not log resource exhausted error by default

## Why?
<!-- Tell your future self why have you made these changes -->
- From our metric data, logging the resource exhausted error consume 2% out of 11.9% cpu for handling a request (StartWorkflowExecution)
- We can still see resource exhausted logs by turning on `system.logAllReqErrors`

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
