### PR TITLE
Add Archetype search attributes schema for CHASM Visibility

### DIFF
--- a/schema/elasticsearch/visibility/versioned/v10/index_template_v7.json
+++ b/schema/elasticsearch/visibility/versioned/v10/index_template_v7.json
@@ -1,0 +1,159 @@
+{
+  "order": 0,
+  "index_patterns": ["temporal_visibility_v1*"],
+  "settings": {
+    "index": {
+      "number_of_shards": "1",
+      "number_of_replicas": "0",
+      "auto_expand_replicas": "0-2",
+      "search.idle.after": "365d",
+      "sort.field": ["CloseTime", "StartTime", "RunId"],
+      "sort.order": ["desc", "desc", "desc"],
+      "sort.missing": ["_first", "_first", "_first"]
+    }
+  },
+  "mappings": {
+    "dynamic": "false",
+    "properties": {
+      "NamespaceId": {
+        "type": "keyword"
+      },
+      "TemporalNamespaceDivision": {
+        "type": "keyword"
+      },
+      "WorkflowId": {
+        "type": "keyword"
+      },
+      "RunId": {
+        "type": "keyword"
+      },
+      "WorkflowType": {
+        "type": "keyword"
+      },
+      "StartTime": {
+        "type": "date_nanos"
+      },
+      "ExecutionTime": {
+        "type": "date_nanos"
+      },
+      "CloseTime": {
+        "type": "date_nanos"
+      },
+      "ExecutionDuration": {
+        "type": "long"
+      },
+      "ExecutionStatus": {
+        "type": "keyword"
+      },
+      "TaskQueue": {
+        "type": "keyword"
+      },
+      "TemporalChangeVersion": {
+        "type": "keyword"
+      },
+      "BatcherNamespace": {
+        "type": "keyword"
+      },
+      "BatcherUser": {
+        "type": "keyword"
+      },
+      "BinaryChecksums": {
+        "type": "keyword"
+      },
+      "HistoryLength": {
+        "type": "long"
+      },
+      "StateTransitionCount": {
+        "type": "long"
+      },
+      "TemporalScheduledStartTime": {
+        "type": "date_nanos"
+      },
+      "TemporalScheduledById": {
+        "type": "keyword"
+      },
+      "TemporalSchedulePaused": {
+        "type": "boolean"
+      },
+      "HistorySizeBytes": {
+        "type": "long"
+      },
+      "BuildIds": {
+        "type": "keyword"
+      },
+      "ParentWorkflowId": {
+        "type": "keyword"
+      },
+      "ParentRunId": {
+        "type": "keyword"
+      },
+      "RootWorkflowId": {
+        "type": "keyword"
+      },
+      "RootRunId": {
+        "type": "keyword"
+      },
+      "TemporalPauseInfo": {
+        "type": "keyword"
+      },
+      "TemporalWorkerDeploymentVersion": {
+        "type": "keyword"
+      },
+      "TemporalWorkflowVersioningBehavior": {
+        "type": "keyword"
+      },
+      "TemporalWorkerDeployment": {
+        "type": "keyword"
+      },
+      "TemporalBool01": {
+        "type": "boolean"
+      },
+      "TemporalBool02": {
+        "type": "boolean"
+      },
+      "TemporalDatetime01": {
+        "type": "date_nanos"
+      },
+      "TemporalDatetime02": {
+        "type": "date_nanos"
+      },
+      "TemporalDouble01": {
+        "type": "double"
+      },
+      "TemporalDouble02": {
+        "type": "double"
+      },
+      "TemporalInt01": {
+        "type": "int"
+      },
+      "TemporalInt02": {
+        "type": "int"
+      },
+      "TemporalKeyword01": {
+        "type": "keyword"
+      },
+      "TemporalKeyword02": {
+        "type": "keyword"
+      },
+      "TemporalKeyword03": {
+        "type": "keyword"
+      },
+      "TemporalKeyword04": {
+        "type": "keyword"
+      },
+      "TemporalText01": {
+        "type": "text"
+      },
+      "TemporalText02": {
+        "type": "text"
+      },
+      "TemporalKeywordList01": {
+        "type": "keyword"
+      },
+      "TemporalKeywordList02": {
+        "type": "keyword"
+      }
+    }
+  },
+  "aliases": {}
+}

