### PR TITLE
Reduce default namespace cache refresh interval to 2s

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -214,7 +214,7 @@ response to a StartWorkflowExecution request and skipping the trip through match
 	)
 	NamespaceCacheRefreshInterval = NewGlobalDurationSetting(
 		"system.namespaceCacheRefreshInterval",
-		10*time.Second,
+		2*time.Second,
 		`NamespaceCacheRefreshInterval is the key for namespace cache refresh interval dynamic config`,
 	)
 	PersistenceHealthSignalMetricsEnabled = NewGlobalBoolSetting(

--- a/service/worker/deletenamespace/reclaimresources/workflow.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow.go
@@ -42,7 +42,7 @@ import (
 const (
 	WorkflowName = "temporal-sys-reclaim-namespace-resources-workflow"
 
-	namespaceCacheRefreshDelay = 11 * time.Second
+	namespaceCacheRefreshDelay = 3 * time.Second
 )
 
 type (


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Reduced the default namespace cache refresh interval (dynamic config `system.namespaceCacheRefreshInterval`) from 10s -> 2s

## Why?
<!-- Tell your future self why have you made these changes -->
1. To increase responsiveness of the system
2. Migration handover wait was reduced to 10s and the cache refresh interval should be shorter than this value.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Additional load on persistence from increased calls to refresh namespaces in the cache.
