### PR TITLE
Overhaul badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build status](https://github.com/temporalio/temporal/actions/workflows/run-tests.yml/badge.svg?branch=main)](https://github.com/temporalio/temporal/commits/main/)
-[![codecov](https://codecov.io/gh/temporalio/temporal/graph/badge.svg?token=FIKJ1QOUWN)](https://codecov.io/gh/temporalio/temporal)
-[![Discourse](https://img.shields.io/static/v1?label=Discourse&message=Get%20Help&color=informational)](https://community.temporal.io)
+![GitHub Release](https://img.shields.io/github/v/release/temporalio/temporal)
+![Static Badge](https://img.shields.io/badge/codecov-report-blue)
+[![Discourse](https://img.shields.io/static/v1?label=community&message=get%20help&color=informational)](https://community.temporal.io)
 [![Go Report Card][go-report-image]][go-report-url]
 
 [go-report-image]: https://goreportcard.com/badge/github.com/temporalio/temporal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GitHub Release](https://img.shields.io/github/v/release/temporalio/temporal)
-![Static Badge](https://img.shields.io/badge/codecov-report-blue)
-[![Discourse](https://img.shields.io/static/v1?label=community&message=get%20help&color=informational)](https://community.temporal.io)
+![Code Coverage](https://img.shields.io/badge/codecov-report-blue)
+[![Community](https://img.shields.io/static/v1?label=community&message=get%20help&color=informational)](https://community.temporal.io)
 [![Go Report Card][go-report-image]][go-report-url]
 
 [go-report-image]: https://goreportcard.com/badge/github.com/temporalio/temporal


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Before

<img width="919" alt="Screenshot 2025-03-14 at 10 04 00 AM" src="https://github.com/user-attachments/assets/71372c24-f489-4cd0-b823-45155587839b" />


After

<img width="928" alt="Screenshot 2025-03-14 at 10 04 20 AM" src="https://github.com/user-attachments/assets/142f074e-78ae-49e8-8331-733b1360a1ea" />

## Why?
<!-- Tell your future self why have you made these changes -->

Improve the first impression of a visitor:

- "All Tests" badge is either green (which doesn't really mean much); or is red due to a flaky test (which looks bad)
- "Codecov" badge looks worse than it is: it should be yellow but is orange.
- "Codecov" badge updates in real-time; meaning it shows lower numbers during a test run 
- use consistent lowercase letters
