### PR TITLE
Fix flaky test TestStartWorkflowExecution_UseExisting_OnConflictOptions

### DIFF
--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -328,9 +328,11 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 			}
 
 			numCallbacks := 1
+			expectedCallbacks := []*commonpb.Callback{cb1}
 			if tc.OnConflictOptions.AttachCompletionCallbacks {
 				s.ProtoElementsMatch(request.CompletionCallbacks, attributes.GetAttachedCompletionCallbacks())
 				numCallbacks += len(request.CompletionCallbacks)
+				expectedCallbacks = append(expectedCallbacks, request.CompletionCallbacks...)
 			} else {
 				s.Empty(attributes.GetAttachedCompletionCallbacks())
 			}
@@ -357,7 +359,7 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 			for i, cb := range descResp.Callbacks {
 				descRespCallbacks[i] = cb.Callback
 			}
-			s.ProtoElementsMatch(append(request.CompletionCallbacks, cb1), descRespCallbacks)
+			s.ProtoElementsMatch(expectedCallbacks, descRespCallbacks)
 		})
 	}
 }

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -353,10 +353,11 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 			)
 			s.NoError(err)
 			s.Len(descResp.Callbacks, numCallbacks)
-			s.ProtoEqual(cb1, descResp.Callbacks[0].Callback)
-			for i, cb := range descResp.Callbacks[1:] {
-				s.ProtoEqual(request.CompletionCallbacks[i], cb.Callback)
+			descRespCallbacks := make([]*commonpb.Callback, len(descResp.Callbacks))
+			for i, cb := range descResp.Callbacks {
+				descRespCallbacks[i] = cb.Callback
 			}
+			s.ProtoElementsMatch(append(request.CompletionCallbacks, cb1), descRespCallbacks)
 		})
 	}
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix flaky tests `TestStartWorkflowExecution_UseExisting_OnConflictOptions`.

Fix proto assert library bugs.

## Why?
<!-- Tell your future self why have you made these changes -->
Callbacks in the describe workflow response is not in the same order as they are added.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
