### PR TITLE
CHASM: support full task refresh

### DIFF
--- a/chasm/test_component_test.go
+++ b/chasm/test_component_test.go
@@ -45,7 +45,7 @@ type (
 
 	TestSubComponent2 struct {
 		UnimplementedComponent
-		SubComponent2Data protoMessageType
+		SubComponent2Data *protoMessageType
 	}
 
 	TestSubComponent interface {

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -1644,11 +1644,11 @@ func (n *Node) resetTaskStatus() bool {
 	}
 
 	reset := false
-	for _, tasks := range [][]*persistencespb.ChasmComponentAttributes_Task{
+	for _, componentTasks := range [][]*persistencespb.ChasmComponentAttributes_Task{
 		componentAttr.PureTasks,
 		componentAttr.SideEffectTasks,
 	} {
-		for _, t := range tasks {
+		for _, t := range componentTasks {
 			if !reset && t.PhysicalTaskStatus == physicalTaskStatusCreated {
 				reset = true
 			}

--- a/service/history/interfaces/chasm_tree.go
+++ b/service/history/interfaces/chasm_tree.go
@@ -19,6 +19,8 @@ type ChasmTree interface {
 	Snapshot(*persistencespb.VersionedTransition) chasm.NodesSnapshot
 	ApplyMutation(chasm.NodesMutation) error
 	ApplySnapshot(chasm.NodesSnapshot) error
+	RefreshTasks() error
+	IsStateDirty() bool
 	IsDirty() bool
 	Terminate(chasm.TerminateComponentRequest) error
 	Archetype() string

--- a/service/history/interfaces/chasm_tree_mock.go
+++ b/service/history/interfaces/chasm_tree_mock.go
@@ -171,6 +171,34 @@ func (mr *MockChasmTreeMockRecorder) IsStale(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStale", reflect.TypeOf((*MockChasmTree)(nil).IsStale), arg0)
 }
 
+// IsStateDirty mocks base method.
+func (m *MockChasmTree) IsStateDirty() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsStateDirty")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsStateDirty indicates an expected call of IsStateDirty.
+func (mr *MockChasmTreeMockRecorder) IsStateDirty() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStateDirty", reflect.TypeOf((*MockChasmTree)(nil).IsStateDirty))
+}
+
+// RefreshTasks mocks base method.
+func (m *MockChasmTree) RefreshTasks() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshTasks")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RefreshTasks indicates an expected call of RefreshTasks.
+func (mr *MockChasmTreeMockRecorder) RefreshTasks() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshTasks", reflect.TypeOf((*MockChasmTree)(nil).RefreshTasks))
+}
+
 // Snapshot mocks base method.
 func (m *MockChasmTree) Snapshot(arg0 *persistence.VersionedTransition) chasm.NodesSnapshot {
 	m.ctrl.T.Helper()

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -6023,7 +6023,7 @@ func (ms *MutableStateImpl) isStateDirty() bool {
 		ms.executionStateUpdated ||
 		ms.workflowTaskUpdated ||
 		(ms.stateMachineNode != nil && ms.stateMachineNode.Dirty()) ||
-		ms.chasmTree.IsDirty() ||
+		ms.chasmTree.IsStateDirty() ||
 		ms.isResetStateUpdated
 }
 

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -2585,7 +2585,7 @@ func (s *mutableStateSuite) TestCloseTransactionUpdateTransition() {
 				mockChasmTree := historyi.NewMockChasmTree(s.controller)
 				mockChasmTree.EXPECT().Archetype().Return("mock-archetype").AnyTimes()
 				gomock.InOrder(
-					mockChasmTree.EXPECT().IsDirty().Return(true).AnyTimes(),
+					mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes(),
 					mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{
 						UpdatedNodes: map[string]*persistencespb.ChasmNode{
 							"node-path": {
@@ -4010,7 +4010,7 @@ func (s *mutableStateSuite) TestCloseTransactionTrackTombstones() {
 				mockChasmTree := historyi.NewMockChasmTree(s.controller)
 				mockChasmTree.EXPECT().Archetype().Return("mock-archetype").AnyTimes()
 				gomock.InOrder(
-					mockChasmTree.EXPECT().IsDirty().Return(true).AnyTimes(),
+					mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes(),
 					mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{
 						DeletedNodes: map[string]struct{}{deletedNodePath: {}},
 					}, nil),
@@ -4160,7 +4160,7 @@ func (s *mutableStateSuite) TestCloseTransactionGenerateCHASMRetentionTask() {
 	mutableState.chasmTree = mockChasmTree
 
 	// Not a workflow, should not generate retention task
-	mockChasmTree.EXPECT().IsDirty().Return(true).AnyTimes()
+	mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes()
 	mockChasmTree.EXPECT().Archetype().Return("").Times(1)
 	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{}, nil).AnyTimes()
 	mutation, _, err := mutableState.CloseTransactionAsMutation(historyi.TransactionPolicyActive)

--- a/service/history/workflow/noop_chasm_tree.go
+++ b/service/history/workflow/noop_chasm_tree.go
@@ -30,6 +30,14 @@ func (*noopChasmTree) ApplySnapshot(chasm.NodesSnapshot) error {
 	return nil
 }
 
+func (*noopChasmTree) RefreshTasks() error {
+	return nil
+}
+
+func (*noopChasmTree) IsStateDirty() bool {
+	return false
+}
+
 func (*noopChasmTree) IsDirty() bool {
 	return false
 }

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -30,6 +30,9 @@ type (
 		// it will be treated the same as lastUpdateVersionedTransition equals to EmptyVersionedTransition.
 		// The provided minVersionedTransition should NOT be nil, and if equals to EmptyVersionedTransition,
 		// the behavior is equivalent to Refresh().
+		//
+		// PartialRefresh does not refresh tasks for CHASM components as they are smart enough to figure out
+		// what tasks need to be generated when seeing a new version of the component.
 		PartialRefresh(
 			ctx context.Context,
 			mutableState historyi.MutableState,
@@ -67,7 +70,11 @@ func (r *TaskRefresherImpl) Refresh(
 		mutableState.GetExecutionInfo().TaskGenerationShardClockTimestamp = r.shard.CurrentVectorClock().GetClock()
 	}
 
-	return r.PartialRefresh(ctx, mutableState, EmptyVersionedTransition, nil)
+	if err := r.PartialRefresh(ctx, mutableState, EmptyVersionedTransition, nil); err != nil {
+		return err
+	}
+
+	return mutableState.ChasmTree().RefreshTasks()
 }
 
 func (r *TaskRefresherImpl) PartialRefresh(


### PR DESCRIPTION
## What changed?
- Support full task refresh

## Why?
- It is a very useful troubleshooting tool for handling lost tasks and unblock stuck state machines. With this case the existing `RefreshWorkflowTasks` API will work on CHASM run as well. Of course we may want to rename that api or create a new one.


- Full task refresh is also needed in replication stack under conflict resolution case as today's conflict resolution logic calls full refresh which updates the task generation lock and invalidates all previous generated tasks. 
    - We can do better in replication stack and use partial task refresh instead (e.g. refresh from lca of the versioned transition), and/or bypass some task refresh logic when the run is a CHASM run instead of workflow. But that's outside the scope of this PR. We need full task refresh any way and that happens to fix this particular replication issue as well.


## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
