### PR TITLE
Nexus: Delete state machine on terminal state -- Part 3 (#6984)

### DIFF
--- a/components/nexusoperations/events.go
+++ b/components/nexusoperations/events.go
@@ -67,9 +67,11 @@ func (d CancelRequestedEventDefinition) Type() enumspb.EventType {
 }
 
 func (d CancelRequestedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+	_, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
 		return o.Cancel(node, event.EventTime.AsTime())
 	})
+
+	return err
 }
 
 func (d CancelRequestedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, _ map[enumspb.ResetReapplyExcludeType]struct{}) error {
@@ -88,13 +90,15 @@ func (d StartedEventDefinition) Type() enumspb.EventType {
 }
 
 func (d StartedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+	_, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
 		return TransitionStarted.Apply(o, EventStarted{
 			Time:       event.EventTime.AsTime(),
 			Node:       node,
 			Attributes: event.GetNexusOperationStartedEventAttributes(),
 		})
 	})
+
+	return err
 }
 
 func (d StartedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
@@ -111,12 +115,17 @@ func (d CompletedEventDefinition) IsWorkflowTaskTrigger() bool {
 }
 
 func (d CompletedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+	node, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
 		return TransitionSucceeded.Apply(o, EventSucceeded{
 			Time: event.EventTime.AsTime(),
 			Node: node,
 		})
 	})
+	if err != nil {
+		return err
+	}
+
+	return root.DeleteChild(node.Key)
 }
 
 func (d CompletedEventDefinition) Type() enumspb.EventType {
@@ -141,13 +150,18 @@ func (d FailedEventDefinition) Type() enumspb.EventType {
 }
 
 func (d FailedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+	node, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
 		return TransitionFailed.Apply(o, EventFailed{
 			Time:       event.EventTime.AsTime(),
 			Attributes: event.GetNexusOperationFailedEventAttributes(),
 			Node:       node,
 		})
 	})
+	if err != nil {
+		return err
+	}
+
+	return root.DeleteChild(node.Key)
 }
 
 func (d FailedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
@@ -168,12 +182,17 @@ func (d CanceledEventDefinition) Type() enumspb.EventType {
 }
 
 func (d CanceledEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+	node, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
 		return TransitionCanceled.Apply(o, EventCanceled{
 			Time: event.EventTime.AsTime(),
 			Node: node,
 		})
 	})
+	if err != nil {
+		return err
+	}
+
+	return root.DeleteChild(node.Key)
 }
 
 func (d CanceledEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
@@ -194,11 +213,16 @@ func (d TimedOutEventDefinition) Type() enumspb.EventType {
 }
 
 func (d TimedOutEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
+	node, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
 		return TransitionTimedOut.Apply(o, EventTimedOut{
 			Node: node,
 		})
 	})
+	if err != nil {
+		return err
+	}
+
+	return root.DeleteChild(node.Key)
 }
 
 func (d TimedOutEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, excludeTypes map[enumspb.ResetReapplyExcludeType]struct{}) error {
@@ -230,14 +254,21 @@ func RegisterEventDefinitions(reg *hsm.Registry) error {
 	return reg.RegisterEventDefinition(TimedOutEventDefinition{})
 }
 
-func transitionOperation(root *hsm.Node, event *historypb.HistoryEvent, fn func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error)) error {
+func transitionOperation(
+	root *hsm.Node,
+	event *historypb.HistoryEvent,
+	fn func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error),
+) (*hsm.Node, error) {
 	node, err := findOperationNode(root, event)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return hsm.MachineTransition(node, func(o Operation) (hsm.TransitionOutput, error) {
+	if err := hsm.MachineTransition(node, func(o Operation) (hsm.TransitionOutput, error) {
 		return fn(node, o)
-	})
+	}); err != nil {
+		return nil, err
+	}
+	return node, nil
 }
 
 func findOperationNode(root *hsm.Node, event *historypb.HistoryEvent) (*hsm.Node, error) {

--- a/components/nexusoperations/events_test.go
+++ b/components/nexusoperations/events_test.go
@@ -23,6 +23,7 @@
 package nexusoperations_test
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/service/history/hsm"
 	"go.temporal.io/server/service/history/hsm/hsmtest"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestCherryPick(t *testing.T) {
@@ -139,4 +141,99 @@ func TestCherryPick(t *testing.T) {
 			require.ErrorIs(t, err, hsm.ErrNotCherryPickable, "%T should not be cherrypickable when shouldExcludeNexusEvent=true", nexusOperation)
 		}
 	})
