### PR TITLE
Support relative timestamp queries for DateTime fields in Visibility APIs

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -319,13 +319,13 @@ func (s *ESVisibilitySuite) Test_convertQuery() {
 	query = `StartTime = "2018-06-07T15:04:05.123456789-08:00"`
 	queryParams, err = s.visibilityStore.convertQuery(testNamespace, testNamespaceID, query)
 	s.NoError(err)
-	s.Equal(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":{"match":{"StartTime":{"query":"2018-06-07T15:04:05.123456789-08:00"}}}}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
+	s.Equal(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":{"match":{"StartTime":{"query":"2018-06-07T23:04:05.123456789Z"}}}}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
 	s.Nil(queryParams.Sorter)
 
 	query = `WorkflowId = 'wid' and StartTime > "2018-06-07T15:04:05+00:00"`
 	queryParams, err = s.visibilityStore.convertQuery(testNamespace, testNamespaceID, query)
 	s.NoError(err)
-	s.Equal(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"range":{"StartTime":{"from":"2018-06-07T15:04:05+00:00","include_lower":false,"include_upper":true,"to":null}}}]}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
+	s.Equal(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"range":{"StartTime":{"from":"2018-06-07T15:04:05Z","include_lower":false,"include_upper":true,"to":null}}}]}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
 	s.Nil(queryParams.Sorter)
 
 	query = `ExecutionTime < 1000000`
@@ -374,7 +374,7 @@ func (s *ESVisibilitySuite) Test_convertQuery() {
 	queryParams, err = s.visibilityStore.convertQuery(testNamespace, testNamespaceID, query)
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)
-	s.Equal(err.Error(), "invalid query: unable to convert filter expression: unable to convert values of comparison expression: invalid value for search attribute ExecutionTime of type Datetime: \"unable to parse\"")
+	s.Contains(err.Error(), "invalid query: unable to convert filter expression: unable to convert values of comparison expression: invalid value for search attribute ExecutionTime")
 
 	// invalid union injection
 	query = `WorkflowId = 'wid' union select * from dummy`

--- a/common/persistence/visibility/store/query/util.go
+++ b/common/persistence/visibility/store/query/util.go
@@ -22,3 +22,21 @@ func ParseExecutionDurationStr(durationStr string) (time.Duration, error) {
 	// To support "hh:mm:ss" durations.
 	return timestamp.ParseHHMMSSDuration(durationStr)
 }
+
+// ParseRelativeOrAbsoluteTime parses a time string that can be either:
+// 1. A relative duration (e.g., "5m", "1h", "2d") - converted to absolute time by adding to now
+// 2. An absolute timestamp in RFC3339Nano format
+//
+// For relative durations, the absolute time is calculated as time.Now().Add(duration).
+// Valid duration units are "ns", "us" (or "µs"), "ms", "s", "m", "h", "d" (days).
+func ParseRelativeOrAbsoluteTime(timeStr string) (time.Time, error) {
+	if duration, err := timestamp.ParseDuration(timeStr); err == nil {
+		return time.Now().Add(duration).UTC(), nil
+	}
+
+	parsedTime, err := time.Parse(time.RFC3339Nano, timeStr)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return parsedTime.UTC(), nil
+}

--- a/common/persistence/visibility/store/query/util_test.go
+++ b/common/persistence/visibility/store/query/util_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseExecutionDurationStr(t *testing.T) {
@@ -60,4 +61,162 @@ func TestParseExecutionDurationStr(t *testing.T) {
 			s.Contains(err.Error(), tc.expectedErr.Error())
 		}
 	}
