### PR TITLE
Add comment containing location of Nexus handlers

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -332,6 +332,7 @@ func (handler *workflowTaskCompletedHandler) handleCommand(
 		return nil, handler.handleCommandProtocolMessage(ctx, command.GetProtocolMessageCommandAttributes(), msgs)
 
 	default:
+		// Nexus command handlers are registered in /components/nexusoperations/workflow/commands.go
 		ch, ok := handler.commandHandlerRegistry.Handler(command.GetCommandType())
 		if !ok {
 			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Unknown command type: %v", command.GetCommandType()))


### PR DESCRIPTION
This comment would help me, because I always forget where to find the Nexus handlers.