### PR TITLE
[CHASM] bug fix: NPE in SQL persistence layer when persisting types with a nil Data field

### DIFF
--- a/common/persistence/sql/execution_state_map.go
+++ b/common/persistence/sql/execution_state_map.go
@@ -478,7 +478,7 @@ func updateChasmNodes(
 	if len(chasmNodes) > 0 {
 		rows := make([]sqlplugin.ChasmNodeMapsRow, 0, len(chasmNodes))
 		for path, node := range chasmNodes {
-			rows = append(rows, sqlplugin.ChasmNodeMapsRow{
+			row := sqlplugin.ChasmNodeMapsRow{
 				ShardID:          shardID,
 				NamespaceID:      namespaceID,
 				WorkflowID:       workflowID,
@@ -486,9 +486,12 @@ func updateChasmNodes(
 				ChasmPath:        path,
 				Metadata:         node.Metadata.Data,
 				MetadataEncoding: node.Metadata.EncodingType.String(),
-				Data:             node.Data.Data,
-				DataEncoding:     node.Data.EncodingType.String(),
-			})
+			}
+			if node.Data != nil {
+				row.Data = node.Data.Data
+				row.DataEncoding = node.Data.EncodingType.String()
+			}
+			rows = append(rows, row)
 		}
 		if _, err := tx.ReplaceIntoChasmNodeMaps(ctx, rows); err != nil {
 			return serviceerror.NewUnavailablef("Failed to update CHASM nodes. Failed to execute update query. Error: %v", err)

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -1811,6 +1811,15 @@ func (s *mutableStateSuite) buildWorkflowMutableState() *persistencespb.Workflow
 			},
 			Data: &commonpb.DataBlob{Data: []byte("test-data")},
 		},
+		"component-path/collection": {
+			Metadata: &persistencespb.ChasmNodeMetadata{
+				InitialVersionedTransition:    &persistencespb.VersionedTransition{NamespaceFailoverVersion: failoverVersion, TransitionCount: 1},
+				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: failoverVersion, TransitionCount: 90},
+				Attributes: &persistencespb.ChasmNodeMetadata_CollectionAttributes{
+					CollectionAttributes: &persistencespb.ChasmCollectionAttributes{},
+				},
+			},
+		},
 	}
 
 	bufferedEvents := []*historypb.HistoryEvent{
@@ -4770,6 +4779,13 @@ func (s *mutableStateSuite) TestApplyMutation() {
 						Attributes:                    &persistencespb.ChasmNodeMetadata_DataAttributes{},
 					},
 					Data: &commonpb.DataBlob{Data: []byte("test-data")},
+				},
+				"node-path/collection-node": {
+					Metadata: &persistencespb.ChasmNodeMetadata{
+						InitialVersionedTransition:    &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 1},
+						LastUpdateVersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 1},
+						Attributes:                    &persistencespb.ChasmNodeMetadata_CollectionAttributes{},
+					},
 				},
 			}
 			targetMockChasmTree.EXPECT().Snapshot(nil).Return(chasm.NodesSnapshot{


### PR DESCRIPTION
## What changed?
- Fixes an NPE in the write path for CHASM nodes without a `Data` field.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [*] added new unit test(s)
- [ ] added new functional test(s)
