### PR TITLE
chore: Add Stringer tags

### DIFF
--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -160,7 +160,7 @@ func (c *clientImpl) processInputPartition(proto *taskqueuepb.TaskQueue, nsid st
 	if err != nil {
 		// We preserve the old logic (not returning error in case of invalid proto info) until it's verified that
 		// clients are not sending invalid names.
-		c.logger.Info("invalid tq partition", tag.Error(err), tag.NewStringTag("proto", proto.String()))
+		c.logger.Info("invalid tq partition", tag.Error(err), tag.NewStringerTag("proto", proto))
 		metrics.MatchingClientInvalidTaskQueuePartition.With(c.metricsHandler).Record(1)
 		return tqid.UnsafeTaskQueueFamily(nsid, proto.GetName()).TaskQueue(taskType).RootPartition(), nil
 	}

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -83,7 +83,7 @@ func workflowListFilterType(listFilterType string) ZapTag {
 
 // WorkflowTimeoutType returns tag for WorkflowTimeoutType
 func WorkflowTimeoutType(timeoutType enumspb.TimeoutType) ZapTag {
-	return NewStringTag("wf-timeout-type", timeoutType.String())
+	return NewStringerTag("wf-timeout-type", timeoutType)
 }
 
 // WorkflowPollContextTimeout returns tag for WorkflowPollContextTimeout
@@ -108,7 +108,7 @@ func WorkflowType(wfType string) ZapTag {
 
 // WorkflowState returns tag for WorkflowState
 func WorkflowState(s enumsspb.WorkflowExecutionState) ZapTag {
-	return NewStringTag("wf-state", s.String())
+	return NewStringerTag("wf-state", s)
 }
 
 // WorkflowRunID returns tag for WorkflowRunID
@@ -266,7 +266,7 @@ func WorkflowBranchID(branchID string) ZapTag {
 
 // WorkflowCommandType returns tag for WorkflowCommandType
 func WorkflowCommandType(commandType enumspb.CommandType) ZapTag {
-	return NewStringTag("command-type", commandType.String())
+	return NewStringerTag("command-type", commandType)
 }
 
 // WorkflowQueryType returns tag for WorkflowQueryType
@@ -276,12 +276,12 @@ func WorkflowQueryType(qt string) ZapTag {
 
 // WorkflowTaskFailedCause returns tag for WorkflowTaskFailedCause
 func WorkflowTaskFailedCause(workflowTaskFailCause enumspb.WorkflowTaskFailedCause) ZapTag {
-	return NewStringTag("workflow-task-fail-cause", workflowTaskFailCause.String())
+	return NewStringerTag("workflow-task-fail-cause", workflowTaskFailCause)
 }
 
 // WorkflowTaskQueueType returns tag for WorkflowTaskQueueType
 func WorkflowTaskQueueType(taskQueueType enumspb.TaskQueueType) ZapTag {
-	return NewStringTag("wf-task-queue-type", taskQueueType.String())
+	return NewStringerTag("wf-task-queue-type", taskQueueType)
 }
 
 // WorkflowTaskQueueName returns tag for WorkflowTaskQueueName
@@ -632,7 +632,7 @@ func TaskVersion(taskVersion int64) ZapTag {
 }
 
 func TaskType(taskType enumsspb.TaskType) ZapTag {
-	return NewStringTag("queue-task-type", taskType.String())
+	return NewStringerTag("queue-task-type", taskType)
 }
 
 func TaskCategoryID(taskCategoryID int) ZapTag {
@@ -972,7 +972,7 @@ func BuildId(buildId string) ZapTag {
 }
 
 func VersioningBehavior(behavior enumspb.VersioningBehavior) ZapTag {
-	return NewStringTag("versioning-behavior", behavior.String())
+	return NewStringerTag("versioning-behavior", behavior)
 }
 
 func Deployment(d *deploymentpb.Deployment) ZapTag {

--- a/common/log/tag/zap_tag.go
+++ b/common/log/tag/zap_tag.go
@@ -1,6 +1,7 @@
 package tag
 
 import (
+	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -42,12 +43,6 @@ func (t ZapTag) Value() interface{} {
 	return nil
 }
 
-func NewBinaryTag(key string, value []byte) ZapTag {
-	return ZapTag{
-		field: zap.Binary(key, value),
-	}
-}
-
 func NewStringTag(key string, value string) ZapTag {
 	return ZapTag{
 		field: zap.String(key, value),
@@ -57,6 +52,18 @@ func NewStringTag(key string, value string) ZapTag {
 func NewStringsTag(key string, value []string) ZapTag {
 	return ZapTag{
 		field: zap.Strings(key, value),
+	}
+}
+
+func NewStringerTag(key string, value fmt.Stringer) ZapTag {
+	return ZapTag{
+		field: zap.Stringer(key, value),
+	}
+}
+
+func NewStringersTag(key string, value []fmt.Stringer) ZapTag {
+	return ZapTag{
+		field: zap.Stringers(key, value),
 	}
 }
 
@@ -123,5 +130,11 @@ func NewTimePtrTag(key string, value *timestamppb.Timestamp) ZapTag {
 func NewAnyTag(key string, value interface{}) ZapTag {
 	return ZapTag{
 		field: zap.Any(key, value),
+	}
+}
+
+func NewBinaryTag(key string, value []byte) ZapTag {
+	return ZapTag{
+		field: zap.Binary(key, value),
 	}
 }

--- a/common/persistence/visibility/visiblity_manager_metrics.go
+++ b/common/persistence/visibility/visiblity_manager_metrics.go
@@ -122,7 +122,7 @@ func (m *visibilityManagerMetrics) ListWorkflowExecutions(
 		m.logger.Warn("List query exceeded threshold",
 			tag.NewDurationTag("duration", elapsed),
 			tag.NewStringTag("visibility-query", request.Query),
-			tag.NewStringTag("namepsace", request.Namespace.String()),
+			tag.NewStringerTag("namepsace", request.Namespace),
 		)
 	}
 	metrics.VisibilityPersistenceLatency.With(handler).Record(elapsed)
@@ -140,7 +140,7 @@ func (m *visibilityManagerMetrics) ScanWorkflowExecutions(
 		m.logger.Warn("Count query exceeded threshold",
 			tag.NewDurationTag("duration", elapsed),
 			tag.NewStringTag("visibility-query", request.Query),
-			tag.NewStringTag("namepsace", request.Namespace.String()),
+			tag.NewStringerTag("namepsace", request.Namespace),
 		)
 	}
 	metrics.VisibilityPersistenceLatency.With(handler).Record(elapsed)

--- a/common/rpc/interceptor/mask_internal_error.go
+++ b/common/rpc/interceptor/mask_internal_error.go
@@ -105,7 +105,7 @@ func (mi *MaskInternalErrorDetailsInterceptor) logError(
 
 	logTags = append(logTags, tag.NewStringTag("hash", errorHash))
 
-	logTags = append(logTags, tag.NewStringTag("grpc_code", statusCode.String()))
+	logTags = append(logTags, tag.NewStringerTag("grpc_code", statusCode))
 	logTags = append(logTags, mi.workflowTags.Extract(req, fullMethod)...)
 
 	mi.logger.Error("masked service failures", append(logTags, tag.Error(err))...)

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -410,7 +410,7 @@ func (ti *TelemetryInterceptor) logError(
 		return
 	}
 
-	logTags = append(logTags, tag.NewStringTag("grpc_code", statusCode.String()))
+	logTags = append(logTags, tag.NewStringerTag("grpc_code", statusCode))
 	logTags = append(logTags, ti.workflowTags.Extract(req, fullMethod)...)
 
 	ti.logger.Error("service failures", append(logTags, tag.Error(err))...)

--- a/components/scheduler/generator_executors.go
+++ b/components/scheduler/generator_executors.go
@@ -62,8 +62,8 @@ func (e generatorTaskExecutor) executeBufferTask(env hsm.Environment, node *hsm.
 	t2 := env.Now().UTC()
 	if t2.Before(t1) {
 		logger.Warn("Time went backwards",
-			tag.NewStringTag("time", t1.String()),
-			tag.NewStringTag("time", t2.String()))
+			tag.NewStringerTag("time", t1),
+			tag.NewStringerTag("time", t2))
 		t2 = t1
 	}
 

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1333,7 +1333,7 @@ Loop:
 			metrics.ShardInfoScheduledQueueLagTimer.With(metricsHandler).
 				Record(lag, metrics.TaskCategoryTag(category.Name()))
 		default:
-			s.contextTaggedLogger.Error("Unknown task category type", tag.NewStringTag("task-category", category.Type().String()))
+			s.contextTaggedLogger.Error("Unknown task category type", tag.NewStringerTag("task-category", category.Type()))
 		}
 	}
 }

--- a/service/history/workflow/update/util.go
+++ b/service/history/workflow/update/util.go
@@ -90,7 +90,7 @@ func (i *instrumentation) invalidStateTransition(updateID string, msg proto.Mess
 	i.log.Error("invalid state transition attempted",
 		tag.NewStringTag("update-id", updateID),
 		tag.NewStringTag("message", fmt.Sprintf("%T", msg)),
-		tag.NewStringTag("state", state.String()))
+		tag.NewStringerTag("state", state))
 }
 
 func (i *instrumentation) updateRegistrySize(size int) {
@@ -104,7 +104,7 @@ func (i *instrumentation) oneOf(counterName string) {
 func (i *instrumentation) stateChange(updateID string, from, to state) {
 	i.log.Debug("update state change",
 		tag.NewStringTag("update-id", updateID),
-		tag.NewStringTag("from-state", from.String()),
-		tag.NewStringTag("to-state", to.String()),
+		tag.NewStringerTag("from-state", from),
+		tag.NewStringerTag("to-state", to),
 	)
 }

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -1036,7 +1036,7 @@ func (l *fxLogAdapter) LogEvent(e fxevent.Event) {
 				tag.ComponentFX,
 				tag.NewStringTag("callee", e.FunctionName),
 				tag.NewStringTag("caller", e.CallerName),
-				tag.NewStringTag("runtime", e.Runtime.String()),
+				tag.NewStringerTag("runtime", e.Runtime),
 			)
 		}
 	case *fxevent.OnStopExecuting:
@@ -1058,7 +1058,7 @@ func (l *fxLogAdapter) LogEvent(e fxevent.Event) {
 				tag.ComponentFX,
 				tag.NewStringTag("callee", e.FunctionName),
 				tag.NewStringTag("caller", e.CallerName),
-				tag.NewStringTag("runtime", e.Runtime.String()),
+				tag.NewStringerTag("runtime", e.Runtime),
 			)
 		}
 	case *fxevent.Supplied:
@@ -1120,7 +1120,7 @@ func (l *fxLogAdapter) LogEvent(e fxevent.Event) {
 	case *fxevent.Stopping:
 		l.logger.Info("received signal",
 			tag.ComponentFX,
-			tag.NewStringTag("signal", e.Signal.String()))
+			tag.NewStringerTag("signal", e.Signal))
 	case *fxevent.Stopped:
 		if e.Err != nil {
 			l.logger.Error("stop failed", tag.ComponentFX, tag.Error(e.Err))


### PR DESCRIPTION
## What changed?

This PR adds easy access to Zap's Stringer and Stringers fields.

## Why?

`Stringer` fields are more efficient than `String` field. In the OSS repo alone we have 22 separate invocations of `tag.NewStringTag(..., foo.String())` which would be better served by using a Stringer tag. This only calls `String` (which can be expensive) when the line is actually emitted.

Meaning fewer wasted cycles when calling `String()` for debug-level logs.


## How did you test it?
- [x] I'm doing this manually elsewhere

