### PR TITLE
Cherry-pick cc0b0840b7631dfa40138acd3314933de2f5d776

### DIFF
--- a/api/replication/v1/message.pb.go
+++ b/api/replication/v1/message.pb.go
@@ -1889,6 +1889,7 @@ type VersionedTransitionArtifact struct {
 	StateAttributes isVersionedTransitionArtifact_StateAttributes `protobuf_oneof:"state_attributes"`
 	EventBatches    []*v11.DataBlob                               `protobuf:"bytes,3,rep,name=event_batches,json=eventBatches,proto3" json:"event_batches,omitempty"`
 	NewRunInfo      *NewRunInfo                                   `protobuf:"bytes,4,opt,name=new_run_info,json=newRunInfo,proto3" json:"new_run_info,omitempty"`
+	IsFirstSync     bool                                          `protobuf:"varint,5,opt,name=is_first_sync,json=isFirstSync,proto3" json:"is_first_sync,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -1960,6 +1961,13 @@ func (x *VersionedTransitionArtifact) GetNewRunInfo() *NewRunInfo {
 		return x.NewRunInfo
 	}
 	return nil
+}
+
+func (x *VersionedTransitionArtifact) GetIsFirstSync() bool {
+	if x != nil {
+		return x.IsFirstSync
+	}
+	return false
 }
 
 type isVersionedTransitionArtifact_StateAttributes interface {
@@ -2147,13 +2155,14 @@ const file_temporal_server_api_replication_v1_message_proto_rawDesc = "" +
 	"\fnamespace_id\x18\x06 \x01(\tR\vnamespaceId\x12\x1f\n" +
 	"\vworkflow_id\x18\a \x01(\tR\n" +
 	"workflowId\x12\x15\n" +
-	"\x06run_id\x18\b \x01(\tR\x05runIdJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05\"\x8e\x04\n" +
+	"\x06run_id\x18\b \x01(\tR\x05runIdJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05\"\xb2\x04\n" +
 	"\x1bVersionedTransitionArtifact\x12\x9f\x01\n" +
 	"'sync_workflow_state_mutation_attributes\x18\x01 \x01(\v2G.temporal.server.api.replication.v1.SyncWorkflowStateMutationAttributesH\x00R#syncWorkflowStateMutationAttributes\x12\x9f\x01\n" +
 	"'sync_workflow_state_snapshot_attributes\x18\x02 \x01(\v2G.temporal.server.api.replication.v1.SyncWorkflowStateSnapshotAttributesH\x00R#syncWorkflowStateSnapshotAttributes\x12E\n" +
 	"\revent_batches\x18\x03 \x03(\v2 .temporal.api.common.v1.DataBlobR\feventBatches\x12P\n" +
 	"\fnew_run_info\x18\x04 \x01(\v2..temporal.server.api.replication.v1.NewRunInfoR\n" +
-	"newRunInfoB\x12\n" +
+	"newRunInfo\x12\"\n" +
+	"\ris_first_sync\x18\x05 \x01(\bR\visFirstSyncB\x12\n" +
 	"\x10state_attributesB5Z3go.temporal.io/server/api/replication/v1;repicationb\x06proto3"
 
 var (

--- a/proto/internal/temporal/server/api/replication/v1/message.proto
+++ b/proto/internal/temporal/server/api/replication/v1/message.proto
@@ -245,4 +245,5 @@ message VersionedTransitionArtifact {
     }
     repeated temporal.api.common.v1.DataBlob event_batches = 3;
     NewRunInfo new_run_info = 4;
+    bool is_first_sync = 5;
 }

--- a/service/history/ndc/workflow_state_replicator_test.go
+++ b/service/history/ndc/workflow_state_replicator_test.go
@@ -916,6 +916,7 @@ func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_FirstTask_Sy
 			},
 		},
 		EventBatches: []*commonpb.DataBlob{eventBatchBlob},
+		IsFirstSync:  true,
 	}
 	mockWeCtx := historyi.NewMockWorkflowContext(s.controller)
 	s.mockWorkflowCache.EXPECT().GetOrCreateWorkflowExecution(
@@ -1012,6 +1013,7 @@ func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_FirstTask_Sy
 			},
 		},
 		EventBatches: []*commonpb.DataBlob{eventBatchBlob},
+		IsFirstSync:  true,
 	}
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespace.ID(namespaceID)).Return(namespace.NewNamespaceForTest(
 		&persistencespb.NamespaceInfo{},

--- a/service/history/replication/sync_state_retriever.go
+++ b/service/history/replication/sync_state_retriever.go
@@ -147,7 +147,7 @@ func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifact(
 		}
 	}
 
-	return s.getSyncStateResult(ctx, namespaceID, execution, mutableState, targetCurrentVersionedTransition, versionHistoriesItems, releaseFunc)
+	return s.getSyncStateResult(ctx, namespaceID, execution, mutableState, targetCurrentVersionedTransition, versionHistoriesItems, releaseFunc, false)
 }
 
 func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifactFromMutableState(
@@ -159,7 +159,7 @@ func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifactFromMutableState(
 	targetVersionHistories [][]*historyspb.VersionHistoryItem,
 	releaseFunc historyi.ReleaseWorkflowContextFunc,
 ) (_ *SyncStateResult, retError error) {
-	return s.getSyncStateResult(ctx, namespaceID, execution, mu, targetCurrentVersionedTransition, targetVersionHistories, releaseFunc)
+	return s.getSyncStateResult(ctx, namespaceID, execution, mu, targetCurrentVersionedTransition, targetVersionHistories, releaseFunc, false)
 }
 
 func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifactFromMutableStateForNewWorkflow(
@@ -170,58 +170,11 @@ func (s *SyncStateRetrieverImpl) GetSyncWorkflowStateArtifactFromMutableStateFor
 	releaseFunc historyi.ReleaseWorkflowContextFunc,
 	taskVersionedTransition *persistencespb.VersionedTransition,
 ) (_ *SyncStateResult, retError error) {
-	versionedTransitionArtifact := &replicationspb.VersionedTransitionArtifact{}
-	mutation, err := s.getMutation(mu, workflow.EmptyVersionedTransition)
-	if err != nil {
-		return nil, err
+	targetVersionedTransition := &persistencespb.VersionedTransition{
+		NamespaceFailoverVersion: taskVersionedTransition.NamespaceFailoverVersion,
+		TransitionCount:          0,
 	}
-	versionedTransitionArtifact.StateAttributes = &replicationspb.VersionedTransitionArtifact_SyncWorkflowStateMutationAttributes{
-		SyncWorkflowStateMutationAttributes: &replicationspb.SyncWorkflowStateMutationAttributes{
-			StateMutation: mutation,
-			ExclusiveStartVersionedTransition: &persistencespb.VersionedTransition{
-				NamespaceFailoverVersion: taskVersionedTransition.NamespaceFailoverVersion,
-				TransitionCount:          0,
-			},
-		},
-	}
-
-	newRunId := mu.GetExecutionInfo().NewExecutionRunId
-	sourceVersionHistories := versionhistory.CopyVersionHistories(mu.GetExecutionInfo().VersionHistories)
-	sourceTransitionHistory := transitionhistory.CopyVersionedTransitions(mu.GetExecutionInfo().TransitionHistory)
-	if releaseFunc != nil {
-		releaseFunc(nil)
-	}
-	if len(newRunId) > 0 {
-		newRunInfo, err := s.getNewRunInfo(ctx, namespace.ID(namespaceID), execution, newRunId)
-		if err != nil {
-			return nil, err
-		}
-		versionedTransitionArtifact.NewRunInfo = newRunInfo
-	}
-	wfKey := definition.WorkflowKey{
-		NamespaceID: namespaceID,
-		WorkflowID:  execution.WorkflowId,
-		RunID:       execution.RunId,
-	}
-	sourceHistory, err := versionhistory.GetCurrentVersionHistory(sourceVersionHistories)
-	if err != nil {
-		return nil, err
-	}
-	sourceLastItem, err := versionhistory.GetLastVersionHistoryItem(sourceHistory)
-	if err != nil {
-		return nil, err
-	}
-	events, err := s.getEventsBlob(ctx, wfKey, sourceHistory, 1, sourceLastItem.GetEventId()+1, false)
-	if err != nil {
-		return nil, err
-	}
-	versionedTransitionArtifact.EventBatches = events
-	result := &SyncStateResult{
-		VersionedTransitionArtifact: versionedTransitionArtifact,
-		VersionedTransitionHistory:  sourceTransitionHistory,
-		SyncedVersionHistory:        sourceHistory,
-	}
-	return result, nil
+	return s.getSyncStateResult(ctx, namespaceID, execution, mu, targetVersionedTransition, nil, releaseFunc, true)
 }
 
 func (s *SyncStateRetrieverImpl) getSyncStateResult(
@@ -232,16 +185,20 @@ func (s *SyncStateRetrieverImpl) getSyncStateResult(
 	targetCurrentVersionedTransition *persistencespb.VersionedTransition,
 	targetVersionHistories [][]*historyspb.VersionHistoryItem,
 	cacheReleaseFunc historyi.ReleaseWorkflowContextFunc,
+	isNewWorkflow bool,
 ) (_ *SyncStateResult, retError error) {
 	shouldReturnMutation := func() bool {
 		if targetCurrentVersionedTransition == nil {
 			return false
 		}
+		tombstoneBatch := mutableState.GetExecutionInfo().SubStateMachineTombstoneBatches
+		if isNewWorkflow && len(tombstoneBatch) != 0 && tombstoneBatch[0].VersionedTransition.TransitionCount == 1 {
+			return true
+		}
 		// not on the same branch
 		if workflow.TransitionHistoryStalenessCheck(mutableState.GetExecutionInfo().TransitionHistory, targetCurrentVersionedTransition) != nil {
 			return false
 		}
-		tombstoneBatch := mutableState.GetExecutionInfo().SubStateMachineTombstoneBatches
 		if len(tombstoneBatch) == 0 {
 			return false
 		}
@@ -284,6 +241,7 @@ func (s *SyncStateRetrieverImpl) getSyncStateResult(
 			},
 		}
 	}
+	versionedTransitionArtifact.IsFirstSync = isNewWorkflow
 
 	newRunId := mutableState.GetExecutionInfo().NewExecutionRunId
 	sourceVersionHistories := versionhistory.CopyVersionHistories(mutableState.GetExecutionInfo().VersionHistories)
@@ -305,9 +263,26 @@ func (s *SyncStateRetrieverImpl) getSyncStateResult(
 		WorkflowID:  execution.WorkflowId,
 		RunID:       execution.RunId,
 	}
-	events, err := s.getSyncStateEvents(ctx, wfKey, targetVersionHistories, sourceVersionHistories)
-	if err != nil {
-		return nil, err
+	var events []*commonpb.DataBlob
+	var err error
+	if isNewWorkflow {
+		sourceHistory, err := versionhistory.GetCurrentVersionHistory(sourceVersionHistories)
+		if err != nil {
+			return nil, err
+		}
+		sourceLastItem, err := versionhistory.GetLastVersionHistoryItem(sourceHistory)
+		if err != nil {
+			return nil, err
+		}
+		events, err = s.getEventsBlob(ctx, wfKey, sourceHistory, 1, sourceLastItem.GetEventId()+1, false)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		events, err = s.getSyncStateEvents(ctx, wfKey, targetVersionHistories, sourceVersionHistories)
+		if err != nil {
+			return nil, err
+		}
 	}
 	versionedTransitionArtifact.EventBatches = events
 	result := &SyncStateResult{

--- a/service/history/replication/sync_state_retriever_test.go
+++ b/service/history/replication/sync_state_retriever_test.go
@@ -27,7 +27,6 @@ import (
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tests"
-	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
 	"go.uber.org/mock/gomock"
 )
@@ -278,6 +277,9 @@ func (s *syncWorkflowStateSuite) TestGetSyncStateRetrieverForNewWorkflow() {
 		},
 		SubStateMachineTombstoneBatches: []*persistencespb.StateMachineTombstoneBatch{
 			{
+				VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 1},
+			},
+			{
 				VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 12},
 			},
 		},
@@ -308,7 +310,10 @@ func (s *syncWorkflowStateSuite) TestGetSyncStateRetrieverForNewWorkflow() {
 	})
 	mu.EXPECT().HSM().Return(nil)
 	mockChasmTree := historyi.NewMockChasmTree(s.controller)
-	mockChasmTree.EXPECT().Snapshot(workflow.EmptyVersionedTransition).
+	mockChasmTree.EXPECT().Snapshot(&persistencespb.VersionedTransition{
+		NamespaceFailoverVersion: 1,
+		TransitionCount:          0,
+	}).
 		Return(chasm.NodesSnapshot{
 			Nodes: map[string]*persistencespb.ChasmNode{
 				"node-path": {


### PR DESCRIPTION
Fix State based replication first task handling
Previously, we made an assumption that it is always safe to return
mutation for first replication task, but it is not true.
When there is replication lag, the workflow may make some progress and
tombstone batch is capped. If we still blindly return mutation,
completed statemachine may still looked pending on the passive side.
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

No risk, the feature is not launched yet.

## What changed?
_Describe what has changed in this PR._

## Why?
_Tell your future self why have you made these changes._

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
