### PR TITLE
Apply backoff retry for application error in replication stream

### DIFF
--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -41,7 +41,7 @@ import (
 
 var (
 	streamRetryPolicy = backoff.NewExponentialRetryPolicy(500 * time.Millisecond).
-		WithMaximumAttempts(50).
+		WithMaximumAttempts(100).
 		WithMaximumInterval(time.Second * 2)
 )
 

--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -31,11 +31,18 @@ import (
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/service/history/shard"
+)
+
+var (
+	streamRetryPolicy = backoff.NewExponentialRetryPolicy(500 * time.Millisecond).
+		WithMaximumAttempts(50).
+		WithMaximumInterval(time.Second * 2)
 )
 
 type (
@@ -69,49 +76,41 @@ func WrapEventLoop(
 	metricsHandler metrics.Handler,
 	fromClusterKey ClusterShardKey,
 	toClusterKey ClusterShardKey,
-	retryInterval time.Duration,
+	retryPolicy backoff.RetryPolicy,
 ) {
 	defer streamStopper()
 
-	for i := 0; i < 50; i++ {
+	longRunningOps := func() error {
 		err := originalEventLoop()
 
-		if err == nil { // shutdown case
-			return
+		if err != nil {
+			var streamError *StreamError
+			if errors.As(err, &streamError) {
+				metrics.ReplicationStreamError.With(metricsHandler).Record(
+					int64(1),
+					metrics.ServiceErrorTypeTag(streamError.cause),
+					metrics.FromClusterIDTag(fromClusterKey.ClusterID),
+					metrics.ToClusterIDTag(toClusterKey.ClusterID),
+				)
+				logger.Warn("ReplicationStreamError", tag.Error(err))
+			} else {
+				metrics.ReplicationServiceError.With(metricsHandler).Record(
+					int64(1),
+					metrics.ServiceErrorTypeTag(err),
+					metrics.FromClusterIDTag(fromClusterKey.ClusterID),
+					metrics.ToClusterIDTag(toClusterKey.ClusterID),
+				)
+				logger.Error("ReplicationServiceError", tag.Error(err))
+			}
+			return err
 		}
-		var streamError *StreamError
-		if errors.As(err, &streamError) {
-			metrics.ReplicationStreamError.With(metricsHandler).Record(
-				int64(1),
-				metrics.ServiceErrorTypeTag(streamError.cause),
-				metrics.FromClusterIDTag(fromClusterKey.ClusterID),
-				metrics.ToClusterIDTag(toClusterKey.ClusterID),
-			)
-			logger.Warn("ReplicationStreamError", tag.Error(err))
-		} else {
-			metrics.ReplicationServiceError.With(metricsHandler).Record(
-				int64(1),
-				metrics.ServiceErrorTypeTag(err),
-				metrics.FromClusterIDTag(fromClusterKey.ClusterID),
-				metrics.ToClusterIDTag(toClusterKey.ClusterID),
-			)
-			logger.Error("ReplicationServiceError", tag.Error(err))
-		}
-		// if it is not a retryable error, we will not retry and terminate the stream, then let the stream_receiver_monitor to restart it
-		if !IsRetryableError(err) {
-			return
-		}
-
-		time.Sleep(retryInterval)
+		// shutdown case
+		return nil
 	}
+	_ = backoff.ThrottleRetry(longRunningOps, retryPolicy, isRetryableError)
 }
 
-func IsStreamError(err error) bool {
-	var streamError *StreamError
-	return errors.As(err, &streamError)
-}
-
-func IsRetryableError(err error) bool {
+func isRetryableError(err error) bool {
 	if shard.IsShardOwnershipLostError(err) {
 		return false
 	}

--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -80,7 +80,7 @@ func WrapEventLoop(
 ) {
 	defer streamStopper()
 
-	longRunningOps := func() error {
+	ops := func() error {
 		err := originalEventLoop()
 
 		if err != nil {
@@ -107,7 +107,7 @@ func WrapEventLoop(
 		// shutdown case
 		return nil
 	}
-	_ = backoff.ThrottleRetry(longRunningOps, retryPolicy, isRetryableError)
+	_ = backoff.ThrottleRetry(ops, retryPolicy, isRetryableError)
 }
 
 func isRetryableError(err error) bool {

--- a/service/history/replication/stream_receiver.go
+++ b/service/history/replication/stream_receiver.go
@@ -143,8 +143,8 @@ func (r *StreamReceiverImpl) Start() {
 		return
 	}
 
-	go WrapEventLoop(r.sendEventLoop, r.Stop, r.logger, r.MetricsHandler, r.clientShardKey, r.serverShardKey, streamReceiverMonitorInterval)
-	go WrapEventLoop(r.recvEventLoop, r.Stop, r.logger, r.MetricsHandler, r.clientShardKey, r.serverShardKey, streamReceiverMonitorInterval)
+	go WrapEventLoop(r.sendEventLoop, r.Stop, r.logger, r.MetricsHandler, r.clientShardKey, r.serverShardKey, streamRetryPolicy)
+	go WrapEventLoop(r.recvEventLoop, r.Stop, r.logger, r.MetricsHandler, r.clientShardKey, r.serverShardKey, streamRetryPolicy)
 
 	r.logger.Info("StreamReceiver started.")
 }

--- a/service/history/replication/stream_test.go
+++ b/service/history/replication/stream_test.go
@@ -117,7 +117,7 @@ func TestWrapEventLoopFn_ReturnServiceError_ShouldRetryUntilStreamError(t *testi
 		stopFunc := func() {
 			stopFuncCallCount++
 		}
-		WrapEventLoop(originalEventLoop, stopFunc, log.NewNoopLogger(), metrics.NoopMetricsHandler, NewClusterShardKey(1, 1), NewClusterShardKey(2, 1), backoff.NewConstantDelayRetryPolicy(time.Millisecond))
+		WrapEventLoop(originalEventLoop, stopFunc, log.NewNoopLogger(), metrics.NoopMetricsHandler, NewClusterShardKey(1, 1), NewClusterShardKey(2, 1), streamRetryPolicy)
 		assertion.Equal(3, originalEventLoopCallCount)
 		assertion.Equal(1, stopFuncCallCount)
 

--- a/service/history/replication/stream_test.go
+++ b/service/history/replication/stream_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
@@ -50,7 +51,7 @@ func TestWrapEventLoopFn_ReturnStreamError_ShouldStopLoop(t *testing.T) {
 		stopFunc := func() {
 			stopFuncCallCount++
 		}
-		WrapEventLoop(originalEventLoop, stopFunc, log.NewNoopLogger(), metrics.NoopMetricsHandler, NewClusterShardKey(1, 1), NewClusterShardKey(2, 1), 0)
+		WrapEventLoop(originalEventLoop, stopFunc, log.NewNoopLogger(), metrics.NoopMetricsHandler, NewClusterShardKey(1, 1), NewClusterShardKey(2, 1), backoff.DisabledRetryPolicy)
 		assertion.Equal(1, originalEventLoopCallCount)
 		assertion.Equal(1, stopFuncCallCount)
 
@@ -82,7 +83,7 @@ func TestWrapEventLoopFn_ReturnShardOwnershipLostError_ShouldStopLoop(t *testing
 		stopFunc := func() {
 			stopFuncCallCount++
 		}
-		WrapEventLoop(originalEventLoop, stopFunc, log.NewNoopLogger(), metrics.NoopMetricsHandler, NewClusterShardKey(1, 1), NewClusterShardKey(2, 1), 0)
+		WrapEventLoop(originalEventLoop, stopFunc, log.NewNoopLogger(), metrics.NoopMetricsHandler, NewClusterShardKey(1, 1), NewClusterShardKey(2, 1), backoff.DisabledRetryPolicy)
 		assertion.Equal(1, originalEventLoopCallCount)
 		assertion.Equal(1, stopFuncCallCount)
 
@@ -116,7 +117,7 @@ func TestWrapEventLoopFn_ReturnServiceError_ShouldRetryUntilStreamError(t *testi
 		stopFunc := func() {
 			stopFuncCallCount++
 		}
-		WrapEventLoop(originalEventLoop, stopFunc, log.NewNoopLogger(), metrics.NoopMetricsHandler, NewClusterShardKey(1, 1), NewClusterShardKey(2, 1), 0)
+		WrapEventLoop(originalEventLoop, stopFunc, log.NewNoopLogger(), metrics.NoopMetricsHandler, NewClusterShardKey(1, 1), NewClusterShardKey(2, 1), backoff.NewConstantDelayRetryPolicy(time.Millisecond))
 		assertion.Equal(3, originalEventLoopCallCount)
 		assertion.Equal(1, stopFuncCallCount)
 


### PR DESCRIPTION
## What changed?
Apply backoff retry for application error in replication stream

## Why?
use backoff retry on application errors i.e. resource exhausted error

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
