### PR TITLE
Respect priority levels in rescheduler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,8 @@ require (
 	modernc.org/sqlite v1.34.1
 )
 
+require github.com/google/btree v1.1.3
+
 require (
 	cel.dev/expr v0.20.0 // indirect
 	cloud.google.com/go v0.118.3 // indirect; indirect e

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/service/history/queues/scheduler.go
+++ b/service/history/queues/scheduler.go
@@ -3,6 +3,7 @@
 package queues
 
 import (
+	"github.com/google/btree"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -256,4 +257,13 @@ func (s *rateLimitedSchedulerImpl) Stop() {
 
 func (s *rateLimitedSchedulerImpl) TaskChannelKeyFn() TaskChannelKeyFn {
 	return s.baseScheduler.TaskChannelKeyFn()
+}
+
+// Less implements btree.Item interface for TaskChannelKey
+func (t TaskChannelKey) Less(than btree.Item) bool {
+	otherKey := than.(TaskChannelKey)
+	if t.Priority == otherKey.Priority {
+		return t.NamespaceID < otherKey.NamespaceID
+	}
+	return t.Priority < otherKey.Priority
 }


### PR DESCRIPTION
## What changed?
Right now reshceulder picks task queues randomly in the reschedule loop. This can make it send low priority tasks before sending high priority tasks. It has to process high priority tasks before processing low priority tasks. This change introduces a btree of taskQueueKeys. Tasks queues are sorted in the order of priority inside this btree. This makes it easy for reschduler to iterate in the order of decreasing priority.

## Why?
Better priority enforcement at task scheduler.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

