### PR TITLE
Add defensive logging and nil-safe access in WorkerDeployment workflow

### DIFF
--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -127,12 +127,17 @@ func (d *WorkflowRunner) updateVersionSummary(summary *deploymentspb.WorkerDeplo
 }
 
 func (d *WorkflowRunner) run(ctx workflow.Context) error {
-	if d.GetState().GetCreateTime() == nil {
-		if d.State == nil {
-			d.State = &deploymentspb.WorkerDeploymentLocalState{}
-		}
-		d.State.CreateTime = timestamppb.New(workflow.Now(ctx))
+	if d.State == nil {
+		d.State = &deploymentspb.WorkerDeploymentLocalState{}
+	}
+
+	// Ensure RoutingConfig is never nil
+	if d.State.RoutingConfig == nil {
 		d.State.RoutingConfig = &deploymentpb.RoutingConfig{CurrentVersion: worker_versioning.UnversionedVersionId}
+	}
+
+	if d.GetState().GetCreateTime() == nil {
+		d.State.CreateTime = timestamppb.New(workflow.Now(ctx))
 		d.State.ConflictToken, _ = workflow.Now(ctx).MarshalBinary()
 
 		// updating the memo since the RoutingConfig is updated

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -637,6 +637,7 @@ func (d *WorkflowRunner) handleDeleteVersion(ctx workflow.Context, args *deploym
 }
 
 func (d *WorkflowRunner) validateStateBeforeAcceptingSetCurrent(args *deploymentspb.SetCurrentVersionArgs) error {
+	//nolint:staticcheck // SA1019: worker versioning v0.31
 	if d.State.GetRoutingConfig().GetCurrentVersion() == args.Version && d.State.GetLastModifierIdentity() == args.Identity {
 		return temporal.NewApplicationError("no change", errNoChangeType, d.State.ConflictToken)
 	}

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -144,7 +144,7 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		d.State.Versions = make(map[string]*deploymentspb.WorkerDeploymentVersionSummary)
 	}
 
-	// Add logging to check state
+	//TODO(carlydf): remove verbose logging
 	d.logger.Info("Starting workflow run",
 		"create_time", d.State.GetCreateTime(),
 		"routing_config", d.State.GetRoutingConfig(),
@@ -244,7 +244,7 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		return nil
 	}
 
-	// Log state before continue-as-new
+	//TODO(carlydf): remove verbose logging
 	d.logger.Info("Continuing workflow as new",
 		"create_time", d.State.GetCreateTime(),
 		"routing_config", d.State.GetRoutingConfig(),
@@ -628,6 +628,7 @@ func (d *WorkflowRunner) handleSetCurrent(ctx workflow.Context, args *deployment
 	}()
 
 	// Log state before update
+	//TODO(carlydf): remove verbose logging
 	d.logger.Info("Starting SetCurrent update",
 		"current_version", d.State.GetRoutingConfig().GetCurrentVersion(),
 		"new_version", args.Version,
@@ -979,7 +980,7 @@ func (d *WorkflowRunner) newUUID(ctx workflow.Context) string {
 }
 
 func (d *WorkflowRunner) updateMemo(ctx workflow.Context) error {
-	// Log state before memo update
+	//TODO(carlydf): remove verbose logging
 	d.logger.Info("Updating workflow memo",
 		"routing_config", d.State.GetRoutingConfig(),
 		"current_version", d.State.GetRoutingConfig().GetCurrentVersion(),

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -127,7 +127,7 @@ func (d *WorkflowRunner) updateVersionSummary(summary *deploymentspb.WorkerDeplo
 }
 
 func (d *WorkflowRunner) run(ctx workflow.Context) error {
-	//TODO(carlydf): remove verbose logging
+	// TODO(carlydf): remove verbose logging
 	d.logger.Info("Raw workflow state at start",
 		"state_nil", d.State == nil,
 		"create_time_nil", d.GetState().GetCreateTime() == nil,
@@ -165,11 +165,13 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		d.State.Versions = make(map[string]*deploymentspb.WorkerDeploymentVersionSummary)
 	}
 
-	//TODO(carlydf): remove verbose logging
+	// TODO(carlydf): remove verbose logging
 	d.logger.Info("Starting workflow run",
 		"create_time", d.State.GetCreateTime(),
 		"routing_config", d.State.GetRoutingConfig(),
+		//nolint:staticcheck // SA1019: worker versioning v0.31
 		"current_version", d.State.GetRoutingConfig().GetCurrentVersion(),
+		//nolint:staticcheck // SA1019: worker versioning v0.31
 		"ramping_version", d.State.GetRoutingConfig().GetRampingVersion())
 
 	err := workflow.SetQueryHandler(ctx, QueryDescribeDeployment, func() (*deploymentspb.QueryDescribeWorkerDeploymentResponse, error) {
@@ -257,7 +259,7 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 			(!d.signalHandler.signalSelector.HasPending() && d.signalHandler.processingSignals == 0 && workflow.AllHandlersFinished(ctx) &&
 				(d.forceCAN || d.stateChanged))
 
-		//TODO(carlydf): remove verbose logging
+		// TODO(carlydf): remove verbose logging
 		if canContinue {
 			d.logger.Info("Workflow can continue as new",
 				"workflow_id", workflow.GetInfo(ctx).WorkflowExecution.ID,
@@ -280,11 +282,13 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		return nil
 	}
 
-	//TODO(carlydf): remove verbose logging
+	// TODO(carlydf): remove verbose logging
 	d.logger.Info("Continuing workflow as new",
 		"create_time", d.State.GetCreateTime(),
 		"routing_config", d.State.GetRoutingConfig(),
+		//nolint:staticcheck // SA1019: worker versioning v0.31
 		"current_version", d.State.GetRoutingConfig().GetCurrentVersion(),
+		//nolint:staticcheck // SA1019: worker versioning v0.31
 		"ramping_version", d.State.GetRoutingConfig().GetRampingVersion(),
 		"state_changed", d.stateChanged,
 		"force_can", d.forceCAN,
@@ -392,6 +396,7 @@ func (d *WorkflowRunner) handleDeleteDeployment(ctx workflow.Context) error {
 }
 
 func (d *WorkflowRunner) validateStateBeforeAcceptingRampingUpdate(args *deploymentspb.SetRampingVersionArgs) error {
+	//nolint:staticcheck // SA1019: worker versioning v0.31
 	if args.Version == d.State.GetRoutingConfig().GetRampingVersion() &&
 		args.Percentage == d.State.GetRoutingConfig().GetRampingVersionPercentage() &&
 		args.Identity == d.State.GetLastModifierIdentity() {
@@ -401,6 +406,7 @@ func (d *WorkflowRunner) validateStateBeforeAcceptingRampingUpdate(args *deploym
 	if args.ConflictToken != nil && !bytes.Equal(args.ConflictToken, d.State.GetConflictToken()) {
 		return temporal.NewApplicationError("conflict token mismatch", errFailedPrecondition)
 	}
+	//nolint:staticcheck // SA1019: worker versioning v0.31
 	if args.Version == d.State.GetRoutingConfig().GetCurrentVersion() {
 		d.logger.Info("version can't be set to ramping since it is already current")
 		return temporal.NewApplicationError(fmt.Sprintf("requested ramping version %s is already current", args.Version), errFailedPrecondition)
@@ -666,8 +672,9 @@ func (d *WorkflowRunner) handleSetCurrent(ctx workflow.Context, args *deployment
 	}()
 
 	// Log state before update
-	//TODO(carlydf): remove verbose logging
+	// TODO(carlydf): remove verbose logging
 	d.logger.Info("Starting SetCurrent update",
+		//nolint:staticcheck // SA1019: worker versioning v0.31
 		"current_version", d.State.GetRoutingConfig().GetCurrentVersion(),
 		"new_version", args.Version,
 		"routing_config", d.State.GetRoutingConfig())
@@ -1018,10 +1025,12 @@ func (d *WorkflowRunner) newUUID(ctx workflow.Context) string {
 }
 
 func (d *WorkflowRunner) updateMemo(ctx workflow.Context) error {
-	//TODO(carlydf): remove verbose logging
+	// TODO(carlydf): remove verbose logging
 	d.logger.Info("Updating workflow memo",
 		"routing_config", d.State.GetRoutingConfig(),
+		//nolint:staticcheck // SA1019: worker versioning v0.31
 		"current_version", d.State.GetRoutingConfig().GetCurrentVersion(),
+		//nolint:staticcheck // SA1019: worker versioning v0.31
 		"ramping_version", d.State.GetRoutingConfig().GetRampingVersion())
 
 	return workflow.UpsertMemo(ctx, map[string]any{


### PR DESCRIPTION
## What Changed
1. Added strategic logging points to track workflow state:
   - At workflow start in `run()`
   - Before continue-as-new transitions
   - During SetCurrent version updates
   - During memo updates

2. Updated validator functions to use nil-safe Get notation:
   - `validateStateBeforeAcceptingRampingUpdate`
   - `validateStateBeforeAcceptingSetCurrent`
   - `validateDeleteVersion`
   - `validateDeleteDeployment`

## Why
1. The logging changes will help diagnose nil pointer errors we're seeing in canary tests by:
   - Tracking the state of `RoutingConfig` throughout the workflow lifecycle
   - Verifying state preservation during continue-as-new transitions
   - Monitoring state changes during updates
   - Confirming state persistence in the memo

2. The nil-safe Get notation changes make the code more defensive by:
   - Preventing nil pointer panics if any part of the state is nil
   - Using protobuf getters that return default values instead of direct field access
   - Making the code more consistent with protobuf best practices

These changes are diagnostic and defensive in nature, helping us track down the root cause of the nil pointer errors while making the code more robust against potential nil states.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
