### PR TITLE
Use Submit on replication task scheduler to avoid dangling task

### DIFF
--- a/service/history/replication/stream_receiver.go
+++ b/service/history/replication/stream_receiver.go
@@ -359,11 +359,7 @@ func (r *StreamReceiverImpl) processMessages(
 			Watermark: exclusiveHighWatermark,
 			Timestamp: exclusiveHighWatermarkTime,
 		}, convertedTasks...) {
-			if submitted := taskScheduler.TrySubmit(task); !submitted {
-				r.logger.Warn("no enough worker to process replication tasks")
-				taskScheduler.Submit(task)
-			}
-
+			taskScheduler.Submit(task)
 		}
 	}
 	return nil


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Use Submit on replication task scheduler to avoid dangling task
## Why?
<!-- Tell your future self why have you made these changes -->
The scheduler implementation does not support TrySubmit then Submit call. If we call in this sequence, it will cause dangling task.
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Verified at test cluster
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no risk. This is to revert a change that introduce a month ago
## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
yes