### PR TITLE
persistence: log shard-id when reporting possible data loss

### DIFF
--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -915,6 +915,7 @@ func (m *executionManagerImpl) readHistoryBranch(
 	dataLossTags := func(cause string) []tag.Tag {
 		return []tag.Tag{
 			tag.Cause(cause),
+			tag.ShardID(request.ShardID),
 			tag.WorkflowBranchToken(request.BranchToken),
 			tag.WorkflowFirstEventID(firstEvent.GetEventId()),
 			tag.FirstEventVersion(firstEvent.GetVersion()),


### PR DESCRIPTION
## What changed?

I've added the `ShardID` to our potential data loss log tags

## Why?

We've wanted this in the past and we'll want it in the future