### PR TITLE
increase the number of returned jobs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -473,11 +473,9 @@ jobs:
       - name: Get job ID from workflow run
         id: get_job_id
         run: |
-          set -eu
+          set -euo pipefail
           test_job_name="Functional test (${{matrix.runs-on}}, ${{matrix.shard_index}}, ${{matrix.name}})"
-          job_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs"
-          echo "Test job name is $test_job_name"
-          echo "Job url is $job_url"
+          job_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100"
           job_id=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" \
@@ -602,9 +600,7 @@ jobs:
         run: |
           set -euo pipefail
           test_job_name="Functional test xdc (${{matrix.name}})"
-          job_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs"
-          echo "Test job name is $test_job_name"
-          echo "Job url is $job_url"
+          job_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100"
           job_id=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" \
@@ -725,11 +721,9 @@ jobs:
       - name: Get job ID from workflow run
         id: get_job_id
         run: |
-          set -eu
+          set -euo pipefail
           test_job_name="Functional test ndc (${{matrix.name}})"
-          job_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs"
-          echo "Test job name is $test_job_name"
-          echo "Job url is $job_url"
+          job_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100"
           job_id=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" \

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -476,6 +476,8 @@ jobs:
           set -eu
           test_job_name="Functional test (${{matrix.runs-on}}, ${{matrix.shard_index}}, ${{matrix.name}})"
           job_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100"
+          # curl or jq might silently fail, but we are okay with that.
+          # We don't want to fail the job if we can't get the job id.          
           job_id=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" \
@@ -483,7 +485,7 @@ jobs:
              "$job_url" \
             | jq "first(.jobs[] | select(.name == \"$test_job_name\") | .id)")
           echo "Job id is $job_id"
-          echo "JOB_ID=${job_id}" >> "$GITHUB_OUTPUT"
+          echo "JOB_ID=${job_id:-unknown}" >> "$GITHUB_OUTPUT"
 
       - name: Run functional test
         if: ${{ inputs.run_single_functional_test != true || (inputs.run_single_functional_test == true && contains(fromJSON(needs.set-up-single-test.outputs.dbs), env.PERSISTENCE_DRIVER)) }}
@@ -601,6 +603,8 @@ jobs:
           set -eu
           test_job_name="Functional test xdc (${{matrix.name}})"
           job_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100"
+          # curl or jq might silently fail, but we are okay with that.
+          # We don't want to fail the job if we can't get the job id.
           job_id=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" \
@@ -608,7 +612,7 @@ jobs:
              "$job_url" \
             | jq "first(.jobs[] | select(.name == \"$test_job_name\") | .id)")
           echo "Job id is $job_id"
-          echo "JOB_ID=${job_id}" >> "$GITHUB_OUTPUT"
+          echo "JOB_ID=${job_id-unknown}" >> "$GITHUB_OUTPUT"
 
       - name: Run functional test xdc
         timeout-minutes: 25   # update this to TEST_TIMEOUT+5 if you update the Makefile
@@ -724,6 +728,8 @@ jobs:
           set -eu
           test_job_name="Functional test ndc (${{matrix.name}})"
           job_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100"
+          # curl or jq might silently fail, but we are okay with that.
+          # We don't want to fail the job if we can't get the job id.
           job_id=$(curl -L \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" \
@@ -731,7 +737,7 @@ jobs:
              "$job_url" \
             | jq "first(.jobs[] | select(.name == \"$test_job_name\") | .id)")
           echo "Job id is $job_id"
-          echo "JOB_ID=${job_id}" >> "$GITHUB_OUTPUT"
+          echo "JOB_ID=${job_id:-unknown}" >> "$GITHUB_OUTPUT"
 
       - name: Run functional test ndc
         timeout-minutes: 15

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -473,7 +473,7 @@ jobs:
       - name: Get job ID from workflow run
         id: get_job_id
         run: |
-          set -euo pipefail
+          set -eu
           test_job_name="Functional test (${{matrix.runs-on}}, ${{matrix.shard_index}}, ${{matrix.name}})"
           job_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100"
           job_id=$(curl -L \
@@ -598,7 +598,7 @@ jobs:
       - name: Get job ID from workflow run
         id: get_job_id
         run: |
-          set -euo pipefail
+          set -eu
           test_job_name="Functional test xdc (${{matrix.name}})"
           job_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100"
           job_id=$(curl -L \
@@ -721,7 +721,7 @@ jobs:
       - name: Get job ID from workflow run
         id: get_job_id
         run: |
-          set -euo pipefail
+          set -eu
           test_job_name="Functional test ndc (${{matrix.name}})"
           job_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100"
           job_id=$(curl -L \


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
* Add page_num parameter to GH jobs API url.
* remove some debug lines
* remove pipefail
## Why?
<!-- Tell your future self why have you made these changes -->
The default number of returned jobs is 30, and we may have more then that.

With pipefail (as I understand it) we can be in a situation when job_id is set to the pipeline errors.
Without it it will be empty. Empty is better then a random error.