### PR TITLE
Consolidate cassandra task queue management queries

### DIFF
--- a/common/persistence/cassandra/matching_task_store.go
+++ b/common/persistence/cassandra/matching_task_store.go
@@ -15,11 +15,10 @@ func NewMatchingTaskStore(
 	logger log.Logger,
 	enableFairness bool,
 ) p.TaskStore {
-	userDataStore := userDataStore{Session: session, Logger: logger}
 	if enableFairness {
-		return newMatchingTaskStoreV2(userDataStore)
+		return newMatchingTaskStoreV2(session, logger)
 	}
-	return newMatchingTaskStoreV1(userDataStore)
+	return newMatchingTaskStoreV1(session, logger)
 }
 
 // We steal some upper bits of the "row type" field to hold a subqueue index.

--- a/common/persistence/cassandra/matching_task_store.go
+++ b/common/persistence/cassandra/matching_task_store.go
@@ -16,9 +16,9 @@ func NewMatchingTaskStore(
 	enableFairness bool,
 ) p.TaskStore {
 	if enableFairness {
-		return newMatchingTaskStoreV2(session, logger)
+		return newMatchingTaskStoreV2(session)
 	}
-	return newMatchingTaskStoreV1(session, logger)
+	return newMatchingTaskStoreV1(session)
 }
 
 // We steal some upper bits of the "row type" field to hold a subqueue index.

