### PR TITLE
CHASM: remove invalid tasks

### DIFF
--- a/chasm/task.go
+++ b/chasm/task.go
@@ -46,7 +46,7 @@ type (
 	}
 
 	TaskValidator[C any, T any] interface {
-		Validate(Context, C, T) error
+		Validate(Context, C, T) (bool, error)
 	}
 )
 

--- a/chasm/task_mock.go
+++ b/chasm/task_mock.go
@@ -141,11 +141,12 @@ func (m *MockTaskValidator[C, T]) EXPECT() *MockTaskValidatorMockRecorder[C, T] 
 }
 
 // Validate mocks base method.
-func (m *MockTaskValidator[C, T]) Validate(arg0 Context, arg1 C, arg2 T) error {
+func (m *MockTaskValidator[C, T]) Validate(arg0 Context, arg1 C, arg2 T) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Validate indicates an expected call of Validate.

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -26,6 +26,7 @@ package chasm
 
 import (
 	"cmp"
+	"context"
 	"fmt"
 	"reflect"
 	"slices"
@@ -669,7 +670,7 @@ func (n *Node) deserializeComponentNode(
 			}
 			protoMessageFound = true
 
-			value, err := n.unmarshalProto(n.serializedNode.GetData(), fieldT)
+			value, err := unmarshalProto(n.serializedNode.GetData(), fieldT)
 			if err != nil {
 				return err
 			}
@@ -717,7 +718,7 @@ func (n *Node) deserializeComponentNode(
 func (n *Node) deserializeDataNode(
 	valueT reflect.Type,
 ) error {
-	value, err := n.unmarshalProto(n.serializedNode.GetData(), valueT)
+	value, err := unmarshalProto(n.serializedNode.GetData(), valueT)
 	if err != nil {
 		return err
 	}
@@ -727,7 +728,7 @@ func (n *Node) deserializeDataNode(
 	return nil
 }
 
-func (n *Node) unmarshalProto(
+func unmarshalProto(
 	dataBlob *commonpb.DataBlob,
 	valueT reflect.Type,
 ) (reflect.Value, error) {
@@ -823,7 +824,25 @@ func (n *Node) closeTransactionUpdateComponentTasks() error {
 			return nil
 		}
 
-		// TODO: Validate existing tasks and remove them if no longer valid.
+		// Validate existing tasks and remove invalid ones.
+		validateContext := NewContext(context.Background(), n)
+		var validationErr error
+		deleteFunc := func(existingTask *persistencespb.ChasmComponentAttributes_Task) bool {
+			valid, err := node.validateComponentTask(validateContext, existingTask)
+			if err != nil {
+				validationErr = err
+				return false
+			}
+			return !valid
+		}
+		componentAttr.SideEffectTasks = slices.DeleteFunc(componentAttr.SideEffectTasks, deleteFunc)
+		if validationErr != nil {
+			return validationErr
+		}
+		componentAttr.PureTasks = slices.DeleteFunc(componentAttr.PureTasks, deleteFunc)
+		if validationErr != nil {
+			return validationErr
+		}
 
 		// no-op if no new tasks for this component
 		newTasks, ok := node.nodeBase.newTasks[node.value]
@@ -867,6 +886,34 @@ func (n *Node) closeTransactionUpdateComponentTasks() error {
 
 		return nil
 	})
+}
+
+func (n *Node) validateComponentTask(
+	validateContext Context,
+	componentTask *persistencespb.ChasmComponentAttributes_Task,
+) (bool, error) {
+	registableTask, ok := n.registry.task(componentTask.Type)
+	if !ok {
+		return false, serviceerror.NewInternal(fmt.Sprintf("task type %s is not registered", componentTask.Type))
+	}
+
+	// TODO: cache validateMethod (reflect.Value) in the registry
+	validator := registableTask.validator
+	validateMethod := reflect.ValueOf(validator).MethodByName("Validate")
+
+	// TODO: cache deserialized task value (reflect.Value) in the node,
+	// use task VT and offset as the key
+	deserizedTaskValue, err := deserializeTask(registableTask, componentTask.Data)
+	if err != nil {
+		return false, err
+	}
+
+	retValues := validateMethod.Call([]reflect.Value{
+		reflect.ValueOf(validateContext),
+		reflect.ValueOf(n.value),
+		deserizedTaskValue,
+	})
+	return retValues[0].IsNil(), nil
 }
 
 func (n *Node) closeTransactionGeneratePhysicalSideEffectTasks() error {
@@ -1327,6 +1374,63 @@ func taskCategory(
 		return tasks.CategoryTransfer, nil
 	}
 	return tasks.CategoryTimer, nil
+}
+
+func deserializeTask(
+	registrableTask *RegistrableTask,
+	taskBlob *commonpb.DataBlob,
+) (taskValue reflect.Value, retErr error) {
+	if registrableTask.goType.AssignableTo(protoMessageT) {
+		taskValue, err := unmarshalProto(taskBlob, registrableTask.goType)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		return taskValue, nil
+	}
+
+	taskGoType := registrableTask.goType
+	if taskGoType.Kind() == reflect.Ptr {
+		taskGoType = taskGoType.Elem()
+	}
+	taskValue = reflect.New(taskGoType)
+
+	// At this point taskGoType is guaranteed to be a struct and
+	// taskValue is a pointer to struct.
+
+	defer func() {
+		if retErr == nil && registrableTask.goType.Kind() == reflect.Struct {
+			taskValue = taskValue.Elem()
+		}
+	}()
+
+	if taskGoType.NumField() == 0 {
+		return taskValue, nil
+	}
+
+	// TODO: consider pre-calculating the proto field num when registring the task type.
+
+	protoMessageFound := false
+	for i := 0; i < taskGoType.NumField(); i++ {
+		fieldV := taskValue.Elem().Field(i)
+		fieldT := taskGoType.Field(i).Type
+		if !fieldT.AssignableTo(protoMessageT) {
+			continue
+		}
+
+		if protoMessageFound {
+			return reflect.Value{}, serviceerror.NewInternal("only one proto field allowed in task struct")
+		}
+		protoMessageFound = true
+
+		value, err := unmarshalProto(taskBlob, fieldT)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+
+		fieldV.Set(value)
+	}
+
+	return taskValue, nil
 }
 
 func serializeTask(

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -913,7 +913,12 @@ func (n *Node) validateComponentTask(
 		reflect.ValueOf(n.value),
 		deserizedTaskValue,
 	})
-	return retValues[0].IsNil(), nil
+	if !retValues[1].IsNil() {
+		//revive:disable-next-line:unchecked-type-assertion
+		return false, retValues[1].Interface().(error)
+	}
+	//revive:disable-next-line:unchecked-type-assertion
+	return retValues[0].Interface().(bool), nil
 }
 
 func (n *Node) closeTransactionGeneratePhysicalSideEffectTasks() error {

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -1070,15 +1070,15 @@ func (s *nodeSuite) TestCloseTransaction_InvalidateComponentTasks() {
 	rt, ok := s.registry.Task("TestLibrary.test_side_effect_task")
 	s.True(ok)
 	rt.validator.(*MockTaskValidator[any, *TestSideEffectTask]).EXPECT().
-		Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("task is invalid")).Times(1)
+		Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 	rt, ok = s.registry.Task("TestLibrary.test_outbound_side_effect_task")
 	s.True(ok)
 	rt.validator.(*MockTaskValidator[any, TestOutboundSideEffectTask]).EXPECT().
-		Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 	rt, ok = s.registry.Task("TestLibrary.test_pure_task")
 	s.True(ok)
 	rt.validator.(*MockTaskValidator[any, *TestPureTask]).EXPECT().
-		Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("task is invalid")).Times(1)
+		Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 
 	err = root.closeTransactionUpdateComponentTasks()
 	s.NoError(err)

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -934,7 +934,7 @@ func (s *nodeSuite) TestGetComponent() {
 	}
 }
 
-func (s *nodeSuite) TestSeralizeTask() {
+func (s *nodeSuite) TestSeralizeDeserializeTask() {
 	payload := &commonpb.Payload{
 		Data: []byte("some-random-data"),
 	}
@@ -945,6 +945,7 @@ func (s *nodeSuite) TestSeralizeTask() {
 		name         string
 		task         any
 		expectedData []byte
+		equalFn      func(t1, t2 any)
 	}{
 		{
 			name: "ProtoTask",
@@ -952,11 +953,19 @@ func (s *nodeSuite) TestSeralizeTask() {
 				Data: []byte("some-random-data"),
 			},
 			expectedData: expectedBlob.GetData(),
+			equalFn: func(t1, t2 any) {
+				protorequire.ProtoEqual(s.T(), t1.(*TestSideEffectTask), t2.(*TestSideEffectTask))
+			},
 		},
 		{
 			name:         "EmptyTask",
 			task:         TestOutboundSideEffectTask{},
 			expectedData: nil,
+			equalFn: func(t1, t2 any) {
+				s.IsType(TestOutboundSideEffectTask{}, t1)
+				s.IsType(TestOutboundSideEffectTask{}, t2)
+				s.Equal(t1, t2)
+			},
 		},
 		{
 			name: "StructWithProtoField",
@@ -964,6 +973,9 @@ func (s *nodeSuite) TestSeralizeTask() {
 				Payload: payload,
 			},
 			expectedData: expectedBlob.GetData(),
+			equalFn: func(t1, t2 any) {
+				protorequire.ProtoEqual(s.T(), t1.(*TestPureTask).Payload, t2.(*TestPureTask).Payload)
+			},
 		},
 	}
 
@@ -975,12 +987,106 @@ func (s *nodeSuite) TestSeralizeTask() {
 			blob, err := serializeTask(rt, tc.task)
 			s.NoError(err)
 
-			// TODO: test the serialized blob by deserializing it back
 			s.NotNil(blob)
 			s.Equal(enumspb.ENCODING_TYPE_PROTO3, blob.GetEncodingType())
 			s.Equal(tc.expectedData, blob.GetData())
+
+			deserializedTaskValue, err := deserializeTask(rt, blob)
+			s.NoError(err)
+			tc.equalFn(tc.task, deserializedTaskValue.Interface())
 		})
 	}
+}
+
+func (s *nodeSuite) TestCloseTransaction_InvalidateComponentTasks() {
+	payload := &commonpb.Payload{
+		Data: []byte("some-random-data"),
+	}
+	taskBlob, err := serialization.ProtoEncodeBlob(payload, enumspb.ENCODING_TYPE_PROTO3)
+	s.NoError(err)
+
+	persistenceNodes := map[string]*persistencespb.ChasmNode{
+		"": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+				Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+					ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+						Type: "TestLibrary.test_component",
+						SideEffectTasks: []*persistencespb.ChasmComponentAttributes_Task{
+							{
+								Type:                      "TestLibrary.test_side_effect_task",
+								VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+								VersionedTransitionOffset: 1,
+								Data:                      taskBlob,
+								PhysicalTaskStatus:        physicalTaskStatusCreated,
+							},
+							{
+								Type:                      "TestLibrary.test_outbound_side_effect_task",
+								VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+								VersionedTransitionOffset: 2,
+								Data: &commonpb.DataBlob{
+									Data:         nil,
+									EncodingType: enumspb.ENCODING_TYPE_PROTO3,
+								},
+								PhysicalTaskStatus: physicalTaskStatusCreated,
+							},
+						},
+						PureTasks: []*persistencespb.ChasmComponentAttributes_Task{
+							{
+								Type:                      "TestLibrary.test_pure_task",
+								VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+								VersionedTransitionOffset: 3,
+								Data:                      taskBlob,
+								PhysicalTaskStatus:        physicalTaskStatusCreated,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	root, err := NewTree(persistenceNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger)
+	s.NoError(err)
+
+	// The idea is to mark the node as dirty by accessing it with a mutable context.
+	// Otherwise, CloseTransaction logic will skip validating tasks for this node.
+	// This is a no-op change right now, since we are manually setting the LastUpdateVersionedTransition
+	// for the node below.
+	// Once CloseTransaction is fully implemented, this will be mark the node as dirty,
+	// and CloseTransaction logic will take care of updating LastUpdateVersionedTransition.
+	mutableContext := NewMutableContext(context.Background(), root)
+	_, err = root.Component(mutableContext, ComponentRef{})
+	s.NoError(err)
+
+	// TODO: remove this when CloseTransaction is fully implemented.
+	root.serializedNode.Metadata.LastUpdateVersionedTransition = &persistencespb.VersionedTransition{
+		TransitionCount: 2,
+	}
+
+	s.nodeBackend.EXPECT().GetCurrentVersion().Return(int64(0)).AnyTimes()
+	s.nodeBackend.EXPECT().NextTransitionCount().Return(int64(2)).AnyTimes()
+
+	rt, ok := s.registry.Task("TestLibrary.test_side_effect_task")
+	s.True(ok)
+	rt.validator.(*MockTaskValidator[any, *TestSideEffectTask]).EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("task is invalid")).Times(1)
+	rt, ok = s.registry.Task("TestLibrary.test_outbound_side_effect_task")
+	s.True(ok)
+	rt.validator.(*MockTaskValidator[any, TestOutboundSideEffectTask]).EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	rt, ok = s.registry.Task("TestLibrary.test_pure_task")
+	s.True(ok)
+	rt.validator.(*MockTaskValidator[any, *TestPureTask]).EXPECT().
+		Validate(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("task is invalid")).Times(1)
+
+	err = root.closeTransactionUpdateComponentTasks()
+	s.NoError(err)
+
+	componentAttr := root.serializedNode.Metadata.GetComponentAttributes()
+	s.Empty(componentAttr.PureTasks)
+	s.Len(componentAttr.SideEffectTasks, 1)
+	s.Equal("TestLibrary.test_outbound_side_effect_task", componentAttr.SideEffectTasks[0].GetType())
 }
 
 func (s *nodeSuite) TestCloseTransaction_NewComponentTasks() {
@@ -1001,7 +1107,6 @@ func (s *nodeSuite) TestCloseTransaction_NewComponentTasks() {
 	s.NoError(err)
 
 	mutableContext := NewMutableContext(context.Background(), root)
-
 	c, err := root.Component(mutableContext, ComponentRef{})
 	s.NoError(err)
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Remove invalid tasks for CHASM component when closing transaction.
- Changes are on top of: https://github.com/temporalio/temporal/pull/7621

## Why?
<!-- Tell your future self why have you made these changes -->
- CHASM  task processing logic

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Added unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
