### PR TITLE
Convert persistence.TimeoutError to servicererror.DeadlineExceeded

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2440,6 +2440,8 @@ func (h *Handler) convertError(err error) error {
 		return serviceerror.NewUnavailable(err.Msg)
 	case *persistence.TransactionSizeLimitError:
 		return serviceerror.NewInvalidArgument(err.Msg)
+	case *persistence.TimeoutError:
+		return serviceerror.NewDeadlineExceeded(err.Msg)
 	}
 
 	return err


### PR DESCRIPTION
## What changed?
Convert persistence.TimeoutError to serviceerror.DeadlineExceeded errors in history handler.

## Why?
Frontend handler will mask these errors if they are not converted to service errors.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

