### PR TITLE
Change test-runner sanity check to verify no missing test cases

### DIFF
--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -104,9 +104,6 @@ func (a attempt) testCases() map[string]struct{} {
 	cases := make(map[string]struct{})
 
 	for _, suite := range a.suites.Suites {
-		if suite.Failures == 0 {
-			continue
-		}
 		for _, tc := range suite.Testcases {
 			cases[tc.Name] = struct{}{}
 		}


### PR DESCRIPTION
## Why?

The numerical comparison wasn't working as expected.