### PR TITLE
Emit queue heartbeat metric for monitoring queue processor liveness

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -734,6 +734,10 @@ var (
 		"shardinfo_scheduled_queue_lag",
 		WithDescription("A histogram across history shards for the difference between the earliest scheduled time of pending history tasks and current time."),
 	)
+	ShardInfoQueueHeartbeatDuration = NewTimerDef(
+		"shardinfo_queue_heartbeat_duration",
+		WithDescription("A histogram across history shard for the duration between two queue updateState calls."),
+	)
 	SyncShardFromRemoteCounter = NewCounterDef("syncshard_remote_count")
 	SyncShardFromRemoteFailure = NewCounterDef("syncshard_remote_failed")
 	FinalizerItemsCompleted    = NewCounterDef("finalizer_items_completed")

--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -161,11 +162,12 @@ func newTestContext(t *resourcetest.Test, eventsCache events.Cache, config Conte
 		lifecycleCancel:     lifecycleCancel,
 		queueMetricEmitter:  sync.Once{},
 
-		state:              contextStateAcquired,
-		engineFuture:       future.NewFuture[Engine](),
-		shardInfo:          config.ShardInfo,
-		remoteClusterInfos: make(map[string]*remoteClusterInfo),
-		handoverNamespaces: make(map[namespace.Name]*namespaceHandOverInfo),
+		state:                 contextStateAcquired,
+		engineFuture:          future.NewFuture[Engine](),
+		shardInfo:             config.ShardInfo,
+		remoteClusterInfos:    make(map[string]*remoteClusterInfo),
+		handoverNamespaces:    make(map[namespace.Name]*namespaceHandOverInfo),
+		queueLastHeatbeatTime: make(map[int]time.Time),
 
 		clusterMetadata:         clusterMetadata,
 		timeSource:              t.TimeSource,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Emit queue heartbeat duration metric

## Why?
<!-- Tell your future self why have you made these changes -->
- For monitoring if queue processor accidentally got shutdown due to a bug.
- We previously rely on queue backlog metric for this purpose, but queue ack level may not move and backlog could be keep increasing for some expected cases (e.g. a namespace get throttled or due to replication delay). We still want the lag metric to be visibility for understanding the backlog, but we need to new metric for monitoring queue liveness.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- WIP (will run server locally and check the metric)

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- Some extra metric load. But the increase should be small as each shard only emit one data pointer per queue every 5mins.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- NO.
