### PR TITLE
Deprecate target workflow info in transfer tasks

### DIFF
--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -6548,14 +6548,22 @@ func addTimerFiredEvent(ms historyi.MutableState, timerID string) *historypb.His
 	return event
 }
 
-func addRequestCancelInitiatedEvent(ms historyi.MutableState, workflowTaskCompletedEventID int64,
-	cancelRequestID string, namespace namespace.Name, namespaceID namespace.ID, workflowID, runID string) (*historypb.HistoryEvent, *persistencespb.RequestCancelInfo) {
+func addRequestCancelInitiatedEvent(
+	ms historyi.MutableState,
+	workflowTaskCompletedEventID int64,
+	cancelRequestID string,
+	namespace namespace.Name,
+	namespaceID namespace.ID,
+	workflowID, runID string,
+	childWorkflowOnly bool,
+) (*historypb.HistoryEvent, *persistencespb.RequestCancelInfo) {
 	event, rci, _ := ms.AddRequestCancelExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID,
 		cancelRequestID, &commandpb.RequestCancelExternalWorkflowExecutionCommandAttributes{
-			Namespace:  namespace.String(),
-			WorkflowId: workflowID,
-			RunId:      runID,
-			Reason:     "cancellation reason",
+			Namespace:         namespace.String(),
+			WorkflowId:        workflowID,
+			RunId:             runID,
+			ChildWorkflowOnly: childWorkflowOnly,
+			Reason:            "cancellation reason",
 		},
 		namespaceID)
 
@@ -6574,9 +6582,19 @@ func addCancelRequestedEvent(
 	return event
 }
 
-func addRequestSignalInitiatedEvent(ms historyi.MutableState, workflowTaskCompletedEventID int64,
-	signalRequestID string, namespace namespace.Name, namespaceID namespace.ID, workflowID, runID, signalName string, input *commonpb.Payloads,
-	control string, header *commonpb.Header) (*historypb.HistoryEvent, *persistencespb.SignalInfo) {
+func addRequestSignalInitiatedEvent(
+	ms historyi.MutableState,
+	workflowTaskCompletedEventID int64,
+	signalRequestID string,
+	namespace namespace.Name,
+	namespaceID namespace.ID,
+	workflowID, runID string,
+	childWorkflowOnly bool,
+	signalName string,
+	input *commonpb.Payloads,
+	control string,
+	header *commonpb.Header,
+) (*historypb.HistoryEvent, *persistencespb.SignalInfo) {
 	event, si, _ := ms.AddSignalExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, signalRequestID,
 		&commandpb.SignalExternalWorkflowExecutionCommandAttributes{
 			Namespace: namespace.String(),
@@ -6584,10 +6602,11 @@ func addRequestSignalInitiatedEvent(ms historyi.MutableState, workflowTaskComple
 				WorkflowId: workflowID,
 				RunId:      runID,
 			},
-			SignalName: signalName,
-			Input:      input,
-			Control:    control,
-			Header:     header,
+			ChildWorkflowOnly: childWorkflowOnly,
+			SignalName:        signalName,
+			Input:             input,
+			Control:           control,
+			Header:            header,
 		}, namespaceID)
 
 	return event, si

--- a/service/history/tasks/child_workflow_task.go
+++ b/service/history/tasks/child_workflow_task.go
@@ -14,10 +14,12 @@ type (
 		definition.WorkflowKey
 		VisibilityTimestamp time.Time
 		TaskID              int64
-		TargetNamespaceID   string
-		TargetWorkflowID    string
-		InitiatedEventID    int64
-		Version             int64
+		// Deprecated: Get this from mutable state.
+		TargetNamespaceID string
+		// Deprecated: Get this from mutable state.
+		TargetWorkflowID string
+		InitiatedEventID int64
+		Version          int64
 	}
 )
 

--- a/service/history/tasks/requst_cancel_task.go
+++ b/service/history/tasks/requst_cancel_task.go
@@ -12,11 +12,15 @@ var _ Task = (*CancelExecutionTask)(nil)
 type (
 	CancelExecutionTask struct {
 		definition.WorkflowKey
-		VisibilityTimestamp     time.Time
-		TaskID                  int64
-		TargetNamespaceID       string
-		TargetWorkflowID        string
-		TargetRunID             string
+		VisibilityTimestamp time.Time
+		TaskID              int64
+		// Deprecated: the TargetNamespaceID from event instead.
+		TargetNamespaceID string
+		// Deprecated: the TargetWorkflowID from event instead.
+		TargetWorkflowID string
+		// Deprecated: the TargetRunID from event instead.
+		TargetRunID string
+		// Deprecated: the TargetChildWorkflowOnly from event instead.
 		TargetChildWorkflowOnly bool
 		InitiatedEventID        int64
 		Version                 int64

--- a/service/history/tasks/signal_task.go
+++ b/service/history/tasks/signal_task.go
@@ -12,11 +12,15 @@ var _ Task = (*SignalExecutionTask)(nil)
 type (
 	SignalExecutionTask struct {
 		definition.WorkflowKey
-		VisibilityTimestamp     time.Time
-		TaskID                  int64
-		TargetNamespaceID       string
-		TargetWorkflowID        string
-		TargetRunID             string
+		VisibilityTimestamp time.Time
+		TaskID              int64
+		// Deprecated: Get TargetNamespaceID from event instead.
+		TargetNamespaceID string
+		// Deprecated: the TargetWorkflowID from event instead.
+		TargetWorkflowID string
+		// Deprecated: the TargetRunID from event instead.
+		TargetRunID string
+		// Deprecated: the TargetChildWorkflowOnly from event instead.
 		TargetChildWorkflowOnly bool
 		InitiatedEventID        int64
 		Version                 int64

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -31,6 +31,7 @@ var (
 	StandbyWithVisibilityArchivalNamespaceID = namespace.ID("deadbeef-0123-4567-890a-bcdef0123461")
 	StandbyWithVisibilityArchivalNamespace   = namespace.Name("mock standby with visibility archival namespace name")
 	MissedNamespaceID                        = namespace.ID("missed-namespace-id")
+	MissedNamespace                          = namespace.Name("missed-namespace-name")
 	WorkflowID                               = "mock-workflow-id"
 	RunID                                    = "0d00698f-08e1-4d36-a3e2-3bf109f5d2d6"
 	WorkflowKey                              = definition.NewWorkflowKey(NamespaceID.String(), WorkflowID, RunID)

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -505,37 +505,42 @@ func (t *transferQueueActiveTaskExecutor) processCancelExecution(
 	}
 	attributes := initiatedEvent.GetRequestCancelExternalWorkflowExecutionInitiatedEventAttributes()
 
-	targetNamespaceEntry, err := t.registry.GetNamespaceByID(namespace.ID(task.TargetNamespaceID))
+	var targetNamespaceName namespace.Name
+	var targetNamespaceID namespace.ID
+	targetNamespaceEntry, err := t.targetNamespaceEntryHelper(
+		namespace.ID(attributes.NamespaceId),
+		namespace.Name(attributes.Namespace),
+	)
 	if err != nil {
-		if _, isNotFound := err.(*serviceerror.NamespaceNotFound); !isNotFound {
-			return err
-		}
-		// It is possible that target namespace got deleted. Record failure.
-		t.logger.Debug("Target namespace is not found.", tag.WorkflowNamespaceID(task.TargetNamespaceID))
-		err = t.requestCancelExternalExecutionFailed(
+		return err
+	}
+
+	if targetNamespaceEntry == nil {
+		return t.requestCancelExternalExecutionFailed(
 			ctx,
 			task,
 			weContext,
-			namespace.Name(task.TargetNamespaceID), // Use ID as namespace name because namespace is already deleted and name is used only for history.
-			namespace.ID(task.TargetNamespaceID),
-			task.TargetWorkflowID,
-			task.TargetRunID,
+			namespace.Name(attributes.Namespace),
+			namespace.ID(attributes.NamespaceId),
+			attributes.GetWorkflowExecution().GetWorkflowId(),
+			attributes.GetWorkflowExecution().GetRunId(),
 			enumspb.CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_NAMESPACE_NOT_FOUND)
-		return err
 	}
-	targetNamespaceName := targetNamespaceEntry.Name()
+
+	targetNamespaceID = targetNamespaceEntry.ID()
+	targetNamespaceName = targetNamespaceEntry.Name()
 
 	// handle workflow cancel itself
-	if task.NamespaceID == task.TargetNamespaceID && task.WorkflowID == task.TargetWorkflowID {
+	if task.NamespaceID == targetNamespaceID.String() && task.WorkflowID == attributes.GetWorkflowExecution().GetWorkflowId() {
 		// it does not matter if the run ID is a mismatch
 		err = t.requestCancelExternalExecutionFailed(
 			ctx,
 			task,
 			weContext,
 			targetNamespaceName,
-			namespace.ID(task.TargetNamespaceID),
-			task.TargetWorkflowID,
-			task.TargetRunID,
+			targetNamespaceID,
+			attributes.GetWorkflowExecution().GetWorkflowId(),
+			attributes.GetWorkflowExecution().GetRunId(),
 			enumspb.CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND)
 		return err
 	}
@@ -544,6 +549,7 @@ func (t *transferQueueActiveTaskExecutor) processCancelExecution(
 		ctx,
 		task,
 		targetNamespaceName,
+		targetNamespaceID,
 		requestCancelInfo,
 		attributes,
 	); err != nil {
@@ -570,9 +576,9 @@ func (t *transferQueueActiveTaskExecutor) processCancelExecution(
 			task,
 			weContext,
 			targetNamespaceName,
-			namespace.ID(task.TargetNamespaceID),
-			task.TargetWorkflowID,
-			task.TargetRunID,
+			targetNamespaceID,
+			attributes.GetWorkflowExecution().GetWorkflowId(),
+			attributes.GetWorkflowExecution().GetRunId(),
 			failedCause,
 		)
 	}
@@ -583,9 +589,9 @@ func (t *transferQueueActiveTaskExecutor) processCancelExecution(
 		task,
 		weContext,
 		targetNamespaceName,
-		namespace.ID(task.TargetNamespaceID),
-		task.TargetWorkflowID,
-		task.TargetRunID,
+		targetNamespaceID,
+		attributes.GetWorkflowExecution().GetWorkflowId(),
+		attributes.GetWorkflowExecution().GetRunId(),
 	)
 }
 
@@ -634,38 +640,44 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 	}
 	attributes := initiatedEvent.GetSignalExternalWorkflowExecutionInitiatedEventAttributes()
 
-	targetNamespaceEntry, err := t.registry.GetNamespaceByID(namespace.ID(task.TargetNamespaceID))
+	var targetNamespaceName namespace.Name
+	var targetNamespaceID namespace.ID
+	targetNamespaceEntry, err := t.targetNamespaceEntryHelper(
+		namespace.ID(attributes.NamespaceId),
+		namespace.Name(attributes.Namespace),
+	)
 	if err != nil {
-		if _, isNotFound := err.(*serviceerror.NamespaceNotFound); !isNotFound {
-			return err
-		}
-		// It is possible that target namespace got deleted. Record failure.
-		t.logger.Debug("Target namespace is not found.", tag.WorkflowNamespaceID(task.TargetNamespaceID))
+		return err
+	}
+
+	if targetNamespaceEntry == nil {
 		return t.signalExternalExecutionFailed(
 			ctx,
 			task,
 			weContext,
-			namespace.Name(task.TargetNamespaceID), // Use ID as namespace name because namespace is already deleted and name is used only for history.
-			namespace.ID(task.TargetNamespaceID),
-			task.TargetWorkflowID,
-			task.TargetRunID,
+			namespace.Name(attributes.Namespace),
+			namespace.ID(attributes.NamespaceId),
+			attributes.GetWorkflowExecution().GetWorkflowId(),
+			attributes.GetWorkflowExecution().GetRunId(),
 			attributes.Control,
 			enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_NAMESPACE_NOT_FOUND,
 		)
 	}
-	targetNamespaceName := targetNamespaceEntry.Name()
+
+	targetNamespaceID = targetNamespaceEntry.ID()
+	targetNamespaceName = targetNamespaceEntry.Name()
 
 	// handle workflow signal itself
-	if task.NamespaceID == task.TargetNamespaceID && task.WorkflowID == task.TargetWorkflowID {
+	if task.NamespaceID == targetNamespaceID.String() && task.WorkflowID == attributes.GetWorkflowExecution().GetWorkflowId() {
 		// it does not matter if the run ID is a mismatch
 		return t.signalExternalExecutionFailed(
 			ctx,
 			task,
 			weContext,
 			targetNamespaceName,
-			namespace.ID(task.TargetNamespaceID),
-			task.TargetWorkflowID,
-			task.TargetRunID,
+			targetNamespaceID,
+			attributes.GetWorkflowExecution().GetWorkflowId(),
+			attributes.GetWorkflowExecution().GetRunId(),
 			attributes.Control,
 			enumspb.SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND,
 		)
@@ -675,6 +687,7 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 		ctx,
 		task,
 		targetNamespaceName,
+		targetNamespaceID,
 		signalInfo,
 		attributes,
 	); err != nil {
@@ -703,9 +716,9 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 			task,
 			weContext,
 			targetNamespaceName,
-			namespace.ID(task.TargetNamespaceID),
-			task.TargetWorkflowID,
-			task.TargetRunID,
+			targetNamespaceID,
+			attributes.GetWorkflowExecution().GetWorkflowId(),
+			attributes.GetWorkflowExecution().GetRunId(),
 			attributes.Control,
 			failedCause,
 		)
@@ -716,9 +729,9 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 		task,
 		weContext,
 		targetNamespaceName,
-		namespace.ID(task.TargetNamespaceID),
-		task.TargetWorkflowID,
-		task.TargetRunID,
+		targetNamespaceID,
+		attributes.GetWorkflowExecution().GetWorkflowId(),
+		attributes.GetWorkflowExecution().GetRunId(),
 		attributes.Control,
 	)
 	if err != nil {
@@ -732,12 +745,9 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 	release(retError)
 	// remove signalRequestedID from target workflow, after Signal detail is removed from source workflow
 	_, err = t.historyRawClient.RemoveSignalMutableState(ctx, &historyservice.RemoveSignalMutableStateRequest{
-		NamespaceId: task.TargetNamespaceID,
-		WorkflowExecution: &commonpb.WorkflowExecution{
-			WorkflowId: task.TargetWorkflowID,
-			RunId:      task.TargetRunID,
-		},
-		RequestId: signalRequestID,
+		NamespaceId:       targetNamespaceID.String(),
+		WorkflowExecution: attributes.GetWorkflowExecution(),
+		RequestId:         signalRequestID,
 	})
 	return err
 }
@@ -773,6 +783,21 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 	if err != nil {
 		return err
 	}
+
+	var targetNamespaceName namespace.Name
+	var targetNamespaceID namespace.ID
+	targetNamespaceEntry, err := t.targetNamespaceEntryHelper(
+		namespace.ID(childInfo.NamespaceId),
+		namespace.Name(childInfo.Namespace),
+	)
+	if err != nil {
+		return err
+	}
+	if targetNamespaceEntry != nil {
+		targetNamespaceID = targetNamespaceEntry.ID()
+		targetNamespaceName = targetNamespaceEntry.Name()
+	}
+	// Continue processing if targetNamespaceEntry is nil, we may need to record start failure below.
 
 	// workflow running or not, child started or not, parent close policy is abandon or not
 	// 8 cases in total
@@ -821,7 +846,12 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		if err != nil {
 			return err
 		}
-		return t.createFirstWorkflowTask(ctx, task.TargetNamespaceID, childExecution, parentClock, childClock)
+
+		if targetNamespaceEntry == nil {
+			return serviceerror.NewNamespaceNotFound(childInfo.Namespace)
+		}
+
+		return t.createFirstWorkflowTask(ctx, targetNamespaceID.String(), childExecution, parentClock, childClock)
 	}
 
 	// remaining 2 cases:
@@ -844,24 +874,14 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		parentNamespaceName = namespaceEntry.Name()
 	}
 
-	var targetNamespaceName namespace.Name
-	var targetNamespaceEntry *namespace.Namespace
-	if targetNamespaceEntry, err = t.registry.GetNamespaceByID(namespace.ID(task.TargetNamespaceID)); err != nil {
-		if _, isNotFound := err.(*serviceerror.NamespaceNotFound); !isNotFound {
-			return err
-		}
-		// It is possible that target namespace got deleted. Record failure.
-		t.logger.Debug("Target namespace is not found.", tag.WorkflowNamespaceID(task.TargetNamespaceID))
-		err = t.recordStartChildExecutionFailed(
+	if targetNamespaceEntry == nil {
+		return t.recordStartChildExecutionFailed(
 			ctx,
 			task,
 			weContext,
 			attributes,
 			enumspb.START_CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_NAMESPACE_NOT_FOUND,
 		)
-		return err
-	} else {
-		targetNamespaceName = targetNamespaceEntry.Name()
 	}
 
 	var sourceVersionStamp *commonpb.WorkerVersionStamp
@@ -946,7 +966,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 			if err != nil {
 				return err
 			}
-			return t.createFirstWorkflowTask(ctx, task.TargetNamespaceID, childExecution, parentClock, childClock)
+			return t.createFirstWorkflowTask(ctx, targetNamespaceID.String(), childExecution, parentClock, childClock)
 		}
 		// now if there was no child found after reset then it could mean one of the following.
 		// 1. The parent never got a chance to start the child. So we should go ahead and start one (below)
@@ -973,6 +993,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		task,
 		parentNamespaceName,
 		targetNamespaceName,
+		namespace.ID(targetNamespaceID),
 		childInfo.CreateRequestId,
 		attributes,
 		sourceVersionStamp,
@@ -1037,8 +1058,8 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 	if err != nil {
 		return err
 	}
-	return t.createFirstWorkflowTask(ctx, task.TargetNamespaceID, &commonpb.WorkflowExecution{
-		WorkflowId: task.TargetWorkflowID,
+	return t.createFirstWorkflowTask(ctx, targetNamespaceID.String(), &commonpb.WorkflowExecution{
+		WorkflowId: childInfo.StartedWorkflowId,
 		RunId:      childRunID,
 	}, parentClock, childClock)
 }
@@ -1258,7 +1279,7 @@ func (t *transferQueueActiveTaskExecutor) recordChildExecutionStarted(
 
 			_, err := mutableState.AddChildWorkflowExecutionStartedEvent(
 				&commonpb.WorkflowExecution{
-					WorkflowId: task.TargetWorkflowID,
+					WorkflowId: ci.StartedWorkflowId,
 					RunId:      runID,
 				},
 				initiatedAttributes.WorkflowType,
@@ -1479,18 +1500,16 @@ func (t *transferQueueActiveTaskExecutor) requestCancelExternalExecution(
 	ctx context.Context,
 	task *tasks.CancelExecutionTask,
 	targetNamespace namespace.Name,
+	targetNamespaceID namespace.ID,
 	requestCancelInfo *persistencespb.RequestCancelInfo,
 	attributes *historypb.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes,
 ) error {
 	request := &historyservice.RequestCancelWorkflowExecutionRequest{
-		NamespaceId: task.TargetNamespaceID,
+		NamespaceId: targetNamespaceID.String(),
 		CancelRequest: &workflowservice.RequestCancelWorkflowExecutionRequest{
-			Namespace: targetNamespace.String(),
-			WorkflowExecution: &commonpb.WorkflowExecution{
-				WorkflowId: task.TargetWorkflowID,
-				RunId:      task.TargetRunID,
-			},
-			Identity: consts.IdentityHistoryService,
+			Namespace:         targetNamespace.String(),
+			WorkflowExecution: attributes.GetWorkflowExecution(),
+			Identity:          consts.IdentityHistoryService,
 			// Use the same request ID to dedupe RequestCancelWorkflowExecution calls
 			RequestId: requestCancelInfo.GetCancelRequestId(),
 			Reason:    attributes.Reason,
@@ -1500,7 +1519,7 @@ func (t *transferQueueActiveTaskExecutor) requestCancelExternalExecution(
 			WorkflowId: task.WorkflowID,
 			RunId:      task.RunID,
 		},
-		ChildWorkflowOnly: task.TargetChildWorkflowOnly,
+		ChildWorkflowOnly: attributes.GetChildWorkflowOnly(),
 	}
 
 	_, err := t.historyRawClient.RequestCancelWorkflowExecution(ctx, request)
@@ -1511,20 +1530,18 @@ func (t *transferQueueActiveTaskExecutor) signalExternalExecution(
 	ctx context.Context,
 	task *tasks.SignalExecutionTask,
 	targetNamespace namespace.Name,
+	targetNamespaceID namespace.ID,
 	signalInfo *persistencespb.SignalInfo,
 	attributes *historypb.SignalExternalWorkflowExecutionInitiatedEventAttributes,
 ) error {
 	request := &historyservice.SignalWorkflowExecutionRequest{
-		NamespaceId: task.TargetNamespaceID,
+		NamespaceId: targetNamespaceID.String(),
 		SignalRequest: &workflowservice.SignalWorkflowExecutionRequest{
-			Namespace: targetNamespace.String(),
-			WorkflowExecution: &commonpb.WorkflowExecution{
-				WorkflowId: task.TargetWorkflowID,
-				RunId:      task.TargetRunID,
-			},
-			Identity:   consts.IdentityHistoryService,
-			SignalName: attributes.SignalName,
-			Input:      attributes.Input,
+			Namespace:         targetNamespace.String(),
+			WorkflowExecution: attributes.GetWorkflowExecution(),
+			Identity:          consts.IdentityHistoryService,
+			SignalName:        attributes.SignalName,
+			Input:             attributes.Input,
 			// Use same request ID to deduplicate SignalWorkflowExecution calls
 			RequestId: signalInfo.GetRequestId(),
 			Control:   attributes.Control,
@@ -1534,7 +1551,7 @@ func (t *transferQueueActiveTaskExecutor) signalExternalExecution(
 			WorkflowId: task.WorkflowID,
 			RunId:      task.RunID,
 		},
-		ChildWorkflowOnly: task.TargetChildWorkflowOnly,
+		ChildWorkflowOnly: attributes.GetChildWorkflowOnly(),
 	}
 
 	_, err := t.historyRawClient.SignalWorkflowExecution(ctx, request)
@@ -1546,6 +1563,7 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 	task *tasks.StartChildExecutionTask,
 	namespace namespace.Name,
 	targetNamespace namespace.Name,
+	targetNamespaceID namespace.ID,
 	childRequestID string,
 	attributes *historypb.StartChildWorkflowExecutionInitiatedEventAttributes,
 	sourceVersionStamp *commonpb.WorkerVersionStamp,
@@ -1581,7 +1599,7 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 	}
 
 	request := common.CreateHistoryStartWorkflowRequest(
-		task.TargetNamespaceID,
+		targetNamespaceID.String(),
 		startRequest,
 		&workflowspb.ParentExecutionInfo{
 			NamespaceId: task.NamespaceID,
@@ -1852,6 +1870,39 @@ func (t *transferQueueActiveTaskExecutor) applyParentClosePolicy(
 	default:
 		return serviceerror.NewInternal(fmt.Sprintf("unknown parent close policy: %v", childInfo.ParentClosePolicy))
 	}
+}
+
+func (t *transferQueueActiveTaskExecutor) targetNamespaceEntryHelper(
+	targetNamespaceID namespace.ID,
+	targetNamespaceName namespace.Name, // fallback if targetNamespaceID is not available.
+) (*namespace.Namespace, error) {
+	if targetNamespaceID == "" {
+		// This is for backward compatibility.
+		// Old mutable state / event may not have the target namespace ID set.
+
+		targetNamespaceEntry, err := t.registry.GetNamespace(targetNamespaceName)
+		if err != nil {
+			if _, isNotFound := err.(*serviceerror.NamespaceNotFound); !isNotFound {
+				return nil, err
+			}
+
+			t.logger.Debug("Target namespace is not found.", tag.WorkflowNamespace(targetNamespaceName.String()))
+			return nil, nil
+		}
+
+		return targetNamespaceEntry, nil
+	}
+
+	targetNamespaceEntry, err := t.registry.GetNamespaceByID(targetNamespaceID)
+	if err != nil {
+		if _, isNotFound := err.(*serviceerror.NamespaceNotFound); !isNotFound {
+			return nil, err
+		}
+
+		t.logger.Debug("Target namespace is not found.", tag.WorkflowNamespaceID(targetNamespaceID.String()))
+		return nil, nil
+	}
+	return targetNamespaceEntry, nil
 }
 
 func copyChildWorkflowInfos(

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -1490,7 +1490,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Succes
 	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
 
 	taskID := s.mustGenerateTaskID()
-	event, rci := addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId())
+	event, rci := addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), s.targetNamespace, s.targetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), true)
 	attributes := event.GetRequestCancelExternalWorkflowExecutionInitiatedEventAttributes()
 
 	transferTask := &tasks.CancelExecutionTask{
@@ -1499,13 +1499,9 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Succes
 			execution.GetWorkflowId(),
 			execution.GetRunId(),
 		),
-		Version:                 s.version,
-		TargetNamespaceID:       s.targetNamespaceID.String(),
-		TargetWorkflowID:        targetExecution.GetWorkflowId(),
-		TargetRunID:             targetExecution.GetRunId(),
-		TaskID:                  taskID,
-		TargetChildWorkflowOnly: true,
-		InitiatedEventID:        event.GetEventId(),
+		Version:          s.version,
+		TaskID:           taskID,
+		InitiatedEventID: event.GetEventId(),
 	}
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
@@ -1553,7 +1549,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Failur
 	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
 
 	taskID := s.mustGenerateTaskID()
-	event, rci := addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId())
+	event, rci := addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), s.targetNamespace, s.targetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), true)
 	attributes := event.GetRequestCancelExternalWorkflowExecutionInitiatedEventAttributes()
 
 	transferTask := &tasks.CancelExecutionTask{
@@ -1562,13 +1558,9 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Failur
 			execution.GetWorkflowId(),
 			execution.GetRunId(),
 		),
-		Version:                 s.version,
-		TargetNamespaceID:       s.targetNamespaceID.String(),
-		TargetWorkflowID:        targetExecution.GetWorkflowId(),
-		TargetRunID:             targetExecution.GetRunId(),
-		TaskID:                  taskID,
-		TargetChildWorkflowOnly: true,
-		InitiatedEventID:        event.GetEventId(),
+		Version:          s.version,
+		TaskID:           taskID,
+		InitiatedEventID: event.GetEventId(),
 	}
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
@@ -1616,7 +1608,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Failur
 	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
 
 	taskID := s.mustGenerateTaskID()
-	event, _ = addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId())
+	event, _ = addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), tests.MissedNamespace, tests.MissedNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), true)
 
 	transferTask := &tasks.CancelExecutionTask{
 		WorkflowKey: definition.NewWorkflowKey(
@@ -1624,13 +1616,9 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Failur
 			execution.GetWorkflowId(),
 			execution.GetRunId(),
 		),
-		Version:                 s.version,
-		TargetNamespaceID:       tests.MissedNamespaceID.String(),
-		TargetWorkflowID:        targetExecution.GetWorkflowId(),
-		TargetRunID:             targetExecution.GetRunId(),
-		TaskID:                  taskID,
-		TargetChildWorkflowOnly: true,
-		InitiatedEventID:        event.GetEventId(),
+		Version:          s.version,
+		TaskID:           taskID,
+		InitiatedEventID: event.GetEventId(),
 	}
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
@@ -1677,7 +1665,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Duplic
 	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
 
 	taskID := s.mustGenerateTaskID()
