### PR TITLE
fix(vscode): add build tags to single functional test debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,9 @@
 			"type": "go",
 			"request": "launch",
 			"mode": "test",
+			"buildFlags": [
+				"-tags=test_dep"
+			],
 			"program": "${relativeFileDirname}",
 			"args": [
 				"-testify.m",


### PR DESCRIPTION
## What changed?
add the `-tags=test_dep` to the VSCode launch configuration

## Why?
Debug fails with a build error
```sh
Build Error: go test -c -o /Users/seankane/git/github.com/temporalio/temporal/tests/__debug_bin1525033192 -gcflags all=-N -l .
# go.temporal.io/server/tests/testcore
testcore/onebox.go:204:39: undefined: testhooks.NewTestHooksImpl
testcore/onebox.go:857:23: undefined: testhooks.Set (exit status 1)
```

## How did you test it?
- [ ] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
No change to production code, only configuration
