### PR TITLE
Refactor updateworkflowoptions package

### DIFF
--- a/service/history/api/updateworkflowoptions/api.go
+++ b/service/history/api/updateworkflowoptions/api.go
@@ -53,8 +53,8 @@ func Invoke(
 			}
 
 			// Merge the requested options mentioned in the field mask with the current options in the mutable state
-			mergedOpts, err := applyWorkflowExecutionOptions(
-				getOptionsFromMutableState(mutableState),
+			mergedOpts, err := MergeWorkflowExecutionOptions(
+				GetOptionsFromMutableState(mutableState),
 				opts,
 				req.GetUpdateMask(),
 			)
@@ -66,7 +66,7 @@ func Invoke(
 			ret.WorkflowExecutionOptions = mergedOpts
 
 			// If there is no mutable state change at all, return with no new history event and Noop=true
-			if proto.Equal(mergedOpts, getOptionsFromMutableState(mutableState)) {
+			if proto.Equal(mergedOpts, GetOptionsFromMutableState(mutableState)) {
 				return &api.UpdateWorkflowAction{
 					Noop:               true,
 					CreateWorkflowTask: false,
@@ -98,7 +98,7 @@ func Invoke(
 	return ret, nil
 }
 
-func getOptionsFromMutableState(ms historyi.MutableState) *workflowpb.WorkflowExecutionOptions {
+func GetOptionsFromMutableState(ms historyi.MutableState) *workflowpb.WorkflowExecutionOptions {
 	opts := &workflowpb.WorkflowExecutionOptions{}
 	if versioningInfo := ms.GetExecutionInfo().GetVersioningInfo(); versioningInfo != nil {
 		override, ok := proto.Clone(versioningInfo.GetVersioningOverride()).(*workflowpb.VersioningOverride)
@@ -110,8 +110,8 @@ func getOptionsFromMutableState(ms historyi.MutableState) *workflowpb.WorkflowEx
 	return opts
 }
 
-// applyWorkflowExecutionOptions copies the given paths in `src` struct to `dst` struct
-func applyWorkflowExecutionOptions(
+// MergeWorkflowExecutionOptions copies the given paths in `src` struct to `dst` struct
+func MergeWorkflowExecutionOptions(
 	mergeInto, mergeFrom *workflowpb.WorkflowExecutionOptions,
 	updateMask *fieldmaskpb.FieldMask,
 ) (*workflowpb.WorkflowExecutionOptions, error) {

--- a/service/history/api/updateworkflowoptions/api_test.go
+++ b/service/history/api/updateworkflowoptions/api_test.go
@@ -35,28 +35,28 @@ func TestMergeOptions_VersionOverrideMask(t *testing.T) {
 	input := emptyOptions
 
 	// Merge unpinned into empty options
-	merged, err := MergeWorkflowExecutionOptions(input, unpinnedOverrideOptions, updateMask)
+	merged, err := mergeWorkflowExecutionOptions(input, unpinnedOverrideOptions, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	assert.EqualExportedValues(t, unpinnedOverrideOptions, merged)
 
 	// Merge pinned_A into unpinned options
-	merged, err = MergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, updateMask)
+	merged, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	assert.EqualExportedValues(t, pinnedOverrideOptionsA, merged)
 
 	// Merge pinned_B into pinned_A options
-	merged, err = MergeWorkflowExecutionOptions(input, pinnedOverrideOptionsB, updateMask)
+	merged, err = mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsB, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	assert.EqualExportedValues(t, pinnedOverrideOptionsB, merged)
 
 	// Unset versioning override
-	merged, err = MergeWorkflowExecutionOptions(input, emptyOptions, updateMask)
+	merged, err = mergeWorkflowExecutionOptions(input, emptyOptions, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
@@ -68,13 +68,13 @@ func TestMergeOptions_PartialMask(t *testing.T) {
 	behaviorOnlyUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"versioning_override.behavior"}}
 	deploymentOnlyUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"versioning_override.deployment"}}
 
-	_, err := MergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, behaviorOnlyUpdateMask)
+	_, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, behaviorOnlyUpdateMask)
 	assert.Error(t, err)
 
-	_, err = MergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, deploymentOnlyUpdateMask)
+	_, err = mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, deploymentOnlyUpdateMask)
 	assert.Error(t, err)
 
-	merged, err := MergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, bothUpdateMask)
+	merged, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, bothUpdateMask)
 	assert.NoError(t, err)
 	assert.EqualExportedValues(t, unpinnedOverrideOptions, merged)
 }
@@ -84,24 +84,24 @@ func TestMergeOptions_EmptyMask(t *testing.T) {
 	input := pinnedOverrideOptionsB
 
 	// Don't merge anything
-	merged, err := MergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, emptyUpdateMask)
+	merged, err := mergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, emptyUpdateMask)
 	assert.NoError(t, err)
 	assert.EqualExportedValues(t, input, merged)
 
 	// Don't merge anything
