### PR TITLE
fix: increase number of attempts if paused activity fails

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5700,6 +5700,7 @@ func (ms *MutableStateImpl) RetryActivity(
 			activityInfo.StartedTime = nil
 			activityInfo.RequestId = ""
 			activityInfo.RetryLastFailure = ms.truncateRetryableActivityFailure(activityFailure)
+			activityInfo.Attempt++
 			return nil
 		}); err != nil {
 			return enumspb.RETRY_STATE_INTERNAL_SERVER_ERROR, err


### PR DESCRIPTION
## What changed?

Increment the attempts for an activity when a paused activity fails

## Why?
Previously this scenario was not incremented

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None aware of, @ychebotarev would know more potential risks
