### PR TITLE
Add a metric activity_failed for tracking failed activity

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1257,4 +1257,7 @@ var (
 	GcPauseNsTotal = NewGaugeDef("memory_pause_total_ns_last",
 		WithDescription("Last runtime.MemStats.PauseTotalNs"),
 	)
+
+	// Activity metrics
+	ActivityFailed = NewCounterDef("activity_failed")
 )

--- a/service/history/api/respondactivitytaskcanceled/api.go
+++ b/service/history/api/respondactivitytaskcanceled/api.go
@@ -141,6 +141,16 @@ func Invoke(
 				metrics.ActivityTypeTag(token.ActivityType),
 			),
 		).Record(time.Since(activityStartedTime))
+
+		metrics.ActivityFailed.With(
+			workflow.GetPerTaskQueueFamilyScope(
+				shard.GetMetricsHandler(), namespace, taskQueue, shard.GetConfig(),
+				metrics.OperationTag(metrics.HistoryRespondActivityTaskCanceledScope),
+				metrics.WorkflowTypeTag(workflowTypeName),
+				metrics.ActivityTypeTag(token.ActivityType),
+				metrics.FailureTag("canceled"),
+			),
+		).Record(1)
 	}
 	return &historyservice.RespondActivityTaskCanceledResponse{}, err
 }

--- a/service/history/api/respondactivitytaskfailed/api.go
+++ b/service/history/api/respondactivitytaskfailed/api.go
@@ -152,6 +152,15 @@ func Invoke(
 				metrics.ActivityTypeTag(token.ActivityType),
 			),
 		).Record(time.Since(activityStartedTime))
+
+		metrics.ActivityFailed.With(
+			workflow.GetPerTaskQueueFamilyScope(
+				shard.GetMetricsHandler(), namespace, taskQueue, shard.GetConfig(),
+				metrics.WorkflowTypeTag(workflowTypeName),
+				metrics.ActivityTypeTag(token.ActivityType),
+				metrics.FailureTag("failed"),
+			),
+		).Record(1)
 	}
 	return &historyservice.RespondActivityTaskFailedResponse{}, err
 }


### PR DESCRIPTION
## What changed?

This metric is a counter that is bumped whenever an activity fails (i.e. is canceled or fails). This metric is bumped every time `RespondActivityFailed/Canceled` is called and thus gets bumped each time an activity retries and fails. This metric has five labels:

1. The workflow type hosting the failed activity,
2. The activity type of the failed activity,
3. A string identifying the failure, right now "canceled" or "failed"
4. The namespace, and
5. The task queue that this activity ran on.

## Why?

The intention is to use this metric to monitor for specific activity failures and potentially raise alerts on activity failures prior to failing a workflow.

## How did you test it?

I ran this locally with a worker with failing activity:

```
$ http localhost:8000/metrics | grep activity_failed
# HELP activity_failed activity_failed counter
# TYPE activity_failed counter
activity_failed{activityType="Activity",failure="failed",namespace="default",service_name="history",taskqueue="hello_world",workflowType="Workflow"} 8
```

## Potential risks

Adding new metrics with potentially high cardinality labels like `namespace` and `task_queue` are potential risks to downstream observability systems.

## Documentation

Not applicable.

## Is hotfix candidate?

No.