-	event, _ = addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId())
+	event, _ = addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), s.targetNamespace, s.targetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), true)
 
 	transferTask := &tasks.CancelExecutionTask{
 		WorkflowKey: definition.NewWorkflowKey(
@@ -1685,13 +1673,9 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Duplic
 			execution.GetWorkflowId(),
 			execution.GetRunId(),
 		),
-		Version:                 s.version,
-		TargetNamespaceID:       s.targetNamespaceID.String(),
-		TargetWorkflowID:        targetExecution.GetWorkflowId(),
-		TargetRunID:             targetExecution.GetRunId(),
-		TaskID:                  taskID,
-		TargetChildWorkflowOnly: true,
-		InitiatedEventID:        event.GetEventId(),
+		Version:          s.version,
+		TaskID:           taskID,
+		InitiatedEventID: event.GetEventId(),
 	}
 
 	event = addCancelRequestedEvent(mutableState, event.GetEventId(), tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId())
@@ -1706,7 +1690,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Duplic
 }
 
 func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Success() {
-	mutableState, event, si := s.setupSignalExternalWorkflowInitiated()
+	mutableState, event, si := s.setupSignalExternalWorkflowInitiated(s.targetNamespace, s.targetNamespaceID)
 	attributes := event.GetSignalExternalWorkflowExecutionInitiatedEventAttributes()
 
 	transferTask := &tasks.SignalExecutionTask{
@@ -1715,13 +1699,9 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Succes
 			mutableState.GetExecutionInfo().WorkflowId,
 			mutableState.GetExecutionState().RunId,
 		),
-		Version:                 s.version,
-		TargetNamespaceID:       attributes.GetNamespaceId(),
-		TargetWorkflowID:        attributes.WorkflowExecution.GetWorkflowId(),
-		TargetRunID:             attributes.WorkflowExecution.GetRunId(),
-		TaskID:                  s.mustGenerateTaskID(),
-		TargetChildWorkflowOnly: true,
-		InitiatedEventID:        event.GetEventId(),
+		Version:          s.version,
+		TaskID:           s.mustGenerateTaskID(),
+		InitiatedEventID: event.GetEventId(),
 	}
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
@@ -1731,12 +1711,9 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Succes
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(s.namespaceEntry.IsGlobalNamespace(), s.version).Return(cluster.TestCurrentClusterName).AnyTimes()
 
 	s.mockHistoryClient.EXPECT().RemoveSignalMutableState(gomock.Any(), &historyservice.RemoveSignalMutableStateRequest{
-		NamespaceId: transferTask.TargetNamespaceID,
-		WorkflowExecution: &commonpb.WorkflowExecution{
-			WorkflowId: transferTask.TargetWorkflowID,
-			RunId:      transferTask.TargetRunID,
-		},
-		RequestId: si.GetRequestId(),
+		NamespaceId:       attributes.GetNamespaceId(),
+		WorkflowExecution: attributes.GetWorkflowExecution(),
+		RequestId:         si.GetRequestId(),
 	}).Return(nil, nil)
 
 	resp := s.transferQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
