### PR TITLE
Allow overriding all postgres connection attributes

### DIFF
--- a/common/persistence/sql/sqlplugin/postgresql/session/session.go
+++ b/common/persistence/sql/sqlplugin/postgresql/session/session.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -54,7 +55,11 @@ func createConnection(
 	d driver.Driver,
 	resolver resolver.ServiceResolver,
 ) (*sqlx.DB, error) {
-	db, err := d.CreateConnection(buildDSN(cfg, resolver))
+	dsn, err := buildDSN(cfg, resolver)
+	if err != nil {
+		return nil, err
+	}
+	db, err := d.CreateConnection(dsn)
 	if err != nil {
 		return nil, err
 	}
@@ -76,21 +81,24 @@ func createConnection(
 func buildDSN(
 	cfg *config.SQL,
 	r resolver.ServiceResolver,
-) string {
-	tlsAttrs := buildDSNAttr(cfg).Encode()
+) (string, error) {
+	tlsAttrs, err := buildDSNAttr(cfg)
+	if err != nil {
+		return "", err
+	}
 	resolvedAddr := r.Resolve(cfg.ConnectAddr)[0]
-	dsn := fmt.Sprintf(
+	return fmt.Sprintf(
 		dsnFmt,
 		cfg.User,
 		url.QueryEscape(cfg.Password),
 		resolvedAddr,
 		cfg.DatabaseName,
-		tlsAttrs,
-	)
-	return dsn
+		tlsAttrs.Encode(),
+	), nil
 }
 
-func buildDSNAttr(cfg *config.SQL) url.Values {
+// nolint: revive
+func buildDSNAttr(cfg *config.SQL) (url.Values, error) {
 	parameters := make(url.Values, len(cfg.ConnectAttributes))
 	for k, v := range cfg.ConnectAttributes {
 		key := strings.TrimSpace(k)
@@ -117,13 +125,26 @@ func buildDSNAttr(cfg *config.SQL) url.Values {
 		if parameters.Get(sslCA) == "" && cfg.TLS.CaFile != "" {
 			parameters.Set(sslCA, cfg.TLS.CaFile)
 		}
-		if parameters.Get(sslKey) == "" && cfg.TLS.KeyFile != "" && parameters.Get(sslCert) == "" && cfg.TLS.CertFile != "" {
-			parameters.Set(sslKey, cfg.TLS.KeyFile)
-			parameters.Set(sslCert, cfg.TLS.CertFile)
+
+		if parameters.Get(sslKey) == "" {
+			if parameters.Get(sslCert) != "" {
+				return nil, errors.New("failed to build postgresql DSN: sslcert connectAttribute is set but sslkey is not set")
+			}
+			if cfg.TLS.KeyFile != "" {
+				if cfg.TLS.CertFile == "" {
+					return nil, errors.New("failed to build postgresql DSN: TLS keyFile is set but TLS certFile is not set")
+				}
+				parameters.Set(sslKey, cfg.TLS.KeyFile)
+				parameters.Set(sslCert, cfg.TLS.CertFile)
+			} else if cfg.TLS.CertFile != "" {
+				return nil, errors.New("failed to build postgresql DSN: TLS certFile is set but TLS keyFile is not set")
+			}
+		} else if parameters.Get(sslCert) == "" {
+			return nil, errors.New("failed to build postgresql DSN: sslkey connectAttribute is set but sslcert is not set")
 		}
 	} else if parameters.Get(sslMode) == "" {
 		parameters.Set(sslMode, sslModeNoop)
 	}
 
-	return parameters
+	return parameters, nil
 }


### PR DESCRIPTION
## What changed?

User provided connection attributes take precedent over ones set automatically the code.

## Why?

This fixes https://github.com/temporalio/temporal/issues/8436 by allowing users to set `sslmode` through `connectAttributes`.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

Users may override values that they didn't intend to, where the server would fail to start up before.
