### PR TITLE
CHASM: include library name in fully qualified component/task type name

### DIFF
--- a/chasm/export_test.go
+++ b/chasm/export_test.go
@@ -39,3 +39,11 @@ func (r *Registry) ComponentFor(componentInstance any) (*RegistrableComponent, b
 func (r *Registry) TaskFor(taskInstance any) (*RegistrableTask, bool) {
 	return r.taskFor(taskInstance)
 }
+
+func (rc RegistrableComponent) FqType() string {
+	return rc.fqType()
+}
+
+func (rt RegistrableTask) FqType() string {
+	return rt.fqType()
+}

--- a/chasm/library.go
+++ b/chasm/library.go
@@ -28,7 +28,7 @@ package chasm
 
 type (
 	Library interface {
-		Namer
+		Name() string
 		Components() []*RegistrableComponent
 		Tasks() []*RegistrableTask
 		// Service()
@@ -38,7 +38,7 @@ type (
 
 	UnimplementedLibrary struct{}
 
-	Namer interface {
+	namer interface {
 		Name() string
 	}
 )

--- a/chasm/library.go
+++ b/chasm/library.go
@@ -28,7 +28,7 @@ package chasm
 
 type (
 	Library interface {
-		Name() string
+		Namer
 		Components() []*RegistrableComponent
 		Tasks() []*RegistrableTask
 		// Service()
@@ -37,6 +37,10 @@ type (
 	}
 
 	UnimplementedLibrary struct{}
+
+	Namer interface {
+		Name() string
+	}
 )
 
 func (UnimplementedLibrary) Components() []*RegistrableComponent {
@@ -48,3 +52,7 @@ func (UnimplementedLibrary) Tasks() []*RegistrableTask {
 }
 
 func (UnimplementedLibrary) mustEmbedUnimplementedLibrary() {}
+
+func fullyQualifiedName(libName, name string) string {
+	return libName + "." + name
+}

--- a/chasm/library_mock.go
+++ b/chasm/library_mock.go
@@ -116,3 +116,41 @@ func (mr *MockLibraryMockRecorder) mustEmbedUnimplementedLibrary() *gomock.Call 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "mustEmbedUnimplementedLibrary", reflect.TypeOf((*MockLibrary)(nil).mustEmbedUnimplementedLibrary))
 }
+
+// MockNamer is a mock of Namer interface.
+type MockNamer struct {
+	ctrl     *gomock.Controller
+	recorder *MockNamerMockRecorder
+	isgomock struct{}
+}
+
+// MockNamerMockRecorder is the mock recorder for MockNamer.
+type MockNamerMockRecorder struct {
+	mock *MockNamer
+}
+
+// NewMockNamer creates a new mock instance.
+func NewMockNamer(ctrl *gomock.Controller) *MockNamer {
+	mock := &MockNamer{ctrl: ctrl}
+	mock.recorder = &MockNamerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockNamer) EXPECT() *MockNamerMockRecorder {
+	return m.recorder
+}
+
+// Name mocks base method.
+func (m *MockNamer) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockNamerMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockNamer)(nil).Name))
+}

--- a/chasm/library_mock.go
+++ b/chasm/library_mock.go
@@ -117,32 +117,32 @@ func (mr *MockLibraryMockRecorder) mustEmbedUnimplementedLibrary() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "mustEmbedUnimplementedLibrary", reflect.TypeOf((*MockLibrary)(nil).mustEmbedUnimplementedLibrary))
 }
 
