### PR TITLE
Refactor: remove custom helpers from functional tests

### DIFF
--- a/common/testing/historyrequire/history_require.go
+++ b/common/testing/historyrequire/history_require.go
@@ -135,9 +135,9 @@ func (h HistoryRequire) WaitForHistoryEvents(expectedHistory string, actualHisto
 	expectedHistoryEvents, expectedEventsAttributes := h.parseHistory(expectedHistory)
 
 	var actualHistoryEvents []*historypb.HistoryEvent
-	require.EventuallyWithT(h.t, func(collect *assert.CollectT) {
+	require.EventuallyWithT(h.t, func(t *assert.CollectT) {
 		actualHistoryEvents = actualHistoryEventsReader()
-		assert.Equalf(collect, len(expectedHistoryEvents), len(actualHistoryEvents),
+		assert.Equalf(t, len(expectedHistoryEvents), len(actualHistoryEvents),
 			"Length of expected(%d) and actual(%d) histories is not equal - actual history: \n%v",
 			len(expectedHistoryEvents), len(actualHistoryEvents), h.formatHistoryEvents(actualHistoryEvents, true))
 	}, waitFor, tick)
@@ -155,10 +155,10 @@ func (h HistoryRequire) WaitForHistoryEventsSuffix(expectedHistorySuffix string,
 	expectedCompactHistory := h.formatHistoryEvents(expectedHistoryEvents, true)
 
 	var actualHistoryEvents []*historypb.HistoryEvent
-	require.EventuallyWithT(h.t, func(collect *assert.CollectT) {
+	require.EventuallyWithT(h.t, func(t *assert.CollectT) {
 		actualHistoryEvents = actualHistoryEventsReader()
 
-		assert.GreaterOrEqualf(collect, len(actualHistoryEvents), len(expectedHistoryEvents),
+		assert.GreaterOrEqualf(t, len(actualHistoryEvents), len(expectedHistoryEvents),
 			"Length of actual history(%d) must be greater or equal to the length of expected history suffix(%d) - actual history: \n%v",
 			len(actualHistoryEvents), len(expectedHistoryEvents), h.formatHistoryEvents(actualHistoryEvents, true))
 		if len(actualHistoryEvents) < len(expectedHistoryEvents) {
@@ -169,15 +169,15 @@ func (h HistoryRequire) WaitForHistoryEventsSuffix(expectedHistorySuffix string,
 		actualHistoryEvents = h.sanitizeActualHistoryEventsForEquals(expectedHistoryEvents, actualHistoryEvents)
 		actualCompactHistory := h.formatHistoryEvents(actualHistoryEvents, true)
 
-		assert.Equalf(collect, actualCompactHistory, expectedCompactHistory,
+		assert.Equalf(t, expectedCompactHistory, actualCompactHistory,
 			"Expected history suffix is not found in actual history. Expected suffix:\n%s\nLast actual:\n%s",
 			expectedCompactHistory, actualCompactHistory)
 	}, waitFor, tick)
 
-	// TODO: Now if expected sequence of events is found, all attributes must match.
-	//  If attributes also need to be checked (but not asserted) then this call
-	//  needs to be moved to Eventually block. This will require passing `collect`
-	//  all way down and replace require with assert.
+	// TODO: Now if expected sequence of events is reached, all attributes must match.
+	//  If attributes values also need to be reached (but not just asserted) then this call
+	//  needs to be moved to Eventually block. This will require passing `t`
+	//  all way down and replace `require` with `assert`.
 	h.equalHistoryEventsAttributes(expectedEventsAttributes, actualHistoryEvents)
 }
 

--- a/tests/testcore/functional_test_sdk_suite.go
+++ b/tests/testcore/functional_test_sdk_suite.go
@@ -25,16 +25,11 @@
 package testcore
 
 import (
-	"context"
 	"errors"
-	"fmt"
 	"time"
 
-	enumspb "go.temporal.io/api/enums/v1"
-	historypb "go.temporal.io/api/history/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
-	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/components/callbacks"
@@ -126,45 +121,4 @@ func (s *FunctionalTestSdkSuite) TearDownTest() {
 		s.sdkClient.Close()
 	}
 	s.FunctionalTestBase.TearDownTest()
-}
-
-func (s *FunctionalTestSdkSuite) EventuallySucceeds(ctx context.Context, operationCtx backoff.OperationCtx) {
-	s.T().Helper()
-	s.NoError(backoff.ThrottleRetryContext(
-		ctx,
-		operationCtx,
-		backoff.NewExponentialRetryPolicy(time.Second),
-		func(err error) bool {
-			// all errors are retryable
-			return true
-		},
-	))
-}
-
-func (s *FunctionalTestSdkSuite) HistoryContainsFailureCausedBy(
-	ctx context.Context,
-	workflowId string,
-	cause enumspb.WorkflowTaskFailedCause,
-) {
-	s.T().Helper()
-	s.EventuallySucceeds(ctx, func(ctx context.Context) error {
-		history := s.sdkClient.GetWorkflowHistory(
-			ctx,
-			workflowId,
-			"",
-			true,
-			enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT,
-		)
-		for history.HasNext() {
-			event, err := history.Next()
-			s.NoError(err)
-			switch a := event.Attributes.(type) {
-			case *historypb.HistoryEvent_WorkflowTaskFailedEventAttributes:
-				if a.WorkflowTaskFailedEventAttributes.Cause == cause {
-					return nil
-				}
-			}
-		}
-		return fmt.Errorf("did not find a failed task whose cause was %q", cause)
-	})
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Refactor: remove custom helpers from functional tests.

## Why?
<!-- Tell your future self why have you made these changes -->
There are standard `s.Eventually` and project wide `historyrequire` package.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run them.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
I am not sure about timing which I put there. I tried to be conservative but if it is too aggressive, times need to be bumped up.
