### PR TITLE
downgrade go version to 1.23.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.temporal.io/server
 
-go 1.24.1
+go 1.23.2
 
 retract (
 	v1.26.1 // Contains retractions only.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
see title.
Not a revert - all changes for preparation for 1.24 are still valid.

## Why?
<!-- Tell your future self why have you made these changes -->
other (internal, cloud) repositories are not ready to move to 1.24