### PR TITLE
Make IsResetRun check backward compatible

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -805,8 +805,14 @@ func (ms *MutableStateImpl) UpdateResetRunID(runID string) {
 
 // IsResetRun returns true if this run is the result of a reset operation.
 // A run is a reset run if OriginalExecutionRunID points to another run.
+//
+// This method only works for workflows started by server version 1.27.0+.
+// Older workflows don't have OriginalExecutionRunID set in mutable state,
+// and this method will NOT try to load WorkflowExecutionStarted event to
+// get that information.
 func (ms *MutableStateImpl) IsResetRun() bool {
-	return ms.GetExecutionInfo().GetOriginalExecutionRunId() != ms.GetExecutionState().GetRunId()
+	originalExecutionRunID := ms.GetExecutionInfo().GetOriginalExecutionRunId()
+	return len(originalExecutionRunID) != 0 && originalExecutionRunID != ms.GetExecutionState().GetRunId()
 }
 
 func (ms *MutableStateImpl) GetBaseWorkflowInfo() *workflowspb.BaseExecutionInfo {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Make IsResetRun check backward compatible by check if mutableState.ExecutionInfo.OriginalRunID is empty

## Why?
<!-- Tell your future self why have you made these changes -->
- OriginalRunID is a new field in mutable state and if empty can't be used to tell if workflow is a reset run or not.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
