### PR TITLE
Small matching cleanups

### DIFF
--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -614,12 +614,6 @@ type (
 		NextPageToken []byte
 	}
 
-	// CompleteTaskRequest is used to complete a task
-	CompleteTaskRequest struct {
-		TaskQueue *TaskQueueKey
-		TaskID    int64
-	}
-
 	// CompleteTasksLessThanRequest contains the request params needed to invoke CompleteTasksLessThan API
 	CompleteTasksLessThanRequest struct {
 		NamespaceID        string

--- a/proto/internal/temporal/server/api/persistence/v1/tasks.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/tasks.proto
@@ -72,9 +72,6 @@ message SubqueueInfo {
 message SubqueueKey {
     // Each subqueue contains tasks from only one priority level.
     int32 priority = 1;
-
-    // // Additionally, tasks may be split by a fairness mechanism into buckets.
-    // int32 fairness_bucket = 2;
 }
 
 message TaskKey {

--- a/schema/cassandra/temporal/schema.cql
+++ b/schema/cassandra/temporal/schema.cql
@@ -84,7 +84,7 @@ CREATE TABLE tasks (
   namespace_id        uuid,
   task_queue_name     text,
   task_queue_type     int, -- enum TaskQueueType {ActivityTask, WorkflowTask}
-  type                int, -- enum rowType {Task, TaskQueue}
+  type                int, -- enum rowType {Task, TaskQueue} and subqueue id
   task_id             bigint,  -- unique identifier for tasks, monotonically increasing
   range_id            bigint, -- Used to ensure that only one process can write to the table
   task                blob,

--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -171,10 +171,6 @@ func (c *backlogManagerImpl) processSpooledTask(
 	return c.pqMgr.ProcessSpooledTask(ctx, task)
 }
 
-func (c *backlogManagerImpl) addSpooledTask(task *internalTask) error {
-	return c.pqMgr.AddSpooledTask(task)
-}
-
 func (c *backlogManagerImpl) BacklogCountHint() int64 {
 	return c.taskAckManager.getBacklogCountHint()
 }

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -28,7 +28,7 @@ type BacklogManagerTestSuite struct {
 	ptqMgr     *MockphysicalTaskQueueManager
 }
 
-func TestBacklogManager_Suite(t *testing.T) {
+func TestBacklogManager_Classic_Suite(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, &BacklogManagerTestSuite{newMatcher: false})
 }

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -28,12 +28,12 @@ type BacklogManagerTestSuite struct {
 	ptqMgr     *MockphysicalTaskQueueManager
 }
 
-func TestBacklogManagerTestSuite(t *testing.T) {
+func TestBacklogManager_Suite(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, &BacklogManagerTestSuite{newMatcher: false})
 }
 
-func TestBacklogManagerWithNewMatcherTestSuite(t *testing.T) {
+func TestBacklogManager_Pri_Suite(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, &BacklogManagerTestSuite{newMatcher: true})
 }

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -322,7 +322,6 @@ func (db *taskQueueDB) getTotalApproximateBacklogCount() (total int64) {
 // CreateTasks creates a batch of given tasks for this task queue
 func (db *taskQueueDB) CreateTasks(
 	ctx context.Context,
-	taskIDs []int64,
 	reqs []*writeTaskRequest,
 ) (createTasksResponse, error) {
 	db.Lock()
@@ -337,7 +336,7 @@ func (db *taskQueueDB) CreateTasks(
 	allSubqueues := make([]int, len(reqs))
 	for i, req := range reqs {
 		task := &persistencespb.AllocatedTaskInfo{
-			TaskId: taskIDs[i],
+			TaskId: req.id,
 			Data:   req.taskInfo,
 		}
 		allTasks[i] = task

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -132,7 +132,7 @@ func createMockNamespaceCache(controller *gomock.Controller, nsName namespace.Na
 }
 
 // TODO(pri): cleanup; delete this
-func TestMatchingEngine_Suite(t *testing.T) {
+func TestMatchingEngine_Classic_Suite(t *testing.T) {
 	suite.Run(t, &matchingEngineSuite{newMatcher: false})
 }
 

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -57,6 +57,7 @@ import (
 	"go.temporal.io/server/common/quotas"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tasktoken"
+	"go.temporal.io/server/common/testing/protoassert"
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/worker_versioning"
@@ -131,11 +132,11 @@ func createMockNamespaceCache(controller *gomock.Controller, nsName namespace.Na
 }
 
 // TODO(pri): cleanup; delete this
-func TestMatchingEngineSuite(t *testing.T) {
+func TestMatchingEngine_Suite(t *testing.T) {
 	suite.Run(t, &matchingEngineSuite{newMatcher: false})
 }
 
-func TestMatchingEngineWithNewMatcherSuite(t *testing.T) {
+func TestMatchingEngine_Pri_Suite(t *testing.T) {
 	suite.Run(t, &matchingEngineSuite{newMatcher: true})
 }
 
@@ -2464,7 +2465,7 @@ func (s *matchingEngineSuite) TestGetTaskQueueUserData_ReturnsData() {
 		LastKnownUserDataVersion: 0,
 	})
 	s.NoError(err)
-	s.Equal(res.UserData, userData)
+	protoassert.ProtoEqual(s.T(), res.UserData, userData)
 }
 
 func (s *matchingEngineSuite) TestGetTaskQueueUserData_ReturnsEmpty() {
@@ -3675,14 +3676,14 @@ type testPhysicalTaskQueueManager struct {
 	userData                *persistencespb.VersionedTaskQueueUserData
 }
 
+func newTestTaskQueueManager() *testPhysicalTaskQueueManager {
+	return &testPhysicalTaskQueueManager{tasks: treemap.NewWith(godsutils.Int64Comparator)}
+}
+
 func (m *testPhysicalTaskQueueManager) RangeID() int64 {
 	m.Lock()
 	defer m.Unlock()
 	return m.rangeID
-}
-
-func newTestTaskQueueManager() *testPhysicalTaskQueueManager {
-	return &testPhysicalTaskQueueManager{tasks: treemap.NewWith(godsutils.Int64Comparator)}
 }
 
 func (m *testTaskManager) CreateTaskQueue(
@@ -3705,7 +3706,6 @@ func (m *testTaskManager) CreateTaskQueue(
 	return &persistence.CreateTaskQueueResponse{}, nil
 }
 
-// UpdateTaskQueue provides a mock function with given fields: request
 func (m *testTaskManager) UpdateTaskQueue(
 	_ context.Context,
 	request *persistence.UpdateTaskQueueRequest,
@@ -3822,7 +3822,6 @@ func (m *testTaskManager) generateErrorRandomly() bool {
 	return false
 }
 
-// CreateTask provides a mock function with given fields: request
 func (m *testTaskManager) CreateTasks(
 	_ context.Context,
 	request *persistence.CreateTasksRequest,
@@ -3872,10 +3871,7 @@ func (m *testTaskManager) CreateTasks(
 
 	// Then insert all tasks if no errors
 	for _, task := range request.Tasks {
-		tlm.tasks.Put(task.GetTaskId(), &persistencespb.AllocatedTaskInfo{
-			Data:   task.Data,
-			TaskId: task.GetTaskId(),
-		})
+		tlm.tasks.Put(task.GetTaskId(), common.CloneProto(task))
 		tlm.createTaskCount++
 		tlm.ApproximateBacklogCount++
 	}
@@ -3883,12 +3879,11 @@ func (m *testTaskManager) CreateTasks(
 	return &persistence.CreateTasksResponse{}, nil
 }
 
-// GetTasks provides a mock function with given fields: request
 func (m *testTaskManager) GetTasks(
 	_ context.Context,
 	request *persistence.GetTasksRequest,
 ) (*persistence.GetTasksResponse, error) {
-	m.logger.Debug("testTaskManager.GetTasks", tag.MinLevel(request.InclusiveMinTaskID), tag.MaxLevel(request.ExclusiveMaxTaskID))
+	m.logger.Debug("testTaskManager.GetTasks", tag.Value(request))
 
 	if m.generateErrorRandomly() {
 		return nil, serviceerror.NewUnavailablef("GetTasks operation failed")
@@ -3900,7 +3895,7 @@ func (m *testTaskManager) GetTasks(
 	var tasks []*persistencespb.AllocatedTaskInfo
 
 	it := tlm.tasks.Iterator()
-	for it.Next() {
+	for it.Next() && len(tasks) < request.PageSize {
 		taskID := it.Key().(int64)
 		if taskID < request.InclusiveMinTaskID {
 			continue
@@ -3911,9 +3906,7 @@ func (m *testTaskManager) GetTasks(
 		tasks = append(tasks, it.Value().(*persistencespb.AllocatedTaskInfo))
 	}
 	tlm.getTasksCount++
-	return &persistence.GetTasksResponse{
-		Tasks: tasks,
-	}, nil
+	return &persistence.GetTasksResponse{Tasks: tasks}, nil
 }
 
 // getTaskCount returns number of tasks in a task queue

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -52,7 +52,7 @@ type PhysicalTaskQueueManagerTestSuite struct {
 }
 
 // TODO(pri): cleanup; delete this
-func TestPhysicalTaskQueueManager_Suite(t *testing.T) {
+func TestPhysicalTaskQueueManager_Classic_Suite(t *testing.T) {
 	suite.Run(t, &PhysicalTaskQueueManagerTestSuite{newMatcher: false})
 }
 

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -52,11 +52,11 @@ type PhysicalTaskQueueManagerTestSuite struct {
 }
 
 // TODO(pri): cleanup; delete this
-func TestPhysicalTaskQueueManagerTestSuite(t *testing.T) {
+func TestPhysicalTaskQueueManager_Suite(t *testing.T) {
 	suite.Run(t, &PhysicalTaskQueueManagerTestSuite{newMatcher: false})
 }
 
-func TestPhysicalTaskQueueManagerWithNewMatcherTestSuite(t *testing.T) {
+func TestPhysicalTaskQueueManager_Pri_Suite(t *testing.T) {
 	suite.Run(t, &PhysicalTaskQueueManagerTestSuite{newMatcher: true})
 }
 
@@ -357,7 +357,7 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesFinalUpdateOnIdleUnload()
 
 func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesNotDoFinalUpdateOnOwnershipLost() {
 	// TODO: use mocks instead of testTaskManager so we can do synchronization better instead of sleeps
-	s.config.UpdateAckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(200 * time.Millisecond)
+	s.config.UpdateAckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(100 * time.Millisecond)
 	s.tqMgr.Start()
 
 	// wait for goroutines to start and to acquire rangeid lock
@@ -378,7 +378,7 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesNotDoFinalUpdateOnOwnersh
 	// on the next periodic write, it'll fail due to conflict and unload the task queue
 	s.Eventually(func() bool {
 		return s.tqMgr.tqCtx.Err() != nil
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 5*time.Second, 20*time.Millisecond)
 
 	// no additional updates (the failed periodic update counts as "1")
 	s.Equal(1, tm.getUpdateCount(s.physicalTaskQueueKey))

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -84,6 +84,9 @@ func newPriTaskReader(
 		outstandingTasks: treemap.NewWith(godsutils.Int64Comparator),
 		readLevel:        initialAckLevel,
 		ackLevel:         initialAckLevel,
+
+		// gc state
+		lastGCTime: time.Now(),
 	}
 }
 
@@ -106,10 +109,7 @@ func (tr *priTaskReader) getOldestBacklogTime() time.Time {
 }
 
 func (tr *priTaskReader) completeTask(task *internalTask, res taskResponse) {
-	err := res.startErr
-	if res.forwarded {
-		err = res.forwardErr
-	}
+	err := res.err()
 
 	// We can handle some transient errors by just putting the task back in the matcher to
 	// match again. Note that for forwarded tasks, it's expected to get DeadlineExceeded when
@@ -157,44 +157,43 @@ func (tr *priTaskReader) getTasksPump() {
 	ctx := tr.backlogMgr.tqCtx
 
 	tr.SignalTaskLoading() // prime pump
-Loop:
 	for {
 		select {
 		case <-ctx.Done():
 			return
-
 		case <-tr.notifyC:
-			if tr.getLoadedTasks() > tr.backlogMgr.config.GetTasksReloadAt() {
-				// Too many loaded already, ignore this signal. We'll get another signal when
-				// loadedTasks drops low enough.
-				continue Loop
-			}
-
-			batch, err := tr.getTaskBatch(ctx)
-			tr.backlogMgr.signalIfFatal(err)
-			if err != nil {
-				// TODO: Should we ever stop retrying on db errors?
-				if common.IsResourceExhausted(err) {
-					tr.backoffSignal(taskReaderThrottleRetryDelay)
-				} else {
-					tr.backoffSignal(tr.retrier.NextBackOff(err))
-				}
-				continue Loop
-			}
-			tr.retrier.Reset()
-
-			if len(batch.tasks) == 0 {
-				tr.setReadLevelAfterGap(batch.readLevel)
-				if !batch.isReadBatchDone {
-					tr.SignalTaskLoading()
-				}
-				continue Loop
-			}
-
-			tr.processTaskBatch(batch.tasks)
-			// There may be more tasks.
-			tr.SignalTaskLoading()
 		}
+
+		if tr.getLoadedTasks() > tr.backlogMgr.config.GetTasksReloadAt() {
+			// Too many loaded already, ignore this signal. We'll get another signal when
+			// loadedTasks drops low enough.
+			continue
+		}
+
+		batch, err := tr.getTaskBatch(ctx)
+		tr.backlogMgr.signalIfFatal(err)
+		if err != nil {
+			// TODO: Should we ever stop retrying on db errors?
+			if common.IsResourceExhausted(err) {
+				tr.backoffSignal(taskReaderThrottleRetryDelay)
+			} else {
+				tr.backoffSignal(tr.retrier.NextBackOff(err))
+			}
+			continue
+		}
+		tr.retrier.Reset()
+
+		if len(batch.tasks) == 0 {
+			tr.setReadLevelAfterGap(batch.readLevel)
+			if !batch.isReadBatchDone {
+				tr.SignalTaskLoading()
+			}
+			continue
+		}
+
+		tr.processTaskBatch(batch.tasks)
+		// There may be more tasks.
+		tr.SignalTaskLoading()
 	}
 }
 

--- a/service/matching/pri_task_writer.go
+++ b/service/matching/pri_task_writer.go
@@ -105,7 +105,7 @@ func (w *priTaskWriter) appendTask(
 	}
 }
 
-func (w *priTaskWriter) allocTaskIDs(reqs []*writeTaskRequest) error {
+func (w *priTaskWriter) assignTaskIDs(reqs []*writeTaskRequest) error {
 	for i := range reqs {
 		if w.taskIDBlock.start > w.taskIDBlock.end {
 			// we ran out of current allocation block
@@ -168,7 +168,7 @@ func (w *priTaskWriter) taskWriterLoop() {
 			reqs = append(reqs[:0], request)
 			reqs = w.getWriteBatch(reqs)
 
-			err := w.allocTaskIDs(reqs)
+			err := w.assignTaskIDs(reqs)
 			if err == nil {
 				err = w.appendTasks(reqs)
 			}

--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -80,6 +80,13 @@ type (
 	}
 )
 
+func (res taskResponse) err() error {
+	if res.forwarded {
+		return res.forwardErr
+	}
+	return res.startErr
+}
+
 func newInternalTaskForSyncMatch(
 	info *persistencespb.TaskInfo,
 	forwardInfo *taskqueuespb.TaskForwardInfo,

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -47,12 +47,12 @@ type PartitionManagerTestSuite struct {
 }
 
 // TODO(pri): cleanup; delete this
-func TestTaskQueuePartitionManagerSuite(t *testing.T) {
+func TestTaskQueuePartitionManager_Suite(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, &PartitionManagerTestSuite{newMatcher: false})
 }
 
-func TestTaskQueuePartitionManagerWithNewMatcherSuite(t *testing.T) {
+func TestTaskQueuePartitionManager_Pri_Suite(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, &PartitionManagerTestSuite{newMatcher: true})
 }

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -47,7 +47,7 @@ type PartitionManagerTestSuite struct {
 }
 
 // TODO(pri): cleanup; delete this
-func TestTaskQueuePartitionManager_Suite(t *testing.T) {
+func TestTaskQueuePartitionManager_Classic_Suite(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, &PartitionManagerTestSuite{newMatcher: false})
 }

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -123,7 +123,7 @@ func (w *taskWriter) appendTask(
 	}
 }
 
-func (w *taskWriter) allocTaskIDs(reqs []*writeTaskRequest) error {
+func (w *taskWriter) assignTaskIDs(reqs []*writeTaskRequest) error {
 	for i := range reqs {
 		if w.taskIDBlock.start > w.taskIDBlock.end {
 			// we ran out of current allocation block
@@ -167,7 +167,7 @@ func (w *taskWriter) taskWriterLoop() {
 			reqs := []*writeTaskRequest{request}
 			reqs = w.getWriteBatch(reqs)
 
-			err := w.allocTaskIDs(reqs)
+			err := w.assignTaskIDs(reqs)
 			if err == nil {
 				err = w.appendTasks(reqs)
 			}

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -19,9 +19,10 @@ import (
 
 type (
 	writeTaskRequest struct {
-		subqueue   int // for priTaskWriter only
 		taskInfo   *persistencespb.TaskInfo
 		responseCh chan<- error
+		subqueue   int   // for priTaskWriter only
+		id         int64 // filled in by taskWriterLoop
 	}
 
 	taskIDBlock struct {
@@ -122,28 +123,24 @@ func (w *taskWriter) appendTask(
 	}
 }
 
-func (w *taskWriter) allocTaskIDs(count int) ([]int64, error) {
-	result := make([]int64, count)
-	for i := 0; i < count; i++ {
+func (w *taskWriter) allocTaskIDs(reqs []*writeTaskRequest) error {
+	for i := range reqs {
 		if w.taskIDBlock.start > w.taskIDBlock.end {
 			// we ran out of current allocation block
 			newBlock, err := w.allocTaskIDBlock(w.taskIDBlock.end)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			w.taskIDBlock = newBlock
 		}
-		result[i] = w.taskIDBlock.start
+		reqs[i].id = w.taskIDBlock.start
 		w.taskIDBlock.start++
 	}
-	return result, nil
+	return nil
 }
 
-func (w *taskWriter) appendTasks(
-	taskIDs []int64,
-	reqs []*writeTaskRequest,
-) error {
-	_, err := w.db.CreateTasks(w.backlogMgr.tqCtx, taskIDs, reqs)
+func (w *taskWriter) appendTasks(reqs []*writeTaskRequest) error {
+	_, err := w.db.CreateTasks(w.backlogMgr.tqCtx, reqs)
 	if err != nil {
 		w.backlogMgr.signalIfFatal(err)
 		w.logger.Error("Persistent store operation failure",
@@ -169,11 +166,10 @@ func (w *taskWriter) taskWriterLoop() {
 			// read a batch of requests from the channel
 			reqs := []*writeTaskRequest{request}
 			reqs = w.getWriteBatch(reqs)
-			batchSize := len(reqs)
 
-			taskIDs, err := w.allocTaskIDs(batchSize)
+			err := w.allocTaskIDs(reqs)
 			if err == nil {
-				err = w.appendTasks(taskIDs, reqs)
+				err = w.appendTasks(reqs)
 			}
 			for _, req := range reqs {
 				req.responseCh <- err

--- a/tests/priority_fairness_test.go
+++ b/tests/priority_fairness_test.go
@@ -21,24 +21,25 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-type PriorityFairnessSuite struct {
+type PrioritySuite struct {
 	testcore.FunctionalTestBase
 }
 
-func TestPriorityFairnessSuite(t *testing.T) {
+func TestPrioritySuite(t *testing.T) {
 	t.Parallel()
-	suite.Run(t, new(PriorityFairnessSuite))
+	suite.Run(t, new(PrioritySuite))
 }
 
-func (s *PriorityFairnessSuite) SetupSuite() {
+func (s *PrioritySuite) SetupSuite() {
 	dynamicConfigOverrides := map[dynamicconfig.Key]any{
 		dynamicconfig.MatchingUseNewMatcher.Key():     true,
 		dynamicconfig.MatchingGetTasksBatchSize.Key(): 20,
+		dynamicconfig.MatchingGetTasksReloadAt.Key():  5,
 	}
 	s.FunctionalTestBase.SetupSuiteWithCluster(testcore.WithDynamicConfigOverrides(dynamicConfigOverrides))
 }
 
-func (s *PriorityFairnessSuite) TestPriority_Activity_Basic() {
+func (s *PrioritySuite) TestPriority_Activity_Basic() {
 	const N = 100
 	const Levels = 5
 
@@ -121,7 +122,7 @@ func (s *PriorityFairnessSuite) TestPriority_Activity_Basic() {
 	s.Less(w, 0.15)
 }
 
-func (s *PriorityFairnessSuite) TestSubqueue_Migration() {
+func (s *PrioritySuite) TestSubqueue_Migration() {
 	tv := testvars.New(s.T())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/tests/testcore/flag.go
+++ b/tests/testcore/flag.go
@@ -3,6 +3,7 @@ package testcore
 import (
 	"flag"
 
+	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
@@ -29,4 +30,8 @@ func UseSQLVisibility() bool {
 	default:
 		return false
 	}
+}
+
+func UseCassandraPersistence() bool {
+	return cliFlags.persistenceType == config.StoreTypeNoSQL && cliFlags.persistenceDriver == "cassandra"
 }


### PR DESCRIPTION
## What changed?
- Consolidate task ids into `writeTaskRequest` instead of separate slice.
- Factor out some common code in `newPhysicalTaskQueueManager`.
- Factor out `taskResponse.err()`.
- Move code out of select in `getTasksPump`.
- Add a `UseCassandraPersistence` test helper.
- Remove some obsolete structs and functions.
- Rename some test functions.
- Update some comments.

## Why?
These are a bunch of small changes from the fairness feature branch that can apply to main immediately, which will make reviewing/merging that branch easier.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
