### PR TITLE
Put NexusOperationCancelRequest[Completed|Failed] behind a feature flag

### DIFF
--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -155,21 +155,29 @@ Adding high-cardinality tags (like unique operation names) can significantly inc
 requirements and query complexity. Consider the cardinality impact when enabling these tags.`,
 )
 
+var RecordCancelRequestCompletionEvents = dynamicconfig.NewGlobalBoolSetting(
+	"component.nexusoperations.recordCancelRequestCompletionEvents",
+	false,
+	`Boolean flag to control whether to record NexusOperationCancelRequestComplete and 
+NexusOperationCancelRequestFailed events. Default false.`,
+)
+
 type Config struct {
-	Enabled                            dynamicconfig.BoolPropertyFn
-	RequestTimeout                     dynamicconfig.DurationPropertyFnWithDestinationFilter
-	MinOperationTimeout                dynamicconfig.DurationPropertyFnWithNamespaceFilter
-	MaxConcurrentOperations            dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxServiceNameLength               dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxOperationNameLength             dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxOperationTokenLength            dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxOperationHeaderSize             dynamicconfig.IntPropertyFnWithNamespaceFilter
-	DisallowedOperationHeaders         dynamicconfig.TypedPropertyFn[[]string]
-	MaxOperationScheduleToCloseTimeout dynamicconfig.DurationPropertyFnWithNamespaceFilter
-	PayloadSizeLimit                   dynamicconfig.IntPropertyFnWithNamespaceFilter
-	CallbackURLTemplate                dynamicconfig.StringPropertyFn
-	EndpointNotFoundAlwaysNonRetryable dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	RetryPolicy                        func() backoff.RetryPolicy
+	Enabled                             dynamicconfig.BoolPropertyFn
+	RequestTimeout                      dynamicconfig.DurationPropertyFnWithDestinationFilter
+	MinOperationTimeout                 dynamicconfig.DurationPropertyFnWithNamespaceFilter
+	MaxConcurrentOperations             dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxServiceNameLength                dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxOperationNameLength              dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxOperationTokenLength             dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxOperationHeaderSize              dynamicconfig.IntPropertyFnWithNamespaceFilter
+	DisallowedOperationHeaders          dynamicconfig.TypedPropertyFn[[]string]
+	MaxOperationScheduleToCloseTimeout  dynamicconfig.DurationPropertyFnWithNamespaceFilter
+	PayloadSizeLimit                    dynamicconfig.IntPropertyFnWithNamespaceFilter
+	CallbackURLTemplate                 dynamicconfig.StringPropertyFn
+	EndpointNotFoundAlwaysNonRetryable  dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	RecordCancelRequestCompletionEvents dynamicconfig.BoolPropertyFn
+	RetryPolicy                         func() backoff.RetryPolicy
 }
 
 func ConfigProvider(dc *dynamicconfig.Collection) *Config {
@@ -193,10 +201,11 @@ func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 			}
 			return keys, nil
 		}).Get,
-		MaxOperationScheduleToCloseTimeout: MaxOperationScheduleToCloseTimeout.Get(dc),
-		PayloadSizeLimit:                   dynamicconfig.BlobSizeLimitError.Get(dc),
-		CallbackURLTemplate:                CallbackURLTemplate.Get(dc),
-		EndpointNotFoundAlwaysNonRetryable: EndpointNotFoundAlwaysNonRetryable.Get(dc),
+		MaxOperationScheduleToCloseTimeout:  MaxOperationScheduleToCloseTimeout.Get(dc),
+		PayloadSizeLimit:                    dynamicconfig.BlobSizeLimitError.Get(dc),
+		CallbackURLTemplate:                 CallbackURLTemplate.Get(dc),
+		EndpointNotFoundAlwaysNonRetryable:  EndpointNotFoundAlwaysNonRetryable.Get(dc),
+		RecordCancelRequestCompletionEvents: RecordCancelRequestCompletionEvents.Get(dc),
 		RetryPolicy: func() backoff.RetryPolicy {
 			return backoff.NewExponentialRetryPolicy(
 				RetryPolicyInitialInterval.Get(dc)(),

--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -158,7 +158,7 @@ requirements and query complexity. Consider the cardinality impact when enabling
 var RecordCancelRequestCompletionEvents = dynamicconfig.NewGlobalBoolSetting(
 	"component.nexusoperations.recordCancelRequestCompletionEvents",
 	false,
-	`Boolean flag to control whether to record NexusOperationCancelRequestComplete and 
+	`Boolean flag to control whether to record NexusOperationCancelRequestCompleted and 
 NexusOperationCancelRequestFailed events. Default false.`,
 )
 

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -668,18 +668,20 @@ func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environ
 				if err != nil {
 					return hsm.TransitionOutput{}, err
 				}
