### PR TITLE
Refactor: use new serviceerror.New...f constructors

### DIFF
--- a/chasm/field.go
+++ b/chasm/field.go
@@ -1,7 +1,6 @@
 package chasm
 
 import (
-	"fmt"
 	"reflect"
 
 	"go.temporal.io/api/serviceerror"
@@ -71,7 +70,7 @@ func (f Field[T]) Get(chasmContext Context) (T, error) {
 		}
 		vT, isT := f.Internal.v.(T)
 		if !isT {
-			return nilT, serviceerror.NewInternal(fmt.Sprintf("internal value doesn't implement %s", reflect.TypeFor[T]().Name()))
+			return nilT, serviceerror.NewInternalf("internal value doesn't implement %s", reflect.TypeFor[T]().Name())
 		}
 		return vT, nil
 	}
@@ -90,7 +89,7 @@ func (f Field[T]) Get(chasmContext Context) (T, error) {
 		//nolint:forbidigo
 		panic("not implemented")
 	default:
-		return nilT, serviceerror.NewInternal(fmt.Sprintf("unsupported field type: %v", f.Internal.fieldType()))
+		return nilT, serviceerror.NewInternalf("unsupported field type: %v", f.Internal.fieldType())
 	}
 
 	if f.Internal.node.value == nil {
@@ -98,7 +97,7 @@ func (f Field[T]) Get(chasmContext Context) (T, error) {
 	}
 	vT, isT := f.Internal.node.value.(T)
 	if !isT {
-		return nilT, serviceerror.NewInternal(fmt.Sprintf("node value doesn't implement %s", reflect.TypeFor[T]().Name()))
+		return nilT, serviceerror.NewInternalf("node value doesn't implement %s", reflect.TypeFor[T]().Name())
 	}
 	return vT, nil
 }

--- a/chasm/fields_iterator.go
+++ b/chasm/fields_iterator.go
@@ -1,7 +1,6 @@
 package chasm
 
 import (
-	"fmt"
 	"iter"
 	"reflect"
 	"strings"
@@ -50,14 +49,14 @@ func fieldsOf(valueV reflect.Value) iter.Seq[fieldInfo] {
 			fieldK := fieldKindUnspecified
 			if fieldT.AssignableTo(protoMessageT) {
 				if dataFieldName != "" {
-					fieldErr = serviceerror.NewInternal(fmt.Sprintf("%s.%s: only one data field %s (implements proto.Message) allowed in component", valueT, fieldN, dataFieldName))
+					fieldErr = serviceerror.NewInternalf("%s.%s: only one data field %s (implements proto.Message) allowed in component", valueT, fieldN, dataFieldName)
 				}
 				dataFieldName = fieldN
 				fieldK = fieldKindData
 			} else {
 				prefix := genericTypePrefix(fieldT)
 				if strings.HasPrefix(prefix, "*") {
-					fieldErr = serviceerror.NewInternal(fmt.Sprintf("%s.%s: chasm field type %s must not be a pointer", valueT, fieldN, fieldT))
+					fieldErr = serviceerror.NewInternalf("%s.%s: chasm field type %s must not be a pointer", valueT, fieldN, fieldT)
 				} else {
 					switch prefix {
 					case chasmFieldTypePrefix:
@@ -65,7 +64,7 @@ func fieldsOf(valueV reflect.Value) iter.Seq[fieldInfo] {
 					case chasmCollectionTypePrefix:
 						fieldK = fieldKindSubCollection
 					default:
-						fieldErr = serviceerror.NewInternal(fmt.Sprintf("%s.%s: unsupported field type %s: must implement proto.Message, or be chasm.Field[T] or chasm.Collection[T]", valueT, fieldN, fieldT))
+						fieldErr = serviceerror.NewInternalf("%s.%s: unsupported field type %s: must implement proto.Message, or be chasm.Field[T] or chasm.Collection[T]", valueT, fieldN, fieldT)
 					}
 				}
 
@@ -77,7 +76,7 @@ func fieldsOf(valueV reflect.Value) iter.Seq[fieldInfo] {
 		}
 		// If the data field is not found, generate one more fake field with only an error set.
 		if dataFieldName == "" {
-			yield(fieldInfo{err: serviceerror.NewInternal(fmt.Sprintf("%s: no data field (implements proto.Message) found", valueT))})
+			yield(fieldInfo{err: serviceerror.NewInternalf("%s: no data field (implements proto.Message) found", valueT)})
 		}
 	}
 }

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -271,8 +271,8 @@ func (n *Node) Component(
 
 	componentValue, ok := node.value.(Component)
 	if !ok {
-		return nil, serviceerror.NewInternal(
-			fmt.Sprintf("component value is not of type Component: %v", reflect.TypeOf(node.value)),
+		return nil, serviceerror.NewInternalf(
+			"component value is not of type Component: %v", reflect.TypeOf(node.value),
 		)
 	}
 
@@ -299,15 +299,15 @@ func (n *Node) prepareComponentValue(
 	metadata := n.serializedNode.Metadata
 	componentAttr := metadata.GetComponentAttributes()
 	if componentAttr == nil {
-		return serviceerror.NewInternal(
-			fmt.Sprintf("expect chasm node to have ComponentAttributes, actual attributes: %v", metadata.Attributes),
+		return serviceerror.NewInternalf(
+			"expect chasm node to have ComponentAttributes, actual attributes: %v", metadata.Attributes,
 		)
 	}
 
 	if n.valueState == valueStateNeedDeserialize {
 		registrableComponent, ok := n.registry.component(componentAttr.GetType())
 		if !ok {
-			return serviceerror.NewInternal(fmt.Sprintf("component type name not registered: %v", componentAttr.GetType()))
+			return serviceerror.NewInternalf("component type name not registered: %v", componentAttr.GetType())
 		}
 
 		if err := n.deserialize(registrableComponent.goType); err != nil {
@@ -332,8 +332,8 @@ func (n *Node) prepareDataValue(
 	metadata := n.serializedNode.Metadata
 	dataAttr := metadata.GetDataAttributes()
 	if dataAttr == nil {
-		return serviceerror.NewInternal(
-			fmt.Sprintf("expect chasm node to have DataAttributes, actual attributes: %v", metadata.Attributes),
+		return serviceerror.NewInternalf(
+			"expect chasm node to have DataAttributes, actual attributes: %v", metadata.Attributes,
 		)
 	}
 
@@ -481,7 +481,7 @@ func (n *Node) serializeComponentNode() error {
 
 		rc, ok := n.registry.componentFor(n.value)
 		if !ok {
-			return serviceerror.NewInternal(fmt.Sprintf("component type %s is not registered", reflect.TypeOf(n.value).String()))
+			return serviceerror.NewInternalf("component type %s is not registered", reflect.TypeOf(n.value).String())
 		}
 
 		n.serializedNode.Data = blob
@@ -836,7 +836,7 @@ func (n *Node) closeTransactionHandleRootLifecycleChange(
 		newState = enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED
 		newStatus = enumspb.WORKFLOW_EXECUTION_STATUS_FAILED
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown component lifecycle state: %v", lifecycleState))
+		return serviceerror.NewInternalf("unknown component lifecycle state: %v", lifecycleState)
 	}
 
 	return n.backend.UpdateWorkflowStateStatus(newState, newStatus)
@@ -907,7 +907,7 @@ func (n *Node) closeTransactionUpdateComponentTasks(
 			taskValue := newTask.task
 			registrableTask, ok := n.registry.taskFor(taskValue)
 			if !ok {
-				return serviceerror.NewInternal(fmt.Sprintf("task type %s is not registered", reflect.TypeOf(taskValue).String()))
+				return serviceerror.NewInternalf("task type %s is not registered", reflect.TypeOf(taskValue).String())
 			}
 
 			taskBlob, err := serializeTask(registrableTask, taskValue)
@@ -946,7 +946,7 @@ func (n *Node) deserializeComponentTask(
 ) (any, error) {
 	registableTask, ok := n.registry.task(componentTask.Type)
 	if !ok {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("task type %s is not registered", componentTask.Type))
+		return nil, serviceerror.NewInternalf("task type %s is not registered", componentTask.Type)
 	}
 
 	// TODO: cache deserialized task value (reflect.Value) in the node,
@@ -965,8 +965,8 @@ func (n *Node) validateTask(
 ) (bool, error) {
 	registableTask, ok := n.registry.taskFor(taskInstance)
 	if !ok {
-		return false, serviceerror.NewInternal(
-			fmt.Sprintf("task type for goType %s is not registered", reflect.TypeOf(taskInstance).Name()))
+		return false, serviceerror.NewInternalf(
+			"task type for goType %s is not registered", reflect.TypeOf(taskInstance).Name())
 	}
 
 	// TODO: cache validateMethod (reflect.Value) in the registry
@@ -1547,8 +1547,8 @@ func taskCategory(
 
 	if task.Destination != "" {
 		if !isImmediate {
-			return tasks.Category{}, serviceerror.NewInternal(
-				fmt.Sprintf("Task cannot have both destination and scheduled time set, destination: %v, scheduled time: %v", task.Destination, task.ScheduledTime.AsTime()),
+			return tasks.Category{}, serviceerror.NewInternalf(
+				"Task cannot have both destination and scheduled time set, destination: %v, scheduled time: %v", task.Destination, task.ScheduledTime.AsTime(),
 			)
 		}
 		return tasks.CategoryOutbound, nil
@@ -1654,7 +1654,7 @@ func serializeTask(
 		}
 
 		if protoMessageFound {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("only one proto field allowed in task struct of type: %v", taskGoType.String()))
+			return nil, serviceerror.NewInternalf("only one proto field allowed in task struct of type: %v", taskGoType.String())
 		}
 		protoMessageFound = true
 

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -5,7 +5,6 @@ package history
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -262,7 +261,7 @@ func (c *clientImpl) shardIDFromWorkflowID(namespaceID, workflowID string) int32
 
 func checkShardID(shardID int32) error {
 	if shardID <= 0 {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid ShardID: %d", shardID))
+		return serviceerror.NewInvalidArgumentf("Invalid ShardID: %d", shardID)
 	}
 	return nil
 }

--- a/client/history/metadata.go
+++ b/client/history/metadata.go
@@ -1,7 +1,6 @@
 package history
 
 import (
-	"fmt"
 	"strconv"
 
 	"go.temporal.io/api/serviceerror"
@@ -60,11 +59,11 @@ func parseInt32(
 	}
 	metadataValue, err := strconv.Atoi(stringValue)
 	if err != nil {
-		return 0, serviceerror.NewInvalidArgument(fmt.Sprintf(
+		return 0, serviceerror.NewInvalidArgumentf(
 			"unable to parse metadata key %v: %v",
 			metadataKey,
 			err,
-		))
+		)
 	}
 	return int32(metadataValue), nil
 }

--- a/common/cluster/frontend_http_client.go
+++ b/common/cluster/frontend_http_client.go
@@ -42,11 +42,11 @@ func (c *FrontendHTTPClientCache) Get(targetClusterName string) (*common.Fronten
 func (c *FrontendHTTPClientCache) newClientForCluster(targetClusterName string) (*common.FrontendHTTPClient, error) {
 	targetInfo, ok := c.metadata.GetAllClusterInfo()[targetClusterName]
 	if !ok {
-		return nil, serviceerror.NewNotFound(fmt.Sprintf("could not find cluster metadata for cluster %s", targetClusterName))
+		return nil, serviceerror.NewNotFoundf("could not find cluster metadata for cluster %s", targetClusterName)
 	}
 
 	if targetInfo.HTTPAddress == "" {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("HTTPAddress not configured for cluster: %s", targetClusterName))
+		return nil, serviceerror.NewInternalf("HTTPAddress not configured for cluster: %s", targetClusterName)
 	}
 	host, _, err := net.SplitHostPort(targetInfo.HTTPAddress)
 	if err != nil {

--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -2,7 +2,6 @@ package headers
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"strings"
 
@@ -127,7 +126,7 @@ func (vc *versionChecker) ClientSupported(ctx context.Context) error {
 		if supportedClientRange, ok := vc.supportedClientsRange[clientName]; ok {
 			clientVersionParsed, parseErr := semver.Parse(clientVersion)
 			if parseErr != nil {
-				return serviceerror.NewInvalidArgument(fmt.Sprintf("Unable to parse client version: %v", parseErr))
+				return serviceerror.NewInvalidArgumentf("Unable to parse client version: %v", parseErr)
 			}
 			if !supportedClientRange(clientVersionParsed) {
 				return serviceerror.NewClientVersionNotSupported(clientVersion, clientName, vc.supportedClients[clientName])
@@ -139,7 +138,7 @@ func (vc *versionChecker) ClientSupported(ctx context.Context) error {
 	if supportedServerVersions != "" {
 		supportedServerVersionsParsed, parseErr := semver.ParseRange(supportedServerVersions)
 		if parseErr != nil {
-			return serviceerror.NewInvalidArgument(fmt.Sprintf("Unable to parse supported server versions: %v", parseErr))
+			return serviceerror.NewInvalidArgumentf("Unable to parse supported server versions: %v", parseErr)
 		}
 		if !supportedServerVersionsParsed(vc.serverVersion) {
 			return serviceerror.NewServerVersionNotSupported(vc.serverVersion.String(), supportedServerVersions)

--- a/common/metrics/panic.go
+++ b/common/metrics/panic.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"fmt"
 	"runtime/debug"
 
 	"go.temporal.io/api/serviceerror"
@@ -18,7 +17,7 @@ func CapturePanic(logger log.Logger, metricHandler Handler, retError *error) {
 	if panicObj := recover(); panicObj != nil {
 		err, ok := panicObj.(error)
 		if !ok {
-			err = serviceerror.NewInternal(fmt.Sprintf("panic: %v", panicObj))
+			err = serviceerror.NewInternalf("panic: %v", panicObj)
 		}
 
 		st := string(debug.Stack())

--- a/common/metrics/panic.go
+++ b/common/metrics/panic.go
@@ -14,10 +14,10 @@ import (
 // And we have to set the returned error otherwise our handler will return nil as error which is incorrect
 func CapturePanic(logger log.Logger, metricHandler Handler, retError *error) {
 	//revive:disable-next-line:defer
-	if panicObj := recover(); panicObj != nil {
-		err, ok := panicObj.(error)
+	if pObj := recover(); pObj != nil {
+		err, ok := pObj.(error)
 		if !ok {
-			err = serviceerror.NewInternalf("panic: %v", panicObj)
+			err = serviceerror.NewInternalf("panic: %v", pObj)
 		}
 
 		st := string(debug.Stack())

--- a/common/namespace/nsmanager/attr_validator.go
+++ b/common/namespace/nsmanager/attr_validator.go
@@ -1,8 +1,6 @@
 package nsmanager
 
 import (
-	"fmt"
-
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -93,7 +91,7 @@ func (d *Validator) validateClusterName(
 	clusterName string,
 ) error {
 	if info, ok := d.clusterMetadata.GetAllClusterInfo()[clusterName]; !ok || !info.Enabled {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid cluster name: %v", clusterName))
+		return serviceerror.NewInvalidArgumentf("Invalid cluster name: %v", clusterName)
 	}
 	return nil
 }

--- a/common/nexus/endpoint_registry.go
+++ b/common/nexus/endpoint_registry.go
@@ -3,7 +3,6 @@ package nexus
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -161,7 +160,7 @@ func (r *EndpointRegistryImpl) GetByName(ctx context.Context, _ namespace.ID, en
 	r.dataLock.RUnlock()
 
 	if !ok {
-		return nil, serviceerror.NewNotFound(fmt.Sprintf("could not find Nexus endpoint by name: %v", endpointName))
+		return nil, serviceerror.NewNotFoundf("could not find Nexus endpoint by name: %v", endpointName)
 	}
 	return endpoint, nil
 }

--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -2,7 +2,6 @@ package cassandra
 
 import (
 	"context"
-	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
@@ -145,12 +144,12 @@ func (h *HistoryStore) ReadHistoryBranch(
 
 	treeID, err := primitives.ValidateUUID(branch.TreeId)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ReadHistoryBranch - Gocql TreeId UUID cast failed. Error: %v", err))
+		return nil, serviceerror.NewInternalf("ReadHistoryBranch - Gocql TreeId UUID cast failed. Error: %v", err)
 	}
 
 	branchID, err := primitives.ValidateUUID(request.BranchID)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ReadHistoryBranch - Gocql BranchId UUID cast failed. Error: %v", err))
+		return nil, serviceerror.NewInternalf("ReadHistoryBranch - Gocql BranchId UUID cast failed. Error: %v", err)
 	}
 
 	var queryString string
@@ -178,7 +177,7 @@ func (h *HistoryStore) ReadHistoryBranch(
 	}
 
 	if err := iter.Close(); err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ReadHistoryBranch. Close operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("ReadHistoryBranch. Close operation failed. Error: %v", err)
 	}
 
 	return &p.InternalReadHistoryBranchResponse{
@@ -244,12 +243,12 @@ func (h *HistoryStore) ForkHistoryBranch(
 
 	cqlTreeID, err := primitives.ValidateUUID(forkB.TreeId)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("ForkHistoryBranch - Gocql TreeId UUID cast failed. Error: %v", err))
+		return serviceerror.NewInternalf("ForkHistoryBranch - Gocql TreeId UUID cast failed. Error: %v", err)
 	}
 
 	cqlNewBranchID, err := primitives.ValidateUUID(request.NewBranchID)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("ForkHistoryBranch - Gocql NewBranchID UUID cast failed. Error: %v", err))
+		return serviceerror.NewInternalf("ForkHistoryBranch - Gocql NewBranchID UUID cast failed. Error: %v", err)
 	}
 	query := h.Session.Query(v2templateInsertTree, cqlTreeID, cqlNewBranchID, datablob.Data, datablob.EncodingType.String()).WithContext(ctx)
 	err = query.Exec()
@@ -330,7 +329,7 @@ func (h *HistoryStore) GetAllHistoryTreeBranches(
 	}
 
 	if err := iter.Close(); err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetAllHistoryTreeBranches. Close operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetAllHistoryTreeBranches. Close operation failed. Error: %v", err)
 	}
 
 	response := &p.InternalGetAllHistoryTreeBranchesResponse{
@@ -354,7 +353,7 @@ func (h *HistoryStore) GetHistoryTreeContainingBranch(
 
 	treeID, err := primitives.ValidateUUID(branch.TreeId)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ReadHistoryBranch. Gocql TreeId UUID cast failed. Error: %v", err))
+		return nil, serviceerror.NewInternalf("ReadHistoryBranch. Gocql TreeId UUID cast failed. Error: %v", err)
 	}
 	query := h.Session.Query(v2templateReadAllBranches, treeID).WithContext(ctx)
 

--- a/common/persistence/cassandra/matching_task_store.go
+++ b/common/persistence/cassandra/matching_task_store.go
@@ -461,7 +461,7 @@ func (d *MatchingTaskStore) GetTasks(
 	}
 
 	if err := iter.Close(); err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTasks operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetTasks operation failed. Error: %v", err)
 	}
 	return response, nil
 }
@@ -613,7 +613,7 @@ func (d *MatchingTaskStore) ListTaskQueueUserDataEntries(ctx context.Context, re
 	}
 
 	if err := iter.Close(); err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListTaskQueueUserDataEntries operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("ListTaskQueueUserDataEntries operation failed. Error: %v", err)
 	}
 	return response, nil
 }
@@ -647,7 +647,7 @@ func (d *MatchingTaskStore) GetTaskQueuesByBuildId(ctx context.Context, request 
 	}
 
 	if err := iter.Close(); err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTaskQueuesByBuildId operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetTaskQueuesByBuildId operation failed. Error: %v", err)
 	}
 	return taskQueues, nil
 }

--- a/common/persistence/cassandra/metadata_store.go
+++ b/common/persistence/cassandra/metadata_store.go
@@ -105,7 +105,7 @@ func (m *MetadataStore) CreateNamespace(
 	existingRow := make(map[string]interface{})
 	applied, err := query.MapScanCAS(existingRow)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("CreateNamespace operation failed. Inserting into namespaces table. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("CreateNamespace operation failed. Inserting into namespaces table. Error: %v", err)
 	}
 
 	if !applied {
@@ -149,7 +149,7 @@ func (m *MetadataStore) CreateNamespaceInV2Table(
 	previous := make(map[string]interface{})
 	applied, iter, err := m.session.MapExecuteBatchCAS(batch, previous)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("CreateNamespace operation failed. Inserting into namespaces table. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("CreateNamespace operation failed. Inserting into namespaces table. Error: %v", err)
 	}
 	defer func() { _ = iter.Close() }()
 	deleteOrphanNamespace := func() {
@@ -221,7 +221,7 @@ func (m *MetadataStore) UpdateNamespace(
 	previous := make(map[string]interface{})
 	applied, iter, err := m.session.MapExecuteBatchCAS(batch, previous)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("UpdateNamespace operation failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("UpdateNamespace operation failed. Error: %v", err)
 	}
 	defer func() { _ = iter.Close() }()
 
@@ -252,7 +252,7 @@ func (m *MetadataStore) RenameNamespace(
 		request.Name,
 		request.Id,
 	).WithContext(ctx).Exec(); updateErr != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("RenameNamespace operation failed to update 'namespaces_by_id' table. Error: %v", updateErr))
+		return serviceerror.NewUnavailablef("RenameNamespace operation failed to update 'namespaces_by_id' table. Error: %v", updateErr)
 	}
 
 	// Step 2.
@@ -275,7 +275,7 @@ func (m *MetadataStore) RenameNamespace(
 	previous := make(map[string]interface{})
 	applied, iter, err := m.session.MapExecuteBatchCAS(batch, previous)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("RenameNamespace operation failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("RenameNamespace operation failed. Error: %v", err)
 	}
 	defer func() { _ = iter.Close() }()
 
@@ -311,7 +311,7 @@ func (m *MetadataStore) GetNamespace(
 			}
 			return serviceerror.NewNamespaceNotFound(identity)
 		}
-		return serviceerror.NewUnavailable(fmt.Sprintf("GetNamespace operation failed. Error %v", err))
+		return serviceerror.NewUnavailablef("GetNamespace operation failed. Error %v", err)
 	}
 
 	namespace := request.Name
@@ -392,7 +392,7 @@ func (m *MetadataStore) ListNamespaces(
 			nextPageToken = nil
 		}
 		if err := iter.Close(); err != nil {
-			return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListNamespaces operation failed. Error: %v", err))
+			return nil, serviceerror.NewUnavailablef("ListNamespaces operation failed. Error: %v", err)
 		}
 
 		if len(nextPageToken) == 0 {
@@ -484,12 +484,12 @@ func (m *MetadataStore) updateMetadataBatch(
 func (m *MetadataStore) deleteNamespace(ctx context.Context, name string, ID []byte) error {
 	query := m.session.Query(templateDeleteNamespaceByNameQueryV2, constNamespacePartition, name).WithContext(ctx)
 	if err := query.Exec(); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("DeleteNamespaceByName operation failed. Error %v", err))
+		return serviceerror.NewUnavailablef("DeleteNamespaceByName operation failed. Error %v", err)
 	}
 
 	query = m.session.Query(templateDeleteNamespaceQuery, ID).WithContext(ctx)
 	if err := query.Exec(); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("DeleteNamespace operation failed. Error %v", err))
+		return serviceerror.NewUnavailablef("DeleteNamespace operation failed. Error %v", err)
 	}
 
 	return nil

--- a/common/persistence/cassandra/mutable_state_store.go
+++ b/common/persistence/cassandra/mutable_state_store.go
@@ -432,7 +432,7 @@ func (d *MutableStateStore) CreateWorkflowExecution(
 		requestCurrentRunID = ""
 
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("CreateWorkflowExecution: unknown mode: %v", request.Mode))
+		return nil, serviceerror.NewInternalf("CreateWorkflowExecution: unknown mode: %v", request.Mode)
 	}
 
 	if err := applyWorkflowSnapshotBatchAsNew(batch,
@@ -504,7 +504,7 @@ func (d *MutableStateStore) GetWorkflowExecution(
 
 	state, err := mutableStateFromRow(result)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetWorkflowExecution operation failed. Error: %v", err)
 	}
 
 	activityInfos := make(map[int64]*commonpb.DataBlob)
@@ -671,7 +671,7 @@ func (d *MutableStateStore) UpdateWorkflowExecution(
 		}
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("UpdateWorkflowExecution: unknown mode: %v", request.Mode))
+		return serviceerror.NewInternalf("UpdateWorkflowExecution: unknown mode: %v", request.Mode)
 	}
 
 	if err := applyWorkflowMutationBatch(batch, shardID, &updateWorkflow); err != nil {
@@ -796,7 +796,7 @@ func (d *MutableStateStore) ConflictResolveWorkflowExecution(
 		)
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("ConflictResolveWorkflowExecution: unknown mode: %v", request.Mode))
+		return serviceerror.NewInternalf("ConflictResolveWorkflowExecution: unknown mode: %v", request.Mode)
 	}
 
 	if err := applyWorkflowSnapshotBatchAsReset(batch, shardID, &resetWorkflow); err != nil {
@@ -958,7 +958,7 @@ func (d *MutableStateStore) GetCurrentExecution(
 	currentRunID := gocql.UUIDToString(result["current_run_id"])
 	executionStateBlob, err := executionStateBlobFromRow(result)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetCurrentExecution operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetCurrentExecution operation failed. Error: %v", err)
 	}
 
 	// TODO: fix blob ExecutionState in storage should not be a blob.

--- a/common/persistence/cassandra/nexus_endpoint_store.go
+++ b/common/persistence/cassandra/nexus_endpoint_store.go
@@ -158,7 +158,7 @@ func (s *NexusEndpointStore) GetNexusEndpoint(
 
 	err := query.Scan(&data, &dataEncoding, &version)
 	if gocql.IsNotFoundError(err) {
-		return nil, serviceerror.NewNotFound(fmt.Sprintf("Nexus endpoint with ID `%v` not found", request.ID))
+		return nil, serviceerror.NewNotFoundf("Nexus endpoint with ID `%v` not found", request.ID)
 	}
 	if err != nil {
 		return nil, gocql.ConvertError("GetNexusEndpoint", err)
@@ -195,7 +195,7 @@ func (s *NexusEndpointStore) ListNexusEndpoints(
 	}
 
 	if err := iter.Close(); err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListNexusEndpoints operation failed: %v", err))
+		return nil, serviceerror.NewUnavailablef("ListNexusEndpoints operation failed: %v", err)
 	}
 
 	currentTableVersion, err := s.getTableVersion(ctx)
@@ -259,7 +259,7 @@ func (s *NexusEndpointStore) DeleteNexusEndpoint(
 				currentTableVersion)
 		}
 
-		return serviceerror.NewNotFound(fmt.Sprintf("nexus endpoint not found for ID: %v", request.ID))
+		return serviceerror.NewNotFoundf("nexus endpoint not found for ID: %v", request.ID)
 	}
 
 	return nil

--- a/common/persistence/cassandra/queue_store.go
+++ b/common/persistence/cassandra/queue_store.go
@@ -145,7 +145,7 @@ func (q *QueueStore) ReadMessages(
 	}
 
 	if err := iter.Close(); err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ReadMessages operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("ReadMessages operation failed. Error: %v", err)
 	}
 
 	return result, nil
@@ -180,7 +180,7 @@ func (q *QueueStore) ReadMessagesFromDLQ(
 		nextPageToken = iter.PageState()
 	}
 	if err := iter.Close(); err != nil {
-		return nil, nil, serviceerror.NewUnavailable(fmt.Sprintf("ReadMessagesFromDLQ operation failed. Error: %v", err))
+		return nil, nil, serviceerror.NewUnavailablef("ReadMessagesFromDLQ operation failed. Error: %v", err)
 	}
 
 	return result, nextPageToken, nil
@@ -193,7 +193,7 @@ func (q *QueueStore) DeleteMessagesBefore(
 
 	query := q.session.Query(templateDeleteMessagesBeforeQuery, q.queueType, messageID).WithContext(ctx)
 	if err := query.Exec(); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("DeleteMessagesBefore operation failed. Error %v", err))
+		return serviceerror.NewUnavailablef("DeleteMessagesBefore operation failed. Error %v", err)
 	}
 	return nil
 }
@@ -206,7 +206,7 @@ func (q *QueueStore) DeleteMessageFromDLQ(
 	// Use negative queue type as the dlq type
 	query := q.session.Query(templateDeleteMessageQuery, q.getDLQTypeFromQueueType(), messageID).WithContext(ctx)
 	if err := query.Exec(); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("DeleteMessageFromDLQ operation failed. Error %v", err))
+		return serviceerror.NewUnavailablef("DeleteMessageFromDLQ operation failed. Error %v", err)
 	}
 
 	return nil
@@ -221,7 +221,7 @@ func (q *QueueStore) RangeDeleteMessagesFromDLQ(
 	// Use negative queue type as the dlq type
 	query := q.session.Query(templateDeleteMessagesQuery, q.getDLQTypeFromQueueType(), firstMessageID, lastMessageID).WithContext(ctx)
 	if err := query.Exec(); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("RangeDeleteMessagesFromDLQ operation failed. Error %v", err))
+		return serviceerror.NewUnavailablef("RangeDeleteMessagesFromDLQ operation failed. Error %v", err)
 	}
 
 	return nil

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -3,7 +3,6 @@ package persistence
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -377,8 +376,8 @@ func (m *executionManagerImpl) GetWorkflowExecution(
 	var notFound *serviceerror.NotFound
 	if errors.As(respErr, &notFound) {
 		// strip persistence-specific error message
-		respErr = serviceerror.NewNotFound(fmt.Sprintf(
-			"workflow execution not found for workflow ID %q and run ID %q", request.WorkflowID, request.RunID))
+		respErr = serviceerror.NewNotFoundf(
+			"workflow execution not found for workflow ID %q and run ID %q", request.WorkflowID, request.RunID)
 	}
 	if respErr != nil && response == nil {
 		// try to utilize resp as much as possible, for RebuildMutableState API
@@ -767,7 +766,7 @@ func (m *executionManagerImpl) GetCurrentExecution(
 	var notFound *serviceerror.NotFound
 	if errors.As(respErr, &notFound) {
 		// strip persistence-specific error message
-		respErr = serviceerror.NewNotFound(fmt.Sprintf("workflow not found for ID: %v", request.WorkflowID))
+		respErr = serviceerror.NewNotFoundf("workflow not found for ID: %v", request.WorkflowID)
 	}
 	if respErr != nil && response == nil {
 		// try to utilize resp as much as possible, for RebuildMutableState API
@@ -1164,7 +1163,7 @@ func validateTaskRange(
 			return serviceerror.NewInvalidArgument("invalid task range, taskID must be empty for scheduled task category")
 		}
 	default:
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("invalid task category type: %v", taskCategoryType))
+		return serviceerror.NewInvalidArgumentf("invalid task category type: %v", taskCategoryType)
 	}
 
 	return nil

--- a/common/persistence/faultinjection/fault.go
+++ b/common/persistence/faultinjection/fault.go
@@ -52,7 +52,7 @@ func newFault(errName string, errRate float64, methodName string) fault {
 			Message: fmt.Sprintf("%s: serviceerror.ResourceExhausted", header),
 		}, errRate)
 	case "Unavailable":
-		return newFaultFromError(serviceerror.NewUnavailable(fmt.Sprintf("%s: serviceerror.Unavailable", header)), errRate)
+		return newFaultFromError(serviceerror.NewUnavailablef("%s: serviceerror.Unavailable", header), errRate)
 	default:
 		panic(fmt.Sprintf("unsupported error type: %v", errName))
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/errors.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/errors.go
@@ -24,7 +24,7 @@ func ConvertError(
 		return &persistence.TimeoutError{Msg: fmt.Sprintf("operation %v encountered %v", operation, err.Error())}
 	}
 	if errors.Is(err, gocql.ErrNotFound) {
-		return serviceerror.NewNotFound(fmt.Sprintf("operation %v encountered %v", operation, err.Error()))
+		return serviceerror.NewNotFoundf("operation %v encountered %v", operation, err.Error())
 	}
 
 	var cqlTimeoutErr gocql.RequestErrWriteTimeout
@@ -52,11 +52,11 @@ func ConvertError(
 				}
 			}
 
-			return serviceerror.NewUnavailable(fmt.Sprintf("operation %v encountered %v", operation, cqlRequestErr.Error()))
+			return serviceerror.NewUnavailablef("operation %v encountered %v", operation, cqlRequestErr.Error())
 		}
 	}
 
-	return serviceerror.NewUnavailable(fmt.Sprintf("operation %v encountered %v", operation, err.Error()))
+	return serviceerror.NewUnavailablef("operation %v encountered %v", operation, err.Error())
 }
 
 func IsNotFoundError(err error) bool {

--- a/common/persistence/operation_mode_validator.go
+++ b/common/persistence/operation_mode_validator.go
@@ -1,8 +1,6 @@
 package persistence
 
 import (
-	"fmt"
-
 	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 )
@@ -45,7 +43,7 @@ func ValidateCreateWorkflowModeState(
 		return nil
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown mode: %v", mode))
+		return serviceerror.NewInternalf("unknown mode: %v", mode)
 	}
 }
 
@@ -135,7 +133,7 @@ func ValidateUpdateWorkflowModeState(
 		return nil
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown mode: %v", mode))
+		return serviceerror.NewInternalf("unknown mode: %v", mode)
 	}
 }
 
@@ -256,7 +254,7 @@ func ValidateConflictResolveWorkflowModeState(
 
 		// precondition
 		if currentWorkflowMutation != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Invalid workflow conflict resolve mode %v, encountered current workflow", mode))
+			return serviceerror.NewInternalf("Invalid workflow conflict resolve mode %v, encountered current workflow", mode)
 		}
 
 		// case 1
@@ -287,7 +285,7 @@ func ValidateConflictResolveWorkflowModeState(
 		return nil
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown mode: %v", mode))
+		return serviceerror.NewInternalf("unknown mode: %v", mode)
 	}
 }
 
@@ -300,7 +298,7 @@ func checkWorkflowState(state enumsspb.WorkflowExecutionState) error {
 		enumsspb.WORKFLOW_EXECUTION_STATE_CORRUPTED:
 		return nil
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", state))
+		return serviceerror.NewInternalf("unknown workflow state: %v", state)
 	}
 }
 
@@ -308,11 +306,10 @@ func newInvalidCreateWorkflowMode(
 	mode CreateWorkflowMode,
 	workflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewInternalf(
 		"Invalid workflow create mode %v, state: %v",
 		mode,
 		workflowState,
-	),
 	)
 }
 
@@ -320,11 +317,10 @@ func newInvalidUpdateWorkflowMode(
 	mode UpdateWorkflowMode,
 	currentWorkflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewInternalf(
 		"Invalid workflow update mode %v, state: %v",
 		mode,
 		currentWorkflowState,
-	),
 	)
 }
 
@@ -333,12 +329,11 @@ func newInvalidUpdateWorkflowWithNewMode(
 	currentWorkflowState enumsspb.WorkflowExecutionState,
 	newWorkflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewInternalf(
 		"Invalid workflow update mode %v, current state: %v, new state: %v",
 		mode,
 		currentWorkflowState,
 		newWorkflowState,
-	),
 	)
 }
 
@@ -346,11 +341,10 @@ func newInvalidConflictResolveWorkflowMode(
 	mode ConflictResolveWorkflowMode,
 	resetWorkflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewInternalf(
 		"Invalid workflow conflict resolve mode %v, reset state: %v",
 		mode,
 		resetWorkflowState,
-	),
 	)
 }
 
@@ -359,12 +353,11 @@ func newInvalidConflictResolveWorkflowWithNewMode(
 	resetWorkflowState enumsspb.WorkflowExecutionState,
 	newWorkflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewInternalf(
 		"Invalid workflow conflict resolve mode %v, reset state: %v, new state: %v",
 		mode,
 		resetWorkflowState,
 		newWorkflowState,
-	),
 	)
 }
 
@@ -373,12 +366,11 @@ func newInvalidConflictResolveWorkflowWithCurrentMode(
 	resetWorkflowState enumsspb.WorkflowExecutionState,
 	currentWorkflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewInternalf(
 		"Invalid workflow conflict resolve mode %v, reset state: %v, current state: %v",
 		mode,
 		resetWorkflowState,
 		currentWorkflowState,
-	),
 	)
 }
 
@@ -388,12 +380,11 @@ func newInvalidConflictResolveWorkflowWithCurrentWithNewMode(
 	newWorkflowState enumsspb.WorkflowExecutionState,
 	currentWorkflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewInternalf(
 		"Invalid workflow conflict resolve mode %v, reset state: %v, new state: %v, current state: %v",
 		mode,
 		resetWorkflowState,
 		newWorkflowState,
 		currentWorkflowState,
-	),
 	)
 }

--- a/common/persistence/persistence_metric_clients.go
+++ b/common/persistence/persistence_metric_clients.go
@@ -2,7 +2,6 @@ package persistence
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -362,7 +361,7 @@ func (p *executionPersistenceClient) GetHistoryTasks(
 	case tasks.CategoryIDOutbound:
 		operation = metrics.PersistenceGetOutboundTasksScope
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("unknown task category type: %v", request.TaskCategory))
+		return nil, serviceerror.NewInternalf("unknown task category type: %v", request.TaskCategory)
 	}
 
 	caller := headers.GetCallerInfo(ctx).CallerName
