### PR TITLE
testTaskManager and matching engine test improvements

### DIFF
--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -552,6 +552,7 @@ func (db *taskQueueDB) ensureDefaultSubqueuesLocked(
 func (db *taskQueueDB) newSubqueueLocked(key *persistencespb.SubqueueKey) *dbSubqueue {
 	// start ack level + max read level just before the current block
 	initAckLevel := rangeIDToTaskIDBlock(db.rangeID, db.config.RangeSize).start - 1
+	softassert.That(db.logger, initAckLevel >= 0, "initAckLevel should not be negative")
 
 	s := &dbSubqueue{maxReadLevel: initAckLevel}
 	s.Key = key

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -328,7 +329,7 @@ func (s *matchingEngineSuite) PollForTasksEmptyResultTest(callContext context.Co
 		s.NotEmpty(descResp.DescResponse.Pollers[0].GetLastAccessTime())
 		s.Nil(descResp.DescResponse.GetTaskQueueStatus())
 	}
-	s.EqualValues(1, s.taskManager.getQueueManagerByKey(tlID).RangeID())
+	s.EqualValues(1, s.taskManager.getQueueDataByKey(tlID).RangeID())
 }
 
 func (s *matchingEngineSuite) TestOnlyUnloadMatchingInstance() {
@@ -602,7 +603,7 @@ func (s *matchingEngineSuite) TestPollActivityTaskQueues_InternalError() {
 	// add an activity task
 	_, _, err := s.matchingEngine.AddActivityTask(context.Background(), &addRequest)
 	s.NoError(err)
-	s.EqualValues(s.taskManager.getTaskCount(newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)), 1)
+	s.EqualValues(1, s.taskManager.getTaskCount(newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)))
 
 	// task is dropped with no retry; RecordActivityTaskStarted should only be called once
 	s.mockHistoryClient.EXPECT().RecordActivityTaskStarted(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -614,7 +615,7 @@ func (s *matchingEngineSuite) TestPollActivityTaskQueues_InternalError() {
 			Identity:  "identity",
 		},
 	}, metrics.NoopMetricsHandler)
-	s.EqualValues(emptyPollActivityTaskQueueResponse, resp)
+	protoassert.ProtoEqual(s.T(), emptyPollActivityTaskQueueResponse, resp)
 	s.NoError(err)
 }
 
@@ -636,7 +637,7 @@ func (s *matchingEngineSuite) TestPollActivityTaskQueues_DataLossError() {
 	// add an activity task
 	_, _, err := s.matchingEngine.AddActivityTask(context.Background(), &addRequest)
 	s.NoError(err)
-	s.EqualValues(s.taskManager.getTaskCount(newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)), 1)
+	s.EqualValues(1, s.taskManager.getTaskCount(newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)))
 
 	// task is dropped with no retry; RecordActivityTaskStarted should only be called once
 	s.mockHistoryClient.EXPECT().RecordActivityTaskStarted(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -649,7 +650,7 @@ func (s *matchingEngineSuite) TestPollActivityTaskQueues_DataLossError() {
 			Identity:  "identity",
 		},
 	}, metrics.NoopMetricsHandler)
-	s.EqualValues(emptyPollActivityTaskQueueResponse, resp)
+	protoassert.ProtoEqual(s.T(), emptyPollActivityTaskQueueResponse, resp)
 	s.NoError(err)
 }
 
@@ -675,7 +676,7 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_InternalError() {
 			Identity:  "identity",
 		},
 	}, metrics.NoopMetricsHandler)
-	s.EqualValues(emptyPollWorkflowTaskQueueResponse, resp)
+	protoassert.ProtoEqual(s.T(), emptyPollWorkflowTaskQueueResponse, resp)
 	s.NoError(err)
 }
 
@@ -701,7 +702,7 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_DataLossError() {
 			Identity:  "identity",
 		},
 	}, metrics.NoopMetricsHandler)
-	s.EqualValues(emptyPollWorkflowTaskQueueResponse, resp)
+	protoassert.ProtoEqual(s.T(), emptyPollWorkflowTaskQueueResponse, resp)
 	s.NoError(err)
 }
 
