### PR TITLE
fix a versioning 3.1 flake 

### DIFF
--- a/tests/worker_deployment_test.go
+++ b/tests/worker_deployment_test.go
@@ -172,7 +172,7 @@ func (s *WorkerDeploymentSuite) TestForceCAN_NoOpenWFS() {
 
 	// Start a version workflow
 	s.startVersionWorkflow(ctx, tv)
-	s.ensureCreateDeployment(tv)
+	s.ensureCreateVersionInDeployment(tv)
 
 	// Set the version as current
 	_, err := s.FrontendClient().SetWorkerDeploymentCurrentVersion(ctx, &workflowservice.SetWorkerDeploymentCurrentVersionRequest{


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- fix `TestWorkerDeploymentSuite/TestForceCAN_NoOpenWFS`

## Why?
<!-- Tell your future self why have you made these changes -->
- no one likes ❌ on their CI status bar

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Ran it locally
- Ran it 50 times against postgres + cassandra in CI

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
