### PR TITLE
fix: handle nil ptr in legacy batch processing

### DIFF
--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -506,6 +506,10 @@ func startTaskProcessor(
 			if isDone(ctx) {
 				return
 			}
+
+			if task.execution == nil {
+				continue
+			}
 			var err error
 
 			switch batchParams.BatchType {


### PR DESCRIPTION
## What changed?
`BatchWorkflow` is not yet deprecated, fix was not properly applied on previous PR

## Why?
nilptr exception

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
na
