### PR TITLE
Workflow Update: check registryClearedErr in a proper place

### DIFF
--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -239,7 +239,7 @@ func (u *Update) WaitLifecycleStage(
 			return nil, ctx.Err()
 		}
 
-		// If err is not coming from stCtx, then it means that the error is coming from the future itself,
+		// If err is not coming from stCtx, then it means that the error is coming from the future itself.
 		// If this err is not registryClearedErr, then it needs to be returned to the caller.
 		if !errors.Is(err, stCtx.Err()) && !errors.Is(err, registryClearedErr) {
 			return nil, err

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -31,7 +31,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
@@ -1326,16 +1325,16 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_ValidateWorkerMessages() {
 			_, err := poller.PollAndProcessWorkflowTask()
 			updateResult := <-updateResultCh
 			if tc.RespondWorkflowTaskError != "" {
-				require.Error(s.T(), err, "RespondWorkflowTaskCompleted should return an error contains `%v`", tc.RespondWorkflowTaskError)
-				require.Contains(s.T(), err.Error(), tc.RespondWorkflowTaskError)
+				s.Error(err, "RespondWorkflowTaskCompleted should return an error contains `%v`", tc.RespondWorkflowTaskError)
+				s.Contains(err.Error(), tc.RespondWorkflowTaskError)
 
 				// When worker returns validation error, API caller got timeout error.
-				require.Error(s.T(), updateResult.err)
-				require.True(s.T(), common.IsContextDeadlineExceededErr(updateResult.err), updateResult.err.Error())
-				require.Nil(s.T(), updateResult.response)
+				s.Error(updateResult.err)
+				s.True(common.IsContextDeadlineExceededErr(updateResult.err), updateResult.err.Error())
+				s.Nil(updateResult.response)
 			} else {
-				require.NoError(s.T(), err)
-				require.NoError(s.T(), updateResult.err)
+				s.NoError(err)
+				s.NoError(updateResult.err)
 			}
 		})
 	}
@@ -1394,9 +1393,9 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_StickySpeculativeWorkflowTask_A
 								Messages: s.UpdateAcceptCompleteMessages(tv, updRequestMsg),
 							}, nil
 						})
-				require.NoError(s.T(), err)
-				require.NotNil(s.T(), res)
-				require.EqualValues(s.T(), 0, res.ResetHistoryEventId)
+				s.NoError(err)
+				s.NotNil(res)
+				s.EqualValues(0, res.ResetHistoryEventId)
 			}()
 
 			// This is to make sure that sticky poller above reached server first.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Moved check for `registryClearedErr` out of `if u.accepted.Ready()...` block.

## Why?
<!-- Tell your future self why have you made these changes -->
Stay tuned! :-)

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run flaky test 1000 times.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.