+}
+
+func TestParseRelativeOrAbsoluteTime(t *testing.T) {
+	now := time.Now().UTC()
+
+	t.Run("relative durations", func(t *testing.T) {
+		testCases := []struct {
+			name            string
+			input           string
+			expectedBefore  time.Time
+			expectedAfter   time.Time
+			allowedVariance time.Duration
+		}{
+			{
+				name:            "5 minutes",
+				input:           "5m",
+				expectedBefore:  now.Add(5*time.Minute - time.Second),
+				expectedAfter:   now.Add(5*time.Minute + time.Second),
+				allowedVariance: 2 * time.Second,
+			},
+			{
+				name:            "1 hour",
+				input:           "1h",
+				expectedBefore:  now.Add(1*time.Hour - time.Second),
+				expectedAfter:   now.Add(1*time.Hour + time.Second),
+				allowedVariance: 2 * time.Second,
+			},
+			{
+				name:            "30 seconds",
+				input:           "30s",
+				expectedBefore:  now.Add(30*time.Second - time.Second),
+				expectedAfter:   now.Add(30*time.Second + time.Second),
+				allowedVariance: 2 * time.Second,
+			},
+			{
+				name:            "2 days",
+				input:           "2d",
+				expectedBefore:  now.Add(48*time.Hour - time.Second),
+				expectedAfter:   now.Add(48*time.Hour + time.Second),
+				allowedVariance: 2 * time.Second,
+			},
+			{
+				name:            "1 hour 30 minutes",
+				input:           "1h30m",
+				expectedBefore:  now.Add(90*time.Minute - time.Second),
+				expectedAfter:   now.Add(90*time.Minute + time.Second),
+				allowedVariance: 2 * time.Second,
+			},
+			{
+				name:            "500 milliseconds",
+				input:           "500ms",
+				expectedBefore:  now.Add(500*time.Millisecond - time.Second),
+				expectedAfter:   now.Add(500*time.Millisecond + time.Second),
+				allowedVariance: 2 * time.Second,
+			},
+			{
+				name:            "negative 5 minutes",
+				input:           "-5m",
+				expectedBefore:  now.Add(-5*time.Minute - time.Second),
+				expectedAfter:   now.Add(-5*time.Minute + time.Second),
+				allowedVariance: 2 * time.Second,
+			},
+			{
+				name:            "negative 1 hour",
+				input:           "-1h",
+				expectedBefore:  now.Add(-1*time.Hour - time.Second),
+				expectedAfter:   now.Add(-1*time.Hour + time.Second),
+				allowedVariance: 2 * time.Second,
+			},
+			{
+				name:            "negative 2 days",
+				input:           "-2d",
+				expectedBefore:  now.Add(-48*time.Hour - time.Second),
+				expectedAfter:   now.Add(-48*time.Hour + time.Second),
+				allowedVariance: 2 * time.Second,
+			},
+			{
+				name:            "negative 1 hour 30 minutes",
+				input:           "-1h30m",
+				expectedBefore:  now.Add(-90*time.Minute - time.Second),
+				expectedAfter:   now.Add(-90*time.Minute + time.Second),
+				allowedVariance: 2 * time.Second,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result, err := ParseRelativeOrAbsoluteTime(tc.input)
+				require.NoError(t, err)
+
+				// Check that the result is within acceptable range
+				// (accounting for test execution time)
+				assert.True(t, result.After(tc.expectedBefore) || result.Equal(tc.expectedBefore),
+					"result %v should be after or equal to %v", result, tc.expectedBefore)
+				assert.True(t, result.Before(tc.expectedAfter) || result.Equal(tc.expectedAfter),
+					"result %v should be before or equal to %v", result, tc.expectedAfter)
+			})
+		}
+	})
+
+	t.Run("absolute timestamps", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			input    string
+			expected time.Time
+		}{
+			{
+				name:     "RFC3339Nano with timezone",
+				input:    "2025-10-16T15:04:05.999999999Z",
+				expected: time.Date(2025, 10, 16, 15, 4, 5, 999999999, time.UTC),
+			},
+			{
+				name:     "RFC3339Nano with offset",
+				input:    "2025-10-16T15:04:05.123456789-08:00",
+				expected: time.Date(2025, 10, 16, 23, 4, 5, 123456789, time.UTC),
+			},
+			{
+				name:     "RFC3339 without nanoseconds",
+				input:    "2025-10-16T15:04:05Z",
+				expected: time.Date(2025, 10, 16, 15, 4, 5, 0, time.UTC),
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result, err := ParseRelativeOrAbsoluteTime(tc.input)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			})
+		}
+	})
+
+	t.Run("invalid inputs", func(t *testing.T) {
+		testCases := []struct {
+			name  string
+			input string
+		}{
+			{
+				name:  "invalid duration unit",
+				input: "5q",
+			},
+			{
+				name:  "invalid timestamp format",
+				input: "2025-13-40",
+			},
+			{
+				name:  "random string",
+				input: "invalid",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := ParseRelativeOrAbsoluteTime(tc.input)
+				assert.Error(t, err)
+			})
+		}
+	})
 }

--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -565,7 +565,7 @@ func (c *QueryConverter) parseSQLVal(
 			tm = time.Unix(0, v)
 		case string:
 			var err error
-			tm, err = time.Parse(time.RFC3339Nano, v)
+			tm, err = query.ParseRelativeOrAbsoluteTime(v)
 			if err != nil {
 				return nil, query.NewConverterError(
 					"%s: unable to parse datetime '%s'",


### PR DESCRIPTION
## What changed?
Adds support for relative timestamp queries for CloseTime, StartTime, ExecutionTime, and custom search attributes with `INDEXED_VALUE_TYPE_DATETIME` as the registered type. The relative timestamp value is directly added to the time of the query execution. 

Example List Filter using the Temporal CLI:
`WorkflowId = '<workflow-id>' and StartTime > '-5h'` filters for workflow executions of the `workflow-id` with `StartTime` absolute timestamp values after `now() - 5h`.

## Why?
https://github.com/temporalio/temporal/issues/8349

User request:
```
I'd like to be able to query with < '5m' or >= '1 day' where it's a relative time and the absolute timestamp is calculated at the time of query execution.
```
This implementation differs from the user request, which requires the user to specify the add or subtraction operator to the relative time duration to calculate the final absolute time. If there is a need to query for a DateTime attribute set in the future, the relative timestamp query would be ambiguous with its resolution.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## TODO
Update [Temporal Public Docs](https://docs.temporal.io/list-filter) once ready.
