### PR TITLE
Fix NPE when emit duplicated replication task metrics

### DIFF
--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -289,9 +289,11 @@ func (e *ExecutableTaskImpl) emitFinishMetrics(
 	now time.Time,
 ) {
 	if e.isDuplicated {
-		metrics.ReplicationDuplicatedTaskCount.With(e.MetricsHandler).Record(1,
-			metrics.OperationTag(e.metricsTag),
-			metrics.NamespaceTag(e.replicationTask.RawTaskInfo.NamespaceId))
+		if e.replicationTask.RawTaskInfo != nil {
+			metrics.ReplicationDuplicatedTaskCount.With(e.MetricsHandler).Record(1,
+				metrics.OperationTag(e.metricsTag),
+				metrics.NamespaceTag(e.replicationTask.RawTaskInfo.NamespaceId))
+		}
 		return
 	}
 	nsTag := metrics.NamespaceUnknownTag()


### PR DESCRIPTION
## What changed?
Fix NPE when emit duplicated replication task metrics
## Why?
To avoid npe

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
no risk.
