### PR TITLE
Raise WorkflowExecutionMaxTotalUpdates to 10K

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1946,7 +1946,7 @@ archivalQueueProcessor`,
 	)
 	WorkflowExecutionMaxTotalUpdates = NewNamespaceIntSetting(
 		"history.maxTotalUpdates",
-		2000,
+		10000,
 		`WorkflowExecutionMaxTotalUpdates is the max number of updates that any given workflow execution can receive. Set to zero to disable.`,
 	)
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

See title.

## Why?
<!-- Tell your future self why have you made these changes -->

Other features such as activities have a 10K limit. There's no reason Updates shouldn't support the same.

It also delays the need for CAN for a Workflow.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

There could be unexpected behavior past the current limit? But that seems unlikely.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
