### PR TITLE
Return error if workflow backoff timer is not fired

### DIFF
--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -446,8 +446,11 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowBackoffTimerTask(
 	if err != nil {
 		return err
 	}
-	if mutableState == nil || !mutableState.IsWorkflowExecutionRunning() {
-		return nil
+	if mutableState == nil {
+		return consts.ErrWorkflowExecutionNotFound
+	}
+	if !mutableState.IsWorkflowExecutionRunning() {
+		return consts.ErrWorkflowCompleted
 	}
 
 	// TODO: deprecated, remove below 3 metrics after v1.25
@@ -476,7 +479,7 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowBackoffTimerTask(
 
 	if mutableState.HadOrHasWorkflowTask() {
 		// already has workflow task
-		return nil
+		return errNoTimerFired
 	}
 
 	// schedule first workflow task

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -447,9 +447,11 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowBackoffTimerTask(
 		return err
 	}
 	if mutableState == nil {
+		release(nil)
 		return consts.ErrWorkflowExecutionNotFound
 	}
 	if !mutableState.IsWorkflowExecutionRunning() {
+		release(nil)
 		return consts.ErrWorkflowCompleted
 	}
 
@@ -479,6 +481,7 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowBackoffTimerTask(
 
 	if mutableState.HadOrHasWorkflowTask() {
 		// already has workflow task
+		release(nil)
 		return errNoTimerFired
 	}
 

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -1303,7 +1303,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowBackoffTimer_Noop() {
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	resp := s.timerQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(timerTask))
-	s.NoError(resp.ExecutionErr)
+	s.ErrorIs(resp.ExecutionErr, errNoTimerFired)
 }
 
 func (s *timerQueueActiveTaskExecutorSuite) TestActivityRetryTimer_Fire() {


### PR DESCRIPTION
## What changed?
Return error from task executor if workflow back of timer is not fired.

## Why?
To prevent outer layers to count no-op timers as fired.

## How did you test it?
Existing unit test

## Potential risks
No

## Is hotfix candidate?
Yes
