### PR TITLE
[CHASM] SQL persistence for CHASM nodes

### DIFF
--- a/common/persistence/sql/execution.go
+++ b/common/persistence/sql/execution.go
@@ -322,6 +322,17 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get buffered events. Error: %v", err))
 	}
 
+	state.ChasmNodes, err = getChasmNodeMap(ctx,
+		m.Db,
+		request.ShardID,
+		namespaceID,
+		workflowID,
+		runID,
+	)
+	if err != nil {
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get CHASM nodes. Error: %v", err))
+	}
+
 	state.SignalRequestedIDs, err = getSignalsRequested(ctx,
 		m.Db,
 		request.ShardID,

--- a/common/persistence/sql/execution_state_map.go
+++ b/common/persistence/sql/execution_state_map.go
@@ -35,6 +35,7 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/primitives"
+	expmaps "golang.org/x/exp/maps"
 )
 
 func updateActivityInfos(
@@ -485,6 +486,94 @@ func deleteSignalInfoMap(
 		RunID:       runID,
 	}); err != nil {
 		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete signal info map. Error: %v", err))
+	}
+	return nil
+}
+
+func updateChasmNodes(
+	ctx context.Context,
+	tx sqlplugin.Tx,
+	chasmNodes map[string]*commonpb.DataBlob,
+	deleteIDs map[string]struct{},
+	shardID int32,
+	namespaceID primitives.UUID,
+	workflowID string,
+	runID primitives.UUID,
+) error {
+	if len(chasmNodes) > 0 {
+		rows := make([]sqlplugin.ChasmNodeMapsRow, 0, len(chasmNodes))
+		for path, blob := range chasmNodes {
+			rows = append(rows, sqlplugin.ChasmNodeMapsRow{
+				ShardID:      shardID,
+				NamespaceID:  namespaceID,
+				WorkflowID:   workflowID,
+				RunID:        runID,
+				ChasmPath:    path,
+				Data:         blob.Data,
+				DataEncoding: blob.EncodingType.String(),
+			})
+		}
+		if _, err := tx.ReplaceIntoChasmNodeMaps(ctx, rows); err != nil {
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update CHASM nodes. Failed to execute update query. Error: %v", err))
+		}
+	}
+
+	if len(deleteIDs) > 0 {
+		if _, err := tx.DeleteFromChasmNodeMaps(ctx, sqlplugin.ChasmNodeMapsFilter{
+			ShardID:     shardID,
+			NamespaceID: namespaceID,
+			WorkflowID:  workflowID,
+			RunID:       runID,
+			ChasmPaths:  expmaps.Keys(deleteIDs),
+		}); err != nil {
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update CHASM nodes. Failed to execute delete query. Error: %v", err))
+		}
+	}
+
+	return nil
+}
+
+func getChasmNodeMap(
+	ctx context.Context,
+	db sqlplugin.DB,
+	shardID int32,
+	namespaceID primitives.UUID,
+	workflowID string,
+	runID primitives.UUID,
+) (map[string]*commonpb.DataBlob, error) {
+	rows, err := db.SelectAllFromChasmNodeMaps(ctx, sqlplugin.ChasmNodeMapsAllFilter{
+		ShardID:     shardID,
+		NamespaceID: namespaceID,
+		WorkflowID:  workflowID,
+		RunID:       runID,
+	})
+	if err != nil && err != sql.ErrNoRows {
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get CHASM nodes. Error: %v", err))
+	}
+
+	ret := make(map[string]*commonpb.DataBlob)
+	for _, row := range rows {
+		ret[row.ChasmPath] = persistence.NewDataBlob(row.Data, row.DataEncoding)
+	}
+
+	return ret, nil
+}
+
+func deleteChasmNodeMap(
+	ctx context.Context,
+	tx sqlplugin.Tx,
+	shardID int32,
+	namespaceID primitives.UUID,
+	workflowID string,
+	runID primitives.UUID,
+) error {
+	if _, err := tx.DeleteAllFromChasmNodeMaps(ctx, sqlplugin.ChasmNodeMapsAllFilter{
+		ShardID:     shardID,
+		NamespaceID: namespaceID,
+		WorkflowID:  workflowID,
+		RunID:       runID,
+	}); err != nil {
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete CHASM node map. Error: %v", err))
 	}
 	return nil
 }

--- a/common/persistence/sql/execution_util.go
+++ b/common/persistence/sql/execution_util.go
@@ -196,6 +196,19 @@ func applyWorkflowMutationTx(
 	); err != nil {
 		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
 	}
+
+	if err := updateChasmNodes(ctx,
+		tx,
+		workflowMutation.UpsertChasmNodes,
+		workflowMutation.DeleteChasmNodes,
+		shardID,
+		namespaceIDBytes,
+		workflowID,
+		runIDBytes,
+	); err != nil {
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+	}
+
 	return nil
 }
 
@@ -399,6 +412,29 @@ func applyWorkflowSnapshotTxAsReset(
 	); err != nil {
 		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear buffered events. Error: %v", err))
 	}
+
+	if err := deleteChasmNodeMap(ctx,
+		tx,
+		shardID,
+		namespaceIDBytes,
+		workflowID,
+		runIDBytes,
+	); err != nil {
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear CHASM nodes. Error: %v", err))
+	}
+
+	if err := updateChasmNodes(ctx,
+		tx,
+		workflowSnapshot.ChasmNodes,
+		nil,
+		shardID,
+		namespaceIDBytes,
+		workflowID,
+		runIDBytes,
+	); err != nil {
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to update CHASM nodes. Error: %v", err))
+	}
+
 	return nil
 }
 
@@ -514,6 +550,18 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		runIDBytes,
 	); err != nil {
 		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into signals requested set after clearing. Error: %v", err))
+	}
+
+	if err := updateChasmNodes(ctx,
+		tx,
+		workflowSnapshot.ChasmNodes,
+		nil,
+		shardID,
+		namespaceIDBytes,
+		workflowID,
+		runIDBytes,
+	); err != nil {
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to update CHASM nodes. Error: %v", err))
 	}
 
 	return nil