@@ -1744,7 +1721,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Succes
 }
 
 func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Failure_TargetWorkflowNotFound() {
-	mutableState, event, si := s.setupSignalExternalWorkflowInitiated()
+	mutableState, event, si := s.setupSignalExternalWorkflowInitiated(s.targetNamespace, s.targetNamespaceID)
 	attributes := event.GetSignalExternalWorkflowExecutionInitiatedEventAttributes()
 
 	transferTask := &tasks.SignalExecutionTask{
@@ -1753,13 +1730,9 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Failur
 			mutableState.GetExecutionInfo().WorkflowId,
 			mutableState.GetExecutionState().RunId,
 		),
-		Version:                 s.version,
-		TargetNamespaceID:       attributes.GetNamespaceId(),
-		TargetWorkflowID:        attributes.WorkflowExecution.GetWorkflowId(),
-		TargetRunID:             attributes.WorkflowExecution.GetRunId(),
-		TaskID:                  s.mustGenerateTaskID(),
-		TargetChildWorkflowOnly: true,
-		InitiatedEventID:        event.GetEventId(),
+		Version:          s.version,
+		TaskID:           s.mustGenerateTaskID(),
+		InitiatedEventID: event.GetEventId(),
 	}
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
@@ -1782,8 +1755,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Failur
 }
 
 func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Failure_TargetNamespaceNotFound() {
-	mutableState, event, si := s.setupSignalExternalWorkflowInitiated()
-	attributes := event.GetSignalExternalWorkflowExecutionInitiatedEventAttributes()
+	mutableState, event, si := s.setupSignalExternalWorkflowInitiated(tests.MissedNamespace, tests.MissedNamespaceID)
 
 	transferTask := &tasks.SignalExecutionTask{
 		WorkflowKey: definition.NewWorkflowKey(
@@ -1791,13 +1763,9 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Failur
 			mutableState.GetExecutionInfo().WorkflowId,
 			mutableState.GetExecutionState().RunId,
 		),
-		Version:                 s.version,
-		TargetNamespaceID:       tests.MissedNamespaceID.String(),
-		TargetWorkflowID:        attributes.WorkflowExecution.GetWorkflowId(),
-		TargetRunID:             attributes.WorkflowExecution.GetRunId(),
-		TaskID:                  s.mustGenerateTaskID(),
-		TargetChildWorkflowOnly: true,
-		InitiatedEventID:        event.GetEventId(),
+		Version:          s.version,
+		TaskID:           s.mustGenerateTaskID(),
+		InitiatedEventID: event.GetEventId(),
 	}
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
@@ -1819,7 +1787,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Failur
 }
 
 func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Failure_SignalCountLimitExceeded() {
-	mutableState, event, si := s.setupSignalExternalWorkflowInitiated()
+	mutableState, event, si := s.setupSignalExternalWorkflowInitiated(s.targetNamespace, s.targetNamespaceID)
 	attributes := event.GetSignalExternalWorkflowExecutionInitiatedEventAttributes()
 
 	transferTask := &tasks.SignalExecutionTask{
@@ -1828,13 +1796,9 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Failur
 			mutableState.GetExecutionInfo().WorkflowId,
 			mutableState.GetExecutionState().RunId,
 		),
-		Version:                 s.version,
-		TargetNamespaceID:       attributes.GetNamespaceId(),
-		TargetWorkflowID:        attributes.WorkflowExecution.GetWorkflowId(),
-		TargetRunID:             attributes.WorkflowExecution.GetRunId(),
-		TaskID:                  s.mustGenerateTaskID(),
-		TargetChildWorkflowOnly: true,
-		InitiatedEventID:        event.GetEventId(),
+		Version:          s.version,
+		TaskID:           s.mustGenerateTaskID(),
+		InitiatedEventID: event.GetEventId(),
 	}
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
@@ -1857,7 +1821,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Failur
 }
 
 func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Duplication() {
-	mutableState, event, _ := s.setupSignalExternalWorkflowInitiated()
+	mutableState, event, _ := s.setupSignalExternalWorkflowInitiated(s.targetNamespace, s.targetNamespaceID)
 	attributes := event.GetSignalExternalWorkflowExecutionInitiatedEventAttributes()
 
 	transferTask := &tasks.SignalExecutionTask{
@@ -1866,20 +1830,16 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Duplic
 			mutableState.GetExecutionInfo().WorkflowId,
 			mutableState.GetExecutionState().RunId,
 		),
-		Version:                 s.version,
-		TargetNamespaceID:       attributes.GetNamespaceId(),
-		TargetWorkflowID:        attributes.WorkflowExecution.GetWorkflowId(),
-		TargetRunID:             attributes.WorkflowExecution.GetRunId(),
-		TaskID:                  s.mustGenerateTaskID(),
-		TargetChildWorkflowOnly: true,
-		InitiatedEventID:        event.GetEventId(),
+		Version:          s.version,
+		TaskID:           s.mustGenerateTaskID(),
+		InitiatedEventID: event.GetEventId(),
 	}
 
 	event = addSignaledEvent(
 		mutableState,
 		event.GetEventId(),
 		tests.TargetNamespace,
-		namespace.ID(transferTask.TargetNamespaceID),
+		namespace.ID(attributes.GetNamespaceId()),
 		attributes.WorkflowExecution.GetWorkflowId(),
 		attributes.WorkflowExecution.GetRunId(),
 		"",
@@ -1894,7 +1854,10 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Duplic
 	s.Nil(resp.ExecutionErr)
 }
 
