### PR TITLE
Change flaky tests report schedule to Wednesdays

### DIFF
--- a/.github/workflows/flaky-tests-report.yml
+++ b/.github/workflows/flaky-tests-report.yml
@@ -2,8 +2,8 @@ name: Flaky Tests Report
 
 on:
   schedule:
-    # Run on Tuesdays and Fridays at noon Eastern time (5 PM UTC)
-    - cron: '0 17 * * 2,5'
+    # Run on Wednesdays at noon Eastern time (5 PM UTC)
+    - cron: '0 17 * * 3'
   workflow_dispatch:
     inputs:
       days:


### PR DESCRIPTION
## What changed?
Change flaky tests to run only on Wednesdays

## Why?
Get a better signal and avoid alert fatigure.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
N/A
