### PR TITLE
Unconditionally return next workflow task in response to a task completed request

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1424,6 +1424,12 @@ timeout timer when execution timeout is specified when starting a workflow.`,
 		`EnableUpdateWorkflowModeIgnoreCurrent controls whether to enable the new logic for updating closed workflow execution
 by mutation using UpdateWorkflowModeIgnoreCurrent`,
 	)
+	EnableReturnNewWorkflowTaskUnconditionally = NewGlobalBoolSetting(
+		"history.enableNewWorkflowTaskUnconditionally",
+		false,
+		`enableNewWorkflowTaskUnconditionally controls whether the history service should return the next workflow task as part
+		of the response even if the SDK has set return_new_workflow_task to false. See OSS-2055.`,
+	)
 	EnableTransitionHistory = NewGlobalBoolSetting(
 		"history.enableTransitionHistory",
 		false,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -240,6 +240,7 @@ type Config struct {
 	WorkflowTaskCriticalAttempts                     dynamicconfig.IntPropertyFn
 	WorkflowTaskRetryMaxInterval                     dynamicconfig.DurationPropertyFn
 	DiscardSpeculativeWorkflowTaskMaximumEventsCount dynamicconfig.IntPropertyFn
+	EnableReturnNewWorkflowTaskUnconditionally       dynamicconfig.BoolPropertyFn
 
 	// The following is used by the new RPC replication stack
 	ReplicationTaskApplyTimeout                          dynamicconfig.DurationPropertyFn
@@ -589,6 +590,7 @@ func NewConfig(
 		WorkflowTaskCriticalAttempts:                     dynamicconfig.WorkflowTaskCriticalAttempts.Get(dc),
 		WorkflowTaskRetryMaxInterval:                     dynamicconfig.WorkflowTaskRetryMaxInterval.Get(dc),
 		DiscardSpeculativeWorkflowTaskMaximumEventsCount: dynamicconfig.DiscardSpeculativeWorkflowTaskMaximumEventsCount.Get(dc),
+		EnableReturnNewWorkflowTaskUnconditionally:       dynamicconfig.EnableReturnNewWorkflowTaskUnconditionally.Get(dc),
 
 		ReplicationTaskApplyTimeout:                  dynamicconfig.ReplicationTaskApplyTimeout.Get(dc),
 		ReplicationTaskFetcherParallelism:            dynamicconfig.ReplicationTaskFetcherParallelism.Get(dc),


### PR DESCRIPTION
## What changed?
The workflow task completion handler returns the next workflow task as part of the response even if the request has not asked for it.

This behavior is controlled by a dynamic config: EnableReturnNewWorkflowTaskUnconditionally
It is disabled by default. Therefore this change by itself is a noop.

## Why?
To standardize on a single worfkflow path in the history service. Always return the next task.

Context: The SDK can set the return_new_workflow_task to false when worker caching is disabled. This is because even if we returned the next task, the worker has to make an RPC to get the full history anyway.

With this change, we will incur an unnecessary extra RPC to fetch the history. But this is acceptable given production workloads are supposed to have caching enabled.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
This change by itself is a noop as it is guarded behind a flag (disabled).
Backwards compatibility: The SDK is expected to handle the case where it receives a new workflow task in the response when it does not have the fully history. So technically this should not break. The only concern is someone using a very old sdk version that does not handle this well.

For this, we can do 1 or more of these:
1. Add a metric to track who is still setting the request option to false, and vet out the impact radius.
2. Enable this flag in couple of SDK tests.
3. Gradually rollout the flag change. If we see customer reports, quickly disable it.

JIRA: OSS-2055, OSS-2057.

