### PR TITLE
add forbid require.Assertions lint rule

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -29,12 +29,13 @@ linters:
       disable:
         - fieldalignment
     forbidigo:
+      analyze-types: true
       forbid:
         - pattern: time.Sleep
           msg: "Please use require.Eventually or assert.Eventually instead unless you've no other option"
         - pattern: panic
           msg: "Please avoid using panic in application code"
-        - p: 'require\.Assertions'
+        - pattern: 'require\.Assertions'
           msg: "use require functions directly instead of require.Assertions"
     importas:
       # Enforce the aliases below.


### PR DESCRIPTION
## What changed?
Added a lint rule to forbid the embedding of require.Assertions in testify test suites. 

## Why?
When a test suite uses embedded `require.Assertions` on a test suite failures are not correctly attributed to subtests. Instead developers should use the require package directly and pass in the appropriate context.  

## How did you test it?
- [x] built
- [x] run locally and tested manually