--- a/schema/elasticsearch/visibility/versioned/v10/upgrade.sh
+++ b/schema/elasticsearch/visibility/versioned/v10/upgrade.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# Prerequisites:
+#   - jq
+#   - curl
+
+# Input parameters.
+: "${ES_SCHEME:=http}"
+: "${ES_SERVER:=127.0.0.1}"
+: "${ES_PORT:=9200}"
+: "${ES_USER:=}"
+: "${ES_PWD:=}"
+: "${ES_VERSION:=v7}"
+: "${ES_VIS_INDEX_V1:=temporal_visibility_v1_dev}"
+: "${AUTO_CONFIRM:=}"
+: "${SLICES_COUNT:=auto}"
+
+es_endpoint="${ES_SCHEME}://${ES_SERVER}:${ES_PORT}"
+
+echo "=== Step 0. Sanity check if Elasticsearch index is accessible ==="
+
+if ! curl --silent --fail --user "${ES_USER}":"${ES_PWD}" "${es_endpoint}/${ES_VIS_INDEX_V1}/_stats/docs" --write-out "\n"; then
+    echo "Elasticsearch index ${ES_VIS_INDEX_V1} is not accessible at ${es_endpoint}."
+    exit 1
+fi
+
+echo "=== Step 1. Add new builtin search attributes ==="
+
+new_mapping='
+{
+  "properties": {
+    "TemporalBool01": {
+      "type": "boolean"
+    },
+    "TemporalBool02": {
+      "type": "boolean"
+    },
+    "TemporalDatetime01": {
+      "type": "date_nanos"
+    },
+    "TemporalDatetime02": {
+      "type": "date_nanos"
+    },
+    "TemporalDouble01": {
+      "type": "double"
+    },
+    "TemporalDouble02": {
+      "type": "double"
+    },
+    "TemporalInt01": {
+      "type": "int"
+    },
+    "TemporalInt02": {
+      "type": "int"
+    },
+    "TemporalKeyword01": {
+      "type": "keyword"
+    },
+    "TemporalKeyword02": {
+      "type": "keyword"
+    },
+    "TemporalKeyword03": {
+      "type": "keyword"
+    },
+    "TemporalKeyword04": {
+      "type": "keyword"
+    },
+    "TemporalText01": {
+      "type": "text"
+    },
+    "TemporalText02": {
+      "type": "text"
+    },
+    "TemporalKeywordList01": {
+      "type": "keyword"
+    },
+    "TemporalKeywordList02": {
+      "type": "keyword"
+    }
+  }
+}
+'
+
+if [ -z "${AUTO_CONFIRM}" ]; then
+    read -p "Add new builtin search attributes to the index ${ES_VIS_INDEX_V1}? (N/y)" -n 1 -r
+    echo
+else
+    REPLY="y"
+fi
+if [ "${REPLY}" = "y" ]; then
+    curl --silent --fail --user "${ES_USER}":"${ES_PWD}" -X PUT "${es_endpoint}/${ES_VIS_INDEX_V1}/_mapping" -H "Content-Type: application/json" --data-binary "$new_mapping" | jq
+    # Wait for mapping changes to go through.
+    until curl --silent --user "${ES_USER}":"${ES_PWD}" "${es_endpoint}/_cluster/health/${ES_VIS_INDEX_V1}" | jq --exit-status '.status=="green" | .'; do
+        echo "Waiting for Elasticsearch index ${ES_VIS_INDEX_V1} become green."
+        sleep 1
+    done
+fi

--- a/schema/mysql/v8/version.go
+++ b/schema/mysql/v8/version.go
@@ -6,4 +6,4 @@ package v8
 const Version = "1.18"
 
 // VisibilityVersion is the MySQL visibility database release version
-const VisibilityVersion = "1.9"
+const VisibilityVersion = "1.10"

--- a/schema/mysql/v8/visibility/schema.sql
+++ b/schema/mysql/v8/visibility/schema.sql
@@ -166,3 +166,59 @@ CREATE FULLTEXT INDEX by_text_03  ON custom_search_attributes (Text03);
 CREATE INDEX by_keyword_list_01   ON custom_search_attributes (namespace_id, (CAST(KeywordList01 AS CHAR(255) ARRAY)));
 CREATE INDEX by_keyword_list_02   ON custom_search_attributes (namespace_id, (CAST(KeywordList02 AS CHAR(255) ARRAY)));
 CREATE INDEX by_keyword_list_03   ON custom_search_attributes (namespace_id, (CAST(KeywordList03 AS CHAR(255) ARRAY)));
