### PR TITLE
Allow reading history reverse when mutable state does not have LastFirstEventTxnId set

### DIFF
--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -1083,6 +1083,9 @@ func (m *executionManagerImpl) filterHistoryNodesReverse(
 		if lastNodeID == defaultLastNodeID {
 			lastNodeID = node.NodeID
 		}
+		if lastTransactionID == 0 {
+			m.logger.Warn("lastTransactionID is not set, this should not happen")
+		}
 		if lastTransactionID != 0 && // in the case where the lastTransactionID is not set, we will not compare
 			node.TransactionID != lastTransactionID {
 			continue

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -1083,7 +1083,8 @@ func (m *executionManagerImpl) filterHistoryNodesReverse(
 		if lastNodeID == defaultLastNodeID {
 			lastNodeID = node.NodeID
 		}
-		if node.TransactionID != lastTransactionID {
+		if lastTransactionID != 0 && // in the case where the lastTransactionID is not set, we will not compare
+			node.TransactionID != lastTransactionID {
 			continue
 		}
 

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -1060,7 +1060,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 		historyEvents = append(historyEvents, events)
 	}
 
-	prevTxnID := common.EmptyEventTaskID
+	prevTxnID := localMutableState.GetExecutionInfo().LastFirstEventTxnId
 	fetchFromRemoteAndAppend := func(
 		startID, // exclusive
 		startVersion,
@@ -1188,6 +1188,7 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 	}
 	versionHistoryToAppend.Items = versionhistory.CopyVersionHistoryItems(sourceVersionHistory.Items)
 	localMutableState.SetHistoryBuilder(historybuilder.NewImmutableForUpdateNextEventID(sourceLastItem))
+	localMutableState.GetExecutionInfo().LastFirstEventTxnId = prevTxnID
 	return nil
 }
 


### PR DESCRIPTION
## What changed?
Allow reading history reverse when mutable state does not have LastFirstEventTxnId set
## Why?
LastFirstEventTxnId maybe not set because of replication.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
No risk.