### PR TITLE
Fix Update-with-Start invalid response

### DIFF
--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -50,7 +50,9 @@ var (
 )
 
 type (
-	updateError  struct{ error }
+	// updateError is a wrapper to distinguish an update error from a start error.
+	updateError struct{ error }
+	// noStartError is a sentinel error that indicates no workflow start occurred.
 	noStartError struct{ startworkflow.StartOutcome }
 )
 

--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -270,18 +270,15 @@ func startAndUpdateWorkflow(
 	updater *updateworkflow.Updater,
 ) (*historyservice.ExecuteMultiOperationResponse, error) {
 	startResp, startOutcome, err := starter.Invoke(ctx)
-
-	switch startOutcome {
-	case startworkflow.StartErr:
+	if err != nil {
 		// An update error occurred.
 		if errors.As(err, &updateError{}) {
 			return nil, newMultiOpError(multiOpAbortedErr, err)
 		}
 		// A start error occurred.
 		return nil, newMultiOpError(err, multiOpAbortedErr)
-	case startworkflow.StartNew:
-		// The workflow was started, as expected.
-	case startworkflow.StartDeduped, startworkflow.StartReused:
+	}
+	if startOutcome != startworkflow.StartNew {
 		// The workflow was not started.
 		// Aborting since the update has not been applied.
 		return nil, &noStartError{startOutcome}

--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -263,7 +263,7 @@ func updateWorkflow(
 	}, nil
 }
 
-// NOTE: Returns a `startDedupedOrReusedErr` if the start was unexpectedly reused/deduped.
+// NOTE: Returns a `noStartError` if the start was unexpectedly reused/deduped.
 func startAndUpdateWorkflow(
 	ctx context.Context,
 	starter *startworkflow.Starter,

--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -213,7 +213,8 @@ func Invoke(
 		//
 		// The best way forward is to exit and retry from the top.
 		// By returning an Unavailable service error, the entire MultiOperation will be retried.
-		return nil, newMultiOpError(serviceerror.NewUnavailable("Workflow could not be started as it is already running"), multiOpAbortedErr)
+		return nil, newMultiOpError(serviceerror.NewUnavailable(
+			fmt.Sprintf("Workflow could not be started as it is already running: %v", outcome)), multiOpAbortedErr)
 	}
 	return resp, err
 }

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -686,3 +686,18 @@ func (s *Starter) generateResponse(
 		},
 	}, nil
 }
+
+func (s StartOutcome) String() string {
+	switch s {
+	case NoStart:
+		return "NoStart"
+	case StartNew:
+		return "StartNew"
+	case StartReused:
+		return "StartReused"
+	case StartDeduped:
+		return "StartDeduped"
+	default:
+		return "Unknown"
+	}
+}

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -66,7 +66,7 @@ const (
 )
 
 const (
-	NoStart StartOutcome = iota
+	StartErr StartOutcome = iota
 	StartNew
 	StartReused
 	StartDeduped
@@ -192,12 +192,12 @@ func (s *Starter) Invoke(
 ) (resp *historyservice.StartWorkflowExecutionResponse, startOutcome StartOutcome, retError error) {
 	request := s.request.StartRequest
 	if err := s.prepare(ctx); err != nil {
-		return nil, NoStart, err
+		return nil, StartErr, err
 	}
 
 	creationParams, err := s.prepareNewWorkflow(request.GetWorkflowId())
 	if err != nil {
-		return nil, NoStart, err
+		return nil, StartErr, err
 	}
 	defer func() {
 		creationParams.workflowLease.GetReleaseFn()(retError)
@@ -205,7 +205,7 @@ func (s *Starter) Invoke(
 
 	currentExecutionLock, err := s.lockCurrentWorkflowExecution(ctx)
 	if err != nil {
-		return nil, NoStart, err
+		return nil, StartErr, err
 	}
 	defer func() {
 		currentExecutionLock(retError)
@@ -219,7 +219,7 @@ func (s *Starter) Invoke(
 			return s.handleConflict(ctx, creationParams, currentWorkflowConditionFailedError)
 		}
 
-		return nil, NoStart, err
+		return nil, StartErr, err
 	}
 
 	resp, err = s.generateResponse(
@@ -320,18 +320,18 @@ func (s *Starter) handleConflict(
 	}
 
 	if err := s.verifyNamespaceActive(creationParams, currentWorkflowConditionFailed); err != nil {
-		return nil, NoStart, err
+		return nil, StartErr, err
 	}
 
 	response, startOutcome, err := s.resolveDuplicateWorkflowID(ctx, currentWorkflowConditionFailed)
 	if err != nil {
-		return nil, NoStart, err
+		return nil, StartErr, err
 	} else if response != nil {
 		return response, startOutcome, nil
 	}
 
 	if err := s.createAsCurrent(ctx, creationParams, currentWorkflowConditionFailed); err != nil {
-		return nil, NoStart, err
+		return nil, StartErr, err
 	}
 
 	resp, err := s.generateResponse(
@@ -422,9 +422,9 @@ func (s *Starter) resolveDuplicateWorkflowID(
 		}
 		return resp, StartReused, nil
 	case err != nil:
-		return nil, NoStart, err
+		return nil, StartErr, err
 	case currentExecutionUpdateAction == nil:
-		return nil, NoStart, nil
+		return nil, StartErr, nil
 	}
 
 	var workflowLease api.WorkflowLease
@@ -484,16 +484,16 @@ func (s *Starter) resolveDuplicateWorkflowID(
 		}
 		events, err := s.getWorkflowHistory(ctx, mutableStateInfo)
 		if err != nil {
-			return nil, NoStart, err
+			return nil, StartErr, err
 		}
 		resp, err := s.generateResponse(newRunID, mutableStateInfo.workflowTask, events)
 		return resp, StartNew, err
 	case consts.ErrWorkflowCompleted:
 		// current workflow already closed
 		// fallthough to the logic for only creating the new workflow below
-		return nil, NoStart, nil
+		return nil, StartErr, nil
 	default:
-		return nil, NoStart, err
+		return nil, StartErr, err
 	}
 }
 
@@ -689,8 +689,8 @@ func (s *Starter) generateResponse(
 
 func (s StartOutcome) String() string {
 	switch s {
-	case NoStart:
-		return "NoStart"
+	case StartErr:
+		return "StartErr"
 	case StartNew:
 		return "StartNew"
 	case StartReused:


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Return `serviceerror.Unavailable` when the start of an Update-with-Start attempt is _deduped_ (same as for reused).

## Why?
<!-- Tell your future self why have you made these changes -->

Otherwise, an invalid response is returned in this case (ie `nil`).

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

I don't know how to write _reliable_ functional test for this. A unit test is also difficult since that would require some mocking which is not available.

I crafted a test that demonstrates the fix is working as intended, but it relies on a hack: https://github.com/temporalio/temporal/compare/main...stephanos:temporal:uws-race-fix-test#diff-f5e0cf22c1120ffc0815f192fe6eca5ef9c52cb3b2eba52926bfd733c9f5af27R5255

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
