### PR TITLE
Limit schedule exclude time search

### DIFF
--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -276,7 +276,7 @@ func (cs *CompiledSpec) GetNextTime(jitterSeed string, after time.Time) GetNextT
 	after = util.MaxTime(after, cs.spec.StartTime.AsTime().Add(-time.Second))
 
 	pastEndTime := func(t time.Time) bool {
-		return cs.spec.EndTime != nil && t.After(cs.spec.EndTime.AsTime())
+		return cs.spec.EndTime != nil && t.After(cs.spec.EndTime.AsTime()) || t.Year() > maxCalendarYear
 	}
 	var nominal time.Time
 	for nominal.IsZero() || cs.excluded(nominal) {

--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -366,6 +366,19 @@ func (s *specSuite) TestSpecExclude() {
 	)
 }
 
+func (s *specSuite) TestExcludeAll() {
+	cs, err := s.specBuilder.NewCompiledSpec(&schedulepb.ScheduleSpec{
+		Interval: []*schedulepb.IntervalSpec{
+			{Interval: durationpb.New(7 * 24 * time.Hour)},
+		},
+		ExcludeCalendar: []*schedulepb.CalendarSpec{
+			&schedulepb.CalendarSpec{Second: "*", Minute: "*", Hour: "*"},
+		},
+	})
+	s.NoError(err)
+	s.Zero(cs.GetNextTime("", time.Date(2022, 3, 23, 12, 53, 2, 9, time.UTC)))
+}
+
 func (s *specSuite) TestSpecStartTime() {
 	s.checkSequenceFull(
 		"",


### PR DESCRIPTION
## What changed?
Stop searching for a matching schedule time after year 2100.

## Why?
If all matching times are also excluded, then the loop in GetNextTime would never return.
Fixes #7793.

## How did you test it?
- [x] run locally and tested manually
- [x] added new unit test(s)
