### PR TITLE
Add metrics for suspected deadlocks

### DIFF
--- a/common/deadlock/deadlock.go
+++ b/common/deadlock/deadlock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"runtime/pprof"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"go.temporal.io/server/common/clock"
@@ -45,6 +46,9 @@ type (
 		roots          []pingable.Pingable
 		pools          []*goro.AdaptivePool
 		loops          goro.Group
+
+		// number of suspected deadlocks that have not resolved yet
+		current atomic.Int64
 	}
 
 	loopContext struct {
@@ -53,6 +57,11 @@ type (
 		p    *goro.AdaptivePool
 	}
 )
+
+// CurrentSuspected returns the number of currently unresolved suspected deadlocks.
+func (dd *deadlockDetector) CurrentSuspected() int64 {
+	return dd.current.Load()
+}
 
 func NewDeadlockDetector(params params) *deadlockDetector {
 	return &deadlockDetector{
@@ -136,6 +145,11 @@ func (dd *deadlockDetector) dumpGoroutines() {
 	dd.logger.Info(b.String())
 }
 
+func (dd *deadlockDetector) adjustCurrent(delta int64) {
+	dd.current.Add(delta)
+	metrics.DDCurrentSuspectedDeadlocks.With(dd.metricsHandler).Record(float64(dd.current.Load()))
+}
+
 func (lc *loopContext) run(ctx context.Context) error {
 	for {
 		// ping blocks until it has passed all checks to a worker goroutine (using an
@@ -163,6 +177,7 @@ func (lc *loopContext) ping(ctx context.Context, pingables []pingable.Pingable) 
 func (lc *loopContext) check(ctx context.Context, check pingable.Check) {
 	lc.dd.logger.Debug("starting ping check", tag.Name(check.Name))
 	startTime := time.Now().UTC()
+	resolved := make(chan struct{})
 
 	// Using AfterFunc is cheaper than creating another goroutine to be the waiter, since
 	// we expect to always cancel it. If the go runtime is so messed up that it can't
@@ -172,13 +187,21 @@ func (lc *loopContext) check(ctx context.Context, check pingable.Check) {
 			// deadlock detector was stopped
 			return
 		}
+		lc.dd.adjustCurrent(1)
+
 		lc.dd.detected(check.Name)
+
+		// Wait and see if Ping() returns past the timeout. If it's a true deadlock, it'll
+		// block here forever.
+		<-resolved
+		lc.dd.adjustCurrent(-1)
 	})
 	newPingables := check.Ping()
 	t.Stop()
 	if len(check.MetricsName) > 0 {
 		lc.dd.metricsHandler.Timer(check.MetricsName).Record(time.Since(startTime))
 	}
+	close(resolved)
 
 	lc.dd.logger.Debug("ping check succeeded", tag.Name(check.Name))
 

--- a/common/deadlock/deadlock.go
+++ b/common/deadlock/deadlock.go
@@ -102,6 +102,8 @@ func (dd *deadlockDetector) Stop() error {
 func (dd *deadlockDetector) detected(name string) {
 	dd.logger.Error("potential deadlock detected", tag.Name(name))
 
+	metrics.DDSuspectedDeadlocks.With(dd.metricsHandler).Record(1)
+
 	if dd.config.DumpGoroutines() {
 		dd.dumpGoroutines()
 	}

--- a/common/deadlock/deadlock_test.go
+++ b/common/deadlock/deadlock_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -49,8 +50,9 @@ func TestCurrentCounterAndGauge(t *testing.T) {
 	capture := mh.StartCapture()
 	go lc.check(context.Background(), check)
 
-	time.Sleep(20 * time.Millisecond)
-	require.Equal(t, int64(1), dd.CurrentSuspected())
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.Equal(collect, int64(1), dd.CurrentSuspected())
+	}, time.Second, time.Millisecond)
 
 	snapshot := capture.Snapshot()
 	current := snapshot[metrics.DDCurrentSuspectedDeadlocks.Name()]
@@ -61,8 +63,9 @@ func TestCurrentCounterAndGauge(t *testing.T) {
 	require.Equal(t, int64(1), counter[0].Value)
 
 	close(b.done)
-	time.Sleep(20 * time.Millisecond)
-	require.Equal(t, int64(0), dd.CurrentSuspected())
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.Equal(collect, int64(0), dd.CurrentSuspected())
+	}, time.Second, time.Millisecond)
 
 	snapshot = capture.Snapshot()
 	current = snapshot[metrics.DDCurrentSuspectedDeadlocks.Name()]

--- a/common/deadlock/deadlock_test.go
+++ b/common/deadlock/deadlock_test.go
@@ -1,0 +1,73 @@
+package deadlock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/goro"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/pingable"
+)
+
+type blockingPingable struct{ done chan struct{} }
+
+func (b *blockingPingable) GetPingChecks() []pingable.Check {
+	return []pingable.Check{{
+		Name:    "test",
+		Timeout: 10 * time.Millisecond,
+		Ping: func() []pingable.Pingable {
+			<-b.done
+			return nil
+		},
+	}}
+}
+
+func TestCurrentCounterAndGauge(t *testing.T) {
+	mh := metricstest.NewCaptureHandler()
+	dd := NewDeadlockDetector(params{
+		Logger:         log.NewNoopLogger(),
+		Collection:     dynamicconfig.NewNoopCollection(),
+		MetricsHandler: mh,
+	})
+
+	lc := &loopContext{
+		dd:   dd,
+		p:    goro.NewAdaptivePool(clock.NewRealTimeSource(), 0, 1, 10*time.Millisecond, 10),
+		root: nil,
+	}
+	defer lc.p.Stop()
+
+	b := &blockingPingable{done: make(chan struct{})}
+	check := b.GetPingChecks()[0]
+
+	capture := mh.StartCapture()
+	go lc.check(context.Background(), check)
+
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, int64(1), dd.CurrentSuspected())
+
+	snapshot := capture.Snapshot()
+	current := snapshot[metrics.DDCurrentSuspectedDeadlocks.Name()]
+	counter := snapshot[metrics.DDSuspectedDeadlocks.Name()]
+	require.Len(t, current, 1)
+	require.Equal(t, 1.0, current[0].Value)
+	require.Len(t, counter, 1)
+	require.Equal(t, int64(1), counter[0].Value)
+
+	close(b.done)
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, int64(0), dd.CurrentSuspected())
+
+	snapshot = capture.Snapshot()
+	current = snapshot[metrics.DDCurrentSuspectedDeadlocks.Name()]
+	counter = snapshot[metrics.DDSuspectedDeadlocks.Name()]
+	require.Len(t, current, 2)
+	require.Equal(t, 0.0, current[1].Value)
+	require.Len(t, counter, 1)
+}

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -980,6 +980,7 @@ var (
 	PausedActivitiesCounter                 = NewCounterDef("paused_activities")
 
 	// Deadlock detector latency metrics
+	DDSuspectedDeadlocks                 = NewCounterDef("dd_suspected_deadlocks")
 	DDClusterMetadataLockLatency         = NewTimerDef("dd_cluster_metadata_lock_latency")
 	DDClusterMetadataCallbackLockLatency = NewTimerDef("dd_cluster_metadata_callback_lock_latency")
 	DDShardControllerLockLatency         = NewTimerDef("dd_shard_controller_lock_latency")

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -979,8 +979,9 @@ var (
 	DynamicWorkerPoolSchedulerRejectedTasks = NewCounterDef("dynamic_worker_pool_scheduler_rejected_tasks")
 	PausedActivitiesCounter                 = NewCounterDef("paused_activities")
 
-	// Deadlock detector latency metrics
+	// Deadlock detector metrics
 	DDSuspectedDeadlocks                 = NewCounterDef("dd_suspected_deadlocks")
+	DDCurrentSuspectedDeadlocks          = NewGaugeDef("dd_current_suspected_deadlocks")
 	DDClusterMetadataLockLatency         = NewTimerDef("dd_cluster_metadata_lock_latency")
 	DDClusterMetadataCallbackLockLatency = NewTimerDef("dd_cluster_metadata_callback_lock_latency")
 	DDShardControllerLockLatency         = NewTimerDef("dd_shard_controller_lock_latency")


### PR DESCRIPTION
## What changed?
- Add counter metric for total suspected deadlocks
- Add gauge metric for current unresolved suspected deadlocks

## Why?
These could be used in alerting or health checking.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
