### PR TITLE
remove old rules when more space is needed

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2702,6 +2702,12 @@ WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 		`WorkflowRulesAPIsEnabled is a "feature enable" flag. `,
 	)
 
+	MaxWorkflowRulesPerNamespace = NewNamespaceIntSetting(
+		"frontend.maxWorkflowRulesPerNamespace",
+		10,
+		`Maximum number of workflow rules in a given namespace`,
+	)
+
 	SlowRequestLoggingThreshold = NewGlobalDurationSetting(
 		"rpc.slowRequestLoggingThreshold",
 		5*time.Second,

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -210,8 +210,9 @@ type Config struct {
 
 	EnableEagerWorkflowStart dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
-	ActivityAPIsEnabled      dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	WorkflowRulesAPIsEnabled dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	ActivityAPIsEnabled          dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	WorkflowRulesAPIsEnabled     dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	MaxWorkflowRulesPerNamespace dynamicconfig.IntPropertyFnWithNamespaceFilter
 
 	HTTPAllowedHosts *dynamicconfig.GlobalCachedTypedValue[*regexp.Regexp]
 }
@@ -361,6 +362,7 @@ func NewConfig(
 		EnableEagerWorkflowStart:       dynamicconfig.EnableEagerWorkflowStart.Get(dc),
 		ActivityAPIsEnabled:            dynamicconfig.ActivityAPIsEnabled.Get(dc),
 		WorkflowRulesAPIsEnabled:       dynamicconfig.WorkflowRulesAPIsEnabled.Get(dc),
+		MaxWorkflowRulesPerNamespace:   dynamicconfig.MaxWorkflowRulesPerNamespace.Get(dc),
 
 		HTTPAllowedHosts: dynamicconfig.NewGlobalCachedTypedValue(dc, dynamicconfig.FrontendHTTPAllowedHosts, func(patterns []string) (*regexp.Regexp, error) {
 			if len(patterns) == 0 {


### PR DESCRIPTION
## What changed?
Remove oldest expired workflow rule is more space is needed.
Add per namespace config options to limit the number of rules.

## Why?
Auto-cleanup expired rules. We keep them in case user still want to use them, but we don't want to fail adding new rule.


## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
