### PR TITLE
Fix TestChildWorkflowInheritance_CrossTQ_NoInherit flake

### DIFF
--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -1969,7 +1969,7 @@ func (s *Versioning3Suite) setCurrentDeployment(tv *testvars.TestVars) {
 		}
 		_, err := s.FrontendClient().SetWorkerDeploymentCurrentVersion(ctx, req)
 		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) || err.Error() == workerdeployment.ErrCurrentVersionDoesNotHaveAllTaskQueues {
+		if errors.As(err, &notFound) || (err != nil && err.Error() == workerdeployment.ErrCurrentVersionDoesNotHaveAllTaskQueues) {
 			return false
 		}
 		s.NoError(err)
@@ -2022,7 +2022,7 @@ func (s *Versioning3Suite) setRampingDeployment(
 		}
 		_, err := s.FrontendClient().SetWorkerDeploymentRampingVersion(ctx, req)
 		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) || err.Error() == workerdeployment.ErrRampingVersionDoesNotHaveAllTaskQueues {
+		if errors.As(err, &notFound) || (err != nil && err.Error() == workerdeployment.ErrRampingVersionDoesNotHaveAllTaskQueues) {
 			return false
 		}
 		s.NoError(err)


### PR DESCRIPTION
## What changed?
Include "new current version does not have task queues" as a retryable error in the SetCurrentVersion eventually.

## Why?
Because eventually those task queues will arrive (in all tests that use that helper), so this fixes the flake

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)