+
+CREATE TABLE archetype_search_attributes (
+  namespace_id      CHAR(64)        NOT NULL,
+  run_id            CHAR(64)        NOT NULL,
+  _version          BIGINT          NOT NULL DEFAULT 0,
+  search_attributes JSON            NULL,
+
+  -- Pre-allocated Archetype search attributes
+  TemporalBool01            BOOLEAN         GENERATED ALWAYS AS (search_attributes->"$.TemporalBool01"),
+  TemporalBool02            BOOLEAN         GENERATED ALWAYS AS (search_attributes->"$.TemporalBool02"),
+  TemporalDatetime01        DATETIME(6)     GENERATED ALWAYS AS (
+    CONVERT_TZ(
+      REGEXP_REPLACE(search_attributes->>"$.TemporalDatetime01", 'Z|[+-][0-9]{2}:[0-9]{2}$', ''),
+      SUBSTR(REPLACE(search_attributes->>"$.TemporalDatetime01", 'Z', '+00:00'), -6, 6),
+      '+00:00'
+    )
+  ),
+  TemporalDatetime02        DATETIME(6)     GENERATED ALWAYS AS (
+    CONVERT_TZ(
+      REGEXP_REPLACE(search_attributes->>"$.TemporalDatetime02", 'Z|[+-][0-9]{2}:[0-9]{2}$', ''),
+      SUBSTR(REPLACE(search_attributes->>"$.TemporalDatetime02", 'Z', '+00:00'), -6, 6),
+      '+00:00'
+    )
+  ),
+  TemporalDouble01          DECIMAL(20, 5)  GENERATED ALWAYS AS (search_attributes->"$.TemporalDouble01"),
+  TemporalDouble02          DECIMAL(20, 5)  GENERATED ALWAYS AS (search_attributes->"$.TemporalDouble02"),
+  TemporalInt01             BIGINT          GENERATED ALWAYS AS (search_attributes->"$.TemporalInt01"),
+  TemporalInt02             BIGINT          GENERATED ALWAYS AS (search_attributes->"$.TemporalInt02"),
+  TemporalKeyword01         VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>"$.TemporalKeyword01"),
+  TemporalKeyword02         VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>"$.TemporalKeyword02"),
+  TemporalKeyword03         VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>"$.TemporalKeyword03"),
+  TemporalKeyword04         VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>"$.TemporalKeyword04"),
+  TemporalText01            TEXT            GENERATED ALWAYS AS (search_attributes->>"$.TemporalText01") STORED,
+  TemporalText02            TEXT            GENERATED ALWAYS AS (search_attributes->>"$.TemporalText02") STORED,
+  TemporalKeywordList01     JSON            GENERATED ALWAYS AS (search_attributes->"$.TemporalKeywordList01"),
+  TemporalKeywordList02     JSON            GENERATED ALWAYS AS (search_attributes->"$.TemporalKeywordList02"),
+
+  PRIMARY KEY (namespace_id, run_id)
+);
+
+CREATE INDEX by_temporal_bool_01           ON archetype_search_attributes (namespace_id, TemporalBool01);
+CREATE INDEX by_temporal_bool_02           ON archetype_search_attributes (namespace_id, TemporalBool02);
+CREATE INDEX by_temporal_datetime_01       ON archetype_search_attributes (namespace_id, TemporalDatetime01);
+CREATE INDEX by_temporal_datetime_02       ON archetype_search_attributes (namespace_id, TemporalDatetime02);
+CREATE INDEX by_temporal_double_01         ON archetype_search_attributes (namespace_id, TemporalDouble01);
+CREATE INDEX by_temporal_double_02         ON archetype_search_attributes (namespace_id, TemporalDouble02);
+CREATE INDEX by_temporal_int_01            ON archetype_search_attributes (namespace_id, TemporalInt01);
+CREATE INDEX by_temporal_int_02            ON archetype_search_attributes (namespace_id, TemporalInt02);
+CREATE INDEX by_temporal_keyword_01        ON archetype_search_attributes (namespace_id, TemporalKeyword01);
+CREATE INDEX by_temporal_keyword_02        ON archetype_search_attributes (namespace_id, TemporalKeyword02);
+CREATE INDEX by_temporal_keyword_03        ON archetype_search_attributes (namespace_id, TemporalKeyword03);
+CREATE INDEX by_temporal_keyword_04        ON archetype_search_attributes (namespace_id, TemporalKeyword04);
+CREATE FULLTEXT INDEX by_temporal_text_01  ON archetype_search_attributes (TemporalText01);
+CREATE FULLTEXT INDEX by_temporal_text_02  ON archetype_search_attributes (TemporalText02);
+CREATE INDEX by_temporal_keyword_list_01   ON archetype_search_attributes (namespace_id, (CAST(TemporalKeywordList01 AS CHAR(255) ARRAY)));
+CREATE INDEX by_temporal_keyword_list_02   ON archetype_search_attributes (namespace_id, (CAST(TemporalKeywordList02 AS CHAR(255) ARRAY)));

