### PR TITLE
Include error when failing to get callback HTTP client

### DIFF
--- a/components/callbacks/fx.go
+++ b/components/callbacks/fx.go
@@ -60,6 +60,7 @@ func HTTPCallerProviderProvider(
 								"HTTPCallerProviderProvider unable to get FrontendHTTPClient for callback target cluster. Using default HTTP client.",
 								tag.SourceCluster(clusterMetadata.GetCurrentClusterName()),
 								tag.TargetCluster(clusterName),
+								tag.Error(err),
 							)
 							return client.Do(r)
 						}


### PR DESCRIPTION
## What changed?
Adding error to log message when failing to get an HTTP client for a remote cluster for a callback request.