-// MockNamer is a mock of Namer interface.
-type MockNamer struct {
+// Mocknamer is a mock of namer interface.
+type Mocknamer struct {
 	ctrl     *gomock.Controller
-	recorder *MockNamerMockRecorder
+	recorder *MocknamerMockRecorder
 	isgomock struct{}
 }
 
-// MockNamerMockRecorder is the mock recorder for MockNamer.
-type MockNamerMockRecorder struct {
-	mock *MockNamer
+// MocknamerMockRecorder is the mock recorder for Mocknamer.
+type MocknamerMockRecorder struct {
+	mock *Mocknamer
 }
 
-// NewMockNamer creates a new mock instance.
-func NewMockNamer(ctrl *gomock.Controller) *MockNamer {
-	mock := &MockNamer{ctrl: ctrl}
-	mock.recorder = &MockNamerMockRecorder{mock}
+// NewMocknamer creates a new mock instance.
+func NewMocknamer(ctrl *gomock.Controller) *Mocknamer {
+	mock := &Mocknamer{ctrl: ctrl}
+	mock.recorder = &MocknamerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockNamer) EXPECT() *MockNamerMockRecorder {
+func (m *Mocknamer) EXPECT() *MocknamerMockRecorder {
 	return m.recorder
 }
 
 // Name mocks base method.
-func (m *MockNamer) Name() string {
+func (m *Mocknamer) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
@@ -150,7 +150,7 @@ func (m *MockNamer) Name() string {
 }
 
 // Name indicates an expected call of Name.
-func (mr *MockNamerMockRecorder) Name() *gomock.Call {
+func (mr *MocknamerMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockNamer)(nil).Name))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*Mocknamer)(nil).Name))
 }

