### PR TITLE
Delete Namespace: move Nexus endpoint validation to workflow

### DIFF
--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -203,8 +203,6 @@ type Config struct {
 	// EnableNexusAPIs controls whether to allow invoking Nexus related APIs.
 	EnableNexusAPIs dynamicconfig.BoolPropertyFn
 
-	AllowDeleteNamespaceIfNexusEndpointTarget dynamicconfig.BoolPropertyFn
-
 	CallbackURLMaxLength    dynamicconfig.IntPropertyFnWithNamespaceFilter
 	CallbackHeaderMaxSize   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxCallbacksPerWorkflow dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -334,11 +332,10 @@ func NewConfig(
 		EnableWorkerVersioningWorkflow: dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs.Get(dc),
 		EnableWorkerVersioningRules:    dynamicconfig.FrontendEnableWorkerVersioningRuleAPIs.Get(dc),
 
-		EnableNexusAPIs: dynamicconfig.EnableNexus.Get(dc),
-		AllowDeleteNamespaceIfNexusEndpointTarget: dynamicconfig.AllowDeleteNamespaceIfNexusEndpointTarget.Get(dc),
-		CallbackURLMaxLength:                      dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
-		CallbackHeaderMaxSize:                     dynamicconfig.FrontendCallbackHeaderMaxSize.Get(dc),
-		MaxCallbacksPerWorkflow:                   dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
+		EnableNexusAPIs:         dynamicconfig.EnableNexus.Get(dc),
+		CallbackURLMaxLength:    dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
+		CallbackHeaderMaxSize:   dynamicconfig.FrontendCallbackHeaderMaxSize.Get(dc),
+		MaxCallbacksPerWorkflow: dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
 
 		NexusRequestHeadersBlacklist: dynamicconfig.NewGlobalCachedTypedValue(
 			dc,

--- a/service/worker/deletenamespace/activities_test.go
+++ b/service/worker/deletenamespace/activities_test.go
@@ -26,10 +26,13 @@ package deletenamespace
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/sdk/temporal"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
@@ -42,7 +45,7 @@ func Test_GenerateDeletedNamespaceNameActivity(t *testing.T) {
 
 	a := &localActivities{
 		metadataManager: metadataManager,
-		logger:          log.NewNoopLogger(),
+		logger:          log.NewTestLogger(),
 	}
 
 	metadataManager.EXPECT().GetNamespace(gomock.Any(), &persistence.GetNamespaceRequest{
@@ -65,6 +68,53 @@ func Test_GenerateDeletedNamespaceNameActivity(t *testing.T) {
 	deletedName, err = a.GenerateDeletedNamespaceNameActivity(context.Background(), "namespace-id", "namespace")
 	require.NoError(t, err)
 	require.Equal(t, namespace.Name("namespace-deleted-namesp"), deletedName)
+
+	ctrl.Finish()
+}
+func Test_ValidateNexusEndpointsActivity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	nexusEndpointManager := persistence.NewMockNexusEndpointManager(ctrl)
+
+	a := &localActivities{
+		nexusEndpointManager: nexusEndpointManager,
+		logger:               log.NewTestLogger(),
+
+		allowDeleteNamespaceIfNexusEndpointTarget: func() bool { return false },
+		nexusEndpointListDefaultPageSize:          func() int { return 100 },
+	}
+
+	// The "fake" namespace ID is associated with a Nexus endoint.
+	nexusEndpointManager.EXPECT().ListNexusEndpoints(gomock.Any(), gomock.Any()).Return(&persistence.ListNexusEndpointsResponse{
+		Entries: []*persistencespb.NexusEndpointEntry{
+			{
+				Endpoint: &persistencespb.NexusEndpoint{
+					Spec: &persistencespb.NexusEndpointSpec{
+						Name: "test-endpoint",
+						Target: &persistencespb.NexusEndpointTarget{
+							Variant: &persistencespb.NexusEndpointTarget_Worker_{
+								Worker: &persistencespb.NexusEndpointTarget_Worker{
+									NamespaceId: "namespace-id",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil).Times(2)
+
+	err := a.ValidateNexusEndpointsActivity(context.Background(), "namespace-id", "namespace")
+	require.Error(t, err)
+	var appErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &appErr)
+
+	err = a.ValidateNexusEndpointsActivity(context.Background(), "namespace2-id", "namespace2")
+	require.NoError(t, err)
+
+	nexusEndpointManager.EXPECT().ListNexusEndpoints(gomock.Any(), gomock.Any()).Return(nil, errors.New("persistence failure"))
+	err = a.ValidateNexusEndpointsActivity(context.Background(), "namespace-id", "namespace")
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "unable to list Nexus endpoints for namespace namespace: persistence failure")
 
 	ctrl.Finish()
 }

--- a/service/worker/deletenamespace/fx.go
+++ b/service/worker/deletenamespace/fx.go
@@ -46,22 +46,27 @@ import (
 type (
 	// deleteNamespaceComponent represent background work needed for delete namespace.
 	deleteNamespaceComponent struct {
-		atWorkerCfg         sdkworker.Options
-		visibilityManager   manager.VisibilityManager
-		metadataManager     persistence.MetadataManager
-		historyClient       resource.HistoryClient
-		metricsHandler      metrics.Handler
-		protectedNamespaces dynamicconfig.TypedPropertyFn[[]string]
-		logger              log.Logger
+		atWorkerCfg          sdkworker.Options
+		visibilityManager    manager.VisibilityManager
+		metadataManager      persistence.MetadataManager
+		nexusEndpointManager persistence.NexusEndpointManager
+		historyClient        resource.HistoryClient
+		metricsHandler       metrics.Handler
+		logger               log.Logger
+
+		protectedNamespaces                       dynamicconfig.TypedPropertyFn[[]string]
+		allowDeleteNamespaceIfNexusEndpointTarget dynamicconfig.BoolPropertyFn
+		nexusEndpointListDefaultPageSize          dynamicconfig.IntPropertyFn
 	}
 	componentParams struct {
 		fx.In
-		DynamicCollection *dynamicconfig.Collection
-		VisibilityManager manager.VisibilityManager
-		MetadataManager   persistence.MetadataManager
-		HistoryClient     resource.HistoryClient
-		MetricsHandler    metrics.Handler
-		Logger            log.Logger
+		DynamicCollection    *dynamicconfig.Collection
+		VisibilityManager    manager.VisibilityManager
+		MetadataManager      persistence.MetadataManager
+		NexusEndpointManager persistence.NexusEndpointManager
+		HistoryClient        resource.HistoryClient
+		MetricsHandler       metrics.Handler
+		Logger               log.Logger
 	}
 )
 
@@ -71,13 +76,16 @@ func newComponent(
 	params componentParams,
 ) workercommon.WorkerComponent {
 	return &deleteNamespaceComponent{
-		atWorkerCfg:         dynamicconfig.WorkerDeleteNamespaceActivityLimits.Get(params.DynamicCollection)(),
-		visibilityManager:   params.VisibilityManager,
-		metadataManager:     params.MetadataManager,
-		historyClient:       params.HistoryClient,
-		metricsHandler:      params.MetricsHandler,
-		protectedNamespaces: dynamicconfig.ProtectedNamespaces.Get(params.DynamicCollection),
-		logger:              params.Logger,
+		atWorkerCfg:          dynamicconfig.WorkerDeleteNamespaceActivityLimits.Get(params.DynamicCollection)(),
+		visibilityManager:    params.VisibilityManager,
+		metadataManager:      params.MetadataManager,
+		nexusEndpointManager: params.NexusEndpointManager,
+		historyClient:        params.HistoryClient,
+		metricsHandler:       params.MetricsHandler,
+		logger:               params.Logger,
+		protectedNamespaces:  dynamicconfig.ProtectedNamespaces.Get(params.DynamicCollection),
+		allowDeleteNamespaceIfNexusEndpointTarget: dynamicconfig.AllowDeleteNamespaceIfNexusEndpointTarget.Get(params.DynamicCollection),
+		nexusEndpointListDefaultPageSize:          dynamicconfig.NexusEndpointListDefaultPageSize.Get(params.DynamicCollection),
 	}
 }
 
@@ -116,7 +124,13 @@ func (wc *deleteNamespaceComponent) DedicatedActivityWorkerOptions() *workercomm
 }
 
 func (wc *deleteNamespaceComponent) deleteNamespaceLocalActivities() *localActivities {
-	return newLocalActivities(wc.metadataManager, wc.protectedNamespaces, wc.logger)
+	return newLocalActivities(
+		wc.metadataManager,
+		wc.nexusEndpointManager,
+		wc.logger,
+		wc.protectedNamespaces,
+		wc.allowDeleteNamespaceIfNexusEndpointTarget,
+		wc.nexusEndpointListDefaultPageSize)
 }
 
 func (wc *deleteNamespaceComponent) reclaimResourcesActivities() *reclaimresources.Activities {

--- a/service/worker/deletenamespace/reclaimresources/activities_test.go
+++ b/service/worker/deletenamespace/reclaimresources/activities_test.go
@@ -54,7 +54,7 @@ func Test_EnsureNoExecutionsAdvVisibilityActivity_NoExecutions(t *testing.T) {
 	a := &Activities{
 		visibilityManager: visibilityManager,
 		metricsHandler:    metrics.NoopMetricsHandler,
-		logger:            log.NewNoopLogger(),
+		logger:            log.NewTestLogger(),
 	}
 
 	err := a.EnsureNoExecutionsAdvVisibilityActivity(context.Background(), "namespace-id", "namespace", 0)
@@ -79,7 +79,7 @@ func Test_EnsureNoExecutionsAdvVisibilityActivity_ExecutionsExist(t *testing.T) 
 	a := &Activities{
 		visibilityManager: visibilityManager,
 		metricsHandler:    metrics.NoopMetricsHandler,
-		logger:            log.NewNoopLogger(),
+		logger:            log.NewTestLogger(),
 	}
 	env.RegisterActivity(a.EnsureNoExecutionsAdvVisibilityActivity)
 
@@ -108,7 +108,7 @@ func Test_EnsureNoExecutionsAdvVisibilityActivity_NotDeletedExecutionsExist(t *t
 	a := &Activities{
 		visibilityManager: visibilityManager,
 		metricsHandler:    metrics.NoopMetricsHandler,
-		logger:            log.NewNoopLogger(),
+		logger:            log.NewTestLogger(),
 	}
 	env.RegisterActivity(a.EnsureNoExecutionsAdvVisibilityActivity)
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Delete Namespace: move Nexus endpoint validation to workflow.

## Why?
<!-- Tell your future self why have you made these changes -->
Consolidate all delete namespace validation logic in one place.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Modified existing and new unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
This is a breaking change for `DeleteNamespace` workflow. But this workflow is very short lived and chances of being upgraded while running are very low.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.