### PR TITLE
[CHASM] Perform access validation in Node.Get

### DIFF
--- a/chasm/component.go
+++ b/chasm/component.go
@@ -110,7 +110,7 @@ func newContextWithOperationIntent(
 func operationIntentFromContext(
 	ctx context.Context,
 ) OperationIntent {
-	intent, ok := ctx.Value(engineCtxKey).(OperationIntent)
+	intent, ok := ctx.Value(operationIntentCtxKey).(OperationIntent)
 	if !ok {
 		return OperationIntentUnspecified
 	}


### PR DESCRIPTION
Still in draft for:
- Detached/newly-created nodes
- Setting OperationIntent from side effect tasks

## What changed?
- Adds `validateAccess` to `chasm.Node` which performs the access rule check

## Why?
- Prevents writes to closed CHASM trees

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
