### PR TITLE
Support subscriptions to settings with constrained defaults

### DIFF
--- a/cmd/tools/gendynamicconfig/dynamic_config.tmpl
+++ b/cmd/tools/gendynamicconfig/dynamic_config.tmpl
@@ -151,8 +151,30 @@ func (s {{$P.Name}}TypedSetting[T]) dispatchUpdate(c *Collection, sub any, cvs [
 	)
 }
 
+{{if eq $P.Name "Global" -}}
+func (s {{$P.Name}}TypedConstrainedDefaultSetting[T]) Subscribe(c *Collection) TypedSubscribable[T] {
+	return func(callback func(T)) (T, func()) {
+		prec := {{$P.Expr}}
+		return subscribeWithConstrainedDefault(c, s.key, s.cdef, s.convert, prec, callback)
+	}
+}
+{{- else -}}
+func (s {{$P.Name}}TypedConstrainedDefaultSetting[T]) Subscribe(c *Collection) TypedSubscribableWith{{$P.Name}}Filter[T] {
+	return func({{$P.GoArgs}}, callback func(T)) (T, func()) {
+		prec := {{$P.Expr}}
+		return subscribeWithConstrainedDefault(c, s.key, s.cdef, s.convert, prec, callback)
+	}
+}
+{{- end}}
+
 func (s {{$P.Name}}TypedConstrainedDefaultSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []ConstrainedValue) {
-	// can't subscribe to constrained default settings
+	dispatchUpdateWithConstrainedDefault(
+		c,
+		s.key,
+		s.convert,
+		sub.(*subscription[T]),
+		cvs,
+	)
 }
 
 {{if eq $P.Name "Global" -}}

--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -53,6 +53,7 @@ type (
 		prec []Constraints
 		f    func(T)
 		def  T
+		cdef []TypedConstrainedValue[T] // nil for regular settings, populated for constrained default settings
 		// protected by subscriptionLock in Collection:
 		raw any // raw value that last sent value was converted from
 	}
@@ -310,6 +311,40 @@ func findMatchWithConstrainedDefaults[T any](cvs []ConstrainedValue, defaultCVs 
 	return
 }
 
