### PR TITLE
add PAUSED and PAUSE_REQUESTED to activity state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.34.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.5.0
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/dig v1.18.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	go.temporal.io/api v1.47.0
+	go.temporal.io/api v1.46.1-0.20250404163325-28451b8db602
 	go.temporal.io/sdk v1.33.0
 	go.temporal.io/version v0.3.0
 	go.uber.org/automaxprocs v1.6.0
@@ -156,7 +156,7 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.34.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.5.0
+	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/dig v1.18.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.47.0 h1:0pg8wZC9Jv79iMpe6jXMPQzADQJ5OiPuklYfC51bXGM=
-go.temporal.io/api v1.47.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.46.1-0.20250404163325-28451b8db602 h1:oSRTfxTwAvqoW+Uv5gSF63AfSwpbypM1f9ZqKwF0JG4=
+go.temporal.io/api v1.46.1-0.20250404163325-28451b8db602/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.33.0 h1:T91UzeRdlHTiMGgpygsItOH9+VSkg+M/mG85PqNjdog=
 go.temporal.io/sdk v1.33.0/go.mod h1:WwCmJZLy7zabz3ar5NRAQEygsdP8tgR9sDjISSHuWZw=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=

--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -154,10 +154,12 @@ func GetPendingActivityInfo(
 	// adjust activity state for paused activities
 	if ai.Paused {
 		if p.State == enumspb.PENDING_ACTIVITY_STATE_SCHEDULED {
+			// this state means activity is not running on the worker
 			// if activity is paused on server and not running on worker - mark it as PAUSED
 			p.State = enumspb.PENDING_ACTIVITY_STATE_PAUSED
 		} else if p.State == enumspb.PENDING_ACTIVITY_STATE_STARTED {
-			// if activity is paused on server, but still paused on worker - mark it as PAUSE_REQUESTED
+			// this state means activity is running on the worker
+			// if activity is paused on server, but still running on worker - mark it as PAUSE_REQUESTED
 			p.State = enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED
 		} // if state is CANCEL_REQUESTEd - it is not modified
 	}

--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -151,6 +151,17 @@ func GetPendingActivityInfo(
 		}
 	}
 
+	// adjust activity state for paused activities
+	if ai.Paused {
+		if p.State == enumspb.PENDING_ACTIVITY_STATE_SCHEDULED {
+			// if activity is paused on server and not running on worker - mark it as PAUSED
+			p.State = enumspb.PENDING_ACTIVITY_STATE_PAUSED
+		} else if p.State == enumspb.PENDING_ACTIVITY_STATE_STARTED {
+			// if activity is paused on server, but still paused on worker - mark it as PAUSE_REQUESTED
+			p.State = enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED
+		} // if state is CANCEL_REQUESTEd - it is not modified
+	}
+
 	return p, nil
 }
 

