### PR TITLE
[GHA] Change GH token permissions in create-tag.yml

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
           private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Increasing the scope of the token.

## Why?
<!-- Tell your future self why have you made these changes -->
The existing token blocks triggering the GHA when the release is published. However, the `api` repo has similar GHA and it works. The only difference I see is that the token is generated with repo owner scope.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
