### PR TITLE
stop infinite activity retries in the entity workflows

### DIFF
--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -111,7 +111,6 @@ var (
 		StartToCloseTimeout: 1 * time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval: 100 * time.Millisecond,
-			MaximumInterval: 60 * time.Second,
 			MaximumAttempts: 5,
 		},
 	}

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -32,6 +32,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/common"
@@ -105,10 +106,19 @@ var (
 	)
 )
 
+var (
+	defaultActivityOptions = workflow.ActivityOptions{
+		StartToCloseTimeout: 1 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval: 100 * time.Millisecond,
+			MaximumInterval: 60 * time.Second,
+			MaximumAttempts: 5,
+		},
+	}
+)
+
 // validateVersionWfParams is a helper that verifies if the fields used for generating
 // Worker Deployment Version related workflowID's are valid
-// todo (Shivam): update with latest checks
-
 func validateVersionWfParams(fieldName string, field string, maxIDLengthLimit int) error {
 	// Length checks
 	if field == "" {

--- a/service/worker/workerdeployment/version_workflow.go
+++ b/service/worker/workerdeployment/version_workflow.go
@@ -26,7 +26,6 @@ package workerdeployment
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/pborman/uuid"
 	commonpb "go.temporal.io/api/common/v1"
@@ -55,16 +54,6 @@ type (
 		signalsCompleted       bool
 		drainageWorkflowFuture *workflow.ChildWorkflowFuture
 		done                   bool
-	}
-)
-
-var (
-	defaultActivityOptions = workflow.ActivityOptions{
-		StartToCloseTimeout: 1 * time.Minute,
-		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval: 100 * time.Millisecond,
-			MaximumInterval: 60 * time.Second,
-		},
 	}
 )
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Right now, entity workflows related to versioning have infinite number of retries happening. In the case of an unforeseen error, this might leave our internal entity workflows locked and might require manual intervention.
- The activity context, being used in all of the activities related to the worker-deployment workflows, now has a maximum number of attempts set to 5. This shall ensure that on the eve of an unforeseen error, the deployment workflow will unlock itself after a maximum time of ~5 mins. [ ~5 mins calculated by doing math involving backoff coefficient, initial interval and maximum attempts ]  

## Why?
<!-- Tell your future self why have you made these changes -->
- To not lock our own workflows.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Current Suite of tests to verify nothing is broken. 

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
