### PR TITLE
Priority-enabled TaskMatcher

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1070,11 +1070,6 @@ See DynamicRateLimitingParams comments for more details.`,
 		time.Minute,
 		`MatchingLongPollExpirationInterval is the long poll expiration interval in the matching service`,
 	)
-	MatchingSyncMatchWaitDuration = NewTaskQueueDurationSetting(
-		"matching.syncMatchWaitDuration",
-		200*time.Millisecond,
-		`MatchingSyncMatchWaitDuration is to wait time for sync match`,
-	)
 	MatchingHistoryMaxPageSize = NewNamespaceIntSetting(
 		"matching.historyMaxPageSize",
 		primitives.GetHistoryMaxPageSize,
@@ -1175,7 +1170,7 @@ for VERSIONED queues.`,
 		1,
 		`MatchingForwarderMaxOutstandingTasks is the max number of inflight addTask/queryTask from the forwarder`,
 	)
-	MatchingForwarderMaxRatePerSecond = NewTaskQueueIntSetting(
+	MatchingForwarderMaxRatePerSecond = NewTaskQueueFloatSetting(
 		"matching.forwarderMaxRatePerSecond",
 		10,
 		`MatchingForwarderMaxRatePerSecond is the max rate at which add/query can be forwarded`,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1070,6 +1070,12 @@ See DynamicRateLimitingParams comments for more details.`,
 		time.Minute,
 		`MatchingLongPollExpirationInterval is the long poll expiration interval in the matching service`,
 	)
+	// TODO(pri): old matcher cleanup
+	MatchingSyncMatchWaitDuration = NewTaskQueueDurationSetting(
+		"matching.syncMatchWaitDuration",
+		200*time.Millisecond,
+		`MatchingSyncMatchWaitDuration is to wait time for sync match`,
+	)
 	MatchingHistoryMaxPageSize = NewNamespaceIntSetting(
 		"matching.historyMaxPageSize",
 		primitives.GetHistoryMaxPageSize,
@@ -1254,6 +1260,11 @@ these log lines can be noisy, we want to be able to turn on and sample selective
 		"matching.maxTaskQueuesInDeployment",
 		1000,
 		`MatchingMaxTaskQueuesInDeployment represents the maximum number of task-queues that can be registed in a single deployment`,
+	)
+	MatchingUseNewMatcher = NewTaskQueueBoolSetting(
+		"matching.useNewMatcher",
+		false,
+		`Use priority-enabled TaskMatcher.`,
 	)
 
 	// keys for history

--- a/common/priorities/priority_util.go
+++ b/common/priorities/priority_util.go
@@ -33,7 +33,7 @@ func Merge(
 	override *commonpb.Priority,
 ) *commonpb.Priority {
 	if base == nil || override == nil {
-		return cmp.Or(base, override)
+		return cmp.Or(override, base)
 	}
 
 	return &commonpb.Priority{

--- a/common/testing/testhooks/test_impl.go
+++ b/common/testing/testhooks/test_impl.go
@@ -58,11 +58,14 @@ type (
 //
 // TestHooks should be used very sparingly, see comment on TestHooks.
 func Get[T any](th TestHooks, key Key) (T, bool) {
+	var zero T
+	if th == nil {
+		return zero, false
+	}
 	if val, ok := th.get(key); ok {
 		// this is only used in test so we want to panic on type mismatch:
 		return val.(T), ok // nolint:revive
 	}
-	var zero T
 	return zero, false
 }
 

--- a/service/matching/backlog_age_tracker.go
+++ b/service/matching/backlog_age_tracker.go
@@ -1,0 +1,71 @@
+// The MIT License
+//
+// Copyright (c) 2025 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"time"
+
+	"github.com/emirpasic/gods/maps/treemap"
+	godsutils "github.com/emirpasic/gods/utils"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const emptyBacklogAge time.Duration = -1
+
+// backlogAgeTracker is not safe for concurrent use
+type backlogAgeTracker struct {
+	tree treemap.Map // unix nano as int64 -> int (count)
+}
+
+func newBacklogAgeTracker() backlogAgeTracker {
+	return backlogAgeTracker{tree: *treemap.NewWith(godsutils.Int64Comparator)}
+}
+
+// record adds or removes a task from the tracker.
+func (b backlogAgeTracker) record(ts *timestamppb.Timestamp, delta int) {
+	if ts == nil {
+		return
+	}
+
+	createTime := ts.AsTime().UnixNano()
+	count := delta
+	if prev, ok := b.tree.Get(createTime); ok {
+		count += prev.(int)
+	}
+	if count = max(0, count); count == 0 {
+		b.tree.Remove(createTime)
+	} else {
+		b.tree.Put(createTime, count)
+	}
+}
+
+// getBacklogAge returns the largest age in this backlog (age of oldest task),
+// or emptyBacklogAge if empty.
+func (b backlogAgeTracker) getAge() time.Duration {
+	if b.tree.Empty() {
+		return emptyBacklogAge
+	}
+	k, _ := b.tree.Min()
+	oldest := k.(int64)
+	return time.Since(time.Unix(0, oldest))
+}

--- a/service/matching/backlog_age_tracker.go
+++ b/service/matching/backlog_age_tracker.go
@@ -50,7 +50,7 @@ func (b backlogAgeTracker) record(ts *timestamppb.Timestamp, delta int) {
 	createTime := ts.AsTime().UnixNano()
 	count := delta
 	if prev, ok := b.tree.Get(createTime); ok {
-		count += prev.(int)
+		count += prev.(int) // nolint:revive
 	}
 	if count = max(0, count); count == 0 {
 		b.tree.Remove(createTime)
@@ -66,6 +66,6 @@ func (b backlogAgeTracker) getAge() time.Duration {
 		return emptyBacklogAge
 	}
 	k, _ := b.tree.Min()
-	oldest := k.(int64)
+	oldest := k.(int64) // nolint:revive
 	return time.Since(time.Unix(0, oldest))
 }

--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -181,15 +181,12 @@ func (c *backlogManagerImpl) SpoolTask(taskInfo *persistencespb.TaskInfo) error 
 	return err
 }
 
-func (c *backlogManagerImpl) processSpooledTask(
-	ctx context.Context,
-	task *internalTask,
-) error {
-	return c.pqMgr.ProcessSpooledTask(ctx, task)
+func (c *backlogManagerImpl) addSpooledTask(ctx context.Context, task *internalTask) error {
+	return c.pqMgr.AddSpooledTask(ctx, task)
 }
 
 func (c *backlogManagerImpl) BacklogCountHint() int64 {
-	return c.taskAckManager.getBacklogCountHint()
+	return c.taskReader.getLoadedTasks()
 }
 
 func (c *backlogManagerImpl) BacklogStatus() *taskqueuepb.TaskQueueStatus {

--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -109,7 +109,7 @@ func newBacklogManager(
 	}
 	bmg.db = newTaskQueueDB(bmg, taskManager, pqMgr.QueueKey(), logger)
 	bmg.taskWriter = newTaskWriter(bmg)
-	if config.NewMatcher() {
+	if config.NewMatcher {
 		bmg.priTaskReader = newPriTaskReader(bmg)
 	} else {
 		bmg.taskReader = newTaskReader(bmg)

--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -68,7 +68,8 @@ type (
 		pqMgr               physicalTaskQueueManager
 		db                  *taskQueueDB
 		taskWriter          *taskWriter
-		taskReader          *taskReader // reads tasks from db and async matches it with poller
+		taskReader          *taskReader    // reads tasks from db and async matches it with poller
+		priTaskReader       *priTaskReader // reads tasks from db and async matches it with poller
 		taskGC              *taskGC
 		taskAckManager      ackManager // tracks ackLevel for delivered messages
 		config              *taskQueueConfig
@@ -108,7 +109,11 @@ func newBacklogManager(
 	}
 	bmg.db = newTaskQueueDB(bmg, taskManager, pqMgr.QueueKey(), logger)
 	bmg.taskWriter = newTaskWriter(bmg)
-	bmg.taskReader = newTaskReader(bmg)
+	if config.NewMatcher() {
+		bmg.priTaskReader = newPriTaskReader(bmg)
+	} else {
+		bmg.taskReader = newTaskReader(bmg)
+	}
 	bmg.taskAckManager = newAckManager(bmg.db, logger)
 	bmg.taskGC = newTaskGC(bmg.db, config)
 
@@ -135,7 +140,11 @@ func (c *backlogManagerImpl) signalIfFatal(err error) bool {
 
 func (c *backlogManagerImpl) Start() {
 	c.taskWriter.Start()
-	c.taskReader.Start()
+	if c.priTaskReader != nil {
+		c.priTaskReader.Start()
+	} else {
+		c.taskReader.Start()
+	}
 }
 
 func (c *backlogManagerImpl) Stop() {
@@ -154,7 +163,11 @@ func (c *backlogManagerImpl) Stop() {
 		c.taskGC.RunNow(ctx, ackLevel)
 	}
 	c.taskWriter.Stop()
-	c.taskReader.Stop()
+	if c.priTaskReader != nil {
+		c.priTaskReader.Stop()
+	} else {
+		c.taskReader.Stop()
+	}
 }
 
 func (c *backlogManagerImpl) SetInitializedError(err error) {
@@ -176,9 +189,21 @@ func (c *backlogManagerImpl) SpoolTask(taskInfo *persistencespb.TaskInfo) error 
 	_, err := c.taskWriter.appendTask(taskInfo)
 	c.signalIfFatal(err)
 	if err == nil {
-		c.taskReader.Signal()
+		if c.priTaskReader != nil {
+			c.priTaskReader.Signal()
+		} else {
+			c.taskReader.Signal()
+		}
 	}
 	return err
+}
+
+// TODO(pri): old matcher cleanup
+func (c *backlogManagerImpl) processSpooledTask(
+	ctx context.Context,
+	task *internalTask,
+) error {
+	return c.pqMgr.ProcessSpooledTask(ctx, task)
 }
 
 func (c *backlogManagerImpl) addSpooledTask(ctx context.Context, task *internalTask) error {
@@ -186,7 +211,24 @@ func (c *backlogManagerImpl) addSpooledTask(ctx context.Context, task *internalT
 }
 
 func (c *backlogManagerImpl) BacklogCountHint() int64 {
-	return c.taskReader.getLoadedTasks()
+	if c.priTaskReader != nil {
+		return c.priTaskReader.getLoadedTasks()
+	}
+	return c.taskAckManager.getBacklogCountHint()
+}
+
+func (c *backlogManagerImpl) BacklogHeadAge() time.Duration {
+	if c.priTaskReader != nil {
+		return c.priTaskReader.getBacklogHeadAge()
+	}
+	return c.taskReader.getBacklogHeadAge()
+}
+
+func (c *backlogManagerImpl) ReadBufferLength() int64 {
+	if c.priTaskReader != nil {
+		return c.priTaskReader.loadedTasks.Load()
+	}
+	return int64(len(c.taskReader.taskBuffer))
 }
 
 func (c *backlogManagerImpl) BacklogStatus() *taskqueuepb.TaskQueueStatus {
@@ -245,7 +287,11 @@ func (c *backlogManagerImpl) completeTask(task *persistencespb.AllocatedTaskInfo
 			c.pqMgr.UnloadFromPartitionManager(unloadCauseOtherError)
 			return
 		}
-		c.taskReader.Signal()
+		if c.priTaskReader != nil {
+			c.priTaskReader.Signal()
+		} else {
+			c.taskReader.Signal()
+		}
 	}
 
 	ackLevel := c.taskAckManager.completeTask(task.GetTaskId())

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -54,7 +54,7 @@ func TestDeliverBufferTasks(t *testing.T) {
 			tlm.backlogMgr.taskReader.taskBuffer <- &persistencespb.AllocatedTaskInfo{
 				Data: &persistencespb.TaskInfo{},
 			}
-			err := tlm.matcher.rateLimiter.Wait(context.Background()) // consume the token
+			err := tlm.oldMatcher.rateLimiter.Wait(context.Background()) // consume the token
 			assert.NoError(t, err)
 			tlm.backlogMgr.taskReader.gorogrp.Cancel()
 		},

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -140,7 +140,7 @@ type (
 		// Time to hold a poll request before returning an empty response if there are no tasks
 		LongPollExpirationInterval func() time.Duration
 		RangeSize                  int64
-		NewMatcher                 func() bool
+		NewMatcher                 bool
 		GetTasksBatchSize          func() int
 		UpdateAckInterval          func() time.Duration
 		MaxTaskQueueIdleTime       func() time.Duration
@@ -292,9 +292,7 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 	return &taskQueueConfig{
 		CallerInfo: headers.NewBackgroundCallerInfo(ns.String()),
 		RangeSize:  config.RangeSize,
-		NewMatcher: func() bool {
-			return config.NewMatcher(ns.String(), taskQueueName, taskType)
-		},
+		NewMatcher: config.NewMatcher(ns.String(), taskQueueName, taskType),
 		GetTasksBatchSize: func() int {
 			return config.GetTasksBatchSize(ns.String(), taskQueueName, taskType)
 		},

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -353,7 +353,7 @@ func (db *taskQueueDB) cachedQueueInfo() *persistencespb.TaskQueueInfo {
 func (db *taskQueueDB) emitBacklogGauges() {
 	if db.backlogMgr.pqMgr.ShouldEmitGauges() {
 		approximateBacklogCount := db.getApproximateBacklogCount()
-		backlogHeadAge := db.backlogMgr.taskReader.getBacklogHeadAge()
+		backlogHeadAge := db.backlogMgr.BacklogHeadAge()
 		metrics.ApproximateBacklogCount.With(db.backlogMgr.metricsHandler).Record(float64(approximateBacklogCount))
 		metrics.ApproximateBacklogAgeSeconds.With(db.backlogMgr.metricsHandler).Record(backlogHeadAge.Seconds())
 

--- a/service/matching/forwarder_test.go
+++ b/service/matching/forwarder_test.go
@@ -62,7 +62,7 @@ func (t *ForwarderTestSuite) SetupTest() {
 	t.client = matchingservicemock.NewMockMatchingServiceClient(t.controller)
 	t.cfg = &forwarderConfig{
 		ForwarderMaxOutstandingPolls: func() int { return 1 },
-		ForwarderMaxRatePerSecond:    func() int { return 2 },
+		ForwarderMaxRatePerSecond:    func() float64 { return 2 },
 		ForwarderMaxChildrenPerNode:  func() int { return 20 },
 		ForwarderMaxOutstandingTasks: func() int { return 1 },
 	}

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -26,18 +26,22 @@ package matching
 
 import (
 	"context"
-	"errors"
 	"math"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/tqid"
+	"go.temporal.io/server/common/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -48,15 +52,12 @@ import (
 type TaskMatcher struct {
 	config *taskQueueConfig
 
-	// synchronous task channel to match producer/consumer
-	taskC chan *internalTask
-	// synchronous task channel to match query task - the reason to have a
-	// separate channel for this is that there are cases where consumers
-	// are interested in queryTasks but not others. One example is when a
-	// namespace is not active in a cluster.
-	queryTaskC chan *internalTask
-	// channel closed when task queue is closed, to interrupt pollers
-	closeC chan struct{}
+	// holds waiting polls and tasks
+	data matcherData
+
+	// Background context used for forwarding tasks. Closed when task queue is closed.
+	matcherCtx       context.Context
+	matcherCtxCancel context.CancelFunc
 
 	// dynamicRate is the dynamic rate & burst for rate limiter
 	dynamicRateBurst quotas.MutableRateBurst
@@ -64,32 +65,46 @@ type TaskMatcher struct {
 	dynamicRateLimiter *quotas.DynamicRateLimiterImpl
 	// forceRefreshRateOnce is used to force refresh rate limit for first time
 	forceRefreshRateOnce sync.Once
-	// rateLimiter that limits the rate at which tasks can be dispatched to consumers
-	rateLimiter quotas.RateLimiter
 
-	fwdr                   *Forwarder
-	metricsHandler         metrics.Handler // namespace metric scope
-	numPartitions          func() int      // number of task queue partitions
-	backlogTasksCreateTime map[int64]int   // task creation time (unix nanos) -> number of tasks with that time
-	backlogTasksLock       sync.Mutex
-	lastPoller             atomic.Int64 // unix nanos of most recent poll start time
+	partition      tqid.Partition
+	fwdr           *Forwarder
+	validator      taskValidator
+	metricsHandler metrics.Handler // namespace metric scope
+	numPartitions  func() int      // number of task queue partitions
+}
+
+type waitingPoller struct {
+	waitableMatchResult
+	startTime       time.Time
+	forwardCtx      context.Context // non-nil iff poll can be forwarded
+	pollMetadata    *pollMetadata   // non-nil iff poll can be forwarded
+	queryOnly       bool            // if true, poller can be given only query task, otherwise any task
+	isTaskForwarder bool
+	isTaskValidator bool
+}
+
+type matchResult struct {
+	task      *internalTask
+	poller    *waitingPoller
+	ctxErr    error // set if context timed out/canceled
+	ctxErrIdx int   // index of context that closed first
 }
 
 const (
-	defaultTaskDispatchRPS                  = 100000.0
-	defaultTaskDispatchRPSTTL               = time.Minute
-	emptyBacklogAge           time.Duration = -1
+	defaultTaskDispatchRPS    = 100000.0
+	defaultTaskDispatchRPSTTL = time.Minute
+
+	// TODO(pri): make dynamic config
+	backlogTaskForwardTimeout = 60 * time.Second
 )
 
 var (
-	// Sentinel error to redirect while blocked in matcher.
-	errInterrupted    = errors.New("interrupted offer")
 	errNoRecentPoller = status.Error(codes.FailedPrecondition, "no poller seen for task queue recently, worker may be down")
 )
 
 // newTaskMatcher returns a task matcher instance. The returned instance can be used by task producers and consumers to
 // find a match. Both sync matches and non-sync matches should use this implementation
-func newTaskMatcher(config *taskQueueConfig, fwdr *Forwarder, metricsHandler metrics.Handler) *TaskMatcher {
+func newTaskMatcher(config *taskQueueConfig, partition tqid.Partition, fwdr *Forwarder, validator taskValidator, metricsHandler metrics.Handler) *TaskMatcher {
 	dynamicRateBurst := quotas.NewMutableRateBurst(
 		defaultTaskDispatchRPS,
 		int(defaultTaskDispatchRPS),
@@ -107,23 +122,183 @@ func newTaskMatcher(config *taskQueueConfig, fwdr *Forwarder, metricsHandler met
 			config.AdminNamespaceToPartitionDispatchRate,
 		),
 	})
+
+	matcherCtx := headers.SetCallerInfo(context.Background(), config.CallerInfo)
+	matcherCtx, matcherCtxCancel := context.WithCancel(matcherCtx)
+
 	return &TaskMatcher{
-		config:                 config,
-		dynamicRateBurst:       dynamicRateBurst,
-		dynamicRateLimiter:     dynamicRateLimiter,
-		rateLimiter:            limiter,
-		metricsHandler:         metricsHandler,
-		fwdr:                   fwdr,
-		taskC:                  make(chan *internalTask),
-		queryTaskC:             make(chan *internalTask),
-		closeC:                 make(chan struct{}),
-		numPartitions:          config.NumReadPartitions,
-		backlogTasksCreateTime: make(map[int64]int),
+		config: config,
+		data: matcherData{
+			config:      config,
+			rateLimiter: limiter,
+			backlogAge:  newBacklogAgeTracker(),
+		},
+		dynamicRateBurst:   dynamicRateBurst,
+		dynamicRateLimiter: dynamicRateLimiter,
+		metricsHandler:     metricsHandler,
+		partition:          partition,
+		fwdr:               fwdr,
+		validator:          validator,
+		matcherCtx:         matcherCtx,
+		matcherCtxCancel:   matcherCtxCancel,
+		numPartitions:      config.NumReadPartitions,
+	}
+}
+
+func (tm *TaskMatcher) Start() {
+	policy := backoff.NewExponentialRetryPolicy(time.Second).
+		WithMaximumInterval(backlogTaskForwardTimeout).
+		WithExpirationInterval(backoff.NoInterval)
+	retrier := backoff.NewRetrier(policy, clock.NewRealTimeSource())
+	lim := quotas.NewDefaultOutgoingRateLimiter(tm.config.ForwarderMaxRatePerSecond)
+
+	if tm.fwdr == nil {
+		// Root doesn't forward. But it does need something to validate tasks.
+		go tm.validateTasksOnRoot(lim, retrier)
+		return
+	}
+
+	// Child partitions:
+	for range tm.config.ForwarderMaxOutstandingTasks() {
+		go tm.forwardTasks(lim, retrier)
+	}
+	for range tm.config.ForwarderMaxOutstandingPolls() {
+		go tm.forwardPolls()
 	}
 }
 
 func (tm *TaskMatcher) Stop() {
-	close(tm.closeC)
+	tm.matcherCtxCancel()
+}
+
+func (tm *TaskMatcher) forwardTasks(lim quotas.RateLimiter, retrier backoff.Retrier) {
+	ctxs := []context.Context{tm.matcherCtx}
+	poller := waitingPoller{isTaskForwarder: true}
+	for {
+		if lim.Wait(tm.matcherCtx) != nil {
+			return
+		}
+
+		res := tm.data.EnqueuePollerAndWait(ctxs, &poller)
+		if res.ctxErr != nil {
+			return // task queue closing
+		}
+		bugIf(res.task == nil, "bug: bad match result in forwardTasks")
+
+		err := tm.forwardTask(res.task)
+
+		// backoff on resource exhausted errors
+		if common.IsResourceExhausted(err) {
+			util.InterruptibleSleep(tm.matcherCtx, retrier.NextBackOff(err))
+		} else {
+			retrier.Reset()
+		}
+	}
+}
+
+func (tm *TaskMatcher) forwardTask(task *internalTask) error {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if task.forwardCtx != nil {
+		// Use sync match context if we have it (for deadline, headers, etc.)
+		// TODO(pri): does it make sense to subtract 1s from the context deadline here?
+		ctx = task.forwardCtx
+	} else {
+		// Task is from local backlog.
+
+		// Before we forward, ask task validator. This will happen every backlogTaskForwardTimeout
+		// to the head of the backlog, which is what taskValidator expects.
+		maybeValid := tm.validator.maybeValidate(task.event.AllocatedTaskInfo, tm.fwdr.partition.TaskType())
+		if !maybeValid {
+			task.finish(nil, false)
+			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1)
+			return nil
+		}
+
+		// Add a timeout for forwarding.
+		// Note that this does not block local match of other local backlog tasks.
+		ctx, cancel = context.WithTimeout(tm.matcherCtx, backlogTaskForwardTimeout)
+		defer cancel()
+	}
+
+	if task.isQuery() {
+		res, err := tm.fwdr.ForwardQueryTask(ctx, task)
+		task.finishForward(res, err, true)
+		return err
+	}
+
+	if task.isNexus() {
+		res, err := tm.fwdr.ForwardNexusTask(ctx, task)
+		task.finishForward(res, err, true)
+		return err
+	}
+
+	// normal wf/activity task
+	err := tm.fwdr.ForwardTask(ctx, task)
+
+	// If task was from our backlog, and forwarding timed out (as opposed to explicitly
+	// failed), then we should re-enqueue the task and let it match or forward again.
+	// Parent may explicitly return errRemoteSyncMatchFailed which is a Canceled error.
+	if task.forwardCtx == nil && (common.IsContextDeadlineExceededErr(err) || common.IsContextCanceledErr(err)) {
+		// Ask the task to redirect itself again. If not, add it back ourselves.
+		tm.data.RedirectOrEnqueue(task)
+	} else {
+		task.finishForward(nil, err, true)
+	}
+	return err
+}
+
+func (tm *TaskMatcher) validateTasksOnRoot(lim quotas.RateLimiter, retrier backoff.Retrier) {
+	ctxs := []context.Context{tm.matcherCtx}
+	poller := &waitingPoller{isTaskForwarder: true, isTaskValidator: true}
+	for {
+		if lim.Wait(tm.matcherCtx) != nil {
+			return
+		}
+
+		res := tm.data.EnqueuePollerAndWait(ctxs, poller)
+		if res.ctxErr != nil {
+			return // task queue closing
+		}
+		bugIf(res.task == nil, "bug: bad match result in validateTasksOnRoot")
+
+		task := res.task
+		maybeValid := tm.validator.maybeValidate(task.event.AllocatedTaskInfo, tm.partition.TaskType())
+		if !maybeValid {
+			// we found an invalid one, complete it and go back for another immediately
+			task.finish(nil, false)
+			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1)
+			retrier.Reset()
+		} else {
+			// Task was valid, put it back and slow down checking.
+			tm.data.RedirectOrEnqueue(task)
+			util.InterruptibleSleep(tm.matcherCtx, retrier.NextBackOff(nil))
+		}
+	}
+}
+
+func (tm *TaskMatcher) forwardPolls() {
+	forwarderTask := &internalTask{isPollForwarder: true}
+	ctxs := []context.Context{tm.matcherCtx}
+	for {
+		res := tm.data.EnqueueTaskAndWait(ctxs, forwarderTask)
+		if res.ctxErr != nil {
+			return // task queue closing
+		}
+		bugIf(res.poller == nil, "bug: bad match result in forwardPolls")
+
+		poller := res.poller
+		// We need to use the real source poller context since it has the poller id and
+		// identity, plus the right deadline.
+		task, err := tm.fwdr.ForwardPoll(poller.forwardCtx, poller.pollMetadata)
+		if err == nil {
+			tm.data.finishMatchAfterPollForward(poller, task)
+		} else {
+			// Re-enqueue to let it match again, if it hasn't gotten a context timeout already.
+			poller.forwardCtx = nil // disable forwarding next time
+			tm.data.ReenqueuePollerIfNotMatched(poller)
+		}
+	}
 }
 
 // Offer offers a task to a potential consumer (poller)
@@ -156,267 +331,120 @@ func (tm *TaskMatcher) Stop() {
 //   - context deadline is exceeded
 //   - task is matched and consumer returns error in response channel
 func (tm *TaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, error) {
-	if !tm.isBacklogNegligible() {
-		// To ensure better dispatch ordering, we block sync match when a significant backlog is present.
-		// Note that this check does not make a noticeable difference for history tasks, as they do not wait for a
-		// poller to become available. In presence of a backlog the chance of a poller being available when sync match
-		// request comes is almost zero.
-		// This check is mostly effective for the sync match requests that come from child partitions for spooled tasks.
-		return false, nil
-	}
-
-	if !task.isForwarded() {
-		if err := tm.rateLimiter.Wait(ctx); err != nil {
-			metrics.SyncThrottlePerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-			return false, err
-		}
-		// because we waited on the rate limiter to offer this task,
-		// attach the rate limiter's RecycleToken func to the task
-		// so that if the task is later determined to be invalid,
-		// we can recycle the token it used.
-		task.recycleToken = tm.rateLimiter.RecycleToken
-	}
-
-	select {
-	case tm.taskC <- task: // poller picked up the task
-		if task.responseC != nil {
-			// if there is a response channel, block until resp is received
-			// and return error if the response contains error
-			err := <-task.responseC
-
-			if err == nil && !task.isForwarded() {
-				tm.emitDispatchLatency(task, false)
-			}
-			return true, err
-		}
-		return false, nil
-	default:
-		// no poller waiting for tasks, try forwarding this task to the
-		// root partition if possible
-		select {
-		case token := <-tm.fwdrAddReqTokenC():
-			if err := tm.fwdr.ForwardTask(ctx, task); err == nil {
+	finish := func() (bool, error) {
+		res, ok := task.getResponse()
+		bugIf(!ok, "Offer must be given a sync match task")
+		if res.forwarded {
+			if res.forwardErr == nil {
 				// task was remotely sync matched on the parent partition
-				token.release()
 				tm.emitDispatchLatency(task, true)
 				return true, nil
 			}
-			token.release()
-		default:
-			if !tm.isForwardingAllowed() && // we are the root partition and forwarding is not possible
-				task.source == enumsspb.TASK_SOURCE_DB_BACKLOG && // task was from backlog (stored in db)
-				task.isForwarded() { // task came from a child partition
-				// a forwarded backlog task from a child partition, block trying
-				// to match with a poller until ctx timeout
-				return tm.offerOrTimeout(ctx, task)
-			}
+			return false, nil // forward error, give up here
 		}
+		// TODO(pri): can we just always do this on the parent and simplify this to:
+		// if res.startErr == nil { tm.emitDispatchLatency(task, task.isForwarded) }
+		// and get rid of the call above so there's only one?
+		if res.startErr == nil && !task.isForwarded() {
+			tm.emitDispatchLatency(task, false)
+		}
+		return true, res.startErr
+	}
 
+	// Fast path if we have a waiting poller (or forwarder).
+	// Forwarding happens here if we match with the task forwarding poller.
+	task.forwardCtx = ctx
+	if canMatch, gotMatch := tm.data.MatchNextPoller(task); gotMatch {
+		return finish()
+	} else if !canMatch {
 		return false, nil
 	}
-}
 
-func (tm *TaskMatcher) offerOrTimeout(ctx context.Context, task *internalTask) (bool, error) {
-	select {
-	case tm.taskC <- task: // poller picked up the task
-		if task.responseC != nil {
-			select {
-			case err := <-task.responseC:
-				return true, err
-			case <-ctx.Done():
-				return false, nil
-			}
-		}
-		return false, nil
-	case <-ctx.Done():
+	// We only block if we are the root and the task is forwarded from a backlog.
+	// Otherwise, stop here.
+	if tm.isForwardingAllowed() ||
+		task.source != enumsspb.TASK_SOURCE_DB_BACKLOG ||
+		!task.isForwarded() {
 		return false, nil
 	}
+
+	res := tm.data.EnqueueTaskAndWait([]context.Context{ctx, tm.matcherCtx}, task)
+
+	if res.ctxErr != nil {
+		return false, nil
+	}
+	bugIf(res.poller == nil, "bug: bad match result in Offer")
+	return finish()
 }
 
-func syncOfferTask[T any](
+func (tm *TaskMatcher) syncOfferTask(
 	ctx context.Context,
-	tm *TaskMatcher,
 	task *internalTask,
-	taskChan chan *internalTask,
-	forwardFunc func(context.Context, *internalTask) (T, error),
 	returnNoPollerErr bool,
-) (T, error) {
-	var t T
-	select {
-	case taskChan <- task:
-		<-task.responseC
-		return t, nil
-	default:
-	}
+) (any, error) {
+	ctxs := []context.Context{ctx, tm.matcherCtx}
 
-	fwdrTokenC := tm.fwdrAddReqTokenC()
-	var noPollerC <-chan time.Time
-
-	for {
-		if returnNoPollerErr {
-			returnNoPollerErr = false // only do this once
-			if deadline, ok := ctx.Deadline(); ok && fwdrTokenC == nil {
-				// Reserving 1sec to customize the timeout error if user is querying a workflow
-				// without having started the workers.
-				noPollerTimeout := time.Until(deadline) - returnEmptyTaskTimeBudget
-				t := time.NewTimer(noPollerTimeout)
-				noPollerC = t.C
-				defer t.Stop()
-			}
-		}
-
-		select {
-		case taskChan <- task:
-			<-task.responseC
-			return t, nil
-		case token := <-fwdrTokenC:
-			resp, err := forwardFunc(ctx, task)
-			token.release()
-			if err == nil {
-				return resp, nil
-			}
-			if errors.Is(err, errForwarderSlowDown) {
-				// if we are rate limited, try only local match for the remainder of the context timeout
-				// left
-				fwdrTokenC = nil
-				continue
-			}
-			return t, err
-		case <-noPollerC:
-			// only error if there has not been a recent poller. Otherwise, let it wait for the remaining time
-			// hopping for a match, or ultimately returning the default CDE error.
-			if tm.timeSinceLastPoll() > tm.config.QueryPollerUnavailableWindow() {
-				return t, errNoRecentPoller
-			}
-			continue
-		case <-ctx.Done():
-			return t, ctx.Err()
+	if returnNoPollerErr {
+		if deadline, ok := ctx.Deadline(); ok && tm.fwdr == nil {
+			// Reserving 1sec to customize the timeout error if user is querying a workflow
+			// without having started the workers.
+			noPollerDeadline := deadline.Add(-returnEmptyTaskTimeBudget)
+			noPollerCtx, cancel := context.WithDeadline(context.Background(), noPollerDeadline)
+			defer cancel()
+			ctxs = append(ctxs, noPollerCtx)
 		}
 	}
+
+	task.forwardCtx = ctx
+again:
+	res := tm.data.EnqueueTaskAndWait(ctxs, task)
+
+	if res.ctxErr != nil {
+		if res.ctxErrIdx == 2 {
+			// Index 2 is the noPollerCtx. Only error if there has not been a recent poller.
+			// Otherwise, let it wait for the remaining time hopping for a match, or ultimately
+			// returning the default CDE error.
+			if tm.data.TimeSinceLastPoll() > tm.config.QueryPollerUnavailableWindow() {
+				return nil, errNoRecentPoller
+			}
+			ctxs = ctxs[:2] // remove noPollerCtx otherwise we'll fail immediately again
+			goto again
+		}
+		return nil, res.ctxErr
+	}
+	bugIf(res.poller == nil, "bug: bad match result in syncOfferTask")
+	response, ok := task.getResponse()
+	bugIf(!ok, "OfferQuery/OfferNexusTask must be given a sync match task")
+	// Note: if task was not forwarded, this will just be the zero value and nil.
+	// That's intended: the query/nexus handler in matchingEngine will wait for the real
+	// result separately.
+	return response.forwardRes, response.forwardErr
 }
 
 // OfferQuery will either match task to local poller or will forward query task.
 // Local match is always attempted before forwarding is attempted. If local match occurs
 // response and error are both nil, if forwarding occurs then response or error is returned.
 func (tm *TaskMatcher) OfferQuery(ctx context.Context, task *internalTask) (*matchingservice.QueryWorkflowResponse, error) {
-	return syncOfferTask(ctx, tm, task, tm.queryTaskC, tm.fwdr.ForwardQueryTask, true)
+	res, err := tm.syncOfferTask(ctx, task, true)
+	if res != nil { // note res may be non-nil "any" containing nil pointer
+		return res.(*matchingservice.QueryWorkflowResponse), err
+	}
+	return nil, err
 }
 
 // OfferNexusTask either matchs a task to a local poller or forwards it if no local pollers available.
 // Local match is always attempted before forwarding. If local match occurs response and error are both nil, if
 // forwarding occurs then response or error is returned.
 func (tm *TaskMatcher) OfferNexusTask(ctx context.Context, task *internalTask) (*matchingservice.DispatchNexusTaskResponse, error) {
-	return syncOfferTask(ctx, tm, task, tm.taskC, tm.fwdr.ForwardNexusTask, false)
+	res, err := tm.syncOfferTask(ctx, task, true)
+	if res != nil { // note res may be non-nil "any" containing nil pointer
+		return res.(*matchingservice.DispatchNexusTaskResponse), err
+	}
+	return nil, err
 }
 
-// MustOffer blocks until a consumer is found to handle this task
-// Returns error only when context is canceled or the ratelimit is set to zero (allow nothing)
-// The passed in context MUST NOT have a deadline associated with it
-// Note that calling MustOffer is the only way that matcher knows there are spooled tasks in the
-// backlog, in absence of a pending MustOffer call, the forwarding logic assumes that backlog is empty.
-func (tm *TaskMatcher) MustOffer(ctx context.Context, task *internalTask, interruptCh <-chan struct{}) error {
-	tm.registerBacklogTask(task)
-	defer tm.unregisterBacklogTask(task)
-
-	if err := tm.rateLimiter.Wait(ctx); err != nil {
-		return err
-	}
-
-	// because we waited on the rate limiter to offer this task,
-	// attach the rate limiter's RecycleToken func to the task
-	// so that if the task is later determined to be invalid,
-	// we can recycle the token it used.
-	task.recycleToken = tm.rateLimiter.RecycleToken
-
-	// attempt a match with local poller first. When that
-	// doesn't succeed, try both local match and remote match
-	select {
-	case tm.taskC <- task:
-		tm.emitDispatchLatency(task, false)
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
-
-	var reconsiderFwdTimer *time.Timer
-	defer func() {
-		if reconsiderFwdTimer != nil {
-			reconsiderFwdTimer.Stop()
-		}
-	}()
-
-forLoop:
-	for {
-		fwdTokenC := tm.fwdrAddReqTokenC()
-		reconsiderFwdTimer = nil
-		var reconsiderFwdTimerC <-chan time.Time
-		if fwdTokenC != nil && !tm.isBacklogNegligible() {
-			// If there is a non-negligible backlog, we stop forwarding to make sure
-			// root and leaf partitions are treated equally and can process their
-			// backlog at the same rate. Stopping task forwarding, prevent poll
-			// forwarding as well (in presence of a backlog). This ensures all partitions
-			// receive polls and tasks at the same rate.
-
-			// Exception: we allow forward if this partition has not got any polls
-			// recently. This is helpful when there are very few pollers and they
-			// and they are all stuck in the wrong (root) partition. (Note that since
-			// frontend balanced the number of pending pollers per partition this only
-			// becomes an issue when the pollers are fewer than the partitions)
-			lp := tm.timeSinceLastPoll()
-			maxWaitForLocalPoller := tm.config.MaxWaitForPollerBeforeFwd()
-			if lp < maxWaitForLocalPoller {
-				fwdTokenC = nil
-				reconsiderFwdTimer = time.NewTimer(maxWaitForLocalPoller - lp)
-				reconsiderFwdTimerC = reconsiderFwdTimer.C
-			}
-		}
-
-		select {
-		case tm.taskC <- task:
-			tm.emitDispatchLatency(task, false)
-			return nil
-		case token := <-fwdTokenC:
-			childCtx, cancel := context.WithTimeout(ctx, time.Second*2)
-			err := tm.fwdr.ForwardTask(childCtx, task)
-			token.release()
-			if err != nil {
-				metrics.ForwardTaskErrorsPerTaskQueue.With(tm.metricsHandler).Record(1)
-				// forwarder returns error only when the call is rate limited. To
-				// avoid a busy loop on such rate limiting events, we only attempt to make
-				// the next forwarded call after this childCtx expires. Till then, we block
-				// hoping for a local poller match
-				select {
-				case tm.taskC <- task:
-					cancel()
-					tm.emitDispatchLatency(task, false)
-					return nil
-				case <-childCtx.Done():
-				case <-ctx.Done():
-					cancel()
-					return ctx.Err()
-				case <-interruptCh:
-					cancel()
-					return errInterrupted
-				}
-				cancel()
-				continue forLoop
-			}
-			cancel()
-			// at this point, we forwarded the task to a parent partition which
-			// in turn dispatched the task to a poller, because there was no error.
-			// Make sure we delete the task from the database.
-			task.finish(nil, true)
-			tm.emitDispatchLatency(task, true)
-			return nil
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-reconsiderFwdTimerC:
-			continue forLoop
-		case <-interruptCh:
-			return errInterrupted
-		}
-	}
+func (tm *TaskMatcher) AddTask(task *internalTask) {
+	tm.data.EnqueueTaskNoWait(task)
 }
 
 func (tm *TaskMatcher) emitDispatchLatency(task *internalTask, forwarded bool) {
@@ -435,15 +463,17 @@ func (tm *TaskMatcher) emitDispatchLatency(task *internalTask, forwarded bool) {
 // On success, the returned task could be a query task or a regular task
 // Returns errNoTasks when context deadline is exceeded
 func (tm *TaskMatcher) Poll(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, error) {
-	task, _, err := tm.poll(ctx, pollMetadata, false)
-	return task, err
+	return tm.poll(ctx, pollMetadata, false)
 }
 
 // PollForQuery blocks until a *query* task is found or context deadline is exceeded
 // Returns errNoTasks when context deadline is exceeded
 func (tm *TaskMatcher) PollForQuery(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, error) {
-	task, _, err := tm.poll(ctx, pollMetadata, true)
-	return task, err
+	return tm.poll(ctx, pollMetadata, true)
+}
+
+func (tm *TaskMatcher) RecheckAllRedirects() {
+	tm.data.RecheckAllRedirects()
 }
 
 // UpdateRatelimit updates the task dispatch rate
@@ -477,188 +507,60 @@ func (tm *TaskMatcher) UpdateRatelimit(rpsPtr *float64) {
 
 // Rate returns the current rate at which tasks are dispatched
 func (tm *TaskMatcher) Rate() float64 {
-	return tm.rateLimiter.Rate()
+	return tm.data.rateLimiter.Rate()
 }
 
 func (tm *TaskMatcher) poll(
 	ctx context.Context, pollMetadata *pollMetadata, queryOnly bool,
-) (task *internalTask, forwardedPoll bool, err error) {
-	taskC, queryTaskC := tm.taskC, tm.queryTaskC
-	if queryOnly {
-		taskC = nil
-	}
-
+) (*internalTask, error) {
 	start := time.Now()
-	tm.lastPoller.Store(start.UnixNano())
+	pollWasForwarded := false
 
 	defer func() {
+		// TODO(pri): can we consolidate all the metrics code below?
 		if pollMetadata.forwardedFrom == "" {
 			// Only recording for original polls
 			metrics.PollLatencyPerTaskQueue.With(tm.metricsHandler).Record(
-				time.Since(start), metrics.StringTag("forwarded", strconv.FormatBool(forwardedPoll)))
-		}
-
-		if err == nil {
-			tm.emitForwardedSourceStats(task.isForwarded(), pollMetadata.forwardedFrom, forwardedPoll)
+				time.Since(start), metrics.StringTag("forwarded", strconv.FormatBool(pollWasForwarded)))
 		}
 	}()
 
-	// We want to effectively do a prioritized select, but Go select is random
-	// if multiple cases are ready, so split into multiple selects.
-	// The priority order is:
-	// 1. ctx.Done or tm.closeC
-	// 2. taskC and queryTaskC
-	// 3. forwarding
-	// 4. block looking locally for remainder of context lifetime
-	// To correctly handle priorities and allow any case to succeed, all select
-	// statements except for the last one must be non-blocking, and the last one
-	// must include all the previous cases.
-
-	// 1. ctx.Done
-	select {
-	case <-ctx.Done():
-		metrics.PollTimeoutPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-		return nil, false, errNoTasks
-	case <-tm.closeC:
-		return nil, false, errNoTasks
-	default:
+	ctxs := []context.Context{ctx, tm.matcherCtx}
+	poller := &waitingPoller{
+		startTime:    start,
+		queryOnly:    queryOnly,
+		forwardCtx:   ctx,
+		pollMetadata: pollMetadata,
 	}
+	res := tm.data.EnqueuePollerAndWait(ctxs, poller)
 
-	// 2. taskC and queryTaskC
-	select {
-	case task := <-taskC:
-		if task.responseC != nil {
-			metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-		}
-		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-		return task, false, nil
-	case task := <-queryTaskC:
-		metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-		return task, false, nil
-	default:
-	}
-
-	if tm.isBacklogNegligible() {
-		// 3. forwarding (and all other clauses repeated)
-		// We don't forward pollers if there is a non-negligible backlog in this partition.
-		select {
-		case <-ctx.Done():
+	if res.ctxErr != nil {
+		if res.ctxErrIdx == 0 {
 			metrics.PollTimeoutPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-			return nil, false, errNoTasks
-		case <-tm.closeC:
-			return nil, false, errNoTasks
-		case task := <-taskC:
-			if task.responseC != nil {
-				metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-			}
-			metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-			return task, false, nil
-		case task := <-queryTaskC:
-			metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-			metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-			return task, false, nil
-		case token := <-tm.fwdrPollReqTokenC():
-			// Arrange to cancel this request if closeC is closed
-			fwdCtx, cancel := contextWithCancelOnChannelClose(ctx, tm.closeC)
-			task, err := tm.fwdr.ForwardPoll(fwdCtx, pollMetadata)
-			cancel()
-			token.release()
-			if err == nil {
-				return task, true, nil
-			}
 		}
+		return nil, errNoTasks
 	}
+	bugIf(res.task == nil, "bug: bad match result in poll")
 
-	// 4. blocking local poll
-	select {
-	case <-ctx.Done():
-		metrics.PollTimeoutPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-		return nil, false, errNoTasks
-	case <-tm.closeC:
-		return nil, false, errNoTasks
-	case task := <-taskC:
-		if task.responseC != nil {
+	task := res.task
+	pollWasForwarded = task.isStarted()
+
+	if !task.isQuery() {
+		if task.isSyncMatchTask() {
 			metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
 		}
 		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-		return task, false, nil
-	case task := <-queryTaskC:
+	} else {
 		metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
 		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-		return task, false, nil
 	}
-}
+	tm.emitForwardedSourceStats(task.isForwarded(), pollMetadata.forwardedFrom, pollWasForwarded)
 
-func (tm *TaskMatcher) fwdrPollReqTokenC() <-chan *ForwarderReqToken {
-	if tm.fwdr == nil {
-		return nil
-	}
-	return tm.fwdr.PollReqTokenC()
-}
-
-func (tm *TaskMatcher) fwdrAddReqTokenC() <-chan *ForwarderReqToken {
-	if tm.fwdr == nil {
-		return nil
-	}
-	return tm.fwdr.AddReqTokenC()
+	return task, nil
 }
 
 func (tm *TaskMatcher) isForwardingAllowed() bool {
 	return tm.fwdr != nil
-}
-
-// isBacklogNegligible returns true of the age of backlog is less than the threshold. Note that this relies on
-// MustOffer being called when there is a backlog, otherwise we'd not know.
-func (tm *TaskMatcher) isBacklogNegligible() bool {
-	return tm.getBacklogAge() < tm.config.BacklogNegligibleAge()
-}
-
-func (tm *TaskMatcher) registerBacklogTask(task *internalTask) {
-	if task.event.Data.CreateTime == nil {
-		return // should not happen but for safety
-	}
-
-	tm.backlogTasksLock.Lock()
-	defer tm.backlogTasksLock.Unlock()
-
-	ts := timestamp.TimeValue(task.event.Data.CreateTime).UnixNano()
-	tm.backlogTasksCreateTime[ts] += 1
-}
-
-func (tm *TaskMatcher) unregisterBacklogTask(task *internalTask) {
-	if task.event.Data.CreateTime == nil {
-		return // should not happen but for safety
-	}
-
-	tm.backlogTasksLock.Lock()
-	defer tm.backlogTasksLock.Unlock()
-
-	ts := timestamp.TimeValue(task.event.Data.CreateTime).UnixNano()
-	counter := tm.backlogTasksCreateTime[ts]
-	if counter == 1 {
-		delete(tm.backlogTasksCreateTime, ts)
-	} else {
-		tm.backlogTasksCreateTime[ts] = counter - 1
-	}
-}
-
-// getBacklogAge is the latest age across all backlogs re-directing to this matcher; may momentarily
-// be 0 cause of race conditions when no reader pushes a task into the matcher at this moment
-func (tm *TaskMatcher) getBacklogAge() time.Duration {
-	tm.backlogTasksLock.Lock()
-	defer tm.backlogTasksLock.Unlock()
-
-	if len(tm.backlogTasksCreateTime) == 0 {
-		return emptyBacklogAge
-	}
-
-	oldest := int64(math.MaxInt64)
-	for createTime := range tm.backlogTasksCreateTime {
-		oldest = min(oldest, createTime)
-	}
-
-	return time.Since(time.Unix(0, oldest))
 }
 
 func (tm *TaskMatcher) emitForwardedSourceStats(
@@ -683,23 +585,4 @@ func (tm *TaskMatcher) emitForwardedSourceStats(
 	default:
 		metrics.LocalToLocalMatchPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
 	}
-}
-
-func (tm *TaskMatcher) timeSinceLastPoll() time.Duration {
-	return time.Since(time.Unix(0, tm.lastPoller.Load()))
-}
-
-// contextWithCancelOnChannelClose returns a child Context and CancelFunc just like
-// context.WithCancel, but additionally propagates cancellation from another channel (besides
-// the parent's cancellation channel).
-func contextWithCancelOnChannelClose(parent context.Context, closeC <-chan struct{}) (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(parent)
-	go func() {
-		select {
-		case <-closeC:
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
-	return ctx, cancel
 }

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -135,15 +135,8 @@ func newTaskMatcher(config *taskQueueConfig, partition tqid.Partition, fwdr *For
 	matcherCtx, matcherCtxCancel := context.WithCancel(matcherCtx)
 
 	return &TaskMatcher{
-		config: config,
-		// FIXME: make real constructor
-		data: matcherData{
-			config:      config,
-			rateLimiter: limiter,
-			tasks: taskPQ{
-				ages: newBacklogAgeTracker(),
-			},
-		},
+		config:             config,
+		data:               newMatcherData(config, limiter),
 		dynamicRateBurst:   dynamicRateBurst,
 		dynamicRateLimiter: dynamicRateLimiter,
 		metricsHandler:     metricsHandler,

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -26,23 +26,18 @@ package matching
 
 import (
 	"context"
+	"errors"
 	"math"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
-	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/backoff"
-	"go.temporal.io/server/common/clock"
-	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/quotas"
-	"go.temporal.io/server/common/tqid"
-	"go.temporal.io/server/common/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -53,12 +48,15 @@ import (
 type TaskMatcher struct {
 	config *taskQueueConfig
 
-	// holds waiting polls and tasks
-	data matcherData
-
-	// Background context used for forwarding tasks. Closed when task queue is closed.
-	matcherCtx       context.Context
-	matcherCtxCancel context.CancelFunc
+	// synchronous task channel to match producer/consumer
+	taskC chan *internalTask
+	// synchronous task channel to match query task - the reason to have a
+	// separate channel for this is that there are cases where consumers
+	// are interested in queryTasks but not others. One example is when a
+	// namespace is not active in a cluster.
+	queryTaskC chan *internalTask
+	// channel closed when task queue is closed, to interrupt pollers
+	closeC chan struct{}
 
 	// dynamicRate is the dynamic rate & burst for rate limiter
 	dynamicRateBurst quotas.MutableRateBurst
@@ -66,53 +64,31 @@ type TaskMatcher struct {
 	dynamicRateLimiter *quotas.DynamicRateLimiterImpl
 	// forceRefreshRateOnce is used to force refresh rate limit for first time
 	forceRefreshRateOnce sync.Once
+	// rateLimiter that limits the rate at which tasks can be dispatched to consumers
+	rateLimiter quotas.RateLimiter
 
-	partition      tqid.Partition
-	fwdr           *Forwarder
-	validator      taskValidator
-	metricsHandler metrics.Handler // namespace metric scope
-	numPartitions  func() int      // number of task queue partitions
-}
-
-type waitingPoller struct {
-	waitableMatchResult
-	startTime       time.Time
-	forwardCtx      context.Context // non-nil iff poll can be forwarded
-	pollMetadata    *pollMetadata   // non-nil iff poll can be forwarded
-	queryOnly       bool            // if true, poller can be given only query task, otherwise any task
-	isTaskForwarder bool
-	isTaskValidator bool
-}
-
-type matchResult struct {
-	task      *internalTask
-	poller    *waitingPoller
-	ctxErr    error // set if context timed out/canceled or reprocess task
-	ctxErrIdx int   // index of context that closed first
+	fwdr                   *Forwarder
+	metricsHandler         metrics.Handler // namespace metric scope
+	numPartitions          func() int      // number of task queue partitions
+	backlogTasksCreateTime map[int64]int   // task creation time (unix nanos) -> number of tasks with that time
+	backlogTasksLock       sync.Mutex
+	lastPoller             atomic.Int64 // unix nanos of most recent poll start time
 }
 
 const (
 	defaultTaskDispatchRPS    = 100000.0
 	defaultTaskDispatchRPSTTL = time.Minute
-
-	// TODO(pri): make dynamic config
-	backlogTaskForwardTimeout = 60 * time.Second
 )
 
 var (
+	// Sentinel error to redirect while blocked in matcher.
+	errInterrupted    = errors.New("interrupted offer")
 	errNoRecentPoller = status.Error(codes.FailedPrecondition, "no poller seen for task queue recently, worker may be down")
-
-	// This is a fake error used to force reprocessing of task redirection as used by versioning.
-	// Situations where we do this:
-	// - after validateTasksOnRoot maybe-validates a task (only local backlog)
-	// - when userdata changes, on in-mem tasks (may be either sync or local backlog)
-	// This must be an error type that taskReader will treat as transient and re-enqueue the task.
-	errReprocessTask = serviceerror.NewCanceled("reprocess task")
 )
 
 // newTaskMatcher returns a task matcher instance. The returned instance can be used by task producers and consumers to
 // find a match. Both sync matches and non-sync matches should use this implementation
-func newTaskMatcher(config *taskQueueConfig, partition tqid.Partition, fwdr *Forwarder, validator taskValidator, metricsHandler metrics.Handler) *TaskMatcher {
+func newTaskMatcher(config *taskQueueConfig, fwdr *Forwarder, metricsHandler metrics.Handler) *TaskMatcher {
 	dynamicRateBurst := quotas.NewMutableRateBurst(
 		defaultTaskDispatchRPS,
 		int(defaultTaskDispatchRPS),
@@ -130,175 +106,26 @@ func newTaskMatcher(config *taskQueueConfig, partition tqid.Partition, fwdr *For
 			config.AdminNamespaceToPartitionDispatchRate,
 		),
 	})
-
-	matcherCtx := headers.SetCallerInfo(context.Background(), config.CallerInfo)
-	matcherCtx, matcherCtxCancel := context.WithCancel(matcherCtx)
-
 	return &TaskMatcher{
-		config:             config,
-		data:               newMatcherData(config, limiter),
-		dynamicRateBurst:   dynamicRateBurst,
-		dynamicRateLimiter: dynamicRateLimiter,
-		metricsHandler:     metricsHandler,
-		partition:          partition,
-		fwdr:               fwdr,
-		validator:          validator,
-		matcherCtx:         matcherCtx,
-		matcherCtxCancel:   matcherCtxCancel,
-		numPartitions:      config.NumReadPartitions,
+		config:                 config,
+		dynamicRateBurst:       dynamicRateBurst,
+		dynamicRateLimiter:     dynamicRateLimiter,
+		rateLimiter:            limiter,
+		metricsHandler:         metricsHandler,
+		fwdr:                   fwdr,
+		taskC:                  make(chan *internalTask),
+		queryTaskC:             make(chan *internalTask),
+		closeC:                 make(chan struct{}),
+		numPartitions:          config.NumReadPartitions,
+		backlogTasksCreateTime: make(map[int64]int),
 	}
 }
 
 func (tm *TaskMatcher) Start() {
-	policy := backoff.NewExponentialRetryPolicy(time.Second).
-		WithMaximumInterval(backlogTaskForwardTimeout).
-		WithExpirationInterval(backoff.NoInterval)
-	retrier := backoff.NewRetrier(policy, clock.NewRealTimeSource())
-	lim := quotas.NewDefaultOutgoingRateLimiter(tm.config.ForwarderMaxRatePerSecond)
-
-	if tm.fwdr == nil {
-		// Root doesn't forward. But it does need something to validate tasks.
-		go tm.validateTasksOnRoot(lim, retrier)
-		return
-	}
-
-	// Child partitions:
-	for range tm.config.ForwarderMaxOutstandingTasks() {
-		go tm.forwardTasks(lim, retrier)
-	}
-	for range tm.config.ForwarderMaxOutstandingPolls() {
-		go tm.forwardPolls()
-	}
 }
 
 func (tm *TaskMatcher) Stop() {
-	tm.matcherCtxCancel()
-}
-
-func (tm *TaskMatcher) forwardTasks(lim quotas.RateLimiter, retrier backoff.Retrier) {
-	ctxs := []context.Context{tm.matcherCtx}
-	poller := waitingPoller{isTaskForwarder: true}
-	for {
-		if lim.Wait(tm.matcherCtx) != nil {
-			return
-		}
-
-		res := tm.data.EnqueuePollerAndWait(ctxs, &poller)
-		if res.ctxErr != nil {
-			return // task queue closing
-		}
-		bugIf(res.task == nil, "bug: bad match result in forwardTasks")
-
-		err := tm.forwardTask(res.task)
-
-		// backoff on resource exhausted errors
-		if common.IsResourceExhausted(err) {
-			util.InterruptibleSleep(tm.matcherCtx, retrier.NextBackOff(err))
-		} else {
-			retrier.Reset()
-		}
-	}
-}
-
-func (tm *TaskMatcher) forwardTask(task *internalTask) error {
-	var ctx context.Context
-	var cancel context.CancelFunc
-	if task.forwardCtx != nil {
-		// Use sync match context if we have it (for deadline, headers, etc.)
-		// TODO(pri): does it make sense to subtract 1s from the context deadline here?
-		ctx = task.forwardCtx
-	} else {
-		// Task is from local backlog.
-
-		// Before we forward, ask task validator. This will happen every backlogTaskForwardTimeout
-		// to the head of the backlog, which is what taskValidator expects.
-		maybeValid := tm.validator.maybeValidate(task.event.AllocatedTaskInfo, tm.fwdr.partition.TaskType())
-		if !maybeValid {
-			task.finish(nil, false)
-			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1)
-			return nil
-		}
-
-		// Add a timeout for forwarding.
-		// Note that this does not block local match of other local backlog tasks.
-		ctx, cancel = context.WithTimeout(tm.matcherCtx, backlogTaskForwardTimeout)
-		defer cancel()
-	}
-
-	if task.isQuery() {
-		res, err := tm.fwdr.ForwardQueryTask(ctx, task)
-		task.finishForward(res, err, true)
-		return err
-	}
-
-	if task.isNexus() {
-		res, err := tm.fwdr.ForwardNexusTask(ctx, task)
-		task.finishForward(res, err, true)
-		return err
-	}
-
-	// normal wf/activity task
-	err := tm.fwdr.ForwardTask(ctx, task)
-	task.finishForward(nil, err, true)
-
-	return err
-}
-
-func (tm *TaskMatcher) validateTasksOnRoot(lim quotas.RateLimiter, retrier backoff.Retrier) {
-	ctxs := []context.Context{tm.matcherCtx}
-	poller := &waitingPoller{isTaskForwarder: true, isTaskValidator: true}
-	for {
-		if lim.Wait(tm.matcherCtx) != nil {
-			return
-		}
-
-		res := tm.data.EnqueuePollerAndWait(ctxs, poller)
-		if res.ctxErr != nil {
-			return // task queue closing
-		}
-		bugIf(res.task == nil, "bug: bad match result in validateTasksOnRoot")
-
-		task := res.task
-		bugIf(task.forwardCtx != nil || task.isSyncMatchTask() || task.source != enumsspb.TASK_SOURCE_DB_BACKLOG,
-			"bug: validator got a sync task")
-		maybeValid := tm.validator == nil || tm.validator.maybeValidate(task.event.AllocatedTaskInfo, tm.partition.TaskType())
-		if !maybeValid {
-			// We found an invalid one, complete it and go back for another immediately.
-			task.finish(nil, false)
-			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1)
-			retrier.Reset()
-		} else {
-			// Task was valid, put it back and slow down checking.
-			task.finish(errReprocessTask, true)
-			// retrier's max interval is backlogTaskForwardTimeout, so for just valid tasks,
-			// this loop will essentially be limited to that interval.
-			util.InterruptibleSleep(tm.matcherCtx, retrier.NextBackOff(nil))
-		}
-	}
-}
-
-func (tm *TaskMatcher) forwardPolls() {
-	forwarderTask := &internalTask{isPollForwarder: true}
-	ctxs := []context.Context{tm.matcherCtx}
-	for {
-		res := tm.data.EnqueueTaskAndWait(ctxs, forwarderTask)
-		if res.ctxErr != nil {
-			return // task queue closing
-		}
-		bugIf(res.poller == nil, "bug: bad match result in forwardPolls")
-
-		poller := res.poller
-		// We need to use the real source poller context since it has the poller id and
-		// identity, plus the right deadline.
-		task, err := tm.fwdr.ForwardPoll(poller.forwardCtx, poller.pollMetadata)
-		if err == nil {
-			tm.data.finishMatchAfterPollForward(poller, task)
-		} else {
-			// Re-enqueue to let it match again, if it hasn't gotten a context timeout already.
-			poller.forwardCtx = nil // disable forwarding next time
-			tm.data.ReenqueuePollerIfNotMatched(poller)
-		}
-	}
+	close(tm.closeC)
 }
 
 // Offer offers a task to a potential consumer (poller)
@@ -331,120 +158,267 @@ func (tm *TaskMatcher) forwardPolls() {
 //   - context deadline is exceeded
 //   - task is matched and consumer returns error in response channel
 func (tm *TaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, error) {
-	finish := func() (bool, error) {
-		res, ok := task.getResponse()
-		bugIf(!ok, "Offer must be given a sync match task")
-		if res.forwarded {
-			if res.forwardErr == nil {
+	if !tm.isBacklogNegligible() {
+		// To ensure better dispatch ordering, we block sync match when a significant backlog is present.
+		// Note that this check does not make a noticeable difference for history tasks, as they do not wait for a
+		// poller to become available. In presence of a backlog the chance of a poller being available when sync match
+		// request comes is almost zero.
+		// This check is mostly effective for the sync match requests that come from child partitions for spooled tasks.
+		return false, nil
+	}
+
+	if !task.isForwarded() {
+		if err := tm.rateLimiter.Wait(ctx); err != nil {
+			metrics.SyncThrottlePerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+			return false, err
+		}
+		// because we waited on the rate limiter to offer this task,
+		// attach the rate limiter's RecycleToken func to the task
+		// so that if the task is later determined to be invalid,
+		// we can recycle the token it used.
+		task.recycleToken = tm.rateLimiter.RecycleToken
+	}
+
+	select {
+	case tm.taskC <- task: // poller picked up the task
+		if task.responseC != nil {
+			// if there is a response channel, block until resp is received
+			// and return error if the response contains error
+			err := <-task.responseC
+
+			if err.startErr == nil && !task.isForwarded() {
+				tm.emitDispatchLatency(task, false)
+			}
+			return true, err.startErr
+		}
+		return false, nil
+	default:
+		// no poller waiting for tasks, try forwarding this task to the
+		// root partition if possible
+		select {
+		case token := <-tm.fwdrAddReqTokenC():
+			if err := tm.fwdr.ForwardTask(ctx, task); err == nil {
 				// task was remotely sync matched on the parent partition
+				token.release()
 				tm.emitDispatchLatency(task, true)
 				return true, nil
 			}
-			return false, nil // forward error, give up here
+			token.release()
+		default:
+			if !tm.isForwardingAllowed() && // we are the root partition and forwarding is not possible
+				task.source == enumsspb.TASK_SOURCE_DB_BACKLOG && // task was from backlog (stored in db)
+				task.isForwarded() { // task came from a child partition
+				// a forwarded backlog task from a child partition, block trying
+				// to match with a poller until ctx timeout
+				return tm.offerOrTimeout(ctx, task)
+			}
 		}
-		// TODO(pri): can we just always do this on the parent and simplify this to:
-		// if res.startErr == nil { tm.emitDispatchLatency(task, task.isForwarded) }
-		// and get rid of the call above so there's only one?
-		if res.startErr == nil && !task.isForwarded() {
-			tm.emitDispatchLatency(task, false)
-		}
-		return true, res.startErr
-	}
 
-	// Fast path if we have a waiting poller (or forwarder).
-	// Forwarding happens here if we match with the task forwarding poller.
-	task.forwardCtx = ctx
-	if canMatch, gotMatch := tm.data.MatchNextPoller(task); gotMatch {
-		return finish()
-	} else if !canMatch {
 		return false, nil
 	}
-
-	// We only block if we are the root and the task is forwarded from a backlog.
-	// Otherwise, stop here.
-	if tm.isForwardingAllowed() ||
-		task.source != enumsspb.TASK_SOURCE_DB_BACKLOG ||
-		!task.isForwarded() {
-		return false, nil
-	}
-
-	res := tm.data.EnqueueTaskAndWait([]context.Context{ctx, tm.matcherCtx}, task)
-
-	if res.ctxErr != nil {
-		return false, res.ctxErr
-	}
-	bugIf(res.poller == nil, "bug: bad match result in Offer")
-	return finish()
 }
 
-func (tm *TaskMatcher) syncOfferTask(
-	ctx context.Context,
-	task *internalTask,
-	returnNoPollerErr bool,
-) (any, error) {
-	ctxs := []context.Context{ctx, tm.matcherCtx}
-
-	if returnNoPollerErr {
-		if deadline, ok := ctx.Deadline(); ok && tm.fwdr == nil {
-			// Reserving 1sec to customize the timeout error if user is querying a workflow
-			// without having started the workers.
-			noPollerDeadline := deadline.Add(-returnEmptyTaskTimeBudget)
-			noPollerCtx, cancel := context.WithDeadline(context.Background(), noPollerDeadline)
-			defer cancel()
-			ctxs = append(ctxs, noPollerCtx)
-		}
-	}
-
-	task.forwardCtx = ctx
-again:
-	res := tm.data.EnqueueTaskAndWait(ctxs, task)
-
-	if res.ctxErr != nil {
-		if res.ctxErrIdx == 2 {
-			// Index 2 is the noPollerCtx. Only error if there has not been a recent poller.
-			// Otherwise, let it wait for the remaining time hopping for a match, or ultimately
-			// returning the default CDE error.
-			if tm.data.TimeSinceLastPoll() > tm.config.QueryPollerUnavailableWindow() {
-				return nil, errNoRecentPoller
+func (tm *TaskMatcher) offerOrTimeout(ctx context.Context, task *internalTask) (bool, error) {
+	select {
+	case tm.taskC <- task: // poller picked up the task
+		if task.responseC != nil {
+			select {
+			case err := <-task.responseC:
+				return true, err.startErr
+			case <-ctx.Done():
+				return false, nil
 			}
-			ctxs = ctxs[:2] // remove noPollerCtx otherwise we'll fail immediately again
-			goto again
 		}
-		return nil, res.ctxErr
+		return false, nil
+	case <-ctx.Done():
+		return false, nil
 	}
-	bugIf(res.poller == nil, "bug: bad match result in syncOfferTask")
-	response, ok := task.getResponse()
-	bugIf(!ok, "OfferQuery/OfferNexusTask must be given a sync match task")
-	// Note: if task was not forwarded, this will just be the zero value and nil.
-	// That's intended: the query/nexus handler in matchingEngine will wait for the real
-	// result separately.
-	return response.forwardRes, response.forwardErr
+}
+
+func syncOfferTask[T any](
+	ctx context.Context,
+	tm *TaskMatcher,
+	task *internalTask,
+	taskChan chan *internalTask,
+	forwardFunc func(context.Context, *internalTask) (T, error),
+	returnNoPollerErr bool,
+) (T, error) {
+	var t T
+	select {
+	case taskChan <- task:
+		<-task.responseC
+		return t, nil
+	default:
+	}
+
+	fwdrTokenC := tm.fwdrAddReqTokenC()
+	var noPollerC <-chan time.Time
+
+	for {
+		if returnNoPollerErr {
+			returnNoPollerErr = false // only do this once
+			if deadline, ok := ctx.Deadline(); ok && fwdrTokenC == nil {
+				// Reserving 1sec to customize the timeout error if user is querying a workflow
+				// without having started the workers.
+				noPollerTimeout := time.Until(deadline) - returnEmptyTaskTimeBudget
+				t := time.NewTimer(noPollerTimeout)
+				noPollerC = t.C
+				defer t.Stop()
+			}
+		}
+
+		select {
+		case taskChan <- task:
+			<-task.responseC
+			return t, nil
+		case token := <-fwdrTokenC:
+			resp, err := forwardFunc(ctx, task)
+			token.release()
+			if err == nil {
+				return resp, nil
+			}
+			if errors.Is(err, errForwarderSlowDown) {
+				// if we are rate limited, try only local match for the remainder of the context timeout
+				// left
+				fwdrTokenC = nil
+				continue
+			}
+			return t, err
+		case <-noPollerC:
+			// only error if there has not been a recent poller. Otherwise, let it wait for the remaining time
+			// hopping for a match, or ultimately returning the default CDE error.
+			if tm.timeSinceLastPoll() > tm.config.QueryPollerUnavailableWindow() {
+				return t, errNoRecentPoller
+			}
+			continue
+		case <-ctx.Done():
+			return t, ctx.Err()
+		}
+	}
 }
 
 // OfferQuery will either match task to local poller or will forward query task.
 // Local match is always attempted before forwarding is attempted. If local match occurs
 // response and error are both nil, if forwarding occurs then response or error is returned.
 func (tm *TaskMatcher) OfferQuery(ctx context.Context, task *internalTask) (*matchingservice.QueryWorkflowResponse, error) {
-	res, err := tm.syncOfferTask(ctx, task, true)
-	if res != nil { // note res may be non-nil "any" containing nil pointer
-		return res.(*matchingservice.QueryWorkflowResponse), err
-	}
-	return nil, err
+	return syncOfferTask(ctx, tm, task, tm.queryTaskC, tm.fwdr.ForwardQueryTask, true)
 }
 
 // OfferNexusTask either matchs a task to a local poller or forwards it if no local pollers available.
 // Local match is always attempted before forwarding. If local match occurs response and error are both nil, if
 // forwarding occurs then response or error is returned.
 func (tm *TaskMatcher) OfferNexusTask(ctx context.Context, task *internalTask) (*matchingservice.DispatchNexusTaskResponse, error) {
-	res, err := tm.syncOfferTask(ctx, task, true)
-	if res != nil { // note res may be non-nil "any" containing nil pointer
-		return res.(*matchingservice.DispatchNexusTaskResponse), err
-	}
-	return nil, err
+	return syncOfferTask(ctx, tm, task, tm.taskC, tm.fwdr.ForwardNexusTask, false)
 }
 
-func (tm *TaskMatcher) AddTask(task *internalTask) {
-	tm.data.EnqueueTaskNoWait(task)
+// MustOffer blocks until a consumer is found to handle this task
+// Returns error only when context is canceled or the ratelimit is set to zero (allow nothing)
+// The passed in context MUST NOT have a deadline associated with it
+// Note that calling MustOffer is the only way that matcher knows there are spooled tasks in the
+// backlog, in absence of a pending MustOffer call, the forwarding logic assumes that backlog is empty.
+func (tm *TaskMatcher) MustOffer(ctx context.Context, task *internalTask, interruptCh <-chan struct{}) error {
+	tm.registerBacklogTask(task)
+	defer tm.unregisterBacklogTask(task)
+
+	if err := tm.rateLimiter.Wait(ctx); err != nil {
+		return err
+	}
+
+	// because we waited on the rate limiter to offer this task,
+	// attach the rate limiter's RecycleToken func to the task
+	// so that if the task is later determined to be invalid,
+	// we can recycle the token it used.
+	task.recycleToken = tm.rateLimiter.RecycleToken
+
+	// attempt a match with local poller first. When that
+	// doesn't succeed, try both local match and remote match
+	select {
+	case tm.taskC <- task:
+		tm.emitDispatchLatency(task, false)
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	var reconsiderFwdTimer *time.Timer
+	defer func() {
+		if reconsiderFwdTimer != nil {
+			reconsiderFwdTimer.Stop()
+		}
+	}()
+
+forLoop:
+	for {
+		fwdTokenC := tm.fwdrAddReqTokenC()
+		reconsiderFwdTimer = nil
+		var reconsiderFwdTimerC <-chan time.Time
+		if fwdTokenC != nil && !tm.isBacklogNegligible() {
+			// If there is a non-negligible backlog, we stop forwarding to make sure
+			// root and leaf partitions are treated equally and can process their
+			// backlog at the same rate. Stopping task forwarding, prevent poll
+			// forwarding as well (in presence of a backlog). This ensures all partitions
+			// receive polls and tasks at the same rate.
+
+			// Exception: we allow forward if this partition has not got any polls
+			// recently. This is helpful when there are very few pollers and they
+			// and they are all stuck in the wrong (root) partition. (Note that since
+			// frontend balanced the number of pending pollers per partition this only
+			// becomes an issue when the pollers are fewer than the partitions)
+			lp := tm.timeSinceLastPoll()
+			maxWaitForLocalPoller := tm.config.MaxWaitForPollerBeforeFwd()
+			if lp < maxWaitForLocalPoller {
+				fwdTokenC = nil
+				reconsiderFwdTimer = time.NewTimer(maxWaitForLocalPoller - lp)
+				reconsiderFwdTimerC = reconsiderFwdTimer.C
+			}
+		}
+
+		select {
+		case tm.taskC <- task:
+			tm.emitDispatchLatency(task, false)
+			return nil
+		case token := <-fwdTokenC:
+			childCtx, cancel := context.WithTimeout(ctx, time.Second*2)
+			err := tm.fwdr.ForwardTask(childCtx, task)
+			token.release()
+			if err != nil {
+				metrics.ForwardTaskErrorsPerTaskQueue.With(tm.metricsHandler).Record(1)
+				// forwarder returns error only when the call is rate limited. To
+				// avoid a busy loop on such rate limiting events, we only attempt to make
+				// the next forwarded call after this childCtx expires. Till then, we block
+				// hoping for a local poller match
+				select {
+				case tm.taskC <- task:
+					cancel()
+					tm.emitDispatchLatency(task, false)
+					return nil
+				case <-childCtx.Done():
+				case <-ctx.Done():
+					cancel()
+					return ctx.Err()
+				case <-interruptCh:
+					cancel()
+					return errInterrupted
+				}
+				cancel()
+				continue forLoop
+			}
+			cancel()
+			// at this point, we forwarded the task to a parent partition which
+			// in turn dispatched the task to a poller, because there was no error.
+			// Make sure we delete the task from the database.
+			task.finish(nil, true)
+			tm.emitDispatchLatency(task, true)
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-reconsiderFwdTimerC:
+			continue forLoop
+		case <-interruptCh:
+			return errInterrupted
+		}
+	}
 }
 
 func (tm *TaskMatcher) emitDispatchLatency(task *internalTask, forwarded bool) {
@@ -463,27 +437,19 @@ func (tm *TaskMatcher) emitDispatchLatency(task *internalTask, forwarded bool) {
 // On success, the returned task could be a query task or a regular task
 // Returns errNoTasks when context deadline is exceeded
 func (tm *TaskMatcher) Poll(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, error) {
-	return tm.poll(ctx, pollMetadata, false)
+	task, _, err := tm.poll(ctx, pollMetadata, false)
+	return task, err
 }
 
 // PollForQuery blocks until a *query* task is found or context deadline is exceeded
 // Returns errNoTasks when context deadline is exceeded
 func (tm *TaskMatcher) PollForQuery(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, error) {
-	return tm.poll(ctx, pollMetadata, true)
+	task, _, err := tm.poll(ctx, pollMetadata, true)
+	return task, err
 }
 
 func (tm *TaskMatcher) ReprocessAllTasks() {
-	tasks := tm.data.ReprocessTasks(func(task *internalTask) (shouldRemove bool) {
-		// TODO(pri): do we have to reprocess _all_ backlog tasks or can we determine
-		// somehow which are potentially redirected?
-		return true
-	})
-	// ReprocessTasks will have woken sync tasks, but for backlog we also need to call finish.
-	for _, task := range tasks {
-		if !task.isSyncMatchTask() {
-			task.finish(errReprocessTask, true)
-		}
-	}
+	// unused in old matcher
 }
 
 // UpdateRatelimit updates the task dispatch rate
@@ -517,60 +483,188 @@ func (tm *TaskMatcher) UpdateRatelimit(rpsPtr *float64) {
 
 // Rate returns the current rate at which tasks are dispatched
 func (tm *TaskMatcher) Rate() float64 {
-	return tm.data.rateLimiter.Rate()
+	return tm.rateLimiter.Rate()
 }
 
 func (tm *TaskMatcher) poll(
 	ctx context.Context, pollMetadata *pollMetadata, queryOnly bool,
-) (*internalTask, error) {
+) (task *internalTask, forwardedPoll bool, err error) {
+	taskC, queryTaskC := tm.taskC, tm.queryTaskC
+	if queryOnly {
+		taskC = nil
+	}
+
 	start := time.Now()
-	pollWasForwarded := false
+	tm.lastPoller.Store(start.UnixNano())
 
 	defer func() {
-		// TODO(pri): can we consolidate all the metrics code below?
 		if pollMetadata.forwardedFrom == "" {
 			// Only recording for original polls
 			metrics.PollLatencyPerTaskQueue.With(tm.metricsHandler).Record(
-				time.Since(start), metrics.StringTag("forwarded", strconv.FormatBool(pollWasForwarded)))
+				time.Since(start), metrics.StringTag("forwarded", strconv.FormatBool(forwardedPoll)))
+		}
+
+		if err == nil {
+			tm.emitForwardedSourceStats(task.isForwarded(), pollMetadata.forwardedFrom, forwardedPoll)
 		}
 	}()
 
-	ctxs := []context.Context{ctx, tm.matcherCtx}
-	poller := &waitingPoller{
-		startTime:    start,
-		queryOnly:    queryOnly,
-		forwardCtx:   ctx,
-		pollMetadata: pollMetadata,
+	// We want to effectively do a prioritized select, but Go select is random
+	// if multiple cases are ready, so split into multiple selects.
+	// The priority order is:
+	// 1. ctx.Done or tm.closeC
+	// 2. taskC and queryTaskC
+	// 3. forwarding
+	// 4. block looking locally for remainder of context lifetime
+	// To correctly handle priorities and allow any case to succeed, all select
+	// statements except for the last one must be non-blocking, and the last one
+	// must include all the previous cases.
+
+	// 1. ctx.Done
+	select {
+	case <-ctx.Done():
+		metrics.PollTimeoutPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+		return nil, false, errNoTasks
+	case <-tm.closeC:
+		return nil, false, errNoTasks
+	default:
 	}
-	res := tm.data.EnqueuePollerAndWait(ctxs, poller)
 
-	if res.ctxErr != nil {
-		if res.ctxErrIdx == 0 {
-			metrics.PollTimeoutPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-		}
-		return nil, errNoTasks
-	}
-	bugIf(res.task == nil, "bug: bad match result in poll")
-
-	task := res.task
-	pollWasForwarded = task.isStarted()
-
-	if !task.isQuery() {
-		if task.isSyncMatchTask() {
+	// 2. taskC and queryTaskC
+	select {
+	case task := <-taskC:
+		if task.responseC != nil {
 			metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
 		}
 		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
-	} else {
+		return task, false, nil
+	case task := <-queryTaskC:
 		metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
 		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+		return task, false, nil
+	default:
 	}
-	tm.emitForwardedSourceStats(task.isForwarded(), pollMetadata.forwardedFrom, pollWasForwarded)
 
-	return task, nil
+	if tm.isBacklogNegligible() {
+		// 3. forwarding (and all other clauses repeated)
+		// We don't forward pollers if there is a non-negligible backlog in this partition.
+		select {
+		case <-ctx.Done():
+			metrics.PollTimeoutPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+			return nil, false, errNoTasks
+		case <-tm.closeC:
+			return nil, false, errNoTasks
+		case task := <-taskC:
+			if task.responseC != nil {
+				metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+			}
+			metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+			return task, false, nil
+		case task := <-queryTaskC:
+			metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+			metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+			return task, false, nil
+		case token := <-tm.fwdrPollReqTokenC():
+			// Arrange to cancel this request if closeC is closed
+			fwdCtx, cancel := contextWithCancelOnChannelClose(ctx, tm.closeC)
+			task, err := tm.fwdr.ForwardPoll(fwdCtx, pollMetadata)
+			cancel()
+			token.release()
+			if err == nil {
+				return task, true, nil
+			}
+		}
+	}
+
+	// 4. blocking local poll
+	select {
+	case <-ctx.Done():
+		metrics.PollTimeoutPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+		return nil, false, errNoTasks
+	case <-tm.closeC:
+		return nil, false, errNoTasks
+	case task := <-taskC:
+		if task.responseC != nil {
+			metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+		}
+		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+		return task, false, nil
+	case task := <-queryTaskC:
+		metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+		return task, false, nil
+	}
+}
+
+func (tm *TaskMatcher) fwdrPollReqTokenC() <-chan *ForwarderReqToken {
+	if tm.fwdr == nil {
+		return nil
+	}
+	return tm.fwdr.PollReqTokenC()
+}
+
+func (tm *TaskMatcher) fwdrAddReqTokenC() <-chan *ForwarderReqToken {
+	if tm.fwdr == nil {
+		return nil
+	}
+	return tm.fwdr.AddReqTokenC()
 }
 
 func (tm *TaskMatcher) isForwardingAllowed() bool {
 	return tm.fwdr != nil
+}
+
+// isBacklogNegligible returns true of the age of backlog is less than the threshold. Note that this relies on
+// MustOffer being called when there is a backlog, otherwise we'd not know.
+func (tm *TaskMatcher) isBacklogNegligible() bool {
+	return tm.getBacklogAge() < tm.config.BacklogNegligibleAge()
+}
+
+func (tm *TaskMatcher) registerBacklogTask(task *internalTask) {
+	if task.event.Data.CreateTime == nil {
+		return // should not happen but for safety
+	}
+
+	tm.backlogTasksLock.Lock()
+	defer tm.backlogTasksLock.Unlock()
+
+	ts := timestamp.TimeValue(task.event.Data.CreateTime).UnixNano()
+	tm.backlogTasksCreateTime[ts] += 1
+}
+
+func (tm *TaskMatcher) unregisterBacklogTask(task *internalTask) {
+	if task.event.Data.CreateTime == nil {
+		return // should not happen but for safety
+	}
+
+	tm.backlogTasksLock.Lock()
+	defer tm.backlogTasksLock.Unlock()
+
+	ts := timestamp.TimeValue(task.event.Data.CreateTime).UnixNano()
+	counter := tm.backlogTasksCreateTime[ts]
+	if counter == 1 {
+		delete(tm.backlogTasksCreateTime, ts)
+	} else {
+		tm.backlogTasksCreateTime[ts] = counter - 1
+	}
+}
+
+// getBacklogAge is the latest age across all backlogs re-directing to this matcher; may momentarily
+// be 0 cause of race conditions when no reader pushes a task into the matcher at this moment
+func (tm *TaskMatcher) getBacklogAge() time.Duration {
+	tm.backlogTasksLock.Lock()
+	defer tm.backlogTasksLock.Unlock()
+
+	if len(tm.backlogTasksCreateTime) == 0 {
+		return emptyBacklogAge
+	}
+
+	oldest := int64(math.MaxInt64)
+	for createTime := range tm.backlogTasksCreateTime {
+		oldest = min(oldest, createTime)
+	}
+
+	return time.Since(time.Unix(0, oldest))
 }
 
 func (tm *TaskMatcher) emitForwardedSourceStats(
@@ -595,4 +689,23 @@ func (tm *TaskMatcher) emitForwardedSourceStats(
 	default:
 		metrics.LocalToLocalMatchPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
 	}
+}
+
+func (tm *TaskMatcher) timeSinceLastPoll() time.Duration {
+	return time.Since(time.Unix(0, tm.lastPoller.Load()))
+}
+
+// contextWithCancelOnChannelClose returns a child Context and CancelFunc just like
+// context.WithCancel, but additionally propagates cancellation from another channel (besides
+// the parent's cancellation channel).
+func contextWithCancelOnChannelClose(parent context.Context, closeC <-chan struct{}) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	go func() {
+		select {
+		case <-closeC:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
 }

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -1,0 +1,516 @@
+// The MIT License
+//
+// Copyright (c) 2025 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"container/heap"
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	enumspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/util"
+)
+
+type matcherData struct {
+	config      *taskQueueConfig
+	rateLimiter quotas.RateLimiter // whole-queue rate limiter
+
+	lock sync.Mutex // covers everything below, and all fields in any waitableMatchResult
+
+	rateLimitTimer         resettableTimer
+	reconsiderForwardTimer resettableTimer
+
+	// waiting pollers and tasks
+	// invariant: all pollers and tasks in these data structures have matchResult == nil
+	pollers pollerPQ
+	tasks   taskPQ
+
+	// backlogAge holds task create time for tasks from merged local backlogs (not forwarded).
+	// note that matcherData may get tasks from multiple versioned backlogs due to
+	// versioning redirection.
+	backlogAge backlogAgeTracker
+	lastPoller time.Time // most recent poll start time
+}
+
+type pollerPQ struct {
+	heap []*waitingPoller
+}
+
+func (p *pollerPQ) Len() int {
+	return len(p.heap)
+}
+
+func (p *pollerPQ) Less(i int, j int) bool {
+	a, b := p.heap[i], p.heap[j]
+	if !(a.isTaskForwarder || a.isTaskValidator) && (b.isTaskForwarder || b.isTaskValidator) {
+		return true
+	} else if a.startTime.Before(b.startTime) {
+		return true
+	}
+	return false
+}
+
+func (p *pollerPQ) Swap(i int, j int) {
+	p.heap[i], p.heap[j] = p.heap[j], p.heap[i]
+	p.heap[i].matchHeapIndex = i
+	p.heap[j].matchHeapIndex = j
+}
+
+func (p *pollerPQ) Push(x any) {
+	poller := x.(*waitingPoller)
+	poller.matchHeapIndex = len(p.heap)
+	p.heap = append(p.heap, poller)
+}
+
+func (p *pollerPQ) Pop() any {
+	last := len(p.heap) - 1
+	poller := p.heap[last]
+	p.heap = p.heap[:last]
+	poller.matchHeapIndex = -11
+	return poller
+}
+
+type taskPQ struct {
+	heap []*internalTask
+}
+
+func (t *taskPQ) Len() int {
+	return len(t.heap)
+}
+
+func (t *taskPQ) Less(i int, j int) bool {
+	a, b := t.heap[i], t.heap[j]
+	if !a.isPollForwarder && b.isPollForwarder {
+		return true
+	}
+	// TODO(pri): use priority, task id, etc.
+	return false
+}
+
+func (t *taskPQ) Swap(i int, j int) {
+	t.heap[i], t.heap[j] = t.heap[j], t.heap[i]
+	t.heap[i].matchHeapIndex = i
+	t.heap[j].matchHeapIndex = j
+}
+
+func (t *taskPQ) Push(x any) {
+	task := x.(*internalTask)
+	task.matchHeapIndex = len(t.heap)
+	t.heap = append(t.heap, task)
+}
+
+func (t *taskPQ) Pop() any {
+	last := len(t.heap) - 1
+	task := t.heap[last]
+	t.heap = t.heap[:last]
+	task.matchHeapIndex = -13
+	return task
+}
+
+func (d *matcherData) EnqueueTaskNoWait(task *internalTask) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if task.source == enumspb.TASK_SOURCE_DB_BACKLOG {
+		d.backlogAge.record(task.event.Data.CreateTime, 1)
+	}
+
+	task.initMatch(d)
+	heap.Push(&d.tasks, task)
+	d.match()
+}
+
+func (d *matcherData) EnqueueTaskAndWait(ctxs []context.Context, task *internalTask) *matchResult {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	// add and look for match
+	task.initMatch(d)
+	heap.Push(&d.tasks, task)
+	d.match()
+
+	// if already matched, return
+	if task.matchResult != nil {
+		return task.matchResult
+	}
+
+	// arrange to wake up on context close
+	for i, ctx := range ctxs {
+		stop := context.AfterFunc(ctx, func() {
+			d.lock.Lock()
+			defer d.lock.Unlock()
+
+			if task.matchResult == nil {
+				heap.Remove(&d.tasks, task.matchHeapIndex)
+				task.wake(&matchResult{ctxErr: ctx.Err(), ctxErrIdx: i})
+			}
+		})
+		defer stop()
+	}
+
+	return task.waitForMatch()
+}
+
+func (d *matcherData) ReenqueuePollerIfNotMatched(poller *waitingPoller) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if poller.matchResult == nil {
+		heap.Push(&d.pollers, poller)
+		d.match()
+	}
+}
+
+func (d *matcherData) EnqueuePollerAndWait(ctxs []context.Context, poller *waitingPoller) *matchResult {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	// update this for timeSinceLastPoll
+	d.lastPoller = util.MaxTime(d.lastPoller, poller.startTime)
+
+	// add and look for match
+	poller.initMatch(d)
+	heap.Push(&d.pollers, poller)
+	d.match()
+
+	// if already matched, return
+	if poller.matchResult != nil {
+		return poller.matchResult
+	}
+
+	// arrange to wake up on context close
+	for i, ctx := range ctxs {
+		stop := context.AfterFunc(ctx, func() {
+			d.lock.Lock()
+			defer d.lock.Unlock()
+
+			if poller.matchResult == nil {
+				// if poll was being forwarded, it would be absent from heap even though
+				// matchResult == nil
+				if poller.matchHeapIndex >= 0 {
+					heap.Remove(&d.pollers, poller.matchHeapIndex)
+				}
+				poller.wake(&matchResult{ctxErr: ctx.Err(), ctxErrIdx: i})
+			}
+		})
+		defer stop()
+	}
+
+	return poller.waitForMatch()
+}
+
+func (d *matcherData) MatchNextPoller(task *internalTask) (canSyncMatch, gotSyncMatch bool) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if !d.isBacklogNegligible() {
+		// To ensure better dispatch ordering, we block sync match when a significant backlog is present.
+		// Note that this check does not make a noticeable difference for history tasks, as they do not wait for a
+		// poller to become available. In presence of a backlog the chance of a poller being available when sync match
+		// request comes is almost zero.
+		// This check is mostly effective for the sync match requests that come from child partitions for spooled tasks.
+		return false, false
+	}
+
+	task.initMatch(d)
+	heap.Push(&d.tasks, task)
+	d.match()
+	// don't wait, check if match() picked this one already
+	if task.matchResult != nil {
+		return true, true
+	}
+	heap.Remove(&d.tasks, task.matchHeapIndex)
+	return true, false
+}
+
+func (d *matcherData) RecheckAllRedirects() {
+	d.lock.Lock()
+
+	// TODO(pri): do we have to do _all_ backlog tasks or can we determine somehow which are
+	// potentially redirected?
+	redirectable := make([]*internalTask, 0, len(d.tasks.heap))
+	d.tasks.heap = slices.DeleteFunc(d.tasks.heap, func(task *internalTask) bool {
+		if task.forwardInfo.GetTaskSource() == enumspb.TASK_SOURCE_DB_BACKLOG {
+			// forwarded from a backlog, kick this back to the child so they can redirect it,
+			// by faking a context cancel
+			task.matchHeapIndex = -13
+			task.wake(&matchResult{ctxErr: context.Canceled})
+			return true
+		} else if task.checkRedirect != nil {
+			redirectable = append(redirectable, task)
+			if task.source == enumspb.TASK_SOURCE_DB_BACKLOG {
+				d.backlogAge.record(task.event.Data.CreateTime, -1)
+			}
+			task.matchHeapIndex = -13
+			return true
+		}
+		return false
+	})
+
+	// fix indexes and re-establish heap
+	for i, task := range d.tasks.heap {
+		task.matchHeapIndex = i
+	}
+	heap.Init(&d.tasks)
+
+	d.lock.Unlock()
+
+	// re-redirect them all (or put back if redirect fails)
+	for _, task := range redirectable {
+		d.RedirectOrEnqueue(task)
+	}
+}
+
+func (d *matcherData) RedirectOrEnqueue(task *internalTask) {
+	if task.checkRedirect == nil || !task.checkRedirect() {
+		d.EnqueueTaskNoWait(task)
+	}
+}
+
+// findMatch should return the highest priority task+poller match even if the per-task rate
+// limit doesn't allow the task to be matched yet.
+// call with lock held
+func (d *matcherData) findMatch(allowForwarding bool) (*internalTask, *waitingPoller) {
+	// FIXME: optimize so it's not O(d*n) worst case
+	// FIXME: this isn't actually correct
+	for _, task := range d.tasks.heap {
+		if !allowForwarding && task.isPollForwarder {
+			continue
+		}
+
+		for _, poller := range d.pollers.heap {
+			// can't match cases:
+			if poller.queryOnly && !(task.isQuery() || task.isPollForwarder) {
+				continue
+			} else if task.isPollForwarder && poller.forwardCtx == nil {
+				continue
+			} else if poller.isTaskForwarder && !allowForwarding {
+				continue
+			} else if poller.isTaskValidator && task.forwardCtx != nil {
+				continue
+			}
+
+			return task, poller
+		}
+	}
+	return nil, nil
+}
+
+// call with lock held
+func (d *matcherData) allowForwarding() (allowForwarding bool) {
+	// If there is a non-negligible backlog, we pause forwarding to make sure
+	// root and leaf partitions are treated equally and can process their
+	// backlog at the same rate. Stopping task forwarding, prevent poll
+	// forwarding as well (in presence of a backlog). This ensures all partitions
+	// receive polls and tasks at the same rate.
+	//
+	// Exception: we allow forward if this partition has not got any polls
+	// recently. This is helpful when there are very few pollers and they
+	// and they are all stuck in the wrong (root) partition. (Note that since
+	// frontend balanced the number of pending pollers per partition this only
+	// becomes an issue when the pollers are fewer than the partitions)
+	//
+	// If allowForwarding was false and changes to true due solely to the passage
+	// of time, then we should ensure that match() is called again so that
+	// pending tasks/polls can now be forwarded. When does that happen? if
+	// isBacklogNegligible changes from false to true, or if we no longer have
+	// recent polls.
+	//
+	// With time, backlog age gets larger, so isBacklogNegligible can go from
+	// true to false and not the other way, so that's safe. But it is possible
+	// that we no longer have recent polls. So we need to ensure that match() is
+	// called again in that case, using reconsiderForwardTimer.
+	defer func() {
+		if allowForwarding {
+			d.reconsiderForwardTimer.unset()
+		}
+	}()
+	if d.isBacklogNegligible() {
+		return true
+	}
+	delayToForwardingAllowed := d.config.MaxWaitForPollerBeforeFwd() - time.Since(d.lastPoller)
+	d.reconsiderForwardTimer.set(d.rematch, delayToForwardingAllowed)
+	return delayToForwardingAllowed <= 0
+}
+
+// call with lock held
+func (d *matcherData) match() {
+	allowForwarding := d.allowForwarding()
+
+	for {
+		// search for highest priority match
+		task, poller := d.findMatch(allowForwarding)
+		if task == nil || poller == nil {
+			// no more current matches, stop timers if they were running
+			d.rateLimitTimer.unset()
+			d.reconsiderForwardTimer.unset()
+			return
+		}
+
+		// got task, check rate limit
+		if !d.rateLimitTask(task) {
+			return // not ready yet, timer will call match later
+		}
+
+		// ready to signal match
+		heap.Remove(&d.tasks, task.matchHeapIndex)
+		heap.Remove(&d.pollers, poller.matchHeapIndex)
+
+		res := &matchResult{task: task, poller: poller}
+
+		task.wake(res)
+		// for poll forwarder: skip waking poller, forwarder will call finishMatchAfterPollForward
+		if !task.isPollForwarder {
+			poller.wake(res)
+		}
+		// TODO(pri): consider having task forwarding work the same way, with a half-match,
+		// instead of full match and then pass forward result on response channel?
+		// TODO(pri): maybe consider leaving tasks and polls in the heap while forwarding and
+		// allow them to be matched locally while forwarded (and then cancel the forward)?
+
+		if task.source == enumspb.TASK_SOURCE_DB_BACKLOG {
+			d.backlogAge.record(task.event.Data.CreateTime, -1)
+		}
+	}
+}
+
+// call with lock held
+// returns true if task can go now
+func (d *matcherData) rateLimitTask(task *internalTask) bool {
+	if task.recycleToken != nil {
+		// we use task.recycleToken as a signal that we've already got a token for this task,
+		// so the next time we see it we'll skip the wait.
+		return true
+	} else if task.isForwarded() {
+		// don't count rate limit for forwarded tasks, it was counted on the child
+		return true
+	}
+
+	delay := d.rateLimiter.Reserve().Delay()
+	task.recycleToken = d.rateLimiter.RecycleToken
+
+	// TODO: account for per-priority/fairness key rate limits also, e.g.
+	// delay = max(delay, perTaskDelay)
+
+	d.rateLimitTimer.set(d.rematch, delay)
+	return delay <= 0
+}
+
+// called from timer
+func (d *matcherData) rematch() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.match()
+}
+
+func (d *matcherData) finishMatchAfterPollForward(poller *waitingPoller, task *internalTask) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if poller.matchResult == nil {
+		poller.wake(&matchResult{task: task, poller: poller})
+	}
+}
+
+// isBacklogNegligible returns true if the age of the task backlog is less than the threshold.
+// call with lock held.
+func (d *matcherData) isBacklogNegligible() bool {
+	return d.backlogAge.getAge() < d.config.BacklogNegligibleAge()
+}
+
+func (d *matcherData) TimeSinceLastPoll() time.Duration {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	return time.Since(d.lastPoller)
+}
+
+// waitable match result:
+
+type waitableMatchResult struct {
+	// these fields are under matcherData.lock even though they're embedded in other structs
+	matchCond      sync.Cond
+	matchResult    *matchResult
+	matchHeapIndex int // current heap index for easy removal
+}
+
+func (w *waitableMatchResult) initMatch(d *matcherData) {
+	w.matchCond.L = &d.lock
+	w.matchResult = nil
+}
+
+// call with matcherData.lock held.
+// w.matchResult must be nil (can't call wake twice).
+// w must not be in queues anymore.
+func (w *waitableMatchResult) wake(res *matchResult) {
+	bugIf(w.matchResult != nil, "bug: wake called twice")
+	bugIf(w.matchHeapIndex >= 0, "bug: wake called but still in heap")
+	w.matchResult = res
+	w.matchCond.Signal()
+}
+
+// call with matcherData.lock held
+func (w *waitableMatchResult) waitForMatch() *matchResult {
+	for w.matchResult == nil {
+		w.matchCond.Wait()
+	}
+	return w.matchResult
+}
+
+// resettable timer:
+
+type resettableTimer struct {
+	timer  *time.Timer // AfterFunc timer
+	target time.Time   // target time of timer
+}
+
+// set sets rt to call f after delay. If it was already set to a future time, it's reset
+// to only the sooner time. If it was already set to a sooner time, it's unchanged.
+// set to <= 0 stops the timer.
+func (rt *resettableTimer) set(f func(), delay time.Duration) {
+	if delay <= 0 {
+		rt.unset()
+	} else if rt.timer == nil {
+		rt.target = time.Now().Add(delay)
+		rt.timer = time.AfterFunc(delay, f)
+	} else if target := time.Now().Add(delay); target.Before(rt.target) {
+		rt.target = target
+		rt.timer.Reset(delay)
+	}
+}
+
+// unset stops the timer.
+func (rt *resettableTimer) unset() {
+	if rt.timer != nil {
+		rt.timer.Stop()
+		rt.timer = nil
+	}
+}
+
+func bugIf(cond bool, msg string) {
+	if cond {
+		panic(msg)
+	}
+}

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -96,12 +96,16 @@ func (t *MatcherTestSuite) SetupTest() {
 	t.fwdr, err = newForwarder(&t.childConfig.forwarderConfig, t.queue, t.client)
 	t.Assert().NoError(err)
 	t.childMatcher = newTaskMatcher(tlCfg, t.fwdr, metrics.NoopMetricsHandler)
+	t.childMatcher.Start()
 
 	t.rootConfig = newTaskQueueConfig(prtn.TaskQueue(), cfg, "test-namespace")
 	t.rootMatcher = newTaskMatcher(t.rootConfig, nil, metrics.NoopMetricsHandler)
+	t.rootMatcher.Start()
 }
 
 func (t *MatcherTestSuite) TearDownTest() {
+	t.childMatcher.Stop()
+	t.rootMatcher.Stop()
 	t.controller.Finish()
 }
 

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -89,7 +89,7 @@ func (t *MatcherTestSuite) SetupTest() {
 	tlCfg.forwarderConfig = forwarderConfig{
 		ForwarderMaxOutstandingPolls: func() int { return 1 },
 		ForwarderMaxOutstandingTasks: func() int { return 1 },
-		ForwarderMaxRatePerSecond:    func() int { return 2 },
+		ForwarderMaxRatePerSecond:    func() float64 { return 2 },
 		ForwarderMaxChildrenPerNode:  func() int { return 20 },
 	}
 	t.childConfig = tlCfg
@@ -752,7 +752,7 @@ func (t *MatcherTestSuite) TestMustOfferRemoteMatch() {
 	}()
 
 	taskCompleted := false
-	completionFunc := func(*persistencespb.AllocatedTaskInfo, error) {
+	completionFunc := func(*internalTask, taskResponse) {
 		taskCompleted = true
 	}
 

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -413,8 +413,27 @@ func (e *matchingEngineImpl) getTaskQueuePartitionManager(
 	logger, throttledLogger, metricsHandler := e.loggerAndMetricsForPartition(nsName, partition, tqConfig)
 	var newPM *taskQueuePartitionManagerImpl
 	onFatalErr := func(cause unloadCause) { newPM.unloadFromEngine(cause) }
-	userDataManager := newUserDataManager(e.taskManager, e.matchingRawClient, onFatalErr, partition, tqConfig, logger, e.namespaceRegistry)
-	newPM, err = newTaskQueuePartitionManager(e, namespaceEntry, partition, tqConfig, logger, throttledLogger, metricsHandler, userDataManager)
+	onUserDataChanged := func() { newPM.userDataChanged() }
+	userDataManager := newUserDataManager(
+		e.taskManager,
+		e.matchingRawClient,
+		onFatalErr,
+		onUserDataChanged,
+		partition,
+		tqConfig,
+		logger,
+		e.namespaceRegistry,
+	)
+	newPM, err = newTaskQueuePartitionManager(
+		e,
+		namespaceEntry,
+		partition,
+		tqConfig,
+		logger,
+		throttledLogger,
+		metricsHandler,
+		userDataManager,
+	)
 	if err != nil {
 		return nil, false, err
 	}

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -528,6 +528,7 @@ func (e *matchingEngineImpl) AddWorkflowTask(
 		ExpiryTime:       expirationTime,
 		CreateTime:       timestamppb.New(now),
 		VersionDirective: addRequest.VersionDirective,
+		Priority:         addRequest.Priority,
 	}
 
 	return pm.AddTask(ctx, addTaskParams{
@@ -566,6 +567,7 @@ func (e *matchingEngineImpl) AddActivityTask(
 		ExpiryTime:       expirationTime,
 		VersionDirective: addRequest.VersionDirective,
 		Stamp:            addRequest.Stamp,
+		Priority:         addRequest.Priority,
 	}
 
 	return pm.AddTask(ctx, addTaskParams{

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -1108,17 +1108,17 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 	mgrImpl, ok := mgr.(*taskQueuePartitionManagerImpl).defaultQueue.(*physicalTaskQueueManagerImpl)
 	s.True(ok)
 
-	mgrImpl.matcher.config.MinTaskThrottlingBurstSize = func() int { return 0 }
-	mgrImpl.matcher.rateLimiter = quotas.NewRateLimiter(
+	mgrImpl.oldMatcher.config.MinTaskThrottlingBurstSize = func() int { return 0 }
+	mgrImpl.oldMatcher.rateLimiter = quotas.NewRateLimiter(
 		defaultTaskDispatchRPS,
 		defaultTaskDispatchRPS,
 	)
-	mgrImpl.matcher.dynamicRateBurst = &dynamicRateBurstWrapper{
+	mgrImpl.oldMatcher.dynamicRateBurst = &dynamicRateBurstWrapper{
 		MutableRateBurst: quotas.NewMutableRateBurst(
 			defaultTaskDispatchRPS,
 			defaultTaskDispatchRPS,
 		),
-		RateLimiterImpl: mgrImpl.matcher.rateLimiter.(*quotas.RateLimiterImpl),
+		RateLimiterImpl: mgrImpl.oldMatcher.rateLimiter.(*quotas.RateLimiterImpl),
 	}
 	s.matchingEngine.updateTaskQueue(dbq.partition, mgr)
 
@@ -1324,17 +1324,17 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 	mgrImpl, ok := mgr.(*taskQueuePartitionManagerImpl).defaultQueue.(*physicalTaskQueueManagerImpl)
 	s.Assert().True(ok)
 
-	mgrImpl.matcher.config.MinTaskThrottlingBurstSize = func() int { return 0 }
-	mgrImpl.matcher.rateLimiter = quotas.NewRateLimiter(
+	mgrImpl.oldMatcher.config.MinTaskThrottlingBurstSize = func() int { return 0 }
+	mgrImpl.oldMatcher.rateLimiter = quotas.NewRateLimiter(
 		defaultTaskDispatchRPS,
 		defaultTaskDispatchRPS,
 	)
-	mgrImpl.matcher.dynamicRateBurst = &dynamicRateBurstWrapper{
+	mgrImpl.oldMatcher.dynamicRateBurst = &dynamicRateBurstWrapper{
 		MutableRateBurst: quotas.NewMutableRateBurst(
 			defaultTaskDispatchRPS,
 			defaultTaskDispatchRPS,
 		),
-		RateLimiterImpl: mgrImpl.matcher.rateLimiter.(*quotas.RateLimiterImpl),
+		RateLimiterImpl: mgrImpl.oldMatcher.rateLimiter.(*quotas.RateLimiterImpl),
 	}
 	s.matchingEngine.updateTaskQueue(dbq.partition, mgr)
 	mgr.Start()

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -401,7 +401,7 @@ func (c *physicalTaskQueueManagerImpl) AddSpooledTaskToMatcher(task *internalTas
 }
 
 func (c *physicalTaskQueueManagerImpl) UserDataChanged() {
-	c.matcher.RecheckAllRedirects()
+	c.matcher.ReprocessAllTasks()
 }
 
 // DispatchQueryTask will dispatch query to local or remote poller. If forwarded then result or error is returned,

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -281,7 +281,7 @@ func newPhysicalTaskQueueManager(
 		partitionMgr.callerInfoContext,
 	)
 
-	if config.NewMatcher() {
+	if config.NewMatcher {
 		var fwdr *priForwarder
 		var err error
 		if !queue.Partition().IsRoot() && queue.Partition().Kind() != enumspb.TASK_QUEUE_KIND_STICKY {

--- a/service/matching/physical_task_queue_manager_interface.go
+++ b/service/matching/physical_task_queue_manager_interface.go
@@ -51,10 +51,9 @@ type (
 		TrySyncMatch(ctx context.Context, task *internalTask) (bool, error)
 		// SpoolTask spools a task to persistence to be matched asynchronously when a poller is available.
 		SpoolTask(taskInfo *persistencespb.TaskInfo) error
-		ProcessSpooledTask(ctx context.Context, task *internalTask) error
-		// DispatchSpooledTask dispatches a task to a poller. When there are no pollers to pick
-		// up the task, this method will return error. Task will not be persisted to db
-		DispatchSpooledTask(ctx context.Context, task *internalTask, userDataChanged <-chan struct{}) error
+		AddSpooledTask(ctx context.Context, task *internalTask) error
+		AddSpooledTaskToMatcher(task *internalTask)
+		UserDataChanged()
 		// DispatchQueryTask will dispatch query to local or remote poller. If forwarded then result or error is returned,
 		// if dispatched to local poller then nil and nil is returned.
 		DispatchQueryTask(ctx context.Context, taskId string, request *matchingservice.QueryWorkflowRequest) (*matchingservice.QueryWorkflowResponse, error)

--- a/service/matching/physical_task_queue_manager_interface.go
+++ b/service/matching/physical_task_queue_manager_interface.go
@@ -51,6 +51,12 @@ type (
 		TrySyncMatch(ctx context.Context, task *internalTask) (bool, error)
 		// SpoolTask spools a task to persistence to be matched asynchronously when a poller is available.
 		SpoolTask(taskInfo *persistencespb.TaskInfo) error
+		// TODO(pri): old matcher cleanup
+		ProcessSpooledTask(ctx context.Context, task *internalTask) error
+		// DispatchSpooledTask dispatches a task to a poller. When there are no pollers to pick
+		// up the task, this method will return error. Task will not be persisted to db
+		// TODO(pri): old matcher cleanup
+		DispatchSpooledTask(ctx context.Context, task *internalTask, userDataChanged <-chan struct{}) error
 		AddSpooledTask(ctx context.Context, task *internalTask) error
 		AddSpooledTaskToMatcher(task *internalTask)
 		UserDataChanged()

--- a/service/matching/physical_task_queue_manager_mock.go
+++ b/service/matching/physical_task_queue_manager_mock.go
@@ -68,6 +68,32 @@ func (m *MockphysicalTaskQueueManager) EXPECT() *MockphysicalTaskQueueManagerMoc
 	return m.recorder
 }
 
+// AddSpooledTask mocks base method.
+func (m *MockphysicalTaskQueueManager) AddSpooledTask(ctx context.Context, task *internalTask) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddSpooledTask", ctx, task)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddSpooledTask indicates an expected call of AddSpooledTask.
+func (mr *MockphysicalTaskQueueManagerMockRecorder) AddSpooledTask(ctx, task any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpooledTask", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).AddSpooledTask), ctx, task)
+}
+
+// AddSpooledTaskToMatcher mocks base method.
+func (m *MockphysicalTaskQueueManager) AddSpooledTaskToMatcher(task *internalTask) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddSpooledTaskToMatcher", task)
+}
+
+// AddSpooledTaskToMatcher indicates an expected call of AddSpooledTaskToMatcher.
+func (mr *MockphysicalTaskQueueManagerMockRecorder) AddSpooledTaskToMatcher(task any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpooledTaskToMatcher", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).AddSpooledTaskToMatcher), task)
+}
+
 // DispatchNexusTask mocks base method.
 func (m *MockphysicalTaskQueueManager) DispatchNexusTask(ctx context.Context, taskId string, request *matchingservice.DispatchNexusTaskRequest) (*matchingservice.DispatchNexusTaskResponse, error) {
 	m.ctrl.T.Helper()
@@ -96,20 +122,6 @@ func (m *MockphysicalTaskQueueManager) DispatchQueryTask(ctx context.Context, ta
 func (mr *MockphysicalTaskQueueManagerMockRecorder) DispatchQueryTask(ctx, taskId, request any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchQueryTask", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).DispatchQueryTask), ctx, taskId, request)
-}
-
-// DispatchSpooledTask mocks base method.
-func (m *MockphysicalTaskQueueManager) DispatchSpooledTask(ctx context.Context, task *internalTask, userDataChanged <-chan struct{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DispatchSpooledTask", ctx, task, userDataChanged)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DispatchSpooledTask indicates an expected call of DispatchSpooledTask.
-func (mr *MockphysicalTaskQueueManagerMockRecorder) DispatchSpooledTask(ctx, task, userDataChanged any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchSpooledTask", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).DispatchSpooledTask), ctx, task, userDataChanged)
 }
 
 // GetAllPollerInfo mocks base method.
@@ -207,20 +219,6 @@ func (m *MockphysicalTaskQueueManager) PollTask(ctx context.Context, pollMetadat
 func (mr *MockphysicalTaskQueueManagerMockRecorder) PollTask(ctx, pollMetadata any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PollTask", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).PollTask), ctx, pollMetadata)
-}
-
-// ProcessSpooledTask mocks base method.
-func (m *MockphysicalTaskQueueManager) ProcessSpooledTask(ctx context.Context, task *internalTask) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessSpooledTask", ctx, task)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ProcessSpooledTask indicates an expected call of ProcessSpooledTask.
-func (mr *MockphysicalTaskQueueManagerMockRecorder) ProcessSpooledTask(ctx, task any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessSpooledTask", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).ProcessSpooledTask), ctx, task)
 }
 
 // QueueKey mocks base method.
@@ -340,6 +338,18 @@ func (m *MockphysicalTaskQueueManager) UpdatePollerInfo(arg0 pollerIdentity, arg
 func (mr *MockphysicalTaskQueueManagerMockRecorder) UpdatePollerInfo(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePollerInfo", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).UpdatePollerInfo), arg0, arg1)
+}
+
+// UserDataChanged mocks base method.
+func (m *MockphysicalTaskQueueManager) UserDataChanged() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UserDataChanged")
+}
+
+// UserDataChanged indicates an expected call of UserDataChanged.
+func (mr *MockphysicalTaskQueueManagerMockRecorder) UserDataChanged() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserDataChanged", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).UserDataChanged))
 }
 
 // WaitUntilInitialized mocks base method.

--- a/service/matching/physical_task_queue_manager_mock.go
+++ b/service/matching/physical_task_queue_manager_mock.go
@@ -124,6 +124,20 @@ func (mr *MockphysicalTaskQueueManagerMockRecorder) DispatchQueryTask(ctx, taskI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchQueryTask", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).DispatchQueryTask), ctx, taskId, request)
 }
 
+// DispatchSpooledTask mocks base method.
+func (m *MockphysicalTaskQueueManager) DispatchSpooledTask(ctx context.Context, task *internalTask, userDataChanged <-chan struct{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DispatchSpooledTask", ctx, task, userDataChanged)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DispatchSpooledTask indicates an expected call of DispatchSpooledTask.
+func (mr *MockphysicalTaskQueueManagerMockRecorder) DispatchSpooledTask(ctx, task, userDataChanged any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchSpooledTask", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).DispatchSpooledTask), ctx, task, userDataChanged)
+}
+
 // GetAllPollerInfo mocks base method.
 func (m *MockphysicalTaskQueueManager) GetAllPollerInfo() []*taskqueue.PollerInfo {
 	m.ctrl.T.Helper()
@@ -219,6 +233,20 @@ func (m *MockphysicalTaskQueueManager) PollTask(ctx context.Context, pollMetadat
 func (mr *MockphysicalTaskQueueManagerMockRecorder) PollTask(ctx, pollMetadata any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PollTask", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).PollTask), ctx, pollMetadata)
+}
+
+// ProcessSpooledTask mocks base method.
+func (m *MockphysicalTaskQueueManager) ProcessSpooledTask(ctx context.Context, task *internalTask) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProcessSpooledTask", ctx, task)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ProcessSpooledTask indicates an expected call of ProcessSpooledTask.
+func (mr *MockphysicalTaskQueueManagerMockRecorder) ProcessSpooledTask(ctx, task any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessSpooledTask", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).ProcessSpooledTask), ctx, task)
 }
 
 // QueueKey mocks base method.

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -283,7 +283,7 @@ func createTestTaskQueueManagerWithConfig(
 	partition := testOpts.dbq.Partition()
 	tqConfig := newTaskQueueConfig(partition.TaskQueue(), me.config, nsName)
 	onFatalErr := func(unloadCause) { t.Fatal("user data manager called onFatalErr") }
-	userDataManager := newUserDataManager(me.taskManager, me.matchingRawClient, onFatalErr, partition, tqConfig, me.logger, me.namespaceRegistry)
+	userDataManager := newUserDataManager(me.taskManager, me.matchingRawClient, onFatalErr, nil, partition, tqConfig, me.logger, me.namespaceRegistry)
 	pm := createTestTaskQueuePartitionManager(ns, partition, tqConfig, me, userDataManager)
 	tlMgr, err := newPhysicalTaskQueueManager(pm, testOpts.dbq, opts...)
 	pm.defaultQueue = tlMgr

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -1,0 +1,598 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.temporal.io/api/serviceerror"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/headers"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/tqid"
+	"go.temporal.io/server/common/util"
+)
+
+// priTaskMatcher matches a task producer with a task consumer
+// Producers are usually rpc calls from history or taskReader
+// that drains backlog from db. Consumers are the task queue pollers
+type priTaskMatcher struct {
+	config *taskQueueConfig
+
+	// holds waiting polls and tasks
+	data matcherData
+
+	// Background context used for forwarding tasks. Closed when task queue is closed.
+	matcherCtx       context.Context
+	matcherCtxCancel context.CancelFunc
+
+	// dynamicRate is the dynamic rate & burst for rate limiter
+	dynamicRateBurst quotas.MutableRateBurst
+	// dynamicRateLimiter is the dynamic rate limiter that can be used to force refresh on new rates.
+	dynamicRateLimiter *quotas.DynamicRateLimiterImpl
+	// forceRefreshRateOnce is used to force refresh rate limit for first time
+	forceRefreshRateOnce sync.Once
+
+	partition      tqid.Partition
+	fwdr           *priForwarder
+	validator      taskValidator
+	metricsHandler metrics.Handler // namespace metric scope
+	numPartitions  func() int      // number of task queue partitions
+}
+
+type waitingPoller struct {
+	waitableMatchResult
+	startTime       time.Time
+	forwardCtx      context.Context // non-nil iff poll can be forwarded
+	pollMetadata    *pollMetadata   // non-nil iff poll can be forwarded
+	queryOnly       bool            // if true, poller can be given only query task, otherwise any task
+	isTaskForwarder bool
+	isTaskValidator bool
+}
+
+type matchResult struct {
+	task      *internalTask
+	poller    *waitingPoller
+	ctxErr    error // set if context timed out/canceled or reprocess task
+	ctxErrIdx int   // index of context that closed first
+}
+
+const (
+	// TODO(pri): old matcher cleanup, move to here
+	// defaultTaskDispatchRPS    = 100000.0
+	// defaultTaskDispatchRPSTTL = time.Minute
+
+	// TODO(pri): make dynamic config
+	backlogTaskForwardTimeout = 60 * time.Second
+)
+
+var (
+	// TODO(pri): old matcher cleanup, move to here
+	// errNoRecentPoller = status.Error(codes.FailedPrecondition, "no poller seen for task queue recently, worker may be down")
+
+	// This is a fake error used to force reprocessing of task redirection as used by versioning.
+	// Situations where we do this:
+	// - after validateTasksOnRoot maybe-validates a task (only local backlog)
+	// - when userdata changes, on in-mem tasks (may be either sync or local backlog)
+	// This must be an error type that taskReader will treat as transient and re-enqueue the task.
+	errReprocessTask = serviceerror.NewCanceled("reprocess task")
+)
+
+// newPriTaskMatcher returns a task matcher instance. The returned instance can be used by task producers and consumers to
+// find a match. Both sync matches and non-sync matches should use this implementation
+func newPriTaskMatcher(config *taskQueueConfig, partition tqid.Partition, fwdr *priForwarder, validator taskValidator, metricsHandler metrics.Handler) *priTaskMatcher {
+	dynamicRateBurst := quotas.NewMutableRateBurst(
+		defaultTaskDispatchRPS,
+		int(defaultTaskDispatchRPS),
+	)
+	dynamicRateLimiter := quotas.NewDynamicRateLimiter(
+		dynamicRateBurst,
+		defaultTaskDispatchRPSTTL,
+	)
+	limiter := quotas.NewMultiRateLimiter([]quotas.RateLimiter{
+		dynamicRateLimiter,
+		quotas.NewDefaultOutgoingRateLimiter(
+			config.AdminNamespaceTaskQueueToPartitionDispatchRate,
+		),
+		quotas.NewDefaultOutgoingRateLimiter(
+			config.AdminNamespaceToPartitionDispatchRate,
+		),
+	})
+
+	matcherCtx := headers.SetCallerInfo(context.Background(), config.CallerInfo)
+	matcherCtx, matcherCtxCancel := context.WithCancel(matcherCtx)
+
+	return &priTaskMatcher{
+		config:             config,
+		data:               newMatcherData(config, limiter),
+		dynamicRateBurst:   dynamicRateBurst,
+		dynamicRateLimiter: dynamicRateLimiter,
+		metricsHandler:     metricsHandler,
+		partition:          partition,
+		fwdr:               fwdr,
+		validator:          validator,
+		matcherCtx:         matcherCtx,
+		matcherCtxCancel:   matcherCtxCancel,
+		numPartitions:      config.NumReadPartitions,
+	}
+}
+
+func (tm *priTaskMatcher) Start() {
+	policy := backoff.NewExponentialRetryPolicy(time.Second).
+		WithMaximumInterval(backlogTaskForwardTimeout).
+		WithExpirationInterval(backoff.NoInterval)
+	retrier := backoff.NewRetrier(policy, clock.NewRealTimeSource())
+	lim := quotas.NewDefaultOutgoingRateLimiter(tm.config.ForwarderMaxRatePerSecond)
+
+	if tm.fwdr == nil {
+		// Root doesn't forward. But it does need something to validate tasks.
+		go tm.validateTasksOnRoot(lim, retrier)
+		return
+	}
+
+	// Child partitions:
+	for range tm.config.ForwarderMaxOutstandingTasks() {
+		go tm.forwardTasks(lim, retrier)
+	}
+	for range tm.config.ForwarderMaxOutstandingPolls() {
+		go tm.forwardPolls()
+	}
+}
+
+func (tm *priTaskMatcher) Stop() {
+	tm.matcherCtxCancel()
+}
+
+func (tm *priTaskMatcher) forwardTasks(lim quotas.RateLimiter, retrier backoff.Retrier) {
+	ctxs := []context.Context{tm.matcherCtx}
+	poller := waitingPoller{isTaskForwarder: true}
+	for {
+		if lim.Wait(tm.matcherCtx) != nil {
+			return
+		}
+
+		res := tm.data.EnqueuePollerAndWait(ctxs, &poller)
+		if res.ctxErr != nil {
+			return // task queue closing
+		}
+		bugIf(res.task == nil, "bug: bad match result in forwardTasks")
+
+		err := tm.forwardTask(res.task)
+
+		// backoff on resource exhausted errors
+		if common.IsResourceExhausted(err) {
+			util.InterruptibleSleep(tm.matcherCtx, retrier.NextBackOff(err))
+		} else {
+			retrier.Reset()
+		}
+	}
+}
+
+func (tm *priTaskMatcher) forwardTask(task *internalTask) error {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if task.forwardCtx != nil {
+		// Use sync match context if we have it (for deadline, headers, etc.)
+		// TODO(pri): does it make sense to subtract 1s from the context deadline here?
+		ctx = task.forwardCtx
+	} else {
+		// Task is from local backlog.
+
+		// Before we forward, ask task validator. This will happen every backlogTaskForwardTimeout
+		// to the head of the backlog, which is what taskValidator expects.
+		maybeValid := tm.validator.maybeValidate(task.event.AllocatedTaskInfo, tm.fwdr.partition.TaskType())
+		if !maybeValid {
+			task.finish(nil, false)
+			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1)
+			return nil
+		}
+
+		// Add a timeout for forwarding.
+		// Note that this does not block local match of other local backlog tasks.
+		ctx, cancel = context.WithTimeout(tm.matcherCtx, backlogTaskForwardTimeout)
+		defer cancel()
+	}
+
+	if task.isQuery() {
+		res, err := tm.fwdr.ForwardQueryTask(ctx, task)
+		task.finishForward(res, err, true)
+		return err
+	}
+
+	if task.isNexus() {
+		res, err := tm.fwdr.ForwardNexusTask(ctx, task)
+		task.finishForward(res, err, true)
+		return err
+	}
+
+	// normal wf/activity task
+	err := tm.fwdr.ForwardTask(ctx, task)
+	task.finishForward(nil, err, true)
+
+	return err
+}
+
+func (tm *priTaskMatcher) validateTasksOnRoot(lim quotas.RateLimiter, retrier backoff.Retrier) {
+	ctxs := []context.Context{tm.matcherCtx}
+	poller := &waitingPoller{isTaskForwarder: true, isTaskValidator: true}
+	for {
+		if lim.Wait(tm.matcherCtx) != nil {
+			return
+		}
+
+		res := tm.data.EnqueuePollerAndWait(ctxs, poller)
+		if res.ctxErr != nil {
+			return // task queue closing
+		}
+		bugIf(res.task == nil, "bug: bad match result in validateTasksOnRoot")
+
+		task := res.task
+		bugIf(task.forwardCtx != nil || task.isSyncMatchTask() || task.source != enumsspb.TASK_SOURCE_DB_BACKLOG,
+			"bug: validator got a sync task")
+		maybeValid := tm.validator == nil || tm.validator.maybeValidate(task.event.AllocatedTaskInfo, tm.partition.TaskType())
+		if !maybeValid {
+			// We found an invalid one, complete it and go back for another immediately.
+			task.finish(nil, false)
+			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1)
+			retrier.Reset()
+		} else {
+			// Task was valid, put it back and slow down checking.
+			task.finish(errReprocessTask, true)
+			// retrier's max interval is backlogTaskForwardTimeout, so for just valid tasks,
+			// this loop will essentially be limited to that interval.
+			util.InterruptibleSleep(tm.matcherCtx, retrier.NextBackOff(nil))
+		}
+	}
+}
+
+func (tm *priTaskMatcher) forwardPolls() {
+	forwarderTask := &internalTask{isPollForwarder: true}
+	ctxs := []context.Context{tm.matcherCtx}
+	for {
+		res := tm.data.EnqueueTaskAndWait(ctxs, forwarderTask)
+		if res.ctxErr != nil {
+			return // task queue closing
+		}
+		bugIf(res.poller == nil, "bug: bad match result in forwardPolls")
+
+		poller := res.poller
+		// We need to use the real source poller context since it has the poller id and
+		// identity, plus the right deadline.
+		task, err := tm.fwdr.ForwardPoll(poller.forwardCtx, poller.pollMetadata)
+		if err == nil {
+			tm.data.finishMatchAfterPollForward(poller, task)
+		} else {
+			// Re-enqueue to let it match again, if it hasn't gotten a context timeout already.
+			poller.forwardCtx = nil // disable forwarding next time
+			tm.data.ReenqueuePollerIfNotMatched(poller)
+		}
+	}
+}
+
+// Offer offers a task to a potential consumer (poller)
+// If the task is successfully matched with a consumer, this
+// method will return true and no error. If the task is matched
+// but consumer returned error, then this method will return
+// true and error message. This method should not be used for query
+// task. This method should ONLY be used for sync match.
+//
+// When a local poller is not available and forwarding to a parent
+// task queue partition is possible, this method will attempt forwarding
+// to the parent partition.
+//
+// Cases when this method will block:
+//
+// Ratelimit:
+// When a ratelimit token is not available, this method might block
+// waiting for a token until the provided context timeout. Rate limits are
+// not enforced for forwarded tasks from child partition.
+//
+// Forwarded tasks that originated from db backlog:
+// When this method is called with a task that is forwarded from a
+// remote partition and if (1) this task queue is root (2) task
+// was from db backlog - this method will block until context timeout
+// trying to match with a poller. The caller is expected to set the
+// correct context timeout.
+//
+// returns error when:
+//   - ratelimit is exceeded (does not apply to query task)
+//   - context deadline is exceeded
+//   - task is matched and consumer returns error in response channel
+func (tm *priTaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, error) {
+	finish := func() (bool, error) {
+		res, ok := task.getResponse()
+		bugIf(!ok, "Offer must be given a sync match task")
+		if res.forwarded {
+			if res.forwardErr == nil {
+				// task was remotely sync matched on the parent partition
+				tm.emitDispatchLatency(task, true)
+				return true, nil
+			}
+			return false, nil // forward error, give up here
+		}
+		// TODO(pri): can we just always do this on the parent and simplify this to:
+		// if res.startErr == nil { tm.emitDispatchLatency(task, task.isForwarded) }
+		// and get rid of the call above so there's only one?
+		if res.startErr == nil && !task.isForwarded() {
+			tm.emitDispatchLatency(task, false)
+		}
+		return true, res.startErr
+	}
+
+	// Fast path if we have a waiting poller (or forwarder).
+	// Forwarding happens here if we match with the task forwarding poller.
+	task.forwardCtx = ctx
+	if canMatch, gotMatch := tm.data.MatchNextPoller(task); gotMatch {
+		return finish()
+	} else if !canMatch {
+		return false, nil
+	}
+
+	// We only block if we are the root and the task is forwarded from a backlog.
+	// Otherwise, stop here.
+	if tm.isForwardingAllowed() ||
+		task.source != enumsspb.TASK_SOURCE_DB_BACKLOG ||
+		!task.isForwarded() {
+		return false, nil
+	}
+
+	res := tm.data.EnqueueTaskAndWait([]context.Context{ctx, tm.matcherCtx}, task)
+
+	if res.ctxErr != nil {
+		return false, res.ctxErr
+	}
+	bugIf(res.poller == nil, "bug: bad match result in Offer")
+	return finish()
+}
+
+func (tm *priTaskMatcher) syncOfferTask(
+	ctx context.Context,
+	task *internalTask,
+	returnNoPollerErr bool,
+) (any, error) {
+	ctxs := []context.Context{ctx, tm.matcherCtx}
+
+	if returnNoPollerErr {
+		if deadline, ok := ctx.Deadline(); ok && tm.fwdr == nil {
+			// Reserving 1sec to customize the timeout error if user is querying a workflow
+			// without having started the workers.
+			noPollerDeadline := deadline.Add(-returnEmptyTaskTimeBudget)
+			noPollerCtx, cancel := context.WithDeadline(context.Background(), noPollerDeadline)
+			defer cancel()
+			ctxs = append(ctxs, noPollerCtx)
+		}
+	}
+
+	task.forwardCtx = ctx
+again:
+	res := tm.data.EnqueueTaskAndWait(ctxs, task)
+
+	if res.ctxErr != nil {
+		if res.ctxErrIdx == 2 {
+			// Index 2 is the noPollerCtx. Only error if there has not been a recent poller.
+			// Otherwise, let it wait for the remaining time hopping for a match, or ultimately
+			// returning the default CDE error.
+			if tm.data.TimeSinceLastPoll() > tm.config.QueryPollerUnavailableWindow() {
+				return nil, errNoRecentPoller
+			}
+			ctxs = ctxs[:2] // remove noPollerCtx otherwise we'll fail immediately again
+			goto again
+		}
+		return nil, res.ctxErr
+	}
+	bugIf(res.poller == nil, "bug: bad match result in syncOfferTask")
+	response, ok := task.getResponse()
+	bugIf(!ok, "OfferQuery/OfferNexusTask must be given a sync match task")
+	// Note: if task was not forwarded, this will just be the zero value and nil.
+	// That's intended: the query/nexus handler in matchingEngine will wait for the real
+	// result separately.
+	return response.forwardRes, response.forwardErr
+}
+
+// OfferQuery will either match task to local poller or will forward query task.
+// Local match is always attempted before forwarding is attempted. If local match occurs
+// response and error are both nil, if forwarding occurs then response or error is returned.
+func (tm *priTaskMatcher) OfferQuery(ctx context.Context, task *internalTask) (*matchingservice.QueryWorkflowResponse, error) {
+	res, err := tm.syncOfferTask(ctx, task, true)
+	if res != nil { // note res may be non-nil "any" containing nil pointer
+		return res.(*matchingservice.QueryWorkflowResponse), err // nolint:revive
+	}
+	return nil, err
+}
+
+// OfferNexusTask either matchs a task to a local poller or forwards it if no local pollers available.
+// Local match is always attempted before forwarding. If local match occurs response and error are both nil, if
+// forwarding occurs then response or error is returned.
+func (tm *priTaskMatcher) OfferNexusTask(ctx context.Context, task *internalTask) (*matchingservice.DispatchNexusTaskResponse, error) {
+	res, err := tm.syncOfferTask(ctx, task, true)
+	if res != nil { // note res may be non-nil "any" containing nil pointer
+		return res.(*matchingservice.DispatchNexusTaskResponse), err // nolint:revive
+	}
+	return nil, err
+}
+
+func (tm *priTaskMatcher) AddTask(task *internalTask) {
+	tm.data.EnqueueTaskNoWait(task)
+}
+
+func (tm *priTaskMatcher) emitDispatchLatency(task *internalTask, forwarded bool) {
+	if task.event.Data.CreateTime == nil {
+		return // should not happen but for safety
+	}
+
+	metrics.TaskDispatchLatencyPerTaskQueue.With(tm.metricsHandler).Record(
+		time.Since(timestamp.TimeValue(task.event.Data.CreateTime)),
+		metrics.StringTag("source", task.source.String()),
+		metrics.StringTag("forwarded", strconv.FormatBool(forwarded)),
+	)
+}
+
+// Poll blocks until a task is found or context deadline is exceeded
+// On success, the returned task could be a query task or a regular task
+// Returns errNoTasks when context deadline is exceeded
+func (tm *priTaskMatcher) Poll(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, error) {
+	return tm.poll(ctx, pollMetadata, false)
+}
+
+// PollForQuery blocks until a *query* task is found or context deadline is exceeded
+// Returns errNoTasks when context deadline is exceeded
+func (tm *priTaskMatcher) PollForQuery(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, error) {
+	return tm.poll(ctx, pollMetadata, true)
+}
+
+func (tm *priTaskMatcher) ReprocessAllTasks() {
+	tasks := tm.data.ReprocessTasks(func(task *internalTask) (shouldRemove bool) {
+		// TODO(pri): do we have to reprocess _all_ backlog tasks or can we determine
+		// somehow which are potentially redirected?
+		return true
+	})
+	// ReprocessTasks will have woken sync tasks, but for backlog we also need to call finish.
+	for _, task := range tasks {
+		if !task.isSyncMatchTask() {
+			task.finish(errReprocessTask, true)
+		}
+	}
+}
+
+// UpdateRatelimit updates the task dispatch rate
+func (tm *priTaskMatcher) UpdateRatelimit(rpsPtr *float64) {
+	if rpsPtr == nil {
+		return
+	}
+
+	rps := *rpsPtr
+	nPartitions := float64(tm.numPartitions())
+	if nPartitions > 0 {
+		// divide the rate equally across all partitions
+		rps = rps / nPartitions
+	}
+	burst := int(math.Ceil(rps))
+
+	minTaskThrottlingBurstSize := tm.config.MinTaskThrottlingBurstSize()
+	if burst < minTaskThrottlingBurstSize {
+		burst = minTaskThrottlingBurstSize
+	}
+
+	tm.dynamicRateBurst.SetRPS(rps)
+	tm.dynamicRateBurst.SetBurst(burst)
+	tm.forceRefreshRateOnce.Do(func() {
+		// Dynamic rate limiter only refresh its rate every 1m. Before that initial 1m interval, it uses default rate
+		// which is 10K and is too large in most cases. We need to force refresh for the first time this rate is set
+		// by poller. Only need to do that once. If the rate change later, it will be refresh in 1m.
+		tm.dynamicRateLimiter.Refresh()
+	})
+}
+
+// Rate returns the current rate at which tasks are dispatched
+func (tm *priTaskMatcher) Rate() float64 {
+	return tm.data.rateLimiter.Rate()
+}
+
+func (tm *priTaskMatcher) poll(
+	ctx context.Context, pollMetadata *pollMetadata, queryOnly bool,
+) (*internalTask, error) {
+	start := time.Now()
+	pollWasForwarded := false
+
+	defer func() {
+		// TODO(pri): can we consolidate all the metrics code below?
+		if pollMetadata.forwardedFrom == "" {
+			// Only recording for original polls
+			metrics.PollLatencyPerTaskQueue.With(tm.metricsHandler).Record(
+				time.Since(start), metrics.StringTag("forwarded", strconv.FormatBool(pollWasForwarded)))
+		}
+	}()
+
+	ctxs := []context.Context{ctx, tm.matcherCtx}
+	poller := &waitingPoller{
+		startTime:    start,
+		queryOnly:    queryOnly,
+		forwardCtx:   ctx,
+		pollMetadata: pollMetadata,
+	}
+	res := tm.data.EnqueuePollerAndWait(ctxs, poller)
+
+	if res.ctxErr != nil {
+		if res.ctxErrIdx == 0 {
+			metrics.PollTimeoutPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+		}
+		return nil, errNoTasks
+	}
+	bugIf(res.task == nil, "bug: bad match result in poll")
+
+	task := res.task
+	pollWasForwarded = task.isStarted()
+
+	if !task.isQuery() {
+		if task.isSyncMatchTask() {
+			metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+		}
+		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+	} else {
+		metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+	}
+	tm.emitForwardedSourceStats(task.isForwarded(), pollMetadata.forwardedFrom, pollWasForwarded)
+
+	return task, nil
+}
+
+func (tm *priTaskMatcher) isForwardingAllowed() bool {
+	return tm.fwdr != nil
+}
+
+func (tm *priTaskMatcher) emitForwardedSourceStats(
+	isTaskForwarded bool,
+	pollForwardedSource string,
+	forwardedPoll bool,
+) {
+	if forwardedPoll {
+		// This means we forwarded the poll to another partition. Skipping this to prevent duplicate emits.
+		// Only the partition in which the match happened should emit this metric.
+		return
+	}
+
+	isPollForwarded := len(pollForwardedSource) > 0
+	switch {
+	case isTaskForwarded && isPollForwarded:
+		metrics.RemoteToRemoteMatchPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+	case isTaskForwarded:
+		metrics.RemoteToLocalMatchPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+	case isPollForwarded:
+		metrics.LocalToRemoteMatchPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+	default:
+		metrics.LocalToLocalMatchPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+	}
+}

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -110,9 +110,14 @@ var (
 	errReprocessTask = serviceerror.NewCanceled("reprocess task")
 )
 
-// newPriTaskMatcher returns a task matcher instance. The returned instance can be used by task producers and consumers to
-// find a match. Both sync matches and non-sync matches should use this implementation
-func newPriTaskMatcher(config *taskQueueConfig, partition tqid.Partition, fwdr *priForwarder, validator taskValidator, metricsHandler metrics.Handler) *priTaskMatcher {
+// newPriTaskMatcher returns a task matcher instance
+func newPriTaskMatcher(
+	config *taskQueueConfig,
+	partition tqid.Partition,
+	fwdr *priForwarder,
+	validator taskValidator,
+	metricsHandler metrics.Handler,
+) *priTaskMatcher {
 	dynamicRateBurst := quotas.NewMutableRateBurst(
 		defaultTaskDispatchRPS,
 		int(defaultTaskDispatchRPS),

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -1,0 +1,431 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/common/util"
+	"go.temporal.io/server/internal/goro"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	// TODO(pri): old matcher cleanup, move to here
+	// taskReaderThrottleRetryDelay = 3 * time.Second
+
+	// Load more tasks when loaded count is <= MaxBatchSize/reloadFraction.
+	// E.g. if MaxBatchSize is 1000, then we'll load 1000, dispatch down to 200,
+	// load another batch to make 1200, down to 200, etc.
+	reloadFraction = 5 // TODO(pri): make dynamic config
+
+	concurrentAddRetries = 10
+)
+
+type (
+	priTaskReader struct {
+		status     int32
+		notifyC    chan struct{} // Used as signal to notify pump of new tasks
+		backlogMgr *backlogManagerImpl
+		gorogrp    goro.Group
+		readerCtx  context.Context // TODO(pri): consolidate contexts and clean this up
+
+		backoffTimerLock sync.Mutex
+		backoffTimer     *time.Timer
+		retrier          backoff.Retrier
+		loadedTasks      atomic.Int64
+
+		backlogAgeLock sync.Mutex
+		backlogAge     backlogAgeTracker
+
+		addRetries *semaphore.Weighted
+	}
+)
+
+var addErrorRetryPolicy = backoff.NewExponentialRetryPolicy(2 * time.Second).
+	WithExpirationInterval(backoff.NoInterval)
+
+func newPriTaskReader(backlogMgr *backlogManagerImpl) *priTaskReader {
+	return &priTaskReader{
+		status:     common.DaemonStatusInitialized,
+		backlogMgr: backlogMgr,
+		notifyC:    make(chan struct{}, 1),
+		retrier: backoff.NewRetrier(
+			common.CreateReadTaskRetryPolicy(),
+			clock.NewRealTimeSource(),
+		),
+		backlogAge: newBacklogAgeTracker(),
+		addRetries: semaphore.NewWeighted(concurrentAddRetries),
+	}
+}
+
+// Start priTaskReader background goroutines.
+func (tr *priTaskReader) Start() {
+	if !atomic.CompareAndSwapInt32(
+		&tr.status,
+		common.DaemonStatusInitialized,
+		common.DaemonStatusStarted,
+	) {
+		return
+	}
+
+	tr.gorogrp.Go(tr.getTasksPump)
+}
+
+// Stop priTaskReader goroutines.
+// Note that this does not wait until they stop before returning.
+func (tr *priTaskReader) Stop() {
+	if !atomic.CompareAndSwapInt32(
+		&tr.status,
+		common.DaemonStatusStarted,
+		common.DaemonStatusStopped,
+	) {
+		return
+	}
+
+	tr.gorogrp.Cancel()
+}
+
+func (tr *priTaskReader) Signal() {
+	select {
+	case tr.notifyC <- struct{}{}:
+	default: // channel already has an event, don't block
+	}
+}
+
+func (tr *priTaskReader) getBacklogHeadAge() time.Duration {
+	tr.backlogAgeLock.Lock()
+	defer tr.backlogAgeLock.Unlock()
+	return max(0, tr.backlogAge.getAge()) // return 0 instead of -1
+}
+
+func (tr *priTaskReader) completeTask(task *internalTask, res taskResponse) {
+	err := res.startErr
+	if res.forwarded {
+		err = res.forwardErr
+	}
+
+	// We can handle some transient errors by just putting the task back in the matcher to
+	// match again. Note that for forwarded tasks, it's expected to get DeadlineExceeded when
+	// the task doesn't match on the root after backlogTaskForwardTimeout, and also expected to
+	// get errRemoteSyncMatchFailed, which is a serviceerror.Canceled error.
+	if err != nil && (common.IsServiceClientTransientError(err) ||
+		common.IsContextDeadlineExceededErr(err) ||
+		common.IsContextCanceledErr(err)) {
+		// TODO(pri): if this was a start error (not a forwarding error): consider adding a
+		// per-task backoff here, in case the error was workflow busy, we don't want to end up
+		// trying the same task immediately. maybe also: after a few attempts on the same task,
+		// let it get cycled to the end of the queue, in case there's some task/wf-specific
+		// thing.
+		tr.addTaskToMatcher(tr.readerCtx, task)
+		return
+	}
+
+	// Otherwise, remove from tracking and pass to backlogManager, which will rewrite the task to the end
+	// of a backlog on error.
+
+	loaded := tr.loadedTasks.Add(-1)
+
+	tr.backlogAgeLock.Lock()
+	tr.backlogAge.record(task.event.AllocatedTaskInfo.Data.CreateTime, -1)
+	tr.backlogAgeLock.Unlock()
+
+	// use == so we just signal once when we cross this threshold
+	if int(loaded) == tr.backlogMgr.config.GetTasksBatchSize()/reloadFraction {
+		tr.Signal()
+	}
+	tr.backlogMgr.completeTask(task.event.AllocatedTaskInfo, err)
+}
+
+// nolint:revive // can simplify later
+func (tr *priTaskReader) getTasksPump(ctx context.Context) error {
+	ctx = tr.backlogMgr.contextInfoProvider(ctx)
+	tr.readerCtx = ctx
+
+	if err := tr.backlogMgr.WaitUntilInitialized(ctx); err != nil {
+		return err
+	}
+
+	updateAckTicker := time.NewTicker(tr.backlogMgr.config.UpdateAckInterval())
+
+	tr.Signal() // prime pump
+Loop:
+	for {
+		// Prioritize exiting over other processing
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case <-tr.notifyC:
+			if int(tr.loadedTasks.Load()) > tr.backlogMgr.config.GetTasksBatchSize()/reloadFraction {
+				// Too many loaded already, ignore this signal. We'll get another signal when
+				// loadedTasks drops low enough.
+				continue Loop
+			}
+
+			batch, err := tr.getTaskBatch(ctx)
+			tr.backlogMgr.signalIfFatal(err)
+			if err != nil {
+				// TODO: Should we ever stop retrying on db errors?
+				if common.IsResourceExhausted(err) {
+					tr.backoffSignal(taskReaderThrottleRetryDelay)
+				} else {
+					tr.backoffSignal(tr.retrier.NextBackOff(err))
+				}
+				continue Loop
+			}
+			tr.retrier.Reset()
+
+			if len(batch.tasks) == 0 {
+				tr.backlogMgr.taskAckManager.setReadLevelAfterGap(batch.readLevel)
+				if !batch.isReadBatchDone {
+					tr.Signal()
+				}
+				continue Loop
+			}
+
+			tr.addTasksToMatcher(ctx, batch.tasks)
+			// There may be more tasks.
+			tr.Signal()
+
+		case <-updateAckTicker.C:
+			err := tr.persistAckBacklogCountLevel(ctx)
+			isConditionFailed := tr.backlogMgr.signalIfFatal(err)
+			if err != nil && !isConditionFailed {
+				tr.logger().Error("Persistent store operation failure",
+					tag.StoreOperationUpdateTaskQueue,
+					tag.Error(err))
+				// keep going as saving ack is not critical
+			}
+			// TODO(pri): don't do this, or else prove that it's needed
+			tr.Signal() // periodically signal pump to check persistence for tasks
+		}
+	}
+}
+
+func (tr *priTaskReader) getTaskBatchWithRange(
+	ctx context.Context,
+	readLevel int64,
+	maxReadLevel int64,
+) ([]*persistencespb.AllocatedTaskInfo, error) {
+	response, err := tr.backlogMgr.db.GetTasks(ctx, readLevel+1, maxReadLevel+1, tr.backlogMgr.config.GetTasksBatchSize())
+	if err != nil {
+		return nil, err
+	}
+	return response.Tasks, err
+}
+
+// type getTasksBatchResponse struct {
+// 	tasks           []*persistencespb.AllocatedTaskInfo
+// 	readLevel       int64
+// 	isReadBatchDone bool
+// }
+
+// Returns a batch of tasks from persistence starting form current read level.
+// Also return a number that can be used to update readLevel
+// Also return a bool to indicate whether read is finished
+func (tr *priTaskReader) getTaskBatch(ctx context.Context) (*getTasksBatchResponse, error) {
+	var tasks []*persistencespb.AllocatedTaskInfo
+	readLevel := tr.backlogMgr.taskAckManager.getReadLevel()
+	maxReadLevel := tr.backlogMgr.db.GetMaxReadLevel()
+
+	// counter i is used to break and let caller check whether taskqueue is still alive and needs to resume read.
+	for i := 0; i < 10 && readLevel < maxReadLevel; i++ {
+		upper := readLevel + tr.backlogMgr.config.RangeSize
+		if upper > maxReadLevel {
+			upper = maxReadLevel
+		}
+		tasks, err := tr.getTaskBatchWithRange(ctx, readLevel, upper)
+		if err != nil {
+			return nil, err
+		}
+		// return as long as it grabs any tasks
+		if len(tasks) > 0 {
+			return &getTasksBatchResponse{
+				tasks:           tasks,
+				readLevel:       upper,
+				isReadBatchDone: true,
+			}, nil
+		}
+		readLevel = upper
+	}
+	return &getTasksBatchResponse{
+		tasks:           tasks,
+		readLevel:       readLevel,
+		isReadBatchDone: readLevel == maxReadLevel,
+	}, nil // caller will update readLevel when no task grabbed
+}
+
+func (tr *priTaskReader) addTasksToMatcher(
+	ctx context.Context,
+	tasks []*persistencespb.AllocatedTaskInfo,
+) {
+	for _, t := range tasks {
+		if IsTaskExpired(t) {
+			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1)
+			// Also increment readLevel for expired tasks otherwise it could result in
+			// looping over the same tasks if all tasks read in the batch are expired
+			tr.backlogMgr.taskAckManager.setReadLevel(t.GetTaskId())
+			continue
+		}
+
+		tr.backlogMgr.taskAckManager.addTask(t.GetTaskId())
+		tr.loadedTasks.Add(1)
+		tr.backlogAgeLock.Lock()
+		tr.backlogAge.record(t.Data.CreateTime, 1)
+		tr.backlogAgeLock.Unlock()
+		task := newInternalTaskFromBacklog(t, tr.completeTask)
+
+		// After we get to this point, we must eventually call task.finish or
+		// task.finishForwarded, which will call tr.completeTask.
+		tr.addTaskToMatcher(ctx, task)
+	}
+}
+
+func (tr *priTaskReader) addTaskToMatcher(ctx context.Context, task *internalTask) {
+	err := tr.backlogMgr.addSpooledTask(ctx, task)
+	if err == nil {
+		return
+	}
+
+	if drop, retry := tr.addErrorBehavior(err); drop {
+		task.finish(nil, false)
+	} else if retry {
+		// This should only be due to persistence problems. Retry in a new goroutine
+		// to not block other tasks, up to some concurrency limit.
+		if tr.addRetries.Acquire(ctx, 1) != nil {
+			return
+		}
+		go tr.retryAddAfterError(ctx, task)
+	}
+}
+
+func (tr *priTaskReader) addErrorBehavior(err error) (drop, retry bool) {
+	// addSpooledTask can only fail due to:
+	// - the task queue is closed (errTaskQueueClosed or context.Canceled)
+	// - ValidateDeployment failed (InvalidArgument)
+	// - versioning wants to get a versioned queue and it can't be initialized
+	// - versioning wants to re-spool the task on a different queue and that failed
+	// - versioning says StickyWorkerUnavailable
+	if errors.Is(err, errTaskQueueClosed) || common.IsContextCanceledErr(err) {
+		return false, false
+	}
+	var stickyUnavailable *serviceerrors.StickyWorkerUnavailable
+	if errors.As(err, &stickyUnavailable) {
+		return true, false // drop the task
+	}
+	var invalid *serviceerror.InvalidArgument
+	var internal *serviceerror.Internal
+	if errors.As(err, &invalid) || errors.As(err, &internal) {
+		tr.throttledLogger().Error("nonretryable error processing spooled task", tag.Error(err))
+		return true, false // drop the task
+	}
+	// For any other error (this should be very rare), we can retry.
+	tr.throttledLogger().Error("retryable error processing spooled task", tag.Error(err))
+	return false, true
+}
+
+func (tr *priTaskReader) retryAddAfterError(ctx context.Context, task *internalTask) {
+	defer tr.addRetries.Release(1)
+	metrics.BufferThrottlePerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1)
+
+	// initial sleep since we just tried once
+	util.InterruptibleSleep(ctx, time.Second)
+
+	_ = backoff.ThrottleRetryContext(
+		ctx,
+		func(ctx context.Context) error {
+			if IsTaskExpired(task.event.AllocatedTaskInfo) {
+				task.finish(nil, false)
+				return nil
+			}
+			err := tr.backlogMgr.addSpooledTask(ctx, task)
+			if drop, retry := tr.addErrorBehavior(err); drop {
+				task.finish(nil, false)
+			} else if retry {
+				metrics.BufferThrottlePerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1)
+				return err
+			}
+			return nil
+		},
+		addErrorRetryPolicy,
+		nil,
+	)
+}
+
+func (tr *priTaskReader) persistAckBacklogCountLevel(ctx context.Context) error {
+	ackLevel := tr.backlogMgr.taskAckManager.getAckLevel()
+	return tr.backlogMgr.db.UpdateState(ctx, ackLevel)
+}
+
+func (tr *priTaskReader) logger() log.Logger {
+	return tr.backlogMgr.logger
+}
+
+func (tr *priTaskReader) throttledLogger() log.ThrottledLogger {
+	return tr.backlogMgr.throttledLogger
+}
+
+func (tr *priTaskReader) taggedMetricsHandler() metrics.Handler {
+	return tr.backlogMgr.metricsHandler
+}
+
+func (tr *priTaskReader) backoffSignal(duration time.Duration) {
+	tr.backoffTimerLock.Lock()
+	defer tr.backoffTimerLock.Unlock()
+
+	if tr.backoffTimer == nil {
+		tr.backoffTimer = time.AfterFunc(duration, func() {
+			tr.backoffTimerLock.Lock()
+			defer tr.backoffTimerLock.Unlock()
+
+			tr.Signal() // re-enqueue the event
+			tr.backoffTimer = nil
+		})
+	}
+}
+
+func (tr *priTaskReader) getLoadedTasks() int64 {
+	return tr.loadedTasks.Load()
+}

--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -71,7 +71,7 @@ type (
 		started          *startedTaskInfo // non-nil for a task received from a parent partition which is already started
 		namespace        namespace.Name
 		source           enumsspb.TaskSource
-		responseC        chan taskResponse // non-nil only where there is a caller waiting for response (sync-match)
+		responseC        chan taskResponse // non-nil only where there is a caller waiting for response (sync match)
 		backlogCountHint func() int64
 		// forwardInfo contains information about forward source partition and versioning decisions made by it
 		// a parent partition receiving forwarded tasks makes no versioning decisions and only follows what the source
@@ -80,11 +80,11 @@ type (
 		// redirectInfo is only set when redirect rule is applied on the task. for forwarded tasks, this is populated
 		// based on forwardInfo.
 		redirectInfo *taskqueuespb.BuildIdRedirectInfo
+		recycleToken func()
 
 		// These fields are for use by matcherData:
 		waitableMatchResult
 		forwardCtx      context.Context // non-nil for sync match task only
-		recycleToken    func()
 		isPollForwarder bool
 	}
 

--- a/service/matching/task_queue_partition_manager_interface.go
+++ b/service/matching/task_queue_partition_manager_interface.go
@@ -55,13 +55,7 @@ type (
 		// maxDispatchPerSecond is the max rate at which tasks are allowed to be dispatched
 		// from this task queue to pollers
 		PollTask(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, bool, error)
-		// ProcessSpooledTask dispatches a task to a poller. When there are no pollers to pick
-		// up the task, this method will return error. Task will not be persisted to db
-		ProcessSpooledTask(
-			ctx context.Context,
-			task *internalTask,
-			backlogQueue *PhysicalTaskQueueKey,
-		) error
+		AddSpooledTask(ctx context.Context, task *internalTask, backlogQueue *PhysicalTaskQueueKey) error
 		// DispatchQueryTask will dispatch query to local or remote poller. If forwarded then result or error is returned,
 		// if dispatched to local poller then nil and nil is returned.
 		DispatchQueryTask(ctx context.Context, taskId string, request *matchingservice.QueryWorkflowRequest) (*matchingservice.QueryWorkflowResponse, error)

--- a/service/matching/task_queue_partition_manager_interface.go
+++ b/service/matching/task_queue_partition_manager_interface.go
@@ -55,6 +55,16 @@ type (
 		// maxDispatchPerSecond is the max rate at which tasks are allowed to be dispatched
 		// from this task queue to pollers
 		PollTask(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, bool, error)
+		// ProcessSpooledTask dispatches a task to a poller. When there are no pollers to pick
+		// up the task, this method will return error. Task will not be persisted to db
+		// TODO(pri): old matcher cleanup
+		ProcessSpooledTask(
+			ctx context.Context,
+			task *internalTask,
+			backlogQueue *PhysicalTaskQueueKey,
+		) error
+		// AddSpooledTask passes a task to the matcher to make it eligible for matching and
+		// returns immediately. (New matcher only)
 		AddSpooledTask(ctx context.Context, task *internalTask, backlogQueue *PhysicalTaskQueueKey) error
 		// DispatchQueryTask will dispatch query to local or remote poller. If forwarded then result or error is returned,
 		// if dispatched to local poller then nil and nil is returned.

--- a/service/matching/task_queue_partition_manager_mock.go
+++ b/service/matching/task_queue_partition_manager_mock.go
@@ -70,6 +70,20 @@ func (m *MocktaskQueuePartitionManager) EXPECT() *MocktaskQueuePartitionManagerM
 	return m.recorder
 }
 
+// AddSpooledTask mocks base method.
+func (m *MocktaskQueuePartitionManager) AddSpooledTask(ctx context.Context, task *internalTask, backlogQueue *PhysicalTaskQueueKey) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddSpooledTask", ctx, task, backlogQueue)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddSpooledTask indicates an expected call of AddSpooledTask.
+func (mr *MocktaskQueuePartitionManagerMockRecorder) AddSpooledTask(ctx, task, backlogQueue any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpooledTask", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).AddSpooledTask), ctx, task, backlogQueue)
+}
+
 // AddTask mocks base method.
 func (m *MocktaskQueuePartitionManager) AddTask(ctx context.Context, params addTaskParams) (string, bool, error) {
 	m.ctrl.T.Helper()
@@ -283,20 +297,6 @@ func (m *MocktaskQueuePartitionManager) PollTask(ctx context.Context, pollMetada
 func (mr *MocktaskQueuePartitionManagerMockRecorder) PollTask(ctx, pollMetadata any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PollTask", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).PollTask), ctx, pollMetadata)
-}
-
-// ProcessSpooledTask mocks base method.
-func (m *MocktaskQueuePartitionManager) ProcessSpooledTask(ctx context.Context, task *internalTask, backlogQueue *PhysicalTaskQueueKey) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessSpooledTask", ctx, task, backlogQueue)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ProcessSpooledTask indicates an expected call of ProcessSpooledTask.
-func (mr *MocktaskQueuePartitionManagerMockRecorder) ProcessSpooledTask(ctx, task, backlogQueue any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessSpooledTask", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).ProcessSpooledTask), ctx, task, backlogQueue)
 }
 
 // Start mocks base method.

--- a/service/matching/task_queue_partition_manager_mock.go
+++ b/service/matching/task_queue_partition_manager_mock.go
@@ -299,6 +299,20 @@ func (mr *MocktaskQueuePartitionManagerMockRecorder) PollTask(ctx, pollMetadata 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PollTask", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).PollTask), ctx, pollMetadata)
 }
 
+// ProcessSpooledTask mocks base method.
+func (m *MocktaskQueuePartitionManager) ProcessSpooledTask(ctx context.Context, task *internalTask, backlogQueue *PhysicalTaskQueueKey) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProcessSpooledTask", ctx, task, backlogQueue)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ProcessSpooledTask indicates an expected call of ProcessSpooledTask.
+func (mr *MocktaskQueuePartitionManagerMockRecorder) ProcessSpooledTask(ctx, task, backlogQueue any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessSpooledTask", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).ProcessSpooledTask), ctx, task, backlogQueue)
+}
+
 // Start mocks base method.
 func (m *MocktaskQueuePartitionManager) Start() {
 	m.ctrl.T.Helper()

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -147,6 +147,11 @@ func (tr *taskReader) completeTask(task *internalTask, res taskResponse) {
 	if err != nil && (common.IsServiceClientTransientError(err) ||
 		common.IsContextDeadlineExceededErr(err) ||
 		common.IsContextCanceledErr(err)) {
+		// TODO(pri): if this was a start error (not a forwarding error): consider adding a
+		// per-task backoff here, in case the error was workflow busy, we don't want to end up
+		// trying the same task immediately. maybe also: after a few attempts on the same task,
+		// let it get cycled to the end of the queue, in case there's some task/wf-specific
+		// thing.
 		tr.addTaskToMatcher(tr.readerCtx, task)
 		return
 	}

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -31,7 +31,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
@@ -39,58 +38,46 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/primitives/timestamp"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/internal/goro"
-	"golang.org/x/sync/semaphore"
 )
 
 const (
+	taskReaderOfferThrottleWait  = time.Second
 	taskReaderThrottleRetryDelay = 3 * time.Second
-
-	// Load more tasks when loaded count is <= MaxBatchSize/reloadFraction.
-	// E.g. if MaxBatchSize is 1000, then we'll load 1000, dispatch down to 200,
-	// load another batch to make 1200, down to 200, etc.
-	reloadFraction = 5 // TODO(pri): make dynamic config
-
-	concurrentAddRetries = 10
 )
 
 type (
 	taskReader struct {
 		status     int32
-		notifyC    chan struct{} // Used as signal to notify pump of new tasks
+		taskBuffer chan *persistencespb.AllocatedTaskInfo // tasks loaded from persistence
+		notifyC    chan struct{}                          // Used as signal to notify pump of new tasks
 		backlogMgr *backlogManagerImpl
 		gorogrp    goro.Group
-		readerCtx  context.Context // TODO(pri): consolidate contexts and clean this up
 
-		backoffTimerLock sync.Mutex
-		backoffTimer     *time.Timer
-		retrier          backoff.Retrier
-		loadedTasks      atomic.Int64
-
-		backlogAgeLock sync.Mutex
-		backlogAge     backlogAgeTracker
-
-		addRetries *semaphore.Weighted
+		backoffTimerLock      sync.Mutex
+		backoffTimer          *time.Timer
+		retrier               backoff.Retrier
+		backlogHeadCreateTime atomic.Int64
 	}
 )
-
-var addErrorRetryPolicy = backoff.NewExponentialRetryPolicy(2 * time.Second).
-	WithExpirationInterval(backoff.NoInterval)
 
 func newTaskReader(backlogMgr *backlogManagerImpl) *taskReader {
 	tr := &taskReader{
 		status:     common.DaemonStatusInitialized,
 		backlogMgr: backlogMgr,
 		notifyC:    make(chan struct{}, 1),
+		// we always dequeue the head of the buffer and try to dispatch it to a poller
+		// so allocate one less than desired target buffer size
+		taskBuffer: make(chan *persistencespb.AllocatedTaskInfo, backlogMgr.config.GetTasksBatchSize()-1),
 		retrier: backoff.NewRetrier(
 			common.CreateReadTaskRetryPolicy(),
 			clock.NewRealTimeSource(),
 		),
-		backlogAge: newBacklogAgeTracker(),
-		addRetries: semaphore.NewWeighted(concurrentAddRetries),
 	}
+	tr.backlogHeadCreateTime.Store(-1)
 	return tr
 }
 
@@ -104,11 +91,12 @@ func (tr *taskReader) Start() {
 		return
 	}
 
+	tr.gorogrp.Go(tr.dispatchBufferedTasks)
 	tr.gorogrp.Go(tr.getTasksPump)
 }
 
 // Stop taskReader goroutines.
-// Note that this does not wait until they stop before returning.
+// Note that this does not wait until
 func (tr *taskReader) Stop() {
 	if !atomic.CompareAndSwapInt32(
 		&tr.status,
@@ -122,65 +110,83 @@ func (tr *taskReader) Stop() {
 }
 
 func (tr *taskReader) Signal() {
+	var event struct{}
 	select {
-	case tr.notifyC <- struct{}{}:
+	case tr.notifyC <- event:
 	default: // channel already has an event, don't block
 	}
 }
 
+func (tr *taskReader) updateBacklogAge(task *internalTask) {
+	if task.event.Data.CreateTime == nil {
+		return // should not happen but for safety
+	}
+	ts := timestamp.TimeValue(task.event.Data.CreateTime).UnixNano()
+	tr.backlogHeadCreateTime.Store(ts)
+}
+
 func (tr *taskReader) getBacklogHeadAge() time.Duration {
-	tr.backlogAgeLock.Lock()
-	defer tr.backlogAgeLock.Unlock()
-	return max(0, tr.backlogAge.getAge()) // return 0 instead of -1
+	if tr.backlogHeadCreateTime.Load() == -1 {
+		return time.Duration(0)
+	}
+	return time.Since(time.Unix(0, tr.backlogHeadCreateTime.Load()))
+}
+
+func (tr *taskReader) dispatchBufferedTasks(ctx context.Context) error {
+	ctx = tr.backlogMgr.contextInfoProvider(ctx)
+
+dispatchLoop:
+	for ctx.Err() == nil {
+		if len(tr.taskBuffer) == 0 {
+			// reset the atomic since we have no tasks from the backlog
+			tr.backlogHeadCreateTime.Store(-1)
+		}
+		select {
+		case taskInfo, ok := <-tr.taskBuffer:
+			if !ok { // Task queue getTasks pump is shutdown
+				break dispatchLoop
+			}
+			task := newInternalTaskFromBacklog(taskInfo, tr.completeTask)
+			for ctx.Err() == nil {
+				tr.updateBacklogAge(task)
+				taskCtx, cancel := context.WithTimeout(ctx, taskReaderOfferTimeout)
+				err := tr.backlogMgr.processSpooledTask(taskCtx, task)
+				cancel()
+				if err == nil {
+					continue dispatchLoop
+				}
+
+				var stickyUnavailable *serviceerrors.StickyWorkerUnavailable
+				// if task is still valid (truly valid or unable to verify if task is valid)
+				metrics.BufferThrottlePerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1)
+				if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) &&
+					// StickyWorkerUnavailable is expected for versioned sticky queues
+					!errors.As(err, &stickyUnavailable) {
+					tr.throttledLogger().Error("taskReader: unexpected error dispatching task", tag.Error(err))
+				}
+				util.InterruptibleSleep(ctx, taskReaderOfferThrottleWait)
+			}
+			return ctx.Err()
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return ctx.Err()
 }
 
 func (tr *taskReader) completeTask(task *internalTask, res taskResponse) {
-	err := res.startErr
-	if res.forwarded {
-		err = res.forwardErr
-	}
-
-	// We can handle some transient errors by just putting the task back in the matcher to
-	// match again. Note that for forwarded tasks, it's expected to get DeadlineExceeded when
-	// the task doesn't match on the root after backlogTaskForwardTimeout, and also expected to
-	// get errRemoteSyncMatchFailed, which is a serviceerror.Canceled error.
-	if err != nil && (common.IsServiceClientTransientError(err) ||
-		common.IsContextDeadlineExceededErr(err) ||
-		common.IsContextCanceledErr(err)) {
-		// TODO(pri): if this was a start error (not a forwarding error): consider adding a
-		// per-task backoff here, in case the error was workflow busy, we don't want to end up
-		// trying the same task immediately. maybe also: after a few attempts on the same task,
-		// let it get cycled to the end of the queue, in case there's some task/wf-specific
-		// thing.
-		tr.addTaskToMatcher(tr.readerCtx, task)
-		return
-	}
-
-	// Otherwise, remove from tracking and pass to backlogManager, which will rewrite the task to the end
-	// of a backlog on error.
-
-	loaded := tr.loadedTasks.Add(-1)
-
-	tr.backlogAgeLock.Lock()
-	tr.backlogAge.record(task.event.AllocatedTaskInfo.Data.CreateTime, -1)
-	tr.backlogAgeLock.Unlock()
-
-	// use == so we just signal once when we cross this threshold
-	if int(loaded) == tr.backlogMgr.config.GetTasksBatchSize()/reloadFraction {
-		tr.Signal()
-	}
-	tr.backlogMgr.completeTask(task.event.AllocatedTaskInfo, err)
+	tr.backlogMgr.completeTask(task.event.AllocatedTaskInfo, res.startErr)
 }
 
 func (tr *taskReader) getTasksPump(ctx context.Context) error {
 	ctx = tr.backlogMgr.contextInfoProvider(ctx)
-	tr.readerCtx = ctx
 
 	if err := tr.backlogMgr.WaitUntilInitialized(ctx); err != nil {
 		return err
 	}
 
-	updateAckTicker := time.NewTicker(tr.backlogMgr.config.UpdateAckInterval())
+	updateAckTimer := time.NewTimer(tr.backlogMgr.config.UpdateAckInterval())
+	defer updateAckTimer.Stop()
 
 	tr.Signal() // prime pump
 Loop:
@@ -197,20 +203,14 @@ Loop:
 			return nil
 
 		case <-tr.notifyC:
-			if int(tr.loadedTasks.Load()) > tr.backlogMgr.config.GetTasksBatchSize()/reloadFraction {
-				// Too many loaded already, ignore this signal. We'll get another signal when
-				// loadedTasks drops low enough.
-				continue Loop
-			}
-
 			batch, err := tr.getTaskBatch(ctx)
 			tr.backlogMgr.signalIfFatal(err)
 			if err != nil {
 				// TODO: Should we ever stop retrying on db errors?
 				if common.IsResourceExhausted(err) {
-					tr.backoffSignal(taskReaderThrottleRetryDelay)
+					tr.reEnqueueAfterDelay(taskReaderThrottleRetryDelay)
 				} else {
-					tr.backoffSignal(tr.retrier.NextBackOff(err))
+					tr.reEnqueueAfterDelay(tr.retrier.NextBackOff(err))
 				}
 				continue Loop
 			}
@@ -224,11 +224,13 @@ Loop:
 				continue Loop
 			}
 
-			tr.addTasksToMatcher(ctx, batch.tasks)
-			// There may be more tasks.
+			// only error here is due to context cancellation which we also
+			// handle above
+			_ = tr.addTasksToBuffer(ctx, batch.tasks)
+			// There maybe more tasks. We yield now, but signal pump to check again later.
 			tr.Signal()
 
-		case <-updateAckTicker.C:
+		case <-updateAckTimer.C:
 			err := tr.persistAckBacklogCountLevel(ctx)
 			isConditionFailed := tr.backlogMgr.signalIfFatal(err)
 			if err != nil && !isConditionFailed {
@@ -237,8 +239,8 @@ Loop:
 					tag.Error(err))
 				// keep going as saving ack is not critical
 			}
-			// TODO(pri): don't do this, or else prove that it's needed
 			tr.Signal() // periodically signal pump to check persistence for tasks
+			updateAckTimer = time.NewTimer(tr.backlogMgr.config.UpdateAckInterval())
 		}
 	}
 }
@@ -296,7 +298,7 @@ func (tr *taskReader) getTaskBatch(ctx context.Context) (*getTasksBatchResponse,
 	}, nil // caller will update readLevel when no task grabbed
 }
 
-func (tr *taskReader) addTasksToMatcher(
+func (tr *taskReader) addTasksToBuffer(
 	ctx context.Context,
 	tasks []*persistencespb.AllocatedTaskInfo,
 ) error {
@@ -308,90 +310,24 @@ func (tr *taskReader) addTasksToMatcher(
 			tr.backlogMgr.taskAckManager.setReadLevel(t.GetTaskId())
 			continue
 		}
-
-		tr.backlogMgr.taskAckManager.addTask(t.GetTaskId())
-		tr.loadedTasks.Add(1)
-		tr.backlogAgeLock.Lock()
-		tr.backlogAge.record(t.Data.CreateTime, 1)
-		tr.backlogAgeLock.Unlock()
-		task := newInternalTaskFromBacklog(t, tr.completeTask)
-
-		// After we get to this point, we must eventually call task.finish or
-		// task.finishForwarded, which will call tr.completeTask.
-		tr.addTaskToMatcher(ctx, task)
+		if err := tr.addSingleTaskToBuffer(ctx, t); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func (tr *taskReader) addTaskToMatcher(ctx context.Context, task *internalTask) {
-	err := tr.backlogMgr.addSpooledTask(ctx, task)
-	if err == nil {
-		return
+func (tr *taskReader) addSingleTaskToBuffer(
+	ctx context.Context,
+	task *persistencespb.AllocatedTaskInfo,
+) error {
+	tr.backlogMgr.taskAckManager.addTask(task.GetTaskId())
+	select {
+	case tr.taskBuffer <- task:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-
-	if drop, retry := tr.addErrorBehavior(err); drop {
-		task.finish(nil, false)
-	} else if retry {
-		// This should only be due to persistence problems. Retry in a new goroutine
-		// to not block other tasks, up to some concurrency limit.
-		if tr.addRetries.Acquire(ctx, 1) != nil {
-			return
-		}
-		go tr.retryAddAfterError(ctx, task)
-	}
-}
-
-func (tr *taskReader) addErrorBehavior(err error) (drop, retry bool) {
-	// addSpooledTask can only fail due to:
-	// - the task queue is closed (errTaskQueueClosed or context.Canceled)
-	// - ValidateDeployment failed (InvalidArgument)
-	// - versioning wants to get a versioned queue and it can't be initialized
-	// - versioning wants to re-spool the task on a different queue and that failed
-	// - versioning says StickyWorkerUnavailable
-	if errors.Is(err, errTaskQueueClosed) || common.IsContextCanceledErr(err) {
-		return false, false
-	}
-	var stickyUnavailable *serviceerrors.StickyWorkerUnavailable
-	if errors.As(err, &stickyUnavailable) {
-		return true, false // drop the task
-	}
-	var invalid *serviceerror.InvalidArgument
-	var internal *serviceerror.Internal
-	if errors.As(err, &invalid) || errors.As(err, &internal) {
-		tr.throttledLogger().Error("nonretryable error processing spooled task", tag.Error(err))
-		return true, false // drop the task
-	}
-	// For any other error (this should be very rare), we can retry.
-	tr.throttledLogger().Error("retryable error processing spooled task", tag.Error(err))
-	return false, true
-}
-
-func (tr *taskReader) retryAddAfterError(ctx context.Context, task *internalTask) {
-	defer tr.addRetries.Release(1)
-	metrics.BufferThrottlePerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1)
-
-	// initial sleep since we just tried once
-	util.InterruptibleSleep(ctx, time.Second)
-
-	backoff.ThrottleRetryContext(
-		ctx,
-		func(ctx context.Context) error {
-			if IsTaskExpired(task.event.AllocatedTaskInfo) {
-				task.finish(nil, false)
-				return nil
-			}
-			err := tr.backlogMgr.addSpooledTask(ctx, task)
-			if drop, retry := tr.addErrorBehavior(err); drop {
-				task.finish(nil, false)
-			} else if retry {
-				metrics.BufferThrottlePerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1)
-				return err
-			}
-			return nil
-		},
-		addErrorRetryPolicy,
-		nil,
-	)
 }
 
 func (tr *taskReader) persistAckBacklogCountLevel(ctx context.Context) error {
@@ -411,7 +347,7 @@ func (tr *taskReader) taggedMetricsHandler() metrics.Handler {
 	return tr.backlogMgr.metricsHandler
 }
 
-func (tr *taskReader) backoffSignal(duration time.Duration) {
+func (tr *taskReader) reEnqueueAfterDelay(duration time.Duration) {
 	tr.backoffTimerLock.Lock()
 	defer tr.backoffTimerLock.Unlock()
 
@@ -424,8 +360,4 @@ func (tr *taskReader) backoffSignal(duration time.Duration) {
 			tr.backoffTimer = nil
 		})
 	}
-}
-
-func (tr *taskReader) getLoadedTasks() int64 {
-	return tr.loadedTasks.Load()
 }

--- a/service/matching/task_validation.go
+++ b/service/matching/task_validation.go
@@ -38,10 +38,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 )
 
-const (
-	taskReaderOfferTimeout        = 60 * time.Second
-	taskReaderValidationThreshold = 600 * time.Second
-)
+const taskReaderValidationThreshold = 600 * time.Second
 
 type (
 	taskValidator interface {

--- a/service/matching/task_validation.go
+++ b/service/matching/task_validation.go
@@ -38,7 +38,10 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 )
 
-const taskReaderValidationThreshold = 600 * time.Second
+const (
+	taskReaderOfferTimeout        = 60 * time.Second // TODO(pri): old matcher cleanup
+	taskReaderValidationThreshold = 600 * time.Second
+)
 
 type (
 	taskValidator interface {

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -214,6 +214,7 @@ func (w *taskWriter) appendTasks(
 			tag.WorkflowTaskQueueType(w.backlogMgr.queueKey().TaskType()))
 		return nil, err
 	}
+	// TODO(pri): we should signal taskreader here, not in the callers of appendTask
 	return resp, nil
 }
 

--- a/service/matching/user_data_manager_test.go
+++ b/service/matching/user_data_manager_test.go
@@ -82,7 +82,7 @@ func createUserDataManager(
 		onFatalErr = func(unloadCause) { t.Fatal("user data manager called onFatalErr") }
 	}
 
-	return newUserDataManager(tm, testOpts.matchingClientMock, onFatalErr, testOpts.dbq.Partition(), newTaskQueueConfig(testOpts.dbq.Partition().TaskQueue(), testOpts.config, ns), logger, mockNamespaceCache)
+	return newUserDataManager(tm, testOpts.matchingClientMock, onFatalErr, nil, testOpts.dbq.Partition(), newTaskQueueConfig(testOpts.dbq.Partition().TaskQueue(), testOpts.config, ns), logger, mockNamespaceCache)
 }
 
 func TestUserData_LoadOnInit(t *testing.T) {

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -588,7 +588,7 @@ func (s *Versioning3Suite) TestTransitionFromActivity_NoSticky() {
 }
 
 func (s *Versioning3Suite) testTransitionFromActivity(sticky bool) {
-	// Wf runs one TWF on d1 and schedules four activities, then:
+	// The workflow runs one WFT on d1 which schedules four activities, then:
 	// 1. The first and second activities starts on d1
 	// 2. Current deployment becomes d2
 	// 3. The third activity is redirected to d2 and starts a transition in the wf, without being
@@ -664,7 +664,7 @@ func (s *Versioning3Suite) testTransitionFromActivity(sticky bool) {
 	// tasks might still be waiting behind the old deployment's poll channel. Partition manage should
 	// immediately react to the deployment data changes, but there still is a race possible and the
 	// only way to safeguard against it is to wait a little while before proceeding.
-	time.Sleep(time.Millisecond * 100) //nolint:forbidigo
+	time.Sleep(time.Millisecond * 200) //nolint:forbidigo
 
 	// Pollers of d1 are there, but should not get any task
 	go s.idlePollActivity(tv1, true, ver3MinPollTime, "activities should not go to the old deployment")
@@ -878,8 +878,8 @@ func respondWftWithActivities(
 					// TODO (shahab): tests with forced task forward take multiple seconds. Need to know why?
 					ScheduleToCloseTimeout: durationpb.New(10 * time.Second),
 					ScheduleToStartTimeout: durationpb.New(10 * time.Second),
-					StartToCloseTimeout:    durationpb.New(1 * time.Second),
-					HeartbeatTimeout:       durationpb.New(1 * time.Second),
+					StartToCloseTimeout:    durationpb.New(3 * time.Second),
+					HeartbeatTimeout:       durationpb.New(3 * time.Second),
 					RequestEagerExecution:  false,
 				},
 			},

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -89,6 +89,11 @@ func (s *Versioning3Suite) SetupSuite() {
 		// this is overridden for tests using RunTestWithMatchingBehavior
 		dynamicconfig.MatchingNumTaskqueueReadPartitions.Key():  4,
 		dynamicconfig.MatchingNumTaskqueueWritePartitions.Key(): 4,
+
+		// Use new matcher for versioning tests. Ideally we would run everything with old and new,
+		// but for now we pick a subset of tests. Versioning tests exercise the most features of
+		// matching so they're a good condidate.
+		dynamicconfig.MatchingUseNewMatcher.Key(): true,
 	}
 	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
 }

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -122,6 +122,11 @@ func (s *VersioningIntegSuite) SetupSuite() {
 		// this is overridden since we don't want caching to be enabled while testing DescribeTaskQueue
 		// behaviour related to versioning
 		dynamicconfig.TaskQueueInfoByBuildIdTTL.Key(): 0 * time.Second,
+
+		// Use new matcher for versioning tests. Ideally we would run everything with old and new,
+		// but for now we pick a subset of tests. Versioning tests exercise the most features of
+		// matching so they're a good condidate.
+		dynamicconfig.MatchingUseNewMatcher.Key(): true,
 	}
 	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
 }

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -255,7 +255,7 @@ func (s *xdcBaseSuite) failover(
 	client workflowservice.WorkflowServiceClient,
 ) {
 	// wait for replication task propagation
-	time.Sleep(4 * time.Second)
+	s.waitForClusterSynced()
 
 	// update namespace to fail over
 	updateReq := &workflowservice.UpdateNamespaceRequest{

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -844,7 +844,43 @@ func (s *FunctionalClustersTestSuite) TestTerminateFailover() {
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
+	// check terminate done
+	getHistoryReq := &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: namespace,
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: id,
+		},
+	}
+
+	s.WaitForHistory(`
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskCompleted
+  5 v1 ActivityTaskScheduled`,
+		func() *historypb.History {
+			historyResponse, err := client1.GetWorkflowExecutionHistory(testcore.NewContext(), getHistoryReq)
+			s.NoError(err)
+			return historyResponse.History
+		}, 1*time.Second, 100*time.Millisecond,
+	)
+
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
+
+	s.WaitForHistory(`
+  1 v1 WorkflowExecutionStarted
+  2 v1 WorkflowTaskScheduled
+  3 v1 WorkflowTaskStarted
+  4 v1 WorkflowTaskCompleted
+  5 v1 ActivityTaskScheduled
+  6 v2 ActivityTaskTimedOut
+  7 v2 WorkflowTaskScheduled`,
+		func() *historypb.History {
+			historyResponse, err := client2.GetWorkflowExecutionHistory(testcore.NewContext(), getHistoryReq)
+			s.NoError(err)
+			return historyResponse.History
+		}, 5*time.Second, 100*time.Millisecond,
+	)
 
 	// terminate workflow at cluster 2
 	terminateReason := "terminate reason"
@@ -861,13 +897,6 @@ func (s *FunctionalClustersTestSuite) TestTerminateFailover() {
 	s.NoError(err)
 
 	// check terminate done
-	getHistoryReq := &workflowservice.GetWorkflowExecutionHistoryRequest{
-		Namespace: namespace,
-		Execution: &commonpb.WorkflowExecution{
-			WorkflowId: id,
-		},
-	}
-
 	s.WaitForHistory(`
   1 v1 WorkflowExecutionStarted
   2 v1 WorkflowTaskScheduled
@@ -1896,6 +1925,54 @@ func (s *FunctionalClustersTestSuite) TestCronWorkflowStartAndFailover() {
 	s.NoError(err)
 }
 
+func (s *FunctionalClustersTestSuite) getLastEvent(
+	client workflowservice.WorkflowServiceClient,
+	namespace string,
+	execution *commonpb.WorkflowExecution,
+) *historypb.HistoryEvent {
+
+	resp, err := client.GetWorkflowExecutionHistory(testcore.NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: namespace,
+		Execution: execution,
+	})
+	s.NoError(err)
+	s.NotNil(resp.History)
+	s.NotEmpty(resp.History.Events)
+
+	return resp.History.Events[len(resp.History.Events)-1]
+}
+
+func (s *FunctionalClustersTestSuite) getNewExecutionRunIdFromLastEvent(
+	client workflowservice.WorkflowServiceClient,
+	namespace string,
+	execution *commonpb.WorkflowExecution,
+) string {
+	lastEvent := s.getLastEvent(client, namespace, execution)
+	s.NotNil(lastEvent)
+
+	if lastEvent.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED {
+		attrs := lastEvent.GetWorkflowExecutionCompletedEventAttributes()
+		s.NotNil(attrs)
+		return attrs.GetNewExecutionRunId()
+	}
+	return ""
+}
+
+func (s *FunctionalClustersTestSuite) waitForNewRunToStart(
+	client workflowservice.WorkflowServiceClient,
+	namespace string,
+	execution *commonpb.WorkflowExecution,
+) string {
+	var newRunID string
+	s.Eventually(func() bool {
+		newRunID = s.getNewExecutionRunIdFromLastEvent(client, namespace, execution)
+		return newRunID != ""
+	}, 10*time.Second, 100*time.Millisecond)
+
+	s.NotEmpty(newRunID, "New run should have started")
+	return newRunID
+}
+
 func (s *FunctionalClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
 	namespace := "test-cron-workflow-complete-and-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.FrontendClient() // active
@@ -1987,6 +2064,8 @@ func (s *FunctionalClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
   3 v1 WorkflowTaskStarted
   4 v1 WorkflowTaskCompleted
   5 v1 WorkflowExecutionCompleted`, events)
+
+	_ = s.waitForNewRunToStart(client1, namespace, executions[0])
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 


### PR DESCRIPTION
## What changed?
- Rewrite TaskMatcher to use explicit priority queues, added as priTaskMatcher.
- Changed taskReader to push all tasks into priTaskMatcher, and loads more when the number outstanding is too low. Added as priTaskReader.
- Modified Forwarder to work with priTaskMatcher, added as priForwarder.
- Config switch to use old or new matcher, and various small changes to support that.

Functional tests: This passes all functional tests, but currently only versioning functional tests flip the switch to use the new matcher (they exercise matching the most).

Unit tests: Tests for new matcher are not there yet. Other tests will need to be modified.

## Why?
- Ability to prioritize uniformly across all pending tasks including queries+nexus.
- Simpler architecture, no new component between taskReader and TaskMatcher.
- More separated concerns, e.g. "forwarding" is (mostly) in one place instead of spread around, "rate limiting" is in one place, etc.
- Easier to understand code, no more nested selects (this is subjective of course).
- Some behavior improvements, e.g. forwarded backlog tasks don't bounce back and forth anymore.
- Maybe better performance (after optimizations).

## How did you test it?
existing functional tests, need to add/update unit tests

## Potential risks
lots of new code, may be new bugs