### PR TITLE
Log prometheus listener error by default

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -486,20 +486,15 @@ func MetricsHandlerFromConfig(logger log.Logger, c *Config) (Handler, error) {
 
 	setDefaultPerUnitHistogramBoundaries(&c.ClientConfig)
 
-	var onListenerError func(error)
+	fatalOnListenerError := true
 	if c.Prometheus.Framework != FrameworkOpentelemetry {
 		c.ClientConfig.WithoutUnitSuffix = true
 		c.ClientConfig.WithoutCounterSuffix = true
 		c.ClientConfig.RecordTimerInSeconds = true
-		onListenerError = func(err error) {
-			logger.Error("error in prometheus listener",
-				tag.Error(err),
-				tag.Address(c.Prometheus.ListenAddress),
-			)
-		}
+		fatalOnListenerError = false
 	}
 
-	otelProvider, err := NewOpenTelemetryProvider(logger, c.Prometheus, &c.ClientConfig, onListenerError)
+	otelProvider, err := NewOpenTelemetryProvider(logger, c.Prometheus, &c.ClientConfig, fatalOnListenerError)
 	if err != nil {
 		logger.Fatal(err.Error())
 	}

--- a/common/metrics/opentelemetry_provider.go
+++ b/common/metrics/opentelemetry_provider.go
@@ -107,7 +107,7 @@ func initPrometheusListener(
 	config *PrometheusConfig,
 	reg *prometheus.Registry,
 	logger log.Logger,
-	onError func(e error),
+	onListenerError func(error),
 ) *http.Server {
 	handlerPath := config.HandlerPath
 	if handlerPath == "" {
@@ -124,8 +124,8 @@ func initPrometheusListener(
 
 	go func() {
 		err := server.ListenAndServe()
-		if onError != nil {
-			onError(err)
+		if onListenerError != nil {
+			onListenerError(err)
 		} else if err != http.ErrServerClosed {
 			logger.Fatal("Failed to initialize prometheus listener.", tag.Address(config.ListenAddress))
 		}

--- a/common/metrics/opentelemetry_provider.go
+++ b/common/metrics/opentelemetry_provider.go
@@ -124,9 +124,12 @@ func initPrometheusListener(
 
 	go func() {
 		err := server.ListenAndServe()
+		if err == http.ErrServerClosed {
+			return
+		}
 		if onListenerError != nil {
 			onListenerError(err)
-		} else if err != http.ErrServerClosed {
+		} else {
 			logger.Fatal("Failed to initialize prometheus listener.", tag.Address(config.ListenAddress))
 		}
 	}()


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Log error instead of panic for existing tally users when prometheus listener can't be created.
- No behavior change for existing OTEL users

## Why?
<!-- Tell your future self why have you made these changes -->
- For backward compatibility

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
