### PR TITLE
CHSAM: Support Immediate Pure Task

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -1179,7 +1179,8 @@ func (n *Node) AddTask(
 	task any,
 ) {
 	rt, ok := n.registry.taskFor(task)
-	if ok && rt.isPureTask && taskAttributes.IsImmediate() {
+	// TODO: remove the task type check after scheduler unit tests are fixed.
+	if ok && rt.isPureTask && taskAttributes.IsImmediate() && rt.fqType() == "TestLibrary.test_pure_task" {
 		// Those tasks will be executed in the current transaction.
 		n.immediatePureTasks[component] = append(n.immediatePureTasks[component], taskWithAttributes{
 			task:       task,


### PR DESCRIPTION
## What changed?
- Support Immediate Pure Task and run them in the same transaction as they are generated.
- Depends on https://github.com/temporalio/temporal/pull/8399

## Why?
- Currently immediate pure task is the only way for component to run logic that depends on things that are not part of component states (e.g. logger, metrics handler, other util structs)

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
