### PR TITLE
CHASM: Non-Workflow Mutable State P1 

### DIFF
--- a/api/persistence/v1/executions.pb.go
+++ b/api/persistence/v1/executions.pb.go
@@ -145,7 +145,7 @@ type WorkflowExecutionInfo struct {
 	WorkflowExecutionTimeout                *durationpb.Duration   `protobuf:"bytes,11,opt,name=workflow_execution_timeout,json=workflowExecutionTimeout,proto3" json:"workflow_execution_timeout,omitempty"`
 	WorkflowRunTimeout                      *durationpb.Duration   `protobuf:"bytes,12,opt,name=workflow_run_timeout,json=workflowRunTimeout,proto3" json:"workflow_run_timeout,omitempty"`
 	DefaultWorkflowTaskTimeout              *durationpb.Duration   `protobuf:"bytes,13,opt,name=default_workflow_task_timeout,json=defaultWorkflowTaskTimeout,proto3" json:"default_workflow_task_timeout,omitempty"`
-	LastEventTaskId                         int64                  `protobuf:"varint,17,opt,name=last_event_task_id,json=lastEventTaskId,proto3" json:"last_event_task_id,omitempty"`
+	LastRunningClock                        int64                  `protobuf:"varint,17,opt,name=last_running_clock,json=lastRunningClock,proto3" json:"last_running_clock,omitempty"`
 	LastFirstEventId                        int64                  `protobuf:"varint,18,opt,name=last_first_event_id,json=lastFirstEventId,proto3" json:"last_first_event_id,omitempty"`
 	LastCompletedWorkflowTaskStartedEventId int64                  `protobuf:"varint,19,opt,name=last_completed_workflow_task_started_event_id,json=lastCompletedWorkflowTaskStartedEventId,proto3" json:"last_completed_workflow_task_started_event_id,omitempty"`
 	// Deprecated. use `WorkflowExecutionState.start_time`
@@ -447,9 +447,9 @@ func (x *WorkflowExecutionInfo) GetDefaultWorkflowTaskTimeout() *durationpb.Dura
 	return nil
 }
 
