### PR TITLE
Improve error message for aborted Update

### DIFF
--- a/docs/architecture/workflow-update.md
+++ b/docs/architecture/workflow-update.md
@@ -161,7 +161,7 @@ An Update is aborted when:
 1. The Update Registry is cleared. Then, a retryable `WorkflowUpdateAbortedErr` error is returned
    (see "Update Registry Lifecycle" above).
 2. The Workflow completes itself (e.g., with `COMPLETE_WORKFLOW_EXECUTION` command) or completed externally
-   (e.g., terminated or timed out). Then, a non-retryable `WorkflowCompletedErr` error or failure is returned
+   (e.g., terminated or timed out). Then, a non-retryable `AbortedByWorkflowClosingErr` error or failure is returned
    to the API caller depending on an Update state.
 3. The Workflow is continuing (e.g., with `CONTINUE_AS_NEW_WORKFLOW_EXECUTION` command) or is retried after
    failure or timeout. Then, a retryable `ErrWorkflowClosing` error or failure is returned to the API caller
@@ -175,10 +175,10 @@ Full "Update state" and "Abort reason" matrix is the following:
 
 | Update State ↓ / Abort Reason →         | (1) RegistryCleared                             | (2) WorkflowCompleted                    | (3) WorkflowContinuing                   | (4) WorkflowTaskFailed                          |
 |-----------------------------------------|-------------------------------------------------|------------------------------------------|------------------------------------------|-------------------------------------------------|
-| **Created**                             | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `WorkflowCompletedErr`                   | `ErrWorkflowClosing`                     | `registryClearedErr`→`WorkflowUpdateAbortedErr` |
-| **ProvisionallyAdmitted**               | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `WorkflowCompletedErr`                   | `ErrWorkflowClosing`                     | `registryClearedErr`→`WorkflowUpdateAbortedErr` |
-| **Admitted**                            | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `WorkflowCompletedErr`                   | `ErrWorkflowClosing`                     | `registryClearedErr`→`WorkflowUpdateAbortedErr` |
-| **Sent**                                | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `WorkflowCompletedErr`                   | `ErrWorkflowClosing`                     | `workflowTaskFailErr`                           |
+| **Created**                             | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `AbortedByWorkflowClosingErr`            | `ErrWorkflowClosing`                     | `registryClearedErr`→`WorkflowUpdateAbortedErr` |
+| **ProvisionallyAdmitted**               | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `AbortedByWorkflowClosingErr`            | `ErrWorkflowClosing`                     | `registryClearedErr`→`WorkflowUpdateAbortedErr` |
+| **Admitted**                            | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `AbortedByWorkflowClosingErr`            | `ErrWorkflowClosing`                     | `registryClearedErr`→`WorkflowUpdateAbortedErr` |
+| **Sent**                                | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `AbortedByWorkflowClosingErr`            | `ErrWorkflowClosing`                     | `workflowTaskFailErr`                           |
 | **ProvisionallyAccepted**               | `registryClearedErr`→`WorkflowUpdateAbortedErr` | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` | `nil`                                           |
 | **Accepted**                            | `registryClearedErr`→`nil`                      | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` | `nil`                                           |
 | **ProvisionallyCompleted**              | `registryClearedErr`→`nil`                      | `acceptedUpdateCompletedWorkflowFailure` | `acceptedUpdateCompletedWorkflowFailure` | `nil`                                           |
@@ -188,7 +188,7 @@ Full "Update state" and "Abort reason" matrix is the following:
 | **Aborted**                             | `nil`                                           | `nil`                                    | `nil`                                    | `nil`                                           |
 
 When the Workflow performs a final completion, all in-flight Updates are aborted: admitted Updates get
-`WorkflowCompletedErr` error on both `accepted` and `completed` futures. Accepted Updates
+`AbortedByWorkflowClosingErr` error on both `accepted` and `completed` futures. Accepted Updates
 are failed with special server `acceptedUpdateCompletedWorkflowFailure` failure because if a client
 knows that Update has been accepted, it expects any following requests to return an Update result
 (or failure) but not an error. This failure is set on the `completed` future only. 

