### PR TITLE
Make replicate stream liveness check dynamic configurable

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2436,6 +2436,16 @@ that task will be sent to DLQ.`,
 		time.Minute,
 		`ReplicationStreamSendEmptyTaskDuration is the interval to sync status when there is no replication task`,
 	)
+	ReplicationStreamReceiverLivenessMultiplier = NewGlobalIntSetting(
+		"history.ReplicationReceiverLivenessMultiplier",
+		3,
+		"ReplicationStreamSendEmptyTask is the multiplier of liveness check interval on stream receiver",
+	)
+	ReplicationStreamSenderLivenessMultiplier = NewGlobalIntSetting(
+		"history.ReplicationStreamSenderLivenessMultiplier",
+		10,
+		"ReplicationStreamSenderLivenessMultiplier is the multiplier of liveness check interval on stream sender",
+	)
 	ReplicationEnableRateLimit = NewGlobalBoolSetting(
 		"history.ReplicationEnableRateLimit",
 		true,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -280,6 +280,8 @@ type Config struct {
 	ReplicationProgressCacheTTL                         dynamicconfig.DurationPropertyFn
 	ReplicationStreamSendEmptyTaskDuration              dynamicconfig.DurationPropertyFn
 	ReplicationEnableRateLimit                          dynamicconfig.BoolPropertyFn
+	ReplicationStreamReceiverLivenessMultiplier         dynamicconfig.IntPropertyFn
+	ReplicationStreamSenderLivenessMultiplier           dynamicconfig.IntPropertyFn
 
 	// The following are used by consistent query
 	MaxBufferedQueryCount dynamicconfig.IntPropertyFn
@@ -545,6 +547,8 @@ func NewConfig(
 		ReplicationProgressCacheTTL:                         dynamicconfig.ReplicationProgressCacheTTL.Get(dc),
 		ReplicationEnableRateLimit:                          dynamicconfig.ReplicationEnableRateLimit.Get(dc),
 		ReplicationStreamSendEmptyTaskDuration:              dynamicconfig.ReplicationStreamSendEmptyTaskDuration.Get(dc),
+		ReplicationStreamReceiverLivenessMultiplier:         dynamicconfig.ReplicationStreamReceiverLivenessMultiplier.Get(dc),
+		ReplicationStreamSenderLivenessMultiplier:           dynamicconfig.ReplicationStreamSenderLivenessMultiplier.Get(dc),
 
 		MaximumBufferedEventsBatch:       dynamicconfig.MaximumBufferedEventsBatch.Get(dc),
 		MaximumBufferedEventsSizeInBytes: dynamicconfig.MaximumBufferedEventsSizeInBytes.Get(dc),

--- a/service/history/replication/stream_receiver.go
+++ b/service/history/replication/stream_receiver.go
@@ -26,9 +26,6 @@ const (
 	ReceiverModeUnset       ReceiverMode = 0
 	ReceiverModeSingleStack ReceiverMode = 1 // default mode. It only uses High Priority Task Tracker for processing tasks.
 	ReceiverModeTieredStack ReceiverMode = 2
-
-	// ReceiveTaskIntervalMultiplier is based on ReplicationStreamSendEmptyTaskDuration. Default duration: 1 min.
-	ReceiveTaskIntervalMultiplier = 3
 )
 
 type (
@@ -126,7 +123,14 @@ func (r *StreamReceiverImpl) Start() {
 
 	go WrapEventLoop(context.Background(), r.sendEventLoop, r.Stop, r.logger, r.MetricsHandler, r.clientShardKey, r.serverShardKey, r.Config)
 	go WrapEventLoop(context.Background(), r.recvEventLoop, r.Stop, r.logger, r.MetricsHandler, r.clientShardKey, r.serverShardKey, r.Config)
-	go livenessMonitor(r.recvSignalChan, r.Config.ReplicationStreamSendEmptyTaskDuration()*ReceiveTaskIntervalMultiplier, r.shutdownChan, r.Stop, r.logger)
+	go livenessMonitor(
+		r.recvSignalChan,
+		r.Config.ReplicationStreamSendEmptyTaskDuration,
+		r.Config.ReplicationStreamReceiverLivenessMultiplier,
+		r.shutdownChan,
+		r.Stop,
+		r.logger,
+	)
 	r.logger.Info("StreamReceiver started.")
 }
 

--- a/service/history/replication/stream_receiver_test.go
+++ b/service/history/replication/stream_receiver_test.go
@@ -13,6 +13,7 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	ctasks "go.temporal.io/server/common/tasks"
@@ -509,7 +510,8 @@ func (s *streamReceiverSuite) TestRecvEventLoop_Panic_Captured() {
 func (s *streamReceiverSuite) TestLivenessMonitor() {
 	livenessMonitor(
 		s.streamReceiver.recvSignalChan,
-		time.Millisecond,
+		dynamicconfig.GetDurationPropertyFn(time.Second),
+		dynamicconfig.GetIntPropertyFn(1),
 		s.streamReceiver.shutdownChan,
 		s.streamReceiver.Stop,
 		s.streamReceiver.logger,

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -36,9 +36,6 @@ import (
 
 const (
 	TaskMaxSkipCount = 1000
-
-	// SyncTaskIntervalMultiplier is based on ReplicationStreamSyncStatusDuration. Default duration is 1s.
-	SyncTaskIntervalMultiplier = 10
 )
 
 type (
@@ -133,7 +130,14 @@ func (s *StreamSenderImpl) Start() {
 	}
 
 	go WrapEventLoop(s.server.Context(), s.recvEventLoop, s.Stop, s.logger, s.metrics, s.clientShardKey, s.serverShardKey, s.config)
-	go livenessMonitor(s.recvSignalChan, s.config.ReplicationStreamSyncStatusDuration()*SyncTaskIntervalMultiplier, s.shutdownChan, s.Stop, s.logger)
+	go livenessMonitor(
+		s.recvSignalChan,
+		s.config.ReplicationStreamSyncStatusDuration,
+		s.config.ReplicationStreamSenderLivenessMultiplier,
+		s.shutdownChan,
+		s.Stop,
+		s.logger,
+	)
 	s.logger.Info("StreamSender started.")
 }
 

--- a/service/history/replication/stream_sender_test.go
+++ b/service/history/replication/stream_sender_test.go
@@ -17,6 +17,7 @@ import (
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -1051,7 +1052,8 @@ func (s *streamSenderSuite) TestLivenessMonitor() {
 
 	livenessMonitor(
 		s.streamSender.recvSignalChan,
-		time.Millisecond,
+		dynamicconfig.GetDurationPropertyFn(time.Second),
+		dynamicconfig.GetIntPropertyFn(1),
 		s.streamSender.shutdownChan,
 		s.streamSender.Stop,
 		s.streamSender.logger,


### PR DESCRIPTION
## What changed?
Make replicate stream liveness check dynamic configurable

## Why?
Easy to adjust the liveness check internal without restart servers.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
