### PR TITLE
CHASM: remove workflow specific logic in migration activities

### DIFF
--- a/api/adminservice/v1/request_response.pb.go
+++ b/api/adminservice/v1/request_response.pb.go
@@ -248,11 +248,12 @@ func (x *ImportWorkflowExecutionResponse) GetToken() []byte {
 }
 
 type DescribeMutableStateRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Namespace     string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	Execution     *v1.WorkflowExecution  `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Namespace       string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Execution       *v1.WorkflowExecution  `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
+	SkipForceReload bool                   `protobuf:"varint,3,opt,name=skip_force_reload,json=skipForceReload,proto3" json:"skip_force_reload,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *DescribeMutableStateRequest) Reset() {
@@ -297,6 +298,13 @@ func (x *DescribeMutableStateRequest) GetExecution() *v1.WorkflowExecution {
 		return x.Execution
 	}
 	return nil
+}
+
+func (x *DescribeMutableStateRequest) GetSkipForceReload() bool {
+	if x != nil {
+		return x.SkipForceReload
+	}
+	return false
 }
 
 type DescribeMutableStateResponse struct {
@@ -5374,10 +5382,11 @@ const file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc = 
 	"\x0fversion_history\x18\x04 \x01(\v2..temporal.server.api.history.v1.VersionHistoryR\x0eversionHistory\x12\x14\n" +
 	"\x05token\x18\x05 \x01(\fR\x05token\"7\n" +
 	"\x1fImportWorkflowExecutionResponse\x12\x14\n" +
-	"\x05token\x18\x01 \x01(\fR\x05token\"\x84\x01\n" +
+	"\x05token\x18\x01 \x01(\fR\x05token\"\xb0\x01\n" +
 	"\x1bDescribeMutableStateRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12G\n" +
-	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\"\xb6\x02\n" +
+	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\x12*\n" +
+	"\x11skip_force_reload\x18\x03 \x01(\bR\x0fskipForceReload\"\xb6\x02\n" +
 	"\x1cDescribeMutableStateResponse\x12\x19\n" +
 	"\bshard_id\x18\x01 \x01(\tR\ashardId\x12!\n" +
 	"\fhistory_addr\x18\x02 \x01(\tR\vhistoryAddr\x12h\n" +

--- a/api/historyservice/v1/request_response.pb.go
+++ b/api/historyservice/v1/request_response.pb.go
@@ -4883,11 +4883,12 @@ func (*SyncActivityResponse) Descriptor() ([]byte, []int) {
 }
 
 type DescribeMutableStateRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	NamespaceId   string                 `protobuf:"bytes,1,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty"`
-	Execution     *v14.WorkflowExecution `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	NamespaceId     string                 `protobuf:"bytes,1,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty"`
+	Execution       *v14.WorkflowExecution `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
+	SkipForceReload bool                   `protobuf:"varint,3,opt,name=skip_force_reload,json=skipForceReload,proto3" json:"skip_force_reload,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *DescribeMutableStateRequest) Reset() {
@@ -4932,6 +4933,13 @@ func (x *DescribeMutableStateRequest) GetExecution() *v14.WorkflowExecution {
 		return x.Execution
 	}
 	return nil
