### PR TITLE
CHASM: set and use valueState field

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -49,6 +49,15 @@ var (
 	errComponentNotFound = serviceerror.NewNotFound("component not found")
 )
 
+type valueState uint8
+
+const (
+	valueStateUndefined valueState = iota
+	valueStateSynced
+	valueStateNeedDeserialize
+	valueStateNeedSerialize
+)
+
 type (
 	// Node is the in-memory representation of a persisted CHASM node.
 	//
@@ -65,16 +74,13 @@ type (
 		serializedNode *persistencespb.ChasmNode // serialized component | data | collection with metadata
 		value          any                       // deserialized component | data | collection
 
-		// If valueSynced is false, the value field is not in sync with the persistence field.
-		// The field is only meaningful when value field is not nil.
-		//
+		// valueState indicates if the value field and the persistence field serializedNode are in sync.
+		// If new value might be changed since it was deserialized and serialize method wasn't called yet, then valueState is valueStateNeedSerialize.
+		// If a node is constructed from the database, then valueState is valueStateNeedDeserialize.
+		// If serialize or deserialize method were called, then valueState is valueStateSynced, and next calls to them would be no-op.
 		// NOTE: This is a different concept from the IsDirty() method needed by MutableState which means
 		// if the state in memory matches the state in DB.
-		//
-		// TODO: synced flag should be cleared
-		//   when values serializedNode and value got in-sync.
-		//   And deserialization/serialization can be skipped if synced flag is true.
-		valueSynced bool
+		valueState valueState
 	}
 
 	// nodeBase is a set of dependencies and states shared by all nodes in a CHASM tree.
@@ -152,9 +158,9 @@ func NewTree(
 		// Initialize empty serializedNode.
 		root.initSerializedNode(fieldTypeComponent)
 		// Although both value and serializedNode.Data are nil, they are considered NOT synced
-		// because value has no type but serializedNode does.
+		// because value has no type and serializedNode does.
 		// deserialize method should set value when called.
-		root.valueSynced = false
+		root.valueState = valueStateNeedDeserialize
 		return root, nil
 	}
 
@@ -247,7 +253,7 @@ func (n *Node) prepareComponentValue(
 		)
 	}
 
