### PR TITLE
fix workflow_query_success_count tag mismatch

### DIFF
--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -49,7 +49,7 @@ const (
 	runInitiator            = "run_initiator"
 	fromUnversioned         = "from_unversioned"
 	toUnversioned           = "to_unversioned"
-	queryType               = "query_type"
+	queryTypeTag            = "query_type"
 	namespaceAllValue       = "all"
 	unknownValue            = "_unknown_"
 	totalMetricSuffix       = "_total"
@@ -428,7 +428,7 @@ func QueryTypeTag(queryType string) Tag {
 		return &tagImpl{key: queryType, value: queryType}
 	}
 	// group all user defined queries into a single tag value
-	return &tagImpl{key: queryType, value: queryTypeUserDefined}
+	return &tagImpl{key: queryTypeTag, value: queryTypeUserDefined}
 }
 
 func VersioningBehaviorBeforeOverrideTag(behavior enumspb.VersioningBehavior) Tag {


### PR DESCRIPTION
## What changed?
workflow_query_success_count was being emitted with variable tag key. fixing it.

## Why?
above.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
none