### PR TITLE
Cloud/v1.29.0 136 -update server version

### DIFF
--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -24,7 +24,7 @@ const (
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
-	ServerVersion = "1.29.0-136.2"
+	ServerVersion = "1.29.0-136.3"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"


### PR DESCRIPTION
## What changed?
- Manually updating the server version here since the createTag GH workflow failed due to this branch having an untagged api dependency :sigh:

## Why?
- hotfix

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- None
