### PR TITLE
Do not call back fill events when replication task does not contain any events

### DIFF
--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -570,6 +570,9 @@ func (r *WorkflowStateReplicatorImpl) backFillEvents(
 		}
 		events = append(events, e)
 	}
+	if len(events) == 0 {
+		return nil
+	}
 	var newRunEvents []*historypb.HistoryEvent
 	var newRunID string
 	if newRunInfo != nil {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Do not call back fill events when replication task does not contain any events
## Why?
<!-- Tell your future self why have you made these changes -->
It is causing DLQ
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
n/a
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
n/a
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
yes