### PR TITLE
Deployment clinet to Retry on multi-operation errors

### DIFF
--- a/service/worker/deployment/deployment_client.go
+++ b/service/worker/deployment/deployment_client.go
@@ -687,6 +687,10 @@ func (d *DeploymentClientImpl) updateWithStart(
 		// successful but un-completed responses.
 		res, err := d.historyClient.ExecuteMultiOperation(ctx, multiOpReq)
 		if err != nil {
+			var multiErr *serviceerror.MultiOperationExecution
+			if errors.As(err, &multiErr) {
+				return errRetry
+			}
 			return err
 		}
 

--- a/service/worker/deployment/deployment_client.go
+++ b/service/worker/deployment/deployment_client.go
@@ -40,6 +40,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -679,7 +680,20 @@ func (d *DeploymentClientImpl) updateWithStart(
 	}
 
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
-	isRetryable := func(err error) bool { return errors.Is(err, errRetry) }
+	isRetryable := func(err error) bool {
+		if errors.Is(err, errRetry) {
+			return true
+		}
+		var multiErr *serviceerror.MultiOperationExecution
+		if errors.As(err, &multiErr) {
+			for _, e := range multiErr.OperationErrors() {
+				if common.IsServiceClientTransientError(e) {
+					return true
+				}
+			}
+		}
+		return false
+	}
 	var outcome *updatepb.Outcome
 
 	err := backoff.ThrottleRetryContext(ctx, func(ctx context.Context) error {
@@ -687,10 +701,6 @@ func (d *DeploymentClientImpl) updateWithStart(
 		// successful but un-completed responses.
 		res, err := d.historyClient.ExecuteMultiOperation(ctx, multiOpReq)
 		if err != nil {
-			var multiErr *serviceerror.MultiOperationExecution
-			if errors.As(err, &multiErr) {
-				return errRetry
-			}
 			return err
 		}
 

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -250,7 +250,6 @@ func (s *Versioning3Suite) testUnpinnedWorkflow(sticky bool) {
 			s.NotNil(task)
 			return respondActivity(), nil
 		})
-	//s.waitForDeploymentDataPropagation(tv, tqTypeAct)
 
 	s.setCurrentDeployment(d)
 	s.waitForDeploymentDataPropagation(tv, tqTypeWf, tqTypeAct)

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -184,9 +184,6 @@ func (s *Versioning3Suite) testWorkflowWithPinnedOverride(sticky bool) {
 			s.NotNil(task)
 			return respondWftWithActivities(tv, tv, sticky, vbUnpinned, "5"), nil
 		})
-	// TODO (shahab): remove the waits once the following error is handled properly.
-	// "MultiOperation could not be executed: Start failed: Workflow was not started: StartReused"
-	s.waitForDeploymentDataPropagation(tv, tqTypeWf)
 
 	actCompleted := make(chan interface{})
 	s.pollActivityAndHandle(tv, actCompleted,
@@ -194,7 +191,6 @@ func (s *Versioning3Suite) testWorkflowWithPinnedOverride(sticky bool) {
 			s.NotNil(task)
 			return respondActivity(), nil
 		})
-	s.waitForDeploymentDataPropagation(tv, tqTypeAct)
 
 	override := makePinnedOverride(tv.Deployment())
 	we := s.startWorkflow(tv, override)
@@ -247,9 +243,6 @@ func (s *Versioning3Suite) testUnpinnedWorkflow(sticky bool) {
 			s.verifyWorkflowVersioning(tv, vbUnspecified, nil, nil, transitionTo(d))
 			return respondWftWithActivities(tv, tv, sticky, vbUnpinned, "5"), nil
 		})
-	// TODO (shahab): remove the waits once the following error is handled properly.
-	// "MultiOperation could not be executed: Start failed: Workflow was not started: StartReused"
-	s.waitForDeploymentDataPropagation(tv, tqTypeWf)
 
 	actCompleted := make(chan interface{})
 	s.pollActivityAndHandle(tv, actCompleted,
@@ -257,7 +250,7 @@ func (s *Versioning3Suite) testUnpinnedWorkflow(sticky bool) {
 			s.NotNil(task)
 			return respondActivity(), nil
 		})
-	s.waitForDeploymentDataPropagation(tv, tqTypeAct)
+	//s.waitForDeploymentDataPropagation(tv, tqTypeAct)
 
 	s.setCurrentDeployment(d)
 	s.waitForDeploymentDataPropagation(tv, tqTypeWf, tqTypeAct)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Deployment client retries on multi-operation errors.

## Why?
<!-- Tell your future self why have you made these changes -->
Errors such as "MultiOperation could not be executed: Start failed: Workflow was not started: StartReused" are expected when there are concurrent pollers, and retry should fix them. We don't want to fail user's poll due to these errors.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Modified existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
