### PR TITLE
Refresh user data from db periodically

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ issues:
       linters:
         - revive
     - path: _test\.go|tests/.+\.go
-      text: "dot-imports"  # helpful in tests
+      text: "(dot-imports|unchecked-type-assertion)"  # helpful in tests
       linters:
         - revive
     - path: ^tools\/.+\.go

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1185,6 +1185,11 @@ This can help reduce effects of task queue movement.`,
 		5*time.Minute-10*time.Second,
 		`MatchingGetUserDataLongPollTimeout is the max length of long polls for GetUserData calls between partitions.`,
 	)
+	MatchingGetUserDataRefresh = NewGlobalDurationSetting(
+		"matching.getUserDataRefresh",
+		5*time.Minute,
+		`MatchingGetUserDataRefresh is how often the user data owner refreshes data from persistence.`,
+	)
 	MatchingBacklogNegligibleAge = NewTaskQueueDurationSetting(
 		"matching.backlogNegligibleAge",
 		5*time.Second,

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -145,6 +145,8 @@ type (
 		GetUserDataLongPollTimeout dynamicconfig.DurationPropertyFn
 		GetUserDataMinWaitTime     time.Duration
 		GetUserDataReturnBudget    time.Duration
+		GetUserDataInitialRefresh  time.Duration
+		GetUserDataRefresh         dynamicconfig.DurationPropertyFn
 
 		// taskWriter configuration
 		OutstandingTaskAppendsThreshold func() int
@@ -313,6 +315,8 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		GetUserDataLongPollTimeout: config.GetUserDataLongPollTimeout,
 		GetUserDataMinWaitTime:     1 * time.Second,
 		GetUserDataReturnBudget:    returnEmptyTaskTimeBudget,
+		GetUserDataInitialRefresh:  ioTimeout,
+		GetUserDataRefresh:         config.GetUserDataLongPollTimeout, // this is just for testing, use same value as long poll
 		OutstandingTaskAppendsThreshold: func() int {
 			return config.OutstandingTaskAppendsThreshold(ns.String(), taskQueueName, taskType)
 		},

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -316,7 +316,9 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		GetUserDataMinWaitTime:     1 * time.Second,
 		GetUserDataReturnBudget:    returnEmptyTaskTimeBudget,
 		GetUserDataInitialRefresh:  ioTimeout,
-		GetUserDataRefresh:         config.GetUserDataLongPollTimeout, // this is just for testing, use same value as long poll
+		// use same value for GetUserDataRefresh as GetUserDataLongPollTimeout (both control
+		// how often we read from the source in the stady state)
+		GetUserDataRefresh: config.GetUserDataLongPollTimeout,
 		OutstandingTaskAppendsThreshold: func() int {
 			return config.OutstandingTaskAppendsThreshold(ns.String(), taskQueueName, taskType)
 		},

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -84,6 +84,7 @@ type (
 		ReachabilityCacheClosedWFsTTL            dynamicconfig.DurationPropertyFn
 		TaskQueueLimitPerBuildId                 dynamicconfig.IntPropertyFnWithNamespaceFilter
 		GetUserDataLongPollTimeout               dynamicconfig.DurationPropertyFn
+		GetUserDataRefresh                       dynamicconfig.DurationPropertyFn
 		BacklogNegligibleAge                     dynamicconfig.DurationPropertyFnWithTaskQueueFilter
 		MaxWaitForPollerBeforeFwd                dynamicconfig.DurationPropertyFnWithTaskQueueFilter
 		QueryPollerUnavailableWindow             dynamicconfig.DurationPropertyFn
@@ -252,6 +253,7 @@ func NewConfig(
 		ReachabilityCacheClosedWFsTTL:            dynamicconfig.ReachabilityCacheClosedWFsTTL.Get(dc),
 		TaskQueueLimitPerBuildId:                 dynamicconfig.TaskQueuesPerBuildIdLimit.Get(dc),
 		GetUserDataLongPollTimeout:               dynamicconfig.MatchingGetUserDataLongPollTimeout.Get(dc), // Use -10 seconds so that we send back empty response instead of timeout
+		GetUserDataRefresh:                       dynamicconfig.MatchingGetUserDataRefresh.Get(dc),
 		BacklogNegligibleAge:                     dynamicconfig.MatchingBacklogNegligibleAge.Get(dc),
 		MaxWaitForPollerBeforeFwd:                dynamicconfig.MatchingMaxWaitForPollerBeforeFwd.Get(dc),
 		QueryPollerUnavailableWindow:             dynamicconfig.QueryPollerUnavailableWindow.Get(dc),
@@ -316,9 +318,7 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		GetUserDataMinWaitTime:     1 * time.Second,
 		GetUserDataReturnBudget:    returnEmptyTaskTimeBudget,
 		GetUserDataInitialRefresh:  ioTimeout,
-		// use same value for GetUserDataRefresh as GetUserDataLongPollTimeout (both control
-		// how often we read from the source in the stady state)
-		GetUserDataRefresh: config.GetUserDataLongPollTimeout,
+		GetUserDataRefresh:         config.GetUserDataRefresh,
 		OutstandingTaskAppendsThreshold: func() int {
 			return config.OutstandingTaskAppendsThreshold(ns.String(), taskQueueName, taskType)
 		},

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -405,8 +405,10 @@ func (e *matchingEngineImpl) getTaskQueuePartitionManager(
 	tqConfig := newTaskQueueConfig(partition.TaskQueue(), e.config, nsName)
 	tqConfig.loadCause = loadCause
 	logger, throttledLogger, metricsHandler := e.loggerAndMetricsForPartition(nsName, partition, tqConfig)
-	userDataManager := newUserDataManager(e.taskManager, e.matchingRawClient, partition, tqConfig, logger, e.namespaceRegistry)
-	newPM, err := newTaskQueuePartitionManager(e, namespaceEntry, partition, tqConfig, logger, throttledLogger, metricsHandler, userDataManager)
+	var newPM *taskQueuePartitionManagerImpl
+	onFatalErr := func(cause unloadCause) { newPM.unloadFromEngine(cause) }
+	userDataManager := newUserDataManager(e.taskManager, e.matchingRawClient, onFatalErr, partition, tqConfig, logger, e.namespaceRegistry)
+	newPM, err = newTaskQueuePartitionManager(e, namespaceEntry, partition, tqConfig, logger, throttledLogger, metricsHandler, userDataManager)
 	if err != nil {
 		return nil, false, err
 	}

--- a/service/matching/user_data_manager.go
+++ b/service/matching/user_data_manager.go
@@ -93,6 +93,7 @@ type (
 	// All other partitions long-poll the latest user data from the owning partition.
 	userDataManagerImpl struct {
 		lock            sync.Mutex
+		onFatalErr      func(unloadCause)
 		partition       tqid.Partition
 		userData        *persistencespb.VersionedTaskQueueUserData
 		userDataChanged chan struct{}
@@ -118,23 +119,25 @@ var (
 	errUserDataNoMutateNonRoot = serviceerror.NewInvalidArgument("can only mutate user data on root workflow task queue")
 	errTaskQueueClosed         = serviceerror.NewUnavailable("task queue closed")
 	errUserDataUnmodified      = errors.New("sentinel error for unchanged user data")
+	errUserDataVersionMismatch = errors.New("user data version mismatch")
 )
 
 func newUserDataManager(
 	store persistence.TaskManager,
 	matchingClient matchingservice.MatchingServiceClient,
+	onFatalErr func(unloadCause),
 	partition tqid.Partition,
 	config *taskQueueConfig,
 	logger log.Logger,
 	registry namespace.Registry,
 ) *userDataManagerImpl {
-
 	m := &userDataManagerImpl{
-		logger:            logger,
+		onFatalErr:        onFatalErr,
 		partition:         partition,
+		userDataChanged:   make(chan struct{}),
 		config:            config,
 		namespaceRegistry: registry,
-		userDataChanged:   make(chan struct{}),
+		logger:            logger,
 		matchingClient:    matchingClient,
 		userDataReady:     future.NewFuture[struct{}](),
 	}
@@ -217,7 +220,20 @@ func (m *userDataManagerImpl) loadUserData(ctx context.Context) error {
 	ctx = m.callerInfoContext(ctx)
 	err := m.loadUserDataFromDB(ctx)
 	m.setUserDataState(userDataEnabled, err)
-	return nil
+
+	// At this point, it's possible that an old owner has updated user data after we read it.
+	// We should re-read it after a few seconds and then periodically after that to ensure that
+	// we notice if someone else has snuck in a write.
+	util.InterruptibleSleep(ctx, backoff.Jitter(m.config.GetUserDataInitialRefresh, 0.1))
+
+	for ctx.Err() == nil {
+		if err = m.refreshUserDataFromDB(ctx); errors.Is(err, errUserDataVersionMismatch) {
+			m.onFatalErr(unloadCauseConflict)
+		}
+		util.InterruptibleSleep(ctx, backoff.Jitter(m.config.GetUserDataRefresh(), 0.2))
+	}
+
+	return ctx.Err()
 }
 
 func (m *userDataManagerImpl) userDataFetchSource() (*tqid.NormalPartition, error) {
@@ -362,6 +378,49 @@ func (m *userDataManagerImpl) loadUserDataFromDB(ctx context.Context) error {
 	defer m.lock.Unlock()
 	m.setUserDataLocked(response.UserData)
 	m.logNewUserData("loaded user data from db", response.UserData)
+
+	return nil
+}
+
+// Checks if data in db has not been modified since we loaded/modified it.
+func (m *userDataManagerImpl) refreshUserDataFromDB(ctx context.Context) error {
+	// Lock here to ensure we're not in the middle of an update, otherwise we may incorrectly
+	// think the db has old data if we update between read and verify.
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	response, err := m.store.GetTaskQueueUserData(ctx, &persistence.GetTaskQueueUserDataRequest{
+		NamespaceID: m.partition.NamespaceId(),
+		TaskQueue:   m.partition.TaskQueue().Name(),
+	})
+	if common.IsNotFoundError(err) {
+		response, err = &persistence.GetTaskQueueUserDataResponse{}, nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if response.UserData.GetVersion() == m.userData.GetVersion() {
+		return nil
+	}
+
+	tags := []tag.Tag{
+		tag.UserDataVersion(response.UserData.GetVersion()),
+		tag.NewInt64("expected-user-data-version", m.userData.GetVersion()),
+		tag.Timestamp(hybrid_logical_clock.UTC(response.UserData.GetData().GetClock())),
+		tag.NewTimeTag("expected-user-data-timestamp", hybrid_logical_clock.UTC(m.userData.GetData().GetClock())),
+	}
+
+	if response.UserData.GetVersion() < m.userData.GetVersion() {
+		// We have newer data in memory than the db. This should only happen if the database
+		// went back in time. We should unload and start over.
+		m.logger.Error("user data version mismatch: db had older data; unloading", tags...)
+		return errUserDataVersionMismatch
+	}
+
+	// The db has newer data. We can just update to it.
+	m.setUserDataLocked(response.UserData)
+	m.logger.Warn("user data version mismatch: db had newer data; reloading", tags...)
 
 	return nil
 }


### PR DESCRIPTION
## What changed?
The task queue user data owner reads from the db periodically after the first read, to catch writes that may have been made by the old owner during ownership change, or in general by any bugs.

## Why?
Membership isn't strongly consistent so an old owner of task queue user data might complete or even start a write after a new owner has done its initial read. This would be detected on an attempted update, but user data is updated rarely so the stale data could persist for a long time.

## How did you test it?
new unit tests