### PR TITLE
Add active cache eviction for history service

### DIFF
--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -73,6 +73,18 @@ type Options struct {
 	// TimeSource is an optional clock to use for time-skipping and testing. If this is nil, a real clock will be used.
 	TimeSource clock.TimeSource
 
+	// ActiveEviction creates background worker that will periodically remove expired elements from cache.
+	// Once true, caller must call Close() on cache wen it's no more used to avoid memory leaks.
+	ActiveEviction bool
+
+	// ActiveEvictionInterval sets interval between eviction runs.
+	// Defaults to [DefaultActiveEvictionInterval] if not set.
+	ActiveEvictionInterval time.Duration
+
+	// ActiveEvictionMaxElements sets maximum count of elements to be removed via single eviction iteration.
+	// Defaults to [DefaultActiveEvictionMaxElements] if not set.
+	ActiveEvictionMaxElements int
+
 	OnPut func(val any)
 
 	OnEvict func(val any)

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -56,6 +56,9 @@ type Cache interface {
 	// Size returns current size of the Cache, the size definition is implementation of SizeGetter interface
 	// for the entry size, if the entry does not implement SizeGetter interface, the size is 1
 	Size() int
+
+	// Close releases underlying resources of the Cache, such as background workers etc.
+	Close()
 }
 
 // Options control the behavior of the cache.

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -110,4 +110,6 @@ type Entry interface {
 	Value() interface{}
 	// CreateTime represents the time when the entry is created
 	CreateTime() time.Time
+	// ExpireTime represent the time when emtry will be considered expired
+	ExpireTime() time.Time
 }

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -33,8 +33,8 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/goro"
 	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/internal/goro"
 )
 
 var (

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -505,6 +505,7 @@ func (c *lru) evictExpired(maxElements int) {
 	now := c.timeSource.Now().UTC()
 	element := c.byAccess.Back()
 	for i := 0; i < maxElements; i++ {
+		//nolint:revive // It's always *entryImpl, no need to check that explicitly.
 		entry := element.Value.(*entryImpl)
 		if !c.isEntryExpired(entry, now) {
 			break

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -342,7 +342,6 @@ func (c *lru) putInternal(key interface{}, value interface{}, allowUpdate bool) 
 				}
 				existingEntry.value = value
 				existingEntry.size = newEntrySize
-				existingEntry.createTime = c.timeSource.Now().UTC()
 				c.currSize = newCacheSize
 				metrics.CacheUsage.With(c.metricsHandler).Record(float64(c.currSize))
 				c.updateEntryTTL(existingEntry)

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -222,6 +222,7 @@ func (c *lru) Get(key interface{}) interface{} {
 		return nil
 	}
 
+	c.updateEntryTTL(entry)
 	c.updateEntryRefCount(entry)
 	c.byAccess.MoveToFront(element)
 	return entry.value

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -190,6 +190,10 @@ func NewLRU(maxSize int, handler metrics.Handler) Cache {
 	return New(maxSize, nil)
 }
 
+func (c *lru) Close() {
+	// Nothing to do yet.
+}
+
 // Get retrieves the value stored under the given key
 func (c *lru) Get(key interface{}) interface{} {
 	if c.maxSize == 0 { //

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -269,11 +269,13 @@ func TestTTLWithPin(t *testing.T) {
 	cache.Release("A")
 	snapshot = capture.Snapshot()
 	assert.Equal(t, float64(0), snapshot[metrics.CachePinnedUsage.Name()][0].Value)
+	capture = metricsHandler.StartCapture()
+	// advance time since previous Get had extendend entry lifetime
+	timeSource.Advance(time.Millisecond * 100)
 	assert.Nil(t, cache.Get("A"))
 	assert.Equal(t, 0, cache.Size())
 	snapshot = capture.Snapshot()
-	// cache.Release() will emit cacheUsage 3 times. cache.Get() will emit cacheUsage once.
-	assert.Equal(t, float64(0), snapshot[metrics.CacheUsage.Name()][3].Value)
+	assert.Equal(t, float64(0), snapshot[metrics.CacheUsage.Name()][0].Value)
 }
 
 func TestMaxSizeWithPin_MidItem(t *testing.T) {

--- a/common/cache/simple.go
+++ b/common/cache/simple.go
@@ -92,6 +92,11 @@ func (e *simpleEntry) CreateTime() time.Time {
 	return DummyCreateTime
 }
 
+// ExpireTime is not implemented for simple cache entries
+func (e *simpleEntry) ExpireTime() time.Time {
+	return DummyCreateTime
+}
+
 // NewSimple creates a new simple cache with given options.
 // Simple cache will never evict entries and it will never reorder the elements.
 // Simple cache also does not have the concept of pinning that LRU cache has.

--- a/common/cache/simple.go
+++ b/common/cache/simple.go
@@ -108,6 +108,10 @@ func NewSimple(opts *SimpleOptions) Cache {
 	}
 }
 
+func (c *simple) Close() {
+	// Nothing to do.
+}
+
 // Get retrieves the value stored under the given key
 func (c *simple) Get(key interface{}) interface{} {
 	c.RLock()

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1467,6 +1467,21 @@ This can help reduce effects of shard movement.`,
 		time.Hour,
 		`EventsCacheTTL is TTL of events cache`,
 	)
+	EnableEventsChacheActiveEviction = NewGlobalBoolSetting(
+		"history.enableEventsCacheActiveEviction",
+		false,
+		`EnableEventsChacheActiveEviction controls if active eviction enabled for events cache`,
+	)
+	EventsCacheActiveEvictionInterval = NewGlobalDurationSetting(
+		"history.eventsCacheActiveEvictionInterval",
+		5*time.Second,
+		`EventsCacheActiveEvictionInterval is interval of expire element eviction for events cache`,
+	)
+	EventsCacheActiveEvictionMaxElements = NewGlobalIntSetting(
+		"history.eventsCacheActiveEvictionMaxElements",
+		32,
+		`EventsCacheActiveEvictionMaxElements is max number of expired elements to be evicted from events cache on active eviction iteration`,
+	)
 	EnableHostLevelEventsCache = NewGlobalBoolSetting(
 		"history.enableHostLevelEventsCache",
 		false,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1396,6 +1396,21 @@ HistoryCacheSizeBasedLimit is set to true.`,
 		time.Hour,
 		`HistoryCacheTTL is TTL of history cache`,
 	)
+	EnableHistoryChacheActiveEviction = NewGlobalBoolSetting(
+		"history.enableCacheActiveEviction",
+		false,
+		`EnableHistoryChacheActiveEviction controls if active eviction enabled for history cache`,
+	)
+	HistoryCacheActiveEvictionInterval = NewGlobalDurationSetting(
+		"history.cacheActiveEvictionInterval",
+		5*time.Second,
+		`HistoryCacheActiveEvictionInterval is interval of expire element eviction for history cache`,
+	)
+	HistoryCacheActiveEvictionMaxElements = NewGlobalIntSetting(
+		"history.cacheActiveEvictionMaxElements",
+		32,
+		`HistoryCacheActiveEvictionMaxElements is max number of expired elements to be evicted from history cache on active eviction iteration`,
+	)
 	HistoryCacheNonUserContextLockTimeout = NewGlobalDurationSetting(
 		"history.cacheNonUserContextLockTimeout",
 		500*time.Millisecond,

--- a/common/namespace/nsregistry/registry.go
+++ b/common/namespace/nsregistry/registry.go
@@ -207,8 +207,6 @@ func (r *registry) Stop() {
 	defer atomic.StoreInt32(&r.status, stopped)
 	r.refresher.Cancel()
 	<-r.refresher.Done()
-	r.cacheByID.Close()
-	r.cacheNameToID.Close()
 	r.readthroughNotFoundCache.Close()
 }
 

--- a/common/namespace/nsregistry/registry.go
+++ b/common/namespace/nsregistry/registry.go
@@ -207,6 +207,9 @@ func (r *registry) Stop() {
 	defer atomic.StoreInt32(&r.status, stopped)
 	r.refresher.Cancel()
 	<-r.refresher.Done()
+	r.cacheByID.Close()
+	r.cacheNameToID.Close()
+	r.readthroughNotFoundCache.Close()
 }
 
 func (r *registry) GetPingChecks() []pingable.Check {

--- a/common/nexus/endpoint_registry.go
+++ b/common/nexus/endpoint_registry.go
@@ -143,6 +143,7 @@ func (r *EndpointRegistryImpl) StartLifecycle() {
 func (r *EndpointRegistryImpl) StopLifecycle() {
 	r.cancelDcSub()
 	r.setEnabled(false)
+	r.readThroughCacheByID.Close()
 }
 
 func (r *EndpointRegistryImpl) setEnabled(enabled bool) {

--- a/common/persistence/client/fx.go
+++ b/common/persistence/client/fx.go
@@ -104,12 +104,15 @@ func ClusterNameProvider(config *cluster.Config) ClusterName {
 func EventBlobCacheProvider(
 	dc *dynamicconfig.Collection,
 	logger log.Logger,
+	lc fx.Lifecycle,
 ) persistence.XDCCache {
-	return persistence.NewEventsBlobCache(
+	c := persistence.NewEventsBlobCache(
 		dynamicconfig.XDCCacheMaxSizeBytes.Get(dc)(),
 		20*time.Second,
 		logger,
 	)
+	lc.Append(fx.StopHook(c.Close))
+	return c
 }
 
 func FactoryProvider(

--- a/common/persistence/xdc_cache.go
+++ b/common/persistence/xdc_cache.go
@@ -57,6 +57,7 @@ type (
 	XDCCache interface {
 		Put(key XDCCacheKey, value XDCCacheValue)
 		Get(key XDCCacheKey) (XDCCacheValue, bool)
+		Close()
 	}
 
 	XDCCacheImpl struct {
@@ -157,6 +158,10 @@ func (e *XDCCacheImpl) Get(key XDCCacheKey) (XDCCacheValue, bool) {
 		return XDCCacheValue{}, false
 	}
 	return value.(XDCCacheValue), true
+}
+
+func (e *XDCCacheImpl) Close() {
+	e.cache.Close()
 }
 
 func GetXDCCacheValue(

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -73,19 +73,22 @@ type Config struct {
 
 	// HistoryCache settings
 	// Change of these configs require shard restart
-	HistoryCacheLimitSizeBased            bool
-	HistoryCacheInitialSize               dynamicconfig.IntPropertyFn
-	HistoryShardLevelCacheMaxSize         dynamicconfig.IntPropertyFn
-	HistoryShardLevelCacheMaxSizeBytes    dynamicconfig.IntPropertyFn
-	HistoryHostLevelCacheMaxSize          dynamicconfig.IntPropertyFn
-	HistoryHostLevelCacheMaxSizeBytes     dynamicconfig.IntPropertyFn
-	HistoryCacheTTL                       dynamicconfig.DurationPropertyFn
-	HistoryCacheNonUserContextLockTimeout dynamicconfig.DurationPropertyFn
-	EnableHostLevelHistoryCache           dynamicconfig.BoolPropertyFn
-	EnableNexus                           dynamicconfig.BoolPropertyFn
-	EnableWorkflowExecutionTimeoutTimer   dynamicconfig.BoolPropertyFn
-	EnableTransitionHistory               dynamicconfig.BoolPropertyFn
-	MaxCallbacksPerWorkflow               dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistoryCacheLimitSizeBased             bool
+	HistoryCacheInitialSize                dynamicconfig.IntPropertyFn
+	HistoryShardLevelCacheMaxSize          dynamicconfig.IntPropertyFn
+	HistoryShardLevelCacheMaxSizeBytes     dynamicconfig.IntPropertyFn
+	HistoryHostLevelCacheMaxSize           dynamicconfig.IntPropertyFn
+	HistoryHostLevelCacheMaxSizeBytes      dynamicconfig.IntPropertyFn
+	HistoryCacheTTL                        dynamicconfig.DurationPropertyFn
+	EnableHistoryChacheActiveEviction      dynamicconfig.BoolPropertyFn
+	HistoryChacheActiveEvictionInterval    dynamicconfig.DurationPropertyFn
+	HistoryChacheActiveEvictionMaxElements dynamicconfig.IntPropertyFn
+	HistoryCacheNonUserContextLockTimeout  dynamicconfig.DurationPropertyFn
+	EnableHostLevelHistoryCache            dynamicconfig.BoolPropertyFn
+	EnableNexus                            dynamicconfig.BoolPropertyFn
+	EnableWorkflowExecutionTimeoutTimer    dynamicconfig.BoolPropertyFn
+	EnableTransitionHistory                dynamicconfig.BoolPropertyFn
+	MaxCallbacksPerWorkflow                dynamicconfig.IntPropertyFnWithNamespaceFilter
 
 	// EventsCache settings
 	// Change of these configs require shard restart
@@ -430,19 +433,22 @@ func NewConfig(
 
 		EmitShardLagLog: dynamicconfig.EmitShardLagLog.Get(dc),
 		// HistoryCacheLimitSizeBased should not change during runtime.
-		HistoryCacheLimitSizeBased:            dynamicconfig.HistoryCacheSizeBasedLimit.Get(dc)(),
-		HistoryCacheInitialSize:               dynamicconfig.HistoryCacheInitialSize.Get(dc),
-		HistoryShardLevelCacheMaxSize:         dynamicconfig.HistoryCacheMaxSize.Get(dc),
-		HistoryShardLevelCacheMaxSizeBytes:    dynamicconfig.HistoryCacheMaxSizeBytes.Get(dc),
-		HistoryHostLevelCacheMaxSize:          dynamicconfig.HistoryCacheHostLevelMaxSize.Get(dc),
-		HistoryHostLevelCacheMaxSizeBytes:     dynamicconfig.HistoryCacheHostLevelMaxSizeBytes.Get(dc),
-		HistoryCacheTTL:                       dynamicconfig.HistoryCacheTTL.Get(dc),
-		HistoryCacheNonUserContextLockTimeout: dynamicconfig.HistoryCacheNonUserContextLockTimeout.Get(dc),
-		EnableHostLevelHistoryCache:           dynamicconfig.EnableHostHistoryCache.Get(dc),
-		EnableNexus:                           dynamicconfig.EnableNexus.Get(dc),
-		EnableWorkflowExecutionTimeoutTimer:   dynamicconfig.EnableWorkflowExecutionTimeoutTimer.Get(dc),
-		EnableTransitionHistory:               dynamicconfig.EnableTransitionHistory.Get(dc),
-		MaxCallbacksPerWorkflow:               dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
+		HistoryCacheLimitSizeBased:             dynamicconfig.HistoryCacheSizeBasedLimit.Get(dc)(),
+		HistoryCacheInitialSize:                dynamicconfig.HistoryCacheInitialSize.Get(dc),
+		HistoryShardLevelCacheMaxSize:          dynamicconfig.HistoryCacheMaxSize.Get(dc),
+		HistoryShardLevelCacheMaxSizeBytes:     dynamicconfig.HistoryCacheMaxSizeBytes.Get(dc),
+		HistoryHostLevelCacheMaxSize:           dynamicconfig.HistoryCacheHostLevelMaxSize.Get(dc),
+		HistoryHostLevelCacheMaxSizeBytes:      dynamicconfig.HistoryCacheHostLevelMaxSizeBytes.Get(dc),
+		HistoryCacheTTL:                        dynamicconfig.HistoryCacheTTL.Get(dc),
+		EnableHistoryChacheActiveEviction:      dynamicconfig.EnableHistoryChacheActiveEviction.Get(dc),
+		HistoryChacheActiveEvictionInterval:    dynamicconfig.HistoryCacheActiveEvictionInterval.Get(dc),
+		HistoryChacheActiveEvictionMaxElements: dynamicconfig.HistoryCacheActiveEvictionMaxElements.Get(dc),
+		HistoryCacheNonUserContextLockTimeout:  dynamicconfig.HistoryCacheNonUserContextLockTimeout.Get(dc),
+		EnableHostLevelHistoryCache:            dynamicconfig.EnableHostHistoryCache.Get(dc),
+		EnableNexus:                            dynamicconfig.EnableNexus.Get(dc),
+		EnableWorkflowExecutionTimeoutTimer:    dynamicconfig.EnableWorkflowExecutionTimeoutTimer.Get(dc),
+		EnableTransitionHistory:                dynamicconfig.EnableTransitionHistory.Get(dc),
+		MaxCallbacksPerWorkflow:                dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
 
 		EventsShardLevelCacheMaxSizeBytes:     dynamicconfig.EventsCacheMaxSizeBytes.Get(dc),          // 512KB
 		EventsHostLevelCacheMaxSizeBytes:      dynamicconfig.EventsHostLevelCacheMaxSizeBytes.Get(dc), // 256MB

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -89,8 +89,11 @@ type Config struct {
 
 	// EventsCache settings
 	// Change of these configs require shard restart
-	EventsShardLevelCacheMaxSizeBytes dynamicconfig.IntPropertyFn
-	EventsCacheTTL                    dynamicconfig.DurationPropertyFn
+	EventsShardLevelCacheMaxSizeBytes     dynamicconfig.IntPropertyFn
+	EventsCacheTTL                        dynamicconfig.DurationPropertyFn
+	EnableEventsChacheActiveEviction      dynamicconfig.BoolPropertyFn
+	EventsChacheActiveEvictionInterval    dynamicconfig.DurationPropertyFn
+	EventsChacheActiveEvictionMaxElements dynamicconfig.IntPropertyFn
 	// Change of these configs require service restart
 	EnableHostLevelEventsCache       dynamicconfig.BoolPropertyFn
 	EventsHostLevelCacheMaxSizeBytes dynamicconfig.IntPropertyFn
@@ -441,10 +444,13 @@ func NewConfig(
 		EnableTransitionHistory:               dynamicconfig.EnableTransitionHistory.Get(dc),
 		MaxCallbacksPerWorkflow:               dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
 
-		EventsShardLevelCacheMaxSizeBytes: dynamicconfig.EventsCacheMaxSizeBytes.Get(dc),          // 512KB
-		EventsHostLevelCacheMaxSizeBytes:  dynamicconfig.EventsHostLevelCacheMaxSizeBytes.Get(dc), // 256MB
-		EventsCacheTTL:                    dynamicconfig.EventsCacheTTL.Get(dc),
-		EnableHostLevelEventsCache:        dynamicconfig.EnableHostLevelEventsCache.Get(dc),
+		EventsShardLevelCacheMaxSizeBytes:     dynamicconfig.EventsCacheMaxSizeBytes.Get(dc),          // 512KB
+		EventsHostLevelCacheMaxSizeBytes:      dynamicconfig.EventsHostLevelCacheMaxSizeBytes.Get(dc), // 256MB
+		EventsCacheTTL:                        dynamicconfig.EventsCacheTTL.Get(dc),
+		EnableEventsChacheActiveEviction:      dynamicconfig.EnableEventsChacheActiveEviction.Get(dc),
+		EventsChacheActiveEvictionInterval:    dynamicconfig.EventsCacheActiveEvictionInterval.Get(dc),
+		EventsChacheActiveEvictionMaxElements: dynamicconfig.EventsCacheActiveEvictionMaxElements.Get(dc),
+		EnableHostLevelEventsCache:            dynamicconfig.EnableHostLevelEventsCache.Get(dc),
 
 		RangeSizeBits: 20, // 20 bits for sequencer, 2^20 sequence number for any range
 

--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -85,7 +85,17 @@ func NewHostLevelEventsCache(
 	logger log.Logger,
 	disabled bool,
 ) Cache {
-	return newEventsCache(executionManager, handler, logger, config.EventsHostLevelCacheMaxSizeBytes(), config.EventsCacheTTL(), disabled)
+	return newEventsCache(
+		executionManager,
+		handler,
+		logger,
+		config.EventsHostLevelCacheMaxSizeBytes(),
+		config.EventsCacheTTL(),
+		config.EnableEventsChacheActiveEviction(),
+		config.EventsChacheActiveEvictionInterval(),
+		config.EventsChacheActiveEvictionMaxElements(),
+		disabled,
+	)
 }
 
 func NewShardLevelEventsCache(
@@ -95,7 +105,17 @@ func NewShardLevelEventsCache(
 	logger log.Logger,
 	disabled bool,
 ) Cache {
-	return newEventsCache(executionManager, handler, logger, config.EventsShardLevelCacheMaxSizeBytes(), config.EventsCacheTTL(), disabled)
+	return newEventsCache(
+		executionManager,
+		handler,
+		logger,
+		config.EventsShardLevelCacheMaxSizeBytes(),
+		config.EventsCacheTTL(),
+		config.EnableEventsChacheActiveEviction(),
+		config.EventsChacheActiveEvictionInterval(),
+		config.EventsChacheActiveEvictionMaxElements(),
+		disabled,
+	)
 }
 
 func newEventsCache(
@@ -104,10 +124,17 @@ func newEventsCache(
 	logger log.Logger,
 	maxSize int,
 	ttl time.Duration,
+	activeEviction bool,
+	activeEvictionInterval time.Duration,
+	ActiveEvictionMaxElements int,
 	disabled bool,
 ) *CacheImpl {
-	opts := &cache.Options{}
-	opts.TTL = ttl
+	opts := &cache.Options{
+		TTL:                       ttl,
+		ActiveEviction:            activeEviction,
+		ActiveEvictionInterval:    activeEvictionInterval,
+		ActiveEvictionMaxElements: ActiveEvictionMaxElements,
+	}
 
 	taggedMetricHandler := metricsHandler.WithTags(metrics.CacheTypeTag(metrics.EventsCacheTypeTagValue))
 	return &CacheImpl{

--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -56,6 +56,7 @@ type (
 		GetEvent(ctx context.Context, shardID int32, key EventKey, firstEventID int64, branchToken []byte) (*historypb.HistoryEvent, error)
 		PutEvent(key EventKey, event *historypb.HistoryEvent)
 		DeleteEvent(key EventKey)
+		Close()
 	}
 
 	CacheImpl struct {

--- a/service/history/events/cache_test.go
+++ b/service/history/events/cache_test.go
@@ -90,6 +90,9 @@ func (s *eventsCacheSuite) newTestEventsCache() *CacheImpl {
 		s.logger,
 		32,
 		time.Minute,
+		false,
+		0,
+		0,
 		false)
 }
 

--- a/service/history/events/events_cache_mock.go
+++ b/service/history/events/events_cache_mock.go
@@ -65,6 +65,18 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockCache) Close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockCacheMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockCache)(nil).Close))
+}
+
 // DeleteEvent mocks base method.
 func (m *MockCache) DeleteEvent(key EventKey) {
 	m.ctrl.T.Helper()

--- a/service/history/events/fx.go
+++ b/service/history/events/fx.go
@@ -33,7 +33,9 @@ import (
 )
 
 var Module = fx.Options(
-	fx.Provide(func(executionManager persistence.ExecutionManager, config *configs.Config, handler metrics.Handler, logger log.Logger) Cache {
-		return NewHostLevelEventsCache(executionManager, config, handler, logger, false)
+	fx.Provide(func(executionManager persistence.ExecutionManager, config *configs.Config, handler metrics.Handler, logger log.Logger, lc fx.Lifecycle) Cache {
+		cache := NewHostLevelEventsCache(executionManager, config, handler, logger, false)
+		lc.Append(fx.StopHook(cache.Close))
+		return cache
 	}),
 )

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -310,6 +310,9 @@ func ReplicationProgressCacheProvider(
 	serviceConfig *configs.Config,
 	logger log.Logger,
 	handler metrics.Handler,
+	lc fx.Lifecycle,
 ) replication.ProgressCache {
-	return replication.NewProgressCache(serviceConfig, logger, handler)
+	c := replication.NewProgressCache(serviceConfig, logger, handler)
+	lc.Append(fx.StopHook(c.Close))
+	return c
 }

--- a/service/history/history_engine_factory.go
+++ b/service/history/history_engine_factory.go
@@ -25,6 +25,8 @@
 package history
 
 import (
+	"context"
+
 	"go.opentelemetry.io/otel/trace"
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/common/persistence"
@@ -85,6 +87,10 @@ func (f *historyEngineFactory) CreateEngine(
 		wfCache = f.WorkflowCache
 	} else {
 		wfCache = f.NewCacheFn(shard.GetConfig(), shard.GetLogger(), shard.GetMetricsHandler())
+		shard.GetFinalizer().Register("wfCache", func(ctx context.Context) error {
+			wfCache.Close()
+			return nil
+		})
 	}
 
 	workflowConsistencyChecker := api.NewWorkflowConsistencyChecker(shard, wfCache)

--- a/service/history/replication/progress_cache.go
+++ b/service/history/replication/progress_cache.go
@@ -53,6 +53,7 @@ type (
 			versionedTransitions []*persistencespb.VersionedTransition,
 			eventVersionHistoryItems []*historyspb.VersionHistoryItem,
 		) error
+		Close()
 	}
 
 	progressCacheImpl struct {
@@ -197,6 +198,10 @@ func (c *progressCacheImpl) Update(
 		c.cache.Put(cacheKey, item)
 	}
 	return nil
+}
+
+func (c *progressCacheImpl) Close() {
+	c.cache.Close()
 }
 
 func (c *ReplicationProgress) LastSyncedTransition() *persistencespb.VersionedTransition {

--- a/service/history/replication/progress_cache_mock.go
+++ b/service/history/replication/progress_cache_mock.go
@@ -65,6 +65,18 @@ func (m *MockProgressCache) EXPECT() *MockProgressCacheMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockProgressCache) Close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockProgressCacheMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockProgressCache)(nil).Close))
+}
+
 // Get mocks base method.
 func (m *MockProgressCache) Get(runID string, targetClusterID int32) *ReplicationProgress {
 	m.ctrl.T.Helper()

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -2162,6 +2162,10 @@ func newContext(
 			shardContext.contextTaggedLogger,
 			false,
 		)
+		shardContext.finalizer.Register("eventsCache", func(ctx context.Context) error {
+			shardContext.eventsCache.Close()
+			return nil
+		})
 	}
 	shardContext.initLastUpdatesTime()
 	return shardContext, nil

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -2162,10 +2162,13 @@ func newContext(
 			shardContext.contextTaggedLogger,
 			false,
 		)
-		shardContext.finalizer.Register("eventsCache", func(ctx context.Context) error {
+		err := shardContext.finalizer.Register("eventsCache", func(ctx context.Context) error {
 			shardContext.eventsCache.Close()
 			return nil
 		})
+		if err != nil {
+			logger.Debug("failed to register finalizer for events cache", tag.Error(err))
+		}
 	}
 	shardContext.initLastUpdatesTime()
 	return shardContext, nil

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -118,6 +118,9 @@ func NewHostLevelCache(
 	return newCache(
 		maxSize,
 		config.HistoryCacheTTL(),
+		config.EnableHistoryChacheActiveEviction(),
+		config.HistoryChacheActiveEvictionInterval(),
+		config.HistoryChacheActiveEvictionMaxElements(),
 		config.HistoryCacheNonUserContextLockTimeout(),
 		logger,
 		handler,
@@ -136,6 +139,9 @@ func NewShardLevelCache(
 	return newCache(
 		maxSize,
 		config.HistoryCacheTTL(),
+		config.EnableHistoryChacheActiveEviction(),
+		config.HistoryChacheActiveEvictionInterval(),
+		config.HistoryChacheActiveEvictionMaxElements(),
 		config.HistoryCacheNonUserContextLockTimeout(),
 		logger,
 		handler,
@@ -145,13 +151,19 @@ func NewShardLevelCache(
 func newCache(
 	size int,
 	ttl time.Duration,
+	activeEviction bool,
+	activeEvictionInterval time.Duration,
+	activeEvictionMaxElements int,
 	nonUserContextLockTimeout time.Duration,
 	logger log.Logger,
 	handler metrics.Handler,
 ) Cache {
 	opts := &cache.Options{
-		TTL: ttl,
-		Pin: true,
+		TTL:                       ttl,
+		ActiveEviction:            activeEviction,
+		ActiveEvictionInterval:    activeEvictionInterval,
+		ActiveEvictionMaxElements: activeEvictionMaxElements,
+		Pin:                       true,
 		OnPut: func(val any) {
 			//revive:disable-next-line:unchecked-type-assertion
 			item := val.(*cacheItem)

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -68,6 +68,8 @@ type (
 			execution *commonpb.WorkflowExecution,
 			lockPriority locks.Priority,
 		) (historyi.WorkflowContext, historyi.ReleaseWorkflowContextFunc, error)
+
+		Close()
 	}
 
 	cacheImpl struct {

--- a/service/history/workflow/cache/cache_mock.go
+++ b/service/history/workflow/cache/cache_mock.go
@@ -68,6 +68,18 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockCache) Close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockCacheMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockCache)(nil).Close))
+}
+
 // GetOrCreateCurrentWorkflowExecution mocks base method.
 func (m *MockCache) GetOrCreateCurrentWorkflowExecution(ctx context.Context, shardContext interfaces.ShardContext, namespaceID namespace.ID, workflowID string, lockPriority locks.Priority) (interfaces.ReleaseWorkflowContextFunc, error) {
 	m.ctrl.T.Helper()

--- a/service/history/workflow/cache/fx.go
+++ b/service/history/workflow/cache/fx.go
@@ -32,8 +32,10 @@ import (
 )
 
 var Module = fx.Options(
-	fx.Provide(func(config *configs.Config, logger log.Logger, handler metrics.Handler) Cache {
-		return NewHostLevelCache(config, logger, handler)
+	fx.Provide(func(config *configs.Config, logger log.Logger, handler metrics.Handler, lc fx.Lifecycle) Cache {
+		cache := NewHostLevelCache(config, logger, handler)
+		lc.Append(fx.StopHook(cache.Close))
+		return cache
 	}),
 	fx.Provide(NewCacheFnProvider),
 )

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -179,7 +179,7 @@ type (
 		// Serialize and batch user data updates by namespace.
 		userDataUpdateBatchers collection.SyncMap[namespace.ID, *stream_batcher.Batcher[*userDataUpdate, error]]
 		// Stores results of reachability queries to visibility
-		reachabilityCache reachabilityCache
+		reachabilityCache *reachabilityCache
 	}
 )
 
@@ -304,7 +304,9 @@ func (e *matchingEngineImpl) Stop() {
 	close(e.membershipChangedCh)
 
 	e.nexusEndpointClient.notifyOwnershipChanged(false)
-	e.reachabilityCache.Close()
+	if e.reachabilityCache != nil {
+		e.reachabilityCache.Close()
+	}
 
 	for _, l := range e.getTaskQueuePartitions(math.MaxInt32) {
 		l.Stop(unloadCauseShuttingDown)

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -304,6 +304,7 @@ func (e *matchingEngineImpl) Stop() {
 	close(e.membershipChangedCh)
 
 	e.nexusEndpointClient.notifyOwnershipChanged(false)
+	e.reachabilityCache.Close()
 
 	for _, l := range e.getTaskQueuePartitions(math.MaxInt32) {
 		l.Stop(unloadCauseShuttingDown)

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -287,6 +287,7 @@ func (c *physicalTaskQueueManagerImpl) Stop(unloadCause unloadCause) {
 	c.matcher.Stop()
 	c.liveness.Stop()
 	c.tqCtxCancel()
+	c.pollerHistory.close()
 	c.logger.Info("Stopped physicalTaskQueueManager", tag.LifeCycleStopped, tag.Cause(unloadCause.String()))
 	c.metricsHandler.Counter(metrics.TaskQueueStoppedCounter.Name()).Record(1)
 	c.partitionMgr.engine.updatePhysicalTaskQueueGauge(c.partitionMgr.ns, c.partitionMgr.partition, c.queue.version, -1)

--- a/service/matching/poller_history.go
+++ b/service/matching/poller_history.go
@@ -90,6 +90,10 @@ func (pollers *pollerHistory) getPollerInfo(earliestAccessTime time.Time) []*tas
 	return result
 }
 
+func (pollers *pollerHistory) close() {
+	pollers.history.Close()
+}
+
 func defaultRPS(wrapper *wrapperspb.DoubleValue) float64 {
 	if wrapper != nil {
 		return wrapper.Value

--- a/service/matching/reachability.go
+++ b/service/matching/reachability.go
@@ -338,6 +338,11 @@ func newReachabilityCache(
 	}
 }
 
+func (c *reachabilityCache) Close() {
+	c.openWFCache.Close()
+	c.closedWFCache.Close()
+}
+
 // Get retrieves the Workflow Count existence value based on the query-string key.
 func (c *reachabilityCache) Get(ctx context.Context, countRequest manager.CountWorkflowExecutionsRequest, open bool) (exists, hit bool, err error) {
 	// try cache

--- a/service/matching/reachability.go
+++ b/service/matching/reachability.go
@@ -78,7 +78,7 @@ var (
 )
 
 type reachabilityCalculator struct {
-	cache                        reachabilityCache
+	cache                        *reachabilityCache
 	nsID                         namespace.ID
 	nsName                       namespace.Name
 	taskQueue                    *tqid.TaskQueueFamily
@@ -90,7 +90,7 @@ type reachabilityCalculator struct {
 
 func newReachabilityCalculator(
 	data *persistencespb.VersioningData,
-	rCache reachabilityCache,
+	rCache *reachabilityCache,
 	nsID, nsName string,
 	taskQueue *tqid.TaskQueueFamily,
 	buildIdVisibilityGracePeriod time.Duration,
@@ -329,8 +329,8 @@ func newReachabilityCache(
 	visibilityMgr manager.VisibilityManager,
 	reachabilityCacheOpenWFExecutionTTL,
 	reachabilityCacheClosedWFExecutionTTL time.Duration,
-) reachabilityCache {
-	return reachabilityCache{
+) *reachabilityCache {
+	return &reachabilityCache{
 		openWFCache:    cache.New(reachabilityCacheMaxSize, &cache.Options{TTL: reachabilityCacheOpenWFExecutionTTL}),
 		closedWFCache:  cache.New(reachabilityCacheMaxSize, &cache.Options{TTL: reachabilityCacheClosedWFExecutionTTL}),
 		metricsHandler: handler,

--- a/service/worker/deployment/deployment_reachability.go
+++ b/service/worker/deployment/deployment_reachability.go
@@ -143,6 +143,11 @@ func newReachabilityCache(
 	}
 }
 
+func (c *reachabilityCache) Close() {
+	c.openWFCache.Close()
+	c.closedWFCache.Close()
+}
+
 // Get retrieves the Workflow Count existence value and update time based on the query-string key.
 func (c *reachabilityCache) Get(
 	ctx context.Context,

--- a/service/worker/scheduler/fx.go
+++ b/service/worker/scheduler/fx.go
@@ -89,7 +89,12 @@ type (
 var Module = fx.Options(
 	fx.Provide(NewResult),
 	fx.Provide(NewSpecBuilder),
+	fx.Invoke(SpecBuilderLifetimeHooks),
 )
+
+func SpecBuilderLifetimeHooks(sb *SpecBuilder, lc fx.Lifecycle) {
+	lc.Append(fx.StopHook(sb.Close))
+}
 
 func NewResult(
 	dc *dynamicconfig.Collection,

--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -77,6 +77,10 @@ func NewSpecBuilder() *SpecBuilder {
 	}
 }
 
+func (b *SpecBuilder) Close() {
+	b.locationCache.Close()
+}
+
 func (b *SpecBuilder) NewCompiledSpec(spec *schedulepb.ScheduleSpec) (*CompiledSpec, error) {
 	spec, err := canonicalizeSpec(spec)
 	if err != nil {


### PR DESCRIPTION
## What changed?

Add active cache eviction for history service (mutablestate and event caches) implemented as background routine per cache instance that periodically evicts at most N expired elements from cache. The eviction interval and number of elements to be evicted during iteratino (N) can be configured via dynamic config on per-instance base.

The feature is disabled by default.

## Why?

In our use-cases Temporal server is deployed in very restricted environments where it shares resources with different services for different use-cases. We faced that after load spikes Temporal keeps consume memory allocated by caches forever (related issue: #4233), and then we found that Temporal implements only passive memory eviction for caches (the terminology is taken form Redis), i.e. element will be removed from cache only when inserting new element in already full cache. Thus we implement active cache eviction and decided to return it back into upstream.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Tested with our internal fork running in several on-premise environments.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

Since the feature is disabled by default, any problems are rarely expected.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
