### PR TITLE
Fix race with evicted fair task

### DIFF
--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -476,11 +476,14 @@ func (s *BacklogManagerTestSuite) testStandingBacklog(p standingBacklogParams) {
 		lock.Lock()
 		defer lock.Unlock()
 		e := tasks.PushBack(t)
-		t.removeFromMatcher = func() {
+		if !t.setRemoveFunc(func() {
 			lock.Lock()
 			defer lock.Unlock()
 			tasks.Remove(e)
 			log("buf evict %s -> %d\n", t.fairLevel(), tasks.Len())
+		}) {
+			tasks.Remove(e)
+			return nil
 		}
 		log("buf add %s -> %d\n", t.fairLevel(), tasks.Len())
 		return nil

--- a/service/matching/fair_task_reader.go
+++ b/service/matching/fair_task_reader.go
@@ -277,6 +277,7 @@ func (tr *fairTaskReader) readTaskBatch(readLevel fairLevel, loadedTasks int) er
 
 // call with_out_ lock held
 func (tr *fairTaskReader) addTaskToMatcher(task *internalTask) {
+	task.resetMatcherState()
 	err := tr.backlogMgr.addSpooledTask(task)
 	if err == nil {
 		return
@@ -437,7 +438,7 @@ func (tr *fairTaskReader) mergeTasksLocked(tasks []*persistencespb.AllocatedTask
 			// Note that the task may have already been matched and removed from the matcher,
 			// but not completed yet. In that case this will be a noop. See comment at the top
 			// of completeTask. Lock order: task reader lock < matcher lock so this is okay.
-			task.removeFromMatcher()
+			task.setEvicted()
 		}
 	}
 

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -396,7 +396,7 @@ func (s *MatcherDataSuite) TestOrder() {
 	t1 := s.newBacklogTaskWithPriority(1, 0, nil, &commonpb.Priority{PriorityKey: 1})
 	t2 := s.newBacklogTaskWithPriority(2, 0, nil, &commonpb.Priority{PriorityKey: 2})
 	t3 := s.newBacklogTaskWithPriority(3, 0, nil, &commonpb.Priority{PriorityKey: 3})
-	tf := &internalTask{isPollForwarder: true}
+	tf := newPollForwarderTask()
 
 	s.md.EnqueueTaskNoWait(t3)
 	s.md.EnqueueTaskNoWait(tf)
@@ -418,7 +418,7 @@ func (s *MatcherDataSuite) TestPollForwardSuccess() {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
-		tres := s.md.EnqueueTaskAndWait([]context.Context{ctx}, &internalTask{isPollForwarder: true})
+		tres := s.md.EnqueueTaskAndWait([]context.Context{ctx}, newPollForwarderTask())
 		// task is woken up with poller to forward
 		s.NotNil(tres.poller)
 		// forward succeeded, pass back task
@@ -440,7 +440,7 @@ func (s *MatcherDataSuite) TestPollForwardFailed() {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
-		tres := s.md.EnqueueTaskAndWait([]context.Context{ctx}, &internalTask{isPollForwarder: true})
+		tres := s.md.EnqueueTaskAndWait([]context.Context{ctx}, newPollForwarderTask())
 		// task is woken up with poller to forward
 		s.NotNil(tres.poller)
 		// there's a new task in the meantime
@@ -465,7 +465,7 @@ func (s *MatcherDataSuite) TestPollForwardFailedTimedOut() {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
-		tres := s.md.EnqueueTaskAndWait([]context.Context{ctx}, &internalTask{isPollForwarder: true})
+		tres := s.md.EnqueueTaskAndWait([]context.Context{ctx}, newPollForwarderTask())
 		// task is woken up with poller to forward
 		s.NotNil(tres.poller)
 		// there's a new task in the meantime
@@ -734,7 +734,7 @@ func FuzzMatcherData(f *testing.F) {
 				sleepTime := randms(100)
 				go func() {
 					defer pollForwarders.Add(-1)
-					res := md.EnqueueTaskAndWait(nil, &internalTask{isPollForwarder: true})
+					res := md.EnqueueTaskAndWait(nil, newPollForwarderTask())
 					softassert.That(md.logger, res.ctxErr == nil && res.poller != nil, "")
 					ts.Sleep(sleepTime)
 					t := &persistencespb.TaskInfo{

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -261,7 +261,7 @@ func (tm *priTaskMatcher) validateTasksOnRoot(lim quotas.RateLimiter, retrier ba
 }
 
 func (tm *priTaskMatcher) forwardPolls() {
-	forwarderTask := &internalTask{isPollForwarder: true}
+	forwarderTask := newPollForwarderTask()
 	ctxs := []context.Context{tm.tqCtx}
 	for {
 		res := tm.data.EnqueueTaskAndWait(ctxs, forwarderTask)
@@ -437,7 +437,9 @@ func (tm *priTaskMatcher) OfferNexusTask(ctx context.Context, task *internalTask
 }
 
 func (tm *priTaskMatcher) AddTask(task *internalTask) {
-	task.removeFromMatcher = func() { tm.data.RemoveTask(task) }
+	if !task.setRemoveFunc(func() { tm.data.RemoveTask(task) }) {
+		return
+	}
 	tm.data.EnqueueTaskNoWait(task)
 }
 

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -290,6 +290,7 @@ func (tr *priTaskReader) addNewTasks(tasks []*persistencespb.AllocatedTaskInfo) 
 }
 
 func (tr *priTaskReader) addTaskToMatcher(task *internalTask) {
+	task.resetMatcherState()
 	err := tr.backlogMgr.addSpooledTask(task)
 	if err == nil {
 		return

--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -42,6 +42,8 @@ type (
 	// internalTask represents an activity, workflow, query or started (received from another host).
 	// this struct is more like a union and only one of [ query, event, forwarded ] is
 	// non-nil for any given task
+	// TODO(pri): after deprecating classic matcher, we can consolidate backlogCountHint, recycleToken,
+	// and removeFromMatcher into a single *physicalTaskQueueManager field.
 	internalTask struct {
 		event            *genericTaskInfo // non-nil for activity or workflow task that's locally generated
 		query            *queryTaskInfo   // non-nil for a query task that's locally sync matched


### PR DESCRIPTION
## What changed?
Handle rare race condition with a task that gets evicted from fairTaskReader in-mem buffer before it was added to the matcher.

## Why?
fix race

## How did you test it?
- [x] covered by existing tests