--- a/service/history/workflow/update/abort_reason.go
+++ b/service/history/workflow/update/abort_reason.go
@@ -49,10 +49,10 @@ var reasonStateMatrix = map[reasonState]failureError{
 	reasonState{r: AbortReasonRegistryCleared, st: stateAborted}:              {f: nil, err: nil},
 
 	// If the Workflow is completed, then pre-accepted Updates are aborted with non-retryable error.
-	reasonState{r: AbortReasonWorkflowCompleted, st: stateCreated}:               {f: nil, err: WorkflowCompletedErr},
-	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyAdmitted}: {f: nil, err: WorkflowCompletedErr},
-	reasonState{r: AbortReasonWorkflowCompleted, st: stateAdmitted}:              {f: nil, err: WorkflowCompletedErr},
-	reasonState{r: AbortReasonWorkflowCompleted, st: stateSent}:                  {f: nil, err: WorkflowCompletedErr},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateCreated}:               {f: nil, err: AbortedByWorkflowClosingErr},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateProvisionallyAdmitted}: {f: nil, err: AbortedByWorkflowClosingErr},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateAdmitted}:              {f: nil, err: AbortedByWorkflowClosingErr},
+	reasonState{r: AbortReasonWorkflowCompleted, st: stateSent}:                  {f: nil, err: AbortedByWorkflowClosingErr},
 	// Accepted Updates are failed with special server failure because if a client knows that Update has been accepted,
 	// it expects any following requests to return an Update result (or failure) but not an error.
 	// There can be different types of Update failures coming from worker and a client must handle them anyway.

