### PR TITLE
Add new SDKs as supported client

### DIFF
--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -43,6 +43,8 @@ const (
 	ClientNamePHPSDK        = "temporal-php"
 	ClientNameTypeScriptSDK = "temporal-typescript"
 	ClientNamePythonSDK     = "temporal-python"
+	ClientNameDotNet        = "temporal-dotnet"
+	ClientNameRuby          = "temporal-ruby"
 	ClientNameCLI           = "temporal-cli"
 	ClientNameUI            = "temporal-ui"
 	ClientNameNexusGoSDK    = "Nexus-go-sdk"
@@ -72,6 +74,9 @@ var (
 		ClientNameJavaSDK:       "<2.0.0",
 		ClientNamePHPSDK:        "<2.0.0",
 		ClientNameTypeScriptSDK: "<2.0.0",
+		ClientNamePythonSDK:     "<2.0.0",
+		ClientNameDotNet:        "<2.0.0",
+		ClientNameRuby:          "<2.0.0",
 		ClientNameCLI:           "<2.0.0",
 		ClientNameServer:        "<2.0.0",
 		ClientNameUI:            "<3.0.0",


### PR DESCRIPTION
## What changed?
Add temporal-dotnet and temporal-ruby as supported SDKs

## Why?
<!-- Tell your future self why have you made these changes -->
Temporal dotnet SDK is available at https://github.com/temporalio/sdk-dotnet
Temporal Ruby SDK is available (still WIP) at https://github.com/temporalio/sdk-ruby
