### PR TITLE
Populate pause info for rule-induced activity pause

### DIFF
--- a/common/namespace/namespace.go
+++ b/common/namespace/namespace.go
@@ -308,6 +308,14 @@ func (ns *Namespace) GetWorkflowRules() []*rulespb.WorkflowRule {
 	return expmaps.Values(ns.config.WorkflowRules)
 }
 
+func (ns *Namespace) GetWorkflowRule(ruleID string) (*rulespb.WorkflowRule, bool) {
+	if ns.config.WorkflowRules == nil {
+		return nil, false
+	}
+	result, ok := ns.config.WorkflowRules[ruleID]
+	return result, ok
+}
+
 // Error returns the reason associated with this bad binary.
 func (e BadBinaryError) Error() string {
 	return e.info.Reason

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	go.temporal.io/api v1.48.0
+	go.temporal.io/api v1.48.1-0.20250426005355-d6c89de822db
 	go.temporal.io/sdk v1.34.0
 	go.temporal.io/version v0.3.0
 	go.uber.org/automaxprocs v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.48.0 h1:qk8c2QkB4RRjBw2yB82hUulbhHxRIYnem+u2mvlbUf8=
-go.temporal.io/api v1.48.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.48.1-0.20250426005355-d6c89de822db h1:QhFqv1bSlM2IwIVf3EbnopvkYRbqvJy4+WodG68RSTA=
+go.temporal.io/api v1.48.1-0.20250426005355-d6c89de822db/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.34.0 h1:VLg/h6ny7GvLFVoQPqz2NcC93V9yXboQwblkRvZ1cZE=
 go.temporal.io/sdk v1.34.0/go.mod h1:iE4U5vFrH3asOhqpBBphpj9zNtw8btp8+MSaf5A0D3w=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=

--- a/proto/internal/temporal/server/api/persistence/v1/executions.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/executions.proto
@@ -588,6 +588,7 @@ message ActivityInfo {
             // Reason for pausing the activity.
             string reason = 2;
         }
+
         oneof paused_by {
             // activity was paused by the manual intervention
             Manual manual = 2;

--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -686,7 +686,8 @@ func (d *namespaceHandler) DeprecateNamespace(
 }
 
 func (d *namespaceHandler) CreateWorkflowRule(
-	ctx context.Context, ruleSpec *rulespb.WorkflowRuleSpec,
+	ctx context.Context,
+	ruleSpec *rulespb.WorkflowRuleSpec,
 	createdByIdentity string,
 	description string,
 	nsName string,

--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -686,7 +686,10 @@ func (d *namespaceHandler) DeprecateNamespace(
 }
 
 func (d *namespaceHandler) CreateWorkflowRule(
-	ctx context.Context, ruleSpec *rulespb.WorkflowRuleSpec, nsName string,
+	ctx context.Context, ruleSpec *rulespb.WorkflowRuleSpec,
+	createdByIdentity string,
+	description string,
+	nsName string,
 ) (*rulespb.WorkflowRule, error) {
 
 	if ruleSpec.GetId() == "" {
@@ -715,8 +718,10 @@ func (d *namespaceHandler) CreateWorkflowRule(
 	}
 
 	workflowRule := &rulespb.WorkflowRule{
-		Spec:       ruleSpec,
-		CreateTime: timestamppb.New(d.timeSource.Now()),
+		Spec:              ruleSpec,
+		CreateTime:        timestamppb.New(d.timeSource.Now()),
+		CreatedByIdentity: createdByIdentity,
+		Description:       description,
 	}
 	config.WorkflowRules[ruleSpec.GetId()] = workflowRule
 

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5902,7 +5902,11 @@ func (wh *WorkflowHandler) CreateWorkflowRule(
 		return nil, errWorkflowRuleIDTooLong
 	}
 
-	rule, err := wh.namespaceHandler.CreateWorkflowRule(ctx, request.GetSpec(), request.GetNamespace())
+	rule, err := wh.namespaceHandler.CreateWorkflowRule(ctx,
+		request.GetSpec(),
+		request.GetIdentity(),
+		request.GetDescription(),
+		request.GetNamespace())
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -176,8 +176,16 @@ func GetPendingActivityInfo(
 					},
 				}
 			} else {
-				p.PauseInfo.PausedBy = &workflowpb.PendingActivityInfo_PauseInfo_RuleId{
-					RuleId: ai.PauseInfo.GetRuleId(),
+				ruleId := ai.PauseInfo.GetRuleId()
+				p.PauseInfo.PausedBy = &workflowpb.PendingActivityInfo_PauseInfo_Rule_{
+					Rule: &workflowpb.PendingActivityInfo_PauseInfo_Rule{
+						RuleId: ruleId,
+					},
+				}
+				rule, ok := mutableState.GetNamespaceEntry().GetWorkflowRule(ruleId)
+				if ok {
+					p.PauseInfo.PausedBy.(*workflowpb.PendingActivityInfo_PauseInfo_Rule_).Rule.Identity = rule.CreatedByIdentity
+					p.PauseInfo.PausedBy.(*workflowpb.PendingActivityInfo_PauseInfo_Rule_).Rule.Reason = rule.Description
 				}
 			}
 		}

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2030,10 +2030,9 @@ func (ms *MutableStateImpl) HasBufferedEvents() bool {
 	return ms.hBuilder.HasBufferEvents()
 }
 
+// HasAnyBufferedEvent returns true if there is at least one buffered event that matches the provided filter.
 func (ms *MutableStateImpl) HasAnyBufferedEvent(filter historybuilder.BufferedEventFilter) bool {
 	return ms.hBuilder.HasAnyBufferedEvent(filter)
-	// HasAnyBufferedEvent returns true if there is at least one buffered event that matches the provided filter.
-
 }
 
 // GetLastFirstEventIDTxnID returns last first event ID and corresponding transaction ID

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2030,9 +2030,10 @@ func (ms *MutableStateImpl) HasBufferedEvents() bool {
 	return ms.hBuilder.HasBufferEvents()
 }
 
-// HasAnyBufferedEvent returns true if there is at least one buffered event that matches the provided filter.
 func (ms *MutableStateImpl) HasAnyBufferedEvent(filter historybuilder.BufferedEventFilter) bool {
 	return ms.hBuilder.HasAnyBufferedEvent(filter)
+	// HasAnyBufferedEvent returns true if there is at least one buffered event that matches the provided filter.
+
 }
 
 // GetLastFirstEventIDTxnID returns last first event ID and corresponding transaction ID

--- a/tests/activity_api_rules_test.go
+++ b/tests/activity_api_rules_test.go
@@ -358,7 +358,9 @@ func (s *ActivityApiRulesClientTestSuite) TestActivityRulesApi_RetryActivity() {
 	s.Equal(1, len(description.PendingActivities))
 	s.True(description.PendingActivities[0].Paused)
 	s.NotNil(description.PendingActivities[0].PauseInfo)
-	s.NotNil(ruleID, description.PendingActivities[0].PauseInfo.GetRuleId())
+	rule := description.PendingActivities[0].PauseInfo.GetRule()
+	s.NotNil(rule)
+	s.Equal(ruleID, rule.RuleId)
 
 	// let activity succeed
 	testWorkflow.letActivitySucceed.Store(true)
@@ -501,7 +503,9 @@ func (s *ActivityApiRulesClientTestSuite) TestActivityRulesApi_RetryTask() {
 	s.Equal(1, len(description.PendingActivities))
 	s.True(description.PendingActivities[0].Paused)
 	s.NotNil(description.PendingActivities[0].PauseInfo)
-	s.NotNil(ruleID, description.PendingActivities[0].PauseInfo.GetRuleId())
+	rule := description.PendingActivities[0].PauseInfo.GetRule()
+	s.NotNil(rule)
+	s.Equal(ruleID, rule.RuleId)
 
 	// let activity succeed
 	testRetryTaskWorkflow.letActivitySucceed.Store(true)
@@ -621,7 +625,7 @@ func (s *ActivityApiRulesClientTestSuite) TestActivityRulesApi_PrePause() {
 			assert.True(t, description.PendingActivities[0].GetActivityType().GetName() == activityType)
 			assert.True(t, description.PendingActivities[0].GetPaused())
 			assert.NotNil(t, description.PendingActivities[0].GetPauseInfo())
-			assert.Equal(t, ruleID, description.PendingActivities[0].GetPauseInfo().GetRuleId())
+			assert.Equal(t, ruleID, description.PendingActivities[0].GetPauseInfo().GetRule().GetRuleId())
 		}
 		// to be sure activity doesn't actually start
 		assert.Equal(t, int32(0), testRetryTaskWorkflow.startedActivityCount.Load())
@@ -633,7 +637,7 @@ func (s *ActivityApiRulesClientTestSuite) TestActivityRulesApi_PrePause() {
 	s.Equal(1, len(description.PendingActivities))
 	s.True(description.PendingActivities[0].Paused)
 	s.NotNil(description.PendingActivities[0].PauseInfo)
-	s.NotNil(ruleID, description.PendingActivities[0].PauseInfo.GetRuleId())
+	s.Equal(ruleID, description.PendingActivities[0].PauseInfo.GetRule().GetRuleId())
 
 	// 6. Remove the rule so it didn't interfere with the activity
 	deleteRuleResponse, err := s.FrontendClient().DeleteWorkflowRule(ctx, &workflowservice.DeleteWorkflowRuleRequest{


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Server-side implementation of this API PR:
https://github.com/temporalio/api/pull/577

Add Identity/Reason to pause info in activity was paused by the rule.
Add "created_by_identity/Description" to CreatewWorkflowRule API
Fix tests.

## Why?
<!-- Tell your future self why have you made these changes -->
Product requert.
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests. 

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
N/A