@@ -393,7 +392,7 @@ func (p *executionPersistenceClient) CompleteHistoryTask(
 	case tasks.CategoryIDOutbound:
 		operation = metrics.PersistenceCompleteOutboundTasksScope
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown task category type: %v", request.TaskCategory))
+		return serviceerror.NewInternalf("unknown task category type: %v", request.TaskCategory)
 	}
 
 	caller := headers.GetCallerInfo(ctx).CallerName
@@ -424,7 +423,7 @@ func (p *executionPersistenceClient) RangeCompleteHistoryTasks(
 	case tasks.CategoryIDOutbound:
 		operation = metrics.PersistenceRangeCompleteOutboundTasksScope
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown task category type: %v", request.TaskCategory))
+		return serviceerror.NewInternalf("unknown task category type: %v", request.TaskCategory)
 	}
 
 	caller := headers.GetCallerInfo(ctx).CallerName

--- a/common/persistence/queue_v2.go
+++ b/common/persistence/queue_v2.go
@@ -1,8 +1,6 @@
 package persistence
 
 import (
-	"fmt"
-
 	"go.temporal.io/api/serviceerror"
 )
 
@@ -37,9 +35,9 @@ var (
 )
 
 func NewQueueNotFoundError(queueType QueueV2Type, queueName string) error {
-	return serviceerror.NewNotFound(fmt.Sprintf(
+	return serviceerror.NewNotFoundf(
 		"queue not found: type = %v and name = %v",
 		queueType,
 		queueName,
-	))
+	)
 }

--- a/common/persistence/serialization/task_serializer.go
+++ b/common/persistence/serialization/task_serializer.go
@@ -1,7 +1,6 @@
 package serialization
 
 import (
-	"fmt"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -42,7 +41,7 @@ func (s *TaskSerializer) SerializeTask(
 	case tasks.CategoryIDOutbound:
 		return s.serializeOutboundTask(task)
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown task category: %v", category))
+		return nil, serviceerror.NewInternalf("Unknown task category: %v", category)
 	}
 }
 
@@ -64,7 +63,7 @@ func (s *TaskSerializer) DeserializeTask(
 	case tasks.CategoryIDOutbound:
 		return s.deserializeOutboundTask(blob)
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown task category: %v", category))
+		return nil, serviceerror.NewInternalf("Unknown task category: %v", category)
 	}
 }
 
@@ -92,7 +91,7 @@ func (s *TaskSerializer) serializeTransferTask(
 	case *tasks.ChasmTask:
 		transferTask = s.transferChasmTaskToProto(task)
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown transfer task type: %v", task))
+		return nil, serviceerror.NewInternalf("Unknown transfer task type: %v", task)
 	}
 
 	return TransferTaskInfoToBlob(transferTask)
@@ -141,7 +140,7 @@ func (s *TaskSerializer) deserializeTransferTasks(
 	case enumsspb.TASK_TYPE_CHASM:
 		task = s.transferChasmTaskFromProto(transferTask)
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown transfer task type: %v", transferTask.TaskType))
+		return nil, serviceerror.NewInternalf("Unknown transfer task type: %v", transferTask.TaskType)
 	}
 	return task, nil
 }
@@ -188,7 +187,7 @@ func (s *TaskSerializer) serializeTimerTask(
 	case *tasks.ChasmTaskPure:
 		timerTask = s.timerChasmPureTaskToProto(task)
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown timer task type: %v", task))
+		return nil, serviceerror.NewInternalf("Unknown timer task type: %v", task)
 	}
 	return TimerTaskInfoToBlob(timerTask)
 }
@@ -251,7 +250,7 @@ func (s *TaskSerializer) deserializeTimerTasks(
 	case enumsspb.TASK_TYPE_CHASM_PURE:
 		timer = s.timerChasmPureTaskFromProto(timerTask)
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown timer task type: %v", timerTask.TaskType))
+		return nil, serviceerror.NewInternalf("Unknown timer task type: %v", timerTask.TaskType)
 	}
 	return timer, nil
 }
@@ -297,7 +296,7 @@ func (s *TaskSerializer) serializeVisibilityTask(
 	case *tasks.DeleteExecutionVisibilityTask:
 		visibilityTask = s.visibilityDeleteTaskToProto(task)
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown visibility task type: %v", task))
+		return nil, serviceerror.NewInternalf("Unknown visibility task type: %v", task)
 	}
 
 	return VisibilityTaskInfoToBlob(visibilityTask)
@@ -322,7 +321,7 @@ func (s *TaskSerializer) deserializeVisibilityTasks(
 	case enumsspb.TASK_TYPE_VISIBILITY_DELETE_EXECUTION:
 		visibility = s.visibilityDeleteTaskFromProto(visibilityTask)
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown visibility task type: %v", visibilityTask.TaskType))
+		return nil, serviceerror.NewInternalf("Unknown visibility task type: %v", visibilityTask.TaskType)
 	}
 	return visibility, nil
 }
@@ -361,7 +360,7 @@ func (s *TaskSerializer) ParseReplicationTask(replicationTask *persistencespb.Re
 	case enumsspb.TASK_TYPE_REPLICATION_SYNC_VERSIONED_TRANSITION:
 		return s.replicationSyncVersionedTransitionTaskFromProto(replicationTask)
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown replication task type: %v", replicationTask.TaskType))
+		return nil, serviceerror.NewInternalf("Unknown replication task type: %v", replicationTask.TaskType)
 	}
 }
 
@@ -378,7 +377,7 @@ func (s *TaskSerializer) ParseReplicationTaskInfo(task tasks.Task) (*persistence
 	case *tasks.SyncVersionedTransitionTask:
 		return s.replicationSyncVersionedTransitionTaskToProto(task)
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown repication task type: %v", task))
+		return nil, serviceerror.NewInternalf("Unknown repication task type: %v", task)
 	}
 }
 
@@ -390,8 +389,8 @@ func (s *TaskSerializer) serializeArchivalTask(
 	case *tasks.ArchiveExecutionTask:
 		archivalTaskInfo = s.archiveExecutionTaskToProto(task)
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf(
-			"Unknown archival task type while serializing: %v", task))
+		return nil, serviceerror.NewInternalf(
+			"Unknown archival task type while serializing: %v", task)
 	}
 
 	return ArchivalTaskInfoToBlob(archivalTaskInfo)
@@ -409,7 +408,7 @@ func (s *TaskSerializer) deserializeArchivalTasks(
 	case enumsspb.TASK_TYPE_ARCHIVAL_ARCHIVE_EXECUTION:
 		task = s.archiveExecutionTaskFromProto(archivalTask)
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown archival task type while deserializing: %v", task))
+		return nil, serviceerror.NewInternalf("Unknown archival task type while deserializing: %v", task)
 	}
 	return task, nil
 }
@@ -1416,7 +1415,7 @@ func (s *TaskSerializer) serializeOutboundTask(task tasks.Task) (*commonpb.DataB
 				ChasmTaskInfo: task.Info,
 			}})
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("unknown outbound task type while serializing: %v", task))
+		return nil, serviceerror.NewInternalf("unknown outbound task type while serializing: %v", task)
 	}
 }
 
@@ -1455,6 +1454,6 @@ func (s *TaskSerializer) deserializeOutboundTask(blob *commonpb.DataBlob) (tasks
 			Destination:         info.Destination,
 		}, nil
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("unknown outbound task type while deserializing: %v", info))
+		return nil, serviceerror.NewInternalf("unknown outbound task type while deserializing: %v", info)
 	}
 }

--- a/common/persistence/sql/common.go
+++ b/common/persistence/sql/common.go
@@ -49,7 +49,7 @@ func (m *SqlStore) Close() {
 func (m *SqlStore) txExecute(ctx context.Context, operation string, f func(tx sqlplugin.Tx) error) error {
 	tx, err := m.Db.BeginTx(ctx)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("%s failed. Failed to start transaction. Error: %v", operation, err))
+		return serviceerror.NewUnavailablef("%s failed. Failed to start transaction. Error: %v", operation, err)
 	}
 	err = f(tx)
 	if err != nil {
@@ -68,11 +68,11 @@ func (m *SqlStore) txExecute(ctx context.Context, operation string, f func(tx sq
 			*serviceerror.NotFound:
 			return err
 		default:
-			return serviceerror.NewUnavailable(fmt.Sprintf("%v: %v", operation, err))
+			return serviceerror.NewUnavailablef("%v: %v", operation, err)
 		}
 	}
 	if err := tx.Commit(); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("%s operation failed. Failed to commit transaction. Error: %v", operation, err))
+		return serviceerror.NewUnavailablef("%s operation failed. Failed to commit transaction. Error: %v", operation, err)
 	}
 	return nil
 }
@@ -82,7 +82,7 @@ func gobSerialize(x interface{}) ([]byte, error) {
 	e := gob.NewEncoder(&b)
 	err := e.Encode(x)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Error in serialization: %v", err))
+		return nil, serviceerror.NewInternalf("Error in serialization: %v", err)
 	}
 	return b.Bytes(), nil
 }
@@ -92,7 +92,7 @@ func gobDeserialize(a []byte, x interface{}) error {
 	d := gob.NewDecoder(b)
 	err := d.Decode(x)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("Error in deserialization: %v", err))
+		return serviceerror.NewInternalf("Error in deserialization: %v", err)
 	}
 	return nil
 }
@@ -127,8 +127,8 @@ func convertCommonErrors(
 	err error,
 ) error {
 	if err == sql.ErrNoRows {
-		return serviceerror.NewNotFound(fmt.Sprintf("%v failed. Error: %v ", operation, err))
+		return serviceerror.NewNotFoundf("%v failed. Error: %v ", operation, err)
 	}
 
-	return serviceerror.NewUnavailable(fmt.Sprintf("%v operation failed. Error: %v", operation, err))
+	return serviceerror.NewUnavailablef("%v operation failed. Error: %v", operation, err)
 }

--- a/common/persistence/sql/execution.go
+++ b/common/persistence/sql/execution.go
@@ -170,7 +170,7 @@ func (m *sqlExecutionStore) createWorkflowExecutionTx(
 		}
 
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("CreteWorkflowExecution: unknown mode: %v", request.Mode))
+		return nil, serviceerror.NewInternalf("CreteWorkflowExecution: unknown mode: %v", request.Mode)
 	}
 
 	row := sqlplugin.CurrentExecutionsRow{
@@ -219,9 +219,9 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 	case nil:
 		// noop
 	case sql.ErrNoRows:
-		return nil, serviceerror.NewNotFound(fmt.Sprintf("Workflow executionsRow not found.  WorkflowId: %v, RunId: %v", workflowID, runID))
+		return nil, serviceerror.NewNotFoundf("Workflow executionsRow not found.  WorkflowId: %v, RunId: %v", workflowID, runID)
 	default:
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetWorkflowExecution: failed. Error: %v", err)
 	}
 
 	state := &p.InternalWorkflowMutableState{
@@ -240,7 +240,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get activity info. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetWorkflowExecution: failed to get activity info. Error: %v", err)
 	}
 
 	state.TimerInfos, err = getTimerInfoMap(ctx,
@@ -251,7 +251,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get timer info. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetWorkflowExecution: failed to get timer info. Error: %v", err)
 	}
 
 	state.ChildExecutionInfos, err = getChildExecutionInfoMap(ctx,
@@ -262,7 +262,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get child executionsRow info. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetWorkflowExecution: failed to get child executionsRow info. Error: %v", err)
 	}
 
 	state.RequestCancelInfos, err = getRequestCancelInfoMap(ctx,
@@ -273,7 +273,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get request cancel info. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetWorkflowExecution: failed to get request cancel info. Error: %v", err)
 	}
 
 	state.SignalInfos, err = getSignalInfoMap(ctx,
@@ -284,7 +284,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get signal info. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetWorkflowExecution: failed to get signal info. Error: %v", err)
 	}
 
 	state.BufferedEvents, err = getBufferedEvents(ctx,
@@ -295,7 +295,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get buffered events. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetWorkflowExecution: failed to get buffered events. Error: %v", err)
 	}
 
 	state.ChasmNodes, err = getChasmNodeMap(ctx,
@@ -306,7 +306,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get CHASM nodes. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetWorkflowExecution: failed to get CHASM nodes. Error: %v", err)
 	}
 
 	state.SignalRequestedIDs, err = getSignalsRequested(ctx,
@@ -317,7 +317,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get signals requested. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetWorkflowExecution: failed to get signals requested. Error: %v", err)
 	}
 
 	return &p.InternalGetWorkflowExecutionResponse{
@@ -420,7 +420,7 @@ func (m *sqlExecutionStore) updateWorkflowExecutionTx(
 		}
 
 	default:
-		return serviceerror.NewUnavailable(fmt.Sprintf("UpdateWorkflowExecution: unknown mode: %v", request.Mode))
+		return serviceerror.NewUnavailablef("UpdateWorkflowExecution: unknown mode: %v", request.Mode)
 	}
 
 	if err := applyWorkflowMutationTx(ctx, tx, shardID, &updateWorkflow); err != nil {
@@ -531,7 +531,7 @@ func (m *sqlExecutionStore) conflictResolveWorkflowExecutionTx(
 		}
 
 	default:
-		return serviceerror.NewUnavailable(fmt.Sprintf("ConflictResolveWorkflowExecution: unknown mode: %v", request.Mode))
+		return serviceerror.NewUnavailablef("ConflictResolveWorkflowExecution: unknown mode: %v", request.Mode)
 	}
 
 	if err := applyWorkflowSnapshotTxAsReset(ctx,
@@ -679,7 +679,7 @@ func (m *sqlExecutionStore) GetCurrentExecution(
 		if err == sql.ErrNoRows {
 			return nil, serviceerror.NewNotFound(err.Error())
 		}
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetCurrentExecution operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetCurrentExecution operation failed. Error: %v", err)
 	}
 
 	return &p.InternalGetCurrentExecutionResponse{

--- a/common/persistence/sql/execution_state_map.go
+++ b/common/persistence/sql/execution_state_map.go
@@ -3,7 +3,6 @@ package sql
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
@@ -40,7 +39,7 @@ func updateActivityInfos(
 		}
 
 		if _, err := tx.ReplaceIntoActivityInfoMaps(ctx, rows); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update activity info. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update activity info. Failed to execute update query. Error: %v", err)
 		}
 	}
 
@@ -52,7 +51,7 @@ func updateActivityInfos(
 			RunID:       runID,
 			ScheduleIDs: convert.Int64SetToSlice(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update activity info. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update activity info. Failed to execute delete query. Error: %v", err)
 		}
 	}
 	return nil
@@ -74,7 +73,7 @@ func getActivityInfoMap(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get activity info. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("Failed to get activity info. Error: %v", err)
 	}
 
 	ret := make(map[int64]*commonpb.DataBlob)
@@ -100,7 +99,7 @@ func deleteActivityInfoMap(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete activity info map. Error: %v", err))
+		return serviceerror.NewUnavailablef("Failed to delete activity info map. Error: %v", err)
 	}
 	return nil
 }
@@ -130,7 +129,7 @@ func updateTimerInfos(
 			})
 		}
 		if _, err := tx.ReplaceIntoTimerInfoMaps(ctx, rows); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update timer info. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update timer info. Failed to execute update query. Error: %v", err)
 		}
 	}
 
@@ -142,7 +141,7 @@ func updateTimerInfos(
 			RunID:       runID,
 			TimerIDs:    convert.StringSetToSlice(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update timer info. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update timer info. Failed to execute delete query. Error: %v", err)
 		}
 	}
 	return nil
@@ -164,7 +163,7 @@ func getTimerInfoMap(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get timer info. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("Failed to get timer info. Error: %v", err)
 	}
 	ret := make(map[string]*commonpb.DataBlob)
 	for _, row := range rows {
@@ -189,7 +188,7 @@ func deleteTimerInfoMap(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete timer info map. Error: %v", err))
+		return serviceerror.NewUnavailablef("Failed to delete timer info map. Error: %v", err)
 	}
 	return nil
 }
@@ -219,7 +218,7 @@ func updateChildExecutionInfos(
 			})
 		}
 		if _, err := tx.ReplaceIntoChildExecutionInfoMaps(ctx, rows); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update child execution info. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update child execution info. Failed to execute update query. Error: %v", err)
 		}
 	}
 
@@ -231,7 +230,7 @@ func updateChildExecutionInfos(
 			RunID:        runID,
 			InitiatedIDs: convert.Int64SetToSlice(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update child execution info. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update child execution info. Failed to execute delete query. Error: %v", err)
 		}
 	}
 	return nil
@@ -253,7 +252,7 @@ func getChildExecutionInfoMap(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get timer info. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("Failed to get timer info. Error: %v", err)
 	}
 
 	ret := make(map[int64]*commonpb.DataBlob)
@@ -279,7 +278,7 @@ func deleteChildExecutionInfoMap(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete timer info map. Error: %v", err))
+		return serviceerror.NewUnavailablef("Failed to delete timer info map. Error: %v", err)
 	}
 	return nil
 }
@@ -310,7 +309,7 @@ func updateRequestCancelInfos(
 		}
 
 		if _, err := tx.ReplaceIntoRequestCancelInfoMaps(ctx, rows); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update request cancel info. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update request cancel info. Failed to execute update query. Error: %v", err)
 		}
 	}
 
@@ -322,7 +321,7 @@ func updateRequestCancelInfos(
 			RunID:        runID,
 			InitiatedIDs: convert.Int64SetToSlice(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update request cancel info. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update request cancel info. Failed to execute delete query. Error: %v", err)
 		}
 	}
 	return nil
@@ -344,7 +343,7 @@ func getRequestCancelInfoMap(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get request cancel info. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("Failed to get request cancel info. Error: %v", err)
 	}
 
 	ret := make(map[int64]*commonpb.DataBlob)
@@ -370,7 +369,7 @@ func deleteRequestCancelInfoMap(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete request cancel info map. Error: %v", err))
+		return serviceerror.NewUnavailablef("Failed to delete request cancel info map. Error: %v", err)
 	}
 	return nil
 }
@@ -401,7 +400,7 @@ func updateSignalInfos(
 		}
 
 		if _, err := tx.ReplaceIntoSignalInfoMaps(ctx, rows); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update signal info. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update signal info. Failed to execute update query. Error: %v", err)
 		}
 	}
 
@@ -413,7 +412,7 @@ func updateSignalInfos(
 			RunID:        runID,
 			InitiatedIDs: convert.Int64SetToSlice(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update signal info. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update signal info. Failed to execute delete query. Error: %v", err)
 		}
 	}
 	return nil
@@ -435,7 +434,7 @@ func getSignalInfoMap(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get signal info. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("Failed to get signal info. Error: %v", err)
 	}
 
 	ret := make(map[int64]*commonpb.DataBlob)
@@ -461,7 +460,7 @@ func deleteSignalInfoMap(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete signal info map. Error: %v", err))
+		return serviceerror.NewUnavailablef("Failed to delete signal info map. Error: %v", err)
 	}
 	return nil
 }
@@ -492,7 +491,7 @@ func updateChasmNodes(
 			})
 		}
 		if _, err := tx.ReplaceIntoChasmNodeMaps(ctx, rows); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update CHASM nodes. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update CHASM nodes. Failed to execute update query. Error: %v", err)
 		}
 	}
 
@@ -504,7 +503,7 @@ func updateChasmNodes(
 			RunID:       runID,
 			ChasmPaths:  expmaps.Keys(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update CHASM nodes. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update CHASM nodes. Failed to execute delete query. Error: %v", err)
 		}
 	}
 
@@ -526,7 +525,7 @@ func getChasmNodeMap(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get CHASM nodes. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("Failed to get CHASM nodes. Error: %v", err)
 	}
 
 	ret := make(map[string]persistence.InternalChasmNode)
@@ -554,7 +553,7 @@ func deleteChasmNodeMap(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete CHASM node map. Error: %v", err))
+		return serviceerror.NewUnavailablef("Failed to delete CHASM node map. Error: %v", err)
 	}
 	return nil
 }

--- a/common/persistence/sql/execution_state_non_map.go
+++ b/common/persistence/sql/execution_state_non_map.go
@@ -3,7 +3,6 @@ package sql
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
@@ -36,7 +35,7 @@ func updateSignalsRequested(
 			})
 		}
 		if _, err := tx.ReplaceIntoSignalsRequestedSets(ctx, rows); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update signals requested. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update signals requested. Failed to execute update query. Error: %v", err)
 		}
 	}
 
@@ -48,7 +47,7 @@ func updateSignalsRequested(
 			RunID:       runID,
 			SignalIDs:   convert.StringSetToSlice(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update signals requested. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailablef("Failed to update signals requested. Failed to execute delete query. Error: %v", err)
 		}
 	}
 	return nil
@@ -70,7 +69,7 @@ func getSignalsRequested(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get signals requested. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("Failed to get signals requested. Error: %v", err)
 	}
 	var ret = make([]string, len(rows))
 	for i, s := range rows {
@@ -94,7 +93,7 @@ func deleteSignalsRequestedSet(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete signals requested set. Error: %v", err))
+		return serviceerror.NewUnavailablef("Failed to delete signals requested set. Error: %v", err)
 	}
 	return nil
 }
@@ -122,7 +121,7 @@ func updateBufferedEvents(
 	}
 
 	if _, err := tx.InsertIntoBufferedEvents(ctx, []sqlplugin.BufferedEventsRow{row}); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("updateBufferedEvents operation failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("updateBufferedEvents operation failed. Error: %v", err)
 	}
 	return nil
 }
@@ -143,7 +142,7 @@ func getBufferedEvents(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("getBufferedEvents operation failed. Select failed: %v", err))
+		return nil, serviceerror.NewUnavailablef("getBufferedEvents operation failed. Select failed: %v", err)
 	}
 	var result []*commonpb.DataBlob
 	for _, row := range rows {
@@ -167,7 +166,7 @@ func deleteBufferedEvents(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("updateBufferedEvents delete operation failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("updateBufferedEvents delete operation failed. Error: %v", err)
 	}
 	return nil
 }

--- a/common/persistence/sql/execution_util.go
+++ b/common/persistence/sql/execution_util.go
@@ -32,12 +32,12 @@ func applyWorkflowMutationTx(
 
 	namespaceIDBytes, err := primitives.ParseUUID(namespaceID)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("uuid parse failed. Error: %v", err))
+		return serviceerror.NewInternalf("uuid parse failed. Error: %v", err)
 	}
 
 	runIDBytes, err := primitives.ParseUUID(runID)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("uuid parse failed. Error: %v", err))
+		return serviceerror.NewInternalf("uuid parse failed. Error: %v", err)
 	}
 
 	// TODO Remove me if UPDATE holds the lock to the end of a transaction
@@ -54,7 +54,7 @@ func applyWorkflowMutationTx(
 		case *p.WorkflowConditionFailedError, *p.ConditionFailedError:
 			return err
 		default:
-			return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Failed to lock executions row. Error: %v", err))
+			return serviceerror.NewUnavailablef("applyWorkflowMutationTx failed. Failed to lock executions row. Error: %v", err)
 		}
 	}
 
@@ -69,7 +69,7 @@ func applyWorkflowMutationTx(
 		workflowMutation.DBRecordVersion,
 		shardID,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Failed to update executions row. Erorr: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowMutationTx failed. Failed to update executions row. Erorr: %v", err)
 	}
 
 	if err := applyTasks(ctx,
@@ -89,7 +89,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowMutationTx failed. Error: %v", err)
 	}
 
 	if err := updateTimerInfos(ctx,
@@ -101,7 +101,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowMutationTx failed. Error: %v", err)
 	}
 
 	if err := updateChildExecutionInfos(ctx,
@@ -113,7 +113,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowMutationTx failed. Error: %v", err)
 	}
 
 	if err := updateRequestCancelInfos(ctx,
@@ -125,7 +125,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowMutationTx failed. Error: %v", err)
 	}
 
 	if err := updateSignalInfos(ctx,
@@ -137,7 +137,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowMutationTx failed. Error: %v", err)
 	}
 
 	if err := updateSignalsRequested(ctx,
@@ -148,7 +148,7 @@ func applyWorkflowMutationTx(
 		namespaceIDBytes,
 		workflowID,
 		runIDBytes); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowMutationTx failed. Error: %v", err)
 	}
 
 	if workflowMutation.ClearBufferedEvents {
@@ -159,7 +159,7 @@ func applyWorkflowMutationTx(
 			workflowID,
 			runIDBytes,
 		); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+			return serviceerror.NewUnavailablef("applyWorkflowMutationTx failed. Error: %v", err)
 		}
 	}
 
@@ -171,7 +171,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowMutationTx failed. Error: %v", err)
 	}
 
 	if err := updateChasmNodes(ctx,
@@ -183,7 +183,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowMutationTx failed. Error: %v", err)
 	}
 
 	return nil
@@ -223,7 +223,7 @@ func applyWorkflowSnapshotTxAsReset(
 		case *p.WorkflowConditionFailedError, *p.ConditionFailedError:
 			return err
 		default:
-			return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to lock executions row. Error: %v", err))
+			return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to lock executions row. Error: %v", err)
 		}
 	}
 
@@ -238,7 +238,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowSnapshot.DBRecordVersion,
 		shardID,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to update executions row. Erorr: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to update executions row. Erorr: %v", err)
 	}
 
 	if err := applyTasks(ctx,
@@ -256,7 +256,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear activity info map. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to clear activity info map. Error: %v", err)
 	}
 
 	if err := updateActivityInfos(ctx,
@@ -268,7 +268,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into activity info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to insert into activity info map after clearing. Error: %v", err)
 	}
 
 	if err := deleteTimerInfoMap(ctx,
@@ -278,7 +278,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear timer info map. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to clear timer info map. Error: %v", err)
 	}
 
 	if err := updateTimerInfos(ctx,
@@ -290,7 +290,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into timer info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to insert into timer info map after clearing. Error: %v", err)
 	}
 
 	if err := deleteChildExecutionInfoMap(ctx,
@@ -300,7 +300,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear child execution info map. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to clear child execution info map. Error: %v", err)
 	}
 
 	if err := updateChildExecutionInfos(ctx,
@@ -312,7 +312,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into activity info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to insert into activity info map after clearing. Error: %v", err)
 	}
 
 	if err := deleteRequestCancelInfoMap(ctx,
@@ -322,7 +322,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear request cancel info map. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to clear request cancel info map. Error: %v", err)
 	}
 
 	if err := updateRequestCancelInfos(ctx,
@@ -334,7 +334,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into request cancel info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to insert into request cancel info map after clearing. Error: %v", err)
 	}
 
 	if err := deleteSignalInfoMap(ctx,
@@ -344,7 +344,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear signal info map. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to clear signal info map. Error: %v", err)
 	}
 
 	if err := updateSignalInfos(ctx,
@@ -356,7 +356,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into signal info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to insert into signal info map after clearing. Error: %v", err)
 	}
 
 	if err := deleteSignalsRequestedSet(ctx,
@@ -365,7 +365,7 @@ func applyWorkflowSnapshotTxAsReset(
 		namespaceIDBytes,
 		workflowID,
 		runIDBytes); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear signals requested set. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to clear signals requested set. Error: %v", err)
 	}
 
 	if err := updateSignalsRequested(ctx,
@@ -377,7 +377,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into signals requested set after clearing. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to insert into signals requested set after clearing. Error: %v", err)
 	}
 
 	if err := deleteBufferedEvents(ctx,
@@ -387,7 +387,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear buffered events. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to clear buffered events. Error: %v", err)
 	}
 
 	if err := deleteChasmNodeMap(ctx,
@@ -397,7 +397,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear CHASM nodes. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to clear CHASM nodes. Error: %v", err)
 	}
 
 	if err := updateChasmNodes(ctx,
@@ -409,7 +409,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to update CHASM nodes. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsReset failed. Failed to update CHASM nodes. Error: %v", err)
 	}
 
 	return nil
