### PR TITLE
Skip the versioned->unversioned error check for Versioning V3

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -238,7 +238,9 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 	if ms.GetMostRecentWorkerVersionStamp().GetUseVersioning() &&
 		//nolint:staticcheck // SA1019 deprecated stamp will clean up later
 		!request.GetWorkerVersionStamp().GetUseVersioning() &&
-		request.GetDeploymentOptions().GetWorkerVersioningMode() != enumspb.WORKER_VERSIONING_MODE_VERSIONED {
+		request.GetDeploymentOptions().GetWorkerVersioningMode() != enumspb.WORKER_VERSIONING_MODE_VERSIONED &&
+		// This check is not needed for V3 versioning
+		ms.GetEffectiveVersioningBehavior() == enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED {
 		// Mutable state wasn't changed yet and doesn't have to be cleared.
 		releaseLeaseWithError = false
 		return nil, serviceerror.NewInvalidArgument("Workflow using versioning must continue to use versioning.")


### PR DESCRIPTION
## What changed?
_Describe what has changed in this PR._
Skip the check preventing wfs from going from versioned to unversioned when wft completes. This check is relevant to V1 only.

## Why?
_Tell your future self why have you made these changes._
When workflow transitions from a versioned worker to unversioned, the possible pending task cannot complete with this check until the task times out and a new wft is scheduled.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)D

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
Patch candidate
