### PR TITLE
Remove schedule spec version

### DIFF
--- a/components/scheduler/spec_processor.go
+++ b/components/scheduler/spec_processor.go
@@ -170,5 +170,5 @@ func (s SpecProcessorImpl) getNextTime(scheduler Scheduler, after time.Time) (sc
 		return scheduler1.GetNextTimeResult{}, err
 	}
 
-	return spec.GetNextTime(scheduler.jitterSeed(), scheduler1.LatestSpecVersion, after), nil
+	return spec.GetNextTime(scheduler.jitterSeed(), after), nil
 }

--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -65,8 +65,6 @@ type (
 		loc *time.Location
 		err error
 	}
-
-	SpecVersion int64
 )
 
 func NewSpecBuilder() *SpecBuilder {

--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -67,7 +67,7 @@ func (s *specSuite) checkSequenceFull(jitterSeed string, spec *schedulepb.Schedu
 	cs, err := s.specBuilder.NewCompiledSpec(spec)
 	s.NoError(err)
 	for _, exp := range seq {
-		result := cs.GetNextTime(jitterSeed, LatestSpecVersion, start)
+		result := cs.GetNextTime(jitterSeed, start)
 		if exp.IsZero() {
 			s.Require().True(
 				result.Nominal.IsZero(),

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -226,7 +226,6 @@ var (
 		ReuseTimer:                        true,
 		NextTimeCacheV2Size:               14, // see note below
 		SpecFieldLengthLimit:              10,
-		SpecVersion:                       FixStartTimeBug,
 		Version:                           ActionResultIncludesStatus,
 	}
 
@@ -493,7 +492,7 @@ func (s *scheduler) getNextTimeV1(after time.Time) GetNextTimeResult {
 	panicIfErr(workflow.SideEffect(s.ctx, func(ctx workflow.Context) interface{} {
 		results := make(map[time.Time]GetNextTimeResult)
 		for t := after; !t.IsZero() && len(results) < nextTimeCacheV1Size; {
-			next := s.cspec.GetNextTime(s.jitterSeed(), s.tweakables.SpecVersion, t)
+			next := s.cspec.GetNextTime(s.jitterSeed(), t)
 			results[t] = next
 			t = next.Next
 		}
@@ -570,7 +569,7 @@ func (s *scheduler) fillNextTimeCacheV2(start time.Time) {
 			NominalTimes: make([]int64, 0, s.tweakables.NextTimeCacheV2Size),
 		}
 		for t := start; len(cache.NextTimes) < s.tweakables.NextTimeCacheV2Size; {
-			next := s.cspec.GetNextTime(s.jitterSeed(), s.tweakables.SpecVersion, t)
+			next := s.cspec.GetNextTime(s.jitterSeed(), t)
 			if next.Next.IsZero() {
 				cache.Completed = true
 				break
@@ -621,7 +620,7 @@ func (s *scheduler) getNextTime(after time.Time) GetNextTimeResult {
 	// existing schedule workflows.
 	var next GetNextTimeResult
 	panicIfErr(workflow.SideEffect(s.ctx, func(ctx workflow.Context) interface{} {
-		return s.cspec.GetNextTime(s.jitterSeed(), s.tweakables.SpecVersion, after)
+		return s.cspec.GetNextTime(s.jitterSeed(), after)
 	}).Get(&next))
 	return next
 }
@@ -962,9 +961,7 @@ func (s *scheduler) getFutureActionTimes(inWorkflowContext bool, n int) []*times
 
 	// Pure version not using workflow context
 	next := func(t time.Time) time.Time {
-		// Note: use LatestSpecVersion since we want to pull in any spec bug fixes immediately on
-		// deployment of new code, even if a workflow task hasn't run to update s.tweakables yet.
-		return s.cspec.GetNextTime(s.jitterSeed(), LatestSpecVersion, t).Next
+		return s.cspec.GetNextTime(s.jitterSeed(), t).Next
 	}
 
 	if inWorkflowContext && s.hasMinVersion(NewCacheAndJitter) {
@@ -1024,7 +1021,7 @@ func (s *scheduler) handleListMatchingTimesQuery(req *workflowservice.ListSchedu
 	t1 := timestamp.TimeValue(req.StartTime)
 	for i := 0; i < maxListMatchingTimesCount; i++ {
 		// don't need to call GetNextTime in SideEffect because this is just a query
-		t1 = s.cspec.GetNextTime(s.jitterSeed(), LatestSpecVersion, t1).Next
+		t1 = s.cspec.GetNextTime(s.jitterSeed(), t1).Next
 		if t1.IsZero() || t1.After(timestamp.TimeValue(req.EndTime)) {
 			break
 		}

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -175,7 +175,6 @@ type (
 		ReuseTimer                        bool                     // Whether to reuse timer. Used for workflow compatibility.
 		NextTimeCacheV2Size               int                      // Size of next time cache (v2)
 		SpecFieldLengthLimit              int                      // item limit per spec field on the ScheduleInfo memo
-		SpecVersion                       SpecVersion              // version for spec logic
 		Version                           SchedulerWorkflowVersion // Used to keep track of schedules version to release new features and for backward compatibility
 		// version 0 corresponds to the schedule version that comes before introducing the Version parameter
 


### PR DESCRIPTION
## What changed?
Revert part of #7389, the spec version mechanism is unnecessary since GetNextTime is always called in a side effect.

## Why?
simplify

## How did you test it?
existing tests