### PR TITLE
Add HTTP tracing to forwarded Nexus requests

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -1013,3 +1013,7 @@ func UserDataVersion(v int64) ZapTag {
 func Cause(cause string) ZapTag {
 	return NewStringTag("cause", cause)
 }
+
+func NexusOperation(operation string) ZapTag {
+	return NewStringTag("nexus-operation", operation)
+}

--- a/common/nexus/trace.go
+++ b/common/nexus/trace.go
@@ -123,6 +123,7 @@ func (p *LoggedHTTPClientTraceProvider) NewForwardingTrace(logger log.Logger) *h
 	return p.newClientTrace(logger, config.Hooks)
 }
 
+//nolint:revive // cognitive complexity (> 25 max) but is just adding a logging function for each method in the list.
 func (p *LoggedHTTPClientTraceProvider) newClientTrace(logger log.Logger, hooks []string) *httptrace.ClientTrace {
 	clientTrace := &httptrace.ClientTrace{}
 	for _, h := range hooks {

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -52,6 +52,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/namespace/nsregistry"
+	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/persistence"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/common/persistence/serialization"
@@ -129,6 +130,7 @@ var Module = fx.Options(
 	deadlock.Module,
 	config.Module,
 	testhooks.Module,
+	fx.Provide(commonnexus.NewLoggedHTTPClientTraceProvider),
 )
 
 var DefaultOptions = fx.Options(

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -206,9 +206,10 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 
 	if e.HTTPTraceProvider != nil {
 		traceLogger := log.With(e.Logger,
+			tag.Operation("StartOperation"),
 			tag.WorkflowNamespace(ns.Name().String()),
 			tag.RequestID(args.requestID),
-			tag.Operation(args.operation),
+			tag.NexusOperation(args.operation),
 			tag.Endpoint(args.endpointName),
 			tag.WorkflowID(ref.WorkflowKey.WorkflowID),
 			tag.WorkflowRunID(ref.WorkflowKey.RunID),
@@ -576,9 +577,10 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 
 	if e.HTTPTraceProvider != nil {
 		traceLogger := log.With(e.Logger,
+			tag.Operation("CancelOperation"),
 			tag.WorkflowNamespace(ns.Name().String()),
 			tag.RequestID(args.requestID),
-			tag.Operation(args.operation),
+			tag.NexusOperation(args.operation),
 			tag.Endpoint(args.endpointName),
 			tag.WorkflowID(ref.WorkflowKey.WorkflowID),
 			tag.WorkflowRunID(ref.WorkflowKey.RunID),

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -762,6 +762,7 @@ func RegisterNexusHTTPHandler(
 	rateLimitInterceptor *interceptor.RateLimitInterceptor,
 	logger log.Logger,
 	router *mux.Router,
+	httpTraceProvider nexus.HTTPClientTraceProvider,
 ) {
 	h := NewNexusHTTPHandler(
 		serviceConfig,
@@ -779,6 +780,7 @@ func RegisterNexusHTTPHandler(
 		namespaceCountLimiterInterceptor,
 		rateLimitInterceptor,
 		logger,
+		httpTraceProvider,
 	)
 	h.RegisterRoutes(router)
 }

--- a/service/frontend/nexus_http_handler.go
+++ b/service/frontend/nexus_http_handler.go
@@ -84,6 +84,7 @@ func NewNexusHTTPHandler(
 	namespaceConcurrencyLimitIntercptor *interceptor.ConcurrentRequestLimitInterceptor,
 	rateLimitInterceptor *interceptor.RateLimitInterceptor,
 	logger log.Logger,
+	httpTraceProvider commonnexus.HTTPClientTraceProvider,
 ) *NexusHTTPHandler {
 	return &NexusHTTPHandler{
 		logger:                               logger,
@@ -111,6 +112,7 @@ func NewNexusHTTPHandler(
 				payloadSizeLimit:              serviceConfig.BlobSizeLimitError,
 				headersBlacklist:              serviceConfig.NexusRequestHeadersBlacklist,
 				metricTagConfig:               serviceConfig.NexusOperationsMetricTagConfig,
+				httpTraceProvider:             httpTraceProvider,
 			},
 			GetResultTimeout: serviceConfig.KeepAliveMaxConnectionIdle(),
 			Logger:           log.NewSlogLogger(logger),

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -36,7 +36,6 @@ import (
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	commonnexus "go.temporal.io/server/common/nexus"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/common/persistence/visibility"
 	"go.temporal.io/server/common/persistence/visibility/manager"
@@ -96,7 +95,6 @@ var Module = fx.Options(
 	fx.Provide(ServerProvider),
 	fx.Provide(NewService),
 	fx.Provide(ReplicationProgressCacheProvider),
-	fx.Provide(commonnexus.NewLoggedHTTPClientTraceProvider),
 	fx.Invoke(ServiceLifetimeHooks),
 
 	callbacks.Module,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Added additional tracing logs for forwarded Nexus HTTP requests.

## Why?
<!-- Tell your future self why have you made these changes -->
Forwarded requests create a new request so they were not copying over the `httptrace.ClientTrace` set in the executors.

