### PR TITLE
Embed Unimplemented*ServiceServer instead of Unsafe*ServiceServer

### DIFF
--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -101,7 +101,7 @@ const (
 type (
 	// AdminHandler - gRPC handler interface for adminservice
 	AdminHandler struct {
-		adminservice.UnsafeAdminServiceServer
+		adminservice.UnimplementedAdminServiceServer
 
 		status int32
 

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -74,7 +74,7 @@ var _ OperatorHandler = (*OperatorHandlerImpl)(nil)
 type (
 	// OperatorHandlerImpl - gRPC handler interface for operator service
 	OperatorHandlerImpl struct {
-		operatorservice.UnsafeOperatorServiceServer
+		operatorservice.UnimplementedOperatorServiceServer
 
 		status int32
 

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -117,7 +117,7 @@ var (
 type (
 	// WorkflowHandler - gRPC handler interface for workflowservice
 	WorkflowHandler struct {
-		workflowservice.UnsafeWorkflowServiceServer
+		workflowservice.UnimplementedWorkflowServiceServer
 		status int32
 
 		tokenSerializer                               *tasktoken.Serializer

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -83,7 +83,7 @@ type (
 
 	// Handler - gRPC handler interface for historyservice
 	Handler struct {
-		historyservice.UnsafeHistoryServiceServer
+		historyservice.UnimplementedHistoryServiceServer
 
 		status int32
 

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -52,7 +52,7 @@ import (
 type (
 	// Handler - gRPC handler interface for matchingservice
 	Handler struct {
-		matchingservice.UnsafeMatchingServiceServer
+		matchingservice.UnimplementedMatchingServiceServer
 
 		engine            Engine
 		config            *Config


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Embed `Unimplemented*ServiceServer` instead of `Unsafe*ServiceServer` in all gRPC handlers.

## Why?
<!-- Tell your future self why have you made these changes -->
Embedding `Unimplemented*ServiceServer` is the right way to keep backward compatibility with future interface changes.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Build and run.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.