### PR TITLE
stubs for Fetch/Update worker config

### DIFF
--- a/client/frontend/client_gen.go
+++ b/client/frontend/client_gen.go
@@ -199,6 +199,16 @@ func (c *clientImpl) ExecuteMultiOperation(
 	return c.client.ExecuteMultiOperation(ctx, request, opts...)
 }
 
+func (c *clientImpl) FetchWorkerConfig(
+	ctx context.Context,
+	request *workflowservice.FetchWorkerConfigRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.FetchWorkerConfigResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.FetchWorkerConfig(ctx, request, opts...)
+}
+
 func (c *clientImpl) GetClusterInfo(
 	ctx context.Context,
 	request *workflowservice.GetClusterInfoRequest,
@@ -867,6 +877,16 @@ func (c *clientImpl) UpdateWorkerBuildIdCompatibility(
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.UpdateWorkerBuildIdCompatibility(ctx, request, opts...)
+}
+
+func (c *clientImpl) UpdateWorkerConfig(
+	ctx context.Context,
+	request *workflowservice.UpdateWorkerConfigRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.UpdateWorkerConfigResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.UpdateWorkerConfig(ctx, request, opts...)
 }
 
 func (c *clientImpl) UpdateWorkerDeploymentVersionMetadata(

--- a/client/frontend/metric_client_gen.go
+++ b/client/frontend/metric_client_gen.go
@@ -275,6 +275,20 @@ func (c *metricClient) ExecuteMultiOperation(
 	return c.client.ExecuteMultiOperation(ctx, request, opts...)
 }
 
+func (c *metricClient) FetchWorkerConfig(
+	ctx context.Context,
+	request *workflowservice.FetchWorkerConfigRequest,
+	opts ...grpc.CallOption,
+) (_ *workflowservice.FetchWorkerConfigResponse, retError error) {
+
+	metricsHandler, startTime := c.startMetricsRecording(ctx, "FrontendClientFetchWorkerConfig")
+	defer func() {
+		c.finishMetricsRecording(metricsHandler, startTime, retError)
+	}()
+
+	return c.client.FetchWorkerConfig(ctx, request, opts...)
+}
+
 func (c *metricClient) GetClusterInfo(
 	ctx context.Context,
 	request *workflowservice.GetClusterInfoRequest,
@@ -1211,6 +1225,20 @@ func (c *metricClient) UpdateWorkerBuildIdCompatibility(
 	}()
 
 	return c.client.UpdateWorkerBuildIdCompatibility(ctx, request, opts...)
+}
+
+func (c *metricClient) UpdateWorkerConfig(
+	ctx context.Context,
+	request *workflowservice.UpdateWorkerConfigRequest,
+	opts ...grpc.CallOption,
+) (_ *workflowservice.UpdateWorkerConfigResponse, retError error) {
+
+	metricsHandler, startTime := c.startMetricsRecording(ctx, "FrontendClientUpdateWorkerConfig")
+	defer func() {
+		c.finishMetricsRecording(metricsHandler, startTime, retError)
+	}()
+
+	return c.client.UpdateWorkerConfig(ctx, request, opts...)
 }
 
 func (c *metricClient) UpdateWorkerDeploymentVersionMetadata(

--- a/client/frontend/retryable_client_gen.go
+++ b/client/frontend/retryable_client_gen.go
@@ -296,6 +296,21 @@ func (c *retryableClient) ExecuteMultiOperation(
 	return resp, err
 }
 
+func (c *retryableClient) FetchWorkerConfig(
+	ctx context.Context,
+	request *workflowservice.FetchWorkerConfigRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.FetchWorkerConfigResponse, error) {
+	var resp *workflowservice.FetchWorkerConfigResponse
+	op := func(ctx context.Context) error {
+		var err error
+		resp, err = c.client.FetchWorkerConfig(ctx, request, opts...)
+		return err
+	}
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
+	return resp, err
+}
+
 func (c *retryableClient) GetClusterInfo(
 	ctx context.Context,
 	request *workflowservice.GetClusterInfoRequest,
@@ -1295,6 +1310,21 @@ func (c *retryableClient) UpdateWorkerBuildIdCompatibility(
 	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.UpdateWorkerBuildIdCompatibility(ctx, request, opts...)
+		return err
+	}
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
+	return resp, err
+}
+
+func (c *retryableClient) UpdateWorkerConfig(
+	ctx context.Context,
+	request *workflowservice.UpdateWorkerConfigRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.UpdateWorkerConfigResponse, error) {
+	var resp *workflowservice.UpdateWorkerConfigResponse
+	op := func(ctx context.Context) error {
+		var err error
+		resp, err = c.client.UpdateWorkerConfig(ctx, request, opts...)
 		return err
 	}
 	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)

--- a/cmd/tools/getproto/files.go
+++ b/cmd/tools/getproto/files.go
@@ -77,6 +77,7 @@ func init() {
 	importMap["temporal/api/schedule/v1/message.proto"] = schedule.File_temporal_api_schedule_v1_message_proto
 	importMap["temporal/api/sdk/v1/task_complete_metadata.proto"] = sdk.File_temporal_api_sdk_v1_task_complete_metadata_proto
 	importMap["temporal/api/sdk/v1/user_metadata.proto"] = sdk.File_temporal_api_sdk_v1_user_metadata_proto
+	importMap["temporal/api/sdk/v1/worker_config.proto"] = sdk.File_temporal_api_sdk_v1_worker_config_proto
 	importMap["temporal/api/taskqueue/v1/message.proto"] = taskqueue.File_temporal_api_taskqueue_v1_message_proto
 	importMap["temporal/api/update/v1/message.proto"] = update.File_temporal_api_update_v1_message_proto
 	importMap["temporal/api/version/v1/message.proto"] = version.File_temporal_api_version_v1_message_proto

--- a/common/api/metadata.go
+++ b/common/api/metadata.go
@@ -158,6 +158,8 @@ var (
 		"RecordWorkerHeartbeat":                 {Scope: ScopeNamespace, Access: AccessWrite, Polling: PollingNone},
 		"ListWorkers":                           {Scope: ScopeNamespace, Access: AccessReadOnly, Polling: PollingNone},
 		"UpdateTaskQueueConfig":                 {Scope: ScopeNamespace, Access: AccessWrite, Polling: PollingNone},
+		"FetchWorkerConfig":                     {Scope: ScopeNamespace, Access: AccessReadOnly, Polling: PollingNone},
+		"UpdateWorkerConfig":                    {Scope: ScopeNamespace, Access: AccessWrite, Polling: PollingNone},
 	}
 	operatorServiceMetadata = map[string]MethodMetadata{
 		"AddSearchAttributes":      {Scope: ScopeNamespace, Access: AccessAdmin, Polling: PollingNone},

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2728,4 +2728,10 @@ WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 		false,
 		`ListWorkersEnabled is a "feature enable" flag. It allows clients to get workers heartbeat information.`,
 	)
+
+	WorkerCommandsEnabled = NewNamespaceBoolSetting(
+		"frontend.WorkerCommandsEnabled",
+		false,
+		`WorkerCommandsEnabled is a "feature enable" flag. It allows clients to send commands to the workers.`,
+	)
 )

--- a/common/rpc/interceptor/logtags/workflow_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/workflow_service_server_gen.go
@@ -91,6 +91,10 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 		return nil
 	case *workflowservice.ExecuteMultiOperationResponse:
 		return nil
+	case *workflowservice.FetchWorkerConfigRequest:
+		return nil
+	case *workflowservice.FetchWorkerConfigResponse:
+		return nil
 	case *workflowservice.GetClusterInfoRequest:
 		return nil
 	case *workflowservice.GetClusterInfoResponse:
@@ -431,6 +435,10 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 	case *workflowservice.UpdateWorkerBuildIdCompatibilityRequest:
 		return nil
 	case *workflowservice.UpdateWorkerBuildIdCompatibilityResponse:
+		return nil
+	case *workflowservice.UpdateWorkerConfigRequest:
+		return nil
+	case *workflowservice.UpdateWorkerConfigResponse:
 		return nil
 	case *workflowservice.UpdateWorkerDeploymentVersionMetadataRequest:
 		return nil

--- a/common/rpc/interceptor/redirection.go
+++ b/common/rpc/interceptor/redirection.go
@@ -131,6 +131,8 @@ var (
 		"RecordWorkerHeartbeat": func() any { return &workflowservice.RecordWorkerHeartbeatResponse{} },
 		"ListWorkers":           func() any { return &workflowservice.ListWorkersResponse{} },
 		"UpdateTaskQueueConfig": func() any { return &workflowservice.UpdateTaskQueueConfigResponse{} },
+		"FetchWorkerConfig":     func() any { return &workflowservice.FetchWorkerConfigResponse{} },
+		"UpdateWorkerConfig":    func() any { return &workflowservice.UpdateWorkerConfigResponse{} },
 	}
 )
 

--- a/common/rpc/interceptor/redirection_test.go
+++ b/common/rpc/interceptor/redirection_test.go
@@ -186,6 +186,8 @@ func (s *redirectionInterceptorSuite) TestGlobalAPI() {
 		"RecordWorkerHeartbeat":                 {},
 		"ListWorkers":                           {},
 		"UpdateTaskQueueConfig":                 {},
+		"FetchWorkerConfig":                     {},
+		"UpdateWorkerConfig":                    {},
 	}, apis)
 }
 

