### PR TITLE
Various small nexus fixes

### DIFF
--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -117,9 +117,8 @@ func UnsuccessfulOperationErrorToTemporalFailure(opErr *nexus.UnsuccessfulOperat
 		nexusFailure = failureErr.Failure
 	} else if opErr.Cause != nil {
 		nexusFailure = nexus.Failure{Message: opErr.Cause.Error()}
-	} else {
-		nexusFailure = nexus.Failure{Message: "canceled"}
 	}
+
 	// Canceled must be translated into a CanceledFailure to match the SDK expectation.
 	if opErr.State == nexus.OperationStateCanceled {
 		if nexusFailure.Metadata != nil && nexusFailure.Metadata["type"] == failureTypeString {

--- a/common/nexus/nexustest/server.go
+++ b/common/nexus/nexustest/server.go
@@ -55,8 +55,11 @@ func NewNexusServer(t *testing.T, listenAddr string, handler nexus.Handler) {
 		// Graceful shutdown
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		require.NoError(t, srv.Shutdown(ctx))
-		require.ErrorIs(t, <-errCh, http.ErrServerClosed)
+		err = srv.Shutdown(ctx)
+		if ctx.Err() != nil {
+			require.NoError(t, err)
+			require.ErrorIs(t, <-errCh, http.ErrServerClosed)
+		}
 	})
 }
 

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -188,6 +188,9 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation() {
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
 		assert.NoError(t, err)
+		if err != nil {
+			return
+		}
 		assert.Equal(t, 1, len(desc.PendingNexusOperations))
 		if len(desc.PendingNexusOperations) < 1 {
 			return
@@ -1868,7 +1871,13 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 				require.EventuallyWithT(t, func(t *assert.CollectT) {
 					desc, err := s.SdkClient().DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
 					require.NoError(t, err)
+					if err != nil {
+						return
+					}
 					assert.Len(t, desc.PendingNexusOperations, 1)
+					if len(desc.PendingNexusOperations) != 1 {
+						return
+					}
 					f = desc.PendingNexusOperations[0].LastAttemptFailure
 					assert.NotNil(t, f)
 


### PR DESCRIPTION
- Fix a couple of occasional panics in Nexus functional and unit tests.
- Remove default failure message for unsuccessful operations.
