### PR TITLE
Skip sending newRuninfo when new run is not created in current cluster

### DIFF
--- a/service/history/replication/sync_state_retriever.go
+++ b/service/history/replication/sync_state_retriever.go
@@ -334,9 +334,7 @@ func (s *SyncStateRetrieverImpl) getNewRunInfo(ctx context.Context, namespaceId 
 		return nil, err
 	}
 	clusterMetadata := s.shardContext.GetClusterMetadata()
-	newRunCluster := clusterMetadata.ClusterNameForFailoverVersion(true, startVersion)
-	currentCluster := clusterMetadata.GetCurrentClusterName()
-	if currentCluster != newRunCluster {
+	if !clusterMetadata.IsVersionFromSameCluster(startVersion, clusterMetadata.GetClusterID()) {
 		return nil, nil
 	}
 

--- a/service/history/replication/sync_state_retriever.go
+++ b/service/history/replication/sync_state_retriever.go
@@ -326,6 +326,20 @@ func (s *SyncStateRetrieverImpl) getNewRunInfo(ctx context.Context, namespaceId 
 	default:
 		return nil, err
 	}
+
+	// if new run is not started by current cluster, it means the new run transaction is not happened at current cluster
+	// so when sending replication task, we should not include new run info
+	startVersion, err := mutableState.GetStartVersion()
+	if err != nil {
+		return nil, err
+	}
+	clusterMetadata := s.shardContext.GetClusterMetadata()
+	newRunCluster := clusterMetadata.ClusterNameForFailoverVersion(true, startVersion)
+	currentCluster := clusterMetadata.GetCurrentClusterName()
+	if currentCluster != newRunCluster {
+		return nil, nil
+	}
+
 	versionHistory, err := versionhistory.GetCurrentVersionHistory(mutableState.GetExecutionInfo().VersionHistories)
 	if err != nil {
 		return nil, err

--- a/service/history/replication/sync_state_retriever_test.go
+++ b/service/history/replication/sync_state_retriever_test.go
@@ -626,8 +626,8 @@ func (s *syncWorkflowStateSuite) TestGetNewRunInfo() {
 	// New logic queries start version and checks cluster affinity
 	mu.EXPECT().GetStartVersion().Return(int64(1), nil)
 	cm := cluster.NewMockMetadata(s.controller)
-	cm.EXPECT().ClusterNameForFailoverVersion(true, int64(1)).Return("cluster-a")
-	cm.EXPECT().GetCurrentClusterName().Return("cluster-a")
+	cm.EXPECT().GetClusterID().Return(int64(1))
+	cm.EXPECT().IsVersionFromSameCluster(int64(1), int64(1)).Return(true)
 	s.mockShard.SetClusterMetadata(cm)
 	s.workflowCache.EXPECT().GetOrCreateWorkflowExecution(gomock.Any(), s.mockShard, namespace.ID(s.namespaceID), &commonpb.WorkflowExecution{
 		WorkflowId: s.execution.WorkflowId,
@@ -682,8 +682,8 @@ func (s *syncWorkflowStateSuite) TestGetNewRunInfo_NewRunFromDifferentCluster_Re
 	// New logic queries start version and checks cluster affinity
 	mu.EXPECT().GetStartVersion().Return(int64(7), nil)
 	cm := cluster.NewMockMetadata(s.controller)
-	cm.EXPECT().ClusterNameForFailoverVersion(true, int64(7)).Return("remote-cluster")
-	cm.EXPECT().GetCurrentClusterName().Return("current-cluster")
+	cm.EXPECT().GetClusterID().Return(int64(1))
+	cm.EXPECT().IsVersionFromSameCluster(int64(7), int64(1)).Return(false)
 	s.mockShard.SetClusterMetadata(cm)
 
 	s.workflowCache.EXPECT().GetOrCreateWorkflowExecution(gomock.Any(), s.mockShard, namespace.ID(s.namespaceID), &commonpb.WorkflowExecution{

--- a/service/history/replication/sync_state_retriever_test.go
+++ b/service/history/replication/sync_state_retriever_test.go
@@ -15,6 +15,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/log"
@@ -622,6 +623,12 @@ func (s *syncWorkflowStateSuite) TestGetNewRunInfo() {
 		NewExecutionRunId: s.newRunId,
 	}
 	mu.EXPECT().GetExecutionInfo().Return(executionInfo).AnyTimes()
+	// New logic queries start version and checks cluster affinity
+	mu.EXPECT().GetStartVersion().Return(int64(1), nil)
+	cm := cluster.NewMockMetadata(s.controller)
+	cm.EXPECT().ClusterNameForFailoverVersion(true, int64(1)).Return("cluster-a")
+	cm.EXPECT().GetCurrentClusterName().Return("cluster-a")
+	s.mockShard.SetClusterMetadata(cm)
 	s.workflowCache.EXPECT().GetOrCreateWorkflowExecution(gomock.Any(), s.mockShard, namespace.ID(s.namespaceID), &commonpb.WorkflowExecution{
 		WorkflowId: s.execution.WorkflowId,
 		RunId:      s.newRunId,
@@ -642,6 +649,53 @@ func (s *syncWorkflowStateSuite) TestGetNewRunInfo() {
 	newRunInfo, err := s.syncStateRetriever.getNewRunInfo(context.Background(), namespace.ID(s.namespaceID), s.execution, s.newRunId)
 	s.NoError(err)
 	s.NotNil(newRunInfo)
+}
+
+func (s *syncWorkflowStateSuite) TestGetNewRunInfo_NewRunFromDifferentCluster_ReturnNil() {
+	mu := historyi.NewMockMutableState(s.controller)
+	versionHistories := &historyspb.VersionHistories{
+		CurrentVersionHistoryIndex: 0,
+		Histories: []*historyspb.VersionHistory{
+			{
+				BranchToken: []byte("branchToken1"),
+				Items: []*historyspb.VersionHistoryItem{
+					{EventId: 1, Version: 7},
+					{EventId: 2, Version: 13},
+				},
+			},
+		},
+	}
+	executionInfo := &persistencespb.WorkflowExecutionInfo{
+		TransitionHistory: []*persistencespb.VersionedTransition{
+			{NamespaceFailoverVersion: 7, TransitionCount: 12},
+			{NamespaceFailoverVersion: 13, TransitionCount: 15},
+		},
+		SubStateMachineTombstoneBatches: []*persistencespb.StateMachineTombstoneBatch{
+			{
+				VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 12},
+			},
+		},
+		VersionHistories:  versionHistories,
+		NewExecutionRunId: s.newRunId,
+	}
+	mu.EXPECT().GetExecutionInfo().Return(executionInfo).AnyTimes()
+	// New logic queries start version and checks cluster affinity
+	mu.EXPECT().GetStartVersion().Return(int64(7), nil)
+	cm := cluster.NewMockMetadata(s.controller)
+	cm.EXPECT().ClusterNameForFailoverVersion(true, int64(7)).Return("remote-cluster")
+	cm.EXPECT().GetCurrentClusterName().Return("current-cluster")
+	s.mockShard.SetClusterMetadata(cm)
+
+	s.workflowCache.EXPECT().GetOrCreateWorkflowExecution(gomock.Any(), s.mockShard, namespace.ID(s.namespaceID), &commonpb.WorkflowExecution{
+		WorkflowId: s.execution.WorkflowId,
+		RunId:      s.newRunId,
+	}, locks.PriorityLow).Return(s.newRunWorkflowContext, s.releaseFunc, nil)
+	s.newRunWorkflowContext.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).
+		Return(mu, nil).Times(1)
+
+	newRunInfo, err := s.syncStateRetriever.getNewRunInfo(context.Background(), namespace.ID(s.namespaceID), s.execution, s.newRunId)
+	s.NoError(err)
+	s.Nil(newRunInfo)
 }
 
 func (s *syncWorkflowStateSuite) TestGetNewRunInfo_NotFound() {


### PR DESCRIPTION
## What changed?
Skip sending newRuninfo when new run is not created in current cluster

## Why?
If new run is not created at current cluster, it means the transaction is not happened at current cluster, so the current cluster should no include new run in the current run replication task.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
no risk.