### PR TITLE
[Scheduled Actions] CHASM Invoker tasks

### DIFF
--- a/chasm/lib/scheduler/invoker_execute_task_test.go
+++ b/chasm/lib/scheduler/invoker_execute_task_test.go
@@ -1,0 +1,391 @@
+package scheduler_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/historyservicemock/v1"
+	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/scheduler"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/testing/mockapi/workflowservicemock/v1"
+	"go.temporal.io/server/service/history/tasks"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type invokerExecuteTaskSuite struct {
+	schedulerSuite
+	executor *scheduler.InvokerExecuteTaskExecutor
+
+	mockFrontendClient *workflowservicemock.MockWorkflowServiceClient
+	mockHistoryClient  *historyservicemock.MockHistoryServiceClient
+}
+
+func TestInvokerExecuteTaskSuite(t *testing.T) {
+	suite.Run(t, &invokerExecuteTaskSuite{})
+}
+
+func (s *invokerExecuteTaskSuite) SetupTest() {
+	s.SetupSuite()
+
+	s.mockFrontendClient = workflowservicemock.NewMockWorkflowServiceClient(s.controller)
+	s.mockHistoryClient = historyservicemock.NewMockHistoryServiceClient(s.controller)
+
+	s.executor = scheduler.NewInvokerExecuteTaskExecutor(scheduler.InvokerTaskExecutorOptions{
+		Config:         defaultConfig(),
+		MetricsHandler: metrics.NoopMetricsHandler,
+		BaseLogger:     s.logger,
+		HistoryClient:  s.mockHistoryClient,
+		FrontendClient: s.mockFrontendClient,
+	})
+}
+
+type executeTestCase struct {
+	InitialBufferedStarts     []*schedulespb.BufferedStart
+	InitialCancelWorkflows    []*commonpb.WorkflowExecution
+	InitialTerminateWorkflows []*commonpb.WorkflowExecution
+	InitialRunningWorkflows   []*commonpb.WorkflowExecution
+
+	ExpectedBufferedStarts      int
+	ExpectedRunningWorkflows    int
+	ExpectedTerminateWorkflows  int
+	ExpectedCancelWorkflows     int
+	ExpectedActionCount         int64
+	ExpectedOverlapSkipped      int64
+	ExpectedMissedCatchupWindow int64
+
+	ValidateInvoker func(invoker *scheduler.Invoker)
+}
+
+// Execute success case.
+func (s *invokerExecuteTaskSuite) TestExecuteTask_Basic() {
+	startTime := timestamppb.New(s.timeSource.Now())
+	bufferedStarts := []*schedulespb.BufferedStart{
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "req1",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       1,
+		},
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        true,
+			RequestId:     "req2",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       1,
+		},
+	}
+
+	// Expect both buffered starts to result in workflow executions.
+	s.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), gomock.Any()).
+		Times(2).
+		Return(&workflowservice.StartWorkflowExecutionResponse{
+			RunId: "run-id",
+		}, nil)
+
+	s.runExecuteTestCase(&executeTestCase{
+		InitialBufferedStarts:    bufferedStarts,
+		ExpectedBufferedStarts:   0,
+		ExpectedRunningWorkflows: 2,
+		ExpectedActionCount:      2,
+	})
+}
+
+// Execute is scheduled with an empty buffer.
+func (s *invokerExecuteTaskSuite) TestExecuteTask_Empty() {
+	s.runExecuteTestCase(&executeTestCase{
+		InitialBufferedStarts: nil,
+	})
+}
+
+// A buffered start fails with a retryable error.
+func (s *invokerExecuteTaskSuite) TestExecuteTask_RetryableFailure() {
+	// Set up the Invoker's buffer with a two starts. One will succeed immediately,
+	// one will fail.
+	startTime := timestamppb.New(s.timeSource.Now())
+	bufferedStarts := []*schedulespb.BufferedStart{
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "fail",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       1,
+		},
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        true,
+			RequestId:     "pass",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       1,
+		},
+	}
+
+	// Fail the first start, and succeed the second.
+	s.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), startWorkflowExecutionRequestIdMatches("fail")).
+		Times(1).
+		Return(nil, serviceerror.NewDeadlineExceeded("deadline exceeded"))
+	s.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), startWorkflowExecutionRequestIdMatches("pass")).
+		Times(1).
+		Return(&workflowservice.StartWorkflowExecutionResponse{
+			RunId: "run-id",
+		}, nil)
+
+	s.runExecuteTestCase(&executeTestCase{
+		InitialBufferedStarts:    bufferedStarts,
+		ExpectedBufferedStarts:   1,
+		ExpectedRunningWorkflows: 1,
+		ExpectedActionCount:      1,
+		ValidateInvoker: func(invoker *scheduler.Invoker) {
+			// The failed start should have had a backoff applied.
+			failedStart := invoker.BufferedStarts[0]
+			backoffTime := failedStart.BackoffTime.AsTime()
+			s.True(backoffTime.After(s.timeSource.Now()))
+			s.Equal(int64(2), failedStart.Attempt)
+		},
+	})
+}
+
+// A buffered start fails when a duplicate workflow has already been started.
+func (s *invokerExecuteTaskSuite) TestExecuteTask_AlreadyStarted() {
+	startTime := timestamppb.New(s.timeSource.Now())
+	bufferedStarts := []*schedulespb.BufferedStart{
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "req",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       1,
+		},
+	}
+
+	// Fail with WorkflowExecutionAlreadyStarted.
+	s.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(nil, serviceerror.NewWorkflowExecutionAlreadyStarted("workflow already started", "", ""))
+
+	s.runExecuteTestCase(&executeTestCase{
+		InitialBufferedStarts:    bufferedStarts,
+		ExpectedBufferedStarts:   0,
+		ExpectedRunningWorkflows: 0,
+		ExpectedActionCount:      0,
+	})
+}
+
+// A buffered start fails from having exceeded its maximum retry limit.
+func (s *invokerExecuteTaskSuite) TestExecuteTask_ExceedsMaxAttempts() {
+	startTime := timestamppb.New(s.timeSource.Now())
+	bufferedStarts := []*schedulespb.BufferedStart{
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "req",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       scheduler.InvokerMaxStartAttempts,
+		},
+	}
+
+	s.runExecuteTestCase(&executeTestCase{
+		InitialBufferedStarts:    bufferedStarts,
+		ExpectedBufferedStarts:   0,
+		ExpectedRunningWorkflows: 0,
+		ExpectedActionCount:      0,
+	})
+}
+
+// An execute task runs with cancels/terminations queued, which fail to execute.
+func (s *invokerExecuteTaskSuite) TestExecuteTask_CancelTerminateFailure() {
+	cancelWorkflows := []*commonpb.WorkflowExecution{
+		{
+			WorkflowId: "wf",
+			RunId:      "run1",
+		},
+	}
+	terminateWorkflows := []*commonpb.WorkflowExecution{
+		{
+			WorkflowId: "wf",
+			RunId:      "run2",
+		},
+	}
+
+	// Fail both service calls.
+	s.mockHistoryClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).Times(1).
+		Return(nil, serviceerror.NewInternal("internal failure"))
+	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).Times(1).
+		Return(nil, serviceerror.NewInternal("internal failure"))
+
+	// Terminate and Cancel are both attempted only once. Regardless of the service
+	// call's outcome, they should have been removed from the Invoker's queue.
+	s.runExecuteTestCase(&executeTestCase{
+		InitialBufferedStarts:      nil,
+		InitialCancelWorkflows:     cancelWorkflows,
+		InitialTerminateWorkflows:  terminateWorkflows,
+		ExpectedBufferedStarts:     0,
+		ExpectedRunningWorkflows:   0,
+		ExpectedActionCount:        0,
+		ExpectedCancelWorkflows:    0,
+		ExpectedTerminateWorkflows: 0,
+	})
+}
+
+// An Execute task runs with cancels/terminations queued, resulting in success.
+func (s *invokerExecuteTaskSuite) TestExecuteTask_CancelTerminateSucceed() {
+	cancelWorkflows := []*commonpb.WorkflowExecution{
+		{
+			WorkflowId: "wf",
+			RunId:      "run1",
+		},
+	}
+	terminateWorkflows := []*commonpb.WorkflowExecution{
+		{
+			WorkflowId: "wf",
+			RunId:      "run2",
+		},
+	}
+
+	// Succeed both service calls.
+	s.mockHistoryClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).Times(1).
+		Return(nil, nil)
+	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).Times(1).
+		Return(nil, nil)
+
+	s.runExecuteTestCase(&executeTestCase{
+		InitialBufferedStarts:      nil,
+		InitialCancelWorkflows:     cancelWorkflows,
+		InitialTerminateWorkflows:  terminateWorkflows,
+		ExpectedBufferedStarts:     0,
+		ExpectedRunningWorkflows:   0,
+		ExpectedActionCount:        0,
+		ExpectedCancelWorkflows:    0,
+		ExpectedTerminateWorkflows: 0,
+	})
+}
+
+// Tests when the ExecuteTask should yield by completing and committing any
+// completed work.
+func (s *invokerExecuteTaskSuite) TestExecuteTask_ExceedsMaxActionsPerExecution() {
+	startTime := timestamppb.New(s.timeSource.Now())
+	var bufferedStarts []*schedulespb.BufferedStart
+	maxStarts := scheduler.DefaultTweakables.MaxActionsPerExecution
+	for i := range maxStarts * 2 {
+		bufferedStarts = append(bufferedStarts,
+			&schedulespb.BufferedStart{
+				NominalTime:   startTime,
+				ActualTime:    startTime,
+				DesiredTime:   startTime,
+				Manual:        false,
+				RequestId:     fmt.Sprintf("req-%d", i),
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+				Attempt:       1,
+			})
+	}
+
+	// Expect both buffered starts to result in workflow executions.
+	s.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), gomock.Any()).
+		Times(maxStarts).
+		Return(&workflowservice.StartWorkflowExecutionResponse{
+			RunId: "run-id",
+		}, nil)
+
+	s.runExecuteTestCase(&executeTestCase{
+		InitialBufferedStarts:    bufferedStarts,
+		ExpectedBufferedStarts:   10,
+		ExpectedRunningWorkflows: 10,
+		ExpectedActionCount:      10,
+	})
+}
+
+func (s *invokerExecuteTaskSuite) runExecuteTestCase(c *executeTestCase) {
+	ctx := s.newMutableContext()
+	invoker, err := s.scheduler.Invoker.Get(ctx)
+	s.NoError(err)
+
+	// Set up initial state
+	invoker.BufferedStarts = c.InitialBufferedStarts
+	invoker.CancelWorkflows = c.InitialCancelWorkflows
+	invoker.TerminateWorkflows = c.InitialTerminateWorkflows
+	s.scheduler.Info.RunningWorkflows = c.InitialRunningWorkflows
+
+	// Set LastProcessedTime to current time to ensure time checks pass
+	invoker.LastProcessedTime = timestamppb.New(s.timeSource.Now())
+
+	s.ExpectReadComponent(invoker)
+	s.ExpectReadComponent(s.scheduler)
+
+	// Set up mock engine expectations for UpdateComponent calls only if there's work to do
+	hasWork := len(c.InitialBufferedStarts) > 0 ||
+		len(c.InitialCancelWorkflows) > 0 ||
+		len(c.InitialTerminateWorkflows) > 0
+
+	if hasWork {
+		s.ExpectUpdateComponent(invoker)
+		s.ExpectUpdateComponent(s.scheduler)
+	}
+
+	// Clear old tasks and run the execute task.
+	s.addedTasks = make([]tasks.Task, 0)
+
+	// Create engine context for side effect task execution
+	engineCtx := s.newEngineContext()
+	err = s.executor.Execute(engineCtx, chasm.ComponentRef{}, chasm.TaskAttributes{}, &schedulespb.InvokerExecuteTask{})
+	s.NoError(err)
+	_, err = s.node.CloseTransaction()
+	s.NoError(err)
+
+	// Validate the results
+	s.Equal(c.ExpectedBufferedStarts, len(invoker.GetBufferedStarts()))
+	s.Equal(c.ExpectedRunningWorkflows, len(s.scheduler.Info.RunningWorkflows))
+	s.Equal(c.ExpectedTerminateWorkflows, len(invoker.TerminateWorkflows))
+	s.Equal(c.ExpectedCancelWorkflows, len(invoker.CancelWorkflows))
+	s.Equal(c.ExpectedActionCount, s.scheduler.Info.ActionCount)
+	s.Equal(c.ExpectedOverlapSkipped, s.scheduler.Info.OverlapSkipped)
+	s.Equal(c.ExpectedMissedCatchupWindow, s.scheduler.Info.MissedCatchupWindow)
+
+	// Callbacks.
+	if c.ValidateInvoker != nil {
+		c.ValidateInvoker(invoker)
+	}
+}
+
+type startWorkflowExecutionRequestIdMatcher struct {
+	RequestId string
+}
+
+var _ gomock.Matcher = &startWorkflowExecutionRequestIdMatcher{}
+
+func startWorkflowExecutionRequestIdMatches(requestId string) *startWorkflowExecutionRequestIdMatcher {
+	return &startWorkflowExecutionRequestIdMatcher{requestId}
+}
+
+func (s *startWorkflowExecutionRequestIdMatcher) String() string {
+	return fmt.Sprintf("StartWorkflowExecutionRequest{RequestId: \"%s\"}", s.RequestId)
+}
+
+func (s *startWorkflowExecutionRequestIdMatcher) Matches(x any) bool {
+	req, ok := x.(*workflowservice.StartWorkflowExecutionRequest)
+	return ok && req.RequestId == s.RequestId
+}