-	merged, err = MergeWorkflowExecutionOptions(input, nil, emptyUpdateMask)
+	merged, err = mergeWorkflowExecutionOptions(input, nil, emptyUpdateMask)
 	assert.NoError(t, err)
 	assert.EqualExportedValues(t, input, merged)
 }
 
 func TestMergeOptions_AsteriskMask(t *testing.T) {
 	asteriskUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"*"}}
-	_, err := MergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, asteriskUpdateMask)
+	_, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, asteriskUpdateMask)
 	assert.Error(t, err)
 }
 
 func TestMergeOptions_FooMask(t *testing.T) {
 	fooUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"foo"}}
-	_, err := MergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, fooUpdateMask)
+	_, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, fooUpdateMask)
 	assert.Error(t, err)
 }

--- a/service/history/api/updateworkflowoptions/api_test.go
+++ b/service/history/api/updateworkflowoptions/api_test.go
@@ -1,11 +1,29 @@
 package updateworkflowoptions
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/historyservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/cluster/clustertest"
+	"go.temporal.io/server/common/locks"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/service/history/api"
+	historyi "go.temporal.io/server/service/history/interfaces"
+	"go.temporal.io/server/service/history/tests"
+	wcache "go.temporal.io/server/service/history/workflow/cache"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
@@ -104,4 +122,106 @@ func TestMergeOptions_FooMask(t *testing.T) {
 	fooUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"foo"}}
 	_, err := mergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, fooUpdateMask)
 	assert.Error(t, err)
+}
+
+type (
+	// updateWorkflowOptionsSuite contains tests for the UpdateWorkflowOptions API.
+	updateWorkflowOptionsSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		controller        *gomock.Controller
+		shardContext      *historyi.MockShardContext
+		namespaceRegistry *namespace.MockRegistry
+
+		workflowCache              *wcache.MockCache
+		workflowConsistencyChecker api.WorkflowConsistencyChecker
+
+		currentContext      *historyi.MockWorkflowContext
+		currentMutableState *historyi.MockMutableState
+	}
+)
+
+func TestUpdateWorkflowOptionsSuite(t *testing.T) {
+	s := new(updateWorkflowOptionsSuite)
+	suite.Run(t, s)
+}
+
+func (s *updateWorkflowOptionsSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.controller = gomock.NewController(s.T())
+	s.namespaceRegistry = namespace.NewMockRegistry(s.controller)
+	s.namespaceRegistry.EXPECT().GetNamespaceByID(tests.GlobalNamespaceEntry.ID()).Return(tests.GlobalNamespaceEntry, nil)
+
+	s.shardContext = historyi.NewMockShardContext(s.controller)
+	s.shardContext.EXPECT().GetNamespaceRegistry().Return(s.namespaceRegistry)
+	s.shardContext.EXPECT().GetClusterMetadata().Return(clustertest.NewMetadataForTest(cluster.NewTestClusterMetadataConfig(true, true)))
+
+	// mock a mutable state with an existing versioning override
+	s.currentMutableState = historyi.NewMockMutableState(s.controller)
+	s.currentMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
+		WorkflowId: tests.WorkflowID,
+		VersioningInfo: &workflowpb.WorkflowExecutionVersioningInfo{
+			VersioningOverride: &workflowpb.VersioningOverride{
+				Behavior:      enumspb.VERSIONING_BEHAVIOR_AUTO_UPGRADE,
+				PinnedVersion: "X.123",
+			},
+		},
+	}).AnyTimes()
+	s.currentMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
+		RunId: tests.RunID,
+	}).AnyTimes()
+
+	s.currentContext = historyi.NewMockWorkflowContext(s.controller)
+	s.currentContext.EXPECT().LoadMutableState(gomock.Any(), s.shardContext).Return(s.currentMutableState, nil)
+
+	s.workflowCache = wcache.NewMockCache(s.controller)
+	s.workflowCache.EXPECT().GetOrCreateWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), locks.PriorityHigh).
+		Return(s.currentContext, wcache.NoopReleaseFn, nil)
+
+	s.workflowConsistencyChecker = api.NewWorkflowConsistencyChecker(
+		s.shardContext,
+		s.workflowCache,
+	)
+}
+
+func (s *updateWorkflowOptionsSuite) TearDownTest() {
+	s.controller.Finish()
+}
+
+func (s *updateWorkflowOptionsSuite) TestInvoke_Success() {
+
+	expectedOverrideOptions := &workflowpb.WorkflowExecutionOptions{
+		VersioningOverride: &workflowpb.VersioningOverride{
+			Behavior:      enumspb.VERSIONING_BEHAVIOR_PINNED,
+			PinnedVersion: "X.A",
+		},
+	}
+	s.currentMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true)
+	s.currentMutableState.EXPECT().AddWorkflowExecutionOptionsUpdatedEvent(expectedOverrideOptions.VersioningOverride, false, "", nil, nil).Return(&historypb.HistoryEvent{}, nil)
+	s.currentContext.EXPECT().UpdateWorkflowExecutionAsActive(gomock.Any(), s.shardContext).Return(nil)
+
+	updateReq := &historyservice.UpdateWorkflowExecutionOptionsRequest{
+		NamespaceId: tests.NamespaceID.String(),
+		UpdateRequest: &workflowservice.UpdateWorkflowExecutionOptionsRequest{
+			Namespace: tests.Namespace.String(),
+			WorkflowExecution: &commonpb.WorkflowExecution{
+				WorkflowId: tests.WorkflowID,
+				RunId:      tests.RunID,
+			},
+			WorkflowExecutionOptions: expectedOverrideOptions,
+			UpdateMask:               &fieldmaskpb.FieldMask{Paths: []string{"versioning_override"}},
+		},
+	}
+
+	resp, err := Invoke(
+		context.Background(),
+		updateReq,
+		s.shardContext,
+		s.workflowConsistencyChecker,
+	)
+	s.NoError(err)
+	s.NotNil(resp)
+	proto.Equal(expectedOverrideOptions, resp.GetWorkflowExecutionOptions())
 }

