### PR TITLE
Handle OTEL shutdown timeout

### DIFF
--- a/common/testing/otellogger/otellogger.go
+++ b/common/testing/otellogger/otellogger.go
@@ -1,0 +1,89 @@
+// The MIT License
+//
+// Copyright (c) 2025 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package otellogger
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+
+	ctrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	trace "go.opentelemetry.io/proto/otlp/trace/v1"
+	"go.temporal.io/server/common/testing/freeport"
+	"google.golang.org/grpc"
+)
+
+type OTELLogger struct {
+	ctrace.UnimplementedTraceServiceServer
+	addr      string
+	spansLock sync.RWMutex
+	spans     []*trace.ResourceSpans
+}
+
+func Start(tb testing.TB) (*OTELLogger, error) {
+	grpcServer := grpc.NewServer()
+	l := &OTELLogger{
+		addr: fmt.Sprintf("localhost:%d", freeport.MustGetFreePort()),
+	}
+	ctrace.RegisterTraceServiceServer(grpcServer, l)
+
+	listener, err := net.Listen("tcp", l.addr)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		if err := grpcServer.Serve(listener); err != nil {
+			tb.Errorf("OTEL logger failed to start: %v", err)
+		}
+	}()
+
+	go func() {
+		<-tb.Context().Done()
+		grpcServer.Stop()
+	}()
+
+	return l, nil
+}
+
+func (l *OTELLogger) Addr() string {
+	return "http://" + l.addr
+}
+
+func (l *OTELLogger) Spans() []*trace.ResourceSpans {
+	l.spansLock.RLock()
+	defer l.spansLock.RUnlock()
+	return l.spans
+}
+
+func (l *OTELLogger) Export(
+	ctx context.Context,
+	request *ctrace.ExportTraceServiceRequest,
+) (*ctrace.ExportTraceServiceResponse, error) {
+	l.spansLock.Lock()
+	defer l.spansLock.Unlock()
+	l.spans = append(l.spans, request.ResourceSpans...)
+	return &ctrace.ExportTraceServiceResponse{}, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.34.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.5.0
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/dig v1.18.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect

--- a/temporal/server_test.go
+++ b/temporal/server_test.go
@@ -73,7 +73,10 @@ func TestNewServerWithOTEL(t *testing.T) {
 
 func startAndStopServer(t *testing.T) {
 	cfg := loadConfig(t)
-	cfg.Global.Metrics.Prometheus.ListenAddress = ":0" // prometheus reporter does not shut down in-between test runs
+	// The prometheus reporter does not shut down in-between test runs.
+	// This will assign a random port to the prometheus reporter,
+	// so that it doesn't conflict with other tests.
+	cfg.Global.Metrics.Prometheus.ListenAddress = ":0"
 	logDetector := newErrorLogDetector(t, log.NewTestLogger())
 	logDetector.Start()
 

--- a/temporal/server_test.go
+++ b/temporal/server_test.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite" // needed to register the sqlite plugin
+	"go.temporal.io/server/common/testing/otellogger"
 	"go.temporal.io/server/service/frontend"
 	"go.temporal.io/server/temporal"
 	"go.temporal.io/server/tests/testutils"
@@ -48,9 +49,31 @@ import (
 // TestNewServer verifies that NewServer doesn't cause any fx errors, and that there are no unexpected error logs after
 // running for a few seconds.
 func TestNewServer(t *testing.T) {
-	t.Parallel()
+	startAndStopServer(t)
+}
 
+// TestNewServerWithOTEL verifies that NewServer doesn't cause any fx errors when OTEL is enabled.
+func TestNewServerWithOTEL(t *testing.T) {
+	t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
+	t.Setenv("OTEL_BSP_SCHEDULE_DELAY", "100")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_INSECURE", "true")
+
+	t.Run("with OTEL Collector running", func(t *testing.T) {
+		otelLogger, err := otellogger.Start(t)
+		require.NoError(t, err)
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", otelLogger.Addr())
+		startAndStopServer(t)
+		require.NotEmpty(t, otelLogger.Spans(), "expected at least one OTEL span")
+	})
+
+	t.Run("without OTEL Collector running", func(t *testing.T) {
+		startAndStopServer(t)
+	})
+}
+
+func startAndStopServer(t *testing.T) {
 	cfg := loadConfig(t)
+	cfg.Global.Metrics.Prometheus.ListenAddress = ":0" // prometheus reporter does not shut down in-between test runs
 	logDetector := newErrorLogDetector(t, log.NewTestLogger())
 	logDetector.Start()
 
@@ -61,12 +84,14 @@ func TestNewServer(t *testing.T) {
 		temporal.WithChainedFrontendGrpcInterceptors(getFrontendInterceptors()),
 	)
 	require.NoError(t, err)
+
 	t.Cleanup(func() {
 		logDetector.Stop()
 		assert.NoError(t, server.Stop())
 	})
+
 	require.NoError(t, server.Start())
-	time.Sleep(10 * time.Second)
+	time.Sleep(10 * time.Second) //nolint:forbidigo
 }
 
 func loadConfig(t *testing.T) *config.Config {
@@ -159,6 +184,7 @@ func (d *errorLogDetector) Warn(msg string, tags ...tag.Tag) {
 	for _, s := range []string{
 		"error creating sdk client",
 		"Failed to poll for task",
+		"OTEL error", // logged when OTEL collector is not running
 	} {
 		if strings.Contains(msg, s) {
 			return


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Gracefully handling the case where the OTEL trace provider shutdown times out.

Before this change, it would propagate the "context deadline exceeded" error to fx and it would fail the entire functional test. But now it swallows that error on shutdown.

## Why?
<!-- Tell your future self why have you made these changes -->

Failure to shut down OTEL should not affect the functional test outcome.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
