### PR TITLE
Nexus callback and task validation fixes

### DIFF
--- a/components/callbacks/executors.go
+++ b/components/callbacks/executors.go
@@ -58,37 +58,65 @@ func RegisterExecutor(
 	)
 }
 
-type (
-	TaskExecutorOptions struct {
-		fx.In
+type TaskExecutorOptions struct {
+	fx.In
 
-		Config             *Config
-		NamespaceRegistry  namespace.Registry
-		MetricsHandler     metrics.Handler
-		Logger             log.Logger
-		HTTPCallerProvider HTTPCallerProvider
-		HistoryClient      resource.HistoryClient
-	}
+	Config             *Config
+	NamespaceRegistry  namespace.Registry
+	MetricsHandler     metrics.Handler
+	Logger             log.Logger
+	HTTPCallerProvider HTTPCallerProvider
+	HistoryClient      resource.HistoryClient
+}
 
-	taskExecutor struct {
-		TaskExecutorOptions
-	}
+type taskExecutor struct {
+	TaskExecutorOptions
+}
 
-	invocationResult int
+// invocationResult is a marker for the callbackInvokable.Invoke result to indicate to the executor how to handle the
+// invocation outcome.
+type invocationResult interface {
+	error() error
+}
 
-	callbackInvokable interface {
-		// Invoke executes the callback logic and returns a result, and the error to be logged in the state machine.
-		Invoke(ctx context.Context, ns *namespace.Namespace, e taskExecutor, task InvocationTask) (invocationResult, error)
-		// WrapError provides each variant the opportunity to return a different error up the call stack than the one logged.
-		WrapError(result invocationResult, err error) error
-	}
-)
+// invocationResultFail marks an invocation as successful.
+type invocationResultOK struct{}
 
