### PR TITLE
[CHASM] Retention component

### DIFF
--- a/api/persistence/v1/chasm.go-helpers.pb.go
+++ b/api/persistence/v1/chasm.go-helpers.pb.go
@@ -300,3 +300,77 @@ func (this *ChasmComponentRef) Equal(that interface{}) bool {
 
 	return proto.Equal(this, that1)
 }
+
+// Marshal an object of type RetentionData to the protobuf v3 wire format
+func (val *RetentionData) Marshal() ([]byte, error) {
+	return proto.Marshal(val)
+}
+
+// Unmarshal an object of type RetentionData from the protobuf v3 wire format
+func (val *RetentionData) Unmarshal(buf []byte) error {
+	return proto.Unmarshal(buf, val)
+}
+
+// Size returns the size of the object, in bytes, once serialized
+func (val *RetentionData) Size() int {
+	return proto.Size(val)
+}
+
+// Equal returns whether two RetentionData values are equivalent by recursively
+// comparing the message's fields.
+// For more information see the documentation for
+// https://pkg.go.dev/google.golang.org/protobuf/proto#Equal
+func (this *RetentionData) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	var that1 *RetentionData
+	switch t := that.(type) {
+	case *RetentionData:
+		that1 = t
+	case RetentionData:
+		that1 = &t
+	default:
+		return false
+	}
+
+	return proto.Equal(this, that1)
+}
+
+// Marshal an object of type RetentionTask to the protobuf v3 wire format
+func (val *RetentionTask) Marshal() ([]byte, error) {
+	return proto.Marshal(val)
+}
+
+// Unmarshal an object of type RetentionTask from the protobuf v3 wire format
+func (val *RetentionTask) Unmarshal(buf []byte) error {
+	return proto.Unmarshal(buf, val)
+}
+
+// Size returns the size of the object, in bytes, once serialized
+func (val *RetentionTask) Size() int {
+	return proto.Size(val)
+}
+
+// Equal returns whether two RetentionTask values are equivalent by recursively
+// comparing the message's fields.
+// For more information see the documentation for
+// https://pkg.go.dev/google.golang.org/protobuf/proto#Equal
+func (this *RetentionTask) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	var that1 *RetentionTask
+	switch t := that.(type) {
+	case *RetentionTask:
+		that1 = t
+	case RetentionTask:
+		that1 = &t
+	default:
+		return false
+	}
+
+	return proto.Equal(this, that1)
+}

--- a/api/persistence/v1/chasm.pb.go
+++ b/api/persistence/v1/chasm.pb.go
@@ -568,6 +568,101 @@ func (x *ChasmComponentRef) GetComponentInitialVersionedTransition() *VersionedT
 	return nil
 }
 
