### PR TITLE
Use metrics.ClientConfig.Prefix as otel namespace

### DIFF
--- a/common/metrics/opentelemetry_provider.go
+++ b/common/metrics/opentelemetry_provider.go
@@ -61,6 +61,9 @@ func NewOpenTelemetryProvider(
 ) (*openTelemetryProviderImpl, error) {
 	reg := prometheus.NewRegistry()
 	exporterOpts := []exporters.Option{exporters.WithRegisterer(reg)}
+	if clientConfig.Prefix != "" {
+		exporterOpts = append(exporterOpts, exporters.WithNamespace(clientConfig.Prefix))
+	}
 	if clientConfig.WithoutUnitSuffix {
 		exporterOpts = append(exporterOpts, exporters.WithoutUnits())
 	}


### PR DESCRIPTION
## What changed?
Propagates `go.temporal.io/sdk/common/metrics.ClientConfig.Prefix` to opentelemetry exporter options in `NewOpenTelemetryProvider`

## Why?
Previously, this was handled by `NewScope`, which is no longer invoked as of https://github.com/temporalio/temporal/pull/7265

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
