### PR TITLE
Rename internal CHASM task processing interface

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -153,10 +153,9 @@ type (
 		Decode(encodedPath string) ([]string, error)
 	}
 
-	// LogicalTaskExecutor must be implemented on backends capable of running logical
-	// task instances to completion. This interface is intended to be implemented and
-	// used within the CHASM framework only.
-	LogicalTaskExecutor interface {
+	// NodeExecutePureTask is intended to be implemented and used within the CHASM
+	// framework only.
+	NodeExecutePureTask interface {
 		ExecutePureTask(baseCtx context.Context, taskInstance any) error
 	}
 )
@@ -1412,7 +1411,7 @@ func isComponentTaskExpired(
 // close).
 func (n *Node) EachPureTask(
 	referenceTime time.Time,
-	callback func(executor LogicalTaskExecutor, task any) error,
+	callback func(executor NodeExecutePureTask, task any) error,
 ) error {
 	// Walk the tree to find all runnable tasks.
 	for _, node := range n.andAllChildren() {

--- a/chasm/tree_mock.go
+++ b/chasm/tree_mock.go
@@ -170,32 +170,32 @@ func (mr *MockNodePathEncoderMockRecorder) Encode(node, path any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Encode", reflect.TypeOf((*MockNodePathEncoder)(nil).Encode), node, path)
 }
 
-// MockLogicalTaskExecutor is a mock of LogicalTaskExecutor interface.
-type MockLogicalTaskExecutor struct {
+// MockNodeExecutePureTask is a mock of NodeExecutePureTask interface.
+type MockNodeExecutePureTask struct {
 	ctrl     *gomock.Controller
-	recorder *MockLogicalTaskExecutorMockRecorder
+	recorder *MockNodeExecutePureTaskMockRecorder
 	isgomock struct{}
 }
 
-// MockLogicalTaskExecutorMockRecorder is the mock recorder for MockLogicalTaskExecutor.
-type MockLogicalTaskExecutorMockRecorder struct {
-	mock *MockLogicalTaskExecutor
+// MockNodeExecutePureTaskMockRecorder is the mock recorder for MockNodeExecutePureTask.
+type MockNodeExecutePureTaskMockRecorder struct {
+	mock *MockNodeExecutePureTask
 }
 
-// NewMockLogicalTaskExecutor creates a new mock instance.
-func NewMockLogicalTaskExecutor(ctrl *gomock.Controller) *MockLogicalTaskExecutor {
-	mock := &MockLogicalTaskExecutor{ctrl: ctrl}
-	mock.recorder = &MockLogicalTaskExecutorMockRecorder{mock}
+// NewMockNodeExecutePureTask creates a new mock instance.
+func NewMockNodeExecutePureTask(ctrl *gomock.Controller) *MockNodeExecutePureTask {
+	mock := &MockNodeExecutePureTask{ctrl: ctrl}
+	mock.recorder = &MockNodeExecutePureTaskMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockLogicalTaskExecutor) EXPECT() *MockLogicalTaskExecutorMockRecorder {
+func (m *MockNodeExecutePureTask) EXPECT() *MockNodeExecutePureTaskMockRecorder {
 	return m.recorder
 }
 
 // ExecutePureTask mocks base method.
-func (m *MockLogicalTaskExecutor) ExecutePureTask(baseCtx context.Context, taskInstance any) error {
+func (m *MockNodeExecutePureTask) ExecutePureTask(baseCtx context.Context, taskInstance any) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExecutePureTask", baseCtx, taskInstance)
 	ret0, _ := ret[0].(error)
@@ -203,7 +203,7 @@ func (m *MockLogicalTaskExecutor) ExecutePureTask(baseCtx context.Context, taskI
 }
 
 // ExecutePureTask indicates an expected call of ExecutePureTask.
-func (mr *MockLogicalTaskExecutorMockRecorder) ExecutePureTask(baseCtx, taskInstance any) *gomock.Call {
+func (mr *MockNodeExecutePureTaskMockRecorder) ExecutePureTask(baseCtx, taskInstance any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecutePureTask", reflect.TypeOf((*MockLogicalTaskExecutor)(nil).ExecutePureTask), baseCtx, taskInstance)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecutePureTask", reflect.TypeOf((*MockNodeExecutePureTask)(nil).ExecutePureTask), baseCtx, taskInstance)
 }

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -1669,7 +1669,7 @@ func (s *nodeSuite) TestEachPureTask() {
 	s.NotNil(root)
 
 	actualTaskCount := 0
-	err = root.EachPureTask(now.Add(time.Minute), func(executor LogicalTaskExecutor, task any) error {
+	err = root.EachPureTask(now.Add(time.Minute), func(executor NodeExecutePureTask, task any) error {
 		s.NotNil(executor)
 
 		_, ok := task.(*TestPureTask)

--- a/service/history/interfaces/chasm_tree.go
+++ b/service/history/interfaces/chasm_tree.go
@@ -24,6 +24,6 @@ type ChasmTree interface {
 
 	EachPureTask(
 		deadline time.Time,
-		callback func(executor chasm.LogicalTaskExecutor, task any) error,
+		callback func(executor chasm.NodeExecutePureTask, task any) error,
 	) error
 }

--- a/service/history/interfaces/chasm_tree_mock.go
+++ b/service/history/interfaces/chasm_tree_mock.go
@@ -100,7 +100,7 @@ func (mr *MockChasmTreeMockRecorder) CloseTransaction() *gomock.Call {
 }
 
 // EachPureTask mocks base method.
-func (m *MockChasmTree) EachPureTask(deadline time.Time, callback func(chasm.LogicalTaskExecutor, any) error) error {
+func (m *MockChasmTree) EachPureTask(deadline time.Time, callback func(chasm.NodeExecutePureTask, any) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EachPureTask", deadline, callback)
 	ret0, _ := ret[0].(error)

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -943,7 +943,7 @@ func (t *timerQueueActiveTaskExecutor) executeChasmPureTimerTask(
 		wfCtx,
 		ms,
 		task,
-		func(executor chasm.LogicalTaskExecutor, task any) error {
+		func(executor chasm.NodeExecutePureTask, task any) error {
 			// ExecutePureTask also calls the task's validator. Invalid tasks will no-op
 			// succeed.
 			if err := executor.ExecutePureTask(ctx, task); err != nil {

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -1910,14 +1910,14 @@ func (s *timerQueueActiveTaskExecutorSuite) TestExecuteChasmPureTimerTask_Execut
 		RunId:      tests.WorkflowKey.RunID,
 	}
 
-	// Mock the CHASM tree and executor.
-	mockExecutor := chasm.NewMockLogicalTaskExecutor(s.controller)
-	mockExecutor.EXPECT().ExecutePureTask(gomock.Any(), gomock.Any()).Times(1)
+	// Mock the CHASM tree and execute interface.
+	mockEach := chasm.NewMockNodeExecutePureTask(s.controller)
+	mockEach.EXPECT().ExecutePureTask(gomock.Any(), gomock.Any()).Times(1)
 	chasmTree := historyi.NewMockChasmTree(s.controller)
 	chasmTree.EXPECT().EachPureTask(gomock.Any(), gomock.Any()).
 		Times(1).Do(
 		func(_ time.Time, callback func(executor chasm.NodeExecutePureTask, task any) error) error {
-			return callback(mockExecutor, nil)
+			return callback(mockEach, nil)
 		})
 
 	// Mock mutable state.

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -1916,7 +1916,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestExecuteChasmPureTimerTask_Execut
 	chasmTree := historyi.NewMockChasmTree(s.controller)
 	chasmTree.EXPECT().EachPureTask(gomock.Any(), gomock.Any()).
 		Times(1).Do(
-		func(_ time.Time, callback func(executor chasm.LogicalTaskExecutor, task any) error) error {
+		func(_ time.Time, callback func(executor chasm.NodeExecutePureTask, task any) error) error {
 			return callback(mockExecutor, nil)
 		})
 

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -128,7 +128,7 @@ func (t *timerQueueStandbyTaskExecutor) executeChasmPureTimerTask(
 			wfContext,
 			mutableState,
 			task,
-			func(_ chasm.LogicalTaskExecutor, task any) error {
+			func(_ chasm.NodeExecutePureTask, task any) error {
 				// If this line of code is reached, the task's Validate() function succeeded, which
 				// indicates that it is still expected to run. Return ErrTaskRetry to wait for the
 				// task to complete on the active cluster, after which Validate will begun returning

--- a/service/history/timer_queue_standby_task_executor_test.go
+++ b/service/history/timer_queue_standby_task_executor_test.go
@@ -2004,13 +2004,13 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestExecuteChasmPureTimerTask_Execu
 		RunId:      tests.WorkflowKey.RunID,
 	}
 
-	// Mock the CHASM tree and executor.
-	mockExecutor := chasm.NewMockLogicalTaskExecutor(s.controller)
+	// Mock the CHASM tree and execute interface.
+	mockEach := chasm.NewMockNodeExecutePureTask(s.controller)
 	chasmTree := historyi.NewMockChasmTree(s.controller)
 	chasmTree.EXPECT().EachPureTask(gomock.Any(), gomock.Any()).
 		Times(1).Do(
 		func(_ time.Time, callback func(executor chasm.NodeExecutePureTask, task any) error) error {
-			return callback(mockExecutor, nil)
+			return callback(mockEach, nil)
 		})
 
 	// Mock mutable state.

--- a/service/history/timer_queue_standby_task_executor_test.go
+++ b/service/history/timer_queue_standby_task_executor_test.go
@@ -2009,7 +2009,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestExecuteChasmPureTimerTask_Execu
 	chasmTree := historyi.NewMockChasmTree(s.controller)
 	chasmTree.EXPECT().EachPureTask(gomock.Any(), gomock.Any()).
 		Times(1).Do(
-		func(_ time.Time, callback func(executor chasm.LogicalTaskExecutor, task any) error) error {
+		func(_ time.Time, callback func(executor chasm.NodeExecutePureTask, task any) error) error {
 			return callback(mockExecutor, nil)
 		})
 

--- a/service/history/timer_queue_task_executor_base.go
+++ b/service/history/timer_queue_task_executor_base.go
@@ -249,7 +249,7 @@ func (t *timerQueueTaskExecutorBase) executeChasmPureTimers(
 	workflowContext historyi.WorkflowContext,
 	ms historyi.MutableState,
 	task *tasks.ChasmTaskPure,
-	execute func(executor chasm.LogicalTaskExecutor, task any) error,
+	execute func(executor chasm.NodeExecutePureTask, task any) error,
 ) error {
 	// Because CHASM timers can target closed workflows, we need to specifically
 	// exclude zombie workflows, instead of merely checking that the workflow is

--- a/service/history/workflow/noop_chasm_tree.go
+++ b/service/history/workflow/noop_chasm_tree.go
@@ -42,7 +42,7 @@ func (*noopChasmTree) Archetype() string {
 
 func (*noopChasmTree) EachPureTask(
 	deadline time.Time,
-	callback func(executor chasm.LogicalTaskExecutor, task any) error,
+	callback func(executor chasm.NodeExecutePureTask, task any) error,
 ) error {
 	return nil
 }


### PR DESCRIPTION
## What changed?
- I originally expected to use this interface for side effect tasks as well, but I think having a more specific name would be better. Open to suggestions.
- 
`LogicalTaskExecutor` -> `NodeExecutePureTask`

## Why?
- Original name is too broad

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
