### PR TITLE
Attempt to fix random describe errors

### DIFF
--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -1381,7 +1381,9 @@ func (d *ClientImpl) isTaskQueueExpectedInNewVersion(
 			Versions: &taskqueuepb.TaskQueueVersionSelection{
 				BuildIds: []string{prevCurrentVersionInfo.GetVersion()}, // pretending the version string is a build id
 			},
-			TaskQueueType: taskQueue.Type, // since request doesn't pass through frontend, this field is not automatically populated
+			// Since request doesn't pass through frontend, this field is not automatically populated.
+			// Moreover, DescribeTaskQueueEnhanced requires this field to be set to WORKFLOW type.
+			TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
 			ReportStats:   true,
 		},
 	}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- `DescribeTaskQueueEnhanced` requests, in the frontend, have taskQueueType overridden to Workflow. Since worker-deployment activities directly call matching, it is important to set this field to Workflow.
- I noticed an error whereby I was filling the request structure with the missing task-queue's type rather than the workflow type. This was resulting in errors like:


```  msg="matching client encountered error" service=worker error="DescribeTaskQueue must be called on the root partition of workflow task queue if api mode is DESCRIBE_TASK_QUEUE_MODE_ENHANCED" service-error-type=serviceerror.InvalidArgument  ```

- This is not desirable and the PR aims to fix that. Note, requesting the correct type for the task-queue in a DescribeTaskQueueEnhanced call is done by filling in the field:

```TaskQueueTypes: []enumspb.TaskQueueType{taskQueue.Type}``` (which we are doing in the code)

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing suite + Antonio's CLI test 

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
