### PR TITLE
When retrying polls, prefer different partitions

### DIFF
--- a/client/matching/retryable_client.go
+++ b/client/matching/retryable_client.go
@@ -1,9 +1,14 @@
 package matching
 
 import (
+	"context"
+
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common/backoff"
 )
+
+type retryHint struct{ bits *uint64 }
+type retryHintCtxKey struct{}
 
 var _ matchingservice.MatchingServiceClient = (*retryableClient)(nil)
 
@@ -26,5 +31,27 @@ func NewRetryableClient(
 		policy:      policy,
 		pollPolicy:  pollPolicy,
 		isRetryable: isRetryable,
+	}
+}
+
+func withRetryHint(ctx context.Context) context.Context {
+	return context.WithValue(ctx, retryHintCtxKey{}, retryHint{bits: new(uint64)})
+}
+
+func getRetryHint(ctx context.Context) retryHint {
+	hint, _ := ctx.Value(retryHintCtxKey{}).(retryHint)
+	return hint
+}
+
+func (r retryHint) used(i int) bool {
+	if r.bits != nil && i >= 0 && i < 64 {
+		return (*r.bits)&(1<<i) != 0
+	}
+	return false
+}
+
+func (r retryHint) set(i int) {
+	if r.bits != nil && i >= 0 && i < 64 {
+		*r.bits |= 1 << i
 	}
 }

--- a/client/matching/retryable_client_gen.go
+++ b/client/matching/retryable_client_gen.go
@@ -352,6 +352,7 @@ func (c *retryableClient) PollActivityTaskQueue(
 		resp, err = c.client.PollActivityTaskQueue(ctx, request, opts...)
 		return err
 	}
+	ctx = withRetryHint(ctx)
 	err := backoff.ThrottleRetryContext(ctx, op, c.pollPolicy, c.isRetryable)
 	return resp, err
 }
@@ -382,6 +383,7 @@ func (c *retryableClient) PollWorkflowTaskQueue(
 		resp, err = c.client.PollWorkflowTaskQueue(ctx, request, opts...)
 		return err
 	}
+	ctx = withRetryHint(ctx)
 	err := backoff.ThrottleRetryContext(ctx, op, c.pollPolicy, c.isRetryable)
 	return resp, err
 }

--- a/cmd/tools/genrpcwrappers/main.go
+++ b/cmd/tools/genrpcwrappers/main.go
@@ -78,6 +78,10 @@ var (
 		"retryableClient.matching.PollActivityTaskQueue": "pollPolicy",
 		"retryableClient.matching.PollNexusTaskQueue":    "pollPolicy",
 	}
+	withRetryHint = map[string]string{
+		"retryableClient.matching.PollWorkflowTaskQueue": "withRetryHint",
+		"retryableClient.matching.PollActivityTaskQueue": "withRetryHint",
+	}
 	ignoreMethod = map[string]bool{
 		// TODO stream APIs are not supported. do not generate.
 		"client.admin.StreamWorkflowReplicationMessages":          true,
@@ -394,6 +398,7 @@ func writeTemplatedMethod(w io.Writer, service service, impl string, m reflect.M
 		"ResponseType": respType.String(),
 		"MetricPrefix": fmt.Sprintf("%s%sClient", strings.ToUpper(service.name[:1]), service.name[1:]),
 		"RetryPolicy":  cmp.Or(longPollRetryPolicy[key], "policy"),
+		"RetryHint":    withRetryHint[key],
 	}
 	if longPollContext[key] {
 		fields["LongPoll"] = "LongPoll"
@@ -588,6 +593,9 @@ func (c *retryableClient) {{.Method}}(
 		resp, err = c.client.{{.Method}}(ctx, request, opts...)
 		return err
 	}
+{{- if .RetryHint }}
+	ctx = {{.RetryHint}}(ctx)
+{{- end}}
 	err := backoff.ThrottleRetryContext(ctx, op, c.{{.RetryPolicy}}, c.isRetryable)
 	return resp, err
 }


### PR DESCRIPTION
## What changed?
Use a hint to make retried polls prefer different partitions.

## Why?
If one partition is on a matching node that's being slow, and there are other partitions available to poll from, we should use them instead.

## How did you test it?
- [x] built
