### PR TITLE
Revert history task processing timeout change

### DIFF
--- a/service/history/outbound_queue_active_task_executor.go
+++ b/service/history/outbound_queue_active_task_executor.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	outboundTaskTimeout = time.Second * 3 * debug.TimeoutMultiplier
+	outboundTaskTimeout = time.Second * 10 * debug.TimeoutMultiplier
 )
 
 type outboundQueueActiveTaskExecutor struct {

--- a/service/history/outbound_queue_active_task_executor.go
+++ b/service/history/outbound_queue_active_task_executor.go
@@ -3,9 +3,11 @@ package history
 import (
 	"context"
 	"fmt"
+	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/service/history/consts"
@@ -13,6 +15,10 @@ import (
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/tasks"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
+)
+
+const (
+	outboundTaskTimeout = time.Second * 3 * debug.TimeoutMultiplier
 )
 
 type outboundQueueActiveTaskExecutor struct {
@@ -94,7 +100,7 @@ func (e *outboundQueueActiveTaskExecutor) executeChasmSideEffectTask(
 	ctx context.Context,
 	task *tasks.ChasmTask,
 ) error {
-	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
+	ctx, cancel := context.WithTimeout(ctx, outboundTaskTimeout)
 	defer cancel()
 
 	weContext, release, err := getWorkflowExecutionContextForTask(ctx, e.shardContext, e.cache, task)
@@ -128,6 +134,8 @@ func (e *outboundQueueActiveTaskExecutor) executeStateMachineTask(
 	ctx context.Context,
 	task tasks.Task,
 ) error {
+	// Timeout for hsm outbound tasks are determined by each component's task executor
+
 	ref, smt, err := StateMachineTask(e.shardContext.StateMachineRegistry(), task)
 	if err != nil {
 		return err

--- a/service/history/transfer_queue_task_executor_base.go
+++ b/service/history/transfer_queue_task_executor_base.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	taskTimeout          = time.Second * 10 * debug.TimeoutMultiplier
+	taskTimeout          = time.Second * 3 * debug.TimeoutMultiplier
 	taskHistoryOpTimeout = 20 * time.Second
 )
 


### PR DESCRIPTION
## What changed?
- Revert history task timeout from 10s to 3s for non-outbound tasks.

## Why?
- The original change was made due to a misunderstanding of my comment [here](https://github.com/temporalio/temporal/pull/7951#discussion_r2173075435). I was meant to say only use 10s as the timeout for outbound chasm tasks. But for other tasks, like transfer/timer, it should still use 3s as the timeout.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
