### PR TITLE
Validate Nexus operation token

### DIFF
--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -79,6 +79,15 @@ ScheduleNexusOperation commands with an operation name that exceeds this limit w
 Uses Go's len() function to determine the length.`,
 )
 
+var MaxOperationTokenLength = dynamicconfig.NewNamespaceIntSetting(
+	"component.nexusoperations.limit.operation.token.length",
+	4096,
+	`Limits the maximum allowed length for a Nexus Operation token. Tokens returned via start responses or via async
+completions that exceed this limit will be rejected. Uses Go's len() function to determine the length.
+Leave this limit long enough to fit a workflow ID and namespace name plus padding at minimum since that's what the SDKs
+use as the token.`,
+)
+
 var MaxOperationHeaderSize = dynamicconfig.NewNamespaceIntSetting(
 	"component.nexusoperations.limit.header.size",
 	4096,
@@ -147,6 +156,7 @@ type Config struct {
 	MaxConcurrentOperations            dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxServiceNameLength               dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxOperationNameLength             dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxOperationTokenLength            dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxOperationHeaderSize             dynamicconfig.IntPropertyFnWithNamespaceFilter
 	DisallowedOperationHeaders         dynamicconfig.TypedPropertyFnWithNamespaceFilter[[]string]
 	MaxOperationScheduleToCloseTimeout dynamicconfig.DurationPropertyFnWithNamespaceFilter
@@ -164,6 +174,7 @@ func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 		MaxConcurrentOperations:            MaxConcurrentOperations.Get(dc),
 		MaxServiceNameLength:               MaxServiceNameLength.Get(dc),
 		MaxOperationNameLength:             MaxOperationNameLength.Get(dc),
+		MaxOperationTokenLength:            MaxOperationTokenLength.Get(dc),
 		MaxOperationHeaderSize:             MaxOperationHeaderSize.Get(dc),
 		DisallowedOperationHeaders:         DisallowedOperationHeaders.Get(dc),
 		MaxOperationScheduleToCloseTimeout: MaxOperationScheduleToCloseTimeout.Get(dc),

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -405,6 +405,27 @@ func TestProcessInvocationTask(t *testing.T) {
 				require.Equal(t, 1, len(events))
 			},
 		},
+		{
+			name:            "token to long",
+			requestTimeout:  time.Hour,
+			destinationDown: false,
+			onStartOperation: func(
+				ctx context.Context,
+				service, operation string,
+				input *nexus.LazyValue,
+				options nexus.StartOperationOptions,
+			) (nexus.HandlerStartOperationResult[any], error) {
+				return &nexus.HandlerStartOperationResultAsync{OperationToken: "12345678901"}, nil
+			},
+			expectedMetricOutcome: "pending",
+			checkOutcome: func(t *testing.T, op nexusoperations.Operation, events []*historypb.HistoryEvent) {
+				require.Equal(t, enumsspb.NEXUS_OPERATION_STATE_FAILED, op.State())
+				require.Equal(t, 1, len(events))
+				failure := events[0].GetNexusOperationFailedEventAttributes().Failure.Cause
+				require.NotNil(t, failure.GetApplicationFailureInfo())
+				require.Equal(t, "invalid operation token: length exceeds allowed limit (11/10)", failure.Message)
+			},
+		},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -490,11 +511,12 @@ func TestProcessInvocationTask(t *testing.T) {
 			}
 			require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{
 				Config: &nexusoperations.Config{
-					Enabled:             dynamicconfig.GetBoolPropertyFn(true),
-					RequestTimeout:      dynamicconfig.GetDurationPropertyFnFilteredByDestination(tc.requestTimeout),
-					MinOperationTimeout: dynamicconfig.GetDurationPropertyFnFilteredByNamespace(time.Millisecond),
-					PayloadSizeLimit:    dynamicconfig.GetIntPropertyFnFilteredByNamespace(2 * 1024 * 1024),
-					CallbackURLTemplate: dynamicconfig.GetStringPropertyFn("http://localhost/callback"),
+					Enabled:                 dynamicconfig.GetBoolPropertyFn(true),
+					RequestTimeout:          dynamicconfig.GetDurationPropertyFnFilteredByDestination(tc.requestTimeout),
+					MaxOperationTokenLength: dynamicconfig.GetIntPropertyFnFilteredByNamespace(10),
+					MinOperationTimeout:     dynamicconfig.GetDurationPropertyFnFilteredByNamespace(time.Millisecond),
+					PayloadSizeLimit:        dynamicconfig.GetIntPropertyFnFilteredByNamespace(2 * 1024 * 1024),
+					CallbackURLTemplate:     dynamicconfig.GetStringPropertyFn("http://localhost/callback"),
 					RetryPolicy: func() backoff.RetryPolicy {
 						return backoff.NewExponentialRetryPolicy(time.Second)
 					},

--- a/components/nexusoperations/frontend/fx.go
+++ b/components/nexusoperations/frontend/fx.go
@@ -33,6 +33,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/rpc"
+	"go.temporal.io/server/components/nexusoperations"
 	"go.uber.org/fx"
 )
 
@@ -48,6 +49,7 @@ func ConfigProvider(coll *dynamicconfig.Collection) *Config {
 		Enabled:                       dynamicconfig.EnableNexus.Get(coll),
 		PayloadSizeLimit:              dynamicconfig.BlobSizeLimitError.Get(coll),
 		ForwardingEnabledForNamespace: dynamicconfig.EnableNamespaceNotActiveAutoForwarding.Get(coll),
+		MaxOperationTokenLength:       nexusoperations.MaxOperationTokenLength.Get(coll),
 	}
 }
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -44,6 +44,7 @@ import (
 	"go.temporal.io/server/common/retrypolicy"
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/components/callbacks"
+	"go.temporal.io/server/components/nexusoperations"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -212,6 +213,7 @@ type Config struct {
 	MaxCallbacksPerWorkflow dynamicconfig.IntPropertyFnWithNamespaceFilter
 	CallbackEndpointConfigs dynamicconfig.TypedPropertyFnWithNamespaceFilter[[]callbacks.AddressMatchRule]
 
+	MaxNexusOperationTokenLength dynamicconfig.IntPropertyFnWithNamespaceFilter
 	NexusRequestHeadersBlacklist *dynamicconfig.GlobalCachedTypedValue[*regexp.Regexp]
 
 	LinkMaxSize        dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -339,11 +341,11 @@ func NewConfig(
 		EnableWorkerVersioningWorkflow: dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs.Get(dc),
 		EnableWorkerVersioningRules:    dynamicconfig.FrontendEnableWorkerVersioningRuleAPIs.Get(dc),
 
-		EnableNexusAPIs:         dynamicconfig.EnableNexus.Get(dc),
-		CallbackURLMaxLength:    dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
-		CallbackHeaderMaxSize:   dynamicconfig.FrontendCallbackHeaderMaxSize.Get(dc),
-		MaxCallbacksPerWorkflow: dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
-
+		EnableNexusAPIs:              dynamicconfig.EnableNexus.Get(dc),
+		CallbackURLMaxLength:         dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
+		CallbackHeaderMaxSize:        dynamicconfig.FrontendCallbackHeaderMaxSize.Get(dc),
+		MaxCallbacksPerWorkflow:      dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
+		MaxNexusOperationTokenLength: nexusoperations.MaxOperationTokenLength.Get(dc),
 		NexusRequestHeadersBlacklist: dynamicconfig.NewGlobalCachedTypedValue(
 			dc,
 			dynamicconfig.FrontendNexusRequestHeadersBlacklist,

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -4977,8 +4977,8 @@ func (wh *WorkflowHandler) RespondNexusTaskCompleted(ctx context.Context, reques
 
 	if r := request.GetResponse().GetStartOperation().GetAsyncSuccess(); r != nil {
 		operationToken := r.OperationToken
-		if operationToken == "" && r.OperationId != "" {
-			operationToken = r.OperationId
+		if operationToken == "" && r.OperationId != "" { //nolint:staticcheck // SA1019 this field might be by old clients.
+			operationToken = r.OperationId //nolint:staticcheck // SA1019 this field might be set by old clients.
 		}
 		if operationToken == "" {
 			return nil, serviceerror.NewInvalidArgument("missing opration token in response")

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -4975,6 +4975,21 @@ func (wh *WorkflowHandler) RespondNexusTaskCompleted(ctx context.Context, reques
 		return nil, errRequestNotSet
 	}
 
+	if r := request.GetResponse().GetStartOperation().GetAsyncSuccess(); r != nil {
+		operationToken := r.OperationToken
+		if operationToken == "" && r.OperationId != "" {
+			operationToken = r.OperationId
+		}
+		if operationToken == "" {
+			return nil, serviceerror.NewInvalidArgument("missing opration token in response")
+		}
+
+		tokenLimit := wh.config.MaxNexusOperationTokenLength(request.Namespace)
+		if len(operationToken) > tokenLimit {
+			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("operation token length exceeds allowed limit (%d/%d)", len(operationToken), tokenLimit))
+		}
+	}
+
 	// Both the task token and the request have a reference to a namespace. We prefer using the namespace ID from
 	// the token as it is a more stable identifier.
 	// There's no need to validate that the namespace in the token and the request match,


### PR DESCRIPTION
## What changed?

Validate the Nexus operation tokens don't exceed a configured length in all APIs that accept it.
Also tidied up code in `completions.go` where we applied the start event no via the event definition, skipping the `MachineTransition` call. There won't be any behavior change since this transition did not generate tasks.

## Why?

It's dangerous for us to accept strings without limiting their length.

## How did you test it?

Added all of the relevant tests.