### PR TITLE
OTEL annotates gRPC responses

### DIFF
--- a/common/rpc/interceptor/logtags/admin_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/admin_service_server_gen.go
@@ -31,128 +31,212 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-func (wt *WorkflowTags) extractFromAdminServiceServerRequest(req any) []tag.Tag {
-	switch r := req.(type) {
+func (wt *WorkflowTags) extractFromAdminServiceServerPayload(payload any) []tag.Tag {
+	switch r := payload.(type) {
 	case *adminservice.AddOrUpdateRemoteClusterRequest:
+		return nil
+	case *adminservice.AddOrUpdateRemoteClusterResponse:
 		return nil
 	case *adminservice.AddSearchAttributesRequest:
 		return nil
+	case *adminservice.AddSearchAttributesResponse:
+		return nil
 	case *adminservice.AddTasksRequest:
+		return nil
+	case *adminservice.AddTasksResponse:
 		return nil
 	case *adminservice.CancelDLQJobRequest:
 		return nil
+	case *adminservice.CancelDLQJobResponse:
+		return nil
 	case *adminservice.CloseShardRequest:
 		return nil
+	case *adminservice.CloseShardResponse:
+		return nil
 	case *adminservice.DeepHealthCheckRequest:
+		return nil
+	case *adminservice.DeepHealthCheckResponse:
 		return nil
 	case *adminservice.DeleteWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *adminservice.DeleteWorkflowExecutionResponse:
+		return nil
 	case *adminservice.DescribeClusterRequest:
 		return nil
+	case *adminservice.DescribeClusterResponse:
+		return nil
 	case *adminservice.DescribeDLQJobRequest:
+		return nil
+	case *adminservice.DescribeDLQJobResponse:
 		return nil
 	case *adminservice.DescribeHistoryHostRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *adminservice.DescribeHistoryHostResponse:
+		return nil
 	case *adminservice.DescribeMutableStateRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *adminservice.DescribeMutableStateResponse:
+		return nil
 	case *adminservice.DescribeTaskQueuePartitionRequest:
 		return nil
+	case *adminservice.DescribeTaskQueuePartitionResponse:
+		return nil
 	case *adminservice.ForceUnloadTaskQueuePartitionRequest:
+		return nil
+	case *adminservice.ForceUnloadTaskQueuePartitionResponse:
 		return nil
 	case *adminservice.GenerateLastHistoryReplicationTasksRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *adminservice.GenerateLastHistoryReplicationTasksResponse:
+		return nil
 	case *adminservice.GetDLQMessagesRequest:
+		return nil
+	case *adminservice.GetDLQMessagesResponse:
 		return nil
 	case *adminservice.GetDLQReplicationMessagesRequest:
 		return nil
+	case *adminservice.GetDLQReplicationMessagesResponse:
+		return nil
 	case *adminservice.GetDLQTasksRequest:
+		return nil
+	case *adminservice.GetDLQTasksResponse:
 		return nil
 	case *adminservice.GetNamespaceRequest:
 		return nil
+	case *adminservice.GetNamespaceResponse:
+		return nil
 	case *adminservice.GetNamespaceReplicationMessagesRequest:
+		return nil
+	case *adminservice.GetNamespaceReplicationMessagesResponse:
 		return nil
 	case *adminservice.GetReplicationMessagesRequest:
 		return nil
+	case *adminservice.GetReplicationMessagesResponse:
+		return nil
 	case *adminservice.GetSearchAttributesRequest:
+		return nil
+	case *adminservice.GetSearchAttributesResponse:
 		return nil
 	case *adminservice.GetShardRequest:
 		return nil
+	case *adminservice.GetShardResponse:
+		return nil
 	case *adminservice.GetTaskQueueTasksRequest:
+		return nil
+	case *adminservice.GetTaskQueueTasksResponse:
 		return nil
 	case *adminservice.GetWorkflowExecutionRawHistoryRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *adminservice.GetWorkflowExecutionRawHistoryResponse:
+		return nil
 	case *adminservice.GetWorkflowExecutionRawHistoryV2Request:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *adminservice.GetWorkflowExecutionRawHistoryV2Response:
+		return nil
 	case *adminservice.ImportWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *adminservice.ImportWorkflowExecutionResponse:
+		return nil
 	case *adminservice.ListClusterMembersRequest:
+		return nil
+	case *adminservice.ListClusterMembersResponse:
 		return nil
 	case *adminservice.ListClustersRequest:
 		return nil
+	case *adminservice.ListClustersResponse:
+		return nil
 	case *adminservice.ListHistoryTasksRequest:
+		return nil
+	case *adminservice.ListHistoryTasksResponse:
 		return nil
 	case *adminservice.ListQueuesRequest:
 		return nil
+	case *adminservice.ListQueuesResponse:
+		return nil
 	case *adminservice.MergeDLQMessagesRequest:
+		return nil
+	case *adminservice.MergeDLQMessagesResponse:
 		return nil
 	case *adminservice.MergeDLQTasksRequest:
 		return nil
+	case *adminservice.MergeDLQTasksResponse:
+		return nil
 	case *adminservice.PurgeDLQMessagesRequest:
 		return nil
+	case *adminservice.PurgeDLQMessagesResponse:
+		return nil
 	case *adminservice.PurgeDLQTasksRequest:
+		return nil
+	case *adminservice.PurgeDLQTasksResponse:
 		return nil
 	case *adminservice.ReapplyEventsRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *adminservice.ReapplyEventsResponse:
+		return nil
 	case *adminservice.RebuildMutableStateRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *adminservice.RebuildMutableStateResponse:
+		return nil
 	case *adminservice.RefreshWorkflowTasksRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *adminservice.RefreshWorkflowTasksResponse:
+		return nil
 	case *adminservice.RemoveRemoteClusterRequest:
+		return nil
+	case *adminservice.RemoveRemoteClusterResponse:
 		return nil
 	case *adminservice.RemoveSearchAttributesRequest:
 		return nil
+	case *adminservice.RemoveSearchAttributesResponse:
+		return nil
 	case *adminservice.RemoveTaskRequest:
+		return nil
+	case *adminservice.RemoveTaskResponse:
 		return nil
 	case *adminservice.ResendReplicationTasksRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
+	case *adminservice.ResendReplicationTasksResponse:
+		return nil
 	case *adminservice.SyncWorkflowStateRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *adminservice.SyncWorkflowStateResponse:
+		return nil
 	default:
 		return nil
 	}

--- a/common/rpc/interceptor/logtags/admin_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/admin_service_server_gen.go
@@ -31,8 +31,8 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-func (wt *WorkflowTags) extractFromAdminServiceServerPayload(payload any) []tag.Tag {
-	switch r := payload.(type) {
+func (wt *WorkflowTags) extractFromAdminServiceServerMessage(message any) []tag.Tag {
+	switch r := message.(type) {
 	case *adminservice.AddOrUpdateRemoteClusterRequest:
 		return nil
 	case *adminservice.AddOrUpdateRemoteClusterResponse:

--- a/common/rpc/interceptor/logtags/history_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/history_service_server_gen.go
@@ -31,8 +31,8 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-func (wt *WorkflowTags) extractFromHistoryServiceServerPayload(payload any) []tag.Tag {
-	switch r := payload.(type) {
+func (wt *WorkflowTags) extractFromHistoryServiceServerMessage(message any) []tag.Tag {
+	switch r := message.(type) {
 	case *historyservice.AddTasksRequest:
 		return nil
 	case *historyservice.AddTasksResponse:

--- a/common/rpc/interceptor/logtags/history_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/history_service_server_gen.go
@@ -31,129 +31,201 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-func (wt *WorkflowTags) extractFromHistoryServiceServerRequest(req any) []tag.Tag {
-	switch r := req.(type) {
+func (wt *WorkflowTags) extractFromHistoryServiceServerPayload(payload any) []tag.Tag {
+	switch r := payload.(type) {
 	case *historyservice.AddTasksRequest:
 		return nil
+	case *historyservice.AddTasksResponse:
+		return nil
 	case *historyservice.CloseShardRequest:
+		return nil
+	case *historyservice.CloseShardResponse:
 		return nil
 	case *historyservice.CompleteNexusOperationRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetCompletion().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetCompletion().GetRunId()),
 		}
+	case *historyservice.CompleteNexusOperationResponse:
+		return nil
 	case *historyservice.DeepHealthCheckRequest:
 		return nil
+	case *historyservice.DeepHealthCheckResponse:
+		return nil
 	case *historyservice.DeleteDLQTasksRequest:
+		return nil
+	case *historyservice.DeleteDLQTasksResponse:
 		return nil
 	case *historyservice.DeleteWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.DeleteWorkflowExecutionResponse:
+		return nil
 	case *historyservice.DeleteWorkflowVisibilityRecordRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *historyservice.DeleteWorkflowVisibilityRecordResponse:
+		return nil
 	case *historyservice.DescribeHistoryHostRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.DescribeHistoryHostResponse:
+		return nil
 	case *historyservice.DescribeMutableStateRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *historyservice.DescribeMutableStateResponse:
+		return nil
 	case *historyservice.DescribeWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetRequest().GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRequest().GetExecution().GetRunId()),
 		}
+	case *historyservice.DescribeWorkflowExecutionResponse:
+		return nil
 	case *historyservice.ExecuteMultiOperationRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 		}
+	case *historyservice.ExecuteMultiOperationResponse:
+		return nil
 	case *historyservice.ForceDeleteWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetRequest().GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRequest().GetExecution().GetRunId()),
 		}
+	case *historyservice.ForceDeleteWorkflowExecutionResponse:
+		return nil
 	case *historyservice.GenerateLastHistoryReplicationTasksRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *historyservice.GenerateLastHistoryReplicationTasksResponse:
+		return nil
 	case *historyservice.GetDLQMessagesRequest:
+		return nil
+	case *historyservice.GetDLQMessagesResponse:
 		return nil
 	case *historyservice.GetDLQReplicationMessagesRequest:
 		return nil
+	case *historyservice.GetDLQReplicationMessagesResponse:
+		return nil
 	case *historyservice.GetDLQTasksRequest:
+		return nil
+	case *historyservice.GetDLQTasksResponse:
 		return nil
 	case *historyservice.GetMutableStateRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *historyservice.GetMutableStateResponse:
+		return []tag.Tag{
+			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
+			tag.WorkflowRunID(r.GetExecution().GetRunId()),
+		}
 	case *historyservice.GetReplicationMessagesRequest:
+		return nil
+	case *historyservice.GetReplicationMessagesResponse:
 		return nil
 	case *historyservice.GetReplicationStatusRequest:
 		return nil
+	case *historyservice.GetReplicationStatusResponse:
+		return nil
 	case *historyservice.GetShardRequest:
+		return nil
+	case *historyservice.GetShardResponse:
 		return nil
 	case *historyservice.GetWorkflowExecutionHistoryRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetRequest().GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRequest().GetExecution().GetRunId()),
 		}
+	case *historyservice.GetWorkflowExecutionHistoryResponse:
+		return nil
 	case *historyservice.GetWorkflowExecutionHistoryReverseRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetRequest().GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRequest().GetExecution().GetRunId()),
 		}
+	case *historyservice.GetWorkflowExecutionHistoryReverseResponse:
+		return nil
 	case *historyservice.GetWorkflowExecutionRawHistoryRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetRequest().GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRequest().GetExecution().GetRunId()),
 		}
+	case *historyservice.GetWorkflowExecutionRawHistoryResponse:
+		return nil
 	case *historyservice.GetWorkflowExecutionRawHistoryV2Request:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetRequest().GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRequest().GetExecution().GetRunId()),
 		}
