### PR TITLE
Improve multi-cursor actions

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1596,7 +1596,14 @@ NOTE: The outbound queue has a separate configuration: outboundQueueMaxPredicate
 	QueueMoveGroupTaskCountBase = NewGlobalIntSetting(
 		"history.queueMoveGroupTaskCountBase",
 		500,
-		`The base number of pending tasks count for a task group to be moved to the next level reader. The actual count is calculated as base * 3^level`,
+		`The base number of pending tasks count for a task group to be moved to the next level reader. 
+The actual count is calculated as base * (multiplier ^ level)`,
+	)
+	QueueMoveGroupTaskCountMultiplier = NewGlobalFloatSetting(
+		"history.queueMoveGroupTaskCountMultiplier",
+		3.0,
+		`The multiplier used to calculate the number of pending tasks for a task group to be moved to the next level reader. 
+The actual count is calculated as base * (multiplier ^ level)`,
 	)
 
 	TaskSchedulerEnableRateLimiter = NewGlobalBoolSetting(

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1586,7 +1586,7 @@ NOTE: The outbound queue has a separate configuration: outboundQueuePendingTaskM
 	)
 	QueueMaxPredicateSize = NewGlobalIntSetting(
 		"history.queueMaxPredicateSize",
-		0,
+		10*1024,
 		`The max size of the multi-cursor predicate structure stored in the shard info record. 0 is considered
 unlimited. When the predicate size is surpassed for a given scope, the predicate is converted to a universal predicate,
 which causes all tasks in the scope's range to eventually be reprocessed without applying any filtering logic.

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1593,6 +1593,11 @@ which causes all tasks in the scope's range to eventually be reprocessed without
 NOTE: The outbound queue has a separate configuration: outboundQueueMaxPredicateSize.
 `,
 	)