-func (x *WorkflowExecutionInfo) GetLastEventTaskId() int64 {
+func (x *WorkflowExecutionInfo) GetLastRunningClock() int64 {
 	if x != nil {
-		return x.LastEventTaskId
+		return x.LastRunningClock
 	}
 	return 0
 }
@@ -4253,7 +4253,7 @@ const file_temporal_server_api_persistence_v1_executions_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\x05R\x03key\x12D\n" +
 	"\x05value\x18\x02 \x01(\v2..temporal.server.api.persistence.v1.QueueStateR\x05value:\x028\x01J\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\b\x10\tJ\x04\b\t\x10\n" +
 	"J\x04\b\n" +
-	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rJ\x04\b\x0e\x10\x0fJ\x04\b\x0f\x10\x10J\x04\b\x10\x10\x11\"\xc6:\n" +
+	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rJ\x04\b\x0e\x10\x0fJ\x04\b\x0f\x10\x10J\x04\b\x10\x10\x11\"\xc7:\n" +
 	"\x15WorkflowExecutionInfo\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12\x1f\n" +
 	"\vworkflow_id\x18\x02 \x01(\tR\n" +
@@ -4269,8 +4269,8 @@ const file_temporal_server_api_persistence_v1_executions_proto_rawDesc = "" +
 	" \x01(\tR\x10workflowTypeName\x12W\n" +
 	"\x1aworkflow_execution_timeout\x18\v \x01(\v2\x19.google.protobuf.DurationR\x18workflowExecutionTimeout\x12K\n" +
 	"\x14workflow_run_timeout\x18\f \x01(\v2\x19.google.protobuf.DurationR\x12workflowRunTimeout\x12\\\n" +
-	"\x1ddefault_workflow_task_timeout\x18\r \x01(\v2\x19.google.protobuf.DurationR\x1adefaultWorkflowTaskTimeout\x12+\n" +
-	"\x12last_event_task_id\x18\x11 \x01(\x03R\x0flastEventTaskId\x12-\n" +
+	"\x1ddefault_workflow_task_timeout\x18\r \x01(\v2\x19.google.protobuf.DurationR\x1adefaultWorkflowTaskTimeout\x12,\n" +
+	"\x12last_running_clock\x18\x11 \x01(\x03R\x10lastRunningClock\x12-\n" +
 	"\x13last_first_event_id\x18\x12 \x01(\x03R\x10lastFirstEventId\x12^\n" +
 	"-last_completed_workflow_task_started_event_id\x18\x13 \x01(\x03R'lastCompletedWorkflowTaskStartedEventId\x129\n" +
 	"\n" +

--- a/common/persistence/versionhistory/version_histories.go
+++ b/common/persistence/versionhistory/version_histories.go
@@ -168,3 +168,12 @@ func SetCurrentVersionHistoryIndex(h *historyspb.VersionHistories, currentVersio
 func GetCurrentVersionHistory(h *historyspb.VersionHistories) (*historyspb.VersionHistory, error) {
 	return GetVersionHistory(h, h.GetCurrentVersionHistoryIndex())
 }
+
+// IsCurrentVersionHistoryEmpty checks if the current VersionHistory is empty.
+func IsCurrentVersionHistoryEmpty(h *historyspb.VersionHistories) (bool, error) {
+	currentVersionHistory, err := GetCurrentVersionHistory(h)
+	if err != nil {
+		return false, err
+	}
+	return IsEmptyVersionHistory(currentVersionHistory), nil
+}

--- a/proto/internal/temporal/server/api/persistence/v1/executions.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/executions.proto
@@ -69,7 +69,7 @@ message WorkflowExecutionInfo {
     reserved 14;
     reserved 15;
     reserved 16;
-    int64 last_event_task_id = 17;
+    int64 last_running_clock = 17;
     int64 last_first_event_id = 18;
     int64 last_completed_workflow_task_started_event_id = 19;
     // Deprecated. use `WorkflowExecutionState.start_time`

--- a/service/history/ndc/workflow_test.go
+++ b/service/history/ndc/workflow_test.go
@@ -60,14 +60,14 @@ func (s *workflowSuite) TearDownTest() {
 }
 
 func (s *workflowSuite) TestGetMethods() {
-	lastEventTaskID := int64(144)
+	lastRunningClock := int64(144)
 	lastEventVersion := int64(12)
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().GetLastWriteVersion().Return(lastEventVersion, nil).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
-		NamespaceId:     s.namespaceID,
-		WorkflowId:      s.workflowID,
-		LastEventTaskId: lastEventTaskID,
+		NamespaceId:      s.namespaceID,
+		WorkflowId:       s.workflowID,
+		LastRunningClock: lastRunningClock,
 	}).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: s.runID,
@@ -88,65 +88,65 @@ func (s *workflowSuite) TestGetMethods() {
 	expectedReleaseFn := runtime.FuncForPC(reflect.ValueOf(wcache.NoopReleaseFn).Pointer()).Name()
 	actualReleaseFn := runtime.FuncForPC(reflect.ValueOf(nDCWorkflow.GetReleaseFn()).Pointer()).Name()
 	s.Equal(expectedReleaseFn, actualReleaseFn)
-	version, taskID, err := nDCWorkflow.GetVectorClock()
+	version, clock, err := nDCWorkflow.GetVectorClock()
 	s.NoError(err)
 	s.Equal(lastEventVersion, version)
-	s.Equal(lastEventTaskID, taskID)
+	s.Equal(lastRunningClock, clock)
 }
 
 func (s *workflowSuite) TestHappensAfter_LargerVersion() {
 	thisLastWriteVersion := int64(0)
-	thisLastEventTaskID := int64(100)
+	thisLastRunningClock := int64(100)
 	thatLastWriteVersion := thisLastWriteVersion - 1
-	thatLastEventTaskID := int64(123)
+	thatLastRunningClock := int64(123)
 
 	s.True(WorkflowHappensAfter(
 		thisLastWriteVersion,
-		thisLastEventTaskID,
+		thisLastRunningClock,
 		thatLastWriteVersion,
-		thatLastEventTaskID,
+		thatLastRunningClock,
 	))
 }
 
 func (s *workflowSuite) TestHappensAfter_SmallerVersion() {
 	thisLastWriteVersion := int64(0)
-	thisLastEventTaskID := int64(100)
+	thisLastRunningClock := int64(100)
 	thatLastWriteVersion := thisLastWriteVersion + 1
-	thatLastEventTaskID := int64(23)
+	thatLastRunningClock := int64(23)
 
 	s.False(WorkflowHappensAfter(
 		thisLastWriteVersion,
-		thisLastEventTaskID,
+		thisLastRunningClock,
 		thatLastWriteVersion,
-		thatLastEventTaskID,
+		thatLastRunningClock,
 	))
 }
 
 func (s *workflowSuite) TestHappensAfter_SameVersion_SmallerTaskID() {
 	thisLastWriteVersion := int64(0)
-	thisLastEventTaskID := int64(100)
+	thisLastRunningClock := int64(100)
 	thatLastWriteVersion := thisLastWriteVersion
-	thatLastEventTaskID := thisLastEventTaskID + 1
+	thatLastRunningClock := thisLastRunningClock + 1
 
 	s.False(WorkflowHappensAfter(
 		thisLastWriteVersion,
-		thisLastEventTaskID,
+		thisLastRunningClock,
 		thatLastWriteVersion,
-		thatLastEventTaskID,
+		thatLastRunningClock,
 	))
 }
 
 func (s *workflowSuite) TestHappensAfter_SameVersion_LatrgerTaskID() {
 	thisLastWriteVersion := int64(0)
-	thisLastEventTaskID := int64(100)
+	thisLastRunningClock := int64(100)
 	thatLastWriteVersion := thisLastWriteVersion
-	thatLastEventTaskID := thisLastEventTaskID - 1
+	thatLastRunningClock := thisLastRunningClock - 1
 
 	s.True(WorkflowHappensAfter(
 		thisLastWriteVersion,
-		thisLastEventTaskID,
+		thisLastRunningClock,
 		thatLastWriteVersion,
-		thatLastEventTaskID,
+		thatLastRunningClock,
 	))
 }
 
@@ -168,28 +168,28 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Error() {
 	)
 
 	// cannot suppress by older workflow
-	lastEventTaskID := int64(144)
+	lastRunningClock := int64(144)
 	lastEventVersion := int64(12)
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().GetLastWriteVersion().Return(lastEventVersion, nil).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
-		NamespaceId:     s.namespaceID,
-		WorkflowId:      s.workflowID,
-		LastEventTaskId: lastEventTaskID,
+		NamespaceId:      s.namespaceID,
+		WorkflowId:       s.workflowID,
+		LastRunningClock: lastRunningClock,
 	}).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: s.runID,
 	}).AnyTimes()
 
 	incomingRunID := uuid.New()
