### PR TITLE
[Nexus] Add CloseTime header field to Nexus operation completions generated from History

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -656,6 +656,7 @@ func (ms *MutableStateImpl) GetNexusCompletion(
 		completion, err := nexus.NewOperationCompletionSuccessful(p, nexus.OperationCompletionSuccessfulOptions{
 			Serializer: commonnexus.PayloadSerializer,
 			StartTime:  ms.executionState.GetStartTime().AsTime(),
+			CloseTime:  ce.GetEventTime().AsTime(),
 			Links:      []nexus.Link{startLink},
 		})
 		if err != nil {
@@ -671,6 +672,7 @@ func (ms *MutableStateImpl) GetNexusCompletion(
 			&nexus.OperationError{State: nexus.OperationStateFailed, Cause: &nexus.FailureError{Failure: f}},
 			nexus.OperationCompletionUnsuccessfulOptions{
 				StartTime: ms.executionState.GetStartTime().AsTime(),
+				CloseTime: ce.GetEventTime().AsTime(),
 				Links:     []nexus.Link{startLink},
 			})
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
@@ -692,6 +694,7 @@ func (ms *MutableStateImpl) GetNexusCompletion(
 			},
 			nexus.OperationCompletionUnsuccessfulOptions{
 				StartTime: ms.executionState.GetStartTime().AsTime(),
+				CloseTime: ce.GetEventTime().AsTime(),
 				Links:     []nexus.Link{startLink},
 			})
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
@@ -708,6 +711,7 @@ func (ms *MutableStateImpl) GetNexusCompletion(
 			&nexus.OperationError{State: nexus.OperationStateFailed, Cause: &nexus.FailureError{Failure: f}},
 			nexus.OperationCompletionUnsuccessfulOptions{
 				StartTime: ms.executionState.GetStartTime().AsTime(),
+				CloseTime: ce.GetEventTime().AsTime(),
 				Links:     []nexus.Link{startLink},
 			})
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
@@ -730,6 +734,7 @@ func (ms *MutableStateImpl) GetNexusCompletion(
 			},
 			nexus.OperationCompletionUnsuccessfulOptions{
 				StartTime: ms.executionState.GetStartTime().AsTime(),
+				CloseTime: ce.GetEventTime().AsTime(),
 				Links:     []nexus.Link{startLink},
 			})
 	}

--- a/service/history/workflow/workflow_test/mutable_state_impl_test.go
+++ b/service/history/workflow/workflow_test/mutable_state_impl_test.go
@@ -360,7 +360,7 @@ func TestGetNexusCompletion(t *testing.T) {
 	cases := []struct {
 		name             string
 		mutateState      func(historyi.MutableState) (*historypb.HistoryEvent, error)
-		verifyCompletion func(*testing.T, nexus.OperationCompletion)
+		verifyCompletion func(*testing.T, *historypb.HistoryEvent, nexus.OperationCompletion)
 	}{
 		{
 			name: "success",
@@ -376,7 +376,7 @@ func TestGetNexusCompletion(t *testing.T) {
 					},
 				}, "")
 			},
-			verifyCompletion: func(t *testing.T, completion nexus.OperationCompletion) {
+			verifyCompletion: func(t *testing.T, event *historypb.HistoryEvent, completion nexus.OperationCompletion) {
 				success, ok := completion.(*nexus.OperationCompletionSuccessful)
 				require.True(t, ok)
 				require.Equal(t, "application/json", success.Reader.Header.Get("type"))
@@ -384,6 +384,7 @@ func TestGetNexusCompletion(t *testing.T) {
 				buf, err := io.ReadAll(success.Reader)
 				require.NoError(t, err)
 				require.Equal(t, []byte("3"), buf)
+				require.Equal(t, event.GetEventTime().AsTime(), success.CloseTime)
 			},
 		},
 		{
@@ -395,11 +396,12 @@ func TestGetNexusCompletion(t *testing.T) {
 					},
 				}, "")
 			},
-			verifyCompletion: func(t *testing.T, completion nexus.OperationCompletion) {
+			verifyCompletion: func(t *testing.T, event *historypb.HistoryEvent, completion nexus.OperationCompletion) {
 				failure, ok := completion.(*nexus.OperationCompletionUnsuccessful)
 				require.True(t, ok)
 				require.Equal(t, nexus.OperationStateFailed, failure.State)
 				require.Equal(t, "workflow failed", failure.Failure.Message)
+				require.Equal(t, event.GetEventTime().AsTime(), failure.CloseTime)
 			},
 		},
 		{
@@ -407,11 +409,12 @@ func TestGetNexusCompletion(t *testing.T) {
 			mutateState: func(mutableState historyi.MutableState) (*historypb.HistoryEvent, error) {
 				return mutableState.AddWorkflowExecutionTerminatedEvent(mutableState.GetNextEventID(), "dont care", nil, "identity", false, nil)
 			},
-			verifyCompletion: func(t *testing.T, completion nexus.OperationCompletion) {
+			verifyCompletion: func(t *testing.T, event *historypb.HistoryEvent, completion nexus.OperationCompletion) {
 				failure, ok := completion.(*nexus.OperationCompletionUnsuccessful)
 				require.True(t, ok)
 				require.Equal(t, nexus.OperationStateFailed, failure.State)
 				require.Equal(t, "operation terminated", failure.Failure.Message)
+				require.Equal(t, event.GetEventTime().AsTime(), failure.CloseTime)
 			},
 		},
 		{
@@ -419,11 +422,12 @@ func TestGetNexusCompletion(t *testing.T) {
 			mutateState: func(mutableState historyi.MutableState) (*historypb.HistoryEvent, error) {
 				return mutableState.AddWorkflowExecutionCanceledEvent(mutableState.GetNextEventID(), &commandpb.CancelWorkflowExecutionCommandAttributes{})
 			},
-			verifyCompletion: func(t *testing.T, completion nexus.OperationCompletion) {
+			verifyCompletion: func(t *testing.T, event *historypb.HistoryEvent, completion nexus.OperationCompletion) {
 				failure, ok := completion.(*nexus.OperationCompletionUnsuccessful)
 				require.True(t, ok)
 				require.Equal(t, nexus.OperationStateCanceled, failure.State)
 				require.Equal(t, "operation canceled", failure.Failure.Message)
+				require.Equal(t, event.GetEventTime().AsTime(), failure.CloseTime)
 			},
 		},
 	}
@@ -458,7 +462,7 @@ func TestGetNexusCompletion(t *testing.T) {
 			events.EXPECT().GetEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(event, nil).Times(1)
 			completion, err := ms.GetNexusCompletion(context.Background(), "")
 			require.NoError(t, err)
-			tc.verifyCompletion(t, completion)
+			tc.verifyCompletion(t, event, completion)
 		})
 	}
 }


### PR DESCRIPTION
## What changed?
- Adds the `CloseTime` header field to Nexus operation completions generated from history.

## Why?
- Scheduler makes use of `CloseTime` to determine optimal latency between requests as a customer metric.
- Depends on https://github.com/nexus-rpc/sdk-go/pull/59

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
