### PR TITLE
only resend parent when wf has transition

### DIFF
--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -278,7 +278,8 @@ func (t *transferQueueStandbyTaskExecutor) processCloseExecution(
 			now := t.getCurrentTime()
 			taskTime := transferTask.GetVisibilityTime()
 			localVerificationTime := taskTime.Add(t.config.MaxLocalParentWorkflowVerificationDuration())
-			resendParent := now.After(localVerificationTime) && t.config.EnableTransitionHistory()
+
+			resendParent := now.After(localVerificationTime) && mutableState.IsTransitionHistoryEnabled() && mutableState.CurrentVersionedTransition() != nil
 
 			_, err := t.historyRawClient.VerifyChildExecutionCompletionRecorded(ctx, &historyservice.VerifyChildExecutionCompletionRecordedRequest{
 				NamespaceId: executionInfo.ParentNamespaceId,

--- a/service/history/workflow/test_util.go
+++ b/service/history/workflow/test_util.go
@@ -79,6 +79,7 @@ func TestGlobalMutableState(
 
 	ms := NewMutableState(shard, eventsCache, logger, tests.GlobalNamespaceEntry, workflowID, runID, time.Now().UTC())
 	ms.GetExecutionInfo().ExecutionTime = ms.GetExecutionState().StartTime
+	ms.GetExecutionInfo().TransitionHistory = UpdatedTransitionHistory(ms.GetExecutionInfo().TransitionHistory, version)
 	_ = ms.UpdateCurrentVersion(version, false)
 	_ = ms.SetHistoryTree(nil, nil, runID)
 


### PR DESCRIPTION
## What changed?
Only resend parent when wf has transition and handle the case when source cluster has transition history disabled.

## Why?
Currently we only use state-based SyncState to resend parent wf. That requires the wf has transition history enabled.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
