### PR TITLE
Add internal HTTP port in docker config templates

### DIFF
--- a/config/docker.yaml
+++ b/config/docker.yaml
@@ -266,6 +266,7 @@ global:
 
 {{- $temporalGrpcPort := default "7233" (env "FRONTEND_GRPC_PORT") }}
 {{- $temporalHTTPPort := default "7243" (env "FRONTEND_HTTP_PORT") }}
+{{- $temporalInternalHTTPPort := default "7246" (env "INTERNAL_FRONTEND_HTTP_PORT") }}
 services:
     frontend:
         rpc:
@@ -280,6 +281,7 @@ services:
             grpcPort: {{ default "7236" (env "INTERNAL_FRONTEND_GRPC_PORT") }}
             membershipPort: {{ default "6936" (env "INTERNAL_FRONTEND_MEMBERSHIP_PORT") }}
             bindOnIP: {{ default "127.0.0.1" (env "BIND_ON_IP") }}
+            httpPort: {{ $temporalInternalHTTPPort }}
     {{- end }}
 
     matching:

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -270,6 +270,7 @@ global:
 
 {{- $temporalGrpcPort := default .Env.FRONTEND_GRPC_PORT "7233" }}
 {{- $temporalHTTPPort := default .Env.FRONTEND_HTTP_PORT "7243" }}
+{{- $temporalInternalHTTPPort := default .Env.INTERNAL_FRONTEND_HTTP_PORT "7246" }}
 services:
     frontend:
         rpc:
@@ -284,6 +285,7 @@ services:
             grpcPort: {{ default .Env.INTERNAL_FRONTEND_GRPC_PORT "7236" }}
             membershipPort: {{ default .Env.INTERNAL_FRONTEND_MEMBERSHIP_PORT "6936" }}
             bindOnIP: "{{ default .Env.BIND_ON_IP "127.0.0.1" }}"
+            httpPort: {{ $temporalInternalHTTPPort }}
     {{- end }}
 
     matching:


### PR DESCRIPTION
## Why?

This was missed in #8327