### PR TITLE
[CHASM] set ref archetype in SideEffect executor

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -2257,6 +2257,7 @@ func (n *Node) ExecuteSideEffectTask(
 
 	ref := ComponentRef{
 		EntityKey:          entityKey,
+		archetype:          n.Archetype(),
 		entityLastUpdateVT: taskInfo.ComponentLastUpdateVersionedTransition,
 		componentPath:      path,
 		componentInitialVT: taskInfo.ComponentInitialVersionedTransition,


### PR DESCRIPTION
## What changed?
- Fixes a bug where archetype was missing from a generated Ref

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
