### PR TITLE
Fix dockerhub links in release info

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -160,9 +160,9 @@ jobs:
           [Helm Chart](https://github.com/temporalio/helm-charts)
 
           ### Docker images for this release (use the tag \`${TAG#v}\`)
-          [Server](https://hub.docker.com/repository/docker/temporalio/server)
-          [Server With Auto Setup](https://hub.docker.com/repository/docker/temporalio/auto-setup) ([what is Auto-Setup?](https://docs.temporal.io/blog/auto-setup))
-          [Admin-Tools](https://hub.docker.com/repository/docker/temporalio/admin-tools)
+          [Server](https://hub.docker.com/r/temporalio/server)
+          [Server With Auto Setup](https://hub.docker.com/r/temporalio/auto-setup) ([what is Auto-Setup?](https://docs.temporal.io/blog/auto-setup))
+          [Admin-Tools](https://hub.docker.com/r/temporalio/admin-tools)
 
           **Full Changelog**: https://github.com/temporalio/temporal/compare/${BASE_TAG}...${TAG}
           EOF


### PR DESCRIPTION
## What changed?
Fix links to point to public pages rather than private pages.

## Why?
The old links would show "Not Authorized" for external user.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None
