### PR TITLE
Remove String methods from matching structs

### DIFF
--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -25,10 +25,8 @@
 package matching
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -61,7 +59,6 @@ type (
 		SpoolTask(taskInfo *persistencespb.TaskInfo) error
 		BacklogCountHint() int64
 		BacklogStatus() *taskqueuepb.TaskQueueStatus
-		String() string
 	}
 
 	backlogManagerImpl struct {
@@ -203,17 +200,6 @@ func (c *backlogManagerImpl) BacklogStatus() *taskqueuepb.TaskQueueStatus {
 			EndId:   taskIDBlock.end,
 		},
 	}
-}
-
-func (c *backlogManagerImpl) String() string {
-	buf := new(bytes.Buffer)
-	rangeID := c.db.RangeID()
-	_, _ = fmt.Fprintf(buf, "RangeID=%v\n", rangeID)
-	_, _ = fmt.Fprintf(buf, "TaskIDBlock=%+v\n", rangeIDToTaskIDBlock(rangeID, c.config.RangeSize))
-	_, _ = fmt.Fprintf(buf, "AckLevel=%v\n", c.taskAckManager.ackLevel)
-	_, _ = fmt.Fprintf(buf, "MaxTaskID=%v\n", c.taskAckManager.getReadLevel())
-
-	return buf.String()
 }
 
 // completeTask marks a task as processed. Only tasks created by taskReader (i.e. backlog from db) reach

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -369,15 +369,6 @@ func (e *matchingEngineImpl) getTaskQueuePartitions(maxCount int) (lists []taskQ
 	return
 }
 
-func (e *matchingEngineImpl) String() string {
-	// Executes taskQueue.String() on each task queue outside of lock
-	buf := new(bytes.Buffer)
-	for _, l := range e.getTaskQueuePartitions(1000) {
-		fmt.Fprintf(buf, "\n%s", l.String())
-	}
-	return buf.String()
-}
-
 // Returns taskQueuePartitionManager for a task queue. If not already cached, and create is true, tries
 // to get new range from DB and create one. This blocks (up to the context deadline) for the
 // task queue to be initialized.

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -25,7 +25,6 @@
 package matching
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -421,18 +420,6 @@ func (c *physicalTaskQueueManagerImpl) GetInternalTaskQueueStatus() *taskqueuesp
 		TaskIdBlock:      &taskqueuepb.TaskIdBlock{StartId: c.backlogMgr.taskWriter.taskIDBlock.start, EndId: c.backlogMgr.taskWriter.taskIDBlock.end},
 		ReadBufferLength: int64(len(c.backlogMgr.taskReader.taskBuffer)),
 	}
-}
-
-func (c *physicalTaskQueueManagerImpl) String() string {
-	buf := new(bytes.Buffer)
-	if c.queue.TaskType() == enumspb.TASK_QUEUE_TYPE_ACTIVITY {
-		buf.WriteString("Activity")
-	} else {
-		buf.WriteString("Workflow")
-	}
-	_, _ = fmt.Fprintf(buf, "Backlog=%s\n", c.backlogMgr.String())
-
-	return buf.String()
 }
 
 func (c *physicalTaskQueueManagerImpl) TrySyncMatch(ctx context.Context, task *internalTask) (bool, error) {

--- a/service/matching/physical_task_queue_manager_interface.go
+++ b/service/matching/physical_task_queue_manager_interface.go
@@ -69,7 +69,6 @@ type (
 		GetStats() *taskqueuepb.TaskQueueStats
 		GetInternalTaskQueueStatus() *taskqueuespb.InternalTaskQueueStatus
 		UnloadFromPartitionManager(unloadCause)
-		String() string
 		QueueKey() *PhysicalTaskQueueKey
 		// ShouldEmitGauges determines whether the gauge metrics should be emitted or not for this particular physical
 		// queue based on dynamic configs.

--- a/service/matching/physical_task_queue_manager_mock.go
+++ b/service/matching/physical_task_queue_manager_mock.go
@@ -289,20 +289,6 @@ func (mr *MockphysicalTaskQueueManagerMockRecorder) Stop(arg0 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).Stop), arg0)
 }
 
-// String mocks base method.
-func (m *MockphysicalTaskQueueManager) String() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "String")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// String indicates an expected call of String.
-func (mr *MockphysicalTaskQueueManagerMockRecorder) String() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).String))
-}
-
 // TrySyncMatch mocks base method.
 func (m *MockphysicalTaskQueueManager) TrySyncMatch(ctx context.Context, task *internalTask) (bool, error) {
 	m.ctrl.T.Helper()

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -598,10 +598,6 @@ func (pm *taskQueuePartitionManagerImpl) Describe(
 	}, nil
 }
 
-func (pm *taskQueuePartitionManagerImpl) String() string {
-	return pm.defaultQueue.String()
-}
-
 func (pm *taskQueuePartitionManagerImpl) Partition() tqid.Partition {
 	return pm.partition
 }

--- a/service/matching/task_queue_partition_manager_interface.go
+++ b/service/matching/task_queue_partition_manager_interface.go
@@ -79,7 +79,6 @@ type (
 		// LegacyDescribeTaskQueue returns information about all pollers of this partition and the status of its unversioned physical queue
 		LegacyDescribeTaskQueue(includeTaskQueueStatus bool) (*matchingservice.DescribeTaskQueueResponse, error)
 		Describe(ctx context.Context, buildIds map[string]bool, includeAllActive, reportStats, reportPollers, internalTaskQueueStatus bool) (*matchingservice.DescribeTaskQueuePartitionResponse, error)
-		String() string
 		Partition() tqid.Partition
 		LongPollExpirationInterval() time.Duration
 		// TimeSinceLastFanOut returns the time since the last DescribeTaskQueuePartition fan out

--- a/service/matching/task_queue_partition_manager_mock.go
+++ b/service/matching/task_queue_partition_manager_mock.go
@@ -324,20 +324,6 @@ func (mr *MocktaskQueuePartitionManagerMockRecorder) Stop(arg0 any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).Stop), arg0)
 }
 
-// String mocks base method.
-func (m *MocktaskQueuePartitionManager) String() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "String")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// String indicates an expected call of String.
-func (mr *MocktaskQueuePartitionManagerMockRecorder) String() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).String))
-}
-
 // TimeSinceLastFanOut mocks base method.
 func (m *MocktaskQueuePartitionManager) TimeSinceLastFanOut() time.Duration {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## What changed?
Remove String methods from matching structs and interfaces.

## Why?
These were just for debugging, but they're not really useful for that.