### PR TITLE
Refactor: rename foreignNamespace to externalNamespace

### DIFF
--- a/tests/cancel_workflow_test.go
+++ b/tests/cancel_workflow_test.go
@@ -147,9 +147,9 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetRu
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
-	foreignRequest := &workflowservice.StartWorkflowExecutionRequest{
+	externalRequest := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.New(),
-		Namespace:           s.ForeignNamespace().String(),
+		Namespace:           s.ExternalNamespace().String(),
 		WorkflowId:          id,
 		WorkflowType:        workflowType,
 		TaskQueue:           taskQueue,
@@ -158,9 +158,9 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetRu
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we2, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), foreignRequest)
+	we2, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), externalRequest)
 	s.NoError(err0)
-	s.Logger.Info("StartWorkflowExecution on foreign namespace", tag.WorkflowNamespace(s.ForeignNamespace().String()), tag.WorkflowRunID(we2.RunId))
+	s.Logger.Info("StartWorkflowExecution on external namespace", tag.WorkflowNamespace(s.ExternalNamespace().String()), tag.WorkflowRunID(we2.RunId))
 
 	cancellationSent := false
 	wtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
@@ -170,7 +170,7 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetRu
 			return []*commandpb.Command{{
 				CommandType: enumspb.COMMAND_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION,
 				Attributes: &commandpb.Command_RequestCancelExternalWorkflowExecutionCommandAttributes{RequestCancelExternalWorkflowExecutionCommandAttributes: &commandpb.RequestCancelExternalWorkflowExecutionCommandAttributes{
-					Namespace:  s.ForeignNamespace().String(),
+					Namespace:  s.ExternalNamespace().String(),
 					WorkflowId: id,
 					RunId:      we2.RunId,
 				}},
@@ -204,7 +204,7 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetRu
 		T:                   s.T(),
 	}
 
-	foreignwtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
+	externalWTFHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
 
 		// Find cancel requested event and verify it.
 		var cancelRequestEvent *historypb.HistoryEvent
@@ -228,17 +228,17 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetRu
 		}}, nil
 	}
 
-	foreignPoller := &testcore.TaskPoller{
+	externalPoller := &testcore.TaskPoller{
 		Client:              s.FrontendClient(),
-		Namespace:           s.ForeignNamespace().String(),
+		Namespace:           s.ExternalNamespace().String(),
 		TaskQueue:           taskQueue,
 		Identity:            identity,
-		WorkflowTaskHandler: foreignwtHandler,
+		WorkflowTaskHandler: externalWTFHandler,
 		Logger:              s.Logger,
 		T:                   s.T(),
 	}
 
-	// Cancel the foreign workflow with this workflow task request.
+	// Cancel the external workflow with this workflow task request.
 	_, err := poller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
@@ -251,8 +251,8 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetRu
 	s.NoError(err)
 
 	// Accept cancellation.
-	_, err = foreignPoller.PollAndProcessWorkflowTask()
-	s.Logger.Info("foreign PollAndProcessWorkflowTask", tag.Error(err))
+	_, err = externalPoller.PollAndProcessWorkflowTask()
+	s.Logger.Info("external PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 }
 
@@ -281,9 +281,9 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetFi
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
-	foreignRequest := &workflowservice.StartWorkflowExecutionRequest{
+	externalRequest := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.New(),
-		Namespace:           s.ForeignNamespace().String(),
+		Namespace:           s.ExternalNamespace().String(),
 		WorkflowId:          id,
 		WorkflowType:        workflowType,
 		TaskQueue:           taskQueue,
@@ -292,9 +292,9 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetFi
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we2, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), foreignRequest)
+	we2, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), externalRequest)
 	s.NoError(err0)
-	s.Logger.Info("StartWorkflowExecution on foreign namespace", tag.WorkflowNamespace(s.ForeignNamespace().String()), tag.WorkflowRunID(we2.RunId))
+	s.Logger.Info("StartWorkflowExecution on external namespace", tag.WorkflowNamespace(s.ExternalNamespace().String()), tag.WorkflowRunID(we2.RunId))
 
 	cancellationSent := false
 	wtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
@@ -304,7 +304,7 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetFi
 			return []*commandpb.Command{{
 				CommandType: enumspb.COMMAND_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION,
 				Attributes: &commandpb.Command_RequestCancelExternalWorkflowExecutionCommandAttributes{RequestCancelExternalWorkflowExecutionCommandAttributes: &commandpb.RequestCancelExternalWorkflowExecutionCommandAttributes{
-					Namespace:  s.ForeignNamespace().String(),
+					Namespace:  s.ExternalNamespace().String(),
 					WorkflowId: id,
 					RunId:      we2.RunId,
 				}},
@@ -338,7 +338,7 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetFi
 		T:                   s.T(),
 	}
 
-	foreignwtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
+	externalWTFHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
 
 		// Find cancel requested event not present
 		var cancelRequestEvent *historypb.HistoryEvent
@@ -358,19 +358,19 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetFi
 		}}, nil
 	}
 
