### PR TITLE
Fixing flake caused by the auto-restart versioning feature

### DIFF
--- a/error.txt
+++ b/error.txt
@@ -1,0 +1,1 @@
+ok  	go.temporal.io/server/tests	80.435s

--- a/error.txt
+++ b/error.txt
@@ -1,1 +1,1 @@
-ok  	go.temporal.io/server/tests	80.435s
+ok  	go.temporal.io/server/tests	79.570s

--- a/error.txt
+++ b/error.txt
@@ -1,1 +1,0 @@
-ok  	go.temporal.io/server/tests	79.570s

--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -956,8 +956,8 @@ func (d *ClientImpl) update(
 
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
-		// Updates admitted as the workflow is closing may result in a ResourceExhausted error, which is considered retryable.
-		return errors.Is(err, errRetry) || (errors.Is(err, consts.ErrWorkflowClosing))
+		// All updates that are admitted as the workflow is closing are considered retryable.
+		return errors.Is(err, errRetry) || err.Error() == consts.ErrWorkflowClosing.Error()
 	}
 
 	var outcome *updatepb.Outcome
@@ -1208,8 +1208,8 @@ func (d *ClientImpl) updateWithStart(
 
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
-		// Updates admitted as the workflow is closing may result in an error which is considered retryable.
-		return errors.Is(err, errRetry) || errors.Is(err, consts.ErrWorkflowClosing)
+		// All updates that are admitted as the workflow is closing are considered retryable.
+		return errors.Is(err, errRetry) || err.Error() == consts.ErrWorkflowClosing.Error()
 	}
 	var outcome *updatepb.Outcome
 

--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -955,7 +955,7 @@ func (d *ClientImpl) update(
 
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
-		return errors.Is(err, errRetry)
+		return errors.Is(err, errRetry) || errors.As(err, new(*serviceerror.ResourceExhausted))
 	}
 
 	var outcome *updatepb.Outcome
@@ -1206,7 +1206,7 @@ func (d *ClientImpl) updateWithStart(
 
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
-		return errors.Is(err, errRetry)
+		return errors.Is(err, errRetry) || errors.As(err, new(*serviceerror.ResourceExhausted))
 	}
 	var outcome *updatepb.Outcome
 

