### PR TITLE
clear drainage future when drained, ignore drainage signals if version is current or ramping

### DIFF
--- a/service/worker/workerdeployment/version_workflow.go
+++ b/service/worker/workerdeployment/version_workflow.go
@@ -280,15 +280,12 @@ func (d *VersionWorkflowRunner) buildSearchAttributes() temporal.SearchAttribute
 }
 
 func (d *VersionWorkflowRunner) stopDrainage(ctx workflow.Context) error {
-	var terminated bool
 	if d.drainageWorkflowFuture == nil {
 		return nil
 	}
 	fut := *d.drainageWorkflowFuture
-	err := fut.SignalChildWorkflow(ctx, TerminateDrainageSignal, nil).Get(ctx, &terminated)
-	if err != nil {
-		return err
-	}
+	_ = fut.SignalChildWorkflow(ctx, TerminateDrainageSignal, nil)
+
 	d.drainageWorkflowFuture = nil
 	return nil
 }

--- a/service/worker/workerdeployment/version_workflow.go
+++ b/service/worker/workerdeployment/version_workflow.go
@@ -97,6 +97,12 @@ func (d *VersionWorkflowRunner) listenToSignals(ctx workflow.Context) {
 		var newInfo *deploymentpb.VersionDrainageInfo
 
 		c.Receive(ctx, &newInfo)
+
+		// if the version is current or ramping, ignore drainage signal since it could have come late
+		if d.VersionState.GetRampingSinceTime() != nil || d.VersionState.GetCurrentSinceTime() != nil {
+			return
+		}
+
 		mergedInfo := &deploymentpb.VersionDrainageInfo{}
 		mergedInfo.LastCheckedTime = newInfo.LastCheckedTime
 		if d.VersionState.GetDrainageInfo().GetStatus() != newInfo.Status {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Right now, when the child drainage workflow signals the version workflow that its drained, the future representing the child workflow is not updated.
- This is really bad as it is causing errors when rolling back onto a version that was previously drained.

- Also, ignore drainage signals if version is ramping or current, since the signal could arrive late

## Why?
<!-- Tell your future self why have you made these changes -->
- Fixing errors

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing suite of tests + Shahab's demo shall test this too
- Added functional test that breaks without this fix and passes with the fix

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
Yes, I think?
