### PR TITLE
add expired tasks state to the metric

### DIFF
--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -479,14 +479,18 @@ func ToUnversionedTag(version string) Tag {
 	return &tagImpl{key: toUnversioned, value: falseValue}
 }
 
+var taskExpireStageReadTag = tagImpl{key: taskExpireStage, value: "read"}
+var taskExpireStageMemoryTag = tagImpl{key: taskExpireStage, value: "memory"}
+var taskExpireStageInvalidTag = tagImpl{key: taskExpireStage, value: "invalid"}
+
 func TaskExpireStageReadTag() Tag {
-	return &tagImpl{key: taskExpireStage, value: "read"}
+	return &taskExpireStageReadTag
 }
 
 func TaskExpireStageMemoryTag() Tag {
-	return &tagImpl{key: taskExpireStage, value: "memory"}
+	return &taskExpireStageMemoryTag
 }
 
 func TaskExpireStageValidateTag() Tag {
-	return &tagImpl{key: taskExpireStage, value: "invalid"}
+	return &taskExpireStageInvalidTag
 }

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -479,18 +479,6 @@ func ToUnversionedTag(version string) Tag {
 	return &tagImpl{key: toUnversioned, value: falseValue}
 }
 
-var taskExpireStageReadTag = tagImpl{key: taskExpireStage, value: "read"}
-var taskExpireStageMemoryTag = tagImpl{key: taskExpireStage, value: "memory"}
-var taskExpireStageInvalidTag = tagImpl{key: taskExpireStage, value: "invalid"}
-
-func TaskExpireStageReadTag() Tag {
-	return &taskExpireStageReadTag
-}
-
-func TaskExpireStageMemoryTag() Tag {
-	return &taskExpireStageMemoryTag
-}
-
-func TaskExpireStageValidateTag() Tag {
-	return &taskExpireStageInvalidTag
-}
+var TaskExpireStageReadTag Tag = &tagImpl{key: taskExpireStage, value: "read"}
+var TaskExpireStageMemoryTag Tag = &tagImpl{key: taskExpireStage, value: "memory"}
+var TaskInvalidTag Tag = &tagImpl{key: taskExpireStage, value: "invalid"}

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -41,6 +41,7 @@ const (
 	// See server.api.enums.v1.ReplicationTaskType
 	replicationTaskType     = "replicationTaskType"
 	replicationTaskPriority = "replicationTaskPriority"
+	taskExpireState         = "task_expire"
 	versioningBehavior      = "versioning_behavior"
 	isFirstAttempt          = "first-attempt"
 	workflowStatus          = "workflow_status"
@@ -476,4 +477,8 @@ func ToUnversionedTag(version string) Tag {
 		return &tagImpl{key: toUnversioned, value: trueValue}
 	}
 	return &tagImpl{key: toUnversioned, value: falseValue}
+}
+
+func TaskExpireStateTag(state string) Tag {
+	return &tagImpl{key: taskExpireState, value: state}
 }

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -41,7 +41,7 @@ const (
 	// See server.api.enums.v1.ReplicationTaskType
 	replicationTaskType     = "replicationTaskType"
 	replicationTaskPriority = "replicationTaskPriority"
-	taskExpireState         = "task_expire"
+	taskExpireStage         = "task_expire_stage"
 	versioningBehavior      = "versioning_behavior"
 	isFirstAttempt          = "first-attempt"
 	workflowStatus          = "workflow_status"
@@ -479,6 +479,14 @@ func ToUnversionedTag(version string) Tag {
 	return &tagImpl{key: toUnversioned, value: falseValue}
 }
 
-func TaskExpireStateTag(state string) Tag {
-	return &tagImpl{key: taskExpireState, value: state}
+func TaskExpireStageReadTag() Tag {
+	return &tagImpl{key: taskExpireStage, value: "read"}
+}
+
+func TaskExpireStageMemoryTag() Tag {
+	return &tagImpl{key: taskExpireStage, value: "memory"}
+}
+
+func TaskExpireStageValidateTag() Tag {
+	return &tagImpl{key: taskExpireStage, value: "invalid"}
 }

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -341,8 +341,7 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 
 		if task.event != nil && IsTaskExpired(task.event.AllocatedTaskInfo) {
 			// task is expired while polling
-			taskExpireStateTag := metrics.TaskExpireStateTag("process")
-			c.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, taskExpireStateTag)
+			c.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, metrics.TaskExpireStageMemoryTag())
 			task.finish(nil, false)
 			continue
 		}
