### PR TITLE
[Nexus operations] Cancel only after Operation started

### DIFF
--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -461,8 +461,10 @@ var TransitionTimedOut = hsm.NewTransition(
 )
 
 // Cancel marks the Operation machine as canceled by spawning a child Cancelation machine. If the
-// Operation ID is set, then transition the Cancelation machine to the SCHEDULED state. Otherwise,
-// the Cancelation machine will wait the Operation machine transition to the STARTED state.
+// Operation already completed, then the Operation cannot be canceled anymore, and the Cancelation
+// machine will stay in UNSPECIFIED state. If the Operation is in STARTED state, then transition the
+// Cancelation machine to the SCHEDULED state. Otherwise, the Cancelation machine will wait the
+// Operation machine transition to the STARTED state.
 func (o Operation) Cancel(node *hsm.Node, t time.Time) (hsm.TransitionOutput, error) {
 	child, err := node.AddChild(CancelationMachineKey, Cancelation{
 		NexusOperationCancellationInfo: &persistencespb.NexusOperationCancellationInfo{},
@@ -472,9 +474,9 @@ func (o Operation) Cancel(node *hsm.Node, t time.Time) (hsm.TransitionOutput, er
 		// more than once.
 		return hsm.TransitionOutput{}, err
 	}
-	// Operation wasn't started yet, we don't know how to cancel it ATM.
-	if o.OperationId == "" {
-		// Don't schedule the cancelation yet. We may schedule it again once the operation is started.
+	if o.State() != enumsspb.NEXUS_OPERATION_STATE_STARTED {
+		// Operation hasn't started yet or has already completed. Either way, cannot schedule
+		// cancelation.
 		return hsm.TransitionOutput{}, nil
 	}
 	return hsm.TransitionOutput{}, hsm.MachineTransition(child, func(c Cancelation) (hsm.TransitionOutput, error) {

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -93,7 +93,7 @@ func AddChild(node *hsm.Node, id string, event *historypb.HistoryEvent, eventTok
 		if err != nil {
 			return output, err
 		}
-		creationTasks, err := op.creationTasks(node)
+		creationTasks, err := op.creationTasks()
 		if err != nil {
 			return output, err
 		}
@@ -160,11 +160,7 @@ func (o Operation) transitionTasks() ([]hsm.Task, error) {
 }
 
 // creationTasks returns tasks that are emitted when the machine is created.
-func (o Operation) creationTasks(node *hsm.Node) ([]hsm.Task, error) {
-	if canceled, err := o.cancelRequested(node); canceled || err != nil {
-		return nil, err
-	}
-
+func (o Operation) creationTasks() ([]hsm.Task, error) {
 	if o.ScheduleToCloseTimeout.AsDuration() != 0 {
 		return []hsm.Task{TimeoutTask{deadline: o.ScheduledTime.AsTime().Add(o.ScheduleToCloseTimeout.AsDuration())}}, nil
 	}
@@ -176,7 +172,7 @@ func (o Operation) RegenerateTasks(node *hsm.Node) ([]hsm.Task, error) {
 	if err != nil {
 		return nil, err
 	}
-	creationTasks, err := o.creationTasks(node)
+	creationTasks, err := o.creationTasks()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Cancel Nexus operation only after the operation has started.

## Why?
<!-- Tell your future self why have you made these changes -->
Can only cancel operation after it has started.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Updated unit test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
