### PR TITLE
Do not add start WFT before processing commands

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -476,7 +476,10 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 		if request.GetForceCreateNewWorkflowTask() || // Heartbeat WT is always of Normal type.
 			wtFailedShouldCreateNewTask ||
 			hasBufferedEventsOrMessages ||
-			activityNotStartedCancelled {
+			activityNotStartedCancelled ||
+			// If the workflow has an ongoing transition to another deployment version, we should ensure
+			// it has a pending wft so it does not remain in the transition phase for long.
+			ms.GetDeploymentTransition() != nil {
 
 			newWorkflowTaskType = enumsspb.WORKFLOW_TASK_TYPE_NORMAL
 

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -1129,16 +1129,6 @@ func (m *workflowTaskStateMachine) afterAddWorkflowTaskCompletedEvent(
 		}
 	}
 
-	if transition != nil {
-		// There is still a transition going on. We need to schedule a new WFT so it goes to the
-		// transition deployment this time.
-		if _, err := m.ms.AddWorkflowTaskScheduledEvent(
-			false,
-			enumsspb.WORKFLOW_TASK_TYPE_NORMAL,
-		); err != nil {
-			return err
-		}
-	}
 	// Deployment and behavior before applying the data came from the completed wft.
 	wfDeploymentBefore := m.ms.GetEffectiveDeployment()
 	wfBehaviorBefore := m.ms.GetEffectiveVersioningBehavior()


### PR DESCRIPTION
## What changed?
In an edge case in versioning we wanted to make sure that a new WFT is generated after processing the previous WFT completed event. The new WFT was added in `afterAddWorkflowTaskCompletedEvent` which is run before processing commands.
Now moved it to the api handler which is anyways taking care of similar cases to create new WFT task after completion of the previous one.

## Why?
The old logic causes issues because it adds the new WFT before the events generated from commands.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