@@ -386,8 +385,7 @@ func (c *physicalTaskQueueManagerImpl) ProcessSpooledTask(
 	if !c.taskValidator.maybeValidate(task.event.AllocatedTaskInfo, c.queue.TaskType()) {
 		task.finish(nil, false)
 
-		taskExpireStateTag := metrics.TaskExpireStateTag("process")
-		c.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, taskExpireStateTag)
+		c.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, metrics.TaskExpireStageMemoryTag())
 		// Don't try to set read level here because it may have been advanced already.
 		return nil
 	}

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -341,7 +341,7 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 
 		if task.event != nil && IsTaskExpired(task.event.AllocatedTaskInfo) {
 			// task is expired while polling
-			c.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, metrics.TaskExpireStageMemoryTag())
+			c.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, metrics.TaskExpireStageMemoryTag)
 			task.finish(nil, false)
 			continue
 		}
@@ -385,11 +385,8 @@ func (c *physicalTaskQueueManagerImpl) ProcessSpooledTask(
 	if !c.taskValidator.maybeValidate(task.event.AllocatedTaskInfo, c.queue.TaskType()) {
 		task.finish(nil, false)
 
-		var expireStateTag = metrics.TaskExpireStageValidateTag()
-		if IsTaskExpired(task.event.AllocatedTaskInfo) {
-			expireStateTag = metrics.TaskExpireStageMemoryTag()
-		}
-		c.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, expireStateTag)
+		var invalidTaskTag = getInvalidTaskTag(task)
+		c.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, invalidTaskTag)
 		// Don't try to set read level here because it may have been advanced already.
 		return nil
 	}

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -385,7 +385,11 @@ func (c *physicalTaskQueueManagerImpl) ProcessSpooledTask(
 	if !c.taskValidator.maybeValidate(task.event.AllocatedTaskInfo, c.queue.TaskType()) {
 		task.finish(nil, false)
 
-		c.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, metrics.TaskExpireStageMemoryTag())
+		var expireStateTag = metrics.TaskExpireStageValidateTag()
+		if IsTaskExpired(task.event.AllocatedTaskInfo) {
+			expireStateTag = metrics.TaskExpireStageMemoryTag()
+		}
+		c.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, expireStateTag)
 		// Don't try to set read level here because it may have been advanced already.
 		return nil
 	}

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -189,8 +189,7 @@ func (tm *priTaskMatcher) forwardTask(task *internalTask) error {
 			task.finish(nil, false)
 
 			// consider this task expired while processing.
-			taskExpireStateTag := metrics.TaskExpireStateTag("process")
-			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, taskExpireStateTag)
+			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, metrics.TaskExpireStageMemoryTag())
 			return nil
 		}
 
