### PR TITLE
Revert nexus cancel request events

### DIFF
--- a/api/persistence/v1/executions.pb.go
+++ b/api/persistence/v1/executions.pb.go
@@ -3606,10 +3606,8 @@ type NexusOperationCancellationInfo struct {
 	LastAttemptFailure *v17.Failure `protobuf:"bytes,5,opt,name=last_attempt_failure,json=lastAttemptFailure,proto3" json:"last_attempt_failure,omitempty"`
 	// The time when the next attempt is scheduled.
 	NextAttemptScheduleTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=next_attempt_schedule_time,json=nextAttemptScheduleTime,proto3" json:"next_attempt_schedule_time,omitempty"`
-	// The event ID of the NEXUS_OPERATION_CANCEL_REQUESTED event for this cancelation.
-	RequestedEventId int64 `protobuf:"varint,7,opt,name=requested_event_id,json=requestedEventId,proto3" json:"requested_event_id,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *NexusOperationCancellationInfo) Reset() {
@@ -3682,13 +3680,6 @@ func (x *NexusOperationCancellationInfo) GetNextAttemptScheduleTime() *timestamp
 		return x.NextAttemptScheduleTime
 	}
 	return nil
-}
-
-func (x *NexusOperationCancellationInfo) GetRequestedEventId() int64 {
-	if x != nil {
-		return x.RequestedEventId
-	}
-	return 0
 }
 
 // ResetChildInfo contains the state and actions to be performed on children when a parent workflow resumes after reset.
@@ -4652,15 +4643,14 @@ const file_temporal_server_api_persistence_v1_executions_proto_rawDesc = "" +
 	"\x14last_attempt_failure\x18\r \x01(\v2 .temporal.api.failure.v1.FailureR\x12lastAttemptFailure\x12W\n" +
 	"\x1anext_attempt_schedule_time\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\x17nextAttemptScheduleTime\x12\x1f\n" +
 	"\vendpoint_id\x18\x0f \x01(\tR\n" +
-	"endpointIdJ\x04\b\x04\x10\x05\"\xff\x03\n" +
+	"endpointIdJ\x04\b\x04\x10\x05\"\xd1\x03\n" +
 	"\x1eNexusOperationCancellationInfo\x12A\n" +
 	"\x0erequested_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\rrequestedTime\x12L\n" +
 	"\x05state\x18\x02 \x01(\x0e26.temporal.api.enums.v1.NexusOperationCancellationStateR\x05state\x12\x18\n" +
 	"\aattempt\x18\x03 \x01(\x05R\aattempt\x12W\n" +
 	"\x1alast_attempt_complete_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x17lastAttemptCompleteTime\x12R\n" +
 	"\x14last_attempt_failure\x18\x05 \x01(\v2 .temporal.api.failure.v1.FailureR\x12lastAttemptFailure\x12W\n" +
-	"\x1anext_attempt_schedule_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x17nextAttemptScheduleTime\x12,\n" +
-	"\x12requested_event_id\x18\a \x01(\x03R\x10requestedEventId\"M\n" +
+	"\x1anext_attempt_schedule_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x17nextAttemptScheduleTime\"M\n" +
 	"\x0eResetChildInfo\x12;\n" +
 	"\x1ashould_terminate_and_start\x18\x01 \x01(\bR\x17shouldTerminateAndStartB6Z4go.temporal.io/server/api/persistence/v1;persistenceb\x06proto3"
 

--- a/components/nexusoperations/events.go
+++ b/components/nexusoperations/events.go
@@ -68,51 +68,13 @@ func (d CancelRequestedEventDefinition) Type() enumspb.EventType {
 
 func (d CancelRequestedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
 	_, err := transitionOperation(root, event, func(node *hsm.Node, o Operation) (hsm.TransitionOutput, error) {
-		return o.Cancel(node, event.EventTime.AsTime(), event.EventId)
+		return o.Cancel(node, event.EventTime.AsTime())
 	})
 
 	return err
 }
 
 func (d CancelRequestedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, _ map[enumspb.ResetReapplyExcludeType]struct{}) error {
-	// We never cherry pick command events, and instead allow user logic to reschedule those commands.
-	return hsm.ErrNotCherryPickable
-}
-
-type CancelRequestCompletedEventDefinition struct{}
-
-func (d CancelRequestCompletedEventDefinition) IsWorkflowTaskTrigger() bool {
-	return false
-}
-
-func (d CancelRequestCompletedEventDefinition) Type() enumspb.EventType {
-	return enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED
-}
-
-func (d CancelRequestCompletedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return nil
-}
-
-func (d CancelRequestCompletedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, _ map[enumspb.ResetReapplyExcludeType]struct{}) error {
-	// We never cherry pick command events, and instead allow user logic to reschedule those commands.
-	return hsm.ErrNotCherryPickable
-}
-
-type CancelRequestFailedEventDefinition struct{}
-
-func (d CancelRequestFailedEventDefinition) IsWorkflowTaskTrigger() bool {
-	return false
-}
-
-func (d CancelRequestFailedEventDefinition) Type() enumspb.EventType {
-	return enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED
-}
-
-func (d CancelRequestFailedEventDefinition) Apply(root *hsm.Node, event *historypb.HistoryEvent) error {
-	return nil
-}
-
-func (d CancelRequestFailedEventDefinition) CherryPick(root *hsm.Node, event *historypb.HistoryEvent, _ map[enumspb.ResetReapplyExcludeType]struct{}) error {
 	// We never cherry pick command events, and instead allow user logic to reschedule those commands.
 	return hsm.ErrNotCherryPickable
 }
@@ -275,12 +237,6 @@ func RegisterEventDefinitions(reg *hsm.Registry) error {
 		return err
 	}
 	if err := reg.RegisterEventDefinition(CancelRequestedEventDefinition{}); err != nil {
-		return err
-	}
-	if err := reg.RegisterEventDefinition(CancelRequestCompletedEventDefinition{}); err != nil {
-		return err
-	}
-	if err := reg.RegisterEventDefinition(CancelRequestFailedEventDefinition{}); err != nil {
 		return err
 	}
 	if err := reg.RegisterEventDefinition(StartedEventDefinition{}); err != nil {

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -663,17 +663,6 @@ func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environ
 				if err != nil {
 					return hsm.TransitionOutput{}, err
 				}
-				n.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED, func(e *historypb.HistoryEvent) {
-					// nolint:revive // We must mutate here even if the linter doesn't like it.
-					e.Attributes = &historypb.HistoryEvent_NexusOperationCancelRequestFailedEventAttributes{
-						NexusOperationCancelRequestFailedEventAttributes: &historypb.NexusOperationCancelRequestFailedEventAttributes{
-							RequestedEventId: c.RequestedEventId,
-							Failure:          failure,
-						},
-					}
-					// nolint:revive // We must mutate here even if the linter doesn't like it.
-					e.WorkerMayIgnore = true // For compatibility with older SDKs.
-				})
 				if !isRetryable {
 					return TransitionCancelationFailed.Apply(c, EventCancelationFailed{
 						Time:    env.Now(),
@@ -691,16 +680,6 @@ func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environ
 			// Cancelation request transmitted successfully.
 			// The operation is not yet canceled and may ignore our request, the outcome will be known via the
 			// completion callback.
-			n.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED, func(e *historypb.HistoryEvent) {
-				// nolint:revive // We must mutate here even if the linter doesn't like it.
-				e.Attributes = &historypb.HistoryEvent_NexusOperationCancelRequestCompletedEventAttributes{
-					NexusOperationCancelRequestCompletedEventAttributes: &historypb.NexusOperationCancelRequestCompletedEventAttributes{
-						RequestedEventId: c.RequestedEventId,
-					},
-				}
-				// nolint:revive // We must mutate here even if the linter doesn't like it.
-				e.WorkerMayIgnore = true // For compatibility with older SDKs.
-			})
 			return TransitionCancelationSucceeded.Apply(c, EventCancelationSucceeded{
 				Time: env.Now(),
 				Node: n,

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -463,7 +463,7 @@ func TestProcessInvocationTask(t *testing.T) {
 			if tc.cancelBeforeStart {
 				op, err := hsm.MachineData[nexusoperations.Operation](node)
 				require.NoError(t, err)
-				_, err = op.Cancel(node, time.Now(), 0)
+				_, err = op.Cancel(node, time.Now())
 				require.NoError(t, err)
 				c, err := op.Cancelation(node)
 				require.NoError(t, err)
@@ -759,7 +759,7 @@ func TestProcessCancelationTask(t *testing.T) {
 				Node: node,
 			})
 			require.NoError(t, err)
-			_, err = op.Cancel(node, time.Now(), 0)
+			_, err = op.Cancel(node, time.Now())
 			require.NoError(t, err)
 			node, err = node.Child([]hsm.Key{nexusoperations.CancelationMachineKey})
 			require.NoError(t, err)
@@ -866,7 +866,7 @@ func TestProcessCancelationTask_OperationCompleted(t *testing.T) {
 		Node: node,
 	})
 	require.NoError(t, err)
-	_, err = op.Cancel(node, time.Now(), 0)
+	_, err = op.Cancel(node, time.Now())
 	require.NoError(t, err)
 	_, err = nexusoperations.TransitionSucceeded.Apply(op, nexusoperations.EventSucceeded{
 		Node: node,
@@ -925,7 +925,7 @@ func TestProcessCancelationBackoffTask(t *testing.T) {
 		Node: node,
 	})
 	require.NoError(t, err)
-	_, err = op.Cancel(node, time.Now(), 0)
+	_, err = op.Cancel(node, time.Now())
 	require.NoError(t, err)
 
 	node, err = node.Child([]hsm.Key{nexusoperations.CancelationMachineKey})

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -410,7 +410,7 @@ var TransitionTimedOut = hsm.NewTransition(
 // machine will stay in UNSPECIFIED state. If the Operation is in STARTED state, then transition the
 // Cancelation machine to the SCHEDULED state. Otherwise, the Cancelation machine will wait the
 // Operation machine transition to the STARTED state.
-func (o Operation) Cancel(node *hsm.Node, t time.Time, requestedEventID int64) (hsm.TransitionOutput, error) {
+func (o Operation) Cancel(node *hsm.Node, t time.Time) (hsm.TransitionOutput, error) {
 	child, err := node.AddChild(CancelationMachineKey, Cancelation{
 		NexusOperationCancellationInfo: &persistencespb.NexusOperationCancellationInfo{},
 	})

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -412,9 +412,7 @@ var TransitionTimedOut = hsm.NewTransition(
 // Operation machine transition to the STARTED state.
 func (o Operation) Cancel(node *hsm.Node, t time.Time, requestedEventID int64) (hsm.TransitionOutput, error) {
 	child, err := node.AddChild(CancelationMachineKey, Cancelation{
-		NexusOperationCancellationInfo: &persistencespb.NexusOperationCancellationInfo{
-			RequestedEventId: requestedEventID,
-		},
+		NexusOperationCancellationInfo: &persistencespb.NexusOperationCancellationInfo{},
 	})
 	if err != nil {
 		// This function should be called as part of command/event handling and it should not be called

--- a/components/nexusoperations/statemachine_test.go
+++ b/components/nexusoperations/statemachine_test.go
@@ -454,7 +454,7 @@ func TestCancel(t *testing.T) {
 		Node: root,
 	})
 	require.NoError(t, err)
-	_, err = op.Cancel(root, time.Now(), 0)
+	_, err = op.Cancel(root, time.Now())
 	require.NoError(t, err)
 	require.Equal(t, enumsspb.NEXUS_OPERATION_STATE_STARTED, op.State())
 	node, err := root.Child([]hsm.Key{nexusoperations.CancelationMachineKey})
@@ -478,7 +478,7 @@ func TestCancelationValidTransitions(t *testing.T) {
 		})
 	}))
 	require.NoError(t, hsm.MachineTransition(root, func(op nexusoperations.Operation) (hsm.TransitionOutput, error) {
-		return op.Cancel(root, time.Now(), 0)
+		return op.Cancel(root, time.Now())
 	}))
 	node, err := root.Child([]hsm.Key{nexusoperations.CancelationMachineKey})
 	require.NoError(t, err)
@@ -577,7 +577,7 @@ func TestCancelationBeforeStarted(t *testing.T) {
 	backend := &hsmtest.NodeBackend{}
 	root := newOperationNode(t, backend, mustNewScheduledEvent(time.Now(), 0))
 	require.NoError(t, hsm.MachineTransition(root, func(op nexusoperations.Operation) (hsm.TransitionOutput, error) {
-		return op.Cancel(root, time.Now(), 0)
+		return op.Cancel(root, time.Now())
 	}))
 	opLog, err := root.Parent.OpLog()
 	require.NoError(t, err)

--- a/proto/internal/temporal/server/api/persistence/v1/executions.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/executions.proto
@@ -800,9 +800,6 @@ message NexusOperationCancellationInfo {
     temporal.api.failure.v1.Failure last_attempt_failure = 5;
     // The time when the next attempt is scheduled.
     google.protobuf.Timestamp next_attempt_schedule_time = 6;
-
-    // The event ID of the NEXUS_OPERATION_CANCEL_REQUESTED event for this cancelation.
-    int64 requested_event_id = 7;
 }
 
 // ResetChildInfo contains the state and actions to be performed on children when a parent workflow resumes after reset.

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -81,7 +81,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation() {
 	taskQueue := testcore.RandomizeStr(s.T().Name())
 	endpointName := testcore.RandomizedNexusEndpoint(s.T().Name())
 
-	errSent := false
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
 			if service != "service" {
@@ -90,11 +89,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation() {
 			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
 		},
 		OnCancelOperation: func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error {
-			if !errSent {
-				// Fail cancel request once to test NexusOperationCancelRequestFailed event is recorded and request is retried.
-				errSent = true
-				return nexus.HandlerErrorf(nexus.HandlerErrorTypeInternal, "intentional cancel error for test")
-			}
 			return nil
 		},
 	}
@@ -209,18 +203,11 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation() {
 		assert.Equal(t, "operation", op.Operation)
 		assert.Equal(t, enumspb.PENDING_NEXUS_OPERATION_STATE_STARTED, op.State)
 		assert.Equal(t, enumspb.NEXUS_OPERATION_CANCELLATION_STATE_SUCCEEDED, op.CancellationInfo.State)
+
 	}, time.Second*10, time.Millisecond*30)
 
 	err = s.SdkClient().TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "test")
 	s.NoError(err)
-
-	hist := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{
-		WorkflowId: run.GetID(),
-		RunId:      run.GetRunID(),
-	})
-	s.ContainsHistoryEvents(`
-NexusOperationCancelRequestFailed
-NexusOperationCancelRequestCompleted`, hist)
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion() {
@@ -1527,15 +1514,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelBeforeStarted_Cancelati
 	// Terminate the workflow for good measure.
 	err = s.SdkClient().TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "test")
 	s.NoError(err)
-
-	// Assert that we did not send a cancel request until after the operation was started.
-	hist := s.GetHistory(s.Namespace().String(), &commonpb.WorkflowExecution{
-		WorkflowId: run.GetID(),
-		RunId:      run.GetRunID(),
-	})
-	s.ContainsHistoryEvents(`
-NexusOperationCancelRequested
-NexusOperationStarted`, hist)
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAfterReset() {


### PR DESCRIPTION
## What changed?
Reverting NexusCancelRequest[Completed|Failed] events.

## Why?
Waiting for one more release to avoid issues with migration or rollback.

