### PR TITLE
Populate ScheduledEventID on NexusOperationCancelRequestCompleted|Failed

### DIFF
--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -545,7 +545,7 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 			handlerError := nexus.HandlerErrorf(nexus.HandlerErrorTypeNotFound, "endpoint not registered")
 
 			// The endpoint is not registered, immediately fail the invocation.
-			return e.saveCancelationResult(ctx, env, ref, handlerError)
+			return e.saveCancelationResult(ctx, env, ref, handlerError, args.scheduledEventID)
 		}
 		return err
 	}
@@ -612,7 +612,7 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 		e.Logger.Error("Nexus CancelOperation request failed", tag.Error(callErr))
 	}
 
-	err = e.saveCancelationResult(ctx, env, ref, callErr)
+	err = e.saveCancelationResult(ctx, env, ref, callErr, args.scheduledEventID)
 
 	if callErr != nil && isDestinationDown(callErr) {
 		err = queues.NewDestinationDownError(callErr.Error(), err)
@@ -625,6 +625,7 @@ type cancelArgs struct {
 	service, operation, token, endpointID, endpointName, requestID string
 	scheduledTime                                                  time.Time
 	scheduleToCloseTimeout                                         time.Duration
+	scheduledEventID                                               int64
 }
 
 // loadArgsForCancelation loads state from the operation state machine that's the parent of the cancelation machine the
@@ -648,12 +649,16 @@ func (e taskExecutor) loadArgsForCancelation(ctx context.Context, env hsm.Enviro
 		args.requestID = op.RequestId
 		args.scheduledTime = op.ScheduledTime.AsTime()
 		args.scheduleToCloseTimeout = op.ScheduleToCloseTimeout.AsDuration()
+		args.scheduledEventID, err = hsm.EventIDFromToken(op.ScheduledEventToken)
+		if err != nil {
+			return err
+		}
 		return nil
 	})
 	return
 }
 
-func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environment, ref hsm.Ref, callErr error) error {
+func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environment, ref hsm.Ref, callErr error, scheduledEventID int64) error {
 	return env.Access(ctx, ref, hsm.AccessWrite, func(n *hsm.Node) error {
 		return hsm.MachineTransition(n, func(c Cancelation) (hsm.TransitionOutput, error) {
 			if callErr != nil {
@@ -667,6 +672,7 @@ func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environ
 					// nolint:revive // We must mutate here even if the linter doesn't like it.
 					e.Attributes = &historypb.HistoryEvent_NexusOperationCancelRequestFailedEventAttributes{
 						NexusOperationCancelRequestFailedEventAttributes: &historypb.NexusOperationCancelRequestFailedEventAttributes{
+							ScheduledEventId: scheduledEventID,
 							RequestedEventId: c.RequestedEventId,
 							Failure:          failure,
 						},
@@ -695,6 +701,7 @@ func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environ
 				// nolint:revive // We must mutate here even if the linter doesn't like it.
 				e.Attributes = &historypb.HistoryEvent_NexusOperationCancelRequestCompletedEventAttributes{
 					NexusOperationCancelRequestCompletedEventAttributes: &historypb.NexusOperationCancelRequestCompletedEventAttributes{
+						ScheduledEventId: scheduledEventID,
 						RequestedEventId: c.RequestedEventId,
 					},
 				}

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	go.temporal.io/api v1.47.1-0.20250416163440-8d5dc336831c
+	go.temporal.io/api v1.47.1-0.20250416230922-71e208db57f4
 	go.temporal.io/sdk v1.33.0
 	go.temporal.io/version v0.3.0
 	go.uber.org/automaxprocs v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.47.1-0.20250416163440-8d5dc336831c h1:KCZNvVGBmJxMQ6OcMWx1TFx1qU8jx1X2OpH7521UwSA=
-go.temporal.io/api v1.47.1-0.20250416163440-8d5dc336831c/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.47.1-0.20250416230922-71e208db57f4 h1:8f0MeKtxfAReDLFiqnf2HNPukUYwh51g5d9KZcizIAI=
+go.temporal.io/api v1.47.1-0.20250416230922-71e208db57f4/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.33.0 h1:T91UzeRdlHTiMGgpygsItOH9+VSkg+M/mG85PqNjdog=
 go.temporal.io/sdk v1.33.0/go.mod h1:WwCmJZLy7zabz3ar5NRAQEygsdP8tgR9sDjISSHuWZw=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=


### PR DESCRIPTION
## What changed?
Populating ScheduledEventID on NexusOperationCancelRequestCompleted and NexusOperationCancelRequestFailed events.

Depends on API PR (see for more details): https://github.com/temporalio/api/pull/572
