### PR TITLE
[CHASM] Outbound SideEffect task executor

### DIFF
--- a/service/history/outbound_queue_active_task_executor.go
+++ b/service/history/outbound_queue_active_task_executor.go
@@ -2,18 +2,22 @@ package history
 
 import (
 	"context"
+	"fmt"
 
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/service/history/consts"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/queues"
+	"go.temporal.io/server/service/history/tasks"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
 )
 
 type outboundQueueActiveTaskExecutor struct {
 	stateMachineEnvironment
+	chasmEngine chasm.Engine
 }
 
 var _ queues.Executor = &outboundQueueActiveTaskExecutor{}
@@ -23,6 +27,7 @@ func newOutboundQueueActiveTaskExecutor(
 	workflowCache wcache.Cache,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
+	chasmEngine chasm.Engine,
 ) *outboundQueueActiveTaskExecutor {
 	return &outboundQueueActiveTaskExecutor{
 		stateMachineEnvironment: stateMachineEnvironment{
@@ -33,6 +38,7 @@ func newOutboundQueueActiveTaskExecutor(
 				metrics.OperationTag(metrics.OperationOutboundQueueProcessorScope),
 			),
 		},
+		chasmEngine: chasmEngine,
 	}
 }
 
@@ -59,11 +65,6 @@ func (e *outboundQueueActiveTaskExecutor) Execute(
 		}
 	}
 
-	ref, smt, err := StateMachineTask(e.shardContext.StateMachineRegistry(), task)
-	if err != nil {
-		return respond(err)
-	}
-
 	// We don't want to execute outbound tasks when handing over a namespace to avoid starting work that may not be
 	// committed and cause duplicate requests.
 	// We check namespace handover state **once** when processing is started. Outbound tasks may take up to 10
@@ -79,7 +80,59 @@ func (e *outboundQueueActiveTaskExecutor) Execute(
 		return respond(err)
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
+	defer cancel()
+
+	switch task := task.(type) {
+	case *tasks.StateMachineOutboundTask:
+		return respond(e.executeStateMachineTask(ctx, task))
+	case *tasks.ChasmTask:
+		return respond(e.executeChasmSideEffectTask(ctx, task))
+	}
+
+	return respond(queues.NewUnprocessableTaskError(fmt.Sprintf("unknown task type '%T'", task)))
+}
+
+func (e *outboundQueueActiveTaskExecutor) executeChasmSideEffectTask(
+	ctx context.Context,
+	task *tasks.ChasmTask,
+) error {
+	weContext, release, err := getWorkflowExecutionContextForTask(ctx, e.shardContext, e.cache, task)
+	if err != nil {
+		return err
+	}
+	defer func() { release(err) }()
+
+	ms, err := loadMutableStateForTransferTask(ctx, e.shardContext, weContext, task, e.metricsHandler, e.logger)
+	if err != nil {
+		return err
+	}
+	tree := ms.ChasmTree()
+
+	// Now that we've loaded the CHASM tree, we can release the lock before task
+	// execution. The task's executor must do its own locking as needed, and additional
+	// mutable state validations will run at access time.
+	release(nil)
+
+	err = executeChasmSideEffectTask(
+		ctx,
+		e.chasmEngine,
+		e.shardContext.ChasmRegistry(),
+		tree,
+		task,
+	)
+	return err
+}
+
+func (e *outboundQueueActiveTaskExecutor) executeStateMachineTask(
+	ctx context.Context,
+	task tasks.Task,
+) error {
+	ref, smt, err := StateMachineTask(e.shardContext.StateMachineRegistry(), task)
+	if err != nil {
+		return err
+	}
+
 	smRegistry := e.shardContext.StateMachineRegistry()
-	err = smRegistry.ExecuteImmediateTask(ctx, e, ref, smt)
-	return respond(err)
+	return smRegistry.ExecuteImmediateTask(ctx, e, ref, smt)
 }

