### PR TITLE
stop potential empty string versions being passed to our syncVersion calls

### DIFF
--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -464,7 +464,8 @@ func (d *WorkflowRunner) handleSetRampingVersion(ctx workflow.Context, args *dep
 			RampPercentage:    0,   // remove ramp
 		}
 
-		if prevRampingVersion != worker_versioning.UnversionedVersionId {
+		// TODO (Shivam): remove the empty string check once canary stops flaking out
+		if prevRampingVersion != worker_versioning.UnversionedVersionId && prevRampingVersion != "" {
 			if _, err := d.syncVersion(ctx, prevRampingVersion, unsetRampUpdateArgs, false); err != nil {
 				return nil, err
 			}
@@ -513,7 +514,8 @@ func (d *WorkflowRunner) handleSetRampingVersion(ctx workflow.Context, args *dep
 			RampingSinceTime:  rampingSinceTime,
 			RampPercentage:    args.Percentage,
 		}
-		if newRampingVersion != worker_versioning.UnversionedVersionId {
+		// TODO (Shivam): remove the empty string check once canary stops flaking out
+		if newRampingVersion != worker_versioning.UnversionedVersionId && newRampingVersion != "" {
 			if _, err := d.syncVersion(ctx, newRampingVersion, setRampUpdateArgs, true); err != nil {
 				return nil, err
 			}
@@ -530,7 +532,8 @@ func (d *WorkflowRunner) handleSetRampingVersion(ctx workflow.Context, args *dep
 				RampingSinceTime:  nil, // remove ramp
 				RampPercentage:    0,   // remove ramp
 			}
-			if prevRampingVersion != worker_versioning.UnversionedVersionId {
+			// TODO (Shivam): remove the empty string check once canary stops flaking out
+			if prevRampingVersion != worker_versioning.UnversionedVersionId && prevRampingVersion != "" {
 				if _, err := d.syncVersion(ctx, prevRampingVersion, unsetRampUpdateArgs, false); err != nil {
 					return nil, err
 				}
@@ -706,7 +709,8 @@ func (d *WorkflowRunner) handleSetCurrent(ctx workflow.Context, args *deployment
 		}
 	}
 
-	if newCurrentVersion != worker_versioning.UnversionedVersionId {
+	// TODO (Shivam): remove the empty string check once canary stops flaking out
+	if newCurrentVersion != worker_versioning.UnversionedVersionId && newCurrentVersion != "" {
 		// Tell new current version that it's current
 		currUpdateArgs := &deploymentspb.SyncVersionStateUpdateArgs{
 			RoutingUpdateTime: updateTime,
@@ -724,7 +728,8 @@ func (d *WorkflowRunner) handleSetCurrent(ctx workflow.Context, args *deployment
 	// do is tell the previous current version that it is not current. Then, the task queues in the
 	// previous current version will have no current version and will become unversioned implicitly.
 
-	if prevCurrentVersion != worker_versioning.UnversionedVersionId {
+	// TODO (Shivam): remove the empty string check once canary stops flaking out
+	if prevCurrentVersion != worker_versioning.UnversionedVersionId && prevCurrentVersion != "" {
 		// Tell previous current that it's no longer current
 		prevUpdateArgs := &deploymentspb.SyncVersionStateUpdateArgs{
 			RoutingUpdateTime: updateTime,


### PR DESCRIPTION
## What changed?
- The canary seems to be erroring out cause there are multiple `syncState` calls where an empty version is being passed. Now, we don't know for sure who and from where these strings are being passed, but to mitigate these failures, I have added some extra checks so that the `syncState` activity doesn't run with empty strings.

## Why?
- to stop the canary from complaining 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- none
