### PR TITLE
tests: remove WorkflowRunTimeout from nexus test

### DIFF
--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -493,7 +493,6 @@ func (s *CallbacksSuite) TestNexusResetWorkflowWithCallback() {
 		WorkflowType:        &commonpb.WorkflowType{Name: "longRunningWorkflow"},
 		TaskQueue:           taskQueue,
 		Input:               nil,
-		WorkflowRunTimeout:  durationpb.New(20 * time.Second),
 		Identity:            s.T().Name(),
 		CompletionCallbacks: []*commonpb.Callback{cbs[0]},
 	}


### PR DESCRIPTION
## What changed?
Remove the `WorkflowRunTimeout` from test workflow

## Why?
Potential cause of flaky tests

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Testing only