--- a/schema/mysql/v8/visibility/versioned/v1.10/add_archetype_search_attributes.sql
+++ b/schema/mysql/v8/visibility/versioned/v1.10/add_archetype_search_attributes.sql
@@ -1,0 +1,55 @@
+CREATE TABLE archetype_search_attributes (
+  namespace_id      CHAR(64)        NOT NULL,
+  run_id            CHAR(64)        NOT NULL,
+  _version          BIGINT          NOT NULL DEFAULT 0,
+  search_attributes JSON            NULL,
+
+  -- Pre-allocated Archetype search attributes
+  TemporalBool01            BOOLEAN         GENERATED ALWAYS AS (search_attributes->"$.TemporalBool01"),
+  TemporalBool02            BOOLEAN         GENERATED ALWAYS AS (search_attributes->"$.TemporalBool02"),
+  TemporalDatetime01        DATETIME(6)     GENERATED ALWAYS AS (
+    CONVERT_TZ(
+      REGEXP_REPLACE(search_attributes->>"$.TemporalDatetime01", 'Z|[+-][0-9]{2}:[0-9]{2}$', ''),
+      SUBSTR(REPLACE(search_attributes->>"$.TemporalDatetime01", 'Z', '+00:00'), -6, 6),
+      '+00:00'
+    )
+  ),
+  TemporalDatetime02        DATETIME(6)     GENERATED ALWAYS AS (
+    CONVERT_TZ(
+      REGEXP_REPLACE(search_attributes->>"$.TemporalDatetime02", 'Z|[+-][0-9]{2}:[0-9]{2}$', ''),
+      SUBSTR(REPLACE(search_attributes->>"$.TemporalDatetime02", 'Z', '+00:00'), -6, 6),
+      '+00:00'
+    )
+  ),
+  TemporalDouble01          DECIMAL(20, 5)  GENERATED ALWAYS AS (search_attributes->"$.TemporalDouble01"),
+  TemporalDouble02          DECIMAL(20, 5)  GENERATED ALWAYS AS (search_attributes->"$.TemporalDouble02"),
+  TemporalInt01             BIGINT          GENERATED ALWAYS AS (search_attributes->"$.TemporalInt01"),
+  TemporalInt02             BIGINT          GENERATED ALWAYS AS (search_attributes->"$.TemporalInt02"),
+  TemporalKeyword01         VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>"$.TemporalKeyword01"),
+  TemporalKeyword02         VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>"$.TemporalKeyword02"),
+  TemporalKeyword03         VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>"$.TemporalKeyword03"),
+  TemporalKeyword04         VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>"$.TemporalKeyword04"),
+  TemporalText01            TEXT            GENERATED ALWAYS AS (search_attributes->>"$.TemporalText01") STORED,
+  TemporalText02            TEXT            GENERATED ALWAYS AS (search_attributes->>"$.TemporalText02") STORED,
+  TemporalKeywordList01     JSON            GENERATED ALWAYS AS (search_attributes->"$.TemporalKeywordList01"),
+  TemporalKeywordList02     JSON            GENERATED ALWAYS AS (search_attributes->"$.TemporalKeywordList02"),
+
+  PRIMARY KEY (namespace_id, run_id)
+);
+
+CREATE INDEX by_temporal_bool_01           ON archetype_search_attributes (namespace_id, TemporalBool01);
+CREATE INDEX by_temporal_bool_02           ON archetype_search_attributes (namespace_id, TemporalBool02);
+CREATE INDEX by_temporal_datetime_01       ON archetype_search_attributes (namespace_id, TemporalDatetime01);
+CREATE INDEX by_temporal_datetime_02       ON archetype_search_attributes (namespace_id, TemporalDatetime02);
+CREATE INDEX by_temporal_double_01         ON archetype_search_attributes (namespace_id, TemporalDouble01);
+CREATE INDEX by_temporal_double_02         ON archetype_search_attributes (namespace_id, TemporalDouble02);
+CREATE INDEX by_temporal_int_01            ON archetype_search_attributes (namespace_id, TemporalInt01);
+CREATE INDEX by_temporal_int_02            ON archetype_search_attributes (namespace_id, TemporalInt02);
+CREATE INDEX by_temporal_keyword_01        ON archetype_search_attributes (namespace_id, TemporalKeyword01);
+CREATE INDEX by_temporal_keyword_02        ON archetype_search_attributes (namespace_id, TemporalKeyword02);
+CREATE INDEX by_temporal_keyword_03        ON archetype_search_attributes (namespace_id, TemporalKeyword03);
+CREATE INDEX by_temporal_keyword_04        ON archetype_search_attributes (namespace_id, TemporalKeyword04);
+CREATE FULLTEXT INDEX by_temporal_text_01  ON archetype_search_attributes (TemporalText01);
+CREATE FULLTEXT INDEX by_temporal_text_02  ON archetype_search_attributes (TemporalText02);
+CREATE INDEX by_temporal_keyword_list_01   ON archetype_search_attributes (namespace_id, (CAST(TemporalKeywordList01 AS CHAR(255) ARRAY)));
+CREATE INDEX by_temporal_keyword_list_02   ON archetype_search_attributes (namespace_id, (CAST(TemporalKeywordList02 AS CHAR(255) ARRAY)));

--- a/schema/mysql/v8/visibility/versioned/v1.10/manifest.json
+++ b/schema/mysql/v8/visibility/versioned/v1.10/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.10",
+  "MinCompatibleVersion": "0.1",
+  "Description": "add archetype search attributes table and indices",
+  "SchemaUpdateCqlFiles": [
+    "add_archetype_search_attributes.sql"
+  ]
+}

