### PR TITLE
Use a concrete type for metrics.Tag

### DIFF
--- a/common/metrics/metricstest/capture_handler.go
+++ b/common/metrics/metricstest/capture_handler.go
@@ -86,10 +86,10 @@ func (c *CaptureHandler) WithTags(tags ...metrics.Tag) metrics.Handler {
 func (c *CaptureHandler) record(name string, v any, unit metrics.MetricUnit, tags ...metrics.Tag) {
 	rec := &CapturedRecording{Value: v, Tags: make(map[string]string, len(c.tags)+len(tags)), Unit: unit}
 	for _, tag := range c.tags {
-		rec.Tags[tag.Key()] = tag.Value()
+		rec.Tags[tag.Key] = tag.Value
 	}
 	for _, tag := range tags {
-		rec.Tags[tag.Key()] = tag.Value()
+		rec.Tags[tag.Key] = tag.Value
 	}
 	c.capturesLock.RLock()
 	defer c.capturesLock.RUnlock()

--- a/common/metrics/metricstest/metricstest.go
+++ b/common/metrics/metricstest/metricstest.go
@@ -177,7 +177,7 @@ func (m *otelProvider) Stop(log.Logger) {}
 func (s Snapshot) getValue(name string, metricType dto.MetricType, tags ...metrics.Tag) (float64, error) {
 	labelValues := map[string]string{}
 	for _, tag := range tags {
-		labelValues[tag.Key()] = tag.Value()
+		labelValues[tag.Key] = tag.Value
 	}
 	sample, ok := s.samples[name]
 	if !ok {
@@ -203,7 +203,7 @@ func (s Snapshot) Gauge(name string, tags ...metrics.Tag) (float64, error) {
 func (s Snapshot) Histogram(name string, tags ...metrics.Tag) ([]HistogramBucket, error) {
 	labelValues := map[string]string{}
 	for _, tag := range tags {
-		labelValues[tag.Key()] = tag.Value()
+		labelValues[tag.Key] = tag.Value
 	}
 
 	sample, ok := s.histogramSamples[name]

--- a/common/metrics/otel_metrics_handler.go
+++ b/common/metrics/otel_metrics_handler.go
@@ -230,12 +230,12 @@ func (omp *otelMetricsHandler) makeSet(tags []Tag) attribute.Set {
 }
 
 func (omp *otelMetricsHandler) convertTag(tag Tag) attribute.KeyValue {
-	if vals, ok := omp.excludeTags[tag.Key()]; ok {
-		if _, ok := vals[tag.Value()]; !ok {
-			return attribute.String(tag.Key(), tagExcludedValue)
+	if vals, ok := omp.excludeTags[tag.Key]; ok {
+		if _, ok := vals[tag.Value]; !ok {
+			return attribute.String(tag.Key, tagExcludedValue)
 		}
 	}
-	return attribute.String(tag.Key(), tag.Value())
+	return attribute.String(tag.Key, tag.Value)
 }
 
 func makeInitialSet(tags map[string]string) attribute.Set {

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -73,22 +73,14 @@ const (
 	unknownRun  = "unknown"
 )
 
-// Tag is an interface to define metrics tags
+// Tag is a struct to define metrics tags
 type Tag struct {
-	key   string
-	value string
-}
-
-func (v Tag) Key() string {
-	return v.key
-}
-
-func (v Tag) Value() string {
-	return v.value
+	Key   string
+	Value string
 }
 
 func (v Tag) String() string {
-	return fmt.Sprintf("tag{key: %q, value: %q}", v.Key(), v.Value())
+	return fmt.Sprintf("tag{key: %q, value: %q}", v.Key, v.Value)
 }
 
 // NamespaceTag returns a new namespace tag. For timers, this also ensures that we
@@ -98,7 +90,7 @@ func NamespaceTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: namespace, value: value}
+	return Tag{Key: namespace, Value: value}
 }
 
 // NamespaceIDTag returns a new namespace ID tag.
@@ -106,10 +98,10 @@ func NamespaceIDTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: namespaceID, value: value}
+	return Tag{Key: namespaceID, Value: value}
 }
 
-var namespaceUnknownTag = Tag{key: namespace, value: unknownValue}
+var namespaceUnknownTag = Tag{Key: namespace, Value: unknownValue}
 
 // NamespaceUnknownTag returns a new namespace:unknown tag-value
 func NamespaceUnknownTag() Tag {
@@ -121,10 +113,10 @@ func NamespaceStateTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: namespaceState, value: value}
+	return Tag{Key: namespaceState, Value: value}
 }
 
-var taskQueueUnknownTag = Tag{key: taskQueue, value: unknownValue}
+var taskQueueUnknownTag = Tag{Key: taskQueue, Value: unknownValue}
 
 // TaskQueueUnknownTag returns a new taskqueue:unknown tag-value
 func TaskQueueUnknownTag() Tag {
@@ -133,7 +125,7 @@ func TaskQueueUnknownTag() Tag {
 
 // InstanceTag returns a new instance tag
 func InstanceTag(value string) Tag {
-	return Tag{key: instance, value: value}
+	return Tag{Key: instance, Value: value}
 }
 
 // SourceClusterTag returns a new source cluster tag.
@@ -141,7 +133,7 @@ func SourceClusterTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: sourceCluster, value: value}
+	return Tag{Key: sourceCluster, Value: value}
 }
 
 // TargetClusterTag returns a new target cluster tag.
@@ -149,17 +141,17 @@ func TargetClusterTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: targetCluster, value: value}
+	return Tag{Key: targetCluster, Value: value}
 }
 
 // FromClusterIDTag returns a new from cluster tag.
 func FromClusterIDTag(value int32) Tag {
-	return Tag{key: fromCluster, value: strconv.FormatInt(int64(value), 10)}
+	return Tag{Key: fromCluster, Value: strconv.FormatInt(int64(value), 10)}
 }
 
 // ToClusterIDTag returns a new to cluster tag.
 func ToClusterIDTag(value int32) Tag {
-	return Tag{key: toCluster, value: strconv.FormatInt(int64(value), 10)}
+	return Tag{Key: toCluster, Value: strconv.FormatInt(int64(value), 10)}
 }
 
 // UnsafeTaskQueueTag returns a new task queue tag.
@@ -174,11 +166,11 @@ func UnsafeTaskQueueTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: taskQueue, value: value}
+	return Tag{Key: taskQueue, Value: value}
 }
 
 func TaskQueueTypeTag(tqType enumspb.TaskQueueType) Tag {
-	return Tag{key: TaskTypeTagName, value: tqType.String()}
+	return Tag{Key: TaskTypeTagName, Value: tqType.String()}
 }
 
 // Consider passing the value of "metrics.breakdownByBuildID" dynamic config to this function.
