### PR TITLE
Refactor: remove clusterNames field from xdcBaseSuite

### DIFF
--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -83,13 +83,13 @@ type (
 
 		Logger log.Logger
 
-		// Test cluster configuration.
-		testClusterFactory TestClusterFactory
-		testCluster        *TestCluster
-		testClusterConfig  *TestClusterConfig
+		testCluster *TestCluster
+		// TODO (alex): this doesn't have to be a separate field. All usages can be replaced with values from testCluster itself.
+		testClusterConfig *TestClusterConfig
 
-		namespace        namespace.Name
-		namespaceID      namespace.ID
+		namespace   namespace.Name
+		namespaceID namespace.ID
+		// TODO (alex): rename to externalNamespace
 		foreignNamespace namespace.Name
 	}
 	// TestClusterParams contains the variables which are used to configure test cluster via the TestClusterOption type.
@@ -214,9 +214,8 @@ func (s *FunctionalTestBase) SetupSuiteWithCluster(clusterConfigFile string, opt
 	s.testClusterConfig.EnableMetricsCapture = true
 	s.testClusterConfig.EnableArchival = params.ArchivalEnabled
 
-	s.testClusterFactory = NewTestClusterFactory()
-
-	s.testCluster, err = s.testClusterFactory.NewCluster(s.T(), s.testClusterConfig, s.Logger)
+	testClusterFactory := NewTestClusterFactory()
+	s.testCluster, err = testClusterFactory.NewCluster(s.T(), s.testClusterConfig, s.Logger)
 	s.Require().NoError(err)
 
 	// Setup test cluster namespaces.

--- a/tests/xdc/activity_api_test.go
+++ b/tests/xdc/activity_api_test.go
@@ -211,7 +211,7 @@ func (s *ActivityApiStateReplicationSuite) TestPauseActivityFailover() {
 	worker1.Stop()
 
 	// failover to standby cluster
-	s.failover(ns, 0, s.clusterNames[1], 2)
+	s.failover(ns, 0, s.cluster2.ClusterName(), 2)
 
 	// get standby client
 	standbyClient, err := sdkclient.Dial(sdkclient.Options{

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -221,7 +221,7 @@ func (s *xdcBaseSuite) tearDownSuite() {
 
 func (s *xdcBaseSuite) waitForClusterSynced() {
 	waitForClusterConnected(s.Assertions, s.logger, s.cluster1, s.cluster1.ClusterName(), s.cluster2.ClusterName(), s.startTime)
-	waitForClusterConnected(s.Assertions, s.logger, s.cluster2, s.cluster1.ClusterName(), s.cluster2.ClusterName(), s.startTime)
+	waitForClusterConnected(s.Assertions, s.logger, s.cluster2, s.cluster2.ClusterName(), s.cluster1.ClusterName(), s.startTime)
 }
 
 func (s *xdcBaseSuite) setupTest() {

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -254,10 +254,9 @@ func (s *xdcBaseSuite) createNamespace(
 	var clusterNames []string
 	if isGlobal {
 		replicationConfigs = make([]*replicationpb.ClusterReplicationConfig, len(clusters))
+		clusterNames = make([]string, len(clusters))
 		for ci, c := range clusters {
-			replicationConfigs[ci] = &replicationpb.ClusterReplicationConfig{
-				ClusterName: c.ClusterName(),
-			}
+			replicationConfigs[ci] = &replicationpb.ClusterReplicationConfig{ClusterName: c.ClusterName()}
 			clusterNames[ci] = c.ClusterName()
 		}
 	}
@@ -385,9 +384,7 @@ func (s *xdcBaseSuite) updateNamespaceClusters(
 	replicationConfigs := make([]*replicationpb.ClusterReplicationConfig, len(clusters))
 	clusterNames := make([]string, len(clusters))
 	for ci, c := range clusters {
-		replicationConfigs[ci] = &replicationpb.ClusterReplicationConfig{
-			ClusterName: c.ClusterName(),
-		}
+		replicationConfigs[ci] = &replicationpb.ClusterReplicationConfig{ClusterName: c.ClusterName()}
 		clusterNames[ci] = c.ClusterName()
 	}
 

--- a/tests/xdc/history_replication_dlq_test.go
+++ b/tests/xdc/history_replication_dlq_test.go
@@ -245,7 +245,7 @@ func (s *historyReplicationDLQSuite) TestWorkflowReplicationTaskFailure() {
 		Namespace: ns,
 		Clusters:  s.clusterReplicationConfig(),
 		// The first cluster is the active cluster.
-		ActiveClusterName: s.clusterNames[0],
+		ActiveClusterName: s.cluster1.ClusterName(),
 		// Needed so that the namespace is replicated.
 		IsGlobalNamespace: true,
 		// This is a required parameter.
@@ -335,7 +335,7 @@ func (s *historyReplicationDLQSuite) TestWorkflowReplicationTaskFailure() {
 		"dlq",
 		"--" + tdbg.FlagDLQVersion, dlqVersion,
 		"merge",
-		"--" + tdbg.FlagCluster, s.clusterNames[0],
+		"--" + tdbg.FlagCluster, s.cluster1.ClusterName(),
 		"--" + tdbg.FlagShardID, "1",
 		"--" + tdbg.FlagLastMessageID, lastMessageID,
 		"--" + tdbg.FlagDLQType, dlqType,
@@ -503,7 +503,7 @@ func (s *historyReplicationDLQSuite) testReadTasks(
 		"dlq",
 		"--" + tdbg.FlagDLQVersion, dlqVersion,
 		"read",
-		"--" + tdbg.FlagCluster, s.clusterNames[0],
+		"--" + tdbg.FlagCluster, s.cluster1.ClusterName(),
 		"--" + tdbg.FlagShardID, "1",
 		"--" + tdbg.FlagLastMessageID, lastMessageID,
 		"--" + tdbg.FlagDLQType, dlqType,

--- a/tests/xdc/history_replication_signals_and_updates_test.go
+++ b/tests/xdc/history_replication_signals_and_updates_test.go
@@ -91,7 +91,6 @@ type (
 		s                         *hrsuTestSuite
 	}
 	hrsuTestCluster struct {
-		name        string
 		testCluster *testcore.TestCluster
 		client      sdkclient.Client
 		// Per-test, per-cluster buffer of history event replication tasks
@@ -182,13 +181,13 @@ func (s *hrsuTestSuite) startHrsuTest() (*hrsuTest, context.Context, context.Can
 	s.testsByNamespaceName[ns] = &t
 	s.testMapLock.Unlock()
 
-	t.cluster1 = t.newHrsuTestCluster(ns, s.clusterNames[0], s.cluster1)
-	t.cluster2 = t.newHrsuTestCluster(ns, s.clusterNames[1], s.cluster2)
+	t.cluster1 = t.newHrsuTestCluster(ns, s.cluster1)
+	t.cluster2 = t.newHrsuTestCluster(ns, s.cluster2)
 	t.registerMultiRegionNamespace(ctx)
 	return &t, ctx, cancel
 }
 
-func (t *hrsuTest) newHrsuTestCluster(ns string, name string, cluster *testcore.TestCluster) hrsuTestCluster {
+func (t *hrsuTest) newHrsuTestCluster(ns string, cluster *testcore.TestCluster) hrsuTestCluster {
 	sdkClient, err := sdkclient.Dial(sdkclient.Options{
 		HostPort:  cluster.Host().FrontendGRPCAddress(),
 		Namespace: ns,
@@ -196,7 +195,6 @@ func (t *hrsuTest) newHrsuTestCluster(ns string, name string, cluster *testcore.
 	})
 	t.s.NoError(err)
 	return hrsuTestCluster{
-		name:                           name,
 		testCluster:                    cluster,
 		client:                         sdkClient,
 		inboundHistoryReplicationTasks: make(chan *hrsuTestExecutableTask, taskBufferCapacity),
@@ -632,10 +630,11 @@ func (t *hrsuTest) enterSplitBrainStateAndCompletedUpdatesInBothClusters(ctx con
 	`, cluster2UpdateId), t.cluster2.getHistory(ctx))
 }
 
+// TODO (alex): replace this with t.s.failover()
 func (t *hrsuTest) failover1To2(ctx context.Context) {
-	t.s.Equal([]string{t.s.clusterNames[0], t.s.clusterNames[0]}, t.getActiveClusters(ctx))
-	t.cluster1.setActive(ctx, t.s.clusterNames[1])
-	t.s.Equal([]string{t.s.clusterNames[1], t.s.clusterNames[0]}, t.getActiveClusters(ctx))
+	t.s.Equal([]string{t.s.cluster1.ClusterName(), t.s.cluster1.ClusterName()}, t.getActiveClusters(ctx))
+	t.cluster1.setActive(ctx, t.s.cluster2.ClusterName())
+	t.s.Equal([]string{t.s.cluster2.ClusterName(), t.s.cluster1.ClusterName()}, t.getActiveClusters(ctx))
 
 	time.Sleep(testcore.NamespaceCacheRefreshInterval) //nolint:forbidigo
 
@@ -643,13 +642,13 @@ func (t *hrsuTest) failover1To2(ctx context.Context) {
 	// Wait for active cluster to be changed in namespace registry entry.
 	// TODO (dan) It would be nice to find a better approach.
 	time.Sleep(testcore.NamespaceCacheRefreshInterval) //nolint:forbidigo
-	t.s.Equal([]string{t.s.clusterNames[1], t.s.clusterNames[1]}, t.getActiveClusters(ctx))
+	t.s.Equal([]string{t.s.cluster2.ClusterName(), t.s.cluster2.ClusterName()}, t.getActiveClusters(ctx))
 }
 
 func (t *hrsuTest) failover2To1(ctx context.Context) {
-	t.s.Equal([]string{t.s.clusterNames[1], t.s.clusterNames[1]}, t.getActiveClusters(ctx))
-	t.cluster1.setActive(ctx, t.s.clusterNames[0])
-	t.s.Equal([]string{t.s.clusterNames[0], t.s.clusterNames[1]}, t.getActiveClusters(ctx))
+	t.s.Equal([]string{t.s.cluster2.ClusterName(), t.s.cluster2.ClusterName()}, t.getActiveClusters(ctx))
+	t.cluster1.setActive(ctx, t.s.cluster1.ClusterName())
+	t.s.Equal([]string{t.s.cluster1.ClusterName(), t.s.cluster2.ClusterName()}, t.getActiveClusters(ctx))
 
 	time.Sleep(testcore.NamespaceCacheRefreshInterval) //nolint:forbidigo
 
@@ -657,15 +656,15 @@ func (t *hrsuTest) failover2To1(ctx context.Context) {
 	// Wait for active cluster to be changed in namespace registry entry.
 	// TODO (dan) It would be nice to find a better approach.
 	time.Sleep(testcore.NamespaceCacheRefreshInterval) //nolint:forbidigo
-	t.s.Equal([]string{t.s.clusterNames[0], t.s.clusterNames[0]}, t.getActiveClusters(ctx))
+	t.s.Equal([]string{t.s.cluster1.ClusterName(), t.s.cluster1.ClusterName()}, t.getActiveClusters(ctx))
 }
 
 func (t *hrsuTest) enterSplitBrainState(ctx context.Context) {
 	// We now create a "split brain" state by setting cluster2 to active. We do not execute namespace replication tasks
 	// afterward, so cluster1 does not learn of the change.
-	t.s.Equal([]string{t.s.clusterNames[0], t.s.clusterNames[0]}, t.getActiveClusters(ctx))
-	t.cluster2.setActive(ctx, t.s.clusterNames[1])
-	t.s.Equal([]string{t.s.clusterNames[0], t.s.clusterNames[1]}, t.getActiveClusters(ctx))
+	t.s.Equal([]string{t.s.cluster1.ClusterName(), t.s.cluster1.ClusterName()}, t.getActiveClusters(ctx))
+	t.cluster2.setActive(ctx, t.s.cluster2.ClusterName())
+	t.s.Equal([]string{t.s.cluster1.ClusterName(), t.s.cluster2.ClusterName()}, t.getActiveClusters(ctx))
 
 	// TODO (dan) Why do the tests still pass with this? Does this not remove the split-brain?
 	// s.executeNamespaceReplicationTasksUntil(ctx, enumsspb.NAMESPACE_OPERATION_UPDATE, 2)
@@ -763,9 +762,9 @@ func (task *hrsuTestExecutableTask) Execute() error {
 		return fmt.Errorf("failed to retrieve test for workflow %s", task.workflowId())
 	}
 	switch task.sourceCluster {
-	case task.s.clusterNames[0]:
+	case task.s.cluster1.ClusterName():
 		test.cluster2.inboundHistoryReplicationTasks <- task
-	case task.s.clusterNames[1]:
+	case task.s.cluster2.ClusterName():
 		test.cluster1.inboundHistoryReplicationTasks <- task
 	default:
 		task.s.FailNow(fmt.Sprintf("invalid cluster name: %s", task.sourceCluster))
@@ -957,7 +956,7 @@ func (c *hrsuTestCluster) completeUpdateMessageHandler(updateId string) func(res
 
 // updateResult returns the update result sent by the worker in this cluster.
 func (c *hrsuTestCluster) updateResult(updateId string) string {
-	return fmt.Sprintf("%s-%s-result", c.name, updateId)
+	return fmt.Sprintf("%s-%s-result", c.testCluster.ClusterName(), updateId)
 }
 
 func (t *hrsuTest) completeUpdateWFTHandler(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
@@ -996,7 +995,7 @@ func (t *hrsuTest) registerMultiRegionNamespace(ctx context.Context) {
 	_, err := t.cluster1.testCluster.FrontendClient().RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{
 		Namespace:                        t.tv.NamespaceName().String(),
 		Clusters:                         t.s.clusterReplicationConfig(),
-		ActiveClusterName:                t.s.clusterNames[0],
+		ActiveClusterName:                t.s.cluster1.ClusterName(),
 		IsGlobalNamespace:                true,                           // Needed so that the namespace is replicated
 		WorkflowExecutionRetentionPeriod: durationpb.New(time.Hour * 24), // Required parameter
 	})
@@ -1004,7 +1003,7 @@ func (t *hrsuTest) registerMultiRegionNamespace(ctx context.Context) {
 	// Namespace event replication tasks are being captured; we need to execute the pending ones now to propagate the
 	// new namespace to cluster 2.
 	t.executeNamespaceReplicationTasksUntil(ctx, enumsspb.NAMESPACE_OPERATION_CREATE)
-	t.s.Equal([]string{t.s.clusterNames[0], t.s.clusterNames[0]}, t.getActiveClusters(ctx))
+	t.s.Equal([]string{t.s.cluster1.ClusterName(), t.s.cluster1.ClusterName()}, t.getActiveClusters(ctx))
 }
 
 func (t *hrsuTest) getActiveClusters(ctx context.Context) []string {

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -208,7 +208,7 @@ func (s *NexusStateReplicationSuite) TestNexusOperationEventsReplicated() {
 	s.waitOperationRetry(ctx, sdkClient2, run)
 
 	// Now failover, and let cluster2 be the active.
-	s.failover(ns, 0, s.clusterNames[1], 2)
+	s.failover(ns, 0, s.cluster2.ClusterName(), 2)
 
 	s.NoError(sdkClient2.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "dont-care", nil))
 
@@ -247,7 +247,7 @@ func (s *NexusStateReplicationSuite) TestNexusOperationEventsReplicated() {
 	s.waitEvent(ctx, sdkClient1, run, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
 
 	// Fail back to cluster1.
-	s.failover(ns, 1, s.clusterNames[0], 11)
+	s.failover(ns, 1, s.cluster1.ClusterName(), 11)
 
 	s.completeNexusOperation(ctx, "result", publicCallbackUrl, callbackToken)
 
@@ -476,7 +476,7 @@ func (s *NexusStateReplicationSuite) TestNexusCallbackReplicated() {
 	})
 
 	// Failover to cluster2.
-	s.failover(ns, 0, s.clusterNames[1], 2)
+	s.failover(ns, 0, s.cluster2.ClusterName(), 2)
 
 	// Unblock callback after failover.
 	failCallback.Store(false)

--- a/tests/xdc/stream_based_replication_test.go
+++ b/tests/xdc/stream_based_replication_test.go
@@ -137,7 +137,7 @@ func (s *streamBasedReplicationTestSuite) SetupTest() {
 			Namespace: s.namespaceName,
 			Clusters:  s.clusterReplicationConfig(),
 			// The first cluster is the active cluster.
-			ActiveClusterName: s.clusterNames[0],
+			ActiveClusterName: s.cluster1.ClusterName(),
 			// Needed so that the namespace is replicated.
 			IsGlobalNamespace: true,
 			// This is a required parameter.

--- a/tests/xdc/user_data_replication_test.go
+++ b/tests/xdc/user_data_replication_test.go
@@ -114,7 +114,7 @@ func (s *UserDataReplicationTestSuite) TestUserDataIsReplicatedFromActiveToPassi
 		Namespace:                        namespace,
 		IsGlobalNamespace:                true,
 		Clusters:                         s.clusterReplicationConfig(),
-		ActiveClusterName:                s.clusterNames[0],
+		ActiveClusterName:                s.cluster1.ClusterName(),
 		WorkflowExecutionRetentionPeriod: durationpb.New(7 * time.Hour * 24),
 	}
 	_, err := activeFrontendClient.RegisterNamespace(testcore.NewContext(), regReq)
@@ -181,7 +181,7 @@ func (s *UserDataReplicationTestSuite) TestUserDataIsReplicatedFromActiveToPassi
 		Namespace:                        namespace,
 		IsGlobalNamespace:                true,
 		Clusters:                         s.clusterReplicationConfig(),
-		ActiveClusterName:                s.clusterNames[0],
+		ActiveClusterName:                s.cluster1.ClusterName(),
 		WorkflowExecutionRetentionPeriod: durationpb.New(7 * time.Hour * 24),
 	}
 	_, err := activeFrontendClient.RegisterNamespace(ctx, regReq)
@@ -354,7 +354,7 @@ func (s *UserDataReplicationTestSuite) TestUserDataEntriesAreReplicatedOnDemand(
 	}
 
 	// update namespace to cross clusters
-	s.updateNamespaceClusters(namespace, 0, s.clusterNames, []*testcore.TestCluster{s.cluster1, s.cluster2})
+	s.updateNamespaceClusters(namespace, 0, []*testcore.TestCluster{s.cluster1, s.cluster2})
 
 	// we should see one new namespace task in the replication queue
 	replicationResponse, err = adminClient.GetNamespaceReplicationMessages(ctx, &adminservice.GetNamespaceReplicationMessagesRequest{
@@ -403,7 +403,7 @@ func (s *UserDataReplicationTestSuite) TestUserDataEntriesAreReplicatedOnDemand(
 	s.Equal(expectedReplicatedTaskQueues, seenTaskQueues)
 
 	// failover and check on the other side
-	s.failover(namespace, 0, s.clusterNames[1], 2)
+	s.failover(namespace, 0, s.cluster2.ClusterName(), 2)
 
 	activeFrontendClient = s.cluster2.FrontendClient()
 	for i := 0; i < numTaskQueues; i++ {
@@ -593,7 +593,7 @@ func (s *UserDataReplicationTestSuite) TestApplyReplicationEventRevivesInUseTomb
 		Namespace:                        namespace,
 		IsGlobalNamespace:                true,
 		Clusters:                         s.clusterReplicationConfig(),
-		ActiveClusterName:                s.clusterNames[0],
+		ActiveClusterName:                s.cluster1.ClusterName(),
 		WorkflowExecutionRetentionPeriod: durationpb.New(7 * time.Hour * 24),
 	})
 	s.Require().NoError(err)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Refactor: remove `clusterNames` field from `xdcBaseSuite`.

## Why?
<!-- Tell your future self why have you made these changes -->
It can come from `testCluster` itself and passing both of them all over the code was annoying.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.