### PR TITLE
Adding namespace handover test case for history executable

### DIFF
--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -795,6 +795,10 @@ func (s *executableSuite) TestTaskNack_Reschedule() {
 			name:    "ErrDeleteOpenExecErr",
 			taskErr: consts.ErrDependencyTaskNotCompleted, // this error won't trigger re-submit
 		},
+		{
+			name:    "ErrNamespaceHandOver",
+			taskErr: consts.ErrNamespaceHandOver, // this error won't trigger re-submit
+		},
 	}
 
 	for _, tc := range testCases {

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -797,7 +797,7 @@ func (s *executableSuite) TestTaskNack_Reschedule() {
 		},
 		{
 			name:    "ErrNamespaceHandOver",
-			taskErr: consts.ErrNamespaceHandOver, // this error won't trigger re-submit
+			taskErr: consts.ErrNamespaceHandover, // this error won't trigger re-submit
 		},
 	}
 


### PR DESCRIPTION
Adding namespace handover test case for queues.*executableImpl.shouldResubmitOnNack

## What changed?
<!-- Describe what has changed in this PR -->
- Added namespace handover test case for queues.*executableImpl.shouldResubmitOnNack

## Why?
<!-- Tell your future self why have you made these changes -->
- Better coverage.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run unit test locally

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