@@ -466,7 +466,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into activity info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsNew failed. Failed to insert into activity info map after clearing. Error: %v", err)
 	}
 
 	if err := updateTimerInfos(ctx,
@@ -478,7 +478,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into timer info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsNew failed. Failed to insert into timer info map after clearing. Error: %v", err)
 	}
 
 	if err := updateChildExecutionInfos(ctx,
@@ -490,7 +490,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into activity info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsNew failed. Failed to insert into activity info map after clearing. Error: %v", err)
 	}
 
 	if err := updateRequestCancelInfos(ctx,
@@ -502,7 +502,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into request cancel info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsNew failed. Failed to insert into request cancel info map after clearing. Error: %v", err)
 	}
 
 	if err := updateSignalInfos(ctx,
@@ -514,7 +514,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into signal info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsNew failed. Failed to insert into signal info map after clearing. Error: %v", err)
 	}
 
 	if err := updateSignalsRequested(ctx,
@@ -526,7 +526,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into signals requested set after clearing. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsNew failed. Failed to insert into signals requested set after clearing. Error: %v", err)
 	}
 
 	if err := updateChasmNodes(ctx,
@@ -538,7 +538,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to update CHASM nodes. Error: %v", err))
+		return serviceerror.NewUnavailablef("applyWorkflowSnapshotTxAsNew failed. Failed to update CHASM nodes. Error: %v", err)
 	}
 
 	return nil
@@ -559,7 +559,7 @@ func applyTasks(
 		case tasks.CategoryTypeScheduled:
 			err = createScheduledTasks(ctx, tx, shardID, category.ID(), tasksByCategory)
 		default:
-			err = serviceerror.NewInternal(fmt.Sprintf("Unknown task category type: %v", category))
+			err = serviceerror.NewInternalf("Unknown task category type: %v", category)
 		}
 
 		if err != nil {
@@ -584,12 +584,12 @@ func lockCurrentExecutionIfExists(
 	})
 	if err != nil {
 		if err != sql.ErrNoRows {
-			return nil, serviceerror.NewUnavailable(fmt.Sprintf("lockCurrentExecutionIfExists failed. Failed to get current_executions row for (shard,namespace,workflow) = (%v, %v, %v). Error: %v", shardID, namespaceID, workflowID, err))
+			return nil, serviceerror.NewUnavailablef("lockCurrentExecutionIfExists failed. Failed to get current_executions row for (shard,namespace,workflow) = (%v, %v, %v). Error: %v", shardID, namespaceID, workflowID, err)
 		}
 	}
 	size := len(rows)
 	if size > 1 {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("lockCurrentExecutionIfExists failed. Multiple current_executions rows for (shard,namespace,workflow) = (%v, %v, %v).", shardID, namespaceID, workflowID))
+		return nil, serviceerror.NewUnavailablef("lockCurrentExecutionIfExists failed. Multiple current_executions rows for (shard,namespace,workflow) = (%v, %v, %v).", shardID, namespaceID, workflowID)
 	}
 	if size == 0 {
 		return nil, nil
@@ -607,11 +607,11 @@ func createOrUpdateCurrentExecution(
 	switch createMode {
 	case p.CreateWorkflowModeUpdateCurrent:
 		if err := updateCurrentExecution(ctx, tx, row); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("createOrUpdateCurrentExecution failed. Failed to reuse workflow ID. Error: %v", err))
+			return serviceerror.NewUnavailablef("createOrUpdateCurrentExecution failed. Failed to reuse workflow ID. Error: %v", err)
 		}
 	case p.CreateWorkflowModeBrandNew:
 		if _, err := tx.InsertIntoCurrentExecutions(ctx, &row); err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("createOrUpdateCurrentExecution failed. Failed to insert into current_executions table. Error: %v", err))
+			return serviceerror.NewUnavailablef("createOrUpdateCurrentExecution failed. Failed to insert into current_executions table. Error: %v", err)
 		}
 	case p.CreateWorkflowModeBypassCurrent:
 		// noop
@@ -685,7 +685,7 @@ func lockExecution(
 					runID),
 			}
 		}
-		return 0, 0, serviceerror.NewUnavailable(fmt.Sprintf("lockNextEventID failed. Error: %v", err))
+		return 0, 0, serviceerror.NewUnavailablef("lockNextEventID failed. Error: %v", err)
 	}
 	return dbRecordVersion, nextEventID, nil
 }
@@ -726,16 +726,16 @@ func createImmediateTasks(
 
 	result, err := tx.InsertIntoHistoryImmediateTasks(ctx, immediateTasksRows)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createImmediateTasks failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("createImmediateTasks failed. Error: %v", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createImmediateTasks failed. Could not verify number of rows inserted. Error: %v", err))
+		return serviceerror.NewUnavailablef("createImmediateTasks failed. Could not verify number of rows inserted. Error: %v", err)
 	}
 
 	if int(rowsAffected) != len(immediateTasksRows) {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createImmediateTasks failed. Inserted %v instead of %v rows into history_immediate_tasks. Error: %v", rowsAffected, len(immediateTasksRows), err))
+		return serviceerror.NewUnavailablef("createImmediateTasks failed. Inserted %v instead of %v rows into history_immediate_tasks. Error: %v", rowsAffected, len(immediateTasksRows), err)
 	}
 	return nil
 }
@@ -772,15 +772,15 @@ func createScheduledTasks(
 
 	result, err := tx.InsertIntoHistoryScheduledTasks(ctx, scheduledTasksRows)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createScheduledTasks failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("createScheduledTasks failed. Error: %v", err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createScheduledTasks failed. Could not verify number of rows inserted. Error: %v", err))
+		return serviceerror.NewUnavailablef("createScheduledTasks failed. Could not verify number of rows inserted. Error: %v", err)
 	}
 
 	if int(rowsAffected) != len(scheduledTasks) {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createScheduledTasks failed. Inserted %v instead of %v rows into history_scheduled_tasks. Error: %v", rowsAffected, len(scheduledTasks), err))
+		return serviceerror.NewUnavailablef("createScheduledTasks failed. Inserted %v instead of %v rows into history_scheduled_tasks. Error: %v", rowsAffected, len(scheduledTasks), err)
 	}
 	return nil
 }
@@ -808,16 +808,16 @@ func createTransferTasks(
 
 	result, err := tx.InsertIntoTransferTasks(ctx, transferTasksRows)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("createTransferTasks failed. Error: %v", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Could not verify number of rows inserted. Error: %v", err))
+		return serviceerror.NewUnavailablef("createTransferTasks failed. Could not verify number of rows inserted. Error: %v", err)
 	}
 
 	if int(rowsAffected) != len(transferTasks) {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Inserted %v instead of %v rows into transfer_tasks. Error: %v", rowsAffected, len(transferTasks), err))
+		return serviceerror.NewUnavailablef("createTransferTasks failed. Inserted %v instead of %v rows into transfer_tasks. Error: %v", rowsAffected, len(transferTasks), err)
 	}
 	return nil
 }
@@ -846,15 +846,15 @@ func createTimerTasks(
 
 	result, err := tx.InsertIntoTimerTasks(ctx, timerTasksRows)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createTimerTasks failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("createTimerTasks failed. Error: %v", err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createTimerTasks failed. Could not verify number of rows inserted. Error: %v", err))
+		return serviceerror.NewUnavailablef("createTimerTasks failed. Could not verify number of rows inserted. Error: %v", err)
 	}
 
 	if int(rowsAffected) != len(timerTasks) {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createTimerTasks failed. Inserted %v instead of %v rows into timer_tasks. Error: %v", rowsAffected, len(timerTasks), err))
+		return serviceerror.NewUnavailablef("createTimerTasks failed. Inserted %v instead of %v rows into timer_tasks. Error: %v", rowsAffected, len(timerTasks), err)
 	}
 	return nil
 }
@@ -882,16 +882,16 @@ func createReplicationTasks(
 
 	result, err := tx.InsertIntoReplicationTasks(ctx, replicationTasksRows)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createReplicationTasks failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("createReplicationTasks failed. Error: %v", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createReplicationTasks failed. Could not verify number of rows inserted. Error: %v", err))
+		return serviceerror.NewUnavailablef("createReplicationTasks failed. Could not verify number of rows inserted. Error: %v", err)
 	}
 
 	if int(rowsAffected) != len(replicationTasks) {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createReplicationTasks failed. Inserted %v instead of %v rows into transfer_tasks. Error: %v", rowsAffected, len(replicationTasks), err))
+		return serviceerror.NewUnavailablef("createReplicationTasks failed. Inserted %v instead of %v rows into transfer_tasks. Error: %v", rowsAffected, len(replicationTasks), err)
 	}
 	return nil
 }
@@ -919,16 +919,16 @@ func createVisibilityTasks(
 
 	result, err := tx.InsertIntoVisibilityTasks(ctx, visibilityTasksRows)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("createTransferTasks failed. Error: %v", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Could not verify number of rows inserted. Error: %v", err))
+		return serviceerror.NewUnavailablef("createTransferTasks failed. Could not verify number of rows inserted. Error: %v", err)
 	}
 
 	if int(rowsAffected) != len(visibilityTasksRows) {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Inserted %v instead of %v rows into transfer_tasks. Error: %v", rowsAffected, len(visibilityTasksRows), err))
+		return serviceerror.NewUnavailablef("createTransferTasks failed. Inserted %v instead of %v rows into transfer_tasks. Error: %v", rowsAffected, len(visibilityTasksRows), err)
 	}
 	return nil
 }
@@ -951,7 +951,7 @@ func assertNotCurrentExecution(
 			// allow bypassing no current record
 			return nil
 		}
-		return serviceerror.NewUnavailable(fmt.Sprintf("assertCurrentExecution failed. Unable to load current record. Error: %v", err))
+		return serviceerror.NewUnavailablef("assertCurrentExecution failed. Unable to load current record. Error: %v", err)
 	}
 	return assertRunIDMismatch(runID, currentRow)
 }
@@ -1014,7 +1014,7 @@ func assertCurrentExecution(
 		WorkflowID:  workflowID,
 	})
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("assertCurrentExecution failed. Unable to load current record. Error: %v", err))
+		return serviceerror.NewUnavailablef("assertCurrentExecution failed. Unable to load current record. Error: %v", err)
 	}
 	return assertFn(currentRow)
 }
@@ -1045,14 +1045,14 @@ func updateCurrentExecution(
 
 	result, err := tx.UpdateCurrentExecutions(ctx, &row)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("updateCurrentExecution failed. Error: %v", err))
+		return serviceerror.NewUnavailablef("updateCurrentExecution failed. Error: %v", err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("updateCurrentExecution failed. Failed to check number of rows updated in current_executions table. Error: %v", err))
+		return serviceerror.NewUnavailablef("updateCurrentExecution failed. Failed to check number of rows updated in current_executions table. Error: %v", err)
 	}
 	if rowsAffected != 1 {
-		return serviceerror.NewUnavailable(fmt.Sprintf("updateCurrentExecution failed. %v rows of current_executions updated instead of 1.", rowsAffected))
+		return serviceerror.NewUnavailablef("updateCurrentExecution failed. %v rows of current_executions updated instead of 1.", rowsAffected)
 	}
 	return nil
 }
@@ -1134,14 +1134,14 @@ func (m *sqlExecutionStore) createExecution(
 				DBRecordVersion: 0,
 			}
 		}
-		return serviceerror.NewUnavailable(fmt.Sprintf("createExecution failed. Erorr: %v", err))
+		return serviceerror.NewUnavailablef("createExecution failed. Erorr: %v", err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("createExecution failed. Failed to verify number of rows affected. Erorr: %v", err))
+		return serviceerror.NewUnavailablef("createExecution failed. Failed to verify number of rows affected. Erorr: %v", err)
 	}
 	if rowsAffected != 1 {
-		return serviceerror.NewNotFound(fmt.Sprintf("createExecution failed. Affected %v rows updated instead of 1.", rowsAffected))
+		return serviceerror.NewNotFoundf("createExecution failed. Affected %v rows updated instead of 1.", rowsAffected)
 	}
 
 	return nil
@@ -1174,14 +1174,14 @@ func updateExecution(
 	}
 	result, err := tx.UpdateExecutions(ctx, row)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("updateExecution failed. Erorr: %v", err))
+		return serviceerror.NewUnavailablef("updateExecution failed. Erorr: %v", err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("updateExecution failed. Failed to verify number of rows affected. Erorr: %v", err))
+		return serviceerror.NewUnavailablef("updateExecution failed. Failed to verify number of rows affected. Erorr: %v", err)
 	}
 	if rowsAffected != 1 {
-		return serviceerror.NewNotFound(fmt.Sprintf("updateExecution failed. Affected %v rows updated instead of 1.", rowsAffected))
+		return serviceerror.NewNotFoundf("updateExecution failed. Affected %v rows updated instead of 1.", rowsAffected)
 	}
 
 	return nil

--- a/common/persistence/sql/history_store.go
+++ b/common/persistence/sql/history_store.go
@@ -61,7 +61,7 @@ func (m *sqlExecutionStore) AppendHistoryNodes(
 			if m.Db.IsDupEntryError(err) {
 				return &p.ConditionFailedError{Msg: fmt.Sprintf("AppendHistoryNodes: row already exist: %v", err)}
 			}
-			return serviceerror.NewUnavailable(fmt.Sprintf("AppendHistoryNodes: %v", err))
+			return serviceerror.NewUnavailablef("AppendHistoryNodes: %v", err)
 		}
 	}
 
@@ -103,7 +103,7 @@ func (m *sqlExecutionStore) AppendHistoryNodes(
 				Msg: err.Error(),
 			}
 		default:
-			return serviceerror.NewUnavailable(fmt.Sprintf("AppendHistoryNodes: %v", err))
+			return serviceerror.NewUnavailablef("AppendHistoryNodes: %v", err)
 		}
 	})
 }
@@ -142,7 +142,7 @@ func (m *sqlExecutionStore) DeleteHistoryNodes(
 
 	_, err = m.Db.DeleteFromHistoryNode(ctx, nodeRow)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("DeleteHistoryNodes: %v", err))
+		return serviceerror.NewUnavailablef("DeleteHistoryNodes: %v", err)
 	}
 	return nil
 }

--- a/common/persistence/sql/metadata.go
+++ b/common/persistence/sql/metadata.go
@@ -53,7 +53,7 @@ func (m *sqlMetadataManagerV2) CreateNamespace(
 			NotificationVersion: metadata.NotificationVersion,
 		}); err != nil {
 			if m.Db.IsDupEntryError(err) {
-				return serviceerror.NewNamespaceAlreadyExists(fmt.Sprintf("name: %v", request.Name))
+				return serviceerror.NewNamespaceAlreadyExistsf("name: %v", request.Name)
 			}
 			return err
 		}
@@ -101,7 +101,7 @@ func (m *sqlMetadataManagerV2) GetNamespace(
 
 			return nil, serviceerror.NewNamespaceNotFound(identity)
 		default:
-			return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetNamespace operation failed. Error %v", err))
+			return nil, serviceerror.NewUnavailablef("GetNamespace operation failed. Error %v", err)
 		}
 	}
 
@@ -213,7 +213,7 @@ func (m *sqlMetadataManagerV2) GetMetadata(
 ) (*persistence.GetMetadataResponse, error) {
 	row, err := m.Db.SelectFromNamespaceMetadata(ctx)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetMetadata operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetMetadata operation failed. Error: %v", err)
 	}
 	return &persistence.GetMetadataResponse{NotificationVersion: row.NotificationVersion}, nil
 }
@@ -235,7 +235,7 @@ func (m *sqlMetadataManagerV2) ListNamespaces(
 		if err == sql.ErrNoRows {
 			return &persistence.InternalListNamespacesResponse{}, nil
 		}
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListNamespaces operation failed. Failed to get namespace rows. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("ListNamespaces operation failed. Failed to get namespace rows. Error: %v", err)
 	}
 
 	var namespaces []*persistence.InternalGetNamespaceResponse
@@ -264,14 +264,14 @@ func updateMetadata(
 		NotificationVersion: oldNotificationVersion,
 	})
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update namespace metadata. Error: %v", err))
+		return serviceerror.NewUnavailablef("Failed to update namespace metadata. Error: %v", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("Could not verify whether namespace metadata update occurred. Error: %v", err))
+		return serviceerror.NewUnavailablef("Could not verify whether namespace metadata update occurred. Error: %v", err)
 	} else if rowsAffected != 1 {
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update namespace metadata. <>1 rows affected. Error: %v", err))
+		return serviceerror.NewUnavailablef("Failed to update namespace metadata. <>1 rows affected. Error: %v", err)
 	}
 
 	return nil
@@ -283,7 +283,7 @@ func lockMetadata(
 ) (*sqlplugin.NamespaceMetadataRow, error) {
 	row, err := tx.LockNamespaceMetadata(ctx)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to lock namespace metadata. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("Failed to lock namespace metadata. Error: %v", err)
 	}
 	return row, nil
 }

--- a/common/persistence/sql/nexus_endpoint_store.go
+++ b/common/persistence/sql/nexus_endpoint_store.go
@@ -43,7 +43,7 @@ func (s *sqlNexusEndpointStore) CreateOrUpdateNexusEndpoint(
 ) error {
 	id, retErr := primitives.ParseUUID(request.Endpoint.ID)
 	if retErr != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("unable to parse endpoint ID as UUID: %v", retErr))
+		return serviceerror.NewInternalf("unable to parse endpoint ID as UUID: %v", retErr)
 	}
 
 	retErr = s.txExecute(ctx, "CreateOrUpdateNexusEndpoint", func(tx sqlplugin.Tx) error {
@@ -93,13 +93,13 @@ func (s *sqlNexusEndpointStore) GetNexusEndpoint(
 ) (*p.InternalNexusEndpoint, error) {
 	id, err := primitives.ParseUUID(request.ID)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("unable to parse endpoint ID as UUID: %v", err))
+		return nil, serviceerror.NewInternalf("unable to parse endpoint ID as UUID: %v", err)
 	}
 
 	row, err := s.Db.GetNexusEndpointByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, serviceerror.NewNotFound(fmt.Sprintf("Nexus endpoint with ID `%v` not found", request.ID))
+			return nil, serviceerror.NewNotFoundf("Nexus endpoint with ID `%v` not found", request.ID)
 		}
 		s.logger.Error(fmt.Sprintf("error getting Nexus endpoint with ID %v", request.ID), tag.Error(err))
 		return nil, serviceerror.NewUnavailable(err.Error())
@@ -181,7 +181,7 @@ func (s *sqlNexusEndpointStore) DeleteNexusEndpoint(
 ) error {
 	id, retErr := primitives.ParseUUID(request.ID)
 	if retErr != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("unable to parse endpoint ID as UUID: %v", retErr))
+		return serviceerror.NewInternalf("unable to parse endpoint ID as UUID: %v", retErr)
 	}
 
 	retErr = s.txExecute(ctx, "DeleteNexusEndpoint", func(tx sqlplugin.Tx) error {
@@ -201,10 +201,10 @@ func (s *sqlNexusEndpointStore) DeleteNexusEndpoint(
 		nRows, err := result.RowsAffected()
 		if err != nil {
 			s.logger.Error("error getting RowsAffected during DeleteNexusEndpoint", tag.Error(err))
-			return serviceerror.NewUnavailable(fmt.Sprintf("rowsAffected returned error: %v", err))
+			return serviceerror.NewUnavailablef("rowsAffected returned error: %v", err)
 		}
 		if nRows != 1 {
-			return serviceerror.NewNotFound(fmt.Sprintf("nexus endpoint not found for ID: %v", request.ID))
+			return serviceerror.NewNotFoundf("nexus endpoint not found for ID: %v", request.ID)
 		}
 
 		return nil

--- a/common/persistence/sql/queue.go
+++ b/common/persistence/sql/queue.go
@@ -107,7 +107,7 @@ func (q *sqlQueue) DeleteMessagesBefore(
 		MaxMessageID: messageID - 1,
 	})
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("DeleteMessagesBefore operation failed. Error %v", err))
+		return serviceerror.NewUnavailablef("DeleteMessagesBefore operation failed. Error %v", err)
 	}
 	return nil
 }
@@ -124,7 +124,7 @@ func (q *sqlQueue) UpdateAckLevel(
 			Version:      metadata.Version,
 		})
 		if err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("UpdateAckLevel operation failed. Error %v", err))
+			return serviceerror.NewUnavailablef("UpdateAckLevel operation failed. Error %v", err)
 		}
 		rowsAffected, err := result.RowsAffected()
 		if err != nil {
@@ -149,7 +149,7 @@ func (q *sqlQueue) GetAckLevels(
 		QueueType: q.queueType,
 	})
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetAckLevels operation failed. Error %v", err))
+		return nil, serviceerror.NewUnavailablef("GetAckLevels operation failed. Error %v", err)
 	}
 
 	return &persistence.InternalQueueMetadata{
@@ -197,7 +197,7 @@ func (q *sqlQueue) ReadMessagesFromDLQ(
 	if len(pageToken) != 0 {
 		lastReadMessageID, err := deserializePageToken(pageToken)
 		if err != nil {
-			return nil, nil, serviceerror.NewInternal(fmt.Sprintf("invalid next page token %v", pageToken))
+			return nil, nil, serviceerror.NewInternalf("invalid next page token %v", pageToken)
 		}
 		firstMessageID = lastReadMessageID
 	}
@@ -209,7 +209,7 @@ func (q *sqlQueue) ReadMessagesFromDLQ(
 		PageSize:     pageSize,
 	})
 	if err != nil {
-		return nil, nil, serviceerror.NewUnavailable(fmt.Sprintf("ReadMessagesFromDLQ operation failed. Error %v", err))
+		return nil, nil, serviceerror.NewUnavailablef("ReadMessagesFromDLQ operation failed. Error %v", err)
 	}
 
 	var messages []*persistence.QueueMessage
@@ -239,7 +239,7 @@ func (q *sqlQueue) DeleteMessageFromDLQ(
 		MessageID: messageID,
 	})
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("DeleteMessageFromDLQ operation failed. Error %v", err))
+		return serviceerror.NewUnavailablef("DeleteMessageFromDLQ operation failed. Error %v", err)
 	}
 	return nil
 }
@@ -255,7 +255,7 @@ func (q *sqlQueue) RangeDeleteMessagesFromDLQ(
 		MaxMessageID: lastMessageID,
 	})
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("RangeDeleteMessagesFromDLQ operation failed. Error %v", err))
+		return serviceerror.NewUnavailablef("RangeDeleteMessagesFromDLQ operation failed. Error %v", err)
 	}
 	return nil
 }
@@ -272,7 +272,7 @@ func (q *sqlQueue) UpdateDLQAckLevel(
 			DataEncoding: metadata.Blob.EncodingType.String(),
 		})
 		if err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("UpdateDLQAckLevel operation failed. Error %v", err))
+			return serviceerror.NewUnavailablef("UpdateDLQAckLevel operation failed. Error %v", err)
 		}
 		rowsAffected, err := result.RowsAffected()
 		if err != nil {
@@ -297,7 +297,7 @@ func (q *sqlQueue) GetDLQAckLevels(
 		QueueType: q.getDLQTypeFromQueueType(),
 	})
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetDLQAckLevels operation failed. Error %v", err))
+		return nil, serviceerror.NewUnavailablef("GetDLQAckLevels operation failed. Error %v", err)
 	}
 
 	return &persistence.InternalQueueMetadata{
@@ -327,7 +327,7 @@ func (q *sqlQueue) initializeQueueMetadata(
 			DataEncoding: blob.EncodingType.String(),
 		})
 		if err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("initializeQueueMetadata operation failed. Error %v", err))
+			return serviceerror.NewUnavailablef("initializeQueueMetadata operation failed. Error %v", err)
 		}
 		rowsAffected, err := result.RowsAffected()
 		if err != nil {
@@ -359,7 +359,7 @@ func (q *sqlQueue) initializeDLQMetadata(
 			DataEncoding: blob.EncodingType.String(),
 		})
 		if err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("initializeDLQMetadata operation failed. Error %v", err))
+			return serviceerror.NewUnavailablef("initializeDLQMetadata operation failed. Error %v", err)
 		}
 		rowsAffected, err := result.RowsAffected()
 		if err != nil {

--- a/common/persistence/sql/shard.go
+++ b/common/persistence/sql/shard.go
@@ -46,16 +46,16 @@ func (m *sqlShardStore) GetOrCreateShard(
 		}, nil
 	case sql.ErrNoRows:
 	default:
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetOrCreateShard: failed to get ShardID %v. Error: %v", request.ShardID, err))
+		return nil, serviceerror.NewUnavailablef("GetOrCreateShard: failed to get ShardID %v. Error: %v", request.ShardID, err)
 	}
 
 	if request.CreateShardInfo == nil {
-		return nil, serviceerror.NewNotFound(fmt.Sprintf("GetOrCreateShard: ShardID %v not found. Error: %v", request.ShardID, err))
+		return nil, serviceerror.NewNotFoundf("GetOrCreateShard: ShardID %v not found. Error: %v", request.ShardID, err)
 	}
 
 	rangeID, shardInfo, err := request.CreateShardInfo()
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetOrCreateShard: failed to encode shard info for ShardID %v. Error: %v", request.ShardID, err))
+		return nil, serviceerror.NewUnavailablef("GetOrCreateShard: failed to encode shard info for ShardID %v. Error: %v", request.ShardID, err)
 	}
 	row = &sqlplugin.ShardsRow{
 		ShardID:      request.ShardID,
@@ -73,7 +73,7 @@ func (m *sqlShardStore) GetOrCreateShard(
 		request.CreateShardInfo = nil // prevent loop
 		return m.GetOrCreateShard(ctx, request)
 	} else {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetOrCreateShard: failed to insert into shards table. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetOrCreateShard: failed to insert into shards table. Error: %v", err)
 	}
 }
 
@@ -138,9 +138,9 @@ func lockShard(
 		}
 		return nil
 	case sql.ErrNoRows:
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to lock shard with ID %v that does not exist.", shardID))
+		return serviceerror.NewUnavailablef("Failed to lock shard with ID %v that does not exist.", shardID)
 	default:
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to lock shard with ID: %v. Error: %v", shardID, err))
+		return serviceerror.NewUnavailablef("Failed to lock shard with ID: %v. Error: %v", shardID, err)
 	}
 }
 
@@ -164,8 +164,8 @@ func readLockShard(
 		}
 		return nil
 	case sql.ErrNoRows:
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to lock shard with ID %v that does not exist.", shardID))
+		return serviceerror.NewUnavailablef("Failed to lock shard with ID %v that does not exist.", shardID)
 	default:
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to lock shard with ID: %v. Error: %v", shardID, err))
+		return serviceerror.NewUnavailablef("Failed to lock shard with ID: %v. Error: %v", shardID, err)
 	}
 }

--- a/common/persistence/sql/sqlplugin/db_handle.go
+++ b/common/persistence/sql/sqlplugin/db_handle.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
-	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -157,7 +156,7 @@ func (h *DatabaseHandle) ConvertError(err error) error {
 		errors.Is(err, syscall.ECONNABORTED) ||
 		errors.Is(err, syscall.ECONNREFUSED) {
 		h.reconnect(true)
-		return serviceerror.NewUnavailable(fmt.Sprintf("database connection lost: %s", err.Error()))
+		return serviceerror.NewUnavailablef("database connection lost: %s", err.Error())
 	}
 	return err
 }

--- a/common/persistence/sql/task.go
+++ b/common/persistence/sql/task.go
@@ -68,7 +68,7 @@ func (m *sqlTaskManager) CreateTaskQueue(
 		if m.Db.IsDupEntryError(err) {
 			return &persistence.ConditionFailedError{Msg: err.Error()}
 		}
-		return serviceerror.NewUnavailable(fmt.Sprintf("CreateTaskQueue operation failed. Failed to make task queue %v of type %v. Error: %v", request.TaskQueue, request.TaskType, err))
+		return serviceerror.NewUnavailablef("CreateTaskQueue operation failed. Failed to make task queue %v of type %v. Error: %v", request.TaskQueue, request.TaskType, err)
 	}
 
 	return nil
@@ -91,9 +91,9 @@ func (m *sqlTaskManager) GetTaskQueue(
 	switch err {
 	case nil:
 		if len(rows) != 1 {
-			return nil, serviceerror.NewUnavailable(
-				fmt.Sprintf("GetTaskQueue operation failed. Expect exactly one result row, but got %d for task queue %v of type %v",
-					len(rows), request.TaskQueue, request.TaskType))
+			return nil, serviceerror.NewUnavailablef(
+				"GetTaskQueue operation failed. Expect exactly one result row, but got %d for task queue %v of type %v",
+				len(rows), request.TaskQueue, request.TaskType)
 		}
 		row := rows[0]
 		return &persistence.InternalGetTaskQueueResponse{
@@ -101,13 +101,13 @@ func (m *sqlTaskManager) GetTaskQueue(
 			TaskQueueInfo: persistence.NewDataBlob(row.Data, row.DataEncoding),
 		}, nil
 	case sql.ErrNoRows:
-		return nil, serviceerror.NewNotFound(
-			fmt.Sprintf("GetTaskQueue operation failed. TaskQueue: %v, TaskQueueType: %v, Error: %v",
-				request.TaskQueue, request.TaskType, err))
+		return nil, serviceerror.NewNotFoundf(
+			"GetTaskQueue operation failed. TaskQueue: %v, TaskQueueType: %v, Error: %v",
+			request.TaskQueue, request.TaskType, err)
 	default:
-		return nil, serviceerror.NewUnavailable(
-			fmt.Sprintf("GetTaskQueue operation failed. Failed to check if task queue %v of type %v existed. Error: %v",
-				request.TaskQueue, request.TaskType, err))
+		return nil, serviceerror.NewUnavailablef(
+			"GetTaskQueue operation failed. Failed to check if task queue %v of type %v existed. Error: %v",
+			request.TaskQueue, request.TaskType, err)
 	}
 }
 
@@ -161,7 +161,7 @@ func (m *sqlTaskManager) ListTaskQueue(
 	pageToken := taskQueuePageToken{MinTaskQueueId: minTaskQueueId}
 	if request.PageToken != nil {
 		if err := gobDeserialize(request.PageToken, &pageToken); err != nil {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("error deserializing page token: %v", err))
+			return nil, serviceerror.NewInternalf("error deserializing page token: %v", err)
 		}
 	}
 	var err error
@@ -249,7 +249,7 @@ func (m *sqlTaskManager) ListTaskQueue(
 	}
 
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("error serializing nextPageToken:%v", err))
+		return nil, serviceerror.NewUnavailablef("error serializing nextPageToken:%v", err)
 	}
 
 	resp.NextPageToken = nextPageToken
@@ -304,7 +304,7 @@ func (m *sqlTaskManager) DeleteTaskQueue(
 	}
 	nRows, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("rowsAffected returned error:%v", err))
+		return serviceerror.NewUnavailablef("rowsAffected returned error:%v", err)
 	}
 	if nRows != 1 {
 		return &persistence.ConditionFailedError{
@@ -397,7 +397,7 @@ func (m *sqlTaskManager) GetTasks(
 		PageSize:           &request.PageSize,
 	})
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTasks operation failed. Failed to get rows. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetTasks operation failed. Failed to get rows. Error: %v", err)
 	}
 
 	response := &persistence.InternalGetTasksResponse{
@@ -442,7 +442,7 @@ func (m *sqlTaskManager) CompleteTasksLessThan(
 	}
 	nRows, err := result.RowsAffected()
 	if err != nil {
-		return 0, serviceerror.NewUnavailable(fmt.Sprintf("rowsAffected returned error: %v", err))
+		return 0, serviceerror.NewUnavailablef("rowsAffected returned error: %v", err)
 	}
 	return int(nRows), nil
 }
@@ -450,7 +450,7 @@ func (m *sqlTaskManager) CompleteTasksLessThan(
 func (m *sqlTaskManager) GetTaskQueueUserData(ctx context.Context, request *persistence.GetTaskQueueUserDataRequest) (*persistence.InternalGetTaskQueueUserDataResponse, error) {
 	namespaceID, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("failed to parse namespace ID as UUID: %v", err))
+		return nil, serviceerror.NewInternalf("failed to parse namespace ID as UUID: %v", err)
 	}
 	response, err := m.Db.GetTaskQueueUserData(ctx, &sqlplugin.GetTaskQueueUserDataRequest{
 		NamespaceID:   namespaceID,
@@ -458,7 +458,7 @@ func (m *sqlTaskManager) GetTaskQueueUserData(ctx context.Context, request *pers
 	})
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, serviceerror.NewNotFound(fmt.Sprintf("task queue user data not found for %v.%v", request.NamespaceID, request.TaskQueue))
+			return nil, serviceerror.NewNotFoundf("task queue user data not found for %v.%v", request.NamespaceID, request.TaskQueue)
 		}
 		return nil, err
 	}
