### PR TITLE
Fix buffered events ordering

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/execution.go
+++ b/common/persistence/sql/sqlplugin/mysql/execution.go
@@ -136,7 +136,7 @@ VALUES (:shard_id, :namespace_id, :workflow_id, :run_id, :data, :data_encoding)`
 
 	deleteBufferedEventsQuery = `DELETE FROM buffered_events WHERE shard_id=? AND namespace_id=? AND workflow_id=? AND run_id=?`
 	getBufferedEventsQuery    = `SELECT data, data_encoding FROM buffered_events WHERE
-shard_id=? AND namespace_id=? AND workflow_id=? AND run_id=?`
+shard_id=? AND namespace_id=? AND workflow_id=? AND run_id=? ORDER BY id`
 
 	insertReplicationTaskDLQQuery = `
 INSERT INTO replication_tasks_dlq 

--- a/common/persistence/sql/sqlplugin/postgresql/execution.go
+++ b/common/persistence/sql/sqlplugin/postgresql/execution.go
@@ -135,7 +135,7 @@ ORDER BY task_id LIMIT $5`
 VALUES (:shard_id, :namespace_id, :workflow_id, :run_id, :data, :data_encoding)`
 
 	deleteBufferedEventsQuery = `DELETE FROM buffered_events WHERE shard_id = $1 AND namespace_id = $2 AND workflow_id = $3 AND run_id = $4`
-	getBufferedEventsQuery    = `SELECT data, data_encoding FROM buffered_events WHERE shard_id = $1 AND namespace_id = $2 AND workflow_id = $3 AND run_id = $4`
+	getBufferedEventsQuery    = `SELECT data, data_encoding FROM buffered_events WHERE shard_id = $1 AND namespace_id = $2 AND workflow_id = $3 AND run_id = $4 ORDER BY id`
 
 	insertReplicationTaskDLQQuery = `
 INSERT INTO replication_tasks_dlq 

--- a/common/persistence/sql/sqlplugin/sqlite/execution.go
+++ b/common/persistence/sql/sqlplugin/sqlite/execution.go
@@ -136,7 +136,7 @@ VALUES (:shard_id, :namespace_id, :workflow_id, :run_id, :data, :data_encoding)`
 
 	deleteBufferedEventsQuery = `DELETE FROM buffered_events WHERE shard_id=? AND namespace_id=? AND workflow_id=? AND run_id=?`
 	getBufferedEventsQuery    = `SELECT data, data_encoding FROM buffered_events WHERE
-shard_id=? AND namespace_id=? AND workflow_id=? AND run_id=?`
+shard_id=? AND namespace_id=? AND workflow_id=? AND run_id=? ORDER BY id`
 
 	insertReplicationTaskDLQQuery = `
 INSERT INTO replication_tasks_dlq 


### PR DESCRIPTION
## Summary
- ensure buffered events from SQL-based DBs are read in insert order by adding `ORDER BY id`

## Testing
- `go test ./...` *(fails: downloading toolchain forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_684efbf31978832cbebc08b6c9b70ba1