### PR TITLE
Delete Namespace: send delete executions heartbeats from separate go routine

### DIFF
--- a/service/worker/deletenamespace/reclaimresources/workflow.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow.go
@@ -73,8 +73,7 @@ var (
 	}
 
 	deleteExecutionsWorkflowOptions = workflow.ChildWorkflowOptions{
-		RetryPolicy:        retryPolicy,
-		WorkflowRunTimeout: 60 * time.Minute,
+		RetryPolicy: retryPolicy,
 	}
 
 	ensureNoExecutionsActivityRetryPolicy = &temporal.RetryPolicy{


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Delete Namespace: send delete executions heartbeats from separate go routine.

## Why?
<!-- Tell your future self why have you made these changes -->
Following best practices heartbeats should be sent outside of main activity function in case if operation takes longer than expected. Also `DeleteExecutionsActivity` doesn't send heartbeats on every deleted execution but sends accumulated result every 5 seconds.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests and manual run.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.