### PR TITLE
Add BestEffort field to CompleteHistoryTaskRequest

### DIFF
--- a/common/persistence/cassandra/mutable_state_task_store.go
+++ b/common/persistence/cassandra/mutable_state_task_store.go
@@ -243,6 +243,10 @@ func (d *MutableStateTaskStore) CompleteHistoryTask(
 	ctx context.Context,
 	request *p.CompleteHistoryTaskRequest,
 ) error {
+	// Ignore the request if it is best effort
+	if request.BestEffort {
+		return nil
+	}
 	switch request.TaskCategory.ID() {
 	case tasks.CategoryIDTransfer:
 		return d.completeTransferTask(ctx, request)

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -416,6 +416,10 @@ type (
 		ShardID      int32
 		TaskCategory tasks.Category
 		TaskKey      tasks.Key
+
+		// BestEffort indicates that this request is a suggestion only.
+		// The system may choose to ignore it without error.
+		BestEffort bool
 	}
 
 	// RangeCompleteHistoryTasksRequest deletes a range of history tasks

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -417,8 +417,7 @@ type (
 		TaskCategory tasks.Category
 		TaskKey      tasks.Key
 
-		// BestEffort indicates that this request is a suggestion only.
-		// The system may choose to ignore it without error.
+		// BestEffort indicates that this request is a suggestion. System may choose to ignore it without error.
 		BestEffort bool
 	}
 

--- a/common/persistence/sql/execution_tasks.go
+++ b/common/persistence/sql/execution_tasks.go
@@ -50,6 +50,10 @@ func (m *sqlExecutionStore) CompleteHistoryTask(
 	ctx context.Context,
 	request *p.CompleteHistoryTaskRequest,
 ) error {
+	// Ignore the request if it is best effort
+	if request.BestEffort {
+		return nil
+	}
 	switch request.TaskCategory.Type() {
 	case tasks.CategoryTypeImmediate:
 		return m.completeHistoryImmediateTask(ctx, request)


### PR DESCRIPTION
## What changed?
Add a field to CompleteHistoryTaskRequest that suggest that this request can be ignored by persistence layer if needed.
Cassandra's MutableStateTaskStore will ignore the request if BestEffort is set to true.

## Why?
This allows persistence layer to ignore requests if it can negatively impact underlying storage.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

