### PR TITLE
RoutingInfo memo fix

### DIFF
--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -774,11 +774,6 @@ func (d *ClientImpl) StartWorkerDeployment(
 		return err
 	}
 
-	memo, err := d.buildInitialMemo(deploymentName)
-	if err != nil {
-		return err
-	}
-
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:                requestID,
 		Namespace:                namespaceEntry.Name().String(),
@@ -789,7 +784,6 @@ func (d *ClientImpl) StartWorkerDeployment(
 		WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
 		SearchAttributes:         d.buildSearchAttributes(),
-		Memo:                     memo,
 	}
 
 	historyStartReq := &historyservice.StartWorkflowExecutionRequest{
@@ -1173,23 +1167,6 @@ func (d *ClientImpl) updateWithStart(
 	}, policy, isRetryable)
 
 	return outcome, err
-}
-
-func (d *ClientImpl) buildInitialMemo(deploymentName string) (*commonpb.Memo, error) {
-	pl, err := sdk.PreferProtoDataConverter.ToPayload(&deploymentspb.WorkerDeploymentWorkflowMemo{
-		DeploymentName: deploymentName,
-		CreateTime:     timestamppb.Now(),
-		RoutingConfig:  &deploymentpb.RoutingConfig{},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &commonpb.Memo{
-		Fields: map[string]*commonpb.Payload{
-			WorkerDeploymentMemoField: pl,
-		},
-	}, nil
 }
 
 func (d *ClientImpl) buildSearchAttributes() *commonpb.SearchAttributes {

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -109,6 +109,11 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		d.State.CreateTime = timestamppb.New(workflow.Now(ctx))
 		d.State.RoutingConfig = &deploymentpb.RoutingConfig{CurrentVersion: worker_versioning.UnversionedVersionId}
 		d.State.ConflictToken, _ = workflow.Now(ctx).MarshalBinary()
+
+		// updating the memo since the RoutingConfig is updated
+		if err := d.updateMemo(ctx); err != nil {
+			return err
+		}
 	}
 	if d.State.Versions == nil {
 		d.State.Versions = make(map[string]*deploymentspb.WorkerDeploymentVersionSummary)

--- a/tests/worker_deployment_test.go
+++ b/tests/worker_deployment_test.go
@@ -510,7 +510,9 @@ func (s *WorkerDeploymentSuite) TestListWorkerDeployments_OneVersion_OneDeployme
 	expectedDeploymentSummaries := s.buildWorkerDeploymentSummary(
 		tv.DeploymentSeries(),
 		timestamppb.Now(),
-		&deploymentpb.RoutingConfig{},
+		&deploymentpb.RoutingConfig{
+			CurrentVersion: worker_versioning.UnversionedVersionId, // default current version is __unversioned__
+		},
 	)
 
 	s.startAndValidateWorkerDeployments(ctx, &workflowservice.ListWorkerDeploymentsRequest{


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Building the worker deployment memo after the workflow has started rather than building it as part of the start-request. This should be done because we update the `routingConfig` when the workflow starts, which makes the memo outdated, hence leading to ListWorkerDeployment calls with stale data. 
- Also realized we may not need to build initial memo since Upsert takes care of adding `and` updating.

## Why?
<!-- Tell your future self why have you made these changes -->
- Right now, there is a bug when users would ListDeployments without a current version being set. The expected answer in this scenario would be that current version is `__unversioned__` but the routingConfig shows to be empty.
- This happens because ListDeployments gets information from the memo stored inside the worker deployment workflows. Rigt now, the memo was being updated before the workflow was starting when instead, it should be updated when the routingConfig is once again updated to have `unversioned` as it's current version.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- modified existing test which catches this.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
