### PR TITLE
Deprecation proposal: Block build-id as a search attribute

### DIFF
--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -128,4 +128,5 @@ var (
 	errWorkerVersioningWorkflowAPIsNotAllowed = serviceerror.NewPermissionDenied("Worker versioning in workflow progress APIs is disabled on this namespace.", "")
 
 	errListHistoryTasksNotAllowed = serviceerror.NewPermissionDenied("ListHistoryTasks feature is disabled on this cluster.", "")
+	errBuildIDAsSearchAttribute   = serviceerror.NewInvalidArgument("BuildIds attribute can't be set in SearchAttributes")
 )

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -128,5 +128,4 @@ var (
 	errWorkerVersioningWorkflowAPIsNotAllowed = serviceerror.NewPermissionDenied("Worker versioning in workflow progress APIs is disabled on this namespace.", "")
 
 	errListHistoryTasksNotAllowed = serviceerror.NewPermissionDenied("ListHistoryTasks feature is disabled on this cluster.", "")
-	errBuildIDAsSearchAttribute   = serviceerror.NewInvalidArgument("BuildIds attribute can't be set in SearchAttributes")
 )

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -202,6 +202,7 @@ func NewWorkflowHandler(
 				config.VisibilityAllowList,
 			),
 			config.SuppressErrorSetSystemSearchAttribute,
+			logger,
 		),
 		archivalMetadata:    archivalMetadata,
 		healthServer:        healthServer,

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -286,6 +286,7 @@ func NewEngineWithShardContext(
 			config.VisibilityAllowList,
 		),
 		config.SuppressErrorSetSystemSearchAttribute,
+		logger,
 	)
 
 	historyEngImpl.replicationDLQHandler = replication.NewLazyDLQHandler(

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -201,6 +201,7 @@ func (s *engine2Suite) SetupTest() {
 			s.mockVisibilityManager,
 			dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 			dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+			s.logger,
 		),
 		workflowConsistencyChecker: api.NewWorkflowConsistencyChecker(mockShard, s.workflowCache),
 		persistenceVisibilityMgr:   s.mockVisibilityManager,


### PR DESCRIPTION
## What changed?
_Describe what has changed in this PR._
-  A deprecation proposal to block the usage of build-id as a search attribute. Note, the changes introduced in this PR shall only emit warnings (for now) to analyze how many current users are actually doing this (expected number to be very low).
- Once we have a confirmation that the number of users who are using this are low, I will send a follow-up to error out when buildID is used as a SA.

## Why?
_Tell your future self why have you made these changes._
- To prevent users from using pre-defined SA's.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)


