### PR TITLE
Follow ReusePolicy AllowDuplicateFailedOnly with TerminateExisting

### DIFF
--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -500,6 +500,7 @@ func (s *Starter) resolveDuplicateWorkflowID(
 		if s.followReusePolicyAfterConflictPolicyTerminate(s.namespace.Name().String()) {
 			// Exit and retry again from the top.
 			// By returning an Unavailable service error, the entire Start request will be retried.
+			// NOTE: This WorkflowIDReusePolicy cannot be RejectDuplicate as the frontend will reject that.
 			return nil, StartErr, serviceerror.NewUnavailable(fmt.Sprintf("Termination failed: %v", err))
 		}
 		// Fallthough to the logic for only creating the new workflow below.

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -349,6 +349,8 @@ type Config struct {
 	EnableEagerWorkflowStart      dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	NamespaceCacheRefreshInterval dynamicconfig.DurationPropertyFn
 
+	FollowReusePolicyAfterConflictPolicyTerminate dynamicconfig.TypedPropertyFnWithNamespaceFilter[bool]
+
 	// ArchivalQueueProcessor settings
 	ArchivalProcessorSchedulerWorkerCount               dynamicconfig.TypedSubscribable[int]
 	ArchivalProcessorMaxPollHostRPS                     dynamicconfig.IntPropertyFn
@@ -547,6 +549,8 @@ func NewConfig(
 		ReplicationResendMaxBatchCount:                      dynamicconfig.ReplicationResendMaxBatchCount.Get(dc),
 		ReplicationProgressCacheMaxSize:                     dynamicconfig.ReplicationProgressCacheMaxSize.Get(dc),
 		ReplicationProgressCacheTTL:                         dynamicconfig.ReplicationProgressCacheTTL.Get(dc),
+
+		FollowReusePolicyAfterConflictPolicyTerminate: dynamicconfig.FollowReusePolicyAfterConflictPolicyTerminate.Get(dc),
 
 		MaximumBufferedEventsBatch:       dynamicconfig.MaximumBufferedEventsBatch.Get(dc),
 		MaximumBufferedEventsSizeInBytes: dynamicconfig.MaximumBufferedEventsSizeInBytes.Get(dc),

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -128,7 +128,6 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution() {
 }
 
 func (s *WorkflowTestSuite) TestStartWorkflowExecution_Terminate() {
-
 	// setting this to 0 to be sure we are terminating old workflow
 	s.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, 0)
 
@@ -145,6 +144,11 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_Terminate() {
 		{
 			"TerminateExisting id workflow conflict policy",
 			enumspb.WORKFLOW_ID_REUSE_POLICY_UNSPECIFIED,
+			enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING,
+		},
+		{
+			"TerminateExisting with AllowDuplicateFailedOnly",
+			enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
 			enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING,
 		},
 	}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Make WorkflowIdConflictPolicy TerminateExisting follow the WorkflowIdReusePolicy after an _unsuccessful_ termination.

NOTE: The frontend change was made in https://github.com/temporalio/temporal/pull/7099

## Why?
<!-- Tell your future self why have you made these changes -->

When the termination from TerminateExisting fails, the user would expect the WorkflowIdReusePolicy to be applied as the Workflow is not running.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Well ... there's no way to test this well right now. There are no unit tests; and the functional test cannot be written without the use of [testhooks](https://github.com/temporalio/temporal/pull/6938) since there is no other way to simulate the race condition here.

I manually added a `sync.Once` into the code that terminates the workflow and can confirm the expected behavior.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