+}
+
+func (x *DescribeMutableStateRequest) GetSkipForceReload() bool {
+	if x != nil {
+		return x.SkipForceReload
+	}
+	return false
 }
 
 type DescribeMutableStateResponse struct {
@@ -10010,10 +10018,11 @@ const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc 
 	"\x16retry_maximum_interval\x18\x17 \x01(\v2\x19.google.protobuf.DurationR\x14retryMaximumInterval\x124\n" +
 	"\x16retry_maximum_attempts\x18\x18 \x01(\x05R\x14retryMaximumAttempts\x12:\n" +
 	"\x19retry_backoff_coefficient\x18\x19 \x01(\x01R\x17retryBackoffCoefficient\"\x16\n" +
-	"\x14SyncActivityResponse\"\xa6\x01\n" +
+	"\x14SyncActivityResponse\"\xd2\x01\n" +
 	"\x1bDescribeMutableStateRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12G\n" +
-	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution:\x1b\x92\xc4\x03\x17*\x15execution.workflow_id\"\xf8\x01\n" +
+	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\x12*\n" +
+	"\x11skip_force_reload\x18\x03 \x01(\bR\x0fskipForceReload:\x1b\x92\xc4\x03\x17*\x15execution.workflow_id\"\xf8\x01\n" +
 	"\x1cDescribeMutableStateResponse\x12h\n" +
 	"\x13cache_mutable_state\x18\x01 \x01(\v28.temporal.server.api.persistence.v1.WorkflowMutableStateR\x11cacheMutableState\x12n\n" +
 	"\x16database_mutable_state\x18\x02 \x01(\v28.temporal.server.api.persistence.v1.WorkflowMutableStateR\x14databaseMutableState\"\xdf\x01\n" +

--- a/proto/internal/temporal/server/api/adminservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/adminservice/v1/request_response.proto
@@ -54,12 +54,14 @@ message ImportWorkflowExecutionResponse {
 message DescribeMutableStateRequest {
   string namespace = 1;
   temporal.api.common.v1.WorkflowExecution execution = 2;
+  bool skip_force_reload = 3;
 }
 
 message DescribeMutableStateResponse {
   string shard_id = 1;
   string history_addr = 2;
   temporal.server.api.persistence.v1.WorkflowMutableState cache_mutable_state = 3;
+  // database_mutable_state is only populated when skip_force_reload is false.
   temporal.server.api.persistence.v1.WorkflowMutableState database_mutable_state = 4;
 }
 

--- a/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
@@ -710,10 +710,12 @@ message DescribeMutableStateRequest {
 
     string namespace_id = 1;
     temporal.api.common.v1.WorkflowExecution execution = 2;
+    bool skip_force_reload = 3;
 }
 
 message DescribeMutableStateResponse {
     temporal.server.api.persistence.v1.WorkflowMutableState cache_mutable_state = 1;
+    // database_mutable_state is only populated when skip_force_reload is false.
     temporal.server.api.persistence.v1.WorkflowMutableState database_mutable_state = 2;
 }
 

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -791,8 +791,9 @@ func (adh *AdminHandler) DescribeMutableState(ctx context.Context, request *admi
 
 	historyAddr := historyHost.GetAddress()
 	historyResponse, err := adh.historyClient.DescribeMutableState(ctx, &historyservice.DescribeMutableStateRequest{
-		NamespaceId: namespaceID.String(),
-		Execution:   request.Execution,
+		NamespaceId:     namespaceID.String(),
+		Execution:       request.Execution,
+		SkipForceReload: request.GetSkipForceReload(),
 	})
 
 	if err != nil {

--- a/service/history/api/describemutablestate/api.go
+++ b/service/history/api/describemutablestate/api.go
@@ -47,7 +47,11 @@ func Invoke(
 		response.CacheMutableState = msb.CloneToProto()
 	}
 
-	// clear mutable state to force reload from persistence. This API returns both cached and persisted version.
+	if !req.GetSkipForceReload() {
+		return response, nil
+	}
+
+	// Clear mutable state to force reload from persistence.
 	chasmLease.GetContext().Clear()
 	mutableState, err := chasmLease.GetContext().LoadMutableState(ctx, shardContext)
 	if err != nil {

--- a/service/history/ndc_standby_task_util.go
+++ b/service/history/ndc_standby_task_util.go
@@ -7,7 +7,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
-	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/adminservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/client"
@@ -98,16 +98,17 @@ func isWorkflowExistOnSource(
 	if err != nil {
 		return true
 	}
-	_, remoteFrontend, err := clientBean.GetRemoteFrontendClient(remoteClusterName)
+	remoteAdminClient, err := clientBean.GetRemoteAdminClient(remoteClusterName)
 	if err != nil {
 		return true
 	}
-	_, err = remoteFrontend.DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+	_, err = remoteAdminClient.DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
 		Namespace: namespaceEntry.Name().String(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: workflowKey.GetWorkflowID(),
 			RunId:      workflowKey.GetRunID(),
 		},
+		SkipForceReload: true,
 	})
 	if err != nil {
 		if common.IsNotFoundError(err) {

--- a/service/history/transfer_queue_standby_task_executor_test.go
+++ b/service/history/transfer_queue_standby_task_executor_test.go
@@ -15,6 +15,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/api/adminservicemock/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
@@ -64,15 +65,15 @@ type (
 		suite.Suite
 		*require.Assertions
 
-		controller          *gomock.Controller
-		mockShard           *shard.ContextTest
-		mockNamespaceCache  *namespace.MockRegistry
-		mockClusterMetadata *cluster.MockMetadata
-		mockAdminClient     *adminservicemock.MockAdminServiceClient
-		mockFrontendClient  *workflowservicemock.MockWorkflowServiceClient
-		mockHistoryClient   *historyservicemock.MockHistoryServiceClient
-		mockMatchingClient  *matchingservicemock.MockMatchingServiceClient
-		mockChasmEngine     chasm.Engine
+		controller            *gomock.Controller
+		mockShard             *shard.ContextTest
+		mockNamespaceCache    *namespace.MockRegistry
+		mockClusterMetadata   *cluster.MockMetadata
+		mockFrontendClient    *workflowservicemock.MockWorkflowServiceClient
+		mockHistoryClient     *historyservicemock.MockHistoryServiceClient
+		mockMatchingClient    *matchingservicemock.MockMatchingServiceClient
+		mockRemoteAdminClient *adminservicemock.MockAdminServiceClient
+		mockChasmEngine       chasm.Engine
 
 		mockExecutionMgr     *persistence.MockExecutionManager
 		mockArchivalMetadata archiver.MetadataMock
@@ -149,7 +150,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) SetupTest() {
 	s.mockArchivalMetadata = s.mockShard.Resource.ArchivalMetadata
 	s.mockArchiverProvider = s.mockShard.Resource.ArchiverProvider
 	s.mockNamespaceCache = s.mockShard.Resource.NamespaceCache
-	s.mockAdminClient = s.mockShard.Resource.RemoteAdminClient
+	s.mockRemoteAdminClient = s.mockShard.Resource.RemoteAdminClient
 	s.mockSearchAttributesProvider = s.mockShard.Resource.SearchAttributesProvider
 	s.mockVisibilityManager = s.mockShard.Resource.VisibilityManager
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(tests.GlobalNamespaceEntry, nil).AnyTimes()
@@ -743,10 +744,11 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessCloseExecution() {
 	})
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespace.ID(parentNamespaceID)).Return(tests.GlobalParentNamespaceEntry, nil).AnyTimes()
-	s.clientBean.EXPECT().GetRemoteFrontendClient(tests.GlobalChildNamespaceEntry.ActiveClusterName()).Return(nil, s.mockFrontendClient, nil).AnyTimes()
-	s.mockFrontendClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: tests.ParentNamespace.String(),
-		Execution: parentExecution,
+	s.clientBean.EXPECT().GetRemoteAdminClient(tests.GlobalChildNamespaceEntry.ActiveClusterName()).Return(s.mockRemoteAdminClient, nil).AnyTimes()
+	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+		Namespace:       tests.ParentNamespace.String(),
+		Execution:       parentExecution,
+		SkipForceReload: true,
 	})).Return(nil, serviceerror.NewInternal("some error")).AnyTimes()
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"slices"
 	"sort"
 	"time"
 
@@ -20,7 +19,7 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	serverClient "go.temporal.io/server/client"
-	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
@@ -450,6 +449,8 @@ func (a *activities) ListWorkflows(ctx context.Context, request *workflowservice
 	ctx = headers.SetCallerInfo(ctx, headers.NewCallerInfo(request.Namespace, headers.CallerTypePreemptable, ""))
 	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(interceptor.DCRedirectionContextHeaderName, "false"))
 
+	// TODO: Use CHASM system List API when it is available.
+	// For now, ListWorkflowExecutions is still compatible with non-workflow archetypes.
 	resp, err := a.frontendClient.ListWorkflowExecutions(ctx, request)
 	if err != nil {
 		return nil, err
@@ -474,6 +475,8 @@ func (a *activities) ListWorkflows(ctx context.Context, request *workflowservice
 func (a *activities) CountWorkflow(ctx context.Context, request *workflowservice.CountWorkflowExecutionsRequest) (*countWorkflowResponse, error) {
 	ctx = headers.SetCallerInfo(ctx, headers.NewCallerInfo(request.Namespace, headers.CallerTypePreemptable, ""))
 
+	// TODO: Use CHASM system Count API when it is available.
+	// For now, ListWorkflowExecutions is still compatible with non-workflow archetypes.
 	resp, err := a.frontendClient.CountWorkflowExecutions(ctx, request)
 	if err != nil {
 		return nil, err
@@ -517,7 +520,7 @@ func (a *activities) GenerateReplicationTasks(ctx context.Context, request *gene
 			request.TargetClusters,
 			generateViaFrontend,
 		); err != nil {
-			if !isNotFoundServiceError(err) {
+			if !common.IsNotFoundError(err) {
 				a.logger.Error("force-replication failed to generate replication task",
 					tag.WorkflowNamespaceID(request.NamespaceID),
 					tag.WorkflowID(we.GetWorkflowId()),
@@ -536,66 +539,6 @@ func (a *activities) GenerateReplicationTasks(ctx context.Context, request *gene
 	}
 
 	return nil
-}
-
-func (a *activities) generateExecutionsToReplicate(
-	ctx context.Context,
-	rateLimiter quotas.RateLimiter,
-	executionDedupMap map[definition.WorkflowKey]struct{},
-	namespaceID string,
-	baseWf *commonpb.WorkflowExecution,
-) ([]definition.WorkflowKey, error) {
-
-	start := time.Now()
-	defer func() {
-		a.forceReplicationMetricsHandler.Timer("GenerateParentWorkflowExecutionsLatency").Record(time.Since(start))
-	}()
-
-	var resultStack []definition.WorkflowKey
-	baseWfKey := definition.NewWorkflowKey(namespaceID, baseWf.GetWorkflowId(), baseWf.GetRunId())
-	queue := []definition.WorkflowKey{baseWfKey}
-	for len(queue) > 0 {
-		var currWorkflow definition.WorkflowKey
-		currWorkflow, queue = queue[0], queue[1:]
-
-		if _, ok := executionDedupMap[currWorkflow]; ok {
-			// already in the result set
-			continue
-		}
-		executionDedupMap[currWorkflow] = struct{}{}
-
-		if err := rateLimiter.WaitN(ctx, 1); err != nil {
-			return nil, err
-		}
-		// Reason to use history client
-		// 1. Reduce networking routing
-		// 2. Bypass frontend per namespace rate limiter
-		resp, err := a.historyClient.DescribeWorkflowExecution(ctx, &historyservice.DescribeWorkflowExecutionRequest{
-			NamespaceId: currWorkflow.GetNamespaceID(),
-			Request: &workflowservice.DescribeWorkflowExecutionRequest{
-				Execution: &commonpb.WorkflowExecution{
-					WorkflowId: currWorkflow.GetWorkflowID(),
-					RunId:      currWorkflow.GetRunID(),
-				},
-			},
-		})
-		if err != nil {
-			if isNotFoundServiceError(err) {
-				continue
-			}
-			return nil, err
-		}
-		resultStack = append(resultStack, currWorkflow)
-
-		parentExecInfo := resp.GetWorkflowExecutionInfo().GetParentExecution()
-		if parentExecInfo != nil {
-			parentExecution := definition.NewWorkflowKey(resp.GetWorkflowExecutionInfo().GetParentNamespaceId(), parentExecInfo.GetWorkflowId(), parentExecInfo.GetRunId())
-			queue = append(queue, parentExecution)
-		}
-	}
-
-	slices.Reverse(resultStack)
-	return resultStack, nil
 }
 
 func (a *activities) setCallerInfoForServerAPI(
@@ -690,25 +633,6 @@ func (a *activities) SeedReplicationQueueWithUserDataEntries(ctx context.Context
 	}
 }
 
-func isNotFoundServiceError(err error) bool {
-	_, ok := err.(*serviceerror.NotFound)
-	return ok
-}
-
-func isCloseToCurrentTime(t time.Time, duration time.Duration) bool {
-	currentTime := time.Now()
-	diff := currentTime.Sub(t)
-
-	// check both before and after current time in case:
-	//   - workflow deletion time has passed (slow delete)
-	//   - workflow is abort to be deleted (target may run with a faster clock)
-	if diff < -duration || diff > duration {
-		return false
-	}
-
-	return true
-}
-
 func (a *activities) checkSkipWorkflowExecution(
 	ctx context.Context,
 	request *verifyReplicationTasksRequest,
@@ -718,12 +642,13 @@ func (a *activities) checkSkipWorkflowExecution(
 	namespaceID := request.NamespaceID
 	tags := []tag.Tag{tag.WorkflowNamespaceID(namespaceID), tag.WorkflowID(we.WorkflowId), tag.WorkflowRunID(we.RunId)}
 	resp, err := a.historyClient.DescribeMutableState(ctx, &historyservice.DescribeMutableStateRequest{
-		NamespaceId: namespaceID,
-		Execution:   we,
+		NamespaceId:     namespaceID,
+		Execution:       we,
+		SkipForceReload: true,
 	})
 
 	if err != nil {
-		if isNotFoundServiceError(err) {
+		if common.IsNotFoundError(err) {
 			// The outstanding workflow execution may be deleted (due to retention) on source cluster after replication tasks were generated.
 			// Since retention runs on both source/target clusters, such execution may also be deleted (hence not found) from target cluster.
 			a.forceReplicationMetricsHandler.WithTags(metrics.NamespaceTag(request.Namespace)).Counter(metrics.EncounterNotFoundWorkflowCount.Name()).Record(1)
@@ -740,7 +665,7 @@ func (a *activities) checkSkipWorkflowExecution(
 
 	// Zombie workflow should be a transient state. However, if there is Zombie workflow on the source cluster,
 	// it is skipped to avoid such workflow being processed on the target cluster.
-	if resp.GetDatabaseMutableState().GetExecutionState().GetState() == enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE {
+	if resp.GetCacheMutableState().GetExecutionState().GetState() == enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE {
 		a.forceReplicationMetricsHandler.WithTags(metrics.NamespaceTag(request.Namespace)).Counter(metrics.EncounterZombieWorkflowCount.Name()).Record(1)
 		a.logger.Info("createReplicationTasks skip Zombie workflow", tags...)
 		return verifyResult{
@@ -750,7 +675,7 @@ func (a *activities) checkSkipWorkflowExecution(
 	}
 
 	// Skip verifying workflow which has already passed retention time.
-	if closeTime := resp.GetDatabaseMutableState().GetExecutionInfo().GetCloseTime(); closeTime != nil && ns != nil && ns.Retention() > 0 {
+	if closeTime := resp.GetCacheMutableState().GetExecutionInfo().GetCloseTime(); closeTime != nil && ns != nil && ns.Retention() > 0 {
 		deleteTime := closeTime.AsTime().Add(ns.Retention())
 		if deleteTime.Before(time.Now()) {
 			a.forceReplicationMetricsHandler.WithTags(metrics.NamespaceTag(request.Namespace)).Counter(metrics.EncounterPassRetentionWorkflowCount.Name()).Record(1)
@@ -769,15 +694,16 @@ func (a *activities) checkSkipWorkflowExecution(
 func (a *activities) verifySingleReplicationTask(
 	ctx context.Context,
 	request *verifyReplicationTasksRequest,
-	remoteClient workflowservice.WorkflowServiceClient,
+	remotAdminClient adminservice.AdminServiceClient,
 	ns *namespace.Namespace,
 	we *commonpb.WorkflowExecution,
 ) (verifyResult, error) {
 	s := time.Now()
 	// Check if execution exists on remote cluster
-	_, err := remoteClient.DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: request.Namespace,
-		Execution: we,
+	_, err := remotAdminClient.DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
+		Namespace:       request.Namespace,
+		Execution:       we,
+		SkipForceReload: true,
 	})
 	a.forceReplicationMetricsHandler.Timer(metrics.VerifyDescribeMutableStateLatency.Name()).Record(time.Since(s))
 
@@ -813,7 +739,7 @@ func (a *activities) verifyReplicationTasks(
 	ctx context.Context,
 	request *verifyReplicationTasksRequest,
 	details *replicationTasksHeartbeatDetails,
-	remoteClient workflowservice.WorkflowServiceClient,
+	remotAdminClient adminservice.AdminServiceClient,
 	ns *namespace.Namespace,
 	heartbeat func(details replicationTasksHeartbeatDetails),
 ) (bool, error) {
@@ -833,7 +759,7 @@ func (a *activities) verifyReplicationTasks(
 
 	for ; details.NextIndex < len(request.Executions); details.NextIndex++ {
 		we := request.Executions[details.NextIndex]
-		r, err := a.verifySingleReplicationTask(ctx, request, remoteClient, ns, we)
+		r, err := a.verifySingleReplicationTask(ctx, request, remotAdminClient, ns, we)
 		if err != nil {
 			return false, err
 		}
@@ -867,7 +793,7 @@ func (a *activities) VerifyReplicationTasks(ctx context.Context, request *verify
 		activity.RecordHeartbeat(ctx, details)
 	}
 
-	_, remoteClient, err := a.clientBean.GetRemoteFrontendClient(request.TargetClusterName)
+	remotAdminClient, err := a.clientBean.GetRemoteAdminClient(request.TargetClusterName)
 	if err != nil {
 		return response, err
 	}
@@ -893,7 +819,7 @@ func (a *activities) VerifyReplicationTasks(ctx context.Context, request *verify
 		// Since replication has a lag, sleep first.
 		time.Sleep(request.VerifyInterval)
 
-		verified, err := a.verifyReplicationTasks(ctx, request, &details, remoteClient, nsEntry,
+		verified, err := a.verifyReplicationTasks(ctx, request, &details, remotAdminClient, nsEntry,
 			func(d replicationTasksHeartbeatDetails) {
 				activity.RecordHeartbeat(ctx, d)
 			})
@@ -901,12 +827,12 @@ func (a *activities) VerifyReplicationTasks(ctx context.Context, request *verify
 			return response, err
 		}
 
-		if verified == true {
+		if verified {
 			response.VerifiedWorkflowCount = int64(len(request.Executions))
 			return response, nil
 		}
 
-		diff := time.Now().Sub(details.CheckPoint)
+		diff := time.Since(details.CheckPoint)
 		if diff > defaultNoProgressNotRetryableTimeout {
 			// Potentially encountered a missing execution, return non-retryable error
 			return response, temporal.NewNonRetryableApplicationError(

--- a/service/worker/migration/activities_test.go
+++ b/service/worker/migration/activities_test.go
@@ -45,10 +45,10 @@ type activitiesSuite struct {
 	mockClientFactory             *client.MockFactory
 	mockClientBean                *client.MockBean
 
-	mockFrontendClient *workflowservicemock.MockWorkflowServiceClient
-	mockAdminClient    *adminservicemock.MockAdminServiceClient
-	mockHistoryClient  *historyservicemock.MockHistoryServiceClient
-	mockRemoteClient   *workflowservicemock.MockWorkflowServiceClient
+	mockFrontendClient    *workflowservicemock.MockWorkflowServiceClient
+	mockAdminClient       *adminservicemock.MockAdminServiceClient
+	mockHistoryClient     *historyservicemock.MockHistoryServiceClient
+	mockRemoteAdminClient *adminservicemock.MockAdminServiceClient
 
 	logger             log.Logger
 	mockMetricsHandler *metrics.MockHandler
@@ -74,7 +74,7 @@ var (
 	}
 
 	completeState = &historyservice.DescribeMutableStateResponse{
-		DatabaseMutableState: &persistencespb.WorkflowMutableState{
+		CacheMutableState: &persistencespb.WorkflowMutableState{
 			ExecutionState: &persistencespb.WorkflowExecutionState{
 				State: enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
 			},
@@ -82,7 +82,7 @@ var (
 	}
 
 	zombieState = &historyservice.DescribeMutableStateResponse{
-		DatabaseMutableState: &persistencespb.WorkflowMutableState{
+		CacheMutableState: &persistencespb.WorkflowMutableState{
 			ExecutionState: &persistencespb.WorkflowExecutionState{
 				State: enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE,
 			},
@@ -107,14 +107,14 @@ func (s *activitiesSuite) SetupTest() {
 	s.mockFrontendClient = workflowservicemock.NewMockWorkflowServiceClient(s.controller)
 	s.mockAdminClient = adminservicemock.NewMockAdminServiceClient(s.controller)
 	s.mockHistoryClient = historyservicemock.NewMockHistoryServiceClient(s.controller)
-	s.mockRemoteClient = workflowservicemock.NewMockWorkflowServiceClient(s.controller)
+	s.mockRemoteAdminClient = adminservicemock.NewMockAdminServiceClient(s.controller)
 
 	s.logger = log.NewNoopLogger()
 	s.mockMetricsHandler = metrics.NewMockHandler(s.controller)
 	s.mockMetricsHandler.EXPECT().WithTags(gomock.Any()).Return(s.mockMetricsHandler).AnyTimes()
 	s.mockMetricsHandler.EXPECT().Timer(gomock.Any()).Return(metrics.NoopTimerMetricFunc).AnyTimes()
 	s.mockMetricsHandler.EXPECT().Counter(gomock.Any()).Return(metrics.NoopCounterMetricFunc).AnyTimes()
-	s.mockClientBean.EXPECT().GetRemoteFrontendClient(remoteCluster).Return(nil, s.mockRemoteClient, nil).AnyTimes()
+	s.mockClientBean.EXPECT().GetRemoteAdminClient(remoteCluster).Return(s.mockRemoteAdminClient, nil).AnyTimes()
 	s.mockNamespaceRegistry.EXPECT().GetNamespaceName(gomock.Any()).
 		Return(namespace.Name(mockedNamespace), nil).AnyTimes()
 	s.mockNamespaceRegistry.EXPECT().GetNamespace(gomock.Any()).
@@ -160,31 +160,34 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_Success() {
 	}
 
 	// Immediately replicated
-	s.mockRemoteClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: mockedNamespace,
-		Execution: execution1,
-	})).Return(&workflowservice.DescribeWorkflowExecutionResponse{}, nil).Times(1)
+	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+		Namespace:       mockedNamespace,
+		Execution:       execution1,
+		SkipForceReload: true,
+	})).Return(&adminservice.DescribeMutableStateResponse{}, nil).Times(1)
 
 	// Slowly replicated
 	replicationSlowReponses := []struct {
-		resp *workflowservice.DescribeWorkflowExecutionResponse
+		resp *adminservice.DescribeMutableStateResponse
 		err  error
 	}{
 		{nil, serviceerror.NewNotFound("")},
 		{nil, serviceerror.NewNotFound("")},
-		{&workflowservice.DescribeWorkflowExecutionResponse{}, nil},
+		{&adminservice.DescribeMutableStateResponse{}, nil},
 	}
 
 	for _, r := range replicationSlowReponses {
-		s.mockRemoteClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: mockedNamespace,
-			Execution: execution2,
+		s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+			Namespace:       mockedNamespace,
+			Execution:       execution2,
+			SkipForceReload: true,
 		})).Return(r.resp, r.err).Times(1)
 	}
 
 	s.mockHistoryClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&historyservice.DescribeMutableStateRequest{
-		NamespaceId: mockedNamespaceID,
-		Execution:   execution2,
+		NamespaceId:     mockedNamespaceID,
+		Execution:       execution2,
+		SkipForceReload: true,
 	})).Return(completeState, nil).Times(2)
 
 	f, err := env.ExecuteActivity(s.a.VerifyReplicationTasks, &request)
@@ -236,15 +239,16 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_SkipWorkflowExecution() {
 	start := time.Now()
 	for _, t := range testcases {
 		env, iceptor := s.initEnv()
-
-		s.mockRemoteClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: mockedNamespace,
-			Execution: execution1,
+		s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+			Namespace:       mockedNamespace,
+			Execution:       execution1,
+			SkipForceReload: true,
 		})).Return(nil, serviceerror.NewNotFound("")).Times(1)
 
 		s.mockHistoryClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&historyservice.DescribeMutableStateRequest{
-			NamespaceId: mockedNamespaceID,
-			Execution:   execution1,
+			NamespaceId:     mockedNamespaceID,
+			Execution:       execution1,
+			SkipForceReload: true,
 		})).Return(t.resp, t.err).Times(1)
 
 		_, err := env.ExecuteActivity(s.a.VerifyReplicationTasks, &request)
@@ -273,14 +277,16 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_FailedNotFound() {
 	}
 
 	s.mockHistoryClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&historyservice.DescribeMutableStateRequest{
-		NamespaceId: mockedNamespaceID,
-		Execution:   execution1,
+		NamespaceId:     mockedNamespaceID,
+		Execution:       execution1,
+		SkipForceReload: true,
 	})).Return(completeState, nil)
 
 	// Workflow not found at target cluster.
-	s.mockRemoteClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: mockedNamespace,
-		Execution: execution1,
+	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+		Namespace:       mockedNamespace,
+		Execution:       execution1,
+		SkipForceReload: true,
 	})).Return(nil, serviceerror.NewNotFound("")).AnyTimes()
 
 	// Set CheckPoint to an early to trigger failure.
@@ -329,26 +335,29 @@ func (s *activitiesSuite) Test_verifySingleReplicationTask() {
 	}
 	ctx := context.TODO()
 
-	s.mockRemoteClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: mockedNamespace,
-		Execution: execution1,
-	})).Return(&workflowservice.DescribeWorkflowExecutionResponse{}, nil).Times(1)
-	result, err := s.a.verifySingleReplicationTask(ctx, &request, s.mockRemoteClient, &testNamespace, request.Executions[0])
+	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+		Namespace:       mockedNamespace,
+		Execution:       execution1,
+		SkipForceReload: true,
+	})).Return(&adminservice.DescribeMutableStateResponse{}, nil).Times(1)
+	result, err := s.a.verifySingleReplicationTask(ctx, &request, s.mockRemoteAdminClient, &testNamespace, request.Executions[0])
 	s.NoError(err)
 	s.True(result.isVerified())
 
 	// Test not verified workflow
-	s.mockRemoteClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: mockedNamespace,
-		Execution: execution2,
-	})).Return(&workflowservice.DescribeWorkflowExecutionResponse{}, serviceerror.NewNotFound("")).Times(1)
+	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+		Namespace:       mockedNamespace,
+		Execution:       execution2,
+		SkipForceReload: true,
+	})).Return(&adminservice.DescribeMutableStateResponse{}, serviceerror.NewNotFound("")).Times(1)
 
 	s.mockHistoryClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&historyservice.DescribeMutableStateRequest{
-		NamespaceId: mockedNamespaceID,
-		Execution:   execution2,
+		NamespaceId:     mockedNamespaceID,
+		Execution:       execution2,
+		SkipForceReload: true,
 	})).Return(completeState, nil).AnyTimes()
 
-	result, err = s.a.verifySingleReplicationTask(ctx, &request, s.mockRemoteClient, &testNamespace, request.Executions[1])
+	result, err = s.a.verifySingleReplicationTask(ctx, &request, s.mockRemoteAdminClient, &testNamespace, request.Executions[1])
 	s.NoError(err)
 	s.False(result.isVerified())
 }
@@ -361,7 +370,7 @@ const (
 	executionErr      executionState = 2
 )
 
-func createExecutions(mockClient *workflowservicemock.MockWorkflowServiceClient, states []executionState, nextIndex int) []*commonpb.WorkflowExecution {
+func createExecutions(mockAdminCliednt *adminservicemock.MockAdminServiceClient, states []executionState, nextIndex int) []*commonpb.WorkflowExecution {
 	var executions []*commonpb.WorkflowExecution
 
 	for i := 0; i < len(states); i++ {
@@ -372,20 +381,23 @@ Loop:
 	for i := nextIndex; i < len(states); i++ {
 		switch states[i] {
 		case executionFound:
-			mockClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
-				Namespace: mockedNamespace,
-				Execution: execution1,
-			})).Return(&workflowservice.DescribeWorkflowExecutionResponse{}, nil).Times(1)
+			mockAdminCliednt.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+				Namespace:       mockedNamespace,
+				Execution:       execution1,
+				SkipForceReload: true,
+			})).Return(&adminservice.DescribeMutableStateResponse{}, nil).Times(1)
 		case executionNotfound:
-			mockClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
-				Namespace: mockedNamespace,
-				Execution: execution1,
+			mockAdminCliednt.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+				Namespace:       mockedNamespace,
+				Execution:       execution1,
+				SkipForceReload: true,
 			})).Return(nil, serviceerror.NewNotFound("")).Times(1)
 			break Loop
 		case executionErr:
