### PR TITLE
[VSCode] Config to connect debugger to a running server instance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,13 @@
 {
 	"version": "0.2.0",
 	"configurations": [
+        {
+            "name": "Debug Running Server",
+            "type": "go",
+            "request": "attach",
+            "mode": "local",
+            "cwd": "${workspaceFolder}",
+        },
 		{
 			"name": "Debug single functional test method",
 			"type": "go",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,13 +1,13 @@
 {
 	"version": "0.2.0",
 	"configurations": [
-        {
-            "name": "Debug Running Server",
-            "type": "go",
-            "request": "attach",
-            "mode": "local",
-            "cwd": "${workspaceFolder}",
-        },
+		{
+			"name": "Debug Running Server",
+			"type": "go",
+			"request": "attach",
+			"mode": "local",
+			"cwd": "${workspaceFolder}",
+		},
 		{
 			"name": "Debug single functional test method",
 			"type": "go",


### PR DESCRIPTION
## What changed?
A new config entry to allow VSCode debugger to connect to a local running instance of server.

## Why?
Makes it easy to quickly connect and breakpoint a dev server. No need to restart the server in debugger everytime.

## How did you test it?
Tested it manually

## Potential risks
N/A

## Documentation
N/A

## Is hotfix candidate?
No