### PR TITLE
Add EagerExecutionAccepted to WorkflowExecutionStartedEventAttributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	go.temporal.io/api v1.50.1-0.20250715164317-6157f960f13b
+	go.temporal.io/api v1.50.1-0.20250716005608-066a1646935b
 	go.temporal.io/sdk v1.34.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/fx v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -399,8 +399,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.50.1-0.20250715164317-6157f960f13b h1:LYi/B1Pewj36fKKMWES4k1UmK0m/bYZwCgR/yFidwdc=
-go.temporal.io/api v1.50.1-0.20250715164317-6157f960f13b/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.50.1-0.20250716005608-066a1646935b h1:LYSZOIWDNtnQ3vX+2YZKoAjIuLtxRv3oTMD8/Zot0w4=
+go.temporal.io/api v1.50.1-0.20250716005608-066a1646935b/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.34.0 h1:VLg/h6ny7GvLFVoQPqz2NcC93V9yXboQwblkRvZ1cZE=
 go.temporal.io/sdk v1.34.0/go.mod h1:iE4U5vFrH3asOhqpBBphpj9zNtw8btp8+MSaf5A0D3w=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/service/history/historybuilder/event_factory.go
+++ b/service/history/historybuilder/event_factory.go
@@ -68,6 +68,8 @@ func (b *EventFactory) CreateWorkflowExecutionStartedEvent(
 		VersioningOverride:              worker_versioning.ConvertOverrideToV32(request.VersioningOverride),
 		Priority:                        req.GetPriority(),
 		InheritedPinnedVersion:          request.InheritedPinnedVersion,
+		// We expect the API handler to unset RequestEagerExecution if eager execution cannot be accepted.
+		EagerExecutionAccepted: req.GetRequestEagerExecution(),
 	}
 
 	parentInfo := request.ParentExecutionInfo

--- a/tests/eager_workflow_start_test.go
+++ b/tests/eager_workflow_start_test.go
@@ -121,7 +121,9 @@ func (s *EagerWorkflowTestSuite) TestEagerWorkflowStart_StartNew() {
 	})
 	task := response.GetEagerWorkflowTask()
 	s.Require().NotNil(task, "StartWorkflowExecution response did not contain a workflow task")
-	kwData := task.History.Events[0].GetWorkflowExecutionStartedEventAttributes().SearchAttributes.IndexedFields["CustomKeywordField"].Data
+	startedEventAttrs := task.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
+	s.Require().True(startedEventAttrs.GetEagerExecutionAccepted(), "Eager execution should be accepted")
+	kwData := startedEventAttrs.SearchAttributes.IndexedFields["CustomKeywordField"].Data
 	s.Require().Equal(`"value"`, string(kwData))
 	s.respondWorkflowTaskCompleted(task, "ok")
 	// Verify workflow completes and client can get the result


### PR DESCRIPTION
## What changed?

Set the `EagerExecutionAccepted` flag to true on `WorkflowExecutionStartedEventAttributes` to indicate that the client requested eager execution and the server has permitted it (the dynamic config is on, and there's no start delay).

## Why?

For debugging purposes.

## How did you test it?
- [x] added new functional test(s)