### PR TITLE
fix cryptic error message for FailedPrecondition failures

### DIFF
--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -543,6 +543,8 @@ func (d *ClientImpl) SetCurrentVersion(
 		return &res, nil
 	} else if failure := outcome.GetFailure(); failure.GetApplicationFailureInfo().GetType() == errVersionNotFound {
 		return nil, serviceerror.NewNotFound(errVersionNotFound)
+	} else if failure.GetApplicationFailureInfo().GetType() == errFailedPrecondition {
+		return nil, serviceerror.NewFailedPrecondition(failure.Message)
 	} else if failure != nil {
 		// TODO: is there an easy way to recover the original type here?
 		return nil, serviceerror.NewInternal(failure.Message)
@@ -635,6 +637,8 @@ func (d *ClientImpl) SetRampingVersion(
 		return nil, serviceerror.NewNotFound(errVersionNotFound)
 	} else if failure.GetApplicationFailureInfo().GetType() == errVersionAlreadyCurrentType {
 		return nil, serviceerror.NewFailedPrecondition(fmt.Sprintf("Ramping version %v is already current", version))
+	} else if failure.GetApplicationFailureInfo().GetType() == errFailedPrecondition {
+		return nil, serviceerror.NewFailedPrecondition(failure.Message)
 	} else if failure != nil {
 		return nil, serviceerror.NewInternal(failure.Message)
 	}

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -95,8 +95,8 @@ const (
 	errConflictTokenMismatchType  = "errConflictTokenMismatch"
 	errFailedPrecondition         = "FailedPrecondition"
 
-	ErrRampingVersionDoesNotHaveAllTaskQueues = "New ramping version does not have all the task queues from the previous current version and some missing task queues are active and would become unversioned after setting the new version as the ramping version"
-	ErrCurrentVersionDoesNotHaveAllTaskQueues = "New current version does not have all the task queues from the previous current version and some missing task queues are active and would become unversioned after setting the new version as the current version"
+	ErrRampingVersionDoesNotHaveAllTaskQueues = "New ramping version is missing active task queues from the current version; these would become unversioned after setting the new version as the ramping version"
+	ErrCurrentVersionDoesNotHaveAllTaskQueues = "New current version is missing active task queues from the previous current version; these would become unversioned after setting the new version as the current version"
 
 	syncBatchSize = 25
 )

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -95,8 +95,8 @@ const (
 	errConflictTokenMismatchType  = "errConflictTokenMismatch"
 	errFailedPrecondition         = "FailedPrecondition"
 
-	ErrRampingVersionDoesNotHaveAllTaskQueues = "New ramping version is missing active task queues from the current version; these would become unversioned after setting the new version as the ramping version"
-	ErrCurrentVersionDoesNotHaveAllTaskQueues = "New current version is missing active task queues from the previous current version; these would become unversioned after setting the new version as the current version"
+	ErrRampingVersionDoesNotHaveAllTaskQueues = "proposed ramping version is missing active task queues from the current version; these would become unversioned if it is set as the ramping version"
+	ErrCurrentVersionDoesNotHaveAllTaskQueues = "proposed current version is missing active task queues from the current version; these would become unversioned if it is set as the current version"
 
 	syncBatchSize = 25
 )

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -95,8 +95,8 @@ const (
 	errConflictTokenMismatchType  = "errConflictTokenMismatch"
 	errFailedPrecondition         = "FailedPrecondition"
 
-	ErrRampingVersionDoesNotHaveAllTaskQueues = "New ramping version does not have all the task queues from the previous current version and some missing task queues are active and would become unversioned after this operation"
-	ErrCurrentVersionDoesNotHaveAllTaskQueues = "New current version does not have all the task queues from the previous current version and some missing task queues are active and would become unversioned after this operation"
+	ErrRampingVersionDoesNotHaveAllTaskQueues = "New ramping version does not have all the task queues from the previous current version and some missing task queues are active and would become unversioned after setting the new version as the ramping version"
+	ErrCurrentVersionDoesNotHaveAllTaskQueues = "New current version does not have all the task queues from the previous current version and some missing task queues are active and would become unversioned after setting the new version as the current version"
 
 	syncBatchSize = 25
 )

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -93,6 +93,10 @@ const (
 	errVersionHasPollers          = "Version cannot be deleted since it has active pollers."
 	errVersionIsCurrentOrRamping  = "Version cannot be deleted since it is current or ramping."
 	errConflictTokenMismatchType  = "errConflictTokenMismatch"
+	errFailedPrecondition         = "FailedPrecondition"
+
+	ErrRampingVersionDoesNotHaveAllTaskQueues = "New ramping version does not have all the task queues from the previous current version and some missing task queues are active and would become unversioned after this operation"
+	ErrCurrentVersionDoesNotHaveAllTaskQueues = "New current version does not have all the task queues from the previous current version and some missing task queues are active and would become unversioned after this operation"
 
 	syncBatchSize = 25
 )

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -405,7 +405,7 @@ func (d *WorkflowRunner) handleSetRampingVersion(ctx workflow.Context, args *dep
 					return nil, err
 				}
 				if isMissingTaskQueues {
-					return nil, serviceerror.NewFailedPrecondition("New ramping version does not have all the task queues from the previous current version and some missing task queues are active and would become unversioned after this operation")
+					return nil, serviceerror.NewFailedPrecondition(ErrRampingVersionDoesNotHaveAllTaskQueues)
 				}
 			}
 			rampingSinceTime = routingUpdateTime