-func (s *transferQueueActiveTaskExecutorSuite) setupSignalExternalWorkflowInitiated() (
+func (s *transferQueueActiveTaskExecutorSuite) setupSignalExternalWorkflowInitiated(
+	targetNamespace namespace.Name,
+	targetNamespaceID namespace.ID,
+) (
 	*workflow.MutableStateImpl,
 	*historypb.HistoryEvent,
 	*persistencespb.SignalInfo,
@@ -1939,7 +1902,7 @@ func (s *transferQueueActiveTaskExecutorSuite) setupSignalExternalWorkflowInitia
 	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
 
 	event, signalInfo := addRequestSignalInitiatedEvent(mutableState, event.GetEventId(), uuid.New(),
-		tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), signalName, signalInput,
+		targetNamespace, targetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), true, signalName, signalInput,
 		signalControl, signalHeader)
 
 	return mutableState, event, signalInfo
@@ -2037,8 +2000,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Su
 			execution.GetRunId(),
 		),
 		Version:             s.version,
-		TargetNamespaceID:   tests.ChildNamespaceID.String(),
-		TargetWorkflowID:    childWorkflowID,
 		TaskID:              taskID,
 		InitiatedEventID:    event.GetEventId(),
 		VisibilityTimestamp: time.Now().UTC(),
