### PR TITLE
Add versioning behavior tag to activity metrics

### DIFF
--- a/service/history/api/respondactivitytaskcanceled/api.go
+++ b/service/history/api/respondactivitytaskcanceled/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
@@ -42,6 +43,7 @@ func Invoke(
 	var firstScheduledTime time.Time
 	var taskQueue string
 	var workflowTypeName string
+	var versioningBehavior enumspb.VersioningBehavior
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		token.Clock,
@@ -100,6 +102,7 @@ func Invoke(
 			attemptStartedTime = ai.StartedTime.AsTime()
 			firstScheduledTime = ai.FirstScheduledTime.AsTime()
 			taskQueue = ai.TaskQueue
+			versioningBehavior = mutableState.GetEffectiveVersioningBehavior()
 			return &api.UpdateWorkflowAction{
 				Noop:               false,
 				CreateWorkflowTask: true,
@@ -124,7 +127,7 @@ func Invoke(
 			metrics.OperationTag(metrics.HistoryRespondActivityTaskCanceledScope),
 			metrics.WorkflowTypeTag(workflowTypeName),
 			metrics.ActivityTypeTag(token.ActivityType),
-		)
+			metrics.VersioningBehaviorTag(versioningBehavior))
 	}
 	return &historyservice.RespondActivityTaskCanceledResponse{}, err
 }

--- a/service/history/api/respondactivitytaskcompleted/api.go
+++ b/service/history/api/respondactivitytaskcompleted/api.go
@@ -112,7 +112,10 @@ func Invoke(
 				// Unable to add ActivityTaskCompleted event to history
 				return nil, err
 			}
-			attemptStartedTime = ai.StartedTime.AsTime()
+			if !fabricateStartedEvent {
+				// leave it zero if the event is fabricated so the latency metrics are not emitted
+				attemptStartedTime = ai.StartedTime.AsTime()
+			}
 			firstScheduledTime = ai.FirstScheduledTime.AsTime()
 			taskQueue = ai.TaskQueue
 			versioningBehavior = mutableState.GetEffectiveVersioningBehavior()
@@ -126,7 +129,7 @@ func Invoke(
 		workflowConsistencyChecker,
 	)
 
