### PR TITLE
expire cached entries in history client

### DIFF
--- a/client/history/caching_redirector.go
+++ b/client/history/caching_redirector.go
@@ -28,10 +28,12 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/goro"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership"
@@ -43,6 +45,7 @@ type (
 		shardID    int32
 		address    rpcAddress
 		connection clientConnection
+		staleAt    time.Time
 	}
 
 	// A cachingRedirector is a redirector that maintains a cache of shard
@@ -57,23 +60,44 @@ type (
 		}
 
 		connections            connectionPool
+		goros                  goro.Group
 		historyServiceResolver membership.ServiceResolver
 		logger                 log.Logger
+		membershipUpdateCh     chan *membership.ChangedEvent
+		staleTTL               time.Duration
 	}
 )
+
+const cachingRedirectorListener = "cachingRedirectorListener"
 
 func newCachingRedirector(
 	connections connectionPool,
 	historyServiceResolver membership.ServiceResolver,
 	logger log.Logger,
+	staleTTL time.Duration,
 ) *cachingRedirector {
 	r := &cachingRedirector{
 		connections:            connections,
 		historyServiceResolver: historyServiceResolver,
 		logger:                 logger,
+		membershipUpdateCh:     make(chan *membership.ChangedEvent, 1),
+		staleTTL:               staleTTL,
 	}
 	r.mu.cache = make(map[int32]cacheEntry)
+
+	if r.staleTTL > 0 {
+		r.goros.Go(func(ctx context.Context) error {
+			r.eventLoop(ctx)
+			return nil
+		})
+	}
+
 	return r
+}
+
+func (r *cachingRedirector) stop() {
+	r.goros.Cancel()
+	r.goros.Wait()
 }
 
 func (r *cachingRedirector) clientForShardID(shardID int32) (historyservice.HistoryServiceClient, error) {
@@ -128,7 +152,10 @@ func (r *cachingRedirector) getOrCreateEntry(shardID int32) (cacheEntry, error) 
 	entry, ok := r.mu.cache[shardID]
 	r.mu.RUnlock()
 	if ok {
-		return entry, nil
+		if entry.staleAt.IsZero() || time.Now().Before(entry.staleAt) {
+			return entry, nil
+		}
+		// Otherwise, check below under write lock.
 	}
 
 	r.mu.Lock()
@@ -137,7 +164,11 @@ func (r *cachingRedirector) getOrCreateEntry(shardID int32) (cacheEntry, error) 
 	// Recheck under write lock.
 	entry, ok = r.mu.cache[shardID]
 	if ok {
-		return entry, nil
+		if entry.staleAt.IsZero() || time.Now().Before(entry.staleAt) {
+			return entry, nil
+		}
+		// Delete and fallthrough below to re-check ownership.
+		delete(r.mu.cache, shardID)
 	}
 
 	address, err := shardLookup(r.historyServiceResolver, shardID)
@@ -166,6 +197,9 @@ func (r *cachingRedirector) cacheAddLocked(shardID int32, addr rpcAddress) cache
 		shardID:    shardID,
 		address:    addr,
 		connection: connection,
+		// staleAt is left at zero; it's only set when r.staleTTL is set,
+		// and after a membership update informs us that this address is no
+		// longer the shard owner.
 	}
 	r.mu.cache[shardID] = entry
 
@@ -211,4 +245,48 @@ func maybeHostDownError(opErr error) bool {
 		return true
 	}
 	return common.IsContextDeadlineExceededErr(opErr)