@@ -2153,8 +2114,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Re
 			execution.GetRunId(),
 		),
 		Version:             s.version,
-		TargetNamespaceID:   tests.ChildNamespaceID.String(),
-		TargetWorkflowID:    childWorkflowID,
 		TaskID:              taskID,
 		InitiatedEventID:    childInitEvent.GetEventId(),
 		VisibilityTimestamp: time.Now().UTC(),
@@ -2273,8 +2232,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Fa
 			execution.GetRunId(),
 		),
 		Version:             s.version,
-		TargetNamespaceID:   tests.ChildNamespaceID.String(),
-		TargetWorkflowID:    childWorkflowID,
 		TaskID:              taskID,
 		InitiatedEventID:    event.GetEventId(),
 		VisibilityTimestamp: time.Now().UTC(),
@@ -2343,8 +2300,8 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Fa
 	event, _ = addStartChildWorkflowExecutionInitiatedEvent(
 		mutableState,
 		event.GetEventId(),
-		s.namespace,
-		s.namespaceID,
+		tests.MissedNamespace,
+		tests.MissedNamespaceID,
 		childWorkflowID,
 		childWorkflowType,
 		childTaskQueueName,
@@ -2362,8 +2319,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Fa
 			execution.GetRunId(),
 		),
 		Version:             s.version,
