### PR TITLE
[CHASM] Pure task processing - GetPureTasks, ExecutePureTasks

### DIFF
--- a/service/history/interfaces/chasm_tree.go
+++ b/service/history/interfaces/chasm_tree.go
@@ -3,6 +3,8 @@
 package interfaces
 
 import (
+	"time"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 )
@@ -15,4 +17,7 @@ type ChasmTree interface {
 	ApplyMutation(chasm.NodesMutation) error
 	ApplySnapshot(chasm.NodesSnapshot) error
 	IsDirty() bool
+
+	GetPureTasks(deadline time.Time) ([]any, error)
+	ExecutePureTask(taskInstance any) error
 }

--- a/service/history/workflow/noop_chasm_tree.go
+++ b/service/history/workflow/noop_chasm_tree.go
@@ -1,6 +1,8 @@
 package workflow
 
 import (
+	"time"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	historyi "go.temporal.io/server/service/history/interfaces"
@@ -28,4 +30,12 @@ func (*noopChasmTree) ApplySnapshot(chasm.NodesSnapshot) error {
 
 func (*noopChasmTree) IsDirty() bool {
 	return false
+}
+
+func (*noopChasmTree) GetPureTasks(deadline time.Time) ([]any, error) {
+	return nil, nil
+}
+
+func (*noopChasmTree) ExecutePureTask(taskInstance any) error {
+	return nil
 }


### PR DESCRIPTION
## What changed?
- Adds `GetPureTasks`, `ExecutePureTask` to the CHASM Tree (`Node`). These will be invoked from the timer queue executors in history service during processing of physical pure tasks.

## Why?
<!-- Tell your future self why have you made these changes -->
- Keeping the majority of the execution and tree traversal logic within CHASM keeps the timer queue's processing agnostic to CHASM's inner workings as possible.
- Side Effect tasks do not need a `GetPureTasks` analog, as they keep a direct `Ref` to the component they're targetting, and their physical tasks are 1:1 with logical tasks.

## How did you test it?
- New tests

