### PR TITLE
Add String() func to timer/transfer tasks for better logging

### DIFF
--- a/service/history/tasks/activity_retry_timer.go
+++ b/service/history/tasks/activity_retry_timer.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -63,4 +64,16 @@ func (r *ActivityRetryTimerTask) GetStamp() int32 {
 
 func (r *ActivityRetryTimerTask) SetStamp(stamp int32) {
 	r.Stamp = stamp
+}
+
+func (r *ActivityRetryTimerTask) String() string {
+	return fmt.Sprintf("ActivityRetryTimerTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, EventID: %v, Version: %v, Attempt: %v, Stamp: %v}",
+		r.WorkflowKey.String(),
+		r.VisibilityTimestamp,
+		r.TaskID,
+		r.EventID,
+		r.Version,
+		r.Attempt,
+		r.Stamp,
+	)
 }

--- a/service/history/tasks/activity_task_timer.go
+++ b/service/history/tasks/activity_task_timer.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
@@ -56,4 +57,16 @@ func (a *ActivityTimeoutTask) GetStamp() int32 {
 
 func (a *ActivityTimeoutTask) SetStamp(stamp int32) {
 	a.Stamp = stamp
+}
+
+func (a *ActivityTimeoutTask) String() string {
+	return fmt.Sprintf("ActivityTimeoutTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, TimeoutType: %v, EventID: %v, Attempt: %v, Stamp: %v}",
+		a.WorkflowKey.String(),
+		a.VisibilityTimestamp,
+		a.TaskID,
+		a.TimeoutType,
+		a.EventID,
+		a.Attempt,
+		a.Stamp,
+	)
 }

--- a/service/history/tasks/child_workflow_task.go
+++ b/service/history/tasks/child_workflow_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -57,4 +58,16 @@ func (u *StartChildExecutionTask) GetCategory() Category {
 
 func (u *StartChildExecutionTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_TRANSFER_START_CHILD_EXECUTION
+}
+
+func (u *StartChildExecutionTask) String() string {
+	return fmt.Sprintf("StartChildExecutionTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, TargetNamespaceID: %v, TargetWorkflowID: %v, InitiatedEventID: %v, Version: %v}",
+		u.WorkflowKey.String(),
+		u.VisibilityTimestamp,
+		u.TaskID,
+		u.TargetNamespaceID,
+		u.TargetWorkflowID,
+		u.InitiatedEventID,
+		u.Version,
+	)
 }

--- a/service/history/tasks/close_task.go
+++ b/service/history/tasks/close_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -54,4 +55,15 @@ func (a *CloseExecutionTask) GetCategory() Category {
 
 func (a *CloseExecutionTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_TRANSFER_CLOSE_EXECUTION
+}
+
+func (a *CloseExecutionTask) String() string {
+	return fmt.Sprintf("CloseExecutionTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, Version: %v, DeleteAfterClose: %v, DeleteProcessStage: %v}",
+		a.WorkflowKey.String(),
+		a.VisibilityTimestamp,
+		a.TaskID,
+		a.Version,
+		a.DeleteAfterClose,
+		a.DeleteProcessStage,
+	)
 }

--- a/service/history/tasks/delete_execution_task.go
+++ b/service/history/tasks/delete_execution_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -45,4 +46,13 @@ func (a *DeleteExecutionTask) GetCategory() Category {
 
 func (a *DeleteExecutionTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_TRANSFER_DELETE_EXECUTION
+}
+
+func (a *DeleteExecutionTask) String() string {
+	return fmt.Sprintf("DeleteExecutionTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, ProcessStage: %v}",
+		a.WorkflowKey.String(),
+		a.VisibilityTimestamp,
+		a.TaskID,
+		a.ProcessStage,
+	)
 }

--- a/service/history/tasks/requst_cancel_task.go
+++ b/service/history/tasks/requst_cancel_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -61,4 +62,18 @@ func (u *CancelExecutionTask) GetCategory() Category {
 
 func (u *CancelExecutionTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_TRANSFER_CANCEL_EXECUTION
+}
+
+func (u *CancelExecutionTask) String() string {
+	return fmt.Sprintf("CancelExecutionTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, TargetNamespaceID: %v, TargetWorkflowID: %v, TargetRunID: %v, TargetChildWorkflowOnly: %v, InitiatedEventID: %v, Version: %v}",
+		u.WorkflowKey.String(),
+		u.VisibilityTimestamp,
+		u.TaskID,
+		u.TargetNamespaceID,
+		u.TargetWorkflowID,
+		u.TargetRunID,
+		u.TargetChildWorkflowOnly,
+		u.InitiatedEventID,
+		u.Version,
+	)
 }

--- a/service/history/tasks/signal_task.go
+++ b/service/history/tasks/signal_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -61,4 +62,18 @@ func (u *SignalExecutionTask) GetCategory() Category {
 
 func (u *SignalExecutionTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_TRANSFER_SIGNAL_EXECUTION
+}
+
+func (u *SignalExecutionTask) String() string {
+	return fmt.Sprintf("SignalExecutionTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, TargetNamespaceID: %v, TargetWorkflowID: %v, TargetRunID: %v, TargetChildWorkflowOnly: %v, InitiatedEventID: %v, Version: %v}",
+		u.WorkflowKey.String(),
+		u.VisibilityTimestamp,
+		u.TaskID,
+		u.TargetNamespaceID,
+		u.TargetWorkflowID,
+		u.TargetRunID,
+		u.TargetChildWorkflowOnly,
+		u.InitiatedEventID,
+		u.Version,
+	)
 }

--- a/service/history/tasks/user_timer.go
+++ b/service/history/tasks/user_timer.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -44,4 +45,13 @@ func (u *UserTimerTask) GetCategory() Category {
 
 func (u *UserTimerTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_USER_TIMER
+}
+
+func (u *UserTimerTask) String() string {
+	return fmt.Sprintf("UserTimerTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, EventID: %v}",
+		u.WorkflowKey.String(),
+		u.VisibilityTimestamp,
+		u.TaskID,
+		u.EventID,
+	)
 }

--- a/service/history/tasks/workflow_cleanup_timer.go
+++ b/service/history/tasks/workflow_cleanup_timer.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -54,4 +55,14 @@ func (a *DeleteHistoryEventTask) GetCategory() Category {
 
 func (a *DeleteHistoryEventTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT
+}
+
+func (a *DeleteHistoryEventTask) String() string {
+	return fmt.Sprintf("DeleteHistoryEventTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, Version: %v, ProcessStage: %v}",
+		a.WorkflowKey.String(),
+		a.VisibilityTimestamp,
+		a.TaskID,
+		a.Version,
+		a.ProcessStage,
+	)
 }

--- a/service/history/tasks/workflow_delay_timer.go
+++ b/service/history/tasks/workflow_delay_timer.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -55,4 +56,14 @@ func (r *WorkflowBackoffTimerTask) GetCategory() Category {
 
 func (r *WorkflowBackoffTimerTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_WORKFLOW_BACKOFF_TIMER
+}
+
+func (r *WorkflowBackoffTimerTask) String() string {
+	return fmt.Sprintf("WorkflowBackoffTimerTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, Version: %v, WorkflowBackoffType: %v}",
+		r.WorkflowKey.String(),
+		r.VisibilityTimestamp,
+		r.TaskID,
+		r.Version,
+		r.WorkflowBackoffType,
+	)
 }

--- a/service/history/tasks/workflow_execution_timer.go
+++ b/service/history/tasks/workflow_execution_timer.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -66,4 +67,14 @@ func (t *WorkflowExecutionTimeoutTask) GetCategory() Category {
 
 func (t *WorkflowExecutionTimeoutTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_WORKFLOW_EXECUTION_TIMEOUT
+}
+
+func (t *WorkflowExecutionTimeoutTask) String() string {
+	return fmt.Sprintf("WorkflowExecutionTimeoutTask{NamespaceID: %v, WorkflowID: %v, FirstRunID: %v, VisibilityTimestamp: %v, TaskID: %v}",
+		t.NamespaceID,
+		t.WorkflowID,
+		t.FirstRunID,
+		t.VisibilityTimestamp,
+		t.TaskID,
+	)
 }

--- a/service/history/tasks/workflow_run_timer.go
+++ b/service/history/tasks/workflow_run_timer.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -52,4 +53,13 @@ func (u *WorkflowRunTimeoutTask) GetCategory() Category {
 
 func (u *WorkflowRunTimeoutTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_WORKFLOW_RUN_TIMEOUT
+}
+
+func (u *WorkflowRunTimeoutTask) String() string {
+	return fmt.Sprintf("WorkflowRunTimeoutTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, Version: %v}",
+		u.WorkflowKey.String(),
+		u.VisibilityTimestamp,
+		u.TaskID,
+		u.Version,
+	)
 }

--- a/service/history/tasks/workflow_task.go
+++ b/service/history/tasks/workflow_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -54,4 +55,15 @@ func (d *WorkflowTask) GetCategory() Category {
 
 func (d *WorkflowTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_TRANSFER_WORKFLOW_TASK
+}
+
+func (d *WorkflowTask) String() string {
+	return fmt.Sprintf("WorkflowTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, TaskQueue: %v, ScheduledEventID: %v, Version: %v}",
+		d.WorkflowKey.String(),
+		d.VisibilityTimestamp,
+		d.TaskID,
+		d.TaskQueue,
+		d.ScheduledEventID,
+		d.Version,
+	)
 }

--- a/service/history/tasks/workflow_task_timer.go
+++ b/service/history/tasks/workflow_task_timer.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -85,4 +86,17 @@ func (d *WorkflowTaskTimeoutTask) Cancel() {
 }
 func (d *WorkflowTaskTimeoutTask) State() ctasks.State {
 	return ctasks.State(d.state.Load())
+}
+
+func (d *WorkflowTaskTimeoutTask) String() string {
+	return fmt.Sprintf("WorkflowTaskTimeoutTask{WorkflowKey: %s, VisibilityTimestamp: %v, TaskID: %v, EventID: %v, ScheduleAttempt: %v, TimeoutType: %v, Version: %v, InMemory: %v}",
+		d.WorkflowKey.String(),
+		d.VisibilityTimestamp,
+		d.TaskID,
+		d.EventID,
+		d.ScheduleAttempt,
+		d.TimeoutType,
+		d.Version,
+		d.InMemory,
+	)
 }


### PR DESCRIPTION
## What changed?
Add String() function to history task, so when logging with task-info tag, we can log more info.

## Why?
For better debug experience when there is task drop.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
No risk.