### PR TITLE
Extend workflowID reuse interval to closed workflows

### DIFF
--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -2,6 +2,7 @@ package signalwithstartworkflow
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -140,7 +141,10 @@ func createWorkflowMutationFunction(
 	}
 	currentMutableState := currentWorkflowLease.GetMutableState()
 	currentExecutionState := currentMutableState.GetExecutionState()
-	currentWorkflowStartTime := currentMutableState.GetExecutionState().StartTime.AsTime()
+	currentWorkflowStartTime := time.Time{}
+	if shardContext.GetConfig().EnableWorkflowIdReuseStartTimeValidation(namespaceEntry.Name().String()) {
+		currentWorkflowStartTime = currentExecutionState.StartTime.AsTime()
+	}
 
 	// It is unclear if currentExecutionState.RunId is the same as
 	// currentWorkflowLease.GetContext().GetWorkflowKey().RunID

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -1943,6 +1943,8 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist() {
 }
 
 func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotRunning() {
+	s.config.EnableWorkflowIdReuseStartTimeValidation = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false)
+
 	we := &commonpb.WorkflowExecution{
 		WorkflowId: "wId",
 		RunId:      tests.RunID,
@@ -2005,6 +2007,8 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotRunning()
 }
 
 func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_DuplicateRequests() {
+	s.config.EnableWorkflowIdReuseStartTimeValidation = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false)
+
 	namespaceID := tests.NamespaceID
 	workflowID := "wId"
 	runID := tests.RunID
@@ -2060,8 +2064,8 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_DuplicateReque
 			},
 		},
 		RunID:            runID,
-		State:            enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
-		Status:           enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+		State:            enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+		Status:           enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
 		LastWriteVersion: common.EmptyVersion,
 		StartTime:        nil,
 	}
@@ -2078,6 +2082,8 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_DuplicateReque
 }
 
 func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_WorkflowAlreadyStarted() {
+	s.config.EnableWorkflowIdReuseStartTimeValidation = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false)
+
 	namespaceID := tests.NamespaceID
 	workflowID := "wId"
 	runID := tests.RunID


### PR DESCRIPTION
## What changed?
- Extend workflowID reuse interval to closed workflows

## Why?
- Current check only applies to conflict policy & running workflows, which can really prevent users from generating hot workflowIDs.
- 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
- This is a hot fix, will follow up with new functional tests in a different PR.

## Potential risks
- This feature is disabled by default.
