### PR TITLE
Replace `golang.org/x/exp/maps` with stdlib `maps`

### DIFF
--- a/cmd/tools/getproto/main.go
+++ b/cmd/tools/getproto/main.go
@@ -29,13 +29,13 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 
-	expmaps "golang.org/x/exp/maps"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -77,7 +77,7 @@ func findProtoImports() []string {
 		}
 		return nil
 	}))
-	return expmaps.Keys(importMap)
+	return slices.Collect(maps.Keys(importMap))
 }
 
 func getImportName(i string) string {
@@ -94,7 +94,7 @@ func mangle(p string) string {
 }
 
 func genFileList(protoImports []string) {
-	sort.Strings(protoImports)
+	slices.Sort(protoImports)
 
 	goImportsMap := make(map[string]string)
 	protoToPackage := make(map[string]string)
@@ -113,8 +113,7 @@ func genFileList(protoImports []string) {
 			protoToPackage[i] = base
 		}
 	}
-	goImports := expmaps.Keys(goImportsMap)
-	sort.Strings(goImports)
+	goImports := slices.Sorted(maps.Keys(goImportsMap))
 
 	out, err := os.Create("cmd/tools/getproto/files.go")
 	fatalIfErr(err)
@@ -152,7 +151,7 @@ func addImports(missing []string) {
 		newImportMap[i] = struct{}{}
 	}
 
-	genFileList(expmaps.Keys(newImportMap))
+	genFileList(slices.Collect(maps.Keys(newImportMap)))
 	fmt.Println("<rerun>")
 	os.Exit(0)
 }
@@ -178,7 +177,7 @@ func checkImports(files map[string]protoreflect.FileDescriptor) {
 		}
 	}
 	if len(missing) > 0 {
-		addImports(expmaps.Keys(missing)) // doesn't return
+		addImports(slices.Collect(maps.Keys(missing))) // doesn't return
 	}
 }
 

--- a/common/api/metadata_test.go
+++ b/common/api/metadata_test.go
@@ -25,15 +25,16 @@
 package api
 
 import (
+	"maps"
 	"reflect"
 	"regexp"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
-	expmaps "golang.org/x/exp/maps"
 )
 
 var publicMethodRgx = regexp.MustCompile("^[A-Z]")
