### PR TITLE
Add unpause to reset activity

### DIFF
--- a/service/history/api/resetactivity/api.go
+++ b/service/history/api/resetactivity/api.go
@@ -54,7 +54,7 @@ func Invoke(
 			activityId := request.GetActivityId()
 
 			if err := workflow.ResetActivityById(
-				shardContext, mutableState, activityId, request.NoWait, request.ResetHeartbeat,
+				shardContext, mutableState, activityId, request.NoWait, request.ResetHeartbeat, false,
 			); err != nil {
 				return nil, err
 			}

--- a/service/history/workflow/activity_test.go
+++ b/service/history/workflow/activity_test.go
@@ -264,11 +264,27 @@ func (s *activitySuite) TestResetPausedActivityAcceptance() {
 	s.NotEqual(prevStamp, ai.Stamp, "ActivityInfo.Stamp should change")
 
 	prevStamp = ai.Stamp
-	err = ResetActivityById(s.mockShard, s.mutableState, ai.ActivityId, false, false)
+	err = ResetActivityById(s.mockShard, s.mutableState, ai.ActivityId, false, false, false)
 	s.NoError(err)
 	s.Equal(int32(1), ai.Attempt, "ActivityInfo.Attempt is not reset")
 	s.Equal(prevStamp, ai.Stamp, "ActivityInfo.Stamp should not change")
 	s.True(ai.Paused, "ActivityInfo.Paused shouldn't change by reset")
+}
+
+func (s *activitySuite) TestResetAndUnPauseActivityAcceptance() {
+	ai := s.AddActivityInfo()
+
+	prevStamp := ai.Stamp
+	err := PauseActivityById(s.mutableState, ai.ActivityId)
+	s.NoError(err)
+	s.NotEqual(prevStamp, ai.Stamp, "ActivityInfo.Stamp should change")
+
+	prevStamp = ai.Stamp
+	err = ResetActivityById(s.mockShard, s.mutableState, ai.ActivityId, false, false, true)
+	s.NoError(err)
+	s.Equal(int32(1), ai.Attempt, "ActivityInfo.Attempt is not reset")
+	s.NotEqual(prevStamp, ai.Stamp, "ActivityInfo.Stamp should change")
+	s.False(ai.Paused, "ActivityInfo.Paused shouldn't change by reset")
 }
 
 func (s *activitySuite) TestUnpauseActivityWithResumeAcceptance() {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Subj. Add "unpause" flag to the reset activity function.

## Why?
<!-- Tell your future self why have you made these changes -->
Feature request. Reset activity should be able to also unpause the activity.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test. Also add/modify func tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
N/A
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No