--- a/service/history/workflow/activity_test.go
+++ b/service/history/workflow/activity_test.go
@@ -24,6 +24,7 @@ package workflow
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -164,6 +165,80 @@ func (s *activitySuite) TestGetPendingActivityInfoAcceptance() {
 	pi, err := GetPendingActivityInfo(context.Background(), s.mockShard, s.mockMutableState, ai)
 	s.NoError(err)
 	s.NotNil(pi)
+}
+
+func (s *activitySuite) TestGetPendingActivityInfo_ActivityState() {
+	testCases := []struct {
+		paused          bool
+		cancelRequested bool
+		startedEventId  int64
+		expectedState   enumspb.PendingActivityState
+	}{
+		{
+			paused:          false,
+			cancelRequested: false,
+			startedEventId:  common.EmptyEventID,
+			expectedState:   enumspb.PENDING_ACTIVITY_STATE_SCHEDULED,
+		},
+		{
+			paused:          false,
+			cancelRequested: false,
+			startedEventId:  1,
+			expectedState:   enumspb.PENDING_ACTIVITY_STATE_STARTED,
+		},
+		{
+			paused:          false,
+			cancelRequested: true,
+			startedEventId:  1,
+			expectedState:   enumspb.PENDING_ACTIVITY_STATE_CANCEL_REQUESTED,
+		},
+		{
+			paused:          true,
+			cancelRequested: false,
+			startedEventId:  common.EmptyEventID,
+			expectedState:   enumspb.PENDING_ACTIVITY_STATE_PAUSED,
+		},
+		{
+			paused:          true,
+			cancelRequested: false,
+			startedEventId:  1,
+			expectedState:   enumspb.PENDING_ACTIVITY_STATE_PAUSE_REQUESTED,
+		},
+		{
+			paused:          true,
+			cancelRequested: true,
+			startedEventId:  1,
+			expectedState:   enumspb.PENDING_ACTIVITY_STATE_CANCEL_REQUESTED,
+		},
+	}
+
+	now := s.mockShard.GetTimeSource().Now().UTC().Round(time.Hour)
+	activityType := commonpb.ActivityType{
+		Name: "activityType",
+	}
+	ai := &persistencespb.ActivityInfo{
+		ActivityType:            &activityType,
+		ActivityId:              "activityID",
+		CancelRequested:         false,
+		StartedEventId:          1,
+		Attempt:                 2,
+		ScheduledTime:           timestamppb.New(now),
+		LastAttemptCompleteTime: timestamppb.New(now.Add(-1 * time.Hour)),
+		HasRetryPolicy:          false,
+	}
+
+	for _, tc := range testCases {
+		ai.Paused = tc.paused
+		ai.CancelRequested = tc.cancelRequested
+		ai.StartedEventId = tc.startedEventId
+
+		s.mockMutableState.EXPECT().GetActivityType(gomock.Any(), gomock.Any()).Return(&activityType, nil).Times(1)
+		pi, err := GetPendingActivityInfo(context.Background(), s.mockShard, s.mockMutableState, ai)
+		s.NoError(err)
+		s.NotNil(pi)
+
+		s.Equal(tc.expectedState, pi.State, fmt.Sprintf("failed for paused: %v, cancelRequested: %v, startedEventId: %v", tc.paused, tc.cancelRequested, tc.startedEventId))
+	}
 }
 
 func (s *activitySuite) TestGetPendingActivityInfoNoRetryPolicy() {

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5447,6 +5447,7 @@ func (ms *MutableStateImpl) RetryActivity(
 			activityInfo.StartedEventId = common.EmptyEventID
 			activityInfo.StartedTime = nil
 			activityInfo.RequestId = ""
+			activityInfo.RetryLastFailure = ms.truncateRetryableActivityFailure(activityFailure)
 			return nil
 		}); err != nil {
 			return enumspb.RETRY_STATE_INTERNAL_SERVER_ERROR, err

--- a/tests/activity_api_reset_test.go
+++ b/tests/activity_api_reset_test.go
@@ -396,7 +396,7 @@ func (s *ActivityApiResetClientTestSuite) TestActivityResetApi_KeepPaused() {
 		assert.NotNil(t, description)
 		if description.GetPendingActivities() != nil {
 			assert.Len(t, description.GetPendingActivities(), 1)
-			assert.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, description.PendingActivities[0].State)
+			assert.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, description.PendingActivities[0].State)
 			// also verify that the number of attempts was not reset
 			assert.True(t, description.PendingActivities[0].Attempt > 1)
 			assert.True(t, description.PendingActivities[0].Paused)
@@ -423,7 +423,7 @@ func (s *ActivityApiResetClientTestSuite) TestActivityResetApi_KeepPaused() {
 		assert.NotNil(t, description)
 		if description.GetPendingActivities() != nil {
 			assert.Len(t, description.GetPendingActivities(), 1)
-			assert.Equal(t, enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, description.PendingActivities[0].State)
+			assert.Equal(t, enumspb.PENDING_ACTIVITY_STATE_PAUSED, description.PendingActivities[0].State)
 			// also verify that the number of attempts was reset
 			assert.Equal(t, int32(1), description.PendingActivities[0].Attempt)
 		}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
In DescribeWorkflow, for pending activities, introduce PAUSE and PAUSE_REQUESTED states.

## Why?
<!-- Tell your future self why have you made these changes -->
To clearly distinguish between "activity is paused on the server but running on the worker" vs "activity is paused on the server and not running on the worker"

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Add unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Some existing scripts, that rely on "activity is running means State == STARTED" may stop working.