### PR TITLE
config: enable dropNonRetryableTasks prometheus metric

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1244,11 +1244,6 @@ these log lines can be noisy, we want to be able to turn on and sample selective
 		5*time.Second,
 		`TaskQueueInfoByBuildIdTTL serves as a TTL for the cache holding DescribeTaskQueue partition results`,
 	)
-	MatchingDropNonRetryableTasks = NewGlobalBoolSetting(
-		"matching.dropNonRetryableTasks",
-		true,
-		`MatchingDropNonRetryableTasks states if we should drop matching tasks with Internal/Dataloss errors`,
-	)
 	MatchingMaxTaskQueuesInDeployment = NewNamespaceIntSetting(
 		"matching.maxTaskQueuesInDeployment",
 		1000,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1246,7 +1246,7 @@ these log lines can be noisy, we want to be able to turn on and sample selective
 	)
 	MatchingDropNonRetryableTasks = NewGlobalBoolSetting(
 		"matching.dropNonRetryableTasks",
-		false,
+		true,
 		`MatchingDropNonRetryableTasks states if we should drop matching tasks with Internal/Dataloss errors`,
 	)
 	MatchingMaxTaskQueuesInDeployment = NewNamespaceIntSetting(

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -28,7 +28,6 @@ type (
 		AlignMembershipChange                dynamicconfig.DurationPropertyFn
 		ShutdownDrainDuration                dynamicconfig.DurationPropertyFn
 		HistoryMaxPageSize                   dynamicconfig.IntPropertyFnWithNamespaceFilter
-		MatchingDropNonRetryableTasks        dynamicconfig.BoolPropertyFn
 		EnableDeployments                    dynamicconfig.BoolPropertyFnWithNamespaceFilter // [cleanup-wv-pre-release]
 		EnableDeploymentVersions             dynamicconfig.BoolPropertyFnWithNamespaceFilter
 		MaxTaskQueuesInDeployment            dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -272,7 +271,6 @@ func NewConfig(
 		TaskQueueInfoByBuildIdTTL:                dynamicconfig.TaskQueueInfoByBuildIdTTL.Get(dc),
 		PriorityLevels:                           dynamicconfig.MatchingPriorityLevels.Get(dc),
 		RateLimiterRefreshInterval:               time.Minute,
-		MatchingDropNonRetryableTasks:            dynamicconfig.MatchingDropNonRetryableTasks.Get(dc),
 		MaxIDLengthLimit:                         dynamicconfig.MaxIDLengthLimit.Get(dc),
 
 		AdminNamespaceToPartitionDispatchRate:          dynamicconfig.AdminMatchingNamespaceToPartitionDispatchRate.Get(dc),

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -687,14 +687,9 @@ pollLoop:
 		if err != nil {
 			switch err := err.(type) {
 			case *serviceerror.Internal, *serviceerror.DataLoss:
-				if e.config.MatchingDropNonRetryableTasks() {
-					e.nonRetryableErrorsDropTask(task, taskQueueName, err)
-					// drop the task as otherwise task would be stuck in a retry-loop
-					task.finish(nil, false)
-				} else {
-					// default case
-					task.finish(err, false)
-				}
+				e.nonRetryableErrorsDropTask(task, taskQueueName, err)
+				// drop the task as otherwise task would be stuck in a retry-loop
+				task.finish(nil, false)
 			case *serviceerror.NotFound: // mutable state not found, workflow not running or workflow task not found
 				e.logger.Info("Workflow task not found",
 					tag.WorkflowTaskQueueName(taskQueueName),
@@ -910,14 +905,9 @@ pollLoop:
 		if err != nil {
 			switch err := err.(type) {
 			case *serviceerror.Internal, *serviceerror.DataLoss:
-				if e.config.MatchingDropNonRetryableTasks() {
-					e.nonRetryableErrorsDropTask(task, taskQueueName, err)
-					// drop the task as otherwise task would be stuck in a retry-loop
-					task.finish(nil, false)
-				} else {
-					// default case
-					task.finish(err, false)
-				}
+				e.nonRetryableErrorsDropTask(task, taskQueueName, err)
+				// drop the task as otherwise task would be stuck in a retry-loop
+				task.finish(nil, false)
 			case *serviceerror.NotFound: // mutable state not found, workflow not running or activity info not found
 				e.logger.Info("Activity task not found",
 					tag.WorkflowNamespaceID(task.event.Data.GetNamespaceId()),

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -366,7 +366,6 @@ func (s *matchingEngineSuite) TestFailAddTaskWithHistoryExhausted() {
 
 func (s *matchingEngineSuite) TestFailAddTaskWithHistoryError() {
 	s.logger.Expect(testlogger.Error, "dropping task due to non-nonretryable errors")
-	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
 	historyError := serviceerror.NewInternal("nothing to start")
 	tqName := "testFailAddTaskWithHistoryError"
 	s.testFailAddTaskWithHistoryError(tqName, true, historyError, nil) // expectedError shall be nil since history drops the task
@@ -588,7 +587,6 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_NamespaceHandover() {
 
 func (s *matchingEngineSuite) TestPollActivityTaskQueues_InternalError() {
 	s.logger.Expect(testlogger.Error, "dropping task due to non-nonretryable errors")
-	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
 	namespaceId := uuid.New()
 	tl := "queue"
 	taskQueue := &taskqueuepb.TaskQueue{Name: "queue", Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
@@ -622,7 +620,6 @@ func (s *matchingEngineSuite) TestPollActivityTaskQueues_InternalError() {
 
 func (s *matchingEngineSuite) TestPollActivityTaskQueues_DataLossError() {
 	s.logger.Expect(testlogger.Error, "dropping task due to non-nonretryable errors")
-	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
 
 	namespaceId := uuid.New()
 	tl := "queue"
@@ -658,7 +655,6 @@ func (s *matchingEngineSuite) TestPollActivityTaskQueues_DataLossError() {
 
 func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_InternalError() {
 	s.logger.Expect(testlogger.Error, "dropping task due to non-nonretryable errors")
-	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
 
 	tqName := "queue"
 	taskQueue := &taskqueuepb.TaskQueue{Name: tqName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
@@ -685,7 +681,6 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_InternalError() {
 
 func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_DataLossError() {
 	s.logger.Expect(testlogger.Error, "dropping task due to non-nonretryable errors")
-	s.matchingEngine.config.MatchingDropNonRetryableTasks = dynamicconfig.GetBoolPropertyFn(true)
 
 	tqName := "queue"
 	taskQueue := &taskqueuepb.TaskQueue{Name: tqName, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}


### PR DESCRIPTION
## What changed?
Removing the dynamic config for `matching.dropNonRetryableTasks` and enable scraping of the metric

## Why?
We want to scrape this metric and alerts for spikes

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Potentially_ this metric could have high cardinality but this is not expected
