### PR TITLE
fixing workflow_query_success_count tag mismatch

### DIFF
--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -425,7 +425,7 @@ func WorkflowStatusTag(status string) Tag {
 
 func QueryTypeTag(queryType string) Tag {
 	if queryType == queryTypeStackTrace || queryType == queryTypeOpenSessions || queryType == queryTypeWorkflowMetadata {
-		return &tagImpl{key: queryType, value: queryType}
+		return &tagImpl{key: queryTypeTag, value: queryType}
 	}
 	// group all user defined queries into a single tag value
 	return &tagImpl{key: queryTypeTag, value: queryTypeUserDefined}


### PR DESCRIPTION
## What changed?
- nightly pipelines caught that the workflow_query_success_count was being emitted with variable tag key for non user-defined query types


## Why?
- to make these pipelines pass

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- None
