### PR TITLE
Enable events cache background eviction

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1484,6 +1484,11 @@ This can help reduce effects of shard movement.`,
 		false,
 		`EnableHostLevelEventsCache controls if the events cache is host level`,
 	)
+	EventsCacheBackgroundEvict = NewGlobalTypedSetting(
+		"history.eventsCacheBackgroundEvict",
+		DefaultHistoryCacheBackgroundEvictSettings,
+		`EventsCacheBackgroundEvict configures background processing to purge expired entries from the events cache.`,
+	)
 	AcquireShardInterval = NewGlobalDurationSetting(
 		"history.acquireShardInterval",
 		time.Minute,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	// Change of these configs require shard restart
 	EventsShardLevelCacheMaxSizeBytes dynamicconfig.IntPropertyFn
 	EventsCacheTTL                    dynamicconfig.DurationPropertyFn
+	EventsCacheBackgroundEvict        dynamicconfig.TypedPropertyFn[dynamicconfig.CacheBackgroundEvictSettings]
 	// Change of these configs require service restart
 	EnableHostLevelEventsCache       dynamicconfig.BoolPropertyFn
 	EventsHostLevelCacheMaxSizeBytes dynamicconfig.IntPropertyFn
@@ -429,6 +430,7 @@ func NewConfig(
 		EventsHostLevelCacheMaxSizeBytes:  dynamicconfig.EventsHostLevelCacheMaxSizeBytes.Get(dc), // 256MB
 		EventsCacheTTL:                    dynamicconfig.EventsCacheTTL.Get(dc),
 		EnableHostLevelEventsCache:        dynamicconfig.EnableHostLevelEventsCache.Get(dc),
+		EventsCacheBackgroundEvict:        dynamicconfig.EventsCacheBackgroundEvict.Get(dc),
 
 		RangeSizeBits: 20, // 20 bits for sequencer, 2^20 sequence number for any range
 

--- a/service/history/events/cache_test.go
+++ b/service/history/events/cache_test.go
@@ -11,6 +11,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -66,6 +67,9 @@ func (s *eventsCacheSuite) newTestEventsCache() *CacheImpl {
 		s.logger,
 		32,
 		time.Minute,
+		func() dynamicconfig.CacheBackgroundEvictSettings {
+			return dynamicconfig.DefaultHistoryCacheBackgroundEvictSettings
+		},
 		false)
 }
 


### PR DESCRIPTION
## What changed?

Extends cache background eviction to include the history events cache in addition to the MS cache. 

## Why?

To reduce the number of objects retained on heap by the events cache. Repeatedly scanning stale cache entries increases GC mark phase CPU usage. 

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
