### PR TITLE
Propagate Nexus failure source header to outbound executor metrics

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -31,6 +31,7 @@ const (
 	ServiceRoleTagName          = "service_role"
 	CacheTypeTagName            = "cache_type"
 	FailureTagName              = "failure"
+	FailureSourceTagName        = "failure_source"
 	TaskCategoryTagName         = "task_category"
 	TaskTypeTagName             = "task_type"
 	TaskPriorityTagName         = "task_priority"

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -246,6 +246,13 @@ func FailureTag(value string) Tag {
 	return &tagImpl{key: FailureTagName, value: value}
 }
 
+func FailureSourceTag(value string) Tag {
+	if len(value) == 0 {
+		value = unknownValue
+	}
+	return &tagImpl{key: FailureSourceTagName, value: value}
+}
+
 func TaskCategoryTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue

--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -48,6 +48,10 @@ type failureSourceContextKeyType struct{}
 
 var FailureSourceContextKey = failureSourceContextKeyType{}
 
+type FailureSourceContextValue struct {
+	Source string
+}
+
 var failureTypeString = string((&failurepb.Failure{}).ProtoReflect().Descriptor().FullName())
 
 // ProtoFailureToNexusFailure converts a proto Nexus Failure to a Nexus SDK Failure.

--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -44,7 +44,9 @@ const (
 	FailureSourceWorker = "worker"
 )
 
-type FailureSourceContextKey struct{}
+type failureSourceContextKeyType struct{}
+
+var FailureSourceContextKey = failureSourceContextKeyType{}
 
 var failureTypeString = string((&failurepb.Failure{}).ProtoReflect().Descriptor().FullName())
 

--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -48,10 +48,6 @@ type failureSourceContextKeyType struct{}
 
 var FailureSourceContextKey = failureSourceContextKeyType{}
 
-type FailureSourceContextValue struct {
-	Source string
-}
-
 var failureTypeString = string((&failurepb.Failure{}).ProtoReflect().Descriptor().FullName())
 
 // ProtoFailureToNexusFailure converts a proto Nexus Failure to a Nexus SDK Failure.

--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -37,6 +37,15 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
+const (
+	// FailureSourceHeaderName is the header used to indicate from where the Nexus failure originated.
+	FailureSourceHeaderName = "Temporal-Nexus-Failure-Source"
+	// FailureSourceWorker indicates the failure originated from outside the server (e.g. bad request or on the Nexus worker).
+	FailureSourceWorker = "worker"
+)
+
+type FailureSourceContextKey struct{}
+
 var failureTypeString = string((&failurepb.Failure{}).ProtoReflect().Descriptor().FullName())
 
 // ProtoFailureToNexusFailure converts a proto Nexus Failure to a Nexus SDK Failure.

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -768,7 +768,7 @@ func callErrToFailure(callErr error, retryable bool) (*failurepb.Failure, error)
 }
 
 func failureSourceFromContext(callCtx context.Context) string {
-	val := callCtx.Value(commonnexus.FailureSourceContextKey{})
+	val := callCtx.Value(commonnexus.FailureSourceContextKey)
 	if val == nil {
 		return ""
 	}

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -460,13 +460,15 @@ func TestProcessInvocationTask(t *testing.T) {
 					metrics.NamespaceTag("ns-name"),
 					metrics.DestinationTag("endpoint"),
 					metrics.NexusMethodTag("StartOperation"),
-					metrics.OutcomeTag(tc.expectedMetricOutcome))
+					metrics.OutcomeTag(tc.expectedMetricOutcome),
+					metrics.FailureSourceTag("_unknown_"))
 				metricsHandler.EXPECT().Timer(nexusoperations.OutboundRequestLatency.Name()).Return(timer)
 				timer.EXPECT().Record(gomock.Any(),
 					metrics.NamespaceTag("ns-name"),
 					metrics.DestinationTag("endpoint"),
 					metrics.NexusMethodTag("StartOperation"),
-					metrics.OutcomeTag(tc.expectedMetricOutcome))
+					metrics.OutcomeTag(tc.expectedMetricOutcome),
+					metrics.FailureSourceTag("_unknown_"))
 			}
 
 			endpointReg := nexustest.FakeEndpointRegistry{
@@ -752,13 +754,15 @@ func TestProcessCancelationTask(t *testing.T) {
 					metrics.NamespaceTag("ns-name"),
 					metrics.DestinationTag("endpoint"),
 					metrics.NexusMethodTag("CancelOperation"),
-					metrics.OutcomeTag(tc.expectedMetricOutcome))
+					metrics.OutcomeTag(tc.expectedMetricOutcome),
+					metrics.FailureSourceTag("_unknown_"))
 				metricsHandler.EXPECT().Timer(nexusoperations.OutboundRequestLatency.Name()).Return(timer)
 				timer.EXPECT().Record(gomock.Any(),
 					metrics.NamespaceTag("ns-name"),
 					metrics.DestinationTag("endpoint"),
 					metrics.NexusMethodTag("CancelOperation"),
-					metrics.OutcomeTag(tc.expectedMetricOutcome))
+					metrics.OutcomeTag(tc.expectedMetricOutcome),
+					metrics.FailureSourceTag("_unknown_"))
 			}
 			endpointReg := nexustest.FakeEndpointRegistry{
 				OnGetByID: func(ctx context.Context, endpointID string) (*persistencespb.NexusEndpointEntry, error) {

--- a/components/nexusoperations/fx.go
+++ b/components/nexusoperations/fx.go
@@ -138,7 +138,14 @@ func ClientProviderFactory(
 		if clusterInfo, ok := clusterMetadata.GetAllClusterInfo()[clusterMetadata.GetCurrentClusterName()]; ok {
 			httpCaller = func(r *http.Request) (*http.Response, error) {
 				r.Header.Set(NexusCallbackSourceHeader, clusterInfo.ClusterID)
-				return httpClient.Do(r)
+				resp, callErr := httpClient.Do(r)
+				if resp != nil && resp.Header != nil {
+					if failureSource := resp.Header.Get(commonnexus.FailureSourceHeaderName); failureSource != "" {
+						// Abuse the context to propagate this value back to the task executor since it cannot access response headers directly.
+						ctx = context.WithValue(ctx, commonnexus.FailureSourceContextKey{}, failureSource)
+					}
+				}
+				return resp, callErr
 			}
 		}
 		return nexus.NewHTTPClient(nexus.HTTPClientOptions{

--- a/components/nexusoperations/fx.go
+++ b/components/nexusoperations/fx.go
@@ -142,7 +142,7 @@ func ClientProviderFactory(
 				if resp != nil && resp.Header != nil {
 					if failureSource := resp.Header.Get(commonnexus.FailureSourceHeaderName); failureSource != "" {
 						// Abuse the context to propagate this value back to the task executor since it cannot access response headers directly.
-						ctx = context.WithValue(ctx, commonnexus.FailureSourceContextKey{}, failureSource)
+						ctx = context.WithValue(ctx, commonnexus.FailureSourceContextKey, failureSource)
 					}
 				}
 				return resp, callErr

--- a/components/nexusoperations/fx.go
+++ b/components/nexusoperations/fx.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"go.temporal.io/api/serviceerror"
@@ -173,7 +174,7 @@ func setFailureSourceOnContext(ctx context.Context, response *http.Response) {
 		return
 	}
 
-	if src, ok := failureSourceContext.(*commonnexus.FailureSourceContextValue); ok {
-		src.Source = failureSourceHeader
+	if val, ok := failureSourceContext.(*atomic.Value); ok {
+		val.Store(failureSourceHeader)
 	}
 }

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -196,7 +196,7 @@ func (c *operationContext) interceptRequest(
 
 	c.cleanupFunctions = append(c.cleanupFunctions, func(respHeaders map[string]string, retErr error) {
 		if retErr != nil {
-			if source, ok := respHeaders[nexusFailureSourceHeaderName]; ok && source != failureSourceWorker {
+			if source, ok := respHeaders[commonnexus.FailureSourceHeaderName]; ok && source != commonnexus.FailureSourceWorker {
 				c.telemetryInterceptor.HandleError(
 					request,
 					"",
@@ -415,7 +415,7 @@ func (h *nexusHandler) StartOperation(
 	case *matchingservice.DispatchNexusTaskResponse_HandlerError:
 		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error"))
 
-		oc.nexusContext.setFailureSource(failureSourceWorker)
+		oc.nexusContext.setFailureSource(commonnexus.FailureSourceWorker)
 
 		err := h.convertOutcomeToNexusHandlerError(t)
 		return nil, err
@@ -444,7 +444,7 @@ func (h *nexusHandler) StartOperation(
 		case *nexuspb.StartOperationResponse_OperationError:
 			oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("operation_error"))
 
-			oc.nexusContext.setFailureSource(failureSourceWorker)
+			oc.nexusContext.setFailureSource(commonnexus.FailureSourceWorker)
 
 			err := &nexus.OperationError{
 				State: nexus.OperationState(t.OperationError.GetOperationState()),
@@ -458,7 +458,7 @@ func (h *nexusHandler) StartOperation(
 	// This is the worker's fault.
 	oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error"))
 
-	oc.nexusContext.setFailureSource(failureSourceWorker)
+	oc.nexusContext.setFailureSource(commonnexus.FailureSourceWorker)
 
 	return nil, nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "empty outcome")
 }
@@ -556,7 +556,7 @@ func (h *nexusHandler) CancelOperation(ctx context.Context, service, operation, 
 	case *matchingservice.DispatchNexusTaskResponse_HandlerError:
 		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error"))
 
-		oc.nexusContext.setFailureSource(failureSourceWorker)
+		oc.nexusContext.setFailureSource(commonnexus.FailureSourceWorker)
 
 		err := h.convertOutcomeToNexusHandlerError(t)
 		return err
@@ -567,7 +567,7 @@ func (h *nexusHandler) CancelOperation(ctx context.Context, service, operation, 
 	// This is the worker's fault.
 	oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error"))
 
-	oc.nexusContext.setFailureSource(failureSourceWorker)
+	oc.nexusContext.setFailureSource(commonnexus.FailureSourceWorker)
 
 	return nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "empty outcome")
 }
@@ -617,7 +617,7 @@ func (h *nexusHandler) nexusClientForActiveCluster(oc *operationContext, service
 			return nil, err
 		}
 
-		if failureSource := response.Header.Get(nexusFailureSourceHeaderName); failureSource != "" {
+		if failureSource := response.Header.Get(commonnexus.FailureSourceHeaderName); failureSource != "" {
 			oc.nexusContext.setFailureSource(failureSource)
 		}
 
@@ -671,5 +671,5 @@ func (h *nexusHandler) convertOutcomeToNexusHandlerError(resp *matchingservice.D
 func (nc *nexusContext) setFailureSource(source string) {
 	nc.responseHeadersMutex.Lock()
 	defer nc.responseHeadersMutex.Unlock()
-	nc.responseHeaders[nexusFailureSourceHeaderName] = source
+	nc.responseHeaders[commonnexus.FailureSourceHeaderName] = source
 }

--- a/service/frontend/nexus_http_response_writer.go
+++ b/service/frontend/nexus_http_response_writer.go
@@ -26,13 +26,6 @@ import (
 	"net/http"
 )
 
-const (
-	// The Failure-Source header is used to indicate from where the Nexus failure originated.
-	nexusFailureSourceHeaderName = "Temporal-Nexus-Failure-Source"
-	// failureSourceWorker indicates the failure originated from outside the server (e.g. bad request or on the Nexus worker).
-	failureSourceWorker = "worker"
-)
-
 // nexusHTTPResponseWriter is a wrapper for http.ResponseWriter that appends headers set on a nexusContext
 // before writing any response.
 type nexusHTTPResponseWriter struct {

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1817,11 +1817,13 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 
 	cases := []struct {
 		outcome            string
+		metricsOutcome     string
 		checkPendingError  func(t *testing.T, pendingErr error)
 		checkWorkflowError func(t *testing.T, wfErr error)
 	}{
 		{
-			outcome: "fail-handler-internal",
+			outcome:        "fail-handler-internal",
+			metricsOutcome: "handler-error:INTERNAL",
 			checkPendingError: func(t *testing.T, pendingErr error) {
 				var handlerErr *nexus.HandlerError
 				require.ErrorAs(t, pendingErr, &handlerErr)
@@ -1832,7 +1834,8 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 			},
 		},
 		{
-			outcome: "fail-handler-app-error",
+			outcome:        "fail-handler-app-error",
+			metricsOutcome: "handler-error:INTERNAL",
 			checkPendingError: func(t *testing.T, pendingErr error) {
 				var handlerErr *nexus.HandlerError
 				require.ErrorAs(t, pendingErr, &handlerErr)
@@ -1847,7 +1850,8 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 			},
 		},
 		{
-			outcome: "fail-handler-bad-request",
+			outcome:        "fail-handler-bad-request",
+			metricsOutcome: "handler-error:BAD_REQUEST",
 			checkWorkflowError: func(t *testing.T, wfErr error) {
 				var opErr *temporal.NexusOperationError
 				require.ErrorAs(t, wfErr, &opErr)
@@ -1857,11 +1861,11 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 				var appErr *temporal.ApplicationError
 				require.ErrorAs(t, handlerErr.Cause, &appErr)
 				require.Equal(t, "bad request", appErr.Message())
-
 			},
 		},
 		{
-			outcome: "fail-operation",
+			outcome:        "fail-operation",
+			metricsOutcome: "operation-unsuccessful:failed",
 			checkWorkflowError: func(t *testing.T, wfErr error) {
 				var opErr *temporal.NexusOperationError
 				require.ErrorAs(t, wfErr, &opErr)
@@ -1871,7 +1875,8 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 			},
 		},
 		{
-			outcome: "fail-operation-app-error",
+			outcome:        "fail-operation-app-error",
+			metricsOutcome: "operation-unsuccessful:failed",
 			checkWorkflowError: func(t *testing.T, wfErr error) {
 				var opErr *temporal.NexusOperationError
 				require.ErrorAs(t, wfErr, &opErr)
@@ -1888,6 +1893,7 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 
 	for _, tc := range cases {
 		s.T().Run(tc.outcome, func(t *testing.T) {
+			capture := s.GetTestCluster().Host().CaptureMetricsHandler().StartCapture()
 			run, err := s.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 				TaskQueue: taskQueue,
 			}, callerWF, tc.outcome)
@@ -1909,12 +1915,17 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 					assert.NotNil(t, f)
 
 				}, 10*time.Second, 100*time.Millisecond)
+				s.GetTestCluster().Host().CaptureMetricsHandler().StopCapture(capture)
 				tc.checkPendingError(t, converter.FailureToError(f))
-				return
+			} else {
+				wfErr := run.Get(ctx, nil)
+				s.GetTestCluster().Host().CaptureMetricsHandler().StopCapture(capture)
+				tc.checkWorkflowError(t, wfErr)
 			}
 
-			wfErr := run.Get(ctx, nil)
-			tc.checkWorkflowError(t, wfErr)
+			snap := capture.Snapshot()
+			require.Len(t, snap["nexus_outbound_requests"], 1)
+			require.Subset(t, snap["nexus_outbound_requests"][0].Tags, map[string]string{"namespace": s.Namespace().String(), "method": "StartOperation", "failure_source": "worker", "outcome": tc.metricsOutcome})
 		})
 
 	}
@@ -2062,13 +2073,19 @@ func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationErrorRehydration() {
 
 	for _, tc := range cases {
 		s.T().Run(tc.outcome+"-"+tc.action, func(t *testing.T) {
+			capture := s.GetTestCluster().Host().CaptureMetricsHandler().StartCapture()
 			run, err := s.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 				TaskQueue: taskQueue,
 			}, callerWF, tc.outcome, tc.action)
 			s.NoError(err)
 
 			wfErr := run.Get(ctx, nil)
+			s.GetTestCluster().Host().CaptureMetricsHandler().StopCapture(capture)
 			tc.checkWorkflowError(t, wfErr)
+
+			snap := capture.Snapshot()
+			require.GreaterOrEqual(t, len(snap["nexus_outbound_requests"]), 1)
+			require.Subset(t, snap["nexus_outbound_requests"][0].Tags, map[string]string{"namespace": s.Namespace().String(), "method": "StartOperation", "failure_source": "_unknown_", "outcome": "pending"})
 		})
 
 	}
@@ -2126,13 +2143,16 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure() {
 	s.NoError(w.Start())
 	s.T().Cleanup(w.Stop)
 
+	capture := s.GetTestCluster().Host().CaptureMetricsHandler().StartCapture()
 	run, err := s.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
 	}, callerWF)
 	s.NoError(err)
+	wfErr := run.Get(ctx, nil)
+	s.GetTestCluster().Host().CaptureMetricsHandler().StopCapture(capture)
 
 	var handlerErr *nexus.HandlerError
-	s.ErrorAs(run.Get(ctx, nil), &handlerErr)
+	s.ErrorAs(wfErr, &handlerErr)
 	s.Equal(nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
 	var appErr *temporal.ApplicationError
 	s.ErrorAs(handlerErr.Cause, &appErr)
@@ -2143,6 +2163,11 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure() {
 	var details string
 	s.NoError(json.Unmarshal(failure.Details, &details))
 	s.Equal("details", details)
+
+	snap := capture.Snapshot()
+	s.Len(snap["nexus_outbound_requests"], 1)
+	// Confirming that requests which do not go through our frontend are not tagged with `failure_source`
+	s.Subset(snap["nexus_outbound_requests"][0].Tags, map[string]string{"namespace": s.Namespace().String(), "method": "StartOperation", "failure_source": "_unknown_", "outcome": "handler-error:BAD_REQUEST"})
 }
 
 func (s *NexusWorkflowTestSuite) sendNexusCompletionRequest(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Propagating the Nexus response header `Temporal-Nexus-Failure-Source` to the outbound queue executor.

## Why?
<!-- Tell your future self why have you made these changes -->
This header is included as a label on the outbound queue metrics so that we can exclude expected user errors from our alerts.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
