### PR TITLE
Cloud/v1.29.0-136 patch

### DIFF
--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -289,9 +289,11 @@ func (e *ExecutableTaskImpl) emitFinishMetrics(
 	now time.Time,
 ) {
 	if e.isDuplicated {
-		metrics.ReplicationDuplicatedTaskCount.With(e.MetricsHandler).Record(1,
-			metrics.OperationTag(e.metricsTag),
-			metrics.NamespaceTag(e.replicationTask.RawTaskInfo.NamespaceId))
+		if e.replicationTask.RawTaskInfo != nil {
+			metrics.ReplicationDuplicatedTaskCount.With(e.MetricsHandler).Record(1,
+				metrics.OperationTag(e.metricsTag),
+				metrics.NamespaceTag(e.replicationTask.RawTaskInfo.NamespaceId))
+		}
 		return
 	}
 	nsTag := metrics.NamespaceUnknownTag()


### PR DESCRIPTION
## What changed?
- cherry-picking https://github.com/temporalio/temporal/pull/8005 to hot-fix the 136 release.

## Why?
- hotfix time

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- None