### PR TITLE
Delete Namespace: block for replicated namespace

### DIFF
--- a/service/worker/deletenamespace/activities.go
+++ b/service/worker/deletenamespace/activities.go
@@ -50,6 +50,7 @@ type (
 	getNamespaceInfoResult struct {
 		NamespaceID namespace.ID
 		Namespace   namespace.Name
+		Clusters    []string
 	}
 )
 
@@ -85,6 +86,7 @@ func (a *localActivities) GetNamespaceInfoActivity(ctx context.Context, nsID nam
 	return getNamespaceInfoResult{
 		NamespaceID: namespace.ID(getNamespaceResponse.Namespace.Info.Id),
 		Namespace:   namespace.Name(getNamespaceResponse.Namespace.Info.Name),
+		Clusters:    getNamespaceResponse.Namespace.ReplicationConfig.Clusters,
 	}, nil
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Delete Namespace: block for replicated namespace.

## Why?
<!-- Tell your future self why have you made these changes -->
Disable namespace deletion if namespace is replicate because:
  - If namespace is passive in the current cluster, then WF executions will keep coming from
    the active cluster and namespace will never be deleted (`ReclaimResourcesWorkflow` will fail).
  - If namespace is active in the current cluster, then it technically can be deleted (and
    in this case it will be deleted from this cluster only because delete operation is not replicated),
    but this is confusing for the users, as they might expect that namespace is deleted from all clusters.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit and functional tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Replicated namespaces can't be deleted anymore and must be disconnected first.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.