@@ -471,7 +471,7 @@ func (m *sqlTaskManager) GetTaskQueueUserData(ctx context.Context, request *pers
 func (m *sqlTaskManager) UpdateTaskQueueUserData(ctx context.Context, request *persistence.InternalUpdateTaskQueueUserDataRequest) error {
 	namespaceID, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("failed to parse namespace ID as UUID: %v", err))
+		return serviceerror.NewInternalf("failed to parse namespace ID as UUID: %v", err)
 	}
 	err = m.txExecute(ctx, "UpdateTaskQueueUserData", func(tx sqlplugin.Tx) error {
 		for taskQueue, update := range request.Updates {
@@ -545,7 +545,7 @@ func (m *sqlTaskManager) ListTaskQueueUserDataEntries(ctx context.Context, reque
 		Limit:             request.PageSize,
 	})
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListTaskQueueUserDataEntries operation failed. Failed to get rows. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("ListTaskQueueUserDataEntries operation failed. Failed to get rows. Error: %v", err)
 	}
 
 	var nextPageToken []byte
@@ -646,7 +646,7 @@ func lockTaskQueue(
 		return &persistence.ConditionFailedError{Msg: "Task queue does not exists"}
 
 	default:
-		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to lock task queue. Error: %v", err))
+		return serviceerror.NewUnavailablef("Failed to lock task queue. Error: %v", err)
 	}
 }
 

