### PR TITLE
CHASM: Fix validation context

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -2747,7 +2747,7 @@ func (n *Node) ExecutePureTask(
 
 	// Ensure this node's component value is hydrated before execution. Component
 	// will also check access rules.
-	component, err := n.Component(validationContext, ComponentRef{})
+	_, err := n.Component(validationContext, ComponentRef{})
 	if err != nil {
 		// NotFound errors are expected here and we can safely skip the task execution.
 		if errors.As(err, new(*serviceerror.NotFound)) {
@@ -2766,7 +2766,7 @@ func (n *Node) ExecutePureTask(
 	}
 
 	executionContext := NewMutableContext(progressIntentCtx, n)
-	component, err = n.Component(executionContext, ComponentRef{})
+	component, err := n.Component(executionContext, ComponentRef{})
 	if err != nil {
 		return false, err
 	}

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -1608,9 +1608,9 @@ func (s *nodeSuite) TestGetComponent() {
 
 			if ok {
 				if tc.nodeDirty {
-					s.True(node.valueState > valueStateSynced)
+					s.Greater(node.valueState, valueStateSynced)
 				} else {
-					s.True(node.valueState <= valueStateSynced)
+					s.LessOrEqual(node.valueState, valueStateSynced)
 				}
 			}
 		})


### PR DESCRIPTION
## What changed?
- Use immutable chasm context to access node when doing validations

## Why?
- Validation doesn't change component state and nothing needs to be persisted.
- Some parts of the system skips persistence when component access fail on validation step, if node is marked dirty, a dirty mutable state panic will be triggered upon releasing the execution lock.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
