### PR TITLE
use initialVersionedTransition for Nexus completion token

### DIFF
--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -177,6 +177,9 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 	smRef := common.CloneProto(ref.StateMachineRef)
 	smRef.MachineTransitionCount = 0
 
+	// Set ms VT to initial version because workflow may switch to a different branch.
+	smRef.MutableStateVersionedTransition = smRef.MachineInitialVersionedTransition
+
 	token, err := e.CallbackTokenGenerator.Tokenize(&tokenspb.NexusOperationCompletion{
 		NamespaceId: ref.WorkflowKey.NamespaceID,
 		WorkflowId:  ref.WorkflowKey.WorkflowID,


### PR DESCRIPTION
## What changed?
Use initialVersionedTransition as ms versionedTransition for state machine reference in the Nexus completion token.

## Why?
When workflow switches branches, the ms versionedTransition in Nexus completion token may become stale and cannot pass the check when completion callback is triggered.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
