### PR TITLE
Pause activity by rules in executeActivityRetryTimerTask

### DIFF
--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -551,7 +551,6 @@ func (t *timerQueueActiveTaskExecutor) executeActivityRetryTimerTask(
 
 	err = t.processActivityWorkflowRules(ctx, weContext, mutableState, activityInfo)
 	if err != nil {
-		release(err)
 		return err
 	}
 

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -44,7 +44,6 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/priorities"
 	"go.temporal.io/server/common/resource"
@@ -914,14 +913,9 @@ func (t *timerQueueActiveTaskExecutor) processActivityWorkflowRules(
 		}
 
 		// need to update mutable state
-		err := weContext.UpdateWorkflowExecutionWithNew(
+		err := weContext.UpdateWorkflowExecutionAsActive(
 			ctx,
 			t.shardContext,
-			persistence.UpdateWorkflowModeUpdateCurrent,
-			nil,
-			nil,
-			historyi.TransactionPolicyActive,
-			nil,
 		)
 		if err != nil {
 			return err

--- a/tests/activity_api_rules_test.go
+++ b/tests/activity_api_rules_test.go
@@ -476,6 +476,7 @@ func (s *ActivityApiRulesClientTestSuite) TestActivityRulesApi_RetryTask() {
 	// Let namespace config propagate.
 	// There is no good way to check if the namespace config has propagated to the history service
 	err = util.InterruptibleSleep(ctx, 2*time.Second)
+	s.NoError(err)
 
 	// 5. wait for activity to be paused by rule. This should happen in the activity retry task
 	s.EventuallyWithT(func(t *assert.CollectT) {

--- a/tests/activity_api_rules_test.go
+++ b/tests/activity_api_rules_test.go
@@ -342,8 +342,9 @@ func (s *ActivityApiRulesClientTestSuite) TestActivityRulesApi_RetryActivity() {
 		}
 	}, 5*time.Second, 200*time.Millisecond)
 
-	// Let activity fail
-	err = util.InterruptibleSleep(ctx, 1*time.Second)
+	// Let namespace config propagate.
+	// There is no good way to check if the namespace config has propagated to the history service
+	err = util.InterruptibleSleep(ctx, 4*time.Second)
 	s.NoError(err)
 
 	testWorkflow.activityFailedCn <- struct{}{}
@@ -381,6 +382,11 @@ func (s *ActivityApiRulesClientTestSuite) TestActivityRulesApi_RetryActivity() {
 		assert.Len(s.T(), nsResp.Rules, 0)
 	}, 5*time.Second, 200*time.Millisecond)
 
+	// Let namespace config propagate.
+	// There is no good way to check if the namespace config has propagated to the history service
+	err = util.InterruptibleSleep(ctx, 4*time.Second)
+	s.NoError(err)
+
 	// unpause the activity
 	_, err = s.FrontendClient().UnpauseActivity(ctx, &workflowservice.UnpauseActivityRequest{
 		Namespace: s.Namespace().String(),
@@ -400,7 +406,7 @@ func (s *ActivityApiRulesClientTestSuite) TestActivityRulesApi_RetryActivity() {
 			assert.True(t, description.PendingActivities[0].GetActivityType().GetName() == activityType)
 			assert.False(t, description.PendingActivities[0].GetPaused())
 		}
-		assert.Equal(t, int32(1), testWorkflow.startedActivityCount.Load())
+		assert.LessOrEqual(t, int32(1), testWorkflow.startedActivityCount.Load())
 	}, 5*time.Second, 200*time.Millisecond)
 
 	// let activity complete


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add code to pause the activity while processing activity retry task.

## Why?
<!-- Tell your future self why have you made these changes -->
Part of the workflow rules efforts. This is another place where we need to check rules related to the activity.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Add functional test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A.
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
N/A.