-	foreignPoller := &testcore.TaskPoller{
+	externalPoller := &testcore.TaskPoller{
 		Client:              s.FrontendClient(),
-		Namespace:           s.ForeignNamespace().String(),
+		Namespace:           s.ExternalNamespace().String(),
 		TaskQueue:           taskQueue,
 		Identity:            identity,
-		WorkflowTaskHandler: foreignwtHandler,
+		WorkflowTaskHandler: externalWTFHandler,
 		Logger:              s.Logger,
 		T:                   s.T(),
 	}
 
 	// Complete target workflow
-	_, err := foreignPoller.PollAndProcessWorkflowTask()
-	s.Logger.Info("foreign PollAndProcessWorkflowTask", tag.Error(err))
+	_, err := externalPoller.PollAndProcessWorkflowTask()
+	s.Logger.Info("external PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Cancel the target workflow with this workflow task request.
@@ -419,7 +419,7 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetNo
 			return []*commandpb.Command{{
 				CommandType: enumspb.COMMAND_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION,
 				Attributes: &commandpb.Command_RequestCancelExternalWorkflowExecutionCommandAttributes{RequestCancelExternalWorkflowExecutionCommandAttributes: &commandpb.RequestCancelExternalWorkflowExecutionCommandAttributes{
-					Namespace:  s.ForeignNamespace().String(),
+					Namespace:  s.ExternalNamespace().String(),
 					WorkflowId: "some-random-non-existence-workflow-id",
 				}},
 			}}, nil

--- a/tests/cancel_workflow_test.go
+++ b/tests/cancel_workflow_test.go
@@ -228,6 +228,7 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetRu
 		}}, nil
 	}
 
+	//nolint:staticcheck // SA1019 TaskPoller replacement needs to be done holistically.
 	externalPoller := &testcore.TaskPoller{
 		Client:              s.FrontendClient(),
 		Namespace:           s.ExternalNamespace().String(),
@@ -358,6 +359,7 @@ func (s *CancelWorkflowSuite) TestRequestCancelWorkflowCommandExecution_TargetFi
 		}}, nil
 	}
 