@@ -188,7 +180,7 @@ func WorkerBuildIdTag(buildId string, buildIdBreakdown bool) Tag {
 	} else if !buildIdBreakdown {
 		buildId = "__versioned__"
 	}
-	return Tag{key: workerBuildId, value: buildId}
+	return Tag{Key: workerBuildId, Value: buildId}
 }
 
 // WorkflowTypeTag returns a new workflow type tag.
@@ -196,7 +188,7 @@ func WorkflowTypeTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: workflowType, value: value}
+	return Tag{Key: workflowType, Value: value}
 }
 
 // ActivityTypeTag returns a new activity type tag.
@@ -204,7 +196,7 @@ func ActivityTypeTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: activityType, value: value}
+	return Tag{Key: activityType, Value: value}
 }
 
 // CommandTypeTag returns a new command type tag.
@@ -212,7 +204,7 @@ func CommandTypeTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: commandType, value: value}
+	return Tag{Key: commandType, Value: value}
 }
 
 // Returns a new service role tag.
@@ -220,7 +212,7 @@ func ServiceRoleTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: ServiceRoleTagName, value: value}
+	return Tag{Key: ServiceRoleTagName, Value: value}
 }
 
 // Returns a new failure type tag
@@ -228,7 +220,7 @@ func FailureTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: FailureTagName, value: value}
+	return Tag{Key: FailureTagName, Value: value}
 }
 
 func FirstAttemptTag(attempt int32) Tag {
@@ -236,140 +228,140 @@ func FirstAttemptTag(attempt int32) Tag {
 	if attempt == 1 {
 		value = trueValue
 	}
-	return Tag{key: isFirstAttempt, value: value}
+	return Tag{Key: isFirstAttempt, Value: value}
 }
 
 func FailureSourceTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: FailureSourceTagName, value: value}
