### PR TITLE
Delete Namespace: clean up errors

### DIFF
--- a/service/worker/deletenamespace/activities.go
+++ b/service/worker/deletenamespace/activities.go
@@ -26,13 +26,13 @@ package deletenamespace
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"slices"
 	"strings"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
@@ -88,11 +88,19 @@ func (a *localActivities) GetNamespaceInfoActivity(ctx context.Context, nsID nam
 
 	getNamespaceResponse, err := a.metadataManager.GetNamespace(ctx, getNamespaceRequest)
 	if err != nil {
+		var nsNotFoundErr *serviceerror.NamespaceNotFound
+		if stderrors.As(err, &nsNotFoundErr) {
+			ns := nsName.String()
+			if ns == "" {
+				ns = nsID.String()
+			}
+			return getNamespaceInfoResult{}, errors.NewInvalidArgument(fmt.Sprintf("namespace %s is not found", ns), err)
+		}
 		return getNamespaceInfoResult{}, err
 	}
 
 	if getNamespaceResponse.Namespace == nil || getNamespaceResponse.Namespace.Info == nil || getNamespaceResponse.Namespace.Info.Id == "" {
-		return getNamespaceInfoResult{}, temporal.NewNonRetryableApplicationError("namespace info is corrupted", "", nil)
+		return getNamespaceInfoResult{}, stderrors.New("namespace info is corrupted")
 	}
 
 	return getNamespaceInfoResult{
@@ -104,35 +112,36 @@ func (a *localActivities) GetNamespaceInfoActivity(ctx context.Context, nsID nam
 
 func (a *localActivities) ValidateProtectedNamespacesActivity(_ context.Context, nsName namespace.Name) error {
 	if slices.Contains(a.protectedNamespaces(), nsName.String()) {
-		return temporal.NewNonRetryableApplicationError(fmt.Sprintf("namespace %s is protected from deletion", nsName), errors.ValidationErrorErrType, nil, nil)
+		return errors.NewFailedPrecondition(fmt.Sprintf("namespace %s is protected from deletion", nsName), nil)
 	}
 	return nil
 }
 
 func (a *localActivities) ValidateNexusEndpointsActivity(ctx context.Context, nsID namespace.ID, nsName namespace.Name) error {
-	if !a.allowDeleteNamespaceIfNexusEndpointTarget() {
-		// Prevent deletion of a namespace that is targeted by a Nexus endpoint.
-		var nextPageToken []byte
-		for {
-			resp, err := a.nexusEndpointManager.ListNexusEndpoints(ctx, &persistence.ListNexusEndpointsRequest{
-				LastKnownTableVersion: 0,
-				NextPageToken:         nextPageToken,
-				PageSize:              a.nexusEndpointListDefaultPageSize(),
-			})
-			if err != nil {
-				a.logger.Error("Unable to list Nexus endpoints from persistence.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
-				return fmt.Errorf("unable to list Nexus endpoints for namespace %s: %w", nsName, err)
-			}
+	if a.allowDeleteNamespaceIfNexusEndpointTarget() {
+		return nil
+	}
+	// Prevent deletion of a namespace that is targeted by a Nexus endpoint.
+	var nextPageToken []byte
+	for {
+		resp, err := a.nexusEndpointManager.ListNexusEndpoints(ctx, &persistence.ListNexusEndpointsRequest{
+			LastKnownTableVersion: 0,
+			NextPageToken:         nextPageToken,
+			PageSize:              a.nexusEndpointListDefaultPageSize(),
+		})
+		if err != nil {
+			a.logger.Error("Unable to list Nexus endpoints from persistence.", tag.WorkflowNamespace(nsName.String()), tag.WorkflowNamespaceID(nsID.String()), tag.Error(err))
+			return fmt.Errorf("unable to list Nexus endpoints for namespace %s: %w", nsName, err)
+		}
 
-			for _, entry := range resp.Entries {
-				if endpointNsID := entry.GetEndpoint().GetSpec().GetTarget().GetWorker().GetNamespaceId(); endpointNsID == nsID.String() {
-					return temporal.NewNonRetryableApplicationError(fmt.Sprintf("cannot delete a namespace that is a target of a Nexus endpoint %s", entry.GetEndpoint().GetSpec().GetName()), errors.ValidationErrorErrType, nil, nil)
-				}
+		for _, entry := range resp.Entries {
+			if endpointNsID := entry.GetEndpoint().GetSpec().GetTarget().GetWorker().GetNamespaceId(); endpointNsID == nsID.String() {
+				return errors.NewFailedPrecondition(fmt.Sprintf("cannot delete a namespace that is a target of a Nexus endpoint %s", entry.GetEndpoint().GetSpec().GetName()), nil)
 			}
-			nextPageToken = resp.NextPageToken
-			if len(nextPageToken) == 0 {
-				break
-			}
+		}
+		nextPageToken = resp.NextPageToken
+		if len(nextPageToken) == 0 {
+			break
 		}
 	}
 	return nil
@@ -201,11 +210,12 @@ func (a *localActivities) GenerateDeletedNamespaceNameActivity(ctx context.Conte
 			return namespace.Name(newName), nil
 		default:
 			logger.Error("Unable to get namespace details.", tag.Error(err))
-			return namespace.EmptyName, err
+			return namespace.EmptyName, fmt.Errorf("unable to get namespace details: %w", err)
 		}
 	}
 	// Should never get here because namespace ID is guaranteed to be unique.
-	panic(fmt.Sprintf("Unable to generate new name for deleted namespace %s. ID %q is not unique.", nsName, nsID))
+	return namespace.EmptyName, fmt.Errorf("unable to generate new name for deleted namespace %s. ID %q is not unique", nsName, nsID)
+
 }
 
 func (a *localActivities) RenameNamespaceActivity(ctx context.Context, previousName namespace.Name, newName namespace.Name) error {

--- a/service/worker/deletenamespace/deleteexecutions/activities.go
+++ b/service/worker/deletenamespace/deleteexecutions/activities.go
@@ -117,7 +117,7 @@ func (a *LocalActivities) GetNextPageTokenActivity(ctx context.Context, params G
 
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {
-		a.logger.Error("Unable to list all workflows to get next page token.", tag.WorkflowNamespace(params.Namespace.String()), tag.Error(err))
+		a.logger.Error("Unable to list all workflows to get next page token.", tag.WorkflowNamespace(params.Namespace.String()), tag.WorkflowNamespaceID(params.NamespaceID.String()), tag.Error(err))
 		return nil, err
 	}
 

--- a/service/worker/deletenamespace/deleteexecutions/workflow_test.go
+++ b/service/worker/deletenamespace/deleteexecutions/workflow_test.go
@@ -255,8 +255,7 @@ func Test_DeleteExecutionsWorkflow_ManyExecutions_ActivityError(t *testing.T) {
 	require.Error(t, err)
 	var appErr *temporal.ApplicationError
 	require.True(t, stderrors.As(err, &appErr))
-	require.Contains(t, appErr.Error(), "unable to execute activity: DeleteExecutionsActivity")
-	require.Contains(t, appErr.Error(), "specific_error_from_activity")
+	require.Equal(t, appErr.Error(), "specific_error_from_activity (type: Unavailable, retryable: true)")
 }
 
 func Test_DeleteExecutionsWorkflow_NoActivityMocks_ManyExecutions(t *testing.T) {

--- a/service/worker/deletenamespace/errors/errors.go
+++ b/service/worker/deletenamespace/errors/errors.go
@@ -28,30 +28,51 @@ import (
 	"errors"
 	"fmt"
 
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/temporal"
 )
 
 const (
-	ValidationErrorErrType                = "ValidationError"
+	InvalidArgumentErrType                = "InvalidArgument"
+	FailedPreconditionErrType             = "FailedPrecondition"
 	ExecutionsStillExistErrType           = "ExecutionsStillExist"
 	NoProgressErrType                     = "NoProgress"
 	NotDeletedExecutionsStillExistErrType = "NotDeletedExecutionsStillExist"
 )
 
-var (
-	ErrUnableToExecuteActivity      = errors.New("unable to execute activity")
-	ErrUnableToExecuteChildWorkflow = errors.New("unable to execute child workflow")
-	ErrUnableToSetUpdateHandler     = errors.New("unable to set Update handler")
-)
+func NewInvalidArgument(message string, cause error) error {
+	return temporal.NewNonRetryableApplicationError(message, InvalidArgumentErrType, cause, nil)
+}
 
-func NewExecutionsStillExistError(count int) error {
+func NewFailedPrecondition(message string, cause error) error {
+	return temporal.NewNonRetryableApplicationError(message, FailedPreconditionErrType, cause, nil)
+}
+
+func NewExecutionsStillExist(count int) error {
 	return temporal.NewApplicationError(fmt.Sprintf("%d executions are still exist", count), ExecutionsStillExistErrType, count)
 }
 
-func NewNoProgressError(count int) error {
+func NewNoProgress(count int) error {
 	return temporal.NewNonRetryableApplicationError(fmt.Sprintf("no progress was made: %d executions are still exist", count), NoProgressErrType, nil, count)
 }
 
-func NewNotDeletedExecutionsStillExistError(count int) error {
+func NewNotDeletedExecutionsStillExist(count int) error {
 	return temporal.NewNonRetryableApplicationError(fmt.Sprintf("%d not deleted executions are still exist", count), NotDeletedExecutionsStillExistErrType, nil, count)
+}
+
+func ToServiceError(err error, workflowID, runID string) error {
+	var appErr *temporal.ApplicationError
+	if errors.As(err, &appErr) {
+		switch appErr.Type() {
+		case InvalidArgumentErrType:
+			return serviceerror.NewInvalidArgument(appErr.Message())
+		case FailedPreconditionErrType:
+			return serviceerror.NewFailedPrecondition(appErr.Message())
+		}
+	}
+	return serviceerror.NewSystemWorkflow(
+		&commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: runID},
+		err,
+	)
 }

--- a/service/worker/deletenamespace/reclaimresources/activities.go
+++ b/service/worker/deletenamespace/reclaimresources/activities.go
@@ -138,18 +138,18 @@ func (a *Activities) EnsureNoExecutionsAdvVisibilityActivity(ctx context.Context
 				// No progress was made. Something bad happened on the task processor side or new executions were created during deletion.
 				// Return non-retryable error and workflow will try to delete executions again.
 				logger.Warn("No progress was made.", tag.Attempt(activityInfo.Attempt), tag.Counter(count))
-				return errors.NewNoProgressError(count)
+				return errors.NewNoProgress(count)
 			}
 		}
 
 		logger.Warn("Some workflow executions still exist.", tag.Counter(count))
 		activity.RecordHeartbeat(ctx, count)
-		return errors.NewExecutionsStillExistError(count)
+		return errors.NewExecutionsStillExist(count)
 	}
 
 	if notDeletedCount > 0 {
 		logger.Warn("Some workflow executions were not deleted and still exist.", tag.Counter(notDeletedCount))
-		return errors.NewNotDeletedExecutionsStillExistError(notDeletedCount)
+		return errors.NewNotDeletedExecutionsStillExist(notDeletedCount)
 	}
 
 	logger.Info("All workflow executions are deleted successfully.")

--- a/service/worker/deletenamespace/reclaimresources/workflow_test.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow_test.go
@@ -138,8 +138,9 @@ func Test_ReclaimResourcesWorkflow_EnsureNoExecutionsActivity_Error(t *testing.T
 	require.True(t, env.IsWorkflowCompleted())
 	err := env.GetWorkflowError()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "unable to execute activity: EnsureNoExecutionsActivity")
-	require.Contains(t, err.Error(), "specific_error_from_activity")
+	require.Equal(t,
+		err.Error(),
+		"workflow execution error (type: ReclaimResourcesWorkflow, workflowID: default-test-workflow-id, runID: default-test-run-id): activity error (type: EnsureNoExecutionsAdvVisibilityActivity, scheduledEventID: 0, startedEventID: 0, identity: ): specific_error_from_activity")
 }
 
 func Test_ReclaimResourcesWorkflow_EnsureNoExecutionsActivity_ExecutionsStillExist(t *testing.T) {
@@ -169,7 +170,7 @@ func Test_ReclaimResourcesWorkflow_EnsureNoExecutionsActivity_ExecutionsStillExi
 
 	env.OnActivity(la.CountExecutionsAdvVisibilityActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace")).Return(int64(10), nil).Once()
 	env.OnActivity(a.EnsureNoExecutionsAdvVisibilityActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace"), 0).
-		Return(errors.NewExecutionsStillExistError(1)).
+		Return(errors.NewExecutionsStillExist(1)).
 		Times(10) // GoSDK defaultMaximumAttemptsForUnitTest value.
 
 	env.ExecuteWorkflow(ReclaimResourcesWorkflow, ReclaimResourcesParams{

--- a/service/worker/deletenamespace/workflow_test.go
+++ b/service/worker/deletenamespace/workflow_test.go
@@ -231,7 +231,7 @@ func Test_DeleteNamespaceUsedByNexus(t *testing.T) {
 		}, nil).Once()
 	env.OnActivity(la.ValidateProtectedNamespacesActivity, mock.Anything, mock.Anything).Return(nil).Once()
 	env.OnActivity(la.ValidateNexusEndpointsActivity, mock.Anything, mock.Anything, mock.Anything).
-		Return(temporal.NewNonRetryableApplicationError("cannot delete a namespace that is a target of a Nexus endpoint", errors.ValidationErrorErrType, nil, nil)).
+		Return(errors.NewFailedPrecondition("cannot delete a namespace that is a target of a Nexus endpoint", nil)).
 		Once()
 
 	env.ExecuteWorkflow(DeleteNamespaceWorkflow, DeleteNamespaceWorkflowParams{

--- a/tests/namespace_delete_test.go
+++ b/tests/namespace_delete_test.go
@@ -570,7 +570,7 @@ func (s *namespaceTestSuite) Test_NamespaceDelete_Protected() {
 	s.Error(err)
 	s.Nil(delResp)
 
-	var invalidArgErr *serviceerror.InvalidArgument
-	s.ErrorAs(err, &invalidArgErr)
-	s.Equal(fmt.Sprintf("namespace %s is protected from deletion", tv.NamespaceName().String()), invalidArgErr.Message)
+	var failedPreconditionErr *serviceerror.FailedPrecondition
+	s.ErrorAs(err, &failedPreconditionErr)
+	s.Equal(fmt.Sprintf("namespace %s is protected from deletion", tv.NamespaceName().String()), failedPreconditionErr.Message)
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Clean up errors in delete namespace workflows:
1. Use `FailedPrecondition` instead of `InvalidArgument` where it makes more sense.
2. Add helpers to construct `ApplicationError`s of different type.
3. Remove `unable to execute activity` error which was wrongly used in many places.
4. Few minor cleanups.

## Why?
<!-- Tell your future self why have you made these changes -->
Simplify and unify error handling in delete namespace workflows.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Modified tests. Manual runs.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.