### PR TITLE
Add backward compatibility configs for tally to otel migration

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -74,11 +74,14 @@ type (
 		PerUnitHistogramBoundaries map[string][]float64 `yaml:"perUnitHistogramBoundaries"`
 
 		// Following configs are added for backwards compatibility when switching from tally to opentelemetry
-		// Both configs should be set to true when using opentelemetry framework to have the same behavior as tally.
+		// All configs should be set to true when using opentelemetry framework to have the same behavior as tally.
 
-		// WithoutUnits controls if metric unit should be added to the metric name as a suffix.
+		// WithoutUnitSuffix controls the additional of unit suffixes to metric names.
 		// This config only takes effect when using opentelemetry framework.
-		WithoutUnits bool `yaml:"withoutUnits"`
+		WithoutUnitSuffix bool `yaml:"withoutUnitSuffix"`
+		// WithoutCounterSuffix controls the additional of _total suffixes to counter metric names.
+		// This config only takes effect when using opentelemetry framework.
+		WithoutCounterSuffix bool `yaml:"withoutCounterSuffix"`
 		// RecordTimerInSeconds controls if Timer metric should be emitted as number of seconds
 		// (instead of milliseconds).
 		// This config only takes effect when using opentelemetry framework.

--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -72,6 +72,17 @@ type (
 		// - "milliseconds"
 		// - "bytes"
 		PerUnitHistogramBoundaries map[string][]float64 `yaml:"perUnitHistogramBoundaries"`
+
+		// Following configs are added for backwards compatibility when switching from tally to opentelemetry
+		// Both configs should be set to true when using opentelemetry framework to have the same behavior as tally.
+
+		// WithoutUnits controls if metric unit should be added to the metric name as a suffix.
+		// This config only takes effect when using opentelemetry framework.
+		WithoutUnits bool `yaml:"withoutUnits"`
+		// RecordTimerInSeconds controls if Timer metric should be emitted as number of seconds
+		// (instead of milliseconds).
+		// This config only takes effect when using opentelemetry framework.
+		RecordTimerInSeconds bool `yaml:"timerInSeconds"`
 	}
 
 	// StatsdConfig contains the config items for statsd metrics reporter
@@ -388,6 +399,12 @@ func setDefaultPerUnitHistogramBoundaries(clientConfig *ClientConfig) {
 	if bucket, ok := clientConfig.PerUnitHistogramBoundaries[UnitNameBytes]; ok {
 		buckets[Bytes] = bucket
 	}
+
+	bucketInSeconds := make([]float64, len(buckets[Milliseconds]))
+	for idx, boundary := range buckets[Milliseconds] {
+		bucketInSeconds[idx] = boundary / float64(time.Second/time.Millisecond)
+	}
+	buckets[Seconds] = bucketInSeconds
 
 	clientConfig.PerUnitHistogramBoundaries = buckets
 }

--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -85,7 +85,7 @@ type (
 		// RecordTimerInSeconds controls if Timer metric should be emitted as number of seconds
 		// (instead of milliseconds).
 		// This config only takes effect when using opentelemetry framework.
-		RecordTimerInSeconds bool `yaml:"timerInSeconds"`
+		RecordTimerInSeconds bool `yaml:"recordTimerInSeconds"`
 	}
 
 	// StatsdConfig contains the config items for statsd metrics reporter

--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -135,22 +135,28 @@ func (s *MetricsSuite) TestSetDefaultPerUnitHistogramBoundaries() {
 		expectResult map[string][]float64
 	}
 
-	customizedBoundaries := map[string][]float64{
-		Dimensionless: {1},
-		Milliseconds:  defaultPerUnitHistogramBoundaries[Milliseconds],
-		Bytes:         defaultPerUnitHistogramBoundaries[Bytes],
-	}
 	testCases := []histogramTest{
 		{
-			input:        nil,
-			expectResult: defaultPerUnitHistogramBoundaries,
+			input: nil,
+			expectResult: map[string][]float64{
+				Dimensionless: defaultPerUnitHistogramBoundaries[Dimensionless],
+				Milliseconds:  defaultPerUnitHistogramBoundaries[Milliseconds],
+				Seconds:       {0.001, 0.002, 0.005, 0.010, 0.020, 0.050, 0.100, 0.200, 0.500, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000},
+				Bytes:         defaultPerUnitHistogramBoundaries[Bytes],
+			},
 		},
 		{
 			input: map[string][]float64{
 				UnitNameDimensionless: {1},
+				UnitNameMilliseconds:  {10, 1000, 2000},
 				"notDefine":           {1},
 			},
-			expectResult: customizedBoundaries,
+			expectResult: map[string][]float64{
+				Dimensionless: {1},
+				Milliseconds:  {10, 1000, 2000},
+				Seconds:       {0.01, 1, 2},
+				Bytes:         defaultPerUnitHistogramBoundaries[Bytes],
+			},
 		},
 	}
 

--- a/common/metrics/consts.go
+++ b/common/metrics/consts.go
@@ -32,4 +32,5 @@ const (
 	Dimensionless = "1"
 	Milliseconds  = "ms"
 	Bytes         = "By"
+	Seconds       = "s"
 )

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -46,7 +46,7 @@ type (
 func NewTimerDef(name string, opts ...Option) timerDefinition {
 	// This line cannot be combined with others!
 	// This ensures the stack trace has information of the caller.
-	def := newMetricDefinition(name, append(opts, WithUnit(Milliseconds))...)
+	def := newMetricDefinition(name, opts...)
 	globalRegistry.register(def)
 	return timerDefinition{def}
 }

--- a/common/metrics/opentelemetry_provider.go
+++ b/common/metrics/opentelemetry_provider.go
@@ -59,14 +59,19 @@ func NewOpenTelemetryProvider(
 	clientConfig *ClientConfig,
 ) (*openTelemetryProviderImpl, error) {
 	reg := prometheus.NewRegistry()
-	exporter, err := exporters.New(exporters.WithRegisterer(reg))
+	exporterOpts := []exporters.Option{exporters.WithRegisterer(reg)}
+	if clientConfig.WithoutUnits {
+		exporterOpts = append(exporterOpts, exporters.WithoutUnits())
+	}
+	exporter, err := exporters.New(exporterOpts...)
+
 	if err != nil {
 		logger.Error("Failed to initialize prometheus exporter.", tag.Error(err))
 		return nil, err
 	}
 
 	var views []sdkmetrics.View
-	for _, u := range []string{Dimensionless, Bytes, Milliseconds} {
+	for _, u := range []string{Dimensionless, Bytes, Milliseconds, Seconds} {
 		views = append(views, sdkmetrics.NewView(
 			sdkmetrics.Instrument{
 				Kind: sdkmetrics.InstrumentKindHistogram,

--- a/common/metrics/opentelemetry_provider.go
+++ b/common/metrics/opentelemetry_provider.go
@@ -60,8 +60,11 @@ func NewOpenTelemetryProvider(
 ) (*openTelemetryProviderImpl, error) {
 	reg := prometheus.NewRegistry()
 	exporterOpts := []exporters.Option{exporters.WithRegisterer(reg)}
-	if clientConfig.WithoutUnits {
+	if clientConfig.WithoutUnitSuffix {
 		exporterOpts = append(exporterOpts, exporters.WithoutUnits())
+	}
+	if clientConfig.WithoutCounterSuffix {
+		exporterOpts = append(exporterOpts, exporters.WithoutCounterSuffixes())
 	}
 	exporter, err := exporters.New(exporterOpts...)
 

--- a/common/metrics/otel_metrics_handler_test.go
+++ b/common/metrics/otel_metrics_handler_test.go
@@ -68,33 +68,33 @@ func TestMeter(t *testing.T) {
 			sdkmetrics.NewView(
 				sdkmetrics.Instrument{
 					Kind: sdkmetrics.InstrumentKindHistogram,
-					Unit: "By",
+					Unit: Bytes,
 				},
 				sdkmetrics.Stream{
 					Aggregation: sdkmetrics.AggregationExplicitBucketHistogram{
-						Boundaries: defaultConfig.PerUnitHistogramBoundaries["By"],
+						Boundaries: defaultConfig.PerUnitHistogramBoundaries[Bytes],
 					},
 				},
 			),
 			sdkmetrics.NewView(
 				sdkmetrics.Instrument{
 					Kind: sdkmetrics.InstrumentKindHistogram,
-					Unit: "1",
+					Unit: Dimensionless,
 				},
 				sdkmetrics.Stream{
 					Aggregation: sdkmetrics.AggregationExplicitBucketHistogram{
-						Boundaries: defaultConfig.PerUnitHistogramBoundaries["1"],
+						Boundaries: defaultConfig.PerUnitHistogramBoundaries[Dimensionless],
 					},
 				},
 			),
 			sdkmetrics.NewView(
 				sdkmetrics.Instrument{
 					Kind: sdkmetrics.InstrumentKindHistogram,
-					Unit: "ms",
+					Unit: Milliseconds,
 				},
 				sdkmetrics.Stream{
 					Aggregation: sdkmetrics.AggregationExplicitBucketHistogram{
-						Boundaries: defaultConfig.PerUnitHistogramBoundaries["ms"],
+						Boundaries: defaultConfig.PerUnitHistogramBoundaries[Milliseconds],
 					},
 				},
 			),
@@ -171,7 +171,7 @@ func TestMeter(t *testing.T) {
 				},
 				Temporality: metricdata.CumulativeTemporality,
 			},
-			Unit: "ms",
+			Unit: Milliseconds,
 		},
 		{
 			Name: "temp",
@@ -200,7 +200,7 @@ func TestMeter(t *testing.T) {
 				},
 				Temporality: metricdata.CumulativeTemporality,
 			},
-			Unit: "By",
+			Unit: Bytes,
 		},
 	}
 	if diff := cmp.Diff(want, got.ScopeMetrics[0].Metrics,
@@ -223,22 +223,94 @@ func TestMeter(t *testing.T) {
 	}
 }
 
+func TestMeter_TimerInSeconds(t *testing.T) {
+	ctx := context.Background()
+	rdr := sdkmetrics.NewManualReader()
+	provider := sdkmetrics.NewMeterProvider(
+		sdkmetrics.WithReader(rdr),
+		sdkmetrics.WithView(
+			sdkmetrics.NewView(
+				sdkmetrics.Instrument{
+					Kind: sdkmetrics.InstrumentKindHistogram,
+					Unit: Seconds,
+				},
+				sdkmetrics.Stream{
+					Aggregation: sdkmetrics.AggregationExplicitBucketHistogram{
+						Boundaries: defaultConfig.PerUnitHistogramBoundaries[Seconds],
+					},
+				},
+			),
+		),
+	)
+
+	timerInSecondsConfig := defaultConfig
+	timerInSecondsConfig.RecordTimerInSeconds = true
+	p, err := NewOtelMetricsHandler(
+		log.NewTestLogger(),
+		&testProvider{meter: provider.Meter("test")},
+		timerInSecondsConfig,
+	)
+	require.NoError(t, err)
+	recordTimer(p)
+
+	var got metricdata.ResourceMetrics
+	err = rdr.Collect(ctx, &got)
+	assert.Nil(t, err)
+
+	want := []metricdata.Metrics{
+		{
+			Name: "latency",
+			Data: metricdata.Histogram[float64]{
+				DataPoints: []metricdata.HistogramDataPoint[float64]{
+					{
+						Count:        2,
+						BucketCounts: []uint64{0, 0, 0, 1, 1, 0},
+						Min:          metricdata.NewExtrema[float64](float64(minLatency) / 1000),
+						Max:          metricdata.NewExtrema[float64](float64(maxLatency) / 1000),
+						Sum:          (minLatency + maxLatency) / 1000,
+						Exemplars:    []metricdata.Exemplar[float64]{},
+					},
+				},
+				Temporality: metricdata.CumulativeTemporality,
+			},
+			Unit: Seconds,
+		},
+	}
+	if diff := cmp.Diff(want, got.ScopeMetrics[0].Metrics,
+		cmp.Comparer(func(e1, e2 metricdata.Extrema[float64]) bool {
+			v1, ok1 := e1.Value()
+			v2, ok2 := e2.Value()
+			return ok1 && ok2 && v1 == v2
+		}),
+		cmp.Comparer(func(a1, a2 attribute.Set) bool {
+			return a1.Equals(&a2)
+		}),
+		cmpopts.IgnoreFields(metricdata.HistogramDataPoint[float64]{}, "StartTime", "Time", "Bounds"),
+	); diff != "" {
+		t.Errorf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
 func recordMetrics(mp Handler) {
 	hitsCounter := mp.Counter("hits")
 	gauge := mp.Gauge("temp")
-
-	timer := mp.Timer("latency")
 	histogram := mp.Histogram("transmission", Bytes)
 	hitsTaggedCounter := mp.Counter("hits-tagged")
 	hitsTaggedExcludedCounter := mp.Counter("hits-tagged-excluded")
 
 	hitsCounter.Record(8)
 	gauge.Record(100, StringTag("location", "Mare Imbrium"))
-	timer.Record(time.Duration(minLatency) * time.Millisecond)
-	timer.Record(time.Duration(maxLatency) * time.Millisecond)
 	histogram.Record(int64(testBytes))
 	hitsTaggedCounter.Record(11, UnsafeTaskQueueTag("__sticky__"))
 	hitsTaggedExcludedCounter.Record(14, UnsafeTaskQueueTag("filtered"))
+
+	recordTimer(mp)
+}
+
+func recordTimer(mp Handler) {
+	timer := mp.Timer("latency")
+	timer.Record(time.Duration(minLatency) * time.Millisecond)
+	timer.Record(time.Duration(maxLatency) * time.Millisecond)
 }
 
 type erroneousMeter struct {

--- a/common/metrics/otel_options.go
+++ b/common/metrics/otel_options.go
@@ -38,9 +38,10 @@ type (
 	optionSet[T any] interface {
 		addOption(option metric.InstrumentOption) T
 	}
-	counterOptions   []metric.Int64CounterOption
-	gaugeOptions     []metric.Float64ObservableGaugeOption
-	histogramOptions []metric.Int64HistogramOption
+	counterOptions          []metric.Int64CounterOption
+	gaugeOptions            []metric.Float64ObservableGaugeOption
+	float64HistogramOptions []metric.Float64HistogramOption
+	int64HistogramOptions   []metric.Int64HistogramOption
 )
 
 func addOptions[T optionSet[T]](omp *otelMetricsHandler, opts T, metricName string) T {
@@ -68,6 +69,10 @@ func (opts gaugeOptions) addOption(option metric.InstrumentOption) gaugeOptions 
 	return append(opts, option)
 }
 
-func (opts histogramOptions) addOption(option metric.InstrumentOption) histogramOptions {
+func (opts float64HistogramOptions) addOption(option metric.InstrumentOption) float64HistogramOptions {
+	return append(opts, option)
+}
+
+func (opts int64HistogramOptions) addOption(option metric.InstrumentOption) int64HistogramOptions {
 	return append(opts, option)
 }

--- a/common/metrics/otel_options_test.go
+++ b/common/metrics/otel_options_test.go
@@ -81,25 +81,30 @@ func TestAddOptions(t *testing.T) {
 
 			handler := &otelMetricsHandler{catalog: c.catalog}
 			var (
-				counter counterOptions
-				gauge   gaugeOptions
-				hist    histogramOptions
+				counter     counterOptions
+				gauge       gaugeOptions
+				int64hist   int64HistogramOptions
+				float64hist float64HistogramOptions
 			)
 			for _, opt := range inputOpts {
 				counter = append(counter, opt.(metric.Int64CounterOption))
 				gauge = append(gauge, opt.(metric.Float64ObservableGaugeOption))
-				hist = append(hist, opt.(metric.Int64HistogramOption))
+				int64hist = append(int64hist, opt.(metric.Int64HistogramOption))
+				float64hist = append(float64hist, opt.(metric.Float64HistogramOption))
 			}
 			counter = addOptions(handler, counter, metricName)
 			gauge = addOptions(handler, gauge, metricName)
-			hist = addOptions(handler, hist, metricName)
+			int64hist = addOptions(handler, int64hist, metricName)
+			float64hist = addOptions(handler, float64hist, metricName)
 			require.Len(t, counter, len(c.expectedOpts))
 			require.Len(t, gauge, len(c.expectedOpts))
-			require.Len(t, hist, len(c.expectedOpts))
+			require.Len(t, int64hist, len(c.expectedOpts))
+			require.Len(t, float64hist, len(c.expectedOpts))
 			for i, opt := range c.expectedOpts {
 				assert.Equal(t, opt, counter[i])
 				assert.Equal(t, opt, gauge[i])
-				assert.Equal(t, opt, hist[i])
+				assert.Equal(t, opt, int64hist[i])
+				assert.Equal(t, opt, float64hist[i])
 			}
 		})
 	}

--- a/common/metrics/tally_metrics_handler_test.go
+++ b/common/metrics/tally_metrics_handler_test.go
@@ -41,8 +41,13 @@ var defaultConfig = ClientConfig{
 		"activityType": {},
 		"workflowType": {},
 	},
-	Prefix:                     "",
-	PerUnitHistogramBoundaries: map[string][]float64{Dimensionless: {0, 10, 100}, Bytes: {1024, 2048}, Milliseconds: {10, 500, 1000, 5000, 10000}},
+	Prefix: "",
+	PerUnitHistogramBoundaries: map[string][]float64{
+		Dimensionless: {0, 10, 100},
+		Bytes:         {1024, 2048},
+		Milliseconds:  {10, 500, 1000, 5000, 10000},
+		Seconds:       {0.01, 0.5, 1, 5, 10},
+	},
 }
 
 func TestTallyScope(t *testing.T) {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Add backward compatibility configs for tally to otel migration

## Why?
<!-- Tell your future self why have you made these changes -->
- There are some breaking changes when switching from tally to otel metric framework.
1. Unit name will be appended to the metric name
2. `_total` will be appended to counter metrics
3. Timer metric will be emitted as milliseconds instead of seconds
This PR adds configs for controlling both behaviors when using otel framework so that the behavior will be the same as tally.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit tests
- Tested locally with various combination of configurations.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- No risk by default. If new options are enabled, timer metric value may be wrong or not bucketed correctly.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- No.
