### PR TITLE
Reenable new matcher for versioning 3 tests

### DIFF
--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -109,7 +109,7 @@ func (s *Versioning3Suite) SetupSuite() {
 		// Use new matcher for versioning tests. Ideally we would run everything with old and new,
 		// but for now we pick a subset of tests. Versioning tests exercise the most features of
 		// matching so they're a good condidate.
-		dynamicconfig.MatchingUseNewMatcher.Key(): false, // TODO(pri): restore after tests are fixed
+		dynamicconfig.MatchingUseNewMatcher.Key(): true,
 	}
 	s.FunctionalTestBase.SetupSuiteWithDefaultCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
 }


### PR DESCRIPTION
## What changed?
Reenable new matcher for versioning 3 tests. This works now after various fixes on the branch and on main.

## Why?
Test coverage