+func resolveConstrainedValue[T any](
+	c *Collection,
+	key Key,
+	convert func(value any) (T, error),
+	cvp *ConstrainedValue,
+	defVal T,
+	valOrder, defOrder int,
+) (value T, raw any) {
+	if defOrder == 0 {
+		// This is a server bug: all precedence lists must end with no-constraints, and all
+		// constrained defaults must have a no-constraints value, so we should have gotten a match.
+		c.logger.Warn("Constrained defaults had no match (this is a bug; fix server code)", tag.Key(key.String()))
+		// leave value as the zero value, that's the best we can do
+		return value, usingDefaultValue
+	} else if valOrder == 0 {
+		if c.throttleLog() {
+			c.logger.Debug("No such key in dynamic config, using default", tag.Key(key.String()))
+		}
+		return defVal, usingDefaultValue
+	} else if defOrder < valOrder {
+		// value was present but constrained default took precedence
+		return defVal, usingDefaultValue // use sentinel since we're using default
+	}
+	typedVal, err := convertWithCache(c, key, convert, cvp)
+	if err != nil {
+		// We failed to convert the value to the desired type. Use the default.
+		if c.throttleLog() {
+			c.logger.Warn("Failed to convert value, using default", tag.Key(key.String()), tag.IgnoredValue(cvp), tag.Error(err))
+		}
+		return defVal, usingDefaultValue
+	}
+	return typedVal, cvp.Value
+}
+
 func matchAndConvertWithConstrainedDefault[T any](
 	c *Collection,
 	key Key,
@@ -319,36 +354,10 @@ func matchAndConvertWithConstrainedDefault[T any](
 ) T {
 	cvs := c.client.GetValue(key)
 	cvp, defVal, valOrder, defOrder := findMatchWithConstrainedDefaults(cvs, cdef, precedence)
-	if defOrder == 0 {
-		// This is a server bug: all precedence lists must end with no-constraints, and all
-		// constrained defaults must have a no-constraints value, so we should have gotten a match.
-		c.logger.Warn("Constrained defaults had no match (this is a bug; fix server code)", tag.Key(key.String()))
-		// leave defVal as the zero value, that's the best we can do
-	}
-	if valOrder == 0 {
-		if c.throttleLog() {
-			c.logger.Debug("No such key in dynamic config, using default", tag.Key(key.String()))
-		}
-		return defVal
-	}
-	if defOrder < valOrder {
-		// value was present but constrained default took precedence
-		return defVal
-	}
-	typedVal, err := convertWithCache(c, key, convert, cvp)
-	if err != nil {
-		// We failed to convert the value to the desired type. Use the default.
-		if c.throttleLog() {
-			c.logger.Warn("Failed to convert value, using default", tag.Key(key.String()), tag.IgnoredValue(cvp), tag.Error(err))
-		}
-		// if defOrder == 0, this will be the zero value, but that's the best we can do
-		return defVal
-	}
-	return typedVal
+	value, _ := resolveConstrainedValue(c, key, convert, cvp, defVal, valOrder, defOrder)
+	return value
 }
 
-// Note: subscriptions currently only work with regular (single default) settings, not
-// constrained default settings.
 func subscribe[T any](
 	c *Collection,
 	key Key,
@@ -382,6 +391,50 @@ func subscribe[T any](
 		prec: prec,
 		f:    callback,
 		def:  def,
+		raw:  raw,
+	}
+
+	return init, func() {
+		c.subscriptionLock.Lock()
+		defer c.subscriptionLock.Unlock()
+		delete(c.subscriptions[key], id)
+	}
+}
+
+func subscribeWithConstrainedDefault[T any](
+	c *Collection,
+	key Key,
+	cdef []TypedConstrainedValue[T],
+	convert func(value any) (T, error),
+	prec []Constraints,
+	callback func(T),
+) (T, func()) {
+	c.subscriptionLock.Lock()
+	defer c.subscriptionLock.Unlock()
+
+	// get one value immediately (note that subscriptionLock is held here so we can't race with
+	// an update)
+	cvs := c.client.GetValue(key)
+	cvp, defVal, valOrder, defOrder := findMatchWithConstrainedDefaults(cvs, cdef, prec)
+	init, raw := resolveConstrainedValue(c, key, convert, cvp, defVal, valOrder, defOrder)
+
+	// As a convenience (and for efficiency), you can pass in a nil callback; we just return the
+	// current value and skip the subscription. The cancellation func returned is also nil.
+	if callback == nil {
+		return init, nil
+	}
+
+	c.subscriptionIdx++
+	id := c.subscriptionIdx
+
+	if c.subscriptions[key] == nil {
+		c.subscriptions[key] = make(map[int]any)
+	}
+
+	c.subscriptions[key][id] = &subscription[T]{
+		prec: prec,
+		f:    callback,
+		cdef: cdef,
 		raw:  raw,
 	}
 
@@ -433,6 +486,34 @@ func dispatchUpdate[T any](
 			}
 			newVal, raw = sub.def, usingDefaultValue
 		}
+	}
+
+	sub.raw = raw
+	c.callbackPool.Do(func() { sub.f(newVal) })
+}
+
+// called with subscriptionLock
+func dispatchUpdateWithConstrainedDefault[T any](
+	c *Collection,
+	key Key,
+	convert func(value any) (T, error),
+	sub *subscription[T],
+	cvs []ConstrainedValue,
+) {
+	cvp, defVal, valOrder, defOrder := findMatchWithConstrainedDefaults(cvs, sub.cdef, sub.prec)
+	// Note: This performs the conversion even if the raw value is unchanged. This isn't ideal,
+	// but so far constrained default settings are only used for primitive values so it's okay.
+	// If we have a constrained default value with a complex conversion function, this could be
+	// optimized to delay conversion until after we check DeepEqual.
+	newVal, raw := resolveConstrainedValue(c, key, convert, cvp, defVal, valOrder, defOrder)
+
+	// compare raw (pre-conversion) values, if unchanged, skip this update. note that
+	// `usingDefaultValue` is equal to itself but nothing else.
+	if reflect.DeepEqual(sub.raw, raw) {
+		// make raw field point to new one, not old one, so that old loaded files can get
+		// garbage collected.
+		sub.raw = raw
+		return
 	}
 
 	sub.raw = raw

--- a/common/dynamicconfig/collection_test.go
+++ b/common/dynamicconfig/collection_test.go
@@ -5,9 +5,11 @@ import (
 	"maps"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -722,4 +724,61 @@ func (s *subscriptionSuite) TestSubscriptionWithDefault() {
 	v, cancel := setting.Subscribe(s.cln)(nil)
 	s.Equal(100, v)
 	s.Nil(cancel)
+}
+
+func (s *subscriptionSuite) TestSubscriptionConstrainedDefaults() {
+	setting := dynamicconfig.NewNamespaceIntSettingWithConstrainedDefault(
+		testGetIntPropertyKey,
+		[]dynamicconfig.TypedConstrainedValue[int]{
+			{Value: 34, Constraints: dynamicconfig.Constraints{Namespace: "special"}},
+			{Value: 10}, // no constraints = default for all
+		},
+		"",
+	)
+
+	var normal, special atomic.Int64
+	var normalCalls, specialCalls atomic.Int64
+
+	waitFor := func(normalv, specialv, normalc, specialc int) {
+		s.EventuallyWithT(func(c *assert.CollectT) {
+			assert.Equal(c, normalv, int(normal.Load()))
+			assert.Equal(c, specialv, int(special.Load()))
+		}, time.Second, time.Millisecond)
+		s.Equal(normalc, int(normalCalls.Load()))
+		s.Equal(specialc, int(specialCalls.Load()))
+	}
+
+	// normal ns
+	normalInit, normalCancel := setting.Subscribe(s.cln)("normal", func(v int) { normal.Store(int64(v)); normalCalls.Add(1) })
+	normal.Store(int64(normalInit))
+	defer normalCancel()
+	s.Equal(10, normalInit)
+
+	// special ns
+	specialInit, specialCancel := setting.Subscribe(s.cln)("special", func(v int) { special.Store(int64(v)); specialCalls.Add(1) })
+	special.Store(int64(specialInit))
+	defer specialCancel()
+	s.Equal(34, specialInit) // Should get the constrained default for "special"
+
+	// set a value for special
+	s.client.Set(setting.Key(), []dynamicconfig.ConstrainedValue{
+		{Value: 200, Constraints: dynamicconfig.Constraints{Namespace: "special"}},
+	})
+	waitFor(10, 200, 0, 1)
+
+	// set a value for normal
+	s.client.Set(setting.Key(), []dynamicconfig.ConstrainedValue{
+		{Value: 123, Constraints: dynamicconfig.Constraints{Namespace: "normal"}},
+	})
+	waitFor(123, 34, 1, 2)
+
+	// set a default value
+	s.client.Set(setting.Key(), []dynamicconfig.ConstrainedValue{
+		{Value: 19},
+	})
+	waitFor(19, 34, 2, 2)
+
+	// remove values
+	s.client.Set(setting.Key(), []dynamicconfig.ConstrainedValue{})
+	waitFor(10, 34, 3, 2)
 }

--- a/common/dynamicconfig/setting_gen.go
+++ b/common/dynamicconfig/setting_gen.go
@@ -843,8 +843,21 @@ func (s GlobalTypedSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []Cons
 	)
 }
 
+func (s GlobalTypedConstrainedDefaultSetting[T]) Subscribe(c *Collection) TypedSubscribable[T] {
+	return func(callback func(T)) (T, func()) {
+		prec := []Constraints{{}}
+		return subscribeWithConstrainedDefault(c, s.key, s.cdef, s.convert, prec, callback)
+	}
+}
+
 func (s GlobalTypedConstrainedDefaultSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []ConstrainedValue) {
-	// can't subscribe to constrained default settings
+	dispatchUpdateWithConstrainedDefault(
+		c,
+		s.key,
+		s.convert,
+		sub.(*subscription[T]),
+		cvs,
+	)
 }
 
 func GetTypedPropertyFn[T any](value T) TypedPropertyFn[T] {
@@ -961,8 +974,21 @@ func (s NamespaceTypedSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []C
 	)
 }
 
+func (s NamespaceTypedConstrainedDefaultSetting[T]) Subscribe(c *Collection) TypedSubscribableWithNamespaceFilter[T] {
+	return func(namespace string, callback func(T)) (T, func()) {
+		prec := []Constraints{{Namespace: namespace}, {}}
+		return subscribeWithConstrainedDefault(c, s.key, s.cdef, s.convert, prec, callback)
+	}
+}
+
 func (s NamespaceTypedConstrainedDefaultSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []ConstrainedValue) {
-	// can't subscribe to constrained default settings
+	dispatchUpdateWithConstrainedDefault(
+		c,
+		s.key,
+		s.convert,
+		sub.(*subscription[T]),
+		cvs,
+	)
 }
 
 func GetTypedPropertyFnFilteredByNamespace[T any](value T) TypedPropertyFnWithNamespaceFilter[T] {
@@ -1079,8 +1105,21 @@ func (s NamespaceIDTypedSetting[T]) dispatchUpdate(c *Collection, sub any, cvs [
 	)
 }
 
+func (s NamespaceIDTypedConstrainedDefaultSetting[T]) Subscribe(c *Collection) TypedSubscribableWithNamespaceIDFilter[T] {
+	return func(namespaceID namespace.ID, callback func(T)) (T, func()) {
+		prec := []Constraints{{NamespaceID: namespaceID.String()}, {}}
+		return subscribeWithConstrainedDefault(c, s.key, s.cdef, s.convert, prec, callback)
+	}
+}
+
 func (s NamespaceIDTypedConstrainedDefaultSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []ConstrainedValue) {
-	// can't subscribe to constrained default settings
+	dispatchUpdateWithConstrainedDefault(
+		c,
+		s.key,
+		s.convert,
+		sub.(*subscription[T]),
+		cvs,
+	)
 }
 
 func GetTypedPropertyFnFilteredByNamespaceID[T any](value T) TypedPropertyFnWithNamespaceIDFilter[T] {
@@ -1215,8 +1254,27 @@ func (s TaskQueueTypedSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []C
 	)
 }
 
+func (s TaskQueueTypedConstrainedDefaultSetting[T]) Subscribe(c *Collection) TypedSubscribableWithTaskQueueFilter[T] {
+	return func(namespace string, taskQueue string, taskQueueType enumspb.TaskQueueType, callback func(T)) (T, func()) {
+		prec := []Constraints{
+			{Namespace: namespace, TaskQueueName: taskQueue, TaskQueueType: taskQueueType},
+			{Namespace: namespace, TaskQueueName: taskQueue},
+			{TaskQueueName: taskQueue},
+			{Namespace: namespace},
+			{},
+		}
+		return subscribeWithConstrainedDefault(c, s.key, s.cdef, s.convert, prec, callback)
+	}
+}
+
 func (s TaskQueueTypedConstrainedDefaultSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []ConstrainedValue) {
-	// can't subscribe to constrained default settings
+	dispatchUpdateWithConstrainedDefault(
+		c,
+		s.key,
+		s.convert,
+		sub.(*subscription[T]),
+		cvs,
+	)
 }
 
 func GetTypedPropertyFnFilteredByTaskQueue[T any](value T) TypedPropertyFnWithTaskQueueFilter[T] {
@@ -1333,8 +1391,21 @@ func (s ShardIDTypedSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []Con
 	)
 }
 
+func (s ShardIDTypedConstrainedDefaultSetting[T]) Subscribe(c *Collection) TypedSubscribableWithShardIDFilter[T] {
+	return func(shardID int32, callback func(T)) (T, func()) {
+		prec := []Constraints{{ShardID: shardID}, {}}
+		return subscribeWithConstrainedDefault(c, s.key, s.cdef, s.convert, prec, callback)
+	}
+}
+
 func (s ShardIDTypedConstrainedDefaultSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []ConstrainedValue) {
-	// can't subscribe to constrained default settings
+	dispatchUpdateWithConstrainedDefault(
+		c,
+		s.key,
+		s.convert,
+		sub.(*subscription[T]),
+		cvs,
+	)
 }
 
 func GetTypedPropertyFnFilteredByShardID[T any](value T) TypedPropertyFnWithShardIDFilter[T] {
@@ -1451,8 +1522,21 @@ func (s TaskTypeTypedSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []Co
 	)
 }
 
+func (s TaskTypeTypedConstrainedDefaultSetting[T]) Subscribe(c *Collection) TypedSubscribableWithTaskTypeFilter[T] {
+	return func(taskType enumsspb.TaskType, callback func(T)) (T, func()) {
+		prec := []Constraints{{TaskType: taskType}, {}}
+		return subscribeWithConstrainedDefault(c, s.key, s.cdef, s.convert, prec, callback)
+	}
+}
+
 func (s TaskTypeTypedConstrainedDefaultSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []ConstrainedValue) {
-	// can't subscribe to constrained default settings
+	dispatchUpdateWithConstrainedDefault(
+		c,
+		s.key,
+		s.convert,
+		sub.(*subscription[T]),
+		cvs,
+	)
 }
 
 func GetTypedPropertyFnFilteredByTaskType[T any](value T) TypedPropertyFnWithTaskTypeFilter[T] {
@@ -1584,8 +1668,26 @@ func (s DestinationTypedSetting[T]) dispatchUpdate(c *Collection, sub any, cvs [
 	)
 }
 
+func (s DestinationTypedConstrainedDefaultSetting[T]) Subscribe(c *Collection) TypedSubscribableWithDestinationFilter[T] {
+	return func(namespace string, destination string, callback func(T)) (T, func()) {
+		prec := []Constraints{
+			{Namespace: namespace, Destination: destination},
+			{Destination: destination},
+			{Namespace: namespace},
+			{},
+		}
+		return subscribeWithConstrainedDefault(c, s.key, s.cdef, s.convert, prec, callback)
+	}
+}
+
 func (s DestinationTypedConstrainedDefaultSetting[T]) dispatchUpdate(c *Collection, sub any, cvs []ConstrainedValue) {
-	// can't subscribe to constrained default settings
+	dispatchUpdateWithConstrainedDefault(
+		c,
+		s.key,
+		s.convert,
+		sub.(*subscription[T]),
+		cvs,
+	)
 }
 
 func GetTypedPropertyFnFilteredByDestination[T any](value T) TypedPropertyFnWithDestinationFilter[T] {


### PR DESCRIPTION
## What changed?
Fill in support for subscriptions to dynamic config values with constrained defaults.

## Why?
We'd like to use this combination of functionality.

## How did you test it?
- [x] added new unit test(s)
