### PR TITLE
Change total in-flight update payload size limit

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1941,7 +1941,7 @@ archivalQueueProcessor`,
 	)
 	WorkflowExecutionMaxInFlightUpdatePayloads = NewNamespaceIntSetting(
 		"history.maxInFlightUpdatePayloads",
-		10*1024*1024,
+		20*1024*1024,
 		`WorkflowExecutionMaxInFlightUpdatePayloads is the max total payload size (in bytes) of in-flight updates (admitted but not yet completed) for any given workflow execution. Set to zero to disable.`,
 	)
 	WorkflowExecutionMaxTotalUpdates = NewNamespaceIntSetting(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

As of https://github.com/temporalio/temporal/pull/7254 a total in-flight payload size limit is enforced. The default is 10MB right now, this PR makes it 20MB.

As the max payload size for Updates is 2MB and the current Update in-flight limit is 10, the effective limit right now is (about) 20MB.

## Why?
<!-- Tell your future self why have you made these changes -->

By enforcing a payload-based limit, we can raise the total in-flight update limit from 10 to ... more, eventually.

But we decided to couple these together, ie increasing the in-flight number when introducing the in-flight size limit.

Therefore we'll set it to be a noop effectively for now.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
