### PR TITLE
fix(dynamicconfig): bad indent in development-sql.yaml comments

### DIFF
--- a/config/dynamicconfig/development-sql.yaml
+++ b/config/dynamicconfig/development-sql.yaml
@@ -1,20 +1,20 @@
 #history.persistenceMaxQPS:
-#- value: 3000
-#  constraints: {}
+#  - value: 3000
+#    constraints: {}
 #frontend.persistenceMaxQPS:
-#- value: 3000
-#  constraints: {}
+#  - value: 3000
+#    constraints: {}
 #frontend.throttledLogRPS:
-#- value: 20
-#  constraints: {}
+#  - value: 20
+#    constraints: {}
 #history.defaultActivityRetryPolicy:
-#- value:
+#  - value:
 #    InitialIntervalInSeconds: 1
 #    MaximumIntervalCoefficient: 100.0
 #    BackoffCoefficient: 2.0
 #    MaximumAttempts: 0
 #history.defaultWorkflowRetryPolicy:
-#- value:
+#  - value:
 #    InitialIntervalInSeconds: 1
 #    MaximumIntervalCoefficient: 100.0
 #    BackoffCoefficient: 2.0
@@ -27,12 +27,12 @@
 #    constraints: {}
 #system.enableParentClosePolicyWorker:
 #  - value: true
-# matching.PollerHistoryTTL:
-#   - value: 1s
-# matching.wv.VersionDrainageStatusVisibilityGracePeriod:
-#   - value: 5s
-# matching.wv.VersionDrainageStatusRefreshInterval:
-#   - value: 5s
+#matching.PollerHistoryTTL:
+#  - value: 1s
+#matching.wv.VersionDrainageStatusVisibilityGracePeriod:
+#  - value: 5s
+#matching.wv.VersionDrainageStatusRefreshInterval:
+#  - value: 5s
 limit.maxIDLength:
   - value: 255
     constraints: {}


### PR DESCRIPTION
## What changed?
Bad indent fixed in commented dynamicconfig file development-sql.yaml

## Why?
Uncommenting this section led to parsing error
