### PR TITLE
[Scheduled Actions] CHASM Generate Task

### DIFF
--- a/chasm/lib/scheduler/generator_tasks.go
+++ b/chasm/lib/scheduler/generator_tasks.go
@@ -1,0 +1,155 @@
+package scheduler
+
+import (
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/serviceerror"
+	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.uber.org/fx"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type (
+	GeneratorTaskExecutorOptions struct {
+		fx.In
+
+		Config         *Config
+		MetricsHandler metrics.Handler
+		BaseLogger     log.Logger
+		SpecProcessor  SpecProcessor
+	}
+
+	GeneratorTaskExecutor struct {
+		GeneratorTaskExecutorOptions
+	}
+)
+
+func NewGeneratorTaskExecutor(opts GeneratorTaskExecutorOptions) *GeneratorTaskExecutor {
+	return &GeneratorTaskExecutor{
+		GeneratorTaskExecutorOptions: opts,
+	}
+}
+
+func (g *GeneratorTaskExecutor) Execute(
+	ctx chasm.MutableContext,
+	generator *Generator,
+	_ chasm.TaskAttributes,
+	_ *schedulespb.GeneratorTask,
+) error {
+	scheduler, err := generator.Scheduler.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("%w: %w",
+			serviceerror.NewInternal("Scheduler tree missing node"),
+			err)
+	}
+	logger := newTaggedLogger(g.BaseLogger, scheduler)
+
+	invoker, err := generator.Invoker.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("%w: %w",
+			serviceerror.NewInternal("Scheduler tree missing node"),
+			err)
+	}
+
+	// If we have no last processed time, this is a new schedule.
+	if generator.LastProcessedTime == nil {
+		createdAt := timestamppb.New(ctx.Now(generator))
+		generator.LastProcessedTime = createdAt
+		scheduler.Info.CreateTime = createdAt
+
+		g.logSchedule(logger, "Starting schedule", scheduler)
+	}
+
+	// Process time range between last high water mark and system time.
+	t1 := generator.LastProcessedTime.AsTime()
+	t2 := ctx.Now(generator).UTC()
+	if t2.Before(t1) {
+		logger.Warn("Time went backwards",
+			tag.NewStringerTag("time", t1),
+			tag.NewStringerTag("time", t2))
+		t2 = t1
+	}
+
+	result, err := g.SpecProcessor.ProcessTimeRange(scheduler, t1, t2, scheduler.overlapPolicy(), "", false, nil)
+	if err != nil {
+		// An error here should be impossible, send to the DLQ.
+		logger.Error("Error processing time range", tag.Error(err))
+		return fmt.Errorf("%w: %w",
+			serviceerror.NewInternalf("Failed to process a time range"),
+			err)
+	}
+
+	// Enqueue newly-generated buffered starts.
+	if len(result.BufferedStarts) > 0 {
+		invoker.EnqueueBufferedStarts(ctx, result.BufferedStarts)
+	}
+
+	// Write the new high water mark.
+	generator.LastProcessedTime = timestamppb.New(result.LastActionTime)
+
+	_, inRetention := g.getRetentionExpiration(ctx, scheduler, result.NextWakeupTime)
+	if inRetention {
+		// We're in retention, no need for another buffer task.
+		//
+		// TODO - add a timer to close this scheduler tree. V1 scheduler waits this
+		// period before exiting, whereas we just stop pumping new tasks.
+		return nil
+	}
+
+	// No more tasks if we're paused.
+	if scheduler.Schedule.State.Paused {
+		return nil
+	}
+
+	// Another buffering task is added if we aren't completely out of actions or paused.
+	ctx.AddTask(generator, chasm.TaskAttributes{
+		ScheduledTime: result.NextWakeupTime,
+	}, &schedulespb.GeneratorTask{})
+
+	return nil
+}
+
+func (g *GeneratorTaskExecutor) logSchedule(logger log.Logger, msg string, scheduler *Scheduler) {
+	// Log spec as json since it's more readable than the Go representation.
+	specJson, _ := protojson.Marshal(scheduler.Schedule.Spec)
+	policiesJson, _ := protojson.Marshal(scheduler.Schedule.Policies)
+	logger.Debug(msg,
+		tag.NewStringTag("spec", string(specJson)),
+		tag.NewStringTag("policies", string(policiesJson)))
+}
+
+func (g *GeneratorTaskExecutor) Validate(
+	ctx chasm.Context,
+	generator *Generator,
+	_ chasm.TaskAttributes,
+	_ *schedulespb.GeneratorTask,
+) (bool, error) {
+	return validateTaskHighWaterMark(generator.GetLastProcessedTime(), ctx.Now(generator))
+}
+
+// getRetentionExpiration returns a retention time and the boolean value of
+// 'true' for when a schedule is in retention (pending soft delete).
+func (g *GeneratorTaskExecutor) getRetentionExpiration(
+	ctx chasm.Context,
+	scheduler *Scheduler,
+	nextWakeup time.Time,
+) (time.Time, bool) {
+	retentionTime := g.Config.Tweakables(scheduler.Namespace).RetentionTime
+
+	// If RetentionTime is not set or the schedule is paused or nextWakeup time is not zero
+	// or there are more actions to take, there is no need for retention.
+	if retentionTime == 0 ||
+		scheduler.Schedule.State.Paused ||
+		(!nextWakeup.IsZero() && scheduler.useScheduledAction(false)) ||
+		scheduler.hasMoreAllowAllBackfills(ctx) {
+		return time.Time{}, false
+	}
+
+	return scheduler.getLastEventTime().Add(retentionTime), true
+}

