### PR TITLE
force-replication ListWorkflows executes on local cell (disable forwarding)

### DIFF
--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -424,6 +424,7 @@ func (a *activities) UpdateActiveCluster(ctx context.Context, req updateActiveCl
 
 func (a *activities) ListWorkflows(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*listWorkflowsResponse, error) {
 	ctx = headers.SetCallerInfo(ctx, headers.NewCallerInfo(request.Namespace, headers.CallerTypePreemptable, ""))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(interceptor.DCRedirectionContextHeaderName, "false"))
 
 	resp, err := a.frontendClient.ListWorkflowExecutions(ctx, request)
 	if err != nil {


### PR DESCRIPTION
## What changed?
- force-replication workflow will no longer forward ListWorkflowExecutions() to the Active cell

## Why?
- The force-replication workflow is used to ensure all workflows are replicated from the local cell (where the workflow is run) to a target cell.
- Part of force-replication is a call to ListWorkflowExecutions() which determines the workflows that need to be forwarded.
- Historically this workflow was always run on the Active cell, so forwarding never occurred.
- As of recently, we plan to run force-replication from the Passive cell.
- For the Passive cell to know which workflows need to be forwarded, we can not have the ListWorkflowExecutions() be forwarded to the Active cell

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