--- a/common/persistence/task_manager.go
+++ b/common/persistence/task_manager.go
@@ -2,7 +2,6 @@ package persistence
 
 import (
 	"context"
-	"fmt"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -174,7 +173,7 @@ func (m *taskManagerImpl) CreateTasks(
 	for i, task := range request.Tasks {
 		taskBlob, err := m.serializer.TaskInfoToBlob(task, enumspb.ENCODING_TYPE_PROTO3)
 		if err != nil {
-			return nil, serviceerror.NewUnavailable(fmt.Sprintf("CreateTasks operation failed during serialization. Error : %v", err))
+			return nil, serviceerror.NewUnavailablef("CreateTasks operation failed during serialization. Error : %v", err)
 		}
 		tasks[i] = &InternalCreateTask{
 			TaskId:     task.GetTaskId(),
@@ -212,7 +211,7 @@ func (m *taskManagerImpl) GetTasks(
 	for i, taskBlob := range internalResp.Tasks {
 		task, err := m.serializer.TaskInfoFromBlob(taskBlob)
 		if err != nil {
-			return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTasks failed to deserialize task: %s", err.Error()))
+			return nil, serviceerror.NewUnavailablef("GetTasks failed to deserialize task: %s", err.Error())
 		}
 		tasks[i] = task
 	}

--- a/common/persistence/versionhistory/version_histories.go
+++ b/common/persistence/versionhistory/version_histories.go
@@ -1,8 +1,6 @@
 package versionhistory
 
 import (
-	"fmt"
-
 	"go.temporal.io/api/serviceerror"
 	historyspb "go.temporal.io/server/api/history/v1"
 )
@@ -166,7 +164,7 @@ func FindFirstVersionHistoryIndexByVersionHistoryItem(h *historyspb.VersionHisto
 			return int32(versionHistoryIndex), nil
 		}
 	}
-	return 0, serviceerror.NewInternal(fmt.Sprintf("version histories does not contains given item: %v, %v", item, h))
+	return 0, serviceerror.NewInternalf("version histories does not contains given item: %v, %v", item, h)
 }
 
 // SetCurrentVersionHistoryIndex set the current VersionHistory index.

--- a/common/persistence/versionhistory/version_history.go
+++ b/common/persistence/versionhistory/version_history.go
@@ -1,8 +1,6 @@
 package versionhistory
 
 import (
-	"fmt"
-
 	"go.temporal.io/api/serviceerror"
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/common"
@@ -73,11 +71,11 @@ func AddOrUpdateVersionHistoryItem(v *historyspb.VersionHistory, item *historysp
 
 	lastItem := v.Items[len(v.Items)-1]
 	if item.Version < lastItem.Version {
-		return serviceerror.NewInternal(fmt.Sprintf("cannot update version history with a lower version %v. Last version: %v", item.Version, lastItem.Version))
+		return serviceerror.NewInternalf("cannot update version history with a lower version %v. Last version: %v", item.Version, lastItem.Version)
 	}
 
 	if item.GetEventId() <= lastItem.GetEventId() {
-		return serviceerror.NewInternal(fmt.Sprintf("cannot add version history with a lower event id %v. Last event id: %v", item.GetEventId(), lastItem.GetEventId()))
+		return serviceerror.NewInternalf("cannot add version history with a lower event id %v. Last event id: %v", item.GetEventId(), lastItem.GetEventId())
 	}
 
 	if item.Version > lastItem.Version {
@@ -234,7 +232,7 @@ func GetVersionHistoryEventVersion(v *historyspb.VersionHistory, eventID int64) 
 		return 0, err
 	}
 	if eventID < common.FirstEventID || eventID > lastItem.GetEventId() {
-		return 0, serviceerror.NewInternal(fmt.Sprintf("input event ID is not in range, eventID: %v", eventID))
+		return 0, serviceerror.NewInternalf("input event ID is not in range, eventID: %v", eventID)
 	}
 
 	// items are sorted by eventID & version
@@ -245,7 +243,7 @@ func GetVersionHistoryEventVersion(v *historyspb.VersionHistory, eventID int64) 
 			return currentItem.GetVersion(), nil
 		}
 	}
-	return 0, serviceerror.NewInternal(fmt.Sprintf("input event ID is not in range, eventID: %v", eventID))
+	return 0, serviceerror.NewInternalf("input event ID is not in range, eventID: %v", eventID)
 }
 
 // IsEmptyVersionHistory indicate whether version history is empty

--- a/common/persistence/visibility/manager_selector.go
+++ b/common/persistence/visibility/manager_selector.go
@@ -3,8 +3,6 @@ package visibility
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination manager_selector_mock.go
 
 import (
-	"fmt"
-
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/namespace"
@@ -51,10 +49,10 @@ func (v *defaultManagerSelector) writeManagers() ([]manager.VisibilityManager, e
 	case SecondaryVisibilityWritingModeDual:
 		return []manager.VisibilityManager{v.visibilityManager, v.secondaryVisibilityManager}, nil
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf(
+		return nil, serviceerror.NewInternalf(
 			"Unknown secondary visibility writing mode: %s",
 			v.secondaryVisibilityWritingMode(),
-		))
+		)
 	}
 }
 

--- a/common/persistence/visibility/store/elasticsearch/query_interceptors.go
+++ b/common/persistence/visibility/store/elasticsearch/query_interceptors.go
@@ -90,8 +90,8 @@ func (ni *nameInterceptor) Name(name string, usage query.FieldNameUsage) (string
 		if fieldType == enumspb.INDEXED_VALUE_TYPE_TEXT {
 			return "", query.NewConverterError(
 				"unable to sort by field of %s type, use field of type %s",
-				enumspb.INDEXED_VALUE_TYPE_TEXT.String(),
-				enumspb.INDEXED_VALUE_TYPE_KEYWORD.String(),
+				enumspb.INDEXED_VALUE_TYPE_TEXT,
+				enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 			)
 		}
 	case query.FieldNameGroupBy:

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -1051,7 +1051,6 @@ func (s *VisibilityStore) ParseESDoc(
 		if err != nil {
 			metrics.ElasticsearchDocumentParseFailuresCount.With(s.metricsHandler).Record(1)
 			return nil, serviceerror.NewInternalf(
-
 				"Unable to encode custom search attributes of Elasticsearch document(%s): %v",
 				docID,
 				err,
@@ -1076,7 +1075,6 @@ func (s *VisibilityStore) ParseESDoc(
 	} else if memo != nil {
 		metrics.ElasticsearchDocumentParseFailuresCount.With(s.metricsHandler).Record(1)
 		return nil, serviceerror.NewInternalf(
-
 			"%q field is missing in Elasticsearch document(%s)",
 			searchattribute.MemoEncoding,
 			docID,
@@ -1434,7 +1432,6 @@ func validateDatetime(value time.Time) error {
 func validateString(value string) error {
 	if len(value) > maxStringLength {
 		return serviceerror.NewInvalidArgumentf(
-
 			"strings with more than %d bytes are not supported (got string of len %d)",
 			maxStringLength,
 			len(value),

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -328,7 +328,7 @@ func (s *VisibilityStore) AddBulkRequestAndWait(
 		}
 		// Returns non-retryable Internal error here because these errors are unexpected.
 		// Visibility task processor retries all errors though; therefore, new request will be generated for the same visibility task.
-		return serviceerror.NewInternal(fmt.Sprintf("visibility task received error: %v", err))
+		return serviceerror.NewInternalf("visibility task received error: %v", err)
 	}
 
 	if !ack {
@@ -530,14 +530,14 @@ func (s *VisibilityStore) GetWorkflowExecution(
 
 	typeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(
-			fmt.Sprintf("unable to read search attribute types: %v", err),
+		return nil, serviceerror.NewUnavailablef(
+			"unable to read search attribute types: %v", err,
 		)
 	}
 
 	if !result.Found {
-		return nil, serviceerror.NewNotFound(
-			fmt.Sprintf("Workflow execution with RunId %s not found", request.RunID),
+		return nil, serviceerror.NewNotFoundf(
+			"Workflow execution with RunId %s not found", request.RunID,
 		)
 	}
 
@@ -681,11 +681,11 @@ func (s *VisibilityStore) processPageToken(
 		return nil
 	}
 	if len(pageToken.SearchAfter) != len(params.Sorter) {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf(
+		return serviceerror.NewInvalidArgumentf(
 			"invalid page token for given sort fields: expected %d fields, got %d",
 			len(params.Sorter),
 			len(pageToken.SearchAfter),
-		))
+		)
 	}
 	if !s.enableManualPagination(namespaceName.String()) || !isDefaultSorter(params.Sorter) {
 		params.SearchAfter = pageToken.SearchAfter
@@ -694,17 +694,17 @@ func (s *VisibilityStore) processPageToken(
 
 	boolQuery, ok := params.Query.(*elastic.BoolQuery)
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf(
+		return serviceerror.NewInternalf(
 			"unexpected query type: expected %T, got %T",
 			&elastic.BoolQuery{},
 			params.Query,
-		))
+		)
 	}
 
 	saTypeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
 	if err != nil {
-		return serviceerror.NewUnavailable(
-			fmt.Sprintf("unable to read search attribute types: %v", err),
+		return serviceerror.NewUnavailablef(
+			"unable to read search attribute types: %v", err,
 		)
 	}
 
@@ -726,7 +726,7 @@ func (s *VisibilityStore) convertQuery(
 ) (*query.QueryParams, error) {
 	saTypeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("unable to read search attribute types: %v", err))
+		return nil, serviceerror.NewUnavailablef("unable to read search attribute types: %v", err)
 	}
 	nameInterceptor := NewNameInterceptor(namespace, saTypeMap, s.searchAttributesMapperProvider)
 	queryConverter := NewQueryConverter(
@@ -796,7 +796,7 @@ func (s *VisibilityStore) GetListWorkflowExecutionsResponse(
 
 	typeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("unable to read search attribute types: %v", err))
+		return nil, serviceerror.NewUnavailablef("unable to read search attribute types: %v", err)
 	}
 
 	response := &store.InternalListWorkflowExecutionsResponse{
@@ -837,7 +837,7 @@ func (s *VisibilityStore) deserializePageToken(data []byte) (*visibilityPageToke
 	dec.UseNumber()
 	err := dec.Decode(&token)
 	if err != nil {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("unable to deserialize page token: %v", err))
+		return nil, serviceerror.NewInvalidArgumentf("unable to deserialize page token: %v", err)
 	}
 	return token, nil
 }
@@ -849,7 +849,7 @@ func (s *VisibilityStore) serializePageToken(token *visibilityPageToken) ([]byte
 
 	data, err := json.Marshal(token)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("unable to serialize page token: %v", err))
+		return nil, serviceerror.NewInternalf("unable to serialize page token: %v", err)
 	}
 	return data, nil
 }
@@ -887,13 +887,13 @@ func (s *VisibilityStore) GenerateESDoc(
 	typeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
 	if err != nil {
 		metrics.ElasticsearchDocumentGenerateFailuresCount.With(s.metricsHandler).Record(1)
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("unable to read search attribute types: %v", err))
+		return nil, serviceerror.NewUnavailablef("unable to read search attribute types: %v", err)
 	}
 
 	searchAttributes, err := searchattribute.Decode(request.SearchAttributes, &typeMap, true)
 	if err != nil {
 		metrics.ElasticsearchDocumentGenerateFailuresCount.With(s.metricsHandler).Record(1)
-		return nil, serviceerror.NewInternal(fmt.Sprintf("unable to decode search attributes: %v", err))
+		return nil, serviceerror.NewInternalf("unable to decode search attributes: %v", err)
 	}
 	// This is to prevent existing tasks to fail indefinitely.
 	// If it's only invalid values error, then silently continue without them.
@@ -942,7 +942,7 @@ func (s *VisibilityStore) ParseESDoc(
 ) (*store.InternalWorkflowExecutionInfo, error) {
 	logParseError := func(fieldName string, fieldValue interface{}, err error, docID string) error {
 		metrics.ElasticsearchDocumentParseFailuresCount.With(s.metricsHandler).Record(1)
-		return serviceerror.NewInternal(fmt.Sprintf("unable to parse Elasticsearch document(%s) %q field value %q: %v", docID, fieldName, fieldValue, err))
+		return serviceerror.NewInternalf("unable to parse Elasticsearch document(%s) %q field value %q: %v", docID, fieldName, fieldValue, err)
 	}
 
 	var sourceMap map[string]interface{}
@@ -951,7 +951,7 @@ func (s *VisibilityStore) ParseESDoc(
 	d.UseNumber()
 	if err := d.Decode(&sourceMap); err != nil {
 		metrics.ElasticsearchDocumentParseFailuresCount.With(s.metricsHandler).Record(1)
-		return nil, serviceerror.NewInternal(fmt.Sprintf("unable to unmarshal JSON from Elasticsearch document(%s): %v", docID, err))
+		return nil, serviceerror.NewInternalf("unable to unmarshal JSON from Elasticsearch document(%s): %v", docID, err)
 	}
 
 	var (
@@ -991,7 +991,7 @@ func (s *VisibilityStore) ParseESDoc(
 				continue
 			}
 			metrics.ElasticsearchDocumentParseFailuresCount.With(s.metricsHandler).Record(1)
-			return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to get type for Elasticsearch document(%s) field %q: %v", docID, fieldName, err))
+			return nil, serviceerror.NewInternalf("Unable to get type for Elasticsearch document(%s) field %q: %v", docID, fieldName, err)
 		}
 
 		fieldValueParsed, err := finishParseJSONValue(fieldValue, fieldType)
@@ -1050,12 +1050,11 @@ func (s *VisibilityStore) ParseESDoc(
 		record.SearchAttributes, err = searchattribute.Encode(customSearchAttributes, &saTypeMap)
 		if err != nil {
 			metrics.ElasticsearchDocumentParseFailuresCount.With(s.metricsHandler).Record(1)
-			return nil, serviceerror.NewInternal(
-				fmt.Sprintf(
-					"Unable to encode custom search attributes of Elasticsearch document(%s): %v",
-					docID,
-					err,
-				),
+			return nil, serviceerror.NewInternalf(
+
+				"Unable to encode custom search attributes of Elasticsearch document(%s): %v",
+				docID,
+				err,
 			)
 		}
 		aliasedSas, err := searchattribute.AliasFields(
@@ -1076,12 +1075,11 @@ func (s *VisibilityStore) ParseESDoc(
 		record.Memo = persistence.NewDataBlob(memo, memoEncoding)
 	} else if memo != nil {
 		metrics.ElasticsearchDocumentParseFailuresCount.With(s.metricsHandler).Record(1)
-		return nil, serviceerror.NewInternal(
-			fmt.Sprintf(
-				"%q field is missing in Elasticsearch document(%s)",
-				searchattribute.MemoEncoding,
-				docID,
-			),
+		return nil, serviceerror.NewInternalf(
+
+			"%q field is missing in Elasticsearch document(%s)",
+			searchattribute.MemoEncoding,
+			docID,
 		)
 	}
 
@@ -1099,8 +1097,8 @@ func (s *VisibilityStore) parseCountGroupByResponse(
 	response := &manager.CountWorkflowExecutionsResponse{}
 	typeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(
-			fmt.Sprintf("unable to read search attribute types: %v", err),
+		return nil, serviceerror.NewUnavailablef(
+			"unable to read search attribute types: %v", err,
 		)
 	}
 	groupByTypes := make([]enumspb.IndexedValueType, len(groupByFields))
@@ -1167,7 +1165,7 @@ func (s *VisibilityStore) parseCountGroupByResponse(
 	dec := json.NewDecoder(bytes.NewReader(searchResult.Aggregations[groupByFields[0]]))
 	dec.UseNumber()
 	if err := dec.Decode(&bucketsJson); err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("unable to unmarshal json response: %v", err))
+		return nil, serviceerror.NewInternalf("unable to unmarshal json response: %v", err)
 	}
 	if err := parseInternal(map[string]any{groupByFields[0]: bucketsJson}, nil); err != nil {
 		return nil, err
@@ -1290,11 +1288,11 @@ func buildPaginationQuery(
 ) ([]elastic.Query, error) {
 	n := len(sorterFields)
 	if len(sorterFields) != len(searchAfter) {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
+		return nil, serviceerror.NewInvalidArgumentf(
 			"invalid page token for given sort fields: expected %d fields, got %d",
 			len(sorterFields),
 			len(searchAfter),
-		))
+		)
 	}
 
 	parsedSearchAfter := make([]any, n)
@@ -1311,10 +1309,10 @@ func buildPaginationQuery(
 
 	// The last field of sorter must be a tiebreaker, and thus cannot contain null value.
 	if parsedSearchAfter[len(parsedSearchAfter)-1] == nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf(
+		return nil, serviceerror.NewInternalf(
 			"last field of sorter cannot be a nullable field: %q has null values",
 			sorterFields[len(sorterFields)-1].name,
-		))
+		)
 	}
 
 	shouldQueries := make([]elastic.Query, 0, len(sorterFields))
@@ -1365,13 +1363,13 @@ func parsePageTokenValue(
 		enumspb.INDEXED_VALUE_TYPE_DATETIME:
 		jsonNumber, ok := jsonValue.(json.Number)
 		if !ok {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
-				"invalid page token: expected interger type, got %q", jsonValue))
+			return nil, serviceerror.NewInvalidArgumentf(
+				"invalid page token: expected interger type, got %q", jsonValue)
 		}
 		num, err := jsonNumber.Int64()
 		if err != nil {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
-				"invalid page token: expected interger type, got %v", jsonValue))
+			return nil, serviceerror.NewInvalidArgumentf(
+				"invalid page token: expected interger type, got %v", jsonValue)
 		}
 		if num == math.MaxInt64 || num == math.MinInt64 {
 			return nil, nil
@@ -1389,21 +1387,21 @@ func parsePageTokenValue(
 		case json.Number:
 			num, err := v.Float64()
 			if err != nil {
-				return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
-					"invalid page token: expected float type, got %v", jsonValue))
+				return nil, serviceerror.NewInvalidArgumentf(
+					"invalid page token: expected float type, got %v", jsonValue)
 			}
 			return num, nil
 		case string:
 			// it can be the string representation of infinity
 			if _, err := strconv.ParseFloat(v, 64); err != nil {
-				return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
-					"invalid page token: expected float type, got %q", jsonValue))
+				return nil, serviceerror.NewInvalidArgumentf(
+					"invalid page token: expected float type, got %q", jsonValue)
 			}
 			return nil, nil
 		default:
 			// it should never reach here
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
-				"invalid page token: expected float type, got %#v", jsonValue))
+			return nil, serviceerror.NewInvalidArgumentf(
+				"invalid page token: expected float type, got %#v", jsonValue)
 		}
 
 	case enumspb.INDEXED_VALUE_TYPE_KEYWORD:
@@ -1411,23 +1409,23 @@ func parsePageTokenValue(
 			return nil, nil
 		}
 		if _, ok := jsonValue.(string); !ok {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
-				"invalid page token: expected string type, got %v", jsonValue))
+			return nil, serviceerror.NewInvalidArgumentf(
+				"invalid page token: expected string type, got %v", jsonValue)
 		}
 		return jsonValue, nil
 
 	default:
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
+		return nil, serviceerror.NewInvalidArgumentf(
 			"invalid field type in sorter: cannot order by %q",
 			fieldName,
-		))
+		)
 	}
 }
 
 func validateDatetime(value time.Time) error {
 	if value.Before(minTime) || value.After(maxTime) {
-		return serviceerror.NewInvalidArgument(
-			fmt.Sprintf("invalid search attribute date: %v, supported range: [%v, %v]", value, minTime, maxTime),
+		return serviceerror.NewInvalidArgumentf(
+			"invalid search attribute date: %v, supported range: [%v, %v]", value, minTime, maxTime,
 		)
 	}
 	return nil
@@ -1435,12 +1433,11 @@ func validateDatetime(value time.Time) error {
 
 func validateString(value string) error {
 	if len(value) > maxStringLength {
-		return serviceerror.NewInvalidArgument(
-			fmt.Sprintf(
-				"strings with more than %d bytes are not supported (got string of len %d)",
-				maxStringLength,
-				len(value),
-			),
+		return serviceerror.NewInvalidArgumentf(
+
+			"strings with more than %d bytes are not supported (got string of len %d)",
+			maxStringLength,
+			len(value),
 		)
 	}
 	return nil

--- a/common/persistence/visibility/store/query/errors.go
+++ b/common/persistence/visibility/store/query/errors.go
@@ -29,7 +29,7 @@ func (c *ConverterError) Error() string {
 }
 
 func (c *ConverterError) ToInvalidArgument() error {
-	return serviceerror.NewInvalidArgument(fmt.Sprintf("invalid query: %v", c))
+	return serviceerror.NewInvalidArgumentf("invalid query: %v", c)
 }
 
 func wrapConverterError(message string, err error) error {

--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -341,7 +341,7 @@ func serializeMemo(memo *commonpb.Memo) (*commonpb.DataBlob, error) {
 
 	data, err := proto.Marshal(memo)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to serialize memo to data blob: %v", err))
+		return nil, serviceerror.NewInternalf("Unable to serialize memo to data blob: %v", err)
 	}
 
 	return &commonpb.DataBlob{

--- a/common/persistence/workflow_state_status_validator.go
+++ b/common/persistence/workflow_state_status_validator.go
@@ -1,8 +1,6 @@
 package persistence
 
 import (
-	"fmt"
-
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -44,7 +42,7 @@ func ValidateCreateWorkflowStateStatus(
 	// validate workflow state & status
 	if (state == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED && status == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING) ||
 		(state != enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED && status != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING) {
-		return serviceerror.NewInternal(fmt.Sprintf("Create workflow with invalid state: %v or status: %v", state, status))
+		return serviceerror.NewInternalf("Create workflow with invalid state: %v or status: %v", state, status)
 	}
 	return nil
 }
@@ -65,7 +63,7 @@ func ValidateUpdateWorkflowStateStatus(
 	// validate workflow state & status
 	if (state == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED && status == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING) ||
 		(state != enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED && status != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING) {
-		return serviceerror.NewInternal(fmt.Sprintf("Update workflow with invalid state: %v or status: %v", state, status))
+		return serviceerror.NewInternalf("Update workflow with invalid state: %v or status: %v", state, status)
 	}
 	return nil
 }
@@ -76,7 +74,7 @@ func validateWorkflowState(
 ) error {
 
 	if _, ok := validWorkflowStates[state]; !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("Invalid workflow state: %v", state))
+		return serviceerror.NewInternalf("Invalid workflow state: %v", state)
 	}
 
 	return nil
@@ -88,7 +86,7 @@ func validateWorkflowStatus(
 ) error {
 
 	if _, ok := validWorkflowStatuses[status]; !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("Invalid workflow status: %v", status))
+		return serviceerror.NewInternalf("Invalid workflow status: %v", status)
 	}
 
 	return nil

--- a/common/retrypolicy/retry_policy.go
+++ b/common/retrypolicy/retry_policy.go
@@ -1,7 +1,6 @@
 package retrypolicy
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -69,13 +68,13 @@ func Validate(policy *commonpb.RetryPolicy) error {
 		return nil
 	}
 	if err := timestamp.ValidateAndCapProtoDuration(policy.GetInitialInterval()); err != nil {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("invalid InitialInterval set on retry policy: %v", err))
+		return serviceerror.NewInvalidArgumentf("invalid InitialInterval set on retry policy: %v", err)
 	}
 	if policy.GetBackoffCoefficient() < 1 {
 		return serviceerror.NewInvalidArgument("BackoffCoefficient cannot be less than 1 on retry policy.")
 	}
 	if err := timestamp.ValidateAndCapProtoDuration(policy.GetMaximumInterval()); err != nil {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("invalid MaximumInterval set on retry policy: %v", err))
+		return serviceerror.NewInvalidArgumentf("invalid MaximumInterval set on retry policy: %v", err)
 	}
 	if timestamp.DurationValue(policy.GetMaximumInterval()) > 0 && timestamp.DurationValue(policy.GetMaximumInterval()) < timestamp.DurationValue(policy.GetInitialInterval()) {
 		return serviceerror.NewInvalidArgument("MaximumInterval cannot be less than InitialInterval on retry policy.")
@@ -89,7 +88,7 @@ func Validate(policy *commonpb.RetryPolicy) error {
 			timeoutTypeValue := nrt[len(TimeoutFailureTypePrefix):]
 			timeoutType, err := enumspb.TimeoutTypeFromString(timeoutTypeValue)
 			if err != nil || enumspb.TimeoutType(timeoutType) == enumspb.TIMEOUT_TYPE_UNSPECIFIED {
-				return serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid timeout type value: %v.", timeoutTypeValue))
+				return serviceerror.NewInvalidArgumentf("Invalid timeout type value: %v.", timeoutTypeValue)
 			}
 		}
 	}

--- a/common/rpc/interceptor/namespace.go
+++ b/common/rpc/interceptor/namespace.go
@@ -1,8 +1,6 @@
 package interceptor
 
 import (
-	"fmt"
-
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/namespace"
@@ -60,6 +58,6 @@ func GetNamespaceName(
 		return namespaceName, nil
 
 	default:
-		return namespace.EmptyName, serviceerror.NewInternal(fmt.Sprintf("unable to extract namespace info from request of type %T", req))
+		return namespace.EmptyName, serviceerror.NewInternalf("unable to extract namespace info from request of type %T", req)
 	}
 }

--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -64,7 +64,6 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 	lengthOfFields := len(searchAttributes.GetIndexedFields())
 	if lengthOfFields > v.searchAttributesNumberOfKeysLimit(namespace) {
 		return serviceerror.NewInvalidArgumentf(
-
 			"number of search attributes %d exceeds limit %d",
 			lengthOfFields,
 			v.searchAttributesNumberOfKeysLimit(namespace),
@@ -165,7 +164,6 @@ func (v *Validator) ValidateSize(searchAttributes *commonpb.SearchAttributes, na
 
 	if searchAttributes.Size() > v.searchAttributesTotalSizeLimit(namespace) {
 		return serviceerror.NewInvalidArgumentf(
-
 			"total size of search attributes %d exceeds size limit %d",
 			searchAttributes.Size(),
 			v.searchAttributesTotalSizeLimit(namespace),

--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -63,12 +63,11 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 
 	lengthOfFields := len(searchAttributes.GetIndexedFields())
 	if lengthOfFields > v.searchAttributesNumberOfKeysLimit(namespace) {
-		return serviceerror.NewInvalidArgument(
-			fmt.Sprintf(
-				"number of search attributes %d exceeds limit %d",
-				lengthOfFields,
-				v.searchAttributesNumberOfKeysLimit(namespace),
-			),
+		return serviceerror.NewInvalidArgumentf(
+
+			"number of search attributes %d exceeds limit %d",
+			lengthOfFields,
+			v.searchAttributesNumberOfKeysLimit(namespace),
 		)
 	}
 
@@ -77,8 +76,8 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 		false,
 	)
 	if err != nil {
-		return serviceerror.NewUnavailable(
-			fmt.Sprintf("unable to get search attributes from cluster metadata: %v", err),
+		return serviceerror.NewUnavailablef(
+			"unable to get search attributes from cluster metadata: %v", err,
 		)
 	}
 
@@ -90,8 +89,8 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 				// if suppressing the error, then just ignore the search attribute
 				continue
 			}
-			return serviceerror.NewInvalidArgument(
-				fmt.Sprintf("%s attribute can't be set in SearchAttributes", saFieldName),
+			return serviceerror.NewInvalidArgumentf(
+				"%s attribute can't be set in SearchAttributes", saFieldName,
 			)
 		}
 
@@ -114,8 +113,8 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 		// Don't allow those SA's that are in predefined but not in predefinedWhiteList to be set by a user
 		if _, ok := predefined[saFieldName]; ok {
 			if _, ok = predefinedWhiteList[saFieldName]; !ok {
-				return serviceerror.NewInvalidArgument(
-					fmt.Sprintf("%s attribute can't be set in SearchAttributes", saFieldName),
+				return serviceerror.NewInvalidArgumentf(
+					"%s attribute can't be set in SearchAttributes", saFieldName,
 				)
 			}
 		}
@@ -165,12 +164,11 @@ func (v *Validator) ValidateSize(searchAttributes *commonpb.SearchAttributes, na
 	}
 
 	if searchAttributes.Size() > v.searchAttributesTotalSizeLimit(namespace) {
-		return serviceerror.NewInvalidArgument(
-			fmt.Sprintf(
-				"total size of search attributes %d exceeds size limit %d",
-				searchAttributes.Size(),
-				v.searchAttributesTotalSizeLimit(namespace),
-			),
+		return serviceerror.NewInvalidArgumentf(
+
+			"total size of search attributes %d exceeds size limit %d",
+			searchAttributes.Size(),
+			v.searchAttributesTotalSizeLimit(namespace),
 		)
 	}
 
@@ -185,7 +183,7 @@ func (v *Validator) validationError(msg string, saFieldName string, namespace st
 	if err != nil {
 		return err
 	}
-	return serviceerror.NewInvalidArgument(fmt.Sprintf(msg, saAlias))
+	return serviceerror.NewInvalidArgumentf(msg, saAlias)
 }
 
 func (v *Validator) getAlias(saFieldName string, namespaceName string) (string, error) {

--- a/common/serviceerror/obsolete_matching_task.go
+++ b/common/serviceerror/obsolete_matching_task.go
@@ -1,6 +1,8 @@
 package serviceerror
 
 import (
+	"fmt"
+
 	errordetailsspb "go.temporal.io/server/api/errordetails/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -24,6 +26,12 @@ type (
 func NewObsoleteMatchingTask(msg string) error {
 	return &ObsoleteMatchingTask{
 		Message: msg,
+	}
+}
+
+func NewObsoleteMatchingTaskf(format string, args ...any) error {
+	return &ObsoleteMatchingTask{
+		Message: fmt.Sprintf(format, args...),
 	}
 }
 

--- a/common/sqlquery/query.go
+++ b/common/sqlquery/query.go
@@ -68,5 +68,5 @@ func ParseValue(sqlValue string) (interface{}, error) {
 		return floatValue, nil
 	}
 
-	return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("invalid expression: unable to parse %s", sqlValue))
+	return nil, serviceerror.NewInvalidArgumentf("invalid expression: unable to parse %s", sqlValue)
 }

--- a/common/tqid/task_queue_id.go
+++ b/common/tqid/task_queue_id.go
@@ -146,7 +146,7 @@ func PartitionFromProto(proto *taskqueuepb.TaskQueue, namespaceId string, taskTy
 	kind := proto.GetKind()
 	normalName := proto.GetNormalName()
 	if normalName != "" && kind != enumspb.TASK_QUEUE_KIND_STICKY {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("only sticky queues can have normal name. tq: %s, normal name: %s", baseName, normalName))
+		return nil, serviceerror.NewInvalidArgumentf("only sticky queues can have normal name. tq: %s, normal name: %s", baseName, normalName)
 	}
 
 	switch kind {

--- a/common/tqid/task_queue_validator.go
+++ b/common/tqid/task_queue_validator.go
@@ -1,7 +1,6 @@
 package tqid
 
 import (
-	"fmt"
 	"strings"
 
 	enumspb "go.temporal.io/api/enums/v1"
@@ -118,7 +117,7 @@ func validate(taskQueueName string, maxLength int, expectRootPartition bool) err
 	}
 
 	if expectRootPartition && strings.HasPrefix(taskQueueName, reservedTaskQueuePrefix) {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("task queue name cannot start with reserved prefix %v", reservedTaskQueuePrefix))
+		return serviceerror.NewInvalidArgumentf("task queue name cannot start with reserved prefix %v", reservedTaskQueuePrefix)
 	}
 
 	return nil

--- a/common/util.go
+++ b/common/util.go
@@ -122,7 +122,7 @@ var (
 
 var (
 	// ErrNamespaceHandover is error indicating namespace is in handover state and cannot process request.
-	ErrNamespaceHandover = serviceerror.NewUnavailablef("Namespace replication in %s state.", enumspb.REPLICATION_STATE_HANDOVER.String())
+	ErrNamespaceHandover = serviceerror.NewUnavailablef("Namespace replication in %s state.", enumspb.REPLICATION_STATE_HANDOVER)
 )
 
 // AwaitWaitGroup calls Wait on the given wait

--- a/common/util.go
+++ b/common/util.go
@@ -122,7 +122,7 @@ var (
 
 var (
 	// ErrNamespaceHandover is error indicating namespace is in handover state and cannot process request.
-	ErrNamespaceHandover = serviceerror.NewUnavailable(fmt.Sprintf("Namespace replication in %s state.", enumspb.REPLICATION_STATE_HANDOVER.String()))
+	ErrNamespaceHandover = serviceerror.NewUnavailablef("Namespace replication in %s state.", enumspb.REPLICATION_STATE_HANDOVER.String())
 )
 
 // AwaitWaitGroup calls Wait on the given wait
@@ -443,11 +443,10 @@ func VerifyShardIDMapping(
 	if thisShardID%shardCountMin == thatShardID%shardCountMin {
 		return nil
 	}
-	return serviceerror.NewInternal(
-		fmt.Sprintf("shard ID mapping verification failed; shard count: %v vs %v, shard ID: %v vs %v",
-			thisShardCount, thatShardCount,
-			thisShardID, thatShardID,
-		),
+	return serviceerror.NewInternalf(
+		"shard ID mapping verification failed; shard count: %v vs %v, shard ID: %v vs %v",
+		thisShardCount, thatShardCount,
+		thisShardID, thatShardID,
 	)
 }
 

--- a/common/worker_versioning/worker_versioning.go
+++ b/common/worker_versioning/worker_versioning.go
@@ -357,6 +357,7 @@ func ValidateVersioningOverride(override *workflowpb.VersioningOverride) error {
 	case enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED:
 		return serviceerror.NewInvalidArgument("override behavior is required")
 	default:
+		//nolint:staticcheck // SA1019 deprecated stamp will clean up later
 		return serviceerror.NewInvalidArgumentf("override behavior %s not recognized", override.GetBehavior())
 	}
 	return nil

--- a/common/worker_versioning/worker_versioning.go
+++ b/common/worker_versioning/worker_versioning.go
@@ -328,7 +328,7 @@ func ValidateDeploymentVersionString(version string) (*deploymentspb.WorkerDeplo
 	}
 	v, err := WorkerDeploymentVersionFromString(version)
 	if err != nil {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("invalid version string %q, expected format is \"<deployment_name>.<build_id>\"", version))
+		return nil, serviceerror.NewInvalidArgumentf("invalid version string %q, expected format is \"<deployment_name>.<build_id>\"", version)
 	}
 	return v, nil
 }
@@ -357,7 +357,7 @@ func ValidateVersioningOverride(override *workflowpb.VersioningOverride) error {
 	case enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED:
 		return serviceerror.NewInvalidArgument("override behavior is required")
 	default:
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("override behavior %s not recognized", override.GetBehavior()))
+		return serviceerror.NewInvalidArgumentf("override behavior %s not recognized", override.GetBehavior())
 	}
 	return nil
 }
@@ -448,9 +448,9 @@ func ValidateTaskVersionDirective(
 		// TODO (shahab): remove this line after v1.27 is released.
 		directiveBehavior != enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED {
 		// This must be a task scheduled before the workflow changes behavior. Matching can drop it.
-		return serviceerrors.NewObsoleteMatchingTask(fmt.Sprintf(
+		return serviceerrors.NewObsoleteMatchingTaskf(
 			"task was scheduled when workflow had versioning behavior %s, now it has versioning behavior %s.",
-			directiveBehavior, wfBehavior))
+			directiveBehavior, wfBehavior)
 	}
 
 	directiveDeployment := DirectiveDeployment(directive)
@@ -461,9 +461,9 @@ func ValidateTaskVersionDirective(
 	if !directiveDeployment.Equal(wfDeployment) {
 		// This must be a task scheduled before the workflow transitions to the current
 		// deployment. Matching can drop it.
-		return serviceerrors.NewObsoleteMatchingTask(fmt.Sprintf(
+		return serviceerrors.NewObsoleteMatchingTaskf(
 			"task was scheduled when workflow was on build %s, now it is on build %s.",
-			directiveDeployment.GetBuildId(), wfDeployment.GetBuildId()))
+			directiveDeployment.GetBuildId(), wfDeployment.GetBuildId())
 	}
 	return nil
 }

--- a/components/callbacks/statemachine.go
+++ b/components/callbacks/statemachine.go
@@ -171,7 +171,7 @@ func (stateMachineDefinition) CompareState(state1, state2 any) (int, error) {
 		return stage1 - stage2, nil
 	}
 	if stage1 == terminalStage && cb1.State() != cb2.State() {
-		return 0, serviceerror.NewInvalidArgument(fmt.Sprintf("cannot compare two distinct terminal states: %v, %v", cb1.State(), cb2.State()))
+		return 0, serviceerror.NewInvalidArgumentf("cannot compare two distinct terminal states: %v, %v", cb1.State(), cb2.State())
 	}
 	return int(attempts1 - attempts2), nil
 }

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -117,7 +117,7 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 	}
 
 	if e.Config.CallbackURLTemplate() == "unset" {
-		return serviceerror.NewInternal(fmt.Sprintf("dynamic config %q is unset", CallbackURLTemplate.Key().String()))
+		return serviceerror.NewInternalf("dynamic config %q is unset", CallbackURLTemplate.Key().String())
 	}
 	// TODO(bergundy): Consider caching this template.
 	callbackURLTemplate, err := template.New("NexusCallbackURL").Parse(e.Config.CallbackURLTemplate())

--- a/components/nexusoperations/statemachine.go
+++ b/components/nexusoperations/statemachine.go
@@ -206,7 +206,7 @@ func (operationMachineDefinition) CompareState(state1, state2 any) (int, error) 
 		return stage1 - stage2, nil
 	}
 	if stage1 == terminalStage && o1.State() != o2.State() {
-		return 0, serviceerror.NewInvalidArgument(fmt.Sprintf("cannot compare two distinct terminal states: %v, %v", o1.State(), o2.State()))
+		return 0, serviceerror.NewInvalidArgumentf("cannot compare two distinct terminal states: %v, %v", o1.State(), o2.State())
 	}
 	return int(attempts1 - attempts2), nil
 }
@@ -479,7 +479,7 @@ func (cancelationMachineDefinition) CompareState(state1, state2 any) (int, error
 		return stage1 - stage2, nil
 	}
 	if stage1 == terminalStage && c1.State() != c2.State() {
-		return 0, serviceerror.NewInvalidArgument(fmt.Sprintf("cannot compare two distinct terminal states: %v, %v", c1.State(), c2.State()))
+		return 0, serviceerror.NewInvalidArgumentf("cannot compare two distinct terminal states: %v, %v", c1.State(), c2.State())
 	}
 	return int(attempts1 - attempts2), nil
 }

--- a/components/nexusoperations/tasks.go
+++ b/components/nexusoperations/tasks.go
@@ -115,7 +115,7 @@ func (InvocationTaskSerializer) Serialize(task hsm.Task) ([]byte, error) {
 	case InvocationTask:
 		return proto.Marshal(&persistencespb.NexusInvocationTaskInfo{Attempt: task.Attempt})
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("unknown HSM task type while serializing: %v", task))
+		return nil, serviceerror.NewInternalf("unknown HSM task type while serializing: %v", task)
 	}
 }
 
@@ -196,7 +196,7 @@ func (CancelationTaskSerializer) Serialize(task hsm.Task) ([]byte, error) {
 	case CancelationTask:
 		return proto.Marshal(&persistencespb.NexusCancelationTaskInfo{Attempt: task.Attempt})
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("unknown HSM task type while serializing: %v", task))
+		return nil, serviceerror.NewInternalf("unknown HSM task type while serializing: %v", task)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	go.temporal.io/api v1.49.2-0.20250514204244-aef60694cca5
+	go.temporal.io/api v1.49.2-0.20250515234522-39aa8c9e49a6
 	go.temporal.io/sdk v1.34.0
 	go.temporal.io/version v0.3.0
 	go.uber.org/automaxprocs v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,12 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
+go.temporal.io/api v1.49.1 h1:CdiIohibamF4YP9k261DjrzPVnuomRoh1iC//gZ1puA=
+go.temporal.io/api v1.49.1/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/api v1.49.2-0.20250514204244-aef60694cca5 h1:+rttnhF8IQs6irpAYbRBXf3bolqG7YkFfO123Poj/tU=
 go.temporal.io/api v1.49.2-0.20250514204244-aef60694cca5/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.49.2-0.20250515234522-39aa8c9e49a6 h1:/OLHubOR0BQ9UGRBddKU/1Cqf1uEF/rckEI2O1GO+AU=
+go.temporal.io/api v1.49.2-0.20250515234522-39aa8c9e49a6/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.34.0 h1:VLg/h6ny7GvLFVoQPqz2NcC93V9yXboQwblkRvZ1cZE=
 go.temporal.io/sdk v1.34.0/go.mod h1:iE4U5vFrH3asOhqpBBphpj9zNtw8btp8+MSaf5A0D3w=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=

--- a/go.sum
+++ b/go.sum
@@ -385,10 +385,6 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.49.1 h1:CdiIohibamF4YP9k261DjrzPVnuomRoh1iC//gZ1puA=
-go.temporal.io/api v1.49.1/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
-go.temporal.io/api v1.49.2-0.20250514204244-aef60694cca5 h1:+rttnhF8IQs6irpAYbRBXf3bolqG7YkFfO123Poj/tU=
-go.temporal.io/api v1.49.2-0.20250514204244-aef60694cca5/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/api v1.49.2-0.20250515234522-39aa8c9e49a6 h1:/OLHubOR0BQ9UGRBddKU/1Cqf1uEF/rckEI2O1GO+AU=
 go.temporal.io/api v1.49.2-0.20250515234522-39aa8c9e49a6/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.34.0 h1:VLg/h6ny7GvLFVoQPqz2NcC93V9yXboQwblkRvZ1cZE=

--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -1067,17 +1067,15 @@ func validateReplicationStateUpdate(existingNamespace *persistence.GetNamespaceR
 
 	if existingNamespace.Namespace.Info.State != enumspb.NAMESPACE_STATE_REGISTERED {
 		return serviceerror.NewInvalidArgumentf(
-
 			"update ReplicationState is only supported when namespace is in %s state, current state: %s",
-			enumspb.NAMESPACE_STATE_REGISTERED.String(),
-			existingNamespace.Namespace.Info.State.String(),
+			enumspb.NAMESPACE_STATE_REGISTERED,
+			existingNamespace.Namespace.Info.State,
 		)
 	}
 
 	if nsUpdateRequest.ReplicationConfig.State == enumspb.REPLICATION_STATE_HANDOVER {
 		if !existingNamespace.IsGlobalNamespace {
 			return serviceerror.NewInvalidArgumentf(
-
 				"%s can only be set for global namespace",
 				enumspb.REPLICATION_STATE_HANDOVER,
 			)

--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -120,7 +120,7 @@ func (d *namespaceHandler) RegisterNamespace(
 	switch err.(type) {
 	case nil:
 		// namespace already exists, cannot proceed
-		return nil, serviceerror.NewNamespaceAlreadyExists(fmt.Sprintf("Namespace %q already exists", registerRequest.GetNamespace()))
+		return nil, serviceerror.NewNamespaceAlreadyExistsf("Namespace %q already exists", registerRequest.GetNamespace())
 	case *serviceerror.NamespaceNotFound:
 		// namespace does not exists, proceeds
 	default:
@@ -465,7 +465,7 @@ func (d *namespaceHandler) UpdateNamespace(
 			bb := d.mergeBadBinaries(config.BadBinaries.Binaries, updatedConfig.BadBinaries.Binaries, time.Now().UTC())
 			config.BadBinaries = &bb
 			if len(config.BadBinaries.Binaries) > maxLength {
-				return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Total resetBinaries cannot exceed the max limit: %v", maxLength))
+				return nil, serviceerror.NewInvalidArgumentf("Total resetBinaries cannot exceed the max limit: %v", maxLength)
 			}
 		}
 		if len(updatedConfig.CustomSearchAttributeAliases) > 0 {
@@ -485,7 +485,7 @@ func (d *namespaceHandler) UpdateNamespace(
 		binChecksum := updateRequest.GetDeleteBadBinary()
 		_, ok := config.BadBinaries.Binaries[binChecksum]
 		if !ok {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Bad binary checksum %v doesn't exists.", binChecksum))
+			return nil, serviceerror.NewInvalidArgumentf("Bad binary checksum %v doesn't exists.", binChecksum)
 		}
 		configurationChanged = true
 		delete(config.BadBinaries.Binaries, binChecksum)
@@ -527,8 +527,8 @@ func (d *namespaceHandler) UpdateNamespace(
 			return nil, err
 		}
 		if !d.clusterMetadata.IsGlobalNamespaceEnabled() {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("global namespace is not enabled on this "+
-				"cluster, cannot update global namespace or promote local namespace: %v", updateRequest.Namespace))
+			return nil, serviceerror.NewInvalidArgumentf("global namespace is not enabled on this "+
+				"cluster, cannot update global namespace or promote local namespace: %v", updateRequest.Namespace)
 		}
 	} else {
 		if err := d.namespaceAttrValidator.ValidateNamespaceReplicationConfigForLocalNamespace(
@@ -692,7 +692,7 @@ func (d *namespaceHandler) CreateWorkflowRule(
 			d.removeOldestExpiredWorkflowRule(config.WorkflowRules)
 		}
 		if len(config.WorkflowRules) >= maxRules {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Workflow Rule limit exceeded. Max: %v", maxRules))
+			return nil, serviceerror.NewInvalidArgumentf("Workflow Rule limit exceeded. Max: %v", maxRules)
 		}
 	}
 
@@ -1066,22 +1066,20 @@ func validateReplicationStateUpdate(existingNamespace *persistence.GetNamespaceR
 	}
 
 	if existingNamespace.Namespace.Info.State != enumspb.NAMESPACE_STATE_REGISTERED {
-		return serviceerror.NewInvalidArgument(
-			fmt.Sprintf(
-				"update ReplicationState is only supported when namespace is in %s state, current state: %s",
-				enumspb.NAMESPACE_STATE_REGISTERED.String(),
-				existingNamespace.Namespace.Info.State.String(),
-			),
+		return serviceerror.NewInvalidArgumentf(
+
+			"update ReplicationState is only supported when namespace is in %s state, current state: %s",
+			enumspb.NAMESPACE_STATE_REGISTERED.String(),
+			existingNamespace.Namespace.Info.State.String(),
 		)
 	}
 
 	if nsUpdateRequest.ReplicationConfig.State == enumspb.REPLICATION_STATE_HANDOVER {
 		if !existingNamespace.IsGlobalNamespace {
-			return serviceerror.NewInvalidArgument(
-				fmt.Sprintf(
-					"%s can only be set for global namespace",
-					enumspb.REPLICATION_STATE_HANDOVER,
-				),
+			return serviceerror.NewInvalidArgumentf(
+
+				"%s can only be set for global namespace",
+				enumspb.REPLICATION_STATE_HANDOVER,
 			)
 		}
 		// verify namespace has more than 1 replication clusters
@@ -1090,7 +1088,7 @@ func validateReplicationStateUpdate(existingNamespace *persistence.GetNamespaceR
 			replicationClusterCount = len(nsUpdateRequest.ReplicationConfig.Clusters)
 		}
 		if replicationClusterCount < 2 {
-			return serviceerror.NewInvalidArgument(fmt.Sprintf("%s require more than one replication clusters", enumspb.REPLICATION_STATE_HANDOVER))
+			return serviceerror.NewInvalidArgumentf("%s require more than one replication clusters", enumspb.REPLICATION_STATE_HANDOVER)
 		}
 	}
 	return nil

--- a/service/frontend/nexus_endpoint_client.go
+++ b/service/frontend/nexus_endpoint_client.go
@@ -342,7 +342,7 @@ func (c *NexusEndpointClient) validateUpsertSpec(spec *nexuspb.EndpointSpec) err
 		if variant.Worker.GetNamespace() == "" {
 			issues.Append("target namespace not set")
 		} else if _, nsErr := c.namespaceRegistry.GetNamespace(namespace.Name(variant.Worker.GetNamespace())); nsErr != nil {
-			return serviceerror.NewFailedPrecondition(fmt.Sprintf("could not verify namespace referenced by target exists: %v", nsErr.Error()))
+			return serviceerror.NewFailedPreconditionf("could not verify namespace referenced by target exists: %v", nsErr.Error())
 		}
 
 		if err := tqid.Validate(variant.Worker.GetTaskQueue(), c.config.maxTaskQueueLength()); err != nil {
@@ -406,7 +406,7 @@ func (c *NexusEndpointClient) validatePageSize(pageSize int32) error {
 
 	maxPageSize := c.config.listMaxPageSize()
 	if pageSize > int32(maxPageSize) {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("page_size exceeds limit of %d", maxPageSize))
+		return serviceerror.NewInvalidArgumentf("page_size exceeds limit of %d", maxPageSize)
 	}
 
 	return nil

--- a/service/frontend/task_reachability.go
+++ b/service/frontend/task_reachability.go
@@ -244,7 +244,7 @@ func (wh *WorkflowHandler) queryVisibilityForExistingWorkflowsReachability(
 	case enumspb.TASK_REACHABILITY_NEW_WORKFLOWS:
 		return nil, nil
 	default:
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Unsupported reachability type: %v", reachabilityType))
+		return nil, serviceerror.NewInvalidArgumentf("Unsupported reachability type: %v", reachabilityType)
 	}
 
 	escapedTaskQueue := sqlparser.String(sqlparser.NewStrVal([]byte(taskQueue)))

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -656,7 +656,7 @@ func (wh *WorkflowHandler) convertToHistoryMultiOperationItem(
 			},
 		}
 	} else {
-		return nil, "", serviceerror.NewInternal(fmt.Sprintf("unsupported operation: %T", op.Operation))
+		return nil, "", serviceerror.NewInternalf("unsupported operation: %T", op.Operation)
 	}
 
 	return opReq, workflowId, nil
@@ -692,7 +692,7 @@ func convertToMultiOperationResponse(
 				},
 			}
 		} else {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("unexpected operation result: %T", op.Response))
+			return nil, serviceerror.NewInternalf("unexpected operation result: %T", op.Response)
 		}
 		resp.Responses[i] = opResp
 	}
@@ -2007,7 +2007,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 	if request.WorkflowIdConflictPolicy == enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL {
 		// Signal-with-*Required*-Start is not supported
 		name := enumspb.WorkflowIdConflictPolicy_name[int32(request.WorkflowIdConflictPolicy.Number())]
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(errUnsupportedIDConflictPolicy, name))
+		return nil, serviceerror.NewInvalidArgumentf(errUnsupportedIDConflictPolicy, name)
 	}
 
 	enums.SetDefaultWorkflowIdReusePolicy(&request.WorkflowIdReusePolicy)
@@ -2072,7 +2072,7 @@ func (wh *WorkflowHandler) ResetWorkflowExecution(ctx context.Context, request *
 
 	enums.SetDefaultResetReapplyType(&request.ResetReapplyType)
 	if _, validType := enumspb.ResetReapplyType_name[int32(request.GetResetReapplyType())]; !validType {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("unknown reset reapply type: %v", request.GetResetReapplyType()))
+		return nil, serviceerror.NewInternalf("unknown reset reapply type: %v", request.GetResetReapplyType())
 	}
 
 	namespaceID, err := wh.namespaceRegistry.GetNamespaceID(namespace.Name(request.GetNamespace()))
@@ -2419,7 +2419,7 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(ctx context.Context, r
 	if request.GetPageSize() <= 0 {
 		request.PageSize = maxPageSize
 	} else if request.GetPageSize() > maxPageSize {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(errPageSizeTooBigMessage, maxPageSize))
+		return nil, serviceerror.NewInvalidArgumentf(errPageSizeTooBigMessage, maxPageSize)
 	}
 
 	if !wh.archivalMetadata.GetVisibilityConfig().ClusterConfiguredForArchival() {
@@ -2458,7 +2458,7 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(ctx context.Context, r
 
 	searchAttributes, err := wh.saProvider.GetSearchAttributes(wh.visibilityMgr.GetIndexName(), false)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
+		return nil, serviceerror.NewUnavailablef(errUnableToGetSearchAttributesMessage, err)
 	}
 
 	archiverResponse, err := visibilityArchiver.Query(
@@ -2558,7 +2558,7 @@ func (wh *WorkflowHandler) GetSearchAttributes(ctx context.Context, _ *workflows
 
 	searchAttributes, err := wh.saProvider.GetSearchAttributes(wh.visibilityMgr.GetIndexName(), false)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
+		return nil, serviceerror.NewUnavailablef(errUnableToGetSearchAttributesMessage, err)
 	}
 	resp := &workflowservice.GetSearchAttributesResponse{
 		Keys: searchAttributes.All(),
@@ -2779,7 +2779,7 @@ func (wh *WorkflowHandler) DescribeWorkflowExecution(ctx context.Context, reques
 	if response.GetWorkflowExecutionInfo().GetSearchAttributes() != nil {
 		saTypeMap, err := wh.saProvider.GetSearchAttributes(wh.visibilityMgr.GetIndexName(), false)
 		if err != nil {
-			return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
+			return nil, serviceerror.NewUnavailablef(errUnableToGetSearchAttributesMessage, err)
 		}
 		searchattribute.ApplyTypeMap(response.GetWorkflowExecutionInfo().GetSearchAttributes(), saTypeMap)
 		aliasedSas, err := searchattribute.AliasFields(wh.saMapperProvider, response.GetWorkflowExecutionInfo().GetSearchAttributes(), request.GetNamespace())
@@ -2837,8 +2837,8 @@ func (wh *WorkflowHandler) DescribeTaskQueue(ctx context.Context, request *workf
 
 	if request.GetReportTaskReachability() &&
 		len(request.GetVersions().GetBuildIds()) > wh.config.ReachabilityQueryBuildIdLimit() {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
-			"Too many build ids queried at once with ReportTaskReachability==true, limit: %d", wh.config.ReachabilityQueryBuildIdLimit()))
+		return nil, serviceerror.NewInvalidArgumentf(
+			"Too many build ids queried at once with ReportTaskReachability==true, limit: %d", wh.config.ReachabilityQueryBuildIdLimit())
 	}
 
 	if request.ApiMode == enumspb.DESCRIBE_TASK_QUEUE_MODE_ENHANCED {
@@ -3622,7 +3622,7 @@ func (wh *WorkflowHandler) DescribeSchedule(ctx context.Context, request *workfl
 	if sas := executionInfo.GetSearchAttributes(); sas != nil {
 		saTypeMap, err := wh.saProvider.GetSearchAttributes(wh.visibilityMgr.GetIndexName(), false)
 		if err != nil {
-			return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
+			return nil, serviceerror.NewUnavailablef(errUnableToGetSearchAttributesMessage, err)
 		}
 		searchattribute.ApplyTypeMap(sas, saTypeMap)
 		aliasedSas, err := searchattribute.AliasFields(wh.saMapperProvider, sas, request.GetNamespace())
@@ -3656,7 +3656,7 @@ func (wh *WorkflowHandler) DescribeSchedule(ctx context.Context, request *workfl
 
 	err = wh.annotateSearchAttributesOfScheduledWorkflow(&queryResponse, request.GetNamespace())
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("describe schedule: %v", err))
+		return nil, serviceerror.NewInternalf("describe schedule: %v", err)
 	}
 	// Search attributes in the Action are already in external ("aliased") form. Do not alias them here.
 
@@ -4068,7 +4068,7 @@ func (wh *WorkflowHandler) ListSchedules(
 	if strings.TrimSpace(request.Query) != "" {
 		saNameType, err := wh.saProvider.GetSearchAttributes(wh.visibilityMgr.GetIndexName(), false)
 		if err != nil {
-			return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
+			return nil, serviceerror.NewUnavailablef(errUnableToGetSearchAttributesMessage, err)
 		}
 		if err := scheduler.ValidateVisibilityQuery(
 			namespaceName,
@@ -4413,7 +4413,7 @@ func (wh *WorkflowHandler) GetWorkerTaskReachability(ctx context.Context, reques
 		return nil, serviceerror.NewInvalidArgument("Must query at least one build ID (or empty string for unversioned worker)")
 	}
 	if len(request.GetBuildIds()) > wh.config.ReachabilityQueryBuildIdLimit() {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Too many build ids queried at once, limit: %d", wh.config.ReachabilityQueryBuildIdLimit()))
+		return nil, serviceerror.NewInvalidArgumentf("Too many build ids queried at once, limit: %d", wh.config.ReachabilityQueryBuildIdLimit())
 	}
 	gotUnversionedRequest := false
 	for _, buildId := range request.GetBuildIds() {
@@ -4555,7 +4555,7 @@ func (wh *WorkflowHandler) StartBatchOperation(
 			// TODO: remove support for old fields later
 			resetType := op.ResetOperation.GetResetType()
 			if _, ok := enumspb.ResetType_name[int32(resetType)]; !ok || resetType == enumspb.RESET_TYPE_UNSPECIFIED {
-				return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("unknown batch reset type %v", resetType))
+				return nil, serviceerror.NewInvalidArgumentf("unknown batch reset type %v", resetType)
 			}
 			resetParams.ResetType = resetType
 			resetParams.ResetReapplyType = op.ResetOperation.GetResetReapplyType()
@@ -4595,7 +4595,7 @@ func (wh *WorkflowHandler) StartBatchOperation(
 		unpauseActivitiesParams.ResetHeartbeat = op.UnpauseActivitiesOperation.ResetHeartbeat
 		unpauseActivitiesParams.Jitter = op.UnpauseActivitiesOperation.Jitter.AsDuration()
 	default:
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("The operation type %T is not supported", op))
+		return nil, serviceerror.NewInvalidArgumentf("The operation type %T is not supported", op)
 	}
 
 	input := &batcher.BatchParams{
@@ -4973,7 +4973,7 @@ func (wh *WorkflowHandler) RespondNexusTaskCompleted(ctx context.Context, reques
 
 		tokenLimit := wh.config.MaxNexusOperationTokenLength(request.Namespace)
 		if len(operationToken) > tokenLimit {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("operation token length exceeds allowed limit (%d/%d)", len(operationToken), tokenLimit))
+			return nil, serviceerror.NewInvalidArgumentf("operation token length exceeds allowed limit (%d/%d)", len(operationToken), tokenLimit)
 		}
 	}
 
@@ -5070,7 +5070,7 @@ func (wh *WorkflowHandler) validateSearchAttributes(searchAttributes *commonpb.S
 func (wh *WorkflowHandler) validateVersionRuleBuildId(request *workflowservice.UpdateWorkerVersioningRulesRequest) error {
 	validateBuildId := func(bid string) error {
 		if len(bid) > 255 {
-			return serviceerror.NewInvalidArgument(fmt.Sprintf("BuildId must be <= 255 characters, was %d", len(bid)))
+			return serviceerror.NewInvalidArgumentf("BuildId must be <= 255 characters, was %d", len(bid))
 		}
 		return nil
 	}
@@ -5159,13 +5159,13 @@ func (wh *WorkflowHandler) validateLinks(
 ) error {
 	maxAllowedLinks := wh.config.MaxLinksPerRequest(ns.String())
 	if len(links) > maxAllowedLinks {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("cannot attach more than %d links per request, got %d", maxAllowedLinks, len(links)))
+		return serviceerror.NewInvalidArgumentf("cannot attach more than %d links per request, got %d", maxAllowedLinks, len(links))
 	}
 
 	maxSize := wh.config.LinkMaxSize(ns.String())
 	for _, l := range links {
 		if l.Size() > maxSize {
-			return serviceerror.NewInvalidArgument(fmt.Sprintf("link exceeds allowed size of %d, got %d", maxSize, l.Size()))
+			return serviceerror.NewInvalidArgumentf("link exceeds allowed size of %d, got %d", maxSize, l.Size())
 		}
 		switch t := l.Variant.(type) {
 		case *commonpb.Link_WorkflowEvent_:
@@ -5479,7 +5479,7 @@ func (wh *WorkflowHandler) unregisterOutstandingPollContext(
 
 func (wh *WorkflowHandler) checkBadBinary(namespaceEntry *namespace.Namespace, binaryChecksum string) error {
 	if err := namespaceEntry.VerifyBinaryChecksum(binaryChecksum); err != nil {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("Binary %v already marked as bad deployment.", binaryChecksum))
+		return serviceerror.NewInvalidArgumentf("Binary %v already marked as bad deployment.", binaryChecksum)
 	}
 	return nil
 }
@@ -5595,7 +5595,7 @@ func (wh *WorkflowHandler) canonicalizeScheduleSpec(schedule *schedulepb.Schedul
 	}
 	compiledSpec, err := wh.scheduleSpecBuilder.NewCompiledSpec(schedule.Spec)
 	if err != nil {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid schedule spec: %v", err))
+		return serviceerror.NewInvalidArgumentf("Invalid schedule spec: %v", err)
 	}
 	// This mutates a part of the request message, but it's safe even in the presence of
 	// retries (reusing the same message) because canonicalization is idempotent.
@@ -5710,7 +5710,7 @@ func (wh *WorkflowHandler) UpdateWorkflowExecutionOptions(
 	}
 	_, err := fieldmaskpb.New(opts, request.GetUpdateMask().GetPaths()...) // errors if paths are not valid for WorkflowExecutionOptions
 	if err != nil {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("error parsing UpdateMask: %s", err.Error()))
+		return nil, serviceerror.NewInvalidArgumentf("error parsing UpdateMask: %s", err.Error())
 	}
 	if err := worker_versioning.ValidateVersioningOverride(opts.GetVersioningOverride()); err != nil {
 		return nil, err

--- a/service/history/api/activity_util.go
+++ b/service/history/api/activity_util.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	"go.temporal.io/api/serviceerror"
 	tokenspb "go.temporal.io/server/api/token/v1"
@@ -49,7 +48,7 @@ func GetActivityScheduledEventID(
 	}
 	activityInfo, ok := mutableState.GetActivityByActivityID(activityID)
 	if !ok {
-		return 0, serviceerror.NewNotFound(fmt.Sprintf("cannot find pending activity with ActivityID %s, check workflow execution history for more details", activityID))
+		return 0, serviceerror.NewNotFoundf("cannot find pending activity with ActivityID %s, check workflow execution history for more details", activityID)
 	}
 	return activityInfo.ScheduledEventId, nil
 }

--- a/service/history/api/addtasks/api.go
+++ b/service/history/api/addtasks/api.go
@@ -2,7 +2,6 @@ package addtasks
 
 import (
 	"context"
-	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
@@ -42,11 +41,11 @@ func Invoke(
 	taskRegistry tasks.TaskCategoryRegistry,
 ) (*historyservice.AddTasksResponse, error) {
 	if len(req.Tasks) > maxTasksPerRequest {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
+		return nil, serviceerror.NewInvalidArgumentf(
 			"Too many tasks in request: %d > %d",
 			len(req.Tasks),
 			maxTasksPerRequest,
-		))
+		)
 	}
 
 	if len(req.Tasks) == 0 {
@@ -57,7 +56,7 @@ func Invoke(
 
 	for i, task := range req.Tasks {
 		if task == nil {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Nil task at index: %d", i))
+			return nil, serviceerror.NewInvalidArgumentf("Nil task at index: %d", i)
 		}
 
 		category, err := api.GetTaskCategory(int(task.CategoryId), taskRegistry)
@@ -66,10 +65,10 @@ func Invoke(
 		}
 
 		if task.Blob == nil {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
+			return nil, serviceerror.NewInvalidArgumentf(
 				"Task blob is nil at index: %d",
 				i,
-			))
+			)
 		}
 
 		deserializedTask, err := deserializer.DeserializeTask(category, task.Blob)
@@ -79,10 +78,10 @@ func Invoke(
 
 		shardID := tasks.GetShardIDForTask(deserializedTask, numShards)
 		if shardID != int(req.ShardId) {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(
+			return nil, serviceerror.NewInvalidArgumentf(
 				"Task is for wrong shard: index = %d, task shard = %d, request shard = %d",
 				i, shardID, req.ShardId,
-			))
+			)
 		}
 
 		// group by namespaceID + workflowID

--- a/service/history/api/command_attr_validator.go
+++ b/service/history/api/command_attr_validator.go
@@ -97,10 +97,10 @@ func (v *CommandAttrValidator) ValidateActivityScheduleAttributes(
 	}
 
 	if activityID == "" {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("ActivityId is not set on ScheduleActivityTaskCommand. ActivityType=%s", activityType))
+		return failedCause, serviceerror.NewInvalidArgumentf("ActivityId is not set on ScheduleActivityTaskCommand. ActivityType=%s", activityType)
 	}
 	if activityType == "" {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("ActivityType is not set on ScheduleActivityTaskCommand. ActivityID=%s", activityID))
+		return failedCause, serviceerror.NewInvalidArgumentf("ActivityType is not set on ScheduleActivityTaskCommand. ActivityID=%s", activityID)
 	}
 	if attributes.RetryPolicy == nil {
 		attributes.RetryPolicy = &commonpb.RetryPolicy{}
@@ -110,24 +110,24 @@ func (v *CommandAttrValidator) ValidateActivityScheduleAttributes(
 		return failedCause, fmt.Errorf("invalid ActivityRetryPolicy on SechduleActivityTaskCommand: %w. ActivityId=%s ActivityType=%s", err, activityID, activityType)
 	}
 	if len(activityID) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("ActivityId on ScheduleActivityTaskCommand exceeds length limit. ActivityId=%s ActivityType=%s Length=%d Limit=%d", activityID, activityType, len(activityID), v.maxIDLengthLimit))
+		return failedCause, serviceerror.NewInvalidArgumentf("ActivityId on ScheduleActivityTaskCommand exceeds length limit. ActivityId=%s ActivityType=%s Length=%d Limit=%d", activityID, activityType, len(activityID), v.maxIDLengthLimit)
 	}
 	if len(activityType) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("ActivityType on ScheduleActivityTaskCommand exceeds length limit. ActivityId=%s ActivityType=%s Length=%d Limit=%d", activityID, activityType, len(activityType), v.maxIDLengthLimit))
+		return failedCause, serviceerror.NewInvalidArgumentf("ActivityType on ScheduleActivityTaskCommand exceeds length limit. ActivityId=%s ActivityType=%s Length=%d Limit=%d", activityID, activityType, len(activityType), v.maxIDLengthLimit)
 	}
 
 	// Only attempt to deduce and fill in unspecified timeouts only when all timeouts are non-negative.
 	if err := timestamp.ValidateAndCapProtoDuration(attributes.GetScheduleToCloseTimeout()); err != nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid ScheduleToCloseTimeout for ScheduleActivityTaskCommand: %v. ActivityId=%s ActivityType=%s", err, activityID, activityType))
+		return failedCause, serviceerror.NewInvalidArgumentf("Invalid ScheduleToCloseTimeout for ScheduleActivityTaskCommand: %v. ActivityId=%s ActivityType=%s", err, activityID, activityType)
 	}
 	if err := timestamp.ValidateAndCapProtoDuration(attributes.GetScheduleToStartTimeout()); err != nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid ScheduleToStartTimeout for ScheduleActivityTaskCommand: %v. ActivityId=%s ActivityType=%s", err, activityID, activityType))
+		return failedCause, serviceerror.NewInvalidArgumentf("Invalid ScheduleToStartTimeout for ScheduleActivityTaskCommand: %v. ActivityId=%s ActivityType=%s", err, activityID, activityType)
 	}
 	if err := timestamp.ValidateAndCapProtoDuration(attributes.GetStartToCloseTimeout()); err != nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid StartToCloseTimeout for ScheduleActivityTaskCommand: %v. ActivityId=%s ActivityType=%s", err, activityID, activityType))
+		return failedCause, serviceerror.NewInvalidArgumentf("Invalid StartToCloseTimeout for ScheduleActivityTaskCommand: %v. ActivityId=%s ActivityType=%s", err, activityID, activityType)
 	}
 	if err := timestamp.ValidateAndCapProtoDuration(attributes.GetHeartbeatTimeout()); err != nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid HeartbeatTimeout for ScheduleActivityTaskCommand: %v. ActivityId=%s ActivityType=%s", err, activityID, activityType))
+		return failedCause, serviceerror.NewInvalidArgumentf("Invalid HeartbeatTimeout for ScheduleActivityTaskCommand: %v. ActivityId=%s ActivityType=%s", err, activityID, activityType)
 	}
 
 	ScheduleToCloseSet := attributes.GetScheduleToCloseTimeout().AsDuration() > 0
@@ -155,7 +155,7 @@ func (v *CommandAttrValidator) ValidateActivityScheduleAttributes(
 		}
 	} else {
 		// Deduction failed as there's not enough information to fill in missing timeouts.
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("A valid StartToClose or ScheduleToCloseTimeout is not set on ScheduleActivityTaskCommand. ActivityId=%s ActivityType=%s", activityID, activityType))
+		return failedCause, serviceerror.NewInvalidArgumentf("A valid StartToClose or ScheduleToCloseTimeout is not set on ScheduleActivityTaskCommand. ActivityId=%s ActivityType=%s", activityID, activityType)
 	}
 	// ensure activity timeout never larger than workflow timeout
 	if runTimeout.AsDuration() > 0 {
@@ -194,10 +194,10 @@ func (v *CommandAttrValidator) ValidateTimerScheduleAttributes(
 		return failedCause, serviceerror.NewInvalidArgument("TimerId is not set on StartTimerCommand.")
 	}
 	if len(timerID) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("TimerId on StartTimerCommand exceeds length limit. TimerId=%s Length=%d Limit=%d", timerID, len(timerID), v.maxIDLengthLimit))
+		return failedCause, serviceerror.NewInvalidArgumentf("TimerId on StartTimerCommand exceeds length limit. TimerId=%s Length=%d Limit=%d", timerID, len(timerID), v.maxIDLengthLimit)
 	}
 	if err := timestamp.ValidateAndCapProtoDuration(attributes.GetStartToFireTimeout()); err != nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("An invalid StartToFireTimeout is set on StartTimerCommand: %v. TimerId=%s", err, timerID))
+		return failedCause, serviceerror.NewInvalidArgumentf("An invalid StartToFireTimeout is set on StartTimerCommand: %v. TimerId=%s", err, timerID)
 	}
 	return enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED, nil
 }
@@ -231,7 +231,7 @@ func (v *CommandAttrValidator) ValidateTimerCancelAttributes(
 		return failedCause, serviceerror.NewInvalidArgument("TimerId is not set on CancelTimerCommand.")
 	}
 	if len(timerID) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("TimerId on CancelTimerCommand exceeds length limit. TimerId=%s Length=%d Limit=%d", timerID, len(timerID), v.maxIDLengthLimit))
+		return failedCause, serviceerror.NewInvalidArgumentf("TimerId on CancelTimerCommand exceeds length limit. TimerId=%s Length=%d Limit=%d", timerID, len(timerID), v.maxIDLengthLimit)
 	}
 	return enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED, nil
 }
@@ -250,7 +250,7 @@ func (v *CommandAttrValidator) ValidateRecordMarkerAttributes(
 		return failedCause, serviceerror.NewInvalidArgument("MarkerName is not set on RecordMarkerCommand.")
 	}
 	if len(markerName) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("MarkerName on RecordMarkerCommand exceeds length limit. MarkerName=%s Length=%d Limit=%d", markerName, len(markerName), v.maxIDLengthLimit))
+		return failedCause, serviceerror.NewInvalidArgumentf("MarkerName on RecordMarkerCommand exceeds length limit. MarkerName=%s Length=%d Limit=%d", markerName, len(markerName), v.maxIDLengthLimit)
 	}
 
 	return enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED, nil
