### PR TITLE
Add metrics for namespace operations

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -601,6 +601,7 @@ var (
 	ServiceErrUnauthorizedCounter            = NewCounterDef("service_errors_unauthorized")
 	ServiceErrAuthorizeFailedCounter         = NewCounterDef("service_errors_authorize_failed")
 	ActionCounter                            = NewCounterDef("action")
+	OperationCounter                         = NewCounterDef("operation")
 	TlsCertsExpired                          = NewGaugeDef("certificates_expired")
 	TlsCertsExpiring                         = NewGaugeDef("certificates_expiring")
 	ServiceAuthorizationLatency              = NewTimerDef("service_authorization_latency")

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/server/common/rpc/interceptor/logtags"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tasktoken"
+	"go.temporal.io/server/service/frontend/configs"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -174,6 +175,10 @@ func (ti *TelemetryInterceptor) UnaryIntercept(
 	}()
 
 	resp, err := handler(ctx, req)
+
+	if configs.IsAPIOperation(info.FullMethod) {
+		metrics.OperationCounter.With(metricsHandler).Record(1)
+	}
 
 	if err != nil {
 		ti.HandleError(req, info.FullMethod, metricsHandler, logTags, err, nsName)

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -182,6 +182,21 @@ var (
 	}
 
 	NamespaceReplicationInducingAPIPrioritiesOrdered = []int{0, 1, 2}
+
+	// APIs that are not considered as a namespace operation. Namespace operations are used to track the usage of a namespace.
+	// This includes some APIs, history tasks, etc.
+	operationExcludedAPIs = map[string]struct{}{
+		// Poll requests are not considered as namespace operations. We will count these operations when we try to match a task
+		// from matching service to this request.
+		"PollWorkflowTaskQueue": {},
+		"PollActivityTaskQueue": {},
+
+		// Replication-related APIs are not counted as operations.
+		"GetWorkflowExecutionRawHistory":   {},
+		"GetWorkflowExecutionRawHistoryV2": {},
+		"ReapplyEvents":                    {},
+		"SyncWorkflowState":                {},
+	}
 )
 
 type (
@@ -332,4 +347,14 @@ func NewNamespaceReplicationInducingAPIPriorityRateLimiter(
 		}
 		return NamespaceReplicationInducingAPIPrioritiesOrdered[len(NamespaceReplicationInducingAPIPrioritiesOrdered)-1]
 	}, rateLimiters)
+}
+
+func IsAPIOperation(apiFullName string) bool {
+	if _, ok := APIToPriority[apiFullName]; ok {
+		if _, ok := operationExcludedAPIs[apiFullName]; ok {
+			return false
+		}
+		return true
+	}
+	return false
 }

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -322,6 +322,7 @@ func (e *executableImpl) Execute() (retErr error) {
 		priorityTaggedProvider := e.metricsHandler.WithTags(metrics.TaskPriorityTag(e.priority.String()))
 		metrics.TaskRequests.With(priorityTaggedProvider).Record(1)
 		metrics.TaskScheduleLatency.With(priorityTaggedProvider).Record(e.scheduleLatency)
+		metrics.OperationCounter.With(e.metricsHandler).Record(1)
 
 		if retErr == nil {
 			e.inMemoryNoUserLatency += e.scheduleLatency + e.attemptNoUserLatency

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -2615,6 +2615,12 @@ func (e *matchingEngineImpl) recordWorkflowTaskStarted(
 	pollReq *workflowservice.PollWorkflowTaskQueueRequest,
 	task *internalTask,
 ) (*historyservice.RecordWorkflowTaskStartedResponse, error) {
+
+	metrics.OperationCounter.With(e.metricsHandler).Record(
+		1,
+		metrics.OperationTag("RecordWorkflowTaskStarted"),
+		metrics.NamespaceTag(pollReq.Namespace),
+	)
 	if e.rateLimiter != nil {
 		err := e.rateLimiter.Wait(ctx, quotas.Request{
 			API:        "RecordWorkflowTaskStarted",
@@ -2665,6 +2671,12 @@ func (e *matchingEngineImpl) recordActivityTaskStarted(
 	pollReq *workflowservice.PollActivityTaskQueueRequest,
 	task *internalTask,
 ) (*historyservice.RecordActivityTaskStartedResponse, error) {
+
+	metrics.OperationCounter.With(e.metricsHandler).Record(
+		1,
+		metrics.OperationTag("RecordActivityTaskStarted"),
+		metrics.NamespaceTag(pollReq.Namespace),
+	)
 	if e.rateLimiter != nil {
 		err := e.rateLimiter.Wait(ctx, quotas.Request{
 			API:        "RecordActivityTaskStarted",


### PR DESCRIPTION
## What changed?
Add a new metric `operation` which can track total number of operations executed by a namespace.
This includes certain APIs, all history tasks and attempts to despatch matching tasks to pollers.

This metric includes failed API calls, and all history task processing attempts. This includes retried
history tasks, background history tasks(like retention timers) etc.

## Why?
To track the overall usage of a namespace in the cluster.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

