### PR TITLE
Add request_id to CallbackInfo in DescribeWorkflowExecutionResponse

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	go.temporal.io/api v1.50.1-0.20250715164317-6157f960f13b
+	go.temporal.io/api v1.50.1-0.20250718173504-3b39dd019560
 	go.temporal.io/sdk v1.34.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/fx v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -399,8 +399,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.50.1-0.20250715164317-6157f960f13b h1:LYi/B1Pewj36fKKMWES4k1UmK0m/bYZwCgR/yFidwdc=
-go.temporal.io/api v1.50.1-0.20250715164317-6157f960f13b/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.50.1-0.20250718173504-3b39dd019560 h1:ZLHq3n4MPhjZYkexyKyVBMQaHC9YmmW27IwG8AehhPE=
+go.temporal.io/api v1.50.1-0.20250718173504-3b39dd019560/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.34.0 h1:VLg/h6ny7GvLFVoQPqz2NcC93V9yXboQwblkRvZ1cZE=
 go.temporal.io/sdk v1.34.0/go.mod h1:iE4U5vFrH3asOhqpBBphpj9zNtw8btp8+MSaf5A0D3w=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -365,6 +365,7 @@ func buildCallbackInfo(
 		LastAttemptFailure:      callback.LastAttemptFailure,
 		NextAttemptScheduleTime: callback.NextAttemptScheduleTime,
 		BlockedReason:           blockedReason,
+		RequestId:               callback.RequestId,
 	}, nil
 }
 

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -424,6 +424,7 @@ func (s *CallbacksSuite) TestWorkflowNexusCallbacks_CarriedOver() {
 							require.Equal(col, enumspb.CALLBACK_STATE_SUCCEEDED, callbackInfo.State)
 							require.Nil(col, callbackInfo.LastAttemptFailure)
 						}
+						require.NotEmpty(col, callbackInfo.RequestId)
 						descCbs = append(descCbs, callbackInfo.Callback)
 					}
 					protoassert.ProtoElementsMatch(col, cbs, descCbs)
@@ -571,6 +572,7 @@ func (s *CallbacksSuite) TestNexusResetWorkflowWithCallback() {
 	for _, callbackInfo := range description.Callbacks {
 		s.Equal(enumspb.CALLBACK_STATE_STANDBY, callbackInfo.State)
 		s.Equal(int32(0), callbackInfo.Attempt)
+		s.NotEmpty(callbackInfo.RequestId)
 		descCbs = append(descCbs, callbackInfo.Callback)
 	}
 	s.ProtoElementsMatch(cbs, descCbs)
@@ -601,6 +603,7 @@ func (s *CallbacksSuite) TestNexusResetWorkflowWithCallback() {
 			descCbs = make([]*commonpb.Callback, 0, len(description.Callbacks))
 			for _, callbackInfo := range description.Callbacks {
 				require.Equal(t, enumspb.CALLBACK_STATE_SUCCEEDED, callbackInfo.State)
+				require.NotEmpty(t, callbackInfo.RequestId)
 				descCbs = append(descCbs, callbackInfo.Callback)
 			}
 			protoassert.ProtoElementsMatch(t, cbs, descCbs)

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -2212,6 +2212,7 @@ func (s *NexusWorkflowTestSuite) TestNexusCallbackAfterCallerComplete() {
 		require.Equal(ct, enumspb.CALLBACK_STATE_FAILED, resp.Callbacks[0].State)
 		require.NotNil(ct, resp.Callbacks[0].LastAttemptFailure)
 		require.Equal(ct, resp.Callbacks[0].LastAttemptFailure.Message, "handler error (NOT_FOUND): workflow execution already completed")
+		require.NotEmpty(ct, resp.Callbacks[0].RequestId)
 	}, 3*time.Second, 200*time.Millisecond)
 }
 


### PR DESCRIPTION
## What changed?
Populate `request_id` in `CallbackInfo` for the `DescribeWorkflowExecutionResponse`

## Why?
Be able to correlate the callback to the history event that added the callback.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

## Potential risks
