### PR TITLE
Add metric for paused activities

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1000,6 +1000,7 @@ var (
 	DynamicWorkerPoolSchedulerEnqueuedTasks = NewCounterDef("dynamic_worker_pool_scheduler_enqueued_tasks")
 	DynamicWorkerPoolSchedulerDequeuedTasks = NewCounterDef("dynamic_worker_pool_scheduler_dequeued_tasks")
 	DynamicWorkerPoolSchedulerRejectedTasks = NewCounterDef("dynamic_worker_pool_scheduler_rejected_tasks")
+	PausedActivitiesCounter                 = NewCounterDef("paused_activities")
 
 	// Deadlock detector latency metrics
 	DDClusterMetadataLockLatency         = NewTimerDef("dd_cluster_metadata_lock_latency")

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5564,6 +5564,16 @@ func (ms *MutableStateImpl) UpdateActivity(scheduledEventId int64, updater histo
 		if err != nil {
 			return err
 		}
+
+		if ai.Paused {
+			metrics.PausedActivitiesCounter.With(
+				ms.metricsHandler.WithTags(
+					metrics.NamespaceTag(ms.namespaceEntry.Name().String()),
+					metrics.WorkflowTypeTag(ms.GetExecutionInfo().WorkflowTypeName),
+					metrics.ActivityTypeTag(ai.ActivityType.Name),
+				),
+			).Record(1)
+		}
 	}
 
 	ms.approximateSize += ai.Size() - originalSize


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add metric for paused activities. Metric is emmited every time pause state changed to "true"

## Why?
<!-- Tell your future self why have you made these changes -->
With introduction of workflow rules pausing activity can become "mass" operation, and no initiated by direct user request.
Thus users need to know about it.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A