### PR TITLE
Make service_errors cover only unexpected errors

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -601,10 +601,16 @@ var (
 		"service_requests",
 		WithDescription("The number of RPC requests received by the service."),
 	)
-	ServicePendingRequests                   = NewGaugeDef("service_pending_requests")
-	ServiceFailures                          = NewCounterDef("service_errors")
-	ServicePanic                             = NewCounterDef("service_panics")
-	ServiceErrorWithType                     = NewCounterDef("service_error_with_type")
+	ServicePendingRequests = NewGaugeDef("service_pending_requests")
+	ServiceFailures        = NewCounterDef(
+		"service_errors",
+		WithDescription("The number of unexpected service request errors."),
+	)
+	ServicePanic         = NewCounterDef("service_panics")
+	ServiceErrorWithType = NewCounterDef(
+		"service_error_with_type",
+		WithDescription("The number of all service request errors by error type."),
+	)
 	ServiceLatency                           = NewTimerDef("service_latency")
 	ServiceLatencyNoUserLatency              = NewTimerDef("service_latency_nouserlatency")
 	ServiceLatencyUserLatency                = NewTimerDef("service_latency_userlatency")

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -26,6 +26,7 @@ package interceptor
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -385,28 +386,34 @@ func (ti *TelemetryInterceptor) HandleError(
 	metricsHandler metrics.Handler,
 	logTags []tag.Tag,
 	err error,
-	nsName namespace.Name) {
+	nsName namespace.Name,
+) {
 	statusCode := serviceerror.ToStatus(err).Code()
+	if statusCode == codes.OK {
+		return
+	}
 
-	recordMetrics(metricsHandler, err, statusCode)
+	isExpectedError := isExpectedErrorByStatusCode(statusCode) || isExpectedErrorByType(err)
 
-	ti.logErrors(req, fullMethod, nsName, err, statusCode, logTags)
+	recordErrorMetrics(metricsHandler, err, isExpectedError)
+	ti.logError(req, fullMethod, nsName, err, statusCode, isExpectedError, logTags)
 }
 
