### PR TITLE
Tag non-default task priority metric

### DIFF
--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -55,6 +55,7 @@ const (
 	workflowType   = "workflowType"
 	activityType   = "activityType"
 	commandType    = "commandType"
+	customPriority = "custom_priority"
 	serviceName    = "service_name"
 	actionType     = "action_type"
 	workerBuildId  = "worker-build-id"
@@ -358,6 +359,10 @@ func ResourceExhaustedScopeTag(scope enumspb.ResourceExhaustedScope) Tag {
 
 func ServiceNameTag(value primitives.ServiceName) Tag {
 	return &tagImpl{key: serviceName, value: string(value)}
+}
+
+func CustomPriority(value bool) Tag {
+	return &tagImpl{key: customPriority, value: fmt.Sprintf("%t", value)}
 }
 
 func ActionType(value string) Tag {

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -582,10 +582,11 @@ func (tm *priTaskMatcher) poll(
 	pollWasForwarded = task.isStarted()
 
 	if !task.isQuery() {
+		priorityTag := metrics.CustomPriority(task.isCustomPriority())
 		if task.isSyncMatchTask() {
-			metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+			metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1, priorityTag)
 		}
-		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
+		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1, priorityTag)
 	} else {
 		metrics.PollSuccessWithSyncPerTaskQueueCounter.With(tm.metricsHandler).Record(1)
 		metrics.PollSuccessPerTaskQueueCounter.With(tm.metricsHandler).Record(1)

--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -218,6 +218,13 @@ func (task *internalTask) isSyncMatchTask() bool {
 	return task.responseC != nil
 }
 
+func (task *internalTask) isCustomPriority() bool {
+	return task.event != nil &&
+		task.event.Data != nil &&
+		task.event.Data.Priority != nil &&
+		task.event.Data.Priority.PriorityKey != 0
+}
+
 func (task *internalTask) workflowExecution() *commonpb.WorkflowExecution {
 	switch {
 	case task.event != nil:


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Added a custom metric tag for labelling a metric as having a non-default priority level set.

## Why?
<!-- Tell your future self why have you made these changes -->

To gauge priority usage.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Ran `PriorityFairnessSuite` and verified it was true at least once.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