-			mockClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
-				Namespace: mockedNamespace,
-				Execution: execution1,
+			mockAdminCliednt.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+				Namespace:       mockedNamespace,
+				Execution:       execution1,
+				SkipForceReload: true,
 			})).Return(nil, serviceerror.NewInternal("")).Times(1)
 		}
 	}
@@ -452,21 +464,22 @@ func (s *activitiesSuite) Test_verifyReplicationTasks() {
 	}
 
 	s.mockHistoryClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&historyservice.DescribeMutableStateRequest{
-		NamespaceId: mockedNamespaceID,
-		Execution:   execution1,
+		NamespaceId:     mockedNamespaceID,
+		Execution:       execution1,
+		SkipForceReload: true,
 	})).Return(completeState, nil).AnyTimes()
 
 	checkPointTime := time.Now()
 	for _, tc := range tests {
 		var recorder mockHeartBeatRecorder
-		mockRemoteClient := workflowservicemock.NewMockWorkflowServiceClient(s.controller)
-		request.Executions = createExecutions(mockRemoteClient, tc.remoteExecutionStates, tc.nextIndex)
+		// mockRemoteClient := workflowservicemock.NewMockWorkflowServiceClient(s.controller)
+		request.Executions = createExecutions(s.mockRemoteAdminClient, tc.remoteExecutionStates, tc.nextIndex)
 		details := replicationTasksHeartbeatDetails{
 			NextIndex:  tc.nextIndex,
 			CheckPoint: checkPointTime,
 		}
 
-		verified, err := s.a.verifyReplicationTasks(ctx, &request, &details, mockRemoteClient, &testNamespace, recorder.hearbeat)
+		verified, err := s.a.verifyReplicationTasks(ctx, &request, &details, s.mockRemoteAdminClient, &testNamespace, recorder.hearbeat)
 		if tc.expectedErr == nil {
 			s.NoError(err)
 		}
@@ -492,12 +505,13 @@ func (s *activitiesSuite) Test_verifyReplicationTasksNoProgress() {
 		Namespace:         mockedNamespace,
 		NamespaceID:       mockedNamespaceID,
 		TargetClusterName: remoteCluster,
-		Executions:        createExecutions(s.mockRemoteClient, []executionState{executionFound, executionFound, executionNotfound, executionFound}, 0),
+		Executions:        createExecutions(s.mockRemoteAdminClient, []executionState{executionFound, executionFound, executionNotfound, executionFound}, 0),
 	}
 
 	s.mockHistoryClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&historyservice.DescribeMutableStateRequest{
-		NamespaceId: mockedNamespaceID,
-		Execution:   execution1,
+		NamespaceId:     mockedNamespaceID,
+		Execution:       execution1,
+		SkipForceReload: true,
 	})).Return(completeState, nil).AnyTimes()
 
 	checkPointTime := time.Now()
