### PR TITLE
Reduce Finalizer logging

### DIFF
--- a/common/finalizer/finalizer.go
+++ b/common/finalizer/finalizer.go
@@ -86,7 +86,7 @@ func (f *Finalizer) Run(
 	timeout time.Duration,
 ) int {
 	if timeout == 0 {
-		f.logger.Info("finalizer skipped: zero timeout")
+		f.logger.Debug("finalizer skipped: zero timeout")
 		return 0
 	}
 
@@ -105,7 +105,7 @@ func (f *Finalizer) Run(
 		return 0
 	}
 
-	f.logger.Info("finalizer starting",
+	f.logger.Debug("finalizer starting",
 		tag.NewInt("items", totalCount),
 		tag.NewDurationTag("timeout", timeout))
 
@@ -131,14 +131,18 @@ func (f *Finalizer) Run(
 		// prevent holding on to the callbacks for longer than needed and allow garbage collection
 		// (safe since any calls to Register/Deregister will be aborted now that the finalizer ran)
 		f.callbacks = nil
-
-		f.logger.Info("finalizer loop ended")
 	}()
 
 	var completedCallbacks int
 	defer func() {
+		var tags []metrics.Tag
+		unfinishedItems := int64(totalCount - completedCallbacks)
+		if unfinishedItems > 0 {
+			tags = append(tags, metrics.FailureTag("timeout"))
+		}
+		metrics.FinalizerRuns.With(f.metricsHandler).Record(1, tags...)
 		metrics.FinalizerItemsCompleted.With(f.metricsHandler).Record(int64(completedCallbacks))
-		metrics.FinalizerItemsUnfinished.With(f.metricsHandler).Record(int64(totalCount - completedCallbacks))
+		metrics.FinalizerItemsUnfinished.With(f.metricsHandler).Record(unfinishedItems)
 	}()
 
 	for {
@@ -146,7 +150,7 @@ func (f *Finalizer) Run(
 		case <-completionChannel:
 			completedCallbacks += 1
 			if completedCallbacks == totalCount {
-				f.logger.Info("finalizer completed",
+				f.logger.Debug("finalizer completed",
 					tag.NewInt("completed", completedCallbacks))
 				return completedCallbacks
 			}

--- a/common/finalizer/finalizer.go
+++ b/common/finalizer/finalizer.go
@@ -135,12 +135,11 @@ func (f *Finalizer) Run(
 
 	var completedCallbacks int
 	defer func() {
-		var tags []metrics.Tag
 		unfinishedItems := int64(totalCount - completedCallbacks)
+		metrics.FinalizerRuns.With(f.metricsHandler).Record(1)
 		if unfinishedItems > 0 {
-			tags = append(tags, metrics.FailureTag("timeout"))
+			metrics.FinalizerRunTimeouts.With(f.metricsHandler).Record(1)
 		}
-		metrics.FinalizerRuns.With(f.metricsHandler).Record(1, tags...)
 		metrics.FinalizerItemsCompleted.With(f.metricsHandler).Record(int64(completedCallbacks))
 		metrics.FinalizerItemsUnfinished.With(f.metricsHandler).Record(unfinishedItems)
 	}()

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -725,7 +725,11 @@ var (
 	SyncShardFromRemoteFailure = NewCounterDef("syncshard_remote_failed")
 	FinalizerRuns              = NewCounterDef(
 		"finalizer_runs",
-		WithDescription("The total number of finalizer runs. Tag `failure` identified failes runs."),
+		WithDescription("The number of finalizer runs."),
+	)
+	FinalizerRunTimeouts = NewCounterDef(
+		"finalizer_run_timeouts",
+		WithDescription("The number of finalizer run timeouts."),
 	)
 	FinalizerItemsCompleted = NewCounterDef(
 		"finalizer_items_completed",

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -723,10 +723,20 @@ var (
 	)
 	SyncShardFromRemoteCounter = NewCounterDef("syncshard_remote_count")
 	SyncShardFromRemoteFailure = NewCounterDef("syncshard_remote_failed")
-	FinalizerItemsCompleted    = NewCounterDef("finalizer_items_completed")
-	FinalizerItemsUnfinished   = NewCounterDef("finalizer_items_unfinished")
-	FinalizerLatency           = NewTimerDef("finalizer_latency")
-	TaskRequests               = NewCounterDef(
+	FinalizerRuns              = NewCounterDef(
+		"finalizer_runs",
+		WithDescription("The total number of finalizer runs. Tag `failure` identified failes runs."),
+	)
+	FinalizerItemsCompleted = NewCounterDef(
+		"finalizer_items_completed",
+		WithDescription("The number of finalizer items that were completed successfully."),
+	)
+	FinalizerItemsUnfinished = NewCounterDef(
+		"finalizer_items_unfinished",
+		WithDescription("The number of finalizer items that were aborted before completion."),
+	)
+	FinalizerLatency = NewTimerDef("finalizer_latency")
+	TaskRequests     = NewCounterDef(
 		"task_requests",
 		WithDescription("The number of history tasks processed."),
 	)


### PR DESCRIPTION
## What changed?

Reduce info logging of Finalizer component.

## Why?

Not that useful (anymore) actually; replaced it with a metric to still have some observability.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

