### PR TITLE
softassert serviceerror.DataLoss helper

### DIFF
--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/pborman/uuid"
@@ -22,9 +23,12 @@ const (
 	// TrimHistoryBranch will only dump metadata, relatively cheap
 	trimHistoryBranchPageSize = 1000
 	dataLossMsg               = "Potential data loss"
-	errNonContiguousEventID   = "corrupted history event batch, eventID is not contiguous"
-	errWrongVersion           = "corrupted history event batch, wrong version and IDs"
-	errEmptyEvents            = "corrupted history event batch, empty events"
+)
+
+var (
+	errNonContiguousEventID = errors.New("corrupted history event batch, eventID is not contiguous")
+	errWrongVersion         = errors.New("corrupted history event batch, wrong version and IDs")
+	errEmptyEvents          = errors.New("corrupted history event batch, empty events")
 )
 
 var _ ExecutionManager = (*executionManagerImpl)(nil)
@@ -631,7 +635,7 @@ func (m *executionManagerImpl) readRawHistoryBranch(
 		}
 
 		if token.CurrentRangeIndex == notStartedIndex {
-			return nil, nil, serviceerror.NewDataLoss("branchRange is corrupted")
+			return nil, nil, softassert.UnexpectedDataLoss(m.logger, "branchRange is corrupted", nil)
 		}
 	}
 
@@ -690,7 +694,7 @@ func (m *executionManagerImpl) readRawHistoryBranchReverse(
 		}
 
 		if token.CurrentRangeIndex == notStartedIndex {
-			return nil, nil, serviceerror.NewDataLoss("branchRange is corrupted")
+			return nil, nil, softassert.UnexpectedDataLoss(m.logger, "branchRange is corrupted", nil)
 		}
 	}
 