@@ -507,7 +521,7 @@ func (s *activitiesSuite) Test_verifyReplicationTasksNoProgress() {
 	}
 
 	ctx := context.TODO()
-	verified, err := s.a.verifyReplicationTasks(ctx, &request, &details, s.mockRemoteClient, &testNamespace, recorder.hearbeat)
+	verified, err := s.a.verifyReplicationTasks(ctx, &request, &details, s.mockRemoteAdminClient, &testNamespace, recorder.hearbeat)
 	s.NoError(err)
 	s.False(verified)
 	// Verify has made progress.
@@ -517,13 +531,14 @@ func (s *activitiesSuite) Test_verifyReplicationTasksNoProgress() {
 	prevDetails := details
 
 	// Mock for one more NotFound call
-	s.mockRemoteClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
-		Namespace: mockedNamespace,
-		Execution: execution1,
+	s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+		Namespace:       mockedNamespace,
+		Execution:       execution1,
+		SkipForceReload: true,
 	})).Return(nil, serviceerror.NewNotFound("")).Times(1)
 
 	// All results should be either NotFound or cached and no progress should be made.
-	verified, err = s.a.verifyReplicationTasks(ctx, &request, &details, s.mockRemoteClient, &testNamespace, recorder.hearbeat)
+	verified, err = s.a.verifyReplicationTasks(ctx, &request, &details, s.mockRemoteAdminClient, &testNamespace, recorder.hearbeat)
 	s.NoError(err)
 	s.False(verified)
 	s.Equal(prevDetails, details)