--- a/schema/postgresql/v12/version.go
+++ b/schema/postgresql/v12/version.go
@@ -8,4 +8,4 @@ const Version = "1.18"
 
 // VisibilityVersion is the Postgres visibility database release version
 // Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres
-const VisibilityVersion = "1.9"
+const VisibilityVersion = "1.10"

--- a/schema/postgresql/v12/visibility/schema.sql
+++ b/schema/postgresql/v12/visibility/schema.sql
@@ -79,6 +79,24 @@ CREATE TABLE executions_visibility (
   KeywordList02   JSONB           GENERATED ALWAYS AS (search_attributes->'KeywordList02')            STORED,
   KeywordList03   JSONB           GENERATED ALWAYS AS (search_attributes->'KeywordList03')            STORED,
 
+  -- Pre-allocated Archetype search attributes
+  TemporalBool01            BOOLEAN         GENERATED ALWAYS AS (search_attributes->'TemporalBool01')                 STORED,
+  TemporalBool02            BOOLEAN         GENERATED ALWAYS AS (search_attributes->'TemporalBool02')                 STORED,
+  TemporalDatetime01        TIMESTAMP       GENERATED ALWAYS AS (convert_ts(search_attributes->>'TemporalDatetime01')) STORED,
+  TemporalDatetime02        TIMESTAMP       GENERATED ALWAYS AS (convert_ts(search_attributes->>'TemporalDatetime02')) STORED,
+  TemporalDouble01          DECIMAL(20, 5)  GENERATED ALWAYS AS ((search_attributes->'TemporalDouble01')::decimal)    STORED,
+  TemporalDouble02          DECIMAL(20, 5)  GENERATED ALWAYS AS ((search_attributes->'TemporalDouble02')::decimal)    STORED,
+  TemporalInt01             BIGINT          GENERATED ALWAYS AS ((search_attributes->'TemporalInt01')::bigint)        STORED,
+  TemporalInt02             BIGINT          GENERATED ALWAYS AS ((search_attributes->'TemporalInt02')::bigint)        STORED,
+  TemporalKeyword01         VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>'TemporalKeyword01')              STORED,
+  TemporalKeyword02         VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>'TemporalKeyword02')              STORED,
+  TemporalKeyword03         VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>'TemporalKeyword03')              STORED,
+  TemporalKeyword04         VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>'TemporalKeyword04')              STORED, 
+  TemporalText01            TSVECTOR        GENERATED ALWAYS AS ((search_attributes->>'TemporalText01')::tsvector)     STORED,
+  TemporalText02            TSVECTOR        GENERATED ALWAYS AS ((search_attributes->>'TemporalText02')::tsvector)     STORED,
+  TemporalKeywordList01     JSONB           GENERATED ALWAYS AS (search_attributes->'TemporalKeywordList01')          STORED,
+  TemporalKeywordList02     JSONB           GENERATED ALWAYS AS (search_attributes->'TemporalKeywordList02')          STORED,
+
   PRIMARY KEY  (namespace_id, run_id)
 );
 
