### PR TITLE
Refactor verifyReplicationTasks

### DIFF
--- a/service/worker/migration/activities_test.go
+++ b/service/worker/migration/activities_test.go
@@ -149,6 +149,7 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_Success() {
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
 		TargetClusterName: remoteCluster,
+		Concurrency:       1,
 		Executions:        []*commonpb.WorkflowExecution{execution1, execution2},
 	}
 
@@ -223,6 +224,7 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_SkipWorkflowExecution() {
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
 		TargetClusterName: remoteCluster,
+		Concurrency:       1,
 		Executions:        []*commonpb.WorkflowExecution{execution1},
 	}
 
@@ -262,6 +264,7 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_FailedNotFound() {
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
 		TargetClusterName: remoteCluster,
+		Concurrency:       1,
 		Executions:        []*commonpb.WorkflowExecution{execution1},
 	}
 
@@ -298,6 +301,7 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_AlreadyVerified() {
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
 		TargetClusterName: remoteCluster,
+		Concurrency:       1,
 		Executions:        []*commonpb.WorkflowExecution{execution1, execution2},
 	}
 
@@ -318,6 +322,7 @@ func (s *activitiesSuite) Test_verifySingleReplicationTask() {
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
 		TargetClusterName: remoteCluster,
+		Concurrency:       1,
 		Executions:        []*commonpb.WorkflowExecution{execution1, execution2},
 	}
 	ctx := context.TODO()
@@ -399,6 +404,7 @@ func (s *activitiesSuite) Test_verifyReplicationTasks() {
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
 		TargetClusterName: remoteCluster,
+		Concurrency:       1,
 	}
 
 	ctx := context.TODO()
@@ -485,6 +491,7 @@ func (s *activitiesSuite) Test_verifyReplicationTasksNoProgress() {
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
 		TargetClusterName: remoteCluster,
+		Concurrency:       1,
 		Executions:        createExecutions(s.mockRemoteClient, []executionState{executionFound, executionFound, executionNotfound, executionFound}, 0),
 	}
 
@@ -527,6 +534,7 @@ func (s *activitiesSuite) Test_verifyReplicationTasksSkipRetention() {
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
 		TargetClusterName: remoteCluster,
+		Concurrency:       1,
 		Executions:        []*commonpb.WorkflowExecution{execution1},
 	}
 

--- a/service/worker/migration/force_replication_workflow.go
+++ b/service/worker/migration/force_replication_workflow.go
@@ -442,6 +442,7 @@ func enqueueReplicationTasks(ctx workflow.Context, workflowExecutionsCh workflow
 					NamespaceID:           namespaceID,
 					Executions:            workflowExecutions,
 					VerifyInterval:        time.Duration(params.VerifyIntervalInSeconds) * time.Second,
+					Concurrency:           params.ConcurrentActivityCount,
 				})
 
 			pendingVerifyTasks++


### PR DESCRIPTION
## Summary
- simplify verifyReplicationTasks logic for clarity
- enable concurrent verification of replication tasks with configurable concurrency

## Testing
- `go test ./service/worker/migration/... -run Test_verifyReplicationTasks -count=1` *(fails: download go1.24.1 toolchain)*