### PR TITLE
Build tag to exclude Cloud archiver providers

### DIFF
--- a/common/archiver/gcloud/history_archiver.go
+++ b/common/archiver/gcloud/history_archiver.go
@@ -13,7 +13,6 @@ import (
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/archiver/gcloud/connector"
 	"go.temporal.io/server/common/codec"
-	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -54,20 +53,6 @@ type getHistoryToken struct {
 	HighestPart          int
 	CurrentPart          int
 	BatchIdxOffset       int
-}
-
-// NewHistoryArchiver creates a new gcloud storage HistoryArchiver
-func NewHistoryArchiver(
-	executionManager persistence.ExecutionManager,
-	logger log.Logger,
-	metricsHandler metrics.Handler,
-	config *config.GstorageArchiver,
-) (archiver.HistoryArchiver, error) {
-	storage, err := connector.NewClient(context.Background(), config)
-	if err == nil {
-		return newHistoryArchiver(executionManager, logger, metricsHandler, nil, storage), nil
-	}
-	return nil, err
 }
 
 func newHistoryArchiver(executionManager persistence.ExecutionManager, logger log.Logger, metricsHandler metrics.Handler, historyIterator archiver.HistoryIterator, storage connector.Client) archiver.HistoryArchiver {

--- a/common/archiver/gcloud/history_archiver_off.go
+++ b/common/archiver/gcloud/history_archiver_off.go
@@ -1,0 +1,10 @@
+//go:build disable_cloud_archival
+
+package gcloud
+
+import "go.temporal.io/server/common/archiver"
+
+// NewHistoryArchiver creates a new gcloud storage HistoryArchiver
+func NewHistoryArchiver(...any) (archiver.HistoryArchiver, error) {
+	panic("cloud archival is disabled via build tag `disable_cloud_archival`")
+}

--- a/common/archiver/gcloud/history_archiver_on.go
+++ b/common/archiver/gcloud/history_archiver_on.go
@@ -1,0 +1,28 @@
+//go:build !disable_cloud_archival
+
+package gcloud
+
+import (
+	"context"
+
+	"go.temporal.io/server/common/archiver"
+	"go.temporal.io/server/common/archiver/gcloud/connector"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+)
+
+// NewHistoryArchiver creates a new gcloud storage HistoryArchiver
+func NewHistoryArchiver(
+	executionManager persistence.ExecutionManager,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
+	cfg *config.GstorageArchiver,
+) (archiver.HistoryArchiver, error) {
+	storage, err := connector.NewClient(context.Background(), cfg)
+	if err == nil {
+		return newHistoryArchiver(executionManager, logger, metricsHandler, nil, storage), nil
+	}
+	return nil, err
+}

--- a/common/archiver/gcloud/visibility_archiver.go
+++ b/common/archiver/gcloud/visibility_archiver.go
@@ -12,7 +12,6 @@ import (
 	archiverspb "go.temporal.io/server/api/archiver/v1"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/archiver/gcloud/connector"
-	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -57,12 +56,6 @@ func newVisibilityArchiver(logger log.Logger, metricsHandler metrics.Handler, st
 		gcloudStorage:  storage,
 		queryParser:    NewQueryParser(),
 	}
-}
-
-// NewVisibilityArchiver creates a new archiver.VisibilityArchiver based on filestore
-func NewVisibilityArchiver(logger log.Logger, metricsHandler metrics.Handler, cfg *config.GstorageArchiver) (archiver.VisibilityArchiver, error) {
-	storage, err := connector.NewClient(context.Background(), cfg)
-	return newVisibilityArchiver(logger, metricsHandler, storage), err
 }
 
 // Archive is used to archive one workflow visibility record.

--- a/common/archiver/gcloud/visibility_archiver_off.go
+++ b/common/archiver/gcloud/visibility_archiver_off.go
@@ -1,0 +1,10 @@
+//go:build disable_cloud_archival
+
+package gcloud
+
+import "go.temporal.io/server/common/archiver"
+
+// NewVisibilityArchiver creates a new archiver.VisibilityArchiver based on filestore
+func NewVisibilityArchiver(...any) (archiver.VisibilityArchiver, error) {
+	panic("cloud archival is disabled via build tag `disable_cloud_archival`")
+}

--- a/common/archiver/gcloud/visibility_archiver_on.go
+++ b/common/archiver/gcloud/visibility_archiver_on.go
@@ -1,0 +1,23 @@
+//go:build !disable_cloud_archival
+
+package gcloud
+
+import (
+	"context"
+
+	"go.temporal.io/server/common/archiver"
+	"go.temporal.io/server/common/archiver/gcloud/connector"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+)
+
+// NewVisibilityArchiver creates a new archiver.VisibilityArchiver based on filestore
+func NewVisibilityArchiver(
+	logger log.Logger,
+	metricsHandler metrics.Handler,
+	cfg *config.GstorageArchiver,
+) (archiver.VisibilityArchiver, error) {
+	storage, err := connector.NewClient(context.Background(), cfg)
+	return newVisibilityArchiver(logger, metricsHandler, storage), err
+}

--- a/common/archiver/s3store/history_archiver.go
+++ b/common/archiver/s3store/history_archiver.go
@@ -66,16 +66,6 @@ type (
 	}
 )
 
-// NewHistoryArchiver creates a new archiver.HistoryArchiver based on s3
-func NewHistoryArchiver(
-	executionManager persistence.ExecutionManager,
-	logger log.Logger,
-	metricsHandler metrics.Handler,
-	config *config.S3Archiver,
-) (archiver.HistoryArchiver, error) {
-	return newHistoryArchiver(executionManager, logger, metricsHandler, config, nil)
-}
-
 func newHistoryArchiver(
 	executionManager persistence.ExecutionManager,
 	logger log.Logger,

--- a/common/archiver/s3store/history_archiver_off.go
+++ b/common/archiver/s3store/history_archiver_off.go
@@ -1,0 +1,10 @@
+//go:build disable_cloud_archival
+
+package s3store
+
+import "go.temporal.io/server/common/archiver"
+
+// NewHistoryArchiver creates a new gcloud storage HistoryArchiver
+func NewHistoryArchiver(...any) (archiver.HistoryArchiver, error) {
+	panic("cloud archival is disabled via build tag `disable_cloud_archival`")
+}

--- a/common/archiver/s3store/history_archiver_on.go
+++ b/common/archiver/s3store/history_archiver_on.go
@@ -1,0 +1,21 @@
+//go:build !disable_cloud_archival
+
+package s3store
+
+import (
+	"go.temporal.io/server/common/archiver"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+)
+
+// NewHistoryArchiver creates a new archiver.HistoryArchiver based on s3
+func NewHistoryArchiver(
+	executionManager persistence.ExecutionManager,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
+	cfg *config.S3Archiver,
+) (archiver.HistoryArchiver, error) {
+	return newHistoryArchiver(executionManager, logger, metricsHandler, cfg, nil)
+}

--- a/common/archiver/s3store/visibility_archiver.go
+++ b/common/archiver/s3store/visibility_archiver.go
@@ -52,15 +52,6 @@ const (
 	primaryIndexKeyWorkflowID       = "workflowID"
 )
 
-// NewVisibilityArchiver creates a new archiver.VisibilityArchiver based on s3
-func NewVisibilityArchiver(
-	logger log.Logger,
-	metricsHandler metrics.Handler,
-	config *config.S3Archiver,
-) (archiver.VisibilityArchiver, error) {
-	return newVisibilityArchiver(logger, metricsHandler, config)
-}
-
 func newVisibilityArchiver(
 	logger log.Logger,
 	metricsHandler metrics.Handler,

--- a/common/archiver/s3store/visibility_archiver_off.go
+++ b/common/archiver/s3store/visibility_archiver_off.go
@@ -1,0 +1,10 @@
+//go:build disable_cloud_archival
+
+package s3store
+
+import "go.temporal.io/server/common/archiver"
+
+// NewVisibilityArchiver creates a new archiver.VisibilityArchiver based on filestore
+func NewVisibilityArchiver(...any) (archiver.VisibilityArchiver, error) {
+	panic("cloud archival is disabled via build tag `disable_cloud_archival`")
+}

--- a/common/archiver/s3store/visibility_archiver_on.go
+++ b/common/archiver/s3store/visibility_archiver_on.go
@@ -1,0 +1,19 @@
+//go:build !disable_cloud_archival
+
+package s3store
+
+import (
+	"go.temporal.io/server/common/archiver"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+)
+
+// NewVisibilityArchiver creates a new archiver.VisibilityArchiver based on s3
+func NewVisibilityArchiver(
+	logger log.Logger,
+	metricsHandler metrics.Handler,
+	cfg *config.S3Archiver,
+) (archiver.VisibilityArchiver, error) {
+	return newVisibilityArchiver(logger, metricsHandler, cfg)
+}


### PR DESCRIPTION
## What changed?

Added a build tag to exclude cloud archiver providers. The filesystem one is unaffected (as it is needed for tests).

## Why?

Reduce binary size by 24MB for when cloud archiver providers are not needed.



**Before** (without `disable_grpc_modules`)

```
-rwxr-xr-x@ 1 stephan  staff   119M Jun 30 16:35 temporal-server
```

**After**

```
-rwxr-xr-x@ 1 stephan  staff    95M Jun 30 16:23 temporal-server
```