--- a/common/persistence/cassandra/matching_task_store_queue.go
+++ b/common/persistence/cassandra/matching_task_store_queue.go
@@ -1,0 +1,338 @@
+package cassandra
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/convert"
+	p "go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	"go.temporal.io/server/common/primitives/timestamp"
+)
+
+// CassandraTaskVersion represents the task schema version
+type CassandraTaskVersion int
+
+const (
+	CassandraTaskVersion1 CassandraTaskVersion = 1
+	CassandraTaskVersion2 CassandraTaskVersion = 2
+)
+
+var switchTasksTableV2Cache sync.Map
+
+// SwitchTasksTable switches table names from tasks to tasks_v2 and modifies queries for v2 schema
+func SwitchTasksTable(baseQuery string, v CassandraTaskVersion) string {
+	if v == CassandraTaskVersion1 {
+		return baseQuery
+	} else if v != CassandraTaskVersion2 {
+		return "_invalid_version_"
+	}
+
+	if v2query, ok := switchTasksTableV2Cache.Load(baseQuery); ok {
+		return v2query.(string)
+	}
+
+	// Replace table name
+	v2query := strings.ReplaceAll(baseQuery, " tasks ", " tasks_v2 ")
+
+	// Handle INSERT queries - need to add pass column
+	if strings.Contains(v2query, "INSERT INTO tasks_v2") {
+		// For task queue inserts, add pass column with value 0
+		if strings.Contains(v2query, "type, task_id") {
+			v2query = strings.ReplaceAll(v2query, "type, task_id", "type, pass, task_id")
+			// Add pass = 0 parameter in VALUES
+			v2query = strings.ReplaceAll(v2query, "?, ?, ?, ?, ?, ?, ?, ?", "?, ?, ?, ?, 0, ?, ?, ?, ?")
+		}
+	}
+
+	// Handle WHERE clauses - add pass = 0 condition for task queue operations
+	if strings.Contains(v2query, "type = ?") && !strings.Contains(v2query, "pass") {
+		// For task queue operations, we need to add "and pass = 0" after "type = ?"
+		v2query = strings.ReplaceAll(v2query, "and type = ?", "and type = ? and pass = 0")
+		// Handle UPDATE WHERE clauses that have different ordering
+		if strings.Contains(v2query, "WHERE") && !strings.Contains(v2query, "and pass = 0") {
+			// Look for patterns like "and type = ? and task_id"
+			v2query = strings.ReplaceAll(v2query, "and type = ? and task_id", "and type = ? and pass = 0 and task_id")
+			// Handle end of WHERE clause
+			if strings.Contains(v2query, "type = ? IF") {
+				v2query = strings.ReplaceAll(v2query, "type = ? IF", "type = ? and pass = 0 IF")
+			}
+		}
+	}
+
+	switchTasksTableV2Cache.Store(baseQuery, v2query)
+	return v2query
+}
+
+// Task queue management queries (these will be unified)
+const (
+	templateGetTaskQueueQuery = `SELECT ` +
+		`range_id, ` +
+		`task_queue, ` +
+		`task_queue_encoding ` +
+		`FROM tasks ` +
+		`WHERE namespace_id = ? ` +
+		`and task_queue_name = ? ` +
+		`and task_queue_type = ? ` +
+		`and type = ? ` +
+		`and task_id = ?`
+
+	templateInsertTaskQueueQuery = `INSERT INTO tasks (` +
+		`namespace_id, ` +
+		`task_queue_name, ` +
+		`task_queue_type, ` +
+		`type, ` +
+		`task_id, ` +
+		`range_id, ` +
+		`task_queue, ` +
+		`task_queue_encoding ` +
+		`) VALUES (?, ?, ?, ?, ?, ?, ?, ?) IF NOT EXISTS`
+
+	templateUpdateTaskQueueQuery = `UPDATE tasks SET ` +
+		`range_id = ?, ` +
+		`task_queue = ?, ` +
+		`task_queue_encoding = ? ` +
+		`WHERE namespace_id = ? ` +
+		`and task_queue_name = ? ` +
+		`and task_queue_type = ? ` +
+		`and type = ? ` +
+		`and task_id = ? ` +
+		`IF range_id = ?`
+
+	templateUpdateTaskQueueQueryWithTTLPart1 = `INSERT INTO tasks (` +
+		`namespace_id, ` +
+		`task_queue_name, ` +
+		`task_queue_type, ` +
+		`type, ` +
+		`task_id ` +
+		`) VALUES (?, ?, ?, ?, ?) USING TTL ?`
+
+	templateUpdateTaskQueueQueryWithTTLPart2 = `UPDATE tasks USING TTL ? SET ` +
+		`range_id = ?, ` +
+		`task_queue = ?, ` +
+		`task_queue_encoding = ? ` +
+		`WHERE namespace_id = ? ` +
+		`and task_queue_name = ? ` +
+		`and task_queue_type = ? ` +
+		`and type = ? ` +
+		`and task_id = ? ` +
+		`IF range_id = ?`
+
+	templateDeleteTaskQueueQuery = `DELETE FROM tasks ` +
+		`WHERE namespace_id = ? ` +
+		`AND task_queue_name = ? ` +
+		`AND task_queue_type = ? ` +
+		`AND type = ? ` +
+		`AND task_id = ? ` +
+		`IF range_id = ?`
+)
+
+// taskQueueStore handles unified task queue operations for both v1 and v2
+type taskQueueStore struct {
+	userDataStore
+	version CassandraTaskVersion
+}
+
+func newTaskQueueStore(
+	userDataStore userDataStore,
+	version CassandraTaskVersion,
+) *taskQueueStore {
+	return &taskQueueStore{
+		userDataStore: userDataStore,
+		version:       version,
+	}
+}
+
+func (d *taskQueueStore) CreateTaskQueue(
+	ctx context.Context,
+	request *p.InternalCreateTaskQueueRequest,
+) error {
+	queryStr := SwitchTasksTable(templateInsertTaskQueueQuery, d.version)
+
+	var query gocql.Query
+	if d.version == CassandraTaskVersion1 {
+		query = d.Session.Query(queryStr,
+			request.NamespaceID,
+			request.TaskQueue,
+			request.TaskType,
+			rowTypeTaskQueue,
+			taskQueueTaskID,
+			request.RangeID,
+			request.TaskQueueInfo.Data,
+			request.TaskQueueInfo.EncodingType.String(),
+		).WithContext(ctx)
+	} else {
+		// For v2, the query rewriting adds pass column, so we need the extra parameter
+		query = d.Session.Query(queryStr,
+			request.NamespaceID,
+			request.TaskQueue,
+			request.TaskType,
+			rowTypeTaskQueue,
+			0, // pass = 0 for task queue metadata
+			taskQueueTaskID,
+			request.RangeID,
+			request.TaskQueueInfo.Data,
+			request.TaskQueueInfo.EncodingType.String(),
+		).WithContext(ctx)
+	}
+
+	previous := make(map[string]interface{})
+	applied, err := query.MapScanCAS(previous)
+	if err != nil {
+		return gocql.ConvertError("CreateTaskQueue", err)
+	}
+
+	if !applied {
+		previousRangeID := previous["range_id"]
+		return &p.ConditionFailedError{
+			Msg: fmt.Sprintf("CreateTaskQueue: TaskQueue:%v, TaskQueueType:%v, PreviousRangeID:%v",
+				request.TaskQueue, request.TaskType, previousRangeID),
+		}
+	}
+
+	return nil
+}
+
+func (d *taskQueueStore) GetTaskQueue(
+	ctx context.Context,
+	request *p.InternalGetTaskQueueRequest,
+) (*p.InternalGetTaskQueueResponse, error) {
+	queryStr := SwitchTasksTable(templateGetTaskQueueQuery, d.version)
+	query := d.Session.Query(queryStr,
+		request.NamespaceID,
+		request.TaskQueue,
+		request.TaskType,
+		rowTypeTaskQueue,
+		taskQueueTaskID,
+	).WithContext(ctx)
+
+	var rangeID int64
+	var tlBytes []byte
+	var tlEncoding string
+	if err := query.Scan(&rangeID, &tlBytes, &tlEncoding); err != nil {
+		return nil, gocql.ConvertError("GetTaskQueue", err)
+	}
+
+	return &p.InternalGetTaskQueueResponse{
+		RangeID:       rangeID,
+		TaskQueueInfo: p.NewDataBlob(tlBytes, tlEncoding),
+	}, nil
+}
+
+func (d *taskQueueStore) UpdateTaskQueue(
+	ctx context.Context,
+	request *p.InternalUpdateTaskQueueRequest,
+) (*p.UpdateTaskQueueResponse, error) {
+	var err error
+	var applied bool
+	previous := make(map[string]interface{})
+
+	if d.version == CassandraTaskVersion1 && request.TaskQueueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+		// V1 TTL logic - only applies to V1
+		if request.ExpiryTime == nil {
+			return nil, serviceerror.NewInternal("ExpiryTime cannot be nil for sticky task queue")
+		}
+		expiryTTL := convert.Int64Ceil(time.Until(timestamp.TimeValue(request.ExpiryTime)).Seconds())
+		if expiryTTL >= maxCassandraTTL {
+			expiryTTL = maxCassandraTTL
+		}
+		batch := d.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+
+		queryStr1 := SwitchTasksTable(templateUpdateTaskQueueQueryWithTTLPart1, d.version)
+		batch.Query(queryStr1,
+			request.NamespaceID,
+			request.TaskQueue,
+			request.TaskType,
+			rowTypeTaskQueue,
+			taskQueueTaskID,
+			expiryTTL,
+		)
+
+		queryStr2 := SwitchTasksTable(templateUpdateTaskQueueQueryWithTTLPart2, d.version)
+		batch.Query(queryStr2,
+			expiryTTL,
+			request.RangeID,
+			request.TaskQueueInfo.Data,
+			request.TaskQueueInfo.EncodingType.String(),
+			request.NamespaceID,
+			request.TaskQueue,
+			request.TaskType,
+			rowTypeTaskQueue,
+			taskQueueTaskID,
+			request.PrevRangeID,
+		)
+		applied, _, err = d.Session.MapExecuteBatchCAS(batch, previous)
+	} else {
+		// Regular update logic for both V1 and V2
+		queryStr := SwitchTasksTable(templateUpdateTaskQueueQuery, d.version)
+		query := d.Session.Query(queryStr,
+			request.RangeID,
+			request.TaskQueueInfo.Data,
+			request.TaskQueueInfo.EncodingType.String(),
+			request.NamespaceID,
+			request.TaskQueue,
+			request.TaskType,
+			rowTypeTaskQueue,
+			taskQueueTaskID,
+			request.PrevRangeID,
+		).WithContext(ctx)
+		applied, err = query.MapScanCAS(previous)
+	}
+
+	if err != nil {
+		return nil, gocql.ConvertError("UpdateTaskQueue", err)
+	}
+
+	if !applied {
+		var columns []string
+		for k, v := range previous {
+			columns = append(columns, fmt.Sprintf("%s=%v", k, v))
+		}
+
+		return nil, &p.ConditionFailedError{
+			Msg: fmt.Sprintf("Failed to update task queue. name: %v, type: %v, rangeID: %v, columns: (%v)",
+				request.TaskQueue, request.TaskType, request.RangeID, strings.Join(columns, ",")),
+		}
+	}
+
+	return &p.UpdateTaskQueueResponse{}, nil
+}
+
+func (d *taskQueueStore) ListTaskQueue(
+	_ context.Context,
+	_ *p.ListTaskQueueRequest,
+) (*p.InternalListTaskQueueResponse, error) {
+	return nil, serviceerror.NewUnavailable("unsupported operation")
+}
+
+func (d *taskQueueStore) DeleteTaskQueue(
+	ctx context.Context,
+	request *p.DeleteTaskQueueRequest,
+) error {
+	queryStr := SwitchTasksTable(templateDeleteTaskQueueQuery, d.version)
+	query := d.Session.Query(queryStr,
+		request.TaskQueue.NamespaceID,
+		request.TaskQueue.TaskQueueName,
+		request.TaskQueue.TaskQueueType,
+		rowTypeTaskQueue,
+		taskQueueTaskID,
+		request.RangeID,
+	).WithContext(ctx)
+
+	previous := make(map[string]interface{})
+	applied, err := query.MapScanCAS(previous)
+	if err != nil {
+		return gocql.ConvertError("DeleteTaskQueue", err)
+	}
+	if !applied {
+		return &p.ConditionFailedError{
+			Msg: fmt.Sprintf("DeleteTaskQueue operation failed: expected_range_id=%v but found %+v", request.RangeID, previous),
+		}
+	}
+	return nil
+}