-				n.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED, func(e *historypb.HistoryEvent) {
-					// nolint:revive // We must mutate here even if the linter doesn't like it.
-					e.Attributes = &historypb.HistoryEvent_NexusOperationCancelRequestFailedEventAttributes{
-						NexusOperationCancelRequestFailedEventAttributes: &historypb.NexusOperationCancelRequestFailedEventAttributes{
-							ScheduledEventId: scheduledEventID,
-							RequestedEventId: c.RequestedEventId,
-							Failure:          failure,
-						},
-					}
-					// nolint:revive // We must mutate here even if the linter doesn't like it.
-					e.WorkerMayIgnore = true // For compatibility with older SDKs.
-				})
+				if e.Config.RecordCancelRequestCompletionEvents() {
+					n.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED, func(e *historypb.HistoryEvent) {
+						// nolint:revive // We must mutate here even if the linter doesn't like it.
+						e.Attributes = &historypb.HistoryEvent_NexusOperationCancelRequestFailedEventAttributes{
+							NexusOperationCancelRequestFailedEventAttributes: &historypb.NexusOperationCancelRequestFailedEventAttributes{
+								ScheduledEventId: scheduledEventID,
+								RequestedEventId: c.RequestedEventId,
+								Failure:          failure,
+							},
+						}
+						// nolint:revive // We must mutate here even if the linter doesn't like it.
+						e.WorkerMayIgnore = true // For compatibility with older SDKs.
+					})
+				}
 				if !isRetryable {
 					return TransitionCancelationFailed.Apply(c, EventCancelationFailed{
 						Time:    env.Now(),
@@ -697,17 +699,19 @@ func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environ
 			// Cancelation request transmitted successfully.
 			// The operation is not yet canceled and may ignore our request, the outcome will be known via the
 			// completion callback.
-			n.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED, func(e *historypb.HistoryEvent) {
-				// nolint:revive // We must mutate here even if the linter doesn't like it.
-				e.Attributes = &historypb.HistoryEvent_NexusOperationCancelRequestCompletedEventAttributes{
-					NexusOperationCancelRequestCompletedEventAttributes: &historypb.NexusOperationCancelRequestCompletedEventAttributes{
-						ScheduledEventId: scheduledEventID,
-						RequestedEventId: c.RequestedEventId,
-					},
-				}
-				// nolint:revive // We must mutate here even if the linter doesn't like it.
-				e.WorkerMayIgnore = true // For compatibility with older SDKs.
-			})
+			if e.Config.RecordCancelRequestCompletionEvents() {
+				n.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED, func(e *historypb.HistoryEvent) {
+					// nolint:revive // We must mutate here even if the linter doesn't like it.
+					e.Attributes = &historypb.HistoryEvent_NexusOperationCancelRequestCompletedEventAttributes{
+						NexusOperationCancelRequestCompletedEventAttributes: &historypb.NexusOperationCancelRequestCompletedEventAttributes{
+							ScheduledEventId: scheduledEventID,
+							RequestedEventId: c.RequestedEventId,
+						},
+					}
+					// nolint:revive // We must mutate here even if the linter doesn't like it.
+					e.WorkerMayIgnore = true // For compatibility with older SDKs.
+				})
+			}
 			return TransitionCancelationSucceeded.Apply(c, EventCancelationSucceeded{
 				Time: env.Now(),
 				Node: n,

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -808,9 +808,10 @@ func TestProcessCancelationTask(t *testing.T) {
 
 			require.NoError(t, nexusoperations.RegisterExecutor(reg, nexusoperations.TaskExecutorOptions{
 				Config: &nexusoperations.Config{
-					Enabled:             dynamicconfig.GetBoolPropertyFn(true),
-					RequestTimeout:      dynamicconfig.GetDurationPropertyFnFilteredByDestination(tc.requestTimeout),
-					MinOperationTimeout: dynamicconfig.GetDurationPropertyFnFilteredByNamespace(time.Millisecond),
+					Enabled:                             dynamicconfig.GetBoolPropertyFn(true),
+					RequestTimeout:                      dynamicconfig.GetDurationPropertyFnFilteredByDestination(tc.requestTimeout),
+					MinOperationTimeout:                 dynamicconfig.GetDurationPropertyFnFilteredByNamespace(time.Millisecond),
+					RecordCancelRequestCompletionEvents: dynamicconfig.GetBoolPropertyFn(true),
 					RetryPolicy: func() backoff.RetryPolicy {
 						return backoff.NewExponentialRetryPolicy(time.Second)
 					},

--- a/tests/testcore/functional_test_sdk_suite.go
+++ b/tests/testcore/functional_test_sdk_suite.go
@@ -87,6 +87,7 @@ func (s *FunctionalTestSdkSuite) SetupSuite() {
 		dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs.Key():      true,
 		dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace.Key(): ClientSuiteLimit,
 		dynamicconfig.RefreshNexusEndpointsMinWait.Key():                    1 * time.Millisecond,
+		nexusoperations.RecordCancelRequestCompletionEvents.Key():           true,
 		callbacks.AllowedAddresses.Key():                                    []any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
 	}
 


### PR DESCRIPTION
## What changed?
Putting NexusOperationCancelRequest[Completed|Failed] behind a feature flag.

## Why?
So that we can wait to enable it until it will not cause issues with migration or rollback.
