### PR TITLE
CHASM: Prefix internal ID with archetype

### DIFF
--- a/chasm/engine.go
+++ b/chasm/engine.go
@@ -1,47 +1,8 @@
-//go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination engine_mock.go
-
 package chasm
 
 import (
 	"context"
 )
-
-type Engine interface {
-	NewEntity(
-		context.Context,
-		ComponentRef,
-		func(MutableContext) (Component, error),
-		...TransitionOption,
-	) (EntityKey, []byte, error)
-	UpdateWithNewEntity(
-		context.Context,
-		ComponentRef,
-		func(MutableContext) (Component, error),
-		func(MutableContext, Component) error,
-		...TransitionOption,
-	) (EntityKey, []byte, error)
-
-	UpdateComponent(
-		context.Context,
-		ComponentRef,
-		func(MutableContext, Component) error,
-		...TransitionOption,
-	) ([]byte, error)
-	ReadComponent(
-		context.Context,
-		ComponentRef,
-		func(Context, Component) error,
-		...TransitionOption,
-	) error
-
-	PollComponent(
-		context.Context,
-		ComponentRef,
-		func(Context, Component) (any, bool, error),
-		func(MutableContext, Component, any) error,
-		...TransitionOption,
-	) ([]byte, error)
-}
 
 type BusinessIDReusePolicy int
 
@@ -279,28 +240,4 @@ func convertComponentRef[R []byte | ComponentRef](
 
 	//revive:disable-next-line:unchecked-type-assertion
 	return any(r).(ComponentRef), nil
-}
-
-type engineCtxKeyType string
-
-const engineCtxKey engineCtxKeyType = "chasmEngine"
-
-// this will be done by the nexus handler?
-// alternatively the engine can be a global variable,
-// but not a good practice in fx.
-func NewEngineContext(
-	ctx context.Context,
-	engine Engine,
-) context.Context {
-	return context.WithValue(ctx, engineCtxKey, engine)
-}
-
-func engineFromContext(
-	ctx context.Context,
-) Engine {
-	e, ok := ctx.Value(engineCtxKey).(Engine)
-	if !ok {
-		return nil
-	}
-	return e
 }

--- a/chasm/engine_internal.go
+++ b/chasm/engine_internal.go
@@ -1,0 +1,68 @@
+//go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination engine_mock.go
+
+package chasm
+
+import "context"
+
+type Engine interface {
+	NewEntity(
+		context.Context,
+		ComponentRef,
+		func(MutableContext) (Component, error),
+		...TransitionOption,
+	) (EntityKey, []byte, error)
+	UpdateWithNewEntity(
+		context.Context,
+		ComponentRef,
+		func(MutableContext) (Component, error),
+		func(MutableContext, Component) error,
+		...TransitionOption,
+	) (EntityKey, []byte, error)
+
+	UpdateComponent(
+		context.Context,
+		ComponentRef,
+		func(MutableContext, Component) error,
+		...TransitionOption,
+	) ([]byte, error)
+	ReadComponent(
+		context.Context,
+		ComponentRef,
+		func(Context, Component) error,
+		...TransitionOption,
+	) error
+
+	PollComponent(
+		context.Context,
+		ComponentRef,
+		func(Context, Component) (any, bool, error),
+		func(MutableContext, Component, any) error,
+		...TransitionOption,
+	) ([]byte, error)
+
+	InternalKeyConverter
+}
+
+type engineCtxKeyType string
+
+const engineCtxKey engineCtxKeyType = "chasmEngine"
+
+// this will be done by the nexus handler?
+// alternatively the engine can be a global variable,
+// but not a good practice in fx.
+func NewEngineContext(
+	ctx context.Context,
+	engine Engine,
+) context.Context {
+	return context.WithValue(ctx, engineCtxKey, engine)
+}
+
+func engineFromContext(
+	ctx context.Context,
+) Engine {
+	e, ok := ctx.Value(engineCtxKey).(Engine)
+	if !ok {
+		return nil
+	}
+	return e
+}

