### PR TITLE
fix: handle nil ptr in batch processing

### DIFF
--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -716,6 +716,11 @@ func startTaskProcessorProtobuf(
 			}
 			var err error
 
+			if task.execution == nil {
+				logger.Error("task execution is nil", tag.WorkflowID(task.execution.WorkflowId), tag.WorkflowRunID(task.execution.RunId))
+				continue
+			}
+
 			switch operation := batchOperation.Request.Operation.(type) {
 			case *workflowservice.StartBatchOperationRequest_TerminationOperation:
 				err = processTask(ctx, limiter, task,
@@ -904,7 +909,6 @@ func processTask(
 	task task,
 	procFn func(*commonpb.WorkflowExecution) error,
 ) error {
-
 	err := limiter.Wait(ctx)
 	if err != nil {
 		return err

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -717,7 +717,6 @@ func startTaskProcessorProtobuf(
 			var err error
 
 			if task.execution == nil {
-				logger.Error("task execution is nil", tag.WorkflowID(task.execution.WorkflowId), tag.WorkflowRunID(task.execution.RunId))
 				continue
 			}
 


### PR DESCRIPTION
## What changed?
Batch workflows were panicking because executions can be nil, but there is no check to prevent nil pointer exception.

## Why?
Prevent nil-ptrs

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
NA
