### PR TITLE
Quick fix to reconfig maximumHandoverTimeoutSeconds

### DIFF
--- a/service/worker/migration/handover_workflow.go
+++ b/service/worker/migration/handover_workflow.go
@@ -37,7 +37,7 @@ const (
 
 	minimumAllowedLaggingSeconds  = 5
 	maximumAllowedLaggingSeconds  = 120
-	maximumHandoverTimeoutSeconds = 10
+	maximumHandoverTimeoutSeconds = 30
 )
 
 type (

--- a/service/worker/migration/handover_workflow_test.go
+++ b/service/worker/migration/handover_workflow_test.go
@@ -62,7 +62,7 @@ func TestHandoverWorkflow(t *testing.T) {
 		Namespace:              "test-ns",
 		RemoteCluster:          "test-remote",
 		AllowedLaggingSeconds:  10,
-		HandoverTimeoutSeconds: 30,
+		HandoverTimeoutSeconds: 10,
 	})
 
 	require.True(t, env.IsWorkflowCompleted())

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -2700,7 +2700,7 @@ func (s *FunctionalClustersTestSuite) TestLocalNamespaceMigration() {
 		Namespace:              namespace,
 		RemoteCluster:          s.clusterNames[1],
 		AllowedLaggingSeconds:  10,
-		HandoverTimeoutSeconds: 30,
+		HandoverTimeoutSeconds: 10,
 	})
 	s.NoError(err)
 	err = run5.Get(testCtx, nil)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Reconfig the maximumHandoverTimeoutSecondto 30s but change the actual input to 10s  for the default tests.

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
