### PR TITLE
Add XDC cache metrics

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -65,6 +65,7 @@ const (
 
 	MutableStateCacheTypeTagValue                     = "mutablestate"
 	EventsCacheTypeTagValue                           = "events"
+	XDCCacheTypeTagValue                              = "xdc"
 	NexusEndpointRegistryReadThroughCacheTypeTagValue = "nexus_endpoint_registry_readthrough"
 
 	InvalidHistoryURITagValue    = "invalid_history_uri"

--- a/common/persistence/client/fx.go
+++ b/common/persistence/client/fx.go
@@ -103,11 +103,13 @@ func ClusterNameProvider(config *cluster.Config) ClusterName {
 
 func EventBlobCacheProvider(
 	dc *dynamicconfig.Collection,
+	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) persistence.XDCCache {
 	return persistence.NewEventsBlobCache(
 		dynamicconfig.XDCCacheMaxSizeBytes.Get(dc)(),
 		20*time.Second,
+		metricsHandler,
 		logger,
 	)
 }

--- a/common/persistence/xdc_cache.go
+++ b/common/persistence/xdc_cache.go
@@ -37,6 +37,7 @@ import (
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/versionhistory"
 )
@@ -113,15 +114,17 @@ func (v XDCCacheValue) CacheSize() int {
 func NewEventsBlobCache(
 	maxBytes int,
 	ttl time.Duration,
+	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *XDCCacheImpl {
 	return &XDCCacheImpl{
-		cache: cache.New(
+		cache: cache.NewWithMetrics(
 			max(xdcMinCacheSize, maxBytes),
 			&cache.Options{
 				TTL: ttl,
 				Pin: false,
 			},
+			metricsHandler.WithTags(metrics.CacheTypeTag(metrics.XDCCacheTypeTagValue)),
 		),
 		logger:     logger,
 		serializer: serialization.NewSerializer(),

--- a/service/history/replication/sync_state_retriever_test.go
+++ b/service/history/replication/sync_state_retriever_test.go
@@ -40,6 +40,7 @@ import (
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/api"
@@ -117,6 +118,7 @@ func (s *syncWorkflowStateSuite) SetupTest() {
 	s.eventBlobCache = persistence.NewEventsBlobCache(
 		1024*1024,
 		20*time.Second,
+		metrics.NoopMetricsHandler,
 		s.logger,
 	)
 	s.syncStateRetriever = NewSyncStateRetriever(s.mockShard, s.workflowCache, s.workflowConsistencyChecker, s.eventBlobCache, s.logger)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Added metrics to XDC cache.

## Why?
<!-- Tell your future self why have you made these changes -->
It will make memory consumption of history service a bit clearer, and also will highlight the fact that XDC cache is always enabled (see #6695).

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
