### PR TITLE
Add rate limiter on low priority replication tasks

### DIFF
--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -119,6 +119,7 @@ func HandlerProvider(args NewHandlerArgs) *Handler {
 		replicationTaskFetcherFactory:    args.ReplicationTaskFetcherFactory,
 		replicationTaskConverterProvider: args.ReplicationTaskConverterFactory,
 		streamReceiverMonitor:            args.StreamReceiverMonitor,
+		serverSchedulerRateLimiter:       args.ServerSchedulerRateLimiter,
 	}
 
 	// prevent us from trying to serve requests before shard controller is started and ready

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -119,7 +119,7 @@ func HandlerProvider(args NewHandlerArgs) *Handler {
 		replicationTaskFetcherFactory:    args.ReplicationTaskFetcherFactory,
 		replicationTaskConverterProvider: args.ReplicationTaskConverterFactory,
 		streamReceiverMonitor:            args.StreamReceiverMonitor,
-		serverSchedulerRateLimiter:       args.ServerSchedulerRateLimiter,
+		replicationServerRateLimiter:     args.ReplicationServerRateLimiter,
 	}
 
 	// prevent us from trying to serve requests before shard controller is started and ready

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -94,7 +94,7 @@ type (
 		replicationTaskFetcherFactory    replication.TaskFetcherFactory
 		replicationTaskConverterProvider replication.SourceTaskConverterProvider
 		streamReceiverMonitor            replication.StreamReceiverMonitor
-		serverSchedulerRateLimiter       replication.ServerSchedulerRateLimiter
+		replicationServerRateLimiter     replication.ServerSchedulerRateLimiter
 	}
 
 	NewHandlerArgs struct {
@@ -127,7 +127,7 @@ type (
 		ReplicationTaskFetcherFactory   replication.TaskFetcherFactory
 		ReplicationTaskConverterFactory replication.SourceTaskConverterProvider
 		StreamReceiverMonitor           replication.StreamReceiverMonitor
-		ServerSchedulerRateLimiter      replication.ServerSchedulerRateLimiter
+		ReplicationServerRateLimiter    replication.ServerSchedulerRateLimiter
 	}
 )
 
