### PR TITLE
Skip error logs CreateWorkflowExecution for ResourceExhausted errors

### DIFF
--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -374,7 +374,7 @@ func createWorkflowExecution(
 			*persistence.ConditionFailedError,
 			*serviceerror.ResourceExhausted:
 			// it is possible that workflow already exists and caller need to apply
-			// workflow ID reuse policy, or the error is due to resource exhausted.
+			// workflow ID reuse policy, or the error is resource exhausted.
 			return nil, err
 		default:
 			shardContext.GetLogger().Error(

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -371,12 +371,13 @@ func createWorkflowExecution(
 		switch err.(type) {
 		case *persistence.CurrentWorkflowConditionFailedError,
 			*persistence.WorkflowConditionFailedError,
-			*persistence.ConditionFailedError:
+			*persistence.ConditionFailedError,
+			*serviceerror.ResourceExhausted:
 			// it is possible that workflow already exists and caller need to apply
 			// workflow ID reuse policy
 			return nil, err
 		default:
-			shardContext.GetThrottledLogger().Error(
+			shardContext.GetLogger().Error(
 				"Persistent store operation Failure",
 				tag.WorkflowNamespaceID(request.NewWorkflowSnapshot.ExecutionInfo.NamespaceId),
 				tag.WorkflowID(request.NewWorkflowSnapshot.ExecutionInfo.WorkflowId),

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -374,7 +374,7 @@ func createWorkflowExecution(
 			*persistence.ConditionFailedError,
 			*serviceerror.ResourceExhausted:
 			// it is possible that workflow already exists and caller need to apply
-			// workflow ID reuse policy
+			// workflow ID reuse policy, or the error is due to resource exhausted.
 			return nil, err
 		default:
 			shardContext.GetLogger().Error(

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -376,7 +376,7 @@ func createWorkflowExecution(
 			// workflow ID reuse policy
 			return nil, err
 		default:
-			shardContext.GetLogger().Error(
+			shardContext.GetThrottledLogger().Error(
 				"Persistent store operation Failure",
 				tag.WorkflowNamespaceID(request.NewWorkflowSnapshot.ExecutionInfo.NamespaceId),
 				tag.WorkflowID(request.NewWorkflowSnapshot.ExecutionInfo.WorkflowId),


### PR DESCRIPTION
## What changed?
Skip error logs CreateWorkflowExecution for ResourceExhausted errors

## Why?
This can lead to large amount of logging. And it is not very useful

