### PR TITLE
Track Priority metrics separately

### DIFF
--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -249,7 +249,7 @@ func newPhysicalTaskQueueManager(
 				return nil, err
 			}
 		}
-		pqMgr.oldMatcher = newTaskMatcher(config, fwdr, pqMgr.metricsHandler)
+		pqMgr.oldMatcher = newTaskMatcher(config, fwdr, taggedMetricsHandler)
 		pqMgr.matcher = pqMgr.oldMatcher
 	}
 	return pqMgr, nil

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -208,7 +208,7 @@ func newPhysicalTaskQueueManager(
 			logger,
 			throttledLogger,
 			e.matchingRawClient,
-			taggedMetricsHandler,
+			newPriMetricsHandler(taggedMetricsHandler),
 		)
 		var fwdr *priForwarder
 		var err error
@@ -226,7 +226,7 @@ func newPhysicalTaskQueueManager(
 			fwdr,
 			pqMgr.taskValidator,
 			logger,
-			newPriMetricsHandler(pqMgr.metricsHandler),
+			newPriMetricsHandler(taggedMetricsHandler),
 		)
 		pqMgr.matcher = pqMgr.priMatcher
 	} else {

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -226,7 +226,7 @@ func newPhysicalTaskQueueManager(
 			fwdr,
 			pqMgr.taskValidator,
 			logger,
-			pqMgr.metricsHandler,
+			newPriMetricsHandler(pqMgr.metricsHandler),
 		)
 		pqMgr.matcher = pqMgr.priMatcher
 	} else {

--- a/service/matching/pri_metrics_handler.go
+++ b/service/matching/pri_metrics_handler.go
@@ -1,0 +1,92 @@
+// The MIT License
+//
+// Copyright (c) 2025 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"time"
+
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+)
+
+type (
+	priMetricHandler struct {
+		handler metrics.Handler
+	}
+	priMetricsTimer struct {
+		name    string
+		handler metrics.Handler
+	}
+	priMetricsCounter struct {
+		name    string
+		handler metrics.Handler
+	}
+)
+
+// TODO(pri): cleanup; delete this
+func newPriMetricsHandler(handler metrics.Handler) priMetricHandler {
+	return priMetricHandler{
+		handler: handler,
+	}
+}
+
+func (p priMetricHandler) Stop(logger log.Logger) {
+	p.handler.Stop(logger)
+}
+
+func (p priMetricHandler) Counter(name string) metrics.CounterIface {
+	return &priMetricsCounter{name: name, handler: p.handler}
+}
+func (p priMetricHandler) Timer(name string) metrics.TimerIface {
+	return &priMetricsTimer{name: name, handler: p.handler}
+}
+
+func (p priMetricHandler) Gauge(name string) metrics.GaugeIface {
+	panic("not implemented")
+}
+
+func (p priMetricHandler) WithTags(...metrics.Tag) metrics.Handler {
+	panic("not implemented")
+}
+
+func (p priMetricHandler) Histogram(string, metrics.MetricUnit) metrics.HistogramIface {
+	panic("not implemented")
+}
+
+func (p priMetricHandler) StartBatch(string) metrics.BatchHandler {
+	panic("not implemented")
+}
+
+func (c priMetricsCounter) Record(i int64, tag ...metrics.Tag) {
+	c.handler.Counter(c.name).Record(i, tag...)
+	c.handler.Counter(withPriPrefix(c.name)).Record(i, tag...)
+}
+
+func (t priMetricsTimer) Record(duration time.Duration, tag ...metrics.Tag) {
+	t.handler.Timer(t.name).Record(duration, tag...)
+	t.handler.Timer(withPriPrefix(t.name)).Record(duration, tag...)
+}
+
+func withPriPrefix(name string) string {
+	return "pri_" + name
+}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Tag metrics belonging to the new priority path separately.

## Why?
<!-- Tell your future self why have you made these changes -->

The priority-related metrics can now be viewed in isolation to drill down into priority-specific behavior.

We still emit the regular metric as before, as to not skew alerting and dashboards.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Checked in local Grafana.

<img width="198" alt="Screenshot 2025-03-19 at 9 46 07 AM" src="https://github.com/user-attachments/assets/3d0b91d1-0388-4747-9902-d0d15ec6e08e" />



## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
