### PR TITLE
new map if SubStateMachinesByType is nil

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -575,6 +575,10 @@ func NewMutableStateInChain(
 }
 
 func (ms *MutableStateImpl) mustInitHSM() {
+	if ms.executionInfo.SubStateMachinesByType == nil {
+		ms.executionInfo.SubStateMachinesByType = make(map[string]*persistencespb.StateMachineMap)
+	}
+
 	// Error only occurs if some initialization path forgets to register the workflow state machine.
 	stateMachineNode, err := hsm.NewRoot(ms.shard.StateMachineRegistry(), StateMachineType, ms, ms.executionInfo.SubStateMachinesByType, ms)
 	if err != nil {

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -4459,8 +4459,10 @@ func (s *mutableStateSuite) TestApplySnapshot() {
 	targetMS.closeTransactionTrackLastUpdateVersionedTransition(historyi.TransactionPolicyActive)
 
 	snapshot := s.buildSnapshot(targetMS)
+	s.Nil(snapshot.ExecutionInfo.SubStateMachinesByType)
 	err = currentMS.ApplySnapshot(snapshot)
 	s.NoError(err)
+	s.NotNil(currentMS.GetExecutionInfo().SubStateMachinesByType)
 
 	s.verifyMutableState(currentMS, targetMS, originMS)
 }


### PR DESCRIPTION
## What changed?
create new map if SubStateMachinesByType is nil after applySnapshot.

## Why?
SubStateMachinesByType in replication task might be nil (due to proto.Clone of empty map). 

## How did you test it?
unit test and local test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
