### PR TITLE
Fix on state based replication

### DIFF
--- a/service/history/ndc/history_replicator.go
+++ b/service/history/ndc/history_replicator.go
@@ -308,20 +308,21 @@ func (r *HistoryReplicatorImpl) applyBackfillEvents(
 	}
 
 	transitionHistory := mutableState.GetExecutionInfo().GetTransitionHistory()
-	if workflow.CompareVersionedTransition(versionedTransition, transitionHistory[len(transitionHistory)-1]) > 0 {
-		return serviceerrors.NewSyncState(
-			mutableStateMissingMessage,
-			task.getNamespaceID().String(),
-			task.getWorkflowID(),
-			task.getRunID(),
-			task.getVersionedTransition(),
-			mutableState.GetExecutionInfo().VersionHistories,
-		)
-	}
-
-	err := workflow.TransitionHistoryStalenessCheck(transitionHistory, versionedTransition)
-	if err == nil {
-		return nil
+	if len(transitionHistory) != 0 {
+		if workflow.CompareVersionedTransition(versionedTransition, transitionHistory[len(transitionHistory)-1]) > 0 {
+			return serviceerrors.NewSyncState(
+				mutableStateMissingMessage,
+				task.getNamespaceID().String(),
+				task.getWorkflowID(),
+				task.getRunID(),
+				task.getVersionedTransition(),
+				mutableState.GetExecutionInfo().VersionHistories,
+			)
+		}
+		err := workflow.TransitionHistoryStalenessCheck(transitionHistory, versionedTransition)
+		if err == nil {
+			return nil
+		}
 	}
 
 	mutableState, prepareHistoryBranchOut, err := r.mutableStateMapper.GetOrCreateHistoryBranch(ctx, wfContext, mutableState, task)

--- a/service/history/replication/executable_backfill_history_events_task.go
+++ b/service/history/replication/executable_backfill_history_events_task.go
@@ -187,7 +187,6 @@ func (e *ExecutableBackfillHistoryEventsTask) HandleErr(err error) error {
 				)
 				return err
 			}
-			// return original task processing error
 			return nil
 		}
 		return e.Execute()

