### PR TITLE
Allow dual ES clusters in visibility config

### DIFF
--- a/common/config/persistence.go
+++ b/common/config/persistence.go
@@ -77,20 +77,6 @@ func (c *Persistence) Validate() error {
 				ErrPersistenceConfig,
 				c.SecondaryVisibilityStore)
 		}
-		if isPrimaryEs && isSecondaryEs {
-			// ElasticSearch config for visibilityStore and secondaryVisibilityStore must be the same except for
-			// `indices.visibility` config key and private fields - this is a restriction due to global ES client
-			esConfig := *c.DataStores[c.VisibilityStore].Elasticsearch
-			secEsConfig := *c.DataStores[c.SecondaryVisibilityStore].Elasticsearch
-			esConfig.Indices = nil
-			secEsConfig.Indices = nil
-			if !reflect.DeepEqual(esConfig, secEsConfig) {
-				return fmt.Errorf(
-					"%w: config mismatch for visibilityStore and secondaryVisibilityStore",
-					ErrPersistenceConfig,
-				)
-			}
-		}
 	}
 
 	for _, st := range stores {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Allow dual ES clusters in visibility config

## Why?
<!-- Tell your future self why have you made these changes -->
Allow to set a different Elasticsearch cluster as secondary Elasticsearch visibility store.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Created two ES clusters as two docker containers, modified the server config with dual visibility enabled, and ran some sample workflow. Verified that visibility records are written to both ES clusters and that the server can read from both of them

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Adding search attributes might be not add to the secondary ES

## Documentation
<!-- Have you made sure this change doesn't falsify anything currently stated in `docs/`? If significant
new behavior is added, have you described that in `docs/`? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