--- a/common/testing/mockapi/workflowservicemock/v1/service_grpc.pb.mock.go
+++ b/common/testing/mockapi/workflowservicemock/v1/service_grpc.pb.mock.go
@@ -422,6 +422,26 @@ func (mr *MockWorkflowServiceClientMockRecorder) ExecuteMultiOperation(ctx, in a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteMultiOperation", reflect.TypeOf((*MockWorkflowServiceClient)(nil).ExecuteMultiOperation), varargs...)
 }
 
+// FetchWorkerConfig mocks base method.
+func (m *MockWorkflowServiceClient) FetchWorkerConfig(ctx context.Context, in *workflowservice.FetchWorkerConfigRequest, opts ...grpc.CallOption) (*workflowservice.FetchWorkerConfigResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "FetchWorkerConfig", varargs...)
+	ret0, _ := ret[0].(*workflowservice.FetchWorkerConfigResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchWorkerConfig indicates an expected call of FetchWorkerConfig.
+func (mr *MockWorkflowServiceClientMockRecorder) FetchWorkerConfig(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchWorkerConfig", reflect.TypeOf((*MockWorkflowServiceClient)(nil).FetchWorkerConfig), varargs...)
+}
+
 // GetClusterInfo mocks base method.
 func (m *MockWorkflowServiceClient) GetClusterInfo(ctx context.Context, in *workflowservice.GetClusterInfoRequest, opts ...grpc.CallOption) (*workflowservice.GetClusterInfoResponse, error) {
 	m.ctrl.T.Helper()
@@ -1760,6 +1780,26 @@ func (mr *MockWorkflowServiceClientMockRecorder) UpdateWorkerBuildIdCompatibilit
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkerBuildIdCompatibility", reflect.TypeOf((*MockWorkflowServiceClient)(nil).UpdateWorkerBuildIdCompatibility), varargs...)
+}
+
+// UpdateWorkerConfig mocks base method.
+func (m *MockWorkflowServiceClient) UpdateWorkerConfig(ctx context.Context, in *workflowservice.UpdateWorkerConfigRequest, opts ...grpc.CallOption) (*workflowservice.UpdateWorkerConfigResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateWorkerConfig", varargs...)
+	ret0, _ := ret[0].(*workflowservice.UpdateWorkerConfigResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateWorkerConfig indicates an expected call of UpdateWorkerConfig.
+func (mr *MockWorkflowServiceClientMockRecorder) UpdateWorkerConfig(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkerConfig", reflect.TypeOf((*MockWorkflowServiceClient)(nil).UpdateWorkerConfig), varargs...)
 }
 
 // UpdateWorkerDeploymentVersionMetadata mocks base method.

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	go.temporal.io/api v1.50.1-0.20250716181412-26fbc96fd502
+	go.temporal.io/api v1.50.1-0.20250721165633-026209e16a17
 	go.temporal.io/sdk v1.34.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/fx v1.23.0

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	go.temporal.io/api v1.50.1-0.20250718211104-1dc43113346a
+	go.temporal.io/api v1.50.1-0.20250716181412-26fbc96fd502
 	go.temporal.io/sdk v1.34.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/fx v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -399,8 +399,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.50.1-0.20250718211104-1dc43113346a h1:6FHXvm124f1Sbge/4VrARNeEMpDkQyNr5axDfebE580=
-go.temporal.io/api v1.50.1-0.20250718211104-1dc43113346a/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.50.1-0.20250716181412-26fbc96fd502 h1:o0nZpAIKXS0S6A9gNZTHPWFxKTHp3wOjntKdPVzEdP4=
+go.temporal.io/api v1.50.1-0.20250716181412-26fbc96fd502/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.34.0 h1:VLg/h6ny7GvLFVoQPqz2NcC93V9yXboQwblkRvZ1cZE=
 go.temporal.io/sdk v1.34.0/go.mod h1:iE4U5vFrH3asOhqpBBphpj9zNtw8btp8+MSaf5A0D3w=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/go.sum
+++ b/go.sum
@@ -399,8 +399,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.50.1-0.20250716181412-26fbc96fd502 h1:o0nZpAIKXS0S6A9gNZTHPWFxKTHp3wOjntKdPVzEdP4=
-go.temporal.io/api v1.50.1-0.20250716181412-26fbc96fd502/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.50.1-0.20250721165633-026209e16a17 h1:sJ873KasmwVFTSTcD+b03I838HYFmlWjfBwEuEsNtF4=
+go.temporal.io/api v1.50.1-0.20250721165633-026209e16a17/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.34.0 h1:VLg/h6ny7GvLFVoQPqz2NcC93V9yXboQwblkRvZ1cZE=
 go.temporal.io/sdk v1.34.0/go.mod h1:iE4U5vFrH3asOhqpBBphpj9zNtw8btp8+MSaf5A0D3w=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -144,6 +144,8 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/ShutdownWorker":                     5,
 		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkflowExecutionHistoryReverse": 5,
 		"/temporal.api.workflowservice.v1.WorkflowService/RecordWorkerHeartbeat":              5,
+		"/temporal.api.workflowservice.v1.WorkflowService/FetchWorkerConfig":                  5,
+		"/temporal.api.workflowservice.v1.WorkflowService/UpdateWorkerConfig":                 5,
 
 		// GetWorkflowExecutionHistory with WaitNewEvent set to true is a long poll API. Consider it as any other poll API.
 		PollWorkflowHistoryAPIName: 5,

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -213,6 +213,7 @@ type Config struct {
 
 	WorkerHeartbeatsEnabled dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	ListWorkersEnabled      dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	WorkerCommandsEnabled   dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
 	HTTPAllowedHosts *dynamicconfig.GlobalCachedTypedValue[*regexp.Regexp]
 }
@@ -363,6 +364,7 @@ func NewConfig(
 		MaxWorkflowRulesPerNamespace:   dynamicconfig.MaxWorkflowRulesPerNamespace.Get(dc),
 		WorkerHeartbeatsEnabled:        dynamicconfig.WorkerHeartbeatsEnabled.Get(dc),
 		ListWorkersEnabled:             dynamicconfig.ListWorkersEnabled.Get(dc),
+		WorkerCommandsEnabled:          dynamicconfig.WorkerCommandsEnabled.Get(dc),
 
 		HTTPAllowedHosts: dynamicconfig.NewGlobalCachedTypedValue(dc, dynamicconfig.FrontendHTTPAllowedHosts, func(patterns []string) (*regexp.Regexp, error) {
 			if len(patterns) == 0 {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -6168,3 +6168,32 @@ func (wh *WorkflowHandler) UpdateTaskQueueConfig(
 		Config: resp.UpdatedTaskqueueConfig,
 	}, nil
 }
+
+func (wh *WorkflowHandler) FetchWorkerConfig(_ context.Context, request *workflowservice.FetchWorkerConfigRequest,
+) (*workflowservice.FetchWorkerConfigResponse, error) {
+	if !wh.config.WorkerCommandsEnabled(request.GetNamespace()) {
+		return nil, serviceerror.NewUnimplemented("FetchWorkerConfig command is not supported")
+	}
+	return nil, serviceerror.NewUnimplemented("FetchWorkerConfig command is not supported")
+}
+
+func (wh *WorkflowHandler) UpdateWorkerConfig(_ context.Context, request *workflowservice.UpdateWorkerConfigRequest,
+) (*workflowservice.UpdateWorkerConfigResponse, error) {
+	if !wh.config.WorkerCommandsEnabled(request.GetNamespace()) {
+		return nil, serviceerror.NewUnimplemented("UpdateWorkerConfig command is not supported")
+	}
+	if request == nil {
+		return nil, errRequestNotSet
+	}
+
+	if request.GetWorkerConfig() == nil {
+		return nil, serviceerror.NewInvalidArgument("WorkerConfig is not set")
+	}
+
+	_, err := wh.namespaceRegistry.GetNamespaceID(namespace.Name(request.GetNamespace()))
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, serviceerror.NewUnimplemented("UpdateWorkerConfig command is not supported")
+}


### PR DESCRIPTION
## What changed?
Add stubs for worker commands.
Corresponding API PR: https://github.com/temporalio/api/pull/612

## Why?
Unblock SDK team.

## How did you test it?
- [X] built
- [X] covered by existing tests