-	if err == nil && !fabricateStartedEvent {
+	if err == nil {
 		workflow.RecordActivityCompletionMetrics(
 			shard,
 			namespace,

--- a/service/history/api/respondactivitytaskcompleted/api.go
+++ b/service/history/api/respondactivitytaskcompleted/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
@@ -43,6 +44,7 @@ func Invoke(
 	var taskQueue string
 	var workflowTypeName string
 	var fabricateStartedEvent bool
+	var versioningBehavior enumspb.VersioningBehavior
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		token.Clock,
@@ -113,6 +115,7 @@ func Invoke(
 			attemptStartedTime = ai.StartedTime.AsTime()
 			firstScheduledTime = ai.FirstScheduledTime.AsTime()
 			taskQueue = ai.TaskQueue
+			versioningBehavior = mutableState.GetEffectiveVersioningBehavior()
 			return &api.UpdateWorkflowAction{
 				Noop:               false,
 				CreateWorkflowTask: true,
@@ -137,6 +140,7 @@ func Invoke(
 			metrics.OperationTag(metrics.HistoryRespondActivityTaskCompletedScope),
 			metrics.WorkflowTypeTag(workflowTypeName),
 			metrics.ActivityTypeTag(token.ActivityType),
+			metrics.VersioningBehaviorTag(versioningBehavior),
 		)
 	}
 	return &historyservice.RespondActivityTaskCompletedResponse{}, err

--- a/service/history/api/respondactivitytaskfailed/api.go
+++ b/service/history/api/respondactivitytaskfailed/api.go
@@ -45,6 +45,7 @@ func Invoke(
 	var taskQueue string
 	var workflowTypeName string
 	var closed bool
+	var versioningBehavior enumspb.VersioningBehavior
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		token.Clock,
@@ -119,6 +120,7 @@ func Invoke(
 			attemptStartedTime = ai.StartedTime.AsTime()
 			firstScheduledTime = ai.FirstScheduledTime.AsTime()
 			taskQueue = ai.TaskQueue
+			versioningBehavior = mutableState.GetEffectiveVersioningBehavior()
 			return postActions, nil
 		},
 		nil,
@@ -133,15 +135,14 @@ func Invoke(
 			Closed:             closed,
 		}
 
-		workflow.RecordActivityCompletionMetrics(
-			shard,
+		workflow.RecordActivityCompletionMetrics(shard,
 			namespace,
 			taskQueue,
 			completionMetrics,
 			metrics.OperationTag(metrics.HistoryRespondActivityTaskFailedScope),
 			metrics.WorkflowTypeTag(workflowTypeName),
 			metrics.ActivityTypeTag(token.ActivityType),
-		)
+			metrics.VersioningBehaviorTag(versioningBehavior))
 	}
 	return &historyservice.RespondActivityTaskFailedResponse{}, err
 }

--- a/service/history/api/respondactivitytaskfailed/api_test.go
+++ b/service/history/api/respondactivitytaskfailed/api_test.go
@@ -110,6 +110,7 @@ func (s *workflowSuite) Test_NormalFlowShouldRescheduleActivity_UpdatesWorkflowE
 
 	s.expectTransientFailureMetricsRecorded(uc, s.shardContext)
 	s.workflowContext.EXPECT().UpdateWorkflowExecutionAsActive(ctx, s.shardContext).Return(nil)
+	s.currentMutableState.EXPECT().GetEffectiveVersioningBehavior().Return(enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED)
 
 	_, err := Invoke(ctx, request, s.shardContext, s.workflowConsistencyChecker)
 	s.NoError(err)
@@ -245,6 +246,7 @@ func (s *workflowSuite) Test_LastHeartBeatDetailsExist_UpdatesMutableState() {
 		Identity:  request.FailedRequest.GetIdentity(),
 		Namespace: request.FailedRequest.GetNamespace(),
 	})
+	s.currentMutableState.EXPECT().GetEffectiveVersioningBehavior().Return(enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED)
 
 	s.expectTransientFailureMetricsRecorded(uc, s.shardContext)
 
@@ -304,6 +306,7 @@ func (s *workflowSuite) Test_NoMoreRetriesAndMutableStateHasNoPendingTasks_WillR
 		request.FailedRequest.WorkerVersion,
 	).Return(nil, nil)
 	s.currentMutableState.EXPECT().AddWorkflowTaskScheduledEvent(false, enumsspb.WORKFLOW_TASK_TYPE_NORMAL)
+	s.currentMutableState.EXPECT().GetEffectiveVersioningBehavior().Return(enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED)
 	s.workflowContext.EXPECT().UpdateWorkflowExecutionAsActive(ctx, s.shardContext).Return(nil)
 
 	_, err := Invoke(ctx, request, s.shardContext, s.workflowConsistencyChecker)
@@ -443,6 +446,7 @@ func (s *workflowSuite) expectTransientFailureMetricsRecorded(uc UsecaseConfig, 
 		metrics.OperationTag(metrics.HistoryRespondActivityTaskFailedScope),
 		metrics.WorkflowTypeTag(uc.wfType.Name),
 		metrics.ActivityTypeTag(uc.activityType),
+		metrics.VersioningBehaviorTag(enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED),
 		metrics.NamespaceTag(uc.namespaceName.String()),
 		metrics.UnsafeTaskQueueTag(uc.taskQueueId),
 	}
@@ -467,6 +471,7 @@ func (s *workflowSuite) expectTerminalFailureMetricsRecorded(uc UsecaseConfig, s
 		metrics.OperationTag(metrics.HistoryRespondActivityTaskFailedScope),
 		metrics.WorkflowTypeTag(uc.wfType.Name),
 		metrics.ActivityTypeTag(uc.activityType),
+		metrics.VersioningBehaviorTag(enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED),
 		metrics.NamespaceTag(uc.namespaceName.String()),
 		metrics.UnsafeTaskQueueTag(uc.taskQueueId),
 	}

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -298,7 +298,7 @@ func (t *timerQueueActiveTaskExecutor) processSingleActivityTimeoutTask(
 
 	workflow.RecordActivityCompletionMetrics(
 		t.shardContext,
-		namespace.Name(mutableState.GetNamespaceEntry().Name()),
+		mutableState.GetNamespaceEntry().Name(),
 		ai.TaskQueue,
 		workflow.ActivityCompletionMetrics{
 			Status:             workflow.ActivityStatusTimeout,
@@ -310,7 +310,7 @@ func (t *timerQueueActiveTaskExecutor) processSingleActivityTimeoutTask(
 		metrics.OperationTag(metrics.TimerActiveTaskActivityTimeoutScope),
 		metrics.WorkflowTypeTag(mutableState.GetWorkflowType().GetName()),
 		metrics.ActivityTypeTag(ai.ActivityType.GetName()),
-	)
+		metrics.VersioningBehaviorTag(mutableState.GetEffectiveVersioningBehavior()))
 
 	if retryState == enumspb.RETRY_STATE_IN_PROGRESS {
 		// TODO uncommment once RETRY_STATE_PAUSED is supported


### PR DESCRIPTION
## What changed?
Adding new `versioning_behavior` tag to the newly added activity metrics so we can compare activity failure and timeout rates between users using versioning vs the ones who don't.

## Why?
above.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None. new tag has only 3 values (low cardinality)