### PR TITLE
Fix ES docID when workflowID contains multi-bytes unicode

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -52,6 +52,7 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/util"
 )
 
 const (
@@ -295,14 +296,11 @@ func GetDocID(workflowID string, runID string) string {
 	const maxDocIDLength = 512
 	// Generally runID is guid and this should never be the case.
 	if len(runID)+len(delimiter) >= maxDocIDLength {
-		if len(runID) >= maxDocIDLength {
-			return runID[0:maxDocIDLength]
-		}
-		return runID[0 : maxDocIDLength-len(delimiter)]
+		return util.TruncateUTF8(runID, maxDocIDLength)
 	}
 
 	if len(workflowID)+len(runID)+len(delimiter) > maxDocIDLength {
-		workflowID = workflowID[0 : maxDocIDLength-len(runID)-len(delimiter)]
+		workflowID = util.TruncateUTF8(workflowID, maxDocIDLength-len(runID)-len(delimiter))
 	}
 
 	return workflowID + delimiter + runID

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_write_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_write_test.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -290,6 +291,16 @@ func (s *ESVisibilitySuite) Test_GetDocID() {
 	s.Equal(strings.Repeat("a", 475)+"~fd86a520-741e-4fd3-a788-165c445ea6f3", GetDocID(strings.Repeat("a", 475), "fd86a520-741e-4fd3-a788-165c445ea6f3"))
 	s.Equal(strings.Repeat("a", 474)+"~fd86a520-741e-4fd3-a788-165c445ea6f3", GetDocID(strings.Repeat("a", 474), "fd86a520-741e-4fd3-a788-165c445ea6f3"))
 	s.Equal(strings.Repeat("a", 400)+"~fd86a520-741e-4fd3-a788-165c445ea6f3", GetDocID(strings.Repeat("a", 400), "fd86a520-741e-4fd3-a788-165c445ea6f3"))
+
+	// construct a workflowID that contains valid utf8 prefix with multi-bytes unicode.
+	// the prefix length is exactly that it will cut on the next multi-bytes unicode.
+	// this test case is to verify that we don't produce invalid docID that consists of invalid utf8 string
+	rid := "rid"
+	prefix := strings.Repeat("a", 512-len(rid)-len(delimiter)-1)
+	wid := prefix + "中文字符"
+	docId := GetDocID(wid, rid)
+	s.True(utf8.ValidString(docId))
+	s.Equal(prefix+"~rid", docId)
 }
 
 func (s *ESVisibilitySuite) Test_GetVisibilityTaskKey() {


### PR DESCRIPTION
## What changed?
Make sure the generated docID for ES is valid utf8 when workflow ID is too long

## Why?
Without proper handling, the result could be invalid utf8 string and ES would encode them result in doc ID longer than 512 limit.

## How did you test it?
unit test

## Potential risks
No

## Documentation
No

## Is hotfix candidate?
Maybe
