### PR TITLE
[Scheduled Actions V2] WIP: top-level Scheduler state machine

### DIFF
--- a/components/scheduler2/core/scheduler.go
+++ b/components/scheduler2/core/scheduler.go
@@ -1,0 +1,171 @@
+package core
+
+import (
+	"fmt"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	schedspb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/service/history/hsm"
+	"go.temporal.io/server/service/worker/scheduler"
+	"google.golang.org/protobuf/proto"
+)
+
+type (
+	// The top-level scheduler state machine is compromised of 3 substate machines:
+	// - Generator: buffers actions according to the schedule specification
+	// - Executor: executes buffered actions
+	// - Backfiller: buffers actions according to requested backfills
+	//
+	// 	A running scheduler will always have exactly one of each of the above substate
+	// machines mounted as nodes within the HSM tree. The top-level	machine itself
+	// remains in a singular running state for its lifetime (all work is done within the
+	// substate machines). The Scheduler state machine is only responsible for creating
+	// the singleton substate machines.
+	Scheduler struct {
+		*schedspb.HsmSchedulerV2State
+
+		// Locally-cached state
+		compiledSpec *scheduler.CompiledSpec
+	}
+
+	// The machine definitions provide serialization/deserialization and type information.
+	machineDefinition struct{}
+)
+
+const (
+	// Unique identifier for top-level scheduler state machine.
+	SchedulerMachineType = "scheduler.SchedulerV2"
+)
+
+var (
+	_ hsm.StateMachine[enumsspb.Scheduler2State] = Scheduler{}
+	_ hsm.StateMachineDefinition                 = &machineDefinition{}
+)
+
+// Registers state machine definitions with the HSM registry. Should be called
+// during dependency injection.
+func RegisterStateMachines(r *hsm.Registry) error {
+	if err := r.RegisterMachine(machineDefinition{}); err != nil {
+		return err
+	}
+	// TODO: add other state machines here
+	return nil
+}
+
+// MachineCollection creates a new typed [statemachines.Collection] for operations.
+func MachineCollection(tree *hsm.Node) hsm.Collection[Scheduler] {
+	return hsm.NewCollection[Scheduler](tree, SchedulerMachineType)
+}
+
+func (s Scheduler) State() enumsspb.Scheduler2State {
+	return s.HsmSchedulerV2State.State
+}
+
+func (s Scheduler) SetState(state enumsspb.Scheduler2State) {
+	s.HsmSchedulerV2State.State = state
+}
+
+func (s Scheduler) RegenerateTasks(node *hsm.Node) ([]hsm.Task, error) {
+	return nil, nil
+}
+
+func (machineDefinition) Type() string {
+	return SchedulerMachineType
+}
+
+func (machineDefinition) Serialize(state any) ([]byte, error) {
+	if state, ok := state.(Scheduler); ok {
+		return proto.Marshal(state.HsmSchedulerV2State)
+	}
+	return nil, fmt.Errorf("invalid scheduler state provided: %v", state)
+}
+
+func (machineDefinition) Deserialize(body []byte) (any, error) {
+	state := &schedspb.HsmSchedulerV2State{}
+	return Scheduler{
+		HsmSchedulerV2State: state,
+		compiledSpec:        nil,
+	}, proto.Unmarshal(body, state)
+}
+
+// Returns:
+//
+// 0 when states are equal
+// 1 when a is newer than b
+// -1 when b is newer than a
+func (machineDefinition) CompareState(a any, b any) (int, error) {
+	s1, ok := a.(Scheduler)
+	if !ok {
+		return 0, fmt.Errorf("%w: expected state1 to be a Scheduler instance, got %v", hsm.ErrIncompatibleType, s1)
+	}
+	s2, ok := a.(Scheduler)
+	if !ok {
+		return 0, fmt.Errorf("%w: expected state1 to be a Scheduler instance, got %v", hsm.ErrIncompatibleType, s2)
+	}
+
+	if s1.State() > s2.State() {
+		return 1, nil
+	} else if s1.State() < s2.State() {
+		return -1, nil
+	}
+
+	return 0, nil
+}
+
+// Returns true when the Scheduler should allow scheduled actions to be taken.
+//
+// When decrement is true, the schedule's state's `RemainingActions` counter
+// is decremented and the conflict token is bumped.
+func (s Scheduler) CanTakeScheduledAction(decrement bool) bool {
+	// If paused, don't do anything
+	if s.Schedule.State.Paused {
+		return false
+	}
+
+	// If unlimited actions, allow
+	if !s.Schedule.State.LimitedActions {
+		return true
+	}
+
+	// Otherwise check and decrement limit
+	if s.Schedule.State.RemainingActions > 0 {
+		if decrement {
+			s.Schedule.State.RemainingActions--
+			s.ConflictToken++
+		}
+		return true
+	}
+
+	// No actions left
+	return false
+}
+
+func (s Scheduler) CompiledSpec(specBuilder *scheduler.SpecBuilder) (*scheduler.CompiledSpec, error) {
+	// cache compiled spec
+	if s.compiledSpec == nil {
+		cspec, err := specBuilder.NewCompiledSpec(s.Schedule.Spec)
+		if err != nil {
+			return nil, err
+		}
+		s.compiledSpec = cspec
+	}
+
+	return s.compiledSpec, nil
+}
+
+func (s Scheduler) JitterSeed() string {
+	return fmt.Sprintf("%s-%s", s.NamespaceId, s.ScheduleId)
+}
+
+func (s Scheduler) Identity() string {
+	return fmt.Sprintf("temporal-scheduler-%s-%s", s.Namespace, s.ScheduleId)
+}
+
+func (s Scheduler) OverlapPolicy() enumspb.ScheduleOverlapPolicy {
+	policy := s.Schedule.Policies.OverlapPolicy
+	if policy == enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED {
+		policy = enumspb.SCHEDULE_OVERLAP_POLICY_SKIP
+	}
+	return policy
+}

