### PR TITLE
Allow disabling the Updates in-flight limit

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1989,7 +1989,7 @@ archivalQueueProcessor`,
 	WorkflowExecutionMaxInFlightUpdates = NewNamespaceIntSetting(
 		"history.maxInFlightUpdates",
 		10,
-		`WorkflowExecutionMaxInFlightUpdates is the max number of updates that can be in-flight (admitted but not yet completed) for any given workflow execution.`,
+		`WorkflowExecutionMaxInFlightUpdates is the max number of updates that can be in-flight (admitted but not yet completed) for any given workflow execution. Set to zero to disable limit.`,
 	)
 	WorkflowExecutionMaxTotalUpdates = NewNamespaceIntSetting(
 		"history.maxTotalUpdates",

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -213,6 +213,7 @@ func TestFindOrCreate(t *testing.T) {
 	tv1 := tv.WithUpdateIDNumber(1)
 	tv2 := tv.WithUpdateIDNumber(2)
 	tv3 := tv.WithUpdateIDNumber(3)
+	tv4 := tv.WithUpdateIDNumber(4)
 
 	t.Run("find stored update", func(t *testing.T) {
 		reg := update.NewRegistry(&mockUpdateStore{
@@ -304,7 +305,7 @@ func TestFindOrCreate(t *testing.T) {
 			limit += 1
 
 			_, existed, err = reg.FindOrCreate(context.Background(), tv2.UpdateID())
-			require.NoError(t, err, "creating update #2 should have beeen created after limit increase")
+			require.NoError(t, err, "update #2 should have beeen created after limit increase")
 			require.False(t, existed)
 			require.Equal(t, 2, reg.Len())
 		})
@@ -313,9 +314,18 @@ func TestFindOrCreate(t *testing.T) {
 			assertRejectUpdateInRegistry(t, reg, evStore, upd1)
 
 			_, existed, err = reg.FindOrCreate(context.Background(), tv3.UpdateID())
-			require.NoError(t, err, "update #3 should be created after #1 completed")
+			require.NoError(t, err, "update #3 should have been created after #1 completed")
 			require.False(t, existed)
 			require.Equal(t, 2, reg.Len())
+		})
+
+		t.Run("disable limit by setting it to zero", func(t *testing.T) {
+			limit = 0
+
+			_, _, err = reg.FindOrCreate(context.Background(), tv4.UpdateID())
+			require.NoError(t, err, "update #4 should have been created")
+			require.False(t, existed)
+			require.Equal(t, 3, reg.Len())
 		})
 	})
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

If the maximum in-flight limit for updates is zero, disable the check.

## Why?
<!-- Tell your future self why have you made these changes -->

Preparation to move towards a payload-based check. Having the option to turn this limit off is useful.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Added test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
