### PR TITLE
add gauge metrics for gc count and pause

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1219,4 +1219,10 @@ var (
 	MemoryStackGauge     = NewGaugeDef("memory_stack")
 	NumGCCounter         = NewBytesHistogramDef("memory_num_gc")
 	GcPauseMsTimer       = NewTimerDef("memory_gc_pause_ms")
+	NumGCGauge           = NewGaugeDef("memory_num_gc_last",
+		WithDescription("Last runtime.MemStats.NumGC"),
+	)
+	GcPauseNsTotal = NewGaugeDef("memory_pause_total_ns_last",
+		WithDescription("Last runtime.MemStats.PauseTotalNs"),
+	)
 )

--- a/common/metrics/runtime.go
+++ b/common/metrics/runtime.go
@@ -97,6 +97,9 @@ func (r *RuntimeMetricsReporter) report() {
 	MemoryHeapInuseGauge.With(r.handler).Record(float64(memStats.HeapInuse))
 	MemoryStackGauge.With(r.handler).Record(float64(memStats.StackInuse))
 
+	NumGCGauge.With(r.handler).Record(float64(memStats.NumGC))
+	GcPauseNsTotal.With(r.handler).Record(float64(memStats.PauseTotalNs))
+
 	// memStats.NumGC is a perpetually incrementing counter (unless it wraps at 2^32)
 	num := memStats.NumGC
 	lastNum := atomic.SwapUint32(&r.lastNumGC, num) // reset for the next iteration


### PR DESCRIPTION
## What changed?
Add 2 new metrics reporting runtime memory information for the number of GC's since program start, and the total time spent in GC pauses.

## Why?
While there were some existing metrics for these values, they were reported as a histogram and timer, and interpretation of them is complex. Reporting these values without any extra processing will make using them easier.

## How did you test it?
Ran locally & verified that these metrics were present via a local prometheus setup.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
No.
