### PR TITLE
Re-use unit tests

### DIFF
--- a/common/softassert/softassert.go
+++ b/common/softassert/softassert.go
@@ -46,3 +46,9 @@ func That(logger log.Logger, condition bool, msg string) bool {
 	}
 	return condition
 }
+
+// Fail logs an error message indicating a failed assertion.
+// It works the same as That, but does not require a condition.
+func Fail(logger log.Logger, msg string) {
+	logger.Error("failed assertion: "+msg, tag.FailedAssertion)
+}

--- a/service/matching/ack_manager_test.go
+++ b/service/matching/ack_manager_test.go
@@ -25,56 +25,181 @@
 package matching
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
+	"github.com/stretchr/testify/suite"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/testing/testlogger"
+	"go.temporal.io/server/common/tqid"
 )
 
-func TestAckManager_AddingTasksIncreasesBacklogCounter(t *testing.T) {
-	t.Parallel()
-
-	controller := gomock.NewController(t)
-	backlogMgr := newBacklogMgr(t, controller, false)
-
-	backlogMgr.taskAckManager.addTask(1)
-	require.Equal(t, backlogMgr.taskAckManager.getBacklogCountHint(), int64(1))
-	backlogMgr.taskAckManager.addTask(12)
-	require.Equal(t, backlogMgr.taskAckManager.getBacklogCountHint(), int64(2))
+type AckManagerTestSuite struct {
+	suite.Suite
+	logger *testlogger.TestLogger
 }
 
-func TestAckManager_CompleteTaskMovesAckLevelUpToGap(t *testing.T) {
+func TestAckManagerTestSuite(t *testing.T) {
 	t.Parallel()
-	controller := gomock.NewController(t)
-	backlogMgr := newBacklogMgr(t, controller, false)
-	_, err := backlogMgr.db.RenewLease(backlogMgr.tqCtx)
-	require.NoError(t, err)
+	suite.Run(t, &AckManagerTestSuite{})
+}
 
-	backlogMgr.taskAckManager.addTask(1)
+func (s *AckManagerTestSuite) SetupTest() {
+	s.logger = testlogger.NewTestLogger(s.T(), testlogger.FailOnAnyUnexpectedError)
+}
+
+func (s *AckManagerTestSuite) AddingTasksIncreasesBacklogCounter() {
+	ackMgr := newTestAckMgr(s.logger)
+
+	ackMgr.addTask(1)
+	s.Equal(ackMgr.getBacklogCountHint(), int64(1))
+
+	ackMgr.addTask(12)
+	s.Equal(ackMgr.getBacklogCountHint(), int64(2))
+}
+
+func (s *AckManagerTestSuite) CompleteTaskMovesAckLevelUpToGap() {
+	ackMgr := newTestAckMgr(s.logger)
+
+	_, err := ackMgr.db.RenewLease(context.Background())
+	s.NoError(err)
+
+	ackMgr.addTask(1)
+	ackMgr.db.updateApproximateBacklogCount(1) // increment the backlog so that we don't under-count
+	s.Equal(int64(-1), ackMgr.getAckLevel(), "should only move ack level on completion")
+
+	ackLevel, numAcked := ackMgr.completeTask(1)
+	s.Equal(int64(1), ackLevel, "should move ack level on completion")
+	s.Equal(int64(1), numAcked, "should move ack level on completion")
+
+	ackMgr.addTask(2)
+	ackMgr.addTask(3)
+	ackMgr.addTask(12)
+	ackMgr.db.updateApproximateBacklogCount(3)
+
+	ackLevel, numAcked = ackMgr.completeTask(3)
+	s.Equal(int64(1), ackLevel, "task 2 is not complete, we should not move ack level")
+	s.Equal(int64(0), numAcked, "task 2 is not complete, we should not move ack level")
+
+	ackLevel, numAcked = ackMgr.completeTask(2)
+	s.Equal(int64(3), ackLevel, "both tasks 2 and 3 are complete")
+	s.Equal(int64(2), numAcked, "both tasks 2 and 3 are complete")
+}
+
+func (s *AckManagerTestSuite) TestAckManager() {
+	ackMgr := newTestAckMgr(s.logger)
+
+	_, err := ackMgr.db.RenewLease(context.Background())
+	s.NoError(err)
+
+	ackMgr.setAckLevel(100)
+	s.EqualValues(100, ackMgr.getAckLevel())
+	s.EqualValues(100, ackMgr.getReadLevel())
+	const t1 = 200
+	const t2 = 220
+	const t3 = 320
+	const t4 = 340
+	const t5 = 360
+	const t6 = 380
+
+	ackMgr.addTask(t1)
+	// Increment the backlog so that we don't under-count
+	// this happens since we decrease the counter on completion of a task
+	ackMgr.db.updateApproximateBacklogCount(1)
+	s.EqualValues(100, ackMgr.getAckLevel())
+	s.EqualValues(t1, ackMgr.getReadLevel())
+
+	ackMgr.addTask(t2)
+	ackMgr.db.updateApproximateBacklogCount(1)
+	s.EqualValues(100, ackMgr.getAckLevel())
+	s.EqualValues(t2, ackMgr.getReadLevel())
+
+	ackMgr.completeTask(t2)
+	s.EqualValues(100, ackMgr.getAckLevel())
+	s.EqualValues(t2, ackMgr.getReadLevel())
+
+	ackMgr.completeTask(t1)
+	s.EqualValues(t2, ackMgr.getAckLevel())
+	s.EqualValues(t2, ackMgr.getReadLevel())
+
+	ackMgr.setAckLevel(300)
+	s.EqualValues(300, ackMgr.getAckLevel())
+	s.EqualValues(300, ackMgr.getReadLevel())
+
+	ackMgr.addTask(t3)
+	ackMgr.db.updateApproximateBacklogCount(1)
+	s.EqualValues(300, ackMgr.getAckLevel())
+	s.EqualValues(t3, ackMgr.getReadLevel())
+
+	ackMgr.addTask(t4)
+	ackMgr.db.updateApproximateBacklogCount(1)
+	s.EqualValues(300, ackMgr.getAckLevel())
+	s.EqualValues(t4, ackMgr.getReadLevel())
+
+	ackMgr.completeTask(t3)
+	s.EqualValues(t3, ackMgr.getAckLevel())
+	s.EqualValues(t4, ackMgr.getReadLevel())
+
+	ackMgr.completeTask(t4)
+	s.EqualValues(t4, ackMgr.getAckLevel())
+	s.EqualValues(t4, ackMgr.getReadLevel())
+
+	ackMgr.setReadLevel(t5)
+	s.EqualValues(t5, ackMgr.getReadLevel())
+
+	ackMgr.setAckLevel(t5)
+	ackMgr.setReadLevelAfterGap(t6)
+	s.EqualValues(t6, ackMgr.getReadLevel())
+	s.EqualValues(t6, ackMgr.getAckLevel())
+}
+
+func (s *AckManagerTestSuite) Sort() {
+	ackMgr := newTestAckMgr(s.logger)
+
+	_, err := ackMgr.db.RenewLease(context.Background())
+	s.NoError(err)
+
+	const t0 = 100
+	ackMgr.setAckLevel(t0)
+	s.EqualValues(t0, ackMgr.getAckLevel())
+	s.EqualValues(t0, ackMgr.getReadLevel())
+	const t1 = 200
+	const t2 = 220
+	const t3 = 320
+	const t4 = 340
+	const t5 = 360
+
+	ackMgr.addTask(t1)
+	ackMgr.addTask(t2)
+	ackMgr.addTask(t3)
+	ackMgr.addTask(t4)
+	ackMgr.addTask(t5)
 
 	// Increment the backlog so that we don't under-count
-	backlogMgr.db.updateApproximateBacklogCount(1)
-	require.Equal(t, int64(-1), backlogMgr.taskAckManager.getAckLevel(), "should only move ack level on completion")
-	ackLevel, numAcked := backlogMgr.taskAckManager.completeTask(1)
-	require.Equal(t, int64(1), ackLevel, "should move ack level on completion")
-	require.Equal(t, int64(1), numAcked, "should move ack level on completion")
+	// this happens since we decrease the counter on completion of a task
+	ackMgr.db.updateApproximateBacklogCount(5)
 
-	backlogMgr.taskAckManager.addTask(2)
-	backlogMgr.taskAckManager.addTask(3)
-	backlogMgr.taskAckManager.addTask(12)
-	backlogMgr.db.updateApproximateBacklogCount(3)
+	ackMgr.completeTask(t2)
+	s.EqualValues(t0, ackMgr.getAckLevel())
 
-	ackLevel, numAcked = backlogMgr.taskAckManager.completeTask(3)
-	require.Equal(t, int64(1), ackLevel, "task 2 is not complete, we should not move ack level")
-	require.Equal(t, int64(0), numAcked, "task 2 is not complete, we should not move ack level")
-	ackLevel, numAcked = backlogMgr.taskAckManager.completeTask(2)
-	require.Equal(t, int64(3), ackLevel, "both tasks 2 and 3 are complete")
-	require.Equal(t, int64(2), numAcked, "both tasks 2 and 3 are complete")
+	ackMgr.completeTask(t1)
+	s.EqualValues(t2, ackMgr.getAckLevel())
+
+	ackMgr.completeTask(t5)
+	s.EqualValues(t2, ackMgr.getAckLevel())
+
+	ackMgr.completeTask(t4)
+	s.EqualValues(t2, ackMgr.getAckLevel())
+
+	ackMgr.completeTask(t3)
+	s.EqualValues(t5, ackMgr.getAckLevel())
 }
 
 func BenchmarkAckManager_AddTask(b *testing.B) {
-	controller := gomock.NewController(b)
+	ackMgr := newTestAckMgr(log.NewTestLogger())
 
 	tasks := make([]int, 1000)
 	for i := 0; i < len(tasks); i++ {
@@ -85,20 +210,19 @@ func BenchmarkAckManager_AddTask(b *testing.B) {
 		// Add 1000 tasks in order and complete them in a random order.
 		// This will cause our ack level to jump as we complete them
 		b.StopTimer()
-		backlogMgr := newBacklogMgr(b, controller, false)
 		rand.Shuffle(len(tasks), func(i, j int) {
 			tasks[i], tasks[j] = tasks[j], tasks[i]
 		})
 		b.StartTimer()
 		for i := 0; i < len(tasks); i++ {
 			tasks[i] = i
-			backlogMgr.taskAckManager.addTask(int64(i))
+			ackMgr.addTask(int64(i))
 		}
 	}
 }
 
 func BenchmarkAckManager_CompleteTask(b *testing.B) {
-	controller := gomock.NewController(b)
+	ackMgr := newTestAckMgr(log.NewTestLogger())
 
 	tasks := make([]int, 1000)
 	b.ResetTimer()
@@ -106,11 +230,10 @@ func BenchmarkAckManager_CompleteTask(b *testing.B) {
 		// Add 1000 tasks in order and complete them in a random order.
 		// This will cause our ack level to jump as we complete them
 		b.StopTimer()
-		backlogMgr := newBacklogMgr(b, controller, false)
 		for i := 0; i < len(tasks); i++ {
 			tasks[i] = i
-			backlogMgr.taskAckManager.addTask(int64(i))
-			backlogMgr.db.updateApproximateBacklogCount(int64(1)) // Increment the backlog so that we don't under-count
+			ackMgr.addTask(int64(i))
+			ackMgr.db.updateApproximateBacklogCount(int64(1)) // Increment the backlog so that we don't under-count
 		}
 		rand.Shuffle(len(tasks), func(i, j int) {
 			tasks[i], tasks[j] = tasks[j], tasks[i]
@@ -118,7 +241,17 @@ func BenchmarkAckManager_CompleteTask(b *testing.B) {
 		b.StartTimer()
 
 		for i := 0; i < len(tasks); i++ {
-			backlogMgr.taskAckManager.completeTask(int64(i))
+			ackMgr.completeTask(int64(i))
 		}
 	}
+}
+
+func newTestAckMgr(logger log.Logger) *ackManager {
+	tm := newTestTaskManager(logger)
+	cfg := NewConfig(dynamicconfig.NewNoopCollection())
+	f, _ := tqid.NewTaskQueueFamily("", "test-queue")
+	prtn := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).NormalPartition(0)
+	tlCfg := newTaskQueueConfig(prtn.TaskQueue(), cfg, "test-namespace")
+	db := newTaskQueueDB(tlCfg, tm, UnversionedQueueKey(prtn), logger)
+	return newAckManager(db, logger)
 }

--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -67,6 +67,9 @@ type (
 		TotalApproximateBacklogCount() int64
 		BacklogHeadAge() time.Duration
 		InternalStatus() []*taskqueuespb.InternalTaskQueueStatus
+
+		// TODO(pri): remove
+		getDB() *taskQueueDB
 	}
 
 	backlogManagerImpl struct {
@@ -232,8 +235,9 @@ func (c *backlogManagerImpl) InternalStatus() []*taskqueuespb.InternalTaskQueueS
 				StartId: c.taskWriter.taskIDBlock.start,
 				EndId:   c.taskWriter.taskIDBlock.end,
 			},
-			LoadedTasks:  c.taskAckManager.getBacklogCountHint(),
-			MaxReadLevel: c.db.GetMaxReadLevel(subqueueZero),
+			LoadedTasks:             c.taskAckManager.getBacklogCountHint(),
+			MaxReadLevel:            c.db.GetMaxReadLevel(subqueueZero),
+			ApproximateBacklogCount: c.db.getApproximateBacklogCount(subqueueZero),
 		},
 	}
 }
@@ -305,4 +309,8 @@ func executeWithRetry(
 
 func (c *backlogManagerImpl) queueKey() *PhysicalTaskQueueKey {
 	return c.pqMgr.QueueKey()
+}
+
+func (c *backlogManagerImpl) getDB() *taskQueueDB {
+	return c.db
 }

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -272,7 +272,7 @@ func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_IncrementedBySpool
 	defer s.blm.Stop()
 
 	taskCount := 10
-	s.ptqMgr.EXPECT().AddSpooledTask(gomock.Any()).Return(nil).MaxTimes(taskCount)
+	s.ptqMgr.EXPECT().AddSpooledTask(gomock.Any()).Return(nil).AnyTimes()
 	for i := 0; i < taskCount; i++ {
 		s.NoError(s.blm.SpoolTask(&persistencespb.TaskInfo{
 			ExpiryTime: timestamp.TimeNowPtrUtcAddSeconds(3000),
@@ -291,7 +291,7 @@ func (s *BacklogManagerTestSuite) TestApproximateBacklogCount_IncrementedBySpool
 	defer s.blm.Stop()
 
 	taskCount := 10
-	s.ptqMgr.EXPECT().AddSpooledTask(gomock.Any()).Return(nil).MaxTimes(taskCount)
+	s.ptqMgr.EXPECT().AddSpooledTask(gomock.Any()).Return(nil).AnyTimes()
 	for i := 0; i < taskCount; i++ {
 		s.Error(s.blm.SpoolTask(&persistencespb.TaskInfo{
 			ExpiryTime: timestamp.TimeNowPtrUtcAddSeconds(3000),

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -78,10 +78,6 @@ func (s *BacklogManagerTestSuite) SetupTest() {
 	s.blm = newBacklogManager(ctx, s.ptqMgr, tlCfg, s.taskMgr, s.logger, s.logger, nil, metrics.NoopMetricsHandler)
 }
 
-func (s *BacklogManagerTestSuite) TearDownTest() {
-	s.controller.Finish()
-}
-
 func (s *BacklogManagerTestSuite) TestReadLevelForAllExpiredTasksInBatch() {
 	s.NoError(s.blm.taskWriter.initReadWriteState())
 	s.Equal(int64(1), s.blm.db.rangeID)

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -264,7 +264,7 @@ func (s *BacklogManagerTestSuite) TestAddTasksValidateBacklogCounter_ServiceErro
 		err := s.blm.SpoolTask(task)
 		s.Error(err)
 	}
-	s.Equal(int64(10), s.blm.TotalApproximateBacklogCount())
+	s.Equal(int64(taskCount), s.blm.TotalApproximateBacklogCount())
 }
 
 func (s *BacklogManagerTestSuite) TestAddMultipleTasksValidateBacklogCounter() {
@@ -280,5 +280,5 @@ func (s *BacklogManagerTestSuite) TestAddMultipleTasksValidateBacklogCounter() {
 		err := s.blm.SpoolTask(task)
 		s.NoError(err)
 	}
-	s.Equal(int64(10), s.blm.TotalApproximateBacklogCount())
+	s.Equal(int64(taskCount), s.blm.TotalApproximateBacklogCount())
 }

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -256,9 +256,7 @@ func (db *taskQueueDB) OldUpdateState(
 		PrevRangeID:   db.rangeID,
 	})
 	if err == nil {
-		db.logger.Info("[pri] before OldUpdateState", tag.NewInt("subqueue", subqueueZero), tag.AckLevel(db.subqueues[subqueueZero].AckLevel))
 		db.subqueues[subqueueZero].AckLevel = ackLevel
-		db.logger.Info("[pri] after OldUpdateState", tag.NewInt("subqueue", subqueueZero), tag.AckLevel(db.subqueues[subqueueZero].AckLevel))
 	}
 	db.emitBacklogGauges()
 	return err

--- a/service/matching/forwarder_test.go
+++ b/service/matching/forwarder_test.go
@@ -332,6 +332,7 @@ func (t *ForwarderTestSuite) TestForwardPollForActivity() {
 	t.Nil(task.pollWorkflowTaskQueueResponse())
 }
 
+// TODO(pri): old matcher cleanup
 func (t *ForwarderTestSuite) TestMaxOutstandingConcurrency() {
 	if t.newFwdr {
 		t.T().Skip("priority forwarder is not compatible with this test")
@@ -390,6 +391,7 @@ func (t *ForwarderTestSuite) TestMaxOutstandingConcurrency() {
 	}
 }
 
+// TODO(pri): old matcher cleanup
 func (t *ForwarderTestSuite) TestMaxOutstandingConfigUpdate() {
 	if t.newFwdr {
 		t.T().Skip("priority forwarder is not compatible with this test")

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -40,9 +40,9 @@ import (
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
-	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/softassert"
+	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/tqid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -64,9 +64,10 @@ func (s *MatcherDataSuite) SetupTest() {
 		NewConfig(dynamicconfig.NewNoopCollection()),
 		"nsname",
 	)
+	logger := testlogger.NewTestLogger(s.T(), testlogger.FailOnAnyUnexpectedError)
 	s.ts = clock.NewEventTimeSource().Update(time.Now())
 	s.ts.UseAsyncTimers(true)
-	s.md = newMatcherData(cfg, log.NewTestLogger(), s.ts, true)
+	s.md = newMatcherData(cfg, logger, s.ts, true)
 }
 
 func (s *MatcherDataSuite) now() time.Time {
@@ -581,7 +582,8 @@ func FuzzMatcherData(f *testing.F) {
 		)
 		ts := clock.NewEventTimeSource()
 		ts.UseAsyncTimers(true)
-		md := newMatcherData(cfg, log.NewTestLogger(), ts, true)
+		logger := testlogger.NewTestLogger(f, testlogger.FailOnAnyUnexpectedError)
+		md := newMatcherData(cfg, logger, ts, true)
 		_ = md
 
 		next := func() int {

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -205,7 +205,7 @@ func (s *matchingEngineSuite) SetupTest() {
 func (s *matchingEngineSuite) newConfig() *Config {
 	res := defaultTestConfig()
 	if s.newMatcher {
-		res = withNewMatcher(res)
+		useNewMatcher(res)
 	}
 	return res
 }
@@ -3803,9 +3803,8 @@ func (d *dynamicRateBurstWrapper) Burst() int {
 }
 
 // TODO(pri): cleanup; delete this
-func withNewMatcher(config *Config) *Config {
+func useNewMatcher(config *Config) {
 	config.NewMatcher = func(_ string, _ string, _ enumspb.TaskQueueType, callback func(bool)) (v bool, cancel func()) {
 		return true, func() {}
 	}
-	return config
 }

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -212,7 +212,6 @@ func (s *matchingEngineSuite) newConfig() *Config {
 
 func (s *matchingEngineSuite) TearDownTest() {
 	s.matchingEngine.Stop()
-	s.controller.Finish()
 }
 
 func (s *matchingEngineSuite) newMatchingEngine(

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3141,7 +3141,7 @@ func (s *matchingEngineSuite) resetBacklogCounter(numWorkers int, taskCount int,
 
 	// Overwrite the maxReadLevel since it could have increased if the previous taskWriter was
 	// stopped (which would not result in resetting).
-	pqMgr.backlogMgr.getDB().setMaxReadLevelForTesting(0, maxTaskId)
+	pqMgr.backlogMgr.getDB().setMaxReadLevelForTesting(subqueueZero, maxTaskId)
 
 	s.EqualValues(0, s.taskManager.getTaskCount(ptq))
 	s.EventuallyWithT(func(collect *assert.CollectT) {

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3072,7 +3072,7 @@ func (s *matchingEngineSuite) TestAddConsumeWorkflowTasksNoDBErrors() {
 
 func (s *matchingEngineSuite) TestAddConsumeWorkflowTasksDBErrors() {
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
-	s.taskManager.dbConditionalFailedError = true
+	s.taskManager.dbRandCondFailedErr = true
 	s.addConsumeAllWorkflowTasksNonConcurrently(100, 1, 1)
 }
 
@@ -3082,7 +3082,7 @@ func (s *matchingEngineSuite) TestMultipleWorkersAddConsumeWorkflowTasksNoDBErro
 
 func (s *matchingEngineSuite) TestMultipleWorkersAddConsumeWorkflowTasksDBErrors() {
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
-	s.taskManager.dbConditionalFailedError = true
+	s.taskManager.dbRandCondFailedErr = true
 	s.addConsumeAllWorkflowTasksNonConcurrently(100, 5, 5)
 }
 
@@ -3159,7 +3159,7 @@ func (s *matchingEngineSuite) TestResetBacklogCounterDBErrors() {
 	}
 
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
-	s.taskManager.dbConditionalFailedError = true
+	s.taskManager.dbRandCondFailedErr = true
 	s.resetBacklogCounter(2, 2, 2)
 }
 
@@ -3172,7 +3172,7 @@ func (s *matchingEngineSuite) TestMoreTasksResetBacklogCounterDBErrors() {
 		s.T().Skip("not supported by new matcher")
 	}
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
-	s.taskManager.dbConditionalFailedError = true
+	s.taskManager.dbRandCondFailedErr = true
 	s.resetBacklogCounter(10, 50, 5)
 }
 
@@ -3203,7 +3203,7 @@ func (s *matchingEngineSuite) TestConcurrentAddWorkflowTasksNoDBErrors() {
 func (s *matchingEngineSuite) TestConcurrentAddWorkflowTasksDBErrors() {
 	s.T().Skip("Skipping this as the backlog counter could under-count. Fix requires making " +
 		"UpdateState an atomic operation.")
-	s.taskManager.dbConditionalFailedError = true
+	s.taskManager.dbRandCondFailedErr = true
 
 	s.concurrentPublishAndConsumeValidateBacklogCounter(150, 100, 0)
 }
@@ -3215,7 +3215,7 @@ func (s *matchingEngineSuite) TestConcurrentAdd_PollWorkflowTasksNoDBErrors() {
 func (s *matchingEngineSuite) TestConcurrentAdd_PollWorkflowTasksDBErrors() {
 	s.T().Skip("Skipping this as the backlog counter could under-count. Fix requires making " +
 		"UpdateState an atomic operation.")
-	s.taskManager.dbConditionalFailedError = true
+	s.taskManager.dbRandCondFailedErr = true
 
 	s.concurrentPublishAndConsumeValidateBacklogCounter(20, 100, 100)
 }
@@ -3227,7 +3227,7 @@ func (s *matchingEngineSuite) TestLesserNumberOfPollersThanTasksNoDBErrors() {
 func (s *matchingEngineSuite) TestLesserNumberOfPollersThanTasksDBErrors() {
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.logger.Expect(testlogger.Error, "unexpected error dispatching task")
-	s.taskManager.dbConditionalFailedError = true
+	s.taskManager.dbRandCondFailedErr = true
 
 	s.concurrentPublishAndConsumeValidateBacklogCounter(1, 500, 200)
 }
@@ -3239,7 +3239,7 @@ func (s *matchingEngineSuite) TestMultipleWorkersLesserNumberOfPollersThanTasksN
 func (s *matchingEngineSuite) TestMultipleWorkersLesserNumberOfPollersThanTasksDBErrors() {
 	s.T().Skip("Skipping this as the backlog counter could under-count. Fix requires making " +
 		"UpdateState an atomic operation.")
-	s.taskManager.dbConditionalFailedError = true
+	s.taskManager.dbRandCondFailedErr = true
 
 	s.concurrentPublishAndConsumeValidateBacklogCounter(5, 500, 200)
 }
@@ -3341,10 +3341,10 @@ var _ persistence.TaskManager = (*testTaskManager)(nil) // Asserts that interfac
 
 type testTaskManager struct {
 	sync.Mutex
-	queues                   map[dbTaskQueueKey]*testPhysicalTaskQueueManager
-	logger                   log.Logger
-	dbConditionalFailedError bool
-	dbServiceError           bool
+	queues              map[dbTaskQueueKey]*testPhysicalTaskQueueManager
+	logger              log.Logger
+	dbRandCondFailedErr bool
+	dbServiceError      bool
 }
 
 type dbTaskQueueKey struct {
@@ -3546,7 +3546,7 @@ func (m *testTaskManager) DeleteTaskQueue(
 
 // generateErrorRandomly states if a taskManager's operation should return an error or not
 func (m *testTaskManager) generateErrorRandomly() bool {
-	if m.dbConditionalFailedError {
+	if m.dbRandCondFailedErr {
 		threshold := 10
 
 		// Generate a random number between 0 and 99

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3162,6 +3162,7 @@ func (s *matchingEngineSuite) TestResetBacklogCounterDBErrors() {
 		s.T().Skip("not supported by new matcher")
 	}
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
+	s.logger.Expect(testlogger.Error, "unexpected error dispatching task")
 	s.taskManager.dbRandCondFailedErr = true
 
 	s.resetBacklogCounter(2, 2, 2)
@@ -3176,6 +3177,7 @@ func (s *matchingEngineSuite) TestMoreTasksResetBacklogCounterDBErrors() {
 		s.T().Skip("not supported by new matcher")
 	}
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
+	s.logger.Expect(testlogger.Error, "unexpected error dispatching task")
 	s.taskManager.dbRandCondFailedErr = true
 
 	s.resetBacklogCounter(10, 50, 5)

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3227,6 +3227,7 @@ func (s *matchingEngineSuite) TestLesserNumberOfPollersThanTasksNoDBErrors() {
 
 func (s *matchingEngineSuite) TestLesserNumberOfPollersThanTasksDBErrors() {
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
+	s.logger.Expect(testlogger.Error, "unexpected error dispatching task")
 	s.taskManager.dbConditionalFailedError = true
 
 	s.concurrentPublishAndConsumeValidateBacklogCounter(1, 500, 200)

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -12,6 +12,7 @@
 // furnished to do so, subject to the following conditions:
 //
 // The above copyright notice and this permission notice shall be included in
+
 // all copies or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -78,6 +79,7 @@ import (
 	"go.temporal.io/server/common/quotas"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tasktoken"
+	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/worker_versioning"
 	"go.temporal.io/server/service/history/consts"
@@ -94,6 +96,8 @@ type (
 	matchingEngineSuite struct {
 		suite.Suite
 		*require.Assertions
+
+		newMatcher               bool
 		controller               *gomock.Controller
 		mockHistoryClient        *historyservicemock.MockHistoryServiceClient
 		mockMatchingClient       *matchingservicemock.MockMatchingServiceClient
@@ -107,8 +111,7 @@ type (
 
 		matchingEngine *matchingEngineImpl
 		taskManager    *testTaskManager
-		logger         log.Logger
-		sync.Mutex
+		logger         *testlogger.TestLogger
 	}
 )
 
@@ -117,12 +120,12 @@ const (
 )
 
 func createTestMatchingEngine(
+	logger log.Logger,
 	controller *gomock.Controller,
 	config *Config,
 	matchingClient matchingservice.MatchingServiceClient,
 	namespaceRegistry namespace.Registry,
 ) *matchingEngineImpl {
-	logger := log.NewTestLogger()
 	tm := newTestTaskManager(logger)
 	mockVisibilityManager := manager.NewMockVisibilityManager(controller)
 	mockVisibilityManager.EXPECT().Close().AnyTimes()
@@ -149,9 +152,13 @@ func createMockNamespaceCache(controller *gomock.Controller, nsName namespace.Na
 	return ns, mockNamespaceCache
 }
 
+// TODO(pri): cleanup; delete this
 func TestMatchingEngineSuite(t *testing.T) {
-	s := new(matchingEngineSuite)
-	suite.Run(t, s)
+	suite.Run(t, &matchingEngineSuite{newMatcher: false})
+}
+
+func TestMatchingEngineWithNewMatcherSuite(t *testing.T) {
+	suite.Run(t, &matchingEngineSuite{newMatcher: true})
 }
 
 func (s *matchingEngineSuite) SetupSuite() {
@@ -162,9 +169,7 @@ func (s *matchingEngineSuite) TearDownSuite() {
 
 func (s *matchingEngineSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
-	s.logger = log.NewTestLogger()
-	s.Lock()
-	defer s.Unlock()
+	s.logger = testlogger.NewTestLogger(s.T(), testlogger.FailOnAnyUnexpectedError)
 	s.controller = gomock.NewController(s.T())
 	s.mockHistoryClient = historyservicemock.NewMockHistoryServiceClient(s.controller)
 	s.mockMatchingClient = matchingservicemock.NewMockMatchingServiceClient(s.controller)
@@ -193,8 +198,16 @@ func (s *matchingEngineSuite) SetupTest() {
 	s.mockNexusEndpointManager = persistence.NewMockNexusEndpointManager(s.controller)
 	s.mockNexusEndpointManager.EXPECT().ListNexusEndpoints(gomock.Any(), gomock.Any()).Return(&persistence.ListNexusEndpointsResponse{}, nil).AnyTimes()
 
-	s.matchingEngine = s.newMatchingEngine(defaultTestConfig(), s.taskManager)
+	s.matchingEngine = s.newMatchingEngine(s.newConfig(), s.taskManager)
 	s.matchingEngine.Start()
+}
+
+func (s *matchingEngineSuite) newConfig() *Config {
+	res := defaultTestConfig()
+	if s.newMatcher {
+		res = withNewMatcher(res)
+	}
+	return res
 }
 
 func (s *matchingEngineSuite) TearDownTest() {
@@ -246,120 +259,10 @@ func newMatchingEngine(
 
 func (s *matchingEngineSuite) newPartitionManager(prtn tqid.Partition, config *Config) taskQueuePartitionManager {
 	tqConfig := newTaskQueueConfig(prtn.TaskQueue(), config, matchingTestNamespace)
-
 	logger, _, metricsHandler := s.matchingEngine.loggerAndMetricsForPartition(matchingTestNamespace, prtn, tqConfig)
 	pm, err := newTaskQueuePartitionManager(s.matchingEngine, s.ns, prtn, tqConfig, logger, logger, metricsHandler, &mockUserDataManager{})
 	s.Require().NoError(err)
 	return pm
-}
-
-func (s *matchingEngineSuite) TestAckManager() {
-	backlogMgr := newBacklogMgr(s.T(), s.controller, false)
-	_, err := backlogMgr.db.RenewLease(backlogMgr.tqCtx)
-	s.NoError(err)
-	m := backlogMgr.taskAckManager
-
-	m.setAckLevel(100)
-	s.EqualValues(100, m.getAckLevel())
-	s.EqualValues(100, m.getReadLevel())
-	const t1 = 200
-	const t2 = 220
-	const t3 = 320
-	const t4 = 340
-	const t5 = 360
-	const t6 = 380
-
-	m.addTask(t1)
-	// Increment the backlog so that we don't under-count
-	// this happens since we decrease the counter on completion of a task
-	backlogMgr.db.updateApproximateBacklogCount(1)
-	s.EqualValues(100, m.getAckLevel())
-	s.EqualValues(t1, m.getReadLevel())
-
-	m.addTask(t2)
-	backlogMgr.db.updateApproximateBacklogCount(1)
-	s.EqualValues(100, m.getAckLevel())
-	s.EqualValues(t2, m.getReadLevel())
-
-	m.completeTask(t2)
-	s.EqualValues(100, m.getAckLevel())
-	s.EqualValues(t2, m.getReadLevel())
-
-	m.completeTask(t1)
-	s.EqualValues(t2, m.getAckLevel())
-	s.EqualValues(t2, m.getReadLevel())
-
-	m.setAckLevel(300)
-	s.EqualValues(300, m.getAckLevel())
-	s.EqualValues(300, m.getReadLevel())
-
-	m.addTask(t3)
-	backlogMgr.db.updateApproximateBacklogCount(1)
-	s.EqualValues(300, m.getAckLevel())
-	s.EqualValues(t3, m.getReadLevel())
-
-	m.addTask(t4)
-	backlogMgr.db.updateApproximateBacklogCount(1)
-	s.EqualValues(300, m.getAckLevel())
-	s.EqualValues(t4, m.getReadLevel())
-
-	m.completeTask(t3)
-	s.EqualValues(t3, m.getAckLevel())
-	s.EqualValues(t4, m.getReadLevel())
-
-	m.completeTask(t4)
-	s.EqualValues(t4, m.getAckLevel())
-	s.EqualValues(t4, m.getReadLevel())
-
-	m.setReadLevel(t5)
-	s.EqualValues(t5, m.getReadLevel())
-
-	m.setAckLevel(t5)
-	m.setReadLevelAfterGap(t6)
-	s.EqualValues(t6, m.getReadLevel())
-	s.EqualValues(t6, m.getAckLevel())
-}
-
-func (s *matchingEngineSuite) TestAckManager_Sort() {
-	backlogMgr := newBacklogMgr(s.T(), s.controller, false)
-	_, err := backlogMgr.db.RenewLease(backlogMgr.tqCtx)
-	s.NoError(err)
-	m := backlogMgr.taskAckManager
-
-	const t0 = 100
-	m.setAckLevel(t0)
-	s.EqualValues(t0, m.getAckLevel())
-	s.EqualValues(t0, m.getReadLevel())
-	const t1 = 200
-	const t2 = 220
-	const t3 = 320
-	const t4 = 340
-	const t5 = 360
-
-	m.addTask(t1)
-	m.addTask(t2)
-	m.addTask(t3)
-	m.addTask(t4)
-	m.addTask(t5)
-
-	// Increment the backlog so that we don't under-count
-	// this happens since we decrease the counter on completion of a task
-	backlogMgr.db.updateApproximateBacklogCount(5)
-
-	m.completeTask(t2)
-	s.EqualValues(t0, m.getAckLevel())
-
-	m.completeTask(t1)
-	s.EqualValues(t2, m.getAckLevel())
-
-	m.completeTask(t5)
-	s.EqualValues(t2, m.getAckLevel())
-
-	m.completeTask(t4)
-	s.EqualValues(t2, m.getAckLevel())
-
-	m.completeTask(t3)
-	s.EqualValues(t5, m.getAckLevel())
 }
 
 func (s *matchingEngineSuite) TestPollActivityTaskQueuesEmptyResult() {
@@ -460,7 +363,7 @@ func (s *matchingEngineSuite) TestOnlyUnloadMatchingInstance() {
 
 	tqm2 := s.newPartitionManager(prtn, s.matchingEngine.config)
 
-	// try to unload a different tqm instance with the same taskqueue ID
+	// try to unload a different tqMgr instance with the same taskqueue ID
 	s.matchingEngine.unloadTaskQueuePartition(tqm2, unloadCauseUnspecified)
 
 	got, _, err := s.matchingEngine.getTaskQueuePartitionManager(context.Background(), prtn, true, loadCauseUnspecified)
@@ -468,7 +371,7 @@ func (s *matchingEngineSuite) TestOnlyUnloadMatchingInstance() {
 	s.Require().Same(tqm, got,
 		"Unload call with non-matching taskQueuePartitionManager should not cause unload")
 
-	// this time unload the right tqm
+	// this time unload the right tqMgr
 	s.matchingEngine.unloadTaskQueuePartition(tqm, unloadCauseUnspecified)
 
 	got, _, err = s.matchingEngine.getTaskQueuePartitionManager(context.Background(), prtn, true, loadCauseUnspecified)
@@ -484,6 +387,7 @@ func (s *matchingEngineSuite) TestFailAddTaskWithHistoryExhausted() {
 }
 
 func (s *matchingEngineSuite) TestFailAddTaskWithHistoryError() {
+	s.logger.Expect(testlogger.Error, "dropping task due to non-nonretryable errors")
 	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
 	historyError := serviceerror.NewInternal("nothing to start")
 	tqName := "testFailAddTaskWithHistoryError"
@@ -705,6 +609,7 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_NamespaceHandover() {
 }
 
 func (s *matchingEngineSuite) TestPollActivityTaskQueues_InternalError() {
+	s.logger.Expect(testlogger.Error, "dropping task due to non-nonretryable errors")
 	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
 	namespaceId := uuid.New()
 	tl := "queue"
@@ -738,6 +643,7 @@ func (s *matchingEngineSuite) TestPollActivityTaskQueues_InternalError() {
 }
 
 func (s *matchingEngineSuite) TestPollActivityTaskQueues_DataLossError() {
+	s.logger.Expect(testlogger.Error, "dropping task due to non-nonretryable errors")
 	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
 
 	namespaceId := uuid.New()
@@ -773,6 +679,7 @@ func (s *matchingEngineSuite) TestPollActivityTaskQueues_DataLossError() {
 }
 
 func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_InternalError() {
+	s.logger.Expect(testlogger.Error, "dropping task due to non-nonretryable errors")
 	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
 
 	tqName := "queue"
@@ -799,6 +706,7 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_InternalError() {
 }
 
 func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_DataLossError() {
+	s.logger.Expect(testlogger.Error, "dropping task due to non-nonretryable errors")
 	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
 
 	tqName := "queue"
@@ -1086,34 +994,28 @@ func (s *matchingEngineSuite) TestAddThenConsumeActivities() {
 
 // TODO: this unit test does not seem to belong to matchingEngine, move it to the right place
 func (s *matchingEngineSuite) TestSyncMatchActivities() {
-	// Set a short long poll expiration so that we don't have to wait too long for 0 throttling cases
-	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(2 * time.Second)
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher")
+	}
+	s.logger.Expect(testlogger.Error, "unexpected error dispatching task")
 
-	runID := uuid.NewRandom().String()
-	workflowID := "workflow1"
-	workflowExecution := &commonpb.WorkflowExecution{RunId: runID, WorkflowId: workflowID}
-
-	const taskCount = 10
-	const initialRangeID = 102
-	// TODO: Understand why publish is low when rangeSize is 3
-	const rangeSize = 30
-
-	namespaceId := uuid.New()
-	tl := "makeToast"
-	dbq := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
-	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
-	// So we can get snapshots
 	scope := tally.NewTestScope("test", nil)
 	s.matchingEngine.metricsHandler = metrics.NewTallyMetricsHandler(metrics.ClientConfig{}, scope).WithTags(metrics.ServiceNameTag(primitives.MatchingService))
 
-	var err error
-	s.taskManager.getQueueManagerByKey(dbq).rangeID = initialRangeID
-	mgr := s.newPartitionManager(dbq.partition, s.matchingEngine.config)
+	// Set a short long poll expiration so that we don't have to wait too long for 0 throttling cases
+	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(2 * time.Second)
+	s.matchingEngine.config.MinTaskThrottlingBurstSize = dynamicconfig.GetIntPropertyFnFilteredByTaskQueue(0)
+	s.matchingEngine.config.RangeSize = 30 // override to low number for the test
 
+	const initialRangeID = 102
+	namespaceId := uuid.New()
+	tl := "makeToast"
+	dbq := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+	s.taskManager.getQueueManagerByKey(dbq).rangeID = initialRangeID
+
+	mgr := s.newPartitionManager(dbq.partition, s.matchingEngine.config)
 	mgrImpl, ok := mgr.(*taskQueuePartitionManagerImpl).defaultQueue.(*physicalTaskQueueManagerImpl)
 	s.True(ok)
-
-	mgrImpl.oldMatcher.config.MinTaskThrottlingBurstSize = func() int { return 0 }
 	mgrImpl.oldMatcher.rateLimiter = quotas.NewRateLimiter(
 		defaultTaskDispatchRPS,
 		defaultTaskDispatchRPS,
@@ -1126,7 +1028,6 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 		RateLimiterImpl: mgrImpl.oldMatcher.rateLimiter.(*quotas.RateLimiterImpl),
 	}
 	s.matchingEngine.updateTaskQueue(dbq.partition, mgr)
-
 	mgr.Start()
 
 	taskQueue := &taskqueuepb.TaskQueue{
@@ -1140,7 +1041,6 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 
 	identity := "nobody"
 
-	// History service is using mock
 	s.mockHistoryClient.EXPECT().RecordActivityTaskStarted(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, taskRequest *historyservice.RecordActivityTaskStartedRequest, arg2 ...interface{}) (*historyservice.RecordActivityTaskStartedResponse, error) {
 			s.logger.Debug("Mock Received RecordActivityTaskStartedRequest")
@@ -1163,6 +1063,10 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 			}, nil
 		}).AnyTimes()
 
+	const taskCount = 10
+	runID := uuid.NewRandom().String()
+	workflowID := "workflow1"
+	workflowExecution := &commonpb.WorkflowExecution{RunId: runID, WorkflowId: workflowID}
 	pollFunc := func(maxDispatch float64) (*matchingservice.PollActivityTaskQueueResponse, error) {
 		return s.matchingEngine.PollActivityTaskQueue(context.Background(), &matchingservice.PollActivityTaskQueueRequest{
 			NamespaceId: namespaceId,
@@ -1173,7 +1077,6 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 			},
 		}, metrics.NoopMetricsHandler)
 	}
-
 	for i := int64(0); i < taskCount; i++ {
 		scheduledEventID := i * 3
 
@@ -1226,6 +1129,7 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 		s.EqualValues(activityType, result.ActivityType)
 		s.EqualValues(activityInput, result.Input)
 		s.EqualValues(workflowExecution, result.WorkflowExecution)
+
 		taskToken := &tokenspb.Task{
 			Attempt:          1,
 			NamespaceId:      namespaceId,
@@ -1235,21 +1139,19 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 			ActivityId:       activityID,
 			ActivityType:     activityTypeName,
 		}
-
 		serializedToken, _ := s.matchingEngine.tokenSerializer.Serialize(taskToken)
-		// s.EqualValues(scheduledEventID, result.Task)
-
 		s.EqualValues(serializedToken, result.TaskToken)
 	}
 
-	time.Sleep(20 * time.Millisecond) // So any buffer tasks from 0 rps get picked up
-	snap := scope.Snapshot()
-	syncCtr := snap.Counters()["test.sync_throttle_count+namespace="+matchingTestNamespace+",operation=TaskQueueMgr,partition=0,service_name=matching,task_type=Activity,taskqueue=makeToast,worker-build-id=__unversioned__"]
-	s.Equal(1, int(syncCtr.Value()))                        // Check times zero rps is set = throttle counter
-	s.EqualValues(1, s.taskManager.getCreateTaskCount(dbq)) // Check times zero rps is set = Tasks stored in persistence
-	s.EqualValues(0, s.taskManager.getTaskCount(dbq))
-	expectedRange := int64(initialRangeID + taskCount/rangeSize)
-	if taskCount%rangeSize > 0 {
+	s.EventuallyWithT(func(collect *assert.CollectT) {
+		assert.EqualValues(collect, 1, s.taskManager.getCreateTaskCount(dbq)) // Check times zero rps is set = Tasks stored in persistence
+		assert.EqualValues(collect, 0, s.taskManager.getTaskCount(dbq))
+	}, 2*time.Second, 100*time.Millisecond)
+
+	syncCtr := scope.Snapshot().Counters()["test.sync_throttle_count+namespace="+matchingTestNamespace+",operation=TaskQueueMgr,partition=0,service_name=matching,task_type=Activity,taskqueue=makeToast,worker-build-id=__unversioned__"]
+	s.Equal(1, int(syncCtr.Value())) // Check times zero rps is set = throttle counter
+	expectedRange := int64(initialRangeID + taskCount/30)
+	if taskCount%30 > 0 {
 		expectedRange++
 	}
 	// Due to conflicts some ids are skipped and more real ranges are used.
@@ -1311,6 +1213,8 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 ) int64 {
 	scope := tally.NewTestScope("test", nil)
 	s.matchingEngine.metricsHandler = metrics.NewTallyMetricsHandler(metrics.ClientConfig{}, scope).WithTags(metrics.ServiceNameTag(primitives.MatchingService))
+	s.matchingEngine.config.MinTaskThrottlingBurstSize = dynamicconfig.GetIntPropertyFnFilteredByTaskQueue(0)
+
 	runID := uuid.NewRandom().String()
 	workflowID := "workflow1"
 	workflowExecution := &commonpb.WorkflowExecution{RunId: runID, WorkflowId: workflowID}
@@ -1325,22 +1229,6 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 
 	s.taskManager.getQueueManagerByKey(dbq).rangeID = initialRangeID
 	mgr := s.newPartitionManager(dbq.partition, s.matchingEngine.config)
-
-	mgrImpl, ok := mgr.(*taskQueuePartitionManagerImpl).defaultQueue.(*physicalTaskQueueManagerImpl)
-	s.Assert().True(ok)
-
-	mgrImpl.oldMatcher.config.MinTaskThrottlingBurstSize = func() int { return 0 }
-	mgrImpl.oldMatcher.rateLimiter = quotas.NewRateLimiter(
-		defaultTaskDispatchRPS,
-		defaultTaskDispatchRPS,
-	)
-	mgrImpl.oldMatcher.dynamicRateBurst = &dynamicRateBurstWrapper{
-		MutableRateBurst: quotas.NewMutableRateBurst(
-			defaultTaskDispatchRPS,
-			defaultTaskDispatchRPS,
-		),
-		RateLimiterImpl: mgrImpl.oldMatcher.rateLimiter.(*quotas.RateLimiterImpl),
-	}
 	s.matchingEngine.updateTaskQueue(dbq.partition, mgr)
 	mgr.Start()
 
@@ -1627,6 +1515,8 @@ func (s *matchingEngineSuite) TestPollWithExpiredContext() {
 }
 
 func (s *matchingEngineSuite) TestForceUnloadTaskQueue() {
+	s.logger.Expect(testlogger.Error, "unexpected error dispatching task", tag.Error(errTaskQueueClosed))
+
 	ctx := context.Background()
 	namespaceId := uuid.New()
 	identity := "nobody"
@@ -1699,7 +1589,7 @@ func (s *matchingEngineSuite) TestMultipleEnginesActivitiesRangeStealing() {
 
 	engines := make([]*matchingEngineImpl, engineCount)
 	for p := 0; p < engineCount; p++ {
-		e := s.newMatchingEngine(defaultTestConfig(), s.taskManager)
+		e := s.newMatchingEngine(s.newConfig(), s.taskManager)
 		e.config.RangeSize = rangeSize
 		engines[p] = e
 		e.Start()
@@ -1857,7 +1747,7 @@ func (s *matchingEngineSuite) TestMultipleEnginesWorkflowTasksRangeStealing() {
 
 	engines := make([]*matchingEngineImpl, engineCount)
 	for p := 0; p < engineCount; p++ {
-		e := s.newMatchingEngine(defaultTestConfig(), s.taskManager)
+		e := s.newMatchingEngine(s.newConfig(), s.taskManager)
 		e.config.RangeSize = rangeSize
 		engines[p] = e
 		e.Start()
@@ -1979,48 +1869,41 @@ func (s *matchingEngineSuite) TestMultipleEnginesWorkflowTasksRangeStealing() {
 }
 
 func (s *matchingEngineSuite) TestAddTaskAfterStartFailure() {
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher")
+	}
+
 	// test default is 100ms, but make it longer for this test so it's not flaky
 	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(10 * time.Second)
-
-	runID := uuid.NewRandom().String()
-	workflowID := "workflow1"
-	workflowExecution := &commonpb.WorkflowExecution{RunId: runID, WorkflowId: workflowID}
 
 	namespaceId := uuid.New()
 	tl := "makeToast"
 	dbq := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 
-	taskQueue := &taskqueuepb.TaskQueue{
-		Name: tl,
-		Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
-	}
-
-	scheduledEventID := int64(0)
-	addRequest := matchingservice.AddActivityTaskRequest{
-		NamespaceId:            namespaceId,
-		Execution:              workflowExecution,
-		ScheduledEventId:       scheduledEventID,
-		TaskQueue:              taskQueue,
-		ScheduleToStartTimeout: timestamp.DurationFromSeconds(100),
-	}
-
-	_, _, err := s.matchingEngine.AddActivityTask(context.Background(), &addRequest)
+	_, _, err := s.matchingEngine.AddActivityTask(context.Background(),
+		&matchingservice.AddActivityTaskRequest{
+			NamespaceId:      namespaceId,
+			Execution:        &commonpb.WorkflowExecution{RunId: uuid.NewRandom().String(), WorkflowId: "workflow1"},
+			ScheduledEventId: int64(0),
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: tl,
+				Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+			},
+			ScheduleToStartTimeout: timestamp.DurationFromSeconds(100),
+		})
 	s.NoError(err)
 	s.EqualValues(1, s.taskManager.getTaskCount(dbq))
 
-	task, _, err := s.matchingEngine.pollTask(context.Background(), dbq.partition, &pollMetadata{})
+	task1, _, err := s.matchingEngine.pollTask(context.Background(), dbq.partition, &pollMetadata{})
 	s.NoError(err)
 
-	task.finish(serviceerror.NewInternal("test error"), true)
+	task1.finish(serviceerror.NewInternal("test error"), true)
 	s.EqualValues(1, s.taskManager.getTaskCount(dbq))
+
 	task2, _, err := s.matchingEngine.pollTask(context.Background(), dbq.partition, &pollMetadata{})
 	s.NoError(err)
-	s.NotNil(task2)
-
-	s.NotEqual(task.event.GetTaskId(), task2.event.GetTaskId())
-	s.Equal(task.event.Data.GetWorkflowId(), task2.event.Data.GetWorkflowId())
-	s.Equal(task.event.Data.GetRunId(), task2.event.Data.GetRunId())
-	s.Equal(task.event.Data.GetScheduledEventId(), task2.event.Data.GetScheduledEventId())
+	s.EqualValues(task1.event.Data, task2.event.Data)
+	s.NotEqual(task1.event.GetTaskId(), task2.event.GetTaskId(), "IDs should not match")
 
 	task2.finish(nil, true)
 	s.EqualValues(0, s.taskManager.getTaskCount(dbq))
@@ -2028,6 +1911,10 @@ func (s *matchingEngineSuite) TestAddTaskAfterStartFailure() {
 
 // TODO: should be moved to backlog_manager_test
 func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch() {
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher")
+	}
+
 	runID := uuid.NewRandom().String()
 	workflowID := "workflow1"
 	workflowExecution := &commonpb.WorkflowExecution{RunId: runID, WorkflowId: workflowID}
@@ -2077,11 +1964,11 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch() {
 
 	// setReadLevel should NEVER be called without updating ackManager.outstandingTasks
 	// This is only for unit test purpose
-	blm.taskAckManager.setReadLevel(blm.db.GetMaxReadLevel(0))
+	blm.taskAckManager.setReadLevel(blm.getDB().GetMaxReadLevel(0))
 	batch, err := blm.taskReader.getTaskBatch(context.Background())
 	s.Nil(err)
 	s.EqualValues(0, len(batch.tasks))
-	s.EqualValues(blm.db.GetMaxReadLevel(0), batch.readLevel)
+	s.EqualValues(blm.getDB().GetMaxReadLevel(0), batch.readLevel)
 	s.True(batch.isReadBatchDone)
 
 	blm.taskAckManager.setReadLevel(0)
@@ -2124,67 +2011,34 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch() {
 	s.True(batch.isReadBatchDone)
 }
 
-// TODO: should be moved to backlog_manager_test
-func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch_ReadBatchDone() {
-	namespaceId := uuid.New()
-	tl := "makeToast"
-	prtn := newRootPartition(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
-
-	const rangeSize = 10
-	const maxReadLevel = int64(120)
-	config := defaultTestConfig()
-	config.RangeSize = rangeSize
-	pm := s.newPartitionManager(prtn, config)
-
-	tlMgr, ok := pm.(*taskQueuePartitionManagerImpl).defaultQueue.(*physicalTaskQueueManagerImpl)
-	s.True(ok)
-
-	tlMgr.Start()
-
-	// tlMgr.taskWriter startup is async so give it time to complete, otherwise
-	// the following few lines get clobbered as part of the taskWriter.Start()
-	time.Sleep(100 * time.Millisecond)
-
-	blm := tlMgr.backlogMgr.(*backlogManagerImpl)
-	blm.taskAckManager.setReadLevel(0)
-	blm.db.setMaxReadLevelForTesting(0, maxReadLevel)
-	batch, err := blm.taskReader.getTaskBatch(context.Background())
-	s.Empty(batch.tasks)
-	s.Equal(int64(rangeSize*10), batch.readLevel)
-	s.False(batch.isReadBatchDone)
-	s.NoError(err)
-
-	blm.taskAckManager.setReadLevel(batch.readLevel)
-	batch, err = blm.taskReader.getTaskBatch(context.Background())
-	s.Empty(batch.tasks)
-	s.Equal(maxReadLevel, batch.readLevel)
-	s.True(batch.isReadBatchDone)
-	s.NoError(err)
-}
-
 func (s *matchingEngineSuite) TestTaskQueueManager_CyclingBehavior() {
-	namespaceId := uuid.New()
-	tl := "makeToast"
-	dbq := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
-	config := defaultTestConfig()
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher")
+	}
+
+	config := s.newConfig()
+	dbq := newUnversionedRootQueueKey(uuid.New(), "makeToast", enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 
 	for i := 0; i < 4; i++ {
 		prevGetTasksCount := s.taskManager.getGetTasksCount(dbq)
 
 		mgr := s.newPartitionManager(dbq.partition, config)
-
 		mgr.Start()
+
 		// tlMgr.taskWriter startup is async so give it time to complete
 		time.Sleep(100 * time.Millisecond)
-		mgr.(*taskQueuePartitionManagerImpl).Stop(unloadCauseUnspecified)
+		mgr.Stop(unloadCauseUnspecified)
 
-		getTasksCount := s.taskManager.getGetTasksCount(dbq) - prevGetTasksCount
-		s.LessOrEqual(getTasksCount, 1)
+		s.LessOrEqual(s.taskManager.getGetTasksCount(dbq)-prevGetTasksCount, 1)
 	}
 }
 
 // TODO: should be moved to backlog_manager_test
 func (s *matchingEngineSuite) TestTaskExpiryAndCompletion() {
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher")
+	}
+
 	runID := uuid.NewRandom().String()
 	workflowID := uuid.New()
 	workflowExecution := &commonpb.WorkflowExecution{RunId: runID, WorkflowId: workflowID}
@@ -2759,7 +2613,7 @@ func (s *matchingEngineSuite) TestDemotedMatch() {
 	// allow taskReader to finish starting dispatch loop so that we can unload tqms cleanly
 	time.Sleep(10 * time.Millisecond)
 
-	// unload base and versioned tqm. note: unload the partition manager unloads both
+	// unload base and versioned tqMgr. note: unload the partition manager unloads both
 	prtn := newRootPartition(namespaceId, tq, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	baseTqm, _, err := s.matchingEngine.getTaskQueuePartitionManager(ctx, prtn, false, loadCauseUnspecified)
 	s.NoError(err)
@@ -2822,7 +2676,7 @@ func (s *matchingEngineSuite) TestUnloadOnMembershipChange() {
 	self := s.mockHostInfoProvider.HostInfo()
 	other := membership.NewHostInfoFromAddress("other")
 
-	config := defaultTestConfig()
+	config := s.newConfig()
 	config.MembershipUnloadDelay = dynamicconfig.GetDurationPropertyFn(10 * time.Millisecond)
 	e := s.newMatchingEngine(config, s.taskManager)
 	e.Start()
@@ -3095,15 +2949,13 @@ func (s *matchingEngineSuite) mockHistoryWhilePolling(workflowType *commonpb.Wor
 }
 
 func (s *matchingEngineSuite) createTQAndPTQForBacklogTests() (*taskqueuepb.TaskQueue, *PhysicalTaskQueueKey) {
+	s.matchingEngine.config.RangeSize = 10
 	tq := "approximateBacklogCounter"
 	ptq := newUnversionedRootQueueKey(namespaceId, tq, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
-	s.matchingEngine.config.RangeSize = 10
-
 	taskQueue := &taskqueuepb.TaskQueue{
 		Name: tq,
 		Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 	}
-
 	return taskQueue, ptq
 }
 
@@ -3220,6 +3072,7 @@ func (s *matchingEngineSuite) TestAddConsumeWorkflowTasksNoDBErrors() {
 }
 
 func (s *matchingEngineSuite) TestAddConsumeWorkflowTasksDBErrors() {
+	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.taskManager.dbConditionalFailedError = true
 	s.addConsumeAllWorkflowTasksNonConcurrently(100, 1, 1)
 }
@@ -3229,6 +3082,7 @@ func (s *matchingEngineSuite) TestMultipleWorkersAddConsumeWorkflowTasksNoDBErro
 }
 
 func (s *matchingEngineSuite) TestMultipleWorkersAddConsumeWorkflowTasksDBErrors() {
+	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.taskManager.dbConditionalFailedError = true
 	s.addConsumeAllWorkflowTasksNonConcurrently(100, 5, 5)
 }
@@ -3250,17 +3104,16 @@ func (s *matchingEngineSuite) resetBacklogCounter(numWorkers int, taskCount int,
 	partitionManager, _, err := s.matchingEngine.getTaskQueuePartitionManager(context.Background(), ptq.Partition(), false, loadCauseTask)
 	s.NoError(err)
 	pqMgr := s.getPhysicalTaskQueueManagerImpl(ptq)
-	blm := pqMgr.backlogMgr.(*backlogManagerImpl)
 
 	s.EqualValues(taskCount*numWorkers, s.taskManager.getTaskCount(ptq))
 
 	// Check the maxReadLevel with the value of task stored in db
 	maxTaskId, ok := s.taskManager.maxTaskID(ptq)
 	s.True(ok)
-	s.EqualValues(maxTaskId, blm.db.GetMaxReadLevel(0))
+	s.EqualValues(maxTaskId, pqMgr.backlogMgr.getDB().GetMaxReadLevel(0))
 
 	// validate the approximateBacklogCounter
-	s.EqualValues(taskCount*numWorkers, blm.TotalApproximateBacklogCount())
+	s.EqualValues(taskCount*numWorkers, pqMgr.backlogMgr.TotalApproximateBacklogCount())
 
 	// Unload the PQM
 	s.matchingEngine.unloadTaskQueuePartition(partitionManager, unloadCauseForce)
@@ -3280,74 +3133,71 @@ func (s *matchingEngineSuite) resetBacklogCounter(numWorkers int, taskCount int,
 	s.NoError(err)
 	s.EqualValues((taskCount*numWorkers)-1, s.taskManager.getTaskCount(ptq))
 
-	// Add pollers which shall also load the fresher version of tqm
+	// Add pollers which shall also load the fresher version of tqMgr
 	s.pollWorkflowTasks(false, workflowType, 1, (taskCount*numWorkers)-1, ptq, taskQueue, nil)
 
 	// Update pgMgr to have the latest pgMgr
 	pqMgr = s.getPhysicalTaskQueueManagerImpl(ptq)
-	blm = pqMgr.backlogMgr.(*backlogManagerImpl)
 
 	// Overwrite the maxReadLevel since it could have increased if the previous taskWriter was
 	// stopped (which would not result in resetting).
-	blm.db.setMaxReadLevelForTesting(0, maxTaskId)
+	pqMgr.backlogMgr.getDB().setMaxReadLevelForTesting(0, maxTaskId)
 
 	s.EqualValues(0, s.taskManager.getTaskCount(ptq))
-	s.Eventually(func() bool {
-		return int64(0) == blm.TotalApproximateBacklogCount()
-	}, 3*time.Second, 10*time.Millisecond, "backlog counter should have been reset")
-
-	s.EqualValues(int64(0), blm.TotalApproximateBacklogCount())
+	s.EventuallyWithT(func(collect *assert.CollectT) {
+		assert.Equal(collect, int64(0), pqMgr.backlogMgr.TotalApproximateBacklogCount())
+	}, 4*time.Second, 10*time.Millisecond, "backlog counter should have been reset")
 }
 
 // TestResettingBacklogCounter tests the scenario where approximateBacklogCounter over-counts and resets it accordingly
 func (s *matchingEngineSuite) TestResetBacklogCounterNoDBErrors() {
-
 	s.resetBacklogCounter(2, 2, 2)
 }
 
 func (s *matchingEngineSuite) TestResetBacklogCounterDBErrors() {
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher")
+	}
+
+	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.taskManager.dbConditionalFailedError = true
 	s.resetBacklogCounter(2, 2, 2)
 }
 
 func (s *matchingEngineSuite) TestMoreTasksResetBacklogCounterNoDBErrors() {
-
 	s.resetBacklogCounter(10, 20, 2)
 }
 
 func (s *matchingEngineSuite) TestMoreTasksResetBacklogCounterDBErrors() {
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher")
+	}
+	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.taskManager.dbConditionalFailedError = true
-
 	s.resetBacklogCounter(10, 50, 5)
 }
 
 // Concurrent tests for testing approximateBacklogCounter
 
-func (s *matchingEngineSuite) concurrentPublishAndConsumeValidateBacklogCounter(numWorkers int, tasksToAdd int, tasksToPoll int) {
-	workflowType, workflowExecution := s.generateWorkflowExecution()
-	taskQueue, ptq := s.createTQAndPTQForBacklogTests()
-
+func (s *matchingEngineSuite) concurrentPublishAndConsumeValidateBacklogCounter(
+	numWorkers, tasksToAdd, tasksToPoll int,
+) {
 	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(10 * time.Millisecond)
 	s.matchingEngine.config.UpdateAckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(1 * time.Millisecond)
 
 	var wg sync.WaitGroup
 	wg.Add(2 * numWorkers)
-
+	workflowType, workflowExecution := s.generateWorkflowExecution()
+	taskQueue, ptq := s.createTQAndPTQForBacklogTests()
 	s.addWorkflowTasks(true, numWorkers, tasksToAdd, taskQueue, workflowExecution, &wg)
 	s.pollWorkflowTasks(true, workflowType, numWorkers, tasksToPoll, ptq, taskQueue, &wg)
-
 	wg.Wait()
 
-	pqMgr := s.getPhysicalTaskQueueManagerImpl(ptq)
-	blm := pqMgr.backlogMgr.(*backlogManagerImpl)
-
-	// force GC to make sure all the acked tasks are cleaned up before validating the count
-	blm.taskGC.RunNow(blm.taskAckManager.getAckLevel())
-	s.LessOrEqual(int64(s.taskManager.getTaskCount(ptq)), blm.TotalApproximateBacklogCount())
+	ptqMgr := s.getPhysicalTaskQueueManagerImpl(ptq)
+	s.LessOrEqual(int64(s.taskManager.getTaskCount(ptq)), ptqMgr.backlogMgr.TotalApproximateBacklogCount())
 }
 
 func (s *matchingEngineSuite) TestConcurrentAddWorkflowTasksNoDBErrors() {
-
 	s.concurrentPublishAndConsumeValidateBacklogCounter(150, 100, 0)
 }
 
@@ -3360,7 +3210,6 @@ func (s *matchingEngineSuite) TestConcurrentAddWorkflowTasksDBErrors() {
 }
 
 func (s *matchingEngineSuite) TestConcurrentAdd_PollWorkflowTasksNoDBErrors() {
-
 	s.concurrentPublishAndConsumeValidateBacklogCounter(20, 100, 100)
 }
 
@@ -3377,13 +3226,13 @@ func (s *matchingEngineSuite) TestLesserNumberOfPollersThanTasksNoDBErrors() {
 }
 
 func (s *matchingEngineSuite) TestLesserNumberOfPollersThanTasksDBErrors() {
+	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.taskManager.dbConditionalFailedError = true
 
 	s.concurrentPublishAndConsumeValidateBacklogCounter(1, 500, 200)
 }
 
 func (s *matchingEngineSuite) TestMultipleWorkersLesserNumberOfPollersThanTasksNoDBErrors() {
-
 	s.concurrentPublishAndConsumeValidateBacklogCounter(5, 500, 200)
 }
 
@@ -3950,4 +3799,12 @@ func (d *dynamicRateBurstWrapper) Rate() float64 {
 
 func (d *dynamicRateBurstWrapper) Burst() int {
 	return d.RateLimiterImpl.Burst()
+}
+
+// TODO(pri): cleanup; delete this
+func withNewMatcher(config *Config) *Config {
+	config.NewMatcher = func(_ string, _ string, _ enumspb.TaskQueueType, callback func(bool)) (v bool, cancel func()) {
+		return true, func() {}
+	}
+	return config
 }

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3072,7 +3072,9 @@ func (s *matchingEngineSuite) TestAddConsumeWorkflowTasksNoDBErrors() {
 
 func (s *matchingEngineSuite) TestAddConsumeWorkflowTasksDBErrors() {
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
+	s.logger.Expect(testlogger.Error, "unexpected error dispatching task")
 	s.taskManager.dbRandCondFailedErr = true
+
 	s.addConsumeAllWorkflowTasksNonConcurrently(100, 1, 1)
 }
 
@@ -3082,7 +3084,9 @@ func (s *matchingEngineSuite) TestMultipleWorkersAddConsumeWorkflowTasksNoDBErro
 
 func (s *matchingEngineSuite) TestMultipleWorkersAddConsumeWorkflowTasksDBErrors() {
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
+	s.logger.Expect(testlogger.Error, "unexpected error dispatching task")
 	s.taskManager.dbRandCondFailedErr = true
+
 	s.addConsumeAllWorkflowTasksNonConcurrently(100, 5, 5)
 }
 
@@ -3157,9 +3161,9 @@ func (s *matchingEngineSuite) TestResetBacklogCounterDBErrors() {
 	if s.newMatcher {
 		s.T().Skip("not supported by new matcher")
 	}
-
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.taskManager.dbRandCondFailedErr = true
+
 	s.resetBacklogCounter(2, 2, 2)
 }
 
@@ -3173,6 +3177,7 @@ func (s *matchingEngineSuite) TestMoreTasksResetBacklogCounterDBErrors() {
 	}
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.taskManager.dbRandCondFailedErr = true
+
 	s.resetBacklogCounter(10, 50, 5)
 }
 

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3343,8 +3343,9 @@ type testTaskManager struct {
 	sync.Mutex
 	queues              map[dbTaskQueueKey]*testPhysicalTaskQueueManager
 	logger              log.Logger
-	dbRandCondFailedErr bool
 	dbServiceError      bool
+	dbCondFailedErr     bool
+	dbRandCondFailedErr bool
 }
 
 type dbTaskQueueKey struct {
@@ -3569,7 +3570,7 @@ func (m *testTaskManager) CreateTasks(
 	rangeID := request.TaskQueueInfo.RangeID
 
 	// Randomly returns a ConditionFailedError
-	if m.generateErrorRandomly() {
+	if m.generateErrorRandomly() || m.dbCondFailedErr {
 		return nil, &persistence.ConditionFailedError{
 			Msg: fmt.Sprintf("Failed to create task. TaskQueue: %v, taskQueueType: %v, rangeID: %v, db rangeID: %v",
 				taskQueue, taskType, rangeID, rangeID),

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -71,8 +71,6 @@ const (
 )
 
 type (
-	taskQueueManagerOpt func(*physicalTaskQueueManagerImpl)
-
 	addTaskParams struct {
 		taskInfo    *persistencespb.TaskInfo
 		forwardInfo *taskqueuespb.TaskForwardInfo

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -144,7 +144,6 @@ var (
 func newPhysicalTaskQueueManager(
 	partitionMgr *taskQueuePartitionManagerImpl,
 	queue *PhysicalTaskQueueKey,
-	opts ...taskQueueManagerOpt,
 ) (*physicalTaskQueueManagerImpl, error) {
 	e := partitionMgr.engine
 	config := partitionMgr.config
@@ -253,9 +252,6 @@ func newPhysicalTaskQueueManager(
 		}
 		pqMgr.oldMatcher = newTaskMatcher(config, fwdr, pqMgr.metricsHandler)
 		pqMgr.matcher = pqMgr.oldMatcher
-	}
-	for _, opt := range opts {
-		opt(pqMgr)
 	}
 	return pqMgr, nil
 }

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -202,6 +202,7 @@ func defaultTqId() *PhysicalTaskQueueKey {
 	return newTestUnversionedPhysicalQueueKey(defaultNamespaceId, defaultRootTqID, enumspb.TASK_QUEUE_TYPE_WORKFLOW, 0)
 }
 
+// TODO(pri): old matcher cleanup
 func (s *PhysicalTaskQueueManagerTestSuite) TestReaderBacklogAge() {
 	if s.newMatcher {
 		s.T().Skip("not supported by new matcher")
@@ -253,6 +254,7 @@ func randomTaskInfoWithAgeTaskID(age time.Duration, TaskID int64) *persistencesp
 	}
 }
 
+// TODO(pri): old matcher cleanup
 func (s *PhysicalTaskQueueManagerTestSuite) TestLegacyDescribeTaskQueue() {
 	if s.newMatcher {
 		s.T().Skip("not supported by new matcher")
@@ -373,6 +375,7 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestAddTaskStandby() {
 	s.Equal(errShutdown, err) // task writer was stopped above
 }
 
+// TODO(pri): old matcher cleanup
 func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesFinalUpdateOnIdleUnload() {
 	if s.newMatcher {
 		s.T().Skip("not supported by new matcher")
@@ -389,6 +392,7 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesFinalUpdateOnIdleUnload()
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
+// TODO(pri): old matcher cleanup
 func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesNotDoFinalUpdateOnOwnershipLost() {
 	if s.newMatcher {
 		s.T().Skip("not supported by new matcher")
@@ -411,6 +415,7 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesNotDoFinalUpdateOnOwnersh
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
+// TODO(pri): old matcher cleanup
 func (s *PhysicalTaskQueueManagerTestSuite) TestTQMInterruptsPollOnClose() {
 	if s.newMatcher {
 		s.T().Skip("not supported by new matcher")

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -371,7 +371,6 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestAddTaskStandby() {
 	s.Equal(errShutdown, err) // task writer was stopped above
 }
 
-// TODO(pri): old matcher cleanup
 func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesFinalUpdateOnIdleUnload() {
 	if s.newMatcher {
 		s.T().Skip("not supported by new matcher")
@@ -388,12 +387,7 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesFinalUpdateOnIdleUnload()
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
-// TODO(pri): old matcher cleanup
 func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesNotDoFinalUpdateOnOwnershipLost() {
-	if s.newMatcher {
-		s.T().Skip("not supported by new matcher")
-	}
-
 	// TODO: use mocks instead of testTaskManager so we can do synchronization better instead of sleeps
 	s.config.UpdateAckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(1 * time.Second)
 	s.tqMgr.Start()
@@ -411,12 +405,7 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesNotDoFinalUpdateOnOwnersh
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
-// TODO(pri): old matcher cleanup
 func (s *PhysicalTaskQueueManagerTestSuite) TestTQMInterruptsPollOnClose() {
-	if s.newMatcher {
-		s.T().Skip("not supported by new matcher")
-	}
-
 	s.tqMgr.Start()
 
 	pollStart := time.Now()

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -174,7 +174,7 @@ func makePollMetadata(rps float64) *pollMetadata {
 	}}
 }
 
-// runOneShotPoller spawns a goroutine to call s.tqMgr.PollTask on the provided s.tqMgr.
+// runOneShotPoller spawns a goroutine to call tqMgr.PollTask on the provided tqMgr.
 // The second return value is a channel of either error or *internalTask.
 func runOneShotPoller(ctx context.Context, tqm physicalTaskQueueManager) (*goro.Handle, chan interface{}) {
 	out := make(chan interface{}, 1)

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -388,6 +388,10 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesFinalUpdateOnIdleUnload()
 }
 
 func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesNotDoFinalUpdateOnOwnershipLost() {
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher; flaky")
+	}
+
 	// TODO: use mocks instead of testTaskManager so we can do synchronization better instead of sleeps
 	s.config.UpdateAckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(1 * time.Second)
 	s.tqMgr.Start()

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -121,10 +121,6 @@ func (s *PhysicalTaskQueueManagerTestSuite) SetupTest() {
 	prtnMgr.defaultQueue = s.tqMgr
 }
 
-func (s *PhysicalTaskQueueManagerTestSuite) TearDownTest() {
-	s.controller.Finish()
-}
-
 /*
 TODO(pri): rewrite or delete this test
 func TestReaderSignaling(t *testing.T) {

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -34,7 +34,7 @@ import (
 
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/server/api/matchingservicemock/v1"
@@ -42,10 +42,12 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/internal/goro"
 	"go.uber.org/mock/gomock"
@@ -61,19 +63,66 @@ const (
 	defaultRootTqID    = "tq"
 )
 
-type tqmTestOpts struct {
-	config              *Config
-	dbq                 *PhysicalTaskQueueKey
-	matchingClientMock  *matchingservicemock.MockMatchingServiceClient
-	expectUserDataError bool
+type PhysicalTaskQueueManagerTestSuite struct {
+	suite.Suite
+
+	newMatcher           bool
+	config               *Config
+	controller           *gomock.Controller
+	physicalTaskQueueKey *PhysicalTaskQueueKey
+	matchingClientMock   *matchingservicemock.MockMatchingServiceClient
+	tqMgr                *physicalTaskQueueManagerImpl
 }
 
-func defaultTqmTestOpts(controller *gomock.Controller) *tqmTestOpts {
-	return &tqmTestOpts{
-		config:             defaultTestConfig(),
-		dbq:                defaultTqId(),
-		matchingClientMock: matchingservicemock.NewMockMatchingServiceClient(controller),
+// TODO(pri): cleanup; delete this
+func TestPhysicalTaskQueueManagerTestSuite(t *testing.T) {
+	suite.Run(t, &PhysicalTaskQueueManagerTestSuite{newMatcher: false})
+}
+
+func TestPhysicalTaskQueueManagerWithNewMatcherTestSuite(t *testing.T) {
+	suite.Run(t, &PhysicalTaskQueueManagerTestSuite{newMatcher: true})
+}
+
+func (s *PhysicalTaskQueueManagerTestSuite) SetupTest() {
+	s.config = defaultTestConfig()
+	if s.newMatcher {
+		s.config = withNewMatcher(s.config)
 	}
+	s.controller = gomock.NewController(s.T())
+	logger := testlogger.NewTestLogger(s.T(), testlogger.FailOnAnyUnexpectedError)
+
+	nsName := namespace.Name("ns-name")
+	ns, registry := createMockNamespaceCache(s.controller, nsName)
+
+	engine := createTestMatchingEngine(logger, s.controller, s.config, nil, registry)
+	engine.metricsHandler = metricstest.NewCaptureHandler()
+
+	s.physicalTaskQueueKey = defaultTqId()
+	prtn := s.physicalTaskQueueKey.Partition()
+	tqConfig := newTaskQueueConfig(prtn.TaskQueue(), engine.config, nsName)
+	onFatalErr := func(unloadCause) { s.T().Fatal("user data manager called onFatalErr") }
+	udMgr := newUserDataManager(engine.taskManager, engine.matchingRawClient, onFatalErr, nil, prtn, tqConfig, engine.logger, engine.namespaceRegistry)
+
+	prtnMgr := &taskQueuePartitionManagerImpl{
+		engine:          engine,
+		partition:       prtn,
+		config:          tqConfig,
+		ns:              ns,
+		logger:          engine.logger,
+		matchingClient:  engine.matchingRawClient,
+		metricsHandler:  metrics.NoopMetricsHandler,
+		userDataManager: udMgr,
+	}
+	engine.partitions[prtn.Key()] = prtnMgr
+
+	var err error
+	s.tqMgr, err = newPhysicalTaskQueueManager(prtnMgr, s.physicalTaskQueueKey)
+	s.NoError(err)
+	prtnMgr.defaultQueue = s.tqMgr
+}
+
+func (s *PhysicalTaskQueueManagerTestSuite) TearDownTest() {
+	s.controller.Finish()
 }
 
 /*
@@ -85,21 +134,21 @@ func TestReaderSignaling(t *testing.T) {
 			<-readerNotifications
 		}
 	}
-	tqm := mustCreateTestPhysicalTaskQueueManager(t, gomock.NewController(t))
+	tqMgr := mustCreateTestPhysicalTaskQueueManager(t, gomock.NewController(t))
 
 	// redirect taskReader signals into our local channel
-	tqm.backlogMgr.taskReader.notifyC = readerNotifications
+	s.tqMgr.backlogMgr.taskReader.notifyC = readerNotifications
 
-	tqm.Start()
-	defer tqm.Stop(unloadCauseUnspecified)
+	s.tqMgr.Start()
+	defer s.tqMgr.Stop(unloadCauseUnspecified)
 
 	// shut down the taskReader so it doesn't steal notifications from us
-	tqm.backlogMgr.taskReader.gorogrp.Cancel()
-	tqm.backlogMgr.taskReader.gorogrp.Wait()
+	s.tqMgr.backlogMgr.taskReader.gorogrp.Cancel()
+	s.tqMgr.backlogMgr.taskReader.gorogrp.Wait()
 
 	clearNotifications()
 
-	err := tqm.SpoolTask(&persistencespb.TaskInfo{
+	err := s.tqMgr.SpoolTask(&persistencespb.TaskInfo{
 		CreateTime: timestamp.TimePtr(time.Now().UTC()),
 	})
 	require.NoError(t, err)
@@ -107,13 +156,13 @@ func TestReaderSignaling(t *testing.T) {
 		"Spool task should signal taskReader")
 
 	clearNotifications()
-	poller, _ := runOneShotPoller(context.Background(), tqm)
+	poller, _ := runOneShotPoller(context.Background(), tqMgr)
 	defer poller.Cancel()
 
 	task := newInternalTaskForSyncMatch(&persistencespb.TaskInfo{
 		CreateTime: timestamp.TimePtr(time.Now().UTC()),
 	}, nil)
-	sync, err := tqm.TrySyncMatch(context.TODO(), task)
+	sync, err := s.tqMgr.TrySyncMatch(context.TODO(), task)
 	require.NoError(t, err)
 	require.True(t, sync)
 	require.Len(t, readerNotifications, 0,
@@ -129,7 +178,7 @@ func makePollMetadata(rps float64) *pollMetadata {
 	}}
 }
 
-// runOneShotPoller spawns a goroutine to call tqm.PollTask on the provided tqm.
+// runOneShotPoller spawns a goroutine to call s.tqMgr.PollTask on the provided s.tqMgr.
 // The second return value is a channel of either error or *internalTask.
 func runOneShotPoller(ctx context.Context, tqm physicalTaskQueueManager) (*goro.Handle, chan interface{}) {
 	out := make(chan interface{}, 1)
@@ -143,7 +192,7 @@ func runOneShotPoller(ctx context.Context, tqm physicalTaskQueueManager) (*goro.
 		out <- task
 		return nil
 	})
-	// tqm.PollTask() needs some time to attach the goro started above to the
+	// tqMgr.PollTask() needs some time to attach the goro started above to the
 	// internal task channel. Sorry for this but it appears unavoidable.
 	time.Sleep(10 * time.Millisecond)
 	return handle, out
@@ -153,96 +202,37 @@ func defaultTqId() *PhysicalTaskQueueKey {
 	return newTestUnversionedPhysicalQueueKey(defaultNamespaceId, defaultRootTqID, enumspb.TASK_QUEUE_TYPE_WORKFLOW, 0)
 }
 
-func mustCreateTestPhysicalTaskQueueManager(
-	t *testing.T,
-	controller *gomock.Controller,
-	opts ...taskQueueManagerOpt,
-) *physicalTaskQueueManagerImpl {
-	t.Helper()
-	return mustCreateTestTaskQueueManagerWithConfig(t, controller, defaultTqmTestOpts(controller), opts...)
-}
-
-func mustCreateTestTaskQueueManagerWithConfig(
-	t *testing.T,
-	controller *gomock.Controller,
-	testOpts *tqmTestOpts,
-	opts ...taskQueueManagerOpt,
-) *physicalTaskQueueManagerImpl {
-	t.Helper()
-	tqm, err := createTestTaskQueueManagerWithConfig(t, controller, testOpts, opts...)
-	require.NoError(t, err)
-	return tqm
-}
-
-func createTestTaskQueueManagerWithConfig(
-	t *testing.T,
-	controller *gomock.Controller,
-	testOpts *tqmTestOpts,
-	opts ...taskQueueManagerOpt,
-) (*physicalTaskQueueManagerImpl, error) {
-	nsName := namespace.Name("ns-name")
-	ns, registry := createMockNamespaceCache(controller, nsName)
-	me := createTestMatchingEngine(controller, testOpts.config, testOpts.matchingClientMock, registry)
-	me.metricsHandler = metricstest.NewCaptureHandler()
-	partition := testOpts.dbq.Partition()
-	tqConfig := newTaskQueueConfig(partition.TaskQueue(), me.config, nsName)
-	onFatalErr := func(unloadCause) { t.Fatal("user data manager called onFatalErr") }
-	userDataManager := newUserDataManager(me.taskManager, me.matchingRawClient, onFatalErr, nil, partition, tqConfig, me.logger, me.namespaceRegistry)
-	pm := createTestTaskQueuePartitionManager(ns, partition, tqConfig, me, userDataManager)
-	tlMgr, err := newPhysicalTaskQueueManager(pm, testOpts.dbq, opts...)
-	pm.defaultQueue = tlMgr
-	if err != nil {
-		return nil, err
+func (s *PhysicalTaskQueueManagerTestSuite) TestReaderBacklogAge() {
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher")
 	}
-	return tlMgr, nil
-}
-
-func createTestTaskQueuePartitionManager(ns *namespace.Namespace, partition tqid.Partition, tqConfig *taskQueueConfig, me *matchingEngineImpl, userDataManager userDataManager) *taskQueuePartitionManagerImpl {
-	pm := &taskQueuePartitionManagerImpl{
-		engine:          me,
-		partition:       partition,
-		config:          tqConfig,
-		ns:              ns,
-		logger:          me.logger,
-		matchingClient:  me.matchingRawClient,
-		metricsHandler:  me.metricsHandler,
-		userDataManager: userDataManager,
-	}
-
-	me.partitions[partition.Key()] = pm
-	return pm
-}
-
-func TestReaderBacklogAge(t *testing.T) {
-	controller := gomock.NewController(t)
 
 	// Create queue Manager and set queue state
-	tlm := mustCreateTestPhysicalTaskQueueManager(t, controller)
-	blm := tlm.backlogMgr.(*backlogManagerImpl)
-	require.NoError(t, blm.taskWriter.initReadWriteState())
-	require.Equal(t, int64(0), blm.taskAckManager.getAckLevel())
-	require.Equal(t, int64(0), blm.taskAckManager.getReadLevel())
+	blm := s.tqMgr.backlogMgr.(*backlogManagerImpl)
+	s.NoError(blm.taskWriter.initReadWriteState())
+	s.Equal(int64(0), blm.taskAckManager.getAckLevel())
+	s.Equal(int64(0), blm.taskAckManager.getReadLevel())
 
 	blm.taskReader.taskBuffer <- randomTaskInfoWithAgeTaskID(time.Minute, 1)
 	blm.taskReader.taskBuffer <- randomTaskInfoWithAgeTaskID(10*time.Second, 2)
 	go blm.taskReader.dispatchBufferedTasks()
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.InDelta(t, time.Minute, blm.taskReader.getBacklogHeadAge(), float64(time.Second))
+	s.EventuallyWithT(func(collect *assert.CollectT) {
+		assert.InDelta(s.T(), time.Minute, blm.taskReader.getBacklogHeadAge(), float64(time.Second))
 	}, time.Second, 10*time.Millisecond)
 
 	_, err := blm.pqMgr.PollTask(context.Background(), makePollMetadata(rpsInf))
-	require.NoError(t, err)
+	s.NoError(err)
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.InDelta(t, 10*time.Second, blm.taskReader.getBacklogHeadAge(), float64(500*time.Millisecond))
+	s.EventuallyWithT(func(collect *assert.CollectT) {
+		assert.InDelta(s.T(), 10*time.Second, blm.taskReader.getBacklogHeadAge(), float64(500*time.Millisecond))
 	}, time.Second, 10*time.Millisecond)
 
 	_, err = blm.pqMgr.PollTask(context.Background(), makePollMetadata(rpsInf))
-	require.NoError(t, err)
+	s.NoError(err)
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.Equalf(t, time.Duration(0), blm.taskReader.getBacklogHeadAge(), "backlog age being reset because of no tasks in the buffer")
+	s.EventuallyWithT(func(collect *assert.CollectT) {
+		assert.Equalf(s.T(), time.Duration(0), blm.taskReader.getBacklogHeadAge(), "backlog age being reset because of no tasks in the buffer")
 	}, time.Second, 10*time.Millisecond)
 }
 
@@ -263,21 +253,18 @@ func randomTaskInfoWithAgeTaskID(age time.Duration, TaskID int64) *persistencesp
 	}
 }
 
-func TestLegacyDescribeTaskQueue(t *testing.T) {
-	controller := gomock.NewController(t)
-	defer controller.Finish()
+func (s *PhysicalTaskQueueManagerTestSuite) TestLegacyDescribeTaskQueue() {
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher")
+	}
+
+	blm := s.tqMgr.backlogMgr.(*backlogManagerImpl)
+	s.NoError(blm.taskWriter.initReadWriteState())
+	s.Equal(int64(0), blm.taskAckManager.getAckLevel())
+	s.Equal(int64(0), blm.taskAckManager.getReadLevel())
 
 	startTaskID := int64(1)
 	taskCount := int64(3)
-	PollerIdentity := "test-poll"
-
-	// Create queue Manager and set queue state
-	tlm := mustCreateTestPhysicalTaskQueueManager(t, controller)
-	blm := tlm.backlogMgr.(*backlogManagerImpl)
-	require.NoError(t, blm.taskWriter.initReadWriteState())
-	require.Equal(t, int64(0), blm.taskAckManager.getAckLevel())
-	require.Equal(t, int64(0), blm.taskAckManager.getReadLevel())
-
 	for i := int64(0); i < taskCount; i++ {
 		blm.taskAckManager.addTask(startTaskID + i)
 	}
@@ -287,284 +274,245 @@ func TestLegacyDescribeTaskQueue(t *testing.T) {
 	blm.db.updateApproximateBacklogCount(taskCount)
 
 	includeTaskStatus := false
-	descResp := tlm.LegacyDescribeTaskQueue(includeTaskStatus)
-	require.Equal(t, 0, len(descResp.DescResponse.GetPollers()))
-	require.Nil(t, descResp.DescResponse.GetTaskQueueStatus())
+	descResp := s.tqMgr.LegacyDescribeTaskQueue(includeTaskStatus)
+	s.Equal(0, len(descResp.DescResponse.GetPollers()))
+	s.Nil(descResp.DescResponse.GetTaskQueueStatus())
 
 	includeTaskStatus = true
-	taskQueueStatus := tlm.LegacyDescribeTaskQueue(includeTaskStatus).DescResponse.GetTaskQueueStatus()
-	require.NotNil(t, taskQueueStatus)
-	require.Zero(t, taskQueueStatus.GetAckLevel())
-	require.Equal(t, taskCount, taskQueueStatus.GetReadLevel())
-	require.Equal(t, taskCount, taskQueueStatus.GetBacklogCountHint())
-	taskIDBlock := taskQueueStatus.GetTaskIdBlock()
-	require.Equal(t, int64(1), taskIDBlock.GetStartId())
-	require.Equal(t, tlm.config.RangeSize, taskIDBlock.GetEndId())
+	taskQueueStatus := s.tqMgr.LegacyDescribeTaskQueue(includeTaskStatus).DescResponse.GetTaskQueueStatus()
+	s.NotNil(taskQueueStatus)
+	s.Zero(taskQueueStatus.GetAckLevel())
+	s.Equal(taskCount, taskQueueStatus.GetReadLevel())
+	s.Equal(taskCount, taskQueueStatus.GetBacklogCountHint())
+	idBlock := taskQueueStatus.GetTaskIdBlock()
+	s.Equal(int64(1), idBlock.GetStartId())
+	s.Equal(s.tqMgr.config.RangeSize, idBlock.GetEndId())
 
 	// Add a poller and complete all tasks
-	tlm.pollerHistory.updatePollerInfo(pollerIdentity(PollerIdentity), &pollMetadata{})
+	pollerIdent := pollerIdentity("test-poll")
+	s.tqMgr.pollerHistory.updatePollerInfo(pollerIdent, &pollMetadata{})
 	for i := int64(0); i < taskCount; i++ {
 		_, numAcked := blm.taskAckManager.completeTask(startTaskID + i)
 		blm.db.updateApproximateBacklogCount(-numAcked)
 	}
 
-	descResp = tlm.LegacyDescribeTaskQueue(includeTaskStatus)
-	require.Equal(t, 1, len(descResp.DescResponse.GetPollers()))
-	require.Equal(t, PollerIdentity, descResp.DescResponse.Pollers[0].GetIdentity())
-	require.NotEmpty(t, descResp.DescResponse.Pollers[0].GetLastAccessTime())
+	descResp = s.tqMgr.LegacyDescribeTaskQueue(includeTaskStatus)
+	s.Equal(1, len(descResp.DescResponse.GetPollers()))
+	s.Equal(string(pollerIdent), descResp.DescResponse.Pollers[0].GetIdentity())
+	s.NotEmpty(descResp.DescResponse.Pollers[0].GetLastAccessTime())
 
 	rps := 5.0
-	tlm.pollerHistory.updatePollerInfo(pollerIdentity(PollerIdentity), makePollMetadata(rps))
-	descResp = tlm.LegacyDescribeTaskQueue(includeTaskStatus)
-	require.Equal(t, 1, len(descResp.DescResponse.GetPollers()))
-	require.Equal(t, PollerIdentity, descResp.DescResponse.Pollers[0].GetIdentity())
-	require.True(t, descResp.DescResponse.Pollers[0].GetRatePerSecond() > 4.0 && descResp.DescResponse.Pollers[0].GetRatePerSecond() < 6.0)
+	s.tqMgr.pollerHistory.updatePollerInfo(pollerIdent, makePollMetadata(rps))
+	descResp = s.tqMgr.LegacyDescribeTaskQueue(includeTaskStatus)
+	s.Equal(1, len(descResp.DescResponse.GetPollers()))
+	s.Equal(string(pollerIdent), descResp.DescResponse.Pollers[0].GetIdentity())
+	s.True(descResp.DescResponse.Pollers[0].GetRatePerSecond() > 4.0 && descResp.DescResponse.Pollers[0].GetRatePerSecond() < 6.0)
 
 	taskQueueStatus = descResp.DescResponse.GetTaskQueueStatus()
-	require.NotNil(t, taskQueueStatus)
-	require.Equal(t, taskCount, taskQueueStatus.GetAckLevel())
-	require.Zero(t, taskQueueStatus.GetBacklogCountHint())
+	s.NotNil(taskQueueStatus)
+	s.Equal(taskCount, taskQueueStatus.GetAckLevel())
+	s.Zero(taskQueueStatus.GetBacklogCountHint())
 }
 
-func TestCheckIdleTaskQueue(t *testing.T) {
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
-	cfg := NewConfig(dynamicconfig.NewNoopCollection())
-	cfg.MaxTaskQueueIdleTime = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(2 * time.Second)
-	tqCfg := defaultTqmTestOpts(controller)
-	tqCfg.config = cfg
-
+func (s *PhysicalTaskQueueManagerTestSuite) TestCheckIdleTaskQueue() {
 	// Idle
-	tlm := mustCreateTestTaskQueueManagerWithConfig(t, controller, tqCfg)
-	tlm.Start()
+	s.tqMgr.Start()
 	time.Sleep(50 * time.Millisecond) // nolint:forbidigo
-	require.Equal(t, common.DaemonStatusStarted, atomic.LoadInt32(&tlm.status))
+	s.Equal(common.DaemonStatusStarted, atomic.LoadInt32(&s.tqMgr.status))
+	s.tqMgr.Stop(unloadCauseShuttingDown)
+	s.Equal(common.DaemonStatusStopped, atomic.LoadInt32(&s.tqMgr.status))
+
+	s.SetupTest()
 
 	// Active poll-er
-	tlm = mustCreateTestTaskQueueManagerWithConfig(t, controller, tqCfg)
-	tlm.Start()
-	tlm.pollerHistory.updatePollerInfo("test-poll", &pollMetadata{})
-	require.Equal(t, 1, len(tlm.GetAllPollerInfo()))
+	s.tqMgr.Start()
+	s.tqMgr.pollerHistory.updatePollerInfo("test-poll", &pollMetadata{})
+	s.Equal(1, len(s.tqMgr.GetAllPollerInfo()))
 	time.Sleep(50 * time.Millisecond) // nolint:forbidigo
-	require.Equal(t, common.DaemonStatusStarted, atomic.LoadInt32(&tlm.status))
-	tlm.Stop(unloadCauseUnspecified)
-	require.Equal(t, common.DaemonStatusStopped, atomic.LoadInt32(&tlm.status))
+	s.Equal(common.DaemonStatusStarted, atomic.LoadInt32(&s.tqMgr.status))
+	s.tqMgr.Stop(unloadCauseUnspecified)
+	s.Equal(common.DaemonStatusStopped, atomic.LoadInt32(&s.tqMgr.status))
+
+	s.SetupTest()
 
 	// Active adding task
-	tlm = mustCreateTestTaskQueueManagerWithConfig(t, controller, tqCfg)
-	tlm.Start()
-	require.Equal(t, 0, len(tlm.GetAllPollerInfo()))
+	s.tqMgr.Start()
+	s.Equal(0, len(s.tqMgr.GetAllPollerInfo()))
 	time.Sleep(50 * time.Millisecond) // nolint:forbidigo
-	require.Equal(t, common.DaemonStatusStarted, atomic.LoadInt32(&tlm.status))
-	tlm.Stop(unloadCauseUnspecified)
-	require.Equal(t, common.DaemonStatusStopped, atomic.LoadInt32(&tlm.status))
+	s.Equal(common.DaemonStatusStarted, atomic.LoadInt32(&s.tqMgr.status))
+	s.tqMgr.Stop(unloadCauseUnspecified)
+	s.Equal(common.DaemonStatusStopped, atomic.LoadInt32(&s.tqMgr.status))
 }
 
-func TestAddTaskStandby(t *testing.T) {
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
-	tlm := mustCreateTestTaskQueueManagerWithConfig(
-		t,
-		controller,
-		defaultTqmTestOpts(controller),
-		func(tqm *physicalTaskQueueManagerImpl) {
-			ns := namespace.NewGlobalNamespaceForTest(
-				&persistencespb.NamespaceInfo{},
-				&persistencespb.NamespaceConfig{},
-				&persistencespb.NamespaceReplicationConfig{
-					ActiveClusterName: cluster.TestAlternativeClusterName,
-				},
-				cluster.TestAlternativeClusterInitialFailoverVersion,
-			)
-
-			// we need to override the mockNamespaceCache to return a passive namespace
-			mockNamespaceCache := namespace.NewMockRegistry(controller)
-			mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(ns, nil).AnyTimes()
-			mockNamespaceCache.EXPECT().GetNamespaceName(gomock.Any()).Return(ns.Name(), nil).AnyTimes()
-			tqm.namespaceRegistry = mockNamespaceCache
+func (s *PhysicalTaskQueueManagerTestSuite) TestAddTaskStandby() {
+	ns := namespace.NewGlobalNamespaceForTest(
+		&persistencespb.NamespaceInfo{},
+		&persistencespb.NamespaceConfig{},
+		&persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
 		},
+		cluster.TestAlternativeClusterInitialFailoverVersion,
 	)
-	tlm.Start()
+
+	// we need to override the mockNamespaceCache to return a passive namespace
+	mockNamespaceCache := namespace.NewMockRegistry(s.controller)
+	mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(ns, nil).AnyTimes()
+	mockNamespaceCache.EXPECT().GetNamespaceName(gomock.Any()).Return(ns.Name(), nil).AnyTimes()
+	s.tqMgr.namespaceRegistry = mockNamespaceCache
+
+	s.tqMgr.Start()
+	defer s.tqMgr.Stop(unloadCauseShuttingDown)
+
 	// stop taskWriter so that we can check if there's any call to it
 	// otherwise the task persist process is async and hard to test
-	tlm.tqCtxCancel()
+	s.tqMgr.tqCtxCancel()
 
-	err := tlm.SpoolTask(&persistencespb.TaskInfo{
+	err := s.tqMgr.SpoolTask(&persistencespb.TaskInfo{
 		CreateTime: timestamp.TimePtr(time.Now().UTC()),
 	})
-	require.Equal(t, errShutdown, err) // task writer was stopped above
+	s.Equal(errShutdown, err) // task writer was stopped above
 }
 
-func TestTQMDoesFinalUpdateOnIdleUnload(t *testing.T) {
-	t.Parallel()
+func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesFinalUpdateOnIdleUnload() {
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher")
+	}
 
-	controller := gomock.NewController(t)
+	s.config.MaxTaskQueueIdleTime = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(1 * time.Second)
+	s.tqMgr.Start()
+	defer s.tqMgr.Stop(unloadCauseShuttingDown)
 
-	cfg := NewConfig(dynamicconfig.NewNoopCollection())
-	cfg.MaxTaskQueueIdleTime = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(1 * time.Second)
-	tqCfg := defaultTqmTestOpts(controller)
-	tqCfg.config = cfg
-
-	tqm := mustCreateTestTaskQueueManagerWithConfig(t, controller, tqCfg)
-	tm, ok := tqm.partitionMgr.engine.taskManager.(*testTaskManager)
-	require.True(t, ok)
-
-	tqm.Start()
-	time.Sleep(2 * time.Second) // will unload due to idleness
-	require.Equal(t, 1, tm.getUpdateCount(tqCfg.dbq))
+	tm, _ := s.tqMgr.partitionMgr.engine.taskManager.(*testTaskManager)
+	s.EventuallyWithT(func(collect *assert.CollectT) {
+		// will unload due to idleness
+		assert.Equal(collect, 1, tm.getUpdateCount(s.physicalTaskQueueKey))
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
-func TestTQMDoesNotDoFinalUpdateOnOwnershipLost(t *testing.T) {
+func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesNotDoFinalUpdateOnOwnershipLost() {
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher")
+	}
+
 	// TODO: use mocks instead of testTaskManager so we can do synchronization better instead of sleeps
-	t.Parallel()
-
-	controller := gomock.NewController(t)
-
-	cfg := NewConfig(dynamicconfig.NewNoopCollection())
-	cfg.UpdateAckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(2 * time.Second)
-	tqCfg := defaultTqmTestOpts(controller)
-	tqCfg.config = cfg
-
-	tqm := mustCreateTestTaskQueueManagerWithConfig(t, controller, tqCfg)
-	tm, ok := tqm.partitionMgr.engine.taskManager.(*testTaskManager)
-	require.True(t, ok)
-
-	tqm.Start()
-	time.Sleep(1 * time.Second)
+	s.config.UpdateAckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(1 * time.Second)
+	s.tqMgr.Start()
+	defer s.tqMgr.Stop(unloadCauseShuttingDown)
 
 	// simulate ownership lost
-	ttm := tm.getQueueManagerByKey(tqCfg.dbq)
-	ttm.Lock()
-	ttm.rangeID++
-	ttm.Unlock()
+	tm, _ := s.tqMgr.partitionMgr.engine.taskManager.(*testTaskManager)
+	ptm := tm.getQueueManagerByKey(s.physicalTaskQueueKey)
+	ptm.Lock()
+	ptm.rangeID++
+	ptm.Unlock()
 
-	time.Sleep(2 * time.Second) // will attempt to update and fail and not try again
-
-	require.Equal(t, 1, tm.getUpdateCount(tqCfg.dbq))
+	s.EventuallyWithT(func(collect *assert.CollectT) {
+		assert.Equal(collect, 1, tm.getUpdateCount(s.physicalTaskQueueKey))
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
-func TestTQMInterruptsPollOnClose(t *testing.T) {
-	t.Parallel()
+func (s *PhysicalTaskQueueManagerTestSuite) TestTQMInterruptsPollOnClose() {
+	if s.newMatcher {
+		s.T().Skip("not supported by new matcher")
+	}
 
-	controller := gomock.NewController(t)
-	tqm := mustCreateTestPhysicalTaskQueueManager(t, controller)
-	tqm.Start()
+	s.tqMgr.Start()
 
 	pollStart := time.Now()
 	pollCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_, pollCh := runOneShotPoller(pollCtx, tqm)
+	_, pollCh := runOneShotPoller(pollCtx, s.tqMgr)
 
-	tqm.Stop(unloadCauseUnspecified) // should interrupt poller
+	s.tqMgr.Stop(unloadCauseUnspecified) // should interrupt poller
 
 	<-pollCh
-	require.Less(t, time.Since(pollStart), 4*time.Second)
+	s.Less(time.Since(pollStart), 4*time.Second)
 }
 
-func TestPollScalingUpOnBacklog(t *testing.T) {
-	controller := gomock.NewController(t)
-	tqm := mustCreateTestPhysicalTaskQueueManager(t, controller)
-
-	rl := quotas.NewMockRateLimiter(controller)
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingUpOnBacklog() {
+	rl := quotas.NewMockRateLimiter(s.controller)
 	rl.EXPECT().AllowN(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-	tqm.pollerScalingRateLimiter = rl
+	s.tqMgr.pollerScalingRateLimiter = rl
 
 	fakeStats := &taskqueuepb.TaskQueueStats{
 		ApproximateBacklogCount: 100,
 		ApproximateBacklogAge:   durationpb.New(1 * time.Minute),
 	}
 
-	decision := tqm.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
-	require.NotNil(t, decision)
-	require.GreaterOrEqual(t, decision.PollRequestDeltaSuggestion, int32(1))
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.NotNil(decision)
+	s.GreaterOrEqual(decision.PollRequestDeltaSuggestion, int32(1))
 }
 
-func TestPollScalingUpAddRateExceedsDispatchRate(t *testing.T) {
-	controller := gomock.NewController(t)
-	tqm := mustCreateTestPhysicalTaskQueueManager(t, controller)
-
-	rl := quotas.NewMockRateLimiter(controller)
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingUpAddRateExceedsDispatchRate() {
+	rl := quotas.NewMockRateLimiter(s.controller)
 	rl.EXPECT().AllowN(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-	tqm.pollerScalingRateLimiter = rl
+	s.tqMgr.pollerScalingRateLimiter = rl
 
 	fakeStats := &taskqueuepb.TaskQueueStats{
 		TasksAddRate:      100,
 		TasksDispatchRate: 10,
 	}
 
-	decision := tqm.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
-	require.NotNil(t, decision)
-	require.GreaterOrEqual(t, decision.PollRequestDeltaSuggestion, int32(1))
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.NotNil(decision)
+	s.GreaterOrEqual(decision.PollRequestDeltaSuggestion, int32(1))
 }
 
-func TestPollScalingNoChangeOnNoBacklogFastMatch(t *testing.T) {
-	controller := gomock.NewController(t)
-	tqm := mustCreateTestPhysicalTaskQueueManager(t, controller)
-
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingNoChangeOnNoBacklogFastMatch() {
 	fakeStats := &taskqueuepb.TaskQueueStats{
 		ApproximateBacklogCount: 0,
 		ApproximateBacklogAge:   durationpb.New(0),
 	}
-	decision := tqm.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
-	require.Nil(t, decision)
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.Nil(decision)
 }
 
-func TestPollScalingNonRootPartition(t *testing.T) {
-	controller := gomock.NewController(t)
-	tqm := mustCreateTestPhysicalTaskQueueManager(t, controller)
-
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingNonRootPartition() {
 	// Non-root partitions only get to emit decisions on high backlog
 	f, err := tqid.NewTaskQueueFamily(namespaceId, taskQueueName)
-	require.NoError(t, err)
+	s.NoError(err)
 	partition := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).NormalPartition(1)
-	tqm.partitionMgr.partition = partition
+	s.tqMgr.partitionMgr.partition = partition
 	// Also disable rate limit to ensure that's not why nil is returned here
-	rl := quotas.NewMockRateLimiter(controller)
+	rl := quotas.NewMockRateLimiter(s.controller)
 	rl.EXPECT().AllowN(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-	tqm.pollerScalingRateLimiter = rl
+	s.tqMgr.pollerScalingRateLimiter = rl
 
 	fakeStats := &taskqueuepb.TaskQueueStats{
 		ApproximateBacklogCount: 100,
 		ApproximateBacklogAge:   durationpb.New(1 * time.Minute),
 	}
-	decision := tqm.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
-	require.NotNil(t, decision)
-	require.GreaterOrEqual(t, decision.PollRequestDeltaSuggestion, int32(1))
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.NotNil(decision)
+	s.GreaterOrEqual(decision.PollRequestDeltaSuggestion, int32(1))
 
 	fakeStats.ApproximateBacklogCount = 0
-	decision = tqm.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
-	require.Nil(t, decision)
+	decision = s.tqMgr.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.Nil(decision)
 }
 
-func TestPollScalingDownOnLongSyncMatch(t *testing.T) {
-	controller := gomock.NewController(t)
-	tqm := mustCreateTestPhysicalTaskQueueManager(t, controller)
-
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingDownOnLongSyncMatch() {
 	fakeStats := &taskqueuepb.TaskQueueStats{
 		ApproximateBacklogCount: 0,
 	}
-	decision := tqm.makePollerScalingDecisionImpl(time.Now().Add(-2*time.Second), func() *taskqueuepb.TaskQueueStats { return fakeStats })
-	require.LessOrEqual(t, decision.PollRequestDeltaSuggestion, int32(-1))
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now().Add(-2*time.Second), func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.LessOrEqual(decision.PollRequestDeltaSuggestion, int32(-1))
 }
 
-func TestPollScalingDecisionsAreRateLimited(t *testing.T) {
-	controller := gomock.NewController(t)
-	tqm := mustCreateTestPhysicalTaskQueueManager(t, controller)
-
-	rl := quotas.NewMockRateLimiter(controller)
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingDecisionsAreRateLimited() {
+	rl := quotas.NewMockRateLimiter(s.controller)
 	rl.EXPECT().AllowN(gomock.Any(), gomock.Any()).Return(true).Times(1)
 	rl.EXPECT().AllowN(gomock.Any(), gomock.Any()).Return(false).Times(1)
-	tqm.pollerScalingRateLimiter = rl
+	s.tqMgr.pollerScalingRateLimiter = rl
 
 	fakeStats := &taskqueuepb.TaskQueueStats{
 		ApproximateBacklogCount: 100,
 		ApproximateBacklogAge:   durationpb.New(1 * time.Minute),
 	}
-	decision := tqm.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
-	require.GreaterOrEqual(t, decision.PollRequestDeltaSuggestion, int32(1))
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.GreaterOrEqual(decision.PollRequestDeltaSuggestion, int32(1))
 
-	decision = tqm.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
-	require.Nil(t, decision)
+	decision = s.tqMgr.makePollerScalingDecisionImpl(time.Now(), func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.Nil(decision)
 }

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -86,7 +86,7 @@ func TestPhysicalTaskQueueManagerWithNewMatcherTestSuite(t *testing.T) {
 func (s *PhysicalTaskQueueManagerTestSuite) SetupTest() {
 	s.config = defaultTestConfig()
 	if s.newMatcher {
-		s.config = withNewMatcher(s.config)
+		useNewMatcher(s.config)
 	}
 	s.controller = gomock.NewController(s.T())
 	logger := testlogger.NewTestLogger(s.T(), testlogger.FailOnAnyUnexpectedError)

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -387,3 +387,7 @@ func (c *priBacklogManagerImpl) respoolTaskAfterError(task *persistencespb.TaskI
 func (c *priBacklogManagerImpl) queueKey() *PhysicalTaskQueueKey {
 	return c.pqMgr.QueueKey()
 }
+
+func (c *priBacklogManagerImpl) getDB() *taskQueueDB {
+	return c.db
+}

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -516,10 +516,10 @@ func (tr *priTaskReader) doGC(ackLevel int64) {
 	ctx, cancel := context.WithTimeout(tr.backlogMgr.tqCtx, ioTimeout)
 	defer cancel()
 
+	n, err := tr.backlogMgr.db.CompleteTasksLessThan(ctx, ackLevel+1, batchSize, tr.subqueue)
+
 	tr.lock.Lock()
 	defer tr.lock.Unlock()
-
-	n, err := tr.backlogMgr.db.CompleteTasksLessThan(ctx, tr.ackLevel+1, batchSize, tr.subqueue)
 
 	tr.inGC = false
 	if err != nil {
@@ -531,6 +531,6 @@ func (tr *priTaskReader) doGC(ackLevel int64) {
 	// if we get UnknownNumRowsAffected or a smaller number than our limit, we know we got
 	// everything <= ackLevel, so we can reset ours. if not, we may have to try again.
 	if n == persistence.UnknownNumRowsAffected || n < batchSize {
-		tr.gcAckLevel = tr.ackLevel
+		tr.gcAckLevel = ackLevel
 	}
 }

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -495,7 +495,7 @@ func (tr *priTaskReader) maybeGCLocked() {
 	tr.inGC = true
 	tr.lastGCTime = time.Now()
 	// gc in new goroutine so poller doesn't have to wait
-	go tr.doGC()
+	go tr.doGC(tr.ackLevel)
 }
 
 func (tr *priTaskReader) shouldGCLocked() bool {
@@ -510,7 +510,7 @@ func (tr *priTaskReader) shouldGCLocked() bool {
 }
 
 // called in new goroutine
-func (tr *priTaskReader) doGC() {
+func (tr *priTaskReader) doGC(ackLevel int64) {
 	batchSize := tr.backlogMgr.config.MaxTaskDeleteBatchSize()
 
 	ctx, cancel := context.WithTimeout(tr.backlogMgr.tqCtx, ioTimeout)

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -89,7 +89,7 @@ func (s *PartitionManagerTestSuite) SetupTest() {
 	ns, registry := createMockNamespaceCache(s.controller, namespace.Name(namespaceName))
 	config := NewConfig(dynamicconfig.NewNoopCollection())
 	if s.newMatcher {
-		config = withNewMatcher(config)
+		useNewMatcher(config)
 	}
 
 	matchingClientMock := matchingservicemock.NewMockMatchingServiceClient(s.controller)

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -112,10 +112,6 @@ func (s *PartitionManagerTestSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *PartitionManagerTestSuite) TearDownTest() {
-	s.controller.Finish()
-}
-
 func (s *PartitionManagerTestSuite) TestAddTask_Forwarded() {
 	_, _, err := s.partitionMgr.AddTask(context.Background(), addTaskParams{
 		taskInfo: &persistencespb.TaskInfo{

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -44,8 +44,10 @@ import (
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	hlc "go.temporal.io/server/common/clock/hybrid_logical_clock"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/worker_versioning"
 	"go.uber.org/mock/gomock"
@@ -61,37 +63,57 @@ const (
 type PartitionManagerTestSuite struct {
 	suite.Suite
 	protorequire.ProtoAssertions
+
+	newMatcher   bool
 	controller   *gomock.Controller
 	userDataMgr  *mockUserDataManager
 	partitionMgr *taskQueuePartitionManagerImpl
 }
 
-func TestPartitionManagerSuite(t *testing.T) {
-	suite.Run(t, new(PartitionManagerTestSuite))
+// TODO(pri): cleanup; delete this
+func TestTaskQueuePartitionManagerSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &PartitionManagerTestSuite{newMatcher: false})
+}
+
+func TestTaskQueuePartitionManagerWithNewMatcherSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &PartitionManagerTestSuite{newMatcher: true})
 }
 
 func (s *PartitionManagerTestSuite) SetupTest() {
 	s.ProtoAssertions = protorequire.New(s.T())
 	s.controller = gomock.NewController(s.T())
+	logger := testlogger.NewTestLogger(s.T(), testlogger.FailOnAnyUnexpectedError)
+
 	ns, registry := createMockNamespaceCache(s.controller, namespace.Name(namespaceName))
 	config := NewConfig(dynamicconfig.NewNoopCollection())
+	if s.newMatcher {
+		config = withNewMatcher(config)
+	}
+
 	matchingClientMock := matchingservicemock.NewMockMatchingServiceClient(s.controller)
-	me := createTestMatchingEngine(s.controller, config, matchingClientMock, registry)
+	engine := createTestMatchingEngine(logger, s.controller, config, matchingClientMock, registry)
+
 	f, err := tqid.NewTaskQueueFamily(namespaceId, taskQueueName)
-	s.Assert().NoError(err)
+	s.NoError(err)
 	partition := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).RootPartition()
-	tqConfig := newTaskQueueConfig(partition.TaskQueue(), me.config, ns.Name())
+	tqConfig := newTaskQueueConfig(partition.TaskQueue(), engine.config, ns.Name())
 	s.userDataMgr = &mockUserDataManager{}
-	logger, _, metricsHandler := me.loggerAndMetricsForPartition(namespace.Name(namespaceName), partition, tqConfig)
-	pm, err := newTaskQueuePartitionManager(me, ns, partition, tqConfig, logger, logger, metricsHandler, s.userDataMgr)
-	s.Assert().NoError(err)
+
+	pm, err := newTaskQueuePartitionManager(engine, ns, partition, tqConfig, logger, logger, metrics.NoopMetricsHandler, s.userDataMgr)
+	s.NoError(err)
 	s.partitionMgr = pm
-	me.Start()
+	engine.Start()
 	pm.Start()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 	err = pm.WaitUntilInitialized(ctx)
-	s.Assert().NoError(err)
+	s.NoError(err)
+}
+
+func (s *PartitionManagerTestSuite) TearDownTest() {
+	s.controller.Finish()
 }
 
 func (s *PartitionManagerTestSuite) TestAddTask_Forwarded() {
@@ -103,7 +125,7 @@ func (s *PartitionManagerTestSuite) TestAddTask_Forwarded() {
 		},
 		forwardInfo: &taskqueuespb.TaskForwardInfo{SourcePartition: "another-partition"},
 	})
-	s.Assert().Equal(errRemoteSyncMatchFailed, err)
+	s.Equal(errRemoteSyncMatchFailed, err)
 }
 
 func (s *PartitionManagerTestSuite) TestAddTaskNoRules_NoVersionDirective() {
@@ -178,8 +200,9 @@ func (s *PartitionManagerTestSuite) TestDescribeTaskQueuePartition_MultipleBuild
 				StartId: 2,
 				EndId:   100000,
 			},
-			LoadedTasks:  1,
-			MaxReadLevel: 1,
+			LoadedTasks:             1,
+			MaxReadLevel:            1,
+			ApproximateBacklogCount: 1,
 		},
 	}
 
@@ -203,8 +226,8 @@ func (s *PartitionManagerTestSuite) TestDescribeTaskQueuePartition_UnloadedVersi
 
 	// task is backlogged in the source queue so it is loaded by now
 	sourceQ, err := s.partitionMgr.getVersionedQueue(ctx, "", bld, nil, false)
-	s.Assert().NoError(err)
-	s.Assert().NotNil(sourceQ)
+	s.NoError(err)
+	s.NotNil(sourceQ)
 
 	// unload sourceQ
 	s.partitionMgr.unloadPhysicalQueue(sourceQ, unloadCauseUnspecified)
@@ -249,7 +272,7 @@ func (s *PartitionManagerTestSuite) TestPollWithRedirectRules() {
 			UseVersioning: true,
 		},
 	})
-	s.Assert().Equal(serviceerror.NewNewerBuildExists(target), err)
+	s.Equal(serviceerror.NewNewerBuildExists(target), err)
 }
 
 func (s *PartitionManagerTestSuite) TestRedirectRuleLoadUpstream() {
@@ -272,8 +295,8 @@ func (s *PartitionManagerTestSuite) TestRedirectRuleLoadUpstream() {
 
 	// task is backlogged in the source queue so it is loaded by now
 	sourceQ, err := s.partitionMgr.getVersionedQueue(ctx, "", source, nil, false)
-	s.Assert().NoError(err)
-	s.Assert().NotNil(sourceQ)
+	s.NoError(err)
+	s.NotNil(sourceQ)
 
 	// unload sourceQ
 	s.partitionMgr.unloadPhysicalQueue(sourceQ, unloadCauseUnspecified)
@@ -283,8 +306,8 @@ func (s *PartitionManagerTestSuite) TestRedirectRuleLoadUpstream() {
 
 	// polling from target should've loaded the source as well
 	sourceQ, err = s.partitionMgr.getVersionedQueue(ctx, "", source, nil, false)
-	s.Assert().NoError(err)
-	s.Assert().NotNil(sourceQ)
+	s.NoError(err)
+	s.NotNil(sourceQ)
 }
 
 func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRules_NoVersionDirective() {
@@ -326,7 +349,7 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRulesAndVersionSets
 
 	s.validateAddTask("", false, versioningData, nil)
 	// make sure version set queue is not loaded
-	s.Assert().Nil(s.partitionMgr.versionedQueues[PhysicalTaskQueueVersion{versionSet: vs.SetIds[0]}])
+	s.Nil(s.partitionMgr.versionedQueues[PhysicalTaskQueueVersion{versionSet: vs.SetIds[0]}])
 	s.validatePollTask("", false)
 }
 
@@ -341,13 +364,13 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRulesAndVersionSets
 	taskBld := "task-bld"
 	s.validateAddTask("", false, versioningData, worker_versioning.MakeBuildIdDirective(taskBld))
 	// make sure version set queue is not loaded
-	s.Assert().Nil(s.partitionMgr.versionedQueues[PhysicalTaskQueueVersion{versionSet: vs.SetIds[0]}])
+	s.Nil(s.partitionMgr.versionedQueues[PhysicalTaskQueueVersion{versionSet: vs.SetIds[0]}])
 	s.validatePollTask(taskBld, true)
 
 	// now use the version set build ID
 	s.validateAddTask("", false, versioningData, worker_versioning.MakeBuildIdDirective(vs.BuildIds[0].Id))
 	// make sure version set queue is loaded
-	s.Assert().NotNil(s.partitionMgr.versionedQueues[PhysicalTaskQueueVersion{versionSet: vs.SetIds[0]}])
+	s.NotNil(s.partitionMgr.versionedQueues[PhysicalTaskQueueVersion{versionSet: vs.SetIds[0]}])
 	s.validatePollTask(vs.BuildIds[0].Id, true)
 }
 
@@ -360,91 +383,93 @@ func (s *PartitionManagerTestSuite) TestAddTaskWithAssignmentRulesAndVersionSets
 	}
 	s.validateAddTask(ruleBld, false, versioningData, worker_versioning.MakeUseAssignmentRulesDirective())
 	// make sure version set queue is not loaded
-	s.Assert().Nil(s.partitionMgr.versionedQueues[PhysicalTaskQueueVersion{versionSet: vs.SetIds[0]}])
+	s.Nil(s.partitionMgr.versionedQueues[PhysicalTaskQueueVersion{versionSet: vs.SetIds[0]}])
 	s.validatePollTask(ruleBld, true)
 }
 
 func (s *PartitionManagerTestSuite) TestGetAllPollerInfo() {
 	// no pollers
 	pollers := s.partitionMgr.GetAllPollerInfo()
-	s.Assert().True(len(pollers) == 0)
+	s.True(len(pollers) == 0)
 
 	// one unversioned poller
 	s.pollWithIdentity("uv", "", false, false)
 	pollers = s.partitionMgr.GetAllPollerInfo()
-	s.Assert().True(len(pollers) == 1)
+	s.True(len(pollers) == 1)
 
 	// one versioned poller
 	s.pollWithIdentity("v", "bid", true, false)
 	pollers = s.partitionMgr.GetAllPollerInfo()
-	s.Assert().True(len(pollers) == 2)
+	s.True(len(pollers) == 2)
 
 	// one unversioned poller with deployment options
 	s.pollWithIdentity("uvdo", "bid", false, true)
 	pollers = s.partitionMgr.GetAllPollerInfo()
-	s.Assert().True(len(pollers) == 3)
+	s.True(len(pollers) == 3)
 
 	for _, p := range pollers {
+		//nolint:staticcheck // SA1019 deprecated GetWorkerVersionCapabilities
+		workerVersionCapabilities := p.GetWorkerVersionCapabilities()
 		switch p.GetIdentity() {
 		case "uv":
-			s.Assert().False(p.GetWorkerVersionCapabilities().GetUseVersioning())
+			s.False(workerVersionCapabilities.GetUseVersioning())
 		case "v":
-			s.Assert().True(p.GetWorkerVersionCapabilities().GetUseVersioning())
-			s.Assert().Equal("bid", p.GetWorkerVersionCapabilities().GetBuildId())
+			s.True(workerVersionCapabilities.GetUseVersioning())
+			s.Equal("bid", workerVersionCapabilities.GetBuildId())
 		case "uvdo":
-			s.Assert().NotNil(p.GetDeploymentOptions())
-			s.Assert().Equal("bid", p.GetDeploymentOptions().GetBuildId())
+			s.NotNil(p.GetDeploymentOptions())
+			s.Equal("bid", p.GetDeploymentOptions().GetBuildId())
 		}
 	}
 }
 
 func (s *PartitionManagerTestSuite) TestHasAnyPollerAfter() {
 	// no pollers
-	s.Assert().False(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-5 * time.Minute)))
+	s.False(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-5 * time.Minute)))
 
 	// one unversioned poller
 	s.pollWithIdentity("uv", "", false, false)
-	s.Assert().True(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-100 * time.Microsecond)))
+	s.True(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-100 * time.Microsecond)))
 	time.Sleep(time.Millisecond)
-	s.Assert().False(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-100 * time.Microsecond)))
+	s.False(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-100 * time.Microsecond)))
 
 	// one versioned poller
 	s.pollWithIdentity("v", "bid", true, false)
-	s.Assert().True(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-100 * time.Microsecond)))
+	s.True(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-100 * time.Microsecond)))
 	time.Sleep(time.Millisecond)
-	s.Assert().False(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-100 * time.Microsecond)))
+	s.False(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-100 * time.Microsecond)))
 }
 
 func (s *PartitionManagerTestSuite) TestHasPollerAfter_Unversioned() {
 	// no pollers
-	s.Assert().False(s.partitionMgr.HasPollerAfter("", time.Now().Add(-5*time.Minute)))
+	s.False(s.partitionMgr.HasPollerAfter("", time.Now().Add(-5*time.Minute)))
 
 	// one unversioned poller
 	s.pollWithIdentity("uv", "", false, false)
-	s.Assert().True(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-500 * time.Microsecond)))
-	s.Assert().True(s.partitionMgr.HasPollerAfter("", time.Now().Add(-500*time.Microsecond)))
+	s.True(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-500 * time.Microsecond)))
+	s.True(s.partitionMgr.HasPollerAfter("", time.Now().Add(-500*time.Microsecond)))
 	time.Sleep(time.Millisecond)
-	s.Assert().False(s.partitionMgr.HasPollerAfter("", time.Now().Add(-100*time.Microsecond)))
+	s.False(s.partitionMgr.HasPollerAfter("", time.Now().Add(-100*time.Microsecond)))
 
 	// one versioned poller
 	s.pollWithIdentity("v", "bid", true, false)
-	s.Assert().False(s.partitionMgr.HasPollerAfter("", time.Now().Add(-100*time.Microsecond)))
+	s.False(s.partitionMgr.HasPollerAfter("", time.Now().Add(-100*time.Microsecond)))
 }
 
 func (s *PartitionManagerTestSuite) TestHasPollerAfter_Versioned() {
 	// no pollers
-	s.Assert().False(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-5 * time.Minute)))
+	s.False(s.partitionMgr.HasAnyPollerAfter(time.Now().Add(-5 * time.Minute)))
 
 	// one version-set poller
 	bid := "bid"
 	s.pollWithIdentity("v", bid, true, false)
-	s.Assert().True(s.partitionMgr.HasPollerAfter(bid, time.Now().Add(-100*time.Microsecond)))
+	s.True(s.partitionMgr.HasPollerAfter(bid, time.Now().Add(-100*time.Microsecond)))
 	time.Sleep(time.Millisecond)
-	s.Assert().False(s.partitionMgr.HasPollerAfter(bid, time.Now().Add(-100*time.Microsecond)))
+	s.False(s.partitionMgr.HasPollerAfter(bid, time.Now().Add(-100*time.Microsecond)))
 
 	// one unversioned poller
 	s.pollWithIdentity("uv", "", false, true)
-	s.Assert().False(s.partitionMgr.HasPollerAfter(bid, time.Now().Add(-100*time.Microsecond)))
+	s.False(s.partitionMgr.HasPollerAfter(bid, time.Now().Add(-100*time.Microsecond)))
 }
 
 func (s *PartitionManagerTestSuite) TestLegacyDescribeTaskQueue() {
@@ -452,27 +477,29 @@ func (s *PartitionManagerTestSuite) TestLegacyDescribeTaskQueue() {
 	// no pollers
 	resp, err := s.partitionMgr.LegacyDescribeTaskQueue(false)
 	s.NoError(err)
-	s.Assert().Equal(0, len(resp.DescResponse.GetPollers()))
+	s.Equal(0, len(resp.DescResponse.GetPollers()))
 
 	// one unversioned poller
 	s.pollWithIdentity("uv", "", false, false)
 	resp, err = s.partitionMgr.LegacyDescribeTaskQueue(false)
 	s.NoError(err)
-	s.Assert().Equal(1, len(resp.DescResponse.GetPollers()))
+	s.Equal(1, len(resp.DescResponse.GetPollers()))
 
 	// one versioned poller
 	s.pollWithIdentity("v", "bid", true, false)
 	resp, err = s.partitionMgr.LegacyDescribeTaskQueue(false)
 	s.NoError(err)
-	s.Assert().Equal(2, len(resp.DescResponse.GetPollers()))
+	s.Equal(2, len(resp.DescResponse.GetPollers()))
 
 	for _, p := range resp.DescResponse.GetPollers() {
+		//nolint:staticcheck // SA1019 deprecated GetWorkerVersionCapabilities
+		workerVersionCapabilities := p.GetWorkerVersionCapabilities()
 		switch p.GetIdentity() {
 		case "uv":
-			s.Assert().False(p.GetWorkerVersionCapabilities().GetUseVersioning())
+			s.False(workerVersionCapabilities.GetUseVersioning())
 		case "v":
-			s.Assert().True(p.GetWorkerVersionCapabilities().GetUseVersioning())
-			s.Assert().Equal("bid", p.GetWorkerVersionCapabilities().GetBuildId())
+			s.True(workerVersionCapabilities.GetUseVersioning())
+			s.Equal("bid", workerVersionCapabilities.GetBuildId())
 		}
 	}
 }
@@ -495,9 +522,9 @@ func (s *PartitionManagerTestSuite) validateAddTask(expectedBuildId string, expe
 			VersionDirective: directive,
 		},
 	})
-	s.Assert().NoError(err)
-	s.Assert().Equal(expectedSyncMatch, syncMatch)
-	s.Assert().Equal(expectedBuildId, buildId)
+	s.NoError(err)
+	s.Equal(expectedSyncMatch, syncMatch)
+	s.Equal(expectedBuildId, buildId)
 }
 
 func (s *PartitionManagerTestSuite) validatePollTaskSyncMatch(buildId string, useVersioning bool) {
@@ -513,9 +540,9 @@ func (s *PartitionManagerTestSuite) validatePollTaskSyncMatch(buildId string, us
 				},
 			},
 		)
-		s.Assert().NoError(err)
-		s.Assert().NotNil(task)
-		s.Assert().NotNil(task.responseC)
+		s.NoError(err)
+		s.NotNil(task)
+		s.NotNil(task.responseC)
 		close(task.responseC)
 	}()
 	// give time for poller to start polling before resuming execution
@@ -533,8 +560,8 @@ func (s *PartitionManagerTestSuite) validatePollTask(buildId string, useVersioni
 			UseVersioning: useVersioning,
 		},
 	})
-	s.Assert().NoError(err)
-	s.Assert().NotNil(task)
+	s.NoError(err)
+	s.NotNil(task)
 
 	return task
 }

--- a/service/matching/task_validation_test.go
+++ b/service/matching/task_validation_test.go
@@ -96,10 +96,6 @@ func (s *taskValidatorSuite) SetupTest() {
 	s.taskValidator = newTaskValidator(context.Background(), s.clusterMetadata, s.namespaceCache, s.historyClient)
 }
 
-func (s *taskValidatorSuite) TeardownTest() {
-	s.controller.Finish()
-}
-
 func (s *taskValidatorSuite) TestPreValidateActive_NewTask_Skip_WithCreationTime() {
 	s.taskValidator.lastValidatedTaskInfo = taskValidationInfo{
 		taskID:         s.task.TaskId - 1,

--- a/service/matching/user_data_manager_test.go
+++ b/service/matching/user_data_manager_test.go
@@ -39,6 +39,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/api/matchingservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -51,6 +52,13 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 )
+
+type tqmTestOpts struct {
+	config              *Config
+	dbq                 *PhysicalTaskQueueKey
+	matchingClientMock  *matchingservicemock.MockMatchingServiceClient
+	expectUserDataError bool
+}
 
 func createUserDataManager(
 	t *testing.T,
@@ -970,4 +978,12 @@ func TestUserData_CheckPropagation(t *testing.T) {
 			return false
 		}
 	}, 100*time.Millisecond, 5*time.Millisecond, "CheckTaskQueueUserDataPropagation did not return fast enough")
+}
+
+func defaultTqmTestOpts(controller *gomock.Controller) *tqmTestOpts {
+	return &tqmTestOpts{
+		config:             defaultTestConfig(),
+		dbq:                defaultTqId(),
+		matchingClientMock: matchingservicemock.NewMockMatchingServiceClient(controller),
+	}
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Re-using existing unit test suites for new priority/backlog/forwarder and:

- fixes two data races
- uses testlogger.Testlogger

Incompatible tests are skipped: `s.T().Skip("not supported by new matcher")`. They can either be ported or left as-is in follow-up PRs.

## Why?
<!-- Tell your future self why have you made these changes -->

Increase test coverage.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

A handful of tests had to be slightly tweaked to make them compatible. It's possible there are regressions in flakiness.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
