### PR TITLE
Fix Nexus endpoint registry min wait

### DIFF
--- a/common/nexus/endpoint_registry.go
+++ b/common/nexus/endpoint_registry.go
@@ -233,9 +233,9 @@ func (r *EndpointRegistryImpl) waitUntilInitialized(ctx context.Context) error {
 
 func (r *EndpointRegistryImpl) refreshEndpointsLoop(ctx context.Context, dataReady *dataReady) error {
 	hasLoadedEndpointData := false
+	minWaitTime := r.config.refreshMinWait()
 
 	for ctx.Err() == nil {
-		minWaitTime := r.config.refreshMinWait()
 		start := time.Now()
 		if !hasLoadedEndpointData {
 			// Loading endpoints for the first time after being (re)enabled, so load with fallback to persistence


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
min wait variable needed to be initialized outside the loop for the increasing wait time to actually take effect.