-const (
-	ok invocationResult = iota
-	retry
-	failed
-)
+func (invocationResultOK) mustImplementInvocationResult() {}
+
+func (invocationResultOK) error() error {
+	return nil
+}
+
+// invocationResultFail marks an invocation as permanently failed.
+type invocationResultFail struct {
+	err error
+}
+
+func (invocationResultFail) mustImplementInvocationResult() {}
+
+func (r invocationResultFail) error() error {
+	return r.err
+}
+
+// invocationResultFail marks an invocation as failed with the intent to retry.
+type invocationResultRetry struct {
+	err error
+}
+
+func (invocationResultRetry) mustImplementInvocationResult() {}
+
+func (r invocationResultRetry) error() error {
+	return r.err
+}
+
+type callbackInvokable interface {
+	// Invoke executes the callback logic and returns the invocation result.
+	Invoke(ctx context.Context, ns *namespace.Namespace, e taskExecutor, task InvocationTask) invocationResult
+	// WrapError provides each variant the opportunity to wrap the error returned by the task executor for, e.g. to
+	// trigger the circuit breaker.
+	WrapError(result invocationResult, err error) error
+}
 
 func (e taskExecutor) executeInvocationTask(
 	ctx context.Context,
@@ -112,13 +140,9 @@ func (e taskExecutor) executeInvocationTask(
 	)
 	defer cancel()
 
-	result, err := invokable.Invoke(callCtx, ns, e, task)
-
-	saveErr := e.saveResult(callCtx, env, ref, result, err)
-	if saveErr != nil {
-		return saveErr
-	}
-	return invokable.WrapError(result, err)
+	result := invokable.Invoke(callCtx, ns, e, task)
+	saveErr := e.saveResult(callCtx, env, ref, result)
+	return invokable.WrapError(result, saveErr)
 }
 
 func (e taskExecutor) loadInvocationArgs(
@@ -174,25 +198,24 @@ func (e taskExecutor) saveResult(
 	env hsm.Environment,
 	ref hsm.Ref,
 	result invocationResult,
-	callErr error,
 ) error {
 	return env.Access(ctx, ref, hsm.AccessWrite, func(node *hsm.Node) error {
 		return hsm.MachineTransition(node, func(callback Callback) (hsm.TransitionOutput, error) {
-			switch result {
-			case ok:
+			switch result.(type) {
+			case invocationResultOK:
 				return TransitionSucceeded.Apply(callback, EventSucceeded{
 					Time: env.Now(),
 				})
-			case retry:
+			case invocationResultRetry:
 				return TransitionAttemptFailed.Apply(callback, EventAttemptFailed{
 					Time:        env.Now(),
-					Err:         callErr,
+					Err:         result.error(),
 					RetryPolicy: e.Config.RetryPolicy(),
 				})
-			case failed:
+			case invocationResultFail:
 				return TransitionFailed.Apply(callback, EventFailed{
 					Time: env.Now(),
-					Err:  callErr,
+					Err:  result.error(),
 				})
 			default:
 				return hsm.TransitionOutput{}, queues.NewUnprocessableTaskError(fmt.Sprintf("unrecognized callback result %v", result))

--- a/components/callbacks/executors.go
+++ b/components/callbacks/executors.go
@@ -76,6 +76,8 @@ type taskExecutor struct {
 // invocationResult is a marker for the callbackInvokable.Invoke result to indicate to the executor how to handle the
 // invocation outcome.
 type invocationResult interface {
+	// A marker for all possible implementations.
+	mustImplementInvocationResult()
 	error() error
 }
 
@@ -99,7 +101,7 @@ func (r invocationResultFail) error() error {
 	return r.err
 }
 
-// invocationResultFail marks an invocation as failed with the intent to retry.
+// invocationResultRetry marks an invocation as failed with the intent to retry.
 type invocationResultRetry struct {
 	err error
 }

--- a/components/callbacks/hsm_invocation.go
+++ b/components/callbacks/hsm_invocation.go
@@ -77,11 +77,11 @@ func (s hsmInvocation) WrapError(invocationResult, error) error {
 	return nil
 }
 
-func (s hsmInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e taskExecutor, task InvocationTask) (invocationResult, error) {
+func (s hsmInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e taskExecutor, task InvocationTask) invocationResult {
 	// TODO(Tianyu): Will this ever be too big for an RPC call?
 	callbackArgSerialized, err := s.callbackArg.Marshal()
 	if err != nil {
-		return failed, fmt.Errorf("failed to serialize completion event: %v", err)
+		return invocationResultFail{fmt.Errorf("failed to serialize completion event: %v", err)}
 	}
 
 	request := historyservice.InvokeStateMachineMethodRequest{
@@ -107,9 +107,9 @@ func (s hsmInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e ta
 	if err != nil {
 		e.Logger.Error("Callback request failed", tag.Error(err))
 		if isRetryableRpcResponse(err) {
-			return retry, err
+			return invocationResultRetry{err}
 		}
-		return failed, err
+		return invocationResultFail{err}
 	}
-	return ok, nil
+	return invocationResultOK{}
 }

--- a/components/callbacks/hsm_invocation.go
+++ b/components/callbacks/hsm_invocation.go
@@ -81,7 +81,7 @@ func (s hsmInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e ta
 	// TODO(Tianyu): Will this ever be too big for an RPC call?
 	callbackArgSerialized, err := s.callbackArg.Marshal()
 	if err != nil {
-		return invocationResultFail{fmt.Errorf("failed to serialize completion event: %v", err)}
+		return invocationResultFail{fmt.Errorf("failed to serialize completion event: %w", err)}
 	}
 
 	request := historyservice.InvokeStateMachineMethodRequest{

--- a/components/callbacks/tasks.go
+++ b/components/callbacks/tasks.go
@@ -23,12 +23,10 @@
 package callbacks
 
 import (
-	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/hsm"
 )
 
@@ -62,19 +60,7 @@ func (t InvocationTask) Deadline() time.Time {
 }
 
 func (InvocationTask) Validate(ref *persistencespb.StateMachineRef, node *hsm.Node) error {
-	cb, err := hsm.MachineData[Callback](node)
-	if err != nil {
-		return err
-	}
-	if cb.State() != enumsspb.CALLBACK_STATE_SCHEDULED {
-		return fmt.Errorf(
-			"%w: %w: expected a machine in SCHEDULED state, got %v",
-			consts.ErrStaleReference,
-			hsm.ErrInvalidTransition,
-			cb.State(),
-		)
-	}
-	return nil
+	return hsm.ValidateState[enumsspb.CallbackState, Callback](node, enumsspb.CALLBACK_STATE_SCHEDULED)
 }
 
 type InvocationTaskSerializer struct{}
@@ -106,19 +92,7 @@ func (BackoffTask) Destination() string {
 }
 
 func (BackoffTask) Validate(ref *persistencespb.StateMachineRef, node *hsm.Node) error {
-	cb, err := hsm.MachineData[Callback](node)
-	if err != nil {
-		return err
-	}
-	if cb.State() != enumsspb.CALLBACK_STATE_BACKING_OFF {
-		return fmt.Errorf(
-			"%w: %w: expected a machine in BACKING_OFF state, got %v",
-			consts.ErrStaleReference,
-			hsm.ErrInvalidTransition,
-			cb.State(),
-		)
-	}
-	return nil
+	return hsm.ValidateState[enumsspb.CallbackState, Callback](node, enumsspb.CALLBACK_STATE_BACKING_OFF)
 }
 
 type BackoffTaskSerializer struct{}

--- a/components/nexusoperations/tasks.go
+++ b/components/nexusoperations/tasks.go
@@ -111,18 +111,7 @@ func (InvocationTask) Validate(ref *persistencespb.StateMachineRef, node *hsm.No
 	if err := node.CheckRunning(); err != nil {
 		return err
 	}
-	op, err := hsm.MachineData[Operation](node)
-	if err != nil {
-		return err
-	}
-	if op.State() != enumsspb.NEXUS_OPERATION_STATE_SCHEDULED {
-		return fmt.Errorf(
-			"%w: operation is not in Scheduled state, current state: %v",
-			consts.ErrStaleReference,
-			op.State(),
-		)
-	}
-	return nil
+	return hsm.ValidateState[enumsspb.NexusOperationState, Operation](node, enumsspb.NEXUS_OPERATION_STATE_SCHEDULED)
 }
 
 type InvocationTaskSerializer struct{}
@@ -157,18 +146,7 @@ func (t BackoffTask) Validate(_ *persistencespb.StateMachineRef, node *hsm.Node)
 	if err := node.CheckRunning(); err != nil {
 		return err
 	}
-	op, err := hsm.MachineData[Operation](node)
-	if err != nil {
-		return err
-	}
-	if op.State() != enumsspb.NEXUS_OPERATION_STATE_BACKING_OFF {
-		return fmt.Errorf(
-			"%w: operation is not in BackingOff state, current state: %v",
-			consts.ErrStaleReference,
-			op.State(),
-		)
-	}
-	return nil
+	return hsm.ValidateState[enumsspb.NexusOperationState, Operation](node, enumsspb.NEXUS_OPERATION_STATE_BACKING_OFF)
 }
 
 type BackoffTaskSerializer struct{}
@@ -200,19 +178,10 @@ func (t CancelationTask) Destination() string {
 }
 
 func (CancelationTask) Validate(ref *persistencespb.StateMachineRef, node *hsm.Node) error {
-	c, err := hsm.MachineData[Cancelation](node)
-	if err != nil {
+	if err := node.CheckRunning(); err != nil {
 		return err
 	}
-	if c.State() != enumspb.NEXUS_OPERATION_CANCELLATION_STATE_SCHEDULED {
-		return fmt.Errorf(
-			"%w: %w: expected a machine in SCHEDULED state, got %v",
-			consts.ErrStaleReference,
-			hsm.ErrInvalidTransition,
-			c.State(),
-		)
-	}
-	return node.CheckRunning()
+	return hsm.ValidateState[enumspb.NexusOperationCancellationState, Cancelation](node, enumspb.NEXUS_OPERATION_CANCELLATION_STATE_SCHEDULED)
 }
 
 type CancelationTaskSerializer struct{}
@@ -244,19 +213,10 @@ func (CancelationBackoffTask) Destination() string {
 }
 
 func (CancelationBackoffTask) Validate(ref *persistencespb.StateMachineRef, node *hsm.Node) error {
-	c, err := hsm.MachineData[Cancelation](node)
-	if err != nil {
+	if err := node.CheckRunning(); err != nil {
 		return err
 	}
-	if c.State() != enumspb.NEXUS_OPERATION_CANCELLATION_STATE_BACKING_OFF {
-		return fmt.Errorf(
-			"%w: %w: expected a machine in BACKING_OFF state, got %v",
-			consts.ErrStaleReference,
-			hsm.ErrInvalidTransition,
-			c.State(),
-		)
-	}
-	return node.CheckRunning()
+	return hsm.ValidateState[enumspb.NexusOperationCancellationState, Cancelation](node, enumspb.NEXUS_OPERATION_CANCELLATION_STATE_BACKING_OFF)
 }
 
 type CancelationBackoffTaskSerializer struct{}

--- a/service/history/hsm/tasks.go
+++ b/service/history/hsm/tasks.go
@@ -82,3 +82,22 @@ func ValidateNotTransitioned(ref *persistencespb.StateMachineRef, node *Node) er
 	}
 	return nil
 }
+
+// ValidateState returns a [consts.ErrStaleReference] if the machine is not in the expected state.
+func ValidateState[S comparable, T StateMachine[S]](node *Node, expected S) error {
+	cb, err := MachineData[T](node)
+	if err != nil {
+		return err
+	}
+	if cb.State() != expected {
+		return fmt.Errorf(
+			"%w: %w: expected a %s machine in %v state, got %v",
+			consts.ErrStaleReference,
+			ErrInvalidTransition,
+			node.Key.ID,
+			expected,
+			cb.State(),
+		)
+	}
+	return nil
+}

--- a/service/history/hsm/tasks.go
+++ b/service/history/hsm/tasks.go
@@ -78,7 +78,7 @@ type TaskSerializer interface {
 // generated.
 func ValidateNotTransitioned(ref *persistencespb.StateMachineRef, node *Node) error {
 	if ref.MachineTransitionCount != node.InternalRepr().TransitionCount {
-		return fmt.Errorf("%w: state machine transitions != ref transitions", consts.ErrStaleReference)
+		return fmt.Errorf("%w: state machine transitions (%d) != ref transitions (%d)", consts.ErrStaleReference, node.InternalRepr().TransitionCount, ref.MachineTransitionCount)
 	}
 	return nil
 }

--- a/service/history/statemachine_environment_test.go
+++ b/service/history/statemachine_environment_test.go
@@ -241,17 +241,6 @@ func TestValidateStateMachineRef(t *testing.T) {
 			},
 		},
 		{
-			name:                    "WithoutTransitionHistory/MachineTransitionInequality",
-			enableTransitionHistory: false,
-			mutateRef: func(ref *hsm.Ref) {
-				ref.StateMachineRef.MachineTransitionCount++
-			},
-			mutateNode: func(node *hsm.Node) {},
-			assertOutcome: func(t *testing.T, err error) {
-				require.ErrorIs(t, err, consts.ErrStaleReference)
-			},
-		},
-		{
 			name:                    "WithTransitionHistory/Valid",
 			enableTransitionHistory: true,
 			mutateRef: func(ref *hsm.Ref) {
@@ -269,42 +258,6 @@ func TestValidateStateMachineRef(t *testing.T) {
 			mutateNode: func(node *hsm.Node) {},
 			assertOutcome: func(t *testing.T, err error) {
 				require.NoError(t, err)
-			},
-		},
-		{
-			name:                    "WithoutTransitionHistory/NodeRebuilt/MachineTransitionInequality",
-			enableTransitionHistory: true,
-			mutateRef: func(ref *hsm.Ref) {
-				// this validates we fallback to the validation logic without transition history
-				ref.StateMachineRef.MachineTransitionCount++
-			},
-			mutateNode: func(node *hsm.Node) {
-				initialVersionedTransition := node.InternalRepr().InitialVersionedTransition
-				node.InternalRepr().InitialVersionedTransition = &persistencespb.VersionedTransition{
-					NamespaceFailoverVersion: initialVersionedTransition.NamespaceFailoverVersion,
-					TransitionCount:          0, // transition history disabled when re-creating the node
-				}
-			},
-			assertOutcome: func(t *testing.T, err error) {
-				require.ErrorIs(t, err, consts.ErrStaleReference)
-			},
-		},
-		{
-			name:                    "WithoutTransitionHistory/NodeTransitioned/MachineTransitionInequality",
-			enableTransitionHistory: true,
-			mutateRef: func(ref *hsm.Ref) {
-				// this validates we fallback to the validation logic without transition history
-				ref.StateMachineRef.MachineTransitionCount++
-			},
-			mutateNode: func(node *hsm.Node) {
-				lastUpdateVersionedTransition := node.InternalRepr().LastUpdateVersionedTransition
-				node.InternalRepr().InitialVersionedTransition = &persistencespb.VersionedTransition{
-					NamespaceFailoverVersion: lastUpdateVersionedTransition.NamespaceFailoverVersion,
-					TransitionCount:          0, // transition history disabled when node transitioned.
-				}
-			},
-			assertOutcome: func(t *testing.T, err error) {
-				require.ErrorIs(t, err, consts.ErrStaleReference)
 			},
 		},
 	}


### PR DESCRIPTION
## What changed?

- Fixed the callback executor to not fail a task on retryable error (a regression introduced while refactoring to support HSM callbacks)
- No longer use `ValidateNotTransitioned` in task validation logic. We can deprecate the `transition_count` field on the state machine node proto after this.

## Why?

The first fix is a simple bug fix, the second change is for unblocking the state replication efforts.

## How did you test it?

Leveraged existing tests.