### PR TITLE
Handle transient namespace rename mismatch

### DIFF
--- a/common/persistence/cassandra/metadata_store.go
+++ b/common/persistence/cassandra/metadata_store.go
@@ -3,10 +3,8 @@ package cassandra
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	p "go.temporal.io/server/common/persistence"


### PR DESCRIPTION
## What changed?
As part of deleting a namespace, we rename the namespace with -deleted suffix. This rename happens in two steps. 
1. Change the mapping in namespaces_by_id table from old namespace name to new name.
2. In a batch operation, create a new namespace entry in namespaces table and delete the old entry.

When step 1 is complete and step 2 is not completed, if a client try to get this namespace details by its ID, it will not find the new entry yet. Server will return not found error in that case. This can cause issues with client. Returning unavailable in this case. This inconsistency should resolve when the second step finishes.

## Why?
Returning inconsistent data about namespace state could cause issues in clients.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None
