### PR TITLE
CHASM: Fix invalid task error type

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -5,7 +5,6 @@ package chasm
 import (
 	"cmp"
 	"context"
-	"errors"
 	"fmt"
 	"iter"
 	"reflect"
@@ -36,9 +35,9 @@ var (
 )
 
 var (
-	errAccessCheckFailed    = serviceerror.NewNotFound("access check failed, CHASM tree is closed for writes")
-	errComponentNotFound    = serviceerror.NewNotFound("component not found")
-	errTaskValidationFailed = errors.New("task validation failed")
+	errAccessCheckFailed = serviceerror.NewNotFound("access check failed, CHASM tree is closed for writes")
+	errComponentNotFound = serviceerror.NewNotFound("component not found")
+	errTaskNotValid      = serviceerror.NewNotFound("task is no longer valid")
 )
 
 type valueState uint8
@@ -2492,8 +2491,7 @@ func makeValidationFn(
 
 		// Handle bool result.
 		if !result[0].Bool() {
-			// TODO: this should be not-found error
-			return errTaskValidationFailed
+			return errTaskNotValid
 		}
 
 		return nil


### PR DESCRIPTION
## What changed?
- Return NotFound error when task is invalid

## Why?
- Invalid task should be dropped and NotFound is one of the error type that will cause it to be dropped by task processing logic. Unknown error will cause the task to keep retrying and go to DLQ.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
