### PR TITLE
CHASM: Workflow library

### DIFF
--- a/chasm/lib/workflow/fx.go
+++ b/chasm/lib/workflow/fx.go
@@ -1,0 +1,14 @@
+package workflow
+
+import (
+	"go.temporal.io/server/chasm"
+	"go.uber.org/fx"
+)
+
+var Module = fx.Module(
+	"chasm.lib.workflow",
+	fx.Provide(NewLibrary),
+	fx.Invoke(func(registry *chasm.Registry, library *Library) error {
+		return registry.Register(library)
+	}),
+)

--- a/chasm/lib/workflow/library.go
+++ b/chasm/lib/workflow/library.go
@@ -1,0 +1,23 @@
+package workflow
+
+import "go.temporal.io/server/chasm"
+
+type (
+	Library struct {
+		chasm.UnimplementedLibrary
+	}
+)
+
+func NewLibrary() *Library {
+	return &Library{}
+}
+
+func (l *Library) Name() string {
+	return "workflow"
+}
+
+func (l *Library) Components() []*chasm.RegistrableComponent {
+	return []*chasm.RegistrableComponent{
+		chasm.NewRegistrableComponent[*Workflow]("Workflow"),
+	}
+}

--- a/chasm/lib/workflow/workflow.go
+++ b/chasm/lib/workflow/workflow.go
@@ -8,7 +8,7 @@ import (
 const (
 	// Archetype for today's workflow implementation.
 	// This value is NOT persisted today, and ok to be changed.
-	Archetype chasm.Archetype = "Workflow"
+	Archetype chasm.Archetype = "workflow.Workflow"
 )
 
 type Workflow struct {

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -4,6 +4,7 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/chasm"
 	chasmscheduler "go.temporal.io/server/chasm/lib/scheduler"
+	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/config"
@@ -81,6 +82,7 @@ var Module = fx.Options(
 	nexusoperations.Module,
 	fx.Invoke(nexusworkflow.RegisterCommandHandlers),
 	chasmscheduler.Module,
+	chasmworkflow.Module,
 )
 
 func ServerProvider(grpcServerOptions []grpc.ServerOption) *grpc.Server {


### PR DESCRIPTION
## What changed?
- Wire up chasm workflow library

## Why?
- https://github.com/temporalio/temporal/pull/8485 makes workflow start to use CHASM as well and we need to register workflow as a chasm library. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- Logic is only used when chasm feature flag is turned on. The change is mainly for functional tests.