+}
+
+func TestTerminalStatesDeletion(t *testing.T) {
+	testCases := []struct {
+		name       string
+		def        hsm.EventDefinition
+		attributes interface{}
+	}{
+		{
+			name: "CompletedDeletesStateMachine",
+			def:  nexusoperations.CompletedEventDefinition{},
+			attributes: &historypb.NexusOperationCompletedEventAttributes{
+				ScheduledEventId: 0,
+			},
+		},
+		{
+			name: "FailedDeletesStateMachine",
+			def:  nexusoperations.FailedEventDefinition{},
+			attributes: &historypb.NexusOperationFailedEventAttributes{
+				ScheduledEventId: 0,
+			},
+		},
+		{
+			name: "CanceledDeletesStateMachine",
+			def:  nexusoperations.CanceledEventDefinition{},
+			attributes: &historypb.NexusOperationCanceledEventAttributes{
+				ScheduledEventId: 0,
+			},
+		},
+		{
+			name: "TimedOutDeletesStateMachine",
+			def:  nexusoperations.TimedOutEventDefinition{},
+			attributes: &historypb.NexusOperationTimedOutEventAttributes{
+				ScheduledEventId: 0,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := newOperationNode(t, &hsmtest.NodeBackend{}, mustNewScheduledEvent(time.Now(), time.Hour))
+			op, err := hsm.MachineData[nexusoperations.Operation](node)
+			require.NoError(t, err)
+			eventID, err := hsm.EventIDFromToken(op.ScheduledEventToken)
+			require.NoError(t, err)
+
+			// Update the event ID in attributes
+			switch a := tc.attributes.(type) {
+			case *historypb.NexusOperationCompletedEventAttributes:
+				a.ScheduledEventId = eventID
+			case *historypb.NexusOperationFailedEventAttributes:
+				a.ScheduledEventId = eventID
+			case *historypb.NexusOperationCanceledEventAttributes:
+				a.ScheduledEventId = eventID
+			case *historypb.NexusOperationTimedOutEventAttributes:
+				a.ScheduledEventId = eventID
+			}
+
+			event := &historypb.HistoryEvent{
+				EventTime: timestamppb.Now(),
+			}
+
+			switch d := tc.def.(type) {
+			case nexusoperations.CompletedEventDefinition:
+				event.EventType = d.Type()
+				event.Attributes = &historypb.HistoryEvent_NexusOperationCompletedEventAttributes{
+					NexusOperationCompletedEventAttributes: tc.attributes.(*historypb.NexusOperationCompletedEventAttributes),
+				}
+			case nexusoperations.FailedEventDefinition:
+				event.EventType = d.Type()
+				event.Attributes = &historypb.HistoryEvent_NexusOperationFailedEventAttributes{
+					NexusOperationFailedEventAttributes: tc.attributes.(*historypb.NexusOperationFailedEventAttributes),
+				}
+			case nexusoperations.CanceledEventDefinition:
+				event.EventType = d.Type()
+				event.Attributes = &historypb.HistoryEvent_NexusOperationCanceledEventAttributes{
+					NexusOperationCanceledEventAttributes: tc.attributes.(*historypb.NexusOperationCanceledEventAttributes),
+				}
+			case nexusoperations.TimedOutEventDefinition:
+				event.EventType = d.Type()
+				event.Attributes = &historypb.HistoryEvent_NexusOperationTimedOutEventAttributes{
+					NexusOperationTimedOutEventAttributes: tc.attributes.(*historypb.NexusOperationTimedOutEventAttributes),
+				}
+			default:
+				t.Fatalf("unknown event definition type: %T", tc.def)
+			}
+
+			err = tc.def.Apply(node.Parent, event)
+			require.NoError(t, err)
+
+			coll := nexusoperations.MachineCollection(node.Parent)
+			_, err = coll.Node(strconv.FormatInt(eventID, 10))
+			require.ErrorIs(t, err, hsm.ErrStateMachineNotFound)
+		})
+	}
 }

--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -209,37 +209,27 @@ func (ch *commandHandler) HandleCancelCommand(
 			Message: "empty CancelNexusOperationCommandAttributes",
 		}
 	}
