### PR TITLE
[Scheduled Actions] Record ScheduleActionDelay in CHASM scheduler, remove some unused metric definitions

### DIFF
--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -547,9 +547,14 @@ func (e *InvokerExecuteTaskExecutor) startWorkflow(
 		return nil, err
 	}
 
+	// realTime may be slightly past the time of the action's first scheduled WFT.
+	realTime := time.Now()
+	desiredTime := start.ActualTime
+	e.MetricsHandler.Timer(metrics.ScheduleActionDelay.Name()).Record(realTime.Sub(desiredTime.AsTime()))
+
 	return &schedulepb.ScheduleActionResult{
-		ScheduleTime: start.ActualTime,
-		ActualTime:   timestamppb.New(time.Now()),
+		ScheduleTime: desiredTime,
+		ActualTime:   timestamppb.New(realTime),
 		StartWorkflowResult: &commonpb.WorkflowExecution{
 			WorkflowId: workflowID,
 			RunId:      result.RunId,

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1216,10 +1216,6 @@ var (
 		"schedule_action_success",
 		WithDescription("The number of schedule actions that were successfully taken by a schedule"),
 	)
-	ScheduleActionAttempt = NewCounterDef(
-		"schedule_action_attempt",
-		WithDescription("The number of schedule actions attempts"),
-	)
 	ScheduleActionErrors = NewCounterDef(
 		"schedule_action_errors",
 		WithDescription("The number of failed attempts from starting schedule actions"),
@@ -1235,10 +1231,6 @@ var (
 	ScheduleActionDelay = NewTimerDef(
 		"schedule_action_delay",
 		WithDescription("Delay between when scheduled actions should/actually happen"),
-	)
-	ScheduleActionDropped = NewCounterDef(
-		"schedule_action_dropped",
-		WithDescription("The number of schedule actions that failed to start"),
 	)
 
 	// Worker Versioning


### PR DESCRIPTION
## What changed?
- Did a pass on metrics for the CHASM scheduler and added the missing delay metric.
- A few of the old schedule metrics aren't used anywhere at all, so I've removed them.

## Why?
_Tell your future self why have you made these changes._

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