+	return Tag{Key: FailureSourceTagName, Value: value}
 }
 
 func TaskCategoryTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: TaskCategoryTagName, value: value}
+	return Tag{Key: TaskCategoryTagName, Value: value}
 }
 
 func TaskTypeTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: TaskTypeTagName, value: value}
+	return Tag{Key: TaskTypeTagName, Value: value}
 }
 
 func PartitionTag(partition string) Tag {
-	return Tag{key: PartitionTagName, value: partition}
+	return Tag{Key: PartitionTagName, Value: partition}
 }
 
 func TaskPriorityTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: TaskPriorityTagName, value: value}
+	return Tag{Key: TaskPriorityTagName, Value: value}
 }
 
 func QueueReaderIDTag(readerID int64) Tag {
-	return Tag{key: QueueReaderIDTagName, value: strconv.Itoa(int(readerID))}
+	return Tag{Key: QueueReaderIDTagName, Value: strconv.Itoa(int(readerID))}
 }
 
 func QueueActionTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: QueueActionTagName, value: value}
+	return Tag{Key: QueueActionTagName, Value: value}
 }
 
 func QueueTypeTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: QueueTypeTagName, value: value}
+	return Tag{Key: QueueTypeTagName, Value: value}
 }
 
 func VisibilityPluginNameTag(value string) Tag {
 	if value == "" {
 		value = unknownValue
 	}
-	return Tag{key: visibilityPluginNameTagName, value: value}
+	return Tag{Key: visibilityPluginNameTagName, Value: value}
 }
 
 func VisibilityIndexNameTag(value string) Tag {
 	if value == "" {
 		value = unknownValue
 	}
-	return Tag{key: visibilityIndexNameTagName, value: value}
+	return Tag{Key: visibilityIndexNameTagName, Value: value}
 }
 
 // VersionedTag represents whether a loaded task queue manager represents a specific version set or build ID or not.
 func VersionedTag(versioned string) Tag {
-	return Tag{key: versionedTagName, value: versioned}
+	return Tag{Key: versionedTagName, Value: versioned}
 }
 
 func ServiceErrorTypeTag(err error) Tag {
-	return Tag{key: ErrorTypeTagName, value: strings.TrimPrefix(util.ErrorType(err), errorPrefix)}
+	return Tag{Key: ErrorTypeTagName, Value: strings.TrimPrefix(util.ErrorType(err), errorPrefix)}
 }
 
 func OutcomeTag(outcome string) Tag {
-	return Tag{key: outcomeTagName, value: outcome}
+	return Tag{Key: outcomeTagName, Value: outcome}
 }
 
 func NexusMethodTag(value string) Tag {
-	return Tag{key: nexusMethodTagName, value: value}
+	return Tag{Key: nexusMethodTagName, Value: value}
 }
 
 func NexusEndpointTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return Tag{key: nexusEndpointTagName, value: value}
