### PR TITLE
Log workflows with empty history

### DIFF
--- a/service/history/api/getworkflowexecutionhistory/api.go
+++ b/service/history/api/getworkflowexecutionhistory/api.go
@@ -264,7 +264,16 @@ func Invoke(
 				if err != nil {
 					return nil, err
 				}
-				// since getHistory func will not return empty history, so the below is safe
+				// GetHistory func will not return empty history. Log workflow details if that is not the cse
+				if len(history.Events) == 0 {
+					shardContext.GetLogger().Error(
+						"GetHistory returned empty history",
+						tag.WorkflowNamespaceID(namespaceID.String()),
+						tag.WorkflowID(execution.GetWorkflowId()),
+						tag.WorkflowRunID(execution.GetRunId()),
+					)
+					return nil, serviceerror.NewDataLoss("no events in workflow history")
+				}
 				history.Events = history.Events[len(history.Events)-1 : len(history.Events)]
 			}
 			continuationToken = nil


### PR DESCRIPTION
## What changed?
Log workflows that has empty history in persistence.

## Why?
To identify these workflows.
