### PR TITLE
Resend parent for standby child completion verification

### DIFF
--- a/api/historyservice/v1/request_response.pb.go
+++ b/api/historyservice/v1/request_response.pb.go
@@ -3721,6 +3721,7 @@ type VerifyChildExecutionCompletionRecordedRequest struct {
 	ParentInitiatedId      int64                  `protobuf:"varint,4,opt,name=parent_initiated_id,json=parentInitiatedId,proto3" json:"parent_initiated_id,omitempty"`
 	ParentInitiatedVersion int64                  `protobuf:"varint,5,opt,name=parent_initiated_version,json=parentInitiatedVersion,proto3" json:"parent_initiated_version,omitempty"`
 	Clock                  *v16.VectorClock       `protobuf:"bytes,6,opt,name=clock,proto3" json:"clock,omitempty"`
+	ResendParent           bool                   `protobuf:"varint,7,opt,name=resend_parent,json=resendParent,proto3" json:"resend_parent,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -3795,6 +3796,13 @@ func (x *VerifyChildExecutionCompletionRecordedRequest) GetClock() *v16.VectorCl
 		return x.Clock
 	}
 	return nil
+}
+
+func (x *VerifyChildExecutionCompletionRecordedRequest) GetResendParent() bool {
+	if x != nil {
+		return x.ResendParent
+	}
+	return false
 }
 
 type VerifyChildExecutionCompletionRecordedResponse struct {
@@ -9881,14 +9889,15 @@ const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc 
 	"\x05clock\x18\x06 \x01(\v2).temporal.server.api.clock.v1.VectorClockR\x05clock\x128\n" +
 	"\x18parent_initiated_version\x18\a \x01(\x03R\x16parentInitiatedVersion\x12>\n" +
 	"\x1cchild_first_execution_run_id\x18\b \x01(\tR\x18childFirstExecutionRunId:\"\x92\xc4\x03\x1e*\x1cparent_execution.workflow_id\"'\n" +
-	"%RecordChildExecutionCompletedResponse\"\xcb\x03\n" +
+	"%RecordChildExecutionCompletedResponse\"\xf0\x03\n" +
 	"-VerifyChildExecutionCompletionRecordedRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12T\n" +
 	"\x10parent_execution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\x0fparentExecution\x12R\n" +
 	"\x0fchild_execution\x18\x03 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\x0echildExecution\x12.\n" +
 	"\x13parent_initiated_id\x18\x04 \x01(\x03R\x11parentInitiatedId\x128\n" +
 	"\x18parent_initiated_version\x18\x05 \x01(\x03R\x16parentInitiatedVersion\x12?\n" +
-	"\x05clock\x18\x06 \x01(\v2).temporal.server.api.clock.v1.VectorClockR\x05clock:\"\x92\xc4\x03\x1e*\x1cparent_execution.workflow_id\"0\n" +
+	"\x05clock\x18\x06 \x01(\v2).temporal.server.api.clock.v1.VectorClockR\x05clock\x12#\n" +
+	"\rresend_parent\x18\a \x01(\bR\fresendParent:\"\x92\xc4\x03\x1e*\x1cparent_execution.workflow_id\"0\n" +
 	".VerifyChildExecutionCompletionRecordedResponse\"\xc7\x01\n" +
 	" DescribeWorkflowExecutionRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12[\n" +

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2332,6 +2332,12 @@ the dlq (or will drop them if not enabled)`,
 that task will be sent to DLQ.`,
 	)
 
+	MaxLocalParentWorkflowVerificationDuration = NewGlobalDurationSetting(
+		"history.maxLocalParentWorkflowVerificationDuration",
+		5*time.Minute,
+		`MaxLocalParentWorkflowVerificationDuration controls the maximum duration to verify on the local cluster before requesting to resend parent workflow.`,
+	)
+
 	ReplicationStreamSyncStatusDuration = NewGlobalDurationSetting(
 		"history.ReplicationStreamSyncStatusDuration",
 		1*time.Second,

--- a/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
@@ -556,6 +556,7 @@ message VerifyChildExecutionCompletionRecordedRequest {
     int64 parent_initiated_id = 4;
     int64 parent_initiated_version = 5;
     temporal.server.api.clock.v1.VectorClock clock = 6;
+    bool resend_parent = 7;
 }
 
 message VerifyChildExecutionCompletionRecordedResponse {

--- a/service/history/api/verifychildworkflowcompletionrecorded/api.go
+++ b/service/history/api/verifychildworkflowcompletionrecorded/api.go
@@ -2,27 +2,32 @@ package verifychildworkflowcompletionrecorded
 
 import (
 	"context"
+	"errors"
 
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/api/adminservice/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence/transitionhistory"
+	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/service/history/api"
 	"go.temporal.io/server/service/history/consts"
+	historyi "go.temporal.io/server/service/history/interfaces"
 )
 
-func Invoke(
+func verifyChildExecution(
 	ctx context.Context,
-	request *historyservice.VerifyChildExecutionCompletionRecordedRequest,
 	workflowConsistencyChecker api.WorkflowConsistencyChecker,
-) (resp *historyservice.VerifyChildExecutionCompletionRecordedResponse, retError error) {
-	namespaceID := namespace.ID(request.GetNamespaceId())
-	if err := api.ValidateNamespaceUUID(namespaceID); err != nil {
-		return nil, err
-	}
-
+	request *historyservice.VerifyChildExecutionCompletionRecordedRequest,
+) (versionedTransition *persistencespb.VersionedTransition,
+	versionHistories *historyspb.VersionHistories, retError error) {
 	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
 		ctx,
 		request.Clock,
@@ -38,7 +43,7 @@ func Invoke(
 		locks.PriorityLow,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer func() { workflowLease.GetReleaseFn()(retError) }()
 
@@ -46,20 +51,20 @@ func Invoke(
 	if !mutableState.IsWorkflowExecutionRunning() &&
 		mutableState.GetExecutionState().State != enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE {
 		// parent has already completed and can't be blocked after failover.
-		return &historyservice.VerifyChildExecutionCompletionRecordedResponse{}, nil
+		return nil, nil, nil
 	}
 
 	onCurrentBranch, err := api.IsHistoryEventOnCurrentBranch(mutableState, request.ParentInitiatedId, request.ParentInitiatedVersion)
 	if err != nil {
 		// initiated event not found on any branch
-		return nil, consts.ErrWorkflowNotReady
+		return nil, nil, consts.ErrWorkflowNotReady
 	}
 
 	if !onCurrentBranch {
 		// due to conflict resolution, the initiated event may on a different branch of the workflow.
 		// we don't have to do anything and can simply return not found error. Standby logic
 		// after seeing this error will give up verification.
-		return nil, consts.ErrChildExecutionNotFound
+		return nil, nil, consts.ErrChildExecutionNotFound
 	}
 
 	ci, isRunning := mutableState.GetChildExecutionInfo(request.ParentInitiatedId)
@@ -67,11 +72,94 @@ func Invoke(
 		if ci.StartedEventId != common.EmptyEventID &&
 			ci.GetStartedWorkflowId() != request.ChildExecution.GetWorkflowId() {
 			// this can happen since we may not have the initiated version
-			return nil, consts.ErrChildExecutionNotFound
+			return nil, nil, consts.ErrChildExecutionNotFound
 		}
 
-		return nil, consts.ErrWorkflowNotReady
+		return nil, nil, consts.ErrWorkflowNotReady
 	}
 
+	versionedTransition = transitionhistory.CopyVersionedTransition(transitionhistory.LastVersionedTransition(mutableState.GetExecutionInfo().TransitionHistory))
+	versionHistories = versionhistory.CopyVersionHistories(mutableState.GetExecutionInfo().VersionHistories)
+	return versionedTransition, versionHistories, nil
+}
+
+func Invoke(
+	ctx context.Context,
+	request *historyservice.VerifyChildExecutionCompletionRecordedRequest,
+	workflowConsistencyChecker api.WorkflowConsistencyChecker,
+	shardContext historyi.ShardContext,
+) (*historyservice.VerifyChildExecutionCompletionRecordedResponse, error) {
+	namespaceID := namespace.ID(request.GetNamespaceId())
+	if err := api.ValidateNamespaceUUID(namespaceID); err != nil {
+		return nil, err
+	}
+
+	resendParent := false
+	versionedTransition, versionHistories, err := verifyChildExecution(ctx, workflowConsistencyChecker, request)
+	switch err.(type) {
+	case nil:
+		return &historyservice.VerifyChildExecutionCompletionRecordedResponse{}, nil
+	case *serviceerror.NotFound, *serviceerror.WorkflowNotReady:
+		resendParent = request.GetResendParent()
+	}
+	if !resendParent {
+		return nil, err
+	}
+
+	// Resend parent workflow from source cluster
+
+	clusterMetadata := shardContext.GetClusterMetadata()
+	targetClusterInfo := clusterMetadata.GetAllClusterInfo()[clusterMetadata.GetCurrentClusterName()]
+
+	namespaceEntry, err := shardContext.GetNamespaceRegistry().GetNamespaceByID(namespace.ID(namespaceID))
+	if err != nil {
+		return nil, err
+	}
+
+	activeClusterName := namespaceEntry.ActiveClusterName()
+	if activeClusterName == clusterMetadata.GetCurrentClusterName() {
+		return nil, errors.New("namespace becomes active when processing task as standby")
+	}
+
+	remoteAdminClient, err := shardContext.GetRemoteAdminClient(activeClusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := remoteAdminClient.SyncWorkflowState(ctx, &adminservice.SyncWorkflowStateRequest{
+		NamespaceId: request.NamespaceId,
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: request.ParentExecution.WorkflowId,
+			RunId:      request.ParentExecution.RunId,
+		},
+		VersionedTransition: versionedTransition,
+		VersionHistories:    versionHistories,
+		TargetClusterId:     int32(targetClusterInfo.InitialFailoverVersion),
+	})
+
+	if err != nil {
+		if common.IsNotFoundError(err) {
+			// parent workflow is not found on source cluster,
+			// we can return empty response to indicate that verification is done
+			// TODO: add parent workflow to workflowNotFoundCache
+			return &historyservice.VerifyChildExecutionCompletionRecordedResponse{}, nil
+		}
+		return nil, err
+	}
+
+	engine, err := shardContext.GetEngine(ctx)
+	if err != nil {
+		return nil, err
+	}
+	err = engine.ReplicateVersionedTransition(ctx, resp.VersionedTransitionArtifact, activeClusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify child execution again after resending parent workflow
+	_, _, err = verifyChildExecution(ctx, workflowConsistencyChecker, request)
+	if err != nil {
+		return nil, err
+	}
 	return &historyservice.VerifyChildExecutionCompletionRecordedResponse{}, nil
 }

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -363,6 +363,8 @@ type Config struct {
 	BreakdownMetricsByTaskQueue dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 
 	LogAllReqErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
+
+	MaxLocalParentWorkflowVerificationDuration dynamicconfig.DurationPropertyFn
 }
 
 // NewConfig returns new service config with default values
@@ -392,6 +394,8 @@ func NewConfig(
 		AllowResetWithPendingChildren:        dynamicconfig.AllowResetWithPendingChildren.Get(dc),
 		MaxAutoResetPoints:                   dynamicconfig.HistoryMaxAutoResetPoints.Get(dc),
 		DefaultWorkflowTaskTimeout:           dynamicconfig.DefaultWorkflowTaskTimeout.Get(dc),
+
+		MaxLocalParentWorkflowVerificationDuration: dynamicconfig.MaxLocalParentWorkflowVerificationDuration.Get(dc),
 
 		VisibilityPersistenceMaxReadQPS:         dynamicconfig.VisibilityPersistenceMaxReadQPS.Get(dc),
 		VisibilityPersistenceMaxWriteQPS:        dynamicconfig.VisibilityPersistenceMaxWriteQPS.Get(dc),

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -695,7 +695,7 @@ func (e *historyEngineImpl) VerifyChildExecutionCompletionRecorded(
 	ctx context.Context,
 	req *historyservice.VerifyChildExecutionCompletionRecordedRequest,
 ) (*historyservice.VerifyChildExecutionCompletionRecordedResponse, error) {
-	return verifychildworkflowcompletionrecorded.Invoke(ctx, req, e.workflowConsistencyChecker)
+	return verifychildworkflowcompletionrecorded.Invoke(ctx, req, e.workflowConsistencyChecker, e.shardContext)
 }
 
 func (e *historyEngineImpl) ReplicateEventsV2(

--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -210,6 +210,10 @@ func (s *ContextTest) SetChasmRegistry(reg *chasm.Registry) {
 	s.chasmRegistry = reg
 }
 
+func (s *ContextTest) SetClusterMetadata(metadata cluster.Metadata) {
+	s.clusterMetadata = metadata
+}
+
 // StopForTest calls FinishStop(). In general only the controller
 // should call that, but integration tests need to do it also to clean up any
 // background acquireShard goroutines that may exist.

--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -241,7 +241,7 @@ func (t *transferQueueStandbyTaskExecutor) processCloseExecution(
 			now := t.getCurrentTime()
 			taskTime := transferTask.GetVisibilityTime()
 			localVerificationTime := taskTime.Add(t.config.MaxLocalParentWorkflowVerificationDuration())
-			resendParent := now.After(localVerificationTime)
+			resendParent := now.After(localVerificationTime) && t.config.EnableTransitionHistory()
 
 			_, err := t.historyRawClient.VerifyChildExecutionCompletionRecorded(ctx, &historyservice.VerifyChildExecutionCompletionRecordedRequest{
 				NamespaceId: executionInfo.ParentNamespaceId,

--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -238,6 +238,11 @@ func (t *transferQueueStandbyTaskExecutor) processCloseExecution(
 		}
 
 		if verifyCompletionRecorded {
+			now := t.getCurrentTime()
+			taskTime := transferTask.GetVisibilityTime()
+			localVerificationTime := taskTime.Add(t.config.MaxLocalParentWorkflowVerificationDuration())
+			resendParent := now.After(localVerificationTime)
+
 			_, err := t.historyRawClient.VerifyChildExecutionCompletionRecorded(ctx, &historyservice.VerifyChildExecutionCompletionRecordedRequest{
 				NamespaceId: executionInfo.ParentNamespaceId,
 				ParentExecution: &commonpb.WorkflowExecution{
@@ -251,6 +256,7 @@ func (t *transferQueueStandbyTaskExecutor) processCloseExecution(
 				ParentInitiatedId:      executionInfo.ParentInitiatedId,
 				ParentInitiatedVersion: executionInfo.ParentInitiatedVersion,
 				Clock:                  executionInfo.ParentClock,
+				ResendParent:           resendParent,
 			})
 			switch err.(type) {
 			case nil, *serviceerror.NamespaceNotFound, *serviceerror.Unimplemented:

--- a/service/history/transfer_queue_standby_task_executor_test.go
+++ b/service/history/transfer_queue_standby_task_executor_test.go
@@ -76,16 +76,17 @@ type (
 		mockArchivalMetadata archiver.MetadataMock
 		mockArchiverProvider *provider.MockArchiverProvider
 
-		workflowCache        wcache.Cache
-		logger               log.Logger
-		namespaceID          namespace.ID
-		namespaceEntry       *namespace.Namespace
-		version              int64
-		clusterName          string
-		now                  time.Time
-		timeSource           *clock.EventTimeSource
-		fetchHistoryDuration time.Duration
-		discardDuration      time.Duration
+		workflowCache             wcache.Cache
+		logger                    log.Logger
+		namespaceID               namespace.ID
+		namespaceEntry            *namespace.Namespace
+		version                   int64
+		clusterName               string
+		now                       time.Time
+		timeSource                *clock.EventTimeSource
+		localVerificationDuration time.Duration
+		fetchHistoryDuration      time.Duration
+		discardDuration           time.Duration
 
 		transferQueueStandbyTaskExecutor *transferQueueStandbyTaskExecutor
 		mockSearchAttributesProvider     *searchattribute.MockProvider
@@ -112,6 +113,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) SetupTest() {
 	s.version = s.namespaceEntry.FailoverVersion()
 	s.now = time.Now().UTC()
 	s.timeSource = clock.NewEventTimeSource().Update(s.now)
+	s.localVerificationDuration = time.Minute * 10
 	s.fetchHistoryDuration = time.Minute * 12
 	s.discardDuration = time.Minute * 30
 
@@ -580,6 +582,16 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessCloseExecution() {
 		Clock:                  parentClock,
 	})
 
+	expectedVerificationWithResendParentRequest := protomock.Eq(&historyservice.VerifyChildExecutionCompletionRecordedRequest{
+		NamespaceId:            parentNamespaceID,
+		ParentExecution:        parentExecution,
+		ChildExecution:         execution,
+		ParentInitiatedId:      parentInitiatedID,
+		ParentInitiatedVersion: parentInitiatedVersion,
+		Clock:                  parentClock,
+		ResendParent:           true,
+	})
+
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespace.ID(parentNamespaceID)).Return(tests.GlobalParentNamespaceEntry, nil).AnyTimes()
 	s.clientBean.EXPECT().GetRemoteFrontendClient(tests.GlobalChildNamespaceEntry.ActiveClusterName()).Return(nil, s.mockFrontendClient, nil).AnyTimes()
 	s.mockFrontendClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
@@ -615,17 +627,22 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessCloseExecution() {
 	var resourceExhaustedErr *serviceerror.ResourceExhausted
 	s.True(errors.As(resp.ExecutionErr, &resourceExhaustedErr))
 
+	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.localVerificationDuration))
+	s.mockHistoryClient.EXPECT().VerifyChildExecutionCompletionRecorded(gomock.Any(), expectedVerificationWithResendParentRequest).Return(nil, consts.ErrWorkflowNotReady)
+	resp = s.transferQueueStandbyTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
+	s.Equal(consts.ErrTaskRetry, resp.ExecutionErr)
+
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
-	s.mockHistoryClient.EXPECT().VerifyChildExecutionCompletionRecorded(gomock.Any(), expectedVerificationRequest).Return(nil, consts.ErrWorkflowNotReady)
+	s.mockHistoryClient.EXPECT().VerifyChildExecutionCompletionRecorded(gomock.Any(), expectedVerificationWithResendParentRequest).Return(nil, consts.ErrWorkflowNotReady)
 	resp = s.transferQueueStandbyTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
 	s.Equal(consts.ErrTaskRetry, resp.ExecutionErr)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
-	s.mockHistoryClient.EXPECT().VerifyChildExecutionCompletionRecorded(gomock.Any(), expectedVerificationRequest).Return(nil, consts.ErrWorkflowNotReady)
+	s.mockHistoryClient.EXPECT().VerifyChildExecutionCompletionRecorded(gomock.Any(), expectedVerificationWithResendParentRequest).Return(nil, consts.ErrWorkflowNotReady)
 	resp = s.transferQueueStandbyTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
 	s.Equal(consts.ErrTaskDiscarded, resp.ExecutionErr)
 
-	s.mockHistoryClient.EXPECT().VerifyChildExecutionCompletionRecorded(gomock.Any(), expectedVerificationRequest).Return(nil, errors.New("some random error"))
+	s.mockHistoryClient.EXPECT().VerifyChildExecutionCompletionRecorded(gomock.Any(), expectedVerificationWithResendParentRequest).Return(nil, errors.New("some random error"))
 	resp = s.transferQueueStandbyTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
 	s.Equal(consts.ErrTaskDiscarded, resp.ExecutionErr)
 }


### PR DESCRIPTION
## What changed?
Resend parent for standby child completion verification.

## Why?
In the case that standby fails to verify child completion when parent workflow is not found or not ready, standby should request resend parent from active so standby can finish verification earlier.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
New calls will be made to active. But this will only happen after the new config maxLocalParentWorkflowVerificationDuration. So impacts to active will be low.