### PR TITLE
Fixes issue #7631 with wrong archiver lookup

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -281,7 +281,7 @@ func WorkflowTaskFailedCause(workflowTaskFailCause enumspb.WorkflowTaskFailedCau
 
 // WorkflowTaskQueueType returns tag for WorkflowTaskQueueType
 func WorkflowTaskQueueType(taskQueueType enumspb.TaskQueueType) ZapTag {
-	return NewStringerTag("wf-task-queue-type", taskQueueType)
+	return NewStringTag("wf-task-queue-type", taskQueueType.String())
 }
 
 // WorkflowTaskQueueName returns tag for WorkflowTaskQueueName
@@ -632,7 +632,7 @@ func TaskVersion(taskVersion int64) ZapTag {
 }
 
 func TaskType(taskType enumsspb.TaskType) ZapTag {
-	return NewStringerTag("queue-task-type", taskType)
+	return NewStringTag("queue-task-type", taskType.String())
 }
 
 func TaskCategoryID(taskCategoryID int) ZapTag {

--- a/common/log/tag/zap_tag.go
+++ b/common/log/tag/zap_tag.go
@@ -55,12 +55,26 @@ func NewStringsTag(key string, value []string) ZapTag {
 	}
 }
 
+// NewStringerTag returns a tag that will lazily generate the string representation
+// of the provided fmt.Stringer value. Note that it does **not** cache the result, so
+// you should use `NewStringTag` instead if the tag is applied to the logger itself using
+// `log.With`.
+//
+// These are still useful if the String() implementation is complicated, especially if
+// you have lots of Debug-level logs that are ignored in production.
 func NewStringerTag(key string, value fmt.Stringer) ZapTag {
 	return ZapTag{
 		field: zap.Stringer(key, value),
 	}
 }
 
+// NewStringersTag returns a tag that will lazily generate the string representation
+// of the provided fmt.Stringer values. Note that it does **not** cache the results, so
+// you should use `NewStringsTag` instead if the tag is applied to the logger itself using
+// `log.With`.
+//
+// These are still useful if the String() implementation is complicated, especially if
+// you have lots of Debug-level logs that are ignored in production.
 func NewStringersTag(key string, value []fmt.Stringer) ZapTag {
 	return ZapTag{
 		field: zap.Stringers(key, value),

--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -953,9 +953,13 @@ func (d *namespaceHandler) validateHistoryArchivalURI(URIString string) error {
 		return err
 	}
 
-	archiver, err := d.archiverProvider.GetHistoryArchiver(URI.Scheme(), string(primitives.FrontendService))
+	var archiver archiver.HistoryArchiver
+	archiver, err = d.archiverProvider.GetHistoryArchiver(URI.Scheme(), string(primitives.FrontendService))
 	if err != nil {
-		return err
+		archiver, err = d.archiverProvider.GetHistoryArchiver(URI.Scheme(), string(primitives.InternalFrontendService))
+		if err != nil {
+			return err
+		}
 	}
 
 	return archiver.ValidateURI(URI)
@@ -967,9 +971,13 @@ func (d *namespaceHandler) validateVisibilityArchivalURI(URIString string) error
 		return err
 	}
 
-	archiver, err := d.archiverProvider.GetVisibilityArchiver(URI.Scheme(), string(primitives.FrontendService))
+	var archiver archiver.VisibilityArchiver
+	archiver, err = d.archiverProvider.GetVisibilityArchiver(URI.Scheme(), string(primitives.FrontendService))
 	if err != nil {
-		return err
+		archiver, err = d.archiverProvider.GetVisibilityArchiver(URI.Scheme(), string(primitives.InternalFrontendService))
+		if err != nil {
+			return err
+		}
 	}
 
 	return archiver.ValidateURI(URI)

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2444,9 +2444,13 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(ctx context.Context, r
 		return nil, err
 	}
 
-	visibilityArchiver, err := wh.archiverProvider.GetVisibilityArchiver(URI.Scheme(), string(primitives.FrontendService))
+	var visibilityArchiver archiver.VisibilityArchiver
+	visibilityArchiver, err = wh.archiverProvider.GetVisibilityArchiver(URI.Scheme(), string(primitives.FrontendService))
 	if err != nil {
-		return nil, err
+		visibilityArchiver, err = wh.archiverProvider.GetVisibilityArchiver(URI.Scheme(), string(primitives.InternalFrontendService))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	archiverRequest := &archiver.QueryVisibilityRequest{
@@ -5387,9 +5391,13 @@ func (wh *WorkflowHandler) getArchivedHistory(
 		return nil, err
 	}
 
-	historyArchiver, err := wh.archiverProvider.GetHistoryArchiver(URI.Scheme(), string(primitives.FrontendService))
+	var historyArchiver archiver.HistoryArchiver
+	historyArchiver, err = wh.archiverProvider.GetHistoryArchiver(URI.Scheme(), string(primitives.FrontendService))
 	if err != nil {
-		return nil, err
+		historyArchiver, err = wh.archiverProvider.GetHistoryArchiver(URI.Scheme(), string(primitives.InternalFrontendService))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	resp, err := historyArchiver.Get(ctx, URI, &archiver.GetHistoryRequest{


### PR DESCRIPTION
Calling the GetVisibilityArchiver and GetHistoryArchiver functions causes errors when the internal frontend is enabled. We should either check the current configuration or simply call these functions with the InternalFrontendService parameter if an error occurs.

## What changed?
Added fallback logic for archiver retrieval in namespace_handler.go and workflow_handler.go to handle cases when the initial call fails.

## Why?
When the internal frontend is enabled, all visibility and history containers are registered under the InternalFrontendService key. However, some calls in namespace_handler.go and workflow_handler.go still attempt to retrieve archivers using the FrontendService key.

## How did you test it?
- [ v] built
- [v ] run locally and tested manually
- [v ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
If the archival configuration is incorrect, the system takes additional time to fail/recognize the error.
