### PR TITLE
Fix Versioning3FunctionalSuite to run locally

### DIFF
--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -101,6 +101,10 @@ func (s *Versioning3Suite) SetupSuite() {
 		// this is overridden for tests using RunTestWithMatchingBehavior
 		dynamicconfig.MatchingNumTaskqueueReadPartitions.Key():  4,
 		dynamicconfig.MatchingNumTaskqueueWritePartitions.Key(): 4,
+
+		// Overriding the number of deployments that can be registered in a single namespace. Done only for this test suite
+		// since it creates a large number of unique deployments in the test suite's namespace.
+		dynamicconfig.MatchingMaxDeployments.Key(): 1000,
 	}
 	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- `Versioning3FunctionalSuite` creates a large number of deployments in a single namespace. It is important to override the limit to not make the suite fail.

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Ran this locally and it works. Existing CI.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
