### PR TITLE
Lint fixes for priority

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,8 +43,6 @@ linters-settings:
     forbid:
       - p: time.Sleep
         msg: "Please use require.Eventually or assert.Eventually instead unless you've no other option"
-      - p: ^time\.After$
-        msg: "time.After may leak resources. Use time.NewTimer instead."
   importas:
     # Enforce the aliases below.
     no-unaliased: true

--- a/common/persistence/cassandra/matching_task_store.go
+++ b/common/persistence/cassandra/matching_task_store.go
@@ -170,7 +170,7 @@ const (
 // 00000100: task in subqueue 1
 // nnnnnn00: task in subqueue n, etc.
 func rowTypeTaskInSubqueue(subqueue int) int {
-	return subqueue<<2 | rowTypeTask
+	return subqueue<<2 | rowTypeTask // nolint:staticcheck
 }
 
 type (

--- a/service/matching/ack_manager.go
+++ b/service/matching/ack_manager.go
@@ -118,7 +118,7 @@ func (m *ackManager) setAckLevel(ackLevel int64) {
 	}
 }
 
-func (m *ackManager) completeTask(taskID int64) (int64, int64) {
+func (m *ackManager) completeTask(taskID int64) (newAckLevel, numberOfAckedTasks int64) {
 	m.Lock()
 	defer m.Unlock()
 
@@ -139,7 +139,6 @@ func (m *ackManager) completeTask(taskID int64) (int64, int64) {
 	m.backlogCountHint.Add(-1)
 
 	// Adjust the ack level as far as we can
-	var numberOfAckedTasks int64
 	for {
 		min, acked := m.outstandingTasks.Min()
 		if min == nil || !acked.(bool) {

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -83,9 +83,9 @@ func (s *BacklogManagerTestSuite) SetupTest() {
 
 	if s.newMatcher {
 		s.blm = newPriBacklogManager(
+			ctx,
 			s.ptqMgr,
 			tlCfg,
-			ctx,
 			s.taskMgr,
 			s.logger,
 			s.logger,

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -511,9 +511,11 @@ func (db *taskQueueDB) cachedQueueInfo() *persistencespb.TaskQueueInfo {
 // should be enabled. Additionally, for versioned queues, BreakdownMetricsByBuildID should also be enabled.
 func (db *taskQueueDB) emitBacklogGauges() {
 	// TODO(pri): need to revisit this for subqueues
+	// nolint:staticcheck
 	shouldEmitGauges := db.config.BreakdownMetricsByTaskQueue() &&
 		db.config.BreakdownMetricsByPartition() &&
 		(!db.queue.IsVersioned() || db.config.BreakdownMetricsByBuildID())
+	// nolint:staticcheck
 	if shouldEmitGauges {
 		// approximateBacklogCount := db.getApproximateBacklogCount()
 		// backlogHeadAge := db.backlogMgr.BacklogHeadAge()

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -448,7 +448,7 @@ func (s *MatcherDataSuite) TestPollForwardFailedTimedOut() {
 		s.NotNil(tres.poller)
 		// there's a new task in the meantime
 		s.md.EnqueueTaskNoWait(t2)
-		time.Sleep(11 * time.Millisecond)
+		time.Sleep(11 * time.Millisecond) // nolint:forbidigo
 		// but we waited too long, poller timed out, so this does nothing (but doesn't crash or assert)
 		s.md.ReenqueuePollerIfNotMatched(tres.poller)
 		done <- struct{}{}
@@ -584,7 +584,6 @@ func FuzzMatcherData(f *testing.F) {
 		ts.UseAsyncTimers(true)
 		logger := testlogger.NewTestLogger(f, testlogger.FailOnAnyUnexpectedError)
 		md := newMatcherData(cfg, logger, ts, true)
-		_ = md
 
 		next := func() int {
 			if len(tape) == 0 {
@@ -601,10 +600,11 @@ func FuzzMatcherData(f *testing.F) {
 		var pollForwarders, taskForwarders atomic.Int64
 		const ops = 20
 
+	loop:
 		for {
 			switch (next() + 1) % ops {
 			case 0:
-				return
+				break loop
 
 			case 1: // add backlog task
 				tid++
@@ -637,7 +637,7 @@ func FuzzMatcherData(f *testing.F) {
 					defer cancel()
 					md.EnqueuePollerAndWait([]context.Context{ctx}, &waitingPoller{
 						startTime:    ts.Now(),
-						forwardCtx:   ctx, // FIXME: not always forwardable?
+						forwardCtx:   ctx, // TODO: not always forwardable?
 						pollMetadata: &pollMetadata{},
 						queryOnly:    queryOnly,
 					})

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -201,9 +201,9 @@ func newPhysicalTaskQueueManager(
 
 	if newMatcher {
 		pqMgr.backlogMgr = newPriBacklogManager(
+			tqCtx,
 			pqMgr,
 			config,
-			tqCtx,
 			e.taskManager,
 			logger,
 			throttledLogger,

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -92,9 +92,9 @@ type (
 var _ backlogManager = (*priBacklogManagerImpl)(nil)
 
 func newPriBacklogManager(
+	tqCtx context.Context,
 	pqMgr physicalTaskQueueManager,
 	config *taskQueueConfig,
-	tqCtx context.Context,
 	taskManager persistence.TaskManager,
 	logger log.Logger,
 	throttledLogger log.ThrottledLogger,
@@ -177,13 +177,13 @@ func (c *priBacklogManagerImpl) WaitUntilInitialized(ctx context.Context) error 
 func (c *priBacklogManagerImpl) loadSubqueuesLocked(subqueues []persistencespb.SubqueueInfo) {
 	// TODO(pri): This assumes that subqueues never shrinks, and priority/fairness index of
 	// existing subqueues never changes. If we change that, this logic will need to change.
-	for i, s := range subqueues {
+	for i := range subqueues {
 		if i >= len(c.subqueues) {
-			r := newPriTaskReader(c, i, s.AckLevel)
+			r := newPriTaskReader(c, i, subqueues[i].AckLevel)
 			r.Start()
 			c.subqueues = append(c.subqueues, r)
 		}
-		c.subqueuesByPriority[s.Key.Priority] = i
+		c.subqueuesByPriority[subqueues[i].Key.Priority] = i
 	}
 }
 


### PR DESCRIPTION
## What changed?
- A few lint fixes.
- Remove forbid warning about time.After, this is no longer true in Go 1.23.
