### PR TITLE
Workflow Update: abort updates with non-retryable error if WFT fails unexpectedly

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -443,6 +443,11 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 	wtFailedShouldCreateNewTask := false
 	if wtFailedCause != nil {
 		effects.Cancel(ctx)
+
+		// Abort all Updates with explicit reason, to prevent them to be aborted with generic
+		// registryClearedErr, which may lead to continuous retries of UpdateWorkflowExecution API.
+		updateRegistry.Abort(update.AbortReasonWorkflowTaskFailed)
+
 		metrics.FailedWorkflowTasksCounter.With(handler.metricsHandler).Record(
 			1,
 			metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope))

--- a/service/history/workflow/update/abort_reason.go
+++ b/service/history/workflow/update/abort_reason.go
@@ -107,14 +107,14 @@ var reasonStateMatrix = map[reasonState]failureError{
 	reasonState{r: AbortReasonWorkflowContinuing, st: stateProvisionallyAborted}: {f: nil, err: nil},
 	reasonState{r: AbortReasonWorkflowContinuing, st: stateAborted}:              {f: nil, err: nil},
 
-	// AbortReasonWorkflowTaskFailed reason is used when WFT fails unexpectedly,
-	// for example, during completion (call to RespondWorkflowTaskCompleted API),
-	// not when WFT is explicitly failing by SDK (call to RespondWorkflowTaskFailed API).
-	// Updates which haven't seen by the Workflow are aborted with retryable registryClearedErr error.
+	// AbortReasonWorkflowTaskFailed reason is used when the WFT fails unexpectedly,
+	// for example, during completion (call to RespondWorkflowTaskCompleted API)
+	// - not when WFT is explicitly failed by SDK (call to RespondWorkflowTaskFailed API).
+	// Updates which have *not* been seen by the Workflow are aborted with a retryable error.
 	reasonState{r: AbortReasonWorkflowTaskFailed, st: stateCreated}:               {f: nil, err: registryClearedErr},
 	reasonState{r: AbortReasonWorkflowTaskFailed, st: stateProvisionallyAdmitted}: {f: nil, err: registryClearedErr},
 	reasonState{r: AbortReasonWorkflowTaskFailed, st: stateAdmitted}:              {f: nil, err: registryClearedErr},
-	// Updates which have been seen by the Workflow are aborted with non-retryable error.
+	// Updates which *have* been seen by the Workflow are aborted with non-retryable error.
 	// Failed WFT will be retried but Update must not. Otherwise, internal retries will exhaust and Unavailable error will be returned to the client.
 	reasonState{r: AbortReasonWorkflowTaskFailed, st: stateSent}: {f: nil, err: workflowTaskFailErr},
 	// Updates which passed Accepted state are not retried when the registry is cleared, so there is no need to abort them.

--- a/service/history/workflow/update/errors_failures.go
+++ b/service/history/workflow/update/errors_failures.go
@@ -28,10 +28,12 @@ import (
 	"errors"
 
 	failurepb "go.temporal.io/api/failure/v1"
+	"go.temporal.io/api/serviceerror"
 )
 
 var (
-	registryClearedErr = errors.New("update registry was cleared")
+	registryClearedErr  = errors.New("update registry was cleared")
+	workflowTaskFailErr = serviceerror.NewWorkflowNotReady("Unable to perform workflow execution update due unexpected workflow task failure.")
 )
 
 var (

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -273,8 +273,9 @@ func (u *Update) abort(
 	reason AbortReason,
 	effects effect.Controller,
 ) {
-	const terminalStates = stateSet(stateCompleted | stateProvisionallyAborted | stateAborted)
-	if u.state.Matches(terminalStates) {
+	abortFailure, abortErr := reason.FailureError(u.state)
+	if abortFailure == nil && abortErr == nil {
+		// If both failure and err are nil, then it means that Update in this state can't be aborted.
 		return
 	}
 
@@ -285,7 +286,6 @@ func (u *Update) abort(
 		if !u.state.Matches(stateSet(stateProvisionallyAborted | stateProvisionallyCompletedAfterAccepted)) {
 			return
 		}
-		abortFailure, abortErr := reason.FailureError(prevState)
 		var abortOutcome *updatepb.Outcome
 		if abortFailure != nil {
 			abortOutcome = &updatepb.Outcome{Value: &updatepb.Outcome_Failure{Failure: abortFailure}}

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -1328,9 +1328,9 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_ValidateWorkerMessages() {
 				s.Error(err, "RespondWorkflowTaskCompleted should return an error contains `%v`", tc.RespondWorkflowTaskError)
 				s.Contains(err.Error(), tc.RespondWorkflowTaskError)
 
-				// When worker returns validation error, API caller got timeout error.
-				s.Error(updateResult.err)
-				s.True(common.IsContextDeadlineExceededErr(updateResult.err), updateResult.err.Error())
+				var wfNotReady *serviceerror.WorkflowNotReady
+				s.ErrorAs(updateResult.err, &wfNotReady, "API caller should get serviceerror.WorkflowNotReady, if server got a validation error while processing worker response.")
+				s.Contains(updateResult.err.Error(), "Unable to perform workflow execution update due unexpected workflow task failure.")
 				s.Nil(updateResult.response)
 			} else {
 				s.NoError(err)
@@ -2226,45 +2226,28 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Fail() 
 		})
 	s.Error(err)
 	s.Contains(err.Error(), "wasn't found")
-	// New normal (but transient) WT will be created but not returned.
 
-	s.waitUpdateAdmitted(tv)
-
-	// Try to accept update in workflow 2nd time: get error. Poller will fail WT.
-	_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv,
-		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
-			// 2nd attempt has same updates attached to it.
-			updRequestMsg := task.Messages[0]
-			s.EqualValues(8, updRequestMsg.GetEventId())
-			// Fail WT one more time. Although 2nd attempt is normal WT, it is also transient and shouldn't appear in the history.
-			// Returning error will cause the poller to fail WT.
-			return nil, errors.New("malformed request")
-		})
-	// The error is from RespondWorkflowTaskFailed, which should go w/o error.
-	s.NoError(err)
-
-	// Wait for UpdateWorkflowExecution to timeout.
-	// This does NOT remove update from registry
+	// Update is aborted, speculative WFT failure is recorded into the history.
 	updateResult := <-updateResultCh
-	s.Error(updateResult.err)
-	s.True(common.IsContextDeadlineExceededErr(updateResult.err), "UpdateWorkflowExecution must timeout after 2 seconds")
-	s.Nil(updateResult.response)
+	var wfNotReady *serviceerror.WorkflowNotReady
+	s.ErrorAs(updateResult.err, &wfNotReady)
+	s.Contains(updateResult.err.Error(), "Unable to perform workflow execution update due unexpected workflow task failure.")
 
-	// Try to accept update in workflow 3rd time: get error. Poller will fail WT.
-	_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv,
-		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
-			// 3rd attempt UpdateWorkflowExecution call has timed out but the
-			// update is still running
-			updRequestMsg := task.Messages[0]
-			s.EqualValues(8, updRequestMsg.GetEventId())
-			// Fail WT one more time. This is transient WT and shouldn't appear in the history.
-			// Returning error will cause the poller to fail WT.
-			return nil, errors.New("malformed request")
-		})
-	// The error is from RespondWorkflowTaskFailed, which should go w/o error.
-	s.NoError(err)
+	// New transient WFT is created, but it is not shown in the history.
+	events := s.GetHistory(s.Namespace().String(), tv.WorkflowExecution())
+	s.EqualHistoryEvents(`
+  1 WorkflowExecutionStarted
+  2 WorkflowTaskScheduled
+  3 WorkflowTaskStarted
+  4 WorkflowTaskCompleted
+  5 WorkflowTaskScheduled
+  6 WorkflowTaskStarted
+  7 WorkflowTaskFailed`, events)
 
-	// Complete workflow.
+	// Send Update again. It will be delivered on existing transient WFT.
+	updateResultCh = s.sendUpdate(timeoutCtx, tv)
+
+	// Try to accept 2nd update in workflow: get error. Poller will fail WFT, but the registry won't be cleared and Update won't be aborted.
 	_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv,
 		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
 			s.EqualHistory(`
@@ -2275,21 +2258,83 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Fail() 
 			  5 WorkflowTaskScheduled
 			  6 WorkflowTaskStarted
 			  7 WorkflowTaskFailed
-			  8 WorkflowTaskScheduled
+			  8 WorkflowTaskScheduled // Transient WFT
+			  9 WorkflowTaskStarted`, task.History)
+
+			updRequestMsg := task.Messages[0]
+			s.EqualValues(8, updRequestMsg.GetEventId())
+			// Returning error will cause the poller to fail WFT.
+			return nil, errors.New("malformed request")
+		})
+	// The error is from RespondWorkflowTaskFailed, which should go w/o error.
+	s.NoError(err)
+
+	// Update timed out, but stays in the registry and will be delivered again on the new transient WFT.
+	updateResult = <-updateResultCh
+	s.Error(updateResult.err)
+	s.True(common.IsContextDeadlineExceededErr(updateResult.err), "UpdateWorkflowExecution must timeout after 2 seconds")
+	s.Nil(updateResult.response)
+
+	// This WFT failure wasn't recorded because WFT was transient.
+	events = s.GetHistory(s.Namespace().String(), tv.WorkflowExecution())
+	s.EqualHistoryEvents(`
+  1 WorkflowExecutionStarted
+  2 WorkflowTaskScheduled
+  3 WorkflowTaskStarted
+  4 WorkflowTaskCompleted
+  5 WorkflowTaskScheduled
+  6 WorkflowTaskStarted
+  7 WorkflowTaskFailed`, events)
+
+	// Try to accept 2nd update in workflow 2nd time: get error. Poller will fail WT. Update is not aborted.
+	_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			// 1st attempt UpdateWorkflowExecution call has timed out but the
+			// update is still running
+			updRequestMsg := task.Messages[0]
+			s.EqualValues(8, updRequestMsg.GetEventId())
+			// Fail WT one more time. This is transient WT and shouldn't appear in the history.
+			// Returning error will cause the poller to fail WT.
+			return nil, errors.New("malformed request")
+		})
+	// The error is from RespondWorkflowTaskFailed, which should go w/o error.
+	s.NoError(err)
+
+	events = s.GetHistory(s.Namespace().String(), tv.WorkflowExecution())
+	s.EqualHistoryEvents(`
+  1 WorkflowExecutionStarted
+  2 WorkflowTaskScheduled
+  3 WorkflowTaskStarted
+  4 WorkflowTaskCompleted
+  5 WorkflowTaskScheduled
+  6 WorkflowTaskStarted
+  7 WorkflowTaskFailed`, events)
+
+	// Complete Update and workflow.
+	_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv,
+		func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+			s.EqualHistory(`
+			  1 WorkflowExecutionStarted
+			  2 WorkflowTaskScheduled
+			  3 WorkflowTaskStarted
+			  4 WorkflowTaskCompleted
+			  5 WorkflowTaskScheduled
+			  6 WorkflowTaskStarted
+			  7 WorkflowTaskFailed
+			  8 WorkflowTaskScheduled // Transient WFT
 			  9 WorkflowTaskStarted`, task.History)
 
 			return &workflowservice.RespondWorkflowTaskCompletedRequest{
-				Commands: []*commandpb.Command{
-					{
-						CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
-						Attributes:  &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{}},
-					},
-				},
+				Messages: s.UpdateAcceptCompleteMessages(tv, task.Messages[0]),
+				Commands: append(s.UpdateAcceptCompleteCommands(tv), &commandpb.Command{
+					CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+					Attributes:  &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{}},
+				}),
 			}, nil
 		})
 	s.NoError(err)
 
