### PR TITLE
fix(testrunner): omit failure Details to maintain xml formatting

### DIFF
--- a/tools/testrunner/junit.go
+++ b/tools/testrunner/junit.go
@@ -83,10 +83,10 @@ func (j *junitReport) appendAlertsSuite(alerts []alert) {
 		if p := primaryTestName(a.Tests); p != "" {
 			name = fmt.Sprintf("%s — in %s", name, p)
 		}
-		// Prepend detected test names to the details for quick context in CI UIs.
-		details := a.Details
+		// Include only test names for context, not the full log details to avoid XML malformation
+		var details string
 		if len(a.Tests) > 0 {
-			details = fmt.Sprintf("Detected in tests:\n\t%s\n\n%s", strings.Join(a.Tests, "\n\t"), a.Details)
+			details = fmt.Sprintf("Detected in tests:\n\t%s", strings.Join(a.Tests, "\n\t"))
 		}
 		r := &junit.Result{Message: string(a.Kind), Data: details}
 		cases = append(cases, junit.Testcase{


### PR DESCRIPTION
## What changed?
Removes the full test failure from the `Details` portion of a `junit.Result` which was breaking XML formatting.

## Why?
Breaks our flaky test analysis

## How did you test it?
- [ ] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Flaky tests reporting could be breaking again.