--- a/chasm/engine_mock.go
+++ b/chasm/engine_mock.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	definition "go.temporal.io/server/common/definition"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -38,6 +39,21 @@ func NewMockEngine(ctrl *gomock.Controller) *MockEngine {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEngine) EXPECT() *MockEngineMockRecorder {
 	return m.recorder
+}
+
+// FromInternalKey mocks base method.
+func (m *MockEngine) FromInternalKey(internalKey definition.WorkflowKey, archetype string) (EntityKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FromInternalKey", internalKey, archetype)
+	ret0, _ := ret[0].(EntityKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FromInternalKey indicates an expected call of FromInternalKey.
+func (mr *MockEngineMockRecorder) FromInternalKey(internalKey, archetype any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FromInternalKey", reflect.TypeOf((*MockEngine)(nil).FromInternalKey), internalKey, archetype)
 }
 
 // NewEntity mocks base method.
@@ -98,6 +114,21 @@ func (mr *MockEngineMockRecorder) ReadComponent(arg0, arg1, arg2 any, arg3 ...an
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadComponent", reflect.TypeOf((*MockEngine)(nil).ReadComponent), varargs...)
+}
+
+// ToInternalKey mocks base method.
+func (m *MockEngine) ToInternalKey(key EntityKey, archetype string) (definition.WorkflowKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ToInternalKey", key, archetype)
+	ret0, _ := ret[0].(definition.WorkflowKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ToInternalKey indicates an expected call of ToInternalKey.
+func (mr *MockEngineMockRecorder) ToInternalKey(key, archetype any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToInternalKey", reflect.TypeOf((*MockEngine)(nil).ToInternalKey), key, archetype)
 }
 
 // UpdateComponent mocks base method.

--- a/chasm/field_test.go
+++ b/chasm/field_test.go
@@ -145,6 +145,7 @@ func (s *fieldSuite) newTestTree(
 		s.timeSource,
 		s.nodeBackend,
 		s.nodePathEncoder,
+		DefaultInternalKeyConverter,
 		s.logger,
 	)
 }

--- a/chasm/ref_internal.go
+++ b/chasm/ref_internal.go
@@ -1,0 +1,52 @@
+package chasm
+
+import (
+	"strings"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/definition"
+)
+
+type InternalKeyConverter interface {
+	ToInternalKey(key EntityKey, archetype string) (definition.WorkflowKey, error)
+	FromInternalKey(internalKey definition.WorkflowKey, archetype string) (EntityKey, error)
+}
+
+const defaultArchetypeSeparator = ":"
+
+// TODO: Consider inject the converter via FX.
+var DefaultInternalKeyConverter = &defaultInternalKeyConverter{}
+
+var _ InternalKeyConverter = (*defaultInternalKeyConverter)(nil)
+
+type defaultInternalKeyConverter struct{}
+
+// TODO: special handle the internal key for Scheduler to match existing Scheduler's WorkflowID.
+
+func (c *defaultInternalKeyConverter) ToInternalKey(
+	key EntityKey,
+	archetype string,
+) (definition.WorkflowKey, error) {
+	return definition.WorkflowKey{
+		NamespaceID: key.NamespaceID,
+		WorkflowID:  archetype + defaultArchetypeSeparator + key.BusinessID,
+		RunID:       key.EntityID,
+	}, nil
+}
+
+func (c *defaultInternalKeyConverter) FromInternalKey(
+	internalKey definition.WorkflowKey,
+	archetype string,
+) (EntityKey, error) {
+	internalID := internalKey.WorkflowID
+	if !strings.HasPrefix(internalID, archetype+defaultArchetypeSeparator) {
+		return EntityKey{}, serviceerror.NewInternalf("invalid internal ID: %s", internalID)
+
+	}
+
+	return EntityKey{
+		NamespaceID: internalKey.NamespaceID,
+		BusinessID:  internalKey.WorkflowID[len(archetype)+1:],
+		EntityID:    internalKey.RunID,
+	}, nil
+}

--- a/chasm/ref_internal_test.go
+++ b/chasm/ref_internal_test.go
@@ -1,0 +1,26 @@
+package chasm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/testing/testvars"
+)
+
+func TestInternalKeyConverter(t *testing.T) {
+	tv := testvars.New(t)
+
+	key := EntityKey{
+		NamespaceID: tv.NamespaceID().String(),
+		BusinessID:  tv.Any().String(),
+		EntityID:    tv.Any().String(),
+	}
+	archetype := tv.Any().String()
+
+	internalKey, err := DefaultInternalKeyConverter.ToInternalKey(key, archetype)
+	require.NoError(t, err)
+
+	convertedKey, err := DefaultInternalKeyConverter.FromInternalKey(internalKey, archetype)
+	require.NoError(t, err)
+	require.Equal(t, key, convertedKey)
+}

--- a/service/history/chasm_task_util.go
+++ b/service/history/chasm_task_util.go
@@ -56,11 +56,11 @@ func executeChasmSideEffectTask(
 	registry *chasm.Registry,
 	tree historyi.ChasmTree,
 	task *tasks.ChasmTask,
+	archetype string,
 ) error {
-	entityKey := chasm.EntityKey{
-		NamespaceID: task.NamespaceID,
-		BusinessID:  task.WorkflowID,
-		EntityID:    task.RunID,
+	entityKey, err := engine.FromInternalKey(task.WorkflowKey, archetype)
+	if err != nil {
+		return err
 	}
 
 	validate := func(backend chasm.NodeBackend, _ chasm.Context, _ chasm.Component) error {
@@ -92,6 +92,7 @@ func executeChasmSideEffectTask(
 		engineCtx,
 		registry,
 		entityKey,
+		archetype,
 		taskAttributes,
 		task.Info,
 		validate,

--- a/service/history/interfaces/chasm_tree.go
+++ b/service/history/interfaces/chasm_tree.go
@@ -32,6 +32,7 @@ type ChasmTree interface {
 		ctx context.Context,
 		registry *chasm.Registry,
 		entityKey chasm.EntityKey,
+		archetype string,
 		taskAttributes chasm.TaskAttributes,
 		taskInfo *persistencespb.ChasmTaskInfo,
 		validate func(chasm.NodeBackend, chasm.Context, chasm.Component) error,

--- a/service/history/interfaces/chasm_tree_mock.go
+++ b/service/history/interfaces/chasm_tree_mock.go
@@ -130,17 +130,17 @@ func (mr *MockChasmTreeMockRecorder) EachPureTask(deadline, callback any) *gomoc
 }
 
 // ExecuteSideEffectTask mocks base method.
-func (m *MockChasmTree) ExecuteSideEffectTask(ctx context.Context, registry *chasm.Registry, entityKey chasm.EntityKey, taskAttributes chasm.TaskAttributes, taskInfo *persistence.ChasmTaskInfo, validate func(chasm.NodeBackend, chasm.Context, chasm.Component) error) error {
+func (m *MockChasmTree) ExecuteSideEffectTask(ctx context.Context, registry *chasm.Registry, entityKey chasm.EntityKey, archetype string, taskAttributes chasm.TaskAttributes, taskInfo *persistence.ChasmTaskInfo, validate func(chasm.NodeBackend, chasm.Context, chasm.Component) error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExecuteSideEffectTask", ctx, registry, entityKey, taskAttributes, taskInfo, validate)
+	ret := m.ctrl.Call(m, "ExecuteSideEffectTask", ctx, registry, entityKey, archetype, taskAttributes, taskInfo, validate)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ExecuteSideEffectTask indicates an expected call of ExecuteSideEffectTask.
-func (mr *MockChasmTreeMockRecorder) ExecuteSideEffectTask(ctx, registry, entityKey, taskAttributes, taskInfo, validate any) *gomock.Call {
+func (mr *MockChasmTreeMockRecorder) ExecuteSideEffectTask(ctx, registry, entityKey, archetype, taskAttributes, taskInfo, validate any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteSideEffectTask", reflect.TypeOf((*MockChasmTree)(nil).ExecuteSideEffectTask), ctx, registry, entityKey, taskAttributes, taskInfo, validate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteSideEffectTask", reflect.TypeOf((*MockChasmTree)(nil).ExecuteSideEffectTask), ctx, registry, entityKey, archetype, taskAttributes, taskInfo, validate)
 }
 
 // IsDirty mocks base method.

--- a/service/history/outbound_queue_active_task_executor.go
+++ b/service/history/outbound_queue_active_task_executor.go
@@ -108,6 +108,7 @@ func (e *outboundQueueActiveTaskExecutor) executeChasmSideEffectTask(
 		return err
 	}
 	tree := ms.ChasmTree()
+	archetype := tree.Archetype()
 
 	// Now that we've loaded the CHASM tree, we can release the lock before task
 	// execution. The task's executor must do its own locking as needed, and additional
@@ -120,6 +121,7 @@ func (e *outboundQueueActiveTaskExecutor) executeChasmSideEffectTask(
 		e.shardContext.ChasmRegistry(),
 		tree,
 		task,
+		archetype,
 	)
 	return err
 }

--- a/service/history/outbound_queue_active_task_executor_test.go
+++ b/service/history/outbound_queue_active_task_executor_test.go
@@ -157,6 +157,7 @@ func (s *outboundQueueActiveTaskExecutorSuite) TestExecute_ChasmTask() {
 						gomock.Any(),
 						gomock.Any(),
 						gomock.Any(),
+						gomock.Any(),
 					)
 			},
 			expectHandlerCalled: true,

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -954,6 +954,7 @@ func (t *timerQueueActiveTaskExecutor) executeChasmSideEffectTimerTask(
 	if tree == nil {
 		return errNoChasmTree
 	}
+	archetype := tree.Archetype()
 
 	// Now that we've loaded the CHASM tree, we can release the lock before task
 	// execution. The task's executor must do its own locking as needed, and additional
@@ -966,6 +967,7 @@ func (t *timerQueueActiveTaskExecutor) executeChasmSideEffectTimerTask(
 		t.shardContext.ChasmRegistry(),
 		tree,
 		task,
+		archetype,
 	)
 }
 

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -1922,6 +1922,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestExecuteChasmSideEffectTimerTask_
 		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
+		gomock.Any(),
 	).Times(1).Return(nil)
 
 	// Mock mutable state.

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -179,6 +179,7 @@ func (t *transferQueueActiveTaskExecutor) executeChasmSideEffectTransferTask(
 	if tree == nil {
 		return errNoChasmTree
 	}
+	archetype := tree.Archetype()
 
 	// Now that we've loaded the CHASM tree, we can release the lock before task
 	// execution. The task's executor must do its own locking as needed, and additional
@@ -191,6 +192,7 @@ func (t *transferQueueActiveTaskExecutor) executeChasmSideEffectTransferTask(
 		t.shardContext.ChasmRegistry(),
 		tree,
 		task,
+		archetype,
 	)
 }
 

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -310,6 +310,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestExecuteChasmSideEffectTransfe
 		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
+		gomock.Any(),
 	).Times(1).Return(nil)
 
 	// Mock mutable state.

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -370,6 +370,7 @@ func NewMutableState(
 			shard.GetTimeSource(),
 			s,
 			chasm.DefaultPathEncoder,
+			chasm.DefaultInternalKeyConverter,
 			shard.GetLogger(),
 		)
 	}
@@ -507,6 +508,7 @@ func NewMutableStateFromDB(
 			shard.GetTimeSource(),
 			mutableState,
 			chasm.DefaultPathEncoder,
+			chasm.DefaultInternalKeyConverter,
 			shard.GetLogger(),
 		)
 		if err != nil {

--- a/service/history/workflow/noop_chasm_tree.go
+++ b/service/history/workflow/noop_chasm_tree.go
@@ -69,6 +69,7 @@ func (*noopChasmTree) ExecuteSideEffectTask(
 	ctx context.Context,
 	registry *chasm.Registry,
 	entityKey chasm.EntityKey,
+	archetype string,
 	taskAttributes chasm.TaskAttributes,
 	taskInfo *persistencespb.ChasmTaskInfo,
 	validate func(chasm.NodeBackend, chasm.Context, chasm.Component) error,


### PR DESCRIPTION
## What changed?
- Prefix internal ID with archetype

## Why?
- Follow the existing approach for separating IDs across archetypes.
- The change only minimize the risk of ID collision across archetype, but can't prevent it from happening entirely as Workflows' ID don't have the prefix and essentially claimed the entire ID space. To really prevent the issue, we need a separate columns in the database table, but that's a very complex change and potentially involves data migration. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
