### PR TITLE
Remove read workflow API during namespace handover

### DIFF
--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -77,32 +77,22 @@ var (
 	// that have `namespace` or `task_token` field in the request object.
 	allowedNamespaceStatesDefault = []enumspb.NamespaceState{enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED}
 
+	// DO NOT allow workflow data read during namespace handover to prevent read-after-write inconsistency.
 	allowedMethodsDuringHandover = map[string]struct{}{
-		"DescribeNamespace":                  {},
-		"UpdateNamespace":                    {},
-		"GetReplicationMessages":             {},
-		"ReplicateEventsV2":                  {},
-		"GetWorkflowExecutionRawHistory":     {},
-		"GetWorkflowExecutionRawHistoryV2":   {},
-		"GetWorkflowExecutionHistory":        {},
-		"GetWorkflowExecutionHistoryReverse": {},
-		"DescribeWorkflowExecution":          {},
-		"DescribeTaskQueue":                  {},
-		"ListTaskQueuePartitions":            {},
-		"ListOpenWorkflowExecutions":         {},
-		"ListClosedWorkflowExecutions":       {},
-		"ListWorkflowExecutions":             {},
-		"ListArchivedWorkflowExecutions":     {},
-		"ScanWorkflowExecutions":             {},
-		"CountWorkflowExecutions":            {},
-		"DescribeSchedule":                   {},
-		"ListScheduleMatchingTimes":          {},
-		"ListSchedules":                      {},
-		"GetWorkerBuildIdCompatibility":      {},
-		"GetWorkerVersioningRules":           {},
-		"GetWorkerTaskReachability":          {},
-		"DescribeBatchOperation":             {},
-		"ListBatchOperations":                {},
+		"DescribeNamespace":                {},
+		"UpdateNamespace":                  {},
+		"GetReplicationMessages":           {},
+		"ReplicateEventsV2":                {},
+		"GetWorkflowExecutionRawHistory":   {},
+		"GetWorkflowExecutionRawHistoryV2": {}, // This is only internal usage.
+		"ListOpenWorkflowExecutions":       {},
+		"ListClosedWorkflowExecutions":     {},
+		"ListWorkflowExecutions":           {},
+		"ListArchivedWorkflowExecutions":   {},
+		"ScanWorkflowExecutions":           {},
+		"CountWorkflowExecutions":          {},
+		"ListSchedules":                    {},
+		"ListBatchOperations":              {},
 	}
 )
 


### PR DESCRIPTION
## What changed?
Remove read workflow API during namespace handover

## Why?
Read workflow data during namespace handover could lead to read-after-write inconsistency.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
