### PR TITLE
Fix cassandra persistence row type constants

### DIFF
--- a/common/persistence/cassandra/matching_task_store.go
+++ b/common/persistence/cassandra/matching_task_store.go
@@ -21,6 +21,12 @@ func NewMatchingTaskStore(
 	return newMatchingTaskStoreV1(session)
 }
 
+const (
+	// Row types for table tasks. Lower bit only: see rowTypeTaskInSubqueue for more details.
+	rowTypeTask      = 0
+	rowTypeTaskQueue = 1
+)
+
 // We steal some upper bits of the "row type" field to hold a subqueue index.
 // Subqueue 0 must be the same as rowTypeTask (before subqueues were introduced).
 // 00000000: task in subqueue 0 (rowTypeTask)

--- a/common/persistence/cassandra/matching_task_store_user_data.go
+++ b/common/persistence/cassandra/matching_task_store_user_data.go
@@ -13,10 +13,6 @@ const (
 	// Not much of a need to make this configurable, we're just reading some strings
 	listTaskQueueNamesByBuildIdPageSize = 100
 
-	// Row types for table tasks. Lower bit only: see rowTypeTaskInSubqueue for more details.
-	rowTypeTask = iota
-	rowTypeTaskQueue
-
 	templateUpdateTaskQueueUserDataQuery = `UPDATE task_queue_user_data SET
 		data = ?,
 		data_encoding = ?,


### PR DESCRIPTION
## What changed?
Fix these constants and move them to a more meaningful place.

## Why?
This code got moved and since the use of `iota` was no longer at the top of its `const` block, the values changed.
