### PR TITLE
Remove cap for dynamic config callback pool

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -18,7 +18,7 @@ var (
 		"dynamicconfig.subscriptionCallback",
 		subscriptionCallbackSettings{
 			MinWorkers:   10,
-			MaxWorkers:   100,
+			MaxWorkers:   1e9, // effectively unlimited
 			TargetDelay:  10 * time.Millisecond,
 			ShrinkFactor: 1000, // 10 seconds
 		},


### PR DESCRIPTION
## What changed?
Set MaxWorkers for dynamic config subscription callback to 1e9 so there's no effective limit.

## Why?
A batch of subscription callbacks are enqueued (though not called) while holding a lock. If a callback somehow makes a call back into dynamic config subscriptions, then it would have to wait for the batch to finish enqueueing. If there's more than MaxWorkers of those, that would cause a deadlock. We don't need to impose a limit on workers here.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

