### PR TITLE
Convert Nexus HandlerError back to serviceerror for gRPC APIs

### DIFF
--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -351,53 +351,24 @@ func ConvertGRPCError(err error, exposeDetails bool) error {
 }
 
 // ConvertHandlerError converts a nexus.HandlerError returned by a Nexus client into a gRPC serviceerror.
-func ConvertHandlerError(err *nexus.HandlerError, exposeDetails bool) error {
-	msg := err.Error()
-
+func ConvertHandlerError(err *nexus.HandlerError) error {
 	switch err.Type {
 	case nexus.HandlerErrorTypeBadRequest:
-		if !exposeDetails {
-			msg = "invalid argument"
-		}
-		return serviceerror.NewInvalidArgument(msg)
+		return serviceerror.NewInvalidArgument(err.Error())
 	case nexus.HandlerErrorTypeUnauthenticated, nexus.HandlerErrorTypeUnauthorized:
-		if exposeDetails {
-			msg = err.Cause.Error()
-		} else {
-			msg = ""
-		}
-		return serviceerror.NewPermissionDenied("permission denied", msg)
+		return serviceerror.NewPermissionDenied("permission denied", err.Cause.Error())
 	case nexus.HandlerErrorTypeNotFound:
-		if !exposeDetails {
-			msg = "not found"
-		}
-		return serviceerror.NewNotFound(msg)
+		return serviceerror.NewNotFound(err.Error())
 	case nexus.HandlerErrorTypeResourceExhausted:
-		if !exposeDetails {
-			msg = "resource exhausted"
-		}
-		return serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_UNSPECIFIED, msg)
+		return serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_UNSPECIFIED, err.Error())
 	case nexus.HandlerErrorTypeInternal:
-		if !exposeDetails {
-			msg = "internal error"
-		}
-		return serviceerror.NewInternal(msg)
+		return serviceerror.NewInternal(err.Error())
 	case nexus.HandlerErrorTypeNotImplemented:
-		if !exposeDetails {
-			msg = "not implemented"
-		}
-		return serviceerror.NewUnimplemented(msg)
+		return serviceerror.NewUnimplemented(err.Error())
 	case nexus.HandlerErrorTypeUnavailable:
-		if !exposeDetails {
-			msg = "unavailable"
-		}
-		return serviceerror.NewUnavailable(msg)
+		return serviceerror.NewUnavailable(err.Error())
 	}
