### PR TITLE
Remove all invalid characters from trace file

### DIFF
--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/dgryski/go-farm"
@@ -393,10 +393,9 @@ func (s *FunctionalTestBase) exportOTELTraces() {
 		return
 	}
 	if s.T().Failed() {
+		var validFilenameChars = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
 		fileName := s.T().Name()
-		fileName = strings.ReplaceAll(fileName, "/", "-")
-		fileName = strings.ReplaceAll(fileName, " ", "-")
-		fileName = strings.ReplaceAll(fileName, "#", "-")
+		fileName = validFilenameChars.ReplaceAllString(fileName, "-") // remove invalid characters
 		fileName = fmt.Sprintf("traces.%s_%d.json", fileName, time.Now().Unix())
 		if filePath, err := s.otelExporter.Write(fileName); err != nil {
 			s.T().Logf("unable to write OTEL traces: %v", err)


### PR DESCRIPTION
## What changed?

Clean OTEL file output from any invalid characters.

## Why?

GHA's upload step choked on a colon: https://github.com/temporalio/temporal/actions/runs/15932623840/job/44945289555

## How did you test it?
- [ ] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

