### PR TITLE
Update-with-Start attach to in-flight Update

### DIFF
--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -52,8 +52,6 @@ var multiOpAbortedErr = serviceerror.NewMultiOperationAborted("Operation was abo
 type (
 	// updateError is a wrapper to distinguish an update error from a start error.
 	updateError struct{ error }
-	// noStartError is a sentinel error that indicates no workflow start occurred.
-	noStartError struct{ startworkflow.StartOutcome }
 )
 
 type (
@@ -128,30 +126,19 @@ func Invoke(
 }
 
 func (mo *multiOp) Invoke(ctx context.Context) (*historyservice.ExecuteMultiOperationResponse, error) {
-	conflictPolicy := mo.startReq.StartRequest.WorkflowIdConflictPolicy
-
 	workflowLease, err := mo.getWorkflowLease(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Workflow was started already.
+	// Workflow already exists.
 	if workflowLease != nil {
-		// Workflow is still running and not requested to be terminated - send the update.
-		if workflowLease.GetMutableState().IsWorkflowExecutionRunning() && conflictPolicy != enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING {
-			if err = mo.allowUpdateRunningWorkflow(workflowLease, conflictPolicy); err != nil {
-				workflowLease.GetReleaseFn()(nil) // nil since nothing was modified
-				return nil, err
-			}
-			return mo.updateWorkflow(ctx, workflowLease) // lease released inside
-		}
+		updateID := mo.updateReq.Request.Request.Meta.GetUpdateId()
 
-		// Workflow is not running anymore and the update already completed - return the outcome.
-		updateId := mo.updateReq.Request.Request.Meta.GetUpdateId()
-		if outcome, err := workflowLease.GetMutableState().GetUpdateOutcome(ctx, updateId); err == nil {
+		// If Update is complete, return it.
+		if outcome, err := workflowLease.GetMutableState().GetUpdateOutcome(ctx, updateID); err == nil {
 			workflowKey := workflowLease.GetContext().GetWorkflowKey()
 			workflowLease.GetReleaseFn()(nil)
-
 			return makeResponse(
 				&historyservice.StartWorkflowExecutionResponse{
 					RunId:   workflowKey.RunID,
@@ -162,28 +149,32 @@ func (mo *multiOp) Invoke(ctx context.Context) (*historyservice.ExecuteMultiOper
 			), nil
 		}
 
-		// Workflow is closed and Update not complete. Will try to start it below.
+		// If Workflow is running ...
+		if workflowLease.GetMutableState().IsWorkflowExecutionRunning() {
+			// If Start is deduped, apply new/attach to update.
+			if canDedup(mo.startReq, workflowLease) {
+				return mo.updateWorkflow(ctx, workflowLease) // lease released inside
+			}
+
+			// If Update exists, attach to update.
+			if upd := workflowLease.GetContext().UpdateRegistry(ctx).Find(ctx, updateID); upd != nil {
+				return mo.updateWorkflow(ctx, workflowLease) // lease released inside
+			}
+
+			// If conflict policy allows re-using the workflow, apply the update.
+			if mo.startReq.StartRequest.WorkflowIdConflictPolicy == enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING {
+				return mo.updateWorkflow(ctx, workflowLease) // lease released inside
+			}
+		}
+
+		// Release before starting workflow further down.
 		workflowLease.GetReleaseFn()(nil)
 	}
 
 	testhooks.Call(mo.testHooks, testhooks.UpdateWithStartInBetweenLockAndStart)
 
-	// Workflow is not running - start and update it!
-	resp, err := mo.startAndUpdateWorkflow(ctx)
-	var noStartErr *noStartError
-	if errors.As(err, &noStartErr) {
-		// The workflow was meant to be started - but was actually *not* started.
-		// The problem is that the update has not been applied.
-		//
-		// This can happen when there's a race: another workflow start occurred right after the check for a
-		// running workflow above - but before the new workflow could be created (and locked).
-		// TODO: Consider a refactoring of the startworkflow.Starter to make this case impossible.
-		//
-		// The best way forward is to exit and retry from the top.
-		// By returning an Unavailable service error, the entire MultiOperation will be retried.
-		return nil, newMultiOpError(serviceerror.NewUnavailable(err.Error()), multiOpAbortedErr)
-	}
-	return resp, err
+	// Workflow does not exist or requires a new run - start and update it!
+	return mo.startAndUpdateWorkflow(ctx)
 }
 
 func (mo *multiOp) workflowLeaseCallback(
@@ -254,46 +245,6 @@ func (mo *multiOp) getWorkflowLease(ctx context.Context) (api.WorkflowLease, err
 	return runningWorkflowLease, nil
 }
 
-func (mo *multiOp) allowUpdateRunningWorkflow(
-	currentWorkflowLease api.WorkflowLease,
-	conflictPolicy enumspb.WorkflowIdConflictPolicy,
-) error {
-	switch conflictPolicy {
-	case enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING:
-		// Allow sending the update.
-		return nil
-
-	case enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL:
-		// If it's the same request ID, allow sending the update.
-		if canDedup(mo.startReq, currentWorkflowLease) {
-			return nil
-		}
-
-		// Otherwise, don't allow sending the update.
-		wfKey := currentWorkflowLease.GetContext().GetWorkflowKey()
-		err := serviceerror.NewWorkflowExecutionAlreadyStarted(
-			fmt.Sprintf("Workflow execution is already running. WorkflowId: %v, RunId: %v.", wfKey.WorkflowID, wfKey.RunID),
-			mo.startReq.StartRequest.RequestId,
-			wfKey.RunID,
-		)
-		return newMultiOpError(err, multiOpAbortedErr)
-
-	case enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING:
-		// Allow sending the update since the termination was deduped earlier.
-		return nil
-
-	case enumspb.WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED:
-		// Don't allow sending the update as the policy is invalid.
-		// This should never happen as it should be validated by the frontend.
-		return serviceerror.NewInvalidArgument("unhandled workflow id conflict policy: unspecified")
-
-	default:
-		// Don't allow sending the update as the policy is invalid.
-		// This should never happen as it should be validated by the frontend.
-		return serviceerror.NewInternal("unhandled workflow id conflict policy")
-	}
-}
-
 func (mo *multiOp) updateWorkflow(
 	ctx context.Context,
 	currentWorkflowLease api.WorkflowLease,
@@ -344,9 +295,18 @@ func (mo *multiOp) startAndUpdateWorkflow(ctx context.Context) (*historyservice.
 		return nil, newMultiOpError(err, multiOpAbortedErr)
 	}
 	if startOutcome != startworkflow.StartNew {
-		// The workflow was not started.
-		// Aborting since the update has not been applied.
-		return nil, &noStartError{startOutcome}
+		// The workflow was meant to be started - but was actually *not* started.
+		// The problem is that the update has not been applied.
+		//
+		// This can happen when there's a race: another workflow start occurred right after the check for a
+		// running workflow above - but before the new workflow could be created (and locked).
+		// TODO: Consider a refactoring of the startworkflow.Starter to make this case impossible.
+		//
+		// The best way forward is to exit and retry from the top.
+		// By returning an Unavailable service error, the entire MultiOperation will be retried.
+		return nil, newMultiOpError(
+			serviceerror.NewUnavailable(fmt.Sprintf("Workflow was not started: %v", startOutcome)),
+			multiOpAbortedErr)
 	}
 
 	// Wait for the update to complete.
@@ -395,8 +355,4 @@ func newMultiOpError(startErr, updateErr error) error {
 
 func canDedup(startReq *historyservice.StartWorkflowExecutionRequest, currentWorkflowLease api.WorkflowLease) bool {
 	return startReq.StartRequest.RequestId == currentWorkflowLease.GetMutableState().GetExecutionState().GetCreateRequestId()
-}
-
-func (e *noStartError) Error() string {
-	return fmt.Sprintf("Workflow was not started: %v", e.StartOutcome)
 }

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -5012,8 +5012,10 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 				s.NotZero(startRes.RunId)
 
 				updateRes := resp.Responses[1].Response.(*workflowservice.ExecuteMultiOperationResponse_Response_UpdateWorkflow).UpdateWorkflow
-				s.NotNil(updateRes.Outcome)
-				s.NotZero(updateRes.Outcome.String())
+				if updateReq.WaitPolicy.LifecycleStage == enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED {
+					s.NotNil(updateRes.Outcome)
+					s.NotZero(updateRes.Outcome.String())
+				}
 			}
 
 			// make sure there's no lock contention
@@ -5222,54 +5224,95 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 			})
 		})
 
-		s.Run("workflow id conflict policy terminate-existing: terminate workflow first, then start and update", func() {
-			tv := testvars.New(s.T())
+		s.Run("workflow id conflict policy terminate-existing", func() {
 
-			// start workflow
-			firstWF, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startWorkflowReq(tv))
-			s.NoError(err)
+			s.Run("terminate workflow first, then start and update", func() {
+				tv := testvars.New(s.T())
 
-			_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv, taskpoller.DrainWorkflowTask)
-			s.NoError(err)
+				// start workflow
+				firstWF, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), startWorkflowReq(tv))
+				s.NoError(err)
 
-			// update-with-start
-			startReq := startWorkflowReq(tv)
-			startReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING
-			updateReq := s.updateWorkflowRequest(tv,
-				&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
-			uwsCh := sendUpdateWithStart(testcore.NewContext(), startReq, updateReq)
-			s.NoError(err)
+				_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv, taskpoller.DrainWorkflowTask)
+				s.NoError(err)
 
-			_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv,
-				func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
-					return &workflowservice.RespondWorkflowTaskCompletedRequest{
-						Messages: s.UpdateAcceptCompleteMessages(tv, task.Messages[0]),
-					}, nil
-				})
-			s.NoError(err)
+				// update-with-start
+				startReq := startWorkflowReq(tv)
+				startReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING
+				updateReq := s.updateWorkflowRequest(tv,
+					&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
+				uwsCh := sendUpdateWithStart(testcore.NewContext(), startReq, updateReq)
 
-			uwsRes := <-uwsCh
-			s.NoError(uwsRes.err)
-			startResp := uwsRes.response.Responses[0].GetStartWorkflow()
-			updateRep := uwsRes.response.Responses[1].GetUpdateWorkflow()
-			s.True(startResp.Started)
-			s.Equal(startResp.RunId, updateRep.UpdateRef.GetWorkflowExecution().RunId)
-			s.EqualValues("success-result-of-"+tv.UpdateID(), testcore.DecodeString(s.T(), updateRep.GetOutcome().GetSuccess()))
+				_, err = s.TaskPoller.PollAndHandleWorkflowTask(tv,
+					func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+						return &workflowservice.RespondWorkflowTaskCompletedRequest{
+							Messages: s.UpdateAcceptCompleteMessages(tv, task.Messages[0]),
+						}, nil
+					})
+				s.NoError(err)
 
-			// ensure workflow was terminated
-			descResp, err := s.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(),
-				&workflowservice.DescribeWorkflowExecutionRequest{
-					Namespace: s.Namespace().String(),
-					Execution: &commonpb.WorkflowExecution{WorkflowId: startReq.WorkflowId, RunId: firstWF.RunId},
-				})
-			s.NoError(err)
-			s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, descResp.WorkflowExecutionInfo.Status)
+				uwsRes := <-uwsCh
+				s.NoError(uwsRes.err)
+				startResp := uwsRes.response.Responses[0].GetStartWorkflow()
+				updateRep := uwsRes.response.Responses[1].GetUpdateWorkflow()
+				s.True(startResp.Started)
+				s.Equal(startResp.RunId, updateRep.UpdateRef.GetWorkflowExecution().RunId)
+				s.EqualValues("success-result-of-"+tv.UpdateID(), testcore.DecodeString(s.T(), updateRep.GetOutcome().GetSuccess()))
 
-			// poll update to ensure same outcome is returned
-			pollRes, err := s.pollUpdate(tv,
-				&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
-			s.Nil(err)
-			s.Equal(updateRep.Outcome.String(), pollRes.Outcome.String())
+				// ensure workflow was terminated
+				descResp, err := s.FrontendClient().DescribeWorkflowExecution(testcore.NewContext(),
+					&workflowservice.DescribeWorkflowExecutionRequest{
+						Namespace: s.Namespace().String(),
+						Execution: &commonpb.WorkflowExecution{WorkflowId: startReq.WorkflowId, RunId: firstWF.RunId},
+					})
+				s.NoError(err)
+				s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, descResp.WorkflowExecutionInfo.Status)
+
+				// poll update to ensure same outcome is returned
+				pollRes, err := s.pollUpdate(tv,
+					&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
+				s.Nil(err)
+				s.Equal(updateRep.Outcome.String(), pollRes.Outcome.String())
+			})
+
+			s.Run("given an accepted update, attach to it", func() {
+				tv := testvars.New(s.T())
+
+				// 1st update-with-start
+				startReq := startWorkflowReq(tv)
+				startReq.WorkflowIdConflictPolicy = enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING
+				updateReq := s.updateWorkflowRequest(tv,
+					&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED})
+				uwsCh1 := sendUpdateWithStart(testcore.NewContext(), startReq, updateReq)
+
+				// accept the update
+				_, err := s.TaskPoller.PollAndHandleWorkflowTask(tv,
+					func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+						return &workflowservice.RespondWorkflowTaskCompletedRequest{
+							Messages: s.UpdateAcceptMessages(tv, task.Messages[0]),
+						}, nil
+					})
+				s.NoError(err)
+
+				uwsRes1 := <-uwsCh1
+				s.NoError(uwsRes1.err)
+				startResp1 := uwsRes1.response.Responses[0].GetStartWorkflow()
+				updateRep1 := uwsRes1.response.Responses[1].GetUpdateWorkflow()
+				s.True(startResp1.Started)
+				s.Equal(startResp1.RunId, updateRep1.UpdateRef.GetWorkflowExecution().RunId)
+				s.Equal(updateRep1.Stage, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED)
+
+				// 2nd update-with-start: attaches to update instead of terminating workflow
+				uwsCh2 := sendUpdateWithStart(testcore.NewContext(), startReq, updateReq)
+
+				uwsRes2 := <-uwsCh2
+				s.NoError(uwsRes2.err)
+				startResp2 := uwsRes2.response.Responses[0].GetStartWorkflow()
+				updateRep2 := uwsRes2.response.Responses[1].GetUpdateWorkflow()
+				s.False(startResp2.Started)
+				s.Equal(startResp2.RunId, startResp1.RunId) // no termination
+				s.Equal(updateRep2.Stage, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED)
+			})
 		})
 
 		s.Run("workflow id conflict policy fail: abort multi operation", func() {
@@ -5313,7 +5356,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 					updReq := s.updateWorkflowRequest(tv,
 						&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
 
-					// 1st
+					// 1st update-with-start
 					uwsCh1 := sendUpdateWithStart(testcore.NewContext(), startReq, updReq)
 					_, err := s.TaskPoller.PollAndHandleWorkflowTask(tv,
 						func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
@@ -5325,7 +5368,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 					uwsRes1 := <-uwsCh1
 					s.NoError(uwsRes1.err)
 
-					// 2nd (using same RequestID and UpdateID)
+					// 2nd update-with-start: using *same* RequestID and UpdateID
 					uwsRes2 := <-sendUpdateWithStart(testcore.NewContext(), startReq, updReq)
 					s.NoError(uwsRes2.err)
 
@@ -5434,7 +5477,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 			s.Equal("Operation was aborted.", errs[1].Error())
 		})
 
-		s.Run("receive update result from closed workflow", func() {
+		s.Run("still receive update result regardless of conflict policy", func() {
 			for _, p := range []enumspb.WorkflowIdConflictPolicy{
 				enumspb.WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING,
 				enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Make UwS attach to any in-flight Update before applying Start operation (like termination).

## Why?
<!-- Tell your future self why have you made these changes -->

Allows to complete in-flight Update instead of terminating the Workflow.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Added test.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
