### PR TITLE
Use separate counter per subqueue

### DIFF
--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -78,7 +78,7 @@ func (s *BacklogManagerTestSuite) SetupTest() {
 			s.logger,
 			nil,
 			metrics.NoopMetricsHandler,
-			counter.NewMapCounter(),
+			func() counter.Counter { return counter.NewMapCounter() },
 		)
 	} else if s.newMatcher {
 		s.blm = newPriBacklogManager(

--- a/service/matching/fair_backlog_manager.go
+++ b/service/matching/fair_backlog_manager.go
@@ -56,7 +56,7 @@ func newFairBacklogManager(
 	throttledLogger log.ThrottledLogger,
 	matchingClient matchingservice.MatchingServiceClient,
 	metricsHandler metrics.Handler,
-	cntr counter.Counter,
+	counterFactory func() counter.Counter,
 ) *fairBacklogManagerImpl {
 	// For the purposes of taskQueueDB, call this just a TaskManager. It'll return errors if we
 	// use it incorectly. TODO(fairness): consider a cleaner way of doing this.
@@ -74,7 +74,7 @@ func newFairBacklogManager(
 		throttledLogger:     throttledLogger,
 		initializedError:    future.NewFuture[struct{}](),
 	}
-	bmg.taskWriter = newFairTaskWriter(bmg, cntr)
+	bmg.taskWriter = newFairTaskWriter(bmg, counterFactory)
 	return bmg
 }
 

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -188,8 +188,10 @@ func newPhysicalTaskQueueManager(
 		pqMgr.logger = log.With(partitionMgr.logger, buildIdTag, backlogTagFairness)
 		pqMgr.throttledLogger = log.With(partitionMgr.throttledLogger, buildIdTag, backlogTagFairness)
 
-		src := rand.NewPCG(rand.Uint64(), rand.Uint64())
-		cntr := counter.NewHybridCounter(config.FairnessCounter(), src)
+		counterFactory := func() counter.Counter {
+			src := rand.NewPCG(rand.Uint64(), rand.Uint64())
+			return counter.NewHybridCounter(config.FairnessCounter(), src)
+		}
 
 		pqMgr.backlogMgr = newFairBacklogManager(
 			tqCtx,
@@ -200,7 +202,7 @@ func newPhysicalTaskQueueManager(
 			pqMgr.throttledLogger,
 			e.matchingRawClient,
 			newFairMetricsHandler(taggedMetricsHandler),
-			cntr,
+			counterFactory,
 		)
 		var fwdr *priForwarder
 		var err error


### PR DESCRIPTION
## What changed?
Use a separate counter per subqueue in fairTaskWriter.

## Why?
It works better:
1. Semantically, we want fairness to apply per priority level (tasks from different levels can't really block each other since they go in sequence).
2. Each subqueue has a separate ack level, and the level is determined by the counter, so it makes sense to have separate counters.

## How did you test it?
- [x] covered by existing tests (to some degree)
