### PR TITLE
Add functional test to verify heartbeat is registered via PollNexusTaskQueue API.

### DIFF
--- a/tests/worker_registry_test.go
+++ b/tests/worker_registry_test.go
@@ -2,11 +2,13 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workerpb "go.temporal.io/api/worker/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -36,15 +38,26 @@ func (s *WorkerRegistryTestSuite) TestWorkerRegistry_DescribeWorker() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	_, err := s.FrontendClient().RecordWorkerHeartbeat(ctx, &workflowservice.RecordWorkerHeartbeatRequest{
+	// Record heartbeat for 2 workers
+	hbResp, err := s.FrontendClient().RecordWorkerHeartbeat(ctx, &workflowservice.RecordWorkerHeartbeatRequest{
 		Namespace: s.Namespace().String(),
 		WorkerHeartbeat: []*workerpb.WorkerHeartbeat{
-			{WorkerInstanceKey: "worker1", TaskQueue: "taskQueue1"},
-			{WorkerInstanceKey: "worker2", TaskQueue: "taskQueue2"},
+			{
+				WorkerInstanceKey:   "worker1",
+				TaskQueue:           "taskQueue1",
+				TotalStickyCacheHit: 1,
+			},
+			{
+				WorkerInstanceKey:   "worker2",
+				TaskQueue:           "taskQueue2",
+				TotalStickyCacheHit: 2,
+			},
 		},
 	})
 	s.NoError(err)
+	s.NotNil(hbResp)
 
