### PR TITLE
Fix Single Test Run Failures

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -512,6 +512,7 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: go-${{ runner.os }}${{ runner.arch }}-build-${{ env.COMMIT }}
+
       - name: Get job ID
         if: ${{ inputs.run_single_functional_test != true || (inputs.run_single_functional_test == true && contains(fromJSON(needs.set-up-single-test.outputs.dbs), env.PERSISTENCE_DRIVER)) }}
         id: get_job_id


### PR DESCRIPTION
## What changed?
Add condition for getting the job id during test runs.

## Why?
Some jobs will fail to find the local action since the checkout does not fire. Adding the same condition to to get job id should skip the step for single test runs. 
