### PR TITLE
Handle empty history events

### DIFF
--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -816,6 +816,9 @@ func (m *executionManagerImpl) readRawHistoryBranchAndFilter(
 		dataBlobs = make([]*commonpb.DataBlob, len(nodes))
 		for index, node := range nodes {
 			dataBlobs[index] = node.Events
+			if node.Events == nil {
+				return nil, nil, nil, nil, 0, serviceerror.NewDataLoss("no events in history node")
+			}
 			dataSize += len(node.Events.Data)
 			transactionIDs = append(transactionIDs, node.TransactionID)
 			nodeIDs = append(nodeIDs, node.NodeID)

--- a/service/history/api/getworkflowexecutionhistory/api.go
+++ b/service/history/api/getworkflowexecutionhistory/api.go
@@ -264,7 +264,16 @@ func Invoke(
 				if err != nil {
 					return nil, err
 				}
-				// since getHistory func will not return empty history, so the below is safe
+				// GetHistory func will not return empty history. Log workflow details if that is not the case
+				if len(history.Events) == 0 {
+					shardContext.GetLogger().Error(
+						"GetHistory returned empty history",
+						tag.WorkflowNamespaceID(namespaceID.String()),
+						tag.WorkflowID(execution.GetWorkflowId()),
+						tag.WorkflowRunID(execution.GetRunId()),
+					)
+					return nil, serviceerror.NewDataLoss("no events in workflow history")
+				}
 				history.Events = history.Events[len(history.Events)-1 : len(history.Events)]
 			}
 			continuationToken = nil


### PR DESCRIPTION
## What changed?
Handle no events in workflow history.

## Why?
To prevent panics in case of data corruption.
