### PR TITLE
Add experimental frontend.CallbackCalidator interface

### DIFF
--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -95,6 +95,7 @@ var Module = fx.Options(
 	fx.Provide(AuthorizationInterceptorProvider),
 	fx.Provide(NamespaceCheckerProvider),
 	fx.Provide(func(so GrpcServerOptions) *grpc.Server { return grpc.NewServer(so.Options...) }),
+	fx.Provide(CallbackValidatorProvider),
 	fx.Provide(HandlerProvider),
 	fx.Provide(AdminHandlerProvider),
 	fx.Provide(OperatorHandlerProvider),
@@ -700,6 +701,11 @@ func OperatorHandlerProvider(
 	return NewOperatorHandlerImpl(args)
 }
 
+func CallbackValidatorProvider() CallbackValidator {
+	// By default, no custom validation is performed.
+	return nil
+}
+
 func HandlerProvider(
 	cfg *config.Config,
 	serviceName primitives.ServiceName,
@@ -731,6 +737,7 @@ func HandlerProvider(
 	membershipMonitor membership.Monitor,
 	healthInterceptor *interceptor.HealthInterceptor,
 	scheduleSpecBuilder *scheduler.SpecBuilder,
+	callbackValidator CallbackValidator,
 ) Handler {
 	wfHandler := NewWorkflowHandler(
 		serviceConfig,
@@ -758,6 +765,7 @@ func HandlerProvider(
 		healthInterceptor,
 		scheduleSpecBuilder,
 		httpEnabled(cfg, serviceName),
+		callbackValidator,
 	)
 	return wfHandler
 }

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -189,6 +189,7 @@ func (s *WorkflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 		healthInterceptor,
 		scheduler.NewSpecBuilder(),
 		true,
+		nil,
 	)
 }
 


### PR DESCRIPTION
## Why?

Allows custom custom server implementations to do stricter validation of callbacks.