### PR TITLE
Refactor: remove cluster.yaml config

### DIFF
--- a/tests/add_tasks_test.go
+++ b/tests/add_tasks_test.go
@@ -142,7 +142,7 @@ func (e *noopExecutor) shouldExecute(task tasks.Task) bool {
 // SetupSuite creates the test cluster and registers the executorWrapper with the history service.
 func (s *AddTasksSuite) SetupSuite() {
 	// Set up the test cluster and register our executable wrapper.
-	s.FunctionalTestSuite.SetupSuiteWithDefaultCluster(testcore.WithFxOptionsForService(
+	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(testcore.WithFxOptionsForService(
 		primitives.HistoryService,
 		fx.Provide(
 			func() queues.ExecutorWrapper {
@@ -163,7 +163,7 @@ func (s *AddTasksSuite) SetupSuite() {
 
 func (s *AddTasksSuite) TearDownSuite() {
 	s.sdkClient.Close()
-	s.FunctionalTestSuite.TearDownSuite()
+	s.FunctionalTestBase.TearDownSuite()
 }
 
 func (s *AddTasksSuite) TestAddTasks_Ok() {

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -71,16 +71,15 @@ import (
 const (
 	numOfRetry   = 50
 	waitTimeInMs = 400
+
+	testSearchAttributeKey = "CustomTextField"
+	testSearchAttributeVal = "test value"
 )
 
 type AdvancedVisibilitySuite struct {
 	testcore.FunctionalTestSuite
 
-	isElasticsearchEnabled bool
-
-	testSearchAttributeKey string
-	testSearchAttributeVal string
-	sdkClient              sdkclient.Client
+	sdkClient sdkclient.Client
 	// client for the system namespace
 	sysSDKClient sdkclient.Client
 }
@@ -103,15 +102,9 @@ func (s *AdvancedVisibilitySuite) SetupSuite() {
 		// Allow the scavenger to remove any build ID regardless of when it was last default for a set.
 		dynamicconfig.RemovableBuildIdDurationSinceDefault.Key(): time.Microsecond,
 	}
+	s.FunctionalTestSuite.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
 
-	if testcore.UsingSQLAdvancedVisibility() {
-		s.FunctionalTestSuite.SetupSuiteWithCluster("testdata/cluster.yaml", testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
-		s.Logger.Info(fmt.Sprintf("Running advanced visibility test with %s/%s persistence", testcore.TestFlags.PersistenceType, testcore.TestFlags.PersistenceDriver))
-		s.isElasticsearchEnabled = false
-	} else {
-		s.FunctionalTestSuite.SetupSuiteWithCluster("testdata/es_cluster.yaml", testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
-		s.Logger.Info("Running advanced visibility test with Elasticsearch persistence")
-		s.isElasticsearchEnabled = true
+	if !testcore.UseSQLVisibility() {
 		// To ensure that Elasticsearch won't return more than defaultPageSize documents,
 		// but returns error if page size on request is greater than defaultPageSize.
 		// Probably can be removed and replaced with assert on items count in response.
@@ -137,23 +130,16 @@ func (s *AdvancedVisibilitySuite) TearDownSuite() {
 	s.FunctionalTestSuite.TearDownSuite()
 }
 
-func (s *AdvancedVisibilitySuite) SetupTest() {
-	s.FunctionalTestSuite.SetupTest()
-
-	s.testSearchAttributeKey = "CustomTextField"
-	s.testSearchAttributeVal = "test value"
-}
-
 func (s *AdvancedVisibilitySuite) TestListOpenWorkflow() {
 	id := "es-functional-start-workflow-test"
 	wt := "es-functional-start-workflow-test-type"
 	tl := "es-functional-start-workflow-test-taskqueue"
 	request := s.createStartWorkflowExecutionRequest(id, wt, tl)
 
-	attrPayload, _ := payload.Encode(s.testSearchAttributeVal)
+	attrPayload, _ := payload.Encode(testSearchAttributeVal)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			s.testSearchAttributeKey: attrPayload,
+			testSearchAttributeKey: attrPayload,
 		},
 	}
 	request.SearchAttributes = searchAttr
@@ -187,7 +173,7 @@ func (s *AdvancedVisibilitySuite) TestListOpenWorkflow() {
 	s.Equal(we.GetRunId(), openExecution.GetExecution().GetRunId())
 
 	s.Equal(1, len(openExecution.GetSearchAttributes().GetIndexedFields()))
-	attrPayloadFromResponse, attrExist := openExecution.GetSearchAttributes().GetIndexedFields()[s.testSearchAttributeKey]
+	attrPayloadFromResponse, attrExist := openExecution.GetSearchAttributes().GetIndexedFields()[testSearchAttributeKey]
 	s.True(attrExist)
 	s.Equal(attrPayload.GetData(), attrPayloadFromResponse.GetData())
 	attrType, typeSet := attrPayloadFromResponse.GetMetadata()[searchattribute.MetadataType]
@@ -256,17 +242,17 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_SearchAttribute() {
 	tl := "es-functional-list-workflow-by-search-attr-test-taskqueue"
 	request := s.createStartWorkflowExecutionRequest(id, wt, tl)
 
-	attrValBytes, _ := payload.Encode(s.testSearchAttributeVal)
+	attrValBytes, _ := payload.Encode(testSearchAttributeVal)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			s.testSearchAttributeKey: attrValBytes,
+			testSearchAttributeKey: attrValBytes,
 		},
 	}
 	request.SearchAttributes = searchAttr
 
 	we, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
 	s.NoError(err)
-	query := fmt.Sprintf(`WorkflowId = "%s" and %s = "%s"`, id, s.testSearchAttributeKey, s.testSearchAttributeVal)
+	query := fmt.Sprintf(`WorkflowId = "%s" and %s = "%s"`, id, testSearchAttributeKey, testSearchAttributeVal)
 	s.testHelperForReadOnce(we.GetRunId(), query, false)
 
 	searchAttributes := s.createSearchAttributes()
@@ -663,7 +649,7 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_MaxWindowSize() {
 }
 
 func (s *AdvancedVisibilitySuite) TestListWorkflow_OrderBy() {
-	if !s.isElasticsearchEnabled {
+	if testcore.UseSQLVisibility() {
 		s.T().Skip("This test is only for Elasticsearch")
 	}
 
@@ -935,15 +921,15 @@ func (s *AdvancedVisibilitySuite) testHelperForReadOnce(expectedRunID string, qu
 	s.Equal(expectedRunID, openExecution.GetExecution().GetRunId())
 	s.True(!openExecution.GetExecutionTime().AsTime().Before(openExecution.GetStartTime().AsTime()))
 	if openExecution.SearchAttributes != nil && len(openExecution.SearchAttributes.GetIndexedFields()) > 0 {
-		searchValBytes := openExecution.SearchAttributes.GetIndexedFields()[s.testSearchAttributeKey]
+		searchValBytes := openExecution.SearchAttributes.GetIndexedFields()[testSearchAttributeKey]
 		var searchVal string
 		_ = payload.Decode(searchValBytes, &searchVal)
-		s.Equal(s.testSearchAttributeVal, searchVal)
+		s.Equal(testSearchAttributeVal, searchVal)
 	}
 }
 
 func (s *AdvancedVisibilitySuite) TestScanWorkflow() {
-	if !s.isElasticsearchEnabled {
+	if testcore.UseSQLVisibility() {
 		s.T().Skip("This test is only for Elasticsearch")
 	}
 
@@ -975,7 +961,7 @@ func (s *AdvancedVisibilitySuite) TestScanWorkflow() {
 }
 
 func (s *AdvancedVisibilitySuite) TestScanWorkflow_SearchAttribute() {
-	if !s.isElasticsearchEnabled {
+	if testcore.UseSQLVisibility() {
 		s.T().Skip("This test is only for Elasticsearch")
 	}
 
@@ -984,22 +970,22 @@ func (s *AdvancedVisibilitySuite) TestScanWorkflow_SearchAttribute() {
 	tl := "es-functional-scan-workflow-search-attr-test-taskqueue"
 	request := s.createStartWorkflowExecutionRequest(id, wt, tl)
 
-	attrValBytes, _ := payload.Encode(s.testSearchAttributeVal)
+	attrValBytes, _ := payload.Encode(testSearchAttributeVal)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			s.testSearchAttributeKey: attrValBytes,
+			testSearchAttributeKey: attrValBytes,
 		},
 	}
 	request.SearchAttributes = searchAttr
 
 	we, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
 	s.NoError(err)
-	query := fmt.Sprintf(`WorkflowId = "%s" and %s = "%s"`, id, s.testSearchAttributeKey, s.testSearchAttributeVal)
+	query := fmt.Sprintf(`WorkflowId = "%s" and %s = "%s"`, id, testSearchAttributeKey, testSearchAttributeVal)
 	s.testHelperForReadOnce(we.GetRunId(), query, true)
 }
 
 func (s *AdvancedVisibilitySuite) TestScanWorkflow_PageToken() {
-	if !s.isElasticsearchEnabled {
+	if testcore.UseSQLVisibility() {
 		s.T().Skip("This test is only for Elasticsearch")
 	}
 
@@ -1034,10 +1020,10 @@ func (s *AdvancedVisibilitySuite) TestCountWorkflow() {
 	tl := "es-functional-count-workflow-test-taskqueue"
 	request := s.createStartWorkflowExecutionRequest(id, wt, tl)
 
-	attrValBytes, _ := payload.Encode(s.testSearchAttributeVal)
+	attrValBytes, _ := payload.Encode(testSearchAttributeVal)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			s.testSearchAttributeKey: attrValBytes,
+			testSearchAttributeKey: attrValBytes,
 		},
 	}
 	request.SearchAttributes = searchAttr
@@ -1045,7 +1031,7 @@ func (s *AdvancedVisibilitySuite) TestCountWorkflow() {
 	_, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
 	s.NoError(err)
 
-	query := fmt.Sprintf(`WorkflowId = "%s" and %s = "%s"`, id, s.testSearchAttributeKey, s.testSearchAttributeVal)
+	query := fmt.Sprintf(`WorkflowId = "%s" and %s = "%s"`, id, testSearchAttributeKey, testSearchAttributeVal)
 	countRequest := &workflowservice.CountWorkflowExecutionsRequest{
 		Namespace: s.Namespace().String(),
 		Query:     query,
@@ -1061,7 +1047,7 @@ func (s *AdvancedVisibilitySuite) TestCountWorkflow() {
 	}
 	s.Equal(int64(1), resp.GetCount())
 
-	query = fmt.Sprintf(`WorkflowId = "%s" and %s = "%s"`, id, s.testSearchAttributeKey, "noMatch")
+	query = fmt.Sprintf(`WorkflowId = "%s" and %s = "%s"`, id, testSearchAttributeKey, "noMatch")
 	countRequest.Query = query
 	resp, err = s.FrontendClient().CountWorkflowExecutions(testcore.NewContext(), countRequest)
 	s.NoError(err)
@@ -1206,10 +1192,10 @@ func (s *AdvancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 		// handle first upsert
 		if commandCount == 0 {
 			commandCount++
-			attrValPayload, _ := payload.Encode(s.testSearchAttributeVal)
+			attrValPayload, _ := payload.Encode(testSearchAttributeVal)
 			upsertSearchAttr := &commonpb.SearchAttributes{
 				IndexedFields: map[string]*commonpb.Payload{
-					s.testSearchAttributeKey: attrValPayload,
+					testSearchAttributeKey: attrValPayload,
 				},
 			}
 			upsertCommand.GetUpsertWorkflowSearchAttributesCommandAttributes().SearchAttributes = upsertSearchAttr
@@ -1294,11 +1280,11 @@ func (s *AdvancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 			execution := resp.GetExecutions()[0]
 			retrievedSearchAttr := execution.SearchAttributes
 			if retrievedSearchAttr != nil && len(retrievedSearchAttr.GetIndexedFields()) > 0 {
-				searchValBytes := retrievedSearchAttr.GetIndexedFields()[s.testSearchAttributeKey]
+				searchValBytes := retrievedSearchAttr.GetIndexedFields()[testSearchAttributeKey]
 				var searchVal string
 				err = payload.Decode(searchValBytes, &searchVal)
 				s.NoError(err)
-				s.Equal(s.testSearchAttributeVal, searchVal)
+				s.Equal(testSearchAttributeVal, searchVal)
 				verified = true
 				break
 			}
@@ -1678,7 +1664,7 @@ func (s *AdvancedVisibilitySuite) testListResultForUpsertSearchAttributes(listRe
 			retrievedSearchAttr := execution.SearchAttributes
 			if retrievedSearchAttr != nil && len(retrievedSearchAttr.GetIndexedFields()) == 5 {
 				fields := retrievedSearchAttr.GetIndexedFields()
-				searchValBytes := fields[s.testSearchAttributeKey]
+				searchValBytes := fields[testSearchAttributeKey]
 				var searchVal string
 				err := payload.Decode(searchValBytes, &searchVal)
 				s.NoError(err)
@@ -1787,7 +1773,7 @@ func (s *AdvancedVisibilitySuite) TestUpsertWorkflowExecution_InvalidKey() {
 		WorkflowId: id,
 		RunId:      we.RunId,
 	})
-	if s.isElasticsearchEnabled {
+	if !testcore.UseSQLVisibility() {
 		s.ErrorContains(err, "BadSearchAttributes: search attribute INVALIDKEY is not defined")
 		s.EqualHistoryEvents(`
   1 WorkflowExecutionStarted

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -102,7 +102,7 @@ func (s *AdvancedVisibilitySuite) SetupSuite() {
 		// Allow the scavenger to remove any build ID regardless of when it was last default for a set.
 		dynamicconfig.RemovableBuildIdDurationSinceDefault.Key(): time.Microsecond,
 	}
-	s.FunctionalTestSuite.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
+	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
 
 	if !testcore.UseSQLVisibility() {
 		// To ensure that Elasticsearch won't return more than defaultPageSize documents,
@@ -127,7 +127,7 @@ func (s *AdvancedVisibilitySuite) SetupSuite() {
 
 func (s *AdvancedVisibilitySuite) TearDownSuite() {
 	s.sdkClient.Close()
-	s.FunctionalTestSuite.TearDownSuite()
+	s.FunctionalTestBase.TearDownSuite()
 }
 
 func (s *AdvancedVisibilitySuite) TestListOpenWorkflow() {

--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -81,7 +81,7 @@ func (s *ArchivalSuite) SetupSuite() {
 		dynamicconfig.ArchivalProcessorArchiveDelay.Key(): time.Duration(0),
 	}
 
-	s.FunctionalTestSuite.SetupSuiteWithDefaultCluster(
+	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(
 		testcore.WithDynamicConfigOverrides(dynamicConfigOverrides),
 		testcore.WithArchivalEnabled(),
 	)

--- a/tests/deployment_test.go
+++ b/tests/deployment_test.go
@@ -101,7 +101,7 @@ func (s *DeploymentSuite) SetupSuite() {
 		dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace.Key(): maxConcurrentBatchOps,
 	}
 
-	s.FunctionalTestSuite.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
+	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
 }
 
 func (s *DeploymentSuite) SetupTest() {

--- a/tests/dlq_test.go
+++ b/tests/dlq_test.go
@@ -127,7 +127,7 @@ func (s *DLQSuite) SetupSuite() {
 	s.dlqTasks = make(chan tasks.Task)
 	testPrefix := "dlq-test-terminal-wfts-"
 	s.failingWorkflowIDPrefix.Store(&testPrefix)
-	s.FunctionalTestSuite.SetupSuiteWithDefaultCluster(
+	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(
 		testcore.WithDynamicConfigOverrides(dynamicConfigOverrides),
 		testcore.WithFxOptionsForService(primitives.HistoryService,
 			fx.Populate(&s.dlq),
@@ -177,7 +177,7 @@ func (s *DLQSuite) SetupSuite() {
 
 func (s *DLQSuite) TearDownSuite() {
 	s.worker.Stop()
-	s.FunctionalTestSuite.TearDownSuite()
+	s.FunctionalTestBase.TearDownSuite()
 }
 
 func myWorkflow(workflow.Context) (string, error) {

--- a/tests/gethistory_test.go
+++ b/tests/gethistory_test.go
@@ -82,7 +82,7 @@ func (s *RawHistorySuite) SetupSuite() {
 	dynamicConfigOverrides := map[dynamicconfig.Key]any{
 		dynamicconfig.SendRawWorkflowHistory.Key(): true,
 	}
-	s.FunctionalTestSuite.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
+	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
 }
 
 func (s *GetHistoryFunctionalSuite) TestGetWorkflowExecutionHistory_All() {

--- a/tests/namespace_delete_test.go
+++ b/tests/namespace_delete_test.go
@@ -74,13 +74,7 @@ func (s *namespaceTestSuite) SetupSuite() {
 		dynamicconfig.TransferProcessorUpdateAckInterval.Key():   1 * time.Second,
 		dynamicconfig.VisibilityProcessorUpdateAckInterval.Key(): 1 * time.Second,
 	}
-
-	if testcore.UsingSQLAdvancedVisibility() {
-		s.SetupSuiteWithCluster("testdata/cluster.yaml", testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
-		s.Logger.Info(fmt.Sprintf("Running delete namespace tests with %s/%s persistence", testcore.TestFlags.PersistenceType, testcore.TestFlags.PersistenceDriver))
-	} else {
-		s.SetupSuiteWithCluster("testdata/es_cluster.yaml", testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
-	}
+	s.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
 }
 
 func (s *namespaceTestSuite) Test_NamespaceDelete_InvalidUTF8() {

--- a/tests/purge_dlq_tasks_api_test.go
+++ b/tests/purge_dlq_tasks_api_test.go
@@ -86,7 +86,7 @@ func (q *faultyDLQ) DeleteTasks(
 }
 
 func (s *PurgeDLQTasksSuite) SetupSuite() {
-	s.FunctionalTestSuite.SetupSuiteWithDefaultCluster(
+	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(
 		testcore.WithFxOptionsForService(primitives.HistoryService,
 			fx.Decorate(func(manager persistence.HistoryTaskQueueManager) persistence.HistoryTaskQueueManager {
 				s.dlq = &faultyDLQ{HistoryTaskQueueManager: manager}

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -86,16 +86,6 @@ func TestScheduleFunctionalSuite(t *testing.T) {
 	suite.Run(t, new(ScheduleFunctionalSuite))
 }
 
-func (s *ScheduleFunctionalSuite) SetupSuite() {
-	if testcore.UsingSQLAdvancedVisibility() {
-		s.FunctionalTestSuite.SetupSuiteWithCluster("testdata/cluster.yaml")
-		s.Logger.Info(fmt.Sprintf("Running schedule tests with %s/%s persistence", testcore.TestFlags.PersistenceType, testcore.TestFlags.PersistenceDriver))
-	} else {
-		s.FunctionalTestSuite.SetupSuiteWithCluster("testdata/es_cluster.yaml")
-		s.Logger.Info("Running schedule tests with Elasticsearch persistence")
-	}
-}
-
 func (s *ScheduleFunctionalSuite) SetupTest() {
 	s.FunctionalTestSuite.SetupTest()
 	s.dataConverter = testcore.NewTestDataConverter()

--- a/tests/testcore/flag.go
+++ b/tests/testcore/flag.go
@@ -49,10 +49,11 @@ func init() {
 	flag.StringVar(&TestFlags.FaultInjectionConfigFile, "FaultInjectionConfigFile", "", "fault injection config file location")
 }
 
-func UsingSQLAdvancedVisibility() bool {
+func UseSQLVisibility() bool {
 	switch TestFlags.PersistenceDriver {
 	case mysql.PluginName, postgresql.PluginName, postgresql.PluginNamePGX, sqlite.PluginName:
 		return true
+	// If the main storage is Cassandra, Elasticsearch is used for visibility.
 	default:
 		return false
 	}

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -258,7 +258,7 @@ func newClusterWithPersistenceTestBaseFactory(t *testing.T, options *TestCluster
 		indexName string
 		esClient  esclient.Client
 	)
-	if !UsingSQLAdvancedVisibility() && options.ESConfig != nil {
+	if !UseSQLVisibility() && options.ESConfig != nil {
 		// Randomize index name to avoid cross tests interference.
 		for k, v := range options.ESConfig.Indices {
 			options.ESConfig.Indices[k] = fmt.Sprintf("%v-%v", v, uuid.New())
@@ -543,7 +543,7 @@ func newArchiverBase(enabled bool, logger log.Logger) *ArchiverBase {
 func (tc *TestCluster) TearDownCluster() error {
 	errs := tc.host.Stop()
 	tc.testBase.TearDownWorkflowStore()
-	if !UsingSQLAdvancedVisibility() && tc.host.esConfig != nil {
+	if !UseSQLVisibility() && tc.host.esConfig != nil {
 		if err := deleteIndex(tc.host.esConfig, tc.host.logger); err != nil {
 			errs = multierr.Combine(errs, err)
 		}

--- a/tests/testdata/cluster.yaml
+++ b/tests/testdata/cluster.yaml
@@ -1,9 +1,0 @@
-enablearchival: true
-enablemetricscapture: true
-clusterno: 0
-historyconfig:
-  numhistoryshards: 4
-  numhistoryhosts: 1
-workerconfig:
-  enablearchiver: true
-  enablereplicator: true

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -90,7 +90,7 @@ func (s *Versioning3Suite) SetupSuite() {
 		dynamicconfig.MatchingNumTaskqueueReadPartitions.Key():  4,
 		dynamicconfig.MatchingNumTaskqueueWritePartitions.Key(): 4,
 	}
-	s.FunctionalTestSuite.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
+	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
 }
 
 func (s *Versioning3Suite) TestPinnedTask_NoProperPoller() {

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -123,7 +123,7 @@ func (s *VersioningIntegSuite) SetupSuite() {
 		// behaviour related to versioning
 		dynamicconfig.TaskQueueInfoByBuildIdTTL.Key(): 0 * time.Second,
 	}
-	s.FunctionalTestSuite.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
+	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
 }
 
 func (s *VersioningIntegSuite) SetupTest() {

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -135,17 +135,7 @@ func (s *AdvVisCrossDCTestSuite) SetupSuite() {
 		dynamicconfig.EnableTransitionHistory.Key(): s.enableTransitionHistory,
 	}
 
-	var fileName string
-	if testcore.UsingSQLAdvancedVisibility() {
-		// NOTE: can't use xdc_clusters.yaml here because it somehow interferes with the other xDC tests.
-		fileName = "../testdata/xdc_adv_vis_clusters.yaml"
-		s.isElasticsearchEnabled = false
-		s.logger.Info(fmt.Sprintf("Running xDC advanced visibility test with %s/%s persistence", testcore.TestFlags.PersistenceType, testcore.TestFlags.PersistenceDriver))
-	} else {
-		fileName = "../testdata/xdc_adv_vis_es_clusters.yaml"
-		s.isElasticsearchEnabled = true
-		s.logger.Info("Running xDC advanced visibility test with Elasticsearch persistence")
-	}
+	fileName := "../testdata/xdc_adv_vis_es_clusters.yaml"
 
 	if testcore.TestFlags.TestClusterConfigFile != "" {
 		fileName = testcore.TestFlags.TestClusterConfigFile
@@ -226,7 +216,7 @@ func (s *AdvVisCrossDCTestSuite) TestSearchAttributes() {
 
 	// Wait for namespace cache to pick the change
 	time.Sleep(cacheRefreshInterval) // nolint:forbidigo
-	if !s.isElasticsearchEnabled {
+	if testcore.UseSQLVisibility() {
 		// When Elasticsearch is enabled, the search attribute aliases are not used.
 		_, err = client1.UpdateNamespace(testcore.NewContext(), &workflowservice.UpdateNamespaceRequest{
 			Namespace: ns,

--- a/tests/xdc/test_data.go
+++ b/tests/xdc/test_data.go
@@ -31,9 +31,10 @@ import (
 )
 
 const (
-	numOfRetry           = 100
-	waitTimeInMs         = 400
-	waitForESToSettle    = 4 * time.Second // wait es shards for some time ensure data consistent
+	numOfRetry        = 100
+	waitTimeInMs      = 400
+	waitForESToSettle = 4 * time.Second // wait es shards for some time ensure data consistent
+	// TODO (alex): remove 5s buffer. Refresh interval is 1s now.
 	cacheRefreshInterval = testcore.NamespaceCacheRefreshInterval + 5*time.Second
 	testTimeout          = 30 * time.Second
 )


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Refactor: remove `cluster.yaml` config.

## Why?
<!-- Tell your future self why have you made these changes -->
It is the same as `es_cluster.yaml` but doesn't have `esConfig` section. The intent was to use this config file when Elasticsearch is not used. But this section is not used if SQL persistence is used, so there is no harm to always use `es_cluster.yaml`.

I am going to significantly decrease number of config files for functional tests (if not remove them all). This is small step in this direction.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.