### PR TITLE
Refactor Visibility SQL parsing search attributes for DB write

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/visibility.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 )
@@ -275,6 +276,14 @@ func (mdb *db) prepareRowForDB(row *sqlplugin.VisibilityRow) *sqlplugin.Visibili
 	finalRow.ExecutionTime = mdb.converter.ToMySQLDateTime(finalRow.ExecutionTime)
 	if finalRow.CloseTime != nil {
 		*finalRow.CloseTime = mdb.converter.ToMySQLDateTime(*finalRow.CloseTime)
+	}
+	if finalRow.SearchAttributes != nil {
+		saMap := *finalRow.SearchAttributes
+		for name, value := range saMap {
+			if dt, ok := value.(time.Time); ok {
+				saMap[name] = dt.Format(time.RFC3339Nano)
+			}
+		}
 	}
 	return &finalRow
 }

--- a/common/persistence/sql/sqlplugin/postgresql/visibility.go
+++ b/common/persistence/sql/sqlplugin/postgresql/visibility.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 )
@@ -166,6 +167,14 @@ func (pdb *db) prepareRowForDB(row *sqlplugin.VisibilityRow) *sqlplugin.Visibili
 	finalRow.ExecutionTime = pdb.converter.ToPostgreSQLDateTime(finalRow.ExecutionTime)
 	if finalRow.CloseTime != nil {
 		*finalRow.CloseTime = pdb.converter.ToPostgreSQLDateTime(*finalRow.CloseTime)
+	}
+	if finalRow.SearchAttributes != nil {
+		saMap := *finalRow.SearchAttributes
+		for name, value := range saMap {
+			if dt, ok := value.(time.Time); ok {
+				saMap[name] = dt.Format(time.RFC3339Nano)
+			}
+		}
 	}
 	return &finalRow
 }

--- a/common/persistence/sql/sqlplugin/sqlite/visibility.go
+++ b/common/persistence/sql/sqlplugin/sqlite/visibility.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 )
@@ -167,6 +168,8 @@ func (mdb *db) prepareRowForDB(row *sqlplugin.VisibilityRow) *sqlplugin.Visibili
 			switch v := value.(type) {
 			case []string:
 				finalSearchAttributes[name] = strings.Join(v, keywordListSeparator)
+			case time.Time:
+				finalSearchAttributes[name] = v.Format(time.RFC3339Nano)
 			default:
 				finalSearchAttributes[name] = v
 			}

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -400,15 +400,6 @@ func (s *VisibilityStore) prepareSearchAttributesForDb(
 			delete(searchAttributes, name)
 			continue
 		}
-		tp, err := saTypeMap.GetType(name)
-		if err != nil {
-			return nil, err
-		}
-		if tp == enumspb.INDEXED_VALUE_TYPE_DATETIME {
-			if dt, ok := value.(time.Time); ok {
-				searchAttributes[name] = dt.Format(time.RFC3339Nano)
-			}
-		}
 	}
 	return &searchAttributes, nil
 }


### PR DESCRIPTION
## What changed?
Move converting `time.Time` values for `Datetime` type search attributes to the DB plugin code. 

## Why?
This gives more flexibility for the plugin implementation to deal with it as needed.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