--- a/service/history/api/updateworkflowoptions/api_test.go
+++ b/service/history/api/updateworkflowoptions/api_test.go
@@ -35,28 +35,28 @@ func TestMergeOptions_VersionOverrideMask(t *testing.T) {
 	input := emptyOptions
 
 	// Merge unpinned into empty options
-	merged, err := applyWorkflowExecutionOptions(input, unpinnedOverrideOptions, updateMask)
+	merged, err := MergeWorkflowExecutionOptions(input, unpinnedOverrideOptions, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	assert.EqualExportedValues(t, unpinnedOverrideOptions, merged)
 
 	// Merge pinned_A into unpinned options
-	merged, err = applyWorkflowExecutionOptions(input, pinnedOverrideOptionsA, updateMask)
+	merged, err = MergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	assert.EqualExportedValues(t, pinnedOverrideOptionsA, merged)
 
 	// Merge pinned_B into pinned_A options
-	merged, err = applyWorkflowExecutionOptions(input, pinnedOverrideOptionsB, updateMask)
+	merged, err = MergeWorkflowExecutionOptions(input, pinnedOverrideOptionsB, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
 	assert.EqualExportedValues(t, pinnedOverrideOptionsB, merged)
 
 	// Unset versioning override
-	merged, err = applyWorkflowExecutionOptions(input, emptyOptions, updateMask)
+	merged, err = MergeWorkflowExecutionOptions(input, emptyOptions, updateMask)
 	if err != nil {
 		t.Error(err)
 	}
@@ -68,13 +68,13 @@ func TestMergeOptions_PartialMask(t *testing.T) {
 	behaviorOnlyUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"versioning_override.behavior"}}
 	deploymentOnlyUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"versioning_override.deployment"}}
 
-	_, err := applyWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, behaviorOnlyUpdateMask)
+	_, err := MergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, behaviorOnlyUpdateMask)
 	assert.Error(t, err)
 
-	_, err = applyWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, deploymentOnlyUpdateMask)
+	_, err = MergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, deploymentOnlyUpdateMask)
 	assert.Error(t, err)
 
-	merged, err := applyWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, bothUpdateMask)
+	merged, err := MergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, bothUpdateMask)
 	assert.NoError(t, err)
 	assert.EqualExportedValues(t, unpinnedOverrideOptions, merged)
 }
@@ -84,24 +84,24 @@ func TestMergeOptions_EmptyMask(t *testing.T) {
 	input := pinnedOverrideOptionsB
 
 	// Don't merge anything
-	merged, err := applyWorkflowExecutionOptions(input, pinnedOverrideOptionsA, emptyUpdateMask)
+	merged, err := MergeWorkflowExecutionOptions(input, pinnedOverrideOptionsA, emptyUpdateMask)
 	assert.NoError(t, err)
 	assert.EqualExportedValues(t, input, merged)
 
 	// Don't merge anything
-	merged, err = applyWorkflowExecutionOptions(input, nil, emptyUpdateMask)
+	merged, err = MergeWorkflowExecutionOptions(input, nil, emptyUpdateMask)
 	assert.NoError(t, err)
 	assert.EqualExportedValues(t, input, merged)
 }
 
 func TestMergeOptions_AsteriskMask(t *testing.T) {
 	asteriskUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"*"}}
-	_, err := applyWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, asteriskUpdateMask)
+	_, err := MergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, asteriskUpdateMask)
 	assert.Error(t, err)
 }
 
 func TestMergeOptions_FooMask(t *testing.T) {
 	fooUpdateMask := &fieldmaskpb.FieldMask{Paths: []string{"foo"}}
-	_, err := applyWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, fooUpdateMask)
+	_, err := MergeWorkflowExecutionOptions(emptyOptions, unpinnedOverrideOptions, fooUpdateMask)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
## What changed?
- Expose `updateworkflowoptions.MergeAndApply()`
- Minor refactors

## Why?
Need `updateworkflowoptions.MergeAndApply()` so that we can update options at the time of workflow reset.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

