### PR TITLE
GetUserDataRetryPolicy should retry forever

### DIFF
--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -398,7 +398,7 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 				return max(1, config.ForwarderMaxChildrenPerNode(ns.String(), taskQueueName, taskType))
 			},
 		},
-		GetUserDataRetryPolicy: backoff.NewExponentialRetryPolicy(1 * time.Second).WithMaximumInterval(5 * time.Minute),
+		GetUserDataRetryPolicy: backoff.NewExponentialRetryPolicy(1 * time.Second).WithMaximumInterval(5 * time.Minute).WithExpirationInterval(backoff.NoInterval),
 		TaskQueueInfoByBuildIdTTL: func() time.Duration {
 			return config.TaskQueueInfoByBuildIdTTL(ns.String(), taskQueueName, taskType)
 		},

--- a/service/matching/user_data_manager_test.go
+++ b/service/matching/user_data_manager_test.go
@@ -459,7 +459,7 @@ func TestUserData_RetriesFetchOnUnavailable(t *testing.T) {
 	m := createUserDataManager(t, controller, tqCfg)
 	m.config.GetUserDataMinWaitTime = 10 * time.Second // wait on success
 	m.config.GetUserDataRetryPolicy = backoff.NewExponentialRetryPolicy(50 * time.Millisecond).
-		WithMaximumInterval(50 * time.Millisecond) // faster retry on failure
+		WithMaximumInterval(50 * time.Millisecond).WithExpirationInterval(backoff.NoInterval) // faster retry on failure
 
 	m.Start()
 
@@ -545,7 +545,7 @@ func TestUserData_RetriesFetchOnUnImplemented(t *testing.T) {
 	m := createUserDataManager(t, controller, tqCfg)
 	m.config.GetUserDataMinWaitTime = 10 * time.Second // wait on success
 	m.config.GetUserDataRetryPolicy = backoff.NewExponentialRetryPolicy(50 * time.Millisecond).
-		WithMaximumInterval(50 * time.Millisecond) // faster retry on failure
+		WithMaximumInterval(50 * time.Millisecond).WithExpirationInterval(backoff.NoInterval) // faster retry on failure
 
 	m.Start()
 
@@ -788,7 +788,7 @@ func TestUserData_Propagation(t *testing.T) {
 		managers[i].config.GetUserDataLongPollTimeout = dynamicconfig.GetDurationPropertyFn(100 * time.Millisecond)
 		managers[i].config.GetUserDataMinWaitTime = 10 * time.Millisecond
 		managers[i].config.GetUserDataReturnBudget = 10 * time.Millisecond
-		managers[i].config.GetUserDataRetryPolicy = backoff.NewExponentialRetryPolicy(100 * time.Millisecond).WithMaximumInterval(1 * time.Second)
+		managers[i].config.GetUserDataRetryPolicy = backoff.NewExponentialRetryPolicy(100 * time.Millisecond).WithMaximumInterval(1 * time.Second).WithExpirationInterval(backoff.NoInterval)
 		managers[i].logger = log.With(managers[i].logger, tag.HostID(fmt.Sprintf("%d", i)))
 	}
 


### PR DESCRIPTION
## What changed?
Fix GetUserDataRetryPolicy to retry forever.

## Why?
The default for retry policies is to give up after 1 minute. For the get user data loop, if we give up then we'll just retry immediately, which is fine, but on error we should follow the backoff schedule.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
