### PR TITLE
Bump test shards to 4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -82,7 +82,7 @@ jobs:
     steps:
       - id: generate_output
         run: |
-          shards=3
+          shards=4
           timeout=35   # update this to TEST_TIMEOUT if you update the Makefile
           runs_on='["ubuntu-latest"]'
           if [[ "${{ inputs.run_single_functional_test }}" == "true" || "${{ inputs.run_single_unit_test }}" == "true" ]]; then


### PR DESCRIPTION
## What changed?

Bump test sharding from 3 to 4.

## Why?

Hot fix to prevent Cassandra tests from terminating ([example](https://github.com/temporalio/temporal/actions/runs/14385910499/job/40341362855)).

There are certainly other options to tackle this, but this seems like a quick fix to try before those.