@@ -50,7 +51,7 @@ func TestOperatorServiceMetadata(t *testing.T) {
 
 func checkService(t *testing.T, tp reflect.Type, m map[string]MethodMetadata) {
 	methods := getMethodNames(tp)
-	require.ElementsMatch(t, methods, expmaps.Keys(m),
+	require.ElementsMatch(t, methods, slices.Collect(maps.Keys(m)),
 		"If you're adding a new method to Workflow/OperatorService, please add metadata for it in metadata.go")
 
 	for _, method := range methods {

--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -29,8 +29,10 @@ package dynamicconfig
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -40,7 +42,6 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
-	expmaps "golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 )
 
@@ -211,7 +212,7 @@ func (fc *fileBasedClient) Update() error {
 	}
 
 	fc.subscriptionLock.Lock()
-	subscriptions := expmaps.Values(fc.subscriptions)
+	subscriptions := slices.Collect(maps.Values(fc.subscriptions))
 	fc.subscriptionLock.Unlock()
 
 	for _, update := range subscriptions {

--- a/common/locks/condition_variable_test.go
+++ b/common/locks/condition_variable_test.go
@@ -254,13 +254,3 @@ func randSignalBroadcast(
 		cv.Broadcast()
 	}
 }
-
-func min(left int, right int) int {
-	if left < right {
-		return left
-	} else if left > right {
-		return right
-	} else {
-		return left
-	}
-}

--- a/common/membership/ringpop/monitor_test.go
+++ b/common/membership/ringpop/monitor_test.go
@@ -26,7 +26,9 @@ package ringpop
 
 import (
 	"fmt"
+	"maps"
 	"math/rand"
+	"slices"
 	"testing"
 	"time"
 
@@ -35,7 +37,6 @@ import (
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/util"
-	expmaps "golang.org/x/exp/maps"
 )
 
 type RpoSuite struct {
@@ -206,7 +207,7 @@ func (s *RpoSuite) verifyMemberDiff(curr []string, new []string, expectedDiff []
 	})
 	newHosts := util.MapSlice(new, func(addr string) *hostInfo { return newHostInfo(addr, nil) })
 	newMembers, event := resolver.compareMembers(newHosts)
-	s.ElementsMatch(new, expmaps.Keys(newMembers))
+	s.ElementsMatch(new, slices.Collect(maps.Keys(newMembers)))
 	s.Equal(expectedDiff != nil, event != nil)
 	if event != nil {
 		s.ElementsMatch(expectedDiff, eventToString(event))

--- a/common/metrics/metrics_test.go
+++ b/common/metrics/metrics_test.go
@@ -26,12 +26,12 @@ package metrics_test
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
-	expmaps "golang.org/x/exp/maps"
 )
 
 var (
@@ -56,8 +56,7 @@ func ExampleHandler() {
 	timer.With(handler).Record(5 * time.Second)
 
 	snapshot := capture.Snapshot()
-	keys := expmaps.Keys(snapshot)
-	slices.Sort(keys)
+	keys := slices.Sorted(maps.Keys(snapshot))
 	for _, key := range keys {
 		fmt.Printf("%s:", key)
 		for _, rec := range snapshot[key] {

--- a/common/namespace/nsregistry/registry.go
+++ b/common/namespace/nsregistry/registry.go
@@ -28,6 +28,8 @@ package nsregistry
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -44,7 +46,6 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/pingable"
 	"go.temporal.io/server/internal/goro"
-	expmaps "golang.org/x/exp/maps"
 )
 
 const (
@@ -443,7 +444,7 @@ func (r *registry) refreshNamespaces(ctx context.Context) error {
 	r.cacheNameToID = newCacheNameToID
 	stateChanged = append(stateChanged, r.stateChangedDuringReadthrough...)
 	r.stateChangedDuringReadthrough = nil
-	stateChangeCallbacks = expmaps.Values(r.stateChangeCallbacks)
+	stateChangeCallbacks = slices.Collect(maps.Values(r.stateChangeCallbacks))
 	r.cacheLock.Unlock()
 
 	// call state change callbacks

--- a/common/persistence/sql/sqlplugin/sqlite/plugin.go
+++ b/common/persistence/sql/sqlplugin/sqlite/plugin.go
@@ -28,8 +28,9 @@ package sqlite
 
 import (
 	"fmt"
+	"maps"
 	"net/url"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/iancoleman/strcase"
@@ -41,7 +42,6 @@ import (
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/resolver"
 	sqliteschema "go.temporal.io/server/schema/sqlite"
-	expmaps "golang.org/x/exp/maps"
 )
 
 const (
@@ -194,8 +194,7 @@ func buildDSNAttr(cfg *config.SQL) (url.Values, error) {
 	parameters := url.Values{}
 
 	// sort ConnectAttributes to get a deterministic order
-	keys := expmaps.Keys(cfg.ConnectAttributes)
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(cfg.ConnectAttributes))
 
 	for _, k := range keys {
 		key := strings.TrimSpace(k)

--- a/common/persistence/sql/store.go
+++ b/common/persistence/sql/store.go
@@ -27,6 +27,7 @@ package sql
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 
 	"go.temporal.io/server/common/config"
@@ -34,7 +35,6 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/resolver"
-	expmaps "golang.org/x/exp/maps"
 )
 
 var ErrPluginNotSupported = errors.New("plugin not supported")
@@ -85,8 +85,7 @@ func NewSQLAdminDB(
 func getPlugin(pluginName string) (sqlplugin.Plugin, error) {
 	plugin, ok := supportedPlugins[pluginName]
 	if !ok {
-		keys := expmaps.Keys(supportedPlugins)
-		slices.Sort(keys)
+		keys := slices.Collect(maps.Keys(supportedPlugins))
 		return nil, fmt.Errorf(
 			"%w: unknown plugin %q, supported plugins: %v",
 			ErrPluginNotSupported,

--- a/common/util/util.go
+++ b/common/util/util.go
@@ -29,10 +29,7 @@ package util
 import (
 	"context"
 	"maps"
-	"sort"
 	"time"
-
-	expconstraints "golang.org/x/exp/constraints"
 )
 
 // MinTime returns the earlier of two given time.Time
@@ -55,14 +52,6 @@ func MaxTime(a, b time.Time) time.Time {
 // of `align` since the unix epoch.
 func NextAlignedTime(t time.Time, align time.Duration) time.Time {
 	return time.Unix(0, (t.UnixNano()/int64(align)+1)*int64(align))
-}
-
-// SortSlice sorts the given slice of an ordered type.
-// Sort is not guaranteed to be stable.
-func SortSlice[S ~[]E, E expconstraints.Ordered](slice S) {
-	sort.Slice(slice, func(i, j int) bool {
-		return slice[i] < slice[j]
-	})
 }
 
 // SliceHead returns the first n elements of s. n may be greater than len(s).

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,6 @@ require (
 	go.uber.org/mock v0.5.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
-	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac
 	golang.org/x/oauth2 v0.26.0
 	golang.org/x/sync v0.11.0
 	golang.org/x/text v0.22.0
@@ -150,6 +149,7 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/dig v1.18.0 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
+	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	google.golang.org/genproto v0.0.0-20250207221924-e9438ea467c6 // indirect

--- a/internal/temporalite/lite_server.go
+++ b/internal/temporalite/lite_server.go
@@ -32,10 +32,11 @@ package temporalite
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -51,7 +52,6 @@ import (
 	"go.temporal.io/server/internal/freeport"
 	"go.temporal.io/server/schema/sqlite"
 	"go.temporal.io/server/temporal"
-	expmaps "golang.org/x/exp/maps"
 )
 
 const localBroadcastAddress = "127.0.0.1"
@@ -371,9 +371,7 @@ var supportedPragmas = map[string]struct{}{
 }
 
 func getAllowedPragmas() []string {
-	allowedPragmaList := expmaps.Keys(supportedPragmas)
-	sort.Strings(allowedPragmaList)
-	return allowedPragmaList
+	return slices.Sorted(maps.Keys(supportedPragmas))
 }
 
 func (cfg *LiteServerConfig) mustGetService(frontendPortOffset int) config.Service {

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -28,6 +28,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -57,7 +59,6 @@ import (
 	"go.temporal.io/server/service/worker/deletenamespace"
 	delnserrors "go.temporal.io/server/service/worker/deletenamespace/errors"
 	"go.uber.org/mock/gomock"
-	expmaps "golang.org/x/exp/maps"
 	"google.golang.org/grpc/health"
 )
 
@@ -819,7 +820,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributesSQL() {
 						opts ...any,
 					) (*workflowservice.UpdateNamespaceResponse, error) {
 						s.Len(r.Config.CustomSearchAttributeAliases, len(tc.customSearchAttributesToAdd))
-						aliases := expmaps.Values(r.Config.CustomSearchAttributeAliases)
+						aliases := slices.Collect(maps.Values(r.Config.CustomSearchAttributeAliases))
 						for _, saName := range tc.customSearchAttributesToAdd {
 							s.Contains(aliases, saName)
 						}

--- a/service/history/queues/convert.go
+++ b/service/history/queues/convert.go
@@ -26,12 +26,13 @@ package queues
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/predicates"
 	"go.temporal.io/server/service/history/tasks"
-	expmaps "golang.org/x/exp/maps"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -296,7 +297,7 @@ func ToPersistenceNamespaceIDPredicate(
 		PredicateType: enumsspb.PREDICATE_TYPE_NAMESPACE_ID,
 		Attributes: &persistencespb.Predicate_NamespaceIdPredicateAttributes{
 			NamespaceIdPredicateAttributes: &persistencespb.NamespaceIdPredicateAttributes{
-				NamespaceIds: expmaps.Keys(namespaceIDPredicate.NamespaceIDs),
+				NamespaceIds: slices.Collect(maps.Keys(namespaceIDPredicate.NamespaceIDs)),
 			},
 		},
 	}
@@ -315,7 +316,7 @@ func ToPersistenceTaskTypePredicate(
 		PredicateType: enumsspb.PREDICATE_TYPE_TASK_TYPE,
 		Attributes: &persistencespb.Predicate_TaskTypePredicateAttributes{
 			TaskTypePredicateAttributes: &persistencespb.TaskTypePredicateAttributes{
-				TaskTypes: expmaps.Keys(taskTypePredicate.Types),
+				TaskTypes: slices.Collect(maps.Keys(taskTypePredicate.Types)),
 			},
 		},
 	}
@@ -334,7 +335,7 @@ func ToPersistenceDestinationPredicate(
 		PredicateType: enumsspb.PREDICATE_TYPE_DESTINATION,
 		Attributes: &persistencespb.Predicate_DestinationPredicateAttributes{
 			DestinationPredicateAttributes: &persistencespb.DestinationPredicateAttributes{
-				Destinations: expmaps.Keys(taskDestinationPredicate.Destinations),
+				Destinations: slices.Collect(maps.Keys(taskDestinationPredicate.Destinations)),
 			},
 		},
 	}
@@ -353,7 +354,7 @@ func ToPersistenceOutboundTaskGroupPredicate(
 		PredicateType: enumsspb.PREDICATE_TYPE_OUTBOUND_TASK_GROUP,
 		Attributes: &persistencespb.Predicate_OutboundTaskGroupPredicateAttributes{
 			OutboundTaskGroupPredicateAttributes: &persistencespb.OutboundTaskGroupPredicateAttributes{
-				Groups: expmaps.Keys(pred.Groups),
+				Groups: slices.Collect(maps.Keys(pred.Groups)),
 			},
 		},
 	}

--- a/service/history/queues/slice.go
+++ b/service/history/queues/slice.go
@@ -26,10 +26,11 @@ package queues
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 
 	"go.temporal.io/server/common/predicates"
 	"go.temporal.io/server/service/history/tasks"
-	expmaps "golang.org/x/exp/maps"
 )
 
 const (
@@ -365,7 +366,7 @@ func (s *SliceImpl) shrinkPredicate() {
 		return
 	}
 
-	s.scope.Predicate = s.grouper.Predicate(expmaps.Keys(pendingPerKey))
+	s.scope.Predicate = s.grouper.Predicate(slices.Collect(maps.Keys(pendingPerKey)))
 	s.ensurePredicateSizeLimit()
 }
 

--- a/service/history/workflow/checksum.go
+++ b/service/history/workflow/checksum.go
@@ -26,12 +26,12 @@ package workflow
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 
 	checksumspb "go.temporal.io/server/api/checksum/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/checksum"
-	"go.temporal.io/server/common/util"
-	expmaps "golang.org/x/exp/maps"
 )
 
 const (
@@ -87,23 +87,19 @@ func newMutableStateChecksumPayload(ms MutableState) *checksumspb.MutableStateCh
 	for _, ti := range ms.GetPendingTimerInfos() {
 		pendingTimerIDs = append(pendingTimerIDs, ti.GetStartedEventId())
 	}
-	util.SortSlice(pendingTimerIDs)
+	slices.Sort(pendingTimerIDs)
 	payload.PendingTimerStartedEventIds = pendingTimerIDs
 
-	pendingActivityIDs := expmaps.Keys(ms.GetPendingActivityInfos())
-	util.SortSlice(pendingActivityIDs)
+	pendingActivityIDs := slices.Sorted(maps.Keys(ms.GetPendingActivityInfos()))
 	payload.PendingActivityScheduledEventIds = pendingActivityIDs
 
-	pendingChildIDs := expmaps.Keys(ms.GetPendingChildExecutionInfos())
-	util.SortSlice(pendingChildIDs)
+	pendingChildIDs := slices.Sorted(maps.Keys(ms.GetPendingChildExecutionInfos()))
 	payload.PendingChildInitiatedEventIds = pendingChildIDs
 
-	signalIDs := expmaps.Keys(ms.GetPendingSignalExternalInfos())
-	util.SortSlice(signalIDs)
+	signalIDs := slices.Sorted(maps.Keys(ms.GetPendingSignalExternalInfos()))
 	payload.PendingSignalInitiatedEventIds = signalIDs
 
-	requestCancelIDs := expmaps.Keys(ms.GetPendingRequestCancelExternalInfos())
-	util.SortSlice(requestCancelIDs)
+	requestCancelIDs := slices.Sorted(maps.Keys(ms.GetPendingRequestCancelExternalInfos()))
 	payload.PendingReqCancelInitiatedEventIds = requestCancelIDs
 	return payload
 }

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -30,6 +30,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -55,7 +56,6 @@ import (
 	"go.temporal.io/server/common/util"
 	workercommon "go.temporal.io/server/service/worker/common"
 	"go.uber.org/fx"
-	expmaps "golang.org/x/exp/maps"
 )
 
 const (
@@ -207,7 +207,7 @@ func (wm *perNamespaceWorkerManager) Stop() {
 	close(wm.membershipChangedCh)
 
 	wm.lock.Lock()
-	workers := expmaps.Values(wm.workers)
+	workers := slices.Collect(maps.Values(wm.workers))
 	maps.DeleteFunc(wm.workers, func(_ namespace.ID, _ *perNamespaceWorker) bool { return true })
 	wm.lock.Unlock()
 

--- a/service/worker/scheduler/query.go
+++ b/service/worker/scheduler/query.go
@@ -25,13 +25,14 @@ package scheduler
 import (
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/searchattribute"
-	expmaps "golang.org/x/exp/maps"
 )
 
 type (
@@ -95,5 +96,5 @@ func getQueryFields(
 		}
 		return nil, err
 	}
-	return expmaps.Keys(fnInterceptor.names), nil
+	return slices.Collect(maps.Keys(fnInterceptor.names)), nil
 }

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"slices"
 
 	"github.com/pborman/uuid"
 	"go.opentelemetry.io/otel"
@@ -74,7 +75,6 @@ import (
 	"go.temporal.io/server/service/worker"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxevent"
-	expmaps "golang.org/x/exp/maps"
 	"google.golang.org/grpc"
 )
 
@@ -897,7 +897,7 @@ var TraceExportModule = fx.Options(
 		// config-defined exporters override env-defined exporters with the same type
 		maps.Copy(exportersByType, exportersByTypeFromEnv)
 
-		exporters := expmaps.Values(exportersByType)
+		exporters := slices.Collect(maps.Values(exportersByType))
 		inputs.Lifecycyle.Append(fx.Hook{
 			OnStart: startAll(exporters),
 			OnStop:  shutdownAll(exporters),


### PR DESCRIPTION
## What changed?

The difference is that `maps.Keys`/`maps.Values` in the `golang.org/x/exp/maps` package return a slice, whereas `maps.Keys`/`maps.Values` in the standard library return an iterator. To work with slices, we need to use `slices.Collect` to convert the iterator into a slice.

Reference: https://go.dev/doc/go1.23#iterators

## Why?
<!-- Tell your future self why have you made these changes -->

Part of the effort for https://github.com/temporalio/temporal/pull/6366

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

```
make unit-test
```

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->



## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->

No
