### PR TITLE
Cherry-pick cc0b0840b7631dfa40138acd3314933de2f5d776

### DIFF
--- a/api/replication/v1/message.pb.go
+++ b/api/replication/v1/message.pb.go
@@ -1889,6 +1889,7 @@ type VersionedTransitionArtifact struct {
 	StateAttributes isVersionedTransitionArtifact_StateAttributes `protobuf_oneof:"state_attributes"`
 	EventBatches    []*v11.DataBlob                               `protobuf:"bytes,3,rep,name=event_batches,json=eventBatches,proto3" json:"event_batches,omitempty"`
 	NewRunInfo      *NewRunInfo                                   `protobuf:"bytes,4,opt,name=new_run_info,json=newRunInfo,proto3" json:"new_run_info,omitempty"`
+	IsFirstSync     bool                                          `protobuf:"varint,5,opt,name=is_first_sync,json=isFirstSync,proto3" json:"is_first_sync,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -1960,6 +1961,13 @@ func (x *VersionedTransitionArtifact) GetNewRunInfo() *NewRunInfo {
 		return x.NewRunInfo
 	}
 	return nil
+}
+
+func (x *VersionedTransitionArtifact) GetIsFirstSync() bool {
+	if x != nil {
+		return x.IsFirstSync
+	}
+	return false
 }
 
 type isVersionedTransitionArtifact_StateAttributes interface {
@@ -2147,13 +2155,14 @@ const file_temporal_server_api_replication_v1_message_proto_rawDesc = "" +
 	"\fnamespace_id\x18\x06 \x01(\tR\vnamespaceId\x12\x1f\n" +
 	"\vworkflow_id\x18\a \x01(\tR\n" +
 	"workflowId\x12\x15\n" +
-	"\x06run_id\x18\b \x01(\tR\x05runIdJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05\"\x8e\x04\n" +
+	"\x06run_id\x18\b \x01(\tR\x05runIdJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05\"\xb2\x04\n" +
 	"\x1bVersionedTransitionArtifact\x12\x9f\x01\n" +
 	"'sync_workflow_state_mutation_attributes\x18\x01 \x01(\v2G.temporal.server.api.replication.v1.SyncWorkflowStateMutationAttributesH\x00R#syncWorkflowStateMutationAttributes\x12\x9f\x01\n" +
 	"'sync_workflow_state_snapshot_attributes\x18\x02 \x01(\v2G.temporal.server.api.replication.v1.SyncWorkflowStateSnapshotAttributesH\x00R#syncWorkflowStateSnapshotAttributes\x12E\n" +
 	"\revent_batches\x18\x03 \x03(\v2 .temporal.api.common.v1.DataBlobR\feventBatches\x12P\n" +
 	"\fnew_run_info\x18\x04 \x01(\v2..temporal.server.api.replication.v1.NewRunInfoR\n" +
-	"newRunInfoB\x12\n" +
+	"newRunInfo\x12\"\n" +
+	"\ris_first_sync\x18\x05 \x01(\bR\visFirstSyncB\x12\n" +
 	"\x10state_attributesB5Z3go.temporal.io/server/api/replication/v1;repicationb\x06proto3"
 
 var (

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -18,7 +18,7 @@ var (
 		"dynamicconfig.subscriptionCallback",
 		subscriptionCallbackSettings{
 			MinWorkers:   10,
-			MaxWorkers:   100,
+			MaxWorkers:   1e9, // effectively unlimited
 			TargetDelay:  10 * time.Millisecond,
 			ShrinkFactor: 1000, // 10 seconds
 		},

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2118,7 +2118,7 @@ the user has not specified an explicit RetryPolicy`,
 		`DefaultWorkflowRetryPolicy represents the out-of-box retry policy for unset fields
 where the user has set an explicit RetryPolicy, but not specified all the fields`,
 	)
