### PR TITLE
Include task payload in OTEL debug

### DIFF
--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -28,6 +28,7 @@ package queues
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -283,7 +284,7 @@ func (e *executableImpl) Execute() (retErr error) {
 	)
 	e.Unlock()
 
-	// Wrapped in if block to avoid unnecessary allocations when OTEL is disables.
+	// Wrapped in if block to avoid unnecessary allocations when OTEL is disabled.
 	if telemetry.IsEnabled(e.tracer) {
 		var span trace.Span
 		ctx, span = e.tracer.Start(
@@ -293,8 +294,17 @@ func (e *executableImpl) Execute() (retErr error) {
 			trace.WithAttributes(
 				attribute.Key(telemetry.WorkflowIDKey).String(e.GetWorkflowID()),
 				attribute.Key(telemetry.WorkflowRunIDKey).String(e.GetRunID()),
-				attribute.Key("task.type").String(e.GetType().String()),
-				attribute.Key("task.id").Int64(e.GetTaskID())))
+				attribute.Key("queue.task.type").String(e.GetType().String()),
+				attribute.Key("queue.task.id").Int64(e.GetTaskID())))
+
+		if telemetry.DebugMode() {
+			if taskPayload, err := json.Marshal(e.GetTask()); err != nil {
+				e.logger.Error("failed to serialize task payload for OTEL span", tag.Error(err))
+			} else {
+				span.SetAttributes(attribute.Key("queue.task.payload").String(string(taskPayload)))
+			}
+		}
+
 		defer func() {
 			if retErr != nil {
 				span.RecordError(retErr)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Include the task data in the OTEL span when OTEL debug is enabled.

## Why?
<!-- Tell your future self why have you made these changes -->

Help with debugging/learning the system.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Checked in Grafana.

Example:

```
  "payload": {
    "NamespaceID": "a9aac188-6188-41f0-b7de-16ef62cb7193",
    "RunID": "0194af8c-df6d-7829-9c35-a88cc288da89",
    "ScheduledEventID": 2,
    "TaskID": 1048633,
    "TaskQueue": "TestUpdateWorkflowSuite/TestUpdateWorkflow_CompleteWorkflow_AbortUpdates/update_admitted_workflow_completed_task_queue",
    "Version": 0,
    "VisibilityTimestamp": "2025-01-29T00:53:52.621907Z",
    "WorkflowID": "TestUpdateWorkflowSuite/TestUpdateWorkflow_CompleteWorkflow_AbortUpdates/update_admitted_workflow_completed_workflow_id"
  }
```

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

Only enabled in debug mode.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