-		TargetNamespaceID:   tests.MissedNamespaceID.String(),
-		TargetWorkflowID:    childWorkflowID,
 		TaskID:              taskID,
 		InitiatedEventID:    event.GetEventId(),
 		VisibilityTimestamp: time.Now().UTC(),
@@ -2436,8 +2391,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Su
 			execution.GetRunId(),
 		),
 		Version:             s.version,
-		TargetNamespaceID:   tests.ChildNamespaceID.String(),
-		TargetWorkflowID:    childWorkflowID,
 		TaskID:              taskID,
 		InitiatedEventID:    event.GetEventId(),
 		VisibilityTimestamp: time.Now().UTC(),
@@ -2539,8 +2492,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Du
 			execution.GetRunId(),
 		),
 		Version:             s.version,
-		TargetNamespaceID:   tests.ChildNamespaceID.String(),
-		TargetWorkflowID:    childExecution.GetWorkflowId(),
 		TaskID:              taskID,
 		InitiatedEventID:    event.GetEventId(),
 		VisibilityTimestamp: time.Now().UTC(),
@@ -2622,8 +2573,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessorStartChildExecution_
 			execution.GetRunId(),
 		),
 		Version:             s.version,
-		TargetNamespaceID:   tests.ChildNamespaceID.String(),
-		TargetWorkflowID:    childExecution.GetWorkflowId(),
 		TaskID:              taskID,
 		InitiatedEventID:    event.GetEventId(),
 		VisibilityTimestamp: time.Now().UTC(),
