### PR TITLE
Nexus gRPC APIs

### DIFF
--- a/client/frontend/client_gen.go
+++ b/client/frontend/client_gen.go
@@ -249,6 +249,26 @@ func (c *clientImpl) GetDeploymentReachability(
 	return c.client.GetDeploymentReachability(ctx, request, opts...)
 }
 
+func (c *clientImpl) GetNexusOperationInfo(
+	ctx context.Context,
+	request *workflowservice.GetNexusOperationInfoRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.GetNexusOperationInfoResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.GetNexusOperationInfo(ctx, request, opts...)
+}
+
+func (c *clientImpl) GetNexusOperationResult(
+	ctx context.Context,
+	request *workflowservice.GetNexusOperationResultRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.GetNexusOperationResultResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.GetNexusOperationResult(ctx, request, opts...)
+}
+
 func (c *clientImpl) GetSearchAttributes(
 	ctx context.Context,
 	request *workflowservice.GetSearchAttributesRequest,
@@ -559,6 +579,16 @@ func (c *clientImpl) RegisterNamespace(
 	return c.client.RegisterNamespace(ctx, request, opts...)
 }
 
+func (c *clientImpl) RequestCancelNexusOperation(
+	ctx context.Context,
+	request *workflowservice.RequestCancelNexusOperationRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.RequestCancelNexusOperationResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.RequestCancelNexusOperation(ctx, request, opts...)
+}
+
 func (c *clientImpl) RequestCancelWorkflowExecution(
 	ctx context.Context,
 	request *workflowservice.RequestCancelWorkflowExecutionRequest,
@@ -787,6 +817,16 @@ func (c *clientImpl) StartBatchOperation(
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.StartBatchOperation(ctx, request, opts...)
+}
+
+func (c *clientImpl) StartNexusOperation(
+	ctx context.Context,
+	request *workflowservice.StartNexusOperationRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.StartNexusOperationResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.StartNexusOperation(ctx, request, opts...)
 }
 
 func (c *clientImpl) StartWorkflowExecution(

--- a/client/frontend/metric_client_gen.go
+++ b/client/frontend/metric_client_gen.go
@@ -345,6 +345,34 @@ func (c *metricClient) GetDeploymentReachability(
 	return c.client.GetDeploymentReachability(ctx, request, opts...)
 }
 
+func (c *metricClient) GetNexusOperationInfo(
+	ctx context.Context,
+	request *workflowservice.GetNexusOperationInfoRequest,
+	opts ...grpc.CallOption,
+) (_ *workflowservice.GetNexusOperationInfoResponse, retError error) {
+
+	metricsHandler, startTime := c.startMetricsRecording(ctx, "FrontendClientGetNexusOperationInfo")
+	defer func() {
+		c.finishMetricsRecording(metricsHandler, startTime, retError)
+	}()
+
+	return c.client.GetNexusOperationInfo(ctx, request, opts...)
+}
+
+func (c *metricClient) GetNexusOperationResult(
+	ctx context.Context,
+	request *workflowservice.GetNexusOperationResultRequest,
+	opts ...grpc.CallOption,
+) (_ *workflowservice.GetNexusOperationResultResponse, retError error) {
+
+	metricsHandler, startTime := c.startMetricsRecording(ctx, "FrontendClientGetNexusOperationResult")
+	defer func() {
+		c.finishMetricsRecording(metricsHandler, startTime, retError)
+	}()
+
+	return c.client.GetNexusOperationResult(ctx, request, opts...)
+}
+
 func (c *metricClient) GetSearchAttributes(
 	ctx context.Context,
 	request *workflowservice.GetSearchAttributesRequest,
@@ -779,6 +807,20 @@ func (c *metricClient) RegisterNamespace(
 	return c.client.RegisterNamespace(ctx, request, opts...)
 }
 
+func (c *metricClient) RequestCancelNexusOperation(
+	ctx context.Context,
+	request *workflowservice.RequestCancelNexusOperationRequest,
+	opts ...grpc.CallOption,
+) (_ *workflowservice.RequestCancelNexusOperationResponse, retError error) {
+
+	metricsHandler, startTime := c.startMetricsRecording(ctx, "FrontendClientRequestCancelNexusOperation")
+	defer func() {
+		c.finishMetricsRecording(metricsHandler, startTime, retError)
+	}()
+
+	return c.client.RequestCancelNexusOperation(ctx, request, opts...)
+}
+
 func (c *metricClient) RequestCancelWorkflowExecution(
 	ctx context.Context,
 	request *workflowservice.RequestCancelWorkflowExecutionRequest,
@@ -1099,6 +1141,20 @@ func (c *metricClient) StartBatchOperation(
 	}()
 
 	return c.client.StartBatchOperation(ctx, request, opts...)
+}
+
+func (c *metricClient) StartNexusOperation(
+	ctx context.Context,
+	request *workflowservice.StartNexusOperationRequest,
+	opts ...grpc.CallOption,
+) (_ *workflowservice.StartNexusOperationResponse, retError error) {
+
+	metricsHandler, startTime := c.startMetricsRecording(ctx, "FrontendClientStartNexusOperation")
+	defer func() {
+		c.finishMetricsRecording(metricsHandler, startTime, retError)
+	}()
+
+	return c.client.StartNexusOperation(ctx, request, opts...)
 }
 
 func (c *metricClient) StartWorkflowExecution(

--- a/client/frontend/retryable_client_gen.go
+++ b/client/frontend/retryable_client_gen.go
@@ -371,6 +371,36 @@ func (c *retryableClient) GetDeploymentReachability(
 	return resp, err
 }
 
+func (c *retryableClient) GetNexusOperationInfo(
+	ctx context.Context,
+	request *workflowservice.GetNexusOperationInfoRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.GetNexusOperationInfoResponse, error) {
+	var resp *workflowservice.GetNexusOperationInfoResponse
+	op := func(ctx context.Context) error {
+		var err error
+		resp, err = c.client.GetNexusOperationInfo(ctx, request, opts...)
+		return err
+	}
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
+	return resp, err
+}
+
+func (c *retryableClient) GetNexusOperationResult(
+	ctx context.Context,
+	request *workflowservice.GetNexusOperationResultRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.GetNexusOperationResultResponse, error) {
+	var resp *workflowservice.GetNexusOperationResultResponse
+	op := func(ctx context.Context) error {
+		var err error
+		resp, err = c.client.GetNexusOperationResult(ctx, request, opts...)
+		return err
+	}
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
+	return resp, err
+}
+
 func (c *retryableClient) GetSearchAttributes(
 	ctx context.Context,
 	request *workflowservice.GetSearchAttributesRequest,
@@ -836,6 +866,21 @@ func (c *retryableClient) RegisterNamespace(
 	return resp, err
 }
 
+func (c *retryableClient) RequestCancelNexusOperation(
+	ctx context.Context,
+	request *workflowservice.RequestCancelNexusOperationRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.RequestCancelNexusOperationResponse, error) {
+	var resp *workflowservice.RequestCancelNexusOperationResponse
+	op := func(ctx context.Context) error {
+		var err error
+		resp, err = c.client.RequestCancelNexusOperation(ctx, request, opts...)
+		return err
+	}
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
+	return resp, err
+}
+
 func (c *retryableClient) RequestCancelWorkflowExecution(
 	ctx context.Context,
 	request *workflowservice.RequestCancelWorkflowExecutionRequest,
@@ -1175,6 +1220,21 @@ func (c *retryableClient) StartBatchOperation(
 	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.StartBatchOperation(ctx, request, opts...)
+		return err
+	}
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
+	return resp, err
+}
+
+func (c *retryableClient) StartNexusOperation(
+	ctx context.Context,
+	request *workflowservice.StartNexusOperationRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.StartNexusOperationResponse, error) {
+	var resp *workflowservice.StartNexusOperationResponse
+	op := func(ctx context.Context) error {
+		var err error
+		resp, err = c.client.StartNexusOperation(ctx, request, opts...)
 		return err
 	}
 	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)

--- a/common/api/metadata.go
+++ b/common/api/metadata.go
@@ -161,6 +161,10 @@ var (
 		"UpdateTaskQueueConfig":                 {Scope: ScopeNamespace, Access: AccessWrite, Polling: PollingNone},
 		"FetchWorkerConfig":                     {Scope: ScopeNamespace, Access: AccessReadOnly, Polling: PollingNone},
 		"UpdateWorkerConfig":                    {Scope: ScopeNamespace, Access: AccessWrite, Polling: PollingNone},
+		"StartNexusOperation":                   {Scope: ScopeNamespace, Access: AccessWrite, Polling: PollingNone},
+		"RequestCancelNexusOperation":           {Scope: ScopeNamespace, Access: AccessWrite, Polling: PollingNone},
+		"GetNexusOperationInfo":                 {Scope: ScopeNamespace, Access: AccessReadOnly, Polling: PollingNone},
+		"GetNexusOperationResult":               {Scope: ScopeNamespace, Access: AccessReadOnly, Polling: PollingNone},
 	}
 	operatorServiceMetadata = map[string]MethodMetadata{
 		"AddSearchAttributes":      {Scope: ScopeNamespace, Access: AccessAdmin, Polling: PollingNone},

--- a/common/rpc/interceptor/logtags/workflow_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/workflow_service_server_gen.go
@@ -111,6 +111,14 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 		return nil
 	case *workflowservice.GetDeploymentReachabilityResponse:
 		return nil
+	case *workflowservice.GetNexusOperationInfoRequest:
+		return nil
+	case *workflowservice.GetNexusOperationInfoResponse:
+		return nil
+	case *workflowservice.GetNexusOperationResultRequest:
+		return nil
+	case *workflowservice.GetNexusOperationResultResponse:
+		return nil
 	case *workflowservice.GetSearchAttributesRequest:
 		return nil
 	case *workflowservice.GetSearchAttributesResponse:
@@ -262,6 +270,10 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 		return nil
 	case *workflowservice.RegisterNamespaceResponse:
 		return nil
+	case *workflowservice.RequestCancelNexusOperationRequest:
+		return nil
+	case *workflowservice.RequestCancelNexusOperationResponse:
+		return nil
 	case *workflowservice.RequestCancelWorkflowExecutionRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowExecution().GetWorkflowId()),
@@ -383,6 +395,10 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 	case *workflowservice.StartBatchOperationRequest:
 		return nil
 	case *workflowservice.StartBatchOperationResponse:
+		return nil
+	case *workflowservice.StartNexusOperationRequest:
+		return nil
+	case *workflowservice.StartNexusOperationResponse:
 		return nil
 	case *workflowservice.StartWorkflowExecutionRequest:
 		return []tag.Tag{

--- a/common/rpc/interceptor/redirection.go
+++ b/common/rpc/interceptor/redirection.go
@@ -134,6 +134,11 @@ var (
 		"UpdateTaskQueueConfig": func() any { return &workflowservice.UpdateTaskQueueConfigResponse{} },
 		"FetchWorkerConfig":     func() any { return &workflowservice.FetchWorkerConfigResponse{} },
 		"UpdateWorkerConfig":    func() any { return &workflowservice.UpdateWorkerConfigResponse{} },
+
+		"StartNexusOperation":         func() any { return &workflowservice.StartNexusOperationResponse{} },
+		"RequestCancelNexusOperation": func() any { return &workflowservice.RequestCancelNexusOperationResponse{} },
+		"GetNexusOperationInfo":       func() any { return &workflowservice.GetNexusOperationInfoResponse{} },
+		"GetNexusOperationResult":     func() any { return &workflowservice.GetNexusOperationResultResponse{} },
 	}
 )
 

--- a/common/rpc/interceptor/redirection_test.go
+++ b/common/rpc/interceptor/redirection_test.go
@@ -189,6 +189,11 @@ func (s *redirectionInterceptorSuite) TestGlobalAPI() {
 		"UpdateTaskQueueConfig":                 {},
 		"FetchWorkerConfig":                     {},
 		"UpdateWorkerConfig":                    {},
+
+		"StartNexusOperation":         {},
+		"RequestCancelNexusOperation": {},
+		"GetNexusOperationInfo":       {},
+		"GetNexusOperationResult":     {},
 	}, apis)
 }
 

--- a/common/testing/mockapi/workflowservicemock/v1/service_grpc.pb.mock.go
+++ b/common/testing/mockapi/workflowservicemock/v1/service_grpc.pb.mock.go
@@ -522,6 +522,46 @@ func (mr *MockWorkflowServiceClientMockRecorder) GetDeploymentReachability(ctx, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentReachability", reflect.TypeOf((*MockWorkflowServiceClient)(nil).GetDeploymentReachability), varargs...)
 }
 
+// GetNexusOperationInfo mocks base method.
+func (m *MockWorkflowServiceClient) GetNexusOperationInfo(ctx context.Context, in *workflowservice.GetNexusOperationInfoRequest, opts ...grpc.CallOption) (*workflowservice.GetNexusOperationInfoResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetNexusOperationInfo", varargs...)
+	ret0, _ := ret[0].(*workflowservice.GetNexusOperationInfoResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNexusOperationInfo indicates an expected call of GetNexusOperationInfo.
+func (mr *MockWorkflowServiceClientMockRecorder) GetNexusOperationInfo(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNexusOperationInfo", reflect.TypeOf((*MockWorkflowServiceClient)(nil).GetNexusOperationInfo), varargs...)
+}
+
+// GetNexusOperationResult mocks base method.
+func (m *MockWorkflowServiceClient) GetNexusOperationResult(ctx context.Context, in *workflowservice.GetNexusOperationResultRequest, opts ...grpc.CallOption) (*workflowservice.GetNexusOperationResultResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetNexusOperationResult", varargs...)
+	ret0, _ := ret[0].(*workflowservice.GetNexusOperationResultResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNexusOperationResult indicates an expected call of GetNexusOperationResult.
+func (mr *MockWorkflowServiceClientMockRecorder) GetNexusOperationResult(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNexusOperationResult", reflect.TypeOf((*MockWorkflowServiceClient)(nil).GetNexusOperationResult), varargs...)
+}
+
 // GetSearchAttributes mocks base method.
 func (m *MockWorkflowServiceClient) GetSearchAttributes(ctx context.Context, in *workflowservice.GetSearchAttributesRequest, opts ...grpc.CallOption) (*workflowservice.GetSearchAttributesResponse, error) {
 	m.ctrl.T.Helper()
@@ -1142,6 +1182,26 @@ func (mr *MockWorkflowServiceClientMockRecorder) RegisterNamespace(ctx, in any, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterNamespace", reflect.TypeOf((*MockWorkflowServiceClient)(nil).RegisterNamespace), varargs...)
 }
 
+// RequestCancelNexusOperation mocks base method.
+func (m *MockWorkflowServiceClient) RequestCancelNexusOperation(ctx context.Context, in *workflowservice.RequestCancelNexusOperationRequest, opts ...grpc.CallOption) (*workflowservice.RequestCancelNexusOperationResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RequestCancelNexusOperation", varargs...)
+	ret0, _ := ret[0].(*workflowservice.RequestCancelNexusOperationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RequestCancelNexusOperation indicates an expected call of RequestCancelNexusOperation.
+func (mr *MockWorkflowServiceClientMockRecorder) RequestCancelNexusOperation(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestCancelNexusOperation", reflect.TypeOf((*MockWorkflowServiceClient)(nil).RequestCancelNexusOperation), varargs...)
+}
+
 // RequestCancelWorkflowExecution mocks base method.
 func (m *MockWorkflowServiceClient) RequestCancelWorkflowExecution(ctx context.Context, in *workflowservice.RequestCancelWorkflowExecutionRequest, opts ...grpc.CallOption) (*workflowservice.RequestCancelWorkflowExecutionResponse, error) {
 	m.ctrl.T.Helper()
@@ -1600,6 +1660,26 @@ func (mr *MockWorkflowServiceClientMockRecorder) StartBatchOperation(ctx, in any
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartBatchOperation", reflect.TypeOf((*MockWorkflowServiceClient)(nil).StartBatchOperation), varargs...)
+}
+
+// StartNexusOperation mocks base method.
+func (m *MockWorkflowServiceClient) StartNexusOperation(ctx context.Context, in *workflowservice.StartNexusOperationRequest, opts ...grpc.CallOption) (*workflowservice.StartNexusOperationResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "StartNexusOperation", varargs...)
+	ret0, _ := ret[0].(*workflowservice.StartNexusOperationResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StartNexusOperation indicates an expected call of StartNexusOperation.
+func (mr *MockWorkflowServiceClientMockRecorder) StartNexusOperation(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartNexusOperation", reflect.TypeOf((*MockWorkflowServiceClient)(nil).StartNexusOperation), varargs...)
 }
 
 // StartWorkflowExecution mocks base method.

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -47,8 +47,12 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/ExecuteMultiOperation": 1,
 
 		// Dispatching a Nexus task is a potentially long running RPC, it's classified in the same bucket as QueryWorkflow.
-		DispatchNexusTaskByNamespaceAndTaskQueueAPIName: 1,
-		DispatchNexusTaskByEndpointAPIName:              1,
+		DispatchNexusTaskByNamespaceAndTaskQueueAPIName:                                1,
+		DispatchNexusTaskByEndpointAPIName:                                             1,
+		"/temporal.api.workflowservice.v1.WorkflowService/StartNexusOperation":         1,
+		"/temporal.api.workflowservice.v1.WorkflowService/RequestCancelNexusOperation": 1,
+		"/temporal.api.workflowservice.v1.WorkflowService/GetNexusOperationInfo":       1,
+		"/temporal.api.workflowservice.v1.WorkflowService/GetNexusOperationResult":     1,
 	}
 
 	// APIToPriority determines common API priorities.
@@ -73,6 +77,7 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/StartBatchOperation":              1,
 		DispatchNexusTaskByNamespaceAndTaskQueueAPIName:                                     1,
 		DispatchNexusTaskByEndpointAPIName:                                                  1,
+		"/temporal.api.workflowservice.v1.WorkflowService/StartNexusOperation":              1,
 
 		// P1: Progress APIs for reporting heartbeats and task completions.
 		// Rejecting them could result in more load to retry the workflow/activity/nexus tasks.
@@ -113,6 +118,7 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkflowRules":                     2,
 		"/temporal.api.workflowservice.v1.WorkflowService/TriggerWorkflowRule":                   2,
 		"/temporal.api.workflowservice.v1.WorkflowService/UpdateTaskQueueConfig":                 2,
+		"/temporal.api.workflowservice.v1.WorkflowService/RequestCancelNexusOperation":           2,
 
 		// P3: Status Querying APIs
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorkflowExecution":       3,
@@ -129,6 +135,8 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorkerDeploymentVersion": 3,
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorkerDeployment":        3,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkerDeployments":           3,
+		"/temporal.api.workflowservice.v1.WorkflowService/GetNexusOperationInfo":           3,
+		"/temporal.api.workflowservice.v1.WorkflowService/GetNexusOperationResult":         3,
 
 		// P3: Progress APIs for reporting cancellations and failures.
 		// They are relatively low priority as the tasks need to be retried anyway.

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -20,7 +20,7 @@ import (
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/nexus"
+	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/visibility"
@@ -720,6 +720,7 @@ func HandlerProvider(
 	membershipMonitor membership.Monitor,
 	healthInterceptor *interceptor.HealthInterceptor,
 	scheduleSpecBuilder *scheduler.SpecBuilder,
+	endpointRegistry commonnexus.EndpointRegistry,
 ) Handler {
 	wfHandler := NewWorkflowHandler(
 		serviceConfig,
@@ -746,6 +747,8 @@ func HandlerProvider(
 		membershipMonitor,
 		healthInterceptor,
 		scheduleSpecBuilder,
+		endpointRegistry,
+		clientBean,
 		httpEnabled(cfg, serviceName),
 	)
 	return wfHandler
@@ -759,7 +762,7 @@ func RegisterNexusHTTPHandler(
 	clusterMetadata cluster.Metadata,
 	clientCache *cluster.FrontendHTTPClientCache,
 	namespaceRegistry namespace.Registry,
-	endpointRegistry nexus.EndpointRegistry,
+	endpointRegistry commonnexus.EndpointRegistry,
 	authInterceptor *authorization.Interceptor,
 	telemetryInterceptor *interceptor.TelemetryInterceptor,
 	redirectionInterceptor *interceptor.Redirection,
@@ -769,7 +772,7 @@ func RegisterNexusHTTPHandler(
 	rateLimitInterceptor *interceptor.RateLimitInterceptor,
 	logger log.Logger,
 	router *mux.Router,
-	httpTraceProvider nexus.HTTPClientTraceProvider,
+	httpTraceProvider commonnexus.HTTPClientTraceProvider,
 ) {
 	h := NewNexusHTTPHandler(
 		serviceConfig,
@@ -877,9 +880,9 @@ func NexusEndpointRegistryProvider(
 	dc *dynamicconfig.Collection,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
-) nexus.EndpointRegistry {
-	registryConfig := nexus.NewEndpointRegistryConfig(dc)
-	return nexus.NewEndpointRegistry(
+) commonnexus.EndpointRegistry {
+	registryConfig := commonnexus.NewEndpointRegistryConfig(dc)
+	return commonnexus.NewEndpointRegistry(
 		registryConfig,
 		matchingClient,
 		nexusEndpointManager,
@@ -888,7 +891,7 @@ func NexusEndpointRegistryProvider(
 	)
 }
 
-func EndpointRegistryLifetimeHooks(lc fx.Lifecycle, registry nexus.EndpointRegistry) {
+func EndpointRegistryLifetimeHooks(lc fx.Lifecycle, registry commonnexus.EndpointRegistry) {
 	lc.Append(fx.StartStopHook(registry.StartLifecycle, registry.StopLifecycle))
 }
 

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -186,6 +186,8 @@ func (s *WorkflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 		s.mockResource.GetMembershipMonitor(),
 		healthInterceptor,
 		scheduler.NewSpecBuilder(),
+		nil,
+		s.mockResource.GetClientBean(),
 		true,
 	)
 }


### PR DESCRIPTION
## What changed?
Added implementations for workflow service APIs to support Nexus calls over gRPC. Except for `CompleteNexusOperation` which will be coming in a followup.

Depends on https://github.com/temporalio/api/pull/605

## Why?
Required to support non-workflow callers using a Temporal client to interact with Nexus operations.

## How did you test it?
Tests will come in a followup.