--- a/chasm/lib/scheduler/generator_tasks_test.go
+++ b/chasm/lib/scheduler/generator_tasks_test.go
@@ -1,0 +1,89 @@
+package scheduler_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/scheduler"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/service/history/tasks"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type generatorTasksSuite struct {
+	schedulerSuite
+	executor *scheduler.GeneratorTaskExecutor
+}
+
+func TestGeneratorTasksSuite(t *testing.T) {
+	suite.Run(t, &generatorTasksSuite{})
+}
+
+func (s *generatorTasksSuite) SetupTest() {
+	s.SetupSuite()
+	s.executor = scheduler.NewGeneratorTaskExecutor(scheduler.GeneratorTaskExecutorOptions{
+		Config:         defaultConfig(),
+		MetricsHandler: metrics.NoopMetricsHandler,
+		BaseLogger:     s.logger,
+		SpecProcessor:  s.specProcessor,
+	})
+}
+
+func (s *generatorTasksSuite) TestExecute_ProcessTimeRangeFails() {
+	sched := s.scheduler
+	ctx := s.newMutableContext()
+
+	// If ProcessTimeRange fails, we should fail the task as an internal error.
+	s.specProcessor.EXPECT().ProcessTimeRange(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(nil, errors.New("processTimeRange bug"))
+
+	// Execute the generate task.
+	generator, err := sched.Generator.Get(ctx)
+	s.NoError(err)
+	err = s.executor.Execute(ctx, generator, chasm.TaskAttributes{}, &schedulespb.GeneratorTask{})
+	s.True(common.IsInternalError(err))
+}
+
+func (s *generatorTasksSuite) TestExecuteBufferTask_Basic() {
+	ctx := s.newMutableContext()
+	sched := s.scheduler
+
+	generator, err := sched.Generator.Get(ctx)
+	s.NoError(err)
+
+	// Use a real SpecProcessor implementation.
+	specProcessor := newTestSpecProcessor(s.controller)
+	s.executor.SpecProcessor = specProcessor
+
+	// Move high water mark back in time (Generator always compares high water mark
+	// against system time) to generate buffered actions.
+	highWatermark := ctx.Now(generator).UTC().Add(-defaultInterval * 5)
+	generator.LastProcessedTime = timestamppb.New(highWatermark)
+
+	// Execute the generate task.
+	err = s.executor.Execute(ctx, generator, chasm.TaskAttributes{}, &schedulespb.GeneratorTask{})
+	s.NoError(err)
+
+	// We expect 5 buffered starts.
+	invoker, err := sched.Invoker.Get(ctx)
+	s.NoError(err)
+	s.Equal(5, len(invoker.BufferedStarts))
+
+	// Generator's high water mark should have advanced.
+	newHighWatermark := generator.LastProcessedTime.AsTime()
+	s.True(newHighWatermark.After(highWatermark))
+
+	// Ensure we scheduled an immediate physical pure task on the tree.
+	_, err = s.node.CloseTransaction()
+	s.NoError(err)
+	s.Equal(1, len(s.addedTasks))
+	task, ok := s.addedTasks[0].(*tasks.ChasmTaskPure)
+	s.True(ok)
+	s.Equal(chasm.TaskScheduledTimeImmediate, task.GetVisibilityTime())
+}


### PR DESCRIPTION
## What changed?
- Port the generate task to CHASM.
- I have a TODO here for adding a timer task to cleanup after the retention period, which would update the scheduler's `LifecycleState`; I meant to discuss this at some point to see if that's the pattern we want in CHASM-world, would love to get thoughts on that in the comments.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
