### PR TITLE
Feature branch pattern

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,8 +6,9 @@ on:
   push:
     branches:
       - main
-      - release/**
-      - cloud/**
+      - cloud/*
+      - feature/*
+      - release/*
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
-      - release/*
       - cloud/*
+      - feature/*
+      - release/*
 
 jobs:
   trigger:


### PR DESCRIPTION
## What changed?

Introduces `feature/*` as a branch pattern for running tests and publishing Docker images.

## Why?

The idea is to have a way for long-running feature branches to be tested more easily. This requires the Docker images to be published. Mixing this with the `cloud/*` or `release/*` branch pattern is not ideal as it's confusing and has problematic branch protection settings.

Follow-up work in https://github.com/temporalio/docker-builds/pull/283.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

