### PR TITLE
Fix replication task batching race condition bug

### DIFF
--- a/service/history/replication/executable_activity_state_task.go
+++ b/service/history/replication/executable_activity_state_task.go
@@ -293,3 +293,8 @@ func (e *ExecutableActivityStateTask) CanBatch() bool {
 func (e *ExecutableActivityStateTask) MarkUnbatchable() {
 	e.batchable = false
 }
+
+func (e *ExecutableActivityStateTask) Cancel() {
+	e.MarkUnbatchable()
+	e.ExecutableTask.Cancel()
+}

--- a/service/history/replication/executable_history_task.go
+++ b/service/history/replication/executable_history_task.go
@@ -492,3 +492,8 @@ func (e *ExecutableHistoryTask) CanBatch() bool {
 func (e *ExecutableHistoryTask) MarkUnbatchable() {
 	e.batchable = false
 }
+
+func (e *ExecutableHistoryTask) Cancel() {
+	e.MarkUnbatchable()
+	e.ExecutableTask.Cancel()
+}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
1. Fix ReplicationHistoryEvents API
2. When cancel the task, also mark it as unbatchable
## Why?
<!-- Tell your future self why have you made these changes -->
Fix the issue where the task are mistakenly deduped.
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
