### PR TITLE
[Scheduled Actions] Clean up test suites' addedTasks checks

### DIFF
--- a/chasm/lib/scheduler/generator_tasks_test.go
+++ b/chasm/lib/scheduler/generator_tasks_test.go
@@ -82,8 +82,5 @@ func (s *generatorTasksSuite) TestExecuteBufferTask_Basic() {
 	// Ensure we scheduled an immediate physical pure task on the tree.
 	_, err = s.node.CloseTransaction()
 	s.NoError(err)
-	s.Equal(1, len(s.addedTasks))
-	task, ok := s.addedTasks[0].(*tasks.ChasmTaskPure)
-	s.True(ok)
-	s.Equal(chasm.TaskScheduledTimeImmediate, task.GetVisibilityTime())
+	s.True(s.hasTask(&tasks.ChasmTaskPure{}, chasm.TaskScheduledTimeImmediate))
 }

--- a/chasm/lib/scheduler/invoker_execute_task_test.go
+++ b/chasm/lib/scheduler/invoker_execute_task_test.go
@@ -16,7 +16,6 @@ import (
 	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/testing/mockapi/workflowservicemock/v1"
-	"go.temporal.io/server/service/history/tasks"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -339,9 +338,6 @@ func (s *invokerExecuteTaskSuite) runExecuteTestCase(c *executeTestCase) {
 	// component, within the same transition.
 	s.ExpectReadComponent(invoker)
 	s.ExpectUpdateComponent(invoker)
-
-	// Clear old tasks and run the execute task.
-	s.addedTasks = make([]tasks.Task, 0)
 
 	// Create engine context for side effect task execution
 	engineCtx := s.newEngineContext()

--- a/chasm/lib/scheduler/invoker_process_buffer_task_test.go
+++ b/chasm/lib/scheduler/invoker_process_buffer_task_test.go
@@ -13,7 +13,6 @@ import (
 	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/util"
-	"go.temporal.io/server/service/history/tasks"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -312,9 +311,6 @@ func (s *invokerProcessBufferTaskSuite) runProcessBufferTestCase(c *processBuffe
 
 	// Set LastProcessedTime to current time to ensure time checks pass
 	invoker.LastProcessedTime = timestamppb.New(s.timeSource.Now())
-
-	// Clear old tasks and run the process buffer task
-	s.addedTasks = make([]tasks.Task, 0)
 
 	err = s.executor.Execute(ctx, invoker, chasm.TaskAttributes{}, &schedulerpb.InvokerProcessBufferTask{})
 	s.NoError(err)

--- a/chasm/lib/scheduler/scheduler_suite_test.go
+++ b/chasm/lib/scheduler/scheduler_suite_test.go
@@ -2,6 +2,7 @@ package scheduler_test
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -84,6 +85,20 @@ func (s *schedulerSuite) SetupSuite() {
 	ctx := s.newMutableContext()
 	s.scheduler = scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, defaultSchedule(), nil)
 	s.node.SetRootComponent(s.scheduler)
+}
+
+// hasTask returns true if the given task type was added at the end of the
+// transaction with the given visibilityTime.
+func (s *schedulerSuite) hasTask(task any, visibilityTime time.Time) bool {
+	taskType := reflect.TypeOf(task)
+	for _, task := range s.addedTasks {
+		if reflect.TypeOf(task) == taskType &&
+			task.GetVisibilityTime().Equal(visibilityTime) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (s *schedulerSuite) newMutableContext() chasm.MutableContext {


### PR DESCRIPTION
## What changed?
- Cleaned up s.addedTasks within test suites

## Why?
- In preparation for adding the Visibility component, which itself also adds tasks (breaking some of the existing asserts).
- I manually verified that the backfiller is properly generating rescheduled tasks and that they validate in CloseTransaction.

## How did you test it?
- [ ] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
