### PR TITLE
Allow more retries for matching client polls

### DIFF
--- a/client/matching/retryable_client.go
+++ b/client/matching/retryable_client.go
@@ -10,14 +10,21 @@ var _ matchingservice.MatchingServiceClient = (*retryableClient)(nil)
 type retryableClient struct {
 	client      matchingservice.MatchingServiceClient
 	policy      backoff.RetryPolicy
+	pollPolicy  backoff.RetryPolicy
 	isRetryable backoff.IsRetryable
 }
 
 // NewRetryableClient creates a new instance of matchingservice.MatchingServiceClient with retry policy
-func NewRetryableClient(client matchingservice.MatchingServiceClient, policy backoff.RetryPolicy, isRetryable backoff.IsRetryable) matchingservice.MatchingServiceClient {
+func NewRetryableClient(
+	client matchingservice.MatchingServiceClient,
+	policy,
+	pollPolicy backoff.RetryPolicy,
+	isRetryable backoff.IsRetryable,
+) matchingservice.MatchingServiceClient {
 	return &retryableClient{
 		client:      client,
 		policy:      policy,
+		pollPolicy:  pollPolicy,
 		isRetryable: isRetryable,
 	}
 }

--- a/client/matching/retryable_client_gen.go
+++ b/client/matching/retryable_client_gen.go
@@ -352,7 +352,7 @@ func (c *retryableClient) PollActivityTaskQueue(
 		resp, err = c.client.PollActivityTaskQueue(ctx, request, opts...)
 		return err
 	}
-	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.pollPolicy, c.isRetryable)
 	return resp, err
 }
 
@@ -367,7 +367,7 @@ func (c *retryableClient) PollNexusTaskQueue(
 		resp, err = c.client.PollNexusTaskQueue(ctx, request, opts...)
 		return err
 	}
-	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.pollPolicy, c.isRetryable)
 	return resp, err
 }
 
@@ -382,7 +382,7 @@ func (c *retryableClient) PollWorkflowTaskQueue(
 		resp, err = c.client.PollWorkflowTaskQueue(ctx, request, opts...)
 		return err
 	}
-	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.pollPolicy, c.isRetryable)
 	return resp, err
 }
 

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -272,6 +272,7 @@ func MatchingClientProvider(matchingRawClient MatchingRawClient) MatchingClient 
 	return matching.NewRetryableClient(
 		matchingRawClient,
 		common.CreateMatchingClientRetryPolicy(),
+		common.CreateMatchingClientLongPollRetryPolicy(),
 		common.IsServiceClientTransientError,
 	)
 }

--- a/common/util.go
+++ b/common/util.go
@@ -178,6 +178,12 @@ func CreateMatchingClientRetryPolicy() backoff.RetryPolicy {
 		WithMaximumAttempts(matchingClientRetryMaxAttempts)
 }
 
+// CreateMatchingClientLongPollRetryPolicy creates a retry policy for poll calls to matching service
+func CreateMatchingClientLongPollRetryPolicy() backoff.RetryPolicy {
+	// no maximum attempts, using default expiration interval of 1 minute
+	return backoff.NewExponentialRetryPolicy(matchingClientRetryInitialInterval)
+}
+
 // CreateFrontendHandlerRetryPolicy creates a retry policy for calls to frontend service
 func CreateFrontendHandlerRetryPolicy() backoff.RetryPolicy {
 	return backoff.NewExponentialRetryPolicy(frontendHandlerRetryInitialInterval).


### PR DESCRIPTION
## What changed?
Allow frontend->matching poll requests to retry up to their context timeout instead of just once.

## Why?
On matching service deployments, a busy new matching node may hit its persistence rps limit trying to acquire new task queues and be unable to accept polls.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
