### PR TITLE
Prioritize worker progress APIs

### DIFF
--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -74,6 +74,17 @@ var (
 		DispatchNexusTaskByNamespaceAndTaskQueueAPIName:                                     1,
 		DispatchNexusTaskByEndpointAPIName:                                                  1,
 
+		// P1: Progress APIs for reporting heartbeats and task completions.
+		// Rejecting them could result in more load to retry the workflow/activity/nexus tasks.
+		"/temporal.api.workflowservice.v1.WorkflowService/RecordActivityTaskHeartbeat":      1,
+		"/temporal.api.workflowservice.v1.WorkflowService/RecordActivityTaskHeartbeatById":  1,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCompleted":     1,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCompletedById": 1,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskCompleted":     1,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondQueryTaskCompleted":        1,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondNexusTaskCompleted":        1,
+		CompleteNexusOperation: 1,
+
 		// P2: Change State APIs
 		"/temporal.api.workflowservice.v1.WorkflowService/RequestCancelWorkflowExecution":        2,
 		"/temporal.api.workflowservice.v1.WorkflowService/TerminateWorkflowExecution":            2,
@@ -103,24 +114,6 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/TriggerWorkflowRule":                   2,
 		"/temporal.api.workflowservice.v1.WorkflowService/UpdateTaskQueueConfig":                 2,
 
-		// P2: Progress APIs
-		// Those are Change State APIs as well and rejecting them could result in more work in the system
-		// to retry the workflow/activity tasks.
-		"/temporal.api.workflowservice.v1.WorkflowService/RecordActivityTaskHeartbeat":      2,
-		"/temporal.api.workflowservice.v1.WorkflowService/RecordActivityTaskHeartbeatById":  2,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCanceled":      2,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCanceledById":  2,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskFailed":        2,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskFailedById":    2,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCompleted":     2,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCompletedById": 2,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskCompleted":     2,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskFailed":        2,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondQueryTaskCompleted":        2,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondNexusTaskCompleted":        2,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondNexusTaskFailed":           2,
-		CompleteNexusOperation: 2,
-
 		// P3: Status Querying APIs
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorkflowExecution":       3,
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeTaskQueue":               3,
@@ -137,7 +130,16 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorkerDeployment":        3,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkerDeployments":           3,
 
-		// P5: Poll APIs and other low priority APIs
+		// P3: Progress APIs for reporting cancellations and failures.
+		// They are relatively low priority as the tasks need to be retried anyway.
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCanceled":     3,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCanceledById": 3,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskFailed":       3,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskFailedById":   3,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskFailed":       3,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondNexusTaskFailed":          3,
+
+		// P4: Poll APIs and other low priority APIs
 		"/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowTaskQueue":              4,
 		"/temporal.api.workflowservice.v1.WorkflowService/PollActivityTaskQueue":              4,
 		"/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowExecutionUpdate":        4,
@@ -151,7 +153,7 @@ var (
 		// GetWorkflowExecutionHistory with WaitNewEvent set to true is a long poll API. Consider it as any other poll API.
 		PollWorkflowHistoryAPIName: 4,
 
-		// P6: Informational API that aren't required for the temporal service to function
+		// P5: Informational API that aren't required for the temporal service to function
 		OpenAPIV3APIName: 5,
 		OpenAPIV2APIName: 5,
 	}

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -103,6 +103,24 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/TriggerWorkflowRule":                   2,
 		"/temporal.api.workflowservice.v1.WorkflowService/UpdateTaskQueueConfig":                 2,
 
+		// P2: Progress APIs
+		// Those are Change State APIs as well and rejecting them could result in more work in the system
+		// to retry the workflow/activity tasks.
+		"/temporal.api.workflowservice.v1.WorkflowService/RecordActivityTaskHeartbeat":      2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RecordActivityTaskHeartbeatById":  2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCanceled":      2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCanceledById":  2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskFailed":        2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskFailedById":    2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCompleted":     2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCompletedById": 2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskCompleted":     2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskFailed":        2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondQueryTaskCompleted":        2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondNexusTaskCompleted":        2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RespondNexusTaskFailed":           2,
+		CompleteNexusOperation: 2,
+
 		// P3: Status Querying APIs
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorkflowExecution":       3,
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeTaskQueue":               3,
@@ -119,43 +137,26 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorkerDeployment":        3,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkerDeployments":           3,
 
-		// P4: Progress APIs
-		"/temporal.api.workflowservice.v1.WorkflowService/RecordActivityTaskHeartbeat":      4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RecordActivityTaskHeartbeatById":  4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCanceled":      4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCanceledById":  4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskFailed":        4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskFailedById":    4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCompleted":     4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCompletedById": 4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskCompleted":     4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskFailed":        4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondQueryTaskCompleted":        4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondNexusTaskCompleted":        4,
-		"/temporal.api.workflowservice.v1.WorkflowService/RespondNexusTaskFailed":           4,
-		CompleteNexusOperation: 4,
-
 		// P5: Poll APIs and other low priority APIs
-		"/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowTaskQueue":              5,
-		"/temporal.api.workflowservice.v1.WorkflowService/PollActivityTaskQueue":              5,
-		"/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowExecutionUpdate":        5,
-		"/temporal.api.workflowservice.v1.WorkflowService/PollNexusTaskQueue":                 5,
-		"/temporal.api.workflowservice.v1.WorkflowService/ResetStickyTaskQueue":               5,
-		"/temporal.api.workflowservice.v1.WorkflowService/ShutdownWorker":                     5,
-		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkflowExecutionHistoryReverse": 5,
-		"/temporal.api.workflowservice.v1.WorkflowService/RecordWorkerHeartbeat":              5,
-		"/temporal.api.workflowservice.v1.WorkflowService/FetchWorkerConfig":                  5,
-		"/temporal.api.workflowservice.v1.WorkflowService/UpdateWorkerConfig":                 5,
-
+		"/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowTaskQueue":              4,
+		"/temporal.api.workflowservice.v1.WorkflowService/PollActivityTaskQueue":              4,
+		"/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowExecutionUpdate":        4,
+		"/temporal.api.workflowservice.v1.WorkflowService/PollNexusTaskQueue":                 4,
+		"/temporal.api.workflowservice.v1.WorkflowService/ResetStickyTaskQueue":               4,
+		"/temporal.api.workflowservice.v1.WorkflowService/ShutdownWorker":                     4,
+		"/temporal.api.workflowservice.v1.WorkflowService/GetWorkflowExecutionHistoryReverse": 4,
+		"/temporal.api.workflowservice.v1.WorkflowService/RecordWorkerHeartbeat":              4,
+		"/temporal.api.workflowservice.v1.WorkflowService/FetchWorkerConfig":                  4,
+		"/temporal.api.workflowservice.v1.WorkflowService/UpdateWorkerConfig":                 4,
 		// GetWorkflowExecutionHistory with WaitNewEvent set to true is a long poll API. Consider it as any other poll API.
-		PollWorkflowHistoryAPIName: 5,
+		PollWorkflowHistoryAPIName: 4,
 
 		// P6: Informational API that aren't required for the temporal service to function
-		OpenAPIV3APIName: 6,
-		OpenAPIV2APIName: 6,
+		OpenAPIV3APIName: 5,
+		OpenAPIV2APIName: 5,
 	}
 
-	ExecutionAPIPrioritiesOrdered = []int{0, 1, 2, 3, 4, 5, 6}
+	ExecutionAPIPrioritiesOrdered = []int{0, 1, 2, 3, 4, 5}
 
 	VisibilityAPIToPriority = map[string]int{
 		"/temporal.api.workflowservice.v1.WorkflowService/CountWorkflowExecutions":        1,


### PR DESCRIPTION
## What changed?
- Prioritize APIs for worker heartbeat & completion in frontend rps rate limiter
- Make them the same priority as other change state APIs

## Why?
- Upon throttling, rejecting those progress APIs could result in workflow/activity/nexus task failure/timeout which means more work for the system to retry those operations and consume more namespace RPS to process the retries.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