@@ -316,19 +316,19 @@ func (v *CommandAttrValidator) ValidateCancelExternalWorkflowExecutionAttributes
 	runID := attributes.GetRunId()
 
 	if workflowID == "" {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("WorkflowId is not set on RequestCancelExternalWorkflowExecutionCommand. Namespace=%s RunId=%s", ns, runID))
+		return failedCause, serviceerror.NewInvalidArgumentf("WorkflowId is not set on RequestCancelExternalWorkflowExecutionCommand. Namespace=%s RunId=%s", ns, runID)
 	}
 	if len(ns) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Namespace on RequestCancelExternalWorkflowExecutionCommand exceeds length limit. WorkflowId=%s RunId=%s Namespace=%s Length=%d Limit=%d", workflowID, runID, ns, len(ns), v.maxIDLengthLimit))
+		return failedCause, serviceerror.NewInvalidArgumentf("Namespace on RequestCancelExternalWorkflowExecutionCommand exceeds length limit. WorkflowId=%s RunId=%s Namespace=%s Length=%d Limit=%d", workflowID, runID, ns, len(ns), v.maxIDLengthLimit)
 	}
 	if len(workflowID) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("WorkflowId on RequestCancelExternalWorkflowExecutionCommand exceeds length limit. WorkflowId=%s Length=%d Limit=%d RunId=%s Namespace=%s", workflowID, len(workflowID), v.maxIDLengthLimit, runID, ns))
+		return failedCause, serviceerror.NewInvalidArgumentf("WorkflowId on RequestCancelExternalWorkflowExecutionCommand exceeds length limit. WorkflowId=%s Length=%d Limit=%d RunId=%s Namespace=%s", workflowID, len(workflowID), v.maxIDLengthLimit, runID, ns)
 	}
 	if runID != "" && uuid.Parse(runID) == nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid RunId set on RequestCancelExternalWorkflowExecutionCommand. WorkflowId=%s RunId=%s Namespace=%s", workflowID, runID, ns))
+		return failedCause, serviceerror.NewInvalidArgumentf("Invalid RunId set on RequestCancelExternalWorkflowExecutionCommand. WorkflowId=%s RunId=%s Namespace=%s", workflowID, runID, ns)
 	}
 	if _, ok := initiatedChildExecutionsInSession[workflowID]; ok {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Start and RequestCancel for child workflow is not allowed in same workflow task. WorkflowId=%s RunId=%s Namespace=%s", workflowID, runID, ns))
+		return failedCause, serviceerror.NewInvalidArgumentf("Start and RequestCancel for child workflow is not allowed in same workflow task. WorkflowId=%s RunId=%s Namespace=%s", workflowID, runID, ns)
 	}
 
 	return enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED, nil
@@ -361,19 +361,19 @@ func (v *CommandAttrValidator) ValidateSignalExternalWorkflowExecutionAttributes
 	signalName := attributes.GetSignalName()
 
 	if workflowID == "" {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("WorkflowId is not set on SignalExternalWorkflowExecutionCommand. Namespace=%s RunId=%s SignalName=%s", ns, targetRunID, signalName))
+		return failedCause, serviceerror.NewInvalidArgumentf("WorkflowId is not set on SignalExternalWorkflowExecutionCommand. Namespace=%s RunId=%s SignalName=%s", ns, targetRunID, signalName)
 	}
 	if len(ns) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Namespace on SignalExternalWorkflowExecutionCommand exceeds length limit. WorkflowId=%s Namespace=%s Length=%d Limit=%d RunId=%s SignalName=%s", workflowID, ns, len(ns), v.maxIDLengthLimit, targetRunID, signalName))
+		return failedCause, serviceerror.NewInvalidArgumentf("Namespace on SignalExternalWorkflowExecutionCommand exceeds length limit. WorkflowId=%s Namespace=%s Length=%d Limit=%d RunId=%s SignalName=%s", workflowID, ns, len(ns), v.maxIDLengthLimit, targetRunID, signalName)
 	}
 	if len(workflowID) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("WorkflowId on SignalExternalWorkflowExecutionCommand exceeds length limit. WorkflowId=%s Length=%d Limit=%d Namespace=%s RunId=%s SignalName=%s", workflowID, len(workflowID), v.maxIDLengthLimit, ns, targetRunID, signalName))
+		return failedCause, serviceerror.NewInvalidArgumentf("WorkflowId on SignalExternalWorkflowExecutionCommand exceeds length limit. WorkflowId=%s Length=%d Limit=%d Namespace=%s RunId=%s SignalName=%s", workflowID, len(workflowID), v.maxIDLengthLimit, ns, targetRunID, signalName)
 	}
 	if targetRunID != "" && uuid.Parse(targetRunID) == nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid RunId set on SignalExternalWorkflowExecutionCommand. WorkflowId=%s Namespace=%s RunId=%s SignalName=%s", workflowID, ns, targetRunID, signalName))
+		return failedCause, serviceerror.NewInvalidArgumentf("Invalid RunId set on SignalExternalWorkflowExecutionCommand. WorkflowId=%s Namespace=%s RunId=%s SignalName=%s", workflowID, ns, targetRunID, signalName)
 	}
 	if attributes.GetSignalName() == "" {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("SignalName is not set on SignalExternalWorkflowExecutionCommand. WorkflowId=%s Namespace=%s RunId=%s", workflowID, ns, targetRunID))
+		return failedCause, serviceerror.NewInvalidArgumentf("SignalName is not set on SignalExternalWorkflowExecutionCommand. WorkflowId=%s Namespace=%s RunId=%s", workflowID, ns, targetRunID)
 	}
 
 	return enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED, nil
@@ -438,7 +438,7 @@ func (v *CommandAttrValidator) ValidateContinueAsNewWorkflowExecutionAttributes(
 
 	wfType := attributes.WorkflowType.GetName()
 	if len(wfType) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("WorkflowType on ContinueAsNewWorkflowExecutionCommand exceeds length limit. WorkflowType=%s Length=%d Limit=%d", wfType, len(wfType), v.maxIDLengthLimit))
+		return failedCause, serviceerror.NewInvalidArgumentf("WorkflowType on ContinueAsNewWorkflowExecutionCommand exceeds length limit. WorkflowType=%s Length=%d Limit=%d", wfType, len(wfType), v.maxIDLengthLimit)
 	}
 
 	// Inherit task queue from previous execution if not provided on command
@@ -452,15 +452,15 @@ func (v *CommandAttrValidator) ValidateContinueAsNewWorkflowExecutionAttributes(
 	}
 
 	if err := timestamp.ValidateAndCapProtoDuration(attributes.GetWorkflowRunTimeout()); err != nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid WorkflowRunTimeout on ContinueAsNewWorkflowExecutionCommand: %v. WorkflowType=%s TaskQueue=%s", err, wfType, attributes.TaskQueue))
+		return failedCause, serviceerror.NewInvalidArgumentf("Invalid WorkflowRunTimeout on ContinueAsNewWorkflowExecutionCommand: %v. WorkflowType=%s TaskQueue=%s", err, wfType, attributes.TaskQueue)
 	}
 
 	if err := timestamp.ValidateAndCapProtoDuration(attributes.GetWorkflowTaskTimeout()); err != nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid WorkflowTaskTimeout on ContinueAsNewWorkflowExecutionCommand: %v. WorkflowType=%s TaskQueue=%s", err, wfType, attributes.TaskQueue))
+		return failedCause, serviceerror.NewInvalidArgumentf("Invalid WorkflowTaskTimeout on ContinueAsNewWorkflowExecutionCommand: %v. WorkflowType=%s TaskQueue=%s", err, wfType, attributes.TaskQueue)
 	}
 
 	if err := timestamp.ValidateAndCapProtoDuration(attributes.GetBackoffStartInterval()); err != nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid BackoffStartInterval on ContinueAsNewWorkflowExecutionCommand: %v. WorkflowType=%s TaskQueue=%s", err, wfType, attributes.TaskQueue))
+		return failedCause, serviceerror.NewInvalidArgumentf("Invalid BackoffStartInterval on ContinueAsNewWorkflowExecutionCommand: %v. WorkflowType=%s TaskQueue=%s", err, wfType, attributes.TaskQueue)
 	}
 
 	if attributes.GetWorkflowRunTimeout().AsDuration() == 0 {
@@ -515,35 +515,35 @@ func (v *CommandAttrValidator) ValidateStartChildExecutionAttributes(
 	ns := attributes.GetNamespace()
 
 	if wfID == "" {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Required field WorkflowId is not set on StartChildWorkflowExecutionCommand. WorkflowType=%s Namespace=%s", wfType, ns))
+		return failedCause, serviceerror.NewInvalidArgumentf("Required field WorkflowId is not set on StartChildWorkflowExecutionCommand. WorkflowType=%s Namespace=%s", wfType, ns)
 	}
 
 	if wfType == "" {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Required field WorkflowType is not set on StartChildWorkflowExecutionCommand. WorkflowId=%s Namespace=%s", wfID, ns))
+		return failedCause, serviceerror.NewInvalidArgumentf("Required field WorkflowType is not set on StartChildWorkflowExecutionCommand. WorkflowId=%s Namespace=%s", wfID, ns)
 	}
 
 	if len(ns) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Namespace on StartChildWorkflowExecutionCommand exceeds length limit. WorkflowId=%s WorkflowType=%s Namespace=%s Length=%d Limit=%d", wfID, wfType, ns, len(ns), v.maxIDLengthLimit))
+		return failedCause, serviceerror.NewInvalidArgumentf("Namespace on StartChildWorkflowExecutionCommand exceeds length limit. WorkflowId=%s WorkflowType=%s Namespace=%s Length=%d Limit=%d", wfID, wfType, ns, len(ns), v.maxIDLengthLimit)
 	}
 
 	if len(wfID) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("WorkflowId on StartChildWorkflowExecutionCommand exceeds length limit. WorkflowId=%s Length=%d Limit=%d WorkflowType=%s Namespace=%s", wfID, len(wfID), v.maxIDLengthLimit, wfType, ns))
+		return failedCause, serviceerror.NewInvalidArgumentf("WorkflowId on StartChildWorkflowExecutionCommand exceeds length limit. WorkflowId=%s Length=%d Limit=%d WorkflowType=%s Namespace=%s", wfID, len(wfID), v.maxIDLengthLimit, wfType, ns)
 	}
 
 	if len(wfType) > v.maxIDLengthLimit {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("WorkflowType on StartChildWorkflowExecutionCommand exceeds length limit. WorkflowId=%s WorkflowType=%s Length=%d Limit=%d Namespace=%s", wfID, wfType, len(wfType), v.maxIDLengthLimit, ns))
+		return failedCause, serviceerror.NewInvalidArgumentf("WorkflowType on StartChildWorkflowExecutionCommand exceeds length limit. WorkflowId=%s WorkflowType=%s Length=%d Limit=%d Namespace=%s", wfID, wfType, len(wfType), v.maxIDLengthLimit, ns)
 	}
 
 	if err := timestamp.ValidateAndCapProtoDuration(attributes.GetWorkflowExecutionTimeout()); err != nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid WorkflowExecutionTimeout on StartChildWorkflowExecutionCommand: %v. WorkflowId=%s WorkflowType=%s Namespace=%s", err, wfID, wfType, ns))
+		return failedCause, serviceerror.NewInvalidArgumentf("Invalid WorkflowExecutionTimeout on StartChildWorkflowExecutionCommand: %v. WorkflowId=%s WorkflowType=%s Namespace=%s", err, wfID, wfType, ns)
 	}
 
 	if err := timestamp.ValidateAndCapProtoDuration(attributes.GetWorkflowRunTimeout()); err != nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid WorkflowRunTimeout on StartChildWorkflowExecutionCommand: %v. WorkflowId=%s WorkflowType=%s Namespace=%s", err, wfID, wfType, ns))