-	events := s.GetHistory(s.Namespace().String(), tv.WorkflowExecution())
+	events = s.GetHistory(s.Namespace().String(), tv.WorkflowExecution())
 	s.EqualHistoryEvents(`
   1 WorkflowExecutionStarted
   2 WorkflowTaskScheduled
@@ -2300,8 +2345,10 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Fail() 
   7 WorkflowTaskFailed
   8 WorkflowTaskScheduled
   9 WorkflowTaskStarted
- 10 WorkflowTaskCompleted
- 11 WorkflowExecutionCompleted`, events)
+ 10 WorkflowTaskCompleted // Transient WFT was completed successfully and end up in the history.
+ 11 WorkflowExecutionUpdateAccepted
+ 12 WorkflowExecutionUpdateCompleted
+ 13 WorkflowExecutionCompleted`, events)
 }
 
 func (s *UpdateWorkflowSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_ConvertToNormalBecauseOfBufferedSignal() {

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -2345,7 +2345,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Fail() 
   7 WorkflowTaskFailed
   8 WorkflowTaskScheduled
   9 WorkflowTaskStarted
- 10 WorkflowTaskCompleted // Transient WFT was completed successfully and end up in the history.
+ 10 WorkflowTaskCompleted // Transient WFT was completed successfully and ended up in the history.
  11 WorkflowExecutionUpdateAccepted
  12 WorkflowExecutionUpdateCompleted
  13 WorkflowExecutionCompleted`, events)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Workflow Update: abort updates with non-retryable error if WFT fails unexpectedly.

## Why?
<!-- Tell your future self why have you made these changes -->
If WFT fails while worker is trying to complete it (because of different size limit violations, or bug in SDK, or other validation errors), server clears Update registry and aborts Updates with retryable `Unavailable` error. Internal retries recreate Update and new WFT. If workers keeps sending same malformed/invalid response then WFT fails again and all of these repeats in the loop until client timeout.

Things are getting worse if Update message is the cause of the WFT failure. In this case, because retries of Update and WFT are not synced, not every WFT got Update message, and empty WFT completes successfully. This means that it starts to jump back and forth between completed and failed state and never become transient, which leads to very fast history grow.

Failing Update with non-retryable `WorkflowNotReady` error stops retries right away and returns error response to the client quicker.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Modified existing functional test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
Needs to be updated.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
Yes.