-	FollowReusePolicyAfterConflictPolicyTerminate = NewNamespaceTypedSetting(
+	FollowReusePolicyAfterConflictPolicyTerminate = NewNamespaceBoolSetting(
 		"history.followReusePolicyAfterConflictPolicyTerminate",
 		true,
 		`Follows WorkflowIdReusePolicy RejectDuplicate and AllowDuplicateFailedOnly after WorkflowIdReusePolicy TerminateExisting was applied.
@@ -2427,6 +2427,13 @@ that task will be sent to DLQ.`,
 		"history.sendRawHistoryBetweenInternalServices",
 		false,
 		`SendRawHistoryBetweenInternalServices is whether to send raw history events between internal temporal services`,
+	)
+
+	// TODO(rodrigozhou): This is temporary dynamic config to be removed before the next release.
+	EnableRequestIdRefLinks = NewGlobalBoolSetting(
+		"history.enableRequestIdRefLinks",
+		false,
+		"Enable generating request ID reference links",
 	)
 
 	// keys for worker

--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -25,7 +25,7 @@ const (
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
-	ServerVersion = "1.28.0-133.0"
+	ServerVersion = "1.28.0-133.1"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"

--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -25,7 +25,7 @@ const (
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
-	ServerVersion = "1.28.0-133.2"
+	ServerVersion = "1.28.0-133.3"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"

--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -25,7 +25,7 @@ const (
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
-	ServerVersion = "1.27.0"
+	ServerVersion = "1.28.0-133.0"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"

--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -25,7 +25,7 @@ const (
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
-	ServerVersion = "1.28.0-133.1"
+	ServerVersion = "1.28.0-133.2"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -792,6 +792,9 @@ func (m *executionManagerImpl) readRawHistoryBranchAndFilter(
 		dataBlobs = make([]*commonpb.DataBlob, len(nodes))
 		for index, node := range nodes {
 			dataBlobs[index] = node.Events
+			if node.Events == nil {
+				return nil, nil, nil, nil, 0, serviceerror.NewDataLoss("no events in history node")
+			}
 			dataSize += len(node.Events.Data)
 			transactionIDs = append(transactionIDs, node.TransactionID)
 			nodeIDs = append(nodeIDs, node.NodeID)

--- a/common/testing/mocksdk/client_mock.go
+++ b/common/testing/mocksdk/client_mock.go
@@ -173,21 +173,6 @@ func (mr *MockClientMockRecorder) DescribeTaskQueueEnhanced(ctx, options any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTaskQueueEnhanced", reflect.TypeOf((*MockClient)(nil).DescribeTaskQueueEnhanced), ctx, options)
 }
 
-// DescribeWorkflow mocks base method.
-func (m *MockClient) DescribeWorkflow(ctx context.Context, workflowID, runID string) (*client.WorkflowExecutionDescription, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DescribeWorkflow", ctx, workflowID, runID)
-	ret0, _ := ret[0].(*client.WorkflowExecutionDescription)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DescribeWorkflow indicates an expected call of DescribeWorkflow.
-func (mr *MockClientMockRecorder) DescribeWorkflow(ctx, workflowID, runID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeWorkflow", reflect.TypeOf((*MockClient)(nil).DescribeWorkflow), ctx, workflowID, runID)
-}
-
 // DescribeWorkflowExecution mocks base method.
 func (m *MockClient) DescribeWorkflowExecution(ctx context.Context, workflowID, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
 	m.ctrl.T.Helper()

--- a/components/nexusoperations/completion.go
+++ b/components/nexusoperations/completion.go
@@ -177,6 +177,12 @@ func CompletionHandler(
 	if errors.As(err, new(*serviceerror.NotFound)) && isRetryableNotFoundErr && ref.WorkflowKey.RunID != "" {
 		// Try again without a run ID in case the original run was reset.
 		ref.WorkflowKey.RunID = ""
+		// VersionedTransition is for a specific run. After reset, the TransitionCount will
+		// start from 1 again. Reset the TransitionCount to 0 here to fallback to old ref
+		// validation logic.
+		ref.StateMachineRef.MutableStateVersionedTransition = nil
+		ref.StateMachineRef.MachineInitialVersionedTransition.TransitionCount = 0
+		ref.StateMachineRef.MachineLastUpdateVersionedTransition.TransitionCount = 0
 		return CompletionHandler(ctx, env, ref, requestID, operationToken, startTime, links, result, opFailedError)
 	}
 	return err

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -16,7 +16,6 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/sdk/temporalnexus"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common"
@@ -312,7 +311,7 @@ func (e taskExecutor) loadOperationArgs(
 		args.scheduleToCloseTimeout = event.GetNexusOperationScheduledEventAttributes().GetScheduleToCloseTimeout().AsDuration()
 		args.payload = event.GetNexusOperationScheduledEventAttributes().GetInput()
 		args.header = event.GetNexusOperationScheduledEventAttributes().GetNexusHeader()
-		args.nexusLink = temporalnexus.ConvertLinkWorkflowEventToNexusLink(&commonpb.Link_WorkflowEvent{
+		args.nexusLink = ConvertLinkWorkflowEventToNexusLink(&commonpb.Link_WorkflowEvent{
 			Namespace:  ns.Name().String(),
 			WorkflowId: ref.WorkflowKey.WorkflowID,
 			RunId:      ref.WorkflowKey.RunID,
@@ -348,7 +347,7 @@ func (e taskExecutor) saveResult(ctx context.Context, env hsm.Environment, ref h
 			for _, nexusLink := range result.Links {
 				switch nexusLink.Type {
 				case string((&commonpb.Link_WorkflowEvent{}).ProtoReflect().Descriptor().FullName()):
-					link, err := temporalnexus.ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
+					link, err := ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
 					if err != nil {
 						// TODO(rodrigozhou): links are non-essential for the execution of the workflow,
 						// so ignoring the error for now; we will revisit how to handle these errors later.

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -15,7 +15,6 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/converter"
-	"go.temporal.io/sdk/temporalnexus"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/backoff"
@@ -62,7 +61,7 @@ func TestProcessInvocationTask(t *testing.T) {
 			},
 		},
 	}
-	handlerNexusLink := temporalnexus.ConvertLinkWorkflowEventToNexusLink(handlerLink)
+	handlerNexusLink := nexusoperations.ConvertLinkWorkflowEventToNexusLink(handlerLink)
 
 	cases := []struct {
 		name                       string
@@ -86,7 +85,7 @@ func TestProcessInvocationTask(t *testing.T) {
 				require.Len(t, options.Links, 1)
 				var links []*commonpb.Link
 				for _, nexusLink := range options.Links {
-					link, err := temporalnexus.ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
+					link, err := nexusoperations.ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
 					require.NoError(t, err)
 					links = append(links, &commonpb.Link{
 						Variant: &commonpb.Link_WorkflowEvent_{

--- a/components/nexusoperations/frontend/handler.go
+++ b/components/nexusoperations/frontend/handler.go
@@ -20,7 +20,6 @@ import (
 	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/sdk/temporalnexus"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/cluster"
@@ -33,6 +32,7 @@ import (
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/rpc/interceptor"
+	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/service/frontend/configs"
 	"go.uber.org/fx"
 	"google.golang.org/grpc/credentials"
@@ -165,7 +165,7 @@ func (h *completionHandler) CompleteOperation(ctx context.Context, r *nexus.Comp
 	for _, nexusLink := range r.Links {
 		switch nexusLink.Type {
 		case string((&commonpb.Link_WorkflowEvent{}).ProtoReflect().Descriptor().FullName()):
-			link, err := temporalnexus.ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
+			link, err := nexusoperations.ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
 			if err != nil {
 				// TODO(rodrigozhou): links are non-essential for the execution of the workflow,
 				// so ignoring the error for now; we will revisit how to handle these errors later.

--- a/components/nexusoperations/link_converter.go
+++ b/components/nexusoperations/link_converter.go
@@ -1,0 +1,208 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// This file is duplicated in sdk-go/temporalnexus/link_converter.go.
+// Any changes here or there must be replicated. This is temporary until the
+// temporal repo updates to the most recent SDK version.
+
+package nexusoperations
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+)
+
+const (
+	urlSchemeTemporalKey = "temporal"
+	urlPathNamespaceKey  = "namespace"
+	urlPathWorkflowIDKey = "workflowID"
+	urlPathRunIDKey      = "runID"
+	urlPathTemplate      = "/namespaces/%s/workflows/%s/%s/history"
+
+	linkWorkflowEventReferenceTypeKey = "referenceType"
+	linkEventIDKey                    = "eventID"
+	linkEventTypeKey                  = "eventType"
+	linkRequestIDKey                  = "requestID"
+)
+
+var (
+	rePatternNamespace  = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathNamespaceKey)
+	rePatternWorkflowID = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathWorkflowIDKey)
+	rePatternRunID      = fmt.Sprintf(`(?P<%s>[^/]+)`, urlPathRunIDKey)
+	urlPathRE           = regexp.MustCompile(fmt.Sprintf(
+		`^/namespaces/%s/workflows/%s/%s/history$`,
+		rePatternNamespace,
+		rePatternWorkflowID,
+		rePatternRunID,
+	))
+	eventReferenceType     = string((&commonpb.Link_WorkflowEvent_EventReference{}).ProtoReflect().Descriptor().Name())
+	requestIDReferenceType = string((&commonpb.Link_WorkflowEvent_RequestIdReference{}).ProtoReflect().Descriptor().Name())
+)
+
+// ConvertLinkWorkflowEventToNexusLink converts a Link_WorkflowEvent type to Nexus Link.
+//
+// NOTE: Experimental
+func ConvertLinkWorkflowEventToNexusLink(we *commonpb.Link_WorkflowEvent) nexus.Link {
+	u := &url.URL{
+		Scheme: urlSchemeTemporalKey,
+		Path:   fmt.Sprintf(urlPathTemplate, we.GetNamespace(), we.GetWorkflowId(), we.GetRunId()),
+		RawPath: fmt.Sprintf(
+			urlPathTemplate,
+			url.PathEscape(we.GetNamespace()),
+			url.PathEscape(we.GetWorkflowId()),
+			url.PathEscape(we.GetRunId()),
+		),
+	}
+
+	switch ref := we.GetReference().(type) {
+	case *commonpb.Link_WorkflowEvent_EventRef:
+		u.RawQuery = convertLinkWorkflowEventEventReferenceToURLQuery(ref.EventRef)
+	case *commonpb.Link_WorkflowEvent_RequestIdRef:
+		u.RawQuery = convertLinkWorkflowEventRequestIdReferenceToURLQuery(ref.RequestIdRef)
+	}
+	return nexus.Link{
+		URL:  u,
+		Type: string(we.ProtoReflect().Descriptor().FullName()),
+	}
+}
+
+// ConvertNexusLinkToLinkWorkflowEvent converts a Nexus Link to Link_WorkflowEvent.
+//
+// NOTE: Experimental
+func ConvertNexusLinkToLinkWorkflowEvent(link nexus.Link) (*commonpb.Link_WorkflowEvent, error) {
+	we := &commonpb.Link_WorkflowEvent{}
+	if link.Type != string(we.ProtoReflect().Descriptor().FullName()) {
+		return nil, fmt.Errorf(
+			"cannot parse link type %q to %q",
+			link.Type,
+			we.ProtoReflect().Descriptor().FullName(),
+		)
+	}
+
+	if link.URL.Scheme != urlSchemeTemporalKey {
+		return nil, fmt.Errorf(
+			"failed to parse link to Link_WorkflowEvent: invalid scheme: %s",
+			link.URL.Scheme,
+		)
+	}
+
+	matches := urlPathRE.FindStringSubmatch(link.URL.EscapedPath())
+	if len(matches) != 4 {
+		return nil, errors.New("failed to parse link to Link_WorkflowEvent: malformed URL path")
+	}
+
+	var err error
+	we.Namespace, err = url.PathUnescape(matches[urlPathRE.SubexpIndex(urlPathNamespaceKey)])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse link to Link_WorkflowEvent: %w", err)
+	}
+
+	we.WorkflowId, err = url.PathUnescape(matches[urlPathRE.SubexpIndex(urlPathWorkflowIDKey)])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse link to Link_WorkflowEvent: %w", err)
+	}
+
+	we.RunId, err = url.PathUnescape(matches[urlPathRE.SubexpIndex(urlPathRunIDKey)])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse link to Link_WorkflowEvent: %w", err)
+	}
+
+	switch refType := link.URL.Query().Get(linkWorkflowEventReferenceTypeKey); refType {
+	case eventReferenceType:
+		eventRef, err := convertURLQueryToLinkWorkflowEventEventReference(link.URL.Query())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse link to Link_WorkflowEvent: %w", err)
+		}
+		we.Reference = &commonpb.Link_WorkflowEvent_EventRef{
+			EventRef: eventRef,
+		}
+	case requestIDReferenceType:
+		requestIDRef, err := convertURLQueryToLinkWorkflowEventRequestIdReference(link.URL.Query())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse link to Link_WorkflowEvent: %w", err)
+		}
+		we.Reference = &commonpb.Link_WorkflowEvent_RequestIdRef{
+			RequestIdRef: requestIDRef,
+		}
+	default:
+		return nil, fmt.Errorf(
+			"failed to parse link to Link_WorkflowEvent: unknown reference type: %q",
+			refType,
+		)
+	}
+
+	return we, nil
+}
+
+func convertLinkWorkflowEventEventReferenceToURLQuery(eventRef *commonpb.Link_WorkflowEvent_EventReference) string {
+	values := url.Values{}
+	values.Set(linkWorkflowEventReferenceTypeKey, eventReferenceType)
+	if eventRef.GetEventId() > 0 {
+		values.Set(linkEventIDKey, strconv.FormatInt(eventRef.GetEventId(), 10))
+	}
+	values.Set(linkEventTypeKey, eventRef.GetEventType().String())
+	return values.Encode()
+}
+
+func convertURLQueryToLinkWorkflowEventEventReference(queryValues url.Values) (*commonpb.Link_WorkflowEvent_EventReference, error) {
+	var err error
+	eventRef := &commonpb.Link_WorkflowEvent_EventReference{}
+	eventIDValue := queryValues.Get(linkEventIDKey)
+	if eventIDValue != "" {
+		eventRef.EventId, err = strconv.ParseInt(queryValues.Get(linkEventIDKey), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+	}
+	eventRef.EventType, err = enumspb.EventTypeFromString(queryValues.Get(linkEventTypeKey))
+	if err != nil {
+		return nil, err
+	}
+	return eventRef, nil
+}
+
+func convertLinkWorkflowEventRequestIdReferenceToURLQuery(requestIDRef *commonpb.Link_WorkflowEvent_RequestIdReference) string {
+	values := url.Values{}
+	values.Set(linkWorkflowEventReferenceTypeKey, requestIDReferenceType)
+	values.Set(linkRequestIDKey, requestIDRef.GetRequestId())
+	values.Set(linkEventTypeKey, requestIDRef.GetEventType().String())
+	return values.Encode()
+}
+
+func convertURLQueryToLinkWorkflowEventRequestIdReference(queryValues url.Values) (*commonpb.Link_WorkflowEvent_RequestIdReference, error) {
+	var err error
+	requestIDRef := &commonpb.Link_WorkflowEvent_RequestIdReference{
+		RequestId: queryValues.Get(linkRequestIDKey),
+	}
+	requestIDRef.EventType, err = enumspb.EventTypeFromString(queryValues.Get(linkEventTypeKey))
+	if err != nil {
+		return nil, err
+	}
+	return requestIDRef, nil
+}

--- a/components/nexusoperations/link_converter_test.go
+++ b/components/nexusoperations/link_converter_test.go
@@ -1,0 +1,471 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package nexusoperations_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/components/nexusoperations"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestConvertLinkWorkflowEventToNexusLink(t *testing.T) {
+	type testcase struct {
+		name      string
+		input     *commonpb.Link_WorkflowEvent
+		output    nexus.Link
+		outputURL string
+	}
+
+	cases := []testcase{
+		{
+			name: "valid",
+			input: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventId:   1,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+			output: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "eventID=1&eventType=WorkflowExecutionStarted&referenceType=EventReference",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			outputURL: "temporal:///namespaces/ns/workflows/wf-id/run-id/history?eventID=1&eventType=WorkflowExecutionStarted&referenceType=EventReference",
+		},
+		{
+			name: "valid with angle bracket",
+			input: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id>",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventId:   1,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+			output: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id>/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id%3E/run-id/history",
+					RawQuery: "eventID=1&eventType=WorkflowExecutionStarted&referenceType=EventReference",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			outputURL: "temporal:///namespaces/ns/workflows/wf-id%3E/run-id/history?eventID=1&eventType=WorkflowExecutionStarted&referenceType=EventReference",
+		},
+		{
+			name: "valid with slash",
+			input: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id/",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventId:   1,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+			output: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id//run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id%2F/run-id/history",
+					RawQuery: "eventID=1&eventType=WorkflowExecutionStarted&referenceType=EventReference",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			outputURL: "temporal:///namespaces/ns/workflows/wf-id%2F/run-id/history?eventID=1&eventType=WorkflowExecutionStarted&referenceType=EventReference",
+		},
+		{
+			name: "valid event id missing",
+			input: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+			output: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "eventType=WorkflowExecutionStarted&referenceType=EventReference",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			outputURL: "temporal:///namespaces/ns/workflows/wf-id/run-id/history?eventType=WorkflowExecutionStarted&referenceType=EventReference",
+		},
+		{
+			name: "valid request id",
+			input: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+					RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+						RequestId: "request-id",
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+					},
+				},
+			},
+			output: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "eventType=WorkflowExecutionOptionsUpdated&referenceType=RequestIdReference&requestID=request-id",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			outputURL: "temporal:///namespaces/ns/workflows/wf-id/run-id/history?eventType=WorkflowExecutionOptionsUpdated&referenceType=RequestIdReference&requestID=request-id",
+		},
+		{
+			name: "valid request id empty",
+			input: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+					RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+						RequestId: "",
+					},
+				},
+			},
+			output: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "eventType=Unspecified&referenceType=RequestIdReference&requestID=",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			outputURL: "temporal:///namespaces/ns/workflows/wf-id/run-id/history?eventType=Unspecified&referenceType=RequestIdReference&requestID=",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			output := nexusoperations.ConvertLinkWorkflowEventToNexusLink(tc.input)
+			require.Equal(t, tc.output, output)
+			require.Equal(t, tc.outputURL, output.URL.String())
+		})
+	}
+}
+
+func TestConvertNexusLinkToLinkWorkflowEvent(t *testing.T) {
+	type testcase struct {
+		name   string
+		input  nexus.Link
+		output *commonpb.Link_WorkflowEvent
+		errMsg string
+	}
+
+	cases := []testcase{
+		{
+			name: "valid long event type",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "referenceType=EventReference&eventID=1&eventType=EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			output: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventId:   1,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+		},
+		{
+			name: "valid short event type",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "referenceType=EventReference&eventID=1&eventType=WorkflowExecutionStarted",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			output: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventId:   1,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+		},
+		{
+			name: "valid with angle bracket",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id>/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id%2E/run-id/history",
+					RawQuery: "referenceType=EventReference&eventID=1&eventType=EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			output: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id>",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventId:   1,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+		},
+		{
+			name: "valid with slash",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id//run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id%2F/run-id/history",
+					RawQuery: "referenceType=EventReference&eventID=1&eventType=EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			output: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id/",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventId:   1,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+		},
+		{
+			name: "valid event id missing",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "referenceType=EventReference&eventID=&eventType=EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			output: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+		},
+		{
+			name: "invalid scheme",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "random",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "referenceType=EventReference&eventID=1&eventType=EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			errMsg: "failed to parse link to Link_WorkflowEvent",
+		},
+		{
+			name: "invalid path missing history",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/",
+					RawPath:  "/namespaces/ns/workflows/wf-id/run-id/",
+					RawQuery: "referenceType=EventReference&eventID=1&eventType=EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			errMsg: "failed to parse link to Link_WorkflowEvent",
+		},
+		{
+			name: "invalid path missing namespace",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces//workflows/wf-id/run-id/history",
+					RawPath:  "/namespaces//workflows/wf-id/run-id/history",
+					RawQuery: "referenceType=EventReference&eventID=1&eventType=EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			errMsg: "failed to parse link to Link_WorkflowEvent",
+		},
+		{
+			name: "invalid event type",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "referenceType=EventReference&eventID=1&eventType=EVENT_TYPE_INVALID",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			errMsg: "failed to parse link to Link_WorkflowEvent",
+		},
+		{
+			name: "valid request id long event type",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "referenceType=RequestIdReference&requestID=request-id&eventType=EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			output: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+					RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+						RequestId: "request-id",
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+					},
+				},
+			},
+		},
+		{
+			name: "valid request id short event type",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "referenceType=RequestIdReference&requestID=request-id&eventType=WorkflowExecutionOptionsUpdated",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			output: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+					RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+						RequestId: "request-id",
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+					},
+				},
+			},
+		},
+		{
+			name: "valid request id empty",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "referenceType=RequestIdReference&requestID=&eventType=EVENT_TYPE_UNSPECIFIED",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			output: &commonpb.Link_WorkflowEvent{
+				Namespace:  "ns",
+				WorkflowId: "wf-id",
+				RunId:      "run-id",
+				Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+					RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+						RequestId: "",
+						EventType: enumspb.EVENT_TYPE_UNSPECIFIED,
+					},
+				},
+			},
+		},
+		{
+			name: "invalid request id reference missing event type",
+			input: nexus.Link{
+				URL: &url.URL{
+					Scheme:   "temporal",
+					Path:     "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawPath:  "/namespaces/ns/workflows/wf-id/run-id/history",
+					RawQuery: "referenceType=RequestIdReference&requestID=",
+				},
+				Type: "temporal.api.common.v1.Link.WorkflowEvent",
+			},
+			errMsg: "failed to parse link to Link_WorkflowEvent",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := nexusoperations.ConvertNexusLinkToLinkWorkflowEvent(tc.input)
+			if tc.errMsg != "" {
+				require.ErrorContains(t, err, tc.errMsg)
+			} else {
+				require.NoError(t, err)
+				if diff := cmp.Diff(tc.output, output, protocmp.Transform()); diff != "" {
+					assert.Fail(t, "Proto mismatch (-want +got):\n", diff)
+				}
+			}
+		})
+	}
+}

--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -58,3 +58,5 @@ history.ReplicationEnableUpdateWithNewTaskMerge:
   - value: true
 history.hostLevelCacheMaxSize:
   - value: 8192
+history.enableTransitionHistory:
+  - value: true

--- a/config/dynamicconfig/development-sql.yaml
+++ b/config/dynamicconfig/development-sql.yaml
@@ -63,3 +63,5 @@ history.ReplicationEnableUpdateWithNewTaskMerge:
   - value: true
 history.hostLevelCacheMaxSize:
   - value: 8192
+history.enableTransitionHistory:
+  - value: true

--- a/config/dynamicconfig/development-xdc.yaml
+++ b/config/dynamicconfig/development-xdc.yaml
@@ -37,10 +37,9 @@ frontend.workerVersioningDataAPIs:
 frontend.workerVersioningWorkflowAPIs:
   - value: true
 system.enableNexus:
-  # enableNexus also controls transition history which can't be enabled now
-  - value: false 
+  - value: true
 component.nexusoperations.callback.endpoint.template:
-  - value: http://localhost:7243/api/v1/namespaces/{{.NamespaceName}}/nexus/callback
+  - value: http://localhost:7243/namespaces/{{.NamespaceName}}/nexus/callback
 component.callbacks.allowedAddresses:
   - value:
       - Pattern: "*"
@@ -48,4 +47,6 @@ component.callbacks.allowedAddresses:
 matching.queryWorkflowTaskTimeoutLogRate:
   - value: 1.0
 history.ReplicationEnableUpdateWithNewTaskMerge:
+  - value: true
+history.enableTransitionHistory:
   - value: true

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
 	go.temporal.io/api v1.49.0
-	go.temporal.io/sdk v1.34.1-0.20250501224827-5de51a1d0a6f
+	go.temporal.io/sdk v1.34.0
 	go.temporal.io/version v0.3.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/fx v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -387,8 +387,8 @@ go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
 go.temporal.io/api v1.49.0 h1:aL+zfrdZC6iRU0Lqc1Qds83oMEj1DwhmPUdfiIenGE4=
 go.temporal.io/api v1.49.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
-go.temporal.io/sdk v1.34.1-0.20250501224827-5de51a1d0a6f h1:LVXfyrcs7GWhF8RxGDqYQEaMR/94f0z+CbTXYL4y3mQ=
-go.temporal.io/sdk v1.34.1-0.20250501224827-5de51a1d0a6f/go.mod h1:V4mc7x+G/snAGyW9nwJYT8kPZZG8c4f+Dd2u4DK6UBs=
+go.temporal.io/sdk v1.34.0 h1:VLg/h6ny7GvLFVoQPqz2NcC93V9yXboQwblkRvZ1cZE=
+go.temporal.io/sdk v1.34.0/go.mod h1:iE4U5vFrH3asOhqpBBphpj9zNtw8btp8+MSaf5A0D3w=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
 go.temporal.io/version v0.3.0/go.mod h1:UA9S8/1LaKYae6TyD9NaPMJTZb911JcbqghI2CBSP78=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/proto/internal/temporal/server/api/replication/v1/message.proto
+++ b/proto/internal/temporal/server/api/replication/v1/message.proto
@@ -245,4 +245,5 @@ message VersionedTransitionArtifact {
     }
     repeated temporal.api.common.v1.DataBlob event_batches = 3;
     NewRunInfo new_run_info = 4;
+    bool is_first_sync = 5;
 }

--- a/service/history/api/getworkflowexecutionhistory/api.go
+++ b/service/history/api/getworkflowexecutionhistory/api.go
@@ -240,7 +240,16 @@ func Invoke(
 				if err != nil {
 					return nil, err
 				}
-				// since getHistory func will not return empty history, so the below is safe
+				// GetHistory func will not return empty history. Log workflow details if that is not the case
+				if len(history.Events) == 0 {
+					shardContext.GetLogger().Error(
+						"GetHistory returned empty history",
+						tag.WorkflowNamespaceID(namespaceID.String()),
+						tag.WorkflowID(execution.GetWorkflowId()),
+						tag.WorkflowRunID(execution.GetRunId()),
+					)
+					return nil, serviceerror.NewDataLoss("no events in workflow history")
+				}
 				history.Events = history.Events[len(history.Events)-1 : len(history.Events)]
 			}
 			continuationToken = nil

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -807,21 +807,24 @@ func (s *Starter) generateStartedEventRefLink(runID string) *commonpb.Link {
 }
 
 func (s *Starter) generateRequestIdRefLink(runID string) *commonpb.Link {
-	return &commonpb.Link{
-		Variant: &commonpb.Link_WorkflowEvent_{
-			WorkflowEvent: &commonpb.Link_WorkflowEvent{
-				Namespace:  s.namespace.Name().String(),
-				WorkflowId: s.request.StartRequest.WorkflowId,
-				RunId:      runID,
-				Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-					RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-						RequestId: s.request.StartRequest.RequestId,
-						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
-					},
-				},
-			},
-		},
-	}
+	// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
+	// Generate an EventReference for now.
+	return s.generateStartedEventRefLink(runID)
+	// return &commonpb.Link{
+	// 	Variant: &commonpb.Link_WorkflowEvent_{
+	// 		WorkflowEvent: &commonpb.Link_WorkflowEvent{
+	// 			Namespace:  s.namespace.Name().String(),
+	// 			WorkflowId: s.request.StartRequest.WorkflowId,
+	// 			RunId:      runID,
+	// 			Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+	// 				RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+	// 					RequestId: s.request.StartRequest.RequestId,
+	// 					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+	// 				},
+	// 			},
+	// 		},
+	// 	},
+	// }
 }
 
 func (s StartOutcome) String() string {

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -807,24 +807,21 @@ func (s *Starter) generateStartedEventRefLink(runID string) *commonpb.Link {
 }
 
 func (s *Starter) generateRequestIdRefLink(runID string) *commonpb.Link {
-	// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
-	// Generate an EventReference for now.
-	return s.generateStartedEventRefLink(runID)
-	// return &commonpb.Link{
-	// 	Variant: &commonpb.Link_WorkflowEvent_{
-	// 		WorkflowEvent: &commonpb.Link_WorkflowEvent{
-	// 			Namespace:  s.namespace.Name().String(),
-	// 			WorkflowId: s.request.StartRequest.WorkflowId,
-	// 			RunId:      runID,
-	// 			Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-	// 				RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-	// 					RequestId: s.request.StartRequest.RequestId,
-	// 					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
-	// 				},
-	// 			},
-	// 		},
-	// 	},
-	// }
+	return &commonpb.Link{
+		Variant: &commonpb.Link_WorkflowEvent_{
+			WorkflowEvent: &commonpb.Link_WorkflowEvent{
+				Namespace:  s.namespace.Name().String(),
+				WorkflowId: s.request.StartRequest.WorkflowId,
+				RunId:      runID,
+				Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+					RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+						RequestId: s.request.StartRequest.RequestId,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+					},
+				},
+			},
+		},
+	}
 }
 
 func (s StartOutcome) String() string {

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	EnableUpdateWorkflowModeIgnoreCurrent dynamicconfig.BoolPropertyFn
 	EnableTransitionHistory               dynamicconfig.BoolPropertyFn
 	MaxCallbacksPerWorkflow               dynamicconfig.IntPropertyFnWithNamespaceFilter
+	EnableRequestIdRefLinks               dynamicconfig.BoolPropertyFn
 
 	// EventsCache settings
 	// Change of these configs require shard restart
@@ -328,7 +329,7 @@ type Config struct {
 	EnableEagerWorkflowStart      dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	NamespaceCacheRefreshInterval dynamicconfig.DurationPropertyFn
 
-	FollowReusePolicyAfterConflictPolicyTerminate dynamicconfig.TypedPropertyFnWithNamespaceFilter[bool]
+	FollowReusePolicyAfterConflictPolicyTerminate dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
 	// ArchivalQueueProcessor settings
 	ArchivalProcessorSchedulerWorkerCount               dynamicconfig.TypedSubscribable[int]
@@ -418,6 +419,7 @@ func NewConfig(
 		EnableUpdateWorkflowModeIgnoreCurrent: dynamicconfig.EnableUpdateWorkflowModeIgnoreCurrent.Get(dc),
 		EnableTransitionHistory:               dynamicconfig.EnableTransitionHistory.Get(dc),
 		MaxCallbacksPerWorkflow:               dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
+		EnableRequestIdRefLinks:               dynamicconfig.EnableRequestIdRefLinks.Get(dc),
 
 		EventsShardLevelCacheMaxSizeBytes: dynamicconfig.EventsCacheMaxSizeBytes.Get(dc),          // 512KB
 		EventsHostLevelCacheMaxSizeBytes:  dynamicconfig.EventsHostLevelCacheMaxSizeBytes.Get(dc), // 256MB

--- a/service/history/hsm/tree.go
+++ b/service/history/hsm/tree.go
@@ -585,7 +585,7 @@ func MachineTransition[T any](n *Node, transitionFn func(T) (TransitionOutput, e
 		NamespaceFailoverVersion: n.backend.GetCurrentVersion(),
 		// The transition count for the backend is only incremented when closing the current transaction,
 		// but any change to state machine node is a state transtion,
-		// so we can safely using next transition count here is safe.
+		// so we can safely using next transition count here.
 		TransitionCount: n.backend.NextTransitionCount(),
 	}
 	// Rollback on error

--- a/service/history/ndc/workflow_state_replicator_test.go
+++ b/service/history/ndc/workflow_state_replicator_test.go
@@ -916,6 +916,7 @@ func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_FirstTask_Sy
 			},
 		},
 		EventBatches: []*commonpb.DataBlob{eventBatchBlob},
+		IsFirstSync:  true,
 	}
 	mockWeCtx := historyi.NewMockWorkflowContext(s.controller)
 	s.mockWorkflowCache.EXPECT().GetOrCreateWorkflowExecution(
@@ -1012,6 +1013,7 @@ func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_FirstTask_Sy
 			},
 		},
 		EventBatches: []*commonpb.DataBlob{eventBatchBlob},
+		IsFirstSync:  true,
 	}
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespace.ID(namespaceID)).Return(namespace.NewNamespaceForTest(
 		&persistencespb.NamespaceInfo{},

--- a/service/history/replication/sync_state_retriever.go
+++ b/service/history/replication/sync_state_retriever.go
@@ -147,7 +147,7 @@ func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifact(
 		}
 	}
 
-	return s.getSyncStateResult(ctx, namespaceID, execution, mutableState, targetCurrentVersionedTransition, versionHistoriesItems, releaseFunc)
+	return s.getSyncStateResult(ctx, namespaceID, execution, mutableState, targetCurrentVersionedTransition, versionHistoriesItems, releaseFunc, false)
 }
 
 func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifactFromMutableState(
@@ -159,7 +159,7 @@ func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifactFromMutableState(
 	targetVersionHistories [][]*historyspb.VersionHistoryItem,
 	releaseFunc historyi.ReleaseWorkflowContextFunc,
 ) (_ *SyncStateResult, retError error) {
-	return s.getSyncStateResult(ctx, namespaceID, execution, mu, targetCurrentVersionedTransition, targetVersionHistories, releaseFunc)
+	return s.getSyncStateResult(ctx, namespaceID, execution, mu, targetCurrentVersionedTransition, targetVersionHistories, releaseFunc, false)
 }
 
 func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifactFromMutableStateForNewWorkflow(
@@ -170,58 +170,11 @@ func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifactFromMutableStateFor
 	releaseFunc historyi.ReleaseWorkflowContextFunc,
 	taskVersionedTransition *persistencespb.VersionedTransition,
 ) (_ *SyncStateResult, retError error) {
-	versionedTransitionArtifact := &replicationspb.VersionedTransitionArtifact{}
-	mutation, err := s.getMutation(mu, workflow.EmptyVersionedTransition)
-	if err != nil {
-		return nil, err
+	targetVersionedTransition := &persistencespb.VersionedTransition{
+		NamespaceFailoverVersion: taskVersionedTransition.NamespaceFailoverVersion,
+		TransitionCount:          0,
 	}
-	versionedTransitionArtifact.StateAttributes = &replicationspb.VersionedTransitionArtifact_SyncWorkflowStateMutationAttributes{
-		SyncWorkflowStateMutationAttributes: &replicationspb.SyncWorkflowStateMutationAttributes{
-			StateMutation: mutation,
-			ExclusiveStartVersionedTransition: &persistencespb.VersionedTransition{
-				NamespaceFailoverVersion: taskVersionedTransition.NamespaceFailoverVersion,
-				TransitionCount:          0,
-			},
-		},
-	}
-
-	newRunId := mu.GetExecutionInfo().NewExecutionRunId
-	sourceVersionHistories := versionhistory.CopyVersionHistories(mu.GetExecutionInfo().VersionHistories)
-	sourceTransitionHistory := transitionhistory.CopyVersionedTransitions(mu.GetExecutionInfo().TransitionHistory)
-	if releaseFunc != nil {
-		releaseFunc(nil)
-	}
-	if len(newRunId) > 0 {
-		newRunInfo, err := s.getNewRunInfo(ctx, namespace.ID(namespaceID), execution, newRunId)
-		if err != nil {
-			return nil, err
-		}
-		versionedTransitionArtifact.NewRunInfo = newRunInfo
-	}
-	wfKey := definition.WorkflowKey{
-		NamespaceID: namespaceID,
-		WorkflowID:  execution.WorkflowId,
-		RunID:       execution.RunId,
-	}
-	sourceHistory, err := versionhistory.GetCurrentVersionHistory(sourceVersionHistories)
-	if err != nil {
-		return nil, err
-	}
-	sourceLastItem, err := versionhistory.GetLastVersionHistoryItem(sourceHistory)
-	if err != nil {
-		return nil, err
-	}
-	events, err := s.getEventsBlob(ctx, wfKey, sourceHistory, 1, sourceLastItem.GetEventId()+1, false)
-	if err != nil {
-		return nil, err
-	}
-	versionedTransitionArtifact.EventBatches = events
-	result := &SyncStateResult{
-		VersionedTransitionArtifact: versionedTransitionArtifact,
-		VersionedTransitionHistory:  sourceTransitionHistory,
-		SyncedVersionHistory:        sourceHistory,
-	}
-	return result, nil
+	return s.getSyncStateResult(ctx, namespaceID, execution, mu, targetVersionedTransition, nil, releaseFunc, true)
 }
 
 func (s *SyncStateRetrieverImpl) getSyncStateResult(
@@ -232,16 +185,20 @@ func (s *SyncStateRetrieverImpl) getSyncStateResult(
 	targetCurrentVersionedTransition *persistencespb.VersionedTransition,
 	targetVersionHistories [][]*historyspb.VersionHistoryItem,
 	cacheReleaseFunc historyi.ReleaseWorkflowContextFunc,
+	isNewWorkflow bool,
 ) (_ *SyncStateResult, retError error) {
 	shouldReturnMutation := func() bool {
 		if targetCurrentVersionedTransition == nil {
 			return false
 		}
+		tombstoneBatch := mutableState.GetExecutionInfo().SubStateMachineTombstoneBatches
+		if isNewWorkflow && len(tombstoneBatch) != 0 && tombstoneBatch[0].VersionedTransition.TransitionCount == 1 {
+			return true
+		}
 		// not on the same branch
 		if workflow.TransitionHistoryStalenessCheck(mutableState.GetExecutionInfo().TransitionHistory, targetCurrentVersionedTransition) != nil {
 			return false
 		}
-		tombstoneBatch := mutableState.GetExecutionInfo().SubStateMachineTombstoneBatches
 		if len(tombstoneBatch) == 0 {
 			return false
 		}
@@ -284,6 +241,7 @@ func (s *SyncStateRetrieverImpl) getSyncStateResult(
 			},
 		}
 	}
+	versionedTransitionArtifact.IsFirstSync = isNewWorkflow
 
 	newRunId := mutableState.GetExecutionInfo().NewExecutionRunId
 	sourceVersionHistories := versionhistory.CopyVersionHistories(mutableState.GetExecutionInfo().VersionHistories)
@@ -305,9 +263,26 @@ func (s *SyncStateRetrieverImpl) getSyncStateResult(
 		WorkflowID:  execution.WorkflowId,
 		RunID:       execution.RunId,
 	}
-	events, err := s.getSyncStateEvents(ctx, wfKey, targetVersionHistories, sourceVersionHistories)
-	if err != nil {
-		return nil, err
+	var events []*commonpb.DataBlob
+	var err error
+	if isNewWorkflow {
+		sourceHistory, err := versionhistory.GetCurrentVersionHistory(sourceVersionHistories)
+		if err != nil {
+			return nil, err
+		}
+		sourceLastItem, err := versionhistory.GetLastVersionHistoryItem(sourceHistory)
+		if err != nil {
+			return nil, err
+		}
+		events, err = s.getEventsBlob(ctx, wfKey, sourceHistory, 1, sourceLastItem.GetEventId()+1, false)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		events, err = s.getSyncStateEvents(ctx, wfKey, targetVersionHistories, sourceVersionHistories)
+		if err != nil {
+			return nil, err
+		}
 	}
 	versionedTransitionArtifact.EventBatches = events
 	result := &SyncStateResult{

--- a/service/history/replication/sync_state_retriever_test.go
+++ b/service/history/replication/sync_state_retriever_test.go
@@ -27,7 +27,6 @@ import (
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tests"
-	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
 	"go.uber.org/mock/gomock"
 )
@@ -278,6 +277,9 @@ func (s *syncWorkflowStateSuite) TestGetSyncStateRetrieverForNewWorkflow() {
 		},
 		SubStateMachineTombstoneBatches: []*persistencespb.StateMachineTombstoneBatch{
 			{
+				VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 1},
+			},
+			{
 				VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 12},
 			},
 		},
@@ -308,7 +310,10 @@ func (s *syncWorkflowStateSuite) TestGetSyncStateRetrieverForNewWorkflow() {
 	})
 	mu.EXPECT().HSM().Return(nil)
 	mockChasmTree := historyi.NewMockChasmTree(s.controller)
-	mockChasmTree.EXPECT().Snapshot(workflow.EmptyVersionedTransition).
+	mockChasmTree.EXPECT().Snapshot(&persistencespb.VersionedTransition{
+		NamespaceFailoverVersion: 1,
+		TransitionCount:          0,
+	}).
 		Return(chasm.NodesSnapshot{
 			Nodes: map[string]*persistencespb.ChasmNode{
 				"node-path": {

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -162,5 +162,6 @@ func NewDynamicConfig() *configs.Config {
 	config.NamespaceCacheRefreshInterval = dynamicconfig.GetDurationPropertyFn(time.Second)
 	config.ReplicationEnableUpdateWithNewTaskMerge = dynamicconfig.GetBoolPropertyFn(true)
 	config.EnableWorkflowIdReuseStartTimeValidation = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
+	config.EnableTransitionHistory = dynamicconfig.GetBoolPropertyFn(true)
 	return config
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -592,20 +592,22 @@ func (ms *MutableStateImpl) GetNexusCompletion(
 		// Backwards compatibility: this is the default link type.
 		Reference: &commonpb.Link_WorkflowEvent_EventRef{
 			EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+				EventId:   common.FirstEventID,
 				EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
 			},
 		},
 	}
-	requestIDInfo := ms.executionState.RequestIds[requestID]
-	if requestIDInfo.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED {
-		// If the callback was attached, then replace with RequestIdReference.
-		link.Reference = &commonpb.Link_WorkflowEvent_RequestIdRef{
-			RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-				RequestId: requestID,
-				EventType: requestIDInfo.GetEventType(),
-			},
-		}
-	}
+	// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
+	// requestIDInfo := ms.executionState.RequestIds[requestID]
+	// if requestIDInfo.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED {
+	// 	// If the callback was attached, then replace with RequestIdReference.
+	// 	link.Reference = &commonpb.Link_WorkflowEvent_RequestIdRef{
+	// 		RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+	// 			RequestId: requestID,
+	// 			EventType: requestIDInfo.GetEventType(),
+	// 		},
+	// 	}
+	// }
 	startLink := temporalnexus.ConvertLinkWorkflowEventToNexusLink(link)
 
 	switch ce.GetEventType() {

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -597,14 +597,16 @@ func (ms *MutableStateImpl) GetNexusCompletion(
 			},
 		},
 	}
-	requestIDInfo := ms.executionState.RequestIds[requestID]
-	if requestIDInfo.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED {
-		// If the callback was attached, then replace with RequestIdReference.
-		link.Reference = &commonpb.Link_WorkflowEvent_RequestIdRef{
-			RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-				RequestId: requestID,
-				EventType: requestIDInfo.GetEventType(),
-			},
+	if ms.config.EnableRequestIdRefLinks() {
+		requestIDInfo := ms.executionState.RequestIds[requestID]
+		if requestIDInfo.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED {
+			// If the callback was attached, then replace with RequestIdReference.
+			link.Reference = &commonpb.Link_WorkflowEvent_RequestIdRef{
+				RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+					RequestId: requestID,
+					EventType: requestIDInfo.GetEventType(),
+				},
+			}
 		}
 	}
 	startLink := nexusoperations.ConvertLinkWorkflowEventToNexusLink(link)

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -25,7 +25,6 @@ import (
 	updatepb "go.temporal.io/api/update/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
-	"go.temporal.io/sdk/temporalnexus"
 	clockspb "go.temporal.io/server/api/clock/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
@@ -58,6 +57,7 @@ import (
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/common/worker_versioning"
 	"go.temporal.io/server/components/callbacks"
+	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/events"
@@ -597,18 +597,17 @@ func (ms *MutableStateImpl) GetNexusCompletion(
 			},
 		},
 	}
-	// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
-	// requestIDInfo := ms.executionState.RequestIds[requestID]
-	// if requestIDInfo.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED {
-	// 	// If the callback was attached, then replace with RequestIdReference.
-	// 	link.Reference = &commonpb.Link_WorkflowEvent_RequestIdRef{
-	// 		RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-	// 			RequestId: requestID,
-	// 			EventType: requestIDInfo.GetEventType(),
-	// 		},
-	// 	}
-	// }
-	startLink := temporalnexus.ConvertLinkWorkflowEventToNexusLink(link)
+	requestIDInfo := ms.executionState.RequestIds[requestID]
+	if requestIDInfo.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED {
+		// If the callback was attached, then replace with RequestIdReference.
+		link.Reference = &commonpb.Link_WorkflowEvent_RequestIdRef{
+			RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+				RequestId: requestID,
+				EventType: requestIDInfo.GetEventType(),
+			},
+		}
+	}
+	startLink := nexusoperations.ConvertLinkWorkflowEventToNexusLink(link)
 
 	switch ce.GetEventType() {
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:

--- a/tests/admin_test.go
+++ b/tests/admin_test.go
@@ -11,6 +11,7 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/api/adminservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/tests/testcore"
 )
@@ -99,18 +100,23 @@ func (s *AdminTestSuite) TestAdminRebuildMutableState() {
 	s.Equal(response1.DatabaseMutableState.ExecutionInfo.VersionHistories, response2.DatabaseMutableState.ExecutionInfo.VersionHistories)
 	s.Equal(response1.DatabaseMutableState.ExecutionInfo.StateTransitionCount, response2.DatabaseMutableState.ExecutionInfo.StateTransitionCount)
 
-	// rebuild explicitly sets start time, thus start time will change after rebuild
 	s.Equal(response1.DatabaseMutableState.ExecutionState.CreateRequestId, response2.DatabaseMutableState.ExecutionState.CreateRequestId)
 	s.Equal(response1.DatabaseMutableState.ExecutionState.RunId, response2.DatabaseMutableState.ExecutionState.RunId)
 	s.Equal(response1.DatabaseMutableState.ExecutionState.State, response2.DatabaseMutableState.ExecutionState.State)
 	s.Equal(response1.DatabaseMutableState.ExecutionState.Status, response2.DatabaseMutableState.ExecutionState.Status)
-	s.Equal(response1.DatabaseMutableState.ExecutionState.LastUpdateVersionedTransition, response2.DatabaseMutableState.ExecutionState.LastUpdateVersionedTransition)
 
+	// From transition history perspective, Rebuild is considered as an update to the workflow and updates
+	// all sub state machines in the workflow, which includes the workflow ExecutionState.
+	s.Equal(&persistencespb.VersionedTransition{
+		NamespaceFailoverVersion: response1.DatabaseMutableState.ExecutionState.LastUpdateVersionedTransition.NamespaceFailoverVersion,
+		TransitionCount:          response1.DatabaseMutableState.ExecutionInfo.StateTransitionCount + 1,
+	}, response2.DatabaseMutableState.ExecutionState.LastUpdateVersionedTransition)
+
+	// Rebuild explicitly sets start time, thus start time will change after rebuild.
 	s.NotNil(response1.DatabaseMutableState.ExecutionState.StartTime)
 	s.NotNil(response2.DatabaseMutableState.ExecutionState.StartTime)
 
 	timeBefore := timestamp.TimeValue(response1.DatabaseMutableState.ExecutionState.StartTime)
 	timeAfter := timestamp.TimeValue(response2.DatabaseMutableState.ExecutionState.StartTime)
-
 	s.False(timeAfter.Before(timeBefore))
 }

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -22,12 +22,12 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
-	"go.temporal.io/sdk/temporalnexus"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	cnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/service/frontend/configs"
 	"go.temporal.io/server/tests/testcore"
 )
@@ -71,7 +71,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes() {
 			},
 		},
 	}
-	callerNexusLink := temporalnexus.ConvertLinkWorkflowEventToNexusLink(callerLink)
+	callerNexusLink := nexusoperations.ConvertLinkWorkflowEventToNexusLink(callerLink)
 
 	handlerLink := &commonpb.Link_WorkflowEvent{
 		Namespace:  "handler-ns",
@@ -84,7 +84,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes() {
 			},
 		},
 	}
