### PR TITLE
Fix functional subtest execution

### DIFF
--- a/tests/testcore/client_suite.go
+++ b/tests/testcore/client_suite.go
@@ -136,6 +136,13 @@ func (s *ClientFunctionalSuite) TearDownTest() {
 	}
 }
 
+func (s *ClientFunctionalSuite) SetupSubTest() {
+	// Because we override `s.Assertions` with `require.Assertions` on test level (above),
+	// it needs to be done on subtest level too. Otherwise, any failed `assert` in
+	// subtest will fail the entire test (not subtest) immediately without running other subtests.
+	s.Assertions = require.New(s.T())
+}
+
 func (s *ClientFunctionalSuite) EventuallySucceeds(ctx context.Context, operationCtx backoff.OperationCtx) {
 	s.T().Helper()
 	s.NoError(backoff.ThrottleRetryContext(

--- a/tests/testcore/functional.go
+++ b/tests/testcore/functional.go
@@ -66,20 +66,25 @@ func (s *FunctionalSuite) TearDownSuite() {
 
 func (s *FunctionalSuite) SetupTest() {
 	s.FunctionalTestBase.SetupTest()
+	s.initAssertions()
+}
 
-	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
+func (s *FunctionalSuite) SetupSubTest() {
+	s.initAssertions()
+}
+
+func (s *FunctionalSuite) initAssertions() {
+	// `s.Assertions` (as well as other test helpers which depends on `s.T()`) must be initialized on
+	// both test and subtest levels (but not suite level, where `s.T()` is `nil`).
+	//
+	// If these helpers are not reinitialized on subtest level, any failed `assert` in
+	// subtest will fail the entire test (not subtest) immediately without running other subtests.
+
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
 	s.HistoryRequire = historyrequire.New(s.T())
 	s.UpdateUtils = updateutils.New(s.T())
 	s.TaskPoller = taskpoller.New(s.T(), s.client, s.Namespace().String())
-}
-
-func (s *FunctionalSuite) SetupSubTest() {
-	// Because we override `s.Assertions` with `require.Assertions` on test level (above),
-	// it needs to be done on subtest level too. Otherwise, any failed `assert` in
-	// subtest will fail the entire test (not subtest) immediately without running other subtests.
-	s.Assertions = require.New(s.T())
 }
 
 func (s *FunctionalSuite) SendSignal(namespace string, execution *commonpb.WorkflowExecution, signalName string,

--- a/tests/testcore/functional.go
+++ b/tests/testcore/functional.go
@@ -75,6 +75,13 @@ func (s *FunctionalSuite) SetupTest() {
 	s.TaskPoller = taskpoller.New(s.T(), s.client, s.Namespace().String())
 }
 
+func (s *FunctionalSuite) SetupSubTest() {
+	// Because we override `s.Assertions` with `require.Assertions` on test level (above),
+	// it needs to be done on subtest level too. Otherwise, any failed `assert` in
+	// subtest will fail the entire test (not subtest) immediately without running other subtests.
+	s.Assertions = require.New(s.T())
+}
+
 func (s *FunctionalSuite) SendSignal(namespace string, execution *commonpb.WorkflowExecution, signalName string,
 	input *commonpb.Payloads, identity string) error {
 	_, err := s.client.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix functional subtest execution.
Credits to @stephanos for the brilliant idea!

## Why?
<!-- Tell your future self why have you made these changes -->
Previously, if there is a assert failure (like `s.Equal`) in subtest, it failed entire test and stoped executing other subtests. Error message went to parent test as well, while subtest failed with wired message "subtest paniced". This is because we override `s.Assertions` in every test with `require.New` and it calls `FailNow` when condition is not meet. Same thing must to be done for every subtest. And every test helper which depends on `s.T()`.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Simulate failure of some sub tests and checked results.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.