### PR TITLE
Exclude Google Cloud Storage gRPC packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ TEMPORAL_DB ?= temporal
 VISIBILITY_DB ?= temporal_visibility
 
 # The `disable_grpc_modules` build tag excludes gRPC dependencies from cloud.google.com/go/storage,
-# reducing binary size by ~20MB since we only use the REST client (storage.NewClient), not the
+# reducing binary size by 16MB since we only use the REST client (storage.NewClient), not the
 # gRPC client (storage.NewGRPCClient). Related issue: https://github.com/googleapis/google-cloud-go/issues/12343
 ALL_BUILD_TAGS := disable_grpc_modules,$(BUILD_TAG)
 ALL_TEST_TAGS := $(ALL_BUILD_TAGS),test_dep,$(TEST_TAG)

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,10 @@ PERSISTENCE_DRIVER ?= cassandra
 TEMPORAL_DB ?= temporal
 VISIBILITY_DB ?= temporal_visibility
 
-ALL_BUILD_TAGS := $(BUILD_TAG),
+# The `disable_grpc_modules` build tag excludes gRPC dependencies from cloud.google.com/go/storage,
+# reducing binary size by ~20MB since we only use the REST client (storage.NewClient), not the
+# gRPC client (storage.NewGRPCClient). Related issue: https://github.com/googleapis/google-cloud-go/issues/12343
+ALL_BUILD_TAGS := disable_grpc_modules,$(BUILD_TAG)
 ALL_TEST_TAGS := $(ALL_BUILD_TAGS),test_dep,$(TEST_TAG)
 BUILD_TAG_FLAG := -tags $(ALL_BUILD_TAGS)
 TEST_TAG_FLAG := -tags $(ALL_TEST_TAGS)

--- a/common/archiver/gcloud/connector/client_delegate.go
+++ b/common/archiver/gcloud/connector/client_delegate.go
@@ -86,7 +86,6 @@ func newDefaultClientDelegate(ctx context.Context) (*clientDelegate, error) {
 }
 
 func newClientDelegateWithCredentials(ctx context.Context, credentialsPath string) (*clientDelegate, error) {
-
 	jsonKey, err := os.ReadFile(credentialsPath)
 	if err != nil {
 		return newDefaultClientDelegate(ctx)

--- a/common/archiver/gcloud/connector/client_test.go
+++ b/common/archiver/gcloud/connector/client_test.go
@@ -310,7 +310,7 @@ func (s *clientSuite) TestNoGRPCUsage() {
 	packageFiles, err := filepath.Glob("*.go")
 	s.NoError(err)
 
-	var checkedFile bool
+	var checkedClientFile bool
 	for _, file := range packageFiles {
 		if strings.HasSuffix(file, "_test.go") {
 			continue
@@ -321,7 +321,8 @@ func (s *clientSuite) TestNoGRPCUsage() {
 		if strings.Contains(string(content), "NewGRPCClient") {
 			s.T().Errorf("❌ Found forbidden gRPC usage in file: %s", file)
 		}
-		checkedFile = true
+
+		checkedClientFile = checkedClientFile || strings.HasSuffix(file, "client.go")
 	}
-	s.True(checkedFile, "checked at least one file")
+	s.True(checkedClientFile, "checked client.go file")
 }

--- a/common/archiver/gcloud/connector/client_test.go
+++ b/common/archiver/gcloud/connector/client_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -316,7 +315,7 @@ func (s *clientSuite) TestNoGRPCUsage() {
 		if strings.HasSuffix(file, "_test.go") {
 			continue
 		}
-		content, err := ioutil.ReadFile(file)
+		content, err := os.ReadFile(file)
 		s.NoError(err)
 
 		if strings.Contains(string(content), "NewGRPCClient") {

--- a/common/archiver/gcloud/connector/client_test.go
+++ b/common/archiver/gcloud/connector/client_test.go
@@ -324,5 +324,5 @@ func (s *clientSuite) TestNoGRPCUsage() {
 
 		checkedClientFile = checkedClientFile || strings.HasSuffix(file, "client.go")
 	}
-	s.True(checkedClientFile, "checked client.go file")
+	s.True(checkedClientFile, "should have checked client.go for gRPC usage")
 }


### PR DESCRIPTION
## What changed?

Stripped Google Cloud Storage's gRPC dependencies out for builds via the Makefile.

## Why?

Reduce binary size by 16MB; and reduces build times a little (ie linking).

**Before**

```
-rwxr-xr-x@ 1 stephan  staff   119M Jun 30 11:23 temporal-server
```

**After**

```
-rwxr-xr-x@ 1 stephan  staff   103M Jun 30 11:24 temporal-server
```

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

Yes, since there are no end-to-end tests, if anyone started using `storage.NewGRPCClient` that would fail silently. I added a (crude) test to catch that.