### PR TITLE
Improve cluster metadata and metadata persistence tests

### DIFF
--- a/common/persistence/persistence-tests/cluster_metadata_manager.go
+++ b/common/persistence/persistence-tests/cluster_metadata_manager.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/serviceerror"
 	versionpb "go.temporal.io/api/version/v1"
-
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/debug"
 	p "go.temporal.io/server/common/persistence"

--- a/common/persistence/persistence-tests/cluster_metadata_manager.go
+++ b/common/persistence/persistence-tests/cluster_metadata_manager.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/serviceerror"
 	versionpb "go.temporal.io/api/version/v1"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/debug"
 	p "go.temporal.io/server/common/persistence"
@@ -65,6 +66,9 @@ func (s *ClusterMetadataManagerSuite) SetupTest() {
 
 // TearDownTest implementation
 func (s *ClusterMetadataManagerSuite) TearDownTest() {
+	// Ensure all tests clean up after themselves
+	// Todo: MetaMgr should provide api to clear all members
+	s.waitForPrune(1 * time.Second)
 	s.cancel()
 }
 
@@ -100,16 +104,12 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipUpsertCanReadAny() {
 	s.Nil(err)
 	s.NotNil(resp)
 	s.NotEmpty(resp.ActiveMembers)
+
+	s.waitForPrune(5 * time.Second)
 }
 
 // TestClusterMembershipUpsertCanRead verifies that we can UpsertClusterMembership and read our result
 func (s *ClusterMetadataManagerSuite) TestClusterMembershipUpsertCanPageRead() {
-	// Expire previous records
-	// Todo: MetaMgr should provide api to clear all members
-	time.Sleep(time.Second * 3)
-	err := s.ClusterMetadataManager.PruneClusterMembership(s.ctx, &p.PruneClusterMembershipRequest{MaxRecordsPruned: 100})
-	s.Nil(err)
-
 	expectedIds := make(map[string]int, 100)
 	for i := 0; i < 100; i++ {
 		hostID := primitives.NewUUID().Downcast()
@@ -148,9 +148,7 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipUpsertCanPageRead() {
 		s.Zero(val, "identifier was either not found in db, or shouldn't be there - "+id)
 	}
 
-	time.Sleep(time.Second * 3)
-	err = s.ClusterMetadataManager.PruneClusterMembership(s.ctx, &p.PruneClusterMembershipRequest{MaxRecordsPruned: 1000})
-	s.NoError(err)
+	s.waitForPrune(5 * time.Second)
 }
 
 func (s *ClusterMetadataManagerSuite) validateUpsert(req *p.UpsertClusterMembershipRequest, resp *p.GetClusterMembersResponse, err error) {
@@ -223,10 +221,7 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipReadFiltersCorrectly(
 	)
 
 	s.validateUpsert(req, resp, err)
-
-	time.Sleep(time.Second * 3)
-	err = s.ClusterMetadataManager.PruneClusterMembership(s.ctx, &p.PruneClusterMembershipRequest{MaxRecordsPruned: 1000})
-	s.NoError(err)
+	s.waitForPrune(5 * time.Second)
 }
 
 // TestClusterMembershipUpsertExpiresCorrectly verifies RecordExpiry functions properly for ClusterMembership records
@@ -263,19 +258,27 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipUpsertExpiresCorrectl
 	s.Equal(resp.ActiveMembers[0].HostID, req.HostID)
 	s.Equal(resp.ActiveMembers[0].Role, req.Role)
 
-	time.Sleep(time.Second * 2)
+	s.waitForPrune(5 * time.Second)
+}
 
-	err = s.ClusterMetadataManager.PruneClusterMembership(s.ctx, &p.PruneClusterMembershipRequest{MaxRecordsPruned: 100})
-	s.Nil(err)
+// waitForPrune waits up for the persistence backend to prune all records. Some persistence backends
+// may not remove TTL'd entries at the exact instant they should expire, so we allow some timing flexibility here.
+func (s *ClusterMetadataManagerSuite) waitForPrune(waitFor time.Duration) {
+	s.Eventually(func() bool {
+		err := s.ClusterMetadataManager.PruneClusterMembership(s.ctx, &p.PruneClusterMembershipRequest{MaxRecordsPruned: 100})
+		s.Nil(err)
 
-	resp, err = s.ClusterMetadataManager.GetClusterMembers(
-		s.ctx,
-		&p.GetClusterMembersRequest{LastHeartbeatWithin: time.Minute * 10},
-	)
+		resp, err := s.ClusterMetadataManager.GetClusterMembers(
+			s.ctx,
+			&p.GetClusterMembersRequest{LastHeartbeatWithin: time.Minute * 10},
+		)
+		s.NoError(err)
+		s.NotNil(resp)
+		return len(resp.ActiveMembers) == 0
 
-	s.Nil(err)
-	s.NotNil(resp)
-	s.Empty(resp.ActiveMembers)
+	},
+		waitFor,
+		500*time.Millisecond)
 }
 
 // TestClusterMembershipUpsertInvalidExpiry verifies we cannot specify a non-positive RecordExpiry duration

--- a/common/persistence/persistence-tests/metadata_persistence_v2.go
+++ b/common/persistence/persistence-tests/metadata_persistence_v2.go
@@ -38,8 +38,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/serviceerror"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/debug"
@@ -47,6 +45,7 @@ import (
 	"go.temporal.io/server/common/persistence/cassandra"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/testing/protorequire"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type (


### PR DESCRIPTION
## What changed?
Improved persistence tests to account for differing behavior of some persistence backends.

## Why?
These tests made assumptions about persistence that don't necessarily apply to all persistence backends. Specifically the tests assumed:
- All persistence backends return a final empty page when paginating results
- All persistence backends are guaranteed to expire TTL'd records (nearly) instantly upon expiration.

## How did you test it?
Ran the tests with various persistence backends

## Potential risks
This is a test-only update

## Documentation
No changes.

## Is hotfix candidate?
No
