### PR TITLE
Replace cache with map in namespace registry

### DIFF
--- a/common/namespace/nsregistry/registry.go
+++ b/common/namespace/nsregistry/registry.go
@@ -236,8 +236,10 @@ func (r *registry) getAllNamespace() []*namespace.Namespace {
 
 func (r *registry) getAllNamespaceLocked() []*namespace.Namespace {
 	result := make([]*namespace.Namespace, len(r.idToNamespace))
+	i := 0
 	for _, value := range r.idToNamespace {
-		result = append(result, value)
+		result[i] = value
+		i++
 	}
 	return result
 }

--- a/common/namespace/nsregistry/registry.go
+++ b/common/namespace/nsregistry/registry.go
@@ -109,7 +109,7 @@ type (
 		logger                  log.Logger
 		refreshInterval         dynamicconfig.DurationPropertyFn
 
-		// registryLock protects nameToID, idToNamespace and stateChangeCallbacks.
+		// nsMapsLock protects nameToID, idToNamespace and stateChangeCallbacks.
 
 		nsMapsLock    sync.RWMutex
 		nameToID      map[namespace.Name]namespace.ID

--- a/common/namespace/nsregistry/registry.go
+++ b/common/namespace/nsregistry/registry.go
@@ -162,7 +162,7 @@ func NewRegistry(
 }
 
 // GetRegistrySize observes the size of the by-name and by-ID maps.
-func (r *registry) GetRegistrySize() (int64, int64) {
+func (r *registry) GetRegistrySize() (idToNamespaceSize int64, nameToIDSize int64) {
 	r.nsMapsLock.RLock()
 	defer r.nsMapsLock.RUnlock()
 	return int64(len(r.idToNamespace)), int64(len(r.nameToID))

--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -46,7 +46,7 @@ type (
 		GetNamespaceByIDWithOptions(id ID, opts GetNamespaceOptions) (*Namespace, error)
 		GetNamespaceID(name Name) (ID, error)
 		GetNamespaceName(id ID) (Name, error)
-		GetCacheSize() (sizeOfCacheByName int64, sizeOfCacheByID int64)
+		GetRegistrySize() (sizeOfCacheByName int64, sizeOfCacheByID int64)
 		// Registers callback for namespace state changes.
 		// StateChangeCallbackFn will be invoked for a new/deleted namespace or namespace that has
 		// State, ReplicationState, ActiveCluster, or isGlobalNamespace config changed.

--- a/common/namespace/registry_mock.go
+++ b/common/namespace/registry_mock.go
@@ -63,21 +63,6 @@ func (m *MockRegistry) EXPECT() *MockRegistryMockRecorder {
 	return m.recorder
 }
 
-// GetCacheSize mocks base method.
-func (m *MockRegistry) GetCacheSize() (int64, int64) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCacheSize")
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(int64)
-	return ret0, ret1
-}
-
-// GetCacheSize indicates an expected call of GetCacheSize.
-func (mr *MockRegistryMockRecorder) GetCacheSize() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCacheSize", reflect.TypeOf((*MockRegistry)(nil).GetCacheSize))
-}
-
 // GetCustomSearchAttributesMapper mocks base method.
 func (m *MockRegistry) GetCustomSearchAttributesMapper(name Name) (CustomSearchAttributesMapper, error) {
 	m.ctrl.T.Helper()
@@ -195,6 +180,21 @@ func (m *MockRegistry) GetPingChecks() []pingable.Check {
 func (mr *MockRegistryMockRecorder) GetPingChecks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPingChecks", reflect.TypeOf((*MockRegistry)(nil).GetPingChecks))
+}
+
+// GetRegistrySize mocks base method.
+func (m *MockRegistry) GetRegistrySize() (int64, int64) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegistrySize")
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(int64)
+	return ret0, ret1
+}
+
+// GetRegistrySize indicates an expected call of GetRegistrySize.
+func (mr *MockRegistryMockRecorder) GetRegistrySize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegistrySize", reflect.TypeOf((*MockRegistry)(nil).GetRegistrySize))
 }
 
 // RefreshNamespaceById mocks base method.

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -693,7 +693,7 @@ func (h *Handler) DescribeHistoryHost(_ context.Context, req *historyservice.Des
 		}
 	}
 
-	itemsInCacheByIDCount, itemsInCacheByNameCount := h.namespaceRegistry.GetCacheSize()
+	itemsInCacheByIDCount, itemsInCacheByNameCount := h.namespaceRegistry.GetRegistrySize()
 	ownedShardIDs := h.controller.ShardIDs()
 	resp := &historyservice.DescribeHistoryHostResponse{
 		ShardsNumber: int32(len(ownedShardIDs)),

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -693,14 +693,14 @@ func (h *Handler) DescribeHistoryHost(_ context.Context, req *historyservice.Des
 		}
 	}
 
-	itemsInCacheByIDCount, itemsInCacheByNameCount := h.namespaceRegistry.GetRegistrySize()
+	itemsInRegistryByIDCount, itemsInRegistryByNameCount := h.namespaceRegistry.GetRegistrySize()
 	ownedShardIDs := h.controller.ShardIDs()
 	resp := &historyservice.DescribeHistoryHostResponse{
 		ShardsNumber: int32(len(ownedShardIDs)),
 		ShardIds:     ownedShardIDs,
 		NamespaceCache: &namespacespb.NamespaceCacheInfo{
-			ItemsInCacheByIdCount:   itemsInCacheByIDCount,
-			ItemsInCacheByNameCount: itemsInCacheByNameCount,
+			ItemsInCacheByIdCount:   itemsInRegistryByIDCount,
+			ItemsInCacheByNameCount: itemsInRegistryByNameCount,
 		},
 		Address: h.hostInfoProvider.HostInfo().GetAddress(),
 	}

--- a/service/history/handler_test.go
+++ b/service/history/handler_test.go
@@ -86,7 +86,7 @@ func TestDescribeHistoryHost(t *testing.T) {
 	)
 	controller.EXPECT().GetShardByID(int32(2)).Return(mockShard2, nil)
 	controller.EXPECT().ShardIDs().Return([]int32{2})
-	namespaceRegistry.EXPECT().GetCacheSize().Return(int64(0), int64(0))
+	namespaceRegistry.EXPECT().GetRegistrySize().Return(int64(0), int64(0))
 	hostInfoProvider.EXPECT().HostInfo().Return(membership.NewHostInfoFromAddress("0.0.0.0"))
 	_, err = h.DescribeHistoryHost(context.Background(), &historyservice.DescribeHistoryHostRequest{
 		ShardId: 2,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Change "cache" with "map" in nsRegistry.

## Why?
<!-- Tell your future self why have you made these changes -->
There is no cache in registry per se. There is no adding one entry at a time, or removing one entry at a time.
Practically it is just a map. This makes code cleaner. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Can't think of anything realistic.