### PR TITLE
Add workflow status tag to query workflow metrics

### DIFF
--- a/service/history/api/queryworkflow/api.go
+++ b/service/history/api/queryworkflow/api.go
@@ -105,6 +105,7 @@ func Invoke(
 
 	req := request.GetRequest()
 	_, mutableStateStatus := workflowLease.GetMutableState().GetWorkflowStateStatus()
+	scope = scope.WithTags(metrics.StringTag("workflow_status", mutableStateStatus.String()))
 	if mutableStateStatus != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING && req.QueryRejectCondition != enumspb.QUERY_REJECT_CONDITION_NONE {
 		notOpenReject := req.GetQueryRejectCondition() == enumspb.QUERY_REJECT_CONDITION_NOT_OPEN
 		notCompletedCleanlyReject := req.GetQueryRejectCondition() == enumspb.QUERY_REJECT_CONDITION_NOT_COMPLETED_CLEANLY && mutableStateStatus != enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED


### PR DESCRIPTION
## What changed?
Add workflow_status tag to workflow query metrics

## Why?
So we can tell what percentage of workflow query are made to closed workflows.

## How did you test it?
Local test, and verify seeing metrics like:
direct_query_dispatch_non_sticky_success{operation="QueryWorkflow",service_name="history",workflow_status="Completed"} 1

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
