### PR TITLE
Add workflowpb.PostResetOperation to ResetParams in batch operations

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -4635,12 +4635,12 @@ func (wh *WorkflowHandler) StartBatchOperation(
 			}
 			resetParams.ResetOptions = encodedResetOptions
 			resetParams.PostResetOperations = make([][]byte, len(op.ResetOperation.PostResetOperations))
-			for _, postResetOperation := range op.ResetOperation.PostResetOperations {
+			for i, postResetOperation := range op.ResetOperation.PostResetOperations {
 				encodedPostResetOperations, err := protojson.Marshal(postResetOperation)
 				if err != nil {
 					return nil, err
 				}
-				resetParams.PostResetOperations = append(resetParams.PostResetOperations, encodedPostResetOperations)
+				resetParams.PostResetOperations[i] = encodedPostResetOperations
 			}
 		} else {
 			// TODO: remove support for old fields later

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -62,7 +62,9 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -2477,6 +2479,155 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Reset(
 	_, err = wh.StartBatchOperation(context.Background(), request)
 	s.NoError(err)
 }
+
+func (s *WorkflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Reset_WithPostResetOperations() {
+	testNamespace := namespace.Name("test-namespace")
+	namespaceID := namespace.ID(uuid.NewString())
+	executions := []*commonpb.WorkflowExecution{
+		{
+			WorkflowId: uuid.NewString(),
+			RunId:      uuid.NewString(),
+		},
+	}
+	reason := "reason"
+	identity := "identity"
+	config := s.newConfig()
+	wh := s.getWorkflowHandler(config)
+
+	// Create post-reset operations to test the serialization fix
+	postResetOps := []*workflowpb.PostResetOperation{
+		{
+			Variant: &workflowpb.PostResetOperation_UpdateWorkflowOptions_{
+				UpdateWorkflowOptions: &workflowpb.PostResetOperation_UpdateWorkflowOptions{
+					WorkflowExecutionOptions: &workflowpb.WorkflowExecutionOptions{},
+					UpdateMask:               &fieldmaskpb.FieldMask{Paths: []string{"versioning_override"}},
+				},
+			},
+		},
+	}
+
+	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(namespaceID, nil).AnyTimes()
+	s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(
+			_ context.Context,
+			request *historyservice.StartWorkflowExecutionRequest,
+			_ ...grpc.CallOption,
+		) (*historyservice.StartWorkflowExecutionResponse, error) {
+			s.Equal(namespaceID.String(), request.NamespaceId)
+			s.Equal(batcher.BatchWFTypeName, request.StartRequest.WorkflowType.Name)
+			s.Equal(primitives.PerNSWorkerTaskQueue, request.StartRequest.TaskQueue.Name)
+			s.Equal(enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE, request.StartRequest.WorkflowIdReusePolicy)
+			s.Equal(identity, request.StartRequest.Identity)
+			s.Equal(payload.EncodeString(batcher.BatchTypeReset), request.StartRequest.Memo.Fields[batcher.BatchOperationTypeMemo])
+			s.Equal(payload.EncodeString(reason), request.StartRequest.Memo.Fields[batcher.BatchReasonMemo])
+			s.Equal(payload.EncodeString(identity), request.StartRequest.SearchAttributes.IndexedFields[searchattribute.BatcherUser])
+
+			// Decode the input and verify PostResetOperations are correctly set
+			var batchParams batcher.BatchParams
+			err := payloads.Decode(request.StartRequest.Input, &batchParams)
+			s.NoError(err)
+
+			// Verify that PostResetOperations slice has the correct length and no nil values
+			s.Len(batchParams.ResetParams.PostResetOperations, len(postResetOps))
+
+			// Ensure no nil values exist in the slice
+			for i, encoded := range batchParams.ResetParams.PostResetOperations {
+				s.NotNil(encoded, "PostResetOperations[%d] should not be nil", i)
+				s.Greater(len(encoded), 0, "PostResetOperations[%d] should not be empty", i)
+
+				// Verify we can unmarshal back to the original operation
+				var decodedOp workflowpb.PostResetOperation
+				err := protojson.Unmarshal(encoded, &decodedOp)
+				s.NoError(err, "Should be able to unmarshal PostResetOperations[%d]", i)
+
+				// Verify the content matches the original
+				s.Equal(postResetOps[i].GetVariant(), decodedOp.GetVariant())
+			}
+
+			return &historyservice.StartWorkflowExecutionResponse{}, nil
+		},
+	)
+	s.mockVisibilityMgr.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&manager.CountWorkflowExecutionsResponse{Count: 0}, nil)
+
+	request := &workflowservice.StartBatchOperationRequest{
+		Namespace: testNamespace.String(),
+		JobId:     uuid.NewString(),
+		Operation: &workflowservice.StartBatchOperationRequest_ResetOperation{
+			ResetOperation: &batchpb.BatchOperationReset{
+				Options: &commonpb.ResetOptions{
+					Target: &commonpb.ResetOptions_WorkflowTaskId{
+						WorkflowTaskId: 10,
+					},
+				},
+				PostResetOperations: postResetOps,
+				Identity:            identity,
+			},
+		},
+		Reason:     reason,
+		Executions: executions,
+	}
+
+	_, err := wh.StartBatchOperation(context.Background(), request)
+	s.NoError(err)
+}
+
+func (s *WorkflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Reset_EmptyPostResetOperations() {
+	testNamespace := namespace.Name("test-namespace")
+	namespaceID := namespace.ID(uuid.NewString())
+	executions := []*commonpb.WorkflowExecution{
+		{
+			WorkflowId: uuid.NewString(),
+			RunId:      uuid.NewString(),
+		},
+	}
+	reason := "reason"
+	identity := "identity"
+	config := s.newConfig()
+	wh := s.getWorkflowHandler(config)
+
+	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(namespaceID, nil).AnyTimes()
+	s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(
+			_ context.Context,
+			request *historyservice.StartWorkflowExecutionRequest,
+			_ ...grpc.CallOption,
+		) (*historyservice.StartWorkflowExecutionResponse, error) {
+			// Decode the input and verify PostResetOperations slice is properly initialized
+			var batchParams batcher.BatchParams
+			err := payloads.Decode(request.StartRequest.Input, &batchParams)
+			s.NoError(err)
+
+			// When PostResetOperations is empty, the slice should be empty, not nil
+			s.NotNil(batchParams.ResetParams.PostResetOperations)
+			s.Len(batchParams.ResetParams.PostResetOperations, 0)
+
+			return &historyservice.StartWorkflowExecutionResponse{}, nil
+		},
+	)
+	s.mockVisibilityMgr.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&manager.CountWorkflowExecutionsResponse{Count: 0}, nil)
+
+	request := &workflowservice.StartBatchOperationRequest{
+		Namespace: testNamespace.String(),
+		JobId:     uuid.NewString(),
+		Operation: &workflowservice.StartBatchOperationRequest_ResetOperation{
+			ResetOperation: &batchpb.BatchOperationReset{
+				Options: &commonpb.ResetOptions{
+					Target: &commonpb.ResetOptions_WorkflowTaskId{
+						WorkflowTaskId: 10,
+					},
+				},
+				PostResetOperations: []*workflowpb.PostResetOperation{}, // Empty slice
+				Identity:            identity,
+			},
+		},
+		Reason:     reason,
+		Executions: executions,
+	}
+
+	_, err := wh.StartBatchOperation(context.Background(), request)
+	s.NoError(err)
+}
+
 func (s *WorkflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_TooMany() {
 	testNamespace := namespace.Name("test-namespace")
 	namespaceID := namespace.ID(uuid.NewString())

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -79,6 +79,11 @@ type (
 		// json dataconverter, which doesn't support the "oneof" field in ResetOptions.
 		ResetOptions []byte
 		resetOptions *commonpb.ResetOptions // deserialized version
+
+		// This is a slice of serialized workflowpb.PostResetOperation.
+		// For the same reason as ResetOptions, we manually serialize/deserialize it.
+		PostResetOperations [][]byte
+		postResetOperations []*workflowpb.PostResetOperation
 		// Deprecated fields:
 		ResetType        enumspb.ResetType
 		ResetReapplyType enumspb.ResetReapplyType


### PR DESCRIPTION
## What changed?
We had missed copying over the `BatchOperationReset.PostResetOperation` to `ResetParams` in the workflow handler. Additionally since this proto message contains `oneof` we need to perform manual protobuf marshal/unmarshal to avoid json serialization/deserialization issues.

## Why?
This parameter is needed to support post reset operations like updating versioning in a batch operation.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
N/A