### PR TITLE
Fail health check if no hosts are available

### DIFF
--- a/service/frontend/health_check.go
+++ b/service/frontend/health_check.go
@@ -53,7 +53,7 @@ func (h *healthCheckerImpl) Check(ctx context.Context) (enumsspb.HealthState, er
 
 	hosts := resolver.AvailableMembers()
 	if len(hosts) == 0 {
-		return enumsspb.HEALTH_STATE_SERVING, nil
+		return enumsspb.HEALTH_STATE_NOT_SERVING, nil
 	}
 
 	receiveCh := make(chan enumsspb.HealthState, len(hosts))


### PR DESCRIPTION
## What changed?
Instead of returning healthy, return unhealthy if no hosts available.

## Why?
 It's a fair assertion that if there are no hosts available, the service is not healthy.

## How did you test it?
- [x ] built
- [ x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
There could be a false positive edge case that I'm not considering, but unlikely. 
