### PR TITLE
Fix for issue 8114: preserve backwards compatibility with v31 VersioningOverride

### DIFF
--- a/common/worker_versioning/worker_versioning.go
+++ b/common/worker_versioning/worker_versioning.go
@@ -485,42 +485,44 @@ func ValidateVersioningOverride(override *workflowpb.VersioningOverride) error {
 		return nil
 	}
 
+	//nolint:staticcheck // SA1019: worker versioning v0.31
+	if override.GetBehavior() != enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED { // v0.31
+		//nolint:staticcheck // SA1019: worker versioning v0.31
+		switch override.GetBehavior() {
+		case enumspb.VERSIONING_BEHAVIOR_PINNED:
+			if override.GetDeployment() != nil {
+				return ValidateDeployment(override.GetDeployment())
+			} else if override.GetPinnedVersion() != "" {
+				_, err := ValidateDeploymentVersionStringV31(override.GetPinnedVersion())
+				return err
+			} else {
+				return serviceerror.NewInvalidArgument("must provide deployment (deprecated) or pinned version if behavior is 'PINNED'")
+			}
+		case enumspb.VERSIONING_BEHAVIOR_AUTO_UPGRADE:
+			if override.GetDeployment() != nil {
+				return serviceerror.NewInvalidArgument("only provide deployment if behavior is 'PINNED'")
+			}
+			if override.GetPinnedVersion() != "" {
+				return serviceerror.NewInvalidArgument("only provide pinned version if behavior is 'PINNED'")
+			}
+		default:
+			//nolint:staticcheck // SA1019 deprecated stamp will clean up later
+			return serviceerror.NewInvalidArgumentf("override behavior %s not recognized", override.GetBehavior())
+		}
+	}
+
 	if override.GetAutoUpgrade() { // v0.32
 		return nil
 	} else if p := override.GetPinned(); p != nil {
 		if p.GetVersion() == nil {
 			return serviceerror.NewInvalidArgument("must provide version if override is pinned.")
 		}
-		if p.GetBehavior() == workflowpb.VersioningOverride_PINNED_OVERRIDE_BEHAVIOR_UNSPECIFIED && override.GetBehavior() != enumspb.VERSIONING_BEHAVIOR_PINNED {
+		if p.GetBehavior() == workflowpb.VersioningOverride_PINNED_OVERRIDE_BEHAVIOR_UNSPECIFIED {
 			return serviceerror.NewInvalidArgument("must specify pinned override behavior if override is pinned.")
 		}
 		return nil
 	}
 
-	//nolint:staticcheck // SA1019: worker versioning v0.31
-	switch override.GetBehavior() {
-	case enumspb.VERSIONING_BEHAVIOR_PINNED:
-		if override.GetDeployment() != nil {
-			return ValidateDeployment(override.GetDeployment())
-		} else if override.GetPinnedVersion() != "" {
-			_, err := ValidateDeploymentVersionStringV31(override.GetPinnedVersion())
-			return err
-		} else {
-			return serviceerror.NewInvalidArgument("must provide deployment (deprecated) or pinned version if behavior is 'PINNED'")
-		}
-	case enumspb.VERSIONING_BEHAVIOR_AUTO_UPGRADE:
-		if override.GetDeployment() != nil {
-			return serviceerror.NewInvalidArgument("only provide deployment if behavior is 'PINNED'")
-		}
-		if override.GetPinnedVersion() != "" {
-			return serviceerror.NewInvalidArgument("only provide pinned version if behavior is 'PINNED'")
-		}
-	case enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED:
-		return serviceerror.NewInvalidArgument("override behavior is required")
-	default:
-		//nolint:staticcheck // SA1019 deprecated stamp will clean up later
-		return serviceerror.NewInvalidArgumentf("override behavior %s not recognized", override.GetBehavior())
-	}
 	return nil
 }
 

--- a/common/worker_versioning/worker_versioning.go
+++ b/common/worker_versioning/worker_versioning.go
@@ -491,7 +491,7 @@ func ValidateVersioningOverride(override *workflowpb.VersioningOverride) error {
 		if p.GetVersion() == nil {
 			return serviceerror.NewInvalidArgument("must provide version if override is pinned.")
 		}
-		if p.GetBehavior() == workflowpb.VersioningOverride_PINNED_OVERRIDE_BEHAVIOR_UNSPECIFIED {
+		if p.GetBehavior() == workflowpb.VersioningOverride_PINNED_OVERRIDE_BEHAVIOR_UNSPECIFIED && override.GetBehavior() != enumspb.VERSIONING_BEHAVIOR_PINNED {
 			return serviceerror.NewInvalidArgument("must specify pinned override behavior if override is pinned.")
 		}
 		return nil


### PR DESCRIPTION
## What changed?
Look at v31 VersionOverride before attempting to validate v32, as validating v32 attributes on a v31 request will always fail a request with PINNED behavior.

## Why?
Issue https://github.com/temporalio/temporal/issues/8114

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Was only able to test with a v31 client, not v32