-
-	if !exposeDetails {
-		msg = "internal error"
-	}
-	return serviceerror.NewInternal(msg)
+	return serviceerror.NewInternal("internal error")
 }
 
 func AdaptAuthorizeError(err error) error {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5103,13 +5103,6 @@ func (wh *WorkflowHandler) RespondNexusTaskCompleted(ctx context.Context, reques
 		return nil, errRequestNotSet
 	}
 
-	if request.GetResponse().GetStartOperation() == nil &&
-		request.GetResponse().GetCancelOperation() == nil &&
-		request.GetResponse().GetFetchOperationInfo() == nil &&
-		request.GetResponse().GetFetchOperationResult() == nil {
-		return nil, serviceerror.NewInvalidArgument("invalid upstream Nexus response")
-	}
-
 	if r := request.GetResponse().GetStartOperation().GetAsyncSuccess(); r != nil {
 		operationToken := r.OperationToken
 		if operationToken == "" && r.OperationId != "" { //nolint:staticcheck // SA1019 this field might be by old clients.
@@ -5260,11 +5253,16 @@ func (wh *WorkflowHandler) StartNexusOperation(ctx context.Context, request *wor
 	if err != nil {
 		var handlerErr *nexus.HandlerError
 		if errors.As(err, &handlerErr) {
-			return &workflowservice.StartNexusOperationResponse{
-				Variant: &workflowservice.StartNexusOperationResponse_HandlerError{
-					HandlerError: commonnexus.NexusHandlerErrorToProtoHandlerError(handlerErr),
-				},
-			}, nil
+			failureSource := commonnexus.GetFailureSourceFromContext(ctx)
+			if failureSource == commonnexus.FailureSourceWorker {
+				return &workflowservice.StartNexusOperationResponse{
+					Variant: &workflowservice.StartNexusOperationResponse_HandlerError{
+						HandlerError: commonnexus.NexusHandlerErrorToProtoHandlerError(handlerErr),
+					},
+				}, nil
+			}
+			wh.logger.Error("received HandlerError from server for gRPC StartNexusOperation", tag.Error(err), tag.Operation("StartNexusOperation"), tag.WorkflowNamespace(ns.Name().String()))
+			return nil, commonnexus.ConvertHandlerError(handlerErr, false)
 		}
 		var opFailedErr *nexus.OperationError
 		if errors.As(err, &opFailedErr) {
@@ -5345,9 +5343,14 @@ func (wh *WorkflowHandler) RequestCancelNexusOperation(ctx context.Context, requ
 	if err != nil {
 		var handlerErr *nexus.HandlerError
 		if errors.As(err, &handlerErr) {
-			return &workflowservice.RequestCancelNexusOperationResponse{
-				HandlerError: commonnexus.NexusHandlerErrorToProtoHandlerError(handlerErr),
-			}, nil
+			failureSource := commonnexus.GetFailureSourceFromContext(ctx)
+			if failureSource == commonnexus.FailureSourceWorker {
+				return &workflowservice.RequestCancelNexusOperationResponse{
+					HandlerError: commonnexus.NexusHandlerErrorToProtoHandlerError(handlerErr),
+				}, nil
+			}
+			wh.logger.Error("received HandlerError from server for gRPC RequestCancelNexusOperation", tag.Error(err), tag.Operation("RequestCancelNexusOperation"), tag.WorkflowNamespace(ns.Name().String()))
+			return nil, commonnexus.ConvertHandlerError(handlerErr, false)
 		}
 		wh.logger.Error("received unexpected error for request cancel Nexus operation HTTP request", tag.Operation("RequestCancelNexusOperation"), tag.WorkflowNamespace(ns.Name().String()), tag.Error(err))
 		return nil, serviceerror.NewInternal("internal error")
@@ -5386,11 +5389,16 @@ func (wh *WorkflowHandler) FetchNexusOperationInfo(ctx context.Context, request 
 	if err != nil {
 		var handlerErr *nexus.HandlerError
 		if errors.As(err, &handlerErr) {
-			return &workflowservice.FetchNexusOperationInfoResponse{
-				Variant: &workflowservice.FetchNexusOperationInfoResponse_HandlerError{
-					HandlerError: commonnexus.NexusHandlerErrorToProtoHandlerError(handlerErr),
-				},
-			}, nil
+			failureSource := commonnexus.GetFailureSourceFromContext(ctx)
+			if failureSource == commonnexus.FailureSourceWorker {
+				return &workflowservice.FetchNexusOperationInfoResponse{
+					Variant: &workflowservice.FetchNexusOperationInfoResponse_HandlerError{
+						HandlerError: commonnexus.NexusHandlerErrorToProtoHandlerError(handlerErr),
+					},
+				}, nil
+			}
+			wh.logger.Error("received HandlerError from server for gRPC FetchNexusOperationInfo", tag.Error(err), tag.Operation("FetchNexusOperationInfo"), tag.WorkflowNamespace(ns.Name().String()))
+			return nil, commonnexus.ConvertHandlerError(handlerErr, false)
 		}
 		wh.logger.Error("received unexpected error for get Nexus operation info HTTP request", tag.Operation("FetchNexusOperationInfo"), tag.WorkflowNamespace(ns.Name().String()), tag.Error(err))
 		return nil, serviceerror.NewInternal("internal error")
@@ -5445,11 +5453,16 @@ func (wh *WorkflowHandler) FetchNexusOperationResult(ctx context.Context, reques
 		}
 		var handlerErr *nexus.HandlerError
 		if errors.As(err, &handlerErr) {
-			return &workflowservice.FetchNexusOperationResultResponse{
-				Variant: &workflowservice.FetchNexusOperationResultResponse_HandlerError{
-					HandlerError: commonnexus.NexusHandlerErrorToProtoHandlerError(handlerErr),
-				},
-			}, nil
+			failureSource := commonnexus.GetFailureSourceFromContext(ctx)
+			if failureSource == commonnexus.FailureSourceWorker {
+				return &workflowservice.FetchNexusOperationResultResponse{
+					Variant: &workflowservice.FetchNexusOperationResultResponse_HandlerError{
+						HandlerError: commonnexus.NexusHandlerErrorToProtoHandlerError(handlerErr),
+					},
+				}, nil
+			}
+			wh.logger.Error("received HandlerError from server for gRPC FetchNexusOperationResult", tag.Error(err), tag.Operation("FetchNexusOperationResult"), tag.WorkflowNamespace(ns.Name().String()))
+			return nil, commonnexus.ConvertHandlerError(handlerErr, false)
 		}
 		var opFailedErr *nexus.OperationError
 		if errors.As(err, &opFailedErr) {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5262,7 +5262,7 @@ func (wh *WorkflowHandler) StartNexusOperation(ctx context.Context, request *wor
 				}, nil
 			}
 			wh.logger.Error("received HandlerError from server for gRPC StartNexusOperation", tag.Error(err), tag.Operation("StartNexusOperation"), tag.WorkflowNamespace(ns.Name().String()))
-			return nil, commonnexus.ConvertHandlerError(handlerErr, false)
+			return nil, commonnexus.ConvertHandlerError(handlerErr)
 		}
 		var opFailedErr *nexus.OperationError
 		if errors.As(err, &opFailedErr) {
@@ -5350,7 +5350,7 @@ func (wh *WorkflowHandler) RequestCancelNexusOperation(ctx context.Context, requ
 				}, nil
 			}
 			wh.logger.Error("received HandlerError from server for gRPC RequestCancelNexusOperation", tag.Error(err), tag.Operation("RequestCancelNexusOperation"), tag.WorkflowNamespace(ns.Name().String()))
-			return nil, commonnexus.ConvertHandlerError(handlerErr, false)
+			return nil, commonnexus.ConvertHandlerError(handlerErr)
 		}
 		wh.logger.Error("received unexpected error for request cancel Nexus operation HTTP request", tag.Operation("RequestCancelNexusOperation"), tag.WorkflowNamespace(ns.Name().String()), tag.Error(err))
 		return nil, serviceerror.NewInternal("internal error")
@@ -5398,7 +5398,7 @@ func (wh *WorkflowHandler) FetchNexusOperationInfo(ctx context.Context, request 
 				}, nil
 			}
 			wh.logger.Error("received HandlerError from server for gRPC FetchNexusOperationInfo", tag.Error(err), tag.Operation("FetchNexusOperationInfo"), tag.WorkflowNamespace(ns.Name().String()))
-			return nil, commonnexus.ConvertHandlerError(handlerErr, false)
+			return nil, commonnexus.ConvertHandlerError(handlerErr)
 		}
 		wh.logger.Error("received unexpected error for get Nexus operation info HTTP request", tag.Operation("FetchNexusOperationInfo"), tag.WorkflowNamespace(ns.Name().String()), tag.Error(err))
 		return nil, serviceerror.NewInternal("internal error")
@@ -5462,7 +5462,7 @@ func (wh *WorkflowHandler) FetchNexusOperationResult(ctx context.Context, reques
 				}, nil
 			}
 			wh.logger.Error("received HandlerError from server for gRPC FetchNexusOperationResult", tag.Error(err), tag.Operation("FetchNexusOperationResult"), tag.WorkflowNamespace(ns.Name().String()))
-			return nil, commonnexus.ConvertHandlerError(handlerErr, false)
+			return nil, commonnexus.ConvertHandlerError(handlerErr)
 		}
 		var opFailedErr *nexus.OperationError
 		if errors.As(err, &opFailedErr) {


### PR DESCRIPTION
## What changed?
For Nexus gRPC APIs, when the Nexus client returns a HandlerError that is the fault of the server, that error is converted back to a `serviceerror`

## Why?
So that metrics and SLAs are tracked appropriately

