### PR TITLE
Validate workflow task attempt in standby task processing

### DIFF
--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -364,6 +364,16 @@ func (t *timerQueueStandbyTaskExecutor) executeWorkflowTaskTimeoutTask(
 			return nil, err
 		}
 
+		if workflowTask.Attempt != timerTask.ScheduleAttempt {
+			return nil, nil
+		}
+
+		// We could check if workflow task is started state (since the timeout type here is START_TO_CLOSE)
+		// but that's unnecessary.
+		//
+		// Ifthe  workflow task is in scheduled state, it must have a higher attempt
+		// count and will be captured by the attempt check above.
+
 		return &struct{}{}, nil
 	}
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Validate workflow task attempt in standby task processing

## Why?
<!-- Tell your future self why have you made these changes -->
- We have a same logic for active timer task, but not in standby.
- This is only needed in  state-based replication world where transient workflow task (attempt > 1) state will be replicated as well. Previously In history-based replication world, the attempt count in standby should always be 1  since transient workflow task has no events and won't be replicated, so the attempt check is not necessary. In state-based replication world, each replicated attempt will generate a start_to_close timeout timer and without this check, timer for previous attempt will keep doing verification and eventually get dropped and trigger alerts. No impact to the workflow though.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- It worst case, after failover, workflow task can't timeout properly and workflow will get stuck.

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- Could be.
