### PR TITLE
Avoid event loading for start child task refresh

### DIFF
--- a/service/history/tasks/child_workflow_task.go
+++ b/service/history/tasks/child_workflow_task.go
@@ -14,10 +14,13 @@ type (
 		definition.WorkflowKey
 		VisibilityTimestamp time.Time
 		TaskID              int64
-		TargetNamespaceID   string
-		TargetWorkflowID    string
-		InitiatedEventID    int64
-		Version             int64
+		// TODO: Deprecate TargetNamespaceID and TargetWorkflowID
+		// and get them from mutable state/history events when
+		// processing the task.
+		TargetNamespaceID string
+		TargetWorkflowID  string
+		InitiatedEventID  int64
+		Version           int64
 	}
 )
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -5280,7 +5280,7 @@ func (ms *MutableStateImpl) AddStartChildWorkflowExecutionInitiatedEvent(
 	}
 	// TODO merge active & passive task generation
 	if err := ms.taskGenerator.GenerateChildWorkflowTasks(
-		event,
+		event.GetEventId(),
 	); err != nil {
 		return nil, nil, err
 	}

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -381,7 +381,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 			if err := taskGenerator.GenerateChildWorkflowTasks(
-				event,
+				event.GetEventId(),
 			); err != nil {
 				return nil, err
 			}

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -1611,7 +1611,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeStartChildWorkflowExecution
 	).Return(ci, nil)
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateChildWorkflowTasks(
-		protomock.Eq(event),
+		event.GetEventId(),
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 

--- a/service/history/workflow/task_generator_mock.go
+++ b/service/history/workflow/task_generator_mock.go
@@ -88,17 +88,17 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateActivityTimerTasks() *gomock.Ca
 }
 
 // GenerateChildWorkflowTasks mocks base method.
-func (m *MockTaskGenerator) GenerateChildWorkflowTasks(event *history.HistoryEvent) error {
+func (m *MockTaskGenerator) GenerateChildWorkflowTasks(childInitiatedEventId int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateChildWorkflowTasks", event)
+	ret := m.ctrl.Call(m, "GenerateChildWorkflowTasks", childInitiatedEventId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateChildWorkflowTasks indicates an expected call of GenerateChildWorkflowTasks.
-func (mr *MockTaskGeneratorMockRecorder) GenerateChildWorkflowTasks(event any) *gomock.Call {
+func (mr *MockTaskGeneratorMockRecorder) GenerateChildWorkflowTasks(childInitiatedEventId any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateChildWorkflowTasks", reflect.TypeOf((*MockTaskGenerator)(nil).GenerateChildWorkflowTasks), event)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateChildWorkflowTasks", reflect.TypeOf((*MockTaskGenerator)(nil).GenerateChildWorkflowTasks), childInitiatedEventId)
 }
 
 // GenerateDelayedWorkflowTasks mocks base method.

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -145,7 +145,6 @@ func (r *TaskRefresherImpl) PartialRefresh(
 	}
 
 	if err := r.refreshTasksForChildWorkflow(
-		ctx,
 		mutableState,
 		taskGenerator,
 		minVersionedTransition,
@@ -448,7 +447,6 @@ func (r *TaskRefresherImpl) refreshTasksForTimer(
 }
 
 func (r *TaskRefresherImpl) refreshTasksForChildWorkflow(
-	ctx context.Context,
 	mutableState historyi.MutableState,
 	taskGenerator TaskGenerator,
 	minVersionedTransition *persistencespb.VersionedTransition,
@@ -477,13 +475,8 @@ func (r *TaskRefresherImpl) refreshTasksForChildWorkflow(
 			continue
 		}
 
-		scheduleEvent, err := mutableState.GetChildExecutionInitiatedEvent(ctx, childWorkflowInfo.InitiatedEventId)
-		if err != nil {
-			return err
-		}
-
 		if err := taskGenerator.GenerateChildWorkflowTasks(
-			scheduleEvent,
+			childWorkflowInfo.InitiatedEventId,
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
## What changed?
- Avoid event loading for start child task refresh

## Why?
- The information needed is already available from mutable state, loading event is unnecessary. 
- We may need to generate start child task for lots of child workflows when refreshing workflow tasks, loading event for each event will cause the operation to timeout.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Risks
- If we ever have an old temporal version where target namespace information is stored only in events but not in mutable state, then this change will break task refresh for workflows created by that old version (and the refreshed task will try to start child in the parent namespace). From git history, there's no such version.
