### PR TITLE
Record various activity metrics

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -826,12 +826,29 @@ var (
 		"pending_tasks",
 		WithDescription("A histogram across history shards for the number of in-memory pending history tasks."),
 	)
-	TaskSchedulerThrottled                               = NewCounterDef("task_scheduler_throttled")
-	QueueScheduleLatency                                 = NewTimerDef("queue_latency_schedule") // latency for scheduling 100 tasks in one task channel
-	QueueReaderCountHistogram                            = NewDimensionlessHistogramDef("queue_reader_count")
-	QueueSliceCountHistogram                             = NewDimensionlessHistogramDef("queue_slice_count")
-	QueueActionCounter                                   = NewCounterDef("queue_actions")
-	ActivityE2ELatency                                   = NewTimerDef("activity_end_to_end_latency")
+	TaskSchedulerThrottled    = NewCounterDef("task_scheduler_throttled")
+	QueueScheduleLatency      = NewTimerDef("queue_latency_schedule") // latency for scheduling 100 tasks in one task channel
+	QueueReaderCountHistogram = NewDimensionlessHistogramDef("queue_reader_count")
+	QueueSliceCountHistogram  = NewDimensionlessHistogramDef("queue_slice_count")
+	QueueActionCounter        = NewCounterDef("queue_actions")
+	ActivityE2ELatency        = NewTimerDef(
+		"activity_end_to_end_latency",
+		WithDescription("DEPRECATED: Will be removed in one of the next releases. Duration of an activity attempt. Use activity_start_to_close_latency instead."),
+	)
+	ActivityStartToCloseLatency = NewTimerDef(
+		"activity_start_to_close_latency",
+		WithDescription("Duration of a single activity attempt. Doesn't include retries or backoffs."),
+	)
+	ActivityScheduleToCloseLatency = NewTimerDef(
+		"activity_schedule_to_close_latency",
+		WithDescription("Duration of activity execution from scheduled time to terminal state. Includes retries and backoffs."),
+	)
+	ActivitySuccess                                      = NewCounterDef("activity_success", WithDescription("Number of activities that succeeded (doesn't include retries)."))
+	ActivityFail                                         = NewCounterDef("activity_fail", WithDescription("Number of activities that failed and won't be retried anymore."))
+	ActivityTaskFail                                     = NewCounterDef("activity_task_fail", WithDescription("Number of activity task failures (includes retries)."))
+	ActivityCancel                                       = NewCounterDef("activity_cancel")
+	ActivityTaskTimeout                                  = NewCounterDef("activity_task_timeout", WithDescription("Number of activity task timeouts (including retries)."))
+	ActivityTimeout                                      = NewCounterDef("activity_timeout", WithDescription("Number of terminal activity timeouts."))
 	AckLevelUpdateCounter                                = NewCounterDef("ack_level_update")
 	AckLevelUpdateFailedCounter                          = NewCounterDef("ack_level_update_failed")
 	CommandCounter                                       = NewCounterDef("command")

--- a/service/history/api/respondactivitytaskcanceled/api.go
+++ b/service/history/api/respondactivitytaskcanceled/api.go
@@ -38,7 +38,8 @@ func Invoke(
 		return nil, err
 	}
 
