### PR TITLE
Matching fairness separate metrics

### DIFF
--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -197,8 +197,7 @@ func newPhysicalTaskQueueManager(
 			pqMgr.logger,
 			pqMgr.throttledLogger,
 			e.matchingRawClient,
-			// TODO(fairness): use "fair_" prefix for metrics
-			newPriMetricsHandler(taggedMetricsHandler),
+			newFairMetricsHandler(taggedMetricsHandler),
 			cntr,
 		)
 		var fwdr *priForwarder
@@ -217,7 +216,7 @@ func newPhysicalTaskQueueManager(
 			fwdr,
 			pqMgr.taskValidator,
 			pqMgr.logger,
-			newPriMetricsHandler(taggedMetricsHandler),
+			newFairMetricsHandler(taggedMetricsHandler),
 		)
 		pqMgr.matcher = pqMgr.priMatcher
 		return pqMgr, nil

--- a/service/matching/pri_metrics_handler.go
+++ b/service/matching/pri_metrics_handler.go
@@ -23,6 +23,21 @@ type (
 		name    string
 		handler metrics.Handler
 	}
+	fairMetricHandler struct {
+		handler metrics.Handler
+	}
+	fairMetricsTimer struct {
+		name    string
+		handler metrics.Handler
+	}
+	fairMetricsCounter struct {
+		name    string
+		handler metrics.Handler
+	}
+	fairMetricsGauge struct {
+		name    string
+		handler metrics.Handler
+	}
 )
 
 // TODO(pri): cleanup; delete this
@@ -76,4 +91,56 @@ func (t priMetricsGauge) Record(v float64, tag ...metrics.Tag) {
 
 func withPriPrefix(name string) string {
 	return "pri_" + name
+}
+
+func newFairMetricsHandler(handler metrics.Handler) fairMetricHandler {
+	return fairMetricHandler{
+		handler: handler,
+	}
+}
+
+func (p fairMetricHandler) Stop(logger log.Logger) {
+	p.handler.Stop(logger)
+}
+
+func (p fairMetricHandler) Counter(name string) metrics.CounterIface {
+	return fairMetricsCounter{name: name, handler: p.handler}
+}
+func (p fairMetricHandler) Timer(name string) metrics.TimerIface {
+	return fairMetricsTimer{name: name, handler: p.handler}
+}
+
+func (p fairMetricHandler) Gauge(name string) metrics.GaugeIface {
+	return fairMetricsGauge{name: name, handler: p.handler}
+}
+
+func (p fairMetricHandler) WithTags(...metrics.Tag) metrics.Handler {
+	panic("not implemented")
+}
+
+func (p fairMetricHandler) Histogram(string, metrics.MetricUnit) metrics.HistogramIface {
+	panic("not implemented")
+}
+
+func (p fairMetricHandler) StartBatch(string) metrics.BatchHandler {
+	panic("not implemented")
+}
+
+func (c fairMetricsCounter) Record(i int64, tag ...metrics.Tag) {
+	c.handler.Counter(c.name).Record(i, tag...)
+	c.handler.Counter(withFairPrefix(c.name)).Record(i, tag...)
+}
+
+func (t fairMetricsTimer) Record(duration time.Duration, tag ...metrics.Tag) {
+	t.handler.Timer(t.name).Record(duration, tag...)
+	t.handler.Timer(withFairPrefix(t.name)).Record(duration, tag...)
+}
+
+func (t fairMetricsGauge) Record(v float64, tag ...metrics.Tag) {
+	t.handler.Gauge(t.name).Record(v, tag...)
+	t.handler.Gauge(withFairPrefix(t.name)).Record(v, tag...)
+}
+
+func withFairPrefix(name string) string {
+	return "fair_" + name
 }


### PR DESCRIPTION
## What changed?
Use separate metrics for fairness backlog manager, and also for priority matcher when using fairness.

## Why?
Better understand behavior in production.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
