### PR TITLE
fix flaky xdc test TestCronWorkflowCompleteAndFailover

### DIFF
--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -255,7 +255,7 @@ func (s *xdcBaseSuite) failover(
 	client workflowservice.WorkflowServiceClient,
 ) {
 	// wait for replication task propagation
-	time.Sleep(4 * time.Second)
+	s.waitForClusterSynced()
 
 	// update namespace to fail over
 	updateReq := &workflowservice.UpdateNamespaceRequest{


### PR DESCRIPTION
## What changed?
Wait for clusters to be synced instead of using Sleep. Make sure second run is started before failover.

## Why?
Current implementation depends on the timing which is not reliable.

## How did you test it?
Repeatedly run the test locally and no failure found.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