@@ -247,8 +246,7 @@ func (tm *priTaskMatcher) validateTasksOnRoot(lim quotas.RateLimiter, retrier ba
 			// We found an invalid one, complete it and go back for another immediately.
 			task.finish(nil, false)
 			// not sure what scenario this fits
-			taskExpireStateTag := metrics.TaskExpireStateTag("memory")
-			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, taskExpireStateTag)
+			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, metrics.TaskExpireStageValidateTag())
 			retrier.Reset()
 		} else {
 			// Task was valid, put it back and slow down checking.

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -246,7 +246,12 @@ func (tm *priTaskMatcher) validateTasksOnRoot(lim quotas.RateLimiter, retrier ba
 			// We found an invalid one, complete it and go back for another immediately.
 			task.finish(nil, false)
 			// not sure what scenario this fits
-			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, metrics.TaskExpireStageValidateTag())
+			var expireStateTag = metrics.TaskExpireStageValidateTag()
+			if IsTaskExpired(task.event.AllocatedTaskInfo) {
+				expireStateTag = metrics.TaskExpireStageMemoryTag()
+			}
+			tm.metricsHandler.Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1, expireStateTag)
+
 			retrier.Reset()
 		} else {
 			// Task was valid, put it back and slow down checking.

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -248,7 +248,7 @@ func (tr *priTaskReader) processTaskBatch(tasks []*persistencespb.AllocatedTaskI
 
 		if IsTaskExpired(t) {
 			// task expired when we read it
-			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.backlogMgr.metricsHandler).Record(1, metrics.TaskExpireStageReadTag())
+			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.backlogMgr.metricsHandler).Record(1, metrics.TaskExpireStageReadTag)
 			return true
 		}
 

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -247,7 +247,9 @@ func (tr *priTaskReader) processTaskBatch(tasks []*persistencespb.AllocatedTaskI
 		tr.readLevel = max(tr.readLevel, t.TaskId)
 
 		if IsTaskExpired(t) {
-			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.backlogMgr.metricsHandler).Record(1)
+			// task expired when we read it
+			taskExpireStateTag := metrics.TaskExpireStateTag("read")
+			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.backlogMgr.metricsHandler).Record(1, taskExpireStateTag)
 			return true
 		}
 

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -248,8 +248,7 @@ func (tr *priTaskReader) processTaskBatch(tasks []*persistencespb.AllocatedTaskI
 
 		if IsTaskExpired(t) {
 			// task expired when we read it
-			taskExpireStateTag := metrics.TaskExpireStateTag("read")
-			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.backlogMgr.metricsHandler).Record(1, taskExpireStateTag)
+			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.backlogMgr.metricsHandler).Record(1, metrics.TaskExpireStageReadTag())
 			return true
 		}
 

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -255,8 +255,7 @@ func (tr *taskReader) addTasksToBuffer(
 	for _, t := range tasks {
 		if IsTaskExpired(t) {
 			// task is expired when "add tasks to buffer" is called, so when we read it
-			taskExpireStateTag := metrics.TaskExpireStateTag("read")
-			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1, taskExpireStateTag)
+			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1, metrics.TaskExpireStageReadTag())
 			// Also increment readLevel for expired tasks otherwise it could result in
 			// looping over the same tasks if all tasks read in the batch are expired
 			tr.backlogMgr.taskAckManager.setReadLevel(t.GetTaskId())

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -255,7 +255,7 @@ func (tr *taskReader) addTasksToBuffer(
 	for _, t := range tasks {
 		if IsTaskExpired(t) {
 			// task is expired when "add tasks to buffer" is called, so when we read it
-			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1, metrics.TaskExpireStageReadTag())
+			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1, metrics.TaskExpireStageReadTag)
 			// Also increment readLevel for expired tasks otherwise it could result in
 			// looping over the same tasks if all tasks read in the batch are expired
 			tr.backlogMgr.taskAckManager.setReadLevel(t.GetTaskId())

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -254,7 +254,9 @@ func (tr *taskReader) addTasksToBuffer(
 ) error {
 	for _, t := range tasks {
 		if IsTaskExpired(t) {
-			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1)
+			// task is expired when "add tasks to buffer" is called, so when we read it
+			taskExpireStateTag := metrics.TaskExpireStateTag("read")
+			metrics.ExpiredTasksPerTaskQueueCounter.With(tr.taggedMetricsHandler()).Record(1, taskExpireStateTag)
 			// Also increment readLevel for expired tasks otherwise it could result in
 			// looping over the same tasks if all tasks read in the batch are expired
 			tr.backlogMgr.taskAckManager.setReadLevel(t.GetTaskId())


### PR DESCRIPTION
## What changed?
add "task expire state" tag to the "ExpiredTasksPerTaskQueueCounter" metric.
Possible states - "read", "process", "memory"

## Why?
For fairness, we remove TTL. We expect that this will lead to reading too many expired tasks.
To be sure we want a metrics tag that will allows us to separate tasks that are expired when we read them from other tasks. 

## How did you test it?
- [X] built
