### PR TITLE
Remove ineffective GetPendingChildExecutionInfos() check

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -6523,12 +6523,6 @@ func (ms *MutableStateImpl) closeTransactionHandleWorkflowResetTask(
 		return nil
 	}
 
-	// only schedule reset task if current doesn't have childWFs.
-	// TODO: This will be removed once our reset allows childWFs
-	if len(ms.GetPendingChildExecutionInfos()) != 0 {
-		return nil
-	}
-
 	namespaceEntry, err := ms.shard.GetNamespaceRegistry().GetNamespaceByID(namespace.ID(ms.executionInfo.NamespaceId))
 	if err != nil {
 		return err


### PR DESCRIPTION
## What changed?
This check is ineffective since the workflow can make progress and start children after this check (and before reset task is executed). Plus this check is done at the time of reset anyways.

## Why?
In effective condition check

## How did you test it?
Existing tests

## Potential risks
N/A

## Documentation
N/A
## Is hotfix candidate?
No