### PR TITLE
Initial implementation for ListWorkers/RecordWorkerHeartbeat

### DIFF
--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/service"
 	"go.temporal.io/server/service/matching/configs"
+	"go.temporal.io/server/service/matching/workers"
 	"go.temporal.io/server/service/worker/deployment"
 	"go.temporal.io/server/service/worker/workerdeployment"
 	"go.uber.org/fx"
@@ -38,6 +39,7 @@ var Module = fx.Options(
 	fx.Provide(TelemetryInterceptorProvider),
 	fx.Provide(RateLimitInterceptorProvider),
 	fx.Provide(VisibilityManagerProvider),
+	fx.Provide(workers.NewRegistry),
 	fx.Provide(NewHandler),
 	fx.Provide(service.GrpcServerOptionsProvider),
 	fx.Provide(NamespaceReplicationQueueProvider),

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -7,7 +7,7 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
-	workersb "go.temporal.io/api/worker/v1"
+	workerpb "go.temporal.io/api/worker/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common"
@@ -554,9 +554,9 @@ func (h *Handler) ListWorkers(
 	if err != nil {
 		return nil, err
 	}
-	var workersInfo []*workersb.WorkerInfo
+	var workersInfo []*workerpb.WorkerInfo
 	for _, heartbeat := range workersHeartbeats {
-		workersInfo = append(workersInfo, &workersb.WorkerInfo{
+		workersInfo = append(workersInfo, &workerpb.WorkerInfo{
 			WorkerHeartbeat: heartbeat,
 		})
 	}

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -68,7 +68,7 @@ type (
 		SearchAttributeProvider       searchattribute.Provider
 		SearchAttributeMapperProvider searchattribute.MapperProvider
 		RateLimiter                   TaskDispatchRateLimiter `optional:"true"`
-		workersRegistry               workers.Registry
+		WorkersRegistry               workers.Registry
 	}
 )
 
@@ -112,7 +112,7 @@ func NewHandler(
 			params.RateLimiter,
 		),
 		namespaceRegistry: params.NamespaceRegistry,
-		workersRegistry:   params.workersRegistry,
+		workersRegistry:   params.WorkersRegistry,
 	}
 
 	// prevent from serving requests before matching engine is started and ready

--- a/service/matching/workers/registry.go
+++ b/service/matching/workers/registry.go
@@ -2,18 +2,18 @@ package workers
 
 import (
 	"go.temporal.io/api/serviceerror"
-	workersb "go.temporal.io/api/worker/v1"
+	workerpb "go.temporal.io/api/worker/v1"
 	"go.temporal.io/server/common/log"
 )
 
 type (
 	Registry interface {
-		RecordWorkerHeartbeat(nsID string, workerHeartbeat *workersb.WorkerHeartbeat)
-		ListWorkers(nsID string, queue string, nextPageToken []byte) ([]*workersb.WorkerHeartbeat, error)
+		RecordWorkerHeartbeat(nsID string, workerHeartbeat *workerpb.WorkerHeartbeat)
+		ListWorkers(nsID string, queue string, nextPageToken []byte) ([]*workerpb.WorkerHeartbeat, error)
 	}
 
 	registryImpl struct {
-		workersStore map[string]map[string]*workersb.WorkerHeartbeat
+		workersStore map[string]map[string]*workerpb.WorkerHeartbeat
 		logger       log.Logger
 	}
 )
@@ -21,26 +21,26 @@ type (
 // NewRegistry creates a new worker registry
 func NewRegistry(logger log.Logger) Registry {
 	return &registryImpl{
-		workersStore: make(map[string]map[string]*workersb.WorkerHeartbeat),
+		workersStore: make(map[string]map[string]*workerpb.WorkerHeartbeat),
 		logger:       logger,
 	}
 }
 
-func (r *registryImpl) RecordWorkerHeartbeat(nsID string, workerHeartbeat *workersb.WorkerHeartbeat) {
+func (r *registryImpl) RecordWorkerHeartbeat(nsID string, workerHeartbeat *workerpb.WorkerHeartbeat) {
 	if r.workersStore[nsID] == nil {
-		r.workersStore[nsID] = make(map[string]*workersb.WorkerHeartbeat)
+		r.workersStore[nsID] = make(map[string]*workerpb.WorkerHeartbeat)
 	}
 
 	r.workersStore[nsID][workerHeartbeat.WorkerInstanceKey] = workerHeartbeat
 }
 
-func (r *registryImpl) ListWorkers(nsID string, _ string, _ []byte) ([]*workersb.WorkerHeartbeat, error) {
+func (r *registryImpl) ListWorkers(nsID string, _ string, _ []byte) ([]*workerpb.WorkerHeartbeat, error) {
 	workerMap, exists := r.workersStore[nsID]
 	if !exists {
 		return nil, serviceerror.NewNamespaceNotFound(nsID)
 	}
 
-	heartbeats := make([]*workersb.WorkerHeartbeat, 0, len(workerMap))
+	heartbeats := make([]*workerpb.WorkerHeartbeat, 0, len(workerMap))
 	for _, heartbeat := range workerMap {
 		heartbeats = append(heartbeats, heartbeat)
 	}

--- a/service/matching/workers/registry.go
+++ b/service/matching/workers/registry.go
@@ -1,0 +1,49 @@
+package workers
+
+import (
+	"go.temporal.io/api/serviceerror"
+	workersb "go.temporal.io/api/worker/v1"
+	"go.temporal.io/server/common/log"
+)
+
+type (
+	Registry interface {
+		RecordWorkerHeartbeat(nsID string, workerHeartbeat *workersb.WorkerHeartbeat)
+		ListWorkers(nsID string, queue string, nextPageToken []byte) ([]*workersb.WorkerHeartbeat, error)
+	}
+
+	registryImpl struct {
+		workersStore map[string]map[string]*workersb.WorkerHeartbeat
+		logger       log.Logger
+	}
+)
+
+// NewRegistry creates a new worker registry
+func NewRegistry(logger log.Logger) Registry {
+	return &registryImpl{
+		workersStore: make(map[string]map[string]*workersb.WorkerHeartbeat),
+		logger:       logger,
+	}
+}
+
+func (r *registryImpl) RecordWorkerHeartbeat(nsID string, workerHeartbeat *workersb.WorkerHeartbeat) {
+	if r.workersStore[nsID] == nil {
+		r.workersStore[nsID] = make(map[string]*workersb.WorkerHeartbeat)
+	}
+
+	r.workersStore[nsID][workerHeartbeat.WorkerInstanceKey] = workerHeartbeat
+}
+
+func (r *registryImpl) ListWorkers(nsID string, _ string, _ []byte) ([]*workersb.WorkerHeartbeat, error) {
+	workerMap, exists := r.workersStore[nsID]
+	if !exists {
+		return nil, serviceerror.NewNamespaceNotFound(nsID)
+	}
+
+	heartbeats := make([]*workersb.WorkerHeartbeat, 0, len(workerMap))
+	for _, heartbeat := range workerMap {
+		heartbeats = append(heartbeats, heartbeat)
+	}
+
+	return heartbeats, nil
+}

--- a/service/matching/workers/registry_test.go
+++ b/service/matching/workers/registry_test.go
@@ -1,0 +1,202 @@
+package workers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	workersb "go.temporal.io/api/worker/v1"
+)
+
+func TestRegistryImpl_RecordWorkerHeartbeat(t *testing.T) {
+	tests := []struct {
+		name            string
+		setup           func(*registryImpl)
+		nsID            string
+		workerHeartbeat *workersb.WorkerHeartbeat
+		expectedWorkers int
+		expectedInStore bool
+		heartbeatCheck  func(*workersb.WorkerHeartbeat)
+	}{
+		{
+			name:  "record worker in new namespace",
+			setup: func(r *registryImpl) {},
+			nsID:  "namespace1",
+			workerHeartbeat: &workersb.WorkerHeartbeat{
+				WorkerInstanceKey: "worker1",
+			},
+			expectedWorkers: 1,
+			expectedInStore: true,
+		},
+		{
+			name: "record worker in existing namespace",
+			setup: func(r *registryImpl) {
+				r.workersStore["namespace1"] = make(map[string]*workersb.WorkerHeartbeat)
+				r.workersStore["namespace1"]["existing-worker"] = &workersb.WorkerHeartbeat{
+					WorkerInstanceKey: "existing-worker",
+				}
+			},
+			nsID: "namespace1",
+			workerHeartbeat: &workersb.WorkerHeartbeat{
+				WorkerInstanceKey: "worker2",
+			},
+			expectedWorkers: 2,
+			expectedInStore: true,
+		},
+		{
+			name: "update existing worker",
+			setup: func(r *registryImpl) {
+				r.workersStore["namespace1"] = make(map[string]*workersb.WorkerHeartbeat)
+				r.workersStore["namespace1"]["worker1"] = &workersb.WorkerHeartbeat{
+					WorkerInstanceKey: "worker1",
+					TaskQueue:         "tq1",
+				}
+			},
+			nsID: "namespace1",
+			workerHeartbeat: &workersb.WorkerHeartbeat{
+				WorkerInstanceKey: "worker1", // Same key, should update
+				TaskQueue:         "tq2",
+			},
+			expectedWorkers: 1,
+			expectedInStore: true,
+			heartbeatCheck: func(h *workersb.WorkerHeartbeat) {
+				assert.Equal(t, "tq2", h.TaskQueue, "worker heartbeat should be updated with new task queue")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &registryImpl{
+				workersStore: make(map[string]map[string]*workersb.WorkerHeartbeat),
+			}
+			tt.setup(r)
+
+			r.RecordWorkerHeartbeat(tt.nsID, tt.workerHeartbeat)
+
+			// Check if namespace exists
+			nsMap, exists := r.workersStore[tt.nsID]
+			assert.True(t, exists, "namespace should exist")
+			assert.Len(t, nsMap, tt.expectedWorkers, "unexpected number of workers")
+
+			// Check if specific worker exists
+			worker, workerExists := nsMap[tt.workerHeartbeat.WorkerInstanceKey]
+			assert.Equal(t, tt.expectedInStore, workerExists, "worker existence mismatch")
+			if workerExists {
+				assert.Equal(t, tt.workerHeartbeat, worker, "worker heartbeat should match")
+				if tt.heartbeatCheck != nil {
+					tt.heartbeatCheck(worker)
+				}
+			}
+		})
+	}
+}
+
+func TestRegistryImpl_ListWorkers(t *testing.T) {
+	tests := []struct {
+		name            string
+		setup           func(*registryImpl)
+		nsID            string
+		expectedCount   int
+		expectedWorkers []string // WorkerInstanceKeys
+		expectError     bool
+	}{
+		{
+			name:        "list workers from non-existent namespace",
+			setup:       func(r *registryImpl) {},
+			nsID:        "non-existent",
+			expectError: true,
+		},
+		{
+			name: "list workers from empty namespace",
+			setup: func(r *registryImpl) {
+				r.workersStore["empty-ns"] = make(map[string]*workersb.WorkerHeartbeat)
+			},
+			nsID:            "empty-ns",
+			expectedCount:   0,
+			expectedWorkers: []string{},
+		},
+		{
+			name: "list single worker",
+			setup: func(r *registryImpl) {
+				r.workersStore["namespace1"] = make(map[string]*workersb.WorkerHeartbeat)
+				r.workersStore["namespace1"]["worker1"] = &workersb.WorkerHeartbeat{
+					WorkerInstanceKey: "worker1",
+				}
+			},
+			nsID:            "namespace1",
+			expectedCount:   1,
+			expectedWorkers: []string{"worker1"},
+		},
+		{
+			name: "list multiple workers",
+			setup: func(r *registryImpl) {
+				r.workersStore["namespace1"] = make(map[string]*workersb.WorkerHeartbeat)
+				r.workersStore["namespace1"]["worker1"] = &workersb.WorkerHeartbeat{
+					WorkerInstanceKey: "worker1",
+				}
+				r.workersStore["namespace1"]["worker2"] = &workersb.WorkerHeartbeat{
+					WorkerInstanceKey: "worker2",
+				}
+				r.workersStore["namespace1"]["worker3"] = &workersb.WorkerHeartbeat{
+					WorkerInstanceKey: "worker3",
+				}
+			},
+			nsID:            "namespace1",
+			expectedCount:   3,
+			expectedWorkers: []string{"worker1", "worker2", "worker3"},
+		},
+		{
+			name: "list workers from specific namespace only",
+			setup: func(r *registryImpl) {
+				// Setup namespace1
+				r.workersStore["namespace1"] = make(map[string]*workersb.WorkerHeartbeat)
+				r.workersStore["namespace1"]["worker1"] = &workersb.WorkerHeartbeat{
+					WorkerInstanceKey: "worker1",
+				}
+				// Setup namespace2
+				r.workersStore["namespace2"] = make(map[string]*workersb.WorkerHeartbeat)
+				r.workersStore["namespace2"]["worker2"] = &workersb.WorkerHeartbeat{
+					WorkerInstanceKey: "worker2",
+				}
+			},
+			nsID:            "namespace1",
+			expectedCount:   1,
+			expectedWorkers: []string{"worker1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &registryImpl{
+				workersStore: make(map[string]map[string]*workersb.WorkerHeartbeat),
+			}
+			tt.setup(r)
+
+			result, err := r.ListWorkers(tt.nsID, "", nil)
+			if tt.expectError {
+				assert.Error(t, err, "expected an error for non-existent namespace")
+				assert.Nil(t, result, "result should be nil when an error occurs")
+				return
+			} else {
+				assert.NoError(t, err, "unexpected error when listing workers")
+			}
+
+			assert.Len(t, result, tt.expectedCount, "unexpected number of workers returned")
+
+			// Check that all expected workers are present
+			actualWorkers := make([]string, len(result))
+			for i, worker := range result {
+				actualWorkers[i] = worker.WorkerInstanceKey
+			}
+
+			if tt.expectedCount > 0 {
+				assert.ElementsMatch(t, tt.expectedWorkers, actualWorkers, "worker lists don't match")
+			}
+
+			// Verify all returned workers are not nil
+			for _, worker := range result {
+				assert.NotNil(t, worker, "returned worker should not be nil")
+			}
+		})
+	}
+}

--- a/service/matching/workers/registry_test.go
+++ b/service/matching/workers/registry_test.go
@@ -177,10 +177,8 @@ func TestRegistryImpl_ListWorkers(t *testing.T) {
 				assert.Error(t, err, "expected an error for non-existent namespace")
 				assert.Nil(t, result, "result should be nil when an error occurs")
 				return
-			} else {
-				assert.NoError(t, err, "unexpected error when listing workers")
 			}
-
+			assert.NoError(t, err, "unexpected error when listing workers")
 			assert.Len(t, result, tt.expectedCount, "unexpected number of workers returned")
 
 			// Check that all expected workers are present


### PR DESCRIPTION
## What changed?
Add initial implementation for
* ListWorkers
* RecordWorkerHeartbeat

I close this in favor of https://github.com/temporalio/temporal/pull/7914


## How did you test it?
- [x] added new unit test(s)