@@ -2867,13 +2816,10 @@ func (s *transferQueueActiveTaskExecutorSuite) createRequestCancelWorkflowExecut
 		WorkflowId: task.WorkflowID,
 		RunId:      task.RunID,
 	}
-	targetExecution := &commonpb.WorkflowExecution{
-		WorkflowId: task.TargetWorkflowID,
-		RunId:      task.TargetRunID,
-	}
+	targetExecution := attributes.GetWorkflowExecution()
 
 	return &historyservice.RequestCancelWorkflowExecutionRequest{
-		NamespaceId: task.TargetNamespaceID,
+		NamespaceId: attributes.GetNamespaceId(),
 		CancelRequest: &workflowservice.RequestCancelWorkflowExecutionRequest{
 			Namespace:         targetNamespace.String(),
 			WorkflowExecution: targetExecution,
@@ -2884,7 +2830,7 @@ func (s *transferQueueActiveTaskExecutorSuite) createRequestCancelWorkflowExecut
 		},
 		ExternalInitiatedEventId:  task.InitiatedEventID,
 		ExternalWorkflowExecution: sourceExecution,
-		ChildWorkflowOnly:         task.TargetChildWorkflowOnly,
+		ChildWorkflowOnly:         attributes.GetChildWorkflowOnly(),
 	}
 }
 
@@ -2898,16 +2844,12 @@ func (s *transferQueueActiveTaskExecutorSuite) createSignalWorkflowExecutionRequ
 		WorkflowId: task.WorkflowID,
 		RunId:      task.RunID,
 	}
-	targetExecution := &commonpb.WorkflowExecution{
-		WorkflowId: task.TargetWorkflowID,
-		RunId:      task.TargetRunID,
-	}
 
 	return &historyservice.SignalWorkflowExecutionRequest{
-		NamespaceId: task.TargetNamespaceID,
+		NamespaceId: attributes.GetNamespaceId(),
 		SignalRequest: &workflowservice.SignalWorkflowExecutionRequest{
 			Namespace:         targetNamespace.String(),
-			WorkflowExecution: targetExecution,
+			WorkflowExecution: attributes.GetWorkflowExecution(),
 			Identity:          consts.IdentityHistoryService,
 			SignalName:        attributes.SignalName,
 			Input:             attributes.Input,
@@ -2916,7 +2858,7 @@ func (s *transferQueueActiveTaskExecutorSuite) createSignalWorkflowExecutionRequ
 			Header:            attributes.Header,
 		},
 		ExternalWorkflowExecution: sourceExecution,
-		ChildWorkflowOnly:         task.TargetChildWorkflowOnly,
+		ChildWorkflowOnly:         attributes.GetChildWorkflowOnly(),
 	}
 }
 
