### PR TITLE
CHASM: Apply chasm nodes mutation and snapshot

### DIFF
--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -162,6 +162,175 @@ func (s *nodeSuite) TestNodeSnapshot() {
 	s.Equal(expectedNodes, snapshot.Nodes)
 }
 
+func (s *nodeSuite) TestApplyMutation() {
+	// Setup initial tree with a root, a child, and a grandchild.
+	persistenceNodes := map[string]*persistencespb.ChasmNode{
+		"": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+			},
+		},
+		"child": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 2},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 2},
+			},
+		},
+		"child/grandchild": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 3},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 3},
+			},
+		},
+		"child/grandchild/grandgrandchild": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 4},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 4},
+			},
+		},
+	}
+	root, err := NewTree(s.registry, persistenceNodes, s.timeSource, s.nodeBackend, s.nodePathEncoder, log.NewTestLogger())
+	s.NoError(err)
+
+	// This decoded value should be reset after applying the mutation
+	root.children["child"].value = "some-random-decoded-value"
+
+	// Prepare mutation: update "child" node, delete "child/grandchild", and add "newchild".
+	updatedChild := &persistencespb.ChasmNode{
+		Metadata: &persistencespb.ChasmNodeMetadata{
+			InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 20},
+			LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 20},
+		},
+	}
+	newChild := &persistencespb.ChasmNode{
+		Metadata: &persistencespb.ChasmNodeMetadata{
+			InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 100},
+			LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 100},
+		},
+	}
+	mutation := NodesMutation{
+		UpdatedNodes: map[string]*persistencespb.ChasmNode{
+			"child":    updatedChild,
+			"newchild": newChild,
+		},
+		DeletedNodes: map[string]struct{}{
+			"child/grandchild":           {}, // this should remove the entire "grandchild" subtree
+			"child/non-exist-grandchild": {},
+		},
+	}
+	err = root.ApplyMutation(mutation)
+	s.NoError(err)
+
+	// Validate the "child" node got updated.
+	childNode, ok := root.children["child"]
+	s.True(ok)
+	s.Equal(updatedChild, childNode.persistence)
+	s.Nil(childNode.value) // value should be reset after mutation
+
+	// Validate the "newchild" node is added.
+	newChildNode, ok := root.children["newchild"]
+	s.True(ok)
+	s.Equal(newChild, newChildNode.persistence)
+
+	// Validate the "grandchild" node is deleted.
+	s.Empty(childNode.children)
+
+	// Validate that nodeBase.mutation reflects the applied mutation.
+	// Only updates on existing nodes are recorded; new nodes are inserted without a mutation record.
+	expectedMutation := NodesMutation{
+		UpdatedNodes: map[string]*persistencespb.ChasmNode{
+			"child":    updatedChild,
+			"newchild": newChild,
+		},
+		DeletedNodes: map[string]struct{}{
+			"child/grandchild":                 {},
+			"child/grandchild/grandgrandchild": {},
+		},
+	}
+	s.Equal(expectedMutation, root.mutation)
+}
+
+func (s *nodeSuite) TestApplySnapshot() {
+	// Setup initial tree with a root, a child, and a grandchild.
+	persistenceNodes := map[string]*persistencespb.ChasmNode{
+		"": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+			},
+		},
+		"child": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 2},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 2},
+			},
+		},
+		"child/grandchild": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 3},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 3},
+			},
+		},
+		"child/grandchild/grandgrandchild": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 4},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 4},
+			},
+		},
+	}
+	root, err := NewTree(s.registry, persistenceNodes, s.timeSource, s.nodeBackend, s.nodePathEncoder, log.NewTestLogger())
+	s.NoError(err)
+
+	// Set a decoded value that should be reset after applying the snapshot.
+	root.children["child"].value = "decoded-value"
+
+	// Prepare an incoming snapshot representing the target state:
+	// - The "child" node is updated (LastUpdateTransition becomes 20),
+	// - the "child/grandchild" node is removed,
+	// - a new node "newchild" is added.
+	incomingSnapshot := NodesSnapshot{
+		Nodes: map[string]*persistencespb.ChasmNode{
+			"": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+				},
+			},
+			"child": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 2},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 20},
+				},
+			},
+			"newchild": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 100},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 100},
+				},
+			},
+		},
+	}
+	err = root.ApplySnapshot(incomingSnapshot)
+	s.NoError(err)
+
+	s.Equal(incomingSnapshot, root.Snapshot(nil))
+	s.Nil(root.children["child"].value) // value should be reset after snapshot
+
+	// Validate that nodeBase.mutation reflects the applied snapshot.
+	expectedMutation := NodesMutation{
+		UpdatedNodes: map[string]*persistencespb.ChasmNode{
+			"child":    incomingSnapshot.Nodes["child"],
+			"newchild": incomingSnapshot.Nodes["newchild"],
+		},
+		DeletedNodes: map[string]struct{}{
+			"child/grandchild":                 {},
+			"child/grandchild/grandgrandchild": {},
+		},
+	}
+	s.Equal(expectedMutation, root.mutation)
+}
+
 func (s *nodeSuite) preorderAndAssertParent(
 	n *Node,
 	parent *Node,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Implement ApplyMutation & ApplySnapshot methods of CHASM Tree
- Introduced a mutation field shared by the entire tree for tracking all the mutation happened so far in a transaction.

## Why?
<!-- Tell your future self why have you made these changes -->
- CHASM implementation

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
