### PR TITLE
Move two settings into dynamic config

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1287,12 +1287,17 @@ second per poller by one physical queue manager`,
 	MatchingUseNewMatcher = NewTaskQueueBoolSetting(
 		"matching.useNewMatcher",
 		false,
-		`Use priority-enabled TaskMatcher.`,
+		`Use priority-enabled TaskMatcher`,
 	)
 	MatchingPriorityLevels = NewTaskQueueIntSetting(
 		"matching.priorityLevels",
 		5,
-		`Number of simple priority levels`,
+		`Number of simple priority levels (requires new matcher)`,
+	)
+	MatchingBacklogTaskForwardTimeout = NewTaskQueueDurationSetting(
+		"matching.backlogTaskForwardTimeout",
+		60*time.Second,
+		`Timeout for forwarded backlog task (requires new matcher)`,
 	)
 
 	// keys for history

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1056,7 +1056,12 @@ See DynamicRateLimitingParams comments for more details.`,
 	MatchingGetTasksBatchSize = NewTaskQueueIntSetting(
 		"matching.getTasksBatchSize",
 		1000,
-		`MatchingGetTasksBatchSize is the maximum batch size to fetch from the task buffer`,
+		`How many backlog tasks to read from persistence at once`,
+	)
+	MatchingGetTasksReloadAt = NewTaskQueueIntSetting(
+		"matching.getTasksReloadAt",
+		100,
+		`Reload a batch of tasks when there are this many remaining. Must be less than MatchingGetTasksBatchSize.`,
 	)
 	MatchingLongPollExpirationInterval = NewTaskQueueDurationSetting(
 		"matching.longPollExpirationInterval",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1061,7 +1061,7 @@ See DynamicRateLimitingParams comments for more details.`,
 	MatchingGetTasksReloadAt = NewTaskQueueIntSetting(
 		"matching.getTasksReloadAt",
 		100,
-		`Reload a batch of tasks when there are this many remaining. Must be less than MatchingGetTasksBatchSize.`,
+		`Reload a batch of tasks when there are this many remaining. Must be less than MatchingGetTasksBatchSize. (Requires new matcher.)`,
 	)
 	MatchingLongPollExpirationInterval = NewTaskQueueDurationSetting(
 		"matching.longPollExpirationInterval",

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -63,6 +63,7 @@ type (
 		RangeSize                                int64
 		NewMatcher                               dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 		GetTasksBatchSize                        dynamicconfig.IntPropertyFnWithTaskQueueFilter
+		GetTasksReloadAt                         dynamicconfig.IntPropertyFnWithTaskQueueFilter
 		UpdateAckInterval                        dynamicconfig.DurationPropertyFnWithTaskQueueFilter
 		MaxTaskQueueIdleTime                     dynamicconfig.DurationPropertyFnWithTaskQueueFilter
 		NumTaskqueueWritePartitions              dynamicconfig.IntPropertyFnWithTaskQueueFilter
@@ -150,6 +151,7 @@ type (
 		RangeSize                  int64
 		NewMatcher                 bool
 		GetTasksBatchSize          func() int
+		GetTasksReloadAt           func() int
 		UpdateAckInterval          func() time.Duration
 		MaxTaskQueueIdleTime       func() time.Duration
 		MinTaskThrottlingBurstSize func() int
@@ -246,6 +248,7 @@ func NewConfig(
 		RangeSize:                                100000,
 		NewMatcher:                               dynamicconfig.MatchingUseNewMatcher.Get(dc),
 		GetTasksBatchSize:                        dynamicconfig.MatchingGetTasksBatchSize.Get(dc),
+		GetTasksReloadAt:                         dynamicconfig.MatchingGetTasksReloadAt.Get(dc),
 		UpdateAckInterval:                        dynamicconfig.MatchingUpdateAckInterval.Get(dc),
 		MaxTaskQueueIdleTime:                     dynamicconfig.MatchingMaxTaskQueueIdleTime.Get(dc),
 		LongPollExpirationInterval:               dynamicconfig.MatchingLongPollExpirationInterval.Get(dc),
@@ -323,6 +326,9 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		NewMatcher: config.NewMatcher(ns.String(), taskQueueName, taskType),
 		GetTasksBatchSize: func() int {
 			return config.GetTasksBatchSize(ns.String(), taskQueueName, taskType)
+		},
+		GetTasksReloadAt: func() int {
+			return config.GetTasksReloadAt(ns.String(), taskQueueName, taskType)
 		},
 		UpdateAckInterval: func() time.Duration {
 			return config.UpdateAckInterval(ns.String(), taskQueueName, taskType)

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -97,6 +97,7 @@ type (
 
 		// Time to hold a poll request before returning an empty response if there are no tasks
 		LongPollExpirationInterval dynamicconfig.DurationPropertyFnWithTaskQueueFilter
+		BacklogTaskForwardTimeout  dynamicconfig.DurationPropertyFnWithTaskQueueFilter
 		MinTaskThrottlingBurstSize dynamicconfig.IntPropertyFnWithTaskQueueFilter
 		MaxTaskDeleteBatchSize     dynamicconfig.IntPropertyFnWithTaskQueueFilter
 		TaskDeleteInterval         dynamicconfig.DurationPropertyFnWithTaskQueueFilter
@@ -145,6 +146,7 @@ type (
 		QueryPollerUnavailableWindow func() time.Duration
 		// Time to hold a poll request before returning an empty response if there are no tasks
 		LongPollExpirationInterval func() time.Duration
+		BacklogTaskForwardTimeout  func() time.Duration
 		RangeSize                  int64
 		NewMatcher                 bool
 		GetTasksBatchSize          func() int
@@ -247,6 +249,7 @@ func NewConfig(
 		UpdateAckInterval:                        dynamicconfig.MatchingUpdateAckInterval.Get(dc),
 		MaxTaskQueueIdleTime:                     dynamicconfig.MatchingMaxTaskQueueIdleTime.Get(dc),
 		LongPollExpirationInterval:               dynamicconfig.MatchingLongPollExpirationInterval.Get(dc),
+		BacklogTaskForwardTimeout:                dynamicconfig.MatchingBacklogTaskForwardTimeout.Get(dc),
 		MinTaskThrottlingBurstSize:               dynamicconfig.MatchingMinTaskThrottlingBurstSize.Get(dc),
 		MaxTaskDeleteBatchSize:                   dynamicconfig.MatchingMaxTaskDeleteBatchSize.Get(dc),
 		TaskDeleteInterval:                       dynamicconfig.MatchingTaskDeleteInterval.Get(dc),
@@ -342,6 +345,9 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		QueryPollerUnavailableWindow: config.QueryPollerUnavailableWindow,
 		LongPollExpirationInterval: func() time.Duration {
 			return config.LongPollExpirationInterval(ns.String(), taskQueueName, taskType)
+		},
+		BacklogTaskForwardTimeout: func() time.Duration {
+			return config.BacklogTaskForwardTimeout(ns.String(), taskQueueName, taskType)
 		},
 		MaxTaskDeleteBatchSize: func() int {
 			return config.MaxTaskDeleteBatchSize(ns.String(), taskQueueName, taskType)

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -50,11 +50,6 @@ const (
 	// TODO(pri): old matcher cleanup, move to here
 	// taskReaderThrottleRetryDelay = 3 * time.Second
 
-	// Load more tasks when loaded count is <= MaxBatchSize/reloadFraction.
-	// E.g. if MaxBatchSize is 1000, then we'll load 1000, dispatch down to 200,
-	// load another batch to make 1200, down to 200, etc.
-	reloadFraction = 5 // TODO(pri): make dynamic config
-
 	concurrentAddRetries = 10
 )
 
@@ -170,7 +165,7 @@ func (tr *priTaskReader) completeTask(task *internalTask, res taskResponse) {
 
 	// use == so we just signal once when we cross this threshold
 	// TODO(pri): is this safe? maybe we need to improve this
-	if tr.loadedTasks == tr.backlogMgr.config.GetTasksBatchSize()/reloadFraction {
+	if tr.loadedTasks == tr.backlogMgr.config.GetTasksReloadAt() {
 		tr.Signal()
 	}
 
@@ -191,7 +186,7 @@ Loop:
 			return
 
 		case <-tr.notifyC:
-			if tr.getLoadedTasks() > tr.backlogMgr.config.GetTasksBatchSize()/reloadFraction {
+			if tr.getLoadedTasks() > tr.backlogMgr.config.GetTasksReloadAt() {
 				// Too many loaded already, ignore this signal. We'll get another signal when
 				// loadedTasks drops low enough.
 				continue Loop


### PR DESCRIPTION
## What changed?
- Add dynamic config for `matching.getTasksReloadAt`
- Add dynamic config for `matching.backlogTaskForwardTimeout`

## Why?
tuning ability