--- a/chasm/registrable_component.go
+++ b/chasm/registrable_component.go
@@ -31,6 +31,7 @@ import (
 type (
 	RegistrableComponent struct {
 		componentType string
+		library       Namer
 		goType        reflect.Type
 
 		ephemeral     bool
@@ -43,10 +44,12 @@ type (
 
 func NewRegistrableComponent[C Component](
 	componentType string,
+	lib Namer,
 	opts ...RegistrableComponentOption,
 ) *RegistrableComponent {
 	rc := &RegistrableComponent{
 		componentType: componentType,
+		library:       lib,
 		goType:        reflect.TypeFor[C](),
 		shardingFn:    defaultShardingFn,
 	}
@@ -77,6 +80,9 @@ func WithShardingFn(
 	}
 }
 
+// Type returns the fully qualified name of the component, which is a combination of
+// the library name and the component type. This is used to uniquely identify
+// the component in the registry.
 func (rc RegistrableComponent) Type() string {
-	return rc.componentType
+	return fullyQualifiedName(rc.library.Name(), rc.componentType)
 }

--- a/chasm/registrable_component.go
+++ b/chasm/registrable_component.go
@@ -31,7 +31,7 @@ import (
 type (
 	RegistrableComponent struct {
 		componentType string
-		library       Namer
+		library       namer
 		goType        reflect.Type
 
 		ephemeral     bool
@@ -78,10 +78,10 @@ func WithShardingFn(
 	}
 }
 
-// Type returns the fully qualified name of the component, which is a combination of
+// fqType returns the fully qualified name of the component, which is a combination of
 // the library name and the component type. This is used to uniquely identify
 // the component in the registry.
-func (rc RegistrableComponent) Type() string {
+func (rc RegistrableComponent) fqType() string {
 	if rc.library == nil {
 		// this should never happen because the component is only accessible from the library.
 		panic("component is not registered to a library")

--- a/chasm/registrable_component.go
+++ b/chasm/registrable_component.go
@@ -44,12 +44,10 @@ type (
 
 func NewRegistrableComponent[C Component](
 	componentType string,
-	lib Namer,
 	opts ...RegistrableComponentOption,
 ) *RegistrableComponent {
 	rc := &RegistrableComponent{
 		componentType: componentType,
-		library:       lib,
 		goType:        reflect.TypeFor[C](),
 		shardingFn:    defaultShardingFn,
 	}
@@ -84,5 +82,9 @@ func WithShardingFn(
 // the library name and the component type. This is used to uniquely identify
 // the component in the registry.
 func (rc RegistrableComponent) Type() string {
+	if rc.library == nil {
+		// this should never happen because the component is only accessible from the library.
+		panic("component is not registered to a library")
+	}
 	return fullyQualifiedName(rc.library.Name(), rc.componentType)
 }

--- a/chasm/registrable_task.go
+++ b/chasm/registrable_task.go
@@ -43,13 +43,11 @@ type (
 // NOTE: C is not Component but any.
 func NewRegistrableTask[C any, T any](
 	taskType string,
-	lib Namer,
 	handler TaskHandler[C, T],
 	opts ...RegistrableTaskOption,
 ) *RegistrableTask {
 	rt := &RegistrableTask{
 		taskType:        taskType,
-		library:         lib,
 		goType:          reflect.TypeFor[T](),
 		componentGoType: reflect.TypeFor[C](),
 		handler:         handler,
@@ -63,6 +61,10 @@ func NewRegistrableTask[C any, T any](
 // Type returns the fully qualified name of the task, which is a combination of
 // the library name and the task type. This is used to uniquely identify
 // the task in the registry.
-func (rc RegistrableTask) Type() string {
-	return fullyQualifiedName(rc.library.Name(), rc.taskType)
+func (rt RegistrableTask) Type() string {
+	if rt.library == nil {
+		// this should never happen because the task is only accessible from the library.
+		panic("task is not registered to a library")
+	}
+	return fullyQualifiedName(rt.library.Name(), rt.taskType)
 }

--- a/chasm/registrable_task.go
+++ b/chasm/registrable_task.go
@@ -31,6 +31,7 @@ import (
 type (
 	RegistrableTask struct {
 		taskType        string
+		library         Namer
 		goType          reflect.Type
 		componentGoType reflect.Type // It is not clear how this one is used.
 		handler         any
@@ -42,11 +43,13 @@ type (
 // NOTE: C is not Component but any.
 func NewRegistrableTask[C any, T any](
 	taskType string,
+	lib Namer,
 	handler TaskHandler[C, T],
 	opts ...RegistrableTaskOption,
 ) *RegistrableTask {
 	rt := &RegistrableTask{
 		taskType:        taskType,
+		library:         lib,
 		goType:          reflect.TypeFor[T](),
 		componentGoType: reflect.TypeFor[C](),
 		handler:         handler,
@@ -57,6 +60,9 @@ func NewRegistrableTask[C any, T any](
 	return rt
 }
 
-func (rt RegistrableTask) Type() string {
-	return rt.taskType
+// Type returns the fully qualified name of the task, which is a combination of
+// the library name and the task type. This is used to uniquely identify
+// the task in the registry.
+func (rc RegistrableTask) Type() string {
+	return fullyQualifiedName(rc.library.Name(), rc.taskType)
 }

--- a/chasm/registrable_task.go
+++ b/chasm/registrable_task.go
@@ -31,7 +31,7 @@ import (
 type (
 	RegistrableTask struct {
 		taskType        string
-		library         Namer
+		library         namer
 		goType          reflect.Type
 		componentGoType reflect.Type // It is not clear how this one is used.
 		handler         any
@@ -58,10 +58,10 @@ func NewRegistrableTask[C any, T any](
 	return rt
 }
 
-// Type returns the fully qualified name of the task, which is a combination of
+// fqType returns the fully qualified name of the task, which is a combination of
 // the library name and the task type. This is used to uniquely identify
 // the task in the registry.
-func (rt RegistrableTask) Type() string {
+func (rt RegistrableTask) fqType() string {
 	if rt.library == nil {
 		// this should never happen because the task is only accessible from the library.
 		panic("task is not registered to a library")

--- a/chasm/registry.go
+++ b/chasm/registry.go
@@ -60,12 +60,12 @@ func (r *Registry) Register(lib Library) error {
 		return err
 	}
 	for _, c := range lib.Components() {
-		if err := r.registerComponent(lib.Name(), c); err != nil {
+		if err := r.registerComponent(lib, c); err != nil {
 			return err
 		}
 	}
 	for _, t := range lib.Tasks() {
-		if err := r.registerTask(lib.Name(), t); err != nil {
+		if err := r.registerTask(lib, t); err != nil {
 			return err
 		}
 	}
@@ -93,15 +93,18 @@ func (r *Registry) taskFor(taskInstance any) (*RegistrableTask, bool) {
 }
 
 func (r *Registry) registerComponent(
-	libName string,
+	lib Namer,
 	rc *RegistrableComponent,
 ) error {
 	if err := r.validateName(rc.componentType); err != nil {
 		return err
 	}
-	fqn := fullyQualifiedName(libName, rc.componentType)
+	fqn := fullyQualifiedName(lib.Name(), rc.componentType)
 	if _, ok := r.componentByType[fqn]; ok {
 		return fmt.Errorf("component %s is already registered", fqn)
+	}
+	if rc.library != nil {
+		return fmt.Errorf("component %s is already registered in library %s", fqn, rc.library.Name())
 	}
 	// rc.goType implements Component interface; therefore, it must be a struct.
 	// This check to protect against the interface itself being registered.
@@ -112,20 +115,25 @@ func (r *Registry) registerComponent(
 	if _, ok := r.componentByGoType[rc.goType]; ok {
 		return fmt.Errorf("component type %s is already registered", rc.goType.String())
 	}
+
+	rc.library = lib
 	r.componentByType[fqn] = rc
 	r.componentByGoType[rc.goType] = rc
 	return nil
 }
 func (r *Registry) registerTask(
-	libName string,
+	lib Namer,
 	rt *RegistrableTask,
 ) error {
 	if err := r.validateName(rt.taskType); err != nil {
 		return err
 	}
-	fqn := fullyQualifiedName(libName, rt.taskType)
+	fqn := fullyQualifiedName(lib.Name(), rt.taskType)
 	if _, ok := r.taskByType[fqn]; ok {
 		return fmt.Errorf("task %s is already registered", fqn)
+	}
+	if rt.library != nil {
+		return fmt.Errorf("task %s is already registered in library %s", fqn, rt.library.Name())
 	}
 	if !(rt.goType.Kind() == reflect.Struct ||
 		(rt.goType.Kind() == reflect.Ptr && rt.goType.Elem().Kind() == reflect.Struct)) {
@@ -141,6 +149,7 @@ func (r *Registry) registerTask(
 		return fmt.Errorf("component type %s must be and interface or struct that implements Component interface", rt.componentGoType.String())
 	}
 
+	rt.library = lib
 	r.taskByType[fqn] = rt
 	r.taskByGoType[rt.goType] = rt
 	return nil

--- a/chasm/registry.go
+++ b/chasm/registry.go
@@ -92,10 +92,6 @@ func (r *Registry) taskFor(taskInstance any) (*RegistrableTask, bool) {
 	return rt, ok
 }
 
-func (r *Registry) fqn(libName, name string) string {
-	return libName + "." + name
-}
-
 func (r *Registry) registerComponent(
 	libName string,
 	rc *RegistrableComponent,
@@ -103,7 +99,7 @@ func (r *Registry) registerComponent(
 	if err := r.validateName(rc.componentType); err != nil {
 		return err
 	}
-	fqn := r.fqn(libName, rc.componentType)
+	fqn := fullyQualifiedName(libName, rc.componentType)
 	if _, ok := r.componentByType[fqn]; ok {
 		return fmt.Errorf("component %s is already registered", fqn)
 	}
@@ -127,7 +123,7 @@ func (r *Registry) registerTask(
 	if err := r.validateName(rt.taskType); err != nil {
 		return err
 	}
-	fqn := r.fqn(libName, rt.taskType)
+	fqn := fullyQualifiedName(libName, rt.taskType)
 	if _, ok := r.taskByType[fqn]; ok {
 		return fmt.Errorf("task %s is already registered", fqn)
 	}

--- a/chasm/registry.go
+++ b/chasm/registry.go
@@ -93,7 +93,7 @@ func (r *Registry) taskFor(taskInstance any) (*RegistrableTask, bool) {
 }
 
 func (r *Registry) registerComponent(
-	lib Namer,
+	lib namer,
 	rc *RegistrableComponent,
 ) error {
 	if err := r.validateName(rc.componentType); err != nil {
@@ -122,7 +122,7 @@ func (r *Registry) registerComponent(
 	return nil
 }
 func (r *Registry) registerTask(
-	lib Namer,
+	lib namer,
 	rt *RegistrableTask,
 ) error {
 	if err := r.validateName(rt.taskType); err != nil {

--- a/chasm/registry_test.go
+++ b/chasm/registry_test.go
@@ -56,7 +56,7 @@ func TestRegistry_RegisterComponents_Success(t *testing.T) {
 
 	rc1, ok := r.Component("TestLibrary.Component1")
 	require.True(t, ok)
-	require.Equal(t, "TestLibrary.Component1", rc1.Type())
+	require.Equal(t, "TestLibrary.Component1", rc1.FqType())
 
 	missingRC, ok := r.Component("TestLibrary.Component2")
 	require.False(t, ok)
@@ -65,7 +65,7 @@ func TestRegistry_RegisterComponents_Success(t *testing.T) {
 	cInstance1 := chasm.NewMockComponent(ctrl)
 	rc2, ok := r.ComponentFor(cInstance1)
 	require.True(t, ok)
-	require.Equal(t, "TestLibrary.Component1", rc2.Type())
+	require.Equal(t, "TestLibrary.Component1", rc2.FqType())
 
 	cInstance2 := "invalid component instance"
 	rc3, ok := r.ComponentFor(cInstance2)
@@ -90,7 +90,7 @@ func TestRegistry_RegisterTasks_Success(t *testing.T) {
 
 	rt1, ok := r.Task("TestLibrary.Task1")
 	require.True(t, ok)
-	require.Equal(t, "TestLibrary.Task1", rt1.Type())
+	require.Equal(t, "TestLibrary.Task1", rt1.FqType())
 
 	missingRT, ok := r.Task("TestLibrary.TaskMissing")
 	require.False(t, ok)
@@ -99,7 +99,7 @@ func TestRegistry_RegisterTasks_Success(t *testing.T) {
 	tInstance1 := testTask2{}
 	rt2, ok := r.TaskFor(tInstance1)
 	require.True(t, ok)
-	require.Equal(t, "TestLibrary.Task2", rt2.Type())
+	require.Equal(t, "TestLibrary.Task2", rt2.FqType())
 
 	tInstance2 := "invalid task instance"
 	rt3, ok := r.TaskFor(tInstance2)

--- a/chasm/test_library_test.go
+++ b/chasm/test_library_test.go
@@ -38,9 +38,9 @@ func (l *TestLibrary) Name() string {
 
 func (l *TestLibrary) Components() []*RegistrableComponent {
 	return []*RegistrableComponent{
-		NewRegistrableComponent[*TestComponent]("test_component"),
-		NewRegistrableComponent[*TestSubComponent1]("test_sub_component_1"),
-		NewRegistrableComponent[*TestSubComponent11]("test_sub_component_11"),
-		NewRegistrableComponent[*TestSubComponent2]("test_sub_component_2"),
+		NewRegistrableComponent[*TestComponent]("test_component", l),
+		NewRegistrableComponent[*TestSubComponent1]("test_sub_component_1", l),
+		NewRegistrableComponent[*TestSubComponent11]("test_sub_component_11", l),
+		NewRegistrableComponent[*TestSubComponent2]("test_sub_component_2", l),
 	}
 }

--- a/chasm/test_library_test.go
+++ b/chasm/test_library_test.go
@@ -38,9 +38,9 @@ func (l *TestLibrary) Name() string {
 
 func (l *TestLibrary) Components() []*RegistrableComponent {
 	return []*RegistrableComponent{
-		NewRegistrableComponent[*TestComponent]("test_component", l),
-		NewRegistrableComponent[*TestSubComponent1]("test_sub_component_1", l),
-		NewRegistrableComponent[*TestSubComponent11]("test_sub_component_11", l),
-		NewRegistrableComponent[*TestSubComponent2]("test_sub_component_2", l),
+		NewRegistrableComponent[*TestComponent]("test_component"),
+		NewRegistrableComponent[*TestSubComponent1]("test_sub_component_1"),
+		NewRegistrableComponent[*TestSubComponent11]("test_sub_component_11"),
+		NewRegistrableComponent[*TestSubComponent2]("test_sub_component_2"),
 	}
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
CHASM: include library name in fully qualified component/task type name.

## Why?
<!-- Tell your future self why have you made these changes -->
Type of `RegistrableComponent` is stored inside `ChasmNode.Metadata` and required to look up go type for proper deserialization. Therefore returned value must be fully qualified type name, not just type name.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Modified existing unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.