### PR TITLE
Fix ack level sync on unload for priBacklogManager

### DIFF
--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -264,20 +264,26 @@ func (db *taskQueueDB) updateAckLevelAndBacklogStats(subqueue int, newAckLevel i
 	db.Lock()
 	defer db.Unlock()
 
-	db.lastChange = time.Now()
 	dbQueue := db.subqueues[subqueue]
 	if newAckLevel < dbQueue.AckLevel {
 		softassert.Fail(db.logger,
 			fmt.Sprintf("ack level in subqueue %d should not move backwards (from %v to %v)",
 				subqueue, dbQueue.AckLevel, newAckLevel))
 	}
-	dbQueue.AckLevel = newAckLevel
+	if dbQueue.AckLevel != newAckLevel {
+		db.lastChange = time.Now()
+		dbQueue.AckLevel = newAckLevel
+	}
 
 	if newAckLevel == db.getMaxReadLevelLocked(subqueue) {
 		// Reset approximateBacklogCount to fix the count divergence issue
-		dbQueue.ApproximateBacklogCount = 0
-		dbQueue.oldestTime = oldestTime
+		if dbQueue.ApproximateBacklogCount != 0 || !dbQueue.oldestTime.Equal(oldestTime) {
+			db.lastChange = time.Now()
+			dbQueue.ApproximateBacklogCount = 0
+			dbQueue.oldestTime = oldestTime
+		}
 	} else if countDelta != 0 {
+		db.lastChange = time.Now()
 		db.updateBacklogStatsLocked(subqueue, countDelta, oldestTime)
 	}
 }

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -2184,10 +2184,6 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch() {
 }
 
 func (s *matchingEngineSuite) TestTaskQueueManager_CyclingBehavior() {
-	if s.newMatcher {
-		s.T().Skip("not supported by new matcher")
-	}
-
 	config := s.newConfig()
 	dbq := newUnversionedRootQueueKey(uuid.New(), "makeToast", enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 


### PR DESCRIPTION
## What changed?

Classic backlog manager synced ack level from taskReader on unload, not just the copy in taskQueueDB. This fixes priBacklogManager to sync from priTaskReader also.

Also be more careful about updating lastChange in updateAckLevelAndBacklogStats only when values change. This lets us be more accurate about avoiding the write on unload if it's not necessary.

## Why?

This allows a jump in ack level after a gap to be synced on unload instead of having to wait for next time.

This fixes (and reenables) the "cycling behavior" test (which shouldn't have been disabled).

## How did you test it?
- [x] covered by existing tests (newly enabled)
