### PR TITLE
improve force replication workflow

### DIFF
--- a/service/worker/migration/force_replication_workflow.go
+++ b/service/worker/migration/force_replication_workflow.go
@@ -103,6 +103,7 @@ var (
 
 const (
 	forceReplicationWorkflowName               = "force-replication"
+	forceReplicationWorkflowV2Name             = "force-replication-v2"
 	forceTaskQueueUserDataReplicationWorkflow  = "force-task-queue-user-data-replication"
 	forceReplicationStatusQueryType            = "force-replication-status"
 	taskQueueUserDataReplicationDoneSignalType = "task-queue-user-data-replication-done"
@@ -197,6 +198,84 @@ func ForceReplicationWorkflow(ctx workflow.Context, params ForceReplicationParam
 	// There are still more workflows to replicate. Continue-as-new to process on a new run.
 	// This prevents history size from exceeding the server-defined limit
 	return workflow.NewContinueAsNewError(ctx, ForceReplicationWorkflow, params)
+}
+
+func ForceReplicationWorkflowV2(ctx workflow.Context, params ForceReplicationParams) error {
+	// For now, we'll return the initial page token for simplicity.
+	// If we want this to be more precise, we could track processed pages.
+	startPageToken := params.NextPageToken
+
+	_ = workflow.SetQueryHandler(ctx, forceReplicationStatusQueryType, func() (ForceReplicationStatus, error) {
+		return ForceReplicationStatus{
+			LastCloseTime:                      params.LastCloseTime,
+			LastStartTime:                      params.LastStartTime,
+			ContinuedAsNewCount:                params.ContinuedAsNewCount,
+			TaskQueueUserDataReplicationStatus: params.TaskQueueUserDataReplicationStatus,
+			TotalWorkflowCount:                 params.TotalForceReplicateWorkflowCount,
+			ReplicatedWorkflowCount:            params.ReplicatedWorkflowCount,
+			ReplicatedWorkflowCountPerSecond:   params.ReplicatedWorkflowCountPerSecond,
+			PageTokenForRestart:                startPageToken,
+		}, nil
+	})
+
+	if err := validateAndSetForceReplicationParams(ctx, &params); err != nil {
+		return err
+	}
+
+	if params.TotalForceReplicateWorkflowCount == 0 {
+		wfCount, err := countWorkflowForReplication(ctx, params)
+		if err != nil {
+			return err
+		}
+		params.TotalForceReplicateWorkflowCount = wfCount
+	}
+
+	metadataResp, err := getClusterMetadata(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	if !params.TaskQueueUserDataReplicationStatus.Done {
+		err = maybeKickoffTaskQueueUserDataReplication(ctx, params, func(failureReason string) {
+			params.TaskQueueUserDataReplicationStatus.FailureMessage = failureReason
+			params.TaskQueueUserDataReplicationStatus.Done = true
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	workflowExecutionsCh := workflow.NewBufferedChannel(ctx, params.PageCountPerExecution)
+	var listWorkflowsErr error
+	workflow.Go(ctx, func(ctx workflow.Context) {
+		listWorkflowsErr = listWorkflowsForReplication(ctx, workflowExecutionsCh, &params)
+
+		// enqueueReplicationTasks only returns when workflowExecutionsCh is closed (or if it encounters an error).
+		// Therefore, listWorkflowsErr will be set prior to their use and params will be updated.
+		workflowExecutionsCh.Close()
+	})
+
+	if err := enqueueReplicationTasksLocal(ctx, workflowExecutionsCh, metadataResp.NamespaceID, &params); err != nil {
+		return err
+	}
+
+	if listWorkflowsErr != nil {
+		return listWorkflowsErr
+	}
+
+	if params.NextPageToken == nil {
+		err := workflow.Await(ctx, func() bool { return params.TaskQueueUserDataReplicationStatus.Done })
+		if err != nil {
+			return err
+		}
+		if params.TaskQueueUserDataReplicationStatus.FailureMessage != "" {
+			return fmt.Errorf("task queue user data replication failed: %v", params.TaskQueueUserDataReplicationStatus.FailureMessage)
+		}
+		return nil
+	}
+
+	params.ContinuedAsNewCount++
+	return workflow.NewContinueAsNewError(ctx, ForceReplicationWorkflowV2, params)
 }
 
 func maybeKickoffTaskQueueUserDataReplication(ctx workflow.Context, params ForceReplicationParams, onDone func(failureReason string)) error {
@@ -464,6 +543,106 @@ func enqueueReplicationTasks(ctx workflow.Context, workflowExecutionsCh workflow
 				}
 			})
 		}
+
+		for pendingGenerateTasks >= params.ConcurrentActivityCount || pendingVerifyTasks >= params.ConcurrentActivityCount {
+			selector.Select(ctx) // this will block until one of the in-flight activities completes
+			if lastActivityErr != nil {
+				return lastActivityErr
+			}
+		}
+	}
+
+	for pendingGenerateTasks > 0 || pendingVerifyTasks > 0 {
+		selector.Select(ctx)
+		if lastActivityErr != nil {
+			return lastActivityErr
+		}
+	}
+
+	return nil
+}
+
+func enqueueReplicationTasksLocal(ctx workflow.Context, workflowExecutionsCh workflow.Channel, namespaceID string, params *ForceReplicationParams) error {
+	selector := workflow.NewSelector(ctx)
+	pendingGenerateTasks := 0
+	pendingVerifyTasks := 0
+
+	lao := workflow.LocalActivityOptions{
+		StartToCloseTimeout: time.Hour,
+		RetryPolicy:         forceReplicationActivityRetryPolicy,
+	}
+
+	lactx := workflow.WithLocalActivityOptions(ctx, lao)
+	var workflowExecutions []*commonpb.WorkflowExecution
+	var lastActivityErr error
+	var a *activities
+
+	var targetClusters []string
+	if params.TargetClusterName != "" {
+		targetClusters = []string{params.TargetClusterName}
+	}
+
+	for workflowExecutionsCh.Receive(ctx, &workflowExecutions) {
+
+		verifyTask := func() {
+			verifyTaskFuture := workflow.ExecuteLocalActivity(
+				lactx,
+				a.VerifyReplicationTasks,
+				&verifyReplicationTasksRequest{
+					TargetClusterEndpoint: params.TargetClusterEndpoint,
+					TargetClusterName:     params.TargetClusterName,
+					Namespace:             params.Namespace,
+					NamespaceID:           namespaceID,
+					Executions:            workflowExecutions,
+					VerifyInterval:        time.Duration(params.VerifyIntervalInSeconds) * time.Second,
+				})
+
+			pendingVerifyTasks++
+			selector.AddFuture(verifyTaskFuture, func(f workflow.Future) {
+				pendingVerifyTasks--
+
+				var verifyTaskResponse verifyReplicationTasksResponse
+				if err := f.Get(ctx, &verifyTaskResponse); err != nil {
+					lastActivityErr = err
+				} else {
+					// Update replication status
+					params.ReplicatedWorkflowCount += int64(verifyTaskResponse.VerifiedWorkflowCount)
+					params.QPSQueue.Enqueue(ctx, params.ReplicatedWorkflowCount)
+					params.ReplicatedWorkflowCountPerSecond = params.QPSQueue.CalculateQPS()
+
+					// Report new QPS to metrics
+					tags := map[string]string{
+						metrics.OperationTagName: metrics.MigrationWorkflowScope,
+						NamespaceTagName:         params.Namespace,
+					}
+					workflow.GetMetricsHandler(ctx).WithTags(tags).Gauge(ForceReplicationRpsTagName).Update(params.ReplicatedWorkflowCountPerSecond)
+				}
+			})
+		}
+
+		generateTaskFuture := workflow.ExecuteLocalActivity(
+			lactx,
+			a.GenerateReplicationTasks,
+			&generateReplicationTasksRequest{
+				NamespaceID:      namespaceID,
+				Executions:       workflowExecutions,
+				RPS:              params.OverallRps / float64(params.ConcurrentActivityCount),
+				GetParentInfoRPS: params.GetParentInfoRPS / float64(params.ConcurrentActivityCount),
+				TargetClusters:   targetClusters,
+			})
+
+		pendingGenerateTasks++
+		selector.AddFuture(generateTaskFuture, func(f workflow.Future) {
+			pendingGenerateTasks--
+
+			if err := f.Get(ctx, nil); err != nil {
+				lastActivityErr = err
+			}
+
+			if params.EnableVerification {
+				verifyTask()
+			}
+		})
 
 		for pendingGenerateTasks >= params.ConcurrentActivityCount || pendingVerifyTasks >= params.ConcurrentActivityCount {
 			selector.Select(ctx) // this will block until one of the in-flight activities completes

--- a/service/worker/migration/force_replication_workflow_test.go
+++ b/service/worker/migration/force_replication_workflow_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -29,7 +29,38 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestForceReplicationWorkflow(t *testing.T) {
+type (
+	ForceReplicationWorkflowTestSuite struct {
+		suite.Suite
+		forceReplicationWorkflowFn interface{}
+	}
+)
+
+func TestForceReplicationWorkflowTestSuite(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name                       string
+		forceReplicationWorkflowFn interface{}
+	}{
+		{
+			name:                       "ForceReplicationWorkflow",
+			forceReplicationWorkflowFn: ForceReplicationWorkflow,
+		},
+		{
+			name:                       "ForceReplicationWorkflowV2",
+			forceReplicationWorkflowFn: ForceReplicationWorkflowV2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &ForceReplicationWorkflowTestSuite{
+				forceReplicationWorkflowFn: tc.forceReplicationWorkflowFn,
+			}
+			suite.Run(t, s)
+		})
+	}
+}
+
+func (s *ForceReplicationWorkflowTestSuite) TestForceReplicationWorkflow() {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
 	env.RegisterWorkflowWithOptions(ForceTaskQueueUserDataReplicationWorkflow, workflow.RegisterOptions{Name: forceTaskQueueUserDataReplicationWorkflow})
@@ -46,7 +77,7 @@ func TestForceReplicationWorkflow(t *testing.T) {
 	closeTime, _ := time.Parse(layout, "2020-02-01 00:00Z")
 
 	env.OnActivity(a.ListWorkflows, mock.Anything, mock.Anything).Return(func(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*listWorkflowsResponse, error) {
-		assert.Equal(t, "test-ns", request.Namespace)
+		s.Equal("test-ns", request.Namespace)
 		currentPageCount++
 		if currentPageCount < totalPageCount {
 			return &listWorkflowsResponse{
@@ -68,7 +99,7 @@ func TestForceReplicationWorkflow(t *testing.T) {
 	env.OnActivity(a.VerifyReplicationTasks, mock.Anything, mock.Anything).Return(verifyReplicationTasksResponse{VerifiedWorkflowCount: 1}, nil).Times(totalPageCount)
 
 	env.OnActivity(a.SeedReplicationQueueWithUserDataEntries, mock.Anything, mock.Anything).Return(nil).Times(1)
-	env.ExecuteWorkflow(ForceReplicationWorkflow, ForceReplicationParams{
+	env.ExecuteWorkflow(s.forceReplicationWorkflowFn, ForceReplicationParams{
 		Namespace:               "test-ns",
 		Query:                   "",
 		ConcurrentActivityCount: 100,
@@ -79,27 +110,27 @@ func TestForceReplicationWorkflow(t *testing.T) {
 		TargetClusterEndpoint:   "test-target",
 	})
 
-	require.True(t, env.IsWorkflowCompleted())
-	require.NoError(t, env.GetWorkflowError())
-	env.AssertExpectations(t)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
 
 	envValue, err := env.QueryWorkflow(forceReplicationStatusQueryType)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	var status ForceReplicationStatus
 	err = envValue.Get(&status)
-	require.NoError(t, err)
-	assert.Equal(t, 0, status.ContinuedAsNewCount)
-	assert.Equal(t, startTime, status.LastStartTime)
-	assert.Equal(t, closeTime, status.LastCloseTime)
-	assert.True(t, status.TaskQueueUserDataReplicationStatus.Done)
-	assert.Equal(t, "", status.TaskQueueUserDataReplicationStatus.FailureMessage)
-	assert.Equal(t, int64(4), status.TotalWorkflowCount)
-	assert.Equal(t, int64(4), status.ReplicatedWorkflowCount)
-	assert.Equal(t, []byte(nil), status.PageTokenForRestart)
+	s.NoError(err)
+	s.Equal(0, status.ContinuedAsNewCount)
+	s.Equal(startTime, status.LastStartTime)
+	s.Equal(closeTime, status.LastCloseTime)
+	s.True(status.TaskQueueUserDataReplicationStatus.Done)
+	s.Equal("", status.TaskQueueUserDataReplicationStatus.FailureMessage)
+	s.Equal(int64(4), status.TotalWorkflowCount)
+	s.Equal(int64(4), status.ReplicatedWorkflowCount)
+	s.Equal([]byte(nil), status.PageTokenForRestart)
 }
 
-func TestForceReplicationWorkflow_ContinueAsNew(t *testing.T) {
+func (s *ForceReplicationWorkflowTestSuite) TestForceReplicationWorkflow_ContinueAsNew() {
 	totalPageCount := 4
 	currentPageCount := 0
 	testMaxPageCountPerExecution := 2
@@ -108,7 +139,7 @@ func TestForceReplicationWorkflow_ContinueAsNew(t *testing.T) {
 	closeTime, _ := time.Parse(layout, "2020-02-01 00:00Z")
 
 	mockListWorkflows := func(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*listWorkflowsResponse, error) {
-		assert.Equal(t, "test-ns", request.Namespace)
+		s.Equal("test-ns", request.Namespace)
 		currentPageCount++
 		if currentPageCount < totalPageCount {
 			return &listWorkflowsResponse{
@@ -152,7 +183,7 @@ func TestForceReplicationWorkflow_ContinueAsNew(t *testing.T) {
 	expectContinueAsNew := true
 
 	// Run the workflow once. We should get a continue as new error.
-	continueAsNewInput, queryStatus := testRunForceReplicationForContinueAsNew(t,
+	continueAsNewInput, queryStatus := s.testRunForceReplicationForContinueAsNew(
 		mockListWorkflows,
 		ForceReplicationParams{
 			Namespace:               "test-ns",
@@ -168,7 +199,7 @@ func TestForceReplicationWorkflow_ContinueAsNew(t *testing.T) {
 		expectContinueAsNew,
 		testMaxPageCountPerExecution,
 	)
-	require.NotNil(t, continueAsNewInput)
+	s.NotNil(continueAsNewInput)
 
 	// tl;dr We do not check TaskQueueUserDataReplicationStatus because we do not know if
 	// ForceTaskQueueUserDataReplicationWorkflow will complete in a given execution of
@@ -189,20 +220,20 @@ func TestForceReplicationWorkflow_ContinueAsNew(t *testing.T) {
 	//   ForceTaskQueueUserDataReplicationWorkflow to finish
 	//
 	// Another test checks that ForceTaskQueueUserDataReplicationWorkflow is invoked correctly.
-	require.Empty(t, cmp.Diff(
+	s.Empty(cmp.Diff(
 		expectedContinueAsNewParams, *continueAsNewInput,
 		cmpopts.IgnoreFields(ForceReplicationParams{}, "TaskQueueUserDataReplicationStatus"),
 		cmpopts.IgnoreFields(ForceReplicationParams{}, "EstimationMultiplier"),
 		cmpopts.IgnoreFields(ForceReplicationParams{}, "QPSQueue"),
 	))
 
-	assert.Equal(t, closeTime, queryStatus.LastCloseTime)
-	assert.Equal(t, startTime, queryStatus.LastStartTime)
-	assert.Equal(t, 1, queryStatus.ContinuedAsNewCount)
-	assert.Equal(t, []byte("fake-initial-page-token"), queryStatus.PageTokenForRestart)
+	s.Equal(closeTime, queryStatus.LastCloseTime)
+	s.Equal(startTime, queryStatus.LastStartTime)
+	s.Equal(1, queryStatus.ContinuedAsNewCount)
+	s.Equal([]byte("fake-initial-page-token"), queryStatus.PageTokenForRestart)
 }
 
-func testRunForceReplicationForContinueAsNew(t *testing.T,
+func (s *ForceReplicationWorkflowTestSuite) testRunForceReplicationForContinueAsNew(
 	mockListWorkflows func(context.Context, *workflowservice.ListWorkflowExecutionsRequest) (*listWorkflowsResponse, error),
 	input ForceReplicationParams,
 	expectContinueAsNew bool,
@@ -225,37 +256,37 @@ func testRunForceReplicationForContinueAsNew(t *testing.T,
 	// executions of ForceReplication. The SeedReplicationQueueWithUserDataEntries activity will eventually run
 	// once, but we aren't guaranteed that it will run during any given execution of ForceReplication.
 	env.OnActivity(a.SeedReplicationQueueWithUserDataEntries, mock.Anything, mock.Anything).Return(nil).Maybe()
-	env.ExecuteWorkflow(ForceReplicationWorkflow, input)
+	env.ExecuteWorkflow(s.forceReplicationWorkflowFn, input)
 
-	require.True(t, env.IsWorkflowCompleted())
+	s.True(env.IsWorkflowCompleted())
 	err := env.GetWorkflowError()
-	env.AssertExpectations(t)
+	env.AssertExpectations(s.T())
 
 	var continueAsNewErr *workflow.ContinueAsNewError
 	var continueAsNewParams *ForceReplicationParams
 	if !expectContinueAsNew {
-		require.NoError(t, err)
+		s.NoError(err)
 	} else {
-		require.Error(t, err)
-		require.True(t, errors.As(err, &continueAsNewErr))
+		s.Error(err)
+		s.True(errors.As(err, &continueAsNewErr))
 
 		var params ForceReplicationParams
 		payloads := continueAsNewErr.Input.GetPayloads()
-		require.Len(t, payloads, 1)
-		require.NoError(t, json.Unmarshal(payloads[0].GetData(), &params))
+		s.Len(payloads, 1)
+		s.NoError(json.Unmarshal(payloads[0].GetData(), &params))
 		continueAsNewParams = &params
 	}
 
 	envValue, err := env.QueryWorkflow(forceReplicationStatusQueryType)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	var status ForceReplicationStatus
-	require.NoError(t, envValue.Get(&status))
+	s.NoError(envValue.Get(&status))
 
 	return continueAsNewParams, status
 }
 
-func TestForceReplicationWorkflow_InvalidInput(t *testing.T) {
+func (s *ForceReplicationWorkflowTestSuite) TestForceReplicationWorkflow_InvalidInput() {
 	testSuite := &testsuite.WorkflowTestSuite{}
 
 	for _, invalidInput := range []ForceReplicationParams{
@@ -269,18 +300,18 @@ func TestForceReplicationWorkflow_InvalidInput(t *testing.T) {
 		},
 	} {
 		env := testSuite.NewTestWorkflowEnvironment()
-		env.ExecuteWorkflow(ForceReplicationWorkflow, invalidInput)
+		env.ExecuteWorkflow(s.forceReplicationWorkflowFn, invalidInput)
 
-		require.True(t, env.IsWorkflowCompleted())
+		s.True(env.IsWorkflowCompleted())
 		err := env.GetWorkflowError()
-		require.Error(t, err)
-		require.ErrorContains(t, err, "InvalidArgument")
-		env.AssertExpectations(t)
+		s.Error(err)
+		s.ErrorContains(err, "InvalidArgument")
+		env.AssertExpectations(s.T())
 
 	}
 }
 
-func TestForceReplicationWorkflow_ListWorkflowsError(t *testing.T) {
+func (s *ForceReplicationWorkflowTestSuite) TestForceReplicationWorkflow_ListWorkflowsError() {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
 	env.RegisterWorkflowWithOptions(ForceTaskQueueUserDataReplicationWorkflow, workflow.RegisterOptions{Name: forceTaskQueueUserDataReplicationWorkflow})
@@ -295,7 +326,7 @@ func TestForceReplicationWorkflow_ListWorkflowsError(t *testing.T) {
 
 	env.OnActivity(a.SeedReplicationQueueWithUserDataEntries, mock.Anything, mock.Anything).Return(nil)
 
-	env.ExecuteWorkflow(ForceReplicationWorkflow, ForceReplicationParams{
+	env.ExecuteWorkflow(s.forceReplicationWorkflowFn, ForceReplicationParams{
 		Namespace:               "test-ns",
 		Query:                   "",
 		ConcurrentActivityCount: 2,
@@ -304,14 +335,14 @@ func TestForceReplicationWorkflow_ListWorkflowsError(t *testing.T) {
 		PageCountPerExecution:   maxPageCountPerExecution,
 	})
 
-	require.True(t, env.IsWorkflowCompleted())
+	s.True(env.IsWorkflowCompleted())
 	err := env.GetWorkflowError()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "mock listWorkflows error")
-	env.AssertExpectations(t)
+	s.Error(err)
+	s.Contains(err.Error(), "mock listWorkflows error")
+	env.AssertExpectations(s.T())
 }
 
-func TestForceReplicationWorkflow_GenerateReplicationTaskRetryableError(t *testing.T) {
+func (s *ForceReplicationWorkflowTestSuite) TestForceReplicationWorkflow_GenerateReplicationTaskRetryableError() {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
 	env.RegisterWorkflowWithOptions(ForceTaskQueueUserDataReplicationWorkflow, workflow.RegisterOptions{Name: forceTaskQueueUserDataReplicationWorkflow})
@@ -324,7 +355,7 @@ func TestForceReplicationWorkflow_GenerateReplicationTaskRetryableError(t *testi
 	totalPageCount := 4
 	currentPageCount := 0
 	env.OnActivity(a.ListWorkflows, mock.Anything, mock.Anything).Return(func(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*listWorkflowsResponse, error) {
-		assert.Equal(t, "test-ns", request.Namespace)
+		s.Equal("test-ns", request.Namespace)
 		currentPageCount++
 		if currentPageCount < totalPageCount {
 			return &listWorkflowsResponse{
@@ -343,7 +374,7 @@ func TestForceReplicationWorkflow_GenerateReplicationTaskRetryableError(t *testi
 
 	env.OnActivity(a.SeedReplicationQueueWithUserDataEntries, mock.Anything, mock.Anything).Return(nil)
 
-	env.ExecuteWorkflow(ForceReplicationWorkflow, ForceReplicationParams{
+	env.ExecuteWorkflow(s.forceReplicationWorkflowFn, ForceReplicationParams{
 		Namespace:               "test-ns",
 		Query:                   "",
 		ConcurrentActivityCount: 2,
@@ -352,14 +383,14 @@ func TestForceReplicationWorkflow_GenerateReplicationTaskRetryableError(t *testi
 		PageCountPerExecution:   4,
 	})
 
-	require.True(t, env.IsWorkflowCompleted())
+	s.True(env.IsWorkflowCompleted())
 	err := env.GetWorkflowError()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "mock generate replication tasks error")
-	env.AssertExpectations(t)
+	s.Error(err)
+	s.Contains(err.Error(), "mock generate replication tasks error")
+	env.AssertExpectations(s.T())
 }
 
-func TestForceReplicationWorkflow_GenerateReplicationTaskNonRetryableError(t *testing.T) {
+func (s *ForceReplicationWorkflowTestSuite) TestForceReplicationWorkflow_GenerateReplicationTaskNonRetryableError() {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
 	env.RegisterWorkflowWithOptions(ForceTaskQueueUserDataReplicationWorkflow, workflow.RegisterOptions{Name: forceTaskQueueUserDataReplicationWorkflow})
@@ -372,7 +403,7 @@ func TestForceReplicationWorkflow_GenerateReplicationTaskNonRetryableError(t *te
 	totalPageCount := 4
 	currentPageCount := 0
 	env.OnActivity(a.ListWorkflows, mock.Anything, mock.Anything).Return(func(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*listWorkflowsResponse, error) {
-		assert.Equal(t, "test-ns", request.Namespace)
+		s.Equal("test-ns", request.Namespace)
 		currentPageCount++
 		if currentPageCount < totalPageCount {
 			return &listWorkflowsResponse{
@@ -396,7 +427,7 @@ func TestForceReplicationWorkflow_GenerateReplicationTaskNonRetryableError(t *te
 
 	env.OnActivity(a.SeedReplicationQueueWithUserDataEntries, mock.Anything, mock.Anything).Return(nil)
 
-	env.ExecuteWorkflow(ForceReplicationWorkflow, ForceReplicationParams{
+	env.ExecuteWorkflow(s.forceReplicationWorkflowFn, ForceReplicationParams{
 		Namespace:               "test-ns",
 		Query:                   "",
 		ConcurrentActivityCount: 1,
@@ -407,14 +438,14 @@ func TestForceReplicationWorkflow_GenerateReplicationTaskNonRetryableError(t *te
 		TargetClusterEndpoint:   "test-target",
 	})
 
-	require.True(t, env.IsWorkflowCompleted())
+	s.True(env.IsWorkflowCompleted())
 	err := env.GetWorkflowError()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), errMsg)
-	env.AssertExpectations(t)
+	s.Error(err)
+	s.Contains(err.Error(), errMsg)
+	env.AssertExpectations(s.T())
 }
 
-func TestForceReplicationWorkflow_VerifyReplicationTaskNonRetryableError(t *testing.T) {
+func (s *ForceReplicationWorkflowTestSuite) TestForceReplicationWorkflow_VerifyReplicationTaskNonRetryableError() {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
 	env.RegisterWorkflowWithOptions(ForceTaskQueueUserDataReplicationWorkflow, workflow.RegisterOptions{Name: forceTaskQueueUserDataReplicationWorkflow})
@@ -427,7 +458,7 @@ func TestForceReplicationWorkflow_VerifyReplicationTaskNonRetryableError(t *test
 	totalPageCount := 4
 	currentPageCount := 0
 	env.OnActivity(a.ListWorkflows, mock.Anything, mock.Anything).Return(func(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*listWorkflowsResponse, error) {
-		assert.Equal(t, "test-ns", request.Namespace)
+		s.Equal("test-ns", request.Namespace)
 		currentPageCount++
 		if currentPageCount < totalPageCount {
 			return &listWorkflowsResponse{
@@ -452,7 +483,7 @@ func TestForceReplicationWorkflow_VerifyReplicationTaskNonRetryableError(t *test
 
 	env.OnActivity(a.SeedReplicationQueueWithUserDataEntries, mock.Anything, mock.Anything).Return(nil)
 
-	env.ExecuteWorkflow(ForceReplicationWorkflow, ForceReplicationParams{
+	env.ExecuteWorkflow(s.forceReplicationWorkflowFn, ForceReplicationParams{
 		Namespace:               "test-ns",
 		Query:                   "",
 		ConcurrentActivityCount: 1,
@@ -463,14 +494,14 @@ func TestForceReplicationWorkflow_VerifyReplicationTaskNonRetryableError(t *test
 		TargetClusterEndpoint:   "test-target",
 	})
 
-	require.True(t, env.IsWorkflowCompleted())
+	s.True(env.IsWorkflowCompleted())
 	err := env.GetWorkflowError()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), errMsg)
-	env.AssertExpectations(t)
+	s.Error(err)
+	s.Contains(err.Error(), errMsg)
+	env.AssertExpectations(s.T())
 }
 
-func TestForceReplicationWorkflow_TaskQueueReplicationFailure(t *testing.T) {
+func (s *ForceReplicationWorkflowTestSuite) TestForceReplicationWorkflow_TaskQueueReplicationFailure() {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
 	env.RegisterWorkflowWithOptions(ForceTaskQueueUserDataReplicationWorkflow, workflow.RegisterOptions{Name: forceTaskQueueUserDataReplicationWorkflow})
@@ -489,7 +520,7 @@ func TestForceReplicationWorkflow_TaskQueueReplicationFailure(t *testing.T) {
 		temporal.NewNonRetryableApplicationError("namespace is required", "InvalidArgument", nil),
 	)
 
-	env.ExecuteWorkflow(ForceReplicationWorkflow, ForceReplicationParams{
+	env.ExecuteWorkflow(s.forceReplicationWorkflowFn, ForceReplicationParams{
 		Namespace:               "test-ns",
 		Query:                   "",
 		ConcurrentActivityCount: 2,
@@ -498,19 +529,19 @@ func TestForceReplicationWorkflow_TaskQueueReplicationFailure(t *testing.T) {
 		PageCountPerExecution:   maxPageCountPerExecution,
 	})
 
-	require.True(t, env.IsWorkflowCompleted())
-	require.Error(t, env.GetWorkflowError())
-	env.AssertExpectations(t)
+	s.True(env.IsWorkflowCompleted())
+	s.Error(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
 
 	envValue, err := env.QueryWorkflow(forceReplicationStatusQueryType)
-	require.NoError(t, err)
+	s.NoError(err)
 
 	var status ForceReplicationStatus
 	err = envValue.Get(&status)
-	require.NoError(t, err)
-	assert.True(t, status.TaskQueueUserDataReplicationStatus.Done)
-	assert.Contains(t, status.TaskQueueUserDataReplicationStatus.FailureMessage, "namespace is required")
-	assert.Equal(t, []byte(nil), status.PageTokenForRestart)
+	s.NoError(err)
+	s.True(status.TaskQueueUserDataReplicationStatus.Done)
+	s.Contains(status.TaskQueueUserDataReplicationStatus.FailureMessage, "namespace is required")
+	s.Equal([]byte(nil), status.PageTokenForRestart)
 }
 
 func TestSeedReplicationQueueWithUserDataEntries_Heartbeats(t *testing.T) {

--- a/service/worker/migration/fx.go
+++ b/service/worker/migration/fx.go
@@ -63,6 +63,7 @@ func NewResult(params initParams) fxResult {
 func (wc *replicationWorkerComponent) RegisterWorkflow(registry sdkworker.Registry) {
 	registry.RegisterWorkflowWithOptions(CatchupWorkflow, workflow.RegisterOptions{Name: catchupWorkflowName})
 	registry.RegisterWorkflowWithOptions(ForceReplicationWorkflow, workflow.RegisterOptions{Name: forceReplicationWorkflowName})
+	registry.RegisterWorkflowWithOptions(ForceReplicationWorkflowV2, workflow.RegisterOptions{Name: forceReplicationWorkflowV2Name})
 	registry.RegisterWorkflowWithOptions(NamespaceHandoverWorkflow, workflow.RegisterOptions{Name: namespaceHandoverWorkflowName})
 	registry.RegisterWorkflowWithOptions(NamespaceHandoverWorkflowV2, workflow.RegisterOptions{Name: namespaceHandoverWorkflowV2Name})
 	registry.RegisterWorkflowWithOptions(ForceTaskQueueUserDataReplicationWorkflow, workflow.RegisterOptions{Name: forceTaskQueueUserDataReplicationWorkflow})


### PR DESCRIPTION
1. Use local activity for GenerateReplicationTasks and VerifyReplicationTasks.
2. Do VerifyReplicationTasks after GenerateReplicationTasks to ensure workflows are replicated before verifying.

## What changed?
_Describe what has changed in this PR._

## Why?
_Tell your future self why have you made these changes._

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
