### PR TITLE
Add tests to improve coverage for worker heartbeat implementation.

### DIFF
--- a/service/matching/workers/registry_impl_test.go
+++ b/service/matching/workers/registry_impl_test.go
@@ -112,6 +112,62 @@ func TestEvictByCapacity(t *testing.T) {
 	assert.LessOrEqual(t, m.total.Load(), maxItems, "total counter should not exceed maxItems")
 }
 
+// Tests the critical edge case where evictByCapacity() cannot evict any entries because they're all
+// protected by minEvictAge. This verifies the "break" logic prevents infinite loops during memory
+// pressure.
+func TestEvictByCapacityWithMinAgeProtection(t *testing.T) {
+	maxItems := int64(2)
+	minEvictAge := 5 * time.Second
+	m := newRegistryImpl(1, time.Hour, minEvictAge, maxItems, time.Hour)
+	defer m.Stop()
+
+	// Add 3 entries (over capacity) - all will be "new" (< minEvictAge)
+	for i := 1; i <= 3; i++ {
+		key := fmt.Sprintf("worker%d", i)
+		hb := &workerpb.WorkerHeartbeat{WorkerInstanceKey: key}
+		m.upsertHeartbeats("ns", []*workerpb.WorkerHeartbeat{hb})
+	}
+
+	// Verify we're over capacity
+	assert.Equal(t, int64(3), m.total.Load(), "should have 3 entries initially")
+	assert.Greater(t, m.total.Load(), maxItems, "should be over capacity")
+
+	// Attempt eviction - should break because all entries are too new
+	m.evictByCapacity()
+
+	// All entries should still be there (protected by minEvictAge)
+	workers := m.filterWorkers("ns", alwaysTrue)
+	assert.Len(t, workers, 3, "all entries should be protected by minEvictAge")
+	assert.Equal(t, int64(3), m.total.Load(), "should still exceed maxItems due to protection")
+}
+
+// Tests that entries can be evicted once they exceed minEvictAge.
+func TestEvictByCapacityAfterMinAge(t *testing.T) {
+	maxItems := int64(2)
+	minEvictAge := 100 * time.Millisecond // Short age for test
+	m := newRegistryImpl(1, time.Hour, minEvictAge, maxItems, time.Hour)
+	defer m.Stop()
+
+	// Add 3 entries (over capacity)
+	for i := 1; i <= 3; i++ {
+		key := fmt.Sprintf("worker%d", i)
+		hb := &workerpb.WorkerHeartbeat{WorkerInstanceKey: key}
+		m.upsertHeartbeats("ns", []*workerpb.WorkerHeartbeat{hb})
+	}
+
+	// Wait for entries to exceed minEvictAge
+	// TODO: Use mock time for more reliable tests.
+	time.Sleep(300 * time.Millisecond)
+
+	// Now eviction should work
+	m.evictByCapacity()
+
+	// Should have evicted down to maxItems
+	workers := m.filterWorkers("ns", alwaysTrue)
+	assert.LessOrEqual(t, len(workers), int(maxItems), "should evict down to maxItems")
+	assert.LessOrEqual(t, m.total.Load(), maxItems, "total should be within limits")
+}
+
 func BenchmarkUpdate(b *testing.B) {
 	m := newRegistryImpl(16, time.Hour, time.Minute, int64(b.N), time.Hour)
 	defer m.Stop()

--- a/service/matching/workers/registry_test.go
+++ b/service/matching/workers/registry_test.go
@@ -195,6 +195,112 @@ func TestRegistryImpl_ListWorkers(t *testing.T) {
 	}
 }
 
+// Exercises the query matching functionality of ListWorkers.
+func TestRegistryImpl_ListWorkersWithQuery(t *testing.T) {
+	tests := []struct {
+		name            string
+		setup           func(*registryImpl)
+		nsID            namespace.ID
+		query           string
+		expectedCount   int
+		expectedWorkers []string // WorkerInstanceKeys
+		expectError     bool
+	}{
+		{
+			name: "valid query - basic filtering",
+			setup: func(r *registryImpl) {
+				r.upsertHeartbeats("namespace1", []*workerpb.WorkerHeartbeat{
+					{WorkerInstanceKey: "worker1", TaskQueue: "queue1"},
+					{WorkerInstanceKey: "worker2", TaskQueue: "queue2"},
+				})
+			},
+			nsID:            "namespace1",
+			query:           "WorkerInstanceKey = 'worker1'",
+			expectedCount:   1,
+			expectedWorkers: []string{"worker1"},
+		},
+		{
+			name: "valid query - no matches",
+			setup: func(r *registryImpl) {
+				r.upsertHeartbeats("namespace1", []*workerpb.WorkerHeartbeat{
+					{WorkerInstanceKey: "worker1", TaskQueue: "queue1"},
+				})
+			},
+			nsID:            "namespace1",
+			query:           "TaskQueue = 'non-existent-queue'",
+			expectedCount:   0,
+			expectedWorkers: []string{},
+		},
+		{
+			name: "invalid query - malformed SQL",
+			setup: func(r *registryImpl) {
+				r.upsertHeartbeats("namespace1", []*workerpb.WorkerHeartbeat{
+					{WorkerInstanceKey: "worker1"},
+				})
+			},
+			nsID:        "namespace1",
+			query:       "invalid SQL syntax here",
+			expectError: true,
+		},
+		{
+			name: "query on empty namespace",
+			setup: func(r *registryImpl) {
+				// No workers added
+			},
+			nsID:            "empty-namespace",
+			query:           "WorkerInstanceKey = 'worker1'",
+			expectedCount:   0,
+			expectedWorkers: []string{},
+		},
+		{
+			name: "query returns requested namespace only",
+			setup: func(r *registryImpl) {
+				// Add workers to namespace1
+				r.upsertHeartbeats("namespace1", []*workerpb.WorkerHeartbeat{
+					{WorkerInstanceKey: "worker1", TaskQueue: "queue"},
+				})
+				// Add workers to namespace2
+				r.upsertHeartbeats("namespace2", []*workerpb.WorkerHeartbeat{
+					{WorkerInstanceKey: "worker2", TaskQueue: "queue"},
+				})
+			},
+			nsID:            "namespace1",
+			query:           "TaskQueue = 'queue'",
+			expectedCount:   1,
+			expectedWorkers: []string{"worker1"}, // Only worker1, not worker2 from namespace2
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newRegistryImpl(
+				defaultBuckets, defaultEntryTTL, defaultMinEvictAge, defaultMaxEntries, defaultEvictionInterval,
+			)
+			tt.setup(r)
+
+			result, err := r.ListWorkers(tt.nsID, tt.query, nil)
+
+			if tt.expectError {
+				assert.Error(t, err, "expected an error for invalid query")
+				assert.Nil(t, result, "result should be nil when an error occurs")
+				return
+			}
+
+			assert.NoError(t, err, "unexpected error when listing workers with query")
+			assert.Len(t, result, tt.expectedCount, "unexpected number of workers returned")
+
+			// Check that all expected workers are present
+			if tt.expectedCount > 0 {
+				actualWorkers := make([]string, len(result))
+				for i, worker := range result {
+					actualWorkers[i] = worker.WorkerInstanceKey
+				}
+				assert.ElementsMatch(t, tt.expectedWorkers, actualWorkers, "worker lists don't match")
+			}
+		})
+	}
+}
+
 func TestRegistryImpl_DescribeWorker(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
## What changed?
Tests for the following cases:
1. Cache eviction logic.
2. ListWorkers API with query predicate.

## Why?
Improve coverage,

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None.