### PR TITLE
Nexus error rehydration

### DIFF
--- a/common/tasks/dynamic_worker_pool_scheduler.go
+++ b/common/tasks/dynamic_worker_pool_scheduler.go
@@ -185,10 +185,13 @@ func (pool *DynamicWorkerPoolScheduler) exportMetricsWorker() {
 			timer.Stop()
 			return
 		case <-timer.C:
+			pool.mu.Lock()
+			bufferSize, runningGoroutines := pool.bufferSize, pool.runningGoroutines
+			pool.mu.Unlock()
 			metrics.DynamicWorkerPoolSchedulerBufferSize.With(pool.metricsHandler).
-				Record(float64(pool.bufferSize))
+				Record(float64(bufferSize))
 			metrics.DynamicWorkerPoolSchedulerActiveWorkers.With(pool.metricsHandler).
-				Record(float64(pool.runningGoroutines))
+				Record(float64(runningGoroutines))
 		}
 	}
 }

--- a/common/testing/mocksdk/client_mock.go
+++ b/common/testing/mocksdk/client_mock.go
@@ -379,6 +379,25 @@ func (mr *MockClientMockRecorder) ListWorkflow(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkflow", reflect.TypeOf((*MockClient)(nil).ListWorkflow), arg0, arg1)
 }
 