@@ -2121,7 +2121,7 @@ func (h *Handler) StreamWorkflowReplicationMessages(
 		server,
 		shardContext,
 		engine,
-		h.serverSchedulerRateLimiter,
+		h.replicationServerRateLimiter,
 		h.replicationTaskConverterProvider(
 			engine,
 			shardContext,

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -94,6 +94,7 @@ type (
 		replicationTaskFetcherFactory    replication.TaskFetcherFactory
 		replicationTaskConverterProvider replication.SourceTaskConverterProvider
 		streamReceiverMonitor            replication.StreamReceiverMonitor
+		serverSchedulerRateLimiter       replication.ServerSchedulerRateLimiter
 	}
 
 	NewHandlerArgs struct {
@@ -126,6 +127,7 @@ type (
 		ReplicationTaskFetcherFactory   replication.TaskFetcherFactory
 		ReplicationTaskConverterFactory replication.SourceTaskConverterProvider
 		StreamReceiverMonitor           replication.StreamReceiverMonitor
+		ServerSchedulerRateLimiter      replication.ServerSchedulerRateLimiter
 	}
 )
 
@@ -2119,6 +2121,7 @@ func (h *Handler) StreamWorkflowReplicationMessages(
 		server,
 		shardContext,
 		engine,
+		h.serverSchedulerRateLimiter,
 		h.replicationTaskConverterProvider(
 			engine,
 			shardContext,

--- a/service/history/replication/batchable_task.go
+++ b/service/history/replication/batchable_task.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -126,6 +127,10 @@ func (w *batchedTask) Reschedule() {
 
 func (w *batchedTask) State() ctasks.State {
 	return w.batchedTask.State()
+}
+
+func (w *batchedTask) ReplicationTask() *replicationspb.ReplicationTask {
+	return w.batchedTask.ReplicationTask()
 }
 
 func (w *batchedTask) callIndividual(f func(task TrackableExecutableTask)) {

--- a/service/history/replication/batchable_task_mock.go
+++ b/service/history/replication/batchable_task_mock.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 	time "time"
 
+	repication "go.temporal.io/server/api/replication/v1"
 	backoff "go.temporal.io/server/common/backoff"
 	tasks "go.temporal.io/server/common/tasks"
 	gomock "go.uber.org/mock/gomock"
@@ -199,6 +200,20 @@ func (m *MockBatchableTask) QueueID() any {
 func (mr *MockBatchableTaskMockRecorder) QueueID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueID", reflect.TypeOf((*MockBatchableTask)(nil).QueueID))
+}
+
+// ReplicationTask mocks base method.
+func (m *MockBatchableTask) ReplicationTask() *repication.ReplicationTask {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReplicationTask")
+	ret0, _ := ret[0].(*repication.ReplicationTask)
+	return ret0
+}
+
+// ReplicationTask indicates an expected call of ReplicationTask.
+func (mr *MockBatchableTaskMockRecorder) ReplicationTask() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicationTask", reflect.TypeOf((*MockBatchableTask)(nil).ReplicationTask))
 }
 
 // Reschedule mocks base method.

--- a/service/history/replication/executable_task_tracker.go
+++ b/service/history/replication/executable_task_tracker.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -24,6 +25,7 @@ type (
 		TaskCreationTime() time.Time
 		MarkPoisonPill() error
 		SourceClusterName() string
+		ReplicationTask() *replicationspb.ReplicationTask
 	}
 	WatermarkInfo struct {
 		Watermark int64

--- a/service/history/replication/executable_task_tracker_mock.go
+++ b/service/history/replication/executable_task_tracker_mock.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 	time "time"
 
+	repication "go.temporal.io/server/api/replication/v1"
 	backoff "go.temporal.io/server/common/backoff"
 	tasks "go.temporal.io/server/common/tasks"
 	gomock "go.uber.org/mock/gomock"
@@ -158,6 +159,20 @@ func (m *MockTrackableExecutableTask) QueueID() any {
 func (mr *MockTrackableExecutableTaskMockRecorder) QueueID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueID", reflect.TypeOf((*MockTrackableExecutableTask)(nil).QueueID))
+}
+
+// ReplicationTask mocks base method.
+func (m *MockTrackableExecutableTask) ReplicationTask() *repication.ReplicationTask {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReplicationTask")
+	ret0, _ := ret[0].(*repication.ReplicationTask)
+	return ret0
+}
+
+// ReplicationTask indicates an expected call of ReplicationTask.
+func (mr *MockTrackableExecutableTaskMockRecorder) ReplicationTask() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicationTask", reflect.TypeOf((*MockTrackableExecutableTask)(nil).ReplicationTask))
 }
 
 // Reschedule mocks base method.

--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -10,14 +10,17 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/client"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/namespace/nsreplication"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/quotas"
 	ctasks "go.temporal.io/server/common/tasks"
 	"go.temporal.io/server/common/xdc"
 	"go.temporal.io/server/service/history/configs"
@@ -41,6 +44,8 @@ var Module = fx.Provide(
 		return m
 	},
 	NewExecutionManagerDLQWriter,
+	ClientSchedulerRateLimiterProvider,
+	ServerSchedulerRateLimiterProvider,
 	replicationTaskConverterFactoryProvider,
 	replicationTaskExecutorProvider,
 	fx.Annotated{
@@ -156,8 +161,11 @@ func replicationStreamHighPrioritySchedulerProvider(
 }
 
 func replicationStreamLowPrioritySchedulerProvider(
+	rateLimiter ClientSchedulerRateLimiter,
+	timeSource clock.TimeSource,
 	config *configs.Config,
 	logger log.Logger,
+	metricsHandler metrics.Handler,
 	lc fx.Lifecycle,
 ) ctasks.Scheduler[TrackableExecutableTask] {
 	queueFactory := func(task TrackableExecutableTask) ctasks.SequentialTaskQueue[TrackableExecutableTask] {
@@ -191,6 +199,24 @@ func replicationStreamLowPrioritySchedulerProvider(
 	channelWeightFn := func(key ClusterChannelKey) int {
 		return 1
 	}
+	taskQuotaRequestFn := func(t TrackableExecutableTask) quotas.Request {
+		var taskType string
+		replicationTask := t.ReplicationTask()
+		if replicationTask != nil {
+			taskType = replicationTask.TaskType.String()
+		}
+
+		return quotas.NewRequest(
+			taskType,
+			taskSchedulerToken,
+			headers.SystemPreemptableCallerInfo.CallerName,
+			headers.SystemPreemptableCallerInfo.CallerType,
+			0,
+			"")
+	}
+	taskMetricsTagsFn := func(e TrackableExecutableTask) []metrics.Tag {
+		return nil
+	}
 	// This creates a per cluster channel.
 	// They share the same weight so it just does a round-robin on all clusters' tasks.
 	rrScheduler := ctasks.NewInterleavedWeightedRoundRobinScheduler(
@@ -201,8 +227,18 @@ func replicationStreamLowPrioritySchedulerProvider(
 		scheduler,
 		logger,
 	)
-	lc.Append(fx.StartStopHook(rrScheduler.Start, rrScheduler.Stop))
-	return rrScheduler
+	ts := ctasks.NewRateLimitedScheduler[TrackableExecutableTask](
+		rrScheduler,
+		rateLimiter,
+		timeSource,
+		taskQuotaRequestFn,
+		taskMetricsTagsFn,
+		ctasks.RateLimitedSchedulerOptions{},
+		logger,
+		metricsHandler,
+	)
+	lc.Append(fx.StartStopHook(ts.Start, ts.Stop))
+	return ts
 }
 
 func sequentialTaskQueueFactoryProvider(

--- a/service/history/replication/quotas.go
+++ b/service/history/replication/quotas.go
@@ -1,0 +1,24 @@
+package replication
+
+import (
+	"go.temporal.io/server/common/quotas"
+)
+
+const (
+	taskSchedulerToken = 1
+)
+
+type (
+	ServerSchedulerRateLimiter quotas.RequestRateLimiter
+	ClientSchedulerRateLimiter quotas.RequestRateLimiter
+)
+
+func ClientSchedulerRateLimiterProvider() (ClientSchedulerRateLimiter, error) {
+	// Experiment with no op rate limiter
+	return quotas.NoopRequestRateLimiter, nil
+}
+
+func ServerSchedulerRateLimiterProvider() (ServerSchedulerRateLimiter, error) {
+	// Experiment with no op rate limiter
+	return quotas.NoopRequestRateLimiter, nil
+}

--- a/service/history/replication/quotas.go
+++ b/service/history/replication/quotas.go
@@ -13,12 +13,12 @@ type (
 	ClientSchedulerRateLimiter quotas.RequestRateLimiter
 )
 
-func ClientSchedulerRateLimiterProvider() (ClientSchedulerRateLimiter, error) {
+func ClientSchedulerRateLimiterProvider() ClientSchedulerRateLimiter {
 	// Experiment with no op rate limiter
-	return quotas.NoopRequestRateLimiter, nil
+	return quotas.NoopRequestRateLimiter
 }
 
-func ServerSchedulerRateLimiterProvider() (ServerSchedulerRateLimiter, error) {
+func ServerSchedulerRateLimiterProvider() ServerSchedulerRateLimiter {
 	// Experiment with no op rate limiter
-	return quotas.NoopRequestRateLimiter, nil
+	return quotas.NoopRequestRateLimiter
 }

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -26,6 +26,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/service/history/configs"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/shard"
@@ -58,6 +59,7 @@ type (
 		isTieredStackEnabled    bool
 		flowController          SenderFlowController
 		sendLock                sync.Mutex
+		ssRateLimiter           ServerSchedulerRateLimiter
 	}
 )
 
@@ -65,6 +67,7 @@ func NewStreamSender(
 	server historyservice.HistoryService_StreamWorkflowReplicationMessagesServer,
 	shardContext historyi.ShardContext,
 	historyEngine historyi.Engine,
+	ssRateLimiter ServerSchedulerRateLimiter,
 	taskConverter SourceTaskConverter,
 	clientClusterName string,
 	clientClusterShardCount int32,
@@ -95,6 +98,7 @@ func NewStreamSender(
 		config:                  config,
 		isTieredStackEnabled:    config.EnableReplicationTaskTieredProcessing(),
 		flowController:          NewSenderFlowController(config, logger),
+		ssRateLimiter:           ssRateLimiter,
 	}
 }
 
@@ -529,6 +533,15 @@ Loop:
 					}
 					// continue to send task if wait operation times out.
 				}
+			}
+			if task.Priority == enumsspb.TASK_PRIORITY_LOW {
+				s.ssRateLimiter.Allow(time.Now(), quotas.NewRequest(
+					task.TaskType.String(),
+					taskSchedulerToken,
+					headers.SystemPreemptableCallerInfo.CallerName,
+					headers.SystemPreemptableCallerInfo.CallerType,
+					0,
+					""))
 			}
 			if err := s.sendToStream(&historyservice.StreamWorkflowReplicationMessagesResponse{
 				Attributes: &historyservice.StreamWorkflowReplicationMessagesResponse_Messages{

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -535,13 +535,16 @@ Loop:
 				}
 			}
 			if task.Priority == enumsspb.TASK_PRIORITY_LOW {
-				s.ssRateLimiter.Allow(time.Now(), quotas.NewRequest(
+				if err := s.ssRateLimiter.Wait(s.server.Context(), quotas.NewRequest(
 					task.TaskType.String(),
 					taskSchedulerToken,
 					headers.SystemPreemptableCallerInfo.CallerName,
 					headers.SystemPreemptableCallerInfo.CallerType,
 					0,
-					""))
+					"",
+				)); err != nil {
+					return err
+				}
 			}
 			if err := s.sendToStream(&historyservice.StreamWorkflowReplicationMessagesResponse{
 				Attributes: &historyservice.StreamWorkflowReplicationMessagesResponse_Messages{

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -535,10 +535,17 @@ Loop:
 				}
 			}
 			if task.Priority == enumsspb.TASK_PRIORITY_LOW {
+				nsName, err := s.shardContext.GetNamespaceRegistry().GetNamespaceName(
+					namespace.ID(item.GetNamespaceID()),
+				)
+				if err != nil {
+					// if there is error, then blindly send the task, better safe than sorry
+					nsName = namespace.EmptyName
+				}
 				if err := s.ssRateLimiter.Wait(s.server.Context(), quotas.NewRequest(
 					task.TaskType.String(),
 					taskSchedulerToken,
-					headers.SystemPreemptableCallerInfo.CallerName,
+					nsName.String(),
 					headers.SystemPreemptableCallerInfo.CallerType,
 					0,
 					"",

--- a/service/history/replication/stream_sender_test.go
+++ b/service/history/replication/stream_sender_test.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/quotas"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/configs"
 	historyi "go.temporal.io/server/service/history/interfaces"
@@ -83,6 +84,7 @@ func (s *streamSenderSuite) SetupTest() {
 		s.server,
 		s.shardContext,
 		s.historyEngine,
+		quotas.NoopRequestRateLimiter,
 		s.taskConverter,
 		"target_cluster",
 		2,

--- a/service/history/replication/stream_sender_test.go
+++ b/service/history/replication/stream_sender_test.go
@@ -953,6 +953,7 @@ func (s *streamSenderSuite) TestSendTasks_TieredStack_LowPriority() {
 		nil, nil, &persistencespb.NamespaceReplicationConfig{
 			Clusters: []string{"source_cluster", "target_cluster"},
 		}, 100), nil).AnyTimes()
+	mockRegistry.EXPECT().GetNamespaceName(namespace.ID("1")).Return(namespace.Name("test"), nil).AnyTimes()
 	s.shardContext.EXPECT().GetNamespaceRegistry().Return(mockRegistry).AnyTimes()
 	iter := collection.NewPagingIterator[tasks.Task](
 		func(paginationToken []byte) ([]tasks.Task, []byte, error) {


### PR DESCRIPTION
## What changed?
Add rate limiter on low priority replication tasks

## Why?
This gives the ability to wire up rate limiter on replication stack.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