+	// Test error case - worker that doesn't exist
 	_, err = s.FrontendClient().DescribeWorker(ctx, &workflowservice.DescribeWorkerRequest{
 		Namespace:         s.Namespace().String(),
 		WorkerInstanceKey: "worker0",
@@ -53,6 +66,7 @@ func (s *WorkerRegistryTestSuite) TestWorkerRegistry_DescribeWorker() {
 	var notFound *serviceerror.NotFound
 	s.ErrorAs(err, &notFound)
 
+	// Test error case - unknown namespace
 	_, err = s.FrontendClient().DescribeWorker(ctx, &workflowservice.DescribeWorkerRequest{
 		Namespace:         "unknown-namespace",
 		WorkerInstanceKey: "worker1",
@@ -61,26 +75,62 @@ func (s *WorkerRegistryTestSuite) TestWorkerRegistry_DescribeWorker() {
 	var namespaceNotFound *serviceerror.NamespaceNotFound
 	s.ErrorAs(err, &namespaceNotFound)
 
-	resp, err := s.FrontendClient().DescribeWorker(ctx, &workflowservice.DescribeWorkerRequest{
-		Namespace:         s.Namespace().String(),
-		WorkerInstanceKey: "worker1",
-	})
-	s.NoError(err)
-	s.NotNil(resp)
+	// Test success case - verify worker1 heartbeat data
+	{
+		resp, err := s.FrontendClient().DescribeWorker(ctx, &workflowservice.DescribeWorkerRequest{
+			Namespace:         s.Namespace().String(),
+			WorkerInstanceKey: "worker1",
+		})
+		s.NoError(err)
+		s.NotNil(resp)
+		s.NotNil(resp.GetWorkerInfo())
+
+		workerHeartbeat := resp.GetWorkerInfo().GetWorkerHeartbeat()
+		s.NotNil(workerHeartbeat)
+		s.Equal("worker1", workerHeartbeat.GetWorkerInstanceKey())
+		s.Equal("taskQueue1", workerHeartbeat.GetTaskQueue())
+		s.Equal(int32(1), workerHeartbeat.GetTotalStickyCacheHit())
+	}
+	// Test success case - verify worker2 heartbeat data
+	{
+		resp, err := s.FrontendClient().DescribeWorker(ctx, &workflowservice.DescribeWorkerRequest{
+			Namespace:         s.Namespace().String(),
+			WorkerInstanceKey: "worker2",
+		})
+		s.NoError(err)
+		s.NotNil(resp)
+		s.NotNil(resp.GetWorkerInfo())
+
+		workerHeartbeat := resp.GetWorkerInfo().GetWorkerHeartbeat()
+		s.NotNil(workerHeartbeat)
+		s.Equal("worker2", workerHeartbeat.GetWorkerInstanceKey())
+		s.Equal("taskQueue2", workerHeartbeat.GetTaskQueue())
+		s.Equal(int32(2), workerHeartbeat.GetTotalStickyCacheHit())
+	}
 }
 
 func (s *WorkerRegistryTestSuite) TestWorkerRegistry_ListWorkers() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	_, err := s.FrontendClient().RecordWorkerHeartbeat(ctx, &workflowservice.RecordWorkerHeartbeatRequest{
+	// Record heartbeats for 2 workers
+	hbResp, err := s.FrontendClient().RecordWorkerHeartbeat(ctx, &workflowservice.RecordWorkerHeartbeatRequest{
 		Namespace: s.Namespace().String(),
 		WorkerHeartbeat: []*workerpb.WorkerHeartbeat{
-			{WorkerInstanceKey: "worker1", TaskQueue: "taskQueueTest"},
-			{WorkerInstanceKey: "worker2", TaskQueue: "taskQueueTest"},
+			{
+				WorkerInstanceKey:   "worker1",
+				TaskQueue:           "taskQueue",
+				TotalStickyCacheHit: 1,
+			},
+			{
+				WorkerInstanceKey:   "worker2",
+				TaskQueue:           "taskQueue",
+				TotalStickyCacheHit: 2,
+			},
 		},
 	})
 	s.NoError(err)
+	s.NotNil(hbResp)
 
 	{
 		resp, err := s.FrontendClient().ListWorkers(ctx, &workflowservice.ListWorkersRequest{
@@ -89,19 +139,43 @@ func (s *WorkerRegistryTestSuite) TestWorkerRegistry_ListWorkers() {
 		})
 		s.NoError(err)
 		s.NotNil(resp)
-		s.Len(resp.GetWorkersInfo(), 1, "Expected one worker with WorkerInstanceKey 'worker1'")
-		s.Equal("worker1", resp.GetWorkersInfo()[0].GetWorkerHeartbeat().WorkerInstanceKey)
+		s.Len(resp.GetWorkersInfo(), 1)
+
+		workerHeartbeat := resp.GetWorkersInfo()[0].GetWorkerHeartbeat()
+		s.Equal("worker1", workerHeartbeat.WorkerInstanceKey)
+		s.Equal("taskQueue", workerHeartbeat.TaskQueue)
+		s.Equal(int32(1), workerHeartbeat.TotalStickyCacheHit)
 	}
 	{
 		resp, err := s.FrontendClient().ListWorkers(ctx, &workflowservice.ListWorkersRequest{
 			Namespace: s.Namespace().String(),
-			Query:     "TaskQueue='taskQueueTest'",
+			Query:     "TaskQueue='taskQueue'",
 		})
 		s.NoError(err)
 		s.NotNil(resp)
-		s.Len(resp.GetWorkersInfo(), 2, "Expected two workers with TaskQueue 'taskQueueTest'")
-		s.Equal("taskQueueTest", resp.GetWorkersInfo()[0].GetWorkerHeartbeat().TaskQueue)
-		s.Equal("taskQueueTest", resp.GetWorkersInfo()[1].GetWorkerHeartbeat().TaskQueue)
+
+		workers := resp.GetWorkersInfo()
+		// Collect workers by their instance key
+		workersByKey := make(map[string]*workerpb.WorkerHeartbeat)
+		for _, workerInfo := range workers {
+			heartbeat := workerInfo.GetWorkerHeartbeat()
+			workersByKey[heartbeat.WorkerInstanceKey] = heartbeat
+		}
+
+		// Verify we have exactly the workers we expect
+		s.Len(workersByKey, 2)
+
+		// Verify worker1
+		worker1, exists := workersByKey["worker1"]
+		s.True(exists, "worker1 should exist")
+		s.Equal("taskQueue", worker1.TaskQueue)
+		s.Equal(int32(1), worker1.TotalStickyCacheHit)
+
+		// Verify worker2
+		worker2, exists := workersByKey["worker2"]
+		s.True(exists, "worker2 should exist")
+		s.Equal("taskQueue", worker2.TaskQueue)
+		s.Equal(int32(2), worker2.TotalStickyCacheHit)
 	}
 	{
 		resp, err := s.FrontendClient().ListWorkers(ctx, &workflowservice.ListWorkersRequest{
@@ -110,6 +184,58 @@ func (s *WorkerRegistryTestSuite) TestWorkerRegistry_ListWorkers() {
 		})
 		s.NoError(err)
 		s.NotNil(resp)
-		s.Len(resp.GetWorkersInfo(), 0, "Expected no workers with WorkerInstanceKey 'worker0'")
+		s.Len(resp.GetWorkersInfo(), 0)
 	}
+}
+
+func (s *WorkerRegistryTestSuite) TestWorkerRegistry_SendHeartbeatViaPollNexusTask() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	heartbeat := &workerpb.WorkerHeartbeat{
+		WorkerInstanceKey:   "nexus-worker1",
+		TaskQueue:           "nexusTaskQueue",
+		TotalStickyCacheHit: 3,
+	}
+
+	// Send worker heartbeat via PollNexusTaskQueue in a goroutine.
+	// This is because PollNexusTaskQueue is a blocking call and we need to wait for the heartbeat to be registered.
+	go func() {
+		_, _ = s.FrontendClient().PollNexusTaskQueue(ctx, &workflowservice.PollNexusTaskQueueRequest{
+			Namespace:       s.Namespace().String(),
+			TaskQueue:       &taskqueuepb.TaskQueue{Name: "nexusTaskQueue"},
+			Identity:        "nexus-worker",
+			WorkerHeartbeat: []*workerpb.WorkerHeartbeat{heartbeat},
+		})
+	}()
+
+	// Use Eventually to verify heartbeat registration
+	s.Eventually(func() bool {
+		resp, err := s.FrontendClient().ListWorkers(ctx, &workflowservice.ListWorkersRequest{
+			Namespace: s.Namespace().String(),
+			Query:     "WorkerInstanceKey='nexus-worker1'",
+		})
+		if err != nil {
+			fmt.Printf("ListWorkers error: %v\n", err)
+			return false
+		}
+
+		workers := resp.GetWorkersInfo()
+		if len(workers) != 1 {
+			fmt.Printf("Expected 1 worker, got count %d\n", len(workers))
+			return false
+		}
+
+		workerHeartbeat := workers[0].GetWorkerHeartbeat()
+
+		// Check each field and log mismatches for easier debugging
+		matches := workerHeartbeat.WorkerInstanceKey == heartbeat.WorkerInstanceKey &&
+			workerHeartbeat.TaskQueue == heartbeat.TaskQueue &&
+			workerHeartbeat.TotalStickyCacheHit == heartbeat.TotalStickyCacheHit
+
+		if !matches {
+			fmt.Printf("Worker heartbeat mismatch:\n  Expected: %+v\n  Got: %+v\n", heartbeat, workerHeartbeat)
+		}
+		return matches
+	}, 2*time.Minute, 100*time.Millisecond, "Worker heartbeat should be registered via PollNexusTaskQueue")
 }


### PR DESCRIPTION
## What changed?
Heartbeat registration can happen as part of PollNexusTaskQueue API as well. This is an optimization to piggy back on the long poll instead of sending a separate heartbeat.

In addition, made changes to existing test to verify the heartbeat result.

## Why?
Increase coverage.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None.
