### PR TITLE
Always use OTEL as metric handler

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -77,14 +77,14 @@ type (
 		// All configs should be set to true when using opentelemetry framework to have the same behavior as tally.
 
 		// WithoutUnitSuffix controls the additional of unit suffixes to metric names.
-		// This config only takes effect when using opentelemetry framework.
+		// This config only takes effect when explicitly using "opentelemetry" as the framework.
 		WithoutUnitSuffix bool `yaml:"withoutUnitSuffix"`
 		// WithoutCounterSuffix controls the additional of _total suffixes to counter metric names.
-		// This config only takes effect when using opentelemetry framework.
+		// This config only takes effect when explicitly using "opentelemetry" as the framework.
 		WithoutCounterSuffix bool `yaml:"withoutCounterSuffix"`
 		// RecordTimerInSeconds controls if Timer metric should be emitted as number of seconds
 		// (instead of milliseconds).
-		// This config only takes effect when using opentelemetry framework.
+		// This config only takes effect when explicitly using "opentelemetry" as the framework.
 		RecordTimerInSeconds bool `yaml:"recordTimerInSeconds"`
 	}
 
@@ -113,6 +113,11 @@ type (
 
 	// PrometheusConfig is a new format for config for prometheus metrics.
 	PrometheusConfig struct {
+		// Deprecated. The underlying framework will always be OpenTelemetry.
+		// However, if the framework is not explicitly set to "opentelemetry", the
+		// behavior will be the same as tally for backward compatibility.
+		// More specifically: WithoutUnitSuffix, WithoutCounterSuffix, and RecordTimerInSeconds
+		// in ClientConfig will be set to true.
 		// Metric framework: Tally/OpenTelemetry
 		Framework string `yaml:"framework"`
 		// Address for prometheus to serve metrics from.
@@ -475,25 +480,24 @@ func newPrometheusScope(
 
 // MetricsHandlerFromConfig is used at startup to construct a MetricsHandler
 func MetricsHandlerFromConfig(logger log.Logger, c *Config) (Handler, error) {
-	if c == nil {
+	if c == nil || c.Prometheus == nil {
 		return NoopMetricsHandler, nil
 	}
 
 	setDefaultPerUnitHistogramBoundaries(&c.ClientConfig)
 
-	if c.Prometheus != nil && c.Prometheus.Framework == FrameworkOpentelemetry {
-		otelProvider, err := NewOpenTelemetryProvider(logger, c.Prometheus, &c.ClientConfig)
-		if err != nil {
-			logger.Fatal(err.Error())
-		}
-
-		return NewOtelMetricsHandler(logger, otelProvider, c.ClientConfig)
+	if c.Prometheus.Framework != FrameworkOpentelemetry {
+		c.ClientConfig.WithoutUnitSuffix = true
+		c.ClientConfig.WithoutCounterSuffix = true
+		c.ClientConfig.RecordTimerInSeconds = true
 	}
 
-	return NewTallyMetricsHandler(
-		c.ClientConfig,
-		NewScope(logger, c),
-	), nil
+	otelProvider, err := NewOpenTelemetryProvider(logger, c.Prometheus, &c.ClientConfig)
+	if err != nil {
+		logger.Fatal(err.Error())
+	}
+
+	return NewOtelMetricsHandler(logger, otelProvider, c.ClientConfig)
 }
 
 func configExcludeTags(cfg ClientConfig) map[string]map[string]struct{} {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Always use OTEL as metric handler

## Why?
<!-- Tell your future self why have you made these changes -->
- Deprecate Tally metrics framework

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Will test locally and also monitor CI

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- Metric could be different and break existing dashboard & alerting systems for existing tally users.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
- No. We keep the behavior unchanged for tally users.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- No
