### PR TITLE
chore: remove unused min func

### DIFF
--- a/common/locks/condition_variable_test.go
+++ b/common/locks/condition_variable_test.go
@@ -230,13 +230,3 @@ func randSignalBroadcast(
 		cv.Broadcast()
 	}
 }
-
-func min(left int, right int) int {
-	if left < right {
-		return left
-	} else if left > right {
-		return right
-	} else {
-		return left
-	}
-}


### PR DESCRIPTION
## What changed?


Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 


## Why?
_Tell your future self why have you made these changes._

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
