### PR TITLE
Identify duplicated replication task and skip emitting lag metrics for duplicated replication task

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -937,6 +937,7 @@ var (
 	ReplicationDLQAckLevelGauge                    = NewGaugeDef("replication_dlq_ack_level")
 	ReplicationNonEmptyDLQCount                    = NewCounterDef("replication_dlq_non_empty")
 	ReplicationOutlierNamespace                    = NewCounterDef("replication_outlier_namespace")
+	ReplicationDuplicatedTaskCount                 = NewCounterDef("replication_duplicated_task")
 	EventReapplySkippedCount                       = NewCounterDef("event_reapply_skipped_count")
 	DirectQueryDispatchLatency                     = NewTimerDef("direct_query_dispatch_latency")
 	DirectQueryDispatchStickyLatency               = NewTimerDef("direct_query_dispatch_sticky_latency")

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -26,6 +26,7 @@ package history
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -1542,10 +1543,10 @@ func (h *Handler) ReplicateWorkflowState(
 	}
 
 	err = engine.ReplicateWorkflowState(ctx, request)
-	if err != nil {
-		return nil, err
+	if err == nil || errors.Is(err, replication.ErrDuplicatedReplicationRequest) {
+		return &historyservice.ReplicateWorkflowStateResponse{}, nil
 	}
-	return &historyservice.ReplicateWorkflowStateResponse{}, nil
+	return nil, err
 }
 
 // SyncShardStatus is called by processor to sync history shard information from another cluster

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -1543,7 +1543,7 @@ func (h *Handler) ReplicateWorkflowState(
 	}
 
 	err = engine.ReplicateWorkflowState(ctx, request)
-	if err == nil || errors.Is(err, replication.ErrDuplicatedReplicationRequest) {
+	if err == nil || errors.Is(err, consts.ErrDuplicate) {
 		return &historyservice.ReplicateWorkflowStateResponse{}, nil
 	}
 	return nil, err

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -1510,7 +1510,7 @@ func (h *Handler) ReplicateEventsV2(ctx context.Context, request *historyservice
 	}
 
 	err2 := engine.ReplicateEventsV2(ctx, request)
-	if err2 != nil {
+	if err2 != nil && errors.Is(err2, consts.ErrDuplicate) {
 		return nil, h.convertError(err2)
 	}
 

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -1510,11 +1510,10 @@ func (h *Handler) ReplicateEventsV2(ctx context.Context, request *historyservice
 	}
 
 	err2 := engine.ReplicateEventsV2(ctx, request)
-	if err2 != nil && errors.Is(err2, consts.ErrDuplicate) {
-		return nil, h.convertError(err2)
+	if err2 == nil || errors.Is(err2, consts.ErrDuplicate) {
+		return &historyservice.ReplicateEventsV2Response{}, nil
 	}
-
-	return &historyservice.ReplicateEventsV2Response{}, nil
+	return nil, h.convertError(err2)
 }
 
 // ReplicateWorkflowState is called by processor to replicate workflow state for passive namespaces

--- a/service/history/ndc/activity_state_replicator.go
+++ b/service/history/ndc/activity_state_replicator.go
@@ -46,6 +46,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
@@ -251,7 +252,7 @@ func (r *ActivityStateReplicatorImpl) SyncActivitiesState(
 		anyEventApplied = anyEventApplied || applied
 	}
 	if !anyEventApplied {
-		return nil
+		return replication.ErrDuplicatedReplicationRequest
 	}
 
 	// passive logic need to explicitly call create timer

--- a/service/history/ndc/activity_state_replicator.go
+++ b/service/history/ndc/activity_state_replicator.go
@@ -46,7 +46,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
-	"go.temporal.io/server/service/history/replication"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
@@ -252,7 +252,7 @@ func (r *ActivityStateReplicatorImpl) SyncActivitiesState(
 		anyEventApplied = anyEventApplied || applied
 	}
 	if !anyEventApplied {
-		return replication.ErrDuplicatedReplicationRequest
+		return consts.ErrDuplicate
 	}
 
 	// passive logic need to explicitly call create timer

--- a/service/history/ndc/activity_state_replicator_test.go
+++ b/service/history/ndc/activity_state_replicator_test.go
@@ -48,6 +48,7 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives/timestamp"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tests"
 	"go.temporal.io/server/service/history/workflow"
@@ -742,6 +743,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_WorkflowClosed() {
 	weContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
+	weContext.EXPECT().Clear().AnyTimes()
 
 	err := wcache.PutContextIfNotExist(s.workflowCache, key, weContext)
 	s.NoError(err)
@@ -782,7 +784,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_WorkflowClosed() {
 	).AnyTimes()
 
 	err = s.nDCActivityStateReplicator.SyncActivitiesState(context.Background(), request)
-	s.Nil(err)
+	s.ErrorIs(err, consts.ErrDuplicate)
 }
 
 func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityNotFound() {
@@ -905,6 +907,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityNotFound() {
 	weContext.EXPECT().Lock(gomock.Any(), locks.PriorityHigh).Return(nil)
 	weContext.EXPECT().Unlock()
 	weContext.EXPECT().IsDirty().Return(false).AnyTimes()
+	weContext.EXPECT().Clear().AnyTimes()
 
 	err := wcache.PutContextIfNotExist(s.workflowCache, key, weContext)
 	s.NoError(err)
@@ -946,7 +949,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityNotFound() {
 	).AnyTimes()
 
 	err = s.nDCActivityStateReplicator.SyncActivitiesState(context.Background(), request)
-	s.Nil(err)
+	s.ErrorIs(err, consts.ErrDuplicate)
 }
 
 func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_Zombie() {

--- a/service/history/ndc/history_replicator.go
+++ b/service/history/ndc/history_replicator.go
@@ -49,7 +49,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
-	"go.temporal.io/server/service/history/replication"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
@@ -323,7 +323,7 @@ func (r *HistoryReplicatorImpl) applyBackfillEvents(
 		}
 		err := workflow.TransitionHistoryStalenessCheck(transitionHistory, versionedTransition)
 		if err == nil {
-			return replication.ErrDuplicatedReplicationRequest
+			return consts.ErrDuplicate
 		}
 	}
 
@@ -334,7 +334,7 @@ func (r *HistoryReplicatorImpl) applyBackfillEvents(
 		metrics.DuplicateReplicationEventsCounter.With(r.metricsHandler).Record(
 			1,
 			metrics.OperationTag(metrics.BackfillHistoryEventsTaskScope))
-		return replication.ErrDuplicatedReplicationRequest
+		return consts.ErrDuplicate
 	}
 
 	if mutableState.GetExecutionInfo().GetVersionHistories().GetCurrentVersionHistoryIndex() == prepareHistoryBranchOut.BranchIndex {
@@ -493,7 +493,7 @@ func (r *HistoryReplicatorImpl) doApplyEvents(
 				metrics.DuplicateReplicationEventsCounter.With(r.metricsHandler).Record(
 					1,
 					metrics.OperationTag(metrics.ReplicateHistoryEventsScope))
-				return replication.ErrDuplicatedReplicationRequest
+				return consts.ErrDuplicate
 			}
 			err = task.skipDuplicatedEvents(prepareHistoryBranchOut.EventsApplyIndex)
 			if err != nil {

--- a/service/history/ndc/history_replicator.go
+++ b/service/history/ndc/history_replicator.go
@@ -49,6 +49,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
@@ -322,7 +323,7 @@ func (r *HistoryReplicatorImpl) applyBackfillEvents(
 		}
 		err := workflow.TransitionHistoryStalenessCheck(transitionHistory, versionedTransition)
 		if err == nil {
-			return nil
+			return replication.ErrDuplicatedReplicationRequest
 		}
 	}
 
@@ -333,7 +334,7 @@ func (r *HistoryReplicatorImpl) applyBackfillEvents(
 		metrics.DuplicateReplicationEventsCounter.With(r.metricsHandler).Record(
 			1,
 			metrics.OperationTag(metrics.BackfillHistoryEventsTaskScope))
-		return nil
+		return replication.ErrDuplicatedReplicationRequest
 	}
 
 	if mutableState.GetExecutionInfo().GetVersionHistories().GetCurrentVersionHistoryIndex() == prepareHistoryBranchOut.BranchIndex {
@@ -492,7 +493,7 @@ func (r *HistoryReplicatorImpl) doApplyEvents(
 				metrics.DuplicateReplicationEventsCounter.With(r.metricsHandler).Record(
 					1,
 					metrics.OperationTag(metrics.ReplicateHistoryEventsScope))
-				return nil
+				return replication.ErrDuplicatedReplicationRequest
 			}
 			err = task.skipDuplicatedEvents(prepareHistoryBranchOut.EventsApplyIndex)
 			if err != nil {

--- a/service/history/ndc/hsm_state_replicator.go
+++ b/service/history/ndc/hsm_state_replicator.go
@@ -41,6 +41,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/hsm"
+	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
@@ -119,8 +120,11 @@ func (r *HSMStateReplicatorImpl) SyncHSMState(
 	}
 
 	synced, err := r.syncHSMNode(mutableState, request)
-	if err != nil || !synced {
+	if err != nil {
 		return err
+	}
+	if !synced {
+		return replication.ErrDuplicatedReplicationRequest
 	}
 
 	state, _ := mutableState.GetWorkflowStateStatus()

--- a/service/history/ndc/hsm_state_replicator.go
+++ b/service/history/ndc/hsm_state_replicator.go
@@ -40,8 +40,8 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/hsm"
-	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
@@ -124,7 +124,7 @@ func (r *HSMStateReplicatorImpl) SyncHSMState(
 		return err
 	}
 	if !synced {
-		return replication.ErrDuplicatedReplicationRequest
+		return consts.ErrDuplicate
 	}
 
 	state, _ := mutableState.GetWorkflowStateStatus()

--- a/service/history/ndc/transaction_manager_new_workflow.go
+++ b/service/history/ndc/transaction_manager_new_workflow.go
@@ -33,6 +33,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
 )
@@ -87,9 +88,12 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) dispatchForNewWorkflow(
 		namespaceID,
 		workflowID,
 	)
-	if err != nil || currentRunID == targetRunID {
+	if err != nil {
 		// error out or workflow already created
 		return err
+	}
+	if currentRunID == targetRunID {
+		return replication.ErrDuplicatedReplicationRequest
 	}
 
 	if currentRunID == "" {

--- a/service/history/ndc/transaction_manager_new_workflow.go
+++ b/service/history/ndc/transaction_manager_new_workflow.go
@@ -33,7 +33,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/service/history/replication"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
 )
@@ -93,7 +93,7 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) dispatchForNewWorkflow(
 		return err
 	}
 	if currentRunID == targetRunID {
-		return replication.ErrDuplicatedReplicationRequest
+		return consts.ErrDuplicate
 	}
 
 	if currentRunID == "" {

--- a/service/history/ndc/transaction_manager_new_workflow_test.go
+++ b/service/history/ndc/transaction_manager_new_workflow_test.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
@@ -96,7 +97,7 @@ func (s *transactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_Dup() {
 	s.mockTransactionMgr.EXPECT().GetCurrentWorkflowRunID(ctx, namespaceID, workflowID).Return(runID, nil)
 
 	err := s.createMgr.dispatchForNewWorkflow(ctx, newWorkflow)
-	s.NoError(err)
+	s.ErrorIs(err, consts.ErrDuplicate)
 }
 
 func (s *transactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_BrandNew() {

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -61,7 +61,6 @@ import (
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/historybuilder"
-	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
@@ -309,14 +308,14 @@ func (r *WorkflowStateReplicatorImpl) ReplicateVersionedTransition(
 				localLastHistoryItem.GetEventId() <= sourceLastHistoryItem.EventId {
 				return r.applySnapshot(ctx, namespaceID, wid, rid, wfCtx, releaseFn, ms, versionedTransition, sourceClusterName)
 			}
-			return replication.ErrDuplicatedReplicationRequest
+			return consts.ErrDuplicate
 		}
 
 		sourceTransitionHistory := executionInfo.TransitionHistory
 		err = workflow.TransitionHistoryStalenessCheck(localTransitionHistory, transitionhistory.LastVersionedTransition(sourceTransitionHistory))
 		switch {
 		case err == nil:
-			return replication.ErrDuplicatedReplicationRequest
+			return consts.ErrDuplicate
 		case errors.Is(err, consts.ErrStaleState):
 			// local is stale, try to apply mutable state update
 			if snapshot != nil {

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -44,6 +44,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/xdc"
+	"go.temporal.io/server/service/history/consts"
 	deletemanager "go.temporal.io/server/service/history/deletemanager"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
@@ -149,7 +150,7 @@ func newDLQHandler(
 					nil,
 					"",
 				)
-				if errors.Is(err, ErrDuplicatedReplicationRequest) {
+				if errors.Is(err, consts.ErrDuplicate) {
 					return nil
 				}
 				return err

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -28,6 +28,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -135,7 +136,7 @@ func newDLQHandler(
 				if err != nil {
 					return err
 				}
-				return engine.ReplicateHistoryEvents(
+				err = engine.ReplicateHistoryEvents(
 					ctx,
 					definition.WorkflowKey{
 						NamespaceID: namespaceId.String(),
@@ -148,6 +149,10 @@ func newDLQHandler(
 					nil,
 					"",
 				)
+				if errors.Is(err, ErrDuplicatedReplicationRequest) {
+					return nil
+				}
+				return err
 
 			},
 			shard.GetPayloadSerializer(),

--- a/service/history/replication/eventhandler/resend_handler.go
+++ b/service/history/replication/eventhandler/resend_handler.go
@@ -45,7 +45,7 @@ import (
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/service/history/configs"
-	"go.temporal.io/server/service/history/replication"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 )
 
@@ -276,7 +276,7 @@ func (r *resendHandlerImpl) replicateRemoteGeneratedEvents(
 			nil,
 			"",
 		)
-		if errors.Is(err, replication.ErrDuplicatedReplicationRequest) {
+		if errors.Is(err, consts.ErrDuplicate) {
 			return nil
 		}
 		if err != nil {

--- a/service/history/replication/eventhandler/resend_handler.go
+++ b/service/history/replication/eventhandler/resend_handler.go
@@ -28,6 +28,7 @@ package eventhandler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	historypb "go.temporal.io/api/history/v1"
@@ -44,6 +45,7 @@ import (
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/shard"
 )
 
@@ -274,6 +276,9 @@ func (r *resendHandlerImpl) replicateRemoteGeneratedEvents(
 			nil,
 			"",
 		)
+		if errors.Is(err, replication.ErrDuplicatedReplicationRequest) {
+			return nil
+		}
 		if err != nil {
 			r.logger.Error("failed to replicate events",
 				tag.WorkflowNamespaceID(namespaceID.String()),

--- a/service/history/replication/eventhandler/resend_handler.go
+++ b/service/history/replication/eventhandler/resend_handler.go
@@ -276,10 +276,7 @@ func (r *resendHandlerImpl) replicateRemoteGeneratedEvents(
 			nil,
 			"",
 		)
-		if errors.Is(err, consts.ErrDuplicate) {
-			return nil
-		}
-		if err != nil {
+		if err != nil && !errors.Is(err, consts.ErrDuplicate) {
 			r.logger.Error("failed to replicate events",
 				tag.WorkflowNamespaceID(namespaceID.String()),
 				tag.WorkflowID(workflowID),

--- a/service/history/replication/executable_activity_state_task.go
+++ b/service/history/replication/executable_activity_state_task.go
@@ -41,6 +41,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	ctasks "go.temporal.io/server/common/tasks"
+	"go.temporal.io/server/service/history/consts"
 )
 
 type (
@@ -197,7 +198,7 @@ func (e *ExecutableActivityStateTask) Execute() error {
 }
 
 func (e *ExecutableActivityStateTask) HandleErr(err error) error {
-	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+	if errors.Is(err, consts.ErrDuplicate) {
 		e.MarkTaskDuplicated()
 		return nil
 	}

--- a/service/history/replication/executable_activity_state_task.go
+++ b/service/history/replication/executable_activity_state_task.go
@@ -26,6 +26,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
@@ -196,6 +197,10 @@ func (e *ExecutableActivityStateTask) Execute() error {
 }
 
 func (e *ExecutableActivityStateTask) HandleErr(err error) error {
+	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+		e.MarkTaskDuplicated()
+		return nil
+	}
 	switch retryErr := err.(type) {
 	case nil, *serviceerror.NotFound:
 		return nil

--- a/service/history/replication/executable_backfill_history_events_task.go
+++ b/service/history/replication/executable_backfill_history_events_task.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	ctasks "go.temporal.io/server/common/tasks"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 )
 
@@ -152,7 +153,7 @@ func (e *ExecutableBackfillHistoryEventsTask) Execute() error {
 }
 
 func (e *ExecutableBackfillHistoryEventsTask) HandleErr(err error) error {
-	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+	if errors.Is(err, consts.ErrDuplicate) {
 		e.MarkTaskDuplicated()
 		return nil
 	}

--- a/service/history/replication/executable_backfill_history_events_task.go
+++ b/service/history/replication/executable_backfill_history_events_task.go
@@ -24,6 +24,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	historypb "go.temporal.io/api/history/v1"
@@ -151,6 +152,10 @@ func (e *ExecutableBackfillHistoryEventsTask) Execute() error {
 }
 
 func (e *ExecutableBackfillHistoryEventsTask) HandleErr(err error) error {
+	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+		e.MarkTaskDuplicated()
+		return nil
+	}
 	e.Logger.Error("BackFillHistoryEvent replication task encountered error",
 		tag.WorkflowNamespaceID(e.NamespaceID),
 		tag.WorkflowID(e.WorkflowID),

--- a/service/history/replication/executable_history_task.go
+++ b/service/history/replication/executable_history_task.go
@@ -46,6 +46,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	ctasks "go.temporal.io/server/common/tasks"
+	"go.temporal.io/server/service/history/consts"
 )
 
 type (
@@ -187,7 +188,7 @@ func (e *ExecutableHistoryTask) Execute() error {
 }
 
 func (e *ExecutableHistoryTask) HandleErr(err error) error {
-	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+	if errors.Is(err, consts.ErrDuplicate) {
 		e.MarkTaskDuplicated()
 		return nil
 	}

--- a/service/history/replication/executable_history_task.go
+++ b/service/history/replication/executable_history_task.go
@@ -26,6 +26,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -186,6 +187,10 @@ func (e *ExecutableHistoryTask) Execute() error {
 }
 
 func (e *ExecutableHistoryTask) HandleErr(err error) error {
+	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+		e.MarkTaskDuplicated()
+		return nil
+	}
 	switch retryErr := err.(type) {
 	case nil, *serviceerror.NotFound:
 		return nil

--- a/service/history/replication/executable_history_task_test.go
+++ b/service/history/replication/executable_history_task_test.go
@@ -53,6 +53,7 @@ import (
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/xdc"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tests"
 	"go.uber.org/mock/gomock"
@@ -330,6 +331,10 @@ func (s *executableHistoryTaskSuite) TestHandleErr_Other() {
 	s.Equal(err, s.task.HandleErr(err))
 
 	err = serviceerror.NewNotFound("")
+	s.Equal(nil, s.task.HandleErr(err))
+
+	err = consts.ErrDuplicate
+	s.executableTask.EXPECT().MarkTaskDuplicated().Times(1)
 	s.Equal(nil, s.task.HandleErr(err))
 
 	err = serviceerror.NewUnavailable("")

--- a/service/history/replication/executable_sync_hsm_task.go
+++ b/service/history/replication/executable_sync_hsm_task.go
@@ -38,6 +38,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	ctasks "go.temporal.io/server/common/tasks"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -143,7 +144,7 @@ func (e *ExecutableSyncHSMTask) Execute() error {
 }
 
 func (e *ExecutableSyncHSMTask) HandleErr(err error) error {
-	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+	if errors.Is(err, consts.ErrDuplicate) {
 		e.MarkTaskDuplicated()
 		return nil
 	}

--- a/service/history/replication/executable_sync_hsm_task.go
+++ b/service/history/replication/executable_sync_hsm_task.go
@@ -24,6 +24,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
@@ -142,6 +143,10 @@ func (e *ExecutableSyncHSMTask) Execute() error {
 }
 
 func (e *ExecutableSyncHSMTask) HandleErr(err error) error {
+	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+		e.MarkTaskDuplicated()
+		return nil
+	}
 	switch retryErr := err.(type) {
 	case nil, *serviceerror.NotFound:
 		return nil

--- a/service/history/replication/executable_sync_versioned_transition_task.go
+++ b/service/history/replication/executable_sync_versioned_transition_task.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	ctasks "go.temporal.io/server/common/tasks"
+	"go.temporal.io/server/service/history/consts"
 )
 
 type (
@@ -130,7 +131,7 @@ func (e *ExecutableSyncVersionedTransitionTask) Execute() error {
 }
 
 func (e *ExecutableSyncVersionedTransitionTask) HandleErr(err error) error {
-	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+	if errors.Is(err, consts.ErrDuplicate) {
 		e.MarkTaskDuplicated()
 		return nil
 	}

--- a/service/history/replication/executable_sync_versioned_transition_task.go
+++ b/service/history/replication/executable_sync_versioned_transition_task.go
@@ -24,6 +24,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -129,6 +130,10 @@ func (e *ExecutableSyncVersionedTransitionTask) Execute() error {
 }
 
 func (e *ExecutableSyncVersionedTransitionTask) HandleErr(err error) error {
+	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+		e.MarkTaskDuplicated()
+		return nil
+	}
 	e.Logger.Error("SyncVersionedTransition replication task encountered error",
 		tag.WorkflowNamespaceID(e.NamespaceID),
 		tag.WorkflowID(e.WorkflowID),

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -309,7 +309,9 @@ func (e *ExecutableTaskImpl) emitFinishMetrics(
 	now time.Time,
 ) {
 	if e.isDuplicated {
-		metrics.ReplicationDuplicatedTaskCount.With(e.MetricsHandler).Record(1)
+		metrics.ReplicationDuplicatedTaskCount.With(e.MetricsHandler).Record(1,
+			metrics.OperationTag(e.metricsTag),
+			metrics.NamespaceTag(e.replicationTask.RawTaskInfo.NamespaceId))
 		return
 	}
 	nsTag := metrics.NamespaceUnknownTag()

--- a/service/history/replication/executable_task_mock.go
+++ b/service/history/replication/executable_task_mock.go
@@ -191,6 +191,18 @@ func (mr *MockExecutableTaskMockRecorder) MarkPoisonPill() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkPoisonPill", reflect.TypeOf((*MockExecutableTask)(nil).MarkPoisonPill))
 }
 
+// MarkTaskDuplicated mocks base method.
+func (m *MockExecutableTask) MarkTaskDuplicated() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MarkTaskDuplicated")
+}
+
+// MarkTaskDuplicated indicates an expected call of MarkTaskDuplicated.
+func (mr *MockExecutableTaskMockRecorder) MarkTaskDuplicated() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkTaskDuplicated", reflect.TypeOf((*MockExecutableTask)(nil).MarkTaskDuplicated))
+}
+
 // Nack mocks base method.
 func (m *MockExecutableTask) Nack(err error) {
 	m.ctrl.T.Helper()

--- a/service/history/replication/executable_verify_versioned_transition_task.go
+++ b/service/history/replication/executable_verify_versioned_transition_task.go
@@ -24,6 +24,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -249,6 +250,10 @@ func (e *ExecutableVerifyVersionedTransitionTask) getMutableState(ctx context.Co
 }
 
 func (e *ExecutableVerifyVersionedTransitionTask) HandleErr(err error) error {
+	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+		e.MarkTaskDuplicated()
+		return nil
+	}
 	e.Logger.Error("VerifyVersionedTransition replication task encountered error",
 		tag.WorkflowNamespaceID(e.NamespaceID),
 		tag.WorkflowID(e.WorkflowID),

--- a/service/history/replication/executable_verify_versioned_transition_task.go
+++ b/service/history/replication/executable_verify_versioned_transition_task.go
@@ -44,6 +44,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	ctasks "go.temporal.io/server/common/tasks"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/workflow"
 )
 
@@ -250,7 +251,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) getMutableState(ctx context.Co
 }
 
 func (e *ExecutableVerifyVersionedTransitionTask) HandleErr(err error) error {
-	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+	if errors.Is(err, consts.ErrDuplicate) {
 		e.MarkTaskDuplicated()
 		return nil
 	}

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -41,6 +41,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	ctasks "go.temporal.io/server/common/tasks"
+	"go.temporal.io/server/service/history/consts"
 )
 
 type (
@@ -141,7 +142,7 @@ func (e *ExecutableWorkflowStateTask) Execute() error {
 }
 
 func (e *ExecutableWorkflowStateTask) HandleErr(err error) error {
-	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+	if errors.Is(err, consts.ErrDuplicate) {
 		e.MarkTaskDuplicated()
 		return nil
 	}

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -26,6 +26,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
@@ -140,6 +141,10 @@ func (e *ExecutableWorkflowStateTask) Execute() error {
 }
 
 func (e *ExecutableWorkflowStateTask) HandleErr(err error) error {
+	if errors.Is(err, ErrDuplicatedReplicationRequest) {
+		e.MarkTaskDuplicated()
+		return nil
+	}
 	switch retryErr := err.(type) {
 	case nil, *serviceerror.NotFound:
 		return nil

--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -45,6 +45,7 @@ import (
 	ctasks "go.temporal.io/server/common/tasks"
 	"go.temporal.io/server/common/xdc"
 	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/replication/eventhandler"
 	"go.temporal.io/server/service/history/shard"
@@ -319,7 +320,7 @@ func ndcHistoryResenderProvider(
 				nil,
 				"",
 			)
-			if errors.Is(err, ErrDuplicatedReplicationRequest) {
+			if errors.Is(err, consts.ErrDuplicate) {
 				return nil
 			}
 			return err

--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -26,6 +26,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"math/rand"
 	"strconv"
 
@@ -305,7 +306,7 @@ func ndcHistoryResenderProvider(
 			if err != nil {
 				return err
 			}
-			return engine.ReplicateHistoryEvents(
+			err = engine.ReplicateHistoryEvents(
 				ctx,
 				definition.WorkflowKey{
 					NamespaceID: namespaceId.String(),
@@ -318,6 +319,10 @@ func ndcHistoryResenderProvider(
 				nil,
 				"",
 			)
+			if errors.Is(err, ErrDuplicatedReplicationRequest) {
+				return nil
+			}
+			return err
 		},
 		serializer,
 		config.StandbyTaskReReplicationContextTimeout,

--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -87,7 +87,7 @@ func WrapEventLoop(
 				metrics.FromClusterIDTag(fromClusterKey.ClusterID),
 				metrics.ToClusterIDTag(toClusterKey.ClusterID),
 			)
-			logger.Error("ReplicationStreamError", tag.Error(err))
+			logger.Warn("ReplicationStreamError", tag.Error(err))
 		} else {
 			metrics.ReplicationServiceError.With(metricsHandler).Record(
 				int64(1),

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -48,6 +48,7 @@ import (
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/xdc"
 	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/deletemanager"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
@@ -131,7 +132,7 @@ func NewTaskProcessorManager(
 					nil,
 					"",
 				)
-				if errors.Is(err, ErrDuplicatedReplicationRequest) {
+				if errors.Is(err, consts.ErrDuplicate) {
 					return nil
 				}
 				return err


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Introduce ErrDuplicate at replication code path to distinguish duplicated replication task
## Why?
<!-- Tell your future self why have you made these changes -->
To better emit replication lag metrics
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
test will be added later.
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
