### PR TITLE
create metric for MemStats.HeapReleased

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1306,20 +1306,21 @@ var (
 	PersistenceSQLInUse                    = NewGaugeDef("persistence_sql_in_use")
 
 	// Common service base metrics
-	RestartCount           = NewCounterDef("restarts")
-	NumGoRoutinesGauge     = NewGaugeDef("num_goroutines")
-	GoMaxProcsGauge        = NewGaugeDef("gomaxprocs")
-	MemoryAllocatedGauge   = NewGaugeDef("memory_allocated")
-	MemoryHeapGauge        = NewGaugeDef("memory_heap")
-	MemoryHeapObjectsGauge = NewGaugeDef("memory_heap_objects")
-	MemoryHeapIdleGauge    = NewGaugeDef("memory_heapidle")
-	MemoryHeapInuseGauge   = NewGaugeDef("memory_heapinuse")
-	MemoryStackGauge       = NewGaugeDef("memory_stack")
-	MemoryMallocsGauge     = NewGaugeDef("memory_mallocs")
-	MemoryFreesGauge       = NewGaugeDef("memory_frees")
-	NumGCCounter           = NewBytesHistogramDef("memory_num_gc")
-	GcPauseMsTimer         = NewTimerDef("memory_gc_pause_ms")
-	NumGCGauge             = NewGaugeDef("memory_num_gc_last",
+	RestartCount            = NewCounterDef("restarts")
+	NumGoRoutinesGauge      = NewGaugeDef("num_goroutines")
+	GoMaxProcsGauge         = NewGaugeDef("gomaxprocs")
+	MemoryAllocatedGauge    = NewGaugeDef("memory_allocated")
+	MemoryHeapGauge         = NewGaugeDef("memory_heap")
+	MemoryHeapObjectsGauge  = NewGaugeDef("memory_heap_objects")
+	MemoryHeapIdleGauge     = NewGaugeDef("memory_heapidle")
+	MemoryHeapInuseGauge    = NewGaugeDef("memory_heapinuse")
+	MemoryHeapReleasedGauge = NewGaugeDef("memory_heapreleased")
+	MemoryStackGauge        = NewGaugeDef("memory_stack")
+	MemoryMallocsGauge      = NewGaugeDef("memory_mallocs")
+	MemoryFreesGauge        = NewGaugeDef("memory_frees")
+	NumGCCounter            = NewBytesHistogramDef("memory_num_gc")
+	GcPauseMsTimer          = NewTimerDef("memory_gc_pause_ms")
+	NumGCGauge              = NewGaugeDef("memory_num_gc_last",
 		WithDescription("Last runtime.MemStats.NumGC"),
 	)
 	GcPauseNsTotal = NewGaugeDef("memory_pause_total_ns_last",

--- a/common/metrics/runtime.go
+++ b/common/metrics/runtime.go
@@ -72,6 +72,7 @@ func (r *RuntimeMetricsReporter) report() {
 	MemoryHeapObjectsGauge.With(r.handler).Record(float64(memStats.HeapObjects))
 	MemoryHeapIdleGauge.With(r.handler).Record(float64(memStats.HeapIdle))
 	MemoryHeapInuseGauge.With(r.handler).Record(float64(memStats.HeapInuse))
+	MemoryHeapReleasedGauge.With(r.handler).Record(float64(memStats.HeapReleased))
 	MemoryStackGauge.With(r.handler).Record(float64(memStats.StackInuse))
 	MemoryMallocsGauge.With(r.handler).Record(float64(memStats.Mallocs))
 	MemoryFreesGauge.With(r.handler).Record(float64(memStats.Frees))


### PR DESCRIPTION
## What changed?
This adds a metric for the runtime `MemStats.HeapReleased` value.

## Why?
We want to understand more about our GC interactions. We already report heap idle, and we want heap released based on this comment in the `MemStats` struct:

```go
	// HeapIdle minus HeapReleased estimates the amount of memory
	// that could be returned to the OS, but is being retained by
	// the runtime so it can grow the heap without requesting more
	// memory from the OS.
```


## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

