### PR TITLE
Cleanup state machine timers on machine deletion

### DIFF
--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -347,10 +347,7 @@ func (r *TaskGeneratorImpl) GenerateDirtySubStateMachineTasks(
 		}
 	}
 
-	if r.mutableState.IsTransitionHistoryEnabled() {
-		// Ensure there's a timer task scheduled if needed
-		AddNextStateMachineTimerTask(r.mutableState)
-	}
+	AddNextStateMachineTimerTask(r.mutableState)
 
 	return nil
 }

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -28,7 +28,6 @@ package workflow
 
 import (
 	"context"
-	"slices"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -657,21 +656,10 @@ func (r *TaskRefresherImpl) refreshTasksForSubStateMachines(
 	}
 
 	if len(nodesToRefresh) != 0 {
-		haveNewDeletedStateMachines := slices.ContainsFunc(mutableState.GetExecutionInfo().SubStateMachineTombstoneBatches, func(batch *persistencespb.StateMachineTombstoneBatch) bool {
-			isFreshBatch := CompareVersionedTransition(
-				batch.VersionedTransition,
-				minVersionedTransition,
-			) >= 0
-			return isFreshBatch || slices.ContainsFunc(batch.StateMachineTombstones, func(ts *persistencespb.StateMachineTombstone) bool {
-				// At least one state machine node was deleted.
-				return ts.GetStateMachinePath() != nil
-			})
-		})
-
-		if len(nodesToRefresh) != 0 || haveNewDeletedStateMachines {
-			if err := TrimStateMachineTimers(mutableState, minVersionedTransition); err != nil {
-				return err
-			}
+		// TODO: after hsm node tombstone is tracked in mutable state,
+		// also trigger trim when there are new tombstones after minVersionedTransition
+		if err := TrimStateMachineTimers(mutableState, minVersionedTransition); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
## What changed?

Delete state machine timers every time we close a transaction on mutable state.

## Why?

Part of the work on state machine deletion

## How did you test it?

Unit tests