### PR TITLE
Add dc to expose Authorizer errors

### DIFF
--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -76,14 +77,15 @@ func PeerCert(tlsInfo *credentials.TLSInfo) *x509.Certificate {
 }
 
 type Interceptor struct {
-	claimMapper         ClaimMapper
-	authorizer          Authorizer
-	metricsHandler      metrics.Handler
-	logger              log.Logger
-	namespaceChecker    NamespaceChecker
-	audienceGetter      JWTAudienceMapper
-	authHeaderName      string
-	authExtraHeaderName string
+	claimMapper            ClaimMapper
+	authorizer             Authorizer
+	metricsHandler         metrics.Handler
+	logger                 log.Logger
+	namespaceChecker       NamespaceChecker
+	audienceGetter         JWTAudienceMapper
+	authHeaderName         string
+	authExtraHeaderName    string
+	exposeAuthorizerErrors dynamicconfig.BoolPropertyFn
 }
 
 // NewInterceptor creates an authorization interceptor.
@@ -96,6 +98,7 @@ func NewInterceptor(
 	audienceGetter JWTAudienceMapper,
 	authHeaderName string,
 	authExtraHeaderName string,
+	exposeAuthorizerErrors dynamicconfig.BoolPropertyFn,
 ) *Interceptor {
 	return &Interceptor{
 		claimMapper:         claimMapper,
@@ -222,6 +225,9 @@ func (a *Interceptor) Authorize(ctx context.Context, claims *Claims, ct *CallTar
 	if err != nil {
 		metrics.ServiceErrAuthorizeFailedCounter.With(mh).Record(1)
 		a.logger.Error("Authorization error", tag.Error(err))
+		if a.exposeAuthorizerErrors != nil && a.exposeAuthorizerErrors() {
+			return err
+		}
 		return errUnauthorized // return a generic error to the caller without disclosing details
 	}
 	if result.Decision != DecisionAllow {

--- a/common/authorization/interceptor_test.go
+++ b/common/authorization/interceptor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -73,6 +74,7 @@ func (s *authorizerInterceptorSuite) SetupTest() {
 		nil,
 		"",
 		"",
+		dynamicconfig.GetBoolPropertyFn(false),
 	)
 	s.handler = func(ctx context.Context, req interface{}) (interface{}, error) { return true, nil }
 }
@@ -155,6 +157,7 @@ func (s *authorizerInterceptorSuite) TestNoopClaimMapperWithoutTLS() {
 		nil,
 		"",
 		"",
+		dynamicconfig.GetBoolPropertyFn(false),
 	)
 	_, err := interceptor.Intercept(ctx, describeNamespaceRequest, describeNamespaceInfo, s.handler)
 	s.NoError(err)
@@ -170,6 +173,7 @@ func (s *authorizerInterceptorSuite) TestAlternateHeaders() {
 		nil,
 		"custom-header",
 		"custom-extra-header",
+		dynamicconfig.GetBoolPropertyFn(false),
 	)
 
 	cases := []struct {

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -785,6 +785,12 @@ This config is EXPERIMENTAL and may be changed or removed in a later release.`,
 		false,
 		`DisableListVisibilityByFilter is config to disable list open/close workflow using filter`,
 	)
+	ExposeAuthorizerErrors = NewGlobalBoolSetting(
+		"frontend.exposeAuthorizerErrors",
+		false,
+		`ExposeAuthorizerErrors controls whether the frontend authorization interceptor will pass through errors returned by
+the Authorizer component. If false, a generic PermissionDenied error without details will be returned. Default false.`,
+	)
 	KeepAliveMinTime = NewGlobalDurationSetting(
 		"frontend.keepAliveMinTime",
 		10*time.Second,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -152,6 +152,7 @@ type GrpcServerOptions struct {
 
 func AuthorizationInterceptorProvider(
 	cfg *config.Config,
+	serviceConfig *Config,
 	logger log.Logger,
 	namespaceChecker authorization.NamespaceChecker,
 	metricsHandler metrics.Handler,
@@ -168,6 +169,7 @@ func AuthorizationInterceptorProvider(
 		audienceGetter,
 		cfg.Global.Authorization.AuthHeaderName,
 		cfg.Global.Authorization.AuthExtraHeaderName,
+		serviceConfig.ExposeAuthorizerErrors,
 	)
 }
 

--- a/service/frontend/nexus_handler_test.go
+++ b/service/frontend/nexus_handler_test.go
@@ -117,7 +117,7 @@ func newOperationContext(options contextOptions) *operationContext {
 	)
 
 	checker := mockNamespaceChecker(oc.namespace.Name())
-	oc.auth = authorization.NewInterceptor(nil, mockAuthorizer{}, oc.metricsHandler, oc.logger, checker, nil, "", "")
+	oc.auth = authorization.NewInterceptor(nil, mockAuthorizer{}, oc.metricsHandler, oc.logger, checker, nil, "", "", dynamicconfig.GetBoolPropertyFn(false))
 	oc.namespaceConcurrencyLimitInterceptor = interceptor.NewConcurrentRequestLimitInterceptor(
 		nil,
 		nil,

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -115,6 +115,9 @@ type Config struct {
 	// EnableTokenNamespaceEnforcement enables enforcement that namespace in completion token matches namespace of the request
 	EnableTokenNamespaceEnforcement dynamicconfig.BoolPropertyFn
 
+	// ExposeAuthorizerErrors controls whether errors returned by the Authorizer will be wrapped with a PermissionDenied error.
+	ExposeAuthorizerErrors dynamicconfig.BoolPropertyFn
+
 	// gRPC keep alive options
 	// If a client pings too frequently, terminate the connection.
 	KeepAliveMinTime dynamicconfig.DurationPropertyFn
@@ -285,6 +288,7 @@ func NewConfig(
 		DefaultWorkflowTaskTimeout:               dynamicconfig.DefaultWorkflowTaskTimeout.Get(dc),
 		EnableServerVersionCheck:                 dynamicconfig.EnableServerVersionCheck.Get(dc),
 		EnableTokenNamespaceEnforcement:          dynamicconfig.EnableTokenNamespaceEnforcement.Get(dc),
+		ExposeAuthorizerErrors:                   dynamicconfig.ExposeAuthorizerErrors.Get(dc),
 		KeepAliveMinTime:                         dynamicconfig.KeepAliveMinTime.Get(dc),
 		KeepAlivePermitWithoutStream:             dynamicconfig.KeepAlivePermitWithoutStream.Get(dc),
 		KeepAliveMaxConnectionIdle:               dynamicconfig.KeepAliveMaxConnectionIdle.Get(dc),


### PR DESCRIPTION
## What changed?
Added a new dynamic config to control whether the frontend authorization interceptor should expose errors returned by the `Authorizer` component. Previously (now default), if the `Authorizer` returned an error, the intercepter would always return a generic `PermissionDenied` error without details.

## Why?
Authorizers may fail with errors that should not be translated into `PermissionDenied`
