### PR TITLE
Configure frontend visibility global rps limit to 60

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -693,7 +693,7 @@ all internal-frontends.`,
 	)
 	FrontendGlobalNamespaceVisibilityRPS = NewNamespaceIntSetting(
 		"frontend.globalNamespaceRPS.visibility",
-		0,
+		60,
 		`FrontendGlobalNamespaceVisibilityRPS is workflow namespace rate limit per second for the whole cluster for visibility API.
 The limit is evenly distributed among available frontend service instances.
 If this is set, it overwrites per instance limit "frontend.namespaceRPS.visibility".


### PR DESCRIPTION
## What changed?
Sets `frontend.globalNamespaceRPS.visibility` limit to 60. This is in parity with the per instance RPS limit of 10.

## Why?
Global visibility limits are a better protection mechanism than per instance quotas, which can increase or decrease during autoscaling.

## How did you test it?
- [X] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
`frontend.globalNamespaceRPS.visibility` sets a higher precedence for namespace constrained dynamic configs. Before merging this change, all namespaces with a higher RPS limit than the default value will have their RPS limit configured with a higher value. Peer review approval will be needed before initiating dynamic config deployments and merging this PR.
