### PR TITLE
fix stubborn flake

### DIFF
--- a/tests/worker_deployment_test.go
+++ b/tests/worker_deployment_test.go
@@ -978,7 +978,7 @@ func (s *WorkerDeploymentSuite) TestSetWorkerDeploymentRampingVersion_Unversione
 
 // Should see that the ramping version of the task queues in the current version is unversioned
 func (s *WorkerDeploymentSuite) TestSetWorkerDeploymentRampingVersion_Unversioned_VersionedCurrent() {
-	s.T().Skip("skipping this test since it's flaking on Cassandra. TODO (Shivam): Fix this.")
+	// s.T().Skip("skipping this test since it's flaking on Cassandra. TODO (Shivam): Fix this.")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()

--- a/tests/worker_deployment_test.go
+++ b/tests/worker_deployment_test.go
@@ -978,8 +978,6 @@ func (s *WorkerDeploymentSuite) TestSetWorkerDeploymentRampingVersion_Unversione
 
 // Should see that the ramping version of the task queues in the current version is unversioned
 func (s *WorkerDeploymentSuite) TestSetWorkerDeploymentRampingVersion_Unversioned_VersionedCurrent() {
-	// s.T().Skip("skipping this test since it's flaking on Cassandra. TODO (Shivam): Fix this.")
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 	tv := testvars.New(s)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Ran this potential flake 50 times against cassandra + sqlite and found no errors.
- Don't think this is a flake anymore.

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- CI run: https://github.com/temporalio/temporal/actions/runs/13399769297/job/37427573823

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
