### PR TITLE
Fix queueBaseSuite

### DIFF
--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -42,14 +42,14 @@ type (
 		mockRescheduler *MockRescheduler
 
 		config         *configs.Config
-		options        *Options
+		options        Options
 		rateLimiter    quotas.RequestRateLimiter
 		logger         log.Logger
 		metricsHandler metrics.Handler
 	}
 )
 
-var testQueueOptions = &Options{
+var testQueueOptions = Options{
 	ReaderOptions: ReaderOptions{
 		BatchSize:            dynamicconfig.GetIntPropertyFn(10),
 		MaxPendingTasksCount: dynamicconfig.GetIntPropertyFn(100),
@@ -685,7 +685,7 @@ func (s *queueBaseSuite) newQueueBase(
 		s.mockScheduler,
 		s.mockRescheduler,
 		factory,
-		s.options,
+		&s.options,
 		s.rateLimiter,
 		NoopReaderCompletionFn,
 		GrouperNamespaceID{},

--- a/service/history/queues/queue_immediate_test.go
+++ b/service/history/queues/queue_immediate_test.go
@@ -55,7 +55,7 @@ func (s *immediateQueueSuite) SetupTest() {
 		tasks.CategoryTransfer,
 		nil, // scheduler
 		nil, // rescheduler
-		testQueueOptions,
+		&testQueueOptions,
 		NewReaderPriorityRateLimiter(
 			func() float64 { return 10 },
 			1,

--- a/service/history/queues/queue_scheduled_test.go
+++ b/service/history/queues/queue_scheduled_test.go
@@ -137,7 +137,7 @@ func (s *scheduledQueueSuite) SetupTest() {
 		scheduler,
 		rescheduler,
 		factory,
-		testQueueOptions,
+		&testQueueOptions,
 		NewReaderPriorityRateLimiter(
 			func() float64 { return 10 },
 			1,


### PR DESCRIPTION
## What changed?
A pointer to testQueueOptions is used in the test suite. This allows tests to directly modify options; later these modified options will be used by other tests, causing them to fail.
Changing testQueueOptions to a struct so that each test can get a copy of it.

## Why?
To fix flakiness when multiple tests are run.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

