### PR TITLE
Ensure nexus_workflow_test cases do not hang

### DIFF
--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1467,7 +1467,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 	s.NoError(err)
 
 	canStartCh <- struct{}{}
-	<-cancelSentCh
+	s.WaitForChannel(ctx, cancelSentCh)
 
 	// Terminate the workflow for good measure.
 	err = s.SdkClient().TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "test")


### PR DESCRIPTION
## What changed?

Found and fixed a case where we block on a channel, which may cause a test to hang.