### PR TITLE
Fix callbacks state machine id

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5109,7 +5109,10 @@ func (wh *WorkflowHandler) validateWorkflowIdReusePolicy(
 	return nil
 }
 
-func (wh *WorkflowHandler) validateOnConflictOptions(_ *workflowpb.OnConflictOptions) error {
+func (wh *WorkflowHandler) validateOnConflictOptions(opts *workflowpb.OnConflictOptions) error {
+	if opts.AttachCompletionCallbacks && !opts.AttachRequestId {
+		return serviceerror.NewInvalidArgument("attaching request ID is required for attaching completion callbacks")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Make `OnConflictOptions.AttachRequestId` required if `OnConflictOptions.AttachCompletionCallbacks` is set.
Change the callback state machine ID builder to use the request ID instead of the history event ID.

## Why?
<!-- Tell your future self why have you made these changes -->
Attaching a callback to a running workflow creates the `WorkflowExecutionOptionsUpdated` event, which can be buffered. In this case, the history event ID does not "exist" yet, and cannot be used to generate the callback state machine ID.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
