### PR TITLE
Delete Namespace: cleanup logs and metrics

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -543,9 +543,8 @@ const (
 	UnknownTaskScope = "UnknownTask"
 	// ParentClosePolicyProcessorScope is scope used by all metrics emitted by worker.ParentClosePolicyProcessor
 	ParentClosePolicyProcessorScope = "ParentClosePolicyProcessor"
-	DeleteNamespaceWorkflowScope    = "DeleteNamespaceWorkflow"
-	ReclaimResourcesWorkflowScope   = "ReclaimResourcesWorkflow"
-	DeleteExecutionsWorkflowScope   = "DeleteExecutionsWorkflow"
+
+	DeleteExecutionsWorkflowScope = "DeleteExecutionsWorkflow"
 )
 
 // History task type
@@ -1075,19 +1074,13 @@ var (
 	ScavengerValidationFailuresCount                = NewCounterDef("scavenger_validation_failures")
 	ScavengerValidationSkipsCount                   = NewCounterDef("scavenger_validation_skips")
 	AddSearchAttributesFailuresCount                = NewCounterDef("add_search_attributes_failures")
-	DeleteNamespaceSuccessCount                     = NewCounterDef("delete_namespace_success")
-	RenameNamespaceSuccessCount                     = NewCounterDef("rename_namespace_success")
-	DeleteExecutionsSuccessCount                    = NewCounterDef("delete_executions_success")
-	DeleteNamespaceFailuresCount                    = NewCounterDef("delete_namespace_failures")
-	UpdateNamespaceFailuresCount                    = NewCounterDef("update_namespace_failures")
-	RenameNamespaceFailuresCount                    = NewCounterDef("rename_namespace_failures")
-	ReadNamespaceFailuresCount                      = NewCounterDef("read_namespace_failures")
-	ListExecutionsFailuresCount                     = NewCounterDef("list_executions_failures")
-	CountExecutionsFailuresCount                    = NewCounterDef("count_executions_failures")
-	DeleteExecutionFailuresCount                    = NewCounterDef("delete_execution_failures")
-	DeleteExecutionNotFoundCount                    = NewCounterDef("delete_execution_not_found")
-	RateLimiterFailuresCount                        = NewCounterDef("rate_limiter_failures")
-	BatcherProcessorSuccess                         = NewCounterDef(
+
+	DeleteExecutionsSuccessCount    = NewCounterDef("delete_executions_success")
+	DeleteExecutionsFailureCount    = NewCounterDef("delete_executions_failure")
+	DeleteExecutionsNotFoundCount   = NewCounterDef("delete_executions_not_found")
+	DeleteExecutionRateLimitedCount = NewCounterDef("delete_executions_rate_limited")
+
+	BatcherProcessorSuccess = NewCounterDef(
 		"batcher_processor_requests",
 		WithDescription("The number of individual workflow execution tasks successfully processed by the batch request processor"),
 	)

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -543,8 +543,6 @@ const (
 	UnknownTaskScope = "UnknownTask"
 	// ParentClosePolicyProcessorScope is scope used by all metrics emitted by worker.ParentClosePolicyProcessor
 	ParentClosePolicyProcessorScope = "ParentClosePolicyProcessor"
-
-	DeleteExecutionsWorkflowScope = "DeleteExecutionsWorkflow"
 )
 
 // History task type
@@ -1073,11 +1071,38 @@ var (
 	ScavengerValidationSkipsCount                   = NewCounterDef("scavenger_validation_skips")
 	AddSearchAttributesFailuresCount                = NewCounterDef("add_search_attributes_failures")
 
-	DeleteExecutionsSuccessCount    = NewCounterDef("delete_executions_success")
-	DeleteExecutionsFailureCount    = NewCounterDef("delete_executions_failure")
-	DeleteExecutionsNotFoundCount   = NewCounterDef("delete_executions_not_found")
-	DeleteExecutionRateLimitedCount = NewCounterDef("delete_executions_rate_limited")
+	// Delete Namespace metrics.
+	ReclaimResourcesNamespaceDeleteSuccessCount = NewCounterDef(
+		"reclaim_resources_namespace_delete_success",
+		WithDescription("Incremented every time when ReclaimResources workflow deletes a namespace successfully"),
+	)
+	ReclaimResourcesNamespaceDeleteFailureCount = NewCounterDef(
+		"reclaim_resources_namespace_delete_failure",
+		WithDescription("Incremented every time when ReclaimResources workflow completes without deleting a namespace"),
+	)
+	ReclaimResourcesDeleteExecutionsSuccessCount = NewCounterDef(
+		"reclaim_resources_delete_executions_success",
+		WithDescription("The number of workflow executions that was successfully deleted when ReclaimResources workflow completes"),
+	)
+	ReclaimResourcesDeleteExecutionsFailureCount = NewCounterDef(
+		"reclaim_resources_delete_executions_failure",
+		WithDescription("The number of workflow executions that got error when ReclaimResources workflow completes"),
+	)
 
+	DeleteExecutionsSuccessCount = NewCounterDef(
+		"delete_executions_success",
+		WithDescription("The number of workflow executions that was successfully deleted by DeleteExecutions workflow"),
+	)
+	DeleteExecutionsFailureCount = NewCounterDef(
+		"delete_executions_failure",
+		WithDescription("The number of workflow executions that got error while deleting by DeleteExecutions workflow"),
+	)
+	DeleteExecutionsNotFoundCount = NewCounterDef(
+		"delete_executions_not_found",
+		WithDescription("The number of workflow executions that wasn't found by DeleteExecutions workflow"),
+	)
+
+	// Batcher metrics.
 	BatcherProcessorSuccess = NewCounterDef(
 		"batcher_processor_requests",
 		WithDescription("The number of individual workflow execution tasks successfully processed by the batch request processor"),

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -668,8 +668,6 @@ var (
 	// Frontend
 	AddSearchAttributesWorkflowSuccessCount  = NewCounterDef("add_search_attributes_workflow_success")
 	AddSearchAttributesWorkflowFailuresCount = NewCounterDef("add_search_attributes_workflow_failure")
-	DeleteNamespaceWorkflowSuccessCount      = NewCounterDef("delete_namespace_workflow_success")
-	DeleteNamespaceWorkflowFailuresCount     = NewCounterDef("delete_namespace_workflow_failure")
 	VersionCheckSuccessCount                 = NewCounterDef("version_check_success")
 	VersionCheckFailedCount                  = NewCounterDef("version_check_failed")
 	VersionCheckRequestFailedCount           = NewCounterDef("version_check_request_failed")

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -680,17 +680,13 @@ func (h *OperatorHandlerImpl) DeleteNamespace(
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToStartWorkflowMessage, deletenamespace.WorkflowName, err))
 	}
 
-	scope := h.metricsHandler.WithTags(metrics.OperationTag(metrics.OperatorDeleteNamespaceScope))
-
 	// Wait for workflow to complete.
 	var wfResult deletenamespace.DeleteNamespaceWorkflowResult
 	err = run.Get(ctx, &wfResult)
 	if err != nil {
-		metrics.DeleteNamespaceWorkflowFailuresCount.With(scope).Record(1)
 		execution := &commonpb.WorkflowExecution{WorkflowId: deletenamespace.WorkflowName, RunId: run.GetRunID()}
 		return nil, serviceerror.NewSystemWorkflow(execution, err)
 	}
-	metrics.DeleteNamespaceWorkflowSuccessCount.With(scope).Record(1)
 
 	return &operatorservice.DeleteNamespaceResponse{
 		DeletedNamespace: wfResult.DeletedNamespace.String(),

--- a/service/worker/deletenamespace/activities_test.go
+++ b/service/worker/deletenamespace/activities_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.uber.org/mock/gomock"
@@ -43,7 +42,6 @@ func Test_GenerateDeletedNamespaceNameActivity(t *testing.T) {
 
 	a := &localActivities{
 		metadataManager: metadataManager,
-		metricsHandler:  metrics.NoopMetricsHandler,
 		logger:          log.NewNoopLogger(),
 	}
 

--- a/service/worker/deletenamespace/deleteexecutions/activities.go
+++ b/service/worker/deletenamespace/deleteexecutions/activities.go
@@ -26,6 +26,7 @@ package deleteexecutions
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
@@ -116,7 +117,6 @@ func (a *LocalActivities) GetNextPageTokenActivity(ctx context.Context, params G
 
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {
-		metrics.ListExecutionsFailuresCount.With(a.metricsHandler).Record(1)
 		a.logger.Error("Unable to list all workflows to get next page token.", tag.WorkflowNamespace(params.Namespace.String()), tag.Error(err))
 		return nil, err
 	}
@@ -174,7 +174,6 @@ func (a *Activities) DeleteExecutionsActivity(ctx context.Context, params Delete
 	}
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {
-		metrics.ListExecutionsFailuresCount.With(a.metricsHandler).Record(1)
 		a.logger.Error("Unable to list all workflow executions.", tag.WorkflowNamespace(params.Namespace.String()), tag.Error(err))
 		return result, err
 	}
@@ -182,9 +181,9 @@ func (a *Activities) DeleteExecutionsActivity(ctx context.Context, params Delete
 	for _, execution := range resp.Executions {
 		err = rateLimiter.Wait(ctx)
 		if err != nil {
-			metrics.RateLimiterFailuresCount.With(a.metricsHandler).Record(1)
+			metrics.DeleteExecutionRateLimitedCount.With(a.metricsHandler.WithTags(metrics.NamespaceTag(params.Namespace.String()))).Record(1)
 			a.logger.Error("Workflow executions delete rate limiter error.", tag.WorkflowNamespace(params.Namespace.String()), tag.Error(err))
-			return result, err
+			return result, fmt.Errorf("rate limiter error: %w", err)
 		}
 		_, err = a.historyClient.DeleteWorkflowExecution(ctx, &historyservice.DeleteWorkflowExecutionRequest{
 			NamespaceId:       params.NamespaceID.String(),
@@ -193,22 +192,22 @@ func (a *Activities) DeleteExecutionsActivity(ctx context.Context, params Delete
 		switch err.(type) {
 		case nil:
 			result.SuccessCount++
-			metrics.DeleteExecutionsSuccessCount.With(a.metricsHandler).Record(1)
+			metrics.DeleteExecutionsSuccessCount.With(a.metricsHandler.WithTags(metrics.NamespaceTag(params.Namespace.String()))).Record(1)
 
 		case *serviceerror.NotFound:
-			metrics.DeleteExecutionNotFoundCount.With(a.metricsHandler).Record(1)
-			a.logger.Info("Workflow execution is not found in history service.", tag.WorkflowNamespace(params.Namespace.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()))
-			// The reasons why workflow execution doesn't exist in history service, but exists in visibility store might be:
-			// 1. The workflow execution was deleted by someone else after last ListWorkflowExecutions call but before historyClient.DeleteWorkflowExecution call.
+			metrics.DeleteExecutionsNotFoundCount.With(a.metricsHandler.WithTags(metrics.NamespaceTag(params.Namespace.String()))).Record(1)
+			a.logger.Info("Workflow execution exists in the visibility store but not in the main store.", tag.WorkflowNamespace(params.Namespace.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()))
+			// The reasons why workflow execution doesn't exist in the main store, but exists in the visibility store might be:
+			// 1. Someone else deleted the workflow execution after the last ListWorkflowExecutions call but before historyClient.DeleteWorkflowExecution call.
 			// 2. Database is in inconsistent state: workflow execution was manually deleted from history store, but not from visibility store.
 			// To avoid continuously getting this workflow execution from visibility store, it needs to be deleted directly from visibility store.
-			s, e := a.deleteWorkflowExecutionFromVisibility(ctx, params.NamespaceID, execution)
+			s, e := a.deleteWorkflowExecutionFromVisibility(ctx, params.NamespaceID, params.Namespace, execution)
 			result.SuccessCount += s
 			result.ErrorCount += e
 
 		default:
 			result.ErrorCount++
-			metrics.DeleteExecutionFailuresCount.With(a.metricsHandler).Record(1)
+			metrics.DeleteExecutionsFailureCount.With(a.metricsHandler.WithTags(metrics.NamespaceTag(params.Namespace.String()))).Record(1)
 			a.logger.Error("Unable to delete workflow execution.", tag.WorkflowNamespace(params.Namespace.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()), tag.Error(err))
 		}
 		select {
@@ -226,28 +225,29 @@ func (a *Activities) DeleteExecutionsActivity(ctx context.Context, params Delete
 
 func (a *Activities) deleteWorkflowExecutionFromVisibility(
 	ctx context.Context,
-	namespaceID namespace.ID,
+	nsID namespace.ID,
+	nsName namespace.Name,
 	execution *workflowpb.WorkflowExecutionInfo,
 ) (successCount int, errorCount int) {
 
-	a.logger.Info("Deleting workflow execution from visibility.", tag.WorkflowNamespaceID(namespaceID.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()))
+	a.logger.Info("Deleting workflow execution from visibility.", tag.WorkflowNamespace(nsName.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()))
 	_, err := a.historyClient.DeleteWorkflowVisibilityRecord(ctx, &historyservice.DeleteWorkflowVisibilityRecordRequest{
-		NamespaceId: namespaceID.String(),
+		NamespaceId: nsID.String(),
 		Execution:   execution.GetExecution(),
 	})
 	switch err.(type) {
 	case nil:
 		// Indicates that main and visibility stores were in inconsistent state.
-		metrics.DeleteExecutionsSuccessCount.With(a.metricsHandler).Record(1)
-		a.logger.Info("Workflow execution deleted from visibility.", tag.WorkflowNamespaceID(namespaceID.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()))
+		metrics.DeleteExecutionsSuccessCount.With(a.metricsHandler.WithTags(metrics.NamespaceTag(nsName.String()))).Record(1)
+		a.logger.Info("Workflow execution deleted from visibility.", tag.WorkflowNamespace(nsName.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()))
 		return 1, 0
 	case *serviceerror.NotFound:
-		// Indicates that workflow execution was deleted by someone else.
-		a.logger.Error("Workflow execution is not found in visibility store.", tag.WorkflowNamespaceID(namespaceID.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()))
+		// Indicates that someone else deleted workflow execution.
+		a.logger.Error("Workflow execution is not found in visibility store.", tag.WorkflowNamespace(nsName.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()))
 		return 0, 0
 	default:
-		metrics.DeleteExecutionFailuresCount.With(a.metricsHandler).Record(1)
-		a.logger.Error("Unable to delete workflow execution from visibility store.", tag.WorkflowNamespaceID(namespaceID.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()), tag.Error(err))
+		metrics.DeleteExecutionsFailureCount.With(a.metricsHandler.WithTags(metrics.NamespaceTag(nsName.String()))).Record(1)
+		a.logger.Error("Unable to delete workflow execution from visibility store.", tag.WorkflowNamespace(nsName.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()), tag.Error(err))
 		return 0, 1
 	}
 }

--- a/service/worker/deletenamespace/errors/errors.go
+++ b/service/worker/deletenamespace/errors/errors.go
@@ -47,12 +47,8 @@ func NewExecutionsStillExistError(count int) error {
 	return temporal.NewApplicationError(fmt.Sprintf("%d executions are still exist", count), ExecutionsStillExistErrType, count)
 }
 
-func NewSomeExecutionsStillExistError() error {
-	return temporal.NewApplicationError("some executions are still exist", ExecutionsStillExistErrType)
-}
-
 func NewNoProgressError(count int) error {
-	return temporal.NewNonRetryableApplicationError(fmt.Sprintf("no progress were made: %d executions are still exist", count), NoProgressErrType, nil, count)
+	return temporal.NewNonRetryableApplicationError(fmt.Sprintf("no progress was made: %d executions are still exist", count), NoProgressErrType, nil, count)
 }
 
 func NewNotDeletedExecutionsStillExistError(count int) error {

--- a/service/worker/deletenamespace/fx.go
+++ b/service/worker/deletenamespace/fx.go
@@ -114,15 +114,15 @@ func (wc *deleteNamespaceComponent) DedicatedActivityWorkerOptions() *workercomm
 }
 
 func (wc *deleteNamespaceComponent) deleteNamespaceLocalActivities() *localActivities {
-	return NewLocalActivities(wc.metadataManager, wc.metricsHandler, wc.logger)
+	return newLocalActivities(wc.metadataManager, wc.logger)
 }
 
 func (wc *deleteNamespaceComponent) reclaimResourcesActivities() *reclaimresources.Activities {
-	return reclaimresources.NewActivities(wc.visibilityManager, wc.metricsHandler, wc.logger)
+	return reclaimresources.NewActivities(wc.visibilityManager, wc.logger)
 }
 
 func (wc *deleteNamespaceComponent) reclaimResourcesLocalActivities() *reclaimresources.LocalActivities {
-	return reclaimresources.NewLocalActivities(wc.visibilityManager, wc.metadataManager, wc.metricsHandler, wc.logger)
+	return reclaimresources.NewLocalActivities(wc.visibilityManager, wc.metadataManager, wc.logger)
 }
 
 func (wc *deleteNamespaceComponent) deleteExecutionsActivities() *deleteexecutions.Activities {

--- a/service/worker/deletenamespace/reclaimresources/activities.go
+++ b/service/worker/deletenamespace/reclaimresources/activities.go
@@ -83,6 +83,10 @@ func (a *LocalActivities) IsAdvancedVisibilityActivity(_ context.Context, _ name
 func (a *LocalActivities) CountExecutionsAdvVisibilityActivity(ctx context.Context, nsID namespace.ID, nsName namespace.Name) (int64, error) {
 	ctx = headers.SetCallerName(ctx, nsName.String())
 
+	logger := log.With(a.logger,
+		tag.WorkflowNamespace(nsName.String()),
+		tag.WorkflowNamespaceID(nsID.String()))
+
 	req := &manager.CountWorkflowExecutionsRequest{
 		NamespaceID: nsID,
 		Namespace:   nsName,
@@ -90,14 +94,14 @@ func (a *LocalActivities) CountExecutionsAdvVisibilityActivity(ctx context.Conte
 	}
 	resp, err := a.visibilityManager.CountWorkflowExecutions(ctx, req)
 	if err != nil {
-		a.logger.Error("Unable to count workflow executions.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
+		logger.Error("Unable to count workflow executions.", tag.Error(err))
 		return 0, err
 	}
 
 	if resp.Count > 0 {
-		a.logger.Info("There are some workflows in namespace.", tag.WorkflowNamespace(nsName.String()), tag.Counter(int(resp.Count)))
+		logger.Info("There are some workflows in namespace.", tag.Counter(int(resp.Count)))
 	} else {
-		a.logger.Info("There are no workflows in namespace.", tag.WorkflowNamespace(nsName.String()))
+		logger.Info("There are no workflows in namespace.")
 	}
 	return resp.Count, err
 }
@@ -105,6 +109,10 @@ func (a *LocalActivities) CountExecutionsAdvVisibilityActivity(ctx context.Conte
 func (a *Activities) EnsureNoExecutionsAdvVisibilityActivity(ctx context.Context, nsID namespace.ID, nsName namespace.Name, notDeletedCount int) error {
 	ctx = headers.SetCallerName(ctx, nsName.String())
 
+	logger := log.With(a.logger,
+		tag.WorkflowNamespace(nsName.String()),
+		tag.WorkflowNamespaceID(nsID.String()))
+
 	req := &manager.CountWorkflowExecutionsRequest{
 		NamespaceID: nsID,
 		Namespace:   nsName,
@@ -112,7 +120,7 @@ func (a *Activities) EnsureNoExecutionsAdvVisibilityActivity(ctx context.Context
 	}
 	resp, err := a.visibilityManager.CountWorkflowExecutions(ctx, req)
 	if err != nil {
-		a.logger.Error("Unable to count workflow executions.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
+		logger.Error("Unable to count workflow executions.", tag.Error(err))
 		return err
 	}
 
@@ -123,33 +131,37 @@ func (a *Activities) EnsureNoExecutionsAdvVisibilityActivity(ctx context.Context
 		if activity.HasHeartbeatDetails(ctx) && activityInfo.Attempt > 7 {
 			var previousAttemptCount int
 			if err := activity.GetHeartbeatDetails(ctx, &previousAttemptCount); err != nil {
-				a.logger.Error("Unable to get previous heartbeat details.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
+				logger.Error("Unable to get previous heartbeat details.", tag.Error(err))
 				return err
 			}
 			if count == previousAttemptCount {
 				// No progress was made. Something bad happened on the task processor side or new executions were created during deletion.
 				// Return non-retryable error and workflow will try to delete executions again.
-				a.logger.Warn("No progress was made.", tag.WorkflowNamespace(nsName.String()), tag.Attempt(activityInfo.Attempt), tag.Counter(count))
+				logger.Warn("No progress was made.", tag.Attempt(activityInfo.Attempt), tag.Counter(count))
 				return errors.NewNoProgressError(count)
 			}
 		}
 
-		a.logger.Warn("Some workflow executions still exist.", tag.WorkflowNamespace(nsName.String()), tag.Counter(count))
+		logger.Warn("Some workflow executions still exist.", tag.Counter(count))
 		activity.RecordHeartbeat(ctx, count)
 		return errors.NewExecutionsStillExistError(count)
 	}
 
 	if notDeletedCount > 0 {
-		a.logger.Warn("Some workflow executions were not deleted and still exist.", tag.WorkflowNamespace(nsName.String()), tag.Counter(notDeletedCount))
+		logger.Warn("Some workflow executions were not deleted and still exist.", tag.Counter(notDeletedCount))
 		return errors.NewNotDeletedExecutionsStillExistError(notDeletedCount)
 	}
 
-	a.logger.Info("All workflow executions are deleted successfully.", tag.WorkflowNamespace(nsName.String()))
+	logger.Info("All workflow executions are deleted successfully.")
 	return nil
 }
 
 func (a *LocalActivities) DeleteNamespaceActivity(ctx context.Context, nsID namespace.ID, nsName namespace.Name) error {
 	ctx = headers.SetCallerName(ctx, nsName.String())
+
+	logger := log.With(a.logger,
+		tag.WorkflowNamespace(nsName.String()),
+		tag.WorkflowNamespaceID(nsID.String()))
 
 	deleteNamespaceRequest := &persistence.DeleteNamespaceByNameRequest{
 		Name: nsName.String(),
@@ -157,10 +169,10 @@ func (a *LocalActivities) DeleteNamespaceActivity(ctx context.Context, nsID name
 
 	err := a.metadataManager.DeleteNamespaceByName(ctx, deleteNamespaceRequest)
 	if err != nil {
-		a.logger.Error("Unable to delete namespace from persistence.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
+		logger.Error("Unable to delete namespace from persistence.", tag.Error(err))
 		return err
 	}
 
-	a.logger.Info("Namespace is deleted.", tag.WorkflowNamespace(nsName.String()), tag.WorkflowNamespaceID(nsID.String()))
+	logger.Info("Namespace is deleted.")
 	return nil
 }

--- a/service/worker/deletenamespace/reclaimresources/activities.go
+++ b/service/worker/deletenamespace/reclaimresources/activities.go
@@ -56,12 +56,10 @@ type (
 
 func NewActivities(
 	visibilityManager manager.VisibilityManager,
-	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *Activities {
 	return &Activities{
 		visibilityManager: visibilityManager,
-		metricsHandler:    metricsHandler.WithTags(metrics.OperationTag(metrics.ReclaimResourcesWorkflowScope)),
 		logger:            logger,
 	}
 }
@@ -69,18 +67,16 @@ func NewActivities(
 func NewLocalActivities(
 	visibilityManager manager.VisibilityManager,
 	metadataManager persistence.MetadataManager,
-	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *LocalActivities {
 	return &LocalActivities{
 		visibilityManager: visibilityManager,
 		metadataManager:   metadataManager,
-		metricsHandler:    metricsHandler.WithTags(metrics.OperationTag(metrics.ReclaimResourcesWorkflowScope)),
 		logger:            logger,
 	}
 }
 
-func (a *LocalActivities) IsAdvancedVisibilityActivity(_ context.Context, nsName namespace.Name) (bool, error) {
+func (a *LocalActivities) IsAdvancedVisibilityActivity(_ context.Context, _ namespace.Name) (bool, error) {
 	return true, nil
 }
 
@@ -94,7 +90,6 @@ func (a *LocalActivities) CountExecutionsAdvVisibilityActivity(ctx context.Conte
 	}
 	resp, err := a.visibilityManager.CountWorkflowExecutions(ctx, req)
 	if err != nil {
-		metrics.CountExecutionsFailuresCount.With(a.metricsHandler).Record(1)
 		a.logger.Error("Unable to count workflow executions.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 		return 0, err
 	}
@@ -117,7 +112,6 @@ func (a *Activities) EnsureNoExecutionsAdvVisibilityActivity(ctx context.Context
 	}
 	resp, err := a.visibilityManager.CountWorkflowExecutions(ctx, req)
 	if err != nil {
-		metrics.CountExecutionsFailuresCount.With(a.metricsHandler).Record(1)
 		a.logger.Error("Unable to count workflow executions.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 		return err
 	}
@@ -125,18 +119,17 @@ func (a *Activities) EnsureNoExecutionsAdvVisibilityActivity(ctx context.Context
 	count := int(resp.Count)
 	if count > notDeletedCount {
 		activityInfo := activity.GetInfo(ctx)
-		// Starting from 8th attempt (after ~127s), workflow executions deletion must show some progress.
+		// Starting from the 8th attempt (after ~127s), workflow executions deletion must show some progress.
 		if activity.HasHeartbeatDetails(ctx) && activityInfo.Attempt > 7 {
 			var previousAttemptCount int
 			if err := activity.GetHeartbeatDetails(ctx, &previousAttemptCount); err != nil {
-				metrics.CountExecutionsFailuresCount.With(a.metricsHandler).Record(1)
 				a.logger.Error("Unable to get previous heartbeat details.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 				return err
 			}
 			if count == previousAttemptCount {
-				// No progress were made. Something bad happened on task processor side or new executions were created during deletion.
+				// No progress was made. Something bad happened on the task processor side or new executions were created during deletion.
 				// Return non-retryable error and workflow will try to delete executions again.
-				a.logger.Warn("No progress were made.", tag.WorkflowNamespace(nsName.String()), tag.Attempt(activityInfo.Attempt), tag.Counter(count))
+				a.logger.Warn("No progress was made.", tag.WorkflowNamespace(nsName.String()), tag.Attempt(activityInfo.Attempt), tag.Counter(count))
 				return errors.NewNoProgressError(count)
 			}
 		}
@@ -164,12 +157,10 @@ func (a *LocalActivities) DeleteNamespaceActivity(ctx context.Context, nsID name
 
 	err := a.metadataManager.DeleteNamespaceByName(ctx, deleteNamespaceRequest)
 	if err != nil {
-		metrics.DeleteNamespaceFailuresCount.With(a.metricsHandler).Record(1)
 		a.logger.Error("Unable to delete namespace from persistence.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 		return err
 	}
 
-	metrics.DeleteNamespaceSuccessCount.With(a.metricsHandler).Record(1)
 	a.logger.Info("Namespace is deleted.", tag.WorkflowNamespace(nsName.String()), tag.WorkflowNamespaceID(nsID.String()))
 	return nil
 }

--- a/service/worker/deletenamespace/reclaimresources/workflow.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow.go
@@ -82,12 +82,6 @@ var (
 		BackoffCoefficient: 2,
 	}
 
-	ensureNoExecutionsStdVisibilityOptionsActivity = workflow.ActivityOptions{
-		RetryPolicy:            ensureNoExecutionsActivityRetryPolicy,
-		StartToCloseTimeout:    30 * time.Second,
-		ScheduleToCloseTimeout: 30 * time.Minute, // ~20 attempts
-	}
-
 	ensureNoExecutionsAdvVisibilityActivityOptions = workflow.ActivityOptions{
 		RetryPolicy:            ensureNoExecutionsActivityRetryPolicy,
 		StartToCloseTimeout:    30 * time.Second,
@@ -121,7 +115,7 @@ func ReclaimResourcesWorkflow(ctx workflow.Context, params ReclaimResourcesParam
 
 	var la *LocalActivities
 
-	// Step 0. This workflow is started right after namespace is marked as DELETED and renamed.
+	// Step 0. This workflow is started right after the namespace is marked as DELETED and renamed.
 	// Wait for namespace cache refresh to make sure no new executions are created.
 	err := workflow.Sleep(ctx, namespaceCacheRefreshDelay)
 	if err != nil {
@@ -134,7 +128,7 @@ func ReclaimResourcesWorkflow(ctx workflow.Context, params ReclaimResourcesParam
 		return result, err
 	}
 
-	// Step 2. Sleep before deleting namespace from database.
+	// Step 2. Sleep before deleting namespace from a database.
 	err = workflow.Sleep(ctx, params.NamespaceDeleteDelay)
 	if err != nil {
 		return result, fmt.Errorf("%w: %v", errors.ErrUnableToSleep, err)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
1. Remove useless metrics.
2. Add useful metrics with useful tags (`namespace`).
3. Improve comments and log messages.

## Why?
<!-- Tell your future self why have you made these changes -->
Make `DeleteNamespaceWorkflow` metrics more useful:
- Use `reclaim_resources_namespace_delete_failure` and/or `reclaim_resources_delete_executions_failure` to alert on `ReclaimResources` workflow failures.
- Use `delete_executions_success` and `delete_executions_failure` to track `DeleteExecutions` workflow progress.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests and few manual runs.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
If someone uses old metrics (I see no reason for it), they won't work anymore. 

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.