--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -33,6 +33,7 @@ import (
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/worker_versioning"
+	"go.temporal.io/server/service/history/consts"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -956,7 +957,7 @@ func (d *ClientImpl) update(
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
 		// Updates admitted as the workflow is closing may result in a ResourceExhausted error, which is considered retryable.
-		return errors.Is(err, errRetry) || (errors.As(err, new(*serviceerror.ResourceExhausted)) && err.Error() == ErrWorkflowClosing)
+		return errors.Is(err, errRetry) || (errors.As(err, new(*serviceerror.ResourceExhausted)) && err.Error() == consts.ErrWorkflowClosing.Error())
 	}
 
 	var outcome *updatepb.Outcome
@@ -1208,7 +1209,7 @@ func (d *ClientImpl) updateWithStart(
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
 		// Updates admitted as the workflow is closing may result in a ResourceExhausted error, which is considered retryable.
-		return errors.Is(err, errRetry) || (errors.As(err, new(*serviceerror.ResourceExhausted)) && err.Error() == ErrWorkflowClosing)
+		return errors.Is(err, errRetry) || (errors.As(err, new(*serviceerror.ResourceExhausted)) && err.Error() == consts.ErrWorkflowClosing.Error())
 	}
 	var outcome *updatepb.Outcome
 

--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -957,7 +957,7 @@ func (d *ClientImpl) update(
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
 		// Updates admitted as the workflow is closing may result in a ResourceExhausted error, which is considered retryable.
-		return errors.Is(err, errRetry) || (errors.As(err, new(*serviceerror.ResourceExhausted)) && err.Error() == consts.ErrWorkflowClosing.Error())
+		return errors.Is(err, errRetry) || (errors.Is(err, consts.ErrWorkflowClosing))
 	}
 
 	var outcome *updatepb.Outcome
@@ -1208,8 +1208,8 @@ func (d *ClientImpl) updateWithStart(
 
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
-		// Updates admitted as the workflow is closing may result in a ResourceExhausted error, which is considered retryable.
-		return errors.Is(err, errRetry) || (errors.As(err, new(*serviceerror.ResourceExhausted)) && err.Error() == consts.ErrWorkflowClosing.Error())
+		// Updates admitted as the workflow is closing may result in an error which is considered retryable.
+		return errors.Is(err, errRetry) || errors.Is(err, consts.ErrWorkflowClosing)
 	}
 	var outcome *updatepb.Outcome
 

--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -955,7 +955,8 @@ func (d *ClientImpl) update(
 
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
-		return errors.Is(err, errRetry) || errors.As(err, new(*serviceerror.ResourceExhausted))
+		// Updates that are admitted as the workflow is closing receive a ResourceExhausted error and are retryable.
+		return errors.Is(err, errRetry) || (errors.As(err, new(*serviceerror.ResourceExhausted)) && err.Error() == ErrWorkflowClosing)
 	}
 
 	var outcome *updatepb.Outcome
@@ -1206,7 +1207,8 @@ func (d *ClientImpl) updateWithStart(
 
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
-		return errors.Is(err, errRetry) || errors.As(err, new(*serviceerror.ResourceExhausted))
+		// Updates that are admitted as the workflow is closing receive a ResourceExhausted error and are retryable.
+		return errors.Is(err, errRetry) || (errors.As(err, new(*serviceerror.ResourceExhausted)) && err.Error() == ErrWorkflowClosing)
 	}
 	var outcome *updatepb.Outcome
 

--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -955,7 +955,7 @@ func (d *ClientImpl) update(
 
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
-		// Updates that are admitted as the workflow is closing receive a ResourceExhausted error and are retryable.
+		// Updates admitted as the workflow is closing may result in a ResourceExhausted error, which is considered retryable.
 		return errors.Is(err, errRetry) || (errors.As(err, new(*serviceerror.ResourceExhausted)) && err.Error() == ErrWorkflowClosing)
 	}
 
@@ -1207,7 +1207,7 @@ func (d *ClientImpl) updateWithStart(
 
 	policy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
 	isRetryable := func(err error) bool {
-		// Updates that are admitted as the workflow is closing receive a ResourceExhausted error and are retryable.
+		// Updates admitted as the workflow is closing may result in a ResourceExhausted error, which is considered retryable.
 		return errors.Is(err, errRetry) || (errors.As(err, new(*serviceerror.ResourceExhausted)) && err.Error() == ErrWorkflowClosing)
 	}
 	var outcome *updatepb.Outcome

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -74,7 +74,6 @@ const (
 
 	ErrRampingVersionDoesNotHaveAllTaskQueues = "proposed ramping version is missing active task queues from the current version; these would become unversioned if it is set as the ramping version"
 	ErrCurrentVersionDoesNotHaveAllTaskQueues = "proposed current version is missing active task queues from the current version; these would become unversioned if it is set as the current version"
-	ErrWorkflowClosing                        = "workflow operation can not be applied because workflow is closing"
 )
 
 var (

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -74,6 +74,7 @@ const (
 
 	ErrRampingVersionDoesNotHaveAllTaskQueues = "proposed ramping version is missing active task queues from the current version; these would become unversioned if it is set as the ramping version"
 	ErrCurrentVersionDoesNotHaveAllTaskQueues = "proposed current version is missing active task queues from the current version; these would become unversioned if it is set as the current version"
+	ErrWorkflowClosing                        = "workflow operation can not be applied because workflow is closing"
 )
 
 var (

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -699,7 +699,7 @@ func (s *Versioning3Suite) testUnpinnedWorkflowWithRamp(toUnversioned bool) {
 		return "v2", nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	w1 := worker.New(s.SdkClient(), tv1.TaskQueue().GetName(), worker.Options{
@@ -1644,7 +1644,7 @@ func (s *Versioning3Suite) waitForDeploymentVersionCreation(
 func (s *Versioning3Suite) setCurrentDeployment(
 	tv *testvars.TestVars,
 ) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	s.Eventually(func() bool {
 		_, err := s.FrontendClient().SetWorkerDeploymentCurrentVersion(ctx,
@@ -1659,7 +1659,7 @@ func (s *Versioning3Suite) setCurrentDeployment(
 		}
 		s.NoError(err)
 		return err == nil
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 60*time.Second, 500*time.Millisecond)
 }
 
 func (s *Versioning3Suite) setRampingDeployment(
@@ -1667,7 +1667,7 @@ func (s *Versioning3Suite) setRampingDeployment(
 	percentage float32,
 	rampUnversioned bool,
 ) {
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	v := tv.DeploymentVersionString()
 	if rampUnversioned {
@@ -1688,7 +1688,7 @@ func (s *Versioning3Suite) setRampingDeployment(
 		}
 		s.NoError(err)
 		return err == nil
-	}, 20*time.Second, 100*time.Millisecond)
+	}, 60*time.Second, 500*time.Millisecond)
 }
 
 func (s *Versioning3Suite) updateTaskQueueDeploymentData(

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -1654,7 +1654,8 @@ func (s *Versioning3Suite) setCurrentDeployment(
 				Version:        tv.DeploymentVersionString(),
 			})
 		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
+		var resourceExhausted *serviceerror.ResourceExhausted
+		if errors.As(err, &notFound) || errors.As(err, &resourceExhausted) {
 			return false
 		}
 		s.NoError(err)
@@ -1683,7 +1684,8 @@ func (s *Versioning3Suite) setRampingDeployment(
 				Percentage:     percentage,
 			})
 		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
+		var resourceExhausted *serviceerror.ResourceExhausted
+		if errors.As(err, &notFound) || errors.As(err, &resourceExhausted) {
 			return false
 		}
 		s.NoError(err)

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -1654,8 +1654,7 @@ func (s *Versioning3Suite) setCurrentDeployment(
 				Version:        tv.DeploymentVersionString(),
 			})
 		var notFound *serviceerror.NotFound
-		var resourceExhausted *serviceerror.ResourceExhausted
-		if errors.As(err, &notFound) || errors.As(err, &resourceExhausted) {
+		if errors.As(err, &notFound) {
 			return false
 		}
 		s.NoError(err)
@@ -1684,8 +1683,7 @@ func (s *Versioning3Suite) setRampingDeployment(
 				Percentage:     percentage,
 			})
 		var notFound *serviceerror.NotFound
-		var resourceExhausted *serviceerror.ResourceExhausted
-		if errors.As(err, &notFound) || errors.As(err, &resourceExhausted) {
+		if errors.As(err, &notFound) {
 			return false
 		}
 		s.NoError(err)


### PR DESCRIPTION
## What changed?
increasing timeouts for breaking test + making the deploymentClient retry on the error returned when an update is admitted but the workflow is closing.

## Why?
- trying to put a band-aid over the breaking func test

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

