### PR TITLE
Add activity options to the pending activity info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	go.temporal.io/api v1.49.1-0.20250507210307-439f7224c9df
+	go.temporal.io/api v1.49.1-0.20250509172953-4c3944c121c0
 	go.temporal.io/sdk v1.34.0
 	go.temporal.io/version v0.3.0
 	go.uber.org/automaxprocs v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	go.temporal.io/api v1.49.1-0.20250502021138-9b54d4a53f2f
+	go.temporal.io/api v1.49.1-0.20250507210307-439f7224c9df
 	go.temporal.io/sdk v1.34.0
 	go.temporal.io/version v0.3.0
 	go.uber.org/automaxprocs v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.49.1-0.20250502021138-9b54d4a53f2f h1:uv+JOsCGhnaEqJlDEfPW4SqewanFQp63C73E5BhDWxA=
-go.temporal.io/api v1.49.1-0.20250502021138-9b54d4a53f2f/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.49.1-0.20250507210307-439f7224c9df h1:WAzMQPMMNCDKXzlduh9KttibcCKVGEeAJ3GC6ARgERE=
+go.temporal.io/api v1.49.1-0.20250507210307-439f7224c9df/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.34.0 h1:VLg/h6ny7GvLFVoQPqz2NcC93V9yXboQwblkRvZ1cZE=
 go.temporal.io/sdk v1.34.0/go.mod h1:iE4U5vFrH3asOhqpBBphpj9zNtw8btp8+MSaf5A0D3w=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.49.1-0.20250507210307-439f7224c9df h1:WAzMQPMMNCDKXzlduh9KttibcCKVGEeAJ3GC6ARgERE=
-go.temporal.io/api v1.49.1-0.20250507210307-439f7224c9df/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.49.1-0.20250509172953-4c3944c121c0 h1:o9iwtENRgyA8sxaigvmf4e6//QHJKG8+mxgl7FjlHQE=
+go.temporal.io/api v1.49.1-0.20250509172953-4c3944c121c0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.34.0 h1:VLg/h6ny7GvLFVoQPqz2NcC93V9yXboQwblkRvZ1cZE=
 go.temporal.io/sdk v1.34.0/go.mod h1:iE4U5vFrH3asOhqpBBphpj9zNtw8btp8+MSaf5A0D3w=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=

--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -29,9 +29,12 @@ import (
 	"math/rand"
 	"time"
 
+	activitypb "go.temporal.io/api/activity/v1"
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	rulespb "go.temporal.io/api/rules/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -199,6 +202,25 @@ func GetPendingActivityInfo(
 				}
 			}
 		}
+	}
+
+	p.ActivityOptions = &activitypb.ActivityOptions{
+		TaskQueue: &taskqueuepb.TaskQueue{
+			// we may need to return sticky task queue name here
+			Name:       ai.TaskQueue,
+			NormalName: ai.TaskQueue,
+		},
+		ScheduleToCloseTimeout: ai.ScheduleToCloseTimeout,
+		ScheduleToStartTimeout: ai.ScheduleToStartTimeout,
+		StartToCloseTimeout:    ai.StartToCloseTimeout,
+		HeartbeatTimeout:       ai.HeartbeatTimeout,
+
+		RetryPolicy: &commonpb.RetryPolicy{
+			InitialInterval:    ai.RetryInitialInterval,
+			BackoffCoefficient: ai.RetryBackoffCoefficient,
+			MaximumInterval:    ai.RetryMaximumInterval,
+			MaximumAttempts:    ai.RetryMaximumAttempts,
+		},
 	}
 
 	return p, nil

--- a/service/history/workflow/activity_test.go
+++ b/service/history/workflow/activity_test.go
@@ -263,6 +263,7 @@ func (s *activitySuite) TestGetPendingActivityInfoHasRetryPolicy() {
 		RetryInitialInterval:    durationpb.New(time.Minute),
 		RetryBackoffCoefficient: 1.0,
 		RetryMaximumAttempts:    10,
+		TaskQueue:               "task-queue",
 	}
 
 	s.mockMutableState.EXPECT().GetActivityType(gomock.Any(), gomock.Any()).Return(&activityType, nil).Times(1)
@@ -281,6 +282,17 @@ func (s *activitySuite) TestGetPendingActivityInfoHasRetryPolicy() {
 	s.Equal(durationpb.New(2*time.Minute), pi.CurrentRetryInterval)
 	s.Equal(ai.ScheduledTime, pi.ScheduledTime)
 	s.Equal(ai.LastAttemptCompleteTime, pi.LastAttemptCompleteTime)
+	s.NotNil(pi.ActivityOptions)
+	s.NotNil(pi.ActivityOptions.RetryPolicy)
+	s.Equal(ai.TaskQueue, pi.ActivityOptions.TaskQueue)
+	s.Equal(ai.ScheduleToCloseTimeout, pi.ActivityOptions.ScheduleToCloseTimeout)
+	s.Equal(ai.ScheduleToStartTimeout, pi.ActivityOptions.ScheduleToStartTimeout)
+	s.Equal(ai.StartToCloseTimeout, pi.ActivityOptions.StartToCloseTimeout)
+	s.Equal(ai.HeartbeatTimeout, pi.ActivityOptions.HeartbeatTimeout)
+	s.Equal(ai.RetryMaximumInterval, pi.ActivityOptions.RetryPolicy.MaximumInterval)
+	s.Equal(ai.RetryInitialInterval, pi.ActivityOptions.RetryPolicy.InitialInterval)
+	s.Equal(ai.RetryBackoffCoefficient, pi.ActivityOptions.RetryPolicy.BackoffCoefficient)
+	s.Equal(ai.RetryMaximumAttempts, pi.ActivityOptions.RetryPolicy.MaximumAttempts)
 }
 
 func (s *activitySuite) AddActivityInfo() *persistencespb.ActivityInfo {

--- a/service/history/workflow/activity_test.go
+++ b/service/history/workflow/activity_test.go
@@ -284,7 +284,7 @@ func (s *activitySuite) TestGetPendingActivityInfoHasRetryPolicy() {
 	s.Equal(ai.LastAttemptCompleteTime, pi.LastAttemptCompleteTime)
 	s.NotNil(pi.ActivityOptions)
 	s.NotNil(pi.ActivityOptions.RetryPolicy)
-	s.Equal(ai.TaskQueue, pi.ActivityOptions.TaskQueue)
+	s.Equal(ai.TaskQueue, pi.ActivityOptions.TaskQueue.Name)
 	s.Equal(ai.ScheduleToCloseTimeout, pi.ActivityOptions.ScheduleToCloseTimeout)
 	s.Equal(ai.ScheduleToStartTimeout, pi.ActivityOptions.ScheduleToStartTimeout)
 	s.Equal(ai.StartToCloseTimeout, pi.ActivityOptions.StartToCloseTimeout)


### PR DESCRIPTION
## What changed?
Populate activity options in DescriveWorfklow request.
Corresponding API PR:
https://github.com/temporalio/api/pull/586

## Why?
* Activity options can be changed, and right now there is no way to know that.
* Requirement in UI.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)