### PR TITLE
Old replication path deletion sync support

### DIFF
--- a/proto/internal/temporal/server/api/persistence/v1/hsm.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/hsm.proto
@@ -39,8 +39,6 @@ message StateMachineNode {
     // This field will always be set even when transition history is disabled.
     // NOTE: If transition history is disabled, the transition_count field will be 0 and 
     // cannot be used to uniquely identify a node.
-    // NOTE: Node deletion is not yet implemented at the time of writing so we can still uniquely identify a node just
-    // with the initial namespace failover version.
     VersionedTransition initial_versioned_transition = 3;
 
     // Versioned transition when the node was last updated.

--- a/service/history/ndc/hsm_state_replicator.go
+++ b/service/history/ndc/hsm_state_replicator.go
@@ -289,7 +289,7 @@ func (r *HSMStateReplicatorImpl) shouldDeleteNode(
 	sourceVersion := request.StateMachineNode.LastUpdateVersionedTransition.NamespaceFailoverVersion
 
 	// Must be same initial version and source strictly newer
-	if targetInitialVersion != sourceInitialVersion {
+	if targetInitialVersion > sourceInitialVersion {
 		return false, nil
 	}
 	if sourceVersion <= targetVersion {

--- a/service/history/ndc/hsm_state_replicator.go
+++ b/service/history/ndc/hsm_state_replicator.go
@@ -292,7 +292,7 @@ func (r *HSMStateReplicatorImpl) shouldDeleteNode(
 	if targetInitialVersion > sourceInitialVersion {
 		return false, nil
 	}
-	if sourceVersion <= targetVersion {
+	if targetVersion > sourceVersion {
 		return false, nil
 	}
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add deletion sync support to old replication logic

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