@@ -590,7 +590,7 @@ func (d *WorkflowRunner) handleSetCurrent(ctx workflow.Context, args *deployment
 			return nil, err
 		}
 		if isMissingTaskQueues {
-			return nil, serviceerror.NewFailedPrecondition("New current version does not have all the task queues from the previous current version and some missing task queues are active and would become unversioned after this operation")
+			return nil, serviceerror.NewFailedPrecondition(ErrCurrentVersionDoesNotHaveAllTaskQueues)
 		}
 	}
 

--- a/tests/worker_deployment_version_test.go
+++ b/tests/worker_deployment_version_test.go
@@ -972,6 +972,9 @@ func (s *DeploymentVersionSuite) TestDeleteVersion_ConcurrentDeleteVersion() {
 
 // VersionMissingTaskQueues
 func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_InvalidSetCurrentVersion() {
+	// Override the dynamic config to verify we don't get any unexpected masked errors.
+	s.OverrideDynamicConfig(dynamicconfig.FrontendMaskInternalErrorDetails, true)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	tv := testvars.New(s)
@@ -1013,8 +1016,7 @@ func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_InvalidSetCurrentV
 
 	// SetCurrent should fail since task_queue_1 does not have a current version than the deployment's existing current version
 	// and it either has a backlog of tasks being present or an add rate > 0.
-	s.Error(err)
-
+	s.EqualErrorf(err, workerdeployment.ErrCurrentVersionDoesNotHaveAllTaskQueues, err.Error())
 }
 
 func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_ValidSetCurrentVersion() {
@@ -1054,6 +1056,9 @@ func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_ValidSetCurrentVer
 }
 
 func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_InvalidSetRampingVersion() {
+	// Override the dynamic config to verify we don't get any unexpected masked errors.
+	s.OverrideDynamicConfig(dynamicconfig.FrontendMaskInternalErrorDetails, true)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	tv := testvars.New(s)
@@ -1095,7 +1100,7 @@ func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_InvalidSetRampingV
 
 	// SetRampingVersion should fail since task_queue_1 does not have a current version than the deployment's existing current version
 	// and it either has a backlog of tasks being present or an add rate > 0.
-	s.Error(err)
+	s.EqualErrorf(err, workerdeployment.ErrRampingVersionDoesNotHaveAllTaskQueues, err.Error())
 }
 
 func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_ValidSetRampingVersion() {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- `FailedPrecondition` Errors from the deployment workflows are returned as `FailedPrecondition` from the deployment client.


## Why?
<!-- Tell your future self why have you made these changes -->
- Right now, if a user were to call SetCurrent/SetRamping and our internal deployment workflows were to throw a FailedPrecondition error, the deployment client would convert them to `Internal` errors which in-turn would be masked by gRPC interceptors. 
- The error message would be super vague and something like (inside actual):
![image](https://github.com/user-attachments/assets/1c808340-5388-4190-86c3-e6fc26bc930e)


## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Altered existing tests to check for this. 

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
