### PR TITLE
Delete Namespace: fix incompatible change in reclaim resources workflow

### DIFF
--- a/service/worker/deletenamespace/reclaimresources/workflow.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow.go
@@ -177,13 +177,17 @@ func ReclaimResourcesWorkflow(ctx workflow.Context, params ReclaimResourcesParam
 
 	var la *LocalActivities
 
-	// Step 0. This workflow is started right after the namespace is marked as DELETED and renamed.
-	// Wait for namespace cache refresh to make sure no new executions are created. 2 secodnds is a random buffer.
-	ctx0 := workflow.WithLocalActivityOptions(ctx, localActivityOptions)
-	var namespaceCacheRefreshDelay time.Duration
-	err = workflow.ExecuteLocalActivity(ctx0, la.GetNamespaceCacheRefreshInterval).Get(ctx, &namespaceCacheRefreshDelay)
-	if err != nil {
-		return result, err
+	// TODO: remove version check and 9s const after v1.27 release.
+	namespaceCacheRefreshDelay := 9 * time.Second
+	v := workflow.GetVersion(ctx, "namespace-refresh-dc", workflow.DefaultVersion, 0)
+	if v != workflow.DefaultVersion {
+		// Step 0. This workflow is started right after the namespace is marked as DELETED and renamed.
+		// Wait for namespace cache refresh to make sure no new executions are created. 2 seconds are a random buffer.
+		ctx0 := workflow.WithLocalActivityOptions(ctx, localActivityOptions)
+		err = workflow.ExecuteLocalActivity(ctx0, la.GetNamespaceCacheRefreshInterval).Get(ctx, &namespaceCacheRefreshDelay)
+		if err != nil {
+			return result, err
+		}
 	}
 
 	err = workflow.Sleep(ctx, namespaceCacheRefreshDelay+2*time.Second)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
#7215 introduced incompatible change in reclaim resources workflow code (extra local activity call). If new version is rolled out while previous workflow is running, it will generate NDE. This PR adds proper version check (patch API) to avoid it.

## Why?
<!-- Tell your future self why have you made these changes -->
Bug fix.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run upgrade locally.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
Yes.