### PR TITLE
Not reapply cancellation on reset

### DIFF
--- a/service/history/ndc/events_reapplier.go
+++ b/service/history/ndc/events_reapplier.go
@@ -81,7 +81,7 @@ func (r *EventsReapplierImpl) ReapplyEvents(
 	if !ms.IsWorkflowExecutionRunning() {
 		return nil, serviceerror.NewInternal("unable to reapply events to closed workflow.")
 	}
-	reappliedEvents, err := reapplyEvents(ctx, ms, updateRegistry, r.stateMachineRegistry, historyEvents, nil, runID)
+	reappliedEvents, err := reapplyEvents(ctx, ms, updateRegistry, r.stateMachineRegistry, historyEvents, nil, runID, false)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -784,7 +784,7 @@ func (r *workflowResetterImpl) reapplyEvents(
 	// When reapplying events during WorkflowReset, we do not check for conflicting update IDs (they are not possible,
 	// since the workflow was in a consistent state before reset), and we do not perform deduplication (because we never
 	// did, before the refactoring that unified two code paths; see comment below.)
-	return reapplyEvents(ctx, mutableState, nil, r.shardContext.StateMachineRegistry(), events, resetReapplyExcludeTypes, "")
+	return reapplyEvents(ctx, mutableState, nil, r.shardContext.StateMachineRegistry(), events, resetReapplyExcludeTypes, "", true)
 }
 
 func reapplyEvents(
@@ -795,6 +795,7 @@ func reapplyEvents(
 	events []*historypb.HistoryEvent,
 	resetReapplyExcludeTypes map[enumspb.ResetReapplyExcludeType]struct{},
 	runIdForDeduplication string,
+	isReset bool,
 ) ([]*historypb.HistoryEvent, error) {
 	// TODO (dan): This implementation is the result of unifying two previous implementations, one of which did
 	// deduplication. Can we always/never do this deduplication, or must it be decided by the caller?
@@ -807,7 +808,6 @@ func reapplyEvents(
 	}
 	_, excludeSignal := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL]
 	_, excludeUpdate := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE]
-	_, excludeCancelRequest := resetReapplyExcludeTypes[enumspb.RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST]
 	var reappliedEvents []*historypb.HistoryEvent
 	for _, event := range events {
 		switch event.GetEventType() {
@@ -871,7 +871,7 @@ func reapplyEvents(
 			}
 			reappliedEvents = append(reappliedEvents, event)
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED:
-			if excludeCancelRequest || isDuplicate(event) {
+			if isReset || isDuplicate(event) {
 				continue
 			}
 			if mutableState.IsCancelRequested() {

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -925,7 +925,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 
 	for _, tc := range testcases {
 		for _, event := range events {
-			switch event.GetEventType() {
+			switch event.GetEventType() { // nolint:exhaustive
 			case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
 				attr := event.GetWorkflowExecutionSignaledEventAttributes()
 				ms.EXPECT().AddWorkflowExecutionSignaled(

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -905,61 +905,81 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 			},
 		},
 	}
-	events := []*historypb.HistoryEvent{event1, event2, event3, event4, event5, event6, event7}
+	events := []*historypb.HistoryEvent{event1, event2, event3, event4, event5, event6, event7, event8}
+
+	testcases := []struct {
+		name    string
+		isReset bool
+	}{
+		{
+			name:    "reset",
+			isReset: true,
+		},
+		{
+			name:    "not reset",
+			isReset: false,
+		},
+	}
 
 	ms := workflow.NewMockMutableState(s.controller)
 
-	for _, event := range events {
-		switch event.GetEventType() {
-		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
-			attr := event.GetWorkflowExecutionSignaledEventAttributes()
-			ms.EXPECT().AddWorkflowExecutionSignaled(
-				attr.GetSignalName(),
-				attr.GetInput(),
-				attr.GetIdentity(),
-				attr.GetHeader(),
-				event.Links,
-			).Return(&historypb.HistoryEvent{}, nil)
-		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED:
-			attr := event.GetWorkflowExecutionUpdateAdmittedEventAttributes()
-			ms.EXPECT().AddWorkflowExecutionUpdateAdmittedEvent(
-				attr.GetRequest(),
-				enumspb.UPDATE_ADMITTED_EVENT_ORIGIN_UNSPECIFIED,
-			).Return(&historypb.HistoryEvent{}, nil)
-		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED:
-			attr := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
-			ms.EXPECT().AddWorkflowExecutionUpdateAdmittedEvent(
-				attr.GetAcceptedRequest(),
-				enumspb.UPDATE_ADMITTED_EVENT_ORIGIN_REAPPLY,
-			).Return(&historypb.HistoryEvent{}, nil)
-		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED:
-			attr := event.GetWorkflowExecutionCancelRequestedEventAttributes()
-			ms.EXPECT().IsCancelRequested().Return(false)
-			ms.EXPECT().AddWorkflowExecutionCancelRequestedEvent(
-				&historyservice.RequestCancelWorkflowExecutionRequest{
-					CancelRequest: &workflowservice.RequestCancelWorkflowExecutionRequest{
-						Reason:   attr.GetCause(),
-						Identity: attr.GetIdentity(),
-						Links:    event.Links,
-					},
-					ExternalInitiatedEventId:  attr.GetExternalInitiatedEventId(),
-					ExternalWorkflowExecution: attr.GetExternalWorkflowExecution(),
-				},
-			).Return(&historypb.HistoryEvent{}, nil)
+	for _, tc := range testcases {
+		for _, event := range events {
+			switch event.GetEventType() {
+			case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
+				attr := event.GetWorkflowExecutionSignaledEventAttributes()
+				ms.EXPECT().AddWorkflowExecutionSignaled(
+					attr.GetSignalName(),
+					attr.GetInput(),
+					attr.GetIdentity(),
+					attr.GetHeader(),
+					event.Links,
+				).Return(&historypb.HistoryEvent{}, nil)
+			case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED:
+				attr := event.GetWorkflowExecutionUpdateAdmittedEventAttributes()
+				ms.EXPECT().AddWorkflowExecutionUpdateAdmittedEvent(
+					attr.GetRequest(),
+					enumspb.UPDATE_ADMITTED_EVENT_ORIGIN_UNSPECIFIED,
+				).Return(&historypb.HistoryEvent{}, nil)
+			case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED:
+				attr := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
+				ms.EXPECT().AddWorkflowExecutionUpdateAdmittedEvent(
+					attr.GetAcceptedRequest(),
+					enumspb.UPDATE_ADMITTED_EVENT_ORIGIN_REAPPLY,
+				).Return(&historypb.HistoryEvent{}, nil)
+			case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED:
+				if !tc.isReset {
+					attr := event.GetWorkflowExecutionCancelRequestedEventAttributes()
+					ms.EXPECT().IsCancelRequested().Return(false)
+					ms.EXPECT().AddWorkflowExecutionCancelRequestedEvent(
+						&historyservice.RequestCancelWorkflowExecutionRequest{
+							CancelRequest: &workflowservice.RequestCancelWorkflowExecutionRequest{
+								Reason:   attr.GetCause(),
+								Identity: attr.GetIdentity(),
+								Links:    event.Links,
+							},
+							ExternalInitiatedEventId:  attr.GetExternalInitiatedEventId(),
+							ExternalWorkflowExecution: attr.GetExternalWorkflowExecution(),
+						},
+					).Return(&historypb.HistoryEvent{}, nil)
+				}
+			}
 		}
+
+		events = append(events, event8)
+		if !tc.isReset {
+			ms.EXPECT().IsCancelRequested().Return(true)
+		}
+
+		smReg := hsm.NewRegistry()
+		s.NoError(workflow.RegisterStateMachine(smReg))
+		root, err := hsm.NewRoot(smReg, workflow.StateMachineType, nil, make(map[string]*persistencespb.StateMachineMap), nil)
+		s.NoError(err)
+		ms.EXPECT().HSM().Return(root).AnyTimes()
+
+		_, err = reapplyEvents(context.Background(), ms, nil, smReg, events, nil, "", tc.isReset)
+		s.NoError(err)
 	}
-
-	events = append(events, event8)
-	ms.EXPECT().IsCancelRequested().Return(true)
-
-	smReg := hsm.NewRegistry()
-	s.NoError(workflow.RegisterStateMachine(smReg))
-	root, err := hsm.NewRoot(smReg, workflow.StateMachineType, nil, make(map[string]*persistencespb.StateMachineMap), nil)
-	s.NoError(err)
-	ms.EXPECT().HSM().Return(root).AnyTimes()
-
-	_, err = reapplyEvents(context.Background(), ms, nil, smReg, events, nil, "")
-	s.NoError(err)
 }
 
 func (s *workflowResetterSuite) TestReapplyEvents_Excludes() {
@@ -1004,17 +1024,7 @@ func (s *workflowResetterSuite) TestReapplyEvents_Excludes() {
 		EventId:   106,
 		EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED,
 	}
-	event7 := &historypb.HistoryEvent{
-		EventId:   107,
-		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED,
-		Attributes: &historypb.HistoryEvent_WorkflowExecutionCancelRequestedEventAttributes{
-			WorkflowExecutionCancelRequestedEventAttributes: &historypb.WorkflowExecutionCancelRequestedEventAttributes{
-				Cause:    testRequestReason,
-				Identity: testIdentity,
-			},
-		},
-	}
-	events := []*historypb.HistoryEvent{event1, event2, event3, event4, event5, event6, event7}
+	events := []*historypb.HistoryEvent{event1, event2, event3, event4, event5, event6}
 
 	ms := workflow.NewMockMutableState(s.controller)
 	// Assert that none of these following methods are invoked.
@@ -1031,12 +1041,26 @@ func (s *workflowResetterSuite) TestReapplyEvents_Excludes() {
 	ms.EXPECT().HSM().Return(root).AnyTimes()
 
 	excludes := map[enumspb.ResetReapplyExcludeType]struct{}{
-		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL:         {},
-		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE:         {},
-		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS:          {},
-		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_CANCEL_REQUEST: {},
+		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_SIGNAL: {},
+		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_UPDATE: {},
+		enumspb.RESET_REAPPLY_EXCLUDE_TYPE_NEXUS:  {},
 	}
-	reappliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, events, excludes, "")
+	reappliedEvents, err := reapplyEvents(context.Background(), ms, nil, smReg, events, excludes, "", false)
+	s.Empty(reappliedEvents)
+	s.NoError(err)
+
+	event7 := &historypb.HistoryEvent{
+		EventId:   107,
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED,
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionCancelRequestedEventAttributes{
+			WorkflowExecutionCancelRequestedEventAttributes: &historypb.WorkflowExecutionCancelRequestedEventAttributes{
+				Cause:    testRequestReason,
+				Identity: testIdentity,
+			},
+		},
+	}
+	events = append(events, event7)
+	reappliedEvents, err = reapplyEvents(context.Background(), ms, nil, smReg, events, excludes, "", true)
 	s.Empty(reappliedEvents)
 	s.NoError(err)
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Do not reapply cancellation in reset operation.

## Why?
<!-- Tell your future self why have you made these changes -->
Cancellation should only be reapplied for conflict resolution. For reset, we should not reapply cancel request.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
