### PR TITLE
fix(schema): check for extension before creating

### DIFF
--- a/common/persistence/query_util.go
+++ b/common/persistence/query_util.go
@@ -97,7 +97,7 @@ func LoadAndSplitQueryFromReaders(
 								return nil, errors.New("error reading contents: unmatched `END IF` keyword")
 							}
 							st = st[:len(st)-1]
-							j = after + len(sqlIfKeyword)
+							j = after + len(sqlIfKeyword) - 1
 						} else {
 							if len(st) == 0 || st[len(st)-1] != sqlBeginKeyword[0] {
 								return nil, fmt.Errorf("error reading contents: unmatched `END` keyword")

--- a/common/persistence/query_util.go
+++ b/common/persistence/query_util.go
@@ -17,7 +17,6 @@ const (
 	sqlLeftParenthesis  = '('
 	sqlRightParenthesis = ')'
 	sqlIfKeyword        = "if"
-	sqlEndIfKeyword     = "end if"
 	sqlBeginKeyword     = "begin"
 	sqlEndKeyword       = "end"
 	sqlLineComment      = "--"
@@ -92,19 +91,20 @@ func LoadAndSplitQueryFromReaders(
 					}
 
 				case sqlEndKeyword[0]:
-					if hasWordAt(contentStr, sqlEndIfKeyword, j) {
-						if len(st) == 0 || st[len(st)-1] != sqlIfKeyword[0] {
-							return nil, errors.New("error reading contents: unmatched `END IF` keyword")
-						}
-						st = st[:len(st)-1]
-						j += len(sqlEndIfKeyword) - 1
-					}
 					if hasWordAt(contentStr, sqlEndKeyword, j) {
-						if len(st) == 0 || st[len(st)-1] != sqlBeginKeyword[0] {
-							return nil, fmt.Errorf("error reading contents: unmatched `END` keyword")
+						if ok, after := hasWordAfter(contentStr, sqlIfKeyword, j+len(sqlEndKeyword)); ok {
+							if len(st) == 0 || st[len(st)-1] != sqlIfKeyword[0] {
+								return nil, errors.New("error reading contents: unmatched `END IF` keyword")
+							}
+							st = st[:len(st)-1]
+							j = after + len(sqlIfKeyword)
+						} else {
+							if len(st) == 0 || st[len(st)-1] != sqlBeginKeyword[0] {
+								return nil, fmt.Errorf("error reading contents: unmatched `END` keyword")
+							}
+							st = st[:len(st)-1]
+							j += len(sqlEndKeyword) - 1
 						}
-						st = st[:len(st)-1]
-						j += len(sqlEndKeyword) - 1
 					}
 
 				case sqlSingleQuote, sqlDoubleQuote:
@@ -167,6 +167,21 @@ func hasWordAt(s, word string, pos int) bool {
 		return false
 	}
 	return true
+}
+
+// hasWordAfter checks if the given word appears after position pos in s,
+// separated by at least one space, and is a whole word.
+func hasWordAfter(s, word string, pos int) (bool, int) {
+	after := pos
+	if after < len(s) && unicode.IsSpace(rune(s[after])) {
+		after++
+	} else {
+		return false, after
+	}
+	for after < len(s) && unicode.IsSpace(rune(s[after])) {
+		after++
+	}
+	return hasWordAt(s, word, after), after
 }
 
 func isAlphanumeric(c byte) bool {

--- a/common/persistence/query_util.go
+++ b/common/persistence/query_util.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -93,7 +94,7 @@ func LoadAndSplitQueryFromReaders(
 				case sqlEndKeyword[0]:
 					if hasWordAt(contentStr, sqlEndIfKeyword, j) {
 						if len(st) == 0 || st[len(st)-1] != sqlIfKeyword[0] {
-							return nil, fmt.Errorf("error reading contents: unmatched `END IF` keyword")
+							return nil, errors.New("error reading contents: unmatched `END IF` keyword")
 						}
 						st = st[:len(st)-1]
 						j += len(sqlEndIfKeyword) - 1

--- a/common/persistence/query_util_test.go
+++ b/common/persistence/query_util_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-
 	"go.temporal.io/server/common/log"
 )
 

--- a/common/persistence/query_util_test.go
+++ b/common/persistence/query_util_test.go
@@ -37,7 +37,7 @@ func (s *queryUtilSuite) TestLoadAndSplitQueryFromReaders() {
 			BEGIN
 				IF ( NOT EXISTS (select extname from pg_extension where extname = 'btree_gin') ) THEN
 					CREATE EXTENSION btree_gin;
-				END IF;
+				END  IF; --Intentionally add multiple spaces between END and IF
 			END
 		$$;
 
@@ -67,7 +67,7 @@ func (s *queryUtilSuite) TestLoadAndSplitQueryFromReaders() {
 			BEGIN
 				IF ( NOT EXISTS (select extname from pg_extension where extname = 'btree_gin') ) THEN
 					CREATE EXTENSION btree_gin;
-				END IF;
+				END  IF;
 			END
 		$$;`,
 		statements[0],

--- a/schema/postgresql/v12/visibility/schema.sql
+++ b/schema/postgresql/v12/visibility/schema.sql
@@ -3,7 +3,7 @@ DO LANGUAGE 'plpgsql' $$
         IF ( NOT EXISTS (select extname from pg_extension where extname = 'btree_gin') ) THEN
             CREATE EXTENSION btree_gin;
         END IF;
-    END;
+    END
 $$;
 
 -- convert_ts converts a timestamp in RFC3339 to UTC timestamp without time zone.

--- a/schema/postgresql/v12/visibility/schema.sql
+++ b/schema/postgresql/v12/visibility/schema.sql
@@ -1,4 +1,10 @@
-CREATE EXTENSION IF NOT EXISTS btree_gin;
+DO LANGUAGE 'plpgsql' $$
+    BEGIN
+        IF ( NOT EXISTS (select extname from pg_extension where extname = 'btree_gin') ) THEN
+            CREATE EXTENSION btree_gin;
+        END IF;
+    END;
+$$;
 
 -- convert_ts converts a timestamp in RFC3339 to UTC timestamp without time zone.
 CREATE FUNCTION convert_ts(s VARCHAR) RETURNS TIMESTAMP AS $$

--- a/schema/postgresql/v12/visibility/versioned/v1.2/advanced_visibility.sql
+++ b/schema/postgresql/v12/visibility/versioned/v1.2/advanced_visibility.sql
@@ -3,7 +3,7 @@ DO LANGUAGE 'plpgsql' $$
         IF ( NOT EXISTS (select extname from pg_extension where extname = 'btree_gin') ) THEN
             CREATE EXTENSION btree_gin;
         END IF;
-    END;
+    END
 $$;
 
 -- convert_ts converts a timestamp in RFC3339 to UTC timestamp without time zone.

--- a/schema/postgresql/v12/visibility/versioned/v1.2/advanced_visibility.sql
+++ b/schema/postgresql/v12/visibility/versioned/v1.2/advanced_visibility.sql
@@ -1,4 +1,10 @@
-CREATE EXTENSION IF NOT EXISTS btree_gin;
+DO LANGUAGE 'plpgsql' $$
+    BEGIN
+        IF ( NOT EXISTS (select extname from pg_extension where extname = 'btree_gin') ) THEN
+            CREATE EXTENSION btree_gin;
+        END IF;
+    END;
+$$;
 
 -- convert_ts converts a timestamp in RFC3339 to UTC timestamp without time zone.
 CREATE FUNCTION convert_ts(s VARCHAR) RETURNS TIMESTAMP AS $$

--- a/tools/common/schema/updatetask.go
+++ b/tools/common/schema/updatetask.go
@@ -60,7 +60,7 @@ const (
 )
 
 var (
-	whitelistedCQLPrefixes = [4]string{"CREATE", "ALTER", "INSERT", "DROP"}
+	whitelistedCQLPrefixes = [5]string{"CREATE", "ALTER", "INSERT", "DROP", "DO"}
 	versionDirectoryRegex  = regexp.MustCompile(`^v[\d.]+`)
 )
 


### PR DESCRIPTION
## What changed?
`CREATE EXTENSION` sql query is replaced with a pgsql script that checks for the existence of the extension programatically.

## Why?
`CREATE EXTENSION` can cause issues in environment where creating extensions are limited to certain users. (e.g. Azure)

## How did you test it?
I've ran the updated schema setup in both environments where btree_gin is installed and and not installed.

## Potential risks
Regression in visibility database setup.

## Documentation
Not needed.

## Is hotfix candidate?
No
