### PR TITLE
Support exposing authorizer error in Nexus APIs

### DIFF
--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -300,10 +300,8 @@ func ConvertGRPCError(err error, exposeDetails bool) error {
 	return err
 }
 
-func AdaptAuthorizeError(err error) error {
-	// Authorize err is either an explicitly set reason, or a generic "Request unauthorized." message.
-	var permissionDeniedError *serviceerror.PermissionDenied
-	if errors.As(err, &permissionDeniedError) && permissionDeniedError.Reason != "" {
+func AdaptAuthorizeError(permissionDeniedError *serviceerror.PermissionDenied) error {
+	if permissionDeniedError.Reason != "" {
 		return nexus.HandlerErrorf(nexus.HandlerErrorTypeUnauthorized, "permission denied: %s", permissionDeniedError.Reason)
 	}
 	return nexus.HandlerErrorf(nexus.HandlerErrorTypeUnauthorized, "permission denied")

--- a/components/nexusoperations/frontend/handler.go
+++ b/components/nexusoperations/frontend/handler.go
@@ -500,11 +500,10 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexus.Co
 		if errors.As(err, &permissionDeniedError) {
 			c.outcomeTag = metrics.OutcomeTag("unauthorized")
 			return commonnexus.AdaptAuthorizeError(permissionDeniedError)
-		} else {
-			c.outcomeTag = metrics.OutcomeTag("internal_auth_error")
-			c.logger.Error("Authorization internal error with processing nexus callback", tag.Error(err))
-			return commonnexus.ConvertGRPCError(err, false)
 		}
+		c.outcomeTag = metrics.OutcomeTag("internal_auth_error")
+		c.logger.Error("Authorization internal error with processing nexus callback", tag.Error(err))
+		return commonnexus.ConvertGRPCError(err, false)
 	}
 
 	if err := c.NamespaceValidationInterceptor.ValidateState(c.namespace, apiName); err != nil {

--- a/components/nexusoperations/frontend/handler.go
+++ b/components/nexusoperations/frontend/handler.go
@@ -493,7 +493,18 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexus.Co
 		Request:   request,
 	})
 	if err != nil {
-		return commonnexus.AdaptAuthorizeError(err)
+		// If frontend.exposeAuthorizerErrors is false, Authorize err is either an explicitly set reason, or a generic
+		// "Request unauthorized." message.
+		// Otherwise, expose the underlying error.
+		var permissionDeniedError *serviceerror.PermissionDenied
+		if errors.As(err, &permissionDeniedError) {
+			c.outcomeTag = metrics.OutcomeTag("unauthorized")
+			return commonnexus.AdaptAuthorizeError(permissionDeniedError)
+		} else {
+			c.outcomeTag = metrics.OutcomeTag("internal_auth_error")
+			c.logger.Error("Authorization internal error with processing nexus callback", tag.Error(err))
+			return commonnexus.ConvertGRPCError(err, false)
+		}
 	}
 
 	if err := c.NamespaceValidationInterceptor.ValidateState(c.namespace, apiName); err != nil {

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -157,8 +157,18 @@ func (c *operationContext) interceptRequest(
 		Request:           request,
 	})
 	if err != nil {
-		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("unauthorized"))
-		return commonnexus.AdaptAuthorizeError(err)
+		// If frontend.exposeAuthorizerErrors is false, Authorize err is either an explicitly set reason, or a generic
+		// "Request unauthorized." message.
+		// Otherwise, expose the underlying error.
+		var permissionDeniedError *serviceerror.PermissionDenied
+		if errors.As(err, &permissionDeniedError) {
+			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("unauthorized"))
+			return commonnexus.AdaptAuthorizeError(permissionDeniedError)
+		} else {
+			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("internal_auth_error"))
+			c.logger.Error("Authorization internal error with processing nexus request", tag.Error(err))
+			return commonnexus.ConvertGRPCError(err, false)
+		}
 	}
 
 	if err := c.namespaceValidationInterceptor.ValidateState(c.namespace, c.apiName); err != nil {

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -164,11 +164,10 @@ func (c *operationContext) interceptRequest(
 		if errors.As(err, &permissionDeniedError) {
 			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("unauthorized"))
 			return commonnexus.AdaptAuthorizeError(permissionDeniedError)
-		} else {
-			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("internal_auth_error"))
-			c.logger.Error("Authorization internal error with processing nexus request", tag.Error(err))
-			return commonnexus.ConvertGRPCError(err, false)
 		}
+		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("internal_auth_error"))
+		c.logger.Error("Authorization internal error with processing nexus request", tag.Error(err))
+		return commonnexus.ConvertGRPCError(err, false)
 	}
 
 	if err := c.namespaceValidationInterceptor.ValidateState(c.namespace, c.apiName); err != nil {

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1295,7 +1295,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionAuthErrors() {
 	res, snap := s.sendNexusCompletionRequest(ctx, s.T(), publicCallbackUrl, completion, "")
 	s.Equal(http.StatusForbidden, res.StatusCode)
 	s.Equal(1, len(snap["nexus_completion_requests"]))
-	s.Subset(snap["nexus_completion_requests"][0].Tags, map[string]string{"namespace": s.Namespace().String(), "outcome": "error_unauthorized"})
+	s.Subset(snap["nexus_completion_requests"][0].Tags, map[string]string{"namespace": s.Namespace().String(), "outcome": "unauthorized"})
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionInternalAuth() {


### PR DESCRIPTION
## What changed?

Adapt the Nexus handler code to be compatible with the `frontend.exposeAuthorizerErrors` dynamic config introduced in #8276 

## Why?

This was missed as part of the initial implementation.

## How did you test it?
Added new functional test(s)