### PR TITLE
Increase timeouts in flaky DeploymentSuite tests

### DIFF
--- a/tests/deployment_test.go
+++ b/tests/deployment_test.go
@@ -186,7 +186,7 @@ func (s *DeploymentSuite) TestDescribeDeployment_RegisterTaskQueue() {
 }
 
 func (s *DeploymentSuite) TestDescribeDeployment_RegisterTaskQueue_ConcurrentPollers() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 	defer cancel()
 
 	// presence of internally used delimiters (:) or escape

--- a/tests/deployment_test.go
+++ b/tests/deployment_test.go
@@ -1027,7 +1027,7 @@ func (s *DeploymentSuite) checkListAndWaitForBatchCompletion(ctx context.Context
 		if len(listResp.GetOperationInfo()) > 0 {
 			a.Equal(jobId, listResp.GetOperationInfo()[0].GetJobId())
 		}
-	}, 5*time.Second, 50*time.Millisecond)
+	}, 10*time.Second, 50*time.Millisecond)
 
 	for {
 		descResp, err := s.FrontendClient().DescribeBatchOperation(ctx, &workflowservice.DescribeBatchOperationRequest{


### PR DESCRIPTION
## What changed?
Increase context deadline from 10s --> 15s in occasionally flaky DescribeDeployment test that fails with context deadline exceeded.

Increase timeout from 5s --> 10s in occasionally flaky TestBatchUpdateWorkflowOptions test that fails because the list of batch workflows was still 0 after 5s. This flake only occurs in cassandra test clusters, so I think this is just a visibility eventual consistency issue, not anything that can be sped up.

## Why?
To reduce observed test flakiness.

## How did you test it?
Currently running 100x in CI.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