+	case *historyservice.GetWorkflowExecutionRawHistoryV2Response:
+		return nil
 	case *historyservice.ImportWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *historyservice.ImportWorkflowExecutionResponse:
+		return nil
 	case *historyservice.InvokeStateMachineMethodRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
+	case *historyservice.InvokeStateMachineMethodResponse:
+		return nil
 	case *historyservice.IsActivityTaskValidRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *historyservice.IsActivityTaskValidResponse:
+		return nil
 	case *historyservice.IsWorkflowTaskValidRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *historyservice.IsWorkflowTaskValidResponse:
+		return nil
 	case *historyservice.ListQueuesRequest:
+		return nil
+	case *historyservice.ListQueuesResponse:
 		return nil
 	case *historyservice.ListTasksRequest:
 		return nil
+	case *historyservice.ListTasksResponse:
+		return nil
 	case *historyservice.MergeDLQMessagesRequest:
+		return nil
+	case *historyservice.MergeDLQMessagesResponse:
 		return nil
 	case *historyservice.PauseActivityRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetFrontendRequest().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetFrontendRequest().GetRunId()),
 		}
+	case *historyservice.PauseActivityResponse:
+		return nil
 	case *historyservice.PollMutableStateRequest:
+		return []tag.Tag{
+			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
+			tag.WorkflowRunID(r.GetExecution().GetRunId()),
+		}
+	case *historyservice.PollMutableStateResponse:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
@@ -163,157 +235,237 @@ func (wt *WorkflowTags) extractFromHistoryServiceServerRequest(req any) []tag.Ta
 			tag.WorkflowID(r.GetRequest().GetUpdateRef().GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRequest().GetUpdateRef().GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.PollWorkflowExecutionUpdateResponse:
+		return nil
 	case *historyservice.PurgeDLQMessagesRequest:
+		return nil
+	case *historyservice.PurgeDLQMessagesResponse:
 		return nil
 	case *historyservice.QueryWorkflowRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetRequest().GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRequest().GetExecution().GetRunId()),
 		}
