### PR TITLE
Reset+version_move: fix decoding bug and add functional test

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -74,7 +74,6 @@ import (
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -4636,7 +4635,7 @@ func (wh *WorkflowHandler) StartBatchOperation(
 			resetParams.ResetOptions = encodedResetOptions
 			resetParams.PostResetOperations = make([][]byte, len(op.ResetOperation.PostResetOperations))
 			for i, postResetOperation := range op.ResetOperation.PostResetOperations {
-				encodedPostResetOperations, err := protojson.Marshal(postResetOperation)
+				encodedPostResetOperations, err := postResetOperation.Marshal()
 				if err != nil {
 					return nil, err
 				}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -54,6 +54,7 @@ import (
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/common/testing/protoassert"
+	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/components/callbacks"
 	"go.temporal.io/server/service/history/api"
 	"go.temporal.io/server/service/history/tests"
@@ -62,7 +63,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -81,6 +81,7 @@ const (
 type (
 	WorkflowHandlerSuite struct {
 		suite.Suite
+		protorequire.ProtoAssertions
 		*require.Assertions
 
 		controller                         *gomock.Controller
@@ -2537,11 +2538,11 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Reset_
 
 				// Verify we can unmarshal back to the original operation
 				var decodedOp workflowpb.PostResetOperation
-				err := protojson.Unmarshal(encoded, &decodedOp)
+				err := decodedOp.Unmarshal(encoded)
 				s.NoError(err, "Should be able to unmarshal PostResetOperations[%d]", i)
 
 				// Verify the content matches the original
-				s.Equal(postResetOps[i].GetVariant(), decodedOp.GetVariant())
+				s.ProtoEqual(postResetOps[i], &decodedOp)
 			}
 
 			return &historyservice.StartWorkflowExecutionResponse{}, nil

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -24,7 +24,6 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/sdk"
 	"golang.org/x/time/rate"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -80,7 +79,7 @@ func (a *activities) BatchActivity(ctx context.Context, batchParams BatchParams)
 		batchParams.ResetParams.postResetOperations = make([]*workflowpb.PostResetOperation, len(postOps))
 		for i, serializedOp := range postOps {
 			op := &workflowpb.PostResetOperation{}
-			if err := protojson.Unmarshal(serializedOp, op); err != nil {
+			if err := op.Unmarshal(serializedOp); err != nil {
 				logger.Error("Failed to deserialize batch post reset operation", tag.Error(err))
 				return hbd, err
 			}

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -24,6 +24,7 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/sdk"
 	"golang.org/x/time/rate"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -79,7 +80,7 @@ func (a *activities) BatchActivity(ctx context.Context, batchParams BatchParams)
 		batchParams.ResetParams.postResetOperations = make([]*workflowpb.PostResetOperation, len(postOps))
 		for i, serializedOp := range postOps {
 			op := &workflowpb.PostResetOperation{}
-			if err := op.Unmarshal(serializedOp); err != nil {
+			if err := protojson.Unmarshal(serializedOp, op); err != nil {
 				logger.Error("Failed to deserialize batch post reset operation", tag.Error(err))
 				return hbd, err
 			}

--- a/tests/workflow_reset_test.go
+++ b/tests/workflow_reset_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
+	batchpb "go.temporal.io/api/batch/v1"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	deploymentpb "go.temporal.io/api/deployment/v1"
@@ -266,6 +267,124 @@ func (s *WorkflowResetSuite) TestResetWorkflowWithOptionsUpdate() {
 	s.ProtoEqual(override, info.WorkflowExecutionInfo.GetVersioningInfo().GetVersioningOverride())
 }
 
+// Test batch reset operation with version update as post reset operation
+func (s *WorkflowResetSuite) TestBatchResetWithOptionsUpdate() {
+	ctx := testcore.NewContext()
+
+	// Create 2 workflows for batch reset
+	workflowID1 := "test-batch-reset-1-" + uuid.NewString()
+	workflowID2 := "test-batch-reset-2-" + uuid.NewString()
+
+	runs1 := s.setupRuns(ctx, workflowID1, 1, true)
+	runs2 := s.setupRuns(ctx, workflowID2, 1, true)
+
+	// Create versioning override for post-reset operations
+	override := &workflowpb.VersioningOverride{
+		Override: &workflowpb.VersioningOverride_Pinned{
+			Pinned: &workflowpb.VersioningOverride_PinnedOverride{
+				Behavior: workflowpb.VersioningOverride_PINNED_OVERRIDE_BEHAVIOR_PINNED,
+				Version: &deploymentpb.WorkerDeploymentVersion{
+					DeploymentName: "batch-testing",
+					BuildId:        "v.456",
+				},
+			},
+		},
+	}
+
+	// Start batch reset operation
+	batchJobID := "batch-reset-job-" + uuid.NewString()
+	_, err := s.FrontendClient().StartBatchOperation(ctx, &workflowservice.StartBatchOperationRequest{
+		Namespace: s.Namespace().String(),
+		JobId:     batchJobID,
+		Reason:    "testing-batch-reset-with-options",
+		Executions: []*commonpb.WorkflowExecution{
+			{WorkflowId: workflowID1, RunId: runs1[0]},
+			{WorkflowId: workflowID2, RunId: runs2[0]},
+		},
+		Operation: &workflowservice.StartBatchOperationRequest_ResetOperation{
+			ResetOperation: &batchpb.BatchOperationReset{
+				Identity: "test-batch-reset",
+				Options: &commonpb.ResetOptions{
+					// Target: &commonpb.ResetOptions_FirstWorkflowTask{},
+					Target: &commonpb.ResetOptions_WorkflowTaskId{
+						WorkflowTaskId: s.getFirstWFTaskCompleteEventID(ctx, workflowID1, runs1[0]),
+					},
+				},
+				PostResetOperations: []*workflowpb.PostResetOperation{
+					{
+						Variant: &workflowpb.PostResetOperation_UpdateWorkflowOptions_{
+							UpdateWorkflowOptions: &workflowpb.PostResetOperation_UpdateWorkflowOptions{
+								WorkflowExecutionOptions: &workflowpb.WorkflowExecutionOptions{
+									VersioningOverride: override,
+								},
+								UpdateMask: &fieldmaskpb.FieldMask{
+									Paths: []string{
+										"versioning_override",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	// Wait for batch operation to complete
+	s.Eventually(func() bool {
+		resp, err := s.FrontendClient().DescribeBatchOperation(ctx, &workflowservice.DescribeBatchOperationRequest{
+			Namespace: s.Namespace().String(),
+			JobId:     batchJobID,
+		})
+		if err != nil {
+			return false
+		}
+		return resp.State == enumspb.BATCH_OPERATION_STATE_COMPLETED
+	}, 20*time.Second, 1*time.Second, "Batch operation should complete")
+
+	// Get the new run IDs after reset
+	// The workflows should be terminated and new runs started
+	newWorkflows := s.getLatestRunsForWorkflows(ctx, []string{workflowID1, workflowID2})
+	s.Len(newWorkflows, 2)
+
+	// Verify both workflows have the options updated event and correct versioning override
+	for i, workflowID := range []string{workflowID1, workflowID2} {
+		newRunID := newWorkflows[i]
+
+		// Find the options updated event in history
+		var optionsUpdatedEvent *historypb.HistoryEvent
+		hist := s.SdkClient().GetWorkflowHistory(ctx, workflowID, newRunID, false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+		for hist.HasNext() {
+			event, err := hist.Next()
+			s.NoError(err)
+			if event.EventType == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED {
+				optionsUpdatedEvent = event
+				break
+			}
+		}
+		s.NotNil(optionsUpdatedEvent, "Workflow %s should have options updated event", workflowID)
+		s.ProtoEqual(override, optionsUpdatedEvent.GetWorkflowExecutionOptionsUpdatedEventAttributes().GetVersioningOverride())
+
+		// Verify the workflow execution info has the correct versioning override
+		info, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowID, newRunID)
+		s.NoError(err)
+
+		expectedOverride := &workflowpb.VersioningOverride{
+			Override: &workflowpb.VersioningOverride_Pinned{
+				Pinned: &workflowpb.VersioningOverride_PinnedOverride{
+					Behavior: workflowpb.VersioningOverride_PINNED_OVERRIDE_BEHAVIOR_PINNED,
+					Version: &deploymentpb.WorkerDeploymentVersion{
+						DeploymentName: "batch-testing",
+						BuildId:        "v.456",
+					},
+				},
+			},
+		}
+		s.ProtoEqual(expectedOverride, info.WorkflowExecutionInfo.GetVersioningInfo().GetVersioningOverride())
+	}
+}
+
 // Helper methods
 
 // getFirstWFTaskCompleteEventID finds the first event corresponding to workflow task completion. This can be used as a good reset point for tests in this suite.
@@ -399,4 +518,16 @@ func (s *WorkflowResetSuite) prepareSingleRun(ctx context.Context, workflowID st
 	})
 	s.NoError(err)
 	return run.GetRunID()
+}
+
+// getLatestRunsForWorkflows gets the latest run IDs for the given workflow IDs
+func (s *WorkflowResetSuite) getLatestRunsForWorkflows(ctx context.Context, workflowIDs []string) []string {
+	var runIDs []string
+	for _, workflowID := range workflowIDs {
+		// Describe the workflow to get the latest run
+		info, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowID, "")
+		s.NoError(err)
+		runIDs = append(runIDs, info.WorkflowExecutionInfo.Execution.RunId)
+	}
+	return runIDs
 }

--- a/tests/workflow_reset_test.go
+++ b/tests/workflow_reset_test.go
@@ -305,7 +305,6 @@ func (s *WorkflowResetSuite) TestBatchResetWithOptionsUpdate() {
 			ResetOperation: &batchpb.BatchOperationReset{
 				Identity: "test-batch-reset",
 				Options: &commonpb.ResetOptions{
-					// Target: &commonpb.ResetOptions_FirstWorkflowTask{},
 					Target: &commonpb.ResetOptions_WorkflowTaskId{
 						WorkflowTaskId: s.getFirstWFTaskCompleteEventID(ctx, workflowID1, runs1[0]),
 					},
@@ -381,7 +380,7 @@ func (s *WorkflowResetSuite) TestBatchResetWithOptionsUpdate() {
 				},
 			},
 		}
-		s.ProtoEqual(expectedOverride, info.WorkflowExecutionInfo.GetVersioningInfo().GetVersioningOverride())
+		s.ProtoEqual(expectedOverride.GetPinned().GetVersion(), info.WorkflowExecutionInfo.GetVersioningInfo().GetVersioningOverride().GetPinned().GetVersion())
 	}
 }
 


### PR DESCRIPTION
## What changed?
I was not decoding the post reset operation message properly in the batch workflow activity. I should have used `protojson.Unmarshal` (instead of op.Unmarshal() which uses proto.Unmarshal())
Added functional test to cover the batch reset operation end-to-end 

## Why?
Fixes a bug I introduced in https://github.com/temporalio/temporal/pull/7911

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

