### PR TITLE
Fix a couple of issues in the slog adapter

### DIFF
--- a/common/log/slog.go
+++ b/common/log/slog.go
@@ -44,7 +44,7 @@ type handler struct {
 
 var _ slog.Handler = (*handler)(nil)
 
-// An interface that allows extracting an underlying slog logger.
+// SLogWrapper allows extracting an underlying slog logger.
 type SLogWrapper interface {
 	SLog() *slog.Logger
 }


### PR DESCRIPTION
## What changed?

- Always carry over the embedded `zapLogger`.
- Ensure `handler` is never `nil`.
- Allow extracting an underlying `slog.Logger`.

## Why?

Realized there are some issues using custom loggers, like the one used by the CLI.