### PR TITLE
Added docs to visibility API quotas for EDU-4119

### DIFF
--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -175,7 +175,10 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkflowExecutions":         1,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListArchivedWorkflowExecutions": 1,
 
-		// APIs that rely on visibility
+		// APIs that rely on visibility.
+		// If you modify this list, please update the docs at
+		// https://docs.temporal.io/cloud/limits#visibility-api-rate-limit or in github at the link below
+		// https://github.com/temporalio/documentation/blob/main/docs/evaluate/temporal-cloud/limits.mdx#visibility-api-rate-limit
 		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkerTaskReachability":         1,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListSchedules":                     1,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListBatchOperations":               1,


### PR DESCRIPTION
## What changed?
Added a note to tell future maintainers that if they edit the visibility API list, they should also update the docs.

## Why?
- Main reason: so the docs don't get out of date
- Secondary reason: so the OSS team checks the PR into the docs to be sure it's right

## How did you test it?
I didn't

## Potential risks
Nothing

## Documentation
The intent of this is to aid docs maintenance

## Is hotfix candidate?
No