+// NewWithStartWorkflowOperation mocks base method.
+func (m *MockClient) NewWithStartWorkflowOperation(arg0 client.StartWorkflowOptions, arg1 any, arg2 ...any) client.WithStartWorkflowOperation {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "NewWithStartWorkflowOperation", varargs...)
+	ret0, _ := ret[0].(client.WithStartWorkflowOperation)
+	return ret0
+}
+
+// NewWithStartWorkflowOperation indicates an expected call of NewWithStartWorkflowOperation.
+func (mr *MockClientMockRecorder) NewWithStartWorkflowOperation(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewWithStartWorkflowOperation", reflect.TypeOf((*MockClient)(nil).NewWithStartWorkflowOperation), varargs...)
+}
+
 // OperatorService mocks base method.
 func (m *MockClient) OperatorService() operatorservice.OperatorServiceClient {
 	m.ctrl.T.Helper()
@@ -561,6 +580,21 @@ func (mr *MockClientMockRecorder) TerminateWorkflow(arg0, arg1, arg2, arg3 any, 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0, arg1, arg2, arg3}, arg4...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateWorkflow", reflect.TypeOf((*MockClient)(nil).TerminateWorkflow), varargs...)
+}
+
+// UpdateWithStartWorkflow mocks base method.
+func (m *MockClient) UpdateWithStartWorkflow(arg0 context.Context, arg1 client.UpdateWithStartWorkflowOptions) (client.WorkflowUpdateHandle, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateWithStartWorkflow", arg0, arg1)
+	ret0, _ := ret[0].(client.WorkflowUpdateHandle)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateWithStartWorkflow indicates an expected call of UpdateWithStartWorkflow.
+func (mr *MockClientMockRecorder) UpdateWithStartWorkflow(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWithStartWorkflow", reflect.TypeOf((*MockClient)(nil).UpdateWithStartWorkflow), arg0, arg1)
 }
 
 // UpdateWorkerBuildIdCompatibility mocks base method.

--- a/components/nexusoperations/completion.go
+++ b/components/nexusoperations/completion.go
@@ -75,6 +75,11 @@ func handleUnsuccessfulOperationError(
 	if err != nil {
 		return hsm.TransitionOutput{}, err
 	}
+	failure, err := commonnexus.UnsuccessfulOperationErrorToTemporalFailure(opFailedError)
+	if err != nil {
+		return hsm.TransitionOutput{}, err
+	}
+
 	switch opFailedError.State { // nolint:exhaustive
 	case nexus.OperationStateFailed:
 		event := node.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED, func(e *historypb.HistoryEvent) {
@@ -82,11 +87,7 @@ func handleUnsuccessfulOperationError(
 			// nolint:revive
 			e.Attributes = &historypb.HistoryEvent_NexusOperationFailedEventAttributes{
 				NexusOperationFailedEventAttributes: &historypb.NexusOperationFailedEventAttributes{
-					Failure: nexusOperationFailure(
-						operation,
-						eventID,
-						commonnexus.UnsuccessfulOperationErrorToTemporalFailure(opFailedError),
-					),
+					Failure:          nexusOperationFailure(operation, eventID, failure),
 					ScheduledEventId: eventID,
 					RequestId:        operation.RequestId,
 				},
@@ -105,11 +106,7 @@ func handleUnsuccessfulOperationError(
 			// nolint:revive
 			e.Attributes = &historypb.HistoryEvent_NexusOperationCanceledEventAttributes{
 				NexusOperationCanceledEventAttributes: &historypb.NexusOperationCanceledEventAttributes{
-					Failure: nexusOperationFailure(
-						operation,
-						eventID,
-						commonnexus.UnsuccessfulOperationErrorToTemporalFailure(opFailedError),
-					),
+					Failure:          nexusOperationFailure(operation, eventID, failure),
 					ScheduledEventId: eventID,
 					RequestId:        operation.RequestId,
 				},

--- a/components/nexusoperations/frontend/handler.go
+++ b/components/nexusoperations/frontend/handler.go
@@ -179,7 +179,7 @@ func (h *completionHandler) CompleteOperation(ctx context.Context, r *nexus.Comp
 		return nexus.HandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid callback token")
 	}
 	var links []*commonpb.Link
-	for _, nexusLink := range r.StartLinks {
+	for _, nexusLink := range r.Links {
 		switch nexusLink.Type {
 		case string((&commonpb.Link_WorkflowEvent{}).ProtoReflect().Descriptor().FullName()):
 			link, err := temporalnexus.ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
@@ -211,8 +211,15 @@ func (h *completionHandler) CompleteOperation(ctx context.Context, r *nexus.Comp
 	}
 	switch r.State { // nolint:exhaustive
 	case nexus.OperationStateFailed, nexus.OperationStateCanceled:
+		failureErr, ok := r.Error.(*nexus.FailureError)
+		if !ok {
+			// This shouldn't happen as the Nexus SDK is always expected to convert Failures from the wire to
+			// FailureErrors.
+			logger.Error("result error is not a FailureError", tag.Error(err))
+			return nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "internal server error")
+		}
 		hr.Outcome = &historyservice.CompleteNexusOperationRequest_Failure{
-			Failure: commonnexus.NexusFailureToProtoFailure(r.Failure),
+			Failure: commonnexus.NexusFailureToProtoFailure(failureErr.Failure),
 		}
 	case nexus.OperationStateSucceeded:
 		var result *commonpb.Payload
@@ -301,13 +308,13 @@ func (h *completionHandler) forwardCompleteOperation(ctx context.Context, r *nex
 
 	// TODO: Upgrade Nexus SDK in order to reduce HTTP exposure
 	handlerErr := &nexus.HandlerError{
-		Type:    commonnexus.HandlerErrorTypeFromHTTPStatus(resp.StatusCode),
-		Failure: &failure,
+		Type:  commonnexus.HandlerErrorTypeFromHTTPStatus(resp.StatusCode),
+		Cause: &nexus.FailureError{Failure: failure},
 	}
 
 	if handlerErr.Type == nexus.HandlerErrorTypeInternal && resp.StatusCode != http.StatusInternalServerError {
 		h.Logger.Warn("received unknown status code on Nexus client unexpected response error", tag.Value(resp.StatusCode))
-		handlerErr.Failure.Message = "internal error"
+		handlerErr.Cause = errors.New("internal error")
 	}
 
 	return handlerErr

--- a/components/nexusoperations/fx.go
+++ b/components/nexusoperations/fx.go
@@ -117,7 +117,7 @@ func ClientProviderFactory(
 			Transport: ResponseSizeLimiter{transport},
 		}, nil
 	})
-	return func(ctx context.Context, namespaceID string, entry *persistencespb.NexusEndpointEntry, service string) (*nexus.Client, error) {
+	return func(ctx context.Context, namespaceID string, entry *persistencespb.NexusEndpointEntry, service string) (*nexus.HTTPClient, error) {
 		var url string
 		var httpClient *http.Client
 		switch variant := entry.Endpoint.Spec.Target.Variant.(type) {
@@ -141,7 +141,7 @@ func ClientProviderFactory(
 				return httpClient.Do(r)
 			}
 		}
-		return nexus.NewClient(nexus.ClientOptions{
+		return nexus.NewHTTPClient(nexus.HTTPClientOptions{
 			BaseURL:    url,
 			Service:    service,
 			HTTPCaller: httpCaller,

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -282,7 +282,7 @@ var TransitionRescheduled = hsm.NewTransition(
 // EventAttemptFailed is triggered when an invocation attempt is failed with a retryable error.
 type EventAttemptFailed struct {
 	Time        time.Time
-	Err         error
+	Failure     *failurepb.Failure
 	Node        *hsm.Node
 	RetryPolicy backoff.RetryPolicy
 }
@@ -293,17 +293,11 @@ var TransitionAttemptFailed = hsm.NewTransition(
 	func(op Operation, event EventAttemptFailed) (hsm.TransitionOutput, error) {
 		op.recordAttempt(event.Time)
 		// Use 0 for elapsed time as we don't limit the retry by time (for now).
-		nextDelay := event.RetryPolicy.ComputeNextDelay(0, int(op.Attempt), event.Err)
+		// The last argument (error) is ignored.
+		nextDelay := event.RetryPolicy.ComputeNextDelay(0, int(op.Attempt), nil)
 		nextAttemptScheduleTime := event.Time.Add(nextDelay)
 		op.NextAttemptScheduleTime = timestamppb.New(nextAttemptScheduleTime)
-		op.LastAttemptFailure = &failurepb.Failure{
-			Message: event.Err.Error(),
-			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
-				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-					NonRetryable: false,
-				},
-			},
-		}
+		op.LastAttemptFailure = event.Failure
 		return op.output()
 	},
 )
@@ -652,7 +646,7 @@ var TransitionCancelationRescheduled = hsm.NewTransition(
 // EventCancelationAttemptFailed is triggered when a cancelation attempt is failed with a retryable error.
 type EventCancelationAttemptFailed struct {
 	Time        time.Time
-	Err         error
+	Failure     *failurepb.Failure
 	Node        *hsm.Node
 	RetryPolicy backoff.RetryPolicy
 }
@@ -663,26 +657,19 @@ var TransitionCancelationAttemptFailed = hsm.NewTransition(
 	func(c Cancelation, event EventCancelationAttemptFailed) (hsm.TransitionOutput, error) {
 		c.recordAttempt(event.Time)
 		// Use 0 for elapsed time as we don't limit the retry by time (for now).
-		nextDelay := event.RetryPolicy.ComputeNextDelay(0, int(c.Attempt), event.Err)
+		nextDelay := event.RetryPolicy.ComputeNextDelay(0, int(c.Attempt), nil)
 		nextAttemptScheduleTime := event.Time.Add(nextDelay)
 		c.NextAttemptScheduleTime = timestamppb.New(nextAttemptScheduleTime)
-		c.LastAttemptFailure = &failurepb.Failure{
-			Message: event.Err.Error(),
-			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
-				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-					NonRetryable: false,
-				},
-			},
-		}
+		c.LastAttemptFailure = event.Failure
 		return c.output(event.Node)
 	},
 )
 
 // EventCancelationFailed is triggered when a cancelation attempt is failed with a non retryable error.
 type EventCancelationFailed struct {
-	Time time.Time
-	Err  error
-	Node *hsm.Node
+	Time    time.Time
+	Failure *failurepb.Failure
+	Node    *hsm.Node
 }
 
 var TransitionCancelationFailed = hsm.NewTransition(
@@ -695,14 +682,7 @@ var TransitionCancelationFailed = hsm.NewTransition(
 	enumspb.NEXUS_OPERATION_CANCELLATION_STATE_FAILED,
 	func(c Cancelation, event EventCancelationFailed) (hsm.TransitionOutput, error) {
 		c.recordAttempt(event.Time)
-		c.LastAttemptFailure = &failurepb.Failure{
-			Message: event.Err.Error(),
-			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
-				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-					NonRetryable: true,
-				},
-			},
-		}
+		c.LastAttemptFailure = event.Failure
 		return c.output(event.Node)
 	},
 )

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/lib/pq v1.10.9
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/nexus-rpc/sdk-go v0.0.12
+	github.com/nexus-rpc/sdk-go v0.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/olivere/elastic/v7 v7.0.32
 	github.com/pborman/uuid v1.2.1
@@ -39,7 +39,7 @@ require (
 	github.com/prometheus/common v0.60.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sony/gobreaker v1.0.0
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/temporalio/ringpop-go v0.0.0-20241119001152-e505ebd8f887
 	github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb
 	github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938
@@ -57,7 +57,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.31.0
 	go.opentelemetry.io/otel/trace v1.31.0
 	go.temporal.io/api v1.43.0
-	go.temporal.io/sdk v1.30.1
+	go.temporal.io/sdk v1.31.0
 	go.temporal.io/version v0.3.0
 	go.uber.org/automaxprocs v1.5.3
 	go.uber.org/fx v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/nexus-rpc/sdk-go v0.0.12 h1:Bsjo3aKIaApgi/eohhzufwrAeK/sEphcbeZM1Z7S/nI=
-github.com/nexus-rpc/sdk-go v0.0.12/go.mod h1:TpfkM2Cw0Rlk9drGkoiSMpFqflKTiQLWUNyKJjF8mKQ=
+github.com/nexus-rpc/sdk-go v0.1.0 h1:PUL/0vEY1//WnqyEHT5ao4LBRQ6MeNUihmnNGn0xMWY=
+github.com/nexus-rpc/sdk-go v0.1.0/go.mod h1:TpfkM2Cw0Rlk9drGkoiSMpFqflKTiQLWUNyKJjF8mKQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
@@ -274,8 +274,9 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/temporalio/ringpop-go v0.0.0-20241119001152-e505ebd8f887 h1:08Y1jDl4UKVu+TiQHIVKcW6TKQaHl15vBKkcZ094/SA=
 github.com/temporalio/ringpop-go v0.0.0-20241119001152-e505ebd8f887/go.mod h1:RE+CHmY+kOZQk47AQaVzwrGmxpflnLgTd6EOK0853j4=
 github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb h1:YzHH/U/dN7vMP+glybzcXRTczTrgfdRisNTzAj7La04=
@@ -332,8 +333,8 @@ go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeX
 go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
 go.temporal.io/api v1.43.0 h1:lBhq+u5qFJqGMXwWsmg/i8qn1UA/3LCwVc88l2xUMHg=
 go.temporal.io/api v1.43.0/go.mod h1:1WwYUMo6lao8yl0371xWUm13paHExN5ATYT/B7QtFis=
-go.temporal.io/sdk v1.30.1 h1:4wgfSjwuaayQl9Q0mUzpNV6w55TPAESSroR6Z5lE49o=
-go.temporal.io/sdk v1.30.1/go.mod h1:hNCZzd6dt7bxD9B4AECQgjHTd2NrzjdmGDbbv4xHuFU=
+go.temporal.io/sdk v1.31.0 h1:CLYiP0R5Sdj0gq8LyYKDDz4ccGOdJPR8wNGJU0JGwj8=
+go.temporal.io/sdk v1.31.0/go.mod h1:8U8H7rF9u4Hyb4Ry9yiEls5716DHPNvVITPNkgWUwE8=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
 go.temporal.io/version v0.3.0/go.mod h1:UA9S8/1LaKYae6TyD9NaPMJTZb911JcbqghI2CBSP78=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=

--- a/service/frontend/nexus_handler_test.go
+++ b/service/frontend/nexus_handler_test.go
@@ -171,7 +171,7 @@ func TestNexusInterceptRequest_InvalidNamespaceState_ResultsInBadRequest(t *test
 	var handlerError *nexus.HandlerError
 	require.ErrorAs(t, err, &handlerError)
 	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerError.Type)
-	require.Equal(t, "bad request", handlerError.Failure.Message)
+	require.Equal(t, "bad request", handlerError.Cause.Error())
 	mh := oc.metricsHandler.(*metricstest.CaptureHandler) //nolint:revive
 	capture := mh.StartCapture()
 	oc.metricsHandler.Counter("test").Record(1)
@@ -195,7 +195,7 @@ func TestNexusInterceptRequest_NamespaceConcurrencyLimited_ResultsInResourceExha
 	var handlerError *nexus.HandlerError
 	require.ErrorAs(t, err, &handlerError)
 	require.Equal(t, nexus.HandlerErrorTypeResourceExhausted, handlerError.Type)
-	require.Equal(t, "resource exhausted", handlerError.Failure.Message)
+	require.Equal(t, "resource exhausted", handlerError.Cause.Error())
 	mh := oc.metricsHandler.(*metricstest.CaptureHandler) //nolint:revive
 	capture := mh.StartCapture()
 	oc.metricsHandler.Counter("test").Record(1)
@@ -219,7 +219,7 @@ func TestNexusInterceptRequest_NamespaceRateLimited_ResultsInResourceExhausted(t
 	var handlerError *nexus.HandlerError
 	require.ErrorAs(t, err, &handlerError)
 	require.Equal(t, nexus.HandlerErrorTypeResourceExhausted, handlerError.Type)
-	require.Equal(t, "namespace rate limit exceeded", handlerError.Failure.Message)
+	require.Equal(t, "namespace rate limit exceeded", handlerError.Cause.Error())
 	mh := oc.metricsHandler.(*metricstest.CaptureHandler) //nolint:revive
 	capture := mh.StartCapture()
 	oc.metricsHandler.Counter("test").Record(1)
@@ -243,7 +243,7 @@ func TestNexusInterceptRequest_GlobalRateLimited_ResultsInResourceExhausted(t *t
 	var handlerError *nexus.HandlerError
 	require.ErrorAs(t, err, &handlerError)
 	require.Equal(t, nexus.HandlerErrorTypeResourceExhausted, handlerError.Type)
-	require.Equal(t, "service rate limit exceeded", handlerError.Failure.Message)
+	require.Equal(t, "service rate limit exceeded", handlerError.Cause.Error())
 	mh := oc.metricsHandler.(*metricstest.CaptureHandler) //nolint:revive
 	capture := mh.StartCapture()
 	oc.metricsHandler.Counter("test").Record(1)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2365,8 +2365,10 @@ func (h *Handler) CompleteNexusOperation(ctx context.Context, request *historyse
 	var opErr *nexus.UnsuccessfulOperationError
 	if request.State != string(nexus.OperationStateSucceeded) {
 		opErr = &nexus.UnsuccessfulOperationError{
-			State:   nexus.OperationState(request.GetState()),
-			Failure: *commonnexus.ProtoFailureToNexusFailure(request.GetFailure()),
+			State: nexus.OperationState(request.GetState()),
+			Cause: &nexus.FailureError{
+				Failure: commonnexus.ProtoFailureToNexusFailure(request.GetFailure()),
+			},
 		}
 	}
 	err = nexusoperations.CompletionHandler(

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -614,41 +614,71 @@ func (ms *MutableStateImpl) GetNexusCompletion(ctx context.Context) (nexus.Opera
 		completion, err := nexus.NewOperationCompletionSuccessful(p, nexus.OperationCompletionSuccessfulOptions{
 			Serializer: commonnexus.PayloadSerializer,
 			StartTime:  ms.executionState.GetStartTime().AsTime(),
-			StartLinks: []nexus.Link{startLink},
+			Links:      []nexus.Link{startLink},
 		})
 		if err != nil {
 			return nil, serviceerror.NewInternal(fmt.Sprintf("failed to construct Nexus completion: %v", err))
 		}
 		return completion, nil
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
-		f := commonnexus.APIFailureToNexusFailure(ce.GetWorkflowExecutionFailedEventAttributes().GetFailure())
-		return &nexus.OperationCompletionUnsuccessful{
-			State:      nexus.OperationStateFailed,
-			StartTime:  ms.executionState.GetStartTime().AsTime(),
-			StartLinks: []nexus.Link{startLink},
-			Failure:    f,
-		}, nil
+		f, err := commonnexus.APIFailureToNexusFailure(ce.GetWorkflowExecutionFailedEventAttributes().GetFailure())
+		if err != nil {
+			return nil, err
+		}
+		return nexus.NewOperationCompletionUnsuccessful(nexus.NewFailedOperationError(&nexus.FailureError{Failure: f}), nexus.OperationCompletionUnsuccessfulOptions{
+			StartTime: ms.executionState.GetStartTime().AsTime(),
+			Links:     []nexus.Link{startLink},
+		})
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
-		return &nexus.OperationCompletionUnsuccessful{
-			State:      nexus.OperationStateCanceled,
-			StartTime:  ms.executionState.GetStartTime().AsTime(),
-			StartLinks: []nexus.Link{startLink},
-			Failure:    &nexus.Failure{Message: "operation canceled"},
-		}, nil
+		failure := &failurepb.Failure{
+			Message: "operation canceled",
+			FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+				CanceledFailureInfo: &failurepb.CanceledFailureInfo{
+					Details: ce.GetWorkflowExecutionCanceledEventAttributes().GetDetails(),
+				},
+			},
+		}
+		f, err := commonnexus.APIFailureToNexusFailure(failure)
+		if err != nil {
+			return nil, err
+		}
+		return nexus.NewOperationCompletionUnsuccessful(nexus.NewCanceledOperationError(&nexus.FailureError{Failure: f}), nexus.OperationCompletionUnsuccessfulOptions{
+			StartTime: ms.executionState.GetStartTime().AsTime(),
+			Links:     []nexus.Link{startLink},
+		})
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
-		return &nexus.OperationCompletionUnsuccessful{
-			State:      nexus.OperationStateFailed,
-			StartTime:  ms.executionState.GetStartTime().AsTime(),
-			StartLinks: []nexus.Link{startLink},
-			Failure:    &nexus.Failure{Message: "operation terminated"},
-		}, nil
+		failure := &failurepb.Failure{
+			Message: "operation terminated",
+			FailureInfo: &failurepb.Failure_TerminatedFailureInfo{
+				TerminatedFailureInfo: &failurepb.TerminatedFailureInfo{},
+			},
+		}
+		f, err := commonnexus.APIFailureToNexusFailure(failure)
+		if err != nil {
+			return nil, err
+		}
+		return nexus.NewOperationCompletionUnsuccessful(nexus.NewFailedOperationError(&nexus.FailureError{Failure: f}), nexus.OperationCompletionUnsuccessfulOptions{
+			StartTime: ms.executionState.GetStartTime().AsTime(),
+			Links:     []nexus.Link{startLink},
+		})
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
-		return &nexus.OperationCompletionUnsuccessful{
-			State:      nexus.OperationStateFailed,
-			StartTime:  ms.executionState.GetStartTime().AsTime(),
-			StartLinks: []nexus.Link{startLink},
-			Failure:    &nexus.Failure{Message: "operation exceeded internal timeout"},
-		}, nil
+		failure := &failurepb.Failure{
+			Message: "operation exceeded internal timeout",
+			FailureInfo: &failurepb.Failure_TimeoutFailureInfo{
+				TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+					// Not filling in timeout type and other information, it's not particularly interesting to a Nexus
+					// caller.
+				},
+			},
+		}
+		f, err := commonnexus.APIFailureToNexusFailure(failure)
+		if err != nil {
+			return nil, err
+		}
+		return nexus.NewOperationCompletionUnsuccessful(nexus.NewFailedOperationError(&nexus.FailureError{Failure: f}), nexus.OperationCompletionUnsuccessfulOptions{
+			StartTime: ms.executionState.GetStartTime().AsTime(),
+			Links:     []nexus.Link{startLink},
+		})
 	}
 	return nil, serviceerror.NewInternal(fmt.Sprintf("invalid workflow execution status: %v", ce.GetEventType()))
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -630,15 +630,14 @@ func (ms *MutableStateImpl) GetNexusCompletion(ctx context.Context) (nexus.Opera
 			Links:     []nexus.Link{startLink},
 		})
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
-		failure := &failurepb.Failure{
+		f, err := commonnexus.APIFailureToNexusFailure(&failurepb.Failure{
 			Message: "operation canceled",
 			FailureInfo: &failurepb.Failure_CanceledFailureInfo{
 				CanceledFailureInfo: &failurepb.CanceledFailureInfo{
 					Details: ce.GetWorkflowExecutionCanceledEventAttributes().GetDetails(),
 				},
 			},
-		}
-		f, err := commonnexus.APIFailureToNexusFailure(failure)
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -647,13 +646,12 @@ func (ms *MutableStateImpl) GetNexusCompletion(ctx context.Context) (nexus.Opera
 			Links:     []nexus.Link{startLink},
 		})
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
-		failure := &failurepb.Failure{
+		f, err := commonnexus.APIFailureToNexusFailure(&failurepb.Failure{
 			Message: "operation terminated",
 			FailureInfo: &failurepb.Failure_TerminatedFailureInfo{
 				TerminatedFailureInfo: &failurepb.TerminatedFailureInfo{},
 			},
-		}
-		f, err := commonnexus.APIFailureToNexusFailure(failure)
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -662,7 +660,7 @@ func (ms *MutableStateImpl) GetNexusCompletion(ctx context.Context) (nexus.Opera
 			Links:     []nexus.Link{startLink},
 		})
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
-		failure := &failurepb.Failure{
+		f, err := commonnexus.APIFailureToNexusFailure(&failurepb.Failure{
 			Message: "operation exceeded internal timeout",
 			FailureInfo: &failurepb.Failure_TimeoutFailureInfo{
 				TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
@@ -670,8 +668,7 @@ func (ms *MutableStateImpl) GetNexusCompletion(ctx context.Context) (nexus.Opera
 					// caller.
 				},
 			},
-		}
-		f, err := commonnexus.APIFailureToNexusFailure(failure)
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/service/history/workflow/workflow_test/mutable_state_impl_test.go
+++ b/service/history/workflow/workflow_test/mutable_state_impl_test.go
@@ -401,9 +401,9 @@ func TestGetNexusCompletion(t *testing.T) {
 			verifyCompletion: func(t *testing.T, completion nexus.OperationCompletion) {
 				success, ok := completion.(*nexus.OperationCompletionSuccessful)
 				require.True(t, ok)
-				require.Equal(t, "application/json", success.Header.Get("content-type"))
-				require.Equal(t, "1", success.Header.Get("content-length"))
-				buf, err := io.ReadAll(success.Body)
+				require.Equal(t, "application/json", success.Reader.Header.Get("type"))
+				require.Equal(t, "1", success.Reader.Header.Get("length"))
+				buf, err := io.ReadAll(success.Reader)
 				require.NoError(t, err)
 				require.Equal(t, []byte("3"), buf)
 			},

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -1934,6 +1934,8 @@ pollLoop:
 
 		nexusReq := task.nexus.request.GetRequest()
 		nexusReq.Header[nexus.HeaderRequestTimeout] = time.Until(task.nexus.deadline).String()
+		// Java SDK currently expects the header in this form. We should be able to remove this duplication sometime mid 2025.
+		nexusReq.Header["Request-Timeout"] = time.Until(task.nexus.deadline).String()
 		if !task.nexus.operationDeadline.IsZero() {
 			nexusReq.Header[nexus.HeaderOperationTimeout] = commonnexus.FormatDuration(time.Until(task.nexus.operationDeadline))
 		}

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -188,10 +188,12 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes() {
 				var operationError *nexus.UnsuccessfulOperationError
 				require.ErrorAs(t, err, &operationError)
 				require.Equal(t, nexus.OperationStateFailed, operationError.State)
-				require.Equal(t, "deliberate test failure", operationError.Failure.Message)
-				require.Equal(t, map[string]string{"k": "v"}, operationError.Failure.Metadata)
+				require.Equal(t, "deliberate test failure", operationError.Cause.Error())
+				var failureErr *nexus.FailureError
+				require.ErrorAs(t, operationError.Cause, &failureErr)
+				require.Equal(t, map[string]string{"k": "v"}, failureErr.Failure.Metadata)
 				var details string
-				err = json.Unmarshal(operationError.Failure.Details, &details)
+				err = json.Unmarshal(failureErr.Failure.Details, &details)
 				require.NoError(t, err)
 				require.Equal(t, "details", details)
 			},
@@ -210,7 +212,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes() {
 				require.ErrorAs(t, err, &handlerErr)
 				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
 				require.Equal(t, "worker", headers.Get("Temporal-Nexus-Failure-Source"))
-				require.Equal(t, "deliberate internal failure", handlerErr.Failure.Message)
+				require.Equal(t, "deliberate internal failure", handlerErr.Cause.Error())
 			},
 		},
 		{
@@ -229,7 +231,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes() {
 				var handlerErr *nexus.HandlerError
 				require.ErrorAs(t, err, &handlerErr)
 				require.Equal(t, nexus.HandlerErrorTypeUpstreamTimeout, handlerErr.Type)
-				require.Equal(t, "upstream timeout", handlerErr.Failure.Message)
+				require.Equal(t, "upstream timeout", handlerErr.Cause.Error())
 			},
 		},
 	}
@@ -239,7 +241,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes() {
 		defer cancel()
 
 		httpCaller, headerCapture := newHeaderCaptureCaller()
-		client, err := nexus.NewClient(nexus.ClientOptions{
+		client, err := nexus.NewHTTPClient(nexus.HTTPClientOptions{
 			BaseURL:    dispatchURL,
 			Service:    "test-service",
 			HTTPCaller: httpCaller,
@@ -313,7 +315,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Na
 	taskQueue := testcore.RandomizeStr("task-queue")
 	namespace := "namespace not/found"
 	u := getDispatchByNsAndTqURL(s.HttpAPIAddress(), namespace, taskQueue)
-	client, err := nexus.NewClient(nexus.ClientOptions{BaseURL: u, Service: "test-service"})
+	client, err := nexus.NewHTTPClient(nexus.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	ctx := testcore.NewContext()
 	capture := s.GetTestCluster().Host().CaptureMetricsHandler().StartCapture()
@@ -322,7 +324,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Na
 	var handlerError *nexus.HandlerError
 	s.ErrorAs(err, &handlerError)
 	s.Equal(nexus.HandlerErrorTypeNotFound, handlerError.Type)
-	s.Equal(fmt.Sprintf("namespace not found: %q", namespace), handlerError.Failure.Message)
+	s.Equal(fmt.Sprintf("namespace not found: %q", namespace), handlerError.Cause.Error())
 
 	snap := capture.Snapshot()
 
@@ -340,7 +342,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Na
 	}
 
 	u := getDispatchByNsAndTqURL(s.HttpAPIAddress(), namespace, taskQueue)
-	client, err := nexus.NewClient(nexus.ClientOptions{BaseURL: u, Service: "test-service"})
+	client, err := nexus.NewHTTPClient(nexus.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	ctx := testcore.NewContext()
 	capture := s.GetTestCluster().Host().CaptureMetricsHandler().StartCapture()
@@ -350,7 +352,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Na
 	s.ErrorAs(err, &handlerErr)
 	s.Equal(nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
 	// I wish we'd never put periods in error messages :(
-	s.Equal("Namespace length exceeds limit.", handlerErr.Failure.Message)
+	s.Equal("Namespace length exceeds limit.", handlerErr.Cause.Error())
 
 	snap := capture.Snapshot()
 
@@ -418,7 +420,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Forbidden() {
 	}
 
 	testFn := func(t *testing.T, tc testcase, dispatchURL string) {
-		client, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test-service"})
+		client, err := nexus.NewHTTPClient(nexus.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
 		require.NoError(t, err)
 		ctx := testcore.NewContext()
 
@@ -435,7 +437,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Forbidden() {
 		var handlerErr *nexus.HandlerError
 		require.ErrorAs(t, err, &handlerErr)
 		require.Equal(t, nexus.HandlerErrorTypeUnauthorized, handlerErr.Type)
-		require.Equal(t, tc.failureMessage, handlerErr.Failure.Message)
+		require.Equal(t, tc.failureMessage, handlerErr.Cause.Error())
 
 		snap := capture.Snapshot()
 
@@ -476,7 +478,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims() {
 				var handlerErr *nexus.HandlerError
 				require.ErrorAs(t, err, &handlerErr)
 				require.Equal(t, nexus.HandlerErrorTypeUnauthorized, handlerErr.Type)
-				require.Equal(t, "permission denied", handlerErr.Failure.Message)
+				require.Equal(t, "permission denied", handlerErr.Cause.Error())
 				require.Equal(t, 0, len(snap["nexus_request_preprocess_errors"]))
 			},
 		},
@@ -489,7 +491,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims() {
 				var handlerErr *nexus.HandlerError
 				require.ErrorAs(t, err, &handlerErr)
 				require.Equal(t, nexus.HandlerErrorTypeUnauthenticated, handlerErr.Type)
-				require.Equal(t, "unauthorized", handlerErr.Failure.Message)
+				require.Equal(t, "unauthorized", handlerErr.Cause.Error())
 				require.Equal(t, 1, len(snap["nexus_request_preprocess_errors"]))
 			},
 		},
@@ -530,7 +532,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims() {
 		ctx, cancel := context.WithCancel(testcore.NewContext())
 		defer cancel()
 
-		client, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test-service"})
+		client, err := nexus.NewHTTPClient(nexus.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
 		s.NoError(err)
 
 		if tc.handler != nil {
@@ -581,7 +583,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_PayloadSizeLimit() {
 		ctx, cancel := context.WithCancel(testcore.NewContext())
 		defer cancel()
 
-		client, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test-service"})
+		client, err := nexus.NewHTTPClient(nexus.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
 		require.NoError(t, err)
 		capture := s.GetTestCluster().Host().CaptureMetricsHandler().StartCapture()
 		defer s.GetTestCluster().Host().CaptureMetricsHandler().StopCapture(capture)
@@ -602,7 +604,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_PayloadSizeLimit() {
 		var handlerErr *nexus.HandlerError
 		require.ErrorAs(t, err, &handlerErr)
 		require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
-		require.Equal(t, "input exceeds size limit", handlerErr.Failure.Message)
+		require.Equal(t, "input exceeds size limit", handlerErr.Cause.Error())
 	}
 
 	s.T().Run("ByNamespaceAndTaskQueue", func(t *testing.T) {
@@ -657,7 +659,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes() {
 				require.ErrorAs(t, err, &handlerErr)
 				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
 				require.Equal(t, "worker", headers.Get("Temporal-Nexus-Failure-Source"))
-				require.Equal(t, "deliberate internal failure", handlerErr.Failure.Message)
+				require.Equal(t, "deliberate internal failure", handlerErr.Cause.Error())
 			},
 		},
 		{
@@ -676,7 +678,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes() {
 				var handlerErr *nexus.HandlerError
 				require.ErrorAs(t, err, &handlerErr)
 				require.Equal(t, nexus.HandlerErrorTypeUpstreamTimeout, handlerErr.Type)
-				require.Equal(t, "upstream timeout", handlerErr.Failure.Message)
+				require.Equal(t, "upstream timeout", handlerErr.Cause.Error())
 			},
 		},
 	}
@@ -686,7 +688,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes() {
 		defer cancel()
 
 		httpCaller, headerCapture := newHeaderCaptureCaller()
-		client, err := nexus.NewClient(nexus.ClientOptions{
+		client, err := nexus.NewHTTPClient(nexus.HTTPClientOptions{
 			BaseURL:    dispatchURL,
 			Service:    "test-service",
 			HTTPCaller: httpCaller,
@@ -767,7 +769,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Su
 	s.NoError(err)
 
 	u := getDispatchByNsAndTqURL(s.HttpAPIAddress(), s.Namespace(), taskQueue)
-	client, err := nexus.NewClient(nexus.ClientOptions{BaseURL: u, Service: "test-service"})
+	client, err := nexus.NewHTTPClient(nexus.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	// Versioned poller gets task
 	go s.versionedNexusTaskPoller(ctx, taskQueue, "new-build-id", nexusEchoHandler)
@@ -822,7 +824,7 @@ func (s *NexusApiTestSuite) TestNexus_RespondNexusTaskMethods_VerifiesTaskTokenM
 
 func (s *NexusApiTestSuite) TestNexusStartOperation_ByEndpoint_EndpointNotFound() {
 	u := getDispatchByEndpointURL(s.HttpAPIAddress(), uuid.NewString())
-	client, err := nexus.NewClient(nexus.ClientOptions{BaseURL: u, Service: "test-service"})
+	client, err := nexus.NewHTTPClient(nexus.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	ctx := testcore.NewContext()
 	capture := s.GetTestCluster().Host().CaptureMetricsHandler().StartCapture()
@@ -831,7 +833,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_ByEndpoint_EndpointNotFound(
 	var handlerErr *nexus.HandlerError
 	s.ErrorAs(err, &handlerErr)
 	s.Equal(nexus.HandlerErrorTypeNotFound, handlerErr.Type)
-	s.Equal("nexus endpoint not found", handlerErr.Failure.Message)
+	s.Equal("nexus endpoint not found", handlerErr.Cause.Error())
 	snap := capture.Snapshot()
 	s.Equal(1, len(snap["nexus_request_preprocess_errors"]))
 }

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -2057,7 +2057,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure() {
 			}
 		},
 	}
-	listenAddr := nexustest.AllocListenAddress(s.T())
+	listenAddr := nexustest.AllocListenAddress()
 	nexustest.NewNexusServer(s.T(), listenAddr, h)
 
 	_, err := s.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -24,6 +24,9 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"slices"
@@ -39,6 +42,7 @@ import (
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/operatorservice/v1"
@@ -1028,12 +1032,8 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure() {
 	s.Greater(startedEventIdx, 0)
 
 	// Send a valid - failed completion request.
-	completion := &nexus.OperationCompletionUnsuccessful{
-		State: nexus.OperationStateFailed,
-		Failure: &nexus.Failure{
-			Message: "test operation failed",
-		},
-	}
+	completion, err := nexus.NewOperationCompletionUnsuccessful(nexus.NewFailedOperationError(errors.New("test operation failed")), nexus.OperationCompletionUnsuccessfulOptions{})
+	s.NoError(err)
 	res, snap := s.sendNexusCompletionRequest(ctx, s.T(), publicCallbackUrl, completion, callbackToken)
 	s.Equal(http.StatusOK, res.StatusCode)
 	s.Equal(1, len(snap["nexus_completion_requests"]))
@@ -1726,6 +1726,387 @@ func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationWithNilIO() {
 			break
 		}
 	}
+}
+
+func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	defer cancel()
+	taskQueue := testcore.RandomizeStr("caller_" + s.T().Name())
+	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
+	converter := temporal.NewDefaultFailureConverter(temporal.DefaultFailureConverterOptions{})
+
+	_, err := s.SdkClient().OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpointName,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: s.Namespace(),
+						TaskQueue: taskQueue,
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	w := worker.New(
+		s.SdkClient(),
+		taskQueue,
+		worker.Options{},
+	)
+
+	svc := nexus.NewService("test")
+	op := temporalnexus.NewSyncOperation("op", func(ctx context.Context, c client.Client, outcome string, soo nexus.StartOperationOptions) (nexus.NoValue, error) {
+		switch outcome {
+		case "fail-handler-internal":
+			return nil, nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "intentional internal error")
+		case "fail-handler-app-error":
+			return nil, temporal.NewApplicationError("app error", "TestError", "details")
+		case "fail-handler-bad-request":
+			return nil, nexus.HandlerErrorf(nexus.HandlerErrorTypeBadRequest, "bad request")
+		case "fail-operation":
+			return nil, nexus.NewFailedOperationError(errors.New("some error"))
+		case "fail-operation-app-error":
+			return nil, temporal.NewNonRetryableApplicationError("app error", "TestError", nil, "details")
+		}
+		return nil, nexus.HandlerErrorf(nexus.HandlerErrorTypeBadRequest, "unexpected outcome: %s", outcome)
+	})
+	svc.Register(op)
+
+	callerWF := func(ctx workflow.Context, outcome string) (nexus.NoValue, error) {
+		c := workflow.NewNexusClient(endpointName, svc.Name)
+		fut := c.ExecuteOperation(ctx, op, outcome, workflow.NexusOperationOptions{})
+		return nil, fut.Get(ctx, nil)
+	}
+
+	w.RegisterNexusService(svc)
+	w.RegisterWorkflow(callerWF)
+	w.Start()
+	defer w.Stop()
+
+	cases := []struct {
+		outcome            string
+		checkPendingError  func(t *testing.T, pendingErr error)
+		checkWorkflowError func(t *testing.T, wfErr error)
+	}{
+		{
+			outcome: "fail-handler-internal",
+			checkPendingError: func(t *testing.T, pendingErr error) {
+				var handlerErr *nexus.HandlerError
+				require.ErrorAs(t, pendingErr, &handlerErr)
+				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
+				var appErr *temporal.ApplicationError
+				require.ErrorAs(t, handlerErr.Cause, &appErr)
+				require.Equal(t, "intentional internal error", appErr.Message())
+			},
+		},
+		{
+			outcome: "fail-handler-app-error",
+			checkPendingError: func(t *testing.T, pendingErr error) {
+				var handlerErr *nexus.HandlerError
+				require.ErrorAs(t, pendingErr, &handlerErr)
+				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
+				var appErr *temporal.ApplicationError
+				require.ErrorAs(t, handlerErr.Cause, &appErr)
+				require.Equal(t, "app error", appErr.Message())
+				require.Equal(t, "TestError", appErr.Type())
+				var details string
+				require.NoError(t, appErr.Details(&details))
+				require.Equal(t, "details", details)
+			},
+		},
+		{
+			outcome: "fail-handler-bad-request",
+			checkWorkflowError: func(t *testing.T, wfErr error) {
+				var opErr *temporal.NexusOperationError
+				require.ErrorAs(t, wfErr, &opErr)
+				var handlerErr *nexus.HandlerError
+				require.ErrorAs(t, opErr, &handlerErr)
+				require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+				var appErr *temporal.ApplicationError
+				require.ErrorAs(t, handlerErr.Cause, &appErr)
+				require.Equal(t, "bad request", appErr.Message())
+
+			},
+		},
+		{
+			outcome: "fail-operation",
+			checkWorkflowError: func(t *testing.T, wfErr error) {
+				var opErr *temporal.NexusOperationError
+				require.ErrorAs(t, wfErr, &opErr)
+				var appErr *temporal.ApplicationError
+				require.ErrorAs(t, opErr, &appErr)
+				require.Equal(t, "some error", appErr.Message())
+			},
+		},
+		{
+			outcome: "fail-operation-app-error",
+			checkWorkflowError: func(t *testing.T, wfErr error) {
+				var opErr *temporal.NexusOperationError
+				require.ErrorAs(t, wfErr, &opErr)
+				var appErr *temporal.ApplicationError
+				require.ErrorAs(t, opErr, &appErr)
+				require.Equal(t, "app error", appErr.Message())
+				require.Equal(t, "TestError", appErr.Type())
+				var details string
+				require.NoError(t, appErr.Details(&details))
+				require.Equal(t, "details", details)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		s.T().Run(tc.outcome, func(t *testing.T) {
+			run, err := s.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+				TaskQueue: taskQueue,
+			}, callerWF, tc.outcome)
+			s.NoError(err)
+
+			if tc.checkPendingError != nil {
+				var f *failurepb.Failure
+				require.EventuallyWithT(t, func(t *assert.CollectT) {
+					desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
+					require.NoError(t, err)
+					assert.Len(t, desc.PendingNexusOperations, 1)
+					f = desc.PendingNexusOperations[0].LastAttemptFailure
+					assert.NotNil(t, f)
+
+				}, 10*time.Second, 100*time.Millisecond)
+				tc.checkPendingError(t, converter.FailureToError(f))
+				return
+			}
+
+			wfErr := run.Get(ctx, nil)
+			tc.checkWorkflowError(t, wfErr)
+		})
+
+	}
+}
+
+func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationErrorRehydration() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	defer cancel()
+	testCtx := ctx
+	taskQueue := testcore.RandomizeStr("caller_" + s.T().Name())
+	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
+
+	_, err := s.SdkClient().OperatorService().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpointName,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_Worker_{
+					Worker: &nexuspb.EndpointTarget_Worker{
+						Namespace: s.Namespace(),
+						TaskQueue: taskQueue,
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	w := worker.New(
+		s.SdkClient(),
+		taskQueue,
+		worker.Options{},
+	)
+
+	svc := nexus.NewService("test")
+
+	handlerWF := func(ctx workflow.Context, outcome string) (nexus.NoValue, error) {
+		switch outcome {
+		case "wait", "timeout":
+			// Wait for the workflow to be canceled.
+			return nil, workflow.Await(ctx, func() bool { return false })
+		case "fail":
+			return nil, temporal.NewApplicationError("app error", "TestError", "details")
+		}
+		return nil, fmt.Errorf("unexpected outcome: %s", outcome)
+	}
+
+	op := temporalnexus.NewWorkflowRunOperation("op", handlerWF, func(ctx context.Context, outcome string, soo nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+		var workflowExecutionTimeout time.Duration
+		if outcome == "timeout" {
+			workflowExecutionTimeout = time.Second
+		}
+		return client.StartWorkflowOptions{ID: soo.RequestID, WorkflowExecutionTimeout: workflowExecutionTimeout}, nil
+	})
+	svc.Register(op)
+
+	callerWF := func(ctx workflow.Context, outcome, action string) (nexus.NoValue, error) {
+		opCtx, cancel := workflow.WithCancel(ctx)
+		defer cancel()
+		c := workflow.NewNexusClient(endpointName, svc.Name)
+		fut := c.ExecuteOperation(opCtx, op, outcome, workflow.NexusOperationOptions{})
+		var exec workflow.NexusOperationExecution
+		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+			return nil, err
+		}
+		switch action {
+		case "terminate":
+			// Lazy man's version of a local activity, don't try this at home.
+			workflow.SideEffect(ctx, func(ctx workflow.Context) any {
+				err := s.SdkClient().TerminateWorkflow(testCtx, exec.OperationID, "", "")
+				if err != nil {
+					panic(err)
+				}
+				return nil
+			})
+		case "cancel":
+			cancel()
+			err := fut.Get(ctx, nil)
+			// The Go SDK unwraps CanceledErrors when an error is returned from the workflow, assert in-workflow.
+			var opErr *temporal.NexusOperationError
+			if !errors.As(err, &opErr) {
+				return nil, fmt.Errorf("expected NexusOperationError, got %w", err)
+			}
+			var canceledErr *temporal.CanceledError
+			if !errors.As(opErr, &canceledErr) {
+				return nil, fmt.Errorf("expected CanceledError, got %w", err)
+			}
+		}
+		return nil, fut.Get(ctx, nil)
+	}
+
+	w.RegisterNexusService(svc)
+	w.RegisterWorkflow(callerWF)
+	w.RegisterWorkflow(handlerWF)
+	w.Start()
+	defer w.Stop()
+
+	cases := []struct {
+		outcome, action    string
+		checkWorkflowError func(t *testing.T, wfErr error)
+	}{
+		{
+			outcome: "fail",
+			checkWorkflowError: func(t *testing.T, wfErr error) {
+				var opErr *temporal.NexusOperationError
+				require.ErrorAs(t, wfErr, &opErr)
+				var appErr *temporal.ApplicationError
+				require.ErrorAs(t, opErr, &appErr)
+				require.Equal(t, "app error", appErr.Message())
+				require.Equal(t, "TestError", appErr.Type())
+				var details string
+				require.NoError(t, appErr.Details(&details))
+				require.Equal(t, "details", details)
+			},
+		},
+		{
+			outcome: "wait",
+			action:  "terminate",
+			checkWorkflowError: func(t *testing.T, wfErr error) {
+				var opErr *temporal.NexusOperationError
+				require.ErrorAs(t, wfErr, &opErr)
+				var termErr *temporal.TerminatedError
+				require.ErrorAs(t, opErr, &termErr)
+			},
+		},
+		{
+			outcome: "wait",
+			action:  "cancel",
+			checkWorkflowError: func(t *testing.T, wfErr error) {
+				// The Go SDK loses the NexusOperationError (as well as any other error if it wraps a CanceledError),
+				// assertions done in workflow.
+				var canceledErr *temporal.CanceledError
+				require.ErrorAs(t, wfErr, &canceledErr)
+			},
+		},
+		{
+			outcome: "timeout",
+			checkWorkflowError: func(t *testing.T, wfErr error) {
+				var opErr *temporal.NexusOperationError
+				require.ErrorAs(t, wfErr, &opErr)
+				var timeoutErr *temporal.TimeoutError
+				require.ErrorAs(t, opErr, &timeoutErr)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		s.T().Run(tc.outcome+"-"+tc.action, func(t *testing.T) {
+			run, err := s.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+				TaskQueue: taskQueue,
+			}, callerWF, tc.outcome, tc.action)
+			s.NoError(err)
+
+			wfErr := run.Get(ctx, nil)
+			tc.checkWorkflowError(t, wfErr)
+		})
+
+	}
+}
+
+func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure() {
+	ctx := testcore.NewContext()
+	taskQueue := testcore.RandomizeStr(s.T().Name())
+	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
+
+	h := nexustest.Handler{
+		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+			return nil, &nexus.HandlerError{
+				Type: nexus.HandlerErrorTypeBadRequest,
+				Cause: &nexus.FailureError{
+					Failure: nexus.Failure{
+						Message:  "fail me",
+						Metadata: map[string]string{"key": "val"},
+						Details:  []byte(`"details"`),
+					},
+				},
+			}
+		},
+	}
+	listenAddr := nexustest.AllocListenAddress(s.T())
+	nexustest.NewNexusServer(s.T(), listenAddr, h)
+
+	_, err := s.OperatorClient().CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+		Spec: &nexuspb.EndpointSpec{
+			Name: endpointName,
+			Target: &nexuspb.EndpointTarget{
+				Variant: &nexuspb.EndpointTarget_External_{
+					External: &nexuspb.EndpointTarget_External{
+						Url: "http://" + listenAddr,
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	w := worker.New(
+		s.SdkClient(),
+		taskQueue,
+		worker.Options{},
+	)
+
+	callerWF := func(ctx workflow.Context) (nexus.NoValue, error) {
+		c := workflow.NewNexusClient(endpointName, "dont-care")
+		fut := c.ExecuteOperation(ctx, "operation", nil, workflow.NexusOperationOptions{})
+		return nil, fut.Get(ctx, nil)
+	}
+
+	w.RegisterWorkflow(callerWF)
+	w.Start()
+	defer w.Stop()
+
+	run, err := s.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue: taskQueue,
+	}, callerWF)
+	s.NoError(err)
+
+	var handlerErr *nexus.HandlerError
+	s.ErrorAs(run.Get(ctx, nil), &handlerErr)
+	s.Equal(nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+	var appErr *temporal.ApplicationError
+	s.ErrorAs(handlerErr.Cause, &appErr)
+	s.Equal(appErr.Message(), "fail me")
+	var failure nexus.Failure
+	s.NoError(appErr.Details(&failure))
+	s.Equal(map[string]string{"key": "val"}, failure.Metadata)
+	var details string
+	s.NoError(json.Unmarshal(failure.Details, &details))
+	s.Equal("details", details)
 }
 
 func (s *NexusWorkflowTestSuite) sendNexusCompletionRequest(

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1772,7 +1772,7 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 		}
 		return nil, nexus.HandlerErrorf(nexus.HandlerErrorTypeBadRequest, "unexpected outcome: %s", outcome)
 	})
-	svc.Register(op)
+	s.NoError(svc.Register(op))
 
 	callerWF := func(ctx workflow.Context, outcome string) (nexus.NoValue, error) {
 		c := workflow.NewNexusClient(endpointName, svc.Name)
@@ -1782,8 +1782,8 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 
 	w.RegisterNexusService(svc)
 	w.RegisterWorkflow(callerWF)
-	w.Start()
-	defer w.Stop()
+	s.NoError(w.Start())
+	s.T().Cleanup(w.Stop)
 
 	cases := []struct {
 		outcome            string
@@ -1932,7 +1932,7 @@ func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationErrorRehydration() {
 		}
 		return client.StartWorkflowOptions{ID: soo.RequestID, WorkflowExecutionTimeout: workflowExecutionTimeout}, nil
 	})
-	svc.Register(op)
+	s.NoError(svc.Register(op))
 
 	callerWF := func(ctx workflow.Context, outcome, action string) (nexus.NoValue, error) {
 		opCtx, cancel := workflow.WithCancel(ctx)
@@ -1972,8 +1972,8 @@ func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationErrorRehydration() {
 	w.RegisterNexusService(svc)
 	w.RegisterWorkflow(callerWF)
 	w.RegisterWorkflow(handlerWF)
-	w.Start()
-	defer w.Stop()
+	s.NoError(w.Start())
+	s.T().Cleanup(w.Stop)
 
 	cases := []struct {
 		outcome, action    string
@@ -2087,8 +2087,8 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure() {
 	}
 
 	w.RegisterWorkflow(callerWF)
-	w.Start()
-	defer w.Stop()
+	s.NoError(w.Start())
+	s.T().Cleanup(w.Stop)
 
 	run, err := s.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,

--- a/tests/xdc/nexus_request_forwarding_test.go
+++ b/tests/xdc/nexus_request_forwarding_test.go
@@ -160,9 +160,9 @@ func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToAc
 				require.ErrorAs(t, retErr, &operationError)
 				require.Equal(t, nexus.OperationStateFailed, operationError.State)
 				require.Equal(t, "deliberate test failure", operationError.Cause.Error())
-				require.Equal(t, map[string]string{"k": "v"}, operationError.Cause.Error())
 				var failureError *nexus.FailureError
 				require.ErrorAs(t, operationError.Cause, &failureError)
+				require.Equal(t, map[string]string{"k": "v"}, failureError.Failure.Metadata)
 				var details string
 				err := json.Unmarshal(failureError.Failure.Details, &details)
 				require.NoError(t, err)

--- a/tests/xdc/nexus_request_forwarding_test.go
+++ b/tests/xdc/nexus_request_forwarding_test.go
@@ -159,10 +159,12 @@ func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToAc
 				var operationError *nexus.UnsuccessfulOperationError
 				require.ErrorAs(t, retErr, &operationError)
 				require.Equal(t, nexus.OperationStateFailed, operationError.State)
-				require.Equal(t, "deliberate test failure", operationError.Failure.Message)
-				require.Equal(t, map[string]string{"k": "v"}, operationError.Failure.Metadata)
+				require.Equal(t, "deliberate test failure", operationError.Cause.Error())
+				require.Equal(t, map[string]string{"k": "v"}, operationError.Cause.Error())
+				var failureError *nexus.FailureError
+				require.ErrorAs(t, operationError.Cause, &failureError)
 				var details string
-				err := json.Unmarshal(operationError.Failure.Details, &details)
+				err := json.Unmarshal(failureError.Failure.Details, &details)
 				require.NoError(t, err)
 				require.Equal(t, "details", details)
 				requireExpectedMetricsCaptured(t, activeSnap, ns, "StartNexusOperation", "operation_error")
@@ -183,7 +185,7 @@ func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToAc
 				var handlerErr *nexus.HandlerError
 				require.ErrorAs(t, retErr, &handlerErr)
 				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
-				require.Equal(t, "deliberate internal failure", handlerErr.Failure.Message)
+				require.Equal(t, "deliberate internal failure", handlerErr.Cause.Error())
 				requireExpectedMetricsCaptured(t, activeSnap, ns, "StartNexusOperation", "handler_error")
 				requireExpectedMetricsCaptured(t, passiveSnap, ns, "StartNexusOperation", "forwarded_request_error")
 			},
@@ -203,7 +205,7 @@ func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToAc
 				var handlerErr *nexus.HandlerError
 				require.ErrorAs(t, retErr, &handlerErr)
 				require.Equal(t, nexus.HandlerErrorTypeUnavailable, handlerErr.Type)
-				require.Equal(t, "cluster inactive", handlerErr.Failure.Message)
+				require.Equal(t, "cluster inactive", handlerErr.Cause.Error())
 				requireExpectedMetricsCaptured(t, passiveSnap, ns, "StartNexusOperation", "namespace_inactive_forwarding_disabled")
 			},
 		},
@@ -213,7 +215,7 @@ func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToAc
 		tc := tc
 		s.T().Run(tc.name, func(t *testing.T) {
 			dispatchURL := fmt.Sprintf("http://%s/%s", s.cluster2.Host().FrontendHTTPAddress(), cnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Path(cnexus.NamespaceAndTaskQueue{Namespace: ns, TaskQueue: tc.taskQueue}))
-			nexusClient, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test-service"})
+			nexusClient, err := nexus.NewHTTPClient(nexus.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
 			s.NoError(err)
 
 			activeMetricsHandler, ok := s.cluster1.Host().GetMetricsHandler().(*metricstest.CaptureHandler)
@@ -284,7 +286,7 @@ func (s *NexusRequestForwardingSuite) TestCancelOperationForwardedFromStandbyToA
 				var handlerErr *nexus.HandlerError
 				require.ErrorAs(t, retErr, &handlerErr)
 				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
-				require.Equal(t, "deliberate internal failure", handlerErr.Failure.Message)
+				require.Equal(t, "deliberate internal failure", handlerErr.Cause.Error())
 				requireExpectedMetricsCaptured(t, activeSnap, ns, "CancelNexusOperation", "handler_error")
 				requireExpectedMetricsCaptured(t, passiveSnap, ns, "CancelNexusOperation", "forwarded_request_error")
 			},
@@ -304,7 +306,7 @@ func (s *NexusRequestForwardingSuite) TestCancelOperationForwardedFromStandbyToA
 				var handlerErr *nexus.HandlerError
 				require.ErrorAs(t, retErr, &handlerErr)
 				require.Equal(t, nexus.HandlerErrorTypeUnavailable, handlerErr.Type)
-				require.Equal(t, "cluster inactive", handlerErr.Failure.Message)
+				require.Equal(t, "cluster inactive", handlerErr.Cause.Error())
 				requireExpectedMetricsCaptured(t, passiveSnap, ns, "CancelNexusOperation", "namespace_inactive_forwarding_disabled")
 			},
 		},
@@ -314,7 +316,7 @@ func (s *NexusRequestForwardingSuite) TestCancelOperationForwardedFromStandbyToA
 		tc := tc
 		s.T().Run(tc.name, func(t *testing.T) {
 			dispatchURL := fmt.Sprintf("http://%s/%s", s.cluster2.Host().FrontendHTTPAddress(), cnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Path(cnexus.NamespaceAndTaskQueue{Namespace: ns, TaskQueue: tc.taskQueue}))
-			nexusClient, err := nexus.NewClient(nexus.ClientOptions{BaseURL: dispatchURL, Service: "test-service"})
+			nexusClient, err := nexus.NewHTTPClient(nexus.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
 			s.NoError(err)
 
 			activeMetricsHandler, ok := s.cluster1.Host().GetMetricsHandler().(*metricstest.CaptureHandler)

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -570,10 +570,11 @@ func (s *NexusStateReplicationSuite) completeNexusOperation(ctx context.Context,
 }
 
 func (s *NexusStateReplicationSuite) cancelNexusOperation(ctx context.Context, callbackUrl, callbackToken string) {
-	completion := &nexus.OperationCompletionUnsuccessful{
-		State:   nexus.OperationStateCanceled,
-		Failure: &nexus.Failure{Message: "operation canceled"},
-	}
+	completion, err := nexus.NewOperationCompletionUnsuccessful(
+		nexus.NewCanceledOperationError(errors.New("operation canceled")),
+		nexus.OperationCompletionUnsuccessfulOptions{},
+	)
+	s.NoError(err)
 	req, err := nexus.NewCompletionHTTPRequest(ctx, callbackUrl, completion)
 	s.NoError(err)
 	if callbackToken != "" {


### PR DESCRIPTION
## What changed?

- Rehydrate Temporal Failures from Nexus operation errors.
- Upgrade the Nexus and Temporal Go SDKs.
- [Fix data race in DynamicWorkerPoolScheduler](https://github.com/temporalio/temporal/pull/6967/commits/da34e3777a29b73ae1ba533403983d9171f22a8a).
- [Add Request-Timeout header in matching](https://github.com/temporalio/temporal/pull/6967/commits/d83c480d01232225c1646e168c62a2f7ec7abe96) in addition to the lower case `request-timeout` header.

## Why?

- On par debugging experience with child workflows and activities.

## How did you test it?

Added a bunch of functional tests. Note that the tests also cover the SDK.