### PR TITLE
Add application logic for NexusCancelRequest[Completed|Failed] events

### DIFF
--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -668,21 +668,21 @@ func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environ
 				if err != nil {
 					return hsm.TransitionOutput{}, err
 				}
-				if e.Config.RecordCancelRequestCompletionEvents() {
-					n.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED, func(e *historypb.HistoryEvent) {
-						// nolint:revive // We must mutate here even if the linter doesn't like it.
-						e.Attributes = &historypb.HistoryEvent_NexusOperationCancelRequestFailedEventAttributes{
-							NexusOperationCancelRequestFailedEventAttributes: &historypb.NexusOperationCancelRequestFailedEventAttributes{
-								ScheduledEventId: scheduledEventID,
-								RequestedEventId: c.RequestedEventId,
-								Failure:          failure,
-							},
-						}
-						// nolint:revive // We must mutate here even if the linter doesn't like it.
-						e.WorkerMayIgnore = true // For compatibility with older SDKs.
-					})
-				}
 				if !isRetryable {
+					if e.Config.RecordCancelRequestCompletionEvents() {
+						n.AddHistoryEvent(enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED, func(e *historypb.HistoryEvent) {
+							// nolint:revive // We must mutate here even if the linter doesn't like it.
+							e.Attributes = &historypb.HistoryEvent_NexusOperationCancelRequestFailedEventAttributes{
+								NexusOperationCancelRequestFailedEventAttributes: &historypb.NexusOperationCancelRequestFailedEventAttributes{
+									ScheduledEventId: scheduledEventID,
+									RequestedEventId: c.RequestedEventId,
+									Failure:          failure,
+								},
+							}
+							// nolint:revive // We must mutate here even if the linter doesn't like it.
+							e.WorkerMayIgnore = true // For compatibility with older SDKs.
+						})
+					}
 					return TransitionCancelationFailed.Apply(c, EventCancelationFailed{
 						Time:    env.Now(),
 						Failure: failure,

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -218,9 +218,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation() {
 		WorkflowId: run.GetID(),
 		RunId:      run.GetRunID(),
 	})
-	s.ContainsHistoryEvents(`
-NexusOperationCancelRequestFailed
-NexusOperationCancelRequestCompleted`, hist)
+	s.ContainsHistoryEvents(`NexusOperationCancelRequestCompleted`, hist)
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion() {


### PR DESCRIPTION
## What changed?
Added application logic for NexusCancelRequest[Completed|Failed] events

## Why?
To support event-based replication

## How did you test it?
Existing tests
