### PR TITLE
Change Nexus HandlerError rehydration to use ApplicationFailure

### DIFF
--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -753,7 +753,7 @@ func callErrToFailure(callErr error, retryable bool) (*failurepb.Failure, error)
 					NonRetryable: !retryable,
 				},
 			},
-			// TODO: Replace with the above FailureInfo once there are more SDKs that support NexusHandlerFailureInfo in
+			// TODO: Replace with the FailureInfo below once there are more SDKs that support NexusHandlerFailureInfo in
 			// the wild.
 			// FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
 			// 	NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -747,12 +747,21 @@ func callErrToFailure(callErr error, retryable bool) (*failurepb.Failure, error)
 	if errors.As(callErr, &handlerErr) {
 		failure := &failurepb.Failure{
 			Message: handlerErr.Error(),
-			FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
-				NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
-					Type: string(handlerErr.Type),
+			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+					Type:         "NexusHandlerError",
+					NonRetryable: !retryable,
 				},
 			},
+			// TODO: Replace with the above FailureInfo once there are more SDKs that support NexusHandlerFailureInfo in
+			// the wild.
+			// FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+			// 	NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+			// 		Type: string(handlerErr.Type),
+			// 	},
+			// },
 		}
+
 		var failureError *nexus.FailureError
 		if errors.As(handlerErr.Cause, &failureError) {
 			var err error

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -308,7 +308,7 @@ func TestProcessInvocationTask(t *testing.T) {
 			expectedMetricOutcome: "handler-error:INTERNAL",
 			checkOutcome: func(t *testing.T, op nexusoperations.Operation, events []*historypb.HistoryEvent) {
 				require.Equal(t, enumsspb.NEXUS_OPERATION_STATE_BACKING_OFF, op.State())
-				require.NotNil(t, op.LastAttemptFailure.GetNexusHandlerFailureInfo())
+				require.NotNil(t, op.LastAttemptFailure.GetApplicationFailureInfo())
 				require.Equal(t, "handler error (INTERNAL): internal server error", op.LastAttemptFailure.Message)
 				require.Equal(t, 0, len(events))
 			},
@@ -638,7 +638,7 @@ func TestProcessCancelationTask(t *testing.T) {
 			expectedMetricOutcome: "handler-error:NOT_FOUND",
 			checkOutcome: func(t *testing.T, c nexusoperations.Cancelation) {
 				require.Equal(t, enumspb.NEXUS_OPERATION_CANCELLATION_STATE_FAILED, c.State())
-				require.NotNil(t, c.LastAttemptFailure.GetNexusHandlerFailureInfo())
+				require.NotNil(t, c.LastAttemptFailure.GetApplicationFailureInfo())
 				require.Equal(t, "handler error (NOT_FOUND): operation not found", c.LastAttemptFailure.Message)
 			},
 		},
@@ -665,7 +665,7 @@ func TestProcessCancelationTask(t *testing.T) {
 			expectedMetricOutcome: "handler-error:INTERNAL",
 			checkOutcome: func(t *testing.T, c nexusoperations.Cancelation) {
 				require.Equal(t, enumspb.NEXUS_OPERATION_CANCELLATION_STATE_BACKING_OFF, c.State())
-				require.NotNil(t, c.LastAttemptFailure.GetNexusHandlerFailureInfo())
+				require.NotNil(t, c.LastAttemptFailure.GetApplicationFailureInfo())
 				require.Equal(t, "handler error (INTERNAL): internal server error", c.LastAttemptFailure.Message)
 			},
 		},
@@ -705,7 +705,7 @@ func TestProcessCancelationTask(t *testing.T) {
 			onCancelOperation: nil, // This should not be called if the endpoint is not found.
 			checkOutcome: func(t *testing.T, c nexusoperations.Cancelation) {
 				require.Equal(t, enumspb.NEXUS_OPERATION_CANCELLATION_STATE_FAILED, c.State())
-				require.NotNil(t, c.LastAttemptFailure.GetNexusHandlerFailureInfo())
+				require.NotNil(t, c.LastAttemptFailure.GetApplicationFailureInfo())
 				require.Equal(t, "handler error (NOT_FOUND): endpoint not registered", c.LastAttemptFailure.Message)
 			},
 		},

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1796,22 +1796,20 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 		{
 			outcome: "fail-handler-internal",
 			checkPendingError: func(t *testing.T, pendingErr error) {
-				var handlerErr *nexus.HandlerError
-				require.ErrorAs(t, pendingErr, &handlerErr)
-				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
 				var appErr *temporal.ApplicationError
-				require.ErrorAs(t, handlerErr.Cause, &appErr)
+				require.ErrorAs(t, pendingErr, &appErr)
+				require.Equal(t, "handler error (INTERNAL): intentional internal error", appErr.Message())
+				require.ErrorAs(t, appErr.Unwrap(), &appErr)
 				require.Equal(t, "intentional internal error", appErr.Message())
 			},
 		},
 		{
 			outcome: "fail-handler-app-error",
 			checkPendingError: func(t *testing.T, pendingErr error) {
-				var handlerErr *nexus.HandlerError
-				require.ErrorAs(t, pendingErr, &handlerErr)
-				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
 				var appErr *temporal.ApplicationError
-				require.ErrorAs(t, handlerErr.Cause, &appErr)
+				require.ErrorAs(t, pendingErr, &appErr)
+				require.Equal(t, "handler error (INTERNAL): app error", appErr.Message())
+				require.ErrorAs(t, appErr.Unwrap(), &appErr)
 				require.Equal(t, "app error", appErr.Message())
 				require.Equal(t, "TestError", appErr.Type())
 				var details string
@@ -1824,11 +1822,10 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 			checkWorkflowError: func(t *testing.T, wfErr error) {
 				var opErr *temporal.NexusOperationError
 				require.ErrorAs(t, wfErr, &opErr)
-				var handlerErr *nexus.HandlerError
-				require.ErrorAs(t, opErr, &handlerErr)
-				require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
 				var appErr *temporal.ApplicationError
-				require.ErrorAs(t, handlerErr.Cause, &appErr)
+				require.ErrorAs(t, opErr, &appErr)
+				require.Equal(t, "handler error (BAD_REQUEST): bad request", appErr.Message())
+				require.ErrorAs(t, appErr.Unwrap(), &appErr)
 				require.Equal(t, "bad request", appErr.Message())
 
 			},
@@ -2104,12 +2101,11 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure() {
 	}, callerWF)
 	s.NoError(err)
 
-	var handlerErr *nexus.HandlerError
-	s.ErrorAs(run.Get(ctx, nil), &handlerErr)
-	s.Equal(nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
 	var appErr *temporal.ApplicationError
-	s.ErrorAs(handlerErr.Cause, &appErr)
-	s.Equal(appErr.Message(), "fail me")
+	s.ErrorAs(run.Get(ctx, nil), &appErr)
+	s.Equal("handler error (BAD_REQUEST): fail me", appErr.Message())
+	s.ErrorAs(appErr.Unwrap(), &appErr)
+	s.Equal("fail me", appErr.Message())
 	var failure nexus.Failure
 	s.NoError(appErr.Details(&failure))
 	s.Equal(map[string]string{"key": "val"}, failure.Metadata)


### PR DESCRIPTION
## Why?

HandlerError rehydration requires the latest Go SDK and isn't yet supported in Java, this change prevents breaking existing SDK users.

## How did you test it?

Modified existing tests.