### PR TITLE
Ensure that RoutingConfig is never nil

### DIFF
--- a/common/worker_versioning/worker_versioning.go
+++ b/common/worker_versioning/worker_versioning.go
@@ -536,6 +536,9 @@ func DirectiveDeployment(directive *taskqueuespb.TaskVersionDirective) *deployme
 // The worker deployment manager workflows still use the v0.31 format, so call this before returning the object to readers
 // to mutatively populate the missing fields.
 func AddV32RoutingConfigToV31(r *deploymentpb.RoutingConfig) *deploymentpb.RoutingConfig {
+	if r == nil {
+		return nil
+	}
 	//nolint:staticcheck // SA1019: worker versioning v0.31
 	r.CurrentDeploymentVersion = ExternalWorkerDeploymentVersionFromString(r.CurrentVersion)
 	//nolint:staticcheck // SA1019: worker versioning v0.31

--- a/common/worker_versioning/worker_versioning.go
+++ b/common/worker_versioning/worker_versioning.go
@@ -536,9 +536,6 @@ func DirectiveDeployment(directive *taskqueuespb.TaskVersionDirective) *deployme
 // The worker deployment manager workflows still use the v0.31 format, so call this before returning the object to readers
 // to mutatively populate the missing fields.
 func AddV32RoutingConfigToV31(r *deploymentpb.RoutingConfig) *deploymentpb.RoutingConfig {
-	if r == nil {
-		return nil
-	}
 	//nolint:staticcheck // SA1019: worker versioning v0.31
 	r.CurrentDeploymentVersion = ExternalWorkerDeploymentVersionFromString(r.CurrentVersion)
 	//nolint:staticcheck // SA1019: worker versioning v0.31
@@ -664,6 +661,11 @@ func WorkerDeploymentVersionFromString(s string) (*deploymentspb.WorkerDeploymen
 // workflowID which are used in our Worker Deployment workflows
 func GenerateDeploymentWorkflowID(deploymentName string) string {
 	return WorkerDeploymentWorkflowIDPrefix + WorkerDeploymentVersionWorkflowIDDelimeter + deploymentName
+}
+
+func GetDeploymentNameFromWorkflowID(workflowID string) string {
+	_, deploymentName, _ := strings.Cut(workflowID, WorkerDeploymentVersionWorkflowIDDelimeter)
+	return deploymentName
 }
 
 // GenerateVersionWorkflowID is a helper that generates a system accepted


### PR DESCRIPTION
## What changed?
Ensure that ListWorkerDeployments never returns a nil RoutingConfig.

## Why?
Nightly run revealed nil pointer panic when ListWorkerDeployments calls AddV32RoutingConfigToV31 on a RoutingConfig in the memo.

When a worker deployment entity workflow starts, we immediately populate the routing config and upsert that to the memo, but it's possible to have a race between the workflow existing in Visibility, but before the memo was upserted. This PR ensures that if the memo is nil when List is called, we return a non-nil routing config and deployment info.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
If this doesn't solve the bug (ie. because memo is empty instead of nil) then we will find out in tonight's nightly