+	return Tag{Key: nexusEndpointTagName, Value: value}
 }
 
 func NexusServiceTag(value string) Tag {
-	return Tag{key: nexusServiceTagName, value: value}
+	return Tag{Key: nexusServiceTagName, Value: value}
 }
 
 func NexusOperationTag(value string) Tag {
-	return Tag{key: nexusOperationTagName, value: value}
+	return Tag{Key: nexusOperationTagName, Value: value}
 }
 
 // HttpStatusTag returns a new httpStatusTag.
 func HttpStatusTag(value int) Tag {
-	return Tag{key: httpStatusTagName, value: strconv.Itoa(value)}
+	return Tag{Key: httpStatusTagName, Value: strconv.Itoa(value)}
 }
 
 func ResourceExhaustedCauseTag(cause enumspb.ResourceExhaustedCause) Tag {
-	return Tag{key: resourceExhaustedTag, value: cause.String()}
+	return Tag{Key: resourceExhaustedTag, Value: cause.String()}
 }
 
 func ResourceExhaustedScopeTag(scope enumspb.ResourceExhaustedScope) Tag {
-	return Tag{key: resourceExhaustedScopeTag, value: scope.String()}
+	return Tag{Key: resourceExhaustedScopeTag, Value: scope.String()}
 }
 
 func ServiceNameTag(value primitives.ServiceName) Tag {
-	return Tag{key: serviceName, value: string(value)}
+	return Tag{Key: serviceName, Value: string(value)}
 }
 
 func ActionType(value string) Tag {
-	return Tag{key: actionType, value: value}
+	return Tag{Key: actionType, Value: value}
 }
 
 func OperationTag(value string) Tag {
-	return Tag{key: OperationTagName, value: value}
+	return Tag{Key: OperationTagName, Value: value}
 }
 
 func StringTag(key string, value string) Tag {
-	return Tag{key: key, value: value}
+	return Tag{Key: key, Value: value}
 }
 
 func CacheTypeTag(value string) Tag {
-	return Tag{key: CacheTypeTagName, value: value}
+	return Tag{Key: CacheTypeTagName, Value: value}
 }
 
 func PriorityTag(value locks.Priority) Tag {
-	return Tag{key: PriorityTagName, value: strconv.Itoa(int(value))}
+	return Tag{Key: PriorityTagName, Value: strconv.Itoa(int(value))}
 }
 
 // ReasonString is just a string but the special type is defined here to remind callers of ReasonTag to limit the
@@ -379,46 +371,46 @@ type ReasonString string
 // ReasonTag is a generic tag can be used anywhere a reason is needed.
 // Make sure that the value is of limited cardinality.
 func ReasonTag(value ReasonString) Tag {
-	return Tag{key: reason, value: string(value)}
+	return Tag{Key: reason, Value: string(value)}
 }
 
 // ReplicationTaskTypeTag returns a new replication task type tag.
 func ReplicationTaskTypeTag(value enumsspb.ReplicationTaskType) Tag {
-	return Tag{key: replicationTaskType, value: value.String()}
+	return Tag{Key: replicationTaskType, Value: value.String()}
 }
 
 // ReplicationTaskPriorityTag returns a replication task priority tag.
 func ReplicationTaskPriorityTag(value enumsspb.TaskPriority) Tag {
-	return Tag{key: replicationTaskPriority, value: value.String()}
+	return Tag{Key: replicationTaskPriority, Value: value.String()}
 }
 
 // DestinationTag is a tag for metrics emitted by outbound task executors for the task's destination.
 func DestinationTag(value string) Tag {
-	return Tag{key: destination, value: value}
+	return Tag{Key: destination, Value: value}
 }
 
 func VersioningBehaviorTag(behavior enumspb.VersioningBehavior) Tag {
-	return Tag{key: versioningBehavior, value: behavior.String()}
+	return Tag{Key: versioningBehavior, Value: behavior.String()}
 }
 
 func WorkflowStatusTag(status string) Tag {
-	return Tag{key: workflowStatus, value: status}
+	return Tag{Key: workflowStatus, Value: status}
 }
 
 func QueryTypeTag(queryType string) Tag {
 	if queryType == queryTypeStackTrace || queryType == queryTypeOpenSessions || queryType == queryTypeWorkflowMetadata {
-		return Tag{key: queryTypeTag, value: queryType}
+		return Tag{Key: queryTypeTag, Value: queryType}
 	}
 	// group all user defined queries into a single tag value
-	return Tag{key: queryTypeTag, value: queryTypeUserDefined}
+	return Tag{Key: queryTypeTag, Value: queryTypeUserDefined}
 }
 
 func VersioningBehaviorBeforeOverrideTag(behavior enumspb.VersioningBehavior) Tag {
-	return Tag{key: behaviorBefore, value: behavior.String()}
+	return Tag{Key: behaviorBefore, Value: behavior.String()}
 }
 
 func VersioningBehaviorAfterOverrideTag(behavior enumspb.VersioningBehavior) Tag {
-	return Tag{key: behaviorAfter, value: behavior.String()}
+	return Tag{Key: behaviorAfter, Value: behavior.String()}
 }
 
 // RunInitiatorTag creates a tag indicating how a workflow run was initiated.
