### PR TITLE
forbid panics in linter

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -43,6 +43,8 @@ linters-settings:
     forbid:
       - p: time.Sleep
         msg: "Please use require.Eventually or assert.Eventually instead unless you've no other option"
+      - p: panic
+        msg: "Please avoid using panic in application code"
   importas:
     # Enforce the aliases below.
     no-unaliased: true

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -93,8 +93,7 @@ func (it *iteratorImpl) HasNext() bool {
 // Next return the next item
 func (it *iteratorImpl) Next() Entry {
 	if it.nextItem == nil {
-		panic("this is my newly introduced panic")
-		// panic("LRU cache iterator Next called when there is no next item")
+		panic("LRU cache iterator Next called when there is no next item")
 	}
 
 	entry := it.nextItem.Value.(*entryImpl)

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -93,7 +93,8 @@ func (it *iteratorImpl) HasNext() bool {
 // Next return the next item
 func (it *iteratorImpl) Next() Entry {
 	if it.nextItem == nil {
-		panic("LRU cache iterator Next called when there is no next item")
+		panic("this is my newly introduced panic")
+		// panic("LRU cache iterator Next called when there is no next item")
 	}
 
 	entry := it.nextItem.Value.(*entryImpl)


### PR DESCRIPTION
## What changed?
Forbid use of panics in new code

## Why?
We had an incident because of a panic, so we want to only add panics if we are very sure panic-ing is the right thing to do. If people need to add a panic they can bypass the linter with a forbidigo comment as we do for time.Sleep

## How did you test it?
I introduced a new panic and saw the linter catch it https://github.com/temporalio/temporal/actions/runs/14503587534

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