+	case *historyservice.QueryWorkflowResponse:
+		return nil
 	case *historyservice.ReapplyEventsRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetRequest().GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRequest().GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.ReapplyEventsResponse:
+		return nil
 	case *historyservice.RebuildMutableStateRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *historyservice.RebuildMutableStateResponse:
+		return nil
 	case *historyservice.RecordActivityTaskHeartbeatRequest:
 		return wt.fromTaskToken(r.GetHeartbeatRequest().GetTaskToken())
+	case *historyservice.RecordActivityTaskHeartbeatResponse:
+		return nil
 	case *historyservice.RecordActivityTaskStartedRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.RecordActivityTaskStartedResponse:
+		return nil
 	case *historyservice.RecordChildExecutionCompletedRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetParentExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetParentExecution().GetRunId()),
 		}
+	case *historyservice.RecordChildExecutionCompletedResponse:
+		return nil
 	case *historyservice.RecordWorkflowTaskStartedRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.RecordWorkflowTaskStartedResponse:
+		return nil
 	case *historyservice.RefreshWorkflowTasksRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetRequest().GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRequest().GetExecution().GetRunId()),
 		}
+	case *historyservice.RefreshWorkflowTasksResponse:
+		return nil
 	case *historyservice.RemoveSignalMutableStateRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.RemoveSignalMutableStateResponse:
+		return nil
 	case *historyservice.RemoveTaskRequest:
+		return nil
+	case *historyservice.RemoveTaskResponse:
 		return nil
 	case *historyservice.ReplicateEventsV2Request:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.ReplicateEventsV2Response:
+		return nil
 	case *historyservice.ReplicateWorkflowStateRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowState().GetExecutionInfo().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowState().GetExecutionState().GetRunId()),
 		}
+	case *historyservice.ReplicateWorkflowStateResponse:
+		return nil
 	case *historyservice.RequestCancelWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetCancelRequest().GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetCancelRequest().GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.RequestCancelWorkflowExecutionResponse:
+		return nil
 	case *historyservice.ResetActivityRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetFrontendRequest().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetFrontendRequest().GetRunId()),
 		}
+	case *historyservice.ResetActivityResponse:
+		return nil
 	case *historyservice.ResetStickyTaskQueueRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *historyservice.ResetStickyTaskQueueResponse:
+		return nil
 	case *historyservice.ResetWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetResetRequest().GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetResetRequest().GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.ResetWorkflowExecutionResponse:
+		return []tag.Tag{
+			tag.WorkflowRunID(r.GetRunId()),
+		}
 	case *historyservice.RespondActivityTaskCanceledRequest:
 		return wt.fromTaskToken(r.GetCancelRequest().GetTaskToken())
+	case *historyservice.RespondActivityTaskCanceledResponse:
+		return nil
 	case *historyservice.RespondActivityTaskCompletedRequest:
 		return wt.fromTaskToken(r.GetCompleteRequest().GetTaskToken())
+	case *historyservice.RespondActivityTaskCompletedResponse:
+		return nil
 	case *historyservice.RespondActivityTaskFailedRequest:
 		return wt.fromTaskToken(r.GetFailedRequest().GetTaskToken())
