### PR TITLE
Reduce logging on WFTCompletedHandler.Invoke error

### DIFF
--- a/internal/effect/buffer.go
+++ b/internal/effect/buffer.go
@@ -49,20 +49,28 @@ func (b *Buffer) OnAfterRollback(effect func(context.Context)) {
 
 // Apply invokes the buffered effect functions in the order that they were added
 // to this Buffer.
-func (b *Buffer) Apply(ctx context.Context) {
+// It returns true if any effects were applied.
+func (b *Buffer) Apply(ctx context.Context) bool {
+	applied := false
 	b.cancels = nil
 	for _, effect := range b.effects {
 		effect(ctx)
+		applied = true
 	}
 	b.effects = nil
+	return applied
 }
 
 // Cancel invokes the buffered rollback functions in the reverse of the order
 // that they were added to this Buffer.
-func (b *Buffer) Cancel(ctx context.Context) {
+// It returns true if any effects were canceled.
+func (b *Buffer) Cancel(ctx context.Context) bool {
+	canceled := false
 	b.effects = nil
 	for i := len(b.cancels) - 1; i >= 0; i-- {
 		b.cancels[i](ctx)
+		canceled = true
 	}
 	b.cancels = nil
+	return canceled
 }

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -237,9 +237,8 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 
 	var effects effect.Buffer
 	defer func() {
-		// `effects` are explicitly immediately canceled if WFT failed or persistence write returned an error,
-		// because logic in handlers of these cases might assume that effects are already canceled.
-		// This `defer` is to support some other rare cases when error is returned from this function.
+		// `effects` are canceled immediately on WFT failure or persistence errors.
+		// This `defer` handles rare cases where an error is returned but the cancellation didn't happen.
 		if retError != nil {
 			cancelled := effects.Cancel(ctx)
 			if cancelled {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Reduce logging on `WFTCompletedHandler.Invoke` error. Now it is emitted only when effects were actually cleared. 

## Why?
<!-- Tell your future self why have you made these changes -->
Remove noisy logs.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Didn't test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.