### PR TITLE
Include rate limit in forwarded activity poll

### DIFF
--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -50,7 +50,7 @@ func TestDeliverBufferTasks(t *testing.T) {
 		func(tlm *physicalTaskQueueManagerImpl) { tlm.backlogMgr.taskReader.gorogrp.Cancel() },
 		func(tlm *physicalTaskQueueManagerImpl) {
 			rps := 0.1
-			tlm.matcher.UpdateRatelimit(&rps)
+			tlm.matcher.UpdateRatelimit(rps)
 			tlm.backlogMgr.taskReader.taskBuffer <- &persistencespb.AllocatedTaskInfo{
 				Data: &persistencespb.TaskInfo{},
 			}

--- a/service/matching/forwarder.go
+++ b/service/matching/forwarder.go
@@ -285,6 +285,7 @@ func (fwdr *Forwarder) ForwardPoll(ctx context.Context, pollMetadata *pollMetada
 					Kind: fwdr.partition.Kind(),
 				},
 				Identity:                  identity,
+				TaskQueueMetadata:         pollMetadata.taskQueueMetadata,
 				WorkerVersionCapabilities: pollMetadata.workerVersionCapabilities,
 				DeploymentOptions:         pollMetadata.deploymentOptions,
 			},

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -447,12 +447,7 @@ func (tm *TaskMatcher) PollForQuery(ctx context.Context, pollMetadata *pollMetad
 }
 
 // UpdateRatelimit updates the task dispatch rate
-func (tm *TaskMatcher) UpdateRatelimit(rpsPtr *float64) {
-	if rpsPtr == nil {
-		return
-	}
-
-	rps := *rpsPtr
+func (tm *TaskMatcher) UpdateRatelimit(rps float64) {
 	nPartitions := float64(tm.numPartitions())
 	if nPartitions > 0 {
 		// divide the rate equally across all partitions

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -106,7 +106,6 @@ type (
 
 	pollMetadata struct {
 		taskQueueMetadata         *taskqueuepb.TaskQueueMetadata
-		ratePerSecond             *float64
 		workerVersionCapabilities *commonpb.WorkerVersionCapabilities
 		deploymentOptions         *deploymentpb.WorkerDeploymentOptions
 		forwardedFrom             string
@@ -840,9 +839,6 @@ pollLoop:
 			workerVersionCapabilities: request.WorkerVersionCapabilities,
 			deploymentOptions:         request.DeploymentOptions,
 			forwardedFrom:             req.GetForwardedSource(),
-		}
-		if v := request.TaskQueueMetadata.GetMaxTasksPerSecond(); v != nil {
-			pollMetadata.ratePerSecond = &v.Value
 		}
 		task, versionSetUsed, err := e.pollTask(pollerCtx, partition, pollMetadata)
 		if err != nil {

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -105,6 +105,7 @@ type (
 	}
 
 	pollMetadata struct {
+		taskQueueMetadata         *taskqueuepb.TaskQueueMetadata
 		ratePerSecond             *float64
 		workerVersionCapabilities *commonpb.WorkerVersionCapabilities
 		deploymentOptions         *deploymentpb.WorkerDeploymentOptions
@@ -835,12 +836,13 @@ pollLoop:
 		pollerCtx := context.WithValue(ctx, pollerIDKey, pollerID)
 		pollerCtx = context.WithValue(pollerCtx, identityKey, request.GetIdentity())
 		pollMetadata := &pollMetadata{
+			taskQueueMetadata:         request.TaskQueueMetadata,
 			workerVersionCapabilities: request.WorkerVersionCapabilities,
 			deploymentOptions:         request.DeploymentOptions,
 			forwardedFrom:             req.GetForwardedSource(),
 		}
-		if request.TaskQueueMetadata != nil && request.TaskQueueMetadata.MaxTasksPerSecond != nil {
-			pollMetadata.ratePerSecond = &request.TaskQueueMetadata.MaxTasksPerSecond.Value
+		if v := request.TaskQueueMetadata.GetMaxTasksPerSecond(); v != nil {
+			pollMetadata.ratePerSecond = &v.Value
 		}
 		task, versionSetUsed, err := e.pollTask(pollerCtx, partition, pollMetadata)
 		if err != nil {

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -259,7 +259,9 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 	// one rateLimiter for this entire task queue and as we get polls,
 	// we update the ratelimiter rps if it has changed from the last
 	// value. Last poller wins if different pollers provide different values
-	c.matcher.UpdateRatelimit(pollMetadata.ratePerSecond)
+	if rps := pollMetadata.taskQueueMetadata.GetMaxTasksPerSecond(); rps != nil {
+		c.matcher.UpdateRatelimit(rps.Value)
+	}
 
 	if !namespaceEntry.ActiveInCluster(c.clusterMeta.GetCurrentClusterName()) {
 		return c.matcher.PollForQuery(ctx, pollMetadata)

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/server/api/matchingservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
@@ -49,6 +50,7 @@ import (
 	"go.temporal.io/server/internal/goro"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 var rpsInf = math.Inf(1)
@@ -172,12 +174,20 @@ func TestReaderSignaling(t *testing.T) {
 		"Sync match should not signal taskReader")
 }
 
+func makePollMetadata(rps float64) *pollMetadata {
+	return &pollMetadata{taskQueueMetadata: &taskqueuepb.TaskQueueMetadata{
+		MaxTasksPerSecond: &wrapperspb.DoubleValue{
+			Value: rps,
+		},
+	}}
+}
+
 // runOneShotPoller spawns a goroutine to call tqm.PollTask on the provided tqm.
 // The second return value is a channel of either error or *internalTask.
 func runOneShotPoller(ctx context.Context, tqm physicalTaskQueueManager) (*goro.Handle, chan interface{}) {
 	out := make(chan interface{}, 1)
 	handle := goro.NewHandle(ctx).Go(func(ctx context.Context) error {
-		task, err := tqm.PollTask(ctx, &pollMetadata{ratePerSecond: &rpsInf})
+		task, err := tqm.PollTask(ctx, makePollMetadata(rpsInf))
 		if task == nil {
 			out <- err
 			return nil
@@ -273,14 +283,14 @@ func TestReaderBacklogAge(t *testing.T) {
 		assert.InDelta(t, time.Minute, tlm.backlogMgr.taskReader.getBacklogHeadAge(), float64(time.Second))
 	}, time.Second, 10*time.Millisecond)
 
-	_, err := tlm.backlogMgr.pqMgr.PollTask(context.Background(), &pollMetadata{ratePerSecond: &rpsInf})
+	_, err := tlm.backlogMgr.pqMgr.PollTask(context.Background(), makePollMetadata(rpsInf))
 	require.NoError(t, err)
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		assert.InDelta(t, 10*time.Second, tlm.backlogMgr.taskReader.getBacklogHeadAge(), float64(500*time.Millisecond))
 	}, time.Second, 10*time.Millisecond)
 
-	_, err = tlm.backlogMgr.pqMgr.PollTask(context.Background(), &pollMetadata{ratePerSecond: &rpsInf})
+	_, err = tlm.backlogMgr.pqMgr.PollTask(context.Background(), makePollMetadata(rpsInf))
 	require.NoError(t, err)
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -354,7 +364,7 @@ func TestLegacyDescribeTaskQueue(t *testing.T) {
 	require.NotEmpty(t, descResp.DescResponse.Pollers[0].GetLastAccessTime())
 
 	rps := 5.0
-	tlm.pollerHistory.updatePollerInfo(pollerIdentity(PollerIdentity), &pollMetadata{ratePerSecond: &rps})
+	tlm.pollerHistory.updatePollerInfo(pollerIdentity(PollerIdentity), makePollMetadata(rps))
 	descResp = tlm.LegacyDescribeTaskQueue(includeTaskStatus)
 	require.Equal(t, 1, len(descResp.DescResponse.GetPollers()))
 	require.Equal(t, PollerIdentity, descResp.DescResponse.Pollers[0].GetIdentity())


### PR DESCRIPTION
## What changed?
Include all poll metadata (including rate limit request) in forwarded activity polls.

## Why?
This has no real behavior change (the rate limit should be the same on all partitions already), but it fixes the rate limit reported in poller info for the root partition, which was getting cleared on forwarded polls and creating confusion.