### PR TITLE
CHASM: Non-Workflow Mutable State P2 Force Termination

### DIFF
--- a/chasm/component_mock.go
+++ b/chasm/component_mock.go
@@ -40,17 +40,32 @@ func (m *MockComponent) EXPECT() *MockComponentMockRecorder {
 }
 
 // LifecycleState mocks base method.
-func (m *MockComponent) LifecycleState() LifecycleState {
+func (m *MockComponent) LifecycleState(arg0 Context) LifecycleState {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LifecycleState")
+	ret := m.ctrl.Call(m, "LifecycleState", arg0)
 	ret0, _ := ret[0].(LifecycleState)
 	return ret0
 }
 
 // LifecycleState indicates an expected call of LifecycleState.
-func (mr *MockComponentMockRecorder) LifecycleState() *gomock.Call {
+func (mr *MockComponentMockRecorder) LifecycleState(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleState", reflect.TypeOf((*MockComponent)(nil).LifecycleState))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleState", reflect.TypeOf((*MockComponent)(nil).LifecycleState), arg0)
+}
+
+// Terminate mocks base method.
+func (m *MockComponent) Terminate(arg0 MutableContext, arg1 TerminateComponentRequest) (TerminateComponentResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Terminate", arg0, arg1)
+	ret0, _ := ret[0].(TerminateComponentResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Terminate indicates an expected call of Terminate.
+func (mr *MockComponentMockRecorder) Terminate(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Terminate", reflect.TypeOf((*MockComponent)(nil).Terminate), arg0, arg1)
 }
 
 // mustEmbedUnimplementedComponent mocks base method.

--- a/chasm/field_test.go
+++ b/chasm/field_test.go
@@ -81,11 +81,11 @@ func (s *fieldSuite) TestFieldGetSimple() {
 				Internal: newFieldInternalWithValue(
 					fieldTypeComponent,
 					&TestSubComponent1{SubComponent1Data: &protoMessageType{
-						ActivityId: "component-data",
+						CreateRequestId: "component-data",
 					}},
 				)},
 			expected: &TestSubComponent1{SubComponent1Data: &protoMessageType{
-				ActivityId: "component-data",
+				CreateRequestId: "component-data",
 			}},
 		},
 		{
@@ -124,13 +124,13 @@ func (s *fieldSuite) TestFieldGetComponent() {
 	s.NoError(err)
 	s.NotNil(sc1)
 	s.ProtoEqual(&protoMessageType{
-		ActivityId: "sub-component1-data",
+		CreateRequestId: "sub-component1-data",
 	}, sc1.SubComponent1Data)
 
 	sd1, err := tc.SubData1.Get(chasmContext)
 	s.NoError(err)
 	s.NotNil(sd1)
 	s.ProtoEqual(&protoMessageType{
-		ActivityId: "sub-data1",
+		CreateRequestId: "sub-data1",
 	}, sd1)
 }

--- a/chasm/fields_iterator_test.go
+++ b/chasm/fields_iterator_test.go
@@ -127,7 +127,7 @@ func (s *fieldsIteratorSuite) TestFieldsOf() {
 			}{},
 			expectedKinds:  []fieldKind{fieldKindData, fieldKindSubField, fieldKindSubCollection},
 			expectedNames:  []string{"DataField", "SubField", "SubCollection"},
-			expectedTypes:  []string{"*persistence.ActivityInfo", "chasm.Field[string]", "chasm.Collection[int]"},
+			expectedTypes:  []string{"*persistence.WorkflowExecutionState", "chasm.Field[string]", "chasm.Collection[int]"},
 			expectedErrors: []string{"", "", ""},
 		},
 		{
@@ -143,7 +143,7 @@ func (s *fieldsIteratorSuite) TestFieldsOf() {
 			input:          &fieldPointer{},
 			expectedKinds:  []fieldKind{fieldKindData, fieldKindUnspecified},
 			expectedNames:  []string{"DataField", "InvalidField"},
-			expectedTypes:  []string{"*persistence.ActivityInfo", "*chasm.Field[string]"},
+			expectedTypes:  []string{"*persistence.WorkflowExecutionState", "*chasm.Field[string]"},
 			expectedErrors: []string{"", "*chasm.fieldPointer.InvalidField: chasm field type *chasm.Field[string] must not be a pointer"},
 		},
 		{
@@ -151,7 +151,7 @@ func (s *fieldsIteratorSuite) TestFieldsOf() {
 			input:          &twoDataFields{},
 			expectedKinds:  []fieldKind{fieldKindData, fieldKindData},
 			expectedNames:  []string{"DataField", "AnotherDataField"},
-			expectedTypes:  []string{"*persistence.ActivityInfo", "*persistence.ActivityInfo"},
+			expectedTypes:  []string{"*persistence.WorkflowExecutionState", "*persistence.WorkflowExecutionState"},
 			expectedErrors: []string{"", "*chasm.twoDataFields.AnotherDataField: only one data field DataField (implements proto.Message) allowed in component"},
 		},
 		{

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -14,6 +14,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/definition"
@@ -77,6 +78,14 @@ type (
 		// Encoded path for different runs of the same Component type are the same.
 		//
 		// encodedPath string
+
+		// When terminated is true, regardless of the Lifecycle state of the component,
+		// the component will be considered as closed.
+		//
+		// This right now only applies to the root node and used to update MutableState
+		// executionState and executionStatus and trigger retention timers.
+		// We could consider extending the force terminate concept to sub-components as well.
+		terminated bool
 	}
 
 	// nodeBase is a set of dependencies and states shared by all nodes in a CHASM tree.
@@ -127,6 +136,10 @@ type (
 		NextTransitionCount() int64
 		GetWorkflowKey() definition.WorkflowKey
 		AddTasks(...tasks.Task)
+		UpdateWorkflowStateStatus(
+			state enumsspb.WorkflowExecutionState,
+			status enumspb.WorkflowExecutionStatus,
+		) error
 	}
 
 	// NodePathEncoder is an interface for encoding and decoding node paths.
@@ -738,7 +751,16 @@ func (n *Node) CloseTransaction() (NodesMutation, error) {
 		n.mutation.UpdatedNodes[encodedPath] = node.serializedNode
 	}
 
-	if err := n.closeTransactionUpdateComponentTasks(); err != nil {
+	nextVersionedTransition := &persistencespb.VersionedTransition{
+		NamespaceFailoverVersion: n.backend.GetCurrentVersion(),
+		TransitionCount:          n.backend.NextTransitionCount(),
+	}
+
+	if err := n.closeTransactionHandleRootLifecycleChange(nextVersionedTransition); err != nil {
+		return NodesMutation{}, err
+	}
+
+	if err := n.closeTransactionUpdateComponentTasks(nextVersionedTransition); err != nil {
 		return NodesMutation{}, err
 	}
 
@@ -753,12 +775,54 @@ func (n *Node) CloseTransaction() (NodesMutation, error) {
 	return n.mutation, nil
 }
 
-func (n *Node) closeTransactionUpdateComponentTasks() error {
-	taskOffset := int64(1)
-	nextVersionedTransition := &persistencespb.VersionedTransition{
-		NamespaceFailoverVersion: n.backend.GetCurrentVersion(),
-		TransitionCount:          n.backend.NextTransitionCount(),
+func (n *Node) closeTransactionHandleRootLifecycleChange(
+	nextVersionedTransition *persistencespb.VersionedTransition,
+) error {
+	lastUpdateVT := n.serializedNode.GetMetadata().LastUpdateVersionedTransition
+	if transitionhistory.Compare(lastUpdateVT, nextVersionedTransition) != 0 {
+		// root not updated in this transition
+		// and this covers all standby logic as well
+		return nil
 	}
+
+	if n.terminated {
+		return n.backend.UpdateWorkflowStateStatus(
+			enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+			enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+		)
+	}
+
+	chasmContext := NewContext(context.Background(), n)
+	component, err := n.Component(chasmContext, ComponentRef{})
+	if err != nil {
+		return err
+	}
+	lifecycleState := component.LifecycleState(chasmContext)
+
+	var newState enumsspb.WorkflowExecutionState
+	var newStatus enumspb.WorkflowExecutionStatus
+	switch lifecycleState {
+	case LifecycleStateRunning:
+		newState = enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING
+		newStatus = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
+	case LifecycleStateCompleted:
+		newState = enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED
+		newStatus = enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
+	case LifecycleStateFailed:
+		newState = enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED
+		newStatus = enumspb.WORKFLOW_EXECUTION_STATUS_FAILED
+	default:
+		return serviceerror.NewInternal(fmt.Sprintf("unknown component lifecycle state: %v", lifecycleState))
+	}
+
+	return n.backend.UpdateWorkflowStateStatus(newState, newStatus)
+}
+
+//nolint:revive // cognitive complexity 28 (> max enabled 25)
+func (n *Node) closeTransactionUpdateComponentTasks(
+	nextVersionedTransition *persistencespb.VersionedTransition,
+) error {
+	taskOffset := int64(1)
 
 	for _, node := range n.andAllChildren() {
 		// no-op if node is not a component
@@ -768,6 +832,8 @@ func (n *Node) closeTransactionUpdateComponentTasks() error {
 		}
 
 		// no-op if node is not updated in this transition
+		// This also prevents standby logic from updating component tasks, since the condition
+		// will never be true.
 		lastUpdateVT := node.serializedNode.GetMetadata().LastUpdateVersionedTransition
 		if transitionhistory.Compare(lastUpdateVT, nextVersionedTransition) != 0 {
 			return nil
@@ -1258,6 +1324,42 @@ func (n *Node) isValueNeedSerialize() bool {
 	}
 
 	return false
+}
+
+func (n *Node) Terminate(
+	request TerminateComponentRequest,
+) error {
+	mutableContext := NewMutableContext(context.Background(), n.root())
+	component, err := n.Component(mutableContext, ComponentRef{})
+	if err != nil {
+		return err
+	}
+
+	_, err = component.Terminate(mutableContext, request)
+	if err != nil {
+		return err
+	}
+
+	n.terminated = true
+	return nil
+}
+
+func (n *Node) Archetype() string {
+	root := n.root()
+	if root.serializedNode == nil {
+		// Empty tree
+		return ""
+	}
+
+	// Root must have be a component.
+	return root.serializedNode.Metadata.GetComponentAttributes().Type
+}
+
+func (n *Node) root() *Node {
+	if n.parent == nil {
+		return n
+	}
+	return n.parent.root()
 }
 
 func newNode(

--- a/chasm/tree_mock.go
+++ b/chasm/tree_mock.go
@@ -12,6 +12,8 @@ package chasm
 import (
 	reflect "reflect"
 
+	enums "go.temporal.io/api/enums/v1"
+	enums0 "go.temporal.io/server/api/enums/v1"
 	definition "go.temporal.io/server/common/definition"
 	tasks "go.temporal.io/server/service/history/tasks"
 	gomock "go.uber.org/mock/gomock"
@@ -97,6 +99,20 @@ func (m *MockNodeBackend) NextTransitionCount() int64 {
 func (mr *MockNodeBackendMockRecorder) NextTransitionCount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextTransitionCount", reflect.TypeOf((*MockNodeBackend)(nil).NextTransitionCount))
+}
+
+// UpdateWorkflowStateStatus mocks base method.
+func (m *MockNodeBackend) UpdateWorkflowStateStatus(state enums0.WorkflowExecutionState, status enums.WorkflowExecutionStatus) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateWorkflowStateStatus", state, status)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateWorkflowStateStatus indicates an expected call of UpdateWorkflowStateStatus.
+func (mr *MockNodeBackendMockRecorder) UpdateWorkflowStateStatus(state, status any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowStateStatus", reflect.TypeOf((*MockNodeBackend)(nil).UpdateWorkflowStateStatus), state, status)
 }
 
 // MockNodePathEncoder is a mock of NodePathEncoder interface.

--- a/service/history/deletemanager/delete_manager.go
+++ b/service/history/deletemanager/delete_manager.go
@@ -33,7 +33,6 @@ type (
 			we *commonpb.WorkflowExecution,
 			weCtx historyi.WorkflowContext,
 			ms historyi.MutableState,
-			forceDeleteFromOpenVisibility bool,
 			stage *tasks.DeleteWorkflowExecutionStage,
 		) error
 		DeleteWorkflowExecutionByRetention(
@@ -110,11 +109,10 @@ func (m *DeleteManagerImpl) DeleteWorkflowExecution(
 	we *commonpb.WorkflowExecution,
 	weCtx historyi.WorkflowContext,
 	ms historyi.MutableState,
-	forceDeleteFromOpenVisibility bool,
 	stage *tasks.DeleteWorkflowExecutionStage,
 ) error {
 
-	return m.deleteWorkflowExecutionInternal(ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility, stage, m.metricsHandler.WithTags(metrics.OperationTag(metrics.HistoryDeleteWorkflowExecutionScope)))
+	return m.deleteWorkflowExecutionInternal(ctx, nsID, we, weCtx, ms, stage, m.metricsHandler.WithTags(metrics.OperationTag(metrics.HistoryDeleteWorkflowExecutionScope)))
 }
 
 func (m *DeleteManagerImpl) DeleteWorkflowExecutionByRetention(
@@ -126,7 +124,7 @@ func (m *DeleteManagerImpl) DeleteWorkflowExecutionByRetention(
 	stage *tasks.DeleteWorkflowExecutionStage,
 ) error {
 
-	return m.deleteWorkflowExecutionInternal(ctx, nsID, we, weCtx, ms, false, stage, m.metricsHandler.WithTags(metrics.OperationTag(metrics.HistoryProcessDeleteHistoryEventScope)))
+	return m.deleteWorkflowExecutionInternal(ctx, nsID, we, weCtx, ms, stage, m.metricsHandler.WithTags(metrics.OperationTag(metrics.HistoryProcessDeleteHistoryEventScope)))
 }
 
 func (m *DeleteManagerImpl) deleteWorkflowExecutionInternal(
@@ -135,7 +133,6 @@ func (m *DeleteManagerImpl) deleteWorkflowExecutionInternal(
 	we *commonpb.WorkflowExecution,
 	weCtx historyi.WorkflowContext,
 	ms historyi.MutableState,
-	forceDeleteFromOpenVisibility bool, //revive:disable-line:flag-parameter
 	stage *tasks.DeleteWorkflowExecutionStage,
 	metricsHandler metrics.Handler,
 ) error {

--- a/service/history/deletemanager/delete_manager_mock.go
+++ b/service/history/deletemanager/delete_manager_mock.go
@@ -59,17 +59,17 @@ func (mr *MockDeleteManagerMockRecorder) AddDeleteWorkflowExecutionTask(ctx, nsI
 }
 
 // DeleteWorkflowExecution mocks base method.
-func (m *MockDeleteManager) DeleteWorkflowExecution(ctx context.Context, nsID namespace.ID, we *common.WorkflowExecution, weCtx interfaces.WorkflowContext, ms interfaces.MutableState, forceDeleteFromOpenVisibility bool, stage *tasks.DeleteWorkflowExecutionStage) error {
+func (m *MockDeleteManager) DeleteWorkflowExecution(ctx context.Context, nsID namespace.ID, we *common.WorkflowExecution, weCtx interfaces.WorkflowContext, ms interfaces.MutableState, stage *tasks.DeleteWorkflowExecutionStage) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility, stage)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, nsID, we, weCtx, ms, stage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecution(ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility, stage any) *gomock.Call {
+func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecution(ctx, nsID, we, weCtx, ms, stage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecution), ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility, stage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecution), ctx, nsID, we, weCtx, ms, stage)
 }
 
 // DeleteWorkflowExecutionByRetention mocks base method.

--- a/service/history/deletemanager/delete_manager_test.go
+++ b/service/history/deletemanager/delete_manager_test.go
@@ -114,7 +114,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteDeletedWorkflowExecution() {
 		&we,
 		mockWeCtx,
 		mockMutableState,
-		false,
 		&stage,
 	)
 	s.NoError(err)
@@ -154,7 +153,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteDeletedWorkflowExecution_Error() 
 		&we,
 		mockWeCtx,
 		mockMutableState,
-		false,
 		&stage,
 	)
 	s.Error(err)
@@ -195,7 +193,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteWorkflowExecution_OpenWorkflow() 
 		&we,
 		mockWeCtx,
 		mockMutableState,
-		true,
 		&stage,
 	)
 	s.NoError(err)

--- a/service/history/interfaces/chasm_tree.go
+++ b/service/history/interfaces/chasm_tree.go
@@ -9,10 +9,14 @@ import (
 
 var _ ChasmTree = (*chasm.Node)(nil)
 
+// TODO: Remove this interface and use *chasm.Node directly
+// when chasm/tree.go implementation completes.
 type ChasmTree interface {
 	CloseTransaction() (chasm.NodesMutation, error)
 	Snapshot(*persistencespb.VersionedTransition) chasm.NodesSnapshot
 	ApplyMutation(chasm.NodesMutation) error
 	ApplySnapshot(chasm.NodesSnapshot) error
 	IsDirty() bool
+	Terminate(chasm.TerminateComponentRequest) error
+	Archetype() string
 }

--- a/service/history/interfaces/chasm_tree_mock.go
+++ b/service/history/interfaces/chasm_tree_mock.go
@@ -69,6 +69,20 @@ func (mr *MockChasmTreeMockRecorder) ApplySnapshot(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplySnapshot", reflect.TypeOf((*MockChasmTree)(nil).ApplySnapshot), arg0)
 }
 
+// Archetype mocks base method.
+func (m *MockChasmTree) Archetype() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Archetype")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Archetype indicates an expected call of Archetype.
+func (mr *MockChasmTreeMockRecorder) Archetype() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Archetype", reflect.TypeOf((*MockChasmTree)(nil).Archetype))
+}
+
 // CloseTransaction mocks base method.
 func (m *MockChasmTree) CloseTransaction() (chasm.NodesMutation, error) {
 	m.ctrl.T.Helper()
@@ -110,4 +124,18 @@ func (m *MockChasmTree) Snapshot(arg0 *persistence.VersionedTransition) chasm.No
 func (mr *MockChasmTreeMockRecorder) Snapshot(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Snapshot", reflect.TypeOf((*MockChasmTree)(nil).Snapshot), arg0)
+}
+
+// Terminate mocks base method.
+func (m *MockChasmTree) Terminate(arg0 chasm.TerminateComponentRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Terminate", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Terminate indicates an expected call of Terminate.
+func (mr *MockChasmTreeMockRecorder) Terminate(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Terminate", reflect.TypeOf((*MockChasmTree)(nil).Terminate), arg0)
 }

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -311,6 +311,8 @@ type (
 		HasCompletedAnyWorkflowTask() bool
 
 		HSM() *hsm.Node
+
+		IsWorkflow() bool
 		ChasmTree() ChasmTree
 
 		// NextTransitionCount returns the next state transition count from the state transition history.

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -2925,6 +2925,20 @@ func (mr *MockMutableStateMockRecorder) IsTransitionHistoryEnabled() *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTransitionHistoryEnabled", reflect.TypeOf((*MockMutableState)(nil).IsTransitionHistoryEnabled))
 }
 
+// IsWorkflow mocks base method.
+func (m *MockMutableState) IsWorkflow() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsWorkflow")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsWorkflow indicates an expected call of IsWorkflow.
+func (mr *MockMutableStateMockRecorder) IsWorkflow() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWorkflow", reflect.TypeOf((*MockMutableState)(nil).IsWorkflow))
+}
+
 // IsWorkflowCloseAttempted mocks base method.
 func (m *MockMutableState) IsWorkflowCloseAttempted() bool {
 	m.ctrl.T.Helper()

--- a/service/history/ndc/buffer_event_flusher_test.go
+++ b/service/history/ndc/buffer_event_flusher_test.go
@@ -134,6 +134,7 @@ func (s *bufferEventFlusherSuite) TestFlushBufferedEvents() {
 	)
 	s.NoError(err)
 
+	s.mockMutableState.EXPECT().IsWorkflow().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().GetLastWriteVersion().Return(lastWriteVersion, nil).AnyTimes()
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()

--- a/service/history/ndc/workflow_test.go
+++ b/service/history/ndc/workflow_test.go
@@ -244,6 +244,7 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, lastEventVersion).Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 
+	s.mockMutableState.EXPECT().IsWorkflow().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().UpdateCurrentVersion(lastEventVersion, true).Return(nil).AnyTimes()
 	startedWorkflowTask := &historyi.WorkflowTaskInfo{
 		Version:          1234,

--- a/service/history/replication/task_executor.go
+++ b/service/history/replication/task_executor.go
@@ -400,7 +400,6 @@ func (e *taskExecutorImpl) cleanupWorkflowExecution(ctx context.Context, namespa
 		&ex,
 		wfCtx,
 		mutableState,
-		false,
 		nil, // stage is not stored during cleanup process.
 	)
 }

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -415,9 +415,6 @@ func (t *transferQueueActiveTaskExecutor) processCloseExecution(
 		err = t.deleteExecution(
 			ctx,
 			task,
-			// Visibility is not updated (to avoid race condition for visibility tasks) and workflow execution is
-			// still open there.
-			true,
 			false,
 			&task.DeleteProcessStage,
 		)

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -1366,7 +1366,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_DeleteA
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	mockDeleteMgr := deletemanager.NewMockDeleteManager(s.controller)
-	mockDeleteMgr.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDeleteMgr.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	s.transferQueueActiveTaskExecutor.workflowDeleteManager = mockDeleteMgr
 	resp := s.transferQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
 	s.NoError(resp.ExecutionErr)
@@ -2723,7 +2723,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestPendingCloseExecutionTasks() 
 			mockWorkflowDeleteManager := deletemanager.NewMockDeleteManager(ctrl)
 			if c.ShouldDelete {
 				mockWorkflowDeleteManager.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+					gomock.Any(), gomock.Any(), gomock.Any())
 			}
 
 			executor := &transferQueueActiveTaskExecutor{

--- a/service/history/transfer_queue_task_executor_base.go
+++ b/service/history/transfer_queue_task_executor_base.go
@@ -198,13 +198,12 @@ func (t *transferQueueTaskExecutorBase) processDeleteExecutionTask(
 	task *tasks.DeleteExecutionTask,
 	ensureNoPendingCloseTask bool,
 ) error {
-	return t.deleteExecution(ctx, task, false, ensureNoPendingCloseTask, &task.ProcessStage)
+	return t.deleteExecution(ctx, task, ensureNoPendingCloseTask, &task.ProcessStage)
 }
 
 func (t *transferQueueTaskExecutorBase) deleteExecution(
 	ctx context.Context,
 	task tasks.Task,
-	forceDeleteFromOpenVisibility bool,
 	ensureNoPendingCloseTask bool,
 	stage *tasks.DeleteWorkflowExecutionStage,
 ) (retError error) {
@@ -275,7 +274,6 @@ func (t *transferQueueTaskExecutorBase) deleteExecution(
 		&workflowExecution,
 		weCtx,
 		mutableState,
-		forceDeleteFromOpenVisibility,
 		stage,
 	)
 }

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -11,6 +11,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/adminservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
@@ -1077,6 +1078,14 @@ func (c *ContextImpl) forceTerminateWorkflow(
 	mutableState, err := c.LoadMutableState(ctx, shardContext)
 	if err != nil {
 		return err
+	}
+
+	if !mutableState.IsWorkflow() {
+		return mutableState.ChasmTree().Terminate(chasm.TerminateComponentRequest{
+			Identity: consts.IdentityHistoryService,
+			Reason:   failureReason,
+			Details:  nil,
+		})
 	}
 
 	return TerminateWorkflow(

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -2465,6 +2465,7 @@ func (s *mutableStateSuite) TestCloseTransactionUpdateTransition() {
 			},
 			txFunc: func(ms historyi.MutableState) (*persistencespb.WorkflowExecutionInfo, error) {
 				mockChasmTree := historyi.NewMockChasmTree(s.controller)
+				mockChasmTree.EXPECT().Archetype().Return("mock-archetype").AnyTimes()
 				gomock.InOrder(
 					mockChasmTree.EXPECT().IsDirty().Return(true).AnyTimes(),
 					mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{
@@ -3871,6 +3872,7 @@ func (s *mutableStateSuite) TestCloseTransactionTrackTombstones() {
 				}
 
 				mockChasmTree := historyi.NewMockChasmTree(s.controller)
+				mockChasmTree.EXPECT().Archetype().Return("mock-archetype").AnyTimes()
 				gomock.InOrder(
 					mockChasmTree.EXPECT().IsDirty().Return(true).AnyTimes(),
 					mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{
@@ -4003,6 +4005,48 @@ func (s *mutableStateSuite) TestCloseTransactionTrackTombstones_OnlyTrackFirstEm
 	tombstoneBatches := mutableState.GetExecutionInfo().SubStateMachineTombstoneBatches
 	s.Len(tombstoneBatches, 1)
 	s.Equal(int64(1), tombstoneBatches[0].VersionedTransition.TransitionCount)
+}
+
+func (s *mutableStateSuite) TestCloseTransactionGenerateCHASMRetentionTask() {
+	dbState := s.buildWorkflowMutableState()
+
+	mutableState, err := NewMutableStateFromDB(s.mockShard, s.mockEventsCache, s.logger, s.namespaceEntry, dbState, 123)
+	s.NoError(err)
+
+	// First close transaction once to get rid of unrelated tasks like UserTimer and ActivityTimeout
+	_, err = mutableState.StartTransaction(s.namespaceEntry)
+	s.NoError(err)
+	_, _, err = mutableState.CloseTransactionAsMutation(historyi.TransactionPolicyActive)
+	s.NoError(err)
+
+	// Switch to a mock CHASM tree
+	mockChasmTree := historyi.NewMockChasmTree(s.controller)
+	mutableState.chasmTree = mockChasmTree
+
+	// Not a workflow, should not generate retention task
+	mockChasmTree.EXPECT().IsDirty().Return(true).AnyTimes()
+	mockChasmTree.EXPECT().Archetype().Return("").Times(1)
+	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{}, nil).AnyTimes()
+	mutation, _, err := mutableState.CloseTransactionAsMutation(historyi.TransactionPolicyActive)
+	s.NoError(err)
+	s.Empty(mutation.Tasks[tasks.CategoryTimer])
+
+	// Now make the mutable state non-workflow.
+	mockChasmTree.EXPECT().Archetype().Return("test-archetype").Times(2) // One time for each CloseTransactionAsMutation call
+	err = mutableState.UpdateWorkflowStateStatus(
+		enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+		enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+	)
+	s.NoError(err)
+	mutation, _, err = mutableState.CloseTransactionAsMutation(historyi.TransactionPolicyActive)
+	s.NoError(err)
+	s.Len(mutation.Tasks[tasks.CategoryTimer], 1)
+	s.Equal(enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT, mutation.Tasks[tasks.CategoryTimer][0].GetType())
+
+	// Already closed before, should not generate retention task again.
+	mutation, _, err = mutableState.CloseTransactionAsMutation(historyi.TransactionPolicyActive)
+	s.NoError(err)
+	s.Empty(mutation.Tasks[tasks.CategoryTimer])
 }
 
 func (s *mutableStateSuite) TestExecutionInfoClone() {

--- a/service/history/workflow/noop_chasm_tree.go
+++ b/service/history/workflow/noop_chasm_tree.go
@@ -29,3 +29,11 @@ func (*noopChasmTree) ApplySnapshot(chasm.NodesSnapshot) error {
 func (*noopChasmTree) IsDirty() bool {
 	return false
 }
+
+func (*noopChasmTree) Terminate(chasm.TerminateComponentRequest) error {
+	return nil
+}
+
+func (*noopChasmTree) Archetype() string {
+	return ""
+}

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -76,6 +76,11 @@ func (r *TaskRefresherImpl) PartialRefresh(
 	minVersionedTransition *persistencespb.VersionedTransition,
 	previousPendingChildIds map[int64]struct{},
 ) error {
+	// TODO: handle task refresh for non workflow mutable states.
+	if !mutableState.IsWorkflow() {
+		return nil
+	}
+
 	taskGenerator := r.taskGeneratorProvider.NewTaskGenerator(
 		r.shard,
 		mutableState,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Support force termination of CHASM runs. 
- Generate retention timers for CHASM runs.
- Get rid of assumptions in workflow.Context and replication that the run is always a Workflow and runs workflow specific logic.

## Why?
<!-- Tell your future self why have you made these changes -->
- CHASM

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Added unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