@@ -427,43 +419,43 @@ func VersioningBehaviorAfterOverrideTag(behavior enumspb.VersioningBehavior) Tag
 // it returns a tag indicating an existing run.
 func RunInitiatorTag(prevRunID string, attributes *historypb.WorkflowExecutionStartedEventAttributes) Tag {
 	if attributes == nil {
-		return Tag{key: runInitiator, value: existingRun}
+		return Tag{Key: runInitiator, Value: existingRun}
 	} else if attributes.GetParentWorkflowExecution() != nil {
-		return Tag{key: runInitiator, value: childRun}
+		return Tag{Key: runInitiator, Value: childRun}
 	}
 
 	switch attributes.GetInitiator() {
 	case enumspb.CONTINUE_AS_NEW_INITIATOR_UNSPECIFIED:
-		return Tag{key: runInitiator, value: newRun}
+		return Tag{Key: runInitiator, Value: newRun}
 	case enumspb.CONTINUE_AS_NEW_INITIATOR_WORKFLOW:
-		return Tag{key: runInitiator, value: canRun}
+		return Tag{Key: runInitiator, Value: canRun}
 	case enumspb.CONTINUE_AS_NEW_INITIATOR_RETRY:
-		return Tag{key: runInitiator, value: retryRun}
+		return Tag{Key: runInitiator, Value: retryRun}
 	case enumspb.CONTINUE_AS_NEW_INITIATOR_CRON_SCHEDULE:
-		return Tag{key: runInitiator, value: cronRun}
+		return Tag{Key: runInitiator, Value: cronRun}
 	default:
-		return Tag{key: runInitiator, value: unknownRun}
+		return Tag{Key: runInitiator, Value: unknownRun}
 	}
 }
 
 func FromUnversionedTag(version string) Tag {
 	if version == "_unversioned_" {
-		return Tag{key: fromUnversioned, value: trueValue}
+		return Tag{Key: fromUnversioned, Value: trueValue}
 	}
-	return Tag{key: fromUnversioned, value: falseValue}
+	return Tag{Key: fromUnversioned, Value: falseValue}
 }
 
 func ToUnversionedTag(version string) Tag {
 	if version == "_unversioned_" {
-		return Tag{key: toUnversioned, value: trueValue}
+		return Tag{Key: toUnversioned, Value: trueValue}
 	}
-	return Tag{key: toUnversioned, value: falseValue}
+	return Tag{Key: toUnversioned, Value: falseValue}
 }
 
-var TaskExpireStageReadTag = Tag{key: taskExpireStage, value: "read"}
-var TaskExpireStageMemoryTag = Tag{key: taskExpireStage, value: "memory"}
-var TaskInvalidTag = Tag{key: taskExpireStage, value: "invalid"}
+var TaskExpireStageReadTag = Tag{Key: taskExpireStage, Value: "read"}
+var TaskExpireStageMemoryTag = Tag{Key: taskExpireStage, Value: "memory"}
+var TaskInvalidTag = Tag{Key: taskExpireStage, Value: "invalid"}
 
 func PersistenceDBKindTag(kind string) Tag {
-	return Tag{key: PersistenceDBKindTagName, value: kind}
+	return Tag{Key: PersistenceDBKindTagName, Value: kind}
 }

