### PR TITLE
Matching fairness update persistence and protos

### DIFF
--- a/api/persistence/v1/tasks.pb.go
+++ b/api/persistence/v1/tasks.pb.go
@@ -334,17 +334,14 @@ type SubqueueInfo struct {
 	// this subqueue. It should not change after being registered in TaskQueueInfo.
 	Key *SubqueueKey `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// The rest are mutable state for the subqueue:
-	AckLevelPass            int64 `protobuf:"varint,4,opt,name=ack_level_pass,json=ackLevelPass,proto3" json:"ack_level_pass,omitempty"`
-	AckLevelId              int64 `protobuf:"varint,2,opt,name=ack_level_id,json=ackLevelId,proto3" json:"ack_level_id,omitempty"`
-	ApproximateBacklogCount int64 `protobuf:"varint,3,opt,name=approximate_backlog_count,json=approximateBacklogCount,proto3" json:"approximate_backlog_count,omitempty"`
+	AckLevel                int64          `protobuf:"varint,2,opt,name=ack_level,json=ackLevel,proto3" json:"ack_level,omitempty"`
+	FairAckLevel            *v11.FairLevel `protobuf:"bytes,4,opt,name=fair_ack_level,json=fairAckLevel,proto3" json:"fair_ack_level,omitempty"`
+	ApproximateBacklogCount int64          `protobuf:"varint,3,opt,name=approximate_backlog_count,json=approximateBacklogCount,proto3" json:"approximate_backlog_count,omitempty"`
 	// Max read level keeps track of the highest task level ever written, but is only
 	// maintained best-effort. Do not trust these values.
-	MaxReadLevelPass int64 `protobuf:"varint,5,opt,name=max_read_level_pass,json=maxReadLevelPass,proto3" json:"max_read_level_pass,omitempty"`
-	// Max read level keeps track of the highest task level ever written, but is only
-	// maintained best-effort. Do not trust these values.
-	MaxReadLevelId int64 `protobuf:"varint,6,opt,name=max_read_level_id,json=maxReadLevelId,proto3" json:"max_read_level_id,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	FairMaxReadLevel *v11.FairLevel `protobuf:"bytes,5,opt,name=fair_max_read_level,json=fairMaxReadLevel,proto3" json:"fair_max_read_level,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *SubqueueInfo) Reset() {
@@ -384,18 +381,18 @@ func (x *SubqueueInfo) GetKey() *SubqueueKey {
 	return nil
 }
 
-func (x *SubqueueInfo) GetAckLevelPass() int64 {
+func (x *SubqueueInfo) GetAckLevel() int64 {
 	if x != nil {
-		return x.AckLevelPass
+		return x.AckLevel
 	}
 	return 0
 }
 
-func (x *SubqueueInfo) GetAckLevelId() int64 {
+func (x *SubqueueInfo) GetFairAckLevel() *v11.FairLevel {
 	if x != nil {
-		return x.AckLevelId
+		return x.FairAckLevel
 	}
-	return 0
+	return nil
 }
 
 func (x *SubqueueInfo) GetApproximateBacklogCount() int64 {
@@ -405,18 +402,11 @@ func (x *SubqueueInfo) GetApproximateBacklogCount() int64 {
 	return 0
 }
 
-func (x *SubqueueInfo) GetMaxReadLevelPass() int64 {
+func (x *SubqueueInfo) GetFairMaxReadLevel() *v11.FairLevel {
 	if x != nil {
-		return x.MaxReadLevelPass
+		return x.FairMaxReadLevel
 	}
-	return 0
-}
-
-func (x *SubqueueInfo) GetMaxReadLevelId() int64 {
-	if x != nil {
-		return x.MaxReadLevelId
-	}
-	return 0
+	return nil
 }
 
 type SubqueueKey struct {
@@ -550,15 +540,13 @@ const file_temporal_server_api_persistence_v1_tasks_proto_rawDesc = "" +
 	"expiryTime\x12D\n" +
 	"\x10last_update_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x0elastUpdateTime\x12:\n" +
 	"\x19approximate_backlog_count\x18\b \x01(\x03R\x17approximateBacklogCount\x12N\n" +
-	"\tsubqueues\x18\t \x03(\v20.temporal.server.api.persistence.v1.SubqueueInfoR\tsubqueues\"\xaf\x02\n" +
+	"\tsubqueues\x18\t \x03(\v20.temporal.server.api.persistence.v1.SubqueueInfoR\tsubqueues\"\xd9\x02\n" +
 	"\fSubqueueInfo\x12A\n" +
-	"\x03key\x18\x01 \x01(\v2/.temporal.server.api.persistence.v1.SubqueueKeyR\x03key\x12$\n" +
-	"\x0eack_level_pass\x18\x04 \x01(\x03R\fackLevelPass\x12 \n" +
-	"\fack_level_id\x18\x02 \x01(\x03R\n" +
-	"ackLevelId\x12:\n" +
-	"\x19approximate_backlog_count\x18\x03 \x01(\x03R\x17approximateBacklogCount\x12-\n" +
-	"\x13max_read_level_pass\x18\x05 \x01(\x03R\x10maxReadLevelPass\x12)\n" +
-	"\x11max_read_level_id\x18\x06 \x01(\x03R\x0emaxReadLevelId\")\n" +
+	"\x03key\x18\x01 \x01(\v2/.temporal.server.api.persistence.v1.SubqueueKeyR\x03key\x12\x1b\n" +
+	"\tack_level\x18\x02 \x01(\x03R\backLevel\x12Q\n" +
+	"\x0efair_ack_level\x18\x04 \x01(\v2+.temporal.server.api.taskqueue.v1.FairLevelR\ffairAckLevel\x12:\n" +
+	"\x19approximate_backlog_count\x18\x03 \x01(\x03R\x17approximateBacklogCount\x12Z\n" +
+	"\x13fair_max_read_level\x18\x05 \x01(\v2+.temporal.server.api.taskqueue.v1.FairLevelR\x10fairMaxReadLevel\")\n" +
 	"\vSubqueueKey\x12\x1a\n" +
 	"\bpriority\x18\x01 \x01(\x05R\bpriority\"[\n" +
 	"\aTaskKey\x127\n" +
@@ -591,6 +579,7 @@ var file_temporal_server_api_persistence_v1_tasks_proto_goTypes = []any{
 	(*v12.Priority)(nil),             // 9: temporal.api.common.v1.Priority
 	(v13.TaskQueueType)(0),           // 10: temporal.api.enums.v1.TaskQueueType
 	(v13.TaskQueueKind)(0),           // 11: temporal.api.enums.v1.TaskQueueKind
+	(*v11.FairLevel)(nil),            // 12: temporal.server.api.taskqueue.v1.FairLevel
 }
 var file_temporal_server_api_persistence_v1_tasks_proto_depIdxs = []int32{
 	1,  // 0: temporal.server.api.persistence.v1.AllocatedTaskInfo.data:type_name -> temporal.server.api.persistence.v1.TaskInfo
@@ -605,12 +594,14 @@ var file_temporal_server_api_persistence_v1_tasks_proto_depIdxs = []int32{
 	6,  // 9: temporal.server.api.persistence.v1.TaskQueueInfo.last_update_time:type_name -> google.protobuf.Timestamp
 	3,  // 10: temporal.server.api.persistence.v1.TaskQueueInfo.subqueues:type_name -> temporal.server.api.persistence.v1.SubqueueInfo
 	4,  // 11: temporal.server.api.persistence.v1.SubqueueInfo.key:type_name -> temporal.server.api.persistence.v1.SubqueueKey
-	6,  // 12: temporal.server.api.persistence.v1.TaskKey.fire_time:type_name -> google.protobuf.Timestamp
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	12, // 12: temporal.server.api.persistence.v1.SubqueueInfo.fair_ack_level:type_name -> temporal.server.api.taskqueue.v1.FairLevel
+	12, // 13: temporal.server.api.persistence.v1.SubqueueInfo.fair_max_read_level:type_name -> temporal.server.api.taskqueue.v1.FairLevel
+	6,  // 14: temporal.server.api.persistence.v1.TaskKey.fire_time:type_name -> google.protobuf.Timestamp
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_api_persistence_v1_tasks_proto_init() }

--- a/api/persistence/v1/tasks.pb.go
+++ b/api/persistence/v1/tasks.pb.go
@@ -31,7 +31,7 @@ const (
 type AllocatedTaskInfo struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Data          *TaskInfo              `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
-	PassNumber    int64                  `protobuf:"varint,3,opt,name=pass_number,json=passNumber,proto3" json:"pass_number,omitempty"`
+	TaskPass      int64                  `protobuf:"varint,3,opt,name=task_pass,json=taskPass,proto3" json:"task_pass,omitempty"`
 	TaskId        int64                  `protobuf:"varint,2,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -74,9 +74,9 @@ func (x *AllocatedTaskInfo) GetData() *TaskInfo {
 	return nil
 }
 
-func (x *AllocatedTaskInfo) GetPassNumber() int64 {
+func (x *AllocatedTaskInfo) GetTaskPass() int64 {
 	if x != nil {
-		return x.PassNumber
+		return x.TaskPass
 	}
 	return 0
 }
@@ -335,7 +335,7 @@ type SubqueueInfo struct {
 	Key *SubqueueKey `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// The rest are mutable state for the subqueue:
 	AckLevelPass            int64 `protobuf:"varint,4,opt,name=ack_level_pass,json=ackLevelPass,proto3" json:"ack_level_pass,omitempty"`
-	AckLevel                int64 `protobuf:"varint,2,opt,name=ack_level,json=ackLevel,proto3" json:"ack_level,omitempty"`
+	AckLevelId              int64 `protobuf:"varint,2,opt,name=ack_level_id,json=ackLevelId,proto3" json:"ack_level_id,omitempty"`
 	ApproximateBacklogCount int64 `protobuf:"varint,3,opt,name=approximate_backlog_count,json=approximateBacklogCount,proto3" json:"approximate_backlog_count,omitempty"`
 	// Max read level keeps track of the highest task level ever written, but is only
 	// maintained best-effort. Do not trust these values.
@@ -391,9 +391,9 @@ func (x *SubqueueInfo) GetAckLevelPass() int64 {
 	return 0
 }
 
-func (x *SubqueueInfo) GetAckLevel() int64 {
+func (x *SubqueueInfo) GetAckLevelId() int64 {
 	if x != nil {
-		return x.AckLevel
+		return x.AckLevelId
 	}
 	return 0
 }
@@ -520,11 +520,10 @@ var File_temporal_server_api_persistence_v1_tasks_proto protoreflect.FileDescrip
 
 const file_temporal_server_api_persistence_v1_tasks_proto_rawDesc = "" +
 	"\n" +
-	".temporal/server/api/persistence/v1/tasks.proto\x12\"temporal.server.api.persistence.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a$temporal/api/common/v1/message.proto\x1a&temporal/api/enums/v1/task_queue.proto\x1a*temporal/server/api/clock/v1/message.proto\x1a.temporal/server/api/taskqueue/v1/message.proto\"\x8f\x01\n" +
+	".temporal/server/api/persistence/v1/tasks.proto\x12\"temporal.server.api.persistence.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a$temporal/api/common/v1/message.proto\x1a&temporal/api/enums/v1/task_queue.proto\x1a*temporal/server/api/clock/v1/message.proto\x1a.temporal/server/api/taskqueue/v1/message.proto\"\x8b\x01\n" +
 	"\x11AllocatedTaskInfo\x12@\n" +
-	"\x04data\x18\x01 \x01(\v2,.temporal.server.api.persistence.v1.TaskInfoR\x04data\x12\x1f\n" +
-	"\vpass_number\x18\x03 \x01(\x03R\n" +
-	"passNumber\x12\x17\n" +
+	"\x04data\x18\x01 \x01(\v2,.temporal.server.api.persistence.v1.TaskInfoR\x04data\x12\x1b\n" +
+	"\ttask_pass\x18\x03 \x01(\x03R\btaskPass\x12\x17\n" +
 	"\atask_id\x18\x02 \x01(\x03R\x06taskId\"\x87\x04\n" +
 	"\bTaskInfo\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12\x1f\n" +
@@ -551,11 +550,12 @@ const file_temporal_server_api_persistence_v1_tasks_proto_rawDesc = "" +
 	"expiryTime\x12D\n" +
 	"\x10last_update_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x0elastUpdateTime\x12:\n" +
 	"\x19approximate_backlog_count\x18\b \x01(\x03R\x17approximateBacklogCount\x12N\n" +
-	"\tsubqueues\x18\t \x03(\v20.temporal.server.api.persistence.v1.SubqueueInfoR\tsubqueues\"\xaa\x02\n" +
+	"\tsubqueues\x18\t \x03(\v20.temporal.server.api.persistence.v1.SubqueueInfoR\tsubqueues\"\xaf\x02\n" +
 	"\fSubqueueInfo\x12A\n" +
 	"\x03key\x18\x01 \x01(\v2/.temporal.server.api.persistence.v1.SubqueueKeyR\x03key\x12$\n" +
-	"\x0eack_level_pass\x18\x04 \x01(\x03R\fackLevelPass\x12\x1b\n" +
-	"\tack_level\x18\x02 \x01(\x03R\backLevel\x12:\n" +
+	"\x0eack_level_pass\x18\x04 \x01(\x03R\fackLevelPass\x12 \n" +
+	"\fack_level_id\x18\x02 \x01(\x03R\n" +
+	"ackLevelId\x12:\n" +
 	"\x19approximate_backlog_count\x18\x03 \x01(\x03R\x17approximateBacklogCount\x12-\n" +
 	"\x13max_read_level_pass\x18\x05 \x01(\x03R\x10maxReadLevelPass\x12)\n" +
 	"\x11max_read_level_id\x18\x06 \x01(\x03R\x0emaxReadLevelId\")\n" +

--- a/api/persistence/v1/tasks.pb.go
+++ b/api/persistence/v1/tasks.pb.go
@@ -31,6 +31,7 @@ const (
 type AllocatedTaskInfo struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Data          *TaskInfo              `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	PassNumber    int64                  `protobuf:"varint,3,opt,name=pass_number,json=passNumber,proto3" json:"pass_number,omitempty"`
 	TaskId        int64                  `protobuf:"varint,2,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -71,6 +72,13 @@ func (x *AllocatedTaskInfo) GetData() *TaskInfo {
 		return x.Data
 	}
 	return nil
+}
+
+func (x *AllocatedTaskInfo) GetPassNumber() int64 {
+	if x != nil {
+		return x.PassNumber
+	}
+	return 0
 }
 
 func (x *AllocatedTaskInfo) GetTaskId() int64 {
@@ -326,10 +334,17 @@ type SubqueueInfo struct {
 	// this subqueue. It should not change after being registered in TaskQueueInfo.
 	Key *SubqueueKey `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// The rest are mutable state for the subqueue:
+	AckLevelPass            int64 `protobuf:"varint,4,opt,name=ack_level_pass,json=ackLevelPass,proto3" json:"ack_level_pass,omitempty"`
 	AckLevel                int64 `protobuf:"varint,2,opt,name=ack_level,json=ackLevel,proto3" json:"ack_level,omitempty"`
 	ApproximateBacklogCount int64 `protobuf:"varint,3,opt,name=approximate_backlog_count,json=approximateBacklogCount,proto3" json:"approximate_backlog_count,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// Max read level keeps track of the highest task level ever written, but is only
+	// maintained best-effort. Do not trust these values.
+	MaxReadLevelPass int64 `protobuf:"varint,5,opt,name=max_read_level_pass,json=maxReadLevelPass,proto3" json:"max_read_level_pass,omitempty"`
+	// Max read level keeps track of the highest task level ever written, but is only
+	// maintained best-effort. Do not trust these values.
+	MaxReadLevelId int64 `protobuf:"varint,6,opt,name=max_read_level_id,json=maxReadLevelId,proto3" json:"max_read_level_id,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *SubqueueInfo) Reset() {
@@ -369,6 +384,13 @@ func (x *SubqueueInfo) GetKey() *SubqueueKey {
 	return nil
 }
 
+func (x *SubqueueInfo) GetAckLevelPass() int64 {
+	if x != nil {
+		return x.AckLevelPass
+	}
+	return 0
+}
+
 func (x *SubqueueInfo) GetAckLevel() int64 {
 	if x != nil {
 		return x.AckLevel
@@ -379,6 +401,20 @@ func (x *SubqueueInfo) GetAckLevel() int64 {
 func (x *SubqueueInfo) GetApproximateBacklogCount() int64 {
 	if x != nil {
 		return x.ApproximateBacklogCount
+	}
+	return 0
+}
+
+func (x *SubqueueInfo) GetMaxReadLevelPass() int64 {
+	if x != nil {
+		return x.MaxReadLevelPass
+	}
+	return 0
+}
+
+func (x *SubqueueInfo) GetMaxReadLevelId() int64 {
+	if x != nil {
+		return x.MaxReadLevelId
 	}
 	return 0
 }
@@ -484,9 +520,11 @@ var File_temporal_server_api_persistence_v1_tasks_proto protoreflect.FileDescrip
 
 const file_temporal_server_api_persistence_v1_tasks_proto_rawDesc = "" +
 	"\n" +
-	".temporal/server/api/persistence/v1/tasks.proto\x12\"temporal.server.api.persistence.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a$temporal/api/common/v1/message.proto\x1a&temporal/api/enums/v1/task_queue.proto\x1a*temporal/server/api/clock/v1/message.proto\x1a.temporal/server/api/taskqueue/v1/message.proto\"n\n" +
+	".temporal/server/api/persistence/v1/tasks.proto\x12\"temporal.server.api.persistence.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a$temporal/api/common/v1/message.proto\x1a&temporal/api/enums/v1/task_queue.proto\x1a*temporal/server/api/clock/v1/message.proto\x1a.temporal/server/api/taskqueue/v1/message.proto\"\x8f\x01\n" +
 	"\x11AllocatedTaskInfo\x12@\n" +
-	"\x04data\x18\x01 \x01(\v2,.temporal.server.api.persistence.v1.TaskInfoR\x04data\x12\x17\n" +
+	"\x04data\x18\x01 \x01(\v2,.temporal.server.api.persistence.v1.TaskInfoR\x04data\x12\x1f\n" +
+	"\vpass_number\x18\x03 \x01(\x03R\n" +
+	"passNumber\x12\x17\n" +
 	"\atask_id\x18\x02 \x01(\x03R\x06taskId\"\x87\x04\n" +
 	"\bTaskInfo\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12\x1f\n" +
@@ -513,11 +551,14 @@ const file_temporal_server_api_persistence_v1_tasks_proto_rawDesc = "" +
 	"expiryTime\x12D\n" +
 	"\x10last_update_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x0elastUpdateTime\x12:\n" +
 	"\x19approximate_backlog_count\x18\b \x01(\x03R\x17approximateBacklogCount\x12N\n" +
-	"\tsubqueues\x18\t \x03(\v20.temporal.server.api.persistence.v1.SubqueueInfoR\tsubqueues\"\xaa\x01\n" +
+	"\tsubqueues\x18\t \x03(\v20.temporal.server.api.persistence.v1.SubqueueInfoR\tsubqueues\"\xaa\x02\n" +
 	"\fSubqueueInfo\x12A\n" +
-	"\x03key\x18\x01 \x01(\v2/.temporal.server.api.persistence.v1.SubqueueKeyR\x03key\x12\x1b\n" +
+	"\x03key\x18\x01 \x01(\v2/.temporal.server.api.persistence.v1.SubqueueKeyR\x03key\x12$\n" +
+	"\x0eack_level_pass\x18\x04 \x01(\x03R\fackLevelPass\x12\x1b\n" +
 	"\tack_level\x18\x02 \x01(\x03R\backLevel\x12:\n" +
-	"\x19approximate_backlog_count\x18\x03 \x01(\x03R\x17approximateBacklogCount\")\n" +
+	"\x19approximate_backlog_count\x18\x03 \x01(\x03R\x17approximateBacklogCount\x12-\n" +
+	"\x13max_read_level_pass\x18\x05 \x01(\x03R\x10maxReadLevelPass\x12)\n" +
+	"\x11max_read_level_id\x18\x06 \x01(\x03R\x0emaxReadLevelId\")\n" +
 	"\vSubqueueKey\x12\x1a\n" +
 	"\bpriority\x18\x01 \x01(\x05R\bpriority\"[\n" +
 	"\aTaskKey\x127\n" +

--- a/api/taskqueue/v1/message.go-helpers.pb.go
+++ b/api/taskqueue/v1/message.go-helpers.pb.go
@@ -42,6 +42,43 @@ func (this *TaskVersionDirective) Equal(that interface{}) bool {
 	return proto.Equal(this, that1)
 }
 
+// Marshal an object of type FairLevel to the protobuf v3 wire format
+func (val *FairLevel) Marshal() ([]byte, error) {
+	return proto.Marshal(val)
+}
+
+// Unmarshal an object of type FairLevel from the protobuf v3 wire format
+func (val *FairLevel) Unmarshal(buf []byte) error {
+	return proto.Unmarshal(buf, val)
+}
+
+// Size returns the size of the object, in bytes, once serialized
+func (val *FairLevel) Size() int {
+	return proto.Size(val)
+}
+
+// Equal returns whether two FairLevel values are equivalent by recursively
+// comparing the message's fields.
+// For more information see the documentation for
+// https://pkg.go.dev/google.golang.org/protobuf/proto#Equal
+func (this *FairLevel) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	var that1 *FairLevel
+	switch t := that.(type) {
+	case *FairLevel:
+		that1 = t
+	case FairLevel:
+		that1 = &t
+	default:
+		return false
+	}
+
+	return proto.Equal(this, that1)
+}
+
 // Marshal an object of type InternalTaskQueueStatus to the protobuf v3 wire format
 func (val *InternalTaskQueueStatus) Marshal() ([]byte, error) {
 	return proto.Marshal(val)

--- a/api/taskqueue/v1/message.pb.go
+++ b/api/taskqueue/v1/message.pb.go
@@ -150,26 +150,76 @@ func (*TaskVersionDirective_UseAssignmentRules) isTaskVersionDirective_BuildId()
 
 func (*TaskVersionDirective_AssignedBuildId) isTaskVersionDirective_BuildId() {}
 
+type FairLevel struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TaskPass      int64                  `protobuf:"varint,1,opt,name=task_pass,json=taskPass,proto3" json:"task_pass,omitempty"`
+	TaskId        int64                  `protobuf:"varint,2,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FairLevel) Reset() {
+	*x = FairLevel{}
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FairLevel) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FairLevel) ProtoMessage() {}
+
+func (x *FairLevel) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FairLevel.ProtoReflect.Descriptor instead.
+func (*FairLevel) Descriptor() ([]byte, []int) {
+	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *FairLevel) GetTaskPass() int64 {
+	if x != nil {
+		return x.TaskPass
+	}
+	return 0
+}
+
+func (x *FairLevel) GetTaskId() int64 {
+	if x != nil {
+		return x.TaskId
+	}
+	return 0
+}
+
 type InternalTaskQueueStatus struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// read_level_pass and read_level (and ack_level_pass and ack_level, etc.) form a
-	// "fairness level" as a pair, so put them next to each other.
-	ReadLevelPass           int64            `protobuf:"varint,7,opt,name=read_level_pass,json=readLevelPass,proto3" json:"read_level_pass,omitempty"`
-	ReadLevel               int64            `protobuf:"varint,1,opt,name=read_level,json=readLevel,proto3" json:"read_level,omitempty"`
-	AckLevelPass            int64            `protobuf:"varint,8,opt,name=ack_level_pass,json=ackLevelPass,proto3" json:"ack_level_pass,omitempty"`
-	AckLevel                int64            `protobuf:"varint,2,opt,name=ack_level,json=ackLevel,proto3" json:"ack_level,omitempty"`
-	TaskIdBlock             *v13.TaskIdBlock `protobuf:"bytes,3,opt,name=task_id_block,json=taskIdBlock,proto3" json:"task_id_block,omitempty"`
-	LoadedTasks             int64            `protobuf:"varint,4,opt,name=loaded_tasks,json=loadedTasks,proto3" json:"loaded_tasks,omitempty"`
-	ApproximateBacklogCount int64            `protobuf:"varint,5,opt,name=approximate_backlog_count,json=approximateBacklogCount,proto3" json:"approximate_backlog_count,omitempty"`
-	MaxReadLevelPass        int64            `protobuf:"varint,9,opt,name=max_read_level_pass,json=maxReadLevelPass,proto3" json:"max_read_level_pass,omitempty"`
-	MaxReadLevel            int64            `protobuf:"varint,6,opt,name=max_read_level,json=maxReadLevel,proto3" json:"max_read_level,omitempty"`
+	state                   protoimpl.MessageState `protogen:"open.v1"`
+	ReadLevel               int64                  `protobuf:"varint,1,opt,name=read_level,json=readLevel,proto3" json:"read_level,omitempty"`
+	FairReadLevel           *FairLevel             `protobuf:"bytes,7,opt,name=fair_read_level,json=fairReadLevel,proto3" json:"fair_read_level,omitempty"`
+	AckLevel                int64                  `protobuf:"varint,2,opt,name=ack_level,json=ackLevel,proto3" json:"ack_level,omitempty"`
+	FairAckLevel            *FairLevel             `protobuf:"bytes,8,opt,name=fair_ack_level,json=fairAckLevel,proto3" json:"fair_ack_level,omitempty"`
+	TaskIdBlock             *v13.TaskIdBlock       `protobuf:"bytes,3,opt,name=task_id_block,json=taskIdBlock,proto3" json:"task_id_block,omitempty"`
+	LoadedTasks             int64                  `protobuf:"varint,4,opt,name=loaded_tasks,json=loadedTasks,proto3" json:"loaded_tasks,omitempty"`
+	ApproximateBacklogCount int64                  `protobuf:"varint,5,opt,name=approximate_backlog_count,json=approximateBacklogCount,proto3" json:"approximate_backlog_count,omitempty"`
+	MaxReadLevel            int64                  `protobuf:"varint,6,opt,name=max_read_level,json=maxReadLevel,proto3" json:"max_read_level,omitempty"`
+	FairMaxReadLevel        *FairLevel             `protobuf:"bytes,9,opt,name=fair_max_read_level,json=fairMaxReadLevel,proto3" json:"fair_max_read_level,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
 
 func (x *InternalTaskQueueStatus) Reset() {
 	*x = InternalTaskQueueStatus{}
-	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[1]
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -181,7 +231,7 @@ func (x *InternalTaskQueueStatus) String() string {
 func (*InternalTaskQueueStatus) ProtoMessage() {}
 
 func (x *InternalTaskQueueStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[1]
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -194,14 +244,7 @@ func (x *InternalTaskQueueStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InternalTaskQueueStatus.ProtoReflect.Descriptor instead.
 func (*InternalTaskQueueStatus) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{1}
-}
-
-func (x *InternalTaskQueueStatus) GetReadLevelPass() int64 {
-	if x != nil {
-		return x.ReadLevelPass
-	}
-	return 0
+	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *InternalTaskQueueStatus) GetReadLevel() int64 {
@@ -211,11 +254,11 @@ func (x *InternalTaskQueueStatus) GetReadLevel() int64 {
 	return 0
 }
 
-func (x *InternalTaskQueueStatus) GetAckLevelPass() int64 {
+func (x *InternalTaskQueueStatus) GetFairReadLevel() *FairLevel {
 	if x != nil {
-		return x.AckLevelPass
+		return x.FairReadLevel
 	}
-	return 0
+	return nil
 }
 
 func (x *InternalTaskQueueStatus) GetAckLevel() int64 {
@@ -223,6 +266,13 @@ func (x *InternalTaskQueueStatus) GetAckLevel() int64 {
 		return x.AckLevel
 	}
 	return 0
+}
+
+func (x *InternalTaskQueueStatus) GetFairAckLevel() *FairLevel {
+	if x != nil {
+		return x.FairAckLevel
+	}
+	return nil
 }
 
 func (x *InternalTaskQueueStatus) GetTaskIdBlock() *v13.TaskIdBlock {
@@ -246,18 +296,18 @@ func (x *InternalTaskQueueStatus) GetApproximateBacklogCount() int64 {
 	return 0
 }
 
-func (x *InternalTaskQueueStatus) GetMaxReadLevelPass() int64 {
-	if x != nil {
-		return x.MaxReadLevelPass
-	}
-	return 0
-}
-
 func (x *InternalTaskQueueStatus) GetMaxReadLevel() int64 {
 	if x != nil {
 		return x.MaxReadLevel
 	}
 	return 0
+}
+
+func (x *InternalTaskQueueStatus) GetFairMaxReadLevel() *FairLevel {
+	if x != nil {
+		return x.FairMaxReadLevel
+	}
+	return nil
 }
 
 type TaskQueueVersionInfoInternal struct {
@@ -269,7 +319,7 @@ type TaskQueueVersionInfoInternal struct {
 
 func (x *TaskQueueVersionInfoInternal) Reset() {
 	*x = TaskQueueVersionInfoInternal{}
-	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[2]
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -281,7 +331,7 @@ func (x *TaskQueueVersionInfoInternal) String() string {
 func (*TaskQueueVersionInfoInternal) ProtoMessage() {}
 
 func (x *TaskQueueVersionInfoInternal) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[2]
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -294,7 +344,7 @@ func (x *TaskQueueVersionInfoInternal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskQueueVersionInfoInternal.ProtoReflect.Descriptor instead.
 func (*TaskQueueVersionInfoInternal) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{2}
+	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *TaskQueueVersionInfoInternal) GetPhysicalTaskQueueInfo() *PhysicalTaskQueueInfo {
@@ -316,7 +366,7 @@ type PhysicalTaskQueueInfo struct {
 
 func (x *PhysicalTaskQueueInfo) Reset() {
 	*x = PhysicalTaskQueueInfo{}
-	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[3]
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -328,7 +378,7 @@ func (x *PhysicalTaskQueueInfo) String() string {
 func (*PhysicalTaskQueueInfo) ProtoMessage() {}
 
 func (x *PhysicalTaskQueueInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[3]
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -341,7 +391,7 @@ func (x *PhysicalTaskQueueInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PhysicalTaskQueueInfo.ProtoReflect.Descriptor instead.
 func (*PhysicalTaskQueueInfo) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{3}
+	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *PhysicalTaskQueueInfo) GetPollers() []*v13.PollerInfo {
@@ -384,7 +434,7 @@ type TaskQueuePartition struct {
 
 func (x *TaskQueuePartition) Reset() {
 	*x = TaskQueuePartition{}
-	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[4]
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -396,7 +446,7 @@ func (x *TaskQueuePartition) String() string {
 func (*TaskQueuePartition) ProtoMessage() {}
 
 func (x *TaskQueuePartition) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[4]
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -409,7 +459,7 @@ func (x *TaskQueuePartition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskQueuePartition.ProtoReflect.Descriptor instead.
 func (*TaskQueuePartition) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{4}
+	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *TaskQueuePartition) GetTaskQueue() string {
@@ -481,7 +531,7 @@ type BuildIdRedirectInfo struct {
 
 func (x *BuildIdRedirectInfo) Reset() {
 	*x = BuildIdRedirectInfo{}
-	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[5]
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -493,7 +543,7 @@ func (x *BuildIdRedirectInfo) String() string {
 func (*BuildIdRedirectInfo) ProtoMessage() {}
 
 func (x *BuildIdRedirectInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[5]
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -506,7 +556,7 @@ func (x *BuildIdRedirectInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildIdRedirectInfo.ProtoReflect.Descriptor instead.
 func (*BuildIdRedirectInfo) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{5}
+	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *BuildIdRedirectInfo) GetAssignedBuildId() string {
@@ -541,7 +591,7 @@ type TaskForwardInfo struct {
 
 func (x *TaskForwardInfo) Reset() {
 	*x = TaskForwardInfo{}
-	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[6]
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -553,7 +603,7 @@ func (x *TaskForwardInfo) String() string {
 func (*TaskForwardInfo) ProtoMessage() {}
 
 func (x *TaskForwardInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[6]
+	mi := &file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -566,7 +616,7 @@ func (x *TaskForwardInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskForwardInfo.ProtoReflect.Descriptor instead.
 func (*TaskForwardInfo) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{6}
+	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *TaskForwardInfo) GetSourcePartition() string {
@@ -618,18 +668,21 @@ const file_temporal_server_api_taskqueue_v1_message_proto_rawDesc = "" +
 	"deployment\x12i\n" +
 	"\x12deployment_version\x18\x05 \x01(\v2:.temporal.server.api.deployment.v1.WorkerDeploymentVersionR\x11deploymentVersionB\n" +
 	"\n" +
-	"\bbuild_id\"\xa3\x03\n" +
-	"\x17InternalTaskQueueStatus\x12&\n" +
-	"\x0fread_level_pass\x18\a \x01(\x03R\rreadLevelPass\x12\x1d\n" +
+	"\bbuild_id\"A\n" +
+	"\tFairLevel\x12\x1b\n" +
+	"\ttask_pass\x18\x01 \x01(\x03R\btaskPass\x12\x17\n" +
+	"\atask_id\x18\x02 \x01(\x03R\x06taskId\"\xaa\x04\n" +
+	"\x17InternalTaskQueueStatus\x12\x1d\n" +
 	"\n" +
-	"read_level\x18\x01 \x01(\x03R\treadLevel\x12$\n" +
-	"\x0eack_level_pass\x18\b \x01(\x03R\fackLevelPass\x12\x1b\n" +
-	"\tack_level\x18\x02 \x01(\x03R\backLevel\x12J\n" +
+	"read_level\x18\x01 \x01(\x03R\treadLevel\x12S\n" +
+	"\x0ffair_read_level\x18\a \x01(\v2+.temporal.server.api.taskqueue.v1.FairLevelR\rfairReadLevel\x12\x1b\n" +
+	"\tack_level\x18\x02 \x01(\x03R\backLevel\x12Q\n" +
+	"\x0efair_ack_level\x18\b \x01(\v2+.temporal.server.api.taskqueue.v1.FairLevelR\ffairAckLevel\x12J\n" +
 	"\rtask_id_block\x18\x03 \x01(\v2&.temporal.api.taskqueue.v1.TaskIdBlockR\vtaskIdBlock\x12!\n" +
 	"\floaded_tasks\x18\x04 \x01(\x03R\vloadedTasks\x12:\n" +
-	"\x19approximate_backlog_count\x18\x05 \x01(\x03R\x17approximateBacklogCount\x12-\n" +
-	"\x13max_read_level_pass\x18\t \x01(\x03R\x10maxReadLevelPass\x12$\n" +
-	"\x0emax_read_level\x18\x06 \x01(\x03R\fmaxReadLevel\"\x90\x01\n" +
+	"\x19approximate_backlog_count\x18\x05 \x01(\x03R\x17approximateBacklogCount\x12$\n" +
+	"\x0emax_read_level\x18\x06 \x01(\x03R\fmaxReadLevel\x12Z\n" +
+	"\x13fair_max_read_level\x18\t \x01(\v2+.temporal.server.api.taskqueue.v1.FairLevelR\x10fairMaxReadLevel\"\x90\x01\n" +
 	"\x1cTaskQueueVersionInfoInternal\x12p\n" +
 	"\x18physical_task_queue_info\x18\x02 \x01(\v27.temporal.server.api.taskqueue.v1.PhysicalTaskQueueInfoR\x15physicalTaskQueueInfo\"\xa5\x02\n" +
 	"\x15PhysicalTaskQueueInfo\x12?\n" +
@@ -666,43 +719,47 @@ func file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP() []byte {
 	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescData
 }
 
-var file_temporal_server_api_taskqueue_v1_message_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_temporal_server_api_taskqueue_v1_message_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_temporal_server_api_taskqueue_v1_message_proto_goTypes = []any{
 	(*TaskVersionDirective)(nil),         // 0: temporal.server.api.taskqueue.v1.TaskVersionDirective
-	(*InternalTaskQueueStatus)(nil),      // 1: temporal.server.api.taskqueue.v1.InternalTaskQueueStatus
-	(*TaskQueueVersionInfoInternal)(nil), // 2: temporal.server.api.taskqueue.v1.TaskQueueVersionInfoInternal
-	(*PhysicalTaskQueueInfo)(nil),        // 3: temporal.server.api.taskqueue.v1.PhysicalTaskQueueInfo
-	(*TaskQueuePartition)(nil),           // 4: temporal.server.api.taskqueue.v1.TaskQueuePartition
-	(*BuildIdRedirectInfo)(nil),          // 5: temporal.server.api.taskqueue.v1.BuildIdRedirectInfo
-	(*TaskForwardInfo)(nil),              // 6: temporal.server.api.taskqueue.v1.TaskForwardInfo
-	(*emptypb.Empty)(nil),                // 7: google.protobuf.Empty
-	(v1.VersioningBehavior)(0),           // 8: temporal.api.enums.v1.VersioningBehavior
-	(*v11.Deployment)(nil),               // 9: temporal.api.deployment.v1.Deployment
-	(*v12.WorkerDeploymentVersion)(nil),  // 10: temporal.server.api.deployment.v1.WorkerDeploymentVersion
-	(*v13.TaskIdBlock)(nil),              // 11: temporal.api.taskqueue.v1.TaskIdBlock
-	(*v13.PollerInfo)(nil),               // 12: temporal.api.taskqueue.v1.PollerInfo
-	(*v13.TaskQueueStats)(nil),           // 13: temporal.api.taskqueue.v1.TaskQueueStats
-	(v1.TaskQueueType)(0),                // 14: temporal.api.enums.v1.TaskQueueType
-	(v14.TaskSource)(0),                  // 15: temporal.server.api.enums.v1.TaskSource
+	(*FairLevel)(nil),                    // 1: temporal.server.api.taskqueue.v1.FairLevel
+	(*InternalTaskQueueStatus)(nil),      // 2: temporal.server.api.taskqueue.v1.InternalTaskQueueStatus
+	(*TaskQueueVersionInfoInternal)(nil), // 3: temporal.server.api.taskqueue.v1.TaskQueueVersionInfoInternal
+	(*PhysicalTaskQueueInfo)(nil),        // 4: temporal.server.api.taskqueue.v1.PhysicalTaskQueueInfo
+	(*TaskQueuePartition)(nil),           // 5: temporal.server.api.taskqueue.v1.TaskQueuePartition
+	(*BuildIdRedirectInfo)(nil),          // 6: temporal.server.api.taskqueue.v1.BuildIdRedirectInfo
+	(*TaskForwardInfo)(nil),              // 7: temporal.server.api.taskqueue.v1.TaskForwardInfo
+	(*emptypb.Empty)(nil),                // 8: google.protobuf.Empty
+	(v1.VersioningBehavior)(0),           // 9: temporal.api.enums.v1.VersioningBehavior
+	(*v11.Deployment)(nil),               // 10: temporal.api.deployment.v1.Deployment
+	(*v12.WorkerDeploymentVersion)(nil),  // 11: temporal.server.api.deployment.v1.WorkerDeploymentVersion
+	(*v13.TaskIdBlock)(nil),              // 12: temporal.api.taskqueue.v1.TaskIdBlock
+	(*v13.PollerInfo)(nil),               // 13: temporal.api.taskqueue.v1.PollerInfo
+	(*v13.TaskQueueStats)(nil),           // 14: temporal.api.taskqueue.v1.TaskQueueStats
+	(v1.TaskQueueType)(0),                // 15: temporal.api.enums.v1.TaskQueueType
+	(v14.TaskSource)(0),                  // 16: temporal.server.api.enums.v1.TaskSource
 }
 var file_temporal_server_api_taskqueue_v1_message_proto_depIdxs = []int32{
-	7,  // 0: temporal.server.api.taskqueue.v1.TaskVersionDirective.use_assignment_rules:type_name -> google.protobuf.Empty
-	8,  // 1: temporal.server.api.taskqueue.v1.TaskVersionDirective.behavior:type_name -> temporal.api.enums.v1.VersioningBehavior
-	9,  // 2: temporal.server.api.taskqueue.v1.TaskVersionDirective.deployment:type_name -> temporal.api.deployment.v1.Deployment
-	10, // 3: temporal.server.api.taskqueue.v1.TaskVersionDirective.deployment_version:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentVersion
-	11, // 4: temporal.server.api.taskqueue.v1.InternalTaskQueueStatus.task_id_block:type_name -> temporal.api.taskqueue.v1.TaskIdBlock
-	3,  // 5: temporal.server.api.taskqueue.v1.TaskQueueVersionInfoInternal.physical_task_queue_info:type_name -> temporal.server.api.taskqueue.v1.PhysicalTaskQueueInfo
-	12, // 6: temporal.server.api.taskqueue.v1.PhysicalTaskQueueInfo.pollers:type_name -> temporal.api.taskqueue.v1.PollerInfo
-	13, // 7: temporal.server.api.taskqueue.v1.PhysicalTaskQueueInfo.task_queue_stats:type_name -> temporal.api.taskqueue.v1.TaskQueueStats
-	1,  // 8: temporal.server.api.taskqueue.v1.PhysicalTaskQueueInfo.internal_task_queue_status:type_name -> temporal.server.api.taskqueue.v1.InternalTaskQueueStatus
-	14, // 9: temporal.server.api.taskqueue.v1.TaskQueuePartition.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
-	15, // 10: temporal.server.api.taskqueue.v1.TaskForwardInfo.task_source:type_name -> temporal.server.api.enums.v1.TaskSource
-	5,  // 11: temporal.server.api.taskqueue.v1.TaskForwardInfo.redirect_info:type_name -> temporal.server.api.taskqueue.v1.BuildIdRedirectInfo
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	8,  // 0: temporal.server.api.taskqueue.v1.TaskVersionDirective.use_assignment_rules:type_name -> google.protobuf.Empty
+	9,  // 1: temporal.server.api.taskqueue.v1.TaskVersionDirective.behavior:type_name -> temporal.api.enums.v1.VersioningBehavior
+	10, // 2: temporal.server.api.taskqueue.v1.TaskVersionDirective.deployment:type_name -> temporal.api.deployment.v1.Deployment
+	11, // 3: temporal.server.api.taskqueue.v1.TaskVersionDirective.deployment_version:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentVersion
+	1,  // 4: temporal.server.api.taskqueue.v1.InternalTaskQueueStatus.fair_read_level:type_name -> temporal.server.api.taskqueue.v1.FairLevel
+	1,  // 5: temporal.server.api.taskqueue.v1.InternalTaskQueueStatus.fair_ack_level:type_name -> temporal.server.api.taskqueue.v1.FairLevel
+	12, // 6: temporal.server.api.taskqueue.v1.InternalTaskQueueStatus.task_id_block:type_name -> temporal.api.taskqueue.v1.TaskIdBlock
+	1,  // 7: temporal.server.api.taskqueue.v1.InternalTaskQueueStatus.fair_max_read_level:type_name -> temporal.server.api.taskqueue.v1.FairLevel
+	4,  // 8: temporal.server.api.taskqueue.v1.TaskQueueVersionInfoInternal.physical_task_queue_info:type_name -> temporal.server.api.taskqueue.v1.PhysicalTaskQueueInfo
+	13, // 9: temporal.server.api.taskqueue.v1.PhysicalTaskQueueInfo.pollers:type_name -> temporal.api.taskqueue.v1.PollerInfo
+	14, // 10: temporal.server.api.taskqueue.v1.PhysicalTaskQueueInfo.task_queue_stats:type_name -> temporal.api.taskqueue.v1.TaskQueueStats
+	2,  // 11: temporal.server.api.taskqueue.v1.PhysicalTaskQueueInfo.internal_task_queue_status:type_name -> temporal.server.api.taskqueue.v1.InternalTaskQueueStatus
+	15, // 12: temporal.server.api.taskqueue.v1.TaskQueuePartition.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
+	16, // 13: temporal.server.api.taskqueue.v1.TaskForwardInfo.task_source:type_name -> temporal.server.api.enums.v1.TaskSource
+	6,  // 14: temporal.server.api.taskqueue.v1.TaskForwardInfo.redirect_info:type_name -> temporal.server.api.taskqueue.v1.BuildIdRedirectInfo
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_api_taskqueue_v1_message_proto_init() }
@@ -714,7 +771,7 @@ func file_temporal_server_api_taskqueue_v1_message_proto_init() {
 		(*TaskVersionDirective_UseAssignmentRules)(nil),
 		(*TaskVersionDirective_AssignedBuildId)(nil),
 	}
-	file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[4].OneofWrappers = []any{
+	file_temporal_server_api_taskqueue_v1_message_proto_msgTypes[5].OneofWrappers = []any{
 		(*TaskQueuePartition_NormalPartitionId)(nil),
 		(*TaskQueuePartition_StickyName)(nil),
 	}
@@ -724,7 +781,7 @@ func file_temporal_server_api_taskqueue_v1_message_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_temporal_server_api_taskqueue_v1_message_proto_rawDesc), len(file_temporal_server_api_taskqueue_v1_message_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/taskqueue/v1/message.pb.go
+++ b/api/taskqueue/v1/message.pb.go
@@ -151,16 +151,18 @@ func (*TaskVersionDirective_UseAssignmentRules) isTaskVersionDirective_BuildId()
 func (*TaskVersionDirective_AssignedBuildId) isTaskVersionDirective_BuildId() {}
 
 type InternalTaskQueueStatus struct {
-	state                   protoimpl.MessageState `protogen:"open.v1"`
-	ReadLevelPass           int64                  `protobuf:"varint,7,opt,name=read_level_pass,json=readLevelPass,proto3" json:"read_level_pass,omitempty"`
-	ReadLevel               int64                  `protobuf:"varint,1,opt,name=read_level,json=readLevel,proto3" json:"read_level,omitempty"`
-	AckLevelPass            int64                  `protobuf:"varint,8,opt,name=ack_level_pass,json=ackLevelPass,proto3" json:"ack_level_pass,omitempty"`
-	AckLevel                int64                  `protobuf:"varint,2,opt,name=ack_level,json=ackLevel,proto3" json:"ack_level,omitempty"`
-	TaskIdBlock             *v13.TaskIdBlock       `protobuf:"bytes,3,opt,name=task_id_block,json=taskIdBlock,proto3" json:"task_id_block,omitempty"`
-	LoadedTasks             int64                  `protobuf:"varint,4,opt,name=loaded_tasks,json=loadedTasks,proto3" json:"loaded_tasks,omitempty"`
-	ApproximateBacklogCount int64                  `protobuf:"varint,5,opt,name=approximate_backlog_count,json=approximateBacklogCount,proto3" json:"approximate_backlog_count,omitempty"`
-	MaxReadLevelPass        int64                  `protobuf:"varint,9,opt,name=max_read_level_pass,json=maxReadLevelPass,proto3" json:"max_read_level_pass,omitempty"`
-	MaxReadLevel            int64                  `protobuf:"varint,6,opt,name=max_read_level,json=maxReadLevel,proto3" json:"max_read_level,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// read_level_pass and read_level (and ack_level_pass and ack_level, etc.) form a
+	// "fairness level" as a pair, so put them next to each other.
+	ReadLevelPass           int64            `protobuf:"varint,7,opt,name=read_level_pass,json=readLevelPass,proto3" json:"read_level_pass,omitempty"`
+	ReadLevel               int64            `protobuf:"varint,1,opt,name=read_level,json=readLevel,proto3" json:"read_level,omitempty"`
+	AckLevelPass            int64            `protobuf:"varint,8,opt,name=ack_level_pass,json=ackLevelPass,proto3" json:"ack_level_pass,omitempty"`
+	AckLevel                int64            `protobuf:"varint,2,opt,name=ack_level,json=ackLevel,proto3" json:"ack_level,omitempty"`
+	TaskIdBlock             *v13.TaskIdBlock `protobuf:"bytes,3,opt,name=task_id_block,json=taskIdBlock,proto3" json:"task_id_block,omitempty"`
+	LoadedTasks             int64            `protobuf:"varint,4,opt,name=loaded_tasks,json=loadedTasks,proto3" json:"loaded_tasks,omitempty"`
+	ApproximateBacklogCount int64            `protobuf:"varint,5,opt,name=approximate_backlog_count,json=approximateBacklogCount,proto3" json:"approximate_backlog_count,omitempty"`
+	MaxReadLevelPass        int64            `protobuf:"varint,9,opt,name=max_read_level_pass,json=maxReadLevelPass,proto3" json:"max_read_level_pass,omitempty"`
+	MaxReadLevel            int64            `protobuf:"varint,6,opt,name=max_read_level,json=maxReadLevel,proto3" json:"max_read_level,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }

--- a/api/taskqueue/v1/message.pb.go
+++ b/api/taskqueue/v1/message.pb.go
@@ -152,11 +152,14 @@ func (*TaskVersionDirective_AssignedBuildId) isTaskVersionDirective_BuildId() {}
 
 type InternalTaskQueueStatus struct {
 	state                   protoimpl.MessageState `protogen:"open.v1"`
+	ReadLevelPass           int64                  `protobuf:"varint,7,opt,name=read_level_pass,json=readLevelPass,proto3" json:"read_level_pass,omitempty"`
 	ReadLevel               int64                  `protobuf:"varint,1,opt,name=read_level,json=readLevel,proto3" json:"read_level,omitempty"`
+	AckLevelPass            int64                  `protobuf:"varint,8,opt,name=ack_level_pass,json=ackLevelPass,proto3" json:"ack_level_pass,omitempty"`
 	AckLevel                int64                  `protobuf:"varint,2,opt,name=ack_level,json=ackLevel,proto3" json:"ack_level,omitempty"`
 	TaskIdBlock             *v13.TaskIdBlock       `protobuf:"bytes,3,opt,name=task_id_block,json=taskIdBlock,proto3" json:"task_id_block,omitempty"`
 	LoadedTasks             int64                  `protobuf:"varint,4,opt,name=loaded_tasks,json=loadedTasks,proto3" json:"loaded_tasks,omitempty"`
 	ApproximateBacklogCount int64                  `protobuf:"varint,5,opt,name=approximate_backlog_count,json=approximateBacklogCount,proto3" json:"approximate_backlog_count,omitempty"`
+	MaxReadLevelPass        int64                  `protobuf:"varint,9,opt,name=max_read_level_pass,json=maxReadLevelPass,proto3" json:"max_read_level_pass,omitempty"`
 	MaxReadLevel            int64                  `protobuf:"varint,6,opt,name=max_read_level,json=maxReadLevel,proto3" json:"max_read_level,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
@@ -192,9 +195,23 @@ func (*InternalTaskQueueStatus) Descriptor() ([]byte, []int) {
 	return file_temporal_server_api_taskqueue_v1_message_proto_rawDescGZIP(), []int{1}
 }
 
+func (x *InternalTaskQueueStatus) GetReadLevelPass() int64 {
+	if x != nil {
+		return x.ReadLevelPass
+	}
+	return 0
+}
+
 func (x *InternalTaskQueueStatus) GetReadLevel() int64 {
 	if x != nil {
 		return x.ReadLevel
+	}
+	return 0
+}
+
+func (x *InternalTaskQueueStatus) GetAckLevelPass() int64 {
+	if x != nil {
+		return x.AckLevelPass
 	}
 	return 0
 }
@@ -223,6 +240,13 @@ func (x *InternalTaskQueueStatus) GetLoadedTasks() int64 {
 func (x *InternalTaskQueueStatus) GetApproximateBacklogCount() int64 {
 	if x != nil {
 		return x.ApproximateBacklogCount
+	}
+	return 0
+}
+
+func (x *InternalTaskQueueStatus) GetMaxReadLevelPass() int64 {
+	if x != nil {
+		return x.MaxReadLevelPass
 	}
 	return 0
 }
@@ -592,14 +616,17 @@ const file_temporal_server_api_taskqueue_v1_message_proto_rawDesc = "" +
 	"deployment\x12i\n" +
 	"\x12deployment_version\x18\x05 \x01(\v2:.temporal.server.api.deployment.v1.WorkerDeploymentVersionR\x11deploymentVersionB\n" +
 	"\n" +
-	"\bbuild_id\"\xa6\x02\n" +
-	"\x17InternalTaskQueueStatus\x12\x1d\n" +
+	"\bbuild_id\"\xa3\x03\n" +
+	"\x17InternalTaskQueueStatus\x12&\n" +
+	"\x0fread_level_pass\x18\a \x01(\x03R\rreadLevelPass\x12\x1d\n" +
 	"\n" +
-	"read_level\x18\x01 \x01(\x03R\treadLevel\x12\x1b\n" +
+	"read_level\x18\x01 \x01(\x03R\treadLevel\x12$\n" +
+	"\x0eack_level_pass\x18\b \x01(\x03R\fackLevelPass\x12\x1b\n" +
 	"\tack_level\x18\x02 \x01(\x03R\backLevel\x12J\n" +
 	"\rtask_id_block\x18\x03 \x01(\v2&.temporal.api.taskqueue.v1.TaskIdBlockR\vtaskIdBlock\x12!\n" +
 	"\floaded_tasks\x18\x04 \x01(\x03R\vloadedTasks\x12:\n" +
-	"\x19approximate_backlog_count\x18\x05 \x01(\x03R\x17approximateBacklogCount\x12$\n" +
+	"\x19approximate_backlog_count\x18\x05 \x01(\x03R\x17approximateBacklogCount\x12-\n" +
+	"\x13max_read_level_pass\x18\t \x01(\x03R\x10maxReadLevelPass\x12$\n" +
 	"\x0emax_read_level\x18\x06 \x01(\x03R\fmaxReadLevel\"\x90\x01\n" +
 	"\x1cTaskQueueVersionInfoInternal\x12p\n" +
 	"\x18physical_task_queue_info\x18\x02 \x01(\v27.temporal.server.api.taskqueue.v1.PhysicalTaskQueueInfoR\x15physicalTaskQueueInfo\"\xa5\x02\n" +

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1306,7 +1306,7 @@ second per poller by one physical queue manager`,
 	MatchingEnableFairness = NewTaskQueueBoolSetting(
 		"matching.enableFairness",
 		false,
-		`Enable fairness for task dispatching`,
+		`Enable fairness for task dispatching. Implies matching.useNewMatcher.`,
 	)
 	MatchingPriorityLevels = NewTaskQueueIntSetting(
 		"matching.priorityLevels",

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1055,7 +1055,8 @@ var (
 	ApproximateBacklogAgeSeconds           = NewGaugeDef("approximate_backlog_age_seconds")
 	NonRetryableTasks                      = NewCounterDef(
 		"non_retryable_tasks",
-		WithDescription("The number of non-retryable matching tasks which are dropped due to specific errors"))
+		WithDescription("The number of non-retryable matching tasks which are dropped due to specific errors"),
+	)
 
 	// Versioning and Reachability
 	ReachabilityExitPointCounter = NewCounterDef("reachability_exit_point_count")

--- a/common/persistence/cassandra/factory.go
+++ b/common/persistence/cassandra/factory.go
@@ -67,8 +67,7 @@ func (f *Factory) NewTaskStore() (p.TaskStore, error) {
 }
 
 // NewTaskStore returns a new task store
-// TODO(fairness): cleanup; rename to NewTaskStore
-func (f *Factory) NewTaskFairnessStore() (p.TaskStore, error) {
+func (f *Factory) NewFairTaskStore() (p.TaskStore, error) {
 	return NewMatchingTaskStore(f.session, f.logger, true), nil
 }
 

--- a/common/persistence/cassandra/matching_task_store.go
+++ b/common/persistence/cassandra/matching_task_store.go
@@ -34,17 +34,17 @@ func rowTypeTaskInSubqueue(subqueue int) int {
 }
 
 func getTaskTTL(expireTime *timestamppb.Timestamp) int64 {
-	var ttl int64
-	if expireTime != nil && !expireTime.AsTime().IsZero() {
-		expiryTtl := convert.Int64Ceil(time.Until(expireTime.AsTime()).Seconds())
-
-		// 0 means no ttl, we dont want that.
-		// Todo: Come back and correctly ignore expired in-memory tasks before persisting
-		if expiryTtl < 1 {
-			expiryTtl = 1
-		}
-
-		ttl = expiryTtl
+	if expireTime == nil || expireTime.AsTime().IsZero() {
+		return 0
 	}
-	return ttl
+
+	expiryTtl := convert.Int64Ceil(time.Until(expireTime.AsTime()).Seconds())
+
+	// 0 means no ttl, we dont want that.
+	// Todo: Come back and correctly ignore expired in-memory tasks before persisting
+	if expiryTtl < 1 {
+		expiryTtl = 1
+	}
+
+	return expiryTtl
 }

--- a/common/persistence/cassandra/matching_task_store.go
+++ b/common/persistence/cassandra/matching_task_store.go
@@ -1,33 +1,13 @@
-// The MIT License
-//
-// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
-//
-// Copyright (c) 2020 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 package cassandra
 
 import (
+	"time"
+
+	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func NewMatchingTaskStore(
@@ -35,9 +15,36 @@ func NewMatchingTaskStore(
 	logger log.Logger,
 	enableFairness bool,
 ) p.TaskStore {
-	userDataStore := &userDataStore{Session: session, Logger: logger}
+	userDataStore := userDataStore{Session: session, Logger: logger}
 	if enableFairness {
 		return newMatchingTaskStoreV2(userDataStore)
 	}
 	return newMatchingTaskStoreV1(userDataStore)
+}
+
+// We steal some upper bits of the "row type" field to hold a subqueue index.
+// Subqueue 0 must be the same as rowTypeTask (before subqueues were introduced).
+// 00000000: task in subqueue 0 (rowTypeTask)
+// 00000001: task queue metadata (rowTypeTaskQueue)
+// xxxxxx1x: reserved
+// 00000100: task in subqueue 1
+// nnnnnn00: task in subqueue n, etc.
+func rowTypeTaskInSubqueue(subqueue int) int {
+	return subqueue<<2 | rowTypeTask // nolint:staticcheck
+}
+
+func getTaskTTL(expireTime *timestamppb.Timestamp) int64 {
+	var ttl int64
+	if expireTime != nil && !expireTime.AsTime().IsZero() {
+		expiryTtl := convert.Int64Ceil(time.Until(expireTime.AsTime()).Seconds())
+
+		// 0 means no ttl, we dont want that.
+		// Todo: Come back and correctly ignore expired in-memory tasks before persisting
+		if expiryTtl < 1 {
+			expiryTtl = 1
+		}
+
+		ttl = expiryTtl
+	}
+	return ttl
 }

--- a/common/persistence/cassandra/matching_task_store_user_data.go
+++ b/common/persistence/cassandra/matching_task_store_user_data.go
@@ -1,40 +1,13 @@
-// The MIT License
-//
-// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
-//
-// Copyright (c) 2020 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 package cassandra
 
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -244,31 +217,4 @@ func (d *userDataStore) CountTaskQueuesByBuildId(ctx context.Context, request *p
 	query := d.Session.Query(templateCountTaskQueueByBuildIdQuery, request.NamespaceID, request.BuildID).WithContext(ctx)
 	err := query.Scan(&count)
 	return count, err
-}
-
-// We steal some upper bits of the "row type" field to hold a subqueue index.
-// Subqueue 0 must be the same as rowTypeTask (before subqueues were introduced).
-// 00000000: task in subqueue 0 (rowTypeTask)
-// 00000001: task queue metadata (rowTypeTaskQueue)
-// xxxxxx1x: reserved
-// 00000100: task in subqueue 1
-// nnnnnn00: task in subqueue n, etc.
-func rowTypeTaskInSubqueue(subqueue int) int {
-	return subqueue<<2 | rowTypeTask // nolint:staticcheck
-}
-
-func getTaskTTL(expireTime *timestamppb.Timestamp) int64 {
-	var ttl int64
-	if expireTime != nil && !expireTime.AsTime().IsZero() {
-		expiryTtl := convert.Int64Ceil(time.Until(expireTime.AsTime()).Seconds())
-
-		// 0 means no ttl, we dont want that.
-		// Todo: Come back and correctly ignore expired in-memory tasks before persisting
-		if expiryTtl < 1 {
-			expiryTtl = 1
-		}
-
-		ttl = expiryTtl
-	}
-	return ttl
 }

--- a/common/persistence/cassandra/matching_task_store_v1.go
+++ b/common/persistence/cassandra/matching_task_store_v1.go
@@ -283,7 +283,7 @@ func (d *matchingTaskStoreV1) CreateTasks(
 	taskQueueType := request.TaskType
 
 	for _, task := range request.Tasks {
-		if task.Pass != 0 {
+		if task.TaskPass != 0 {
 			return nil, serviceerror.NewInternal("invalid non-fair queue task with pass number")
 		}
 

--- a/common/persistence/cassandra/matching_task_store_v1.go
+++ b/common/persistence/cassandra/matching_task_store_v1.go
@@ -1,27 +1,3 @@
-// The MIT License
-//
-// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
-//
-// Copyright (c) 2020 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 package cassandra
 
 import (
@@ -125,11 +101,11 @@ const (
 )
 
 type matchingTaskStoreV1 struct {
-	*userDataStore
+	userDataStore
 }
 
 func newMatchingTaskStoreV1(
-	userDataStore *userDataStore,
+	userDataStore userDataStore,
 ) *matchingTaskStoreV1 {
 	return &matchingTaskStoreV1{userDataStore: userDataStore}
 }
@@ -307,6 +283,10 @@ func (d *matchingTaskStoreV1) CreateTasks(
 	taskQueueType := request.TaskType
 
 	for _, task := range request.Tasks {
+		if task.Pass != 0 {
+			return nil, serviceerror.NewInternal("invalid non-fair queue task with pass number")
+		}
+
 		ttl := getTaskTTL(task.ExpiryTime)
 
 		if ttl <= 0 || ttl > maxCassandraTTL {
@@ -365,6 +345,10 @@ func (d *matchingTaskStoreV1) GetTasks(
 	ctx context.Context,
 	request *p.GetTasksRequest,
 ) (*p.InternalGetTasksResponse, error) {
+	if request.InclusiveMinPass != 0 {
+		return nil, serviceerror.NewInternal("invalid GetTasks request on queue")
+	}
+
 	// Reading taskqueue tasks need to be quorum level consistent, otherwise we could lose tasks
 	query := d.Session.Query(templateGetTasksQuery,
 		request.NamespaceID,
@@ -392,7 +376,6 @@ func (d *matchingTaskStoreV1) GetTasks(
 		if !ok {
 			var byteSliceType []byte
 			return nil, newPersistedTypeMismatchError("task", byteSliceType, rawTask, task)
-
 		}
 
 		rawEncoding, ok := task["task_encoding"]
@@ -425,6 +408,10 @@ func (d *matchingTaskStoreV1) CompleteTasksLessThan(
 	ctx context.Context,
 	request *p.CompleteTasksLessThanRequest,
 ) (int, error) {
+	if request.ExclusiveMaxPass != 0 {
+		return 0, serviceerror.NewInternal("invalid CompleteTasksLessThan request on queue")
+	}
+
 	query := d.Session.Query(
 		templateCompleteTasksLessThanQuery,
 		request.NamespaceID,

--- a/common/persistence/cassandra/matching_task_store_v2.go
+++ b/common/persistence/cassandra/matching_task_store_v2.go
@@ -238,7 +238,7 @@ func (d *matchingTaskStoreV2) CreateTasks(
 	taskQueueType := request.TaskType
 
 	for _, task := range request.Tasks {
-		if task.Pass == 0 {
+		if task.TaskPass == 0 {
 			return nil, serviceerror.NewInternal("invalid fair queue task missing pass number")
 		}
 
@@ -247,7 +247,7 @@ func (d *matchingTaskStoreV2) CreateTasks(
 			taskQueue,
 			taskQueueType,
 			rowTypeTaskInSubqueue(task.Subqueue),
-			task.Pass,
+			task.TaskPass,
 			task.TaskId,
 			task.Task.Data,
 			task.Task.EncodingType.String())

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -28,7 +28,7 @@ type (
 		Close()
 		// NewTaskManager returns a new task manager
 		NewTaskManager() (persistence.TaskManager, error)
-		// NewFairTaskManager returns a new task (fairness) manager
+		// NewFairTaskManager returns a new fair task manager
 		NewFairTaskManager() (persistence.FairTaskManager, error)
 		// NewShardManager returns a new shard manager
 		NewShardManager() (persistence.ShardManager, error)
@@ -116,9 +116,8 @@ func (f *factoryImpl) NewTaskManager() (persistence.TaskManager, error) {
 }
 
 // NewFairTaskManager returns a new task fairness manager
-// TODO(fairness): cleanup; rename to NewTaskManager
 func (f *factoryImpl) NewFairTaskManager() (persistence.FairTaskManager, error) {
-	taskStore, err := f.dataStoreFactory.NewTaskFairnessStore()
+	taskStore, err := f.dataStoreFactory.NewFairTaskStore()
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/client/fx.go
+++ b/common/persistence/client/fx.go
@@ -1,9 +1,11 @@
 package client
 
 import (
+	"errors"
 	"time"
 
 	"go.opentelemetry.io/otel/trace"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -197,6 +199,11 @@ func managerProvider[T persistence.Closeable](newManagerFn func(Factory) (T, err
 	return func(f Factory, lc fx.Lifecycle) (T, error) {
 		manager, err := newManagerFn(f) // passing receiver (Factory) as first argument.
 		if err != nil {
+			var unimpl *serviceerror.Unimplemented
+			if errors.As(err, &unimpl) {
+				// allow factories to return Unimplemented, and turn into nil so that fx init doesn't fail.
+				err = nil
+			}
 			var nilT T
 			return nilT, err
 		}

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -601,10 +601,12 @@ type (
 		NamespaceID        string
 		TaskQueue          string
 		TaskType           enumspb.TaskQueueType
+		InclusiveMinPass   int64 // FairTaskManager only
 		InclusiveMinTaskID int64
 		ExclusiveMaxTaskID int64
 		Subqueue           int
 		PageSize           int
+		UseLimit           bool // If true, use LIMIT in the query
 		NextPageToken      []byte
 	}
 
@@ -619,6 +621,7 @@ type (
 		NamespaceID        string
 		TaskQueueName      string
 		TaskType           enumspb.TaskQueueType
+		ExclusiveMaxPass   int64 // If set, delete tasks less than <ExclusiveMaxPass, ExclusiveMaxTaskID>
 		ExclusiveMaxTaskID int64 // Tasks less than this ID will be completed
 		Subqueue           int
 		Limit              int // Limit on the max number of tasks that can be completed. Required param

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -598,10 +598,13 @@ type (
 
 	// GetTasksRequest is used to retrieve tasks of a task queue
 	GetTasksRequest struct {
-		NamespaceID        string
-		TaskQueue          string
-		TaskType           enumspb.TaskQueueType
-		InclusiveMinPass   int64 // FairTaskManager only
+		NamespaceID string
+		TaskQueue   string
+		TaskType    enumspb.TaskQueueType
+		// If InclusiveMinPass is set, return tasks greater or equal to <InclusiveMinPass,
+		// InclusiveMinTaskID> with no upper bound. InclusiveMinPass must be >= 1 for fair task
+		// manager and must be 0 for classic task manager.
+		InclusiveMinPass   int64
 		InclusiveMinTaskID int64
 		ExclusiveMaxTaskID int64
 		Subqueue           int

--- a/common/persistence/faultinjection/data_store_factory.go
+++ b/common/persistence/faultinjection/data_store_factory.go
@@ -53,10 +53,9 @@ func (d *FaultInjectionDataStoreFactory) NewTaskStore() (persistence.TaskStore, 
 	return d.taskStore, nil
 }
 
-// TODO(fairness): cleanup; rename to NewTaskStore
-func (d *FaultInjectionDataStoreFactory) NewTaskFairnessStore() (persistence.TaskStore, error) {
+func (d *FaultInjectionDataStoreFactory) NewFairTaskStore() (persistence.TaskStore, error) {
 	if d.taskStore == nil {
-		baseStore, err := d.baseFactory.NewTaskFairnessStore()
+		baseStore, err := d.baseFactory.NewFairTaskStore()
 		if err != nil {
 			return nil, err
 		}

--- a/common/persistence/mock/store_mock.go
+++ b/common/persistence/mock/store_mock.go
@@ -84,6 +84,21 @@ func (mr *MockDataStoreFactoryMockRecorder) NewExecutionStore() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewExecutionStore", reflect.TypeOf((*MockDataStoreFactory)(nil).NewExecutionStore))
 }
 
+// NewFairTaskStore mocks base method.
+func (m *MockDataStoreFactory) NewFairTaskStore() (persistence.TaskStore, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewFairTaskStore")
+	ret0, _ := ret[0].(persistence.TaskStore)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewFairTaskStore indicates an expected call of NewFairTaskStore.
+func (mr *MockDataStoreFactoryMockRecorder) NewFairTaskStore() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewFairTaskStore", reflect.TypeOf((*MockDataStoreFactory)(nil).NewFairTaskStore))
+}
+
 // NewMetadataStore mocks base method.
 func (m *MockDataStoreFactory) NewMetadataStore() (persistence.MetadataStore, error) {
 	m.ctrl.T.Helper()
@@ -157,21 +172,6 @@ func (m *MockDataStoreFactory) NewShardStore() (persistence.ShardStore, error) {
 func (mr *MockDataStoreFactoryMockRecorder) NewShardStore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewShardStore", reflect.TypeOf((*MockDataStoreFactory)(nil).NewShardStore))
-}
-
-// NewTaskFairnessStore mocks base method.
-func (m *MockDataStoreFactory) NewTaskFairnessStore() (persistence.TaskStore, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewTaskFairnessStore")
-	ret0, _ := ret[0].(persistence.TaskStore)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NewTaskFairnessStore indicates an expected call of NewTaskFairnessStore.
-func (mr *MockDataStoreFactoryMockRecorder) NewTaskFairnessStore() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewTaskFairnessStore", reflect.TypeOf((*MockDataStoreFactory)(nil).NewTaskFairnessStore))
 }
 
 // NewTaskStore mocks base method.

--- a/common/persistence/persistence-tests/persistence_test_base.go
+++ b/common/persistence/persistence-tests/persistence_test_base.go
@@ -71,7 +71,7 @@ type (
 		Factory                   client.Factory
 		ExecutionManager          persistence.ExecutionManager
 		TaskMgr                   persistence.TaskManager
-		TaskFairnessMgr           persistence.FairTaskManager // TODO(fairness): cleanup; rename to TaskMgr
+		FairTaskMgr               persistence.FairTaskManager
 		ClusterMetadataManager    persistence.ClusterMetadataManager
 		MetadataManager           persistence.MetadataManager
 		NamespaceReplicationQueue persistence.NamespaceReplicationQueue
@@ -217,8 +217,7 @@ func (s *TestBase) Setup(clusterMetadataConfig *cluster.Config) {
 	s.TaskMgr, err = factory.NewTaskManager()
 	s.fatalOnError("NewTaskManager", err)
 
-	// TODO(fairness): cleanup; rename to TaskMgr
-	s.TaskFairnessMgr, err = factory.NewFairTaskManager()
+	s.FairTaskMgr, err = factory.NewFairTaskManager()
 	s.fatalOnError("NewFairTaskManager", err)
 
 	s.ClusterMetadataManager, err = factory.NewClusterMetadataManager()

--- a/common/persistence/persistence-tests/persistence_test_base.go
+++ b/common/persistence/persistence-tests/persistence_test_base.go
@@ -218,7 +218,8 @@ func (s *TestBase) Setup(clusterMetadataConfig *cluster.Config) {
 	s.fatalOnError("NewTaskManager", err)
 
 	s.FairTaskMgr, err = factory.NewFairTaskManager()
-	s.fatalOnError("NewFairTaskManager", err)
+	// TODO: re-enable error check after FairTaskManager is implemented for sql
+	// s.fatalOnError("NewFairTaskManager", err)
 
 	s.ClusterMetadataManager, err = factory.NewClusterMetadataManager()
 	s.fatalOnError("NewClusterMetadataManager", err)

--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -33,8 +33,8 @@ type (
 		Close()
 		// NewTaskStore returns a new task store
 		NewTaskStore() (TaskStore, error)
-		// NewTaskStore returns a new task store
-		NewTaskFairnessStore() (TaskStore, error)
+		// NewFairTaskStore returns a new task store with fairness enabled
+		NewFairTaskStore() (TaskStore, error)
 		// NewShardStore returns a new shard store
 		NewShardStore() (ShardStore, error)
 		// NewMetadataStore returns a new metadata store
@@ -69,8 +69,6 @@ type (
 		UpdateTaskQueue(ctx context.Context, request *InternalUpdateTaskQueueRequest) (*UpdateTaskQueueResponse, error)
 		ListTaskQueue(ctx context.Context, request *ListTaskQueueRequest) (*InternalListTaskQueueResponse, error)
 		DeleteTaskQueue(ctx context.Context, request *DeleteTaskQueueRequest) error
-		GetTaskQueuesByBuildId(ctx context.Context, request *GetTaskQueuesByBuildIdRequest) ([]string, error)
-		CountTaskQueuesByBuildId(ctx context.Context, request *CountTaskQueuesByBuildIdRequest) (int, error)
 
 		CreateTasks(ctx context.Context, request *InternalCreateTasksRequest) (*CreateTasksResponse, error)
 		GetTasks(ctx context.Context, request *GetTasksRequest) (*InternalGetTasksResponse, error)
@@ -79,6 +77,8 @@ type (
 		GetTaskQueueUserData(ctx context.Context, request *GetTaskQueueUserDataRequest) (*InternalGetTaskQueueUserDataResponse, error)
 		UpdateTaskQueueUserData(ctx context.Context, request *InternalUpdateTaskQueueUserDataRequest) error
 		ListTaskQueueUserDataEntries(ctx context.Context, request *ListTaskQueueUserDataEntriesRequest) (*InternalListTaskQueueUserDataEntriesResponse, error)
+		GetTaskQueuesByBuildId(ctx context.Context, request *GetTaskQueuesByBuildIdRequest) ([]string, error)
+		CountTaskQueuesByBuildId(ctx context.Context, request *CountTaskQueuesByBuildIdRequest) (int, error)
 	}
 
 	// MetadataStore is a lower level of MetadataManager

--- a/common/persistence/persistence_interface.go
+++ b/common/persistence/persistence_interface.go
@@ -305,8 +305,8 @@ type (
 	}
 
 	InternalCreateTask struct {
+		TaskPass   int64
 		TaskId     int64
-		Pass       int64
 		ExpiryTime *timestamppb.Timestamp
 		Task       *commonpb.DataBlob
 		Subqueue   int

--- a/common/persistence/sql/factory.go
+++ b/common/persistence/sql/factory.go
@@ -1,6 +1,7 @@
 package sql
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -73,14 +74,9 @@ func (f *Factory) NewTaskStore() (p.TaskStore, error) {
 	return newTaskPersistence(conn, f.cfg.TaskScanPartitions, f.logger)
 }
 
-// NewTaskFairnessStore returns a new task store
-// TODO(fairness): cleanup; rename to NewTaskStore
-func (f *Factory) NewTaskFairnessStore() (p.TaskStore, error) {
-	conn, err := f.mainDBConn.Get()
-	if err != nil {
-		return nil, err
-	}
-	return newTaskPersistence(conn, f.cfg.TaskScanPartitions, f.logger)
+// NewFairTaskStore returns a new task store
+func (f *Factory) NewFairTaskStore() (p.TaskStore, error) {
+	return nil, errors.New("not implemented")
 }
 
 // NewShardStore returns a new shard store

--- a/common/persistence/sql/factory.go
+++ b/common/persistence/sql/factory.go
@@ -1,7 +1,6 @@
 package sql
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -76,7 +75,10 @@ func (f *Factory) NewTaskStore() (p.TaskStore, error) {
 
 // NewFairTaskStore returns a new task store
 func (f *Factory) NewFairTaskStore() (p.TaskStore, error) {
-	return nil, errors.New("not implemented")
+	// We don't have an implementation of fair TaskStore for SQL yet.
+	// Don't return an error, because fx won't allow the process to start at all, so just
+	// return nil and let it crash if someone tries to use it.
+	return nil, nil
 }
 
 // NewShardStore returns a new shard store

--- a/common/persistence/sql/factory.go
+++ b/common/persistence/sql/factory.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -75,10 +76,7 @@ func (f *Factory) NewTaskStore() (p.TaskStore, error) {
 
 // NewFairTaskStore returns a new task store
 func (f *Factory) NewFairTaskStore() (p.TaskStore, error) {
-	// We don't have an implementation of fair TaskStore for SQL yet.
-	// Don't return an error, because fx won't allow the process to start at all, so just
-	// return nil and let it crash if someone tries to use it.
-	return nil, nil
+	return nil, serviceerror.NewUnimplemented("not implemented for sql")
 }
 
 // NewShardStore returns a new shard store

--- a/common/persistence/task_manager.go
+++ b/common/persistence/task_manager.go
@@ -176,7 +176,8 @@ func (m *taskManagerImpl) CreateTasks(
 			return nil, serviceerror.NewUnavailablef("CreateTasks operation failed during serialization. Error : %v", err)
 		}
 		tasks[i] = &InternalCreateTask{
-			TaskId:     task.GetTaskId(),
+			TaskId:     task.TaskId,
+			Pass:       task.PassNumber,
 			ExpiryTime: task.Data.ExpiryTime,
 			Task:       taskBlob,
 		}

--- a/common/persistence/task_manager.go
+++ b/common/persistence/task_manager.go
@@ -176,8 +176,8 @@ func (m *taskManagerImpl) CreateTasks(
 			return nil, serviceerror.NewUnavailablef("CreateTasks operation failed during serialization. Error : %v", err)
 		}
 		tasks[i] = &InternalCreateTask{
+			TaskPass:   task.TaskPass,
 			TaskId:     task.TaskId,
-			Pass:       task.TaskPass,
 			ExpiryTime: task.Data.ExpiryTime,
 			Task:       taskBlob,
 		}

--- a/common/persistence/task_manager.go
+++ b/common/persistence/task_manager.go
@@ -177,7 +177,7 @@ func (m *taskManagerImpl) CreateTasks(
 		}
 		tasks[i] = &InternalCreateTask{
 			TaskId:     task.TaskId,
-			Pass:       task.PassNumber,
+			Pass:       task.TaskPass,
 			ExpiryTime: task.Data.ExpiryTime,
 			Task:       taskBlob,
 		}

--- a/common/persistence/telemetry/data_store_factory.go
+++ b/common/persistence/telemetry/data_store_factory.go
@@ -50,10 +50,9 @@ func (d *TelemetryDataStoreFactory) NewTaskStore() (persistence.TaskStore, error
 	return d.taskStore, nil
 }
 
-// TODO(fairness): cleanup; rename to NewTaskStore
-func (d *TelemetryDataStoreFactory) NewTaskFairnessStore() (persistence.TaskStore, error) {
+func (d *TelemetryDataStoreFactory) NewFairTaskStore() (persistence.TaskStore, error) {
 	if d.taskStore == nil {
-		baseStore, err := d.baseFactory.NewTaskFairnessStore()
+		baseStore, err := d.baseFactory.NewFairTaskStore()
 		if err != nil {
 			return nil, err
 		}

--- a/common/persistence/tests/cassandra_test.go
+++ b/common/persistence/tests/cassandra_test.go
@@ -212,18 +212,8 @@ func TestCassandraTaskQueueSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-// TODO(fairness): cleanup; rename to TestCassandraTaskQueueSuite
-func TestCassandraTaskFairnessQueueSuite(t *testing.T) {
-	testData, tearDown := setUpCassandraTest(t)
-	defer tearDown()
-
-	taskQueueStore, err := testData.Factory.NewTaskFairnessStore()
-	if err != nil {
-		t.Fatalf("unable to create Cassandra DB: %v", err)
-	}
-
-	s := NewTaskQueueSuite(t, taskQueueStore, testData.Logger)
-	suite.Run(t, s)
+func TestCassandraFairTaskQueueSuite(t *testing.T) {
+	// TODO(fairness): adapt test suite for fair task store
 }
 
 func TestCassandraTaskQueueTaskSuite(t *testing.T) {
@@ -237,6 +227,10 @@ func TestCassandraTaskQueueTaskSuite(t *testing.T) {
 
 	s := NewTaskQueueTaskSuite(t, taskQueueStore, testData.Logger)
 	suite.Run(t, s)
+}
+
+func TestCassandraFairTaskQueueTaskSuite(t *testing.T) {
+	// TODO(fairness): adapt test suite for fair task store
 }
 
 func TestCassandraTaskQueueUserDataSuite(t *testing.T) {

--- a/proto/internal/temporal/server/api/persistence/v1/tasks.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/tasks.proto
@@ -14,7 +14,7 @@ import "temporal/server/api/taskqueue/v1/message.proto";
 // task column
 message AllocatedTaskInfo {
     TaskInfo data = 1;
-    int64 pass_number = 3;
+    int64 task_pass = 3;
     int64 task_id = 2;
 }
 
@@ -67,7 +67,7 @@ message SubqueueInfo {
 
     // The rest are mutable state for the subqueue:
     int64 ack_level_pass = 4;
-    int64 ack_level = 2;
+    int64 ack_level_id = 2;
     int64 approximate_backlog_count = 3;
 
     // Max read level keeps track of the highest task level ever written, but is only

--- a/proto/internal/temporal/server/api/persistence/v1/tasks.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/tasks.proto
@@ -66,16 +66,14 @@ message SubqueueInfo {
     SubqueueKey key = 1;
 
     // The rest are mutable state for the subqueue:
-    int64 ack_level_pass = 4;
-    int64 ack_level_id = 2;
+    int64 ack_level = 2;
+    temporal.server.api.taskqueue.v1.FairLevel fair_ack_level = 4;
+
     int64 approximate_backlog_count = 3;
 
     // Max read level keeps track of the highest task level ever written, but is only
     // maintained best-effort. Do not trust these values.
-    int64 max_read_level_pass = 5;
-    // Max read level keeps track of the highest task level ever written, but is only
-    // maintained best-effort. Do not trust these values.
-    int64 max_read_level_id = 6;
+    temporal.server.api.taskqueue.v1.FairLevel fair_max_read_level = 5;
 }
 
 message SubqueueKey {

--- a/proto/internal/temporal/server/api/persistence/v1/tasks.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/tasks.proto
@@ -14,6 +14,7 @@ import "temporal/server/api/taskqueue/v1/message.proto";
 // task column
 message AllocatedTaskInfo {
     TaskInfo data = 1;
+    int64 pass_number = 3;
     int64 task_id = 2;
 }
 
@@ -65,8 +66,16 @@ message SubqueueInfo {
     SubqueueKey key = 1;
 
     // The rest are mutable state for the subqueue:
+    int64 ack_level_pass = 4;
     int64 ack_level = 2;
     int64 approximate_backlog_count = 3;
+
+    // Max read level keeps track of the highest task level ever written, but is only
+    // maintained best-effort. Do not trust these values.
+    int64 max_read_level_pass = 5;
+    // Max read level keeps track of the highest task level ever written, but is only
+    // maintained best-effort. Do not trust these values.
+    int64 max_read_level_id = 6;
 }
 
 message SubqueueKey {

--- a/proto/internal/temporal/server/api/taskqueue/v1/message.proto
+++ b/proto/internal/temporal/server/api/taskqueue/v1/message.proto
@@ -40,18 +40,21 @@ message TaskVersionDirective {
     temporal.server.api.deployment.v1.WorkerDeploymentVersion deployment_version = 5;
 }
 
+message FairLevel {
+    int64 task_pass = 1;
+    int64 task_id = 2;
+}
+
 message InternalTaskQueueStatus {
-    // read_level_pass and read_level (and ack_level_pass and ack_level, etc.) form a
-    // "fairness level" as a pair, so put them next to each other.
-    int64 read_level_pass = 7;
     int64 read_level = 1;
-    int64 ack_level_pass = 8;
+    FairLevel fair_read_level = 7;
     int64 ack_level = 2;
+    FairLevel fair_ack_level = 8;
     temporal.api.taskqueue.v1.TaskIdBlock task_id_block = 3;
     int64 loaded_tasks = 4;
     int64 approximate_backlog_count = 5;
-    int64 max_read_level_pass = 9;
     int64 max_read_level = 6;
+    FairLevel fair_max_read_level = 9;
 }
 
 message TaskQueueVersionInfoInternal {

--- a/proto/internal/temporal/server/api/taskqueue/v1/message.proto
+++ b/proto/internal/temporal/server/api/taskqueue/v1/message.proto
@@ -41,11 +41,14 @@ message TaskVersionDirective {
 }
 
 message InternalTaskQueueStatus {
+    int64 read_level_pass = 7;
     int64 read_level = 1;
+    int64 ack_level_pass = 8;
     int64 ack_level = 2;
     temporal.api.taskqueue.v1.TaskIdBlock task_id_block = 3;
     int64 loaded_tasks = 4;
     int64 approximate_backlog_count = 5;
+    int64 max_read_level_pass = 9;
     int64 max_read_level = 6;
 }
 

--- a/proto/internal/temporal/server/api/taskqueue/v1/message.proto
+++ b/proto/internal/temporal/server/api/taskqueue/v1/message.proto
@@ -41,6 +41,8 @@ message TaskVersionDirective {
 }
 
 message InternalTaskQueueStatus {
+    // read_level_pass and read_level (and ack_level_pass and ack_level, etc.) form a
+    // "fairness level" as a pair, so put them next to each other.
     int64 read_level_pass = 7;
     int64 read_level = 1;
     int64 ack_level_pass = 8;

--- a/schema/cassandra/temporal/schema.cql
+++ b/schema/cassandra/temporal/schema.cql
@@ -80,7 +80,6 @@ CREATE TABLE history_tree (
 };
 
 -- Stores activity or workflow tasks
--- TODO(fairness): cleanup; remove this table
 CREATE TABLE tasks (
   namespace_id        uuid,
   task_queue_name     text,
@@ -103,7 +102,7 @@ CREATE TABLE tasks_v2 (
   namespace_id        uuid,
   task_queue_name     text,
   task_queue_type     int, -- enum TaskQueueType {ActivityTask, WorkflowTask}
-  type                int, -- enum rowType {Task, TaskQueue}
+  type                int, -- enum rowType {Task, TaskQueue} and subqueue id
   pass                bigint, -- pass for tasks (see stride scheduling algorithm for fairness)
   task_id             bigint, -- unique identifier for tasks
   range_id            bigint, -- used to ensure that only one process can write to the table

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -138,7 +138,7 @@ func (db *taskQueueDB) RenewLease(
 	}
 	return taskQueueState{
 		rangeID:   db.rangeID,
-		ackLevel:  db.subqueues[subqueueZero].AckLevelId, // TODO(pri): cleanup, only used by old backlog manager
+		ackLevel:  db.subqueues[subqueueZero].AckLevel, // TODO(pri): cleanup, only used by old backlog manager
 		subqueues: db.cloneSubqueues(),
 	}, nil
 }
@@ -186,7 +186,7 @@ func (db *taskQueueDB) takeOverTaskQueueLocked(
 		// In this case, ensureDefaultSubqueuesLocked already initialized subqueue 0 to have
 		// ackLevel and maxReadLevel 0, so we don't need to initialize them.
 		softassert.That(db.logger, db.subqueues[0].maxReadLevel == 0, "should have maxReadLevel 0 here")
-		softassert.That(db.logger, db.subqueues[0].AckLevelId == 0, "should have ackLevel 0 here")
+		softassert.That(db.logger, db.subqueues[0].AckLevel == 0, "should have ackLevel 0 here")
 		return nil
 
 	default:
@@ -237,7 +237,7 @@ func (db *taskQueueDB) OldUpdateState(
 		PrevRangeID:   db.rangeID,
 	})
 	if err == nil {
-		db.subqueues[subqueueZero].AckLevelId = ackLevel
+		db.subqueues[subqueueZero].AckLevel = ackLevel
 	}
 	db.emitBacklogGaugesLocked()
 	return err
@@ -265,12 +265,12 @@ func (db *taskQueueDB) updateAckLevelAndBacklogStats(subqueue int, newAckLevel i
 
 	db.lastChange = time.Now()
 	dbQueue := db.subqueues[subqueue]
-	if newAckLevel < dbQueue.AckLevelId {
+	if newAckLevel < dbQueue.AckLevel {
 		softassert.Fail(db.logger,
 			fmt.Sprintf("ack level in subqueue %d should not move backwards (from %v to %v)",
-				subqueue, dbQueue.AckLevelId, newAckLevel))
+				subqueue, dbQueue.AckLevel, newAckLevel))
 	}
-	dbQueue.AckLevelId = newAckLevel
+	dbQueue.AckLevel = newAckLevel
 
 	if newAckLevel == db.getMaxReadLevelLocked(subqueue) {
 		// Reset approximateBacklogCount to fix the count divergence issue
@@ -480,7 +480,7 @@ func (db *taskQueueDB) cachedQueueInfo() *persistencespb.TaskQueueInfo {
 		Name:                    db.queue.PersistenceName(),
 		TaskType:                db.queue.TaskType(),
 		Kind:                    db.queue.Partition().Kind(),
-		AckLevel:                db.subqueues[subqueueZero].AckLevelId, // backwards compatibility
+		AckLevel:                db.subqueues[subqueueZero].AckLevel, // backwards compatibility
 		ExpiryTime:              db.expiryTime(),
 		LastUpdateTime:          timestamp.TimeNowPtrUtc(),
 		ApproximateBacklogCount: db.subqueues[subqueueZero].ApproximateBacklogCount, // backwards compatibility
@@ -505,7 +505,7 @@ func (db *taskQueueDB) emitBacklogGaugesLocked() {
 		oldestTime = minNonZeroTime(oldestTime, s.oldestTime)
 		// note: this metric is only an estimation for the lag.
 		// taskID in DB may not be continuous, especially when task list ownership changes.
-		totalLag += s.maxReadLevel - s.AckLevelId
+		totalLag += s.maxReadLevel - s.AckLevel
 	}
 
 	metrics.ApproximateBacklogCount.With(db.metricsHandler).Record(float64(approximateBacklogCount))
@@ -541,7 +541,7 @@ func (db *taskQueueDB) ensureDefaultSubqueuesLocked(
 		// If we are transitioning from no-subqueues to subqueues, initialize subqueue 0 with
 		// the ack level and approx count from TaskQueueInfo.
 		if len(subqueues) == 1 {
-			subqueues[subqueueZero].AckLevelId = initAckLevel
+			subqueues[subqueueZero].AckLevel = initAckLevel
 			subqueues[subqueueZero].ApproximateBacklogCount = initApproxCount
 		}
 	}
@@ -554,7 +554,7 @@ func (db *taskQueueDB) newSubqueueLocked(key *persistencespb.SubqueueKey) *dbSub
 
 	s := &dbSubqueue{maxReadLevel: initAckLevel}
 	s.Key = key
-	s.AckLevelId = initAckLevel
+	s.AckLevel = initAckLevel
 	return s
 }
 

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -192,7 +192,7 @@ var _ Engine = (*matchingEngineImpl)(nil) // Asserts that interface is indeed im
 // NewEngine creates an instance of matching engine
 func NewEngine(
 	taskManager persistence.TaskManager,
-	FairTaskManager persistence.FairTaskManager,
+	fairTaskManager persistence.FairTaskManager,
 	historyClient resource.HistoryClient,
 	matchingRawClient resource.MatchingRawClient,
 	deploymentStoreClient deployment.DeploymentStoreClient, // [wv-cleanup-pre-release]
@@ -217,7 +217,7 @@ func NewEngine(
 	e := &matchingEngineImpl{
 		status:                        common.DaemonStatusInitialized,
 		taskManager:                   taskManager,
-		fairTaskManager:               FairTaskManager,
+		fairTaskManager:               fairTaskManager,
 		historyClient:                 historyClient,
 		matchingRawClient:             matchingRawClient,
 		deploymentStoreClient:         deploymentStoreClient,

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -109,7 +109,7 @@ type (
 	matchingEngineImpl struct {
 		status                        int32
 		taskManager                   persistence.TaskManager
-		FairTaskManager               persistence.FairTaskManager
+		fairTaskManager               persistence.FairTaskManager
 		historyClient                 resource.HistoryClient
 		matchingRawClient             resource.MatchingRawClient
 		deploymentStoreClient         deployment.DeploymentStoreClient
@@ -217,7 +217,7 @@ func NewEngine(
 	e := &matchingEngineImpl{
 		status:                        common.DaemonStatusInitialized,
 		taskManager:                   taskManager,
-		FairTaskManager:               FairTaskManager,
+		fairTaskManager:               FairTaskManager,
 		historyClient:                 historyClient,
 		matchingRawClient:             matchingRawClient,
 		deploymentStoreClient:         deploymentStoreClient,

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -186,7 +186,7 @@ func newPhysicalTaskQueueManager(
 
 	var taskManager persistence.TaskManager
 	if newFairness {
-		taskManager = e.FairTaskManager
+		taskManager = e.fairTaskManager
 	} else {
 		taskManager = e.taskManager
 	}

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -154,7 +154,7 @@ func (c *priBacklogManagerImpl) loadSubqueuesLocked(subqueues []persistencespb.S
 	// existing subqueues never changes. If we change that, this logic will need to change.
 	for i := range subqueues {
 		if i >= len(c.subqueues) {
-			r := newPriTaskReader(c, i, subqueues[i].AckLevelId)
+			r := newPriTaskReader(c, i, subqueues[i].AckLevel)
 			r.Start()
 			c.subqueues = append(c.subqueues, r)
 		}

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -154,7 +154,7 @@ func (c *priBacklogManagerImpl) loadSubqueuesLocked(subqueues []persistencespb.S
 	// existing subqueues never changes. If we change that, this logic will need to change.
 	for i := range subqueues {
 		if i >= len(c.subqueues) {
-			r := newPriTaskReader(c, i, subqueues[i].AckLevel)
+			r := newPriTaskReader(c, i, subqueues[i].AckLevelId)
 			r.Start()
 			c.subqueues = append(c.subqueues, r)
 		}


### PR DESCRIPTION
## What changed?
- Add pass number fields to some protos.
- Implement pass handling in task store v2.
- Remove TTLs from task store v2.
- Add some error checking to prevent misuse.
- Add support for using LIMIT in the GetTasks query.
- Rename some things.

## Why?
Start implementing matching task fairness.

## How did you test it?
- [x] built
- [x] covered by existing tests
