### PR TITLE
Only trigger Docker builds if explicitly enabled in repository config

### DIFF
--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -30,6 +30,7 @@ jobs:
           private_key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
 
       - name: Dispatch docker builds Github Action
+        if: ${{ vars.SHOULD_TRIGGER_DOCKER_BUILD == 'true' }}
         env:
           PAT: ${{ steps.generate_token.outputs.token }}
           PARENT_REPO: temporalio/docker-builds


### PR DESCRIPTION
This commit references a repository GitHub actions variable, `SHOULD_TRIGGER_DOCKER_BUILD`, and only triggers a docker build if this variable is set to `true`. This is to prevent forks of this repository from triggering builds in the `temporalio/docker-builds` repository, which is almost certainly not what those forks want.