+		return failedCause, serviceerror.NewInvalidArgumentf("Invalid WorkflowRunTimeout on StartChildWorkflowExecutionCommand: %v. WorkflowId=%s WorkflowType=%s Namespace=%s", err, wfID, wfType, ns)
 	}
 
 	if err := timestamp.ValidateAndCapProtoDuration(attributes.GetWorkflowTaskTimeout()); err != nil {
-		return failedCause, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid WorkflowTaskTimeout on StartChildWorkflowExecutionCommand: %v. WorkflowId=%s WorkflowType=%s Namespace=%s", err, wfID, wfType, ns))
+		return failedCause, serviceerror.NewInvalidArgumentf("Invalid WorkflowTaskTimeout on StartChildWorkflowExecutionCommand: %v. WorkflowId=%s WorkflowType=%s Namespace=%s", err, wfID, wfType, ns)
 	}
 
 	if err := v.validateWorkflowRetryPolicy(namespace.Name(attributes.GetNamespace()), attributes.RetryPolicy); err != nil {
@@ -653,7 +653,7 @@ func (v *CommandAttrValidator) createCrossNamespaceCallError(
 	namespaceEntry *namespace.Namespace,
 	targetNamespaceEntry *namespace.Namespace,
 ) error {
-	return serviceerror.NewInvalidArgument(fmt.Sprintf("unable to process cross namespace command between %v and %v", namespaceEntry.Name(), targetNamespaceEntry.Name()))
+	return serviceerror.NewInvalidArgumentf("unable to process cross namespace command between %v and %v", namespaceEntry.Name(), targetNamespaceEntry.Name())
 }
 
 func (v *CommandAttrValidator) ValidateCommandSequence(
@@ -663,10 +663,10 @@ func (v *CommandAttrValidator) ValidateCommandSequence(
 
 	for _, command := range commands {
 		if closeCommand != enumspb.COMMAND_TYPE_UNSPECIFIED {
-			return serviceerror.NewInvalidArgument(fmt.Sprintf(
+			return serviceerror.NewInvalidArgumentf(
 				"invalid command sequence: [%v], command %s must be the last command.",
 				strings.Join(v.commandTypes(commands), ", "), closeCommand.String(),
-			))
+			)
 		}
 
 		// nolint:exhaustive
@@ -693,7 +693,7 @@ func (v *CommandAttrValidator) ValidateCommandSequence(
 		default:
 			// The default is to fail with invalid argument to force authors of new commands to consider whether it's a
 			// close command however unlikely that may be.
-			return serviceerror.NewInvalidArgument(fmt.Sprintf("unknown command type: %v", command.GetCommandType()))
+			return serviceerror.NewInvalidArgumentf("unknown command type: %v", command.GetCommandType())
 		}
 	}
 	return nil

--- a/service/history/api/create_workflow_util.go
+++ b/service/history/api/create_workflow_util.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -271,13 +270,13 @@ func ValidateStartWorkflowExecutionRequest(
 		return serviceerror.NewInvalidArgument("Missing request ID.")
 	}
 	if err := timestamp.ValidateAndCapProtoDuration(request.GetWorkflowExecutionTimeout()); err != nil {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("invalid WorkflowExecutionTimeoutSeconds: %s", err.Error()))
+		return serviceerror.NewInvalidArgumentf("invalid WorkflowExecutionTimeoutSeconds: %s", err.Error())
 	}
 	if err := timestamp.ValidateAndCapProtoDuration(request.GetWorkflowRunTimeout()); err != nil {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("invalid WorkflowRunTimeoutSeconds: %s", err.Error()))
+		return serviceerror.NewInvalidArgumentf("invalid WorkflowRunTimeoutSeconds: %s", err.Error())
 	}
 	if err := timestamp.ValidateAndCapProtoDuration(request.GetWorkflowTaskTimeout()); err != nil {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("invalid WorkflowTaskTimeoutSeconds: %s", err.Error()))
+		return serviceerror.NewInvalidArgumentf("invalid WorkflowTaskTimeoutSeconds: %s", err.Error())
 	}
 	if request.TaskQueue == nil || request.TaskQueue.GetName() == "" {
 		return serviceerror.NewInvalidArgument("Missing Taskqueue.")

--- a/service/history/api/get_history_util.go
+++ b/service/history/api/get_history_util.go
@@ -336,7 +336,6 @@ func validateTransientWorkflowTaskEvents(
 		expectedEventID := eventIDOffset + int64(i)
 		if event.GetEventId() != expectedEventID {
 			return serviceerror.NewInternalf(
-
 				"invalid transient workflow task at position %v; expected event ID %v, found event ID %v",
 				i,
 				expectedEventID,

--- a/service/history/api/get_history_util.go
+++ b/service/history/api/get_history_util.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -300,7 +299,7 @@ func ProcessOutgoingSearchAttributes(
 ) error {
 	saTypeMap, err := saProvider.GetSearchAttributes(persistenceVisibilityMgr.GetIndexName(), false)
 	if err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf(consts.ErrUnableToGetSearchAttributesMessage, err))
+		return serviceerror.NewUnavailablef(consts.ErrUnableToGetSearchAttributesMessage, err)
 	}
 	for _, event := range events {
 		var searchAttributes *commonpb.SearchAttributes
@@ -336,12 +335,12 @@ func validateTransientWorkflowTaskEvents(
 	for i, event := range transientWorkflowTaskInfo.HistorySuffix {
 		expectedEventID := eventIDOffset + int64(i)
 		if event.GetEventId() != expectedEventID {
-			return serviceerror.NewInternal(
-				fmt.Sprintf(
-					"invalid transient workflow task at position %v; expected event ID %v, found event ID %v",
-					i,
-					expectedEventID,
-					event.GetEventId()))
+			return serviceerror.NewInternalf(
+
+				"invalid transient workflow task at position %v; expected event ID %v, found event ID %v",
+				i,
+				expectedEventID,
+				event.GetEventId())
 		}
 	}
 
@@ -372,7 +371,7 @@ func VerifyHistoryIsComplete(
 	if !isFirstPage { // at least one page of history has been read previously
 		if firstEvent.GetEventId() <= expectedFirstEventID {
 			// not first page and no events have been read in the previous pages - not possible
-			return serviceerror.NewDataLoss(fmt.Sprintf("Invalid history: expected first eventID to be > %v but got %v", expectedFirstEventID, firstEvent.GetEventId()))
+			return serviceerror.NewDataLossf("Invalid history: expected first eventID to be > %v but got %v", expectedFirstEventID, firstEvent.GetEventId())
 		}
 		expectedFirstEventID = firstEvent.GetEventId()
 	}
@@ -391,7 +390,7 @@ func VerifyHistoryIsComplete(
 		return nil
 	}
 
-	return serviceerror.NewDataLoss(fmt.Sprintf("Incomplete history: expected events [%v-%v] but got events [%v-%v] of length %v: isFirstPage=%v,isLastPage=%v,pageSize=%v",
+	return serviceerror.NewDataLossf("Incomplete history: expected events [%v-%v] but got events [%v-%v] of length %v: isFirstPage=%v,isLastPage=%v,pageSize=%v",
 		expectedFirstEventID,
 		expectedLastEventID,
 		firstEvent.GetEventId(),
@@ -399,7 +398,7 @@ func VerifyHistoryIsComplete(
 		eventCount,
 		isFirstPage,
 		isLastPage,
-		pageSize))
+		pageSize)
 }
 
 // ProcessInternalRawHistory processes history in the field response.History.

--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -258,9 +258,9 @@ func GetMutableState(
 ) (_ *historyservice.GetMutableStateResponse, retError error) {
 
 	if len(workflowKey.RunID) == 0 {
-		return nil, serviceerror.NewInternal(fmt.Sprintf(
+		return nil, serviceerror.NewInternalf(
 			"getMutableState encountered empty run ID: %v", workflowKey,
-		))
+		)
 	}
 
 	workflowLease, err := workflowConsistencyChecker.GetWorkflowLease(
@@ -292,9 +292,9 @@ func GetMutableStateWithConsistencyCheck(
 ) (_ *historyservice.GetMutableStateResponse, retError error) {
 
 	if len(workflowKey.RunID) == 0 {
-		return nil, serviceerror.NewInternal(fmt.Sprintf(
+		return nil, serviceerror.NewInternalf(
 			"getMutableState encountered empty run ID: %v", workflowKey,
-		))
+		)
 	}
 
 	workflowLease, err := workflowConsistencyChecker.GetWorkflowLeaseWithConsistencyCheck(

--- a/service/history/api/getdlqtasks/api.go
+++ b/service/history/api/getdlqtasks/api.go
@@ -4,7 +4,6 @@ package getdlqtasks
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"go.temporal.io/api/serviceerror"
 	commonspb "go.temporal.io/server/api/common/v1"
@@ -43,7 +42,7 @@ func Invoke(
 			return nil, consts.ErrInvalidPageSize
 		}
 
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetDLQTasks failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("GetDLQTasks failed. Error: %v", err)
 	}
 
 	dlqTasks := make([]*commonspb.HistoryDLQTask, len(response.Tasks))

--- a/service/history/api/listqueues/api.go
+++ b/service/history/api/listqueues/api.go
@@ -3,7 +3,6 @@ package listqueues
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/historyservice/v1"
@@ -28,7 +27,7 @@ func Invoke(
 		if errors.Is(err, persistence.ErrNegativeListQueuesOffset) || errors.Is(err, persistence.ErrInvalidListQueuesNextPageToken) {
 			return nil, consts.ErrInvalidPaginationToken
 		}
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListQueues failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailablef("ListQueues failed. Error: %v", err)
 	}
 	var queues []*historyservice.ListQueuesResponse_QueueInfo
 	for _, queue := range resp.Queues {

--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -297,7 +297,7 @@ func (mo *multiOp) startAndUpdateWorkflow(ctx context.Context) (*historyservice.
 		// The best way forward is to exit and retry from the top.
 		// By returning an Unavailable service error, the entire MultiOperation will be retried.
 		return nil, newMultiOpError(
-			serviceerror.NewUnavailable(fmt.Sprintf("Workflow was not started: %v", startOutcome)),
+			serviceerror.NewUnavailablef("Workflow was not started: %v", startOutcome),
 			multiOpAbortedErr)
 	}
 

--- a/service/history/api/pollupdate/api.go
+++ b/service/history/api/pollupdate/api.go
@@ -2,7 +2,6 @@ package pollupdate
 
 import (
 	"context"
-	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
@@ -51,7 +50,7 @@ func Invoke(
 		return nil, err
 	}
 	if upd == nil {
-		return nil, serviceerror.NewNotFound(fmt.Sprintf("update %q not found", updateRef.GetUpdateId()))
+		return nil, serviceerror.NewNotFoundf("update %q not found", updateRef.GetUpdateId())
 	}
 
 	namespaceID := namespace.ID(req.GetNamespaceId())

--- a/service/history/api/resetworkflow/api.go
+++ b/service/history/api/resetworkflow/api.go
@@ -2,7 +2,6 @@ package resetworkflow
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/uuid"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -205,7 +204,7 @@ func validatePostResetOperationInputs(postResetOperations []*workflowpb.PostRese
 				return err
 			}
 		default:
-			return serviceerror.NewInvalidArgument(fmt.Sprintf("unsupported post reset operation: %T", op))
+			return serviceerror.NewInvalidArgumentf("unsupported post reset operation: %T", op)
 		}
 	}
 	return nil

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -332,8 +332,8 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 		wtFailedCause = newWorkflowTaskFailedCause(
 			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_BINARY,
 			serviceerror.NewInvalidArgumentf(
-
 				"binary %v is marked as bad deployment",
+				//nolint:staticcheck // SA1019 deprecated stamp will clean up later
 				request.GetBinaryChecksum()),
 			false)
 	} else {

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -2,7 +2,6 @@ package respondworkflowtaskcompleted
 
 import (
 	"context"
-	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -209,7 +208,7 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 		if wftCompletedBuildId != wftStartedBuildId {
 			// Mutable state wasn't changed yet and doesn't have to be cleared.
 			releaseLeaseWithError = false
-			return nil, serviceerror.NewNotFound(fmt.Sprintf("this workflow task was dispatched to Build ID %s, not %s", wftStartedBuildId, wftCompletedBuildId))
+			return nil, serviceerror.NewNotFoundf("this workflow task was dispatched to Build ID %s, not %s", wftStartedBuildId, wftCompletedBuildId)
 		}
 	}
 
@@ -332,10 +331,10 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 	if err := namespaceEntry.VerifyBinaryChecksum(request.GetBinaryChecksum()); err != nil {
 		wtFailedCause = newWorkflowTaskFailedCause(
 			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_BINARY,
-			serviceerror.NewInvalidArgument(
-				fmt.Sprintf(
-					"binary %v is marked as bad deployment",
-					request.GetBinaryChecksum())),
+			serviceerror.NewInvalidArgumentf(
+
+				"binary %v is marked as bad deployment",
+				request.GetBinaryChecksum()),
 			false)
 	} else {
 		namespace := namespaceEntry.Name()

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -311,7 +311,7 @@ func (handler *workflowTaskCompletedHandler) handleCommand(
 		// Nexus command handlers are registered in /components/nexusoperations/workflow/commands.go
 		ch, ok := handler.commandHandlerRegistry.Handler(command.GetCommandType())
 		if !ok {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Unknown command type: %v", command.GetCommandType()))
+			return nil, serviceerror.NewInvalidArgumentf("Unknown command type: %v", command.GetCommandType())
 		}
 		validator := commandValidator{sizeChecker: handler.sizeLimitChecker, commandType: command.GetCommandType()}
 		err := ch(ctx, handler.mutableState, validator, handler.workflowTaskCompletedID, command)
@@ -366,7 +366,7 @@ func (handler *workflowTaskCompletedHandler) handleMessage(
 			// Update was not found in the registry and can't be resurrected.
 			return handler.failWorkflowTask(
 				enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
-				serviceerror.NewNotFound(fmt.Sprintf("update %s wasn't found on the server. This is most likely a transient error which will be resolved automatically by retries", message.ProtocolInstanceId)))
+				serviceerror.NewNotFoundf("update %s wasn't found on the server. This is most likely a transient error which will be resolved automatically by retries", message.ProtocolInstanceId))
 		}
 
 		if err := upd.OnProtocolMessage(message, workflow.WithEffects(handler.effects, handler.mutableState)); err != nil {
@@ -376,7 +376,7 @@ func (handler *workflowTaskCompletedHandler) handleMessage(
 	default:
 		return handler.failWorkflowTask(
 			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
-			serviceerror.NewInvalidArgument(fmt.Sprintf("unsupported protocol type %s", protocolType)))
+			serviceerror.NewInvalidArgumentf("unsupported protocol type %s", protocolType))
 	}
 
 	return nil
@@ -407,7 +407,7 @@ func (handler *workflowTaskCompletedHandler) handleCommandProtocolMessage(
 	}
 	return handler.failWorkflowTask(
 		enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
-		serviceerror.NewInvalidArgument(fmt.Sprintf("ProtocolMessageCommand referenced absent message ID %s", attr.MessageId)),
+		serviceerror.NewInvalidArgumentf("ProtocolMessageCommand referenced absent message ID %s", attr.MessageId),
 	)
 }
 
@@ -1158,7 +1158,7 @@ func (handler *workflowTaskCompletedHandler) handleCommandUpsertWorkflowSearchAt
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
 	namespaceEntry, err := handler.namespaceRegistry.GetNamespaceByID(namespaceID)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to get namespace for namespaceID: %v.", namespaceID))
+		return nil, serviceerror.NewUnavailablef("Unable to get namespace for namespaceID: %v.", namespaceID)
 	}
 	namespace := namespaceEntry.Name()
 
@@ -1226,7 +1226,7 @@ func (handler *workflowTaskCompletedHandler) handleCommandModifyWorkflowProperti
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
 	_, err := handler.namespaceRegistry.GetNamespaceByID(namespaceID)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to get namespace for namespaceID: %v.", namespaceID))
+		return nil, serviceerror.NewUnavailablef("Unable to get namespace for namespaceID: %v.", namespaceID)
 	}
 
 	// valid properties

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -3,7 +3,6 @@ package startworkflow
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -496,7 +495,7 @@ func (s *Starter) resolveDuplicateWorkflowID(
 			// Exit and retry again from the top.
 			// By returning an Unavailable service error, the entire Start request will be retried.
 			// NOTE: This WorkflowIDReusePolicy cannot be RejectDuplicate as the frontend will reject that.
-			return nil, StartErr, serviceerror.NewUnavailable(fmt.Sprintf("Termination failed: %v", err))
+			return nil, StartErr, serviceerror.NewUnavailablef("Termination failed: %v", err)
 		}
 		// Fallthough to the logic for only creating the new workflow below.
 		return nil, StartNew, nil

--- a/service/history/api/updateworkflowoptions/api.go
+++ b/service/history/api/updateworkflowoptions/api.go
@@ -2,7 +2,6 @@ package updateworkflowoptions
 
 import (
 	"context"
-	"fmt"
 
 	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
@@ -97,7 +96,7 @@ func MergeAndApply(
 		updateMask,
 	)
 	if err != nil {
-		return nil, false, serviceerror.NewInvalidArgument(fmt.Sprintf("error applying update_options: %v", err))
+		return nil, false, serviceerror.NewInvalidArgumentf("error applying update_options: %v", err)
 	}
 
 	// If there is no mutable state change at all, return with no new history event and Noop=true

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -3,7 +3,6 @@ package history
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -703,7 +702,7 @@ func (h *Handler) RemoveTask(ctx context.Context, request *historyservice.Remove
 	var err error
 	category, ok := h.taskCategoryRegistry.GetCategoryByID(int(request.Category))
 	if !ok {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid task category ID: %v", request.Category))
+		return nil, serviceerror.NewInvalidArgumentf("Invalid task category ID: %v", request.Category)
 	}
 
 	key := tasks.NewKey(
@@ -711,7 +710,7 @@ func (h *Handler) RemoveTask(ctx context.Context, request *historyservice.Remove
 		request.GetTaskId(),
 	)
 	if err := tasks.ValidateKey(key); err != nil {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid task key: %v", err.Error()))
+		return nil, serviceerror.NewInvalidArgumentf("Invalid task key: %v", err.Error())
 	}
 
 	err = h.persistenceExecutionManager.CompleteHistoryTask(ctx, &persistence.CompleteHistoryTaskRequest{
@@ -2089,11 +2088,11 @@ func (h *Handler) StreamWorkflowReplicationMessages(
 		return err
 	}
 	if serverClusterShardID.ClusterID != int32(h.clusterMetadata.GetClusterID()) {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf(
+		return serviceerror.NewInvalidArgumentf(
 			"wrong cluster: target: %v, current: %v",
 			serverClusterShardID.ClusterID,
 			h.clusterMetadata.GetClusterID(),
-		))
+		)
 	}
 	shardContext, err := h.controller.GetShardByID(serverClusterShardID.ShardID)
 	if err != nil {

--- a/service/history/hsm/tree.go
+++ b/service/history/hsm/tree.go
@@ -697,7 +697,7 @@ func GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error) {
 
 	// Attributes is always a struct with a single field (e.g: HistoryEvent_NexusOperationScheduledEventAttributes)
 	if attrs.Kind() != reflect.Struct || attrs.NumField() != 1 {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("got an invalid event structure: %v", event.EventType))
+		return nil, serviceerror.NewInternalf("got an invalid event structure: %v", event.EventType)
 	}
 
 	f := attrs.Field(0).Interface()
@@ -712,7 +712,7 @@ func GenerateEventLoadToken(event *historypb.HistoryEvent) ([]byte, error) {
 	} else {
 		// By default, events aren't referenceable as they may end up buffered.
 		// This limitation may be relaxed later and the platform would need a way to fix references to buffered events.
-		return nil, serviceerror.NewInternal(fmt.Sprintf("cannot reference event: %v", event.EventType))
+		return nil, serviceerror.NewInternalf("cannot reference event: %v", event.EventType)
 	}
 	ref := &tokenspb.HistoryEventRef{
 		EventId:      event.EventId,

--- a/service/history/ndc/replication_task.go
+++ b/service/history/ndc/replication_task.go
@@ -1,7 +1,6 @@
 package ndc
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -324,7 +323,7 @@ func (t *replicationTaskImpl) skipDuplicatedEvents(index int) error {
 		return nil
 	}
 	if index >= len(t.events) || index < 0 {
-		return serviceerror.NewInternal(fmt.Sprintf("Invalid skip index: Length=%v, skipIndex=%v", len(t.events), index))
+		return serviceerror.NewInternalf("Invalid skip index: Length=%v, skipIndex=%v", len(t.events), index)
 	}
 	t.events = t.events[index:]
 	t.firstEvent = t.events[0][0]

--- a/service/history/ndc/state_rebuilder.go
+++ b/service/history/ndc/state_rebuilder.go
@@ -4,7 +4,6 @@ package ndc
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -275,11 +274,11 @@ func (r *StateRebuilderImpl) buildMutableStateFromEvent(
 			baseLastEventID,
 			*baseLastEventVersion,
 		)) {
-			return nil, 0, serviceerror.NewInvalidArgument(fmt.Sprintf(
+			return nil, 0, serviceerror.NewInvalidArgumentf(
 				"StateRebuilder unable to Rebuild mutable state to event ID: %v, version: %v, this event must be at the boundary",
 				baseLastEventID,
 				*baseLastEventVersion,
-			))
+			)
 		}
 	}
 	return rebuiltMutableState, lastTxnId, nil

--- a/service/history/ndc/transaction_manager_existing_workflow.go
+++ b/service/history/ndc/transaction_manager_existing_workflow.go
@@ -4,7 +4,6 @@ package ndc
 
 import (
 	"context"
-	"fmt"
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/namespace"
@@ -497,7 +496,7 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) executeTransaction(
 		)
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("transactionMgr: encountered unknown transaction type: %v", transactionPolicy))
+		return serviceerror.NewInternalf("transactionMgr: encountered unknown transaction type: %v", transactionPolicy)
 	}
 }
 

--- a/service/history/ndc/transaction_manager_new_workflow.go
+++ b/service/history/ndc/transaction_manager_new_workflow.go
@@ -4,7 +4,6 @@ package ndc
 
 import (
 	"context"
-	"fmt"
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/namespace"
@@ -326,7 +325,7 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) executeTransaction(
 		)
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("transactionMgr: encountered unknown transaction type: %v", transactionPolicy))
+		return serviceerror.NewInternalf("transactionMgr: encountered unknown transaction type: %v", transactionPolicy)
 	}
 }
 

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -5,7 +5,6 @@ package ndc
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -42,7 +41,7 @@ const (
 )
 
 var (
-	errWorkflowResetterMaxChildren = serviceerror.NewInvalidArgument(fmt.Sprintf("WorkflowResetter encountered max allowed children [%d] while resetting.", maxChildrenInResetMutableState))
+	errWorkflowResetterMaxChildren = serviceerror.NewInvalidArgumentf("WorkflowResetter encountered max allowed children [%d] while resetting.", maxChildrenInResetMutableState)
 )
 
 type (
@@ -504,10 +503,10 @@ func (r *workflowResetterImpl) failWorkflowTask(
 		//  meaning workflow history has NO workflow task ever
 		//  should also allow workflow reset, the only remaining issues are
 		//  * what if workflow is a cron workflow, e.g. should add a workflow task directly or still respect the cron job
-		return serviceerror.NewInvalidArgument(fmt.Sprintf(
+		return serviceerror.NewInvalidArgumentf(
 			"Can only reset workflow to event ID in range [WorkflowTaskScheduled +1, WorkflowTaskStarted + 1]: %v",
 			baseRebuildLastEventID+1,
-		))
+		)
 	}
 
 	var err error
@@ -1095,7 +1094,7 @@ func reapplyChildEvents(mutableState historyi.MutableState, event *historypb.His
 			return err
 		}
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("WorkflowResetter encountered an unexpected child event: [%s]", event.GetEventType().String()))
+		return serviceerror.NewInternalf("WorkflowResetter encountered an unexpected child event: [%s]", event.GetEventType().String())
 	}
 	return nil
 }

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -203,7 +203,7 @@ func (r *WorkflowStateReplicatorImpl) ReplicateVersionedTransition(
 	case *replicationspb.VersionedTransitionArtifact_SyncWorkflowStateMutationAttributes:
 		mutation = versionedTransition.GetSyncWorkflowStateMutationAttributes()
 	default:
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("unknown artifact type %T", artifactType))
+		return serviceerror.NewInvalidArgumentf("unknown artifact type %T", artifactType)
 	}
 
 	if versionedTransition.IsFirstSync {
@@ -337,7 +337,7 @@ func (r *WorkflowStateReplicatorImpl) handleFirstReplicationTask(
 	case *replicationspb.VersionedTransitionArtifact_SyncWorkflowStateMutationAttributes:
 		mutation = versionedTransition.GetSyncWorkflowStateMutationAttributes()
 	default:
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("unknown artifact type %T", artifactType))
+		return serviceerror.NewInvalidArgumentf("unknown artifact type %T", artifactType)
 	}
 	executionState, executionInfo := func() (*persistencespb.WorkflowExecutionState, *persistencespb.WorkflowExecutionInfo) {
 		if snapshot != nil {
@@ -506,13 +506,13 @@ func (r *WorkflowStateReplicatorImpl) prepareFirstReplicationTaskEvents(
 					return fmt.Errorf("failed to get event version %w, eventId: %v, versionHistory: %v", err, historyEvent.EventId, currentVersionHistory)
 				}
 				if historyEvent.EventId != expectedEventId || historyEvent.Version != expectedEventVersion {
-					return serviceerror.NewInvalidArgument(fmt.Sprintf("eventId %v, version %v is not expected, expected eventId %v, version %v", historyEvent.EventId, historyEvent.Version, expectedEventId, expectedEventVersion))
+					return serviceerror.NewInvalidArgumentf("eventId %v, version %v is not expected, expected eventId %v, version %v", historyEvent.EventId, historyEvent.Version, expectedEventId, expectedEventVersion)
 				}
 				expectedEventId++
 			}
 		}
 		if expectedEventId != lastVersionHistoryItem.EventId+1 {
-			return serviceerror.NewInvalidArgument(fmt.Sprintf("event not match. Expected eventId %v, but got %v", expectedEventId, lastVersionHistoryItem.EventId+1))
+			return serviceerror.NewInvalidArgumentf("event not match. Expected eventId %v, but got %v", expectedEventId, lastVersionHistoryItem.EventId+1)
 		}
 		return nil
 	}
@@ -1043,10 +1043,10 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 		}
 		version, err := versionhistory.GetVersionHistoryEventVersion(sourceVersionHistory, currentEventId)
 		if err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to get version for event id %v from history %v", currentEventId, sourceVersionHistory))
+			return serviceerror.NewInternalf("Failed to get version for event id %v from history %v", currentEventId, sourceVersionHistory)
 		}
 		if version != currentEventVersion {
-			return serviceerror.NewInternal(fmt.Sprintf("Event Version does not match. Expected %v, but got %v", version, currentEventVersion))
+			return serviceerror.NewInternalf("Event Version does not match. Expected %v, but got %v", version, currentEventVersion)
 		}
 		expectedEventID = currentEventId + 1
 		return nil
@@ -1184,7 +1184,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 		}
 	}
 	if expectedEventID != endEventID+1 {
-		return serviceerror.NewInternal(fmt.Sprintf("Event not match. Expected %v, but got %v", expectedEventID, endEventID+1))
+		return serviceerror.NewInternalf("Event not match. Expected %v, but got %v", expectedEventID, endEventID+1)
 	}
 	versionHistoryToAppend.Items = versionhistory.CopyVersionHistoryItems(sourceVersionHistory.Items)
 	localMutableState.SetHistoryBuilder(historybuilder.NewImmutableForUpdateNextEventID(sourceLastItem))