-	var activityStartedTime time.Time
+	var attemptStartedTime time.Time
+	var firstScheduledTime time.Time
 	var taskQueue string
 	var workflowTypeName string
 	err = api.GetAndUpdateWorkflowWithNew(
@@ -96,7 +97,8 @@ func Invoke(
 				return nil, err
 			}
 
-			activityStartedTime = ai.StartedTime.AsTime()
+			attemptStartedTime = ai.StartedTime.AsTime()
+			firstScheduledTime = ai.FirstScheduledTime.AsTime()
 			taskQueue = ai.TaskQueue
 			return &api.UpdateWorkflowAction{
 				Noop:               false,
@@ -108,15 +110,21 @@ func Invoke(
 		workflowConsistencyChecker,
 	)
 
-	if err == nil && !activityStartedTime.IsZero() {
-		metrics.ActivityE2ELatency.With(
-			workflow.GetPerTaskQueueFamilyScope(
-				shard.GetMetricsHandler(), namespace, taskQueue, shard.GetConfig(),
-				metrics.OperationTag(metrics.HistoryRespondActivityTaskCanceledScope),
-				metrics.WorkflowTypeTag(workflowTypeName),
-				metrics.ActivityTypeTag(token.ActivityType),
-			),
-		).Record(time.Since(activityStartedTime))
+	if err == nil {
+		workflow.RecordActivityCompletionMetrics(
+			shard,
+			namespace,
+			taskQueue,
+			workflow.ActivityCompletionMetrics{
+				State:              workflow.ActivityStateCanceled,
+				AttemptStartedTime: attemptStartedTime,
+				FirstScheduledTime: firstScheduledTime,
+				Closed:             true,
+			},
+			metrics.OperationTag(metrics.HistoryRespondActivityTaskCanceledScope),
+			metrics.WorkflowTypeTag(workflowTypeName),
+			metrics.ActivityTypeTag(token.ActivityType),
+		)
 	}
 	return &historyservice.RespondActivityTaskCanceledResponse{}, err
 }

--- a/service/history/api/respondactivitytaskcanceled/api.go
+++ b/service/history/api/respondactivitytaskcanceled/api.go
@@ -116,7 +116,7 @@ func Invoke(
 			namespace,
 			taskQueue,
 			workflow.ActivityCompletionMetrics{
-				State:              workflow.ActivityStateCanceled,
+				Status:             workflow.ActivityStatusCanceled,
 				AttemptStartedTime: attemptStartedTime,
 				FirstScheduledTime: firstScheduledTime,
 				Closed:             true,

--- a/service/history/api/respondactivitytaskcompleted/api.go
+++ b/service/history/api/respondactivitytaskcompleted/api.go
@@ -38,7 +38,8 @@ func Invoke(
 		return nil, err
 	}
 
-	var activityStartedTime time.Time
+	var attemptStartedTime time.Time
+	var firstScheduledTime time.Time
 	var taskQueue string
 	var workflowTypeName string
 	var fabricateStartedEvent bool
@@ -109,7 +110,8 @@ func Invoke(
 				// Unable to add ActivityTaskCompleted event to history
 				return nil, err
 			}
-			activityStartedTime = ai.StartedTime.AsTime()
+			attemptStartedTime = ai.StartedTime.AsTime()
+			firstScheduledTime = ai.FirstScheduledTime.AsTime()
 			taskQueue = ai.TaskQueue
 			return &api.UpdateWorkflowAction{
 				Noop:               false,
@@ -121,15 +123,21 @@ func Invoke(
 		workflowConsistencyChecker,
 	)
 
-	if err == nil && !activityStartedTime.IsZero() && !fabricateStartedEvent {
-		metrics.ActivityE2ELatency.With(
-			workflow.GetPerTaskQueueFamilyScope(
-				shard.GetMetricsHandler(), namespace, taskQueue, shard.GetConfig(),
-				metrics.OperationTag(metrics.HistoryRespondActivityTaskCompletedScope),
-				metrics.WorkflowTypeTag(workflowTypeName),
-				metrics.ActivityTypeTag(token.ActivityType),
-			),
-		).Record(time.Since(activityStartedTime))
+	if err == nil && !fabricateStartedEvent {
+		workflow.RecordActivityCompletionMetrics(
+			shard,
+			namespace,
+			taskQueue,
+			workflow.ActivityCompletionMetrics{
+				AttemptStartedTime: attemptStartedTime,
+				FirstScheduledTime: firstScheduledTime,
+				State:              workflow.ActivityStateSucceeded,
+				Closed:             true,
+			},
+			metrics.OperationTag(metrics.HistoryRespondActivityTaskCompletedScope),
+			metrics.WorkflowTypeTag(workflowTypeName),
+			metrics.ActivityTypeTag(token.ActivityType),
+		)
 	}
 	return &historyservice.RespondActivityTaskCompletedResponse{}, err
 }

--- a/service/history/api/respondactivitytaskcompleted/api.go
+++ b/service/history/api/respondactivitytaskcompleted/api.go
@@ -131,7 +131,7 @@ func Invoke(
 			workflow.ActivityCompletionMetrics{
 				AttemptStartedTime: attemptStartedTime,
 				FirstScheduledTime: firstScheduledTime,
-				State:              workflow.ActivityStateSucceeded,
+				Status:             workflow.ActivityStatusSucceeded,
 				Closed:             true,
 			},
 			metrics.OperationTag(metrics.HistoryRespondActivityTaskCompletedScope),

--- a/service/history/api/respondactivitytaskfailed/api.go
+++ b/service/history/api/respondactivitytaskfailed/api.go
@@ -40,9 +40,11 @@ func Invoke(
 		return nil, err
 	}
 
-	var activityStartedTime time.Time
+	var attemptStartedTime time.Time
+	var firstScheduledTime time.Time
 	var taskQueue string
 	var workflowTypeName string
+	var closed bool
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		token.Clock,
@@ -109,9 +111,13 @@ func Invoke(
 					return nil, err
 				}
 				postActions.CreateWorkflowTask = true
+				closed = true
+			} else {
+				closed = false
 			}
 
-			activityStartedTime = ai.StartedTime.AsTime()
+			attemptStartedTime = ai.StartedTime.AsTime()
+			firstScheduledTime = ai.FirstScheduledTime.AsTime()
 			taskQueue = ai.TaskQueue
 			return postActions, nil
 		},
@@ -119,15 +125,23 @@ func Invoke(
 		shard,
 		workflowConsistencyChecker,
 	)
-	if err == nil && !activityStartedTime.IsZero() {
-		metrics.ActivityE2ELatency.With(
-			workflow.GetPerTaskQueueFamilyScope(
-				shard.GetMetricsHandler(), namespace, taskQueue, shard.GetConfig(),
-				metrics.OperationTag(metrics.HistoryRespondActivityTaskFailedScope),
-				metrics.WorkflowTypeTag(workflowTypeName),
-				metrics.ActivityTypeTag(token.ActivityType),
-			),
-		).Record(time.Since(activityStartedTime))
+	if err == nil {
+		completionMetrics := workflow.ActivityCompletionMetrics{
+			AttemptStartedTime: attemptStartedTime,
+			FirstScheduledTime: firstScheduledTime,
+			State:              workflow.ActivityStateFailed,
+			Closed:             closed,
+		}
+
+		workflow.RecordActivityCompletionMetrics(
+			shard,
+			namespace,
+			taskQueue,
+			completionMetrics,
+			metrics.OperationTag(metrics.HistoryRespondActivityTaskFailedScope),
+			metrics.WorkflowTypeTag(workflowTypeName),
+			metrics.ActivityTypeTag(token.ActivityType),
+		)
 	}
 	return &historyservice.RespondActivityTaskFailedResponse{}, err
 }

--- a/service/history/api/respondactivitytaskfailed/api.go
+++ b/service/history/api/respondactivitytaskfailed/api.go
@@ -129,7 +129,7 @@ func Invoke(
 		completionMetrics := workflow.ActivityCompletionMetrics{
 			AttemptStartedTime: attemptStartedTime,
 			FirstScheduledTime: firstScheduledTime,
-			State:              workflow.ActivityStateFailed,
+			Status:             workflow.ActivityStatusFailed,
 			Closed:             closed,
 		}
 

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -301,7 +301,7 @@ func (t *timerQueueActiveTaskExecutor) processSingleActivityTimeoutTask(
 		namespace.Name(mutableState.GetNamespaceEntry().Name()),
 		ai.TaskQueue,
 		workflow.ActivityCompletionMetrics{
-			State:              workflow.ActivityStateTimeout,
+			Status:             workflow.ActivityStatusTimeout,
 			AttemptStartedTime: timestamp.TimeValue(ai.StartedTime),
 			FirstScheduledTime: timestamp.TimeValue(ai.FirstScheduledTime),
 			Closed:             retryState != enumspb.RETRY_STATE_IN_PROGRESS,

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -307,6 +307,9 @@ func (t *timerQueueActiveTaskExecutor) processSingleActivityTimeoutTask(
 			Closed:             retryState != enumspb.RETRY_STATE_IN_PROGRESS,
 			TimerType:          timerSequenceID.TimerType,
 		},
+		metrics.OperationTag(metrics.TimerActiveTaskActivityTimeoutScope),
+		metrics.WorkflowTypeTag(mutableState.GetWorkflowType().GetName()),
+		metrics.ActivityTypeTag(ai.ActivityType.GetName()),
 	)
 
 	if retryState == enumspb.RETRY_STATE_IN_PROGRESS {

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -296,6 +296,19 @@ func (t *timerQueueActiveTaskExecutor) processSingleActivityTimeoutTask(
 		return result, nil
 	}
 
+	workflow.RecordActivityCompletionMetrics(
+		t.shardContext,
+		namespace.Name(mutableState.GetNamespaceEntry().Name()),
+		ai.TaskQueue,
+		workflow.ActivityCompletionMetrics{
+			State:              workflow.ActivityStateTimeout,
+			AttemptStartedTime: timestamp.TimeValue(ai.StartedTime),
+			FirstScheduledTime: timestamp.TimeValue(ai.FirstScheduledTime),
+			Closed:             retryState != enumspb.RETRY_STATE_IN_PROGRESS,
+			TimerType:          timerSequenceID.TimerType,
+		},
+	)
+
 	if retryState == enumspb.RETRY_STATE_IN_PROGRESS {
 		// TODO uncommment once RETRY_STATE_PAUSED is supported
 		// || retryState == enumspb.RETRY_STATE_PAUSED {

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -2309,6 +2309,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessSingleActivityTimeoutTask
 		s.Run(tc.name, func() {
 			if tc.expectRetryActivity {
 				ms.EXPECT().RetryActivity(gomock.Any(), gomock.Any()).Return(tc.retryState, tc.retryError)
+				ms.EXPECT().GetWorkflowType().Return(&commonpb.WorkflowType{Name: "test-workflow-type"}).AnyTimes()
 			}
 
 			if tc.expectAddTimedTask {

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -2316,6 +2316,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessSingleActivityTimeoutTask
 				ms.EXPECT().AddActivityTaskTimedOutEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 			}
 			ms.EXPECT().GetEffectiveVersioningBehavior().Return(enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED).AnyTimes()
+			ms.EXPECT().GetNamespaceEntry().Return(tests.LocalNamespaceEntry).AnyTimes()
 
 			result, err := s.timerQueueActiveTaskExecutor.processSingleActivityTimeoutTask(
 				ms, tc.timerSequenceID, tc.ai)

--- a/service/history/workflow/metrics.go
+++ b/service/history/workflow/metrics.go
@@ -160,14 +160,14 @@ type ActivityCompletionMetrics struct {
 
 func RecordActivityCompletionMetrics(
 	shard historyi.ShardContext,
-	namespace namespace.Name,
+	namespaceName namespace.Name,
 	taskQueue string,
 	metricsState ActivityCompletionMetrics,
 	tags ...metrics.Tag,
 ) {
 	metricsHandler := GetPerTaskQueueFamilyScope(
 		shard.GetMetricsHandler(),
-		namespace,
+		namespaceName,
 		taskQueue,
 		shard.GetConfig(),
 		tags...,

--- a/service/history/workflow/metrics.go
+++ b/service/history/workflow/metrics.go
@@ -1,6 +1,8 @@
 package workflow
 
 import (
+	"time"
+
 	enumspb "go.temporal.io/api/enums/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/metrics"
@@ -8,6 +10,7 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/service/history/configs"
+	historyi "go.temporal.io/server/service/history/interfaces"
 )
 
 func emitWorkflowHistoryStats(
@@ -130,4 +133,75 @@ func GetPerTaskQueueFamilyScope(
 		config.BreakdownMetricsByTaskQueue(namespaceName.String(), taskQueueFamily, enumspb.TASK_QUEUE_TYPE_WORKFLOW),
 		tags...,
 	)
+}
+
+type ActivityExecutionState int
+
+const (
+	ActivityStateUnknown ActivityExecutionState = iota
+	ActivityStateSucceeded
+	ActivityStateFailed
+	ActivityStateCanceled
+	ActivityStateTimeout
+)
+
+type ActivityCompletionMetrics struct {
+	// State determines whether the activity succeeded, and whether it is/will be retried
+	State ActivityExecutionState
+	// AttemptStartedTime is the start time of the current attempt
+	AttemptStartedTime time.Time
+	// FirstScheduledTime is the scheduled time of the first attempt
+	FirstScheduledTime time.Time
+	// Closed is true if no more attempts will be made to execute the activity.
+	Closed bool
+	// TimerType is the type of timer that caused the activity execution to timeout.
+	TimerType enumspb.TimeoutType
+}
+
+func RecordActivityCompletionMetrics(
+	shard historyi.ShardContext,
+	namespace namespace.Name,
+	taskQueue string,
+	metricsState ActivityCompletionMetrics,
+	tags ...metrics.Tag,
+) {
+	metricsHandler := GetPerTaskQueueFamilyScope(
+		shard.GetMetricsHandler(),
+		namespace,
+		taskQueue,
+		shard.GetConfig(),
+		tags...,
+	)
+
+	if !metricsState.AttemptStartedTime.IsZero() {
+		latency := time.Since(metricsState.AttemptStartedTime)
+		// ActivityE2ELatency is deprecated due to its inaccurate naming. It captures the attempt duration instead of an end-to-end duration as its name suggests. For now record both metrics
+		metrics.ActivityE2ELatency.With(metricsHandler).Record(latency)
+		metrics.ActivityStartToCloseLatency.With(metricsHandler).Record(latency)
+	}
+
+	// Record true end-to-end duration only for terminal states (includes retries and backoffs)
+	if metricsState.Closed && !metricsState.FirstScheduledTime.IsZero() {
+		scheduleToCloseLatency := time.Since(metricsState.FirstScheduledTime)
+		metrics.ActivityScheduleToCloseLatency.With(metricsHandler).Record(scheduleToCloseLatency)
+	}
+
+	switch metricsState.State {
+	case ActivityStateFailed:
+		metrics.ActivityTaskFail.With(metricsHandler).Record(1)
+		if metricsState.Closed {
+			metrics.ActivityFail.With(metricsHandler).Record(1)
+		}
+	case ActivityStateCanceled:
+		metrics.ActivityCancel.With(metricsHandler).Record(1)
+	case ActivityStateSucceeded:
+		metrics.ActivitySuccess.With(metricsHandler).Record(1)
+	case ActivityStateTimeout:
+		metrics.ActivityTaskTimeout.With(metricsHandler).Record(1, metrics.StringTag("timeout_type", metricsState.TimerType.String()))
+		if metricsState.Closed {
+			metrics.ActivityTimeout.With(metricsHandler).Record(1, metrics.StringTag("timeout_type", metricsState.TimerType.String()))
+		}
+	case ActivityStateUnknown:
+		// Do nothing
+	}
 }

--- a/service/history/workflow/metrics.go
+++ b/service/history/workflow/metrics.go
@@ -201,7 +201,7 @@ func RecordActivityCompletionMetrics(
 		if metricsState.Closed {
 			metrics.ActivityTimeout.With(metricsHandler).Record(1, metrics.StringTag("timeout_type", metricsState.TimerType.String()))
 		}
-	case ActivityStateUnknown:
+	default:
 		// Do nothing
 	}
 }


### PR DESCRIPTION
## What changed?
Changes activity metrics

### Deprecated Metrics

- **activity_e2e_latency** → Deprecated, as it measures individual attempts rather than true end-to-end latency, and replaced with clearer **activity_start_to_close_latency**

### New & Replacement Metrics

- **activity_start_to_close_latency**: Measures the latency from activity start to close (per attempt).
- **activity_schedule_to_close_latency**: Measures true end-to-end duration, including retries and backoff.
- **activity_success**: Counts the number of succeeded activities. Aligned with the existing **workflow_success** counter.
- **activity_fail**: Counts final failures for activities. Similar to **workflow_failed,** although it doesn’t include retries.
- **activity_timeout**: Incremented on the final activity timeout (including ScheduleToStartTimeout), tagged by `timeout_type`. Aligned with the existing **workflow_timeout** counter.
- **activity_task_fail**: Counts failures for activities including retries. Note that we don’t need to capture the number of retries, as this metric represents this number well.
- **activity_task_timeout**: Incremented on the activity attempt timeout (including ScheduleToStartTimeout), tagged by `timeout_type`.
- **activity_cancel:** Incremented when an activity is cancelled ****

## Why?
ActivityE2ELatency is inaccurate, since it measures only individual attempts. The other metrics are not recorded yet.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

Ran the server locally and checked the metrics in Prometheus:

Test 1: Activity with 5 attempts (1s each, 1s gap, all time out)

- activity_task_timeout = 5
- activity_timeout = 1
- activity_success = 0
- activity_fail = 0 (counted as timeout instead)
- activity_task_fail = 0 (counted as timeout instead)
- activity_schedule_to_close_latency_sum = 9s
- activity_end_to_end_latency_sum = 1s (deprecated) 
- activity_start_to_close_latency_sum = 1s

Test 2: Basic helloworld activity

- activity_success = 1

Test 3: Activity with 5 attempts (1s each, 1s gap, all fail except for the last one)
- activity_task_fail = 4
- activity_success = 1