+	QueueMoveGroupTaskCountBase = NewGlobalIntSetting(
+		"history.queueMoveGroupTaskCountBase",
+		500,
+		`The base number of pending tasks count for a task group to be moved to the next level reader. The actual count is calculated as base * 3^level`,
+	)
 
 	TaskSchedulerEnableRateLimiter = NewGlobalBoolSetting(
 		"history.taskSchedulerEnableRateLimiter",

--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -190,6 +190,7 @@ func (f *archivalQueueFactory) newScheduledQueue(shard historyi.ShardContext, ex
 			CheckpointInterval:                  f.Config.ArchivalProcessorUpdateAckInterval,
 			CheckpointIntervalJitterCoefficient: f.Config.ArchivalProcessorUpdateAckIntervalJitterCoefficient,
 			MaxReaderCount:                      f.Config.ArchivalQueueMaxReaderCount,
+			MoveGroupTaskCountBase:              f.Config.QueueMoveGroupTaskCountBase,
 		},
 		f.HostReaderRateLimiter,
 		logger,

--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -191,6 +191,7 @@ func (f *archivalQueueFactory) newScheduledQueue(shard historyi.ShardContext, ex
 			CheckpointIntervalJitterCoefficient: f.Config.ArchivalProcessorUpdateAckIntervalJitterCoefficient,
 			MaxReaderCount:                      f.Config.ArchivalQueueMaxReaderCount,
 			MoveGroupTaskCountBase:              f.Config.QueueMoveGroupTaskCountBase,
+			MoveGroupTaskCountMultiplier:        f.Config.QueueMoveGroupTaskCountMultiplier,
 		},
 		f.HostReaderRateLimiter,
 		logger,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -96,6 +96,7 @@ type Config struct {
 	QueueCriticalSlicesCount         dynamicconfig.IntPropertyFn
 	QueuePendingTaskMaxCount         dynamicconfig.IntPropertyFn
 	QueueMaxPredicateSize            dynamicconfig.IntPropertyFn
+	QueueMoveGroupTaskCountBase      dynamicconfig.IntPropertyFn
 
 	TaskDLQEnabled                 dynamicconfig.BoolPropertyFn
 	TaskDLQUnexpectedErrorAttempts dynamicconfig.IntPropertyFn
@@ -456,6 +457,7 @@ func NewConfig(
 		QueueCriticalSlicesCount:         dynamicconfig.QueueCriticalSlicesCount.Get(dc),
 		QueuePendingTaskMaxCount:         dynamicconfig.QueuePendingTaskMaxCount.Get(dc),
 		QueueMaxPredicateSize:            dynamicconfig.QueueMaxPredicateSize.Get(dc),
+		QueueMoveGroupTaskCountBase:      dynamicconfig.QueueMoveGroupTaskCountBase.Get(dc),
 
 		TaskDLQEnabled:                 dynamicconfig.HistoryTaskDLQEnabled.Get(dc),
 		TaskDLQUnexpectedErrorAttempts: dynamicconfig.HistoryTaskDLQUnexpectedErrorAttempts.Get(dc),

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -91,12 +91,13 @@ type Config struct {
 	StandbyTaskMissingEventsResendDelay  dynamicconfig.DurationPropertyFnWithTaskTypeFilter
 	StandbyTaskMissingEventsDiscardDelay dynamicconfig.DurationPropertyFnWithTaskTypeFilter
 
-	QueuePendingTaskCriticalCount    dynamicconfig.IntPropertyFn
-	QueueReaderStuckCriticalAttempts dynamicconfig.IntPropertyFn
-	QueueCriticalSlicesCount         dynamicconfig.IntPropertyFn
-	QueuePendingTaskMaxCount         dynamicconfig.IntPropertyFn
-	QueueMaxPredicateSize            dynamicconfig.IntPropertyFn
-	QueueMoveGroupTaskCountBase      dynamicconfig.IntPropertyFn
+	QueuePendingTaskCriticalCount     dynamicconfig.IntPropertyFn
+	QueueReaderStuckCriticalAttempts  dynamicconfig.IntPropertyFn
+	QueueCriticalSlicesCount          dynamicconfig.IntPropertyFn
+	QueuePendingTaskMaxCount          dynamicconfig.IntPropertyFn
+	QueueMaxPredicateSize             dynamicconfig.IntPropertyFn
+	QueueMoveGroupTaskCountBase       dynamicconfig.IntPropertyFn
+	QueueMoveGroupTaskCountMultiplier dynamicconfig.FloatPropertyFn
 
 	TaskDLQEnabled                 dynamicconfig.BoolPropertyFn
 	TaskDLQUnexpectedErrorAttempts dynamicconfig.IntPropertyFn
@@ -452,12 +453,13 @@ func NewConfig(
 		StandbyTaskMissingEventsResendDelay:  dynamicconfig.StandbyTaskMissingEventsResendDelay.Get(dc),
 		StandbyTaskMissingEventsDiscardDelay: dynamicconfig.StandbyTaskMissingEventsDiscardDelay.Get(dc),
 
-		QueuePendingTaskCriticalCount:    dynamicconfig.QueuePendingTaskCriticalCount.Get(dc),
-		QueueReaderStuckCriticalAttempts: dynamicconfig.QueueReaderStuckCriticalAttempts.Get(dc),
-		QueueCriticalSlicesCount:         dynamicconfig.QueueCriticalSlicesCount.Get(dc),
-		QueuePendingTaskMaxCount:         dynamicconfig.QueuePendingTaskMaxCount.Get(dc),
-		QueueMaxPredicateSize:            dynamicconfig.QueueMaxPredicateSize.Get(dc),
-		QueueMoveGroupTaskCountBase:      dynamicconfig.QueueMoveGroupTaskCountBase.Get(dc),
+		QueuePendingTaskCriticalCount:     dynamicconfig.QueuePendingTaskCriticalCount.Get(dc),
+		QueueReaderStuckCriticalAttempts:  dynamicconfig.QueueReaderStuckCriticalAttempts.Get(dc),
+		QueueCriticalSlicesCount:          dynamicconfig.QueueCriticalSlicesCount.Get(dc),
+		QueuePendingTaskMaxCount:          dynamicconfig.QueuePendingTaskMaxCount.Get(dc),
+		QueueMaxPredicateSize:             dynamicconfig.QueueMaxPredicateSize.Get(dc),
+		QueueMoveGroupTaskCountBase:       dynamicconfig.QueueMoveGroupTaskCountBase.Get(dc),
+		QueueMoveGroupTaskCountMultiplier: dynamicconfig.QueueMoveGroupTaskCountMultiplier.Get(dc),
 
 		TaskDLQEnabled:                 dynamicconfig.HistoryTaskDLQEnabled.Get(dc),
 		TaskDLQUnexpectedErrorAttempts: dynamicconfig.HistoryTaskDLQUnexpectedErrorAttempts.Get(dc),

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -275,6 +275,7 @@ func (f *outboundQueueFactory) CreateQueue(
 			CheckpointIntervalJitterCoefficient: f.Config.OutboundProcessorUpdateAckIntervalJitterCoefficient,
 			MaxReaderCount:                      f.Config.OutboundQueueMaxReaderCount,
 			MoveGroupTaskCountBase:              f.Config.QueueMoveGroupTaskCountBase,
+			MoveGroupTaskCountMultiplier:        f.Config.QueueMoveGroupTaskCountMultiplier,
 		},
 		f.hostReaderRateLimiter,
 		queues.GrouperStateMachineNamespaceIDAndDestination{},

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -274,6 +274,7 @@ func (f *outboundQueueFactory) CreateQueue(
 			CheckpointInterval:                  f.Config.OutboundProcessorUpdateAckInterval,
 			CheckpointIntervalJitterCoefficient: f.Config.OutboundProcessorUpdateAckIntervalJitterCoefficient,
 			MaxReaderCount:                      f.Config.OutboundQueueMaxReaderCount,
+			MoveGroupTaskCountBase:              f.Config.QueueMoveGroupTaskCountBase,
 		},
 		f.hostReaderRateLimiter,
 		queues.GrouperStateMachineNamespaceIDAndDestination{},

--- a/service/history/queues/action.go
+++ b/service/history/queues/action.go
@@ -5,6 +5,6 @@ type (
 	// It is created and run by Mitigator upon receiving an Alert.
 	Action interface {
 		Name() string
-		Run(*ReaderGroup)
+		Run(*ReaderGroup) (actionTaken bool)
 	}
 )

--- a/service/history/queues/action_move_group.go
+++ b/service/history/queues/action_move_group.go
@@ -1,22 +1,23 @@
 package queues
 
-const moveGroupTaskCountMutiplier = 3
-
 type actionMoveGroup struct {
-	maxReaderCount         int
-	grouper                Grouper
-	moveGroupTaskCountBase int
+	maxReaderCount               int
+	grouper                      Grouper
+	moveGroupTaskCountBase       int
+	moveGroupTaskCountMultiplier float64
 }
 
 func newMoveGroupAction(
 	maxReaderCount int,
 	grouper Grouper,
 	moveGroupTaskCountBase int,
+	moveGroupTaskCountMultiplier float64,
 ) *actionMoveGroup {
 	return &actionMoveGroup{
-		maxReaderCount:         maxReaderCount,
-		grouper:                grouper,
-		moveGroupTaskCountBase: moveGroupTaskCountBase,
+		maxReaderCount:               maxReaderCount,
+		grouper:                      grouper,
+		moveGroupTaskCountBase:       moveGroupTaskCountBase,
+		moveGroupTaskCountMultiplier: moveGroupTaskCountMultiplier,
 	}
 }
 
@@ -39,7 +40,7 @@ func (a *actionMoveGroup) Run(readerGroup *ReaderGroup) bool {
 	moveGroupMinTaskCount := a.moveGroupTaskCountBase
 	for readerID := DefaultReaderId; readerID+1 < int64(a.maxReaderCount); readerID++ {
 		if readerID != DefaultReaderId {
-			moveGroupMinTaskCount *= moveGroupTaskCountMutiplier
+			moveGroupMinTaskCount = int(float64(moveGroupMinTaskCount) * a.moveGroupTaskCountMultiplier)
 		}
 
 		reader, ok := readerGroup.ReaderByID(readerID)

--- a/service/history/queues/action_move_group.go
+++ b/service/history/queues/action_move_group.go
@@ -1,0 +1,90 @@
+package queues
+
+const moveGroupTaskCountMutiplier = 3
+
+type actionMoveGroup struct {
+	maxReaderCount         int
+	grouper                Grouper
+	moveGroupTaskCountBase int
+}
+
+func newMoveGroupAction(
+	maxReaderCount int,
+	grouper Grouper,
+	moveGroupTaskCountBase int,
+) *actionMoveGroup {
+	return &actionMoveGroup{
+		maxReaderCount:         maxReaderCount,
+		grouper:                grouper,
+		moveGroupTaskCountBase: moveGroupTaskCountBase,
+	}
+}
+
+func (a *actionMoveGroup) Name() string {
+	return "move-group"
+}
+
+func (a *actionMoveGroup) Run(readerGroup *ReaderGroup) bool {
+
+	// Move task groups from reader x to x+1 if the # of pending tasks for a group is higher than
+	// a threashold. The threshold is calculated as:
+	//   moveGroupTaskCountBase * (moveGroupTaskCountMutiplier ^ x) = base * (3 ^ x)
+	//
+	// If after moving a group to reader x+1, the # of pending tasks for that group becomes higher than
+	// the threshold for reader x+1, it will be moved to reader x+2 in the next iteration.
+
+	// TODO: instead of moving task groups down by just one reader, directly move it to the reader level
+	// based on the total number of pending tasks across all readers.
+
+	moveGroupMinTaskCount := a.moveGroupTaskCountBase
+	for readerID := DefaultReaderId; readerID+1 < int64(a.maxReaderCount); readerID++ {
+		if readerID != DefaultReaderId {
+			moveGroupMinTaskCount *= moveGroupTaskCountMutiplier
+		}
+
+		reader, ok := readerGroup.ReaderByID(readerID)
+		if !ok {
+			continue
+		}
+
+		pendingTaskPerGroup := make(map[any]int)
+		reader.WalkSlices(func(s Slice) {
+			for key, pendingTaskCount := range s.TaskStats().PendingPerKey {
+				pendingTaskPerGroup[key] += pendingTaskCount
+			}
+		})
+
+		groupsToMove := make([]any, 0, len(pendingTaskPerGroup))
+		for key, pendingTaskCount := range pendingTaskPerGroup {
+			if pendingTaskCount >= moveGroupMinTaskCount {
+				groupsToMove = append(groupsToMove, key)
+			}
+		}
+
+		if len(groupsToMove) == 0 {
+			continue
+		}
+
+		predicateForSplit := a.grouper.Predicate(groupsToMove)
+
+		var slicesToMove []Slice
+		reader.SplitSlices(func(s Slice) ([]Slice, bool) {
+			// Technically we don't need this empty scope check, but it helps avoid
+			// unnecessary allocation and task movement.
+			scope := s.Scope()
+			splitScope, _ := scope.SplitByPredicate(predicateForSplit)
+			if splitScope.IsEmpty() {
+				return nil, false
+			}
+
+			split, remain := s.SplitByPredicate(predicateForSplit)
+			slicesToMove = append(slicesToMove, split)
+			return []Slice{remain}, true
+		})
+
+		nextReader := readerGroup.GetOrCreateReader(readerID + 1)
+		nextReader.MergeSlices(slicesToMove...)
+	}
+
+	return true
+}

--- a/service/history/queues/action_reader_stuck.go
+++ b/service/history/queues/action_reader_stuck.go
@@ -29,11 +29,11 @@ func (a *actionReaderStuck) Name() string {
 	return "reader-stuck"
 }
 
-func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) {
+func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) bool {
 	reader, ok := readerGroup.ReaderByID(a.attributes.ReaderID)
 	if !ok {
 		a.logger.Info("Failed to get queue with readerID for reader stuck action", tag.QueueReaderID(a.attributes.ReaderID))
-		return
+		return false
 	}
 
 	stuckRange := NewRange(
@@ -77,9 +77,10 @@ func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) {
 	})
 
 	if len(splitSlices) == 0 {
-		return
+		return false
 	}
 
 	nextReader := readerGroup.GetOrCreateReader(a.attributes.ReaderID + 1)
 	nextReader.MergeSlices(splitSlices...)
+	return true
 }

--- a/service/history/queues/action_slice_predicate.go
+++ b/service/history/queues/action_slice_predicate.go
@@ -46,14 +46,14 @@ func (a *slicePredicateAction) Name() string {
 	return "slice-predicate"
 }
 
-func (a *slicePredicateAction) Run(readerGroup *ReaderGroup) {
+func (a *slicePredicateAction) Run(readerGroup *ReaderGroup) bool {
 	reader, ok := readerGroup.ReaderByID(DefaultReaderId)
 	if !ok {
-		return
+		return false
 	}
 
 	if int64(a.maxReaderCount) <= DefaultReaderId+1 {
-		return
+		return false
 	}
 
 	sliceCount := a.monitor.GetSliceCount(DefaultReaderId)
@@ -72,7 +72,7 @@ func (a *slicePredicateAction) Run(readerGroup *ReaderGroup) {
 	if !hasNonUniversalPredicate ||
 		(pendingTasks < moveSliceDefaultReaderMinPendingTaskCount &&
 			sliceCount < moveSliceDefaultReaderMinSliceCount) {
-		return
+		return false
 	}
 
 	var moveSlices []Slice
@@ -86,9 +86,10 @@ func (a *slicePredicateAction) Run(readerGroup *ReaderGroup) {
 	})
 
 	if len(moveSlices) == 0 {
-		return
+		return false
 	}
 
 	nextReader := readerGroup.GetOrCreateReader(DefaultReaderId + 1)
 	nextReader.MergeSlices(moveSlices...)
+	return true
 }

--- a/service/history/queues/mitigator.go
+++ b/service/history/queues/mitigator.go
@@ -99,8 +99,10 @@ func runAction(
 	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) {
+	if action.Run(readerGroup) {
+		return
+	}
+
 	metricsHandler = metricsHandler.WithTags(metrics.QueueActionTag(action.Name()))
 	metrics.QueueActionCounter.With(metricsHandler).Record(1)
-
-	action.Run(readerGroup)
 }

--- a/service/history/queues/mitigator.go
+++ b/service/history/queues/mitigator.go
@@ -17,7 +17,7 @@ type (
 		Mitigate(Alert)
 	}
 
-	actionRunner func(Action, *ReaderGroup, metrics.Handler, log.Logger)
+	actionRunner func(Action, *ReaderGroup, metrics.Handler)
 
 	mitigatorImpl struct {
 		sync.Mutex
@@ -87,7 +87,6 @@ func (m *mitigatorImpl) Mitigate(alert Alert) {
 		action,
 		m.readerGroup,
 		m.metricsHandler,
-		log.With(m.logger, tag.QueueAlert(alert)),
 	)
 
 	m.monitor.ResolveAlert(alert.AlertType)
@@ -97,7 +96,6 @@ func runAction(
 	action Action,
 	readerGroup *ReaderGroup,
 	metricsHandler metrics.Handler,
-	logger log.Logger,
 ) {
 	if action.Run(readerGroup) {
 		return

--- a/service/history/queues/mitigator_test.go
+++ b/service/history/queues/mitigator_test.go
@@ -94,7 +94,6 @@ func (s *mitigatorSuite) TestMitigate_ActionMatchAlert() {
 		action Action,
 		_ *ReaderGroup,
 		_ metrics.Handler,
-		_ log.Logger,
 	) {
 		actualAction = action
 	}
@@ -110,7 +109,6 @@ func (s *mitigatorSuite) TestMitigate_ResolveAlert() {
 		_ Action,
 		_ *ReaderGroup,
 		_ metrics.Handler,
-		_ log.Logger,
 	) {
 	}
 

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -298,14 +298,14 @@ func (p *queueBase) checkpoint() {
 		// Run an action to proactively move task group with high pending task to non-default reader
 		// so that upon shard reload, those groups won't block other tasks in the default reader from
 		// being loaded.
-		checkpointAction = newMoveGroupAction(maxReaderCount, p.grouper, taskCountBase, p.options.MoveGroupTaskCountMultiplier())
+		checkpointAction = newMoveGroupAction(maxReaderCount, p.grouper, taskCountBase, p.options.MoveGroupTaskCountMultiplier(), p.logger)
 	} else {
 		// Run slicePredicateAction to move slices with non-universal predicate to non-default reader
 		// so that upon shard reload, task loading for those slices won't block other slices in the default reader.
 		checkpointAction = newSlicePredicateAction(p.monitor, maxReaderCount)
 	}
 
-	runAction(checkpointAction, p.readerGroup, p.metricsHandler, p.logger)
+	runAction(checkpointAction, p.readerGroup, p.metricsHandler)
 
 	readerScopes := make(map[int64][]Scope)
 	newExclusiveDeletionHighWatermark := p.nonReadableScope.Range.InclusiveMin

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -2,6 +2,7 @@ package queues
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
@@ -24,10 +25,11 @@ import (
 const (
 	DefaultReaderId = common.DefaultQueueReaderID
 
-	// Non-default readers will use critical pending task count * this coefficient
+	// Non-default readers will use critical pending task count * (this multiplier ^ readerID)
 	// as its max pending task count so that their loading will never trigger pending
 	// task alert & action
-	nonDefaultReaderMaxPendingTaskCoefficient = 0.8
+	maxPendingTaskMultiplier = 0.8
+	minMaxPendingTaskCount   = 1000
 
 	queueIOTimeout = 5 * time.Second * debug.TimeoutMultiplier
 
@@ -95,6 +97,7 @@ type (
 		CheckpointIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
 		MaxReaderCount                      dynamicconfig.IntPropertyFn
 		MoveGroupTaskCountBase              dynamicconfig.IntPropertyFn
+		MoveGroupTaskCountMultiplier        dynamicconfig.FloatPropertyFn
 	}
 )
 
@@ -142,9 +145,14 @@ func newQueueBase(
 			// otherwise those readers will keep loading, hit pending task count limit, unload, throttle, load, etc...
 			// use a limit lower than the critical pending task count instead
 
-			// TODO: use lower threshold for higher readerID
+			// Use lower maxPendingTaskCount for lower reader to guarantee that higher reader can
+			// always have some tasks loaded.
 			readerOptions.MaxPendingTasksCount = func() int {
-				return int(float64(options.PendingTasksCriticalCount()) * nonDefaultReaderMaxPendingTaskCoefficient)
+				return max(
+					minMaxPendingTaskCount,
+					int(float64(options.PendingTasksCriticalCount())*
+						math.Pow(maxPendingTaskMultiplier, float64(readerID))),
+				)
 			}
 		}
 
@@ -290,7 +298,7 @@ func (p *queueBase) checkpoint() {
 		// Run an action to proactively move task group with high pending task to non-default reader
 		// so that upon shard reload, those groups won't block other tasks in the default reader from
 		// being loaded.
-		checkpointAction = newMoveGroupAction(maxReaderCount, p.grouper, taskCountBase)
+		checkpointAction = newMoveGroupAction(maxReaderCount, p.grouper, taskCountBase, p.options.MoveGroupTaskCountMultiplier())
 	} else {
 		// Run slicePredicateAction to move slices with non-universal predicate to non-default reader
 		// so that upon shard reload, task loading for those slices won't block other slices in the default reader.

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -67,7 +67,8 @@ var testQueueOptions = &Options{
 	CheckpointInterval:                  dynamicconfig.GetDurationPropertyFn(100 * time.Millisecond),
 	CheckpointIntervalJitterCoefficient: dynamicconfig.GetFloatPropertyFn(0.15),
 	MaxReaderCount:                      dynamicconfig.GetIntPropertyFn(5),
-	MoveGroupTaskCountBase:              dynamicconfig.GetIntPropertyFn(0), // disable the new move group action
+	MoveGroupTaskCountBase:              dynamicconfig.GetIntPropertyFn(0),
+	MoveGroupTaskCountMultiplier:        dynamicconfig.GetFloatPropertyFn(3.0),
 }
 
 func TestQueueBaseSuite(t *testing.T) {

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -213,6 +213,9 @@ func (r *ReaderImpl) SplitSlices(splitter SliceSplitter) {
 		}
 
 		for _, newSlice := range newSlices {
+			if scope := newSlice.Scope(); scope.IsEmpty() {
+				continue
+			}
 			splitSlices.PushBack(newSlice)
 		}
 	}
@@ -290,6 +293,9 @@ func (r *ReaderImpl) AppendSlices(incomingSlices ...Slice) {
 	defer r.Unlock()
 
 	for _, incomingSlice := range incomingSlices {
+		if scope := incomingSlice.Scope(); scope.IsEmpty() {
+			continue
+		}
 		r.slices.PushBack(incomingSlice)
 	}
 
@@ -529,6 +535,10 @@ func mergeOrAppendSlice(
 	slices *list.List,
 	incomingSlice Slice,
 ) {
+	if scope := incomingSlice.Scope(); scope.IsEmpty() {
+		return
+	}
+
 	if slices.Len() == 0 {
 		slices.PushBack(incomingSlice)
 		return

--- a/service/history/queues/scope.go
+++ b/service/history/queues/scope.go
@@ -55,10 +55,7 @@ func (s *Scope) SplitByPredicate(
 	)
 	failScope := NewScope(
 		s.Range,
-		predicates.And(
-			s.Predicate,
-			predicates.Not(predicate),
-		),
+		tasks.AndPredicates(s.Predicate, predicates.Not(predicate)),
 	)
 	return passScope, failScope
 }

--- a/service/history/queues/slice_test.go
+++ b/service/history/queues/slice_test.go
@@ -128,7 +128,7 @@ func (s *sliceSuite) TestSplitByPredicate() {
 	s.Equal(r, passSlice.Scope().Range)
 	s.Equal(r, failSlice.Scope().Range)
 	s.True(tasks.AndPredicates(slice.scope.Predicate, splitPredicate).Equals(passSlice.Scope().Predicate))
-	s.True(predicates.And(slice.scope.Predicate, predicates.Not[tasks.Task](splitPredicate)).Equals(failSlice.Scope().Predicate))
+	s.True(tasks.AndPredicates(slice.scope.Predicate, predicates.Not(splitPredicate)).Equals(failSlice.Scope().Predicate))
 
 	s.validateSliceState(passSlice.(*SliceImpl))
 	s.validateSliceState(failSlice.(*SliceImpl))

--- a/service/history/tasks/predicates_test.go
+++ b/service/history/tasks/predicates_test.go
@@ -364,12 +364,32 @@ func (s *predicatesSuite) TestAndPredicates() {
 			predicateB: NewTypePredicate([]enumsspb.TaskType{
 				enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
 			}),
-			expectedResult: predicates.And[Task](
+			expectedResult: predicates.And(
 				NewNamespacePredicate([]string{"namespace1"}),
 				NewTypePredicate([]enumsspb.TaskType{
 					enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
 				}),
 			),
+		},
+		{
+			predicateA:     NewNamespacePredicate([]string{"namespace1", "namespace2"}),
+			predicateB:     predicates.Not(NewNamespacePredicate([]string{"namespace2", "namespace3"})),
+			expectedResult: NewNamespacePredicate([]string{"namespace1"}),
+		},
+		{
+			predicateA:     predicates.Not(NewNamespacePredicate([]string{"namespace2", "namespace3"})),
+			predicateB:     NewNamespacePredicate([]string{"namespace1", "namespace2"}),
+			expectedResult: NewNamespacePredicate([]string{"namespace1"}),
+		},
+		{
+			predicateA:     predicates.Not(NewNamespacePredicate([]string{"namespace1", "namespace2"})),
+			predicateB:     predicates.Not(NewNamespacePredicate([]string{"namespace2", "namespace3"})),
+			expectedResult: predicates.Not(NewNamespacePredicate([]string{"namespace1", "namespace2", "namespace3"})),
+		},
+		{
+			predicateA:     NewNamespacePredicate([]string{"namespace1", "namespace2"}),
+			predicateB:     predicates.Not(NewNamespacePredicate([]string{"namespace1", "namespace2", "namespace3"})),
+			expectedResult: predicates.Empty[Task](),
 		},
 	}
 
@@ -431,12 +451,27 @@ func (s *predicatesSuite) TestOrPredicates() {
 			predicateB: NewTypePredicate([]enumsspb.TaskType{
 				enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
 			}),
-			expectedResult: predicates.Or[Task](
+			expectedResult: predicates.Or(
 				NewNamespacePredicate([]string{"namespace1"}),
 				NewTypePredicate([]enumsspb.TaskType{
 					enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
 				}),
 			),
+		},
+		{
+			predicateA:     NewNamespacePredicate([]string{"namespace1", "namespace2"}),
+			predicateB:     predicates.Not(NewNamespacePredicate([]string{"namespace2", "namespace3"})),
+			expectedResult: predicates.Not(NewNamespacePredicate([]string{"namespace3"})),
+		},
+		{
+			predicateA:     predicates.Not(NewNamespacePredicate([]string{"namespace2", "namespace3"})),
+			predicateB:     NewNamespacePredicate([]string{"namespace1", "namespace2"}),
+			expectedResult: predicates.Not(NewNamespacePredicate([]string{"namespace3"})),
+		},
+		{
+			predicateA:     predicates.Not(NewNamespacePredicate([]string{"namespace1", "namespace2"})),
+			predicateB:     predicates.Not(NewNamespacePredicate([]string{"namespace2", "namespace3"})),
+			expectedResult: predicates.Not(NewNamespacePredicate([]string{"namespace2"})),
 		},
 	}
 

--- a/service/history/timer_queue_factory.go
+++ b/service/history/timer_queue_factory.go
@@ -185,6 +185,7 @@ func (f *timerQueueFactory) CreateQueue(
 			CheckpointInterval:                  f.Config.TimerProcessorUpdateAckInterval,
 			CheckpointIntervalJitterCoefficient: f.Config.TimerProcessorUpdateAckIntervalJitterCoefficient,
 			MaxReaderCount:                      f.Config.TimerQueueMaxReaderCount,
+			MoveGroupTaskCountBase:              f.Config.QueueMoveGroupTaskCountBase,
 		},
 		f.HostReaderRateLimiter,
 		logger,

--- a/service/history/timer_queue_factory.go
+++ b/service/history/timer_queue_factory.go
@@ -186,6 +186,7 @@ func (f *timerQueueFactory) CreateQueue(
 			CheckpointIntervalJitterCoefficient: f.Config.TimerProcessorUpdateAckIntervalJitterCoefficient,
 			MaxReaderCount:                      f.Config.TimerQueueMaxReaderCount,
 			MoveGroupTaskCountBase:              f.Config.QueueMoveGroupTaskCountBase,
+			MoveGroupTaskCountMultiplier:        f.Config.QueueMoveGroupTaskCountMultiplier,
 		},
 		f.HostReaderRateLimiter,
 		logger,

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -178,6 +178,7 @@ func (f *transferQueueFactory) CreateQueue(
 			CheckpointInterval:                  f.Config.TransferProcessorUpdateAckInterval,
 			CheckpointIntervalJitterCoefficient: f.Config.TransferProcessorUpdateAckIntervalJitterCoefficient,
 			MaxReaderCount:                      f.Config.TransferQueueMaxReaderCount,
+			MoveGroupTaskCountBase:              f.Config.QueueMoveGroupTaskCountBase,
 		},
 		f.HostReaderRateLimiter,
 		queues.GrouperNamespaceID{},

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -179,6 +179,7 @@ func (f *transferQueueFactory) CreateQueue(
 			CheckpointIntervalJitterCoefficient: f.Config.TransferProcessorUpdateAckIntervalJitterCoefficient,
 			MaxReaderCount:                      f.Config.TransferQueueMaxReaderCount,
 			MoveGroupTaskCountBase:              f.Config.QueueMoveGroupTaskCountBase,
+			MoveGroupTaskCountMultiplier:        f.Config.QueueMoveGroupTaskCountMultiplier,
 		},
 		f.HostReaderRateLimiter,
 		queues.GrouperNamespaceID{},

--- a/service/history/visibility_queue_factory.go
+++ b/service/history/visibility_queue_factory.go
@@ -146,6 +146,7 @@ func (f *visibilityQueueFactory) CreateQueue(
 			CheckpointInterval:                  f.Config.VisibilityProcessorUpdateAckInterval,
 			CheckpointIntervalJitterCoefficient: f.Config.VisibilityProcessorUpdateAckIntervalJitterCoefficient,
 			MaxReaderCount:                      f.Config.VisibilityQueueMaxReaderCount,
+			MoveGroupTaskCountBase:              f.Config.QueueMoveGroupTaskCountBase,
 		},
 		f.HostReaderRateLimiter,
 		queues.GrouperNamespaceID{},

--- a/service/history/visibility_queue_factory.go
+++ b/service/history/visibility_queue_factory.go
@@ -147,6 +147,7 @@ func (f *visibilityQueueFactory) CreateQueue(
 			CheckpointIntervalJitterCoefficient: f.Config.VisibilityProcessorUpdateAckIntervalJitterCoefficient,
 			MaxReaderCount:                      f.Config.VisibilityQueueMaxReaderCount,
 			MoveGroupTaskCountBase:              f.Config.QueueMoveGroupTaskCountBase,
+			MoveGroupTaskCountMultiplier:        f.Config.QueueMoveGroupTaskCountMultiplier,
 		},
 		f.HostReaderRateLimiter,
 		queues.GrouperNamespaceID{},


### PR DESCRIPTION
## What changed?
- Introduced a new "move (task) group" action replacing the "incorrect" slice-predicate action. See inline comment for how it works.
- Improve task Predicate AND/OR calculation to reduce predicate size.
- Skip empty slices when adding queue slices to readers.

## Why?
- Better namespace isolation.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- The new action can be disabled via dc. 
