### PR TITLE
Enable RateLimitedScheduler unconditionally

### DIFF
--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -2,10 +2,12 @@ package history
 
 import (
 	"go.temporal.io/server/client"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/telemetry"
@@ -77,22 +79,26 @@ func (f *transferQueueFactory) CreateQueue(
 
 	currentClusterName := f.ClusterMetadata.GetCurrentClusterName()
 
-	var shardScheduler = f.HostScheduler
-	if f.Config.TaskSchedulerEnableRateLimiter() {
-		shardScheduler = queues.NewRateLimitedScheduler(
-			f.HostScheduler,
-			queues.RateLimitedSchedulerOptions{
-				EnableShadowMode: f.Config.TaskSchedulerEnableRateLimiterShadowMode,
-				StartupDelay:     f.Config.TaskSchedulerRateLimiterStartupDelay,
-			},
-			currentClusterName,
-			f.NamespaceRegistry,
-			f.SchedulerRateLimiter,
-			f.TimeSource,
-			logger,
-			metricsHandler,
-		)
+	schedulerRateLimiter := f.SchedulerRateLimiter
+	shadowMode := f.Config.TaskSchedulerEnableRateLimiterShadowMode
+	if !f.Config.TaskSchedulerEnableRateLimiter() {
+		schedulerRateLimiter = quotas.NoopRequestRateLimiter
+		shadowMode = dynamicconfig.GetBoolPropertyFn(false)
 	}
+
+	shardScheduler := queues.NewRateLimitedScheduler(
+		f.HostScheduler,
+		queues.RateLimitedSchedulerOptions{
+			EnableShadowMode: shadowMode,
+			StartupDelay:     f.Config.TaskSchedulerRateLimiterStartupDelay,
+		},
+		currentClusterName,
+		f.NamespaceRegistry,
+		schedulerRateLimiter,
+		f.TimeSource,
+		logger,
+		metricsHandler,
+	)
 
 	rescheduler := queues.NewRescheduler(
 		shardScheduler,


### PR DESCRIPTION
## Summary
- always build RateLimitedScheduler for history queues
- use a noop SchedulerRateLimiter when TaskSchedulerEnableRateLimiter is disabled

## Testing
- `make unit-test` *(fails: go: -race requires cgo; enable cgo by setting CGO_ENABLED=1)*

------
https://chatgpt.com/codex/tasks/task_b_68681cd1002c8330a364e9ce815cad82