### PR TITLE
CHASM: ComponentPointer support

### DIFF
--- a/chasm/context.go
+++ b/chasm/context.go
@@ -13,8 +13,8 @@ type Context interface {
 
 	// NOTE: component created in the current transaction won't have a ref
 	// this is a Ref to the component state at the start of the transition
-	RefC(Component) (ComponentRef, bool)
-	RefD(proto.Message) (ComponentRef, bool)
+	Ref(Component) (ComponentRef, error)
+	refData(proto.Message) (ComponentRef, error)
 	Now(Component) time.Time
 
 	// Intent() OperationIntent
@@ -31,13 +31,13 @@ type MutableContext interface {
 	// Add more methods here for other storage commands/primitives.
 	// e.g. HistoryEvent
 
-	// Get a RefC for the component
+	// Get a Ref for the component
 	// This ref to the component state at the end of the transition
-	// Same as RefC(Component) method in Context,
+	// Same as Ref(Component) method in Context,
 	// this only works for components that already exists at the start of the transition
 	//
 	// If we provide this method, then the method on the engine doesn't need to
-	// return a RefC
+	// return a Ref
 	// NewRef(Component) (ComponentRef, bool)
 }
 
@@ -63,12 +63,12 @@ func NewContext(
 	}
 }
 
-func (c *ContextImpl) RefC(component Component) (ComponentRef, bool) {
-	return c.root.RefC(component)
+func (c *ContextImpl) Ref(component Component) (ComponentRef, error) {
+	return c.root.Ref(component)
 }
 
-func (c *ContextImpl) RefD(data proto.Message) (ComponentRef, bool) {
-	return c.root.RefD(data)
+func (c *ContextImpl) refData(data proto.Message) (ComponentRef, error) {
+	return c.root.refData(data)
 }
 
 func (c *ContextImpl) Now(component Component) time.Time {

--- a/chasm/context.go
+++ b/chasm/context.go
@@ -13,8 +13,8 @@ type Context interface {
 
 	// NOTE: component created in the current transaction won't have a ref
 	// this is a Ref to the component state at the start of the transition
-	Ref(Component) (ComponentRef, bool)
-	DataRef(data proto.Message) (ComponentRef, bool)
+	RefC(Component) (ComponentRef, bool)
+	RefD(proto.Message) (ComponentRef, bool)
 	Now(Component) time.Time
 
 	// Intent() OperationIntent
@@ -31,13 +31,13 @@ type MutableContext interface {
 	// Add more methods here for other storage commands/primitives.
 	// e.g. HistoryEvent
 
-	// Get a Ref for the component
+	// Get a RefC for the component
 	// This ref to the component state at the end of the transition
-	// Same as Ref(Component) method in Context,
+	// Same as RefC(Component) method in Context,
 	// this only works for components that already exists at the start of the transition
 	//
 	// If we provide this method, then the method on the engine doesn't need to
-	// return a Ref
+	// return a RefC
 	// NewRef(Component) (ComponentRef, bool)
 }
 
@@ -63,12 +63,12 @@ func NewContext(
 	}
 }
 
-func (c *ContextImpl) Ref(component Component) (ComponentRef, bool) {
-	return c.root.Ref(component)
+func (c *ContextImpl) RefC(component Component) (ComponentRef, bool) {
+	return c.root.RefC(component)
 }
 
-func (c *ContextImpl) DataRef(data proto.Message) (ComponentRef, bool) {
-	return c.root.DataRef(data)
+func (c *ContextImpl) RefD(data proto.Message) (ComponentRef, bool) {
+	return c.root.RefD(data)
 }
 
 func (c *ContextImpl) Now(component Component) time.Time {

--- a/chasm/context.go
+++ b/chasm/context.go
@@ -3,6 +3,8 @@ package chasm
 import (
 	"context"
 	"time"
+
+	"google.golang.org/protobuf/proto"
 )
 
 type Context interface {
@@ -12,6 +14,7 @@ type Context interface {
 	// NOTE: component created in the current transaction won't have a ref
 	// this is a Ref to the component state at the start of the transition
 	Ref(Component) (ComponentRef, bool)
+	DataRef(data proto.Message) (ComponentRef, bool)
 	Now(Component) time.Time
 
 	// Intent() OperationIntent
@@ -62,6 +65,10 @@ func NewContext(
 
 func (c *ContextImpl) Ref(component Component) (ComponentRef, bool) {
 	return c.root.Ref(component)
+}
+
+func (c *ContextImpl) DataRef(data proto.Message) (ComponentRef, bool) {
+	return c.root.DataRef(data)
 }
 
 func (c *ContextImpl) Now(component Component) time.Time {

--- a/chasm/field.go
+++ b/chasm/field.go
@@ -44,25 +44,27 @@ func NewComponentField[C Component](
 	}
 }
 
-func ComponentPointerFor[C Component](
+func ComponentPointerTo[C Component](
 	ctx MutableContext,
 	c C,
 ) (Field[C], error) {
-	path, exists := ctx.Ref(c)
+	path, exists := ctx.RefC(c)
 	if !exists {
-		return NewEmptyField[C](), serviceerror.NewInvalidArgumentf("component field is not found")
+		// TODO: ctx.RefC should return error message which should be just propagated here.
+		return NewEmptyField[C](), serviceerror.NewInvalidArgument("component field is not found")
 	}
 	return Field[C]{
 		Internal: newFieldInternalWithValue(fieldTypePointer, path.componentPath),
 	}, nil
 }
 
-func DataPointerFor[D proto.Message](
+func DataPointerTo[D proto.Message](
 	ctx MutableContext,
 	d D,
 ) (Field[D], error) {
-	path, exists := ctx.DataRef(d)
+	path, exists := ctx.RefD(d)
 	if !exists {
+		// TODO: ctx.RefD should return error message which should be just propagated here.
 		return NewEmptyField[D](), serviceerror.NewInvalidArgumentf("data field is not found")
 	}
 	return Field[D]{

--- a/chasm/field.go
+++ b/chasm/field.go
@@ -50,7 +50,7 @@ func NewComponentPointerField[C Component](
 ) Field[C] {
 	path, exists := ctx.Ref(c)
 	if !exists {
-		// TODO (alex): error?
+		// TODO (alex): It is better return error here but constructors shouldn't return errors.
 		return NewEmptyField[C]()
 	}
 	return Field[C]{
@@ -62,7 +62,7 @@ func NewDataPointerField[D proto.Message](
 	ctx MutableContext,
 	d D,
 ) Field[D] {
-	// TODO (alex): this needs to be implmeted somehow too
+	// TODO (alex): this needs to be implemented somehow too.
 	//nolint:forbidigo
 	panic("not implemented")
 }

--- a/chasm/field_type.go
+++ b/chasm/field_type.go
@@ -5,6 +5,6 @@ type fieldType int
 const (
 	fieldTypeUnspecified fieldType = iota
 	fieldTypeComponent
-	fieldTypeComponentPointer
+	fieldTypePointer
 	fieldTypeData
 )

--- a/chasm/test_component_test.go
+++ b/chasm/test_component_test.go
@@ -20,12 +20,13 @@ type (
 	TestComponent    struct {
 		UnimplementedComponent
 
-		ComponentData     *protoMessageType
-		SubComponent1     Field[*TestSubComponent1]
-		SubComponent2     Field[*TestSubComponent2]
-		SubData1          Field[*protoMessageType]
-		SubComponents     Map[string, *TestSubComponent1]
-		PendingActivities Map[int, *TestSubComponent1]
+		ComponentData         *protoMessageType
+		SubComponent1         Field[*TestSubComponent1]
+		SubComponent2         Field[*TestSubComponent2]
+		SubData1              Field[*protoMessageType]
+		SubComponents         Map[string, *TestSubComponent1]
+		PendingActivities     Map[int, *TestSubComponent1]
+		SubComponent11Pointer Field[*TestSubComponent11]
 	}
 
 	TestSubComponent1 struct {

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -375,8 +375,7 @@ func (n *Node) preparePointerValue(
 }
 
 func (n *Node) findNode(path []string) *Node {
-	if len(path) == 0 {
-		// shouldn't happen. softassert?
+	if !softassert.That(n.logger, len(path) > 0, "path must have at least one element") {
 		return nil
 	}
 
@@ -845,8 +844,9 @@ func (n *Node) serializeCollectionNode() error {
 func (n *Node) serializePointerNode() error {
 	path, isPathValid := n.value.([]string)
 	if !isPathValid {
-		// TODO (alex): may be not needed. it must be always be []string
-		return serviceerror.NewInternal(fmt.Sprintf("pointer path is not []string but %T", n.value))
+		msg := fmt.Sprintf("pointer path is not []string but %T for node %s", n.value, n.nodeName)
+		softassert.Fail(n.logger, msg)
+		return serviceerror.NewInternal(msg)
 	}
 
 	// TODO: should it go to Data instead ???

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -842,6 +842,7 @@ func (n *Node) serializeCollectionNode() error {
 	return nil
 }
 
+// serializePointerNode doesn't serialize anything but named this way for consistency.
 func (n *Node) serializePointerNode() error {
 	path, isPathValid := n.value.([]string)
 	if !isPathValid {
@@ -965,6 +966,7 @@ func (n *Node) deserializeDataNode(
 	return nil
 }
 
+// deserializePointerNode doesn't deserialize anything but named this way for consistency.
 func (n *Node) deserializePointerNode() error {
 	n.value = n.serializedNode.GetMetadata().GetPointerAttributes().GetNodePath()
 	n.valueState = valueStateSynced

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -430,6 +430,93 @@ func (s *nodeSuite) TestCollectionAttributes() {
 	}
 }
 
+func (s *nodeSuite) TestPointerAttributes() {
+	tv := testvars.New(s.T())
+
+	s.nodeBackend.EXPECT().NextTransitionCount().Return(int64(1)).AnyTimes()
+	s.nodeBackend.EXPECT().GetCurrentVersion().Return(int64(1)).AnyTimes()
+	s.nodeBackend.EXPECT().UpdateWorkflowStateStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	s.nodeBackend.EXPECT().GetWorkflowKey().Return(tv.Any().WorkflowKey()).AnyTimes()
+
+	var persistedNodes map[string]*persistencespb.ChasmNode
+
+	sc11 := &TestSubComponent11{
+		SubComponent11Data: &protoMessageType{
+			RunId: tv.WithWorkflowIDNumber(11).WorkflowID(),
+		},
+	}
+
+	s.Run("Sync and serialize component with pointer", func() {
+		var nilSerializedNodes map[string]*persistencespb.ChasmNode
+		rootNode, err := NewTree(nilSerializedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger)
+		s.NoError(err)
+
+		sc1 := &TestSubComponent1{
+			SubComponent1Data: &protoMessageType{
+				RunId: tv.WithWorkflowIDNumber(1).WorkflowID(),
+			},
+			SubComponent11: NewComponentField[*TestSubComponent11](nil, sc11),
+		}
+
+		rootComponent := &TestComponent{
+			SubComponent1: NewComponentField[*TestSubComponent1](nil, sc1),
+		}
+
+		rootNode.value = rootComponent
+		rootNode.valueState = valueStateNeedSerialize
+
+		ctx := NewMutableContext(context.Background(), rootNode)
+		rootComponent.SubComponent11Pointer, err = ComponentPointerTo(ctx, sc11)
+		s.NoError(err)
+		s.Equal([]string{"SubComponent1", "SubComponent11"}, rootComponent.SubComponent11Pointer.Internal.v)
+
+		mutations, err := rootNode.CloseTransaction()
+		s.NoError(err)
+		s.Len(mutations.UpdatedNodes, 4, "root, SubComponent1, SubComponent11, and SubComponent11Pointer must be updated")
+		s.Empty(mutations.DeletedNodes)
+
+		s.Equal([]string{"SubComponent1", "SubComponent11"}, rootNode.children["SubComponent11Pointer"].serializedNode.GetMetadata().GetPointerAttributes().GetNodePath())
+
+		// Save it use in other subtests.
+		persistedNodes = common.CloneProtoMap(mutations.UpdatedNodes)
+	})
+
+	s.NotNil(persistedNodes)
+
+	s.Run("Deserialize pointer component", func() {
+		rootNode, err := NewTree(persistedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger)
+		s.NoError(err)
+
+		err = rootNode.deserialize(reflect.TypeFor[*TestComponent]())
+		s.NoError(err)
+
+		rootComponent := rootNode.value.(*TestComponent)
+
+		chasmContext := NewMutableContext(context.Background(), rootNode)
+		sc11Des, err := rootComponent.SubComponent11Pointer.Get(chasmContext)
+		s.NoError(err)
+		s.NotNil(sc11Des)
+		s.Equal(sc11.SubComponent11Data.GetRunId(), sc11Des.SubComponent11Data.GetRunId())
+	})
+
+	s.Run("Clear pointer by setting it to the empty field", func() {
+		rootNode, err := NewTree(persistedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger)
+		s.NoError(err)
+
+		err = rootNode.deserialize(reflect.TypeFor[*TestComponent]())
+		s.NoError(err)
+
+		rootComponent := rootNode.value.(*TestComponent)
+
+		rootComponent.SubComponent11Pointer = NewEmptyField[*TestSubComponent11]()
+
+		mutation, err := rootNode.CloseTransaction()
+		s.NoError(err)
+		s.Empty(mutation.UpdatedNodes, "no nodes should be updated")
+		s.Len(mutation.DeletedNodes, 1, "SubComponent11Pointer must be deleted")
+	})
+}
+
 func (s *nodeSuite) TestSyncSubComponents_DeleteLeafNode() {
 	node := s.testComponentTree()
 

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -1227,7 +1227,7 @@ func (s *nodeSuite) TestGetComponent() {
 			if tc.expectedErr == nil {
 				// s.Equal(tc.expectedComponent, component)
 
-				node, ok := root.getNodeByPath(tc.ref.componentPath)
+				node, ok := root.findNode(tc.ref.componentPath)
 				s.True(ok)
 				s.Equal(component, node.value)
 				s.Equal(tc.valueState, node.valueState)

--- a/service/history/chasm_engine.go
+++ b/service/history/chasm_engine.go
@@ -85,7 +85,7 @@ func (e *ChasmEngine) UpdateComponent(
 		return chasm.ComponentRef{}, err
 	}
 
-	newRef, ok := mutableContext.RefC(component)
+	newRef, ok := mutableContext.Ref(component)
 	if !ok {
 		return chasm.ComponentRef{}, serviceerror.NewInternal(
 			fmt.Sprintf("component not found in the new component tree after mutation, componentRef: %+v", ref),

--- a/service/history/chasm_engine.go
+++ b/service/history/chasm_engine.go
@@ -3,7 +3,6 @@ package history
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
@@ -57,12 +56,10 @@ func (e *ChasmEngine) UpdateComponent(
 	mutableState := executionLease.GetMutableState()
 	chasmTree, ok := mutableState.ChasmTree().(*chasm.Node)
 	if !ok {
-		return chasm.ComponentRef{}, serviceerror.NewInternal(
-			fmt.Sprintf(
-				"CHASM tree implementation not properly wired up, encountered type: %T, expected type: %T",
-				mutableState.ChasmTree(),
-				&chasm.Node{},
-			),
+		return chasm.ComponentRef{}, serviceerror.NewInternalf(
+			"CHASM tree implementation not properly wired up, encountered type: %T, expected type: %T",
+			mutableState.ChasmTree(),
+			&chasm.Node{},
 		)
 	}
 
@@ -85,11 +82,9 @@ func (e *ChasmEngine) UpdateComponent(
 		return chasm.ComponentRef{}, err
 	}
 
-	newRef, ok := mutableContext.Ref(component)
-	if !ok {
-		return chasm.ComponentRef{}, serviceerror.NewInternal(
-			fmt.Sprintf("component not found in the new component tree after mutation, componentRef: %+v", ref),
-		)
+	newRef, err := mutableContext.Ref(component)
+	if err != nil {
+		return chasm.ComponentRef{}, serviceerror.NewInternalf("componentRef: %+v: %s", ref, err)
 	}
 
 	return newRef, nil
@@ -113,12 +108,10 @@ func (e *ChasmEngine) ReadComponent(
 
 	chasmTree, ok := executionLease.GetMutableState().ChasmTree().(*chasm.Node)
 	if !ok {
-		return serviceerror.NewInternal(
-			fmt.Sprintf(
-				"CHASM tree implementation not properly wired up, encountered type: %T, expected type: %T",
-				executionLease.GetMutableState().ChasmTree(),
-				&chasm.Node{},
-			),
+		return serviceerror.NewInternalf(
+			"CHASM tree implementation not properly wired up, encountered type: %T, expected type: %T",
+			executionLease.GetMutableState().ChasmTree(),
+			&chasm.Node{},
 		)
 	}
 

--- a/service/history/chasm_engine.go
+++ b/service/history/chasm_engine.go
@@ -85,7 +85,7 @@ func (e *ChasmEngine) UpdateComponent(
 		return chasm.ComponentRef{}, err
 	}
 
-	newRef, ok := mutableContext.Ref(component)
+	newRef, ok := mutableContext.RefC(component)
 	if !ok {
 		return chasm.ComponentRef{}, serviceerror.NewInternal(
 			fmt.Sprintf("component not found in the new component tree after mutation, componentRef: %+v", ref),

--- a/service/history/chasm_engine_test.go
+++ b/service/history/chasm_engine_test.go
@@ -165,7 +165,7 @@ func (s *chasmEngineSuite) TestUpdateComponent_Success() {
 		},
 	).Times(1)
 
-	// TODO: validate returned component once RefC() method of chasm tree is implememented.
+	// TODO: validate returned component once Ref() method of chasm tree is implememented.
 	_, err := s.engine.UpdateComponent(
 		context.Background(),
 		ref,

--- a/service/history/chasm_engine_test.go
+++ b/service/history/chasm_engine_test.go
@@ -165,7 +165,7 @@ func (s *chasmEngineSuite) TestUpdateComponent_Success() {
 		},
 	).Times(1)
 
-	// TODO: validate returned component once Ref() method of chasm tree is implememented.
+	// TODO: validate returned component once RefC() method of chasm tree is implememented.
 	_, err := s.engine.UpdateComponent(
 		context.Background(),
 		ref,


### PR DESCRIPTION
## What changed?
CHASM: Add basic `ComponentPointer` support to CHASM component.

## Why?
Part of CHASM workstream. Few things are still pending:
1. `RefC` and `RefD` should return error.
2. Implementation of `RefC` and `RefD` needs to be revisited. It is not clear if it is possible to implement w/o deserializing entire component starting from root and all the way down, because `n.value` is needed to compare with passed argument.
3. Dangling pointers protection is not implemented.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