--- a/common/persistence/sql/sqlplugin/history_chasm.go
+++ b/common/persistence/sql/sqlplugin/history_chasm.go
@@ -1,3 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package sqlplugin
 
 import (

--- a/common/persistence/sql/sqlplugin/history_chasm.go
+++ b/common/persistence/sql/sqlplugin/history_chasm.go
@@ -1,0 +1,54 @@
+package sqlplugin
+
+import (
+	"context"
+	"database/sql"
+
+	"go.temporal.io/server/common/primitives"
+)
+
+type (
+	// ChasmNodeMapsRow represents a row in the chasm_node_maps table.
+	ChasmNodeMapsRow struct {
+		ShardID      int32
+		NamespaceID  primitives.UUID
+		WorkflowID   string
+		RunID        primitives.UUID
+		ChasmPath    string
+		Data         []byte
+		DataEncoding string
+	}
+
+	// ChasmNodeMapsFilter represents parameters to selecting a particular subset of
+	// a workflow's CHASM nodes.
+	ChasmNodeMapsFilter struct {
+		ShardID     int32
+		NamespaceID primitives.UUID
+		WorkflowID  string
+		RunID       primitives.UUID
+		ChasmPaths  []string
+	}
+
+	// ChasmNodeMapsFilter represents parameters to selecting all of a workflow's
+	// CHASM nodes.
+	ChasmNodeMapsAllFilter struct {
+		ShardID     int32
+		NamespaceID primitives.UUID
+		WorkflowID  string
+		RunID       primitives.UUID
+	}
+
+	HistoryExecutionChasm interface {
+		// SelectAllFromChasmNodeMaps returns all rows related to a particular workflow from the chasm_node_maps table.
+		SelectAllFromChasmNodeMaps(ctx context.Context, filter ChasmNodeMapsAllFilter) ([]ChasmNodeMapsRow, error)
+
+		// ReplaceIntoChasmNodeMaps replaces one or more rows in the chasm_node_maps table.
+		ReplaceIntoChasmNodeMaps(ctx context.Context, rows []ChasmNodeMapsRow) (sql.Result, error)
+
+		// DeleteFromChasmNodeMaps deletes one or more rows in the chasm_node_maps table.
+		DeleteFromChasmNodeMaps(ctx context.Context, filter ChasmNodeMapsFilter) (sql.Result, error)
+
+		// DeleteAllFromChasmNodeMaps deletes all rows related to a particular workflow in the chasm_node_maps table.
+		DeleteAllFromChasmNodeMaps(ctx context.Context, filter ChasmNodeMapsAllFilter) (sql.Result, error)
+	}
+)

--- a/common/persistence/sql/sqlplugin/history_chasm.go
+++ b/common/persistence/sql/sqlplugin/history_chasm.go
@@ -53,7 +53,7 @@ type (
 		ChasmPaths  []string
 	}
 
-	// ChasmNodeMapsFilter represents parameters to selecting all of a workflow's
+	// ChasmNodeMapsAllFilter represents parameters to selecting all of a workflow's
 	// CHASM nodes.
 	ChasmNodeMapsAllFilter struct {
 		ShardID     int32

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -86,6 +86,7 @@ type (
 		HistoryExecutionRequestCancel
 		HistoryExecutionSignal
 		HistoryExecutionSignalRequest
+		HistoryExecutionChasm
 
 		HistoryImmediateTask
 		HistoryScheduledTask

--- a/common/persistence/sql/sqlplugin/mysql/execution_maps.go
+++ b/common/persistence/sql/sqlplugin/mysql/execution_maps.go
@@ -645,3 +645,82 @@ func (mdb *db) DeleteAllFromSignalsRequestedSets(
 		filter.RunID,
 	)
 }
+
+var (
+	chasmNodeColumns = []string{
+		"data",
+		"data_encoding",
+	}
+	chasmNodeTableName = "chasm_node_maps"
+	chasmNodeKey       = "chasm_path"
+
+	deleteChasmNodeMapSQLQuery      = makeDeleteMapQry(chasmNodeTableName)
+	setKeyInChasmNodeMapSQLQuery    = makeSetKeyInMapQry(chasmNodeTableName, chasmNodeColumns, chasmNodeKey)
+	deleteKeyInChasmNodeMapSQLQuery = makeDeleteKeyInMapQry(chasmNodeTableName, chasmNodeKey)
+	getChasmNodeMapSQLQuery         = makeGetMapQryTemplate(chasmNodeTableName, chasmNodeColumns, chasmNodeKey)
+)
+
+func (mdb *db) SelectAllFromChasmNodeMaps(
+	ctx context.Context,
+	filter sqlplugin.ChasmNodeMapsAllFilter,
+) ([]sqlplugin.ChasmNodeMapsRow, error) {
+	var rows []sqlplugin.ChasmNodeMapsRow
+
+	if err := mdb.SelectContext(ctx,
+		&rows,
+		getChasmNodeMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	); err != nil {
+		return nil, err
+	}
+
+	for i := range rows {
+		rows[i].ShardID = filter.ShardID
+		rows[i].NamespaceID = filter.NamespaceID
+		rows[i].WorkflowID = filter.WorkflowID
+		rows[i].RunID = filter.RunID
+	}
+
+	return rows, nil
+}
+
+func (mdb *db) ReplaceIntoChasmNodeMaps(
+	ctx context.Context,
+	rows []sqlplugin.ChasmNodeMapsRow,
+) (sql.Result, error) {
+	return mdb.NamedExecContext(ctx,
+		setKeyInChasmNodeMapSQLQuery,
+		rows,
+	)
+}
+
+func (mdb *db) DeleteFromChasmNodeMaps(ctx context.Context, filter sqlplugin.ChasmNodeMapsFilter) (sql.Result, error) {
+	query, args, err := sqlx.In(
+		deleteKeyInChasmNodeMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+		filter.ChasmPaths,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return mdb.ExecContext(ctx,
+		mdb.Rebind(query),
+		args...,
+	)
+}
+
+func (mdb *db) DeleteAllFromChasmNodeMaps(ctx context.Context, filter sqlplugin.ChasmNodeMapsAllFilter) (sql.Result, error) {
+	return mdb.ExecContext(ctx,
+		deleteChasmNodeMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}

--- a/common/persistence/sql/sqlplugin/postgresql/execution_maps.go
+++ b/common/persistence/sql/sqlplugin/postgresql/execution_maps.go
@@ -648,3 +648,82 @@ func (pdb *db) DeleteAllFromSignalsRequestedSets(
 		filter.RunID,
 	)
 }
+
+var (
+	chasmNodeColumns = []string{
+		"data",
+		"data_encoding",
+	}
+	chasmNodeTableName = "chasm_node_maps"
+	chasmNodeKey       = "chasm_path"
+
+	deleteChasmNodeMapSQLQuery      = makeDeleteMapQry(chasmNodeTableName)
+	setKeyInChasmNodeMapSQLQuery    = makeSetKeyInMapQry(chasmNodeTableName, chasmNodeColumns, chasmNodeKey)
+	deleteKeyInChasmNodeMapSQLQuery = makeDeleteKeyInMapQry(chasmNodeTableName, chasmNodeKey)
+	getChasmNodeMapSQLQuery         = makeGetMapQryTemplate(chasmNodeTableName, chasmNodeColumns, chasmNodeKey)
+)
+
+func (pdb *db) SelectAllFromChasmNodeMaps(
+	ctx context.Context,
+	filter sqlplugin.ChasmNodeMapsAllFilter,
+) ([]sqlplugin.ChasmNodeMapsRow, error) {
+	var rows []sqlplugin.ChasmNodeMapsRow
+
+	if err := pdb.SelectContext(ctx,
+		&rows,
+		getChasmNodeMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	); err != nil {
+		return nil, err
+	}
+
+	for i := range rows {
+		rows[i].ShardID = filter.ShardID
+		rows[i].NamespaceID = filter.NamespaceID
+		rows[i].WorkflowID = filter.WorkflowID
+		rows[i].RunID = filter.RunID
+	}
+
+	return rows, nil
+}
+
+func (pdb *db) ReplaceIntoChasmNodeMaps(
+	ctx context.Context,
+	rows []sqlplugin.ChasmNodeMapsRow,
+) (sql.Result, error) {
+	return pdb.NamedExecContext(ctx,
+		setKeyInChasmNodeMapSQLQuery,
+		rows,
+	)
+}
+
+func (pdb *db) DeleteFromChasmNodeMaps(ctx context.Context, filter sqlplugin.ChasmNodeMapsFilter) (sql.Result, error) {
+	query, args, err := sqlx.In(
+		deleteKeyInChasmNodeMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+		filter.ChasmPaths,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return pdb.ExecContext(ctx,
+		pdb.Rebind(query),
+		args...,
+	)
+}
+
+func (pdb *db) DeleteAllFromChasmNodeMaps(ctx context.Context, filter sqlplugin.ChasmNodeMapsAllFilter) (sql.Result, error) {
+	return pdb.ExecContext(ctx,
+		deleteChasmNodeMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}

--- a/common/persistence/sql/sqlplugin/sqlite/execution_maps.go
+++ b/common/persistence/sql/sqlplugin/sqlite/execution_maps.go
@@ -646,3 +646,82 @@ func (mdb *db) DeleteAllFromSignalsRequestedSets(
 		filter.RunID,
 	)
 }
+
+var (
+	chasmNodeColumns = []string{
+		"data",
+		"data_encoding",
+	}
+	chasmNodeTableName = "chasm_node_maps"
+	chasmNodeKey       = "chasm_path"
+
+	deleteChasmNodeMapSQLQuery      = makeDeleteMapQry(chasmNodeTableName)
+	setKeyInChasmNodeMapSQLQuery    = makeSetKeyInMapQry(chasmNodeTableName, chasmNodeColumns, chasmNodeKey)
+	deleteKeyInChasmNodeMapSQLQuery = makeDeleteKeyInMapQry(chasmNodeTableName, chasmNodeKey)
+	getChasmNodeMapSQLQuery         = makeGetMapQryTemplate(chasmNodeTableName, chasmNodeColumns, chasmNodeKey)
+)
+
+func (mdb *db) SelectAllFromChasmNodeMaps(
+	ctx context.Context,
+	filter sqlplugin.ChasmNodeMapsAllFilter,
+) ([]sqlplugin.ChasmNodeMapsRow, error) {
+	var rows []sqlplugin.ChasmNodeMapsRow
+
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getChasmNodeMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	); err != nil {
+		return nil, err
+	}
+
+	for i := range rows {
+		rows[i].ShardID = filter.ShardID
+		rows[i].NamespaceID = filter.NamespaceID
+		rows[i].WorkflowID = filter.WorkflowID
+		rows[i].RunID = filter.RunID
+	}
+
+	return rows, nil
+}
+
+func (mdb *db) ReplaceIntoChasmNodeMaps(
+	ctx context.Context,
+	rows []sqlplugin.ChasmNodeMapsRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		setKeyInChasmNodeMapSQLQuery,
+		rows,
+	)
+}
+
+func (mdb *db) DeleteFromChasmNodeMaps(ctx context.Context, filter sqlplugin.ChasmNodeMapsFilter) (sql.Result, error) {
+	query, args, err := sqlx.In(
+		deleteKeyInChasmNodeMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+		filter.ChasmPaths,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return mdb.conn.ExecContext(ctx,
+		mdb.conn.Rebind(query),
+		args...,
+	)
+}
+
+func (mdb *db) DeleteAllFromChasmNodeMaps(ctx context.Context, filter sqlplugin.ChasmNodeMapsAllFilter) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteChasmNodeMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}

--- a/common/persistence/sql/sqlplugin/tests/history_execution_chasm.go
+++ b/common/persistence/sql/sqlplugin/tests/history_execution_chasm.go
@@ -1,3 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package tests
 
 import (

--- a/common/persistence/sql/sqlplugin/tests/history_execution_chasm.go
+++ b/common/persistence/sql/sqlplugin/tests/history_execution_chasm.go
@@ -87,8 +87,8 @@ func (s *historyExecutionChasmSuite) runTestCase(tc *testCase) {
 		s.NoError(err)
 
 		// We set clientFoundRows to true in our MySQL session, which makes the result count
-		// for updates not useful for comparison here, as rows matched by WHERE (not just
-		// those updated with IN) are counted:
+		// for updates not useful for comparison here, as rows that have been updated
+		// are double-counted in `INSERT ... ON DUPLICATE KEY UPDATE` statements:
 		//
 		// https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_row-count
 		//

--- a/common/persistence/sql/sqlplugin/tests/history_execution_chasm.go
+++ b/common/persistence/sql/sqlplugin/tests/history_execution_chasm.go
@@ -1,0 +1,251 @@
+package tests
+
+import (
+	"math/rand/v2"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	"go.temporal.io/server/common/primitives"
+)
+
+type (
+	historyExecutionChasmSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		store sqlplugin.HistoryExecutionChasm
+	}
+)
+
+func NewHistoryExecutionChasmSuite(
+	t *testing.T,
+	store sqlplugin.HistoryExecutionChasm,
+) *historyExecutionChasmSuite {
+	return &historyExecutionChasmSuite{
+		Assertions: require.New(t),
+		store:      store,
+	}
+}
+
+func (s *historyExecutionChasmSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+
+type testCase struct {
+	InsertRows    []sqlplugin.ChasmNodeMapsRow
+	ReplaceRows   []sqlplugin.ChasmNodeMapsRow // executed after InsertRows to test update functionality
+	DeleteRows    *sqlplugin.ChasmNodeMapsFilter
+	DeleteAllRows *sqlplugin.ChasmNodeMapsAllFilter
+
+	ExpectedRowsFilter sqlplugin.ChasmNodeMapsAllFilter // used to selected the rows compared against ExpectedRows
+	ExpectedRows       []sqlplugin.ChasmNodeMapsRow     // asserted after all mutations are completed
+}
+
+func (s *historyExecutionChasmSuite) runTestCase(tc *testCase) {
+	ctx := newExecutionContext()
+
+	if len(tc.InsertRows) > 0 {
+		res, err := s.store.ReplaceIntoChasmNodeMaps(ctx, tc.InsertRows)
+		s.NoError(err)
+		affected, err := res.RowsAffected()
+		s.NoError(err)
+		s.Equal(int64(len(tc.InsertRows)), affected)
+	}
+
+	// Inserts and Replaces are applied identically, but in sequence.
+	if len(tc.ReplaceRows) > 0 {
+		res, err := s.store.ReplaceIntoChasmNodeMaps(ctx, tc.ReplaceRows)
+		s.NoError(err)
+		affected, err := res.RowsAffected()
+		s.NoError(err)
+
+		// We set clientFoundRows to true in our MySQL session, which makes the result count
+		// for updates not useful for comparison here, as rows matched by WHERE (not just
+		// those updated with IN) are counted:
+		//
+		// https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_row-count
+		//
+		// See common/persistence/sql/sqlplugin/mysql/session/session.go
+		if !strings.Contains(strings.ToLower(s.T().Name()), "mysql") {
+			s.Equal(int64(len(tc.ReplaceRows)), affected)
+		}
+	}
+
+	if tc.DeleteRows != nil {
+		res, err := s.store.DeleteFromChasmNodeMaps(ctx, *tc.DeleteRows)
+		s.NoError(err)
+		affected, err := res.RowsAffected()
+		s.NoError(err)
+		s.Equal(int64(len(tc.DeleteRows.ChasmPaths)), affected)
+	}
+
+	if tc.DeleteAllRows != nil {
+		_, err := s.store.DeleteAllFromChasmNodeMaps(ctx, *tc.DeleteAllRows)
+		s.NoError(err)
+	}
+
+	// Verify expected rows are set after all mutations are applied.
+	actualRows, err := s.store.SelectAllFromChasmNodeMaps(ctx, tc.ExpectedRowsFilter)
+	s.NoError(err)
+	s.ElementsMatch(tc.ExpectedRows, actualRows)
+}
+
+func newChasmNodeMapsAllFilter() sqlplugin.ChasmNodeMapsAllFilter {
+	return sqlplugin.ChasmNodeMapsAllFilter{
+		ShardID:     rand.Int32(),
+		NamespaceID: primitives.NewUUID(),
+		WorkflowID:  primitives.NewUUID().String(),
+		RunID:       primitives.NewUUID(),
+	}
+}
+
+func newChasmRowFromFilter(filter sqlplugin.ChasmNodeMapsAllFilter) sqlplugin.ChasmNodeMapsRow {
+	return sqlplugin.ChasmNodeMapsRow{
+		ShardID:      filter.ShardID,
+		NamespaceID:  filter.NamespaceID,
+		WorkflowID:   filter.WorkflowID,
+		RunID:        filter.RunID,
+		ChasmPath:    primitives.NewUUID().String(),
+		Data:         []byte(primitives.NewUUID().String()),
+		DataEncoding: "utf8",
+	}
+}
+
+func (s *historyExecutionChasmSuite) TestInsert() {
+	filter := newChasmNodeMapsAllFilter()
+
+	var expectedRows []sqlplugin.ChasmNodeMapsRow
+	for range 10 {
+		expectedRows = append(expectedRows, newChasmRowFromFilter(filter))
+	}
+
+	tc := &testCase{
+		InsertRows:         expectedRows,
+		ExpectedRowsFilter: filter,
+		ExpectedRows:       expectedRows,
+	}
+	s.runTestCase(tc)
+}
+
+func (s *historyExecutionChasmSuite) TestUpdate() {
+	filter := newChasmNodeMapsAllFilter()
+
+	var initialRows []sqlplugin.ChasmNodeMapsRow
+	for range 10 {
+		initialRows = append(initialRows, newChasmRowFromFilter(filter))
+	}
+
+	// Update first half of inserted rows.
+	pivot := len(initialRows) / 2
+	updatedRows := make([]sqlplugin.ChasmNodeMapsRow, pivot)
+	for i, row := range initialRows[:pivot] {
+		path := row.ChasmPath
+		updatedRows[i] = newChasmRowFromFilter(filter)
+		updatedRows[i].ChasmPath = path
+	}
+	unchangedRows := initialRows[pivot:]
+	expectedRows := append(updatedRows, unchangedRows...)
+	s.NotElementsMatch(initialRows, expectedRows)
+
+	tc := &testCase{
+		InsertRows:         initialRows,
+		ReplaceRows:        updatedRows,
+		ExpectedRowsFilter: filter,
+		ExpectedRows:       expectedRows,
+	}
+	s.runTestCase(tc)
+}
+
+func (s *historyExecutionChasmSuite) TestDelete() {
+	filter := newChasmNodeMapsAllFilter()
+
+	var initialRows []sqlplugin.ChasmNodeMapsRow
+	for range 10 {
+		initialRows = append(initialRows, newChasmRowFromFilter(filter))
+	}
+
+	// Delete half of inserted rows.
+	pivot := len(initialRows) / 2
+	var deletedPaths []string
+	for _, row := range initialRows[pivot:] {
+		deletedPaths = append(deletedPaths, row.ChasmPath)
+	}
+	expectedRows := initialRows[:pivot]
+
+	tc := &testCase{
+		InsertRows: initialRows,
+		DeleteRows: &sqlplugin.ChasmNodeMapsFilter{
+			ShardID:     filter.ShardID,
+			NamespaceID: filter.NamespaceID,
+			WorkflowID:  filter.WorkflowID,
+			RunID:       filter.RunID,
+			ChasmPaths:  deletedPaths,
+		},
+		ExpectedRowsFilter: filter,
+		ExpectedRows:       expectedRows,
+	}
+	s.runTestCase(tc)
+}
+
+func (s *historyExecutionChasmSuite) TestDeleteAll() {
+	filter := newChasmNodeMapsAllFilter()
+
+	var initialRows []sqlplugin.ChasmNodeMapsRow
+	for range 10 {
+		initialRows = append(initialRows, newChasmRowFromFilter(filter))
+	}
+
+	tc := &testCase{
+		InsertRows:         initialRows,
+		DeleteAllRows:      &filter,
+		ExpectedRowsFilter: filter,
+		ExpectedRows:       nil,
+	}
+	s.runTestCase(tc)
+}
+
+func (s *historyExecutionChasmSuite) TestInsertReplaceDelete() {
+	filter := newChasmNodeMapsAllFilter()
+
+	// Insert 15 rows.
+	var initialRows []sqlplugin.ChasmNodeMapsRow
+	for range 15 {
+		initialRows = append(initialRows, newChasmRowFromFilter(filter))
+	}
+
+	// Delete a third of the inserted rows.
+	pivot := len(initialRows) / 3
+	var deletedPaths []string
+	for _, row := range initialRows[:pivot] {
+		deletedPaths = append(deletedPaths, row.ChasmPath)
+	}
+
+	// Replace another third of the inserted rows.
+	updatedRows := make([]sqlplugin.ChasmNodeMapsRow, pivot)
+	for i := range pivot {
+		path := initialRows[i+pivot].ChasmPath
+		updatedRows[i] = newChasmRowFromFilter(filter)
+		updatedRows[i].ChasmPath = path
+	}
+
+	// Last third of initial batch, and updated rows, remain.
+	expectedRows := append(initialRows[pivot*2:], updatedRows...)
+
+	tc := &testCase{
+		InsertRows:  initialRows,
+		ReplaceRows: updatedRows,
+		DeleteRows: &sqlplugin.ChasmNodeMapsFilter{
+			ShardID:     filter.ShardID,
+			NamespaceID: filter.NamespaceID,
+			WorkflowID:  filter.WorkflowID,
+			RunID:       filter.RunID,
+			ChasmPaths:  deletedPaths,
+		},
+		ExpectedRowsFilter: filter,
+		ExpectedRows:       expectedRows,
+	}
+	s.runTestCase(tc)
+}

--- a/common/persistence/tests/mysql_test.go
+++ b/common/persistence/tests/mysql_test.go
@@ -524,6 +524,23 @@ func TestMySQLHistoryExecutionTimerSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
+func TestMySQLHistoryExecutionChasmSuite(t *testing.T) {
+	cfg := NewMySQLConfig()
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+	if err != nil {
+		t.Fatalf("unable to create MySQL DB: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+		TearDownMySQLDatabase(t, cfg)
+	}()
+
+	s := sqltests.NewHistoryExecutionChasmSuite(t, store)
+	suite.Run(t, s)
+}
+
 func TestMySQLHistoryExecutionRequestCancelSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(t, cfg)

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -524,6 +524,24 @@ func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionTimerSuite() {
 	suite.Run(p.T(), s)
 }
 
+func (p *PostgreSQLSuite) TestPostgresHistoryExecutionChasmSuite() {
+	cfg := NewPostgreSQLConfig(p.pluginName)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
+
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+	if err != nil {
+		p.T().Fatalf("unable to create Postgres DB: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+		TearDownPostgreSQLDatabase(p.T(), cfg)
+	}()
+
+	s := sqltests.NewHistoryExecutionChasmSuite(p.T(), store)
+	suite.Run(p.T(), s)
+}
+
 func (p *PostgreSQLSuite) TestPostgreSQLHistoryExecutionRequestCancelSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(p.T(), cfg)

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -771,6 +771,20 @@ func TestSQLiteHistoryExecutionTimerSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
+func TestSQLiteHistoryExecutionChasmSuite(t *testing.T) {
+	cfg := NewSQLiteMemoryConfig()
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+	if err != nil {
+		t.Fatalf("unable to create SQLite DB: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+	}()
+
+	s := sqltests.NewHistoryExecutionChasmSuite(t, store)
+	suite.Run(t, s)
+}
+
 func TestSQLiteHistoryExecutionRequestCancelSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -1071,6 +1085,19 @@ func TestSQLiteFileHistoryExecutionTimerSuite(t *testing.T) {
 	defer os.Remove(cfg.DatabaseName)
 
 	s := sqltests.NewHistoryExecutionTimerSuite(t, store)
+	suite.Run(t, s)
+}
+
+func TestSQLiteFileHistoryExecutionChasmSuite(t *testing.T) {
+	cfg := NewSQLiteFileConfig()
+	SetupSQLiteDatabase(t, cfg)
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+	if err != nil {
+		t.Fatalf("unable to create SQLite DB: %v", err)
+	}
+	defer os.Remove(cfg.DatabaseName)
+
+	s := sqltests.NewHistoryExecutionChasmSuite(t, store)
 	suite.Run(t, s)
 }
 

--- a/common/persistence/tests/util.go
+++ b/common/persistence/tests/util.go
@@ -71,7 +71,7 @@ func RandomSnapshot(
 ) (*p.WorkflowSnapshot, []*p.WorkflowEvents) {
 	// TODO - remove this branching when other persistence implementations land for CHASM
 	var chasmNodes map[string]*persistencespb.ChasmNode
-	if !strings.HasPrefix(t.Name(), "TestSaas") {
+	if !strings.HasPrefix(t.Name(), "TestCDS") {
 		chasmNodes = RandomChasmNodeMap()
 	}
 
@@ -124,7 +124,7 @@ func RandomMutation(
 ) (*p.WorkflowMutation, []*p.WorkflowEvents) {
 	// TODO - remove this branching when other persistence implementations land for CHASM
 	var chasmNodes map[string]*persistencespb.ChasmNode
-	if !strings.HasPrefix(t.Name(), "TestSaas") {
+	if !strings.HasPrefix(t.Name(), "TestCDS") {
 		chasmNodes = RandomChasmNodeMap()
 	}
 

--- a/common/persistence/tests/util.go
+++ b/common/persistence/tests/util.go
@@ -26,6 +26,7 @@ package tests
 
 import (
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -68,6 +69,12 @@ func RandomSnapshot(
 	dbRecordVersion int64,
 	branchToken []byte,
 ) (*p.WorkflowSnapshot, []*p.WorkflowEvents) {
+	// TODO - remove this branching when other persistence implementations land for CHASM
+	var chasmNodes map[string]*persistencespb.ChasmNode
+	if !strings.HasPrefix(t.Name(), "TestSaas") {
+		chasmNodes = RandomChasmNodeMap()
+	}
+
 	snapshot := &p.WorkflowSnapshot{
 		ExecutionInfo:  RandomExecutionInfo(namespaceID, workflowID, eventID, lastWriteVersion, branchToken),
 		ExecutionState: RandomExecutionState(runID, state, status),
@@ -80,7 +87,7 @@ func RandomSnapshot(
 		RequestCancelInfos:  RandomInt64RequestCancelInfoMap(),
 		SignalInfos:         RandomInt64SignalInfoMap(),
 		SignalRequestedIDs:  map[string]struct{}{uuid.New().String(): {}},
-		ChasmNodes:          RandomChasmNodeMap(),
+		ChasmNodes:          chasmNodes,
 
 		Tasks: map[tasks.Category][]tasks.Task{
 			tasks.CategoryTransfer:    {},
@@ -115,6 +122,12 @@ func RandomMutation(
 	dbRecordVersion int64,
 	branchToken []byte,
 ) (*p.WorkflowMutation, []*p.WorkflowEvents) {
+	// TODO - remove this branching when other persistence implementations land for CHASM
+	var chasmNodes map[string]*persistencespb.ChasmNode
+	if !strings.HasPrefix(t.Name(), "TestSaas") {
+		chasmNodes = RandomChasmNodeMap()
+	}
+
 	mutation := &p.WorkflowMutation{
 		ExecutionInfo:  RandomExecutionInfo(namespaceID, workflowID, eventID, lastWriteVersion, branchToken),
 		ExecutionState: RandomExecutionState(runID, state, status),
@@ -133,7 +146,7 @@ func RandomMutation(
 		DeleteSignalInfos:         map[int64]struct{}{rand.Int63(): {}},
 		UpsertSignalRequestedIDs:  map[string]struct{}{uuid.New().String(): {}},
 		DeleteSignalRequestedIDs:  map[string]struct{}{uuid.New().String(): {}},
-		UpsertChasmNodes:          RandomChasmNodeMap(),
+		UpsertChasmNodes:          chasmNodes,
 		DeleteChasmNodes:          map[string]struct{}{uuid.New().String(): {}},
 		// NewBufferedEvents: see below
 		// ClearBufferedEvents: see below

--- a/common/persistence/tests/util.go
+++ b/common/persistence/tests/util.go
@@ -26,7 +26,6 @@ package tests
 
 import (
 	"math/rand"
-	"strings"
 	"testing"
 	"time"
 
@@ -69,12 +68,6 @@ func RandomSnapshot(
 	dbRecordVersion int64,
 	branchToken []byte,
 ) (*p.WorkflowSnapshot, []*p.WorkflowEvents) {
-	// TODO - remove this branching when other persistence implementations land for CHASM
-	var chasmNodes map[string]*persistencespb.ChasmNode
-	if strings.HasPrefix(t.Name(), "TestCassandra") {
-		chasmNodes = RandomChasmNodeMap()
-	}
-
 	snapshot := &p.WorkflowSnapshot{
 		ExecutionInfo:  RandomExecutionInfo(namespaceID, workflowID, eventID, lastWriteVersion, branchToken),
 		ExecutionState: RandomExecutionState(runID, state, status),
@@ -87,7 +80,7 @@ func RandomSnapshot(
 		RequestCancelInfos:  RandomInt64RequestCancelInfoMap(),
 		SignalInfos:         RandomInt64SignalInfoMap(),
 		SignalRequestedIDs:  map[string]struct{}{uuid.New().String(): {}},
-		ChasmNodes:          chasmNodes,
+		ChasmNodes:          RandomChasmNodeMap(),
 
 		Tasks: map[tasks.Category][]tasks.Task{
 			tasks.CategoryTransfer:    {},
@@ -122,12 +115,6 @@ func RandomMutation(
 	dbRecordVersion int64,
 	branchToken []byte,
 ) (*p.WorkflowMutation, []*p.WorkflowEvents) {
-	// TODO - remove this branching when other persistence implementations land for CHASM
-	var chasmNodes map[string]*persistencespb.ChasmNode
-	if strings.HasPrefix(t.Name(), "TestCassandra") {
-		chasmNodes = RandomChasmNodeMap()
-	}
-
 	mutation := &p.WorkflowMutation{
 		ExecutionInfo:  RandomExecutionInfo(namespaceID, workflowID, eventID, lastWriteVersion, branchToken),
 		ExecutionState: RandomExecutionState(runID, state, status),
@@ -146,7 +133,7 @@ func RandomMutation(
 		DeleteSignalInfos:         map[int64]struct{}{rand.Int63(): {}},
 		UpsertSignalRequestedIDs:  map[string]struct{}{uuid.New().String(): {}},
 		DeleteSignalRequestedIDs:  map[string]struct{}{uuid.New().String(): {}},
-		UpsertChasmNodes:          chasmNodes,
+		UpsertChasmNodes:          RandomChasmNodeMap(),
 		DeleteChasmNodes:          map[string]struct{}{uuid.New().String(): {}},
 		// NewBufferedEvents: see below
 		// ClearBufferedEvents: see below

--- a/schema/mysql/v8/temporal/schema.sql
+++ b/schema/mysql/v8/temporal/schema.sql
@@ -256,7 +256,7 @@ CREATE TABLE chasm_node_maps (
   namespace_id BINARY(16) NOT NULL,
   workflow_id VARCHAR(255) NOT NULL,
   run_id BINARY(16) NOT NULL,
-  chasm_path VARCHAR(384) NOT NULL,
+  chasm_path VARBINARY(1536) NOT NULL,
 --
   data MEDIUMBLOB NOT NULL,
   data_encoding VARCHAR(16),

--- a/schema/mysql/v8/temporal/schema.sql
+++ b/schema/mysql/v8/temporal/schema.sql
@@ -251,6 +251,18 @@ CREATE TABLE signals_requested_sets (
   PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, signal_id)
 );
 
+CREATE TABLE chasm_node_maps (
+  shard_id INT NOT NULL,
+  namespace_id BINARY(16) NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BINARY(16) NOT NULL,
+  chasm_path VARCHAR(384) NOT NULL,
+--
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, chasm_path)
+);
+
 -- history eventsV2: history_node stores history event data
 CREATE TABLE history_node (
   shard_id       INT NOT NULL,

--- a/schema/mysql/v8/temporal/versioned/v1.17/add_chasm_node_maps.sql
+++ b/schema/mysql/v8/temporal/versioned/v1.17/add_chasm_node_maps.sql
@@ -3,7 +3,7 @@ CREATE TABLE chasm_node_maps (
   namespace_id BINARY(16) NOT NULL,
   workflow_id VARCHAR(255) NOT NULL,
   run_id BINARY(16) NOT NULL,
-  chasm_path VARCHAR(384) NOT NULL,
+  chasm_path VARBINARY(1536) NOT NULL,
 --
   data MEDIUMBLOB NOT NULL,
   data_encoding VARCHAR(16),

--- a/schema/mysql/v8/temporal/versioned/v1.17/add_chasm_node_maps.sql
+++ b/schema/mysql/v8/temporal/versioned/v1.17/add_chasm_node_maps.sql
@@ -1,0 +1,11 @@
+CREATE TABLE chasm_node_maps (
+  shard_id INT NOT NULL,
+  namespace_id BINARY(16) NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BINARY(16) NOT NULL,
+  chasm_path VARCHAR(384) NOT NULL,
+--
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, chasm_path)
+);

--- a/schema/mysql/v8/temporal/versioned/v1.17/manifest.json
+++ b/schema/mysql/v8/temporal/versioned/v1.17/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.17",
+  "MinCompatibleVersion": "1.0",
+  "Description": "Add new chasm_node_maps table",
+  "SchemaUpdateCqlFiles": [
+    "add_chasm_node_maps.sql"
+  ]
+}

--- a/schema/mysql/v8/version.go
+++ b/schema/mysql/v8/version.go
@@ -27,7 +27,7 @@ package v8
 // NOTE: whenever there is a new database schema update, plz update the following versions
 
 // Version is the MySQL database release version
-const Version = "1.16"
+const Version = "1.17"
 
 // VisibilityVersion is the MySQL visibility database release version
 const VisibilityVersion = "1.9"

--- a/schema/postgresql/v12/temporal/schema.sql
+++ b/schema/postgresql/v12/temporal/schema.sql
@@ -256,7 +256,7 @@ CREATE TABLE chasm_node_maps (
   namespace_id BYTEA NOT NULL,
   workflow_id VARCHAR(255) NOT NULL,
   run_id BYTEA NOT NULL,
-  chasm_path VARCHAR(384) NOT NULL,
+  chasm_path BYTEA NOT NULL,
 --
   data BYTEA NOT NULL,
   data_encoding VARCHAR(16),

--- a/schema/postgresql/v12/temporal/schema.sql
+++ b/schema/postgresql/v12/temporal/schema.sql
@@ -251,6 +251,18 @@ CREATE TABLE signals_requested_sets (
   PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, signal_id)
 );
 
+CREATE TABLE chasm_node_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  chasm_path VARCHAR(384) NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, chasm_path)
+);
+
 -- history eventsV2: history_node stores history event data
 CREATE TABLE history_node (
   shard_id       INTEGER NOT NULL,

--- a/schema/postgresql/v12/temporal/versioned/v1.17/add_chasm_node_maps.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.17/add_chasm_node_maps.sql
@@ -1,0 +1,11 @@
+CREATE TABLE chasm_node_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  chasm_path VARCHAR(384) NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, chasm_path)
+);

--- a/schema/postgresql/v12/temporal/versioned/v1.17/add_chasm_node_maps.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.17/add_chasm_node_maps.sql
@@ -3,7 +3,7 @@ CREATE TABLE chasm_node_maps (
   namespace_id BYTEA NOT NULL,
   workflow_id VARCHAR(255) NOT NULL,
   run_id BYTEA NOT NULL,
-  chasm_path VARCHAR(384) NOT NULL,
+  chasm_path BYTEA NOT NULL,
 --
   data BYTEA NOT NULL,
   data_encoding VARCHAR(16),

--- a/schema/postgresql/v12/temporal/versioned/v1.17/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.17/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.17",
+  "MinCompatibleVersion": "1.0",
+  "Description": "Add new chasm_node_maps table",
+  "SchemaUpdateCqlFiles": [
+    "add_chasm_node_maps.sql"
+  ]
+}

--- a/schema/postgresql/v12/version.go
+++ b/schema/postgresql/v12/version.go
@@ -28,7 +28,7 @@ package v12
 
 // Version is the Postgres database release version
 // Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres
-const Version = "1.16"
+const Version = "1.17"
 
 // VisibilityVersion is the Postgres visibility database release version
 // Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres

--- a/schema/sqlite/v3/temporal/schema.sql
+++ b/schema/sqlite/v3/temporal/schema.sql
@@ -250,6 +250,18 @@ CREATE TABLE signals_requested_sets (
 	PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, signal_id)
 );
 
+CREATE TABLE chasm_node_maps (
+  shard_id INT NOT NULL,
+  namespace_id BINARY(16) NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BINARY(16) NOT NULL,
+  chasm_path VARCHAR(384) NOT NULL,
+--
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, chasm_path)
+);
+
 -- history eventsV2: history_node stores history event data
 CREATE TABLE history_node (
 	shard_id INT NOT NULL,

--- a/schema/sqlite/v3/temporal/schema.sql
+++ b/schema/sqlite/v3/temporal/schema.sql
@@ -255,7 +255,7 @@ CREATE TABLE chasm_node_maps (
   namespace_id BINARY(16) NOT NULL,
   workflow_id VARCHAR(255) NOT NULL,
   run_id BINARY(16) NOT NULL,
-  chasm_path VARCHAR(384) NOT NULL,
+  chasm_path BINARY(1536) NOT NULL,
 --
   data MEDIUMBLOB NOT NULL,
   data_encoding VARCHAR(16),

--- a/schema/sqlite/v3/temporal/versioned/v0.9/add_chasm_node_maps.sql
+++ b/schema/sqlite/v3/temporal/versioned/v0.9/add_chasm_node_maps.sql
@@ -3,7 +3,7 @@ CREATE TABLE chasm_node_maps (
   namespace_id BINARY(16) NOT NULL,
   workflow_id VARCHAR(255) NOT NULL,
   run_id BINARY(16) NOT NULL,
-  chasm_path VARCHAR(384) NOT NULL,
+  chasm_path BINARY(1536) NOT NULL,
 --
   data MEDIUMBLOB NOT NULL,
   data_encoding VARCHAR(16),

--- a/schema/sqlite/v3/temporal/versioned/v0.9/add_chasm_node_maps.sql
+++ b/schema/sqlite/v3/temporal/versioned/v0.9/add_chasm_node_maps.sql
@@ -1,0 +1,11 @@
+CREATE TABLE chasm_node_maps (
+  shard_id INT NOT NULL,
+  namespace_id BINARY(16) NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BINARY(16) NOT NULL,
+  chasm_path VARCHAR(384) NOT NULL,
+--
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, chasm_path)
+);

--- a/schema/sqlite/v3/temporal/versioned/v0.9/manifest.json
+++ b/schema/sqlite/v3/temporal/versioned/v0.9/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.9",
+  "MinCompatibleVersion": "1.0",
+  "Description": "Add new chasm_node_maps table",
+  "SchemaUpdateCqlFiles": [
+    "add_chasm_node_maps.sql"
+  ]
+}

--- a/schema/sqlite/version.go
+++ b/schema/sqlite/version.go
@@ -27,7 +27,7 @@
 package sqlite
 
 // Version is the SQLite database release version
-const Version = "0.8"
+const Version = "0.9"
 
 // VisibilityVersion is the SQLite visibility database release version
 const VisibilityVersion = "0.1"


### PR DESCRIPTION
## What changed?
SQL persistence support has been added for CHASM nodes. 

- A new `chasm_node_maps` table has been added to SQL schemas
- SQL test suites updated
- SQL execution manager/util updated
- SQL plugins for `chasm_node_map` table

## Why?
- We've landed Cassandra persistence support for CHASM nodes, this brings SQL support up to parity.

## How did you test it?
- New tests ran on all SQL plugins
- `go test -v ./...`

## Potential risks
- No application paths write chasm_node_maps yet, but change does involve a schema change

