### PR TITLE
TestRunner skips reporting parent test cases

### DIFF
--- a/tools/testrunner/junit.go
+++ b/tools/testrunner/junit.go
@@ -122,9 +122,11 @@ func mergeReports(reports []*junitReport) (*junitReport, error) {
 		return nil, errors.New("no reports to merge")
 	}
 
-	var combined junit.Testsuites
 	var reportingErrs []error
-
+	var combined junit.Testsuites
+	combined.XMLName = reports[0].Testsuites.XMLName
+	combined.Name = reports[0].Testsuites.Name
+	
 	// Collect all test case names into the tree
 	testNameTree := redblacktree.NewWithStringComparator()
 	for _, report := range reports {
@@ -136,11 +138,6 @@ func mergeReports(reports []*junitReport) (*junitReport, error) {
 	}
 
 	for i, report := range reports {
-		if i == 0 {
-			combined.XMLName = report.Testsuites.XMLName
-			combined.Name = report.Testsuites.Name
-		}
-
 		combined.Tests += report.Testsuites.Tests
 		combined.Errors += report.Testsuites.Errors
 		combined.Failures += report.Testsuites.Failures

--- a/tools/testrunner/junit.go
+++ b/tools/testrunner/junit.go
@@ -126,7 +126,7 @@ func mergeReports(reports []*junitReport) (*junitReport, error) {
 	var combined junit.Testsuites
 	combined.XMLName = reports[0].Testsuites.XMLName
 	combined.Name = reports[0].Testsuites.Name
-	
+
 	// Collect all test case names into the tree
 	testNameTree := redblacktree.NewWithStringComparator()
 	for _, report := range reports {

--- a/tools/testrunner/junit_test.go
+++ b/tools/testrunner/junit_test.go
@@ -1,10 +1,12 @@
 package testrunner
 
 import (
+	"errors"
 	"os"
 	"slices"
 	"testing"
 
+	"github.com/jstemmer/go-junit-report/v2/junit"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,7 +61,20 @@ func TestNode(t *testing.T) {
 	require.Equal(t, []string{"a", "a/b", "b"}, paths)
 }
 
-func TestMergeReports(t *testing.T) {
+func TestMergeReports_SingleReport(t *testing.T) {
+	j1 := &junitReport{path: "testdata/junit-attempt-1.xml"}
+	require.NoError(t, j1.read())
+
+	report, err := mergeReports([]*junitReport{j1})
+	require.NoError(t, err)
+
+	suites := report.Testsuites.Suites
+	require.Len(t, suites, 1)
+	require.Equal(t, 2, report.Testsuites.Failures)
+	require.NotContains(t, collectTestNames(suites), "TestCallbacksSuite")
+}
+
+func TestMergeReports_MultipleReports(t *testing.T) {
 	j1 := &junitReport{path: "testdata/junit-attempt-1.xml"}
 	require.NoError(t, j1.read())
 	j2 := &junitReport{path: "testdata/junit-attempt-2.xml"}
@@ -72,6 +87,33 @@ func TestMergeReports(t *testing.T) {
 	require.Len(t, suites, 2)
 	require.Equal(t, 4, report.Testsuites.Failures)
 	require.Equal(t, "go.temporal.io/server/tests (retry 1)", suites[1].Name)
-	require.Len(t, suites[1].Testcases, 2)
+	require.NotContains(t, collectTestNames(suites), "TestCallbacksSuite")
 	require.Equal(t, "TestCallbacksSuite/TestWorkflowCallbacks_InvalidArgument (retry 1)", suites[1].Testcases[0].Name)
+}
+
+func TestMergeReports_MissingRerun(t *testing.T) {
+	j1 := &junitReport{path: "testdata/junit-attempt-1.xml"}
+	require.NoError(t, j1.read())
+	j2 := &junitReport{path: "testdata/junit-empty.xml"}
+	require.NoError(t, j2.read())
+	j3 := &junitReport{path: "testdata/junit-attempt-2.xml"}
+	require.NoError(t, j3.read())
+	j4 := &junitReport{path: "testdata/junit-empty.xml"}
+	require.NoError(t, j4.read())
+
+	report, err := mergeReports([]*junitReport{j1, j2, j3, j4})
+	require.NoError(t, err)
+	require.Len(t, report.reportingErrs, 2)
+	require.Equal(t, errors.New("expected rerun of all failures from previous attempt, missing: [TestCallbacksSuite/TestWorkflowCallbacks_InvalidArgument]"), report.reportingErrs[0])
+	require.Equal(t, errors.New("expected rerun of all failures from previous attempt, missing: [TestCallbacksSuite/TestWorkflowCallbacks_InvalidArgument]"), report.reportingErrs[1])
+}
+
+func collectTestNames(suites []junit.Testsuite) []string {
+	var testNames []string
+	for _, suite := range suites {
+		for _, test := range suite.Testcases {
+			testNames = append(testNames, test.Name)
+		}
+	}
+	return testNames
 }

--- a/tools/testrunner/testdata/junit-empty.xml
+++ b/tools/testrunner/testdata/junit-empty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="2" failures="2" errors="0" time="2.244000">
+</testsuites>

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -208,6 +208,9 @@ func Main() {
 	if err = mergedReport.write(); err != nil {
 		log.Fatal(err)
 	}
+	if len(mergedReport.reportingErrs) > 0 {
+		log.Fatal(mergedReport.reportingErrs)
+	}
 
 	// Exit with the exit code of the last attempt.
 	if currentAttempt.exitErr != nil {


### PR DESCRIPTION
## What changed?

(1) Testrunner won't report parents like `TestCallbacksSuite` from `TestCallbacksSuite/TestWorkflowCallbacks_InvalidArgument`.

(2) Testrunner will still write JUnit file even if missing test case is detected.

## Why?

re (1): Less verbose; reporting parents doesn't add anything.

re (2): JUnit file is still valid + helpful and should be written.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
