### PR TITLE
Refresh Nexus endpoints from db periodically

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1223,10 +1223,10 @@ duration since last poll exceeds this threshold.`,
 		5*time.Minute-10*time.Second,
 		`MatchingListNexusEndpointsLongPollTimeout is the max length of long polls for ListNexusEndpoints calls.`,
 	)
-	MatchingLoadNexusEndpointsRefresh = NewGlobalDurationSetting(
-		"matching.loadNexusEndpointsRefresh",
+	MatchingNexusEndpointsRefreshInterval = NewGlobalDurationSetting(
+		"matching.nexusEndpointsRefreshInterval",
 		10*time.Second,
-		`MatchingLoadNexusEndpointsRefresh is the time to wait between calls to check that the in-memory view of Nexus 
+		`MatchingNexusEndpointsRefreshInterval is the time to wait between calls to check that the in-memory view of Nexus 
 endpoints matches the persisted state.`,
 	)
 	MatchingMembershipUnloadDelay = NewGlobalDurationSetting(

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1223,6 +1223,12 @@ duration since last poll exceeds this threshold.`,
 		5*time.Minute-10*time.Second,
 		`MatchingListNexusEndpointsLongPollTimeout is the max length of long polls for ListNexusEndpoints calls.`,
 	)
+	MatchingLoadNexusEndpointsRefresh = NewGlobalDurationSetting(
+		"matching.loadNexusEndpointsRefresh",
+		10*time.Second,
+		`MatchingLoadNexusEndpointsRefresh is the time to wait between calls to check that the in-memory view of Nexus 
+endpoints matches the persisted state.`,
+	)
 	MatchingMembershipUnloadDelay = NewGlobalDurationSetting(
 		"matching.membershipUnloadDelay",
 		500*time.Millisecond,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1226,8 +1226,7 @@ duration since last poll exceeds this threshold.`,
 	MatchingNexusEndpointsRefreshInterval = NewGlobalDurationSetting(
 		"matching.nexusEndpointsRefreshInterval",
 		10*time.Second,
-		`MatchingNexusEndpointsRefreshInterval is the time to wait between calls to check that the in-memory view of Nexus 
-endpoints matches the persisted state.`,
+		`Time to wait between calls to check that the in-memory view of Nexus endpoints matches the persisted state.`,
 	)
 	MatchingMembershipUnloadDelay = NewGlobalDurationSetting(
 		"matching.membershipUnloadDelay",

--- a/common/persistence/sql/nexus_endpoint_store.go
+++ b/common/persistence/sql/nexus_endpoint_store.go
@@ -159,10 +159,12 @@ func (s *sqlNexusEndpointStore) ListNexusEndpoints(
 			return p.ErrNexusTableVersionConflict
 		}
 
-		rows, err = tx.ListNexusEndpoints(ctx, &sqlplugin.ListNexusEndpointsRequest{
-			LastID: lastID,
-			Limit:  request.PageSize,
-		})
+		if request.PageSize > 0 {
+			rows, err = tx.ListNexusEndpoints(ctx, &sqlplugin.ListNexusEndpointsRequest{
+				LastID: lastID,
+				Limit:  request.PageSize,
+			})
+		}
 
 		return err
 	})