-func (ti *TelemetryInterceptor) logErrors(
+func (ti *TelemetryInterceptor) logError(
 	req any,
 	fullMethod string,
 	nsName namespace.Name,
 	err error,
 	statusCode codes.Code,
+	isExpectedError bool,
 	logTags []tag.Tag,
 ) {
 	logAllErrors := nsName != "" && ti.logAllReqErrors(nsName.String())
-	if !logAllErrors && (common.IsContextDeadlineExceededErr(err) || common.IsContextCanceledErr(err)) {
-		return
-	}
-
-	if !logAllErrors && isRecordingNeeded(statusCode) {
+	// context errors may not be user errors, but still too noisy to log by default
+	if !logAllErrors && (isExpectedError ||
+		common.IsContextDeadlineExceededErr(err) ||
+		common.IsContextCanceledErr(err) ||
+		common.IsResourceExhausted(err)) {
 		return
 	}
 
@@ -423,41 +430,66 @@ func (ti *TelemetryInterceptor) logErrors(
 	ti.logger.Error("service failures", append(logTags, tag.Error(err))...)
 }
 
-func isRecordingNeeded(statusCode codes.Code) bool {
+func recordErrorMetrics(metricsHandler metrics.Handler, err error, isExpectedError bool) {
+	metrics.ServiceErrorWithType.With(metricsHandler).Record(1, metrics.ServiceErrorTypeTag(err))
+
+	var resourceExhaustedErr *serviceerror.ResourceExhausted
+	if errors.As(err, &resourceExhaustedErr) {
+		metrics.ServiceErrResourceExhaustedCounter.With(metricsHandler).Record(
+			1,
+			metrics.ResourceExhaustedCauseTag(resourceExhaustedErr.Cause),
+			metrics.ResourceExhaustedScopeTag(resourceExhaustedErr.Scope),
+		)
+	}
+
+	if isExpectedError {
+		return
+	}
+
+	metrics.ServiceFailures.With(metricsHandler).Record(1)
+}
+
+func isExpectedErrorByStatusCode(statusCode codes.Code) bool {
 	switch statusCode {
-	case codes.InvalidArgument,
+	case codes.Canceled,
+		codes.InvalidArgument,
+		codes.NotFound,
 		codes.AlreadyExists,
+		codes.PermissionDenied,
 		codes.FailedPrecondition,
 		codes.OutOfRange,
-		codes.PermissionDenied,
-		codes.Unauthenticated,
-		codes.NotFound,
-		codes.ResourceExhausted:
+		codes.Unauthenticated:
 		return true
-	case codes.OK,
-		codes.Canceled,
-		codes.Unknown,
+	// We could just return false here, but making it explicit what codes are
+	// considered (potentially) server errors.
+	case codes.Unknown,
 		codes.DeadlineExceeded,
+		// the result for resource exhausted depends on the resource exhausted scope and
+		// will be handled by isExpectedErrorByType()
+		codes.ResourceExhausted,
 		codes.Aborted,
 		codes.Unimplemented,
 		codes.Internal,
 		codes.Unavailable,
 		codes.DataLoss:
 		return false
+	default:
+		return false
 	}
-
-	return false
 }
 
-func recordMetrics(metricsHandler metrics.Handler, err error, statusCode codes.Code) {
-	metrics.ServiceErrorWithType.With(metricsHandler).Record(1, metrics.ServiceErrorTypeTag(err))
-
+func isExpectedErrorByType(err error) bool {
+	// This is not a full list of service errors.
+	// Only errors with status code that fails the isExpectedErrorByStatusCode() check
+	// but are actually expected need to be explicitly handled here.
+	//
+	// Some of the errors listed below does not failed the isExpectedErrorByStatusCode() check
+	// but are listed nonetheless.
 	switch err := err.(type) {
 	case *serviceerror.ResourceExhausted:
-		metrics.ServiceErrResourceExhaustedCounter.With(metricsHandler).Record(
-			1, metrics.ResourceExhaustedCauseTag(err.Cause), metrics.ResourceExhaustedScopeTag(err.Scope))
-		return
-	case *serviceerror.AlreadyExists,
+		return err.Scope == enumspb.RESOURCE_EXHAUSTED_SCOPE_NAMESPACE
+	case *serviceerror.Canceled,
+		*serviceerror.AlreadyExists,
 		*serviceerror.CancellationAlreadyRequested,
 		*serviceerror.FailedPrecondition,
 		*serviceerror.NamespaceInvalidState,
@@ -474,14 +506,12 @@ func recordMetrics(metricsHandler metrics.Handler, err error, statusCode codes.C
 		*serviceerror.PermissionDenied,
 		*serviceerror.NewerBuildExists,
 		*serviceerrors.StickyWorkerUnavailable,
-		*serviceerrors.ShardOwnershipLost,
 		*serviceerrors.TaskAlreadyStarted,
-		*serviceerrors.RetryReplication:
-		return
-	}
-
-	if !isRecordingNeeded(statusCode) {
-		metrics.ServiceFailures.With(metricsHandler).Record(1)
+		*serviceerrors.RetryReplication,
+		*serviceerrors.SyncState:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/common/rpc/interceptor/telemetry_test.go
+++ b/common/rpc/interceptor/telemetry_test.go
@@ -25,6 +25,7 @@
 package interceptor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -325,22 +327,57 @@ func TestHandleError(t *testing.T) {
 			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
 		},
 		{
-			name:                      "resource-exhausted",
-			err:                       serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_UNSPECIFIED, "resource exhausted"),
+			name: "resource-exhausted-system",
+			err: &serviceerror.ResourceExhausted{
+				Message: "resource exhausted",
+				Cause:   enumspb.RESOURCE_EXHAUSTED_CAUSE_UNSPECIFIED,
+				Scope:   enumspb.RESOURCE_EXHAUSTED_SCOPE_SYSTEM,
+			},
 			expectLogging:             false,
-			ServiceFailuresCount:      0,
+			ServiceFailuresCount:      1,
 			ResourceExhaustedCount:    1,
 			ServiceErrorWithTypeCount: 1,
 			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		},
 		{
-			name:                      "resource-exhausted",
-			err:                       serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_UNSPECIFIED, "resource exhausted"),
+			name: "resource-exhausted-namespace",
+			err: &serviceerror.ResourceExhausted{
+				Message: "resource exhausted",
+				Cause:   enumspb.RESOURCE_EXHAUSTED_CAUSE_UNSPECIFIED,
+				Scope:   enumspb.RESOURCE_EXHAUSTED_SCOPE_NAMESPACE,
+			},
 			expectLogging:             true,
 			ServiceFailuresCount:      0,
 			ResourceExhaustedCount:    1,
 			ServiceErrorWithTypeCount: 1,
 			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+		},
+		{
+			name:                      "canceled",
+			err:                       context.Canceled,
+			expectLogging:             false,
+			ServiceFailuresCount:      0,
+			ResourceExhaustedCount:    0,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		},
+		{
+			name:                      "deadline-exceeded",
+			err:                       context.DeadlineExceeded,
+			expectLogging:             true,
+			ServiceFailuresCount:      1,
+			ResourceExhaustedCount:    0,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+		},
+		{
+			name:                      "shard-ownership-lost",
+			err:                       serviceerrors.NewShardOwnershipLost("shard ownership lost", "hostname"),
+			expectLogging:             true,
+			ServiceFailuresCount:      1,
+			ResourceExhaustedCount:    0,
+			ServiceErrorWithTypeCount: 1,
+			logAllErrors:              dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		},
 	}
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Make service_errors cover only unexpected errors

## Why?
<!-- Tell your future self why have you made these changes -->
- Easier to alert on the # of service errors. Without this change, we need use `service_error_with_type` and exclude a long list of expected error types. 
- `service_error` before this change is already very close to unexpected change but not quite, this PR basically make those two things the same.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
