### PR TITLE
Remove workflowCache from QueueFactory interface

### DIFF
--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -100,9 +100,8 @@ func newQueueFactoryBase(params ArchivalQueueFactoryParams) QueueFactoryBase {
 // CreateQueue creates a new archival queue for the given shard.
 func (f *archivalQueueFactory) CreateQueue(
 	shard historyi.ShardContext,
-	workflowCache wcache.Cache,
 ) queues.Queue {
-	executor := f.newArchivalTaskExecutor(shard, workflowCache)
+	executor := f.newArchivalTaskExecutor(shard, f.WorkflowCache)
 	if f.ExecutorWrapper != nil {
 		executor = f.ExecutorWrapper.Wrap(executor)
 	}

--- a/service/history/archival_queue_factory_test.go
+++ b/service/history/archival_queue_factory_test.go
@@ -62,7 +62,7 @@ func TestArchivalQueueFactory(t *testing.T) {
 			TracerProvider:    noop.NewTracerProvider(),
 		},
 	})
-	queue := queueFactory.CreateQueue(mockShard, nil)
+	queue := queueFactory.CreateQueue(mockShard)
 
 	require.NotNil(t, queue)
 	assert.Equal(t, tasks.CategoryArchival, queue.Category())

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -217,7 +217,7 @@ func NewEngineWithShardContext(
 
 	historyEngImpl.queueProcessors = make(map[tasks.Category]queues.Queue)
 	for _, factory := range queueProcessorFactories {
-		processor := factory.CreateQueue(shard, workflowCache)
+		processor := factory.CreateQueue(shard)
 		historyEngImpl.queueProcessors[processor.Category()] = processor
 	}
 

--- a/service/history/memory_scheduled_queue_factory.go
+++ b/service/history/memory_scheduled_queue_factory.go
@@ -23,6 +23,7 @@ type (
 
 		NamespaceRegistry namespace.Registry
 		ClusterMetadata   cluster.Metadata
+		WorkflowCache     wcache.Cache
 		Config            *configs.Config
 		TimeSource        clock.TimeSource
 		MetricsHandler    metrics.Handler
@@ -38,6 +39,7 @@ type (
 
 		namespaceRegistry namespace.Registry
 		clusterMetadata   cluster.Metadata
+		workflowCache     wcache.Cache
 		timeSource        clock.TimeSource
 		metricsHandler    metrics.Handler
 		tracer            trace.Tracer
@@ -66,6 +68,7 @@ func NewMemoryScheduledQueueFactory(
 		priorityAssigner:  queues.NewPriorityAssigner(),
 		namespaceRegistry: params.NamespaceRegistry,
 		clusterMetadata:   params.ClusterMetadata,
+		workflowCache:     params.WorkflowCache,
 		timeSource:        params.TimeSource,
 		metricsHandler:    metricsHandler,
 		tracer:            params.TracerProvider.Tracer(telemetry.ComponentQueueMemory),
@@ -84,14 +87,13 @@ func (f *memoryScheduledQueueFactory) Stop() {
 
 func (f *memoryScheduledQueueFactory) CreateQueue(
 	shardCtx historyi.ShardContext,
-	workflowCache wcache.Cache,
 ) queues.Queue {
 
 	// Reuse TimerQueueActiveTaskExecutor only to executeWorkflowTaskTimeoutTask.
 	// Unused dependencies are nil.
 	speculativeWorkflowTaskTimeoutExecutor := newTimerQueueActiveTaskExecutor(
 		shardCtx,
-		workflowCache,
+		f.workflowCache,
 		nil,
 		f.logger,
 		f.metricsHandler,

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -17,7 +17,6 @@ import (
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/tasks"
-	wcache "go.temporal.io/server/service/history/workflow/cache"
 	"go.uber.org/fx"
 )
 
@@ -192,7 +191,6 @@ func (f *outboundQueueFactory) Stop() {
 
 func (f *outboundQueueFactory) CreateQueue(
 	shardContext historyi.ShardContext,
-	workflowCache wcache.Cache,
 ) queues.Queue {
 	logger := log.With(shardContext.GetLogger(), tag.ComponentOutboundQueue)
 	metricsHandler := getOutbountQueueProcessorMetricsHandler(f.MetricsHandler)
@@ -208,7 +206,7 @@ func (f *outboundQueueFactory) CreateQueue(
 
 	activeExecutor := newOutboundQueueActiveTaskExecutor(
 		shardContext,
-		workflowCache,
+		f.WorkflowCache,
 		logger,
 		metricsHandler,
 	)
@@ -216,7 +214,7 @@ func (f *outboundQueueFactory) CreateQueue(
 	// not implemented yet
 	standbyExecutor := newOutboundQueueStandbyTaskExecutor(
 		shardContext,
-		workflowCache,
+		f.WorkflowCache,
 		currentClusterName,
 		logger,
 		metricsHandler,

--- a/service/history/queue_factory_base.go
+++ b/service/history/queue_factory_base.go
@@ -34,14 +34,8 @@ type (
 		Start()
 		Stop()
 
-		// TODO:
-		// 1. Remove the cache parameter after workflow cache become a host level component
-		// and it can be provided as a parameter when creating a QueueFactory instance.
-		// Currently, workflow cache is shard level, but we can't get it from shard or engine interface,
-		// as that will lead to a cycle dependency issue between shard and workflow package.
-		// 2. Move this interface to queues package after 1 is done so that there's no cycle dependency
-		// between workflow and queues package.
-		CreateQueue(shardContext historyi.ShardContext, cache wcache.Cache) queues.Queue
+		// TODO: Move this interface to queues package
+		CreateQueue(shardContext historyi.ShardContext) queues.Queue
 	}
 
 	QueueFactoryBaseParams struct {
@@ -49,6 +43,7 @@ type (
 
 		NamespaceRegistry    namespace.Registry
 		ClusterMetadata      cluster.Metadata
+		WorkflowCache        wcache.Cache
 		Config               *configs.Config
 		TimeSource           clock.TimeSource
 		MetricsHandler       metrics.Handler

--- a/service/history/queue_factory_base_test.go
+++ b/service/history/queue_factory_base_test.go
@@ -26,6 +26,7 @@ import (
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
+	"go.temporal.io/server/service/history/workflow/cache"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
 )
@@ -152,4 +153,5 @@ type unusedDependencies struct {
 	archival.Archiver
 	workflow.RelocatableAttributesFetcher
 	persistence.HistoryTaskQueueManager
+	cache.Cache
 }

--- a/service/history/timer_queue_factory.go
+++ b/service/history/timer_queue_factory.go
@@ -12,7 +12,6 @@ import (
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/tasks"
-	wcache "go.temporal.io/server/service/history/workflow/cache"
 	"go.uber.org/fx"
 )
 
@@ -69,7 +68,6 @@ func NewTimerQueueFactory(
 
 func (f *timerQueueFactory) CreateQueue(
 	shardContext historyi.ShardContext,
-	workflowCache wcache.Cache,
 ) queues.Queue {
 	logger := log.With(shardContext.GetLogger(), tag.ComponentTimerQueue)
 	metricsHandler := f.MetricsHandler.WithTags(metrics.OperationTag(metrics.OperationTimerQueueProcessorScope))
@@ -77,7 +75,7 @@ func (f *timerQueueFactory) CreateQueue(
 	currentClusterName := f.ClusterMetadata.GetCurrentClusterName()
 	workflowDeleteManager := deletemanager.NewDeleteManager(
 		shardContext,
-		workflowCache,
+		f.WorkflowCache,
 		f.Config,
 		shardContext.GetTimeSource(),
 		f.VisibilityManager,
@@ -109,7 +107,7 @@ func (f *timerQueueFactory) CreateQueue(
 
 	activeExecutor := newTimerQueueActiveTaskExecutor(
 		shardContext,
-		workflowCache,
+		f.WorkflowCache,
 		workflowDeleteManager,
 		logger,
 		f.MetricsHandler,
@@ -120,7 +118,7 @@ func (f *timerQueueFactory) CreateQueue(
 
 	standbyExecutor := newTimerQueueStandbyTaskExecutor(
 		shardContext,
-		workflowCache,
+		f.WorkflowCache,
 		workflowDeleteManager,
 		f.MatchingRawClient,
 		nil, // TODO - use ChasmEngine once we have an implementation ready

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -12,7 +12,6 @@ import (
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/tasks"
-	wcache "go.temporal.io/server/service/history/workflow/cache"
 	"go.uber.org/fx"
 )
 
@@ -72,7 +71,6 @@ func NewTransferQueueFactory(
 
 func (f *transferQueueFactory) CreateQueue(
 	shardContext historyi.ShardContext,
-	workflowCache wcache.Cache,
 ) queues.Queue {
 	logger := log.With(shardContext.GetLogger(), tag.ComponentTransferQueue)
 	metricsHandler := f.MetricsHandler.WithTags(metrics.OperationTag(metrics.OperationTransferQueueProcessorScope))
@@ -105,7 +103,7 @@ func (f *transferQueueFactory) CreateQueue(
 
 	activeExecutor := newTransferQueueActiveTaskExecutor(
 		shardContext,
-		workflowCache,
+		f.WorkflowCache,
 		f.SdkClientFactory,
 		logger,
 		f.MetricsHandler,
@@ -117,7 +115,7 @@ func (f *transferQueueFactory) CreateQueue(
 
 	standbyExecutor := newTransferQueueStandbyTaskExecutor(
 		shardContext,
-		workflowCache,
+		f.WorkflowCache,
 		logger,
 		f.MetricsHandler,
 		currentClusterName,

--- a/service/history/visibility_queue_factory.go
+++ b/service/history/visibility_queue_factory.go
@@ -9,7 +9,6 @@ import (
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/tasks"
-	wcache "go.temporal.io/server/service/history/workflow/cache"
 	"go.uber.org/fx"
 )
 
@@ -65,7 +64,6 @@ func NewVisibilityQueueFactory(
 
 func (f *visibilityQueueFactory) CreateQueue(
 	shard historyi.ShardContext,
-	workflowCache wcache.Cache,
 ) queues.Queue {
 	logger := log.With(shard.GetLogger(), tag.ComponentVisibilityQueue)
 	metricsHandler := f.MetricsHandler.WithTags(metrics.OperationTag(metrics.OperationVisibilityQueueProcessorScope))
@@ -96,7 +94,7 @@ func (f *visibilityQueueFactory) CreateQueue(
 
 	executor := newVisibilityQueueTaskExecutor(
 		shard,
-		workflowCache,
+		f.WorkflowCache,
 		f.VisibilityMgr,
 		logger,
 		f.MetricsHandler,


### PR DESCRIPTION
## What changed?
- Remove workflowCache from QueueFactory interface

## Why?
- Address old TODO, pave the road for moving QueueFactory interface into history/queues package.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