+	case *historyservice.RespondActivityTaskFailedResponse:
+		return nil
 	case *historyservice.RespondWorkflowTaskCompletedRequest:
 		return wt.fromTaskToken(r.GetCompleteRequest().GetTaskToken())
+	case *historyservice.RespondWorkflowTaskCompletedResponse:
+		return nil
 	case *historyservice.RespondWorkflowTaskFailedRequest:
 		return wt.fromTaskToken(r.GetFailedRequest().GetTaskToken())
+	case *historyservice.RespondWorkflowTaskFailedResponse:
+		return nil
 	case *historyservice.ScheduleWorkflowTaskRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.ScheduleWorkflowTaskResponse:
+		return nil
 	case *historyservice.SignalWithStartWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetSignalWithStartRequest().GetWorkflowId()),
+		}
+	case *historyservice.SignalWithStartWorkflowExecutionResponse:
+		return []tag.Tag{
+			tag.WorkflowRunID(r.GetRunId()),
 		}
 	case *historyservice.SignalWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetSignalRequest().GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetSignalRequest().GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.SignalWorkflowExecutionResponse:
+		return nil
 	case *historyservice.StartWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetStartRequest().GetWorkflowId()),
+		}
+	case *historyservice.StartWorkflowExecutionResponse:
+		return []tag.Tag{
+			tag.WorkflowRunID(r.GetRunId()),
 		}
 	case *historyservice.SyncActivityRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
+	case *historyservice.SyncActivityResponse:
+		return nil
 	case *historyservice.SyncShardStatusRequest:
+		return nil
+	case *historyservice.SyncShardStatusResponse:
 		return nil
 	case *historyservice.SyncWorkflowStateRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *historyservice.SyncWorkflowStateResponse:
+		return nil
 	case *historyservice.TerminateWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetTerminateRequest().GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetTerminateRequest().GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.TerminateWorkflowExecutionResponse:
+		return nil
 	case *historyservice.UnpauseActivityRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetFrontendRequest().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetFrontendRequest().GetRunId()),
 		}
+	case *historyservice.UnpauseActivityResponse:
+		return nil
 	case *historyservice.UpdateActivityOptionsRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetUpdateRequest().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetUpdateRequest().GetRunId()),
 		}
+	case *historyservice.UpdateActivityOptionsResponse:
+		return nil
 	case *historyservice.UpdateWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetRequest().GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRequest().GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.UpdateWorkflowExecutionResponse:
+		return nil
 	case *historyservice.UpdateWorkflowExecutionOptionsRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetUpdateRequest().GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetUpdateRequest().GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.UpdateWorkflowExecutionOptionsResponse:
+		return nil
 	case *historyservice.VerifyChildExecutionCompletionRecordedRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetParentExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetParentExecution().GetRunId()),
 		}
+	case *historyservice.VerifyChildExecutionCompletionRecordedResponse:
+		return nil
 	case *historyservice.VerifyFirstWorkflowTaskScheduledRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *historyservice.VerifyFirstWorkflowTaskScheduledResponse:
+		return nil
 	default:
 		return nil
 	}

