### PR TITLE
Fix TestBufferedEventsMutableStateSizeLimit

### DIFF
--- a/tests/max_buffered_event_test.go
+++ b/tests/max_buffered_event_test.go
@@ -137,7 +137,6 @@ func (s *MaxBufferedEventSuite) TestMaxBufferedEventsLimit() {
 	}
 	s.Equal(enumspb.WORKFLOW_TASK_FAILED_CAUSE_FORCE_CLOSE_COMMAND, failedCause)
 	s.Equal(1, failedCount)
-
 }
 
 func (s *MaxBufferedEventSuite) TestBufferedEventsMutableStateSizeLimit() {


### PR DESCRIPTION
## What changed?
TestBufferedEventsMutableStateSizeLimit was written in the assumption that max buffered event size is 16MB. But the default value has changed to 2MB.
Rewriting this test to fix this. Added a check to make sure that the test will fail if the limit is changed again.

## Why?
This test is flaky. This fix might help with that.

## How did you test it?


## Potential risks
None

## Documentation

## Is hotfix candidate?
No
