### PR TITLE
Return error for non retry case in stream sender

### DIFF
--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -36,7 +36,8 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/common/persistence"
+	serviceerrors "go.temporal.io/server/common/serviceerror"
 )
 
 var (
@@ -111,11 +112,15 @@ func WrapEventLoop(
 }
 
 func isRetryableError(err error) bool {
-	if shard.IsShardOwnershipLostError(err) {
+	var streamError *StreamError
+	var shardOwnershipLostError *persistence.ShardOwnershipLostError
+	var shardOwnershipLost *serviceerrors.ShardOwnershipLost
+	switch {
+	case errors.As(err, &shardOwnershipLostError):
 		return false
-	}
-	switch err.(type) {
-	case *StreamError:
+	case errors.As(err, &shardOwnershipLost):
+		return false
+	case errors.As(err, &streamError):
 		return false
 	default:
 		return true

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -198,7 +198,7 @@ func (s *StreamSenderImpl) recvEventLoop() (retErr error) {
 		switch attr := req.GetAttributes().(type) {
 		case *historyservice.StreamWorkflowReplicationMessagesRequest_SyncReplicationState:
 			if err := s.recvSyncReplicationState(attr.SyncReplicationState); err != nil {
-				return err
+				return fmt.Errorf("ReplicationServiceError StreamSender unable to handle SyncReplicationState: %w", err)
 			}
 			metrics.ReplicationTasksRecv.With(s.metrics).Record(
 				int64(1),

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -198,7 +198,7 @@ func (s *StreamSenderImpl) recvEventLoop() (retErr error) {
 		switch attr := req.GetAttributes().(type) {
 		case *historyservice.StreamWorkflowReplicationMessagesRequest_SyncReplicationState:
 			if err := s.recvSyncReplicationState(attr.SyncReplicationState); err != nil {
-				return fmt.Errorf("ReplicationServiceError StreamSender unable to handle SyncReplicationState: %w", err)
+				return err
 			}
 			metrics.ReplicationTasksRecv.With(s.metrics).Record(
 				int64(1),


### PR DESCRIPTION
## What changed?
Return error for non retry case in stream sender

## Why?
recvSyncReplicationState can return stream error or sol error

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
