### PR TITLE
Update ServerVersion to next minor

### DIFF
--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -49,7 +49,7 @@ const (
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
-	ServerVersion = "1.26.0"
+	ServerVersion = "1.27.0"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"


### PR DESCRIPTION
Part of the release process now that `v1.26.2` is out.