### PR TITLE
Remove dynamicconfig debug logs

### DIFF
--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -256,9 +256,6 @@ func matchAndConvertCvs[T any](
 ) (T, any) {
 	cvp, err := findMatch(cvs, precedence)
 	if err != nil {
-		if c.throttleLog() {
-			c.logger.Debug("No such key in dynamic config, using default", tag.Key(key.String()), tag.Error(err))
-		}
 		// couldn't find a constrained match, use default
 		return def, usingDefaultValue
 	}
@@ -326,9 +323,6 @@ func findAndResolveWithConstrainedDefaults[T any](
 		// leave value as the zero value, that's the best we can do
 		return value, usingDefaultValue
 	} else if valOrder == 0 {
-		if c.throttleLog() {
-			c.logger.Debug("No such key in dynamic config, using default", tag.Key(key.String()))
-		}
 		return defVal, usingDefaultValue
 	} else if defOrder < valOrder {
 		// value was present but constrained default took precedence
@@ -454,9 +448,6 @@ func dispatchUpdate[T any](
 	var raw any
 	cvp, err := findMatch(cvs, sub.prec)
 	if err != nil {
-		if c.throttleLog() {
-			c.logger.Debug("No such key in dynamic config, using default", tag.Key(key.String()), tag.Error(err))
-		}
 		raw = usingDefaultValue
 	} else {
 		raw = cvp.Value

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -11,7 +11,6 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/retrypolicy"
 	"go.uber.org/mock/gomock"
 )
@@ -335,7 +334,6 @@ testGetBoolPropertyKey:
 	reader.EXPECT().GetModTime().Return(originModTime, nil).Times(2)
 	reader.EXPECT().ReadFile().Return(originFileData, nil)
 
-	mockLogger.EXPECT().Debug(gomock.Any(), tag.Key(dynamicconfig.DynamicConfigSubscriptionCallback.Key().String()), gomock.Any()).AnyTimes()
 	mockLogger.EXPECT().Info(gomock.Any()).Times(6)
 	client, err := dynamicconfig.NewFileBasedClientWithReader(reader,
 		&dynamicconfig.FileBasedClientConfig{

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -116,7 +116,6 @@ type (
 		chasmRegistry         *chasm.Registry
 		grpcClientInterceptor *grpcinject.Interceptor
 		spanExporters         map[telemetry.SpanExporterType]sdktrace.SpanExporter
-		dynamicConfigLogger   log.Logger
 	}
 
 	// FrontendConfig is the config for the frontend service
@@ -210,12 +209,7 @@ func newTemporal(t *testing.T, params *TemporalParams) *TemporalImpl {
 		captureMetricsHandler:            params.CaptureMetricsHandler,
 		dcClient:                         dynamicconfig.NewMemoryClient(),
 		// If this doesn't build, make sure you're building with tags 'test_dep':
-		testHooks: testhooks.NewTestHooksImpl(),
-		// We are overriding the dynamic config logger with a new one that uses the INFO level
-		// because there are some debug logs that are too verbose for testing.
-		// ex: "No such key in dynamic config, using default"
-		// this can be removed if logging from this package becomes less verbose
-		dynamicConfigLogger:      log.NewZapLogger(log.BuildZapLogger(log.Config{Level: "info"})),
+		testHooks:                testhooks.NewTestHooksImpl(),
 		serviceFxOptions:         params.ServiceFxOptions,
 		taskCategoryRegistry:     params.TaskCategoryRegistry,
 		chasmRegistry:            params.ChasmRegistry,
@@ -235,7 +229,6 @@ func newTemporal(t *testing.T, params *TemporalParams) *TemporalImpl {
 }
 
 func (c *TemporalImpl) Start() error {
-
 	// create temporal-system namespace, this must be created before starting
 	// the services - so directly use the metadataManager to create this
 	if err := c.createSystemNamespace(); err != nil {
@@ -378,11 +371,6 @@ func (c *TemporalImpl) startFrontend() {
 			fx.Provide(func() persistenceClient.AbstractDataStoreFactory { return c.abstractDataStoreFactory }),
 			fx.Provide(func() visibility.VisibilityStoreFactory { return c.visibilityStoreFactory }),
 			fx.Provide(func() dynamicconfig.Client { return c.dcClient }),
-			fx.Decorate(func(client dynamicconfig.Client, lc fx.Lifecycle) *dynamicconfig.Collection {
-				col := dynamicconfig.NewCollection(client, c.dynamicConfigLogger)
-				lc.Append(fx.StartStopHook(col.Start, col.Stop))
-				return col
-			}),
 			fx.Decorate(func() testhooks.TestHooks { return c.testHooks }),
 			fx.Provide(resource.DefaultSnTaggedLoggerProvider),
 			fx.Provide(func() esclient.Client { return c.esClient }),
@@ -458,11 +446,6 @@ func (c *TemporalImpl) startHistory() {
 			fx.Provide(func() persistenceClient.AbstractDataStoreFactory { return c.abstractDataStoreFactory }),
 			fx.Provide(func() visibility.VisibilityStoreFactory { return c.visibilityStoreFactory }),
 			fx.Provide(func() dynamicconfig.Client { return c.dcClient }),
-			fx.Decorate(func(client dynamicconfig.Client, lc fx.Lifecycle) *dynamicconfig.Collection {
-				col := dynamicconfig.NewCollection(client, c.dynamicConfigLogger)
-				lc.Append(fx.StartStopHook(col.Start, col.Stop))
-				return col
-			}),
 			fx.Decorate(func() testhooks.TestHooks { return c.testHooks }),
 			fx.Provide(resource.DefaultSnTaggedLoggerProvider),
 			fx.Provide(func() esclient.Client { return c.esClient }),
@@ -524,11 +507,6 @@ func (c *TemporalImpl) startMatching() {
 			fx.Provide(func() persistenceClient.AbstractDataStoreFactory { return c.abstractDataStoreFactory }),
 			fx.Provide(func() visibility.VisibilityStoreFactory { return c.visibilityStoreFactory }),
 			fx.Provide(func() dynamicconfig.Client { return c.dcClient }),
-			fx.Decorate(func(client dynamicconfig.Client, lc fx.Lifecycle) *dynamicconfig.Collection {
-				col := dynamicconfig.NewCollection(client, c.dynamicConfigLogger)
-				lc.Append(fx.StartStopHook(col.Start, col.Stop))
-				return col
-			}),
 			fx.Decorate(func() testhooks.TestHooks { return c.testHooks }),
 			fx.Provide(func() esclient.Client { return c.esClient }),
 			fx.Provide(c.GetTLSConfigProvider),
@@ -596,11 +574,6 @@ func (c *TemporalImpl) startWorker() {
 			fx.Provide(func() persistenceClient.AbstractDataStoreFactory { return c.abstractDataStoreFactory }),
 			fx.Provide(func() visibility.VisibilityStoreFactory { return c.visibilityStoreFactory }),
 			fx.Provide(func() dynamicconfig.Client { return c.dcClient }),
-			fx.Decorate(func(client dynamicconfig.Client, lc fx.Lifecycle) *dynamicconfig.Collection {
-				col := dynamicconfig.NewCollection(client, c.dynamicConfigLogger)
-				lc.Append(fx.StartStopHook(col.Start, col.Stop))
-				return col
-			}),
 			fx.Decorate(func() testhooks.TestHooks { return c.testHooks }),
 			fx.Provide(resource.DefaultSnTaggedLoggerProvider),
 			fx.Provide(func() esclient.Client { return c.esClient }),


### PR DESCRIPTION
## What changed?
Remove logging when default dynamic config values are used.
Also revert #8354 which was just to avoid these logs in tests.

## Why?
These logs are not really useful, we expect almost all keys to usually be unset.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
