### PR TITLE
disable RSA key length error in test

### DIFF
--- a/tests/testutils/tls.go
+++ b/tests/testutils/tls.go
@@ -133,7 +133,7 @@ func GenerateSelfSignedCAPool(caCert *tls.Certificate) (*x509.CertPool, error) {
 }
 
 func GenerateSelfSignedCA(filePath string) (*tls.Certificate, error) {
-	caCert, err := generateSelfSignedX509CA("undefined", nil, 512)
+	caCert, err := generateSelfSignedX509CA("undefined", nil, 1024)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/tls_test.go
+++ b/tests/tls_test.go
@@ -45,11 +45,12 @@ type TLSFunctionalSuite struct {
 }
 
 func TestTLSFunctionalSuite(t *testing.T) {
-	t.Parallel()
+	// can't use Parallel with Setenv
 	suite.Run(t, new(TLSFunctionalSuite))
 }
 
 func (s *TLSFunctionalSuite) SetupSuite() {
+	s.T().Setenv("GODEBUG", "rsa1024min=0")
 	s.FunctionalTestBase.SetupSuiteWithCluster("testdata/tls_cluster.yaml")
 }
 

--- a/tests/tls_test.go
+++ b/tests/tls_test.go
@@ -45,12 +45,11 @@ type TLSFunctionalSuite struct {
 }
 
 func TestTLSFunctionalSuite(t *testing.T) {
-	// can't use Parallel with Setenv
+	t.Parallel()
 	suite.Run(t, new(TLSFunctionalSuite))
 }
 
 func (s *TLSFunctionalSuite) SetupSuite() {
-	s.T().Setenv("GODEBUG", "rsa1024min=0")
 	s.FunctionalTestBase.SetupSuiteWithCluster("testdata/tls_cluster.yaml")
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
We use 512 key in tests, this generate an error in go 1.24 for some reason.
 `rsa1024min=0` GODEBUG setting suppresses this error.
We already use it in other places in the code.

Also removed t.Parallel()

## Why?
<!-- Tell your future self why have you made these changes -->
Otherwise go 1.24 generate and error in func test.
t.Parallel() can't be used with t.Setenv

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
By running test with go 1.24

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
None.
Though we probably should be using same key length we use in prod.
