### PR TITLE
Support metric prefix in OTEL

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -61,6 +61,11 @@ type (
 		// Each value in values list will white-list tag values to be reported as usual.
 		ExcludeTags map[string][]string `yaml:"excludeTags"`
 		// Prefix sets the prefix to all outgoing metrics
+		// When migrating from tally to opentelemetry and to be backward compatible with the existing metric names,
+		// if the prefix has a "_" suffix, add an additional "_" at the end.
+		// i.e. "temporal" -> "temporal", but "temporal_" -> "temporal__", "temporal__" -> "temporal___".
+		// This is because tally implementation blindly adds "_" as the separator between the prefix
+		// and the metric name, while opentelemetry implementation only adds it if it's not already there.
 		Prefix string `yaml:"prefix"`
 
 		// DefaultHistogramBoundaries defines the default histogram bucket

--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -215,5 +215,4 @@ func TestMetricsHandlerFromConfig(t *testing.T) {
 			assert.IsType(t, c.expectedType, handler)
 		})
 	}
-
 }

--- a/common/metrics/opentelemetry_provider.go
+++ b/common/metrics/opentelemetry_provider.go
@@ -67,8 +67,10 @@ func NewOpenTelemetryProvider(
 	if clientConfig.WithoutCounterSuffix {
 		exporterOpts = append(exporterOpts, exporters.WithoutCounterSuffixes())
 	}
+	if clientConfig.Prefix != "" {
+		exporterOpts = append(exporterOpts, exporters.WithNamespace(clientConfig.Prefix))
+	}
 	exporter, err := exporters.New(exporterOpts...)
-
 	if err != nil {
 		logger.Error("Failed to initialize prometheus exporter.", tag.Error(err))
 		return nil, err


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Support metric prefix in OTEL
- NOTE: this is a breaking change for OTEL users who current have the `Prefix` field set but also expect NOT to see the prefix in the emitted metric name.

## Why?
<!-- Tell your future self why have you made these changes -->
- It's needed for backward compatibility for existing tally users as now we always otel implementation under the hood.
- It was missed when doing OTEL implementation initially. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit test
- Tested locally

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
