### PR TITLE
Break out of pagination in scavenger on errors

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2609,7 +2609,8 @@ Should be at least WorkerESProcessorFlushInterval+<time to process request>.`,
 	ExecutionsScannerEnabled = NewGlobalBoolSetting(
 		"worker.executionsScannerEnabled",
 		false,
-		`ExecutionsScannerEnabled indicates if executions scanner should be started as part of worker.Scanner`,
+		`ExecutionsScannerEnabled indicates if executions scanner should be started as part of worker.Scanner. This flag has no effect when SQL persistence is used, 
+because executions scanner support for SQL is not yet implemented.`,
 	)
 	HistoryScannerDataMinAge = NewGlobalDurationSetting(
 		"worker.historyScannerDataMinAge",

--- a/service/worker/scanner/executions/task.go
+++ b/service/worker/scanner/executions/task.go
@@ -96,9 +96,10 @@ func (t *task) Run() executor.TaskStatus {
 		record, err := iter.Next()
 		if err != nil {
 			metrics.ScavengerValidationSkipsCount.With(t.metricsHandler).Record(1)
-			// continue validation process and retry after all workflow records has been iterated.
+			// break out of the loop when pagination fails
 			t.logger.Error("unable to paginate concrete execution", tag.ShardID(t.shardID), tag.Error(err))
 			retryTask = true
+			break
 		}
 
 		mutableState := &MutableState{WorkflowMutableState: record}

--- a/service/worker/scanner/executions/task_test.go
+++ b/service/worker/scanner/executions/task_test.go
@@ -1,0 +1,72 @@
+package executions
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/service/worker/scanner/executor"
+	"go.uber.org/mock/gomock"
+)
+
+type taskTestSuite struct {
+	suite.Suite
+	controller       *gomock.Controller
+	executionManager *persistence.MockExecutionManager
+	rateLimiter      *quotas.MockRateLimiter
+}
+
+func TestTaskTestSuite(t *testing.T) {
+	suite.Run(t, new(taskTestSuite))
+}
+
+func (s *taskTestSuite) SetupTest() {
+	s.controller = gomock.NewController(s.T())
+	s.executionManager = persistence.NewMockExecutionManager(s.controller)
+	s.rateLimiter = quotas.NewMockRateLimiter(s.controller)
+}
+
+func (s *taskTestSuite) TearDownTest() {
+	s.controller.Finish()
+}
+
+func (s *taskTestSuite) createTask() *task {
+	return &task{
+		shardID:          1,
+		executionManager: s.executionManager,
+		metricsHandler:   metrics.NoopMetricsHandler,
+		logger:           log.NewNoopLogger(),
+		scavenger:        &Scavenger{numHistoryShards: 4},
+		ctx:              context.Background(),
+		rateLimiter:      s.rateLimiter,
+	}
+}
+
+func (s *taskTestSuite) TestRun_Success_EmptyResults() {
+	task := s.createTask()
+
+	s.executionManager.EXPECT().
+		ListConcreteExecutions(gomock.Any(), gomock.Any()).
+		Return(&persistence.ListConcreteExecutionsResponse{}, nil)
+
+	status := task.Run()
+	assert.Equal(s.T(), executor.TaskStatusDone, status)
+}
+
+func (s *taskTestSuite) TestRun_PaginationError() {
+	task := s.createTask()
+
+	s.rateLimiter.EXPECT().Wait(gomock.Any()).Return(nil)
+	s.executionManager.EXPECT().
+		ListConcreteExecutions(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("pagination error"))
+
+	status := task.Run()
+	assert.Equal(s.T(), executor.TaskStatusDefer, status)
+}

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -159,10 +159,12 @@ func (s *Scanner) Start() error {
 	}
 
 	var workerTaskQueueNames []string
-	if s.context.cfg.ExecutionsScannerEnabled() {
+	if s.context.cfg.Persistence.DefaultStoreType() != config.StoreTypeSQL && s.context.cfg.ExecutionsScannerEnabled() {
 		s.wg.Add(1)
 		go s.startWorkflowWithRetry(ctx, executionsScannerWFStartOptions, executionsScannerWFTypeName)
 		workerTaskQueueNames = append(workerTaskQueueNames, executionsScannerTaskQueueName)
+	} else if s.context.cfg.ExecutionsScannerEnabled() {
+		s.context.logger.Info("ExecutionsScanner is not supported for SQL store")
 	}
 
 	if s.context.cfg.Persistence.DefaultStoreType() == config.StoreTypeSQL && s.context.cfg.TaskQueueScannerEnabled() {

--- a/service/worker/scanner/scanner_test.go
+++ b/service/worker/scanner/scanner_test.go
@@ -134,7 +134,7 @@ func (s *scannerTestSuite) TestScannerEnabled() {
 			HistoryScannerEnabled:    false,
 			BuildIdScavengerEnabled:  false,
 			DefaultStore:             config.StoreTypeSQL,
-			ExpectedScanners:         []expectedScanner{executionScanner},
+			ExpectedScanners:         []expectedScanner{}, // ExecutionsScanner is not supported for SQL store
 		},
 		{
 			Name:                     "BuildIdScavengerNoSQL",
@@ -161,7 +161,16 @@ func (s *scannerTestSuite) TestScannerEnabled() {
 			HistoryScannerEnabled:    true,
 			BuildIdScavengerEnabled:  true,
 			DefaultStore:             config.StoreTypeSQL,
-			ExpectedScanners:         []expectedScanner{historyScanner, taskQueueScanner, executionScanner, buildIdScavenger},
+			ExpectedScanners:         []expectedScanner{historyScanner, taskQueueScanner, buildIdScavenger}, // ExecutionsScanner is not supported for SQL store
+		},
+		{
+			Name:                     "AllScannersNoSQL",
+			ExecutionsScannerEnabled: true,
+			TaskQueueScannerEnabled:  true,
+			HistoryScannerEnabled:    true,
+			BuildIdScavengerEnabled:  true,
+			DefaultStore:             config.StoreTypeNoSQL,
+			ExpectedScanners:         []expectedScanner{historyScanner, executionScanner, buildIdScavenger}, // TaskQueueScanner is only supported for SQL store
 		},
 	} {
 		s.Run(c.Name, func() {


### PR DESCRIPTION
## What changed?
Break out of the loop, when iteration through mutable states fails

## Why?
Previously, we continued to iterate, leading to the panic: https://github.com/temporalio/temporal/issues/8037

## How did you test it?
- [X] run locally and tested manually
- [X] added new unit test(s)