### PR TITLE
[Scheduled Actions] Use the Execution returned from PollMutableState when calling GetWorkflowExecutionHistory

### DIFF
--- a/service/worker/scheduler/activities.go
+++ b/service/worker/scheduler/activities.go
@@ -162,8 +162,13 @@ func (a *activities) tryWatchWorkflow(ctx context.Context, req *schedulespb.Watc
 
 	// get last event from history
 	histReq := &workflowservice.GetWorkflowExecutionHistoryRequest{
-		Namespace:              a.namespace.String(),
-		Execution:              req.Execution,
+		Namespace: a.namespace.String(),
+
+		// If a workflow is started and completed while we were polling, PollMutableState
+		// may return a different Execution than what we'd requested. Make sure to request
+		// events for the latest.
+		Execution: pollRes.Execution,
+
 		MaximumPageSize:        1,
 		HistoryEventFilterType: enumspb.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT,
 		SkipArchival:           true, // should be recently closed, no need for archival


### PR DESCRIPTION
## What changed?
- In WatchWorkflow, we'll now use the Execution returned as a result from `PollMutableState`, instead of the Execution we used as part of the `PollMutableState` request.

## Why?
- We have a likely race condition if a workflow starts and completes during the `PollMutableState` call, where our originally-requested Execution is no longer the latest.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