--- a/components/scheduler2/scheduler.go
+++ b/components/scheduler2/scheduler.go
@@ -201,6 +201,13 @@ func (s Scheduler) overlapPolicy() enumspb.ScheduleOverlapPolicy {
 	return policy
 }
 
+func (s Scheduler) resolveOverlapPolicy(overlapPolicy enumspb.ScheduleOverlapPolicy) enumspb.ScheduleOverlapPolicy {
+	if overlapPolicy == enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED {
+		overlapPolicy = s.overlapPolicy()
+	}
+	return overlapPolicy
+}
+
 // validateCachedState clears cached fields whenever the Scheduler's
 // ConflictToken doesn't match its cacheConflictToken field. Validation is only
 // as effective as the Scheduler's backing persisted state is up-to-date.

--- a/components/scheduler2/scheduler.go
+++ b/components/scheduler2/scheduler.go
@@ -41,7 +41,7 @@ type (
 
 const (
 	// Unique identifier for top-level scheduler state machine.
-	SchedulerMachineType = "scheduler.SchedulerV2"
+	SchedulerMachineType = "scheduler.Scheduler"
 
 	// The top-level scheduler only has a single, constant state.
 	SchedulerMachineStateRunning SchedulerMachineState = 0
@@ -100,11 +100,6 @@ func RegisterStateMachines(r *hsm.Registry) error {
 	}
 	// TODO: add other state machines here
 	return nil
-}
-
-// MachineCollection creates a new typed [statemachines.Collection] for operations.
-func MachineCollection(tree *hsm.Node) hsm.Collection[Scheduler] {
-	return hsm.NewCollection[Scheduler](tree, SchedulerMachineType)
 }
 
 func (s Scheduler) State() SchedulerMachineState {

--- a/components/scheduler2/scheduler_test.go
+++ b/components/scheduler2/scheduler_test.go
@@ -1,0 +1,97 @@
+package scheduler2_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	apischedule "go.temporal.io/api/schedule/v1"
+	srvschedule "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/components/scheduler2"
+	v1scheduler "go.temporal.io/server/service/worker/scheduler"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestUseScheduledActionPeek(t *testing.T) {
+	const initialRemainingActions int64 = 10
+	const initialConflictToken int64 = 0
+	decrement := false
+
+	// Starts paused, with unlimited actions.
+	scheduler := scheduler2.Scheduler{
+		SchedulerInternal: &srvschedule.SchedulerInternal{
+			ConflictToken: initialConflictToken,
+			Schedule: &apischedule.Schedule{
+				State: &apischedule.ScheduleState{
+					Paused:           true,
+					LimitedActions:   false,
+					RemainingActions: initialRemainingActions,
+				},
+			},
+		},
+	}
+
+	// Paused schedules should deny and never mutate.
+	require.False(t, scheduler.UseScheduledAction(decrement))
+	require.Equal(t, initialRemainingActions, scheduler.Schedule.State.RemainingActions)
+	require.Equal(t, initialConflictToken, scheduler.ConflictToken)
+
+	// Running schedules with unlimited actions should allow and never mutate.
+	scheduler.Schedule.State.Paused = false
+	require.True(t, scheduler.UseScheduledAction(decrement))
+	require.Equal(t, initialRemainingActions, scheduler.Schedule.State.RemainingActions)
+	require.Equal(t, initialConflictToken, scheduler.ConflictToken)
+
+	// Limit the schedule's actions, and check that we can peek the value.
+	scheduler.Schedule.State.LimitedActions = true
+	decrement = false
+	require.True(t, scheduler.UseScheduledAction(decrement))
+	require.Equal(t, initialRemainingActions, scheduler.Schedule.State.RemainingActions)
+	require.Equal(t, initialConflictToken, scheduler.ConflictToken)
+
+	// When not peeking, we should mutate RemainingActions and ConflictToken.
+	decrement = true
+	require.True(t, scheduler.UseScheduledAction(decrement))
+	require.Equal(t, initialRemainingActions-1, scheduler.Schedule.State.RemainingActions)
+	require.NotEqual(t, initialConflictToken, scheduler.ConflictToken)
+
+	// False when out of remaining actions.
+	scheduler.Schedule.State.RemainingActions = 0
+	oldConflictToken := scheduler.ConflictToken
+	require.False(t, scheduler.UseScheduledAction(decrement))
+	require.Equal(t, oldConflictToken, scheduler.ConflictToken)
+}
+
+func TestCompiledSpec(t *testing.T) {
+	const initialConflictToken int64 = 0
+	initialInterval := apischedule.IntervalSpec{
+		Interval: durationpb.New(time.Minute),
+		Phase:    durationpb.New(0),
+	}
+
+	scheduler := scheduler2.Scheduler{
+		SchedulerInternal: &srvschedule.SchedulerInternal{
+			ConflictToken: initialConflictToken,
+			Schedule: &apischedule.Schedule{
+				Spec: &apischedule.ScheduleSpec{
+					Interval: []*apischedule.IntervalSpec{&initialInterval},
+				},
+			},
+		},
+	}
+	specBuilder := v1scheduler.NewSpecBuilder()
+
+	// Test that the same compiled spec is returned between invocations.
+	spec, err := scheduler.CompiledSpec(specBuilder)
+	require.NoError(t, err)
+
+	spec2, err := scheduler.CompiledSpec(specBuilder)
+	require.NoError(t, err)
+	require.Equal(t, spec, spec2)
+
+	// Test that an update to conflict token will recompile the spec.
+	scheduler.UpdateConflictToken()
+	spec3, err := scheduler.CompiledSpec(specBuilder)
+	require.NoError(t, err)
+	require.NotSame(t, spec, spec3)
+}

--- a/components/scheduler2/scheduler_test.go
+++ b/components/scheduler2/scheduler_test.go
@@ -1,4 +1,4 @@
-package scheduler2_test
+package scheduler2
 
 import (
 	"testing"
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 	apischedule "go.temporal.io/api/schedule/v1"
 	srvschedule "go.temporal.io/server/api/schedule/v1"
-	"go.temporal.io/server/components/scheduler2"
 	v1scheduler "go.temporal.io/server/service/worker/scheduler"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -18,7 +17,7 @@ func TestUseScheduledActionPeek(t *testing.T) {
 	decrement := false
 
 	// Starts paused, with unlimited actions.
-	scheduler := scheduler2.Scheduler{
+	scheduler := Scheduler{
 		SchedulerInternal: &srvschedule.SchedulerInternal{
 			ConflictToken: initialConflictToken,
 			Schedule: &apischedule.Schedule{
@@ -32,33 +31,33 @@ func TestUseScheduledActionPeek(t *testing.T) {
 	}
 
 	// Paused schedules should deny and never mutate.
-	require.False(t, scheduler.UseScheduledAction(decrement))
+	require.False(t, scheduler.useScheduledAction(decrement))
 	require.Equal(t, initialRemainingActions, scheduler.Schedule.State.RemainingActions)
 	require.Equal(t, initialConflictToken, scheduler.ConflictToken)
 
 	// Running schedules with unlimited actions should allow and never mutate.
 	scheduler.Schedule.State.Paused = false
-	require.True(t, scheduler.UseScheduledAction(decrement))
+	require.True(t, scheduler.useScheduledAction(decrement))
 	require.Equal(t, initialRemainingActions, scheduler.Schedule.State.RemainingActions)
 	require.Equal(t, initialConflictToken, scheduler.ConflictToken)
 
 	// Limit the schedule's actions, and check that we can peek the value.
 	scheduler.Schedule.State.LimitedActions = true
 	decrement = false
-	require.True(t, scheduler.UseScheduledAction(decrement))
+	require.True(t, scheduler.useScheduledAction(decrement))
 	require.Equal(t, initialRemainingActions, scheduler.Schedule.State.RemainingActions)
 	require.Equal(t, initialConflictToken, scheduler.ConflictToken)
 
 	// When not peeking, we should mutate RemainingActions and ConflictToken.
 	decrement = true
-	require.True(t, scheduler.UseScheduledAction(decrement))
+	require.True(t, scheduler.useScheduledAction(decrement))
 	require.Equal(t, initialRemainingActions-1, scheduler.Schedule.State.RemainingActions)
 	require.NotEqual(t, initialConflictToken, scheduler.ConflictToken)
 
 	// False when out of remaining actions.
 	scheduler.Schedule.State.RemainingActions = 0
 	oldConflictToken := scheduler.ConflictToken
-	require.False(t, scheduler.UseScheduledAction(decrement))
+	require.False(t, scheduler.useScheduledAction(decrement))
 	require.Equal(t, oldConflictToken, scheduler.ConflictToken)
 }
 
@@ -69,7 +68,7 @@ func TestCompiledSpec(t *testing.T) {
 		Phase:    durationpb.New(0),
 	}
 
-	scheduler := scheduler2.Scheduler{
+	scheduler := Scheduler{
 		SchedulerInternal: &srvschedule.SchedulerInternal{
 			ConflictToken: initialConflictToken,
 			Schedule: &apischedule.Schedule{
@@ -82,16 +81,16 @@ func TestCompiledSpec(t *testing.T) {
 	specBuilder := v1scheduler.NewSpecBuilder()
 
 	// Test that the same compiled spec is returned between invocations.
-	spec, err := scheduler.CompiledSpec(specBuilder)
+	spec, err := scheduler.getCompiledSpec(specBuilder)
 	require.NoError(t, err)
 
-	spec2, err := scheduler.CompiledSpec(specBuilder)
+	spec2, err := scheduler.getCompiledSpec(specBuilder)
 	require.NoError(t, err)
 	require.Equal(t, spec, spec2)
 
 	// Test that an update to conflict token will recompile the spec.
-	scheduler.UpdateConflictToken()
-	spec3, err := scheduler.CompiledSpec(specBuilder)
+	scheduler.updateConflictToken()
+	spec3, err := scheduler.getCompiledSpec(specBuilder)
 	require.NoError(t, err)
 	require.NotSame(t, spec, spec3)
 }


### PR DESCRIPTION
**Based on #6903**

## What changed?
- Added the WIP top-level Scheduler state machine

## Why?
- The top-level scheduler is responsible for some of the schedule's internal state, and for parenting the other sub state machines. It does not have any tasks of its own. 

## How did you test it?
- New tests, `go test -v`

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
