### PR TITLE
Refactor chasm statemachine helper

### DIFF
--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -17,6 +17,8 @@ type Callback struct {
 
 	// Persisted internal state
 	*callbackspb.CallbackState
+
+	status *callbackspb.CallbackStatus
 }
 
 func NewCallback(
@@ -39,11 +41,11 @@ func (c *Callback) LifecycleState(_ chasm.Context) chasm.LifecycleState {
 	return chasm.LifecycleStateRunning
 }
 
-func (c *Callback) State() callbackspb.CallbackStatus {
+func (c *Callback) StateMachineState() callbackspb.CallbackStatus {
 	return c.Status
 }
 
-func (c *Callback) SetState(status callbackspb.CallbackStatus) {
+func (c *Callback) SetStateMachineState(status callbackspb.CallbackStatus) {
 	c.Status = status
 }
 

--- a/chasm/lib/callback/statemachine.go
+++ b/chasm/lib/callback/statemachine.go
@@ -17,7 +17,7 @@ type EventScheduled struct{}
 var TransitionScheduled = chasm.NewTransition(
 	[]callbackspb.CallbackStatus{callbackspb.CALLBACK_STATUS_STANDBY},
 	callbackspb.CALLBACK_STATUS_SCHEDULED,
-	func(ctx chasm.MutableContext, cb *Callback, event EventScheduled) error {
+	func(cb *Callback, ctx chasm.MutableContext, event EventScheduled) error {
 		ctx.AddTask(cb, chasm.TaskAttributes{}, &callbackspb.InvocationTask{})
 		return nil
 	},
@@ -29,7 +29,7 @@ type EventRescheduled struct{}
 var TransitionRescheduled = chasm.NewTransition(
 	[]callbackspb.CallbackStatus{callbackspb.CALLBACK_STATUS_BACKING_OFF},
 	callbackspb.CALLBACK_STATUS_SCHEDULED,
-	func(mctx chasm.MutableContext, cb *Callback, event EventRescheduled) error {
+	func(cb *Callback, mctx chasm.MutableContext, event EventRescheduled) error {
 		cb.NextAttemptScheduleTime = nil
 		mctx.AddTask(cb, chasm.TaskAttributes{ScheduledTime: time.Time{}}, &callbackspb.InvocationTask{})
 		return nil
@@ -46,7 +46,7 @@ type EventAttemptFailed struct {
 var TransitionAttemptFailed = chasm.NewTransition(
 	[]callbackspb.CallbackStatus{callbackspb.CALLBACK_STATUS_SCHEDULED},
 	callbackspb.CALLBACK_STATUS_BACKING_OFF,
-	func(mctx chasm.MutableContext, cb *Callback, event EventAttemptFailed) error {
+	func(cb *Callback, mctx chasm.MutableContext, event EventAttemptFailed) error {
 		cb.recordAttempt(event.Time)
 		// Use 0 for elapsed time as we don't limit the retry by time (for now).
 		nextDelay := event.RetryPolicy.ComputeNextDelay(0, int(cb.Attempt), event.Err)
@@ -74,7 +74,7 @@ type EventFailed struct {
 var TransitionFailed = chasm.NewTransition(
 	[]callbackspb.CallbackStatus{callbackspb.CALLBACK_STATUS_SCHEDULED},
 	callbackspb.CALLBACK_STATUS_FAILED,
-	func(mctx chasm.MutableContext, cb *Callback, event EventFailed) error {
+	func(cb *Callback, ctx chasm.MutableContext, event EventFailed) error {
 		cb.recordAttempt(event.Time)
 		cb.LastAttemptFailure = &failurepb.Failure{
 			Message: event.Err.Error(),
@@ -84,7 +84,7 @@ var TransitionFailed = chasm.NewTransition(
 				},
 			},
 		}
-		mctx.AddTask(cb, chasm.TaskAttributes{ScheduledTime: time.Time{}}, &callbackspb.InvocationTask{})
+		ctx.AddTask(cb, chasm.TaskAttributes{ScheduledTime: time.Time{}}, &callbackspb.InvocationTask{})
 		return nil
 	},
 )
@@ -97,10 +97,10 @@ type EventSucceeded struct {
 var TransitionSucceeded = chasm.NewTransition(
 	[]callbackspb.CallbackStatus{callbackspb.CALLBACK_STATUS_SCHEDULED},
 	callbackspb.CALLBACK_STATUS_SUCCEEDED,
-	func(mctx chasm.MutableContext, cb *Callback, event EventSucceeded) error {
+	func(cb *Callback, ctx chasm.MutableContext, event EventSucceeded) error {
 		cb.recordAttempt(event.Time)
 		cb.LastAttemptFailure = nil
-		mctx.AddTask(cb, chasm.TaskAttributes{}, &callbackspb.InvocationTask{})
+		ctx.AddTask(cb, chasm.TaskAttributes{}, &callbackspb.InvocationTask{})
 		return nil
 	},
 )

--- a/chasm/lib/callback/statemachine_test.go
+++ b/chasm/lib/callback/statemachine_test.go
@@ -26,7 +26,7 @@ func TestValidTransitions(t *testing.T) {
 			},
 		},
 	}
-	callback.SetState(callbackspb.CALLBACK_STATUS_SCHEDULED)
+	callback.SetStateMachineState(callbackspb.CALLBACK_STATUS_SCHEDULED)
 
 	// AttemptFailed
 	mctx := &chasm.MockMutableContext{}
@@ -38,7 +38,7 @@ func TestValidTransitions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert info object is updated
-	require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, callback.State())
+	require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, callback.StateMachineState())
 	require.Equal(t, int32(1), callback.Attempt)
 	require.Equal(t, "test", callback.LastAttemptFailure.Message)
 	require.False(t, callback.LastAttemptFailure.GetApplicationFailureInfo().NonRetryable)
@@ -56,7 +56,7 @@ func TestValidTransitions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert info object is updated only where needed
-	require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, callback.State())
+	require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, callback.StateMachineState())
 	require.Equal(t, int32(1), callback.Attempt)
 	require.Equal(t, "test", callback.LastAttemptFailure.Message)
 	// Remains unmodified
@@ -71,7 +71,7 @@ func TestValidTransitions(t *testing.T) {
 	dup := &Callback{
 		CallbackState: proto.Clone(callback.CallbackState).(*callbackspb.CallbackState),
 	}
-	dup.Status = callback.State()
+	dup.Status = callback.StateMachineState()
 
 	// Succeeded
 	currentTime = currentTime.Add(time.Second)
@@ -80,7 +80,7 @@ func TestValidTransitions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert info object is updated only where needed
-	require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, callback.State())
+	require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, callback.StateMachineState())
 	require.Equal(t, int32(2), callback.Attempt)
 	require.Nil(t, callback.LastAttemptFailure)
 	require.Equal(t, currentTime, callback.LastAttemptCompleteTime.AsTime())
@@ -100,7 +100,7 @@ func TestValidTransitions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert info object is updated only where needed
-	require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, callback.State())
+	require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, callback.StateMachineState())
 	require.Equal(t, int32(2), callback.Attempt)
 	require.Equal(t, "failed", callback.LastAttemptFailure.Message)
 	require.True(t, callback.LastAttemptFailure.GetApplicationFailureInfo().NonRetryable)

--- a/chasm/statemachine.go
+++ b/chasm/statemachine.go
@@ -12,8 +12,8 @@ var ErrInvalidTransition = errors.New("invalid transition")
 // A StateMachine is anything that can get and set a comparable state S and re-generate tasks based on current state.
 // It is meant to be used with [Transition] objects to safely transition their state on a given event.
 type StateMachine[S comparable] interface {
-	State() S
-	SetState(S)
+	StateMachineState() S
+	SetStateMachineState(S)
 }
 
 // Transition represents a state machine transition for a machine of type SM with state S and event E.
@@ -23,12 +23,12 @@ type Transition[S comparable, SM StateMachine[S], E any] struct {
 	// Destination state to transition to.
 	Destination S
 	// Function to apply the transition. Mutate the state machine object here and schedule tasks.
-	apply func(MutableContext, SM, E) error
+	apply func(SM, MutableContext, E) error
 }
 
 // NewTransition creates a new [Transition] from the given source states to a destination state for a given event.
 // The apply function is called after verifying the transition is possible and setting the destination state.
-func NewTransition[S comparable, SM StateMachine[S], E any](src []S, dst S, apply func(MutableContext, SM, E) error) Transition[S, SM, E] {
+func NewTransition[S comparable, SM StateMachine[S], E any](src []S, dst S, apply func(sm SM, ctx MutableContext, event E) error) Transition[S, SM, E] {
 	return Transition[S, SM, E]{
 		Sources:     src,
 		Destination: dst,
@@ -38,17 +38,17 @@ func NewTransition[S comparable, SM StateMachine[S], E any](src []S, dst S, appl
 
 // Possible returns a boolean indicating whether the transition is possible for the current state.
 func (t Transition[S, SM, E]) Possible(sm SM) bool {
-	return slices.Contains(t.Sources, sm.State())
+	return slices.Contains(t.Sources, sm.StateMachineState())
 }
 
 // Apply applies a transition event to the given state machine changing the state machine's state to the transition's
 // Destination on success.
 func (t Transition[S, SM, E]) Apply(ctx MutableContext, sm SM, event E) error {
-	prevState := sm.State()
+	prevState := sm.StateMachineState()
 	if !t.Possible(sm) {
 		return fmt.Errorf("%w from %v: %v", ErrInvalidTransition, prevState, event)
 	}
 
-	sm.SetState(t.Destination)
-	return t.apply(ctx, sm, event)
+	sm.SetStateMachineState(t.Destination)
+	return t.apply(sm, ctx, event)
 }


### PR DESCRIPTION
## What changed?

- Change the signature of the apply function to take the context as a second argument to allow passing in method pointers.
- Rename the "state" concept to "status" as that is what we are converging on when representing these status enums.