### PR TITLE
Fix start time calculation in schedule spec

### DIFF
--- a/components/scheduler/spec_processor.go
+++ b/components/scheduler/spec_processor.go
@@ -170,5 +170,5 @@ func (s SpecProcessorImpl) getNextTime(scheduler Scheduler, after time.Time) (sc
 		return scheduler1.GetNextTimeResult{}, err
 	}
 
-	return spec.GetNextTime(scheduler.jitterSeed(), after), nil
+	return spec.GetNextTime(scheduler.jitterSeed(), scheduler1.LatestSpecVersion, after), nil
 }

--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cache"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/util"
 )
 
 type (
@@ -295,9 +296,7 @@ func (cs *CompiledSpec) CanonicalForm() *schedulepb.ScheduleSpec {
 func (cs *CompiledSpec) GetNextTime(jitterSeed string, after time.Time) GetNextTimeResult {
 	// If we're starting before the schedule's allowed time range, jump up to right before
 	// it (so that we can still return the first second of the range if it happens to match).
-	if cs.spec.StartTime != nil && after.Before(timestamp.TimeValue(cs.spec.StartTime)) {
-		after = cs.spec.StartTime.AsTime().Add(-time.Second)
-	}
+	after = util.MaxTime(after, cs.spec.StartTime.AsTime().Add(-time.Second))
 
 	pastEndTime := func(t time.Time) bool {
 		return cs.spec.EndTime != nil && t.After(cs.spec.EndTime.AsTime())

--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -73,6 +73,9 @@ const (
 	// Versions of schedule spec logic.
 	InitialSpecVersion SpecVersion = 0
 	FixStartTimeBug    SpecVersion = 1
+
+	// Versions should be checked with >=, so this is equivalent to the latest version.
+	LatestSpecVersion SpecVersion = math.MaxInt64
 )
 
 func NewSpecBuilder() *SpecBuilder {

--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -65,6 +65,14 @@ type (
 		loc *time.Location
 		err error
 	}
+
+	SpecVersion int64
+)
+
+const (
+	// Versions of schedule spec logic.
+	InitialSpecVersion SpecVersion = 0
+	FixStartTimeBug    SpecVersion = 1
 )
 
 func NewSpecBuilder() *SpecBuilder {
@@ -293,10 +301,15 @@ func (cs *CompiledSpec) CanonicalForm() *schedulepb.ScheduleSpec {
 // Returns the earliest time that matches the schedule spec that is after the given time.
 // Returns: Nominal is the time that matches, pre-jitter. Next is the nominal time with
 // jitter applied. If there is no matching time, Nominal and Next will be the zero time.
-func (cs *CompiledSpec) GetNextTime(jitterSeed string, after time.Time) GetNextTimeResult {
+func (cs *CompiledSpec) GetNextTime(jitterSeed string, ver SpecVersion, after time.Time) GetNextTimeResult {
 	// If we're starting before the schedule's allowed time range, jump up to right before
 	// it (so that we can still return the first second of the range if it happens to match).
-	after = util.MaxTime(after, cs.spec.StartTime.AsTime().Add(-time.Second))
+	if ver >= FixStartTimeBug {
+		// note: AsTime returns unix epoch on nil StartTime
+		after = util.MaxTime(after, cs.spec.StartTime.AsTime().Add(-time.Second))
+	} else if cs.spec.StartTime != nil && after.Before(timestamp.TimeValue(cs.spec.StartTime)) {
+		after = cs.spec.StartTime.AsTime().Add(-time.Second)
+	}
 
 	pastEndTime := func(t time.Time) bool {
 		return cs.spec.EndTime != nil && t.After(cs.spec.EndTime.AsTime())

--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -407,6 +407,20 @@ func (s *specSuite) TestSpecStartTime() {
 	)
 }
 
+func (s *specSuite) TestSpecStartTimeMinusOneSecond() {
+	s.checkSequenceFull(
+		"",
+		&schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{Interval: durationpb.New(time.Hour)},
+			},
+			StartTime: timestamppb.New(time.Date(2022, 3, 23, 12, 0, 0, 456000000, time.UTC)),
+		},
+		time.Date(2022, 3, 23, 12, 00, 0, 123000000, time.UTC),
+		time.Date(2022, 3, 23, 13, 00, 0, 0, time.UTC),
+	)
+}
+
 func (s *specSuite) TestSpecEndTime() {
 	s.checkSequenceFull(
 		"",

--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -67,7 +67,7 @@ func (s *specSuite) checkSequenceFull(jitterSeed string, spec *schedulepb.Schedu
 	cs, err := s.specBuilder.NewCompiledSpec(spec)
 	s.NoError(err)
 	for _, exp := range seq {
-		result := cs.GetNextTime(jitterSeed, start)
+		result := cs.GetNextTime(jitterSeed, FixStartTimeBug, start)
 		if exp.IsZero() {
 			s.Require().True(
 				result.Nominal.IsZero(),

--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -67,7 +67,7 @@ func (s *specSuite) checkSequenceFull(jitterSeed string, spec *schedulepb.Schedu
 	cs, err := s.specBuilder.NewCompiledSpec(spec)
 	s.NoError(err)
 	for _, exp := range seq {
-		result := cs.GetNextTime(jitterSeed, FixStartTimeBug, start)
+		result := cs.GetNextTime(jitterSeed, LatestSpecVersion, start)
 		if exp.IsZero() {
 			s.Require().True(
 				result.Nominal.IsZero(),
@@ -408,6 +408,7 @@ func (s *specSuite) TestSpecStartTime() {
 }
 
 func (s *specSuite) TestSpecStartTimeMinusOneSecond() {
+	// This checks the bug fixed by FixStartTimeBug.
 	s.checkSequenceFull(
 		"",
 		&schedulepb.ScheduleSpec{

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -226,7 +226,7 @@ var (
 		ReuseTimer:                        true,
 		NextTimeCacheV2Size:               14, // see note below
 		SpecFieldLengthLimit:              10,
-		SpecVersion:                       InitialSpecVersion,
+		SpecVersion:                       FixStartTimeBug,
 		Version:                           ActionResultIncludesStatus,
 	}
 

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -175,6 +175,7 @@ type (
 		ReuseTimer                        bool                     // Whether to reuse timer. Used for workflow compatibility.
 		NextTimeCacheV2Size               int                      // Size of next time cache (v2)
 		SpecFieldLengthLimit              int                      // item limit per spec field on the ScheduleInfo memo
+		SpecVersion                       SpecVersion              // version for spec logic
 		Version                           SchedulerWorkflowVersion // Used to keep track of schedules version to release new features and for backward compatibility
 		// version 0 corresponds to the schedule version that comes before introducing the Version parameter
 
@@ -225,6 +226,7 @@ var (
 		ReuseTimer:                        true,
 		NextTimeCacheV2Size:               14, // see note below
 		SpecFieldLengthLimit:              10,
+		SpecVersion:                       FixStartTimeBug,
 		Version:                           ActionResultIncludesStatus,
 	}
 
@@ -491,7 +493,7 @@ func (s *scheduler) getNextTimeV1(after time.Time) GetNextTimeResult {
 	panicIfErr(workflow.SideEffect(s.ctx, func(ctx workflow.Context) interface{} {
 		results := make(map[time.Time]GetNextTimeResult)
 		for t := after; !t.IsZero() && len(results) < nextTimeCacheV1Size; {
-			next := s.cspec.GetNextTime(s.jitterSeed(), t)
+			next := s.cspec.GetNextTime(s.jitterSeed(), s.tweakables.SpecVersion, t)
 			results[t] = next
 			t = next.Next
 		}
@@ -568,7 +570,7 @@ func (s *scheduler) fillNextTimeCacheV2(start time.Time) {
 			NominalTimes: make([]int64, 0, s.tweakables.NextTimeCacheV2Size),
 		}
 		for t := start; len(cache.NextTimes) < s.tweakables.NextTimeCacheV2Size; {
-			next := s.cspec.GetNextTime(s.jitterSeed(), t)
+			next := s.cspec.GetNextTime(s.jitterSeed(), s.tweakables.SpecVersion, t)
 			if next.Next.IsZero() {
 				cache.Completed = true
 				break
@@ -619,7 +621,7 @@ func (s *scheduler) getNextTime(after time.Time) GetNextTimeResult {
 	// existing schedule workflows.
 	var next GetNextTimeResult
 	panicIfErr(workflow.SideEffect(s.ctx, func(ctx workflow.Context) interface{} {
-		return s.cspec.GetNextTime(s.jitterSeed(), after)
+		return s.cspec.GetNextTime(s.jitterSeed(), s.tweakables.SpecVersion, after)
 	}).Get(&next))
 	return next
 }
@@ -960,7 +962,10 @@ func (s *scheduler) getFutureActionTimes(inWorkflowContext bool, n int) []*times
 
 	// Pure version not using workflow context
 	next := func(t time.Time) time.Time {
-		return s.cspec.GetNextTime(s.jitterSeed(), t).Next
+		// Note: use CurrentTweakablePolicies.SpecVersion since we want to pull in any spec bug
+		// fixes immediately on deployment of new code, even if a workflow task hasn't run to
+		// update s.tweakables yet.
+		return s.cspec.GetNextTime(s.jitterSeed(), CurrentTweakablePolicies.SpecVersion, t).Next
 	}
 
 	if inWorkflowContext && s.hasMinVersion(NewCacheAndJitter) {
@@ -1020,7 +1025,7 @@ func (s *scheduler) handleListMatchingTimesQuery(req *workflowservice.ListSchedu
 	t1 := timestamp.TimeValue(req.StartTime)
 	for i := 0; i < maxListMatchingTimesCount; i++ {
 		// don't need to call GetNextTime in SideEffect because this is just a query
-		t1 = s.cspec.GetNextTime(s.jitterSeed(), t1).Next
+		t1 = s.cspec.GetNextTime(s.jitterSeed(), CurrentTweakablePolicies.SpecVersion, t1).Next
 		if t1.IsZero() || t1.After(timestamp.TimeValue(req.EndTime)) {
 			break
 		}


### PR DESCRIPTION
## What changed?
- Fix handling of start time in schedule specs that could result in GetNextTime returning the time that it was given.
- Introduce a SpecVersion as part of tweakables but separate from workflow logic version to control this behavior.
- Non-workflow logic can always use the latest version.
- Workflow logic is initialized with the fixed version, which is technically not downgrade-compatible, but it should affect very few workflows.

## Why?
This would lead to incorrect results and infinite loops.

## How did you test it?
new unit test, manual replay tests

## Potential risks
This was done in a way to be upgrade-compatible, but is not downgrade-compatible for workflows that hit this edge case after the upgrade.