@@ -557,17 +572,18 @@ func (s *activitiesSuite) Test_verifyReplicationTasksSkipRetention() {
 		retention := time.Hour
 		closeTime := deleteTime.Add(-retention)
 
-		mockRemoteClient := workflowservicemock.NewMockWorkflowServiceClient(s.controller)
-		mockRemoteClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), protomock.Eq(&workflowservice.DescribeWorkflowExecutionRequest{
-			Namespace: mockedNamespace,
-			Execution: execution1,
+		s.mockRemoteAdminClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&adminservice.DescribeMutableStateRequest{
+			Namespace:       mockedNamespace,
+			Execution:       execution1,
+			SkipForceReload: true,
 		})).Return(nil, serviceerror.NewNotFound("")).Times(1)
 
 		s.mockHistoryClient.EXPECT().DescribeMutableState(gomock.Any(), protomock.Eq(&historyservice.DescribeMutableStateRequest{
-			NamespaceId: mockedNamespaceID,
-			Execution:   execution1,
+			NamespaceId:     mockedNamespaceID,
+			Execution:       execution1,
+			SkipForceReload: true,
 		})).Return(&historyservice.DescribeMutableStateResponse{
-			DatabaseMutableState: &persistencespb.WorkflowMutableState{
+			CacheMutableState: &persistencespb.WorkflowMutableState{
 				ExecutionState: &persistencespb.WorkflowExecutionState{
 					State: enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
 				},
@@ -587,18 +603,11 @@ func (s *activitiesSuite) Test_verifyReplicationTasksSkipRetention() {
 
 		details := replicationTasksHeartbeatDetails{}
 		ctx := context.TODO()
-		verified, err := s.a.verifyReplicationTasks(ctx, &request, &details, mockRemoteClient, ns, recorder.hearbeat)
+		verified, err := s.a.verifyReplicationTasks(ctx, &request, &details, s.mockRemoteAdminClient, ns, recorder.hearbeat)
 		s.NoError(err)
 		s.Equal(tc.verified, verified)
 		s.Equal(recorder.lastHeartBeat, details)
 	}
-}
-
-func (s *activitiesSuite) Test_isNotFoundServiceError() {
-	s.True(isNotFoundServiceError(serviceerror.NewNotFound("")))
-	var err error
-	s.False(isNotFoundServiceError(err))
-	s.False(isNotFoundServiceError(serviceerror.NewInternal("")))
 }
 
 func (s *activitiesSuite) TestGenerateReplicationTasks_Success() {


### PR DESCRIPTION
## What changed?
- Remove workflow specific logic in migration activities
- Add `SkipForceReload` flag to admin describeMutableState api to avoid unnecessary mutable state loading.

## Why?
- Migration workflow needs to work with chasm runs as well, not just workflows.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
