### PR TITLE
Fix Namespace delete validation

### DIFF
--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -630,6 +630,7 @@ func (h *OperatorHandlerImpl) DeleteNamespace(
 			ConcurrentDeleteExecutionsActivities: h.config.DeleteNamespaceConcurrentDeleteExecutionsActivities(),
 		},
 		NamespaceDeleteDelay: namespaceDeleteDelay,
+		CurrentClusterName:   h.clusterMetadata.GetCurrentClusterName(),
 	}
 
 	sdkClient := h.sdkClientFactory.GetSystemClient()


### PR DESCRIPTION
## What changed?
Fix Namespace delete validation on placed cluster.

## Why?
State 1: Namespace contains A B C clusters.
Transition: Remove cluster C from the ns.
State 2: Namespace contains A B clusters.
We should allow NS remove from cluster C.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
