### PR TITLE
Add error type as suffix to nexus handler metrics

### DIFF
--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -449,7 +449,7 @@ func (h *nexusHandler) StartOperation(
 	// Convert to standard Nexus SDK response.
 	switch t := response.GetOutcome().(type) {
 	case *matchingservice.DispatchNexusTaskResponse_HandlerError:
-		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error"))
+		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.HandlerError.GetErrorType()))
 
 		oc.nexusContext.setFailureSource(commonnexus.FailureSourceWorker)
 
@@ -492,7 +492,7 @@ func (h *nexusHandler) StartOperation(
 		}
 	}
 	// This is the worker's fault.
-	oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error"))
+	oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:EMPTY_OUTCOME"))
 
 	oc.nexusContext.setFailureSource(commonnexus.FailureSourceWorker)
 
@@ -608,7 +608,7 @@ func (h *nexusHandler) CancelOperation(ctx context.Context, service, operation, 
 	// Convert to standard Nexus SDK response.
 	switch t := response.GetOutcome().(type) {
 	case *matchingservice.DispatchNexusTaskResponse_HandlerError:
-		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error"))
+		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.HandlerError.GetErrorType()))
 
 		oc.nexusContext.setFailureSource(commonnexus.FailureSourceWorker)
 
@@ -619,7 +619,7 @@ func (h *nexusHandler) CancelOperation(ctx context.Context, service, operation, 
 		return nil
 	}
 	// This is the worker's fault.
-	oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error"))
+	oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:EMPTY_OUTCOME"))
 
 	oc.nexusContext.setFailureSource(commonnexus.FailureSourceWorker)
 

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -205,7 +205,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes() {
 		},
 		{
 			name:     "handler_error",
-			outcome:  "handler_error",
+			outcome:  "handler_error:INTERNAL",
 			endpoint: s.createNexusEndpoint(testcore.RandomizeStr("test-endpoint"), testcore.RandomizeStr("task-queue")),
 			handler: func(res *workflowservice.PollNexusTaskQueueResponse) (*nexuspb.Response, *nexuspb.HandlerError) {
 				return nil, &nexuspb.HandlerError{
@@ -224,7 +224,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes() {
 		},
 		{
 			name:     "handler_error_non_retryable",
-			outcome:  "handler_error",
+			outcome:  "handler_error:INTERNAL",
 			endpoint: s.createNexusEndpoint(testcore.RandomizeStr("test-endpoint"), testcore.RandomizeStr("task-queue")),
 			handler: func(res *workflowservice.PollNexusTaskQueueResponse) (*nexuspb.Response, *nexuspb.HandlerError) {
 				return nil, &nexuspb.HandlerError{
@@ -674,7 +674,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes() {
 			},
 		},
 		{
-			outcome:  "handler_error",
+			outcome:  "handler_error:INTERNAL",
 			endpoint: s.createNexusEndpoint(testcore.RandomizeStr("test-endpoint"), testcore.RandomizeStr("task-queue")),
 			handler: func(res *workflowservice.PollNexusTaskQueueResponse) (*nexuspb.Response, *nexuspb.HandlerError) {
 				return nil, &nexuspb.HandlerError{

--- a/tests/xdc/nexus_request_forwarding_test.go
+++ b/tests/xdc/nexus_request_forwarding_test.go
@@ -185,7 +185,7 @@ func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToAc
 				require.ErrorAs(t, retErr, &handlerErr)
 				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
 				require.Equal(t, "deliberate internal failure", handlerErr.Cause.Error())
-				requireExpectedMetricsCaptured(t, activeSnap, ns, "StartNexusOperation", "handler_error")
+				requireExpectedMetricsCaptured(t, activeSnap, ns, "StartNexusOperation", "handler_error:INTERNAL")
 				requireExpectedMetricsCaptured(t, passiveSnap, ns, "StartNexusOperation", "forwarded_request_error")
 			},
 		},
@@ -286,7 +286,7 @@ func (s *NexusRequestForwardingSuite) TestCancelOperationForwardedFromStandbyToA
 				require.ErrorAs(t, retErr, &handlerErr)
 				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
 				require.Equal(t, "deliberate internal failure", handlerErr.Cause.Error())
-				requireExpectedMetricsCaptured(t, activeSnap, ns, "CancelNexusOperation", "handler_error")
+				requireExpectedMetricsCaptured(t, activeSnap, ns, "CancelNexusOperation", "handler_error:INTERNAL")
 				requireExpectedMetricsCaptured(t, passiveSnap, ns, "CancelNexusOperation", "forwarded_request_error")
 			},
 		},


### PR DESCRIPTION
## Why?

Better observability.

## How did you test it?

Updated existing tests.

## Potential risks

There may be alerts depending on these values, they will need to be adjusted.