### PR TITLE
Matching unit test cleanup

### DIFF
--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -41,48 +41,6 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-/* TODO: I can't figure out what these tests are testing
-
-func TestDeliverBufferTasks(t *testing.T) {
-	controller := gomock.NewController(t)
-
-	tests := []func(tlm *physicalTaskQueueManagerImpl){
-		func(tlm *physicalTaskQueueManagerImpl) { close(tlm.backlogMgr.taskReader.taskBuffer) },
-		func(tlm *physicalTaskQueueManagerImpl) { tlm.tqCtxCancel() },
-		func(tlm *physicalTaskQueueManagerImpl) {
-			rps := 0.1
-			tlm.matcher.UpdateRatelimit(rps)
-			tlm.backlogMgr.taskReader.taskBuffer <- &persistencespb.AllocatedTaskInfo{
-				Data: &persistencespb.TaskInfo{},
-			}
-			err := tlm.oldMatcher.rateLimiter.Wait(context.Background()) // consume the token
-			assert.NoError(t, err)
-			tlm.tqCtxCancel()
-		},
-	}
-	for _, test := range tests {
-		// TODO: do not create pq manager, directly create backlog manager
-		tlm := mustCreateTestPhysicalTaskQueueManager(t, controller)
-		go tlm.backlogMgr.taskReader.dispatchBufferedTasks()
-		test(tlm)
-		// dispatchBufferedTasks should stop after invocation of the test function
-	}
-}
-
-func TestDeliverBufferTasks_NoPollers(t *testing.T) {
-	controller := gomock.NewController(t)
-
-	// TODO: do not create pq manager, directly create backlog manager
-	tlm := mustCreateTestPhysicalTaskQueueManager(t, controller)
-	tlm.backlogMgr.taskReader.taskBuffer <- &persistencespb.AllocatedTaskInfo{
-		Data: &persistencespb.TaskInfo{},
-	}
-	go tlm.backlogMgr.taskReader.dispatchBufferedTasks()
-	time.Sleep(100 * time.Millisecond) // let go routine run first and block on tasksForPoll
-	tlm.tqCtxCancel()
-}
-*/
-
 func TestReadLevelForAllExpiredTasksInBatch(t *testing.T) {
 	controller := gomock.NewController(t)
 

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -74,65 +74,6 @@ func defaultTqmTestOpts(controller *gomock.Controller) *tqmTestOpts {
 	}
 }
 
