### PR TITLE
Support updating closed workflows by mutation

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1430,6 +1430,12 @@ HistoryCacheSizeBasedLimit is set to true.`,
 		`EnableWorkflowExecutionTimeoutTimer controls whether to enable the new logic for generating a workflow execution
 timeout timer when execution timeout is specified when starting a workflow.`,
 	)
+	EnableUpdateClosedWorkflowByMutation = NewGlobalBoolSetting(
+		"history.enableUpdateClosedWorkflowByMutation",
+		true,
+		`EnableUpdateClosedWorkflowByMutation controls whether to enable the new logic for updating closed workflow execution
+by mutation using UpdateWorkflowModeSkipCurrent`,
+	)
 	EnableTransitionHistory = NewGlobalBoolSetting(
 		"history.enableTransitionHistory",
 		false,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1430,11 +1430,11 @@ HistoryCacheSizeBasedLimit is set to true.`,
 		`EnableWorkflowExecutionTimeoutTimer controls whether to enable the new logic for generating a workflow execution
 timeout timer when execution timeout is specified when starting a workflow.`,
 	)
-	EnableUpdateClosedWorkflowByMutation = NewGlobalBoolSetting(
-		"history.enableUpdateClosedWorkflowByMutation",
+	EnableUpdateWorkflowModeIgnoreCurrent = NewGlobalBoolSetting(
+		"history.enableUpdateWorkflowModeIgnoreCurrent",
 		true,
-		`EnableUpdateClosedWorkflowByMutation controls whether to enable the new logic for updating closed workflow execution
-by mutation using UpdateWorkflowModeSkipCurrent`,
+		`EnableUpdateWorkflowModeIgnoreCurrent controls whether to enable the new logic for updating closed workflow execution
+by mutation using UpdateWorkflowModeIgnoreCurrent`,
 	)
 	EnableTransitionHistory = NewGlobalBoolSetting(
 		"history.enableTransitionHistory",

--- a/common/persistence/cassandra/mutable_state_store.go
+++ b/common/persistence/cassandra/mutable_state_store.go
@@ -626,7 +626,7 @@ func (d *MutableStateStore) UpdateWorkflowExecution(
 	shardID := request.ShardID
 
 	switch request.Mode {
-	case p.UpdateWorkflowModeSkipCurrent:
+	case p.UpdateWorkflowModeIgnoreCurrent:
 		// noop
 
 	case p.UpdateWorkflowModeBypassCurrent:

--- a/common/persistence/cassandra/mutable_state_store.go
+++ b/common/persistence/cassandra/mutable_state_store.go
@@ -626,6 +626,9 @@ func (d *MutableStateStore) UpdateWorkflowExecution(
 	shardID := request.ShardID
 
 	switch request.Mode {
+	case p.UpdateWorkflowModeSkipCurrent:
+		// noop
+
 	case p.UpdateWorkflowModeBypassCurrent:
 		if err := d.assertNotCurrentExecution(
 			ctx,

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -82,12 +82,12 @@ const (
 	// UpdateWorkflowModeBypassCurrent update workflow, without current record
 	// NOTE: current record CANNOT point to the workflow to be updated
 	UpdateWorkflowModeBypassCurrent
-	// UpdateWorkflowModeSkipCurrent update workflow, without checking or update current record
-	// This mode should only be used when we don't know if the workflow being updated is the current workflow or not.
+	// UpdateWorkflowModeIgnoreCurrent update workflow, without checking or update current record.
+	// This mode should only be used when we don't know if the workflow being updated is the current workflow or not in DB.
 	// For example, when updating a closed workflow, it may or may not be the current workflow.
 	// This is similar to SetWorkflowExecution, but UpdateWorkflowExecution with this mode persists the workflow as a mutation,
 	// instead of a snapshot.
-	UpdateWorkflowModeSkipCurrent
+	UpdateWorkflowModeIgnoreCurrent
 )
 
 // ConflictResolveWorkflowMode conflict resolve mode

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -82,6 +82,12 @@ const (
 	// UpdateWorkflowModeBypassCurrent update workflow, without current record
 	// NOTE: current record CANNOT point to the workflow to be updated
 	UpdateWorkflowModeBypassCurrent
+	// UpdateWorkflowModeSkipCurrent update workflow, without checking or update current record
+	// This mode should only be used when we don't know if the workflow being updated is the current workflow or not.
+	// For example, when updating a closed workflow, it may or may not be the current workflow.
+	// This is similar to SetWorkflowExecution, but UpdateWorkflowExecution with this mode persists the workflow as a mutation,
+	// instead of a snapshot.
+	UpdateWorkflowModeSkipCurrent
 )
 
 // ConflictResolveWorkflowMode conflict resolve mode

--- a/common/persistence/operation_mode_validator.go
+++ b/common/persistence/operation_mode_validator.go
@@ -147,6 +147,17 @@ func ValidateUpdateWorkflowModeState(
 		}
 		return nil
 
+	case UpdateWorkflowModeSkipCurrent:
+		// Cannot have new workflow when skipping current workflow check
+		if newWorkflowState != nil {
+			return newInvalidUpdateWorkflowWithNewMode(
+				mode,
+				currentWorkflowState,
+				*newWorkflowState,
+			)
+		}
+		return nil
+
 	default:
 		return serviceerror.NewInternal(fmt.Sprintf("unknown mode: %v", mode))
 	}

--- a/common/persistence/operation_mode_validator.go
+++ b/common/persistence/operation_mode_validator.go
@@ -147,7 +147,7 @@ func ValidateUpdateWorkflowModeState(
 		}
 		return nil
 
-	case UpdateWorkflowModeSkipCurrent:
+	case UpdateWorkflowModeIgnoreCurrent:
 		// Cannot have new workflow when skipping current workflow check
 		if newWorkflowState != nil {
 			return newInvalidUpdateWorkflowWithNewMode(

--- a/common/persistence/sql/execution.go
+++ b/common/persistence/sql/execution.go
@@ -392,6 +392,9 @@ func (m *sqlExecutionStore) updateWorkflowExecutionTx(
 	shardID := request.ShardID
 
 	switch request.Mode {
+	case p.UpdateWorkflowModeSkipCurrent:
+		// noop
+
 	case p.UpdateWorkflowModeBypassCurrent:
 		if err := assertNotCurrentExecution(ctx,
 			tx,

--- a/common/persistence/sql/execution.go
+++ b/common/persistence/sql/execution.go
@@ -392,7 +392,7 @@ func (m *sqlExecutionStore) updateWorkflowExecutionTx(
 	shardID := request.ShardID
 
 	switch request.Mode {
-	case p.UpdateWorkflowModeSkipCurrent:
+	case p.UpdateWorkflowModeIgnoreCurrent:
 		// noop
 
 	case p.UpdateWorkflowModeBypassCurrent:

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -875,7 +875,7 @@ func (s *ExecutionMutableStateSuite) TestUpdate_ClosedWorkflow_IsCurrent() {
 	_, err := s.ExecutionManager.UpdateWorkflowExecution(s.Ctx, &p.UpdateWorkflowExecutionRequest{
 		ShardID: s.ShardID,
 		RangeID: s.RangeID,
-		Mode:    p.UpdateWorkflowModeSkipCurrent,
+		Mode:    p.UpdateWorkflowModeIgnoreCurrent,
 
 		UpdateWorkflowMutation: *currentMutation,
 		UpdateWorkflowEvents:   nil,
@@ -943,7 +943,7 @@ func (s *ExecutionMutableStateSuite) TestUpdate_ClosedWorkflow_IsNonCurrent() {
 	_, err = s.ExecutionManager.UpdateWorkflowExecution(s.Ctx, &p.UpdateWorkflowExecutionRequest{
 		ShardID: s.ShardID,
 		RangeID: s.RangeID,
-		Mode:    p.UpdateWorkflowModeSkipCurrent,
+		Mode:    p.UpdateWorkflowModeIgnoreCurrent,
 
 		UpdateWorkflowMutation: *nonCurrentMutation,
 		UpdateWorkflowEvents:   nil,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -84,7 +84,7 @@ type Config struct {
 	EnableHostLevelHistoryCache           dynamicconfig.BoolPropertyFn
 	EnableNexus                           dynamicconfig.BoolPropertyFn
 	EnableWorkflowExecutionTimeoutTimer   dynamicconfig.BoolPropertyFn
-	EnableUpdateClosedWorkflowByMutation  dynamicconfig.BoolPropertyFn
+	EnableUpdateWorkflowModeIgnoreCurrent dynamicconfig.BoolPropertyFn
 	EnableTransitionHistory               dynamicconfig.BoolPropertyFn
 	MaxCallbacksPerWorkflow               dynamicconfig.IntPropertyFnWithNamespaceFilter
 
@@ -439,7 +439,7 @@ func NewConfig(
 		EnableHostLevelHistoryCache:           dynamicconfig.EnableHostHistoryCache.Get(dc),
 		EnableNexus:                           dynamicconfig.EnableNexus.Get(dc),
 		EnableWorkflowExecutionTimeoutTimer:   dynamicconfig.EnableWorkflowExecutionTimeoutTimer.Get(dc),
-		EnableUpdateClosedWorkflowByMutation:  dynamicconfig.EnableUpdateClosedWorkflowByMutation.Get(dc),
+		EnableUpdateWorkflowModeIgnoreCurrent: dynamicconfig.EnableUpdateWorkflowModeIgnoreCurrent.Get(dc),
 		EnableTransitionHistory:               dynamicconfig.EnableTransitionHistory.Get(dc),
 		MaxCallbacksPerWorkflow:               dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -84,6 +84,7 @@ type Config struct {
 	EnableHostLevelHistoryCache           dynamicconfig.BoolPropertyFn
 	EnableNexus                           dynamicconfig.BoolPropertyFn
 	EnableWorkflowExecutionTimeoutTimer   dynamicconfig.BoolPropertyFn
+	EnableUpdateClosedWorkflowByMutation  dynamicconfig.BoolPropertyFn
 	EnableTransitionHistory               dynamicconfig.BoolPropertyFn
 	MaxCallbacksPerWorkflow               dynamicconfig.IntPropertyFnWithNamespaceFilter
 
@@ -438,6 +439,7 @@ func NewConfig(
 		EnableHostLevelHistoryCache:           dynamicconfig.EnableHostHistoryCache.Get(dc),
 		EnableNexus:                           dynamicconfig.EnableNexus.Get(dc),
 		EnableWorkflowExecutionTimeoutTimer:   dynamicconfig.EnableWorkflowExecutionTimeoutTimer.Get(dc),
+		EnableUpdateClosedWorkflowByMutation:  dynamicconfig.EnableUpdateClosedWorkflowByMutation.Get(dc),
 		EnableTransitionHistory:               dynamicconfig.EnableTransitionHistory.Get(dc),
 		MaxCallbacksPerWorkflow:               dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
 

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -2681,7 +2681,7 @@ func (s *engine2Suite) TestRefreshWorkflowTasks() {
 	wfMs := workflow.TestCloneToProto(ms)
 	gwmsResponse := &persistence.GetWorkflowExecutionResponse{State: wfMs}
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
-	s.mockExecutionMgr.EXPECT().SetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.SetWorkflowExecutionResponse{}, nil)
+	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil)
 	s.mockEventsCache.EXPECT().GetEvent(
 		gomock.Any(),
 		gomock.Any(),

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -222,7 +222,7 @@ type (
 		IsCancelRequested() bool
 		IsWorkflowCloseAttempted() bool
 		IsCurrentWorkflowGuaranteed() bool
-		IsNonCurrentWorkflowGuaranteed() bool
+		IsNonCurrentWorkflowGuaranteed() (bool, error)
 		IsSignalRequested(requestID string) bool
 		GetApproximatePersistedSize() int
 

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -222,6 +222,7 @@ type (
 		IsCancelRequested() bool
 		IsWorkflowCloseAttempted() bool
 		IsCurrentWorkflowGuaranteed() bool
+		IsNonCurrentWorkflowGuaranteed() bool
 		IsSignalRequested(requestID string) bool
 		GetApproximatePersistedSize() int
 

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -2822,6 +2822,20 @@ func (mr *MockMutableStateMockRecorder) IsDirty() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDirty", reflect.TypeOf((*MockMutableState)(nil).IsDirty))
 }
 
+// IsNonCurrentWorkflowGuaranteed mocks base method.
+func (m *MockMutableState) IsNonCurrentWorkflowGuaranteed() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsNonCurrentWorkflowGuaranteed")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsNonCurrentWorkflowGuaranteed indicates an expected call of IsNonCurrentWorkflowGuaranteed.
+func (mr *MockMutableStateMockRecorder) IsNonCurrentWorkflowGuaranteed() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNonCurrentWorkflowGuaranteed", reflect.TypeOf((*MockMutableState)(nil).IsNonCurrentWorkflowGuaranteed))
+}
+
 // IsResetRun mocks base method.
 func (m *MockMutableState) IsResetRun() bool {
 	m.ctrl.T.Helper()

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -2823,11 +2823,12 @@ func (mr *MockMutableStateMockRecorder) IsDirty() *gomock.Call {
 }
 
 // IsNonCurrentWorkflowGuaranteed mocks base method.
-func (m *MockMutableState) IsNonCurrentWorkflowGuaranteed() bool {
+func (m *MockMutableState) IsNonCurrentWorkflowGuaranteed() (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsNonCurrentWorkflowGuaranteed")
 	ret0, _ := ret[0].(bool)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // IsNonCurrentWorkflowGuaranteed indicates an expected call of IsNonCurrentWorkflowGuaranteed.

--- a/service/history/ndc/activity_state_replicator.go
+++ b/service/history/ndc/activity_state_replicator.go
@@ -176,11 +176,11 @@ func (r *ActivityStateReplicatorImpl) SyncActivityState(
 		return err
 	}
 
-	if r.shardContext.GetConfig().EnableUpdateClosedWorkflowByMutation() {
+	if r.shardContext.GetConfig().EnableUpdateWorkflowModeIgnoreCurrent() {
 		return executionContext.UpdateWorkflowExecutionAsPassive(ctx, r.shardContext)
 	}
 
-	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
+	// TODO: remove following code once EnableUpdateWorkflowModeIgnoreCurrent config is deprecated.
 	updateMode := persistence.UpdateWorkflowModeUpdateCurrent
 	if state, _ := mutableState.GetWorkflowStateStatus(); state == enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE {
 		updateMode = persistence.UpdateWorkflowModeBypassCurrent
@@ -267,11 +267,11 @@ func (r *ActivityStateReplicatorImpl) SyncActivitiesState(
 		return err
 	}
 
-	if r.shardContext.GetConfig().EnableUpdateClosedWorkflowByMutation() {
+	if r.shardContext.GetConfig().EnableUpdateWorkflowModeIgnoreCurrent() {
 		return executionContext.UpdateWorkflowExecutionAsPassive(ctx, r.shardContext)
 	}
 
-	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
+	// TODO: remove following code once EnableUpdateWorkflowModeIgnoreCurrent config is deprecated.
 	updateMode := persistence.UpdateWorkflowModeUpdateCurrent
 	if state, _ := mutableState.GetWorkflowStateStatus(); state == enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE {
 		updateMode = persistence.UpdateWorkflowModeBypassCurrent

--- a/service/history/ndc/activity_state_replicator.go
+++ b/service/history/ndc/activity_state_replicator.go
@@ -176,6 +176,11 @@ func (r *ActivityStateReplicatorImpl) SyncActivityState(
 		return err
 	}
 
+	if r.shardContext.GetConfig().EnableUpdateClosedWorkflowByMutation() {
+		return executionContext.UpdateWorkflowExecutionAsPassive(ctx, r.shardContext)
+	}
+
+	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
 	updateMode := persistence.UpdateWorkflowModeUpdateCurrent
 	if state, _ := mutableState.GetWorkflowStateStatus(); state == enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE {
 		updateMode = persistence.UpdateWorkflowModeBypassCurrent
@@ -262,6 +267,11 @@ func (r *ActivityStateReplicatorImpl) SyncActivitiesState(
 		return err
 	}
 
+	if r.shardContext.GetConfig().EnableUpdateClosedWorkflowByMutation() {
+		return executionContext.UpdateWorkflowExecutionAsPassive(ctx, r.shardContext)
+	}
+
+	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
 	updateMode := persistence.UpdateWorkflowModeUpdateCurrent
 	if state, _ := mutableState.GetWorkflowStateStatus(); state == enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE {
 		updateMode = persistence.UpdateWorkflowModeBypassCurrent

--- a/service/history/ndc/activity_state_replicator_test.go
+++ b/service/history/ndc/activity_state_replicator_test.go
@@ -1035,15 +1035,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_Zombie() {
 		}).Return(false)
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(map[int64]*persistencespb.ActivityInfo{})
 
-	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
-		gomock.Any(),
-		s.mockShard,
-		persistence.UpdateWorkflowModeBypassCurrent,
-		historyi.WorkflowContext(nil),
-		historyi.MutableState(nil),
-		historyi.TransactionPolicyPassive,
-		(*historyi.TransactionPolicy)(nil),
-	).Return(nil)
+	weContext.EXPECT().UpdateWorkflowExecutionAsPassive(gomock.Any(), s.mockShard).Return(nil)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespaceID).Return(
 		namespace.NewGlobalNamespaceForTest(
@@ -1148,15 +1140,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityFound_Zombie()
 		}).Return(false)
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(map[int64]*persistencespb.ActivityInfo{})
 
-	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
-		gomock.Any(),
-		s.mockShard,
-		persistence.UpdateWorkflowModeBypassCurrent,
-		historyi.WorkflowContext(nil),
-		historyi.MutableState(nil),
-		historyi.TransactionPolicyPassive,
-		(*historyi.TransactionPolicy)(nil),
-	).Return(nil)
+	weContext.EXPECT().UpdateWorkflowExecutionAsPassive(gomock.Any(), s.mockShard).Return(nil)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespaceID).Return(
 		namespace.NewGlobalNamespaceForTest(
@@ -1257,15 +1241,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_NonZombie(
 		}).Return(false)
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(map[int64]*persistencespb.ActivityInfo{})
 
-	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
-		gomock.Any(),
-		s.mockShard,
-		persistence.UpdateWorkflowModeUpdateCurrent,
-		historyi.WorkflowContext(nil),
-		historyi.MutableState(nil),
-		historyi.TransactionPolicyPassive,
-		(*historyi.TransactionPolicy)(nil),
-	).Return(nil)
+	weContext.EXPECT().UpdateWorkflowExecutionAsPassive(gomock.Any(), s.mockShard).Return(nil)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespaceID).Return(
 		namespace.NewGlobalNamespaceForTest(
@@ -1370,15 +1346,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityFound_NonZombi
 		}).Return(false)
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(map[int64]*persistencespb.ActivityInfo{})
 
-	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
-		gomock.Any(),
-		s.mockShard,
-		persistence.UpdateWorkflowModeUpdateCurrent,
-		historyi.WorkflowContext(nil),
-		historyi.MutableState(nil),
-		historyi.TransactionPolicyPassive,
-		(*historyi.TransactionPolicy)(nil),
-	).Return(nil)
+	weContext.EXPECT().UpdateWorkflowExecutionAsPassive(gomock.Any(), s.mockShard).Return(nil)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespaceID).Return(
 		namespace.NewGlobalNamespaceForTest(

--- a/service/history/ndc/hsm_state_replicator.go
+++ b/service/history/ndc/hsm_state_replicator.go
@@ -128,11 +128,11 @@ func (r *HSMStateReplicatorImpl) SyncHSMState(
 		return consts.ErrDuplicate
 	}
 
-	if r.shardContext.GetConfig().EnableUpdateClosedWorkflowByMutation() {
+	if r.shardContext.GetConfig().EnableUpdateWorkflowModeIgnoreCurrent() {
 		return workflowContext.UpdateWorkflowExecutionAsPassive(ctx, r.shardContext)
 	}
 
-	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
+	// TODO: remove following code once EnableUpdateWorkflowModeIgnoreCurrent config is deprecated.
 	state, _ := mutableState.GetWorkflowStateStatus()
 	if state == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
 		return workflowContext.SubmitClosedWorkflowSnapshot(

--- a/service/history/ndc/hsm_state_replicator.go
+++ b/service/history/ndc/hsm_state_replicator.go
@@ -128,6 +128,11 @@ func (r *HSMStateReplicatorImpl) SyncHSMState(
 		return consts.ErrDuplicate
 	}
 
+	if r.shardContext.GetConfig().EnableUpdateClosedWorkflowByMutation() {
+		return workflowContext.UpdateWorkflowExecutionAsPassive(ctx, r.shardContext)
+	}
+
+	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
 	state, _ := mutableState.GetWorkflowStateStatus()
 	if state == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
 		return workflowContext.SubmitClosedWorkflowSnapshot(

--- a/service/history/ndc/hsm_state_replicator_test.go
+++ b/service/history/ndc/hsm_state_replicator_test.go
@@ -645,7 +645,7 @@ func (s *hsmStateReplicatorSuite) TestSyncHSM_IncomingStateNewer_WorkflowClosed(
 
 	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, request *persistence.UpdateWorkflowExecutionRequest) (*persistence.UpdateWorkflowExecutionResponse, error) {
-			s.Equal(persistence.UpdateWorkflowModeSkipCurrent, request.Mode)
+			s.Equal(persistence.UpdateWorkflowModeIgnoreCurrent, request.Mode)
 			subStateMachineByType := request.UpdateWorkflowMutation.ExecutionInfo.SubStateMachinesByType
 			s.Len(subStateMachineByType, 1)
 			machines := subStateMachineByType[s.stateMachineDef.Type()]

--- a/service/history/ndc/hsm_state_replicator_test.go
+++ b/service/history/ndc/hsm_state_replicator_test.go
@@ -251,11 +251,7 @@ func (s *hsmStateReplicatorSuite) TestSyncHSM_LocalEventVersionSuperSet() {
 
 	// Only asserting state sync happens here
 	// There are other tests asserting the actual state sync result
-	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.UpdateWorkflowExecutionResponse{
-		UpdateMutableStateStats: persistence.MutableStateStatistics{
-			HistoryStatistics: &persistence.HistoryStatistics{},
-		},
-	}, nil).Times(1)
+	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil).Times(1)
 
 	err := s.nDCHSMStateReplicator.SyncHSMState(context.Background(), &historyi.SyncHSMRequest{
 		WorkflowKey: s.workflowKey,
@@ -455,11 +451,7 @@ func (s *hsmStateReplicatorSuite) TestSyncHSM_IncomingLastUpdateVersionNewer() {
 		DBRecordVersion: 777,
 	}, nil).Times(1)
 
-	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.UpdateWorkflowExecutionResponse{
-		UpdateMutableStateStats: persistence.MutableStateStatistics{
-			HistoryStatistics: &persistence.HistoryStatistics{},
-		},
-	}, nil).Times(1)
+	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil).Times(1)
 
 	err := s.nDCHSMStateReplicator.SyncHSMState(context.Background(), &historyi.SyncHSMRequest{
 		WorkflowKey:         s.workflowKey,
@@ -501,11 +493,7 @@ func (s *hsmStateReplicatorSuite) TestSyncHSM_IncomingLastUpdateVersionedTransit
 		DBRecordVersion: 777,
 	}, nil).Times(1)
 
-	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.UpdateWorkflowExecutionResponse{
-		UpdateMutableStateStats: persistence.MutableStateStatistics{
-			HistoryStatistics: &persistence.HistoryStatistics{},
-		},
-	}, nil).Times(1)
+	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil).Times(1)
 
 	err := s.nDCHSMStateReplicator.SyncHSMState(context.Background(), &historyi.SyncHSMRequest{
 		WorkflowKey:         s.workflowKey,
@@ -563,11 +551,7 @@ func (s *hsmStateReplicatorSuite) TestSyncHSM_IncomingStateNewer_WorkflowOpen() 
 			s.Empty(request.UpdateWorkflowEvents)
 			s.Empty(request.NewWorkflowEvents)
 			s.Empty(request.NewWorkflowSnapshot)
-			return &persistence.UpdateWorkflowExecutionResponse{
-				UpdateMutableStateStats: persistence.MutableStateStatistics{
-					HistoryStatistics: &persistence.HistoryStatistics{},
-				},
-			}, nil
+			return tests.UpdateWorkflowExecutionResponse, nil
 		},
 	).Times(1)
 
@@ -615,11 +599,7 @@ func (s *hsmStateReplicatorSuite) TestSyncHSM_IncomingStateNewer_WorkflowZombie(
 		func(ctx context.Context, request *persistence.UpdateWorkflowExecutionRequest) (*persistence.UpdateWorkflowExecutionResponse, error) {
 			s.Equal(persistence.UpdateWorkflowModeBypassCurrent, request.Mode)
 			// other fields are tested in TestSyncHSM_IncomingStateNewer_WorkflowOpen
-			return &persistence.UpdateWorkflowExecutionResponse{
-				UpdateMutableStateStats: persistence.MutableStateStatistics{
-					HistoryStatistics: &persistence.HistoryStatistics{},
-				},
-			}, nil
+			return tests.UpdateWorkflowExecutionResponse, nil
 		},
 	).Times(1)
 
@@ -663,19 +643,19 @@ func (s *hsmStateReplicatorSuite) TestSyncHSM_IncomingStateNewer_WorkflowClosed(
 		DBRecordVersion: 777,
 	}, nil).Times(1)
 
-	s.mockExecutionMgr.EXPECT().SetWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, request *persistence.SetWorkflowExecutionRequest) (*persistence.SetWorkflowExecutionResponse, error) {
-
-			subStateMachineByType := request.SetWorkflowSnapshot.ExecutionInfo.SubStateMachinesByType
+	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, request *persistence.UpdateWorkflowExecutionRequest) (*persistence.UpdateWorkflowExecutionResponse, error) {
+			s.Equal(persistence.UpdateWorkflowModeSkipCurrent, request.Mode)
+			subStateMachineByType := request.UpdateWorkflowMutation.ExecutionInfo.SubStateMachinesByType
 			s.Len(subStateMachineByType, 1)
 			machines := subStateMachineByType[s.stateMachineDef.Type()]
 			s.Len(machines.MachinesById, 1)
 			machine := machines.MachinesById["child1"]
 			s.Equal([]byte(hsmtest.State3), machine.Data)
 			s.Equal(int64(24), machine.TransitionCount) // transition count is cluster local and should only be increamented by 1
-			s.Len(request.SetWorkflowSnapshot.Tasks[tasks.CategoryTimer], 1)
-			s.Len(request.SetWorkflowSnapshot.Tasks[tasks.CategoryOutbound], 1)
-			return &persistence.SetWorkflowExecutionResponse{}, nil
+			s.Len(request.UpdateWorkflowMutation.Tasks[tasks.CategoryTimer], 1)
+			s.Len(request.UpdateWorkflowMutation.Tasks[tasks.CategoryOutbound], 1)
+			return tests.UpdateWorkflowExecutionResponse, nil
 		},
 	).Times(1)
 

--- a/service/history/statemachine_environment.go
+++ b/service/history/statemachine_environment.go
@@ -396,11 +396,11 @@ func (e *stateMachineEnvironment) Access(ctx context.Context, ref hsm.Ref, acces
 		return nil
 	}
 
-	if e.shardContext.GetConfig().EnableUpdateClosedWorkflowByMutation() {
+	if e.shardContext.GetConfig().EnableUpdateWorkflowModeIgnoreCurrent() {
 		return wfCtx.UpdateWorkflowExecutionAsActive(ctx, e.shardContext)
 	}
 
-	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
+	// TODO: remove following code once EnableUpdateWorkflowModeIgnoreCurrent config is deprecated.
 	if ms.GetExecutionState().State == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
 		// Can't use UpdateWorkflowExecutionAsActive since it updates the current run, and we are operating on closed
 		// workflows.

--- a/service/history/statemachine_environment.go
+++ b/service/history/statemachine_environment.go
@@ -396,6 +396,11 @@ func (e *stateMachineEnvironment) Access(ctx context.Context, ref hsm.Ref, acces
 		return nil
 	}
 
+	if e.shardContext.GetConfig().EnableUpdateClosedWorkflowByMutation() {
+		return wfCtx.UpdateWorkflowExecutionAsActive(ctx, e.shardContext)
+	}
+
+	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
 	if ms.GetExecutionState().State == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
 		// Can't use UpdateWorkflowExecutionAsActive since it updates the current run, and we are operating on closed
 		// workflows.

--- a/service/history/statemachine_environment_test.go
+++ b/service/history/statemachine_environment_test.go
@@ -400,7 +400,7 @@ func TestAccess(t *testing.T) {
 			persistenceMutableState := workflow.TestCloneToProto(mutableState)
 			em := s.mockShard.GetExecutionManager().(*persistence.MockExecutionManager)
 			em.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
-			em.EXPECT().SetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.SetWorkflowExecutionResponse{}, nil).Times(tc.expectedSetRequests)
+			em.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil).Times(tc.expectedSetRequests)
 
 			exec := stateMachineEnvironment{
 				shardContext:   s.mockShard,

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -837,11 +837,11 @@ func (t *timerQueueActiveTaskExecutor) executeStateMachineTimerTask(
 		return nil
 	}
 
-	if t.config.EnableUpdateClosedWorkflowByMutation() {
+	if t.config.EnableUpdateWorkflowModeIgnoreCurrent() {
 		return wfCtx.UpdateWorkflowExecutionAsActive(ctx, t.shardContext)
 	}
 
-	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
+	// TODO: remove following code once EnableUpdateWorkflowModeIgnoreCurrent config is deprecated.
 	if ms.GetExecutionState().State == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
 		// Can't use UpdateWorkflowExecutionAsActive since it updates the current run, and we are operating on a
 		// closed workflow.

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -837,6 +837,11 @@ func (t *timerQueueActiveTaskExecutor) executeStateMachineTimerTask(
 		return nil
 	}
 
+	if t.config.EnableUpdateClosedWorkflowByMutation() {
+		return wfCtx.UpdateWorkflowExecutionAsActive(ctx, t.shardContext)
+	}
+
+	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
 	if ms.GetExecutionState().State == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
 		// Can't use UpdateWorkflowExecutionAsActive since it updates the current run, and we are operating on a
 		// closed workflow.

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -536,6 +536,11 @@ func (t *timerQueueStandbyTaskExecutor) executeStateMachineTimerTask(
 			return nil, nil
 		}
 
+		if t.config.EnableUpdateClosedWorkflowByMutation() {
+			return nil, wfContext.UpdateWorkflowExecutionAsPassive(ctx, t.shardContext)
+		}
+
+		// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
 		if mutableState.GetExecutionState().State == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
 			// Can't use UpdateWorkflowExecutionAsPassive since it updates the current run,
 			// and we are operating on a closed workflow.

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -536,11 +536,11 @@ func (t *timerQueueStandbyTaskExecutor) executeStateMachineTimerTask(
 			return nil, nil
 		}
 
-		if t.config.EnableUpdateClosedWorkflowByMutation() {
+		if t.config.EnableUpdateWorkflowModeIgnoreCurrent() {
 			return nil, wfContext.UpdateWorkflowExecutionAsPassive(ctx, t.shardContext)
 		}
 
-		// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
+		// TODO: remove following code once EnableUpdateWorkflowModeIgnoreCurrent config is deprecated.
 		if mutableState.GetExecutionState().State == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
 			// Can't use UpdateWorkflowExecutionAsPassive since it updates the current run,
 			// and we are operating on a closed workflow.

--- a/service/history/visibility_queue_task_executor.go
+++ b/service/history/visibility_queue_task_executor.go
@@ -461,6 +461,12 @@ func (t *visibilityQueueTaskExecutor) cleanupExecutionInfo(
 	executionInfo.Memo = nil
 	executionInfo.SearchAttributes = nil
 	executionInfo.RelocatableAttributesRemoved = true
+
+	if t.shardContext.GetConfig().EnableUpdateClosedWorkflowByMutation() {
+		return weContext.UpdateWorkflowExecutionAsPassive(ctx, t.shardContext)
+	}
+
+	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
 	return weContext.SetWorkflowExecution(ctx, t.shardContext)
 }
 

--- a/service/history/visibility_queue_task_executor.go
+++ b/service/history/visibility_queue_task_executor.go
@@ -462,11 +462,11 @@ func (t *visibilityQueueTaskExecutor) cleanupExecutionInfo(
 	executionInfo.SearchAttributes = nil
 	executionInfo.RelocatableAttributesRemoved = true
 
-	if t.shardContext.GetConfig().EnableUpdateClosedWorkflowByMutation() {
+	if t.shardContext.GetConfig().EnableUpdateWorkflowModeIgnoreCurrent() {
 		return weContext.UpdateWorkflowExecutionAsPassive(ctx, t.shardContext)
 	}
 
-	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
+	// TODO: remove following code once EnableUpdateWorkflowModeIgnoreCurrent config is deprecated.
 	return weContext.SetWorkflowExecution(ctx, t.shardContext)
 }
 

--- a/service/history/visibility_queue_task_executor_test.go
+++ b/service/history/visibility_queue_task_executor_test.go
@@ -149,7 +149,8 @@ func (s *visibilityQueueTaskExecutorSuite) SetupTest() {
 
 	mockClusterMetadata := s.mockShard.Resource.ClusterMetadata
 	mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
-	mockClusterMetadata.EXPECT().GetClusterID().Return(int64(1)).AnyTimes()
+	mockClusterMetadata.EXPECT().GetClusterID().Return(tests.Version).AnyTimes()
+	mockClusterMetadata.EXPECT().IsVersionFromSameCluster(tests.Version, tests.Version).Return(true).AnyTimes()
 	mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(true).AnyTimes()
 	mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, s.version).Return(mockClusterMetadata.GetCurrentClusterName()).AnyTimes()
@@ -338,7 +339,7 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessCloseExecutionWithWorkflow
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
-	s.mockExecutionMgr.EXPECT().SetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.SetWorkflowExecutionResponse{}, nil)
+	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil)
 	s.mockVisibilityMgr.EXPECT().RecordWorkflowExecutionClosed(
 		gomock.Any(),
 		s.createRecordWorkflowExecutionClosedRequest(

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -743,7 +743,7 @@ func (c *ContextImpl) updateWorkflowExecutionEventReapply(
 	eventBatch1 []*persistence.WorkflowEvents,
 	eventBatch2 []*persistence.WorkflowEvents,
 ) error {
-	if updateMode == persistence.UpdateWorkflowModeSkipCurrent {
+	if updateMode == persistence.UpdateWorkflowModeIgnoreCurrent {
 		if len(eventBatch1) != 0 || len(eventBatch2) != 0 {
 			return serviceerror.NewInternal("encountered events reapplication without knowing if workflow is current. Events generated for a close workflow?")
 		}
@@ -780,11 +780,11 @@ func (c *ContextImpl) conflictResolveEventReapply(
 
 func (c *ContextImpl) updateWorkflowMode() persistence.UpdateWorkflowMode {
 	updateMode := persistence.UpdateWorkflowModeUpdateCurrent
-	if !c.config.EnableUpdateClosedWorkflowByMutation() {
+	if !c.config.EnableUpdateWorkflowModeIgnoreCurrent() {
 		return persistence.UpdateWorkflowModeUpdateCurrent
 	}
 
-	updateMode = persistence.UpdateWorkflowModeSkipCurrent
+	updateMode = persistence.UpdateWorkflowModeIgnoreCurrent
 	if c.MutableState.IsCurrentWorkflowGuaranteed() {
 		updateMode = persistence.UpdateWorkflowModeUpdateCurrent
 	}
@@ -899,11 +899,11 @@ func (c *ContextImpl) RefreshTasks(
 		return err
 	}
 
-	if c.config.EnableUpdateClosedWorkflowByMutation() {
+	if c.config.EnableUpdateWorkflowModeIgnoreCurrent() {
 		return c.UpdateWorkflowExecutionAsPassive(ctx, shardContext)
 	}
 
-	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
+	// TODO: remove following code once EnableUpdateWorkflowModeIgnoreCurrent config is deprecated.
 	if !mutableState.IsWorkflowExecutionRunning() {
 		// Can't use UpdateWorkflowExecutionAsPassive since it updates the current run,
 		// and we are operating on a closed workflow.

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -331,13 +331,15 @@ func (c *ContextImpl) ConflictResolveWorkflowExecution(
 
 	eventsToReapply := resetWorkflowEventsSeq
 	if len(resetWorkflowEventsSeq) == 0 {
-		eventsToReapply = []*persistence.WorkflowEvents{
-			{
-				NamespaceID: c.workflowKey.NamespaceID,
-				WorkflowID:  c.workflowKey.WorkflowID,
-				RunID:       c.workflowKey.RunID,
-				Events:      resetMutableState.GetReapplyCandidateEvents(),
-			},
+		if reapplyCandidateEvents := resetMutableState.GetReapplyCandidateEvents(); len(reapplyCandidateEvents) != 0 {
+			eventsToReapply = []*persistence.WorkflowEvents{
+				{
+					NamespaceID: c.workflowKey.NamespaceID,
+					WorkflowID:  c.workflowKey.WorkflowID,
+					RunID:       c.workflowKey.RunID,
+					Events:      reapplyCandidateEvents,
+				},
+			}
 		}
 	}
 
@@ -405,7 +407,7 @@ func (c *ContextImpl) UpdateWorkflowExecutionAsActive(
 	err = c.UpdateWorkflowExecutionWithNew(
 		ctx,
 		shardContext,
-		persistence.UpdateWorkflowModeUpdateCurrent,
+		c.updateWorkflowMode(),
 		nil,
 		nil,
 		historyi.TransactionPolicyActive,
@@ -457,7 +459,7 @@ func (c *ContextImpl) UpdateWorkflowExecutionAsPassive(
 	return c.UpdateWorkflowExecutionWithNew(
 		ctx,
 		shardContext,
-		persistence.UpdateWorkflowModeUpdateCurrent,
+		c.updateWorkflowMode(),
 		nil,
 		nil,
 		historyi.TransactionPolicyPassive,
@@ -532,13 +534,15 @@ func (c *ContextImpl) UpdateWorkflowExecutionWithNew(
 
 	eventsToReapply := updateWorkflowEventsSeq
 	if len(updateWorkflowEventsSeq) == 0 {
-		eventsToReapply = []*persistence.WorkflowEvents{
-			{
-				NamespaceID: c.workflowKey.NamespaceID,
-				WorkflowID:  c.workflowKey.WorkflowID,
-				RunID:       c.workflowKey.RunID,
-				Events:      c.MutableState.GetReapplyCandidateEvents(),
-			},
+		if reapplyCandidateEvents := c.MutableState.GetReapplyCandidateEvents(); len(reapplyCandidateEvents) != 0 {
+			eventsToReapply = []*persistence.WorkflowEvents{
+				{
+					NamespaceID: c.workflowKey.NamespaceID,
+					WorkflowID:  c.workflowKey.WorkflowID,
+					RunID:       c.workflowKey.RunID,
+					Events:      reapplyCandidateEvents,
+				},
+			}
 		}
 	}
 
@@ -739,6 +743,12 @@ func (c *ContextImpl) updateWorkflowExecutionEventReapply(
 	eventBatch1 []*persistence.WorkflowEvents,
 	eventBatch2 []*persistence.WorkflowEvents,
 ) error {
+	if updateMode == persistence.UpdateWorkflowModeSkipCurrent {
+		if len(eventBatch1) != 0 || len(eventBatch2) != 0 {
+			return serviceerror.NewInternal("encountered events reapplication without knowing if workflow is current. Events generated for a close workflow?")
+		}
+		return nil
+	}
 
 	if updateMode != persistence.UpdateWorkflowModeBypassCurrent {
 		return nil
@@ -766,6 +776,22 @@ func (c *ContextImpl) conflictResolveEventReapply(
 	eventBatches = append(eventBatches, eventBatch1...)
 	eventBatches = append(eventBatches, eventBatch2...)
 	return c.ReapplyEvents(ctx, shardContext, eventBatches)
+}
+
+func (c *ContextImpl) updateWorkflowMode() persistence.UpdateWorkflowMode {
+	updateMode := persistence.UpdateWorkflowModeUpdateCurrent
+	if !c.config.EnableUpdateClosedWorkflowByMutation() {
+		return persistence.UpdateWorkflowModeUpdateCurrent
+	}
+
+	updateMode = persistence.UpdateWorkflowModeSkipCurrent
+	if c.MutableState.IsCurrentWorkflowGuaranteed() {
+		updateMode = persistence.UpdateWorkflowModeUpdateCurrent
+	}
+	if c.MutableState.IsNonCurrentWorkflowGuaranteed() {
+		updateMode = persistence.UpdateWorkflowModeBypassCurrent
+	}
+	return updateMode
 }
 
 func (c *ContextImpl) ReapplyEvents(
@@ -873,6 +899,11 @@ func (c *ContextImpl) RefreshTasks(
 		return err
 	}
 
+	if c.config.EnableUpdateClosedWorkflowByMutation() {
+		return c.UpdateWorkflowExecutionAsPassive(ctx, shardContext)
+	}
+
+	// TODO: remove following code once EnableUpdateClosedWorkflowByMutation config is deprecated.
 	if !mutableState.IsWorkflowExecutionRunning() {
 		// Can't use UpdateWorkflowExecutionAsPassive since it updates the current run,
 		// and we are operating on a closed workflow.

--- a/service/history/workflow/context_test.go
+++ b/service/history/workflow/context_test.go
@@ -545,7 +545,7 @@ func (s *contextSuite) TestRefreshTask() {
 				mockShard.Resource.ExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, request *persistence.UpdateWorkflowExecutionRequest) (*persistence.UpdateWorkflowExecutionResponse, error) {
 						s.NotEmpty(request.UpdateWorkflowMutation.Tasks)
-						s.Equal(persistence.UpdateWorkflowModeSkipCurrent, request.Mode)
+						s.Equal(persistence.UpdateWorkflowModeIgnoreCurrent, request.Mode)
 						return tests.UpdateWorkflowExecutionResponse, nil
 					}).Times(1)
 			},

--- a/service/history/workflow/context_test.go
+++ b/service/history/workflow/context_test.go
@@ -525,11 +525,7 @@ func (s *contextSuite) TestRefreshTask() {
 						s.Equal(persistence.UpdateWorkflowModeUpdateCurrent, request.Mode)
 						s.NotEmpty(request.UpdateWorkflowMutation.Tasks)
 						s.Empty(request.UpdateWorkflowEvents)
-						return &persistence.UpdateWorkflowExecutionResponse{
-							UpdateMutableStateStats: persistence.MutableStateStatistics{
-								HistoryStatistics: &persistence.HistoryStatistics{},
-							},
-						}, nil
+						return tests.UpdateWorkflowExecutionResponse, nil
 					}).Times(1)
 			},
 		},
@@ -546,10 +542,11 @@ func (s *contextSuite) TestRefreshTask() {
 				return base
 			},
 			setupMock: func(mockShard *shard.ContextTest) {
-				mockShard.Resource.ExecutionMgr.EXPECT().SetWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ context.Context, request *persistence.SetWorkflowExecutionRequest) (*persistence.SetWorkflowExecutionResponse, error) {
-						s.NotEmpty(request.SetWorkflowSnapshot.Tasks)
-						return &persistence.SetWorkflowExecutionResponse{}, nil
+				mockShard.Resource.ExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, request *persistence.UpdateWorkflowExecutionRequest) (*persistence.UpdateWorkflowExecutionResponse, error) {
+						s.NotEmpty(request.UpdateWorkflowMutation.Tasks)
+						s.Equal(persistence.UpdateWorkflowModeSkipCurrent, request.Mode)
+						return tests.UpdateWorkflowExecutionResponse, nil
 					}).Times(1)
 			},
 		},
@@ -574,10 +571,11 @@ func (s *contextSuite) TestRefreshTask() {
 					Version:    common.EmptyVersion,
 					Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{},
 				}, nil).Times(2)
-				mockShard.Resource.ExecutionMgr.EXPECT().SetWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ context.Context, request *persistence.SetWorkflowExecutionRequest) (*persistence.SetWorkflowExecutionResponse, error) {
-						s.NotEmpty(request.SetWorkflowSnapshot.Tasks)
-						return &persistence.SetWorkflowExecutionResponse{}, nil
+				mockShard.Resource.ExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, request *persistence.UpdateWorkflowExecutionRequest) (*persistence.UpdateWorkflowExecutionResponse, error) {
+						s.NotEmpty(request.UpdateWorkflowMutation.Tasks)
+						s.Equal(persistence.UpdateWorkflowModeBypassCurrent, request.Mode)
+						return tests.UpdateWorkflowExecutionResponse, nil
 					}).Times(1)
 			},
 		},

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1020,22 +1020,22 @@ func (ms *MutableStateImpl) IsCurrentWorkflowGuaranteed() bool {
 	}
 }
 
-func (ms *MutableStateImpl) IsNonCurrentWorkflowGuaranteed() bool {
+func (ms *MutableStateImpl) IsNonCurrentWorkflowGuaranteed() (bool, error) {
 	switch ms.stateInDB {
 	case enumsspb.WORKFLOW_EXECUTION_STATE_VOID:
-		return true
+		return true, nil
 	case enumsspb.WORKFLOW_EXECUTION_STATE_CREATED:
-		return false
+		return false, nil
 	case enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING:
-		return false
+		return false, nil
 	case enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED:
-		return false
+		return false, nil
 	case enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE:
-		return true
+		return true, nil
 	case enumsspb.WORKFLOW_EXECUTION_STATE_CORRUPTED:
-		return false
+		return false, nil
 	default:
-		panic(fmt.Sprintf("unknown workflow state: %v", ms.executionState.State))
+		return false, serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", ms.executionState.State.String()))
 	}
 }
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1020,6 +1020,25 @@ func (ms *MutableStateImpl) IsCurrentWorkflowGuaranteed() bool {
 	}
 }
 
+func (ms *MutableStateImpl) IsNonCurrentWorkflowGuaranteed() bool {
+	switch ms.stateInDB {
+	case enumsspb.WORKFLOW_EXECUTION_STATE_VOID:
+		return true
+	case enumsspb.WORKFLOW_EXECUTION_STATE_CREATED:
+		return false
+	case enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING:
+		return false
+	case enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED:
+		return false
+	case enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE:
+		return true
+	case enumsspb.WORKFLOW_EXECUTION_STATE_CORRUPTED:
+		return false
+	default:
+		panic(fmt.Sprintf("unknown workflow state: %v", ms.executionState.State))
+	}
+}
+
 func (ms *MutableStateImpl) GetNamespaceEntry() *namespace.Namespace {
 	return ms.namespaceEntry
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Support update closed workflow by mutation

## Why?
<!-- Tell your future self why have you made these changes -->
- Today, any updates (e.g. update callbacks after workflows & update branch token. With CHASM, there will be more cases) for closed workflows require persisting the entire mutable snapshot using the `SetWorkflowExecution` persistence API in order to skip the current record validation. 
- Application logic is complex and have to call different APIs based on workflow state
- Performance is also bad as we are writing unnecessary data when persisting a snapshot, even if they haven't been mutated.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit & persistence integration tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- No.
