### PR TITLE
Enable worker heartbeat feature by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2879,13 +2879,13 @@ WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 
 	WorkerHeartbeatsEnabled = NewNamespaceBoolSetting(
 		"frontend.WorkerHeartbeatsEnabled",
-		false,
+		true,
 		`WorkerHeartbeatsEnabled is a "feature enable" flag. It allows workers to send periodic heartbeats to the server.`,
 	)
 
 	ListWorkersEnabled = NewNamespaceBoolSetting(
 		"frontend.ListWorkersEnabled",
-		false,
+		true,
 		`ListWorkersEnabled is a "feature enable" flag. It allows clients to get workers heartbeat information.`,
 	)
 

--- a/service/frontend/namespace_handler_test.go
+++ b/service/frontend/namespace_handler_test.go
@@ -383,14 +383,14 @@ func (s *namespaceHandlerCommonSuite) TestCapabilities() {
 	s.True(resp.NamespaceInfo.Capabilities.SyncUpdate)
 	s.True(resp.NamespaceInfo.Capabilities.AsyncUpdate)
 	s.False(resp.NamespaceInfo.Capabilities.ReportedProblemsSearchAttribute)
-	s.False(resp.NamespaceInfo.Capabilities.WorkerHeartbeats)
+	s.True(resp.NamespaceInfo.Capabilities.WorkerHeartbeats)
 
 	// Second call: Override the default value of dynamic configs.
 	s.config.EnableEagerWorkflowStart = dc.GetBoolPropertyFnFilteredByNamespace(false)
 	s.config.EnableUpdateWorkflowExecution = dc.GetBoolPropertyFnFilteredByNamespace(false)
 	s.config.EnableUpdateWorkflowExecutionAsyncAccepted = dc.GetBoolPropertyFnFilteredByNamespace(false)
 	s.config.NumConsecutiveWorkflowTaskProblemsToTriggerSearchAttribute = dc.GetIntPropertyFnFilteredByNamespace(5)
-	s.config.WorkerHeartbeatsEnabled = dc.GetBoolPropertyFnFilteredByNamespace(true)
+	s.config.WorkerHeartbeatsEnabled = dc.GetBoolPropertyFnFilteredByNamespace(false)
 
 	resp, err = s.handler.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: "ns",
@@ -400,7 +400,7 @@ func (s *namespaceHandlerCommonSuite) TestCapabilities() {
 	s.False(resp.NamespaceInfo.Capabilities.SyncUpdate)
 	s.False(resp.NamespaceInfo.Capabilities.AsyncUpdate)
 	s.True(resp.NamespaceInfo.Capabilities.ReportedProblemsSearchAttribute)
-	s.True(resp.NamespaceInfo.Capabilities.WorkerHeartbeats)
+	s.False(resp.NamespaceInfo.Capabilities.WorkerHeartbeats)
 }
 
 func (s *namespaceHandlerCommonSuite) TestRegisterNamespace_WithOneCluster() {
@@ -1775,7 +1775,7 @@ func (s *namespaceHandlerCommonSuite) TestDeleteWorkflowRule() {
 	ruleId := "test-id"
 	nsConfig := &persistencespb.NamespaceConfig{
 		WorkflowRules: map[string]*rulespb.WorkflowRule{
-			ruleId: &rulespb.WorkflowRule{
+			ruleId: {
 				Spec: &rulespb.WorkflowRuleSpec{Id: ruleId},
 			},
 		},
@@ -1820,7 +1820,7 @@ func (s *namespaceHandlerCommonSuite) TestDescribeWorkflowRule() {
 	ruleId := "test-id"
 	nsConfig := &persistencespb.NamespaceConfig{
 		WorkflowRules: map[string]*rulespb.WorkflowRule{
-			ruleId: &rulespb.WorkflowRule{
+			ruleId: {
 				Spec: &rulespb.WorkflowRuleSpec{Id: ruleId},
 			},
 		},


### PR DESCRIPTION
## What changed?
Enabled the flags that control sending heartbeat and retrieving them.

## Why?
To prepare for public preview.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Tested this feature in canary and also a test cell.
