### PR TITLE
Always populate cause on nexus HandlerError

### DIFF
--- a/components/nexusoperations/completion.go
+++ b/components/nexusoperations/completion.go
@@ -62,7 +62,7 @@ func handleSuccessfulOperationResult(
 	return CompletedEventDefinition{}.Apply(node.Parent, event)
 }
 
-func handleUnsuccessfulOperationError(
+func handleOperationError(
 	node *hsm.Node,
 	operation Operation,
 	opFailedError *nexus.OperationError,
@@ -184,7 +184,7 @@ func CompletionHandler(
 			return serviceerror.NewNotFound("operation not found")
 		}
 		if opFailedError != nil {
-			err = handleUnsuccessfulOperationError(node, operation, opFailedError)
+			err = handleOperationError(node, operation, opFailedError)
 		} else {
 			err = handleSuccessfulOperationResult(node, operation, result, nil)
 		}

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -380,6 +380,8 @@ func TestProcessInvocationTask(t *testing.T) {
 				failure := events[0].GetNexusOperationFailedEventAttributes().Failure.Cause
 				require.NotNil(t, failure.GetNexusHandlerFailureInfo())
 				require.Equal(t, "handler error (NOT_FOUND): endpoint not registered", failure.Message)
+				require.NotNil(t, failure.Cause.GetApplicationFailureInfo())
+				require.Equal(t, "endpoint not registered", failure.Cause.Message)
 			},
 		},
 		{


### PR DESCRIPTION
## Why?

The SDK requires a cause on failures with `HandlerFailureInfo` to properly reconstruct a `HandlerError` object.


## How did you test it?

Added a unit test.