### PR TITLE
Fix validateStateMachineRef when transition history is cleared

### DIFF
--- a/service/history/statemachine_environment.go
+++ b/service/history/statemachine_environment.go
@@ -233,7 +233,8 @@ func (e *stateMachineEnvironment) validateStateMachineRef(
 	if ref.StateMachineRef.MutableStateVersionedTransition == nil ||
 		ref.StateMachineRef.MachineInitialVersionedTransition.TransitionCount == 0 ||
 		(ref.StateMachineRef.MachineLastUpdateVersionedTransition != nil &&
-			ref.StateMachineRef.MachineLastUpdateVersionedTransition.TransitionCount == 0) {
+			ref.StateMachineRef.MachineLastUpdateVersionedTransition.TransitionCount == 0) ||
+		len(ms.GetExecutionInfo().TransitionHistory) == 0 {
 		// Transtion history was disabled when the ref is generated,
 		// fallback to the old validation logic.
 		return e.validateStateMachineRefWithoutTransitionHistory(ms, ref, potentialStaleState)

--- a/service/history/statemachine_environment_test.go
+++ b/service/history/statemachine_environment_test.go
@@ -148,6 +148,7 @@ func TestValidateStateMachineRef(t *testing.T) {
 		mutateRef               func(*hsm.Ref)
 		mutateNode              func(*hsm.Node)
 		assertOutcome           func(*testing.T, error)
+		clearTransitionHistory  bool
 	}{
 		{
 			name:                    "TaskGenerationStale",
@@ -251,6 +252,17 @@ func TestValidateStateMachineRef(t *testing.T) {
 			},
 		},
 		{
+			name:                    "WithTransitionHistory/TransitionHistoryCleared/Valid",
+			enableTransitionHistory: true,
+			mutateRef: func(ref *hsm.Ref) {
+			},
+			mutateNode: func(node *hsm.Node) {},
+			assertOutcome: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+			clearTransitionHistory: true,
+		},
+		{
 			name:                    "WithoutTransitionHistory/Valid",
 			enableTransitionHistory: false,
 			mutateRef: func(ref *hsm.Ref) {
@@ -285,6 +297,9 @@ func TestValidateStateMachineRef(t *testing.T) {
 			tc.mutateRef(&ref)
 
 			workflowContext := workflow.NewContext(s.mockShard.GetConfig(), mutableState.GetWorkflowKey(), log.NewTestLogger(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+			if tc.clearTransitionHistory {
+				mutableState.GetExecutionInfo().TransitionHistory = nil
+			}
 			err = exec.validateStateMachineRef(context.Background(), workflowContext, mutableState, ref, true)
 			tc.assertOutcome(t, err)
 		})


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
add a condition check for transition history to decide if fallback is needed.
## Why?
<!-- Tell your future self why have you made these changes -->
Handle the case where when task generated there is transition count but when processing tasks, the transition history is cleared because of disabling transition history. 
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
n/a
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
no