### PR TITLE
Creates additional S3 directory structures for optimized historical data retrieval.

### DIFF
--- a/common/archiver/s3store/query_parser_test.go
+++ b/common/archiver/s3store/query_parser_test.go
@@ -22,7 +22,7 @@ func TestQueryParserSuite(t *testing.T) {
 
 func (s *queryParserSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
-	s.parser = NewQueryParser()
+	s.parser = NewQueryParser(false)
 }
 
 func (s *queryParserSuite) TestParseWorkflowIDAndWorkflowTypeName() {

--- a/common/archiver/s3store/visibility_archiver_test.go
+++ b/common/archiver/s3store/visibility_archiver_test.go
@@ -97,7 +97,7 @@ func (s *visibilityArchiverSuite) newTestVisibilityArchiver() *visibilityArchive
 		logger:         s.logger,
 		metricsHandler: s.metricsHandler,
 		s3cli:          s.s3cli,
-		queryParser:    NewQueryParser(),
+		queryParser:    NewQueryParser(false),
 	}
 }
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -508,10 +508,11 @@ type (
 
 	// S3Archiver contains the config for S3 archiver
 	S3Archiver struct {
-		Region           string  `yaml:"region"`
-		Endpoint         *string `yaml:"endpoint"`
-		S3ForcePathStyle bool    `yaml:"s3ForcePathStyle"`
-		LogLevel         uint    `yaml:"logLevel"`
+		Region               string  `yaml:"region"`
+		Endpoint             *string `yaml:"endpoint"`
+		S3ForcePathStyle     bool    `yaml:"s3ForcePathStyle"`
+		WithSearchAttributes bool    `yaml:"withSearchAttributes"`
+		LogLevel             uint    `yaml:"logLevel"`
 	}
 
 	// PublicClient is the config for internal nodes (history/matching/worker) connecting to


### PR DESCRIPTION
In archival process temporal creates two paths in S3 visibility storage for start and close time attributes. 

## What changed?
In archival configuration added withSearchAttributes (boolean) to enable/disable extended search functionality.  VisibilityArchiver creates additional hierarchical paths in S3 based on SearchAttributes from the archive request. The query parser now accepts filters for these SearchAttributes in combination with workflowTypeName.

## Why?
Searching workflows by other attributes becomes inefficient, as these queries require full scans instead of leveraging optimized S3 paths.

## How did you test it?
- [v ] built
- [v ] run locally and tested manually
- [v ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
More disk space is required to store data in S3.
