### PR TITLE
Check if activity is paused or stamp mismatch in processActivityTask()

### DIFF
--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -229,6 +229,11 @@ func (t *transferQueueActiveTaskExecutor) processActivityTask(
 		return consts.ErrActivityTaskNotFound
 	}
 
+	if ai.Stamp != task.Stamp || ai.Paused {
+		release(nil)                    // release(nil) so that the mutable state is not unloaded from cache
+		return consts.ErrStaleReference // drop the task
+	}
+
 	err = CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), ai.Version, task.Version, task)
 	if err != nil {
 		return err

--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -164,7 +164,7 @@ func (t *transferQueueStandbyTaskExecutor) processActivityTask(
 		}
 
 		if activityInfo.Stamp != transferTask.Stamp || activityInfo.Paused {
-			return nil, consts.ErrStaleReference // drop the task
+			return nil, nil // drop the task
 		}
 
 		err := CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), activityInfo.Version, transferTask.Version, transferTask)

--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -172,6 +172,10 @@ func (t *transferQueueStandbyTaskExecutor) processActivityTask(
 			return newActivityTaskPostActionInfo(mutableState, activityInfo)
 		}
 
+		if activityInfo.Stamp != transferTask.Stamp || activityInfo.Paused {
+			return nil, consts.ErrStaleReference // drop the task
+		}
+
 		return nil, nil
 	}
 

--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -163,6 +163,10 @@ func (t *transferQueueStandbyTaskExecutor) processActivityTask(
 			return nil, nil
 		}
 
+		if activityInfo.Stamp != transferTask.Stamp || activityInfo.Paused {
+			return nil, consts.ErrStaleReference // drop the task
+		}
+
 		err := CheckTaskVersion(t.shardContext, t.logger, mutableState.GetNamespaceEntry(), activityInfo.Version, transferTask.Version, transferTask)
 		if err != nil {
 			return nil, err
@@ -170,10 +174,6 @@ func (t *transferQueueStandbyTaskExecutor) processActivityTask(
 
 		if activityInfo.StartedEventId == common.EmptyEventID {
 			return newActivityTaskPostActionInfo(mutableState, activityInfo)
-		}
-
-		if activityInfo.Stamp != transferTask.Stamp || activityInfo.Paused {
-			return nil, consts.ErrStaleReference // drop the task
 		}
 
 		return nil, nil

--- a/service/history/transfer_queue_standby_task_executor_test.go
+++ b/service/history/transfer_queue_standby_task_executor_test.go
@@ -488,7 +488,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessActivityTask_Paused()
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
 	resp := s.transferQueueStandbyTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
-	s.ErrorIs(resp.ExecutionErr, consts.ErrStaleReference)
+	s.NoError(resp.ExecutionErr)
 }
 
 func (s *transferQueueStandbyTaskExecutorSuite) TestProcessWorkflowTask_Pending() {


### PR DESCRIPTION
## What changed?
Now checking if the activity is paused or if the stamp is outdated before dispatching a matching task.

## Why?
Prevents unnecessary creation and retrying of tasks in matching queues.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
N/A