### PR TITLE
Scheduler: set WFID reuse policy to reject duplicates for scheduled starts

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -1315,6 +1315,13 @@ func (s *scheduler) startWorkflow(
 		continuedFailure = nil
 	}
 
+	// Reject duplicates as part of WFID reuse policy when possible, as a measure
+	// against WFT timeouts/failures that lead to non-determinism.
+	reusePolicy := enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
+	if start.Manual {
+		reusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
+	}
+
 	req := &schedulespb.StartWorkflowRequest{
 		Request: &workflowservice.StartWorkflowExecutionRequest{
 			WorkflowId:               workflowID,
@@ -1326,7 +1333,7 @@ func (s *scheduler) startWorkflow(
 			WorkflowTaskTimeout:      newWorkflow.WorkflowTaskTimeout,
 			Identity:                 s.identity(),
 			RequestId:                s.newUUIDString(),
-			WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			WorkflowIdReusePolicy:    reusePolicy,
 			RetryPolicy:              newWorkflow.RetryPolicy,
 			Memo:                     newWorkflow.Memo,
 			SearchAttributes:         s.addSearchAttributes(newWorkflow.SearchAttributes, nominalTimeSec),


### PR DESCRIPTION
## What changed?
- The WFID reuse policy within the scheduler workflow has been updated.

## Why?
- Helps avoid a situation where a runaway WFT, timed out from the history end, still manages to make the `StartWorkflowExecution` request without recording its progress.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- Reuse policy isn't ever written to the scheduler memo, nor would it affect the recorded events, so it shouldn't cause replay problems (or necessitate a version bump)
