### PR TITLE
Reduce chance of flakes in TestNexusSyncOperationErrorRehydration

### DIFF
--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1932,6 +1932,7 @@ func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration() {
 				}, 10*time.Second, 100*time.Millisecond)
 				s.GetTestCluster().Host().CaptureMetricsHandler().StopCapture(capture)
 				tc.checkPendingError(t, converter.FailureToError(f))
+				s.NoError(s.SdkClient().TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "test cleanup"))
 			} else {
 				wfErr := run.Get(ctx, nil)
 				s.GetTestCluster().Host().CaptureMetricsHandler().StopCapture(capture)


### PR DESCRIPTION
The test started workflow that weren't cleaned up, causing extra requests to be generated making it harder to verify the metrics.

This fix makes it slightly better but not perfect.