### PR TITLE
Use otel metrics by default

### DIFF
--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -196,6 +196,16 @@ func TestMetricsHandlerFromConfig(t *testing.T) {
 			},
 			expectedType: &otelMetricsHandler{},
 		},
+		{
+			name: "", // default to otel
+			cfg: &Config{
+				Prometheus: &PrometheusConfig{
+					Framework:     FrameworkOpentelemetry,
+					ListenAddress: "localhost:0",
+				},
+			},
+			expectedType: &otelMetricsHandler{},
+		},
 	} {
 		c := c
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## What changed?
Use otel metrics by default if not specified. 

## Why?
Otel metrics is stable and tally is abandoned 

## How did you test it?
Unit test

## Potential risks
The metrics may not be 100% exactly the same between otel and tally.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
No
