### PR TITLE
Restore task queue name in proto message

### DIFF
--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -84,6 +84,11 @@ func (c *clientImpl) AddActivityTask(
 	ctx context.Context,
 	request *matchingservice.AddActivityTaskRequest,
 	opts ...grpc.CallOption) (*matchingservice.AddActivityTaskResponse, error) {
+	if tqProto := request.GetTaskQueue(); tqProto != nil {
+		// pickClientForWrite mutates the Name field. Restore it after the call returns.
+		origName := tqProto.Name
+		defer func() { tqProto.Name = origName }()
+	}
 	client, err := c.pickClientForWrite(
 		request.GetTaskQueue(),
 		request.GetNamespaceId(),
@@ -101,6 +106,11 @@ func (c *clientImpl) AddWorkflowTask(
 	ctx context.Context,
 	request *matchingservice.AddWorkflowTaskRequest,
 	opts ...grpc.CallOption) (*matchingservice.AddWorkflowTaskResponse, error) {
+	if tqProto := request.GetTaskQueue(); tqProto != nil {
+		// pickClientForWrite mutates the Name field. Restore it after the call returns.
+		origName := tqProto.Name
+		defer func() { tqProto.Name = origName }()
+	}
 	client, err := c.pickClientForWrite(
 		request.GetTaskQueue(),
 		request.GetNamespaceId(),
@@ -165,6 +175,11 @@ func (c *clientImpl) PollWorkflowTaskQueue(
 }
 
 func (c *clientImpl) QueryWorkflow(ctx context.Context, request *matchingservice.QueryWorkflowRequest, opts ...grpc.CallOption) (*matchingservice.QueryWorkflowResponse, error) {
+	if tqProto := request.GetTaskQueue(); tqProto != nil {
+		// pickClientForWrite mutates the Name field. Restore it after the call returns.
+		origName := tqProto.Name
+		defer func() { tqProto.Name = origName }()
+	}
 	client, err := c.pickClientForWrite(request.GetTaskQueue(), request.GetNamespaceId(), enumspb.TASK_QUEUE_TYPE_WORKFLOW, request.GetForwardInfo().GetSourcePartition())
 	if err != nil {
 		return nil, err

--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -118,6 +118,11 @@ func (c *clientImpl) PollActivityTaskQueue(
 	ctx context.Context,
 	request *matchingservice.PollActivityTaskQueueRequest,
 	opts ...grpc.CallOption) (*matchingservice.PollActivityTaskQueueResponse, error) {
+	if tqProto := request.GetPollRequest().GetTaskQueue(); tqProto != nil {
+		// pickClientForRead mutates the Name field. Restore it after the call returns.
+		origName := tqProto.Name
+		defer func() { tqProto.Name = origName }()
+	}
 	client, release, err := c.pickClientForRead(
 		request.GetPollRequest().GetTaskQueue(),
 		request.GetNamespaceId(),
@@ -138,6 +143,11 @@ func (c *clientImpl) PollWorkflowTaskQueue(
 	ctx context.Context,
 	request *matchingservice.PollWorkflowTaskQueueRequest,
 	opts ...grpc.CallOption) (*matchingservice.PollWorkflowTaskQueueResponse, error) {
+	if tqProto := request.GetPollRequest().GetTaskQueue(); tqProto != nil {
+		// pickClientForRead mutates the Name field. Restore it after the call returns.
+		origName := tqProto.Name
+		defer func() { tqProto.Name = origName }()
+	}
 	client, release, err := c.pickClientForRead(
 		request.GetPollRequest().GetTaskQueue(),
 		request.GetNamespaceId(),


### PR DESCRIPTION
## What changed?
Restore the original task queue name in poll proto messages after the call to matching returns.

## Why?
If the frontend does an internal retry, we want the request to be the same as the first time it came in.

## How did you test it?
existing tests