### PR TITLE
Cache component in PartitionManager

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -1134,33 +1134,27 @@ func (e *matchingEngineImpl) DescribeTaskQueue(
 			return nil, err
 		}
 
-		timeSinceLastFanOut := rootPM.TimeSinceLastFanOut()
-		lastFanOutTTL := tqConfig.TaskQueueInfoByBuildIdTTL()
-
 		// TODO bug fix: We cache the last response for each build ID. timeSinceLastFanOut is the last fan out time, that means some enteries in the cache can be more stale if
 		// user is calling this API back-to-back but with different version selection.
-		cacheIsFresh := timeSinceLastFanOut <= lastFanOutTTL
 		missingItemsInCache := false
 		physicalInfoByBuildId := make(map[string]map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo)
-		if cacheIsFresh {
-			// fetch info from rootPartition's cache for the cached versions
-			cache := rootPM.GetPhysicalTaskQueueInfoFromCache()
-			requestedBuildIds, err := e.getBuildIds(req.Versions)
-			if err != nil {
-				return nil, err
-			}
-			for b := range requestedBuildIds {
-				if c, ok := cache[b]; ok {
-					physicalInfoByBuildId[b] = c
-				} else {
-					missingItemsInCache = true
-				}
-			}
+		requestedBuildIds, err := e.getBuildIds(req.Versions)
+		if err != nil {
+			return nil, err
 		}
-		if !cacheIsFresh || missingItemsInCache {
+		for b := range requestedBuildIds {
+			c := rootPM.GetCache(b) // any expired cache entry will return nil
+			if c == nil {
+				missingItemsInCache = true
+				break // once we find a missing item, we can stop checking the cache
+			}
+			//revive:disable-next-line:unchecked-type-assertion
+			physicalInfoByBuildId[b] = c.(map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo)
+		}
+		if missingItemsInCache {
 			// Fan out to partitions to get the needed info
+			var foundBuildIds []string
 			numPartitions := max(tqConfig.NumWritePartitions(), tqConfig.NumReadPartitions())
-
 			for _, taskQueueType := range req.TaskQueueTypes {
 				for i := 0; i < numPartitions; i++ {
 					partitionResp, err := e.matchingRawClient.DescribeTaskQueuePartition(ctx, &matchingservice.DescribeTaskQueuePartitionRequest{
@@ -1178,6 +1172,7 @@ func (e *matchingEngineImpl) DescribeTaskQueue(
 						return nil, err
 					}
 					for buildId, vii := range partitionResp.VersionsInfoInternal {
+						foundBuildIds = append(foundBuildIds, buildId)
 						if _, ok := physicalInfoByBuildId[buildId]; !ok {
 							physicalInfoByBuildId[buildId] = make(map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo)
 						}
@@ -1207,8 +1202,10 @@ func (e *matchingEngineImpl) DescribeTaskQueue(
 					}
 				}
 			}
-			// update cache
-			rootPM.UpdateTimeSinceLastFanOutAndCache(physicalInfoByBuildId, cacheIsFresh)
+
+			for _, b := range foundBuildIds {
+				rootPM.PutCache(b, physicalInfoByBuildId[b])
+			}
 		}
 
 		// smush internal info into versions info

--- a/service/matching/task_queue_partition_manager_interface.go
+++ b/service/matching/task_queue_partition_manager_interface.go
@@ -6,10 +6,8 @@ import (
 	"context"
 	"time"
 
-	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
-	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/tqid"
 )
@@ -61,11 +59,7 @@ type (
 		Describe(ctx context.Context, buildIds map[string]bool, includeAllActive, reportStats, reportPollers, internalTaskQueueStatus bool) (*matchingservice.DescribeTaskQueuePartitionResponse, error)
 		Partition() tqid.Partition
 		LongPollExpirationInterval() time.Duration
-		// TimeSinceLastFanOut returns the time since the last DescribeTaskQueuePartition fan out
-		TimeSinceLastFanOut() time.Duration
-		// UpdateTimeSinceLastFanOutAndCache updates the cache and it's TTL
-		UpdateTimeSinceLastFanOutAndCache(physicalInfoByBuildId map[string]map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo, upsert bool)
-		// GetPhysicalTaskQueueInfoFromCache returns the cached physicalInfoByBuildId
-		GetPhysicalTaskQueueInfoFromCache() map[string]map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo
+		PutCache(key any, value any)
+		GetCache(key any) any
 	}
 )

--- a/service/matching/task_queue_partition_manager_mock.go
+++ b/service/matching/task_queue_partition_manager_mock.go
@@ -14,10 +14,8 @@ import (
 	reflect "reflect"
 	time "time"
 
-	enums "go.temporal.io/api/enums/v1"
 	taskqueue "go.temporal.io/api/taskqueue/v1"
 	matchingservice "go.temporal.io/server/api/matchingservice/v1"
-	taskqueue0 "go.temporal.io/server/api/taskqueue/v1"
 	namespace "go.temporal.io/server/common/namespace"
 	tqid "go.temporal.io/server/common/tqid"
 	gomock "go.uber.org/mock/gomock"
@@ -136,18 +134,18 @@ func (mr *MocktaskQueuePartitionManagerMockRecorder) GetAllPollerInfo() *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllPollerInfo", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).GetAllPollerInfo))
 }
 
-// GetPhysicalTaskQueueInfoFromCache mocks base method.
-func (m *MocktaskQueuePartitionManager) GetPhysicalTaskQueueInfoFromCache() map[string]map[enums.TaskQueueType]*taskqueue0.PhysicalTaskQueueInfo {
+// GetCache mocks base method.
+func (m *MocktaskQueuePartitionManager) GetCache(key any) any {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPhysicalTaskQueueInfoFromCache")
-	ret0, _ := ret[0].(map[string]map[enums.TaskQueueType]*taskqueue0.PhysicalTaskQueueInfo)
+	ret := m.ctrl.Call(m, "GetCache", key)
+	ret0, _ := ret[0].(any)
 	return ret0
 }
 
-// GetPhysicalTaskQueueInfoFromCache indicates an expected call of GetPhysicalTaskQueueInfoFromCache.
-func (mr *MocktaskQueuePartitionManagerMockRecorder) GetPhysicalTaskQueueInfoFromCache() *gomock.Call {
+// GetCache indicates an expected call of GetCache.
+func (mr *MocktaskQueuePartitionManagerMockRecorder) GetCache(key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPhysicalTaskQueueInfoFromCache", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).GetPhysicalTaskQueueInfoFromCache))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCache", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).GetCache), key)
 }
 
 // GetUserDataManager mocks base method.
@@ -291,6 +289,18 @@ func (mr *MocktaskQueuePartitionManagerMockRecorder) ProcessSpooledTask(ctx, tas
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessSpooledTask", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).ProcessSpooledTask), ctx, task, backlogQueue)
 }
 
+// PutCache mocks base method.
+func (m *MocktaskQueuePartitionManager) PutCache(key, value any) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "PutCache", key, value)
+}
+
+// PutCache indicates an expected call of PutCache.
+func (mr *MocktaskQueuePartitionManagerMockRecorder) PutCache(key, value any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutCache", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).PutCache), key, value)
+}
+
 // Start mocks base method.
 func (m *MocktaskQueuePartitionManager) Start() {
 	m.ctrl.T.Helper()
@@ -313,32 +323,6 @@ func (m *MocktaskQueuePartitionManager) Stop(arg0 unloadCause) {
 func (mr *MocktaskQueuePartitionManagerMockRecorder) Stop(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).Stop), arg0)
-}
-
-// TimeSinceLastFanOut mocks base method.
-func (m *MocktaskQueuePartitionManager) TimeSinceLastFanOut() time.Duration {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TimeSinceLastFanOut")
-	ret0, _ := ret[0].(time.Duration)
-	return ret0
-}
-
-// TimeSinceLastFanOut indicates an expected call of TimeSinceLastFanOut.
-func (mr *MocktaskQueuePartitionManagerMockRecorder) TimeSinceLastFanOut() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TimeSinceLastFanOut", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).TimeSinceLastFanOut))
-}
-
-// UpdateTimeSinceLastFanOutAndCache mocks base method.
-func (m *MocktaskQueuePartitionManager) UpdateTimeSinceLastFanOutAndCache(physicalInfoByBuildId map[string]map[enums.TaskQueueType]*taskqueue0.PhysicalTaskQueueInfo, upsert bool) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateTimeSinceLastFanOutAndCache", physicalInfoByBuildId, upsert)
-}
-
-// UpdateTimeSinceLastFanOutAndCache indicates an expected call of UpdateTimeSinceLastFanOutAndCache.
-func (mr *MocktaskQueuePartitionManagerMockRecorder) UpdateTimeSinceLastFanOutAndCache(physicalInfoByBuildId, upsert any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTimeSinceLastFanOutAndCache", reflect.TypeOf((*MocktaskQueuePartitionManager)(nil).UpdateTimeSinceLastFanOutAndCache), physicalInfoByBuildId, upsert)
 }
 
 // WaitUntilInitialized mocks base method.


### PR DESCRIPTION
## What changed?

Replaced the ad-hoc cache in partition manager with the existing (common) cache component.

## Why?

DRY. Plus, I need to cache a separate cache key/value pair and didn't want to duplicate everything for that cache again.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

