### PR TITLE
Always issue RPC in DescribeVersionedTaskQueues

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -1397,7 +1397,7 @@ func (e *matchingEngineImpl) DescribeVersionedTaskQueues(
 						Name: tq.Name,
 						Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 					},
-					TaskQueueType: enumspb.TaskQueueType(tq.Type),
+					TaskQueueType: tq.Type,
 					ReportStats:   true,
 				},
 				Version: request.Version,


### PR DESCRIPTION
## What changed?

Always go through matching client to query `DescribeTaskQueue` endpoint.

## Why?

Ensure ownership is correct; a shortcut to the local partition doesn't account for that.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

