### PR TITLE
Matching fairness per-key rate limits

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1308,6 +1308,11 @@ second per poller by one physical queue manager`,
 		counter.DefaultCounterParams,
 		`Configuration for counter used in matching fairness.`,
 	)
+	MatchingFairnessKeyRateLimitCacheSize = NewTaskQueueIntSetting(
+		"matching.fairnessKeyRateLimitCacheSize",
+		2000,
+		"Cache size for fairness key rate limits.",
+	)
 
 	// keys for history
 

--- a/service/matching/fairness_util.go
+++ b/service/matching/fairness_util.go
@@ -1,0 +1,26 @@
+package matching
+
+import commonpb "go.temporal.io/api/common/v1"
+
+const (
+	// minWeight * strideFactor must be >= 1
+	strideFactor = 1000
+	minWeight    = 0.001
+)
+
+type fairnessWeightOverrides map[string]float32
+
+func getEffectiveWeight(overrides fairnessWeightOverrides, pri *commonpb.Priority) float32 {
+	key := pri.GetFairnessKey()
+	weight, ok := overrides[key]
+	if !ok {
+		weight = pri.GetFairnessWeight()
+	}
+	// zero means default weight (1.0). negative doesn't make sense, map it to 1.0 also.
+	if weight <= 0.0 {
+		weight = 1.0
+	} else {
+		weight = max(weight, minWeight)
+	}
+	return weight
+}

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -136,7 +136,7 @@ func (t *taskPQ) consumeTokens(now int64, task *internalTask, tokens int64) {
 		p.interval = time.Duration(float32(p.interval) / weight) // scale by weight
 		var sl simpleLimiter
 		if v := t.perKeyReady.Get(key); v != nil {
-			sl = v.(simpleLimiter)
+			sl = v.(simpleLimiter) // nolint:revive
 		}
 		t.perKeyReady.Put(key, sl.consume(p, now, tokens))
 	}
@@ -308,7 +308,7 @@ func (d *matcherData) UpdatePerKeyRateLimit(rate float64, burstDuration time.Dur
 	it := d.tasks.perKeyReady.Iterator()
 	for it.HasNext() {
 		e := it.Next()
-		sl := e.Value().(simpleLimiter)
+		sl := e.Value().(simpleLimiter) //nolint:revive
 		if clipped := sl.clip(d.tasks.perKeyLimit, now, maxTokens); clipped != sl {
 			if updates == nil {
 				updates = make(map[string]simpleLimiter)

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -270,7 +270,8 @@ func newMatcherData(config *taskQueueConfig, logger log.Logger, timeSource clock
 		timeSource: timeSource,
 		canForward: canForward,
 		tasks: taskPQ{
-			ages: newBacklogAgeTracker(),
+			ages:        newBacklogAgeTracker(),
+			perKeyReady: make(map[string]simpleLimiter),
 		},
 	}
 }

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -18,6 +18,7 @@ import (
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/softassert"
 	"go.temporal.io/server/common/testing/testlogger"
@@ -560,7 +561,7 @@ func FuzzMatcherData(f *testing.F) {
 		)
 		ts := clock.NewEventTimeSource()
 		ts.UseAsyncTimers(true)
-		logger := testlogger.NewTestLogger(f, testlogger.FailOnAnyUnexpectedError)
+		logger := log.NewNoopLogger()
 		md := newMatcherData(cfg, logger, ts, true)
 
 		next := func() int {

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -541,6 +541,7 @@ func TestSimpleLimiter(t *testing.T) {
 	now += int64(1 * time.Millisecond)
 	require.GreaterOrEqual(t, now, ready)
 	ready = ready.consume(p, now, 1)
+	require.Less(t, now, ready)
 }
 
 func TestSimpleLimiterOverTime(t *testing.T) {


### PR DESCRIPTION
## What changed?
- Add support for per-key rate limits that are scaled by weight (so maintaining dispatch in the same order that tasks are read in).
- Refactor simpleLimiter to split parameters and ready time.

## Why?
Support simple per-key limits.

This uses an LRU cache to track recent tasks by fairness key, default size 2000. With target dispatch rate of 1000 tasks/second/partition, that corresponds to at least 2 seconds of keys (equal in the worst case of fully uniform key distribution, which is unlikely). That means that rates >= 0.5 tasks/second/key/partition should be handled accurately (2 tasks/second/key for default 4 partitions). To handle even lower rates, partition count and task size can be tuned.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