--- a/common/persistence/cassandra/matching_task_store_queue.go
+++ b/common/persistence/cassandra/matching_task_store_queue.go
@@ -72,6 +72,7 @@ const (
 		`AND task_queue_name = ? ` +
 		`AND task_queue_type = ? ` +
 		`AND type = ? ` +
+		`AND pass = 0 ` +
 		`AND task_id = ? ` +
 		`IF range_id = ?`
 

--- a/common/persistence/cassandra/matching_task_store_queue.go
+++ b/common/persistence/cassandra/matching_task_store_queue.go
@@ -30,11 +30,11 @@ func switchTasksTable(baseQuery string, v matchingTaskVersion) string {
 	if v == matchingTaskVersion2 {
 		return baseQuery
 	} else if v != matchingTaskVersion1 {
-		panic("invalid task schema version")
+		panic("invalid task schema version") // nolint:forbidigo // hardcoded constants
 	}
 
 	if v1query, ok := switchTasksTableV1Cache.Load(baseQuery); ok {
-		return v1query.(string)
+		return v1query.(string) // nolint:revive
 	}
 
 	v1query := strings.ReplaceAll(baseQuery, " tasks_v2 ", " tasks ")

--- a/common/persistence/cassandra/matching_task_store_queue.go
+++ b/common/persistence/cassandra/matching_task_store_queue.go
@@ -15,21 +15,21 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 )
 
-// cassandraTaskVersion represents the task schema version
-type cassandraTaskVersion int
+// matchingTaskVersion represents the task schema version
+type matchingTaskVersion int
 
 const (
-	cassandraTaskVersion1 cassandraTaskVersion = 1
-	cassandraTaskVersion2 cassandraTaskVersion = 2
+	matchingTaskVersion1 matchingTaskVersion = 1
+	matchingTaskVersion2 matchingTaskVersion = 2
 )
 
 var switchTasksTableV1Cache sync.Map
 
 // switchTasksTable switches table names from tasks to tasks_v2 and modifies queries for v2 schema
-func switchTasksTable(baseQuery string, v cassandraTaskVersion) string {
-	if v == cassandraTaskVersion2 {
+func switchTasksTable(baseQuery string, v matchingTaskVersion) string {
+	if v == matchingTaskVersion2 {
 		return baseQuery
-	} else if v != cassandraTaskVersion1 {
+	} else if v != matchingTaskVersion1 {
 		panic("invalid task schema version")
 	}
 
@@ -105,7 +105,7 @@ const (
 // taskQueueStore handles unified task queue operations for both v1 and v2
 type taskQueueStore struct {
 	Session gocql.Session
-	version cassandraTaskVersion
+	version matchingTaskVersion
 }
 
 func (d *taskQueueStore) CreateTaskQueue(
@@ -173,7 +173,7 @@ func (d *taskQueueStore) UpdateTaskQueue(
 	var applied bool
 	previous := make(map[string]interface{})
 
-	if d.version == cassandraTaskVersion1 && request.TaskQueueKind == enumspb.TASK_QUEUE_KIND_STICKY {
+	if d.version == matchingTaskVersion1 && request.TaskQueueKind == enumspb.TASK_QUEUE_KIND_STICKY {
 		// V1 TTL logic - only applies to V1
 		if request.ExpiryTime == nil {
 			return nil, serviceerror.NewInternal("ExpiryTime cannot be nil for sticky task queue")

--- a/common/persistence/cassandra/matching_task_store_user_data.go
+++ b/common/persistence/cassandra/matching_task_store_user_data.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 )
@@ -45,7 +44,6 @@ const (
 
 type userDataStore struct {
 	Session gocql.Session
-	Logger  log.Logger
 }
 
 func (d *userDataStore) GetTaskQueueUserData(

--- a/common/persistence/cassandra/matching_task_store_v1.go
+++ b/common/persistence/cassandra/matching_task_store_v1.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 )
@@ -44,11 +43,10 @@ type matchingTaskStoreV1 struct {
 
 func newMatchingTaskStoreV1(
 	session gocql.Session,
-	logger log.Logger,
 ) *matchingTaskStoreV1 {
 	return &matchingTaskStoreV1{
 		Session:        session,
-		userDataStore:  userDataStore{Session: session, Logger: logger},
+		userDataStore:  userDataStore{Session: session},
 		taskQueueStore: taskQueueStore{Session: session, version: cassandraTaskVersion1},
 	}
 }

--- a/common/persistence/cassandra/matching_task_store_v1.go
+++ b/common/persistence/cassandra/matching_task_store_v1.go
@@ -47,7 +47,7 @@ func newMatchingTaskStoreV1(
 	return &matchingTaskStoreV1{
 		Session:        session,
 		userDataStore:  userDataStore{Session: session},
-		taskQueueStore: taskQueueStore{Session: session, version: cassandraTaskVersion1},
+		taskQueueStore: taskQueueStore{Session: session, version: matchingTaskVersion1},
 	}
 }
 
@@ -91,7 +91,7 @@ func (d *matchingTaskStoreV1) CreateTasks(
 	}
 
 	// The following query is used to ensure that range_id didn't change
-	batch.Query(switchTasksTable(templateUpdateTaskQueueQuery, cassandraTaskVersion1),
+	batch.Query(switchTasksTable(templateUpdateTaskQueueQuery, matchingTaskVersion1),
 		request.RangeID,
 		request.TaskQueueInfo.Data,
 		request.TaskQueueInfo.EncodingType.String(),

--- a/common/persistence/cassandra/matching_task_store_v1.go
+++ b/common/persistence/cassandra/matching_task_store_v1.go
@@ -3,15 +3,10 @@ package cassandra
 import (
 	"context"
 	"fmt"
-	"strings"
-	"time"
 
-	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/server/common/convert"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
-	"go.temporal.io/server/common/primitives/timestamp"
 )
 
 const (
@@ -38,238 +33,20 @@ const (
 		`AND task_queue_type = ? ` +
 		`AND type = ? ` +
 		`AND task_id < ? `
-
-	templateGetTaskQueueQuery = `SELECT ` +
-		`range_id, ` +
-		`task_queue, ` +
-		`task_queue_encoding ` +
-		`FROM tasks ` +
-		`WHERE namespace_id = ? ` +
-		`and task_queue_name = ? ` +
-		`and task_queue_type = ? ` +
-		`and type = ? ` +
-		`and task_id = ?`
-
-	templateInsertTaskQueueQuery = `INSERT INTO tasks (` +
-		`namespace_id, ` +
-		`task_queue_name, ` +
-		`task_queue_type, ` +
-		`type, ` +
-		`task_id, ` +
-		`range_id, ` +
-		`task_queue, ` +
-		`task_queue_encoding ` +
-		`) VALUES (?, ?, ?, ?, ?, ?, ?, ?) IF NOT EXISTS`
-
-	templateUpdateTaskQueueQuery = `UPDATE tasks SET ` +
-		`range_id = ?, ` +
-		`task_queue = ?, ` +
-		`task_queue_encoding = ? ` +
-		`WHERE namespace_id = ? ` +
-		`and task_queue_name = ? ` +
-		`and task_queue_type = ? ` +
-		`and type = ? ` +
-		`and task_id = ? ` +
-		`IF range_id = ?`
-
-	templateUpdateTaskQueueQueryWithTTLPart1 = `INSERT INTO tasks (` +
-		`namespace_id, ` +
-		`task_queue_name, ` +
-		`task_queue_type, ` +
-		`type, ` +
-		`task_id ` +
-		`) VALUES (?, ?, ?, ?, ?) USING TTL ?`
-
-	templateUpdateTaskQueueQueryWithTTLPart2 = `UPDATE tasks USING TTL ? SET ` +
-		`range_id = ?, ` +
-		`task_queue = ?, ` +
-		`task_queue_encoding = ? ` +
-		`WHERE namespace_id = ? ` +
-		`and task_queue_name = ? ` +
-		`and task_queue_type = ? ` +
-		`and type = ? ` +
-		`and task_id = ? ` +
-		`IF range_id = ?`
-
-	templateDeleteTaskQueueQuery = `DELETE FROM tasks ` +
-		`WHERE namespace_id = ? ` +
-		`AND task_queue_name = ? ` +
-		`AND task_queue_type = ? ` +
-		`AND type = ? ` +
-		`AND task_id = ? ` +
-		`IF range_id = ?`
 )
 
 type matchingTaskStoreV1 struct {
 	userDataStore
+	*taskQueueStore
 }
 
 func newMatchingTaskStoreV1(
 	userDataStore userDataStore,
 ) *matchingTaskStoreV1 {
-	return &matchingTaskStoreV1{userDataStore: userDataStore}
-}
-
-func (d *matchingTaskStoreV1) CreateTaskQueue(
-	ctx context.Context,
-	request *p.InternalCreateTaskQueueRequest,
-) error {
-	query := d.Session.Query(templateInsertTaskQueueQuery,
-		request.NamespaceID,
-		request.TaskQueue,
-		request.TaskType,
-		rowTypeTaskQueue,
-		taskQueueTaskID,
-		request.RangeID,
-		request.TaskQueueInfo.Data,
-		request.TaskQueueInfo.EncodingType.String(),
-	).WithContext(ctx)
-
-	previous := make(map[string]interface{})
-	applied, err := query.MapScanCAS(previous)
-	if err != nil {
-		return gocql.ConvertError("CreateTaskQueue", err)
+	return &matchingTaskStoreV1{
+		userDataStore:  userDataStore,
+		taskQueueStore: newTaskQueueStore(userDataStore, CassandraTaskVersion1),
 	}
-
-	if !applied {
-		previousRangeID := previous["range_id"]
-		return &p.ConditionFailedError{
-			Msg: fmt.Sprintf("CreateTaskQueue: TaskQueue:%v, TaskQueueType:%v, PreviousRangeID:%v",
-				request.TaskQueue, request.TaskType, previousRangeID),
-		}
-	}
-
-	return nil
-}
-
-func (d *matchingTaskStoreV1) GetTaskQueue(
-	ctx context.Context,
-	request *p.InternalGetTaskQueueRequest,
-) (*p.InternalGetTaskQueueResponse, error) {
-	query := d.Session.Query(templateGetTaskQueueQuery,
-		request.NamespaceID,
-		request.TaskQueue,
-		request.TaskType,
-		rowTypeTaskQueue,
-		taskQueueTaskID,
-	).WithContext(ctx)
-
-	var rangeID int64
-	var tlBytes []byte
-	var tlEncoding string
-	if err := query.Scan(&rangeID, &tlBytes, &tlEncoding); err != nil {
-		return nil, gocql.ConvertError("GetTaskQueue", err)
-	}
-
-	return &p.InternalGetTaskQueueResponse{
-		RangeID:       rangeID,
-		TaskQueueInfo: p.NewDataBlob(tlBytes, tlEncoding),
-	}, nil
-}
-
-// UpdateTaskQueue update task queue
-func (d *matchingTaskStoreV1) UpdateTaskQueue(
-	ctx context.Context,
-	request *p.InternalUpdateTaskQueueRequest,
-) (*p.UpdateTaskQueueResponse, error) {
-	var err error
-	var applied bool
-	previous := make(map[string]interface{})
-	if request.TaskQueueKind == enumspb.TASK_QUEUE_KIND_STICKY { // if task_queue is sticky, then update with TTL
-		if request.ExpiryTime == nil {
-			return nil, serviceerror.NewInternal("ExpiryTime cannot be nil for sticky task queue")
-		}
-		expiryTTL := convert.Int64Ceil(time.Until(timestamp.TimeValue(request.ExpiryTime)).Seconds())
-		if expiryTTL >= maxCassandraTTL {
-			expiryTTL = maxCassandraTTL
-		}
-		batch := d.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
-		batch.Query(templateUpdateTaskQueueQueryWithTTLPart1,
-			request.NamespaceID,
-			request.TaskQueue,
-			request.TaskType,
-			rowTypeTaskQueue,
-			taskQueueTaskID,
-			expiryTTL,
-		)
-		batch.Query(templateUpdateTaskQueueQueryWithTTLPart2,
-			expiryTTL,
-			request.RangeID,
-			request.TaskQueueInfo.Data,
-			request.TaskQueueInfo.EncodingType.String(),
-			request.NamespaceID,
-			request.TaskQueue,
-			request.TaskType,
-			rowTypeTaskQueue,
-			taskQueueTaskID,
-			request.PrevRangeID,
-		)
-		applied, _, err = d.Session.MapExecuteBatchCAS(batch, previous)
-	} else {
-		query := d.Session.Query(templateUpdateTaskQueueQuery,
-			request.RangeID,
-			request.TaskQueueInfo.Data,
-			request.TaskQueueInfo.EncodingType.String(),
-			request.NamespaceID,
-			request.TaskQueue,
-			request.TaskType,
-			rowTypeTaskQueue,
-			taskQueueTaskID,
-			request.PrevRangeID,
-		).WithContext(ctx)
-		applied, err = query.MapScanCAS(previous)
-	}
-
-	if err != nil {
-		return nil, gocql.ConvertError("UpdateTaskQueue", err)
-	}
-
-	if !applied {
-		var columns []string
-		for k, v := range previous {
-			columns = append(columns, fmt.Sprintf("%s=%v", k, v))
-		}
-
-		return nil, &p.ConditionFailedError{
-			Msg: fmt.Sprintf("Failed to update task queue. name: %v, type: %v, rangeID: %v, columns: (%v)",
-				request.TaskQueue, request.TaskType, request.RangeID, strings.Join(columns, ",")),
-		}
-	}
-
-	return &p.UpdateTaskQueueResponse{}, nil
-}
-
-func (d *matchingTaskStoreV1) ListTaskQueue(
-	_ context.Context,
-	_ *p.ListTaskQueueRequest,
-) (*p.InternalListTaskQueueResponse, error) {
-	return nil, serviceerror.NewUnavailable("unsupported operation")
-}
-
-func (d *matchingTaskStoreV1) DeleteTaskQueue(
-	ctx context.Context,
-	request *p.DeleteTaskQueueRequest,
-) error {
-	query := d.Session.Query(
-		templateDeleteTaskQueueQuery,
-		request.TaskQueue.NamespaceID,
-		request.TaskQueue.TaskQueueName,
-		request.TaskQueue.TaskQueueType,
-		rowTypeTaskQueue,
-		taskQueueTaskID,
-		request.RangeID,
-	).WithContext(ctx)
-	previous := make(map[string]interface{})
-	applied, err := query.MapScanCAS(previous)
-	if err != nil {
-		return gocql.ConvertError("DeleteTaskQueue", err)
-	}
-	if !applied {
-		return &p.ConditionFailedError{
-			Msg: fmt.Sprintf("DeleteTaskQueue operation failed: expected_range_id=%v but found %+v", request.RangeID, previous),
-		}
-	}
-	return nil
 }
 
 // CreateTasks add tasks
@@ -312,7 +89,8 @@ func (d *matchingTaskStoreV1) CreateTasks(
 	}
 
 	// The following query is used to ensure that range_id didn't change
-	batch.Query(templateUpdateTaskQueueQuery,
+	updateQueryStr := SwitchTasksTable(templateUpdateTaskQueueQuery, CassandraTaskVersion1)
+	batch.Query(updateQueryStr,
 		request.RangeID,
 		request.TaskQueueInfo.Data,
 		request.TaskQueueInfo.EncodingType.String(),

--- a/common/persistence/cassandra/matching_task_store_v1.go
+++ b/common/persistence/cassandra/matching_task_store_v1.go
@@ -91,8 +91,7 @@ func (d *matchingTaskStoreV1) CreateTasks(
 	}
 
 	// The following query is used to ensure that range_id didn't change
-	updateQueryStr := switchTasksTable(templateUpdateTaskQueueQuery, cassandraTaskVersion1)
-	batch.Query(updateQueryStr,
+	batch.Query(switchTasksTable(templateUpdateTaskQueueQuery, cassandraTaskVersion1),
 		request.RangeID,
 		request.TaskQueueInfo.Data,
 		request.TaskQueueInfo.EncodingType.String(),

--- a/common/persistence/cassandra/matching_task_store_v2.go
+++ b/common/persistence/cassandra/matching_task_store_v2.go
@@ -6,7 +6,6 @@ import (
 	"math"
 
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 )
@@ -51,11 +50,10 @@ type matchingTaskStoreV2 struct {
 
 func newMatchingTaskStoreV2(
 	session gocql.Session,
-	logger log.Logger,
 ) *matchingTaskStoreV2 {
 	return &matchingTaskStoreV2{
 		Session:        session,
-		userDataStore:  userDataStore{Session: session, Logger: logger},
+		userDataStore:  userDataStore{Session: session},
 		taskQueueStore: taskQueueStore{Session: session, version: cassandraTaskVersion2},
 	}
 }

--- a/common/persistence/cassandra/matching_task_store_v2.go
+++ b/common/persistence/cassandra/matching_task_store_v2.go
@@ -54,7 +54,7 @@ func newMatchingTaskStoreV2(
 	return &matchingTaskStoreV2{
 		Session:        session,
 		userDataStore:  userDataStore{Session: session},
-		taskQueueStore: taskQueueStore{Session: session, version: cassandraTaskVersion2},
+		taskQueueStore: taskQueueStore{Session: session, version: matchingTaskVersion2},
 	}
 }
 
@@ -85,7 +85,7 @@ func (d *matchingTaskStoreV2) CreateTasks(
 	}
 
 	// The following query is used to ensure that range_id didn't change
-	batch.Query(switchTasksTable(templateUpdateTaskQueueQuery, cassandraTaskVersion2),
+	batch.Query(switchTasksTable(templateUpdateTaskQueueQuery, matchingTaskVersion2),
 		request.RangeID,
 		request.TaskQueueInfo.Data,
 		request.TaskQueueInfo.EncodingType.String(),

--- a/common/persistence/cassandra/matching_task_store_v2.go
+++ b/common/persistence/cassandra/matching_task_store_v2.go
@@ -85,8 +85,7 @@ func (d *matchingTaskStoreV2) CreateTasks(
 	}
 
 	// The following query is used to ensure that range_id didn't change
-	updateQueryStr := switchTasksTable(templateUpdateTaskQueueQuery, cassandraTaskVersion2)
-	batch.Query(updateQueryStr,
+	batch.Query(switchTasksTable(templateUpdateTaskQueueQuery, cassandraTaskVersion2),
 		request.RangeID,
 		request.TaskQueueInfo.Data,
 		request.TaskQueueInfo.EncodingType.String(),

--- a/common/persistence/cassandra/matching_task_store_v2.go
+++ b/common/persistence/cassandra/matching_task_store_v2.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strings"
 
 	"go.temporal.io/api/serviceerror"
 	p "go.temporal.io/server/common/persistence"
@@ -39,192 +38,22 @@ const (
 		`AND task_queue_type = ? ` +
 		`AND type = ? ` +
 		`and (pass, task_id) < (?, ?)`
-
-	templateGetTaskQueueQuery_v2 = `SELECT ` +
-		`range_id, ` +
-		`task_queue, ` +
-		`task_queue_encoding ` +
-		`FROM tasks_v2 ` +
-		`WHERE namespace_id = ? ` +
-		`and task_queue_name = ? ` +
-		`and task_queue_type = ? ` +
-		`and type = ? ` +
-		`and pass = 0 ` +
-		`and task_id = ?`
-
-	templateInsertTaskQueueQuery_v2 = `INSERT INTO tasks_v2 (` +
-		`namespace_id, ` +
-		`task_queue_name, ` +
-		`task_queue_type, ` +
-		`type, ` +
-		`pass, ` +
-		`task_id, ` +
-		`range_id, ` +
-		`task_queue, ` +
-		`task_queue_encoding ` +
-		`) VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?) IF NOT EXISTS`
-
-	templateUpdateTaskQueueQuery_v2 = `UPDATE tasks_v2 SET ` +
-		`range_id = ?, ` +
-		`task_queue = ?, ` +
-		`task_queue_encoding = ? ` +
-		`WHERE namespace_id = ? ` +
-		`and task_queue_name = ? ` +
-		`and task_queue_type = ? ` +
-		`and pass = 0 ` +
-		`and type = ? ` +
-		`and task_id = ? ` +
-		`IF range_id = ?`
-
-	templateDeleteTaskQueueQuery_v2 = `DELETE FROM tasks_v2 ` +
-		`WHERE namespace_id = ? ` +
-		`AND task_queue_name = ? ` +
-		`AND task_queue_type = ? ` +
-		`AND type = ? ` +
-		`and pass = 0 ` +
-		`AND task_id = ? ` +
-		`IF range_id = ?`
 )
 
 // matchingTaskStoreV2 is a fork of matchingTaskStoreV1 that uses a new task schema.
-// All methods and queries were duplicated (even if they didn't change) to reduce the shared code.
-// Eventually, the original matchingTaskStoreV1 will be removed.
+// Task queue operations are now unified with V1 through query rewriting.
 type matchingTaskStoreV2 struct {
 	userDataStore
+	*taskQueueStore
 }
 
 func newMatchingTaskStoreV2(
 	userDataStore userDataStore,
 ) *matchingTaskStoreV2 {
-	return &matchingTaskStoreV2{userDataStore: userDataStore}
-}
-
-func (d *matchingTaskStoreV2) CreateTaskQueue(
-	ctx context.Context,
-	request *p.InternalCreateTaskQueueRequest,
-) error {
-	query := d.Session.Query(templateInsertTaskQueueQuery_v2,
-		request.NamespaceID,
-		request.TaskQueue,
-		request.TaskType,
-		rowTypeTaskQueue,
-		taskQueueTaskID,
-		request.RangeID,
-		request.TaskQueueInfo.Data,
-		request.TaskQueueInfo.EncodingType.String(),
-	).WithContext(ctx)
-
-	previous := make(map[string]interface{})
-	applied, err := query.MapScanCAS(previous)
-	if err != nil {
-		return gocql.ConvertError("CreateTaskQueue", err)
+	return &matchingTaskStoreV2{
+		userDataStore:  userDataStore,
+		taskQueueStore: newTaskQueueStore(userDataStore, CassandraTaskVersion2),
 	}
-
-	if !applied {
-		previousRangeID := previous["range_id"]
-		return &p.ConditionFailedError{
-			Msg: fmt.Sprintf("CreateTaskQueue: TaskQueue:%v, TaskQueueType:%v, PreviousRangeID:%v",
-				request.TaskQueue, request.TaskType, previousRangeID),
-		}
-	}
-
-	return nil
-}
-
-func (d *matchingTaskStoreV2) GetTaskQueue(
-	ctx context.Context,
-	request *p.InternalGetTaskQueueRequest,
-) (*p.InternalGetTaskQueueResponse, error) {
-	query := d.Session.Query(templateGetTaskQueueQuery_v2,
-		request.NamespaceID,
-		request.TaskQueue,
-		request.TaskType,
-		rowTypeTaskQueue,
-		taskQueueTaskID,
-	).WithContext(ctx)
-
-	var rangeID int64
-	var tlBytes []byte
-	var tlEncoding string
-	if err := query.Scan(&rangeID, &tlBytes, &tlEncoding); err != nil {
-		return nil, gocql.ConvertError("GetTaskQueue", err)
-	}
-
-	return &p.InternalGetTaskQueueResponse{
-		RangeID:       rangeID,
-		TaskQueueInfo: p.NewDataBlob(tlBytes, tlEncoding),
-	}, nil
-}
-
-// UpdateTaskQueue update task queue
-func (d *matchingTaskStoreV2) UpdateTaskQueue(
-	ctx context.Context,
-	request *p.InternalUpdateTaskQueueRequest,
-) (*p.UpdateTaskQueueResponse, error) {
-	previous := make(map[string]interface{})
-	query := d.Session.Query(templateUpdateTaskQueueQuery_v2,
-		request.RangeID,
-		request.TaskQueueInfo.Data,
-		request.TaskQueueInfo.EncodingType.String(),
-		request.NamespaceID,
-		request.TaskQueue,
-		request.TaskType,
-		rowTypeTaskQueue,
-		taskQueueTaskID,
-		request.PrevRangeID,
-	).WithContext(ctx)
-	applied, err := query.MapScanCAS(previous)
-
-	if err != nil {
-		return nil, gocql.ConvertError("UpdateTaskQueue", err)
-	}
-
-	if !applied {
-		var columns []string
-		for k, v := range previous {
-			columns = append(columns, fmt.Sprintf("%s=%v", k, v))
-		}
-
-		return nil, &p.ConditionFailedError{
-			Msg: fmt.Sprintf("Failed to update task queue. name: %v, type: %v, rangeID: %v, columns: (%v)",
-				request.TaskQueue, request.TaskType, request.RangeID, strings.Join(columns, ",")),
-		}
-	}
-
-	return &p.UpdateTaskQueueResponse{}, nil
-}
-
-func (d *matchingTaskStoreV2) ListTaskQueue(
-	_ context.Context,
-	_ *p.ListTaskQueueRequest,
-) (*p.InternalListTaskQueueResponse, error) {
-	return nil, serviceerror.NewUnavailable("unsupported operation")
-}
-
-func (d *matchingTaskStoreV2) DeleteTaskQueue(
-	ctx context.Context,
-	request *p.DeleteTaskQueueRequest,
-) error {
-	query := d.Session.Query(
-		templateDeleteTaskQueueQuery_v2,
-		request.TaskQueue.NamespaceID,
-		request.TaskQueue.TaskQueueName,
-		request.TaskQueue.TaskQueueType,
-		rowTypeTaskQueue,
-		taskQueueTaskID,
-		request.RangeID,
-	).WithContext(ctx)
-	previous := make(map[string]interface{})
-	applied, err := query.MapScanCAS(previous)
-	if err != nil {
-		return gocql.ConvertError("DeleteTaskQueue", err)
-	}
-	if !applied {
-		return &p.ConditionFailedError{
-			Msg: fmt.Sprintf("DeleteTaskQueue operation failed: expected_range_id=%v but found %+v", request.RangeID, previous),
-		}
-	}
-	return nil
 }
 
 // CreateTasks add tasks
@@ -254,7 +83,8 @@ func (d *matchingTaskStoreV2) CreateTasks(
 	}
 
 	// The following query is used to ensure that range_id didn't change
-	batch.Query(templateUpdateTaskQueueQuery_v2,
+	updateQueryStr := SwitchTasksTable(templateUpdateTaskQueueQuery, CassandraTaskVersion2)
+	batch.Query(updateQueryStr,
 		request.RangeID,
 		request.TaskQueueInfo.Data,
 		request.TaskQueueInfo.EncodingType.String(),

--- a/common/persistence/sql/sqlplugin/matching_task_queue.go
+++ b/common/persistence/sql/sqlplugin/matching_task_queue.go
@@ -65,7 +65,7 @@ func SwitchTaskQueuesTable(baseQuery string, v MatchingTaskVersion) string {
 	if v == MatchingTaskVersion2 {
 		return baseQuery
 	} else if v != MatchingTaskVersion1 {
-		panic("invalid task schema version")
+		panic("invalid task schema version") // nolint:forbidigo // hardcoded constants
 	}
 	if v1query, ok := switchTaskQueuesTableV1Cache.Load(baseQuery); ok {
 		return v1query.(string) // nolint:revive

--- a/common/persistence/sql/sqlplugin/matching_task_queue.go
+++ b/common/persistence/sql/sqlplugin/matching_task_queue.go
@@ -59,18 +59,18 @@ const (
 	MatchingTaskVersion2 MatchingTaskVersion = 2
 )
 
-var switchTaskQueuesTableV2Cache sync.Map
+var switchTaskQueuesTableV1Cache sync.Map
 
 func SwitchTaskQueuesTable(baseQuery string, v MatchingTaskVersion) string {
-	if v == MatchingTaskVersion1 {
+	if v == MatchingTaskVersion2 {
 		return baseQuery
-	} else if v != MatchingTaskVersion2 {
-		return "_invalid_version_"
+	} else if v != MatchingTaskVersion1 {
+		panic("invalid task schema version")
 	}
-	if v2query, ok := switchTaskQueuesTableV2Cache.Load(baseQuery); ok {
-		return v2query.(string) // nolint:revive
+	if v1query, ok := switchTaskQueuesTableV1Cache.Load(baseQuery); ok {
+		return v1query.(string) // nolint:revive
 	}
-	v2query := strings.ReplaceAll(baseQuery, " task_queues ", " task_queues_v2 ")
-	switchTaskQueuesTableV2Cache.Store(baseQuery, v2query)
-	return v2query
+	v1query := strings.ReplaceAll(baseQuery, " task_queues_v2 ", " task_queues ")
+	switchTaskQueuesTableV1Cache.Store(baseQuery, v1query)
+	return v1query
 }

--- a/common/persistence/sql/sqlplugin/mysql/task_queues.go
+++ b/common/persistence/sql/sqlplugin/mysql/task_queues.go
@@ -9,13 +9,13 @@ import (
 )
 
 const (
-	taskQueueCreatePart = `INTO task_queues (range_hash, task_queue_id, range_id, data, data_encoding) ` +
+	taskQueueCreatePart = `INTO task_queues_v2 (range_hash, task_queue_id, range_id, data, data_encoding) ` +
 		`VALUES (:range_hash, :task_queue_id, :range_id, :data, :data_encoding)`
 
 	// (default range ID: initialRangeID == 1)
 	createTaskQueueQry = `INSERT ` + taskQueueCreatePart
 
-	updateTaskQueueQry = `UPDATE task_queues SET
+	updateTaskQueueQry = `UPDATE task_queues_v2 SET
 	range_id = :range_id,
 	data = :data,
 	data_encoding = :data_encoding
@@ -24,7 +24,7 @@ const (
 	task_queue_id = :task_queue_id
 	`
 
-	listTaskQueueRowSelect = `SELECT range_hash, task_queue_id, range_id, data, data_encoding FROM task_queues `
+	listTaskQueueRowSelect = `SELECT range_hash, task_queue_id, range_id, data, data_encoding FROM task_queues_v2 `
 
 	listTaskQueueWithHashRangeQry = listTaskQueueRowSelect +
 		`WHERE range_hash >= ? AND range_hash <= ? AND task_queue_id > ? ORDER BY task_queue_id ASC LIMIT ?`
@@ -35,13 +35,13 @@ const (
 	getTaskQueueQry = listTaskQueueRowSelect +
 		`WHERE range_hash = ? AND task_queue_id = ?`
 
-	deleteTaskQueueQry = `DELETE FROM task_queues WHERE range_hash=? AND task_queue_id=? AND range_id=?`
+	deleteTaskQueueQry = `DELETE FROM task_queues_v2 WHERE range_hash=? AND task_queue_id=? AND range_id=?`
 
-	lockTaskQueueQry = `SELECT range_id FROM task_queues ` +
+	lockTaskQueueQry = `SELECT range_id FROM task_queues_v2 ` +
 		`WHERE range_hash = ? AND task_queue_id = ? FOR UPDATE`
 )
 
-// InsertIntoTaskQueues inserts one or more rows into task_queues table
+// InsertIntoTaskQueues inserts one or more rows into task_queues[_v2] table
 func (mdb *db) InsertIntoTaskQueues(
 	ctx context.Context,
 	row *sqlplugin.TaskQueuesRow,
@@ -53,7 +53,7 @@ func (mdb *db) InsertIntoTaskQueues(
 	)
 }
 
-// UpdateTaskQueues updates a row in task_queues table
+// UpdateTaskQueues updates a row in task_queues[_v2] table
 func (mdb *db) UpdateTaskQueues(
 	ctx context.Context,
 	row *sqlplugin.TaskQueuesRow,
@@ -65,7 +65,7 @@ func (mdb *db) UpdateTaskQueues(
 	)
 }
 
-// SelectFromTaskQueues reads one or more rows from task_queues table
+// SelectFromTaskQueues reads one or more rows from task_queues[_v2] table
 func (mdb *db) SelectFromTaskQueues(
 	ctx context.Context,
 	filter sqlplugin.TaskQueuesFilter,
@@ -140,7 +140,7 @@ func (mdb *db) rangeSelectFromTaskQueues(
 	return rows, nil
 }
 
-// DeleteFromTaskQueues deletes a row from task_queues table
+// DeleteFromTaskQueues deletes a row from task_queues[_v2] table
 func (mdb *db) DeleteFromTaskQueues(
 	ctx context.Context,
 	filter sqlplugin.TaskQueuesFilter,
@@ -154,7 +154,7 @@ func (mdb *db) DeleteFromTaskQueues(
 	)
 }
 
-// LockTaskQueues locks a row in task_queues table
+// LockTaskQueues locks a row in task_queues[_v2] table
 func (mdb *db) LockTaskQueues(
 	ctx context.Context,
 	filter sqlplugin.TaskQueuesFilter,

--- a/common/persistence/sql/sqlplugin/postgresql/task_queues.go
+++ b/common/persistence/sql/sqlplugin/postgresql/task_queues.go
@@ -9,13 +9,13 @@ import (
 )
 
 const (
-	taskQueueCreatePart = `INTO task_queues (range_hash, task_queue_id, range_id, data, data_encoding) ` +
+	taskQueueCreatePart = `INTO task_queues_v2 (range_hash, task_queue_id, range_id, data, data_encoding) ` +
 		`VALUES (:range_hash, :task_queue_id, :range_id, :data, :data_encoding)`
 
 	// (default range ID: initialRangeID == 1)
 	createTaskQueueQry = `INSERT ` + taskQueueCreatePart
 
-	updateTaskQueueQry = `UPDATE task_queues SET
+	updateTaskQueueQry = `UPDATE task_queues_v2 SET
 	range_id = :range_id,
 	data = :data,
 	data_encoding = :data_encoding
@@ -24,7 +24,7 @@ const (
 	task_queue_id = :task_queue_id
 	`
 
-	listTaskQueueRowSelect = `SELECT range_hash, task_queue_id, range_id, data, data_encoding FROM task_queues `
+	listTaskQueueRowSelect = `SELECT range_hash, task_queue_id, range_id, data, data_encoding FROM task_queues_v2 `
 
 	listTaskQueueWithHashRangeQry = listTaskQueueRowSelect +
 		`WHERE range_hash >= $1 AND range_hash <= $2 AND task_queue_id > $3 ORDER BY task_queue_id ASC LIMIT $4`
@@ -35,13 +35,13 @@ const (
 	getTaskQueueQry = listTaskQueueRowSelect +
 		`WHERE range_hash = $1 AND task_queue_id=$2`
 
-	deleteTaskQueueQry = `DELETE FROM task_queues WHERE range_hash=$1 AND task_queue_id=$2 AND range_id=$3`
+	deleteTaskQueueQry = `DELETE FROM task_queues_v2 WHERE range_hash=$1 AND task_queue_id=$2 AND range_id=$3`
 
-	lockTaskQueueQry = `SELECT range_id FROM task_queues ` +
+	lockTaskQueueQry = `SELECT range_id FROM task_queues_v2 ` +
 		`WHERE range_hash=$1 AND task_queue_id=$2 FOR UPDATE`
 )
 
-// InsertIntoTaskQueues inserts one or more rows into task_queues table
+// InsertIntoTaskQueues inserts one or more rows into task_queues[_v2] table
 func (pdb *db) InsertIntoTaskQueues(
 	ctx context.Context,
 	row *sqlplugin.TaskQueuesRow,
@@ -53,7 +53,7 @@ func (pdb *db) InsertIntoTaskQueues(
 	)
 }
 
-// UpdateTaskQueues updates a row in task_queues table
+// UpdateTaskQueues updates a row in task_queues[_v2] table
 func (pdb *db) UpdateTaskQueues(
 	ctx context.Context,
 	row *sqlplugin.TaskQueuesRow,
@@ -65,7 +65,7 @@ func (pdb *db) UpdateTaskQueues(
 	)
 }
 
-// SelectFromTaskQueues reads one or more rows from task_queues table
+// SelectFromTaskQueues reads one or more rows from task_queues[_v2] table
 func (pdb *db) SelectFromTaskQueues(
 	ctx context.Context,
 	filter sqlplugin.TaskQueuesFilter,
@@ -140,7 +140,7 @@ func (pdb *db) rangeSelectFromTaskQueues(
 	return rows, nil
 }
 
-// DeleteFromTaskQueues deletes a row from task_queues table
+// DeleteFromTaskQueues deletes a row from task_queues[_v2] table
 func (pdb *db) DeleteFromTaskQueues(
 	ctx context.Context,
 	filter sqlplugin.TaskQueuesFilter,
@@ -154,7 +154,7 @@ func (pdb *db) DeleteFromTaskQueues(
 	)
 }
 
-// LockTaskQueues locks a row in task_queues table
+// LockTaskQueues locks a row in task_queues[_v2] table
 func (pdb *db) LockTaskQueues(
 	ctx context.Context,
 	filter sqlplugin.TaskQueuesFilter,

--- a/common/persistence/sql/sqlplugin/sqlite/task_queues.go
+++ b/common/persistence/sql/sqlplugin/sqlite/task_queues.go
@@ -9,13 +9,13 @@ import (
 )
 
 const (
-	taskQueueCreatePart = `INTO task_queues (range_hash, task_queue_id, range_id, data, data_encoding) ` +
+	taskQueueCreatePart = `INTO task_queues_v2 (range_hash, task_queue_id, range_id, data, data_encoding) ` +
 		`VALUES (:range_hash, :task_queue_id, :range_id, :data, :data_encoding)`
 
 	// (default range ID: initialRangeID == 1)
 	createTaskQueueQry = `INSERT ` + taskQueueCreatePart
 
-	updateTaskQueueQry = `UPDATE task_queues SET
+	updateTaskQueueQry = `UPDATE task_queues_v2 SET
 	range_id = :range_id,
 	data = :data,
 	data_encoding = :data_encoding
@@ -24,7 +24,7 @@ const (
 	task_queue_id = :task_queue_id
 	`
 
-	listTaskQueueRowSelect = `SELECT range_hash, task_queue_id, range_id, data, data_encoding FROM task_queues `
+	listTaskQueueRowSelect = `SELECT range_hash, task_queue_id, range_id, data, data_encoding FROM task_queues_v2 `
 
 	listTaskQueueWithHashRangeQry = listTaskQueueRowSelect +
 		`WHERE range_hash >= ? AND range_hash <= ? AND task_queue_id > ? ORDER BY task_queue_id ASC LIMIT ?`
@@ -35,13 +35,13 @@ const (
 	getTaskQueueQry = listTaskQueueRowSelect +
 		`WHERE range_hash = ? AND task_queue_id = ?`
 
-	deleteTaskQueueQry = `DELETE FROM task_queues WHERE range_hash=? AND task_queue_id=? AND range_id=?`
+	deleteTaskQueueQry = `DELETE FROM task_queues_v2 WHERE range_hash=? AND task_queue_id=? AND range_id=?`
 
-	lockTaskQueueQry = `SELECT range_id FROM task_queues ` +
+	lockTaskQueueQry = `SELECT range_id FROM task_queues_v2 ` +
 		`WHERE range_hash = ? AND task_queue_id = ?`
 )
 
-// InsertIntoTaskQueues inserts one or more rows into task_queues table
+// InsertIntoTaskQueues inserts one or more rows into task_queues[_v2] table
 func (mdb *db) InsertIntoTaskQueues(
 	ctx context.Context,
 	row *sqlplugin.TaskQueuesRow,
@@ -53,7 +53,7 @@ func (mdb *db) InsertIntoTaskQueues(
 	)
 }
 
-// UpdateTaskQueues updates a row in task_queues table
+// UpdateTaskQueues updates a row in task_queues[_v2] table
 func (mdb *db) UpdateTaskQueues(
 	ctx context.Context,
 	row *sqlplugin.TaskQueuesRow,
@@ -65,7 +65,7 @@ func (mdb *db) UpdateTaskQueues(
 	)
 }
 
-// SelectFromTaskQueues reads one or more rows from task_queues table
+// SelectFromTaskQueues reads one or more rows from task_queues[_v2] table
 func (mdb *db) SelectFromTaskQueues(
 	ctx context.Context,
 	filter sqlplugin.TaskQueuesFilter,
@@ -140,7 +140,7 @@ func (mdb *db) rangeSelectFromTaskQueues(
 	return rows, nil
 }
 
-// DeleteFromTaskQueues deletes a row from task_queues table
+// DeleteFromTaskQueues deletes a row from task_queues[_v2] table
 func (mdb *db) DeleteFromTaskQueues(
 	ctx context.Context,
 	filter sqlplugin.TaskQueuesFilter,
@@ -154,7 +154,7 @@ func (mdb *db) DeleteFromTaskQueues(
 	)
 }
 
-// LockTaskQueues locks a row in task_queues table
+// LockTaskQueues locks a row in task_queues[_v2] table
 func (mdb *db) LockTaskQueues(
 	ctx context.Context,
 	filter sqlplugin.TaskQueuesFilter,


### PR DESCRIPTION
## What changed?
Remove some code duplication for cassandra matching task queue persistence by rewriting v2 to v1 queries.
Switch same scheme for SQL queries to use the v2 table name in the base query and rewriting v1.
Use panic instead of returning an invalid query.

## Why?
Remove code duplication.

## How did you test it?
- [x] covered by existing tests
