### PR TITLE
Revert "[CHASM] Cassandra Persistence for CHASM nodes (#7414)"

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -120,23 +120,6 @@ func NewTree(
 	return root, nil
 }
 
-// NewEmptyTree creates a new empty in-memory CHASM tree.
-func NewEmptyTree(
-	registry *Registry,
-	timeSource clock.TimeSource,
-	backend NodeBackend,
-	pathEncoder NodePathEncoder,
-) *Node {
-	base := &nodeBase{
-		registry:    registry,
-		timeSource:  timeSource,
-		backend:     backend,
-		pathEncoder: pathEncoder,
-	}
-	root := newNode(base, nil)
-	return root
-}
-
 // Component retrieves a component from the tree rooted at node n
 // using the provided component reference
 // It also performs consistency, access rule, and task validation checks

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -899,7 +899,6 @@ var (
 	SignalInfoSize                        = NewBytesHistogramDef("signal_info_size")
 	SignalRequestIDSize                   = NewBytesHistogramDef("signal_request_id_size")
 	BufferedEventsSize                    = NewBytesHistogramDef("buffered_events_size")
-	ChasmTotalSize                        = NewBytesHistogramDef("chasm_total_size")
 	ActivityInfoCount                     = NewDimensionlessHistogramDef("activity_info_count")
 	TimerInfoCount                        = NewDimensionlessHistogramDef("timer_info_count")
 	ChildInfoCount                        = NewDimensionlessHistogramDef("child_info_count")

--- a/common/persistence/cassandra/mutable_state_store.go
+++ b/common/persistence/cassandra/mutable_state_store.go
@@ -80,7 +80,6 @@ const (
 
 	templateGetWorkflowExecutionQuery = `SELECT execution, execution_encoding, execution_state, execution_state_encoding, next_event_id, activity_map, activity_map_encoding, timer_map, timer_map_encoding, ` +
 		`child_executions_map, child_executions_map_encoding, request_cancel_map, request_cancel_map_encoding, signal_map, signal_map_encoding, signal_requested, buffered_events_list, ` +
-		`chasm_node_map, chasm_node_map_encoding, ` +
 		`checksum, checksum_encoding, db_record_version ` +
 		`FROM executions ` +
 		`WHERE shard_id = ? ` +
@@ -233,26 +232,6 @@ const (
 		`and visibility_ts = ? ` +
 		`and task_id = ? `
 
-	templateResetChasmNodeQuery = `UPDATE executions ` +
-		`SET chasm_node_map = ?, chasm_node_map_encoding = ? ` +
-		`WHERE shard_id = ? ` +
-		`and type = ? ` +
-		`and namespace_id = ? ` +
-		`and workflow_id = ? ` +
-		`and run_id = ? ` +
-		`and visibility_ts = ? ` +
-		`and task_id = ? `
-
-	templateUpdateChasmNodeQuery = `UPDATE executions ` +
-		`SET chasm_node_map[ ? ] = ?, chasm_node_map_encoding = ? ` +
-		`WHERE shard_id = ? ` +
-		`and type = ? ` +
-		`and namespace_id = ? ` +
-		`and workflow_id = ? ` +
-		`and run_id = ? ` +
-		`and visibility_ts = ? ` +
-		`and task_id = ? `
-
 	templateResetSignalInfoQuery = `UPDATE executions ` +
 		`SET signal_map = ?, signal_map_encoding = ? ` +
 		`WHERE shard_id = ? ` +
@@ -344,16 +323,6 @@ const (
 		`and task_id = ? `
 
 	templateDeleteSignalInfoQuery = `DELETE signal_map[ ? ] ` +
-		`FROM executions ` +
-		`WHERE shard_id = ? ` +
-		`and type = ? ` +
-		`and namespace_id = ? ` +
-		`and workflow_id = ? ` +
-		`and run_id = ? ` +
-		`and visibility_ts = ? ` +
-		`and task_id = ? `
-
-	templateDeleteChasmNodeQuery = `DELETE chasm_node_map[ ? ] ` +
 		`FROM executions ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
@@ -571,20 +540,6 @@ func (d *MutableStateStore) GetWorkflowExecution(
 	}
 	state.SignalInfos = signalInfos
 	state.SignalRequestedIDs = gocql.UUIDsToStringSlice(result["signal_requested"])
-
-	chasmNodeBlobs := make(map[string]*commonpb.DataBlob)
-	chasmNodeEncoding, ok := result["chasm_node_map_encoding"].(string)
-	if !ok {
-		return nil, serviceerror.NewInternal("GetWorkflowExecution failed: unknown chasm_node_map_encoding type")
-	}
-	chasmNodeBytes, ok := result["chasm_node_map"].(map[string][]byte)
-	if !ok {
-		return nil, serviceerror.NewInternal("GetWorkflowExecution failed: unknown chasm_node_map type")
-	}
-	for key, value := range chasmNodeBytes {
-		chasmNodeBlobs[key] = p.NewDataBlob(value, chasmNodeEncoding)
-	}
-	state.ChasmNodes = chasmNodeBlobs
 
 	eList := result["buffered_events_list"].([]map[string]interface{})
 	bufferedEventsBlobs := make([]*commonpb.DataBlob, 0, len(eList))

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -723,7 +723,6 @@ type (
 		SignalInfoSize        int
 		SignalRequestIDSize   int
 		BufferedEventsSize    int
-		ChasmTotalSize        int // total size of all CHASM nodes within a record
 		// UpdateInfoSize is included in ExecutionInfoSize
 
 		// Item count for various information captured within mutable state

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -577,9 +577,6 @@ func (m *executionManagerImpl) SerializeWorkflowMutation( // unexport
 		UpsertSignalInfos: make(map[int64]*commonpb.DataBlob, len(input.UpsertSignalInfos)),
 		DeleteSignalInfos: input.DeleteSignalInfos,
 
-		UpsertChasmNodes: make(map[string]*commonpb.DataBlob, len(input.UpsertChasmNodes)),
-		DeleteChasmNodes: input.DeleteChasmNodes,
-
 		UpsertSignalRequestedIDs: input.UpsertSignalRequestedIDs,
 		DeleteSignalRequestedIDs: input.DeleteSignalRequestedIDs,
 
@@ -645,14 +642,6 @@ func (m *executionManagerImpl) SerializeWorkflowMutation( // unexport
 		result.UpsertSignalInfos[key] = blob
 	}
 
-	for key, node := range input.UpsertChasmNodes {
-		blob, err := m.serializer.ChasmNodeToBlob(node, enumspb.ENCODING_TYPE_PROTO3)
-		if err != nil {
-			return nil, err
-		}
-		result.UpsertChasmNodes[key] = blob
-	}
-
 	if len(input.NewBufferedEvents) > 0 {
 		result.NewBufferedEvents, err = m.serializer.SerializeEvents(input.NewBufferedEvents, enumspb.ENCODING_TYPE_PROTO3)
 		if err != nil {
@@ -691,7 +680,6 @@ func (m *executionManagerImpl) SerializeWorkflowSnapshot( // unexport
 		ChildExecutionInfos: make(map[int64]*commonpb.DataBlob, len(input.ChildExecutionInfos)),
 		RequestCancelInfos:  make(map[int64]*commonpb.DataBlob, len(input.RequestCancelInfos)),
 		SignalInfos:         make(map[int64]*commonpb.DataBlob, len(input.SignalInfos)),
-		ChasmNodes:          make(map[string]*commonpb.DataBlob, len(input.ChasmNodes)),
 
 		ExecutionInfo:      input.ExecutionInfo,
 		ExecutionState:     input.ExecutionState,
@@ -754,13 +742,6 @@ func (m *executionManagerImpl) SerializeWorkflowSnapshot( // unexport
 	}
 	for key := range input.SignalRequestedIDs {
 		result.SignalRequestedIDs[key] = struct{}{}
-	}
-	for key, node := range input.ChasmNodes {
-		blob, err := m.serializer.ChasmNodeToBlob(node, enumspb.ENCODING_TYPE_PROTO3)
-		if err != nil {
-			return nil, err
-		}
-		result.ChasmNodes[key] = blob
 	}
 
 	result.Checksum, err = m.serializer.ChecksumToBlob(input.Checksum, enumspb.ENCODING_TYPE_PROTO3)
@@ -1029,7 +1010,6 @@ func (m *executionManagerImpl) toWorkflowMutableState(internState *InternalWorkf
 		ChildExecutionInfos: make(map[int64]*persistencespb.ChildExecutionInfo),
 		RequestCancelInfos:  make(map[int64]*persistencespb.RequestCancelInfo),
 		SignalInfos:         make(map[int64]*persistencespb.SignalInfo),
-		ChasmNodes:          make(map[string]*persistencespb.ChasmNode),
 		SignalRequestedIds:  internState.SignalRequestedIDs,
 		NextEventId:         internState.NextEventID,
 		BufferedEvents:      make([]*historypb.HistoryEvent, len(internState.BufferedEvents)),
@@ -1068,13 +1048,6 @@ func (m *executionManagerImpl) toWorkflowMutableState(internState *InternalWorkf
 			return nil, err
 		}
 		state.SignalInfos[key] = info
-	}
-	for key, blob := range internState.ChasmNodes {
-		node, err := m.serializer.ChasmNodeFromBlob(blob)
-		if err != nil {
-			return nil, err
-		}
-		state.ChasmNodes[key] = node
 	}
 	var err error
 	state.ExecutionInfo, err = m.serializer.WorkflowExecutionInfoFromBlob(internState.ExecutionInfo)

--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -410,7 +410,6 @@ type (
 		ChildExecutionInfos map[int64]*commonpb.DataBlob  `json:",omitempty"` // ChildExecutionInfo
 		RequestCancelInfos  map[int64]*commonpb.DataBlob  `json:",omitempty"` // RequestCancelInfo
 		SignalInfos         map[int64]*commonpb.DataBlob  `json:",omitempty"` // SignalInfo
-		ChasmNodes          map[string]*commonpb.DataBlob `json:",omitempty"` // persistencespb.ChasmNode
 		SignalRequestedIDs  []string                      `json:",omitempty"`
 		ExecutionInfo       *commonpb.DataBlob            // WorkflowExecutionInfo
 		ExecutionState      *commonpb.DataBlob            // WorkflowExecutionState
@@ -462,8 +461,6 @@ type (
 		DeleteRequestCancelInfos  map[int64]struct{}            `json:",omitempty"`
 		UpsertSignalInfos         map[int64]*commonpb.DataBlob  `json:",omitempty"`
 		DeleteSignalInfos         map[int64]struct{}            `json:",omitempty"`
-		UpsertChasmNodes          map[string]*commonpb.DataBlob `json:",omitempty"`
-		DeleteChasmNodes          map[string]struct{}           `json:",omitempty"`
 		UpsertSignalRequestedIDs  map[string]struct{}           `json:",omitempty"`
 		DeleteSignalRequestedIDs  map[string]struct{}           `json:",omitempty"`
 		NewBufferedEvents         *commonpb.DataBlob
@@ -497,7 +494,6 @@ type (
 		ChildExecutionInfos map[int64]*commonpb.DataBlob  `json:",omitempty"`
 		RequestCancelInfos  map[int64]*commonpb.DataBlob  `json:",omitempty"`
 		SignalInfos         map[int64]*commonpb.DataBlob  `json:",omitempty"`
-		ChasmNodes          map[string]*commonpb.DataBlob `json:",omitempty"`
 		SignalRequestedIDs  map[string]struct{}           `json:",omitempty"`
 
 		Tasks map[tasks.Category][]InternalHistoryTask `json:",omitempty"`

--- a/common/persistence/serialization/serializer.go
+++ b/common/persistence/serialization/serializer.go
@@ -118,9 +118,6 @@ type (
 
 		NexusEndpointToBlob(endpoint *persistencespb.NexusEndpoint, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
 		NexusEndpointFromBlob(data *commonpb.DataBlob) (*persistencespb.NexusEndpoint, error)
-
-		ChasmNodeToBlob(node *persistencespb.ChasmNode, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
-		ChasmNodeFromBlob(data *commonpb.DataBlob) (*persistencespb.ChasmNode, error)
 	}
 
 	// SerializationError is an error type for serialization
@@ -575,15 +572,6 @@ func (t *serializerImpl) NexusEndpointToBlob(endpoint *persistencespb.NexusEndpo
 
 func (t *serializerImpl) NexusEndpointFromBlob(data *commonpb.DataBlob) (*persistencespb.NexusEndpoint, error) {
 	result := &persistencespb.NexusEndpoint{}
-	return result, ProtoDecodeBlob(data, result)
-}
-
-func (t *serializerImpl) ChasmNodeToBlob(node *persistencespb.ChasmNode, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
-	return ProtoEncodeBlob(node, encodingType)
-}
-
-func (t *serializerImpl) ChasmNodeFromBlob(data *commonpb.DataBlob) (*persistencespb.ChasmNode, error) {
-	result := &persistencespb.ChasmNode{}
 	return result, ProtoDecodeBlob(data, result)
 }
 

--- a/common/persistence/size.go
+++ b/common/persistence/size.go
@@ -71,8 +71,6 @@ func statusOfInternalWorkflow(
 	totalUpdateCount := state.ExecutionInfo.UpdateCount
 	updateInfoCount := len(state.ExecutionInfo.UpdateInfos)
 
-	chasmTotalSize := sizeOfStringBlobMap(internalState.ChasmNodes)
-
 	totalSize := executionInfoSize
 	totalSize += executionStateSize
 	totalSize += activityInfoSize
@@ -82,7 +80,6 @@ func statusOfInternalWorkflow(
 	totalSize += signalInfoSize
 	totalSize += signalRequestIDSize
 	totalSize += bufferedEventsSize
-	totalSize += chasmTotalSize
 
 	return &MutableStateStatistics{
 		TotalSize:         totalSize,
@@ -120,8 +117,6 @@ func statusOfInternalWorkflow(
 
 		UpdateInfoCount:  updateInfoCount,
 		TotalUpdateCount: totalUpdateCount,
-
-		ChasmTotalSize: chasmTotalSize,
 	}
 }
 
@@ -184,9 +179,6 @@ func statusOfInternalWorkflowMutation(
 
 	taskCountByCategory := taskCountsByCategory(&mutation.Tasks)
 
-	chasmTotalSize := sizeOfStringBlobMap(mutation.UpsertChasmNodes)
-	chasmTotalSize += sizeOfStringSet(mutation.DeleteChasmNodes)
-
 	// TODO what about checksum?
 
 	totalSize := executionInfoSize
@@ -198,7 +190,6 @@ func statusOfInternalWorkflowMutation(
 	totalSize += signalInfoSize
 	totalSize += signalRequestIDSize
 	totalSize += bufferedEventsSize
-	totalSize += chasmTotalSize
 
 	return &MutableStateStatistics{
 		TotalSize:         totalSize,
@@ -238,8 +229,6 @@ func statusOfInternalWorkflowMutation(
 
 		TotalUpdateCount: totalUpdateCount,
 		UpdateInfoCount:  updateInfoCount,
-
-		ChasmTotalSize: chasmTotalSize,
 	}
 }
 
@@ -292,8 +281,6 @@ func statusOfInternalWorkflowSnapshot(
 	bufferedEventsCount := 0
 	bufferedEventsSize := 0
 
-	chasmTotalSize := sizeOfStringBlobMap(snapshot.ChasmNodes)
-
 	totalSize := executionInfoSize
 	totalSize += executionStateSize
 	totalSize += activityInfoSize
@@ -303,7 +290,6 @@ func statusOfInternalWorkflowSnapshot(
 	totalSize += signalInfoSize
 	totalSize += signalRequestIDSize
 	totalSize += bufferedEventsSize
-	totalSize += chasmTotalSize
 
 	taskCountByCategory := taskCountsByCategory(&snapshot.Tasks)
 
@@ -345,7 +331,5 @@ func statusOfInternalWorkflowSnapshot(
 
 		TotalUpdateCount: totalUpdateCount,
 		UpdateInfoCount:  updateInfoCount,
-
-		ChasmTotalSize: chasmTotalSize,
 	}
 }

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -27,7 +27,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"maps"
 	"math"
 	"math/rand"
 	"testing"
@@ -206,7 +205,6 @@ func (s *ExecutionMutableStateSuite) TestCreate_Reuse() {
 	newRunID := uuid.New().String()
 	newBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, newRunID, s.historyBranchUtil)
 	newSnapshot, newEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		newRunID,
@@ -290,7 +288,6 @@ func (s *ExecutionMutableStateSuite) TestCreate_Zombie() {
 	newRunID := uuid.New().String()
 	newBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, newRunID, s.historyBranchUtil)
 	newSnapshot, newEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		newRunID,
@@ -366,7 +363,6 @@ func (s *ExecutionMutableStateSuite) TestCreate_ClosedWorkflow_Bypass() {
 	newRunID := uuid.New().String()
 	newBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, newRunID, s.historyBranchUtil)
 	newSnapshot, newEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		newRunID,
@@ -407,7 +403,6 @@ func (s *ExecutionMutableStateSuite) TestCreate_ClosedWorkflow_UpdateCurrent() {
 	newRunID := uuid.New().String()
 	newBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, newRunID, s.historyBranchUtil)
 	newSnapshot, newEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		newRunID,
@@ -577,7 +572,6 @@ func (s *ExecutionMutableStateSuite) TestUpdate_NotZombie_WithNew() {
 	newRunID := uuid.New().String()
 	newBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, newRunID, s.historyBranchUtil)
 	newSnapshot, newEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		newRunID,
@@ -618,7 +612,6 @@ func (s *ExecutionMutableStateSuite) TestUpdate_Zombie() {
 	zombieRunID := uuid.New().String()
 	zombieBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, zombieRunID, s.historyBranchUtil)
 	zombieSnapshot, zombieEvents1 := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		zombieRunID,
@@ -719,7 +712,6 @@ func (s *ExecutionMutableStateSuite) TestUpdate_Zombie_Conflict() {
 	zombieRunID := uuid.New().String()
 	zombieBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, zombieRunID, s.historyBranchUtil)
 	zombieSnapshot, zombieEvents1 := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		zombieRunID,
@@ -782,7 +774,6 @@ func (s *ExecutionMutableStateSuite) TestUpdate_Zombie_WithNew() {
 	zombieRunID := uuid.New().String()
 	zombieBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, zombieRunID, s.historyBranchUtil)
 	zombieSnapshot, zombieEvents1 := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		zombieRunID,
@@ -821,7 +812,6 @@ func (s *ExecutionMutableStateSuite) TestUpdate_Zombie_WithNew() {
 	newRunID := uuid.New().String()
 	newBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, newRunID, s.historyBranchUtil)
 	newZombieSnapshot, newEvents3 := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		newRunID,
@@ -862,7 +852,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent() {
 	baseRunID := uuid.New().String()
 	baseBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, baseRunID, s.historyBranchUtil)
 	baseSnapshot, baseEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -887,7 +876,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent() {
 	s.NoError(err)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -943,7 +931,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_Current
 	baseRunID := uuid.New().String()
 	baseBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, baseRunID, s.historyBranchUtil)
 	baseSnapshot, baseEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -968,7 +955,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_Current
 	s.NoError(err)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1025,7 +1011,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_Conflic
 	baseRunID := uuid.New().String()
 	baseBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, baseRunID, s.historyBranchUtil)
 	baseSnapshot, baseEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1050,7 +1035,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_Conflic
 	s.NoError(err)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1105,7 +1089,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_Conflic
 	baseRunID := uuid.New().String()
 	baseBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, baseRunID, s.historyBranchUtil)
 	baseSnapshot, baseEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1130,7 +1113,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_Conflic
 	s.NoError(err)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1185,7 +1167,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_WithNew
 	baseRunID := uuid.New().String()
 	baseBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, baseRunID, s.historyBranchUtil)
 	baseSnapshot, baseEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1210,7 +1191,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_WithNew
 	s.NoError(err)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1224,7 +1204,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_SuppressCurrent_WithNew
 	newRunID := uuid.New().String()
 	newBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, newRunID, s.historyBranchUtil)
 	newSnapshot, newEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		newRunID,
@@ -1280,7 +1259,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_ResetCurrent() {
 	)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -1321,7 +1299,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_ResetCurrent_CurrentCon
 	baseRunID := uuid.New().String()
 	baseBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, baseRunID, s.historyBranchUtil)
 	baseSnapshot, baseEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1346,7 +1323,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_ResetCurrent_CurrentCon
 	s.NoError(err)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1386,7 +1362,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_ResetCurrent_Conflict()
 	)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -1426,7 +1401,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_ResetCurrent_WithNew() 
 	)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -1440,7 +1414,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_ResetCurrent_WithNew() 
 	newRunID := uuid.New().String()
 	newBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, newRunID, s.historyBranchUtil)
 	newSnapshot, newEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		newRunID,
@@ -1483,7 +1456,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_Zombie() {
 	baseRunID := uuid.New().String()
 	baseBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, baseRunID, s.historyBranchUtil)
 	baseSnapshot, baseEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1508,7 +1480,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_Zombie() {
 	s.NoError(err)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1548,7 +1519,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_Zombie_CurrentConflict(
 	)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -1589,7 +1559,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_Zombie_Conflict() {
 	baseRunID := uuid.New().String()
 	baseBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, baseRunID, s.historyBranchUtil)
 	baseSnapshot, baseEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1614,7 +1583,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_Zombie_Conflict() {
 	s.NoError(err)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1655,7 +1623,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_Zombie_WithNew() {
 	baseRunID := uuid.New().String()
 	baseBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, baseRunID, s.historyBranchUtil)
 	baseSnapshot, baseEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1680,7 +1647,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_Zombie_WithNew() {
 	s.NoError(err)
 
 	resetSnapshot, resetEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		baseRunID,
@@ -1694,7 +1660,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_Zombie_WithNew() {
 	newRunID := uuid.New().String()
 	newBranchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, newRunID, s.historyBranchUtil)
 	newSnapshot, newEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		newRunID,
@@ -1730,7 +1695,6 @@ func (s *ExecutionMutableStateSuite) TestConflictResolve_Zombie_WithNew() {
 func (s *ExecutionMutableStateSuite) TestSet_NotExists() {
 	branchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, s.RunID, s.historyBranchUtil)
 	setSnapshot, _ := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -1761,7 +1725,6 @@ func (s *ExecutionMutableStateSuite) TestSet_Conflict() {
 	)
 
 	setSnapshot, _ := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -1793,7 +1756,6 @@ func (s *ExecutionMutableStateSuite) TestSet() {
 	)
 
 	setSnapshot, _ := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -1847,7 +1809,6 @@ func (s *ExecutionMutableStateSuite) TestDeleteCurrent_IsCurrent() {
 func (s *ExecutionMutableStateSuite) TestDeleteCurrent_NotCurrent() {
 	branchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, s.RunID, s.historyBranchUtil)
 	newSnapshot, newEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -1895,7 +1856,6 @@ func (s *ExecutionMutableStateSuite) TestDeleteCurrent_NotCurrent() {
 func (s *ExecutionMutableStateSuite) TestDelete_Exists() {
 	branchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, s.RunID, s.historyBranchUtil)
 	newSnapshot, newEvents := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -1951,7 +1911,6 @@ func (s *ExecutionMutableStateSuite) CreateWorkflow(
 ) ([]byte, *p.WorkflowSnapshot, []*p.WorkflowEvents) {
 	branchToken := RandomBranchToken(s.NamespaceID, s.WorkflowID, s.RunID, s.historyBranchUtil)
 	snapshot, events := RandomSnapshot(
-		s.T(),
 		s.NamespaceID,
 		s.WorkflowID,
 		s.RunID,
@@ -2076,7 +2035,6 @@ func (s *ExecutionMutableStateSuite) Accumulate(
 		RequestCancelInfos:  snapshot.RequestCancelInfos,
 		SignalInfos:         snapshot.SignalInfos,
 		SignalRequestedIds:  convert.StringSetToSlice(snapshot.SignalRequestedIDs),
-		ChasmNodes:          snapshot.ChasmNodes,
 	}
 	dbRecordVersion := snapshot.DBRecordVersion
 
@@ -2090,48 +2048,54 @@ func (s *ExecutionMutableStateSuite) Accumulate(
 		mutableState.NextEventId = mutation.NextEventID
 
 		// activity infos
-		maps.Copy(mutableState.ActivityInfos, mutation.UpsertActivityInfos)
+		for key, info := range mutation.UpsertActivityInfos {
+			mutableState.ActivityInfos[key] = info
+		}
 		for key := range mutation.DeleteActivityInfos {
 			delete(mutableState.ActivityInfos, key)
 		}
 
 		// timer infos
-		maps.Copy(mutableState.TimerInfos, mutation.UpsertTimerInfos)
+		for key, info := range mutation.UpsertTimerInfos {
+			mutableState.TimerInfos[key] = info
+		}
 		for key := range mutation.DeleteTimerInfos {
 			delete(mutableState.TimerInfos, key)
 		}
 
 		// child workflow infos
-		maps.Copy(mutableState.ChildExecutionInfos, mutation.UpsertChildExecutionInfos)
+		for key, info := range mutation.UpsertChildExecutionInfos {
+			mutableState.ChildExecutionInfos[key] = info
+		}
 		for key := range mutation.DeleteChildExecutionInfos {
 			delete(mutableState.ChildExecutionInfos, key)
 		}
 
 		// request cancel infos
-		maps.Copy(mutableState.RequestCancelInfos, mutation.UpsertRequestCancelInfos)
+		for key, info := range mutation.UpsertRequestCancelInfos {
+			mutableState.RequestCancelInfos[key] = info
+		}
 		for key := range mutation.DeleteRequestCancelInfos {
 			delete(mutableState.RequestCancelInfos, key)
 		}
 
 		// signal infos
-		maps.Copy(mutableState.SignalInfos, mutation.UpsertSignalInfos)
+		for key, info := range mutation.UpsertSignalInfos {
+			mutableState.SignalInfos[key] = info
+		}
 		for key := range mutation.DeleteSignalInfos {
 			delete(mutableState.SignalInfos, key)
 		}
 
 		// signal request IDs
 		signalRequestIDs := convert.StringSliceToSet(mutableState.SignalRequestedIds)
-		maps.Copy(signalRequestIDs, mutation.UpsertSignalRequestedIDs)
+		for key, info := range mutation.UpsertSignalRequestedIDs {
+			signalRequestIDs[key] = info
+		}
 		for key := range mutation.DeleteSignalRequestedIDs {
 			delete(signalRequestIDs, key)
 		}
 		mutableState.SignalRequestedIds = convert.StringSetToSlice(signalRequestIDs)
-
-		// chasm nodes
-		maps.Copy(mutableState.ChasmNodes, mutation.UpsertChasmNodes)
-		for key := range mutation.DeleteChasmNodes {
-			delete(mutableState.ChasmNodes, key)
-		}
 
 		// buffered events
 		if mutation.ClearBufferedEvents {
@@ -2169,9 +2133,6 @@ func (s *ExecutionMutableStateSuite) Accumulate(
 	}
 	if mutableState.BufferedEvents == nil {
 		mutableState.BufferedEvents = make([]*historypb.HistoryEvent, 0)
-	}
-	if mutableState.ChasmNodes == nil {
-		mutableState.ChasmNodes = make(map[string]*persistencespb.ChasmNode)
 	}
 
 	return mutableState, dbRecordVersion

--- a/schema/cassandra/temporal/schema.cql
+++ b/schema/cassandra/temporal/schema.cql
@@ -42,8 +42,6 @@ CREATE TABLE executions (
   signal_map                     map<bigint, blob>,
   signal_map_encoding            text,
   signal_requested               set<uuid>,
-  chasm_node_map                 map<text, blob>, -- Map from path to CHASM node blob
-  chasm_node_map_encoding        text,
   buffered_events_list           list<frozen<serialized_event_batch>>,
   workflow_last_write_version    bigint,
   workflow_state                 int,

--- a/schema/cassandra/temporal/versioned/v1.12/chasm_node_map.cql
+++ b/schema/cassandra/temporal/versioned/v1.12/chasm_node_map.cql
@@ -1,3 +1,0 @@
-ALTER TABLE executions ADD chasm_node_map map<text, blob>;
-ALTER TABLE executions ADD chasm_node_map_encoding text;
-

--- a/schema/cassandra/temporal/versioned/v1.12/manifest.json
+++ b/schema/cassandra/temporal/versioned/v1.12/manifest.json
@@ -1,6 +1,0 @@
-{
-  "CurrVersion": "1.12",
-  "MinCompatibleVersion": "1.0",
-  "Description": "Add the chasm_node_map to the executions table",
-  "SchemaUpdateCqlFiles": ["chasm_node_map.cql"]
-}

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -27,4 +27,4 @@ package cassandra
 // NOTE: whenever there is a new database schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "1.12"
+const Version = "1.11"

--- a/service/history/workflow/metrics.go
+++ b/service/history/workflow/metrics.go
@@ -86,7 +86,6 @@ func emitMutableStateStatus(
 	metrics.TotalSignalCount.With(batchHandler).Record(stats.TotalSignalCount)
 	metrics.BufferedEventsSize.With(batchHandler).Record(int64(stats.BufferedEventsSize))
 	metrics.BufferedEventsCount.With(batchHandler).Record(int64(stats.BufferedEventsCount))
-	metrics.ChasmTotalSize.With(batchHandler).Record(int64(stats.ChasmTotalSize))
 
 	if stats.HistoryStatistics != nil {
 		metrics.HistorySize.With(batchHandler).Record(int64(stats.HistoryStatistics.SizeDiff))


### PR DESCRIPTION
This reverts commit 5385b99301ac436a17569ba29740cdd097e4b28d.

CDS tests are broken unless all columns are updated in lockstep:

https://github.com/temporalio/saas-temporal/actions/runs/13938361013/job/39010690272?pr=3111#step:6:1563

Reverting
