### PR TITLE
Nexus: Delete state machine on terminal state -- Part 3

### DIFF
--- a/components/nexusoperations/events.go
+++ b/components/nexusoperations/events.go
@@ -112,10 +112,18 @@ func (d CompletedEventDefinition) IsWorkflowTaskTrigger() bool {
 
 func (d CompletedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
 	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
-		return TransitionSucceeded.Apply(o, EventSucceeded{
+		output, err := TransitionSucceeded.Apply(o, EventSucceeded{
 			Time: event.EventTime.AsTime(),
 			Node: node,
 		})
+		if err != nil {
+			return output, err
+		}
+
+		if err := root.DeleteChild(node.Key); err != nil {
+			return output, err
+		}
+		return output, nil
 	})
 }
 
@@ -142,11 +150,19 @@ func (d FailedEventDefinition) Type() enumspb.EventType {
 
 func (d FailedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
 	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
-		return TransitionFailed.Apply(o, EventFailed{
+		output, err := TransitionFailed.Apply(o, EventFailed{
 			Time:       event.EventTime.AsTime(),
 			Attributes: event.GetNexusOperationFailedEventAttributes(),
 			Node:       node,
 		})
+		if err != nil {
+			return output, err
+		}
+
+		if err := root.DeleteChild(node.Key); err != nil {
+			return output, err
+		}
+		return output, nil
 	})
 }
 
@@ -169,10 +185,18 @@ func (d CanceledEventDefinition) Type() enumspb.EventType {
 
 func (d CanceledEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
 	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
-		return TransitionCanceled.Apply(o, EventCanceled{
+		output, err := TransitionCanceled.Apply(o, EventCanceled{
 			Time: event.EventTime.AsTime(),
 			Node: node,
 		})
+		if err != nil {
+			return output, err
+		}
+
+		if err := root.DeleteChild(node.Key); err != nil {
+			return output, err
+		}
+		return output, nil
 	})
 }
 
@@ -195,9 +219,17 @@ func (d TimedOutEventDefinition) Type() enumspb.EventType {
 
 func (d TimedOutEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
 	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
-		return TransitionTimedOut.Apply(o, EventTimedOut{
+		output, err := TransitionTimedOut.Apply(o, EventTimedOut{
 			Node: node,
 		})
+		if err != nil {
+			return output, err
+		}
+
+		if err := root.DeleteChild(node.Key); err != nil {
+			return output, err
+		}
+		return output, nil
 	})
 }
 

--- a/components/nexusoperations/events.go
+++ b/components/nexusoperations/events.go
@@ -47,7 +47,7 @@ func (d ScheduledEventDefinition) Apply(root *hsm.Node, event *historypb.History
 	if err != nil {
 		return err
 	}
-	_, err = AddChild(root, strconv.FormatInt(event.EventId, 10), event, token, true)
+	_, err = AddChild(root, strconv.FormatInt(event.EventId, 10), event, token)
 	return err
 }
 
@@ -67,9 +67,11 @@ func (d CancelRequestedEventDefinition) Type() enumspb.EventType {
 }
 
 func (d CancelRequestedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+	_, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
 		return o.Cancel(node, event.EventTime.AsTime())
 	})
+
+	return err
 }
 
 func (d CancelRequestedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, _ map[enumspb.ResetReapplyExcludeType]struct{}) error {
@@ -88,13 +90,15 @@ func (d StartedEventDefinition) Type() enumspb.EventType {
 }
 
 func (d StartedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+	_, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
 		return TransitionStarted.Apply(o, EventStarted{
 			Time:       event.EventTime.AsTime(),
 			Node:       node,
 			Attributes: event.GetNexusOperationStartedEventAttributes(),
 		})
 	})
+
+	return err
 }
 
 func (d StartedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
@@ -111,20 +115,17 @@ func (d CompletedEventDefinition) IsWorkflowTaskTrigger() bool {
 }
 
 func (d CompletedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
-		output, err := TransitionSucceeded.Apply(o, EventSucceeded{
+	node, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+		return TransitionSucceeded.Apply(o, EventSucceeded{
 			Time: event.EventTime.AsTime(),
 			Node: node,
 		})
-		if err != nil {
-			return output, err
-		}
-
-		if err := root.DeleteChild(node.Key); err != nil {
-			return output, err
-		}
-		return output, nil
 	})
+	if err != nil {
+		return err
+	}
+
+	return root.DeleteChild(node.Key)
 }
 
 func (d CompletedEventDefinition) Type() enumspb.EventType {
@@ -149,21 +150,18 @@ func (d FailedEventDefinition) Type() enumspb.EventType {
 }
 
 func (d FailedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
-		output, err := TransitionFailed.Apply(o, EventFailed{
+	node, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+		return TransitionFailed.Apply(o, EventFailed{
 			Time:       event.EventTime.AsTime(),
 			Attributes: event.GetNexusOperationFailedEventAttributes(),
 			Node:       node,
 		})
-		if err != nil {
-			return output, err
-		}
-
-		if err := root.DeleteChild(node.Key); err != nil {
-			return output, err
-		}
-		return output, nil
 	})
+	if err != nil {
+		return err
+	}
+
+	return root.DeleteChild(node.Key)
 }
 
 func (d FailedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
@@ -184,20 +182,17 @@ func (d CanceledEventDefinition) Type() enumspb.EventType {
 }
 
 func (d CanceledEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
-		output, err := TransitionCanceled.Apply(o, EventCanceled{
+	node, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+		return TransitionCanceled.Apply(o, EventCanceled{
 			Time: event.EventTime.AsTime(),
 			Node: node,
 		})
-		if err != nil {
-			return output, err
-		}
-
-		if err := root.DeleteChild(node.Key); err != nil {
-			return output, err
-		}
-		return output, nil
 	})
+	if err != nil {
+		return err
+	}
+
+	return root.DeleteChild(node.Key)
 }
 
 func (d CanceledEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
@@ -218,19 +213,16 @@ func (d TimedOutEventDefinition) Type() enumspb.EventType {
 }
 
 func (d TimedOutEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
-		output, err := TransitionTimedOut.Apply(o, EventTimedOut{
+	node, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+		return TransitionTimedOut.Apply(o, EventTimedOut{
 			Node: node,
 		})
-		if err != nil {
-			return output, err
-		}
-
-		if err := root.DeleteChild(node.Key); err != nil {
-			return output, err
-		}
-		return output, nil
 	})
+	if err != nil {
+		return err
+	}
+
+	return root.DeleteChild(node.Key)
 }
 
 func (d TimedOutEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
@@ -262,14 +254,21 @@ func RegisterEventDefinitions(reg *hsm.Registry) error {
 	return reg.RegisterEventDefinition(TimedOutEventDefinition{})
 }
 
-func transitionOperation(root *hsm.Node, event *historypb.HistoryEvent, fn func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error)) error {
+func transitionOperation(
+	root *hsm.Node,
+	event *historypb.HistoryEvent,
+	fn func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error),
+) (*hsm.Node, error) {
 	node, err := findOperationNode(root, event)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return hsm.MachineTransition(node, func(o Operation) (hsm.TransitionOutput, error) {
+	if err := hsm.MachineTransition(node, func(o Operation) (hsm.TransitionOutput, error) {
 		return fn(node, o)
-	})
+	}); err != nil {
+		return nil, err
+	}
+	return node, nil
 }
 
 func findOperationNode(root *hsm.Node, event *historypb.HistoryEvent) (*hsm.Node, error) {

--- a/components/nexusoperations/events_test.go
+++ b/components/nexusoperations/events_test.go
@@ -144,15 +144,6 @@ func TestCherryPick(t *testing.T) {
 }
 
 func TestTerminalStatesDeletion(t *testing.T) {
-	setup := func(t *testing.T) (*hsm.Node, nexusoperations.Operation, int64) {
-		node := newOperationNode(t, &hsmtest.NodeBackend{}, mustNewScheduledEvent(time.Now(), time.Hour))
-		op, err := hsm.MachineData[nexusoperations.Operation](node)
-		require.NoError(t, err)
-		eventID, err := hsm.EventIDFromToken(op.ScheduledEventToken)
-		require.NoError(t, err)
-		return node, op, eventID
-	}
-
 	applyEventAndCheckDeletion := func(
 		t *testing.T,
 		node *hsm.Node,
@@ -234,7 +225,11 @@ func TestTerminalStatesDeletion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			node, _, eventID := setup(t)
+			node := newOperationNode(t, &hsmtest.NodeBackend{}, mustNewScheduledEvent(time.Now(), time.Hour))
+			op, err := hsm.MachineData[nexusoperations.Operation](node)
+			require.NoError(t, err)
+			eventID, err := hsm.EventIDFromToken(op.ScheduledEventToken)
+			require.NoError(t, err)
 
 			// Update the event ID in attributes
 			switch a := tc.attributes.(type) {

--- a/components/nexusoperations/events_test.go
+++ b/components/nexusoperations/events_test.go
@@ -23,6 +23,7 @@
 package nexusoperations_test
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/service/history/hsm"
 	"go.temporal.io/server/service/history/hsm/hsmtest"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestCherryPick(t *testing.T) {
@@ -139,4 +141,114 @@ func TestCherryPick(t *testing.T) {
 			require.ErrorIs(t, err, hsm.ErrNotCherryPickable, "%T should not be cherrypickable when shouldExcludeNexusEvent=true", nexusOperation)
 		}
 	})
+}
+
+func TestTerminalStatesDeletion(t *testing.T) {
+	setup := func(t *testing.T) (*hsm.Node, nexusoperations.Operation, int64) {
+		node := newOperationNode(t, &hsmtest.NodeBackend{}, mustNewScheduledEvent(time.Now(), time.Hour))
+		op, err := hsm.MachineData[nexusoperations.Operation](node)
+		require.NoError(t, err)
+		eventID, err := hsm.EventIDFromToken(op.ScheduledEventToken)
+		require.NoError(t, err)
+		return node, op, eventID
+	}
+
+	applyEventAndCheckDeletion := func(
+		t *testing.T,
+		node *hsm.Node,
+		eventID int64,
+		def hsm.EventDefinition,
+		attr interface{},
+	) {
+		event := &historypb.HistoryEvent{
+			EventTime: timestamppb.Now(),
+		}
+
+		switch d := def.(type) {
+		case nexusoperations.CompletedEventDefinition:
+			event.EventType = d.Type()
+			event.Attributes = &historypb.HistoryEvent_NexusOperationCompletedEventAttributes{
+				NexusOperationCompletedEventAttributes: attr.(*historypb.NexusOperationCompletedEventAttributes),
+			}
+		case nexusoperations.FailedEventDefinition:
+			event.EventType = d.Type()
+			event.Attributes = &historypb.HistoryEvent_NexusOperationFailedEventAttributes{
+				NexusOperationFailedEventAttributes: attr.(*historypb.NexusOperationFailedEventAttributes),
+			}
+		case nexusoperations.CanceledEventDefinition:
+			event.EventType = d.Type()
+			event.Attributes = &historypb.HistoryEvent_NexusOperationCanceledEventAttributes{
+				NexusOperationCanceledEventAttributes: attr.(*historypb.NexusOperationCanceledEventAttributes),
+			}
+		case nexusoperations.TimedOutEventDefinition:
+			event.EventType = d.Type()
+			event.Attributes = &historypb.HistoryEvent_NexusOperationTimedOutEventAttributes{
+				NexusOperationTimedOutEventAttributes: attr.(*historypb.NexusOperationTimedOutEventAttributes),
+			}
+		default:
+			t.Fatalf("unknown event definition type: %T", def)
+		}
+
+		err := def.Apply(node.Parent, event)
+		require.NoError(t, err)
+
+		coll := nexusoperations.MachineCollection(node.Parent)
+		_, err = coll.Node(strconv.FormatInt(eventID, 10))
+		require.ErrorIs(t, err, hsm.ErrStateMachineNotFound)
+	}
+
+	testCases := []struct {
+		name       string
+		def        hsm.EventDefinition
+		attributes interface{}
+	}{
+		{
+			name: "CompletedDeletesStateMachine",
+			def:  nexusoperations.CompletedEventDefinition{},
+			attributes: &historypb.NexusOperationCompletedEventAttributes{
+				ScheduledEventId: 0,
+			},
+		},
+		{
+			name: "FailedDeletesStateMachine",
+			def:  nexusoperations.FailedEventDefinition{},
+			attributes: &historypb.NexusOperationFailedEventAttributes{
+				ScheduledEventId: 0,
+			},
+		},
+		{
+			name: "CanceledDeletesStateMachine",
+			def:  nexusoperations.CanceledEventDefinition{},
+			attributes: &historypb.NexusOperationCanceledEventAttributes{
+				ScheduledEventId: 0,
+			},
+		},
+		{
+			name: "TimedOutDeletesStateMachine",
+			def:  nexusoperations.TimedOutEventDefinition{},
+			attributes: &historypb.NexusOperationTimedOutEventAttributes{
+				ScheduledEventId: 0,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node, _, eventID := setup(t)
+
+			// Update the event ID in attributes
+			switch a := tc.attributes.(type) {
+			case *historypb.NexusOperationCompletedEventAttributes:
+				a.ScheduledEventId = eventID
+			case *historypb.NexusOperationFailedEventAttributes:
+				a.ScheduledEventId = eventID
+			case *historypb.NexusOperationCanceledEventAttributes:
+				a.ScheduledEventId = eventID
+			case *historypb.NexusOperationTimedOutEventAttributes:
+				a.ScheduledEventId = eventID
+			}
+
+			applyEventAndCheckDeletion(t, node, eventID, tc.def, tc.attributes)
+		})
+	}
 }

--- a/components/nexusoperations/helpers_test.go
+++ b/components/nexusoperations/helpers_test.go
@@ -79,7 +79,7 @@ func newOperationNode(t *testing.T, backend *hsmtest.NodeBackend, event *history
 	root := newRoot(t, backend)
 	token, err := hsm.GenerateEventLoadToken(event)
 	require.NoError(t, err)
-	node, err := nexusoperations.AddChild(root, fmt.Sprintf("%d", event.EventId), event, token, false)
+	node, err := nexusoperations.AddChild(root, fmt.Sprintf("%d", event.EventId), event, token)
 	require.NoError(t, err)
 	return node
 }

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -65,7 +65,7 @@ type Operation struct {
 }
 
 // AddChild adds a new operation child machine to the given node and transitions it to the SCHEDULED state.
-func AddChild(node *hsm.Node, id string, event *historypb.HistoryEvent, eventToken []byte, deleteOnCompletion bool) (*hsm.Node, error) {
+func AddChild(node *hsm.Node, id string, event *historypb.HistoryEvent, eventToken []byte) (*hsm.Node, error) {
 	attrs := event.GetNexusOperationScheduledEventAttributes()
 
 	node, err := node.AddChild(hsm.Key{Type: OperationMachineType, ID: id}, Operation{
@@ -78,9 +78,7 @@ func AddChild(node *hsm.Node, id string, event *historypb.HistoryEvent, eventTok
 			ScheduleToCloseTimeout: attrs.ScheduleToCloseTimeout,
 			RequestId:              attrs.RequestId,
 			State:                  enumsspb.NEXUS_OPERATION_STATE_UNSPECIFIED,
-			// TODO(bergundy): actually delete on completion if this is set.
-			DeleteOnCompletion:  deleteOnCompletion,
-			ScheduledEventToken: eventToken,
+			ScheduledEventToken:    eventToken,
 		},
 	})
 

--- a/components/nexusoperations/statemachine_test.go
+++ b/components/nexusoperations/statemachine_test.go
@@ -84,7 +84,7 @@ func TestAddChild(t *testing.T) {
 					},
 				},
 			}
-			child, err := nexusoperations.AddChild(root, "test-id", event, []byte("token"), false)
+			child, err := nexusoperations.AddChild(root, "test-id", event, []byte("token"))
 			require.NoError(t, err)
 			opLog, err := root.Outputs()
 			require.NoError(t, err)

--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -219,7 +219,6 @@ func (ch *commandHandler) HandleCancelCommand(
 				return workflow.FailWorkflowTaskError{
 					Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES,
 					Message: fmt.Sprintf("requested cancelation for a non-existing or already completed operation with scheduled event ID of %d", attrs.ScheduledEventId),
-
 				}
 			}
 			// Fallthrough and apply the event, there's special logic that will handle state machine not found below.
@@ -247,7 +246,7 @@ func (ch *commandHandler) HandleCancelCommand(
 	if errors.Is(err, hsm.ErrStateMachineAlreadyExists) {
 		return workflow.FailWorkflowTaskError{
 			Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES,
-			Message: fmt.Sprintf("requested cancelation for operation with scheduled event ID %d that is already being canceled", attrs.ScheduledEventId),
+			Message: fmt.Sprintf("cancelation was already requested for an operation with scheduled event ID %d", attrs.ScheduledEventId),
 		}
 	} else if errors.Is(err, hsm.ErrStateMachineNotFound) {
 		// This may happen if there's a buffered completion. Ignore.

--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -218,7 +218,8 @@ func (ch *commandHandler) HandleCancelCommand(
 			if !ms.HasAnyBufferedEvent(makeNexusOperationTerminalEventFilter(attrs.ScheduledEventId)) {
 				return workflow.FailWorkflowTaskError{
 					Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES,
-					Message: fmt.Sprintf("requested cancelation for a non-existing operation with scheduled event ID of %d", attrs.ScheduledEventId),
+					Message: fmt.Sprintf("requested cancelation for a non-existing or already completed operation with scheduled event ID of %d", attrs.ScheduledEventId),
+
 				}
 			}
 			// Fallthrough and apply the event, there's special logic that will handle state machine not found below.

--- a/components/nexusoperations/workflow/commands_test.go
+++ b/components/nexusoperations/workflow/commands_test.go
@@ -560,7 +560,7 @@ func TestHandleCancelCommand(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		require.Equal(t, 2, len(tcx.history.Events))
+		require.Equal(t, 2, len(tcx.history.Events)) // Only scheduled event should be recorded.
 	})
 
 	t.Run("sets event attributes with UserMetadata and spawns cancelation child machine", func(t *testing.T) {

--- a/components/nexusoperations/workflow/commands_test.go
+++ b/components/nexusoperations/workflow/commands_test.go
@@ -572,6 +572,8 @@ func TestHandleCancelCommand(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(tcx.history.Events)) // Both scheduled and cancel requested events should be recorded
+		crAttrs := tcx.history.Events[1].GetNexusOperationCancelRequestedEventAttributes()
+		require.Equal(t, event.EventId, crAttrs.ScheduledEventId)
 	})
 
 	t.Run("sets event attributes with UserMetadata and spawns cancelation child machine", func(t *testing.T) {

--- a/components/nexusoperations/workflow/commands_test.go
+++ b/components/nexusoperations/workflow/commands_test.go
@@ -532,7 +532,7 @@ func TestHandleCancelCommand(t *testing.T) {
 		require.ErrorAs(t, err, &failWFTErr)
 		require.False(t, failWFTErr.TerminateWorkflow)
 		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES, failWFTErr.Cause)
-		require.Equal(t, 1, len(tcx.history.Events))
+		require.Equal(t, 1, len(tcx.history.Events)) // Only scheduled event should be recorded.
 	})
 
 	t.Run("operation already completed - completion buffered", func(t *testing.T) {

--- a/components/nexusoperations/workflow/commands_test.go
+++ b/components/nexusoperations/workflow/commands_test.go
@@ -656,8 +656,7 @@ func TestOperationNodeDeletionOnTerminalEvents(t *testing.T) {
 			EventTime: timestamppb.Now(),
 		}
 
-		// Set the correct attributes field based on eventType
-		switch eventType {
+		switch eventType { //nolint:exhaustive
 		case enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED:
 			event.Attributes = &historypb.HistoryEvent_NexusOperationCompletedEventAttributes{
 				NexusOperationCompletedEventAttributes: eventAttr.(*historypb.NexusOperationCompletedEventAttributes),

--- a/service/history/workflow/task_generator_test.go
+++ b/service/history/workflow/task_generator_test.go
@@ -491,7 +491,7 @@ func TestTaskGenerator_GenerateDirtySubStateMachineTasks(t *testing.T) {
 				ScheduleToCloseTimeout: durationpb.New(time.Hour),
 			},
 		},
-	}, []byte("token"), false)
+	}, []byte("token"))
 	require.NoError(t, err)
 	err = taskGenerator.GenerateDirtySubStateMachineTasks(reg)
 	require.NoError(t, err)


### PR DESCRIPTION
## What changed?

Add deletion calls for Nexus operation nodes once they reach a terminal state (Completed, Failed, Canceled, Timed Out). Previously, terminal operations lingered in the state machine, potentially causing confusion and wasting resources. In addition, this PR addresses previously existing TODOs related to node cleanup.

### Key Changes
- **Automatic Node Deletion on Terminal States:**  
  Operations are now removed from the state machine immediately after they complete, fail, cancel, or time out.
- **Handler Updates:**  
  The command handlers (schedule and cancel) now reflect the new terminal state deletion. Attempts to cancel an operation that has already reached a terminal state will produce a clear, non-retryable error.
- **Tests for Terminal State Deletion:**  
  Introduced two new test suites:
  - `TestTerminalStatesDeletion` to verify that applying terminal events removes the operation node as expected.
  - `TestOperationNodeDeletionOnTerminalEvents` to ensure no further modifications (like cancelation) can be made after an operation is terminal.

### Areas for Review Focus
1. **Deletion Semantics:** Verify that node removal is triggered correctly for all terminal states and that no non-terminal states inadvertently trigger deletion.
2. **Handler Consistency:** Ensure that the updated schedule/cancel handlers function correctly when dealing with non-existent or already terminated operations.
3. **Error Handling:** Confirm that attempts to modify a deleted operation produce the intended error behavior.
4. **Test Coverage:** Review the newly added test suites to ensure all terminal states and edge cases are thoroughly tested.

## Why?

- Prevent confusion and wasted resources by removing irrelevant operation nodes.
- Prevent customers from experiencing workflow task failures prematurely.

## How did you test it?

- **New Test Suites:**  
  Added `TestTerminalStatesDeletion` and `TestOperationNodeDeletionOnTerminalEvents` to specifically target and validate the new deletion behavior.
- **Existing Tests:**  
  All pre-existing tests have been re-run to ensure no regressions.

## Potential risks

- **Assumptions About Completed Operations:**  
  If any internal or external code implicitly relied on the presence of completed operations, its assumptions might break. Such usage was never officially supported.
  
## Documentation

No external or user-facing documentation changes are required since this feature matches the intended design.

## Is hotfix candidate?

No. This change is an enhancement to internal logic and state management, not a fix for a critical bug, so it should follow the normal release process.
