### PR TITLE
Use handle for dynamicconfig.Key

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -85,7 +85,7 @@ func buildCLI() *cli.App {
 					if err != nil {
 						return err
 					}
-					result := dynamicconfig.ValidateFile(contents)
+					result := dynamicconfig.LoadYamlFile(contents)
 					total += len(result.Errors)
 					fmt.Println(fileName)
 					t := template.Must(template.New("").Parse(

--- a/cmd/tools/gendynamicconfig/dynamic_config.tmpl
+++ b/cmd/tools/gendynamicconfig/dynamic_config.tmpl
@@ -26,9 +26,9 @@ type {{$P.Name}}TypedSetting[T any] setting[T, func({{$P.GoArgs}})]
 // New{{$P.Name}}TypedSetting creates a setting that uses mapstructure to handle complex structured
 // values. The value from dynamic config will be copied over a shallow copy of 'def', which means
 // 'def' must not contain any non-nil slices, maps, or pointers.
-func New{{$P.Name}}TypedSetting[T any](key Key, def T, description string) {{$P.Name}}TypedSetting[T] {
+func New{{$P.Name}}TypedSetting[T any](key string, def T, description string) {{$P.Name}}TypedSetting[T] {
 	s := {{$P.Name}}TypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     ConvertStructure[T](def),
 		description: description,
@@ -38,9 +38,9 @@ func New{{$P.Name}}TypedSetting[T any](key Key, def T, description string) {{$P.
 }
 
 // New{{$P.Name}}TypedSettingWithConverter creates a setting with a custom converter function.
-func New{{$P.Name}}TypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) {{$P.Name}}TypedSetting[T] {
+func New{{$P.Name}}TypedSettingWithConverter[T any](key string, convert func(any) (T, error), def T, description string) {{$P.Name}}TypedSetting[T] {
 	s := {{$P.Name}}TypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     convert,
 		description: description,
@@ -50,9 +50,9 @@ func New{{$P.Name}}TypedSettingWithConverter[T any](key Key, convert func(any) (
 }
 
 // New{{$P.Name}}TypedSettingWithConstrainedDefault creates a setting with a compound default value.
-func New{{$P.Name}}TypedSettingWithConstrainedDefault[T any](key Key, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) {{$P.Name}}TypedSetting[T] {
+func New{{$P.Name}}TypedSettingWithConstrainedDefault[T any](key string, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) {{$P.Name}}TypedSetting[T] {
 	s := {{$P.Name}}TypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		cdef:        &cdef,
 		convert:     convert,
 		description: description,
@@ -139,11 +139,11 @@ func GetTypedPropertyFnFilteredBy{{$P.Name}}[T any](value T) TypedPropertyFnWith
 {{else -}}
 type {{$P.Name}}{{$T.Name}}Setting = {{$P.Name}}TypedSetting[{{$T.GoType}}]
 
-func New{{$P.Name}}{{$T.Name}}Setting(key Key, def {{$T.GoType}}, description string) {{$P.Name}}{{$T.Name}}Setting {
+func New{{$P.Name}}{{$T.Name}}Setting(key string, def {{$T.GoType}}, description string) {{$P.Name}}{{$T.Name}}Setting {
 	return New{{$P.Name}}TypedSettingWithConverter[{{$T.GoType}}](key, convert{{$T.Name}}, def, description)
 }
 
-func New{{$P.Name}}{{$T.Name}}SettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[{{$T.GoType}}], description string) {{$P.Name}}{{$T.Name}}Setting {
+func New{{$P.Name}}{{$T.Name}}SettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[{{$T.GoType}}], description string) {{$P.Name}}{{$T.Name}}Setting {
 	return New{{$P.Name}}TypedSettingWithConstrainedDefault[{{$T.GoType}}](key, convert{{$T.Name}}, cdef, description)
 }
 

--- a/common/dynamicconfig/client.go
+++ b/common/dynamicconfig/client.go
@@ -1,6 +1,8 @@
 package dynamicconfig
 
 import (
+	"strings"
+
 	enumspb "go.temporal.io/api/enums/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 )
@@ -31,7 +33,7 @@ type (
 	NotifyingClient interface {
 		// Adds a subscription to all updates from this Client. `update` will be called on any
 		// change to the current value set. The caller should call `cancel` to cancel the
-		// subscription. Calls to `update` will not be made concurrently.
+		// subscription.
 		Subscribe(update ClientUpdateFunc) (cancel func())
 	}
 
@@ -96,4 +98,8 @@ type (
 
 func (k Key) String() string {
 	return string(k)
+}
+
+func (k Key) Lower() Key {
+	return Key(strings.ToLower(string(k)))
 }

--- a/common/dynamicconfig/client.go
+++ b/common/dynamicconfig/client.go
@@ -1,8 +1,6 @@
 package dynamicconfig
 
 import (
-	"strings"
-
 	enumspb "go.temporal.io/api/enums/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 )
@@ -40,10 +38,6 @@ type (
 	// Called with modified keys on any change to the current value set.
 	// Deleted keys/constraints will get a nil value.
 	ClientUpdateFunc func(map[Key][]ConstrainedValue)
-
-	// Key is a key/property stored in dynamic config. For convenience, it is recommended that
-	// you treat keys as case-insensitive.
-	Key string
 
 	// ConstrainedValue is a value plus associated constraints.
 	//
@@ -95,11 +89,3 @@ type (
 		Destination   string
 	}
 )
-
-func (k Key) String() string {
-	return string(k)
-}
-
-func (k Key) Lower() Key {
-	return Key(strings.ToLower(string(k)))
-}

--- a/common/dynamicconfig/client_diff.go
+++ b/common/dynamicconfig/client_diff.go
@@ -84,7 +84,7 @@ func diffAndLogValue(logger log.Logger, key Key, oldValue *ConstrainedValue, new
 	logLine := &strings.Builder{}
 	logLine.Grow(128)
 	logLine.WriteString("dynamic config changed for the key: ")
-	logLine.WriteString(string(key))
+	logLine.WriteString(key.String())
 	logLine.WriteString(" oldValue: ")
 	appendConstrainedValue(logLine, oldValue)
 	logLine.WriteString(" newValue: ")

--- a/common/dynamicconfig/client_diff.go
+++ b/common/dynamicconfig/client_diff.go
@@ -1,0 +1,123 @@
+package dynamicconfig
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/common/log"
+)
+
+// DiffAndLogConfigs computes the difference between two ConfigValueMaps. The result is
+// returned as a ConfigValueMap that can be merged with old to produce new, except with deleted
+// keys mapped to nil. It also logs the differences to a logger.
+func DiffAndLogConfigs(logger log.Logger, old ConfigValueMap, new ConfigValueMap) ConfigValueMap {
+	changedMap := make(map[Key][]ConstrainedValue)
+
+	for key, newValues := range new {
+		oldValues, ok := old[key]
+		if !ok {
+			for _, newValue := range newValues {
+				// new key added
+				diffAndLogValue(logger, key, nil, &newValue)
+			}
+			changedMap[Key(key)] = newValues
+		} else {
+			// compare existing keys
+			changed := diffAndLogConstraints(logger, key, oldValues, newValues)
+			if changed {
+				changedMap[Key(key)] = newValues
+			}
+		}
+	}
+
+	// check for removed values
+	for key, oldValues := range old {
+		if _, ok := new[key]; !ok {
+			for _, oldValue := range oldValues {
+				diffAndLogValue(logger, key, &oldValue, nil)
+			}
+			changedMap[Key(key)] = nil
+		}
+	}
+
+	return changedMap
+}
+
+func diffAndLogConstraints(logger log.Logger, key Key, oldValues []ConstrainedValue, newValues []ConstrainedValue) bool {
+	changed := false
+	for _, oldValue := range oldValues {
+		matchFound := false
+		for _, newValue := range newValues {
+			if oldValue.Constraints == newValue.Constraints {
+				matchFound = true
+				if !reflect.DeepEqual(oldValue.Value, newValue.Value) {
+					diffAndLogValue(logger, key, &oldValue, &newValue)
+					changed = true
+				}
+			}
+		}
+		if !matchFound {
+			diffAndLogValue(logger, key, &oldValue, nil)
+			changed = true
+		}
+	}
+
+	for _, newValue := range newValues {
+		matchFound := false
+		for _, oldValue := range oldValues {
+			if oldValue.Constraints == newValue.Constraints {
+				matchFound = true
+			}
+		}
+		if !matchFound {
+			diffAndLogValue(logger, key, nil, &newValue)
+			changed = true
+		}
+	}
+	return changed
+}
+
+func diffAndLogValue(logger log.Logger, key Key, oldValue *ConstrainedValue, newValue *ConstrainedValue) {
+	logLine := &strings.Builder{}
+	logLine.Grow(128)
+	logLine.WriteString("dynamic config changed for the key: ")
+	logLine.WriteString(string(key))
+	logLine.WriteString(" oldValue: ")
+	appendConstrainedValue(logLine, oldValue)
+	logLine.WriteString(" newValue: ")
+	appendConstrainedValue(logLine, newValue)
+	logger.Info(logLine.String())
+}
+
+func appendConstrainedValue(logLine *strings.Builder, value *ConstrainedValue) {
+	if value == nil {
+		logLine.WriteString("nil")
+	} else {
+		logLine.WriteString("{ constraints: {")
+		if value.Constraints.Namespace != "" {
+			logLine.WriteString(fmt.Sprintf("{Namespace:%s}", value.Constraints.Namespace))
+		}
+		if value.Constraints.NamespaceID != "" {
+			logLine.WriteString(fmt.Sprintf("{NamespaceID:%s}", value.Constraints.NamespaceID))
+		}
+		if value.Constraints.TaskQueueName != "" {
+			logLine.WriteString(fmt.Sprintf("{TaskQueueName:%s}", value.Constraints.TaskQueueName))
+		}
+		if value.Constraints.TaskQueueType != enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
+			logLine.WriteString(fmt.Sprintf("{TaskQueueType:%s}", value.Constraints.TaskQueueType))
+		}
+		if value.Constraints.ShardID != 0 {
+			logLine.WriteString(fmt.Sprintf("{ShardID:%d}", value.Constraints.ShardID))
+		}
+		if value.Constraints.TaskType != enumsspb.TASK_TYPE_UNSPECIFIED {
+			logLine.WriteString(fmt.Sprintf("{HistoryTaskType:%s}", value.Constraints.TaskType))
+		}
+		if value.Constraints.Destination != "" {
+			logLine.WriteString(fmt.Sprintf("{Destination:%s}", value.Constraints.Destination))
+		}
+		logLine.WriteString(fmt.Sprint("} value: ", value.Value, " }"))
+	}
+}

--- a/common/dynamicconfig/client_subscriptions.go
+++ b/common/dynamicconfig/client_subscriptions.go
@@ -1,0 +1,54 @@
+package dynamicconfig
+
+import (
+	"sync"
+
+	expmaps "golang.org/x/exp/maps"
+)
+
+type (
+	// NotifyingClientImpl implements NotifyingClient and is intended to be embedded in another struct.
+	// NotifyingClientImpl must not be copied after first use.
+	NotifyingClientImpl struct {
+		subscriptionLock sync.Mutex
+		subscriptionIdx  int
+		subscriptions    map[int]ClientUpdateFunc
+	}
+)
+
+var _ NotifyingClient = (*NotifyingClientImpl)(nil)
+
+func NewNotifyingClientImpl() NotifyingClientImpl {
+	return NotifyingClientImpl{subscriptions: make(map[int]ClientUpdateFunc)}
+}
+
+// Adds a subscription to all updates from this Client.
+func (n *NotifyingClientImpl) Subscribe(f ClientUpdateFunc) (cancel func()) {
+	n.subscriptionLock.Lock()
+	defer n.subscriptionLock.Unlock()
+
+	n.subscriptionIdx++
+	id := n.subscriptionIdx
+	n.subscriptions[id] = f
+
+	return func() {
+		n.subscriptionLock.Lock()
+		defer n.subscriptionLock.Unlock()
+		delete(n.subscriptions, id)
+	}
+}
+
+// PublishUpdates calls all subscribed update functions with the changed keys.
+func (n *NotifyingClientImpl) PublishUpdates(changed map[Key][]ConstrainedValue) {
+	if len(changed) == 0 {
+		return
+	}
+
+	n.subscriptionLock.Lock()
+	subscriptions := expmaps.Values(n.subscriptions)
+	n.subscriptionLock.Unlock()
+
+	for _, update := range subscriptions {
+		update(changed)
+	}
+}

--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -77,7 +77,7 @@ func NewFileBasedClientWithReader(reader FileReader, config *FileBasedClientConf
 
 func (fc *fileBasedClient) GetValue(key Key) []ConstrainedValue {
 	values := fc.values.Load().(ConfigValueMap)
-	return values[key.Lower()]
+	return values[key]
 }
 
 func (fc *fileBasedClient) init() error {

--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -1,23 +1,15 @@
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination file_based_client_mock.go
-
 package dynamicconfig
 
 import (
 	"errors"
 	"fmt"
 	"os"
-	"reflect"
-	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
-	enumspb "go.temporal.io/api/enums/v1"
-	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
-	expmaps "golang.org/x/exp/maps"
-	"gopkg.in/yaml.v3"
 )
 
 var _ Client = (*fileBasedClient)(nil)
@@ -41,38 +33,21 @@ type (
 		PollInterval time.Duration `yaml:"pollInterval"`
 	}
 
-	configValueMap map[string][]ConstrainedValue
-
 	fileBasedClient struct {
-		values          atomic.Value // configValueMap
+		values          atomic.Value // ConfigValueMap
 		logger          log.Logger
 		reader          FileReader
 		lastUpdatedTime time.Time
 		config          *FileBasedClientConfig
 		doneCh          <-chan interface{}
 
-		subscriptionLock sync.Mutex
-		subscriptionIdx  int
-		subscriptions    map[int]ClientUpdateFunc
+		NotifyingClientImpl
 	}
 
 	osReader struct {
 		path string
 	}
-
-	// Results of processing and loading dynamic config file contents.
-	// Warnings should be reported but not block using the new values.
-	// Errors should abort the loading process.
-	LoadResult struct {
-		Warnings []error
-		Errors   []error
-	}
 )
-
-func ValidateFile(contents []byte) *LoadResult {
-	_, lr := loadFile(contents)
-	return lr
-}
 
 // NewFileBasedClient creates a file based client.
 func NewFileBasedClient(config *FileBasedClientConfig, logger log.Logger, doneCh <-chan interface{}) (*fileBasedClient, error) {
@@ -85,11 +60,11 @@ func NewFileBasedClient(config *FileBasedClientConfig, logger log.Logger, doneCh
 
 func NewFileBasedClientWithReader(reader FileReader, config *FileBasedClientConfig, logger log.Logger, doneCh <-chan interface{}) (*fileBasedClient, error) {
 	client := &fileBasedClient{
-		logger:        logger,
-		reader:        reader,
-		config:        config,
-		doneCh:        doneCh,
-		subscriptions: make(map[int]ClientUpdateFunc),
+		logger:              logger,
+		reader:              reader,
+		config:              config,
+		doneCh:              doneCh,
+		NotifyingClientImpl: NewNotifyingClientImpl(),
 	}
 
 	err := client.init()
@@ -101,23 +76,8 @@ func NewFileBasedClientWithReader(reader FileReader, config *FileBasedClientConf
 }
 
 func (fc *fileBasedClient) GetValue(key Key) []ConstrainedValue {
-	values := fc.values.Load().(configValueMap)
-	return values[strings.ToLower(key.String())]
-}
-
-func (fc *fileBasedClient) Subscribe(f ClientUpdateFunc) (cancel func()) {
-	fc.subscriptionLock.Lock()
-	defer fc.subscriptionLock.Unlock()
-
-	fc.subscriptionIdx++
-	id := fc.subscriptionIdx
-	fc.subscriptions[id] = f
-
-	return func() {
-		fc.subscriptionLock.Lock()
-		defer fc.subscriptionLock.Unlock()
-		delete(fc.subscriptions, id)
-	}
+	values := fc.values.Load().(ConfigValueMap)
+	return values[key.Lower()]
 }
 
 func (fc *fileBasedClient) init() error {
@@ -165,7 +125,7 @@ func (fc *fileBasedClient) Update() error {
 		return fmt.Errorf("dynamic config file: %s: %w", fc.config.Filepath, err)
 	}
 
-	newValues, lr := loadFile(contents)
+	lr := LoadYamlFile(contents)
 	for _, e := range lr.Errors {
 		fc.logger.Warn("dynamic config error", tag.Error(e))
 	}
@@ -177,72 +137,13 @@ func (fc *fileBasedClient) Update() error {
 			len(lr.Errors), len(lr.Warnings))
 	}
 
-	prev := fc.values.Swap(newValues)
-	oldValues, _ := prev.(configValueMap)
-	changedMap := fc.diffAndLog(oldValues, newValues)
+	prev := fc.values.Swap(lr.Map)
+	oldValues, _ := prev.(ConfigValueMap)
+	changedMap := DiffAndLogConfigs(fc.logger, oldValues, lr.Map)
 	fc.logger.Info("Updated dynamic config")
 
-	if len(changedMap) == 0 {
-		return nil
-	}
-
-	fc.subscriptionLock.Lock()
-	subscriptions := expmaps.Values(fc.subscriptions)
-	fc.subscriptionLock.Unlock()
-
-	for _, update := range subscriptions {
-		update(changedMap)
-	}
-
+	fc.PublishUpdates(changedMap)
 	return nil
-}
-
-func loadFile(contents []byte) (configValueMap, *LoadResult) {
-	lr := &LoadResult{}
-
-	var yamlValues map[string][]struct {
-		Constraints map[string]any
-		Value       any
-	}
-	if err := yaml.Unmarshal(contents, &yamlValues); err != nil {
-		return nil, lr.errorf("decode error: %w", err)
-	}
-
-	newValues := make(configValueMap, len(yamlValues))
-	for key, yamlCV := range yamlValues {
-		precedence := PrecedenceUnknown
-		setting := queryRegistry(Key(key))
-		if setting == nil {
-			lr.warnf("unregistered key %q", key)
-		} else {
-			precedence = setting.Precedence()
-		}
-
-		cvs := make([]ConstrainedValue, len(yamlCV))
-		for i, cv := range yamlCV {
-			// yaml will unmarshal map into map[interface{}]interface{} instead of map[string]interface{}
-			// manually convert key type to string for all values here
-			val, err := convertKeyTypeToString(cv.Value)
-			if err != nil {
-				lr.error(err)
-				continue
-			}
-
-			// try validating if known setting
-			if setting != nil {
-				if valErr := setting.Validate(val); valErr != nil {
-					// TODO: raise this to error level
-					lr.warnf("validation failed: key %q value %v: %w", key, cv.Value, valErr)
-				}
-			}
-
-			cvs[i].Value = val
-			cvs[i].Constraints = convertYamlConstraints(key, cv.Constraints, precedence, lr)
-		}
-		newValues[strings.ToLower(key)] = cvs
-	}
-
-	return newValues, lr
 }
 
 func (fc *fileBasedClient) validateStaticConfig(config *FileBasedClientConfig) error {
@@ -258,244 +159,6 @@ func (fc *fileBasedClient) validateStaticConfig(config *FileBasedClientConfig) e
 	return nil
 }
 
-func (fc *fileBasedClient) diffAndLog(old configValueMap, new configValueMap) map[Key][]ConstrainedValue {
-	changedMap := make(map[Key][]ConstrainedValue)
-
-	for key, newValues := range new {
-		oldValues, ok := old[key]
-		if !ok {
-			for _, newValue := range newValues {
-				// new key added
-				fc.diffAndLogValue(key, nil, &newValue)
-			}
-			changedMap[Key(key)] = newValues
-		} else {
-			// compare existing keys
-			changed := fc.diffAndLogConstraints(key, oldValues, newValues)
-			if changed {
-				changedMap[Key(key)] = newValues
-			}
-		}
-	}
-
-	// check for removed values
-	for key, oldValues := range old {
-		if _, ok := new[key]; !ok {
-			for _, oldValue := range oldValues {
-				fc.diffAndLogValue(key, &oldValue, nil)
-			}
-			changedMap[Key(key)] = nil
-		}
-	}
-
-	return changedMap
-}
-
-func (fc *fileBasedClient) diffAndLogConstraints(key string, oldValues []ConstrainedValue, newValues []ConstrainedValue) bool {
-	changed := false
-	for _, oldValue := range oldValues {
-		matchFound := false
-		for _, newValue := range newValues {
-			if oldValue.Constraints == newValue.Constraints {
-				matchFound = true
-				if !reflect.DeepEqual(oldValue.Value, newValue.Value) {
-					fc.diffAndLogValue(key, &oldValue, &newValue)
-					changed = true
-				}
-			}
-		}
-		if !matchFound {
-			fc.diffAndLogValue(key, &oldValue, nil)
-			changed = true
-		}
-	}
-
-	for _, newValue := range newValues {
-		matchFound := false
-		for _, oldValue := range oldValues {
-			if oldValue.Constraints == newValue.Constraints {
-				matchFound = true
-			}
-		}
-		if !matchFound {
-			fc.diffAndLogValue(key, nil, &newValue)
-			changed = true
-		}
-	}
-	return changed
-}
-
-func (fc *fileBasedClient) diffAndLogValue(key string, oldValue *ConstrainedValue, newValue *ConstrainedValue) {
-	logLine := &strings.Builder{}
-	logLine.Grow(128)
-	logLine.WriteString("dynamic config changed for the key: ")
-	logLine.WriteString(key)
-	logLine.WriteString(" oldValue: ")
-	fc.appendConstrainedValue(logLine, oldValue)
-	logLine.WriteString(" newValue: ")
-	fc.appendConstrainedValue(logLine, newValue)
-	fc.logger.Info(logLine.String())
-}
-
-func (fc *fileBasedClient) appendConstrainedValue(logLine *strings.Builder, value *ConstrainedValue) {
-	if value == nil {
-		logLine.WriteString("nil")
-	} else {
-		logLine.WriteString("{ constraints: {")
-		if value.Constraints.Namespace != "" {
-			logLine.WriteString(fmt.Sprintf("{Namespace:%s}", value.Constraints.Namespace))
-		}
-		if value.Constraints.NamespaceID != "" {
-			logLine.WriteString(fmt.Sprintf("{NamespaceID:%s}", value.Constraints.NamespaceID))
-		}
-		if value.Constraints.TaskQueueName != "" {
-			logLine.WriteString(fmt.Sprintf("{TaskQueueName:%s}", value.Constraints.TaskQueueName))
-		}
-		if value.Constraints.TaskQueueType != enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
-			logLine.WriteString(fmt.Sprintf("{TaskQueueType:%s}", value.Constraints.TaskQueueType))
-		}
-		if value.Constraints.ShardID != 0 {
-			logLine.WriteString(fmt.Sprintf("{ShardID:%d}", value.Constraints.ShardID))
-		}
-		if value.Constraints.TaskType != enumsspb.TASK_TYPE_UNSPECIFIED {
-			logLine.WriteString(fmt.Sprintf("{HistoryTaskType:%s}", value.Constraints.TaskType))
-		}
-		if value.Constraints.Destination != "" {
-			logLine.WriteString(fmt.Sprintf("{Destination:%s}", value.Constraints.Destination))
-		}
-		logLine.WriteString(fmt.Sprint("} value: ", value.Value, " }"))
-	}
-}
-
-func convertKeyTypeToString(v interface{}) (interface{}, error) {
-	switch v := v.(type) {
-	case map[interface{}]interface{}:
-		return convertKeyTypeToStringMap(v)
-	case []interface{}:
-		return convertKeyTypeToStringSlice(v)
-	default:
-		return v, nil
-	}
-}
-
-func convertKeyTypeToStringMap(m map[interface{}]interface{}) (map[string]interface{}, error) {
-	stringKeyMap := make(map[string]interface{})
-	for key, value := range m {
-		stringKey, ok := key.(string)
-		if !ok {
-			return nil, fmt.Errorf("type of key %v is not string", key)
-		}
-		convertedValue, err := convertKeyTypeToString(value)
-		if err != nil {
-			return nil, err
-		}
-		stringKeyMap[stringKey] = convertedValue
-	}
-	return stringKeyMap, nil
-}
-
-func convertKeyTypeToStringSlice(s []interface{}) ([]interface{}, error) {
-	stringKeySlice := make([]interface{}, len(s))
-	for idx, value := range s {
-		convertedValue, err := convertKeyTypeToString(value)
-		if err != nil {
-			return nil, err
-		}
-		stringKeySlice[idx] = convertedValue
-	}
-	return stringKeySlice, nil
-}
-
-func convertYamlConstraints(key string, m map[string]any, precedence Precedence, lr *LoadResult) Constraints {
-	var cs Constraints
-	for k, v := range m {
-		validConstraint := true
-		switch strings.ToLower(k) {
-		case "namespace":
-			if v, ok := v.(string); ok {
-				cs.Namespace = v
-			} else {
-				lr.errorf("namespace constraint must be string")
-			}
-			validConstraint = precedence == PrecedenceNamespace || precedence == PrecedenceTaskQueue || precedence == PrecedenceDestination
-		case "namespaceid":
-			if v, ok := v.(string); ok {
-				cs.NamespaceID = v
-			} else {
-				lr.errorf("namespaceID constraint must be string")
-			}
-			validConstraint = precedence == PrecedenceNamespaceID
-		case "taskqueuename":
-			if v, ok := v.(string); ok {
-				cs.TaskQueueName = v
-			} else {
-				lr.errorf("taskQueueName constraint must be string")
-			}
-			validConstraint = precedence == PrecedenceTaskQueue
-		case "tasktype":
-			switch v := v.(type) {
-			case string:
-				i, err := enumspb.TaskQueueTypeFromString(v)
-				if err != nil {
-					lr.errorf("invalid value for taskType: %w", err)
-				} else if i <= enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
-					lr.errorf("taskType constraint must be Workflow/Activity")
-				}
-				cs.TaskQueueType = i
-			case int:
-				if v > int(enumspb.TASK_QUEUE_TYPE_UNSPECIFIED) {
-					cs.TaskQueueType = enumspb.TaskQueueType(v)
-				} else {
-					lr.errorf("taskType constraint must be Workflow/Activity")
-				}
-			default:
-				lr.errorf("taskType constraint must be Workflow/Activity")
-			}
-			validConstraint = precedence == PrecedenceTaskQueue
-		case "historytasktype":
-			switch v := v.(type) {
-			case string:
-				tt, err := enumsspb.TaskTypeFromString(v)
-				if err != nil {
-					lr.errorf("invalid value for historytasktype constraint: %w", err)
-				} else if tt <= enumsspb.TASK_TYPE_UNSPECIFIED {
-					lr.errorf("historytasktype %s constraint is not supported", v)
-				}
-				cs.TaskType = tt
-			case int:
-				cs.TaskType = enumsspb.TaskType(v)
-			default:
-				lr.errorf("historytasktype %T constraint is not supported", v)
-			}
-			validConstraint = precedence == PrecedenceTaskType
-		case "shardid":
-			if v, ok := v.(int); ok {
-				cs.ShardID = int32(v)
-			} else {
-				lr.errorf("shardID constraint must be integer")
-			}
-			validConstraint = precedence == PrecedenceShardID
-		case "destination":
-			if v, ok := v.(string); ok {
-				cs.Destination = v
-			} else {
-				lr.errorf("destination constraint must be string")
-			}
-			validConstraint = precedence == PrecedenceDestination
-		default:
-			lr.errorf("unknown constraint type %q", k)
-		}
-
-		// don't log error for PrecedenceUnknown, we would already have logged for an
-		// unregistered key above
-		// TODO: raise this to error level
-		if !validConstraint && precedence != PrecedenceUnknown {
-			lr.warnf("constraint %q isn't valid for dynamic config key %q", k, key)
-		}
-	}
-	return cs
-}
-
 func (r *osReader) ReadFile() ([]byte, error) {
 	return os.ReadFile(r.path)
 }
@@ -506,22 +169,4 @@ func (r *osReader) GetModTime() (time.Time, error) {
 		return time.Time{}, err
 	}
 	return fi.ModTime(), nil
-}
-
-func (lr *LoadResult) warn(err error) *LoadResult {
-	lr.Warnings = append(lr.Warnings, err)
-	return lr
-}
-
-func (lr *LoadResult) warnf(format string, args ...any) *LoadResult {
-	return lr.warn(fmt.Errorf(format, args...))
-}
-
-func (lr *LoadResult) error(err error) *LoadResult {
-	lr.Errors = append(lr.Errors, err)
-	return lr
-}
-
-func (lr *LoadResult) errorf(format string, args ...any) *LoadResult {
-	return lr.error(fmt.Errorf(format, args...))
 }

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -543,7 +543,7 @@ testGetFloat64PropertyKey:
 func (s *fileBasedClientSuite) TestWarnUnregisteredKey() {
 	dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 0, "")
 
-	lr := dynamicconfig.ValidateFile([]byte(`
+	lr := dynamicconfig.LoadYamlFile([]byte(`
 testGetIntPropertyKey:
 - value: 2000
 testGetFloat64PropertyKey:
@@ -557,7 +557,7 @@ testGetFloat64PropertyKey:
 func (s *fileBasedClientSuite) TestWarnValidationInt() {
 	dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 0, "")
 
-	lr := dynamicconfig.ValidateFile([]byte(`
+	lr := dynamicconfig.LoadYamlFile([]byte(`
 testGetIntPropertyKey:
 - value: not a number
 `))
@@ -569,7 +569,7 @@ testGetIntPropertyKey:
 func (s *fileBasedClientSuite) TestWarnConstraint() {
 	dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 0, "")
 
-	lr := dynamicconfig.ValidateFile([]byte(`
+	lr := dynamicconfig.LoadYamlFile([]byte(`
 testGetIntPropertyKey:
 - value: 5005
   constraints:
@@ -583,7 +583,7 @@ testGetIntPropertyKey:
 func (s *fileBasedClientSuite) TestWarnMultiple() {
 	dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 0, "")
 
-	lr := dynamicconfig.ValidateFile([]byte(`
+	lr := dynamicconfig.LoadYamlFile([]byte(`
 unknownKey:
 - value: "5d"
 testGetIntPropertyKey:
@@ -596,7 +596,7 @@ testGetIntPropertyKey:
 }
 
 func (s *fileBasedClientSuite) TestErrorYamlDecode() {
-	lr := dynamicconfig.ValidateFile([]byte(`}}}}}}}}}`))
+	lr := dynamicconfig.LoadYamlFile([]byte(`}}}}}}}}}`))
 	s.Equal(1, len(lr.Errors))
 	s.ErrorContains(lr.Errors[0], "decode error")
 }
@@ -604,7 +604,7 @@ func (s *fileBasedClientSuite) TestErrorYamlDecode() {
 func (s *fileBasedClientSuite) TestErrorBadConstraint() {
 	dynamicconfig.NewNamespaceBoolSetting(testGetBoolPropertyKey, true, "")
 
-	lr := dynamicconfig.ValidateFile([]byte(`
+	lr := dynamicconfig.LoadYamlFile([]byte(`
 testGetBoolPropertyKey:
 - value: false
   constraints:
@@ -617,7 +617,7 @@ testGetBoolPropertyKey:
 func (s *fileBasedClientSuite) TestErrorBadConstraints() {
 	dynamicconfig.NewTaskQueueBoolSetting(testGetBoolPropertyKey, true, "")
 
-	lr := dynamicconfig.ValidateFile([]byte(`
+	lr := dynamicconfig.LoadYamlFile([]byte(`
 testGetBoolPropertyKey:
 - value: false
   constraints:

--- a/common/dynamicconfig/key.go
+++ b/common/dynamicconfig/key.go
@@ -1,0 +1,21 @@
+package dynamicconfig
+
+import (
+	"strings"
+	"unique"
+)
+
+type (
+	// Key is a key/property stored in dynamic config.
+	Key struct {
+		handle unique.Handle[string] // string must be lower-case
+	}
+)
+
+func MakeKey(s string) Key {
+	return Key{handle: unique.Make(strings.ToLower(s))}
+}
+
+func (k Key) String() string {
+	return k.handle.Value()
+}

--- a/common/dynamicconfig/registry.go
+++ b/common/dynamicconfig/registry.go
@@ -2,13 +2,12 @@ package dynamicconfig
 
 import (
 	"fmt"
-	"strings"
 	"sync/atomic"
 )
 
 type (
 	registry struct {
-		settings map[string]GenericSetting
+		settings map[Key]GenericSetting
 		queried  atomic.Bool
 	}
 )
@@ -22,20 +21,20 @@ func register(s GenericSetting) {
 		panic("dynamicconfig.New*Setting must only be called from static initializers")
 	}
 	if globalRegistry.settings == nil {
-		globalRegistry.settings = make(map[string]GenericSetting)
+		globalRegistry.settings = make(map[Key]GenericSetting)
 	}
-	keyStr := strings.ToLower(s.Key().String())
-	if globalRegistry.settings[keyStr] != nil {
-		panic(fmt.Sprintf("duplicate registration of dynamic config key: %q", keyStr))
+	lowerKey := s.Key().Lower()
+	if globalRegistry.settings[lowerKey] != nil {
+		panic(fmt.Sprintf("duplicate registration of dynamic config key: %q", lowerKey))
 	}
-	globalRegistry.settings[keyStr] = s
+	globalRegistry.settings[lowerKey] = s
 }
 
 func queryRegistry(k Key) GenericSetting {
 	if !globalRegistry.queried.Load() {
 		globalRegistry.queried.Store(true)
 	}
-	return globalRegistry.settings[strings.ToLower(k.String())]
+	return globalRegistry.settings[k.Lower()]
 }
 
 // For testing only; do not call from regular code!

--- a/common/dynamicconfig/registry.go
+++ b/common/dynamicconfig/registry.go
@@ -23,18 +23,17 @@ func register(s GenericSetting) {
 	if globalRegistry.settings == nil {
 		globalRegistry.settings = make(map[Key]GenericSetting)
 	}
-	lowerKey := s.Key().Lower()
-	if globalRegistry.settings[lowerKey] != nil {
-		panic(fmt.Sprintf("duplicate registration of dynamic config key: %q", lowerKey))
+	if globalRegistry.settings[s.Key()] != nil {
+		panic(fmt.Sprintf("duplicate registration of dynamic config key: %q", s.Key().String()))
 	}
-	globalRegistry.settings[lowerKey] = s
+	globalRegistry.settings[s.Key()] = s
 }
 
 func queryRegistry(k Key) GenericSetting {
 	if !globalRegistry.queried.Load() {
 		globalRegistry.queried.Store(true)
 	}
-	return globalRegistry.settings[k.Lower()]
+	return globalRegistry.settings[k]
 }
 
 // For testing only; do not call from regular code!

--- a/common/dynamicconfig/setting_gen.go
+++ b/common/dynamicconfig/setting_gen.go
@@ -23,11 +23,11 @@ const (
 
 type GlobalBoolSetting = GlobalTypedSetting[bool]
 
-func NewGlobalBoolSetting(key Key, def bool, description string) GlobalBoolSetting {
+func NewGlobalBoolSetting(key string, def bool, description string) GlobalBoolSetting {
 	return NewGlobalTypedSettingWithConverter[bool](key, convertBool, def, description)
 }
 
-func NewGlobalBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[bool], description string) GlobalBoolSetting {
+func NewGlobalBoolSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[bool], description string) GlobalBoolSetting {
 	return NewGlobalTypedSettingWithConstrainedDefault[bool](key, convertBool, cdef, description)
 }
 
@@ -39,11 +39,11 @@ func GetBoolPropertyFn(value bool) BoolPropertyFn {
 
 type NamespaceBoolSetting = NamespaceTypedSetting[bool]
 
-func NewNamespaceBoolSetting(key Key, def bool, description string) NamespaceBoolSetting {
+func NewNamespaceBoolSetting(key string, def bool, description string) NamespaceBoolSetting {
 	return NewNamespaceTypedSettingWithConverter[bool](key, convertBool, def, description)
 }
 
-func NewNamespaceBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[bool], description string) NamespaceBoolSetting {
+func NewNamespaceBoolSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[bool], description string) NamespaceBoolSetting {
 	return NewNamespaceTypedSettingWithConstrainedDefault[bool](key, convertBool, cdef, description)
 }
 
@@ -55,11 +55,11 @@ func GetBoolPropertyFnFilteredByNamespace(value bool) BoolPropertyFnWithNamespac
 
 type NamespaceIDBoolSetting = NamespaceIDTypedSetting[bool]
 
-func NewNamespaceIDBoolSetting(key Key, def bool, description string) NamespaceIDBoolSetting {
+func NewNamespaceIDBoolSetting(key string, def bool, description string) NamespaceIDBoolSetting {
 	return NewNamespaceIDTypedSettingWithConverter[bool](key, convertBool, def, description)
 }
 
-func NewNamespaceIDBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[bool], description string) NamespaceIDBoolSetting {
+func NewNamespaceIDBoolSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[bool], description string) NamespaceIDBoolSetting {
 	return NewNamespaceIDTypedSettingWithConstrainedDefault[bool](key, convertBool, cdef, description)
 }
 
@@ -71,11 +71,11 @@ func GetBoolPropertyFnFilteredByNamespaceID(value bool) BoolPropertyFnWithNamesp
 
 type TaskQueueBoolSetting = TaskQueueTypedSetting[bool]
 
-func NewTaskQueueBoolSetting(key Key, def bool, description string) TaskQueueBoolSetting {
+func NewTaskQueueBoolSetting(key string, def bool, description string) TaskQueueBoolSetting {
 	return NewTaskQueueTypedSettingWithConverter[bool](key, convertBool, def, description)
 }
 
-func NewTaskQueueBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[bool], description string) TaskQueueBoolSetting {
+func NewTaskQueueBoolSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[bool], description string) TaskQueueBoolSetting {
 	return NewTaskQueueTypedSettingWithConstrainedDefault[bool](key, convertBool, cdef, description)
 }
 
@@ -87,11 +87,11 @@ func GetBoolPropertyFnFilteredByTaskQueue(value bool) BoolPropertyFnWithTaskQueu
 
 type ShardIDBoolSetting = ShardIDTypedSetting[bool]
 
-func NewShardIDBoolSetting(key Key, def bool, description string) ShardIDBoolSetting {
+func NewShardIDBoolSetting(key string, def bool, description string) ShardIDBoolSetting {
 	return NewShardIDTypedSettingWithConverter[bool](key, convertBool, def, description)
 }
 
-func NewShardIDBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[bool], description string) ShardIDBoolSetting {
+func NewShardIDBoolSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[bool], description string) ShardIDBoolSetting {
 	return NewShardIDTypedSettingWithConstrainedDefault[bool](key, convertBool, cdef, description)
 }
 
@@ -103,11 +103,11 @@ func GetBoolPropertyFnFilteredByShardID(value bool) BoolPropertyFnWithShardIDFil
 
 type TaskTypeBoolSetting = TaskTypeTypedSetting[bool]
 
-func NewTaskTypeBoolSetting(key Key, def bool, description string) TaskTypeBoolSetting {
+func NewTaskTypeBoolSetting(key string, def bool, description string) TaskTypeBoolSetting {
 	return NewTaskTypeTypedSettingWithConverter[bool](key, convertBool, def, description)
 }
 
-func NewTaskTypeBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[bool], description string) TaskTypeBoolSetting {
+func NewTaskTypeBoolSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[bool], description string) TaskTypeBoolSetting {
 	return NewTaskTypeTypedSettingWithConstrainedDefault[bool](key, convertBool, cdef, description)
 }
 
@@ -119,11 +119,11 @@ func GetBoolPropertyFnFilteredByTaskType(value bool) BoolPropertyFnWithTaskTypeF
 
 type DestinationBoolSetting = DestinationTypedSetting[bool]
 
-func NewDestinationBoolSetting(key Key, def bool, description string) DestinationBoolSetting {
+func NewDestinationBoolSetting(key string, def bool, description string) DestinationBoolSetting {
 	return NewDestinationTypedSettingWithConverter[bool](key, convertBool, def, description)
 }
 
-func NewDestinationBoolSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[bool], description string) DestinationBoolSetting {
+func NewDestinationBoolSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[bool], description string) DestinationBoolSetting {
 	return NewDestinationTypedSettingWithConstrainedDefault[bool](key, convertBool, cdef, description)
 }
 
@@ -135,11 +135,11 @@ func GetBoolPropertyFnFilteredByDestination(value bool) BoolPropertyFnWithDestin
 
 type GlobalIntSetting = GlobalTypedSetting[int]
 
-func NewGlobalIntSetting(key Key, def int, description string) GlobalIntSetting {
+func NewGlobalIntSetting(key string, def int, description string) GlobalIntSetting {
 	return NewGlobalTypedSettingWithConverter[int](key, convertInt, def, description)
 }
 
-func NewGlobalIntSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[int], description string) GlobalIntSetting {
+func NewGlobalIntSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[int], description string) GlobalIntSetting {
 	return NewGlobalTypedSettingWithConstrainedDefault[int](key, convertInt, cdef, description)
 }
 
@@ -151,11 +151,11 @@ func GetIntPropertyFn(value int) IntPropertyFn {
 
 type NamespaceIntSetting = NamespaceTypedSetting[int]
 
-func NewNamespaceIntSetting(key Key, def int, description string) NamespaceIntSetting {
+func NewNamespaceIntSetting(key string, def int, description string) NamespaceIntSetting {
 	return NewNamespaceTypedSettingWithConverter[int](key, convertInt, def, description)
 }
 
-func NewNamespaceIntSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[int], description string) NamespaceIntSetting {
+func NewNamespaceIntSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[int], description string) NamespaceIntSetting {
 	return NewNamespaceTypedSettingWithConstrainedDefault[int](key, convertInt, cdef, description)
 }
 
@@ -167,11 +167,11 @@ func GetIntPropertyFnFilteredByNamespace(value int) IntPropertyFnWithNamespaceFi
 
 type NamespaceIDIntSetting = NamespaceIDTypedSetting[int]
 
-func NewNamespaceIDIntSetting(key Key, def int, description string) NamespaceIDIntSetting {
+func NewNamespaceIDIntSetting(key string, def int, description string) NamespaceIDIntSetting {
 	return NewNamespaceIDTypedSettingWithConverter[int](key, convertInt, def, description)
 }
 
-func NewNamespaceIDIntSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[int], description string) NamespaceIDIntSetting {
+func NewNamespaceIDIntSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[int], description string) NamespaceIDIntSetting {
 	return NewNamespaceIDTypedSettingWithConstrainedDefault[int](key, convertInt, cdef, description)
 }
 
@@ -183,11 +183,11 @@ func GetIntPropertyFnFilteredByNamespaceID(value int) IntPropertyFnWithNamespace
 
 type TaskQueueIntSetting = TaskQueueTypedSetting[int]
 
-func NewTaskQueueIntSetting(key Key, def int, description string) TaskQueueIntSetting {
+func NewTaskQueueIntSetting(key string, def int, description string) TaskQueueIntSetting {
 	return NewTaskQueueTypedSettingWithConverter[int](key, convertInt, def, description)
 }
 
-func NewTaskQueueIntSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[int], description string) TaskQueueIntSetting {
+func NewTaskQueueIntSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[int], description string) TaskQueueIntSetting {
 	return NewTaskQueueTypedSettingWithConstrainedDefault[int](key, convertInt, cdef, description)
 }
 
@@ -199,11 +199,11 @@ func GetIntPropertyFnFilteredByTaskQueue(value int) IntPropertyFnWithTaskQueueFi
 
 type ShardIDIntSetting = ShardIDTypedSetting[int]
 
-func NewShardIDIntSetting(key Key, def int, description string) ShardIDIntSetting {
+func NewShardIDIntSetting(key string, def int, description string) ShardIDIntSetting {
 	return NewShardIDTypedSettingWithConverter[int](key, convertInt, def, description)
 }
 
-func NewShardIDIntSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[int], description string) ShardIDIntSetting {
+func NewShardIDIntSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[int], description string) ShardIDIntSetting {
 	return NewShardIDTypedSettingWithConstrainedDefault[int](key, convertInt, cdef, description)
 }
 
@@ -215,11 +215,11 @@ func GetIntPropertyFnFilteredByShardID(value int) IntPropertyFnWithShardIDFilter
 
 type TaskTypeIntSetting = TaskTypeTypedSetting[int]
 
-func NewTaskTypeIntSetting(key Key, def int, description string) TaskTypeIntSetting {
+func NewTaskTypeIntSetting(key string, def int, description string) TaskTypeIntSetting {
 	return NewTaskTypeTypedSettingWithConverter[int](key, convertInt, def, description)
 }
 
-func NewTaskTypeIntSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[int], description string) TaskTypeIntSetting {
+func NewTaskTypeIntSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[int], description string) TaskTypeIntSetting {
 	return NewTaskTypeTypedSettingWithConstrainedDefault[int](key, convertInt, cdef, description)
 }
 
@@ -231,11 +231,11 @@ func GetIntPropertyFnFilteredByTaskType(value int) IntPropertyFnWithTaskTypeFilt
 
 type DestinationIntSetting = DestinationTypedSetting[int]
 
-func NewDestinationIntSetting(key Key, def int, description string) DestinationIntSetting {
+func NewDestinationIntSetting(key string, def int, description string) DestinationIntSetting {
 	return NewDestinationTypedSettingWithConverter[int](key, convertInt, def, description)
 }
 
-func NewDestinationIntSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[int], description string) DestinationIntSetting {
+func NewDestinationIntSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[int], description string) DestinationIntSetting {
 	return NewDestinationTypedSettingWithConstrainedDefault[int](key, convertInt, cdef, description)
 }
 
@@ -247,11 +247,11 @@ func GetIntPropertyFnFilteredByDestination(value int) IntPropertyFnWithDestinati
 
 type GlobalFloatSetting = GlobalTypedSetting[float64]
 
-func NewGlobalFloatSetting(key Key, def float64, description string) GlobalFloatSetting {
+func NewGlobalFloatSetting(key string, def float64, description string) GlobalFloatSetting {
 	return NewGlobalTypedSettingWithConverter[float64](key, convertFloat, def, description)
 }
 
-func NewGlobalFloatSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[float64], description string) GlobalFloatSetting {
+func NewGlobalFloatSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[float64], description string) GlobalFloatSetting {
 	return NewGlobalTypedSettingWithConstrainedDefault[float64](key, convertFloat, cdef, description)
 }
 
@@ -263,11 +263,11 @@ func GetFloatPropertyFn(value float64) FloatPropertyFn {
 
 type NamespaceFloatSetting = NamespaceTypedSetting[float64]
 
-func NewNamespaceFloatSetting(key Key, def float64, description string) NamespaceFloatSetting {
+func NewNamespaceFloatSetting(key string, def float64, description string) NamespaceFloatSetting {
 	return NewNamespaceTypedSettingWithConverter[float64](key, convertFloat, def, description)
 }
 
-func NewNamespaceFloatSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[float64], description string) NamespaceFloatSetting {
+func NewNamespaceFloatSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[float64], description string) NamespaceFloatSetting {
 	return NewNamespaceTypedSettingWithConstrainedDefault[float64](key, convertFloat, cdef, description)
 }
 
@@ -279,11 +279,11 @@ func GetFloatPropertyFnFilteredByNamespace(value float64) FloatPropertyFnWithNam
 
 type NamespaceIDFloatSetting = NamespaceIDTypedSetting[float64]
 
-func NewNamespaceIDFloatSetting(key Key, def float64, description string) NamespaceIDFloatSetting {
+func NewNamespaceIDFloatSetting(key string, def float64, description string) NamespaceIDFloatSetting {
 	return NewNamespaceIDTypedSettingWithConverter[float64](key, convertFloat, def, description)
 }
 
-func NewNamespaceIDFloatSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[float64], description string) NamespaceIDFloatSetting {
+func NewNamespaceIDFloatSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[float64], description string) NamespaceIDFloatSetting {
 	return NewNamespaceIDTypedSettingWithConstrainedDefault[float64](key, convertFloat, cdef, description)
 }
 
@@ -295,11 +295,11 @@ func GetFloatPropertyFnFilteredByNamespaceID(value float64) FloatPropertyFnWithN
 
 type TaskQueueFloatSetting = TaskQueueTypedSetting[float64]
 
-func NewTaskQueueFloatSetting(key Key, def float64, description string) TaskQueueFloatSetting {
+func NewTaskQueueFloatSetting(key string, def float64, description string) TaskQueueFloatSetting {
 	return NewTaskQueueTypedSettingWithConverter[float64](key, convertFloat, def, description)
 }
 
-func NewTaskQueueFloatSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[float64], description string) TaskQueueFloatSetting {
+func NewTaskQueueFloatSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[float64], description string) TaskQueueFloatSetting {
 	return NewTaskQueueTypedSettingWithConstrainedDefault[float64](key, convertFloat, cdef, description)
 }
 
@@ -311,11 +311,11 @@ func GetFloatPropertyFnFilteredByTaskQueue(value float64) FloatPropertyFnWithTas
 
 type ShardIDFloatSetting = ShardIDTypedSetting[float64]
 
-func NewShardIDFloatSetting(key Key, def float64, description string) ShardIDFloatSetting {
+func NewShardIDFloatSetting(key string, def float64, description string) ShardIDFloatSetting {
 	return NewShardIDTypedSettingWithConverter[float64](key, convertFloat, def, description)
 }
 
-func NewShardIDFloatSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[float64], description string) ShardIDFloatSetting {
+func NewShardIDFloatSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[float64], description string) ShardIDFloatSetting {
 	return NewShardIDTypedSettingWithConstrainedDefault[float64](key, convertFloat, cdef, description)
 }
 
@@ -327,11 +327,11 @@ func GetFloatPropertyFnFilteredByShardID(value float64) FloatPropertyFnWithShard
 
 type TaskTypeFloatSetting = TaskTypeTypedSetting[float64]
 
-func NewTaskTypeFloatSetting(key Key, def float64, description string) TaskTypeFloatSetting {
+func NewTaskTypeFloatSetting(key string, def float64, description string) TaskTypeFloatSetting {
 	return NewTaskTypeTypedSettingWithConverter[float64](key, convertFloat, def, description)
 }
 
-func NewTaskTypeFloatSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[float64], description string) TaskTypeFloatSetting {
+func NewTaskTypeFloatSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[float64], description string) TaskTypeFloatSetting {
 	return NewTaskTypeTypedSettingWithConstrainedDefault[float64](key, convertFloat, cdef, description)
 }
 
@@ -343,11 +343,11 @@ func GetFloatPropertyFnFilteredByTaskType(value float64) FloatPropertyFnWithTask
 
 type DestinationFloatSetting = DestinationTypedSetting[float64]
 
-func NewDestinationFloatSetting(key Key, def float64, description string) DestinationFloatSetting {
+func NewDestinationFloatSetting(key string, def float64, description string) DestinationFloatSetting {
 	return NewDestinationTypedSettingWithConverter[float64](key, convertFloat, def, description)
 }
 
-func NewDestinationFloatSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[float64], description string) DestinationFloatSetting {
+func NewDestinationFloatSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[float64], description string) DestinationFloatSetting {
 	return NewDestinationTypedSettingWithConstrainedDefault[float64](key, convertFloat, cdef, description)
 }
 
@@ -359,11 +359,11 @@ func GetFloatPropertyFnFilteredByDestination(value float64) FloatPropertyFnWithD
 
 type GlobalStringSetting = GlobalTypedSetting[string]
 
-func NewGlobalStringSetting(key Key, def string, description string) GlobalStringSetting {
+func NewGlobalStringSetting(key string, def string, description string) GlobalStringSetting {
 	return NewGlobalTypedSettingWithConverter[string](key, convertString, def, description)
 }
 
-func NewGlobalStringSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[string], description string) GlobalStringSetting {
+func NewGlobalStringSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[string], description string) GlobalStringSetting {
 	return NewGlobalTypedSettingWithConstrainedDefault[string](key, convertString, cdef, description)
 }
 
@@ -375,11 +375,11 @@ func GetStringPropertyFn(value string) StringPropertyFn {
 
 type NamespaceStringSetting = NamespaceTypedSetting[string]
 
-func NewNamespaceStringSetting(key Key, def string, description string) NamespaceStringSetting {
+func NewNamespaceStringSetting(key string, def string, description string) NamespaceStringSetting {
 	return NewNamespaceTypedSettingWithConverter[string](key, convertString, def, description)
 }
 
-func NewNamespaceStringSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[string], description string) NamespaceStringSetting {
+func NewNamespaceStringSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[string], description string) NamespaceStringSetting {
 	return NewNamespaceTypedSettingWithConstrainedDefault[string](key, convertString, cdef, description)
 }
 
@@ -391,11 +391,11 @@ func GetStringPropertyFnFilteredByNamespace(value string) StringPropertyFnWithNa
 
 type NamespaceIDStringSetting = NamespaceIDTypedSetting[string]
 
-func NewNamespaceIDStringSetting(key Key, def string, description string) NamespaceIDStringSetting {
+func NewNamespaceIDStringSetting(key string, def string, description string) NamespaceIDStringSetting {
 	return NewNamespaceIDTypedSettingWithConverter[string](key, convertString, def, description)
 }
 
-func NewNamespaceIDStringSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[string], description string) NamespaceIDStringSetting {
+func NewNamespaceIDStringSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[string], description string) NamespaceIDStringSetting {
 	return NewNamespaceIDTypedSettingWithConstrainedDefault[string](key, convertString, cdef, description)
 }
 
@@ -407,11 +407,11 @@ func GetStringPropertyFnFilteredByNamespaceID(value string) StringPropertyFnWith
 
 type TaskQueueStringSetting = TaskQueueTypedSetting[string]
 
-func NewTaskQueueStringSetting(key Key, def string, description string) TaskQueueStringSetting {
+func NewTaskQueueStringSetting(key string, def string, description string) TaskQueueStringSetting {
 	return NewTaskQueueTypedSettingWithConverter[string](key, convertString, def, description)
 }
 
-func NewTaskQueueStringSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[string], description string) TaskQueueStringSetting {
+func NewTaskQueueStringSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[string], description string) TaskQueueStringSetting {
 	return NewTaskQueueTypedSettingWithConstrainedDefault[string](key, convertString, cdef, description)
 }
 
@@ -423,11 +423,11 @@ func GetStringPropertyFnFilteredByTaskQueue(value string) StringPropertyFnWithTa
 
 type ShardIDStringSetting = ShardIDTypedSetting[string]
 
-func NewShardIDStringSetting(key Key, def string, description string) ShardIDStringSetting {
+func NewShardIDStringSetting(key string, def string, description string) ShardIDStringSetting {
 	return NewShardIDTypedSettingWithConverter[string](key, convertString, def, description)
 }
 
-func NewShardIDStringSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[string], description string) ShardIDStringSetting {
+func NewShardIDStringSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[string], description string) ShardIDStringSetting {
 	return NewShardIDTypedSettingWithConstrainedDefault[string](key, convertString, cdef, description)
 }
 
@@ -439,11 +439,11 @@ func GetStringPropertyFnFilteredByShardID(value string) StringPropertyFnWithShar
 
 type TaskTypeStringSetting = TaskTypeTypedSetting[string]
 
-func NewTaskTypeStringSetting(key Key, def string, description string) TaskTypeStringSetting {
+func NewTaskTypeStringSetting(key string, def string, description string) TaskTypeStringSetting {
 	return NewTaskTypeTypedSettingWithConverter[string](key, convertString, def, description)
 }
 
-func NewTaskTypeStringSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[string], description string) TaskTypeStringSetting {
+func NewTaskTypeStringSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[string], description string) TaskTypeStringSetting {
 	return NewTaskTypeTypedSettingWithConstrainedDefault[string](key, convertString, cdef, description)
 }
 
@@ -455,11 +455,11 @@ func GetStringPropertyFnFilteredByTaskType(value string) StringPropertyFnWithTas
 
 type DestinationStringSetting = DestinationTypedSetting[string]
 
-func NewDestinationStringSetting(key Key, def string, description string) DestinationStringSetting {
+func NewDestinationStringSetting(key string, def string, description string) DestinationStringSetting {
 	return NewDestinationTypedSettingWithConverter[string](key, convertString, def, description)
 }
 
-func NewDestinationStringSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[string], description string) DestinationStringSetting {
+func NewDestinationStringSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[string], description string) DestinationStringSetting {
 	return NewDestinationTypedSettingWithConstrainedDefault[string](key, convertString, cdef, description)
 }
 
@@ -471,11 +471,11 @@ func GetStringPropertyFnFilteredByDestination(value string) StringPropertyFnWith
 
 type GlobalDurationSetting = GlobalTypedSetting[time.Duration]
 
-func NewGlobalDurationSetting(key Key, def time.Duration, description string) GlobalDurationSetting {
+func NewGlobalDurationSetting(key string, def time.Duration, description string) GlobalDurationSetting {
 	return NewGlobalTypedSettingWithConverter[time.Duration](key, convertDuration, def, description)
 }
 
-func NewGlobalDurationSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[time.Duration], description string) GlobalDurationSetting {
+func NewGlobalDurationSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[time.Duration], description string) GlobalDurationSetting {
 	return NewGlobalTypedSettingWithConstrainedDefault[time.Duration](key, convertDuration, cdef, description)
 }
 
@@ -487,11 +487,11 @@ func GetDurationPropertyFn(value time.Duration) DurationPropertyFn {
 
 type NamespaceDurationSetting = NamespaceTypedSetting[time.Duration]
 
-func NewNamespaceDurationSetting(key Key, def time.Duration, description string) NamespaceDurationSetting {
+func NewNamespaceDurationSetting(key string, def time.Duration, description string) NamespaceDurationSetting {
 	return NewNamespaceTypedSettingWithConverter[time.Duration](key, convertDuration, def, description)
 }
 
-func NewNamespaceDurationSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[time.Duration], description string) NamespaceDurationSetting {
+func NewNamespaceDurationSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[time.Duration], description string) NamespaceDurationSetting {
 	return NewNamespaceTypedSettingWithConstrainedDefault[time.Duration](key, convertDuration, cdef, description)
 }
 
@@ -503,11 +503,11 @@ func GetDurationPropertyFnFilteredByNamespace(value time.Duration) DurationPrope
 
 type NamespaceIDDurationSetting = NamespaceIDTypedSetting[time.Duration]
 
-func NewNamespaceIDDurationSetting(key Key, def time.Duration, description string) NamespaceIDDurationSetting {
+func NewNamespaceIDDurationSetting(key string, def time.Duration, description string) NamespaceIDDurationSetting {
 	return NewNamespaceIDTypedSettingWithConverter[time.Duration](key, convertDuration, def, description)
 }
 
-func NewNamespaceIDDurationSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[time.Duration], description string) NamespaceIDDurationSetting {
+func NewNamespaceIDDurationSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[time.Duration], description string) NamespaceIDDurationSetting {
 	return NewNamespaceIDTypedSettingWithConstrainedDefault[time.Duration](key, convertDuration, cdef, description)
 }
 
@@ -519,11 +519,11 @@ func GetDurationPropertyFnFilteredByNamespaceID(value time.Duration) DurationPro
 
 type TaskQueueDurationSetting = TaskQueueTypedSetting[time.Duration]
 
-func NewTaskQueueDurationSetting(key Key, def time.Duration, description string) TaskQueueDurationSetting {
+func NewTaskQueueDurationSetting(key string, def time.Duration, description string) TaskQueueDurationSetting {
 	return NewTaskQueueTypedSettingWithConverter[time.Duration](key, convertDuration, def, description)
 }
 
-func NewTaskQueueDurationSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[time.Duration], description string) TaskQueueDurationSetting {
+func NewTaskQueueDurationSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[time.Duration], description string) TaskQueueDurationSetting {
 	return NewTaskQueueTypedSettingWithConstrainedDefault[time.Duration](key, convertDuration, cdef, description)
 }
 
@@ -535,11 +535,11 @@ func GetDurationPropertyFnFilteredByTaskQueue(value time.Duration) DurationPrope
 
 type ShardIDDurationSetting = ShardIDTypedSetting[time.Duration]
 
-func NewShardIDDurationSetting(key Key, def time.Duration, description string) ShardIDDurationSetting {
+func NewShardIDDurationSetting(key string, def time.Duration, description string) ShardIDDurationSetting {
 	return NewShardIDTypedSettingWithConverter[time.Duration](key, convertDuration, def, description)
 }
 
-func NewShardIDDurationSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[time.Duration], description string) ShardIDDurationSetting {
+func NewShardIDDurationSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[time.Duration], description string) ShardIDDurationSetting {
 	return NewShardIDTypedSettingWithConstrainedDefault[time.Duration](key, convertDuration, cdef, description)
 }
 
@@ -551,11 +551,11 @@ func GetDurationPropertyFnFilteredByShardID(value time.Duration) DurationPropert
 
 type TaskTypeDurationSetting = TaskTypeTypedSetting[time.Duration]
 
-func NewTaskTypeDurationSetting(key Key, def time.Duration, description string) TaskTypeDurationSetting {
+func NewTaskTypeDurationSetting(key string, def time.Duration, description string) TaskTypeDurationSetting {
 	return NewTaskTypeTypedSettingWithConverter[time.Duration](key, convertDuration, def, description)
 }
 
-func NewTaskTypeDurationSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[time.Duration], description string) TaskTypeDurationSetting {
+func NewTaskTypeDurationSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[time.Duration], description string) TaskTypeDurationSetting {
 	return NewTaskTypeTypedSettingWithConstrainedDefault[time.Duration](key, convertDuration, cdef, description)
 }
 
@@ -567,11 +567,11 @@ func GetDurationPropertyFnFilteredByTaskType(value time.Duration) DurationProper
 
 type DestinationDurationSetting = DestinationTypedSetting[time.Duration]
 
-func NewDestinationDurationSetting(key Key, def time.Duration, description string) DestinationDurationSetting {
+func NewDestinationDurationSetting(key string, def time.Duration, description string) DestinationDurationSetting {
 	return NewDestinationTypedSettingWithConverter[time.Duration](key, convertDuration, def, description)
 }
 
-func NewDestinationDurationSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[time.Duration], description string) DestinationDurationSetting {
+func NewDestinationDurationSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[time.Duration], description string) DestinationDurationSetting {
 	return NewDestinationTypedSettingWithConstrainedDefault[time.Duration](key, convertDuration, cdef, description)
 }
 
@@ -583,11 +583,11 @@ func GetDurationPropertyFnFilteredByDestination(value time.Duration) DurationPro
 
 type GlobalMapSetting = GlobalTypedSetting[map[string]any]
 
-func NewGlobalMapSetting(key Key, def map[string]any, description string) GlobalMapSetting {
+func NewGlobalMapSetting(key string, def map[string]any, description string) GlobalMapSetting {
 	return NewGlobalTypedSettingWithConverter[map[string]any](key, convertMap, def, description)
 }
 
-func NewGlobalMapSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[map[string]any], description string) GlobalMapSetting {
+func NewGlobalMapSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[map[string]any], description string) GlobalMapSetting {
 	return NewGlobalTypedSettingWithConstrainedDefault[map[string]any](key, convertMap, cdef, description)
 }
 
@@ -599,11 +599,11 @@ func GetMapPropertyFn(value map[string]any) MapPropertyFn {
 
 type NamespaceMapSetting = NamespaceTypedSetting[map[string]any]
 
-func NewNamespaceMapSetting(key Key, def map[string]any, description string) NamespaceMapSetting {
+func NewNamespaceMapSetting(key string, def map[string]any, description string) NamespaceMapSetting {
 	return NewNamespaceTypedSettingWithConverter[map[string]any](key, convertMap, def, description)
 }
 
-func NewNamespaceMapSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[map[string]any], description string) NamespaceMapSetting {
+func NewNamespaceMapSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[map[string]any], description string) NamespaceMapSetting {
 	return NewNamespaceTypedSettingWithConstrainedDefault[map[string]any](key, convertMap, cdef, description)
 }
 
@@ -615,11 +615,11 @@ func GetMapPropertyFnFilteredByNamespace(value map[string]any) MapPropertyFnWith
 
 type NamespaceIDMapSetting = NamespaceIDTypedSetting[map[string]any]
 
-func NewNamespaceIDMapSetting(key Key, def map[string]any, description string) NamespaceIDMapSetting {
+func NewNamespaceIDMapSetting(key string, def map[string]any, description string) NamespaceIDMapSetting {
 	return NewNamespaceIDTypedSettingWithConverter[map[string]any](key, convertMap, def, description)
 }
 
-func NewNamespaceIDMapSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[map[string]any], description string) NamespaceIDMapSetting {
+func NewNamespaceIDMapSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[map[string]any], description string) NamespaceIDMapSetting {
 	return NewNamespaceIDTypedSettingWithConstrainedDefault[map[string]any](key, convertMap, cdef, description)
 }
 
@@ -631,11 +631,11 @@ func GetMapPropertyFnFilteredByNamespaceID(value map[string]any) MapPropertyFnWi
 
 type TaskQueueMapSetting = TaskQueueTypedSetting[map[string]any]
 
-func NewTaskQueueMapSetting(key Key, def map[string]any, description string) TaskQueueMapSetting {
+func NewTaskQueueMapSetting(key string, def map[string]any, description string) TaskQueueMapSetting {
 	return NewTaskQueueTypedSettingWithConverter[map[string]any](key, convertMap, def, description)
 }
 
-func NewTaskQueueMapSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[map[string]any], description string) TaskQueueMapSetting {
+func NewTaskQueueMapSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[map[string]any], description string) TaskQueueMapSetting {
 	return NewTaskQueueTypedSettingWithConstrainedDefault[map[string]any](key, convertMap, cdef, description)
 }
 
@@ -647,11 +647,11 @@ func GetMapPropertyFnFilteredByTaskQueue(value map[string]any) MapPropertyFnWith
 
 type ShardIDMapSetting = ShardIDTypedSetting[map[string]any]
 
-func NewShardIDMapSetting(key Key, def map[string]any, description string) ShardIDMapSetting {
+func NewShardIDMapSetting(key string, def map[string]any, description string) ShardIDMapSetting {
 	return NewShardIDTypedSettingWithConverter[map[string]any](key, convertMap, def, description)
 }
 
-func NewShardIDMapSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[map[string]any], description string) ShardIDMapSetting {
+func NewShardIDMapSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[map[string]any], description string) ShardIDMapSetting {
 	return NewShardIDTypedSettingWithConstrainedDefault[map[string]any](key, convertMap, cdef, description)
 }
 
@@ -663,11 +663,11 @@ func GetMapPropertyFnFilteredByShardID(value map[string]any) MapPropertyFnWithSh
 
 type TaskTypeMapSetting = TaskTypeTypedSetting[map[string]any]
 
-func NewTaskTypeMapSetting(key Key, def map[string]any, description string) TaskTypeMapSetting {
+func NewTaskTypeMapSetting(key string, def map[string]any, description string) TaskTypeMapSetting {
 	return NewTaskTypeTypedSettingWithConverter[map[string]any](key, convertMap, def, description)
 }
 
-func NewTaskTypeMapSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[map[string]any], description string) TaskTypeMapSetting {
+func NewTaskTypeMapSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[map[string]any], description string) TaskTypeMapSetting {
 	return NewTaskTypeTypedSettingWithConstrainedDefault[map[string]any](key, convertMap, cdef, description)
 }
 
@@ -679,11 +679,11 @@ func GetMapPropertyFnFilteredByTaskType(value map[string]any) MapPropertyFnWithT
 
 type DestinationMapSetting = DestinationTypedSetting[map[string]any]
 
-func NewDestinationMapSetting(key Key, def map[string]any, description string) DestinationMapSetting {
+func NewDestinationMapSetting(key string, def map[string]any, description string) DestinationMapSetting {
 	return NewDestinationTypedSettingWithConverter[map[string]any](key, convertMap, def, description)
 }
 
-func NewDestinationMapSettingWithConstrainedDefault(key Key, cdef []TypedConstrainedValue[map[string]any], description string) DestinationMapSetting {
+func NewDestinationMapSettingWithConstrainedDefault(key string, cdef []TypedConstrainedValue[map[string]any], description string) DestinationMapSetting {
 	return NewDestinationTypedSettingWithConstrainedDefault[map[string]any](key, convertMap, cdef, description)
 }
 
@@ -698,9 +698,9 @@ type GlobalTypedSetting[T any] setting[T, func()]
 // NewGlobalTypedSetting creates a setting that uses mapstructure to handle complex structured
 // values. The value from dynamic config will be copied over a shallow copy of 'def', which means
 // 'def' must not contain any non-nil slices, maps, or pointers.
-func NewGlobalTypedSetting[T any](key Key, def T, description string) GlobalTypedSetting[T] {
+func NewGlobalTypedSetting[T any](key string, def T, description string) GlobalTypedSetting[T] {
 	s := GlobalTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     ConvertStructure[T](def),
 		description: description,
@@ -710,9 +710,9 @@ func NewGlobalTypedSetting[T any](key Key, def T, description string) GlobalType
 }
 
 // NewGlobalTypedSettingWithConverter creates a setting with a custom converter function.
-func NewGlobalTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) GlobalTypedSetting[T] {
+func NewGlobalTypedSettingWithConverter[T any](key string, convert func(any) (T, error), def T, description string) GlobalTypedSetting[T] {
 	s := GlobalTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     convert,
 		description: description,
@@ -722,9 +722,9 @@ func NewGlobalTypedSettingWithConverter[T any](key Key, convert func(any) (T, er
 }
 
 // NewGlobalTypedSettingWithConstrainedDefault creates a setting with a compound default value.
-func NewGlobalTypedSettingWithConstrainedDefault[T any](key Key, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) GlobalTypedSetting[T] {
+func NewGlobalTypedSettingWithConstrainedDefault[T any](key string, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) GlobalTypedSetting[T] {
 	s := GlobalTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		cdef:        &cdef,
 		convert:     convert,
 		description: description,
@@ -792,9 +792,9 @@ type NamespaceTypedSetting[T any] setting[T, func(namespace string)]
 // NewNamespaceTypedSetting creates a setting that uses mapstructure to handle complex structured
 // values. The value from dynamic config will be copied over a shallow copy of 'def', which means
 // 'def' must not contain any non-nil slices, maps, or pointers.
-func NewNamespaceTypedSetting[T any](key Key, def T, description string) NamespaceTypedSetting[T] {
+func NewNamespaceTypedSetting[T any](key string, def T, description string) NamespaceTypedSetting[T] {
 	s := NamespaceTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     ConvertStructure[T](def),
 		description: description,
@@ -804,9 +804,9 @@ func NewNamespaceTypedSetting[T any](key Key, def T, description string) Namespa
 }
 
 // NewNamespaceTypedSettingWithConverter creates a setting with a custom converter function.
-func NewNamespaceTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) NamespaceTypedSetting[T] {
+func NewNamespaceTypedSettingWithConverter[T any](key string, convert func(any) (T, error), def T, description string) NamespaceTypedSetting[T] {
 	s := NamespaceTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     convert,
 		description: description,
@@ -816,9 +816,9 @@ func NewNamespaceTypedSettingWithConverter[T any](key Key, convert func(any) (T,
 }
 
 // NewNamespaceTypedSettingWithConstrainedDefault creates a setting with a compound default value.
-func NewNamespaceTypedSettingWithConstrainedDefault[T any](key Key, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) NamespaceTypedSetting[T] {
+func NewNamespaceTypedSettingWithConstrainedDefault[T any](key string, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) NamespaceTypedSetting[T] {
 	s := NamespaceTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		cdef:        &cdef,
 		convert:     convert,
 		description: description,
@@ -886,9 +886,9 @@ type NamespaceIDTypedSetting[T any] setting[T, func(namespaceID namespace.ID)]
 // NewNamespaceIDTypedSetting creates a setting that uses mapstructure to handle complex structured
 // values. The value from dynamic config will be copied over a shallow copy of 'def', which means
 // 'def' must not contain any non-nil slices, maps, or pointers.
-func NewNamespaceIDTypedSetting[T any](key Key, def T, description string) NamespaceIDTypedSetting[T] {
+func NewNamespaceIDTypedSetting[T any](key string, def T, description string) NamespaceIDTypedSetting[T] {
 	s := NamespaceIDTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     ConvertStructure[T](def),
 		description: description,
@@ -898,9 +898,9 @@ func NewNamespaceIDTypedSetting[T any](key Key, def T, description string) Names
 }
 
 // NewNamespaceIDTypedSettingWithConverter creates a setting with a custom converter function.
-func NewNamespaceIDTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) NamespaceIDTypedSetting[T] {
+func NewNamespaceIDTypedSettingWithConverter[T any](key string, convert func(any) (T, error), def T, description string) NamespaceIDTypedSetting[T] {
 	s := NamespaceIDTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     convert,
 		description: description,
@@ -910,9 +910,9 @@ func NewNamespaceIDTypedSettingWithConverter[T any](key Key, convert func(any) (
 }
 
 // NewNamespaceIDTypedSettingWithConstrainedDefault creates a setting with a compound default value.
-func NewNamespaceIDTypedSettingWithConstrainedDefault[T any](key Key, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) NamespaceIDTypedSetting[T] {
+func NewNamespaceIDTypedSettingWithConstrainedDefault[T any](key string, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) NamespaceIDTypedSetting[T] {
 	s := NamespaceIDTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		cdef:        &cdef,
 		convert:     convert,
 		description: description,
@@ -980,9 +980,9 @@ type TaskQueueTypedSetting[T any] setting[T, func(namespace string, taskQueue st
 // NewTaskQueueTypedSetting creates a setting that uses mapstructure to handle complex structured
 // values. The value from dynamic config will be copied over a shallow copy of 'def', which means
 // 'def' must not contain any non-nil slices, maps, or pointers.
-func NewTaskQueueTypedSetting[T any](key Key, def T, description string) TaskQueueTypedSetting[T] {
+func NewTaskQueueTypedSetting[T any](key string, def T, description string) TaskQueueTypedSetting[T] {
 	s := TaskQueueTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     ConvertStructure[T](def),
 		description: description,
@@ -992,9 +992,9 @@ func NewTaskQueueTypedSetting[T any](key Key, def T, description string) TaskQue
 }
 
 // NewTaskQueueTypedSettingWithConverter creates a setting with a custom converter function.
-func NewTaskQueueTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) TaskQueueTypedSetting[T] {
+func NewTaskQueueTypedSettingWithConverter[T any](key string, convert func(any) (T, error), def T, description string) TaskQueueTypedSetting[T] {
 	s := TaskQueueTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     convert,
 		description: description,
@@ -1004,9 +1004,9 @@ func NewTaskQueueTypedSettingWithConverter[T any](key Key, convert func(any) (T,
 }
 
 // NewTaskQueueTypedSettingWithConstrainedDefault creates a setting with a compound default value.
-func NewTaskQueueTypedSettingWithConstrainedDefault[T any](key Key, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) TaskQueueTypedSetting[T] {
+func NewTaskQueueTypedSettingWithConstrainedDefault[T any](key string, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) TaskQueueTypedSetting[T] {
 	s := TaskQueueTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		cdef:        &cdef,
 		convert:     convert,
 		description: description,
@@ -1086,9 +1086,9 @@ type ShardIDTypedSetting[T any] setting[T, func(shardID int32)]
 // NewShardIDTypedSetting creates a setting that uses mapstructure to handle complex structured
 // values. The value from dynamic config will be copied over a shallow copy of 'def', which means
 // 'def' must not contain any non-nil slices, maps, or pointers.
-func NewShardIDTypedSetting[T any](key Key, def T, description string) ShardIDTypedSetting[T] {
+func NewShardIDTypedSetting[T any](key string, def T, description string) ShardIDTypedSetting[T] {
 	s := ShardIDTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     ConvertStructure[T](def),
 		description: description,
@@ -1098,9 +1098,9 @@ func NewShardIDTypedSetting[T any](key Key, def T, description string) ShardIDTy
 }
 
 // NewShardIDTypedSettingWithConverter creates a setting with a custom converter function.
-func NewShardIDTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) ShardIDTypedSetting[T] {
+func NewShardIDTypedSettingWithConverter[T any](key string, convert func(any) (T, error), def T, description string) ShardIDTypedSetting[T] {
 	s := ShardIDTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     convert,
 		description: description,
@@ -1110,9 +1110,9 @@ func NewShardIDTypedSettingWithConverter[T any](key Key, convert func(any) (T, e
 }
 
 // NewShardIDTypedSettingWithConstrainedDefault creates a setting with a compound default value.
-func NewShardIDTypedSettingWithConstrainedDefault[T any](key Key, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) ShardIDTypedSetting[T] {
+func NewShardIDTypedSettingWithConstrainedDefault[T any](key string, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) ShardIDTypedSetting[T] {
 	s := ShardIDTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		cdef:        &cdef,
 		convert:     convert,
 		description: description,
@@ -1180,9 +1180,9 @@ type TaskTypeTypedSetting[T any] setting[T, func(taskType enumsspb.TaskType)]
 // NewTaskTypeTypedSetting creates a setting that uses mapstructure to handle complex structured
 // values. The value from dynamic config will be copied over a shallow copy of 'def', which means
 // 'def' must not contain any non-nil slices, maps, or pointers.
-func NewTaskTypeTypedSetting[T any](key Key, def T, description string) TaskTypeTypedSetting[T] {
+func NewTaskTypeTypedSetting[T any](key string, def T, description string) TaskTypeTypedSetting[T] {
 	s := TaskTypeTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     ConvertStructure[T](def),
 		description: description,
@@ -1192,9 +1192,9 @@ func NewTaskTypeTypedSetting[T any](key Key, def T, description string) TaskType
 }
 
 // NewTaskTypeTypedSettingWithConverter creates a setting with a custom converter function.
-func NewTaskTypeTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) TaskTypeTypedSetting[T] {
+func NewTaskTypeTypedSettingWithConverter[T any](key string, convert func(any) (T, error), def T, description string) TaskTypeTypedSetting[T] {
 	s := TaskTypeTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     convert,
 		description: description,
@@ -1204,9 +1204,9 @@ func NewTaskTypeTypedSettingWithConverter[T any](key Key, convert func(any) (T, 
 }
 
 // NewTaskTypeTypedSettingWithConstrainedDefault creates a setting with a compound default value.
-func NewTaskTypeTypedSettingWithConstrainedDefault[T any](key Key, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) TaskTypeTypedSetting[T] {
+func NewTaskTypeTypedSettingWithConstrainedDefault[T any](key string, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) TaskTypeTypedSetting[T] {
 	s := TaskTypeTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		cdef:        &cdef,
 		convert:     convert,
 		description: description,
@@ -1274,9 +1274,9 @@ type DestinationTypedSetting[T any] setting[T, func(namespace string, destinatio
 // NewDestinationTypedSetting creates a setting that uses mapstructure to handle complex structured
 // values. The value from dynamic config will be copied over a shallow copy of 'def', which means
 // 'def' must not contain any non-nil slices, maps, or pointers.
-func NewDestinationTypedSetting[T any](key Key, def T, description string) DestinationTypedSetting[T] {
+func NewDestinationTypedSetting[T any](key string, def T, description string) DestinationTypedSetting[T] {
 	s := DestinationTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     ConvertStructure[T](def),
 		description: description,
@@ -1286,9 +1286,9 @@ func NewDestinationTypedSetting[T any](key Key, def T, description string) Desti
 }
 
 // NewDestinationTypedSettingWithConverter creates a setting with a custom converter function.
-func NewDestinationTypedSettingWithConverter[T any](key Key, convert func(any) (T, error), def T, description string) DestinationTypedSetting[T] {
+func NewDestinationTypedSettingWithConverter[T any](key string, convert func(any) (T, error), def T, description string) DestinationTypedSetting[T] {
 	s := DestinationTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		def:         def,
 		convert:     convert,
 		description: description,
@@ -1298,9 +1298,9 @@ func NewDestinationTypedSettingWithConverter[T any](key Key, convert func(any) (
 }
 
 // NewDestinationTypedSettingWithConstrainedDefault creates a setting with a compound default value.
-func NewDestinationTypedSettingWithConstrainedDefault[T any](key Key, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) DestinationTypedSetting[T] {
+func NewDestinationTypedSettingWithConstrainedDefault[T any](key string, convert func(any) (T, error), cdef []TypedConstrainedValue[T], description string) DestinationTypedSetting[T] {
 	s := DestinationTypedSetting[T]{
-		key:         key,
+		key:         MakeKey(key),
 		cdef:        &cdef,
 		convert:     convert,
 		description: description,
@@ -1372,3 +1372,4 @@ func GetTypedPropertyFnFilteredByDestination[T any](value T) TypedPropertyFnWith
 		return value
 	}
 }
+

--- a/common/dynamicconfig/yaml_loader.go
+++ b/common/dynamicconfig/yaml_loader.go
@@ -58,7 +58,7 @@ func (lr *YamlLoader) LoadFile(contents []byte) {
 	}
 
 	for key, yamlCV := range yamlValues {
-		lr.add(Key(key), yamlCV)
+		lr.add(MakeKey(key), yamlCV)
 	}
 }
 
@@ -106,7 +106,7 @@ func (lr *YamlLoader) add(key Key, yamlCV yamlConstrainedValue) {
 		cvs[i].Value = val
 		cvs[i].Constraints = convertYamlConstraints(key, cv.Constraints, precedence, lr)
 	}
-	lr.Map[key.Lower()] = cvs
+	lr.Map[key] = cvs
 }
 
 func (lr *YamlLoader) warn(err error) {

--- a/common/dynamicconfig/yaml_loader.go
+++ b/common/dynamicconfig/yaml_loader.go
@@ -1,0 +1,255 @@
+package dynamicconfig
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	"gopkg.in/yaml.v3"
+)
+
+type (
+	ConfigValueMap map[Key][]ConstrainedValue
+
+	// YamlLoader loads files and individual values from yaml files.
+	// Intended usage is to create a YamlLoader and call LoadFile or LoadValue.
+	// The parsed values will be placed in Map (initialized if nil).
+	// You can place your own map in Map before calling LoadFile/LoadValue if desired.
+	//
+	// Any warnings or errors encountered during parsing will be added to Warnings or Errors.
+	// Warnings should be reported but not block using the new values.
+	// Errors should abort the loading process.
+	YamlLoader struct {
+		Map      ConfigValueMap
+		Warnings []error
+		Errors   []error
+	}
+
+	yamlConstrainedValue []struct {
+		Constraints map[string]any
+		Value       any
+	}
+)
+
+// LoadYamlFile is a convenience function to create a YamlLoader and call LoadFile.
+func LoadYamlFile(contents []byte) *YamlLoader {
+	var lr YamlLoader
+	lr.LoadFile(contents)
+	return &lr
+}
+
+// Err returns a joined error of lr.Errors.
+func (lr *YamlLoader) Err() error {
+	return errors.Join(lr.Errors...)
+}
+
+// LoadFile parses and processes the given file contents into lr.Map (initialized if nil).
+func (lr *YamlLoader) LoadFile(contents []byte) {
+	var yamlValues map[string]yamlConstrainedValue
+	if err := yaml.Unmarshal(contents, &yamlValues); err != nil {
+		lr.errorf("decode error: %w", err)
+		return
+	}
+
+	if lr.Map == nil {
+		lr.Map = make(ConfigValueMap, len(yamlValues))
+	}
+
+	for key, yamlCV := range yamlValues {
+		lr.add(Key(key), yamlCV)
+	}
+}
+
+// LoadValue parses and processes the given single value into lr.Map (initialized if nil).
+func (lr *YamlLoader) LoadValue(key Key, contents []byte) {
+	var yamlCV yamlConstrainedValue
+	if err := yaml.Unmarshal(contents, &yamlCV); err != nil {
+		lr.errorf("decode error: %w", err)
+		return
+	}
+
+	if lr.Map == nil {
+		lr.Map = make(ConfigValueMap)
+	}
+	lr.add(key, yamlCV)
+}
+
+func (lr *YamlLoader) add(key Key, yamlCV yamlConstrainedValue) {
+	precedence := PrecedenceUnknown
+	setting := queryRegistry(key)
+	if setting == nil {
+		lr.warnf("unregistered key %q", key)
+	} else {
+		precedence = setting.Precedence()
+	}
+
+	cvs := make([]ConstrainedValue, len(yamlCV))
+	for i, cv := range yamlCV {
+		// yaml will unmarshal map into map[interface{}]interface{} instead of map[string]interface{}
+		// manually convert key type to string for all values here
+		val, err := convertKeyTypeToString(cv.Value)
+		if err != nil {
+			lr.error(err)
+			continue
+		}
+
+		// try validating if known setting
+		if setting != nil {
+			if valErr := setting.Validate(val); valErr != nil {
+				// TODO: raise this to error level
+				lr.warnf("validation failed: key %q value %v: %w", key, cv.Value, valErr)
+			}
+		}
+
+		cvs[i].Value = val
+		cvs[i].Constraints = convertYamlConstraints(key, cv.Constraints, precedence, lr)
+	}
+	lr.Map[key.Lower()] = cvs
+}
+
+func (lr *YamlLoader) warn(err error) {
+	lr.Warnings = append(lr.Warnings, err)
+}
+
+func (lr *YamlLoader) warnf(format string, args ...any) {
+	lr.warn(fmt.Errorf(format, args...))
+}
+
+func (lr *YamlLoader) error(err error) {
+	lr.Errors = append(lr.Errors, err)
+}
+
+func (lr *YamlLoader) errorf(format string, args ...any) {
+	lr.error(fmt.Errorf(format, args...))
+}
+
+func convertKeyTypeToString(v interface{}) (interface{}, error) {
+	switch v := v.(type) {
+	case map[interface{}]interface{}:
+		return convertKeyTypeToStringMap(v)
+	case []interface{}:
+		return convertKeyTypeToStringSlice(v)
+	default:
+		return v, nil
+	}
+}
+
+func convertKeyTypeToStringMap(m map[interface{}]interface{}) (map[string]interface{}, error) {
+	stringKeyMap := make(map[string]interface{})
+	for key, value := range m {
+		stringKey, ok := key.(string)
+		if !ok {
+			return nil, fmt.Errorf("type of key %v is not string", key)
+		}
+		convertedValue, err := convertKeyTypeToString(value)
+		if err != nil {
+			return nil, err
+		}
+		stringKeyMap[stringKey] = convertedValue
+	}
+	return stringKeyMap, nil
+}
+
+func convertKeyTypeToStringSlice(s []interface{}) ([]interface{}, error) {
+	stringKeySlice := make([]interface{}, len(s))
+	for idx, value := range s {
+		convertedValue, err := convertKeyTypeToString(value)
+		if err != nil {
+			return nil, err
+		}
+		stringKeySlice[idx] = convertedValue
+	}
+	return stringKeySlice, nil
+}
+
+func convertYamlConstraints(key Key, m map[string]any, precedence Precedence, lr *YamlLoader) Constraints {
+	var cs Constraints
+	for k, v := range m {
+		validConstraint := true
+		switch strings.ToLower(k) {
+		case "namespace":
+			if v, ok := v.(string); ok {
+				cs.Namespace = v
+			} else {
+				lr.errorf("namespace constraint must be string")
+			}
+			validConstraint = precedence == PrecedenceNamespace || precedence == PrecedenceTaskQueue || precedence == PrecedenceDestination
+		case "namespaceid":
+			if v, ok := v.(string); ok {
+				cs.NamespaceID = v
+			} else {
+				lr.errorf("namespaceID constraint must be string")
+			}
+			validConstraint = precedence == PrecedenceNamespaceID
+		case "taskqueuename":
+			if v, ok := v.(string); ok {
+				cs.TaskQueueName = v
+			} else {
+				lr.errorf("taskQueueName constraint must be string")
+			}
+			validConstraint = precedence == PrecedenceTaskQueue
+		case "tasktype":
+			switch v := v.(type) {
+			case string:
+				i, err := enumspb.TaskQueueTypeFromString(v)
+				if err != nil {
+					lr.errorf("invalid value for taskType: %w", err)
+				} else if i <= enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
+					lr.errorf("taskType constraint must be Workflow/Activity")
+				}
+				cs.TaskQueueType = i
+			case int:
+				if v > int(enumspb.TASK_QUEUE_TYPE_UNSPECIFIED) {
+					cs.TaskQueueType = enumspb.TaskQueueType(v)
+				} else {
+					lr.errorf("taskType constraint must be Workflow/Activity")
+				}
+			default:
+				lr.errorf("taskType constraint must be Workflow/Activity")
+			}
+			validConstraint = precedence == PrecedenceTaskQueue
+		case "historytasktype":
+			switch v := v.(type) {
+			case string:
+				tt, err := enumsspb.TaskTypeFromString(v)
+				if err != nil {
+					lr.errorf("invalid value for historytasktype constraint: %w", err)
+				} else if tt <= enumsspb.TASK_TYPE_UNSPECIFIED {
+					lr.errorf("historytasktype %s constraint is not supported", v)
+				}
+				cs.TaskType = tt
+			case int:
+				cs.TaskType = enumsspb.TaskType(v)
+			default:
+				lr.errorf("historytasktype %T constraint is not supported", v)
+			}
+			validConstraint = precedence == PrecedenceTaskType
+		case "shardid":
+			if v, ok := v.(int); ok {
+				cs.ShardID = int32(v)
+			} else {
+				lr.errorf("shardID constraint must be integer")
+			}
+			validConstraint = precedence == PrecedenceShardID
+		case "destination":
+			if v, ok := v.(string); ok {
+				cs.Destination = v
+			} else {
+				lr.errorf("destination constraint must be string")
+			}
+			validConstraint = precedence == PrecedenceDestination
+		default:
+			lr.errorf("unknown constraint type %q", k)
+		}
+
+		// don't log error for PrecedenceUnknown, we would already have logged for an
+		// unregistered key above
+		// TODO: raise this to error level
+		if !validConstraint && precedence != PrecedenceUnknown {
+			lr.warnf("constraint %q isn't valid for dynamic config key %q", k, key)
+		}
+	}
+	return cs
+}


### PR DESCRIPTION
**Depends on #8147, review after that**

## What changed?
Use unique.Handle for dynamicconfig.Keys instead of strings.

## Why?
Force keys to always be lowercase so we don't have to convert at lookup time, and also speed up lookups by interning.

## How did you test it?
- [x] covered by existing tests
