### PR TITLE
reapply wf terminated event for conflict resolution

### DIFF
--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -894,6 +894,22 @@ func reapplyEvents(
 				return reappliedEvents, err
 			}
 			reappliedEvents = append(reappliedEvents, event)
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
+			if isReset || isDuplicate(event) {
+				continue
+			}
+			attr := event.GetWorkflowExecutionTerminatedEventAttributes()
+			if err := workflow.TerminateWorkflow(
+				mutableState,
+				attr.GetReason(),
+				attr.GetDetails(),
+				attr.GetIdentity(),
+				false,
+				event.Links,
+			); err != nil {
+				return reappliedEvents, err
+			}
+			reappliedEvents = append(reappliedEvents, event)
 		default:
 			root := mutableState.HSM()
 			def, ok := stateMachineRegistry.EventDefinition(event.GetEventType())

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -905,7 +905,18 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 			},
 		},
 	}
-	events := []*historypb.HistoryEvent{event1, event2, event3, event4, event5, event6, event7, event8}
+	event9 := &historypb.HistoryEvent{
+		EventId:   109,
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED,
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionTerminatedEventAttributes{
+			WorkflowExecutionTerminatedEventAttributes: &historypb.WorkflowExecutionTerminatedEventAttributes{
+				Reason:   testRequestReason,
+				Details:  payloads.EncodeString("test details"),
+				Identity: testIdentity,
+			},
+		},
+	}
+	events := []*historypb.HistoryEvent{event1, event2, event3, event4, event5, event6, event7, event8, event9}
 
 	testcases := []struct {
 		name    string
@@ -961,6 +972,20 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 							ExternalInitiatedEventId:  attr.GetExternalInitiatedEventId(),
 							ExternalWorkflowExecution: attr.GetExternalWorkflowExecution(),
 						},
+					).Return(&historypb.HistoryEvent{}, nil)
+				}
+			case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
+				if !tc.isReset {
+					ms.EXPECT().GetNextEventID().Return(event.GetEventId() + 1)
+					ms.EXPECT().GetStartedWorkflowTask().Return(nil)
+					attr := event.GetWorkflowExecutionTerminatedEventAttributes()
+					ms.EXPECT().AddWorkflowExecutionTerminatedEvent(
+						event.GetEventId()+1,
+						attr.GetReason(),
+						attr.GetDetails(),
+						attr.GetIdentity(),
+						false,
+						event.Links,
 					).Return(&historypb.HistoryEvent{}, nil)
 				}
 			}
@@ -1059,7 +1084,18 @@ func (s *workflowResetterSuite) TestReapplyEvents_Excludes() {
 			},
 		},
 	}
-	events = append(events, event7)
+	event8 := &historypb.HistoryEvent{
+		EventId:   108,
+		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED,
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionTerminatedEventAttributes{
+			WorkflowExecutionTerminatedEventAttributes: &historypb.WorkflowExecutionTerminatedEventAttributes{
+				Reason:   testRequestReason,
+				Details:  payloads.EncodeString("test details"),
+				Identity: testIdentity,
+			},
+		},
+	}
+	events = append(events, event7, event8)
 	reappliedEvents, err = reapplyEvents(context.Background(), ms, nil, smReg, events, excludes, "", true)
 	s.Empty(reappliedEvents)
 	s.NoError(err)

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -865,7 +865,9 @@ func (c *ContextImpl) ReapplyEvents(
 			switch event.GetEventType() {
 			case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED,
 				enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ADMITTED,
-				enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED:
+				enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
+				enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED,
+				enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
 
 				reapplyEvents = append(reapplyEvents, event)
 			}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
reapply wf terminated event for conflict resolution

## Why?
<!-- Tell your future self why have you made these changes -->
During conflict resolution, EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED should be reapplied to current branch.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
