### PR TITLE
Fix call to assert.Fail in protoassert

### DIFF
--- a/common/testing/protoassert/assert.go
+++ b/common/testing/protoassert/assert.go
@@ -26,6 +26,8 @@
 package protoassert
 
 import (
+	"fmt"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"go.temporal.io/api/temporalproto"
@@ -51,7 +53,7 @@ func ProtoEqual(t assert.TestingT, a proto.Message, b proto.Message) bool {
 		th.Helper()
 	}
 	if diff := cmp.Diff(a, b, protocmp.Transform()); diff != "" {
-		return assert.Fail(t, "Proto mismatch (-want +got):\n", diff)
+		return assert.Fail(t, fmt.Sprintf("Proto mismatch (-want +got):\n%v", diff))
 	}
 	return true
 }
@@ -79,7 +81,7 @@ func ProtoSliceEqual[T proto.Message](t assert.TestingT, a []T, b []T) bool {
 	}
 	for i := 0; i < len(a); i++ {
 		if diff := cmp.Diff(a[i], b[i], protocmp.Transform()); diff != "" {
-			return assert.Fail(t, "Proto mismatch at index %d (-want +got):\n%v", i, diff)
+			return assert.Fail(t, fmt.Sprintf("Proto mismatch at index %d (-want +got):\n%v", i, diff))
 		}
 	}
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix call to `assert.Fail` in `protoassert`

## Why?
<!-- Tell your future self why have you made these changes -->
Bug fix: instead of getting details of the failed assertion, the test log was reporting a panic due to improper call to `assert.Fail`.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
