### PR TITLE
Extract fairness key from activity ID

### DIFF
--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -426,10 +426,13 @@ func (handler *workflowTaskCompletedHandler) handleCommandScheduleActivity(
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
 
 	// TODO(fairness): remove this again once the SDK allows setting the fairness key
-	const fairnessKeyPrefix = "x-temporal-internal-fairness-key-"
-	if key, ok := strings.CutPrefix(attr.GetActivityId(), fairnessKeyPrefix); ok {
-		attr.Priority = cmp.Or(attr.Priority, &commonpb.Priority{})
-		attr.Priority.FairnessKey = key
+	const fairnessKeyPrefix = "x-temporal-internal-fairness-key["
+	if after, ok := strings.CutPrefix(attr.GetActivityId(), fairnessKeyPrefix); ok {
+		if endIndex := strings.Index(after, "]"); endIndex != -1 {
+			key := after[:endIndex]
+			attr.Priority = cmp.Or(attr.Priority, &commonpb.Priority{})
+			attr.Priority.FairnessKey = key
+		}
 	}
 
 	if err := handler.validateCommandAttr(

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -426,10 +426,10 @@ func (handler *workflowTaskCompletedHandler) handleCommandScheduleActivity(
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
 
 	// TODO(fairness): remove this again once the SDK allows setting the fairness key
-	fairnessKeyPrefix := "x-temporal-internal-fairness-key-"
-	if strings.HasPrefix(attr.GetActivityId(), fairnessKeyPrefix) {
+	const fairnessKeyPrefix = "x-temporal-internal-fairness-key-"
+	if key, ok := strings.CutPrefix(attr.GetActivityId(), fairnessKeyPrefix); ok {
 		attr.Priority = cmp.Or(attr.Priority, &commonpb.Priority{})
-		attr.Priority.FairnessKey = strings.TrimPrefix(attr.GetActivityId(), fairnessKeyPrefix)
+		attr.Priority.FairnessKey = key
 	}
 
 	if err := handler.validateCommandAttr(


### PR DESCRIPTION
## What changed?

Extract fairness key from activity ID.

## Why?

For testing purposes only.

## How did you test it?
- [ ] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

It will be removed before merging to `main`; but even if it's not, the identifier was carefully chosen to minimize overlap with users'.