### PR TITLE
Keep subqueue ack level in sync in taskQueueDB

### DIFF
--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -213,7 +213,7 @@ func (db *taskQueueDB) updateTaskQueueLocked(ctx context.Context, incrementRange
 
 // OldUpdateState updates the queue state with the given value. This is used by old backlog
 // manager (not subqueue-enabled).
-// TODO(pro): old matcher cleanup
+// TODO(pri): old matcher cleanup
 func (db *taskQueueDB) OldUpdateState(
 	ctx context.Context,
 	ackLevel int64,
@@ -230,15 +230,12 @@ func (db *taskQueueDB) OldUpdateState(
 		db.subqueues[subqueueZero].oldestTime = time.Time{} // zero time means no backlog
 	}
 
-	queueInfo := db.cachedQueueInfo()
-	queueInfo.AckLevel = ackLevel
-	_, err := db.store.UpdateTaskQueue(ctx, &persistence.UpdateTaskQueueRequest{
-		RangeID:       db.rangeID,
-		TaskQueueInfo: queueInfo,
-		PrevRangeID:   db.rangeID,
-	})
-	if err == nil {
-		db.subqueues[subqueueZero].AckLevel = ackLevel
+	prevAckLevel := db.subqueues[subqueueZero].AckLevel
+	db.subqueues[subqueueZero].AckLevel = ackLevel
+
+	err := db.updateTaskQueueLocked(ctx, false)
+	if err != nil {
+		db.subqueues[subqueueZero].AckLevel = prevAckLevel
 	}
 	db.emitBacklogGaugesLocked()
 	return err


### PR DESCRIPTION
## What changed?
When updating ack level for the classic backlog manager, keep the ack level of subqueue zero in sync with the old top-level AckLevel field (used for backwards compatibility).

## Why?
The periodic sync and sync on unload would previously write the backwards-compatible field, but would only update subqueue zero in memory, to be written on the _next_ update. This made the sync on unload partially ineffective and could lead to needing to scan large ranges on queue reload.

## How did you test it?
- [x] run locally and tested manually
- [x] covered by existing tests

Testing note: This behavior regressed in #7372, but the test that was supposed to catch the regression, `TestTaskQueueManager_CyclingBehavior`, didn't catch it because the test framework had other bugs. Those bugs are being fixed separately in #8016 so this one is easier to cherry-pick.