### PR TITLE
Revert "Always use OTEL as metric handler (#7265)"

### DIFF
--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -176,34 +176,11 @@ func TestMetricsHandlerFromConfig(t *testing.T) {
 		name         string
 		cfg          *Config
 		expectedType interface{}
-		cfgValidator func(*Config) bool
 	}{
 		{
 			name:         "nil config",
 			cfg:          nil,
 			expectedType: &noopMetricsHandler{},
-			cfgValidator: func(c *Config) bool { return true },
-		},
-		{
-			name:         "nil prometheus config",
-			cfg:          &Config{Prometheus: nil},
-			expectedType: &noopMetricsHandler{},
-			cfgValidator: func(c *Config) bool { return true },
-		},
-		{
-			name: "no framework set",
-			cfg: &Config{
-				Prometheus: &PrometheusConfig{
-					Framework:     "",
-					ListenAddress: "localhost:0",
-				},
-			},
-			expectedType: &otelMetricsHandler{},
-			cfgValidator: func(c *Config) bool {
-				return c.ClientConfig.WithoutUnitSuffix &&
-					c.ClientConfig.WithoutCounterSuffix &&
-					c.ClientConfig.RecordTimerInSeconds
-			},
 		},
 		{
 			name: "tally",
@@ -213,30 +190,17 @@ func TestMetricsHandlerFromConfig(t *testing.T) {
 					ListenAddress: "localhost:0",
 				},
 			},
-			expectedType: &otelMetricsHandler{},
-			cfgValidator: func(c *Config) bool {
-				return c.ClientConfig.WithoutUnitSuffix &&
-					c.ClientConfig.WithoutCounterSuffix &&
-					c.ClientConfig.RecordTimerInSeconds
-			},
+			expectedType: &tallyMetricsHandler{},
 		},
 		{
 			name: "opentelemetry",
 			cfg: &Config{
-				ClientConfig: ClientConfig{
-					WithoutUnitSuffix: true,
-				},
 				Prometheus: &PrometheusConfig{
 					Framework:     FrameworkOpentelemetry,
 					ListenAddress: "localhost:0",
 				},
 			},
 			expectedType: &otelMetricsHandler{},
-			cfgValidator: func(c *Config) bool {
-				return c.ClientConfig.WithoutUnitSuffix &&
-					!c.ClientConfig.WithoutCounterSuffix &&
-					!c.ClientConfig.RecordTimerInSeconds
-			},
 		},
 	} {
 		c := c
@@ -249,7 +213,6 @@ func TestMetricsHandlerFromConfig(t *testing.T) {
 				handler.Stop(logger)
 			})
 			assert.IsType(t, c.expectedType, handler)
-			assert.True(t, c.cfgValidator(c.cfg))
 		})
 	}
 


### PR DESCRIPTION
This reverts commit c156e8467987dc8a919a1ed4437464713d5c2175.

## What changed?
<!-- Describe what has changed in this PR -->
- Revert "Always use OTEL as metric handler (#7265)"

## Why?
<!-- Tell your future self why have you made these changes -->
- StatsD still needs tally to function
- OTEL metric handler doesn't support Prefix and the same customized/default sanitization logic as tally
