### PR TITLE
Populate ResetRunId in historyservice.DescribeWorkflowExecutionResponse

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	go.temporal.io/api v1.46.1-0.20250402001719-05dc3fdedf2a
+	go.temporal.io/api v1.47.0
 	go.temporal.io/sdk v1.33.0
 	go.temporal.io/version v0.3.0
 	go.uber.org/automaxprocs v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.46.1-0.20250402001719-05dc3fdedf2a h1:4+udCndRuhstWyqo/O/pJ/E7IeXAPefQTIpK/9TQUA4=
-go.temporal.io/api v1.46.1-0.20250402001719-05dc3fdedf2a/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.47.0 h1:0pg8wZC9Jv79iMpe6jXMPQzADQJ5OiPuklYfC51bXGM=
+go.temporal.io/api v1.47.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.33.0 h1:T91UzeRdlHTiMGgpygsItOH9+VSkg+M/mG85PqNjdog=
 go.temporal.io/sdk v1.33.0/go.mod h1:WwCmJZLy7zabz3ar5NRAQEygsdP8tgR9sDjISSHuWZw=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -161,6 +161,7 @@ func Invoke(
 			RunExpirationTime:       executionInfo.WorkflowRunExpirationTime,
 			OriginalStartTime:       startEvent.EventTime,
 			CancelRequested:         executionInfo.CancelRequested,
+			ResetRunId:              executionInfo.ResetRunId,
 		},
 	}
 


### PR DESCRIPTION
## What changed?
We are now exposing `ResetRunID` in WorkflowExtendedInfo field in DescribeWorkflowExecutionResponse.

## Why?
This is needed so that UI can point to the new run when viewing a run that was reset.

## How did you test it?
Manually ran the UI server locally. Examined the response to DescribeWorkflowExecution

## Potential risks
N/A

## Documentation
N/A

## Is hotfix candidate?
No