### PR TITLE
[CHASM] Generate InternalChasmNode.CassandraBlob for CDS

### DIFF
--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -1198,7 +1198,7 @@ func (m *executionManagerImpl) makeInternalChasmNodeMap(
 	nodes map[string]*persistencespb.ChasmNode,
 ) (map[string]InternalChasmNode, error) {
 	res := make(map[string]InternalChasmNode, len(nodes))
-	isCassandra := strings.Contains(m.GetName(), "cassandra")
+	isCassandra := strings.Contains(m.GetName(), "cassandra") || strings.Contains(m.GetName(), "cds")
 
 	for path, node := range nodes {
 		var internal InternalChasmNode


### PR DESCRIPTION
## What changed?
- When serializing InternalWorkflowSnapshot/InternalWorkflowMutation, we must set the Cassandra field for the CDS engine as well as our built-in Cassandra engine.

## Why?
- CDS [will expect the Cassandra blob to be set](https://github.com/temporalio/saas-temporal/pull/3249), persisting the whole blob directly.

