### PR TITLE
[Reset] Set flags for replication

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -6527,6 +6527,7 @@ func (ms *MutableStateImpl) cleanupTransaction() error {
 	ms.visibilityUpdated = false
 	ms.executionStateUpdated = false
 	ms.workflowTaskUpdated = false
+	ms.isResetStateUpdated = false
 	ms.updateInfoUpdated = make(map[string]struct{})
 	ms.timerInfosUserDataUpdated = make(map[string]struct{})
 	ms.activityInfosUserDataUpdated = make(map[int64]struct{})

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -226,6 +226,9 @@ type (
 		activityInfosUserDataUpdated map[int64]struct{}
 		timerInfosUserDataUpdated    map[string]struct{}
 
+		// isResetStateUpdated is used to track if resetRunID is updated.
+		isResetStateUpdated bool
+
 		// in memory fields to track potential reapply events that needs to be reapplied during workflow update
 		// should only be used in the state based replication as state based replication does not have
 		// event inside history builder. This is only for x-run reapply (from zombie wf to current wf)
@@ -822,6 +825,7 @@ func (ms *MutableStateImpl) SetBaseWorkflow(
 }
 
 func (ms *MutableStateImpl) UpdateResetRunID(runID string) {
+	ms.isResetStateUpdated = true
 	ms.executionInfo.ResetRunId = runID
 }
 
@@ -839,6 +843,7 @@ func (ms *MutableStateImpl) IsResetRun() bool {
 
 func (ms *MutableStateImpl) SetChildrenInitializedPostResetPoint(children map[string]*persistencespb.ResetChildInfo) {
 	ms.executionInfo.ChildrenInitializedPostResetPoint = children
+	ms.isResetStateUpdated = true
 }
 
 func (ms *MutableStateImpl) GetChildrenInitializedPostResetPoint() map[string]*persistencespb.ResetChildInfo {
@@ -5785,7 +5790,8 @@ func (ms *MutableStateImpl) isStateDirty() bool {
 		ms.executionStateUpdated ||
 		ms.workflowTaskUpdated ||
 		(ms.stateMachineNode != nil && ms.stateMachineNode.Dirty()) ||
-		ms.chasmTree.IsDirty()
+		ms.chasmTree.IsDirty() ||
+		ms.isResetStateUpdated
 }
 
 func (ms *MutableStateImpl) IsTransitionHistoryEnabled() bool {


### PR DESCRIPTION
## What changed?
This PR sets the dirty flags so that we can correctly replicate the state changes related to Reset operation. 

## Why?
In most cases when a workflow is reset, the corresponding state changes will be replicated since there are other changes in the workflow that would trigger a sync. However, in the cases when we reset a workflow that was already closes/terminated, there won't be any other state changes made in the workflow that will trigger a replication. With this change we take care of replicating the state when there are any reset related stat changes.

Note that I'll be using `isResetStateUpdated` to cover a few additional fields in an upcoming PR. So kept the flag name generic. 

## How did you test it?
1. Setup local XDC with cluster-a & cluster-b.
2. Make cluster-a active.
3. Reset a closed workflow.
4. Inspect the `executions.execution` column from the cluster-b DB. Verify that the `resetRunId` field is correctly replicated.

Additionally verified that without this change the `resetRunId` field is in fact not replicated to cluster-b.

## Potential risks
N/A

## Documentation
N/A

## Is hotfix candidate?
No