--- a/common/metrics/tally_metrics_handler.go
+++ b/common/metrics/tally_metrics_handler.go
@@ -112,14 +112,14 @@ func tagsToMap(t1 []Tag, e excludeTags) map[string]string {
 	m := make(map[string]string, len(t1))
 
 	convert := func(tag Tag) {
-		if vals, ok := e[tag.Key()]; ok {
-			if _, ok := vals[tag.Value()]; !ok {
-				m[tag.Key()] = tagExcludedValue
+		if vals, ok := e[tag.Key]; ok {
+			if _, ok := vals[tag.Value]; !ok {
+				m[tag.Key] = tagExcludedValue
 				return
 			}
 		}
 
-		m[tag.Key()] = tag.Value()
+		m[tag.Key] = tag.Value
 	}
 
 	for i := range t1 {

--- a/common/persistence/persistence_metrics_clients_test.go
+++ b/common/persistence/persistence_metrics_clients_test.go
@@ -68,10 +68,10 @@ func TestExecutionPersistenceClient_DataLossMetrics_EmittedOnDataLossError(t *te
 
 	// Verify tags are properly set (caller comes from context headers, which defaults to _unknown_)
 	tags := recording.Tags
-	assert.Equal(t, "_unknown_", tags[metrics.NamespaceTag("").Key()])
+	assert.Equal(t, "_unknown_", tags[metrics.NamespaceTag("").Key])
 	assert.Equal(t, "test-workflow-id", tags["workflow_id"])
 	assert.Equal(t, "test-run-id", tags["run_id"])
-	assert.Equal(t, metrics.PersistenceGetWorkflowExecutionScope, tags[metrics.OperationTag("").Key()])
+	assert.Equal(t, metrics.PersistenceGetWorkflowExecutionScope, tags[metrics.OperationTag("").Key])
 	assert.Equal(t, "test data loss error", tags["error"])
 }
 
@@ -227,7 +227,7 @@ func TestExecutionPersistenceClient_DataLossMetrics_WithWrappedDataLossError(t *
 
 	// Verify tags include workflow details (caller comes from context headers, which defaults to _unknown_)
 	tags := recording.Tags
-	assert.Equal(t, "_unknown_", tags[metrics.NamespaceTag("").Key()])
+	assert.Equal(t, "_unknown_", tags[metrics.NamespaceTag("").Key])
 	assert.Equal(t, "test-workflow-id", tags["workflow_id"])
 	assert.Equal(t, "", tags["run_id"]) // No run ID in GetCurrentExecutionRequest
 }
@@ -285,5 +285,5 @@ func TestExecutionPersistenceClient_DataLossMetrics_WithEmptyWorkflowDetails(t *
 	tags := recording.Tags
 	assert.Equal(t, "", tags["workflow_id"])
 	assert.Equal(t, "", tags["run_id"])
-	assert.Equal(t, metrics.PersistenceListConcreteExecutionsScope, tags[metrics.OperationTag("").Key()])
+	assert.Equal(t, metrics.PersistenceListConcreteExecutionsScope, tags[metrics.OperationTag("").Key])
 }

--- a/common/persistence/visibility/factory.go
+++ b/common/persistence/visibility/factory.go
@@ -130,8 +130,8 @@ func newVisibilityManager(
 	}
 	logger.Info(
 		"creating new visibility manager",
-		tag.NewStringTag(visibilityPluginNameTag.Key(), visibilityPluginNameTag.Value()),
-		tag.NewStringTag(visibilityIndexNameTag.Key(), visibilityIndexNameTag.Value()),
+		tag.NewStringTag(visibilityPluginNameTag.Key, visibilityPluginNameTag.Value),
+		tag.NewStringTag(visibilityIndexNameTag.Key, visibilityIndexNameTag.Value),
 	)
 	var visManager manager.VisibilityManager = newVisibilityManagerImpl(visStore, logger)
 

--- a/components/nexusoperations/frontend/handler.go
+++ b/components/nexusoperations/frontend/handler.go
@@ -438,7 +438,7 @@ func (c *requestContext) capturePanicAndRecordMetrics(ctxPtr *context.Context, e
 		} else {
 			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("success"))
 		}
-	} else if c.outcomeTag.Key() != "" {
+	} else if c.outcomeTag.Key != "" {
 		c.metricsHandler = c.metricsHandler.WithTags(c.outcomeTag)
 	} else {
 		var he *nexus.HandlerError

--- a/service/history/api/respondworkflowtaskcompleted/workflow_size_checker.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_size_checker.go
@@ -68,7 +68,7 @@ func (c *workflowSizeChecker) checkIfPayloadSizeExceedsLimit(
 		executionState.RunId,
 		c.metricsHandler.WithTags(commandTypeTag),
 		c.logger,
-		tag.BlobSizeViolationOperation(commandTypeTag.Value()),
+		tag.BlobSizeViolationOperation(commandTypeTag.Value),
 	)
 	if err != nil {
 		return fmt.Errorf("%s", message) // nolint:err113
@@ -96,7 +96,7 @@ func (c *workflowSizeChecker) checkIfMemoSizeExceedsLimit(
 		executionState.RunId,
 		c.metricsHandler.WithTags(commandTypeTag),
 		c.logger,
-		tag.BlobSizeViolationOperation(commandTypeTag.Value()),
+		tag.BlobSizeViolationOperation(commandTypeTag.Value),
 	)
 	if err != nil {
 		return fmt.Errorf("%s", message) // nolint:err113

--- a/service/history/archival_queue_factory_test.go
+++ b/service/history/archival_queue_factory_test.go
@@ -26,8 +26,8 @@ func TestArchivalQueueFactory(t *testing.T) {
 	metricsHandler.EXPECT().WithTags(gomock.Any()).DoAndReturn(
 		func(tags ...metrics.Tag) metrics.Handler {
 			require.Len(t, tags, 1)
-			assert.Equal(t, metrics.OperationTagName, tags[0].Key())
-			assert.Equal(t, "ArchivalQueueProcessor", tags[0].Value())
+			assert.Equal(t, metrics.OperationTagName, tags[0].Key)
+			assert.Equal(t, "ArchivalQueueProcessor", tags[0].Value)
 			return metricsHandler
 		},
 	).Times(1)

--- a/service/history/queues/dlq_writer_test.go
+++ b/service/history/queues/dlq_writer_test.go
@@ -80,7 +80,7 @@ func TestDLQWriter_ErrGetNamespaceName(t *testing.T) {
 	assert.Len(t, recordings[0].Tags, 2)
 	assert.Equal(t, "transfer", recordings[0].Tags[metrics.TaskCategoryTagName])
 	namespaceStateTag := metrics.NamespaceStateTag(metrics.ActiveNamespaceStateTagValue)
-	assert.Equal(t, metrics.ActiveNamespaceStateTagValue, recordings[0].Tags[namespaceStateTag.Key()])
+	assert.Equal(t, metrics.ActiveNamespaceStateTagValue, recordings[0].Tags[namespaceStateTag.Key])
 }
 
 func TestDLQWriter_Ok(t *testing.T) {
@@ -126,5 +126,5 @@ func TestDLQWriter_Ok(t *testing.T) {
 	assert.Len(t, recordings[0].Tags, 2)
 	assert.Equal(t, "transfer", recordings[0].Tags[metrics.TaskCategoryTagName])
 	namespaceStateTag := metrics.NamespaceStateTag("active")
-	assert.Equal(t, "active", recordings[0].Tags[namespaceStateTag.Key()])
+	assert.Equal(t, "active", recordings[0].Tags[namespaceStateTag.Key])
 }

--- a/service/history/replication/dlq_writer_test.go
+++ b/service/history/replication/dlq_writer_test.go
@@ -115,7 +115,7 @@ func TestNewDLQWriterAdapter(t *testing.T) {
 				assert.Len(t, recordings[0].Tags, 2)
 				assert.Equal(t, "replication", recordings[0].Tags[metrics.TaskCategoryTagName])
 				namespaceStateTag := metrics.NamespaceStateTag(metrics.PassiveNamespaceStateTagValue)
-				assert.Equal(t, metrics.PassiveNamespaceStateTagValue, recordings[0].Tags[namespaceStateTag.Key()])
+				assert.Equal(t, metrics.PassiveNamespaceStateTagValue, recordings[0].Tags[namespaceStateTag.Key])
 			}
 		})
 	}


### PR DESCRIPTION
## What changed?

Changes `metrics.Tag` from an interface to a concrete type. 

## Why?

To reduce allocations and GC pressure. Tags are often created in hot paths as part of metrics instrumentation, and interface boxing can trigger heap allocations.

Here's a benchmark for `metrics.OperationTag("test")`
```
BenchmarkTags-14    	1000000000	       0.3070 ns/op	       0 B/op	       0 allocs/op
BenchmarkTags-14    	69621046	        17.08 ns/op	      32 B/op	       1 allocs/op
```

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)