### PR TITLE
Fix command line flag argument parsing for elasticsearch-tool.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -526,13 +526,13 @@ install-schema-postgresql12: temporal-sql-tool
 
 install-schema-es: temporal-elasticsearch-tool
 	@printf $(COLOR) "Install Elasticsearch schema..."
-	./temporal-elasticsearch-tool -e http://127.0.0.1:9200 setup-schema
-	./temporal-elasticsearch-tool -e http://127.0.0.1:9200 create-index --index temporal_visibility_v1_dev
+	./temporal-elasticsearch-tool -ep http://127.0.0.1:9200 setup-schema
+	./temporal-elasticsearch-tool -ep http://127.0.0.1:9200 create-index --index temporal_visibility_v1_dev
 
 install-schema-es-secondary: temporal-elasticsearch-tool
 	@printf $(COLOR) "Install Elasticsearch schema..."
-	./temporal-elasticsearch-tool -e http://127.0.0.1:8200 setup-schema
-	./temporal-elasticsearch-tool -e http://127.0.0.1:8200 create-index --index temporal_visibility_v1_secondary
+	./temporal-elasticsearch-tool -ep http://127.0.0.1:8200 setup-schema
+	./temporal-elasticsearch-tool -ep http://127.0.0.1:8200 create-index --index temporal_visibility_v1_secondary
 
 install-schema-xdc: temporal-cassandra-tool temporal-elasticsearch-tool
 	@printf $(COLOR)  "Install Cassandra schema (active)..."
@@ -554,15 +554,15 @@ install-schema-xdc: temporal-cassandra-tool temporal-elasticsearch-tool
 	./temporal-cassandra-tool -k temporal_cluster_c update-schema -d ./schema/cassandra/temporal/versioned
 
 	@printf $(COLOR) "Install Elasticsearch schemas..."
-	./temporal-elasticsearch-tool -e http://127.0.0.1:9200 setup-schema
+	./temporal-elasticsearch-tool -ep http://127.0.0.1:9200 setup-schema
 # Delete indices if they exist (drop-index fails silently if index doesn't exist)
-	./temporal-elasticsearch-tool -e http://127.0.0.1:9200 drop-index --index temporal_visibility_v1_dev_cluster_a --fail
-	./temporal-elasticsearch-tool -e http://127.0.0.1:9200 drop-index --index temporal_visibility_v1_dev_cluster_b --fail
-	./temporal-elasticsearch-tool -e http://127.0.0.1:9200 drop-index --index temporal_visibility_v1_dev_cluster_c --fail
+	./temporal-elasticsearch-tool -ep http://127.0.0.1:9200 drop-index --index temporal_visibility_v1_dev_cluster_a --fail
+	./temporal-elasticsearch-tool -ep http://127.0.0.1:9200 drop-index --index temporal_visibility_v1_dev_cluster_b --fail
+	./temporal-elasticsearch-tool -ep http://127.0.0.1:9200 drop-index --index temporal_visibility_v1_dev_cluster_c --fail
 # Create indices
-	./temporal-elasticsearch-tool -e http://127.0.0.1:9200 create-index --index temporal_visibility_v1_dev_cluster_a
-	./temporal-elasticsearch-tool -e http://127.0.0.1:9200 create-index --index temporal_visibility_v1_dev_cluster_b
-	./temporal-elasticsearch-tool -e http://127.0.0.1:9200 create-index --index temporal_visibility_v1_dev_cluster_c
+	./temporal-elasticsearch-tool -ep http://127.0.0.1:9200 create-index --index temporal_visibility_v1_dev_cluster_a
+	./temporal-elasticsearch-tool -ep http://127.0.0.1:9200 create-index --index temporal_visibility_v1_dev_cluster_b
+	./temporal-elasticsearch-tool -ep http://127.0.0.1:9200 create-index --index temporal_visibility_v1_dev_cluster_c
 
 ##### Run server #####
 DOCKER_COMPOSE_FILES     := -f ./develop/docker-compose/docker-compose.yml -f ./develop/docker-compose/docker-compose.$(GOOS).yml

