### PR TITLE
fix: use rpc identity value for batch unpause activities

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -4598,6 +4598,7 @@ func (wh *WorkflowHandler) StartBatchOperation(
 		unpauseActivitiesParams.ResetAttempts = op.UnpauseActivitiesOperation.ResetAttempts
 		unpauseActivitiesParams.ResetHeartbeat = op.UnpauseActivitiesOperation.ResetHeartbeat
 		unpauseActivitiesParams.Jitter = op.UnpauseActivitiesOperation.Jitter.AsDuration()
+		unpauseActivitiesParams.Identity = op.UnpauseActivitiesOperation.GetIdentity()
 	case *workflowservice.StartBatchOperationRequest_ResetActivitiesOperation:
 		operationType = batcher.BatchTypeResetActivities
 		if op.ResetActivitiesOperation == nil {

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -341,7 +341,7 @@ func startTaskProcessor(
 								WorkflowId: workflowID,
 								RunId:      runID,
 							},
-							Identity:       "batch unpause",
+							Identity:       batchParams.UnpauseActivitiesParams.Identity,
 							Activity:       &workflowservice.UnpauseActivityRequest_Type{Type: batchParams.UnpauseActivitiesParams.ActivityType},
 							ResetAttempts:  !batchParams.UnpauseActivitiesParams.ResetAttempts,
 							ResetHeartbeat: batchParams.UnpauseActivitiesParams.ResetHeartbeat,

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -100,6 +100,7 @@ type (
 	}
 
 	UnpauseActivitiesParams struct {
+		Identity       string
 		ActivityType   string
 		MatchAll       bool
 		ResetAttempts  bool


### PR DESCRIPTION
## What changed?
The `Identity` field is changed from a hardcoded `batch unpause` to the value provided by the client.

## Why?
Consistency with other activity batch requests 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Minimal, identity is not exposed to users or used by internal systems