-	handlerNexusLink := temporalnexus.ConvertLinkWorkflowEventToNexusLink(handlerLink)
+	handlerNexusLink := nexusoperations.ConvertLinkWorkflowEventToNexusLink(handlerLink)
 
 	type testcase struct {
 		name      string

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -215,7 +215,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion() {
 			},
 		},
 	}
-	handlerNexusLink := temporalnexus.ConvertLinkWorkflowEventToNexusLink(handlerLink)
+	handlerNexusLink := nexusoperations.ConvertLinkWorkflowEventToNexusLink(handlerLink)
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
@@ -460,7 +460,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion() {
 			},
 		},
 	}
-	handlerNexusLink := temporalnexus.ConvertLinkWorkflowEventToNexusLink(handlerLink)
+	handlerNexusLink := nexusoperations.ConvertLinkWorkflowEventToNexusLink(handlerLink)
 
 	h := nexustest.Handler{
 		OnStartOperation: func(
@@ -474,7 +474,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion() {
 			s.Len(options.Links, 1)
 			var links []*commonpb.Link
 			for _, nexusLink := range options.Links {
-				link, err := temporalnexus.ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
+				link, err := nexusoperations.ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
 				s.NoError(err)
 				links = append(links, &commonpb.Link{
 					Variant: &commonpb.Link_WorkflowEvent_{
@@ -928,19 +928,12 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionBeforeStart() 
 			Namespace:  s.Namespace().String(),
 			WorkflowId: completionWFID,
 			RunId:      completionWfRunIDs[1],
-			// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
-			Reference: &commonpb.Link_WorkflowEvent_EventRef{
-				EventRef: &commonpb.Link_WorkflowEvent_EventReference{
-					EventId:   common.FirstEventID,
-					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+			Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+				RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+					RequestId: completionWFStartRequestIDs[1],
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
 				},
 			},
-			// Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-			// 	RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-			// 		RequestId: completionWFStartRequestIDs[1],
-			// 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
-			// 	},
-			// },
 		},
 	}
 

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -758,6 +758,8 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletion() {
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionBeforeStart() {
+	s.OverrideDynamicConfig(dynamicconfig.EnableRequestIdRefLinks, true)
+
 	ctx := testcore.NewContext()
 	taskQueues := []string{testcore.RandomizeStr(s.T().Name()), testcore.RandomizeStr(s.T().Name())}
 	wfRuns := []client.WorkflowRun{}
@@ -2231,7 +2233,7 @@ func (s *NexusWorkflowTestSuite) TestNexusCallbackAfterCallerComplete() {
 		})
 		require.NoError(ct, err)
 		require.Len(ct, resp.Callbacks, 1)
-		require.Equal(ct, resp.Callbacks[0].State, enumspb.CALLBACK_STATE_FAILED)
+		require.Equal(ct, enumspb.CALLBACK_STATE_FAILED, resp.Callbacks[0].State)
 		require.NotNil(ct, resp.Callbacks[0].LastAttemptFailure)
 		require.Equal(ct, resp.Callbacks[0].LastAttemptFailure.Message, "handler error (NOT_FOUND): workflow execution already completed")
 	}, 3*time.Second, 200*time.Millisecond)

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -919,6 +919,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionBeforeStart() 
 			RunId:      completionWfRunIDs[0],
 			Reference: &commonpb.Link_WorkflowEvent_EventRef{
 				EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+					EventId:   common.FirstEventID,
 					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
 				},
 			},
@@ -927,12 +928,19 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionBeforeStart() 
 			Namespace:  s.Namespace().String(),
 			WorkflowId: completionWFID,
 			RunId:      completionWfRunIDs[1],
-			Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-				RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-					RequestId: completionWFStartRequestIDs[1],
-					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+			// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
+			Reference: &commonpb.Link_WorkflowEvent_EventRef{
+				EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+					EventId:   common.FirstEventID,
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
 				},
 			},
+			// Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+			// 	RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+			// 		RequestId: completionWFStartRequestIDs[1],
+			// 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+			// 	},
+			// },
 		},
 	}
 

