### PR TITLE
Prevent taskIdBlock data race

### DIFF
--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -223,7 +223,7 @@ func (c *backlogManagerImpl) TotalApproximateBacklogCount() int64 {
 }
 
 func (c *backlogManagerImpl) InternalStatus() []*taskqueuespb.InternalTaskQueueStatus {
-	currentTaskIDBlock := c.taskWriter.getTaskIDBlock()
+	currentTaskIDBlock := c.taskWriter.getCurrentTaskIDBlock()
 	return []*taskqueuespb.InternalTaskQueueStatus{
 		&taskqueuespb.InternalTaskQueueStatus{
 			ReadLevel: c.taskAckManager.getReadLevel(),

--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -223,14 +223,14 @@ func (c *backlogManagerImpl) TotalApproximateBacklogCount() int64 {
 }
 
 func (c *backlogManagerImpl) InternalStatus() []*taskqueuespb.InternalTaskQueueStatus {
+	currentTaskIDBlock := c.taskWriter.getTaskIDBlock()
 	return []*taskqueuespb.InternalTaskQueueStatus{
 		&taskqueuespb.InternalTaskQueueStatus{
 			ReadLevel: c.taskAckManager.getReadLevel(),
 			AckLevel:  c.taskAckManager.getAckLevel(),
 			TaskIdBlock: &taskqueuepb.TaskIdBlock{
-				// TODO(pri): this is a data race, it should only be read by taskWriterLoop
-				StartId: c.taskWriter.taskIDBlock.start,
-				EndId:   c.taskWriter.taskIDBlock.end,
+				StartId: currentTaskIDBlock.start,
+				EndId:   currentTaskIDBlock.end,
 			},
 			LoadedTasks:  c.taskAckManager.getBacklogCountHint(),
 			MaxReadLevel: c.db.GetMaxReadLevel(subqueueZero),

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -323,7 +323,7 @@ func (c *priBacklogManagerImpl) TotalApproximateBacklogCount() int64 {
 }
 
 func (c *priBacklogManagerImpl) InternalStatus() []*taskqueuespb.InternalTaskQueueStatus {
-	currentTaskIDBlock := c.taskWriter.currentTaskIDBlock()
+	currentTaskIDBlock := c.taskWriter.getCurrentTaskIDBlock()
 
 	c.subqueueLock.Lock()
 	defer c.subqueueLock.Unlock()

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -323,11 +323,7 @@ func (c *priBacklogManagerImpl) TotalApproximateBacklogCount() int64 {
 }
 
 func (c *priBacklogManagerImpl) InternalStatus() []*taskqueuespb.InternalTaskQueueStatus {
-	// TODO(pri): this is a data race, it should only be read by taskWriterLoop
-	idBlock := &taskqueuepb.TaskIdBlock{
-		StartId: c.taskWriter.taskIDBlock.start,
-		EndId:   c.taskWriter.taskIDBlock.end,
-	}
+	currentTaskIDBlock := c.taskWriter.currentTaskIDBlock()
 
 	c.subqueueLock.Lock()
 	defer c.subqueueLock.Unlock()
@@ -336,9 +332,12 @@ func (c *priBacklogManagerImpl) InternalStatus() []*taskqueuespb.InternalTaskQue
 	for i, r := range c.subqueues {
 		readLevel, ackLevel := r.getLevels()
 		status[i] = &taskqueuespb.InternalTaskQueueStatus{
-			ReadLevel:               readLevel,
-			AckLevel:                ackLevel,
-			TaskIdBlock:             idBlock,
+			ReadLevel: readLevel,
+			AckLevel:  ackLevel,
+			TaskIdBlock: &taskqueuepb.TaskIdBlock{
+				StartId: currentTaskIDBlock.start,
+				EndId:   currentTaskIDBlock.end,
+			},
 			LoadedTasks:             int64(r.getLoadedTasks()),
 			MaxReadLevel:            c.db.GetMaxReadLevel(i),
 			ApproximateBacklogCount: c.db.getApproximateBacklogCount(i),


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Prevent data race when accessing task writer's `taskIdBlock`.


