### PR TITLE
Ability to generate migration task via frontend

### DIFF
--- a/api/adminservice/v1/request_response.pb.go
+++ b/api/adminservice/v1/request_response.pb.go
@@ -4865,11 +4865,12 @@ func (x *SyncWorkflowStateResponse) GetVersionedTransitionArtifact() *v15.Versio
 }
 
 type GenerateLastHistoryReplicationTasksRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Namespace     string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	Execution     *v1.WorkflowExecution  `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Namespace      string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Execution      *v1.WorkflowExecution  `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
+	TargetClusters []string               `protobuf:"bytes,3,rep,name=target_clusters,json=targetClusters,proto3" json:"target_clusters,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *GenerateLastHistoryReplicationTasksRequest) Reset() {
@@ -4912,6 +4913,13 @@ func (x *GenerateLastHistoryReplicationTasksRequest) GetNamespace() string {
 func (x *GenerateLastHistoryReplicationTasksRequest) GetExecution() *v1.WorkflowExecution {
 	if x != nil {
 		return x.Execution
+	}
+	return nil
+}
+
+func (x *GenerateLastHistoryReplicationTasksRequest) GetTargetClusters() []string {
+	if x != nil {
+		return x.TargetClusters
 	}
 	return nil
 }
@@ -5704,10 +5712,11 @@ const file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc = 
 	"\x11version_histories\x18\x04 \x01(\v20.temporal.server.api.history.v1.VersionHistoriesR\x10versionHistories\x12*\n" +
 	"\x11target_cluster_id\x18\x05 \x01(\x05R\x0ftargetClusterId\"\xb9\x01\n" +
 	"\x19SyncWorkflowStateResponse\x12\x83\x01\n" +
-	"\x1dversioned_transition_artifact\x18\x05 \x01(\v2?.temporal.server.api.replication.v1.VersionedTransitionArtifactR\x1bversionedTransitionArtifactJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05\"\x93\x01\n" +
+	"\x1dversioned_transition_artifact\x18\x05 \x01(\v2?.temporal.server.api.replication.v1.VersionedTransitionArtifactR\x1bversionedTransitionArtifactJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05\"\xbc\x01\n" +
 	"*GenerateLastHistoryReplicationTasksRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12G\n" +
-	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\"\x8a\x01\n" +
+	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\x12'\n" +
+	"\x0ftarget_clusters\x18\x03 \x03(\tR\x0etargetClusters\"\x8a\x01\n" +
 	"+GenerateLastHistoryReplicationTasksResponse\x124\n" +
 	"\x16state_transition_count\x18\x01 \x01(\x03R\x14stateTransitionCount\x12%\n" +
 	"\x0ehistory_length\x18\x02 \x01(\x03R\rhistoryLength\"\xfc\x01\n" +

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2682,6 +2682,11 @@ Valid fields: MaxConcurrentActivityExecutionSize, TaskQueueActivitiesPerSecond,
 WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 `,
 	)