--- a/tests/testcore/dynamic_config_overrides.go
+++ b/tests/testcore/dynamic_config_overrides.go
@@ -50,5 +50,6 @@ var (
 		dynamicconfig.EnableEagerWorkflowStart.Key():            true,
 		dynamicconfig.FrontendEnableExecuteMultiOperation.Key(): true,
 		dynamicconfig.ActivityAPIsEnabled.Key():                 true,
+		dynamicconfig.EnableTransitionHistory.Key():             true,
 	}
 )

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -20,7 +20,6 @@ import (
 	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/headers"
@@ -361,19 +360,12 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 					Namespace:  s.Namespace().String(),
 					WorkflowId: request.WorkflowId,
 					RunId:      we1.RunId,
-					// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
-					Reference: &commonpb.Link_WorkflowEvent_EventRef{
-						EventRef: &commonpb.Link_WorkflowEvent_EventReference{
-							EventId:   common.FirstEventID,
-							EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+						RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+							RequestId: request.RequestId,
+							EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
 						},
 					},
-					// Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-					// 	RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-					// 		RequestId: request.RequestId,
-					// 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
-					// 	},
-					// },
 				},
 				we1.Link.GetWorkflowEvent(),
 			)
@@ -492,19 +484,12 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 			Namespace:  s.Namespace().String(),
 			WorkflowId: request.WorkflowId,
 			RunId:      we1.RunId,