@@ -858,14 +859,12 @@ func (s *matchingEngineSuite) TestAddThenConsumeActivities() {
 	workflowExecution := &commonpb.WorkflowExecution{RunId: runID, WorkflowId: workflowID}
 
 	const taskCount = 1000
-	const initialRangeID = 102
 	// TODO: Understand why publish is low when rangeSize is 3
 	const rangeSize = 30
 
 	namespaceId := uuid.New()
 	tl := "makeToast"
 	tlID := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
-	s.taskManager.getQueueManagerByKey(tlID).rangeID = initialRangeID
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
 
 	taskQueue := &taskqueuepb.TaskQueue{
@@ -961,12 +960,9 @@ func (s *matchingEngineSuite) TestAddThenConsumeActivities() {
 		i++
 	}
 	s.EqualValues(0, s.taskManager.getTaskCount(tlID))
-	expectedRange := int64(initialRangeID + taskCount/rangeSize)
-	if taskCount%rangeSize > 0 {
-		expectedRange++
-	}
+	expectedRange := int64((taskCount + 1) / rangeSize)
 	// Due to conflicts some ids are skipped and more real ranges are used.
-	s.True(expectedRange <= s.taskManager.getQueueManagerByKey(tlID).rangeID)
+	s.LessOrEqual(expectedRange, s.taskManager.getQueueDataByKey(tlID).rangeID)
 }
 
 // TODO: this unit test does not seem to belong to matchingEngine, move it to the right place
@@ -989,12 +985,9 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 	s.matchingEngine.config.AdminNamespaceToPartitionDispatchRate = dynamicconfig.GetFloatPropertyFnFilteredByNamespace(25000)
 	s.matchingEngine.config.AdminNamespaceTaskqueueToPartitionDispatchRate = dynamicconfig.GetFloatPropertyFnFilteredByTaskQueue(25000)
 
-	const initialRangeID = 102
 	namespaceId := uuid.New()
 	tl := "makeToast"
 	dbq := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
-	s.taskManager.getQueueManagerByKey(dbq).rangeID = initialRangeID
-
 	mgr := s.newPartitionManager(dbq.partition, s.matchingEngine.config)
 
 	s.matchingEngine.updateTaskQueue(dbq.partition, mgr)
@@ -1120,12 +1113,9 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 
 	syncCtr := scope.Snapshot().Counters()["test.sync_throttle_count+namespace="+matchingTestNamespace+",operation=TaskQueueMgr,partition=0,service_name=matching,task_type=Activity,taskqueue=makeToast,worker-build-id=__unversioned__"]
 	s.Equal(1, int(syncCtr.Value())) // Check times zero rps is set = throttle counter
-	expectedRange := int64(initialRangeID + taskCount/30)
-	if taskCount%30 > 0 {
-		expectedRange++
-	}
+	expectedRange := int64((taskCount + 1) / 30)
 	// Due to conflicts some ids are skipped and more real ranges are used.
-	s.True(expectedRange <= s.taskManager.getQueueManagerByKey(dbq).rangeID)
+	s.LessOrEqual(expectedRange, s.taskManager.getQueueDataByKey(dbq).rangeID)
 
 	// check the poller information
 	tlType := enumspb.TASK_QUEUE_TYPE_ACTIVITY
@@ -1144,7 +1134,7 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 	s.Equal(defaultTaskDispatchRPS, descResp.DescResponse.Pollers[0].GetRatePerSecond())
 	s.NotNil(descResp.DescResponse.GetTaskQueueStatus())
 	numPartitions := float64(s.matchingEngine.config.NumTaskqueueWritePartitions("", "", tlType))
-	s.True(descResp.DescResponse.GetTaskQueueStatus().GetRatePerSecond()*numPartitions >= (defaultTaskDispatchRPS - 1))
+	s.GreaterOrEqual(descResp.DescResponse.GetTaskQueueStatus().GetRatePerSecond()*numPartitions, (defaultTaskDispatchRPS - 1))
 }
 
 func (s *matchingEngineSuite) TestRateLimiterAcrossVersionedQueues() {
@@ -1175,7 +1165,6 @@ func (s *matchingEngineSuite) TestRateLimiterAcrossVersionedQueues() {
 
 	tl := "makeToast"
 	dbq := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
-	s.taskManager.getQueueManagerByKey(dbq).rangeID = initialRangeID
 
 	runID := uuid.NewRandom().String()
 	workflowID := "workflow1"
@@ -1365,7 +1354,7 @@ func (s *matchingEngineSuite) TestConcurrentPublishConsumeActivitiesWithZeroDisp
 	s.logger.Info("Number of tasks throttled", tag.Number(throttleCt))
 	// atleast once from 0 dispatch poll, and until TTL is hit at which time throttle limit is reset
 	// hard to predict exactly how many times, since the atomic.Value load might not have updated.
-	s.True(throttleCt >= 1)
+	s.GreaterOrEqual(throttleCt, 1)
 }
 
 func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
@@ -1381,7 +1370,6 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 	workflowID := "workflow1"
 	workflowExecution := &commonpb.WorkflowExecution{RunId: runID, WorkflowId: workflowID}
 
-	const initialRangeID = 0
 	const rangeSize = 3
 	var scheduledEventID int64 = 123
 	namespaceId := uuid.New()
@@ -1389,7 +1377,6 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 	dbq := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
 
-	s.taskManager.getQueueManagerByKey(dbq).rangeID = initialRangeID
 	mgr := s.newPartitionManager(dbq.partition, s.matchingEngine.config)
 	s.matchingEngine.updateTaskQueue(dbq.partition, mgr)
 	mgr.Start()
@@ -1491,8 +1478,7 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 				}
 				resultToken, err := s.matchingEngine.tokenSerializer.Deserialize(result.TaskToken)
 				s.NoError(err)
-
-				s.EqualValues(taskToken, resultToken, fmt.Sprintf("%v!=%v", taskToken, resultToken))
+				protoassert.ProtoEqual(s.T(), taskToken, resultToken)
 				i++
 			}
 		}(p)
@@ -1501,12 +1487,9 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 	totalTasks := int(taskCount) * workerCount
 	persisted := s.taskManager.getCreateTaskCount(dbq)
 	s.True(persisted < totalTasks)
-	expectedRange := int64(initialRangeID + persisted/rangeSize)
-	if persisted%rangeSize > 0 {
-		expectedRange++
-	}
+	expectedRange := int64((persisted + 1) / rangeSize)
 	// Due to conflicts some ids are skipped and more real ranges are used.
-	s.True(expectedRange <= s.taskManager.getQueueManagerByKey(dbq).rangeID)
+	s.LessOrEqual(expectedRange, s.taskManager.getQueueDataByKey(dbq).rangeID)
 	s.EqualValues(0, s.taskManager.getTaskCount(dbq))
 
 	syncCtr := scope.Snapshot().Counters()["test.sync_throttle_count+namespace="+matchingTestNamespace+",operation=TaskQueueMgr,taskqueue=makeToast"]
