### PR TITLE
refactor: replace urfave/cli v1 with v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938
 	github.com/temporalio/tctl-kit v0.0.0-20250107205014-58462b03dfb2
 	github.com/uber-go/tally/v4 v4.1.17
-	github.com/urfave/cli v1.22.16
 	github.com/urfave/cli/v2 v2.27.5
 	go.opentelemetry.io/collector/pdata v1.34.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0

--- a/go.sum
+++ b/go.sum
@@ -27,7 +27,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 h1:ErKg/3iS1AKcTkf3yixlZ54f9U1rljCkQyEXWUnIUxc=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0/go.mod h1:yAZHSGnqScoU556rBOVkwLze6WP5N+U11RHuWaGVxwY=
@@ -79,7 +78,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42 h1:Om6kYQYDUk5wWbT0t0q6pvyM49i9XZAv9dDrkDA7gjk=
 github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
-github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -319,8 +317,6 @@ github.com/spiffe/go-spiffe/v2 v2.5.0 h1:N2I01KCUkv1FAjZXJMwh95KK1ZIQLYbPfhaxw8W
 github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GBUCwT2wPmb7g=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -328,10 +324,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/temporalio/ringpop-go v0.0.0-20250130211428-b97329e994f7 h1:lEebX/hZss+TSH3EBwhztnBavJVj7pWGJOH8UgKHS0w=
@@ -355,8 +347,6 @@ github.com/uber/jaeger-client-go v2.22.1+incompatible h1:NHcubEkVbahf9t3p75TOCR8
 github.com/uber/jaeger-client-go v2.22.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
-github.com/urfave/cli v1.22.16 h1:MH0k6uJxdwdeWQTwhSO42Pwr4YLrNLwBtg1MRgTqPdQ=
-github.com/urfave/cli v1.22.16/go.mod h1:EeJR6BKodywf4zciqrdw6hpCPk68JO9z5LazXZMn5Po=
 github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=
 github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=

--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/auth"
 	c "go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
@@ -70,9 +70,9 @@ func createKeyspace(cli *cli.Context, logger log.Logger) error {
 		logger.Error("Unable to read config.", tag.Error(schema.NewConfigError(err.Error())))
 		return err
 	}
-	keyspace := cli.String(schema.CLIOptKeyspace)
+	keyspace := cli.String(schema.CLIFlagKeyspace)
 	if keyspace == "" {
-		err := fmt.Errorf("missing %s argument", flag(schema.CLIOptKeyspace))
+		err := fmt.Errorf("missing %s argument", flag(schema.CLIFlagKeyspace))
 		logger.Error("Unable to read config.", tag.Error(schema.NewConfigError(err.Error())))
 		return err
 	}
@@ -90,9 +90,9 @@ func dropKeyspace(cli *cli.Context, logger log.Logger) error {
 		logger.Error("Unable to read config.", tag.Error(schema.NewConfigError(err.Error())))
 		return err
 	}
-	keyspace := cli.String(schema.CLIOptKeyspace)
+	keyspace := cli.String(schema.CLIFlagKeyspace)
 	if keyspace == "" {
-		err := fmt.Errorf("missing %s argument", flag(schema.CLIOptKeyspace))
+		err := fmt.Errorf("missing %s argument", flag(schema.CLIFlagKeyspace))
 		logger.Error("Unable to read config.", tag.Error(schema.NewConfigError(err.Error())))
 		return err
 	}
@@ -143,35 +143,35 @@ func doDropKeyspace(cfg *CQLClientConfig, name string, logger log.Logger) error 
 	return client.dropKeyspace(name)
 }
 
