### PR TITLE
Reduce max proto duration cap to 100 years

### DIFF
--- a/common/primitives/timestamp/duration.go
+++ b/common/primitives/timestamp/duration.go
@@ -31,8 +31,9 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-// 250 years. Maximum representable golang time.Duration is approximately 290 years (INT64_MAX * time.Nanosecond)
-const maxAllowedDuration = 250 * 365 * 24 * time.Hour
+// 100 years. Maximum representable golang time.Duration is approximately 290 years (INT64_MAX * time.Nanosecond)
+// ElasticSearch only supports datetimes up to 2262, so cap at 100 years to be safe.
+const maxAllowedDuration = 100 * 365 * 24 * time.Hour
 
 var (
 	errNegativeDuration = fmt.Errorf("negative duration")


### PR DESCRIPTION
## What changed?
Reduced max proto duration cap from 250 to 100 years.

## Why?
ElasticSearch can only handle datetimes up to ~2262

## How did you test it?
Existing tests
