### PR TITLE
Enable execution timeout timer by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1394,11 +1394,9 @@ HistoryCacheSizeBasedLimit is set to true.`,
 	)
 	EnableWorkflowExecutionTimeoutTimer = NewGlobalBoolSetting(
 		"history.enableWorkflowExecutionTimeoutTimer",
-		false,
+		true,
 		`EnableWorkflowExecutionTimeoutTimer controls whether to enable the new logic for generating a workflow execution
-timeout timer when execution timeout is specified when starting a workflow.
-For backward compatibility, this feature is disabled by default and should only be enabled after server version
-containing this flag is deployed to all history service nodes in the cluster.`,
+timeout timer when execution timeout is specified when starting a workflow.`,
 	)
 	EnableTransitionHistory = NewGlobalBoolSetting(
 		"history.enableTransitionHistory",

--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -56,7 +56,5 @@ matching.queryWorkflowTaskTimeoutLogRate:
   - value: 1.0
 history.ReplicationEnableUpdateWithNewTaskMerge:
   - value: true
-history.enableWorkflowExecutionTimeoutTimer:
-  - value: true
 history.hostLevelCacheMaxSize:
   - value: 8192

--- a/config/dynamicconfig/development-sql.yaml
+++ b/config/dynamicconfig/development-sql.yaml
@@ -59,7 +59,5 @@ matching.queryWorkflowTaskTimeoutLogRate:
   - value: 1.0
 history.ReplicationEnableUpdateWithNewTaskMerge:
   - value: true
-history.enableWorkflowExecutionTimeoutTimer:
-  - value: true
 history.hostLevelCacheMaxSize:
   - value: 8192

--- a/config/dynamicconfig/development-xdc.yaml
+++ b/config/dynamicconfig/development-xdc.yaml
@@ -49,5 +49,3 @@ matching.queryWorkflowTaskTimeoutLogRate:
   - value: 1.0
 history.ReplicationEnableUpdateWithNewTaskMerge:
   - value: true
-history.enableWorkflowExecutionTimeoutTimer:
-  - value: true

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -185,7 +185,6 @@ func NewDynamicConfig() *configs.Config {
 	config.EnableEagerWorkflowStart = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.NamespaceCacheRefreshInterval = dynamicconfig.GetDurationPropertyFn(time.Second)
 	config.ReplicationEnableUpdateWithNewTaskMerge = dynamicconfig.GetBoolPropertyFn(true)
-	config.EnableWorkflowExecutionTimeoutTimer = dynamicconfig.GetBoolPropertyFn(true)
 	config.EnableWorkflowIdReuseStartTimeValidation = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	return config
 }

--- a/tests/testcore/dynamic_config_overrides.go
+++ b/tests/testcore/dynamic_config_overrides.go
@@ -61,7 +61,6 @@ var (
 		dynamicconfig.ClusterMetadataRefreshInterval.Key():                      100 * time.Millisecond,
 		dynamicconfig.NamespaceCacheRefreshInterval.Key():                       NamespaceCacheRefreshInterval,
 		dynamicconfig.ReplicationEnableUpdateWithNewTaskMerge.Key():             true,
-		dynamicconfig.EnableWorkflowExecutionTimeoutTimer.Key():                 true,
 		dynamicconfig.FrontendMaskInternalErrorDetails.Key():                    false,
 		dynamicconfig.HistoryScannerEnabled.Key():                               false,
 		dynamicconfig.TaskQueueScannerEnabled.Key():                             false,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Enable execution timeout timer by default

## Why?
<!-- Tell your future self why have you made these changes -->
- it's been several server releases since this feature is merged, it's safe to enable it by default now without any backward compatibility concerns
- Will remove the flag after next oss release if not issue reported about it.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- Very low. Already enabled in all production envs

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
