### PR TITLE
Add Workflow static check to CI

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -75,9 +75,7 @@ jobs:
       - uses: arduino/setup-protoc@v3
 
       - name: lint system workflows with workflowcheck
-        run: |
-          make workflowcheck      
-          - run: make workflowcheck
+        run: make workflowcheck
 
   fmt-imports:
     runs-on: ubuntu-latest

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -58,6 +58,26 @@ jobs:
       - name: lint protobuf API definitions
         run: |
           make lint-api
+          
+
+  lint-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+
+      - uses: arduino/setup-protoc@v3
+
+      - name: lint system workflows with workflowcheck
+        run: |
+          make workflowcheck      
+          - run: make workflowcheck
 
   fmt-imports:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -224,6 +224,9 @@ jobs:
       - run: make clean-bins ci-build-misc
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
 
+      - run: make workflowcheck
+        if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
+
   unit-test:
     if: ${{ inputs.run_single_functional_test != true }}
     name: Unit test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -224,9 +224,6 @@ jobs:
       - run: make clean-bins ci-build-misc
         if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
 
-      - run: make workflowcheck
-        if: ${{ !inputs.run_single_functional_test && !inputs.run_single_unit_test }}
-
   unit-test:
     if: ${{ inputs.run_single_functional_test != true }}
     name: Unit test

--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ shell-check:
 
 workflowcheck: $(WORKFLOWCHECK)
 	@printf $(COLOR) "Run workflowcheck for system workflows..."
-	for dir in ./service/worker/*/ ; do \
+	for dir in $(SYSTEM_WORKFLOWS_ROOT)/*/ ; do \
 		echo "Running workflowcheck on $$dir" ; \
 		$(WORKFLOWCHECK) "$$dir" ; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -205,9 +205,10 @@ ACTIONLINT := $(LOCALBIN)/actionlint-$(ACTIONLINT_VER)
 $(ACTIONLINT): | $(LOCALBIN)
 	$(call go-install-tool,$(ACTIONLINT),github.com/rhysd/actionlint/cmd/actionlint,$(ACTIONLINT_VER))
 
-WORKFLOWCHECK := $(LOCALBIN)/workflowcheck
+WORKFLOWCHECK_VER := v0.3.0
+WORKFLOWCHECK := $(LOCALBIN)/workflowcheck-$(WORKFLOWCHECK_VER)
 $(WORKFLOWCHECK): | $(LOCALBIN)
-	$(call go-install-tool,$(WORKFLOWCHECK),go.temporal.io/sdk/contrib/tools/workflowcheck,latest)
+	$(call go-install-tool,$(WORKFLOWCHECK),go.temporal.io/sdk/contrib/tools/workflowcheck,$(WORKFLOWCHECK_VER))
 
 # The following tools need to have a consistent name, so we use a versioned stamp file to ensure the version we want is installed
 # while installing to an unversioned binary name.

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,6 @@ ACTIONLINT := $(LOCALBIN)/actionlint-$(ACTIONLINT_VER)
 $(ACTIONLINT): | $(LOCALBIN)
 	$(call go-install-tool,$(ACTIONLINT),github.com/rhysd/actionlint/cmd/actionlint,$(ACTIONLINT_VER))
 
-WORKFLOWCHECK_VER := latest
 WORKFLOWCHECK := $(LOCALBIN)/workflowcheck
 $(WORKFLOWCHECK): | $(LOCALBIN)
 	$(call go-install-tool,$(WORKFLOWCHECK),go.temporal.io/sdk/contrib/tools/workflowcheck,latest)

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ INTEGRATION_TEST_DIRS := $(DB_INTEGRATION_TEST_ROOT) $(DB_TOOL_INTEGRATION_TEST_
 ifeq ($(UNIT_TEST_DIRS),)
 UNIT_TEST_DIRS := $(filter-out $(FUNCTIONAL_TEST_ROOT)% $(FUNCTIONAL_TEST_XDC_ROOT)% $(FUNCTIONAL_TEST_NDC_ROOT)% $(DB_INTEGRATION_TEST_ROOT)% $(DB_TOOL_INTEGRATION_TEST_ROOT)% ./temporaltest%,$(TEST_DIRS))
 endif
+SYSTEM_WORKFLOWS_ROOT := ./service/worker
 
 # Pinning modernc.org/sqlite to this version until https://gitlab.com/cznic/sqlite/-/issues/196 is resolved.
 PINNED_DEPENDENCIES := \
@@ -203,6 +204,11 @@ ACTIONLINT_VER := v1.7.7
 ACTIONLINT := $(LOCALBIN)/actionlint-$(ACTIONLINT_VER)
 $(ACTIONLINT): | $(LOCALBIN)
 	$(call go-install-tool,$(ACTIONLINT),github.com/rhysd/actionlint/cmd/actionlint,$(ACTIONLINT_VER))
+
+WORKFLOWCHECK_VER := latest
+WORKFLOWCHECK := $(LOCALBIN)/workflowcheck
+$(WORKFLOWCHECK): | $(LOCALBIN)
+	$(call go-install-tool,$(WORKFLOWCHECK),go.temporal.io/sdk/contrib/tools/workflowcheck,latest)
 
 # The following tools need to have a consistent name, so we use a versioned stamp file to ensure the version we want is installed
 # while installing to an unversioned binary name.
@@ -380,6 +386,13 @@ buf-breaking: $(BUF) $(API_BINPB) $(INTERNAL_BINPB)
 shell-check:
 	@printf $(COLOR) "Run shellcheck for script files..."
 	@shellcheck $(ALL_SCRIPTS)
+
+workflowcheck: $(WORKFLOWCHECK)
+	@printf $(COLOR) "Run workflowcheck for system workflows..."
+	for dir in ./service/worker/*/ ; do \
+		echo "Running workflowcheck on $$dir" ; \
+		$(WORKFLOWCHECK) "$$dir" ; \
+	done
 
 check: copyright-check lint shell-check
 

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -222,7 +222,8 @@ func (d *WorkflowRunner) addVersionToWorkerDeployment(ctx workflow.Context, args
 		return nil
 	}
 
-	for _, v := range d.State.Versions {
+	for _, k := range workflow.DeterministicKeys(d.State.Versions) {
+		v := d.State.Versions[k]
 		if v.Version == args.Version {
 			return nil
 		}


### PR DESCRIPTION
## What changed?
- Add `make workflowcheck` and run it in CI checks
- Fix issues in existing system workflows. These fixes should not cause replay errors, because the ordering of map keys did not change which Temporal history events were generated, nor does switching from `time.Now()` to `workflow.Now()`
## Why?
<!-- Tell your future self why have you made these changes -->

## How did you test it?
- Scheduler has replay unit tests that should catch any issues introduced by these changes
- Worker Deployment also has replay unit tests
- Deployment isn't used by any customers, so the lack of replay tests doesn't matter
- Replication workflow does not have replay tests, but the only change there was `time.Now()->workflow.Now()`

## Potential risks
Force replication workflow gets an NDE because `time.Now()` was replaced with `workflow.Now()`

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