+}
+
+func (r *cachingRedirector) eventLoop(ctx context.Context) {
+	if err := r.historyServiceResolver.AddListener(cachingRedirectorListener, r.membershipUpdateCh); err != nil {
+		r.logger.Fatal("Error adding listener", tag.Error(err))
+	}
+	defer func() {
+		if err := r.historyServiceResolver.RemoveListener(cachingRedirectorListener); err != nil {
+			r.logger.Warn("Error removing listener", tag.Error(err))
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _ = <-r.membershipUpdateCh:
+			r.staleCheck()
+		}
+	}
+}
+
+func (r *cachingRedirector) staleCheck() {
+	if r.staleTTL == 0 {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	for shardID, entry := range r.mu.cache {
+		if !entry.staleAt.IsZero() {
+			if now.After(entry.staleAt) {
+				delete(r.mu.cache, shardID)
+			}
+			continue
+		}
+		addr, err := shardLookup(r.historyServiceResolver, shardID)
+		if err != nil || addr != entry.address {
+			entry.staleAt = now.Add(r.staleTTL)
+			r.mu.cache[shardID] = entry
+		}
+	}
 }

--- a/client/history/caching_redirector_test.go
+++ b/client/history/caching_redirector_test.go
@@ -73,7 +73,8 @@ func (s *cachingRedirectorSuite) TearDownTest() {
 }
 
 func (s *cachingRedirectorSuite) TestShardCheck() {
-	r := newCachingRedirector(s.connections, s.resolver, s.logger)
+	r := newCachingRedirector(s.connections, s.resolver, s.logger, 0)
+	defer r.stop()
 
 	invalErr := &serviceerror.InvalidArgument{}
 	err := r.execute(
@@ -113,7 +114,8 @@ func cacheRetainingTest(s *cachingRedirectorSuite, opErr error, verify func(erro
 		}
 		return opErr
 	}
-	r := newCachingRedirector(s.connections, s.resolver, s.logger)
+	r := newCachingRedirector(s.connections, s.resolver, s.logger, 0)
+	defer r.stop()
 
 	for i := 0; i < 3; i++ {
 		err := r.execute(
@@ -160,7 +162,8 @@ func hostDownErrorTest(s *cachingRedirectorSuite, clientOp clientOperation, veri
 		resetConnectBackoff(clientConn).
 		Times(1)
 
-	r := newCachingRedirector(s.connections, s.resolver, s.logger)
+	r := newCachingRedirector(s.connections, s.resolver, s.logger, 0)
+	defer r.stop()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -203,7 +206,8 @@ func (s *cachingRedirectorSuite) TestShardOwnershipLostErrors() {
 	mockClient1 := historyservicemock.NewMockHistoryServiceClient(s.controller)
 	mockClient2 := historyservicemock.NewMockHistoryServiceClient(s.controller)
 
-	r := newCachingRedirector(s.connections, s.resolver, s.logger)
+	r := newCachingRedirector(s.connections, s.resolver, s.logger, 0)
+	defer r.stop()
 	opCalls := 1
 	doExecute := func() error {
 		return r.execute(
@@ -345,7 +349,8 @@ func (s *cachingRedirectorSuite) TestClientForTargetByShard() {
 		resetConnectBackoff(clientConn).
 		Times(1)
 
-	r := newCachingRedirector(s.connections, s.resolver, s.logger)
+	r := newCachingRedirector(s.connections, s.resolver, s.logger, 0)
+	defer r.stop()
 	cli, err := r.clientForShardID(shardID)
 	s.NoError(err)
 	s.Equal(mockClient, cli)
@@ -354,4 +359,73 @@ func (s *cachingRedirectorSuite) TestClientForTargetByShard() {
 	cli, err = r.clientForShardID(shardID)
 	s.NoError(err)
 	s.Equal(mockClient, cli)
+}
+
+func (s *cachingRedirectorSuite) TestStaleTTL() {
+	testAddr1 := rpcAddress("testaddr1")
+	shardID := int32(1)
+	mockClient1 := historyservicemock.NewMockHistoryServiceClient(s.controller)
+	clientConn1 := clientConnection{
+		historyClient: mockClient1,
+	}
+	s.resolver.EXPECT().AddListener(cachingRedirectorListener, gomock.Any()).Return(nil).Times(1)
+	s.resolver.EXPECT().RemoveListener(cachingRedirectorListener).Return(nil).AnyTimes()
+
+	staleTTL := 500 * time.Millisecond
+	r := newCachingRedirector(s.connections, s.resolver, s.logger, staleTTL)
+	defer r.stop()
+
+	// Trigger the creation of a cache entry for the shard.
+	s.resolver.EXPECT().
+		Lookup(convert.Int32ToString(shardID)).
+		Return(membership.NewHostInfoFromAddress(string(testAddr1)), nil).
+		Times(1)
+
+	s.connections.EXPECT().
+		getOrCreateClientConn(testAddr1).
+		Return(clientConn1).
+		Times(1)
+	s.connections.EXPECT().
+		resetConnectBackoff(clientConn1).
+		Times(1)
+
+	cli, err := r.clientForShardID(shardID)
+	s.NoError(err)
+	s.Equal(mockClient1, cli)
+
+	// Now simulate a membership update that changes the shard owner.
+	mockClient2 := historyservicemock.NewMockHistoryServiceClient(s.controller)
+	clientConn2 := clientConnection{
+		historyClient: mockClient2,
+	}
+	testAddr2 := rpcAddress("testaddr2")
+	s.resolver.EXPECT().
+		Lookup(convert.Int32ToString(shardID)).
+		Return(membership.NewHostInfoFromAddress(string(testAddr2)), nil).
+		Times(1)
+
+	// Simulate the update, should see the entry marked as stale.
+	r.membershipUpdateCh <- &membership.ChangedEvent{}
+	s.Eventually(func() bool {
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		entry := r.mu.cache[shardID]
+		return !entry.staleAt.IsZero()
+	}, 4*staleTTL, staleTTL)
+
+	s.resolver.EXPECT().
+		Lookup(convert.Int32ToString(shardID)).
+		Return(membership.NewHostInfoFromAddress(string(testAddr2)), nil).
+		Times(1)
+	s.connections.EXPECT().
+		getOrCreateClientConn(testAddr2).
+		Return(clientConn2).
+		Times(1)
+	s.connections.EXPECT().
+		resetConnectBackoff(clientConn2).
+		Times(1)
+
+	cli, err = r.clientForShardID(shardID)
+	s.NoError(err)
+	s.Equal(mockClient2, cli)
 }

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -81,7 +81,8 @@ func NewClient(
 	var redirector redirector
 	if dynamicconfig.HistoryClientOwnershipCachingEnabled.Get(dc)() {
 		logger.Info("historyClient: ownership caching enabled")
-		redirector = newCachingRedirector(connections, historyServiceResolver, logger)
+		staleTTL := dynamicconfig.HistoryClientOwnershipCachingStaleTTL.Get(dc)()
+		redirector = newCachingRedirector(connections, historyServiceResolver, logger, staleTTL)
 	} else {
 		logger.Info("historyClient: ownership caching disabled")
 		redirector = newBasicRedirector(connections, historyServiceResolver)

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -81,8 +81,12 @@ func NewClient(
 	var redirector redirector
 	if dynamicconfig.HistoryClientOwnershipCachingEnabled.Get(dc)() {
 		logger.Info("historyClient: ownership caching enabled")
-		staleTTL := dynamicconfig.HistoryClientOwnershipCachingStaleTTL.Get(dc)()
-		redirector = newCachingRedirector(connections, historyServiceResolver, logger, staleTTL)
+		redirector = newCachingRedirector(
+			connections,
+			historyServiceResolver,
+			logger,
+			dynamicconfig.HistoryClientOwnershipCachingStaleTTL.Get(dc),
+		)
 	} else {
 		logger.Info("historyClient: ownership caching disabled")
 		redirector = newBasicRedirector(connections, historyServiceResolver)

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1516,6 +1516,12 @@ shard ownership information, instead of checking membership for each request.
 Only inspected when an instance first creates a history client, so changes
 to this require a restart to take effect.`,
 	)
+	HistoryClientOwnershipCachingStaleTTL = NewGlobalDurationSetting(
+		"history.clientOwnershipCachingUnusedTTL",
+		30*time.Second,
+		`HistoryClientOwnershipCachingStaleTTL, if non-zero, configures the TTL
+for cached shard ownership entries after a membership update.`,
+	)
 	ShardIOConcurrency = NewGlobalIntSetting(
 		"history.shardIOConcurrency",
 		1,


### PR DESCRIPTION
## What changed?
In the history client caching redirector, limit the time that a cached client will be used after a membership update signals the shard has moved, defaulting to 30 seconds.

## Why?
The redirector already removed entries that fail with timeouts or shard ownership lost. However, the impact of timeouts can be high, especially when an old shard owners address is unreachable. This manifested as high tail latencies for API calls after history restarts.

## How did you test it?
Added a unit test & in a test setup.
