### PR TITLE
CHASM: Add more persistence layer tests

### DIFF
--- a/common/persistence/tests/util.go
+++ b/common/persistence/tests/util.go
@@ -48,7 +48,7 @@ func RandomSnapshot(
 ) (*p.WorkflowSnapshot, []*p.WorkflowEvents) {
 	snapshot := &p.WorkflowSnapshot{
 		ExecutionInfo:  RandomExecutionInfo(namespaceID, workflowID, eventID, lastWriteVersion, branchToken),
-		ExecutionState: RandomExecutionState(runID, state, status),
+		ExecutionState: RandomExecutionState(runID, state, status, lastWriteVersion),
 
 		NextEventID: eventID + 1, // NOTE: RandomSnapshot generates a single history event, hence NextEventID is plus 1
 
@@ -98,7 +98,7 @@ func RandomMutation(
 ) (*p.WorkflowMutation, []*p.WorkflowEvents) {
 	mutation := &p.WorkflowMutation{
 		ExecutionInfo:  RandomExecutionInfo(namespaceID, workflowID, eventID, lastWriteVersion, branchToken),
-		ExecutionState: RandomExecutionState(runID, state, status),
+		ExecutionState: RandomExecutionState(runID, state, status, lastWriteVersion),
 
 		NextEventID: eventID + 1, // NOTE: RandomMutation generates a single history event, hence NextEventID is plus 1
 
@@ -210,6 +210,7 @@ func RandomExecutionState(
 	runID string,
 	state enumsspb.WorkflowExecutionState,
 	status enumspb.WorkflowExecutionStatus,
+	lastWriteVersion int64,
 ) *persistencespb.WorkflowExecutionState {
 	createRequestID := uuid.NewString()
 	return &persistencespb.WorkflowExecutionState{
@@ -217,6 +218,10 @@ func RandomExecutionState(
 		RunId:           runID,
 		State:           state,
 		Status:          status,
+		LastUpdateVersionedTransition: &persistencespb.VersionedTransition{
+			NamespaceFailoverVersion: lastWriteVersion,
+			TransitionCount:          rand.Int63(),
+		},
 		RequestIds: map[string]*persistencespb.RequestIDInfo{
 			createRequestID: {
 				EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,


### PR DESCRIPTION
## What changed?
- Add more persistence layer tests for CHASM workloads

## Why?
- Persistence requests from CHASM doesn't have event and the version history field in mutable state is also empty. This may break certain persistence implementations. Adding more tests for better coverage.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
