### PR TITLE
Make ChildWorkflowExecution inherit versioning override of parent

### DIFF
--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -854,6 +854,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		rootExecutionInfo,
 		inheritedBuildId,
 		initiatedEvent.GetUserMetadata(),
+		mutableState.GetExecutionInfo().GetVersioningInfo().GetVersioningOverride(),
 	)
 	if err != nil {
 		t.logger.Debug("Failed to start child workflow execution", tag.Error(err))
@@ -1344,6 +1345,7 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 	rootExecutionInfo *workflowspb.RootExecutionInfo,
 	inheritedBuildId string,
 	userMetadata *sdkpb.UserMetadata,
+	inheritedOverride *workflowpb.VersioningOverride,
 ) (string, *clockspb.VectorClock, error) {
 	request := common.CreateHistoryStartWorkflowRequest(
 		task.TargetNamespaceID,
@@ -1366,6 +1368,7 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 			Memo:                  attributes.Memo,
 			SearchAttributes:      attributes.SearchAttributes,
 			UserMetadata:          userMetadata,
+			VersioningOverride:    inheritedOverride,
 		},
 		&workflowspb.ParentExecutionInfo{
 			NamespaceId: task.NamespaceID,


### PR DESCRIPTION
## What changed?
Pass VersioningOverride of parent to `StartWorkflowExecutionRequest` for child workflow

## Why?
Because if a user is overriding a workflow's deployment, we expect that they want to override to apply to children too, since user is likely doing a canary test or debugging something.

## How did you test it?
Working on a test. I expect all existing child workflow execution tests to pass with no change.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