-func newCQLClientConfig(cli *cli.Context) (*CQLClientConfig, error) {
+func newCQLClientConfig(ctx *cli.Context) (*CQLClientConfig, error) {
 	config := &CQLClientConfig{
-		Hosts:                    cli.GlobalString(schema.CLIOptEndpoint),
-		Port:                     cli.GlobalInt(schema.CLIOptPort),
-		User:                     cli.GlobalString(schema.CLIOptUser),
-		Password:                 cli.GlobalString(schema.CLIOptPassword),
-		AllowedAuthenticators:    cli.GlobalStringSlice(schema.CLIOptAllowedAuthenticators),
-		Timeout:                  cli.GlobalInt(schema.CLIOptTimeout),
-		Keyspace:                 cli.GlobalString(schema.CLIOptKeyspace),
-		numReplicas:              cli.Int(schema.CLIOptReplicationFactor),
-		Datacenter:               cli.String(schema.CLIOptDatacenter),
-		Consistency:              cli.String(schema.CLIOptConsistency),
-		DisableInitialHostLookup: cli.GlobalBool(schema.CLIFlagDisableInitialHostLookup),
+		Hosts:                    ctx.String(schema.CLIFlagEndpoint),
+		Port:                     ctx.Int(schema.CLIFlagPort),
+		User:                     ctx.String(schema.CLIFlagUser),
+		Password:                 ctx.String(schema.CLIFlagPassword),
+		AllowedAuthenticators:    cli.NewStringSlice(schema.CLIFlagAllowedAuthenticators).Value(),
+		Timeout:                  ctx.Int(schema.CLIFlagTimeout),
+		Keyspace:                 ctx.String(schema.CLIFlagKeyspace),
+		numReplicas:              ctx.Int(schema.CLIFlagReplicationFactor),
+		Datacenter:               ctx.String(schema.CLIFlagDatacenter),
+		Consistency:              ctx.String(schema.CLIOptConsistency),
+		DisableInitialHostLookup: ctx.Bool(schema.CLIFlagDisableInitialHostLookup),
 	}
 
-	if cli.GlobalBool(schema.CLIFlagEnableTLS) {
+	if ctx.Bool(schema.CLIFlagEnableTLS) {
 		config.TLS = &auth.TLS{
 			Enabled:                true,
-			CertFile:               cli.GlobalString(schema.CLIFlagTLSCertFile),
-			KeyFile:                cli.GlobalString(schema.CLIFlagTLSKeyFile),
-			CaFile:                 cli.GlobalString(schema.CLIFlagTLSCaFile),
-			ServerName:             cli.GlobalString(schema.CLIFlagTLSHostName),
-			EnableHostVerification: !cli.GlobalBool(schema.CLIFlagTLSDisableHostVerification),
+			CertFile:               ctx.String(schema.CLIFlagTLSCertFile),
+			KeyFile:                ctx.String(schema.CLIFlagTLSKeyFile),
+			CaFile:                 ctx.String(schema.CLIFlagTLSCaFile),
+			ServerName:             ctx.String(schema.CLIFlagTLSHostName),
+			EnableHostVerification: !ctx.Bool(schema.CLIFlagTLSDisableHostVerification),
 		}
 	}
 
 	config.AddressTranslator = &c.CassandraAddressTranslator{
-		Translator: cli.GlobalString(schema.CLIOptAddressTranslator),
-		Options:    parseOptionsMap(cli.GlobalString(schema.CLIOptAddressTranslatorOptions)),
+		Translator: ctx.String(schema.CLIOptAddressTranslator),
+		Options:    parseOptionsMap(ctx.String(schema.CLIOptAddressTranslatorOptions)),
 	}
 
 	if err := validateCQLClientConfig(config); err != nil {
@@ -207,10 +207,10 @@ func parseOptionsMap(value string) map[string]string {
 
 func validateCQLClientConfig(config *CQLClientConfig) error {
 	if len(config.Hosts) == 0 {
-		return schema.NewConfigError("missing cassandra endpoint argument " + flag(schema.CLIOptEndpoint))
+		return schema.NewConfigError("missing cassandra endpoint argument " + flag(schema.CLIFlagEndpoint))
 	}
 	if config.Keyspace == "" {
-		return schema.NewConfigError("missing " + flag(schema.CLIOptKeyspace) + " argument ")
+		return schema.NewConfigError("missing " + flag(schema.CLIFlagKeyspace) + " argument ")
 	}
 	if config.Port == 0 {
 		config.Port = environment.GetCassandraPort()

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	dbschemas "go.temporal.io/server/schema"
@@ -22,7 +22,7 @@ var osExit = os.Exit
 
 // root handler for all cli commands
 func cliHandler(c *cli.Context, handler func(c *cli.Context, logger log.Logger) error, logger log.Logger) {
-	quiet := c.GlobalBool(schema.CLIOptQuiet)
+	quiet := c.Bool(schema.CLIFlagQuiet)
 	err := handler(c, logger)
 	if err != nil && !quiet {
 		osExit(1)
@@ -30,7 +30,6 @@ func cliHandler(c *cli.Context, handler func(c *cli.Context, logger log.Logger) 
 }
 
 func buildCLIOptions() *cli.App {
-
 	app := cli.NewApp()
 	app.Name = "temporal-cassandra-tool"
 	app.Usage = "Command line tool for temporal cassandra operations"
@@ -38,138 +37,153 @@ func buildCLIOptions() *cli.App {
 	logger := log.NewCLILogger()
 
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:   schema.CLIFlagEndpoint,
-			Value:  environment.GetCassandraAddress(),
-			Usage:  "hostname or ip address of cassandra host to connect to",
-			EnvVar: "CASSANDRA_HOST",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagEndpoint,
+			Aliases: []string{schema.CLIFlagEndpointAlias},
+			Value:   environment.GetCassandraAddress(),
+			Usage:   "hostname or ip address of cassandra host to connect to",
+			EnvVars: []string{"CASSANDRA_HOST"},
 		},
-		cli.IntFlag{
-			Name:   schema.CLIFlagPort,
-			Value:  environment.GetCassandraPort(),
-			Usage:  "Port of cassandra host to connect to",
-			EnvVar: "CASSANDRA_PORT",
+		&cli.IntFlag{
+			Name:    schema.CLIFlagPort,
+			Aliases: []string{schema.CLIFlagPortAlias},
+			Value:   environment.GetCassandraPort(),
+			Usage:   "Port of cassandra host to connect to",
+			EnvVars: []string{"CASSANDRA_PORT"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagUser,
-			Value:  "",
-			Usage:  "User name used for authentication for connecting to cassandra host",
-			EnvVar: "CASSANDRA_USER",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagUser,
+			Aliases: []string{schema.CLIFlagUserAlias},
+			Value:   "",
+			Usage:   "User name used for authentication for connecting to cassandra host",
+			EnvVars: []string{"CASSANDRA_USER"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagPassword,
-			Value:  "",
-			Usage:  "Password used for authentication for connecting to cassandra host",
-			EnvVar: "CASSANDRA_PASSWORD",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagPassword,
+			Aliases: []string{schema.CLIFlagPasswordAlias},
+			Value:   "",
+			Usage:   "Password used for authentication for connecting to cassandra host",
+			EnvVars: []string{"CASSANDRA_PASSWORD"},
 		},
-		cli.StringSliceFlag{
-			Name:   schema.CLIFlagAllowedAuthenticators,
-			Value:  nil,
-			Usage:  "List of authenticators allowed to be used by the gocql client while connecting to the server.",
-			EnvVar: "CASSANDRA_ALLOWED_AUTHENTICATORS",
+		&cli.StringSliceFlag{
+			Name:    schema.CLIFlagAllowedAuthenticators,
+			Aliases: []string{schema.CLIFlagAllowedAuthenticatorsAlias},
+			Value:   nil,
+			Usage:   "List of authenticators allowed to be used by the gocql client while connecting to the server.",
+			EnvVars: []string{"CASSANDRA_ALLOWED_AUTHENTICATORS"},
 		},
-		cli.IntFlag{
-			Name:   schema.CLIFlagTimeout,
-			Value:  defaultTimeout,
-			Usage:  "request Timeout in seconds used for cql client",
-			EnvVar: "CASSANDRA_TIMEOUT",
+		&cli.IntFlag{
+			Name:    schema.CLIFlagTimeout,
+			Aliases: []string{schema.CLIFlagTimeoutAlias},
+			Value:   defaultTimeout,
+			Usage:   "request Timeout in seconds used for cql client",
+			EnvVars: []string{"CASSANDRA_TIMEOUT"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagKeyspace,
-			Value:  "temporal",
-			Usage:  "name of the cassandra Keyspace",
-			EnvVar: "CASSANDRA_KEYSPACE",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagKeyspace,
+			Aliases: []string{schema.CLIFlagKeyspaceAlias},
+			Value:   "temporal",
+			Usage:   "name of the cassandra Keyspace",
+			EnvVars: []string{"CASSANDRA_KEYSPACE"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagDatacenter,
-			Value:  "",
-			Usage:  "enable NetworkTopologyStrategy by providing datacenter name",
-			EnvVar: "CASSANDRA_DATACENTER",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagDatacenter,
+			Aliases: []string{schema.CLIFlagDatacenterAlias},
+			Value:   "",
+			Usage:   "enable NetworkTopologyStrategy by providing datacenter name",
+			EnvVars: []string{"CASSANDRA_DATACENTER"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIOptAddressTranslator,
-			Value:  "",
-			Usage:  "name of address translator for cassandra hosts",
-			EnvVar: "CASSANDRA_ADDRESS_TRANSLATOR",
+		&cli.StringFlag{
+			Name:    schema.CLIOptAddressTranslator,
+			Value:   "",
+			Usage:   "name of address translator for cassandra hosts",
+			EnvVars: []string{"CASSANDRA_ADDRESS_TRANSLATOR"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIOptAddressTranslatorOptions,
-			Value:  "",
-			Usage:  "colon-separated list of key=value pairs as options for address translator",
-			EnvVar: "CASSANDRA_ADDRESS_TRANSLATOR_OPTIONS_CLI",
+		&cli.StringFlag{
+			Name:    schema.CLIOptAddressTranslatorOptions,
+			Value:   "",
+			Usage:   "colon-separated list of key=value pairs as options for address translator",
+			EnvVars: []string{"CASSANDRA_ADDRESS_TRANSLATOR_OPTIONS_CLI"},
 		},
-		cli.BoolFlag{
-			Name:  schema.CLIFlagQuiet,
-			Usage: "Don't set exit status to 1 on error",
+		&cli.BoolFlag{
+			Name:    schema.CLIFlagQuiet,
+			Aliases: []string{schema.CLIFlagQuietAlias},
+			Usage:   "Don't set exit status to 1 on error",
 		},
-		cli.BoolFlag{
-			Name:   schema.CLIFlagDisableInitialHostLookup,
-			Usage:  "instructs gocql driver to only connect to the supplied hosts vs. attempting to lookup additional hosts via the system.peers table",
-			EnvVar: "CASSANDRA_DISABLE_INITIAL_HOST_LOOKUP",
+		&cli.BoolFlag{
+			Name:    schema.CLIFlagDisableInitialHostLookup,
+			Usage:   "instructs gocql driver to only connect to the supplied hosts vs. attempting to lookup additional hosts via the system.peers table",
+			EnvVars: []string{"CASSANDRA_DISABLE_INITIAL_HOST_LOOKUP"},
 		},
-		cli.BoolFlag{
-			Name:   schema.CLIFlagEnableTLS,
-			Usage:  "enable TLS",
-			EnvVar: "CASSANDRA_ENABLE_TLS",
+		&cli.BoolFlag{
+			Name:    schema.CLIFlagEnableTLS,
+			Usage:   "enable TLS",
+			EnvVars: []string{"CASSANDRA_ENABLE_TLS"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagTLSCertFile,
-			Usage:  "TLS cert file",
-			EnvVar: "CASSANDRA_TLS_CERT",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagTLSCertFile,
+			Usage:   "TLS cert file",
+			EnvVars: []string{"CASSANDRA_TLS_CERT"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagTLSKeyFile,
-			Usage:  "TLS key file",
-			EnvVar: "CASSANDRA_TLS_KEY",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagTLSKeyFile,
+			Usage:   "TLS key file",
+			EnvVars: []string{"CASSANDRA_TLS_KEY"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagTLSCaFile,
-			Usage:  "TLS CA file",
-			EnvVar: "CASSANDRA_TLS_CA",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagTLSCaFile,
+			Usage:   "TLS CA file",
+			EnvVars: []string{"CASSANDRA_TLS_CA"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagTLSHostName,
-			Value:  "",
-			Usage:  "override for target server name",
-			EnvVar: "CASSANDRA_TLS_SERVER_NAME",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagTLSHostName,
+			Value:   "",
+			Usage:   "override for target server name",
+			EnvVars: []string{"CASSANDRA_TLS_SERVER_NAME"},
 		},
-		cli.BoolFlag{
-			Name:   schema.CLIFlagTLSDisableHostVerification,
-			Usage:  "disable tls host name verification (tls must be enabled)",
-			EnvVar: "CASSANDRA_TLS_DISABLE_HOST_VERIFICATION",
+		&cli.BoolFlag{
+			Name:    schema.CLIFlagTLSDisableHostVerification,
+			Usage:   "disable tls host name verification (tls must be enabled)",
+			EnvVars: []string{"CASSANDRA_TLS_DISABLE_HOST_VERIFICATION"},
 		},
 	}
 
-	app.Commands = []cli.Command{
+	app.Commands = []*cli.Command{
 		{
 			Name:    "setup-schema",
 			Aliases: []string{"setup"},
 			Usage:   "setup initial version of cassandra schema",
 			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  schema.CLIFlagVersion,
-					Usage: "initial version of the schema, cannot be used with disable-versioning",
+				&cli.StringFlag{
+					Name:    schema.CLIFlagVersion,
+					Aliases: []string{schema.CLIFlagVersionAlias},
+					Usage:   "initial version of the schema, cannot be used with disable-versioning",
 				},
-				cli.StringFlag{
-					Name:  schema.CLIFlagSchemaFile,
-					Usage: "path to the .cql schema file; if un-specified, will just setup versioning tables",
+				&cli.StringFlag{
+					Name:    schema.CLIFlagSchemaFile,
+					Aliases: []string{schema.CLIFlagSchemaFileAlias},
+					Usage:   "path to the .cql schema file; if un-specified, will just setup versioning tables",
 				},
-				cli.StringFlag{
-					Name: schema.CLIFlagSchemaName,
+				&cli.StringFlag{
+					Name:    schema.CLIFlagSchemaName,
+					Aliases: []string{schema.CLIFlagSchemaNameAlias},
 					Usage: fmt.Sprintf("name of embedded schema directory with .cql file, one of: %v",
 						dbschemas.PathsByDB("cassandra")),
 				},
-				cli.BoolFlag{
-					Name:  schema.CLIFlagDisableVersioning,
-					Usage: "disable setup of schema versioning",
+				&cli.BoolFlag{
+					Name:    schema.CLIFlagDisableVersioning,
+					Aliases: []string{schema.CLIFlagDisableVersioningAlias},
+					Usage:   "disable setup of schema versioning",
 				},
-				cli.BoolFlag{
-					Name:  schema.CLIFlagOverwrite,
-					Usage: "drop all existing tables before setting up new schema",
+				&cli.BoolFlag{
+					Name:    schema.CLIFlagOverwrite,
+					Aliases: []string{schema.CLIFlagOverwriteAlias},
+					Usage:   "drop all existing tables before setting up new schema",
 				},
 			},
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) error {
 				cliHandler(c, setupSchema, logger)
+				return nil
 			},
 		},
 		{
@@ -177,22 +191,26 @@ func buildCLIOptions() *cli.App {
 			Aliases: []string{"update"},
 			Usage:   "update cassandra schema to a specific version",
 			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  schema.CLIFlagTargetVersion,
-					Usage: "target version for the schema update, defaults to latest",
+				&cli.StringFlag{
+					Name:    schema.CLIFlagTargetVersion,
+					Aliases: []string{schema.CLIFlagTargetVersionAlias},
+					Usage:   "target version for the schema update, defaults to latest",
 				},
-				cli.StringFlag{
-					Name:  schema.CLIFlagSchemaDir,
-					Usage: "path to directory containing versioned schema",
+				&cli.StringFlag{
+					Name:    schema.CLIFlagSchemaDir,
+					Aliases: []string{schema.CLIFlagSchemaDirAlias},
+					Usage:   "path to directory containing versioned schema",
 				},
-				cli.StringFlag{
-					Name: schema.CLIFlagSchemaName,
+				&cli.StringFlag{
+					Name:    schema.CLIFlagSchemaName,
+					Aliases: []string{schema.CLIFlagSchemaNameAlias},
 					Usage: fmt.Sprintf("name of embedded versioned schema, one of: %v",
 						dbschemas.PathsByDB("cassandra")),
 				},
 			},
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) error {
 				cliHandler(c, updateSchema, logger)
+				return nil
 			},
 		},
 		{
@@ -200,23 +218,27 @@ func buildCLIOptions() *cli.App {
 			Aliases: []string{"create", "create-Keyspace"},
 			Usage:   "creates a keyspace with simple strategy or network topology if datacenter name is provided",
 			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  schema.CLIFlagKeyspace,
-					Usage: "name of the keyspace",
+				&cli.StringFlag{
+					Name:    schema.CLIFlagKeyspace,
+					Aliases: []string{schema.CLIFlagKeyspaceAlias},
+					Usage:   "name of the keyspace",
 				},
-				cli.IntFlag{
-					Name:  schema.CLIFlagReplicationFactor,
-					Value: 1,
-					Usage: "replication factor for the keyspace",
+				&cli.IntFlag{
+					Name:    schema.CLIFlagReplicationFactor,
+					Aliases: []string{schema.CLIFlagReplicationFactorAlias},
+					Value:   1,
+					Usage:   "replication factor for the keyspace",
 				},
-				cli.StringFlag{
-					Name:  schema.CLIFlagDatacenter,
-					Value: "",
-					Usage: "enable NetworkTopologyStrategy by providing datacenter name",
+				&cli.StringFlag{
+					Name:    schema.CLIFlagDatacenter,
+					Aliases: []string{schema.CLIFlagDatacenterAlias},
+					Value:   "",
+					Usage:   "enable NetworkTopologyStrategy by providing datacenter name",
 				},
 			},
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) error {
 				cliHandler(c, createKeyspace, logger)
+				return nil
 			},
 		},
 		{
@@ -224,29 +246,33 @@ func buildCLIOptions() *cli.App {
 			Aliases: []string{"drop"},
 			Usage:   "drops a keyspace with simple strategy or network topology if datacenter name is provided",
 			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  schema.CLIFlagKeyspace,
-					Usage: "name of the keyspace",
+				&cli.StringFlag{
+					Name:    schema.CLIFlagKeyspace,
+					Aliases: []string{schema.CLIFlagKeyspaceAlias},
+					Usage:   "name of the keyspace",
 				},
-				cli.IntFlag{
-					Name:  schema.CLIFlagReplicationFactor,
-					Value: 1,
-					Usage: "replication factor for the keyspace",
+				&cli.IntFlag{
+					Name:    schema.CLIFlagReplicationFactor,
+					Aliases: []string{schema.CLIFlagReplicationFactorAlias},
+					Value:   1,
+					Usage:   "replication factor for the keyspace",
 				},
-				cli.StringFlag{
-					Name:  schema.CLIFlagDatacenter,
-					Value: "",
-					Usage: "enable NetworkTopologyStrategy by providing datacenter name",
+				&cli.StringFlag{
+					Name:    schema.CLIFlagDatacenter,
+					Aliases: []string{schema.CLIFlagDatacenterAlias},
+					Value:   "",
+					Usage:   "enable NetworkTopologyStrategy by providing datacenter name",
 				},
-				cli.BoolFlag{
-					Name:  schema.CLIFlagForce,
-					Usage: "don't prompt for confirmation",
+				&cli.BoolFlag{
+					Name:    schema.CLIFlagForce,
+					Aliases: []string{schema.CLIFlagForceAlias},
+					Usage:   "don't prompt for confirmation",
 				},
 			},
-			Action: func(c *cli.Context) {
-				drop := c.Bool(schema.CLIOptForce)
+			Action: func(c *cli.Context) error {
+				drop := c.Bool(schema.CLIFlagForce)
 				if !drop {
-					keyspace := c.String(schema.CLIOptKeyspace)
+					keyspace := c.String(schema.CLIFlagKeyspace)
 					fmt.Printf("Are you sure you want to drop keyspace %q (y/N)? ", keyspace)
 					y := ""
 					_, _ = fmt.Scanln(&y)
@@ -257,14 +283,16 @@ func buildCLIOptions() *cli.App {
 				if drop {
 					cliHandler(c, dropKeyspace, logger)
 				}
+				return nil
 			},
 		},
 		{
 			Name:    "validate-health",
 			Aliases: []string{"vh"},
 			Usage:   "validates health of cassandra by attempting to establish CQL session to system keyspace",
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) error {
 				cliHandler(c, validateHealth, logger)
+				return nil
 			},
 		},
 	}

--- a/tools/common/schema/handler.go
+++ b/tools/common/schema/handler.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/log"
 	dbschemas "go.temporal.io/server/schema"
 )
@@ -30,9 +30,9 @@ func Update(cli *cli.Context, db DB, logger log.Logger) error {
 
 func newUpdateConfig(cli *cli.Context, db DB) (*UpdateConfig, error) {
 	config := new(UpdateConfig)
-	config.SchemaDir = cli.String(CLIOptSchemaDir)
-	config.SchemaName = cli.String(CLIOptSchemaName)
-	config.TargetVersion = cli.String(CLIOptTargetVersion)
+	config.SchemaDir = cli.String(CLIFlagSchemaDir)
+	config.SchemaName = cli.String(CLIFlagSchemaName)
+	config.TargetVersion = cli.String(CLIFlagTargetVersion)
 
 	if err := validateUpdateConfig(config, db); err != nil {
 		return nil, err
@@ -42,11 +42,11 @@ func newUpdateConfig(cli *cli.Context, db DB) (*UpdateConfig, error) {
 
 func newSetupConfig(cli *cli.Context, db DB) (*SetupConfig, error) {
 	config := new(SetupConfig)
-	config.SchemaFilePath = cli.String(CLIOptSchemaFile)
-	config.SchemaName = cli.String(CLIOptSchemaName)
-	config.InitialVersion = cli.String(CLIOptVersion)
-	config.DisableVersioning = cli.Bool(CLIOptDisableVersioning)
-	config.Overwrite = cli.Bool(CLIOptOverwrite)
+	config.SchemaFilePath = cli.String(CLIFlagSchemaFile)
+	config.SchemaName = cli.String(CLIFlagSchemaName)
+	config.InitialVersion = cli.String(CLIFlagVersion)
+	config.DisableVersioning = cli.Bool(CLIFlagDisableVersioning)
+	config.Overwrite = cli.Bool(CLIFlagOverwrite)
 
 	if err := validateSetupConfig(config, db); err != nil {
 		return nil, err
@@ -56,27 +56,27 @@ func newSetupConfig(cli *cli.Context, db DB) (*SetupConfig, error) {
 
 func validateSetupConfig(config *SetupConfig, db DB) error {
 	if len(config.SchemaFilePath) == 0 && len(config.SchemaName) == 0 && config.DisableVersioning {
-		return NewConfigError("needs either " + flag(CLIOptSchemaFile) + " or " + flag(CLIOptSchemaName))
+		return NewConfigError("needs either " + flag(CLIFlagSchemaFile) + " or " + flag(CLIFlagSchemaName))
 	}
 	if (config.DisableVersioning && len(config.InitialVersion) > 0) ||
 		(!config.DisableVersioning && len(config.InitialVersion) == 0) {
-		return NewConfigError("missing argument; either " + flag(CLIOptDisableVersioning) + " or " +
-			flag(CLIOptVersion) + " but not both must be specified")
+		return NewConfigError("missing argument; either " + flag(CLIFlagDisableVersioning) + " or " +
+			flag(CLIFlagVersion) + " but not both must be specified")
 	}
 	if len(config.SchemaFilePath) > 0 && len(config.SchemaName) > 0 {
-		return NewConfigError("either" + flag(CLIOptSchemaFile) + " or " +
-			flag(CLIOptSchemaName) + " must be specified")
+		return NewConfigError("either" + flag(CLIFlagSchemaFile) + " or " +
+			flag(CLIFlagSchemaName) + " must be specified")
 	}
 	if len(config.SchemaName) > 0 {
 		if !slices.Contains(dbschemas.PathsByDB(db.Type()), config.SchemaName) {
 			return NewConfigError(fmt.Sprintf("%s must be one of: %v",
-				flag(CLIOptSchemaName), dbschemas.PathsByDB(db.Type())))
+				flag(CLIFlagSchemaName), dbschemas.PathsByDB(db.Type())))
 		}
 	}
 	if !config.DisableVersioning {
 		ver, err := normalizeVersionString(config.InitialVersion)
 		if err != nil {
-			return NewConfigError("invalid " + flag(CLIOptVersion) + " argument:" + err.Error())
+			return NewConfigError("invalid " + flag(CLIFlagVersion) + " argument:" + err.Error())
 		}
 		config.InitialVersion = ver
 	}
@@ -85,23 +85,23 @@ func validateSetupConfig(config *SetupConfig, db DB) error {
 
 func validateUpdateConfig(config *UpdateConfig, db DB) error {
 	if len(config.SchemaDir) == 0 && len(config.SchemaName) == 0 {
-		return NewConfigError("missing argument; either" + flag(CLIOptSchemaDir) + " or " +
-			flag(CLIOptSchemaName) + " must be specified")
+		return NewConfigError("missing argument; either" + flag(CLIFlagSchemaDir) + " or " +
+			flag(CLIFlagSchemaName) + " must be specified")
 	}
 	if len(config.SchemaDir) > 0 && len(config.SchemaName) > 0 {
-		return NewConfigError("either" + flag(CLIOptSchemaDir) + " or " +
-			flag(CLIOptSchemaName) + " must be specified")
+		return NewConfigError("either" + flag(CLIFlagSchemaDir) + " or " +
+			flag(CLIFlagSchemaName) + " must be specified")
 	}
 	if len(config.SchemaName) > 0 {
 		if !slices.Contains(dbschemas.PathsByDB(db.Type()), config.SchemaName) {
 			return NewConfigError(fmt.Sprintf("%s must be one of: %v",
-				flag(CLIOptSchemaName), dbschemas.PathsByDB(db.Type())))
+				flag(CLIFlagSchemaName), dbschemas.PathsByDB(db.Type())))
 		}
 	}
 	if len(config.TargetVersion) > 0 {
 		ver, err := normalizeVersionString(config.TargetVersion)
 		if err != nil {
-			return NewConfigError("invalid " + flag(CLIOptTargetVersion) + " argument:" + err.Error())
+			return NewConfigError("invalid " + flag(CLIFlagTargetVersion) + " argument:" + err.Error())
 		}
 		config.TargetVersion = ver
 	}

--- a/tools/common/schema/test/setuptest.go
+++ b/tools/common/schema/test/setuptest.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -48,7 +48,8 @@ func (tb *SetupSchemaTestBase) TearDownSuiteBase() {
 
 // RunSetupTest exercises the SetupSchema task
 func (tb *SetupSchemaTestBase) RunSetupTest(
-	app *cli.App, db DB, dbNameFlag string, sqlFileContent string, expectedTables []string) {
+	app *cli.App, db DB, dbNameFlag string, sqlFileContent string, expectedTables []string,
+) {
 	// test command fails without required arguments
 	command := append(tb.getCommandBase(), []string{
 		dbNameFlag, tb.DBName,

--- a/tools/common/schema/test/updatetest.go
+++ b/tools/common/schema/test/updatetest.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/tests/testutils"

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -53,103 +53,103 @@ type (
 )
 
 const (
-	// CLIOptEndpoint is the cli option for endpoint
-	CLIOptEndpoint = "endpoint"
-	// CLIOptPort is the cli option for port
-	CLIOptPort = "port"
-	// CLIOptUser is the cli option for user
-	CLIOptUser = "user"
-	// CLIOptPassword is the cli option for password
-	CLIOptPassword = "password"
+	// CLIFlagEndpoint is the cli option for endpoint
+	CLIFlagEndpoint = "endpoint"
+	// CLIFlagEndpointAlias is the cli flag alias for endpoint
+	CLIFlagEndpointAlias = "ep"
+	// CLIFlagPort is the cli option for port
+	CLIFlagPort = "port"
+	// CLIFlagPortAlias is the cli flag alias for port
+	CLIFlagPortAlias = "p"
+	// CLIFlagUser is the cli option for user
+	CLIFlagUser = "user"
+	// CLIFlagUserAlias is the cli flag alias for user
+	CLIFlagUserAlias = "u"
+	// CLIFlagPassword is the cli option for password
+	CLIFlagPassword = "password"
+	// CLIFlagPasswordAlias is the cli flag alias for password
+	CLIFlagPasswordAlias = "pw"
 	// CLIOptAuthenticator is the cli option for allowed authenticator settings
-	CLIOptAllowedAuthenticators = "allowed-authenticators"
-	// CLIOptTimeout is the cli option for timeout
-	CLIOptTimeout = "timeout"
-	// CLIOptKeyspace is the cli option for keyspace
-	CLIOptKeyspace = "keyspace"
-	// CLIOptDatabase is the cli option for database
-	CLIOptDatabase = "database"
-	// CLIOptDefaultDb is the cli option used as defaultdb to connect to
-	CLIOptDefaultDb = "defaultdb"
-	// CLIOptPluginName is the cli option for plugin name
-	CLIOptPluginName = "plugin"
-	// CLIOptConnectAttributes is the cli option for connect attributes (key/values via a url query string)
-	CLIOptConnectAttributes = "connect-attributes"
-	// CLIOptVersion is the cli option for version
-	CLIOptVersion = "version"
-	// CLIOptSchemaFile is the cli option for schema file
-	CLIOptSchemaFile = "schema-file"
-	// CLIOptOverwrite is the cli option for overwrite
-	CLIOptOverwrite = "overwrite"
-	// CLIOptDisableVersioning is the cli option to disabling versioning
-	CLIOptDisableVersioning = "disable-versioning"
-	// CLIOptTargetVersion is the cli option for target version
-	CLIOptTargetVersion = "version"
-	// CLIOptSchemaDir is the cli option for schema directory
-	CLIOptSchemaDir = "schema-dir"
-	// CLIOptSchemaName is the cli option for which pre-embedded schema to use
-	CLIOptSchemaName = "schema-name"
-	// CLIOptReplicationFactor is the cli option for replication factor
-	CLIOptReplicationFactor = "replication-factor"
-	// CLIOptDatacenter is the cli option for NetworkTopologyStrategy datacenter
-	CLIOptDatacenter = "datacenter"
+	CLIFlagAllowedAuthenticators = "allowed-authenticators"
+	// CLIFlagAllowedAuthenticatorsAlias is the cli flag alias for allowed authenticators
+	CLIFlagAllowedAuthenticatorsAlias = "aa"
+	// CLIFlagTimeout is the cli option for timeout
+	CLIFlagTimeout = "timeout"
+	// CLIFlagTimeoutAlias is the cli flag alias for timeout
+	CLIFlagTimeoutAlias = "t"
+	// CLIFlagKeyspace is the cli option for keyspace
+	CLIFlagKeyspace = "keyspace"
+	// CLIFlagKeyspaceAlias is the cli flag alias for keyspace
+	CLIFlagKeyspaceAlias = "k"
+	// CLIFlagDatabase is the cli option for database
+	CLIFlagDatabase = "database"
+	// CLIFlagDatabaseAlias is the cli flag alias for database
+	CLIFlagDatabaseAlias = "db"
+	// CLIFlagDefaultDb is the cli option used as defaultdb to connect to
+	CLIFlagDefaultDb = "defaultdb"
+	// CLIFlagPluginName is the cli option for plugin name
+	CLIFlagPluginName = "plugin"
+	// CLIFlagPluginNameAlias is the cli flag alias for plugin name
+	CLIFlagPluginNameAlias = "pl"
+	// CLIFlagConnectAttributes is the cli option for connect attributes (key/values via a url query string)
+	CLIFlagConnectAttributes = "connect-attributes"
+	// CLIFlagConnectAttributesAlias is the cli flag alias for connect attributes
+	CLIFlagConnectAttributesAlias = "ca"
+	// CLIFlagVersion is the cli option for version
+	CLIFlagVersion = "version"
+	// CLIFlagVersionAlias is the cli flag alias for version
+	CLIFlagVersionAlias = "v"
+	// CLIFlagSchemaFile is the cli option for schema file
+	CLIFlagSchemaFile = "schema-file"
+	// CLIFlagSchemaFileAlias is the cli flag alias for schema file
+	CLIFlagSchemaFileAlias = "f"
+	// CLIFlagOverwrite is the cli option for overwrite
+	CLIFlagOverwrite = "overwrite"
+	// CLIFlagOverwriteAlias is the cli flag alias for overwrite
+	CLIFlagOverwriteAlias = "o"
+	// CLIFlagDisableVersioning is the cli option to disabling versioning
+	CLIFlagDisableVersioning = "disable-versioning"
+	// CLIFlagDisableVersioningAlias is the cli flag alias to disabling versioning
+	CLIFlagDisableVersioningAlias = "d"
+	// CLIFlagTargetVersion is the cli option for target version
+	CLIFlagTargetVersion = "version"
+	// CLIFlagTargetVersionAlias is the cli flag alias for target version
+	CLIFlagTargetVersionAlias = "v"
+	// CLIFlagSchemaDir is the cli option for schema directory
+	CLIFlagSchemaDir = "schema-dir"
+	// CLIFlagSchemaDirAlias is the cli flag alias for schema directory
+	CLIFlagSchemaDirAlias = "d"
+	// CLIFlagSchemaName is the cli option for which pre-embedded schema to use
+	CLIFlagSchemaName = "schema-name"
+	// CLIFlagSchemaNameAlias is the cli flag alias for which pre-embedded schema to use
+	CLIFlagSchemaNameAlias = "s"
+	// CLIFlagReplicationFactor is the cli option for replication factor
+	CLIFlagReplicationFactor = "replication-factor"
+	// CLIFlagReplicationFactorAlias is the cli flag alias for replication factor
+	CLIFlagReplicationFactorAlias = "rf"
+	// CLIFlagDatacenter is the cli option for NetworkTopologyStrategy datacenter
+	CLIFlagDatacenter = "datacenter"
+	// CLIFlagDatacenterAlias is the cli flag alias for NetworkTopologyStrategy datacenter
+	CLIFlagDatacenterAlias = "dc"
 	// CLIOptConsistency is the cli option for consistency settings
 	CLIOptConsistency = "consistency"
 	// CLIOptAddressTranslator is the cli option for address translator for Cassandra
 	CLIOptAddressTranslator = "address-translator"
+	// CLIFlagAddressTranslatorAlias is the cli flag alias for address translator
+	CLIFlagAddressTranslatorAlias = "at"
 	// CLIOptAddressTranslatorOptions is the cli option for options for address translator
 	CLIOptAddressTranslatorOptions = "address-translator-options"
-	// CLIOptQuiet is the cli option for quiet mode
-	CLIOptQuiet = "quiet"
-	// CLIOptForce is the cli option for force mode
-	CLIOptForce = "force"
+	// CLIFlagQuiet is the cli option for quiet mode
+	CLIFlagQuiet = "quiet"
+	// CLIFlagQuietAlias is the cli flag alias for quiet mode
+	CLIFlagQuietAlias = "q"
+	// CLIFlagForce is the cli flag for force mode
+	CLIFlagForce = "force"
+	// CLIFlagForceAlias is the cli flag alias for force mode
+	CLIFlagForceAlias = "f"
 
-	// CLIFlagEndpoint is the cli flag for endpoint
-	CLIFlagEndpoint = CLIOptEndpoint + ", ep"
-	// CLIFlagPort is the cli flag for port
-	CLIFlagPort = CLIOptPort + ", p"
-	// CLIFlagUser is the cli flag for user
-	CLIFlagUser = CLIOptUser + ", u"
-	// CLIFlagPassword is the cli flag for password
-	CLIFlagPassword = CLIOptPassword + ", pw"
-	// CLIFlagAllowedAuthenticators is the cli flag for allowed authenticators
-	CLIFlagAllowedAuthenticators = CLIOptAllowedAuthenticators + ", aa"
-	// CLIFlagTimeout is the cli flag for timeout
-	CLIFlagTimeout = CLIOptTimeout + ", t"
-	// CLIFlagKeyspace is the cli flag for keyspace
-	CLIFlagKeyspace = CLIOptKeyspace + ", k"
-	// CLIFlagDatabase is the cli flag for database
-	CLIFlagDatabase = CLIOptDatabase + ", db"
-	// CLIFlagPluginName is the cli flag for plugin name
-	CLIFlagPluginName = CLIOptPluginName + ", pl"
-	// CLIFlagConnectAttributes allows arbitrary connect attributes
-	CLIFlagConnectAttributes = CLIOptConnectAttributes + ", ca"
-	// CLIFlagVersion is the cli flag for version
-	CLIFlagVersion = CLIOptVersion + ", v"
-	// CLIFlagSchemaFile is the cli flag for schema file
-	CLIFlagSchemaFile = CLIOptSchemaFile + ", f"
-	// CLIFlagOverwrite is the cli flag for overwrite
-	CLIFlagOverwrite = CLIOptOverwrite + ", o"
-	// CLIFlagDisableVersioning is the cli flag for disabling versioning
-	CLIFlagDisableVersioning = CLIOptDisableVersioning + ", d"
-	// CLIFlagTargetVersion is the cli flag for target version
-	CLIFlagTargetVersion = CLIOptTargetVersion + ", v"
-	// CLIFlagSchemaDir is the cli flag for schema directory
-	CLIFlagSchemaDir = CLIOptSchemaDir + ", d"
-	// CLIFlagSchemaName is the cli flag that says which pre-embedded schema to use
-	CLIFlagSchemaName = CLIOptSchemaName + ", s"
-	// CLIFlagReplicationFactor is the cli flag for replication factor
-	CLIFlagReplicationFactor = CLIOptReplicationFactor + ", rf"
-	// CLIFlagDatacenter is the cli option for NetworkTopologyStrategy datacenter
-	CLIFlagDatacenter = CLIOptDatacenter + ", dc"
-	// CLIFlagAddressTranslator is the cli option for address translator for Cassandra
-	CLIFlagAddressTranslator = CLIOptAddressTranslator + ", at"
 	// CLIFlagAddressTranslatorOptions is the cli option for address translator of Cassandra
 	CLIFlagAddressTranslatorOptions
-	// CLIFlagQuiet is the cli flag for quiet mode
-	CLIFlagQuiet = CLIOptQuiet + ", q"
-	// CLIFlagForce is the cli flag for force mode
-	CLIFlagForce = CLIOptForce + ", f"
 	// CLIFlagDisableInitialHostLookup is the cli flag for only using supplied hosts to connect to the database
 	CLIFlagDisableInitialHostLookup = "disable-initial-host-lookup"
 

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"net/url"
 
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
@@ -63,7 +63,7 @@ func createDatabase(cli *cli.Context, logger log.Logger) error {
 		logger.Error("Unable to read config.", tag.Error(schema.NewConfigError(err.Error())))
 		return err
 	}
-	defaultDb := cli.String(schema.CLIOptDefaultDb)
+	defaultDb := cli.String(schema.CLIFlagDefaultDb)
 	err = DoCreateDatabase(cfg, defaultDb, logger)
 	if err != nil {
 		logger.Error("Unable to create SQL database.", tag.Error(err))
@@ -90,7 +90,7 @@ func dropDatabase(cli *cli.Context, logger log.Logger) error {
 		logger.Error("Unable to read config.", tag.Error(schema.NewConfigError(err.Error())))
 		return err
 	}
-	defaultDb := cli.String(schema.CLIOptDefaultDb)
+	defaultDb := cli.String(schema.CLIFlagDefaultDb)
 	err = DoDropDatabase(cfg, defaultDb, logger)
 	if err != nil {
 		logger.Error("Unable to drop SQL database.", tag.Error(err))
@@ -117,18 +117,18 @@ func DoDropDatabase(cfg *config.SQL, defaultDb string, logger log.Logger) error 
 func parseConnectConfig(cli *cli.Context) (*config.SQL, error) {
 	cfg := new(config.SQL)
 
-	host := cli.GlobalString(schema.CLIOptEndpoint)
-	port := cli.GlobalInt(schema.CLIOptPort)
+	host := cli.String(schema.CLIFlagEndpoint)
+	port := cli.Int(schema.CLIFlagPort)
 	cfg.ConnectAddr = fmt.Sprintf("%s:%v", host, port)
-	cfg.User = cli.GlobalString(schema.CLIOptUser)
-	cfg.Password = cli.GlobalString(schema.CLIOptPassword)
-	cfg.DatabaseName = cli.GlobalString(schema.CLIOptDatabase)
-	cfg.PluginName = cli.GlobalString(schema.CLIOptPluginName)
+	cfg.User = cli.String(schema.CLIFlagUser)
+	cfg.Password = cli.String(schema.CLIFlagPassword)
+	cfg.DatabaseName = cli.String(schema.CLIFlagDatabase)
+	cfg.PluginName = cli.String(schema.CLIFlagPluginName)
 
 	if cfg.ConnectAttributes == nil {
 		cfg.ConnectAttributes = map[string]string{}
 	}
-	connectAttributesQueryString := cli.GlobalString(schema.CLIOptConnectAttributes)
+	connectAttributesQueryString := cli.String(schema.CLIFlagConnectAttributes)
 	if connectAttributesQueryString != "" {
 		values, err := url.ParseQuery(connectAttributesQueryString)
 		if err != nil {
@@ -143,14 +143,14 @@ func parseConnectConfig(cli *cli.Context) (*config.SQL, error) {
 		}
 	}
 
-	if cli.GlobalBool(schema.CLIFlagEnableTLS) {
+	if cli.Bool(schema.CLIFlagEnableTLS) {
 		cfg.TLS = &auth.TLS{
 			Enabled:                true,
-			CertFile:               cli.GlobalString(schema.CLIFlagTLSCertFile),
-			KeyFile:                cli.GlobalString(schema.CLIFlagTLSKeyFile),
-			CaFile:                 cli.GlobalString(schema.CLIFlagTLSCaFile),
-			ServerName:             cli.GlobalString(schema.CLIFlagTLSHostName),
-			EnableHostVerification: !cli.GlobalBool(schema.CLIFlagTLSDisableHostVerification),
+			CertFile:               cli.String(schema.CLIFlagTLSCertFile),
+			KeyFile:                cli.String(schema.CLIFlagTLSKeyFile),
+			CaFile:                 cli.String(schema.CLIFlagTLSCaFile),
+			ServerName:             cli.String(schema.CLIFlagTLSHostName),
+			EnableHostVerification: !cli.Bool(schema.CLIFlagTLSDisableHostVerification),
 		}
 	}
 
@@ -168,10 +168,10 @@ func ValidateConnectConfig(cfg *config.SQL) error {
 		return schema.NewConfigError("invalid host and port " + cfg.ConnectAddr)
 	}
 	if len(host) == 0 {
-		return schema.NewConfigError("missing sql endpoint argument " + flag(schema.CLIOptEndpoint))
+		return schema.NewConfigError("missing sql endpoint argument " + flag(schema.CLIFlagEndpoint))
 	}
 	if cfg.DatabaseName == "" {
-		return schema.NewConfigError("missing " + flag(schema.CLIOptDatabase) + " argument")
+		return schema.NewConfigError("missing " + flag(schema.CLIFlagDatabase) + " argument")
 	}
 
 	return nil

--- a/tools/sql/main.go
+++ b/tools/sql/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"
@@ -21,7 +21,7 @@ func RunTool(args []string) error {
 
 // root handler for all cli commands
 func cliHandler(c *cli.Context, handler func(c *cli.Context, logger log.Logger) error, logger log.Logger) {
-	quiet := c.GlobalBool(schema.CLIOptQuiet)
+	quiet := c.Bool(schema.CLIFlagQuiet)
 	err := handler(c, logger)
 	if err != nil && !quiet {
 		os.Exit(1)
@@ -30,7 +30,6 @@ func cliHandler(c *cli.Context, handler func(c *cli.Context, logger log.Logger) 
 
 // BuildCLIOptions builds the options for cli
 func BuildCLIOptions() *cli.App {
-
 	app := cli.NewApp()
 	app.Name = "temporal-sql-tool"
 	app.Usage = "Command line tool for temporal sql operations"
@@ -39,114 +38,128 @@ func BuildCLIOptions() *cli.App {
 	logger := log.NewCLILogger()
 
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:   schema.CLIFlagEndpoint,
-			Value:  environment.GetMySQLAddress(),
-			Usage:  "hostname or ip address of sql host to connect to",
-			EnvVar: "SQL_HOST",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagEndpoint,
+			Aliases: []string{schema.CLIFlagEndpointAlias},
+			Value:   environment.GetMySQLAddress(),
+			Usage:   "hostname or ip address of sql host to connect to",
+			EnvVars: []string{"SQL_HOST"},
 		},
-		cli.IntFlag{
-			Name:   schema.CLIFlagPort,
-			Value:  environment.GetMySQLPort(),
-			Usage:  "port of sql host to connect to",
-			EnvVar: "SQL_PORT",
+		&cli.IntFlag{
+			Name:    schema.CLIFlagPort,
+			Aliases: []string{schema.CLIFlagPortAlias},
+			Value:   environment.GetMySQLPort(),
+			Usage:   "port of sql host to connect to",
+			EnvVars: []string{"SQL_PORT"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagUser,
-			Value:  "",
-			Usage:  "user name used for authentication when connecting to sql host",
-			EnvVar: "SQL_USER",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagUser,
+			Aliases: []string{schema.CLIFlagUserAlias},
+			Value:   "",
+			Usage:   "user name used for authentication when connecting to sql host",
+			EnvVars: []string{"SQL_USER"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagPassword,
-			Value:  "",
-			Usage:  "password used for authentication when connecting to sql host",
-			EnvVar: "SQL_PASSWORD",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagPassword,
+			Aliases: []string{schema.CLIFlagPasswordAlias},
+			Value:   "",
+			Usage:   "password used for authentication when connecting to sql host",
+			EnvVars: []string{"SQL_PASSWORD"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagDatabase,
-			Value:  "temporal",
-			Usage:  "name of the sql database",
-			EnvVar: "SQL_DATABASE",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagDatabase,
+			Aliases: []string{schema.CLIFlagDatabaseAlias},
+			Value:   "temporal",
+			Usage:   "name of the sql database",
+			EnvVars: []string{"SQL_DATABASE"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagPluginName,
-			Value:  mysql.PluginName,
-			Usage:  "name of the sql plugin",
-			EnvVar: "SQL_PLUGIN",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagPluginName,
+			Aliases: []string{schema.CLIFlagPluginNameAlias},
+			Value:   mysql.PluginName,
+			Usage:   "name of the sql plugin",
+			EnvVars: []string{"SQL_PLUGIN"},
 		},
-		cli.BoolFlag{
-			Name:  schema.CLIFlagQuiet,
-			Usage: "Don't set exit status to 1 on error",
+		&cli.BoolFlag{
+			Name:    schema.CLIFlagQuiet,
+			Aliases: []string{schema.CLIFlagQuietAlias},
+			Usage:   "Don't set exit status to 1 on error",
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagConnectAttributes,
-			Usage:  "sql connect attributes",
-			EnvVar: "SQL_CONNECT_ATTRIBUTES",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagConnectAttributes,
+			Aliases: []string{schema.CLIFlagConnectAttributesAlias},
+			Usage:   "sql connect attributes",
+			EnvVars: []string{"SQL_CONNECT_ATTRIBUTES"},
 		},
-		cli.BoolFlag{
-			Name:   schema.CLIFlagEnableTLS,
-			Usage:  "enable TLS over sql connection",
-			EnvVar: "SQL_TLS",
+		&cli.BoolFlag{
+			Name:    schema.CLIFlagEnableTLS,
+			Usage:   "enable TLS over sql connection",
+			EnvVars: []string{"SQL_TLS"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagTLSCertFile,
-			Usage:  "sql tls client cert path (tls must be enabled)",
-			EnvVar: "SQL_TLS_CERT_FILE",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagTLSCertFile,
+			Usage:   "sql tls client cert path (tls must be enabled)",
+			EnvVars: []string{"SQL_TLS_CERT_FILE"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagTLSKeyFile,
-			Usage:  "sql tls client key path (tls must be enabled)",
-			EnvVar: "SQL_TLS_KEY_FILE",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagTLSKeyFile,
+			Usage:   "sql tls client key path (tls must be enabled)",
+			EnvVars: []string{"SQL_TLS_KEY_FILE"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagTLSCaFile,
-			Usage:  "sql tls client ca file (tls must be enabled)",
-			EnvVar: "SQL_TLS_CA_FILE",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagTLSCaFile,
+			Usage:   "sql tls client ca file (tls must be enabled)",
+			EnvVars: []string{"SQL_TLS_CA_FILE"},
 		},
-		cli.StringFlag{
-			Name:   schema.CLIFlagTLSHostName,
-			Value:  "",
-			Usage:  "override for target server name",
-			EnvVar: "SQL_TLS_SERVER_NAME",
+		&cli.StringFlag{
+			Name:    schema.CLIFlagTLSHostName,
+			Value:   "",
+			Usage:   "override for target server name",
+			EnvVars: []string{"SQL_TLS_SERVER_NAME"},
 		},
-		cli.BoolFlag{
-			Name:   schema.CLIFlagTLSDisableHostVerification,
-			Usage:  "disable tls host name verification (tls must be enabled)",
-			EnvVar: "SQL_TLS_DISABLE_HOST_VERIFICATION",
+		&cli.BoolFlag{
+			Name:    schema.CLIFlagTLSDisableHostVerification,
+			Usage:   "disable tls host name verification (tls must be enabled)",
+			EnvVars: []string{"SQL_TLS_DISABLE_HOST_VERIFICATION"},
 		},
 	}
 
-	app.Commands = []cli.Command{
+	app.Commands = []*cli.Command{
 		{
 			Name:    "setup-schema",
 			Aliases: []string{"setup"},
 			Usage:   "setup initial version of sql schema",
 			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  schema.CLIFlagVersion,
-					Usage: "initial version of the schema, cannot be used with disable-versioning",
+				&cli.StringFlag{
+					Name:    schema.CLIFlagVersion,
+					Aliases: []string{schema.CLIFlagVersionAlias},
+					Usage:   "initial version of the schema, cannot be used with disable-versioning",
 				},
-				cli.StringFlag{
-					Name:  schema.CLIFlagSchemaFile,
-					Usage: "path to the .sql schema file; if un-specified, will just setup versioning tables",
+				&cli.StringFlag{
+					Name:    schema.CLIFlagSchemaFile,
+					Aliases: []string{schema.CLIFlagSchemaFileAlias},
+					Usage:   "path to the .sql schema file; if un-specified, will just setup versioning tables",
 				},
-				cli.StringFlag{
-					Name: schema.CLIFlagSchemaName,
+				&cli.StringFlag{
+					Name:    schema.CLIFlagSchemaName,
+					Aliases: []string{schema.CLIFlagSchemaNameAlias},
 					Usage: fmt.Sprintf("name of embedded schema directory with .sql file, one of: %v",
 						dbschemas.PathsByDB("sql")),
 				},
-				cli.BoolFlag{
-					Name:  schema.CLIFlagDisableVersioning,
-					Usage: "disable setup of schema versioning",
+				&cli.BoolFlag{
+					Name:    schema.CLIFlagDisableVersioning,
+					Aliases: []string{schema.CLIFlagDisableVersioningAlias},
+					Usage:   "disable setup of schema versioning",
 				},
-				cli.BoolFlag{
-					Name:  schema.CLIFlagOverwrite,
-					Usage: "drop all existing tables before setting up new schema",
+				&cli.BoolFlag{
+					Name:    schema.CLIFlagOverwrite,
+					Aliases: []string{schema.CLIFlagOverwriteAlias},
+					Usage:   "drop all existing tables before setting up new schema",
 				},
 			},
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) error {
 				cliHandler(c, setupSchema, logger)
+				return nil
 			},
 		},
 		{
@@ -154,22 +167,26 @@ func BuildCLIOptions() *cli.App {
 			Aliases: []string{"update"},
 			Usage:   "update sql schema to a specific version",
 			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  schema.CLIFlagTargetVersion,
-					Usage: "target version for the schema update, defaults to latest",
+				&cli.StringFlag{
+					Name:    schema.CLIFlagTargetVersion,
+					Aliases: []string{schema.CLIFlagTargetVersionAlias},
+					Usage:   "target version for the schema update, defaults to latest",
 				},
-				cli.StringFlag{
-					Name:  schema.CLIFlagSchemaDir,
-					Usage: "path to directory containing versioned schema",
+				&cli.StringFlag{
+					Name:    schema.CLIFlagSchemaDir,
+					Aliases: []string{schema.CLIFlagSchemaDirAlias},
+					Usage:   "path to directory containing versioned schema",
 				},
-				cli.StringFlag{
-					Name: schema.CLIFlagSchemaName,
+				&cli.StringFlag{
+					Name:    schema.CLIFlagSchemaName,
+					Aliases: []string{schema.CLIFlagSchemaNameAlias},
 					Usage: fmt.Sprintf("name of embedded versioned schema, one of: %v",
 						dbschemas.PathsByDB("mysql")),
 				},
 			},
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) error {
 				cliHandler(c, updateSchema, logger)
+				return nil
 			},
 		},
 		{
@@ -177,13 +194,14 @@ func BuildCLIOptions() *cli.App {
 			Aliases: []string{"create"},
 			Usage:   "creates a database",
 			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  schema.CLIOptDefaultDb,
+				&cli.StringFlag{
+					Name:  schema.CLIFlagDefaultDb,
 					Usage: "optional default db to connect to, this is not the db to be created",
 				},
 			},
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) error {
 				cliHandler(c, createDatabase, logger)
+				return nil
 			},
 		},
 		{
@@ -191,19 +209,21 @@ func BuildCLIOptions() *cli.App {
 			Aliases: []string{"drop"},
 			Usage:   "drops a database",
 			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  schema.CLIOptDefaultDb,
+				&cli.StringFlag{
+					Name:  schema.CLIFlagDefaultDb,
 					Usage: "optional default db to connect to, not the db to be deleted",
 				},
-				cli.BoolFlag{
-					Name:  schema.CLIFlagForce,
-					Usage: "don't prompt for confirmation",
+				&cli.BoolFlag{
+					Name:    schema.CLIFlagForce,
+					Aliases: []string{schema.CLIFlagForceAlias},
+					Value:   false,
+					Usage:   "don't prompt for confirmation",
 				},
 			},
-			Action: func(c *cli.Context) {
-				drop := c.Bool(schema.CLIOptForce)
+			Action: func(c *cli.Context) error {
+				drop := c.Bool(schema.CLIFlagForce)
 				if !drop {
-					database := c.GlobalString(schema.CLIOptDatabase)
+					database := c.String(schema.CLIFlagDatabase)
 					fmt.Printf("Are you sure you want to drop database %q (y/N)? ", database)
 					y := ""
 					_, _ = fmt.Scanln(&y)
@@ -214,6 +234,7 @@ func BuildCLIOptions() *cli.App {
 				if drop {
 					cliHandler(c, dropDatabase, logger)
 				}
+				return nil
 			},
 		},
 	}


### PR DESCRIPTION
## What changed?

There are two versions of github.com/urfave/cli. This PR migrates it to v2 version.

## Why?

For some reason, the project uses both versions of the same dependency, which is not ideal.

## How did you test it?

- [x] built
- [x] run locally and tested manually

