### PR TITLE
Fix flaky TestForceMigration_ResetWorkflow test

### DIFF
--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -2487,6 +2487,8 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
 	err = sysWfRun.Get(testCtx, nil)
 	s.NoError(err)
 
+	s.waitForClusterSynced()
+
 	// Verify all wf in ns is now available in cluster2
 	client2, _ := s.newClientAndWorker(s.cluster2.Host().FrontendGRPCAddress(), namespace, taskqueue, "worker2")
 	verifyHistory := func(wfID string, runID string) {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix flaky `TestForceMigration_ResetWorkflow` test.

## Why?
<!-- Tell your future self why have you made these changes -->
Completion of `ForceReplication` Workflow doesn't mean that all replication tasks are delivered and processed on standby cluster. Test needs to wait for replication queue to drain before making assertions.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run it.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.