### PR TITLE
Reduce PollWorkflowExecution priority

### DIFF
--- a/common/rpc/interceptor/namespace_rate_limit.go
+++ b/common/rpc/interceptor/namespace_rate_limit.go
@@ -64,7 +64,7 @@ func (ni *NamespaceRateLimitInterceptorImpl) Intercept(
 ) (interface{}, error) {
 	if ns := MustGetNamespaceName(ni.namespaceRegistry, req); ns != namespace.EmptyName {
 		method := info.FullMethod
-		if isLongPollGetHistoryRequest(req) {
+		if IsLongPollGetHistoryRequest(req) {
 			method = configs.PollWorkflowHistoryAPIName
 		}
 		if err := ni.Allow(ns, method, headers.NewGRPCHeaderGetter(ctx)); err != nil {
@@ -94,7 +94,7 @@ func (ni *NamespaceRateLimitInterceptorImpl) Allow(namespaceName namespace.Name,
 	return nil
 }
 
-func isLongPollGetHistoryRequest(
+func IsLongPollGetHistoryRequest(
 	req interface{},
 ) bool {
 	switch request := req.(type) {

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -150,8 +150,9 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/RecordWorkerHeartbeat":              4,
 		"/temporal.api.workflowservice.v1.WorkflowService/FetchWorkerConfig":                  4,
 		"/temporal.api.workflowservice.v1.WorkflowService/UpdateWorkerConfig":                 4,
-		// GetWorkflowExecutionHistory with WaitNewEvent set to true is a long poll API. Consider it as any other poll API.
-		PollWorkflowHistoryAPIName: 4,
+		// GetWorkflowExecutionHistory with WaitNewEvent set to true is a long poll API.
+		// Treat as long-poll but lower priority (5) so spikes don’t block Poll* APIs.
+		PollWorkflowHistoryAPIName: 5,
 
 		// P5: Informational API that aren't required for the temporal service to function
 		OpenAPIV3APIName: 5,

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -150,11 +150,11 @@ var (
 		"/temporal.api.workflowservice.v1.WorkflowService/RecordWorkerHeartbeat":              4,
 		"/temporal.api.workflowservice.v1.WorkflowService/FetchWorkerConfig":                  4,
 		"/temporal.api.workflowservice.v1.WorkflowService/UpdateWorkerConfig":                 4,
-		// GetWorkflowExecutionHistory with WaitNewEvent set to true is a long poll API.
+
+		// P5: GetWorkflowExecutionHistory with WaitNewEvent set to true is a long poll API.
 		// Treat as long-poll but lower priority (5) so spikes don’t block Poll* APIs.
 		PollWorkflowHistoryAPIName: 5,
-
-		// P5: Informational API that aren't required for the temporal service to function
+		// Informational API that aren't required for the temporal service to function
 		OpenAPIV3APIName: 5,
 		OpenAPIV2APIName: 5,
 	}


### PR DESCRIPTION
## What changed?
Reduce PollWorkflowExecution API priority to 5.

## Why?
A spike in PollWorkflowExecution requests should not block other Poll* APIs stalling workflow progress.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