@@ -1504,11 +1504,11 @@ BackfillLoop:
 				currentAncestor = sortedAncestors[sortedAncestorsIdx]
 				branchID = currentAncestor.GetBranchId()
 				if historyBlob.nodeID < currentAncestor.GetBeginNodeId() || historyBlob.nodeID >= currentAncestor.GetEndNodeId() {
-					return serviceerror.NewInternal(
-						fmt.Sprintf("The backfill history blob node id %d is not in acestoer range [%d, %d]",
-							historyBlob.nodeID,
-							currentAncestor.GetBeginNodeId(),
-							currentAncestor.GetEndNodeId()),
+					return serviceerror.NewInternalf(
+						"The backfill history blob node id %d is not in acestoer range [%d, %d]",
+						historyBlob.nodeID,
+						currentAncestor.GetBeginNodeId(),
+						currentAncestor.GetEndNodeId(),
 					)
 				}
 			}

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -290,10 +290,10 @@ func (e *executableImpl) Execute() (retErr error) {
 	}
 
 	defer func() {
-		if panicObj := recover(); panicObj != nil {
-			err, ok := panicObj.(error)
+		if pObj := recover(); pObj != nil {
+			err, ok := pObj.(error)
 			if !ok {
-				err = serviceerror.NewInternalf("panic: %v", panicObj)
+				err = serviceerror.NewInternalf("panic: %v", pObj)
 			}
 
 			e.logger.Error("Panic is captured", tag.SysStackTrace(string(debug.Stack())), tag.Error(err))

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -293,7 +293,7 @@ func (e *executableImpl) Execute() (retErr error) {
 		if panicObj := recover(); panicObj != nil {
 			err, ok := panicObj.(error)
 			if !ok {
-				err = serviceerror.NewInternal(fmt.Sprintf("panic: %v", panicObj))
+				err = serviceerror.NewInternalf("panic: %v", panicObj)
 			}
 
 			e.logger.Error("Panic is captured", tag.SysStackTrace(string(debug.Stack())), tag.Error(err))

--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -4,7 +4,6 @@ package replication
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -239,7 +238,7 @@ func (p *ackMgrImpl) GetTask(
 			TaskID:              taskInfo.TaskId,
 		})
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown replication task type: %v", taskInfo.TaskType))
+		return nil, serviceerror.NewInternalf("Unknown replication task type: %v", taskInfo.TaskType)
 	}
 }
 

--- a/service/history/replication/eager_namespace_refresher.go
+++ b/service/history/replication/eager_namespace_refresher.go
@@ -2,7 +2,6 @@ package replication
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"go.temporal.io/api/serviceerror"
@@ -137,7 +136,7 @@ func (e *eagerNamespaceRefresherImpl) SyncNamespaceFromSourceCluster(
 		return nil, err
 	}
 	if !resp.GetIsGlobalNamespace() {
-		return nil, serviceerror.NewFailedPrecondition(fmt.Sprintf("Not a global namespace: %v", namespaceId))
+		return nil, serviceerror.NewFailedPreconditionf("Not a global namespace: %v", namespaceId)
 	}
 	hasCurrentCluster := false
 	for _, c := range resp.GetReplicationConfig().GetClusters() {

--- a/service/history/replication/eventhandler/history_events_handler.go
+++ b/service/history/replication/eventhandler/history_events_handler.go
@@ -2,7 +2,6 @@ package eventhandler
 
 import (
 	"context"
-	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
 	historypb "go.temporal.io/api/history/v1"
@@ -180,7 +179,7 @@ func (h *historyEventsHandlerImpl) handleLocalGeneratedEvent(
 		_, err = versionhistory.FindFirstVersionHistoryIndexByVersionHistoryItem(mu.GetVersionHistories(), lastVersionHistoryItem)
 		// if mutable state is found, we expect it should have at least events to the last local generated event, otherwise it is a data lose
 		if err != nil {
-			return serviceerror.NewInvalidArgument(fmt.Sprintf("Encountered data lose issue when handling local generated events, expected event: %v, version : %v", lastVersionHistoryItem.EventId, lastVersionHistoryItem.Version))
+			return serviceerror.NewInvalidArgumentf("Encountered data lose issue when handling local generated events, expected event: %v, version : %v", lastVersionHistoryItem.EventId, lastVersionHistoryItem.Version)
 		}
 		return nil
 	case *serviceerror.NotFound:

--- a/service/history/replication/eventhandler/resend_handler.go
+++ b/service/history/replication/eventhandler/resend_handler.go
@@ -5,7 +5,6 @@ package eventhandler
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
@@ -142,7 +141,7 @@ func (r *resendHandlerImpl) ResendHistoryEvents(
 
 	if startEventID != common.EmptyEventID {
 		// make sure resend is requesting from the first event when requesting local generated portion
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid Resend Request: expecting to resend from first event for local generated portion, but startEventID is %v", startEventID))
+		return serviceerror.NewInvalidArgumentf("Invalid Resend Request: expecting to resend from first event for local generated portion, but startEventID is %v", startEventID)
 	}
 	lastLocalItem := localVersionHistory[len(localVersionHistory)-1]
 	err = r.resendLocalGeneratedHistoryEvents(ctx, remoteClusterName, namespaceID, workflowID, runID, lastLocalItem.EventId, lastLocalItem.Version)

--- a/service/history/replication/executable_sync_versioned_transition_task.go
+++ b/service/history/replication/executable_sync_versioned_transition_task.go
@@ -3,7 +3,6 @@ package replication
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
@@ -168,7 +167,7 @@ func (e *ExecutableSyncVersionedTransitionTask) HandleErr(err error) error {
 		case *replicationspb.VersionedTransitionArtifact_SyncWorkflowStateMutationAttributes:
 			mutation = e.taskAttr.VersionedTransitionArtifact.GetSyncWorkflowStateMutationAttributes()
 		default:
-			return serviceerror.NewInvalidArgument(fmt.Sprintf("unknown artifact type %T", artifactType))
+			return serviceerror.NewInvalidArgumentf("unknown artifact type %T", artifactType)
 		}
 		versionHistories := func() *historyspb.VersionHistories {
 			if snapshot != nil {

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -515,15 +515,15 @@ func (e *ExecutableTaskImpl) BackFillEvents(
 			endEventVersion,
 		)
 		if !iterator.HasNext() {
-			return serviceerror.NewInternal(fmt.Sprintf("failed to get new run history when backfill"))
+			return serviceerror.NewInternalf("failed to get new run history when backfill")
 		}
 		batch, err := iterator.Next()
 		if err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("failed to get new run history when backfill: %v", err))
+			return serviceerror.NewInternalf("failed to get new run history when backfill: %v", err)
 		}
 		events, err := e.EventSerializer.DeserializeEvents(batch.RawEventBatch)
 		if err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("failed to deserailize run history events when backfill: %v", err))
+			return serviceerror.NewInternalf("failed to deserailize run history events when backfill: %v", err)
 		}
 		newRunEvents = events
 	}
@@ -542,7 +542,7 @@ func (e *ExecutableTaskImpl) BackFillEvents(
 		}
 		err := engine.BackfillHistoryEvents(ctx, backFillRequest)
 		if err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("failed to backfill: %v", err))
+			return serviceerror.NewInternalf("failed to backfill: %v", err)
 		}
 		eventsBatch = nil
 		versionHistory = nil
@@ -727,7 +727,7 @@ func (e *ExecutableTaskImpl) GetNamespaceInfo(
 	case nil:
 		if e.replicationTask.VersionedTransition != nil && e.replicationTask.VersionedTransition.NamespaceFailoverVersion > namespaceEntry.FailoverVersion() {
 			if !e.ProcessToolBox.Config.EnableReplicationEagerRefreshNamespace() {
-				return "", false, serviceerror.NewInternal(fmt.Sprintf("cannot process task because namespace failover version is not up to date, task version: %v, namespace version: %v", e.replicationTask.VersionedTransition.NamespaceFailoverVersion, namespaceEntry.FailoverVersion()))
+				return "", false, serviceerror.NewInternalf("cannot process task because namespace failover version is not up to date, task version: %v, namespace version: %v", e.replicationTask.VersionedTransition.NamespaceFailoverVersion, namespaceEntry.FailoverVersion())
 			}
 			_, err = e.ProcessToolBox.EagerNamespaceRefresher.SyncNamespaceFromSourceCluster(ctx, namespace.ID(namespaceID), e.sourceClusterName)
 			if err != nil {
@@ -752,7 +752,7 @@ func (e *ExecutableTaskImpl) GetNamespaceInfo(
 	}
 	// need to make sure ns in cache is up-to-date
 	if e.replicationTask.VersionedTransition != nil && namespaceEntry.FailoverVersion() < e.replicationTask.VersionedTransition.NamespaceFailoverVersion {
-		return "", false, serviceerror.NewInternal(fmt.Sprintf("cannot process task because namespace failover version is not up to date after sync, task version: %v, namespace version: %v", e.replicationTask.VersionedTransition.NamespaceFailoverVersion, namespaceEntry.FailoverVersion()))
+		return "", false, serviceerror.NewInternalf("cannot process task because namespace failover version is not up to date after sync, task version: %v, namespace version: %v", e.replicationTask.VersionedTransition.NamespaceFailoverVersion, namespaceEntry.FailoverVersion())
 	}
 
 	e.namespace.Store(namespaceEntry.Name())

--- a/service/history/replication/executable_verify_versioned_transition_task.go
+++ b/service/history/replication/executable_verify_versioned_transition_task.go
@@ -3,7 +3,6 @@ package replication
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -126,8 +125,8 @@ func (e *ExecutableVerifyVersionedTransitionTask) Execute() error {
 	// case 1: VersionedTransition is up-to-date on current mutable state
 	if err == nil {
 		if ms.GetNextEventId() < e.taskAttr.NextEventId {
-			return serviceerror.NewDataLoss(fmt.Sprintf("Workflow event missed. NamespaceId: %v, workflowId: %v, runId: %v, expected last eventId: %v, versionedTransition: %v",
-				e.NamespaceID, e.WorkflowID, e.RunID, e.taskAttr.NextEventId-1, e.ReplicationTask().VersionedTransition))
+			return serviceerror.NewDataLossf("Workflow event missed. NamespaceId: %v, workflowId: %v, runId: %v, expected last eventId: %v, versionedTransition: %v",
+				e.NamespaceID, e.WorkflowID, e.RunID, e.taskAttr.NextEventId-1, e.ReplicationTask().VersionedTransition)
 		}
 		return e.verifyNewRunExist(ctx)
 	}
@@ -195,8 +194,8 @@ func (e *ExecutableVerifyVersionedTransitionTask) verifyNewRunExist(ctx context.
 	case nil:
 		return nil
 	case *serviceerror.NotFound:
-		return serviceerror.NewDataLoss(fmt.Sprintf("workflow new run not found. NamespaceId: %v, workflowId: %v, runId: %v, newRunId: %v",
-			e.NamespaceID, e.WorkflowID, e.RunID, e.taskAttr.NewRunId))
+		return serviceerror.NewDataLossf("workflow new run not found. NamespaceId: %v, workflowId: %v, runId: %v, newRunId: %v",
+			e.NamespaceID, e.WorkflowID, e.RunID, e.taskAttr.NewRunId)
 	default:
 		return err
 	}

--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -3,7 +3,6 @@ package replication
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
@@ -44,7 +43,7 @@ func ClusterIDToClusterNameShardCount(
 			return clusterName, clusterInfo.ShardCount, nil
 		}
 	}
-	return "", 0, serviceerror.NewInternal(fmt.Sprintf("unknown cluster ID: %v", clusterID))
+	return "", 0, serviceerror.NewInternalf("unknown cluster ID: %v", clusterID)
 }
 
 func WrapEventLoop(

--- a/service/history/replication/stream_receiver.go
+++ b/service/history/replication/stream_receiver.go
@@ -348,7 +348,7 @@ func (r *StreamReceiverImpl) getTrackerAndSchedulerByPriority(priority enumsspb.
 	case enumsspb.TASK_PRIORITY_LOW:
 		return r.lowPriorityTaskTracker, r.ProcessToolBox.LowPriorityTaskScheduler, nil
 	default:
-		return nil, nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Unknown task priority: %v", priority))
+		return nil, nil, serviceerror.NewInvalidArgumentf("Unknown task priority: %v", priority)
 	}
 }
 
@@ -391,7 +391,7 @@ func ValidateTasksHaveSamePriority(messageBatchPriority enumsspb.TaskPriority, t
 	}
 	for _, task := range tasks {
 		if task.Priority != messageBatchPriority {
-			return serviceerror.NewInvalidArgument(fmt.Sprintf("Task priority does not match batch priority: %v, %v", task.Priority, messageBatchPriority))
+			return serviceerror.NewInvalidArgumentf("Task priority does not match batch priority: %v, %v", task.Priority, messageBatchPriority)
 		}
 	}
 	return nil

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -427,10 +427,10 @@ func (s *StreamSenderImpl) sendTasks(
 	endExclusiveWatermark int64,
 ) error {
 	if beginInclusiveWatermark > endExclusiveWatermark {
-		err := serviceerror.NewInternal(fmt.Sprintf("StreamWorkflowReplication encountered invalid task range [%v, %v)",
+		err := serviceerror.NewInternalf("StreamWorkflowReplication encountered invalid task range [%v, %v)",
 			beginInclusiveWatermark,
 			endExclusiveWatermark,
-		))
+		)
 		return err
 	}
 	if beginInclusiveWatermark == endExclusiveWatermark {

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -428,7 +428,7 @@ func (s *ContextImpl) UpdateRemoteReaderInfo(
 	clusterName, _, ok := clusterNameInfoFromClusterID(s.clusterMetadata.GetAllClusterInfo(), clusterID)
 	if !ok {
 		// cluster is not present in cluster metadata map
-		return serviceerror.NewInternal(fmt.Sprintf("unknown cluster ID: %v", clusterID))
+		return serviceerror.NewInternalf("unknown cluster ID: %v", clusterID)
 	}
 
 	s.wLock()

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -1782,7 +1782,7 @@ func (t *transferQueueActiveTaskExecutor) applyParentClosePolicy(
 		return err
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown parent close policy: %v", childInfo.ParentClosePolicy))
+		return serviceerror.NewInternalf("unknown parent close policy: %v", childInfo.ParentClosePolicy)
 	}
 }
 

--- a/service/history/vclock/vclock.go
+++ b/service/history/vclock/vclock.go
@@ -1,8 +1,6 @@
 package vclock
 
 import (
-	"fmt"
-
 	"go.temporal.io/api/serviceerror"
 	clockspb "go.temporal.io/server/api/clock/v1"
 )
@@ -35,13 +33,13 @@ func Compare(
 	clock2 *clockspb.VectorClock,
 ) (int, error) {
 	if !Comparable(clock1, clock2) {
-		return 0, serviceerror.NewInternal(fmt.Sprintf(
+		return 0, serviceerror.NewInternalf(
 			"Encountered shard ID mismatch: %v:%v vs %v:%v",
 			clock1.GetClusterId(),
 			clock1.GetShardId(),
 			clock2.GetClusterId(),
 			clock2.GetShardId(),
-		))
+		)
 	}
 
 	vClock1 := clock1.GetClock()

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel/trace"
 	commonpb "go.temporal.io/api/common/v1"
@@ -678,7 +677,7 @@ func (c *ContextImpl) mergeUpdateWithNewReplicationTasks(
 		newRunID = task.RunID
 	default:
 		// Handle unexpected types or log an error if this case is not expected
-		return serviceerror.NewInternal(fmt.Sprintf("unexpected replication task type for new run task %T", newRunTask))
+		return serviceerror.NewInternalf("unexpected replication task type for new run task %T", newRunTask)
 	}
 	taskUpdated := false
 
@@ -863,7 +862,7 @@ func (c *ContextImpl) ReapplyEvents(
 	}
 	if sourceAdminClient == nil {
 		// TODO: will this ever happen?
-		return serviceerror.NewInternal(fmt.Sprintf("cannot find cluster config %v to do reapply", activeCluster))
+		return serviceerror.NewInternalf("cannot find cluster config %v to do reapply", activeCluster)
 	}
 
 	_, err = sourceAdminClient.ReapplyEvents(

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -6,7 +6,6 @@ package workflow
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pborman/uuid"
 	commonpb "go.temporal.io/api/common/v1"
@@ -613,11 +612,11 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			if newRunID == "" {
 				newRunID = continuedAsNewRunID
 			} else if newRunID != continuedAsNewRunID {
-				return nil, serviceerror.NewInternal(fmt.Sprintf(
+				return nil, serviceerror.NewInternalf(
 					"ApplyEvents encounted newRunID mismatch for continuedAsNew event, task newRunID: %v, event newRunID: %v",
 					newRunID,
 					continuedAsNewRunID,
-				))
+				)
 			}
 
 			if err := b.mutableState.ApplyWorkflowExecutionContinuedAsNewEvent(
@@ -659,7 +658,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 		default:
 			def, ok := b.shard.StateMachineRegistry().EventDefinition(event.GetEventType())
 			if !ok {
-				return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Unknown event type: %v", event.GetEventType()))
+				return nil, serviceerror.NewInvalidArgumentf("Unknown event type: %v", event.GetEventType())
 			}
 			if err := def.Apply(b.mutableState.HSM(), event); err != nil {
 				return nil, err

--- a/service/history/workflow/mutable_state_state_status.go
+++ b/service/history/workflow/mutable_state_state_status.go
@@ -1,8 +1,6 @@
 package workflow
 
 import (
-	"fmt"
-
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -48,7 +46,7 @@ func setStateStatus(
 			}
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", state))
+			return serviceerror.NewInternalf("unknown workflow state: %v", state)
 		}
 	case enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING:
 		switch state {
@@ -71,7 +69,7 @@ func setStateStatus(
 			}
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", state))
+			return serviceerror.NewInternalf("unknown workflow state: %v", state)
 		}
 	case enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED:
 		switch state {
@@ -90,7 +88,7 @@ func setStateStatus(
 			return invalidStateTransitionErr(e.GetState(), state, status)
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", state))
+			return serviceerror.NewInternalf("unknown workflow state: %v", state)
 		}
 	case enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE:
 		switch state {
@@ -115,10 +113,10 @@ func setStateStatus(
 			}
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", state))
+			return serviceerror.NewInternalf("unknown workflow state: %v", state)
 		}
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", state))
+		return serviceerror.NewInternalf("unknown workflow state: %v", state)
 	}
 
 	e.State = state
@@ -131,10 +129,10 @@ func invalidStateTransitionErr(
 	targetState enumsspb.WorkflowExecutionState,
 	targetStatus enumspb.WorkflowExecutionStatus,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewInternalf(
 		invalidStateTransitionMsg,
 		currentState,
 		targetState,
 		targetStatus,
-	))
+	)
 }

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -403,10 +403,10 @@ func (r *TaskGeneratorImpl) GenerateScheduleWorkflowTaskTasks(
 		workflowTaskScheduledEventID,
 	)
 	if workflowTask == nil {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending workflow task: %v", workflowTaskScheduledEventID))
+		return serviceerror.NewInternalf("it could be a bug, cannot get pending workflow task: %v", workflowTaskScheduledEventID)
 	}
 	if workflowTask.Type == enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, GenerateScheduleSpeculativeWorkflowTaskTasks must be called for speculative workflow task: %v", workflowTaskScheduledEventID))
+		return serviceerror.NewInternalf("it could be a bug, GenerateScheduleSpeculativeWorkflowTaskTasks must be called for speculative workflow task: %v", workflowTaskScheduledEventID)
 	}
 
 	if r.mutableState.IsStickyTaskQueueSet() {
@@ -495,7 +495,7 @@ func (r *TaskGeneratorImpl) GenerateStartWorkflowTaskTasks(
 		workflowTaskScheduledEventID,
 	)
 	if workflowTask == nil {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending workflow task: %v", workflowTaskScheduledEventID))
+		return serviceerror.NewInternalf("it could be a bug, cannot get pending workflow task: %v", workflowTaskScheduledEventID)
 	}
 
 	isSpeculative := workflowTask.Type == enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE
@@ -524,7 +524,7 @@ func (r *TaskGeneratorImpl) GenerateActivityTasks(
 ) error {
 	activityInfo, ok := r.mutableState.GetActivityInfo(activityScheduledEventID)
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending activity: %v", activityScheduledEventID))
+		return serviceerror.NewInternalf("it could be a bug, cannot get pending activity: %v", activityScheduledEventID)
 	}
 
 	r.mutableState.AddTasks(&tasks.ActivityTask{
@@ -560,7 +560,7 @@ func (r *TaskGeneratorImpl) GenerateChildWorkflowTasks(
 
 	childWorkflowInfo, ok := r.mutableState.GetChildExecutionInfo(childWorkflowScheduledEventID)
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending child workflow: %v", childWorkflowScheduledEventID))
+		return serviceerror.NewInternalf("it could be a bug, cannot get pending child workflow: %v", childWorkflowScheduledEventID)
 	}
 
 	targetNamespaceID, err := r.getTargetNamespaceID(namespace.Name(attr.GetNamespace()), namespace.ID(attr.GetNamespaceId()))
@@ -593,7 +593,7 @@ func (r *TaskGeneratorImpl) GenerateRequestCancelExternalTasks(
 
 	_, ok := r.mutableState.GetRequestCancelInfo(scheduledEventID)
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending request cancel external workflow: %v", scheduledEventID))
+		return serviceerror.NewInternalf("it could be a bug, cannot get pending request cancel external workflow: %v", scheduledEventID)
 	}
 
 	targetNamespaceID, err := r.getTargetNamespaceID(namespace.Name(attr.GetNamespace()), namespace.ID(attr.GetNamespaceId()))
@@ -628,7 +628,7 @@ func (r *TaskGeneratorImpl) GenerateSignalExternalTasks(
 
 	_, ok := r.mutableState.GetSignalInfo(scheduledEventID)
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending signal external workflow: %v", scheduledEventID))
+		return serviceerror.NewInternalf("it could be a bug, cannot get pending signal external workflow: %v", scheduledEventID)
 	}
 
 	targetNamespaceID, err := r.getTargetNamespaceID(namespace.Name(attr.GetNamespace()), namespace.ID(attr.GetNamespaceId()))
@@ -843,7 +843,7 @@ func generateSubStateMachineTask(
 ) error {
 	ser, ok := stateMachineRegistry.TaskSerializer(task.Type())
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("no task serializer for %v", task.Type()))
+		return serviceerror.NewInternalf("no task serializer for %v", task.Type())
 	}
 	data, err := ser.Serialize(task)
 	if err != nil {

--- a/service/history/workflow/test_util.go
+++ b/service/history/workflow/test_util.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -63,7 +62,7 @@ func NewMapEventCache(
 				if event, ok := m[key]; ok {
 					return event, nil
 				}
-				return nil, serviceerror.NewNotFound(fmt.Sprintf("event %#v not found", key))
+				return nil, serviceerror.NewNotFoundf("event %#v not found", key)
 			},
 		)
 	return cache

--- a/service/history/workflow/timer_sequence.go
+++ b/service/history/workflow/timer_sequence.go
@@ -3,7 +3,6 @@
 package workflow
 
 import (
-	"fmt"
 	"sort"
 	"time"
 
@@ -89,7 +88,7 @@ func (t *timerSequenceImpl) CreateNextUserTimer() (bool, error) {
 
 	timerInfo, ok := t.mutableState.GetUserTimerInfoByEventID(firstTimerTask.EventID)
 	if !ok {
-		return false, serviceerror.NewInternal(fmt.Sprintf("unable to load timer info %v", firstTimerTask.EventID))
+		return false, serviceerror.NewInternalf("unable to load timer info %v", firstTimerTask.EventID)
 	}
 	// mark timer task mask as indication that timer task is generated
 	// here TaskID is misleading attr, should be called timer created flag or something
@@ -128,7 +127,7 @@ func (t *timerSequenceImpl) CreateNextActivityTimer() (bool, error) {
 
 	activityInfo, ok := t.mutableState.GetActivityInfo(firstTimerTask.EventID)
 	if !ok {
-		return false, serviceerror.NewInternal(fmt.Sprintf("unable to load activity info %v", firstTimerTask.EventID))
+		return false, serviceerror.NewInternalf("unable to load activity info %v", firstTimerTask.EventID)
 	}
 	// mark timer task mask as indication that timer task is generated
 	activityInfo.TimerTaskStatus |= timerTypeToTimerMask(firstTimerTask.TimerType)

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -241,7 +241,7 @@ func (r *registry) TryResurrect(_ context.Context, acptOrRejMsg *protocolpb.Mess
 
 	body, err := acptOrRejMsg.Body.UnmarshalNew()
 	if err != nil {
-		return nil, invalidArgf("unable to unmarshal request: %v", err)
+		return nil, serviceerror.NewInvalidArgumentf("unable to unmarshal request: %v", err)
 	}
 
 	var reqMsg *updatepb.Request
@@ -258,7 +258,7 @@ func (r *registry) TryResurrect(_ context.Context, acptOrRejMsg *protocolpb.Mess
 	}
 	reqAny, err := anypb.New(reqMsg)
 	if err != nil {
-		return nil, invalidArgf("unable to marshal request: %v", err)
+		return nil, serviceerror.NewInvalidArgumentf("unable to marshal request: %v", err)
 	}
 
 	updateID := acptOrRejMsg.ProtocolInstanceId

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -331,7 +331,7 @@ func (u *Update) Admit(
 	// Marshal Update request here to return InvalidArgument to the API caller if it can't be marshaled.
 	reqAny, err := anypb.New(req)
 	if err != nil {
-		return invalidArgf("unable to unmarshal request: %v", err)
+		return serviceerror.NewInvalidArgumentf("unable to unmarshal request: %v", err)
 	}
 	u.request = reqAny
 
@@ -369,16 +369,16 @@ func (u *Update) OnProtocolMessage(
 	eventStore EventStore,
 ) error {
 	if protocolMsg == nil {
-		return invalidArgf("Update %s received nil message", u.id)
+		return serviceerror.NewInvalidArgumentf("Update %s received nil message", u.id)
 	}
 
 	if protocolMsg.Body == nil {
-		return invalidArgf("Update %s received message with nil body", u.id)
+		return serviceerror.NewInvalidArgumentf("Update %s received message with nil body", u.id)
 	}
 
 	body, err := protocolMsg.Body.UnmarshalNew()
 	if err != nil {
-		return invalidArgf("unable to unmarshal request: %v", err)
+		return serviceerror.NewInvalidArgumentf("unable to unmarshal request: %v", err)
 	}
 
 	// If no new events can be added to the event store (e.g., workflow is completed),
@@ -399,7 +399,7 @@ func (u *Update) OnProtocolMessage(
 	case *updatepb.Response:
 		return u.onResponseMsg(updMsg, eventStore)
 	default:
-		return invalidArgf("Message type %T not supported", body)
+		return serviceerror.NewInvalidArgumentf("Message type %T not supported", body)
 	}
 }
 
@@ -493,7 +493,7 @@ func (u *Update) onAcceptanceMsg(
 	if u.request != nil {
 		acceptedRequest = &updatepb.Request{}
 		if err := u.request.UnmarshalTo(acceptedRequest); err != nil {
-			return internalErrorf("unable to unmarshal original request: %v", err)
+			return serviceerror.NewInternalf("unable to unmarshal original request: %v", err)
 		}
 	}
 
@@ -654,7 +654,7 @@ func (u *Update) checkStateSet(msg proto.Message, allowed stateSet) error {
 		return nil
 	}
 	u.instrumentation.invalidStateTransition(u.id, msg, u.state)
-	return invalidArgf("invalid state transition attempted for Update %s: "+
+	return serviceerror.NewInvalidArgumentf("invalid state transition attempted for Update %s: "+
 		"received %T message while in state %s", u.id, msg, u.state)
 }
 

--- a/service/history/workflow/update/util.go
+++ b/service/history/workflow/update/util.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/otel/trace"
-	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -27,14 +26,6 @@ var (
 		tracer:  telemetry.NoopTracer,
 	}
 )
-
-func invalidArgf(tmpl string, args ...any) error {
-	return serviceerror.NewInvalidArgument(fmt.Sprintf(tmpl, args...))
-}
-
-func internalErrorf(tmpl string, args ...any) error {
-	return serviceerror.NewInternal(fmt.Sprintf(tmpl, args...))
-}
 
 func (i *instrumentation) countRequestMsg() {
 	i.oneOf(metrics.MessageTypeRequestWorkflowExecutionUpdateCounter.Name())

--- a/service/history/workflow/update/validation.go
+++ b/service/history/workflow/update/validation.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
 	"google.golang.org/protobuf/proto"
 )
@@ -9,7 +10,7 @@ func notZero[T comparable](v T, label string, msg proto.Message) func() error {
 	return func() error {
 		var zero T
 		if v == zero {
-			return invalidArgf("invalid %T: %v is not set", msg, label)
+			return serviceerror.NewInvalidArgumentf("invalid %T: %v is not set", msg, label)
 		}
 		return nil
 	}
@@ -24,7 +25,7 @@ func eq[T comparable](
 ) func() error {
 	return func() error {
 		if left != right {
-			return invalidArgf("invalid %T: %v != %v", msg, leftLbl, rightLbl)
+			return serviceerror.NewInvalidArgumentf("invalid %T: %v != %v", msg, leftLbl, rightLbl)
 		}
 		return nil
 	}

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -4,7 +4,6 @@ package workflow
 
 import (
 	"cmp"
-	"fmt"
 	"math"
 	"time"
 
@@ -173,7 +172,7 @@ func (m *workflowTaskStateMachine) ApplyWorkflowTaskStartedEvent(
 	if workflowTask == nil {
 		workflowTask = m.GetWorkflowTaskByID(scheduledEventID)
 		if workflowTask == nil {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("unable to find workflow task: %v", scheduledEventID))
+			return nil, serviceerror.NewInternalf("unable to find workflow task: %v", scheduledEventID)
 		}
 		// Transient workflow task events are not applied but attempt count in mutable state
 		// can be updated from previous workflow task failed/timeout event.
@@ -1297,7 +1296,7 @@ func (m *workflowTaskStateMachine) convertSpeculativeWorkflowTaskToNormal() erro
 	)
 
 	if scheduledEvent.EventId != wt.ScheduledEventID {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, scheduled event Id: %d for normal workflow task doesn't match the one from speculative workflow task: %d", scheduledEvent.EventId, wt.ScheduledEventID))
+		return serviceerror.NewInternalf("it could be a bug, scheduled event Id: %d for normal workflow task doesn't match the one from speculative workflow task: %d", scheduledEvent.EventId, wt.ScheduledEventID)
 	}
 
 	if wtAlreadyStarted := wt.StartedEventID != common.EmptyEventID; wtAlreadyStarted {

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -1379,8 +1379,8 @@ func (e *matchingEngineImpl) UpdateWorkerVersioningRules(
 			return nil, false, err
 		}
 		if !bytes.Equal(cT, prevCT) {
-			return nil, false, serviceerror.NewFailedPrecondition(
-				fmt.Sprintf("provided conflict token '%v' does not match existing one '%v'", cT, prevCT),
+			return nil, false, serviceerror.NewFailedPreconditionf(
+				"provided conflict token '%v' does not match existing one '%v'", cT, prevCT,
 			)
 		}
 
@@ -1606,7 +1606,7 @@ func (e *matchingEngineImpl) UpdateWorkerBuildIdCompatibility(
 				req.GetPersistUnknownBuildId(),
 			)
 		default:
-			return nil, false, serviceerror.NewInvalidArgument(fmt.Sprintf("invalid operation: %v", req.GetOperation()))
+			return nil, false, serviceerror.NewInvalidArgumentf("invalid operation: %v", req.GetOperation())
 		}
 		// Avoid mutation
 		ret := common.CloneProto(data)
@@ -2203,7 +2203,7 @@ func (e *matchingEngineImpl) ListNexusEndpoints(ctx context.Context, request *ma
 	isOwner, ownershipLostCh, err := e.checkNexusEndpointsOwnership()
 	if err != nil {
 		e.logger.Error("Failed to check Nexus endpoints ownership", tag.Error(err))
-		return nil, serviceerror.NewFailedPrecondition(fmt.Sprintf("cannot verify ownership of Nexus endpoints table: %v", err))
+		return nil, serviceerror.NewFailedPreconditionf("cannot verify ownership of Nexus endpoints table: %v", err)
 	}
 	if !isOwner {
 		e.logger.Error("Matching node doesn't think it's the Nexus endpoints table owner", tag.Error(err))

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3656,7 +3656,7 @@ func (m *testTaskManager) CreateTasks(
 	}
 
 	if m.dbServiceError {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("CreateTasks operation failed during serialization. Error : %v", errors.New("failure")))
+		return nil, serviceerror.NewUnavailablef("CreateTasks operation failed during serialization. Error : %v", errors.New("failure"))
 	}
 
 	tlm := m.getQueueManager(taskQueue, namespaceId, taskType)
@@ -3706,7 +3706,7 @@ func (m *testTaskManager) GetTasks(
 	m.logger.Debug("testTaskManager.GetTasks", tag.MinLevel(request.InclusiveMinTaskID), tag.MaxLevel(request.ExclusiveMaxTaskID))
 
 	if m.generateErrorRandomly() {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTasks operation failed"))
+		return nil, serviceerror.NewUnavailablef("GetTasks operation failed")
 	}
 
 	tlm := m.getQueueManager(request.TaskQueue, request.NamespaceID, request.TaskType)

--- a/service/matching/nexus_endpoint_client.go
+++ b/service/matching/nexus_endpoint_client.go
@@ -97,7 +97,7 @@ func (m *nexusEndpointClient) CreateNexusEndpoint(
 	defer m.Unlock()
 
 	if _, exists := m.endpointsByName[request.spec.GetName()]; exists {
-		return nil, serviceerror.NewAlreadyExist(fmt.Sprintf("error creating Nexus endpoint. Endpoint with name %v already registered", request.spec.GetName()))
+		return nil, serviceerror.NewAlreadyExistsf("error creating Nexus endpoint. Endpoint with name %v already registered", request.spec.GetName())
 	}
 
 	entry := &persistencespb.NexusEndpointEntry{
@@ -149,11 +149,11 @@ func (m *nexusEndpointClient) UpdateNexusEndpoint(
 
 	previous, exists := m.endpointsByID[request.endpointID]
 	if !exists {
-		return nil, serviceerror.NewNotFound(fmt.Sprintf("error updating Nexus endpoint. endpoint ID %v not found", request.endpointID))
+		return nil, serviceerror.NewNotFoundf("error updating Nexus endpoint. endpoint ID %v not found", request.endpointID)
 	}
 
 	if request.version != previous.Version {
-		return nil, serviceerror.NewFailedPrecondition(fmt.Sprintf("nexus endpoint version mismatch. received: %v expected %v", request.version, previous.Version))
+		return nil, serviceerror.NewFailedPreconditionf("nexus endpoint version mismatch. received: %v expected %v", request.version, previous.Version)
 	}
 
 	entry := &persistencespb.NexusEndpointEntry{
@@ -215,7 +215,7 @@ func (m *nexusEndpointClient) DeleteNexusEndpoint(
 
 	entry, ok := m.endpointsByID[request.Id]
 	if !ok {
-		return nil, serviceerror.NewNotFound(fmt.Sprintf("error deleting nexus endpoint with ID: %v", request.Id))
+		return nil, serviceerror.NewNotFoundf("error deleting nexus endpoint with ID: %v", request.Id)
 	}
 
 	err := m.persistence.DeleteNexusEndpoint(ctx, &p.DeleteNexusEndpointRequest{
@@ -260,7 +260,7 @@ func (m *nexusEndpointClient) ListNexusEndpoints(
 	defer m.RUnlock()
 
 	if request.LastKnownTableVersion != 0 && request.LastKnownTableVersion != m.tableVersion {
-		return nil, nil, serviceerror.NewFailedPrecondition(fmt.Sprintf("nexus endpoints table version mismatch. received: %v expected %v", request.LastKnownTableVersion, m.tableVersion))
+		return nil, nil, serviceerror.NewFailedPreconditionf("nexus endpoints table version mismatch. received: %v expected %v", request.LastKnownTableVersion, m.tableVersion)
 	}
 
 	startIdx := 0

--- a/service/matching/user_data_manager.go
+++ b/service/matching/user_data_manager.go
@@ -3,7 +3,6 @@ package matching
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -486,7 +485,7 @@ func (m *userDataManagerImpl) updateUserData(
 		preUpdateData = &persistencespb.TaskQueueUserData{}
 	}
 	if options.KnownVersion > 0 && preUpdateVersion != options.KnownVersion {
-		return nil, false, serviceerror.NewFailedPrecondition(fmt.Sprintf("user data version mismatch: requested: %d, current: %d", options.KnownVersion, preUpdateVersion))
+		return nil, false, serviceerror.NewFailedPreconditionf("user data version mismatch: requested: %d, current: %d", options.KnownVersion, preUpdateVersion)
 	}
 	updatedUserData, shouldReplicate, err := updateFn(preUpdateData)
 	if err == errUserDataUnmodified {
@@ -510,7 +509,7 @@ func (m *userDataManagerImpl) updateUserData(
 				return nil, false, err
 			}
 			if numTaskQueues >= options.TaskQueueLimitPerBuildId {
-				return nil, false, serviceerror.NewFailedPrecondition(fmt.Sprintf("Exceeded max task queues allowed to be mapped to a single build ID: %d", options.TaskQueueLimitPerBuildId))
+				return nil, false, serviceerror.NewFailedPreconditionf("Exceeded max task queues allowed to be mapped to a single build ID: %d", options.TaskQueueLimitPerBuildId)
 			}
 		}
 	}

--- a/service/matching/version_rule_helpers.go
+++ b/service/matching/version_rule_helpers.go
@@ -1,7 +1,6 @@
 package matching
 
 import (
-	"fmt"
 	"math"
 	"math/rand"
 	"slices"
@@ -29,20 +28,20 @@ var (
 	errSourceIsVersionSetMember                          = serviceerror.NewFailedPrecondition("update breaks requirement, source build ID is already a member of a version set")
 	errPartiallyRampedAssignmentRuleIsRedirectRuleSource = serviceerror.NewFailedPrecondition("update breaks requirement, this build ID cannot be the target of a partially-ramped assignment rule because it is the source of a redirect rule")
 	errAssignmentRuleIndexOutOfBounds                    = func(idx, length int) error {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("rule index %d is out of bounds for assignment rule list of length %d", idx, length))
+		return serviceerror.NewInvalidArgumentf("rule index %d is out of bounds for assignment rule list of length %d", idx, length)
 	}
 	errSourceIsPartiallyRampedAssignmentRuleTarget = serviceerror.NewFailedPrecondition("redirect rule source build ID cannot be the target of any partially-ramped assignment rule")
 	errSourceAlreadyExists                         = func(source, target string) error {
-		return serviceerror.NewAlreadyExist(fmt.Sprintf("source %s already redirects to target %s", source, target))
+		return serviceerror.NewAlreadyExistsf("source %s already redirects to target %s", source, target)
 	}
 	errSourceNotFound = func(source string) error {
-		return serviceerror.NewNotFound(fmt.Sprintf("no redirect rule found with source ID %s", source))
+		return serviceerror.NewNotFoundf("no redirect rule found with source ID %s", source)
 	}
 	errNoRecentPollerOnCommitVersion = func(target string) error {
-		return serviceerror.NewFailedPrecondition(fmt.Sprintf("no versioned poller with build ID '%s' seen within the last %s, use force=true to commit anyways", target, versioningPollerSeenWindow.String()))
+		return serviceerror.NewFailedPreconditionf("no versioned poller with build ID '%s' seen within the last %s, use force=true to commit anyways", target, versioningPollerSeenWindow.String())
 	}
 	errExceedsMaxAssignmentRules = func(cnt, max int) error {
-		return serviceerror.NewFailedPrecondition(fmt.Sprintf("update exceeds number of assignment rules permitted in namespace (%v/%v)", cnt, max))
+		return serviceerror.NewFailedPreconditionf("update exceeds number of assignment rules permitted in namespace (%v/%v)", cnt, max)
 	}
 	// errRequireFullyRampedAssignmentRule is thrown if the task queue previously had a fully-ramped assignment rule and
 	// the requested operation would result in a list of assignment rules without a fully-ramped assigment rule, which
@@ -54,11 +53,11 @@ var (
 	// a versioned default Build ID to an unversioned default Build ID, use force=true to bypass this requirement.
 	errRequireFullyRampedAssignmentRule = serviceerror.NewFailedPrecondition("at least one fully-ramped assignment rule must exist (use force=true to bypass this requirement and set the unversioned queue as the default)")
 	errExceedsMaxRedirectRules          = func(cnt, max int) error {
-		return serviceerror.NewFailedPrecondition(fmt.Sprintf("update exceeds number of redirect rules permitted in namespace (%v/%v)", cnt, max))
+		return serviceerror.NewFailedPreconditionf("update exceeds number of redirect rules permitted in namespace (%v/%v)", cnt, max)
 	}
 	errIsCyclic                   = serviceerror.NewFailedPrecondition("update would break acyclic requirement")
 	errExceedsMaxUpstreamBuildIDs = func(cnt, max int) error {
-		return serviceerror.NewFailedPrecondition(fmt.Sprintf("update exceeds number of upstream build ids permitted in namespace (%v/%v)", cnt, max))
+		return serviceerror.NewFailedPreconditionf("update exceeds number of upstream build ids permitted in namespace (%v/%v)", cnt, max)
 	}
 	errUnversionedRedirectRuleTarget = serviceerror.NewInvalidArgument("the unversioned build ID cannot be the target of a redirect rule")
 )

--- a/service/worker/deployment/deployment_client.go
+++ b/service/worker/deployment/deployment_client.go
@@ -3,7 +3,6 @@ package deployment
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -388,8 +387,8 @@ func (d *DeploymentClientImpl) SetCurrentDeployment(
 	}
 
 	if failure := outcome.GetFailure(); failure.GetApplicationFailureInfo().GetType() == errNoChangeType {
-		return nil, nil, serviceerror.NewAlreadyExist(fmt.Sprintf("Build ID %q is already current for %q",
-			deployment.BuildId, deployment.SeriesName))
+		return nil, nil, serviceerror.NewAlreadyExistsf("Build ID %q is already current for %q",
+			deployment.BuildId, deployment.SeriesName)
 	} else if failure != nil {
 		// TODO: is there an easy way to recover the original type here?
 		return nil, nil, serviceerror.NewInternal(failure.Message)

--- a/service/worker/deployment/deployment_util.go
+++ b/service/worker/deployment/deployment_util.go
@@ -68,12 +68,12 @@ var (
 func ValidateDeploymentWfParams(fieldName string, field string, maxIDLengthLimit int) error {
 	// Length checks
 	if field == "" {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("%v cannot be empty", fieldName))
+		return serviceerror.NewInvalidArgumentf("%v cannot be empty", fieldName)
 	}
 
 	// Length of each field should be: (MaxIDLengthLimit - prefix and delimeter length) / 2
 	if len(field) > (maxIDLengthLimit-DeploymentWorkflowIDInitialSize)/2 {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("size of %v larger than the maximum allowed", fieldName))
+		return serviceerror.NewInvalidArgumentf("size of %v larger than the maximum allowed", fieldName)
 	}
 
 	return nil

--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -249,7 +249,7 @@ func (d *ClientImpl) DescribeVersion(
 ) (_ *deploymentpb.WorkerDeploymentVersionInfo, retErr error) {
 	v, err := worker_versioning.WorkerDeploymentVersionFromString(version)
 	if err != nil {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("invalid version string %q, expected format is \"<deployment_name>.<build_id>\"", version))
+		return nil, serviceerror.NewInvalidArgumentf("invalid version string %q, expected format is \"<deployment_name>.<build_id>\"", version)
 	}
 	deploymentName := v.GetDeploymentName()
 	buildID := v.GetBuildId()
@@ -474,7 +474,7 @@ func (d *ClientImpl) SetCurrentVersion(
 		return nil, serviceerror.NewInvalidArgument("invalid version string: " + err.Error())
 	}
 	if versionObj.GetDeploymentName() != "" && versionObj.GetDeploymentName() != deploymentName {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("invalid version string '%s' does not match deployment name '%s'", version, deploymentName))
+		return nil, serviceerror.NewInvalidArgumentf("invalid version string '%s' does not match deployment name '%s'", version, deploymentName)
 	}
 
 	err = validateVersionWfParams(WorkerDeploymentNameFieldName, deploymentName, d.maxIDLengthLimit())
@@ -561,7 +561,7 @@ func (d *ClientImpl) SetRampingVersion(
 			return nil, serviceerror.NewInvalidArgument("invalid version string: " + err.Error())
 		}
 		if versionObj.GetDeploymentName() != "" && versionObj.GetDeploymentName() != deploymentName {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("invalid version string '%s' does not match deployment name '%s'", version, deploymentName))
+			return nil, serviceerror.NewInvalidArgumentf("invalid version string '%s' does not match deployment name '%s'", version, deploymentName)
 		}
 	}
 
@@ -614,7 +614,7 @@ func (d *ClientImpl) SetRampingVersion(
 	} else if failure := outcome.GetFailure(); failure.GetApplicationFailureInfo().GetType() == errVersionNotFound {
 		return nil, serviceerror.NewNotFound(errVersionNotFound)
 	} else if failure.GetApplicationFailureInfo().GetType() == errVersionAlreadyCurrentType {
-		return nil, serviceerror.NewFailedPrecondition(fmt.Sprintf("Ramping version %v is already current", version))
+		return nil, serviceerror.NewFailedPreconditionf("Ramping version %v is already current", version)
 	} else if failure.GetApplicationFailureInfo().GetType() == errFailedPrecondition {
 		return nil, serviceerror.NewFailedPrecondition(failure.Message)
 	} else if failure != nil {
@@ -641,7 +641,7 @@ func (d *ClientImpl) DeleteWorkerDeploymentVersion(
 ) (retErr error) {
 	v, err := worker_versioning.WorkerDeploymentVersionFromString(version)
 	if err != nil {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("invalid version string %q, expected format is \"<deployment_name>.<build_id>\"", version))
+		return serviceerror.NewInvalidArgumentf("invalid version string %q, expected format is \"<deployment_name>.<build_id>\"", version)
 	}
 	deploymentName := v.GetDeploymentName()
 	buildId := v.GetBuildId()
@@ -1134,12 +1134,12 @@ func (d *ClientImpl) AddVersionToWorkerDeployment(
 	} else if failure := outcome.GetFailure(); failure.GetApplicationFailureInfo().GetType() == errTooManyVersions {
 		return nil, serviceerror.NewFailedPrecondition(failure.Message)
 	} else if failure != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("failed to add version %v to worker deployment %v with error %v", args.Version, deploymentName, failure.Message))
+		return nil, serviceerror.NewInternalf("failed to add version %v to worker deployment %v with error %v", args.Version, deploymentName, failure.Message)
 	}
 
 	success := outcome.GetSuccess()
 	if success == nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("outcome missing success and failure while adding version %v to worker deployment %v", args.Version, deploymentName))
+		return nil, serviceerror.NewInternalf("outcome missing success and failure while adding version %v to worker deployment %v", args.Version, deploymentName)
 	}
 
 	return &deploymentspb.AddVersionToWorkerDeploymentResponse{}, nil
@@ -1377,12 +1377,12 @@ func (d *ClientImpl) IsVersionMissingTaskQueues(ctx context.Context, namespaceEn
 	// Check if all the task-queues in the prevCurrentVersion are present in the newCurrentVersion (newVersion is either the new ramping version or the new current version)
 	prevCurrentVersionInfo, err := d.DescribeVersion(ctx, namespaceEntry, prevCurrentVersion)
 	if err != nil {
-		return false, serviceerror.NewFailedPrecondition(fmt.Sprintf("Version %s not found in deployment with error: %v", prevCurrentVersion, err))
+		return false, serviceerror.NewFailedPreconditionf("Version %s not found in deployment with error: %v", prevCurrentVersion, err)
 	}
 
 	newVersionInfo, err := d.DescribeVersion(ctx, namespaceEntry, newVersion)
 	if err != nil {
-		return false, serviceerror.NewFailedPrecondition(fmt.Sprintf("Version %s not found in deployment with error: %v", newVersion, err))
+		return false, serviceerror.NewFailedPreconditionf("Version %s not found in deployment with error: %v", newVersion, err)
 	}
 
 	missingTaskQueues, err := d.checkForMissingTaskQueues(prevCurrentVersionInfo, newVersionInfo)

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -103,22 +103,22 @@ var (
 func validateVersionWfParams(fieldName string, field string, maxIDLengthLimit int) error {
 	// Length checks
 	if field == "" {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("%v cannot be empty", fieldName))
+		return serviceerror.NewInvalidArgumentf("%v cannot be empty", fieldName)
 	}
 
 	// Length of each field should be: (MaxIDLengthLimit - (prefix + delimeter length)) / 2
 	if len(field) > (maxIDLengthLimit-WorkerDeploymentVersionWorkflowIDInitialSize)/2 {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("size of %v larger than the maximum allowed", fieldName))
+		return serviceerror.NewInvalidArgumentf("size of %v larger than the maximum allowed", fieldName)
 	}
 
 	// deploymentName cannot have "."
 	if fieldName == WorkerDeploymentNameFieldName && strings.Contains(field, worker_versioning.WorkerDeploymentVersionIdDelimiter) {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("worker deployment name cannot contain '%s'", worker_versioning.WorkerDeploymentVersionIdDelimiter))
+		return serviceerror.NewInvalidArgumentf("worker deployment name cannot contain '%s'", worker_versioning.WorkerDeploymentVersionIdDelimiter)
 	}
 
 	// buildID or deployment name cannot start with "__"
 	if strings.HasPrefix(field, "__") {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("%v cannot start with '__'", fieldName))
+		return serviceerror.NewInvalidArgumentf("%v cannot start with '__'", fieldName)
 	}
 
 	return nil


### PR DESCRIPTION
## What changed?
Refactor: use new `serviceerror.New...f` constructors.

## Why?
Most of service errors now supports `fmt.Sprintf` format and they should be used instead of `fmt.Sprintf`.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