-			// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
-			Reference: &commonpb.Link_WorkflowEvent_EventRef{
-				EventRef: &commonpb.Link_WorkflowEvent_EventReference{
-					EventId:   common.FirstEventID,
-					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+			Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+				RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+					RequestId: request.RequestId,
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
 				},
 			},
-			// Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-			// 	RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-			// 		RequestId: request.RequestId,
-			// 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
-			// 	},
-			// },
 		},
 		we1.Link.GetWorkflowEvent(),
 	)
@@ -534,19 +519,12 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 			Namespace:  s.Namespace().String(),
 			WorkflowId: request.WorkflowId,
 			RunId:      we2.RunId,
-			// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
-			Reference: &commonpb.Link_WorkflowEvent_EventRef{
-				EventRef: &commonpb.Link_WorkflowEvent_EventReference{
-					EventId:   common.FirstEventID,
-					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+			Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+				RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+					RequestId: request.RequestId,
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
 				},
 			},
-			// Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-			// 	RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-			// 		RequestId: request.RequestId,
-			// 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
-			// 	},
-			// },
 		},
 		we2.Link.GetWorkflowEvent(),
 	)
@@ -671,19 +649,12 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 			Namespace:  s.Namespace().String(),
 			WorkflowId: request.WorkflowId,
 			RunId:      we2.RunId,
