### PR TITLE
Refactor dynamicconfig.FileBasedClient to make reusable

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -85,7 +85,7 @@ func buildCLI() *cli.App {
 					if err != nil {
 						return err
 					}
-					result := dynamicconfig.ValidateFile(contents)
+					result := dynamicconfig.LoadYamlFile(contents)
 					total += len(result.Errors)
 					fmt.Println(fileName)
 					t := template.Must(template.New("").Parse(

--- a/common/dynamicconfig/client.go
+++ b/common/dynamicconfig/client.go
@@ -1,6 +1,8 @@
 package dynamicconfig
 
 import (
+	"strings"
+
 	enumspb "go.temporal.io/api/enums/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 )
@@ -31,7 +33,7 @@ type (
 	NotifyingClient interface {
 		// Adds a subscription to all updates from this Client. `update` will be called on any
 		// change to the current value set. The caller should call `cancel` to cancel the
-		// subscription. Calls to `update` will not be made concurrently.
+		// subscription.
 		Subscribe(update ClientUpdateFunc) (cancel func())
 	}
 
@@ -96,4 +98,8 @@ type (
 
 func (k Key) String() string {
 	return string(k)
+}
+
+func (k Key) Lower() Key {
+	return Key(strings.ToLower(string(k)))
 }

--- a/common/dynamicconfig/client_diff.go
+++ b/common/dynamicconfig/client_diff.go
@@ -1,0 +1,123 @@
+package dynamicconfig
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/common/log"
+)
+
+// DiffAndLogConfigs computes the difference between two ConfigValueMaps. The result is
+// returned as a ConfigValueMap that can be merged with old to produce new, except with deleted
+// keys mapped to nil. It also logs the differences to a logger.
+func DiffAndLogConfigs(logger log.Logger, old ConfigValueMap, new ConfigValueMap) ConfigValueMap {
+	changedMap := make(map[Key][]ConstrainedValue)
+
+	for key, newValues := range new {
+		oldValues, ok := old[key]
+		if !ok {
+			for _, newValue := range newValues {
+				// new key added
+				diffAndLogValue(logger, key, nil, &newValue)
+			}
+			changedMap[Key(key)] = newValues
+		} else {
+			// compare existing keys
+			changed := diffAndLogConstraints(logger, key, oldValues, newValues)
+			if changed {
+				changedMap[Key(key)] = newValues
+			}
+		}
+	}
+
+	// check for removed values
+	for key, oldValues := range old {
+		if _, ok := new[key]; !ok {
+			for _, oldValue := range oldValues {
+				diffAndLogValue(logger, key, &oldValue, nil)
+			}
+			changedMap[Key(key)] = nil
+		}
+	}
+
+	return changedMap
+}
+
+func diffAndLogConstraints(logger log.Logger, key Key, oldValues []ConstrainedValue, newValues []ConstrainedValue) bool {
+	changed := false
+	for _, oldValue := range oldValues {
+		matchFound := false
+		for _, newValue := range newValues {
+			if oldValue.Constraints == newValue.Constraints {
+				matchFound = true
+				if !reflect.DeepEqual(oldValue.Value, newValue.Value) {
+					diffAndLogValue(logger, key, &oldValue, &newValue)
+					changed = true
+				}
+			}
+		}
+		if !matchFound {
+			diffAndLogValue(logger, key, &oldValue, nil)
+			changed = true
+		}
+	}
+
+	for _, newValue := range newValues {
+		matchFound := false
+		for _, oldValue := range oldValues {
+			if oldValue.Constraints == newValue.Constraints {
+				matchFound = true
+			}
+		}
+		if !matchFound {
+			diffAndLogValue(logger, key, nil, &newValue)
+			changed = true
+		}
+	}
+	return changed
+}
+
+func diffAndLogValue(logger log.Logger, key Key, oldValue *ConstrainedValue, newValue *ConstrainedValue) {
+	logLine := &strings.Builder{}
+	logLine.Grow(128)
+	logLine.WriteString("dynamic config changed for the key: ")
+	logLine.WriteString(string(key))
+	logLine.WriteString(" oldValue: ")
+	appendConstrainedValue(logLine, oldValue)
+	logLine.WriteString(" newValue: ")
+	appendConstrainedValue(logLine, newValue)
+	logger.Info(logLine.String())
+}
+
+func appendConstrainedValue(logLine *strings.Builder, value *ConstrainedValue) {
+	if value == nil {
+		logLine.WriteString("nil")
+	} else {
+		logLine.WriteString("{ constraints: {")
+		if value.Constraints.Namespace != "" {
+			logLine.WriteString(fmt.Sprintf("{Namespace:%s}", value.Constraints.Namespace))
+		}
+		if value.Constraints.NamespaceID != "" {
+			logLine.WriteString(fmt.Sprintf("{NamespaceID:%s}", value.Constraints.NamespaceID))
+		}
+		if value.Constraints.TaskQueueName != "" {
+			logLine.WriteString(fmt.Sprintf("{TaskQueueName:%s}", value.Constraints.TaskQueueName))
+		}
+		if value.Constraints.TaskQueueType != enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
+			logLine.WriteString(fmt.Sprintf("{TaskQueueType:%s}", value.Constraints.TaskQueueType))
+		}
+		if value.Constraints.ShardID != 0 {
+			logLine.WriteString(fmt.Sprintf("{ShardID:%d}", value.Constraints.ShardID))
+		}
+		if value.Constraints.TaskType != enumsspb.TASK_TYPE_UNSPECIFIED {
+			logLine.WriteString(fmt.Sprintf("{HistoryTaskType:%s}", value.Constraints.TaskType))
+		}
+		if value.Constraints.Destination != "" {
+			logLine.WriteString(fmt.Sprintf("{Destination:%s}", value.Constraints.Destination))
+		}
+		logLine.WriteString(fmt.Sprint("} value: ", value.Value, " }"))
+	}
+}

--- a/common/dynamicconfig/client_subscriptions.go
+++ b/common/dynamicconfig/client_subscriptions.go
@@ -1,0 +1,54 @@
+package dynamicconfig
+
+import (
+	"sync"
+
+	expmaps "golang.org/x/exp/maps"
+)
+
+type (
+	// NotifyingClientImpl implements NotifyingClient and is intended to be embedded in another struct.
+	// NotifyingClientImpl must not be copied after first use.
+	NotifyingClientImpl struct {
+		subscriptionLock sync.Mutex
+		subscriptionIdx  int
+		subscriptions    map[int]ClientUpdateFunc
+	}
+)
+
+var _ NotifyingClient = (*NotifyingClientImpl)(nil)
+
+func NewNotifyingClientImpl() NotifyingClientImpl {
+	return NotifyingClientImpl{subscriptions: make(map[int]ClientUpdateFunc)}
+}
+
+// Adds a subscription to all updates from this Client.
+func (n *NotifyingClientImpl) Subscribe(f ClientUpdateFunc) (cancel func()) {
+	n.subscriptionLock.Lock()
+	defer n.subscriptionLock.Unlock()
+
+	n.subscriptionIdx++
+	id := n.subscriptionIdx
+	n.subscriptions[id] = f
+
+	return func() {
+		n.subscriptionLock.Lock()
+		defer n.subscriptionLock.Unlock()
+		delete(n.subscriptions, id)
+	}
+}
+
+// PublishUpdates calls all subscribed update functions with the changed keys.
+func (n *NotifyingClientImpl) PublishUpdates(changed map[Key][]ConstrainedValue) {
+	if len(changed) == 0 {
+		return
+	}
+
+	n.subscriptionLock.Lock()
+	subscriptions := expmaps.Values(n.subscriptions)
+	n.subscriptionLock.Unlock()
+
+	for _, update := range subscriptions {
+		update(changed)
+	}
+}

--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -1,23 +1,15 @@
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination file_based_client_mock.go
-
 package dynamicconfig
 
 import (
 	"errors"
 	"fmt"
 	"os"
-	"reflect"
-	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
-	enumspb "go.temporal.io/api/enums/v1"
-	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
-	expmaps "golang.org/x/exp/maps"
-	"gopkg.in/yaml.v3"
 )
 
 var _ Client = (*fileBasedClient)(nil)
@@ -41,38 +33,21 @@ type (
 		PollInterval time.Duration `yaml:"pollInterval"`
 	}
 
-	configValueMap map[string][]ConstrainedValue
-
 	fileBasedClient struct {
-		values          atomic.Value // configValueMap
+		values          atomic.Value // ConfigValueMap
 		logger          log.Logger
 		reader          FileReader
 		lastUpdatedTime time.Time
 		config          *FileBasedClientConfig
 		doneCh          <-chan interface{}
 
-		subscriptionLock sync.Mutex
-		subscriptionIdx  int
-		subscriptions    map[int]ClientUpdateFunc
+		NotifyingClientImpl
 	}
 
 	osReader struct {
 		path string
 	}
-
-	// Results of processing and loading dynamic config file contents.
-	// Warnings should be reported but not block using the new values.
-	// Errors should abort the loading process.
-	LoadResult struct {
-		Warnings []error
-		Errors   []error
-	}
 )
-
-func ValidateFile(contents []byte) *LoadResult {
-	_, lr := loadFile(contents)
-	return lr
-}
 
 // NewFileBasedClient creates a file based client.
 func NewFileBasedClient(config *FileBasedClientConfig, logger log.Logger, doneCh <-chan interface{}) (*fileBasedClient, error) {
@@ -85,11 +60,11 @@ func NewFileBasedClient(config *FileBasedClientConfig, logger log.Logger, doneCh
 
 func NewFileBasedClientWithReader(reader FileReader, config *FileBasedClientConfig, logger log.Logger, doneCh <-chan interface{}) (*fileBasedClient, error) {
 	client := &fileBasedClient{
-		logger:        logger,
-		reader:        reader,
-		config:        config,
-		doneCh:        doneCh,
-		subscriptions: make(map[int]ClientUpdateFunc),
+		logger:              logger,
+		reader:              reader,
+		config:              config,
+		doneCh:              doneCh,
+		NotifyingClientImpl: NewNotifyingClientImpl(),
 	}
 
 	err := client.init()
@@ -101,23 +76,8 @@ func NewFileBasedClientWithReader(reader FileReader, config *FileBasedClientConf
 }
 
 func (fc *fileBasedClient) GetValue(key Key) []ConstrainedValue {
-	values := fc.values.Load().(configValueMap)
-	return values[strings.ToLower(key.String())]
-}
-
-func (fc *fileBasedClient) Subscribe(f ClientUpdateFunc) (cancel func()) {
-	fc.subscriptionLock.Lock()
-	defer fc.subscriptionLock.Unlock()
-
-	fc.subscriptionIdx++
-	id := fc.subscriptionIdx
-	fc.subscriptions[id] = f
-
-	return func() {
-		fc.subscriptionLock.Lock()
-		defer fc.subscriptionLock.Unlock()
-		delete(fc.subscriptions, id)
-	}
+	values := fc.values.Load().(ConfigValueMap)
+	return values[key.Lower()]
 }
 
 func (fc *fileBasedClient) init() error {
@@ -165,7 +125,7 @@ func (fc *fileBasedClient) Update() error {
 		return fmt.Errorf("dynamic config file: %s: %w", fc.config.Filepath, err)
 	}
 
-	newValues, lr := loadFile(contents)
+	lr := LoadYamlFile(contents)
 	for _, e := range lr.Errors {
 		fc.logger.Warn("dynamic config error", tag.Error(e))
 	}
@@ -177,72 +137,13 @@ func (fc *fileBasedClient) Update() error {
 			len(lr.Errors), len(lr.Warnings))
 	}
 
-	prev := fc.values.Swap(newValues)
-	oldValues, _ := prev.(configValueMap)
-	changedMap := fc.diffAndLog(oldValues, newValues)
+	prev := fc.values.Swap(lr.Map)
+	oldValues, _ := prev.(ConfigValueMap)
+	changedMap := DiffAndLogConfigs(fc.logger, oldValues, lr.Map)
 	fc.logger.Info("Updated dynamic config")
 
-	if len(changedMap) == 0 {
-		return nil
-	}
-
-	fc.subscriptionLock.Lock()
-	subscriptions := expmaps.Values(fc.subscriptions)
-	fc.subscriptionLock.Unlock()
-
-	for _, update := range subscriptions {
-		update(changedMap)
-	}
-
+	fc.PublishUpdates(changedMap)
 	return nil
-}
-
-func loadFile(contents []byte) (configValueMap, *LoadResult) {
-	lr := &LoadResult{}
-
-	var yamlValues map[string][]struct {
-		Constraints map[string]any
-		Value       any
-	}
-	if err := yaml.Unmarshal(contents, &yamlValues); err != nil {
-		return nil, lr.errorf("decode error: %w", err)
-	}
-
-	newValues := make(configValueMap, len(yamlValues))
-	for key, yamlCV := range yamlValues {
-		precedence := PrecedenceUnknown
-		setting := queryRegistry(Key(key))
-		if setting == nil {
-			lr.warnf("unregistered key %q", key)
-		} else {
-			precedence = setting.Precedence()
-		}
-
-		cvs := make([]ConstrainedValue, len(yamlCV))
-		for i, cv := range yamlCV {
-			// yaml will unmarshal map into map[interface{}]interface{} instead of map[string]interface{}
-			// manually convert key type to string for all values here
-			val, err := convertKeyTypeToString(cv.Value)
-			if err != nil {
-				lr.error(err)
-				continue
-			}
-
-			// try validating if known setting
-			if setting != nil {
-				if valErr := setting.Validate(val); valErr != nil {
-					// TODO: raise this to error level
-					lr.warnf("validation failed: key %q value %v: %w", key, cv.Value, valErr)
-				}
-			}
-
-			cvs[i].Value = val
-			cvs[i].Constraints = convertYamlConstraints(key, cv.Constraints, precedence, lr)
-		}
-		newValues[strings.ToLower(key)] = cvs
-	}
-
-	return newValues, lr
 }
 
 func (fc *fileBasedClient) validateStaticConfig(config *FileBasedClientConfig) error {
@@ -258,244 +159,6 @@ func (fc *fileBasedClient) validateStaticConfig(config *FileBasedClientConfig) e
 	return nil
 }
 
-func (fc *fileBasedClient) diffAndLog(old configValueMap, new configValueMap) map[Key][]ConstrainedValue {
-	changedMap := make(map[Key][]ConstrainedValue)
-
-	for key, newValues := range new {
-		oldValues, ok := old[key]
-		if !ok {
-			for _, newValue := range newValues {
-				// new key added
-				fc.diffAndLogValue(key, nil, &newValue)
-			}
-			changedMap[Key(key)] = newValues
-		} else {
-			// compare existing keys
-			changed := fc.diffAndLogConstraints(key, oldValues, newValues)
-			if changed {
-				changedMap[Key(key)] = newValues
-			}
-		}
-	}
-
-	// check for removed values
-	for key, oldValues := range old {
-		if _, ok := new[key]; !ok {
-			for _, oldValue := range oldValues {
-				fc.diffAndLogValue(key, &oldValue, nil)
-			}
-			changedMap[Key(key)] = nil
-		}
-	}
-
-	return changedMap
-}
-
-func (fc *fileBasedClient) diffAndLogConstraints(key string, oldValues []ConstrainedValue, newValues []ConstrainedValue) bool {
-	changed := false
-	for _, oldValue := range oldValues {
-		matchFound := false
-		for _, newValue := range newValues {
-			if oldValue.Constraints == newValue.Constraints {
-				matchFound = true
-				if !reflect.DeepEqual(oldValue.Value, newValue.Value) {
-					fc.diffAndLogValue(key, &oldValue, &newValue)
-					changed = true
-				}
-			}
-		}
-		if !matchFound {
-			fc.diffAndLogValue(key, &oldValue, nil)
-			changed = true
-		}
-	}
-
-	for _, newValue := range newValues {
-		matchFound := false
-		for _, oldValue := range oldValues {
-			if oldValue.Constraints == newValue.Constraints {
-				matchFound = true
-			}
-		}
-		if !matchFound {
-			fc.diffAndLogValue(key, nil, &newValue)
-			changed = true
-		}
-	}
-	return changed
-}
-
-func (fc *fileBasedClient) diffAndLogValue(key string, oldValue *ConstrainedValue, newValue *ConstrainedValue) {
-	logLine := &strings.Builder{}
-	logLine.Grow(128)
-	logLine.WriteString("dynamic config changed for the key: ")
-	logLine.WriteString(key)
-	logLine.WriteString(" oldValue: ")
-	fc.appendConstrainedValue(logLine, oldValue)
-	logLine.WriteString(" newValue: ")
-	fc.appendConstrainedValue(logLine, newValue)
-	fc.logger.Info(logLine.String())
-}
-
-func (fc *fileBasedClient) appendConstrainedValue(logLine *strings.Builder, value *ConstrainedValue) {
-	if value == nil {
-		logLine.WriteString("nil")
-	} else {
-		logLine.WriteString("{ constraints: {")
-		if value.Constraints.Namespace != "" {
-			logLine.WriteString(fmt.Sprintf("{Namespace:%s}", value.Constraints.Namespace))
-		}
-		if value.Constraints.NamespaceID != "" {
-			logLine.WriteString(fmt.Sprintf("{NamespaceID:%s}", value.Constraints.NamespaceID))
-		}
-		if value.Constraints.TaskQueueName != "" {
-			logLine.WriteString(fmt.Sprintf("{TaskQueueName:%s}", value.Constraints.TaskQueueName))
-		}
-		if value.Constraints.TaskQueueType != enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
-			logLine.WriteString(fmt.Sprintf("{TaskQueueType:%s}", value.Constraints.TaskQueueType))
-		}
-		if value.Constraints.ShardID != 0 {
-			logLine.WriteString(fmt.Sprintf("{ShardID:%d}", value.Constraints.ShardID))
-		}
-		if value.Constraints.TaskType != enumsspb.TASK_TYPE_UNSPECIFIED {
-			logLine.WriteString(fmt.Sprintf("{HistoryTaskType:%s}", value.Constraints.TaskType))
-		}
-		if value.Constraints.Destination != "" {
-			logLine.WriteString(fmt.Sprintf("{Destination:%s}", value.Constraints.Destination))
-		}
-		logLine.WriteString(fmt.Sprint("} value: ", value.Value, " }"))
-	}
-}
-
-func convertKeyTypeToString(v interface{}) (interface{}, error) {
-	switch v := v.(type) {
-	case map[interface{}]interface{}:
-		return convertKeyTypeToStringMap(v)
-	case []interface{}:
-		return convertKeyTypeToStringSlice(v)
-	default:
-		return v, nil
-	}
-}
-
-func convertKeyTypeToStringMap(m map[interface{}]interface{}) (map[string]interface{}, error) {
-	stringKeyMap := make(map[string]interface{})
-	for key, value := range m {
-		stringKey, ok := key.(string)
-		if !ok {
-			return nil, fmt.Errorf("type of key %v is not string", key)
-		}
-		convertedValue, err := convertKeyTypeToString(value)
-		if err != nil {
-			return nil, err
-		}
-		stringKeyMap[stringKey] = convertedValue
-	}
-	return stringKeyMap, nil
-}
-
-func convertKeyTypeToStringSlice(s []interface{}) ([]interface{}, error) {
-	stringKeySlice := make([]interface{}, len(s))
-	for idx, value := range s {
-		convertedValue, err := convertKeyTypeToString(value)
-		if err != nil {
-			return nil, err
-		}
-		stringKeySlice[idx] = convertedValue
-	}
-	return stringKeySlice, nil
-}
-
-func convertYamlConstraints(key string, m map[string]any, precedence Precedence, lr *LoadResult) Constraints {
-	var cs Constraints
-	for k, v := range m {
-		validConstraint := true
-		switch strings.ToLower(k) {
-		case "namespace":
-			if v, ok := v.(string); ok {
-				cs.Namespace = v
-			} else {
-				lr.errorf("namespace constraint must be string")
-			}
-			validConstraint = precedence == PrecedenceNamespace || precedence == PrecedenceTaskQueue || precedence == PrecedenceDestination
-		case "namespaceid":
-			if v, ok := v.(string); ok {
-				cs.NamespaceID = v
-			} else {
-				lr.errorf("namespaceID constraint must be string")
-			}
-			validConstraint = precedence == PrecedenceNamespaceID
-		case "taskqueuename":
-			if v, ok := v.(string); ok {
-				cs.TaskQueueName = v
-			} else {
-				lr.errorf("taskQueueName constraint must be string")
-			}
-			validConstraint = precedence == PrecedenceTaskQueue
-		case "tasktype":
-			switch v := v.(type) {
-			case string:
-				i, err := enumspb.TaskQueueTypeFromString(v)
-				if err != nil {
-					lr.errorf("invalid value for taskType: %w", err)
-				} else if i <= enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
-					lr.errorf("taskType constraint must be Workflow/Activity")
-				}
-				cs.TaskQueueType = i
-			case int:
-				if v > int(enumspb.TASK_QUEUE_TYPE_UNSPECIFIED) {
-					cs.TaskQueueType = enumspb.TaskQueueType(v)
-				} else {
-					lr.errorf("taskType constraint must be Workflow/Activity")
-				}
-			default:
-				lr.errorf("taskType constraint must be Workflow/Activity")
-			}
-			validConstraint = precedence == PrecedenceTaskQueue
-		case "historytasktype":
-			switch v := v.(type) {
-			case string:
-				tt, err := enumsspb.TaskTypeFromString(v)
-				if err != nil {
-					lr.errorf("invalid value for historytasktype constraint: %w", err)
-				} else if tt <= enumsspb.TASK_TYPE_UNSPECIFIED {
-					lr.errorf("historytasktype %s constraint is not supported", v)
-				}
-				cs.TaskType = tt
-			case int:
-				cs.TaskType = enumsspb.TaskType(v)
-			default:
-				lr.errorf("historytasktype %T constraint is not supported", v)
-			}
-			validConstraint = precedence == PrecedenceTaskType
-		case "shardid":
-			if v, ok := v.(int); ok {
-				cs.ShardID = int32(v)
-			} else {
-				lr.errorf("shardID constraint must be integer")
-			}
-			validConstraint = precedence == PrecedenceShardID
-		case "destination":
-			if v, ok := v.(string); ok {
-				cs.Destination = v
-			} else {
-				lr.errorf("destination constraint must be string")
-			}
-			validConstraint = precedence == PrecedenceDestination
-		default:
-			lr.errorf("unknown constraint type %q", k)
-		}
-
-		// don't log error for PrecedenceUnknown, we would already have logged for an
-		// unregistered key above
-		// TODO: raise this to error level
-		if !validConstraint && precedence != PrecedenceUnknown {
-			lr.warnf("constraint %q isn't valid for dynamic config key %q", k, key)
-		}
-	}
-	return cs
-}
-
 func (r *osReader) ReadFile() ([]byte, error) {
 	return os.ReadFile(r.path)
 }
@@ -506,22 +169,4 @@ func (r *osReader) GetModTime() (time.Time, error) {
 		return time.Time{}, err
 	}
 	return fi.ModTime(), nil
-}
-
-func (lr *LoadResult) warn(err error) *LoadResult {
-	lr.Warnings = append(lr.Warnings, err)
-	return lr
-}
-
-func (lr *LoadResult) warnf(format string, args ...any) *LoadResult {
-	return lr.warn(fmt.Errorf(format, args...))
-}
-
-func (lr *LoadResult) error(err error) *LoadResult {
-	lr.Errors = append(lr.Errors, err)
-	return lr
-}
-
-func (lr *LoadResult) errorf(format string, args ...any) *LoadResult {
-	return lr.error(fmt.Errorf(format, args...))
 }

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -543,7 +543,7 @@ testGetFloat64PropertyKey:
 func (s *fileBasedClientSuite) TestWarnUnregisteredKey() {
 	dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 0, "")
 
-	lr := dynamicconfig.ValidateFile([]byte(`
+	lr := dynamicconfig.LoadYamlFile([]byte(`
 testGetIntPropertyKey:
 - value: 2000
 testGetFloat64PropertyKey:
@@ -557,7 +557,7 @@ testGetFloat64PropertyKey:
 func (s *fileBasedClientSuite) TestWarnValidationInt() {
 	dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 0, "")
 
-	lr := dynamicconfig.ValidateFile([]byte(`
+	lr := dynamicconfig.LoadYamlFile([]byte(`
 testGetIntPropertyKey:
 - value: not a number
 `))
@@ -569,7 +569,7 @@ testGetIntPropertyKey:
 func (s *fileBasedClientSuite) TestWarnConstraint() {
 	dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 0, "")
 
-	lr := dynamicconfig.ValidateFile([]byte(`
+	lr := dynamicconfig.LoadYamlFile([]byte(`
 testGetIntPropertyKey:
 - value: 5005
   constraints:
@@ -583,7 +583,7 @@ testGetIntPropertyKey:
 func (s *fileBasedClientSuite) TestWarnMultiple() {
 	dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 0, "")
 
-	lr := dynamicconfig.ValidateFile([]byte(`
+	lr := dynamicconfig.LoadYamlFile([]byte(`
 unknownKey:
 - value: "5d"
 testGetIntPropertyKey:
@@ -596,7 +596,7 @@ testGetIntPropertyKey:
 }
 
 func (s *fileBasedClientSuite) TestErrorYamlDecode() {
-	lr := dynamicconfig.ValidateFile([]byte(`}}}}}}}}}`))
+	lr := dynamicconfig.LoadYamlFile([]byte(`}}}}}}}}}`))
 	s.Equal(1, len(lr.Errors))
 	s.ErrorContains(lr.Errors[0], "decode error")
 }
@@ -604,7 +604,7 @@ func (s *fileBasedClientSuite) TestErrorYamlDecode() {
 func (s *fileBasedClientSuite) TestErrorBadConstraint() {
 	dynamicconfig.NewNamespaceBoolSetting(testGetBoolPropertyKey, true, "")
 
-	lr := dynamicconfig.ValidateFile([]byte(`
+	lr := dynamicconfig.LoadYamlFile([]byte(`
 testGetBoolPropertyKey:
 - value: false
   constraints:
@@ -617,7 +617,7 @@ testGetBoolPropertyKey:
 func (s *fileBasedClientSuite) TestErrorBadConstraints() {
 	dynamicconfig.NewTaskQueueBoolSetting(testGetBoolPropertyKey, true, "")
 
-	lr := dynamicconfig.ValidateFile([]byte(`
+	lr := dynamicconfig.LoadYamlFile([]byte(`
 testGetBoolPropertyKey:
 - value: false
   constraints:

--- a/common/dynamicconfig/registry.go
+++ b/common/dynamicconfig/registry.go
@@ -2,13 +2,12 @@ package dynamicconfig
 
 import (
 	"fmt"
-	"strings"
 	"sync/atomic"
 )
 
 type (
 	registry struct {
-		settings map[string]GenericSetting
+		settings map[Key]GenericSetting
 		queried  atomic.Bool
 	}
 )
@@ -22,20 +21,20 @@ func register(s GenericSetting) {
 		panic("dynamicconfig.New*Setting must only be called from static initializers")
 	}
 	if globalRegistry.settings == nil {
-		globalRegistry.settings = make(map[string]GenericSetting)
+		globalRegistry.settings = make(map[Key]GenericSetting)
 	}
-	keyStr := strings.ToLower(s.Key().String())
-	if globalRegistry.settings[keyStr] != nil {
-		panic(fmt.Sprintf("duplicate registration of dynamic config key: %q", keyStr))
+	lowerKey := s.Key().Lower()
+	if globalRegistry.settings[lowerKey] != nil {
+		panic(fmt.Sprintf("duplicate registration of dynamic config key: %q", lowerKey))
 	}
-	globalRegistry.settings[keyStr] = s
+	globalRegistry.settings[lowerKey] = s
 }
 
 func queryRegistry(k Key) GenericSetting {
 	if !globalRegistry.queried.Load() {
 		globalRegistry.queried.Store(true)
 	}
-	return globalRegistry.settings[strings.ToLower(k.String())]
+	return globalRegistry.settings[k.Lower()]
 }
 
 // For testing only; do not call from regular code!

--- a/common/dynamicconfig/yaml_loader.go
+++ b/common/dynamicconfig/yaml_loader.go
@@ -1,0 +1,255 @@
+package dynamicconfig
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	"gopkg.in/yaml.v3"
+)
+
+type (
+	ConfigValueMap map[Key][]ConstrainedValue
+
+	// YamlLoader loads files and individual values from yaml files.
+	// Intended usage is to create a YamlLoader and call LoadFile or LoadValue.
+	// The parsed values will be placed in Map (initialized if nil).
+	// You can place your own map in Map before calling LoadFile/LoadValue if desired.
+	//
+	// Any warnings or errors encountered during parsing will be added to Warnings or Errors.
+	// Warnings should be reported but not block using the new values.
+	// Errors should abort the loading process.
+	YamlLoader struct {
+		Map      ConfigValueMap
+		Warnings []error
+		Errors   []error
+	}
+
+	yamlConstrainedValue []struct {
+		Constraints map[string]any
+		Value       any
+	}
+)
+
+// LoadYamlFile is a convenience function to create a YamlLoader and call LoadFile.
+func LoadYamlFile(contents []byte) *YamlLoader {
+	var lr YamlLoader
+	lr.LoadFile(contents)
+	return &lr
+}
+
+// Err returns a joined error of lr.Errors.
+func (lr *YamlLoader) Err() error {
+	return errors.Join(lr.Errors...)
+}
+
+// LoadFile parses and processes the given file contents into lr.Map (initialized if nil).
+func (lr *YamlLoader) LoadFile(contents []byte) {
+	var yamlValues map[string]yamlConstrainedValue
+	if err := yaml.Unmarshal(contents, &yamlValues); err != nil {
+		lr.errorf("decode error: %w", err)
+		return
+	}
+
+	if lr.Map == nil {
+		lr.Map = make(ConfigValueMap, len(yamlValues))
+	}
+
+	for key, yamlCV := range yamlValues {
+		lr.add(Key(key), yamlCV)
+	}
+}
+
+// LoadValue parses and processes the given single value into lr.Map (initialized if nil).
+func (lr *YamlLoader) LoadValue(key Key, contents []byte) {
+	var yamlCV yamlConstrainedValue
+	if err := yaml.Unmarshal(contents, &yamlCV); err != nil {
+		lr.errorf("decode error: %w", err)
+		return
+	}
+
+	if lr.Map == nil {
+		lr.Map = make(ConfigValueMap)
+	}
+	lr.add(key, yamlCV)
+}
+
+func (lr *YamlLoader) add(key Key, yamlCV yamlConstrainedValue) {
+	precedence := PrecedenceUnknown
+	setting := queryRegistry(key)
+	if setting == nil {
+		lr.warnf("unregistered key %q", key)
+	} else {
+		precedence = setting.Precedence()
+	}
+
+	cvs := make([]ConstrainedValue, len(yamlCV))
+	for i, cv := range yamlCV {
+		// yaml will unmarshal map into map[interface{}]interface{} instead of map[string]interface{}
+		// manually convert key type to string for all values here
+		val, err := convertKeyTypeToString(cv.Value)
+		if err != nil {
+			lr.error(err)
+			continue
+		}
+
+		// try validating if known setting
+		if setting != nil {
+			if valErr := setting.Validate(val); valErr != nil {
+				// TODO: raise this to error level
+				lr.warnf("validation failed: key %q value %v: %w", key, cv.Value, valErr)
+			}
+		}
+
+		cvs[i].Value = val
+		cvs[i].Constraints = convertYamlConstraints(key, cv.Constraints, precedence, lr)
+	}
+	lr.Map[key.Lower()] = cvs
+}
+
+func (lr *YamlLoader) warn(err error) {
+	lr.Warnings = append(lr.Warnings, err)
+}
+
+func (lr *YamlLoader) warnf(format string, args ...any) {
+	lr.warn(fmt.Errorf(format, args...))
+}
+
+func (lr *YamlLoader) error(err error) {
+	lr.Errors = append(lr.Errors, err)
+}
+
+func (lr *YamlLoader) errorf(format string, args ...any) {
+	lr.error(fmt.Errorf(format, args...))
+}
+
+func convertKeyTypeToString(v interface{}) (interface{}, error) {
+	switch v := v.(type) {
+	case map[interface{}]interface{}:
+		return convertKeyTypeToStringMap(v)
+	case []interface{}:
+		return convertKeyTypeToStringSlice(v)
+	default:
+		return v, nil
+	}
+}
+
+func convertKeyTypeToStringMap(m map[interface{}]interface{}) (map[string]interface{}, error) {
+	stringKeyMap := make(map[string]interface{})
+	for key, value := range m {
+		stringKey, ok := key.(string)
+		if !ok {
+			return nil, fmt.Errorf("type of key %v is not string", key)
+		}
+		convertedValue, err := convertKeyTypeToString(value)
+		if err != nil {
+			return nil, err
+		}
+		stringKeyMap[stringKey] = convertedValue
+	}
+	return stringKeyMap, nil
+}
+
+func convertKeyTypeToStringSlice(s []interface{}) ([]interface{}, error) {
+	stringKeySlice := make([]interface{}, len(s))
+	for idx, value := range s {
+		convertedValue, err := convertKeyTypeToString(value)
+		if err != nil {
+			return nil, err
+		}
+		stringKeySlice[idx] = convertedValue
+	}
+	return stringKeySlice, nil
+}
+
+func convertYamlConstraints(key Key, m map[string]any, precedence Precedence, lr *YamlLoader) Constraints {
+	var cs Constraints
+	for k, v := range m {
+		validConstraint := true
+		switch strings.ToLower(k) {
+		case "namespace":
+			if v, ok := v.(string); ok {
+				cs.Namespace = v
+			} else {
+				lr.errorf("namespace constraint must be string")
+			}
+			validConstraint = precedence == PrecedenceNamespace || precedence == PrecedenceTaskQueue || precedence == PrecedenceDestination
+		case "namespaceid":
+			if v, ok := v.(string); ok {
+				cs.NamespaceID = v
+			} else {
+				lr.errorf("namespaceID constraint must be string")
+			}
+			validConstraint = precedence == PrecedenceNamespaceID
+		case "taskqueuename":
+			if v, ok := v.(string); ok {
+				cs.TaskQueueName = v
+			} else {
+				lr.errorf("taskQueueName constraint must be string")
+			}
+			validConstraint = precedence == PrecedenceTaskQueue
+		case "tasktype":
+			switch v := v.(type) {
+			case string:
+				i, err := enumspb.TaskQueueTypeFromString(v)
+				if err != nil {
+					lr.errorf("invalid value for taskType: %w", err)
+				} else if i <= enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
+					lr.errorf("taskType constraint must be Workflow/Activity")
+				}
+				cs.TaskQueueType = i
+			case int:
+				if v > int(enumspb.TASK_QUEUE_TYPE_UNSPECIFIED) {
+					cs.TaskQueueType = enumspb.TaskQueueType(v)
+				} else {
+					lr.errorf("taskType constraint must be Workflow/Activity")
+				}
+			default:
+				lr.errorf("taskType constraint must be Workflow/Activity")
+			}
+			validConstraint = precedence == PrecedenceTaskQueue
+		case "historytasktype":
+			switch v := v.(type) {
+			case string:
+				tt, err := enumsspb.TaskTypeFromString(v)
+				if err != nil {
+					lr.errorf("invalid value for historytasktype constraint: %w", err)
+				} else if tt <= enumsspb.TASK_TYPE_UNSPECIFIED {
+					lr.errorf("historytasktype %s constraint is not supported", v)
+				}
+				cs.TaskType = tt
+			case int:
+				cs.TaskType = enumsspb.TaskType(v)
+			default:
+				lr.errorf("historytasktype %T constraint is not supported", v)
+			}
+			validConstraint = precedence == PrecedenceTaskType
+		case "shardid":
+			if v, ok := v.(int); ok {
+				cs.ShardID = int32(v)
+			} else {
+				lr.errorf("shardID constraint must be integer")
+			}
+			validConstraint = precedence == PrecedenceShardID
+		case "destination":
+			if v, ok := v.(string); ok {
+				cs.Destination = v
+			} else {
+				lr.errorf("destination constraint must be string")
+			}
+			validConstraint = precedence == PrecedenceDestination
+		default:
+			lr.errorf("unknown constraint type %q", k)
+		}
+
+		// don't log error for PrecedenceUnknown, we would already have logged for an
+		// unregistered key above
+		// TODO: raise this to error level
+		if !validConstraint && precedence != PrecedenceUnknown {
+			lr.warnf("constraint %q isn't valid for dynamic config key %q", k, key)
+		}
+	}
+	return cs
+}


### PR DESCRIPTION
## What changed?
Pull out parts of FileBasedConfig to make them reusable.

## Why?
Make it easier to build other Clients.

## How did you test it?
- [x] built
- [x] covered by existing tests
