### PR TITLE
Preparing for go 1.24 - remove rand.Seed from tests

### DIFF
--- a/common/backoff/retrypolicy.go
+++ b/common/backoff/retrypolicy.go
@@ -51,7 +51,6 @@ var (
 	DisabledRetryPolicy RetryPolicy = &disabledRetryPolicyImpl{}
 
 	// common 'globalToFile' rand instance, used in adding jitter to next interval in retry policy
-	//jitterRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 	jitterRand atomic.Pointer[rand.Rand]
 )
 

--- a/common/backoff/retrypolicy_test.go
+++ b/common/backoff/retrypolicy_test.go
@@ -47,7 +47,8 @@ type (
 // maximum interval of 10 seconds. Keep in mind that there is a random jitter in these times, so they are not exactly
 // what you'd expect.
 func ExampleExponentialRetryPolicy_WithMaximumInterval() {
-	rand.Seed(42)
+	jitterRand = rand.New(rand.NewSource(42))
+
 	p1 := NewExponentialRetryPolicy(time.Second).
 		WithBackoffCoefficient(2.0).
 		WithMaximumInterval(0).

--- a/common/backoff/retrypolicy_test.go
+++ b/common/backoff/retrypolicy_test.go
@@ -47,7 +47,7 @@ type (
 // maximum interval of 10 seconds. Keep in mind that there is a random jitter in these times, so they are not exactly
 // what you'd expect.
 func ExampleExponentialRetryPolicy_WithMaximumInterval() {
-	jitterRand = rand.New(rand.NewSource(42))
+	jitterRand.Store(rand.New(rand.NewSource(42)))
 
 	p1 := NewExponentialRetryPolicy(time.Second).
 		WithBackoffCoefficient(2.0).


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Subj.
Replace rand.Seed with `rand.New(rand.NewSource`

## Why?
<!-- Tell your future self why have you made these changes -->
rand.Seed will be no-op in 1.24. and tests using rand.Seed will start failing.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No, current rand.Seed/rand.Intn implementation is a wrapper around globalRand singleton.