--- a/service/history/workflow/update/errors_failures.go
+++ b/service/history/workflow/update/errors_failures.go
@@ -8,10 +8,10 @@ import (
 )
 
 var (
-	registryClearedErr       = errors.New("update registry was cleared")
-	WorkflowUpdateAbortedErr = serviceerror.NewUnavailable("workflow update was aborted")
-	WorkflowCompletedErr     = serviceerror.NewNotFound("workflow update was aborted by closing workflow")
-	workflowTaskFailErr      = serviceerror.NewWorkflowNotReady("Unable to perform workflow execution update due to unexpected workflow task failure.")
+	registryClearedErr          = errors.New("update registry was cleared")
+	AbortedByServerErr          = serviceerror.NewUnavailable("workflow update was aborted")
+	AbortedByWorkflowClosingErr = serviceerror.NewNotFound("workflow update was aborted by closing workflow")
+	workflowTaskFailErr         = serviceerror.NewWorkflowNotReady("Unable to perform workflow execution update due to unexpected workflow task failure.")
 )
 
 var (

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -671,7 +671,7 @@ func TestAbort(t *testing.T) {
 	upd1 := reg.Find(context.Background(), tv.WithUpdateIDNumber(1).UpdateID())
 	require.NotNil(t, upd1)
 	status1, err := upd1.WaitLifecycleStage(context.Background(), 0, 2*time.Second)
-	require.Equal(t, update.WorkflowCompletedErr, err)
+	require.Equal(t, update.AbortedByWorkflowClosingErr, err)
 	require.Nil(t, status1)
 
 	upd2 := reg.Find(context.Background(), tv.WithUpdateIDNumber(2).UpdateID())
@@ -708,7 +708,7 @@ func TestClear(t *testing.T) {
 		defer wg.Done()
 		_, err := upd.WaitLifecycleStage(
 			context.Background(), enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, 2*time.Second)
-		require.Equal(t, update.WorkflowUpdateAbortedErr, err)
+		require.Equal(t, update.AbortedByServerErr, err)
 	}()
 
 	reg.Clear()

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -222,7 +222,7 @@ func (u *Update) WaitLifecycleStage(
 	// This error will be retried (by history service handler, or history service client in frontend,
 	// or SDK, or user client). This will recreate Update in the Registry.
 	if errors.Is(err, registryClearedErr) {
-		return nil, WorkflowUpdateAbortedErr
+		return nil, AbortedByServerErr
 	}
 
 	// TODO: assert(err == nil)

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -165,16 +165,16 @@ func TestUpdateState(t *testing.T) {
 					}()
 
 					err := admit(t, readonlyStore, upd) // NOTE the store!
-					require.ErrorIs(t, update.WorkflowCompletedErr, err)
+					require.ErrorIs(t, update.AbortedByWorkflowClosingErr, err)
 					effects.Apply(context.Background())
 
 					// ensure waiter received response
 					waiterRes := <-ch
-					require.EqualExportedValues(t, update.WorkflowCompletedErr, waiterRes)
+					require.EqualExportedValues(t, update.AbortedByWorkflowClosingErr, waiterRes)
 
 					// new waiter receives same response
 					_, err = upd.WaitLifecycleStage(immediateCtx, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, immediateTimeout)
-					require.ErrorIs(t, err, update.WorkflowCompletedErr)
+					require.ErrorIs(t, err, update.AbortedByWorkflowClosingErr)
 				},
 			}, {
 				title:        "fail to transition to stateSent",
@@ -208,14 +208,14 @@ func TestUpdateState(t *testing.T) {
 				apply: func() {
 					abort(t, store, upd, update.AbortReasonRegistryCleared)
 					effects.Apply(context.Background())
-					assertAborted(t, upd, update.WorkflowUpdateAbortedErr)
+					assertAborted(t, upd, update.AbortedByServerErr)
 				},
 			}, {
 				title: "aborted because Workflow completed",
 				apply: func() {
 					abort(t, store, upd, update.AbortReasonWorkflowCompleted)
 					effects.Apply(context.Background())
-					assertAborted(t, upd, update.WorkflowCompletedErr)
+					assertAborted(t, upd, update.AbortedByWorkflowClosingErr)
 				},
 			}, {
 				title: "aborted because Workflow completing",
@@ -308,14 +308,14 @@ func TestUpdateState(t *testing.T) {
 				apply: func() {
 					abort(t, store, upd, update.AbortReasonRegistryCleared)
 					effects.Apply(context.Background())
-					assertAborted(t, upd, update.WorkflowUpdateAbortedErr)
+					assertAborted(t, upd, update.AbortedByServerErr)
 				},
 			}, {
 				title: "aborted because Workflow completed",
 				apply: func() {
 					abort(t, store, upd, update.AbortReasonWorkflowCompleted)
 					effects.Apply(context.Background())
-					assertAborted(t, upd, update.WorkflowCompletedErr)
+					assertAborted(t, upd, update.AbortedByWorkflowClosingErr)
 				},
 			}, {
 				title: "aborted because Workflow completing",
@@ -441,16 +441,16 @@ func TestUpdateState(t *testing.T) {
 					effects.Apply(context.Background())
 
 					status, err := upd.WaitLifecycleStage(immediateCtx, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED, immediateTimeout)
-					require.ErrorIs(t, err, update.WorkflowCompletedErr)
+					require.ErrorIs(t, err, update.AbortedByWorkflowClosingErr)
 					require.Nil(t, status)
 
 					// ensure waiter received response
 					waiterRes := <-ch
-					require.EqualExportedValues(t, update.WorkflowCompletedErr, waiterRes)
+					require.EqualExportedValues(t, update.AbortedByWorkflowClosingErr, waiterRes)
 
 					// new waiter still sees same result
 					_, err = upd.WaitLifecycleStage(immediateCtx, UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, immediateTimeout)
-					require.EqualExportedValues(t, update.WorkflowCompletedErr, err)
+					require.EqualExportedValues(t, update.AbortedByWorkflowClosingErr, err)
 				},
 			}, {
 				title: "transition to stateRejected",
@@ -635,14 +635,14 @@ func TestUpdateState(t *testing.T) {
 				apply: func() {
 					abort(t, store, upd, update.AbortReasonRegistryCleared)
 					effects.Apply(context.Background())
-					assertAborted(t, upd, update.WorkflowUpdateAbortedErr)
+					assertAborted(t, upd, update.AbortedByServerErr)
 				},
 			}, {
 				title: "aborted because Workflow completed",
 				apply: func() {
 					abort(t, store, upd, update.AbortReasonWorkflowCompleted)
 					effects.Apply(context.Background())
-					assertAborted(t, upd, update.WorkflowCompletedErr)
+					assertAborted(t, upd, update.AbortedByWorkflowClosingErr)
 				},
 			}, {
 				title: "aborted because Workflow completing",

--- a/tests/client_misc_test.go
+++ b/tests/client_misc_test.go
@@ -579,7 +579,7 @@ func (s *ClientMiscTestSuite) TestWorkflowCanBeCompletedDespiteAdmittedUpdate() 
 	s.Error(updateErr)
 	var notFound *serviceerror.NotFound
 	s.ErrorAs(updateErr, &notFound)
-	s.ErrorContains(updateErr, update.WorkflowCompletedErr.Error())
+	s.ErrorContains(updateErr, update.AbortedByWorkflowClosingErr.Error())
 	updateHandle := <-updateHandleCh
 	s.Nil(updateHandle)
 	// Uncomment the following when durable admitted is implemented.

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -2953,7 +2953,7 @@ func (s *UpdateWorkflowSuite) TestStartedSpeculativeWorkflowTask_TerminateWorkfl
 	s.Error(updateResult.err)
 	var notFound *serviceerror.NotFound
 	s.ErrorAs(updateResult.err, &notFound)
-	s.ErrorContains(updateResult.err, update.WorkflowCompletedErr.Error())
+	s.ErrorContains(updateResult.err, update.AbortedByWorkflowClosingErr.Error())
 	s.Nil(updateResult.response)
 
 	s.Equal(2, wtHandlerCalls)
@@ -3040,7 +3040,7 @@ func (s *UpdateWorkflowSuite) TestScheduledSpeculativeWorkflowTask_TerminateWork
 	s.Error(updateResult.err)
 	var notFound *serviceerror.NotFound
 	s.ErrorAs(updateResult.err, &notFound)
-	s.ErrorContains(updateResult.err, update.WorkflowCompletedErr.Error())
+	s.ErrorContains(updateResult.err, update.AbortedByWorkflowClosingErr.Error())
 	s.Nil(updateResult.response)
 
 	s.Equal(1, wtHandlerCalls)
@@ -3084,10 +3084,10 @@ func (s *UpdateWorkflowSuite) TestCompleteWorkflow_AbortUpdates() {
 			name:        "update admitted",
 			description: "update in stateAdmitted must get an error",
 			updateErr: map[string]string{
-				"workflow completed":                      update.WorkflowCompletedErr.Error(),
+				"workflow completed":                      update.AbortedByWorkflowClosingErr.Error(),
 				"workflow continued as new without runID": "workflow operation can not be applied because workflow is closing",
 				"workflow continued as new with runID":    "workflow operation can not be applied because workflow is closing",
-				"workflow failed":                         update.WorkflowCompletedErr.Error(),
+				"workflow failed":                         update.AbortedByWorkflowClosingErr.Error(),
 			},
 			updateFailure: "",
 			commands:      func(_ *testvars.TestVars) []*commandpb.Command { return nil },


### PR DESCRIPTION
## What changed?

Improve the error message for an Update that is aborted by a closing workflow.

## Why?

To make it easier for users to understand what happend; and for devs to debug it easier.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

Very low as the service error _type_ is still the same (NotFound).