### PR TITLE
Use WorkflowStateTask for closed workflow replication

### DIFF
--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -758,22 +758,6 @@ func (r *TaskGeneratorImpl) GenerateMigrationTasks() ([]tasks.Task, int64, error
 			Version:     lastItem.GetVersion(),
 			Priority:    enumsspb.TASK_PRIORITY_LOW,
 		}}
-		if r.mutableState.IsTransitionHistoryEnabled() &&
-			// even though current cluster may enabled state transition, but transition history can be cleared
-			// by processing a replication task from a cluster that has state transition disabled
-			len(executionInfo.TransitionHistory) > 0 {
-
-			transitionHistory := executionInfo.TransitionHistory
-			return []tasks.Task{&tasks.SyncVersionedTransitionTask{
-				WorkflowKey:         workflowKey,
-				Priority:            enumsspb.TASK_PRIORITY_LOW,
-				VersionedTransition: transitionhistory.LastVersionedTransition(transitionHistory),
-				FirstEventID:        executionInfo.LastFirstEventId,
-				FirstEventVersion:   lastItem.Version,
-				NextEventID:         lastItem.GetEventId() + 1,
-				TaskEquivalents:     syncWorkflowStateTask,
-			}}, 1, nil
-		}
 		return syncWorkflowStateTask, 1, nil
 	}
 

--- a/service/history/workflow/task_generator_test.go
+++ b/service/history/workflow/task_generator_test.go
@@ -746,8 +746,8 @@ func TestTaskGeneratorImpl_GenerateMigrationTasks(t *testing.T) {
 			transitionHistoryEnabled:    true,
 			workflowState:               enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
 			pendingActivityInfo:         map[int64]*persistencespb.ActivityInfo{},
-			expectedTaskTypes:           []enumsspb.TaskType{enumsspb.TASK_TYPE_REPLICATION_SYNC_VERSIONED_TRANSITION},
-			expectedTaskEquivalentTypes: []enumsspb.TaskType{enumsspb.TASK_TYPE_REPLICATION_SYNC_WORKFLOW_STATE},
+			expectedTaskTypes:           []enumsspb.TaskType{enumsspb.TASK_TYPE_REPLICATION_SYNC_WORKFLOW_STATE},
+			expectedTaskEquivalentTypes: nil,
 		},
 		{
 			name:                     "transition history enabled, execution running",
@@ -833,7 +833,8 @@ func TestTaskGeneratorImpl_GenerateMigrationTasks(t *testing.T) {
 			resultTasks, _, err := taskGenerator.GenerateMigrationTasks()
 			require.NoError(t, err)
 			require.Equal(t, len(tc.expectedTaskTypes), len(resultTasks))
-			if tc.transitionHistoryEnabled {
+
+			if tc.workflowState != enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED && tc.transitionHistoryEnabled {
 				require.Equal(t, 1, len(resultTasks))
 				require.Equal(t, tc.expectedTaskTypes[0].String(), resultTasks[0].GetType().String())
 				syncVersionTask, ok := resultTasks[0].(*tasks.SyncVersionedTransitionTask)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
For closed workflow, we do not send events by default and let target to decide if event is needed.
## Why?
<!-- Tell your future self why have you made these changes -->
To stick with old logic
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no risk
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
no