### PR TITLE
Allow batched user data updates to succeed individually

### DIFF
--- a/common/persistence/cassandra/matching_task_store.go
+++ b/common/persistence/cassandra/matching_task_store.go
@@ -550,6 +550,11 @@ func (d *MatchingTaskStore) UpdateTaskQueueUserData(
 
 	previous := make(map[string]any)
 	applied, iter, err := d.Session.MapExecuteBatchCAS(batch, previous)
+	for _, update := range request.Updates {
+		if update.Applied != nil {
+			*update.Applied = applied
+		}
+	}
 	if err != nil {
 		return gocql.ConvertError("UpdateTaskQueueUserData", err)
 	}

--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -298,6 +298,7 @@ type (
 		// Used to build an index of build_id to task_queues
 		BuildIdsAdded   []string `json:",omitempty"`
 		BuildIdsRemoved []string `json:",omitempty"`
+		Applied         *bool
 		Conflicting     *bool
 	}
 

--- a/common/persistence/task_manager.go
+++ b/common/persistence/task_manager.go
@@ -270,6 +270,7 @@ func (m *taskManagerImpl) UpdateTaskQueueUserData(ctx context.Context, request *
 			UserData:        userData,
 			BuildIdsAdded:   update.BuildIdsAdded,
 			BuildIdsRemoved: update.BuildIdsRemoved,
+			Applied:         update.Applied,
 			Conflicting:     update.Conflicting,
 		}
 	}

--- a/common/stream_batcher/batcher.go
+++ b/common/stream_batcher/batcher.go
@@ -76,9 +76,9 @@ func NewBatcher[T, R any](fn func([]T) R, opts BatcherOptions, timeSource clock.
 }
 
 // Add adds an item to the stream and returns when it has been processed, or if the context is
-// canceled or times out. It returns two values: the value that the batch processor returned,
-// and a context error. Even if Add returns a context error, the item may still be processed in
-// the future!
+// canceled or times out. It returns two values: the value that the batch processor returned
+// for the whole batch that the item ended up in, and a context error. Even if Add returns a
+// context error, the item may still be processed in the future!
 func (b *Batcher[T, R]) Add(ctx context.Context, t T) (R, error) {
 	resp := make(chan R)
 	pair := batchPair[T, R]{resp: resp, item: t}
@@ -168,7 +168,7 @@ func (b *Batcher[T, R]) loop(runningC *chan struct{}) {
 		// process batch
 		r := b.fn(items)
 
-		// send responses
+		// send the single response to all items in the batch
 		for _, resp := range resps {
 			resp <- r
 		}


### PR DESCRIPTION
## What changed?
Following from #7039, the batch update isn't required to be transactional. The persistence interface returns an error if any failed, but update success is reported individually.

## Why?
ease adaptation to less-transactional stores

## How did you test it?
updated integration test