--- a/common/persistence/sql/nexus_endpoint_store.go
+++ b/common/persistence/sql/nexus_endpoint_store.go
@@ -160,6 +160,7 @@ func (s *sqlNexusEndpointStore) ListNexusEndpoints(
 		}
 
 		if request.PageSize > 0 {
+			// PageSize could be zero when fetching just the table version.
 			rows, err = tx.ListNexusEndpoints(ctx, &sqlplugin.ListNexusEndpointsRequest{
 				LastID: lastID,
 				Limit:  request.PageSize,
@@ -175,6 +176,7 @@ func (s *sqlNexusEndpointStore) ListNexusEndpoints(
 
 	var nextPageToken []byte
 	if len(rows) > 0 && len(rows) == request.PageSize {
+		// len(rows) could be zero when fetching just the table version.
 		nextPageToken, retErr = serializePageTokenJson(&listEndpointsNextPageToken{
 			LastID: rows[request.PageSize-1].ID,
 		})

--- a/common/persistence/sql/nexus_endpoint_store.go
+++ b/common/persistence/sql/nexus_endpoint_store.go
@@ -172,7 +172,7 @@ func (s *sqlNexusEndpointStore) ListNexusEndpoints(
 	}
 
 	var nextPageToken []byte
-	if len(rows) == request.PageSize {
+	if len(rows) > 0 && len(rows) == request.PageSize {
 		nextPageToken, retErr = serializePageTokenJson(&listEndpointsNextPageToken{
 			LastID: rows[request.PageSize-1].ID,
 		})

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -117,6 +117,7 @@ type (
 		LoadUserData dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 
 		ListNexusEndpointsLongPollTimeout dynamicconfig.DurationPropertyFn
+		LoadNexusEndpointsRefresh         dynamicconfig.DurationPropertyFn
 
 		LogAllReqErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}
@@ -276,6 +277,7 @@ func NewConfig(
 		VisibilityEnableManualPagination:        dynamicconfig.VisibilityEnableManualPagination.Get(dc),
 
 		ListNexusEndpointsLongPollTimeout: dynamicconfig.MatchingListNexusEndpointsLongPollTimeout.Get(dc),
+		LoadNexusEndpointsRefresh:         dynamicconfig.MatchingLoadNexusEndpointsRefresh.Get(dc),
 
 		LogAllReqErrors: dynamicconfig.LogAllReqErrors.Get(dc),
 	}

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -117,7 +117,7 @@ type (
 		LoadUserData dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 
 		ListNexusEndpointsLongPollTimeout dynamicconfig.DurationPropertyFn
-		LoadNexusEndpointsRefresh         dynamicconfig.DurationPropertyFn
+		NexusEndpointsRefreshInterval     dynamicconfig.DurationPropertyFn
 
 		LogAllReqErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}
@@ -277,7 +277,7 @@ func NewConfig(
 		VisibilityEnableManualPagination:        dynamicconfig.VisibilityEnableManualPagination.Get(dc),
 
 		ListNexusEndpointsLongPollTimeout: dynamicconfig.MatchingListNexusEndpointsLongPollTimeout.Get(dc),
-		LoadNexusEndpointsRefresh:         dynamicconfig.MatchingLoadNexusEndpointsRefresh.Get(dc),
+		NexusEndpointsRefreshInterval:     dynamicconfig.MatchingNexusEndpointsRefreshInterval.Get(dc),
 
 		LogAllReqErrors: dynamicconfig.LogAllReqErrors.Get(dc),
 	}

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -222,7 +222,7 @@ func NewEngine(
 		clusterMeta:                   clusterMeta,
 		timeSource:                    clock.NewRealTimeSource(), // No need to mock this at the moment
 		visibilityManager:             visibilityManager,
-		nexusEndpointClient:           newEndpointClient(config.LoadNexusEndpointsRefresh, nexusEndpointManager),
+		nexusEndpointClient:           newEndpointClient(config.NexusEndpointsRefreshInterval, nexusEndpointManager),
 		nexusEndpointsOwnershipLostCh: make(chan struct{}),
 		metricsHandler:                scopedMetricsHandler,
 		partitions:                    make(map[tqid.PartitionKey]taskQueuePartitionManager),
@@ -290,7 +290,7 @@ func (e *matchingEngineImpl) watchMembership() {
 			continue
 		}
 
-		e.notifyIfNexusEndpointsOwnershipLost()
+		e.notifyNexusEndpointsOwnershipChange()
 
 		// Check all our loaded partitions to see if we lost ownership of any of them.
 		e.partitionsLock.RLock()
@@ -2078,7 +2078,7 @@ func (e *matchingEngineImpl) checkNexusEndpointsOwnership() (bool, <-chan struct
 	return owner.Identity() == self, ch, nil
 }
 
-func (e *matchingEngineImpl) notifyIfNexusEndpointsOwnershipLost() {
+func (e *matchingEngineImpl) notifyNexusEndpointsOwnershipChange() {
 	// We don't care about the channel returned here. This method is ensured to only be called from the single
 	// watchMembership method and is the only way the channel may be replaced.
 	isOwner, _, err := e.checkNexusEndpointsOwnership()

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -272,6 +272,8 @@ func (e *matchingEngineImpl) Stop() {
 	_ = e.serviceResolver.RemoveListener(e.listenerKey())
 	close(e.membershipChangedCh)
 
+	e.nexusEndpointClient.notifyOwnershipChanged(false)
+
 	for _, l := range e.getTaskQueuePartitions(math.MaxInt32) {
 		l.Stop(unloadCauseShuttingDown)
 	}

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -93,15 +93,16 @@ type (
 	matchingEngineSuite struct {
 		suite.Suite
 		*require.Assertions
-		controller            *gomock.Controller
-		mockHistoryClient     *historyservicemock.MockHistoryServiceClient
-		mockMatchingClient    *matchingservicemock.MockMatchingServiceClient
-		ns                    *namespace.Namespace
-		mockNamespaceCache    *namespace.MockRegistry
-		mockVisibilityManager *manager.MockVisibilityManager
-		mockHostInfoProvider  *membership.MockHostInfoProvider
-		mockServiceResolver   *membership.MockServiceResolver
-		hostInfoForResolver   membership.HostInfo
+		controller               *gomock.Controller
+		mockHistoryClient        *historyservicemock.MockHistoryServiceClient
+		mockMatchingClient       *matchingservicemock.MockMatchingServiceClient
+		ns                       *namespace.Namespace
+		mockNamespaceCache       *namespace.MockRegistry
+		mockVisibilityManager    *manager.MockVisibilityManager
+		mockHostInfoProvider     *membership.MockHostInfoProvider
+		mockServiceResolver      *membership.MockServiceResolver
+		hostInfoForResolver      membership.HostInfo
+		mockNexusEndpointManager *persistence.MockNexusEndpointManager
 
 		matchingEngine *matchingEngineImpl
 		taskManager    *testTaskManager
@@ -134,7 +135,9 @@ func createTestMatchingEngine(
 	mockServiceResolver.EXPECT().Lookup(gomock.Any()).Return(hostInfo, nil).AnyTimes()
 	mockServiceResolver.EXPECT().AddListener(gomock.Any(), gomock.Any()).AnyTimes()
 	mockServiceResolver.EXPECT().RemoveListener(gomock.Any()).AnyTimes()
-	return newMatchingEngine(config, tm, mockHistoryClient, logger, namespaceRegistry, matchingClient, mockVisibilityManager, mockHostInfoProvider, mockServiceResolver)
+	mockNexusEndpointManager := persistence.NewMockNexusEndpointManager(controller)
+	mockNexusEndpointManager.EXPECT().ListNexusEndpoints(gomock.Any(), gomock.Any()).Return(&persistence.ListNexusEndpointsResponse{}).AnyTimes()
+	return newMatchingEngine(config, tm, mockHistoryClient, logger, namespaceRegistry, matchingClient, mockVisibilityManager, mockHostInfoProvider, mockServiceResolver, mockNexusEndpointManager)
 }
 
 func createMockNamespaceCache(controller *gomock.Controller, nsName namespace.Name) (*namespace.Namespace, *namespace.MockRegistry) {
@@ -186,6 +189,8 @@ func (s *matchingEngineSuite) SetupTest() {
 	}).AnyTimes()
 	s.mockServiceResolver.EXPECT().AddListener(gomock.Any(), gomock.Any()).AnyTimes()
 	s.mockServiceResolver.EXPECT().RemoveListener(gomock.Any()).AnyTimes()
+	s.mockNexusEndpointManager = persistence.NewMockNexusEndpointManager(s.controller)
+	s.mockNexusEndpointManager.EXPECT().ListNexusEndpoints(gomock.Any(), gomock.Any()).Return(&persistence.ListNexusEndpointsResponse{}, nil).AnyTimes()
 
 	s.matchingEngine = s.newMatchingEngine(defaultTestConfig(), s.taskManager)
 	s.matchingEngine.Start()
@@ -200,13 +205,14 @@ func (s *matchingEngineSuite) newMatchingEngine(
 	config *Config, taskMgr persistence.TaskManager,
 ) *matchingEngineImpl {
 	return newMatchingEngine(config, taskMgr, s.mockHistoryClient, s.logger, s.mockNamespaceCache, s.mockMatchingClient, s.mockVisibilityManager,
-		s.mockHostInfoProvider, s.mockServiceResolver)
+		s.mockHostInfoProvider, s.mockServiceResolver, s.mockNexusEndpointManager)
 }
 
 func newMatchingEngine(
 	config *Config, taskMgr persistence.TaskManager, mockHistoryClient historyservice.HistoryServiceClient,
 	logger log.Logger, mockNamespaceCache namespace.Registry, mockMatchingClient matchingservice.MatchingServiceClient,
-	mockVisibilityManager manager.VisibilityManager, mockHostInfoProvider membership.HostInfoProvider, mockServiceResolver membership.ServiceResolver,
+	mockVisibilityManager manager.VisibilityManager, mockHostInfoProvider membership.HostInfoProvider,
+	mockServiceResolver membership.ServiceResolver, nexusEndpointManager persistence.NexusEndpointManager,
 ) *matchingEngineImpl {
 	return &matchingEngineImpl{
 		taskManager:   taskMgr,
@@ -232,6 +238,7 @@ func newMatchingEngine(
 		clusterMeta:                   clustertest.NewMetadataForTest(cluster.NewTestClusterMetadataConfig(false, true)),
 		timeSource:                    clock.NewRealTimeSource(),
 		visibilityManager:             mockVisibilityManager,
+		nexusEndpointClient:           newEndpointClient(config.LoadNexusEndpointsRefresh, nexusEndpointManager),
 		nexusEndpointsOwnershipLostCh: make(chan struct{}),
 	}
 }

--- a/service/matching/nexus_endpoint_client.go
+++ b/service/matching/nexus_endpoint_client.go
@@ -362,10 +362,6 @@ func (m *nexusEndpointClient) loadEndpoints(ctx context.Context) error {
 	}
 
 	m.hasLoadedEndpoints.Store(ctx.Err() == nil)
-	ch := m.tableVersionChanged
-	m.tableVersionChanged = make(chan struct{})
-	close(ch)
-
 	return ctx.Err()
 }
 
@@ -416,5 +412,8 @@ func (m *nexusEndpointClient) checkTableVersion(ctx context.Context) {
 	})
 	if err != nil || resp.TableVersion != m.tableVersion {
 		m.hasLoadedEndpoints.Store(false)
+		ch := m.tableVersionChanged
+		m.tableVersionChanged = make(chan struct{})
+		close(ch)
 	}
 }

--- a/service/matching/nexus_endpoint_client.go
+++ b/service/matching/nexus_endpoint_client.go
@@ -373,7 +373,7 @@ func (m *nexusEndpointClient) resetCacheStateLocked() {
 }
 
 // notifyOwnershipChanged starts or stops a background routine which watches the Nexus endpoints table version for
-// changes. This is not thread-safe and only expected to be called from matchingEngineImpl.notifyIfNexusEndpointsOwnershipLost()
+// changes. This is only expected to be called from matchingEngineImpl.notifyIfNexusEndpointsOwnershipLost()
 func (m *nexusEndpointClient) notifyOwnershipChanged(isOwner bool) {
 	oldIsOwner := m.isTableOwner.Swap(isOwner)
 	if isOwner && !oldIsOwner {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Added a background routine to `matching/nexus_endpoint_client` which checks whether the last known table version has changed.

## Why?
<!-- Tell your future self why have you made these changes -->
In rare cases, when a new node acquires ownership it may miss in-flight updates from the previous owner and has no way of detecting this inconsistency.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests

