### PR TITLE
CHASM: Make Archetype strongly typed

### DIFF
--- a/chasm/archetype.go
+++ b/chasm/archetype.go
@@ -1,9 +1,12 @@
 package chasm
 
-// TODO: Define a separate type for Archetype
-// (similar to NamespaceID)
+type Archetype string
+
+func (a Archetype) String() string {
+	return string(a)
+}
 
 const (
 	// ArchetypeAny is a special value that matches any archetype.
-	ArchetypeAny = "__any__"
+	ArchetypeAny Archetype = "__any__"
 )

--- a/chasm/lib/workflow/workflow.go
+++ b/chasm/lib/workflow/workflow.go
@@ -1,7 +1,9 @@
 package workflow
 
+import "go.temporal.io/server/chasm"
+
 const (
 	// Archetype for today's workflow implementation.
 	// This value is NOT persisted today, and ok to be changed.
-	Archetype = "Workflow"
+	Archetype chasm.Archetype = "Workflow"
 )

--- a/chasm/ref_test.go
+++ b/chasm/ref_test.go
@@ -53,7 +53,7 @@ func (s *componentRefSuite) TestArchetype() {
 	rc, ok := s.registry.ComponentOf(reflect.TypeFor[*TestComponent]())
 	s.True(ok)
 
-	s.Equal(rc.FqType(), archetype)
+	s.Equal(rc.FqType(), archetype.String())
 }
 
 func (s *componentRefSuite) TestShardingKey() {
@@ -106,7 +106,7 @@ func (s *componentRefSuite) TestSerializeDeserialize() {
 
 	rootRc, ok := s.registry.ComponentFor(&TestComponent{})
 	s.True(ok)
-	s.Equal(rootRc.FqType(), deserializedRef.archetype)
+	s.Equal(rootRc.FqType(), deserializedRef.archetype.String())
 
 	s.Equal(ref.EntityKey, deserializedRef.EntityKey)
 	s.Equal(ref.componentPath, deserializedRef.componentPath)

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -266,11 +266,11 @@ func (n *Node) Component(
 		if !ok {
 			return nil, errComponentNotFound
 		}
-		ref.archetype = rootRC.fqType()
+		ref.archetype = Archetype(rootRC.fqType())
 
 	}
 	if ref.archetype != "" &&
-		n.root().serializedNode.GetMetadata().GetComponentAttributes().Type != ref.archetype {
+		n.root().serializedNode.GetMetadata().GetComponentAttributes().Type != ref.archetype.String() {
 		return nil, errComponentNotFound
 	}
 
@@ -1074,7 +1074,7 @@ func (n *Node) Ref(
 					BusinessID:  workflowKey.WorkflowID,
 					EntityID:    workflowKey.RunID,
 				},
-				archetype: n.root().serializedNode.GetMetadata().GetComponentAttributes().Type,
+				archetype: n.Archetype(),
 				// TODO: Consider using node's LastUpdateVersionedTransition for checking staleness here.
 				// Using VersionedTransition of the entire tree might be too strict.
 				entityLastUpdateVT: transitionhistory.CopyVersionedTransition(node.backend.CurrentVersionedTransition()),
@@ -1882,7 +1882,7 @@ func (n *Node) Terminate(
 	return nil
 }
 
-func (n *Node) Archetype() string {
+func (n *Node) Archetype() Archetype {
 	root := n.root()
 	if root.serializedNode == nil {
 		// Empty tree
@@ -1890,7 +1890,7 @@ func (n *Node) Archetype() string {
 	}
 
 	// Root must have be a component.
-	return root.serializedNode.Metadata.GetComponentAttributes().Type
+	return Archetype(root.serializedNode.Metadata.GetComponentAttributes().Type)
 }
 
 func (n *Node) root() *Node {

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -1494,7 +1494,7 @@ func (s *nodeSuite) TestRef() {
 
 	rc, ok := s.registry.ComponentFor(testComponent)
 	s.True(ok)
-	archetype := rc.FqType()
+	archetype := Archetype(rc.FqType())
 
 	subComponent1, err := testComponent.SubComponent1.Get(chasmContext)
 	s.NoError(err)

--- a/service/history/api/consistency_checker.go
+++ b/service/history/api/consistency_checker.go
@@ -8,6 +8,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	clockspb "go.temporal.io/server/api/clock/v1"
+	"go.temporal.io/server/chasm"
 	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/locks"
@@ -49,7 +50,7 @@ type (
 			ctx context.Context,
 			reqClock *clockspb.VectorClock,
 			workflowKey definition.WorkflowKey,
-			archetype string,
+			archetype chasm.Archetype,
 			lockPriority locks.Priority,
 		) (WorkflowLease, error)
 
@@ -58,7 +59,7 @@ type (
 			reqClock *clockspb.VectorClock,
 			consistencyPredicate MutableStateConsistencyPredicate,
 			workflowKey definition.WorkflowKey,
-			archetype string,
+			archetype chasm.Archetype,
 			lockPriority locks.Priority,
 		) (WorkflowLease, error)
 	}
@@ -125,7 +126,7 @@ func (c *WorkflowConsistencyCheckerImpl) GetChasmLease(
 	ctx context.Context,
 	reqClock *clockspb.VectorClock,
 	workflowKey definition.WorkflowKey,
-	archetype string,
+	archetype chasm.Archetype,
 	lockPriority locks.Priority,
 ) (WorkflowLease, error) {
 	return c.getWorkflowLeaseImpl(ctx, reqClock, nil, workflowKey, archetype, lockPriority)
@@ -136,7 +137,7 @@ func (c *WorkflowConsistencyCheckerImpl) GetChasmLeaseWithConsistencyCheck(
 	reqClock *clockspb.VectorClock,
 	consistencyPredicate MutableStateConsistencyPredicate,
 	workflowKey definition.WorkflowKey,
-	archetype string,
+	archetype chasm.Archetype,
 	lockPriority locks.Priority,
 ) (WorkflowLease, error) {
 	return c.getWorkflowLeaseImpl(ctx, reqClock, consistencyPredicate, workflowKey, archetype, lockPriority)
@@ -147,7 +148,7 @@ func (c *WorkflowConsistencyCheckerImpl) getWorkflowLeaseImpl(
 	reqClock *clockspb.VectorClock,
 	consistencyPredicate MutableStateConsistencyPredicate,
 	workflowKey definition.WorkflowKey,
-	archetype string,
+	archetype chasm.Archetype,
 	lockPriority locks.Priority,
 ) (WorkflowLease, error) {
 	if err := c.clockConsistencyCheck(reqClock); err != nil {
@@ -200,7 +201,7 @@ func (c *WorkflowConsistencyCheckerImpl) getCurrentWorkflowLease(
 	consistencyPredicate MutableStateConsistencyPredicate,
 	namespaceID string,
 	workflowID string,
-	archetype string,
+	archetype chasm.Archetype,
 	lockPriority locks.Priority,
 ) (WorkflowLease, error) {
 	runID, err := c.GetCurrentRunID(
@@ -245,7 +246,7 @@ func (c *WorkflowConsistencyCheckerImpl) getWorkflowLease(
 	ctx context.Context,
 	consistencyPredicate MutableStateConsistencyPredicate,
 	workflowKey definition.WorkflowKey,
-	archetype string,
+	archetype chasm.Archetype,
 	lockPriority locks.Priority,
 ) (WorkflowLease, error) {
 

--- a/service/history/api/consistency_checker_mock.go
+++ b/service/history/api/consistency_checker_mock.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	clock "go.temporal.io/server/api/clock/v1"
+	chasm "go.temporal.io/server/chasm"
 	definition "go.temporal.io/server/common/definition"
 	locks "go.temporal.io/server/common/locks"
 	cache "go.temporal.io/server/service/history/workflow/cache"
@@ -45,7 +46,7 @@ func (m *MockWorkflowConsistencyChecker) EXPECT() *MockWorkflowConsistencyChecke
 }
 
 // GetChasmLease mocks base method.
-func (m *MockWorkflowConsistencyChecker) GetChasmLease(ctx context.Context, reqClock *clock.VectorClock, workflowKey definition.WorkflowKey, archetype string, lockPriority locks.Priority) (WorkflowLease, error) {
+func (m *MockWorkflowConsistencyChecker) GetChasmLease(ctx context.Context, reqClock *clock.VectorClock, workflowKey definition.WorkflowKey, archetype chasm.Archetype, lockPriority locks.Priority) (WorkflowLease, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetChasmLease", ctx, reqClock, workflowKey, archetype, lockPriority)
 	ret0, _ := ret[0].(WorkflowLease)
@@ -60,7 +61,7 @@ func (mr *MockWorkflowConsistencyCheckerMockRecorder) GetChasmLease(ctx, reqCloc
 }
 
 // GetChasmLeaseWithConsistencyCheck mocks base method.
-func (m *MockWorkflowConsistencyChecker) GetChasmLeaseWithConsistencyCheck(ctx context.Context, reqClock *clock.VectorClock, consistencyPredicate MutableStateConsistencyPredicate, workflowKey definition.WorkflowKey, archetype string, lockPriority locks.Priority) (WorkflowLease, error) {
+func (m *MockWorkflowConsistencyChecker) GetChasmLeaseWithConsistencyCheck(ctx context.Context, reqClock *clock.VectorClock, consistencyPredicate MutableStateConsistencyPredicate, workflowKey definition.WorkflowKey, archetype chasm.Archetype, lockPriority locks.Priority) (WorkflowLease, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetChasmLeaseWithConsistencyCheck", ctx, reqClock, consistencyPredicate, workflowKey, archetype, lockPriority)
 	ret0, _ := ret[0].(WorkflowLease)

--- a/service/history/chasm_engine_test.go
+++ b/service/history/chasm_engine_test.go
@@ -432,7 +432,7 @@ func (s *chasmEngineSuite) validateNewEntityResponseRef(
 
 	archetype, err := deserializedRef.Archetype(s.registry)
 	s.NoError(err)
-	s.Equal("TestLibrary.test_component", archetype)
+	s.Equal("TestLibrary.test_component", archetype.String())
 }
 
 func (s *chasmEngineSuite) currentRunConditionFailedErr(

--- a/service/history/interfaces/chasm_tree.go
+++ b/service/history/interfaces/chasm_tree.go
@@ -23,7 +23,7 @@ type ChasmTree interface {
 	IsStateDirty() bool
 	IsDirty() bool
 	Terminate(chasm.TerminateComponentRequest) error
-	Archetype() string
+	Archetype() chasm.Archetype
 	EachPureTask(
 		deadline time.Time,
 		callback func(executor chasm.NodePureTask, taskAttributes chasm.TaskAttributes, task any) error,

--- a/service/history/interfaces/chasm_tree_mock.go
+++ b/service/history/interfaces/chasm_tree_mock.go
@@ -72,10 +72,10 @@ func (mr *MockChasmTreeMockRecorder) ApplySnapshot(arg0 any) *gomock.Call {
 }
 
 // Archetype mocks base method.
-func (m *MockChasmTree) Archetype() string {
+func (m *MockChasmTree) Archetype() chasm.Archetype {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Archetype")
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(chasm.Archetype)
 	return ret0
 }
 

--- a/service/history/interfaces/workflow_context.go
+++ b/service/history/interfaces/workflow_context.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/persistence"
@@ -22,7 +23,7 @@ type (
 	WorkflowContext interface {
 		GetWorkflowKey() definition.WorkflowKey
 
-		SetArchetype(archetype string)
+		SetArchetype(archetype chasm.Archetype)
 		LoadMutableState(ctx context.Context, shardContext ShardContext) (MutableState, error)
 		LoadExecutionStats(ctx context.Context, shardContext ShardContext) (*persistencespb.ExecutionStats, error)
 		Clear()

--- a/service/history/interfaces/workflow_context_mock.go
+++ b/service/history/interfaces/workflow_context_mock.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	persistence "go.temporal.io/server/api/persistence/v1"
+	chasm "go.temporal.io/server/chasm"
 	definition "go.temporal.io/server/common/definition"
 	locks "go.temporal.io/server/common/locks"
 	persistence0 "go.temporal.io/server/common/persistence"
@@ -206,7 +207,7 @@ func (mr *MockWorkflowContextMockRecorder) RefreshTasks(ctx, shardContext any) *
 }
 
 // SetArchetype mocks base method.
-func (m *MockWorkflowContext) SetArchetype(archetype string) {
+func (m *MockWorkflowContext) SetArchetype(archetype chasm.Archetype) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetArchetype", archetype)
 }

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -9,6 +9,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/log"
@@ -120,7 +121,7 @@ type (
 			namespaceID namespace.ID,
 			workflowID string,
 			runID string,
-			archetype string,
+			archetype chasm.Archetype,
 		) (Workflow, error)
 	}
 
@@ -417,7 +418,7 @@ func (r *transactionMgrImpl) LoadWorkflow(
 	namespaceID namespace.ID,
 	workflowID string,
 	runID string,
-	archetype string,
+	archetype chasm.Archetype,
 ) (Workflow, error) {
 
 	weContext, release, err := r.workflowCache.GetOrCreateChasmEntity(

--- a/service/history/ndc/transaction_manager_mock.go
+++ b/service/history/ndc/transaction_manager_mock.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	chasm "go.temporal.io/server/chasm"
 	namespace "go.temporal.io/server/common/namespace"
 	persistence "go.temporal.io/server/common/persistence"
 	gomock "go.uber.org/mock/gomock"
@@ -106,7 +107,7 @@ func (mr *MockTransactionManagerMockRecorder) GetCurrentWorkflowRunID(ctx, names
 }
 
 // LoadWorkflow mocks base method.
-func (m *MockTransactionManager) LoadWorkflow(ctx context.Context, namespaceID namespace.ID, workflowID, runID, archetype string) (Workflow, error) {
+func (m *MockTransactionManager) LoadWorkflow(ctx context.Context, namespaceID namespace.ID, workflowID, runID string, archetype chasm.Archetype) (Workflow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadWorkflow", ctx, namespaceID, workflowID, runID, archetype)
 	ret0, _ := ret[0].(Workflow)

--- a/service/history/replication/raw_task_converter.go
+++ b/service/history/replication/raw_task_converter.go
@@ -373,7 +373,7 @@ func generateStateReplicationTask(
 	ctx context.Context,
 	shardContext historyi.ShardContext,
 	workflowKey definition.WorkflowKey,
-	archetype string,
+	archetype chasm.Archetype,
 	workflowCache wcache.Cache,
 	action func(mutableState historyi.MutableState, releaseFunc historyi.ReleaseWorkflowContextFunc) (*replicationspb.ReplicationTask, error),
 ) (retReplicationTask *replicationspb.ReplicationTask, retError error) {

--- a/service/history/statemachine_environment.go
+++ b/service/history/statemachine_environment.go
@@ -65,7 +65,7 @@ func getWorkflowExecutionContext(
 	shardContext historyi.ShardContext,
 	workflowCache wcache.Cache,
 	key definition.WorkflowKey,
-	archetype string,
+	archetype chasm.Archetype,
 	lockPriority locks.Priority,
 ) (historyi.WorkflowContext, historyi.ReleaseWorkflowContextFunc, error) {
 	if key.GetRunID() == "" {
@@ -108,7 +108,7 @@ func getCurrentWorkflowExecutionContext(
 	workflowCache wcache.Cache,
 	namespaceID string,
 	workflowID string,
-	archetype string,
+	archetype chasm.Archetype,
 	lockPriority locks.Priority,
 ) (historyi.WorkflowContext, historyi.ReleaseWorkflowContextFunc, error) {
 	currentRunID, err := wcache.GetCurrentRunID(

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -52,7 +52,7 @@ type (
 			shardContext historyi.ShardContext,
 			namespaceID namespace.ID,
 			execution *commonpb.WorkflowExecution,
-			archetype string,
+			archetype chasm.Archetype,
 			lockPriority locks.Priority,
 		) (historyi.WorkflowContext, historyi.ReleaseWorkflowContextFunc, error)
 	}
@@ -186,23 +186,6 @@ func (c *cacheImpl) GetOrCreateCurrentWorkflowExecution(
 	workflowID string,
 	lockPriority locks.Priority,
 ) (historyi.ReleaseWorkflowContextFunc, error) {
-	// 	return c.GetOrCreateCurrentEntity(
-	// 		ctx,
-	// 		shardContext,
-	// 		namespaceID,
-	// 		workflowID,
-	// 		lockPriority,
-	// 	)
-	// }
-
-	// func (c *cacheImpl) GetOrCreateCurrentEntity(
-	// 	ctx context.Context,
-	// 	shardContext historyi.ShardContext,
-	// 	namespaceID namespace.ID,
-	// 	workflowID string,
-	// 	lockPriority locks.Priority,
-	// ) (historyi.ReleaseWorkflowContextFunc, error) {
-
 	if err := c.validateWorkflowID(workflowID); err != nil {
 		return nil, err
 	}
@@ -246,7 +229,7 @@ func (c *cacheImpl) GetOrCreateChasmEntity(
 	shardContext historyi.ShardContext,
 	namespaceID namespace.ID,
 	execution *commonpb.WorkflowExecution,
-	archetype string,
+	archetype chasm.Archetype,
 	lockPriority locks.Priority,
 ) (historyi.WorkflowContext, historyi.ReleaseWorkflowContextFunc, error) {
 
@@ -285,7 +268,7 @@ func (c *cacheImpl) getOrCreateWorkflowExecutionInternal(
 	shardContext historyi.ShardContext,
 	namespaceID namespace.ID,
 	execution *commonpb.WorkflowExecution,
-	archetype string,
+	archetype chasm.Archetype,
 	handler metrics.Handler,
 	forceClearContext bool,
 	lockPriority locks.Priority,

--- a/service/history/workflow/cache/cache_mock.go
+++ b/service/history/workflow/cache/cache_mock.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	common "go.temporal.io/api/common/v1"
+	chasm "go.temporal.io/server/chasm"
 	locks "go.temporal.io/server/common/locks"
 	namespace "go.temporal.io/server/common/namespace"
 	interfaces "go.temporal.io/server/service/history/interfaces"
@@ -45,7 +46,7 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 }
 
 // GetOrCreateChasmEntity mocks base method.
-func (m *MockCache) GetOrCreateChasmEntity(ctx context.Context, shardContext interfaces.ShardContext, namespaceID namespace.ID, execution *common.WorkflowExecution, archetype string, lockPriority locks.Priority) (interfaces.WorkflowContext, interfaces.ReleaseWorkflowContextFunc, error) {
+func (m *MockCache) GetOrCreateChasmEntity(ctx context.Context, shardContext interfaces.ShardContext, namespaceID namespace.ID, execution *common.WorkflowExecution, archetype chasm.Archetype, lockPriority locks.Priority) (interfaces.WorkflowContext, interfaces.ReleaseWorkflowContextFunc, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrCreateChasmEntity", ctx, shardContext, namespaceID, execution, archetype, lockPriority)
 	ret0, _ := ret[0].(interfaces.WorkflowContext)

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -31,7 +31,7 @@ import (
 type (
 	ContextImpl struct {
 		workflowKey     definition.WorkflowKey
-		archetype       string
+		archetype       chasm.Archetype
 		logger          log.Logger
 		throttledLogger log.ThrottledLogger
 		metricsHandler  metrics.Handler
@@ -115,7 +115,7 @@ func (c *ContextImpl) GetNamespace(shardContext historyi.ShardContext) namespace
 	return namespaceEntry.Name()
 }
 
-func (c *ContextImpl) SetArchetype(archetype string) {
+func (c *ContextImpl) SetArchetype(archetype chasm.Archetype) {
 	c.archetype = archetype
 }
 
@@ -168,8 +168,8 @@ func (c *ContextImpl) LoadMutableState(ctx context.Context, shardContext history
 
 	if actualArchetype := c.MutableState.ChasmTree().Archetype(); c.archetype != chasm.ArchetypeAny && c.archetype != actualArchetype {
 		c.logger.Warn("Potential ID conflict across different archetypes",
-			tag.Archetype(c.archetype),
-			tag.NewStringTag("actual-archetype", actualArchetype),
+			tag.Archetype(c.archetype.String()),
+			tag.NewStringTag("actual-archetype", actualArchetype.String()),
 		)
 		return nil, serviceerror.NewNotFoundf(
 			"CHASM Archetype missmatch for %v, expected: %s, actual: %s",

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -32,6 +32,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/chasm"
+	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
@@ -2592,7 +2593,7 @@ func (s *mutableStateSuite) TestCloseTransactionUpdateTransition() {
 			},
 			txFunc: func(ms historyi.MutableState) (*persistencespb.WorkflowExecutionInfo, error) {
 				mockChasmTree := historyi.NewMockChasmTree(s.controller)
-				mockChasmTree.EXPECT().Archetype().Return("mock-archetype").AnyTimes()
+				mockChasmTree.EXPECT().Archetype().Return(chasm.Archetype("mock-archetype")).AnyTimes()
 				gomock.InOrder(
 					mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes(),
 					mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{
@@ -4017,7 +4018,7 @@ func (s *mutableStateSuite) TestCloseTransactionTrackTombstones() {
 				}
 
 				mockChasmTree := historyi.NewMockChasmTree(s.controller)
-				mockChasmTree.EXPECT().Archetype().Return("mock-archetype").AnyTimes()
+				mockChasmTree.EXPECT().Archetype().Return(chasm.Archetype("mock-archetype")).AnyTimes()
 				gomock.InOrder(
 					mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes(),
 					mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{
@@ -4168,16 +4169,16 @@ func (s *mutableStateSuite) TestCloseTransactionGenerateCHASMRetentionTask() {
 	mockChasmTree := historyi.NewMockChasmTree(s.controller)
 	mutableState.chasmTree = mockChasmTree
 
-	// Not a workflow, should not generate retention task
+	// Is workflow, should not generate retention task
 	mockChasmTree.EXPECT().IsStateDirty().Return(true).AnyTimes()
-	mockChasmTree.EXPECT().Archetype().Return("").Times(1)
+	mockChasmTree.EXPECT().Archetype().Return(chasmworkflow.Archetype).Times(1)
 	mockChasmTree.EXPECT().CloseTransaction().Return(chasm.NodesMutation{}, nil).AnyTimes()
 	mutation, _, err := mutableState.CloseTransactionAsMutation(historyi.TransactionPolicyActive)
 	s.NoError(err)
 	s.Empty(mutation.Tasks[tasks.CategoryTimer])
 
 	// Now make the mutable state non-workflow.
-	mockChasmTree.EXPECT().Archetype().Return("test-archetype").Times(2) // One time for each CloseTransactionAsMutation call
+	mockChasmTree.EXPECT().Archetype().Return(chasm.Archetype("test-archetype")).Times(2) // One time for each CloseTransactionAsMutation call
 	err = mutableState.UpdateWorkflowStateStatus(
 		enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
 		enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,

--- a/service/history/workflow/noop_chasm_tree.go
+++ b/service/history/workflow/noop_chasm_tree.go
@@ -47,7 +47,7 @@ func (*noopChasmTree) Terminate(chasm.TerminateComponentRequest) error {
 	return nil
 }
 
-func (*noopChasmTree) Archetype() string {
+func (*noopChasmTree) Archetype() chasm.Archetype {
 	return chasmworkflow.Archetype
 }
 


### PR DESCRIPTION
## What changed?
- CHASM: Make Archetype strongly typed

## Why?
- Make it easier to tell what value needs to be passed when calling a function expecting an archetype as argument. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