--- a/service/history/outbound_queue_active_task_executor_test.go
+++ b/service/history/outbound_queue_active_task_executor_test.go
@@ -1,0 +1,268 @@
+package history
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/testing/testvars"
+	"go.temporal.io/server/service/history/hsm"
+	historyi "go.temporal.io/server/service/history/interfaces"
+	"go.temporal.io/server/service/history/queues"
+	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/tests"
+	"go.temporal.io/server/service/history/workflow/cache"
+	"go.uber.org/mock/gomock"
+)
+
+type outboundQueueActiveTaskExecutorSuite struct {
+	suite.Suite
+	*require.Assertions
+
+	controller            *gomock.Controller
+	mockShard             *shard.ContextTest
+	mockWorkflowCache     *cache.MockCache
+	mockChasmEngine       *chasm.MockEngine
+	mockNamespaceRegistry *namespace.MockRegistry
+	hsmRegistry           *hsm.Registry
+	mockWorkflowContext   *historyi.MockWorkflowContext
+	mockMutableState      *historyi.MockMutableState
+	mockExecutable        *queues.MockExecutable
+	mockChasmTree         *historyi.MockChasmTree
+
+	logger         log.Logger
+	metricsHandler metrics.Handler
+
+	namespaceID    namespace.ID
+	namespaceEntry *namespace.Namespace
+
+	executor *outboundQueueActiveTaskExecutor
+}
+
+func TestOutboundQueueActiveTaskExecutorSuite(t *testing.T) {
+	s := new(outboundQueueActiveTaskExecutorSuite)
+	suite.Run(t, s)
+}
+
+func (s *outboundQueueActiveTaskExecutorSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.namespaceID = tests.NamespaceID
+	s.namespaceEntry = tests.GlobalNamespaceEntry
+
+	// Setup controller and mocks
+	s.controller = gomock.NewController(s.T())
+	s.mockShard = shard.NewTestContext(
+		s.controller,
+		&persistencespb.ShardInfo{
+			ShardId: 1,
+			RangeId: 1,
+		},
+		tests.NewDynamicConfig(),
+	)
+	s.mockWorkflowCache = cache.NewMockCache(s.controller)
+	s.mockChasmEngine = chasm.NewMockEngine(s.controller)
+	s.mockNamespaceRegistry = namespace.NewMockRegistry(s.controller)
+	s.hsmRegistry = hsm.NewRegistry()
+	s.mockWorkflowContext = historyi.NewMockWorkflowContext(s.controller)
+	s.mockMutableState = historyi.NewMockMutableState(s.controller)
+	s.mockExecutable = queues.NewMockExecutable(s.controller)
+	s.mockChasmTree = historyi.NewMockChasmTree(s.controller)
+
+	s.logger = s.mockShard.GetLogger()
+	s.metricsHandler = s.mockShard.GetMetricsHandler()
+
+	ns := namespace.NewLocalNamespaceForTest(&persistencespb.NamespaceInfo{
+		Name: s.namespaceEntry.Name().String(),
+		Id:   string(s.namespaceID),
+	}, nil, "")
+	s.mockNamespaceRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(ns, nil).AnyTimes()
+	s.mockNamespaceRegistry.EXPECT().GetNamespaceName(gomock.Any()).Return(ns.Name(), nil).AnyTimes()
+
+	s.mockShard.Resource.ClusterMetadata.EXPECT().GetClusterID().Return(int64(s.mockShard.GetShardID())).AnyTimes()
+	s.mockShard.Resource.NamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(s.namespaceEntry, nil).AnyTimes()
+	s.mockShard.SetStateMachineRegistry(s.hsmRegistry)
+	s.mockShard.Resource.NamespaceCache.EXPECT().
+		GetNamespaceByID(gomock.Any()).
+		Return(s.namespaceEntry, nil).
+		AnyTimes()
+
+	s.mockWorkflowCache.EXPECT().GetOrCreateCurrentWorkflowExecution(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(cache.NoopReleaseFn, nil).AnyTimes()
+
+	s.mockMutableState.EXPECT().GetCurrentVersion().Return(int64(1)).AnyTimes()
+	s.mockMutableState.EXPECT().NextTransitionCount().Return(int64(0)).AnyTimes()
+	s.mockMutableState.EXPECT().GetWorkflowKey().Return(tests.WorkflowKey).AnyTimes()
+
+	s.executor = newOutboundQueueActiveTaskExecutor(
+		s.mockShard,
+		s.mockWorkflowCache,
+		s.logger,
+		s.metricsHandler,
+		s.mockChasmEngine,
+	)
+}
+
+func (s *outboundQueueActiveTaskExecutorSuite) TearDownTest() {
+	s.controller.Finish()
+	s.mockShard.StopForTest()
+}
+
+func (s *outboundQueueActiveTaskExecutorSuite) TestExecute_ChasmTask() {
+	tv := testvars.New(s.T())
+	ctx := context.Background()
+
+	testCases := []struct {
+		name                string
+		setupMocks          func(*tasks.ChasmTask)
+		expectHandlerCalled bool
+		expectedError       string
+	}{
+		{
+			name: "success",
+			setupMocks: func(task *tasks.ChasmTask) {
+				// Setup successful workflow context loading and CHASM execution
+
+				s.mockWorkflowCache.EXPECT().
+					GetOrCreateWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(s.mockWorkflowContext, func(error) {}, nil)
+
+				s.mockWorkflowContext.EXPECT().
+					LoadMutableState(gomock.Any(), gomock.Any()).
+					Return(s.mockMutableState, nil)
+
+				s.mockMutableState.EXPECT().
+					ChasmTree().
+					Return(s.mockChasmTree)
+
+				s.mockChasmTree.EXPECT().
+					ExecuteSideEffectTask(
+						gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
+					)
+			},
+			expectHandlerCalled: true,
+		},
+		{
+			name: "mutable state failure",
+			setupMocks: func(task *tasks.ChasmTask) {
+				// Workflow context loads but mutable state fails
+				s.mockWorkflowCache.EXPECT().
+					GetOrCreateWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(s.mockWorkflowContext, func(error) {}, nil)
+
+				s.mockWorkflowContext.EXPECT().
+					LoadMutableState(gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("mutable state failed to load"))
+			},
+			expectHandlerCalled: false,
+			expectedError:       "mutable state failed to load",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Create a CHASM task
+			task := &tasks.ChasmTask{
+				WorkflowKey: tv.Any().WorkflowKey(),
+				TaskID:      s.mustGenerateTaskID(),
+				Category:    tasks.CategoryOutbound,
+				Destination: tv.Any().String(),
+				Info: &persistencespb.ChasmTaskInfo{
+					Type: tv.Any().String(),
+				},
+			}
+
+			tc.setupMocks(task)
+			s.mockExecutable.EXPECT().GetTask().Return(task).AnyTimes()
+
+			result := s.executor.Execute(ctx, s.mockExecutable)
+
+			if tc.expectedError != "" {
+				s.Error(result.ExecutionErr)
+				s.Contains(result.ExecutionErr.Error(), tc.expectedError)
+			} else {
+				s.NoError(result.ExecutionErr)
+			}
+			s.True(result.ExecutedAsActive)
+			s.NotEmpty(result.ExecutionMetricTags)
+		})
+	}
+}
+
+func (s *outboundQueueActiveTaskExecutorSuite) TestExecute_PreValidationFails() {
+	tv := testvars.New(s.T())
+	ctx := context.Background()
+
+	testCases := []struct {
+		name          string
+		setupTask     func() tasks.Task
+		setupMocks    func(tasks.Task)
+		expectedError string
+	}{
+		{
+			name: "invalid task type",
+			setupTask: func() tasks.Task {
+				// Create a task type that's NOT StateMachineOutboundTask or ChasmTask
+				return &tasks.ActivityTask{
+					WorkflowKey: tv.Any().WorkflowKey(),
+					TaskID:      s.mustGenerateTaskID(),
+					TaskQueue:   tv.Any().String(),
+				}
+			},
+			setupMocks:    func(task tasks.Task) {},
+			expectedError: "unknown task type",
+		},
+		{
+			name: "clock validation failure",
+			setupTask: func() tasks.Task {
+				return &tasks.ChasmTask{
+					Destination: tv.Any().String(),
+					TaskID:      math.MaxInt64,
+					Info:        &persistencespb.ChasmTaskInfo{},
+				}
+			},
+			setupMocks:    func(task tasks.Task) {},
+			expectedError: "task clock validation failed",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			task := tc.setupTask()
+			tc.setupMocks(task)
+			s.mockExecutable.EXPECT().GetTask().Return(task)
+
+			result := s.executor.Execute(ctx, s.mockExecutable)
+
+			s.Error(result.ExecutionErr)
+			s.Contains(result.ExecutionErr.Error(), tc.expectedError)
+			s.True(result.ExecutedAsActive)
+			s.NotEmpty(result.ExecutionMetricTags)
+		})
+	}
+}
+
+func (s *outboundQueueActiveTaskExecutorSuite) mustGenerateTaskID() int64 {
+	taskID, err := s.mockShard.GenerateTaskID()
+	s.NoError(err)
+	return taskID
+}

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -209,6 +209,7 @@ func (f *outboundQueueFactory) CreateQueue(
 		f.WorkflowCache,
 		logger,
 		metricsHandler,
+		nil,
 	)
 
 	// not implemented yet
