### PR TITLE
Debug : TaskQueue Fairness Rate Limit 

### DIFF
--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -406,11 +406,6 @@ func (tm *TaskMatcher) ReprocessAllTasks() {
 	// unused in old matcher
 }
 
-// Rate returns the current rate at which tasks are dispatched
-func (tm *TaskMatcher) Rate() float64 {
-	return tm.rateLimiter.Rate()
-}
-
 func (tm *TaskMatcher) poll(
 	ctx context.Context, pollMetadata *pollMetadata, queryOnly bool,
 ) (task *internalTask, forwardedPoll bool, err error) {

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -1014,6 +1014,9 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 	dbq := newUnversionedRootQueueKey(namespaceId, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 	mgr := s.newPartitionManager(dbq.partition, s.matchingEngine.config)
 
+	// Directly override admin rate limits to simulate dynamic config at rateLimitManager.
+	mgr.GetRateLimitManager().SetAdminRateForTesting(25000.0)
+
 	s.matchingEngine.updateTaskQueue(dbq.partition, mgr)
 	mgr.Start()
 

--- a/service/matching/pri_matcher.go
+++ b/service/matching/pri_matcher.go
@@ -3,7 +3,6 @@ package matching
 import (
 	"context"
 	"strconv"
-	"sync"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
@@ -33,20 +32,14 @@ type priTaskMatcher struct {
 	// Background context used for forwarding tasks. Closed when task queue is closed.
 	tqCtx context.Context
 
-	partition      tqid.Partition
-	fwdr           *priForwarder
-	validator      taskValidator
-	metricsHandler metrics.Handler // namespace metric scope
-	logger         log.Logger
-	numPartitions  func() int // number of task queue partitions
-	markAlive      func()     // function to mark the physical task queue alive
-
-	limiterLock sync.Mutex
-	adminNsRate float64
-	adminTqRate float64
-	dynamicRate float64
-
-	cancel1, cancel2 func()
+	partition        tqid.Partition
+	fwdr             *priForwarder
+	validator        taskValidator
+	rateLimitManager *rateLimitManager
+	metricsHandler   metrics.Handler // namespace metric scope
+	logger           log.Logger
+	numPartitions    func() int // number of task queue partitions
+	markAlive        func()     // function to mark the physical task queue alive
 }
 
 type waitingPoller struct {
@@ -65,16 +58,6 @@ type matchResult struct {
 	ctxErr    error // set if context timed out/canceled or reprocess task
 	ctxErrIdx int   // index of context that closed first
 }
-
-const (
-	// TODO(pri): old matcher cleanup, move to here
-	// defaultTaskDispatchRPS = 100000.0
-
-	// How much rate limit a task queue can use up in an instant. E.g., for a rate of
-	// 100/second and burst duration of 2 seconds, the capacity of a bucket-type limiting
-	// algorithm would be 200.
-	burstDuration = time.Second
-)
 
 var (
 	// TODO(pri): old matcher cleanup, move to here
@@ -98,25 +81,22 @@ func newPriTaskMatcher(
 	validator taskValidator,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
+	rateLimitManager *rateLimitManager,
 	markAlive func(),
 ) *priTaskMatcher {
 	tm := &priTaskMatcher{
-		config:         config,
-		data:           newMatcherData(config, logger, clock.NewRealTimeSource(), fwdr != nil),
-		tqCtx:          tqCtx,
-		logger:         logger,
-		metricsHandler: metricsHandler,
-		partition:      partition,
-		fwdr:           fwdr,
-		validator:      validator,
-		numPartitions:  config.NumReadPartitions,
-		markAlive:      markAlive,
-		dynamicRate:    defaultTaskDispatchRPS,
+		config:           config,
+		data:             newMatcherData(config, logger, clock.NewRealTimeSource(), fwdr != nil, rateLimitManager),
+		tqCtx:            tqCtx,
+		logger:           logger,
+		metricsHandler:   metricsHandler,
+		partition:        partition,
+		fwdr:             fwdr,
+		validator:        validator,
+		rateLimitManager: rateLimitManager,
+		numPartitions:    config.NumReadPartitions,
+		markAlive:        markAlive,
 	}
-
-	tm.adminNsRate, tm.cancel1 = config.AdminNamespaceToPartitionRateSub(tm.setAdminNsRate)
-	tm.adminTqRate, tm.cancel2 = config.AdminNamespaceTaskQueueToPartitionRateSub(tm.setAdminTqRate)
-	tm.setLimitLocked()
 
 	return tm
 }
@@ -143,10 +123,7 @@ func (tm *priTaskMatcher) Start() {
 	}
 }
 
-func (tm *priTaskMatcher) Stop() {
-	tm.cancel1()
-	tm.cancel2()
-}
+func (tm *priTaskMatcher) Stop() {}
 
 func (tm *priTaskMatcher) forwardTasks(lim quotas.RateLimiter, retrier backoff.Retrier) {
 	ctxs := []context.Context{tm.tqCtx}
@@ -496,52 +473,6 @@ func (tm *priTaskMatcher) ReprocessAllTasks() {
 			task.finish(errReprocessTask, true)
 		}
 	}
-}
-
-// UpdateRatelimit updates the task dispatch rate
-func (tm *priTaskMatcher) UpdateRatelimit(rps float64) {
-	tm.limiterLock.Lock()
-	defer tm.limiterLock.Unlock()
-	tm.dynamicRate = rps
-	tm.setLimitLocked()
-}
-
-func (tm *priTaskMatcher) setAdminNsRate(rps float64) {
-	tm.limiterLock.Lock()
-	defer tm.limiterLock.Unlock()
-	tm.adminNsRate = rps
-	tm.setLimitLocked()
-}
-
-func (tm *priTaskMatcher) setAdminTqRate(rps float64) {
-	tm.limiterLock.Lock()
-	defer tm.limiterLock.Unlock()
-	tm.adminTqRate = rps
-	tm.setLimitLocked()
-}
-
-func (tm *priTaskMatcher) setLimitLocked() {
-	perPartitionDynamicRate := tm.dynamicRate
-
-	if n := tm.numPartitions(); n > 0 {
-		// divide the rate equally across all partitions
-		perPartitionDynamicRate /= float64(n)
-	}
-
-	rate := min(
-		perPartitionDynamicRate,
-		tm.adminNsRate,
-		tm.adminTqRate,
-	)
-
-	tm.data.UpdateRateLimit(rate, burstDuration)
-}
-
-// Rate returns the current dynamic rate setting
-func (tm *priTaskMatcher) Rate() float64 {
-	tm.limiterLock.Lock()
-	defer tm.limiterLock.Unlock()
-	return tm.dynamicRate
 }
 
 func (tm *priTaskMatcher) poll(

--- a/service/matching/ratelimit_manager.go
+++ b/service/matching/ratelimit_manager.go
@@ -3,8 +3,11 @@ package matching
 import (
 	"math"
 	"sync"
+	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/cache"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/quotas"
 )
 
@@ -12,22 +15,51 @@ type (
 	rateLimitManager struct {
 		mu sync.Mutex
 
-		effectiveRPS    float64                 // Min of api/worker set RPS and system defaults. Always reflects the overall task queue RPS.
-		rateLimitSource enumspb.RateLimitSource // Source of the rate limit, can be set via API, worker or system default.
-		userDataManager userDataManager         // User data manager to fetch user data for task queue configurations.
-		workerRPS       *float64                // RPS set by worker at the time of polling, if available.
-		apiConfigRPS    *float64                // RPS set via API, if available.
-		systemRPS       float64                 // Min of partition level dispatch rates times the number of read partitions.
-		config          *taskQueueConfig        // Dynamic configuration for task queues set by system.
-		taskQueueType   enumspb.TaskQueueType   // Task queue type
+		// Dependencies
+		userDataManager userDataManager       // User data manager to fetch user data for task queue configurations.
+		config          *taskQueueConfig      // Dynamic configuration for task queues set by system.
+		taskQueueType   enumspb.TaskQueueType // Task queue type
+		timeSource      clock.TimeSource
 
-		// dynamicRate is the dynamic rate & burst for rate limiter
+		// Sources of the effective RPS.
+		workerRPS                   *float64 // RPS set by worker at the time of polling, if available.
+		apiConfigRPS                *float64 // RPS set via API, if available.
+		fairnessKeyRateLimitDefault *float64 // per-partition fairnessKeyRateLimitDefault set via API, if available
+		adminNsRate                 float64
+		adminTqRate                 float64
+		numReadPartitions           int
+
+		// Derived from the above sources.
+		effectiveRPS    float64                 // Min of api/worker set RPS and system defaults. Always reflects the per-partition wise task queue RPS.
+		systemRPS       float64                 // Min of partition level dispatch rates times the number of read partitions.
+		rateLimitSource enumspb.RateLimitSource // Source of the rate limit, can be set via API, worker or system default.
+		// Derived from the `defaultTaskDispatchRPS`.
+		// dynamicRateBurst is the dynamic rate & burst for rate limiter
 		dynamicRateBurst quotas.MutableRateBurst
 		// dynamicRateLimiter is the dynamic rate limiter that can be used to force refresh on new rates.
 		dynamicRateLimiter *quotas.DynamicRateLimiterImpl
-		// forceRefreshRateOnce is used to force refresh rate limit for first time
-		forceRefreshRateOnce sync.Once
+		// Fairness tasks rate limiter.
+		wholeQueueLimit simpleLimiterParams
+		wholeQueueReady simpleLimiter
+		// Rate limiter for individual fairness keys.
+		// Note that we currently have only one limit for all keys, which is scaled by the key's
+		// weight. If we do this, we can assume that all keys are either at or below their rate
+		// limit at the same time, so that if the head of the queue is at its limit, then the rest
+		// must also be, and so we don't have to "skip over" the head of the queue due to rate
+		// limits. This isn't true in situations where weights have changed in between writing and
+		// reading. We'll handle that situation better in the future.
+		perKeyLimit     simpleLimiterParams
+		perKeyReady     cache.Cache
+		perKeyOverrides fairnessWeightOverrides // TODO(fairness): get this from config
+		cancels         []func()
 	}
+)
+
+const (
+	// How much rate limit a task queue can use up in an instant. E.g., for a rate of
+	// 100/second and burst duration of 2 seconds, the capacity of a bucket-type limiting
+	// algorithm would be 200.
+	defaultBurstDuration = time.Second
 )
 
 // Create a new rate limit manager for the task queue partition.
@@ -39,6 +71,8 @@ func newRateLimitManager(userDataManager userDataManager,
 		userDataManager: userDataManager,
 		config:          config,
 		taskQueueType:   taskQueueType,
+		perKeyReady:     cache.New(config.FairnessKeyRateLimitCacheSize(), nil),
+		timeSource:      clock.NewRealTimeSource(),
 	}
 	r.dynamicRateBurst = quotas.NewMutableRateBurst(
 		defaultTaskDispatchRPS,
@@ -48,17 +82,37 @@ func newRateLimitManager(userDataManager userDataManager,
 		r.dynamicRateBurst,
 		config.RateLimiterRefreshInterval,
 	)
+	var cancel func()
+	r.adminNsRate, cancel = config.AdminNamespaceToPartitionRateSub(r.setAdminNsRate)
+	r.cancels = append(r.cancels, cancel)
+	r.adminTqRate, cancel = config.AdminNamespaceTaskQueueToPartitionRateSub(r.setAdminTqRate)
+	r.cancels = append(r.cancels, cancel)
+	r.numReadPartitions, cancel = config.NumReadPartitionsSub(r.setNumReadPartitions)
+	r.cancels = append(r.cancels, cancel)
 	r.computeEffectiveRPSAndSource()
 	return r
 }
 
-func (r *rateLimitManager) getNumberOfReadPartitions() float64 {
-	nPartitions := float64(r.config.NumReadPartitions())
-	if nPartitions <= 0 {
-		// Defaulting to 1 partition if misconfigured
-		nPartitions = 1
-	}
-	return nPartitions
+func (r *rateLimitManager) setAdminNsRate(rps float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adminNsRate = rps
+	r.computeAndApplyRateLimitLocked()
+}
+
+func (r *rateLimitManager) setAdminTqRate(rps float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adminTqRate = rps
+	r.computeAndApplyRateLimitLocked()
+}
+
+func (r *rateLimitManager) setNumReadPartitions(val int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Defaulting to 1 partition if misconfigured
+	r.numReadPartitions = max(val, 1)
+	r.computeAndApplyRateLimitLocked()
 }
 
 func (r *rateLimitManager) computeEffectiveRPSAndSource() {
@@ -77,18 +131,17 @@ func (r *rateLimitManager) computeEffectiveRPSAndSourceLocked() {
 		effectiveRPS    = math.Inf(1)
 		rateLimitSource enumspb.RateLimitSource
 	)
-	// Overall system rate limit will be the min of the two configs that are partition wise times the number of partions.
 	systemRPS := min(
-		r.config.AdminNamespaceTaskQueueToPartitionDispatchRate(),
-		r.config.AdminNamespaceToPartitionDispatchRate(),
-	) * r.getNumberOfReadPartitions()
+		r.adminNsRate,
+		r.adminTqRate,
+	)
 	r.systemRPS = systemRPS
 	switch {
 	case r.apiConfigRPS != nil:
-		effectiveRPS = *r.apiConfigRPS
+		effectiveRPS = *r.apiConfigRPS / float64(r.numReadPartitions)
 		rateLimitSource = enumspb.RATE_LIMIT_SOURCE_API
 	case r.workerRPS != nil:
-		effectiveRPS = *r.workerRPS
+		effectiveRPS = *r.workerRPS / float64(r.numReadPartitions)
 		rateLimitSource = enumspb.RATE_LIMIT_SOURCE_WORKER
 	}
 
@@ -101,8 +154,22 @@ func (r *rateLimitManager) computeEffectiveRPSAndSourceLocked() {
 	}
 }
 
+func (r *rateLimitManager) computeAndApplyRateLimitLocked() {
+	oldRPS := r.effectiveRPS
+	r.computeEffectiveRPSAndSourceLocked()
+	newRPS := r.effectiveRPS
+	// If the effective RPS has changed, we need to update the rate limiters.
+	if oldRPS != newRPS {
+		r.updateRatelimitLocked()
+		r.updateSimpleRateLimitLocked(defaultBurstDuration)
+	}
+	// Internally, checks if the per-key rate limit has changed and updates it accordingly.
+	r.updatePerKeySimpleRateLimitLocked(defaultBurstDuration)
+}
+
 // Lazy injection of poll metadata.
-// Internally call UpdateRateLimit to share the same mutex.
+// Called whenever a new poll request comes in.
+// This allows the rate limit manager to adjust its rate limits based on any updates right before polling happens.
 func (r *rateLimitManager) InjectWorkerRPS(meta *pollMetadata) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -114,9 +181,7 @@ func (r *rateLimitManager) InjectWorkerRPS(meta *pollMetadata) {
 		}
 	}
 	r.workerRPS = rps
-	// updateRatelimitLocked includes internal logic to determine if an update is needed,
-	// so calling it unconditionally is safe and avoids redundant updates.
-	r.updateRatelimitLocked()
+	r.computeAndApplyRateLimitLocked()
 }
 
 // Return the effective RPS and its source together.
@@ -125,8 +190,7 @@ func (r *rateLimitManager) InjectWorkerRPS(meta *pollMetadata) {
 func (r *rateLimitManager) GetEffectiveRPSAndSource() (float64, enumspb.RateLimitSource) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.computeEffectiveRPSAndSourceLocked()
-	return r.effectiveRPS, r.rateLimitSource
+	return r.effectiveRPS * float64(r.numReadPartitions), r.rateLimitSource
 }
 
 func (r *rateLimitManager) GetRateLimiter() quotas.RateLimiter {
@@ -138,51 +202,159 @@ func (r *rateLimitManager) GetRateLimiter() quotas.RateLimiter {
 func (r *rateLimitManager) UserDataChanged() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	// Immediately recompute and apply rate limit if necessary.
-	r.updateRatelimitLocked()
+	// Fetch the latest user data and update the API-configured RPS.
+	r.trySetRPSFromUserDataLocked()
+	r.computeAndApplyRateLimitLocked()
 }
 
 // trySetRPSFromUserDataLocked sets the apiConfigRPS from user data.
+// Called exclusively in response to updates in user data.
 func (r *rateLimitManager) trySetRPSFromUserDataLocked() {
 	userData, _, err := r.userDataManager.GetUserData()
 	if err != nil {
 		return
 	}
 	config := userData.GetData().GetPerType()[int32(r.taskQueueType)].GetConfig()
-	if config == nil {
-		return
-	}
 	// If rate limit is an empty message, it means rate limit could have been unset via API.
 	// In this case, the apiConfigRPS will need to be unset.
-	rateLimit := config.GetQueueRateLimit()
-	if rateLimit.GetRateLimit() == nil {
+	queueRateLimit := config.GetQueueRateLimit()
+	if queueRateLimit.GetRateLimit() == nil {
 		r.apiConfigRPS = nil
-		return
+	} else {
+		val := float64(queueRateLimit.GetRateLimit().GetRequestsPerSecond())
+		r.apiConfigRPS = &val
 	}
-	val := float64(rateLimit.GetRateLimit().GetRequestsPerSecond())
-	r.apiConfigRPS = &val
+	fairnessKeyRateLimitDefault := config.GetFairnessKeysRateLimitDefault()
+	if fairnessKeyRateLimitDefault.GetRateLimit() == nil {
+		r.fairnessKeyRateLimitDefault = nil
+	} else {
+		// Maintain the fairnessKeyRateLimitDefault as per-partition rate.
+		val := float64(fairnessKeyRateLimitDefault.GetRateLimit().GetRequestsPerSecond()) / float64(r.numReadPartitions)
+		r.fairnessKeyRateLimitDefault = &val
+	}
 }
 
-// updateRatelimitLocked checks and updates the rate limit if changed.
+// updateRatelimitLocked checks and updates the overall queue rate limit if changed.
 func (r *rateLimitManager) updateRatelimitLocked() {
-	// Always check for api configured rate limits before any update to the rate limits.
-	r.trySetRPSFromUserDataLocked()
-	oldRPS := r.effectiveRPS
-	r.computeEffectiveRPSAndSourceLocked()
 	newRPS := r.effectiveRPS
-	if oldRPS == newRPS {
-		// No update required
+	// If the effective RPS is zero, we set the burst to zero as well.
+	// This prevents any initial tasks from executing immediately.
+	// Allows pausing of the task queue by setting the RPS to zero.
+	var burst int
+	if newRPS != 0 {
+		// If the effective RPS is non-zero, we can set a burst based on the effective RPS.
+		burst = max(int(math.Ceil(newRPS)), r.config.MinTaskThrottlingBurstSize())
+	}
+	r.dynamicRateBurst.SetRPS(newRPS)
+	r.dynamicRateBurst.SetBurst(burst)
+	// updateRatelimitLocked is invoked whenever the effective RPS value changes.
+	// At this point, the dynamicRateLimiter is always updated with the latest rate and burst values,
+	// ensuring that the new rate limit takes effect immediately.
+	r.dynamicRateLimiter.Refresh()
+}
+
+// UpdateSimpleRateLimit updates the overall queue rate limits for the simpleRateLimiter implementation
+func (r *rateLimitManager) updateSimpleRateLimitLocked(burstDuration time.Duration) {
+	newRPS := r.effectiveRPS
+	r.wholeQueueLimit = makeSimpleLimiterParams(newRPS, burstDuration)
+
+	// Clip to handle the case where we have increased from a zero or very low limit and had
+	// ready times in the far future.
+	now := r.timeSource.Now().UnixNano()
+	r.wholeQueueReady = r.wholeQueueReady.clip(r.wholeQueueLimit, now, maxTokens)
+}
+
+// UpdatePerKeySimpleRateLimit updates the per-key rate limit for the simpleRateLimit implementation
+// UpdateTaskQueueConfig api is the single source for the per-key rate limit.
+func (r *rateLimitManager) updatePerKeySimpleRateLimitLocked(burstDuration time.Duration) {
+	if r.fairnessKeyRateLimitDefault == nil {
+		r.clearPerKeyRateLimitsLocked()
 		return
 	}
-	effectiveRPSPartitionWise := r.effectiveRPS / r.getNumberOfReadPartitions()
-	burst := int(math.Ceil(effectiveRPSPartitionWise))
-	burst = max(burst, r.config.MinTaskThrottlingBurstSize())
-	r.dynamicRateBurst.SetRPS(effectiveRPSPartitionWise)
-	r.dynamicRateBurst.SetBurst(burst)
-	r.forceRefreshRateOnce.Do(func() {
-		// Dynamic rate limiter only refresh its rate every 1m. Before that initial 1m interval, it uses default rate
-		// which is 10K and is too large in most cases. We need to force refresh for the first time this rate is set
-		// by poller. Only need to do that once. If the rate change later, it will be refresh in 1m.
-		r.dynamicRateLimiter.Refresh()
-	})
+	rate := *r.fairnessKeyRateLimitDefault
+	slp := makeSimpleLimiterParams(rate, burstDuration)
+	if slp == r.perKeyLimit {
+		// No change in per-key rate limit, no need to update.
+		return
+	}
+	r.perKeyLimit = slp
+
+	// Clip to handle the case where we have increased from a zero or very low limit and had
+	// ready times in the far future.
+	var updates map[string]simpleLimiter
+	now := r.timeSource.Now().UnixNano()
+	it := r.perKeyReady.Iterator()
+	for it.HasNext() {
+		e := it.Next()
+		sl := e.Value().(simpleLimiter) //nolint:revive
+		if clipped := sl.clip(r.perKeyLimit, now, maxTokens); clipped != sl {
+			if updates == nil {
+				updates = make(map[string]simpleLimiter)
+			}
+			updates[e.Key().(string)] = clipped
+		}
+	}
+	it.Close()
+
+	// This messes up the LRU order, but we can't avoid that here without adding new
+	// functionality to Cache.
+	for key, clipped := range updates {
+		r.perKeyReady.Put(key, clipped)
+	}
+}
+
+// clearPerKeyRateLimitsLocked removes all fairness per-key rate limits.
+func (r *rateLimitManager) clearPerKeyRateLimitsLocked() {
+	r.perKeyReady = cache.New(r.config.FairnessKeyRateLimitCacheSize(), nil)
+	r.perKeyLimit = simpleLimiterParams{}
+}
+
+func (r *rateLimitManager) readyTimeForTask(task *internalTask) simpleLimiter {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// TODO(pri): after we have task-specific ready time, we can re-enable this
+	// if task.isForwarded() {
+	// 	// don't count any rate limit for forwarded tasks, it was counted on the child
+	// 	return 0
+	// }
+	ready := r.wholeQueueReady
+
+	if r.perKeyLimit.limited() {
+		key := task.getPriority().GetFairnessKey()
+		if v := r.perKeyReady.Get(key); v != nil {
+			ready = max(ready, v.(simpleLimiter))
+		}
+	}
+
+	return ready
+}
+
+func (r *rateLimitManager) consumeTokens(now int64, task *internalTask, tokens int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if task.isForwarded() {
+		// don't count any rate limit for forwarded tasks, it was counted on the child
+		return
+	}
+
+	r.wholeQueueReady = r.wholeQueueReady.consume(r.wholeQueueLimit, now, tokens)
+
+	if r.perKeyLimit.limited() {
+		pri := task.getPriority()
+		key := pri.GetFairnessKey()
+		weight := getEffectiveWeight(r.perKeyOverrides, pri)
+		p := r.perKeyLimit
+		p.interval = time.Duration(float32(p.interval) / weight) // scale by weight
+		var sl simpleLimiter
+		if v := r.perKeyReady.Get(key); v != nil {
+			sl = v.(simpleLimiter) // nolint:revive
+		}
+		r.perKeyReady.Put(key, sl.consume(p, now, tokens))
+	}
+}
+
+func (r *rateLimitManager) Stop() {
+	for _, cancel := range r.cancels {
+		cancel()
+	}
 }

--- a/service/matching/ratelimit_manager_test.go
+++ b/service/matching/ratelimit_manager_test.go
@@ -1,0 +1,91 @@
+package matching
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/tqid"
+)
+
+type RateLimitManagerSuite struct {
+	suite.Suite
+	*require.Assertions
+}
+
+func TestRateLimitManagerSuite(t *testing.T) {
+	suite.Run(t, new(RateLimitManagerSuite))
+}
+
+func (s *RateLimitManagerSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *RateLimitManagerSuite) TestUpdatePerKeySimpleRateLimitLocked_WhenFairnessKeyRateLimitDefaultIsNil() {
+	mockUserDataManager := &mockUserDataManager{}
+	config := newTaskQueueConfig(
+		tqid.UnsafeTaskQueueFamily("test-namespace", "test-task-queue").TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY),
+		NewConfig(dynamicconfig.NewNoopCollection()),
+		"test-namespace",
+	)
+	rateLimitManager := newRateLimitManager(mockUserDataManager, config, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+	rateLimitManager.mu.Lock()
+	// Simulate the condition where fairnessKeyRateLimitDefault is nil
+	rateLimitManager.fairnessKeyRateLimitDefault = nil
+	// Add per-key ready entries to verify they get cleared
+	rateLimitManager.perKeyReady.Put("key1", simpleLimiter(1000))
+	rateLimitManager.perKeyReady.Put("key2", simpleLimiter(2000))
+	// Set per-key limit to verify it gets cleared
+	rateLimitManager.perKeyLimit = simpleLimiterParams{
+		interval: time.Second,
+		burst:    10,
+	}
+	// Verify initial state
+	s.Equal(2, rateLimitManager.perKeyReady.Size())
+	s.True(rateLimitManager.perKeyLimit.limited())
+	// Update the per-key simple rate limit with fairnessKeyRateLimitDefault as nil
+	rateLimitManager.updatePerKeySimpleRateLimitLocked(time.Second)
+	// Verify that clearPerKeyRateLimitsLocked was called
+	// The cache should be replaced with a new empty cache
+	s.Equal(0, rateLimitManager.perKeyReady.Size(), "All per-key ready entries should be cleared")
+	s.False(rateLimitManager.perKeyLimit.limited(), "Per-key limit should be cleared")
+	rateLimitManager.mu.Unlock()
+}
+
+// Additions to rateLimitManager for use by other unit tests:
+
+func (r *rateLimitManager) UpdateSimpleRateLimitForTesting(burstDuration time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.updateSimpleRateLimitLocked(burstDuration)
+}
+
+func (r *rateLimitManager) UpdatePerKeySimpleRateLimitForTesting(burstDuration time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.updatePerKeySimpleRateLimitLocked(burstDuration)
+}
+
+func (r *rateLimitManager) SetAdminRateForTesting(rps float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adminNsRate = rps
+	r.adminTqRate = rps
+}
+
+func (r *rateLimitManager) SetEffectiveRPSAndSourceForTesting(rps float64, source enumspb.RateLimitSource) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.effectiveRPS = rps
+	r.fairnessKeyRateLimitDefault = &rps
+	r.rateLimitSource = source
+}
+
+func (r *rateLimitManager) SetFairnessKeyRateLimitDefaultForTesting(rps float64, source enumspb.RateLimitSource) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.fairnessKeyRateLimitDefault = &rps
+}

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -132,6 +132,7 @@ func (pm *taskQueuePartitionManagerImpl) GetRateLimitManager() *rateLimitManager
 // Stop does not unload the partition from matching engine. It is intended to be called by matching engine when
 // unloading the partition. For stopping and unloading a partition call unloadFromEngine instead.
 func (pm *taskQueuePartitionManagerImpl) Stop(unloadCause unloadCause) {
+	pm.rateLimitManager.Stop()
 	pm.versionedQueuesLock.Lock()
 	defer pm.versionedQueuesLock.Unlock()
 	for _, vq := range pm.versionedQueues {

--- a/tests/task_queue_test.go
+++ b/tests/task_queue_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -19,8 +22,11 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/testing/taskpoller"
 	"go.temporal.io/server/common/testing/testvars"
 	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type TaskQueueSuite struct {
@@ -167,6 +173,86 @@ func (s *TaskQueueSuite) testTaskQueueRateLimitName(nPartitions, nWorkers int, u
 	return "OldMatching_" + ret
 }
 
+// configureRateLimitAndLaunchWorkflows sets up the test environment to validate task queue API rate limiting behavior.
+//   - Applies an API-level RPS override on the activity task queue by calling the updateTaskQueueConfig api.
+//   - Starts an activity worker with a specified worker-side RPS limit.
+//   - Starts a workflow worker that dispatches activities to the activity queue.
+//   - Launches a given number of workflows that each execute a single activity.
+//   - Tracks the time each activity is executed (via runTimes) for test assertions.
+//   - Returns the context, cancel function, and both workers so the caller can manage their lifecycle.
+func (s *TaskQueueSuite) configureRateLimitAndLaunchWorkflows(
+	activityTaskQueue string,
+	activityName string,
+	taskCount int,
+	workerRPS float64,
+	drainTimeout time.Duration,
+	runTimes *[]time.Time,
+	wg *sync.WaitGroup,
+	apiRPS float64,
+	mu *sync.Mutex,
+) (ctx context.Context, cancel context.CancelFunc, activityWorker worker.Worker, wfWorker worker.Worker) {
+	tv := testvars.New(s.T())
+	// Apply API rate limit on `activityTaskQueue`
+	_, err := s.FrontendClient().UpdateTaskQueueConfig(context.Background(), &workflowservice.UpdateTaskQueueConfigRequest{
+		Namespace:     s.Namespace().String(),
+		Identity:      tv.ClientIdentity(),
+		TaskQueue:     activityTaskQueue,
+		TaskQueueType: enumspb.TASK_QUEUE_TYPE_ACTIVITY,
+		UpdateQueueRateLimit: &workflowservice.UpdateTaskQueueConfigRequest_RateLimitUpdate{
+			RateLimit: &taskqueuepb.RateLimit{RequestsPerSecond: float32(apiRPS)},
+			Reason:    "Test API override",
+		},
+	})
+	s.NoError(err)
+
+	wg.Add(taskCount)
+	// Track activity run times
+	activityFunc := func(context.Context) error {
+		defer wg.Done()
+		mu.Lock()
+		*runTimes = append(*runTimes, time.Now())
+		time.Sleep(250 * time.Millisecond) //nolint
+		mu.Unlock()
+		return nil
+	}
+
+	workflowFn := func(ctx workflow.Context) error {
+		ao := workflow.ActivityOptions{
+			// Route activity tasks to a dedicated task queue named `activityTaskQueue`.
+			// This isolates the test by ensuring that only the dedicated worker polls the queue
+			TaskQueue:           activityTaskQueue,
+			StartToCloseTimeout: 5 * time.Second,
+		}
+		ctx = workflow.WithActivityOptions(ctx, ao)
+		return workflow.ExecuteActivity(ctx, activityName).Get(ctx, nil)
+	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), drainTimeout)
+
+	// Start the activity worker
+	activityWorker = worker.New(s.SdkClient(), activityTaskQueue, worker.Options{
+		// Setting rate limit at worker level (this will be ignored in favor of the limit set through the api)
+		TaskQueueActivitiesPerSecond: workerRPS,
+	})
+	activityWorker.RegisterActivityWithOptions(activityFunc, activity.RegisterOptions{Name: activityName})
+	s.NoError(activityWorker.Start())
+
+	// Start the workflow worker
+	wfWorker = worker.New(s.SdkClient(), tv.TaskQueue().GetName(), worker.Options{})
+	wfWorker.RegisterWorkflow(workflowFn)
+	s.NoError(wfWorker.Start())
+
+	// Launch workflows
+	for i := range taskCount {
+		_, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+			TaskQueue: tv.TaskQueue().GetName(),
+			ID:        fmt.Sprintf("wf-%d", i),
+		}, workflowFn)
+		s.NoError(err)
+	}
+	return ctx, cancel, activityWorker, wfWorker
+}
+
 // TestTaskQueueAPIRateLimitOverridesWorkerLimit tests that the API rate limit overrides the worker rate limit.
 // It sets the API rate limit on a task queue to 5 RPS and then launches 25 activities.
 // Burst = 5 i.e max(int(math.Ceil(effectiveRPSPartitionWise)), r.config.MinTaskThrottlingBurstSize())
@@ -178,7 +264,7 @@ func (s *TaskQueueSuite) TestTaskQueueAPIRateLimitOverridesWorkerLimit() {
 	const (
 		apiRPS            = 5.0
 		taskCount         = 25
-		buffer            = time.Second
+		buffer            = time.Duration(3.5 * float64(time.Second)) // High Buffer to account for test flakiness
 		activityTaskQueue = "RateLimitTest"
 	)
 	expectedTotal := time.Duration(float64(taskCount-int(apiRPS))/apiRPS) * time.Second
@@ -199,67 +285,21 @@ func (s *TaskQueueSuite) TestTaskQueueAPIRateLimitOverridesWorkerLimit() {
 		drainTimeout = 10 * time.Second
 		activityName = "trackableActivity"
 	)
-	tv := testvars.New(s.T())
-	// Apply API rate limit on `activityTaskQueue`
-	_, err := s.FrontendClient().UpdateTaskQueueConfig(context.Background(), &workflowservice.UpdateTaskQueueConfigRequest{
-		Namespace:     s.Namespace().String(),
-		Identity:      tv.ClientIdentity(),
-		TaskQueue:     activityTaskQueue,
-		TaskQueueType: enumspb.TASK_QUEUE_TYPE_ACTIVITY,
-		UpdateQueueRateLimit: &workflowservice.UpdateTaskQueueConfigRequest_RateLimitUpdate{
-			RateLimit: &taskqueuepb.RateLimit{RequestsPerSecond: apiRPS},
-			Reason:    "Test API override",
-		},
-	})
-	s.NoError(err)
 
-	wg.Add(taskCount)
-	// Track activity run times
-	activityFunc := func(context.Context) error {
-		defer wg.Done()
-		mu.Lock()
-		runTimes = append(runTimes, time.Now())
-		mu.Unlock()
-		return nil
-	}
-
-	workflowFn := func(ctx workflow.Context) error {
-		ao := workflow.ActivityOptions{
-			// Route activity tasks to a dedicated task queue named `activityTaskQueue`.
-			// This isolates the test by ensuring that only the dedicated worker polls the queue
-			TaskQueue:           activityTaskQueue,
-			StartToCloseTimeout: 5 * time.Second,
-		}
-		ctx = workflow.WithActivityOptions(ctx, ao)
-		return workflow.ExecuteActivity(ctx, activityName).Get(ctx, nil)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+	_, cancel, activityWorker, wfWorker := s.configureRateLimitAndLaunchWorkflows(
+		activityTaskQueue,
+		activityName,
+		taskCount,
+		workerRPS,
+		drainTimeout,
+		&runTimes,
+		&wg,
+		apiRPS,
+		&mu,
+	)
 	defer cancel()
-
-	// Start the activity worker
-	activityWorker := worker.New(s.SdkClient(), activityTaskQueue, worker.Options{
-		// Setting rate limit at worker level (this will be ignored in favor of the limit set through the api)
-		TaskQueueActivitiesPerSecond: workerRPS,
-	})
-	activityWorker.RegisterActivityWithOptions(activityFunc, activity.RegisterOptions{Name: activityName})
-	s.NoError(activityWorker.Start())
 	defer activityWorker.Stop()
-
-	// Start the workflow worker
-	wfWorker := worker.New(s.SdkClient(), tv.TaskQueue().GetName(), worker.Options{})
-	wfWorker.RegisterWorkflow(workflowFn)
-	s.NoError(wfWorker.Start())
 	defer wfWorker.Stop()
-
-	// Launch workflows
-	for i := range taskCount {
-		_, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
-			TaskQueue: tv.TaskQueue().GetName(),
-			ID:        fmt.Sprintf("wf-%d", i),
-		}, workflowFn)
-		s.NoError(err)
-	}
 
 	// Wait for all activities to complete
 	s.True(common.AwaitWaitGroup(&wg, drainTimeout), "timeout waiting for activities to complete")
@@ -268,6 +308,384 @@ func (s *TaskQueueSuite) TestTaskQueueAPIRateLimitOverridesWorkerLimit() {
 	totalGap := runTimes[len(runTimes)-1].Sub(runTimes[0])
 	s.GreaterOrEqual(totalGap, expectedTotal-buffer, "Activity run time too short — API rate limit override not taking effect over the worker rate limit")
 	s.LessOrEqual(totalGap, expectedTotal+buffer, "Activity run time too long — API rate limit override not enforced as expected")
+}
+
+// TestTaskQueueAPIRateLimitZero ensures that when the API rate limit is set to 0,
+// no activity tasks are dispatched. Also checks if the rate limit is set to 0,
+// then the burst is defaulted to 0 to prevent any initial tasks from executing immediately.
+func (s *TaskQueueSuite) TestTaskQueueAPIRateLimitZero() {
+	const (
+		apiRPS            = 0.0
+		taskCount         = 10
+		drainTimeout      = 3 * time.Second
+		activityTaskQueue = "RateLimitTestZero"
+	)
+
+	// Override configs
+	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
+	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
+	s.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond)
+
+	var (
+		mu       sync.Mutex
+		runTimes []time.Time
+		wg       sync.WaitGroup
+	)
+
+	const (
+		workerRPS    = 50.0
+		activityName = "noopActivity"
+	)
+
+	_, cancel, activityWorker, wfWorker := s.configureRateLimitAndLaunchWorkflows(
+		activityTaskQueue,
+		activityName,
+		taskCount,
+		workerRPS,
+		drainTimeout,
+		&runTimes,
+		&wg,
+		apiRPS,
+		&mu,
+	)
+	defer cancel()
+	defer activityWorker.Stop()
+	defer wfWorker.Stop()
+
+	// Wait for the duration and ensure no tasks executed
+	s.False(common.AwaitWaitGroup(&wg, drainTimeout), "Some activities unexpectedly completed despite API RPS = 0")
+	s.Len(runTimes, 0, "No activities should run when API rate limit is 0")
+}
+
+func (s *TaskQueueSuite) TestTaskQueueRateLimit_UpdateFromWorkerConfigAndAPI() {
+	const (
+		workerSetRPS      = 2.0 // Worker rate limit for activities
+		apiSetRPS         = 4.0 // API rate limit for activities set to half of workerSetRPS to test override behavior
+		taskCount         = 12  // Number of tasks to launch
+		activityTaskQueue = "RateLimitTest_Update"
+		drainTimeout      = 15 * time.Second // 5 second additional buffer to prevent flakiness
+		buffer            = 3 * time.Second  // Increased buffer to prevent flakes
+		activityName      = "timedActivity"
+	)
+
+	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
+	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
+	s.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond)
+
+	var (
+		mu       sync.Mutex
+		runTimes []time.Time
+		wg       sync.WaitGroup
+	)
+
+	wg.Add(taskCount)
+
+	// Activity: record run time
+	activityFunc := func(ctx context.Context) error {
+		defer wg.Done()
+		mu.Lock()
+		runTimes = append(runTimes, time.Now())
+		mu.Unlock()
+		return nil
+	}
+
+	// Workflow: calls the activity
+	workflowFn := func(ctx workflow.Context) error {
+		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			TaskQueue:           activityTaskQueue,
+			StartToCloseTimeout: 5 * time.Second,
+		})
+		return workflow.ExecuteActivity(ctx, activityName).Get(ctx, nil)
+	}
+
+	// Start activity worker
+	activityWorker := worker.New(s.SdkClient(), activityTaskQueue, worker.Options{
+		TaskQueueActivitiesPerSecond: workerSetRPS, // worker set RPS should take effect initially
+	})
+	activityWorker.RegisterActivityWithOptions(activityFunc, activity.RegisterOptions{Name: activityName})
+	s.NoError(activityWorker.Start())
+	defer activityWorker.Stop()
+
+	// Start workflow worker
+	tv := testvars.New(s.T())
+	wfWorker := worker.New(s.SdkClient(), tv.TaskQueue().GetName(), worker.Options{})
+	wfWorker.RegisterWorkflow(workflowFn)
+	s.NoError(wfWorker.Start())
+	defer wfWorker.Stop()
+
+	// Launch workflows under workerSetRPS
+	for i := range taskCount {
+		_, err := s.SdkClient().ExecuteWorkflow(context.Background(), sdkclient.StartWorkflowOptions{
+			TaskQueue: tv.TaskQueue().GetName(),
+			ID:        fmt.Sprintf("wf-dynamic-%d", i),
+		}, workflowFn)
+		s.NoError(err)
+	}
+
+	s.True(common.AwaitWaitGroup(&wg, drainTimeout), "tasks with dynamic config didn't complete")
+	s.Len(runTimes, taskCount, "task count mismatch")
+
+	// Measure duration with workerSetRPS config
+	firstGap := runTimes[len(runTimes)-1].Sub(runTimes[0])
+
+	// Reset for API override phase
+	runTimes = nil
+	wg.Add(taskCount)
+
+	//  Apply API rate limit override workerSetRPS to set the effective RPS to apiSetRPS
+	_, err := s.FrontendClient().UpdateTaskQueueConfig(context.Background(), &workflowservice.UpdateTaskQueueConfigRequest{
+		Namespace:     s.Namespace().String(),
+		Identity:      tv.ClientIdentity(),
+		TaskQueue:     activityTaskQueue,
+		TaskQueueType: enumspb.TASK_QUEUE_TYPE_ACTIVITY,
+		UpdateQueueRateLimit: &workflowservice.UpdateTaskQueueConfigRequest_RateLimitUpdate{
+			RateLimit: &taskqueuepb.RateLimit{RequestsPerSecond: float32(apiSetRPS)},
+			Reason:    "test api override",
+		},
+	})
+	s.NoError(err)
+
+	require.Eventually(s.T(), func() bool {
+		describeResp, err := s.FrontendClient().DescribeTaskQueue(context.Background(), &workflowservice.DescribeTaskQueueRequest{
+			Namespace:     s.Namespace().String(),
+			TaskQueue:     &taskqueuepb.TaskQueue{Name: activityTaskQueue},
+			TaskQueueType: enumspb.TASK_QUEUE_TYPE_ACTIVITY,
+			ReportConfig:  true,
+		})
+		if err != nil {
+			return false
+		}
+		cfg := describeResp.GetConfig()
+		rl := cfg.GetQueueRateLimit().GetRateLimit()
+		if rl == nil {
+			s.T().Logf("Rate limit not set in Persistence")
+			return false
+		}
+		if rl.GetRequestsPerSecond() == float32(apiSetRPS) {
+			s.T().Logf("Rate limit set in Persistence: %v", rl.GetRequestsPerSecond())
+			return true
+		}
+		return false
+	}, 3*time.Second, 100*time.Millisecond, "DescribeTaskQueue did not reflect override")
+
+	// Launch workflows under API override
+	for i := range taskCount {
+		_, err := s.SdkClient().ExecuteWorkflow(context.Background(), sdkclient.StartWorkflowOptions{
+			TaskQueue: tv.TaskQueue().GetName(),
+			ID:        fmt.Sprintf("wf-api-%d", i),
+		}, workflowFn)
+		s.NoError(err)
+	}
+
+	s.True(common.AwaitWaitGroup(&wg, drainTimeout), "tasks with API override didn't complete")
+	s.Len(runTimes, taskCount, "task count mismatch after API override")
+
+	// Measure duration with API override
+	secondGap := runTimes[len(runTimes)-1].Sub(runTimes[0])
+	s.T().Logf("Completion time for First set of Activity tasks: %v, Second Activity tasks: %v", firstGap, secondGap)
+
+	// first gap must be ideally twice as larger as the effective RPS is doubled
+	// To avoid flakiness, we allow a buffer of 1.5x the first gap along with an additional buffer of 3s
+	s.Greater(firstGap, time.Duration(1.5*float64(secondGap))-buffer,
+		"Expected ~2x span at 2 rps vs 4 rps: first=%v (2rps) second=%v (4rps)",
+		firstGap, secondGap)
+}
+
+func (s *TaskQueueSuite) setupPerKeyRateLimitWorkflow(
+	ctx context.Context,
+	tv *testvars.TestVars,
+	keys []string,
+	tasksPerKey int,
+	wholeQueueRPS float64,
+	perKeyRPS float64,
+) (map[string][]time.Time, []time.Time) {
+
+	total := len(keys) * tasksPerKey
+
+	// Enable fairness
+	s.OverrideDynamicConfig(dynamicconfig.MatchingEnableFairness, true)
+	// Single partition for simplicity.
+	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
+	s.OverrideDynamicConfig(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
+	// Fast refresh so limiter state picks up config quickly.
+	s.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond)
+
+	// generate a unique base so IDs don't collide across shards/tests
+	base := uuid.NewString()
+	parsePattern := fmt.Sprintf("perkey-wf-%s-%%d", base) // for Sscanf later
+
+	// Set up the task queue config with whole-queue and per-key rate limits.
+	_, err := s.FrontendClient().UpdateTaskQueueConfig(ctx, &workflowservice.UpdateTaskQueueConfigRequest{
+		Namespace:     s.Namespace().String(),
+		Identity:      tv.ClientIdentity(),
+		TaskQueue:     tv.TaskQueue().GetName(),
+		TaskQueueType: enumspb.TASK_QUEUE_TYPE_ACTIVITY,
+		UpdateQueueRateLimit: &workflowservice.UpdateTaskQueueConfigRequest_RateLimitUpdate{
+			RateLimit: &taskqueuepb.RateLimit{RequestsPerSecond: float32(wholeQueueRPS)},
+			Reason:    "test: whole-queue limit",
+		},
+		UpdateFairnessKeyRateLimitDefault: &workflowservice.UpdateTaskQueueConfigRequest_RateLimitUpdate{
+			RateLimit: &taskqueuepb.RateLimit{RequestsPerSecond: float32(perKeyRPS)},
+			Reason:    "test: per-key default",
+		},
+	})
+	s.NoError(err)
+
+	// Start workflows (each will schedule one activity tagged with a fairness key).
+	for i := range total {
+		wfID := fmt.Sprintf("perkey-wf-%s-%d", base, i)
+		_, err := s.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+			Namespace:    s.Namespace().String(),
+			WorkflowId:   wfID,
+			WorkflowType: tv.WorkflowType(),
+			TaskQueue:    tv.TaskQueue(),
+		})
+		s.NoError(err)
+	}
+
+	// Drain workflow tasks -> schedule activities with Priority.FairnessKey.
+	wfHandled := 0
+	for wfHandled < total {
+		if err := ctx.Err(); err != nil {
+			s.T().Fatalf("context deadline while draining workflow tasks: handled=%d/%d: %v", wfHandled, total, err)
+		}
+		_, err := s.TaskPoller().PollAndHandleWorkflowTask(
+			tv,
+			func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+				s.Equal(3, len(task.History.Events))
+
+				var idx int
+				_, scanErr := fmt.Sscanf(task.WorkflowExecution.WorkflowId, parsePattern, &idx)
+				s.NoError(scanErr)
+
+				key := keys[idx%len(keys)]
+				input, encErr := payloads.Encode(key)
+				s.NoError(encErr)
+
+				cmd := &commandpb.Command{
+					CommandType: enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK,
+					Attributes: &commandpb.Command_ScheduleActivityTaskCommandAttributes{
+						ScheduleActivityTaskCommandAttributes: &commandpb.ScheduleActivityTaskCommandAttributes{
+							ActivityId:             fmt.Sprintf("act-%d", idx),
+							ActivityType:           tv.ActivityType(),
+							TaskQueue:              tv.TaskQueue(),
+							ScheduleToCloseTimeout: durationpb.New(30 * time.Second),
+							Priority:               &commonpb.Priority{FairnessKey: key},
+							Input:                  input,
+						},
+					},
+				}
+				return &workflowservice.RespondWorkflowTaskCompletedRequest{Commands: []*commandpb.Command{cmd}}, nil
+			},
+			taskpoller.WithContext(ctx),
+		)
+		if err == nil {
+			wfHandled++
+		}
+	}
+	s.Equal(total, wfHandled)
+
+	// Drain activity tasks, recording times.
+	perKeyTimes := make(map[string][]time.Time, len(keys))
+	for _, k := range keys {
+		perKeyTimes[k] = []time.Time{}
+	}
+	allTimes := make([]time.Time, 0, total)
+
+	actsHandled := 0
+	for actsHandled < total {
+		if err := ctx.Err(); err != nil {
+			s.T().Fatalf("context deadline while draining activity tasks: handled=%d/%d: %v", actsHandled, total, err)
+		}
+		_, err := s.TaskPoller().PollAndHandleActivityTask(
+			tv,
+			func(task *workflowservice.PollActivityTaskQueueResponse) (*workflowservice.RespondActivityTaskCompletedRequest, error) {
+				var key string
+				s.NoError(payloads.Decode(task.Input, &key))
+				now := time.Now()
+				perKeyTimes[key] = append(perKeyTimes[key], now)
+				allTimes = append(allTimes, now)
+				nothing, encErr := payloads.Encode()
+				s.NoError(encErr)
+				return &workflowservice.RespondActivityTaskCompletedRequest{Result: nothing}, nil
+			},
+			taskpoller.WithContext(ctx),
+		)
+		if err == nil {
+			actsHandled++
+		}
+	}
+	s.Equal(total, actsHandled)
+
+	// perKeyTimes : Used to verify that each key's activities are throttled correctly.
+	// allTimes : Used to verify the overall throughput of the task queue.
+	return perKeyTimes, allTimes
+}
+
+func (s *TaskQueueSuite) TestWholeQueueLimit_TighterThanPerKeyDefault_IsEnforced() {
+	const (
+		wholeQueueRPS = 10.0 // tighter
+		perKeyRPS     = 50.0 // looser than whole queue, should not bind
+		tasksPerKey   = 30
+		buffer        = 3 * time.Second // CI jitter
+	)
+	keys := []string{"A", "B", "C"}
+	tv := testvars.New(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, allTimes := s.setupPerKeyRateLimitWorkflow(ctx, tv, keys, tasksPerKey, wholeQueueRPS, perKeyRPS)
+
+	// Measure overall throughput after initial burst, which should be limited by wholeQueueRPS.
+	start := allTimes[0]
+	end := allTimes[len(allTimes)-1]
+
+	expected := time.Duration(float64(tasksPerKey*len(keys))/wholeQueueRPS) * time.Second
+	actual := end.Sub(start)
+
+	s.T().Logf("Time taken for tasks across fairness keys to drain is %v vs expected %v", actual, expected)
+	s.GreaterOrEqual(actual, expected-buffer,
+		"whole-queue RPS violated: actual %v < expected %v (-%v buffer)", actual, expected, buffer)
+
+	s.LessOrEqual(actual, expected+buffer,
+		"too slow overall: actual %v > expected %v (+%v buffer)", actual, expected, buffer)
+}
+
+func (s *TaskQueueSuite) TestPerKeyRateLimit_Default_IsEnforcedAcrossThreeKeys() {
+	const (
+		perKeyRPS     = 5.0
+		wholeQueueRPS = 1000.0 // tighter
+		tasksPerKey   = 30
+		buffer        = 3 * time.Second // relax for CI jitter
+	)
+	keys := []string{"A", "B", "C"}
+
+	tv := testvars.New(s.T())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	perKeyTimes, _ := s.setupPerKeyRateLimitWorkflow(ctx, tv, keys, tasksPerKey, wholeQueueRPS, perKeyRPS)
+
+	for _, key := range keys {
+		times := perKeyTimes[key]
+		s.Len(times, tasksPerKey, "unexpected count for key %s", key)
+
+		start := times[0]
+		end := times[len(times)-1]
+
+		expected := time.Duration(float64(tasksPerKey)/perKeyRPS) * time.Second
+		actual := end.Sub(start)
+
+		s.T().Logf("Time taken for fairness key %s to drain : %v vs expected %v", key, actual, expected)
+		s.GreaterOrEqual(actual, expected-buffer,
+			"per-key RPS violated for key %s: actual %v < expected %v (-%v buffer)",
+			key, actual, expected)
+
+		s.LessOrEqual(actual, expected+buffer,
+			"too slow for key %s: actual %v > expected %v (+%v buffer)", key, actual, expected, buffer)
+	}
 }
 
 // TestUpdateAndDescribeTaskQueueConfig tests the update and describe task queue config functionality.


### PR DESCRIPTION
## What changed?

- Move the rate limit logic for fairness from priMatcher to taskQueuePartitionManagerLevel
- Attach the fairness queue rate limit and the per-key rate limit to the simple rate limiter implementation.

## Why?

- Implementation of UpdateTaskQueueConfig api for fairness tasks.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks
- Need to debug flaky tests post attaching the fairness simple rate limiter.
