### PR TITLE
Modify incoming batch query to select only running workflows for certain batch operations

### DIFF
--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -346,20 +346,14 @@ func (s *activitiesSuite) TestAdjustQuery() {
 		},
 		{
 			name:           "Contains status - 1",
-			query:          "Status=Completed",
-			expectedResult: "Status=Completed",
+			query:          "ExecutionStatus=Completed",
+			expectedResult: fmt.Sprintf("(ExecutionStatus=Completed) AND (%s)", statusRunningQueryFilter),
 			batchType:      BatchTypeTerminate,
 		},
 		{
 			name:           "Contains status - 2",
-			query:          "A=B OR Status=Completed",
-			expectedResult: "A=B OR Status=Completed",
-			batchType:      BatchTypeTerminate,
-		},
-		{
-			name:           "Contains status as a part of different cause",
-			query:          "A=B OR NewStatus=Completed",
-			expectedResult: fmt.Sprintf("(A=B OR NewStatus=Completed) AND (%s)", statusRunningQueryFilter),
+			query:          "A=B OR ExecutionStatus='Completed'",
+			expectedResult: fmt.Sprintf("(A=B OR ExecutionStatus='Completed') AND (%s)", statusRunningQueryFilter),
 			batchType:      BatchTypeTerminate,
 		},
 		{


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add "Status='Running'" to the query for certain batch operation types.
Note - if query is empty or already contains 'Status' cause - it will not be added.


## Why?
<!-- Tell your future self why have you made these changes -->
There is no need to run those operations on not-running workflows, but omitting this cause can significantly increase run time.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
add unit test

## Potential risks
N/A

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
May be...


## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No