### PR TITLE
Change RunIDs to use UUIDv7

### DIFF
--- a/common/primitives/uuid.go
+++ b/common/primitives/uuid.go
@@ -29,7 +29,6 @@ import (
 	"encoding/hex"
 
 	guuid "github.com/google/uuid"
-	"github.com/pborman/uuid"
 )
 
 // UUID represents a 16-byte universally unique identifier
@@ -93,7 +92,12 @@ func ValidateUUID(s string) (string, error) {
 
 // NewUUID generates a new random UUID
 func NewUUID() UUID {
-	return UUID(uuid.NewRandom())
+	u, err := guuid.NewV7()
+	if err != nil {
+		// Should never happen, but this matches the behavior of pborman/uuid.NewRandom
+		return nil
+	}
+	return u[:]
 }
 
 // Downcast returns the UUID as a byte slice. This is necessary when passing to type sensitive interfaces such as cql.

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -27,6 +27,7 @@ package startworkflow
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -249,7 +250,11 @@ func (s *Starter) lockCurrentWorkflowExecution(
 // prepareNewWorkflow creates a new workflow context, and closes its mutable state transaction as snapshot.
 // It returns the creationContext which can later be used to insert into the executions table.
 func (s *Starter) prepareNewWorkflow(workflowID string) (*creationParams, error) {
-	runID := uuid.NewString()
+	runUUID, err := uuid.NewV7()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate run id: %w", err)
+	}
+	runID := runUUID.String()
 	mutableState, err := api.NewWorkflowWithSignal(
 		s.shardContext,
 		s.namespace,

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -408,7 +408,11 @@ func (s *Starter) resolveDuplicateWorkflowID(
 	// Using a new RunID here to simplify locking: MultiOperation, that re-uses the Starter, is creating
 	// a locked workflow context for each new workflow. Using a fresh RunID prevents a deadlock with the
 	// previously created workflow context.
-	newRunID := uuid.NewString()
+	newRunUUID, err := uuid.NewV7()
+	if err != nil {
+		return nil, StartErr, fmt.Errorf("failed to generate run id: %w", err)
+	}
+	newRunID := newRunUUID.String()
 
 	currentExecutionUpdateAction, err := api.ResolveDuplicateWorkflowID(
 		s.shardContext,

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -27,10 +27,8 @@ package startworkflow
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
@@ -45,6 +43,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/service/history/api"
 	"go.temporal.io/server/service/history/consts"
@@ -250,11 +249,7 @@ func (s *Starter) lockCurrentWorkflowExecution(
 // prepareNewWorkflow creates a new workflow context, and closes its mutable state transaction as snapshot.
 // It returns the creationContext which can later be used to insert into the executions table.
 func (s *Starter) prepareNewWorkflow(workflowID string) (*creationParams, error) {
-	runUUID, err := uuid.NewV7()
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate run id: %w", err)
-	}
-	runID := runUUID.String()
+	runID := primitives.NewUUID().String()
 	mutableState, err := api.NewWorkflowWithSignal(
 		s.shardContext,
 		s.namespace,
@@ -408,11 +403,7 @@ func (s *Starter) resolveDuplicateWorkflowID(
 	// Using a new RunID here to simplify locking: MultiOperation, that re-uses the Starter, is creating
 	// a locked workflow context for each new workflow. Using a fresh RunID prevents a deadlock with the
 	// previously created workflow context.
-	newRunUUID, err := uuid.NewV7()
-	if err != nil {
-		return nil, StartErr, fmt.Errorf("failed to generate run id: %w", err)
-	}
-	newRunID := newRunUUID.String()
+	newRunID := primitives.NewUUID().String()
 
 	currentExecutionUpdateAction, err := api.ResolveDuplicateWorkflowID(
 		s.shardContext,


### PR DESCRIPTION
## What changed?

I changed our RunID generation to use [UUIDv7](https://buildkite.com/resources/blog/goodbye-integers-hello-uuids/) instead of V4 by default.

## Why?

UUIDv7s have a timestamp as their prefix, which will help us optimize the physical storage layout of our workflow-related data.

## How did you test it?
Existing tests

## Potential risks
I don't believe there are any

## Documentation
Not necessary.

## Is hotfix candidate?
No
