### PR TITLE
CHASM: force component to implement LifecycleState method

### DIFF
--- a/chasm/component.go
+++ b/chasm/component.go
@@ -30,10 +30,6 @@ type TerminateComponentResponse struct{}
 // Embed UnimplementedComponent to get forward compatibility
 type UnimplementedComponent struct{}
 
-func (UnimplementedComponent) LifecycleState(Context) LifecycleState {
-	return LifecycleStateUnspecified
-}
-
 func (UnimplementedComponent) Terminate(MutableContext, TerminateComponentRequest) (TerminateComponentResponse, error) {
 	return TerminateComponentResponse{}, nil
 }
@@ -59,18 +55,14 @@ const (
 	// LifecycleStateTerminated
 	// LifecycleStateTimedout
 	// LifecycleStateReset
-
-	LifecycleStateUnspecified = LifecycleState(0)
 )
 
 func (s LifecycleState) IsClosed() bool {
-	return s == LifecycleStateCompleted || s == LifecycleStateFailed
+	return s >= LifecycleStateCompleted
 }
 
 func (s LifecycleState) String() string {
 	switch s {
-	case LifecycleStateUnspecified:
-		return "Unspecified"
 	case LifecycleStateRunning:
 		return "Running"
 	case LifecycleStateCompleted:

--- a/chasm/test_component_test.go
+++ b/chasm/test_component_test.go
@@ -86,8 +86,20 @@ func (tc *TestComponent) Fail(_ MutableContext) {
 	tc.ComponentData.Status = enumspb.WORKFLOW_EXECUTION_STATUS_FAILED
 }
 
+func (tsc1 *TestSubComponent1) LifecycleState(_ Context) LifecycleState {
+	return LifecycleStateRunning
+}
+
 func (tsc1 *TestSubComponent1) GetData() string {
 	return tsc1.SubComponent1Data.GetCreateRequestId()
+}
+
+func (tsc11 *TestSubComponent11) LifecycleState(_ Context) LifecycleState {
+	return LifecycleStateRunning
+}
+
+func (tsc2 *TestSubComponent2) LifecycleState(_ Context) LifecycleState {
+	return LifecycleStateRunning
 }
 
 func setTestComponentFields(c *TestComponent) {


### PR DESCRIPTION
## What changed?
- Force component to implement LifecycleState method
- Remove LifecycleStateUnspecified definition

## Why?
- Component author should always think about and specify the component's lifecycle state, that's a core concept in the framework. Default implementation doesn't really work.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
