### PR TITLE
[Reset] Skip parent close policy only if the parent is reset and we are using the new reset flow.

### DIFF
--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -403,7 +403,7 @@ func (t *transferQueueActiveTaskExecutor) processCloseExecution(
 	// process parentClosePolicy except when the execution was reset. In case of reset, we need to keep the children around so that we can reconnect to them.
 	// We know an execution was reset when ResetRunId was populated in it.
 	// TODO (Chetan): update this condition as new reset policies are added. For now we keep all children since "Reconnect" is the only policy available.
-	allowResetWithPendingChildren := t.shardContext.GetConfig().AllowResetWithPendingChildren(namespaceName.String())
+	allowResetWithPendingChildren := t.config.AllowResetWithPendingChildren(namespaceName.String())
 	shouldSkipParentClosePolicy := false
 	if executionInfo.GetResetRunId() != "" && allowResetWithPendingChildren {
 		shouldSkipParentClosePolicy = true // only skip if the parent is reset and we are using the new flow.

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -1057,6 +1057,10 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_ParentW
 	s.Nil(err)
 
 	mutableState.GetExecutionInfo().ResetRunId = uuid.New() // indicate that the execution was reset.
+	s.mockShard.GetConfig().AllowResetWithPendingChildren = func(namespace string) bool {
+		return true // force the dynamic config to allow reset with pending children.
+	}
+
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
 	wt.StartedEventID = event.GetEventId()

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -1172,7 +1172,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 	}
 
 	event, _ = mutableState.AddWorkflowTaskCompletedEvent(wt, &workflowservice.RespondWorkflowTaskCompletedRequest{
-		Identity: "some random identity",
+		Identity: consts.IdentityResetter,
 		Commands: commands,
 	}, defaultWorkflowTaskCompletionLimits)
 

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -1084,7 +1084,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_ParentW
 	}
 
 	event, _ = mutableState.AddWorkflowTaskCompletedEvent(wt, &workflowservice.RespondWorkflowTaskCompletedRequest{
-		Identity: "some random identity",
+		Identity: consts.IdentityResetter,
 		Commands: commands,
 	}, defaultWorkflowTaskCompletionLimits)
 
@@ -1104,7 +1104,9 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_ParentW
 	mutableState.FlushBufferedEvents()
 
 	taskID := s.mustGenerateTaskID()
-	event = addCompleteWorkflowEvent(mutableState, event.GetEventId(), nil)
+	// Simulate termination due to reset.
+	event, err = mutableState.AddWorkflowExecutionTerminatedEvent(event.GetEventId(), "some reason", nil, consts.IdentityResetter, false, nil)
+	s.NoError(err)
 
 	transferTask := &tasks.CloseExecutionTask{
 		WorkflowKey: definition.NewWorkflowKey(


### PR DESCRIPTION
## What changed?
The parent will skip applying parent close policy only when it is reset and if we are taking the new reset flow (i.e `AllowResetWithPendingChildren` config is enabled)

## Why?
This fixes a bug I introduced in https://github.com/temporalio/temporal/pull/6935. I am skipping the parent close policy whenever a parent is reset. This was done under the assumption that the server never allowed a parent to be reset which has a pending child. Unfortunately this assumption is not true and the server allowed resetting of parents with pending children in some cases. And in these cases the parent would apply the given parent close policy to the child. So, this change restores the original behavior.
Additionally we need to further fix this by skipping parent close policies only to children that were started *before* the reset point. Will work on that in a following PR since it needs mutable state change.

## How did you test it?
Manual test

## Potential risks
N/A

## Documentation
N/A

## Is hotfix candidate?
Yes