### PR TITLE
Reset backlog age when backlog count becomes 0

### DIFF
--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -227,6 +227,7 @@ func (db *taskQueueDB) OldUpdateState(
 	maxReadLevel := db.getMaxReadLevelLocked(subqueueZero)
 	if ackLevel == maxReadLevel {
 		db.subqueues[subqueueZero].ApproximateBacklogCount = 0
+		db.subqueues[subqueueZero].oldestTime = time.Time{} // zero time means no backlog
 	}
 
 	queueInfo := db.cachedQueueInfo()
@@ -275,7 +276,7 @@ func (db *taskQueueDB) updateAckLevelAndBacklogStats(subqueue int, newAckLevel i
 	if newAckLevel == db.getMaxReadLevelLocked(subqueue) {
 		// Reset approximateBacklogCount to fix the count divergence issue
 		dbQueue.ApproximateBacklogCount = 0
-		dbQueue.oldestTime = time.Time{} // zero time means no backlog
+		dbQueue.oldestTime = oldestTime
 	} else if countDelta != 0 {
 		db.updateBacklogStatsLocked(subqueue, countDelta, oldestTime)
 	}

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -275,7 +275,7 @@ func (db *taskQueueDB) updateAckLevelAndBacklogStats(subqueue int, newAckLevel i
 	if newAckLevel == db.getMaxReadLevelLocked(subqueue) {
 		// Reset approximateBacklogCount to fix the count divergence issue
 		dbQueue.ApproximateBacklogCount = 0
-		dbQueue.oldestTime = oldestTime
+		dbQueue.oldestTime = time.Time{} // zero time means no backlog
 	} else if countDelta != 0 {
 		db.updateBacklogStatsLocked(subqueue, countDelta, oldestTime)
 	}


### PR DESCRIPTION
## What changed?
Reset backlog age when backlog count becomes zero.

## Why?
Backlog age metric remains non-zero even after the backlog is empty. This PR fixes that.

## How did you test it?
- [x] built
- [ ] rrun locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None
