### PR TITLE
Fix handling of completion callbacks in retry and cron cases

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2166,37 +2166,9 @@ func (ms *MutableStateImpl) addWorkflowExecutionStartedEventForContinueAsNew(
 	// for other fields as well.
 	runTimeout := command.GetWorkflowRunTimeout()
 
-	cbColl := callbacks.MachineCollection(previousExecutionState.HSM())
-	completionCallbacks := make([]*commonpb.Callback, 0, cbColl.Size())
-	for _, node := range cbColl.List() {
-		cb, err := cbColl.Data(node.Key.ID)
-		if err != nil {
-			return nil, err
-		}
-		if _, ok := cb.Trigger.Variant.(*persistencespb.CallbackInfo_Trigger_WorkflowClosed); !ok {
-			continue
-		}
-		cbSpec := &commonpb.Callback{}
-		switch variant := cb.Callback.Variant.(type) {
-		case *persistencespb.Callback_Nexus_:
-			cbSpec.Variant = &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{
-					Url:    variant.Nexus.GetUrl(),
-					Header: variant.Nexus.GetHeader(),
-				},
-			}
-		default:
-			data, err := proto.Marshal(cb.Callback)
-			if err != nil {
-				return nil, err
-			}
-			cbSpec.Variant = &commonpb.Callback_Internal_{
-				Internal: &commonpb.Callback_Internal{
-					Data: data,
-				},
-			}
-		}
-		completionCallbacks = append(completionCallbacks, cbSpec)
+	completionCallbacks, err := getCompletionCallbacksAsProtoSlice(previousExecutionState)
+	if err != nil {
+		return nil, err
 	}
 
 	createRequest := &workflowservice.StartWorkflowExecutionRequest{
@@ -3862,7 +3834,12 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionFailedEvent(
 	ms.executionInfo.CloseTime = event.GetEventTime()
 	ms.ClearStickyTaskQueue()
 	ms.writeEventToCache(event)
-	return ms.processCloseCallbacks()
+
+	attrs := event.GetWorkflowExecutionFailedEventAttributes()
+	if attrs.RetryState != enumspb.RETRY_STATE_IN_PROGRESS {
+		return ms.processCloseCallbacks()
+	}
+	return nil
 }
 
 func (ms *MutableStateImpl) AddTimeoutWorkflowEvent(
@@ -3904,7 +3881,12 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionTimedoutEvent(
 	ms.executionInfo.CloseTime = event.GetEventTime()
 	ms.ClearStickyTaskQueue()
 	ms.writeEventToCache(event)
-	return ms.processCloseCallbacks()
+
+	attrs := event.GetWorkflowExecutionTimedOutEventAttributes()
+	if attrs.RetryState != enumspb.RETRY_STATE_IN_PROGRESS {
+		return ms.processCloseCallbacks()
+	}
+	return nil
 }
 
 func (ms *MutableStateImpl) AddWorkflowExecutionCancelRequestedEvent(
@@ -5659,8 +5641,7 @@ func (ms *MutableStateImpl) AddHistorySize(size int64) {
 // processCloseCallbacks triggers "WorkflowClosed" callbacks, applying the state machine transition that schedules
 // callback tasks.
 func (ms *MutableStateImpl) processCloseCallbacks() error {
-	continuedAsNew := ms.GetExecutionInfo().NewExecutionRunId != ""
-	if continuedAsNew || ms.GetExecutionInfo().GetWorkflowWasReset() {
+	if ms.GetExecutionInfo().GetWorkflowWasReset() {
 		return nil
 	}
 

--- a/service/history/workflow/retry.go
+++ b/service/history/workflow/retry.go
@@ -257,6 +257,14 @@ func SetupNewWorkflowForRetryOrCron(
 	// validateContinueAsNewWorkflowExecutionAttributes
 	runTimeout := startAttr.GetWorkflowRunTimeout()
 
+	var completionCallbacks []*commonpb.Callback
+	if initiator == enumspb.CONTINUE_AS_NEW_INITIATOR_RETRY {
+		completionCallbacks, err = getCompletionCallbacksAsProtoSlice(previousMutableState)
+		if err != nil {
+			return err
+		}
+	}
+
 	createRequest := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:                uuid.New(),
 		Namespace:                newMutableState.GetNamespaceEntry().Name().String(),
@@ -272,7 +280,7 @@ func SetupNewWorkflowForRetryOrCron(
 		CronSchedule:             startAttr.CronSchedule,
 		Memo:                     startAttr.Memo,
 		SearchAttributes:         startAttr.SearchAttributes,
-		CompletionCallbacks:      startAttr.CompletionCallbacks,
+		CompletionCallbacks:      completionCallbacks,
 		Links:                    startLinks,
 		Priority:                 startAttr.Priority,
 	}

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -32,13 +32,16 @@ import (
 	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/effect"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/worker_versioning"
+	"go.temporal.io/server/components/callbacks"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/hsm"
 	historyi "go.temporal.io/server/service/history/interfaces"
+	"google.golang.org/protobuf/proto"
 )
 
 func failWorkflowTask(
@@ -272,4 +275,40 @@ func shouldReapplyEvent(stateMachineRegistry *hsm.Registry, event *historypb.His
 	}
 
 	return false
+}
+
+func getCompletionCallbacksAsProtoSlice(ms historyi.MutableState) ([]*commonpb.Callback, error) {
+	coll := callbacks.MachineCollection(ms.HSM())
+	result := make([]*commonpb.Callback, 0, coll.Size())
+	for _, node := range coll.List() {
+		cb, err := coll.Data(node.Key.ID)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := cb.Trigger.Variant.(*persistencespb.CallbackInfo_Trigger_WorkflowClosed); !ok {
+			continue
+		}
+		cbSpec := &commonpb.Callback{}
+		switch variant := cb.Callback.Variant.(type) {
+		case *persistencespb.Callback_Nexus_:
+			cbSpec.Variant = &commonpb.Callback_Nexus_{
+				Nexus: &commonpb.Callback_Nexus{
+					Url:    variant.Nexus.GetUrl(),
+					Header: variant.Nexus.GetHeader(),
+				},
+			}
+		default:
+			data, err := proto.Marshal(cb.Callback)
+			if err != nil {
+				return nil, err
+			}
+			cbSpec.Variant = &commonpb.Callback_Internal_{
+				Internal: &commonpb.Callback_Internal{
+					Data: data,
+				},
+			}
+		}
+		result = append(result, cbSpec)
+	}
+	return result, nil
 }

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -31,8 +31,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
-	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -48,8 +48,10 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/testing/freeport"
 	"go.temporal.io/server/common/testing/protoassert"
+	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/components/callbacks"
 	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -177,7 +179,7 @@ func (s *CallbacksSuite) TestWorkflowCallbacks_InvalidArgument() {
 				})
 			}
 			request := &workflowservice.StartWorkflowExecutionRequest{
-				RequestId:           uuid.New(),
+				RequestId:           uuid.NewString(),
 				Namespace:           s.Namespace().String(),
 				WorkflowId:          testcore.RandomizeStr(s.T().Name()),
 				WorkflowType:        &commonpb.WorkflowType{Name: workflowType},
@@ -211,6 +213,7 @@ func (s *CallbacksSuite) TestWorkflowNexusCallbacks_CarriedOver() {
 			name: "ContinueAsNew",
 			wf: func(ctx workflow.Context) (int, error) {
 				if workflow.GetInfo(ctx).ContinuedExecutionRunID == "" {
+					workflow.GetSignalChannel(ctx, "continue").Receive(ctx, nil)
 					return 0, workflow.NewContinueAsNewError(ctx, "test")
 				}
 				return 666, nil
@@ -222,18 +225,20 @@ func (s *CallbacksSuite) TestWorkflowNexusCallbacks_CarriedOver() {
 			wf: func(ctx workflow.Context) (int, error) {
 				info := workflow.GetInfo(ctx)
 				if info.FirstRunID == info.WorkflowExecution.RunID {
-					return 0, workflow.Sleep(ctx, 1*time.Second)
+					workflow.GetSignalChannel(ctx, "continue").Receive(ctx, nil)
+					return 0, workflow.Sleep(ctx, 10*time.Second)
 				}
 				s.Greater(info.Attempt, int32(1))
 				return 666, nil
 			},
-			runTimeout: 100 * time.Millisecond,
+			runTimeout: 500 * time.Millisecond,
 		},
 		{
 			name: "WorkflowFailureRetry",
 			wf: func(ctx workflow.Context) (int, error) {
 				info := workflow.GetInfo(ctx)
 				if info.FirstRunID == info.WorkflowExecution.RunID {
+					workflow.GetSignalChannel(ctx, "continue").Receive(ctx, nil)
 					return 0, errors.New("intentional workflow failure")
 				}
 				s.Greater(info.Attempt, int32(1))
@@ -245,6 +250,7 @@ func (s *CallbacksSuite) TestWorkflowNexusCallbacks_CarriedOver() {
 
 	for _, tc := range cases {
 		s.T().Run(tc.name, func(t *testing.T) {
+			tv := testvars.New(t)
 			ctx := testcore.NewContext()
 			sdkClient, err := client.Dial(client.Options{
 				HostPort:  s.FrontendGRPCAddress(),
@@ -254,10 +260,11 @@ func (s *CallbacksSuite) TestWorkflowNexusCallbacks_CarriedOver() {
 
 			taskQueue := testcore.RandomizeStr(s.T().Name())
 			workflowType := "test"
+			workflowID := tv.WorkflowID()
 
 			ch := &completionHandler{
-				requestCh:         make(chan *nexus.CompletionRequest, 1),
-				requestCompleteCh: make(chan error, 1),
+				requestCh:         make(chan *nexus.CompletionRequest, 2),
+				requestCompleteCh: make(chan error, 2),
 			}
 			callbackAddress := fmt.Sprintf("localhost:%d", freeport.MustGetFreePort())
 			shutdownServer := s.runNexusCompletionHTTPServer(ch, callbackAddress)
@@ -269,6 +276,23 @@ func (s *CallbacksSuite) TestWorkflowNexusCallbacks_CarriedOver() {
 			w.RegisterWorkflowWithOptions(tc.wf, workflow.RegisterOptions{Name: workflowType})
 			s.NoError(w.Start())
 			defer w.Stop()
+
+			cbs := []*commonpb.Callback{
+				{
+					Variant: &commonpb.Callback_Nexus_{
+						Nexus: &commonpb.Callback_Nexus{
+							Url: "http://" + callbackAddress + "/cb1",
+						},
+					},
+				},
+				{
+					Variant: &commonpb.Callback_Nexus_{
+						Nexus: &commonpb.Callback_Nexus{
+							Url: "http://" + callbackAddress + "/cb2",
+						},
+					},
+				},
+			}
 
 			startLink := &commonpb.Link{
 				Variant: &commonpb.Link_WorkflowEvent_{
@@ -285,9 +309,9 @@ func (s *CallbacksSuite) TestWorkflowNexusCallbacks_CarriedOver() {
 				},
 			}
 			request := &workflowservice.StartWorkflowExecutionRequest{
-				RequestId:          uuid.New(),
+				RequestId:          uuid.NewString(),
 				Namespace:          s.Namespace().String(),
-				WorkflowId:         testcore.RandomizeStr(s.T().Name()),
+				WorkflowId:         workflowID,
 				WorkflowType:       &commonpb.WorkflowType{Name: workflowType},
 				TaskQueue:          &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 				Input:              nil,
@@ -298,44 +322,72 @@ func (s *CallbacksSuite) TestWorkflowNexusCallbacks_CarriedOver() {
 					MaximumInterval:    durationpb.New(1 * time.Second),
 					BackoffCoefficient: 1,
 				},
-				CompletionCallbacks: []*commonpb.Callback{
-					{
-						Variant: &commonpb.Callback_Nexus_{
-							Nexus: &commonpb.Callback_Nexus{
-								Url: "http://" + callbackAddress,
-							},
-						},
-					},
-				},
-				Links: []*commonpb.Link{startLink},
+				CompletionCallbacks: []*commonpb.Callback{cbs[0]},
+				Links:               []*commonpb.Link{startLink},
 			}
 
-			_, err = s.FrontendClient().StartWorkflowExecution(ctx, request)
+			response1, err := s.FrontendClient().StartWorkflowExecution(ctx, request)
 			s.NoError(err)
 
-			run := sdkClient.GetWorkflow(ctx, request.WorkflowId, "")
+			workflowExecution := &commonpb.WorkflowExecution{
+				WorkflowId: workflowID,
+				RunId:      response1.RunId,
+			}
+
+			// Send another request to attach callback
+			request2 := proto.Clone(request).(*workflowservice.StartWorkflowExecutionRequest)
+			request2.RequestId = uuid.NewString()
+			request2.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+			request2.OnConflictOptions = &workflowpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			}
+			request2.CompletionCallbacks = []*commonpb.Callback{cbs[1]}
+
+			response2, err := s.FrontendClient().StartWorkflowExecution(ctx, request2)
+			s.NoError(err)
+			s.False(response2.Started)
+			s.Equal(workflowExecution.RunId, response2.RunId)
+
+			_, err = s.FrontendClient().SignalWorkflowExecution(
+				ctx,
+				&workflowservice.SignalWorkflowExecutionRequest{
+					Namespace:         s.Namespace().String(),
+					WorkflowExecution: workflowExecution,
+					SignalName:        "continue",
+				},
+			)
+			s.NoError(err)
+
+			// Wait for workflow to complete.
+			run := sdkClient.GetWorkflow(ctx, workflowID, "")
 			s.NoError(run.Get(ctx, nil))
 
 			numAttempts := 2
 			for attempt := 1; attempt <= numAttempts; attempt++ {
-				completion := <-ch.requestCh
-				s.Equal(nexus.OperationStateSucceeded, completion.State)
-				var result int
-				s.NoError(completion.Result.Consume(&result))
-				s.Equal(666, result)
-				var err error
-				if attempt < numAttempts {
-					// force retry
-					err = nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "intentional error")
+				for range cbs {
+					completion := <-ch.requestCh
+					s.Equal(nexus.OperationStateSucceeded, completion.State)
+					var result int
+					s.NoError(completion.Result.Consume(&result))
+					s.Equal(666, result)
 				}
-				ch.requestCompleteCh <- err
+
+				for range cbs {
+					var err error
+					if attempt < numAttempts {
+						// force retry
+						err = nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "intentional error")
+					}
+					ch.requestCompleteCh <- err
+				}
 
 				getHistoryResponse, err := s.FrontendClient().GetWorkflowExecutionHistory(
 					ctx,
 					&workflowservice.GetWorkflowExecutionHistoryRequest{
 						Namespace: s.Namespace().String(),
 						Execution: &commonpb.WorkflowExecution{
-							WorkflowId: request.WorkflowId,
+							WorkflowId: workflowID,
 						},
 						MaximumPageSize: 1, // only interested in the start event
 					},
@@ -347,28 +399,48 @@ func (s *CallbacksSuite) TestWorkflowNexusCallbacks_CarriedOver() {
 				s.ProtoElementsMatch(request.Links, startEvent.Links)
 				startEventAttr := startEvent.GetWorkflowExecutionStartedEventAttributes()
 				s.NotNil(startEventAttr)
-				s.ProtoElementsMatch(request.CompletionCallbacks, startEventAttr.CompletionCallbacks)
+				// Start event contains all callbacks attached to the first workflow.
+				s.ProtoElementsMatch(cbs, startEventAttr.CompletionCallbacks)
 
 				s.EventuallyWithT(func(col *assert.CollectT) {
-					description, err := sdkClient.DescribeWorkflowExecution(ctx, request.WorkflowId, "")
+					description, err := sdkClient.DescribeWorkflowExecution(ctx, workflowID, "")
 					assert.NoError(col, err)
-					assert.Equal(col, 1, len(description.Callbacks))
-					callbackInfo := description.Callbacks[0]
-					protoassert.ProtoEqual(col, request.CompletionCallbacks[0], callbackInfo.Callback)
-					protoassert.ProtoEqual(col, &workflowpb.CallbackInfo_Trigger{Variant: &workflowpb.CallbackInfo_Trigger_WorkflowClosed{WorkflowClosed: &workflowpb.CallbackInfo_WorkflowClosed{}}}, callbackInfo.Trigger)
-					if !assert.Equal(col, int32(attempt), callbackInfo.Attempt) {
-						// Return early to avoid evaluating further assertions.
-						return
+					assert.Equal(col, len(cbs), len(description.Callbacks))
+					descCbs := make([]*commonpb.Callback, 0, len(description.Callbacks))
+					for _, callbackInfo := range description.Callbacks {
+						protoassert.ProtoEqual(
+							col,
+							&workflowpb.CallbackInfo_Trigger{
+								Variant: &workflowpb.CallbackInfo_Trigger_WorkflowClosed{
+									WorkflowClosed: &workflowpb.CallbackInfo_WorkflowClosed{},
+								},
+							},
+							callbackInfo.Trigger,
+						)
+						if !assert.Equal(col, int32(attempt), callbackInfo.Attempt) {
+							// Return early to avoid evaluating further assertions.
+							return
+						}
+						// Loose check to see that this is set.
+						assert.Greater(
+							col,
+							callbackInfo.LastAttemptCompleteTime.AsTime(),
+							time.Now().Add(-time.Hour),
+						)
+						if attempt < numAttempts {
+							assert.Equal(col, enumspb.CALLBACK_STATE_BACKING_OFF, callbackInfo.State)
+							assert.Equal(
+								col,
+								"handler error (INTERNAL): intentional error",
+								callbackInfo.LastAttemptFailure.Message,
+							)
+						} else {
+							assert.Equal(col, enumspb.CALLBACK_STATE_SUCCEEDED, callbackInfo.State)
+							assert.Nil(col, callbackInfo.LastAttemptFailure)
+						}
+						descCbs = append(descCbs, callbackInfo.Callback)
 					}
-					// Loose check to see that this is set.
-					assert.Greater(col, callbackInfo.LastAttemptCompleteTime.AsTime(), time.Now().Add(-time.Hour))
-					if attempt < numAttempts {
-						assert.Equal(col, enumspb.CALLBACK_STATE_BACKING_OFF, callbackInfo.State)
-						assert.Equal(col, "handler error (INTERNAL): intentional error", callbackInfo.LastAttemptFailure.Message)
-					} else {
-						assert.Equal(col, enumspb.CALLBACK_STATE_SUCCEEDED, callbackInfo.State)
-						assert.Nil(col, callbackInfo.LastAttemptFailure)
-					}
+					protoassert.ProtoElementsMatch(col, cbs, descCbs)
 				}, 2*time.Second, 100*time.Millisecond)
 			}
 		})
@@ -381,6 +453,7 @@ func (s *CallbacksSuite) TestNexusResetWorkflowWithCallback() {
 		[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
 	)
 
+	tv := testvars.New(s.T())
 	ctx := testcore.NewContext()
 	sdkClient, err := client.Dial(client.Options{
 		HostPort:  s.FrontendGRPCAddress(),
@@ -388,11 +461,12 @@ func (s *CallbacksSuite) TestNexusResetWorkflowWithCallback() {
 	})
 	s.NoError(err)
 
-	taskQueue := testcore.RandomizeStr(s.T().Name())
+	taskQueue := tv.TaskQueue()
+	workflowID := tv.WorkflowID()
 
 	ch := &completionHandler{
-		requestCh:         make(chan *nexus.CompletionRequest, 1),
-		requestCompleteCh: make(chan error, 1),
+		requestCh:         make(chan *nexus.CompletionRequest, 2),
+		requestCompleteCh: make(chan error, 2),
 	}
 	callbackAddress := fmt.Sprintf("localhost:%d", freeport.MustGetFreePort())
 	shutdownServer := s.runNexusCompletionHTTPServer(ch, callbackAddress)
@@ -400,7 +474,7 @@ func (s *CallbacksSuite) TestNexusResetWorkflowWithCallback() {
 		require.NoError(s.T(), shutdownServer())
 	})
 
-	w := worker.New(sdkClient, taskQueue, worker.Options{})
+	w := worker.New(sdkClient, taskQueue.GetName(), worker.Options{})
 
 	// A workflow that completes once it has been reset.
 	longRunningWorkflow := func(ctx workflow.Context) error {
@@ -417,33 +491,42 @@ func (s *CallbacksSuite) TestNexusResetWorkflowWithCallback() {
 	s.NoError(w.Start())
 	defer w.Stop()
 
-	request := &workflowservice.StartWorkflowExecutionRequest{
-		RequestId:          uuid.New(),
-		Namespace:          s.Namespace().String(),
-		WorkflowId:         testcore.RandomizeStr(s.T().Name()),
-		WorkflowType:       &commonpb.WorkflowType{Name: "longRunningWorkflow"},
-		TaskQueue:          &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-		Input:              nil,
-		WorkflowRunTimeout: durationpb.New(20 * time.Second),
-		Identity:           s.T().Name(),
-		CompletionCallbacks: []*commonpb.Callback{
-			{
-				Variant: &commonpb.Callback_Nexus_{
-					Nexus: &commonpb.Callback_Nexus{
-						Url: "http://" + callbackAddress,
-					},
+	cbs := []*commonpb.Callback{
+		{
+			Variant: &commonpb.Callback_Nexus_{
+				Nexus: &commonpb.Callback_Nexus{
+					Url: "http://" + callbackAddress + "/cb1",
+				},
+			},
+		},
+		{
+			Variant: &commonpb.Callback_Nexus_{
+				Nexus: &commonpb.Callback_Nexus{
+					Url: "http://" + callbackAddress + "/cb2",
 				},
 			},
 		},
 	}
 
-	startResponse, err := s.FrontendClient().StartWorkflowExecution(ctx, request)
+	request1 := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           s.Namespace().String(),
+		WorkflowId:          workflowID,
+		WorkflowType:        &commonpb.WorkflowType{Name: "longRunningWorkflow"},
+		TaskQueue:           taskQueue,
+		Input:               nil,
+		WorkflowRunTimeout:  durationpb.New(20 * time.Second),
+		Identity:            s.T().Name(),
+		CompletionCallbacks: []*commonpb.Callback{cbs[0]},
+	}
+
+	startResponse1, err := s.FrontendClient().StartWorkflowExecution(ctx, request1)
 	s.NoError(err)
 
-	// Get history, iterate to ensure workflow task completed event exists. then reset
+	// Get history, iterate to ensure workflow task completed event exists.
 	workflowExecution := &commonpb.WorkflowExecution{
-		WorkflowId: request.WorkflowId,
-		RunId:      startResponse.RunId,
+		WorkflowId: workflowID,
+		RunId:      startResponse1.RunId,
 	}
 	s.WaitForHistoryEvents(`
 			1 WorkflowExecutionStarted
@@ -454,6 +537,33 @@ func (s *CallbacksSuite) TestNexusResetWorkflowWithCallback() {
 		5*time.Second,
 		10*time.Millisecond)
 
+	// Try starting another workflow, which will have the callback attached to the previous workflow.
+	request2 := proto.Clone(request1).(*workflowservice.StartWorkflowExecutionRequest)
+	request2.RequestId = uuid.NewString()
+	request2.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING
+	request2.OnConflictOptions = &workflowpb.OnConflictOptions{
+		AttachRequestId:           true,
+		AttachCompletionCallbacks: true,
+	}
+	request2.CompletionCallbacks = []*commonpb.Callback{cbs[1]}
+
+	startResponse2, err := s.FrontendClient().StartWorkflowExecution(ctx, request2)
+	s.NoError(err)
+	s.False(startResponse2.Started)
+	s.Equal(workflowExecution.RunId, startResponse2.RunId)
+
+	// Get history, iterate to ensure workflow execution options updated event exists.
+	s.WaitForHistoryEvents(`
+			1 WorkflowExecutionStarted
+  			2 WorkflowTaskScheduled
+  			3 WorkflowTaskStarted
+  			4 WorkflowTaskCompleted
+     		5 WorkflowExecutionOptionsUpdated`,
+		s.GetHistoryFunc(s.Namespace().String(), workflowExecution),
+		5*time.Second,
+		10*time.Millisecond)
+
+	// Reset workflow must copy all callbacks even after the reset point.
 	resetWfResponse, err := sdkClient.ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
 		Namespace: s.Namespace().String(),
 
@@ -465,32 +575,51 @@ func (s *CallbacksSuite) TestNexusResetWorkflowWithCallback() {
 	s.NoError(err)
 
 	// Get the description of the run that was reset and ensure that its callback is still in STANDBY state.
-	description, err := sdkClient.DescribeWorkflowExecution(ctx, request.WorkflowId, startResponse.RunId)
+	description, err := sdkClient.DescribeWorkflowExecution(ctx, workflowID, startResponse1.RunId)
 	s.NoError(err)
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, description.WorkflowExecutionInfo.Status)
 
 	// Should not be invoked during a reset
-	s.Equal(1, len(description.Callbacks))
-	callbackInfo := description.Callbacks[0]
-	s.ProtoEqual(request.CompletionCallbacks[0], callbackInfo.Callback)
-	s.Equal(enumspb.CALLBACK_STATE_STANDBY, callbackInfo.State)
-	s.Equal(int32(0), callbackInfo.Attempt)
+	s.Equal(len(cbs), len(description.Callbacks))
+	descCbs := make([]*commonpb.Callback, 0, len(description.Callbacks))
+	for _, callbackInfo := range description.Callbacks {
+		s.Equal(enumspb.CALLBACK_STATE_STANDBY, callbackInfo.State)
+		s.Equal(int32(0), callbackInfo.Attempt)
+		descCbs = append(descCbs, callbackInfo.Callback)
+	}
+	s.ProtoElementsMatch(cbs, descCbs)
 
-	resetWorkflowRun := sdkClient.GetWorkflow(ctx, request.WorkflowId, resetWfResponse.RunId)
+	resetWorkflowRun := sdkClient.GetWorkflow(ctx, workflowID, resetWfResponse.RunId)
 	err = resetWorkflowRun.Get(ctx, nil)
 	s.NoError(err)
 
-	completion := <-ch.requestCh
-	s.Equal(nexus.OperationStateSucceeded, completion.State)
-	ch.requestCompleteCh <- err
+	for range cbs {
+		completion := <-ch.requestCh
+		s.Equal(nexus.OperationStateSucceeded, completion.State)
+		ch.requestCompleteCh <- nil
+	}
 
-	// Get the description of the run post-reset and ensure that its callback is in SUCCEEDED state.
-	description, err = sdkClient.DescribeWorkflowExecution(ctx, resetWorkflowRun.GetID(), "")
-	s.NoError(err)
-	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, description.WorkflowExecutionInfo.Status)
+	s.EventuallyWithT(
+		func(t *assert.CollectT) {
+			// Get the description of the run post-reset and ensure its callbacks are in SUCCEEDED
+			// state.
+			description, err = sdkClient.DescribeWorkflowExecution(ctx, resetWorkflowRun.GetID(), "")
+			assert.NoError(t, err)
+			assert.Equal(
+				t,
+				enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+				description.WorkflowExecutionInfo.Status,
+			)
 
-	s.Equal(1, len(description.Callbacks))
-	callbackInfo = description.Callbacks[0]
-	s.ProtoEqual(request.CompletionCallbacks[0], callbackInfo.Callback)
-	s.Equal(enumspb.CALLBACK_STATE_SUCCEEDED, callbackInfo.State)
+			assert.Equal(t, len(cbs), len(description.Callbacks))
+			descCbs = make([]*commonpb.Callback, 0, len(description.Callbacks))
+			for _, callbackInfo := range description.Callbacks {
+				assert.Equal(t, enumspb.CALLBACK_STATE_SUCCEEDED, callbackInfo.State)
+				descCbs = append(descCbs, callbackInfo.Callback)
+			}
+			protoassert.ProtoElementsMatch(t, cbs, descCbs)
+		},
+		2*time.Second,
+		100*time.Millisecond,
+	)
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Bugs fixed in the PR
1. If a callback is attached to a cron workflow, it would never call it.
2. If a workflow retries (failed or timed out), the completion callbacks would not be called and only the callbacks in the `WorkflowExecutionStarted` event would be copied to the new workflow.

The fixes:
1. Cron workflow will call the completion callbacks upon completion, unless they are retried.
2. When a workflow is retried, copy all attached callbacks to the new workflow.

## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added functional tests, and verified that they fail in main, but passes with this PR.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