+	//nolint:staticcheck // SA1019 TaskPoller replacement needs to be done holistically.
 	externalPoller := &testcore.TaskPoller{
 		Client:              s.FrontendClient(),
 		Namespace:           s.ExternalNamespace().String(),

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -812,7 +812,7 @@ func (s *NexusApiTestSuite) TestNexus_RespondNexusTaskMethods_VerifiesTaskTokenM
 	s.NoError(err)
 
 	_, err = s.GetTestCluster().FrontendClient().RespondNexusTaskCompleted(ctx, &workflowservice.RespondNexusTaskCompletedRequest{
-		Namespace: s.ForeignNamespace().String(),
+		Namespace: s.ExternalNamespace().String(),
 		Identity:  uuid.NewString(),
 		TaskToken: ttBytes,
 		Response:  &nexuspb.Response{},
@@ -820,7 +820,7 @@ func (s *NexusApiTestSuite) TestNexus_RespondNexusTaskMethods_VerifiesTaskTokenM
 	s.ErrorContains(err, "Operation requested with a token from a different namespace.")
 
 	_, err = s.GetTestCluster().FrontendClient().RespondNexusTaskFailed(ctx, &workflowservice.RespondNexusTaskFailedRequest{
-		Namespace: s.ForeignNamespace().String(),
+		Namespace: s.ExternalNamespace().String(),
 		Identity:  uuid.NewString(),
 		TaskToken: ttBytes,
 		Error:     &nexuspb.HandlerError{},

--- a/tests/signal_workflow_test.go
+++ b/tests/signal_workflow_test.go
@@ -882,6 +882,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_WithoutRunID
 		}}, nil
 	}
 
+	//nolint:staticcheck // SA1019 TaskPoller replacement needs to be done holistically.
 	externalPoller := &testcore.TaskPoller{
 		Client:              s.FrontendClient(),
 		Namespace:           s.ExternalNamespace().String(),

--- a/tests/signal_workflow_test.go
+++ b/tests/signal_workflow_test.go
@@ -399,9 +399,9 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand() {
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
-	foreignRequest := &workflowservice.StartWorkflowExecutionRequest{
+	externalRequest := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.New(),
-		Namespace:           s.ForeignNamespace().String(),
+		Namespace:           s.ExternalNamespace().String(),
 		WorkflowId:          id,
 		WorkflowType:        workflowType,
 		TaskQueue:           taskQueue,
@@ -410,9 +410,9 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand() {
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we2, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), foreignRequest)
+	we2, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), externalRequest)
 	s.NoError(err0)
-	s.Logger.Info("StartWorkflowExecution on foreign Namespace", tag.WorkflowNamespace(s.ForeignNamespace().String()), tag.WorkflowRunID(we2.RunId))
+	s.Logger.Info("StartWorkflowExecution on external Namespace", tag.WorkflowNamespace(s.ExternalNamespace().String()), tag.WorkflowRunID(we2.RunId))
 
 	activityCount := int32(1)
 	activityCounter := int32(0)
@@ -445,7 +445,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand() {
 		return []*commandpb.Command{{
 			CommandType: enumspb.COMMAND_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION,
 			Attributes: &commandpb.Command_SignalExternalWorkflowExecutionCommandAttributes{SignalExternalWorkflowExecutionCommandAttributes: &commandpb.SignalExternalWorkflowExecutionCommandAttributes{
-				Namespace: s.ForeignNamespace().String(),
+				Namespace: s.ExternalNamespace().String(),
 				Execution: &commonpb.WorkflowExecution{
 					WorkflowId: id,
 					RunId:      we2.GetRunId(),
@@ -473,19 +473,19 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand() {
 	}
 
 	workflowComplete := false
-	foreignActivityCount := int32(1)
-	foreignActivityCounter := int32(0)
+	externalActivityCount := int32(1)
+	externalActivityCounter := int32(0)
 	var signalEvent *historypb.HistoryEvent
-	foreignwtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
-		if foreignActivityCounter < foreignActivityCount {
-			foreignActivityCounter++
+	externalWFTHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
+		if externalActivityCounter < externalActivityCount {
+			externalActivityCounter++
 			buf := new(bytes.Buffer)
-			s.Nil(binary.Write(buf, binary.LittleEndian, foreignActivityCounter))
+			s.Nil(binary.Write(buf, binary.LittleEndian, externalActivityCounter))
 
 			return []*commandpb.Command{{
 				CommandType: enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK,
 				Attributes: &commandpb.Command_ScheduleActivityTaskCommandAttributes{ScheduleActivityTaskCommandAttributes: &commandpb.ScheduleActivityTaskCommandAttributes{
-					ActivityId:             convert.Int32ToString(foreignActivityCounter),
+					ActivityId:             convert.Int32ToString(externalActivityCounter),
 					ActivityType:           &commonpb.ActivityType{Name: activityName},
 					TaskQueue:              &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					Input:                  payloads.EncodeBytes(buf.Bytes()),
@@ -513,31 +513,31 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand() {
 		}}, nil
 	}
 
-	foreignPoller := &testcore.TaskPoller{
+	externalPoller := &testcore.TaskPoller{
 		Client:              s.FrontendClient(),
-		Namespace:           s.ForeignNamespace().String(),
+		Namespace:           s.ExternalNamespace().String(),
 		TaskQueue:           taskQueue,
 		Identity:            identity,
-		WorkflowTaskHandler: foreignwtHandler,
+		WorkflowTaskHandler: externalWFTHandler,
 		ActivityTaskHandler: atHandler,
 		Logger:              s.Logger,
 		T:                   s.T(),
 	}
 
-	// Start both current and foreign workflows to make some progress.
+	// Start both current and external workflows to make some progress.
 	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = foreignPoller.PollAndProcessWorkflowTask()
-	s.Logger.Info("foreign PollAndProcessWorkflowTask", tag.Error(err))
+	_, err = externalPoller.PollAndProcessWorkflowTask()
+	s.Logger.Info("external PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	err = foreignPoller.PollAndProcessActivityTask(false)
-	s.Logger.Info("foreign PollAndProcessActivityTask", tag.Error(err))
+	err = externalPoller.PollAndProcessActivityTask(false)
+	s.Logger.Info("external PollAndProcessActivityTask", tag.Error(err))
 	s.NoError(err)
 
-	// Signal the foreign workflow with this command.
+	// Signal the external workflow with this command.
 	_, err = poller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
@@ -574,8 +574,8 @@ CheckHistoryLoopForSignalSent:
  11 ExternalWorkflowExecutionSignaled {"InitiatedEventId":10,"WorkflowExecution":{"RunId":"%s","WorkflowId":"%s"}}
  12 WorkflowTaskScheduled`, we2.RunId, id), historyEvents)
 
-	// Process signal in workflow for foreign workflow
-	_, err = foreignPoller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
+	// Process signal in workflow for external workflow
+	_, err = externalPoller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -771,9 +771,9 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_WithoutRunID
 	s.NoError(err0)
 	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
-	foreignRequest := &workflowservice.StartWorkflowExecutionRequest{
+	externalRequest := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.New(),
-		Namespace:           s.ForeignNamespace().String(),
+		Namespace:           s.ExternalNamespace().String(),
 		WorkflowId:          id,
 		WorkflowType:        workflowType,
 		TaskQueue:           taskQueue,
@@ -782,9 +782,9 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_WithoutRunID
 		WorkflowTaskTimeout: durationpb.New(1 * time.Second),
 		Identity:            identity,
 	}
-	we2, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), foreignRequest)
+	we2, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), externalRequest)
 	s.NoError(err0)
-	s.Logger.Info("StartWorkflowExecution on foreign Namespace", tag.WorkflowNamespace(s.ForeignNamespace().String()), tag.WorkflowRunID(we2.RunId))
+	s.Logger.Info("StartWorkflowExecution on external Namespace", tag.WorkflowNamespace(s.ExternalNamespace().String()), tag.WorkflowRunID(we2.RunId))
 
 	activityCount := int32(1)
 	activityCounter := int32(0)
@@ -814,7 +814,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_WithoutRunID
 		return []*commandpb.Command{{
 			CommandType: enumspb.COMMAND_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION,
 			Attributes: &commandpb.Command_SignalExternalWorkflowExecutionCommandAttributes{SignalExternalWorkflowExecutionCommandAttributes: &commandpb.SignalExternalWorkflowExecutionCommandAttributes{
-				Namespace: s.ForeignNamespace().String(),
+				Namespace: s.ExternalNamespace().String(),
 				Execution: &commonpb.WorkflowExecution{
 					WorkflowId: id,
 					// No RunID in command
@@ -841,19 +841,19 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_WithoutRunID
 	}
 
 	workflowComplete := false
-	foreignActivityCount := int32(1)
-	foreignActivityCounter := int32(0)
+	externalActivityCount := int32(1)
+	externalActivityCounter := int32(0)
 	var signalEvent *historypb.HistoryEvent
-	foreignwtHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
-		if foreignActivityCounter < foreignActivityCount {
-			foreignActivityCounter++
+	externalWFTHandler := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
+		if externalActivityCounter < externalActivityCount {
+			externalActivityCounter++
 			buf := new(bytes.Buffer)
-			s.Nil(binary.Write(buf, binary.LittleEndian, foreignActivityCounter))
+			s.Nil(binary.Write(buf, binary.LittleEndian, externalActivityCounter))
 
 			return []*commandpb.Command{{
 				CommandType: enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK,
 				Attributes: &commandpb.Command_ScheduleActivityTaskCommandAttributes{ScheduleActivityTaskCommandAttributes: &commandpb.ScheduleActivityTaskCommandAttributes{
-					ActivityId:             convert.Int32ToString(foreignActivityCounter),
+					ActivityId:             convert.Int32ToString(externalActivityCounter),
 					ActivityType:           &commonpb.ActivityType{Name: activityName},
 					TaskQueue:              &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 					Input:                  payloads.EncodeBytes(buf.Bytes()),
@@ -881,31 +881,31 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_WithoutRunID
 		}}, nil
 	}
 
-	foreignPoller := &testcore.TaskPoller{
+	externalPoller := &testcore.TaskPoller{
 		Client:              s.FrontendClient(),
-		Namespace:           s.ForeignNamespace().String(),
+		Namespace:           s.ExternalNamespace().String(),
 		TaskQueue:           taskQueue,
 		Identity:            identity,
-		WorkflowTaskHandler: foreignwtHandler,
+		WorkflowTaskHandler: externalWFTHandler,
 		ActivityTaskHandler: atHandler,
 		Logger:              s.Logger,
 		T:                   s.T(),
 	}
 
-	// Start both current and foreign workflows to make some progress.
+	// Start both current and external workflows to make some progress.
 	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = foreignPoller.PollAndProcessWorkflowTask()
-	s.Logger.Info("foreign PollAndProcessWorkflowTask", tag.Error(err))
+	_, err = externalPoller.PollAndProcessWorkflowTask()
+	s.Logger.Info("external PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	err = foreignPoller.PollAndProcessActivityTask(false)
-	s.Logger.Info("foreign PollAndProcessActivityTask", tag.Error(err))
+	err = externalPoller.PollAndProcessActivityTask(false)
+	s.Logger.Info("external PollAndProcessActivityTask", tag.Error(err))
 	s.NoError(err)
 
-	// Signal the foreign workflow with this command.
+	// Signal the external workflow with this command.
 	_, err = poller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
@@ -943,8 +943,8 @@ CheckHistoryLoopForSignalSent:
  11 ExternalWorkflowExecutionSignaled {"InitiatedEventId":10,"WorkflowExecution":{"RunId":"","WorkflowId":"%s"}}
  12 WorkflowTaskScheduled`, id), historyEvents)
 
-	// Process signal in workflow for foreign workflow
-	_, err = foreignPoller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
+	// Process signal in workflow for external workflow
+	_, err = externalPoller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1009,7 +1009,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_UnKnownTarge
 		return []*commandpb.Command{{
 			CommandType: enumspb.COMMAND_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION,
 			Attributes: &commandpb.Command_SignalExternalWorkflowExecutionCommandAttributes{SignalExternalWorkflowExecutionCommandAttributes: &commandpb.SignalExternalWorkflowExecutionCommandAttributes{
-				Namespace: s.ForeignNamespace().String(),
+				Namespace: s.ExternalNamespace().String(),
 				Execution: &commonpb.WorkflowExecution{
 					WorkflowId: "workflow_not_exist",
 					RunId:      we.GetRunId(),
@@ -1040,7 +1040,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_UnKnownTarge
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	// Signal the foreign workflow with this command.
+	// Signal the external workflow with this command.
 	_, err = poller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
@@ -1162,7 +1162,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand_SignalSelf()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	// Signal the foreign workflow with this command.
+	// Signal the external workflow with this command.
 	_, err = poller.PollAndProcessWorkflowTask(testcore.WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)

--- a/tests/signal_workflow_test.go
+++ b/tests/signal_workflow_test.go
@@ -513,6 +513,7 @@ func (s *SignalWorkflowTestSuite) TestSignalExternalWorkflowCommand() {
 		}}, nil
 	}
 
+	//nolint:staticcheck // SA1019 TaskPoller replacement needs to be done holistically.
 	externalPoller := &testcore.TaskPoller{
 		Client:              s.FrontendClient(),
 		Namespace:           s.ExternalNamespace().String(),

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -66,10 +66,9 @@ type (
 		// TODO (alex): this doesn't have to be a separate field. All usages can be replaced with values from testCluster itself.
 		testClusterConfig *TestClusterConfig
 
-		namespace   namespace.Name
-		namespaceID namespace.ID
-		// TODO (alex): rename to externalNamespace
-		foreignNamespace namespace.Name
+		namespace         namespace.Name
+		namespaceID       namespace.ID
+		externalNamespace namespace.Name
 
 		// Fields used by SDK based tests.
 		sdkClient sdkclient.Client
@@ -181,8 +180,8 @@ func (s *FunctionalTestBase) NamespaceID() namespace.ID {
 	return s.namespaceID
 }
 
-func (s *FunctionalTestBase) ForeignNamespace() namespace.Name {
-	return s.foreignNamespace
+func (s *FunctionalTestBase) ExternalNamespace() namespace.Name {
+	return s.externalNamespace
 }
 
 func (s *FunctionalTestBase) FrontendGRPCAddress() string {
@@ -257,8 +256,8 @@ func (s *FunctionalTestBase) SetupSuiteWithCluster(options ...TestClusterOption)
 	s.namespaceID, err = s.RegisterNamespace(s.Namespace(), 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
 	s.Require().NoError(err)
 
-	s.foreignNamespace = namespace.Name(RandomizeStr("foreign-namespace"))
-	_, err = s.RegisterNamespace(s.ForeignNamespace(), 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
+	s.externalNamespace = namespace.Name(RandomizeStr("external-namespace"))
+	_, err = s.RegisterNamespace(s.ExternalNamespace(), 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
 	s.Require().NoError(err)
 }
 
@@ -361,7 +360,7 @@ func (s *FunctionalTestBase) setupSdk() {
 
 func (s *FunctionalTestBase) TearDownCluster() {
 	s.Require().NoError(s.MarkNamespaceAsDeleted(s.Namespace()))
-	s.Require().NoError(s.MarkNamespaceAsDeleted(s.ForeignNamespace()))
+	s.Require().NoError(s.MarkNamespaceAsDeleted(s.ExternalNamespace()))
 
 	if s.testCluster != nil {
 		s.Require().NoError(s.testCluster.TearDownCluster())


### PR DESCRIPTION
## What changed?
Refactor: rename `foreignNamespace` to `externalNamespace`.

## Why?
Better readability.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
