### PR TITLE
Set `ForceAttemptHTTP2=true` for remote frontend HTTP clients

### DIFF
--- a/common/cluster/frontend_http_client.go
+++ b/common/cluster/frontend_http_client.go
@@ -61,7 +61,10 @@ func (c *FrontendHTTPClientCache) newClientForCluster(targetClusterName string) 
 		if err != nil {
 			return nil, err
 		}
-		client.Transport = &http.Transport{TLSClientConfig: tlsClientConfig}
+		client.Transport = &http.Transport{
+			TLSClientConfig:   tlsClientConfig,
+			ForceAttemptHTTP2: true,
+		}
 		if tlsClientConfig != nil {
 			urlScheme = "https"
 		}

--- a/common/cluster/frontend_http_client.go
+++ b/common/cluster/frontend_http_client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common"
@@ -53,7 +54,20 @@ func (c *FrontendHTTPClientCache) newClientForCluster(targetClusterName string) 
 		return nil, fmt.Errorf("%w: %w", serviceerror.NewInternal("invalid frontend address"), err)
 	}
 
-	client := http.Client{}
+	// dialer and transport field values copied from http.DefaultTransport.
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 
 	urlScheme := "http"
 	if c.tlsProvider != nil {
@@ -61,11 +75,8 @@ func (c *FrontendHTTPClientCache) newClientForCluster(targetClusterName string) 
 		if err != nil {
 			return nil, err
 		}
-		client.Transport = &http.Transport{
-			TLSClientConfig:   tlsClientConfig,
-			ForceAttemptHTTP2: true,
-		}
 		if tlsClientConfig != nil {
+			transport.TLSClientConfig = tlsClientConfig
 			urlScheme = "https"
 		}
 	}
@@ -73,7 +84,7 @@ func (c *FrontendHTTPClientCache) newClientForCluster(targetClusterName string) 
 	return &common.FrontendHTTPClient{
 		Address: targetInfo.HTTPAddress,
 		Scheme:  urlScheme,
-		Client:  client,
+		Client:  http.Client{Transport: transport},
 	}, nil
 }
 


### PR DESCRIPTION
## What changed?
Setting `ForceAttemptHTTP2=true` for remote frontend HTTP clients. Local FE clients already set this.

## Why?
ForceAttemptHTTP2 is the default except when providing a custom Dial , DialTLS , DialContext , or TLSClientConfig to prevent breaking older code: https://github.com/golang/go/issues/14275

We set this parameter to true for local clients, so when TLS is enabled and a failover happens, callback requests will fail because the cluster uses a local frontend to make the request with HTTP2 which is then forwarded using HTTP1.x and causes a malformed response.
