### PR TITLE
Handle shard ownership lost when reading history tasks

### DIFF
--- a/service/history/queues/queue_immediate.go
+++ b/service/history/queues/queue_immediate.go
@@ -76,7 +76,7 @@ func NewImmediateQueue(
 				NextPageToken:       paginationToken,
 			}
 
-			resp, err := shard.GetExecutionManager().GetHistoryTasks(ctx, request)
+			resp, err := shard.GetHistoryTasks(ctx, request)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/service/history/queues/queue_immediate_test.go
+++ b/service/history/queues/queue_immediate_test.go
@@ -1,0 +1,111 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package queues
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/tests"
+	"go.uber.org/mock/gomock"
+)
+
+type (
+	immediateQueueSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		controller           *gomock.Controller
+		mockShard            *shard.ContextTest
+		mockExecutionManager *persistence.MockExecutionManager
+
+		immediateQueue *immediateQueue
+	}
+)
+
+func TestImmediateQueueSuite(t *testing.T) {
+	s := new(immediateQueueSuite)
+	suite.Run(t, s)
+}
+
+func (s *immediateQueueSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.controller = gomock.NewController(s.T())
+	s.mockShard = shard.NewTestContext(
+		s.controller,
+		&persistencespb.ShardInfo{
+			ShardId: 0,
+			RangeId: 1,
+			Owner:   "test-shard-owner",
+		},
+		tests.NewDynamicConfig(),
+	)
+	s.mockExecutionManager = s.mockShard.Resource.ExecutionMgr
+	s.mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+
+	s.immediateQueue = NewImmediateQueue(
+		s.mockShard,
+		tasks.CategoryTransfer,
+		nil, // scheduler
+		nil, // rescheduler
+		testQueueOptions,
+		NewReaderPriorityRateLimiter(
+			func() float64 { return 10 },
+			1,
+		),
+		GrouperNamespaceID{},
+		log.NewTestLogger(),
+		metrics.NoopMetricsHandler,
+		nil, // execuable factory
+	)
+}
+
+func (s *immediateQueueSuite) TearDownTest() {
+	s.controller.Finish()
+}
+
+func (s *immediateQueueSuite) TestPaginationFnProvider_ShardOwnershipLost() {
+	paginationFnProvider := s.immediateQueue.paginationFnProvider
+
+	s.mockExecutionManager.EXPECT().GetHistoryTasks(gomock.Any(), gomock.Any()).Return(nil, &persistence.ShardOwnershipLostError{
+		ShardID: s.mockShard.GetShardID(),
+	}).Times(1)
+
+	paginationFn := paginationFnProvider(NewRandomRange())
+	_, _, err := paginationFn(nil)
+	s.True(shard.IsShardOwnershipLostError(err))
+
+	// make sure shard is also marked as invalid
+	s.False(s.mockShard.IsValid())
+}

--- a/service/history/queues/queue_scheduled.go
+++ b/service/history/queues/queue_scheduled.go
@@ -92,7 +92,7 @@ func NewScheduledQueue(
 				NextPageToken: paginationToken,
 			}
 
-			resp, err := shard.GetExecutionManager().GetHistoryTasks(ctx, request)
+			resp, err := shard.GetHistoryTasks(ctx, request)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -275,7 +275,7 @@ func (p *scheduledQueue) lookAheadTask() {
 		BatchSize:           1,
 		NextPageToken:       nil,
 	}
-	response, err := p.shard.GetExecutionManager().GetHistoryTasks(ctx, request)
+	response, err := p.shard.GetHistoryTasks(ctx, request)
 	if err != nil {
 		p.logger.Error("Failed to load look ahead task", tag.Error(err))
 		if common.IsResourceExhausted(err) {

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -108,6 +108,7 @@ type (
 
 		AddTasks(ctx context.Context, request *persistence.AddHistoryTasksRequest) error
 		AddSpeculativeWorkflowTaskTimeoutTask(task *tasks.WorkflowTaskTimeoutTask) error
+		GetHistoryTasks(ctx context.Context, request *persistence.GetHistoryTasksRequest) (*persistence.GetHistoryTasksResponse, error)
 		CreateWorkflowExecution(ctx context.Context, request *persistence.CreateWorkflowExecutionRequest) (*persistence.CreateWorkflowExecutionResponse, error)
 		UpdateWorkflowExecution(ctx context.Context, request *persistence.UpdateWorkflowExecutionRequest) (*persistence.UpdateWorkflowExecutionResponse, error)
 		ConflictResolveWorkflowExecution(ctx context.Context, request *persistence.ConflictResolveWorkflowExecutionRequest) (*persistence.ConflictResolveWorkflowExecutionResponse, error)

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -574,6 +574,18 @@ func (s *ContextImpl) AddSpeculativeWorkflowTaskTimeoutTask(
 	return nil
 }
 
+func (s *ContextImpl) GetHistoryTasks(
+	ctx context.Context,
+	request *persistence.GetHistoryTasksRequest,
+) (*persistence.GetHistoryTasksResponse, error) {
+	if err := s.errorByState(); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.executionManager.GetHistoryTasks(ctx, request)
+	return resp, s.handleReadError(err)
+}
+
 func (s *ContextImpl) CreateWorkflowExecution(
 	ctx context.Context,
 	request *persistence.CreateWorkflowExecutionRequest,

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -372,6 +372,21 @@ func (mr *MockContextMockRecorder) GetHistoryClient() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryClient", reflect.TypeOf((*MockContext)(nil).GetHistoryClient))
 }
 
+// GetHistoryTasks mocks base method.
+func (m *MockContext) GetHistoryTasks(ctx context.Context, request *persistence0.GetHistoryTasksRequest) (*persistence0.GetHistoryTasksResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHistoryTasks", ctx, request)
+	ret0, _ := ret[0].(*persistence0.GetHistoryTasksResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHistoryTasks indicates an expected call of GetHistoryTasks.
+func (mr *MockContextMockRecorder) GetHistoryTasks(ctx, request any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTasks", reflect.TypeOf((*MockContext)(nil).GetHistoryTasks), ctx, request)
+}
+
 // GetLogger mocks base method.
 func (m *MockContext) GetLogger() log.Logger {
 	m.ctrl.T.Helper()
@@ -1098,6 +1113,21 @@ func (m *MockControllableContext) GetHistoryClient() historyservice.HistoryServi
 func (mr *MockControllableContextMockRecorder) GetHistoryClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryClient", reflect.TypeOf((*MockControllableContext)(nil).GetHistoryClient))
+}
+
+// GetHistoryTasks mocks base method.
+func (m *MockControllableContext) GetHistoryTasks(ctx context.Context, request *persistence0.GetHistoryTasksRequest) (*persistence0.GetHistoryTasksResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHistoryTasks", ctx, request)
+	ret0, _ := ret[0].(*persistence0.GetHistoryTasksResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHistoryTasks indicates an expected call of GetHistoryTasks.
+func (mr *MockControllableContextMockRecorder) GetHistoryTasks(ctx, request any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTasks", reflect.TypeOf((*MockControllableContext)(nil).GetHistoryTasks), ctx, request)
 }
 
 // GetLogger mocks base method.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Wrap ExecutionManager.GetHistoryTasks in shard context to handler shardOwnershipLost errors.
- Will need to follow up and audit all usage of this method and other methods on execution manager. This PR is only for fixing the issue we are seeing.

## Why?
<!-- Tell your future self why have you made these changes -->
- If shard has no (api) traffic, and ownership already got lost in the background (from some persistence implementations). Task processing can get stuck forever trying to load tasks and see this shard ownership lost error.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
