### PR TITLE
Set Worker binary checksum in test

### DIFF
--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -44,6 +44,7 @@ import (
 	namespacepb "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/worker"
 	"go.temporal.io/server/api/adminservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
@@ -101,6 +102,13 @@ type (
 	}
 	TestClusterOption func(params *TestClusterParams)
 )
+
+func init() {
+	// By default, the SDK worker will calculate a checksum of the binary and use that as an identifier.
+	// But given the size of the test binary, that has a significant performance impact (100 ms or more).
+	// By specifying a checksum here, we can avoid that overhead.
+	worker.SetBinaryChecksum("oss-server-test")
+}
 
 // WithFxOptionsForService returns an Option which, when passed as an argument to setupSuite, will append the given list
 // of fx options to the end of the arguments to the fx.New call for the given service. For example, if you want to


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Setting worker binary checksum manually in functional tests.

## Why?
<!-- Tell your future self why have you made these changes -->

Slightly faster functional test startup.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

**Before**
<img width="3280" alt="Screenshot 2025-04-07 at 9 03 52 AM" src="https://github.com/user-attachments/assets/376937f0-8695-4e2f-8488-ef4265aa3d53" />

**After**
<img width="3280" alt="Screenshot 2025-04-07 at 9 04 34 AM" src="https://github.com/user-attachments/assets/d1bc16ae-dd0c-4313-8e8b-9ed7f7a08f28" />

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