--- a/schema/embed.go
+++ b/schema/embed.go
@@ -58,7 +58,7 @@ func ElasticsearchClusterSettings() (string, error) {
 
 // ElasticsearchIndexTemplate returns the embedded index template for Elasticsearch v7 (latest version)
 func ElasticsearchIndexTemplate() (string, error) {
-	data, err := assets.ReadFile("elasticsearch/visibility/index_template_v7.json")
+	data, err := assets.ReadFile("elasticsearch/visibility/versioned/v9/index_template_v7.json")
 	if err != nil {
 		return "", err
 	}

--- a/schema/embed_test.go
+++ b/schema/embed_test.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,6 +25,33 @@ func TestSchemaDirs(t *testing.T) {
 		"postgresql/v12/temporal",
 		"postgresql/v12/visibility",
 	}, dirs)
+
+	dirs = PathsByDir("elasticsearch")
+	requireContains(t, []string{
+		"elasticsearch/visibility/cluster_settings_v7.json",
+	}, dirs)
+}
+
+func TestElasticsearchIndexTemplateIsLatest(t *testing.T) {
+	embeddedContent, err := ElasticsearchIndexTemplate()
+	require.NoError(t, err, "Failed to get embedded index template")
+
+	symlinkPath := "elasticsearch/visibility/index_template_v7.json"
+	symlinkInfo, err := os.Lstat(symlinkPath)
+	require.NoError(t, err, "Failed to get symlink info")
+	require.True(t, symlinkInfo.Mode()&os.ModeSymlink != 0, "File is not a symlink")
+
+	targetPath, err := os.Readlink(symlinkPath)
+	require.NoError(t, err, "Failed to read symlink target")
+
+	fullTargetPath := filepath.Join(filepath.Dir(symlinkPath), targetPath)
+	targetContent, err := os.ReadFile(fullTargetPath)
+	require.NoError(t, err, "Failed to read symlink target file")
+
+	require.Equal(t, string(targetContent), embeddedContent,
+		"Embedded content does not match symlink target. "+
+			"Symlink points to: %s. "+
+			"Update the ElasticsearchIndexTemplate() function to use the correct path.", targetPath)
 }
 
 func requireContains(t *testing.T, expected []string, actual []string) {

--- a/schema/embed_test.go
+++ b/schema/embed_test.go
@@ -25,11 +25,6 @@ func TestSchemaDirs(t *testing.T) {
 		"postgresql/v12/temporal",
 		"postgresql/v12/visibility",
 	}, dirs)
