### PR TITLE
Workflow Update: fix doc on when WorkflowUpdateAbortedErr is returned

### DIFF
--- a/docs/architecture/workflow-update.md
+++ b/docs/architecture/workflow-update.md
@@ -169,19 +169,19 @@ An Update is aborted when:
 
 Full "Update state" and "Abort reason" matrix is the following:
 
-| Update State / Abort Reason             | (1) RegistryCleared        | (2) WorkflowCompleted                    | (3) WorkflowContinuing                   |
-|-----------------------------------------|----------------------------|------------------------------------------|------------------------------------------|
-| **Created**                             | `WorkflowUpdateAbortedErr` | `ErrWorkflowCompleted`                   | `ErrWorkflowClosing`                     |
-| **ProvisionallyAdmitted**               | `WorkflowUpdateAbortedErr` | `ErrWorkflowCompleted`                   | `ErrWorkflowClosing`                     |
-| **Admitted**                            | `WorkflowUpdateAbortedErr` | `ErrWorkflowCompleted`                   | `ErrWorkflowClosing`                     |
-| **Sent**                                | `WorkflowUpdateAbortedErr` | `ErrWorkflowCompleted`                   | `ErrWorkflowClosing`                     |
-| **ProvisionallyAccepted**               | `WorkflowUpdateAbortedErr` | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
-| **Accepted**                            | `WorkflowUpdateAbortedErr` | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
-| **ProvisionallyCompleted**              | `WorkflowUpdateAbortedErr` | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
-| **ProvisionallyCompletedAfterAccepted** | `WorkflowUpdateAbortedErr` | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
-| **Completed**                           | `nil`                      | `nil`                                    | `nil`                                    |
-| **ProvisionallyAborted**                | `nil`                      | `nil`                                    | `nil`                                    |
-| **Aborted**                             | `nil`                      | `nil`                                    | `nil`                                    |
+| Update State ↓ / Abort Reason →         | (1) RegistryCleared                             | (2) WorkflowCompleted                    | (3) WorkflowContinuing                   |
+|-----------------------------------------|-------------------------------------------------|------------------------------------------|------------------------------------------|
+| **Created**                             | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `ErrWorkflowCompleted`                   | `ErrWorkflowClosing`                     |
+| **ProvisionallyAdmitted**               | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `ErrWorkflowCompleted`                   | `ErrWorkflowClosing`                     |
+| **Admitted**                            | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `ErrWorkflowCompleted`                   | `ErrWorkflowClosing`                     |
+| **Sent**                                | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `ErrWorkflowCompleted`                   | `ErrWorkflowClosing`                     |
+| **ProvisionallyAccepted**               | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
+| **Accepted**                            | `registryClearedErr`→`nil`                      | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
+| **ProvisionallyCompleted**              | `registryClearedErr`→`nil`                      | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
+| **ProvisionallyCompletedAfterAccepted** | `registryClearedErr`→`nil`                      | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` |
+| **Completed**                           | `nil`                                           | `nil`                                    | `nil`                                    |
+| **ProvisionallyAborted**                | `nil`                                           | `nil`                                    | `nil`                                    |
+| **Aborted**                             | `nil`                                           | `nil`                                    | `nil`                                    |
 
 When the Workflow performs a final completion, all in-flight Updates are aborted: admitted Updates get
 `ErrWorkflowCompleted` error on both `accepted` and `completed` futures. Accepted Updates
@@ -197,8 +197,12 @@ was running haven't been seen by the Workflow yet, they can be safely retried on
 It also provides a better experience for API callers since they will not notice that the Workflow
 started a new run.
 
-`WorkflowUpdateAbortedErr` is also retried internally by the server providing a better experience
-to the API caller: they will not notice that the Update was lost.
+`WorkflowUpdateAbortedErr` error is also retried internally by the server providing a better experience
+to the API caller: they will not notice that the Update was lost. Internally this case is communicated
+via `registryClearedErr` error which is set on Update futures every time the Registry is cleared.
+But if Update was already accepted, it is converted to `ACCEPTED` stage (with `nil` error) which is 
+returned to the API caller instead of `WorkflowUpdateAbortedErr` error.
+See `WaitLifecycleStage` methods for details.
 
 `Aborted` is a terminal state. Updates remain in the `Aborted` state in the Registry even after
 the Update Registry is reconstructed from the history.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Workflow Update: fix doc on when `WorkflowUpdateAbortedErr` is returned.

## Why?
<!-- Tell your future self why have you made these changes -->
Make doc in-sync with code.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
N/A

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
It is it.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.