### PR TITLE
Nexus remove direct dispatch + rename Get to Fetch

### DIFF
--- a/client/frontend/client_gen.go
+++ b/client/frontend/client_gen.go
@@ -209,6 +209,26 @@ func (c *clientImpl) ExecuteMultiOperation(
 	return c.client.ExecuteMultiOperation(ctx, request, opts...)
 }
 
+func (c *clientImpl) FetchNexusOperationInfo(
+	ctx context.Context,
+	request *workflowservice.FetchNexusOperationInfoRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.FetchNexusOperationInfoResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.FetchNexusOperationInfo(ctx, request, opts...)
+}
+
+func (c *clientImpl) FetchNexusOperationResult(
+	ctx context.Context,
+	request *workflowservice.FetchNexusOperationResultRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.FetchNexusOperationResultResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.FetchNexusOperationResult(ctx, request, opts...)
+}
+
 func (c *clientImpl) FetchWorkerConfig(
 	ctx context.Context,
 	request *workflowservice.FetchWorkerConfigRequest,
@@ -247,26 +267,6 @@ func (c *clientImpl) GetDeploymentReachability(
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.GetDeploymentReachability(ctx, request, opts...)
-}
-
-func (c *clientImpl) GetNexusOperationInfo(
-	ctx context.Context,
-	request *workflowservice.GetNexusOperationInfoRequest,
-	opts ...grpc.CallOption,
-) (*workflowservice.GetNexusOperationInfoResponse, error) {
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.GetNexusOperationInfo(ctx, request, opts...)
-}
-
-func (c *clientImpl) GetNexusOperationResult(
-	ctx context.Context,
-	request *workflowservice.GetNexusOperationResultRequest,
-	opts ...grpc.CallOption,
-) (*workflowservice.GetNexusOperationResultResponse, error) {
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.GetNexusOperationResult(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetSearchAttributes(

--- a/client/frontend/metric_client_gen.go
+++ b/client/frontend/metric_client_gen.go
@@ -289,6 +289,34 @@ func (c *metricClient) ExecuteMultiOperation(
 	return c.client.ExecuteMultiOperation(ctx, request, opts...)
 }
 
+func (c *metricClient) FetchNexusOperationInfo(
+	ctx context.Context,
+	request *workflowservice.FetchNexusOperationInfoRequest,
+	opts ...grpc.CallOption,
+) (_ *workflowservice.FetchNexusOperationInfoResponse, retError error) {
+
+	metricsHandler, startTime := c.startMetricsRecording(ctx, "FrontendClientFetchNexusOperationInfo")
+	defer func() {
+		c.finishMetricsRecording(metricsHandler, startTime, retError)
+	}()
+
+	return c.client.FetchNexusOperationInfo(ctx, request, opts...)
+}
+
+func (c *metricClient) FetchNexusOperationResult(
+	ctx context.Context,
+	request *workflowservice.FetchNexusOperationResultRequest,
+	opts ...grpc.CallOption,
+) (_ *workflowservice.FetchNexusOperationResultResponse, retError error) {
+
+	metricsHandler, startTime := c.startMetricsRecording(ctx, "FrontendClientFetchNexusOperationResult")
+	defer func() {
+		c.finishMetricsRecording(metricsHandler, startTime, retError)
+	}()
+
+	return c.client.FetchNexusOperationResult(ctx, request, opts...)
+}
+
 func (c *metricClient) FetchWorkerConfig(
 	ctx context.Context,
 	request *workflowservice.FetchWorkerConfigRequest,
@@ -343,34 +371,6 @@ func (c *metricClient) GetDeploymentReachability(
 	}()
 
 	return c.client.GetDeploymentReachability(ctx, request, opts...)
-}
-
-func (c *metricClient) GetNexusOperationInfo(
-	ctx context.Context,
-	request *workflowservice.GetNexusOperationInfoRequest,
-	opts ...grpc.CallOption,
-) (_ *workflowservice.GetNexusOperationInfoResponse, retError error) {
-
-	metricsHandler, startTime := c.startMetricsRecording(ctx, "FrontendClientGetNexusOperationInfo")
-	defer func() {
-		c.finishMetricsRecording(metricsHandler, startTime, retError)
-	}()
-
-	return c.client.GetNexusOperationInfo(ctx, request, opts...)
-}
-
-func (c *metricClient) GetNexusOperationResult(
-	ctx context.Context,
-	request *workflowservice.GetNexusOperationResultRequest,
-	opts ...grpc.CallOption,
-) (_ *workflowservice.GetNexusOperationResultResponse, retError error) {
-
-	metricsHandler, startTime := c.startMetricsRecording(ctx, "FrontendClientGetNexusOperationResult")
-	defer func() {
-		c.finishMetricsRecording(metricsHandler, startTime, retError)
-	}()
-
-	return c.client.GetNexusOperationResult(ctx, request, opts...)
 }
 
 func (c *metricClient) GetSearchAttributes(

--- a/client/frontend/retryable_client_gen.go
+++ b/client/frontend/retryable_client_gen.go
@@ -311,6 +311,36 @@ func (c *retryableClient) ExecuteMultiOperation(
 	return resp, err
 }
 
+func (c *retryableClient) FetchNexusOperationInfo(
+	ctx context.Context,
+	request *workflowservice.FetchNexusOperationInfoRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.FetchNexusOperationInfoResponse, error) {
+	var resp *workflowservice.FetchNexusOperationInfoResponse
+	op := func(ctx context.Context) error {
+		var err error
+		resp, err = c.client.FetchNexusOperationInfo(ctx, request, opts...)
+		return err
+	}
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
+	return resp, err
+}
+
+func (c *retryableClient) FetchNexusOperationResult(
+	ctx context.Context,
+	request *workflowservice.FetchNexusOperationResultRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.FetchNexusOperationResultResponse, error) {
+	var resp *workflowservice.FetchNexusOperationResultResponse
+	op := func(ctx context.Context) error {
+		var err error
+		resp, err = c.client.FetchNexusOperationResult(ctx, request, opts...)
+		return err
+	}
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
+	return resp, err
+}
+
 func (c *retryableClient) FetchWorkerConfig(
 	ctx context.Context,
 	request *workflowservice.FetchWorkerConfigRequest,
@@ -365,36 +395,6 @@ func (c *retryableClient) GetDeploymentReachability(
 	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetDeploymentReachability(ctx, request, opts...)
-		return err
-	}
-	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
-	return resp, err
-}
-
-func (c *retryableClient) GetNexusOperationInfo(
-	ctx context.Context,
-	request *workflowservice.GetNexusOperationInfoRequest,
-	opts ...grpc.CallOption,
-) (*workflowservice.GetNexusOperationInfoResponse, error) {
-	var resp *workflowservice.GetNexusOperationInfoResponse
-	op := func(ctx context.Context) error {
-		var err error
-		resp, err = c.client.GetNexusOperationInfo(ctx, request, opts...)
-		return err
-	}
-	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
-	return resp, err
-}
-
-func (c *retryableClient) GetNexusOperationResult(
-	ctx context.Context,
-	request *workflowservice.GetNexusOperationResultRequest,
-	opts ...grpc.CallOption,
-) (*workflowservice.GetNexusOperationResultResponse, error) {
-	var resp *workflowservice.GetNexusOperationResultResponse
-	op := func(ctx context.Context) error {
-		var err error
-		resp, err = c.client.GetNexusOperationResult(ctx, request, opts...)
 		return err
 	}
 	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)

--- a/common/api/metadata.go
+++ b/common/api/metadata.go
@@ -163,8 +163,8 @@ var (
 		"UpdateWorkerConfig":                    {Scope: ScopeNamespace, Access: AccessWrite, Polling: PollingNone},
 		"StartNexusOperation":                   {Scope: ScopeNamespace, Access: AccessWrite, Polling: PollingNone},
 		"RequestCancelNexusOperation":           {Scope: ScopeNamespace, Access: AccessWrite, Polling: PollingNone},
-		"GetNexusOperationInfo":                 {Scope: ScopeNamespace, Access: AccessReadOnly, Polling: PollingNone},
-		"GetNexusOperationResult":               {Scope: ScopeNamespace, Access: AccessReadOnly, Polling: PollingCapable},
+		"FetchNexusOperationInfo":               {Scope: ScopeNamespace, Access: AccessReadOnly, Polling: PollingNone},
+		"FetchNexusOperationResult":             {Scope: ScopeNamespace, Access: AccessReadOnly, Polling: PollingCapable},
 	}
 	operatorServiceMetadata = map[string]MethodMetadata{
 		"AddSearchAttributes":      {Scope: ScopeNamespace, Access: AccessAdmin, Polling: PollingNone},

--- a/common/rpc/interceptor/logtags/workflow_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/workflow_service_server_gen.go
@@ -95,6 +95,14 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 		return nil
 	case *workflowservice.ExecuteMultiOperationResponse:
 		return nil
+	case *workflowservice.FetchNexusOperationInfoRequest:
+		return nil
+	case *workflowservice.FetchNexusOperationInfoResponse:
+		return nil
+	case *workflowservice.FetchNexusOperationResultRequest:
+		return nil
+	case *workflowservice.FetchNexusOperationResultResponse:
+		return nil
 	case *workflowservice.FetchWorkerConfigRequest:
 		return nil
 	case *workflowservice.FetchWorkerConfigResponse:
@@ -110,14 +118,6 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 	case *workflowservice.GetDeploymentReachabilityRequest:
 		return nil
 	case *workflowservice.GetDeploymentReachabilityResponse:
-		return nil
-	case *workflowservice.GetNexusOperationInfoRequest:
-		return nil
-	case *workflowservice.GetNexusOperationInfoResponse:
-		return nil
-	case *workflowservice.GetNexusOperationResultRequest:
-		return nil
-	case *workflowservice.GetNexusOperationResultResponse:
 		return nil
 	case *workflowservice.GetSearchAttributesRequest:
 		return nil

--- a/common/rpc/interceptor/redirection_test.go
+++ b/common/rpc/interceptor/redirection_test.go
@@ -192,8 +192,8 @@ func (s *redirectionInterceptorSuite) TestGlobalAPI() {
 
 		"StartNexusOperation":         {},
 		"RequestCancelNexusOperation": {},
-		"GetNexusOperationInfo":       {},
-		"GetNexusOperationResult":     {},
+		"FetchNexusOperationInfo":     {},
+		"FetchNexusOperationResult":   {},
 	}, apis)
 }
 

--- a/common/testing/mockapi/workflowservicemock/v1/service_grpc.pb.mock.go
+++ b/common/testing/mockapi/workflowservicemock/v1/service_grpc.pb.mock.go
@@ -442,6 +442,46 @@ func (mr *MockWorkflowServiceClientMockRecorder) ExecuteMultiOperation(ctx, in a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteMultiOperation", reflect.TypeOf((*MockWorkflowServiceClient)(nil).ExecuteMultiOperation), varargs...)
 }
 
+// FetchNexusOperationInfo mocks base method.
+func (m *MockWorkflowServiceClient) FetchNexusOperationInfo(ctx context.Context, in *workflowservice.FetchNexusOperationInfoRequest, opts ...grpc.CallOption) (*workflowservice.FetchNexusOperationInfoResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "FetchNexusOperationInfo", varargs...)
+	ret0, _ := ret[0].(*workflowservice.FetchNexusOperationInfoResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchNexusOperationInfo indicates an expected call of FetchNexusOperationInfo.
+func (mr *MockWorkflowServiceClientMockRecorder) FetchNexusOperationInfo(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchNexusOperationInfo", reflect.TypeOf((*MockWorkflowServiceClient)(nil).FetchNexusOperationInfo), varargs...)
+}
+
+// FetchNexusOperationResult mocks base method.
+func (m *MockWorkflowServiceClient) FetchNexusOperationResult(ctx context.Context, in *workflowservice.FetchNexusOperationResultRequest, opts ...grpc.CallOption) (*workflowservice.FetchNexusOperationResultResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "FetchNexusOperationResult", varargs...)
+	ret0, _ := ret[0].(*workflowservice.FetchNexusOperationResultResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchNexusOperationResult indicates an expected call of FetchNexusOperationResult.
+func (mr *MockWorkflowServiceClientMockRecorder) FetchNexusOperationResult(ctx, in any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchNexusOperationResult", reflect.TypeOf((*MockWorkflowServiceClient)(nil).FetchNexusOperationResult), varargs...)
+}
+
 // FetchWorkerConfig mocks base method.
 func (m *MockWorkflowServiceClient) FetchWorkerConfig(ctx context.Context, in *workflowservice.FetchWorkerConfigRequest, opts ...grpc.CallOption) (*workflowservice.FetchWorkerConfigResponse, error) {
 	m.ctrl.T.Helper()
@@ -520,46 +560,6 @@ func (mr *MockWorkflowServiceClientMockRecorder) GetDeploymentReachability(ctx, 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentReachability", reflect.TypeOf((*MockWorkflowServiceClient)(nil).GetDeploymentReachability), varargs...)
-}
-
-// GetNexusOperationInfo mocks base method.
-func (m *MockWorkflowServiceClient) GetNexusOperationInfo(ctx context.Context, in *workflowservice.GetNexusOperationInfoRequest, opts ...grpc.CallOption) (*workflowservice.GetNexusOperationInfoResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []any{ctx, in}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "GetNexusOperationInfo", varargs...)
-	ret0, _ := ret[0].(*workflowservice.GetNexusOperationInfoResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNexusOperationInfo indicates an expected call of GetNexusOperationInfo.
-func (mr *MockWorkflowServiceClientMockRecorder) GetNexusOperationInfo(ctx, in any, opts ...any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx, in}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNexusOperationInfo", reflect.TypeOf((*MockWorkflowServiceClient)(nil).GetNexusOperationInfo), varargs...)
-}
-
-// GetNexusOperationResult mocks base method.
-func (m *MockWorkflowServiceClient) GetNexusOperationResult(ctx context.Context, in *workflowservice.GetNexusOperationResultRequest, opts ...grpc.CallOption) (*workflowservice.GetNexusOperationResultResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []any{ctx, in}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "GetNexusOperationResult", varargs...)
-	ret0, _ := ret[0].(*workflowservice.GetNexusOperationResultResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNexusOperationResult indicates an expected call of GetNexusOperationResult.
-func (mr *MockWorkflowServiceClientMockRecorder) GetNexusOperationResult(ctx, in any, opts ...any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx, in}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNexusOperationResult", reflect.TypeOf((*MockWorkflowServiceClient)(nil).GetNexusOperationResult), varargs...)
 }
 
 // GetSearchAttributes mocks base method.

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -51,8 +51,8 @@ var (
 		DispatchNexusTaskByEndpointAPIName:                                             1,
 		"/temporal.api.workflowservice.v1.WorkflowService/StartNexusOperation":         1,
 		"/temporal.api.workflowservice.v1.WorkflowService/RequestCancelNexusOperation": 1,
-		"/temporal.api.workflowservice.v1.WorkflowService/GetNexusOperationInfo":       1,
-		"/temporal.api.workflowservice.v1.WorkflowService/GetNexusOperationResult":     1,
+		"/temporal.api.workflowservice.v1.WorkflowService/FetchNexusOperationInfo":     1,
+		"/temporal.api.workflowservice.v1.WorkflowService/FetchNexusOperationResult":   1,
 	}
 
 	// APIToPriority determines common API priorities.
@@ -135,8 +135,8 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorkerDeploymentVersion": 3,
 		"/temporal.api.workflowservice.v1.WorkflowService/DescribeWorkerDeployment":        3,
 		"/temporal.api.workflowservice.v1.WorkflowService/ListWorkerDeployments":           3,
-		"/temporal.api.workflowservice.v1.WorkflowService/GetNexusOperationInfo":           3,
-		"/temporal.api.workflowservice.v1.WorkflowService/GetNexusOperationResult":         3,
+		"/temporal.api.workflowservice.v1.WorkflowService/FetchNexusOperationInfo":         3,
+		"/temporal.api.workflowservice.v1.WorkflowService/FetchNexusOperationResult":       3,
 
 		// P3: Progress APIs for reporting cancellations and failures.
 		// They are relatively low priority as the tasks need to be retried anyway.

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5105,8 +5105,8 @@ func (wh *WorkflowHandler) RespondNexusTaskCompleted(ctx context.Context, reques
 
 	if request.GetResponse().GetStartOperation() == nil &&
 		request.GetResponse().GetCancelOperation() == nil &&
-		request.GetResponse().GetGetOperationInfo() == nil &&
-		request.GetResponse().GetGetOperationResult() == nil {
+		request.GetResponse().GetFetchOperationInfo() == nil &&
+		request.GetResponse().GetFetchOperationResult() == nil {
 		return nil, serviceerror.NewInvalidArgument("invalid upstream Nexus response")
 	}
 
@@ -5145,8 +5145,8 @@ func (wh *WorkflowHandler) RespondNexusTaskCompleted(ctx context.Context, reques
 	var details []byte
 	if request.GetResponse().GetStartOperation() != nil {
 		details = request.GetResponse().GetStartOperation().GetOperationError().GetFailure().GetDetails()
-	} else if request.Response.GetGetOperationResult() != nil {
-		details = request.GetResponse().GetGetOperationResult().GetUnsuccessful().GetOperationError().GetFailure().GetDetails()
+	} else if request.Response.GetFetchOperationResult() != nil {
+		details = request.GetResponse().GetFetchOperationResult().GetUnsuccessful().GetOperationError().GetFailure().GetDetails()
 	}
 	if details != nil && !json.Valid(details) {
 		return nil, serviceerror.NewInvalidArgument("failure details must be JSON serializable")

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -943,14 +943,14 @@ func (s *NexusApiTestSuite) TestNexusGetOperationInfo_Outcomes() {
 			handler: func(res *workflowservice.PollNexusTaskQueueResponse) (*nexuspb.Response, *nexuspb.HandlerError) {
 				// Choose an arbitrary test case to assert that all of the input is delivered to the
 				// poll response.
-				op := res.Request.Variant.(*nexuspb.Request_GetOperationInfo).GetOperationInfo
+				op := res.Request.Variant.(*nexuspb.Request_FetchOperationInfo).FetchOperationInfo
 				s.Equal("test-service", op.Service)
 				s.Equal("operation", op.Operation)
 				s.Equal("token", op.OperationToken)
 				s.Equal("value", res.Request.Header["key"])
 				return &nexuspb.Response{
-					Variant: &nexuspb.Response_GetOperationInfo{
-						GetOperationInfo: &nexuspb.GetOperationInfoResponse{
+					Variant: &nexuspb.Response_FetchOperationInfo{
+						FetchOperationInfo: &nexuspb.FetchOperationInfoResponse{
 							Info: &nexuspb.OperationInfo{
 								State: string(nexus.OperationStateRunning),
 								Token: op.OperationToken,
@@ -1109,17 +1109,17 @@ func (s *NexusApiTestSuite) TestNexusGetOperationResult_Outcomes() {
 			handler: func(res *workflowservice.PollNexusTaskQueueResponse) (*nexuspb.Response, *nexuspb.HandlerError) {
 				// Choose an arbitrary test case to assert that all of the input is delivered to the
 				// poll response.
-				op := res.Request.Variant.(*nexuspb.Request_GetOperationResult).GetOperationResult
+				op := res.Request.Variant.(*nexuspb.Request_FetchOperationResult).FetchOperationResult
 				s.Equal("test-service", op.Service)
 				s.Equal("operation", op.Operation)
 				s.Equal("token", op.OperationToken)
 				s.Equal("value", res.Request.Header["key"])
 				return &nexuspb.Response{
-					Variant: &nexuspb.Response_GetOperationResult{
-						GetOperationResult: &nexuspb.GetOperationResultResponse{
+					Variant: &nexuspb.Response_FetchOperationResult{
+						FetchOperationResult: &nexuspb.FetchOperationResultResponse{
 							Links: []*nexuspb.Link{{Url: handlerNexusLink.URL.String(), Type: handlerNexusLink.Type}},
-							Variant: &nexuspb.GetOperationResultResponse_Successful_{
-								Successful: &nexuspb.GetOperationResultResponse_Successful{
+							Variant: &nexuspb.FetchOperationResultResponse_Successful_{
+								Successful: &nexuspb.FetchOperationResultResponse_Successful{
 									Result: payload.EncodeString("hello world"),
 								},
 							},
@@ -1144,17 +1144,17 @@ func (s *NexusApiTestSuite) TestNexusGetOperationResult_Outcomes() {
 			handler: func(res *workflowservice.PollNexusTaskQueueResponse) (*nexuspb.Response, *nexuspb.HandlerError) {
 				// Choose an arbitrary test case to assert that all of the input is delivered to the
 				// poll response.
-				op := res.Request.Variant.(*nexuspb.Request_GetOperationResult).GetOperationResult
+				op := res.Request.Variant.(*nexuspb.Request_FetchOperationResult).FetchOperationResult
 				s.Equal("test-service", op.Service)
 				s.Equal("operation", op.Operation)
 				s.Equal("token", op.OperationToken)
 				s.Equal("value", res.Request.Header["key"])
 				return &nexuspb.Response{
-					Variant: &nexuspb.Response_GetOperationResult{
-						GetOperationResult: &nexuspb.GetOperationResultResponse{
+					Variant: &nexuspb.Response_FetchOperationResult{
+						FetchOperationResult: &nexuspb.FetchOperationResultResponse{
 							Links: []*nexuspb.Link{},
-							Variant: &nexuspb.GetOperationResultResponse_Unsuccessful_{
-								Unsuccessful: &nexuspb.GetOperationResultResponse_Unsuccessful{
+							Variant: &nexuspb.FetchOperationResultResponse_Unsuccessful_{
+								Unsuccessful: &nexuspb.FetchOperationResultResponse_Unsuccessful{
 									OperationError: &nexuspb.UnsuccessfulOperationError{
 										OperationState: string(nexus.OperationStateFailed),
 										Failure: &nexuspb.Failure{
@@ -1191,17 +1191,17 @@ func (s *NexusApiTestSuite) TestNexusGetOperationResult_Outcomes() {
 			handler: func(res *workflowservice.PollNexusTaskQueueResponse) (*nexuspb.Response, *nexuspb.HandlerError) {
 				// Choose an arbitrary test case to assert that all of the input is delivered to the
 				// poll response.
-				op := res.Request.Variant.(*nexuspb.Request_GetOperationResult).GetOperationResult
+				op := res.Request.Variant.(*nexuspb.Request_FetchOperationResult).FetchOperationResult
 				s.Equal("test-service", op.Service)
 				s.Equal("operation", op.Operation)
 				s.Equal("token", op.OperationToken)
 				s.Equal("value", res.Request.Header["key"])
 				return &nexuspb.Response{
-					Variant: &nexuspb.Response_GetOperationResult{
-						GetOperationResult: &nexuspb.GetOperationResultResponse{
+					Variant: &nexuspb.Response_FetchOperationResult{
+						FetchOperationResult: &nexuspb.FetchOperationResultResponse{
 							Links: []*nexuspb.Link{},
-							Variant: &nexuspb.GetOperationResultResponse_StillRunning_{
-								StillRunning: &nexuspb.GetOperationResultResponse_StillRunning{},
+							Variant: &nexuspb.FetchOperationResultResponse_StillRunning_{
+								StillRunning: &nexuspb.FetchOperationResultResponse_StillRunning{},
 							},
 						},
 					},
@@ -1351,7 +1351,7 @@ func (s *NexusApiTestSuite) versionedNexusTaskPoller(ctx context.Context, taskQu
 		panic(err)
 	}
 	if res.Request.GetStartOperation().GetService() != "test-service" && res.Request.GetCancelOperation().GetService() != "test-service" &&
-		res.Request.GetGetOperationInfo().GetService() != "test-service" && res.Request.GetGetOperationResult().GetService() != "test-service" {
+		res.Request.GetFetchOperationInfo().GetService() != "test-service" && res.Request.GetFetchOperationResult().GetService() != "test-service" {
 		panic("expected service to be test-service")
 	}
 	response, handlerError := handler(res)

--- a/tests/nexus_test_base.go
+++ b/tests/nexus_test_base.go
@@ -57,7 +57,7 @@ func (s *NexusTestBaseSuite) versionedNexusTaskPoller(ctx context.Context, taskQ
 		panic(err)
 	}
 	if res.Request.GetStartOperation().GetService() != "test-service" && res.Request.GetCancelOperation().GetService() != "test-service" &&
-		res.Request.GetGetOperationInfo().GetService() != "test-service" && res.Request.GetGetOperationResult().GetService() != "test-service" {
+		res.Request.GetFetchOperationInfo().GetService() != "test-service" && res.Request.GetFetchOperationResult().GetService() != "test-service" {
 		panic("expected service to be test-service")
 	}
 	response, handlerError := handler(res)


### PR DESCRIPTION
## What changed?
* Renamed Get -> Fetch for Nexus external caller APIs
* Removed direct Nexus task dispatch by task queue

