### PR TITLE
Prevent a namespace from being deleted if it is the target of a Nexus endpoint

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -869,7 +869,7 @@ server hosts for it to take effect.`,
 	AllowDeleteNamespaceIfNexusEndpointTarget = NewGlobalBoolSetting(
 		"frontend.allowDeleteNamespaceIfNexusEndpointTarget",
 		false,
-		`If set to true (default) namespaces that are Nexus endpoint targets will be prevented from being deleted.`,
+		`If set to true (default is false), namespaces that are Nexus endpoint targets will be prevented from being deleted.`,
 	)
 
 	RefreshNexusEndpointsLongPollTimeout = NewGlobalDurationSetting(

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -865,6 +865,13 @@ and deployment interaction in matching and history.`,
 		`EnableNexus toggles all Nexus functionality on the server. Note that toggling this requires restarting
 server hosts for it to take effect.`,
 	)
+
+	AllowDeleteNamespaceIfNexusEndpointTarget = NewGlobalBoolSetting(
+		"frontend.allowDeleteNamespaceIfNexusEndpointTarget",
+		false,
+		`If set to true (default) namespaces that are Nexus endpoint targets will be prevented from being deleted.`,
+	)
+
 	RefreshNexusEndpointsLongPollTimeout = NewGlobalDurationSetting(
 		"system.refreshNexusEndpointsLongPollTimeout",
 		5*time.Minute,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -660,6 +660,7 @@ func OperatorHandlerProvider(
 	clusterMetadataManager persistence.ClusterMetadataManager,
 	clusterMetadata cluster.Metadata,
 	clientFactory client.Factory,
+	namespaceRegistry namespace.Registry,
 	nexusEndpointClient *NexusEndpointClient,
 ) *OperatorHandlerImpl {
 	args := NewOperatorHandlerImplArgs{
@@ -675,6 +676,7 @@ func OperatorHandlerProvider(
 		clusterMetadataManager,
 		clusterMetadata,
 		clientFactory,
+		namespaceRegistry,
 		nexusEndpointClient,
 	}
 	return NewOperatorHandlerImpl(args)

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -88,6 +88,7 @@ type (
 		clusterMetadataManager persistence.ClusterMetadataManager
 		clusterMetadata        clustermetadata.Metadata
 		clientFactory          svc.Factory
+		namespaceRegistry      namespace.Registry
 		nexusEndpointClient    *NexusEndpointClient
 	}
 
@@ -104,6 +105,7 @@ type (
 		clusterMetadataManager persistence.ClusterMetadataManager
 		clusterMetadata        clustermetadata.Metadata
 		clientFactory          svc.Factory
+		namespaceRegistry      namespace.Registry
 		nexusEndpointClient    *NexusEndpointClient
 	}
 )
@@ -133,6 +135,7 @@ func NewOperatorHandlerImpl(
 		clusterMetadataManager: args.clusterMetadataManager,
 		clusterMetadata:        args.clusterMetadata,
 		clientFactory:          args.clientFactory,
+		namespaceRegistry:      args.namespaceRegistry,
 		nexusEndpointClient:    args.nexusEndpointClient,
 	}
 
@@ -609,6 +612,38 @@ func (h *OperatorHandlerImpl) DeleteNamespace(
 
 	if request.GetNamespace() == primitives.SystemLocalNamespace || request.GetNamespaceId() == primitives.SystemNamespaceID {
 		return nil, errUnableDeleteSystemNamespace
+	}
+
+	var nextPageToken []byte
+
+	// Get the namespace name in case the request is to delete by ID so we can verify that this namespace is not
+	// associated with a Nexus endpoint.
+	requestNSName := request.GetNamespace()
+	if request.GetNamespaceId() != "" {
+		nsName, err := h.namespaceRegistry.GetNamespaceName(namespace.ID(request.GetNamespaceId()))
+		if err != nil {
+			return nil, err
+		}
+		requestNSName = nsName.String()
+	}
+
+	// Prevent deletion of a namespace that is associated with any Nexus endpoints.
+	for {
+		resp, err := h.nexusEndpointClient.List(ctx, &operatorservice.ListNexusEndpointsRequest{
+			// Don't specify PageSize and fallback to default.
+			NextPageToken: nextPageToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range resp.GetEndpoints() {
+			if nsName := entry.GetSpec().GetTarget().GetWorker().GetNamespace(); nsName == requestNSName {
+				return nil, serviceerror.NewFailedPrecondition(fmt.Sprintf("cannot delete a namespace that is a target of a Nexus endpoint (%s)", entry.GetSpec().GetName()))
+			}
+		}
+		if len(nextPageToken) == 0 {
+			break
+		}
 	}
 
 	namespaceDeleteDelay := h.config.DeleteNamespaceNamespaceDeleteDelay()

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -44,6 +44,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"
 	"go.temporal.io/server/common/persistence/visibility"
@@ -70,8 +71,9 @@ type (
 		suite.Suite
 		*require.Assertions
 
-		controller   *gomock.Controller
-		mockResource *resourcetest.Test
+		controller                      *gomock.Controller
+		mockResource                    *resourcetest.Test
+		nexusEndpointPersistenceManager *persistence.MockNexusEndpointManager
 
 		handler *OperatorHandlerImpl
 	}
@@ -88,12 +90,13 @@ func (s *operatorHandlerSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockResource = resourcetest.NewTest(s.controller, primitives.FrontendService)
 	s.mockResource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(uuid.New()).AnyTimes()
+	s.nexusEndpointPersistenceManager = persistence.NewMockNexusEndpointManager(s.controller)
 
 	endpointClient := newNexusEndpointClient(
 		newNexusEndpointClientConfig(dynamicconfig.NewNoopCollection()),
 		s.mockResource.NamespaceCache,
 		s.mockResource.MatchingClient,
-		persistence.NewMockNexusEndpointManager(s.controller),
+		s.nexusEndpointPersistenceManager,
 		s.mockResource.Logger,
 	)
 
@@ -110,6 +113,7 @@ func (s *operatorHandlerSuite) SetupTest() {
 		s.mockResource.GetClusterMetadataManager(),
 		s.mockResource.GetClusterMetadata(),
 		s.mockResource.GetClientFactory(),
+		s.mockResource.NamespaceCache,
 		endpointClient,
 	}
 	s.handler = NewOperatorHandlerImpl(args)
@@ -1154,6 +1158,32 @@ func (s *operatorHandlerSuite) Test_DeleteNamespace() {
 		})
 	}
 
+	// The "fake" namespace ID is associated with a Nexus endoint.
+	s.nexusEndpointPersistenceManager.EXPECT().ListNexusEndpoints(gomock.Any(), gomock.Any()).Return(&persistence.ListNexusEndpointsResponse{
+		Entries: []*persistencespb.NexusEndpointEntry{
+			{
+				Endpoint: &persistencespb.NexusEndpoint{
+					Spec: &persistencespb.NexusEndpointSpec{
+						Name: "test-endpoint",
+						Target: &persistencespb.NexusEndpointTarget{
+							Variant: &persistencespb.NexusEndpointTarget_Worker_{
+								Worker: &persistencespb.NexusEndpointTarget_Worker{
+									NamespaceId: "fake",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil).AnyTimes()
+	// Map "fake" namespace ID to the "namespace-with-nexus-endpoint" name.
+	s.mockResource.NamespaceCache.EXPECT().GetNamespaceName(namespace.ID("fake")).
+		Return(namespace.Name("namespace-with-nexus-endpoint"), nil).AnyTimes()
+	// Map "c13c01a7-3887-4eda-ba4b-9a07a6359e7e" namespace ID to the "test-namespace-deleted-ka2te" name.
+	s.mockResource.NamespaceCache.EXPECT().GetNamespaceName(namespace.ID("c13c01a7-3887-4eda-ba4b-9a07a6359e7e")).
+		Return(namespace.Name("test-namespace-deleted-ka2te"), nil).AnyTimes()
+
 	mockSdkClient := mocksdk.NewMockClient(s.controller)
 	s.mockResource.SDKClientFactory.EXPECT().GetSystemClient().Return(mockSdkClient).AnyTimes()
 
@@ -1165,9 +1195,21 @@ func (s *operatorHandlerSuite) Test_DeleteNamespace() {
 		DeleteNamespaceNamespaceDeleteDelay:                 dynamicconfig.GetDurationPropertyFn(22 * time.Hour),
 	}
 
+	// Delete by name: Nexus endpoint associated.
+	resp, err := handler.DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
+		Namespace: "namespace-with-nexus-endpoint",
+	})
+	s.ErrorContains(err, "cannot delete a namespace that is a target of a Nexus endpoint (test-endpoint)")
+
+	// Delete by ID: Nexus endpoint associated.
+	resp, err = handler.DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
+		NamespaceId: "fake",
+	})
+	s.ErrorContains(err, "cannot delete a namespace that is a target of a Nexus endpoint (test-endpoint)")
+
 	// Start workflow failed.
 	mockSdkClient.EXPECT().ExecuteWorkflow(gomock.Any(), gomock.Any(), "temporal-sys-delete-namespace-workflow", gomock.Any()).Return(nil, errors.New("start failed"))
-	resp, err := handler.DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
+	resp, err = handler.DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
 		Namespace: "test-namespace",
 	})
 	s.Error(err)

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -1196,20 +1196,20 @@ func (s *operatorHandlerSuite) Test_DeleteNamespace() {
 	}
 
 	// Delete by name: Nexus endpoint associated.
-	resp, err := handler.DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
+	_, err := handler.DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
 		Namespace: "namespace-with-nexus-endpoint",
 	})
 	s.ErrorContains(err, "cannot delete a namespace that is a target of a Nexus endpoint (test-endpoint)")
 
 	// Delete by ID: Nexus endpoint associated.
-	resp, err = handler.DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
+	_, err = handler.DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
 		NamespaceId: "fake",
 	})
 	s.ErrorContains(err, "cannot delete a namespace that is a target of a Nexus endpoint (test-endpoint)")
 
 	// Start workflow failed.
 	mockSdkClient.EXPECT().ExecuteWorkflow(gomock.Any(), gomock.Any(), "temporal-sys-delete-namespace-workflow", gomock.Any()).Return(nil, errors.New("start failed"))
-	resp, err = handler.DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
+	resp, err := handler.DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
 		Namespace: "test-namespace",
 	})
 	s.Error(err)

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -198,6 +198,8 @@ type Config struct {
 	// EnableNexusAPIs controls whether to allow invoking Nexus related APIs.
 	EnableNexusAPIs dynamicconfig.BoolPropertyFn
 
+	AllowDeleteNamespaceIfNexusEndpointTarget dynamicconfig.BoolPropertyFn
+
 	CallbackURLMaxLength    dynamicconfig.IntPropertyFnWithNamespaceFilter
 	CallbackHeaderMaxSize   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxCallbacksPerWorkflow dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -324,10 +326,11 @@ func NewConfig(
 		EnableWorkerVersioningWorkflow: dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs.Get(dc),
 		EnableWorkerVersioningRules:    dynamicconfig.FrontendEnableWorkerVersioningRuleAPIs.Get(dc),
 
-		EnableNexusAPIs:         dynamicconfig.EnableNexus.Get(dc),
-		CallbackURLMaxLength:    dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
-		CallbackHeaderMaxSize:   dynamicconfig.FrontendCallbackHeaderMaxSize.Get(dc),
-		MaxCallbacksPerWorkflow: dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
+		EnableNexusAPIs: dynamicconfig.EnableNexus.Get(dc),
+		AllowDeleteNamespaceIfNexusEndpointTarget: dynamicconfig.AllowDeleteNamespaceIfNexusEndpointTarget.Get(dc),
+		CallbackURLMaxLength:                      dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
+		CallbackHeaderMaxSize:                     dynamicconfig.FrontendCallbackHeaderMaxSize.Get(dc),
+		MaxCallbacksPerWorkflow:                   dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
 
 		LinkMaxSize:        dynamicconfig.FrontendLinkMaxSize.Get(dc),
 		MaxLinksPerRequest: dynamicconfig.FrontendMaxLinksPerRequest.Get(dc),


### PR DESCRIPTION
## Why?

Avoid breaking callers.

## How did you test it?

Added unit test assertions.