### PR TITLE
Allow setting client/worker options in FunctionalTestSdkSuite

### DIFF
--- a/tests/testcore/functional_test_sdk_suite.go
+++ b/tests/testcore/functional_test_sdk_suite.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/components/callbacks"
 	"go.temporal.io/server/components/nexusoperations"
 )
@@ -44,6 +45,12 @@ type (
 	// TODO (alex): merge this with FunctionalTestBase.
 	FunctionalTestSdkSuite struct {
 		FunctionalTestBase
+
+		// Suites can override client or worker options by modifying these before calling
+		// FunctionalTestSdkSuite.SetupSuite. ClientOptions.HostPort and Namespace cannot be
+		// overridden.
+		ClientOptions sdkclient.Options
+		WorkerOptions worker.Options
 
 		sdkClient sdkclient.Client
 		worker    worker.Worker
@@ -94,17 +101,18 @@ func (s *FunctionalTestSdkSuite) SetupTest() {
 		nexusoperations.CallbackURLTemplate,
 		"http://"+s.HttpAPIAddress()+"/namespaces/{{.NamespaceName}}/nexus/callback")
 
+	s.ClientOptions.HostPort = s.FrontendGRPCAddress()
+	s.ClientOptions.Namespace = s.Namespace().String()
+	if s.ClientOptions.Logger == nil {
+		s.ClientOptions.Logger = log.NewSdkLogger(s.Logger)
+	}
+
 	var err error
-	s.sdkClient, err = sdkclient.Dial(sdkclient.Options{
-		HostPort:  s.FrontendGRPCAddress(),
-		Namespace: s.Namespace().String(),
-	})
+	s.sdkClient, err = sdkclient.Dial(s.ClientOptions)
 	s.NoError(err)
 	s.taskQueue = RandomizeStr("tq")
 
-	// We need to set this timeout to 0 to disable the deadlock detector. Otherwise, the deadlock detector will cause
-	// TestTooManyChildWorkflows to fail because it thinks there is a deadlock due to the blocked child workflows.
-	s.worker = worker.New(s.sdkClient, s.taskQueue, worker.Options{DeadlockDetectionTimeout: 0})
+	s.worker = worker.New(s.sdkClient, s.taskQueue, s.WorkerOptions)
 	err = s.worker.Start()
 	s.NoError(err)
 }


### PR DESCRIPTION
## What changed?
- Allow suites using FunctionalTestSdkSuite to override client or worker options
- Default the SDK logger to the test logger

## Why?
- More flexibility for tests
- Consistent logging