### PR TITLE
Use OperatorHandler interface in fx graph

### DIFF
--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -143,7 +143,7 @@ func NewServiceProvider(
 	httpAPIServer *HTTPAPIServer,
 	handler Handler,
 	adminHandler *AdminHandler,
-	operatorHandler *OperatorHandlerImpl,
+	operatorHandler OperatorHandler,
 	versionChecker *VersionChecker,
 	visibilityMgr manager.VisibilityManager,
 	logger log.SnTaggedLogger,
@@ -684,7 +684,7 @@ func OperatorHandlerProvider(
 	clientFactory client.Factory,
 	namespaceRegistry namespace.Registry,
 	nexusEndpointClient *NexusEndpointClient,
-) *OperatorHandlerImpl {
+) OperatorHandler {
 	args := NewOperatorHandlerImplArgs{
 		configuration,
 		esClient,
@@ -843,7 +843,7 @@ func HTTPAPIServerProvider(
 	grpcListener net.Listener,
 	tlsConfigProvider encryption.TLSConfigProvider,
 	handler Handler,
-	operatorHandler *OperatorHandlerImpl,
+	operatorHandler OperatorHandler,
 	grpcServerOptions GrpcServerOptions,
 	metricsHandler metrics.Handler,
 	namespaceRegistry namespace.Registry,

--- a/service/frontend/http_api_server.go
+++ b/service/frontend/http_api_server.go
@@ -96,7 +96,7 @@ func NewHTTPAPIServer(
 	grpcListener net.Listener,
 	tlsConfigProvider encryption.TLSConfigProvider,
 	handler Handler,
-	operatorHandler *OperatorHandlerImpl,
+	operatorHandler OperatorHandler,
 	interceptors []grpc.UnaryServerInterceptor,
 	metricsHandler metrics.Handler,
 	router *mux.Router,

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -396,7 +396,7 @@ type Service struct {
 	healthServer      *health.Server
 	handler           Handler
 	adminHandler      *AdminHandler
-	operatorHandler   *OperatorHandlerImpl
+	operatorHandler   OperatorHandler
 	versionChecker    *VersionChecker
 	visibilityManager manager.VisibilityManager
 	server            *grpc.Server
@@ -415,7 +415,7 @@ func NewService(
 	httpAPIServer *HTTPAPIServer,
 	handler Handler,
 	adminHandler *AdminHandler,
-	operatorHandler *OperatorHandlerImpl,
+	operatorHandler OperatorHandler,
 	versionChecker *VersionChecker,
 	visibilityMgr manager.VisibilityManager,
 	logger log.Logger,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Replaced the concrete implementation `OperatorHandlerImpl` with the `OperatorHandler` interface in the dependency graph.

## Why?
<!-- Tell your future self why have you made these changes -->
To allow custom implementations of `OperatorHandler`

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Service won't start if there are issues with the dependency graph

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
