### PR TITLE
Populate request ID in Nexus cancellation request events

### DIFF
--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -412,7 +412,9 @@ var TransitionTimedOut = hsm.NewTransition(
 // Operation machine transition to the STARTED state.
 func (o Operation) Cancel(node *hsm.Node, t time.Time, requestedEventID int64) (hsm.TransitionOutput, error) {
 	child, err := node.AddChild(CancelationMachineKey, Cancelation{
-		NexusOperationCancellationInfo: &persistencespb.NexusOperationCancellationInfo{},
+		NexusOperationCancellationInfo: &persistencespb.NexusOperationCancellationInfo{
+			RequestedEventId: requestedEventID,
+		},
 	})
 	if err != nil {
 		// This function should be called as part of command/event handling and it should not be called


### PR DESCRIPTION
## What changed?
Populating request ID in `NexusOperationCancelRequestCompleted` and `NexusOperationCancelRequestFailed` events.

## Why?
Missed in last PR
