### PR TITLE
Log errors when doing version compatibility check for Cassandra and SQL

### DIFF
--- a/common/persistence/cassandra/version_checker.go
+++ b/common/persistence/cassandra/version_checker.go
@@ -19,9 +19,10 @@ import (
 func VerifyCompatibleVersion(
 	cfg config.Persistence,
 	r resolver.ServiceResolver,
+	logger log.Logger,
 ) error {
 
-	if err := checkMainKeyspace(cfg, r); err != nil {
+	if err := checkMainKeyspace(cfg, r, logger); err != nil {
 		return err
 	}
 	return nil
@@ -30,10 +31,11 @@ func VerifyCompatibleVersion(
 func checkMainKeyspace(
 	cfg config.Persistence,
 	r resolver.ServiceResolver,
+	logger log.Logger,
 ) error {
 	ds, ok := cfg.DataStores[cfg.DefaultStore]
 	if ok && ds.Cassandra != nil {
-		return CheckCompatibleVersion(*ds.Cassandra, r, cassandraschema.Version)
+		return CheckCompatibleVersion(*ds.Cassandra, r, cassandraschema.Version, logger)
 	}
 	return nil
 }
@@ -43,13 +45,14 @@ func CheckCompatibleVersion(
 	cfg config.Cassandra,
 	r resolver.ServiceResolver,
 	expectedVersion string,
+	logger log.Logger,
 ) error {
 
 	session, err := commongocql.NewSession(
 		func() (*gocql.ClusterConfig, error) {
 			return commongocql.NewCassandraCluster(cfg, r)
 		},
-		log.NewNoopLogger(),
+		logger,
 		metrics.NoopMetricsHandler,
 	)
 	if err != nil {

--- a/common/persistence/cassandra/version_checker.go
+++ b/common/persistence/cassandra/version_checker.go
@@ -31,13 +31,13 @@ func checkMainKeyspace(
 ) error {
 	ds, ok := cfg.DataStores[cfg.DefaultStore]
 	if ok && ds.Cassandra != nil {
-		return checkCompatibleVersion(*ds.Cassandra, r, cassandraschema.Version, logger)
+		return CheckCompatibleVersion(*ds.Cassandra, r, cassandraschema.Version, logger)
 	}
 	return nil
 }
 
-// checkCompatibleVersion check the version compatibility
-func checkCompatibleVersion(
+// CheckCompatibleVersion check the version compatibility
+func CheckCompatibleVersion(
 	cfg config.Cassandra,
 	r resolver.ServiceResolver,
 	expectedVersion string,

--- a/common/persistence/cassandra/version_checker.go
+++ b/common/persistence/cassandra/version_checker.go
@@ -21,11 +21,7 @@ func VerifyCompatibleVersion(
 	r resolver.ServiceResolver,
 	logger log.Logger,
 ) error {
-
-	if err := checkMainKeyspace(cfg, r, logger); err != nil {
-		return err
-	}
-	return nil
+	return checkMainKeyspace(cfg, r, logger)
 }
 
 func checkMainKeyspace(
@@ -35,13 +31,13 @@ func checkMainKeyspace(
 ) error {
 	ds, ok := cfg.DataStores[cfg.DefaultStore]
 	if ok && ds.Cassandra != nil {
-		return CheckCompatibleVersion(*ds.Cassandra, r, cassandraschema.Version, logger)
+		return checkCompatibleVersion(*ds.Cassandra, r, cassandraschema.Version, logger)
 	}
 	return nil
 }
 
-// CheckCompatibleVersion check the version compatibility
-func CheckCompatibleVersion(
+// checkCompatibleVersion check the version compatibility
+func checkCompatibleVersion(
 	cfg config.Cassandra,
 	r resolver.ServiceResolver,
 	expectedVersion string,

--- a/common/persistence/sql/version_checker.go
+++ b/common/persistence/sql/version_checker.go
@@ -13,13 +13,14 @@ import (
 func VerifyCompatibleVersion(
 	cfg config.Persistence,
 	r resolver.ServiceResolver,
+	logger log.Logger,
 ) error {
 
-	if err := checkMainDatabase(cfg, r); err != nil {
+	if err := checkMainDatabase(cfg, r, logger); err != nil {
 		return err
 	}
 	if cfg.VisibilityConfigExist() {
-		return checkVisibilityDatabase(cfg, r)
+		return checkVisibilityDatabase(cfg, r, logger)
 	}
 	return nil
 }
@@ -27,10 +28,11 @@ func VerifyCompatibleVersion(
 func checkMainDatabase(
 	cfg config.Persistence,
 	r resolver.ServiceResolver,
+	logger log.Logger,
 ) error {
 	ds, ok := cfg.DataStores[cfg.DefaultStore]
 	if ok && ds.SQL != nil {
-		return checkCompatibleVersion(ds.SQL, r, sqlplugin.DbKindMain)
+		return checkCompatibleVersion(ds.SQL, r, sqlplugin.DbKindMain, logger)
 	}
 	return nil
 }
@@ -38,10 +40,11 @@ func checkMainDatabase(
 func checkVisibilityDatabase(
 	cfg config.Persistence,
 	r resolver.ServiceResolver,
+	logger log.Logger,
 ) error {
 	ds, ok := cfg.DataStores[cfg.VisibilityStore]
 	if ok && ds.SQL != nil {
-		return checkCompatibleVersion(ds.SQL, r, sqlplugin.DbKindVisibility)
+		return checkCompatibleVersion(ds.SQL, r, sqlplugin.DbKindVisibility, logger)
 	}
 	return nil
 }
@@ -50,8 +53,9 @@ func checkCompatibleVersion(
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
 	dbKind sqlplugin.DbKind,
+	logger log.Logger,
 ) error {
-	db, err := NewSQLAdminDB(dbKind, cfg, r, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	db, err := NewSQLAdminDB(dbKind, cfg, r, logger, metrics.NoopMetricsHandler)
 	if err != nil {
 		return err
 	}

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -830,16 +830,16 @@ func ServerLifetimeHooks(
 }
 
 func verifyPersistenceCompatibleVersion(
-	config config.Persistence,
+	cfg config.Persistence,
 	persistenceServiceResolver resolver.ServiceResolver,
 	logger log.Logger,
 ) error {
 	// cassandra schema version validation
-	if err := cassandra.VerifyCompatibleVersion(config, persistenceServiceResolver, logger); err != nil {
+	if err := cassandra.VerifyCompatibleVersion(cfg, persistenceServiceResolver, logger); err != nil {
 		return fmt.Errorf("cassandra schema version compatibility check failed: %w", err)
 	}
 	// sql schema version validation
-	if err := sql.VerifyCompatibleVersion(config, persistenceServiceResolver, logger); err != nil {
+	if err := sql.VerifyCompatibleVersion(cfg, persistenceServiceResolver, logger); err != nil {
 		return fmt.Errorf("sql schema version compatibility check failed: %w", err)
 	}
 	return nil

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -166,19 +166,19 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 		return serverOptionsProvider{}, err
 	}
 
-	persistenceConfig := so.config.Persistence
-	err = verifyPersistenceCompatibleVersion(persistenceConfig, so.persistenceServiceResolver)
-	if err != nil {
-		return serverOptionsProvider{}, err
-	}
-
-	stopChan := make(chan interface{})
-
 	// Logger
 	logger := so.logger
 	if logger == nil {
 		logger = log.NewZapLogger(log.BuildZapLogger(so.config.Log))
 	}
+
+	persistenceConfig := so.config.Persistence
+	err = verifyPersistenceCompatibleVersion(persistenceConfig, so.persistenceServiceResolver, logger)
+	if err != nil {
+		return serverOptionsProvider{}, err
+	}
+
+	stopChan := make(chan interface{})
 
 	// ClientFactoryProvider
 	clientFactoryProvider := so.clientFactoryProvider
@@ -829,13 +829,17 @@ func ServerLifetimeHooks(
 	lc.Append(fx.StartStopHook(svr.Start, svr.Stop))
 }
 
-func verifyPersistenceCompatibleVersion(config config.Persistence, persistenceServiceResolver resolver.ServiceResolver) error {
+func verifyPersistenceCompatibleVersion(
+	config config.Persistence,
+	persistenceServiceResolver resolver.ServiceResolver,
+	logger log.Logger,
+) error {
 	// cassandra schema version validation
-	if err := cassandra.VerifyCompatibleVersion(config, persistenceServiceResolver); err != nil {
+	if err := cassandra.VerifyCompatibleVersion(config, persistenceServiceResolver, logger); err != nil {
 		return fmt.Errorf("cassandra schema version compatibility check failed: %w", err)
 	}
 	// sql schema version validation
-	if err := sql.VerifyCompatibleVersion(config, persistenceServiceResolver); err != nil {
+	if err := sql.VerifyCompatibleVersion(config, persistenceServiceResolver, logger); err != nil {
 		return fmt.Errorf("sql schema version compatibility check failed: %w", err)
 	}
 	return nil

--- a/tools/cassandra/version_tests.go
+++ b/tools/cassandra/version_tests.go
@@ -52,7 +52,7 @@ func (s *VersionTestSuite) TestVerifyCompatibleVersion() {
 		},
 		TransactionSizeLimit: dynamicconfig.GetIntPropertyFn(primitives.DefaultTransactionSizeLimit),
 	}
-	s.NoError(cassandra.VerifyCompatibleVersion(cfg, resolver.NewNoopResolver()))
+	s.NoError(cassandra.VerifyCompatibleVersion(cfg, resolver.NewNoopResolver(), log.NewNoopLogger()))
 }
 
 func (s *VersionTestSuite) createKeyspace(keyspace string) func() {

--- a/tools/sql/clitest/version_tests.go
+++ b/tools/sql/clitest/version_tests.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
 	persistencesql "go.temporal.io/server/common/persistence/sql"
 	"go.temporal.io/server/common/primitives"
@@ -106,7 +107,7 @@ func (s *VersionTestSuite) TestVerifyCompatibleVersion() {
 		},
 		TransactionSizeLimit: dynamicconfig.GetIntPropertyFn(primitives.DefaultTransactionSizeLimit),
 	}
-	s.NoError(persistencesql.VerifyCompatibleVersion(cfg, resolver.NewNoopResolver()))
+	s.NoError(persistencesql.VerifyCompatibleVersion(cfg, resolver.NewNoopResolver(), log.NewNoopLogger()))
 }
 
 func (s *VersionTestSuite) createDatabase(database string) func() {


### PR DESCRIPTION
## What changed?
Changes version compability checks to pass the real logger, so that the error messages would be seeing in the log

## Why?

Before, the error was generic and there were no logs indicating the real error (see https://github.com/temporalio/temporal/issues/7939):
```
sql schema version compatibility check failed: unable to read DB schema version keyspace/database: temporal error: no usable database connection found
```

With this change, the log would contain the actual error:
```
{"level":"error","ts":"2025-07-25T15:30:49.660-0700","msg":"sql handle: unable to refresh database connection pool","error":"pq: no pg_hba.conf entry for host \"127.0.0.1\", ...
```

The alternative solution would be to return the error, but the design of common/persistence/sql/sqlplugin/db_handle.go suggests we hold the abstraction boundaries, by returning generic errors and logging specific errors.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests