### PR TITLE
[Reset] Carry over ChildrenInitializedPostResetPoint when continue-as-new

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -555,6 +555,7 @@ func NewMutableStateInChain(
 
 	// carry over necessary fields from current mutable state
 	newMutableState.executionInfo.WorkflowExecutionTimerTaskStatus = currentMutableState.GetExecutionInfo().WorkflowExecutionTimerTaskStatus
+	newMutableState.executionInfo.ChildrenInitializedPostResetPoint = currentMutableState.GetExecutionInfo().ChildrenInitializedPostResetPoint
 
 	// Copy completion callbacks to new run.
 	oldCallbacks := callbacks.MachineCollection(currentMutableState.HSM())


### PR DESCRIPTION
## What changed?
Copying `executionInfo.ChildrenInitializedPostResetPoint` over into new run in continue-as-new operation.

## Why?
This is needed so that we can apply appropriate reset policy (if needed) to children started in new runs.

## How did you test it?
manual test.

## Potential risks
N/A

## Documentation
Documentation pending.

## Is hotfix candidate?
No