### PR TITLE
Enable HTTP API server on internal frontend

### DIFF
--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -823,7 +823,7 @@ func MuxRouterProvider() *mux.Router {
 
 func httpEnabled(cfg *config.Config, serviceName primitives.ServiceName) bool {
 	// If the service is not the frontend service, HTTP API is disabled
-	if serviceName != primitives.FrontendService {
+	if serviceName != primitives.FrontendService && serviceName != primitives.InternalFrontendService {
 		return false
 	}
 	// If HTTP API port is 0, it is disabled


### PR DESCRIPTION
## What changed?

Enable HTTP API on internal frontend if HTTP port is configured.

## Why?

Closes #7386

## How did you test it?

Ran the server with all services:

```
go run ./cmd/server --env development-sqlite --allow-no-auth start --service internal-frontend --service ...
```

Added an `internal-frontend` config to `config/development-sqlite.yaml` and removed the `frontend` HTTP port:

```
-      httpPort: 7243

+  internal-frontend:
+    rpc:
+      grpcPort: 7236
+      membershipPort: 6936
+      bindOnLocalHost: true
+      httpPort: 7246
```

Ran the Go Nexus sample.