### PR TITLE
Add namespace tag to Update metrics

### DIFF
--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -915,7 +915,9 @@ func (c *ContextImpl) UpdateRegistry(ctx context.Context) update.Registry {
 		c.updateRegistry = update.NewRegistry(
 			c.MutableState,
 			update.WithLogger(c.logger),
-			update.WithMetrics(c.metricsHandler),
+			update.WithMetrics(c.metricsHandler.WithTags(
+				metrics.NamespaceTag(nsName),
+			)),
 			update.WithTracerProvider(trace.SpanFromContext(ctx).TracerProvider()),
 			update.WithInFlightLimit(
 				func() int {


### PR DESCRIPTION
## What changed?

Added namespace tag to Update registry metrics handler.

## Why?

To correlate metrics to a namespace.

## How did you test it?

I didn't.

## Potential risks

Cardinality should be fine, I assume.