@@ -2938,7 +2880,7 @@ func (s *transferQueueActiveTaskExecutorSuite) createChildWorkflowExecutionReque
 	now := s.timeSource.Now().UTC()
 	return &historyservice.StartWorkflowExecutionRequest{
 		Attempt:     1,
-		NamespaceId: task.TargetNamespaceID,
+		NamespaceId: ci.NamespaceId,
 		StartRequest: &workflowservice.StartWorkflowExecutionRequest{
 			Namespace:                childNamespace.String(),
 			WorkflowId:               attributes.WorkflowId,

--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -437,8 +437,20 @@ func (t *transferQueueStandbyTaskExecutor) processStartChildExecution(
 			return &struct{}{}, nil
 		}
 
+		targetNamespaceID := childWorkflowInfo.NamespaceId
+		if targetNamespaceID == "" {
+			// This is for backward compatibility.
+			// Old mutable state may not have the target namespace ID set in childWorkflowInfo.
+
+			targetNamespaceEntry, err := t.registry.GetNamespace(namespace.Name(childWorkflowInfo.Namespace))
+			if err != nil {
+				return nil, err
+			}
+			targetNamespaceID = targetNamespaceEntry.ID().String()
+		}
+
 		_, err = t.historyRawClient.VerifyFirstWorkflowTaskScheduled(ctx, &historyservice.VerifyFirstWorkflowTaskScheduledRequest{
-			NamespaceId: transferTask.TargetNamespaceID,
+			NamespaceId: targetNamespaceID,
 			WorkflowExecution: &commonpb.WorkflowExecution{
 				WorkflowId: childWorkflowInfo.StartedWorkflowId,
 				RunId:      childWorkflowInfo.StartedRunId,

--- a/service/history/transfer_queue_standby_task_executor_test.go
+++ b/service/history/transfer_queue_standby_task_executor_test.go
@@ -770,7 +770,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessCancelExecution_Pendi
 	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
 
 	taskID := s.mustGenerateTaskID()
-	event, _ = addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId())
+	event, _ = addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), true)
 
 	now := time.Now().UTC()
 	transferTask := &tasks.CancelExecutionTask{
@@ -779,14 +779,10 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessCancelExecution_Pendi
 			execution.GetWorkflowId(),
 			execution.GetRunId(),
 		),
-		Version:                 s.version,
-		VisibilityTimestamp:     now,
-		TargetNamespaceID:       tests.TargetNamespaceID.String(),
-		TargetWorkflowID:        targetExecution.GetWorkflowId(),
-		TargetRunID:             targetExecution.GetRunId(),
-		TargetChildWorkflowOnly: true,
-		TaskID:                  taskID,
-		InitiatedEventID:        event.GetEventId(),
+		Version:             s.version,
+		VisibilityTimestamp: now,
+		TaskID:              taskID,
+		InitiatedEventID:    event.GetEventId(),
 	}
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
@@ -840,7 +836,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessCancelExecution_Succe
 	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
 
 	taskID := s.mustGenerateTaskID()
-	event, _ = addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId())
+	event, _ = addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), false)
 
 	now := time.Now().UTC()
 	transferTask := &tasks.CancelExecutionTask{
@@ -851,9 +847,6 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessCancelExecution_Succe
 		),
 		Version:             s.version,
 		VisibilityTimestamp: now,
-		TargetNamespaceID:   tests.TargetNamespaceID.String(),
-		TargetWorkflowID:    targetExecution.GetWorkflowId(),
-		TargetRunID:         targetExecution.GetRunId(),
 		TaskID:              taskID,
 		InitiatedEventID:    event.GetEventId(),
 	}
@@ -907,7 +900,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessSignalExecution_Pendi
 
 	taskID := s.mustGenerateTaskID()
 	event, _ = addRequestSignalInitiatedEvent(mutableState, event.GetEventId(), uuid.New(),
-		tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), signalName, nil, "", nil)
+		tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), false, signalName, nil, "", nil)
 
 	now := time.Now().UTC()
 	transferTask := &tasks.SignalExecutionTask{
@@ -918,9 +911,6 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessSignalExecution_Pendi
 		),
 		Version:             s.version,
 		VisibilityTimestamp: now,
-		TargetNamespaceID:   tests.TargetNamespaceID.String(),
-		TargetWorkflowID:    targetExecution.GetWorkflowId(),
-		TargetRunID:         targetExecution.GetRunId(),
 		TaskID:              taskID,
 		InitiatedEventID:    event.GetEventId(),
 	}
@@ -978,7 +968,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessSignalExecution_Succe
 
 	taskID := s.mustGenerateTaskID()
 	event, _ = addRequestSignalInitiatedEvent(mutableState, event.GetEventId(), uuid.New(),
-		tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), signalName, nil, "", nil)
+		tests.TargetNamespace, tests.TargetNamespaceID, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), false, signalName, nil, "", nil)
 
 	now := time.Now().UTC()
 	transferTask := &tasks.SignalExecutionTask{
@@ -989,9 +979,6 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessSignalExecution_Succe
 		),
 		Version:             s.version,
 		VisibilityTimestamp: now,
-		TargetNamespaceID:   tests.TargetNamespaceID.String(),
-		TargetWorkflowID:    targetExecution.GetWorkflowId(),
-		TargetRunID:         targetExecution.GetRunId(),
 		TaskID:              taskID,
 		InitiatedEventID:    event.GetEventId(),
 	}
@@ -1054,8 +1041,6 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessStartChildExecution_P
 		),
 		Version:             s.version,
 		VisibilityTimestamp: now,
-		TargetNamespaceID:   tests.ChildNamespaceID.String(),
-		TargetWorkflowID:    childWorkflowID,
 		TaskID:              taskID,
 		InitiatedEventID:    event.GetEventId(),
 	}
@@ -1164,8 +1149,6 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessStartChildExecution_S
 		),
 		Version:             s.version,
 		VisibilityTimestamp: now,
-		TargetNamespaceID:   tests.ChildNamespaceID.String(),
-		TargetWorkflowID:    childWorkflowID,
 		TaskID:              taskID,
 		InitiatedEventID:    event.GetEventId(),
 	}

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -580,6 +580,9 @@ func (r *TaskGeneratorImpl) GenerateChildWorkflowTasks(
 	return nil
 }
 
+// TODO: Take in scheduledEventID instead of event once
+// TargetNamespaceID, TargetWorkflowID, TargetRunID & TargetChildWorkflowOnly
+// are removed from CancelExecutionTask.
 func (r *TaskGeneratorImpl) GenerateRequestCancelExternalTasks(
 	event *historypb.HistoryEvent,
 ) error {
@@ -615,6 +618,9 @@ func (r *TaskGeneratorImpl) GenerateRequestCancelExternalTasks(
 	return nil
 }
 
+// TODO: Take in scheduledEventID instead of event once
+// TargetNamespaceID, TargetWorkflowID, TargetRunID & TargetChildWorkflowOnly
+// are removed from SignalExecutionTask.
 func (r *TaskGeneratorImpl) GenerateSignalExternalTasks(
 	event *historypb.HistoryEvent,
 ) error {


### PR DESCRIPTION
## What changed?
- Deprecate target workflow info in transfer tasks and not using them in task processing logic.

## Why?
- The main goal is to reduce event loading during task refresh, which could lead to request timeout when workflow history is long/large. We load events to populate certain fields in the transfer tasks and those fields are using during transfer task processing logic. So to reduce event loading, we need remove the usage of those field first in the task processing logic.
- To support rollback, we can only get rid of those fields in transfer tasks and event loading logic in next release + 1.
- Removing fields from transfer tasks can also make them smaller in terms of data size.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
