### PR TITLE
Reload task queues on change to new matcher setting

### DIFF
--- a/service/matching/unloadcause_string_gen.go
+++ b/service/matching/unloadcause_string_gen.go
@@ -15,12 +15,13 @@ func _() {
 	_ = x[unloadCauseConflict-4]
 	_ = x[unloadCauseShuttingDown-5]
 	_ = x[unloadCauseForce-6]
-	_ = x[unloadCauseOtherError-7]
+	_ = x[unloadCauseConfigChange-7]
+	_ = x[unloadCauseOtherError-8]
 }
 
-const _unloadCause_name = "UnspecifiedInitErrorIdleMembershipConflictShuttingDownForceOtherError"
+const _unloadCause_name = "UnspecifiedInitErrorIdleMembershipConflictShuttingDownForceConfigChangeOtherError"
 
-var _unloadCause_index = [...]uint8{0, 11, 20, 24, 34, 42, 54, 59, 69}
+var _unloadCause_index = [...]uint8{0, 11, 20, 24, 34, 42, 54, 59, 71, 81}
 
 func (i unloadCause) String() string {
 	if i < 0 || i >= unloadCause(len(_unloadCause_index)-1) {


### PR DESCRIPTION
## What changed?
When `MatchingUseNewMatcher` changes, unload task queue (and let it get reloaded).

## Why?
Easily enable/disable new matcher without manually reloading task queues.

## How did you test it?
New functional test to flip back and forth, manually verified reload was happening.