### PR TITLE
Bump main version to 1.29

### DIFF
--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -24,7 +24,7 @@ const (
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
-	ServerVersion = "1.27.0"
+	ServerVersion = "1.29.0"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"


### PR DESCRIPTION
## Why?
- We're releasing 1.28, main should point to 1.29.
