### PR TITLE
Delete Namespace: protect critical namespaces from deletion

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1015,8 +1015,8 @@ Default is 4.`,
 after all namespace resources (i.e. workflow executions) are deleted.
 Default is 0, means, namespace will be deleted immediately.`,
 	)
-	DeleteNamespaceBlockedNamespaces = NewGlobalTypedSetting(
-		"worker.deleteNamespaceBlockedNamespaces",
+	ProtectedNamespaces = NewGlobalTypedSetting(
+		"worker.protectedNamespaces",
 		([]string)(nil),
 		`List of namespace names that can't be deleted.`,
 	)

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1015,6 +1015,11 @@ Default is 4.`,
 after all namespace resources (i.e. workflow executions) are deleted.
 Default is 0, means, namespace will be deleted immediately.`,
 	)
+	DeleteNamespaceBlockedNamespaces = NewGlobalTypedSetting(
+		"worker.deleteNamespaceBlockedNamespaces",
+		([]string)(nil),
+		`List of namespace names that can't be deleted.`,
+	)
 
 	// keys for matching
 

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -75,7 +75,6 @@ var (
 	errStatusFilterMustBeNotRunning                       = serviceerror.NewInvalidArgument("StatusFilter must be specified and must be not Running.")
 	errCronNotAllowed                                     = serviceerror.NewInvalidArgument("Scheduled workflow must not contain CronSchedule")
 	errIDReusePolicyNotAllowed                            = serviceerror.NewInvalidArgument("Scheduled workflow must not contain WorkflowIDReusePolicy")
-	errUnableDeleteSystemNamespace                        = serviceerror.NewInvalidArgument("Unable to delete system namespace.")
 	errBatchJobIDNotSet                                   = serviceerror.NewInvalidArgument("JobId is not set on request.")
 	errNamespaceNotSet                                    = serviceerror.NewInvalidArgument("Namespace is not set on request.")
 	errReasonNotSet                                       = serviceerror.NewInvalidArgument("Reason is not set on request.")

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -63,7 +63,7 @@ import (
 	"go.temporal.io/server/service/worker/addsearchattributes"
 	"go.temporal.io/server/service/worker/deletenamespace"
 	"go.temporal.io/server/service/worker/deletenamespace/deleteexecutions"
-	delns_errors "go.temporal.io/server/service/worker/deletenamespace/errors"
+	delnserrors "go.temporal.io/server/service/worker/deletenamespace/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -685,7 +685,7 @@ func (h *OperatorHandlerImpl) DeleteNamespace(
 	if err != nil {
 		// Special handling for validation errors. Convert them to InvalidArgument.
 		var appErr *temporal.ApplicationError
-		if errors.As(err, &appErr) && appErr.Type() == delns_errors.ValidationErrorErrType {
+		if errors.As(err, &appErr) && appErr.Type() == delnserrors.ValidationErrorErrType {
 			return nil, serviceerror.NewInvalidArgument(appErr.Message())
 		}
 		return nil, serviceerror.NewSystemWorkflow(&commonpb.WorkflowExecution{WorkflowId: deletenamespace.WorkflowName, RunId: run.GetRunID()}, err)

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -57,7 +57,7 @@ import (
 	"go.temporal.io/server/common/testing/mocksdk"
 	"go.temporal.io/server/service/worker/addsearchattributes"
 	"go.temporal.io/server/service/worker/deletenamespace"
-	delns_errors "go.temporal.io/server/service/worker/deletenamespace/errors"
+	delnserrors "go.temporal.io/server/service/worker/deletenamespace/errors"
 	"go.uber.org/mock/gomock"
 	expmaps "golang.org/x/exp/maps"
 	"google.golang.org/grpc/health"
@@ -1230,7 +1230,7 @@ func (s *operatorHandlerSuite) Test_DeleteNamespace() {
 
 	// Workflow failed because of validation error (an attempt to delete system namespace).
 	mockRun2 := mocksdk.NewMockWorkflowRun(s.controller)
-	mockRun2.EXPECT().Get(gomock.Any(), gomock.Any()).Return(temporal.NewNonRetryableApplicationError("unable to delete system namespace", delns_errors.ValidationErrorErrType, nil, nil))
+	mockRun2.EXPECT().Get(gomock.Any(), gomock.Any()).Return(temporal.NewNonRetryableApplicationError("unable to delete system namespace", delnserrors.ValidationErrorErrType, nil, nil))
 	mockSdkClient.EXPECT().ExecuteWorkflow(gomock.Any(), gomock.Any(), "temporal-sys-delete-namespace-workflow", gomock.Any()).Return(mockRun2, nil)
 	resp, err = handler.DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
 		Namespace: "temporal-system",

--- a/service/worker/deletenamespace/activities.go
+++ b/service/worker/deletenamespace/activities.go
@@ -42,9 +42,9 @@ import (
 
 type (
 	localActivities struct {
-		metadataManager   persistence.MetadataManager
-		blockedNamespaces dynamicconfig.TypedPropertyFn[[]string]
-		logger            log.Logger
+		metadataManager     persistence.MetadataManager
+		protectedNamespaces dynamicconfig.TypedPropertyFn[[]string]
+		logger              log.Logger
 	}
 
 	getNamespaceInfoResult struct {
@@ -52,21 +52,17 @@ type (
 		Namespace   namespace.Name
 		Clusters    []string
 	}
-
-	blockedNamespaces struct {
-		Names []string
-	}
 )
 
 func newLocalActivities(
 	metadataManager persistence.MetadataManager,
-	blockedNamespaces dynamicconfig.TypedPropertyFn[[]string],
+	protectedNamespaces dynamicconfig.TypedPropertyFn[[]string],
 	logger log.Logger,
 ) *localActivities {
 	return &localActivities{
-		metadataManager:   metadataManager,
-		blockedNamespaces: blockedNamespaces,
-		logger:            logger,
+		metadataManager:     metadataManager,
+		protectedNamespaces: protectedNamespaces,
+		logger:              logger,
 	}
 }
 
@@ -94,8 +90,8 @@ func (a *localActivities) GetNamespaceInfoActivity(ctx context.Context, nsID nam
 	}, nil
 }
 
-func (a *localActivities) GetBlockedNamespacesActivity(_ context.Context) (blockedNamespaces, error) {
-	return blockedNamespaces{Names: a.blockedNamespaces()}, nil
+func (a *localActivities) GetProtectedNamespacesActivity(_ context.Context) ([]string, error) {
+	return a.protectedNamespaces(), nil
 }
 
 func (a *localActivities) MarkNamespaceDeletedActivity(ctx context.Context, nsName namespace.Name) error {

--- a/service/worker/deletenamespace/errors/errors.go
+++ b/service/worker/deletenamespace/errors/errors.go
@@ -32,6 +32,7 @@ import (
 )
 
 const (
+	ValidationErrorErrType                = "ValidationError"
 	ExecutionsStillExistErrType           = "ExecutionsStillExist"
 	NoProgressErrType                     = "NoProgress"
 	NotDeletedExecutionsStillExistErrType = "NotDeletedExecutionsStillExist"

--- a/service/worker/deletenamespace/fx.go
+++ b/service/worker/deletenamespace/fx.go
@@ -46,13 +46,13 @@ import (
 type (
 	// deleteNamespaceComponent represent background work needed for delete namespace.
 	deleteNamespaceComponent struct {
-		atWorkerCfg       sdkworker.Options
-		visibilityManager manager.VisibilityManager
-		metadataManager   persistence.MetadataManager
-		historyClient     resource.HistoryClient
-		metricsHandler    metrics.Handler
-		blockedNamespaces dynamicconfig.TypedPropertyFn[[]string]
-		logger            log.Logger
+		atWorkerCfg         sdkworker.Options
+		visibilityManager   manager.VisibilityManager
+		metadataManager     persistence.MetadataManager
+		historyClient       resource.HistoryClient
+		metricsHandler      metrics.Handler
+		protectedNamespaces dynamicconfig.TypedPropertyFn[[]string]
+		logger              log.Logger
 	}
 	componentParams struct {
 		fx.In
@@ -71,13 +71,13 @@ func newComponent(
 	params componentParams,
 ) workercommon.WorkerComponent {
 	return &deleteNamespaceComponent{
-		atWorkerCfg:       dynamicconfig.WorkerDeleteNamespaceActivityLimits.Get(params.DynamicCollection)(),
-		visibilityManager: params.VisibilityManager,
-		metadataManager:   params.MetadataManager,
-		historyClient:     params.HistoryClient,
-		metricsHandler:    params.MetricsHandler,
-		blockedNamespaces: dynamicconfig.DeleteNamespaceBlockedNamespaces.Get(params.DynamicCollection),
-		logger:            params.Logger,
+		atWorkerCfg:         dynamicconfig.WorkerDeleteNamespaceActivityLimits.Get(params.DynamicCollection)(),
+		visibilityManager:   params.VisibilityManager,
+		metadataManager:     params.MetadataManager,
+		historyClient:       params.HistoryClient,
+		metricsHandler:      params.MetricsHandler,
+		protectedNamespaces: dynamicconfig.ProtectedNamespaces.Get(params.DynamicCollection),
+		logger:              params.Logger,
 	}
 }
 
@@ -116,7 +116,7 @@ func (wc *deleteNamespaceComponent) DedicatedActivityWorkerOptions() *workercomm
 }
 
 func (wc *deleteNamespaceComponent) deleteNamespaceLocalActivities() *localActivities {
-	return newLocalActivities(wc.metadataManager, wc.blockedNamespaces, wc.logger)
+	return newLocalActivities(wc.metadataManager, wc.protectedNamespaces, wc.logger)
 }
 
 func (wc *deleteNamespaceComponent) reclaimResourcesActivities() *reclaimresources.Activities {

--- a/service/worker/deletenamespace/fx.go
+++ b/service/worker/deletenamespace/fx.go
@@ -51,6 +51,7 @@ type (
 		metadataManager   persistence.MetadataManager
 		historyClient     resource.HistoryClient
 		metricsHandler    metrics.Handler
+		blockedNamespaces dynamicconfig.TypedPropertyFn[[]string]
 		logger            log.Logger
 	}
 	componentParams struct {
@@ -75,6 +76,7 @@ func newComponent(
 		metadataManager:   params.MetadataManager,
 		historyClient:     params.HistoryClient,
 		metricsHandler:    params.MetricsHandler,
+		blockedNamespaces: dynamicconfig.DeleteNamespaceBlockedNamespaces.Get(params.DynamicCollection),
 		logger:            params.Logger,
 	}
 }
@@ -114,7 +116,7 @@ func (wc *deleteNamespaceComponent) DedicatedActivityWorkerOptions() *workercomm
 }
 
 func (wc *deleteNamespaceComponent) deleteNamespaceLocalActivities() *localActivities {
-	return newLocalActivities(wc.metadataManager, wc.logger)
+	return newLocalActivities(wc.metadataManager, wc.blockedNamespaces, wc.logger)
 }
 
 func (wc *deleteNamespaceComponent) reclaimResourcesActivities() *reclaimresources.Activities {

--- a/service/worker/deletenamespace/workflow.go
+++ b/service/worker/deletenamespace/workflow.go
@@ -129,14 +129,14 @@ func validateNamespace(ctx workflow.Context, nsID namespace.ID, nsName namespace
 	var la *localActivities
 
 	ctx1 := workflow.WithLocalActivityOptions(ctx, localActivityOptions)
-	var bns blockedNamespaces
-	err := workflow.ExecuteLocalActivity(ctx1, la.GetBlockedNamespacesActivity).Get(ctx, &bns)
+	var protectedNamespaces []string
+	err := workflow.ExecuteLocalActivity(ctx1, la.GetProtectedNamespacesActivity).Get(ctx, &protectedNamespaces)
 	if err != nil {
-		return fmt.Errorf("%w: GetBlockedNamespacesActivity: %v", errors.ErrUnableToExecuteActivity, err)
+		return fmt.Errorf("%w: GetProtectedNamespacesActivity: %v", errors.ErrUnableToExecuteActivity, err)
 	}
-	for _, blockedNsName := range bns.Names {
-		if blockedNsName == nsName.String() {
-			return temporal.NewNonRetryableApplicationError(fmt.Sprintf("namespace %s is blocked from deletion", nsName), errors.ValidationErrorErrType, nil, nil)
+	for _, protectedNamespace := range protectedNamespaces {
+		if protectedNamespace == nsName.String() {
+			return temporal.NewNonRetryableApplicationError(fmt.Sprintf("namespace %s is protected from deletion", nsName), errors.ValidationErrorErrType, nil, nil)
 		}
 	}
 

--- a/service/worker/deletenamespace/workflow.go
+++ b/service/worker/deletenamespace/workflow.go
@@ -107,6 +107,42 @@ func validateParams(params *DeleteNamespaceWorkflowParams) error {
 	return nil
 }
 
+func validateNamespace(ctx workflow.Context, nsID namespace.ID, nsName namespace.Name, nsClusters []string) error {
+
+	if nsName == primitives.SystemLocalNamespace || nsID == primitives.SystemNamespaceID {
+		return temporal.NewNonRetryableApplicationError("unable to delete system namespace", errors.ValidationErrorErrType, nil, nil)
+	}
+
+	// Disable namespace deletion if namespace is replicate because:
+	//  - If namespace is passive in the current cluster, then WF executions will keep coming from
+	//    the active cluster and namespace will never be deleted (ReclaimResourcesWorkflow will fail).
+	//  - If namespace is active in the current cluster, then it technically can be deleted (and
+	//    in this case it will be deleted from this cluster only because delete operation is not replicated),
+	//    but this is confusing for the users, as they might expect that namespace is deleted from all clusters.
+	if len(nsClusters) > 1 {
+		return temporal.NewNonRetryableApplicationError(fmt.Sprintf("namespace %s is replicated in several clusters [%s]: remove all other cluster and retry", nsName, strings.Join(nsClusters, ",")), errors.ValidationErrorErrType, nil)
+	}
+
+	// NOTE: there is very little chance that another cluster is added after the check above,
+	// but before namespace is marked as deleted below.
+
+	var la *localActivities
+
+	ctx1 := workflow.WithLocalActivityOptions(ctx, localActivityOptions)
+	var bns blockedNamespaces
+	err := workflow.ExecuteLocalActivity(ctx1, la.GetBlockedNamespacesActivity).Get(ctx, &bns)
+	if err != nil {
+		return fmt.Errorf("%w: GetBlockedNamespacesActivity: %v", errors.ErrUnableToExecuteActivity, err)
+	}
+	for _, blockedNsName := range bns.Names {
+		if blockedNsName == nsName.String() {
+			return temporal.NewNonRetryableApplicationError(fmt.Sprintf("namespace %s is blocked from deletion", nsName), errors.ValidationErrorErrType, nil, nil)
+		}
+	}
+
+	return nil
+}
+
 func DeleteNamespaceWorkflow(ctx workflow.Context, params DeleteNamespaceWorkflowParams) (DeleteNamespaceWorkflowResult, error) {
 	logger := log.With(
 		workflow.GetLogger(ctx),
@@ -135,23 +171,15 @@ func DeleteNamespaceWorkflow(ctx workflow.Context, params DeleteNamespaceWorkflo
 		if ns == "" {
 			ns = params.NamespaceID.String()
 		}
-		return result, temporal.NewNonRetryableApplicationError(fmt.Sprintf("namespace %s is not found", ns), "", err)
+		return result, temporal.NewNonRetryableApplicationError(fmt.Sprintf("namespace %s is not found", ns), errors.ValidationErrorErrType, err)
 	}
 	params.Namespace = namespaceInfo.Namespace
 	params.NamespaceID = namespaceInfo.NamespaceID
 
-	// Disable namespace deletion if namespace is replicate because:
-	//  - If namespace is passive in the current cluster, then WF executions will keep coming from
-	//    the active cluster and namespace will never be deleted (ReclaimResourcesWorkflow will fail).
-	//  - If namespace is active in the current cluster, then it technically can be deleted (and
-	//    in this case it will be deleted from this cluster only because delete operation is not replicated),
-	//    but this is confusing for the users, as they might expect that namespace is deleted from all clusters.
-	if len(namespaceInfo.Clusters) > 1 {
-		return result, temporal.NewNonRetryableApplicationError(fmt.Sprintf("namespace %s is replicated in several clusters [%s]: remove all other cluster and retry", params.Namespace, strings.Join(namespaceInfo.Clusters, ",")), "", nil)
+	// Step 1.1. Validate namespace.
+	if err := validateNamespace(ctx, params.NamespaceID, params.Namespace, namespaceInfo.Clusters); err != nil {
+		return result, err
 	}
-
-	// NOTE: there is very little chance that another cluster is added after the check above,
-	// but before namespace is marked as deleted below.
 
 	// Step 2. Mark namespace as deleted.
 	ctx2 := workflow.WithLocalActivityOptions(ctx, localActivityOptions)

--- a/service/worker/deletenamespace/workflow_test.go
+++ b/service/worker/deletenamespace/workflow_test.go
@@ -49,8 +49,7 @@ func Test_DeleteNamespaceWorkflow_ByName(t *testing.T) {
 			NamespaceID: "namespace-id",
 			Namespace:   "namespace",
 		}, nil).Once()
-	env.OnActivity(la.GetBlockedNamespacesActivity, mock.Anything).Return(
-		blockedNamespaces{}, nil).Once()
+	env.OnActivity(la.GetProtectedNamespacesActivity, mock.Anything).Return(nil, nil).Once()
 	env.OnActivity(la.MarkNamespaceDeletedActivity, mock.Anything, namespace.Name("namespace")).Return(nil).Once()
 	env.OnActivity(la.GenerateDeletedNamespaceNameActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace")).Return(namespace.Name("namespace-delete-220878"), nil).Once()
 	env.OnActivity(la.RenameNamespaceActivity, mock.Anything, namespace.Name("namespace"), namespace.Name("namespace-delete-220878")).Return(nil).Once()
@@ -95,8 +94,7 @@ func Test_DeleteNamespaceWorkflow_ByID(t *testing.T) {
 			NamespaceID: "namespace-id",
 			Namespace:   "namespace",
 		}, nil).Once()
-	env.OnActivity(la.GetBlockedNamespacesActivity, mock.Anything).Return(
-		blockedNamespaces{}, nil).Once()
+	env.OnActivity(la.GetProtectedNamespacesActivity, mock.Anything).Return(nil, nil).Once()
 	env.OnActivity(la.MarkNamespaceDeletedActivity, mock.Anything, namespace.Name("namespace")).Return(nil).Once()
 	env.OnActivity(la.GenerateDeletedNamespaceNameActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace")).Return(namespace.Name("namespace-delete-220878"), nil).Once()
 	env.OnActivity(la.RenameNamespaceActivity, mock.Anything, namespace.Name("namespace"), namespace.Name("namespace-delete-220878")).Return(nil).Once()
@@ -190,7 +188,7 @@ func Test_DeleteSystemNamespace(t *testing.T) {
 	require.Contains(t, err.Error(), "unable to delete system namespace")
 }
 
-func Test_DeleteBlockedNamespace(t *testing.T) {
+func Test_DeleteProtectedNamespace(t *testing.T) {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
 	var la *localActivities
@@ -201,10 +199,7 @@ func Test_DeleteBlockedNamespace(t *testing.T) {
 			Namespace:   "namespace",
 		}, nil).Once()
 
-	env.OnActivity(la.GetBlockedNamespacesActivity, mock.Anything).Return(
-		blockedNamespaces{
-			Names: []string{"namespace"},
-		}, nil).Once()
+	env.OnActivity(la.GetProtectedNamespacesActivity, mock.Anything).Return([]string{"namespace"}, nil).Once()
 
 	env.ExecuteWorkflow(DeleteNamespaceWorkflow, DeleteNamespaceWorkflowParams{
 		NamespaceID: "namespace-id",
@@ -213,5 +208,5 @@ func Test_DeleteBlockedNamespace(t *testing.T) {
 	require.True(t, env.IsWorkflowCompleted())
 	err := env.GetWorkflowError()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "namespace namespace is blocked from deletion")
+	require.Contains(t, err.Error(), "namespace namespace is protected from deletion")
 }

--- a/tests/namespace_delete_test.go
+++ b/tests/namespace_delete_test.go
@@ -548,7 +548,7 @@ func (s *namespaceTestSuite) checkTestShard() {
 	s.T().Logf("Running %s in test shard %d/%d", s.T().Name(), index+1, total)
 }
 
-func (s *namespaceTestSuite) Test_NamespaceDelete_Blocked() {
+func (s *namespaceTestSuite) Test_NamespaceDelete_Protected() {
 	ctx := context.Background()
 
 	tv := testvars.New(s.T())
@@ -562,7 +562,7 @@ func (s *namespaceTestSuite) Test_NamespaceDelete_Blocked() {
 	})
 	s.NoError(err)
 
-	s.cluster.OverrideDynamicConfig(s.T(), dynamicconfig.DeleteNamespaceBlockedNamespaces, []string{tv.NamespaceName().String()})
+	s.cluster.OverrideDynamicConfig(s.T(), dynamicconfig.ProtectedNamespaces, []string{tv.NamespaceName().String()})
 
 	delResp, err := s.operatorClient.DeleteNamespace(ctx, &operatorservice.DeleteNamespaceRequest{
 		Namespace: tv.NamespaceName().String(),
@@ -572,5 +572,5 @@ func (s *namespaceTestSuite) Test_NamespaceDelete_Blocked() {
 
 	var invalidArgErr *serviceerror.InvalidArgument
 	s.ErrorAs(err, &invalidArgErr)
-	s.Equal(fmt.Sprintf("namespace %s is blocked from deletion", tv.NamespaceName().String()), invalidArgErr.Message)
+	s.Equal(fmt.Sprintf("namespace %s is protected from deletion", tv.NamespaceName().String()), invalidArgErr.Message)
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Protect critical namespaces from deletion.

## Why?
<!-- Tell your future self why have you made these changes -->
Safety net to prevent deletion of critical namespaces. Use:
```yaml
worker.protectedNamespaces:
  - value:
      - critical_namespace
      - just_very_important_namespace
```
dynamic config to list critical namespaces.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit and functional tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Change in `DeleteNamespace` workflow is not backward compatible (added new local activity), but this is a very short lived workflow (it starts actual deletion in abandon child mode) and shouldn't bring any real problems.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.