### PR TITLE
[Reset] Set AllowResetWithPendingChildren to true by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -463,7 +463,7 @@ recently-current deployment can arrive in visibility.`,
 	VersionDrainageStatusVisibilityGracePeriod = NewNamespaceDurationSetting(
 		"matching.wv.VersionDrainageStatusVisibilityGracePeriod",
 		3*time.Minute,
-		`VersionDrainageStatusVisibilityGracePeriod is the time period for which non-current / non-ramping worker deployment versions 
+		`VersionDrainageStatusVisibilityGracePeriod is the time period for which non-current / non-ramping worker deployment versions
 are still considered active to account for the delay in updating the build id field in visibility.`,
 	)
 	VersionDrainageStatusRefreshInterval = NewNamespaceDurationSetting(
@@ -2080,7 +2080,7 @@ This configuration will be become the default behavior in the next release and r
 	)
 	AllowResetWithPendingChildren = NewNamespaceBoolSetting(
 		"history.allowResetWithPendingChildren",
-		false,
+		true,
 		`Allows resetting of workflows with pending children when set to true`,
 	)
 	HistoryMaxAutoResetPoints = NewNamespaceIntSetting(


### PR DESCRIPTION
## What changed?
Setting the dynamic config to true by default.

## Why?
We want to make this feature turned on by default.

## How did you test it?
Flipped the flag and reset the workflow with a child. Verified that the reset goes through and parent makes progress when the reset-point is in between child init & completed events.

## Potential risks
This is a new feature. If things don't work as expected then we can flip this flag back to false (globally of by namespace)

## Documentation
N/A

## Is hotfix candidate?
Yes