-type testIDBlockAlloc struct {
-	rid   int64
-	alloc func() (taskQueueState, error)
-}
-
-func (a *testIDBlockAlloc) RangeID() int64 {
-	return a.rid
-}
-
-func (a *testIDBlockAlloc) RenewLease(_ context.Context) (taskQueueState, error) {
-	s, err := a.alloc()
-	if err == nil {
-		a.rid = s.rangeID
-	}
-	return s, err
-}
-
-func makeTestBlocAlloc(f func() (taskQueueState, error)) taskQueueManagerOpt {
-	return withIDBlockAllocator(&testIDBlockAlloc{alloc: f})
-}
-
-func withIDBlockAllocator(ibl idBlockAllocator) taskQueueManagerOpt {
-	return func(tqm *physicalTaskQueueManagerImpl) {
-		blm := tqm.backlogMgr.(*backlogManagerImpl)
-		blm.taskWriter.idAlloc = ibl
-	}
-}
-
-/* TODO(pri): test is too awkward to fix and low value
-func TestForeignPartitionOwnerCausesUnload(t *testing.T) {
-	cfg := NewConfig(dynamicconfig.NewNoopCollection())
-	cfg.RangeSize = 1 // TaskID block size
-	var leaseErr error
-	tqm := mustCreateTestPhysicalTaskQueueManager(t, gomock.NewController(t),
-		makeTestBlocAlloc(func() (taskQueueState, error) {
-			return taskQueueState{rangeID: 1}, leaseErr
-		}))
-	tqm.Start()
-	defer tqm.Stop(unloadCauseUnspecified)
-
-	// TQM started succesfully with an ID block of size 1. Perform one send
-	// without a poller to consume the one task ID from the reserved block.
-	err := tqm.SpoolTask(&persistencespb.TaskInfo{
-		CreateTime: timestamp.TimePtr(time.Now().UTC()),
-	})
-	require.NoError(t, err)
-
-	// TQM's ID block should be empty so the next AddTask will trigger an
-	// attempt to obtain more IDs. This specific error type indicates that
-	// another service instance has become the owner of the partition
-	leaseErr = &persistence.ConditionFailedError{Msg: "should kill the tqm"}
-
-	err = tqm.SpoolTask(&persistencespb.TaskInfo{
-		CreateTime: timestamp.TimePtr(time.Now().UTC()),
-	})
-	require.NoError(t, err)
-}
-*/
-
 /*
 TODO(pri): rewrite or delete this test
 func TestReaderSignaling(t *testing.T) {

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -27,7 +27,6 @@ package matching
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
@@ -58,19 +57,14 @@ type (
 		end   int64
 	}
 
-	idBlockAllocator interface {
-		RenewLease(context.Context) (taskQueueState, error)
-		RangeID() int64
-	}
-
 	// taskWriter writes tasks sequentially to persistence
 	taskWriter struct {
 		backlogMgr  *backlogManagerImpl
 		config      *taskQueueConfig
+		db          *taskQueueDB
+		logger      log.Logger
 		appendCh    chan *writeTaskRequest
 		taskIDBlock taskIDBlock
-		logger      log.Logger
-		idAlloc     idBlockAllocator
 	}
 )
 
@@ -88,10 +82,10 @@ func newTaskWriter(
 	return &taskWriter{
 		backlogMgr:  backlogMgr,
 		config:      backlogMgr.config,
+		db:          backlogMgr.db,
+		logger:      backlogMgr.logger,
 		appendCh:    make(chan *writeTaskRequest, backlogMgr.config.OutstandingTaskAppendsThreshold()),
 		taskIDBlock: noTaskIDs,
-		logger:      backlogMgr.logger,
-		idAlloc:     backlogMgr.db,
 	}
 }
 
@@ -176,7 +170,7 @@ func (w *taskWriter) appendTasks(
 	reqs []*writeTaskRequest,
 ) (*persistence.CreateTasksResponse, error) {
 
-	resp, err := w.backlogMgr.db.CreateTasks(w.backlogMgr.tqCtx, taskIDs, reqs)
+	resp, err := w.db.CreateTasks(w.backlogMgr.tqCtx, taskIDs, reqs)
 	if err != nil {
 		w.backlogMgr.signalIfFatal(err)
 		w.logger.Error("Persistent store operation failure",
@@ -252,7 +246,7 @@ func (w *taskWriter) renewLeaseWithRetry(
 ) (taskQueueState, error) {
 	var newState taskQueueState
 	op := func(ctx context.Context) (err error) {
-		newState, err = w.idAlloc.RenewLease(ctx)
+		newState, err = w.db.RenewLease(ctx)
 		return
 	}
 	metrics.LeaseRequestPerTaskQueueCounter.With(w.backlogMgr.metricsHandler).Record(1)
@@ -265,15 +259,9 @@ func (w *taskWriter) renewLeaseWithRetry(
 }
 
 func (w *taskWriter) allocTaskIDBlock(prevBlockEnd int64) (taskIDBlock, error) {
-	currBlock := rangeIDToTaskIDBlock(w.idAlloc.RangeID(), w.config.RangeSize)
+	currBlock := rangeIDToTaskIDBlock(w.db.RangeID(), w.config.RangeSize)
 	if currBlock.end != prevBlockEnd {
-		return taskIDBlock{},
-			fmt.Errorf(
-				"%w: allocTaskIDBlock: invalid state: prevBlockEnd:%v != currTaskIDBlock:%+v",
-				errNonContiguousBlocks,
-				prevBlockEnd,
-				currBlock,
-			)
+		return taskIDBlock{}, errNonContiguousBlocks
 	}
 	state, err := w.renewLeaseWithRetry(persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
 	if err != nil {


### PR DESCRIPTION
## What changed?
- Remove idBlockAllocator interface
- Remove confusing/low-value unit tests

## Why?
Simpler tests