### PR TITLE
add Namespace State to the metrics at partition manager creation time

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -427,7 +427,7 @@ func (e *matchingEngineImpl) getTaskQueuePartitionManager(
 
 	tqConfig := newTaskQueueConfig(partition.TaskQueue(), e.config, namespaceEntry.Name())
 	tqConfig.loadCause = loadCause
-	logger, throttledLogger, metricsHandler := e.loggerAndMetricsForPartition(namespaceEntry, e.clusterMeta.GetCurrentClusterName(), partition, tqConfig)
+	logger, throttledLogger, metricsHandler := e.loggerAndMetricsForPartition(namespaceEntry, partition, tqConfig)
 	onFatalErr := func(cause unloadCause) { newPM.unloadFromEngine(cause) }
 	onUserDataChanged := func() { newPM.userDataChanged() }
 	userDataManager := newUserDataManager(
@@ -471,13 +471,12 @@ func (e *matchingEngineImpl) getTaskQueuePartitionManager(
 
 func (e *matchingEngineImpl) loggerAndMetricsForPartition(
 	nsEntry *namespace.Namespace,
-	clusterName string,
 	partition tqid.Partition,
 	tqConfig *taskQueueConfig,
 ) (log.Logger, log.Logger, metrics.Handler) {
 	nsName := nsEntry.Name().String()
 	var nsState string
-	if nsEntry.ActiveInCluster(clusterName) {
+	if nsEntry.ActiveInCluster(e.clusterMeta.GetCurrentClusterName()) {
 		nsState = metrics.ActiveNamespaceStateTagValue
 	} else {
 		nsState = metrics.PassiveNamespaceStateTagValue

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -265,7 +265,7 @@ func newMatchingEngine(
 
 func (s *matchingEngineSuite) newPartitionManager(prtn tqid.Partition, config *Config) taskQueuePartitionManager {
 	tqConfig := newTaskQueueConfig(prtn.TaskQueue(), config, matchingTestNamespace)
-	logger, _, metricsHandler := s.matchingEngine.loggerAndMetricsForPartition(s.ns, cluster.TestCurrentClusterName, prtn, tqConfig)
+	logger, _, metricsHandler := s.matchingEngine.loggerAndMetricsForPartition(s.ns, prtn, tqConfig)
 	pm, err := newTaskQueuePartitionManager(s.matchingEngine, s.ns, prtn, tqConfig, logger, logger, metricsHandler, &mockUserDataManager{})
 	s.Require().NoError(err)
 	return pm


### PR DESCRIPTION
## What changed?
add Namespace State to the metrics at partition manager creation time

## Why?
This is the allow us to easier filter out out metrics from passive clusters.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Marked as draft until more manual testing is done.
