### PR TITLE
Adding interface methods for setting Idempotency and SpeculativeRetryPolicy on the underlying gocql query

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interfaces.go
@@ -2,6 +2,8 @@ package gocql
 
 import (
 	"context"
+
+	"github.com/gocql/gocql"
 )
 
 // Note: this file defines the minimal interface that is needed by Temporal's cassandra
@@ -34,6 +36,8 @@ type (
 		WithTimestamp(int64) Query
 		Consistency(Consistency) Query
 		Bind(...interface{}) Query
+		Idempotent(bool) Query
+		SetSpeculativeExecutionPolicy(SpeculativeExecutionPolicy) Query
 	}
 
 	// Iter is the interface for executing and iterating over all resulting rows.
@@ -52,4 +56,7 @@ type (
 
 	// SerialConsistency is the serial consistency level used by a Query
 	SerialConsistency uint16
+
+	// SpeculativeExecutionPolicy is a gocql SpeculativeExecutionPolicy
+	SpeculativeExecutionPolicy gocql.SpeculativeExecutionPolicy
 )

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go
@@ -100,3 +100,11 @@ func (q *query) Bind(v ...interface{}) Query {
 	q.gocqlQuery.Bind(v...)
 	return newQuery(q.session, q.gocqlQuery)
 }
+
+func (q *query) Idempotent(value bool) Query {
+	return newQuery(q.session, q.gocqlQuery.Idempotent(value))
+}
+
+func (q *query) SetSpeculativeExecutionPolicy(policy SpeculativeExecutionPolicy) Query {
+	return newQuery(q.session, q.gocqlQuery.SetSpeculativeExecutionPolicy(policy))
+}


### PR DESCRIPTION
## What changed?
Adding interface methods to Set Idempotency and SpeculativeRetryPolicy on gocql queries

## Why?
We want to experiment with setting speculative retry policy in queries from cds to allow for faster detection of faulty nodes and return result before timeout by trying a different node.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

