### PR TITLE
Limit the number of parts allowed for auth token

### DIFF
--- a/common/authorization/default_jwt_claim_mapper.go
+++ b/common/authorization/default_jwt_claim_mapper.go
@@ -81,6 +81,8 @@ func (a *defaultJWTClaimMapper) GetClaims(authInfo *AuthInfo) (*Claims, error) {
 		return &claims, nil
 	}
 
+	// We use strings.SplitN even though we check the length later, to avoid
+	// unnecessary allocations if the format is correct.
 	parts := strings.SplitN(authInfo.AuthToken, " ", 2)
 	if len(parts) != 2 {
 		return nil, serviceerror.NewPermissionDenied("unexpected authorization token format", "")

--- a/common/authorization/default_jwt_claim_mapper.go
+++ b/common/authorization/default_jwt_claim_mapper.go
@@ -81,7 +81,7 @@ func (a *defaultJWTClaimMapper) GetClaims(authInfo *AuthInfo) (*Claims, error) {
 		return &claims, nil
 	}
 
-	parts := strings.Split(authInfo.AuthToken, " ")
+	parts := strings.SplitN(authInfo.AuthToken, " ", 2)
 	if len(parts) != 2 {
 		return nil, serviceerror.NewPermissionDenied("unexpected authorization token format", "")
 	}


### PR DESCRIPTION
## What changed?

This PR aims to add a limit to the number of parts when splitting an `Authorization` header `Bearer $token` values. 

## Why?

This is useful for limiting potential abuses from maliciously crafted header values. 

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

I don't think there's any major risk here?
