### PR TITLE
Set API caller type header for CompleteNexusOperation requests

### DIFF
--- a/components/callbacks/nexus_invocation.go
+++ b/components/callbacks/nexus_invocation.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -109,6 +110,7 @@ func (n nexusInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e 
 	for k, v := range n.nexus.Header {
 		request.Header.Set(k, v)
 	}
+	request.Header.Set(headers.CallerTypeHeaderName, headers.CallerTypeAPI)
 
 	caller := e.HTTPCallerProvider(queues.NamespaceIDAndDestination{
 		NamespaceID: ns.ID().String(),

--- a/service/history/configs/quotas.go
+++ b/service/history/configs/quotas.go
@@ -63,7 +63,6 @@ func NewPriorityRateLimiter(
 			return priority
 		}
 		// unknown caller type, default to api to be consistent with existing behavior
-		// TODO: this happens for CompleteNexusOperation right now. Need to fix it.
 		return CallerTypeToPriority[headers.CallerTypeAPI]
 	}, rateLimiters)
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Explicitly setting the caller type header to API for CompleteNexusOperation requests.

## Why?
<!-- Tell your future self why have you made these changes -->


## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