@@ -1532,7 +1515,6 @@ func (s *matchingEngineSuite) TestConcurrentPublishConsumeWorkflowTasks() {
 
 	const workerCount = 20
 	const taskCount = 100
-	const initialRangeID = 0
 	const rangeSize = 5
 	var scheduledEventID int64 = 123
 	var startedEventID int64 = 1412
@@ -1540,7 +1522,6 @@ func (s *matchingEngineSuite) TestConcurrentPublishConsumeWorkflowTasks() {
 	namespaceId := uuid.New()
 	tl := "makeToast"
 	tlID := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
-	s.taskManager.getQueueManagerByKey(tlID).rangeID = initialRangeID
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
 
 	taskQueue := &taskqueuepb.TaskQueue{
@@ -1623,8 +1604,7 @@ func (s *matchingEngineSuite) TestConcurrentPublishConsumeWorkflowTasks() {
 				if err != nil {
 					panic(err)
 				}
-
-				s.EqualValues(taskToken, resultToken, fmt.Sprintf("%v!=%v", taskToken, resultToken))
+				protoassert.ProtoEqual(s.T(), taskToken, resultToken)
 				i++
 			}
 			wg.Done()
@@ -1635,12 +1615,9 @@ func (s *matchingEngineSuite) TestConcurrentPublishConsumeWorkflowTasks() {
 	totalTasks := taskCount * workerCount
 	persisted := s.taskManager.getCreateTaskCount(tlID)
 	s.True(persisted < totalTasks)
-	expectedRange := int64(initialRangeID + persisted/rangeSize)
-	if persisted%rangeSize > 0 {
-		expectedRange++
-	}
+	expectedRange := int64((persisted + 1) / rangeSize)
 	// Due to conflicts some ids are skipped and more real ranges are used.
-	s.True(expectedRange <= s.taskManager.getQueueManagerByKey(tlID).rangeID)
+	s.LessOrEqual(expectedRange, s.taskManager.getQueueDataByKey(tlID).rangeID)
 }
 
 func (s *matchingEngineSuite) TestPollWithExpiredContext() {
@@ -1741,14 +1718,12 @@ func (s *matchingEngineSuite) TestMultipleEnginesActivitiesRangeStealing() {
 	const engineCount = 2
 	const taskCount = 400
 	const iterations = 2
-	const initialRangeID = 0
 	const rangeSize = 10
 	var scheduledEventID int64 = 123
 
 	namespaceId := uuid.New()
 	tl := "makeToast"
 	tlID := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
-	s.taskManager.getQueueManagerByKey(tlID).rangeID = initialRangeID
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
 
 	taskQueue := &taskqueuepb.TaskQueue{
@@ -1868,7 +1843,7 @@ func (s *matchingEngineSuite) TestMultipleEnginesActivitiesRangeStealing() {
 
 				// we don't know the expected scheduledEventID for the task polled, so just set it to the result
 				taskToken.ScheduledEventId = resultToken.ScheduledEventId
-				s.EqualValues(taskToken, resultToken, fmt.Sprintf("%v!=%v", taskToken, resultToken))
+				protoassert.ProtoEqual(s.T(), taskToken, resultToken)
 				i++
 			}
 		}
@@ -1883,12 +1858,9 @@ func (s *matchingEngineSuite) TestMultipleEnginesActivitiesRangeStealing() {
 	persisted := s.taskManager.getCreateTaskCount(tlID)
 	// No sync matching as all messages are published first
 	s.EqualValues(totalTasks, persisted)
-	expectedRange := int64(initialRangeID + persisted/rangeSize)
-	if persisted%rangeSize > 0 {
-		expectedRange++
-	}
+	expectedRange := int64((persisted + 1) / rangeSize)
 	// Due to conflicts some ids are skipped and more real ranges are used.
-	s.True(expectedRange <= s.taskManager.getQueueManagerByKey(tlID).rangeID)
+	s.LessOrEqual(expectedRange, s.taskManager.getQueueDataByKey(tlID).rangeID)
 }
 
 func (s *matchingEngineSuite) TestMultipleEnginesWorkflowTasksRangeStealing() {
@@ -1902,14 +1874,12 @@ func (s *matchingEngineSuite) TestMultipleEnginesWorkflowTasksRangeStealing() {
 	const engineCount = 2
 	const taskCount = 400
 	const iterations = 2
-	const initialRangeID = 0
 	const rangeSize = 10
 	var scheduledEventID int64 = 123
 
 	namespaceId := uuid.New()
 	tl := "makeToast"
 	tlID := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
-	s.taskManager.getQueueManagerByKey(tlID).rangeID = initialRangeID
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
 
 	taskQueue := &taskqueuepb.TaskQueue{
@@ -2017,7 +1987,7 @@ func (s *matchingEngineSuite) TestMultipleEnginesWorkflowTasksRangeStealing() {
 
 				// we don't know the expected scheduledEventID for the task polled, so just set it to the result
 				taskToken.ScheduledEventId = resultToken.ScheduledEventId
-				s.EqualValues(taskToken, resultToken, fmt.Sprintf("%v!=%v", taskToken, resultToken))
+				protoassert.ProtoEqual(s.T(), taskToken, resultToken)
 				i++
 			}
 		}
@@ -2032,12 +2002,9 @@ func (s *matchingEngineSuite) TestMultipleEnginesWorkflowTasksRangeStealing() {
 	persisted := s.taskManager.getCreateTaskCount(tlID)
 	// No sync matching as all messages are published first
 	s.EqualValues(totalTasks, persisted)
-	expectedRange := int64(initialRangeID + persisted/rangeSize)
-	if persisted%rangeSize > 0 {
-		expectedRange++
-	}
+	expectedRange := int64((persisted + 1) / rangeSize)
 	// Due to conflicts some ids are skipped and more real ranges are used.
-	s.True(expectedRange <= s.taskManager.getQueueManagerByKey(tlID).rangeID)
+	s.LessOrEqual(expectedRange, s.taskManager.getQueueDataByKey(tlID).rangeID)
 }
 
 func (s *matchingEngineSuite) TestAddTaskAfterStartFailure() {
@@ -3232,7 +3199,7 @@ func (s *matchingEngineSuite) addConsumeAllWorkflowTasksNonConcurrently(taskCoun
 
 	// Extract the pgMgr for validating approximateBacklogCounter
 	pgMgr := s.getPhysicalTaskQueueManagerImpl(ptq)
-	s.EqualValues(int64(taskCount*numWorkers), pgMgr.backlogMgr.TotalApproximateBacklogCount())
+	s.EqualValues(taskCount*numWorkers, pgMgr.backlogMgr.TotalApproximateBacklogCount())
 
 	s.pollWorkflowTasks(false, workflowType, numPollers, taskCount, ptq, taskQueue, nil)
 
@@ -3246,7 +3213,8 @@ func (s *matchingEngineSuite) TestAddConsumeWorkflowTasksNoDBErrors() {
 func (s *matchingEngineSuite) TestAddConsumeWorkflowTasksDBErrors() {
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.logger.Expect(testlogger.Error, "unexpected error dispatching task")
-	s.taskManager.dbRandCondFailedErr = true
+	s.taskManager.addFault("CreateTasks", "ConditionFailed", 0.1)
+	s.taskManager.addFault("GetTasks", "Unavailable", 0.1)
 
 	s.addConsumeAllWorkflowTasksNonConcurrently(100, 1, 1)
 }
@@ -3258,7 +3226,8 @@ func (s *matchingEngineSuite) TestMultipleWorkersAddConsumeWorkflowTasksNoDBErro
 func (s *matchingEngineSuite) TestMultipleWorkersAddConsumeWorkflowTasksDBErrors() {
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.logger.Expect(testlogger.Error, "unexpected error dispatching task")
-	s.taskManager.dbRandCondFailedErr = true
+	s.taskManager.addFault("CreateTasks", "ConditionFailed", 0.1)
+	s.taskManager.addFault("GetTasks", "Unavailable", 0.1)
 
 	s.addConsumeAllWorkflowTasksNonConcurrently(100, 5, 5)
 }
@@ -3336,11 +3305,12 @@ func (s *matchingEngineSuite) TestResetBacklogCounterNoDBErrors() {
 
 func (s *matchingEngineSuite) TestResetBacklogCounterDBErrors() {
 	if s.newMatcher {
-		s.T().Skip("not supported by new matcher")
+		s.T().Skip("test is flaky with new matcher")
 	}
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.logger.Expect(testlogger.Error, "unexpected error dispatching task")
-	s.taskManager.dbRandCondFailedErr = true
+	s.taskManager.addFault("CreateTasks", "ConditionFailed", 0.1)
+	s.taskManager.addFault("GetTasks", "Unavailable", 0.1)
 
 	s.resetBacklogCounter(2, 2, 2)
 }
@@ -3354,11 +3324,12 @@ func (s *matchingEngineSuite) TestMoreTasksResetBacklogCounterNoDBErrors() {
 
 func (s *matchingEngineSuite) TestMoreTasksResetBacklogCounterDBErrors() {
 	if s.newMatcher {
-		s.T().Skip("not supported by new matcher")
+		s.T().Skip("test is flaky with new matcher")
 	}
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.logger.Expect(testlogger.Error, "unexpected error dispatching task")
-	s.taskManager.dbRandCondFailedErr = true
+	s.taskManager.addFault("CreateTasks", "ConditionFailed", 0.1)
+	s.taskManager.addFault("GetTasks", "Unavailable", 0.1)
 
 	s.resetBacklogCounter(10, 50, 5)
 }
@@ -3390,7 +3361,8 @@ func (s *matchingEngineSuite) TestConcurrentAddWorkflowTasksNoDBErrors() {
 func (s *matchingEngineSuite) TestConcurrentAddWorkflowTasksDBErrors() {
 	s.T().Skip("Skipping this as the backlog counter could under-count. Fix requires making " +
 		"UpdateState an atomic operation.")
-	s.taskManager.dbRandCondFailedErr = true
+	s.taskManager.addFault("CreateTasks", "ConditionFailed", 0.1)
+	s.taskManager.addFault("GetTasks", "Unavailable", 0.1)
 
 	s.concurrentPublishAndConsumeValidateBacklogCounter(150, 100, 0)
 }
@@ -3405,7 +3377,8 @@ func (s *matchingEngineSuite) TestConcurrentAdd_PollWorkflowTasksNoDBErrors() {
 func (s *matchingEngineSuite) TestConcurrentAdd_PollWorkflowTasksDBErrors() {
 	s.T().Skip("Skipping this as the backlog counter could under-count. Fix requires making " +
 		"UpdateState an atomic operation.")
-	s.taskManager.dbRandCondFailedErr = true
+	s.taskManager.addFault("CreateTasks", "ConditionFailed", 0.1)
+	s.taskManager.addFault("GetTasks", "Unavailable", 0.1)
 
 	s.concurrentPublishAndConsumeValidateBacklogCounter(20, 100, 100)
 }
@@ -3417,7 +3390,8 @@ func (s *matchingEngineSuite) TestLesserNumberOfPollersThanTasksNoDBErrors() {
 func (s *matchingEngineSuite) TestLesserNumberOfPollersThanTasksDBErrors() {
 	s.logger.Expect(testlogger.Error, "Persistent store operation failure")
 	s.logger.Expect(testlogger.Error, "unexpected error dispatching task")
-	s.taskManager.dbRandCondFailedErr = true
+	s.taskManager.addFault("CreateTasks", "ConditionFailed", 0.1)
+	s.taskManager.addFault("GetTasks", "Unavailable", 0.1)
 
 	s.concurrentPublishAndConsumeValidateBacklogCounter(1, 500, 200)
 }
@@ -3429,7 +3403,8 @@ func (s *matchingEngineSuite) TestMultipleWorkersLesserNumberOfPollersThanTasksN
 func (s *matchingEngineSuite) TestMultipleWorkersLesserNumberOfPollersThanTasksDBErrors() {
 	s.T().Skip("Skipping this as the backlog counter could under-count. Fix requires making " +
 		"UpdateState an atomic operation.")
-	s.taskManager.dbRandCondFailedErr = true
+	s.taskManager.addFault("CreateTasks", "ConditionFailed", 0.1)
+	s.taskManager.addFault("GetTasks", "Unavailable", 0.1)
 
 	s.concurrentPublishAndConsumeValidateBacklogCounter(5, 500, 200)
 }
@@ -3486,7 +3461,7 @@ func (s *matchingEngineSuite) TestPollActivityTaskQueueWithRateLimiterError() {
 
 	_, _, err := s.matchingEngine.AddActivityTask(context.Background(), &addRequest)
 	s.NoError(err)
-	s.EqualValues(s.taskManager.getTaskCount(newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)), 1)
+	s.EqualValues(1, s.taskManager.getTaskCount(newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)))
 
 	mockRateLimiter.EXPECT().
 		Wait(gomock.Any(), gomock.Any()).
@@ -3520,7 +3495,7 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueueWithRateLimiterError() {
 
 	_, _, err := s.matchingEngine.AddWorkflowTask(context.Background(), &addRequest)
 	s.NoError(err)
-	s.EqualValues(s.taskManager.getTaskCount(newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_WORKFLOW)), 1)
+	s.EqualValues(1, s.taskManager.getTaskCount(newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_WORKFLOW)))
 
 	mockRateLimiter.EXPECT().
 		Wait(gomock.Any(), gomock.Any()).
@@ -3587,24 +3562,24 @@ func newActivityTaskScheduledEvent(eventID int64, workflowTaskCompletedEventID i
 }
 
 func newHistoryEvent(eventID int64, eventType enumspb.EventType) *historypb.HistoryEvent {
-	historyEvent := &historypb.HistoryEvent{
+	return &historypb.HistoryEvent{
 		EventId:   eventID,
 		EventTime: timestamppb.New(time.Now().UTC()),
 		EventType: eventType,
 	}
-
-	return historyEvent
 }
 
 var _ persistence.TaskManager = (*testTaskManager)(nil) // Asserts that interface is indeed implemented
 
 type testTaskManager struct {
 	sync.Mutex
-	queues              map[dbTaskQueueKey]*testPhysicalTaskQueueManager
-	logger              log.Logger
-	dbServiceError      bool
-	dbCondFailedErr     bool
-	dbRandCondFailedErr bool
+	queues map[dbTaskQueueKey]*testQueueData
+	logger log.Logger
+
+	// TODO: run some tests with this and without
+	updateMetadataOnCreateTasks bool
+
+	faultInjection map[string]float32 // "op:error" -> fraction of time
 }
 
 type dbTaskQueueKey struct {
@@ -3614,7 +3589,11 @@ type dbTaskQueueKey struct {
 }
 
 func newTestTaskManager(logger log.Logger) *testTaskManager {
-	return &testTaskManager{queues: make(map[dbTaskQueueKey]*testPhysicalTaskQueueManager), logger: logger}
+	return &testTaskManager{
+		queues:                      make(map[dbTaskQueueKey]*testQueueData),
+		logger:                      logger,
+		updateMetadataOnCreateTasks: true,
+	}
 }
 
 func (m *testTaskManager) GetName() string {
@@ -3624,21 +3603,20 @@ func (m *testTaskManager) GetName() string {
 func (m *testTaskManager) Close() {
 }
 
-func (m *testTaskManager) getQueueManagerByKey(dbq *PhysicalTaskQueueKey) *testPhysicalTaskQueueManager {
-	return m.getQueueManager(dbq.PersistenceName(), dbq.NamespaceId(), dbq.TaskType())
+func (m *testTaskManager) getQueueDataByKey(dbq *PhysicalTaskQueueKey) *testQueueData {
+	return m.getQueueData(dbq.PersistenceName(), dbq.NamespaceId(), dbq.TaskType())
 }
 
-func (m *testTaskManager) getQueueManager(name, namespaceId string, taskType enumspb.TaskQueueType) *testPhysicalTaskQueueManager {
+func (m *testTaskManager) getQueueData(name, namespaceId string, taskType enumspb.TaskQueueType) *testQueueData {
 	key := dbTaskQueueKey{persistenceName: name, namespaceId: namespaceId, taskType: taskType}
 	m.Lock()
 	defer m.Unlock()
-	result, ok := m.queues[key]
-	if ok {
-		return result
+	if queue, ok := m.queues[key]; ok {
+		return queue
 	}
-	result = newTestTaskQueueManager()
-	m.queues[key] = result
-	return result
+	queue := newTestQueueData()
+	m.queues[key] = queue
+	return queue
 }
 
 func newUnversionedRootQueueKey(namespaceId string, name string, taskType enumspb.TaskQueueType) *PhysicalTaskQueueKey {
@@ -3657,28 +3635,38 @@ func newTestTaskQueue(namespaceId string, name string, taskType enumspb.TaskQueu
 	return result.TaskQueue(taskType)
 }
 
-type testPhysicalTaskQueueManager struct {
+type testQueueData struct {
 	sync.Mutex
-	queue                   *PhysicalTaskQueueKey
-	rangeID                 int64
-	ackLevel                int64
-	ApproximateBacklogCount int64
-	createTaskCount         int
-	getTasksCount           int
-	getUserDataCount        int
-	updateCount             int
-	tasks                   *treemap.Map
-	userData                *persistencespb.VersionedTaskQueueUserData
+	rangeID  int64
+	info     *persistencespb.TaskQueueInfo
+	tasks    treemap.Map
+	userData *persistencespb.VersionedTaskQueueUserData
+
+	createTaskCount  int
+	getTasksCount    int
+	getUserDataCount int
+	updateCount      int
 }
 
-func newTestTaskQueueManager() *testPhysicalTaskQueueManager {
-	return &testPhysicalTaskQueueManager{tasks: treemap.NewWith(godsutils.Int64Comparator)}
+func newTestQueueData() *testQueueData {
+	return &testQueueData{tasks: *treemap.NewWith(godsutils.Int64Comparator)}
 }
 
-func (m *testPhysicalTaskQueueManager) RangeID() int64 {
-	m.Lock()
-	defer m.Unlock()
-	return m.rangeID
+func (q *testQueueData) String() string {
+	var out strings.Builder
+	q.Lock()
+	defer q.Unlock()
+	fmt.Fprintf(&out, "<task queue ")
+	fmt.Fprintf(&out, "rangeID: %d ", q.rangeID)
+	fmt.Fprintf(&out, "info: %s ", q.info.String())
+	fmt.Fprintf(&out, "tasks: %d>", q.tasks.Size())
+	return out.String()
+}
+
+func (q *testQueueData) RangeID() int64 {
+	q.Lock()
+	defer q.Unlock()
+	return q.rangeID
 }
 
 func (m *testTaskManager) CreateTaskQueue(
@@ -3686,7 +3674,7 @@ func (m *testTaskManager) CreateTaskQueue(
 	request *persistence.CreateTaskQueueRequest,
 ) (*persistence.CreateTaskQueueResponse, error) {
 	tli := request.TaskQueueInfo
-	tlm := m.getQueueManager(tli.Name, tli.NamespaceId, tli.TaskType)
+	tlm := m.getQueueData(tli.Name, tli.NamespaceId, tli.TaskType)
 	tlm.Lock()
 	defer tlm.Unlock()
 
@@ -3695,9 +3683,8 @@ func (m *testTaskManager) CreateTaskQueue(
 			Msg: fmt.Sprintf("Failed to create task queue: name=%v, type=%v", tli.Name, tli.TaskType),
 		}
 	}
-
 	tlm.rangeID = request.RangeID
-	tlm.ackLevel = tli.AckLevel
+	tlm.info = common.CloneProto(tli)
 	return &persistence.CreateTaskQueueResponse{}, nil
 }
 
@@ -3706,9 +3693,10 @@ func (m *testTaskManager) UpdateTaskQueue(
 	request *persistence.UpdateTaskQueueRequest,
 ) (*persistence.UpdateTaskQueueResponse, error) {
 	tli := request.TaskQueueInfo
-	tlm := m.getQueueManager(tli.Name, tli.NamespaceId, tli.TaskType)
+	tlm := m.getQueueData(tli.Name, tli.NamespaceId, tli.TaskType)
 	tlm.Lock()
 	defer tlm.Unlock()
+
 	tlm.updateCount++
 
 	if tlm.rangeID != request.PrevRangeID {
@@ -3716,9 +3704,8 @@ func (m *testTaskManager) UpdateTaskQueue(
 			Msg: fmt.Sprintf("Failed to update task queue: name=%v, type=%v", tli.Name, tli.TaskType),
 		}
 	}
-	tlm.ackLevel = tli.AckLevel
-	tlm.ApproximateBacklogCount = tli.ApproximateBacklogCount
 	tlm.rangeID = request.RangeID
+	tlm.info = common.CloneProto(tli)
 	return &persistence.UpdateTaskQueueResponse{}, nil
 }
 
@@ -3726,7 +3713,7 @@ func (m *testTaskManager) GetTaskQueue(
 	_ context.Context,
 	request *persistence.GetTaskQueueRequest,
 ) (*persistence.GetTaskQueueResponse, error) {
-	tlm := m.getQueueManager(request.TaskQueue, request.NamespaceID, request.TaskType)
+	tlm := m.getQueueData(request.TaskQueue, request.NamespaceID, request.TaskType)
 	tlm.Lock()
 	defer tlm.Unlock()
 
@@ -3734,23 +3721,14 @@ func (m *testTaskManager) GetTaskQueue(
 		return nil, serviceerror.NewNotFound("task queue not found")
 	}
 	return &persistence.GetTaskQueueResponse{
-		TaskQueueInfo: &persistencespb.TaskQueueInfo{
-			NamespaceId:             request.NamespaceID,
-			Name:                    request.TaskQueue,
-			TaskType:                request.TaskType,
-			Kind:                    enumspb.TASK_QUEUE_KIND_NORMAL,
-			AckLevel:                tlm.ackLevel,
-			ExpiryTime:              nil,
-			LastUpdateTime:          timestamp.TimeNowPtrUtc(),
-			ApproximateBacklogCount: tlm.ApproximateBacklogCount,
-		},
-		RangeID: tlm.rangeID,
+		RangeID:       tlm.rangeID,
+		TaskQueueInfo: common.CloneProto(tlm.info),
 	}, nil
 }
 
 // minTaskID returns the minimum value of the TaskID present in testTaskManager
 func (m *testTaskManager) minTaskID(dbq *PhysicalTaskQueueKey) (int64, bool) {
-	tlm := m.getQueueManagerByKey(dbq)
+	tlm := m.getQueueDataByKey(dbq)
 	tlm.Lock()
 	defer tlm.Unlock()
 	minKey, _ := tlm.tasks.Min()
@@ -3760,7 +3738,7 @@ func (m *testTaskManager) minTaskID(dbq *PhysicalTaskQueueKey) (int64, bool) {
 
 // maxTaskID returns the maximum value of the TaskID present in testTaskManager
 func (m *testTaskManager) maxTaskID(dbq *PhysicalTaskQueueKey) (int64, bool) {
-	tlm := m.getQueueManagerByKey(dbq)
+	tlm := m.getQueueDataByKey(dbq)
 	tlm.Lock()
 	defer tlm.Unlock()
 	maxKey, _ := tlm.tasks.Max()
@@ -3772,7 +3750,7 @@ func (m *testTaskManager) CompleteTasksLessThan(
 	_ context.Context,
 	request *persistence.CompleteTasksLessThanRequest,
 ) (int, error) {
-	tlm := m.getQueueManager(request.TaskQueueName, request.NamespaceID, request.TaskType)
+	tlm := m.getQueueData(request.TaskQueueName, request.NamespaceID, request.TaskType)
 	tlm.Lock()
 	defer tlm.Unlock()
 	keys := tlm.tasks.Keys()
@@ -3803,18 +3781,16 @@ func (m *testTaskManager) DeleteTaskQueue(
 	return nil
 }
 
-// generateErrorRandomly states if a taskManager's operation should return an error or not
-func (m *testTaskManager) generateErrorRandomly() bool {
-	if m.dbRandCondFailedErr {
-		threshold := 10
-
-		// Generate a random number between 0 and 99
-		randomNumber := rand.Intn(100)
-		if randomNumber < threshold {
-			return true
-		}
+// all calls to addFault should be done before starting to call methods on testTaskManager
+func (m *testTaskManager) addFault(method, err string, fraction float32) {
+	if m.faultInjection == nil {
+		m.faultInjection = make(map[string]float32)
 	}
-	return false
+	m.faultInjection[method+":"+err] = fraction
+}
+
+func (m *testTaskManager) fault(method, err string) bool {
+	return rand.Float32() < m.faultInjection[method+":"+err]
 }
 
 func (m *testTaskManager) CreateTasks(
@@ -3826,21 +3802,25 @@ func (m *testTaskManager) CreateTasks(
 	taskType := request.TaskQueueInfo.Data.TaskType
 	rangeID := request.TaskQueueInfo.RangeID
 
-	// Randomly returns a ConditionFailedError
-	if m.generateErrorRandomly() || m.dbCondFailedErr {
+	if m.fault("CreateTasks", "ConditionFailed") {
 		return nil, &persistence.ConditionFailedError{
 			Msg: fmt.Sprintf("Failed to create task. TaskQueue: %v, taskQueueType: %v, rangeID: %v, db rangeID: %v",
 				taskQueue, taskType, rangeID, rangeID),
 		}
-	}
-
-	if m.dbServiceError {
+	} else if m.fault("CreateTasks", "Unavailable") {
 		return nil, serviceerror.NewUnavailablef("CreateTasks operation failed during serialization. Error : %v", errors.New("failure"))
 	}
 
-	tlm := m.getQueueManager(taskQueue, namespaceId, taskType)
+	tlm := m.getQueueData(taskQueue, namespaceId, taskType)
 	tlm.Lock()
 	defer tlm.Unlock()
+
+	if tlm.rangeID != rangeID {
+		return nil, &persistence.ConditionFailedError{
+			Msg: fmt.Sprintf("Failed to create task. TaskQueue: %v, taskQueueType: %v, rangeID: %v, db rangeID: %v",
+				taskQueue, taskType, rangeID, tlm.rangeID),
+		}
+	}
 
 	// First validate the entire batch
 	for _, task := range request.Tasks {
@@ -3868,10 +3848,14 @@ func (m *testTaskManager) CreateTasks(
 	for _, task := range request.Tasks {
 		tlm.tasks.Put(task.GetTaskId(), common.CloneProto(task))
 		tlm.createTaskCount++
-		tlm.ApproximateBacklogCount++
 	}
 
-	return &persistence.CreateTasksResponse{}, nil
+	resp := &persistence.CreateTasksResponse{}
+	if m.updateMetadataOnCreateTasks {
+		tlm.info = common.CloneProto(request.TaskQueueInfo.Data)
+		resp.UpdatedMetadata = true
+	}
+	return resp, nil
 }
 
 func (m *testTaskManager) GetTasks(
@@ -3880,11 +3864,11 @@ func (m *testTaskManager) GetTasks(
 ) (*persistence.GetTasksResponse, error) {
 	m.logger.Debug("testTaskManager.GetTasks", tag.Value(request))
 
-	if m.generateErrorRandomly() {
+	if m.fault("GetTasks", "Unavailable") {
 		return nil, serviceerror.NewUnavailablef("GetTasks operation failed")
 	}
 
-	tlm := m.getQueueManager(request.TaskQueue, request.NamespaceID, request.TaskType)
+	tlm := m.getQueueData(request.TaskQueue, request.NamespaceID, request.TaskType)
 	tlm.Lock()
 	defer tlm.Unlock()
 	var tasks []*persistencespb.AllocatedTaskInfo
@@ -3906,7 +3890,7 @@ func (m *testTaskManager) GetTasks(
 
 // getTaskCount returns number of tasks in a task queue
 func (m *testTaskManager) getTaskCount(q *PhysicalTaskQueueKey) int {
-	tlm := m.getQueueManagerByKey(q)
+	tlm := m.getQueueDataByKey(q)
 	tlm.Lock()
 	defer tlm.Unlock()
 	return tlm.tasks.Size()
@@ -3914,7 +3898,7 @@ func (m *testTaskManager) getTaskCount(q *PhysicalTaskQueueKey) int {
 
 // getCreateTaskCount returns how many times CreateTask was called
 func (m *testTaskManager) getCreateTaskCount(q *PhysicalTaskQueueKey) int {
-	tlm := m.getQueueManagerByKey(q)
+	tlm := m.getQueueDataByKey(q)
 	tlm.Lock()
 	defer tlm.Unlock()
 	return tlm.createTaskCount
@@ -3922,7 +3906,7 @@ func (m *testTaskManager) getCreateTaskCount(q *PhysicalTaskQueueKey) int {
 
 // getGetTasksCount returns how many times GetTasks was called
 func (m *testTaskManager) getGetTasksCount(q *PhysicalTaskQueueKey) int {
-	tlm := m.getQueueManagerByKey(q)
+	tlm := m.getQueueDataByKey(q)
 	tlm.Lock()
 	defer tlm.Unlock()
 	return tlm.getTasksCount
@@ -3930,7 +3914,7 @@ func (m *testTaskManager) getGetTasksCount(q *PhysicalTaskQueueKey) int {
 
 // getGetUserDataCount returns how many times GetUserData was called
 func (m *testTaskManager) getGetUserDataCount(q *PhysicalTaskQueueKey) int {
-	tlm := m.getQueueManagerByKey(q)
+	tlm := m.getQueueDataByKey(q)
 	tlm.Lock()
 	defer tlm.Unlock()
 	return tlm.getUserDataCount
@@ -3938,7 +3922,7 @@ func (m *testTaskManager) getGetUserDataCount(q *PhysicalTaskQueueKey) int {
 
 // getUpdateCount returns how many times UpdateTaskQueue was called
 func (m *testTaskManager) getUpdateCount(q *PhysicalTaskQueueKey) int {
-	tlm := m.getQueueManagerByKey(q)
+	tlm := m.getQueueDataByKey(q)
 	tlm.Lock()
 	defer tlm.Unlock()
 	return tlm.updateCount
@@ -3947,31 +3931,17 @@ func (m *testTaskManager) getUpdateCount(q *PhysicalTaskQueueKey) int {
 func (m *testTaskManager) String() string {
 	m.Lock()
 	defer m.Unlock()
-	var result string
-	for _, q := range m.queues {
-		q.Lock()
-		if q.queue.TaskType() == enumspb.TASK_QUEUE_TYPE_ACTIVITY {
-			result += "Activity"
-		} else {
-			result += "Workflow"
-		}
-		result += " task queue " + q.queue.PersistenceName()
-		result += "\n"
-		result += fmt.Sprintf("AckLevel=%v\n", q.ackLevel)
-		result += fmt.Sprintf("CreateTaskCount=%v\n", q.createTaskCount)
-		result += fmt.Sprintf("RangeID=%v\n", q.rangeID)
-		result += "Tasks=\n"
-		for _, t := range q.tasks.Values() {
-			result += fmt.Sprintf("%v\n", t)
-		}
-		q.Unlock()
+	var out strings.Builder
+	fmt.Fprintf(&out, "testTaskManager: %d queues:\n", len(m.queues))
+	for k, q := range m.queues {
+		fmt.Fprintf(&out, "  %s %s: %s\n", k.persistenceName, k.taskType, q)
 	}
-	return result
+	return out.String()
 }
 
 // GetTaskQueueData implements persistence.TaskManager
 func (m *testTaskManager) GetTaskQueueUserData(_ context.Context, request *persistence.GetTaskQueueUserDataRequest) (*persistence.GetTaskQueueUserDataResponse, error) {
-	tlm := m.getQueueManager(request.TaskQueue, request.NamespaceID, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+	tlm := m.getQueueData(request.TaskQueue, request.NamespaceID, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	tlm.Lock()
 	defer tlm.Unlock()
 	tlm.getUserDataCount++
@@ -3983,7 +3953,7 @@ func (m *testTaskManager) GetTaskQueueUserData(_ context.Context, request *persi
 // UpdateTaskQueueUserData implements persistence.TaskManager
 func (m *testTaskManager) UpdateTaskQueueUserData(_ context.Context, request *persistence.UpdateTaskQueueUserDataRequest) error {
 	for tq, update := range request.Updates {
-		tlm := m.getQueueManager(tq, request.NamespaceID, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+		tlm := m.getQueueData(tq, request.NamespaceID, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 		tlm.Lock()
 		newData := common.CloneProto(update.UserData)
 		newData.Version++

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -367,7 +367,7 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestTQMDoesNotDoFinalUpdateOnOwnersh
 	s.Equal(0, tm.getUpdateCount(s.physicalTaskQueueKey))
 
 	// simulate stolen lock
-	ptm := tm.getQueueManagerByKey(s.physicalTaskQueueKey)
+	ptm := tm.getQueueDataByKey(s.physicalTaskQueueKey)
 	ptm.Lock()
 	ptm.rangeID++
 	ptm.Unlock()


### PR DESCRIPTION
## What changed?
- Improve testTaskManager (in-memory matching persistence implementation used by unit tests) to behave closer to a real persistence implementation.
  - The main change is that task queue metadata is now stored as-is.
  - One spot where testTaskManager was messing with metadata directly is removed.
  - Add a flag for updateMetadataOnCreateTasks, default true (behave like cassandra).
- Improve fault injection to be more flexible.
- Various small unit test improvements mostly in matchingEngineSuite.
- Disable a few of the reset backlog count tests for priority backlog manager.

## Why?
- The incomplete behavior of testTaskManager was covering up some bugs (e.g. #8015), though some of it cancelled out the other parts.
- Fault injection can be used in future tests.
- The new updateMetadataOnCreateTasks flag can be used in future tests to get better coverage for SQL persistence.

## How did you test it?
Improved and ran unit tests.
