### PR TITLE
chore: bump the scheduler version for TriggerImmediatelyTimestamp bug

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -203,7 +203,7 @@ var (
 		ReuseTimer:                        true,
 		NextTimeCacheV2Size:               14, // see note below
 		SpecFieldLengthLimit:              10,
-		Version:                           ActionResultIncludesStatus,
+		Version:                           TriggerImmediatelyTimestamp,
 	}
 
 	// Note on NextTimeCacheV2Size: This value must be > FutureActionCountForList. Each

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1130,10 +1130,6 @@ func (s *workflowSuite) TestCompileError() {
 }
 
 func (s *workflowSuite) TestTriggerImmediate() {
-	currentVersion := CurrentTweakablePolicies.Version
-	CurrentTweakablePolicies.Version = 12
-	defer func() { CurrentTweakablePolicies.Version = currentVersion }()
-
 	s.runAcrossContinue(
 		[]workflowRun{
 			{


### PR DESCRIPTION
## What changed?
Bump the `Version` of the `TweakablePolicies` for scheduler component

## Why?
Patches bug in scheduler

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None aware of
