### PR TITLE
Enforce Update Registry size limit

### DIFF
--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -997,7 +997,7 @@ func (c *ContextImpl) UpdateRegistry(ctx context.Context) update.Registry {
 					return c.config.WorkflowExecutionMaxInFlightUpdates(nsName)
 				},
 			),
-			update.WithRegistrySizeLimit(
+			update.WithInFlightSizeLimit(
 				func() int {
 					return c.config.WorkflowExecutionMaxInFlightUpdatePayloads(nsName)
 				},


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Enforce the configurable inflight size limit for Updates.

## Why?
<!-- Tell your future self why have you made these changes -->

Instead of only using a fixed number of inflight Updates, a size-based approach is more helpful.

The limit is at 10MB right now. But will likely be lowered very soon.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Added tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
