### PR TITLE
Refactor archival fx initialization

### DIFF
--- a/common/archiver/README.md
+++ b/common/archiver/README.md
@@ -9,7 +9,7 @@ This README explains how to add new Archiver implementations.
 Create a new directory in the `archiver` folder. The structure should look like the following:
 ```
 ./common/archiver
-  - filestore/                      -- Filestore implementation 
+  - filestore/                      -- Filestore implementation
   - provider/
       - provider.go                 -- Provider of archiver instances
   - yourImplementation/
@@ -28,17 +28,17 @@ type HistoryArchiver interface {
     // the resource that histories should be archived into. The implementor gets to determine how to interpret the URI.
     // The Archive method may or may not be automatically retried by the caller. The ArchiveOptions are used
     // to interact with these retries including giving the implementor the ability to cancel retries and record progress
-    // between retry attempts. 
+    // between retry attempts.
     // This method will be invoked after a workflow passes its retention period.
     // It's possible that this method will be invoked for one workflow multiple times and potentially concurrently,
     // implementation should correctly handle the workflow not exist case and return nil error.
     Archive(context.Context, URI, *ArchiveHistoryRequest, ...ArchiveOption) error
-    
+
     // Get is used to access an archived history. When context expires method should stop trying to fetch history.
     // The URI identifies the resource from which history should be accessed and it is up to the implementor to interpret this URI.
     // This method should thrift errors - see filestore as an example.
     Get(context.Context, URI, *GetHistoryRequest) (*GetHistoryResponse, error)
-    
+
     // ValidateURI is used to define what a valid URI for an implementation is.
     ValidateURI(URI) error
 }
@@ -48,17 +48,17 @@ type HistoryArchiver interface {
 
 ```go
 type VisibilityArchiver interface {
-    // Archive is used to archive one workflow visibility record. 
-    // Check the Archive() method of the HistoryArchiver interface in Step 2 for parameters' meaning and requirements. 
-    // The only difference is that the ArchiveOption parameter won't include an option for recording process. 
-    // Please make sure your implementation is lossless. If any in-memory batching mechanism is used, then those batched records will be lost during server restarts. 
+    // Archive is used to archive one workflow visibility record.
+    // Check the Archive() method of the HistoryArchiver interface in Step 2 for parameters' meaning and requirements.
+    // The only difference is that the ArchiveOption parameter won't include an option for recording process.
+    // Please make sure your implementation is lossless. If any in-memory batching mechanism is used, then those batched records will be lost during server restarts.
     // This method will be invoked when workflow closes. Note that because of conflict resolution, it is possible for a workflow to through the closing process multiple times, which means that this method can be invoked more than once after a workflow closes.
     Archive(context.Context, URI, *ArchiveVisibilityRequest, ...ArchiveOption) error
-    
-    // Query is used to retrieve archived visibility records. 
+
+    // Query is used to retrieve archived visibility records.
     // Check the Get() method of the HistoryArchiver interface in Step 2 for parameters' meaning and requirements.
-    // The request includes a string field called query, which describes what kind of visibility records should be returned. For example, it can be some SQL-like syntax query string. 
-    // Your implementation is responsible for parsing and validating the query, and also returning all visibility records that match the query. 
+    // The request includes a string field called query, which describes what kind of visibility records should be returned. For example, it can be some SQL-like syntax query string.
+    // Your implementation is responsible for parsing and validating the query, and also returning all visibility records that match the query.
     // Currently the maximum context timeout passed into the method is 3 minutes, so it's ok if this method takes a long time to run.
     Query(context.Context, URI, *QueryVisibilityRequest) (*QueryVisibilityResponse, error)
 
@@ -69,21 +69,21 @@ type VisibilityArchiver interface {
 
 **Step 4: Update provider to provide access to your implementation**
 
-Modify the `./provider/provider.go` file so that the `ArchiverProvider` knows how to create an instance of your archiver. 
-Also, add configs for you archiver to static yaml config files and modify the `HistoryArchiverProvider` 
+Modify the `./provider/provider.go` file so that the `ArchiverProvider` knows how to create an instance of your archiver.
+Also, add configs for you archiver to static yaml config files and modify the `HistoryArchiverProvider`
 and `VisibilityArchiverProvider` struct in the `../common/service/config.go` accordingly.
 
 
 ## FAQ
 **If my Archive method can automatically be retried by caller how can I record and access progress between retries?**
 
-ArchiverOptions is used to handle this. The following shows and example: 
+ArchiverOptions is used to handle this. The following shows and example:
 ```go
 func (a *Archiver) Archive(
-	ctx context.Context,
-	URI string,
-	request *ArchiveRequest,
-	opts ...ArchiveOption,
+  ctx context.Context,
+  URI string,
+  request *ArchiveRequest,
+  opts ...ArchiveOption,
 ) error {
   featureCatalog := GetFeatureCatalog(opts...) // this function is defined in options.go
 
@@ -101,7 +101,7 @@ func (a *Archiver) Archive(
   // Record current progress
   if featureCatalog.ProgressManager != nil {
     if err := featureCatalog.ProgressManager.RecordProgress(ctx, progress); err != nil {
-      // log some error message and return error if needed. 
+      // log some error message and return error if needed.
     }
   }
 }
@@ -111,17 +111,17 @@ func (a *Archiver) Archive(
 
 ```go
 func (a *Archiver) Archive(
-	ctx context.Context,
-	URI string,
-	request *ArchiveRequest,
-	opts ...ArchiveOption,
+  ctx context.Context,
+  URI string,
+  request *ArchiveRequest,
+  opts ...ArchiveOption,
 ) error {
   featureCatalog := GetFeatureCatalog(opts...) // this function is defined in options.go
 
   err := youArchiverImpl()
   if nonRetryableErr(err) {
     if featureCatalog.NonRetryableError != nil {
-	  return featureCatalog.NonRetryableError() // when the caller gets this error type back it will not retry anymore.
+      return featureCatalog.NonRetryableError() // when the caller gets this error type back it will not retry anymore.
     }
   }
 }
@@ -129,10 +129,9 @@ func (a *Archiver) Archive(
 
 **How does my history archiver implementation read history?**
 
-The `archiver` package provides a utility class called `HistoryIterator` which is a wrapper of `ExecutionManager`. 
-Its usage is simpler than the `ExecutionManager` given in the `BootstrapContainer`, 
-so archiver implementations can choose to use it when reading workflow histories. 
-See the `historyIterator.go` file for more details. 
+The `archiver` package provides a utility class called `HistoryIterator` which is a wrapper of `ExecutionManager`.
+Its usage is simpler than `ExecutionManager`, so archiver implementations can choose to use it when reading workflow histories.
+See the `historyIterator.go` file for more details.
 Sample usage can be found in the filestore historyArchiver implementation.
 
 **Should my archiver define all its own error types?**

--- a/common/archiver/constants.go
+++ b/common/archiver/constants.go
@@ -16,8 +16,6 @@ const (
 	ErrReasonInvalidURI = "URI is invalid"
 	// ErrReasonInvalidArchiveRequest is the error reason for invalid archive request
 	ErrReasonInvalidArchiveRequest = "archive request is invalid"
-	// ErrReasonConstructHistoryIterator is the error reason for failing to construct history iterator
-	ErrReasonConstructHistoryIterator = "failed to construct history iterator"
 	// ErrReasonReadHistory is the error reason for failing to read history
 	ErrReasonReadHistory = "failed to read history batches"
 	// ErrReasonHistoryMutated is the error reason for mutated history
@@ -31,8 +29,6 @@ var (
 	ErrURISchemeMismatch = errors.New("URI scheme does not match the archiver")
 	// ErrHistoryMutated is the error for mutated history
 	ErrHistoryMutated = errors.New("history was mutated")
-	// ErrContextTimeout is the error for context timeout
-	ErrContextTimeout = errors.New("archive aborted because context timed out")
 	// ErrInvalidGetHistoryRequest is the error for invalid GetHistory request
 	ErrInvalidGetHistoryRequest = errors.New("get archived history request is invalid")
 	// ErrInvalidQueryVisibilityRequest is the error for invalid Query Visibility request

--- a/common/archiver/filestore/history_archiver.go
+++ b/common/archiver/filestore/history_archiver.go
@@ -49,9 +49,11 @@ var (
 
 type (
 	historyArchiver struct {
-		container *archiver.HistoryBootstrapContainer
-		fileMode  os.FileMode
-		dirMode   os.FileMode
+		executionManager persistence.ExecutionManager
+		logger           log.Logger
+		metricsHandler   metrics.Handler
+		fileMode         os.FileMode
+		dirMode          os.FileMode
 
 		// only set in test code
 		historyIterator archiver.HistoryIterator
@@ -65,14 +67,18 @@ type (
 
 // NewHistoryArchiver creates a new archiver.HistoryArchiver based on filestore
 func NewHistoryArchiver(
-	container *archiver.HistoryBootstrapContainer,
+	executionManager persistence.ExecutionManager,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
 	config *config.FilestoreArchiver,
 ) (archiver.HistoryArchiver, error) {
-	return newHistoryArchiver(container, config, nil)
+	return newHistoryArchiver(executionManager, logger, metricsHandler, config, nil)
 }
 
 func newHistoryArchiver(
-	container *archiver.HistoryBootstrapContainer,
+	executionManager persistence.ExecutionManager,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
 	config *config.FilestoreArchiver,
 	historyIterator archiver.HistoryIterator,
 ) (*historyArchiver, error) {
@@ -85,10 +91,12 @@ func newHistoryArchiver(
 		return nil, errInvalidDirMode
 	}
 	return &historyArchiver{
-		container:       container,
-		fileMode:        os.FileMode(fileMode),
-		dirMode:         os.FileMode(dirMode),
-		historyIterator: historyIterator,
+		executionManager: executionManager,
+		logger:           logger,
+		metricsHandler:   metricsHandler,
+		fileMode:         os.FileMode(fileMode),
+		dirMode:          os.FileMode(dirMode),
+		historyIterator:  historyIterator,
 	}, nil
 }
 
@@ -105,7 +113,7 @@ func (h *historyArchiver) Archive(
 		}
 	}()
 
-	logger := archiver.TagLoggerWithArchiveHistoryRequestAndURI(h.container.Logger, request, URI.String())
+	logger := archiver.TagLoggerWithArchiveHistoryRequestAndURI(h.logger, request, URI.String())
 
 	if err := h.ValidateURI(URI); err != nil {
 		logger.Error(archiver.ArchiveNonRetryableErrorMsg, tag.ArchivalArchiveFailReason(archiver.ErrReasonInvalidURI), tag.Error(err))
@@ -119,7 +127,7 @@ func (h *historyArchiver) Archive(
 
 	historyIterator := h.historyIterator
 	if historyIterator == nil { // will only be set by testing code
-		historyIterator = archiver.NewHistoryIterator(request, h.container.ExecutionManager, targetHistoryBlobSize)
+		historyIterator = archiver.NewHistoryIterator(request, h.executionManager, targetHistoryBlobSize)
 	}
 
 	var historyBatches []*historypb.History

--- a/common/archiver/filestore/history_archiver.go
+++ b/common/archiver/filestore/history_archiver.go
@@ -29,6 +29,8 @@ import (
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
 )
 
 const (

--- a/common/archiver/filestore/history_archiver_test.go
+++ b/common/archiver/filestore/history_archiver_test.go
@@ -559,9 +559,9 @@ func (s *historyArchiverSuite) newTestHistoryArchiver(historyIterator archiver.H
 		FileMode: testFileModeStr,
 		DirMode:  testDirModeStr,
 	}
-	archiver, err := newHistoryArchiver(s.executionManager, s.logger, s.metricsHandler, config, historyIterator)
+	a, err := newHistoryArchiver(s.executionManager, s.logger, s.metricsHandler, config, historyIterator)
 	s.NoError(err)
-	return archiver
+	return a
 }
 
 func (s *historyArchiverSuite) setupHistoryDirectory() {

--- a/common/archiver/filestore/history_archiver_test.go
+++ b/common/archiver/filestore/history_archiver_test.go
@@ -44,7 +44,9 @@ type historyArchiverSuite struct {
 	*require.Assertions
 	suite.Suite
 
-	container          *archiver.HistoryBootstrapContainer
+	logger             log.Logger
+	executionManager   persistence.ExecutionManager
+	metricsHandler     metrics.Handler
 	testArchivalURI    archiver.URI
 	testGetDirectory   string
 	historyBatchesV1   []*historypb.History
@@ -72,9 +74,8 @@ func (s *historyArchiverSuite) TearDownSuite() {
 
 func (s *historyArchiverSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
-	s.container = &archiver.HistoryBootstrapContainer{
-		Logger: log.NewNoopLogger(),
-	}
+	s.logger = log.NewNoopLogger()
+	s.metricsHandler = metrics.NoopMetricsHandler
 }
 
 func (s *historyArchiverSuite) TestValidateURI() {
@@ -556,7 +557,7 @@ func (s *historyArchiverSuite) newTestHistoryArchiver(historyIterator archiver.H
 		FileMode: testFileModeStr,
 		DirMode:  testDirModeStr,
 	}
-	archiver, err := newHistoryArchiver(s.container, config, historyIterator)
+	archiver, err := newHistoryArchiver(s.executionManager, s.logger, s.metricsHandler, config, historyIterator)
 	s.NoError(err)
 	return archiver
 }

--- a/common/archiver/filestore/history_archiver_test.go
+++ b/common/archiver/filestore/history_archiver_test.go
@@ -18,6 +18,8 @@ import (
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/tests/testutils"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/common/archiver/filestore/visibility_archiver.go
+++ b/common/archiver/filestore/visibility_archiver.go
@@ -16,7 +16,9 @@ import (
 	archiverspb "go.temporal.io/server/api/archiver/v1"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
 )

--- a/common/archiver/filestore/visibility_archiver_test.go
+++ b/common/archiver/filestore/visibility_archiver_test.go
@@ -559,9 +559,9 @@ func (s *visibilityArchiverSuite) newTestVisibilityArchiver() *visibilityArchive
 		FileMode: testFileModeStr,
 		DirMode:  testDirModeStr,
 	}
-	archiver, err := NewVisibilityArchiver(s.logger, s.metricsHandler, config)
+	a, err := NewVisibilityArchiver(s.logger, s.metricsHandler, config)
 	s.NoError(err)
-	return archiver.(*visibilityArchiver)
+	return a.(*visibilityArchiver)
 }
 
 func (s *visibilityArchiverSuite) setupVisibilityDirectory() {

--- a/common/archiver/filestore/visibility_archiver_test.go
+++ b/common/archiver/filestore/visibility_archiver_test.go
@@ -36,7 +36,8 @@ type visibilityArchiverSuite struct {
 	*require.Assertions
 	suite.Suite
 
-	container          *archiver.VisibilityBootstrapContainer
+	logger             log.Logger
+	metricsHandler     metrics.Handler
 	testArchivalURI    archiver.URI
 	testQueryDirectory string
 	visibilityRecords  []*archiverspb.VisibilityRecord
@@ -65,9 +66,8 @@ func (s *visibilityArchiverSuite) TearDownSuite() {
 
 func (s *visibilityArchiverSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
-	s.container = &archiver.VisibilityBootstrapContainer{
-		Logger: log.NewNoopLogger(),
-	}
+	s.logger = log.NewNoopLogger()
+	s.metricsHandler = metrics.NoopMetricsHandler
 	s.controller = gomock.NewController(s.T())
 }
 
@@ -558,7 +558,7 @@ func (s *visibilityArchiverSuite) newTestVisibilityArchiver() *visibilityArchive
 		FileMode: testFileModeStr,
 		DirMode:  testDirModeStr,
 	}
-	archiver, err := NewVisibilityArchiver(s.container, config)
+	archiver, err := NewVisibilityArchiver(s.logger, s.metricsHandler, config)
 	s.NoError(err)
 	return archiver.(*visibilityArchiver)
 }

--- a/common/archiver/filestore/visibility_archiver_test.go
+++ b/common/archiver/filestore/visibility_archiver_test.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/server/common/codec"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"

--- a/common/archiver/gcloud/history_archiver_test.go
+++ b/common/archiver/gcloud/history_archiver_test.go
@@ -17,6 +17,7 @@ import (
 	"go.temporal.io/server/common/archiver/gcloud/connector"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/util"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/common/archiver/gcloud/visibility_archiver.go
+++ b/common/archiver/gcloud/visibility_archiver.go
@@ -31,9 +31,10 @@ var (
 
 type (
 	visibilityArchiver struct {
-		container     *archiver.VisibilityBootstrapContainer
-		gcloudStorage connector.Client
-		queryParser   QueryParser
+		logger         log.Logger
+		metricsHandler metrics.Handler
+		gcloudStorage  connector.Client
+		queryParser    QueryParser
 	}
 
 	queryVisibilityToken struct {
@@ -48,18 +49,19 @@ type (
 	}
 )
 
-func newVisibilityArchiver(container *archiver.VisibilityBootstrapContainer, storage connector.Client) *visibilityArchiver {
+func newVisibilityArchiver(logger log.Logger, metricsHandler metrics.Handler, storage connector.Client) *visibilityArchiver {
 	return &visibilityArchiver{
-		container:     container,
-		gcloudStorage: storage,
-		queryParser:   NewQueryParser(),
+		logger:         logger,
+		metricsHandler: metricsHandler,
+		gcloudStorage:  storage,
+		queryParser:    NewQueryParser(),
 	}
 }
 
 // NewVisibilityArchiver creates a new archiver.VisibilityArchiver based on filestore
-func NewVisibilityArchiver(container *archiver.VisibilityBootstrapContainer, config *config.GstorageArchiver) (archiver.VisibilityArchiver, error) {
+func NewVisibilityArchiver(logger log.Logger, metricsHandler metrics.Handler, config *config.GstorageArchiver) (archiver.VisibilityArchiver, error) {
 	storage, err := connector.NewClient(context.Background(), config)
-	return newVisibilityArchiver(container, storage), err
+	return newVisibilityArchiver(logger, metricsHandler, storage), err
 }
 
 // Archive is used to archive one workflow visibility record.
@@ -68,7 +70,7 @@ func NewVisibilityArchiver(container *archiver.VisibilityBootstrapContainer, con
 // Please make sure your implementation is lossless. If any in-memory batching mechanism is used, then those batched records will be lost during server restarts.
 // This method will be invoked when workflow closes. Note that because of conflict resolution, it is possible for a workflow to through the closing process multiple times, which means that this method can be invoked more than once after a workflow closes.
 func (v *visibilityArchiver) Archive(ctx context.Context, URI archiver.URI, request *archiverspb.VisibilityRecord, opts ...archiver.ArchiveOption) (err error) {
-	handler := v.container.MetricsHandler.WithTags(metrics.OperationTag(metrics.HistoryArchiverScope), metrics.NamespaceTag(request.Namespace))
+	handler := v.metricsHandler.WithTags(metrics.OperationTag(metrics.HistoryArchiverScope), metrics.NamespaceTag(request.Namespace))
 	featureCatalog := archiver.GetFeatureCatalog(opts...)
 	startTime := time.Now().UTC()
 	defer func() {
@@ -85,7 +87,7 @@ func (v *visibilityArchiver) Archive(ctx context.Context, URI archiver.URI, requ
 		}
 	}()
 
-	logger := archiver.TagLoggerWithArchiveVisibilityRequestAndURI(v.container.Logger, request, URI.String())
+	logger := archiver.TagLoggerWithArchiveVisibilityRequestAndURI(v.logger, request, URI.String())
 
 	if err := v.ValidateURI(URI); err != nil {
 		if isRetryableError(err) {

--- a/common/archiver/gcloud/visibility_archiver.go
+++ b/common/archiver/gcloud/visibility_archiver.go
@@ -60,8 +60,8 @@ func newVisibilityArchiver(logger log.Logger, metricsHandler metrics.Handler, st
 }
 
 // NewVisibilityArchiver creates a new archiver.VisibilityArchiver based on filestore
-func NewVisibilityArchiver(logger log.Logger, metricsHandler metrics.Handler, config *config.GstorageArchiver) (archiver.VisibilityArchiver, error) {
-	storage, err := connector.NewClient(context.Background(), config)
+func NewVisibilityArchiver(logger log.Logger, metricsHandler metrics.Handler, cfg *config.GstorageArchiver) (archiver.VisibilityArchiver, error) {
+	storage, err := connector.NewClient(context.Background(), cfg)
 	return newVisibilityArchiver(logger, metricsHandler, storage), err
 }
 

--- a/common/archiver/gcloud/visibility_archiver.go
+++ b/common/archiver/gcloud/visibility_archiver.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/archiver/gcloud/connector"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/searchattribute"

--- a/common/archiver/gcloud/visibility_archiver_test.go
+++ b/common/archiver/gcloud/visibility_archiver_test.go
@@ -34,10 +34,8 @@ const (
 func (s *visibilityArchiverSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.controller = gomock.NewController(s.T())
-	s.container = &archiver.VisibilityBootstrapContainer{
-		Logger:         log.NewNoopLogger(),
-		MetricsHandler: metrics.NoopMetricsHandler,
-	}
+	s.logger = log.NewNoopLogger()
+	s.metricsHandler = metrics.NoopMetricsHandler
 	s.expectedVisibilityRecords = []*archiverspb.VisibilityRecord{
 		{
 			NamespaceId:      testNamespaceID,
@@ -66,7 +64,8 @@ type visibilityArchiverSuite struct {
 	protorequire.ProtoAssertions
 	suite.Suite
 	controller                *gomock.Controller
-	container                 *archiver.VisibilityBootstrapContainer
+	logger                    log.Logger
+	metricsHandler            metrics.Handler
 	expectedVisibilityRecords []*archiverspb.VisibilityRecord
 }
 
@@ -118,7 +117,7 @@ func (s *visibilityArchiverSuite) TestArchive_Fail_InvalidVisibilityURI() {
 	s.NoError(err)
 	storageWrapper := connector.NewMockClient(s.controller)
 
-	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
+	visibilityArchiver := newVisibilityArchiver(s.logger, s.metricsHandler, storageWrapper)
 	s.NoError(err)
 	request := &archiverspb.VisibilityRecord{
 		NamespaceId: testNamespaceID,
@@ -137,7 +136,7 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidVisibilityURI() {
 	s.NoError(err)
 	storageWrapper := connector.NewMockClient(s.controller)
 
-	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
+	visibilityArchiver := newVisibilityArchiver(s.logger, s.metricsHandler, storageWrapper)
 	s.NoError(err)
 	request := &archiver.QueryVisibilityRequest{
 		NamespaceID: testNamespaceID,
@@ -157,7 +156,7 @@ func (s *visibilityArchiverSuite) TestVisibilityArchive() {
 	storageWrapper.EXPECT().Exist(gomock.Any(), URI, gomock.Any()).Return(false, nil)
 	storageWrapper.EXPECT().Upload(gomock.Any(), URI, gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
-	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
+	visibilityArchiver := newVisibilityArchiver(s.logger, s.metricsHandler, storageWrapper)
 	s.NoError(err)
 
 	request := &archiverspb.VisibilityRecord{
@@ -183,7 +182,7 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidQuery() {
 	s.NoError(err)
 	storageWrapper := connector.NewMockClient(s.controller)
 	storageWrapper.EXPECT().Exist(gomock.Any(), URI, gomock.Any()).Return(false, nil)
-	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
+	visibilityArchiver := newVisibilityArchiver(s.logger, s.metricsHandler, storageWrapper)
 	s.NoError(err)
 
 	mockParser := NewMockQueryParser(s.controller)
@@ -203,7 +202,7 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidToken() {
 	s.NoError(err)
 	storageWrapper := connector.NewMockClient(s.controller)
 	storageWrapper.EXPECT().Exist(gomock.Any(), URI, gomock.Any()).Return(false, nil)
-	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
+	visibilityArchiver := newVisibilityArchiver(s.logger, s.metricsHandler, storageWrapper)
 	s.NoError(err)
 
 	mockParser := NewMockQueryParser(s.controller)
@@ -236,7 +235,7 @@ func (s *visibilityArchiverSuite) TestQuery_Success_NoNextPageToken() {
 	storageWrapper.EXPECT().QueryWithFilters(gomock.Any(), URI, gomock.Any(), 10, 0, gomock.Any()).Return([]string{"closeTimeout_2020-02-05T09:56:14Z_test-workflow-id_MobileOnlyWorkflow::processMobileOnly_test-run-id.visibility"}, true, 1, nil)
 	storageWrapper.EXPECT().Get(gomock.Any(), URI, "test-namespace-id/closeTimeout_2020-02-05T09:56:14Z_test-workflow-id_MobileOnlyWorkflow::processMobileOnly_test-run-id.visibility").Return([]byte(exampleVisibilityRecord), nil)
 
-	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
+	visibilityArchiver := newVisibilityArchiver(s.logger, s.metricsHandler, storageWrapper)
 	s.NoError(err)
 
 	mockParser := NewMockQueryParser(s.controller)
@@ -279,7 +278,7 @@ func (s *visibilityArchiverSuite) TestQuery_Success_SmallPageSize() {
 	storageWrapper.EXPECT().Get(gomock.Any(), URI, "test-namespace-id/closeTimeout_2020-02-05T09:56:15Z_test-workflow-id_MobileOnlyWorkflow::processMobileOnly_test-run-id.visibility").Return([]byte(exampleVisibilityRecord), nil)
 	storageWrapper.EXPECT().Get(gomock.Any(), URI, "test-namespace-id/closeTimeout_2020-02-05T09:56:16Z_test-workflow-id_MobileOnlyWorkflow::processMobileOnly_test-run-id.visibility").Return([]byte(exampleVisibilityRecord), nil)
 
-	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
+	visibilityArchiver := newVisibilityArchiver(s.logger, s.metricsHandler, storageWrapper)
 	s.NoError(err)
 
 	mockParser := NewMockQueryParser(s.controller)
@@ -327,7 +326,7 @@ func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_InvalidNamespace() {
 	s.NoError(err)
 	storageWrapper := connector.NewMockClient(s.controller)
 	storageWrapper.EXPECT().Exist(gomock.Any(), URI, gomock.Any()).Return(false, nil)
-	arc := newVisibilityArchiver(s.container, storageWrapper)
+	arc := newVisibilityArchiver(s.logger, s.metricsHandler, storageWrapper)
 	req := &archiver.QueryVisibilityRequest{
 		NamespaceID:   "",
 		PageSize:      1,
@@ -346,7 +345,7 @@ func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_ZeroPageSize() {
 	s.NoError(err)
 	storageWrapper := connector.NewMockClient(s.controller)
 	storageWrapper.EXPECT().Exist(gomock.Any(), URI, gomock.Any()).Return(false, nil)
-	arc := newVisibilityArchiver(s.container, storageWrapper)
+	arc := newVisibilityArchiver(s.logger, s.metricsHandler, storageWrapper)
 
 	req := &archiver.QueryVisibilityRequest{
 		NamespaceID:   testNamespaceID,
@@ -402,7 +401,7 @@ func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_Pagination() {
 		"test-namespace-id/closeTimeout_2020-02-05T09:56:14Z_test-workflow-id2_MobileOnlyWorkflow"+
 			"::processMobileOnly_test-run-id.visibility").Return([]byte(exampleVisibilityRecord2), nil)
 
-	arc := newVisibilityArchiver(s.container, storageWrapper)
+	arc := newVisibilityArchiver(s.logger, s.metricsHandler, storageWrapper)
 
 	response := &archiver.QueryVisibilityResponse{
 		Executions:    nil,

--- a/common/archiver/interface.go
+++ b/common/archiver/interface.go
@@ -8,9 +8,6 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	archiverspb "go.temporal.io/server/api/archiver/v1"
-	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/searchattribute"
 )
 

--- a/common/archiver/interface.go
+++ b/common/archiver/interface.go
@@ -8,7 +8,6 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	archiverspb "go.temporal.io/server/api/archiver/v1"
-	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
@@ -44,14 +43,6 @@ type (
 		NextPageToken  []byte
 	}
 
-	// HistoryBootstrapContainer contains components needed by all history Archiver implementations
-	HistoryBootstrapContainer struct {
-		ExecutionManager persistence.ExecutionManager
-		Logger           log.Logger
-		MetricsHandler   metrics.Handler
-		ClusterMetadata  cluster.Metadata
-	}
-
 	// HistoryArchiver is used to archive history and read archived history
 	HistoryArchiver interface {
 		// Archive is used to archive a Workflow's history. When the context expires the method should stop trying to archive.
@@ -68,13 +59,6 @@ type (
 		Get(ctx context.Context, url URI, request *GetHistoryRequest) (*GetHistoryResponse, error)
 		// ValidateURI is used to define what a valid URI for an implementation is.
 		ValidateURI(uri URI) error
-	}
-
-	// VisibilityBootstrapContainer contains components needed by all visibility Archiver implementations
-	VisibilityBootstrapContainer struct {
-		Logger          log.Logger
-		MetricsHandler  metrics.Handler
-		ClusterMetadata cluster.Metadata
 	}
 
 	// QueryVisibilityRequest is the request to query archived visibility records

--- a/common/archiver/provider/provider.go
+++ b/common/archiver/provider/provider.go
@@ -67,9 +67,8 @@ func NewArchiverProvider(
 }
 
 func (p *archiverProvider) GetHistoryArchiver(scheme string) (historyArchiver archiver.HistoryArchiver, err error) {
-	archiverKey := p.getArchiverKey(scheme)
 	p.RLock()
-	if historyArchiver, ok := p.historyArchivers[archiverKey]; ok {
+	if historyArchiver, ok := p.historyArchivers[scheme]; ok {
 		p.RUnlock()
 		return historyArchiver, nil
 	}
@@ -104,17 +103,16 @@ func (p *archiverProvider) GetHistoryArchiver(scheme string) (historyArchiver ar
 
 	p.Lock()
 	defer p.Unlock()
-	if existingHistoryArchiver, ok := p.historyArchivers[archiverKey]; ok {
+	if existingHistoryArchiver, ok := p.historyArchivers[scheme]; ok {
 		return existingHistoryArchiver, nil
 	}
-	p.historyArchivers[archiverKey] = historyArchiver
+	p.historyArchivers[scheme] = historyArchiver
 	return historyArchiver, nil
 }
 
 func (p *archiverProvider) GetVisibilityArchiver(scheme string) (archiver.VisibilityArchiver, error) {
-	archiverKey := p.getArchiverKey(scheme)
 	p.RLock()
-	if visibilityArchiver, ok := p.visibilityArchivers[archiverKey]; ok {
+	if visibilityArchiver, ok := p.visibilityArchivers[scheme]; ok {
 		p.RUnlock()
 		return visibilityArchiver, nil
 	}
@@ -149,14 +147,10 @@ func (p *archiverProvider) GetVisibilityArchiver(scheme string) (archiver.Visibi
 
 	p.Lock()
 	defer p.Unlock()
-	if existingVisibilityArchiver, ok := p.visibilityArchivers[archiverKey]; ok {
+	if existingVisibilityArchiver, ok := p.visibilityArchivers[scheme]; ok {
 		return existingVisibilityArchiver, nil
 	}
-	p.visibilityArchivers[archiverKey] = visibilityArchiver
+	p.visibilityArchivers[scheme] = visibilityArchiver
 	return visibilityArchiver, nil
 
-}
-
-func (p *archiverProvider) getArchiverKey(scheme string) string {
-	return scheme
 }

--- a/common/archiver/provider/provider_mock.go
+++ b/common/archiver/provider/provider_mock.go
@@ -41,45 +41,31 @@ func (m *MockArchiverProvider) EXPECT() *MockArchiverProviderMockRecorder {
 }
 
 // GetHistoryArchiver mocks base method.
-func (m *MockArchiverProvider) GetHistoryArchiver(scheme, serviceName string) (archiver.HistoryArchiver, error) {
+func (m *MockArchiverProvider) GetHistoryArchiver(scheme string) (archiver.HistoryArchiver, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHistoryArchiver", scheme, serviceName)
+	ret := m.ctrl.Call(m, "GetHistoryArchiver", scheme)
 	ret0, _ := ret[0].(archiver.HistoryArchiver)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetHistoryArchiver indicates an expected call of GetHistoryArchiver.
-func (mr *MockArchiverProviderMockRecorder) GetHistoryArchiver(scheme, serviceName any) *gomock.Call {
+func (mr *MockArchiverProviderMockRecorder) GetHistoryArchiver(scheme any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryArchiver", reflect.TypeOf((*MockArchiverProvider)(nil).GetHistoryArchiver), scheme, serviceName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryArchiver", reflect.TypeOf((*MockArchiverProvider)(nil).GetHistoryArchiver), scheme)
 }
 
 // GetVisibilityArchiver mocks base method.
-func (m *MockArchiverProvider) GetVisibilityArchiver(scheme, serviceName string) (archiver.VisibilityArchiver, error) {
+func (m *MockArchiverProvider) GetVisibilityArchiver(scheme string) (archiver.VisibilityArchiver, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVisibilityArchiver", scheme, serviceName)
+	ret := m.ctrl.Call(m, "GetVisibilityArchiver", scheme)
 	ret0, _ := ret[0].(archiver.VisibilityArchiver)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetVisibilityArchiver indicates an expected call of GetVisibilityArchiver.
-func (mr *MockArchiverProviderMockRecorder) GetVisibilityArchiver(scheme, serviceName any) *gomock.Call {
+func (mr *MockArchiverProviderMockRecorder) GetVisibilityArchiver(scheme any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVisibilityArchiver", reflect.TypeOf((*MockArchiverProvider)(nil).GetVisibilityArchiver), scheme, serviceName)
-}
-
-// RegisterBootstrapContainer mocks base method.
-func (m *MockArchiverProvider) RegisterBootstrapContainer(serviceName string, historyContainer *archiver.HistoryBootstrapContainer, visibilityContainter *archiver.VisibilityBootstrapContainer) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterBootstrapContainer", serviceName, historyContainer, visibilityContainter)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RegisterBootstrapContainer indicates an expected call of RegisterBootstrapContainer.
-func (mr *MockArchiverProviderMockRecorder) RegisterBootstrapContainer(serviceName, historyContainer, visibilityContainter any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterBootstrapContainer", reflect.TypeOf((*MockArchiverProvider)(nil).RegisterBootstrapContainer), serviceName, historyContainer, visibilityContainter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVisibilityArchiver", reflect.TypeOf((*MockArchiverProvider)(nil).GetVisibilityArchiver), scheme)
 }

--- a/common/archiver/s3store/history_archiver.go
+++ b/common/archiver/s3store/history_archiver.go
@@ -45,8 +45,10 @@ var (
 
 type (
 	historyArchiver struct {
-		container *archiver.HistoryBootstrapContainer
-		s3cli     s3iface.S3API
+		executionManager persistence.ExecutionManager
+		logger           log.Logger
+		metricsHandler   metrics.Handler
+		s3cli            s3iface.S3API
 		// only set in test code
 		historyIterator archiver.HistoryIterator
 	}
@@ -66,14 +68,18 @@ type (
 
 // NewHistoryArchiver creates a new archiver.HistoryArchiver based on s3
 func NewHistoryArchiver(
-	container *archiver.HistoryBootstrapContainer,
+	executionManager persistence.ExecutionManager,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
 	config *config.S3Archiver,
 ) (archiver.HistoryArchiver, error) {
-	return newHistoryArchiver(container, config, nil)
+	return newHistoryArchiver(executionManager, logger, metricsHandler, config, nil)
 }
 
 func newHistoryArchiver(
-	container *archiver.HistoryBootstrapContainer,
+	executionManager persistence.ExecutionManager,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
 	config *config.S3Archiver,
 	historyIterator archiver.HistoryIterator,
 ) (*historyArchiver, error) {
@@ -92,9 +98,11 @@ func newHistoryArchiver(
 	}
 
 	return &historyArchiver{
-		container:       container,
-		s3cli:           s3.New(sess),
-		historyIterator: historyIterator,
+		executionManager: executionManager,
+		logger:           logger,
+		metricsHandler:   metricsHandler,
+		s3cli:            s3.New(sess),
+		historyIterator:  historyIterator,
 	}, nil
 }
 func (h *historyArchiver) Archive(
@@ -103,7 +111,7 @@ func (h *historyArchiver) Archive(
 	request *archiver.ArchiveHistoryRequest,
 	opts ...archiver.ArchiveOption,
 ) (err error) {
-	handler := h.container.MetricsHandler.WithTags(metrics.OperationTag(metrics.HistoryArchiverScope), metrics.NamespaceTag(request.Namespace))
+	handler := h.metricsHandler.WithTags(metrics.OperationTag(metrics.HistoryArchiverScope), metrics.NamespaceTag(request.Namespace))
 	featureCatalog := archiver.GetFeatureCatalog(opts...)
 	startTime := time.Now().UTC()
 	defer func() {
@@ -120,7 +128,7 @@ func (h *historyArchiver) Archive(
 		}
 	}()
 
-	logger := archiver.TagLoggerWithArchiveHistoryRequestAndURI(h.container.Logger, request, URI.String())
+	logger := archiver.TagLoggerWithArchiveHistoryRequestAndURI(h.logger, request, URI.String())
 
 	if err := SoftValidateURI(URI); err != nil {
 		logger.Error(archiver.ArchiveNonRetryableErrorMsg, tag.ArchivalArchiveFailReason(archiver.ErrReasonInvalidURI), tag.Error(err))
@@ -135,7 +143,7 @@ func (h *historyArchiver) Archive(
 	var progress uploadProgress
 	historyIterator := h.historyIterator
 	if historyIterator == nil { // will only be set by testing code
-		historyIterator = loadHistoryIterator(ctx, request, h.container.ExecutionManager, featureCatalog, &progress)
+		historyIterator = loadHistoryIterator(ctx, request, h.executionManager, featureCatalog, &progress)
 	}
 	for historyIterator.HasNext() {
 		historyBlob, err := historyIterator.Next(ctx)

--- a/common/archiver/s3store/history_archiver_test.go
+++ b/common/archiver/s3store/history_archiver_test.go
@@ -28,6 +28,7 @@ import (
 	"go.temporal.io/server/common/codec"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/util"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -52,6 +53,7 @@ type historyArchiverSuite struct {
 	suite.Suite
 	s3cli              *mocks.MockS3API
 	logger             log.Logger
+	executionManager   persistence.ExecutionManager
 	metricsHandler     metrics.Handler
 	testArchivalURI    archiver.URI
 	historyBatchesV1   []*archiverspb.HistoryBlob

--- a/common/archiver/s3store/history_archiver_test.go
+++ b/common/archiver/s3store/history_archiver_test.go
@@ -52,8 +52,8 @@ type historyArchiverSuite struct {
 	*require.Assertions
 	suite.Suite
 	s3cli              *mocks.MockS3API
-	logger             log.Logger
 	executionManager   persistence.ExecutionManager
+	logger             log.Logger
 	metricsHandler     metrics.Handler
 	testArchivalURI    archiver.URI
 	historyBatchesV1   []*archiverspb.HistoryBlob

--- a/common/archiver/s3store/visibility_archiver.go
+++ b/common/archiver/s3store/visibility_archiver.go
@@ -14,6 +14,7 @@ import (
 	archiverspb "go.temporal.io/server/api/archiver/v1"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives/timestamp"

--- a/common/archiver/s3store/visibility_archiver_test.go
+++ b/common/archiver/s3store/visibility_archiver_test.go
@@ -36,7 +36,8 @@ type visibilityArchiverSuite struct {
 	suite.Suite
 	s3cli *mocks.MockS3API
 
-	container         *archiver.VisibilityBootstrapContainer
+	logger            log.Logger
+	metricsHandler    metrics.Handler
 	visibilityRecords []*archiverspb.VisibilityRecord
 
 	controller      *gomock.Controller
@@ -93,9 +94,10 @@ func (s *visibilityArchiverSuite) TestValidateURI() {
 
 func (s *visibilityArchiverSuite) newTestVisibilityArchiver() *visibilityArchiver {
 	return &visibilityArchiver{
-		container:   s.container,
-		s3cli:       s.s3cli,
-		queryParser: NewQueryParser(),
+		logger:         s.logger,
+		metricsHandler: s.metricsHandler,
+		s3cli:          s.s3cli,
+		queryParser:    NewQueryParser(),
 	}
 }
 
@@ -108,10 +110,8 @@ func (s *visibilityArchiverSuite) SetupSuite() {
 
 	s.testArchivalURI, err = archiver.NewURI(testBucketURI)
 	s.Require().NoError(err)
-	s.container = &archiver.VisibilityBootstrapContainer{
-		Logger:         log.NewNoopLogger(),
-		MetricsHandler: metrics.NoopMetricsHandler,
-	}
+	s.logger = log.NewNoopLogger()
+	s.metricsHandler = metrics.NoopMetricsHandler
 }
 
 func (s *visibilityArchiverSuite) TearDownSuite() {

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -296,7 +296,6 @@ func ArchiverProviderProvider(
 	persistenceExecutionManager persistence.ExecutionManager,
 	logger log.SnTaggedLogger,
 	metricsHandler metrics.Handler,
-	clusterMetadata cluster.Metadata,
 ) provider.ArchiverProvider {
 	return provider.NewArchiverProvider(
 		cfg.Archival.History.Provider,
@@ -304,7 +303,6 @@ func ArchiverProviderProvider(
 		persistenceExecutionManager,
 		logger,
 		metricsHandler,
-		clusterMetadata,
 	)
 }
 

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -86,8 +86,6 @@ var Module = fx.Options(
 		fx.ResultTags(`group:"deadlockDetectorRoots"`),
 	)),
 	fx.Provide(serialization.NewSerializer),
-	fx.Provide(HistoryBootstrapContainerProvider),
-	fx.Provide(VisibilityBootstrapContainerProvider),
 	fx.Provide(ClientFactoryProvider),
 	fx.Provide(ClientBeanProvider),
 	fx.Provide(FrontendClientProvider),
@@ -100,7 +98,6 @@ var Module = fx.Options(
 	fx.Provide(MatchingClientProvider),
 	membership.GRPCResolverModule,
 	fx.Provide(FrontendHTTPClientCacheProvider),
-	fx.Invoke(RegisterBootstrapContainer),
 	fx.Provide(PersistenceConfigProvider),
 	fx.Provide(health.NewServer),
 	deadlock.Module,
@@ -251,45 +248,6 @@ func RuntimeMetricsReporterProvider(
 	)
 }
 
-func VisibilityBootstrapContainerProvider(
-	logger log.SnTaggedLogger,
-	metricsHandler metrics.Handler,
-	clusterMetadata cluster.Metadata,
-) *archiver.VisibilityBootstrapContainer {
-	return &archiver.VisibilityBootstrapContainer{
-		Logger:          logger,
-		MetricsHandler:  metricsHandler,
-		ClusterMetadata: clusterMetadata,
-	}
-}
-
-func HistoryBootstrapContainerProvider(
-	logger log.SnTaggedLogger,
-	metricsHandler metrics.Handler,
-	clusterMetadata cluster.Metadata,
-	executionManager persistence.ExecutionManager,
-) *archiver.HistoryBootstrapContainer {
-	return &archiver.HistoryBootstrapContainer{
-		ExecutionManager: executionManager,
-		Logger:           logger,
-		MetricsHandler:   metricsHandler,
-		ClusterMetadata:  clusterMetadata,
-	}
-}
-
-func RegisterBootstrapContainer(
-	archiverProvider provider.ArchiverProvider,
-	serviceName primitives.ServiceName,
-	visibilityArchiverBootstrapContainer *archiver.VisibilityBootstrapContainer,
-	historyArchiverBootstrapContainer *archiver.HistoryBootstrapContainer,
-) error {
-	return archiverProvider.RegisterBootstrapContainer(
-		string(serviceName),
-		historyArchiverBootstrapContainer,
-		visibilityArchiverBootstrapContainer,
-	)
-}
-
 func HistoryRawClientProvider(clientBean client.Bean) HistoryRawClient {
 	return clientBean.GetHistoryClient()
 }
@@ -333,8 +291,21 @@ func ArchivalMetadataProvider(dc *dynamicconfig.Collection, cfg *config.Config) 
 	)
 }
 
-func ArchiverProviderProvider(cfg *config.Config) provider.ArchiverProvider {
-	return provider.NewArchiverProvider(cfg.Archival.History.Provider, cfg.Archival.Visibility.Provider)
+func ArchiverProviderProvider(
+	cfg *config.Config,
+	persistenceExecutionManager persistence.ExecutionManager,
+	logger log.SnTaggedLogger,
+	metricsHandler metrics.Handler,
+	clusterMetadata cluster.Metadata,
+) provider.ArchiverProvider {
+	return provider.NewArchiverProvider(
+		cfg.Archival.History.Provider,
+		cfg.Archival.Visibility.Provider,
+		persistenceExecutionManager,
+		logger,
+		metricsHandler,
+		clusterMetadata,
+	)
 }
 
 func SdkClientFactoryProvider(

--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -983,12 +983,12 @@ func (d *namespaceHandler) validateHistoryArchivalURI(URIString string) error {
 		return err
 	}
 
-	archiver, err := d.archiverProvider.GetHistoryArchiver(URI.Scheme())
+	a, err := d.archiverProvider.GetHistoryArchiver(URI.Scheme())
 	if err != nil {
 		return err
 	}
 
-	return archiver.ValidateURI(URI)
+	return a.ValidateURI(URI)
 }
 
 func (d *namespaceHandler) validateVisibilityArchivalURI(URIString string) error {
@@ -997,12 +997,12 @@ func (d *namespaceHandler) validateVisibilityArchivalURI(URIString string) error
 		return err
 	}
 
-	archiver, err := d.archiverProvider.GetVisibilityArchiver(URI.Scheme())
+	a, err := d.archiverProvider.GetVisibilityArchiver(URI.Scheme())
 	if err != nil {
 		return err
 	}
 
-	return archiver.ValidateURI(URI)
+	return a.ValidateURI(URI)
 }
 
 // maybeUpdateFailoverHistory adds an entry if the Namespace is becoming active in a new cluster.

--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -27,7 +27,6 @@ import (
 	"go.temporal.io/server/common/namespace/nsmanager"
 	"go.temporal.io/server/common/namespace/nsreplication"
 	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/util"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -984,7 +983,7 @@ func (d *namespaceHandler) validateHistoryArchivalURI(URIString string) error {
 		return err
 	}
 
-	archiver, err := d.archiverProvider.GetHistoryArchiver(URI.Scheme(), string(primitives.FrontendService))
+	archiver, err := d.archiverProvider.GetHistoryArchiver(URI.Scheme())
 	if err != nil {
 		return err
 	}
@@ -998,7 +997,7 @@ func (d *namespaceHandler) validateVisibilityArchivalURI(URIString string) error
 		return err
 	}
 
-	archiver, err := d.archiverProvider.GetVisibilityArchiver(URI.Scheme(), string(primitives.FrontendService))
+	archiver, err := d.archiverProvider.GetVisibilityArchiver(URI.Scheme())
 	if err != nil {
 		return err
 	}

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2444,7 +2444,7 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(ctx context.Context, r
 		return nil, err
 	}
 
-	visibilityArchiver, err := wh.archiverProvider.GetVisibilityArchiver(URI.Scheme(), string(primitives.FrontendService))
+	visibilityArchiver, err := wh.archiverProvider.GetVisibilityArchiver(URI.Scheme())
 	if err != nil {
 		return nil, err
 	}
@@ -5387,7 +5387,7 @@ func (wh *WorkflowHandler) getArchivedHistory(
 		return nil, err
 	}
 
-	historyArchiver, err := wh.archiverProvider.GetHistoryArchiver(URI.Scheme(), string(primitives.FrontendService))
+	historyArchiver, err := wh.archiverProvider.GetHistoryArchiver(URI.Scheme())
 	if err != nil {
 		return nil, err
 	}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -1112,8 +1112,8 @@ func (s *WorkflowHandlerSuite) TestRegisterNamespace_Failure_InvalidArchivalURI(
 	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
 	s.mockVisibilityArchiver.EXPECT().ValidateURI(gomock.Any()).Return(errors.New("invalid URI"))
-	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
-	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), gomock.Any()).Return(s.mockVisibilityArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any()).Return(s.mockHistoryArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any()).Return(s.mockVisibilityArchiver, nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -1139,8 +1139,8 @@ func (s *WorkflowHandlerSuite) TestRegisterNamespace_Success_EnabledWithNoArchiv
 	}, nil)
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
 	s.mockVisibilityArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
-	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
-	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), gomock.Any()).Return(s.mockVisibilityArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any()).Return(s.mockHistoryArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any()).Return(s.mockVisibilityArchiver, nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -1161,8 +1161,8 @@ func (s *WorkflowHandlerSuite) TestRegisterNamespace_Success_EnabledWithArchival
 	}, nil)
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
 	s.mockVisibilityArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
-	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
-	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), gomock.Any()).Return(s.mockVisibilityArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any()).Return(s.mockHistoryArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any()).Return(s.mockVisibilityArchiver, nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -1467,7 +1467,7 @@ func (s *WorkflowHandlerSuite) TestUpdateNamespace_Failure_UpdateExistingArchiva
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
-	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any()).Return(s.mockHistoryArchiver, nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -1492,7 +1492,7 @@ func (s *WorkflowHandlerSuite) TestUpdateNamespace_Failure_InvalidArchivalURI() 
 	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(getNamespaceResp, nil)
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(errors.New("invalid URI"))
-	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any()).Return(s.mockHistoryArchiver, nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -1522,8 +1522,8 @@ func (s *WorkflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToArch
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
 	s.mockVisibilityArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
-	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
-	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), gomock.Any()).Return(s.mockVisibilityArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any()).Return(s.mockHistoryArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any()).Return(s.mockVisibilityArchiver, nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -1586,8 +1586,8 @@ func (s *WorkflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToArch
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
 	s.mockVisibilityArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
-	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
-	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), gomock.Any()).Return(s.mockVisibilityArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any()).Return(s.mockHistoryArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any()).Return(s.mockVisibilityArchiver, nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -1622,8 +1622,8 @@ func (s *WorkflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToEnab
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
 	s.mockVisibilityArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
-	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
-	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), gomock.Any()).Return(s.mockVisibilityArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any()).Return(s.mockHistoryArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any()).Return(s.mockVisibilityArchiver, nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -1659,8 +1659,8 @@ func (s *WorkflowHandlerSuite) TestUpdateNamespace_Success_ArchivalNeverEnabledT
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
 	s.mockVisibilityArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
-	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
-	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), gomock.Any()).Return(s.mockVisibilityArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any()).Return(s.mockHistoryArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any()).Return(s.mockVisibilityArchiver, nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -1800,7 +1800,7 @@ func (s *WorkflowHandlerSuite) TestGetArchivedHistory_Success_GetFirstPage() {
 		NextPageToken:  nextPageToken,
 		HistoryBatches: []*historypb.History{historyBatch1, historyBatch2},
 	}, nil)
-	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any()).Return(s.mockHistoryArchiver, nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -1890,7 +1890,7 @@ func (s *WorkflowHandlerSuite) TestListArchivedVisibility_Success() {
 	), nil).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "random URI")).Times(2)
 	s.mockVisibilityArchiver.EXPECT().Query(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&archiver.QueryVisibilityResponse{}, nil)
-	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), gomock.Any()).Return(s.mockVisibilityArchiver, nil)
+	s.mockArchiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any()).Return(s.mockVisibilityArchiver, nil)
 	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes("", false)
 
 	wh := s.getWorkflowHandler(s.newConfig())

--- a/service/history/archival/archiver.go
+++ b/service/history/archival/archiver.go
@@ -184,7 +184,7 @@ func (a *archiver) archiveHistory(ctx context.Context, request *Request, logger 
 	)
 	defer a.recordArchiveTargetResult(logger, time.Now(), TargetHistory, &err)
 
-	historyArchiver, err := a.archiverProvider.GetHistoryArchiver(request.HistoryURI.Scheme(), request.CallerService)
+	historyArchiver, err := a.archiverProvider.GetHistoryArchiver(request.HistoryURI.Scheme())
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func (a *archiver) archiveVisibility(ctx context.Context, request *Request, logg
 	)
 	defer a.recordArchiveTargetResult(logger, time.Now(), TargetVisibility, &err)
 
-	visibilityArchiver, err := a.archiverProvider.GetVisibilityArchiver(request.VisibilityURI.Scheme(), request.CallerService)
+	visibilityArchiver, err := a.archiverProvider.GetVisibilityArchiver(request.VisibilityURI.Scheme())
 	if err != nil {
 		return err
 	}

--- a/service/history/archival/archiver_test.go
+++ b/service/history/archival/archiver_test.go
@@ -172,13 +172,13 @@ func TestArchiver(t *testing.T) {
 			require.NoError(t, err)
 
 			if c.ExpectArchiveHistory {
-				archiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(historyArchiver, nil)
+				archiverProvider.EXPECT().GetHistoryArchiver(gomock.Any()).Return(historyArchiver, nil)
 				historyArchiver.EXPECT().Archive(gomock.Any(), historyURI, gomock.Any()).Return(c.ArchiveHistoryErr)
 			}
 
 			visibilityURI, err := carchiver.NewURI("test:///visibility/archival")
 			require.NoError(t, err)
-			archiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), gomock.Any()).
+			archiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any()).
 				Return(visibilityArchiver, nil).AnyTimes()
 
 			if c.ExpectArchiveVisibility {

--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -26,7 +26,6 @@ import (
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/versionhistory"
-	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/testing/protoassert"
 	"go.temporal.io/server/tests/testcore"
@@ -177,12 +176,10 @@ func (s *ArchivalSuite) TestVisibilityArchival() {
 
 // workflowIsArchived asserts that both the workflow history and workflow visibility are archived.
 func (s *ArchivalSuite) workflowIsArchived(namespaceID namespace.ID, execution *commonpb.WorkflowExecution) {
-	serviceName := string(primitives.HistoryService)
 	historyURI, err := archiver.NewURI(s.GetTestCluster().ArchiverBase().HistoryURI())
 	s.NoError(err)
 	historyArchiver, err := s.GetTestCluster().ArchiverBase().Provider().GetHistoryArchiver(
 		historyURI.Scheme(),
-		serviceName,
 	)
 	s.NoError(err)
 
@@ -190,7 +187,6 @@ func (s *ArchivalSuite) workflowIsArchived(namespaceID namespace.ID, execution *
 	s.NoError(err)
 	visibilityArchiver, err := s.GetTestCluster().ArchiverBase().Provider().GetVisibilityArchiver(
 		visibilityURI.Scheme(),
-		serviceName,
 	)
 	s.NoError(err)
 

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -473,7 +473,7 @@ func newArchiverBase(enabled bool, executionManager persistence.ExecutionManager
 	if !enabled {
 		return &ArchiverBase{
 			metadata: archiver.NewArchivalMetadata(dcCollection, "", false, "", false, &config.ArchivalNamespaceDefaults{}),
-			provider: provider.NewArchiverProvider(nil, nil, nil, logger, metrics.NoopMetricsHandler, nil),
+			provider: provider.NewArchiverProvider(nil, nil, nil, logger, metrics.NoopMetricsHandler),
 		}
 	}
 
@@ -499,7 +499,6 @@ func newArchiverBase(enabled bool, executionManager persistence.ExecutionManager
 		executionManager,
 		logger,
 		metrics.NoopMetricsHandler,
-		nil,
 	)
 	return &ArchiverBase{
 		metadata: archiver.NewArchivalMetadata(dcCollection, "enabled", true, "enabled", true, &config.ArchivalNamespaceDefaults{

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -226,7 +226,7 @@ func newClusterWithPersistenceTestBaseFactory(t *testing.T, clusterConfig *TestC
 	testBase := tbFactory.NewTestBase(&clusterConfig.Persistence)
 
 	testBase.Setup(clusterMetadataConfig)
-	archiverBase := newArchiverBase(clusterConfig.EnableArchival, logger)
+	archiverBase := newArchiverBase(clusterConfig.EnableArchival, testBase.ExecutionManager, logger)
 
 	pConfig := testBase.DefaultTestCluster.Config()
 	pConfig.NumHistoryShards = clusterConfig.HistoryConfig.NumHistoryShards
@@ -468,7 +468,7 @@ func newPProfInitializerImpl(logger log.Logger, port int) *pprof.PProfInitialize
 	}
 }
 
-func newArchiverBase(enabled bool, logger log.Logger) *ArchiverBase {
+func newArchiverBase(enabled bool, executionManager persistence.ExecutionManager, logger log.Logger) *ArchiverBase {
 	dcCollection := dynamicconfig.NewNoopCollection()
 	if !enabled {
 		return &ArchiverBase{
@@ -496,7 +496,7 @@ func newArchiverBase(enabled bool, logger log.Logger) *ArchiverBase {
 		&config.VisibilityArchiverProvider{
 			Filestore: cfg,
 		},
-		nil,
+		executionManager,
 		logger,
 		metrics.NoopMetricsHandler,
 		nil,

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -28,6 +28,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership/static"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace/nsreplication"
 	"go.temporal.io/server/common/persistence"
@@ -472,7 +473,7 @@ func newArchiverBase(enabled bool, logger log.Logger) *ArchiverBase {
 	if !enabled {
 		return &ArchiverBase{
 			metadata: archiver.NewArchivalMetadata(dcCollection, "", false, "", false, &config.ArchivalNamespaceDefaults{}),
-			provider: provider.NewArchiverProvider(nil, nil),
+			provider: provider.NewArchiverProvider(nil, nil, nil, logger, metrics.NoopMetricsHandler, nil),
 		}
 	}
 
@@ -495,6 +496,10 @@ func newArchiverBase(enabled bool, logger log.Logger) *ArchiverBase {
 		&config.VisibilityArchiverProvider{
 			Filestore: cfg,
 		},
+		nil,
+		logger,
+		metrics.NoopMetricsHandler,
+		nil,
 	)
 	return &ArchiverBase{
 		metadata: archiver.NewArchivalMetadata(dcCollection, "enabled", true, "enabled", true, &config.ArchivalNamespaceDefaults{


### PR DESCRIPTION
## What changed?
Refactor how archival subsystem gets its dependencies to work better with fx:
- Remove service type maps (archivalProvider is already service-specific)
- Remove "bootstrap" structs and just pass around dependencies

## Why?
The service type maps were causing issues like #7631, and are unnecessary.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
