### PR TITLE
Do not bypass task generation when version changes

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -535,11 +535,10 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 				}
 			}
 		}
-		pollerDeployment := worker_versioning.DeploymentFromDeploymentVersion(worker_versioning.DeploymentVersionFromOptions(request.GetDeploymentOptions()))
-		wfDeployment := ms.GetEffectiveDeployment()
-		if !pollerDeployment.Equal(wfDeployment) {
-			// Do not return new wft to worker if it's version does not match wf's
-			// let the task go through matching and get dispatched to the right worker
+
+		if ms.GetDeploymentTransition() != nil {
+			// Do not return new wft to worker if the workflow is transitioning to a different deployment version.
+			// Let the task go through matching and get dispatched to the right worker
 			bypassTaskGeneration = false
 		}
 

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -535,6 +535,13 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 				}
 			}
 		}
+		pollerDeployment := worker_versioning.DeploymentFromDeploymentVersion(worker_versioning.DeploymentVersionFromOptions(request.GetDeploymentOptions()))
+		wfDeployment := ms.GetEffectiveDeployment()
+		if !pollerDeployment.Equal(wfDeployment) {
+			// Do not return new wft to worker if it's version does not match wf's
+			// let the task go through matching and get dispatched to the right worker
+			bypassTaskGeneration = false
+		}
 
 		var newWTErr error
 		// If we checked WT heartbeat timeout before and WT wasn't timed out,


### PR DESCRIPTION
## What changed?
Server sends new wft in response of preious wft completion. This should not happen if the next wft is supposed to go to a different worker version.

## Why?
When there is a transition, workflow could fall into an infinite loop of workflow tasks because they never go to the right worker.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
will be verified in Nightlies.

## Potential risks
None
