### PR TITLE
Retry tests with previous attempt args if more than 10 tests fail

### DIFF
--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -314,8 +314,10 @@ func Main() {
 		}
 		// Don't rerun if there's more than 10 failures in a single suite.
 		if len(failures) > 10 && retry < r.retries {
-			log.Printf("will not rerun tests, number of failures exceeds configured threshold (%d/%d)", len(failures), 10)
-			break
+			log.Printf(
+				"number of failures exceeds configured threshold (%d/%d) for narrowing down tests to retry, retrying with previous attempt's args",
+				len(failures), 10)
+			continue
 		}
 		args = stripRunFromArgs(args)
 		for i, failure := range failures {

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -312,7 +312,7 @@ func Main() {
 		if len(failures) == 0 {
 			log.Fatalf("tests failed but no failures have been detected, not rerunning tests")
 		}
-		// Don't rerun if there's more than 10 failures in a single suite.
+		// Rerun all tests from previous attempt if there's more than 10 failures in a single suite.
 		if len(failures) > 10 && retry < r.retries {
 			log.Printf(
 				"number of failures exceeds configured threshold (%d/%d) for narrowing down tests to retry, retrying with previous attempt's args",


### PR DESCRIPTION
Previous behavior was to not retry if number of failures was more than 10. We want to be more forgiving.