### PR TITLE
fixed alert on version match #4094

### DIFF
--- a/service/frontend/version_checker.go
+++ b/service/frontend/version_checker.go
@@ -25,6 +25,7 @@
 package frontend
 
 import (
+	"strings"
 	"context"
 	"runtime"
 	"sync"
@@ -189,6 +190,11 @@ func (vc *VersionChecker) saveVersionInfo(ctx context.Context, resp *check.Versi
 
 func toVersionInfo(resp *check.VersionCheckResponse) (*versionpb.VersionInfo, error) {
 	for _, product := range resp.Products {
+
+		if strings.TrimSpace(product.Current.Version) == strings.TrimSpace(product.Recommended.Version) {
+			product.Alerts = nil
+		}
+
 		if product.Product == headers.ClientNameServer {
 			return &versionpb.VersionInfo{
 				Current:        convertReleaseInfo(product.Current),


### PR DESCRIPTION
## What changed?
Added a condition in `toVersionInfo` (in `version_checker.go`) that removes the version alert when the current version matches the recommended version. This prevents unnecessary alerts like “A new release is available!” from showing up after the server has already been upgraded.

## Why?
To fix [Issue #4094](https://github.com/temporalio/temporal/issues/4094). The version alert was being shown even when both the current and recommended versions were the same, which can be misleading for users who already upgraded their cluster.

## How did you test it?
Ran ```make all``` and ```make test```.

## Potential risks
Low risk — only affects display logic for version alerts. Doesn’t interfere with critical cluster functionality.

## Documentation
No changes to documentation needed. This only affects backend logic for version info output.

## Is hotfix candidate?
No


Fix: issue #4094