### PR TITLE
fix inconsistent label cardinality error

### DIFF
--- a/service/history/replication/task_executor.go
+++ b/service/history/replication/task_executor.go
@@ -141,6 +141,7 @@ func (e *taskExecutorImpl) handleActivityTask(
 		metrics.ServiceLatency.With(e.metricsHandler).Record(
 			time.Since(startTime),
 			metrics.OperationTag(metrics.SyncActivityTaskScope),
+			metrics.NamespaceTag(attr.GetNamespaceId()),
 		)
 	}()
 
@@ -238,6 +239,7 @@ func (e *taskExecutorImpl) handleHistoryReplicationTask(
 		metrics.ServiceLatency.With(e.metricsHandler).Record(
 			time.Since(startTime),
 			metrics.OperationTag(metrics.HistoryReplicationTaskScope),
+			metrics.NamespaceTag(attr.GetNamespaceId()),
 		)
 	}()
 


### PR DESCRIPTION
## What changed?
fix inconsistent label cardinality error

`inconsistent label cardinality: expected 3 label values but got 4 in prometheus.Labels{"multi_region_namespace":"true", "operation":"SyncActivityTask", "service_name":"history", "temporal_service_type":"history"}`

`inconsistent label cardinality: expected 4 label values but got 5 in prometheus.Labels{"multi_region_namespace":"true", "namespace":"app-1996-frontline-uat.pfayb", "operation":"SyncActivityTask", "service_name":"history", "temporal_service_type":"history"}`

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