+// TODO TODO TODO - move into retention/proto/v1 as soon as Roey's PR lands
+//
+// Data for the Retention component.
+type RetentionData struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// True once the retention timer has fired and the component is now in its
+	// terminal state.
+	Closed bool `protobuf:"varint,1,opt,name=closed,proto3" json:"closed,omitempty"`
+	// The desired terminal chasm.LifecycleState (either Completed or Failed).
+	TerminalState int64 `protobuf:"varint,2,opt,name=terminal_state,json=terminalState,proto3" json:"terminal_state,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RetentionData) Reset() {
+	*x = RetentionData{}
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RetentionData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RetentionData) ProtoMessage() {}
+
+func (x *RetentionData) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RetentionData.ProtoReflect.Descriptor instead.
+func (*RetentionData) Descriptor() ([]byte, []int) {
+	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *RetentionData) GetClosed() bool {
+	if x != nil {
+		return x.Closed
+	}
+	return false
+}
+
+func (x *RetentionData) GetTerminalState() int64 {
+	if x != nil {
+		return x.TerminalState
+	}
+	return 0
+}
+
+// TODO TODO TODO - move into retention/proto/v1 as soon as Roey's PR lands
+type RetentionTask struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RetentionTask) Reset() {
+	*x = RetentionTask{}
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RetentionTask) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RetentionTask) ProtoMessage() {}
+
+func (x *RetentionTask) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RetentionTask.ProtoReflect.Descriptor instead.
+func (*RetentionTask) Descriptor() ([]byte, []int) {
+	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP(), []int{9}
+}
+
 type ChasmComponentAttributes_Task struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Fully qualified type name of a registered task.
@@ -591,7 +686,7 @@ type ChasmComponentAttributes_Task struct {
 
 func (x *ChasmComponentAttributes_Task) Reset() {
 	*x = ChasmComponentAttributes_Task{}
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[8]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -603,7 +698,7 @@ func (x *ChasmComponentAttributes_Task) String() string {
 func (*ChasmComponentAttributes_Task) ProtoMessage() {}
 
 func (x *ChasmComponentAttributes_Task) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[8]
+	mi := &file_temporal_server_api_persistence_v1_chasm_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -716,7 +811,11 @@ const file_temporal_server_api_persistence_v1_chasm_proto_rawDesc = "" +
 	"\tarchetype\x18\x04 \x01(\tR\tarchetype\x12w\n" +
 	"\x1bentity_versioned_transition\x18\x05 \x01(\v27.temporal.server.api.persistence.v1.VersionedTransitionR\x19entityVersionedTransition\x12%\n" +
 	"\x0ecomponent_path\x18\x06 \x03(\tR\rcomponentPath\x12\x8c\x01\n" +
-	"&component_initial_versioned_transition\x18\a \x01(\v27.temporal.server.api.persistence.v1.VersionedTransitionR#componentInitialVersionedTransitionB6Z4go.temporal.io/server/api/persistence/v1;persistenceb\x06proto3"
+	"&component_initial_versioned_transition\x18\a \x01(\v27.temporal.server.api.persistence.v1.VersionedTransitionR#componentInitialVersionedTransition\"N\n" +
+	"\rRetentionData\x12\x16\n" +
+	"\x06closed\x18\x01 \x01(\bR\x06closed\x12%\n" +
+	"\x0eterminal_state\x18\x02 \x01(\x03R\rterminalState\"\x0f\n" +
+	"\rRetentionTaskB6Z4go.temporal.io/server/api/persistence/v1;persistenceb\x06proto3"
 
 var (
 	file_temporal_server_api_persistence_v1_chasm_proto_rawDescOnce sync.Once
@@ -730,7 +829,7 @@ func file_temporal_server_api_persistence_v1_chasm_proto_rawDescGZIP() []byte {
 	return file_temporal_server_api_persistence_v1_chasm_proto_rawDescData
 }
 
-var file_temporal_server_api_persistence_v1_chasm_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_temporal_server_api_persistence_v1_chasm_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_temporal_server_api_persistence_v1_chasm_proto_goTypes = []any{
 	(*ChasmNode)(nil),                     // 0: temporal.server.api.persistence.v1.ChasmNode
 	(*ChasmNodeMetadata)(nil),             // 1: temporal.server.api.persistence.v1.ChasmNodeMetadata
@@ -740,30 +839,32 @@ var file_temporal_server_api_persistence_v1_chasm_proto_goTypes = []any{
 	(*ChasmPointerAttributes)(nil),        // 5: temporal.server.api.persistence.v1.ChasmPointerAttributes
 	(*ChasmTaskInfo)(nil),                 // 6: temporal.server.api.persistence.v1.ChasmTaskInfo
 	(*ChasmComponentRef)(nil),             // 7: temporal.server.api.persistence.v1.ChasmComponentRef
-	(*ChasmComponentAttributes_Task)(nil), // 8: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task
-	(*v1.DataBlob)(nil),                   // 9: temporal.api.common.v1.DataBlob
-	(*VersionedTransition)(nil),           // 10: temporal.server.api.persistence.v1.VersionedTransition
-	(*timestamppb.Timestamp)(nil),         // 11: google.protobuf.Timestamp
+	(*RetentionData)(nil),                 // 8: temporal.server.api.persistence.v1.RetentionData
+	(*RetentionTask)(nil),                 // 9: temporal.server.api.persistence.v1.RetentionTask
+	(*ChasmComponentAttributes_Task)(nil), // 10: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task
+	(*v1.DataBlob)(nil),                   // 11: temporal.api.common.v1.DataBlob
+	(*VersionedTransition)(nil),           // 12: temporal.server.api.persistence.v1.VersionedTransition
+	(*timestamppb.Timestamp)(nil),         // 13: google.protobuf.Timestamp
 }
 var file_temporal_server_api_persistence_v1_chasm_proto_depIdxs = []int32{
 	1,  // 0: temporal.server.api.persistence.v1.ChasmNode.metadata:type_name -> temporal.server.api.persistence.v1.ChasmNodeMetadata
-	9,  // 1: temporal.server.api.persistence.v1.ChasmNode.data:type_name -> temporal.api.common.v1.DataBlob
-	10, // 2: temporal.server.api.persistence.v1.ChasmNodeMetadata.initial_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	10, // 3: temporal.server.api.persistence.v1.ChasmNodeMetadata.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	11, // 1: temporal.server.api.persistence.v1.ChasmNode.data:type_name -> temporal.api.common.v1.DataBlob
+	12, // 2: temporal.server.api.persistence.v1.ChasmNodeMetadata.initial_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	12, // 3: temporal.server.api.persistence.v1.ChasmNodeMetadata.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
 	2,  // 4: temporal.server.api.persistence.v1.ChasmNodeMetadata.component_attributes:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes
 	3,  // 5: temporal.server.api.persistence.v1.ChasmNodeMetadata.data_attributes:type_name -> temporal.server.api.persistence.v1.ChasmDataAttributes
 	4,  // 6: temporal.server.api.persistence.v1.ChasmNodeMetadata.collection_attributes:type_name -> temporal.server.api.persistence.v1.ChasmCollectionAttributes
 	5,  // 7: temporal.server.api.persistence.v1.ChasmNodeMetadata.pointer_attributes:type_name -> temporal.server.api.persistence.v1.ChasmPointerAttributes
-	8,  // 8: temporal.server.api.persistence.v1.ChasmComponentAttributes.side_effect_tasks:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes.Task
-	8,  // 9: temporal.server.api.persistence.v1.ChasmComponentAttributes.pure_tasks:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes.Task
-	10, // 10: temporal.server.api.persistence.v1.ChasmTaskInfo.component_initial_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	10, // 11: temporal.server.api.persistence.v1.ChasmTaskInfo.component_last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	9,  // 12: temporal.server.api.persistence.v1.ChasmTaskInfo.data:type_name -> temporal.api.common.v1.DataBlob
-	10, // 13: temporal.server.api.persistence.v1.ChasmComponentRef.entity_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	10, // 14: temporal.server.api.persistence.v1.ChasmComponentRef.component_initial_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	11, // 15: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task.scheduled_time:type_name -> google.protobuf.Timestamp
-	9,  // 16: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task.data:type_name -> temporal.api.common.v1.DataBlob
-	10, // 17: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	10, // 8: temporal.server.api.persistence.v1.ChasmComponentAttributes.side_effect_tasks:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes.Task
+	10, // 9: temporal.server.api.persistence.v1.ChasmComponentAttributes.pure_tasks:type_name -> temporal.server.api.persistence.v1.ChasmComponentAttributes.Task
+	12, // 10: temporal.server.api.persistence.v1.ChasmTaskInfo.component_initial_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	12, // 11: temporal.server.api.persistence.v1.ChasmTaskInfo.component_last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	11, // 12: temporal.server.api.persistence.v1.ChasmTaskInfo.data:type_name -> temporal.api.common.v1.DataBlob
+	12, // 13: temporal.server.api.persistence.v1.ChasmComponentRef.entity_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	12, // 14: temporal.server.api.persistence.v1.ChasmComponentRef.component_initial_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	13, // 15: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task.scheduled_time:type_name -> google.protobuf.Timestamp
+	11, // 16: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task.data:type_name -> temporal.api.common.v1.DataBlob
+	12, // 17: temporal.server.api.persistence.v1.ChasmComponentAttributes.Task.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
 	18, // [18:18] is the sub-list for method output_type
 	18, // [18:18] is the sub-list for method input_type
 	18, // [18:18] is the sub-list for extension type_name
@@ -789,7 +890,7 @@ func file_temporal_server_api_persistence_v1_chasm_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_temporal_server_api_persistence_v1_chasm_proto_rawDesc), len(file_temporal_server_api_persistence_v1_chasm_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/chasm/lib/retention/retention.go
+++ b/chasm/lib/retention/retention.go
@@ -1,0 +1,55 @@
+package retention
+
+import (
+	"time"
+
+	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
+)
+
+// Retention timer component. This component can be used to close out a CHASM
+// component after a period of time has elapsed. This is a separate timer from the
+// namespace-level workflow/mutable state retention (which takes effect *after* the workflow has
+// closed, e.g., by this component).
+type Retention struct {
+	chasm.UnimplementedComponent
+
+	*persistencespb.RetentionData
+}
+
+// NewRetention creates a new Retention component whose LifecycleState will flip
+// to the given terminalState after the given duration has elapsed.
+func NewRetention(
+	ctx chasm.MutableContext,
+	duration time.Duration,
+	terminalState chasm.LifecycleState,
+) (*Retention, error) {
+	if !terminalState.IsClosed() {
+		return nil,
+			serviceerror.NewInternalf("terminalState isn't a 'Closed' state: %v", terminalState)
+	}
+
+	r := &Retention{
+		RetentionData: &persistencespb.RetentionData{
+			TerminalState: int64(terminalState),
+		},
+	}
+
+	// Adds a timer task to flip the latch to closed after the retention period
+	// elapses.
+	scheduledTime := ctx.Now(r).Add(duration)
+	ctx.AddTask(r, chasm.TaskAttributes{
+		ScheduledTime: scheduledTime,
+	}, &persistencespb.RetentionTask{})
+
+	return r, nil
+}
+
+func (r *Retention) LifecycleState(ctx chasm.Context) chasm.LifecycleState {
+	if r.Closed {
+		return chasm.LifecycleState(r.TerminalState)
+	}
+
+	return chasm.LifecycleStateRunning
+}

--- a/chasm/lib/retention/retention_task.go
+++ b/chasm/lib/retention/retention_task.go
@@ -1,0 +1,35 @@
+package retention
+
+import (
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
+)
+
+type RetentionTaskExecutor struct{}
+
+func NewRetentionTaskExecutor() *RetentionTaskExecutor {
+	return &RetentionTaskExecutor{}
+}
+
+func (r *RetentionTaskExecutor) Execute(
+	ctx chasm.MutableContext,
+	retention *Retention,
+	_ chasm.TaskAttributes,
+	_ *persistencespb.RetentionTask,
+) error {
+	retention.Closed = true
+	return nil
+}
+
+func (r *RetentionTaskExecutor) Validate(
+	ctx chasm.Context,
+	retention *Retention,
+	_ chasm.TaskAttributes,
+	_ *persistencespb.RetentionTask,
+) (bool, error) {
+	if retention.Closed {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/chasm/lib/retention/retention_test.go
+++ b/chasm/lib/retention/retention_test.go
@@ -1,0 +1,73 @@
+package retention_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/retention"
+	"go.uber.org/mock/gomock"
+)
+
+type retentionSuite struct {
+	suite.Suite
+	*require.Assertions
+	controller *gomock.Controller
+
+	mockCtx *chasm.MockMutableContext
+	now     time.Time
+}
+
+func (s *retentionSuite) SetupSuite() {
+	s.Assertions = require.New(s.T())
+	s.controller = gomock.NewController(s.T())
+	s.mockCtx = chasm.NewMockMutableContext(s.controller)
+
+	s.now = time.Now()
+	s.mockCtx.EXPECT().Now(gomock.Any()).Return(s.now).AnyTimes()
+}
+
+func TestRetention(t *testing.T) {
+	suite.Run(t, &retentionSuite{})
+}
+
+func (s *retentionSuite) TestNewRetentionValidation() {
+	_, err := retention.NewRetention(s.mockCtx, 1*time.Hour, chasm.LifecycleStateRunning)
+	s.ErrorContains(err, "terminalState isn't a 'Closed' state: Running")
+}
+
+func (s *retentionSuite) TestNewRetentionTask() {
+	duration := 1 * time.Hour
+	expectedAt := s.now.Add(duration)
+	expectedState := chasm.LifecycleStateCompleted
+
+	s.mockCtx.EXPECT().AddTask(gomock.Any(), gomock.Any(), gomock.Any()).
+		Do(func(_ chasm.Component, attrs chasm.TaskAttributes, _ *persistencespb.RetentionTask) {
+			s.Equal(expectedAt, attrs.ScheduledTime)
+		}).
+		Times(1)
+
+	// Create the retention component, which should create the timer task.
+	r, err := retention.NewRetention(s.mockCtx, 1*time.Hour, expectedState)
+	s.NoError(err)
+	s.Equal(chasm.LifecycleStateRunning, r.LifecycleState(s.mockCtx))
+
+	// Execute task.
+	executor := retention.NewRetentionTaskExecutor()
+
+	valid, err := executor.Validate(s.mockCtx, r, chasm.TaskAttributes{}, nil)
+	s.True(valid)
+	s.NoError(err)
+
+	err = executor.Execute(s.mockCtx, r, chasm.TaskAttributes{}, nil)
+	s.NoError(err)
+	s.True(r.Closed)
+	s.Equal(expectedState, r.LifecycleState(s.mockCtx))
+
+	valid, err = executor.Validate(s.mockCtx, r, chasm.TaskAttributes{}, nil)
+	s.False(valid)
+	s.NoError(err)
+}

--- a/proto/internal/temporal/server/api/persistence/v1/chasm.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/chasm.proto
@@ -101,3 +101,18 @@ message ChasmComponentRef {
     repeated string component_path = 6;
     VersionedTransition component_initial_versioned_transition = 7;
 }
+
+// TODO TODO TODO - move into retention/proto/v1 as soon as Roey's PR lands
+// 
+// Data for the Retention component.
+message RetentionData {
+    // True once the retention timer has fired and the component is now in its
+    // terminal state.
+    bool closed = 1;    
+
+    // The desired terminal chasm.LifecycleState (either Completed or Failed).
+    int64 terminal_state = 2;
+}
+
+// TODO TODO TODO - move into retention/proto/v1 as soon as Roey's PR lands
+message RetentionTask {}


### PR DESCRIPTION
## What changed?
- Added a new reusable CHASM component, `Retention`, which simply updates its own LifecycleState to a given terminal state after a given duration elapses.

## Why?
- Schedules make use of this sort of timer to hold the workflow open for a period before the workflow actually closes, and the namespace-level workflow retention period takes effect. This is used to keep a completed schedule visible in the UI/frontend API for a period of time after it is completed. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
