### PR TITLE
Close Transfer Ack proto change

### DIFF
--- a/api/replication/v1/message.pb.go
+++ b/api/replication/v1/message.pb.go
@@ -1826,7 +1826,6 @@ type SyncVersionedTransitionTaskAttributes struct {
 	NamespaceId                 string                       `protobuf:"bytes,6,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty"`
 	WorkflowId                  string                       `protobuf:"bytes,7,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`
 	RunId                       string                       `protobuf:"bytes,8,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
-	IsCloseTransferTaskAcked    bool                         `protobuf:"varint,9,opt,name=is_close_transfer_task_acked,json=isCloseTransferTaskAcked,proto3" json:"is_close_transfer_task_acked,omitempty"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
@@ -1889,25 +1888,19 @@ func (x *SyncVersionedTransitionTaskAttributes) GetRunId() string {
 	return ""
 }
 
-func (x *SyncVersionedTransitionTaskAttributes) GetIsCloseTransferTaskAcked() bool {
-	if x != nil {
-		return x.IsCloseTransferTaskAcked
-	}
-	return false
-}
-
 type VersionedTransitionArtifact struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to StateAttributes:
 	//
 	//	*VersionedTransitionArtifact_SyncWorkflowStateMutationAttributes
 	//	*VersionedTransitionArtifact_SyncWorkflowStateSnapshotAttributes
-	StateAttributes isVersionedTransitionArtifact_StateAttributes `protobuf_oneof:"state_attributes"`
-	EventBatches    []*v11.DataBlob                               `protobuf:"bytes,3,rep,name=event_batches,json=eventBatches,proto3" json:"event_batches,omitempty"`
-	NewRunInfo      *NewRunInfo                                   `protobuf:"bytes,4,opt,name=new_run_info,json=newRunInfo,proto3" json:"new_run_info,omitempty"`
-	IsFirstSync     bool                                          `protobuf:"varint,5,opt,name=is_first_sync,json=isFirstSync,proto3" json:"is_first_sync,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	StateAttributes          isVersionedTransitionArtifact_StateAttributes `protobuf_oneof:"state_attributes"`
+	EventBatches             []*v11.DataBlob                               `protobuf:"bytes,3,rep,name=event_batches,json=eventBatches,proto3" json:"event_batches,omitempty"`
+	NewRunInfo               *NewRunInfo                                   `protobuf:"bytes,4,opt,name=new_run_info,json=newRunInfo,proto3" json:"new_run_info,omitempty"`
+	IsFirstSync              bool                                          `protobuf:"varint,5,opt,name=is_first_sync,json=isFirstSync,proto3" json:"is_first_sync,omitempty"`
+	IsCloseTransferTaskAcked bool                                          `protobuf:"varint,6,opt,name=is_close_transfer_task_acked,json=isCloseTransferTaskAcked,proto3" json:"is_close_transfer_task_acked,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *VersionedTransitionArtifact) Reset() {
@@ -1982,6 +1975,13 @@ func (x *VersionedTransitionArtifact) GetNewRunInfo() *NewRunInfo {
 func (x *VersionedTransitionArtifact) GetIsFirstSync() bool {
 	if x != nil {
 		return x.IsFirstSync
+	}
+	return false
+}
+
+func (x *VersionedTransitionArtifact) GetIsCloseTransferTaskAcked() bool {
+	if x != nil {
+		return x.IsCloseTransferTaskAcked
 	}
 	return false
 }
@@ -2166,21 +2166,21 @@ const file_temporal_server_api_replication_v1_message_proto_rawDesc = "" +
 	"\rnext_event_id\x18\x04 \x01(\x03R\vnextEventId\x12f\n" +
 	"\x15event_version_history\x18\x05 \x03(\v22.temporal.server.api.history.v1.VersionHistoryItemR\x13eventVersionHistory\x12\x1c\n" +
 	"\n" +
-	"new_run_id\x18\x06 \x01(\tR\bnewRunId\"\xe0\x02\n" +
+	"new_run_id\x18\x06 \x01(\tR\bnewRunId\"\xa0\x02\n" +
 	"%SyncVersionedTransitionTaskAttributes\x12\x83\x01\n" +
 	"\x1dversioned_transition_artifact\x18\x05 \x01(\v2?.temporal.server.api.replication.v1.VersionedTransitionArtifactR\x1bversionedTransitionArtifact\x12!\n" +
 	"\fnamespace_id\x18\x06 \x01(\tR\vnamespaceId\x12\x1f\n" +
 	"\vworkflow_id\x18\a \x01(\tR\n" +
 	"workflowId\x12\x15\n" +
-	"\x06run_id\x18\b \x01(\tR\x05runId\x12>\n" +
-	"\x1cis_close_transfer_task_acked\x18\t \x01(\bR\x18isCloseTransferTaskAckedJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05\"\xb2\x04\n" +
+	"\x06run_id\x18\b \x01(\tR\x05runIdJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05\"\xf2\x04\n" +
 	"\x1bVersionedTransitionArtifact\x12\x9f\x01\n" +
 	"'sync_workflow_state_mutation_attributes\x18\x01 \x01(\v2G.temporal.server.api.replication.v1.SyncWorkflowStateMutationAttributesH\x00R#syncWorkflowStateMutationAttributes\x12\x9f\x01\n" +
 	"'sync_workflow_state_snapshot_attributes\x18\x02 \x01(\v2G.temporal.server.api.replication.v1.SyncWorkflowStateSnapshotAttributesH\x00R#syncWorkflowStateSnapshotAttributes\x12E\n" +
 	"\revent_batches\x18\x03 \x03(\v2 .temporal.api.common.v1.DataBlobR\feventBatches\x12P\n" +
 	"\fnew_run_info\x18\x04 \x01(\v2..temporal.server.api.replication.v1.NewRunInfoR\n" +
 	"newRunInfo\x12\"\n" +
-	"\ris_first_sync\x18\x05 \x01(\bR\visFirstSyncB\x12\n" +
+	"\ris_first_sync\x18\x05 \x01(\bR\visFirstSync\x12>\n" +
+	"\x1cis_close_transfer_task_acked\x18\x06 \x01(\bR\x18isCloseTransferTaskAckedB\x12\n" +
 	"\x10state_attributesB5Z3go.temporal.io/server/api/replication/v1;repicationb\x06proto3"
 
 var (

--- a/proto/internal/temporal/server/api/replication/v1/message.proto
+++ b/proto/internal/temporal/server/api/replication/v1/message.proto
@@ -237,7 +237,6 @@ message SyncVersionedTransitionTaskAttributes {
     string namespace_id = 6;
     string workflow_id = 7;
     string run_id = 8;
-    bool is_close_transfer_task_acked = 9;
 }
 
 message VersionedTransitionArtifact {
@@ -248,4 +247,5 @@ message VersionedTransitionArtifact {
     repeated temporal.api.common.v1.DataBlob event_batches = 3;
     NewRunInfo new_run_info = 4;
     bool is_first_sync = 5;
+    bool is_close_transfer_task_acked = 6;
 }


### PR DESCRIPTION
## What changed?
Adding in new field for SyncVersionedTransition to denote if close transfer has been executed on source side.

## Why?

Enabling this flag will allow us to optimize replication of closed workflows during forced replication to not reexecute closed child workflows from verifying against their parent.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
