### PR TITLE
Separate some interfaces from implementation

### DIFF
--- a/components/callbacks/executors.go
+++ b/components/callbacks/executors.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/resource"
+	components "go.temporal.io/server/components/common"
 	"go.temporal.io/server/service/history/hsm"
 	"go.temporal.io/server/service/history/queues"
 	"go.uber.org/fx"
@@ -160,7 +161,7 @@ func (e taskExecutor) loadInvocationArgs(
 
 		switch variant := callback.GetCallback().GetVariant().(type) {
 		case *persistencespb.Callback_Nexus_:
-			target, err := hsm.MachineData[CanGetNexusCompletion](node.Parent)
+			target, err := hsm.MachineData[components.CanGetNexusCompletion](node.Parent)
 			if err != nil {
 				return err
 			}
@@ -173,7 +174,7 @@ func (e taskExecutor) loadInvocationArgs(
 				return err
 			}
 		case *persistencespb.Callback_Hsm:
-			target, err := hsm.MachineData[CanGetHSMCompletionCallbackArg](node.Parent)
+			target, err := hsm.MachineData[components.CanGetHSMCompletionCallbackArg](node.Parent)
 			if err != nil {
 				return err
 			}

--- a/components/callbacks/hsm_invocation.go
+++ b/components/callbacks/hsm_invocation.go
@@ -36,10 +36,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type CanGetHSMCompletionCallbackArg interface {
-	GetHSMCompletionCallbackArg(ctx context.Context) (*persistencespb.HSMCompletionCallbackArg, error)
-}
-
 type hsmInvocation struct {
 	hsm         *persistencespb.Callback_HSM
 	callbackArg *persistencespb.HSMCompletionCallbackArg

--- a/components/callbacks/nexus_invocation.go
+++ b/components/callbacks/nexus_invocation.go
@@ -43,10 +43,6 @@ var retryable4xxErrorTypes = []int{
 	http.StatusTooManyRequests,
 }
 
-type CanGetNexusCompletion interface {
-	GetNexusCompletion(ctx context.Context) (nexus.OperationCompletion, error)
-}
-
 type nexusInvocation struct {
 	nexus      *persistencespb.Callback_Nexus
 	completion nexus.OperationCompletion

--- a/components/common/hsm_completion_callback.go
+++ b/components/common/hsm_completion_callback.go
@@ -1,0 +1,33 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package common
+
+import (
+	"context"
+
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+)
+
+type CanGetHSMCompletionCallbackArg interface {
+	GetHSMCompletionCallbackArg(ctx context.Context) (*persistencespb.HSMCompletionCallbackArg, error)
+}

--- a/components/common/nexus_completion.go
+++ b/components/common/nexus_completion.go
@@ -1,0 +1,33 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package common
+
+import (
+	"context"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+)
+
+type CanGetNexusCompletion interface {
+	GetNexusCompletion(ctx context.Context) (nexus.OperationCompletion, error)
+}

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -51,7 +51,7 @@ import (
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/components/callbacks"
+	components "go.temporal.io/server/components/common"
 	"go.temporal.io/server/service/history/historybuilder"
 	"go.temporal.io/server/service/history/hsm"
 	"go.temporal.io/server/service/history/tasks"
@@ -151,8 +151,8 @@ type (
 	ActivityUpdater func(*persistencespb.ActivityInfo, MutableState) error
 
 	MutableState interface {
-		callbacks.CanGetNexusCompletion
-		callbacks.CanGetHSMCompletionCallbackArg
+		components.CanGetNexusCompletion
+		components.CanGetHSMCompletionCallbackArg
 		AddHistoryEvent(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent
 		LoadHistoryEvent(ctx context.Context, token []byte) (*historypb.HistoryEvent, error)
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Extract interface definitions into separate sub-module.

## Why?
<!-- Tell your future self why have you made these changes -->
Part of _very_ long (not even sure if I will not give up) chain of refactoring efforts to improve overall design.
MutableState extends those interfaces. But they are defined alongside implementations, and some other structures.
As the result this introduce long chains of dependencies for MutableState, not needed by MutableState itself.
Eventually this leads to some unwanted "cycling dependencies" along the path to refactoring.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Unit tests