### PR TITLE
Add jitter to UnpauseActivity functions

### DIFF
--- a/service/history/api/unpauseactivity/api.go
+++ b/service/history/api/unpauseactivity/api.go
@@ -25,6 +25,7 @@ package unpauseactivity
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
@@ -99,12 +100,13 @@ func processUnpauseActivityRequest(
 		return &historyservice.UnpauseActivityResponse{}, nil
 	}
 
+	var jitter time.Duration
 	switch op := request.GetFrontendRequest().Operation.(type) {
 	case *workflowservice.UnpauseActivityByIdRequest_Resume:
-		return workflow.UnpauseActivityWithResume(shardContext, mutableState, ai, op.Resume.NoWait)
+		return workflow.UnpauseActivityWithResume(shardContext, mutableState, ai, op.Resume.NoWait, jitter)
 
 	case *workflowservice.UnpauseActivityByIdRequest_Reset_:
-		return workflow.UnpauseActivityWithReset(shardContext, mutableState, ai, op.Reset_.NoWait, op.Reset_.ResetHeartbeat)
+		return workflow.UnpauseActivityWithReset(shardContext, mutableState, ai, op.Reset_.NoWait, op.Reset_.ResetHeartbeat, jitter)
 	default:
 		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("The operation type %T is not supported", op))
 	}

--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -326,11 +326,7 @@ func regenerateActivityRetryTask(
 			scheduleTime = scheduleTime.Add(randomOffset)
 		}
 	}
-	if err := ms.RegenerateActivityRetryTask(activityInfo, scheduleTime); err != nil {
-		return err
-	}
-
-	return nil
+	return ms.RegenerateActivityRetryTask(activityInfo, scheduleTime)
 }
 
 func needRegenerateRetryTask(ai *persistencespb.ActivityInfo, scheduleNewRun bool) bool {

--- a/service/history/workflow/activity_test.go
+++ b/service/history/workflow/activity_test.go
@@ -282,7 +282,7 @@ func (s *activitySuite) TestUnpauseActivityWithResumeAcceptance() {
 	s.NotEqual(prevStamp, ai.Stamp, "ActivityInfo.Stamp should change")
 	s.Equal(true, ai.Paused, "ActivityInfo.Paused was not unpaused")
 	prevStamp = ai.Stamp
-	_, err = UnpauseActivityWithResume(s.mockShard, s.mutableState, ai, false)
+	_, err = UnpauseActivityWithResume(s.mockShard, s.mutableState, ai, false, 0)
 	s.NoError(err)
 
 	s.Equal(int32(1), ai.Attempt, "ActivityInfo.Attempt is shouldn't change")
@@ -303,7 +303,7 @@ func (s *activitySuite) TestUnpauseActivityWithNewRun() {
 	prevStamp = ai.Stamp
 	fakeScheduledTime := time.Now().UTC().Add(5 * time.Minute)
 	ai.ScheduledTime = timestamppb.New(fakeScheduledTime)
-	_, err = UnpauseActivityWithResume(s.mockShard, s.mutableState, ai, true)
+	_, err = UnpauseActivityWithResume(s.mockShard, s.mutableState, ai, true, 0)
 	s.NoError(err)
 
 	// scheduled time should be reset to
@@ -325,7 +325,7 @@ func (s *activitySuite) TestUnpauseActivityWithResetAcceptance() {
 	s.Equal(true, ai.Paused, "ActivityInfo.Paused was not unpaused")
 
 	prevStamp = ai.Stamp
-	_, err = UnpauseActivityWithReset(s.mockShard, s.mutableState, ai, false, true)
+	_, err = UnpauseActivityWithReset(s.mockShard, s.mutableState, ai, false, true, 0)
 	s.NoError(err)
 	s.Equal(int32(1), ai.Attempt, "ActivityInfo.Attempt is shouldn't change")
 	s.Equal(false, ai.Paused, "ActivityInfo.Paused was not unpaused")


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add a jitter (duration) to the UnpauseActivity functions.
## Why?
<!-- Tell your future self why have you made these changes -->
part of batch API work. It may be unsafe to unpause many activities at once.
Jitter allows to "spread" starting of unpause activities over a specified period of time.


## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
N/A

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
N/A