### PR TITLE
Remove frontend.enableClientVersionCheck commented configs

### DIFF
--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -1,6 +1,3 @@
-#frontend.enableClientVersionCheck:
-#- value: true
-#  constraints: {}
 #history.persistenceMaxQPS:
 #- value: 3000
 #  constraints: {}

--- a/config/dynamicconfig/development-sql.yaml
+++ b/config/dynamicconfig/development-sql.yaml
@@ -1,6 +1,3 @@
-#frontend.enableClientVersionCheck:
-#- value: true
-#  constraints: {}
 #history.persistenceMaxQPS:
 #- value: 3000
 #  constraints: {}

--- a/config/dynamicconfig/development-xdc.yaml
+++ b/config/dynamicconfig/development-xdc.yaml
@@ -1,6 +1,3 @@
-#frontend.enableClientVersionCheck:
-#- value: true
-#  constraints: {}
 #history.persistenceMaxQPS:
 #- value: 3000
 #  constraints: {}


### PR DESCRIPTION
## Why?

The config was commented out in our development config files but has been removed from the codebase since v1.18.