### PR TITLE
Matching fairness: handle read+write by buffering tasks

### DIFF
--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3188,7 +3188,6 @@ func (s *matchingEngineSuite) pollWorkflowTasks(
 	for range taskCount {
 		s.createPollWorkflowTaskRequestAndPoll(taskQueue)
 		tasksPolled += 1
-		fmt.Printf("@@@ polled %d\n", tasksPolled)
 
 		// relax ApproximateBacklogCount for fairness impl
 		if !s.fairness {
@@ -3898,7 +3897,6 @@ func (m *testTaskManager) CreateTasks(
 		tlm.tasks.Put(fairLevelFromAllocatedTask(task), common.CloneProto(task))
 		tlm.createTaskCount++
 	}
-	fmt.Printf("@@@ ttm CreateTasks now %d\n", tlm.tasks.Size())
 
 	resp := &persistence.CreateTasksResponse{}
 	if m.updateMetadataOnCreateTasks {
@@ -3947,7 +3945,6 @@ func (m *testTaskManager) GetTasks(
 		tasks = append(tasks, it.Value().(*persistencespb.AllocatedTaskInfo))
 	}
 	tlm.getTasksCount++
-	fmt.Printf("@@@ ttm GetTasks %s- returning %d\n", fairLevel{pass: request.InclusiveMinPass, id: request.InclusiveMinTaskID}, len(tasks))
 	return &persistence.GetTasksResponse{Tasks: tasks}, nil
 }
 

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3231,14 +3231,14 @@ func (s *matchingEngineSuite) addConsumeAllWorkflowTasksNonConcurrently(taskCoun
 	s.Equal(taskCount, s.taskManager.getTaskCount(ptq))
 
 	pgMgr := s.getPhysicalTaskQueueManagerImpl(ptq)
-	// backlogCount := totalApproximateBacklogCount(pgMgr.backlogMgr)
-	// if s.fairness {
-	// 	// Relax this condition for fairBacklogManager: it can sometimes reset backlog count on
-	// 	// read, making it more accurate in theory, but breaking this test's assumptions.
-	// 	s.InDelta(expected, backlogCount, 2)
-	// } else {
-	// s.EqualValues(taskCount, backlogCount)
-	// }
+	backlogCount := totalApproximateBacklogCount(pgMgr.backlogMgr)
+	if s.fairness {
+		// Relax this condition for fairBacklogManager: it can sometimes reset backlog count on
+		// read, making it more accurate in theory, but breaking this test's assumptions.
+		s.InDelta(taskCount, backlogCount, 2)
+	} else {
+		s.EqualValues(taskCount, backlogCount)
+	}
 
 	s.pollWorkflowTasks(workflowType, taskCount, ptq, taskQueue)
 


### PR DESCRIPTION
## What changed?
Buffer tasks that come from a write while a read is pending and process them after the read completes.
Also a bunch of unit test cleanup to make the tests more clear.

## Why?
fairTaskReader could get confused in some concurrent read+write situations and drop tasks that should have ended up in memory.

## How did you test it?
- [x] covered by existing tests, cleaned up tests
