### PR TITLE
Do not overwrite access type in stateMachineEnvironment.Access

### DIFF
--- a/service/history/statemachine_environment.go
+++ b/service/history/statemachine_environment.go
@@ -340,11 +340,12 @@ func (e *stateMachineEnvironment) validateNotZombieWorkflow(
 func (e *stateMachineEnvironment) Access(ctx context.Context, ref hsm.Ref, accessType hsm.AccessType, accessor func(*hsm.Node) error) (retErr error) {
 	wfCtx, release, ms, err := e.getValidatedMutableState(
 		ctx, ref.WorkflowKey, func(workflowContext historyi.WorkflowContext, ms historyi.MutableState, potentialStaleState bool) error {
-			// For task references we never want to access a zombie workflow, even if the machine is accessed for read.
+			accessTypeForZombieValidation := accessType
 			if ref.TaskID != 0 {
-				accessType = hsm.AccessWrite
+				// For task references we never want to access a zombie workflow, even if the machine is accessed for read.
+				accessTypeForZombieValidation = hsm.AccessWrite
 			}
-			if err := e.validateNotZombieWorkflow(ms, accessType); err != nil {
+			if err := e.validateNotZombieWorkflow(ms, accessTypeForZombieValidation); err != nil {
 				return err
 			}
 			return e.validateStateMachineRef(ctx, workflowContext, ms, ref, potentialStaleState)


### PR DESCRIPTION
## What changed?
Updated `stateMachineEnvironment.Access` to not overwrite access type for task references when checking for zombie workflows.

## Why?
The outbound standby task executor calls `Access` with access type Read just to check that the task is still valid. The access type was getting overwritten and causing it to try to call `wfCtx.UpdateWorkflowExecutionAsActive` which was just returning a NamespaceNotActiveError.
