### PR TITLE
Omit empty persistence fields in JSON

### DIFF
--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -293,8 +293,8 @@ type (
 		Version     int64
 		UserData    *commonpb.DataBlob
 		// Used to build an index of build_id to task_queues
-		BuildIdsAdded   []string
-		BuildIdsRemoved []string
+		BuildIdsAdded   []string `json:",omitempty"`
+		BuildIdsRemoved []string `json:",omitempty"`
 	}
 
 	InternalTaskQueueUserDataEntry struct {
@@ -305,7 +305,7 @@ type (
 
 	InternalListTaskQueueUserDataEntriesResponse struct {
 		NextPageToken []byte
-		Entries       []InternalTaskQueueUserDataEntry
+		Entries       []InternalTaskQueueUserDataEntry `json:",omitempty"`
 	}
 
 	InternalCreateTasksRequest struct {
@@ -314,7 +314,7 @@ type (
 		TaskType      enumspb.TaskQueueType
 		RangeID       int64
 		TaskQueueInfo *commonpb.DataBlob
-		Tasks         []*InternalCreateTask
+		Tasks         []*InternalCreateTask `json:",omitempty"`
 	}
 
 	InternalCreateTask struct {
@@ -324,12 +324,12 @@ type (
 	}
 
 	InternalGetTasksResponse struct {
-		Tasks         []*commonpb.DataBlob
+		Tasks         []*commonpb.DataBlob `json:",omitempty"`
 		NextPageToken []byte
 	}
 
 	InternalListTaskQueueResponse struct {
-		Items         []*InternalListTaskQueueItem
+		Items         []*InternalListTaskQueueItem `json:",omitempty"`
 		NextPageToken []byte
 	}
 
@@ -353,7 +353,7 @@ type (
 		PreviousLastWriteVersion int64
 
 		NewWorkflowSnapshot  InternalWorkflowSnapshot
-		NewWorkflowNewEvents []*InternalAppendHistoryNodesRequest
+		NewWorkflowNewEvents []*InternalAppendHistoryNodesRequest `json:",omitempty"`
 	}
 
 	// InternalCreateWorkflowExecutionResponse is the response from persistence for create new workflow execution
@@ -368,9 +368,9 @@ type (
 		Mode UpdateWorkflowMode
 
 		UpdateWorkflowMutation  InternalWorkflowMutation
-		UpdateWorkflowNewEvents []*InternalAppendHistoryNodesRequest
+		UpdateWorkflowNewEvents []*InternalAppendHistoryNodesRequest `json:",omitempty"`
 		NewWorkflowSnapshot     *InternalWorkflowSnapshot
-		NewWorkflowNewEvents    []*InternalAppendHistoryNodesRequest
+		NewWorkflowNewEvents    []*InternalAppendHistoryNodesRequest `json:",omitempty"`
 	}
 
 	// InternalConflictResolveWorkflowExecutionRequest is used to reset workflow execution state for Persistence Interface
@@ -382,14 +382,14 @@ type (
 
 		// workflow to be resetted
 		ResetWorkflowSnapshot        InternalWorkflowSnapshot
-		ResetWorkflowEventsNewEvents []*InternalAppendHistoryNodesRequest
+		ResetWorkflowEventsNewEvents []*InternalAppendHistoryNodesRequest `json:",omitempty"`
 		// maybe new workflow
 		NewWorkflowSnapshot        *InternalWorkflowSnapshot
-		NewWorkflowEventsNewEvents []*InternalAppendHistoryNodesRequest
+		NewWorkflowEventsNewEvents []*InternalAppendHistoryNodesRequest `json:",omitempty"`
 
 		// current workflow
 		CurrentWorkflowMutation        *InternalWorkflowMutation
-		CurrentWorkflowEventsNewEvents []*InternalAppendHistoryNodesRequest
+		CurrentWorkflowEventsNewEvents []*InternalAppendHistoryNodesRequest `json:",omitempty"`
 	}
 	InternalSetWorkflowExecutionRequest struct {
 		ShardID int32
@@ -400,17 +400,17 @@ type (
 
 	// InternalWorkflowMutableState indicates workflow related state for Persistence Interface
 	InternalWorkflowMutableState struct {
-		ActivityInfos       map[int64]*commonpb.DataBlob  // ActivityInfo
-		TimerInfos          map[string]*commonpb.DataBlob // TimerInfo
-		ChildExecutionInfos map[int64]*commonpb.DataBlob  // ChildExecutionInfo
-		RequestCancelInfos  map[int64]*commonpb.DataBlob  // RequestCancelInfo
-		SignalInfos         map[int64]*commonpb.DataBlob  // SignalInfo
-		SignalRequestedIDs  []string
-		ExecutionInfo       *commonpb.DataBlob // WorkflowExecutionInfo
-		ExecutionState      *commonpb.DataBlob // WorkflowExecutionState
+		ActivityInfos       map[int64]*commonpb.DataBlob  `json:",omitempty"` // ActivityInfo
+		TimerInfos          map[string]*commonpb.DataBlob `json:",omitempty"` // TimerInfo
+		ChildExecutionInfos map[int64]*commonpb.DataBlob  `json:",omitempty"` // ChildExecutionInfo
+		RequestCancelInfos  map[int64]*commonpb.DataBlob  `json:",omitempty"` // RequestCancelInfo
+		SignalInfos         map[int64]*commonpb.DataBlob  `json:",omitempty"` // SignalInfo
+		SignalRequestedIDs  []string                      `json:",omitempty"`
+		ExecutionInfo       *commonpb.DataBlob            // WorkflowExecutionInfo
+		ExecutionState      *commonpb.DataBlob            // WorkflowExecutionState
 		NextEventID         int64
-		BufferedEvents      []*commonpb.DataBlob
-		Checksum            *commonpb.DataBlob // persistencespb.Checksum
+		BufferedEvents      []*commonpb.DataBlob `json:",omitempty"`
+		Checksum            *commonpb.DataBlob   // persistencespb.Checksum
 		DBRecordVersion     int64
 	}
 
@@ -427,7 +427,7 @@ type (
 		NamespaceID string
 		WorkflowID  string
 
-		Tasks map[tasks.Category][]InternalHistoryTask
+		Tasks map[tasks.Category][]InternalHistoryTask `json:",omitempty"`
 	}
 
 	// InternalWorkflowMutation is used as generic workflow execution state mutation for Persistence Interface
@@ -446,22 +446,22 @@ type (
 		LastWriteVersion   int64
 		DBRecordVersion    int64
 
-		UpsertActivityInfos       map[int64]*commonpb.DataBlob
-		DeleteActivityInfos       map[int64]struct{}
-		UpsertTimerInfos          map[string]*commonpb.DataBlob
-		DeleteTimerInfos          map[string]struct{}
-		UpsertChildExecutionInfos map[int64]*commonpb.DataBlob
-		DeleteChildExecutionInfos map[int64]struct{}
-		UpsertRequestCancelInfos  map[int64]*commonpb.DataBlob
-		DeleteRequestCancelInfos  map[int64]struct{}
-		UpsertSignalInfos         map[int64]*commonpb.DataBlob
-		DeleteSignalInfos         map[int64]struct{}
-		UpsertSignalRequestedIDs  map[string]struct{}
-		DeleteSignalRequestedIDs  map[string]struct{}
+		UpsertActivityInfos       map[int64]*commonpb.DataBlob  `json:",omitempty"`
+		DeleteActivityInfos       map[int64]struct{}            `json:",omitempty"`
+		UpsertTimerInfos          map[string]*commonpb.DataBlob `json:",omitempty"`
+		DeleteTimerInfos          map[string]struct{}           `json:",omitempty"`
+		UpsertChildExecutionInfos map[int64]*commonpb.DataBlob  `json:",omitempty"`
+		DeleteChildExecutionInfos map[int64]struct{}            `json:",omitempty"`
+		UpsertRequestCancelInfos  map[int64]*commonpb.DataBlob  `json:",omitempty"`
+		DeleteRequestCancelInfos  map[int64]struct{}            `json:",omitempty"`
+		UpsertSignalInfos         map[int64]*commonpb.DataBlob  `json:",omitempty"`
+		DeleteSignalInfos         map[int64]struct{}            `json:",omitempty"`
+		UpsertSignalRequestedIDs  map[string]struct{}           `json:",omitempty"`
+		DeleteSignalRequestedIDs  map[string]struct{}           `json:",omitempty"`
 		NewBufferedEvents         *commonpb.DataBlob
 		ClearBufferedEvents       bool
 
-		Tasks map[tasks.Category][]InternalHistoryTask
+		Tasks map[tasks.Category][]InternalHistoryTask `json:",omitempty"`
 
 		Condition int64
 
@@ -484,14 +484,14 @@ type (
 		NextEventID        int64
 		DBRecordVersion    int64
 
-		ActivityInfos       map[int64]*commonpb.DataBlob
-		TimerInfos          map[string]*commonpb.DataBlob
-		ChildExecutionInfos map[int64]*commonpb.DataBlob
-		RequestCancelInfos  map[int64]*commonpb.DataBlob
-		SignalInfos         map[int64]*commonpb.DataBlob
-		SignalRequestedIDs  map[string]struct{}
+		ActivityInfos       map[int64]*commonpb.DataBlob  `json:",omitempty"`
+		TimerInfos          map[string]*commonpb.DataBlob `json:",omitempty"`
+		ChildExecutionInfos map[int64]*commonpb.DataBlob  `json:",omitempty"`
+		RequestCancelInfos  map[int64]*commonpb.DataBlob  `json:",omitempty"`
+		SignalInfos         map[int64]*commonpb.DataBlob  `json:",omitempty"`
+		SignalRequestedIDs  map[string]struct{}           `json:",omitempty"`
 
-		Tasks map[tasks.Category][]InternalHistoryTask
+		Tasks map[tasks.Category][]InternalHistoryTask `json:",omitempty"`
 
 		Condition int64
 
@@ -541,7 +541,7 @@ type (
 
 	// InternalListConcreteExecutionsResponse is the response to ListConcreteExecutions for Persistence Interface
 	InternalListConcreteExecutionsResponse struct {
-		States        []*InternalWorkflowMutableState
+		States        []*InternalWorkflowMutableState `json:",omitempty"`
 		NextPageToken []byte
 	}
 
@@ -550,7 +550,7 @@ type (
 	}
 
 	InternalGetHistoryTasksResponse struct {
-		Tasks         []InternalHistoryTask
+		Tasks         []InternalHistoryTask `json:",omitempty"`
 		NextPageToken []byte
 	}
 
@@ -597,7 +597,7 @@ type (
 		// Used in sharded data stores to identify which shard to use
 		ShardID int32
 		// branch ranges is used to delete range of history nodes from target branch and it ancestors.
-		BranchRanges []InternalDeleteHistoryBranchRange
+		BranchRanges []InternalDeleteHistoryBranchRange `json:",omitempty"`
 	}
 
 	// InternalDeleteHistoryBranchRange is used to delete a range of history nodes of a branch
@@ -641,7 +641,7 @@ type (
 	// InternalReadHistoryBranchResponse is the response to ReadHistoryBranchRequest
 	InternalReadHistoryBranchResponse struct {
 		// History nodes
-		Nodes []InternalHistoryNode
+		Nodes []InternalHistoryNode `json:",omitempty"`
 		// Pagination token
 		NextPageToken []byte
 	}
@@ -652,7 +652,7 @@ type (
 		// pagination token
 		NextPageToken []byte
 		// all branches of all trees
-		Branches []InternalHistoryBranchDetail
+		Branches []InternalHistoryBranchDetail `json:",omitempty"`
 	}
 
 	// InternalHistoryBranchDetail used by InternalGetAllHistoryTreeBranchesResponse
@@ -675,7 +675,7 @@ type (
 	// Only used by persistence layer
 	InternalGetHistoryTreeContainingBranchResponse struct {
 		// TreeInfos
-		TreeInfos []*commonpb.DataBlob
+		TreeInfos []*commonpb.DataBlob `json:",omitempty"`
 	}
 
 	// InternalCreateNamespaceRequest is used to create the namespace
@@ -714,7 +714,7 @@ type (
 
 	// InternalListNamespacesResponse is the response for GetNamespace
 	InternalListNamespacesResponse struct {
-		Namespaces    []*InternalGetNamespaceResponse
+		Namespaces    []*InternalGetNamespaceResponse `json:",omitempty"`
 		NextPageToken []byte
 	}
 
@@ -726,7 +726,7 @@ type (
 
 	// InternalListClusterMetadataResponse is the response for ListClusterMetadata
 	InternalListClusterMetadataResponse struct {
-		ClusterMetadata []*InternalGetClusterMetadataResponse
+		ClusterMetadata []*InternalGetClusterMetadataResponse `json:",omitempty"`
 		NextPageToken   []byte
 	}
 
@@ -775,7 +775,7 @@ type (
 	InternalListNexusEndpointsResponse struct {
 		TableVersion  int64
 		NextPageToken []byte
-		Endpoints     []InternalNexusEndpoint
+		Endpoints     []InternalNexusEndpoint `json:",omitempty"`
 	}
 
 	// QueueV2 is an interface for a generic FIFO queue. It should eventually replace the Queue interface. Why do we
@@ -846,7 +846,7 @@ type (
 	}
 
 	InternalReadMessagesResponse struct {
-		Messages      []QueueV2Message
+		Messages      []QueueV2Message `json:",omitempty"`
 		NextPageToken []byte
 	}
 
@@ -882,7 +882,7 @@ type (
 	}
 
 	InternalListQueuesResponse struct {
-		Queues        []QueueInfo
+		Queues        []QueueInfo `json:",omitempty"`
 		NextPageToken []byte
 	}
 )


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Added a few `,omitempty` across the data persistence types on list and map fields.

Some of these may never be empty, but it's easier to just annotate them all. 

## Why?
<!-- Tell your future self why have you made these changes -->

When these types are JSON serialized (for debugging/observability), the empty fields are just noise.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Checked OTEL output.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

No _meaningful_ behavior change is expected.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
