### PR TITLE
Refactor: move all archival related scaffolding to ArchivalSuite

### DIFF
--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -78,9 +78,12 @@ func TestArchivalSuite(t *testing.T) {
 }
 
 func (s *ArchivalSuite) SetupSuite() {
-	dynamicConfigOverrides :=map[dynamicconfig.Key]any{
-			dynamicconfig.ArchivalProcessorArchiveDelay.Key(): time.Duration(0),
-		}s.FunctionalTestSuite.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides),
+	dynamicConfigOverrides := map[dynamicconfig.Key]any{
+		dynamicconfig.ArchivalProcessorArchiveDelay.Key(): time.Duration(0),
+	}
+
+	s.FunctionalTestSuite.SetupSuiteWithDefaultCluster(
+		testcore.WithDynamicConfigOverrides(dynamicConfigOverrides),
 		testcore.WithArchivalEnabled(),
 	)
 

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -149,7 +149,6 @@ type (
 
 	// WorkerConfig is the config for the worker service
 	WorkerConfig struct {
-		EnableArchiver   bool
 		EnableReplicator bool
 		NumWorkers       int
 		DisableWorker    bool // overrides NumWorkers

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -561,7 +561,7 @@ func (tc *TestCluster) TestBase() *persistencetests.TestBase {
 	return tc.testBase
 }
 
-func (tc *TestCluster) ArchivalBase() *ArchiverBase {
+func (tc *TestCluster) ArchiverBase() *ArchiverBase {
 	return tc.archiverBase
 }
 

--- a/tests/testdata/acquire_shard_deadline_exceeded_error.yaml
+++ b/tests/testdata/acquire_shard_deadline_exceeded_error.yaml
@@ -1,10 +1,8 @@
-enablearchival: false
 clusterno: 0
 historyconfig:
   numhistoryshards: 1
   numhistoryhosts: 1
 workerconfig:
-  enablearchiver: false
   enablereplicator: false
 faultInjection:
   targets:

--- a/tests/testdata/acquire_shard_eventual_success.yaml
+++ b/tests/testdata/acquire_shard_eventual_success.yaml
@@ -1,10 +1,8 @@
-enablearchival: false
 clusterno: 0
 historyconfig:
   numhistoryshards: 1
   numhistoryhosts: 1
 workerconfig:
-  enablearchiver: false
   enablereplicator: false
 faultInjection:
   targets:

--- a/tests/testdata/acquire_shard_ownership_lost_error.yaml
+++ b/tests/testdata/acquire_shard_ownership_lost_error.yaml
@@ -1,10 +1,8 @@
-enablearchival: false
 clusterno: 0
 historyconfig:
   numhistoryshards: 1
   numhistoryhosts: 1
 workerconfig:
-  enablearchiver: false
   enablereplicator: false
 faultInjection:
   targets:

--- a/tests/testdata/client_cluster.yaml
+++ b/tests/testdata/client_cluster.yaml
@@ -1,11 +1,8 @@
-enablearchival: false
-enablemetricscapture: true
 clusterno: 0
 historyconfig:
   numhistoryshards: 4
   numhistoryhosts: 1
 workerconfig:
-  enablearchiver: false
   enablereplicator: false
 esconfig:
   version: "${ES_VERSION}"

--- a/tests/testdata/es_cluster.yaml
+++ b/tests/testdata/es_cluster.yaml
@@ -1,11 +1,8 @@
-enablearchival: true
-enablemetricscapture: true
 clusterno: 0
 historyconfig:
   numhistoryshards: 4
   numhistoryhosts: 1
 workerconfig:
-  enablearchiver: true
   enablereplicator: true
 esconfig:
   version: "${ES_VERSION}"

--- a/tests/testdata/ndc_clusters.yaml
+++ b/tests/testdata/ndc_clusters.yaml
@@ -21,9 +21,7 @@
         initialFailoverVersion: 3
         rpcName: "frontend"
         rpcAddress: "nowhere3:7134"
-  enablearchival: false
   workerconfig:
-    enablearchiver: false
     enablereplicator: true
   clusterno: 0
   historyconfig:
@@ -60,9 +58,7 @@
         initialFailoverVersion: 3
         rpcName: "frontend"
         rpcAddress: "nowhere3:7134"
-  enablearchival: false
   workerconfig:
-    enablearchiver: false
     enablereplicator: true
   clusterno: 1
   historyconfig:
@@ -99,9 +95,7 @@
         initialFailoverVersion: 3
         rpcName: "frontend"
         rpcAddress: "nowhere3:7134"
-  enablearchival: false
   workerconfig:
-    enablearchiver: false
     enablereplicator: true
   clusterno: 2
   historyconfig:

--- a/tests/testdata/tls_cluster.yaml
+++ b/tests/testdata/tls_cluster.yaml
@@ -1,11 +1,8 @@
-enablearchival: false
-enablemetricscapture: true
 clusterno: 0
 historyconfig:
   numhistoryshards: 4
   numhistoryhosts: 1
 workerconfig:
-  enablearchiver: false
   enablereplicator: false
 generatemtls: true
 esconfig:

--- a/tests/testdata/xdc_adv_vis_clusters.yaml
+++ b/tests/testdata/xdc_adv_vis_clusters.yaml
@@ -10,9 +10,7 @@
         enabled: true
         initialFailoverVersion: 1
         rpcName: "frontend"
-  enablearchival: false
   workerconfig:
-    enablearchiver: false
     enablereplicator: true
   clusterno: 2
   historyconfig:
@@ -31,9 +29,7 @@
         enabled: true
         initialFailoverVersion: 2
         rpcName: "frontend"
-  enablearchival: false
   workerconfig:
-    enablearchiver: false
     enablereplicator: true
   clusterno: 3
   historyconfig:

--- a/tests/testdata/xdc_adv_vis_es_clusters.yaml
+++ b/tests/testdata/xdc_adv_vis_es_clusters.yaml
@@ -10,9 +10,7 @@
         enabled: true
         initialFailoverVersion: 1
         rpcName: "frontend"
-  enablearchival: false
   workerconfig:
-    enablearchiver: false
     enablereplicator: true
   clusterno: 2
   historyconfig:
@@ -38,9 +36,7 @@
         enabled: true
         initialFailoverVersion: 2
         rpcName: "frontend"
-  enablearchival: false
   workerconfig:
-    enablearchiver: false
     enablereplicator: true
   clusterno: 3
   historyconfig:

--- a/tests/testdata/xdc_clusters.yaml
+++ b/tests/testdata/xdc_clusters.yaml
@@ -1,9 +1,7 @@
 - clustermetadata:
     enableGlobalNamespace: true
     failoverVersionIncrement: 10
-  enablearchival: false
   workerconfig:
-    enablearchiver: false
     enablereplicator: true
   clusterno: 0
   historyconfig:
@@ -20,9 +18,7 @@
 - clustermetadata:
     enableGlobalNamespace: true
     failoverVersionIncrement: 10
-  enablearchival: false
   workerconfig:
-    enablearchiver: false
     enablereplicator: true
   clusterno: 1
   historyconfig:

--- a/tests/workflow_delete_execution_test.go
+++ b/tests/workflow_delete_execution_test.go
@@ -185,8 +185,8 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecution_CompetedWorkf
 				Execution: we,
 			},
 		)
-		var invalidArgumentErr *serviceerror.InvalidArgument
-		s.ErrorAs(err, &invalidArgumentErr)
+		var notFoundErr *serviceerror.NotFound
+		s.ErrorAs(err, &notFoundErr)
 		s.Nil(historyResponse)
 
 		s.Eventually(
@@ -300,8 +300,8 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecution_RunningWorkfl
 				Execution: we,
 			},
 		)
-		var invalidArgumentErr *serviceerror.InvalidArgument
-		s.ErrorAs(err, &invalidArgumentErr)
+		var notFoundErr *serviceerror.NotFound
+		s.ErrorAs(err, &notFoundErr)
 		s.Nil(historyResponse)
 
 		s.Eventually(
@@ -429,8 +429,8 @@ func (s *WorkflowDeleteExecutionSuite) TestDeleteWorkflowExecution_JustTerminate
 				Execution: we,
 			},
 		)
-		var invalidArgumentErr *serviceerror.InvalidArgument
-		s.ErrorAs(err, &invalidArgumentErr)
+		var notFoundErr *serviceerror.NotFound
+		s.ErrorAs(err, &notFoundErr)
 		s.Nil(historyResponse)
 
 		s.Eventually(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Refactor: move all archival related scaffolding to `ArchivalSuite`.

## Why?
<!-- Tell your future self why have you made these changes -->
There was some archival related code in `FunctionalTestBase` which is used only be `ArchivalSuite`. No reason to have it the base struct.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Removed `Skip` for one archival tests. Added `Eventually` there. Run it multiply times and it never failed. If it start fail, might be skipped again.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.