### PR TITLE
Add subqueueKey and priorityKey types

### DIFF
--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -193,7 +193,7 @@ func (c *backlogManagerImpl) BacklogStatus() *taskqueuepb.TaskQueueStatus {
 }
 
 func (c *backlogManagerImpl) BacklogStatsByPriority() map[int32]*taskqueuepb.TaskQueueStats {
-	defaultPriority := defaultPriorityLevel(c.config.PriorityLevels())
+	defaultPriority := int32(defaultPriorityLevel(c.config.PriorityLevels()))
 	return map[int32]*taskqueuepb.TaskQueueStats{
 		defaultPriority: &taskqueuepb.TaskQueueStats{
 			ApproximateBacklogCount: c.db.getTotalApproximateBacklogCount(),

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -441,6 +441,6 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 	}
 }
 
-func defaultPriorityLevel(priorityLevels int32) int32 {
-	return (priorityLevels + 1) / 2
+func defaultPriorityLevel(priorityLevels int32) priorityKey {
+	return priorityKey(priorityLevels+1) / 2
 }

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -140,7 +140,7 @@ type (
 		MinTaskThrottlingBurstSize func() int
 		MaxTaskDeleteBatchSize     func() int
 		TaskDeleteInterval         func() time.Duration
-		PriorityLevels             func() int32
+		PriorityLevels             func() priorityKey
 
 		GetUserDataLongPollTimeout dynamicconfig.DurationPropertyFn
 		GetUserDataMinWaitTime     time.Duration
@@ -360,8 +360,8 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		TaskDeleteInterval: func() time.Duration {
 			return config.TaskDeleteInterval(ns.String(), taskQueueName, taskType)
 		},
-		PriorityLevels: func() int32 {
-			return int32(config.PriorityLevels(ns.String(), taskQueueName, taskType))
+		PriorityLevels: func() priorityKey {
+			return priorityKey(config.PriorityLevels(ns.String(), taskQueueName, taskType))
 		},
 		GetUserDataLongPollTimeout: config.GetUserDataLongPollTimeout,
 		GetUserDataMinWaitTime:     1 * time.Second,
@@ -441,6 +441,6 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 	}
 }
 
-func defaultPriorityLevel(priorityLevels int32) priorityKey {
+func defaultPriorityLevel(priorityLevels priorityKey) priorityKey {
 	return priorityKey(priorityLevels+1) / 2
 }

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -346,7 +346,7 @@ func (db *taskQueueDB) updateBacklogStats(countDelta int64, oldestTime time.Time
 	db.Lock()
 	defer db.Unlock()
 	db.lastChange = time.Now()
-	db.updateBacklogStatsLocked(subqueueKey(0), countDelta, oldestTime)
+	db.updateBacklogStatsLocked(subqueueZero, countDelta, oldestTime)
 }
 
 func (db *taskQueueDB) updateBacklogStatsLocked(subqueue subqueueKey, countDelta int64, oldestTime time.Time) {
@@ -729,7 +729,7 @@ func (db *taskQueueDB) ensureDefaultSubqueuesLocked(
 
 	// check for default priority and add if not present (this may be initializing subqueue 0)
 	defKey := &persistencespb.SubqueueKey{
-		Priority: defaultPriorityLevel(db.config.PriorityLevels()),
+		Priority: int32(defaultPriorityLevel(db.config.PriorityLevels())),
 	}
 	hasDefault := slices.ContainsFunc(subqueues, func(s *dbSubqueue) bool {
 		return proto.Equal(s.Key, defKey)

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -426,7 +426,7 @@ func (db *taskQueueDB) CreateTasks(
 	}
 
 	for sq, update := range updates {
-		db.subqueues[int(sq)].ApproximateBacklogCount += int64(len(update.tasks))
+		db.subqueues[sq].ApproximateBacklogCount += int64(len(update.tasks))
 	}
 
 	resp, err := db.store.CreateTasks(
@@ -444,7 +444,7 @@ func (db *taskQueueDB) CreateTasks(
 	// so that taskReader is guaranteed to see the new read level when SpoolTask wakes it up.
 	// Do this even if the write fails, we won't reuse the task ids.
 	for sq, update := range updates {
-		db.subqueues[int(sq)].maxReadLevel = update.maxReadLevelAfter
+		db.subqueues[sq].maxReadLevel = update.maxReadLevelAfter
 	}
 
 	if err == nil {
@@ -456,7 +456,7 @@ func (db *taskQueueDB) CreateTasks(
 		// tasks definitely were not created, restore the counter. For other errors tasks may or may not be created.
 		// In those cases we keep the count incremented, hence it may be an overestimate.
 		for i, update := range updates {
-			db.subqueues[int(i)].ApproximateBacklogCount -= int64(len(update.tasks))
+			db.subqueues[i].ApproximateBacklogCount -= int64(len(update.tasks))
 		}
 	}
 	return createTasksResponse{bySubqueue: updates}, err
@@ -491,7 +491,7 @@ func (db *taskQueueDB) CreateFairTasks(
 	}
 
 	for sq, tasks := range newTasks {
-		db.subqueues[int(sq)].ApproximateBacklogCount += int64(len(tasks))
+		db.subqueues[sq].ApproximateBacklogCount += int64(len(tasks))
 	}
 
 	// Unlike in CreateTasks, we can set the persisted FairMaxReadLevel before persisting.
@@ -499,7 +499,7 @@ func (db *taskQueueDB) CreateFairTasks(
 	// the FairMaxReadLevel will be more up-to-date. The max read level is not used by
 	// fairTaskReader, so there's no correctness issue with doing this.
 	for sq, level := range newMaxLevel {
-		db.subqueues[int(sq)].FairMaxReadLevel = fairLevelFromProto(db.subqueues[int(sq)].FairMaxReadLevel).max(level).toProto()
+		db.subqueues[sq].FairMaxReadLevel = fairLevelFromProto(db.subqueues[sq].FairMaxReadLevel).max(level).toProto()
 	}
 
 	resp, err := db.store.CreateTasks(
@@ -523,7 +523,7 @@ func (db *taskQueueDB) CreateFairTasks(
 		// In those cases we keep the count incremented, hence it may be an overestimate.
 		// Don't bother restoring MaxReadLevel, it's okay if that's too high.
 		for i, tasks := range newTasks {
-			db.subqueues[int(i)].ApproximateBacklogCount -= int64(len(tasks))
+			db.subqueues[i].ApproximateBacklogCount -= int64(len(tasks))
 		}
 	}
 	return newTasks, err

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -27,7 +27,7 @@ const (
 
 	// Subqueue zero corresponds to "the queue" before migrating metadata to subqueues.
 	// For backwards compatibility, some operations only apply to subqueue zero for now.
-	subqueueZero = 0
+	subqueueZero = subqueueKey(0)
 )
 
 type (
@@ -58,8 +58,10 @@ type (
 		subqueues []persistencespb.SubqueueInfo
 	}
 
+	subqueueKey int
+
 	createTasksResponse struct {
-		bySubqueue map[int]subqueueCreateTasksResponse
+		bySubqueue map[subqueueKey]subqueueCreateTasksResponse
 	}
 
 	subqueueCreateTasksResponse struct {
@@ -68,7 +70,7 @@ type (
 		maxReadLevelAfter  int64
 	}
 
-	createFairTasksResponse map[int][]*persistencespb.AllocatedTaskInfo // subqueue -> tasks
+	createFairTasksResponse map[subqueueKey][]*persistencespb.AllocatedTaskInfo // subqueue -> tasks
 )
 
 // newTaskQueueDB returns an instance of an object that represents
@@ -105,29 +107,29 @@ func (db *taskQueueDB) RangeID() int64 {
 }
 
 // GetMaxReadLevel returns the current maxReadLevel
-func (db *taskQueueDB) GetMaxReadLevel(subqueue int) int64 {
+func (db *taskQueueDB) GetMaxReadLevel(subqueue subqueueKey) int64 {
 	db.Lock()
 	defer db.Unlock()
 	return db.getMaxReadLevelLocked(subqueue)
 }
 
-func (db *taskQueueDB) getMaxReadLevelLocked(subqueue int) int64 {
+func (db *taskQueueDB) getMaxReadLevelLocked(subqueue subqueueKey) int64 {
 	return db.subqueues[subqueue].maxReadLevel
 }
 
 // GetMaxReadLevel returns the current maxReadLevel
-func (db *taskQueueDB) GetMaxFairReadLevel(subqueue int) fairLevel {
+func (db *taskQueueDB) GetMaxFairReadLevel(subqueue subqueueKey) fairLevel {
 	db.Lock()
 	defer db.Unlock()
 	return db.getMaxFairReadLevelLocked(subqueue)
 }
 
-func (db *taskQueueDB) getMaxFairReadLevelLocked(subqueue int) fairLevel {
+func (db *taskQueueDB) getMaxFairReadLevelLocked(subqueue subqueueKey) fairLevel {
 	return fairLevelFromProto(db.subqueues[subqueue].FairMaxReadLevel)
 }
 
 // This is only exposed for testing!
-func (db *taskQueueDB) setMaxReadLevelForTesting(subqueue int, level int64) {
+func (db *taskQueueDB) setMaxReadLevelForTesting(subqueue subqueueKey, level int64) {
 	db.Lock()
 	defer db.Unlock()
 	db.subqueues[subqueue].maxReadLevel = level
@@ -273,7 +275,7 @@ func (db *taskQueueDB) SyncState(ctx context.Context) error {
 	return db.updateTaskQueueLocked(ctx, false)
 }
 
-func (db *taskQueueDB) updateAckLevelAndBacklogStats(subqueue int, newAckLevel int64, countDelta int64, oldestTime time.Time) {
+func (db *taskQueueDB) updateAckLevelAndBacklogStats(subqueue subqueueKey, newAckLevel int64, countDelta int64, oldestTime time.Time) {
 	db.Lock()
 	defer db.Unlock()
 
@@ -301,7 +303,7 @@ func (db *taskQueueDB) updateAckLevelAndBacklogStats(subqueue int, newAckLevel i
 	}
 }
 
-func (db *taskQueueDB) updateFairAckLevel(subqueue int, newAckLevel fairLevel, countDelta, knownCount int64, oldestTime time.Time) {
+func (db *taskQueueDB) updateFairAckLevel(subqueue subqueueKey, newAckLevel fairLevel, countDelta, knownCount int64, oldestTime time.Time) {
 	db.Lock()
 	defer db.Unlock()
 
@@ -325,7 +327,7 @@ func (db *taskQueueDB) updateFairAckLevel(subqueue int, newAckLevel fairLevel, c
 
 // Use this to reset ApproximateBacklogCount when the backlog count is known, e.g. when you're
 // read to the end of the backlog.
-func (db *taskQueueDB) setKnownFairBacklogCount(subqueue int, count int64) {
+func (db *taskQueueDB) setKnownFairBacklogCount(subqueue subqueueKey, count int64) {
 	db.Lock()
 	defer db.Unlock()
 
@@ -344,10 +346,10 @@ func (db *taskQueueDB) updateBacklogStats(countDelta int64, oldestTime time.Time
 	db.Lock()
 	defer db.Unlock()
 	db.lastChange = time.Now()
-	db.updateBacklogStatsLocked(0, countDelta, oldestTime)
+	db.updateBacklogStatsLocked(subqueueKey(0), countDelta, oldestTime)
 }
 
-func (db *taskQueueDB) updateBacklogStatsLocked(subqueue int, countDelta int64, oldestTime time.Time) {
+func (db *taskQueueDB) updateBacklogStatsLocked(subqueue subqueueKey, countDelta int64, oldestTime time.Time) {
 	// Prevent under-counting
 	count := &db.subqueues[subqueue].ApproximateBacklogCount
 	if *count+countDelta < 0 {
@@ -374,7 +376,7 @@ func (db *taskQueueDB) getApproximateBacklogCountsBySubqueue() []int64 {
 	return result
 }
 
-func (db *taskQueueDB) getApproximateBacklogCountAndMaxReadLevel(subqueue int) (int64, fairLevel) {
+func (db *taskQueueDB) getApproximateBacklogCountAndMaxReadLevel(subqueue subqueueKey) (int64, fairLevel) {
 	db.Lock()
 	defer db.Unlock()
 	s := db.subqueues[subqueue]
@@ -404,7 +406,7 @@ func (db *taskQueueDB) CreateTasks(
 		return createTasksResponse{}, nil
 	}
 
-	updates := make(map[int]subqueueCreateTasksResponse)
+	updates := make(map[subqueueKey]subqueueCreateTasksResponse)
 	allTasks := make([]*persistencespb.AllocatedTaskInfo, len(reqs))
 	allSubqueues := make([]int, len(reqs))
 	for i, req := range reqs {
@@ -413,7 +415,7 @@ func (db *taskQueueDB) CreateTasks(
 			Data:   req.taskInfo,
 		}
 		allTasks[i] = task
-		allSubqueues[i] = req.subqueue
+		allSubqueues[i] = int(req.subqueue)
 
 		u := updates[req.subqueue]
 		updates[req.subqueue] = subqueueCreateTasksResponse{
@@ -424,7 +426,7 @@ func (db *taskQueueDB) CreateTasks(
 	}
 
 	for sq, update := range updates {
-		db.subqueues[sq].ApproximateBacklogCount += int64(len(update.tasks))
+		db.subqueues[int(sq)].ApproximateBacklogCount += int64(len(update.tasks))
 	}
 
 	resp, err := db.store.CreateTasks(
@@ -442,7 +444,7 @@ func (db *taskQueueDB) CreateTasks(
 	// so that taskReader is guaranteed to see the new read level when SpoolTask wakes it up.
 	// Do this even if the write fails, we won't reuse the task ids.
 	for sq, update := range updates {
-		db.subqueues[sq].maxReadLevel = update.maxReadLevelAfter
+		db.subqueues[int(sq)].maxReadLevel = update.maxReadLevelAfter
 	}
 
 	if err == nil {
@@ -454,7 +456,7 @@ func (db *taskQueueDB) CreateTasks(
 		// tasks definitely were not created, restore the counter. For other errors tasks may or may not be created.
 		// In those cases we keep the count incremented, hence it may be an overestimate.
 		for i, update := range updates {
-			db.subqueues[i].ApproximateBacklogCount -= int64(len(update.tasks))
+			db.subqueues[int(i)].ApproximateBacklogCount -= int64(len(update.tasks))
 		}
 	}
 	return createTasksResponse{bySubqueue: updates}, err
@@ -473,7 +475,7 @@ func (db *taskQueueDB) CreateFairTasks(
 	}
 
 	newTasks := make(createFairTasksResponse)
-	newMaxLevel := make(map[int]fairLevel)
+	newMaxLevel := make(map[subqueueKey]fairLevel)
 	allTasks := make([]*persistencespb.AllocatedTaskInfo, len(reqs))
 	allSubqueues := make([]int, len(reqs))
 	for i, req := range reqs {
@@ -483,13 +485,13 @@ func (db *taskQueueDB) CreateFairTasks(
 			Data:     req.taskInfo,
 		}
 		allTasks[i] = task
-		allSubqueues[i] = req.subqueue
+		allSubqueues[i] = int(req.subqueue)
 		newTasks[req.subqueue] = append(newTasks[req.subqueue], task)
 		newMaxLevel[req.subqueue] = newMaxLevel[req.subqueue].max(req.fairLevel)
 	}
 
 	for sq, tasks := range newTasks {
-		db.subqueues[sq].ApproximateBacklogCount += int64(len(tasks))
+		db.subqueues[int(sq)].ApproximateBacklogCount += int64(len(tasks))
 	}
 
 	// Unlike in CreateTasks, we can set the persisted FairMaxReadLevel before persisting.
@@ -497,7 +499,7 @@ func (db *taskQueueDB) CreateFairTasks(
 	// the FairMaxReadLevel will be more up-to-date. The max read level is not used by
 	// fairTaskReader, so there's no correctness issue with doing this.
 	for sq, level := range newMaxLevel {
-		db.subqueues[sq].FairMaxReadLevel = fairLevelFromProto(db.subqueues[sq].FairMaxReadLevel).max(level).toProto()
+		db.subqueues[int(sq)].FairMaxReadLevel = fairLevelFromProto(db.subqueues[int(sq)].FairMaxReadLevel).max(level).toProto()
 	}
 
 	resp, err := db.store.CreateTasks(
@@ -521,7 +523,7 @@ func (db *taskQueueDB) CreateFairTasks(
 		// In those cases we keep the count incremented, hence it may be an overestimate.
 		// Don't bother restoring MaxReadLevel, it's okay if that's too high.
 		for i, tasks := range newTasks {
-			db.subqueues[i].ApproximateBacklogCount -= int64(len(tasks))
+			db.subqueues[int(i)].ApproximateBacklogCount -= int64(len(tasks))
 		}
 	}
 	return newTasks, err
@@ -530,7 +532,7 @@ func (db *taskQueueDB) CreateFairTasks(
 // GetTasks returns a batch of tasks between the given range
 func (db *taskQueueDB) GetTasks(
 	ctx context.Context,
-	subqueue int,
+	subqueue subqueueKey,
 	inclusiveMinTaskID int64,
 	exclusiveMaxTaskID int64,
 	batchSize int,
@@ -541,7 +543,7 @@ func (db *taskQueueDB) GetTasks(
 		TaskType:           db.queue.TaskType(),
 		InclusiveMinTaskID: inclusiveMinTaskID,
 		ExclusiveMaxTaskID: exclusiveMaxTaskID,
-		Subqueue:           subqueue,
+		Subqueue:           int(subqueue),
 		PageSize:           batchSize,
 	})
 }
@@ -549,7 +551,7 @@ func (db *taskQueueDB) GetTasks(
 // GetFairTasks returns a batch of tasks after the given level
 func (db *taskQueueDB) GetFairTasks(
 	ctx context.Context,
-	subqueue int,
+	subqueue subqueueKey,
 	inclusiveMinLevel fairLevel,
 	batchSize int,
 ) (*persistence.GetTasksResponse, error) {
@@ -560,7 +562,7 @@ func (db *taskQueueDB) GetFairTasks(
 		InclusiveMinPass:   inclusiveMinLevel.pass,
 		InclusiveMinTaskID: inclusiveMinLevel.id,
 		ExclusiveMaxTaskID: math.MaxInt64,
-		Subqueue:           subqueue,
+		Subqueue:           int(subqueue),
 		PageSize:           batchSize,
 		UseLimit:           true,
 	})
@@ -573,14 +575,14 @@ func (db *taskQueueDB) CompleteTasksLessThan(
 	ctx context.Context,
 	exclusiveMaxTaskID int64,
 	limit int,
-	subqueue int,
+	subqueue subqueueKey,
 ) (int, error) {
 	n, err := db.store.CompleteTasksLessThan(ctx, &persistence.CompleteTasksLessThanRequest{
 		NamespaceID:        db.queue.NamespaceId(),
 		TaskQueueName:      db.queue.PersistenceName(),
 		TaskType:           db.queue.TaskType(),
 		ExclusiveMaxTaskID: exclusiveMaxTaskID,
-		Subqueue:           subqueue,
+		Subqueue:           int(subqueue),
 		Limit:              limit,
 	})
 	if err != nil {
@@ -602,7 +604,7 @@ func (db *taskQueueDB) CompleteFairTasksLessThan(
 	ctx context.Context,
 	exclusiveMaxLevel fairLevel,
 	limit int,
-	subqueue int,
+	subqueue subqueueKey,
 ) (int, error) {
 	n, err := db.store.CompleteTasksLessThan(ctx, &persistence.CompleteTasksLessThanRequest{
 		NamespaceID:        db.queue.NamespaceId(),
@@ -610,7 +612,7 @@ func (db *taskQueueDB) CompleteFairTasksLessThan(
 		TaskType:           db.queue.TaskType(),
 		ExclusiveMaxPass:   exclusiveMaxLevel.pass,
 		ExclusiveMaxTaskID: exclusiveMaxLevel.id,
-		Subqueue:           subqueue,
+		Subqueue:           int(subqueue),
 		Limit:              limit,
 	})
 	if err != nil {

--- a/service/matching/fair_backlog_manager.go
+++ b/service/matching/fair_backlog_manager.go
@@ -32,9 +32,9 @@ type (
 		taskWriter *fairTaskWriter
 
 		subqueueLock        sync.Mutex
-		subqueues           []*fairTaskReader           // subqueue index -> fairTaskReader
-		subqueuesByPriority map[priorityKey]subqueueKey // priority key -> subqueue index
-		priorityBySubqueue  map[subqueueKey]priorityKey // subqueue index -> priority key
+		subqueues           []*fairTaskReader // subqueue index -> fairTaskReader
+		subqueuesByPriority map[priorityKey]subqueueKey
+		priorityBySubqueue  map[subqueueKey]priorityKey
 
 		logger           log.Logger
 		throttledLogger  log.ThrottledLogger

--- a/service/matching/fair_backlog_manager.go
+++ b/service/matching/fair_backlog_manager.go
@@ -166,13 +166,13 @@ func (c *fairBacklogManagerImpl) loadSubqueuesLocked(subqueues []persistencespb.
 func (c *fairBacklogManagerImpl) getSubqueueForPriority(priority priorityKey) subqueueKey {
 	levels := c.config.PriorityLevels()
 	if priority == 0 {
-		priority = defaultPriorityLevel(int32(levels))
+		priority = defaultPriorityLevel(levels)
 	}
 	if priority < 1 {
 		// this should have been rejected much earlier, but just clip it here
 		priority = 1
-	} else if priority > priorityKey(levels) {
-		priority = priorityKey(levels)
+	} else if priority > levels {
+		priority = levels
 	}
 
 	c.subqueueLock.Lock()
@@ -290,7 +290,7 @@ func (c *fairBacklogManagerImpl) BacklogStatsByPriority() map[int32]*taskqueuepb
 		result[pk].ApproximateBacklogCount += backlogCounts[subqueueKey]
 
 		// Find greatest backlog age for across all subqueues for the same priority.
-		oldestBacklogTime := c.subqueues[int(subqueueKey)].getOldestBacklogTime()
+		oldestBacklogTime := c.subqueues[subqueueKey].getOldestBacklogTime()
 		if !oldestBacklogTime.IsZero() {
 			oldestBacklogAge := time.Since(oldestBacklogTime)
 			if oldestBacklogAge > result[pk].ApproximateBacklogAge.AsDuration() {

--- a/service/matching/fair_task_reader.go
+++ b/service/matching/fair_task_reader.go
@@ -26,7 +26,7 @@ import (
 type (
 	fairTaskReader struct {
 		backlogMgr *fairBacklogManagerImpl
-		subqueue   subqueueKey
+		subqueue   subqueueIndex
 		logger     log.Logger
 
 		lock sync.Mutex
@@ -70,7 +70,7 @@ const (
 
 func newFairTaskReader(
 	backlogMgr *fairBacklogManagerImpl,
-	subqueue subqueueKey,
+	subqueue subqueueIndex,
 	initialAckLevel fairLevel,
 ) *fairTaskReader {
 	return &fairTaskReader{

--- a/service/matching/fair_task_reader.go
+++ b/service/matching/fair_task_reader.go
@@ -26,7 +26,7 @@ import (
 type (
 	fairTaskReader struct {
 		backlogMgr *fairBacklogManagerImpl
-		subqueue   int
+		subqueue   subqueueKey
 		logger     log.Logger
 
 		lock sync.Mutex
@@ -70,7 +70,7 @@ const (
 
 func newFairTaskReader(
 	backlogMgr *fairBacklogManagerImpl,
-	subqueue int,
+	subqueue subqueueKey,
 	initialAckLevel fairLevel,
 ) *fairTaskReader {
 	return &fairTaskReader{

--- a/service/matching/fair_task_writer.go
+++ b/service/matching/fair_task_writer.go
@@ -29,8 +29,8 @@ type (
 
 		// state:
 		taskIDBlock        taskIDBlock
-		currentTaskIDBlock taskIDBlock             // copy of taskIDBlock for safe concurrent access via getCurrentTaskIDBlock()
-		counters           map[subqueueKey]counter.Counter // subqueue -> Counter. only used in taskWriterLoop.
+		currentTaskIDBlock taskIDBlock                     // copy of taskIDBlock for safe concurrent access via getCurrentTaskIDBlock()
+		counters           map[subqueueKey]counter.Counter // only used in taskWriterLoop.
 	}
 )
 

--- a/service/matching/fair_task_writer.go
+++ b/service/matching/fair_task_writer.go
@@ -30,7 +30,7 @@ type (
 		// state:
 		taskIDBlock        taskIDBlock
 		currentTaskIDBlock taskIDBlock             // copy of taskIDBlock for safe concurrent access via getCurrentTaskIDBlock()
-		counters           map[int]counter.Counter // subqueue -> Counter. only used in taskWriterLoop.
+		counters           map[subqueueKey]counter.Counter // subqueue -> Counter. only used in taskWriterLoop.
 	}
 )
 
@@ -47,7 +47,7 @@ func newFairTaskWriter(
 		appendCh:       make(chan *writeTaskRequest, backlogMgr.config.OutstandingTaskAppendsThreshold()),
 
 		taskIDBlock: noTaskIDs,
-		counters:    make(map[int]counter.Counter),
+		counters:    make(map[subqueueKey]counter.Counter),
 	}
 }
 
@@ -57,7 +57,7 @@ func (w *fairTaskWriter) Start() {
 }
 
 func (w *fairTaskWriter) appendTask(
-	subqueue int,
+	subqueue subqueueKey,
 	taskInfo *persistencespb.TaskInfo,
 ) error {
 	select {

--- a/service/matching/fair_task_writer.go
+++ b/service/matching/fair_task_writer.go
@@ -29,8 +29,8 @@ type (
 
 		// state:
 		taskIDBlock        taskIDBlock
-		currentTaskIDBlock taskIDBlock                     // copy of taskIDBlock for safe concurrent access via getCurrentTaskIDBlock()
-		counters           map[subqueueKey]counter.Counter // only used in taskWriterLoop.
+		currentTaskIDBlock taskIDBlock                       // copy of taskIDBlock for safe concurrent access via getCurrentTaskIDBlock()
+		counters           map[subqueueIndex]counter.Counter // only used in taskWriterLoop.
 	}
 )
 
@@ -47,7 +47,7 @@ func newFairTaskWriter(
 		appendCh:       make(chan *writeTaskRequest, backlogMgr.config.OutstandingTaskAppendsThreshold()),
 
 		taskIDBlock: noTaskIDs,
-		counters:    make(map[subqueueKey]counter.Counter),
+		counters:    make(map[subqueueIndex]counter.Counter),
 	}
 }
 
@@ -57,7 +57,7 @@ func (w *fairTaskWriter) Start() {
 }
 
 func (w *fairTaskWriter) appendTask(
-	subqueue subqueueKey,
+	subqueue subqueueIndex,
 	taskInfo *persistencespb.TaskInfo,
 ) error {
 	select {

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -63,7 +63,7 @@ type (
 		partitionMgr       *taskQueuePartitionManagerImpl
 		queue              *PhysicalTaskQueueKey
 		config             *taskQueueConfig
-		defaultPriorityKey int32
+		defaultPriorityKey priorityKey
 
 		// This context is valid for lifetime of this physicalTaskQueueManagerImpl.
 		// It can be used to notify when the task queue is closing.
@@ -92,8 +92,8 @@ type (
 		pollerScalingRateLimiter    quotas.RateLimiter
 
 		taskTrackerLock sync.RWMutex
-		tasksAdded      map[int32]*taskTracker
-		tasksDispatched map[int32]*taskTracker
+		tasksAdded      map[priorityKey]*taskTracker
+		tasksDispatched map[priorityKey]*taskTracker
 	}
 
 	// TODO(pri): old matcher cleanup
@@ -142,7 +142,7 @@ func newPhysicalTaskQueueManager(
 		return config.PollerScalingDecisionsPerSecond() * 1e6
 	}
 	pqMgr := &physicalTaskQueueManagerImpl{
-		defaultPriorityKey:       defaultPriorityLevel(config.PriorityLevels()),
+		defaultPriorityKey:       priorityKey(defaultPriorityLevel(config.PriorityLevels())),
 		status:                   common.DaemonStatusInitialized,
 		partitionMgr:             partitionMgr,
 		queue:                    queue,
@@ -153,8 +153,8 @@ func newPhysicalTaskQueueManager(
 		matchingClient:           e.matchingRawClient,
 		clusterMeta:              e.clusterMeta,
 		metricsHandler:           taggedMetricsHandler,
-		tasksAdded:               make(map[int32]*taskTracker),
-		tasksDispatched:          make(map[int32]*taskTracker),
+		tasksAdded:               make(map[priorityKey]*taskTracker),
+		tasksDispatched:          make(map[priorityKey]*taskTracker),
 		pollerScalingRateLimiter: quotas.NewDefaultOutgoingRateLimiter(pollerScalingRateLimitFn),
 		deploymentRegistrationCh: make(chan struct{}, 1),
 	}
@@ -410,7 +410,7 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 
 		if pollMetadata.forwardedFrom == "" && // only track the original polls, not forwarded ones.
 			(!task.isStarted() || !task.started.hasEmptyResponse()) { // Need to filter out the empty "started" ones
-			c.getOrCreateTaskTracker(c.tasksDispatched, task.getPriority().GetPriorityKey()).incrementTaskCount()
+			c.getOrCreateTaskTracker(c.tasksDispatched, priorityKey(task.getPriority().GetPriorityKey())).incrementTaskCount()
 		}
 		return task, nil
 	}
@@ -473,7 +473,7 @@ func (c *physicalTaskQueueManagerImpl) DispatchQueryTask(
 ) (*matchingservice.QueryWorkflowResponse, error) {
 	task := newInternalQueryTask(taskId, request)
 	if !task.isForwarded() {
-		c.getOrCreateTaskTracker(c.tasksAdded, request.GetPriority().GetPriorityKey()).incrementTaskCount()
+		c.getOrCreateTaskTracker(c.tasksAdded, priorityKey(request.GetPriority().GetPriorityKey())).incrementTaskCount()
 	}
 	return c.matcher.OfferQuery(ctx, task)
 }
@@ -498,7 +498,7 @@ func (c *physicalTaskQueueManagerImpl) DispatchNexusTask(
 	}
 	task := newInternalNexusTask(taskId, deadline, opDeadline, request)
 	if !task.isForwarded() {
-		c.getOrCreateTaskTracker(c.tasksAdded, 0).incrementTaskCount() // Nexus has no priorities
+		c.getOrCreateTaskTracker(c.tasksAdded, priorityKey(0)).incrementTaskCount() // Nexus has no priorities
 	}
 	return c.matcher.OfferNexusTask(ctx, task)
 }
@@ -550,16 +550,16 @@ func (c *physicalTaskQueueManagerImpl) GetStatsByPriority() map[int32]*taskqueue
 	defer c.taskTrackerLock.RUnlock()
 
 	for pri, tt := range c.tasksAdded {
-		if _, ok := stats[pri]; !ok {
-			stats[pri] = &taskqueuepb.TaskQueueStats{}
+		if _, ok := stats[int32(pri)]; !ok {
+			stats[int32(pri)] = &taskqueuepb.TaskQueueStats{}
 		}
-		stats[pri].TasksAddRate = tt.rate()
+		stats[int32(pri)].TasksAddRate = tt.rate()
 	}
 	for pri, tt := range c.tasksDispatched {
-		if _, ok := stats[pri]; !ok {
-			stats[pri] = &taskqueuepb.TaskQueueStats{}
+		if _, ok := stats[int32(pri)]; !ok {
+			stats[int32(pri)] = &taskqueuepb.TaskQueueStats{}
 		}
-		stats[pri].TasksDispatchRate = tt.rate()
+		stats[int32(pri)].TasksDispatchRate = tt.rate()
 	}
 	return stats
 }
@@ -572,7 +572,7 @@ func (c *physicalTaskQueueManagerImpl) TrySyncMatch(ctx context.Context, task *i
 	if !task.isForwarded() {
 		// request sent by history service
 		c.liveness.markAlive()
-		c.getOrCreateTaskTracker(c.tasksAdded, task.getPriority().GetPriorityKey()).incrementTaskCount()
+		c.getOrCreateTaskTracker(c.tasksAdded, priorityKey(task.getPriority().GetPriorityKey())).incrementTaskCount()
 		if disable, _ := testhooks.Get[bool](c.partitionMgr.engine.testHooks, testhooks.MatchingDisableSyncMatch); disable {
 			return false, nil
 		}
@@ -781,8 +781,8 @@ func (c *physicalTaskQueueManagerImpl) makePollerScalingDecisionImpl(
 }
 
 func (c *physicalTaskQueueManagerImpl) getOrCreateTaskTracker(
-	intervals map[int32]*taskTracker,
-	priorityKey int32,
+	intervals map[priorityKey]*taskTracker,
+	priorityKey priorityKey,
 ) *taskTracker {
 	if priorityKey == 0 {
 		priorityKey = c.defaultPriorityKey

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -142,7 +142,7 @@ func newPhysicalTaskQueueManager(
 		return config.PollerScalingDecisionsPerSecond() * 1e6
 	}
 	pqMgr := &physicalTaskQueueManagerImpl{
-		defaultPriorityKey:       priorityKey(defaultPriorityLevel(config.PriorityLevels())),
+		defaultPriorityKey:       defaultPriorityLevel(config.PriorityLevels()),
 		status:                   common.DaemonStatusInitialized,
 		partitionMgr:             partitionMgr,
 		queue:                    queue,

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -51,9 +51,9 @@ type (
 		taskWriter *priTaskWriter
 
 		subqueueLock        sync.Mutex
-		subqueues           []*priTaskReader // subqueue index -> fairTaskReader
-		subqueuesByPriority map[int32]int    // priority key -> subqueue index
-		priorityBySubqueue  map[int]int32    // subqueue index -> priority key
+		subqueues           []*priTaskReader            // subqueue index -> fairTaskReader
+		subqueuesByPriority map[priorityKey]subqueueKey // priority key -> subqueue index
+		priorityBySubqueue  map[subqueueKey]priorityKey // subqueue index -> priority key
 
 		logger           log.Logger
 		throttledLogger  log.ThrottledLogger
@@ -64,6 +64,8 @@ type (
 		// update before unloading
 		skipFinalUpdate atomic.Bool
 	}
+
+	priorityKey int32
 )
 
 var _ backlogManager = (*priBacklogManagerImpl)(nil)
@@ -83,8 +85,8 @@ func newPriBacklogManager(
 		config:              config,
 		tqCtx:               tqCtx,
 		db:                  newTaskQueueDB(config, taskManager, pqMgr.QueueKey(), logger, metricsHandler),
-		subqueuesByPriority: make(map[int32]int),
-		priorityBySubqueue:  make(map[int]int32),
+		subqueuesByPriority: make(map[priorityKey]subqueueKey),
+		priorityBySubqueue:  make(map[subqueueKey]priorityKey),
 		matchingClient:      matchingClient,
 		metricsHandler:      metricsHandler,
 		logger:              logger,
@@ -131,7 +133,7 @@ func (c *priBacklogManagerImpl) Stop() {
 	for i, r := range c.subqueues {
 		_, ackLevel := r.getLevels()
 		// oldestTime can be time.Time{} here since countDelta is 0
-		c.db.updateAckLevelAndBacklogStats(i, ackLevel, 0, time.Time{})
+		c.db.updateAckLevelAndBacklogStats(subqueueKey(i), ackLevel, 0, time.Time{})
 	}
 	c.subqueueLock.Unlock()
 
@@ -167,25 +169,25 @@ func (c *priBacklogManagerImpl) loadSubqueuesLocked(subqueues []persistencespb.S
 	// existing subqueues never changes. If we change that, this logic will need to change.
 	for i := range subqueues {
 		if i >= len(c.subqueues) {
-			r := newPriTaskReader(c, i, subqueues[i].AckLevel)
+			r := newPriTaskReader(c, subqueueKey(i), subqueues[i].AckLevel)
 			r.Start()
 			c.subqueues = append(c.subqueues, r)
 		}
-		c.subqueuesByPriority[subqueues[i].Key.Priority] = i
-		c.priorityBySubqueue[i] = subqueues[i].Key.Priority
+		c.subqueuesByPriority[priorityKey(subqueues[i].Key.Priority)] = subqueueKey(i)
+		c.priorityBySubqueue[subqueueKey(i)] = priorityKey(subqueues[i].Key.Priority)
 	}
 }
 
-func (c *priBacklogManagerImpl) getSubqueueForPriority(priority int32) int {
+func (c *priBacklogManagerImpl) getSubqueueForPriority(priority priorityKey) subqueueKey {
 	levels := c.config.PriorityLevels()
 	if priority == 0 {
-		priority = defaultPriorityLevel(levels)
+		priority = priorityKey(defaultPriorityLevel(int32(levels)))
 	}
 	if priority < 1 {
 		// this should have been rejected much earlier, but just clip it here
 		priority = 1
-	} else if priority > int32(levels) {
-		priority = int32(levels)
+	} else if priority > priorityKey(levels) {
+		priority = priorityKey(levels)
 	}
 
 	c.subqueueLock.Lock()
@@ -199,13 +201,13 @@ func (c *priBacklogManagerImpl) getSubqueueForPriority(priority int32) int {
 	// but we want to serialize these updates.
 	// TODO(pri): maybe we can improve that
 	subqueues, err := c.db.AllocateSubqueue(c.tqCtx, &persistencespb.SubqueueKey{
-		Priority: priority,
+		Priority: int32(priority),
 	})
 	if err != nil {
 		c.signalIfFatal(err)
 		// If we failed to write the metadata update, just use 0. If err was a fatal error
 		// (most likely case), the subsequent call to SpoolTask will fail.
-		return 0
+		return subqueueKey(0)
 	}
 
 	c.loadSubqueuesLocked(subqueues)
@@ -217,7 +219,7 @@ func (c *priBacklogManagerImpl) getSubqueueForPriority(priority int32) int {
 	}
 
 	// But if something went wrong, return zero.
-	return subqueueZero
+	return subqueueKey(0)
 }
 
 func (c *priBacklogManagerImpl) periodicSync() {
@@ -235,7 +237,7 @@ func (c *priBacklogManagerImpl) periodicSync() {
 }
 
 func (c *priBacklogManagerImpl) SpoolTask(taskInfo *persistencespb.TaskInfo) error {
-	subqueue := c.getSubqueueForPriority(taskInfo.Priority.GetPriorityKey())
+	subqueue := c.getSubqueueForPriority(priorityKey(taskInfo.Priority.GetPriorityKey()))
 	err := c.taskWriter.appendTask(subqueue, taskInfo)
 	c.signalIfFatal(err)
 	return err
@@ -272,8 +274,8 @@ func (c *priBacklogManagerImpl) BacklogStatsByPriority() map[int32]*taskqueuepb.
 	backlogCounts := c.db.getApproximateBacklogCountsBySubqueue()
 	for subqueueKey, priorityKey := range c.priorityBySubqueue {
 		// Note that there could be more than one subqueue for the same priority.
-		if _, ok := result[priorityKey]; !ok {
-			result[priorityKey] = &taskqueuepb.TaskQueueStats{
+		if _, ok := result[int32(priorityKey)]; !ok {
+			result[int32(priorityKey)] = &taskqueuepb.TaskQueueStats{
 				// TODO(pri): returning 0 to match existing behavior, but maybe emptyBacklogAge would
 				// be more appropriate in the future.
 				ApproximateBacklogAge: durationpb.New(0),
@@ -281,14 +283,14 @@ func (c *priBacklogManagerImpl) BacklogStatsByPriority() map[int32]*taskqueuepb.
 		}
 
 		// Add backlog counts together across all subqueues for the same priority.
-		result[priorityKey].ApproximateBacklogCount += backlogCounts[subqueueKey]
+		result[int32(priorityKey)].ApproximateBacklogCount += backlogCounts[subqueueKey]
 
 		// Find greatest backlog age for across all subqueues for the same priority.
-		oldestBacklogTime := c.subqueues[subqueueKey].getOldestBacklogTime()
+		oldestBacklogTime := c.subqueues[int(subqueueKey)].getOldestBacklogTime()
 		if !oldestBacklogTime.IsZero() {
 			oldestBacklogAge := time.Since(oldestBacklogTime)
-			if oldestBacklogAge > result[priorityKey].ApproximateBacklogAge.AsDuration() {
-				result[priorityKey].ApproximateBacklogAge = durationpb.New(oldestBacklogAge)
+			if oldestBacklogAge > result[int32(priorityKey)].ApproximateBacklogAge.AsDuration() {
+				result[int32(priorityKey)].ApproximateBacklogAge = durationpb.New(oldestBacklogAge)
 			}
 		}
 	}
@@ -336,8 +338,8 @@ func (c *priBacklogManagerImpl) InternalStatus() []*taskqueuespb.InternalTaskQue
 				EndId:   currentTaskIDBlock.end,
 			},
 			LoadedTasks:             int64(r.getLoadedTasks()),
-			MaxReadLevel:            c.db.GetMaxReadLevel(i),
-			ApproximateBacklogCount: backlogCountsBySubqueue[i],
+			MaxReadLevel:            c.db.GetMaxReadLevel(subqueueKey(i)),
+			ApproximateBacklogCount: backlogCountsBySubqueue[subqueueKey(i)],
 		}
 	}
 	return status

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -181,13 +181,13 @@ func (c *priBacklogManagerImpl) loadSubqueuesLocked(subqueues []persistencespb.S
 func (c *priBacklogManagerImpl) getSubqueueForPriority(priority priorityKey) subqueueKey {
 	levels := c.config.PriorityLevels()
 	if priority == 0 {
-		priority = defaultPriorityLevel(int32(levels))
+		priority = defaultPriorityLevel(levels)
 	}
 	if priority < 1 {
 		// this should have been rejected much earlier, but just clip it here
 		priority = 1
-	} else if priority > priorityKey(levels) {
-		priority = priorityKey(levels)
+	} else if priority > levels {
+		priority = levels
 	}
 
 	c.subqueueLock.Lock()
@@ -288,7 +288,7 @@ func (c *priBacklogManagerImpl) BacklogStatsByPriority() map[int32]*taskqueuepb.
 		result[pk].ApproximateBacklogCount += backlogCounts[subqueueKey]
 
 		// Find greatest backlog age for across all subqueues for the same priority.
-		oldestBacklogTime := c.subqueues[int(subqueueKey)].getOldestBacklogTime()
+		oldestBacklogTime := c.subqueues[subqueueKey].getOldestBacklogTime()
 		if !oldestBacklogTime.IsZero() {
 			oldestBacklogAge := time.Since(oldestBacklogTime)
 			if oldestBacklogAge > result[pk].ApproximateBacklogAge.AsDuration() {
@@ -341,7 +341,7 @@ func (c *priBacklogManagerImpl) InternalStatus() []*taskqueuespb.InternalTaskQue
 			},
 			LoadedTasks:             int64(r.getLoadedTasks()),
 			MaxReadLevel:            c.db.GetMaxReadLevel(subqueueKey(i)),
-			ApproximateBacklogCount: backlogCountsBySubqueue[subqueueKey(i)],
+			ApproximateBacklogCount: backlogCountsBySubqueue[i],
 		}
 	}
 	return status

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -34,7 +34,7 @@ const (
 type (
 	priTaskReader struct {
 		backlogMgr *priBacklogManagerImpl
-		subqueue   subqueueKey
+		subqueue   subqueueIndex
 		notifyC    chan struct{} // Used as signal to notify pump of new tasks
 		logger     log.Logger
 
@@ -65,7 +65,7 @@ var addErrorRetryPolicy = backoff.NewExponentialRetryPolicy(2 * time.Second).
 
 func newPriTaskReader(
 	backlogMgr *priBacklogManagerImpl,
-	subqueue subqueueKey,
+	subqueue subqueueIndex,
 	initialAckLevel int64,
 ) *priTaskReader {
 	return &priTaskReader{

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -34,7 +34,7 @@ const (
 type (
 	priTaskReader struct {
 		backlogMgr *priBacklogManagerImpl
-		subqueue   int
+		subqueue   subqueueKey
 		notifyC    chan struct{} // Used as signal to notify pump of new tasks
 		logger     log.Logger
 
@@ -65,7 +65,7 @@ var addErrorRetryPolicy = backoff.NewExponentialRetryPolicy(2 * time.Second).
 
 func newPriTaskReader(
 	backlogMgr *priBacklogManagerImpl,
-	subqueue int,
+	subqueue subqueueKey,
 	initialAckLevel int64,
 ) *priTaskReader {
 	return &priTaskReader{

--- a/service/matching/pri_task_writer.go
+++ b/service/matching/pri_task_writer.go
@@ -66,7 +66,7 @@ func (w *priTaskWriter) Start() {
 }
 
 func (w *priTaskWriter) appendTask(
-	subqueue subqueueKey,
+	subqueue subqueueIndex,
 	taskInfo *persistencespb.TaskInfo,
 ) error {
 	select {

--- a/service/matching/pri_task_writer.go
+++ b/service/matching/pri_task_writer.go
@@ -66,7 +66,7 @@ func (w *priTaskWriter) Start() {
 }
 
 func (w *priTaskWriter) appendTask(
-	subqueue int,
+	subqueue subqueueKey,
 	taskInfo *persistencespb.TaskInfo,
 ) error {
 	select {

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -21,8 +21,8 @@ type (
 	writeTaskRequest struct {
 		taskInfo   *persistencespb.TaskInfo
 		responseCh chan<- error
-		subqueue   subqueueKey // for priTaskWriter only
-		fairLevel              // filled in by taskWriterLoop
+		subqueue   subqueueIndex // for priTaskWriter only
+		fairLevel                // filled in by taskWriterLoop
 	}
 
 	taskIDBlock struct {

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -22,7 +22,7 @@ type (
 		taskInfo   *persistencespb.TaskInfo
 		responseCh chan<- error
 		subqueue   subqueueKey // for priTaskWriter only
-		fairLevel      // filled in by taskWriterLoop
+		fairLevel              // filled in by taskWriterLoop
 	}
 
 	taskIDBlock struct {

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -21,7 +21,7 @@ type (
 	writeTaskRequest struct {
 		taskInfo   *persistencespb.TaskInfo
 		responseCh chan<- error
-		subqueue   int // for priTaskWriter only
+		subqueue   subqueueKey // for priTaskWriter only
 		fairLevel      // filled in by taskWriterLoop
 	}
 


### PR DESCRIPTION
## What changed?

Added new types `subqueueKey` and `priorityKey`.

## Why?

Instead of int/int32, the types help with documentation and incorrect usage.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
