### PR TITLE
Delete Namespace: add stats query to DeleteExecutionsWorkflow

### DIFF
--- a/service/worker/deletenamespace/deleteexecutions/workflow.go
+++ b/service/worker/deletenamespace/deleteexecutions/workflow.go
@@ -139,8 +139,9 @@ func DeleteExecutionsWorkflow(ctx workflow.Context, params DeleteExecutionsParam
 		if params.TotalExecutionsCount > 0 {
 			des.RemainingExecutionsCount = params.TotalExecutionsCount - (result.SuccessCount + result.ErrorCount)
 		}
-		if now.After(params.FirstRunStartTime) {
-			des.AverageRPS = (result.SuccessCount + result.ErrorCount) / int(now.Sub(params.FirstRunStartTime).Seconds())
+		secondsSinceStart := int(now.Sub(params.FirstRunStartTime).Seconds())
+		if secondsSinceStart > 0 {
+			des.AverageRPS = (result.SuccessCount + result.ErrorCount) / secondsSinceStart
 		}
 		if des.AverageRPS > 0 {
 			des.ApproximateTimeLeft = time.Duration(des.RemainingExecutionsCount/des.AverageRPS) * time.Second

--- a/service/worker/deletenamespace/deleteexecutions/workflow_test.go
+++ b/service/worker/deletenamespace/deleteexecutions/workflow_test.go
@@ -524,7 +524,7 @@ func Test_DeleteExecutionsWorkflow_QueryStats(t *testing.T) {
 			ConcurrentDeleteExecutionsActivities: 1, // To linearize the execution of activities.
 		},
 		TotalExecutionsCount: (10 + 220) * 4,
-		StartTime:            startTime,
+		FirstRunStartTime:    startTime,
 	})
 
 	require.True(t, env.IsWorkflowCompleted())

--- a/service/worker/deletenamespace/reclaimresources/workflow.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow.go
@@ -251,9 +251,7 @@ func deleteWorkflowExecutions(ctx workflow.Context, logger log.Logger, params Re
 	if executionsCount == 0 {
 		return result, nil
 	}
-
 	params.DeleteExecutionsParams.TotalExecutionsCount = int(executionsCount)
-	params.DeleteExecutionsParams.StartTime = workflow.Now(ctx).UTC()
 
 	ctx2 := workflow.WithChildOptions(ctx, deleteExecutionsWorkflowOptions)
 	ctx2 = workflow.WithWorkflowID(ctx2, fmt.Sprintf("%s/%s", deleteexecutions.WorkflowName, params.Namespace))

--- a/service/worker/deletenamespace/reclaimresources/workflow.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow.go
@@ -252,6 +252,9 @@ func deleteWorkflowExecutions(ctx workflow.Context, logger log.Logger, params Re
 		return result, nil
 	}
 
+	params.DeleteExecutionsParams.TotalExecutionsCount = int(executionsCount)
+	params.DeleteExecutionsParams.StartTime = workflow.Now(ctx).UTC()
+
 	ctx2 := workflow.WithChildOptions(ctx, deleteExecutionsWorkflowOptions)
 	ctx2 = workflow.WithWorkflowID(ctx2, fmt.Sprintf("%s/%s", deleteexecutions.WorkflowName, params.Namespace))
 	var der deleteexecutions.DeleteExecutionsResult

--- a/service/worker/deletenamespace/reclaimresources/workflow_test.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow_test.go
@@ -63,7 +63,6 @@ func Test_ReclaimResourcesWorkflow_Success(t *testing.T) {
 			PagesPerExecution:                    256,
 			ConcurrentDeleteExecutionsActivities: 4,
 		},
-		StartTime:            env.Now().UTC().Add(10*time.Second + 2*time.Second), // Namespace cache refresh interval (10s) + random buffer (2s).
 		TotalExecutionsCount: 10,
 		PreviousSuccessCount: 0,
 		PreviousErrorCount:   0,
@@ -116,7 +115,6 @@ func Test_ReclaimResourcesWorkflow_EnsureNoExecutionsActivity_Error(t *testing.T
 			PagesPerExecution:                    256,
 			ConcurrentDeleteExecutionsActivities: 4,
 		},
-		StartTime:            env.Now().UTC().Add(10*time.Second + 2*time.Second), // Namespace cache refresh interval (10s) + random buffer (2s).
 		TotalExecutionsCount: 10,
 		PreviousSuccessCount: 0,
 		PreviousErrorCount:   0,
@@ -167,7 +165,6 @@ func Test_ReclaimResourcesWorkflow_EnsureNoExecutionsActivity_ExecutionsStillExi
 			PagesPerExecution:                    256,
 			ConcurrentDeleteExecutionsActivities: 4,
 		},
-		StartTime:            env.Now().UTC().Add(10*time.Second + 2*time.Second), // Namespace cache refresh interval (10s) + random buffer (2s).
 		TotalExecutionsCount: 10,
 		PreviousSuccessCount: 0,
 		PreviousErrorCount:   0,
@@ -267,7 +264,6 @@ func Test_ReclaimResourcesWorkflow_NoActivityMocks_Success(t *testing.T) {
 			PagesPerExecution:                    256,
 			ConcurrentDeleteExecutionsActivities: 4,
 		},
-		StartTime:            env.Now().UTC().Add(10*time.Second + 2*time.Second), // Namespace cache refresh interval (10s) + random buffer (2s).
 		TotalExecutionsCount: 1,
 		PreviousSuccessCount: 0,
 		PreviousErrorCount:   0,
@@ -346,7 +342,6 @@ func Test_ReclaimResourcesWorkflow_NoActivityMocks_NoProgressMade(t *testing.T) 
 			PagesPerExecution:                    256,
 			ConcurrentDeleteExecutionsActivities: 4,
 		},
-		StartTime:            env.Now().UTC().Add(10*time.Second + 2*time.Second), // Namespace cache refresh interval (10s) + random buffer (2s).
 		TotalExecutionsCount: 1,
 		PreviousSuccessCount: 0,
 		PreviousErrorCount:   0,

--- a/service/worker/deletenamespace/reclaimresources/workflow_test.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow_test.go
@@ -63,6 +63,8 @@ func Test_ReclaimResourcesWorkflow_Success(t *testing.T) {
 			PagesPerExecution:                    256,
 			ConcurrentDeleteExecutionsActivities: 4,
 		},
+		StartTime:            env.Now().UTC().Add(10*time.Second + 2*time.Second), // Namespace cache refresh interval (10s) + random buffer (2s).
+		TotalExecutionsCount: 10,
 		PreviousSuccessCount: 0,
 		PreviousErrorCount:   0,
 	}).Return(deleteexecutions.DeleteExecutionsResult{
@@ -114,6 +116,8 @@ func Test_ReclaimResourcesWorkflow_EnsureNoExecutionsActivity_Error(t *testing.T
 			PagesPerExecution:                    256,
 			ConcurrentDeleteExecutionsActivities: 4,
 		},
+		StartTime:            env.Now().UTC().Add(10*time.Second + 2*time.Second), // Namespace cache refresh interval (10s) + random buffer (2s).
+		TotalExecutionsCount: 10,
 		PreviousSuccessCount: 0,
 		PreviousErrorCount:   0,
 	}).Return(deleteexecutions.DeleteExecutionsResult{
@@ -163,6 +167,8 @@ func Test_ReclaimResourcesWorkflow_EnsureNoExecutionsActivity_ExecutionsStillExi
 			PagesPerExecution:                    256,
 			ConcurrentDeleteExecutionsActivities: 4,
 		},
+		StartTime:            env.Now().UTC().Add(10*time.Second + 2*time.Second), // Namespace cache refresh interval (10s) + random buffer (2s).
+		TotalExecutionsCount: 10,
 		PreviousSuccessCount: 0,
 		PreviousErrorCount:   0,
 	}).Return(deleteexecutions.DeleteExecutionsResult{
@@ -261,6 +267,8 @@ func Test_ReclaimResourcesWorkflow_NoActivityMocks_Success(t *testing.T) {
 			PagesPerExecution:                    256,
 			ConcurrentDeleteExecutionsActivities: 4,
 		},
+		StartTime:            env.Now().UTC().Add(10*time.Second + 2*time.Second), // Namespace cache refresh interval (10s) + random buffer (2s).
+		TotalExecutionsCount: 1,
 		PreviousSuccessCount: 0,
 		PreviousErrorCount:   0,
 	}).Return(deleteexecutions.DeleteExecutionsResult{
@@ -338,6 +346,8 @@ func Test_ReclaimResourcesWorkflow_NoActivityMocks_NoProgressMade(t *testing.T) 
 			PagesPerExecution:                    256,
 			ConcurrentDeleteExecutionsActivities: 4,
 		},
+		StartTime:            env.Now().UTC().Add(10*time.Second + 2*time.Second), // Namespace cache refresh interval (10s) + random buffer (2s).
+		TotalExecutionsCount: 1,
 		PreviousSuccessCount: 0,
 		PreviousErrorCount:   0,
 	}).Return(deleteexecutions.DeleteExecutionsResult{


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Delete Namespace: add `stats` query to `DeleteExecutionsWorkflow`.

## Why?
<!-- Tell your future self why have you made these changes -->
`DeleteExecutionsWorkflow` is long running Workflow which can run for hours. After namespace is marked as deleted there is no easy way to find out how many Workflow Executions were in it and how many left to delete. New query handler will return all current statistics.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks. Workflow code changes are backward compatible.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.