### PR TITLE
Fix data race in Nexus config provider

### DIFF
--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -149,7 +149,7 @@ type Config struct {
 	MaxOperationNameLength              dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxOperationTokenLength             dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxOperationHeaderSize              dynamicconfig.IntPropertyFnWithNamespaceFilter
-	DisallowedOperationHeaders          dynamicconfig.TypedPropertyFn[[]string]
+	DisallowedOperationHeaders          *dynamicconfig.GlobalCachedTypedValue[[]string]
 	MaxOperationScheduleToCloseTimeout  dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	PayloadSizeLimit                    dynamicconfig.IntPropertyFnWithNamespaceFilter
 	CallbackURLTemplate                 dynamicconfig.StringPropertyFn
@@ -178,7 +178,7 @@ func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 				keys[i] = strings.ToLower(k)
 			}
 			return keys, nil
-		}).Get,
+		}),
 		MaxOperationScheduleToCloseTimeout:  MaxOperationScheduleToCloseTimeout.Get(dc),
 		PayloadSizeLimit:                    dynamicconfig.BlobSizeLimitError.Get(dc),
 		CallbackURLTemplate:                 CallbackURLTemplate.Get(dc),

--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -109,7 +109,7 @@ func (ch *commandHandler) HandleScheduleCommand(
 	headerLength := 0
 	for k, v := range attrs.NexusHeader {
 		headerLength += len(k) + len(v)
-		if slices.Contains(ch.config.DisallowedOperationHeaders(), strings.ToLower(k)) {
+		if slices.Contains(ch.config.DisallowedOperationHeaders.Get(), strings.ToLower(k)) {
 			return workflow.FailWorkflowTaskError{
 				Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES,
 				Message: fmt.Sprintf("ScheduleNexusOperationCommandAttributes.NexusHeader contains a disallowed header key: %q", k),


### PR DESCRIPTION
## What changed?
Adjusting dynamic config types to address a data race in Nexus config provider that occurred during xdc tests. Ran several times locally to verify fix.
