### PR TITLE
Force UUID on RegisterNamespace()

### DIFF
--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -207,8 +207,17 @@ func (d *namespaceHandler) RegisterNamespace(
 		}
 	}
 
+	const forceNamespaceUuid = "__temporal-force-namespace-uuid"
+	id := registerRequest.Data[forceNamespaceUuid]
+	if id == "" {
+		id = uuid.New()
+	} else {
+		d.logger.Warn(fmt.Sprintf("registerRequest with %s %s", forceNamespaceUuid, id))
+		delete(registerRequest.Data, forceNamespaceUuid)
+	}
+
 	info := &persistencespb.NamespaceInfo{
-		Id:          uuid.New(),
+		Id:          id,
 		Name:        registerRequest.GetNamespace(),
 		State:       enumspb.NAMESPACE_STATE_REGISTERED,
 		Owner:       registerRequest.GetOwnerEmail(),


### PR DESCRIPTION
## What changed?
We allow forcing the UUID of a RegisterNamespace() for the purpose of Emergency Migration.

## Why?
To facility Emergency Migration, an "Imposter" of the original namespace is needed on a different Cell

## How did you test it?
This is a private branch only.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