@@ -140,3 +158,21 @@ CREATE INDEX by_text_03         ON executions_visibility USING GIN (namespace_id
 CREATE INDEX by_keyword_list_01 ON executions_visibility USING GIN (namespace_id, KeywordList01 jsonb_path_ops);
 CREATE INDEX by_keyword_list_02 ON executions_visibility USING GIN (namespace_id, KeywordList02 jsonb_path_ops);
 CREATE INDEX by_keyword_list_03 ON executions_visibility USING GIN (namespace_id, KeywordList03 jsonb_path_ops);
+
+-- Indexes for the pre-allocated Archetype search attributes
+CREATE INDEX by_temporal_bool_01          ON executions_visibility (namespace_id, TemporalBool01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_bool_02          ON executions_visibility (namespace_id, TemporalBool02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_datetime_01      ON executions_visibility (namespace_id, TemporalDatetime01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_datetime_02      ON executions_visibility (namespace_id, TemporalDatetime02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_double_01        ON executions_visibility (namespace_id, TemporalDouble01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_double_02        ON executions_visibility (namespace_id, TemporalDouble02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_int_01           ON executions_visibility (namespace_id, TemporalInt01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_int_02           ON executions_visibility (namespace_id, TemporalInt02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_keyword_01       ON executions_visibility (namespace_id, TemporalKeyword01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_keyword_02       ON executions_visibility (namespace_id, TemporalKeyword02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_keyword_03       ON executions_visibility (namespace_id, TemporalKeyword03, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_keyword_04       ON executions_visibility (namespace_id, TemporalKeyword04, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_text_01          ON executions_visibility USING GIN (namespace_id, TemporalText01);
+CREATE INDEX by_temporal_text_02          ON executions_visibility USING GIN (namespace_id, TemporalText02);
+CREATE INDEX by_temporal_keyword_list_01  ON executions_visibility USING GIN (namespace_id, TemporalKeywordList01 jsonb_path_ops);
+CREATE INDEX by_temporal_keyword_list_02  ON executions_visibility USING GIN (namespace_id, TemporalKeywordList02 jsonb_path_ops);

--- a/schema/postgresql/v12/visibility/versioned/v1.10/add_archetype_search_attributes.sql
+++ b/schema/postgresql/v12/visibility/versioned/v1.10/add_archetype_search_attributes.sql
@@ -1,0 +1,36 @@
+-- Pre-allocated archetype search attributes
+ALTER TABLE executions_visibility
+  ADD COLUMN TemporalBool01         BOOLEAN         GENERATED ALWAYS AS ((search_attributes->'TemporalBool01')::boolean) STORED,
+  ADD COLUMN TemporalBool02         BOOLEAN         GENERATED ALWAYS AS ((search_attributes->'TemporalBool02')::boolean) STORED,
+  ADD COLUMN TemporalDatetime01     TIMESTAMP       GENERATED ALWAYS AS (convert_ts(search_attributes->>'TemporalDatetime01'))   STORED,
+  ADD COLUMN TemporalDatetime02     TIMESTAMP       GENERATED ALWAYS AS (convert_ts(search_attributes->>'TemporalDatetime02'))   STORED,
+  ADD COLUMN TemporalDouble01       DECIMAL(20, 5)  GENERATED ALWAYS AS ((search_attributes->'TemporalDouble01')::decimal)       STORED,
+  ADD COLUMN TemporalDouble02       DECIMAL(20, 5)  GENERATED ALWAYS AS ((search_attributes->'TemporalDouble02')::decimal)       STORED,
+  ADD COLUMN TemporalInt01          BIGINT          GENERATED ALWAYS AS ((search_attributes->'TemporalInt01')::bigint)           STORED,
+  ADD COLUMN TemporalInt02          BIGINT          GENERATED ALWAYS AS ((search_attributes->'TemporalInt02')::bigint)           STORED,
+  ADD COLUMN TemporalKeyword01      VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>'TemporalKeyword01')                STORED,
+  ADD COLUMN TemporalKeyword02      VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>'TemporalKeyword02')                STORED,
+  ADD COLUMN TemporalKeyword03      VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>'TemporalKeyword03')                STORED,
+  ADD COLUMN TemporalKeyword04      VARCHAR(255)    GENERATED ALWAYS AS (search_attributes->>'TemporalKeyword04')                STORED,
+  ADD COLUMN TemporalText01         TSVECTOR        GENERATED ALWAYS AS ((search_attributes->>'TemporalText01')::tsvector)       STORED,
+  ADD COLUMN TemporalText02         TSVECTOR        GENERATED ALWAYS AS ((search_attributes->>'TemporalText02')::tsvector)       STORED,
+  ADD COLUMN TemporalKeywordList01  JSONB           GENERATED ALWAYS AS (search_attributes->'TemporalKeywordList01')             STORED,
+  ADD COLUMN TemporalKeywordList02  JSONB           GENERATED ALWAYS AS (search_attributes->'TemporalKeywordList02')             STORED,
+
+-- Indexes for the pre-allocated Archetype search attributes
+CREATE INDEX by_temporal_bool_01          ON executions_visibility (namespace_id, TemporalBool01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_bool_02          ON executions_visibility (namespace_id, TemporalBool02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_datetime_01      ON executions_visibility (namespace_id, TemporalDatetime01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_datetime_02      ON executions_visibility (namespace_id, TemporalDatetime02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_double_01        ON executions_visibility (namespace_id, TemporalDouble01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_double_02        ON executions_visibility (namespace_id, TemporalDouble02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_int_01           ON executions_visibility (namespace_id, TemporalInt01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_int_02           ON executions_visibility (namespace_id, TemporalInt02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_keyword_01       ON executions_visibility (namespace_id, TemporalKeyword01, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_keyword_02       ON executions_visibility (namespace_id, TemporalKeyword02, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_keyword_03       ON executions_visibility (namespace_id, TemporalKeyword03, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_keyword_04       ON executions_visibility (namespace_id, TemporalKeyword04, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_text_01          ON executions_visibility USING GIN (namespace_id, TemporalText01);
+CREATE INDEX by_temporal_text_02          ON executions_visibility USING GIN (namespace_id, TemporalText02);
+CREATE INDEX by_temporal_keyword_list_01  ON executions_visibility USING GIN (namespace_id, TemporalKeywordList01 jsonb_path_ops);
+CREATE INDEX by_temporal_keyword_list_02  ON executions_visibility USING GIN (namespace_id, TemporalKeywordList02 jsonb_path_ops);

--- a/schema/postgresql/v12/visibility/versioned/v1.10/manifest.json
+++ b/schema/postgresql/v12/visibility/versioned/v1.10/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.10",
+  "MinCompatibleVersion": "0.1",
+  "Description": "add archetype search attributes columns and indices",
+  "SchemaUpdateCqlFiles": [
+    "add_archetype_search_attributes.sql"
+  ]
+}

--- a/schema/sqlite/v3/visibility/schema.sql
+++ b/schema/sqlite/v3/visibility/schema.sql
@@ -65,6 +65,24 @@ CREATE TABLE executions_visibility (
   KeywordList02   TEXT            GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.KeywordList02")) STORED,
   KeywordList03   TEXT            GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.KeywordList03")) STORED,
 
+  -- Pre-allocated archetype search attributes
+  TemporalBool01          BOOLEAN         GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalBool01")),
+  TemporalBool02          BOOLEAN         GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalBool02")),
+  TemporalDatetime01      TIMESTAMP       GENERATED ALWAYS AS (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', JSON_EXTRACT(search_attributes, "$.TemporalDatetime01"))),
+  TemporalDatetime02      TIMESTAMP       GENERATED ALWAYS AS (STRFTIME('%Y-%m-%d %H:%M:%f+00:00', JSON_EXTRACT(search_attributes, "$.TemporalDatetime02"))),
+  TemporalDouble01        DECIMAL(20, 5)  GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalDouble01")),
+  TemporalDouble02        DECIMAL(20, 5)  GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalDouble02")),
+  TemporalInt01           BIGINT          GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalInt01")),
+  TemporalInt02           BIGINT          GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalInt02")),
+  TemporalKeyword01       VARCHAR(255)    GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalKeyword01")),
+  TemporalKeyword02       VARCHAR(255)    GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalKeyword02")),
+  TemporalKeyword03       VARCHAR(255)    GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalKeyword03")),
+  TemporalKeyword04       VARCHAR(255)    GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalKeyword04")),
+  TemporalText01          TEXT            GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalText01"))        STORED,
+  TemporalText02          TEXT            GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalText02"))        STORED,
+  TemporalKeywordList01   TEXT            GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalKeywordList01")) STORED,
+  TemporalKeywordList02   TEXT            GENERATED ALWAYS AS (JSON_EXTRACT(search_attributes, "$.TemporalKeywordList02")) STORED,
+  
   PRIMARY KEY (namespace_id, run_id)
 );
 
@@ -118,11 +136,26 @@ CREATE INDEX by_keyword_08  ON executions_visibility (namespace_id, Keyword08,  
 CREATE INDEX by_keyword_09  ON executions_visibility (namespace_id, Keyword09,  (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
 CREATE INDEX by_keyword_10  ON executions_visibility (namespace_id, Keyword10,  (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
 
+-- Indexes for the pre-allocated Archetype search attributes
+CREATE INDEX by_temporal_bool_01     ON executions_visibility (namespace_id, TemporalBool01,     (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_bool_02     ON executions_visibility (namespace_id, TemporalBool02,     (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_datetime_01 ON executions_visibility (namespace_id, TemporalDatetime01, (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_datetime_02 ON executions_visibility (namespace_id, TemporalDatetime02, (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_double_01   ON executions_visibility (namespace_id, TemporalDouble01,   (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_double_02   ON executions_visibility (namespace_id, TemporalDouble02,   (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_int_01      ON executions_visibility (namespace_id, TemporalInt01,      (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_int_02      ON executions_visibility (namespace_id, TemporalInt02,      (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_keyword_01  ON executions_visibility (namespace_id, TemporalKeyword01,  (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_keyword_02  ON executions_visibility (namespace_id, TemporalKeyword02,  (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_keyword_03  ON executions_visibility (namespace_id, TemporalKeyword03,  (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
+CREATE INDEX by_temporal_keyword_04  ON executions_visibility (namespace_id, TemporalKeyword04,  (COALESCE(close_time, '9999-12-31 23:59:59+00:00')) DESC, start_time DESC, run_id);
 
 CREATE VIRTUAL TABLE executions_visibility_fts_text USING fts5 (
   Text01,
   Text02,
   Text03,
+  TemporalText01,
+  TemporalText02,
   content='executions_visibility',
   tokenize="unicode61 remove_diacritics 2"
 );
@@ -140,6 +173,8 @@ CREATE VIRTUAL TABLE executions_visibility_fts_keyword_list USING fts5 (
   KeywordList01,
   KeywordList02,
   KeywordList03,
+  TemporalKeywordList01,
+  TemporalKeywordList02,
   content='executions_visibility',
   tokenize="unicode61 remove_diacritics 0 categories 'C* L* M* N* P* S* Z*' separators '♡'"
 );
@@ -151,12 +186,16 @@ BEGIN
     rowid,
     Text01,
     Text02,
-    Text03
+    Text03,
+    TemporalText01,
+    TemporalText02
   ) VALUES (
     NEW.rowid,
     NEW.Text01,
     NEW.Text02,
-    NEW.Text03
+    NEW.Text03,
+    NEW.TemporalText01,
+    NEW.TemporalText02
   );
   -- insert into fts_keyword_list table
   INSERT INTO executions_visibility_fts_keyword_list (
@@ -167,7 +206,9 @@ BEGIN
     TemporalPauseInfo,
     KeywordList01,
     KeywordList02,
-    KeywordList03
+    KeywordList03,
+    TemporalKeywordList01,
+    TemporalKeywordList02
   ) VALUES (
     NEW.rowid,
     NEW.TemporalChangeVersion,
@@ -176,7 +217,9 @@ BEGIN
     NEW.TemporalPauseInfo,
     NEW.KeywordList01,
     NEW.KeywordList02,
-    NEW.KeywordList03
+    NEW.KeywordList03,
+    NEW.TemporalKeywordList01,
+    NEW.TemporalKeywordList02
   );
 END;
 
@@ -188,13 +231,17 @@ BEGIN
     rowid,
     Text01,
     Text02,
-    Text03
+    Text03,
+    TemporalText01,
+    TemporalText02
   ) VALUES (
     'delete',
     OLD.rowid,
     OLD.Text01,
     OLD.Text02,
-    OLD.Text03
+    OLD.Text03,
+    OLD.TemporalText01,
+    OLD.TemporalText02
   );
   -- delete from fts_keyword_list table
   INSERT INTO executions_visibility_fts_keyword_list (
@@ -206,7 +253,9 @@ BEGIN
     TemporalPauseInfo,
     KeywordList01,
     KeywordList02,
-    KeywordList03
+    KeywordList03,
+    TemporalKeywordList01,
+    TemporalKeywordList02
   ) VALUES (
     'delete',
     OLD.rowid,
@@ -216,7 +265,9 @@ BEGIN
     OLD.TemporalPauseInfo,
     OLD.KeywordList01,
     OLD.KeywordList02,
-    OLD.KeywordList03
+    OLD.KeywordList03,
+    OLD.TemporalKeywordList01,
+    OLD.TemporalKeywordList02
   );
 END;
 
@@ -228,24 +279,32 @@ BEGIN
     rowid,
     Text01,
     Text02,
-    Text03
+    Text03,
+    TemporalText01,
+    TemporalText02
   ) VALUES (
     'delete',
     OLD.rowid,
     OLD.Text01,
     OLD.Text02,
-    OLD.Text03
+    OLD.Text03,
+    OLD.TemporalText01,
+    OLD.TemporalText02
   );
   INSERT INTO executions_visibility_fts_text (
     rowid,
     Text01,
     Text02,
-    Text03
+    Text03,
+    TemporalText01,
+    TemporalText02
   ) VALUES (
     NEW.rowid,
     NEW.Text01,
     NEW.Text02,
-    NEW.Text03
+    NEW.Text03,
+    NEW.TemporalText01,
+    NEW.TemporalText02
   );
   -- update fts_keyword_list table
   INSERT INTO executions_visibility_fts_keyword_list (
@@ -257,7 +316,9 @@ BEGIN
     TemporalPauseInfo,
     KeywordList01,
     KeywordList02,
-    KeywordList03
+    KeywordList03,
+    TemporalKeywordList01,
+    TemporalKeywordList02
   ) VALUES (
     'delete',
     OLD.rowid,
@@ -267,7 +328,9 @@ BEGIN
     OLD.TemporalPauseInfo,
     OLD.KeywordList01,
     OLD.KeywordList02,
-    OLD.KeywordList03
+    OLD.KeywordList03,
+    OLD.TemporalKeywordList01,
+    OLD.TemporalKeywordList02
   );
   INSERT INTO executions_visibility_fts_keyword_list (
     rowid,
@@ -277,7 +340,9 @@ BEGIN
     TemporalPauseInfo,
     KeywordList01,
     KeywordList02,
-    KeywordList03
+    KeywordList03,
+    TemporalKeywordList01,
+    TemporalKeywordList02
   ) VALUES (
     NEW.rowid,
     NEW.TemporalChangeVersion,
@@ -286,6 +351,8 @@ BEGIN
     NEW.TemporalPauseInfo,
     NEW.KeywordList01,
     NEW.KeywordList02,
-    NEW.KeywordList03
+    NEW.KeywordList03,
+    NEW.TemporalKeywordList01,
+    NEW.TemporalKeywordList02
   );
 END;


### PR DESCRIPTION
## What changed?
Adds Archetype search attributes schema for CHASM Visibility. Functions similarly to custom search attributes, where pre-allocated column names or explicit properties, called field names, will map to user aliased Archetype search attributes.

## Why?
Required for CHASM Visibility support. Component authors will register a component with tagged attribute values for querying (List, Count APIs for now), and executions of the registered component will be tagged with these attributes.

Archetype name used for querying is left out of this schema change, may require further discussion.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] added new unit test(s)
- [ ] added new functional test(s)

