### PR TITLE
Fix `TestDeploymentSuite/TestBatchUpdateWorkflowExecutionOptions_SetPinnedThenUnset` flake

### DIFF
--- a/tests/deployment_test.go
+++ b/tests/deployment_test.go
@@ -1042,18 +1042,16 @@ func (s *DeploymentSuite) TestBatchUpdateWorkflowExecutionOptions_SetPinnedThenU
 
 func (s *DeploymentSuite) startBatchJobWithinConcurrentJobLimit(ctx context.Context, req *workflowservice.StartBatchOperationRequest) error {
 	var err error
-	started := false
-	for !started {
+	s.Eventually(func() bool {
 		_, err = s.FrontendClient().StartBatchOperation(ctx, req)
 		if err == nil {
-			started = true
-			return nil
+			return true
 		} else if strings.Contains(err.Error(), "Max concurrent batch operations is reached") {
-			time.Sleep(500 * time.Millisecond)
+			return false // retry
 		} else {
-			return err
+			return true // don't retry, just return error to test
 		}
-	}
+	}, 5*time.Second, 500*time.Millisecond)
 	return err
 }
 

--- a/tests/deployment_test.go
+++ b/tests/deployment_test.go
@@ -1048,9 +1048,8 @@ func (s *DeploymentSuite) startBatchJobWithinConcurrentJobLimit(ctx context.Cont
 			return true
 		} else if strings.Contains(err.Error(), "Max concurrent batch operations is reached") {
 			return false // retry
-		} else {
-			return true // don't retry, just return error to test
 		}
+		return true
 	}, 5*time.Second, 500*time.Millisecond)
 	return err
 }


### PR DESCRIPTION
## What changed?
- Increase max concurrent batch jobs from 1 to 3 in DeploymentTestSuite
- Sleep and retry if max concurrent batch operations is hit

## Why?
`TestDeploymentSuite/TestBatchUpdateWorkflowExecutionOptions_SetPinnedThenUnset` was flaking due to "Max concurrent batch operations is reached"

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
