### PR TITLE
Set history builder when no events appended

### DIFF
--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -770,6 +770,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 		return err
 	}
 	if versionhistory.IsEqualVersionHistoryItem(localLastItem, sourceLastItem) {
+		localMutableState.SetHistoryBuilder(historybuilder.NewImmutableForUpdateNextEventID(sourceLastItem))
 		return nil
 	}
 

--- a/service/history/ndc/workflow_state_replicator_test.go
+++ b/service/history/ndc/workflow_state_replicator_test.go
@@ -677,6 +677,7 @@ func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_SameBranch_S
 		},
 		locks.PriorityLow,
 	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
+	mockMutableState.EXPECT().SetHistoryBuilder(gomock.Any()).Times(1)
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(mockMutableState, nil)
 	mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		VersionHistories: versionHistories,
@@ -765,6 +766,7 @@ func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_DifferentBra
 		},
 		locks.PriorityLow,
 	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
+	mockMutableState.EXPECT().SetHistoryBuilder(gomock.Any()).Times(1)
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(mockMutableState, nil)
 	mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		VersionHistories: versionHistories,
@@ -850,6 +852,7 @@ func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_SameBranch_S
 		},
 		locks.PriorityLow,
 	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
+	mockMutableState.EXPECT().SetHistoryBuilder(gomock.Any()).Times(1)
 	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).Return(mockMutableState, nil)
 	mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		VersionHistories: versionHistories,
@@ -1049,7 +1052,7 @@ func (s *workflowReplicatorSuite) Test_bringLocalEventsUpToSourceCurrentBranch_W
 	mockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: s.runID,
 	}).AnyTimes()
-	mockMutableState.EXPECT().SetHistoryBuilder(gomock.Any())
+	mockMutableState.EXPECT().SetHistoryBuilder(gomock.Any()).Times(1)
 
 	allEvents := append(gapEvents, requestedEvents...)
 	allEvents = append(allEvents, tailEvents...)
@@ -1212,6 +1215,7 @@ func (s *workflowReplicatorSuite) Test_bringLocalEventsUpToSourceCurrentBranch_C
 	}).Return(&persistence.ForkHistoryBranchResponse{
 		NewBranchToken: forkedBranchToken,
 	}, nil)
+	mockMutableState.EXPECT().SetHistoryBuilder(gomock.Any()).Times(1)
 	err := s.workflowStateReplicator.bringLocalEventsUpToSourceCurrentBranch(
 		context.Background(),
 		namespace.ID(namespaceID),


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Set history builder when no events appended
## Why?
<!-- Tell your future self why have you made these changes -->
When new history branch is forked and assigned as current branch, we may not need to append events there but we should set history builder to update next event ID, otherwise the next eventId in mutable state does not match the version history.
i.e. 
local mutable state version history [100, 1], got a replication task to sync mutable state up to [80,1]. In this case, we will fork a new branch, but no event appended.
If we don't have this fix, the replication task will be landed in DLQ.
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no risk
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
yes