### PR TITLE
Fix potential NPE in workflow context

### DIFF
--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -282,8 +282,9 @@ func (c *ContextImpl) LoadMutableState(ctx context.Context, shardContext shard.C
 
 		// NOTE: we can't not assigned the result directly to c.MutableState like below
 		// c.MutableState, err = NewMutableStateFromDB(...)
-		// Otherwise c.MutableState itself will not be nil, but can potentially point to a nil *MutableStateImpl,
-		// and causing NPE (e.g. when calling c.Clear()) or other unexpected behavior.
+		// Otherwise c.MutableState (an interface) will not be nil, but can point to a nil *MutableStateImpl pointer
+		// returned by NewMutableStateFromDB().
+		// Thus causing NPE (e.g. when calling c.Clear()) or other unexpected behavior.
 		c.MutableState = mutableState
 	}
 

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -268,7 +268,7 @@ func (c *ContextImpl) LoadMutableState(ctx context.Context, shardContext shard.C
 			return nil, err
 		}
 
-		c.MutableState, err = NewMutableStateFromDB(
+		mutableState, err := NewMutableStateFromDB(
 			shardContext,
 			shardContext.GetEventsCache(),
 			c.logger,
@@ -279,6 +279,12 @@ func (c *ContextImpl) LoadMutableState(ctx context.Context, shardContext shard.C
 		if err != nil {
 			return nil, err
 		}
+
+		// NOTE: we can't not assigned the result directly to c.MutableState like below
+		// c.MutableState, err = NewMutableStateFromDB(...)
+		// Otherwise c.MutableState itself will not be nil, but can potentially point to a nil *MutableStateImpl,
+		// and causing NPE (e.g. when calling c.Clear()) or other unexpected behavior.
+		c.MutableState = mutableState
 	}
 
 	flushBeforeReady, err := c.MutableState.StartTransaction(namespaceEntry)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Set workflowContext.MutableState only when mutable state is not nil
- The case won't happen today as `NewMutableStateFromDB` never returns nil, but could happen in the future.

## Why?
<!-- Tell your future self why have you made these changes -->
- Prevent potential NPE when the interface value is not nil but points to a nil value. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Tested in cicd

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- N/A

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
- N/A

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- No