+
 	coll := nexusoperations.MachineCollection(ms.HSM())
 	nodeID := strconv.FormatInt(attrs.ScheduledEventId, 10)
-	node, err := coll.Node(nodeID)
+	_, err := coll.Node(nodeID)
 	if err != nil {
 		if errors.Is(err, hsm.ErrStateMachineNotFound) {
-			return workflow.FailWorkflowTaskError{
-				Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES,
-				Message: fmt.Sprintf("requested cancelation for a non-existing operation with scheduled event ID of %d", attrs.ScheduledEventId),
-				// TODO(bergundy): Message: fmt.Sprintf("requested cancelation for a non-existing or already completed operation with scheduled event ID of %d", attrs.ScheduledEventId),
+			if !ms.HasAnyBufferedEvent(makeNexusOperationTerminalEventFilter(attrs.ScheduledEventId)) {
+				return workflow.FailWorkflowTaskError{
+					Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES,
+					Message: fmt.Sprintf("requested cancelation for a non-existing or already completed operation with scheduled event ID of %d", attrs.ScheduledEventId),
+				}
 			}
-		}
-		return err
-	}
-	// TODO(bergundy): Remove this when operation auto-deletes itself on terminal state.
-	// Operation may already be in a terminal state because it doesn't yet delete itself. We don't want to accept
-	// cancelation in this case.
-	op, err := hsm.MachineData[nexusoperations.Operation](node)
-	if err != nil {
-		return err
-	}
-	// The operation is already in a terminal state and the terminal NexusOperation event has not just been buffered.
-	// We allow the workflow to request canceling an operation that has just completed while a workflow task is in
-	// flight since it cannot know about the state of the operation.
-	// TODO(bergundy): When we support state machine deletion, this condition will have to change.
-	if !nexusoperations.TransitionCanceled.Possible(op) && !ms.HasAnyBufferedEvent(makeNexusOperationTerminalEventFilter(attrs.ScheduledEventId)) {
-		return workflow.FailWorkflowTaskError{
-			Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES,
-			Message: fmt.Sprintf("requested cancelation for an already complete operation with scheduled event ID of %d", attrs.ScheduledEventId),
+			// Fallthrough and apply the event, there's special logic that will handle state machine not found below.
+		} else {
+			return err
 		}
 	}
 
+	// Always create the event even if there's a buffered completion to avoid breaking replay in the SDK.
+	// The event will be applied before the completion since buffered events are reordered and put at the end of the
+	// batch, after command events from the workflow task.
 	event := ms.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED, func(he *historypb.HistoryEvent) {
 		he.Attributes = &historypb.HistoryEvent_NexusOperationCancelRequestedEventAttributes{
 			NexusOperationCancelRequestedEventAttributes: &historypb.NexusOperationCancelRequestedEventAttributes{
@@ -256,8 +246,11 @@ func (ch *commandHandler) HandleCancelCommand(
 	if errors.Is(err, hsm.ErrStateMachineAlreadyExists) {
 		return workflow.FailWorkflowTaskError{
 			Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES,
-			Message: fmt.Sprintf("cancelation was already requested for an operation with scheduled event ID of %d", attrs.ScheduledEventId),
+			Message: fmt.Sprintf("cancelation was already requested for an operation with scheduled event ID %d", attrs.ScheduledEventId),
 		}
+	} else if errors.Is(err, hsm.ErrStateMachineNotFound) {
+		// This may happen if there's a buffered completion. Ignore.
+		return nil
 	}
 
 	return err

--- a/components/nexusoperations/workflow/commands_test.go
+++ b/components/nexusoperations/workflow/commands_test.go
@@ -24,6 +24,7 @@ package workflow_test
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -448,7 +449,6 @@ func TestHandleScheduleCommand(t *testing.T) {
 		require.NotNil(t, child)
 		require.EqualExportedValues(t, userMetadata, event.UserMetadata)
 	})
-
 }
 
 func TestHandleCancelCommand(t *testing.T) {
@@ -476,6 +476,8 @@ func TestHandleCancelCommand(t *testing.T) {
 
 	t.Run("operation not found", func(t *testing.T) {
 		tcx := newTestContext(t, defaultConfig)
+		tcx.ms.EXPECT().HasAnyBufferedEvent(gomock.Any()).Return(false)
+
 		err := tcx.cancelHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 1, &commandpb.Command{
 			Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
 				RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
@@ -507,16 +509,18 @@ func TestHandleCancelCommand(t *testing.T) {
 		require.Equal(t, 1, len(tcx.history.Events))
 		event := tcx.history.Events[0]
 
-		coll := nexusoperations.MachineCollection(tcx.ms.HSM())
-		node, err := coll.Node(strconv.FormatInt(event.EventId, 10))
-		require.NoError(t, err)
-		op, err := coll.Data(strconv.FormatInt(event.EventId, 10))
-		require.NoError(t, err)
-		_, err = nexusoperations.TransitionSucceeded.Apply(op, nexusoperations.EventSucceeded{
-			Node: node,
+		// Complete the operation using CompletedEventDefinition to ensure proper deletion
+		err = nexusoperations.CompletedEventDefinition{}.Apply(tcx.ms.HSM(), &historypb.HistoryEvent{
+			EventId: event.EventId + 1,
+			Attributes: &historypb.HistoryEvent_NexusOperationCompletedEventAttributes{
+				NexusOperationCompletedEventAttributes: &historypb.NexusOperationCompletedEventAttributes{
+					ScheduledEventId: event.EventId,
+				},
+			},
 		})
 		require.NoError(t, err)
 
+		// Try to cancel - should fail since operation is deleted
 		err = tcx.cancelHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 1, &commandpb.Command{
 			Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
 				RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
@@ -548,16 +552,17 @@ func TestHandleCancelCommand(t *testing.T) {
 		require.Equal(t, 1, len(tcx.history.Events))
 		event := tcx.history.Events[0]
 
-		coll := nexusoperations.MachineCollection(tcx.ms.HSM())
-		node, err := coll.Node(strconv.FormatInt(event.EventId, 10))
-		require.NoError(t, err)
-		op, err := coll.Data(strconv.FormatInt(event.EventId, 10))
-		require.NoError(t, err)
-		_, err = nexusoperations.TransitionSucceeded.Apply(op, nexusoperations.EventSucceeded{
-			Node: node,
+		err = nexusoperations.CompletedEventDefinition{}.Apply(tcx.ms.HSM(), &historypb.HistoryEvent{
+			EventId: event.EventId + 1,
+			Attributes: &historypb.HistoryEvent_NexusOperationCompletedEventAttributes{
+				NexusOperationCompletedEventAttributes: &historypb.NexusOperationCompletedEventAttributes{
+					ScheduledEventId: event.EventId,
+				},
+			},
 		})
 		require.NoError(t, err)
 
+		// Try to cancel - should succeed because there's a buffered completion
 		err = tcx.cancelHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 1, &commandpb.Command{
 			Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
 				RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
@@ -566,7 +571,7 @@ func TestHandleCancelCommand(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		require.Equal(t, 2, len(tcx.history.Events)) // Only scheduled event should be recorded.
+		require.Equal(t, 2, len(tcx.history.Events)) // Both scheduled and cancel requested events should be recorded
 		crAttrs := tcx.history.Events[1].GetNexusOperationCancelRequestedEventAttributes()
 		require.Equal(t, event.EventId, crAttrs.ScheduledEventId)
 	})
@@ -622,4 +627,138 @@ func TestHandleCancelCommand(t *testing.T) {
 		require.NotNil(t, child)
 		userMetadata = nil
 	})
+}
+
+func TestOperationNodeDeletionOnTerminalEvents(t *testing.T) {
+	scheduleOperation := func(t *testing.T, tcx testContext) (scheduledEvent *historypb.HistoryEvent, nodeID string) {
+		err := tcx.scheduleHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 100}, 1, &commandpb.Command{
+			Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
+				ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
+					Endpoint:  "endpoint",
+					Service:   "service",
+					Operation: "op",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, tcx.history.Events, 1)
+		scheduledEvent = tcx.history.Events[0]
+
+		coll := nexusoperations.MachineCollection(tcx.ms.HSM())
+		nodeID = strconv.FormatInt(scheduledEvent.EventId, 10)
+		_, err = coll.Node(nodeID)
+		require.NoError(t, err)
+		return
+	}
+
+	applyTerminalEventAndAssertDeletion := func(
+		t *testing.T,
+		tcx testContext,
+		scheduledEventID int64,
+		eventType enumspb.EventType,
+		eventAttr interface{},
+		def hsm.EventDefinition,
+	) {
+		coll := nexusoperations.MachineCollection(tcx.ms.HSM())
+		nodeID := strconv.FormatInt(scheduledEventID, 10)
+
+		event := &historypb.HistoryEvent{
+			Version:   1,
+			EventId:   scheduledEventID + 1,
+			EventType: eventType,
+			EventTime: timestamppb.Now(),
+		}
+
+		switch eventType { //nolint:exhaustive
+		case enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED:
+			event.Attributes = &historypb.HistoryEvent_NexusOperationCompletedEventAttributes{
+				NexusOperationCompletedEventAttributes: eventAttr.(*historypb.NexusOperationCompletedEventAttributes),
+			}
+		case enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED:
+			event.Attributes = &historypb.HistoryEvent_NexusOperationFailedEventAttributes{
+				NexusOperationFailedEventAttributes: eventAttr.(*historypb.NexusOperationFailedEventAttributes),
+			}
+		case enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED:
+			event.Attributes = &historypb.HistoryEvent_NexusOperationCanceledEventAttributes{
+				NexusOperationCanceledEventAttributes: eventAttr.(*historypb.NexusOperationCanceledEventAttributes),
+			}
+		case enumspb.EVENT_TYPE_NEXUS_OPERATION_TIMED_OUT:
+			event.Attributes = &historypb.HistoryEvent_NexusOperationTimedOutEventAttributes{
+				NexusOperationTimedOutEventAttributes: eventAttr.(*historypb.NexusOperationTimedOutEventAttributes),
+			}
+		default:
+			panic(fmt.Sprintf("unexpected event type in test: %v", eventType))
+		}
+
+		require.NoError(t, def.Apply(tcx.ms.HSM(), event))
+
+		_, err := coll.Node(nodeID)
+		require.Error(t, err, "node should be deleted after terminal event")
+
+		tcx.ms.EXPECT().HasAnyBufferedEvent(gomock.Any()).Return(false)
+
+		err = tcx.cancelHandler(context.Background(), tcx.ms, commandValidator{maxPayloadSize: 1}, 2, &commandpb.Command{
+			Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
+				RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
+					ScheduledEventId: scheduledEventID,
+				},
+			},
+		})
+		var failWFTErr workflow.FailWorkflowTaskError
+		require.ErrorAs(t, err, &failWFTErr)
+		require.Equal(t, enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES, failWFTErr.Cause)
+		require.Len(t, tcx.history.Events, 1, "no new events after attempting to cancel a terminated operation")
+	}
+
+	cases := []struct {
+		name      string
+		eventType enumspb.EventType
+		eventAttr interface{}
+		eventDef  hsm.EventDefinition
+	}{
+		{
+			name:      "completed event deletes node",
+			eventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED,
+			eventAttr: &historypb.NexusOperationCompletedEventAttributes{},
+			eventDef:  nexusoperations.CompletedEventDefinition{},
+		},
+		{
+			name:      "failed event deletes node",
+			eventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED,
+			eventAttr: &historypb.NexusOperationFailedEventAttributes{},
+			eventDef:  nexusoperations.FailedEventDefinition{},
+		},
+		{
+			name:      "canceled event deletes node",
+			eventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED,
+			eventAttr: &historypb.NexusOperationCanceledEventAttributes{},
+			eventDef:  nexusoperations.CanceledEventDefinition{},
+		},
+		{
+			name:      "timed out event deletes node",
+			eventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_TIMED_OUT,
+			eventAttr: &historypb.NexusOperationTimedOutEventAttributes{},
+			eventDef:  nexusoperations.TimedOutEventDefinition{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tcx := newTestContext(t, defaultConfig)
+			scheduledEvent, _ := scheduleOperation(t, tcx)
+
+			switch a := tc.eventAttr.(type) {
+			case *historypb.NexusOperationCompletedEventAttributes:
+				a.ScheduledEventId = scheduledEvent.EventId
+			case *historypb.NexusOperationFailedEventAttributes:
+				a.ScheduledEventId = scheduledEvent.EventId
+			case *historypb.NexusOperationCanceledEventAttributes:
+				a.ScheduledEventId = scheduledEvent.EventId
+			case *historypb.NexusOperationTimedOutEventAttributes:
+				a.ScheduledEventId = scheduledEvent.EventId
+			}
+
+			applyTerminalEventAndAssertDeletion(t, tcx, scheduledEvent.EventId, tc.eventType, tc.eventAttr, tc.eventDef)
+		})
+	}
 }

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -55,6 +55,7 @@ import (
 	"go.temporal.io/server/components/callbacks"
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type NexusStateReplicationSuite struct {
@@ -490,6 +491,190 @@ func (s *NexusStateReplicationSuite) TestNexusCallbackReplicated() {
 		}, func(callback *workflowpb.CallbackInfo) bool {
 			return callback.State == enumspb.CALLBACK_STATE_SUCCEEDED
 		})
+	}
+}
+
+func (s *NexusStateReplicationSuite) TestNexusOperationBufferedCompletionReplicated() {
+	ctx := testcore.NewContext()
+	ns := s.createGlobalNamespace()
+	taskQueue := "tq"
+
+	allowCompletion := atomic.Bool{}
+	attemptCount := atomic.Int32{}
+
+	h := nexustest.Handler{
+		OnStartOperation: func(
+			ctx context.Context,
+			service, operation string,
+			input *nexus.LazyValue,
+			options nexus.StartOperationOptions,
+		) (nexus.HandlerStartOperationResult[any], error) {
+			attemptCount.Add(1)
+			if !allowCompletion.Load() {
+				return nil, nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "injected error to trigger operation retry")
+			}
+
+			return &nexus.HandlerStartOperationResultSync[any]{
+				Value: "",
+			}, nil
+		},
+	}
+
+	listenAddr := nexustest.AllocListenAddress()
+	nexustest.NewNexusServer(s.T(), listenAddr, h)
+
+	for _, cluster := range []*testcore.TestCluster{s.cluster1, s.cluster2} {
+		cluster.OverrideDynamicConfig(
+			s.T(),
+			nexusoperations.CallbackURLTemplate,
+			"http://"+s.cluster1.Host().FrontendHTTPAddress()+"/namespaces/{{.NamespaceName}}/nexus/callback",
+		)
+	}
+
+	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
+	for _, cl := range []operatorservice.OperatorServiceClient{s.cluster1.OperatorClient(), s.cluster2.OperatorClient()} {
+		_, err := cl.CreateNexusEndpoint(ctx, &operatorservice.CreateNexusEndpointRequest{
+			Spec: &nexuspb.EndpointSpec{
+				Name: endpointName,
+				Target: &nexuspb.EndpointTarget{
+					Variant: &nexuspb.EndpointTarget_External_{
+						External: &nexuspb.EndpointTarget_External{
+							Url: "http://" + listenAddr,
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+	}
+
+	sdkClient1, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  s.cluster1.Host().FrontendGRPCAddress(),
+		Namespace: ns,
+	})
+	s.NoError(err)
+	sdkClient2, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  s.cluster2.Host().FrontendGRPCAddress(),
+		Namespace: ns,
+	})
+	s.NoError(err)
+
+	run, err := sdkClient1.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+		TaskQueue: taskQueue,
+	}, "workflow")
+	s.NoError(err)
+
+	pollResp := s.pollWorkflowTask(ctx, s.cluster1.FrontendClient(), ns)
+
+	// Schedule operation and start timer to force next WFT
+	_, err = s.cluster1.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		Identity:  "test",
+		TaskToken: pollResp.TaskToken,
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION,
+				Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
+					ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
+						Endpoint:  endpointName,
+						Service:   "service",
+						Operation: "operation",
+					},
+				},
+			},
+			{
+				CommandType: enumspb.COMMAND_TYPE_START_TIMER,
+				Attributes: &commandpb.Command_StartTimerCommandAttributes{
+					StartTimerCommandAttributes: &commandpb.StartTimerCommandAttributes{
+						TimerId:            "timer-1",
+						StartToFireTimeout: durationpb.New(1 * time.Second),
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	// Poll next WFT which will be scheduled when timer fires
+	secondPollResp, err := s.cluster1.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+		Namespace: ns,
+		TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Identity:  "test",
+	})
+	s.NoError(err)
+	s.NotNil(secondPollResp)
+
+	// Find the scheduled event ID from history
+	var scheduledEventID int64
+	for _, e := range secondPollResp.History.Events {
+		if e.GetEventType() == enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED {
+			scheduledEventID = e.GetEventId()
+			break
+		}
+	}
+	s.Greater(scheduledEventID, int64(0))
+
+	// Allow operation to complete synchronously during next retry attempt
+	allowCompletion.Store(true)
+
+	// Wait for operation completion to be recorded
+	s.Eventually(func() bool {
+		desc, err := sdkClient1.DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
+		s.NoError(err)
+		return len(desc.PendingNexusOperations) == 0
+	}, 10*time.Second, 200*time.Millisecond)
+
+	// Try to cancel operation - should succeed since completion is buffered
+	_, err = s.cluster1.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		Identity:  "test",
+		TaskToken: secondPollResp.TaskToken,
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION,
+				Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
+					RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
+						ScheduledEventId: scheduledEventID,
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err, "Cancel request should be accepted when operation has buffered completion")
+
+	// Ensure no pending operations in passive cluster state
+	s.Eventually(func() bool {
+		desc, err := sdkClient2.DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
+		s.NoError(err)
+		return len(desc.PendingNexusOperations) == 0
+	}, 10*time.Second, 200*time.Millisecond)
+
+	finalPollResp := s.pollWorkflowTask(ctx, s.cluster1.FrontendClient(), ns)
+	_, err = s.cluster1.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		Identity:  "test",
+		TaskToken: finalPollResp.TaskToken,
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+					CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	// Verify history in both clusters
+	for _, sdkClient := range []sdkclient.Client{sdkClient1, sdkClient2} {
+		historyIterator := sdkClient.GetWorkflowHistory(ctx, run.GetID(), run.GetRunID(), false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+		var events []*historypb.HistoryEvent
+		for historyIterator.HasNext() {
+			e, err := historyIterator.Next()
+			s.NoError(err)
+			events = append(events, e)
+		}
+		s.ContainsHistoryEvents(`
+NexusOperationCancelRequested
+NexusOperationCompleted
+`, events)
 	}
 }
 


### PR DESCRIPTION
Reinstate what was reverted in https://github.com/temporalio/temporal/pull/7024

## What changed?

Add deletion calls for Nexus operation nodes once they reach a terminal
state (Completed, Failed, Canceled, Timed Out). Previously, terminal
operations lingered in the state machine, potentially causing confusion
and wasting resources. In addition, this PR addresses previously
existing TODOs related to node cleanup.

### Key Changes
- **Automatic Node Deletion on Terminal States:**  
Operations are now removed from the state machine immediately after they
complete, fail, cancel, or time out.
- **Handler Updates:**  
The command handlers (schedule and cancel) now reflect the new terminal
state deletion. Attempts to cancel an operation that has already reached
a terminal state will produce a clear, non-retryable error.
- **Tests for Terminal State Deletion:**  
  Introduced two new test suites:
- `TestTerminalStatesDeletion` to verify that applying terminal events
removes the operation node as expected.
- `TestOperationNodeDeletionOnTerminalEvents` to ensure no further
modifications (like cancelation) can be made after an operation is
terminal.

### Areas for Review Focus
1. **Deletion Semantics:** Verify that node removal is triggered
correctly for all terminal states and that no non-terminal states
inadvertently trigger deletion.
2. **Handler Consistency:** Ensure that the updated schedule/cancel
handlers function correctly when dealing with non-existent or already
terminated operations.
3. **Error Handling:** Confirm that attempts to modify a deleted
operation produce the intended error behavior.
4. **Test Coverage:** Review the newly added test suites to ensure all
terminal states and edge cases are thoroughly tested.

## Why?

- Prevent confusion and wasted resources by removing irrelevant
operation nodes.
- Prevent customers from experiencing workflow task failures
prematurely.

## How did you test it?

- **New Test Suites:**  
Added `TestTerminalStatesDeletion` and
`TestOperationNodeDeletionOnTerminalEvents` to specifically target and
validate the new deletion behavior.
- **Existing Tests:**  
  All pre-existing tests have been re-run to ensure no regressions.

## Potential risks

- **Assumptions About Completed Operations:**  
If any internal or external code implicitly relied on the presence of
completed operations, its assumptions might break. Such usage was never
officially supported.
  
## Documentation

No external or user-facing documentation changes are required since this
feature matches the intended design.

## Is hotfix candidate?

No. This change is an enhancement to internal logic and state
management, not a fix for a critical bug, so it should follow the normal
release process.

---------

Co-authored-by: Roey Berman <roey.berman@gmail.com>
Co-authored-by: Roey Berman <roey@temporal.io>

## What changed?
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
