### PR TITLE
Fix Update-with-Start for closed workflow

### DIFF
--- a/service/history/api/create_workflow_util.go
+++ b/service/history/api/create_workflow_util.go
@@ -59,7 +59,7 @@ type (
 		RunID            string
 		LastWriteVersion int64
 	}
-	CreateLeaseFunc func(shard.Context, workflow.MutableState) (WorkflowLease, error)
+	CreateLeaseFunc func(WorkflowLease, shard.Context, workflow.MutableState) (WorkflowLease, error)
 )
 
 func NewWorkflowWithSignal(
@@ -170,9 +170,14 @@ func NewWorkflowWithSignal(
 
 // NOTE: must implement CreateLeaseFunc.
 func NewWorkflowLeaseAndContext(
+	existingLease WorkflowLease,
 	shardCtx shard.Context,
 	ms workflow.MutableState,
 ) (WorkflowLease, error) {
+	// TODO(stephanos): remove this hack
+	if existingLease != nil {
+		return existingLease, nil
+	}
 	return NewWorkflowLease(
 		workflow.NewContext(
 			shardCtx.GetConfig(),

--- a/service/history/api/create_workflow_util.go
+++ b/service/history/api/create_workflow_util.go
@@ -59,7 +59,7 @@ type (
 		RunID            string
 		LastWriteVersion int64
 	}
-	CreateLeaseFunc func(WorkflowLease, shard.Context, workflow.MutableState) (WorkflowLease, error)
+	CreateOrUpdateLeaseFunc func(WorkflowLease, shard.Context, workflow.MutableState) (WorkflowLease, error)
 )
 
 func NewWorkflowWithSignal(
@@ -168,7 +168,7 @@ func NewWorkflowWithSignal(
 	return newMutableState, nil
 }
 
-// NOTE: must implement CreateLeaseFunc.
+// NOTE: must implement CreateOrUpdateLeaseFunc.
 func NewWorkflowLeaseAndContext(
 	existingLease WorkflowLease,
 	shardCtx shard.Context,

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -101,7 +101,7 @@ func startAndSignalWorkflow(
 		return "", false, err
 	}
 
-	newWorkflowLease, err := api.NewWorkflowLeaseAndContext(shard, newMutableState)
+	newWorkflowLease, err := api.NewWorkflowLeaseAndContext(nil, shard, newMutableState)
 	if err != nil {
 		return "", false, err
 	}

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -80,7 +80,7 @@ type Starter struct {
 	visibilityManager          manager.VisibilityManager
 	request                    *historyservice.StartWorkflowExecutionRequest
 	namespace                  *namespace.Namespace
-	createOrUpdateLeaseFn      api.CreateLeaseFunc
+	createOrUpdateLeaseFn      api.CreateOrUpdateLeaseFunc
 }
 
 // creationParams is a container for all information obtained from creating the uncommitted execution.
@@ -109,7 +109,7 @@ func NewStarter(
 	tokenSerializer common.TaskTokenSerializer,
 	visibilityManager manager.VisibilityManager,
 	request *historyservice.StartWorkflowExecutionRequest,
-	createLeaseFn api.CreateLeaseFunc,
+	createLeaseFn api.CreateOrUpdateLeaseFunc,
 ) (*Starter, error) {
 	namespaceEntry, err := api.GetActiveNamespace(shardContext, namespace.ID(request.GetNamespaceId()))
 	if err != nil {

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -5183,7 +5183,8 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 			s.Equal("MultiOperation could not be executed.", uwsRes.err.Error())
 			errs := uwsRes.err.(*serviceerror.MultiOperationExecution).OperationErrors()
 			s.Len(errs, 2)
-			s.Contains(errs[0].Error(), "Workflow execution is already running")
+			var alreadyStartedErr *serviceerror.WorkflowExecutionAlreadyStarted
+			s.ErrorAs(errs[0], &alreadyStartedErr)
 			s.Equal("Operation was aborted.", errs[1].Error())
 		})
 
@@ -5229,6 +5230,92 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 					s.Equal(uwsRes1.response.Responses[1].GetUpdateWorkflow().Outcome.String(), pollRes.Outcome.String())
 				})
 			}
+		})
+	})
+
+	s.Run("workflow is closed", func() {
+
+		s.Run("workflow id reuse policy allow-duplicate", func() {
+			tv := testvars.New(s.T())
+
+			// start and terminate workflow
+			_, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startWorkflowReq(tv))
+			s.NoError(err)
+
+			_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv, taskpoller.DrainWorkflowTask)
+			s.NoError(err)
+
+			_, err = s.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(),
+				&workflowservice.TerminateWorkflowExecutionRequest{
+					Namespace:         s.Namespace(),
+					WorkflowExecution: tv.WorkflowExecution(),
+					Reason:            tv.Any().String(),
+				})
+			s.NoError(err)
+
+			// update-with-start
+			startReq := startWorkflowReq(tv)
+			startReq.WorkflowIdReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
+			updateReq := s.updateWorkflowRequest(tv,
+				&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED}, "1")
+			uwsCh := sendUpdateWithStart(testcore.NewContext(), startReq, updateReq)
+
+			_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv,
+				func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+					return &workflowservice.RespondWorkflowTaskCompletedRequest{
+						Messages: s.UpdateAcceptCompleteMessages(tv, task.Messages[0], "1"),
+					}, nil
+				})
+			s.NoError(err)
+
+			uwsRes := <-uwsCh
+			s.NoError(uwsRes.err)
+			startResp := uwsRes.response.Responses[0].GetStartWorkflow()
+			updateRep := uwsRes.response.Responses[1].GetUpdateWorkflow()
+			s.True(startResp.Started)
+			s.EqualValues("success-result-of-"+tv.UpdateID("1"), testcore.DecodeString(s.T(), updateRep.GetOutcome().GetSuccess()))
+
+			// poll update to ensure same outcome is returned
+			pollRes, err := s.pollUpdate(tv, "1",
+				&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
+			s.Nil(err)
+			s.Equal(updateRep.Outcome.String(), pollRes.Outcome.String())
+		})
+
+		s.Run("workflow id reuse policy reject-duplicate", func() {
+			tv := testvars.New(s.T())
+
+			// start and terminate workflow
+			_, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startWorkflowReq(tv))
+			s.NoError(err)
+
+			_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv, taskpoller.DrainWorkflowTask)
+			s.NoError(err)
+
+			_, err = s.FrontendClient().TerminateWorkflowExecution(testcore.NewContext(),
+				&workflowservice.TerminateWorkflowExecutionRequest{
+					Namespace:         s.Namespace(),
+					WorkflowExecution: tv.WorkflowExecution(),
+					Reason:            tv.Any().String(),
+				})
+			s.NoError(err)
+
+			// update-with-start
+			startReq := startWorkflowReq(tv)
+			startReq.WorkflowIdReusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
+			updateReq := s.updateWorkflowRequest(tv,
+				&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED}, "1")
+			uwsCh := sendUpdateWithStart(testcore.NewContext(), startReq, updateReq)
+
+			uwsRes := <-uwsCh
+			s.Error(uwsRes.err)
+			s.Equal("MultiOperation could not be executed.", uwsRes.err.Error())
+			errs := uwsRes.err.(*serviceerror.MultiOperationExecution).OperationErrors()
+			s.Len(errs, 2)
+			s.Contains(errs[0].Error(), "Workflow execution already finished")
+			var alreadyStartedErr *serviceerror.WorkflowExecutionAlreadyStarted
+			s.ErrorAs(errs[0], &alreadyStartedErr)
+			s.Equal("Operation was aborted.", errs[1].Error())
 		})
 	})
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Fixed bug where UwS does not work for a closed workflow even though the reuse policy is `ALLOW_DUPLICATE`.

## Why?
<!-- Tell your future self why have you made these changes -->

Bug.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Added new tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

I kept the changes to the non-UwS path to an _absolute_ minimum. I don't believe it changes the non-UwS behavior in any way.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