-			// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
-			Reference: &commonpb.Link_WorkflowEvent_EventRef{
-				EventRef: &commonpb.Link_WorkflowEvent_EventReference{
-					EventId:   common.FirstEventID,
-					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+			Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+				RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+					RequestId: request.RequestId,
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
 				},
 			},
-			// Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-			// 	RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-			// 		RequestId: request.RequestId,
-			// 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
-			// 	},
-			// },
 		},
 		we2.Link.GetWorkflowEvent(),
 	)

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -20,6 +20,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/headers"
@@ -360,12 +361,19 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 					Namespace:  s.Namespace().String(),
 					WorkflowId: request.WorkflowId,
 					RunId:      we1.RunId,
-					Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-						RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-							RequestId: request.RequestId,
-							EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+					// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
+					Reference: &commonpb.Link_WorkflowEvent_EventRef{
+						EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+							EventId:   common.FirstEventID,
+							EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
 						},
 					},
+					// Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+					// 	RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+					// 		RequestId: request.RequestId,
+					// 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+					// 	},
+					// },
 				},
 				we1.Link.GetWorkflowEvent(),
 			)
@@ -484,12 +492,19 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 			Namespace:  s.Namespace().String(),
 			WorkflowId: request.WorkflowId,
 			RunId:      we1.RunId,
