### PR TITLE
Added SQL Support for Fairness

### DIFF
--- a/common/persistence/sql/factory.go
+++ b/common/persistence/sql/factory.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync"
 
-	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -71,12 +70,16 @@ func (f *Factory) NewTaskStore() (p.TaskStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newTaskPersistence(conn, f.cfg.TaskScanPartitions, f.logger)
+	return newTaskPersistence(conn, f.cfg.TaskScanPartitions, f.logger, false) // false indicates no fairness
 }
 
 // NewFairTaskStore returns a new task store
 func (f *Factory) NewFairTaskStore() (p.TaskStore, error) {
-	return nil, serviceerror.NewUnimplemented("not implemented for sql")
+	conn, err := f.mainDBConn.Get()
+	if err != nil {
+		return nil, err
+	}
+	return newTaskPersistence(conn, f.cfg.TaskScanPartitions, f.logger, true) // true indicates fairness
 }
 
 // NewShardStore returns a new shard store

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -44,7 +44,10 @@ type (
 		QueueV2Metadata
 
 		MatchingTask
+		MatchingTaskV2
 		MatchingTaskQueue
+		MatchingTaskQueueV2
+		MatchingTaskQueueUserData
 
 		NexusEndpoints
 

--- a/common/persistence/sql/sqlplugin/matching_task_queue_user_data.go
+++ b/common/persistence/sql/sqlplugin/matching_task_queue_user_data.go
@@ -1,0 +1,54 @@
+package sqlplugin
+
+import "context"
+
+type (
+	GetTaskQueueUserDataRequest struct {
+		NamespaceID   []byte
+		TaskQueueName string
+	}
+
+	ListTaskQueueUserDataEntriesRequest struct {
+		NamespaceID       []byte
+		LastTaskQueueName string
+		Limit             int
+	}
+
+	AddToBuildIdToTaskQueueMapping struct {
+		NamespaceID   []byte
+		TaskQueueName string
+		BuildIds      []string
+	}
+
+	RemoveFromBuildIdToTaskQueueMapping struct {
+		NamespaceID   []byte
+		TaskQueueName string
+		BuildIds      []string
+	}
+
+	GetTaskQueuesByBuildIdRequest struct {
+		NamespaceID []byte
+		BuildID     string
+	}
+
+	CountTaskQueuesByBuildIdRequest struct {
+		NamespaceID []byte
+		BuildID     string
+	}
+
+	TaskQueueUserDataEntry struct {
+		TaskQueueName string
+		VersionedBlob
+	}
+
+	MatchingTaskQueueUserData interface {
+		GetTaskQueueUserData(ctx context.Context, request *GetTaskQueueUserDataRequest) (*VersionedBlob, error)
+		UpdateTaskQueueUserData(ctx context.Context, request *UpdateTaskQueueDataRequest) error
+		ListTaskQueueUserDataEntries(ctx context.Context, request *ListTaskQueueUserDataEntriesRequest) ([]TaskQueueUserDataEntry, error)
+
+		AddToBuildIdToTaskQueueMapping(ctx context.Context, request AddToBuildIdToTaskQueueMapping) error
+		RemoveFromBuildIdToTaskQueueMapping(ctx context.Context, request RemoveFromBuildIdToTaskQueueMapping) error
+		GetTaskQueuesByBuildId(ctx context.Context, request *GetTaskQueuesByBuildIdRequest) ([]string, error)
+		CountTaskQueuesByBuildId(ctx context.Context, request *CountTaskQueuesByBuildIdRequest) (int, error)
+	}
+)

--- a/common/persistence/sql/sqlplugin/matching_task_queue_v2.go
+++ b/common/persistence/sql/sqlplugin/matching_task_queue_v2.go
@@ -7,7 +7,7 @@ import (
 
 type (
 	// TaskQueuesRow represents a row in task_queues table
-	TaskQueuesRow struct {
+	TaskQueuesRowV2 struct {
 		RangeHash    uint32
 		TaskQueueID  []byte
 		RangeID      int64
@@ -17,7 +17,7 @@ type (
 
 	// TaskQueuesFilter contains the column names within task_queues table that
 	// can be used to filter results through a WHERE clause
-	TaskQueuesFilter struct {
+	TaskQueuesFilterV2 struct {
 		RangeHash                   uint32
 		RangeHashGreaterThanEqualTo uint32
 		RangeHashLessThanEqualTo    uint32
@@ -27,7 +27,7 @@ type (
 		PageSize                    *int
 	}
 
-	UpdateTaskQueueDataRequest struct {
+	UpdateTaskQueueDataRequestV2 struct {
 		NamespaceID   []byte
 		TaskQueueName string
 		Version       int64
@@ -36,15 +36,15 @@ type (
 	}
 
 	// MatchingTaskQueue is the SQL persistence interface for matching task queues
-	MatchingTaskQueue interface {
-		InsertIntoTaskQueues(ctx context.Context, row *TaskQueuesRow) (sql.Result, error)
-		UpdateTaskQueues(ctx context.Context, row *TaskQueuesRow) (sql.Result, error)
+	MatchingTaskQueueV2 interface {
+		InsertIntoTaskQueuesV2(ctx context.Context, row *TaskQueuesRowV2) (sql.Result, error)
+		UpdateTaskQueuesV2(ctx context.Context, row *TaskQueuesRowV2) (sql.Result, error)
 		// SelectFromTaskQueues returns one or more rows from task_queues table
 		// Required Filter params:
 		//  to read a single row: {shardID, namespaceID, name, taskType}
 		//  to range read multiple rows: {shardID, namespaceIDGreaterThan, nameGreaterThan, taskTypeGreaterThan, pageSize}
-		SelectFromTaskQueues(ctx context.Context, filter TaskQueuesFilter) ([]TaskQueuesRow, error)
-		DeleteFromTaskQueues(ctx context.Context, filter TaskQueuesFilter) (sql.Result, error)
-		LockTaskQueues(ctx context.Context, filter TaskQueuesFilter) (int64, error)
+		SelectFromTaskQueuesV2(ctx context.Context, filter TaskQueuesFilterV2) ([]TaskQueuesRowV2, error)
+		DeleteFromTaskQueuesV2(ctx context.Context, filter TaskQueuesFilterV2) (sql.Result, error)
+		LockTaskQueuesV2(ctx context.Context, filter TaskQueuesFilterV2) (int64, error)
 	}
 )

--- a/common/persistence/sql/sqlplugin/matching_task_v2.go
+++ b/common/persistence/sql/sqlplugin/matching_task_v2.go
@@ -1,0 +1,46 @@
+package sqlplugin
+
+import (
+	"context"
+	"database/sql"
+)
+
+type (
+	// TasksRow represents a row in tasks table
+	TasksRowV2 struct {
+		RangeHash    uint32
+		TaskQueueID  []byte
+		TaskID       int64
+		Pass         int64 // pass for tasks (see stride scheduling algorithm for fairness)
+		Data         []byte
+		DataEncoding string
+	}
+
+	// TasksFilter contains the column names within tasks table that
+	// can be used to filter results through a WHERE clause
+	TasksFilterV2 struct {
+		RangeHash          uint32
+		TaskQueueID        []byte
+		Pass               int64 // pass for tasks (see stride scheduling algorithm for fairness)
+		InclusiveMinTaskID *int64
+		ExclusiveMaxTaskID *int64
+		Limit              *int
+		PageSize           *int
+	}
+
+	// MatchingTaskV2 is the SQL persistence interface for matching fairness tasks
+	MatchingTaskV2 interface {
+		// InsertIntoTasksV2 inserts one or more rows into tasks_v2 table for matching fairness
+		InsertIntoTasksV2(ctx context.Context, rows []TasksRowV2) (sql.Result, error)
+		// SelectFromTasks retrieves one or more rows from the tasks_v2 table
+		// Required filter params - {RangeHash, TaskQueueID, Pass, inclusiveMinTaskID, exclusiveMaxTaskID, pageSize}
+		// Returns tasks where the (pass, task_id) tuple is greater than or equal to the provided values,
+		// effectively filtering tasks that are at or beyond a specific fairness pass and task ID boundary.
+		SelectFromTasksV2(ctx context.Context, filter TasksFilterV2) ([]TasksRowV2, error)
+		// DeleteFromTasks deletes multiple rows from tasks table
+		// Required filter params:
+		//    - {namespaceID, taskqueueName, taskType, exclusiveMaxTaskID, limit }
+		//    - this will delete upto limit number of tasks less than the given max task id
+		DeleteFromTasksV2(ctx context.Context, filter TasksFilterV2) (sql.Result, error)
+	}
+)

--- a/common/persistence/sql/sqlplugin/mysql/task_user_data.go
+++ b/common/persistence/sql/sqlplugin/mysql/task_user_data.go
@@ -1,0 +1,127 @@
+package mysql
+
+import (
+	"context"
+	"strings"
+
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	getTaskQueueUserDataQry = `SELECT data, data_encoding, version FROM task_queue_user_data ` +
+		`WHERE namespace_id = ? AND task_queue_name = ?`
+
+	updateTaskQueueUserDataQry = `UPDATE task_queue_user_data SET ` +
+		`data = ?, ` +
+		`data_encoding = ?, ` +
+		`version = ? ` +
+		`WHERE namespace_id = ? ` +
+		`AND task_queue_name = ? ` +
+		`AND version = ?`
+
+	insertTaskQueueUserDataQry = `INSERT INTO task_queue_user_data` +
+		`(namespace_id, task_queue_name, data, data_encoding, version) ` +
+		`VALUES (?, ?, ?, ?, 1)`
+
+	listTaskQueueUserDataQry = `SELECT task_queue_name, data, data_encoding, version FROM task_queue_user_data WHERE namespace_id = ? AND task_queue_name > ? LIMIT ?`
+
+	addBuildIdToTaskQueueMappingQry    = `INSERT INTO build_id_to_task_queue (namespace_id, build_id, task_queue_name) VALUES `
+	removeBuildIdToTaskQueueMappingQry = `DELETE FROM build_id_to_task_queue WHERE namespace_id = ? AND task_queue_name = ? AND build_id IN (`
+	listTaskQueuesByBuildIdQry         = `SELECT task_queue_name FROM build_id_to_task_queue WHERE namespace_id = ? AND build_id = ?`
+	countTaskQueuesByBuildIdQry        = `SELECT COUNT(*) FROM build_id_to_task_queue WHERE namespace_id = ? AND build_id = ?`
+)
+
+func (mdb *db) GetTaskQueueUserData(ctx context.Context, request *sqlplugin.GetTaskQueueUserDataRequest) (*sqlplugin.VersionedBlob, error) {
+	var row sqlplugin.VersionedBlob
+	err := mdb.GetContext(ctx, &row, getTaskQueueUserDataQry, request.NamespaceID, request.TaskQueueName)
+	return &row, err
+}
+
+func (mdb *db) UpdateTaskQueueUserData(ctx context.Context, request *sqlplugin.UpdateTaskQueueDataRequest) error {
+	if request.Version == 0 {
+		_, err := mdb.ExecContext(
+			ctx,
+			insertTaskQueueUserDataQry,
+			request.NamespaceID,
+			request.TaskQueueName,
+			request.Data,
+			request.DataEncoding)
+		return err
+	}
+	result, err := mdb.ExecContext(
+		ctx,
+		updateTaskQueueUserDataQry,
+		request.Data,
+		request.DataEncoding,
+		request.Version+1,
+		request.NamespaceID,
+		request.TaskQueueName,
+		request.Version)
+	if err != nil {
+		return err
+	}
+	numRows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if numRows != 1 {
+		return &persistence.ConditionFailedError{Msg: "Expected exactly one row to be updated"}
+	}
+	return nil
+}
+
+func (mdb *db) ListTaskQueueUserDataEntries(ctx context.Context, request *sqlplugin.ListTaskQueueUserDataEntriesRequest) ([]sqlplugin.TaskQueueUserDataEntry, error) {
+	var rows []sqlplugin.TaskQueueUserDataEntry
+	err := mdb.SelectContext(ctx, &rows, listTaskQueueUserDataQry, request.NamespaceID, request.LastTaskQueueName, request.Limit)
+	return rows, err
+}
+
+func (mdb *db) AddToBuildIdToTaskQueueMapping(ctx context.Context, request sqlplugin.AddToBuildIdToTaskQueueMapping) error {
+	query := addBuildIdToTaskQueueMappingQry
+	var params []any
+	for idx, buildId := range request.BuildIds {
+		if idx == len(request.BuildIds)-1 {
+			query += "(?, ?, ?)"
+		} else {
+			query += "(?, ?, ?), "
+		}
+		params = append(params, request.NamespaceID, buildId, request.TaskQueueName)
+	}
+
+	_, err := mdb.ExecContext(ctx, query, params...)
+	return err
+}
+
+func (mdb *db) RemoveFromBuildIdToTaskQueueMapping(ctx context.Context, request sqlplugin.RemoveFromBuildIdToTaskQueueMapping) error {
+	query := removeBuildIdToTaskQueueMappingQry + strings.Repeat("?, ", len(request.BuildIds)-1) + "?)"
+	// Golang doesn't support appending a string slice to an any slice which is essentially what we're doing here.
+	params := make([]any, len(request.BuildIds)+2)
+	params[0] = request.NamespaceID
+	params[1] = request.TaskQueueName
+	for i, buildId := range request.BuildIds {
+		params[i+2] = buildId
+	}
+
+	_, err := mdb.ExecContext(ctx, query, params...)
+	return err
+}
+
+func (mdb *db) GetTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.GetTaskQueuesByBuildIdRequest) ([]string, error) {
+	var rows []struct {
+		TaskQueueName string
+	}
+
+	err := mdb.SelectContext(ctx, &rows, listTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
+	taskQueues := make([]string, len(rows))
+	for i, row := range rows {
+		taskQueues[i] = row.TaskQueueName
+	}
+	return taskQueues, err
+}
+
+func (mdb *db) CountTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.CountTaskQueuesByBuildIdRequest) (int, error) {
+	var count int
+	err := mdb.GetContext(ctx, &count, countTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
+	return count, err
+}

--- a/common/persistence/sql/sqlplugin/postgresql/task_user_data.go
+++ b/common/persistence/sql/sqlplugin/postgresql/task_user_data.go
@@ -1,0 +1,131 @@
+package postgresql
+
+import (
+	"context"
+	"fmt"
+
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	getTaskQueueUserDataQry = `SELECT data, data_encoding, version FROM task_queue_user_data ` +
+		`WHERE namespace_id = $1 AND task_queue_name = $2`
+
+	updateTaskQueueUserDataQry = `UPDATE task_queue_user_data SET ` +
+		`data = $1, ` +
+		`data_encoding = $2, ` +
+		`version = $3 ` +
+		`WHERE namespace_id = $4 ` +
+		`AND task_queue_name = $5 ` +
+		`AND version = $6`
+
+	insertTaskQueueUserDataQry = `INSERT INTO task_queue_user_data` +
+		`(namespace_id, task_queue_name, data, data_encoding, version) ` +
+		`VALUES ($1, $2, $3, $4, 1)`
+
+	listTaskQueueUserDataQry = `SELECT task_queue_name, data, data_encoding, version FROM task_queue_user_data WHERE namespace_id = $1 AND task_queue_name > $2 LIMIT $3`
+
+	addBuildIdToTaskQueueMappingQry    = `INSERT INTO build_id_to_task_queue (namespace_id, build_id, task_queue_name) VALUES `
+	removeBuildIdToTaskQueueMappingQry = `DELETE FROM build_id_to_task_queue WHERE namespace_id = $1 AND task_queue_name = $2 AND build_id IN (`
+	listTaskQueuesByBuildIdQry         = `SELECT task_queue_name FROM build_id_to_task_queue WHERE namespace_id = $1 AND build_id = $2`
+	countTaskQueuesByBuildIdQry        = `SELECT COUNT(*) FROM build_id_to_task_queue WHERE namespace_id = $1 AND build_id = $2`
+)
+
+func (pdb *db) GetTaskQueueUserData(ctx context.Context, request *sqlplugin.GetTaskQueueUserDataRequest) (*sqlplugin.VersionedBlob, error) {
+	var row sqlplugin.VersionedBlob
+	err := pdb.GetContext(ctx, &row, getTaskQueueUserDataQry, request.NamespaceID, request.TaskQueueName)
+	return &row, err
+}
+
+func (pdb *db) UpdateTaskQueueUserData(ctx context.Context, request *sqlplugin.UpdateTaskQueueDataRequest) error {
+	if request.Version == 0 {
+		_, err := pdb.ExecContext(
+			ctx,
+			insertTaskQueueUserDataQry,
+			request.NamespaceID,
+			request.TaskQueueName,
+			request.Data,
+			request.DataEncoding)
+		return err
+	}
+	result, err := pdb.ExecContext(
+		ctx,
+		updateTaskQueueUserDataQry,
+		request.Data,
+		request.DataEncoding,
+		request.Version+1,
+		request.NamespaceID,
+		request.TaskQueueName,
+		request.Version)
+	if err != nil {
+		return err
+	}
+	numRows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if numRows != 1 {
+		return &persistence.ConditionFailedError{Msg: "Expected exactly one row to be updated"}
+	}
+	return nil
+}
+
+func (pdb *db) ListTaskQueueUserDataEntries(ctx context.Context, request *sqlplugin.ListTaskQueueUserDataEntriesRequest) ([]sqlplugin.TaskQueueUserDataEntry, error) {
+	var rows []sqlplugin.TaskQueueUserDataEntry
+	err := pdb.SelectContext(ctx, &rows, listTaskQueueUserDataQry, request.NamespaceID, request.LastTaskQueueName, request.Limit)
+	return rows, err
+}
+
+func (pdb *db) AddToBuildIdToTaskQueueMapping(ctx context.Context, request sqlplugin.AddToBuildIdToTaskQueueMapping) error {
+	query := addBuildIdToTaskQueueMappingQry
+	var params []any
+	for idx, buildId := range request.BuildIds {
+		query += fmt.Sprintf("($%d, $%d, $%d)", idx*3+1, idx*3+2, idx*3+3)
+		if idx < len(request.BuildIds)-1 {
+			query += ", "
+		}
+		params = append(params, request.NamespaceID, buildId, request.TaskQueueName)
+	}
+
+	_, err := pdb.ExecContext(ctx, query, params...)
+	return err
+}
+
+func (pdb *db) RemoveFromBuildIdToTaskQueueMapping(ctx context.Context, request sqlplugin.RemoveFromBuildIdToTaskQueueMapping) error {
+	query := removeBuildIdToTaskQueueMappingQry
+	// Golang doesn't support appending a string slice to an any slice which is essentially what we're doing here.
+	params := make([]any, len(request.BuildIds)+2)
+	params[0] = request.NamespaceID
+	params[1] = request.TaskQueueName
+	for idx, buildId := range request.BuildIds {
+		sep := ", "
+		if idx == len(request.BuildIds)-1 {
+			sep = ")"
+		}
+		query += fmt.Sprintf("$%d%s", idx+3, sep)
+		params[idx+2] = buildId
+	}
+
+	_, err := pdb.ExecContext(ctx, query, params...)
+	return err
+}
+
+func (pdb *db) GetTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.GetTaskQueuesByBuildIdRequest) ([]string, error) {
+	var rows []struct {
+		TaskQueueName string
+	}
+
+	err := pdb.SelectContext(ctx, &rows, listTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
+	taskQueues := make([]string, len(rows))
+	for i, row := range rows {
+		taskQueues[i] = row.TaskQueueName
+	}
+	return taskQueues, err
+}
+
+func (pdb *db) CountTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.CountTaskQueuesByBuildIdRequest) (int, error) {
+	var count int
+	err := pdb.GetContext(ctx, &count, countTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
+	return count, err
+}

--- a/common/persistence/sql/sqlplugin/sqlite/task.go
+++ b/common/persistence/sql/sqlplugin/sqlite/task.go
@@ -3,10 +3,8 @@ package sqlite
 import (
 	"context"
 	"database/sql"
-	"strings"
 
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 )
 
@@ -18,13 +16,13 @@ const (
 	createTaskQueueQry = `INSERT ` + taskQueueCreatePart
 
 	updateTaskQueueQry = `UPDATE task_queues SET
-range_id = :range_id,
-data = :data,
-data_encoding = :data_encoding
-WHERE
-range_hash = :range_hash AND
-task_queue_id = :task_queue_id
-`
+	range_id = :range_id,
+	data = :data,
+	data_encoding = :data_encoding
+	WHERE
+	range_hash = :range_hash AND
+	task_queue_id = :task_queue_id
+	`
 
 	listTaskQueueRowSelect = `SELECT range_hash, task_queue_id, range_id, data, data_encoding from task_queues `
 
@@ -57,35 +55,13 @@ task_queue_id = :task_queue_id
 		`tasks(range_hash, task_queue_id, task_id, data, data_encoding) ` +
 		`VALUES(:range_hash, :task_queue_id, :task_id, :data, :data_encoding)`
 
-	deleteTaskQry = `DELETE FROM tasks ` +
-		`WHERE range_hash = ? AND task_queue_id = ? AND task_id = ?`
+	// deleteTaskQry = `DELETE FROM tasks ` +
+	// 	`WHERE range_hash = ? AND task_queue_id = ? AND task_id = ?`
 
 	rangeDeleteTaskQry = `DELETE FROM tasks ` +
 		`WHERE range_hash = ? AND task_queue_id = ? AND task_id IN (SELECT task_id FROM
 		 tasks WHERE range_hash = ? AND task_queue_id = ? AND task_id < ? ` +
 		`ORDER BY task_queue_id,task_id LIMIT ? ) `
-
-	getTaskQueueUserDataQry = `SELECT data, data_encoding, version FROM task_queue_user_data ` +
-		`WHERE namespace_id = ? AND task_queue_name = ?`
-
-	updateTaskQueueUserDataQry = `UPDATE task_queue_user_data SET ` +
-		`data = ?, ` +
-		`data_encoding = ?, ` +
-		`version = ? ` +
-		`WHERE namespace_id = ? ` +
-		`AND task_queue_name = ? ` +
-		`AND version = ?`
-
-	insertTaskQueueUserDataQry = `INSERT INTO task_queue_user_data` +
-		`(namespace_id, task_queue_name, data, data_encoding, version) ` +
-		`VALUES (?, ?, ?, ?, 1)`
-
-	listTaskQueueUserDataQry = `SELECT task_queue_name, data, data_encoding, version FROM task_queue_user_data WHERE namespace_id = ? AND task_queue_name > ? LIMIT ?`
-
-	addBuildIdToTaskQueueMappingQry    = `INSERT INTO build_id_to_task_queue (namespace_id, build_id, task_queue_name) VALUES `
-	removeBuildIdToTaskQueueMappingQry = `DELETE FROM build_id_to_task_queue WHERE namespace_id = ? AND task_queue_name = ? AND build_id IN (`
-	listTaskQueuesByBuildIdQry         = `SELECT task_queue_name FROM build_id_to_task_queue WHERE namespace_id = ? AND build_id = ?`
-	countTaskQueuesByBuildIdQry        = `SELECT COUNT(*) FROM build_id_to_task_queue WHERE namespace_id = ? AND build_id = ?`
 )
 
 // InsertIntoTasks inserts one or more rows into tasks table
@@ -273,98 +249,4 @@ func (mdb *db) LockTaskQueues(
 		filter.TaskQueueID,
 	)
 	return rangeID, err
-}
-
-func (mdb *db) GetTaskQueueUserData(ctx context.Context, request *sqlplugin.GetTaskQueueUserDataRequest) (*sqlplugin.VersionedBlob, error) {
-	var row sqlplugin.VersionedBlob
-	err := mdb.conn.GetContext(ctx, &row, getTaskQueueUserDataQry, request.NamespaceID, request.TaskQueueName)
-	return &row, err
-}
-
-func (mdb *db) UpdateTaskQueueUserData(ctx context.Context, request *sqlplugin.UpdateTaskQueueDataRequest) error {
-	if request.Version == 0 {
-		_, err := mdb.conn.ExecContext(
-			ctx,
-			insertTaskQueueUserDataQry,
-			request.NamespaceID,
-			request.TaskQueueName,
-			request.Data,
-			request.DataEncoding)
-		return err
-	}
-	result, err := mdb.conn.ExecContext(
-		ctx,
-		updateTaskQueueUserDataQry,
-		request.Data,
-		request.DataEncoding,
-		request.Version+1,
-		request.NamespaceID,
-		request.TaskQueueName,
-		request.Version)
-	if err != nil {
-		return err
-	}
-	numRows, err := result.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if numRows != 1 {
-		return &persistence.ConditionFailedError{Msg: "Expected exactly one row to be updated"}
-	}
-	return nil
-}
-
-func (mdb *db) AddToBuildIdToTaskQueueMapping(ctx context.Context, request sqlplugin.AddToBuildIdToTaskQueueMapping) error {
-	query := addBuildIdToTaskQueueMappingQry
-	var params []any
-	for idx, buildId := range request.BuildIds {
-		if idx == len(request.BuildIds)-1 {
-			query += "(?, ?, ?)"
-		} else {
-			query += "(?, ?, ?), "
-		}
-		params = append(params, request.NamespaceID, buildId, request.TaskQueueName)
-	}
-
-	_, err := mdb.conn.ExecContext(ctx, query, params...)
-	return err
-}
-
-func (mdb *db) RemoveFromBuildIdToTaskQueueMapping(ctx context.Context, request sqlplugin.RemoveFromBuildIdToTaskQueueMapping) error {
-	query := removeBuildIdToTaskQueueMappingQry + strings.Repeat("?, ", len(request.BuildIds)-1) + "?)"
-	// Golang doesn't support appending a string slice to an any slice which is essentially what we're doing here.
-	params := make([]any, len(request.BuildIds)+2)
-	params[0] = request.NamespaceID
-	params[1] = request.TaskQueueName
-	for i, buildId := range request.BuildIds {
-		params[i+2] = buildId
-	}
-
-	_, err := mdb.conn.ExecContext(ctx, query, params...)
-	return err
-}
-
-func (mdb *db) ListTaskQueueUserDataEntries(ctx context.Context, request *sqlplugin.ListTaskQueueUserDataEntriesRequest) ([]sqlplugin.TaskQueueUserDataEntry, error) {
-	var rows []sqlplugin.TaskQueueUserDataEntry
-	err := mdb.conn.SelectContext(ctx, &rows, listTaskQueueUserDataQry, request.NamespaceID, request.LastTaskQueueName, request.Limit)
-	return rows, err
-}
-
-func (mdb *db) GetTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.GetTaskQueuesByBuildIdRequest) ([]string, error) {
-	var rows []struct {
-		TaskQueueName string
-	}
-
-	err := mdb.conn.SelectContext(ctx, &rows, listTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
-	taskQueues := make([]string, len(rows))
-	for i, row := range rows {
-		taskQueues[i] = row.TaskQueueName
-	}
-	return taskQueues, err
-}
-
-func (mdb *db) CountTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.CountTaskQueuesByBuildIdRequest) (int, error) {
-	var count int
-	err := mdb.conn.GetContext(ctx, &count, countTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
-	return count, err
 }

--- a/common/persistence/sql/sqlplugin/sqlite/task_user_data.go
+++ b/common/persistence/sql/sqlplugin/sqlite/task_user_data.go
@@ -1,0 +1,127 @@
+package sqlite
+
+import (
+	"context"
+	"strings"
+
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	getTaskQueueUserDataQry = `SELECT data, data_encoding, version FROM task_queue_user_data ` +
+		`WHERE namespace_id = ? AND task_queue_name = ?`
+
+	updateTaskQueueUserDataQry = `UPDATE task_queue_user_data SET ` +
+		`data = ?, ` +
+		`data_encoding = ?, ` +
+		`version = ? ` +
+		`WHERE namespace_id = ? ` +
+		`AND task_queue_name = ? ` +
+		`AND version = ?`
+
+	insertTaskQueueUserDataQry = `INSERT INTO task_queue_user_data` +
+		`(namespace_id, task_queue_name, data, data_encoding, version) ` +
+		`VALUES (?, ?, ?, ?, 1)`
+
+	listTaskQueueUserDataQry = `SELECT task_queue_name, data, data_encoding, version FROM task_queue_user_data WHERE namespace_id = ? AND task_queue_name > ? LIMIT ?`
+
+	addBuildIdToTaskQueueMappingQry    = `INSERT INTO build_id_to_task_queue (namespace_id, build_id, task_queue_name) VALUES `
+	removeBuildIdToTaskQueueMappingQry = `DELETE FROM build_id_to_task_queue WHERE namespace_id = ? AND task_queue_name = ? AND build_id IN (`
+	listTaskQueuesByBuildIdQry         = `SELECT task_queue_name FROM build_id_to_task_queue WHERE namespace_id = ? AND build_id = ?`
+	countTaskQueuesByBuildIdQry        = `SELECT COUNT(*) FROM build_id_to_task_queue WHERE namespace_id = ? AND build_id = ?`
+)
+
+func (mdb *db) GetTaskQueueUserData(ctx context.Context, request *sqlplugin.GetTaskQueueUserDataRequest) (*sqlplugin.VersionedBlob, error) {
+	var row sqlplugin.VersionedBlob
+	err := mdb.conn.GetContext(ctx, &row, getTaskQueueUserDataQry, request.NamespaceID, request.TaskQueueName)
+	return &row, err
+}
+
+func (mdb *db) UpdateTaskQueueUserData(ctx context.Context, request *sqlplugin.UpdateTaskQueueDataRequest) error {
+	if request.Version == 0 {
+		_, err := mdb.conn.ExecContext(
+			ctx,
+			insertTaskQueueUserDataQry,
+			request.NamespaceID,
+			request.TaskQueueName,
+			request.Data,
+			request.DataEncoding)
+		return err
+	}
+	result, err := mdb.conn.ExecContext(
+		ctx,
+		updateTaskQueueUserDataQry,
+		request.Data,
+		request.DataEncoding,
+		request.Version+1,
+		request.NamespaceID,
+		request.TaskQueueName,
+		request.Version)
+	if err != nil {
+		return err
+	}
+	numRows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if numRows != 1 {
+		return &persistence.ConditionFailedError{Msg: "Expected exactly one row to be updated"}
+	}
+	return nil
+}
+
+func (mdb *db) ListTaskQueueUserDataEntries(ctx context.Context, request *sqlplugin.ListTaskQueueUserDataEntriesRequest) ([]sqlplugin.TaskQueueUserDataEntry, error) {
+	var rows []sqlplugin.TaskQueueUserDataEntry
+	err := mdb.conn.SelectContext(ctx, &rows, listTaskQueueUserDataQry, request.NamespaceID, request.LastTaskQueueName, request.Limit)
+	return rows, err
+}
+
+func (mdb *db) AddToBuildIdToTaskQueueMapping(ctx context.Context, request sqlplugin.AddToBuildIdToTaskQueueMapping) error {
+	query := addBuildIdToTaskQueueMappingQry
+	var params []any
+	for idx, buildId := range request.BuildIds {
+		if idx == len(request.BuildIds)-1 {
+			query += "(?, ?, ?)"
+		} else {
+			query += "(?, ?, ?), "
+		}
+		params = append(params, request.NamespaceID, buildId, request.TaskQueueName)
+	}
+
+	_, err := mdb.conn.ExecContext(ctx, query, params...)
+	return err
+}
+
+func (mdb *db) RemoveFromBuildIdToTaskQueueMapping(ctx context.Context, request sqlplugin.RemoveFromBuildIdToTaskQueueMapping) error {
+	query := removeBuildIdToTaskQueueMappingQry + strings.Repeat("?, ", len(request.BuildIds)-1) + "?)"
+	// Golang doesn't support appending a string slice to an any slice which is essentially what we're doing here.
+	params := make([]any, len(request.BuildIds)+2)
+	params[0] = request.NamespaceID
+	params[1] = request.TaskQueueName
+	for i, buildId := range request.BuildIds {
+		params[i+2] = buildId
+	}
+
+	_, err := mdb.conn.ExecContext(ctx, query, params...)
+	return err
+}
+
+func (mdb *db) GetTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.GetTaskQueuesByBuildIdRequest) ([]string, error) {
+	var rows []struct {
+		TaskQueueName string
+	}
+
+	err := mdb.conn.SelectContext(ctx, &rows, listTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
+	taskQueues := make([]string, len(rows))
+	for i, row := range rows {
+		taskQueues[i] = row.TaskQueueName
+	}
+	return taskQueues, err
+}
+
+func (mdb *db) CountTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.CountTaskQueuesByBuildIdRequest) (int, error) {
+	var count int
+	err := mdb.conn.GetContext(ctx, &count, countTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
+	return count, err
+}

--- a/common/persistence/sql/sqlplugin/sqlite/task_v2.go
+++ b/common/persistence/sql/sqlplugin/sqlite/task_v2.go
@@ -1,0 +1,264 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	taskQueueV2CreatePart = `INTO task_queues_v2(range_hash, task_queue_id, range_id, data, data_encoding) ` +
+		`VALUES (:range_hash, :task_queue_id, :range_id, :data, :data_encoding)`
+
+	// (default range ID: initialRangeID == 1)
+	createTaskQueueQryV2 = `INSERT ` + taskQueueV2CreatePart
+
+	updateTaskQueueQryV2 = `UPDATE task_queues_v2 SET
+		range_id = :range_id,
+		data = :data,
+		data_encoding = :data_encoding
+		WHERE
+		range_hash = :range_hash AND
+		task_queue_id = :task_queue_id
+		`
+
+	listTaskQueueV2RowSelect = `SELECT range_hash, task_queue_id, range_id, data, data_encoding from task_queues_v2 `
+
+	listTaskQueueWithHashRangeQryV2 = listTaskQueueV2RowSelect +
+		`WHERE range_hash >= ? AND range_hash <= ? AND task_queue_id > ? ORDER BY task_queue_id ASC LIMIT ?`
+
+	listTaskQueueQryV2 = listTaskQueueRowSelect +
+		`WHERE range_hash = ? AND task_queue_id > ? ORDER BY task_queue_id ASC LIMIT ?`
+
+	getTaskQueueQryV2 = listTaskQueueRowSelect +
+		`WHERE range_hash = ? AND task_queue_id = ?`
+
+	deleteTaskQueueQryV2 = `DELETE FROM task_queues_v2 WHERE range_hash=? AND task_queue_id=? AND range_id=?`
+
+	lockTaskQueueQryV2 = `SELECT range_id FROM task_queues_v2 ` +
+		`WHERE range_hash = ? AND task_queue_id = ?`
+	// *** Task_Queues Table Above ***
+
+	// *** Tasks Below ***
+	getTaskMinMaxQryV2 = `SELECT task_id, data, data_encoding ` +
+		`FROM tasks_v2 ` +
+		`WHERE range_hash = ? ` +
+		`AND task_queue_id = ? ` +
+		`AND (pass, task_id) >= (?, ?) ` +
+		`AND task_id < ? ` +
+		`ORDER BY pass, task_id ` +
+		`LIMIT ?`
+
+	getFairnessTaskQry = `SELECT task_id, data, data_encoding ` +
+		`FROM tasks_v2 ` +
+		`WHERE range_hash = ? ` +
+		`AND task_queue_id = ? ` +
+		`AND (pass, task_id) >= (?, ?) ` +
+		`ORDER BY pass, task_id `
+
+	getFairnessTaskQryWithLimit = `SELECT task_id, data, data_encoding ` +
+		`FROM tasks_v2 ` +
+		`WHERE range_hash = ? ` +
+		`AND task_queue_id = ? ` +
+		`AND (pass, task_id) >= (?, ?) ` +
+		`ORDER BY pass, task_id ` +
+		`LIMIT ?`
+
+	createTaskQryV2 = `INSERT INTO ` +
+		`tasks_v2(range_hash, task_queue_id, task_id, pass, data, data_encoding) ` +
+		`VALUES(:range_hash, :task_queue_id, :task_id, :pass, :data, :data_encoding)`
+
+	rangeDeleteTaskQryV2 = `DELETE FROM tasks_v2 ` +
+		`WHERE range_hash = ? AND task_queue_id = ? AND task_id IN (SELECT task_id FROM
+		 tasks_v2 WHERE range_hash = ? AND task_queue_id = ? AND task_id < ? ` +
+		`ORDER BY task_queue_id,task_id LIMIT ? ) `
+
+	rangeDeleteFairnessTaskQry = `DELETE FROM tasks_v2 ` +
+		`WHERE range_hash = ? ` +
+		`AND task_queue_id = ? ` +
+		`AND (pass, task_id) < (?, ?) `
+)
+
+// InsertIntoTasks inserts one or more rows into tasks_v2 table
+func (mdb *db) InsertIntoTasksV2(
+	ctx context.Context,
+	rows []sqlplugin.TasksRowV2,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		createTaskQryV2,
+		rows,
+	)
+}
+
+// SelectFromTasks reads one or more rows from tasks_v2 table
+func (mdb *db) SelectFromTasksV2(
+	ctx context.Context,
+	filter sqlplugin.TasksFilterV2,
+) ([]sqlplugin.TasksRowV2, error) {
+	var err error
+	var rows []sqlplugin.TasksRowV2
+	switch {
+	case filter.PageSize != nil:
+		err = mdb.conn.SelectContext(ctx,
+			&rows, getFairnessTaskQryWithLimit,
+			filter.RangeHash,
+			filter.TaskQueueID,
+			filter.Pass,
+			*filter.InclusiveMinTaskID,
+			*filter.PageSize,
+		)
+	default:
+		err = mdb.conn.SelectContext(ctx,
+			&rows, getFairnessTaskQry,
+			filter.RangeHash,
+			filter.TaskQueueID,
+			filter.Pass,
+			*filter.InclusiveMinTaskID,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// DeleteFromTasks deletes one or more rows from tasks_v2 table
+func (mdb *db) DeleteFromTasksV2(
+	ctx context.Context,
+	filter sqlplugin.TasksFilterV2,
+) (sql.Result, error) {
+	if filter.ExclusiveMaxTaskID == nil {
+		return nil, serviceerror.NewInternal("missing ExclusiveMaxTaskID parameter")
+	}
+	return mdb.conn.ExecContext(ctx,
+		rangeDeleteFairnessTaskQry,
+		filter.RangeHash,
+		filter.TaskQueueID,
+		filter.Pass,
+		*filter.ExclusiveMaxTaskID,
+	)
+}
+
+// InsertIntoTaskQueues inserts one or more rows into task_queues table
+func (mdb *db) InsertIntoTaskQueuesV2(
+	ctx context.Context,
+	row *sqlplugin.TaskQueuesRowV2,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		createTaskQueueQryV2,
+		row,
+	)
+}
+
+// UpdateTaskQueues updates a row in task_queues table
+func (mdb *db) UpdateTaskQueuesV2(
+	ctx context.Context,
+	row *sqlplugin.TaskQueuesRowV2,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		updateTaskQueueQryV2,
+		row,
+	)
+}
+
+// SelectFromTaskQueues reads one or more rows from task_queues table
+func (mdb *db) SelectFromTaskQueuesV2(
+	ctx context.Context,
+	filter sqlplugin.TaskQueuesFilterV2,
+) ([]sqlplugin.TaskQueuesRowV2, error) {
+	switch {
+	case filter.TaskQueueID != nil:
+		if filter.RangeHashLessThanEqualTo != 0 || filter.RangeHashGreaterThanEqualTo != 0 {
+			return nil, serviceerror.NewInternal("range of hashes not supported for specific selection")
+		}
+		return mdb.selectFromTaskQueuesV2(ctx, filter)
+	case filter.RangeHashLessThanEqualTo != 0 && filter.PageSize != nil:
+		if filter.RangeHashLessThanEqualTo < filter.RangeHashGreaterThanEqualTo {
+			return nil, serviceerror.NewInternal("range of hashes bound is invalid")
+		}
+		return mdb.rangeSelectFromTaskQueueV2(ctx, filter)
+	case filter.TaskQueueIDGreaterThan != nil && filter.PageSize != nil:
+		return mdb.rangeSelectFromTaskQueueV2(ctx, filter)
+	default:
+		return nil, serviceerror.NewInternal("invalid set of query filter params")
+	}
+}
+
+func (mdb *db) selectFromTaskQueuesV2(
+	ctx context.Context,
+	filter sqlplugin.TaskQueuesFilterV2,
+) ([]sqlplugin.TaskQueuesRowV2, error) {
+	var err error
+	var row sqlplugin.TaskQueuesRowV2
+	err = mdb.conn.GetContext(ctx,
+		&row,
+		getTaskQueueQryV2,
+		filter.RangeHash,
+		filter.TaskQueueID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return []sqlplugin.TaskQueuesRowV2{row}, nil
+}
+
+func (mdb *db) rangeSelectFromTaskQueueV2(
+	ctx context.Context,
+	filter sqlplugin.TaskQueuesFilterV2,
+) ([]sqlplugin.TaskQueuesRowV2, error) {
+	var err error
+	var rows []sqlplugin.TaskQueuesRowV2
+
+	if filter.RangeHashLessThanEqualTo != 0 {
+		err = mdb.conn.SelectContext(ctx,
+			&rows,
+			listTaskQueueWithHashRangeQryV2,
+			filter.RangeHashGreaterThanEqualTo,
+			filter.RangeHashLessThanEqualTo,
+			filter.TaskQueueIDGreaterThan,
+			*filter.PageSize,
+		)
+	} else {
+		err = mdb.conn.SelectContext(ctx,
+			&rows,
+			listTaskQueueQryV2,
+			filter.RangeHash,
+			filter.TaskQueueIDGreaterThan,
+			*filter.PageSize,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// DeleteFromTaskQueues deletes a row from task_queues table
+func (mdb *db) DeleteFromTaskQueuesV2(
+	ctx context.Context,
+	filter sqlplugin.TaskQueuesFilterV2,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteTaskQueueQryV2,
+		filter.RangeHash,
+		filter.TaskQueueID,
+		*filter.RangeID,
+	)
+}
+
+// LockTaskQueues locks a row in task_queues table
+func (mdb *db) LockTaskQueuesV2(
+	ctx context.Context,
+	filter sqlplugin.TaskQueuesFilterV2,
+) (int64, error) {
+	var rangeID int64
+	err := mdb.conn.GetContext(ctx,
+		&rangeID,
+		lockTaskQueueQryV2,
+		filter.RangeHash,
+		filter.TaskQueueID,
+	)
+	return rangeID, err
+}

--- a/common/persistence/sql/sqlplugin/tests/matching_task.go
+++ b/common/persistence/sql/sqlplugin/tests/matching_task.go
@@ -263,3 +263,17 @@ func (s *matchingTaskSuite) newRandomTasksRow(
 		DataEncoding: testMatchingTaskEncoding,
 	}
 }
+
+func (s *matchingTaskSuite) newRandomTasksRowV2(
+	queueID []byte,
+	taskID int64,
+) sqlplugin.TasksRowV2 {
+	return sqlplugin.TasksRowV2{
+		RangeHash:    testMatchingTaskRangeHash,
+		TaskQueueID:  queueID,
+		TaskID:       taskID,
+		Pass:         0,
+		Data:         shuffle.Bytes(testMatchingTaskTaskData),
+		DataEncoding: testMatchingTaskEncoding,
+	}
+}

--- a/common/persistence/sql/sqlplugin/tests/matching_task_queue_v2.go
+++ b/common/persistence/sql/sqlplugin/tests/matching_task_queue_v2.go
@@ -1,0 +1,288 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	"go.temporal.io/server/common/shuffle"
+	"go.temporal.io/server/common/util"
+)
+
+const (
+	testMatchingTaskQueueRangeHashV2 = 42
+	testMatchingTaskQueueEncodingV2  = "random encoding"
+)
+
+var (
+	testMatchingTaskTaskQueueIDV2   = []byte("random matching task queue")
+	testMatchingTaskTaskQueueDataV2 = []byte("random matching task data")
+)
+
+type (
+	matchingTaskQueueSuiteV2 struct {
+		suite.Suite
+		*require.Assertions
+
+		store sqlplugin.MatchingTaskQueueV2
+	}
+)
+
+// TODO SelectFromTaskQueues with RangeHashGreaterThanEqualTo / RangeHashLessThanEqualTo / TaskQueueIDGreaterThan looks weird
+//  need to go over the logic in matching engine
+
+func NewMatchingTaskQueueSuiteV2(
+	t *testing.T,
+	store sqlplugin.MatchingTaskQueue,
+) *matchingTaskQueueSuite {
+	return &matchingTaskQueueSuite{
+		Assertions: require.New(t),
+		store:      store,
+	}
+}
+
+func (s *matchingTaskQueueSuiteV2) SetupSuiteV2() {
+
+}
+
+func (s *matchingTaskQueueSuiteV2) TearDownSuiteV2() {
+
+}
+
+func (s *matchingTaskQueueSuiteV2) SetupTestV2() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *matchingTaskQueueSuiteV2) TearDownTestV2() {
+
+}
+
+func (s *matchingTaskQueueSuiteV2) TestInsert_SuccessV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueIDV2)
+	rangeID := int64(1)
+
+	taskQueue := s.newRandomTasksQueueRowV2(queueID, rangeID)
+	result, err := s.store.InsertIntoTaskQueuesV2(newExecutionContext(), &taskQueue)
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+}
+
+func (s *matchingTaskQueueSuiteV2) TestInsert_Fail_DuplicateV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueIDV2)
+	rangeID := int64(1)
+
+	taskQueue := s.newRandomTasksQueueRowV2(queueID, rangeID)
+	result, err := s.store.InsertIntoTaskQueuesV2(newExecutionContext(), &taskQueue)
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+
+	taskQueue = s.newRandomTasksQueueRowV2(queueID, rangeID)
+	_, err = s.store.InsertIntoTaskQueuesV2(newExecutionContext(), &taskQueue)
+	s.Error(err) // TODO persistence layer should do proper error translation
+}
+
+func (s *matchingTaskQueueSuiteV2) TestInsertSelectV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueIDV2)
+	rangeID := int64(1)
+
+	taskQueue := s.newRandomTasksQueueRowV2(queueID, rangeID)
+	result, err := s.store.InsertIntoTaskQueuesV2(newExecutionContext(), &taskQueue)
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+
+	filter := sqlplugin.TaskQueuesFilterV2{
+		RangeHash:   testMatchingTaskQueueRangeHashV2,
+		TaskQueueID: queueID,
+	}
+	rows, err := s.store.SelectFromTaskQueuesV2(newExecutionContext(), filter)
+	s.NoError(err)
+	s.Equal([]sqlplugin.TaskQueuesRowV2{taskQueue}, rows)
+}
+
+func (s *matchingTaskQueueSuiteV2) TestInsertUpdate_SuccessV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueIDV2)
+	rangeID := int64(1)
+
+	taskQueue := s.newRandomTasksQueueRowV2(queueID, rangeID)
+	rangeID++
+	result, err := s.store.InsertIntoTaskQueuesV2(newExecutionContext(), &taskQueue)
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+
+	taskQueue = s.newRandomTasksQueueRowV2(queueID, rangeID)
+	result, err = s.store.UpdateTaskQueuesV2(newExecutionContext(), &taskQueue)
+	s.NoError(err)
+	rowsAffected, err = result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+}
+
+func (s *matchingTaskQueueSuiteV2) TestUpdate_FailV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueIDV2)
+	rangeID := int64(1)
+
+	taskQueue := s.newRandomTasksQueueRowV2(queueID, rangeID)
+	result, err := s.store.UpdateTaskQueuesV2(newExecutionContext(), &taskQueue)
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(0, int(rowsAffected))
+}
+
+func (s *matchingTaskQueueSuiteV2) TestInsertUpdateSelectV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueIDV2)
+	rangeID := int64(1)
+
+	taskQueue := s.newRandomTasksQueueRowV2(queueID, rangeID)
+	rangeID++
+	result, err := s.store.InsertIntoTaskQueuesV2(newExecutionContext(), &taskQueue)
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+
+	taskQueue = s.newRandomTasksQueueRowV2(queueID, rangeID)
+	result, err = s.store.UpdateTaskQueuesV2(newExecutionContext(), &taskQueue)
+	s.NoError(err)
+	rowsAffected, err = result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+
+	filter := sqlplugin.TaskQueuesFilterV2{
+		RangeHash:   testMatchingTaskQueueRangeHashV2,
+		TaskQueueID: queueID,
+	}
+	rows, err := s.store.SelectFromTaskQueuesV2(newExecutionContext(), filter)
+	s.NoError(err)
+	s.Equal([]sqlplugin.TaskQueuesRowV2{taskQueue}, rows)
+}
+
+func (s *matchingTaskQueueSuiteV2) TestDeleteSelectV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueIDV2)
+	rangeID := int64(1)
+
+	filter := sqlplugin.TaskQueuesFilterV2{
+		RangeHash:   testMatchingTaskQueueRangeHashV2,
+		TaskQueueID: queueID,
+		RangeID:     util.Ptr(rangeID),
+	}
+	result, err := s.store.DeleteFromTaskQueuesV2(newExecutionContext(), filter)
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(0, int(rowsAffected))
+
+	filter = sqlplugin.TaskQueuesFilterV2{
+		RangeHash:   testMatchingTaskQueueRangeHashV2,
+		TaskQueueID: queueID,
+	}
+	// TODO the behavior is weird
+	_, err = s.store.SelectFromTaskQueuesV2(newExecutionContext(), filter)
+	s.Error(err) // TODO persistence layer should do proper error translation
+}
+
+func (s *matchingTaskQueueSuiteV2) TestInsertDeleteSelect_SuccessV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueIDV2)
+	rangeID := int64(1)
+
+	taskQueue := s.newRandomTasksQueueRowV2(queueID, rangeID)
+	result, err := s.store.InsertIntoTaskQueuesV2(newExecutionContext(), &taskQueue)
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+
+	filter := sqlplugin.TaskQueuesFilterV2{
+		RangeHash:   testMatchingTaskQueueRangeHashV2,
+		TaskQueueID: queueID,
+		RangeID:     util.Ptr(rangeID),
+	}
+	result, err = s.store.DeleteFromTaskQueuesV2(newExecutionContext(), filter)
+	s.NoError(err)
+	rowsAffected, err = result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+
+	filter = sqlplugin.TaskQueuesFilterV2{
+		RangeHash:   testMatchingTaskQueueRangeHashV2,
+		TaskQueueID: queueID,
+	}
+	rows, err := s.store.SelectFromTaskQueuesV2(newExecutionContext(), filter)
+	s.Error(err) // TODO persistence layer should do proper error translation
+	s.Nil(rows)
+}
+
+func (s *matchingTaskQueueSuiteV2) TestInsertDeleteSelect_FailV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueIDV2)
+	rangeID := int64(1)
+
+	taskQueue := s.newRandomTasksQueueRowV2(queueID, rangeID)
+	result, err := s.store.InsertIntoTaskQueuesV2(newExecutionContext(), &taskQueue)
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+
+	filter := sqlplugin.TaskQueuesFilterV2{
+		RangeHash:   testMatchingTaskQueueRangeHashV2,
+		TaskQueueID: queueID,
+		RangeID:     util.Ptr(rangeID + 1),
+	}
+	result, err = s.store.DeleteFromTaskQueuesV2(newExecutionContext(), filter)
+	s.NoError(err)
+	rowsAffected, err = result.RowsAffected()
+	s.NoError(err)
+	s.Equal(0, int(rowsAffected))
+
+	filter = sqlplugin.TaskQueuesFilterV2{
+		RangeHash:   testMatchingTaskQueueRangeHashV2,
+		TaskQueueID: queueID,
+	}
+	rows, err := s.store.SelectFromTaskQueuesV2(newExecutionContext(), filter)
+	s.NoError(err)
+	s.Equal([]sqlplugin.TaskQueuesRowV2{taskQueue}, rows)
+}
+
+func (s *matchingTaskQueueSuiteV2) TestInsertLockV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueIDV2)
+	rangeID := int64(2)
+
+	taskQueue := s.newRandomTasksQueueRowV2(queueID, rangeID)
+	result, err := s.store.InsertIntoTaskQueuesV2(newExecutionContext(), &taskQueue)
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+
+	// NOTE: lock without transaction is equivalent to select
+	//  this test only test the select functionality
+	filter := sqlplugin.TaskQueuesFilterV2{
+		RangeHash:   testMatchingTaskQueueRangeHashV2,
+		TaskQueueID: queueID,
+	}
+	rangeIDInDB, err := s.store.LockTaskQueuesV2(newExecutionContext(), filter)
+	s.NoError(err)
+	s.Equal(rangeID, rangeIDInDB)
+}
+
+func (s *matchingTaskQueueSuiteV2) newRandomTasksQueueRowV2(
+	queueID []byte,
+	rangeID int64,
+) sqlplugin.TaskQueuesRowV2 {
+	return sqlplugin.TaskQueuesRowV2{
+		RangeHash:    testMatchingTaskQueueRangeHashV2,
+		TaskQueueID:  queueID,
+		RangeID:      rangeID,
+		Data:         shuffle.Bytes(testMatchingTaskTaskQueueDataV2),
+		DataEncoding: testMatchingTaskQueueEncodingV2,
+	}
+}

--- a/common/persistence/sql/sqlplugin/tests/matching_task_v2.go
+++ b/common/persistence/sql/sqlplugin/tests/matching_task_v2.go
@@ -1,0 +1,268 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	"go.temporal.io/server/common/shuffle"
+	"go.temporal.io/server/common/util"
+)
+
+const (
+	testMatchingTaskRangeHashV2 = 42
+	testMatchingTaskEncodingV2  = "random encoding"
+)
+
+var (
+	testMatchingTaskTaskDataV2 = []byte("random matching task data")
+)
+
+type (
+	matchingTaskSuiteV2 struct {
+		suite.Suite
+		*require.Assertions
+
+		store sqlplugin.MatchingTaskV2
+	}
+)
+
+func NewMatchingTaskSuiteV2(
+	t *testing.T,
+	store sqlplugin.MatchingTaskV2,
+) *matchingTaskSuiteV2 {
+	return &matchingTaskSuiteV2{
+		Assertions: require.New(t),
+		store:      store,
+	}
+}
+
+func (s *matchingTaskSuiteV2) SetupSuiteV2() {
+
+}
+
+func (s *matchingTaskSuiteV2) TearDownSuiteV2() {
+
+}
+
+func (s *matchingTaskSuiteV2) SetupTestV2() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *matchingTaskSuiteV2) TearDownTestV2() {
+
+}
+
+func (s *matchingTaskSuiteV2) TestInsert_Single_SuccessV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueID)
+	taskID := int64(1)
+
+	task := s.newRandomTasksRowV2(queueID, taskID)
+	result, err := s.store.InsertIntoTasksV2(newExecutionContext(), []sqlplugin.TasksRowV2{task})
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+}
+
+func (s *matchingTaskSuiteV2) TestInsert_Multiple_Successv2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueID)
+	taskID := int64(1)
+
+	task1 := s.newRandomTasksRowV2(queueID, taskID)
+	taskID++
+	task2 := s.newRandomTasksRowV2(queueID, taskID)
+	taskID++
+	result, err := s.store.InsertIntoTasksV2(newExecutionContext(), []sqlplugin.TasksRowV2{task1, task2})
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(2, int(rowsAffected))
+}
+
+func (s *matchingTaskSuiteV2) TestInsert_Single_Fail_DuplicateV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueID)
+	taskID := int64(1)
+
+	task := s.newRandomTasksRowV2(queueID, taskID)
+	result, err := s.store.InsertIntoTasksV2(newExecutionContext(), []sqlplugin.TasksRowV2{task})
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+
+	task = s.newRandomTasksRowV2(queueID, taskID)
+	_, err = s.store.InsertIntoTasksV2(newExecutionContext(), []sqlplugin.TasksRowV2{task})
+	s.Error(err) // TODO persistence layer should do proper error translation
+}
+
+func (s *matchingTaskSuiteV2) TestInsert_Multiple_Fail_DuplicateV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueID)
+	taskID := int64(1)
+
+	task1 := s.newRandomTasksRowV2(queueID, taskID)
+	taskID++
+	task2 := s.newRandomTasksRowV2(queueID, taskID)
+	result, err := s.store.InsertIntoTasksV2(newExecutionContext(), []sqlplugin.TasksRowV2{task1, task2})
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(2, int(rowsAffected))
+
+	task2 = s.newRandomTasksRowV2(queueID, taskID)
+	taskID++
+	task3 := s.newRandomTasksRowV2(queueID, taskID)
+	_, err = s.store.InsertIntoTasksV2(newExecutionContext(), []sqlplugin.TasksRowV2{task2, task3})
+	s.Error(err) // TODO persistence layer should do proper error translation
+}
+
+func (s *matchingTaskSuiteV2) TestInsertSelect_SingleV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueID)
+	taskID := int64(100)
+
+	task := s.newRandomTasksRowV2(queueID, taskID)
+	result, err := s.store.InsertIntoTasksV2(newExecutionContext(), []sqlplugin.TasksRowV2{task})
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+
+	inclusiveMinTaskID := util.Ptr(taskID)
+	exclusiveMaxTaskID := util.Ptr(taskID + 1)
+	pageSize := util.Ptr(1)
+	filter := sqlplugin.TasksFilterV2{
+		RangeHash:          testMatchingTaskRangeHashV2,
+		TaskQueueID:        queueID,
+		Pass:               0, // pass for tasks (see stride scheduling algorithm for fairness)
+		InclusiveMinTaskID: inclusiveMinTaskID,
+		ExclusiveMaxTaskID: exclusiveMaxTaskID,
+		PageSize:           pageSize,
+	}
+	rows, err := s.store.SelectFromTasksV2(newExecutionContext(), filter)
+	s.NoError(err)
+	// fill in some omitted info
+	for index := range rows {
+		rows[index].RangeHash = testMatchingTaskRangeHashV2
+		rows[index].TaskQueueID = queueID
+	}
+	s.Equal([]sqlplugin.TasksRowV2{task}, rows)
+}
+
+func (s *matchingTaskSuiteV2) TestInsertSelect_MultipleV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueID)
+	taskID := int64(100)
+
+	task1 := s.newRandomTasksRowV2(queueID, taskID)
+	taskID++
+	task2 := s.newRandomTasksRowV2(queueID, taskID)
+	result, err := s.store.InsertIntoTasksV2(newExecutionContext(), []sqlplugin.TasksRowV2{task1, task2})
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(2, int(rowsAffected))
+
+	inclusiveMinTaskID := util.Ptr(taskID - 1)
+	exclusiveMaxTaskID := util.Ptr(taskID + 1)
+	pageSize := util.Ptr(2)
+	filter := sqlplugin.TasksFilterV2{
+		RangeHash:          testMatchingTaskRangeHashV2,
+		TaskQueueID:        queueID,
+		Pass:               0, // pass for tasks (see stride scheduling algorithm for fairness)
+		InclusiveMinTaskID: inclusiveMinTaskID,
+		ExclusiveMaxTaskID: exclusiveMaxTaskID,
+		PageSize:           pageSize,
+	}
+	rows, err := s.store.SelectFromTasksV2(newExecutionContext(), filter)
+	s.NoError(err)
+	// fill in some omitted info
+	for index := range rows {
+		rows[index].RangeHash = testMatchingTaskRangeHashV2
+		rows[index].TaskQueueID = queueID
+	}
+	s.Equal([]sqlplugin.TasksRowV2{task1, task2}, rows)
+}
+
+func (s *matchingTaskSuiteV2) TestDeleteSingle_FailV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueID)
+
+	filter := sqlplugin.TasksFilterV2{
+		RangeHash:   testMatchingTaskRangeHashV2,
+		TaskQueueID: queueID,
+	}
+	_, err := s.store.DeleteFromTasksV2(newExecutionContext(), filter)
+	s.Error(err)
+}
+
+func (s *matchingTaskSuiteV2) TestInsertDeleteSingle_FailV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueID)
+	taskID := int64(100)
+
+	task := s.newRandomTasksRowV2(queueID, taskID)
+	result, err := s.store.InsertIntoTasksV2(newExecutionContext(), []sqlplugin.TasksRowV2{task})
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(1, int(rowsAffected))
+
+	filter := sqlplugin.TasksFilterV2{
+		RangeHash:   testMatchingTaskRangeHashV2,
+		TaskQueueID: queueID,
+	}
+	_, err = s.store.DeleteFromTasksV2(newExecutionContext(), filter)
+	s.Error(err)
+}
+
+func (s *matchingTaskSuiteV2) TestInsertDeleteSelect_MultipleV2() {
+	queueID := shuffle.Bytes(testMatchingTaskTaskQueueID)
+	taskID := int64(100)
+
+	task1 := s.newRandomTasksRowV2(queueID, taskID)
+	taskID++
+	task2 := s.newRandomTasksRowV2(queueID, taskID)
+	result, err := s.store.InsertIntoTasksV2(newExecutionContext(), []sqlplugin.TasksRowV2{task1, task2})
+	s.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	s.NoError(err)
+	s.Equal(2, int(rowsAffected))
+
+	filter := sqlplugin.TasksFilterV2{
+		RangeHash:          testMatchingTaskRangeHashV2,
+		TaskQueueID:        queueID,
+		ExclusiveMaxTaskID: util.Ptr(taskID + 1),
+		Limit:              util.Ptr(2),
+	}
+	result, err = s.store.DeleteFromTasksV2(newExecutionContext(), filter)
+	s.NoError(err)
+	rowsAffected, err = result.RowsAffected()
+	s.NoError(err)
+	s.Equal(2, int(rowsAffected))
+
+	inclusiveMinTaskID := util.Ptr(taskID - 1)
+	exclusiveMaxTaskID := util.Ptr(taskID + 1)
+	pageSize := util.Ptr(2)
+	filter = sqlplugin.TasksFilterV2{
+		RangeHash:          testMatchingTaskRangeHashV2,
+		TaskQueueID:        queueID,
+		InclusiveMinTaskID: inclusiveMinTaskID,
+		ExclusiveMaxTaskID: exclusiveMaxTaskID,
+		PageSize:           pageSize,
+	}
+	rows, err := s.store.SelectFromTasksV2(newExecutionContext(), filter)
+	s.NoError(err)
+	s.Equal([]sqlplugin.TasksRowV2(nil), rows)
+}
+
+func (s *matchingTaskSuiteV2) newRandomTasksRowV2(
+	queueID []byte,
+	taskID int64,
+) sqlplugin.TasksRowV2 {
+	return sqlplugin.TasksRowV2{
+		RangeHash:    testMatchingTaskRangeHashV2,
+		TaskQueueID:  queueID,
+		TaskID:       taskID,
+		Pass:         0,
+		Data:         shuffle.Bytes(testMatchingTaskTaskDataV2),
+		DataEncoding: testMatchingTaskEncodingV2,
+	}
+}

--- a/common/persistence/sql/task_store.go
+++ b/common/persistence/sql/task_store.go
@@ -1,0 +1,34 @@
+package sql
+
+import (
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+type taskQueuePageToken struct {
+	MinRangeHash   uint32
+	MinTaskQueueId []byte
+}
+
+type matchingTaskPageToken struct {
+	TaskID int64
+}
+
+type userDataListNextPageToken struct {
+	LastTaskQueueName string
+}
+
+// newTaskPersistence creates a new instance of TaskManager
+func newTaskPersistence(
+	db sqlplugin.DB,
+	taskScanPartitions int,
+	logger log.Logger,
+	enableFairness bool,
+) (persistence.TaskStore, error) {
+	userDataStore := newUserDataStore(db, logger)
+	if enableFairness {
+		return newTaskManagerV2(db, userDataStore, taskScanPartitions, logger)
+	}
+	return newTaskManagerV1(db, userDataStore, taskScanPartitions, logger)
+}

--- a/common/persistence/sql/task_user_data.go
+++ b/common/persistence/sql/task_user_data.go
@@ -1,0 +1,194 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	"go.temporal.io/server/common/primitives"
+)
+
+type userDataStore struct {
+	UserDB sqlplugin.DB
+	logger log.Logger
+}
+
+func newUserDataStore(db sqlplugin.DB, logger log.Logger) *userDataStore {
+	return &userDataStore{
+		UserDB: db,
+		logger: logger,
+	}
+}
+
+func (uds *userDataStore) GetTaskQueueUserData(ctx context.Context, request *persistence.GetTaskQueueUserDataRequest) (*persistence.InternalGetTaskQueueUserDataResponse, error) {
+	namespaceID, err := primitives.ParseUUID(request.NamespaceID)
+	if err != nil {
+		return nil, serviceerror.NewInternalf("failed to parse namespace ID as UUID: %v", err)
+	}
+	response, err := uds.UserDB.GetTaskQueueUserData(ctx, &sqlplugin.GetTaskQueueUserDataRequest{
+		NamespaceID:   namespaceID,
+		TaskQueueName: request.TaskQueue,
+	})
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, serviceerror.NewNotFoundf("task queue user data not found for %v.%v", request.NamespaceID, request.TaskQueue)
+		}
+		return nil, err
+	}
+	return &persistence.InternalGetTaskQueueUserDataResponse{
+		Version:  response.Version,
+		UserData: persistence.NewDataBlob(response.Data, response.DataEncoding),
+	}, nil
+}
+
+func (uds *userDataStore) UpdateTaskQueueUserData(ctx context.Context, request *persistence.InternalUpdateTaskQueueUserDataRequest) error {
+	namespaceID, err := primitives.ParseUUID(request.NamespaceID)
+	if err != nil {
+		return serviceerror.NewInternalf("failed to parse namespace ID as UUID: %v", err)
+	}
+	err = uds.txExecute(ctx, "UpdateTaskQueueUserData", func(tx sqlplugin.Tx) error {
+		for taskQueue, update := range request.Updates {
+			err := tx.UpdateTaskQueueUserData(ctx, &sqlplugin.UpdateTaskQueueDataRequest{
+				NamespaceID:   namespaceID,
+				TaskQueueName: taskQueue,
+				Data:          update.UserData.Data,
+				DataEncoding:  update.UserData.EncodingType.String(),
+				Version:       update.Version,
+			})
+			// note these are in a transaction: if one fails the others will be rolled back
+			if uds.UserDB.IsDupEntryError(err) {
+				err = &persistence.ConditionFailedError{Msg: err.Error()}
+			}
+			if persistence.IsConflictErr(err) && update.Conflicting != nil {
+				*update.Conflicting = true
+			}
+			if err != nil {
+				return err
+			}
+			if len(update.BuildIdsAdded) > 0 {
+				err = tx.AddToBuildIdToTaskQueueMapping(ctx, sqlplugin.AddToBuildIdToTaskQueueMapping{
+					NamespaceID:   namespaceID,
+					TaskQueueName: taskQueue,
+					BuildIds:      update.BuildIdsAdded,
+				})
+				if err != nil {
+					return err
+				}
+			}
+			if len(update.BuildIdsRemoved) > 0 {
+				err = tx.RemoveFromBuildIdToTaskQueueMapping(ctx, sqlplugin.RemoveFromBuildIdToTaskQueueMapping{
+					NamespaceID:   namespaceID,
+					TaskQueueName: taskQueue,
+					BuildIds:      update.BuildIdsRemoved,
+				})
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+	// only set Applied if the whole transaction succeeded
+	for _, update := range request.Updates {
+		if update.Applied != nil {
+			*update.Applied = err == nil
+		}
+	}
+	return err
+}
+
+func (uds *userDataStore) ListTaskQueueUserDataEntries(ctx context.Context, request *persistence.ListTaskQueueUserDataEntriesRequest) (*persistence.InternalListTaskQueueUserDataEntriesResponse, error) {
+	namespaceID, err := primitives.ParseUUID(request.NamespaceID)
+	if err != nil {
+		return nil, serviceerror.NewInternal(err.Error())
+	}
+
+	lastQueueName := ""
+	if len(request.NextPageToken) != 0 {
+		token, err := deserializePageTokenJson[userDataListNextPageToken](request.NextPageToken)
+		if err != nil {
+			return nil, err
+		}
+		lastQueueName = token.LastTaskQueueName
+	}
+
+	rows, err := uds.UserDB.ListTaskQueueUserDataEntries(ctx, &sqlplugin.ListTaskQueueUserDataEntriesRequest{
+		NamespaceID:       namespaceID,
+		LastTaskQueueName: lastQueueName,
+		Limit:             request.PageSize,
+	})
+	if err != nil {
+		return nil, serviceerror.NewUnavailablef("ListTaskQueueUserDataEntries operation failed. Failed to get rows. Error: %v", err)
+	}
+
+	var nextPageToken []byte
+	if len(rows) == request.PageSize {
+		nextPageToken, err = serializePageTokenJson(&userDataListNextPageToken{LastTaskQueueName: rows[request.PageSize-1].TaskQueueName})
+		if err != nil {
+			return nil, serviceerror.NewInternal(err.Error())
+		}
+	}
+	entries := make([]persistence.InternalTaskQueueUserDataEntry, len(rows))
+	for i, row := range rows {
+		entries[i].TaskQueue = rows[i].TaskQueueName
+		entries[i].Data = persistence.NewDataBlob(row.Data, row.DataEncoding)
+		entries[i].Version = rows[i].Version
+	}
+	response := &persistence.InternalListTaskQueueUserDataEntriesResponse{
+		Entries:       entries,
+		NextPageToken: nextPageToken,
+	}
+
+	return response, nil
+}
+
+func (uds *userDataStore) GetTaskQueuesByBuildId(ctx context.Context, request *persistence.GetTaskQueuesByBuildIdRequest) ([]string, error) {
+	namespaceID, err := primitives.ParseUUID(request.NamespaceID)
+	if err != nil {
+		return nil, serviceerror.NewInternal(err.Error())
+	}
+	return uds.UserDB.GetTaskQueuesByBuildId(ctx, &sqlplugin.GetTaskQueuesByBuildIdRequest{NamespaceID: namespaceID, BuildID: request.BuildID})
+}
+
+func (uds *userDataStore) CountTaskQueuesByBuildId(ctx context.Context, request *persistence.CountTaskQueuesByBuildIdRequest) (int, error) {
+	namespaceID, err := primitives.ParseUUID(request.NamespaceID)
+	if err != nil {
+		return 0, serviceerror.NewInternal(err.Error())
+	}
+	return uds.UserDB.CountTaskQueuesByBuildId(ctx, &sqlplugin.CountTaskQueuesByBuildIdRequest{NamespaceID: namespaceID, BuildID: request.BuildID})
+}
+
+func (uds *userDataStore) txExecute(ctx context.Context, operation string, f func(tx sqlplugin.Tx) error) error {
+	tx, err := uds.UserDB.BeginTx(ctx)
+	if err != nil {
+		return serviceerror.NewUnavailablef("%s failed. Failed to start transaction. Error: %v", operation, err)
+	}
+	err = f(tx)
+	if err != nil {
+		rollBackErr := tx.Rollback()
+		if rollBackErr != nil {
+			uds.logger.Error("transaction rollback error", tag.Error(rollBackErr))
+		}
+
+		switch err.(type) {
+		case *persistence.ConditionFailedError,
+			*persistence.CurrentWorkflowConditionFailedError,
+			*persistence.WorkflowConditionFailedError,
+			*serviceerror.NamespaceAlreadyExists,
+			*persistence.ShardOwnershipLostError,
+			*serviceerror.Unavailable,
+			*serviceerror.NotFound:
+			return err
+		default:
+			return serviceerror.NewUnavailablef("%v: %v", operation, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return serviceerror.NewUnavailablef("%s operation failed. Failed to commit transaction. Error: %v", operation, err)
+	}
+	return nil
+}

--- a/common/persistence/sql/task_util.go
+++ b/common/persistence/sql/task_util.go
@@ -1,0 +1,34 @@
+package sql
+
+import (
+	"math"
+)
+
+func getPartitionForRangeHash(rangeHash uint32, totalPartitions uint32) uint32 {
+	if totalPartitions == 0 {
+		return 0
+	}
+	return rangeHash / getPartitionBoundaryStart(1, totalPartitions)
+}
+
+func getPartitionBoundaryStart(partition uint32, totalPartitions uint32) uint32 {
+	if totalPartitions == 0 {
+		return 0
+	}
+
+	if partition >= totalPartitions {
+		return math.MaxUint32
+	}
+
+	return uint32((float32(partition) / float32(totalPartitions)) * math.MaxUint32)
+}
+
+func getBoundariesForPartition(partition uint32, totalPartitions uint32) (uint32, uint32) {
+	endBoundary := getPartitionBoundaryStart(partition+1, totalPartitions)
+
+	if endBoundary != math.MaxUint32 {
+		endBoundary--
+	}
+
+	return getPartitionBoundaryStart(partition, totalPartitions), endBoundary
+}

--- a/common/persistence/sql/task_v1.go
+++ b/common/persistence/sql/task_v1.go
@@ -1,0 +1,476 @@
+package sql
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/dgryski/go-farm"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	"go.temporal.io/server/common/primitives"
+)
+
+type (
+	sqlTaskManagerV1 struct {
+		SqlStore
+		taskScanPartitions uint32
+		userDataStore
+	}
+)
+
+var (
+	// minUUID = primitives.MustParseUUID("00000000-0000-0000-0000-000000000000")
+	minTaskQueueId = make([]byte, 0)
+)
+
+func newTaskManagerV1(db sqlplugin.DB, uds *userDataStore, taskScanPartitions int, logger log.Logger) (*sqlTaskManagerV1, error) {
+	return &sqlTaskManagerV1{
+		SqlStore:           NewSqlStore(db, logger),
+		taskScanPartitions: uint32(taskScanPartitions),
+		userDataStore:      *uds,
+	}, nil
+}
+
+func (m *sqlTaskManagerV1) CreateTaskQueue(
+	ctx context.Context,
+	request *persistence.InternalCreateTaskQueueRequest,
+) error {
+	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
+	if err != nil {
+		return serviceerror.NewInternal(err.Error())
+	}
+	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue, request.TaskType, persistence.SubqueueZero)
+
+	row := sqlplugin.TaskQueuesRow{
+		RangeHash:    tqHash,
+		TaskQueueID:  tqId,
+		RangeID:      request.RangeID,
+		Data:         request.TaskQueueInfo.Data,
+		DataEncoding: request.TaskQueueInfo.EncodingType.String(),
+	}
+	if _, err := m.Db.InsertIntoTaskQueues(ctx, &row); err != nil {
+		if m.Db.IsDupEntryError(err) {
+			return &persistence.ConditionFailedError{Msg: err.Error()}
+		}
+		return serviceerror.NewUnavailablef("CreateTaskQueue operation failed. Failed to make task queue %v of type %v. Error: %v", request.TaskQueue, request.TaskType, err)
+	}
+
+	return nil
+}
+
+func (m *sqlTaskManagerV1) GetTaskQueue(
+	ctx context.Context,
+	request *persistence.InternalGetTaskQueueRequest,
+) (*persistence.InternalGetTaskQueueResponse, error) {
+	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
+	if err != nil {
+		return nil, serviceerror.NewInternal(err.Error())
+	}
+	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue, request.TaskType, persistence.SubqueueZero)
+	rows, err := m.Db.SelectFromTaskQueues(ctx, sqlplugin.TaskQueuesFilter{
+		RangeHash:   tqHash,
+		TaskQueueID: tqId,
+	})
+
+	switch err {
+	case nil:
+		if len(rows) != 1 {
+			return nil, serviceerror.NewUnavailablef(
+				"GetTaskQueue operation failed. Expect exactly one result row, but got %d for task queue %v of type %v",
+				len(rows), request.TaskQueue, request.TaskType)
+		}
+		row := rows[0]
+		return &persistence.InternalGetTaskQueueResponse{
+			RangeID:       row.RangeID,
+			TaskQueueInfo: persistence.NewDataBlob(row.Data, row.DataEncoding),
+		}, nil
+	case sql.ErrNoRows:
+		return nil, serviceerror.NewNotFoundf(
+			"GetTaskQueue operation failed. TaskQueue: %v, TaskQueueType: %v, Error: %v",
+			request.TaskQueue, request.TaskType, err)
+	default:
+		return nil, serviceerror.NewUnavailablef(
+			"GetTaskQueue operation failed. Failed to check if task queue %v of type %v existed. Error: %v",
+			request.TaskQueue, request.TaskType, err)
+	}
+}
+
+func (m *sqlTaskManagerV1) UpdateTaskQueue(
+	ctx context.Context,
+	request *persistence.InternalUpdateTaskQueueRequest,
+) (*persistence.UpdateTaskQueueResponse, error) {
+	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
+	if err != nil {
+		return nil, serviceerror.NewInternal(err.Error())
+	}
+
+	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue, request.TaskType, persistence.SubqueueZero)
+	var resp *persistence.UpdateTaskQueueResponse
+	err = m.SqlStore.txExecute(ctx, "UpdateTaskQueue", func(tx sqlplugin.Tx) error {
+		if err := lockTaskQueue(ctx,
+			tx,
+			tqHash,
+			tqId,
+			request.PrevRangeID,
+		); err != nil {
+			return err
+		}
+		result, err := tx.UpdateTaskQueues(ctx, &sqlplugin.TaskQueuesRow{
+			RangeHash:    tqHash,
+			TaskQueueID:  tqId,
+			RangeID:      request.RangeID,
+			Data:         request.TaskQueueInfo.Data,
+			DataEncoding: request.TaskQueueInfo.EncodingType.String(),
+		})
+		if err != nil {
+			return err
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if rowsAffected != 1 {
+			return fmt.Errorf("%v rows were affected instead of 1", rowsAffected)
+		}
+		resp = &persistence.UpdateTaskQueueResponse{}
+		return nil
+	})
+	return resp, err
+}
+
+func (m *sqlTaskManagerV1) ListTaskQueue(
+	ctx context.Context,
+	request *persistence.ListTaskQueueRequest,
+) (*persistence.InternalListTaskQueueResponse, error) {
+	pageToken := taskQueuePageToken{MinTaskQueueId: minTaskQueueId}
+	if request.PageToken != nil {
+		if err := gobDeserialize(request.PageToken, &pageToken); err != nil {
+			return nil, serviceerror.NewInternalf("error deserializing page token: %v", err)
+		}
+	}
+	var err error
+	var rows []sqlplugin.TaskQueuesRow
+	var shardGreaterThan uint32
+	var shardLessThan uint32
+
+	i := uint32(0)
+	if pageToken.MinRangeHash > 0 {
+		// Resume partition position from page token, if exists, before entering loop
+		i = getPartitionForRangeHash(pageToken.MinRangeHash, m.taskScanPartitions)
+	}
+
+	lastPageFull := !bytes.Equal(pageToken.MinTaskQueueId, minTaskQueueId)
+	for ; i < m.taskScanPartitions; i++ {
+		// Get start/end boundaries for partition
+		shardGreaterThan, shardLessThan = getBoundariesForPartition(i, m.taskScanPartitions)
+
+		// If page token hash is greater than the boundaries for this partition, use the pageToken hash for resume point
+		if pageToken.MinRangeHash > shardGreaterThan {
+			shardGreaterThan = pageToken.MinRangeHash
+		}
+
+		filter := sqlplugin.TaskQueuesFilter{
+			RangeHashGreaterThanEqualTo: shardGreaterThan,
+			RangeHashLessThanEqualTo:    shardLessThan,
+			TaskQueueIDGreaterThan:      minTaskQueueId,
+			PageSize:                    &request.PageSize,
+		}
+
+		if lastPageFull {
+			// Use page token TaskQueueID filter for this query and set this to false
+			// in order for the next partition so we don't miss any results.
+			filter.TaskQueueIDGreaterThan = pageToken.MinTaskQueueId
+			lastPageFull = false
+		}
+
+		rows, err = m.Db.SelectFromTaskQueues(ctx, filter)
+		if err != nil {
+			return nil, serviceerror.NewUnavailable(err.Error())
+		}
+
+		if len(rows) > 0 {
+			break
+		}
+	}
+
+	maxRangeHash := uint32(0)
+	resp := &persistence.InternalListTaskQueueResponse{
+		Items: make([]*persistence.InternalListTaskQueueItem, len(rows)),
+	}
+
+	for i, row := range rows {
+		resp.Items[i] = &persistence.InternalListTaskQueueItem{
+			RangeID:   row.RangeID,
+			TaskQueue: persistence.NewDataBlob(row.Data, row.DataEncoding),
+		}
+
+		// Only want to look at up to PageSize number of records to prevent losing data.
+		if row.RangeHash > maxRangeHash {
+			maxRangeHash = row.RangeHash
+		}
+
+		// Enforces PageSize
+		if i >= request.PageSize-1 {
+			break
+		}
+	}
+
+	var nextPageToken []byte
+	switch {
+	case len(rows) >= request.PageSize:
+		// Store the details of the lastRow seen up to PageSize.
+		// Note we don't increment the rangeHash as we do in the case below.
+		// This is so we can exhaust this hash before moving forward.
+		lastRow := &rows[request.PageSize-1]
+		nextPageToken, err = gobSerialize(&taskQueuePageToken{
+			MinRangeHash:   shardGreaterThan,
+			MinTaskQueueId: lastRow.TaskQueueID,
+		})
+	case shardLessThan < math.MaxUint32:
+		// Create page token with +1 from the last rangeHash we have seen to prevent duplicating the last row.
+		// Since we have not exceeded PageSize, we are confident we won't lose data here and we have exhausted this hash.
+		nextPageToken, err = gobSerialize(&taskQueuePageToken{MinRangeHash: shardLessThan + 1, MinTaskQueueId: minTaskQueueId})
+	}
+
+	if err != nil {
+		return nil, serviceerror.NewUnavailablef("error serializing nextPageToken:%v", err)
+	}
+
+	resp.NextPageToken = nextPageToken
+	return resp, nil
+}
+
+func (m *sqlTaskManagerV1) DeleteTaskQueue(
+	ctx context.Context,
+	request *persistence.DeleteTaskQueueRequest,
+) error {
+	nidBytes, err := primitives.ParseUUID(request.TaskQueue.NamespaceID)
+	if err != nil {
+		return serviceerror.NewUnavailable(err.Error())
+	}
+	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue.TaskQueueName, request.TaskQueue.TaskQueueType, persistence.SubqueueZero)
+	result, err := m.Db.DeleteFromTaskQueues(ctx, sqlplugin.TaskQueuesFilter{
+		RangeHash:   tqHash,
+		TaskQueueID: tqId,
+		RangeID:     &request.RangeID,
+	})
+	if err != nil {
+		return serviceerror.NewUnavailable(err.Error())
+	}
+	nRows, err := result.RowsAffected()
+	if err != nil {
+		return serviceerror.NewUnavailablef("rowsAffected returned error:%v", err)
+	}
+	if nRows != 1 {
+		return &persistence.ConditionFailedError{
+			Msg: fmt.Sprintf("delete failed: %v rows affected instead of 1", nRows),
+		}
+	}
+	return nil
+}
+func (m *sqlTaskManagerV1) CreateTasks(
+	ctx context.Context,
+	request *persistence.InternalCreateTasksRequest,
+) (*persistence.CreateTasksResponse, error) {
+	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
+	if err != nil {
+		return nil, serviceerror.NewUnavailable(err.Error())
+	}
+
+	// cache by subqueue to minimize calls to taskQueueIdAndHash
+	type pair struct {
+		id   []byte
+		hash uint32
+	}
+	cache := make(map[int]pair)
+	idAndHash := func(subqueue int) ([]byte, uint32) {
+		if pair, ok := cache[subqueue]; ok {
+			return pair.id, pair.hash
+		}
+		id, hash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue, request.TaskType, subqueue)
+		cache[subqueue] = pair{id: id, hash: hash}
+		return id, hash
+	}
+
+	tasksRows := make([]sqlplugin.TasksRow, len(request.Tasks))
+	for i, v := range request.Tasks {
+		tqId, tqHash := idAndHash(v.Subqueue)
+		tasksRows[i] = sqlplugin.TasksRow{
+			RangeHash:    tqHash,
+			TaskQueueID:  tqId,
+			TaskID:       v.TaskId,
+			Data:         v.Task.Data,
+			DataEncoding: v.Task.EncodingType.String(),
+		}
+	}
+	var resp *persistence.CreateTasksResponse
+	err = m.SqlStore.txExecute(ctx, "CreateTasks", func(tx sqlplugin.Tx) error {
+		if _, err1 := tx.InsertIntoTasks(ctx, tasksRows); err1 != nil {
+			return err1
+		}
+		// Lock task queue before committing.
+		tqId, tqHash := idAndHash(persistence.SubqueueZero)
+		if err := lockTaskQueue(ctx,
+			tx,
+			tqHash,
+			tqId,
+			request.RangeID,
+		); err != nil {
+			return err
+		}
+		resp = &persistence.CreateTasksResponse{UpdatedMetadata: false}
+		return nil
+	})
+	return resp, err
+}
+
+func (m *sqlTaskManagerV1) GetTasks(
+	ctx context.Context,
+	request *persistence.GetTasksRequest,
+) (*persistence.InternalGetTasksResponse, error) {
+	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
+	if err != nil {
+		return nil, serviceerror.NewUnavailable(err.Error())
+	}
+
+	inclusiveMinTaskID := request.InclusiveMinTaskID
+	exclusiveMaxTaskID := request.ExclusiveMaxTaskID
+	if len(request.NextPageToken) != 0 {
+		token, err := deserializePageTokenJson[matchingTaskPageToken](request.NextPageToken)
+		if err != nil {
+			return nil, err
+		}
+		inclusiveMinTaskID = token.TaskID
+	}
+
+	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue, request.TaskType, request.Subqueue)
+	rows, err := m.Db.SelectFromTasks(ctx, sqlplugin.TasksFilter{
+		RangeHash:          tqHash,
+		TaskQueueID:        tqId,
+		InclusiveMinTaskID: &inclusiveMinTaskID,
+		ExclusiveMaxTaskID: &exclusiveMaxTaskID,
+		PageSize:           &request.PageSize,
+	})
+	if err != nil {
+		return nil, serviceerror.NewUnavailablef("GetTasks operation failed. Failed to get rows. Error: %v", err)
+	}
+
+	response := &persistence.InternalGetTasksResponse{
+		Tasks: make([]*commonpb.DataBlob, len(rows)),
+	}
+	for i, v := range rows {
+		response.Tasks[i] = persistence.NewDataBlob(v.Data, v.DataEncoding)
+	}
+	if len(rows) == request.PageSize {
+		nextTaskID := rows[len(rows)-1].TaskID + 1
+		if nextTaskID < exclusiveMaxTaskID {
+			token, err := serializePageTokenJson(&matchingTaskPageToken{
+				TaskID: nextTaskID,
+			})
+			if err != nil {
+				return nil, err
+			}
+			response.NextPageToken = token
+		}
+	}
+
+	return response, nil
+}
+
+func (m *sqlTaskManagerV1) CompleteTasksLessThan(
+	ctx context.Context,
+	request *persistence.CompleteTasksLessThanRequest,
+) (int, error) {
+	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
+	if err != nil {
+		return 0, serviceerror.NewUnavailable(err.Error())
+	}
+	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueueName, request.TaskType, request.Subqueue)
+	result, err := m.Db.DeleteFromTasks(ctx, sqlplugin.TasksFilter{
+		RangeHash:          tqHash,
+		TaskQueueID:        tqId,
+		ExclusiveMaxTaskID: &request.ExclusiveMaxTaskID,
+		Limit:              &request.Limit,
+	})
+	if err != nil {
+		return 0, serviceerror.NewUnavailable(err.Error())
+	}
+	nRows, err := result.RowsAffected()
+	if err != nil {
+		return 0, serviceerror.NewUnavailablef("rowsAffected returned error: %v", err)
+	}
+	return int(nRows), nil
+}
+
+// Returns the persistence task queue id and a uint32 hash for a task queue.
+func (m *sqlTaskManagerV1) taskQueueIdAndHash(
+	namespaceID primitives.UUID,
+	taskQueueName string,
+	taskType enumspb.TaskQueueType,
+	subqueue int,
+) ([]byte, uint32) {
+	id := m.taskQueueId(namespaceID, taskQueueName, taskType, subqueue)
+	return id, farm.Fingerprint32(id)
+}
+
+func (m *sqlTaskManagerV1) taskQueueId(
+	namespaceID primitives.UUID,
+	taskQueueName string,
+	taskType enumspb.TaskQueueType,
+	subqueue int,
+) []byte {
+	idBytes := make([]byte, 0, 16+len(taskQueueName)+1+binary.MaxVarintLen16)
+	idBytes = append(idBytes, namespaceID...)
+	idBytes = append(idBytes, []byte(taskQueueName)...)
+
+	// To ensure that different names+types+subqueue ids never collide, we mark types
+	// containing subqueues with an extra high bit, and then append the subqueue id. There are
+	// only a few task queue types (currently 3), so the high bits are free. (If we have more
+	// fields to append, we can use the next lower bit to mark the presence of that one, etc..)
+	const hasSubqueue = 0x80
+
+	if subqueue > 0 {
+		idBytes = append(idBytes, uint8(taskType)|hasSubqueue)
+		idBytes = binary.AppendUvarint(idBytes, uint64(subqueue))
+	} else {
+		idBytes = append(idBytes, uint8(taskType))
+	}
+
+	return idBytes
+}
+
+func lockTaskQueue(
+	ctx context.Context,
+	tx sqlplugin.Tx,
+	tqHash uint32,
+	tqId []byte,
+	oldRangeID int64,
+) error {
+	rangeID, err := tx.LockTaskQueues(ctx, sqlplugin.TaskQueuesFilter{
+		RangeHash:   tqHash,
+		TaskQueueID: tqId,
+	})
+	switch err {
+	case nil:
+		if rangeID != oldRangeID {
+			return &persistence.ConditionFailedError{
+				Msg: fmt.Sprintf("Task queue range ID was %v when it was should have been %v", rangeID, oldRangeID),
+			}
+		}
+		return nil
+
+	case sql.ErrNoRows:
+		return &persistence.ConditionFailedError{Msg: "Task queue does not exists"}
+
+	default:
+		return serviceerror.NewUnavailablef("Failed to lock task queue. Error: %v", err)
+	}
+}

--- a/common/persistence/tests/mysql_test.go
+++ b/common/persistence/tests/mysql_test.go
@@ -245,6 +245,23 @@ func TestMySQLMatchingTaskSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
+func TestMySQLMatchingTaskV2Suite(t *testing.T) {
+	cfg := NewMySQLConfig()
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+	if err != nil {
+		t.Fatalf("unable to create MySQL DB: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+		TearDownMySQLDatabase(t, cfg)
+	}()
+
+	s := sqltests.NewMatchingTaskSuiteV2(t, store)
+	suite.Run(t, s)
+}
+
 func TestMySQLMatchingTaskQueueSuite(t *testing.T) {
 	cfg := NewMySQLConfig()
 	SetupMySQLDatabase(t, cfg)
@@ -259,6 +276,23 @@ func TestMySQLMatchingTaskQueueSuite(t *testing.T) {
 	}()
 
 	s := sqltests.NewMatchingTaskQueueSuite(t, store)
+	suite.Run(t, s)
+}
+
+func TestMySQLMatchingTaskQueueSuiteV2(t *testing.T) {
+	cfg := NewMySQLConfig()
+	SetupMySQLDatabase(t, cfg)
+	SetupMySQLSchema(t, cfg)
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+	if err != nil {
+		t.Fatalf("unable to create MySQL DB: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+		TearDownMySQLDatabase(t, cfg)
+	}()
+
+	s := sqltests.NewMatchingTaskQueueSuiteV2(t, store)
 	suite.Run(t, s)
 }
 

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -245,6 +245,23 @@ func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskSuite() {
 	suite.Run(p.T(), s)
 }
 
+func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskV2Suite() {
+	cfg := NewPostgreSQLConfig(p.pluginName)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+	if err != nil {
+		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+		TearDownPostgreSQLDatabase(p.T(), cfg)
+	}()
+
+	s := sqltests.NewMatchingTaskSuiteV2(p.T(), store)
+	suite.Run(p.T(), s)
+}
+
 func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskQueueSuite() {
 	cfg := NewPostgreSQLConfig(p.pluginName)
 	SetupPostgreSQLDatabase(p.T(), cfg)
@@ -259,6 +276,23 @@ func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskQueueSuite() {
 	}()
 
 	s := sqltests.NewMatchingTaskQueueSuite(p.T(), store)
+	suite.Run(p.T(), s)
+}
+
+func (p *PostgreSQLSuite) TestPostgreSQLMatchingTaskQueueSuiteV2() {
+	cfg := NewPostgreSQLConfig(p.pluginName)
+	SetupPostgreSQLDatabase(p.T(), cfg)
+	SetupPostgreSQLSchema(p.T(), cfg)
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+	if err != nil {
+		p.T().Fatalf("unable to create PostgreSQL DB: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+		TearDownPostgreSQLDatabase(p.T(), cfg)
+	}()
+
+	s := sqltests.NewMatchingTaskQueueSuiteV2(p.T(), store)
 	suite.Run(p.T(), s)
 }
 

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -537,6 +537,20 @@ func TestSQLiteMatchingTaskSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
+func TestSQLiteMatchingTaskV2Suite(t *testing.T) {
+	cfg := NewSQLiteMemoryConfig()
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+	if err != nil {
+		t.Fatalf("unable to create SQLite DB: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+	}()
+
+	s := sqltests.NewMatchingTaskSuiteV2(t, store)
+	suite.Run(t, s)
+}
+
 func TestSQLiteMatchingTaskQueueSuite(t *testing.T) {
 	cfg := NewSQLiteMemoryConfig()
 	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
@@ -548,6 +562,20 @@ func TestSQLiteMatchingTaskQueueSuite(t *testing.T) {
 	}()
 
 	s := sqltests.NewMatchingTaskQueueSuite(t, store)
+	suite.Run(t, s)
+}
+
+func TestSQLiteMatchingTaskQueueSuiteV2(t *testing.T) {
+	cfg := NewSQLiteMemoryConfig()
+	store, err := sql.NewSQLDB(sqlplugin.DbKindMain, cfg, resolver.NewNoopResolver(), log.NewTestLogger(), metrics.NoopMetricsHandler)
+	if err != nil {
+		t.Fatalf("unable to create SQLite DB: %v", err)
+	}
+	defer func() {
+		_ = store.Close()
+	}()
+
+	s := sqltests.NewMatchingTaskQueueSuiteV2(t, store)
 	suite.Run(t, s)
 }
 

--- a/schema/mysql/v8/temporal/schema.sql
+++ b/schema/mysql/v8/temporal/schema.sql
@@ -83,8 +83,32 @@ CREATE TABLE tasks (
   PRIMARY KEY (range_hash, task_queue_id, task_id)
 );
 
+-- Stores activity or workflow tasks
+-- Used for fairness scheduling. (pass, task_id) are monotonically increasing.
+CREATE TABLE tasks_v2 (
+  range_hash INT UNSIGNED NOT NULL,
+  task_queue_id VARBINARY(272) NOT NULL,
+  task_id BIGINT NOT NULL,
+  pass BIGINT NOT NULL, -- pass for tasks (see stride scheduling algorithm for fairness)
+  --
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id, pass, task_id)
+);
+
 -- Stores ephemeral task queue information such as ack levels and expiry times
 CREATE TABLE task_queues (
+  range_hash INT UNSIGNED NOT NULL,
+  task_queue_id VARBINARY(272) NOT NULL,
+  --
+  range_id BIGINT NOT NULL,
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id)
+);
+
+-- Stores ephemeral task queue information such as ack levels and expiry times
+CREATE TABLE task_queues_v2 (
   range_hash INT UNSIGNED NOT NULL,
   task_queue_id VARBINARY(272) NOT NULL,
   --

--- a/schema/mysql/v8/temporal/versioned/v1.18/manifest.json
+++ b/schema/mysql/v8/temporal/versioned/v1.18/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.18",
+  "MinCompatibleVersion": "1.0",
+  "Description": "Adds tasks_v2 table for fairness tasks",
+  "SchemaUpdateCqlFiles": [
+    "tasks_v2.sql"
+]
+}

--- a/schema/mysql/v8/temporal/versioned/v1.18/tasks_v2.sql
+++ b/schema/mysql/v8/temporal/versioned/v1.18/tasks_v2.sql
@@ -1,0 +1,24 @@
+
+-- Stores activity or workflow tasks
+-- Used for fairness scheduling. (pass, task_id) are monotonically increasing.
+CREATE TABLE tasks_v2 (
+  range_hash INT UNSIGNED NOT NULL,
+  task_queue_id VARBINARY(272) NOT NULL,
+  task_id BIGINT NOT NULL,
+  pass BIGINT NOT NULL, -- pass for tasks (see stride scheduling algorithm for fairness)
+  --
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id, pass, task_id)
+);
+
+-- Stores ephemeral task queue information such as ack levels and expiry times
+CREATE TABLE task_queues_v2 (
+  range_hash INT UNSIGNED NOT NULL,
+  task_queue_id VARBINARY(272) NOT NULL,
+  --
+  range_id BIGINT NOT NULL,
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id)
+);

--- a/schema/mysql/v8/version.go
+++ b/schema/mysql/v8/version.go
@@ -3,7 +3,7 @@ package v8
 // NOTE: whenever there is a new database schema update, plz update the following versions
 
 // Version is the MySQL database release version
-const Version = "1.17"
+const Version = "1.18"
 
 // VisibilityVersion is the MySQL visibility database release version
 const VisibilityVersion = "1.9"

--- a/schema/postgresql/v12/temporal/schema.sql
+++ b/schema/postgresql/v12/temporal/schema.sql
@@ -83,8 +83,32 @@ CREATE TABLE tasks (
   PRIMARY KEY (range_hash, task_queue_id, task_id)
 );
 
+-- Stores activity or workflow tasks
+-- Used for fairness scheduling. (pass, task_id) are monotonically increasing.
+CREATE TABLE tasks_v2 (
+  range_hash BIGINT NOT NULL,
+  task_queue_id BYTEA NOT NULL,
+  task_id BIGINT NOT NULL,
+  pass BIGINT NOT NULL, -- pass for tasks (see stride scheduling algorithm for fairness)
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id, pass, task_id)
+);
+
 -- Stores ephemeral task queue information such as ack levels and expiry times
 CREATE TABLE task_queues (
+  range_hash BIGINT NOT NULL,
+  task_queue_id BYTEA NOT NULL,
+  --
+  range_id BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id)
+);
+
+-- Stores ephemeral task queue information such as ack levels and expiry times
+CREATE TABLE task_queues_v2 (
   range_hash BIGINT NOT NULL,
   task_queue_id BYTEA NOT NULL,
   --

--- a/schema/postgresql/v12/temporal/versioned/v1.18/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.18/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.18",
+  "MinCompatibleVersion": "1.0",
+  "Description": "Adds tasks_v2 table for fairness tasks",
+  "SchemaUpdateCqlFiles": [
+    "tasks_v2.sql"
+  ]
+}

--- a/schema/postgresql/v12/temporal/versioned/v1.18/tasks_v2.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.18/tasks_v2.sql
@@ -1,0 +1,24 @@
+
+-- Stores activity or workflow tasks
+-- Used for fairness scheduling. (pass, task_id) are monotonically increasing.
+CREATE TABLE tasks_v2 (
+  range_hash INT UNSIGNED NOT NULL,
+  task_queue_id VARBINARY(272) NOT NULL,
+  task_id BIGINT NOT NULL,
+  pass BIGINT NOT NULL, -- pass for tasks (see stride scheduling algorithm for fairness)
+  --
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id, pass, task_id)
+);
+
+-- Stores ephemeral task queue information such as ack levels and expiry times
+CREATE TABLE task_queues_v2 (
+  range_hash BIGINT NOT NULL,
+  task_queue_id BYTEA NOT NULL,
+  --
+  range_id BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id)
+);

--- a/schema/postgresql/v12/version.go
+++ b/schema/postgresql/v12/version.go
@@ -4,7 +4,7 @@ package v12
 
 // Version is the Postgres database release version
 // Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres
-const Version = "1.17"
+const Version = "1.18"
 
 // VisibilityVersion is the Postgres visibility database release version
 // Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres

--- a/schema/sqlite/v3/temporal/schema.sql
+++ b/schema/sqlite/v3/temporal/schema.sql
@@ -82,8 +82,32 @@ CREATE TABLE tasks (
 	PRIMARY KEY (range_hash, task_queue_id, task_id)
 );
 
+-- Stores activity or workflow tasks
+-- Used for fairness scheduling. (pass, task_id) are monotonically increasing.
+CREATE TABLE tasks_v2 (
+	range_hash INT UNSIGNED NOT NULL,
+	task_queue_id VARBINARY(272) NOT NULL,
+	task_id BIGINT NOT NULL,
+	pass BIGINT NOT NULL, -- pass for tasks (see stride scheduling algorithm for fairness)
+	--
+	data MEDIUMBLOB NOT NULL,
+	data_encoding VARCHAR(16) NOT NULL,
+	PRIMARY KEY (range_hash, task_queue_id, task_id)
+);
+
 -- Stores ephemeral task queue information such as ack levels and expiry times
 CREATE TABLE task_queues (
+	range_hash INT UNSIGNED NOT NULL,
+	task_queue_id VARBINARY(272) NOT NULL,
+	--
+	range_id BIGINT NOT NULL,
+	data MEDIUMBLOB NOT NULL,
+	data_encoding VARCHAR(16) NOT NULL,
+	PRIMARY KEY (range_hash, task_queue_id)
+);
+
+-- Stores ephemeral task queue information such as ack levels and expiry times
+CREATE TABLE task_queues_v2 (
 	range_hash INT UNSIGNED NOT NULL,
 	task_queue_id VARBINARY(272) NOT NULL,
 	--

--- a/schema/sqlite/v3/temporal/versioned/v1.0/manifest.json
+++ b/schema/sqlite/v3/temporal/versioned/v1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.18",
+  "MinCompatibleVersion": "1.0",
+  "Description": "Adds tasks_v2 table for fairness tasks",
+  "SchemaUpdateCqlFiles": [
+    "tasks_v2.sql"
+  ]
+}

--- a/schema/sqlite/v3/temporal/versioned/v1.0/tasks_v2.sql
+++ b/schema/sqlite/v3/temporal/versioned/v1.0/tasks_v2.sql
@@ -1,0 +1,21 @@
+CREATE TABLE tasks_v2 (
+  range_hash INT UNSIGNED NOT NULL,
+  task_queue_id VARBINARY(272) NOT NULL,
+  task_id BIGINT NOT NULL,
+  pass BIGINT NOT NULL, -- pass for tasks (see stride scheduling algorithm for fairness)
+  --
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id, pass, task_id)
+);
+
+-- Stores ephemeral task queue information such as ack levels and expiry times
+CREATE TABLE task_queues_v2 (
+	range_hash INT UNSIGNED NOT NULL,
+	task_queue_id VARBINARY(272) NOT NULL,
+	--
+	range_id BIGINT NOT NULL,
+	data MEDIUMBLOB NOT NULL,
+	data_encoding VARCHAR(16) NOT NULL,
+	PRIMARY KEY (range_hash, task_queue_id)
+);

--- a/schema/sqlite/version.go
+++ b/schema/sqlite/version.go
@@ -1,7 +1,7 @@
 package sqlite
 
 // Version is the SQLite database release version
-const Version = "0.9"
+const Version = "1.0"
 
 // VisibilityVersion is the SQLite visibility database release version
 const VisibilityVersion = "0.1"


### PR DESCRIPTION
Created a new table in SQL schema - tasks_v2 to support Fairness. Added schema changes for MySQL, PostgreSQL, and SQLite. Added new SQL plugin files for matching task queue and task v2. Updated existing SQL plugin files to support the new task v2 structure. Updated tests to cover the new task v2 functionality.

## What changed?
+ Introduced 2 new tables tasks_v2 and task_queue_v2 to support fairness and be consistent with cassandra schema.
+ Added schema changes for MySQL, PostgreSQL, and SQLite. 
+ Added new SQL plugin files for matching task queue and task v2. 
+ Updated existing SQL plugin files to support the new task v2 structure. 
+ Updated tests to cover the new task v2 functionality.

## Why?
+ Updated tasks to store pass value for fairness.
+ Maintain separate tables for fairness and eventually deprecate the V1 schema. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
