### PR TITLE
OTEL omit redundant persistence blobs

### DIFF
--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -438,9 +438,9 @@ type (
 		RunID       string
 
 		ExecutionInfo      *persistencespb.WorkflowExecutionInfo
-		ExecutionInfoBlob  *commonpb.DataBlob
+		ExecutionInfoBlob  *commonpb.DataBlob `json:"-"` // redundant in JSON
 		ExecutionState     *persistencespb.WorkflowExecutionState
-		ExecutionStateBlob *commonpb.DataBlob
+		ExecutionStateBlob *commonpb.DataBlob `json:"-"` // redundant in JSON
 		NextEventID        int64
 		StartVersion       int64
 		LastWriteVersion   int64
@@ -476,9 +476,9 @@ type (
 		RunID       string
 
 		ExecutionInfo      *persistencespb.WorkflowExecutionInfo
-		ExecutionInfoBlob  *commonpb.DataBlob
+		ExecutionInfoBlob  *commonpb.DataBlob `json:"-"` // redundant in JSON
 		ExecutionState     *persistencespb.WorkflowExecutionState
-		ExecutionStateBlob *commonpb.DataBlob
+		ExecutionStateBlob *commonpb.DataBlob `json:"-"` // redundant in JSON
 		StartVersion       int64
 		LastWriteVersion   int64
 		NextEventID        int64


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Omitting redundant persistence data blobs.

## Why?
<!-- Tell your future self why have you made these changes -->

Since the original data is already there, serializing the blobs is not useful. Removing it reduces noise.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
