### PR TITLE
Make target to update major versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,13 @@ $(STAMPDIR)/gowrap-$(GOWRAP_VER): | $(STAMPDIR) $(LOCALBIN)
 	@touch $@
 $(GOWRAP): $(STAMPDIR)/gowrap-$(GOWRAP_VER)
 
+GOMAJOR_VER := v0.14.0
+GOMAJOR := $(LOCALBIN)/gomajor
+$(STAMPDIR)/gomajor-$(GOMAJOR_VER): | $(STAMPDIR) $(LOCALBIN)
+	$(call go-install-tool,$(GOMAJOR),github.com/icholy/gomajor,$(GOMAJOR_VER))
+	@touch $@
+$(GOMAJOR): $(STAMPDIR)/gomajor-$(GOMAJOR_VER)
+
 # Mockgen is called by name throughout the codebase, so we need to keep the binary name consistent
 MOCKGEN_VER := v0.4.0
 MOCKGEN := $(LOCALBIN)/mockgen
@@ -575,8 +582,16 @@ gomodtidy:
 	@go mod tidy
 
 update-dependencies:
-	@printf $(COLOR) "Update dependencies..."
+	@printf $(COLOR) "Update dependencies (minor versions only) ..."
 	@go get -u -t $(PINNED_DEPENDENCIES) ./...
+	@go mod tidy
+
+update-dependencies-major: $(GOMAJOR)
+	@printf $(COLOR) "Major version upgrades available:"
+	@$(GOMAJOR) list -major
+	@echo ""
+	@printf $(COLOR) "Update dependencies (major versions only) ..."
+	@$(GOMAJOR) get -major all
 	@go mod tidy
 
 go-generate: $(MOCKGEN) $(GOIMPORTS) $(STRINGER) $(GOWRAP)


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Added Makefile target `update-dependencies-major`.

It lists all _major_ version upgrades and performs them; compared to `update-dependencies` which only updates _minor_ versions.

## Why?
<!-- Tell your future self why have you made these changes -->

To assess major version upgrades and perform them, if needed.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Example output:

```
Major version upgrades available:
github.com/golang-jwt/jwt/v4: v4.5.1 [latest v5.2.2]
github.com/sony/gobreaker: v1.0.0 [latest v2.1.0]
github.com/urfave/cli: v1.22.16 [latest v2.27.6]

Update dependencies (major versions only) ...
go get github.com/golang-jwt/jwt/v5@v5.2.2
go: added github.com/golang-jwt/jwt/v5 v5.2.2
common/authorization/default_jwt_claim_mapper.go:32:2 github.com/golang-jwt/jwt/v5
common/authorization/default_jwt_claim_mapper_test.go:37:2 github.com/golang-jwt/jwt/v5
common/authorization/default_token_key_provider.go:38:2 github.com/golang-jwt/jwt/v5
common/authorization/token_key_provider.go:32:2 github.com/golang-jwt/jwt/v5
go get github.com/sony/gobreaker/v2@v2.1.0
go: added github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f
go: added github.com/go-redsync/redsync/v4 v4.13.0
go: added github.com/hashicorp/errwrap v1.1.0
go: added github.com/hashicorp/go-multierror v1.1.1
go: added github.com/redis/go-redis/v9 v9.7.0
go: added github.com/sony/gobreaker/v2 v2.1.0
common/circuitbreaker/circuitbreaker.go:29:2 github.com/sony/gobreaker/v2
service/history/api/describeworkflow/api.go:33:2 github.com/sony/gobreaker/v2
go get github.com/urfave/cli/v2@v2.27.6
go: upgraded github.com/urfave/cli/v2 v2.27.5 => v2.27.6
tools/cassandra/handler.go:31:2 github.com/urfave/cli/v2
tools/cassandra/main.go:31:2 github.com/urfave/cli/v2
tools/common/schema/handler.go:32:2 github.com/urfave/cli/v2
tools/common/schema/test/setuptest.go:34:2 github.com/urfave/cli/v2
tools/common/schema/test/updatetest.go:35:2 github.com/urfave/cli/v2
tools/sql/handler.go:32:2 github.com/urfave/cli/v2
```

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