--- a/chasm/lib/scheduler/invoker_process_buffer_task_test.go
+++ b/chasm/lib/scheduler/invoker_process_buffer_task_test.go
@@ -1,0 +1,335 @@
+package scheduler_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/scheduler"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/util"
+	"go.temporal.io/server/service/history/tasks"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type invokerProcessBufferTaskSuite struct {
+	schedulerSuite
+	executor *scheduler.InvokerProcessBufferTaskExecutor
+}
+
+func TestInvokerProcessBufferTaskSuite(t *testing.T) {
+	suite.Run(t, &invokerProcessBufferTaskSuite{})
+}
+
+func (s *invokerProcessBufferTaskSuite) SetupTest() {
+	s.SetupSuite()
+
+	s.executor = scheduler.NewInvokerProcessBufferTaskExecutor(scheduler.InvokerTaskExecutorOptions{
+		Config:         defaultConfig(),
+		MetricsHandler: metrics.NoopMetricsHandler,
+		BaseLogger:     s.logger,
+	})
+}
+
+type processBufferTestCase struct {
+	InitialBufferedStarts     []*schedulespb.BufferedStart
+	InitialCancelWorkflows    []*commonpb.WorkflowExecution
+	InitialTerminateWorkflows []*commonpb.WorkflowExecution
+	InitialRunningWorkflows   []*commonpb.WorkflowExecution
+
+	ExpectedBufferedStarts      int
+	ExpectedRunningWorkflows    int
+	ExpectedTerminateWorkflows  int
+	ExpectedCancelWorkflows     int
+	ExpectedOverlapSkipped      int64
+	ExpectedMissedCatchupWindow int64
+
+	ValidateInvoker func(invoker *scheduler.Invoker)
+}
+
+// ProcessBuffer attempts all buffered starts with ALLOW_ALL policy.
+func (s *invokerProcessBufferTaskSuite) TestProcessBufferTask_AllowAll() {
+	startTime := timestamppb.New(s.timeSource.Now())
+	bufferedStarts := []*schedulespb.BufferedStart{
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "req1",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+		},
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "req2",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+		},
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "req3",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+		},
+	}
+
+	s.runProcessBufferTestCase(&processBufferTestCase{
+		InitialBufferedStarts:  bufferedStarts,
+		ExpectedBufferedStarts: 3,
+		ExpectedOverlapSkipped: 0,
+		ValidateInvoker: func(invoker *scheduler.Invoker) {
+			s.Equal(3, len(util.FilterSlice(invoker.GetBufferedStarts(), func(start *schedulespb.BufferedStart) bool {
+				return start.Attempt > 0
+			})))
+		},
+	})
+}
+
+// ProcessBuffer processes a start that missed the catchup window.
+func (s *invokerProcessBufferTaskSuite) TestProcessBufferTask_MissedCatchupWindow() {
+	now := s.timeSource.Now()
+	startTime := now.Add(-defaultCatchupWindow * 2)
+	startTimestamp := timestamppb.New(startTime)
+	bufferedStarts := []*schedulespb.BufferedStart{
+		{
+			NominalTime:   startTimestamp,
+			ActualTime:    startTimestamp,
+			DesiredTime:   startTimestamp,
+			Manual:        false,
+			RequestId:     "req1",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+		},
+	}
+
+	s.runProcessBufferTestCase(&processBufferTestCase{
+		InitialBufferedStarts:       bufferedStarts,
+		ExpectedBufferedStarts:      0,
+		ExpectedOverlapSkipped:      0,
+		ExpectedMissedCatchupWindow: 1,
+	})
+}
+
+// ProcessBuffer defers a start (from overlap policy) by placing it into NewBuffer.
+func (s *invokerProcessBufferTaskSuite) TestProcessBufferTask_BufferOne() {
+	startTime := timestamppb.New(s.timeSource.Now())
+	bufferedStarts := []*schedulespb.BufferedStart{
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "req1",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+		},
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "req2",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+		},
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "req3",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+		},
+	}
+
+	s.runProcessBufferTestCase(&processBufferTestCase{
+		InitialBufferedStarts: bufferedStarts,
+		// Because no workflows are running, we'll immediately kick off one
+		// BufferedStart, and then buffer the next. This leaves us with 1 ready start,
+		// and 1 still buffered.
+		ExpectedBufferedStarts: 2,
+		ExpectedOverlapSkipped: 1,
+		ValidateInvoker: func(invoker *scheduler.Invoker) {
+			// Only one start should be set for execution (Attempt > 0)
+			s.Equal(1, len(util.FilterSlice(invoker.GetBufferedStarts(), func(start *schedulespb.BufferedStart) bool {
+				return start.Attempt > 0
+			})))
+		},
+	})
+}
+
+// ProcessBuffer is scheduled with an empty buffer.
+func (s *invokerProcessBufferTaskSuite) TestProcessBufferTask_Empty() {
+	s.runProcessBufferTestCase(&processBufferTestCase{
+		InitialBufferedStarts: nil,
+	})
+}
+
+// ProcessBuffer is scheduled with a buffer of starts all backing off.
+func (s *invokerProcessBufferTaskSuite) TestProcessBufferTask_BackingOff() {
+	startTime := timestamppb.New(s.timeSource.Now())
+	backoffTime := startTime.AsTime().Add(30 * time.Minute)
+	bufferedStarts := []*schedulespb.BufferedStart{
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "req1",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       2,
+			BackoffTime:   timestamppb.New(backoffTime),
+		},
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        true,
+			RequestId:     "req2",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       3,
+			BackoffTime:   timestamppb.New(backoffTime),
+		},
+	}
+
+	s.runProcessBufferTestCase(&processBufferTestCase{
+		InitialBufferedStarts:  bufferedStarts,
+		ExpectedBufferedStarts: 2,
+	})
+}
+
+// ProcessBuffer is scheduled with a start that was backing off, but ready to retry.
+func (s *invokerProcessBufferTaskSuite) TestProcessBufferTask_BackingOffReady() {
+	startTime := timestamppb.New(s.timeSource.Now())
+	backoffTime := s.timeSource.Now().Add(-1 * time.Minute)
+	bufferedStarts := []*schedulespb.BufferedStart{
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "req1",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       2,
+			BackoffTime:   timestamppb.New(backoffTime),
+		},
+	}
+
+	s.runProcessBufferTestCase(&processBufferTestCase{
+		InitialBufferedStarts:  bufferedStarts,
+		ExpectedBufferedStarts: 1,
+		ValidateInvoker: func(invoker *scheduler.Invoker) {
+			// The start should be ready for execution (Attempt > 0)
+			s.Equal(1, len(util.FilterSlice(invoker.GetBufferedStarts(), func(start *schedulespb.BufferedStart) bool {
+				return start.Attempt > 0
+			})))
+		},
+	})
+}
+
+// A buffered start with an overlap policy to terminate other workflows is processed.
+func (s *invokerProcessBufferTaskSuite) TestProcessBufferTask_NeedsTerminate() {
+	// Add a running workflow to the Scheduler.
+	initialRunningWorkflows := []*commonpb.WorkflowExecution{{
+		WorkflowId: "existing-wf",
+		RunId:      "existing-run",
+	}}
+
+	// Set up the BufferedStart with a policy that will terminate existing workflows.
+	startTime := timestamppb.New(s.timeSource.Now())
+	bufferedStarts := []*schedulespb.BufferedStart{
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "new-wf",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER,
+		},
+	}
+
+	s.runProcessBufferTestCase(&processBufferTestCase{
+		InitialBufferedStarts:   bufferedStarts,
+		InitialRunningWorkflows: initialRunningWorkflows,
+		// Buffer should still contain the buffered start. The existing workflow will still
+		// remain in RunningWorkflows as well, since it is the Watcher's job to remove it
+		// after termination/cancelation takes effect.
+		ExpectedBufferedStarts:     1,
+		ExpectedRunningWorkflows:   1,
+		ExpectedTerminateWorkflows: 1,
+	})
+}
+
+// A buffered start with an overlap policy to cancel other workflows is processed.
+func (s *invokerProcessBufferTaskSuite) TestProcessBufferTask_NeedsCancel() {
+	// Add a running workflow to the Scheduler.
+	initialRunningWorkflows := []*commonpb.WorkflowExecution{{
+		WorkflowId: "existing-wf",
+		RunId:      "existing-run",
+	}}
+
+	// Set up the BufferedStart with a policy that will cancel existing workflows.
+	startTime := timestamppb.New(s.timeSource.Now())
+	bufferedStarts := []*schedulespb.BufferedStart{
+		{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			Manual:        false,
+			RequestId:     "new-wf",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_CANCEL_OTHER,
+		},
+	}
+
+	s.runProcessBufferTestCase(&processBufferTestCase{
+		InitialBufferedStarts:   bufferedStarts,
+		InitialRunningWorkflows: initialRunningWorkflows,
+		// Buffer should still contain the buffered start. The existing workflow will still
+		// remain in RunningWorkflows as well, since it is the Watcher's job to remove it
+		// after termination/cancelation takes effect.
+		ExpectedBufferedStarts:   1,
+		ExpectedRunningWorkflows: 1,
+		ExpectedCancelWorkflows:  1,
+	})
+}
+
+func (s *invokerProcessBufferTaskSuite) runProcessBufferTestCase(c *processBufferTestCase) {
+	ctx := s.newMutableContext()
+	invoker, err := s.scheduler.Invoker.Get(ctx)
+	s.NoError(err)
+
+	// Set up initial state
+	invoker.BufferedStarts = c.InitialBufferedStarts
+	invoker.CancelWorkflows = c.InitialCancelWorkflows
+	invoker.TerminateWorkflows = c.InitialTerminateWorkflows
+	s.scheduler.Info.RunningWorkflows = c.InitialRunningWorkflows
+
+	// Set LastProcessedTime to current time to ensure time checks pass
+	invoker.LastProcessedTime = timestamppb.New(s.timeSource.Now())
+
+	// Clear old tasks and run the process buffer task
+	s.addedTasks = make([]tasks.Task, 0)
+
+	err = s.executor.Execute(ctx, invoker, chasm.TaskAttributes{}, &schedulespb.InvokerProcessBufferTask{})
+	s.NoError(err)
+	_, err = s.node.CloseTransaction()
+	s.NoError(err)
+
+	// Validate the results
+	s.Equal(c.ExpectedBufferedStarts, len(invoker.GetBufferedStarts()))
+	s.Equal(c.ExpectedRunningWorkflows, len(s.scheduler.Info.RunningWorkflows))
+	s.Equal(c.ExpectedTerminateWorkflows, len(invoker.TerminateWorkflows))
+	s.Equal(c.ExpectedCancelWorkflows, len(invoker.CancelWorkflows))
+	s.Equal(c.ExpectedOverlapSkipped, s.scheduler.Info.OverlapSkipped)
+	s.Equal(c.ExpectedMissedCatchupWindow, s.scheduler.Info.MissedCatchupWindow)
+
+	// Callbacks
+	if c.ValidateInvoker != nil {
+		c.ValidateInvoker(invoker)
+	}
+}

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -1,0 +1,610 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/historyservice/v1"
+	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/resource"
+	"go.temporal.io/server/common/util"
+	scheduler1 "go.temporal.io/server/service/worker/scheduler"
+	"go.uber.org/fx"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type (
+	InvokerTaskExecutorOptions struct {
+		fx.In
+
+		Config         *Config
+		MetricsHandler metrics.Handler
+		BaseLogger     log.Logger
+		HistoryClient  resource.HistoryClient
+		FrontendClient workflowservice.WorkflowServiceClient
+	}
+
+	InvokerExecuteTaskExecutor struct {
+		InvokerTaskExecutorOptions
+	}
+
+	InvokerProcessBufferTaskExecutor struct {
+		InvokerTaskExecutorOptions
+	}
+
+	// Per-task context.
+	invokerTaskExecutorContext struct {
+		context.Context
+
+		actionsTaken int
+		maxActions   int
+	}
+
+	rateLimitedError struct {
+		// The requested interval to delay processing by rescheduilng.
+		delay time.Duration
+	}
+)
+
+const (
+	// Lower bound for the deadline in which buffered actions are dropped.
+	startWorkflowMinDeadline = 5 * time.Second
+
+	// Because the catchup window doesn't apply to a manual start, pick a custom
+	// execution deadline before timing out a start.
+	manualStartExecutionDeadline = 1 * time.Hour
+
+	// Upper bound on how many times starting an individual buffered action should be retried.
+	InvokerMaxStartAttempts = 10 // TODO - dial this up/remove it
+)
+
+var (
+	errRetryLimitExceeded       = errors.New("retry limit exceeded")
+	_                     error = &rateLimitedError{}
+)
+
+func NewInvokerExecuteTaskExecutor(opts InvokerTaskExecutorOptions) *InvokerExecuteTaskExecutor {
+	return &InvokerExecuteTaskExecutor{
+		InvokerTaskExecutorOptions: opts,
+	}
+}
+
+func NewInvokerProcessBufferTaskExecutor(opts InvokerTaskExecutorOptions) *InvokerProcessBufferTaskExecutor {
+	return &InvokerProcessBufferTaskExecutor{
+		InvokerTaskExecutorOptions: opts,
+	}
+}
+
+func (e *InvokerExecuteTaskExecutor) Validate(
+	_ chasm.Context,
+	invoker *Invoker,
+	_ chasm.TaskAttributes,
+	_ *schedulespb.InvokerExecuteTask,
+) (bool, error) {
+	// If another execute task already happened to kick everything off, we don't need
+	// this one.
+	eligibleStarts := invoker.getEligibleBufferedStarts()
+	valid := len(invoker.GetTerminateWorkflows())+
+		len(invoker.GetCancelWorkflows())+
+		len(eligibleStarts) > 0
+	return valid, nil
+}
+
+func (e *InvokerExecuteTaskExecutor) Execute(
+	ctx context.Context,
+	invokerRef chasm.ComponentRef,
+	_ chasm.TaskAttributes,
+	_ *schedulespb.InvokerExecuteTask,
+) error {
+	var result executeResult
+
+	invoker, err := chasm.ReadComponent(
+		ctx,
+		invokerRef,
+		func(i *Invoker, _ chasm.Context, _ struct{}) (*Invoker, error) {
+			return i, nil
+		},
+		struct{}{},
+	)
+	if err != nil {
+		return fmt.Errorf("%w: %w",
+			serviceerror.NewInternal("Failed to read component"),
+			err)
+	}
+
+	schedulerRef := chasm.ComponentRef{
+		EntityKey: invokerRef.EntityKey,
+	}
+	scheduler, err := chasm.ReadComponent(
+		ctx,
+		schedulerRef,
+		func(s *Scheduler, _ chasm.Context, _ struct{}) (*Scheduler, error) {
+			return s, nil
+		},
+		struct{}{},
+	)
+	if err != nil {
+		return fmt.Errorf("%w: %w",
+			serviceerror.NewInternal("Failed to read component"),
+			err)
+	}
+	logger := newTaggedLogger(e.BaseLogger, scheduler)
+
+	// If we have nothing to do, we can return without any additional writes.
+	eligibleStarts := invoker.getEligibleBufferedStarts()
+	if len(invoker.GetTerminateWorkflows())+
+		len(invoker.GetCancelWorkflows())+
+		len(eligibleStarts) == 0 {
+		return nil
+	}
+
+	// Terminate, cancel, and start workflows. The result struct contains the
+	// complete outcome of all requests executed in a single batch.
+	ictx := e.newInvokerTaskExecutorContext(ctx, scheduler)
+	result = result.Append(e.terminateWorkflows(ictx, logger, scheduler, invoker.GetTerminateWorkflows()))
+	result = result.Append(e.cancelWorkflows(ictx, logger, scheduler, invoker.GetCancelWorkflows()))
+	sres, startResults := e.startWorkflows(ictx, logger, scheduler, eligibleStarts)
+	result = result.Append(sres)
+
+	// Record completed executions on the Invoker (internal state).
+	_, _, err = chasm.UpdateComponent(
+		ctx,
+		invokerRef,
+		(*Invoker).recordExecuteResult,
+		&result,
+	)
+	if err != nil {
+		return fmt.Errorf("%w: %w",
+			serviceerror.NewInternal("Failed to update component state"),
+			err)
+	}
+
+	// Record action results on the Scheduler (user-facing metrics).
+	_, _, err = chasm.UpdateComponent(
+		ctx,
+		schedulerRef,
+		(*Scheduler).recordActionResult,
+		&schedulerActionResult{Starts: startResults},
+	)
+	if err != nil {
+		return fmt.Errorf("%w: %w",
+			serviceerror.NewInternal("Failed to update component state"),
+			err)
+	}
+
+	return nil
+}
+
+// takeNextAction increments the context's actionTaken counter, returning true if
+// the action should be executed, and false if the task should instead yield.
+func (c *invokerTaskExecutorContext) takeNextAction() bool {
+	taken := c.actionsTaken
+	c.actionsTaken++
+	return taken < c.maxActions
+}
+
+// cancelWorkflows does a best-effort attempt to cancel all workflow executions provided in targets.
+func (e *InvokerExecuteTaskExecutor) cancelWorkflows(
+	ctx invokerTaskExecutorContext,
+	logger log.Logger,
+	scheduler *Scheduler,
+	targets []*commonpb.WorkflowExecution,
+) (result executeResult) {
+	for _, wf := range targets {
+		if !ctx.takeNextAction() {
+			break
+		}
+
+		err := e.cancelWorkflow(ctx, scheduler, wf)
+		if err != nil {
+			logger.Error("Failed to cancel workflow", tag.Error(err), tag.WorkflowID(wf.WorkflowId))
+			e.MetricsHandler.Counter(metrics.ScheduleCancelWorkflowErrors.Name()).Record(1)
+		}
+
+		// Cancels are only attempted once.
+		result.CompletedCancels = append(result.CompletedCancels, wf)
+	}
+	return
+}
+
+// terminateWorkflows does a best-effort attempt to terminate all workflow executions provided in targets.
+func (e *InvokerExecuteTaskExecutor) terminateWorkflows(
+	ctx invokerTaskExecutorContext,
+	logger log.Logger,
+	scheduler *Scheduler,
+	targets []*commonpb.WorkflowExecution,
+) (result executeResult) {
+	for _, wf := range targets {
+		if !ctx.takeNextAction() {
+			break
+		}
+
+		err := e.terminateWorkflow(ctx, scheduler, wf)
+		if err != nil {
+			logger.Error("Failed to terminate workflow", tag.Error(err), tag.WorkflowID(wf.WorkflowId))
+			e.MetricsHandler.Counter(metrics.ScheduleTerminateWorkflowErrors.Name()).Record(1)
+		}
+
+		// Terminates are only attempted once.
+		result.CompletedTerminates = append(result.CompletedTerminates, wf)
+	}
+	return
+}
+
+// startWorkflows executes the provided list of starts, returning a result with their outcomes.
+func (e *InvokerExecuteTaskExecutor) startWorkflows(
+	ctx invokerTaskExecutorContext,
+	logger log.Logger,
+	scheduler *Scheduler,
+	starts []*schedulespb.BufferedStart,
+) (result executeResult, startResults []*schedulepb.ScheduleActionResult) {
+	metricsWithTag := e.MetricsHandler.WithTags(
+		metrics.StringTag(metrics.ScheduleActionTypeTag, metrics.ScheduleActionStartWorkflow))
+
+	for _, start := range starts {
+		// Starts that haven't been executed yet will remain in `BufferedStarts`,
+		// without change, so another ExecuteTask will be immediately created to continue
+		// processing in a new task.
+		if !ctx.takeNextAction() {
+			break
+		}
+
+		startResult, err := e.startWorkflow(ctx, scheduler, start)
+		if err != nil {
+			logger.Error("Failed to start workflow", tag.Error(err))
+
+			// Don't count "already started" for the error metric or retry, as it is most likely
+			// due to misconfiguration.
+			if !isAlreadyStartedError(err) {
+				metricsWithTag.Counter(metrics.ScheduleActionErrors.Name()).Record(1)
+			}
+
+			if isRetryableError(err) {
+				// Apply backoff to start and retry.
+				e.applyBackoff(start, err)
+				result.RetryableStarts = append(result.RetryableStarts, start)
+			} else {
+				// Drop the start from the buffer.
+				result.FailedStarts = append(result.FailedStarts, start)
+			}
+
+			continue
+		}
+
+		metricsWithTag.Counter(metrics.ScheduleActionSuccess.Name()).Record(1)
+		result.CompletedStarts = append(result.CompletedStarts, start)
+		startResults = append(startResults, startResult)
+	}
+	return
+}
+
+func (e *InvokerProcessBufferTaskExecutor) Validate(
+	ctx chasm.Context,
+	invoker *Invoker,
+	attrs chasm.TaskAttributes,
+	_ *schedulespb.InvokerProcessBufferTask,
+) (bool, error) {
+	return validateTaskHighWaterMark(invoker.GetLastProcessedTime(), attrs.ScheduledTime)
+}
+
+func (e *InvokerProcessBufferTaskExecutor) Execute(
+	ctx chasm.MutableContext,
+	invoker *Invoker,
+	_ chasm.TaskAttributes,
+	_ *schedulespb.InvokerProcessBufferTask,
+) error {
+	scheduler, err := invoker.Scheduler.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("%w: %w",
+			serviceerror.NewInternal("Failed to read component"),
+			err)
+	}
+
+	// Make sure we have something to start. If not, we can clear the buffer and
+	// complete without adding more tasks.
+	executionInfo := scheduler.Schedule.Action.GetStartWorkflow()
+	if executionInfo == nil || len(invoker.GetBufferedStarts()) == 0 {
+		invoker.recordProcessBufferResult(ctx, &processBufferResult{
+			DiscardStarts: invoker.GetBufferedStarts(),
+		})
+		return nil
+	}
+
+	// Compute actions to take from the current buffer.
+	result := e.processBuffer(ctx, invoker, scheduler)
+
+	// Update Scheduler metadata.
+	_, err = scheduler.recordActionResult(ctx, &schedulerActionResult{
+		OverlapSkipped:      result.OverlapSkipped,
+		BufferDropped:       result.BufferDropped,
+		MissedCatchupWindow: result.MissedCatchupWindow,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Update internal state and create new tasks.
+	invoker.recordProcessBufferResult(ctx, &result)
+
+	return nil
+}
+
+// processBuffer resolves the Invoker's buffered starts that haven't yet begun
+// execution. This is where the decision is made to drive execution to
+// completion, or skip/drop a start.
+func (e *InvokerProcessBufferTaskExecutor) processBuffer(
+	ctx chasm.MutableContext,
+	invoker *Invoker,
+	scheduler *Scheduler,
+) (result processBufferResult) {
+	isRunning := len(scheduler.Info.RunningWorkflows) > 0
+
+	// Processing completely ignores any BufferedStart that's already executing/backing off.
+	pendingBufferedStarts := util.FilterSlice(invoker.GetBufferedStarts(), func(start *schedulespb.BufferedStart) bool {
+		return start.Attempt == 0
+	})
+
+	// Resolve overlap policies and trim BufferedStarts that are skipped by policy.
+	action := scheduler1.ProcessBuffer(pendingBufferedStarts, isRunning, scheduler.resolveOverlapPolicy)
+
+	// ProcessBuffer will drop starts by omitting them from NewBuffer. Start with the
+	// diff between the input and NewBuffer, and add any executing starts.
+	keepStarts := make(map[string]struct{}) // request ID -> is present
+	for _, start := range action.NewBuffer {
+		keepStarts[start.GetRequestId()] = struct{}{}
+	}
+
+	// Combine all available starts.
+	readyStarts := action.OverlappingStarts
+	if action.NonOverlappingStart != nil {
+		readyStarts = append(readyStarts, action.NonOverlappingStart)
+	}
+
+	// Update result metrics.
+	result.OverlapSkipped = action.OverlapSkipped
+
+	// Add starting workflows to result, trim others.
+	for _, start := range readyStarts {
+		// Ensure we can take more actions. Manual actions are always allowed.
+		if !start.Manual && !scheduler.useScheduledAction(true) {
+			// Drop buffered automated actions while paused.
+			result.DiscardStarts = append(result.DiscardStarts, start)
+			continue
+		}
+
+		if ctx.Now(invoker).After(e.startWorkflowDeadline(scheduler, start)) {
+			// Drop expired starts.
+			result.MissedCatchupWindow++
+			result.DiscardStarts = append(result.DiscardStarts, start)
+			continue
+		}
+
+		// Append for immediate execution.
+		keepStarts[start.GetRequestId()] = struct{}{}
+		result.StartWorkflows = append(result.StartWorkflows, start)
+	}
+
+	result.DiscardStarts = util.FilterSlice(pendingBufferedStarts, func(start *schedulespb.BufferedStart) bool {
+		_, keep := keepStarts[start.GetRequestId()]
+		return !keep
+	})
+
+	// Terminate overrides cancel if both are requested.
+	if action.NeedTerminate {
+		result.TerminateWorkflows = scheduler.GetInfo().GetRunningWorkflows()
+	} else if action.NeedCancel {
+		result.CancelWorkflows = scheduler.GetInfo().GetRunningWorkflows()
+	}
+
+	return
+}
+
+// applyBackoff updates start's BackoffTime based on err and the retry policy.
+func (e *InvokerExecuteTaskExecutor) applyBackoff(start *schedulespb.BufferedStart, err error) {
+	if err == nil {
+		return
+	}
+
+	var delay time.Duration
+	if rateLimitDelay, ok := isRateLimitedError(err); ok {
+		// If we have the rate limiter's delay, use that.
+		delay = rateLimitDelay
+	} else {
+		// Otherwise, use the backoff policy. Elapsed time is left at 0 because we bound
+		// on number of attempts.
+		delay = e.Config.RetryPolicy().ComputeNextDelay(0, int(start.Attempt), nil)
+	}
+
+	start.BackoffTime = timestamppb.New(time.Now().Add(delay))
+}
+
+// startWorkflowDeadline returns the latest time at which a buffered workflow
+// should be started, instead of dropped. The deadline puts an upper bound on
+// the number of retry attempts per buffered start.
+func (e *InvokerTaskExecutorOptions) startWorkflowDeadline(
+	scheduler *Scheduler,
+	start *schedulespb.BufferedStart,
+) time.Time {
+	var timeout time.Duration
+	if start.Manual {
+		// For manual starts, use a default static value, as the catchup window doesn't apply.
+		timeout = manualStartExecutionDeadline
+	} else {
+		// Set request deadline based on the schedule's catchup window, which is the
+		// latest time that it's acceptable to start this workflow.
+		tweakables := e.Config.Tweakables(scheduler.Namespace)
+		timeout = catchupWindow(scheduler, tweakables)
+	}
+
+	timeout = max(timeout, startWorkflowMinDeadline)
+
+	return start.ActualTime.AsTime().Add(timeout)
+}
+
+func (e *InvokerExecuteTaskExecutor) startWorkflow(
+	ctx context.Context,
+	scheduler *Scheduler,
+	start *schedulespb.BufferedStart,
+) (*schedulepb.ScheduleActionResult, error) {
+	requestSpec := scheduler.GetSchedule().GetAction().GetStartWorkflow()
+	nominalTimeSec := start.NominalTime.AsTime().Truncate(time.Second)
+	workflowID := fmt.Sprintf("%s-%s", requestSpec.WorkflowId, nominalTimeSec.Format(time.RFC3339))
+
+	if start.Attempt >= InvokerMaxStartAttempts {
+		return nil, errRetryLimitExceeded
+	}
+
+	// Get rate limiter permission once per buffered start, on the first attempt only.
+	if start.Attempt == 1 {
+		delay, err := e.getRateLimiterPermission()
+		if err != nil {
+			return nil, err
+		}
+		if delay > 0 {
+			return nil, newRateLimitedError(delay)
+		}
+	}
+
+	reusePolicy := enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
+	if start.Manual {
+		reusePolicy = enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
+	}
+
+	// TODO - set last completion result/continued failure (watcher)
+	// TODO - set search attributes
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		Namespace:                scheduler.Namespace,
+		WorkflowId:               workflowID,
+		WorkflowType:             requestSpec.WorkflowType,
+		TaskQueue:                requestSpec.TaskQueue,
+		Input:                    requestSpec.Input,
+		WorkflowExecutionTimeout: requestSpec.WorkflowExecutionTimeout,
+		WorkflowRunTimeout:       requestSpec.WorkflowRunTimeout,
+		WorkflowTaskTimeout:      requestSpec.WorkflowTaskTimeout,
+		Identity:                 scheduler.identity(),
+		RequestId:                start.RequestId,
+		WorkflowIdReusePolicy:    reusePolicy,
+		RetryPolicy:              requestSpec.RetryPolicy,
+		Memo:                     requestSpec.Memo,
+		SearchAttributes:         nil,
+		Header:                   requestSpec.Header,
+		LastCompletionResult:     nil,
+		ContinuedFailure:         nil,
+		UserMetadata:             requestSpec.UserMetadata,
+	}
+	result, err := e.FrontendClient.StartWorkflowExecution(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return &schedulepb.ScheduleActionResult{
+		ScheduleTime: start.ActualTime,
+		ActualTime:   timestamppb.New(time.Now()),
+		StartWorkflowResult: &commonpb.WorkflowExecution{
+			WorkflowId: workflowID,
+			RunId:      result.RunId,
+		},
+		StartWorkflowStatus: result.Status, // usually should be RUNNING
+	}, nil
+}
+
+func (e *InvokerExecuteTaskExecutor) terminateWorkflow(
+	ctx context.Context,
+	scheduler *Scheduler,
+	target *commonpb.WorkflowExecution,
+) error {
+	request := &historyservice.TerminateWorkflowExecutionRequest{
+		NamespaceId: scheduler.NamespaceId,
+		TerminateRequest: &workflowservice.TerminateWorkflowExecutionRequest{
+			Namespace:           scheduler.Namespace,
+			WorkflowExecution:   &commonpb.WorkflowExecution{WorkflowId: target.WorkflowId},
+			Reason:              "terminated by schedule overlap policy",
+			Identity:            scheduler.identity(),
+			FirstExecutionRunId: target.RunId,
+		},
+	}
+	_, err := e.HistoryClient.TerminateWorkflowExecution(ctx, request)
+	return err
+}
+
+func (e *InvokerExecuteTaskExecutor) cancelWorkflow(
+	ctx context.Context,
+	scheduler *Scheduler,
+	target *commonpb.WorkflowExecution,
+) error {
+	request := &historyservice.RequestCancelWorkflowExecutionRequest{
+		NamespaceId: scheduler.NamespaceId,
+		CancelRequest: &workflowservice.RequestCancelWorkflowExecutionRequest{
+			Namespace:           scheduler.Namespace,
+			WorkflowExecution:   &commonpb.WorkflowExecution{WorkflowId: target.WorkflowId},
+			Reason:              "cancelled by schedule overlap policy",
+			Identity:            scheduler.identity(),
+			FirstExecutionRunId: target.RunId,
+		},
+	}
+	_, err := e.HistoryClient.RequestCancelWorkflowExecution(ctx, request)
+	return err
+}
+
+// getRateLimiterPermission returns a delay for which the caller should wait
+// before proceeding. If an error is returned, execution should not proceed, and
+// reservation should be retried.
+func (e *InvokerExecuteTaskExecutor) getRateLimiterPermission() (delay time.Duration, err error) {
+	// For now, we're only going to rate limit via APS.
+	return
+}
+
+func isAlreadyStartedError(err error) bool {
+	var expectedErr *serviceerror.WorkflowExecutionAlreadyStarted
+	return errors.As(err, &expectedErr)
+}
+
+func isRateLimitedError(err error) (time.Duration, bool) {
+	var expectedErr *rateLimitedError
+	if errors.As(err, &expectedErr) {
+		return expectedErr.delay, true
+	}
+	return 0, false
+}
+
+func isRetryableError(err error) bool {
+	_, rateLimited := isRateLimitedError(err)
+	return !errors.Is(err, errRetryLimitExceeded) &&
+		(rateLimited ||
+			common.IsServiceTransientError(err) ||
+			common.IsContextDeadlineExceededErr(err))
+}
+
+func newRateLimitedError(delay time.Duration) error {
+	return &rateLimitedError{delay}
+}
+
+func (r *rateLimitedError) Error() string {
+	return fmt.Sprintf("rate limited for %s", r.delay)
+}
+
+func (e *InvokerExecuteTaskExecutor) newInvokerTaskExecutorContext(
+	ctx context.Context,
+	scheduler *Scheduler,
+) invokerTaskExecutorContext {
+	tweakables := e.Config.Tweakables(scheduler.Namespace)
+	maxActions := tweakables.MaxActionsPerExecution
+
+	return invokerTaskExecutorContext{
+		Context:      ctx,
+		actionsTaken: 0,
+		maxActions:   maxActions,
+	}
+}


### PR DESCRIPTION
## What changed?
- Port Invoker tasks to CHASM.
- Invoker is now mercifully split into two (still large) parts: `invokerExecuteTask` and `invokerProcessBufferTask`
- I wanted to do the 1:1 port from what HSM had before I started adding in CHASM visibility and workflow watcher; I'll be following with both of those. 
- I'm considering just getting rid of the local rate limiting hooks - I don't think we plan to make use of them at this point. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
