### PR TITLE
Add DescribeTaskQueue Stats cache test

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -1142,25 +1142,41 @@ func (e *matchingEngineImpl) DescribeTaskQueue(
 
 		// TODO bug fix: We cache the last response for each build ID. timeSinceLastFanOut is the last fan out time, that means some enteries in the cache can be more stale if
 		// user is calling this API back-to-back but with different version selection.
+		cacheKeyFunc := func(buildId string, taskQueueType enumspb.TaskQueueType) string {
+			return fmt.Sprintf("%s.%s", buildId, taskQueueType.String())
+		}
 		missingItemsInCache := false
-		physicalInfoByBuildId := make(map[string]map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo)
+		physicalTqInfos := make(map[string]map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo)
 		//nolint:staticcheck // SA1019 deprecated
 		requestedBuildIds, err := e.getBuildIds(req.Versions)
 		if err != nil {
 			return nil, err
 		}
-		for b := range requestedBuildIds {
-			c := rootPM.GetCache(b) // any expired cache entry will return nil
-			if c == nil {
-				missingItemsInCache = true
-				break // once we find a missing item, we can stop checking the cache
+
+		for buildId := range requestedBuildIds {
+			physicalTqInfos[buildId] = make(map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo)
+			//nolint:staticcheck // SA1019 deprecated
+			for _, taskQueueType := range req.TaskQueueTypes {
+				cacheKey := cacheKeyFunc(buildId, taskQueueType)
+				cachedInfo := rootPM.GetCache(cacheKey) // any expired cache entry will return nil
+				if cachedInfo == nil {
+					missingItemsInCache = true
+					break // once we find a missing item, we can stop checking the cache
+				}
+				//revive:disable-next-line:unchecked-type-assertion
+				physicalTqInfos[buildId][taskQueueType] = cachedInfo.(*taskqueuespb.PhysicalTaskQueueInfo)
 			}
-			//revive:disable-next-line:unchecked-type-assertion
-			physicalInfoByBuildId[b] = c.(map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo)
+			if missingItemsInCache {
+				break // stop checking other build IDs if we already found missing items
+			}
 		}
+
 		if missingItemsInCache {
 			// Fan out to partitions to get the needed info
-			var foundBuildIds []string
+			var foundItems []struct {
+				buildId       string
+				taskQueueType enumspb.TaskQueueType
+			}
 			numPartitions := max(tqConfig.NumWritePartitions(), tqConfig.NumReadPartitions())
 			for _, taskQueueType := range req.TaskQueueTypes {
 				for i := 0; i < numPartitions; i++ {
@@ -1179,20 +1195,22 @@ func (e *matchingEngineImpl) DescribeTaskQueue(
 						return nil, err
 					}
 					for buildId, vii := range partitionResp.VersionsInfoInternal {
-						foundBuildIds = append(foundBuildIds, buildId)
-						if _, ok := physicalInfoByBuildId[buildId]; !ok {
-							physicalInfoByBuildId[buildId] = make(map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo)
+						foundItems = append(foundItems, struct {
+							buildId       string
+							taskQueueType enumspb.TaskQueueType
+						}{buildId, taskQueueType})
+
+						if _, ok := physicalTqInfos[buildId]; !ok {
+							physicalTqInfos[buildId] = make(map[enumspb.TaskQueueType]*taskqueuespb.PhysicalTaskQueueInfo)
 						}
-						if physInfo, ok := physicalInfoByBuildId[buildId][taskQueueType]; !ok {
-							physicalInfoByBuildId[buildId][taskQueueType] = vii.PhysicalTaskQueueInfo
+						if physInfo, ok := physicalTqInfos[buildId][taskQueueType]; !ok {
+							physicalTqInfos[buildId][taskQueueType] = vii.PhysicalTaskQueueInfo
 						} else {
 							var mergedStats *taskqueuepb.TaskQueueStats
 
-							// only report Task Queue Statistics if requested.
 							if req.GetReportStats() {
-								totalStats := physicalInfoByBuildId[buildId][taskQueueType].TaskQueueStats
+								totalStats := physicalTqInfos[buildId][taskQueueType].TaskQueueStats
 								partitionStats := vii.PhysicalTaskQueueInfo.TaskQueueStats
-
 								mergedStats = &taskqueuepb.TaskQueueStats{
 									ApproximateBacklogCount: totalStats.ApproximateBacklogCount + partitionStats.ApproximateBacklogCount,
 									ApproximateBacklogAge:   largerBacklogAge(totalStats.ApproximateBacklogAge, partitionStats.ApproximateBacklogAge),
@@ -1200,24 +1218,26 @@ func (e *matchingEngineImpl) DescribeTaskQueue(
 									TasksDispatchRate:       totalStats.TasksDispatchRate + partitionStats.TasksDispatchRate,
 								}
 							}
-							merged := &taskqueuespb.PhysicalTaskQueueInfo{
+
+							physicalTqInfos[buildId][taskQueueType] = &taskqueuespb.PhysicalTaskQueueInfo{
 								Pollers:        dedupPollers(append(physInfo.GetPollers(), vii.PhysicalTaskQueueInfo.GetPollers()...)),
 								TaskQueueStats: mergedStats,
 							}
-							physicalInfoByBuildId[buildId][taskQueueType] = merged
 						}
 					}
 				}
 			}
 
-			for _, b := range foundBuildIds {
-				rootPM.PutCache(b, physicalInfoByBuildId[b])
+			// put the found items into cache
+			for _, item := range foundItems {
+				physicalTqInfo := physicalTqInfos[item.buildId][item.taskQueueType]
+				rootPM.PutCache(cacheKeyFunc(item.buildId, item.taskQueueType), physicalTqInfo)
 			}
 		}
 
 		// smush internal info into versions info
 		versionsInfo := make(map[string]*taskqueuepb.TaskQueueVersionInfo, 0)
-		for bid, typeMap := range physicalInfoByBuildId {
+		for bid, typeMap := range physicalTqInfos {
 			typesInfo := make(map[int32]*taskqueuepb.TaskQueueTypeInfo, 0)
 			for taskQueueType, physicalInfo := range typeMap {
 				typesInfo[int32(taskQueueType)] = &taskqueuepb.TaskQueueTypeInfo{

--- a/tests/describe_task_queue_test.go
+++ b/tests/describe_task_queue_test.go
@@ -28,11 +28,27 @@ type (
 	DescribeTaskQueueSuite struct {
 		testcore.FunctionalTestBase
 	}
+
+	TaskQueueExpectations struct {
+		BacklogCount     int
+		MaxExtraTasks    int
+		ExpectedAddRate  bool
+		ExpectedDispatch bool
+	}
+
+	// TaskQueueExpectationsByType maps task queue types to their expectations
+	TaskQueueExpectationsByType map[enumspb.TaskQueueType]TaskQueueExpectations
 )
 
 func TestDescribeTaskQueueSuite(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, new(DescribeTaskQueueSuite))
+}
+
+func (s *DescribeTaskQueueSuite) SetupTest() {
+	s.FunctionalTestBase.SetupTest()
+	s.OverrideDynamicConfig(dynamicconfig.EnableDeploymentVersions, true)
+	s.OverrideDynamicConfig(dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs, true)
 }
 
 func (s *DescribeTaskQueueSuite) TestNonRoot() {
@@ -56,13 +72,14 @@ func (s *DescribeTaskQueueSuite) TestAddNoTasks_ValidateStats() {
 	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 4)
 	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 4)
 	s.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
-	s.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 0*time.Millisecond)
+	s.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond)
 
 	s.publishConsumeWorkflowTasksValidateStats(0, false)
 }
 
 func (s *DescribeTaskQueueSuite) TestAddSingleTaskPerVersion_ValidateStats() {
 	s.OverrideDynamicConfig(dynamicconfig.MatchingUpdateAckInterval, 5*time.Second)
+	s.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond)
 
 	s.RunTestWithMatchingBehavior(func() {
 		s.publishConsumeWorkflowTasksValidateStats(2, false) // 1 unversioned, 1 versioned
@@ -78,12 +95,39 @@ func (s *DescribeTaskQueueSuite) TestAddMultipleTasks_MultiplePartitions_Validat
 	s.publishConsumeWorkflowTasksValidateStats(50, false) // 25 unversioned, 25 versioned
 }
 
-func (s *DescribeTaskQueueSuite) TestAddSingleTaskPerVersion_SinglePartition_ValidateStats() {
-	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
-	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
+// NOTE: Cache _eviction_ is already covered by the other tests.
+func (s *DescribeTaskQueueSuite) TestAddMultipleTasks_MultiplePartitions_ValidateStats_Cached() {
 	s.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
+	s.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Minute) // using a long TTL to verify caching
 
-	s.publishConsumeWorkflowTasksValidateStats(2, true) // 1 unversioned, 1 versioned
+	tqName := testcore.RandomizeStr("backlog-counter-task-queue")
+	workflows := 50 // 25 unversioned, 25 versioned
+
+	// Expect at least *one* of the workflow/activity tasks to be in the stats.
+	expectations := TaskQueueExpectations{
+		BacklogCount:     1,
+		MaxExtraTasks:    workflows,
+		ExpectedAddRate:  true,
+		ExpectedDispatch: true,
+	}
+
+	s.enqueueWorkflows(workflows, tqName)
+	s.enqueueActivitiesForEachWorkflow(2, tqName) // to prevent flakiness, ensure 1 task per version was added
+
+	// Expect the workflow backlog to be non-empty now.
+	s.validateDescribeTaskQueueByType(tqName, enumspb.TASK_QUEUE_TYPE_WORKFLOW, expectations, false)
+
+	s.enqueueActivitiesForEachWorkflow(workflows-2, tqName)
+	s.pollActivities(2, tqName) // to prevent flakiness, ensure 1 task per version was added
+
+	// Expect the activity backlog to be non-empty now.
+	s.validateDescribeTaskQueueByType(tqName, enumspb.TASK_QUEUE_TYPE_ACTIVITY, expectations, false)
+
+	s.pollActivities(workflows-2, tqName)
+
+	// Despite polling all the workflows/activies; the stats won't have changed at all since they were cached.
+	s.validateDescribeTaskQueueByType(tqName, enumspb.TASK_QUEUE_TYPE_WORKFLOW, expectations, false)
+	s.validateDescribeTaskQueueByType(tqName, enumspb.TASK_QUEUE_TYPE_ACTIVITY, expectations, false)
 }
 
 // publish 50% to default/unversioned task queue and 50% to versioned task queue
@@ -92,31 +136,82 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateStats(workfl
 		s.T().Fatal("workflows must be an even number to ensure half of them are versioned and half are unversioned")
 	}
 
-	s.OverrideDynamicConfig(dynamicconfig.EnableDeploymentVersions, true)
-	s.OverrideDynamicConfig(dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs, true)
+	tqName := testcore.RandomizeStr("backlog-counter-task-queue")
 
-	expectedBacklogCount := make(map[enumspb.TaskQueueType]int64)
-	maxBacklogExtraTasks := make(map[enumspb.TaskQueueType]int64)
-	expectedAddRate := make(map[enumspb.TaskQueueType]bool)
-	expectedDispatchRate := make(map[enumspb.TaskQueueType]bool)
+	// verify both workflow and activity backlogs are empty
+	expectations := TaskQueueExpectationsByType{
+		enumspb.TASK_QUEUE_TYPE_WORKFLOW: {
+			BacklogCount:     0,
+			MaxExtraTasks:    0,
+			ExpectedAddRate:  false,
+			ExpectedDispatch: false,
+		},
+		enumspb.TASK_QUEUE_TYPE_ACTIVITY: {
+			BacklogCount:     0,
+			MaxExtraTasks:    0,
+			ExpectedAddRate:  false,
+			ExpectedDispatch: false,
+		},
+	}
+
+	s.validateDescribeTaskQueue(tqName, expectations, singlePartition)
 
 	// Actual counter can be greater than the expected due to History->Matching retries.
 	// We make sure the counter is in range [expected, expected+maxExtraTasksAllowed].
-	maxExtraTasksAllowed := int64(3)
+	maxExtraTasksAllowed := 3
 	if workflows <= 0 {
-		maxExtraTasksAllowed = int64(0)
+		maxExtraTasksAllowed = 0
 	}
 
-	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = 0
-	maxBacklogExtraTasks[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = 0
-	expectedAddRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = false
-	expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = false
+	// enqueue workflows
+	s.enqueueWorkflows(workflows, tqName)
 
-	identity := "worker-multiple-tasks"
-	tqName := testcore.RandomizeStr("backlog-counter-task-queue")
+	// verify workflow backlog is not empty, activity backlog is empty
+	expectations[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = TaskQueueExpectations{
+		BacklogCount:     int(workflows),
+		MaxExtraTasks:    maxExtraTasksAllowed,
+		ExpectedAddRate:  workflows > 0,
+		ExpectedDispatch: false,
+	}
+
+	s.validateDescribeTaskQueue(tqName, expectations, singlePartition)
+
+	// poll all workflow tasks and enqueue one activity task for each workflow
+	s.enqueueActivitiesForEachWorkflow(workflows, tqName)
+
+	// verify workflow backlog is empty, activity backlog is not
+	expectations[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = TaskQueueExpectations{
+		BacklogCount:     0,
+		MaxExtraTasks:    maxExtraTasksAllowed,
+		ExpectedAddRate:  workflows > 0,
+		ExpectedDispatch: workflows > 0,
+	}
+	expectations[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = TaskQueueExpectations{
+		BacklogCount:     int(workflows),
+		MaxExtraTasks:    maxExtraTasksAllowed,
+		ExpectedAddRate:  workflows > 0,
+		ExpectedDispatch: false,
+	}
+
+	s.validateDescribeTaskQueue(tqName, expectations, singlePartition)
+
+	// poll all activity tasks
+	s.pollActivities(workflows, tqName)
+
+	// verify both workflow and activity backlogs are empty
+	expectations[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = TaskQueueExpectations{
+		BacklogCount:     0,
+		MaxExtraTasks:    maxExtraTasksAllowed,
+		ExpectedAddRate:  workflows > 0,
+		ExpectedDispatch: workflows > 0,
+	}
+
+	s.validateDescribeTaskQueue(tqName, expectations, singlePartition)
+}
+
+func (s *DescribeTaskQueueSuite) enqueueWorkflows(count int, tqName string) {
 	deploymentOpts := s.deploymentOptions()
 
-	// manually add worker deployment version
 	_, err := s.GetTestCluster().MatchingClient().SyncDeploymentUserData(
 		testcore.NewContext(), &matchingservice.SyncDeploymentUserDataRequest{
 			NamespaceId: s.NamespaceID().String(),
@@ -137,9 +232,8 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateStats(workfl
 	)
 	s.NoError(err)
 
-	// enqueue workflows
 	tq := &taskqueuepb.TaskQueue{Name: tqName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
-	for i := 0; i < workflows; i++ {
+	for i := 0; i < count; i++ {
 		wt := "functional-workflow-multiple-tasks"
 		workflowType := &commonpb.WorkflowType{Name: wt}
 
@@ -151,7 +245,6 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateStats(workfl
 			Input:               nil,
 			WorkflowRunTimeout:  durationpb.New(10 * time.Minute),
 			WorkflowTaskTimeout: durationpb.New(10 * time.Minute),
-			Identity:            identity,
 		}
 
 		// half of them are versioned
@@ -172,20 +265,15 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateStats(workfl
 		_, err = s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
 		s.NoError(err)
 	}
+}
 
-	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = int64(workflows)
-	maxBacklogExtraTasks[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = maxExtraTasksAllowed
-	expectedAddRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = workflows > 0
-	expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = false
+func (s *DescribeTaskQueueSuite) enqueueActivitiesForEachWorkflow(count int, tqName string) {
+	deploymentOpts := s.deploymentOptions()
 
-	s.validateDescribeTaskQueue(tqName, expectedBacklogCount, maxBacklogExtraTasks, expectedAddRate, expectedDispatchRate, singlePartition)
-
-	// poll workflow tasks
-	for i := 0; i < workflows; {
+	for i := 0; i < count; {
 		pollReq := &workflowservice.PollWorkflowTaskQueueRequest{
 			Namespace: s.Namespace().String(),
-			TaskQueue: tq,
-			Identity:  identity,
+			TaskQueue: &taskqueuepb.TaskQueue{Name: tqName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		}
 		if i%2 == 0 {
 			pollReq.DeploymentOptions = deploymentOpts
@@ -199,7 +287,6 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateStats(workfl
 
 		respondReq := &workflowservice.RespondWorkflowTaskCompletedRequest{
 			Namespace: s.Namespace().String(),
-			Identity:  identity,
 			TaskToken: resp.TaskToken,
 			Commands: []*commandpb.Command{
 				{
@@ -208,7 +295,7 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateStats(workfl
 						ScheduleActivityTaskCommandAttributes: &commandpb.ScheduleActivityTaskCommandAttributes{
 							ActivityId:            "activity1",
 							ActivityType:          &commonpb.ActivityType{Name: "activity_type1"},
-							TaskQueue:             tq,
+							TaskQueue:             &taskqueuepb.TaskQueue{Name: tqName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 							StartToCloseTimeout:   durationpb.New(time.Minute),
 							RequestEagerExecution: false,
 						},
@@ -225,28 +312,19 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateStats(workfl
 
 		i++
 	}
+}
 
-	// call describeTaskQueue to verify if the WTF backlog decreased and activity backlog increased
-	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = int64(0)
-	expectedAddRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = workflows > 0
-	expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW] = workflows > 0
-
-	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = int64(workflows)
-	maxBacklogExtraTasks[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = maxExtraTasksAllowed
-	expectedAddRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = workflows > 0
-	expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = false
-
-	s.validateDescribeTaskQueue(tqName, expectedBacklogCount, maxBacklogExtraTasks, expectedAddRate, expectedDispatchRate, singlePartition)
-
-	// poll activity tasks
-	for i := 0; i < workflows; {
+func (s *DescribeTaskQueueSuite) pollActivities(activities int, tqName string) {
+	for i := 0; i < activities; {
 		pollReq := &workflowservice.PollActivityTaskQueueRequest{
 			Namespace: s.Namespace().String(),
-			TaskQueue: tq,
-			Identity:  identity,
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: tqName,
+				Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+			},
 		}
 		if i%2 == 0 {
-			pollReq.DeploymentOptions = deploymentOpts
+			pollReq.DeploymentOptions = s.deploymentOptions()
 		}
 
 		resp, err := s.FrontendClient().PollActivityTaskQueue(
@@ -258,20 +336,27 @@ func (s *DescribeTaskQueueSuite) publishConsumeWorkflowTasksValidateStats(workfl
 		}
 		i++
 	}
-
-	expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = int64(0)
-	expectedAddRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = workflows > 0
-	expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY] = workflows > 0
-
-	s.validateDescribeTaskQueue(tqName, expectedBacklogCount, maxBacklogExtraTasks, expectedAddRate, expectedDispatchRate, singlePartition)
 }
 
 func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(
 	tq string,
-	expectedBacklogCount map[enumspb.TaskQueueType]int64,
-	maxBacklogExtraTasks map[enumspb.TaskQueueType]int64,
-	expectedAddRate map[enumspb.TaskQueueType]bool,
-	expectedDispatchRate map[enumspb.TaskQueueType]bool,
+	expectations TaskQueueExpectationsByType,
+	singlePartition bool,
+) {
+	for taskQueueType, expectation := range expectations {
+		s.validateDescribeTaskQueueByType(
+			tq,
+			taskQueueType,
+			expectation,
+			singlePartition,
+		)
+	}
+}
+
+func (s *DescribeTaskQueueSuite) validateDescribeTaskQueueByType(
+	tq string,
+	taskQueueType enumspb.TaskQueueType,
+	expectation TaskQueueExpectations,
 	singlePartition bool,
 ) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -295,7 +380,7 @@ func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(
 					})},
 				Unversioned: true,
 			},
-			TaskQueueTypes:         nil, // both defaultVersionInfoByType
+			TaskQueueTypes:         []enumspb.TaskQueueType{taskQueueType},
 			ReportPollers:          true,
 			ReportTaskReachability: false,
 			ReportStats:            true,
@@ -309,101 +394,57 @@ func (s *DescribeTaskQueueSuite) validateDescribeTaskQueue(
 		for _, v := range resp.GetVersionsInfo() {
 			a.Equal(enumspb.BUILD_ID_TASK_REACHABILITY_UNSPECIFIED, v.GetTaskReachability())
 
-			versionInfoByType := v.GetTypesInfo()
-			a.Equal(len(versionInfoByType), len(expectedBacklogCount))
+			info := v.GetTypesInfo()[int32(taskQueueType)]
+			a.NotNil(info, "should have info for task queue type %s", taskQueueType)
+			stats := info.Stats
 
-			validateDescribeTaskQueueStats(
-				a,
-				v.GetTypesInfo()[int32(enumspb.TASK_QUEUE_TYPE_WORKFLOW)].Stats,
-				expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW]/2, // since versioning is half/half
-				maxBacklogExtraTasks[enumspb.TASK_QUEUE_TYPE_WORKFLOW]/2,
-				expectedAddRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW],
-				expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW])
-
-			validateDescribeTaskQueueStats(
-				a,
-				v.GetTypesInfo()[int32(enumspb.TASK_QUEUE_TYPE_ACTIVITY)].Stats,
-				expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY]/2, // since versioning is half/half
-				maxBacklogExtraTasks[enumspb.TASK_QUEUE_TYPE_ACTIVITY]/2,
-				expectedAddRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY],
-				expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY])
+			// only expecting half of the backlog count for each version
+			validateDescribeTaskQueueStats(a, stats, TaskQueueExpectations{
+				BacklogCount:     expectation.BacklogCount / 2,
+				MaxExtraTasks:    expectation.MaxExtraTasks / 2,
+				ExpectedAddRate:  expectation.ExpectedAddRate,
+				ExpectedDispatch: expectation.ExpectedDispatch,
+			})
 		}
-	}, 6*time.Second, 100*time.Millisecond)
+	}, 5*time.Second, 100*time.Millisecond)
 
 	// ==== Default API Mode
 
 	s.EventuallyWithT(func(c *assert.CollectT) {
 		a := require.New(c)
 
-		// workflows task queue type
-
-		workflowResp, err := s.FrontendClient().DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
+		resp, err := s.FrontendClient().DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
 			Namespace:              s.Namespace().String(),
 			TaskQueue:              &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			TaskQueueType:          enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+			TaskQueueType:          taskQueueType,
 			IncludeTaskQueueStatus: true,
 			ReportStats:            true,
 		})
 		a.NoError(err)
-		a.NotNil(workflowResp)
+		a.NotNil(resp)
 
 		if singlePartition {
 			//nolint:staticcheck // SA1019 deprecated field
-			a.Equal(expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW]/2, // only reports default queue
-				workflowResp.TaskQueueStatus.GetBacklogCountHint())
+			a.Equal(expectation.BacklogCount/2, // only reports default queue
+				resp.TaskQueueStatus.GetBacklogCountHint())
 		}
 
-		validateDescribeTaskQueueStats(
-			a,
-			workflowResp.Stats,
-			expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_WORKFLOW],
-			maxBacklogExtraTasks[enumspb.TASK_QUEUE_TYPE_WORKFLOW],
-			expectedAddRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW],
-			expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_WORKFLOW])
-
-		// activity task queue type
-
-		activityResp, err := s.FrontendClient().DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
-			Namespace:              s.Namespace().String(),
-			TaskQueue:              &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-			TaskQueueType:          enumspb.TASK_QUEUE_TYPE_ACTIVITY,
-			IncludeTaskQueueStatus: true,
-			ReportStats:            true,
-		})
-		a.NoError(err)
-		a.NotNil(activityResp)
-
-		if singlePartition {
-			//nolint:staticcheck // SA1019 deprecated field
-			a.Equal(expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY]/2, // only reports default queue
-				activityResp.TaskQueueStatus.GetBacklogCountHint())
-		}
-
-		validateDescribeTaskQueueStats(
-			a,
-			activityResp.Stats,
-			expectedBacklogCount[enumspb.TASK_QUEUE_TYPE_ACTIVITY],
-			maxBacklogExtraTasks[enumspb.TASK_QUEUE_TYPE_ACTIVITY],
-			expectedAddRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY],
-			expectedDispatchRate[enumspb.TASK_QUEUE_TYPE_ACTIVITY])
-	}, 10*time.Second, 100*time.Millisecond)
+		validateDescribeTaskQueueStats(a, resp.Stats, expectation)
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
 func validateDescribeTaskQueueStats(
 	a *require.Assertions,
 	stats *taskqueuepb.TaskQueueStats,
-	expectedBacklogCount int64,
-	maxBacklogExtraTasks int64,
-	expectedAddRate bool,
-	expectedDispatchRate bool,
+	expectation TaskQueueExpectations,
 ) {
 	// Actual counter can be greater than the expected due to history retries. We make sure the counter is in
 	// range [expected, expected+maxBacklogExtraTasks]
-	a.GreaterOrEqual(stats.ApproximateBacklogCount, expectedBacklogCount)
-	a.LessOrEqual(stats.ApproximateBacklogCount, expectedBacklogCount+maxBacklogExtraTasks)
+	a.GreaterOrEqual(stats.ApproximateBacklogCount, int64(expectation.BacklogCount))
+	a.LessOrEqual(stats.ApproximateBacklogCount, int64(expectation.BacklogCount+expectation.MaxExtraTasks))
 	a.Equal(stats.ApproximateBacklogCount == 0, stats.ApproximateBacklogAge.AsDuration() == time.Duration(0))
-	a.Equal(expectedAddRate, stats.TasksAddRate > 0)
-	a.Equal(expectedDispatchRate, stats.TasksDispatchRate > 0)
+	a.Equal(expectation.ExpectedAddRate, stats.TasksAddRate > 0)
+	a.Equal(expectation.ExpectedDispatch, stats.TasksDispatchRate > 0)
 }
 
 func (s *DescribeTaskQueueSuite) deploymentOptions() *deploymentpb.WorkerDeploymentOptions {


### PR DESCRIPTION
## What changed?

Added test to verify DescribeTaskQueue Stats are cached.

## Why?

Regression testing.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)
