### PR TITLE
Handle permission denied error in Nexus HandleScheduleCommand

### DIFF
--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -63,6 +63,11 @@ func (ch *commandHandler) HandleScheduleCommand(
 				}
 			}
 			// Ignore, and let the operation fail when the task is executed.
+		} else if errors.As(err, new(*serviceerror.PermissionDenied)) {
+			return workflow.FailWorkflowTaskError{
+				Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES,
+				Message: fmt.Sprintf("caller namespace %q unauthorized for %q", ns.ID(), attrs.Endpoint),
+			}
 		} else {
 			return err
 		}


### PR DESCRIPTION
## What changed?
_Describe what has changed in this PR._
Nexus HandleScheduleCommand handles PermissionDenied by failing the WFT.

## Why?
_Tell your future self why have you made these changes._
We want to distinguish between Nexus endpoint not found and caller namespace unauthorized errors.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