-	incomingLastEventTaskID := int64(144)
+	incomingLastRunningClock := int64(144)
 	incomingLastEventVersion := lastEventVersion - 1
 	incomingMockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	incomingMockMutableState.EXPECT().GetLastWriteVersion().Return(incomingLastEventVersion, nil).AnyTimes()
 	incomingMockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
-		NamespaceId:     s.namespaceID,
-		WorkflowId:      s.workflowID,
-		LastEventTaskId: incomingLastEventTaskID,
+		NamespaceId:      s.namespaceID,
+		WorkflowId:       s.workflowID,
+		LastRunningClock: incomingLastRunningClock,
 	}).AnyTimes()
 	incomingMockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: incomingRunID,
@@ -202,13 +202,13 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Error() {
 func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 	randomEventID := int64(2208)
 	wtFailedEventID := int64(2)
-	lastEventTaskID := int64(144)
+	lastRunningClock := int64(144)
 	lastEventVersion := int64(12)
 	s.mockMutableState.EXPECT().GetNextEventID().Return(randomEventID).AnyTimes() // This doesn't matter, GetNextEventID is not used if there is started WT.
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
-		NamespaceId:     s.namespaceID,
-		WorkflowId:      s.workflowID,
-		LastEventTaskId: lastEventTaskID,
+		NamespaceId:      s.namespaceID,
+		WorkflowId:       s.workflowID,
+		LastRunningClock: lastRunningClock,
 	}).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: s.runID,