-			Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-				RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-					RequestId: request.RequestId,
-					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+			// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
+			Reference: &commonpb.Link_WorkflowEvent_EventRef{
+				EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+					EventId:   common.FirstEventID,
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
 				},
 			},
+			// Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+			// 	RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+			// 		RequestId: request.RequestId,
+			// 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+			// 	},
+			// },
 		},
 		we1.Link.GetWorkflowEvent(),
 	)
@@ -519,12 +534,19 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 			Namespace:  s.Namespace().String(),
 			WorkflowId: request.WorkflowId,
 			RunId:      we2.RunId,
-			Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-				RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-					RequestId: request.RequestId,
-					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+			// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
+			Reference: &commonpb.Link_WorkflowEvent_EventRef{
+				EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+					EventId:   common.FirstEventID,
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
 				},
 			},
+			// Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+			// 	RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+			// 		RequestId: request.RequestId,
+			// 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+			// 	},
+			// },
 		},
 		we2.Link.GetWorkflowEvent(),
 	)
@@ -649,12 +671,19 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 			Namespace:  s.Namespace().String(),
 			WorkflowId: request.WorkflowId,
 			RunId:      we2.RunId,
-			Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-				RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-					RequestId: request.RequestId,
-					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+			// TODO(rodrigozhou): RequestIdReference depends on a new release of sdk-go.
+			Reference: &commonpb.Link_WorkflowEvent_EventRef{
+				EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+					EventId:   common.FirstEventID,
+					EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
 				},
 			},
