### PR TITLE
Add task_priority label to task_dispatch_latency and poll_latency

### DIFF
--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -410,6 +410,7 @@ func (tm *TaskMatcher) emitDispatchLatency(task *internalTask, forwarded bool) {
 		time.Since(timestamp.TimeValue(task.event.Data.CreateTime)),
 		metrics.StringTag("source", task.source.String()),
 		metrics.StringTag("forwarded", strconv.FormatBool(forwarded)),
+		metrics.StringTag(metrics.TaskPriorityTagName, ""),
 	)
 }
 
@@ -476,7 +477,10 @@ func (tm *TaskMatcher) poll(
 		if pollMetadata.forwardedFrom == "" {
 			// Only recording for original polls
 			metrics.PollLatencyPerTaskQueue.With(tm.metricsHandler).Record(
-				time.Since(start), metrics.StringTag("forwarded", strconv.FormatBool(forwardedPoll)))
+				time.Since(start),
+				metrics.StringTag("forwarded", strconv.FormatBool(forwardedPoll)),
+				metrics.StringTag(metrics.TaskPriorityTagName, ""),
+			)
 		}
 
 		if err == nil {


### PR DESCRIPTION
## What changed?
Split poll_latency and task_dispatch_latency metrics by simple priority level.

## Why?
Observability, to have stats on throughput and latency by level.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

