### PR TITLE
Handle ResourceExhausted from RecordTaskStarted in task poll

### DIFF
--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -227,8 +227,6 @@ func (c *backlogManagerImpl) completeTask(task *persistencespb.AllocatedTaskInfo
 		// We handle this by writing the task back to persistence with a higher taskID.
 		// This will allow subsequent tasks to make progress, and hopefully by the time this task is picked-up
 		// again the underlying reason for failing to start will be resolved.
-		// Note that RecordTaskStarted only fails after retrying for a long time, so a single task will not be
-		// re-written to persistence frequently.
 		err = executeWithRetry(context.Background(), func(_ context.Context) error {
 			_, err := c.taskWriter.appendTask(task.Data)
 			return err
@@ -237,7 +235,9 @@ func (c *backlogManagerImpl) completeTask(task *persistencespb.AllocatedTaskInfo
 		if err != nil {
 			// OK, we also failed to write to persistence.
 			// This should only happen in very extreme cases where persistence is completely down.
-			// We still can't lose the old task, so we just unload the entire task queue
+			// We still can't lose the old task, so we just unload the entire task queue.
+			// We haven't advanced the ack level past this task, so when the task queue reloads,
+			// it will see this task again.
 			c.logger.Error("Persistent store operation failure",
 				tag.StoreOperationStopTaskQueue,
 				tag.Error(err),


### PR DESCRIPTION
## What changed?
Return ResourceExhausted directly to client if we get it from history on RecordTaskStarted.

## Why?
If history is overloaded and we retry immediately, we can end up in a loop where we keep matching tasks and sending them to history, increasing load on history and also persistence as we cycle tasks to the end of the queue. Returning the error effectively inserts the client in this loop, slowing it down.

## How did you test it?
existing tests

## Potential risks

## Is hotfix candidate?
yes
