### PR TITLE
populate params for unpause batch operation

### DIFF
--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -47,8 +47,6 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/sdk"
 	"golang.org/x/time/rate"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -342,7 +340,6 @@ func startTaskProcessor(
 						return err
 					})
 			case BatchTypeUnpauseActivities:
-				err = status.Errorf(codes.Unimplemented, "BatchTypeUnpauseActivities is not implemented")
 				operations := []*workflowservice.ManageActivityRequest_Operation{
 					{
 						OperationType: &workflowservice.ManageActivityRequest_Operation_Unpause{

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -49,6 +49,7 @@ import (
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 const (
@@ -342,6 +343,39 @@ func startTaskProcessor(
 					})
 			case BatchTypeUnpauseActivities:
 				err = status.Errorf(codes.Unimplemented, "BatchTypeUnpauseActivities is not implemented")
+				operations := []*workflowservice.ManageActivityRequest_Operation{
+					{
+						OperationType: &workflowservice.ManageActivityRequest_Operation_Unpause{
+							Unpause: &workflowservice.ManageActivityRequest_UnpauseActivityRequest{
+								Jitter: durationpb.New(batchParams.UnpauseActivitiesParams.Jitter),
+							}}},
+				}
+
+				if batchParams.UnpauseActivitiesParams.KeepAttempts == false {
+					// also reset the activity
+					resetOperation := &workflowservice.ManageActivityRequest_Operation{
+						OperationType: &workflowservice.ManageActivityRequest_Operation_Reset_{
+							Reset_: &workflowservice.ManageActivityRequest_ResetActivityRequest{
+								KeepPaused:     false,
+								ResetHeartbeat: batchParams.UnpauseActivitiesParams.ResetHeartbeat,
+							}}}
+
+					operations = append(operations, resetOperation)
+				}
+
+				err = processTask(ctx, limiter, task,
+					func(workflowID, runID string) error {
+						var err error
+						_, err = frontendClient.ManageActivity(ctx, &workflowservice.ManageActivityRequest{
+							Namespace:    batchParams.Namespace,
+							WorkflowId:   workflowID,
+							RunId:        runID,
+							ActivityType: batchParams.UnpauseActivitiesParams.ActivityType,
+							Operations:   operations,
+						})
+						return err
+					})
+
 			case BatchTypeUpdateOptions:
 				err = processTask(ctx, limiter, task,
 					func(workflowID, runID string) error {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Extract parameters from batch unpause activity request, convert them to ManageActivity params, and call ManageActivity API.

## Why?
<!-- Tell your future self why have you made these changes -->
To connect batch unpause to a single API.


## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
N/A
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No