### PR TITLE
Use existing replication task encoding

### DIFF
--- a/service/history/ndc/replication_task.go
+++ b/service/history/ndc/replication_task.go
@@ -1,6 +1,7 @@
 package ndc
 
 import (
+	"cmp"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -519,8 +520,7 @@ func deserializeBlob(
 	if blob == nil {
 		return nil, nil
 	}
-
-	blob.EncodingType = enumspb.ENCODING_TYPE_PROTO3
+	blob.EncodingType = cmp.Or(blob.EncodingType, enumspb.ENCODING_TYPE_PROTO3)
 	return historySerializer.DeserializeEvents(blob)
 }
 
@@ -533,7 +533,7 @@ func DeserializeBlobs(
 		return eventBatches, nil
 	}
 	for _, blob := range blobs {
-		blob.EncodingType = enumspb.ENCODING_TYPE_PROTO3
+		blob.EncodingType = cmp.Or(blob.EncodingType, enumspb.ENCODING_TYPE_PROTO3)
 		events, err := historySerializer.DeserializeEvents(blob)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## What changed?

Use assigned encoding type if it's not undefined. Enforce proto encoding otherwise.

## Why?

My long-term goal is to make JSON encoding for persistence payload a working alternative to proto encoding (for debugging purposes only!).

This change allows JSON encoding here by not enforcing proto encoding.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

If was inclined to remove the line altogether, but I wasn't sure whether that's a risk or not. So I took the safe approach.