### PR TITLE
Validate Priority metadata

### DIFF
--- a/common/priorities/priority_util.go
+++ b/common/priorities/priority_util.go
@@ -4,6 +4,17 @@ import (
 	"cmp"
 
 	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
+)
+
+const (
+	fairnessKeyMaxLength = 64
+)
+
+var (
+	ErrInvalidPriority       = serviceerror.NewInvalidArgument("PriorityKey can't be negative")
+	ErrFairnessKeyLength     = serviceerror.NewInvalidArgument("FairnessKey length exceeds limit")
+	ErrInvalidFairnessWeight = serviceerror.NewInvalidArgument("FairnessWeight can't be negative")
 )
 
 func Merge(
@@ -21,4 +32,17 @@ func Merge(
 		FairnessKey:    cmp.Or(override.FairnessKey, base.FairnessKey),
 		FairnessWeight: cmp.Or(override.FairnessWeight, base.FairnessWeight),
 	}
+}
+
+func Validate(p *commonpb.Priority) error {
+	if p == nil {
+		return nil
+	} else if p.PriorityKey < 0 {
+		return ErrInvalidPriority
+	} else if len(p.FairnessKey) > fairnessKeyMaxLength {
+		return ErrFairnessKeyLength
+	} else if p.FairnessWeight < 0 {
+		return ErrInvalidFairnessWeight
+	}
+	return nil
 }

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -59,6 +59,7 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/priorities"
 	"go.temporal.io/server/common/retrypolicy"
 	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/rpc/interceptor"
@@ -485,6 +486,10 @@ func (wh *WorkflowHandler) prepareStartWorkflowRequest(
 		// in case of retries, the field is set to the original value.
 		request = common.CloneProto(request)
 		request.SearchAttributes = sa
+	}
+
+	if err := priorities.Validate(request.Priority); err != nil {
+		return nil, err
 	}
 
 	if err := wh.validateWorkflowCompletionCallbacks(namespaceName, request.GetCompletionCallbacks()); err != nil {
@@ -2063,6 +2068,10 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		// cloning here so in case of retry the field is set to the current search attributes
 		request = common.CloneProto(request)
 		request.SearchAttributes = sa
+	}
+
+	if err := priorities.Validate(request.Priority); err != nil {
+		return nil, err
 	}
 
 	if err := wh.validateLinks(namespaceName, request.GetLinks()); err != nil {


### PR DESCRIPTION
## What changed?
Add validation for Priority metadata.

## Why?
Negative keys/weights are ignored but we should reject requests with too-long keys.

## How did you test it?
- [x] added new unit test(s)
