### PR TITLE
Change Nexus endpoint registry backoff logic to allow faster reload

### DIFF
--- a/common/nexus/endpoint_registry_test.go
+++ b/common/nexus/endpoint_registry_test.go
@@ -69,13 +69,13 @@ func TestGet(t *testing.T) {
 
 	// first long poll
 	mocks.matchingClient.EXPECT().ListNexusEndpoints(gomock.Any(), &matchingservice.ListNexusEndpointsRequest{
-		PageSize:              int32(1000),
+		PageSize:              int32(100),
 		LastKnownTableVersion: int64(1),
 		Wait:                  true,
 	}).DoAndReturn(func(context.Context, *matchingservice.ListNexusEndpointsRequest, ...interface{}) (*matchingservice.ListNexusEndpointsResponse, error) {
 		time.Sleep(20 * time.Millisecond)
 		return &matchingservice.ListNexusEndpointsResponse{TableVersion: int64(1)}, nil
-	}).MaxTimes(1)
+	}).AnyTimes()
 
 	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	reg.StartLifecycle()
@@ -109,13 +109,13 @@ func TestGetNotFound(t *testing.T) {
 
 	// first long poll
 	mocks.matchingClient.EXPECT().ListNexusEndpoints(gomock.Any(), &matchingservice.ListNexusEndpointsRequest{
-		PageSize:              int32(1000),
+		PageSize:              int32(100),
 		LastKnownTableVersion: int64(1),
 		Wait:                  true,
 	}).DoAndReturn(func(context.Context, *matchingservice.ListNexusEndpointsRequest, ...interface{}) (*matchingservice.ListNexusEndpointsResponse, error) {
 		time.Sleep(20 * time.Millisecond)
 		return &matchingservice.ListNexusEndpointsResponse{TableVersion: int64(1)}, nil
-	}).MaxTimes(1)
+	}).AnyTimes()
 
 	// readthrough
 	mocks.persistence.EXPECT().GetNexusEndpoint(gomock.Any(), &persistence.GetNexusEndpointRequest{ID: testEntry.Id}).Return(testEntry, nil)


### PR DESCRIPTION
## What?

Change Nexus endpoint registry backoff logic to allow faster reload.
Specifically, we don't wait between polls if the data changes now, and we don't back off exponentially when no changes occur. In the worst case where the remote has a bug, we will poll the registry every second, which is roughly what the current namespace registry refresh interval is but since there won't be any changes, no new data should be transmitted and our in memory cache should stay valid and won't cost any CPU to reconstruct.

## Why?

The previous logic was causing high delays in test scenarios where endpoints were created very frequently, causing the refresh loop to back off more with every successful attempt. The more tests we added the longer it took to refresh the endpoints, causing later tests to eventually time out.

