### PR TITLE
chore: be smarter about when to use Stringer vs String

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -281,7 +281,7 @@ func WorkflowTaskFailedCause(workflowTaskFailCause enumspb.WorkflowTaskFailedCau
 
 // WorkflowTaskQueueType returns tag for WorkflowTaskQueueType
 func WorkflowTaskQueueType(taskQueueType enumspb.TaskQueueType) ZapTag {
-	return NewStringerTag("wf-task-queue-type", taskQueueType)
+	return NewStringTag("wf-task-queue-type", taskQueueType.String())
 }
 
 // WorkflowTaskQueueName returns tag for WorkflowTaskQueueName
@@ -632,7 +632,7 @@ func TaskVersion(taskVersion int64) ZapTag {
 }
 
 func TaskType(taskType enumsspb.TaskType) ZapTag {
-	return NewStringerTag("queue-task-type", taskType)
+	return NewStringTag("queue-task-type", taskType.String())
 }
 
 func TaskCategoryID(taskCategoryID int) ZapTag {

--- a/common/log/tag/zap_tag.go
+++ b/common/log/tag/zap_tag.go
@@ -55,12 +55,20 @@ func NewStringsTag(key string, value []string) ZapTag {
 	}
 }
 
+// NewStringerTag returns a tag that will lazily generate the string representation
+// of the provided fmt.Stringer value. Note that it does **not** cache the result, so
+// you should use `NewStringTag` instead if the tag is applied to the logger itself using
+// `log.With`.
 func NewStringerTag(key string, value fmt.Stringer) ZapTag {
 	return ZapTag{
 		field: zap.Stringer(key, value),
 	}
 }
 
+// NewStringersTag returns a tag that will lazily generate the string representation
+// of the provided fmt.Stringer values. Note that it does **not** cache the results, so
+// you should use `NewStringsTag` instead if the tag is applied to the logger itself using
+// `log.With`.
 func NewStringersTag(key string, value []fmt.Stringer) ZapTag {
 	return ZapTag{
 		field: zap.Stringers(key, value),

--- a/common/log/tag/zap_tag.go
+++ b/common/log/tag/zap_tag.go
@@ -59,6 +59,9 @@ func NewStringsTag(key string, value []string) ZapTag {
 // of the provided fmt.Stringer value. Note that it does **not** cache the result, so
 // you should use `NewStringTag` instead if the tag is applied to the logger itself using
 // `log.With`.
+//
+// These are still useful if the String() implementation is complicated, especially if
+// you have lots of Debug-level logs that are ignored in production.
 func NewStringerTag(key string, value fmt.Stringer) ZapTag {
 	return ZapTag{
 		field: zap.Stringer(key, value),
@@ -69,6 +72,9 @@ func NewStringerTag(key string, value fmt.Stringer) ZapTag {
 // of the provided fmt.Stringer values. Note that it does **not** cache the results, so
 // you should use `NewStringsTag` instead if the tag is applied to the logger itself using
 // `log.With`.
+//
+// These are still useful if the String() implementation is complicated, especially if
+// you have lots of Debug-level logs that are ignored in production.
 func NewStringersTag(key string, value []fmt.Stringer) ZapTag {
 	return ZapTag{
 		field: zap.Stringers(key, value),


### PR DESCRIPTION

## What changed?

I've changed _some_ of the tags I altered in #7738 back to StringTags from StringerTags and added usage recommendations to the StringerTag (and StringersTag) methods.

## Why?

@prathyushpv rightly pointed out that some of the tags I changed in #7738  are applied to the loggers themselves and not just the messages. This means that the `String()` method will be invoked _every time_ a log is to be emitted. This incurs extra allocations etc. etc.