### PR TITLE
CHASM: define exported Tree methods

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -37,13 +37,17 @@ type (
 		// persistence *persistencespb.ChasmNode
 	}
 
+	// NodesMutation is a set of mutations for all nodes rooted at a given node n,
+	// including the node n itself.
 	NodesMutation struct {
-		UpdatedNodes map[string]*persistencespb.ChasmNode
+		UpdatedNodes map[string]*persistencespb.ChasmNode // flattened node path -> chasm node
 		DeletedNodes map[string]struct{}
 	}
 
+	// NodesSnapshot is a snapshot for all nodes rooted at a given node n,
+	// including the node n itself.
 	NodesSnapshot struct {
-		Nodes map[string]*persistencespb.ChasmNode
+		Nodes map[string]*persistencespb.ChasmNode // flattened node path -> chasm node
 	}
 
 	NodeBackend interface {
@@ -86,7 +90,9 @@ func (n *Node) Ref(
 }
 
 // Now implements the CHASM Context interface
-func (n *Node) Now() time.Time {
+func (n *Node) Now(
+	component Component,
+) time.Time {
 	panic("not implemented")
 }
 

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -1,0 +1,135 @@
+// The MIT License
+//
+// Copyright (c) 2025 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package chasm
+
+import (
+	"time"
+
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+)
+
+type (
+	Node struct {
+		// TODO: add necessary fields here, e.g.
+		//
+		// parent   *Node
+		// children map[string]*Node
+		// persistence *persistencespb.ChasmNode
+	}
+
+	NodesMutation struct {
+		UpdatedNodes map[string]*persistencespb.ChasmNode
+		DeletedNodes map[string]struct{}
+	}
+
+	NodesSnapshot struct {
+		Nodes map[string]*persistencespb.ChasmNode
+	}
+
+	NodeBackend interface {
+		// TODO: Add methods needed from MutateState here.
+		//
+		// This is for breaking cycle dependency between
+		// this package and service/history/workflow package
+		// where MutableState is defined.
+	}
+)
+
+// NewTree creates a new in-memory CHASM tree from flattened persistence CHASM nodes.
+//
+// CHASM Tree and all its methods are NOT meant to be used by CHASM component authors.
+// They are exported for use by the CHASM engine and underlying MutableState implementation only.
+func NewTree(
+	registry *Registry,
+	persistenceNodes map[string]*persistencespb.ChasmNode,
+	nodeBackend NodeBackend,
+) (*Node, error) {
+	panic("not implemented")
+}
+
+// Component retrieves a component from the tree rooted at node n
+// using the provided component reference
+// It also performs consistency, access rule, and task validation checks
+// (for task processing requests) before returning the component.
+func (n *Node) Component(
+	chasmContext Context,
+	ref ComponentRef,
+) (Component, error) {
+	panic("not implemented")
+}
+
+// Ref implements the CHASM Context interface
+func (n *Node) Ref(
+	component Component,
+) (ComponentRef, bool) {
+	panic("not implemented")
+}
+
+// Now implements the CHASM Context interface
+func (n *Node) Now() time.Time {
+	panic("not implemented")
+}
+
+// AddTask implements the CHASM MutableContext interface
+func (n *Node) AddTask(
+	component Component,
+	taskAttributes TaskAttributes,
+	task interface{},
+) error {
+	panic("not implemented")
+}
+
+// CloseTransactionAsMutation is used by MutableState
+// to close the transaction and persist mutations into DB.
+func (n *Node) CloseTransactionAsMutation() (*NodesMutation, error) {
+	panic("not implemented")
+}
+
+// CloseTransactionAsSnapshot is used by MutableState
+// to close the transaction and persist entire CHASM tree into DB.
+func (n *Node) CloseTransactionAsSnapshot() (*NodesSnapshot, error) {
+	panic("not implemented")
+}
+
+// ApplyMutation is used by replication stack to apply node
+// mutations from the source cluster.
+func (n *Node) ApplyMutation(
+	mutation NodesMutation,
+) error {
+	panic("not implemented")
+}
+
+// ApplySnapshot is used by replication stack to apply node
+// snapshot from the source cluster.
+//
+// If we simply substituting the entire CHASM tree, we will be
+// forced to close the transaction as snapshot and potentially
+// write extra data to persistence.
+// This method will instead figure out the mutations needed to
+// bring the current tree to the be the same as the snapshot,
+// thus allowing us to close the transaction as mutation.
+func (n *Node) ApplySnapshot(
+	snapshot NodesSnapshot,
+) error {
+	panic("not implemented")
+}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- CHASM: define exported Tree methods

## Why?
<!-- Tell your future self why have you made these changes -->
- CHASM tree is the core of the entire CHASM framework. Although its own implementation is complex, by defining its exported method, we can unblock the work needed in mutable state, chasm engine & replication

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- N/A, not actual implementation in this PR.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