+	WorkerGenerateMigrationTaskViaFrontend = NewGlobalBoolSetting(
+		"worker.generateMigrationTaskViaFrontend",
+		false,
+		`WorkerGenerateMigrationTaskViaFrontend controls whether to generate migration tasks via frontend admin service.`,
+	)
 	MaxUserMetadataSummarySize = NewNamespaceIntSetting(
 		"limit.userMetadataSummarySize",
 		400,

--- a/proto/internal/temporal/server/api/adminservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/adminservice/v1/request_response.proto
@@ -562,6 +562,7 @@ message SyncWorkflowStateResponse {
 message GenerateLastHistoryReplicationTasksRequest {
   string namespace = 1;
   temporal.api.common.v1.WorkflowExecution execution = 2;
+  repeated string target_clusters = 3;
 }
 
 message GenerateLastHistoryReplicationTasksResponse {

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -2135,8 +2135,9 @@ func (adh *AdminHandler) GenerateLastHistoryReplicationTasks(
 	resp, err := adh.historyClient.GenerateLastHistoryReplicationTasks(
 		ctx,
 		&historyservice.GenerateLastHistoryReplicationTasksRequest{
-			NamespaceId: namespaceEntry.ID().String(),
-			Execution:   request.Execution,
+			NamespaceId:    namespaceEntry.ID().String(),
+			Execution:      request.Execution,
+			TargetClusters: request.TargetClusters,
 		},
 	)
 	if err != nil {

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -506,7 +506,8 @@ func (a *activities) GenerateReplicationTasks(ctx context.Context, request *gene
 	}
 
 	generateViaFrontend := a.generateMigrationTaskViaFrontend()
-	for i, we := range request.Executions {
+	for i := startIndex; i < len(request.Executions); i++ {
+		we := request.Executions[i]
 		if err := a.generateWorkflowReplicationTask(
 			ctx,
 			rateLimiter,

--- a/service/worker/migration/activities_test.go
+++ b/service/worker/migration/activities_test.go
@@ -13,11 +13,14 @@ import (
 	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/worker"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/api/adminservicemock/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/client"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -43,6 +46,7 @@ type activitiesSuite struct {
 	mockClientBean                *client.MockBean
 
 	mockFrontendClient *workflowservicemock.MockWorkflowServiceClient
+	mockAdminClient    *adminservicemock.MockAdminServiceClient
 	mockHistoryClient  *historyservicemock.MockHistoryServiceClient
 	mockRemoteClient   *workflowservicemock.MockWorkflowServiceClient
 
@@ -101,6 +105,7 @@ func (s *activitiesSuite) SetupTest() {
 	s.mockClientBean = client.NewMockBean(s.controller)
 
 	s.mockFrontendClient = workflowservicemock.NewMockWorkflowServiceClient(s.controller)
+	s.mockAdminClient = adminservicemock.NewMockAdminServiceClient(s.controller)
 	s.mockHistoryClient = historyservicemock.NewMockHistoryServiceClient(s.controller)
 	s.mockRemoteClient = workflowservicemock.NewMockWorkflowServiceClient(s.controller)
 
@@ -116,16 +121,18 @@ func (s *activitiesSuite) SetupTest() {
 		Return(&testNamespace, nil).AnyTimes()
 
 	s.a = &activities{
-		namespaceRegistry:              s.mockNamespaceRegistry,
-		namespaceReplicationQueue:      s.mockNamespaceReplicationQueue,
-		clientFactory:                  s.mockClientFactory,
-		clientBean:                     s.mockClientBean,
-		taskManager:                    s.mockTaskManager,
-		frontendClient:                 s.mockFrontendClient,
-		historyClient:                  s.mockHistoryClient,
-		logger:                         log.NewCLILogger(),
-		metricsHandler:                 s.mockMetricsHandler,
-		forceReplicationMetricsHandler: s.mockMetricsHandler,
+		namespaceRegistry:                s.mockNamespaceRegistry,
+		namespaceReplicationQueue:        s.mockNamespaceReplicationQueue,
+		clientFactory:                    s.mockClientFactory,
+		clientBean:                       s.mockClientBean,
+		taskManager:                      s.mockTaskManager,
+		frontendClient:                   s.mockFrontendClient,
+		adminClient:                      s.mockAdminClient,
+		historyClient:                    s.mockHistoryClient,
+		logger:                           log.NewCLILogger(),
+		metricsHandler:                   s.mockMetricsHandler,
+		forceReplicationMetricsHandler:   s.mockMetricsHandler,
+		generateMigrationTaskViaFrontend: dynamicconfig.GetBoolPropertyFn(false),
 	}
 }
 
@@ -649,6 +656,36 @@ func (s *activitiesSuite) TestGenerateReplicationTasks_Failed() {
 	lastHeartBeat := iceptor.generateReplicationRecordedHeartbeats[lastIdx]
 	// Only the generation of 1st execution suceeded.
 	s.Equal(0, lastHeartBeat)
+}
+
+func (s *activitiesSuite) TestGenerateReplicationTasks_Success_ViaFrontend() {
+	env, iceptor := s.initEnv()
+	s.a.generateMigrationTaskViaFrontend = dynamicconfig.GetBoolPropertyFn(true)
+
+	request := generateReplicationTasksRequest{
+		NamespaceID:      mockedNamespaceID,
+		RPS:              10,
+		GetParentInfoRPS: 10,
+		Executions:       []*commonpb.WorkflowExecution{execution1, execution2},
+		TargetClusters:   []string{remoteCluster},
+	}
+
+	for i := 0; i < len(request.Executions); i++ {
+		we := request.Executions[i]
+		s.mockAdminClient.EXPECT().GenerateLastHistoryReplicationTasks(gomock.Any(), protomock.Eq(&adminservice.GenerateLastHistoryReplicationTasksRequest{
+			Namespace:      mockedNamespace,
+			Execution:      we,
+			TargetClusters: []string{remoteCluster},
+		})).Return(&adminservice.GenerateLastHistoryReplicationTasksResponse{}, nil).Times(1)
+	}
+
+	_, err := env.ExecuteActivity(s.a.GenerateReplicationTasks, &request)
+	s.NoError(err)
+
+	s.Greater(len(iceptor.generateReplicationRecordedHeartbeats), 0)
+	lastIdx := len(iceptor.generateReplicationRecordedHeartbeats) - 1
+	lastHeartBeat := iceptor.generateReplicationRecordedHeartbeats[lastIdx]
+	s.Equal(lastIdx, lastHeartBeat)
 }
 
 func (s *activitiesSuite) TestCountWorkflows() {

--- a/service/worker/migration/fx.go
+++ b/service/worker/migration/fx.go
@@ -8,6 +8,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 	serverClient "go.temporal.io/server/client"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -33,6 +34,7 @@ type (
 		TaskManager               persistence.TaskManager
 		Logger                    log.Logger
 		MetricsHandler            metrics.Handler
+		DynamicCollection         *dynamicconfig.Collection
 	}
 
 	fxResult struct {
@@ -85,17 +87,18 @@ func (wc *replicationWorkerComponent) DedicatedActivityWorkerOptions() *workerco
 
 func (wc *replicationWorkerComponent) activities() *activities {
 	return &activities{
-		historyShardCount:              wc.PersistenceConfig.NumHistoryShards,
-		executionManager:               wc.ExecutionManager,
-		namespaceRegistry:              wc.NamespaceRegistry,
-		historyClient:                  wc.HistoryClient,
-		frontendClient:                 wc.FrontendClient,
-		clientFactory:                  wc.ClientFactory,
-		clientBean:                     wc.ClientBean,
-		namespaceReplicationQueue:      wc.NamespaceReplicationQueue,
-		taskManager:                    wc.TaskManager,
-		logger:                         wc.Logger,
-		metricsHandler:                 wc.MetricsHandler,
-		forceReplicationMetricsHandler: wc.MetricsHandler.WithTags(metrics.WorkflowTypeTag(forceReplicationWorkflowName)),
+		historyShardCount:                wc.PersistenceConfig.NumHistoryShards,
+		executionManager:                 wc.ExecutionManager,
+		namespaceRegistry:                wc.NamespaceRegistry,
+		historyClient:                    wc.HistoryClient,
+		frontendClient:                   wc.FrontendClient,
+		clientFactory:                    wc.ClientFactory,
+		clientBean:                       wc.ClientBean,
+		namespaceReplicationQueue:        wc.NamespaceReplicationQueue,
+		taskManager:                      wc.TaskManager,
+		logger:                           wc.Logger,
+		metricsHandler:                   wc.MetricsHandler,
+		forceReplicationMetricsHandler:   wc.MetricsHandler.WithTags(metrics.WorkflowTypeTag(forceReplicationWorkflowName)),
+		generateMigrationTaskViaFrontend: dynamicconfig.WorkerGenerateMigrationTaskViaFrontend.Get(wc.DynamicCollection),
 	}
 }


### PR DESCRIPTION
## What changed?
- Add capability to generate migration task via frontend.

## Why?
- We don't really have per namespace rate limiting on history client, going through frontend allow us to rate limiting migration traffic per namespace and protect the cluster.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- Feature is behind a feature flag, so should be safe.
- The feature flag can only be enabled after the change in the admin handler (for forwarding the target cluster field) is deployed.