--- a/service/history/replication/executable_backfill_history_events_task.go
+++ b/service/history/replication/executable_backfill_history_events_task.go
@@ -151,6 +151,13 @@ func (e *ExecutableBackfillHistoryEventsTask) Execute() error {
 }
 
 func (e *ExecutableBackfillHistoryEventsTask) HandleErr(err error) error {
+	e.Logger.Error("BackFillHistoryEvent replication task encountered error",
+		tag.WorkflowNamespaceID(e.NamespaceID),
+		tag.WorkflowID(e.WorkflowID),
+		tag.WorkflowRunID(e.RunID),
+		tag.TaskID(e.ExecutableTask.TaskID()),
+		tag.Error(err),
+	)
 	switch taskErr := err.(type) {
 	case nil, *serviceerror.NotFound:
 		return nil
@@ -171,16 +178,17 @@ func (e *ExecutableBackfillHistoryEventsTask) HandleErr(err error) error {
 			ResendAttempt,
 		); syncStateErr != nil || !doContinue {
 			if syncStateErr != nil {
-				e.Logger.Error("Backfill history events replication task encountered error during sync state",
+				e.Logger.Error("BackFillHistoryEvent replication task encountered error during sync state",
 					tag.WorkflowNamespaceID(e.NamespaceID),
 					tag.WorkflowID(e.WorkflowID),
 					tag.WorkflowRunID(e.RunID),
 					tag.TaskID(e.ExecutableTask.TaskID()),
 					tag.Error(syncStateErr),
 				)
+				return err
 			}
 			// return original task processing error
-			return err
+			return nil
 		}
 		return e.Execute()
 	case *serviceerrors.RetryReplication:

--- a/service/history/replication/executable_verify_versioned_transition_task.go
+++ b/service/history/replication/executable_verify_versioned_transition_task.go
@@ -248,6 +248,13 @@ func (e *ExecutableVerifyVersionedTransitionTask) getMutableState(ctx context.Co
 }
 
 func (e *ExecutableVerifyVersionedTransitionTask) HandleErr(err error) error {
+	e.Logger.Error("VerifyVersionedTransition replication task encountered error",
+		tag.WorkflowNamespaceID(e.NamespaceID),
+		tag.WorkflowID(e.WorkflowID),
+		tag.WorkflowRunID(e.RunID),
+		tag.TaskID(e.ExecutableTask.TaskID()),
+		tag.Error(err),
+	)
 	switch taskErr := err.(type) {
 	case *serviceerrors.SyncState:
 		namespaceName, _, nsError := e.GetNamespaceInfo(headers.SetCallerInfo(
@@ -273,19 +280,12 @@ func (e *ExecutableVerifyVersionedTransitionTask) HandleErr(err error) error {
 					tag.TaskID(e.ExecutableTask.TaskID()),
 					tag.Error(syncStateErr),
 				)
+				return err
 			}
-			// return original task processing error
-			return err
+			return nil
 		}
 		return e.Execute()
 	default:
-		e.Logger.Error("VerifyVersionedTransition replication task encountered error",
-			tag.WorkflowNamespaceID(e.NamespaceID),
-			tag.WorkflowID(e.WorkflowID),
-			tag.WorkflowRunID(e.RunID),
-			tag.TaskID(e.ExecutableTask.TaskID()),
-			tag.Error(err),
-		)
 		return err
 	}
 }

--- a/service/history/replication/raw_task_converter.go
+++ b/service/history/replication/raw_task_converter.go
@@ -648,6 +648,7 @@ func (c *syncVersionedTransitionTaskConverter) convert(
 	// If workflow is not on any versionedTransition (in an unknown state from state-based replication perspective),
 	// we can't convert this raw task to a replication task, instead we need to rely on its task equivalents.
 	if len(executionInfo.TransitionHistory) == 0 {
+		releaseFunc(nil)
 		return c.convertTaskEquivalents(ctx, taskInfo, targetClusterID)
 	}
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5487,8 +5487,10 @@ func (ms *MutableStateImpl) UpdateWorkflowStateStatus(
 	state enumsspb.WorkflowExecutionState,
 	status enumspb.WorkflowExecutionStatus,
 ) error {
-	ms.executionStateUpdated = true
-	ms.visibilityUpdated = true // workflow status & state change triggers visibility change as well
+	if state != enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE {
+		ms.executionStateUpdated = true
+		ms.visibilityUpdated = true // workflow status & state change triggers visibility change as well
+	}
 	return setStateStatus(ms.executionState, state, status)
 }
 

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -757,12 +757,12 @@ func (r *TaskGeneratorImpl) GenerateMigrationTasks() ([]tasks.Task, int64, error
 			Version:     lastItem.GetVersion(),
 			Priority:    enumsspb.TASK_PRIORITY_LOW,
 		}}
-		if r.mutableState.IsTransitionHistoryEnabled() {
+		if r.mutableState.IsTransitionHistoryEnabled() &&
+			// even though current cluster may enabled state transition, but transition history can be cleared
+			// by processing a replication task from a cluster that has state transition disabled
+			len(executionInfo.TransitionHistory) != 0 {
+
 			transitionHistory := executionInfo.TransitionHistory
-			if len(transitionHistory) == 0 {
-				// TODO: Handle the case where state-based replication is re-enabled.
-				return nil, 0, serviceerror.NewInternal("TaskGeneratorImpl encountered empty transition history")
-			}
 			return []tasks.Task{&tasks.SyncVersionedTransitionTask{
 				WorkflowKey:         workflowKey,
 				Priority:            enumsspb.TASK_PRIORITY_LOW,
@@ -801,12 +801,12 @@ func (r *TaskGeneratorImpl) GenerateMigrationTasks() ([]tasks.Task, int64, error
 		})
 	}
 
-	if r.mutableState.IsTransitionHistoryEnabled() {
+	if r.mutableState.IsTransitionHistoryEnabled()
+	// even though current cluster may enabled state transition, but transition history can be cleared
+	// by processing a replication task from a cluster that has state transition disabled
+		len(executionInfo.TransitionHistory) != 0 {
+		
 		transitionHistory := executionInfo.TransitionHistory
-		if len(transitionHistory) == 0 {
-			// TODO: Handle the case where state-based replication is re-enabled.
-			return nil, 0, serviceerror.NewInternal("TaskGeneratorImpl encountered empty transition history")
-		}
 		return []tasks.Task{&tasks.SyncVersionedTransitionTask{
 			WorkflowKey:         workflowKey,
 			Priority:            enumsspb.TASK_PRIORITY_LOW,

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -760,7 +760,7 @@ func (r *TaskGeneratorImpl) GenerateMigrationTasks() ([]tasks.Task, int64, error
 		if r.mutableState.IsTransitionHistoryEnabled() &&
 			// even though current cluster may enabled state transition, but transition history can be cleared
 			// by processing a replication task from a cluster that has state transition disabled
-			len(executionInfo.TransitionHistory) != 0 {
+			len(executionInfo.TransitionHistory) > 0 {
 
 			transitionHistory := executionInfo.TransitionHistory
 			return []tasks.Task{&tasks.SyncVersionedTransitionTask{
@@ -801,11 +801,11 @@ func (r *TaskGeneratorImpl) GenerateMigrationTasks() ([]tasks.Task, int64, error
 		})
 	}
 
-	if r.mutableState.IsTransitionHistoryEnabled()
-	// even though current cluster may enabled state transition, but transition history can be cleared
-	// by processing a replication task from a cluster that has state transition disabled
-		len(executionInfo.TransitionHistory) != 0 {
-		
+	if r.mutableState.IsTransitionHistoryEnabled() &&
+		// even though current cluster may enabled state transition, but transition history can be cleared
+		// by processing a replication task from a cluster that has state transition disabled
+		len(executionInfo.TransitionHistory) > 0 {
+
 		transitionHistory := executionInfo.TransitionHistory
 		return []tasks.Task{&tasks.SyncVersionedTransitionTask{
 			WorkflowKey:         workflowKey,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
1. Improve logging on replication task execution
2. Check versioned transition existence before reading it. (avoid panic)
3. When SyncState returning `nil` error and 'false` doContinue, ignore the task instead of keep retrying. Otherwise this will cause DLQ.
4. release workflow lock before `convertTaskEquivalents`, otherwise deadlock.
## Why?
<!-- Tell your future self why have you made these changes -->
Fix on state based replication
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Ran tasks on test clusters
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
n/a
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
no