### PR TITLE
Task Queue Fairness Rate Limit Implementation

### DIFF
--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -45,6 +45,7 @@ type (
 		MaxTaskQueueIdleTime                     dynamicconfig.DurationPropertyFnWithTaskQueueFilter
 		NumTaskqueueWritePartitions              dynamicconfig.IntPropertyFnWithTaskQueueFilter
 		NumTaskqueueReadPartitions               dynamicconfig.IntPropertyFnWithTaskQueueFilter
+		NumTaskqueueReadPartitionsSub            dynamicconfig.TypedSubscribableWithTaskQueueFilter[int]
 		BreakdownMetricsByTaskQueue              dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 		BreakdownMetricsByPartition              dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 		BreakdownMetricsByBuildID                dynamicconfig.BoolPropertyFnWithTaskQueueFilter
@@ -153,6 +154,7 @@ type (
 		MaxTaskBatchSize                func() int
 		NumWritePartitions              func() int
 		NumReadPartitions               func() int
+		NumReadPartitionsSub            func(func(int)) (int, func())
 
 		// partition qps = AdminNamespaceToPartitionDispatchRate(namespace)
 		AdminNamespaceToPartitionDispatchRate func() float64
@@ -252,6 +254,7 @@ func NewConfig(
 		ThrottledLogRPS:                          dynamicconfig.MatchingThrottledLogRPS.Get(dc),
 		NumTaskqueueWritePartitions:              dynamicconfig.MatchingNumTaskqueueWritePartitions.Get(dc),
 		NumTaskqueueReadPartitions:               dynamicconfig.MatchingNumTaskqueueReadPartitions.Get(dc),
+		NumTaskqueueReadPartitionsSub:            dynamicconfig.MatchingNumTaskqueueReadPartitions.Subscribe(dc),
 		BreakdownMetricsByTaskQueue:              dynamicconfig.MetricsBreakdownByTaskQueue.Get(dc),
 		BreakdownMetricsByPartition:              dynamicconfig.MetricsBreakdownByPartition.Get(dc),
 		BreakdownMetricsByBuildID:                dynamicconfig.MetricsBreakdownByBuildID.Get(dc),
@@ -379,6 +382,10 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		},
 		NumReadPartitions: func() int {
 			return max(1, config.NumTaskqueueReadPartitions(ns.String(), taskQueueName, taskType))
+		},
+		NumReadPartitionsSub: func(cb func(int)) (int, func()) {
+			val, cancel := config.NumTaskqueueReadPartitionsSub(ns.String(), taskQueueName, taskType, cb)
+			return max(1, val), cancel
 		},
 		BreakdownMetricsByTaskQueue: func() bool {
 			return config.BreakdownMetricsByTaskQueue(ns.String(), taskQueueName, taskType)

--- a/service/matching/matcher_data.go
+++ b/service/matching/matcher_data.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
-	"go.temporal.io/server/common/cache"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/softassert"
@@ -83,22 +82,6 @@ type taskPQ struct {
 	// note that matcherData may get tasks from multiple versioned backlogs due to
 	// versioning redirection.
 	ages backlogAgeTracker
-
-	// Rate limiter for overall queue
-	wholeQueueLimit simpleLimiterParams
-	wholeQueueReady simpleLimiter
-
-	// Rate limiter for individual fairness keys.
-	//
-	// Note that we currently have only one limit for all keys, which is scaled by the key's
-	// weight. If we do this, we can assume that all keys are either at or below their rate
-	// limit at the same time, so that if the head of the queue is at its limit, then the rest
-	// must also be, and so we don't have to "skip over" the head of the queue due to rate
-	// limits. This isn't true in situations where weights have changed in between writing and
-	// reading. We'll handle that situation better in the future.
-	perKeyLimit     simpleLimiterParams
-	perKeyOverrides fairnessWeightOverrides // TODO(fairness): get this from config
-	perKeyReady     cache.Cache
 }
 
 func (t *taskPQ) Add(task *internalTask) {
@@ -107,46 +90,6 @@ func (t *taskPQ) Add(task *internalTask) {
 
 func (t *taskPQ) Remove(task *internalTask) {
 	heap.Remove(t, task.matchHeapIndex)
-}
-
-func (t *taskPQ) readyTimeForTask(task *internalTask) simpleLimiter {
-	// TODO(pri): after we have task-specific ready time, we can re-enable this
-	// if task.isForwarded() {
-	// 	// don't count any rate limit for forwarded tasks, it was counted on the child
-	// 	return 0
-	// }
-	ready := t.wholeQueueReady
-
-	if t.perKeyLimit.limited() {
-		key := task.getPriority().GetFairnessKey()
-		if v := t.perKeyReady.Get(key); v != nil {
-			ready = max(ready, v.(simpleLimiter))
-		}
-	}
-
-	return ready
-}
-
-func (t *taskPQ) consumeTokens(now int64, task *internalTask, tokens int64) {
-	if task.isForwarded() {
-		// don't count any rate limit for forwarded tasks, it was counted on the child
-		return
-	}
-
-	t.wholeQueueReady = t.wholeQueueReady.consume(t.wholeQueueLimit, now, tokens)
-
-	if t.perKeyLimit.limited() {
-		pri := task.getPriority()
-		key := pri.GetFairnessKey()
-		weight := getEffectiveWeight(t.perKeyOverrides, pri)
-		p := t.perKeyLimit
-		p.interval = time.Duration(float32(p.interval) / weight) // scale by weight
-		var sl simpleLimiter
-		if v := t.perKeyReady.Get(key); v != nil {
-			sl = v.(simpleLimiter) // nolint:revive
-		}
-		t.perKeyReady.Put(key, sl.consume(p, now, tokens))
-	}
 }
 
 // implements heap.Interface
@@ -268,6 +211,7 @@ type matcherData struct {
 
 	rateLimitTimer         resettableTimer
 	reconsiderForwardTimer resettableTimer
+	rateLimitManager       *rateLimitManager
 
 	// waiting pollers and tasks
 	// invariant: all pollers and tasks in these data structures have matchResult == nil
@@ -277,58 +221,16 @@ type matcherData struct {
 	lastPoller time.Time // most recent poll start time
 }
 
-func newMatcherData(config *taskQueueConfig, logger log.Logger, timeSource clock.TimeSource, canForward bool) matcherData {
+func newMatcherData(config *taskQueueConfig, logger log.Logger, timeSource clock.TimeSource, canForward bool, rateLimitManager *rateLimitManager) matcherData {
 	return matcherData{
 		config:     config,
 		logger:     logger,
 		timeSource: timeSource,
 		canForward: canForward,
 		tasks: taskPQ{
-			ages:        newBacklogAgeTracker(),
-			perKeyReady: cache.New(config.FairnessKeyRateLimitCacheSize(), nil),
+			ages: newBacklogAgeTracker(),
 		},
-	}
-}
-
-func (d *matcherData) UpdateRateLimit(rate float64, burstDuration time.Duration) {
-	d.lock.Lock()
-	defer d.lock.Unlock()
-
-	d.tasks.wholeQueueLimit = makeSimpleLimiterParams(rate, burstDuration)
-
-	// Clip to handle the case where we have increased from a zero or very low limit and had
-	// ready times in the far future.
-	now := d.timeSource.Now().UnixNano()
-	d.tasks.wholeQueueReady = d.tasks.wholeQueueReady.clip(d.tasks.wholeQueueLimit, now, maxTokens)
-}
-
-func (d *matcherData) UpdatePerKeyRateLimit(rate float64, burstDuration time.Duration) {
-	d.lock.Lock()
-	defer d.lock.Unlock()
-
-	d.tasks.perKeyLimit = makeSimpleLimiterParams(rate, burstDuration)
-
-	// Clip to handle the case where we have increased from a zero or very low limit and had
-	// ready times in the far future.
-	var updates map[string]simpleLimiter
-	now := d.timeSource.Now().UnixNano()
-	it := d.tasks.perKeyReady.Iterator()
-	for it.HasNext() {
-		e := it.Next()
-		sl := e.Value().(simpleLimiter) //nolint:revive
-		if clipped := sl.clip(d.tasks.perKeyLimit, now, maxTokens); clipped != sl {
-			if updates == nil {
-				updates = make(map[string]simpleLimiter)
-			}
-			updates[e.Key().(string)] = clipped
-		}
-	}
-	it.Close()
-
-	// This messes up the LRU order, but we can't avoid that here without adding new
-	// functionality to Cache.
-	for key, clipped := range updates {
-		d.tasks.perKeyReady.Put(key, clipped)
+		rateLimitManager: rateLimitManager,
 	}
 }
 
@@ -550,7 +452,9 @@ func (d *matcherData) findAndWakeMatches() {
 		}
 
 		// check ready time
-		delay := d.tasks.readyTimeForTask(task).delay(now)
+		d.rateLimitManager.mu.Lock()
+		delay := d.rateLimitManager.readyTimeForTask(task).delay(now)
+		d.rateLimitManager.mu.Unlock()
 		d.rateLimitTimer.set(d.timeSource, d.rematchAfterTimer, delay)
 		if delay > 0 {
 			return // not ready yet, timer will call match later
@@ -561,7 +465,7 @@ func (d *matcherData) findAndWakeMatches() {
 		d.pollers.Remove(poller)
 
 		// TODO(pri): maybe we can allow tasks to have costs other than 1
-		d.tasks.consumeTokens(now, task, 1)
+		d.rateLimitManager.consumeTokens(now, task, 1)
 		task.recycleToken = d.recycleToken
 
 		res := &matchResult{task: task, poller: poller}
@@ -582,7 +486,7 @@ func (d *matcherData) recycleToken(task *internalTask) {
 	defer d.lock.Unlock()
 
 	now := d.timeSource.Now().UnixNano()
-	d.tasks.consumeTokens(now, task, -1)
+	d.rateLimitManager.consumeTokens(now, task, -1)
 	d.findAndWakeMatches() // another task may be ready to match now
 }
 

--- a/service/matching/matcher_data_test.go
+++ b/service/matching/matcher_data_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
@@ -46,7 +47,16 @@ func (s *MatcherDataSuite) SetupTest() {
 	logger := testlogger.NewTestLogger(s.T(), testlogger.FailOnAnyUnexpectedError)
 	s.ts = clock.NewEventTimeSource().Update(time.Now())
 	s.ts.UseAsyncTimers(true)
-	s.md = newMatcherData(cfg, logger, s.ts, true)
+	userData := &persistencespb.TaskQueueUserData{}
+	setRPSForTaskQueueUserData(userData, enumspb.TASK_QUEUE_TYPE_ACTIVITY, 10.0)
+	mockUDM := &mockUserDataManager{
+		data: &persistencespb.VersionedTaskQueueUserData{
+			Data:    userData,
+			Version: 1,
+		},
+	}
+	rateLimitManager := newRateLimitManager(mockUDM, cfg, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+	s.md = newMatcherData(cfg, logger, s.ts, true, rateLimitManager)
 }
 
 func (s *MatcherDataSuite) now() time.Time {
@@ -310,9 +320,38 @@ func (s *MatcherDataSuite) TestTaskForward() {
 	s.ErrorIs(fres.forwardErr, someError)
 }
 
+// Sets both QueueRateLimit and FairnessKeysRateLimitDefault for the given task queue type
+func setRPSForTaskQueueUserData(
+	userData *persistencespb.TaskQueueUserData,
+	taskQueueType enumspb.TaskQueueType,
+	rps float32,
+) {
+	if userData.PerType == nil {
+		userData.PerType = make(map[int32]*persistencespb.TaskQueueTypeUserData)
+	}
+
+	key := int32(taskQueueType)
+	if userData.PerType[key] == nil {
+		userData.PerType[key] = &persistencespb.TaskQueueTypeUserData{}
+	}
+
+	tqTypeData := userData.PerType[key]
+	if tqTypeData.Config == nil {
+		tqTypeData.Config = &taskqueuepb.TaskQueueConfig{}
+	}
+
+	rateLimit := &taskqueuepb.RateLimit{RequestsPerSecond: rps}
+	rateLimitConfig := &taskqueuepb.RateLimitConfig{RateLimit: rateLimit}
+
+	tqTypeData.Config.QueueRateLimit = rateLimitConfig
+	tqTypeData.Config.FairnessKeysRateLimitDefault = rateLimitConfig
+}
+
 func (s *MatcherDataSuite) TestRateLimitedBacklog() {
+	s.md.rateLimitManager.mu.Lock()
 	// 10 tasks/sec with burst of 3
-	s.md.UpdateRateLimit(10, 300*time.Millisecond)
+	s.md.rateLimitManager.updateSimpleRateLimitLocked(300 * time.Millisecond)
+	s.md.rateLimitManager.mu.Unlock()
 
 	// register some backlog with old tasks
 	for i := range 100 {
@@ -351,8 +390,9 @@ func (s *MatcherDataSuite) TestRateLimitedBacklog() {
 
 func (s *MatcherDataSuite) TestPerKeyRateLimit() {
 	// 10 tasks/key/sec with burst of 3
-	s.md.UpdatePerKeyRateLimit(10, 300*time.Millisecond)
-
+	s.md.rateLimitManager.mu.Lock()
+	s.md.rateLimitManager.updatePerKeySimpleRateLimitLocked(300 * time.Millisecond)
+	s.md.rateLimitManager.mu.Unlock()
 	// register some backlog with three keys
 	keys := []string{"key1", "key2", "key3"}
 	for i := range 300 {
@@ -656,7 +696,8 @@ func FuzzMatcherData(f *testing.F) {
 		ts := clock.NewEventTimeSource()
 		ts.UseAsyncTimers(true)
 		logger := log.NewNoopLogger()
-		md := newMatcherData(cfg, logger, ts, true)
+		rateLimitManager := newRateLimitManager(&mockUserDataManager{}, cfg, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+		md := newMatcherData(cfg, logger, ts, true, rateLimitManager)
 
 		next := func() int {
 			if len(tape) == 0 {

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -1014,6 +1014,10 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 	dbq := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 	mgr := s.newPartitionManager(dbq.partition, s.matchingEngine.config)
 
+	// Set the admin namespace and task queue dispatch rates to 25000.0 to enforce the override of the dynamic config.
+	mgr.GetRateLimitManager().adminNsRate = 25000.0
+	mgr.GetRateLimitManager().adminTqRate = 25000.0
+
 	s.matchingEngine.updateTaskQueue(dbq.partition, mgr)
 	mgr.Start()
 

--- a/service/matching/ratelimit_manager.go
+++ b/service/matching/ratelimit_manager.go
@@ -3,8 +3,11 @@ package matching
 import (
 	"math"
 	"sync"
+	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/cache"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/quotas"
 )
 
@@ -17,9 +20,15 @@ type (
 		userDataManager userDataManager         // User data manager to fetch user data for task queue configurations.
 		workerRPS       *float64                // RPS set by worker at the time of polling, if available.
 		apiConfigRPS    *float64                // RPS set via API, if available.
+		fairnessRPS     *float64                // fairnessKeyRateLimitDefault set via API, if available
 		systemRPS       float64                 // Min of partition level dispatch rates times the number of read partitions.
 		config          *taskQueueConfig        // Dynamic configuration for task queues set by system.
 		taskQueueType   enumspb.TaskQueueType   // Task queue type
+
+		timeSource        clock.TimeSource
+		adminNsRate       float64
+		adminTqRate       float64
+		numReadPartitions int
 
 		// dynamicRate is the dynamic rate & burst for rate limiter
 		dynamicRateBurst quotas.MutableRateBurst
@@ -27,7 +36,30 @@ type (
 		dynamicRateLimiter *quotas.DynamicRateLimiterImpl
 		// forceRefreshRateOnce is used to force refresh rate limit for first time
 		forceRefreshRateOnce sync.Once
+
+		// Fairness tasks rate limiter.
+		wholeQueueLimit simpleLimiterParams
+		wholeQueueReady simpleLimiter
+
+		// Rate limiter for individual fairness keys.
+		// Note that we currently have only one limit for all keys, which is scaled by the key's
+		// weight. If we do this, we can assume that all keys are either at or below their rate
+		// limit at the same time, so that if the head of the queue is at its limit, then the rest
+		// must also be, and so we don't have to "skip over" the head of the queue due to rate
+		// limits. This isn't true in situations where weights have changed in between writing and
+		// reading. We'll handle that situation better in the future.
+		perKeyLimit               simpleLimiterParams
+		perKeyReady               cache.Cache
+		perKeyOverrides           fairnessWeightOverrides // TODO(fairness): get this from config
+		cancel1, cancel2, cancel3 func()
 	}
+)
+
+const (
+	// How much rate limit a task queue can use up in an instant. E.g., for a rate of
+	// 100/second and burst duration of 2 seconds, the capacity of a bucket-type limiting
+	// algorithm would be 200.
+	defaultBurstDuration = time.Second
 )
 
 // Create a new rate limit manager for the task queue partition.
@@ -39,6 +71,8 @@ func newRateLimitManager(userDataManager userDataManager,
 		userDataManager: userDataManager,
 		config:          config,
 		taskQueueType:   taskQueueType,
+		perKeyReady:     cache.New(config.FairnessKeyRateLimitCacheSize(), nil),
+		timeSource:      clock.NewRealTimeSource(),
 	}
 	r.dynamicRateBurst = quotas.NewMutableRateBurst(
 		defaultTaskDispatchRPS,
@@ -48,17 +82,35 @@ func newRateLimitManager(userDataManager userDataManager,
 		r.dynamicRateBurst,
 		config.RateLimiterRefreshInterval,
 	)
+	// Overall system rate limit will be the min of the two configs that are partition wise times the number of partions.
+	r.adminNsRate, r.cancel1 = config.AdminNamespaceToPartitionRateSub(r.setAdminNsRate)
+	r.adminTqRate, r.cancel2 = config.AdminNamespaceTaskQueueToPartitionRateSub(r.setAdminTqRate)
+	r.numReadPartitions, r.cancel3 = config.NumReadPartitionsSub(r.setNumReadPartitions)
 	r.computeEffectiveRPSAndSource()
 	return r
 }
 
-func (r *rateLimitManager) getNumberOfReadPartitions() float64 {
-	nPartitions := float64(r.config.NumReadPartitions())
-	if nPartitions <= 0 {
+func (r *rateLimitManager) setAdminNsRate(rps float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adminNsRate = rps
+}
+
+func (r *rateLimitManager) setAdminTqRate(rps float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adminTqRate = rps
+}
+
+func (r *rateLimitManager) setNumReadPartitions(val int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if val <= 0 {
 		// Defaulting to 1 partition if misconfigured
-		nPartitions = 1
+		r.numReadPartitions = 1
+	} else {
+		r.numReadPartitions = val
 	}
-	return nPartitions
 }
 
 func (r *rateLimitManager) computeEffectiveRPSAndSource() {
@@ -79,9 +131,9 @@ func (r *rateLimitManager) computeEffectiveRPSAndSourceLocked() {
 	)
 	// Overall system rate limit will be the min of the two configs that are partition wise times the number of partions.
 	systemRPS := min(
-		r.config.AdminNamespaceTaskQueueToPartitionDispatchRate(),
-		r.config.AdminNamespaceToPartitionDispatchRate(),
-	) * r.getNumberOfReadPartitions()
+		r.adminNsRate,
+		r.adminTqRate,
+	) * float64(r.numReadPartitions)
 	r.systemRPS = systemRPS
 	switch {
 	case r.apiConfigRPS != nil:
@@ -117,6 +169,7 @@ func (r *rateLimitManager) InjectWorkerRPS(meta *pollMetadata) {
 	// updateRatelimitLocked includes internal logic to determine if an update is needed,
 	// so calling it unconditionally is safe and avoids redundant updates.
 	r.updateRatelimitLocked()
+	r.updateSimpleRateLimitLocked(defaultBurstDuration)
 }
 
 // Return the effective RPS and its source together.
@@ -140,6 +193,10 @@ func (r *rateLimitManager) UserDataChanged() {
 	defer r.mu.Unlock()
 	// Immediately recompute and apply rate limit if necessary.
 	r.updateRatelimitLocked()
+	r.updateSimpleRateLimitLocked(defaultBurstDuration)
+	// UpdateTaskQueueConfig api is the single source for fairness per-key rate limit defaults.
+	// Fairness per-key rate limits are only updated upon updates to `fairnessKeyRateLimitDefault`.
+	r.updatePerKeySimpleRateLimitLocked(defaultBurstDuration)
 }
 
 // trySetRPSFromUserDataLocked sets the apiConfigRPS from user data.
@@ -154,30 +211,42 @@ func (r *rateLimitManager) trySetRPSFromUserDataLocked() {
 	}
 	// If rate limit is an empty message, it means rate limit could have been unset via API.
 	// In this case, the apiConfigRPS will need to be unset.
-	rateLimit := config.GetQueueRateLimit()
-	if rateLimit.GetRateLimit() == nil {
+	queueRateLimit := config.GetQueueRateLimit()
+	if queueRateLimit.GetRateLimit() == nil {
 		r.apiConfigRPS = nil
-		return
+	} else {
+		val := float64(queueRateLimit.GetRateLimit().GetRequestsPerSecond())
+		r.apiConfigRPS = &val
 	}
-	val := float64(rateLimit.GetRateLimit().GetRequestsPerSecond())
-	r.apiConfigRPS = &val
+	fairnessKeyRateLimitDefault := config.GetFairnessKeysRateLimitDefault()
+	if fairnessKeyRateLimitDefault.GetRateLimit() == nil {
+		r.fairnessRPS = nil
+	} else {
+		val := float64(fairnessKeyRateLimitDefault.GetRateLimit().GetRequestsPerSecond())
+		r.fairnessRPS = &val
+	}
 }
 
 // updateRatelimitLocked checks and updates the rate limit if changed.
 func (r *rateLimitManager) updateRatelimitLocked() {
 	// Always check for api configured rate limits before any update to the rate limits.
 	r.trySetRPSFromUserDataLocked()
-	oldRPS := r.effectiveRPS
+	oldRPS := r.effectiveRPS / float64(r.numReadPartitions)
 	r.computeEffectiveRPSAndSourceLocked()
-	newRPS := r.effectiveRPS
+	newRPS := r.effectiveRPS / float64(r.numReadPartitions)
 	if oldRPS == newRPS {
 		// No update required
 		return
 	}
-	effectiveRPSPartitionWise := r.effectiveRPS / r.getNumberOfReadPartitions()
-	burst := int(math.Ceil(effectiveRPSPartitionWise))
-	burst = max(burst, r.config.MinTaskThrottlingBurstSize())
-	r.dynamicRateBurst.SetRPS(effectiveRPSPartitionWise)
+	// If the effective RPS is zero, we set the burst to zero as well.
+	// This prevents any initial tasks from executing immediately.
+	// Allows pausing of the task queue by setting the RPS to zero.
+	var burst int
+	if newRPS != 0 {
+		// If the effective RPS is non-zero, we can set a burst based on the effective RPS.
+		burst = max(int(math.Ceil(newRPS)), r.config.MinTaskThrottlingBurstSize())
+	}
+	r.dynamicRateBurst.SetRPS(newRPS)
 	r.dynamicRateBurst.SetBurst(burst)
 	r.forceRefreshRateOnce.Do(func() {
 		// Dynamic rate limiter only refresh its rate every 1m. Before that initial 1m interval, it uses default rate
@@ -185,4 +254,121 @@ func (r *rateLimitManager) updateRatelimitLocked() {
 		// by poller. Only need to do that once. If the rate change later, it will be refresh in 1m.
 		r.dynamicRateLimiter.Refresh()
 	})
+}
+
+// UpdateSimpleRateLimit updates the overall queue rate limits for the simpleRateLimiter implementation
+func (r *rateLimitManager) updateSimpleRateLimitLocked(burstDuration time.Duration) {
+	r.trySetRPSFromUserDataLocked()
+	r.computeEffectiveRPSAndSourceLocked()
+	newRPS := r.effectiveRPS
+	// Always update the rate limit when called, even if RPS hasn't changed
+	// This ensures that the burst duration is properly applied
+	r.wholeQueueLimit = makeSimpleLimiterParams(newRPS, burstDuration)
+
+	// Clip to handle the case where we have increased from a zero or very low limit and had
+	// ready times in the far future.
+	now := r.timeSource.Now().UnixNano()
+	r.wholeQueueReady = r.wholeQueueReady.clip(r.wholeQueueLimit, now, maxTokens)
+}
+
+// UpdatePerKeySimpleRateLimit updates the per-key rate limit for the simpleRateLimit implementation
+func (r *rateLimitManager) updatePerKeySimpleRateLimitLocked(burstDuration time.Duration) {
+	r.trySetRPSFromUserDataLocked()
+	if r.fairnessRPS == nil {
+		return
+	}
+	r.computeEffectiveRPSAndSourceLocked()
+	if r.fairnessRPS == nil {
+		r.clearPerKeyRateLimitsLocked()
+		return
+	}
+	rate := *r.fairnessRPS
+	r.perKeyLimit = makeSimpleLimiterParams(rate, burstDuration)
+
+	// Clip to handle the case where we have increased from a zero or very low limit and had
+	// ready times in the far future.
+	var updates map[string]simpleLimiter
+	now := r.timeSource.Now().UnixNano()
+	it := r.perKeyReady.Iterator()
+	for it.HasNext() {
+		e := it.Next()
+		sl := e.Value().(simpleLimiter) //nolint:revive
+		if clipped := sl.clip(r.perKeyLimit, now, maxTokens); clipped != sl {
+			if updates == nil {
+				updates = make(map[string]simpleLimiter)
+			}
+			updates[e.Key().(string)] = clipped
+		}
+	}
+	it.Close()
+
+	// This messes up the LRU order, but we can't avoid that here without adding new
+	// functionality to Cache.
+	for key, clipped := range updates {
+		r.perKeyReady.Put(key, clipped)
+	}
+}
+
+// clearPerKeyRateLimitsLocked removes all fairness per-key rate limits.
+func (r *rateLimitManager) clearPerKeyRateLimitsLocked() {
+	it := r.perKeyReady.Iterator()
+	for it.HasNext() {
+		e := it.Next()
+		r.perKeyReady.Delete(e.Key())
+	}
+	it.Close()
+
+	r.perKeyLimit = simpleLimiterParams{}
+}
+
+func (r *rateLimitManager) readyTimeForTask(task *internalTask) simpleLimiter {
+	// TODO(pri): after we have task-specific ready time, we can re-enable this
+	// if task.isForwarded() {
+	// 	// don't count any rate limit for forwarded tasks, it was counted on the child
+	// 	return 0
+	// }
+	ready := r.wholeQueueReady
+
+	if r.perKeyLimit.limited() {
+		key := task.getPriority().GetFairnessKey()
+		if v := r.perKeyReady.Get(key); v != nil {
+			ready = max(ready, v.(simpleLimiter))
+		}
+	}
+
+	return ready
+}
+
+func (r *rateLimitManager) consumeTokens(now int64, task *internalTask, tokens int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.consumeTokensLocked(now, task, tokens)
+}
+
+func (r *rateLimitManager) consumeTokensLocked(now int64, task *internalTask, tokens int64) {
+	if task.isForwarded() {
+		// don't count any rate limit for forwarded tasks, it was counted on the child
+		return
+	}
+
+	r.wholeQueueReady = r.wholeQueueReady.consume(r.wholeQueueLimit, now, tokens)
+
+	if r.perKeyLimit.limited() {
+		pri := task.getPriority()
+		key := pri.GetFairnessKey()
+		weight := getEffectiveWeight(r.perKeyOverrides, pri)
+		p := r.perKeyLimit
+		p.interval = time.Duration(float32(p.interval) / weight) // scale by weight
+		var sl simpleLimiter
+		if v := r.perKeyReady.Get(key); v != nil {
+			sl = v.(simpleLimiter) // nolint:revive
+		}
+		r.perKeyReady.Put(key, sl.consume(p, now, tokens))
+	}
+}
+
+func (r *rateLimitManager) Stop() {
+	r.cancel1()
+	r.cancel2()
+	r.cancel3()
 }

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -132,6 +132,7 @@ func (pm *taskQueuePartitionManagerImpl) GetRateLimitManager() *rateLimitManager
 // Stop does not unload the partition from matching engine. It is intended to be called by matching engine when
 // unloading the partition. For stopping and unloading a partition call unloadFromEngine instead.
 func (pm *taskQueuePartitionManagerImpl) Stop(unloadCause unloadCause) {
+	pm.rateLimitManager.Stop()
 	pm.versionedQueuesLock.Lock()
 	defer pm.versionedQueuesLock.Unlock()
 	for _, vq := range pm.versionedQueues {

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -87,10 +87,12 @@ func newTaskQueuePartitionManager(
 	metricsHandler metrics.Handler,
 	userDataManager userDataManager,
 ) (*taskQueuePartitionManagerImpl, error) {
+	isSticky := partition.Kind() == enumspb.TASK_QUEUE_KIND_STICKY
 	rateLimitManager := newRateLimitManager(
 		userDataManager,
 		tqConfig,
-		partition.TaskQueue().TaskType())
+		partition.TaskQueue().TaskType(),
+		isSticky)
 	pm := &taskQueuePartitionManagerImpl{
 		engine:           e,
 		partition:        partition,


### PR DESCRIPTION
## What changed?
 - PR dependent on : https://github.com/temporalio/temporal/pull/8058 [ Will merge after this PR is reviewed and merged ]
 -  Move the rate limit logic for fairness from priMatcher to taskQueuePartitionManagerLevel
 -  Attach the fairness queue rate limit and the per-key rate limit to the simple rate limiter implementation.

## Why?
- Implementation of UpdateTaskQueueConfig api for fairness tasks.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
N/A

