### PR TITLE
Fix Nexus context header propagation

### DIFF
--- a/components/nexusoperations/frontend/handler.go
+++ b/components/nexusoperations/frontend/handler.go
@@ -382,13 +382,16 @@ func (c *requestContext) augmentContext(ctx context.Context, header http.Header)
 	if userAgent := header.Get(http.CanonicalHeaderKey(headerUserAgent)); userAgent != "" {
 		parts := strings.Split(userAgent, clientNameVersionDelim)
 		if len(parts) == 2 {
-			return metadata.NewIncomingContext(ctx, metadata.New(map[string]string{
-				headers.ClientNameHeaderName:    parts[0],
-				headers.ClientVersionHeaderName: parts[1],
-			}))
+			mdIncoming, ok := metadata.FromIncomingContext(ctx)
+			if !ok {
+				mdIncoming = metadata.MD{}
+			}
+			mdIncoming.Set(headers.ClientNameHeaderName, parts[0])
+			mdIncoming.Set(headers.ClientVersionHeaderName, parts[1])
+			ctx = metadata.NewIncomingContext(ctx, mdIncoming)
 		}
 	}
-	return ctx
+	return headers.Propagate(ctx)
 }
 
 func (c *requestContext) capturePanicAndRecordMetrics(ctxPtr *context.Context, errPtr *error) {

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -148,13 +148,16 @@ func (c *operationContext) augmentContext(ctx context.Context, header nexus.Head
 	if userAgent, ok := header[headerUserAgent]; ok {
 		parts := strings.Split(userAgent, clientNameVersionDelim)
 		if len(parts) == 2 {
-			return metadata.NewIncomingContext(ctx, metadata.New(map[string]string{
-				headers.ClientNameHeaderName:    parts[0],
-				headers.ClientVersionHeaderName: parts[1],
-			}))
+			mdIncoming, ok := metadata.FromIncomingContext(ctx)
+			if !ok {
+				mdIncoming = metadata.MD{}
+			}
+			mdIncoming.Set(headers.ClientNameHeaderName, parts[0])
+			mdIncoming.Set(headers.ClientVersionHeaderName, parts[1])
+			ctx = metadata.NewIncomingContext(ctx, mdIncoming)
 		}
 	}
-	return ctx
+	return headers.Propagate(ctx)
 }
 
 func (c *operationContext) interceptRequest(

--- a/service/history/configs/quotas.go
+++ b/service/history/configs/quotas.go
@@ -63,7 +63,6 @@ func NewPriorityRateLimiter(
 			return priority
 		}
 		// unknown caller type, default to api to be consistent with existing behavior
-		// TODO: this happens for CompleteNexusOperation right now. Need to fix it.
 		return CallerTypeToPriority[headers.CallerTypeAPI]
 	}, rateLimiters)
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fixed propagating headers from incoming context to outgoing context for Nexus HTTP requests.

## Why?
<!-- Tell your future self why have you made these changes -->
Bug fix. Headers used for rate limiting were not being set appropriately.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests.

