### PR TITLE
Change sys background low to use the correct level

### DIFF
--- a/common/headers/caller_info.go
+++ b/common/headers/caller_info.go
@@ -33,7 +33,7 @@ var (
 	}
 	SystemBackgroundLowCallerInfo = CallerInfo{
 		CallerName: CallerNameSystem,
-		CallerType: CallerTypeBackgroundHigh,
+		CallerType: CallerTypeBackgroundLow,
 	}
 	SystemPreemptableCallerInfo = CallerInfo{
 		CallerName: CallerNameSystem,


### PR DESCRIPTION
## What changed?
Change sys background low to use the correct level

## Why?
Fix this based on the variable name

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