-
-	dirs = PathsByDir("elasticsearch")
-	requireContains(t, []string{
-		"elasticsearch/visibility/cluster_settings_v7.json",
-	}, dirs)
 }
 
 func TestElasticsearchIndexTemplateIsLatest(t *testing.T) {

--- a/tools/elasticsearch/handler.go
+++ b/tools/elasticsearch/handler.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
@@ -94,14 +94,14 @@ func ping(cli *cli.Context, logger log.Logger) error {
 func parseElasticConfig(cli *cli.Context) (*esclient.Config, error) {
 	cfg := new(esclient.Config)
 
-	u, err := url.Parse(cli.String(CLIOptESURL))
+	u, err := url.Parse(cli.GlobalString(commonschema.CLIOptEndpoint))
 	if err != nil {
-		return nil, fmt.Errorf("invalid elasticsearch URL %q: %w", cli.String(CLIOptESURL), err)
+		return nil, fmt.Errorf("invalid elasticsearch URL %q: %w", cli.GlobalString(commonschema.CLIOptEndpoint), err)
 	}
 
 	cfg.URL = *u
-	cfg.Username = cli.String(CLIOptESUsername)
-	cfg.Password = cli.String(CLIOptESPassword)
+	cfg.Username = cli.GlobalString(commonschema.CLIOptUser)
+	cfg.Password = cli.GlobalString(commonschema.CLIOptPassword)
 	cfg.Version = "v7" // Fixed schema version 7
 	cfg.Indices = map[string]string{}
 
@@ -109,14 +109,14 @@ func parseElasticConfig(cli *cli.Context) (*esclient.Config, error) {
 		cfg.Indices[esclient.VisibilityAppName] = cli.String(CLIOptVisibilityIndex)
 	}
 
-	if cli.String(CLIOptAWSCredentials) != "" {
-		cfg.AWSRequestSigning.CredentialProvider = cli.String(CLIOptAWSCredentials)
+	if cli.GlobalString(CLIOptAWSCredentials) != "" {
+		cfg.AWSRequestSigning.CredentialProvider = cli.GlobalString(CLIOptAWSCredentials)
 		cfg.AWSRequestSigning.Enabled = true
 
 		if cfg.AWSRequestSigning.CredentialProvider == "static" {
 			cfg.AWSRequestSigning.Static.AccessKeyID = cfg.Username
 			cfg.AWSRequestSigning.Static.SecretAccessKey = cfg.Password
-			cfg.AWSRequestSigning.Static.Token = cli.String(CLIOptAWSToken)
+			cfg.AWSRequestSigning.Static.Token = cli.GlobalString(CLIOptAWSToken)
 		}
 	}
 

--- a/tools/elasticsearch/main.go
+++ b/tools/elasticsearch/main.go
@@ -3,25 +3,19 @@ package elasticsearch
 import (
 	"os"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/tools/common/schema"
+	commonschema "go.temporal.io/server/tools/common/schema"
 )
 
 const (
-	CLIOptESURL           = "endpoint"
-	CLIOptESUsername      = "user"
-	CLIOptESPassword      = "password"
 	CLIOptVisibilityIndex = "index"
 	CLIOptAWSCredentials  = "aws-credentials"
 	CLIOptAWSToken        = "aws-session-token"
 	CLIOptFailSilently    = "fail"
 
-	CLIFlagESURL           = CLIOptESURL + ", e"
-	CLIFlagESUsername      = CLIOptESUsername + ", u"
-	CLIFlagESPassword      = CLIOptESPassword + ", p"
-	CLIFlagAWSToken        = CLIOptAWSToken
 	CLIFlagVisibilityIndex = CLIOptVisibilityIndex + ", i"
+	CLIFlagAWSToken        = CLIOptAWSToken
 	CLIFlagAWSCredentials  = CLIOptAWSCredentials + ", aws"
 	CLIFlagFailSilently    = CLIOptFailSilently
 )
@@ -36,7 +30,7 @@ var osExit = os.Exit
 
 // root handler for all cli commands
 func cliHandler(c *cli.Context, handler func(c *cli.Context, logger log.Logger) error, logger log.Logger) {
-	quiet := c.Bool(schema.CLIOptQuiet)
+	quiet := c.GlobalBool(commonschema.CLIOptQuiet)
 	err := handler(c, logger)
 	if err != nil && !quiet {
 		osExit(1)
@@ -54,48 +48,48 @@ func BuildCLIOptions() *cli.App {
 	logger := log.NewCLILogger()
 
 	app.Flags = []cli.Flag{
-		&cli.StringFlag{
-			Name:    CLIFlagESURL,
-			Value:   "http://127.0.0.1:9200",
-			Usage:   "hostname or ip address of elasticsearch server",
-			EnvVars: []string{"ES_SERVER"},
+		cli.StringFlag{
+			Name:   commonschema.CLIFlagEndpoint,
+			Value:  "http://127.0.0.1:9200",
+			Usage:  "hostname or ip address of elasticsearch server",
+			EnvVar: "ES_SERVER",
 		},
-		&cli.StringFlag{
-			Name:    CLIFlagESUsername,
-			Value:   "",
-			Usage:   "username for elasticsearch or aws_access_key_id if using static aws credentials",
-			EnvVars: []string{"ES_USER"},
+		cli.StringFlag{
+			Name:   commonschema.CLIFlagUser,
+			Value:  "",
+			Usage:  "username for elasticsearch or aws_access_key_id if using static aws credentials",
+			EnvVar: "ES_USER",
 		},
-		&cli.StringFlag{
-			Name:    CLIFlagESPassword,
-			Value:   "",
-			Usage:   "password for elasticsearch or aws_secret_access_key if using static aws credentials",
-			EnvVars: []string{"ES_PWD"},
+		cli.StringFlag{
+			Name:   commonschema.CLIFlagPassword,
+			Value:  "",
+			Usage:  "password for elasticsearch or aws_secret_access_key if using static aws credentials",
+			EnvVar: "ES_PWD",
 		},
-		&cli.StringFlag{
-			Name:    CLIFlagAWSCredentials,
-			Value:   "",
-			Usage:   "AWS credentials provider (supported ['static', 'environment', 'aws-sdk-default'])",
-			EnvVars: []string{"AWS_CREDENTIALS"},
+		cli.StringFlag{
+			Name:   CLIFlagAWSCredentials,
+			Value:  "",
+			Usage:  "AWS credentials provider (supported ['static', 'environment', 'aws-sdk-default'])",
+			EnvVar: "AWS_CREDENTIALS",
 		},
-		&cli.StringFlag{
-			Name:    CLIFlagAWSToken,
-			Value:   "",
-			Usage:   "AWS sessiontoken for use with 'static' AWS credentials provider",
-			EnvVars: []string{"AWS_SESSION_TOKEN"},
+		cli.StringFlag{
+			Name:   CLIFlagAWSToken,
+			Value:  "",
+			Usage:  "AWS sessiontoken for use with 'static' AWS credentials provider",
+			EnvVar: "AWS_SESSION_TOKEN",
 		},
-		&cli.BoolFlag{
-			Name:  schema.CLIOptQuiet,
+		cli.BoolFlag{
+			Name:  commonschema.CLIOptQuiet,
 			Usage: "don't log errors to stderr",
 		},
 	}
 
-	app.Commands = []*cli.Command{
+	app.Commands = []cli.Command{
 		{
 			Name:  "setup-schema",
 			Usage: "setup elasticsearch cluster settings and index template",
 			Flags: []cli.Flag{
-				&cli.BoolFlag{
+				cli.BoolFlag{
 					Name:  CLIFlagFailSilently,
 					Usage: "fail silently on HTTP errors",
 				},
@@ -109,12 +103,12 @@ func BuildCLIOptions() *cli.App {
 			Name:  "update-schema",
 			Usage: "update elasticsearch index template, and index mappings if --index is specified",
 			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:    CLIFlagVisibilityIndex,
-					Usage:   "name of the visibility index to update mappings for (optional)",
-					EnvVars: []string{"ES_VISIBILITY_INDEX"},
+				cli.StringFlag{
+					Name:   CLIFlagVisibilityIndex,
+					Usage:  "name of the visibility index to update mappings for (optional)",
+					EnvVar: "ES_VISIBILITY_INDEX",
 				},
-				&cli.BoolFlag{
+				cli.BoolFlag{
 					Name:  CLIFlagFailSilently,
 					Usage: "fail silently on HTTP errors",
 				},
@@ -128,13 +122,13 @@ func BuildCLIOptions() *cli.App {
 			Name:  "create-index",
 			Usage: "create elasticsearch visibility index",
 			Flags: []cli.Flag{
-				&cli.StringFlag{
+				cli.StringFlag{
 					Name:     CLIFlagVisibilityIndex,
 					Usage:    "name of the visibility index to create",
 					Required: true,
-					EnvVars:  []string{"ES_VISIBILITY_INDEX"},
+					EnvVar:   "ES_VISIBILITY_INDEX",
 				},
-				&cli.BoolFlag{
+				cli.BoolFlag{
 					Name:  CLIFlagFailSilently,
 					Usage: "fail silently on HTTP errors",
 				},
@@ -148,13 +142,13 @@ func BuildCLIOptions() *cli.App {
 			Name:  "drop-index",
 			Usage: "delete elasticsearch visibility index",
 			Flags: []cli.Flag{
-				&cli.StringFlag{
+				cli.StringFlag{
 					Name:     CLIFlagVisibilityIndex,
 					Usage:    "name of the visibility index to delete",
 					Required: true,
-					EnvVars:  []string{"ES_VISIBILITY_INDEX"},
+					EnvVar:   "ES_VISIBILITY_INDEX",
 				},
-				&cli.BoolFlag{
+				cli.BoolFlag{
 					Name:  CLIFlagFailSilently,
 					Usage: "fail silently on HTTP errors",
 				},


### PR DESCRIPTION

## What changed?
Reverts to urlfav/cli v1 as per other tools and uses shared flag aliases where appropriate for more consistency with the other tools.

Works around Go embed's lack of support for symlinks by hard coding the path to the index template to use. Adds a test to ensure this doesn't get out of sync with the latest.

## Why?
Better consistency with other tools and being able to actually find the index template :)

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches elasticsearch-tool to urfave/cli v1 with shared global flags and updates Makefile calls; embeds ES index template via versioned path with a guard test.
> 
> - **Tools/Elasticsearch**:
>   - Migrate to `urfave/cli` v1; use shared global flags (`--endpoint/-ep`, `--user/-u`, `--password/-p`, AWS flags) and `Global*` accessors.
>   - Update command/flag definitions to v1 style; adjust config parsing accordingly.
> - **Makefile**:
>   - Update `temporal-elasticsearch-tool` invocations to use `-ep` and new flag names across install and XDC targets.
> - **Schema**:
>   - `ElasticsearchIndexTemplate()` now reads from `elasticsearch/visibility/versioned/v9/index_template_v7.json`.
>   - Add unit test ensuring embedded template matches the symlink target.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd136ca5333217f9db6954dde7cdeeaf5197f4c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->