### PR TITLE
Remove dynamic config warnings for shared structures

### DIFF
--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -105,9 +105,6 @@ var (
 // NewCollection creates a new collection. For subscriptions to work, you must call Start/Stop.
 // Get will work without Start/Stop.
 func NewCollection(client Client, logger log.Logger) *Collection {
-	// Do this at the first convenient place we have a logger:
-	logSharedStructureWarnings(logger)
-
 	return &Collection{
 		client:        client,
 		logger:        logger,


### PR DESCRIPTION
## What changed?
Removed warning logs for shared dynamic config structures

## Why?
Was failing integration tests
