### PR TITLE
debugtimeout.Multiplier

### DIFF
--- a/client/admin/client.go
+++ b/client/admin/client.go
@@ -8,17 +8,17 @@ import (
 	"time"
 
 	"go.temporal.io/server/api/adminservice/v1"
-	"go.temporal.io/server/common/debug"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"google.golang.org/grpc"
 )
 
 var _ adminservice.AdminServiceClient = (*clientImpl)(nil)
 
-const (
+var (
 	// DefaultTimeout is the default timeout used to make calls
-	DefaultTimeout = 10 * time.Second * debug.TimeoutMultiplier
+	DefaultTimeout = 10 * time.Second * debugtimeout.Multiplier
 	// DefaultLargeTimeout is the default timeout used to make calls
-	DefaultLargeTimeout = time.Minute * debug.TimeoutMultiplier
+	DefaultLargeTimeout = time.Minute * debugtimeout.Multiplier
 )
 
 type clientImpl struct {

--- a/client/frontend/client.go
+++ b/client/frontend/client.go
@@ -8,14 +8,14 @@ import (
 	"time"
 
 	"go.temporal.io/api/workflowservice/v1"
-	"go.temporal.io/server/common/debug"
+	"go.temporal.io/server/common/testing/debugtimeout"
 )
 
-const (
+var (
 	// DefaultTimeout is the default timeout used to make calls
-	DefaultTimeout = 10 * time.Second * debug.TimeoutMultiplier
+	DefaultTimeout = 10 * time.Second * debugtimeout.Multiplier
 	// DefaultLongPollTimeout is the long poll default timeout used to make calls
-	DefaultLongPollTimeout = time.Minute * 3 * debug.TimeoutMultiplier
+	DefaultLongPollTimeout = time.Minute * 3 * debugtimeout.Multiplier
 )
 
 var _ workflowservice.WorkflowServiceClient = (*clientImpl)(nil)

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -13,13 +13,13 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/tasktoken"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -28,9 +28,9 @@ var (
 	_ historyservice.HistoryServiceClient = (*clientImpl)(nil)
 )
 
-const (
+var (
 	// DefaultTimeout is the default timeout used to make calls
-	DefaultTimeout = time.Second * 30 * debug.TimeoutMultiplier
+	DefaultTimeout = time.Second * 30 * debugtimeout.Multiplier
 )
 
 type clientImpl struct {

--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -11,21 +11,21 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/tqid"
 	"google.golang.org/grpc"
 )
 
 var _ matchingservice.MatchingServiceClient = (*clientImpl)(nil)
 
-const (
+var (
 	// DefaultTimeout is the max timeout for regular calls
-	DefaultTimeout = time.Minute * debug.TimeoutMultiplier
+	DefaultTimeout = time.Minute * debugtimeout.Multiplier
 	// DefaultLongPollTimeout is the max timeout for long poll calls
-	DefaultLongPollTimeout = time.Minute * 5 * debug.TimeoutMultiplier
+	DefaultLongPollTimeout = time.Minute * 5 * debugtimeout.Multiplier
 )
 
 type clientImpl struct {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,7 +13,6 @@ import (
 	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/build"
 	"go.temporal.io/server/common/config"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
@@ -174,7 +173,6 @@ func buildCLI() *cli.App {
 					tag.NewStringTag("go-version", build.InfoData.GoVersion),
 					tag.NewBoolTag("cgo-enabled", build.InfoData.CgoEnabled),
 					tag.NewStringTag("server-version", headers.ServerVersion),
-					tag.NewBoolTag("debug-mode", debug.Enabled),
 				)
 
 				var dynamicConfigClient dynamicconfig.Client

--- a/common/debug/debug.go
+++ b/common/debug/debug.go
@@ -1,9 +1,0 @@
-//go:build TEMPORAL_DEBUG
-
-package debug
-
-const (
-	Enabled = true
-
-	TimeoutMultiplier = 100
-)

--- a/common/debug/not_debug.go
+++ b/common/debug/not_debug.go
@@ -1,9 +1,0 @@
-//go:build !TEMPORAL_DEBUG
-
-package debug
-
-const (
-	Enabled = false
-
-	TimeoutMultiplier = 1
-)

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -7,9 +7,9 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	sdkworker "go.temporal.io/sdk/worker"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/retrypolicy"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/service/matching/counter"
 )
 
@@ -1516,7 +1516,7 @@ for cached shard ownership entries after a membership update.`,
 	)
 	ShardIOTimeout = NewGlobalDurationSetting(
 		"history.shardIOTimeout",
-		5*time.Second*debug.TimeoutMultiplier,
+		5*time.Second*debugtimeout.Multiplier,
 		`ShardIOTimeout sets the timeout for persistence operations in the shard context`,
 	)
 	StandbyClusterDelay = NewGlobalDurationSetting(

--- a/common/persistence/cassandra/test.go
+++ b/common/persistence/cassandra/test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gocql/gocql"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/config"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -17,6 +16,7 @@ import (
 	commongocql "go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/resolver"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/temporal/environment"
 	"go.temporal.io/server/tests/testutils"
 )
@@ -56,7 +56,7 @@ func NewTestCluster(keyspace, username, password, host string, port int, schemaD
 		Hosts:          host,
 		Port:           port,
 		MaxConns:       2,
-		ConnectTimeout: 30 * time.Second * debug.TimeoutMultiplier,
+		ConnectTimeout: 30 * time.Second * debugtimeout.Multiplier,
 		Keyspace:       keyspace,
 	}
 	result.faultInjection = faultInjection

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -13,9 +13,9 @@ import (
 	"github.com/gocql/gocql"
 	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/config"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/translator"
 	"go.temporal.io/server/common/resolver"
+	"go.temporal.io/server/common/testing/debugtimeout"
 )
 
 func NewCassandraCluster(
@@ -128,7 +128,7 @@ func ConfigureCassandraCluster(cfg config.Cassandra, cluster *gocql.ClusterConfi
 		cluster.NumConns = cfg.MaxConns
 	}
 
-	cluster.ConnectTimeout = 10 * time.Second * debug.TimeoutMultiplier
+	cluster.ConnectTimeout = 10 * time.Second * debugtimeout.Multiplier
 	if cfg.ConnectTimeout > 0 {
 		cluster.ConnectTimeout = cfg.ConnectTimeout
 	}

--- a/common/persistence/persistence-tests/cluster_metadata_manager.go
+++ b/common/persistence/persistence-tests/cluster_metadata_manager.go
@@ -10,9 +10,9 @@ import (
 	"go.temporal.io/api/serviceerror"
 	versionpb "go.temporal.io/api/version/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/common/debug"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/testing/debugtimeout"
 )
 
 type (
@@ -36,7 +36,7 @@ func (s *ClusterMetadataManagerSuite) SetupSuite() {
 func (s *ClusterMetadataManagerSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 }
 
 // TearDownTest implementation

--- a/common/persistence/persistence-tests/history_v2_persistence.go
+++ b/common/persistence/persistence-tests/history_v2_persistence.go
@@ -13,8 +13,8 @@ import (
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/backoff"
-	"go.temporal.io/server/common/debug"
 	p "go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/testing/protorequire"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -66,7 +66,7 @@ func (s *HistoryV2PersistenceSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
 
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 }
 
 // TearDownTest implementation

--- a/common/persistence/persistence-tests/metadata_persistence_v2.go
+++ b/common/persistence/persistence-tests/metadata_persistence_v2.go
@@ -16,10 +16,10 @@ import (
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/cluster"
-	"go.temporal.io/server/common/debug"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/cassandra"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/testing/protorequire"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -47,7 +47,7 @@ func (m *MetadataPersistenceSuiteV2) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	m.Assertions = require.New(m.T())
 	m.ProtoAssertions = protorequire.New(m.T())
-	m.ctx, m.cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	m.ctx, m.cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 
 	// cleanup the namespace created
 	var token []byte

--- a/common/persistence/persistence-tests/queue_persistence.go
+++ b/common/persistence/persistence-tests/queue_persistence.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/testing/debugtimeout"
 )
 
 type (
@@ -34,7 +34,7 @@ func (s *QueuePersistenceSuite) SetupSuite() {
 func (s *QueuePersistenceSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 }
 
 func (s *QueuePersistenceSuite) TearDownTest() {

--- a/common/persistence/sql/sqlplugin/tests/context.go
+++ b/common/persistence/sql/sqlplugin/tests/context.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"time"
 
-	"go.temporal.io/server/common/debug"
+	"go.temporal.io/server/common/testing/debugtimeout"
 )
 
-const (
-	executionTimeout  = 2 * time.Second * debug.TimeoutMultiplier
-	visibilityTimeout = 4 * time.Second * debug.TimeoutMultiplier
+var (
+	executionTimeout  = 2 * time.Second * debugtimeout.Multiplier
+	visibilityTimeout = 4 * time.Second * debugtimeout.Multiplier
 )
 
 func newExecutionContext() context.Context {

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -19,12 +19,12 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/convert"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/testing/protorequire"
 	"google.golang.org/protobuf/proto"
 )
@@ -86,7 +86,7 @@ func (s *ExecutionMutableStateSuite) TearDownSuite() {
 
 func (s *ExecutionMutableStateSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
-	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 
 	s.ShardID++
 	resp, err := s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{

--- a/common/persistence/tests/execution_mutable_state_task.go
+++ b/common/persistence/tests/execution_mutable_state_task.go
@@ -13,13 +13,13 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/service/history/tasks"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -89,7 +89,7 @@ func NewExecutionMutableStateTaskSuite(
 
 func (s *ExecutionMutableStateTaskSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
-	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 
 	s.ShardID++
 	resp, err := s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{

--- a/common/persistence/tests/history_store.go
+++ b/common/persistence/tests/history_store.go
@@ -12,11 +12,11 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/testing/protorequire"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -82,7 +82,7 @@ func (s *HistoryEventsSuite) TearDownSuite() {
 func (s *HistoryEventsSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
-	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 
 	s.ShardID++
 }

--- a/common/persistence/tests/shard.go
+++ b/common/persistence/tests/shard.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/testing/protorequire"
 )
 
@@ -57,7 +57,7 @@ func (s *ShardSuite) TearDownSuite() {
 func (s *ShardSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
-	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 
 	s.ShardID++
 }

--- a/common/persistence/tests/task_queue.go
+++ b/common/persistence/tests/task_queue.go
@@ -12,10 +12,10 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/testing/protorequire"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -63,7 +63,7 @@ func (s *TaskQueueSuite) TearDownSuite() {
 
 func (s *TaskQueueSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 
 	s.stickyTTL = time.Second * 10
 	s.namespaceID = uuid.New().String()

--- a/common/persistence/tests/task_queue_fair_task.go
+++ b/common/persistence/tests/task_queue_fair_task.go
@@ -13,10 +13,10 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	clockspb "go.temporal.io/server/api/clock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/testing/protorequire"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -64,7 +64,7 @@ func (s *TaskQueueFairTaskSuite) TearDownSuite() {
 
 func (s *TaskQueueFairTaskSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 
 	s.stickyTTL = time.Second * 10
 	s.taskTTL = time.Second * 16

--- a/common/persistence/tests/task_queue_task.go
+++ b/common/persistence/tests/task_queue_task.go
@@ -12,10 +12,10 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	clockspb "go.temporal.io/server/api/clock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/testing/protorequire"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -62,7 +62,7 @@ func (s *TaskQueueTaskSuite) TearDownSuite() {
 
 func (s *TaskQueueTaskSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 
 	s.stickyTTL = time.Second * 10
 	s.taskTTL = time.Second * 16

--- a/common/persistence/tests/task_queue_user_data.go
+++ b/common/persistence/tests/task_queue_user_data.go
@@ -11,10 +11,10 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/clock"
 	hlc "go.temporal.io/server/common/clock/hybrid_logical_clock"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/testing/debugtimeout"
 )
 
 type (
@@ -49,7 +49,7 @@ func NewTaskQueueUserDataSuite(
 
 func (s *TaskQueueUserDataSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 
 	s.namespaceID = uuid.New().String()
 }

--- a/common/persistence/tests/visibility_persistence_suite.go
+++ b/common/persistence/tests/visibility_persistence_suite.go
@@ -11,7 +11,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -24,6 +23,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.uber.org/mock/gomock"
 )
 
@@ -92,7 +92,7 @@ func (s *VisibilityPersistenceSuite) SetupSuite() {
 func (s *VisibilityPersistenceSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debug.TimeoutMultiplier)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second*debugtimeout.Multiplier)
 }
 
 func (s *VisibilityPersistenceSuite) TearDownTest() {

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -18,7 +18,6 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/temporalproto"
 	"go.temporal.io/api/workflowservice/v1"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -26,6 +25,7 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.uber.org/mock/gomock"
 )
@@ -106,7 +106,7 @@ func (s *ESVisibilitySuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
 
-	esProcessorAckTimeout := dynamicconfig.GetDurationPropertyFn(1 * time.Minute * debug.TimeoutMultiplier)
+	esProcessorAckTimeout := dynamicconfig.GetDurationPropertyFn(1 * time.Minute * debugtimeout.Multiplier)
 	visibilityDisableOrderByClause := dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false)
 	visibilityEnableManualPagination := dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 
@@ -1764,7 +1764,7 @@ func (s *ESVisibilitySuite) TestProcessPageToken() {
 				searchAttributesProvider:       searchattribute.NewTestProvider(),
 				searchAttributesMapperProvider: searchattribute.NewTestMapperProvider(nil),
 				processor:                      s.mockProcessor,
-				processorAckTimeout:            dynamicconfig.GetDurationPropertyFn(1 * time.Minute * debug.TimeoutMultiplier),
+				processorAckTimeout:            dynamicconfig.GetDurationPropertyFn(1 * time.Minute * debugtimeout.Multiplier),
 				disableOrderByClause:           dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 				enableManualPagination:         dynamicconfig.GetBoolPropertyFnFilteredByNamespace(tc.manualPagination),
 				metricsHandler:                 s.mockMetricsHandler,

--- a/common/primitives/constants.go
+++ b/common/primitives/constants.go
@@ -3,17 +3,12 @@ package primitives
 import (
 	"time"
 
-	"go.temporal.io/server/common/debug"
+	"go.temporal.io/server/common/testing/debugtimeout"
 )
 
 const (
 	// DefaultTransactionSizeLimit is the largest allowed transaction size to persistence
 	DefaultTransactionSizeLimit = 4 * 1024 * 1024
-)
-
-const (
-	// DefaultWorkflowTaskTimeout sets the Default Workflow Task timeout for a Workflow
-	DefaultWorkflowTaskTimeout = 10 * time.Second * debug.TimeoutMultiplier
 )
 
 const (
@@ -29,4 +24,9 @@ const (
 
 const (
 	ScheduleWorkflowIDPrefix = "temporal-sys-scheduler:"
+)
+
+var (
+	// DefaultWorkflowTaskTimeout sets the Default Workflow Task timeout for a Workflow
+	DefaultWorkflowTaskTimeout = 10 * time.Second * debugtimeout.Multiplier
 )

--- a/common/testing/debugtimeout/debugtimeout.go
+++ b/common/testing/debugtimeout/debugtimeout.go
@@ -1,0 +1,26 @@
+//go:build test_dep || integration
+
+package debugtimeout
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+var Multiplier = getMultiplier()
+
+func getMultiplier() time.Duration {
+	v, ok := os.LookupEnv("TEMPORAL_DEBUG_TIMEOUT")
+	if !ok {
+		return time.Duration(1)
+	}
+	if v == "" {
+		return time.Duration(10)
+	}
+	parsed, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		panic("TEMPORAL_DEBUG_TIMEOUT should be empty or a valid integer, got: " + v)
+	}
+	return time.Duration(parsed)
+}

--- a/common/testing/debugtimeout/debugtimeout_prod.go
+++ b/common/testing/debugtimeout/debugtimeout_prod.go
@@ -1,0 +1,9 @@
+//go:build !test_dep && !integration
+
+package debugtimeout
+
+import (
+	"time"
+)
+
+const Multiplier time.Duration = 1

--- a/common/testing/debugtimeout/debugtimeout_test.go
+++ b/common/testing/debugtimeout/debugtimeout_test.go
@@ -1,0 +1,55 @@
+//go:build test_dep
+
+package debugtimeout
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugTimeoutMultiplierInTestFiles(t *testing.T) {
+
+	t.Run("DefaultValueInTestFiles", func(t *testing.T) {
+		assert.Equal(t, time.Duration(1), Multiplier, "Multiplier should be 1 by default in test files")
+	})
+
+	t.Run("EnvironmentVariableOverride", func(t *testing.T) {
+		// Save original environment variable value
+		originalValue := os.Getenv("TEMPORAL_DEBUG_TIMEOUT")
+
+		// Restore original environment variable after test
+		defer func() {
+			if originalValue == "" {
+				os.Unsetenv("TEMPORAL_DEBUG_TIMEOUT")
+			} else {
+				os.Setenv("TEMPORAL_DEBUG_TIMEOUT", originalValue)
+			}
+		}()
+
+		// Check that multiplier is set to default.
+		err := os.Setenv("TEMPORAL_DEBUG_TIMEOUT", "")
+		require.NoError(t, err)
+
+		assert.Equal(t, time.Duration(10), getMultiplier(),
+			"Multiplier should be 10 when TEMPORAL_DEBUG_TIMEOUT is set with an empty value")
+
+		// Check that it uses the value from the environment variable.
+		err = os.Setenv("TEMPORAL_DEBUG_TIMEOUT", "5")
+		require.NoError(t, err)
+
+		assert.Equal(t, time.Duration(5), getMultiplier(),
+			"Multiplier should be overridden by TEMPORAL_DEBUG_TIMEOUT environment variable")
+
+		// Check that it panics for invalid values.
+		err = os.Setenv("TEMPORAL_DEBUG_TIMEOUT", "abc")
+		require.NoError(t, err)
+
+		require.Panics(t, func() {
+			_ = getMultiplier()
+		}, "Expected panic for non-numeric TEMPORAL_DEBUG_TIMEOUT")
+	})
+}

--- a/common/testing/taskpoller/taskpoller.go
+++ b/common/testing/taskpoller/taskpoller.go
@@ -15,9 +15,9 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/rpc"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/testing/testvars"
 )
 
@@ -662,7 +662,7 @@ func newOptions(
 
 func newContext(opts *options) (context.Context, context.CancelFunc) {
 	if opts.ctx != nil {
-		return rpc.NewContextFromParentWithTimeoutAndVersionHeaders(opts.ctx, opts.timeout*debug.TimeoutMultiplier)
+		return rpc.NewContextFromParentWithTimeoutAndVersionHeaders(opts.ctx, opts.timeout*debugtimeout.Multiplier)
 	}
-	return rpc.NewContextWithTimeoutAndVersionHeaders(opts.timeout * debug.TimeoutMultiplier)
+	return rpc.NewContextWithTimeoutAndVersionHeaders(opts.timeout * debugtimeout.Multiplier)
 }

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -8,7 +8,6 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
@@ -17,6 +16,7 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/predicates"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/tasks"
 )
@@ -29,8 +29,6 @@ const (
 	// task alert & action
 	nonDefaultReaderMaxPendingTaskCoefficient = 0.8
 
-	queueIOTimeout = 5 * time.Second * debug.TimeoutMultiplier
-
 	// Force creating new slice every forceNewSliceDuration
 	// so that the last slice in the default reader won't grow
 	// infinitely.
@@ -42,6 +40,10 @@ const (
 	// slice. If there's only one slice, we may unload all tasks for a
 	// given namespace.
 	forceNewSliceDuration = 5 * time.Minute
+)
+
+var (
+	queueIOTimeout = 5 * time.Second * debugtimeout.Multiplier
 )
 
 type (

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -28,7 +28,6 @@ import (
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/convert"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/finalizer"
@@ -46,6 +45,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
@@ -188,13 +188,14 @@ var (
 
 	// errInvalidTransition is an internal error used for acquireShard and transition
 	errInvalidTransition = errors.New("invalid state transition request")
+
+	minContextTimeout = 2 * time.Second * debugtimeout.Multiplier
 )
 
 const (
 	logWarnImmediateTaskLag = 3000000 // 3 million
 	logWarnScheduledTaskLag = time.Duration(30 * time.Minute)
 	historySizeLogThreshold = 10 * 1024 * 1024
-	minContextTimeout       = 2 * time.Second * debug.TimeoutMultiplier
 )
 
 func (s *ContextImpl) String() string {

--- a/service/history/transfer_queue_task_executor_base.go
+++ b/service/history/transfer_queue_task_executor_base.go
@@ -12,7 +12,6 @@ import (
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -21,6 +20,7 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/deletemanager"
@@ -33,12 +33,12 @@ import (
 )
 
 const (
-	taskTimeout          = time.Second * 10 * debug.TimeoutMultiplier
 	taskHistoryOpTimeout = 20 * time.Second
 )
 
 var (
 	errUnknownTransferTask = serviceerror.NewInternal("Unknown transfer task")
+	taskTimeout            = time.Second * 10 * debugtimeout.Multiplier
 )
 
 type (

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -20,12 +20,12 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/worker_versioning"
 	"go.temporal.io/server/service/matching/counter"
@@ -41,13 +41,15 @@ const (
 	// Fake Task ID to wrap a task for syncmatch
 	syncMatchTaskId = -137
 
-	ioTimeout = 5 * time.Second * debug.TimeoutMultiplier
-
 	// Threshold for counting a AddTask call as a no recent poller call
 	noPollerThreshold = time.Minute * 2
 
 	// We avoid retrying failed deployment registration for this period.
 	deploymentRegisterErrorBackoff = 5 * time.Second
+)
+
+var (
+	ioTimeout = 5 * time.Second * debugtimeout.Multiplier
 )
 
 type (

--- a/service/worker/dlq/workflow.go
+++ b/service/worker/dlq/workflow.go
@@ -16,10 +16,10 @@ import (
 	"go.temporal.io/server/api/adminservice/v1"
 	commonspb "go.temporal.io/server/api/common/v1"
 	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	workercommon "go.temporal.io/server/service/worker/common"
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
@@ -156,13 +156,6 @@ const (
 	deleteTasksActivityName      = "dlq-delete-tasks-activity"
 	readTasksActivityName        = "dlq-read-tasks-activity"
 	reEnqueueTasksActivityName   = "dlq-re-enqueue-tasks-activity"
-
-	// deleteTasksActivityTimeout is long because all tasks are deleted in a single go. This only applies when using the
-	// purge workflow, not when the delete activity is used in the merge workflow.
-	deleteTasksActivityTimeout = 5 * time.Minute * debug.TimeoutMultiplier
-	// mergeTasksActivityTimeout controls the timeout of all activities used in the merge workflow. It is relatively
-	// short because we're only processing a single batch of tasks at a time.
-	mergeTasksActivityTimeout = 15 * time.Second * debug.TimeoutMultiplier
 )
 
 var (
@@ -189,6 +182,13 @@ var (
 		BackoffCoefficient: 1.2,
 		MaximumAttempts:    10,
 	}
+
+	// deleteTasksActivityTimeout is long because all tasks are deleted in a single go. This only applies when using the
+	// purge workflow, not when the delete activity is used in the merge workflow.
+	deleteTasksActivityTimeout = 5 * time.Minute * debugtimeout.Multiplier
+	// mergeTasksActivityTimeout controls the timeout of all activities used in the merge workflow. It is relatively
+	// short because we're only processing a single batch of tasks at a time.
+	mergeTasksActivityTimeout = 15 * time.Second * debugtimeout.Multiplier
 )
 
 func newComponent(params workerComponentParams) workercommon.WorkerComponent {

--- a/tests/add_tasks_test.go
+++ b/tests/add_tasks_test.go
@@ -16,9 +16,9 @@ import (
 	"go.temporal.io/server/api/adminservice/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/shard"
@@ -166,7 +166,7 @@ func (s *AddTasksSuite) TestAddTasks_Ok() {
 			s.shouldSkip.Store(true)
 			s.skippedTasks = make(chan tasks.Task)
 			ctx := context.Background()
-			timeout := 5 * debug.TimeoutMultiplier * time.Second
+			timeout := 5 * debugtimeout.Multiplier * time.Second
 			ctx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
 			run, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{

--- a/tests/chasm_test.go
+++ b/tests/chasm_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/tests"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/tests/testcore"
 )
 
-const (
-	chasmTestTimeout = 10 * time.Second * debug.TimeoutMultiplier
+var (
+	chasmTestTimeout = 10 * time.Second * debugtimeout.Multiplier
 )
 
 type ChasmTestSuite struct {

--- a/tests/dlq_test.go
+++ b/tests/dlq_test.go
@@ -25,12 +25,12 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/codec"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/sdk"
+	"go.temporal.io/server/common/testing/debugtimeout"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/tests/testcore"
@@ -83,8 +83,8 @@ type (
 	}
 )
 
-const (
-	dlqTestTimeout = 10 * time.Second * debug.TimeoutMultiplier
+var (
+	dlqTestTimeout = 10 * time.Second * debugtimeout.Multiplier
 )
 
 func TestDLQSuite(t *testing.T) {

--- a/tests/testcore/context.go
+++ b/tests/testcore/context.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"time"
 
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/rpc"
+	"go.temporal.io/server/common/testing/debugtimeout"
 )
 
 // NewContext create new context with default timeout 90 seconds.
 func NewContext() context.Context {
-	ctx, _ := rpc.NewContextWithTimeoutAndVersionHeaders(90 * time.Second * debug.TimeoutMultiplier)
+	ctx, _ := rpc.NewContextWithTimeoutAndVersionHeaders(90 * time.Second * debugtimeout.Multiplier)
 	return ctx
 }


### PR DESCRIPTION
## What changed?

Right now, `TEMPORAL_DEBUG` is build tag that multiplies selected timeouts with `100` to give more time to debug an issue when running tests.

This PR 

- changes it from a build tag an env variable
- renames it from `TEMPORAL_DEBUG` to `TEMPORAL_DEBUG_TIMEOUT` (clearer!)
- changes the default from 100 to 10
- makes it configurable 

I also had to change a few `const`s to `var`s now.

## Why?

All other test-specific overrides are env variables.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

Once this is merged, I'll get [docs](https://github.com/temporalio/temporal/pull/7991) merged.