### PR TITLE
testhooks: add context-wrapping functionality

### DIFF
--- a/common/testing/testhooks/noop_impl.go
+++ b/common/testing/testhooks/noop_impl.go
@@ -2,7 +2,11 @@
 
 package testhooks
 
-import "go.uber.org/fx"
+import (
+	"context"
+
+	"go.uber.org/fx"
+)
 
 var Module = fx.Options(
 	fx.Provide(func() (_ TestHooks) { return }),
@@ -27,8 +31,23 @@ func Get[T any](_ TestHooks, key Key) (T, bool) {
 	return zero, false
 }
 
+// GetCtx gets the value of a test hook from the registry embedded in the
+// context chain.
+//
+// TestHooks should be used sparingly, see comment on TestHooks.
+func GetCtx[T any](ctx context.Context, key Key) (T, bool) {
+	var zero T
+	return zero, false
+}
+
 // Call calls a func() hook if present.
 //
 // TestHooks should be used very sparingly, see comment on TestHooks.
 func Call(_ TestHooks, key Key) {
+}
+
+// CallCtx calls a func(context.Context) hook if present.
+//
+// TestHooks should be used very sparingly, see comment on TestHooks.
+func CallCtx(_ context.Context, key Key) {
 }

--- a/common/testing/testhooks/test_impl.go
+++ b/common/testing/testhooks/test_impl.go
@@ -3,6 +3,7 @@
 package testhooks
 
 import (
+	"context"
 	"sync"
 
 	"go.uber.org/fx"
@@ -30,11 +31,13 @@ type (
 	testHooksImpl struct {
 		m sync.Map
 	}
+
+	contextKey struct{}
 )
 
 // Get gets the value of a test hook from the registry.
 //
-// TestHooks should be used very sparingly, see comment on TestHooks.
+// TestHooks should be used sparingly, see comment on TestHooks.
 func Get[T any](th TestHooks, key Key) (T, bool) {
 	var zero T
 	if th == nil {
@@ -47,20 +50,55 @@ func Get[T any](th TestHooks, key Key) (T, bool) {
 	return zero, false
 }
 
+// GetCtx gets the value of a test hook from the registry embedded in the
+// context chain.
+//
+// TestHooks should be used sparingly, see comment on TestHooks.
+func GetCtx[T any](ctx context.Context, key Key) (T, bool) {
+	hooks := ctx.Value(contextKey{})
+	if hooks, ok := hooks.(TestHooks); ok {
+		return Get[T](hooks, key)
+	}
+	var zero T
+	return zero, false
+}
+
 // Call calls a func() hook if present.
 //
-// TestHooks should be used very sparingly, see comment on TestHooks.
+// TestHooks should be used sparingly, see comment on TestHooks.
 func Call(th TestHooks, key Key) {
 	if hook, ok := Get[func()](th, key); ok {
 		hook()
 	}
 }
 
+// CallCtx calls a func() hook if present and a TestHooks implementation
+// exists in the context chain.
+//
+// TestHooks should be used sparingly, see comment on TestHooks.
+func CallCtx(ctx context.Context, key Key) {
+	hooks := ctx.Value(contextKey{})
+	if hooks, ok := hooks.(TestHooks); ok {
+		Call(hooks, key)
+	}
+}
+
 // Set sets a test hook to a value and returns a cleanup function to unset it.
-// Calls to Set and the cleanup functions should form a stack.
+// Calls to Set and the cleanup function should form a stack.
 func Set[T any](th TestHooks, key Key, val T) func() {
 	th.set(key, val)
 	return func() { th.del(key) }
+}
+
+// SetCtx sets a test hook to a value on the provided context and returns a
+// cleanup function to unset it. Calls to SetCtx and the cleanup function
+// should form a stack.
+func SetCtx[T any](ctx context.Context, key Key, val T) func() {
+	hooks := ctx.Value(contextKey{})
+	if hooks, ok := hooks.(TestHooks); ok {
+		return Set(hooks, key, val)
+	}
+	return func() {}
 }
 
 // NewTestHooksImpl returns a new instance of a test hook registry. This is provided and used
@@ -68,6 +106,13 @@ func Set[T any](th TestHooks, key Key, val T) func() {
 // explicitly constructed instance.
 func NewTestHooksImpl() TestHooks {
 	return &testHooksImpl{}
+}
+
+// NewInjectedTestHooksImpl returns a new instance of a test hook registry and a context with the
+// registry injected.
+func NewInjectedTestHooksImpl(parent context.Context) (context.Context, TestHooks) {
+	hooks := NewTestHooksImpl()
+	return context.WithValue(parent, contextKey{}, hooks), hooks
 }
 
 func (th *testHooksImpl) get(key Key) (any, bool) {

--- a/common/testing/testhooks/test_impl_test.go
+++ b/common/testing/testhooks/test_impl_test.go
@@ -1,0 +1,52 @@
+//go:build test_dep
+
+package testhooks
+
+import "testing"
+
+// Ensure that testhook functionality that operates on contexts functions as
+// expected.
+func TestTestHooks_Context(t *testing.T) {
+	t.Run("Values can be set and get on the context directly", func(t *testing.T) {
+		ctx, _ := NewInjectedTestHooksImpl(t.Context())
+		cleanup := SetCtx(ctx, UpdateWithStartInBetweenLockAndStart, 33)
+		defer cleanup()
+
+		v, ok := GetCtx[int](ctx, UpdateWithStartInBetweenLockAndStart)
+		if !ok {
+			t.Fatal("Expected TestHooksImpl to contain value")
+		}
+		if v != 33 {
+			t.Fatal("Expected value to be 33")
+		}
+	})
+
+	t.Run("Values set directly on the registry are visible through the context", func(t *testing.T) {
+		ctx, reg := NewInjectedTestHooksImpl(t.Context())
+		cleanup := Set(reg, UpdateWithStartInBetweenLockAndStart, 44)
+		defer cleanup()
+
+		v, ok := GetCtx[int](ctx, UpdateWithStartInBetweenLockAndStart)
+		if !ok {
+			t.Fatal("Expected TestHooksImpl to contain value")
+		}
+		if v != 44 {
+			t.Fatal("Expected value to be 44")
+		}
+	})
+
+	t.Run("CallCtx uses the registry injected into the context", func(t *testing.T) {
+		ctx, reg := NewInjectedTestHooksImpl(t.Context())
+		var value int
+		callback := func() {
+			value = 55
+		}
+		cleanup := Set(reg, UpdateWithStartInBetweenLockAndStart, callback)
+		defer cleanup()
+
+		CallCtx(ctx, UpdateWithStartInBetweenLockAndStart)
+		if value != 55 {
+			t.Fatal("Expected value to be 55")
+		}
+	})
+}


### PR DESCRIPTION
## What changed?

I've added context-based methods to our testhooks package. This includes:

- `NewInjectedTestHooksImpl` - returns a context and the registry injected into its chain
- `SetCtx` - set a testhooks key on the first TestHooks implementor found in the context chain
- `GetCtx` - get a testhooks value from the first TestHooks implementor found in the context chain
- `CallCtx` - call a testhooks callback value in the first TestHooks implementor found in the context chain

## Why?

This simplifies TestHook usage for modules that have an externally-controllable context. Rather than attach a TestHooks implementation to your production structs, you can instead inject it into the context provided by your tests.

This does not work for temporal's end-to-end or functional tests at the moment, though a gRPC interceptor that injects a registry would not be difficult to write.


## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None