### PR TITLE
Remove check that prevent passive update workflow after workflow closed

### DIFF
--- a/service/history/ndc/transaction_manager_existing_workflow.go
+++ b/service/history/ndc/transaction_manager_existing_workflow.go
@@ -116,10 +116,6 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) dispatchForExistingWorkflow(
 	}
 
 	if currentRunID == targetRunID {
-		if !mutableState.IsTransitionHistoryEnabled() && !isWorkflowRebuilt {
-			return serviceerror.NewInternal("transactionMgr: encountered workflow not rebuilt & current workflow not guaranteed")
-		}
-
 		// update to current record, since target workflow is pointed by current record
 		return r.dispatchWorkflowUpdateAsCurrent(
 			ctx,

--- a/service/history/ndc/transaction_manager_existing_workflow_test.go
+++ b/service/history/ndc/transaction_manager_existing_workflow_test.go
@@ -116,36 +116,6 @@ func (s *transactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkflow
 	s.True(newReleaseCalled)
 }
 
-func (s *transactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkflow_NoRebuild_CurrentWorkflowNotGuaranteed_IsCurrent() {
-	ctx := context.Background()
-
-	namespaceID := namespace.ID("some random namespace ID")
-	workflowID := "some random workflow ID"
-	targetRunID := "some random run ID"
-
-	isWorkflowRebuilt := false
-
-	targetWorkflow := NewMockWorkflow(s.controller)
-	targetMutableState := workflow.NewMockMutableState(s.controller)
-	targetWorkflow.EXPECT().GetMutableState().Return(targetMutableState).AnyTimes()
-
-	newWorkflow := NewMockWorkflow(s.controller)
-
-	targetMutableState.EXPECT().IsCurrentWorkflowGuaranteed().Return(false).AnyTimes()
-	targetMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
-		NamespaceId: namespaceID.String(),
-		WorkflowId:  workflowID,
-	}).AnyTimes()
-	targetMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
-		RunId: targetRunID,
-	}).AnyTimes()
-	targetMutableState.EXPECT().IsTransitionHistoryEnabled().Return(false)
-	s.mockTransactionMgr.EXPECT().GetCurrentWorkflowRunID(ctx, namespaceID, workflowID).Return(targetRunID, nil)
-
-	err := s.updateMgr.dispatchForExistingWorkflow(ctx, isWorkflowRebuilt, targetWorkflow, newWorkflow)
-	s.Error(err)
-}
-
 func (s *transactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkflow_NoRebuild_CurrentWorkflowNotGuaranteed_NotCurrent_CurrentRunning_UpdateAsCurrent() {
 	ctx := context.Background()
 
@@ -483,7 +453,6 @@ func (s *transactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkflow
 	targetMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: targetRunID,
 	}).AnyTimes()
-	targetMutableState.EXPECT().IsTransitionHistoryEnabled().Return(false)
 	s.mockTransactionMgr.EXPECT().GetCurrentWorkflowRunID(ctx, namespaceID, workflowID).Return(targetRunID, nil)
 
 	targetContext.EXPECT().ConflictResolveWorkflowExecution(


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Remove check that prevent passive update workflow after workflow closed
## Why?
<!-- Tell your future self why have you made these changes -->
The assumption is no longer hold as Nexus callback could update workflow even after workflow is closed.
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
n/a
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no risk
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
no