### PR TITLE
Port previous NewTestLogger flags over

### DIFF
--- a/common/log/zap_logger.go
+++ b/common/log/zap_logger.go
@@ -38,9 +38,10 @@ import (
 const (
 	skipForZapLogger = 3
 	// we put a default message when it is empty so that the log can be searchable/filterable
-	defaultMsgForEmpty  = "none"
-	testLogFormatEnvVar = "TEMPORAL_TEST_LOG_FORMAT" // set to "json" for json logs in tests
-	testLogLevelEnvVar  = "TEMPORAL_TEST_LOG_LEVEL"  // set to "debug" for debug level logs in tests
+	defaultMsgForEmpty = "none"
+	// TODO: once `NewTestLogger` has been removed, move these vars into testlogger.TestLogger
+	TestLogFormatEnvVar = "TEMPORAL_TEST_LOG_FORMAT" // set to "json" for json logs in tests
+	TestLogLevelEnvVar  = "TEMPORAL_TEST_LOG_LEVEL"  // set to "debug" for debug level logs in tests
 )
 
 type (
@@ -55,13 +56,13 @@ var _ Logger = (*zapLogger)(nil)
 
 // NewTestLogger returns a logger for tests
 func NewTestLogger() *zapLogger {
-	format := os.Getenv(testLogFormatEnvVar)
+	format := os.Getenv(TestLogFormatEnvVar)
 	if format == "" {
 		format = "console"
 	}
 
 	logger := BuildZapLogger(Config{
-		Level:       os.Getenv(testLogLevelEnvVar),
+		Level:       os.Getenv(TestLogLevelEnvVar),
 		Format:      format,
 		Development: true,
 	})

--- a/common/log/zap_logger.go
+++ b/common/log/zap_logger.go
@@ -55,6 +55,7 @@ type (
 var _ Logger = (*zapLogger)(nil)
 
 // NewTestLogger returns a logger for tests
+// Deprecated: Use testlogger.TestLogger instead.
 func NewTestLogger() *zapLogger {
 	format := os.Getenv(TestLogFormatEnvVar)
 	if format == "" {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Ports `TEMPORAL_TEST_LOG_FORMAT` and `TEMPORAL_TEST_LOG_LEVEL` to testlogger.TestLogger.

## Why?
<!-- Tell your future self why have you made these changes -->

To not break developer setups.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
