### PR TITLE
Reduce dynamic config client log level to INFO to address noisy debug logging

### DIFF
--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -210,7 +210,11 @@ func newTemporal(t *testing.T, params *TemporalParams) *TemporalImpl {
 		captureMetricsHandler:            params.CaptureMetricsHandler,
 		dcClient:                         dynamicconfig.NewMemoryClient(),
 		// If this doesn't build, make sure you're building with tags 'test_dep':
-		testHooks:                testhooks.NewTestHooksImpl(),
+		testHooks: testhooks.NewTestHooksImpl(),
+		// We are overriding the dynamic config logger with a new one that uses the INFO level
+		// because there are some debug logs that are too verbose for testing.
+		// ex: "No such key in dynamic config, using default"
+		// this can be removed if logging from this package becomes less verbose
 		dynamicConfigLogger:      log.NewZapLogger(log.BuildZapLogger(log.Config{Level: "info"})),
 		serviceFxOptions:         params.ServiceFxOptions,
 		taskCategoryRegistry:     params.TaskCategoryRegistry,


### PR DESCRIPTION
## What changed?
Added functionality to override the dynamic config client log level to INFO for all services in the functional tests. 

### Why?
The dynamic config client introduced in #7052 logs "No such key in dynamic config, using default" at DEBUG level every time a dynamic config key is checked without an override. This creates extremely noisy logs during testing as it fires for many dynamic config checks, making it difficult to see relevant test output and debug information.

This approach:
- Only affects the dynamic config client logging, not the main service logs
- Only applicable to tests not production code

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
