### PR TITLE
Reserve update names for internal updates

### DIFF
--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -101,6 +101,7 @@ var (
 	errUpdateMetaNotSet       = serviceerror.NewInvalidArgument("Update meta is not set on request.")
 	errUpdateInputNotSet      = serviceerror.NewInvalidArgument("Update input is not set on request.")
 	errUpdateNameNotSet       = serviceerror.NewInvalidArgument("Update name is not set on request.")
+	errUpdateNameInvalid      = serviceerror.NewInvalidArgument("Update name is not allowed to start with 'temporal-sys-'.")
 	errUpdateIDTooLong        = serviceerror.NewInvalidArgument("UpdateId length exceeds limit.")
 	errUpdateRefNotSet        = serviceerror.NewInvalidArgument("UpdateRef is not set on request.")
 	errUpdateWaitPolicyNotSet = serviceerror.NewInvalidArgument("WaitPolicy is not set on request.")

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3903,9 +3903,11 @@ func (wh *WorkflowHandler) prepareUpdateWorkflowRequest(
 	if request.GetRequest().GetInput() == nil {
 		return errUpdateInputNotSet
 	}
-
 	if request.GetRequest().GetInput().GetName() == "" {
 		return errUpdateNameNotSet
+	}
+	if strings.HasPrefix(request.GetRequest().GetInput().GetName(), "temporal-sys-") {
+		return errUpdateNameInvalid
 	}
 
 	if request.GetWaitPolicy() == nil {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Reject updates requests if the update name starts with `temporal-sys-`.

## Why?
<!-- Tell your future self why have you made these changes -->

To reserve those kinds of updates for internal usage. (no concrete plans here yet)

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

This is technically a breaking as there are no limitations on the update name right now. But it seems extremely unlikely to me that someone is using this prefix right now. (especially since in most SDKs, it's derived from the method name, and most languages don't support `-` there)

But if there's doubt, I can put it behind a dynamic config.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
