### PR TITLE
Fix Update-with-Start serviceerrors

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -342,12 +342,12 @@ func IsServiceHandlerRetryableError(err error) bool {
 		return false
 	}
 
-	switch t := err.(type) {
+	switch err := err.(type) {
 	case *serviceerror.Internal,
 		*serviceerror.Unavailable:
 		return true
 	case *serviceerror.MultiOperationExecution:
-		for _, opErr := range t.OperationErrors() {
+		for _, opErr := range err.OperationErrors() {
 			if IsServiceHandlerRetryableError(opErr) {
 				return true
 			}

--- a/common/util.go
+++ b/common/util.go
@@ -348,7 +348,7 @@ func IsServiceHandlerRetryableError(err error) bool {
 		return true
 	case *serviceerror.MultiOperationExecution:
 		for _, opErr := range err.OperationErrors() {
-			if IsServiceHandlerRetryableError(opErr) {
+			if opErr != nil && IsServiceHandlerRetryableError(opErr) {
 				return true
 			}
 		}

--- a/common/util.go
+++ b/common/util.go
@@ -342,10 +342,16 @@ func IsServiceHandlerRetryableError(err error) bool {
 		return false
 	}
 
-	switch err.(type) {
+	switch t := err.(type) {
 	case *serviceerror.Internal,
 		*serviceerror.Unavailable:
 		return true
+	case *serviceerror.MultiOperationExecution:
+		for _, opErr := range t.OperationErrors() {
+			if IsServiceHandlerRetryableError(opErr) {
+				return true
+			}
+		}
 	}
 
 	return false

--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -192,7 +192,7 @@ func Invoke(
 		case enumspb.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED:
 			// ... fail since this policy is invalid
 			currentWorkflowLease.GetReleaseFn()(nil) // nil since nothing was modified
-			return nil, serviceerror.NewUnimplemented("unhandled workflow id conflict policy: unspecified")
+			return nil, serviceerror.NewInvalidArgument("unhandled workflow id conflict policy: unspecified")
 		}
 	}
 

--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -66,12 +66,12 @@ func Invoke(
 	matchingClient matchingservice.MatchingServiceClient,
 ) (*historyservice.ExecuteMultiOperationResponse, error) {
 	if len(req.Operations) != 2 {
-		return nil, serviceerror.NewInternal("expected exactly 2 operations")
+		return nil, serviceerror.NewInvalidArgument("expected exactly 2 operations")
 	}
 
 	updateReq := req.Operations[1].GetUpdateWorkflow()
 	if updateReq == nil {
-		return nil, serviceerror.NewInternal("expected second operation to be Update Workflow")
+		return nil, serviceerror.NewInvalidArgument("expected second operation to be Update Workflow")
 	}
 	updater := updateworkflow.NewUpdater(
 		shardContext,
@@ -82,7 +82,7 @@ func Invoke(
 
 	startReq := req.Operations[0].GetStartWorkflow()
 	if startReq == nil {
-		return nil, serviceerror.NewInternal("expected first operation to be Start Workflow")
+		return nil, serviceerror.NewInvalidArgument("expected first operation to be Start Workflow")
 	}
 	starter, err := startworkflow.NewStarter(
 		shardContext,
@@ -192,7 +192,7 @@ func Invoke(
 		case enumspb.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED:
 			// ... fail since this policy is invalid
 			currentWorkflowLease.GetReleaseFn()(nil) // nil since nothing was modified
-			return nil, serviceerror.NewInternal("unhandled workflow id conflict policy: unspecified")
+			return nil, serviceerror.NewUnimplemented("unhandled workflow id conflict policy: unspecified")
 		}
 	}
 

--- a/service/worker/deployment/deployment_client.go
+++ b/service/worker/deployment/deployment_client.go
@@ -40,7 +40,6 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -681,18 +680,7 @@ func (d *DeploymentClientImpl) updateWithStart(
 
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
-		if errors.Is(err, errRetry) {
-			return true
-		}
-		var multiErr *serviceerror.MultiOperationExecution
-		if errors.As(err, &multiErr) {
-			for _, e := range multiErr.OperationErrors() {
-				if common.IsServiceClientTransientError(e) {
-					return true
-				}
-			}
-		}
-		return false
+		return errors.Is(err, errRetry)
 	}
 	var outcome *updatepb.Outcome
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Changing client and handler behavior to retry MultiOperations if it contains an operation that itself is retryable.

## Why?
<!-- Tell your future self why have you made these changes -->

There are transient issues that require a retry; and should not be returned to the client immediately as-is.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

MultiOperations are never nested anywhere; so there's no real threat of endless loops.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