+			// Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
+			// 	RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+			// 		RequestId: request.RequestId,
+			// 		EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
+			// 	},
+			// },
 		},
 		we2.Link.GetWorkflowEvent(),
 	)

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -198,6 +198,7 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting() {
 }
 
 func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOptions() {
+	s.OverrideDynamicConfig(dynamicconfig.EnableRequestIdRefLinks, true)
 	s.OverrideDynamicConfig(
 		callbacks.AllowedAddresses,
 		[]any{
@@ -440,6 +441,7 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 }
 
 func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOptions_Dedup() {
+	s.OverrideDynamicConfig(dynamicconfig.EnableRequestIdRefLinks, true)
 	tv := testvars.New(s.T())
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:          tv.RequestID(),
@@ -570,6 +572,7 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 }
 
 func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOptions_NoDedup() {
+	s.OverrideDynamicConfig(dynamicconfig.EnableRequestIdRefLinks, true)
 	tv := testvars.New(s.T())
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:          uuid.New(),


### PR DESCRIPTION
- **Handle no events in workflow history (#7703)**
- **Revert generating RequestIdReference links (#7705)**
- **Bump Server version to 1.28.0-133.0**
- **Copy nexus link converter from sdk-go (#7711)**
- **Dynamic config to enable generating request id reference links (#7712)**
- **Bump Server version to 1.28.0-133.1**
- **Remove cap for dynamic config callback pool (#7723)**
- **Bump Server version to 1.28.0-133.2**
- **Enable transition history in dev env and tests (#7737)**
- **Bump Server version to 1.28.0-133.3**
- **Fix State based replication first task handling (#7754)**

## What changed?
_Describe what has changed in this PR._

## Why?
_Tell your future self why have you made these changes._

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