--- a/common/rpc/interceptor/logtags/matching_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/matching_service_server_gen.go
@@ -31,80 +31,150 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-func (wt *WorkflowTags) extractFromMatchingServiceServerRequest(req any) []tag.Tag {
-	switch r := req.(type) {
+func (wt *WorkflowTags) extractFromMatchingServiceServerPayload(payload any) []tag.Tag {
+	switch r := payload.(type) {
 	case *matchingservice.AddActivityTaskRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *matchingservice.AddActivityTaskResponse:
+		return nil
 	case *matchingservice.AddWorkflowTaskRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *matchingservice.AddWorkflowTaskResponse:
+		return nil
 	case *matchingservice.ApplyTaskQueueUserDataReplicationEventRequest:
+		return nil
+	case *matchingservice.ApplyTaskQueueUserDataReplicationEventResponse:
 		return nil
 	case *matchingservice.CancelOutstandingPollRequest:
 		return nil
+	case *matchingservice.CancelOutstandingPollResponse:
+		return nil
 	case *matchingservice.CheckTaskQueueUserDataPropagationRequest:
+		return nil
+	case *matchingservice.CheckTaskQueueUserDataPropagationResponse:
 		return nil
 	case *matchingservice.CreateNexusEndpointRequest:
 		return nil
+	case *matchingservice.CreateNexusEndpointResponse:
+		return nil
 	case *matchingservice.DeleteNexusEndpointRequest:
+		return nil
+	case *matchingservice.DeleteNexusEndpointResponse:
 		return nil
 	case *matchingservice.DescribeTaskQueueRequest:
 		return nil
+	case *matchingservice.DescribeTaskQueueResponse:
+		return nil
 	case *matchingservice.DescribeTaskQueuePartitionRequest:
+		return nil
+	case *matchingservice.DescribeTaskQueuePartitionResponse:
 		return nil
 	case *matchingservice.DispatchNexusTaskRequest:
 		return nil
+	case *matchingservice.DispatchNexusTaskResponse:
+		return nil
 	case *matchingservice.ForceLoadTaskQueuePartitionRequest:
+		return nil
+	case *matchingservice.ForceLoadTaskQueuePartitionResponse:
 		return nil
 	case *matchingservice.ForceUnloadTaskQueueRequest:
 		return nil
+	case *matchingservice.ForceUnloadTaskQueueResponse:
+		return nil
 	case *matchingservice.ForceUnloadTaskQueuePartitionRequest:
+		return nil
+	case *matchingservice.ForceUnloadTaskQueuePartitionResponse:
 		return nil
 	case *matchingservice.GetBuildIdTaskQueueMappingRequest:
 		return nil
+	case *matchingservice.GetBuildIdTaskQueueMappingResponse:
+		return nil
 	case *matchingservice.GetTaskQueueUserDataRequest:
+		return nil
+	case *matchingservice.GetTaskQueueUserDataResponse:
 		return nil
 	case *matchingservice.GetWorkerBuildIdCompatibilityRequest:
 		return nil
+	case *matchingservice.GetWorkerBuildIdCompatibilityResponse:
+		return nil
 	case *matchingservice.GetWorkerVersioningRulesRequest:
+		return nil
+	case *matchingservice.GetWorkerVersioningRulesResponse:
 		return nil
 	case *matchingservice.ListNexusEndpointsRequest:
 		return nil
+	case *matchingservice.ListNexusEndpointsResponse:
+		return nil
 	case *matchingservice.ListTaskQueuePartitionsRequest:
+		return nil
+	case *matchingservice.ListTaskQueuePartitionsResponse:
 		return nil
 	case *matchingservice.PollActivityTaskQueueRequest:
 		return nil
+	case *matchingservice.PollActivityTaskQueueResponse:
+		return []tag.Tag{
+			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
+			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
+		}
 	case *matchingservice.PollNexusTaskQueueRequest:
+		return nil
+	case *matchingservice.PollNexusTaskQueueResponse:
 		return nil
 	case *matchingservice.PollWorkflowTaskQueueRequest:
 		return nil
+	case *matchingservice.PollWorkflowTaskQueueResponse:
+		return []tag.Tag{
+			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
+			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
+		}
 	case *matchingservice.QueryWorkflowRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetQueryRequest().GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetQueryRequest().GetExecution().GetRunId()),
 		}
+	case *matchingservice.QueryWorkflowResponse:
+		return nil
 	case *matchingservice.ReplicateTaskQueueUserDataRequest:
+		return nil
+	case *matchingservice.ReplicateTaskQueueUserDataResponse:
 		return nil
 	case *matchingservice.RespondNexusTaskCompletedRequest:
 		return nil
+	case *matchingservice.RespondNexusTaskCompletedResponse:
+		return nil
 	case *matchingservice.RespondNexusTaskFailedRequest:
+		return nil
+	case *matchingservice.RespondNexusTaskFailedResponse:
 		return nil
 	case *matchingservice.RespondQueryTaskCompletedRequest:
 		return nil
+	case *matchingservice.RespondQueryTaskCompletedResponse:
+		return nil
 	case *matchingservice.SyncDeploymentUserDataRequest:
+		return nil
+	case *matchingservice.SyncDeploymentUserDataResponse:
 		return nil
 	case *matchingservice.UpdateNexusEndpointRequest:
 		return nil
+	case *matchingservice.UpdateNexusEndpointResponse:
+		return nil
 	case *matchingservice.UpdateTaskQueueUserDataRequest:
+		return nil
+	case *matchingservice.UpdateTaskQueueUserDataResponse:
 		return nil
 	case *matchingservice.UpdateWorkerBuildIdCompatibilityRequest:
 		return nil
+	case *matchingservice.UpdateWorkerBuildIdCompatibilityResponse:
+		return nil
 	case *matchingservice.UpdateWorkerVersioningRulesRequest:
+		return nil
+	case *matchingservice.UpdateWorkerVersioningRulesResponse:
 		return nil
 	default:
 		return nil

--- a/common/rpc/interceptor/logtags/matching_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/matching_service_server_gen.go
@@ -31,8 +31,8 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-func (wt *WorkflowTags) extractFromMatchingServiceServerPayload(payload any) []tag.Tag {
-	switch r := payload.(type) {
+func (wt *WorkflowTags) extractFromMatchingServiceServerMessage(message any) []tag.Tag {
+	switch r := message.(type) {
 	case *matchingservice.AddActivityTaskRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),

--- a/common/rpc/interceptor/logtags/workflow_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/workflow_service_server_gen.go
@@ -31,8 +31,8 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-func (wt *WorkflowTags) extractFromWorkflowServiceServerPayload(payload any) []tag.Tag {
-	switch r := payload.(type) {
+func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []tag.Tag {
+	switch r := message.(type) {
 	case *workflowservice.CountWorkflowExecutionsRequest:
 		return nil
 	case *workflowservice.CountWorkflowExecutionsResponse:

--- a/common/rpc/interceptor/logtags/workflow_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/workflow_service_server_gen.go
@@ -31,223 +31,389 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-func (wt *WorkflowTags) extractFromWorkflowServiceServerRequest(req any) []tag.Tag {
-	switch r := req.(type) {
+func (wt *WorkflowTags) extractFromWorkflowServiceServerPayload(payload any) []tag.Tag {
+	switch r := payload.(type) {
 	case *workflowservice.CountWorkflowExecutionsRequest:
+		return nil
+	case *workflowservice.CountWorkflowExecutionsResponse:
 		return nil
 	case *workflowservice.CreateScheduleRequest:
 		return nil
+	case *workflowservice.CreateScheduleResponse:
+		return nil
 	case *workflowservice.DeleteScheduleRequest:
+		return nil
+	case *workflowservice.DeleteScheduleResponse:
 		return nil
 	case *workflowservice.DeleteWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *workflowservice.DeleteWorkflowExecutionResponse:
+		return nil
 	case *workflowservice.DeprecateNamespaceRequest:
+		return nil
+	case *workflowservice.DeprecateNamespaceResponse:
 		return nil
 	case *workflowservice.DescribeBatchOperationRequest:
 		return nil
+	case *workflowservice.DescribeBatchOperationResponse:
+		return nil
 	case *workflowservice.DescribeDeploymentRequest:
+		return nil
+	case *workflowservice.DescribeDeploymentResponse:
 		return nil
 	case *workflowservice.DescribeNamespaceRequest:
 		return nil
+	case *workflowservice.DescribeNamespaceResponse:
+		return nil
 	case *workflowservice.DescribeScheduleRequest:
 		return nil
+	case *workflowservice.DescribeScheduleResponse:
+		return nil
 	case *workflowservice.DescribeTaskQueueRequest:
+		return nil
+	case *workflowservice.DescribeTaskQueueResponse:
 		return nil
 	case *workflowservice.DescribeWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *workflowservice.DescribeWorkflowExecutionResponse:
+		return nil
 	case *workflowservice.ExecuteMultiOperationRequest:
+		return nil
+	case *workflowservice.ExecuteMultiOperationResponse:
 		return nil
 	case *workflowservice.GetClusterInfoRequest:
 		return nil
+	case *workflowservice.GetClusterInfoResponse:
+		return nil
 	case *workflowservice.GetCurrentDeploymentRequest:
+		return nil
+	case *workflowservice.GetCurrentDeploymentResponse:
 		return nil
 	case *workflowservice.GetDeploymentReachabilityRequest:
 		return nil
+	case *workflowservice.GetDeploymentReachabilityResponse:
+		return nil
 	case *workflowservice.GetSearchAttributesRequest:
+		return nil
+	case *workflowservice.GetSearchAttributesResponse:
 		return nil
 	case *workflowservice.GetSystemInfoRequest:
 		return nil
+	case *workflowservice.GetSystemInfoResponse:
+		return nil
 	case *workflowservice.GetWorkerBuildIdCompatibilityRequest:
+		return nil
+	case *workflowservice.GetWorkerBuildIdCompatibilityResponse:
 		return nil
 	case *workflowservice.GetWorkerTaskReachabilityRequest:
 		return nil
+	case *workflowservice.GetWorkerTaskReachabilityResponse:
+		return nil
 	case *workflowservice.GetWorkerVersioningRulesRequest:
+		return nil
+	case *workflowservice.GetWorkerVersioningRulesResponse:
 		return nil
 	case *workflowservice.GetWorkflowExecutionHistoryRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *workflowservice.GetWorkflowExecutionHistoryResponse:
+		return nil
 	case *workflowservice.GetWorkflowExecutionHistoryReverseRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *workflowservice.GetWorkflowExecutionHistoryReverseResponse:
+		return nil
 	case *workflowservice.ListArchivedWorkflowExecutionsRequest:
+		return nil
+	case *workflowservice.ListArchivedWorkflowExecutionsResponse:
 		return nil
 	case *workflowservice.ListBatchOperationsRequest:
 		return nil
+	case *workflowservice.ListBatchOperationsResponse:
+		return nil
 	case *workflowservice.ListClosedWorkflowExecutionsRequest:
+		return nil
+	case *workflowservice.ListClosedWorkflowExecutionsResponse:
 		return nil
 	case *workflowservice.ListDeploymentsRequest:
 		return nil
+	case *workflowservice.ListDeploymentsResponse:
+		return nil
 	case *workflowservice.ListNamespacesRequest:
+		return nil
+	case *workflowservice.ListNamespacesResponse:
 		return nil
 	case *workflowservice.ListOpenWorkflowExecutionsRequest:
 		return nil
+	case *workflowservice.ListOpenWorkflowExecutionsResponse:
+		return nil
 	case *workflowservice.ListScheduleMatchingTimesRequest:
+		return nil
+	case *workflowservice.ListScheduleMatchingTimesResponse:
 		return nil
 	case *workflowservice.ListSchedulesRequest:
 		return nil
+	case *workflowservice.ListSchedulesResponse:
+		return nil
 	case *workflowservice.ListTaskQueuePartitionsRequest:
+		return nil
+	case *workflowservice.ListTaskQueuePartitionsResponse:
 		return nil
 	case *workflowservice.ListWorkflowExecutionsRequest:
 		return nil
+	case *workflowservice.ListWorkflowExecutionsResponse:
+		return nil
 	case *workflowservice.PatchScheduleRequest:
+		return nil
+	case *workflowservice.PatchScheduleResponse:
 		return nil
 	case *workflowservice.PauseActivityByIdRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
+	case *workflowservice.PauseActivityByIdResponse:
+		return nil
 	case *workflowservice.PollActivityTaskQueueRequest:
 		return nil
+	case *workflowservice.PollActivityTaskQueueResponse:
+		return []tag.Tag{
+			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
+			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
+		}
 	case *workflowservice.PollNexusTaskQueueRequest:
 		return nil
+	case *workflowservice.PollNexusTaskQueueResponse:
+		return wt.fromTaskToken(r.GetTaskToken())
 	case *workflowservice.PollWorkflowExecutionUpdateRequest:
+		return []tag.Tag{
+			tag.WorkflowID(r.GetUpdateRef().GetWorkflowExecution().GetWorkflowId()),
+			tag.WorkflowRunID(r.GetUpdateRef().GetWorkflowExecution().GetRunId()),
+		}
+	case *workflowservice.PollWorkflowExecutionUpdateResponse:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetUpdateRef().GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetUpdateRef().GetWorkflowExecution().GetRunId()),
 		}
 	case *workflowservice.PollWorkflowTaskQueueRequest:
 		return nil
+	case *workflowservice.PollWorkflowTaskQueueResponse:
+		return []tag.Tag{
+			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
+			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
+		}
 	case *workflowservice.QueryWorkflowRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *workflowservice.QueryWorkflowResponse:
+		return nil
 	case *workflowservice.RecordActivityTaskHeartbeatRequest:
 		return wt.fromTaskToken(r.GetTaskToken())
+	case *workflowservice.RecordActivityTaskHeartbeatResponse:
+		return nil
 	case *workflowservice.RecordActivityTaskHeartbeatByIdRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
+	case *workflowservice.RecordActivityTaskHeartbeatByIdResponse:
+		return nil
 	case *workflowservice.RegisterNamespaceRequest:
+		return nil
+	case *workflowservice.RegisterNamespaceResponse:
 		return nil
 	case *workflowservice.RequestCancelWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *workflowservice.RequestCancelWorkflowExecutionResponse:
+		return nil
 	case *workflowservice.ResetActivityByIdRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
+	case *workflowservice.ResetActivityByIdResponse:
+		return nil
 	case *workflowservice.ResetStickyTaskQueueRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetExecution().GetRunId()),
 		}
+	case *workflowservice.ResetStickyTaskQueueResponse:
+		return nil
 	case *workflowservice.ResetWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *workflowservice.ResetWorkflowExecutionResponse:
+		return []tag.Tag{
+			tag.WorkflowRunID(r.GetRunId()),
+		}
 	case *workflowservice.RespondActivityTaskCanceledRequest:
 		return wt.fromTaskToken(r.GetTaskToken())
+	case *workflowservice.RespondActivityTaskCanceledResponse:
+		return nil
 	case *workflowservice.RespondActivityTaskCanceledByIdRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
+	case *workflowservice.RespondActivityTaskCanceledByIdResponse:
+		return nil
 	case *workflowservice.RespondActivityTaskCompletedRequest:
 		return wt.fromTaskToken(r.GetTaskToken())
+	case *workflowservice.RespondActivityTaskCompletedResponse:
+		return nil
 	case *workflowservice.RespondActivityTaskCompletedByIdRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
+	case *workflowservice.RespondActivityTaskCompletedByIdResponse:
+		return nil
 	case *workflowservice.RespondActivityTaskFailedRequest:
 		return wt.fromTaskToken(r.GetTaskToken())
+	case *workflowservice.RespondActivityTaskFailedResponse:
+		return nil
 	case *workflowservice.RespondActivityTaskFailedByIdRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
+	case *workflowservice.RespondActivityTaskFailedByIdResponse:
+		return nil
 	case *workflowservice.RespondNexusTaskCompletedRequest:
+		return nil
+	case *workflowservice.RespondNexusTaskCompletedResponse:
 		return nil
 	case *workflowservice.RespondNexusTaskFailedRequest:
 		return nil
+	case *workflowservice.RespondNexusTaskFailedResponse:
+		return nil
 	case *workflowservice.RespondQueryTaskCompletedRequest:
+		return nil
+	case *workflowservice.RespondQueryTaskCompletedResponse:
 		return nil
 	case *workflowservice.RespondWorkflowTaskCompletedRequest:
 		return wt.fromTaskToken(r.GetTaskToken())
+	case *workflowservice.RespondWorkflowTaskCompletedResponse:
+		return nil
 	case *workflowservice.RespondWorkflowTaskFailedRequest:
 		return wt.fromTaskToken(r.GetTaskToken())
+	case *workflowservice.RespondWorkflowTaskFailedResponse:
+		return nil
 	case *workflowservice.ScanWorkflowExecutionsRequest:
+		return nil
+	case *workflowservice.ScanWorkflowExecutionsResponse:
 		return nil
 	case *workflowservice.SetCurrentDeploymentRequest:
 		return nil
+	case *workflowservice.SetCurrentDeploymentResponse:
+		return nil
 	case *workflowservice.ShutdownWorkerRequest:
+		return nil
+	case *workflowservice.ShutdownWorkerResponse:
 		return nil
 	case *workflowservice.SignalWithStartWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
+		}
+	case *workflowservice.SignalWithStartWorkflowExecutionResponse:
+		return []tag.Tag{
+			tag.WorkflowRunID(r.GetRunId()),
 		}
 	case *workflowservice.SignalWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *workflowservice.SignalWorkflowExecutionResponse:
+		return nil
 	case *workflowservice.StartBatchOperationRequest:
+		return nil
+	case *workflowservice.StartBatchOperationResponse:
 		return nil
 	case *workflowservice.StartWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 		}
+	case *workflowservice.StartWorkflowExecutionResponse:
+		return []tag.Tag{
+			tag.WorkflowRunID(r.GetRunId()),
+		}
 	case *workflowservice.StopBatchOperationRequest:
+		return nil
+	case *workflowservice.StopBatchOperationResponse:
 		return nil
 	case *workflowservice.TerminateWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *workflowservice.TerminateWorkflowExecutionResponse:
+		return nil
 	case *workflowservice.UnpauseActivityByIdRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
+	case *workflowservice.UnpauseActivityByIdResponse:
+		return nil
 	case *workflowservice.UpdateActivityOptionsByIdRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
+	case *workflowservice.UpdateActivityOptionsByIdResponse:
+		return nil
 	case *workflowservice.UpdateNamespaceRequest:
+		return nil
+	case *workflowservice.UpdateNamespaceResponse:
 		return nil
 	case *workflowservice.UpdateScheduleRequest:
 		return nil
+	case *workflowservice.UpdateScheduleResponse:
+		return nil
 	case *workflowservice.UpdateWorkerBuildIdCompatibilityRequest:
 		return nil
+	case *workflowservice.UpdateWorkerBuildIdCompatibilityResponse:
+		return nil
 	case *workflowservice.UpdateWorkerVersioningRulesRequest:
+		return nil
+	case *workflowservice.UpdateWorkerVersioningRulesResponse:
 		return nil
 	case *workflowservice.UpdateWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *workflowservice.UpdateWorkflowExecutionResponse:
+		return []tag.Tag{
+			tag.WorkflowID(r.GetUpdateRef().GetWorkflowExecution().GetWorkflowId()),
+			tag.WorkflowRunID(r.GetUpdateRef().GetWorkflowExecution().GetRunId()),
+		}
 	case *workflowservice.UpdateWorkflowExecutionOptionsRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
 			tag.WorkflowRunID(r.GetWorkflowExecution().GetRunId()),
 		}
+	case *workflowservice.UpdateWorkflowExecutionOptionsResponse:
+		return nil
 	default:
 		return nil
 	}

--- a/common/rpc/interceptor/logtags/workflow_tags.go
+++ b/common/rpc/interceptor/logtags/workflow_tags.go
@@ -53,22 +53,22 @@ func NewWorkflowTags(
 	}
 }
 
-func (wt *WorkflowTags) Extract(req any, fullMethod string) []tag.Tag {
-	if req == nil {
+func (wt *WorkflowTags) Extract(payload any, fullMethod string) []tag.Tag {
+	if payload == nil {
 		return nil
 	}
 	switch {
 	case strings.HasPrefix(fullMethod, api.WorkflowServicePrefix):
-		return wt.extractFromWorkflowServiceServerRequest(req)
+		return wt.extractFromWorkflowServiceServerPayload(payload)
 	case strings.HasPrefix(fullMethod, api.OperatorServicePrefix):
 		// OperatorService doesn't have a single API with workflow tags.
 		return nil
 	case strings.HasPrefix(fullMethod, api.AdminServicePrefix):
-		return wt.extractFromAdminServiceServerRequest(req)
+		return wt.extractFromAdminServiceServerPayload(payload)
 	case strings.HasPrefix(fullMethod, api.HistoryServicePrefix):
-		return wt.extractFromHistoryServiceServerRequest(req)
+		return wt.extractFromHistoryServiceServerPayload(payload)
 	case strings.HasPrefix(fullMethod, api.MatchingServicePrefix):
-		return wt.extractFromMatchingServiceServerRequest(req)
+		return wt.extractFromMatchingServiceServerPayload(payload)
 	default:
 		return nil
 	}

--- a/common/rpc/interceptor/logtags/workflow_tags.go
+++ b/common/rpc/interceptor/logtags/workflow_tags.go
@@ -59,16 +59,16 @@ func (wt *WorkflowTags) Extract(req any, fullMethod string) []tag.Tag {
 	}
 	switch {
 	case strings.HasPrefix(fullMethod, api.WorkflowServicePrefix):
-		return wt.extractFromWorkflowServiceServerPayload(req)
+		return wt.extractFromWorkflowServiceServerMessage(req)
 	case strings.HasPrefix(fullMethod, api.OperatorServicePrefix):
 		// OperatorService doesn't have a single API with workflow tags.
 		return nil
 	case strings.HasPrefix(fullMethod, api.AdminServicePrefix):
-		return wt.extractFromAdminServiceServerPayload(req)
+		return wt.extractFromAdminServiceServerMessage(req)
 	case strings.HasPrefix(fullMethod, api.HistoryServicePrefix):
-		return wt.extractFromHistoryServiceServerPayload(req)
+		return wt.extractFromHistoryServiceServerMessage(req)
 	case strings.HasPrefix(fullMethod, api.MatchingServicePrefix):
-		return wt.extractFromMatchingServiceServerPayload(req)
+		return wt.extractFromMatchingServiceServerMessage(req)
 	default:
 		return nil
 	}

--- a/common/rpc/interceptor/logtags/workflow_tags.go
+++ b/common/rpc/interceptor/logtags/workflow_tags.go
@@ -53,22 +53,22 @@ func NewWorkflowTags(
 	}
 }
 
-func (wt *WorkflowTags) Extract(payload any, fullMethod string) []tag.Tag {
-	if payload == nil {
+func (wt *WorkflowTags) Extract(req any, fullMethod string) []tag.Tag {
+	if req == nil {
 		return nil
 	}
 	switch {
 	case strings.HasPrefix(fullMethod, api.WorkflowServicePrefix):
-		return wt.extractFromWorkflowServiceServerPayload(payload)
+		return wt.extractFromWorkflowServiceServerPayload(req)
 	case strings.HasPrefix(fullMethod, api.OperatorServicePrefix):
 		// OperatorService doesn't have a single API with workflow tags.
 		return nil
 	case strings.HasPrefix(fullMethod, api.AdminServicePrefix):
-		return wt.extractFromAdminServiceServerPayload(payload)
+		return wt.extractFromAdminServiceServerPayload(req)
 	case strings.HasPrefix(fullMethod, api.HistoryServicePrefix):
-		return wt.extractFromHistoryServiceServerPayload(payload)
+		return wt.extractFromHistoryServiceServerPayload(req)
 	case strings.HasPrefix(fullMethod, api.MatchingServicePrefix):
-		return wt.extractFromMatchingServiceServerPayload(payload)
+		return wt.extractFromMatchingServiceServerPayload(req)
 	default:
 		return nil
 	}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Added support for our OTEL interceptor to parse tags from the gRPC response (not just the request).

## Why?
<!-- Tell your future self why have you made these changes -->

Without annotating the responses, traces from calls like `PollWorkflowTaskQueue` cannot be queried for since the ID is only on the response but not the request.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Verified in Tempo:

<img width="1573" alt="image" src="https://github.com/user-attachments/assets/96a1f1b3-99f5-48f4-b603-b0b66f158538" />


## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

There is one other caller of `Extract`, but they are only feeding in the request payload. So no behavior change is expected.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
