### PR TITLE
Change default for `component.nexusoperations.recordCancelRequestCompletionEvents`

### DIFF
--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -141,9 +141,9 @@ requirements and query complexity. Consider the cardinality impact when enabling
 
 var RecordCancelRequestCompletionEvents = dynamicconfig.NewGlobalBoolSetting(
 	"component.nexusoperations.recordCancelRequestCompletionEvents",
-	false,
+	true,
 	`Boolean flag to control whether to record NexusOperationCancelRequestCompleted and 
-NexusOperationCancelRequestFailed events. Default false.`,
+NexusOperationCancelRequestFailed events. Default true.`,
 )
 
 type Config struct {


### PR DESCRIPTION
## What changed?
Changed default for `component.nexusoperations.recordCancelRequestCompletionEvents` to `true`

## Why?
Flag was added to ensure backwards compatibility. Now that 1.28 is released, can change the default. Flag will be removed after 1.29 is released.

