### PR TITLE
Split Background task priority to PriorityHigh and PriorityLow

### DIFF
--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -208,7 +208,7 @@ func (m *metadataImpl) Start() {
 	// TODO: specify a timeout for the context
 	ctx := headers.SetCallerInfo(
 		context.TODO(),
-		headers.SystemBackgroundCallerInfo,
+		headers.SystemBackgroundHighCallerInfo,
 	)
 	err := m.refreshClusterMetadata(ctx)
 	if err != nil {

--- a/common/headers/caller_info.go
+++ b/common/headers/caller_info.go
@@ -7,27 +7,33 @@ import (
 )
 
 const (
-	CallerTypeOperator    = "operator"
-	CallerTypeAPI         = "api"
-	CallerTypeBackground  = "background"
-	CallerTypePreemptable = "preemptable"
+	CallerTypeOperator       = "operator"
+	CallerTypeAPI            = "api"
+	CallerTypeBackgroundHigh = "background_high"
+	CallerTypeBackgroundLow  = "background_low"
+	CallerTypePreemptable    = "preemptable"
 
 	CallerNameSystem = "system"
 )
 
 var (
 	ValidCallerTypes = map[string]struct{}{
-		CallerTypeOperator:    {},
-		CallerTypeAPI:         {},
-		CallerTypeBackground:  {},
-		CallerTypePreemptable: {},
+		CallerTypeOperator:       {},
+		CallerTypeAPI:            {},
+		CallerTypeBackgroundHigh: {},
+		CallerTypeBackgroundLow:  {},
+		CallerTypePreemptable:    {},
 	}
 )
 
 var (
-	SystemBackgroundCallerInfo = CallerInfo{
+	SystemBackgroundHighCallerInfo = CallerInfo{
 		CallerName: CallerNameSystem,
-		CallerType: CallerTypeBackground,
+		CallerType: CallerTypeBackgroundHigh,
+	}
+	SystemBackgroundLowCallerInfo = CallerInfo{
+		CallerName: CallerNameSystem,
+		CallerType: CallerTypeBackgroundHigh,
 	}
 	SystemPreemptableCallerInfo = CallerInfo{
 		CallerName: CallerNameSystem,
@@ -65,15 +71,27 @@ func NewCallerInfo(
 	}
 }
 
-// NewBackgroundCallerInfo creates a new CallerInfo with Background callerType
+// NewBackgroundHighCallerInfo creates a new CallerInfo with BackgroundHigh callerType
 // and empty callOrigin.
-// This is equivalent to NewCallerInfo(callerName, CallerTypeBackground, "")
-func NewBackgroundCallerInfo(
+// This is equivalent to NewCallerInfo(callerName, CallerTypeBackgroundHigh, "")
+func NewBackgroundHighCallerInfo(
 	callerName string,
 ) CallerInfo {
 	return CallerInfo{
 		CallerName: callerName,
-		CallerType: CallerTypeBackground,
+		CallerType: CallerTypeBackgroundHigh,
+	}
+}
+
+// NewBackgroundLowCallerInfo creates a new CallerInfo with BackgroundLow callerType
+// and empty callOrigin.
+// This is equivalent to NewCallerInfo(callerName, CallerTypeBackgroundLow, "")
+func NewBackgroundLowCallerInfo(
+	callerName string,
+) CallerInfo {
+	return CallerInfo{
+		CallerName: callerName,
+		CallerType: CallerTypeBackgroundLow,
 	}
 }
 

--- a/common/headers/caller_info_test.go
+++ b/common/headers/caller_info_test.go
@@ -48,13 +48,13 @@ func (s *callerInfoSuite) TestSetCallerType() {
 	info := GetCallerInfo(ctx)
 	s.Empty(info.CallerType)
 
-	ctx = SetCallerType(ctx, CallerTypeBackground)
+	ctx = SetCallerType(ctx, CallerTypeBackgroundHigh)
 	info = GetCallerInfo(ctx)
-	s.Equal(CallerTypeBackground, info.CallerType)
+	s.Equal(CallerTypeBackgroundHigh, info.CallerType)
 
 	ctx = SetCallerName(ctx, "")
 	info = GetCallerInfo(ctx)
-	s.Equal(CallerTypeBackground, info.CallerType)
+	s.Equal(CallerTypeBackgroundHigh, info.CallerType)
 
 	ctx = SetCallerType(ctx, CallerTypeAPI)
 	info = GetCallerInfo(ctx)
@@ -129,7 +129,7 @@ func (s *callerInfoSuite) TestSetCallerInfo_NoExistingCallerInfo() {
 
 func (s *callerInfoSuite) TestSetCallerInfo_WithExistingCallerInfo() {
 	callerName := CallerNameSystem
-	callerType := CallerTypeBackground
+	callerType := CallerTypeBackgroundHigh
 	callOrigin := "methodName"
 
 	ctx := SetCallerName(context.Background(), callerName)

--- a/common/membership/ringpop/factory.go
+++ b/common/membership/ringpop/factory.go
@@ -92,7 +92,7 @@ func (factory *factory) getMonitor() *monitor {
 		ctx, cancel := context.WithTimeout(context.Background(), persistenceOperationTimeout)
 		defer cancel()
 
-		ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundCallerInfo)
+		ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo)
 		currentClusterMetadata, err := factory.MetadataManager.GetCurrentClusterMetadata(ctx)
 		if err != nil {
 			factory.Logger.Fatal("Failed to get current cluster ID", tag.Error(err))

--- a/common/membership/ringpop/monitor.go
+++ b/common/membership/ringpop/monitor.go
@@ -85,7 +85,7 @@ func newMonitor(
 	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 	lifecycleCtx = headers.SetCallerInfo(
 		lifecycleCtx,
-		headers.SystemBackgroundCallerInfo,
+		headers.SystemBackgroundHighCallerInfo,
 	)
 
 	rpo := &monitor{

--- a/common/namespace/nsregistry/registry.go
+++ b/common/namespace/nsregistry/registry.go
@@ -165,7 +165,7 @@ func (r *registry) Start() {
 	// initialize the namespace registry by initial scan
 	ctx := headers.SetCallerInfo(
 		context.Background(),
-		headers.SystemBackgroundCallerInfo,
+		headers.SystemBackgroundHighCallerInfo,
 	)
 
 	err := r.refreshNamespaces(ctx)

--- a/common/nexus/endpoint_registry.go
+++ b/common/nexus/endpoint_registry.go
@@ -127,7 +127,7 @@ func (r *EndpointRegistryImpl) setEnabled(enabled bool) {
 	if oldReady == nil && enabled {
 		backgroundCtx := headers.SetCallerInfo(
 			context.Background(),
-			headers.SystemBackgroundCallerInfo,
+			headers.SystemBackgroundHighCallerInfo,
 		)
 		newReady := &dataReady{
 			refresh: goro.NewHandle(backgroundCtx),

--- a/common/persistence/client/quotas.go
+++ b/common/persistence/client/quotas.go
@@ -18,10 +18,11 @@ type (
 
 var (
 	CallerTypeDefaultPriority = map[string]int{
-		headers.CallerTypeOperator:    0,
-		headers.CallerTypeAPI:         2,
-		headers.CallerTypeBackground:  4,
-		headers.CallerTypePreemptable: 5,
+		headers.CallerTypeOperator:       0,
+		headers.CallerTypeAPI:            2,
+		headers.CallerTypeBackgroundHigh: 4,
+		headers.CallerTypeBackgroundLow:  5,
+		headers.CallerTypePreemptable:    6,
 	}
 
 	APITypeCallOriginPriorityOverride = map[string]int{
@@ -56,7 +57,7 @@ var (
 		p.ConstructHistoryTaskAPI("GetHistoryTasks", tasks.CategoryVisibility): 3,
 	}
 
-	RequestPrioritiesOrdered = []int{0, 1, 2, 3, 4, 5}
+	RequestPrioritiesOrdered = []int{0, 1, 2, 3, 4, 5, 6}
 )
 
 func NewPriorityRateLimiter(
@@ -271,7 +272,7 @@ func RequestPriorityFn(req quotas.Request) int {
 			return priority
 		}
 		return CallerTypeDefaultPriority[req.CallerType]
-	case headers.CallerTypeBackground:
+	case headers.CallerTypeBackgroundHigh:
 		if priority, ok := BackgroundTypeAPIPriorityOverride[req.API]; ok {
 			return priority
 		}

--- a/common/persistence/client/quotas.go
+++ b/common/persistence/client/quotas.go
@@ -272,7 +272,7 @@ func RequestPriorityFn(req quotas.Request) int {
 			return priority
 		}
 		return CallerTypeDefaultPriority[req.CallerType]
-	case headers.CallerTypeBackgroundHigh:
+	case headers.CallerTypeBackgroundHigh, headers.CallerTypeBackgroundLow:
 		if priority, ok := BackgroundTypeAPIPriorityOverride[req.API]; ok {
 			return priority
 		}

--- a/common/rpc/interceptor/caller_info_test.go
+++ b/common/rpc/interceptor/caller_info_test.go
@@ -65,7 +65,7 @@ func (s *callerInfoSuite) TestIntercept_CallerName() {
 		{
 			// test context with caller type but no caller name
 			setupIncomingCtx: func() context.Context {
-				return headers.SetCallerType(context.Background(), headers.CallerTypeBackground)
+				return headers.SetCallerType(context.Background(), headers.CallerTypeBackgroundHigh)
 			},
 			request: &workflowservice.StartWorkflowExecutionRequest{
 				Namespace: testNamespaceName,
@@ -151,10 +151,10 @@ func (s *callerInfoSuite) TestIntercept_CallerType() {
 		{
 			// test context with caller type
 			setupIncomingCtx: func() context.Context {
-				return headers.SetCallerType(context.Background(), headers.CallerTypeBackground)
+				return headers.SetCallerType(context.Background(), headers.CallerTypeBackgroundHigh)
 			},
 			request:            &workflowservice.StartWorkflowExecutionRequest{},
-			expectedCallerType: headers.CallerTypeBackground,
+			expectedCallerType: headers.CallerTypeBackgroundHigh,
 		},
 		{
 			// test context with empty caller type
@@ -225,7 +225,7 @@ func (s *callerInfoSuite) TestIntercept_CallOrigin() {
 		{
 			// test context with background caller type but no call origin
 			setupIncomingCtx: func() context.Context {
-				return headers.SetCallerInfo(context.Background(), headers.SystemBackgroundCallerInfo)
+				return headers.SetCallerInfo(context.Background(), headers.SystemBackgroundHighCallerInfo)
 			},
 			request:            &workflowservice.StartWorkflowExecutionRequest{},
 			expectedCallOrigin: "",

--- a/common/searchattribute/manager.go
+++ b/common/searchattribute/manager.go
@@ -118,7 +118,7 @@ func (m *managerImpl) refreshCache(saCache cache, now time.Time) (cache, error) 
 	// TODO: specify a timeout for the context
 	ctx := headers.SetCallerInfo(
 		context.TODO(),
-		headers.SystemBackgroundCallerInfo,
+		headers.SystemBackgroundHighCallerInfo,
 	)
 
 	clusterMetadata, err := m.clusterMetadataManager.GetCurrentClusterMetadata(ctx)

--- a/common/tasks/priority.go
+++ b/common/tasks/priority.go
@@ -27,34 +27,34 @@ const (
 )
 
 var (
-	PriorityHigh       = getPriority(highPriorityClass, mediumPrioritySubclass)
-	PriorityLow        = getPriority(highPriorityClass, lowPrioritySubclass)
-	PriorityBackground = getPriority(lowPriorityClass, mediumPrioritySubclass)
+	PriorityHigh        = getPriority(highPriorityClass, mediumPrioritySubclass)
+	PriorityLow         = getPriority(highPriorityClass, lowPrioritySubclass)
+	PriorityPreemptable = getPriority(lowPriorityClass, mediumPrioritySubclass)
 )
 
 var (
 	PriorityName = map[Priority]string{
-		PriorityHigh:       "high",
-		PriorityLow:        "low",
-		PriorityBackground: "background",
+		PriorityHigh:        "high",
+		PriorityLow:         "low",
+		PriorityPreemptable: "preemptable",
 	}
 
 	PriorityValue = map[string]Priority{
 		"high":       PriorityHigh,
 		"low":        PriorityLow,
-		"background": PriorityBackground,
+		"background": PriorityPreemptable,
 	}
 
 	CallerTypeToPriority = map[string]Priority{
 		headers.CallerTypeBackgroundHigh: PriorityHigh,
 		headers.CallerTypeBackgroundLow:  PriorityLow,
-		headers.CallerTypePreemptable:    PriorityBackground,
+		headers.CallerTypePreemptable:    PriorityPreemptable,
 	}
 
 	PriorityToCallerType = map[Priority]string{
-		PriorityHigh:       headers.CallerTypeBackgroundHigh,
-		PriorityLow:        headers.CallerTypeBackgroundLow,
-		PriorityBackground: headers.CallerTypePreemptable,
+		PriorityHigh:        headers.CallerTypeBackgroundHigh,
+		PriorityLow:         headers.CallerTypeBackgroundLow,
+		PriorityPreemptable: headers.CallerTypePreemptable,
 	}
 )
 

--- a/common/tasks/priority.go
+++ b/common/tasks/priority.go
@@ -27,29 +27,34 @@ const (
 )
 
 var (
-	PriorityHigh = getPriority(highPriorityClass, mediumPrioritySubclass)
-	PriorityLow  = getPriority(lowPriorityClass, mediumPrioritySubclass)
+	PriorityHigh       = getPriority(highPriorityClass, mediumPrioritySubclass)
+	PriorityLow        = getPriority(highPriorityClass, lowPrioritySubclass)
+	PriorityBackground = getPriority(lowPriorityClass, mediumPrioritySubclass)
 )
 
 var (
 	PriorityName = map[Priority]string{
-		PriorityHigh: "high",
-		PriorityLow:  "low",
+		PriorityHigh:       "high",
+		PriorityLow:        "low",
+		PriorityBackground: "background",
 	}
 
 	PriorityValue = map[string]Priority{
-		"high": PriorityHigh,
-		"low":  PriorityLow,
+		"high":       PriorityHigh,
+		"low":        PriorityLow,
+		"background": PriorityBackground,
 	}
 
 	CallerTypeToPriority = map[string]Priority{
-		headers.CallerTypeBackground:  PriorityHigh,
-		headers.CallerTypePreemptable: PriorityLow,
+		headers.CallerTypeBackgroundHigh: PriorityHigh,
+		headers.CallerTypeBackgroundLow:  PriorityLow,
+		headers.CallerTypePreemptable:    PriorityBackground,
 	}
 
 	PriorityToCallerType = map[Priority]string{
-		PriorityHigh: headers.CallerTypeBackground,
-		PriorityLow:  headers.CallerTypePreemptable,
+		PriorityHigh:       headers.CallerTypeBackgroundHigh,
+		PriorityLow:        headers.CallerTypeBackgroundLow,
+		PriorityBackground: headers.CallerTypePreemptable,
 	}
 )
 

--- a/service/frontend/version_checker.go
+++ b/service/frontend/version_checker.go
@@ -51,7 +51,7 @@ func (vc *VersionChecker) Start() {
 			// TODO: specify a timeout for the context
 			ctx := headers.SetCallerInfo(
 				context.TODO(),
-				headers.SystemBackgroundCallerInfo,
+				headers.SystemBackgroundHighCallerInfo,
 			)
 
 			go vc.versionCheckLoop(ctx)

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3765,7 +3765,7 @@ func (wh *WorkflowHandler) DescribeSchedule(ctx context.Context, request *workfl
 		// we noticed some "running workflows" aren't running anymore. poke the workflow to
 		// refresh, but don't wait for the state to change. ignore errors.
 		go func() {
-			disconnectedCtx := headers.SetCallerInfo(context.Background(), headers.NewBackgroundCallerInfo(request.Namespace))
+			disconnectedCtx := headers.SetCallerInfo(context.Background(), headers.NewBackgroundHighCallerInfo(request.Namespace))
 			_, _ = wh.historyClient.SignalWorkflowExecution(disconnectedCtx, &historyservice.SignalWorkflowExecutionRequest{
 				NamespaceId: namespaceID.String(),
 				SignalRequest: &workflowservice.SignalWorkflowExecutionRequest{

--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -29,7 +29,7 @@ var (
 	// ArchivalTaskPriorities is the map of task priority to weight for the archival queue.
 	// The archival queue only uses the low task priority, so we only define a weight for that priority.
 	ArchivalTaskPriorities = configs.ConvertWeightsToDynamicConfigValue(map[ctasks.Priority]int{
-		ctasks.PriorityLow: 10,
+		ctasks.PriorityBackground: 10,
 	})
 )
 

--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -29,7 +29,7 @@ var (
 	// ArchivalTaskPriorities is the map of task priority to weight for the archival queue.
 	// The archival queue only uses the low task priority, so we only define a weight for that priority.
 	ArchivalTaskPriorities = configs.ConvertWeightsToDynamicConfigValue(map[ctasks.Priority]int{
-		ctasks.PriorityBackground: 10,
+		ctasks.PriorityPreemptable: 10,
 	})
 )
 

--- a/service/history/chasm_engine.go
+++ b/service/history/chasm_engine.go
@@ -510,7 +510,7 @@ func (e *ChasmEngine) getExecutionLease(
 
 	lockPriority := locks.PriorityHigh
 	callerType := headers.GetCallerInfo(ctx).CallerType
-	if callerType == headers.CallerTypeBackground || callerType == headers.CallerTypePreemptable {
+	if callerType == headers.CallerTypeBackgroundHigh || callerType == headers.CallerTypeBackgroundLow || callerType == headers.CallerTypePreemptable {
 		lockPriority = locks.PriorityLow
 	}
 

--- a/service/history/configs/quotas.go
+++ b/service/history/configs/quotas.go
@@ -13,13 +13,14 @@ const (
 
 var (
 	CallerTypeToPriority = map[string]int{
-		headers.CallerTypeOperator:    OperatorPriority,
-		headers.CallerTypeAPI:         1,
-		headers.CallerTypeBackground:  2,
-		headers.CallerTypePreemptable: 3,
+		headers.CallerTypeOperator:       OperatorPriority,
+		headers.CallerTypeAPI:            1,
+		headers.CallerTypeBackgroundHigh: 2,
+		headers.CallerTypeBackgroundLow:  3,
+		headers.CallerTypePreemptable:    4,
 	}
 
-	APIPrioritiesOrdered = []int{OperatorPriority, 1, 2, 3}
+	APIPrioritiesOrdered = []int{OperatorPriority, 1, 2, 3, 4}
 )
 
 func NewPriorityRateLimiter(

--- a/service/history/configs/task.go
+++ b/service/history/configs/task.go
@@ -8,16 +8,16 @@ import (
 
 var (
 	DefaultActiveTaskPriorityWeight = map[tasks.Priority]int{
-		tasks.PriorityHigh:       10,
-		tasks.PriorityLow:        9,
-		tasks.PriorityBackground: 1,
+		tasks.PriorityHigh:        10,
+		tasks.PriorityLow:         9,
+		tasks.PriorityPreemptable: 1,
 	}
 
 	DefaultStandbyTaskPriorityWeight = map[tasks.Priority]int{
 		// we basically treat standby tasks as low priority tasks
-		tasks.PriorityHigh:       1,
-		tasks.PriorityLow:        1,
-		tasks.PriorityBackground: 1,
+		tasks.PriorityHigh:        1,
+		tasks.PriorityLow:         1,
+		tasks.PriorityPreemptable: 1,
 	}
 )
 

--- a/service/history/configs/task.go
+++ b/service/history/configs/task.go
@@ -8,14 +8,16 @@ import (
 
 var (
 	DefaultActiveTaskPriorityWeight = map[tasks.Priority]int{
-		tasks.PriorityHigh: 10,
-		tasks.PriorityLow:  1,
+		tasks.PriorityHigh:       10,
+		tasks.PriorityLow:        9,
+		tasks.PriorityBackground: 1,
 	}
 
 	DefaultStandbyTaskPriorityWeight = map[tasks.Priority]int{
-		// we basically treat standby tasks as low prority tasks
-		tasks.PriorityHigh: 1,
-		tasks.PriorityLow:  1,
+		// we basically treat standby tasks as low priority tasks
+		tasks.PriorityHigh:       1,
+		tasks.PriorityLow:        1,
+		tasks.PriorityBackground: 1,
 	}
 )
 

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -249,7 +249,9 @@ func (e *executableImpl) Execute() (retErr error) {
 	var callerInfo headers.CallerInfo
 	switch e.priority {
 	case ctasks.PriorityHigh:
-		callerInfo = headers.NewBackgroundCallerInfo(ns.String())
+		callerInfo = headers.NewBackgroundHighCallerInfo(ns.String())
+	case ctasks.PriorityLow:
+		callerInfo = headers.NewBackgroundLowCallerInfo(ns.String())
 	default:
 		// priority low or unknown
 		callerInfo = headers.NewPreemptableCallerInfo(ns.String())

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -253,7 +253,7 @@ func (e *executableImpl) Execute() (retErr error) {
 	case ctasks.PriorityLow:
 		callerInfo = headers.NewBackgroundLowCallerInfo(ns.String())
 	default:
-		// priority low or unknown
+		// priority background or unknown
 		callerInfo = headers.NewPreemptableCallerInfo(ns.String())
 	}
 	ctx := headers.SetCallerInfo(

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -253,7 +253,7 @@ func (e *executableImpl) Execute() (retErr error) {
 	case ctasks.PriorityLow:
 		callerInfo = headers.NewBackgroundLowCallerInfo(ns.String())
 	default:
-		// priority background or unknown
+		// priority preemptable or unknown
 		callerInfo = headers.NewPreemptableCallerInfo(ns.String())
 	}
 	ctx := headers.SetCallerInfo(

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -319,7 +319,7 @@ func (s *executableSuite) TestExecute_CallerInfo() {
 
 	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).DoAndReturn(
 		func(ctx context.Context, _ queues.Executable) queues.ExecuteResponse {
-			s.Equal(headers.CallerTypeBackground, headers.GetCallerInfo(ctx).CallerType)
+			s.Equal(headers.CallerTypeBackgroundHigh, headers.GetCallerInfo(ctx).CallerType)
 			return queues.ExecuteResponse{
 				ExecutionMetricTags: nil,
 				ExecutedAsActive:    true,
@@ -331,6 +331,21 @@ func (s *executableSuite) TestExecute_CallerInfo() {
 
 	executable = s.newTestExecutable(func(p *params) {
 		p.priorityAssigner = queues.NewStaticPriorityAssigner(ctasks.PriorityLow)
+	})
+	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).DoAndReturn(
+		func(ctx context.Context, _ queues.Executable) queues.ExecuteResponse {
+			s.Equal(headers.CallerTypeBackgroundLow, headers.GetCallerInfo(ctx).CallerType)
+			return queues.ExecuteResponse{
+				ExecutionMetricTags: nil,
+				ExecutedAsActive:    true,
+				ExecutionErr:        nil,
+			}
+		},
+	)
+	s.NoError(executable.Execute())
+
+	executable = s.newTestExecutable(func(p *params) {
+		p.priorityAssigner = queues.NewStaticPriorityAssigner(ctasks.PriorityBackground)
 	})
 	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).DoAndReturn(
 		func(ctx context.Context, _ queues.Executable) queues.ExecuteResponse {

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -345,7 +345,7 @@ func (s *executableSuite) TestExecute_CallerInfo() {
 	s.NoError(executable.Execute())
 
 	executable = s.newTestExecutable(func(p *params) {
-		p.priorityAssigner = queues.NewStaticPriorityAssigner(ctasks.PriorityBackground)
+		p.priorityAssigner = queues.NewStaticPriorityAssigner(ctasks.PriorityPreemptable)
 	})
 	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).DoAndReturn(
 		func(ctx context.Context, _ queues.Executable) queues.ExecuteResponse {

--- a/service/history/queues/priority_assigner.go
+++ b/service/history/queues/priority_assigner.go
@@ -37,12 +37,12 @@ func (a *priorityAssignerImpl) Assign(executable Executable) tasks.Priority {
 		enumsspb.TASK_TYPE_UNSPECIFIED:
 		// add more task types here if we believe it's ok to delay those tasks
 		// and assign them the same priority as throttled tasks
-		return tasks.PriorityBackground
+		return tasks.PriorityPreemptable
 	}
 
 	if _, ok := enumsspb.TaskType_name[int32(taskType)]; !ok {
 		// low priority for unknown task types
-		return tasks.PriorityBackground
+		return tasks.PriorityPreemptable
 	}
 
 	return tasks.PriorityHigh

--- a/service/history/queues/priority_assigner.go
+++ b/service/history/queues/priority_assigner.go
@@ -25,6 +25,11 @@ func NewPriorityAssigner() PriorityAssigner {
 func (a *priorityAssignerImpl) Assign(executable Executable) tasks.Priority {
 	taskType := executable.GetType()
 	switch taskType {
+	case enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
+		enumsspb.TASK_TYPE_WORKFLOW_TASK_TIMEOUT,
+		enumsspb.TASK_TYPE_WORKFLOW_RUN_TIMEOUT,
+		enumsspb.TASK_TYPE_WORKFLOW_EXECUTION_TIMEOUT:
+		return tasks.PriorityLow
 	case enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
 		enumsspb.TASK_TYPE_TRANSFER_DELETE_EXECUTION,
 		enumsspb.TASK_TYPE_VISIBILITY_DELETE_EXECUTION,
@@ -32,12 +37,12 @@ func (a *priorityAssignerImpl) Assign(executable Executable) tasks.Priority {
 		enumsspb.TASK_TYPE_UNSPECIFIED:
 		// add more task types here if we believe it's ok to delay those tasks
 		// and assign them the same priority as throttled tasks
-		return tasks.PriorityLow
+		return tasks.PriorityBackground
 	}
 
 	if _, ok := enumsspb.TaskType_name[int32(taskType)]; !ok {
 		// low priority for unknown task types
-		return tasks.PriorityLow
+		return tasks.PriorityBackground
 	}
 
 	return tasks.PriorityHigh

--- a/service/history/queues/priority_assigner_test.go
+++ b/service/history/queues/priority_assigner_test.go
@@ -42,30 +42,52 @@ func (s *priorityAssignerSuite) TestAssign_SelectedTaskTypes() {
 	mockExecutable := NewMockExecutable(s.controller)
 	mockExecutable.EXPECT().GetType().Return(enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT).Times(1)
 
-	s.Equal(tasks.PriorityLow, s.priorityAssigner.Assign(mockExecutable))
+	s.Equal(tasks.PriorityBackground, s.priorityAssigner.Assign(mockExecutable))
 }
 
 func (s *priorityAssignerSuite) TestAssign_UnknownTaskTypes() {
 	mockExecutable := NewMockExecutable(s.controller)
 	mockExecutable.EXPECT().GetType().Return(enumsspb.TaskType(1234)).Times(1)
 
-	s.Equal(tasks.PriorityLow, s.priorityAssigner.Assign(mockExecutable))
+	s.Equal(tasks.PriorityBackground, s.priorityAssigner.Assign(mockExecutable))
 }
 
 func (s *priorityAssignerSuite) TestAssign_HighPriorityTaskTypes() {
-	mockExecutable := NewMockExecutable(s.controller)
-	mockExecutable.EXPECT().GetType().Return(enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER).Times(1)
+	for _, taskType := range []enumsspb.TaskType{
+		enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
+		enumsspb.TASK_TYPE_USER_TIMER,
+		enumsspb.TASK_TYPE_WORKFLOW_BACKOFF_TIMER,
+		enumsspb.TASK_TYPE_TRANSFER_WORKFLOW_TASK,
+		enumsspb.TASK_TYPE_TRANSFER_ACTIVITY_TASK,
+	} {
+		mockExecutable := NewMockExecutable(s.controller)
+		mockExecutable.EXPECT().GetType().Return(taskType).Times(1)
 
-	s.Equal(tasks.PriorityHigh, s.priorityAssigner.Assign(mockExecutable))
+		s.Equal(tasks.PriorityHigh, s.priorityAssigner.Assign(mockExecutable))
+	}
 }
 
-func (s *priorityAssignerSuite) TestAssign_LowPriorityTaskTypes() {
+func (s *priorityAssignerSuite) TestAssign_BackgroundPriorityTaskTypes() {
 	for _, taskType := range []enumsspb.TaskType{
 		enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
 		enumsspb.TASK_TYPE_TRANSFER_DELETE_EXECUTION,
 		enumsspb.TASK_TYPE_VISIBILITY_DELETE_EXECUTION,
 		enumsspb.TASK_TYPE_ARCHIVAL_ARCHIVE_EXECUTION,
 		enumsspb.TASK_TYPE_UNSPECIFIED,
+	} {
+		mockExecutable := NewMockExecutable(s.controller)
+		mockExecutable.EXPECT().GetType().Return(taskType).Times(1)
+
+		s.Equal(tasks.PriorityBackground, s.priorityAssigner.Assign(mockExecutable))
+	}
+}
+
+func (s *priorityAssignerSuite) TestAssign_LowPriorityTaskTypes() {
+	for _, taskType := range []enumsspb.TaskType{
+		enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
+		enumsspb.TASK_TYPE_WORKFLOW_TASK_TIMEOUT,
+		enumsspb.TASK_TYPE_WORKFLOW_RUN_TIMEOUT,
+		enumsspb.TASK_TYPE_WORKFLOW_EXECUTION_TIMEOUT,
 	} {
 		mockExecutable := NewMockExecutable(s.controller)
 		mockExecutable.EXPECT().GetType().Return(taskType).Times(1)

--- a/service/history/queues/priority_assigner_test.go
+++ b/service/history/queues/priority_assigner_test.go
@@ -42,14 +42,14 @@ func (s *priorityAssignerSuite) TestAssign_SelectedTaskTypes() {
 	mockExecutable := NewMockExecutable(s.controller)
 	mockExecutable.EXPECT().GetType().Return(enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT).Times(1)
 
-	s.Equal(tasks.PriorityBackground, s.priorityAssigner.Assign(mockExecutable))
+	s.Equal(tasks.PriorityPreemptable, s.priorityAssigner.Assign(mockExecutable))
 }
 
 func (s *priorityAssignerSuite) TestAssign_UnknownTaskTypes() {
 	mockExecutable := NewMockExecutable(s.controller)
 	mockExecutable.EXPECT().GetType().Return(enumsspb.TaskType(1234)).Times(1)
 
-	s.Equal(tasks.PriorityBackground, s.priorityAssigner.Assign(mockExecutable))
+	s.Equal(tasks.PriorityPreemptable, s.priorityAssigner.Assign(mockExecutable))
 }
 
 func (s *priorityAssignerSuite) TestAssign_HighPriorityTaskTypes() {
@@ -78,7 +78,7 @@ func (s *priorityAssignerSuite) TestAssign_BackgroundPriorityTaskTypes() {
 		mockExecutable := NewMockExecutable(s.controller)
 		mockExecutable.EXPECT().GetType().Return(taskType).Times(1)
 
-		s.Equal(tasks.PriorityBackground, s.priorityAssigner.Assign(mockExecutable))
+		s.Equal(tasks.PriorityPreemptable, s.priorityAssigner.Assign(mockExecutable))
 	}
 }
 

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -432,6 +432,6 @@ func createCheckpointRetryPolicy() backoff.RetryPolicy {
 
 func newQueueIOContext() (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(context.Background(), queueIOTimeout)
-	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundCallerInfo)
+	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo)
 	return ctx, cancel
 }

--- a/service/history/queues/scheduler_quotas.go
+++ b/service/history/queues/scheduler_quotas.go
@@ -39,7 +39,7 @@ func NewPrioritySchedulerRateLimiter(
 		}
 
 		// default to low priority
-		return int(tasks.PriorityBackground)
+		return int(tasks.PriorityPreemptable)
 	}
 
 	priorityToRateLimiters := make(map[int]quotas.RequestRateLimiter, len(tasks.PriorityName))

--- a/service/history/queues/scheduler_quotas.go
+++ b/service/history/queues/scheduler_quotas.go
@@ -39,7 +39,7 @@ func NewPrioritySchedulerRateLimiter(
 		}
 
 		// default to low priority
-		return int(tasks.PriorityLow)
+		return int(tasks.PriorityBackground)
 	}
 
 	priorityToRateLimiters := make(map[int]quotas.RequestRateLimiter, len(tasks.PriorityName))

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -2272,7 +2272,7 @@ func (s *ContextImpl) newDetachedContext(
 
 func (s *ContextImpl) newIOContext() (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(s.lifecycleCtx, s.config.ShardIOTimeout())
-	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundCallerInfo)
+	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo)
 
 	return ctx, cancel
 }

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -387,7 +387,7 @@ func (c *ControllerImpl) acquireShards(ctx context.Context) {
 		metrics.AcquireShardsLatency.With(c.taggedMetricsHandler).Record(time.Since(startTime))
 	}()
 
-	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundCallerInfo)
+	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo)
 
 	// Readiness check: if we haven't marked readiness yet, then we need to set up a context to
 	// run the readiness check on owned shards.

--- a/service/history/workflow/cache/cache_test.go
+++ b/service/history/workflow/cache/cache_test.go
@@ -515,12 +515,12 @@ func (s *workflowCacheSuite) TestCacheImpl_lockWorkflowExecution() {
 		},
 		{
 			name:       "Non API context with timeout without locking beforehand should return an error",
-			callerType: headers.CallerTypeBackground,
+			callerType: headers.CallerTypeBackgroundHigh,
 		},
 		{
 			name:             "Non API context with timeout and locking beforehand should return an error",
 			shouldLockBefore: true,
-			callerType:       headers.CallerTypeBackground,
+			callerType:       headers.CallerTypeBackgroundHigh,
 			wantErr:          true,
 		},
 	}

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -2384,7 +2384,7 @@ func (e *matchingEngineImpl) getUserDataBatcher(namespaceId namespace.ID) *strea
 func (e *matchingEngineImpl) applyUserDataUpdateBatch(namespaceId namespace.ID, batch []*userDataUpdate) error {
 	ctx, cancel := context.WithTimeout(context.Background(), ioTimeout)
 	// TODO: should use namespace name here
-	ctx = headers.SetCallerInfo(ctx, headers.NewBackgroundCallerInfo(namespaceId.String()))
+	ctx = headers.SetCallerInfo(ctx, headers.NewBackgroundHighCallerInfo(namespaceId.String()))
 	defer cancel()
 
 	// convert to map

--- a/service/matching/nexus_endpoint_client.go
+++ b/service/matching/nexus_endpoint_client.go
@@ -360,7 +360,7 @@ func (m *nexusEndpointClient) notifyOwnershipChanged(isOwner bool) {
 		// Just acquired ownership. Start refresh loop on table version to catch any updates from previous owner.
 		backgroundCtx := headers.SetCallerInfo(
 			context.Background(),
-			headers.SystemBackgroundCallerInfo,
+			headers.SystemBackgroundHighCallerInfo,
 		)
 		m.refreshHandle = goro.NewHandle(backgroundCtx)
 		m.refreshHandle.Go(m.refreshTableVersion)

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -749,7 +749,7 @@ func (pm *taskQueuePartitionManagerImpl) LongPollExpirationInterval() time.Durat
 }
 
 func (pm *taskQueuePartitionManagerImpl) callerInfoContext(ctx context.Context) context.Context {
-	return headers.SetCallerInfo(ctx, headers.NewBackgroundCallerInfo(pm.ns.Name().String()))
+	return headers.SetCallerInfo(ctx, headers.NewBackgroundHighCallerInfo(pm.ns.Name().String()))
 }
 
 // ForceLoadAllNonRootPartitions spins off go routines which make RPC calls to all the

--- a/service/matching/user_data_manager.go
+++ b/service/matching/user_data_manager.go
@@ -683,7 +683,7 @@ func (m *userDataManagerImpl) setUserDataForNonOwningPartition(userData *persist
 
 func (m *userDataManagerImpl) callerInfoContext(ctx context.Context) context.Context {
 	ns, _ := m.namespaceRegistry.GetNamespaceName(namespace.ID(m.partition.NamespaceId()))
-	return headers.SetCallerInfo(ctx, headers.NewBackgroundCallerInfo(ns.String()))
+	return headers.SetCallerInfo(ctx, headers.NewBackgroundHighCallerInfo(ns.String()))
 }
 
 func (m *userDataManagerImpl) logNewUserData(message string, data *persistencespb.VersionedTaskQueueUserData, tags ...tag.Tag) {

--- a/service/worker/parentclosepolicy/processor.go
+++ b/service/worker/parentclosepolicy/processor.go
@@ -80,7 +80,7 @@ func (s *Processor) Start() error {
 
 func getWorkerOptions(p *Processor) worker.Options {
 	ctx := context.WithValue(context.Background(), processorContextKey, p)
-	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundCallerInfo)
+	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo)
 
 	return worker.Options{
 		MaxConcurrentActivityExecutionSize:     p.cfg.MaxConcurrentActivityExecutionSize(),

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -479,7 +479,7 @@ func (w *perNamespaceWorker) startWorker(
 	sdkoptions.MaxConcurrentWorkflowTaskPollers = max(cmp.Or(w.opts.MaxConcurrentWorkflowTaskPollers, 2), 2)
 	sdkoptions.StickyScheduleToStartTimeout = w.opts.StickyScheduleToStartTimeout
 
-	sdkoptions.BackgroundActivityContext = headers.SetCallerInfo(context.Background(), headers.NewBackgroundCallerInfo(nsName))
+	sdkoptions.BackgroundActivityContext = headers.SetCallerInfo(context.Background(), headers.NewBackgroundHighCallerInfo(nsName))
 	sdkoptions.Identity = fmt.Sprintf("temporal-system@%s@%s", w.wm.hostName, nsName)
 	// increase these if we're supposed to run with more allocation
 	sdkoptions.MaxConcurrentWorkflowTaskPollers *= allocation.local

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -145,7 +145,7 @@ func New(
 // Start starts the scanner
 func (s *Scanner) Start() error {
 	ctx := context.WithValue(context.Background(), scannerContextKey, s.context)
-	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundCallerInfo)
+	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo)
 	ctx, s.lifecycleCancel = context.WithCancel(ctx)
 
 	workerOpts := worker.Options{

--- a/service/worker/scanner/taskqueue/scavenger.go
+++ b/service/worker/scanner/taskqueue/scavenger.go
@@ -84,7 +84,7 @@ func NewScavenger(db p.TaskManager, metricsHandler metrics.Handler, logger log.L
 	lifecycleCtx, lifecycleCancel := context.WithCancel(
 		headers.SetCallerInfo(
 			context.Background(),
-			headers.SystemBackgroundCallerInfo,
+			headers.SystemBackgroundHighCallerInfo,
 		),
 	)
 	return &Scavenger{

--- a/service/worker/worker.go
+++ b/service/worker/worker.go
@@ -55,7 +55,7 @@ func (wm *workerManager) Start() {
 	defaultWorkerOptions := sdkworker.Options{
 		Identity: "temporal-system@" + wm.hostInfo.Identity(),
 		// TODO: add dynamic config for worker options
-		BackgroundActivityContext: headers.SetCallerType(context.Background(), headers.CallerTypeBackground),
+		BackgroundActivityContext: headers.SetCallerType(context.Background(), headers.CallerTypeBackgroundHigh),
 	}
 	sdkClient := wm.sdkClientFactory.GetSystemClient()
 	defaultWorker := wm.sdkClientFactory.NewWorker(sdkClient, primitives.DefaultWorkerTaskQueue, defaultWorkerOptions)

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -624,7 +624,7 @@ func ApplyClusterMetadataConfigProvider(
 			tag.ClusterName(clusterMetadata.CurrentClusterName))
 		return svc.ClusterMetadata, svc.Persistence, missingCurrentClusterMetadataErr
 	}
-	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundCallerInfo)
+	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo)
 	resp, err := clusterMetadataManager.GetClusterMetadata(
 		ctx,
 		&persistence.GetClusterMetadataRequest{ClusterName: clusterMetadata.CurrentClusterName},

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -177,7 +177,7 @@ func initSystemNamespaces(
 	}
 	defer metadataManager.Close()
 	ctx, cancel := context.WithTimeout(
-		headers.SetCallerInfo(ctx, headers.SystemBackgroundCallerInfo),
+		headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo),
 		30*time.Second,
 	)
 	defer cancel()


### PR DESCRIPTION
## What changed?
Split background task priority to two levels BackgroundLow and BackgroundHigh.
Tasks like ActivityTimeout, WorkflowTaskTimeout, WorkflowRunTimeout, WorkflowExecutionTimeout will have BackgroundLow priority.
Other tasks like UserTime, TransferWorkflowTask, TransferActivity task etc will have BackgroundHigh priority.
System tasks like retention timers will still have the lowest priority level as before.

## Why?
This will help the task processor prioritize important tasks like UserTimer and TransferWorkflowTasks when there is rate limiting.
Tasks like timeout timers have comparatively lower priority.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