@@ -218,6 +219,7 @@ func (f *outboundQueueFactory) CreateQueue(
 		currentClusterName,
 		logger,
 		metricsHandler,
+		nil, // TODO - replace with real chasm.Engine
 	)
 
 	executor := queues.NewActiveStandbyExecutor(

--- a/service/history/outbound_queue_standby_task_executor.go
+++ b/service/history/outbound_queue_standby_task_executor.go
@@ -3,7 +3,9 @@ package history
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -19,7 +21,8 @@ import (
 
 type outboundQueueStandbyTaskExecutor struct {
 	stateMachineEnvironment
-	config *configs.Config
+	chasmEngine chasm.Engine
+	config      *configs.Config
 
 	clusterName string
 }
@@ -32,6 +35,7 @@ func newOutboundQueueStandbyTaskExecutor(
 	clusterName string,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
+	chasmEngine chasm.Engine,
 ) *outboundQueueStandbyTaskExecutor {
 	return &outboundQueueStandbyTaskExecutor{
 		stateMachineEnvironment: stateMachineEnvironment{
@@ -44,6 +48,7 @@ func newOutboundQueueStandbyTaskExecutor(
 		},
 		config:      shardCtx.GetConfig(),
 		clusterName: clusterName,
+		chasmEngine: chasmEngine,
 	}
 }
 
@@ -53,9 +58,13 @@ func (e *outboundQueueStandbyTaskExecutor) Execute(
 ) queues.ExecuteResponse {
 	task := executable.GetTask()
 	taskType := queues.GetOutboundTaskTypeTagValue(task, false)
+	namespaceTag, _ := getNamespaceTagAndReplicationStateByID(
+		e.shardContext.GetNamespaceRegistry(),
+		task.GetNamespaceID(),
+	)
 	respond := func(err error) queues.ExecuteResponse {
 		metricsTags := []metrics.Tag{
-			getNamespaceTagByID(e.shardContext.GetNamespaceRegistry(), task.GetNamespaceID()),
+			namespaceTag,
 			metrics.TaskTypeTag(taskType),
 			metrics.OperationTag(taskType),
 		}
@@ -66,30 +75,45 @@ func (e *outboundQueueStandbyTaskExecutor) Execute(
 		}
 	}
 
-	return respond(e.processTask(ctx, task))
-}
-
-func (e *outboundQueueStandbyTaskExecutor) processTask(
-	ctx context.Context,
-	task tasks.Task,
-) error {
-	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
-	defer cancel()
-
 	nsRecord, err := e.shardContext.GetNamespaceRegistry().GetNamespaceByID(
 		namespace.ID(task.GetNamespaceID()),
 	)
 	if err != nil {
-		return err
+		return respond(err)
 	}
 
 	if !nsRecord.IsOnCluster(e.clusterName) {
 		// namespace is not replicated to local cluster, ignore corresponding tasks
-		return nil
+		return respond(nil)
 	}
 
 	if err := validateTaskByClock(e.shardContext, task); err != nil {
-		return err
+		return respond(err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
+	defer cancel()
+
+	nsName := nsRecord.Name().String()
+
+	switch task := task.(type) {
+	case *tasks.StateMachineOutboundTask:
+		return respond(e.executeStateMachineTask(ctx, task, nsName))
+	case *tasks.ChasmTask:
+		return respond(e.executeChasmSideEffectTask(ctx, task))
+	}
+
+	return respond(queues.NewUnprocessableTaskError(fmt.Sprintf("unknown task type '%T'", task)))
+}
+
+func (e *outboundQueueStandbyTaskExecutor) executeStateMachineTask(
+	ctx context.Context,
+	task tasks.Task,
+	nsName string,
+) error {
+	destination := ""
+	if dtask, ok := task.(tasks.HasDestination); ok {
+		destination = dtask.GetDestination()
 	}
 
 	ref, _, err := StateMachineTask(e.shardContext.StateMachineRegistry(), task)
@@ -117,12 +141,7 @@ func (e *outboundQueueStandbyTaskExecutor) processTask(
 	// The *likely* reasons are: a) delay in the replication stack; b) destination is down.
 	// In any case, the task needs to be retried (or discarded, based on the configured discard delay).
 
-	destination := ""
-	if dtask, ok := task.(tasks.HasDestination); ok {
-		destination = dtask.GetDestination()
-	}
-
-	discardTime := task.GetVisibilityTime().Add(e.config.OutboundStandbyTaskMissingEventsDiscardDelay(nsRecord.Name().String(), destination))
+	discardTime := task.GetVisibilityTime().Add(e.config.OutboundStandbyTaskMissingEventsDiscardDelay(nsName, destination))
 	// now > task start time + discard delay
 	if e.Now().After(discardTime) {
 		e.logger.Warn("Discarding standby outbound task due to task being pending for too long.", tag.Task(task))
@@ -130,7 +149,7 @@ func (e *outboundQueueStandbyTaskExecutor) processTask(
 	}
 
 	err = consts.ErrTaskRetry
-	if e.config.OutboundStandbyTaskMissingEventsDestinationDownErr(nsRecord.Name().String(), destination) {
+	if e.config.OutboundStandbyTaskMissingEventsDestinationDownErr(nsName, destination) {
 		// Wrap the retry error with DestinationDownError so it can trigger the circuit breaker on
 		// the standby side. This won't do any harm, at most some delay processing the standby task.
 		// Assuming the dynamic config OutboundStandbyTaskMissingEventsDiscardDelay is long enough,
@@ -140,6 +159,36 @@ func (e *outboundQueueStandbyTaskExecutor) processTask(
 			"standby task executor returned retryable error",
 			err,
 		)
+		return err
 	}
+
+	return nil
+}
+
+func (e *outboundQueueStandbyTaskExecutor) executeChasmSideEffectTask(
+	ctx context.Context,
+	task *tasks.ChasmTask,
+) error {
+	weContext, release, err := getWorkflowExecutionContextForTask(ctx, e.shardContext, e.cache, task)
+	if err != nil {
+		return err
+	}
+	defer func() { release(err) }()
+
+	ms, err := weContext.LoadMutableState(ctx, e.shardContext)
+	if err != nil {
+		return err
+	}
+
+	shouldRetry, err := validateChasmSideEffectTask(
+		ctx,
+		e.shardContext.ChasmRegistry(),
+		ms,
+		task,
+	)
+	if shouldRetry != nil {
+		err = consts.ErrTaskRetry
+	}
+
 	return err
 }

--- a/service/history/outbound_queue_standby_task_executor_test.go
+++ b/service/history/outbound_queue_standby_task_executor_test.go
@@ -1,0 +1,281 @@
+package history
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/testing/testvars"
+	"go.temporal.io/server/service/history/hsm"
+	historyi "go.temporal.io/server/service/history/interfaces"
+	"go.temporal.io/server/service/history/queues"
+	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/tests"
+	"go.temporal.io/server/service/history/workflow/cache"
+	"go.uber.org/mock/gomock"
+)
+
+type outboundQueueStandbyTaskExecutorSuite struct {
+	suite.Suite
+	*require.Assertions
+
+	controller            *gomock.Controller
+	mockShard             *shard.ContextTest
+	mockWorkflowCache     *cache.MockCache
+	mockChasmEngine       *chasm.MockEngine
+	mockNamespaceRegistry *namespace.MockRegistry
+	hsmRegistry           *hsm.Registry
+	mockWorkflowContext   *historyi.MockWorkflowContext
+	mockMutableState      *historyi.MockMutableState
+	mockExecutable        *queues.MockExecutable
+	mockChasmTree         *historyi.MockChasmTree
+
+	logger         log.Logger
+	metricsHandler metrics.Handler
+
+	namespaceID    namespace.ID
+	namespaceEntry *namespace.Namespace
+	clusterName    string
+	now            time.Time
+
+	executor *outboundQueueStandbyTaskExecutor
+}
+
+func TestOutboundQueueStandbyTaskExecutorSuite(t *testing.T) {
+	s := new(outboundQueueStandbyTaskExecutorSuite)
+	suite.Run(t, s)
+}
+
+func (s *outboundQueueStandbyTaskExecutorSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.namespaceID = tests.NamespaceID
+	s.namespaceEntry = tests.GlobalNamespaceEntry
+	s.clusterName = cluster.TestAlternativeClusterName
+	s.now = time.Now()
+
+	// Setup controller and mocks
+	s.controller = gomock.NewController(s.T())
+
+	s.mockShard = shard.NewTestContext(
+		s.controller,
+		&persistencespb.ShardInfo{
+			ShardId: 1,
+			RangeId: 1,
+		},
+		tests.NewDynamicConfig(),
+	)
+	s.mockWorkflowCache = cache.NewMockCache(s.controller)
+	s.mockChasmEngine = chasm.NewMockEngine(s.controller)
+	s.mockNamespaceRegistry = namespace.NewMockRegistry(s.controller)
+	s.hsmRegistry = hsm.NewRegistry()
+	s.mockWorkflowContext = historyi.NewMockWorkflowContext(s.controller)
+	s.mockMutableState = historyi.NewMockMutableState(s.controller)
+	s.mockExecutable = queues.NewMockExecutable(s.controller)
+	s.mockChasmTree = historyi.NewMockChasmTree(s.controller)
+
+	s.logger = s.mockShard.GetLogger()
+	s.metricsHandler = s.mockShard.GetMetricsHandler()
+
+	ns := namespace.NewLocalNamespaceForTest(&persistencespb.NamespaceInfo{
+		Name: s.namespaceEntry.Name().String(),
+		Id:   string(s.namespaceID),
+	}, nil, "")
+	s.mockNamespaceRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(ns, nil).AnyTimes()
+	s.mockNamespaceRegistry.EXPECT().GetNamespaceName(gomock.Any()).Return(ns.Name(), nil).AnyTimes()
+
+	s.mockShard.Resource.ClusterMetadata.EXPECT().GetClusterID().Return(int64(s.mockShard.GetShardID())).AnyTimes()
+	s.mockShard.Resource.NamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(s.namespaceEntry, nil).AnyTimes()
+	s.mockShard.SetStateMachineRegistry(s.hsmRegistry)
+	s.mockShard.Resource.NamespaceCache.EXPECT().
+		GetNamespaceByID(gomock.Any()).
+		Return(s.namespaceEntry, nil).
+		AnyTimes()
+
+	s.mockWorkflowCache.EXPECT().GetOrCreateCurrentWorkflowExecution(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(cache.NoopReleaseFn, nil).AnyTimes()
+
+	s.mockMutableState.EXPECT().GetCurrentVersion().Return(int64(1)).AnyTimes()
+	s.mockMutableState.EXPECT().NextTransitionCount().Return(int64(0)).AnyTimes()
+	s.mockMutableState.EXPECT().GetWorkflowKey().Return(tests.WorkflowKey).AnyTimes()
+	s.mockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
+		State: enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+	}).AnyTimes()
+
+	s.executor = newOutboundQueueStandbyTaskExecutor(
+		s.mockShard,
+		s.mockWorkflowCache,
+		s.clusterName,
+		s.logger,
+		s.metricsHandler,
+		s.mockChasmEngine,
+	)
+}
+
+func (s *outboundQueueStandbyTaskExecutorSuite) TearDownTest() {
+	s.controller.Finish()
+	s.mockShard.StopForTest()
+}
+
+func (s *outboundQueueStandbyTaskExecutorSuite) TestExecute_ChasmTask() {
+	tv := testvars.New(s.T())
+	ctx := context.Background()
+
+	testCases := []struct {
+		name                string
+		setupMocks          func(*tasks.ChasmTask)
+		expectHandlerCalled bool
+		expectedError       string
+	}{
+		{
+			name: "success",
+			setupMocks: func(task *tasks.ChasmTask) {
+				// Setup successful workflow context loading and CHASM execution
+
+				s.mockWorkflowCache.EXPECT().
+					GetOrCreateWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(s.mockWorkflowContext, func(error) {}, nil)
+
+				s.mockWorkflowContext.EXPECT().
+					LoadMutableState(gomock.Any(), gomock.Any()).
+					Return(s.mockMutableState, nil)
+
+				s.mockMutableState.EXPECT().
+					ChasmTree().
+					Return(s.mockChasmTree)
+
+				s.mockChasmTree.EXPECT().
+					ValidateSideEffectTask(gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
+					)
+			},
+			expectHandlerCalled: true,
+		},
+		{
+			name: "mutable state failure",
+			setupMocks: func(task *tasks.ChasmTask) {
+				// Workflow context loads but mutable state fails
+				s.mockWorkflowCache.EXPECT().
+					GetOrCreateWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(s.mockWorkflowContext, func(error) {}, nil)
+
+				s.mockWorkflowContext.EXPECT().
+					LoadMutableState(gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("mutable state failed to load"))
+			},
+			expectHandlerCalled: false,
+			expectedError:       "mutable state failed to load",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Create a CHASM task
+			task := &tasks.ChasmTask{
+				WorkflowKey: tv.Any().WorkflowKey(),
+				TaskID:      s.mustGenerateTaskID(),
+				Category:    tasks.CategoryOutbound,
+				Destination: tv.Any().String(),
+				Info: &persistencespb.ChasmTaskInfo{
+					Type: tv.Any().String(),
+				},
+				VisibilityTimestamp: s.now,
+			}
+
+			tc.setupMocks(task)
+			s.mockExecutable.EXPECT().GetTask().Return(task).AnyTimes()
+
+			result := s.executor.Execute(ctx, s.mockExecutable)
+
+			if tc.expectedError != "" {
+				s.Error(result.ExecutionErr)
+				s.Contains(result.ExecutionErr.Error(), tc.expectedError)
+			} else {
+				s.NoError(result.ExecutionErr)
+			}
+			s.False(result.ExecutedAsActive)
+			s.NotEmpty(result.ExecutionMetricTags)
+		})
+	}
+}
+
+func (s *outboundQueueStandbyTaskExecutorSuite) TestExecute_PreValidationFails() {
+	tv := testvars.New(s.T())
+	ctx := context.Background()
+
+	testCases := []struct {
+		name          string
+		setupTask     func() tasks.Task
+		setupMocks    func(tasks.Task)
+		expectedError string
+	}{
+		{
+			name: "invalid task type",
+			setupTask: func() tasks.Task {
+				// Create a task type that's NOT StateMachineOutboundTask or ChasmTask
+				return &tasks.ActivityTask{
+					WorkflowKey:         tv.Any().WorkflowKey(),
+					TaskID:              s.mustGenerateTaskID(),
+					VisibilityTimestamp: s.now,
+					TaskQueue:           tv.Any().String(),
+				}
+			},
+			setupMocks:    func(task tasks.Task) {},
+			expectedError: "unknown task type",
+		},
+		{
+			name: "clock validation failure",
+			setupTask: func() tasks.Task {
+				return &tasks.ChasmTask{
+					Destination:         tv.Any().String(),
+					TaskID:              math.MaxInt64,
+					Info:                &persistencespb.ChasmTaskInfo{},
+					VisibilityTimestamp: s.now,
+					Category:            tasks.Category{},
+				}
+			},
+			setupMocks:    func(task tasks.Task) {},
+			expectedError: "task clock validation failed",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			task := tc.setupTask()
+			tc.setupMocks(task)
+			s.mockExecutable.EXPECT().GetTask().Return(task)
+
+			result := s.executor.Execute(ctx, s.mockExecutable)
+
+			s.Error(result.ExecutionErr)
+			s.Contains(result.ExecutionErr.Error(), tc.expectedError)
+			s.False(result.ExecutedAsActive)
+			s.NotEmpty(result.ExecutionMetricTags)
+		})
+	}
+}
+
+func (s *outboundQueueStandbyTaskExecutorSuite) mustGenerateTaskID() int64 {
+	taskID, err := s.mockShard.GenerateTaskID()
+	s.NoError(err)
+	return taskID
+}

--- a/service/history/queues/metrics.go
+++ b/service/history/queues/metrics.go
@@ -151,11 +151,14 @@ func GetOutboundTaskTypeTagValue(task tasks.Task, isActive bool) string {
 		prefix = "OutboundStandby"
 	}
 
-	outbound, ok := task.(*tasks.StateMachineOutboundTask)
-	if !ok {
+	switch task := task.(type) {
+	case *tasks.StateMachineOutboundTask:
+		return prefix + "." + task.StateMachineTaskType()
+	case *tasks.ChasmTask:
+		return prefix + "." + task.Info.Type
+	default:
 		return prefix + "Unknown"
 	}
-	return prefix + "." + outbound.StateMachineTaskType()
 }
 
 func GetTimerStateMachineTaskTypeTagValue(taskType string, isActive bool) string {

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"math"
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
@@ -163,5 +164,6 @@ func NewDynamicConfig() *configs.Config {
 	config.ReplicationEnableUpdateWithNewTaskMerge = dynamicconfig.GetBoolPropertyFn(true)
 	config.EnableWorkflowIdReuseStartTimeValidation = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.EnableTransitionHistory = dynamicconfig.GetBoolPropertyFn(true)
+	config.OutboundStandbyTaskMissingEventsDiscardDelay = dynamicconfig.GetDurationPropertyFnFilteredByDestination(time.Duration(math.MaxInt64))
 	return config
 }


### PR DESCRIPTION
## What changed?
- Adds CHASM task executors for the outbound queue.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
