### PR TITLE
Handle permission denied error in Nexus HandleScheduleCommand

### DIFF
--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -63,6 +63,11 @@ func (ch *commandHandler) HandleScheduleCommand(
 				}
 			}
 			// Ignore, and let the operation fail when the task is executed.
+		} else if errors.As(err, new(*serviceerror.PermissionDenied)) {
+			return workflow.FailWorkflowTaskError{
+				Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES,
+				Message: fmt.Sprintf("caller namespace %q unauthorized for %q", ns.ID(), attrs.Endpoint),
+			}
 		} else {
 			return err
 		}

--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -66,7 +66,7 @@ func (ch *commandHandler) HandleScheduleCommand(
 		} else if errors.As(err, new(*serviceerror.PermissionDenied)) {
 			return workflow.FailWorkflowTaskError{
 				Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES,
-				Message: fmt.Sprintf("caller namespace %q unauthorized for %q", ns.ID(), attrs.Endpoint),
+				Message: fmt.Sprintf("caller namespace %q unauthorized for %q", ns.Name(), attrs.Endpoint),
 			}
 		} else {
 			return err


### PR DESCRIPTION
## What changed?
Nexus HandleScheduleCommand handles PermissionDenied by failing the WFT.


## Why?
We want to distinguish between Nexus endpoint not found and caller namespace unauthorized errors.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle `PermissionDenied` from endpoint lookup by failing the workflow task and add a targeted unit test.
> 
> - **Workflow command handling** (`components/nexusoperations/workflow/commands.go`):
>   - On `GetByName` error `PermissionDenied`, return `FailWorkflowTaskError` with cause `WORKFLOW_TASK_FAILED_CAUSE_BAD_SCHEDULE_NEXUS_OPERATION_ATTRIBUTES` and an authorization message, instead of propagating the error.
> - **Tests** (`components/nexusoperations/workflow/commands_test.go`):
>   - Extend fake endpoint registry to simulate `PermissionDenied` for a specific endpoint name.
>   - Add test "caller namespace unauthorized" asserting WFT failure and no history events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7585f5a9406e095ee4ef0878519376cbe7cea656. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->