### PR TITLE
Fix bug in stream batcher after timeout

### DIFF
--- a/common/clock/context.go
+++ b/common/clock/context.go
@@ -65,7 +65,10 @@ func (ctx *ctxWithDeadline) deadlineExceeded() {
 
 func (ctx *ctxWithDeadline) cancel() {
 	ctx.once.Do(func() {
-		ctx.timer.Stop()
+		// We'd like to call ctx.timer.Stop() here, but we can't: the time source may call
+		// deadlineExceeded while holding its lock, which acquires the once mutex. Here we have
+		// the once mutex and want to cancel a timer, which would create a potential lock
+		// cycle. So just leave the timer as a no-op.
 		ctx.err = context.Canceled
 		close(ctx.done)
 	})

--- a/common/stream_batcher/batcher.go
+++ b/common/stream_batcher/batcher.go
@@ -80,7 +80,7 @@ func NewBatcher[T, R any](fn func([]T) R, opts BatcherOptions, timeSource clock.
 // for the whole batch that the item ended up in, and a context error. Even if Add returns a
 // context error, the item may still be processed in the future!
 func (b *Batcher[T, R]) Add(ctx context.Context, t T) (R, error) {
-	resp := make(chan R)
+	resp := make(chan R, 1)
 	pair := batchPair[T, R]{resp: resp, item: t}
 
 	for {


### PR DESCRIPTION
## What changed?
There was a potential deadlock in stream batcher after an Add call timed out. Make the channel buffered to fix it.

## Why?
Bug

## How did you test it?
Unit tests