### PR TITLE
Add dynamic config for forwarded Nexus request dispatch type

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -901,6 +901,15 @@ used when the first cache layer has a miss. Requires server restart for change t
 Wildcards (*) are expanded to allow any substring. By default blacklist is empty.
 Concrete type should be list of strings.`,
 	)
+	FrontendNexusForwardRequestUseEndpointDispatch = NewGlobalBoolSetting(
+		"frontend.nexusForwardRequestUseEndpointDispatch",
+		false,
+		`!EXPERIMENTAL! NB: This config will be removed in a future release. Controls whether to use Nexus 
+task dispatch by endpoint URLs for forwarded Nexus requests. If set to true, forwarded requests will use the same 
+dispatch type (by endpoint or by namespace + task queue) as the original request. If false, dispatch by namespace + task
+queue will always be used for forwarded requests. Defaults to false because Nexus endpoints do not support replication, 
+so forwarding by endpoint ID will not work out of the box.`,
+	)
 	FrontendCallbackURLMaxLength = NewNamespaceIntSetting(
 		"frontend.callbackURLMaxLength",
 		1000,

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -301,6 +301,7 @@ type nexusHandler struct {
 	forwardingClients             *cluster.FrontendHTTPClientCache
 	payloadSizeLimit              dynamicconfig.IntPropertyFnWithNamespaceFilter
 	headersBlacklist              dynamicconfig.TypedPropertyFn[*regexp.Regexp]
+	useForwardByEndpoint          dynamicconfig.BoolPropertyFn
 	metricTagConfig               dynamicconfig.TypedPropertyFn[nexusoperations.NexusMetricTagConfig]
 	httpTraceProvider             commonnexus.HTTPClientTraceProvider
 }
@@ -664,7 +665,7 @@ func (h *nexusHandler) nexusClientForActiveCluster(oc *operationContext, service
 	}
 
 	var baseURL string
-	if oc.endpointID != "" {
+	if h.useForwardByEndpoint() && oc.endpointID != "" {
 		// If the request was originally dispatched by endpoint, forward by endpoint as well.
 		baseURL, err = url.JoinPath(httpClient.BaseURL(),
 			commonnexus.RouteDispatchNexusTaskByEndpoint.Path(oc.endpointID))

--- a/service/frontend/nexus_http_handler.go
+++ b/service/frontend/nexus_http_handler.go
@@ -89,6 +89,7 @@ func NewNexusHTTPHandler(
 				forwardingClients:             clientCache,
 				payloadSizeLimit:              serviceConfig.BlobSizeLimitError,
 				headersBlacklist:              serviceConfig.NexusRequestHeadersBlacklist,
+				useForwardByEndpoint:          serviceConfig.NexusForwardRequestUseEndpoint,
 				metricTagConfig:               serviceConfig.NexusOperationsMetricTagConfig,
 				httpTraceProvider:             httpTraceProvider,
 			},

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -185,6 +185,7 @@ type Config struct {
 
 	MaxNexusOperationTokenLength   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	NexusRequestHeadersBlacklist   dynamicconfig.TypedPropertyFn[*regexp.Regexp]
+	NexusForwardRequestUseEndpoint dynamicconfig.BoolPropertyFn
 	NexusOperationsMetricTagConfig dynamicconfig.TypedPropertyFn[nexusoperations.NexusMetricTagConfig]
 
 	LinkMaxSize        dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -325,6 +326,7 @@ func NewConfig(
 		MaxCallbacksPerWorkflow:        dynamicconfig.MaxCallbacksPerWorkflow.Get(dc),
 		MaxNexusOperationTokenLength:   nexusoperations.MaxOperationTokenLength.Get(dc),
 		NexusRequestHeadersBlacklist:   dynamicconfig.FrontendNexusRequestHeadersBlacklist.Get(dc),
+		NexusForwardRequestUseEndpoint: dynamicconfig.FrontendNexusForwardRequestUseEndpointDispatch.Get(dc),
 		NexusOperationsMetricTagConfig: nexusoperations.MetricTagConfiguration.Get(dc),
 
 		LinkMaxSize:        dynamicconfig.FrontendLinkMaxSize.Get(dc),


### PR DESCRIPTION
## What changed?
Added a new dynamic config to control whether forwarded Nexus HTTP requests should use the same dispatch type as the original request or always use dispatch by namespace + task queue.

## Why?
Endpoints do not support replication, so forwarding by endpoint will not work because the two clusters will have a different ID for the endpoint.

