### PR TITLE
Fix replication task skip count calculation

### DIFF
--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -529,7 +529,7 @@ Loop:
 			continue Loop
 		}
 		if !s.shouldProcessTask(item) {
-			continue
+			continue Loop
 		}
 		metrics.ReplicationTaskLoadLatency.With(s.metrics).Record(
 			time.Since(item.GetVisibilityTime()),


### PR DESCRIPTION
## What changed?
Fix replication task skip count calculation.

## Why?
If we skip the task due to namespace clusters check, we should also count as skipped task. So empty task will be sent to passive side to update watermark.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
no risk.
