### PR TITLE
Allow empty data in DataBlob

### DIFF
--- a/common/persistence/data_blob.go
+++ b/common/persistence/data_blob.go
@@ -8,10 +8,6 @@ import (
 // NewDataBlob returns a new DataBlob.
 // TODO: return an UnknowEncodingType error with the actual type string when encodingTypeStr is invalid
 func NewDataBlob(data []byte, encodingTypeStr string) *commonpb.DataBlob {
-	if len(data) == 0 {
-		return nil
-	}
-
 	encodingType, err := enumspb.EncodingTypeFromString(encodingTypeStr)
 	if err != nil {
 		// encodingTypeStr not valid, an error will be returned on deserialization


### PR DESCRIPTION
## What changed?
Remove check for zero-length data in NewDataBlob.

## Why?
Zero-length data is a valid encoding for some encodings, e.g. proto3. NewDataBlob should not have an opinion on the length of data.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Some code may be making assumptions about this behavior.