@@ -793,7 +797,7 @@ func (m *executionManagerImpl) readRawHistoryBranchAndFilter(
 		for index, node := range nodes {
 			dataBlobs[index] = node.Events
 			if node.Events == nil {
-				return nil, nil, nil, nil, 0, serviceerror.NewDataLoss("no events in history node")
+				return nil, nil, nil, nil, 0, softassert.UnexpectedDataLoss(m.logger, "no events in history node", nil)
 			}
 			dataSize += len(node.Events.Data)
 			transactionIDs = append(transactionIDs, node.TransactionID)
@@ -912,9 +916,9 @@ func (m *executionManagerImpl) readHistoryBranch(
 	var firstEvent, lastEvent *historypb.HistoryEvent
 	var eventCount int
 
-	dataLossTags := func(cause string) []tag.Tag {
+	dataLossTags := func(cause error) []tag.Tag {
 		return []tag.Tag{
-			tag.Cause(cause),
+			tag.Cause(cause.Error()),
 			tag.ShardID(request.ShardID),
 			tag.WorkflowBranchToken(request.BranchToken),
 			tag.WorkflowFirstEventID(firstEvent.GetEventId()),
@@ -932,8 +936,7 @@ func (m *executionManagerImpl) readHistoryBranch(
 			return nil, nil, nil, nil, dataSize, err
 		}
 		if len(events) == 0 {
-			softassert.Fail(m.logger, dataLossMsg, dataLossTags(errEmptyEvents)...)
-			return nil, nil, nil, nil, dataSize, serviceerror.NewDataLoss(errEmptyEvents)
+			return nil, nil, nil, nil, dataSize, softassert.UnexpectedDataLoss(m.logger, dataLossMsg, errEmptyEvents, dataLossTags(errEmptyEvents)...)
 		}
 
 		firstEvent = events[0]
@@ -942,12 +945,10 @@ func (m *executionManagerImpl) readHistoryBranch(
 
 		if firstEvent.GetVersion() != lastEvent.GetVersion() || firstEvent.GetEventId()+int64(eventCount-1) != lastEvent.GetEventId() {
 			// in a single batch, version should be the same, and ID should be contiguous
-			softassert.Fail(m.logger, dataLossMsg, dataLossTags(errWrongVersion)...)
-			return historyEvents, historyEventBatches, transactionIDs, nil, dataSize, serviceerror.NewDataLoss(errWrongVersion)
+			return historyEvents, historyEventBatches, transactionIDs, nil, dataSize, softassert.UnexpectedDataLoss(m.logger, dataLossMsg, errWrongVersion, dataLossTags(errWrongVersion)...)
 		}
 		if firstEvent.GetEventId() != token.LastEventID+1 {
-			softassert.Fail(m.logger, dataLossMsg, dataLossTags(errNonContiguousEventID)...)
-			return historyEvents, historyEventBatches, transactionIDs, nil, dataSize, serviceerror.NewDataLoss(errNonContiguousEventID)
+			return historyEvents, historyEventBatches, transactionIDs, nil, dataSize, softassert.UnexpectedDataLoss(m.logger, dataLossMsg, errNonContiguousEventID, dataLossTags(errNonContiguousEventID)...)
 		}
 
 		if byBatch {
@@ -980,9 +981,9 @@ func (m *executionManagerImpl) readHistoryBranchReverse(
 	var firstEvent, lastEvent *historypb.HistoryEvent
 	var eventCount int
 
-	datalossTags := func(cause string) []tag.Tag {
+	datalossTags := func(cause error) []tag.Tag {
 		return []tag.Tag{
-			tag.Cause(cause),
+			tag.Cause(cause.Error()),
 			tag.WorkflowBranchToken(request.BranchToken),
 			tag.WorkflowFirstEventID(firstEvent.GetEventId()),
 			tag.FirstEventVersion(firstEvent.GetVersion()),
@@ -999,8 +1000,7 @@ func (m *executionManagerImpl) readHistoryBranchReverse(
 			return nil, nil, nil, dataSize, err
 		}
 		if len(events) == 0 {
-			softassert.Fail(m.logger, dataLossMsg, datalossTags(errEmptyEvents)...)
-			return nil, nil, nil, dataSize, serviceerror.NewDataLoss(errEmptyEvents)
+			return nil, nil, nil, dataSize, softassert.UnexpectedDataLoss(m.logger, dataLossMsg, errEmptyEvents, datalossTags(errEmptyEvents)...)
 		}
 
 		firstEvent = events[0]
@@ -1009,12 +1009,10 @@ func (m *executionManagerImpl) readHistoryBranchReverse(
 
 		if firstEvent.GetVersion() != lastEvent.GetVersion() || firstEvent.GetEventId()+int64(eventCount-1) != lastEvent.GetEventId() {
 			// in a single batch, version should be the same, and ID should be contiguous
-			softassert.Fail(m.logger, dataLossMsg, datalossTags(errWrongVersion)...)
-			return historyEvents, transactionIDs, nil, dataSize, serviceerror.NewDataLoss(errWrongVersion)
+			return historyEvents, transactionIDs, nil, dataSize, softassert.UnexpectedDataLoss(m.logger, dataLossMsg, errWrongVersion, datalossTags(errWrongVersion)...)
 		}
 		if (token.LastEventID != common.EmptyEventID) && (lastEvent.GetEventId() != token.LastEventID-1) {
-			softassert.Fail(m.logger, dataLossMsg, datalossTags(errNonContiguousEventID)...)
-			return historyEvents, transactionIDs, nil, dataSize, serviceerror.NewDataLoss(errNonContiguousEventID)
+			return historyEvents, transactionIDs, nil, dataSize, softassert.UnexpectedDataLoss(m.logger, dataLossMsg, errNonContiguousEventID, datalossTags(errNonContiguousEventID)...)
 		}
 
 		events = m.reverseSlice(events)
@@ -1060,9 +1058,9 @@ func (m *executionManagerImpl) filterHistoryNodes(
 
 		switch {
 		case node.NodeID < lastNodeID:
-			return nil, serviceerror.NewDataLoss("corrupted data, nodeID cannot decrease")
+			return nil, softassert.UnexpectedDataLoss(m.logger, "corrupted data, nodeID cannot decrease", nil)
 		case node.NodeID == lastNodeID:
-			return nil, serviceerror.NewDataLoss("corrupted data, same nodeID must have smaller txnID")
+			return nil, softassert.UnexpectedDataLoss(m.logger, "corrupted data, same nodeID must have smaller txnID", nil)
 		default: // row.NodeID > lastNodeID:
 			// NOTE: when row.nodeID > lastNodeID, we expect the one with largest txnID comes first
 			lastTransactionID = node.TransactionID
@@ -1093,7 +1091,7 @@ func (m *executionManagerImpl) filterHistoryNodesReverse(
 
 		switch {
 		case node.NodeID > lastNodeID:
-			return nil, serviceerror.NewDataLoss("corrupted data, nodeID cannot decrease")
+			return nil, softassert.UnexpectedDataLoss(m.logger, "corrupted data, nodeID cannot decrease", nil)
 		default:
 			lastTransactionID = node.PrevTransactionID
 			lastNodeID = node.NodeID

--- a/common/softassert/serviceerror.go
+++ b/common/softassert/serviceerror.go
@@ -16,7 +16,7 @@ const (
 // UnexpectedDataLoss creates a serviceerror.DataLoss from a static message and optional error.
 // The error message follows the format "<staticMessage>: <optionalErr>", if optionalErr is not nil.
 //
-// It also logs the error using softassert.Fail.
+// It also logs `staticMessage` using softassert.Fail.
 // `optionalErr` is added as a tag with key "softassert-error-details".
 func UnexpectedDataLoss(logger log.Logger, staticMessage string, optionalErr error, tags ...tag.Tag) error {
 	// (1) trigger softassert

--- a/common/softassert/serviceerror.go
+++ b/common/softassert/serviceerror.go
@@ -1,0 +1,35 @@
+package softassert
+
+import (
+	"fmt"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+)
+
+const (
+	// using a unique tag name to avoid potential conflicts with other tags
+	errorDetailsTagName = "softassert-error-details"
+)
+
+// UnexpectedDataLoss creates a serviceerror.DataLoss from a static message and optional error.
+// The error message follows the format "<staticMessage>: <optionalErr>", if optionalErr is not nil.
+//
+// It also logs the error using softassert.Fail.
+// `optionalErr` is added as a tag with key "softassert-error-details".
+func UnexpectedDataLoss(logger log.Logger, staticMessage string, optionalErr error, tags ...tag.Tag) error {
+	// (1) trigger softassert
+	combinedTags := tags
+	if optionalErr != nil {
+		combinedTags = append([]tag.Tag{tag.NewErrorTag(errorDetailsTagName, optionalErr)}, tags...)
+	}
+	Fail(logger, staticMessage, combinedTags...)
+
+	// (2) return serviceerror
+	message := staticMessage
+	if optionalErr != nil {
+		message = fmt.Sprintf("%s: %s", staticMessage, optionalErr)
+	}
+	return serviceerror.NewDataLoss(message)
+}

--- a/common/softassert/softassert.go
+++ b/common/softassert/softassert.go
@@ -25,7 +25,6 @@ import (
 //
 // Example:
 // softassert.That(logger, object.state == "ready", "object is not ready")
-
 func That(logger log.Logger, condition bool, staticMessage string, tags ...tag.Tag) bool {
 	if !condition {
 		// By using the same prefix for all assertions, they can be reliably found in logs.

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -43,6 +43,7 @@ import (
 	"go.temporal.io/server/common/cluster"
 	dc "go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
@@ -2132,6 +2133,7 @@ func (s *WorkflowHandlerSuite) TestCountWorkflowExecutions() {
 }
 
 func (s *WorkflowHandlerSuite) TestVerifyHistoryIsComplete() {
+	logger := log.NewTestLogger()
 	events := make([]*historyspb.StrippedHistoryEvent, 50)
 	for i := 0; i < len(events); i++ {
 		events[i] = &historyspb.StrippedHistoryEvent{EventId: int64(i + 1)}
@@ -2176,6 +2178,7 @@ func (s *WorkflowHandlerSuite) TestVerifyHistoryIsComplete() {
 
 	for i, tc := range testCases {
 		err := api.VerifyHistoryIsComplete(
+			logger,
 			tc.events[0],
 			tc.events[len(tc.events)-1],
 			len(tc.events),

--- a/service/history/api/getworkflowexecutionhistory/api.go
+++ b/service/history/api/getworkflowexecutionhistory/api.go
@@ -250,8 +250,8 @@ func Invoke(
 				if len(history.Events) == 0 {
 					dataLossErr := softassert.UnexpectedDataLoss(
 						shardContext.GetLogger(),
-						"GetHistory returned empty history",
-						errors.New("no events in workflow history"),
+						"no events in workflow history",
+						nil,
 						tag.WorkflowNamespaceID(namespaceID.String()),
 						tag.WorkflowNamespace(request.GetRequest().GetNamespace()),
 						tag.WorkflowID(execution.GetWorkflowId()),

--- a/service/history/api/getworkflowexecutionhistory/api.go
+++ b/service/history/api/getworkflowexecutionhistory/api.go
@@ -22,6 +22,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/common/softassert"
 	"go.temporal.io/server/service/history/api"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/events"
@@ -247,14 +248,15 @@ func Invoke(
 				}
 				// GetHistory func will not return empty history. Log workflow details if that is not the case
 				if len(history.Events) == 0 {
-					shardContext.GetLogger().Error(
+					dataLossErr := softassert.UnexpectedDataLoss(
+						shardContext.GetLogger(),
 						"GetHistory returned empty history",
+						errors.New("no events in workflow history"),
 						tag.WorkflowNamespaceID(namespaceID.String()),
 						tag.WorkflowNamespace(request.GetRequest().GetNamespace()),
 						tag.WorkflowID(execution.GetWorkflowId()),
 						tag.WorkflowRunID(execution.GetRunId()),
 					)
-					dataLossErr := serviceerror.NewDataLoss("no events in workflow history")
 					// Emit dataloss metric
 					if shardContext.GetConfig().EnableDataLossMetrics() {
 						persistence.EmitDataLossMetric(


### PR DESCRIPTION
## What changed?

Added a new helper `UnexpectedDataLoss` to combine logging and error construction in one go.

And applied it everywhere since I assume every DataLoss is _unexpected_.

## Why?

Just like https://github.com/temporalio/temporal/pull/8388 it combines the two affordances of `softassert.Fail` and constructing an error.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

