### PR TITLE
Assertion function

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -160,6 +160,11 @@ func WorkflowBinaryChecksum(cs string) ZapTag {
 	return NewStringTag("wf-binary-checksum", cs)
 }
 
+// FailedAssertion returns tag for marking a message as a failed assertion.
+func FailedAssertion() ZapTag {
+	return NewBoolTag("failed-assertion", true)
+}
+
 // WorkflowActivityID returns tag for WorkflowActivityID
 func WorkflowActivityID(id string) ZapTag {
 	return NewStringTag("wf-activity-id", id)

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -568,7 +568,7 @@ func WorkerComponent(v interface{}) ZapTag {
 	return NewStringTag("worker-component", fmt.Sprintf("%T", v))
 }
 
-// FailedAssertion returns tag for marking a message as a failed assertion.
+// FailedAssertion is a tag for marking a message as a failed assertion.
 var FailedAssertion = NewBoolTag("failed-assertion", true)
 
 // history engine shard

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -160,11 +160,6 @@ func WorkflowBinaryChecksum(cs string) ZapTag {
 	return NewStringTag("wf-binary-checksum", cs)
 }
 
-// FailedAssertion returns tag for marking a message as a failed assertion.
-func FailedAssertion() ZapTag {
-	return NewBoolTag("failed-assertion", true)
-}
-
 // WorkflowActivityID returns tag for WorkflowActivityID
 func WorkflowActivityID(id string) ZapTag {
 	return NewStringTag("wf-activity-id", id)
@@ -572,6 +567,9 @@ func CertThumbprint(thumbprint string) ZapTag {
 func WorkerComponent(v interface{}) ZapTag {
 	return NewStringTag("worker-component", fmt.Sprintf("%T", v))
 }
+
+// FailedAssertion returns tag for marking a message as a failed assertion.
+var FailedAssertion = NewBoolTag("failed-assertion", true)
 
 // history engine shard
 

--- a/common/softassert/softassert.go
+++ b/common/softassert/softassert.go
@@ -44,8 +44,7 @@ import (
 func That(logger log.Logger, condition bool, format string, args ...any) bool {
 	if !condition {
 		// By using the same prefix for all assertions, they can be reliably found in logs.
-		msg := fmt.Sprintf("failed assertion: %v", fmt.Sprintf(format, args...))
-		logger.Error(msg, tag.FailedAssertion())
+		logger.Error("failed assertion: "+fmt.Sprintf(format, args...), tag.FailedAssertion())
 	}
 	return condition
 }

--- a/common/softassert/softassert.go
+++ b/common/softassert/softassert.go
@@ -1,0 +1,51 @@
+// The MIT License
+//
+// Copyright (c) 2025 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package softassert
+
+import (
+	"fmt"
+
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+)
+
+// That performs a soft assertion by logging an error if the given condition is false.
+// It is meant to indicate a condition that are always expected to be true.
+// Returns true if the condition is met, otherwise false.
+//
+// Example:
+// softassert.That(logger, object.state == "ready", "object is not ready: %v", object.state)
+//
+// Best practices:
+// - Use it to check for programming errors and invariants.
+// - Use it to communicate assumptions about the code.
+// - Use it to abort or recover from an unexpected state.
+// - Never use it as a substitute for regular error handling, validation, or control flow.
+func That(logger log.Logger, condition bool, format string, args ...any) bool {
+	if !condition {
+		// By using the same prefix for all assertions, they can be reliably found in logs.
+		msg := fmt.Sprintf("failed assertion: %v", fmt.Sprintf(format, args...))
+		logger.Error(msg, tag.FailedAssertion())
+	}
+	return condition
+}

--- a/common/softassert/softassert.go
+++ b/common/softassert/softassert.go
@@ -23,8 +23,6 @@
 package softassert
 
 import (
-	"fmt"
-
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 )
@@ -34,17 +32,17 @@ import (
 // Returns true if the condition is met, otherwise false.
 //
 // Example:
-// softassert.That(logger, object.state == "ready", "object is not ready: %v", object.state)
+// softassert.That(logger, object.state == "ready", "object is not ready")
 //
 // Best practices:
 // - Use it to check for programming errors and invariants.
 // - Use it to communicate assumptions about the code.
 // - Use it to abort or recover from an unexpected state.
 // - Never use it as a substitute for regular error handling, validation, or control flow.
-func That(logger log.Logger, condition bool, format string, args ...any) bool {
+func That(logger log.Logger, condition bool, msg string) bool {
 	if !condition {
 		// By using the same prefix for all assertions, they can be reliably found in logs.
-		logger.Error("failed assertion: "+fmt.Sprintf(format, args...), tag.FailedAssertion)
+		logger.Error("failed assertion: "+msg, tag.FailedAssertion)
 	}
 	return condition
 }

--- a/common/softassert/softassert.go
+++ b/common/softassert/softassert.go
@@ -44,7 +44,7 @@ import (
 func That(logger log.Logger, condition bool, format string, args ...any) bool {
 	if !condition {
 		// By using the same prefix for all assertions, they can be reliably found in logs.
-		logger.Error("failed assertion: "+fmt.Sprintf(format, args...), tag.FailedAssertion())
+		logger.Error("failed assertion: "+fmt.Sprintf(format, args...), tag.FailedAssertion)
 	}
 	return condition
 }

--- a/common/testing/testlogger/testlogger.go
+++ b/common/testing/testlogger/testlogger.go
@@ -1,0 +1,504 @@
+// The MIT License
+//
+// Copyright (c) 2025 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testlogger
+
+import (
+	"container/list"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+)
+
+type Level string
+
+const (
+	Debug Level = "debug"
+	Info  Level = "info"
+	Warn  Level = "warn"
+	// Panics, DPanics, and Fatal logs are considered errors
+	Error Level = "error"
+)
+
+// This is a subset of the testing.T interface that we use in this package that is
+// also shared with *rapid.T.
+type TestingT interface {
+	zaptest.TestingT
+	Helper()
+	Name() string
+	Logf(format string, args ...any)
+	Log(args ...any)
+	Fatalf(format string, args ...any)
+	Fatal(args ...any)
+}
+
+// CleanupCapable is an interface that allows a test to register cleanup functions.
+// This is /not/ implemented by *rapid.T but is by *testing.T
+type CleanupCapableT interface {
+	TestingT
+	Cleanup(func())
+}
+
+func (l Level) String() string {
+	return string(l)
+}
+
+// Expectations represent errors we expect to happen in tests.
+// Their only purpose is to allow un-expecting (hah!) an error we've
+// marked as expected
+type Expectation struct {
+	e          *list.Element
+	testLogger *TestLogger
+	lvl        Level
+	unexpected bool
+}
+
+// Forget removes a previously registered expectation.
+// It will no longer be used to determine if a log message is expected or unexpected.
+func (e *Expectation) Forget() {
+	e.testLogger.Forget(e)
+}
+
+type matcher struct {
+	expectation *Expectation
+	msg         *regexp.Regexp
+	tags        map[string]*regexp.Regexp
+}
+
+func newMatcher(msg string, tags []tag.Tag, e *Expectation) matcher {
+	var rgx *regexp.Regexp
+	if msg != "" {
+		rgx = regexp.MustCompile(msg)
+	}
+	m := matcher{
+		expectation: e,
+		msg:         rgx,
+		tags:        map[string]*regexp.Regexp{},
+	}
+	for _, t := range tags {
+		m.tags[t.Key()] = regexp.MustCompile(formatValue(t))
+	}
+	return m
+}
+
+func (m matcher) Matches(msg string, tags []tag.Tag) bool {
+	// A nil regexp (meaning original string "") means we're only matching based on tags.
+	if m.msg != nil && !m.msg.MatchString(msg) {
+		return false
+	}
+
+	if len(m.tags) == 0 {
+		return true
+	}
+
+	// We need to match all tags specified in the matcher,
+	// not all tags on the message
+	remainingMatches := len(m.tags)
+	for _, t := range tags {
+		pat, ok := m.tags[t.Key()]
+		if !ok {
+			continue
+		}
+		if pat.MatchString(formatValue(t)) {
+			remainingMatches--
+		}
+	}
+	if remainingMatches == 0 {
+		return true
+	}
+	return false
+}
+
+type SharedTestLoggerState struct {
+	failOnDPanic atomic.Bool
+	failOnError  atomic.Bool
+	t            TestingT
+	mu           struct {
+		sync.RWMutex
+		expectations   map[Level]*list.List // Map[Level]List[matcher]
+		closed         bool
+		unexpectedErrs bool
+	}
+	logExpectations bool
+	logCaller       bool
+	level           zapcore.Level
+}
+
+// TestLogger is a log.Logger implementation that logs to the test's logger
+// _but_ will fail the test if log levels _above_ Warn are present
+type TestLogger struct {
+	wrapped log.Logger
+	state   *SharedTestLoggerState
+	tags    []tag.Tag
+}
+
+type LoggerOption func(*TestLogger)
+
+func DontFailOnError(t *TestLogger) *TestLogger {
+	t.state.failOnError.Store(false)
+	return t
+}
+
+func DontFailOnDPanic(t *TestLogger) *TestLogger {
+	t.state.failOnDPanic.Store(false)
+	return t
+}
+
+func LogExpectations(t *TestLogger) *TestLogger {
+	t.state.logExpectations = true
+	return t
+}
+
+// WithLogTags adds tags to the logs emitted by the underlying logger
+func WithLogTags(tags ...tag.Tag) LoggerOption {
+	return func(t *TestLogger) {
+		t.tags = tags
+	}
+}
+
+func WrapLogger(l log.Logger) LoggerOption {
+	return func(t *TestLogger) {
+		t.wrapped = l
+	}
+}
+
+func WithoutCaller() LoggerOption {
+	return func(t *TestLogger) {
+		t.state.logCaller = false
+	}
+}
+
+// SetLogLevel overrides the temporal test log level during this test.
+func SetLogLevel(tt CleanupCapableT, level zapcore.Level) LoggerOption {
+	return func(t *TestLogger) {
+		oldLevel := os.Getenv("TEMPORAL_TEST_LOG_LEVEL")
+		_ = os.Setenv("TEMPORAL_TEST_LOG_LEVEL", level.String())
+		tt.Cleanup(func() {
+			_ = os.Setenv("TEMPORAL_TEST_LOG_LEVEL", oldLevel)
+		})
+
+		t.state.level = level
+	}
+}
+
+var _ log.Logger = (*TestLogger)(nil)
+
+// NewTestLogger creates a new TestLogger that logs to the provided testing.T.
+// By default it will fail the test if Error, or DPanic is called.
+func NewTestLogger(t TestingT, opts ...LoggerOption) *TestLogger {
+	tl := &TestLogger{
+		state: &SharedTestLoggerState{
+			t:               t,
+			logExpectations: false,
+			level:           zapcore.DebugLevel,
+			logCaller:       true,
+		},
+	}
+	tl.state.failOnError.Store(true)
+	tl.state.failOnDPanic.Store(true)
+	tl.state.mu.expectations = map[Level]*list.List{
+		Debug: list.New(),
+		Info:  list.New(),
+		Warn:  list.New(),
+		Error: list.New(),
+	}
+	for _, opt := range opts {
+		opt(tl)
+	}
+	if tl.wrapped == nil {
+		ztl := zaptest.NewLogger(t,
+			zaptest.Level(tl.state.level),
+			zaptest.WrapOptions(
+				zap.AddStacktrace(zap.ErrorLevel),
+				zap.WithCaller(tl.state.logCaller),
+			),
+		)
+		tl.wrapped = log.NewZapLogger(ztl).Skip(1)
+	}
+
+	// Only possible with a *testing.T until *rapid.T supports `Cleanup`
+	if ct, ok := t.(CleanupCapableT); ok {
+		// NOTE(tim): We don't care about anything logged after the test completes. Sure, this is racy,
+		// but it reduces the likelihood that we see stupid errors due to testing.T.Logf race conditions...
+		ct.Cleanup(tl.Close)
+	}
+
+	return tl
+}
+
+// ResetUnexpectedErrors resets the unexpected error state, returning the previous value.
+func (tl *TestLogger) ResetUnexpectedErrors() bool {
+	tl.state.mu.Lock()
+	defer tl.state.mu.Unlock()
+	prevUnexpectedLogs := tl.state.mu.unexpectedErrs
+	tl.state.mu.unexpectedErrs = false
+	return prevUnexpectedLogs
+}
+
+// Expect instructs the logger to expect certain errors, as specified by the msg and tag arguments.
+// This is useful for ignoring certain errors that are expected.
+func (tl *TestLogger) Expect(level Level, msg string, tags ...tag.Tag) *Expectation {
+	tl.state.mu.Lock()
+	defer tl.state.mu.Unlock()
+	if tl.state.logExpectations {
+		tl.wrapped.Info(fmt.Sprintf("(%p) TestLogger::Expecting: '%s'\n", tl, msg))
+	}
+	return tl.addExpectationLocked(false, level, msg, tags...)
+}
+
+// DontExpect instructs the logger to _not_ expect certain errors, as specified by the msg and tag arguments.
+// This is useful for ensuring that certain errors _do not_ occur during a test.
+func (tl *TestLogger) DontExpect(level Level, msg string, tags ...tag.Tag) *Expectation {
+	tl.state.mu.Lock()
+	defer tl.state.mu.Unlock()
+	if tl.state.logExpectations {
+		tl.wrapped.Info(fmt.Sprintf("(%p) TestLogger::NotExpecting: '%s'\n", tl, msg))
+	}
+	return tl.addExpectationLocked(true, level, msg, tags...)
+}
+
+func (tl *TestLogger) addExpectationLocked(unexpected bool, level Level, msg string, tags ...tag.Tag) *Expectation {
+	e := &Expectation{
+		testLogger: tl,
+		lvl:        level,
+		unexpected: unexpected,
+	}
+	m := newMatcher(msg, tags, e)
+	e.e = tl.state.mu.expectations[level].PushBack(m)
+	return e
+}
+
+// Forget removes a previously registered expectation.
+// It will no longer be used to determine if a log message is expected or unexpected.
+func (tl *TestLogger) Forget(e *Expectation) {
+	tl.state.mu.Lock()
+	defer tl.state.mu.Unlock()
+	tl.state.mu.expectations[e.lvl].Remove(e.e)
+}
+
+func (tl *TestLogger) isUnexpected(level Level, msg string, tags []tag.Tag) bool {
+	expectations := tl.state.mu.expectations[level]
+	for e := expectations.Front(); e != nil; e = e.Next() {
+		m, ok := e.Value.(matcher)
+		if !ok {
+			tl.state.t.Fatalf("Bug in TestLogger: invalid %T value in matcher list", e.Value)
+		}
+		if m.Matches(msg, tags) {
+			return m.expectation.unexpected
+		}
+	}
+	return false
+}
+
+// FailOnError overrides the behavior of this logger. It returns the previous value
+// so that it can be restored later.
+func (tl *TestLogger) FailOnError(v bool) bool {
+	return tl.state.failOnError.Swap(v)
+}
+
+// DPanic implements log.Logger.
+func (tl *TestLogger) DPanic(msg string, tags ...tag.Tag) {
+	tl.state.mu.RLock()
+	defer tl.state.mu.RUnlock()
+	if tl.state.mu.closed {
+		return
+	}
+	if tl.tags != nil {
+		tags = append(tags, tl.tags...)
+	}
+	// note, actual panic'ing in wrapped is turned off so we can control.
+	tl.wrapped.DPanic(msg, tags...)
+	if tl.state.failOnDPanic.Load() && tl.isUnexpected(Error, msg, tags) {
+		tl.state.t.Helper()
+		panic(failureMessage("DPanic", msg, tags))
+	}
+}
+
+// Debug implements log.Logger.
+func (tl *TestLogger) Debug(msg string, tags ...tag.Tag) {
+	tl.state.mu.RLock()
+	defer tl.state.mu.RUnlock()
+	if tl.state.mu.closed {
+		return
+	}
+	if tl.tags != nil {
+		tags = append(tags, tl.tags...)
+	}
+	_ = tl.isUnexpected(Debug, msg, tags)
+	tl.wrapped.Debug(msg, append(tags, tl.tags...)...)
+}
+
+// Error implements log.Logger.
+func (tl *TestLogger) Error(msg string, tags ...tag.Tag) {
+	tl.state.mu.RLock()
+	if tl.state.mu.closed {
+		tl.state.mu.RUnlock()
+		return
+	}
+	if tl.tags != nil {
+		tags = append(tags, tl.tags...)
+	}
+	if !tl.isUnexpected(Error, msg, tags) {
+		tl.wrapped.Error(msg, tags...)
+		tl.state.mu.RUnlock()
+		return
+	}
+	tl.state.mu.RUnlock()
+
+	if tl.state.failOnError.Load() {
+		tl.state.t.Helper()
+		tl.wrapped.Error(msg, tags...)
+		panic(failureMessage("Error", msg, tags))
+	}
+
+	// Labeling the error as unexpected; so it can be found later.
+	tl.wrapped.Error(errorMessage("Error", msg), tags...)
+	tl.state.mu.Lock()
+	tl.state.mu.unexpectedErrs = true
+	tl.state.mu.Unlock()
+}
+
+// Fatal implements log.Logger.
+func (tl *TestLogger) Fatal(msg string, tags ...tag.Tag) {
+	tl.state.mu.RLock()
+	defer tl.state.mu.RUnlock()
+	if tl.state.mu.closed {
+		return
+	}
+	if tl.tags != nil {
+		tags = append(tags, tl.tags...)
+	}
+	tl.state.t.Helper()
+	tl.state.t.Fatal(failureMessage("Fatal", msg, tags))
+}
+
+// Info implements log.Logger.
+func (tl *TestLogger) Info(msg string, tags ...tag.Tag) {
+	tl.state.mu.RLock()
+	defer tl.state.mu.RUnlock()
+	if tl.state.mu.closed {
+		return
+	}
+	if tl.tags != nil {
+		tags = append(tags, tl.tags...)
+	}
+	_ = tl.isUnexpected(Info, msg, tags)
+	tl.wrapped.Info(msg, tags...)
+}
+
+// Panic implements log.Logger.
+func (tl *TestLogger) Panic(msg string, tags ...tag.Tag) {
+	tl.state.mu.RLock()
+	defer tl.state.mu.RUnlock()
+	if tl.state.mu.closed {
+		return
+	}
+	if tl.tags != nil {
+		tags = append(tags, tl.tags...)
+	}
+	tl.state.t.Helper()
+	tl.state.t.Fatal(failureMessage("Panic", msg, tags))
+}
+
+// Warn implements log.Logger.
+func (tl *TestLogger) Warn(msg string, tags ...tag.Tag) {
+	tl.state.mu.RLock()
+	defer tl.state.mu.RUnlock()
+	if tl.state.mu.closed {
+		return
+	}
+	if tl.tags != nil {
+		tags = append(tags, tl.tags...)
+	}
+	_ = tl.isUnexpected(Warn, msg, tags)
+	tl.wrapped.Warn(msg, tags...)
+}
+
+// WithTags gives you a new logger, copying the tags of the source, appending the provided new Tags
+func (tl *TestLogger) WithTags(tags ...tag.Tag) *TestLogger {
+	allTags := make([]tag.Tag, len(tl.tags)+len(tags))
+	copy(allTags, tl.tags)
+	copy(allTags[len(tl.tags):], tags)
+	newtl := &TestLogger{
+		wrapped: tl.wrapped,
+		state:   tl.state,
+		tags:    allTags,
+	}
+	return newtl
+}
+
+// Close disallows any further logging, preventing the test framework from complaining about
+// logging post-test.
+func (tl *TestLogger) Close() {
+	// Taking the write lock ensures all in-progress log calls complete before we close.
+	// This prevents a race condition after the test has completed.
+	tl.state.mu.Lock()
+	tl.state.mu.closed = true
+	tl.state.mu.Unlock()
+}
+
+func (tl *TestLogger) T() TestingT {
+	return tl.state.t
+}
+
+// Format the log.Logger tags and such into a useful message
+func failureMessage(level string, msg string, tags []tag.Tag) string {
+	var b strings.Builder
+	b.WriteString("FAIL: ")
+	b.WriteString(errorMessage(level, msg))
+	for _, t := range tags {
+		b.WriteString(t.Key())
+		b.WriteString("=")
+		b.WriteString(formatValue(t))
+		b.WriteString(" ")
+	}
+	return b.String()
+}
+
+func errorMessage(level string, msg string) string {
+	var b strings.Builder
+	b.WriteString("Unexpected ")
+	b.WriteString(level)
+	b.WriteString(" log encountered: ")
+	b.WriteString(msg)
+	return b.String()
+}
+
+func formatValue(t tag.Tag) string {
+	switch v := t.Value().(type) {
+	case fmt.Stringer:
+		return v.String()
+	case string:
+		return v
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/common/testing/testlogger/testlogger.go
+++ b/common/testing/testlogger/testlogger.go
@@ -131,10 +131,7 @@ func (m matcher) Matches(msg string, tags []tag.Tag) bool {
 			remainingMatches--
 		}
 	}
-	if remainingMatches == 0 {
-		return true
-	}
-	return false
+	return remainingMatches == 0
 }
 
 type SharedTestLoggerState struct {

--- a/common/testing/testlogger/testlogger.go
+++ b/common/testing/testlogger/testlogger.go
@@ -82,7 +82,7 @@ type Expectation struct {
 }
 
 // Forget removes a previously registered expectation.
-// It will no longer be used to determine if a log message is expected or unexpected.
+// A forgotten expectation will no longer be evaluated when errors are encountered.
 func (e *Expectation) Forget() {
 	e.testLogger.Forget(e)
 }

--- a/common/testing/testlogger/testlogger.go
+++ b/common/testing/testlogger/testlogger.go
@@ -301,7 +301,7 @@ func (tl *TestLogger) Forget(e *Expectation) {
 	tl.state.mu.expectations[e.lvl].Remove(e.e)
 }
 
-func (tl *TestLogger) isUnexpected(level Level, msg string, tags []tag.Tag) bool {
+func (tl *TestLogger) shouldFailTest(level Level, msg string, tags []tag.Tag) bool {
 	expectations := tl.state.mu.expectations[level]
 	for e := expectations.Front(); e != nil; e = e.Next() {
 		m, ok := e.Value.(matcher)
@@ -333,7 +333,7 @@ func (tl *TestLogger) DPanic(msg string, tags ...tag.Tag) {
 	}
 	// note, actual panic'ing in wrapped is turned off so we can control.
 	tl.wrapped.DPanic(msg, tags...)
-	if tl.state.failOnDPanic.Load() && tl.isUnexpected(Error, msg, tags) {
+	if tl.state.failOnDPanic.Load() && tl.shouldFailTest(Error, msg, tags) {
 		tl.state.t.Helper()
 		panic(failureMessage("DPanic", msg, tags))
 	}
@@ -349,7 +349,7 @@ func (tl *TestLogger) Debug(msg string, tags ...tag.Tag) {
 	if tl.tags != nil {
 		tags = append(tags, tl.tags...)
 	}
-	_ = tl.isUnexpected(Debug, msg, tags)
+	_ = tl.shouldFailTest(Debug, msg, tags)
 	tl.wrapped.Debug(msg, append(tags, tl.tags...)...)
 }
 
@@ -363,7 +363,7 @@ func (tl *TestLogger) Error(msg string, tags ...tag.Tag) {
 	if tl.tags != nil {
 		tags = append(tags, tl.tags...)
 	}
-	if !tl.isUnexpected(Error, msg, tags) {
+	if !tl.shouldFailTest(Error, msg, tags) {
 		tl.wrapped.Error(msg, tags...)
 		tl.state.mu.RUnlock()
 		return
@@ -407,7 +407,7 @@ func (tl *TestLogger) Info(msg string, tags ...tag.Tag) {
 	if tl.tags != nil {
 		tags = append(tags, tl.tags...)
 	}
-	_ = tl.isUnexpected(Info, msg, tags)
+	_ = tl.shouldFailTest(Info, msg, tags)
 	tl.wrapped.Info(msg, tags...)
 }
 
@@ -435,7 +435,7 @@ func (tl *TestLogger) Warn(msg string, tags ...tag.Tag) {
 	if tl.tags != nil {
 		tags = append(tags, tl.tags...)
 	}
-	_ = tl.isUnexpected(Warn, msg, tags)
+	_ = tl.shouldFailTest(Warn, msg, tags)
 	tl.wrapped.Warn(msg, tags...)
 }
 

--- a/common/testing/testlogger/testlogger.go
+++ b/common/testing/testlogger/testlogger.go
@@ -360,7 +360,6 @@ func (tl *TestLogger) Debug(msg string, tags ...tag.Tag) {
 	if tl.tags != nil {
 		tags = append(tags, tl.tags...)
 	}
-	_ = tl.shouldFailTest(Debug, msg, tags)
 	tl.wrapped.Debug(msg, append(tags, tl.tags...)...)
 }
 
@@ -420,7 +419,6 @@ func (tl *TestLogger) Info(msg string, tags ...tag.Tag) {
 	if tl.tags != nil {
 		tags = append(tags, tl.tags...)
 	}
-	_ = tl.shouldFailTest(Info, msg, tags)
 	tl.wrapped.Info(msg, tags...)
 }
 
@@ -448,7 +446,6 @@ func (tl *TestLogger) Warn(msg string, tags ...tag.Tag) {
 	if tl.tags != nil {
 		tags = append(tags, tl.tags...)
 	}
-	_ = tl.shouldFailTest(Warn, msg, tags)
 	tl.wrapped.Warn(msg, tags...)
 }
 

--- a/common/testing/testlogger/testlogger.go
+++ b/common/testing/testlogger/testlogger.go
@@ -198,7 +198,19 @@ func WrapLogger(l log.Logger) LoggerOption {
 	}
 }
 
+func LogLevel(level zapcore.Level) LoggerOption {
+	return func(t *TestLogger) {
+		t.state.level = level
+	}
+}
+
 func WithoutCaller() LoggerOption {
+	return func(t *TestLogger) {
+		t.state.logCaller = false
+	}
+}
+
+func LogCaller() LoggerOption {
 	return func(t *TestLogger) {
 		t.state.logCaller = false
 	}

--- a/tests/deployment_test.go
+++ b/tests/deployment_test.go
@@ -117,10 +117,10 @@ func (s *DeploymentSuite) SetupTest() {
 }
 
 func (s *DeploymentSuite) TearDownTest() {
-	s.FunctionalTestBase.TearDownTest()
 	if s.sdkClient != nil {
 		s.sdkClient.Close()
 	}
+	s.FunctionalTestBase.TearDownTest()
 }
 
 // pollFromDeployment calls PollWorkflowTaskQueue to start deployment related workflows

--- a/tests/deployment_test.go
+++ b/tests/deployment_test.go
@@ -117,6 +117,7 @@ func (s *DeploymentSuite) SetupTest() {
 }
 
 func (s *DeploymentSuite) TearDownTest() {
+	s.FunctionalTestBase.TearDownTest()
 	if s.sdkClient != nil {
 		s.sdkClient.Close()
 	}

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -105,6 +105,7 @@ func (s *ScheduleFunctionalSuite) SetupTest() {
 }
 
 func (s *ScheduleFunctionalSuite) TearDownTest() {
+	s.FunctionalTestBase.TearDownTest()
 	if s.worker != nil {
 		s.worker.Stop()
 	}

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -105,13 +105,13 @@ func (s *ScheduleFunctionalSuite) SetupTest() {
 }
 
 func (s *ScheduleFunctionalSuite) TearDownTest() {
-	s.FunctionalTestBase.TearDownTest()
 	if s.worker != nil {
 		s.worker.Stop()
 	}
 	if s.sdkClient != nil {
 		s.sdkClient.Close()
 	}
+	s.FunctionalTestBase.TearDownTest()
 }
 
 func (s *ScheduleFunctionalSuite) TestBasics() {

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -199,20 +199,14 @@ func (s *FunctionalTestBase) SetupSuiteWithDefaultCluster(options ...TestCluster
 func (s *FunctionalTestBase) SetupSuiteWithCluster(clusterConfigFile string, options ...TestClusterOption) {
 	params := ApplyTestClusterOptions(options)
 
-	// Logger might be already set by the test suite.
-	if s.Logger == nil {
-		tl := testlogger.NewTestLogger(s.T())
-
-		// Instead of failing immediately, TearDownTest will check for unexpected
-		// errors after each test completed. This is better since otherwise is would fail inside
-		// the server and not the test, creating a lot of noise and possibly stuck tests.
-		testlogger.DontFailOnError(tl)
-
-		// Fail test when an assertion fails (see `softassert` package).
-		tl.DontExpect(testlogger.Error, ".*", tag.FailedAssertion())
-
-		s.Logger = tl
-	}
+	tl := testlogger.NewTestLogger(s.T())
+	// Instead of failing immediately, TearDownTest will check for unexpected
+	// errors after each test completed. This is better since otherwise is would fail inside
+	// the server and not the test, creating a lot of noise and possibly stuck tests.
+	testlogger.DontFailOnError(tl)
+	// Fail test when an assertion fails (see `softassert` package).
+	tl.DontExpect(testlogger.Error, ".*", tag.FailedAssertion())
+	s.Logger = tl
 
 	// Setup test cluster.
 	var err error

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -273,7 +273,6 @@ func (s *FunctionalTestBase) initAssertions() {
 	s.ProtoAssertions = protorequire.New(s.T())
 	s.HistoryRequire = historyrequire.New(s.T())
 	s.UpdateUtils = updateutils.New(s.T())
-	s.checkNoUnexpectedErrorLogs() // should have already been called in TearDownTest, but just in case
 }
 
 // checkTestShard supports test sharding based on environment variables.
@@ -368,6 +367,10 @@ func (s *FunctionalTestBase) TearDownCluster() {
 }
 
 func (s *FunctionalTestBase) TearDownTest() {
+	s.checkNoUnexpectedErrorLogs()
+}
+
+func (s *FunctionalTestBase) TearDownSubTest() {
 	s.checkNoUnexpectedErrorLogs()
 }
 

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -199,13 +199,13 @@ func (s *FunctionalTestBase) SetupSuiteWithDefaultCluster(options ...TestCluster
 func (s *FunctionalTestBase) SetupSuiteWithCluster(clusterConfigFile string, options ...TestClusterOption) {
 	params := ApplyTestClusterOptions(options)
 
-	tl := testlogger.NewTestLogger(s.T())
-	// Instead of failing immediately, TearDownTest will check for unexpected
-	// errors after each test completed. This is better since otherwise is would fail inside
+	tl := testlogger.NewTestLogger(s.T(), testlogger.FailOnExpectedErrorOnly)
+	// Instead of panic'ing immediately, TearDownTest will check if the test logger failed
+	// after each test completed. This is better since otherwise is would fail inside
 	// the server and not the test, creating a lot of noise and possibly stuck tests.
-	testlogger.DontFailOnError(tl)
+	testlogger.DontPanicOnError(tl)
 	// Fail test when an assertion fails (see `softassert` package).
-	tl.DontExpect(testlogger.Error, ".*", tag.FailedAssertion)
+	tl.Expect(testlogger.Error, ".*", tag.FailedAssertion)
 	s.Logger = tl
 
 	// Setup test cluster.

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -199,14 +199,17 @@ func (s *FunctionalTestBase) SetupSuiteWithDefaultCluster(options ...TestCluster
 func (s *FunctionalTestBase) SetupSuiteWithCluster(clusterConfigFile string, options ...TestClusterOption) {
 	params := ApplyTestClusterOptions(options)
 
-	tl := testlogger.NewTestLogger(s.T(), testlogger.FailOnExpectedErrorOnly)
-	// Instead of panic'ing immediately, TearDownTest will check if the test logger failed
-	// after each test completed. This is better since otherwise is would fail inside
-	// the server and not the test, creating a lot of noise and possibly stuck tests.
-	testlogger.DontPanicOnError(tl)
-	// Fail test when an assertion fails (see `softassert` package).
-	tl.Expect(testlogger.Error, ".*", tag.FailedAssertion)
-	s.Logger = tl
+	// NOTE: A suite might set its own logger. Example: AcquireShardSuiteBase.
+	if s.Logger == nil {
+		tl := testlogger.NewTestLogger(s.T(), testlogger.FailOnExpectedErrorOnly)
+		// Instead of panic'ing immediately, TearDownTest will check if the test logger failed
+		// after each test completed. This is better since otherwise is would fail inside
+		// the server and not the test, creating a lot of noise and possibly stuck tests.
+		testlogger.DontPanicOnError(tl)
+		// Fail test when an assertion fails (see `softassert` package).
+		tl.Expect(testlogger.Error, ".*", tag.FailedAssertion)
+		s.Logger = tl
+	}
 
 	// Setup test cluster.
 	var err error

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -367,10 +367,12 @@ func (s *FunctionalTestBase) TearDownCluster() {
 	}
 }
 
+// **IMPORTANT**: When overridding this, make sure to invoke `s.FunctionalTestBase.TearDownTest()`.
 func (s *FunctionalTestBase) TearDownTest() {
 	s.checkNoUnexpectedErrorLogs()
 }
 
+// **IMPORTANT**: When overridding this, make sure to invoke `s.FunctionalTestBase.TearDownSubTest()`.
 func (s *FunctionalTestBase) TearDownSubTest() {
 	s.checkNoUnexpectedErrorLogs()
 }

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -205,7 +205,7 @@ func (s *FunctionalTestBase) SetupSuiteWithCluster(clusterConfigFile string, opt
 	// the server and not the test, creating a lot of noise and possibly stuck tests.
 	testlogger.DontFailOnError(tl)
 	// Fail test when an assertion fails (see `softassert` package).
-	tl.DontExpect(testlogger.Error, ".*", tag.FailedAssertion())
+	tl.DontExpect(testlogger.Error, ".*", tag.FailedAssertion)
 	s.Logger = tl
 
 	// Setup test cluster.
@@ -373,7 +373,7 @@ func (s *FunctionalTestBase) TearDownSubTest() {
 
 func (s *FunctionalTestBase) checkNoUnexpectedErrorLogs() {
 	if tl, ok := s.Logger.(*testlogger.TestLogger); ok {
-		if tl.ResetUnexpectedErrors() {
+		if tl.ResetFailureStatus() {
 			s.Fail(`Failing test as unexpected error logs were found.
 Look for 'Unexpected Error log encountered'.`)
 		}

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -254,11 +254,13 @@ func (s *FunctionalTestBase) SetupSuiteWithCluster(clusterConfigFile string, opt
 // into partitions. Otherwise, the test suite will be executed multiple times
 // in each partition.
 func (s *FunctionalTestBase) SetupTest() {
+	s.checkNoUnexpectedErrorLogs() // make sure the previous test was cleaned up properly
 	s.checkTestShard()
 	s.initAssertions()
 }
 
 func (s *FunctionalTestBase) SetupSubTest() {
+	s.checkNoUnexpectedErrorLogs() // make sure the previous sub test was cleaned up properly
 	s.initAssertions()
 }
 

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -254,7 +254,6 @@ func (s *FunctionalTestBase) SetupSuiteWithCluster(clusterConfigFile string, opt
 // into partitions. Otherwise, the test suite will be executed multiple times
 // in each partition.
 func (s *FunctionalTestBase) SetupTest() {
-	s.checkNoUnexpectedErrorLogs() // make sure the previous test was cleaned up properly
 	s.checkTestShard()
 	s.initAssertions()
 }

--- a/tests/testcore/functional_test_sdk_suite.go
+++ b/tests/testcore/functional_test_sdk_suite.go
@@ -118,6 +118,7 @@ func (s *FunctionalTestSdkSuite) SetupTest() {
 }
 
 func (s *FunctionalTestSdkSuite) TearDownTest() {
+	s.FunctionalTestBase.TearDownTest()
 	if s.worker != nil {
 		s.worker.Stop()
 	}

--- a/tests/testcore/functional_test_sdk_suite.go
+++ b/tests/testcore/functional_test_sdk_suite.go
@@ -118,13 +118,13 @@ func (s *FunctionalTestSdkSuite) SetupTest() {
 }
 
 func (s *FunctionalTestSdkSuite) TearDownTest() {
-	s.FunctionalTestBase.TearDownTest()
 	if s.worker != nil {
 		s.worker.Stop()
 	}
 	if s.sdkClient != nil {
 		s.sdkClient.Close()
 	}
+	s.FunctionalTestBase.TearDownTest()
 }
 
 func (s *FunctionalTestSdkSuite) EventuallySucceeds(ctx context.Context, operationCtx backoff.OperationCtx) {

--- a/tests/tls_test.go
+++ b/tests/tls_test.go
@@ -72,6 +72,7 @@ func (s *TLSFunctionalSuite) SetupTest() {
 }
 
 func (s *TLSFunctionalSuite) TearDownTest() {
+	s.FunctionalTestBase.TearDownTest()
 	if s.sdkClient != nil {
 		s.sdkClient.Close()
 	}

--- a/tests/tls_test.go
+++ b/tests/tls_test.go
@@ -72,10 +72,10 @@ func (s *TLSFunctionalSuite) SetupTest() {
 }
 
 func (s *TLSFunctionalSuite) TearDownTest() {
-	s.FunctionalTestBase.TearDownTest()
 	if s.sdkClient != nil {
 		s.sdkClient.Close()
 	}
+	s.FunctionalTestBase.TearDownTest()
 }
 
 func (s *TLSFunctionalSuite) TestGRPCMTLS() {

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -138,6 +138,7 @@ func (s *VersioningIntegSuite) SetupTest() {
 }
 
 func (s *VersioningIntegSuite) TearDownTest() {
+	s.FunctionalTestBase.TearDownTest()
 	if s.sdkClient != nil {
 		s.sdkClient.Close()
 	}

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -138,10 +138,10 @@ func (s *VersioningIntegSuite) SetupTest() {
 }
 
 func (s *VersioningIntegSuite) TearDownTest() {
-	s.FunctionalTestBase.TearDownTest()
 	if s.sdkClient != nil {
 		s.sdkClient.Close()
 	}
+	s.FunctionalTestBase.TearDownTest()
 }
 
 func (s *VersioningIntegSuite) TestVersionRuleConflictToken() {

--- a/tests/worker_deployment_version_test.go
+++ b/tests/worker_deployment_version_test.go
@@ -110,10 +110,10 @@ func (s *DeploymentVersionSuite) SetupTest() {
 }
 
 func (s *DeploymentVersionSuite) TearDownTest() {
-	s.FunctionalTestBase.TearDownTest()
 	if s.sdkClient != nil {
 		s.sdkClient.Close()
 	}
+	s.FunctionalTestBase.TearDownTest()
 }
 
 // pollFromDeployment calls PollWorkflowTaskQueue to start deployment related workflows

--- a/tests/worker_deployment_version_test.go
+++ b/tests/worker_deployment_version_test.go
@@ -110,6 +110,7 @@ func (s *DeploymentVersionSuite) SetupTest() {
 }
 
 func (s *DeploymentVersionSuite) TearDownTest() {
+	s.FunctionalTestBase.TearDownTest()
 	if s.sdkClient != nil {
 		s.sdkClient.Close()
 	}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

- Added a new function `softassert.That` that logs an error if the provided condition is false
- Added `testlogger.Testlogger` (copied and slightly modified from our internal repository) to functional tests

## Why?
<!-- Tell your future self why have you made these changes -->

To allow developers to verify pre- and post-conditions in their code.

**Why not panic?** Maybe in the future. For now, we're happy with finding these failed assertions in functional tests.

**What about nightlies/long-haul tests?** I've filed a ticket to detect a failed assertion there and surface them as an alert.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Planted a failing assertion.

**The error log:**
```
logger.go:146: 2025-03-04T20:50:08.578Z	ERROR	log/zap_logger.go:154	Unexpected Error log encountered: failed assertion: wake called twice	{"host": "127.0.0.1:35427", "component": "matching-engine", "wf-task-queue-name": "/_sys/temporal-sys-processor-parent-close-policy/1", "wf-task-queue-type": "Workflow", "wf-namespace": "temporal-system", "worker-build-id": "_unversioned_", "failed-assertion": true, "logging-call-at": "/home/runner/work/temporal/temporal/common/log/with_logger.go:72"}
        go.temporal.io/server/common/log.(*zapLogger).Error
        	/home/runner/work/temporal/temporal/common/log/zap_logger.go:154
        go.temporal.io/server/common/testing/testlogger.(*TestLogger).Error
        	/home/runner/work/temporal/temporal/common/testing/testlogger/testlogger.go:359
        go.temporal.io/server/common/log.(*withLogger).Error
        	/home/runner/work/temporal/temporal/common/log/with_logger.go:72
        go.temporal.io/server/common/log.(*withLogger).Error
        	/home/runner/work/temporal/temporal/common/log/with_logger.go:72
        go.temporal.io/server/common/log.(*withLogger).Error
        	/home/runner/work/temporal/temporal/common/log/with_logger.go:72
        go.temporal.io/server/common/log.(*withLogger).Error
        	/home/runner/work/temporal/temporal/common/log/with_logger.go:72
        go.temporal.io/server/common/softassert.That
        	/home/runner/work/temporal/temporal/common/softassert/softassert.go:50
        go.temporal.io/server/service/matching.(*waitableMatchResult).wake
        	/home/runner/work/temporal/temporal/service/matching/matcher_data.go:560
```

https://github.com/temporalio/temporal/actions/runs/13662479940/job/38196953773?pr=7411#step:9:1638

**The test result:**
```
=== Failed
=== FAIL: tests TestPriorityFairnessSuite/TestPriority_Activity_Basic (0.00s)
    functional_test_base.go:301: Running TestPriorityFairnessSuite/TestPriority_Activity_Basic in test shard 2/3
    functional_test_base.go:373: 
        	Error Trace:	/home/runner/work/temporal/temporal/tests/testcore/functional_test_base.go:373
        	            				/home/runner/work/temporal/temporal/tests/testcore/functional_test_base.go:272
        	            				/home/runner/work/temporal/temporal/tests/testcore/functional_test_base.go:254
        	            				/home/runner/work/temporal/temporal/tests/testcore/functional_test_sdk_suite.go:97
        	            				/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.10.0/suite/suite.go:192
        	Error:      	Failing test as unexpected error logs were found.
        	            	Look for 'Unexpected Error log encountered'.
        	Test:       	TestPriorityFairnessSuite/TestPriority_Activity_Basic
```
https://github.com/temporalio/temporal/actions/runs/13662479940/job/38196953773?pr=7411#step:9:1053


## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
