### PR TITLE
Remove scan API from visibility

### DIFF
--- a/common/persistence/visibility/manager/visibility_manager.go
+++ b/common/persistence/visibility/manager/visibility_manager.go
@@ -33,7 +33,6 @@ type (
 
 		// Read APIs.
 		ListWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error)
-		ScanWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error)
 		CountWorkflowExecutions(ctx context.Context, request *CountWorkflowExecutionsRequest) (*CountWorkflowExecutionsResponse, error)
 		GetWorkflowExecution(ctx context.Context, request *GetWorkflowExecutionRequest) (*GetWorkflowExecutionResponse, error)
 

--- a/common/persistence/visibility/manager/visibility_manager_mock.go
+++ b/common/persistence/visibility/manager/visibility_manager_mock.go
@@ -210,21 +210,6 @@ func (mr *MockVisibilityManagerMockRecorder) RecordWorkflowExecutionStarted(ctx,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordWorkflowExecutionStarted", reflect.TypeOf((*MockVisibilityManager)(nil).RecordWorkflowExecutionStarted), ctx, request)
 }
 
-// ScanWorkflowExecutions mocks base method.
-func (m *MockVisibilityManager) ScanWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScanWorkflowExecutions", ctx, request)
-	ret0, _ := ret[0].(*ListWorkflowExecutionsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ScanWorkflowExecutions indicates an expected call of ScanWorkflowExecutions.
-func (mr *MockVisibilityManagerMockRecorder) ScanWorkflowExecutions(ctx, request any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanWorkflowExecutions", reflect.TypeOf((*MockVisibilityManager)(nil).ScanWorkflowExecutions), ctx, request)
-}
-
 // UpsertWorkflowExecution mocks base method.
 func (m *MockVisibilityManager) UpsertWorkflowExecution(ctx context.Context, request *UpsertWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()

--- a/common/persistence/visibility/store/elasticsearch/client/client.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client.go
@@ -32,14 +32,6 @@ type (
 		CreateIndex(ctx context.Context, index string, body map[string]any) (bool, error)
 		DeleteIndex(ctx context.Context, indexName string) (bool, error)
 		CatIndices(ctx context.Context, target string) (elastic.CatIndicesResponse, error)
-
-		OpenScroll(ctx context.Context, p *SearchParameters, keepAliveInterval string) (*elastic.SearchResult, error)
-		Scroll(ctx context.Context, id string, keepAliveInterval string) (*elastic.SearchResult, error)
-		CloseScroll(ctx context.Context, id string) error
-
-		IsPointInTimeSupported(ctx context.Context) bool
-		OpenPointInTime(ctx context.Context, index string, keepAliveInterval string) (string, error)
-		ClosePointInTime(ctx context.Context, id string) (bool, error)
 	}
 
 	CLIClient interface {
@@ -57,13 +49,10 @@ type (
 
 	// SearchParameters holds all required and optional parameters for executing a search.
 	SearchParameters struct {
-		Index    string
-		Query    elastic.Query
-		PageSize int
-		Sorter   []elastic.Sorter
-
+		Index       string
+		Query       elastic.Query
+		PageSize    int
+		Sorter      []elastic.Sorter
 		SearchAfter []interface{}
-		ScrollID    string
-		PointInTime *elastic.PointInTime
 	}
 )

--- a/common/persistence/visibility/store/elasticsearch/client/client_mock.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_mock.go
@@ -57,35 +57,6 @@ func (mr *MockClientMockRecorder) CatIndices(ctx, target any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CatIndices", reflect.TypeOf((*MockClient)(nil).CatIndices), ctx, target)
 }
 
-// ClosePointInTime mocks base method.
-func (m *MockClient) ClosePointInTime(ctx context.Context, id string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClosePointInTime", ctx, id)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ClosePointInTime indicates an expected call of ClosePointInTime.
-func (mr *MockClientMockRecorder) ClosePointInTime(ctx, id any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosePointInTime", reflect.TypeOf((*MockClient)(nil).ClosePointInTime), ctx, id)
-}
-
-// CloseScroll mocks base method.
-func (m *MockClient) CloseScroll(ctx context.Context, id string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloseScroll", ctx, id)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CloseScroll indicates an expected call of CloseScroll.
-func (mr *MockClientMockRecorder) CloseScroll(ctx, id any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseScroll", reflect.TypeOf((*MockClient)(nil).CloseScroll), ctx, id)
-}
-
 // Count mocks base method.
 func (m *MockClient) Count(ctx context.Context, index string, query elastic.Query) (int64, error) {
 	m.ctrl.T.Helper()
@@ -191,50 +162,6 @@ func (mr *MockClientMockRecorder) IndexExists(ctx, indexName any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexExists", reflect.TypeOf((*MockClient)(nil).IndexExists), ctx, indexName)
 }
 
-// IsPointInTimeSupported mocks base method.
-func (m *MockClient) IsPointInTimeSupported(ctx context.Context) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPointInTimeSupported", ctx)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsPointInTimeSupported indicates an expected call of IsPointInTimeSupported.
-func (mr *MockClientMockRecorder) IsPointInTimeSupported(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPointInTimeSupported", reflect.TypeOf((*MockClient)(nil).IsPointInTimeSupported), ctx)
-}
-
-// OpenPointInTime mocks base method.
-func (m *MockClient) OpenPointInTime(ctx context.Context, index, keepAliveInterval string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenPointInTime", ctx, index, keepAliveInterval)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// OpenPointInTime indicates an expected call of OpenPointInTime.
-func (mr *MockClientMockRecorder) OpenPointInTime(ctx, index, keepAliveInterval any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPointInTime", reflect.TypeOf((*MockClient)(nil).OpenPointInTime), ctx, index, keepAliveInterval)
-}
-
-// OpenScroll mocks base method.
-func (m *MockClient) OpenScroll(ctx context.Context, p *SearchParameters, keepAliveInterval string) (*elastic.SearchResult, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenScroll", ctx, p, keepAliveInterval)
-	ret0, _ := ret[0].(*elastic.SearchResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// OpenScroll indicates an expected call of OpenScroll.
-func (mr *MockClientMockRecorder) OpenScroll(ctx, p, keepAliveInterval any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenScroll", reflect.TypeOf((*MockClient)(nil).OpenScroll), ctx, p, keepAliveInterval)
-}
-
 // PutMapping mocks base method.
 func (m *MockClient) PutMapping(ctx context.Context, index string, mapping map[string]enums.IndexedValueType) (bool, error) {
 	m.ctrl.T.Helper()
@@ -263,21 +190,6 @@ func (m *MockClient) RunBulkProcessor(ctx context.Context, p *BulkProcessorParam
 func (mr *MockClientMockRecorder) RunBulkProcessor(ctx, p any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunBulkProcessor", reflect.TypeOf((*MockClient)(nil).RunBulkProcessor), ctx, p)
-}
-
-// Scroll mocks base method.
-func (m *MockClient) Scroll(ctx context.Context, id, keepAliveInterval string) (*elastic.SearchResult, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Scroll", ctx, id, keepAliveInterval)
-	ret0, _ := ret[0].(*elastic.SearchResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Scroll indicates an expected call of Scroll.
-func (mr *MockClientMockRecorder) Scroll(ctx, id, keepAliveInterval any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockClient)(nil).Scroll), ctx, id, keepAliveInterval)
 }
 
 // Search mocks base method.
@@ -347,35 +259,6 @@ func (m *MockCLIClient) CatIndices(ctx context.Context, target string) (elastic.
 func (mr *MockCLIClientMockRecorder) CatIndices(ctx, target any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CatIndices", reflect.TypeOf((*MockCLIClient)(nil).CatIndices), ctx, target)
-}
-
-// ClosePointInTime mocks base method.
-func (m *MockCLIClient) ClosePointInTime(ctx context.Context, id string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClosePointInTime", ctx, id)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ClosePointInTime indicates an expected call of ClosePointInTime.
-func (mr *MockCLIClientMockRecorder) ClosePointInTime(ctx, id any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosePointInTime", reflect.TypeOf((*MockCLIClient)(nil).ClosePointInTime), ctx, id)
-}
-
-// CloseScroll mocks base method.
-func (m *MockCLIClient) CloseScroll(ctx context.Context, id string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloseScroll", ctx, id)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CloseScroll indicates an expected call of CloseScroll.
-func (mr *MockCLIClientMockRecorder) CloseScroll(ctx, id any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseScroll", reflect.TypeOf((*MockCLIClient)(nil).CloseScroll), ctx, id)
 }
 
 // Count mocks base method.
@@ -497,50 +380,6 @@ func (mr *MockCLIClientMockRecorder) IndexExists(ctx, indexName any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexExists", reflect.TypeOf((*MockCLIClient)(nil).IndexExists), ctx, indexName)
 }
 
-// IsPointInTimeSupported mocks base method.
-func (m *MockCLIClient) IsPointInTimeSupported(ctx context.Context) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPointInTimeSupported", ctx)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsPointInTimeSupported indicates an expected call of IsPointInTimeSupported.
-func (mr *MockCLIClientMockRecorder) IsPointInTimeSupported(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPointInTimeSupported", reflect.TypeOf((*MockCLIClient)(nil).IsPointInTimeSupported), ctx)
-}
-
-// OpenPointInTime mocks base method.
-func (m *MockCLIClient) OpenPointInTime(ctx context.Context, index, keepAliveInterval string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenPointInTime", ctx, index, keepAliveInterval)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// OpenPointInTime indicates an expected call of OpenPointInTime.
-func (mr *MockCLIClientMockRecorder) OpenPointInTime(ctx, index, keepAliveInterval any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPointInTime", reflect.TypeOf((*MockCLIClient)(nil).OpenPointInTime), ctx, index, keepAliveInterval)
-}
-
-// OpenScroll mocks base method.
-func (m *MockCLIClient) OpenScroll(ctx context.Context, p *SearchParameters, keepAliveInterval string) (*elastic.SearchResult, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenScroll", ctx, p, keepAliveInterval)
-	ret0, _ := ret[0].(*elastic.SearchResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// OpenScroll indicates an expected call of OpenScroll.
-func (mr *MockCLIClientMockRecorder) OpenScroll(ctx, p, keepAliveInterval any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenScroll", reflect.TypeOf((*MockCLIClient)(nil).OpenScroll), ctx, p, keepAliveInterval)
-}
-
 // PutMapping mocks base method.
 func (m *MockCLIClient) PutMapping(ctx context.Context, index string, mapping map[string]enums.IndexedValueType) (bool, error) {
 	m.ctrl.T.Helper()
@@ -569,21 +408,6 @@ func (m *MockCLIClient) RunBulkProcessor(ctx context.Context, p *BulkProcessorPa
 func (mr *MockCLIClientMockRecorder) RunBulkProcessor(ctx, p any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunBulkProcessor", reflect.TypeOf((*MockCLIClient)(nil).RunBulkProcessor), ctx, p)
-}
-
-// Scroll mocks base method.
-func (m *MockCLIClient) Scroll(ctx context.Context, id, keepAliveInterval string) (*elastic.SearchResult, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Scroll", ctx, id, keepAliveInterval)
-	ret0, _ := ret[0].(*elastic.SearchResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Scroll indicates an expected call of Scroll.
-func (mr *MockCLIClientMockRecorder) Scroll(ctx, id, keepAliveInterval any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockCLIClient)(nil).Scroll), ctx, id, keepAliveInterval)
 }
 
 // Search mocks base method.
@@ -653,35 +477,6 @@ func (m *MockIntegrationTestsClient) CatIndices(ctx context.Context, target stri
 func (mr *MockIntegrationTestsClientMockRecorder) CatIndices(ctx, target any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CatIndices", reflect.TypeOf((*MockIntegrationTestsClient)(nil).CatIndices), ctx, target)
-}
-
-// ClosePointInTime mocks base method.
-func (m *MockIntegrationTestsClient) ClosePointInTime(ctx context.Context, id string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClosePointInTime", ctx, id)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ClosePointInTime indicates an expected call of ClosePointInTime.
-func (mr *MockIntegrationTestsClientMockRecorder) ClosePointInTime(ctx, id any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosePointInTime", reflect.TypeOf((*MockIntegrationTestsClient)(nil).ClosePointInTime), ctx, id)
-}
-
-// CloseScroll mocks base method.
-func (m *MockIntegrationTestsClient) CloseScroll(ctx context.Context, id string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloseScroll", ctx, id)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CloseScroll indicates an expected call of CloseScroll.
-func (mr *MockIntegrationTestsClientMockRecorder) CloseScroll(ctx, id any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseScroll", reflect.TypeOf((*MockIntegrationTestsClient)(nil).CloseScroll), ctx, id)
 }
 
 // Count mocks base method.
@@ -834,50 +629,6 @@ func (mr *MockIntegrationTestsClientMockRecorder) IndexPutTemplate(ctx, template
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexPutTemplate", reflect.TypeOf((*MockIntegrationTestsClient)(nil).IndexPutTemplate), ctx, templateName, bodyString)
 }
 
-// IsPointInTimeSupported mocks base method.
-func (m *MockIntegrationTestsClient) IsPointInTimeSupported(ctx context.Context) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPointInTimeSupported", ctx)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsPointInTimeSupported indicates an expected call of IsPointInTimeSupported.
-func (mr *MockIntegrationTestsClientMockRecorder) IsPointInTimeSupported(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPointInTimeSupported", reflect.TypeOf((*MockIntegrationTestsClient)(nil).IsPointInTimeSupported), ctx)
-}
-
-// OpenPointInTime mocks base method.
-func (m *MockIntegrationTestsClient) OpenPointInTime(ctx context.Context, index, keepAliveInterval string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenPointInTime", ctx, index, keepAliveInterval)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// OpenPointInTime indicates an expected call of OpenPointInTime.
-func (mr *MockIntegrationTestsClientMockRecorder) OpenPointInTime(ctx, index, keepAliveInterval any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPointInTime", reflect.TypeOf((*MockIntegrationTestsClient)(nil).OpenPointInTime), ctx, index, keepAliveInterval)
-}
-
-// OpenScroll mocks base method.
-func (m *MockIntegrationTestsClient) OpenScroll(ctx context.Context, p *SearchParameters, keepAliveInterval string) (*elastic.SearchResult, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenScroll", ctx, p, keepAliveInterval)
-	ret0, _ := ret[0].(*elastic.SearchResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// OpenScroll indicates an expected call of OpenScroll.
-func (mr *MockIntegrationTestsClientMockRecorder) OpenScroll(ctx, p, keepAliveInterval any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenScroll", reflect.TypeOf((*MockIntegrationTestsClient)(nil).OpenScroll), ctx, p, keepAliveInterval)
-}
-
 // Ping mocks base method.
 func (m *MockIntegrationTestsClient) Ping(ctx context.Context) error {
 	m.ctrl.T.Helper()
@@ -920,21 +671,6 @@ func (m *MockIntegrationTestsClient) RunBulkProcessor(ctx context.Context, p *Bu
 func (mr *MockIntegrationTestsClientMockRecorder) RunBulkProcessor(ctx, p any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunBulkProcessor", reflect.TypeOf((*MockIntegrationTestsClient)(nil).RunBulkProcessor), ctx, p)
-}
-
-// Scroll mocks base method.
-func (m *MockIntegrationTestsClient) Scroll(ctx context.Context, id, keepAliveInterval string) (*elastic.SearchResult, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Scroll", ctx, id, keepAliveInterval)
-	ret0, _ := ret[0].(*elastic.SearchResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Scroll indicates an expected call of Scroll.
-func (mr *MockIntegrationTestsClientMockRecorder) Scroll(ctx, id, keepAliveInterval any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockIntegrationTestsClient)(nil).Scroll), ctx, id, keepAliveInterval)
 }
 
 // Search mocks base method.

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -228,13 +228,6 @@ func (s *VisibilityStore) ListWorkflowExecutions(
 	}, nil
 }
 
-func (s *VisibilityStore) ScanWorkflowExecutions(
-	ctx context.Context,
-	request *manager.ListWorkflowExecutionsRequestV2,
-) (*store.InternalListWorkflowExecutionsResponse, error) {
-	return s.ListWorkflowExecutions(ctx, request)
-}
-
 func (s *VisibilityStore) CountWorkflowExecutions(
 	ctx context.Context,
 	request *manager.CountWorkflowExecutionsRequest,

--- a/common/persistence/visibility/store/visibility_store.go
+++ b/common/persistence/visibility/store/visibility_store.go
@@ -33,7 +33,6 @@ type (
 
 		// Read APIs.
 		ListWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error)
-		ScanWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error)
 		CountWorkflowExecutions(ctx context.Context, request *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error)
 		GetWorkflowExecution(ctx context.Context, request *manager.GetWorkflowExecutionRequest) (*InternalGetWorkflowExecutionResponse, error)
 

--- a/common/persistence/visibility/store/visibility_store_mock.go
+++ b/common/persistence/visibility/store/visibility_store_mock.go
@@ -182,21 +182,6 @@ func (mr *MockVisibilityStoreMockRecorder) RecordWorkflowExecutionStarted(ctx, r
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordWorkflowExecutionStarted", reflect.TypeOf((*MockVisibilityStore)(nil).RecordWorkflowExecutionStarted), ctx, request)
 }
 
-// ScanWorkflowExecutions mocks base method.
-func (m *MockVisibilityStore) ScanWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScanWorkflowExecutions", ctx, request)
-	ret0, _ := ret[0].(*InternalListWorkflowExecutionsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ScanWorkflowExecutions indicates an expected call of ScanWorkflowExecutions.
-func (mr *MockVisibilityStoreMockRecorder) ScanWorkflowExecutions(ctx, request any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanWorkflowExecutions", reflect.TypeOf((*MockVisibilityStore)(nil).ScanWorkflowExecutions), ctx, request)
-}
-
 // UpsertWorkflowExecution mocks base method.
 func (m *MockVisibilityStore) UpsertWorkflowExecution(ctx context.Context, request *InternalUpsertWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()

--- a/common/persistence/visibility/visibility_manager_dual.go
+++ b/common/persistence/visibility/visibility_manager_dual.go
@@ -159,19 +159,6 @@ func (v *VisibilityManagerDual) ListWorkflowExecutions(
 	)
 }
 
-func (v *VisibilityManagerDual) ScanWorkflowExecutions(
-	ctx context.Context,
-	request *manager.ListWorkflowExecutionsRequestV2,
-) (*manager.ListWorkflowExecutionsResponse, error) {
-	return dualReadWrapper(
-		ctx,
-		v,
-		request,
-		request.Namespace,
-		manager.VisibilityManager.ScanWorkflowExecutions,
-	)
-}
-
 func (v *VisibilityManagerDual) CountWorkflowExecutions(
 	ctx context.Context,
 	request *manager.CountWorkflowExecutionsRequest,

--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -140,18 +140,6 @@ func (p *visibilityManagerImpl) ListWorkflowExecutions(
 	return p.convertInternalListResponse(response)
 }
 
-func (p *visibilityManagerImpl) ScanWorkflowExecutions(
-	ctx context.Context,
-	request *manager.ListWorkflowExecutionsRequestV2,
-) (*manager.ListWorkflowExecutionsResponse, error) {
-	response, err := p.store.ScanWorkflowExecutions(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-
-	return p.convertInternalListResponse(response)
-}
-
 func (p *visibilityManagerImpl) CountWorkflowExecutions(
 	ctx context.Context,
 	request *manager.CountWorkflowExecutionsRequest,

--- a/common/persistence/visibility/visibility_manager_rate_limited.go
+++ b/common/persistence/visibility/visibility_manager_rate_limited.go
@@ -116,16 +116,6 @@ func (m *visibilityManagerRateLimited) ListWorkflowExecutions(
 	return m.delegate.ListWorkflowExecutions(ctx, request)
 }
 
-func (m *visibilityManagerRateLimited) ScanWorkflowExecutions(
-	ctx context.Context,
-	request *manager.ListWorkflowExecutionsRequestV2,
-) (*manager.ListWorkflowExecutionsResponse, error) {
-	if ok := allow(ctx, "ScanWorkflowExecutions", m.readRateLimiter); !ok {
-		return nil, persistence.ErrPersistenceSystemLimitExceeded
-	}
-	return m.delegate.ScanWorkflowExecutions(ctx, request)
-}
-
 func (m *visibilityManagerRateLimited) CountWorkflowExecutions(
 	ctx context.Context,
 	request *manager.CountWorkflowExecutionsRequest,

--- a/common/persistence/visibility/visiblity_manager_metrics.go
+++ b/common/persistence/visibility/visiblity_manager_metrics.go
@@ -129,24 +129,6 @@ func (m *visibilityManagerMetrics) ListWorkflowExecutions(
 	return response, m.updateErrorMetric(handler, err)
 }
 
-func (m *visibilityManagerMetrics) ScanWorkflowExecutions(
-	ctx context.Context,
-	request *manager.ListWorkflowExecutionsRequestV2,
-) (*manager.ListWorkflowExecutionsResponse, error) {
-	handler, startTime := m.tagScope(metrics.VisibilityPersistenceScanWorkflowExecutionsScope)
-	response, err := m.delegate.ScanWorkflowExecutions(ctx, request)
-	elapsed := time.Since(startTime)
-	if elapsed > m.slowQueryThreshold() {
-		m.logger.Warn("Count query exceeded threshold",
-			tag.NewDurationTag("duration", elapsed),
-			tag.NewStringTag("visibility-query", request.Query),
-			tag.NewStringerTag("namespace", request.Namespace),
-		)
-	}
-	metrics.VisibilityPersistenceLatency.With(handler).Record(elapsed)
-	return response, m.updateErrorMetric(handler, err)
-}
-
 func (m *visibilityManagerMetrics) CountWorkflowExecutions(
 	ctx context.Context,
 	request *manager.CountWorkflowExecutionsRequest,

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2111,68 +2111,6 @@ func (s *WorkflowHandlerSuite) TestListWorkflowExecutions() {
 	s.Equal(query, listRequest.GetQuery())
 }
 
-func (s *WorkflowHandlerSuite) TestScanWorkflowExecutions() {
-	config := s.newConfig()
-	wh := s.getWorkflowHandler(config)
-	s.mockNamespaceCache.EXPECT().GetNamespaceID(s.testNamespace).Return(s.testNamespaceID, nil).AnyTimes()
-	s.mockVisibilityMgr.EXPECT().GetReadStoreName(s.testNamespace).Return(elasticsearch.PersistenceName).AnyTimes()
-
-	query := "WorkflowId = 'wid'"
-	scanRequest := &workflowservice.ScanWorkflowExecutionsRequest{
-		Namespace: s.testNamespace.String(),
-		PageSize:  int32(config.VisibilityMaxPageSize(s.testNamespace.String())),
-		Query:     query,
-	}
-	ctx := context.Background()
-
-	// page size <= 0 => max page size = 1000
-	s.mockVisibilityMgr.EXPECT().ScanWorkflowExecutions(
-		gomock.Any(),
-		&manager.ListWorkflowExecutionsRequestV2{
-			NamespaceID:   s.testNamespaceID,
-			Namespace:     s.testNamespace,
-			PageSize:      config.VisibilityMaxPageSize(s.testNamespace.String()),
-			NextPageToken: nil,
-			Query:         query,
-		},
-	).Return(&manager.ListWorkflowExecutionsResponse{}, nil)
-	_, err := wh.ScanWorkflowExecutions(ctx, scanRequest)
-	s.NoError(err)
-	s.Equal(query, scanRequest.GetQuery())
-
-	// page size > 1000 => max page size = 1000
-	s.mockVisibilityMgr.EXPECT().ScanWorkflowExecutions(
-		gomock.Any(),
-		&manager.ListWorkflowExecutionsRequestV2{
-			NamespaceID:   s.testNamespaceID,
-			Namespace:     s.testNamespace,
-			PageSize:      config.VisibilityMaxPageSize(s.testNamespace.String()),
-			NextPageToken: nil,
-			Query:         query,
-		},
-	).Return(&manager.ListWorkflowExecutionsResponse{}, nil)
-	scanRequest.PageSize = int32(config.VisibilityMaxPageSize(s.testNamespace.String())) + 1
-	_, err = wh.ScanWorkflowExecutions(ctx, scanRequest)
-	s.NoError(err)
-	s.Equal(query, scanRequest.GetQuery())
-
-	// page size between 0 and 1000
-	s.mockVisibilityMgr.EXPECT().ScanWorkflowExecutions(
-		gomock.Any(),
-		&manager.ListWorkflowExecutionsRequestV2{
-			NamespaceID:   s.testNamespaceID,
-			Namespace:     s.testNamespace,
-			PageSize:      10,
-			NextPageToken: nil,
-			Query:         query,
-		},
-	).Return(&manager.ListWorkflowExecutionsResponse{}, nil)
-	scanRequest.PageSize = 10
-	_, err = wh.ScanWorkflowExecutions(ctx, scanRequest)
-	s.NoError(err)
-	s.Equal(query, scanRequest.GetQuery())
-}
-
 func (s *WorkflowHandlerSuite) TestCountWorkflowExecutions() {
 	wh := s.getWorkflowHandler(s.newConfig())
 


### PR DESCRIPTION
## What changed?
Removing scan API from Visibility

## Why?
Visibility Scan API has been marked as deprecated since v1.27.0.
`Scan` in Visibility with SQL DB is the same as the `List` API. With Elasticsearch, it provides a search without an order of the results, and we don't see any reason to use it instead of the `List` API.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Users will be required to migrate to `List` API prior to upgrading Temporal.