-	if !n.valueSynced {
+	if n.valueState == valueStateNeedDeserialize {
 		registrableComponent, ok := n.registry.component(componentAttr.GetType())
 		if !ok {
 			return nil, serviceerror.NewInternal(fmt.Sprintf("component type name not registered: %v", componentAttr.GetType()))
@@ -261,7 +267,9 @@ func (n *Node) prepareComponentValue(
 	// For now, we assume if a node is accessed with a MutableContext,
 	// its value will be mutated and no longer in sync with the serializedNode.
 	_, componentCanBeMutated := chasmContext.(MutableContext)
-	n.valueSynced = !componentCanBeMutated
+	if componentCanBeMutated {
+		n.valueState = valueStateNeedSerialize
+	}
 
 	return n.value, nil
 }
@@ -331,7 +339,7 @@ func (n *Node) setSerializedNode(
 ) {
 	if len(nodePath) == 0 {
 		n.serializedNode = serializedNode
-		n.valueSynced = false
+		n.valueState = valueStateNeedDeserialize
 		return
 	}
 
@@ -346,7 +354,7 @@ func (n *Node) setSerializedNode(
 
 // serialize sets or updates serializedValue field of the node n with serialized value.
 func (n *Node) serialize() error {
-	if n.valueSynced {
+	if n.valueState != valueStateNeedSerialize {
 		return nil
 	}
 
@@ -397,7 +405,9 @@ func (n *Node) serializeComponentNode() error {
 		n.serializedNode.Data = blob
 		n.serializedNode.GetMetadata().GetComponentAttributes().Type = rc.fqType()
 		n.updateLastUpdateVersionedTransition()
-		n.valueSynced = true
+		n.valueState = valueStateSynced
+
+		// continue to iterate over fields to validate that there is only one proto field in the component.
 	}
 	return nil
 }
@@ -457,7 +467,7 @@ func (n *Node) syncSubComponentsInternal(
 				}
 				childNode.value = internal.value
 				childNode.initSerializedNode(deduceFieldType(internal.value))
-				childNode.valueSynced = false
+				childNode.valueState = valueStateNeedSerialize
 
 				n.children[fieldN] = childNode
 				internal.node = childNode
@@ -514,7 +524,7 @@ func (n *Node) serializeDataNode() error {
 	}
 	n.serializedNode.Data = blob
 	n.updateLastUpdateVersionedTransition()
-	n.valueSynced = true
+	n.valueState = valueStateSynced
 
 	return nil
 }
@@ -537,7 +547,7 @@ func (n *Node) deserialize(
 		return err
 	}
 
-	if n.valueSynced {
+	if n.valueState != valueStateNeedDeserialize {
 		return nil
 	}
 
@@ -563,7 +573,7 @@ func (n *Node) deserializeComponentNode(
 		// serializedNode is empty (has only metadata) => use constructed value of valueT type as value and return.
 		// deserialize method acts as component constructor.
 		n.value = valueV.Interface()
-		n.valueSynced = true
+		n.valueState = valueStateSynced
 		return nil
 	}
 
@@ -625,7 +635,7 @@ func (n *Node) deserializeComponentNode(
 	}
 
 	n.value = valueV.Interface()
-	n.valueSynced = true
+	n.valueState = valueStateSynced
 	return nil
 }
 
@@ -638,7 +648,7 @@ func (n *Node) deserializeDataNode(
 	}
 
 	n.value = value.Interface()
-	n.valueSynced = true
+	n.valueState = valueStateSynced
 	return nil
 }
 
@@ -855,7 +865,7 @@ func (n *Node) applyUpdates(
 			n.mutation.UpdatedNodes[encodedPath] = updatedNode
 			node.serializedNode = updatedNode
 			node.value = nil
-			n.valueSynced = false
+			n.valueState = valueStateNeedDeserialize
 
 			// Clearing decoded value for ancestor nodes is not necessary because the value field is not referenced directly.
 			// Parent node is pointing to the Node struct.
@@ -918,21 +928,21 @@ func (n *Node) IsDirty() bool {
 		return true
 	}
 
-	return !n.isValueSynced()
+	return n.isValueNeedSerialize()
 }
 
-func (n *Node) isValueSynced() bool {
-	if !n.valueSynced {
-		return false
+func (n *Node) isValueNeedSerialize() bool {
+	if n.valueState == valueStateNeedSerialize {
+		return true
 	}
 
 	for _, childNode := range n.children {
-		if !childNode.isValueSynced() {
-			return false
+		if childNode.isValueNeedSerialize() {
+			return true
 		}
 	}
 
-	return true
+	return false
 }
 
 func newNode(

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -770,8 +770,10 @@ func (s *nodeSuite) testComponentTree() *Node {
 	s.NoError(err)
 	s.NotNil(node.value)
 
-	// Create subcommponents by assigning fileds to TestComponent instance.
+	// Create subcomponents by assigning fields to TestComponent instance.
 	setTestComponentFields(node.value.(*TestComponent))
+	// TODO: remove this when Field.Get is implemented.
+	node.valueSynced = false
 
 	// Sync tree with subcomponents of TestComponent.
 	s.nodeBackend.EXPECT().NextTransitionCount().Return(int64(1)).Times(4) // for InitialVersionedTransition of children.

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -152,7 +152,7 @@ func (s *nodeSuite) TestSerializeNode_ComponentAttributes() {
 	s.NotNil(node.serializedNode)
 	s.NotNil(node.serializedNode.GetData(), "node serialized value must have data after serialize is called")
 	s.Equal("TestLibrary.test_component", node.serializedNode.GetMetadata().GetComponentAttributes().GetType(), "node serialized value must have type set")
-	s.True(node.valueSynced)
+	s.Equal(valueStateSynced, node.valueState)
 
 	// Serialize subcomponents (there are 2 subcomponents).
 	sc1Node := node.children["SubComponent1"]
@@ -163,7 +163,7 @@ func (s *nodeSuite) TestSerializeNode_ComponentAttributes() {
 	for _, childNode := range node.children {
 		err = childNode.serialize()
 		s.NoError(err)
-		s.True(childNode.valueSynced)
+		s.Equal(valueStateSynced, childNode.valueState)
 	}
 	s.NotNil(sc1Node.serializedNode.GetData(), "child node serialized value must have data after serialize is called")
 	s.Equal("TestLibrary.test_sub_component_1", sc1Node.serializedNode.GetMetadata().GetComponentAttributes().GetType(), "node serialized value must have type set")
@@ -187,7 +187,7 @@ func (s *nodeSuite) TestSerializeNode_ClearComponentData() {
 	s.NotNil(node.serializedNode.GetMetadata().GetComponentAttributes(), "metadata must have component attributes")
 	s.Nil(node.serializedNode.GetData(), "data field must cleared to nil")
 	s.Equal("TestLibrary.test_component", node.serializedNode.GetMetadata().GetComponentAttributes().GetType(), "type must present")
-	s.True(node.valueSynced)
+	s.Equal(valueStateSynced, node.valueState)
 }
 
 func (s *nodeSuite) TestSerializeNode_ClearSubDataField() {
@@ -226,6 +226,7 @@ func (s *nodeSuite) TestSerializeNode_DataAttributes() {
 	node := newNode(s.nodeBase(), nil, "")
 	node.initSerializedNode(fieldTypeData)
 	node.value = component
+	node.valueState = valueStateNeedSerialize
 
 	s.nodeBackend.EXPECT().NextTransitionCount().Return(int64(1)).Times(1)
 	s.nodeBackend.EXPECT().GetCurrentVersion().Return(int64(1)).Times(1)
@@ -233,7 +234,7 @@ func (s *nodeSuite) TestSerializeNode_DataAttributes() {
 	s.NoError(err)
 	s.NotNil(node.serializedNode.GetData(), "child node serialized value must have data after serialize is called")
 	s.Equal([]byte{0x42, 0x2, 0x32, 0x32}, node.serializedNode.GetData().GetData())
-	s.True(node.valueSynced)
+	s.Equal(valueStateSynced, node.valueState)
 }
 
 func (s *nodeSuite) TestSyncSubComponents_DeleteLeafNode() {
@@ -289,7 +290,7 @@ func (s *nodeSuite) TestDeserializeNode_EmptyPersistence() {
 	s.NotNil(node.value)
 	s.IsType(&TestComponent{}, node.value)
 	tc := node.value.(*TestComponent)
-	s.True(node.valueSynced)
+	s.Equal(valueStateSynced, node.valueState)
 	s.Nil(tc.SubComponent1.Internal.node)
 	s.Nil(tc.SubComponent1.Internal.value)
 	s.Nil(tc.ComponentData)
@@ -302,7 +303,7 @@ func (s *nodeSuite) TestDeserializeNode_ComponentAttributes() {
 	s.NoError(err)
 	s.Nil(node.value)
 	s.NotNil(node.serializedNode)
-	s.False(node.valueSynced)
+	s.Equal(valueStateNeedDeserialize, node.valueState)
 
 	err = node.deserialize(reflect.TypeOf(&TestComponent{}))
 	s.NoError(err)
@@ -311,16 +312,16 @@ func (s *nodeSuite) TestDeserializeNode_ComponentAttributes() {
 	tc := node.value.(*TestComponent)
 	s.Equal(tc.SubComponent1.Internal.node, node.children["SubComponent1"])
 	s.Equal(tc.ComponentData.ActivityId, "component-data")
-	s.True(node.valueSynced)
+	s.Equal(valueStateSynced, node.valueState)
 
 	s.Nil(tc.SubComponent1.Internal.value)
-	s.False(tc.SubComponent1.Internal.node.valueSynced)
+	s.Equal(valueStateNeedDeserialize, tc.SubComponent1.Internal.node.valueState)
 	err = tc.SubComponent1.Internal.node.deserialize(reflect.TypeOf(&TestSubComponent1{}))
 	s.NoError(err)
 	s.NotNil(tc.SubComponent1.Internal.node.value)
 	s.IsType(&TestSubComponent1{}, tc.SubComponent1.Internal.node.value)
 	s.Equal("sub-component1-data", tc.SubComponent1.Internal.node.value.(*TestSubComponent1).SubComponent1Data.ActivityId)
-	s.True(tc.SubComponent1.Internal.node.valueSynced)
+	s.Equal(valueStateSynced, tc.SubComponent1.Internal.node.valueState)
 }
 
 func (s *nodeSuite) TestDeserializeNode_DataAttributes() {
@@ -334,7 +335,7 @@ func (s *nodeSuite) TestDeserializeNode_DataAttributes() {
 	err = node.deserialize(reflect.TypeOf(&TestComponent{}))
 	s.NoError(err)
 	s.NotNil(node.value)
-	s.True(node.valueSynced)
+	s.Equal(valueStateSynced, node.valueState)
 
 	s.IsType(&TestComponent{}, node.value)
 	tc := node.value.(*TestComponent)
@@ -345,7 +346,7 @@ func (s *nodeSuite) TestDeserializeNode_DataAttributes() {
 	err = tc.SubData1.Internal.node.deserialize(reflect.TypeOf(&protoMessageType{}))
 	s.NoError(err)
 	s.NotNil(tc.SubData1.Internal.node.value)
-	s.True(tc.SubData1.Internal.node.valueSynced)
+	s.Equal(valueStateSynced, tc.SubData1.Internal.node.valueState)
 	s.IsType(&protoMessageType{}, tc.SubData1.Internal.node.value)
 	s.Equal("sub-data1", tc.SubData1.Internal.node.value.(*protoMessageType).ActivityId)
 }
@@ -631,7 +632,7 @@ func (s *nodeSuite) TestComponent() {
 		chasmContext    Context
 		ref             ComponentRef
 		expectedErr     error
-		valueSynced     bool
+		valueState      valueState
 		assertComponent func(Component)
 	}{
 		{
@@ -684,7 +685,7 @@ func (s *nodeSuite) TestComponent() {
 				},
 			},
 			expectedErr:     nil,
-			valueSynced:     true,
+			valueState:      valueStateSynced,
 			assertComponent: assertTestComponent,
 		},
 		{
@@ -694,7 +695,7 @@ func (s *nodeSuite) TestComponent() {
 				componentPath: []string{}, // root
 			},
 			expectedErr:     nil,
-			valueSynced:     false,
+			valueState:      valueStateNeedSerialize,
 			assertComponent: assertTestComponent,
 		},
 	}
@@ -709,7 +710,7 @@ func (s *nodeSuite) TestComponent() {
 				node, ok := root.getNodeByPath(tc.ref.componentPath)
 				s.True(ok)
 				s.Equal(component, node.value)
-				s.Equal(tc.valueSynced, node.valueSynced)
+				s.Equal(tc.valueState, node.valueState)
 			}
 		})
 	}
@@ -781,12 +782,12 @@ func (s *nodeSuite) testComponentTree() *Node {
 	err = node.deserialize(reflect.TypeOf(&TestComponent{}))
 	s.NoError(err)
 	s.NotNil(node.value)
-	s.True(node.valueSynced)
+	s.Equal(valueStateSynced, node.valueState)
 
 	// Create subcomponents by assigning fields to TestComponent instance.
 	setTestComponentFields(node.value.(*TestComponent))
 	// TODO: remove this when Field.Get is implemented.
-	node.valueSynced = false
+	node.valueState = valueStateNeedSerialize
 
 	// Sync tree with subcomponents of TestComponent.
 	s.nodeBackend.EXPECT().NextTransitionCount().Return(int64(1)).Times(4) // for InitialVersionedTransition of children.


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
CHASM: set and use `valueState` field.

## Why?
<!-- Tell your future self why have you made these changes -->
`valueState` indicates if `value` and `serializedNode` are the same and call to `serialize`/`deserialize` methods can exit earlier and save on serialization/deserialization cost.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Modified existing unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No.