@@ -221,7 +221,7 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 	)
 
 	incomingRunID := uuid.New()
-	incomingLastEventTaskID := int64(144)
+	incomingLastRunningClock := int64(144)
 	incomingLastEventVersion := lastEventVersion + 1
 	incomingMockContext := historyi.NewMockWorkflowContext(s.controller)
 	incomingMockMutableState := historyi.NewMockMutableState(s.controller)
@@ -234,9 +234,9 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 	incomingMockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	incomingMockMutableState.EXPECT().GetLastWriteVersion().Return(incomingLastEventVersion, nil).AnyTimes()
 	incomingMockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
-		NamespaceId:     s.namespaceID,
-		WorkflowId:      s.workflowID,
-		LastEventTaskId: incomingLastEventTaskID,
+		NamespaceId:      s.namespaceID,
+		WorkflowId:       s.workflowID,
+		LastRunningClock: incomingLastRunningClock,
 	}).AnyTimes()
 	incomingMockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: incomingRunID,
@@ -283,12 +283,12 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 }
 
 func (s *workflowSuite) TestSuppressWorkflowBy_Zombiefy() {
-	lastEventTaskID := int64(144)
+	lastRunningClock := int64(144)
 	lastEventVersion := int64(12)
 	executionInfo := &persistencespb.WorkflowExecutionInfo{
-		NamespaceId:     s.namespaceID,
-		WorkflowId:      s.workflowID,
-		LastEventTaskId: lastEventTaskID,
+		NamespaceId:      s.namespaceID,
+		WorkflowId:       s.workflowID,
+		LastRunningClock: lastRunningClock,
 	}
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(executionInfo).AnyTimes()
 	executionState := &persistencespb.WorkflowExecutionState{
@@ -308,7 +308,7 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Zombiefy() {
 	)
 
 	incomingRunID := uuid.New()
-	incomingLastEventTaskID := int64(144)
+	incomingLastRunningClock := int64(144)
 	incomingLastEventVersion := lastEventVersion + 1
 	incomingMockContext := historyi.NewMockWorkflowContext(s.controller)
 	incomingMockMutableState := historyi.NewMockMutableState(s.controller)
@@ -321,9 +321,9 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Zombiefy() {
 	incomingMockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	incomingMockMutableState.EXPECT().GetLastWriteVersion().Return(incomingLastEventVersion, nil).AnyTimes()
 	incomingMockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
-		NamespaceId:     s.namespaceID,
-		WorkflowId:      s.workflowID,
-		LastEventTaskId: incomingLastEventTaskID,
+		NamespaceId:      s.namespaceID,
+		WorkflowId:       s.workflowID,
+		LastRunningClock: incomingLastRunningClock,
 	}).AnyTimes()
 	incomingMockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: incomingRunID,

--- a/service/history/replication/executable_verify_versioned_transition_task.go
+++ b/service/history/replication/executable_verify_versioned_transition_task.go
@@ -149,6 +149,11 @@ func (e *ExecutableVerifyVersionedTransitionTask) Execute() error {
 		return e.verifyNewRunExist(ctx)
 	}
 
+	if len(e.taskAttr.EventVersionHistory) == 0 {
+		// no events to verify
+		return nil
+	}
+
 	targetHistory := &historyspb.VersionHistory{
 		Items: e.taskAttr.EventVersionHistory,
 	}

--- a/service/history/replication/sync_state_retriever.go
+++ b/service/history/replication/sync_state_retriever.go
@@ -522,6 +522,14 @@ func (s *SyncStateRetrieverImpl) getSyncStateEvents(ctx context.Context, workflo
 	if err != nil {
 		return nil, err
 	}
+
+	if versionhistory.IsEmptyVersionHistory(sourceHistory) {
+		return nil, nil
+	}
+
+	// TODO: we may need to handle the case where mutable state only starts to generate events during middle of its execution.
+	// In that case targetVersionHistories maybe empty and sourceVersionHistories is not empty.
+	// The LCA logic doesn't work in that case today.
 	lcaItem, _, err := versionhistory.FindLCAVersionHistoryItemFromItems(targetVersionHistories, sourceHistory.Items)
 	if err != nil {
 		return nil, err

--- a/service/history/timer_queue_standby_task_executor_test.go
+++ b/service/history/timer_queue_standby_task_executor_test.go
@@ -714,10 +714,10 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityTimeout_Multiple
 			s.Equal(1, len(input.UpdateWorkflowMutation.UpsertActivityInfos))
 			mutableState.GetExecutionInfo().LastUpdateTime = input.UpdateWorkflowMutation.ExecutionInfo.LastUpdateTime
 			input.RangeID = 0
-			input.UpdateWorkflowMutation.ExecutionInfo.LastEventTaskId = 0
+			input.UpdateWorkflowMutation.ExecutionInfo.LastRunningClock = 0
 			input.UpdateWorkflowMutation.ExecutionInfo.LastFirstEventTxnId = 0
 			input.UpdateWorkflowMutation.ExecutionInfo.StateTransitionCount = 0
-			mutableState.GetExecutionInfo().LastEventTaskId = 0
+			mutableState.GetExecutionInfo().LastRunningClock = 0
 			mutableState.GetExecutionInfo().LastFirstEventTxnId = 0
 			mutableState.GetExecutionInfo().StateTransitionCount = 0
 			mutableState.GetExecutionInfo().WorkflowTaskOriginalScheduledTime = input.UpdateWorkflowMutation.ExecutionInfo.WorkflowTaskOriginalScheduledTime

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -6567,9 +6567,9 @@ func (ms *MutableStateImpl) closeTransactionPrepareReplicationTasks(
 			replicationTasks = append(replicationTasks, task...)
 		}
 	}
-
 	replicationTasks = append(replicationTasks, ms.syncActivityToReplicationTask(transactionPolicy)...)
 	replicationTasks = append(replicationTasks, ms.dirtyHSMToReplicationTask(transactionPolicy, eventBatches, clearBufferEvents)...)
+
 	if ms.transitionHistoryEnabled {
 		switch transactionPolicy {
 		case historyi.TransactionPolicyActive:
@@ -6596,6 +6596,7 @@ func (ms *MutableStateImpl) closeTransactionPrepareReplicationTasks(
 					}
 					if !versionhistory.IsEmptyVersionHistory(currentHistory) {
 						item, err := versionhistory.GetLastVersionHistoryItem(currentHistory)
+						//nolint:revive // max-control-nesting: control flow nesting exceeds 5
 						if err != nil {
 							return err
 						}

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -4171,7 +4171,7 @@ func (s *mutableStateSuite) verifyExecutionInfo(current, target, origin *persist
 	s.True(proto.Equal(target.WorkflowExecutionTimeout, current.WorkflowExecutionTimeout), "WorkflowExecutionTimeout mismatch")
 	s.True(proto.Equal(target.WorkflowRunTimeout, current.WorkflowRunTimeout), "WorkflowRunTimeout mismatch")
 	s.True(proto.Equal(target.DefaultWorkflowTaskTimeout, current.DefaultWorkflowTaskTimeout), "DefaultWorkflowTaskTimeout mismatch")
-	s.Equal(target.LastEventTaskId, current.LastEventTaskId, "LastEventTaskId mismatch")
+	s.Equal(target.LastRunningClock, current.LastRunningClock, "LastRunningClock mismatch")
 	s.Equal(target.LastFirstEventId, current.LastFirstEventId, "LastFirstEventId mismatch")
 	s.Equal(target.LastCompletedWorkflowTaskStartedEventId, current.LastCompletedWorkflowTaskStartedEventId, "LastCompletedWorkflowTaskStartedEventId mismatch")
 	s.True(proto.Equal(target.StartTime, current.StartTime), "StartTime mismatch")

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -139,7 +139,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 	)); err != nil {
 		return nil, err
 	}
-	executionInfo.LastEventTaskId = lastEvent.GetTaskId()
+	executionInfo.LastRunningClock = lastEvent.GetTaskId()
 
 	for _, event := range history {
 		switch event.GetEventType() {

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -200,7 +200,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_No
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_WithCronSchedule() {
@@ -249,7 +249,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_Wi
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTimedOut() {
@@ -281,7 +281,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTimedOut()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTimedOut_WithNewRunHistory() {
@@ -345,7 +345,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTimedOut_W
 	newRunStateBuilder, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), newRunEvents, newRunID)
 	s.Nil(err)
 	s.NotNil(newRunStateBuilder)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 
 	newRunTasks := newRunStateBuilder.PopTasks()
 	s.Len(newRunTasks[tasks.CategoryTimer], 1)      // backoffTimer
@@ -380,7 +380,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTerminated
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTerminated_WithNewRunHistory() {
@@ -438,7 +438,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTerminated
 	newRunStateBuilder, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), newRunEvents, uuid.New())
 	s.Nil(err)
 	s.NotNil(newRunStateBuilder)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 
 	newRunTasks := newRunStateBuilder.PopTasks()
 	s.Len(newRunTasks[tasks.CategoryTimer], 3)      // backoff timer, runTimeout timer, executionTimeout timer
@@ -474,7 +474,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionFailed() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionFailed_WithNewRunHistory() {
@@ -538,7 +538,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionFailed_Wit
 	newRunStateBuilder, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), newRunEvents, newRunID)
 	s.Nil(err)
 	s.NotNil(newRunStateBuilder)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 
 	newRunTasks := newRunStateBuilder.PopTasks()
 	s.Len(newRunTasks[tasks.CategoryTimer], 2)      // backoffTimer, runTimeout timer
@@ -574,7 +574,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCompleted(
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCompleted_WithNewRunHistory() {
@@ -637,7 +637,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCompleted_
 	newRunStateBuilder, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), newRunEvents, newRunID)
 	s.Nil(err)
 	s.NotNil(newRunStateBuilder)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 
 	newRunTasks := newRunStateBuilder.PopTasks()
 	s.Len(newRunTasks[tasks.CategoryTimer], 0)
@@ -673,7 +673,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCanceled()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedAsNew() {
@@ -786,7 +786,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	)
 	s.Nil(err)
 	s.NotNil(newRunStateBuilder)
-	s.Equal(continueAsNewEvent.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(continueAsNewEvent.TaskId, s.executionInfo.LastRunningClock)
 
 	newRunTasks := newRunStateBuilder.PopTasks()
 	s.Empty(newRunTasks[tasks.CategoryTimer])
@@ -835,7 +835,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	)
 	s.Nil(err)
 	s.Nil(newRunStateBuilder)
-	s.Equal(continueAsNewEvent.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(continueAsNewEvent.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionSignaled() {
@@ -863,7 +863,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionSignaled()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCancelRequested() {
@@ -891,7 +891,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCancelRequ
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeUpsertWorkflowSearchAttributes() {
@@ -922,7 +922,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeUpsertWorkflowSearchAttribu
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowPropertiesModified() {
@@ -953,7 +953,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowPropertiesModified(
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeMarkerRecorded() {
@@ -980,7 +980,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeMarkerRecorded() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 // workflow task operations
@@ -1032,7 +1032,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskScheduled() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskStarted() {
 	version := int64(1)
@@ -1081,7 +1081,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskStarted() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskTimedOut() {
@@ -1126,7 +1126,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskTimedOut() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskFailed() {
@@ -1170,7 +1170,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskFailed() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskCompleted() {
@@ -1203,7 +1203,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskCompleted() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 // user timer operations
@@ -1248,7 +1248,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerStarted() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerFired() {
@@ -1279,7 +1279,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerFired() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerCanceled() {
@@ -1310,7 +1310,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerCanceled() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 // activity operations
@@ -1368,7 +1368,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskScheduled() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskStarted() {
@@ -1411,7 +1411,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskStarted() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(startedEvent), nil, "")
 	s.Nil(err)
-	s.Equal(startedEvent.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(startedEvent.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskTimedOut() {
@@ -1443,7 +1443,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskTimedOut() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskFailed() {
@@ -1474,7 +1474,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskFailed() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskCompleted() {
@@ -1505,7 +1505,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskCompleted() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskCancelRequested() {
@@ -1533,7 +1533,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskCancelRequested
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskCanceled() {
@@ -1564,7 +1564,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskCanceled() {
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 // child workflow operations
@@ -1617,7 +1617,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeStartChildWorkflowExecution
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeStartChildWorkflowExecutionFailed() {
@@ -1645,7 +1645,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeStartChildWorkflowExecution
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionStarted() {
@@ -1673,7 +1673,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionStart
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionTimedOut() {
@@ -1701,7 +1701,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionTimed
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionTerminated() {
@@ -1729,7 +1729,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionTermi
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionFailed() {
@@ -1757,7 +1757,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionFaile
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionCompleted() {
@@ -1785,7 +1785,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionCompl
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 // cancel external workflow operations
@@ -1842,7 +1842,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeRequestCancelExternalWorkfl
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeRequestCancelExternalWorkflowExecutionFailed() {
@@ -1870,7 +1870,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeRequestCancelExternalWorkfl
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeExternalWorkflowExecutionCancelRequested() {
@@ -1898,7 +1898,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeExternalWorkflowExecutionCa
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionCanceled() {
@@ -1926,7 +1926,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionCance
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 // signal external workflow operations
@@ -1989,7 +1989,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeSignalExternalWorkflowExecu
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeSignalExternalWorkflowExecutionFailed() {
@@ -2017,7 +2017,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeSignalExternalWorkflowExecu
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeExternalWorkflowExecutionSignaled() {
@@ -2045,7 +2045,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeExternalWorkflowExecutionSi
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.Nil(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionUpdateAccepted() {
@@ -2077,7 +2077,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionUpdateAcce
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.NoError(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionUpdateCompleted() {
@@ -2107,7 +2107,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionUpdateComp
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
 	s.NoError(err)
-	s.Equal(event.TaskId, s.executionInfo.LastEventTaskId)
+	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
 func (s *stateBuilderSuite) TestApplyEvents_HSMRegistry() {

--- a/service/history/workflow/mutable_state_state_status.go
+++ b/service/history/workflow/mutable_state_state_status.go
@@ -84,8 +84,8 @@ func setStateStatus(
 		case enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED:
 			if status != e.GetStatus() {
 				return invalidStateTransitionErr(e.GetState(), state, status)
-
 			}
+
 		case enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE:
 			return invalidStateTransitionErr(e.GetState(), state, status)
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Changes are mainly on replication side:
- Update mutable state GetCurrentVersion/StartVersion/CloseVersion() methods
- Update mutable state executionInfo.LastEventTaskID. and make sure it's updated even if a transition doesn't generate any events.
- Update state based replication logic to handle no event case (more changes in https://github.com/temporalio/temporal/pull/7700).

## Why?
<!-- Tell your future self why have you made these changes -->
- CHASM runs may not have events at all. We need to make sure logic continue to work in that case.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Existing tests
- Will have functional tests later when CHASM is ready to ensure things can work e2e.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
