### PR TITLE
Add history routing by binary CHASM ref

### DIFF
--- a/api/historyservice/v1/request_response.pb.go
+++ b/api/historyservice/v1/request_response.pb.go
@@ -65,9 +65,11 @@ type RoutingOptions struct {
 	// Request will be routed by resolving the namespace ID and the workflow ID from this task token to a given shard.
 	TaskToken string `protobuf:"bytes,6,opt,name=task_token,json=taskToken,proto3" json:"task_token,omitempty"`
 	// Request will be routed by resolving the namespace ID and the workflow ID from the first task info element.
-	TaskInfos     string `protobuf:"bytes,7,opt,name=task_infos,json=taskInfos,proto3" json:"task_infos,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	TaskInfos string `protobuf:"bytes,7,opt,name=task_infos,json=taskInfos,proto3" json:"task_infos,omitempty"`
+	// Request will be routed by resolving the namespace ID and the workflow ID from this chasm ref to a given shard.
+	ChasmComponentRef string `protobuf:"bytes,8,opt,name=chasm_component_ref,json=chasmComponentRef,proto3" json:"chasm_component_ref,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *RoutingOptions) Reset() {
@@ -145,6 +147,13 @@ func (x *RoutingOptions) GetTaskToken() string {
 func (x *RoutingOptions) GetTaskInfos() string {
 	if x != nil {
 		return x.TaskInfos
+	}
+	return ""
+}
+
+func (x *RoutingOptions) GetChasmComponentRef() string {
+	if x != nil {
+		return x.ChasmComponentRef
 	}
 	return ""
 }
@@ -9794,7 +9803,7 @@ var File_temporal_server_api_historyservice_v1_request_response_proto protorefle
 
 const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc = "" +
 	"\n" +
-	"<temporal/server/api/historyservice/v1/request_response.proto\x12%temporal.server.api.historyservice.v1\x1a google/protobuf/descriptor.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a%temporal/api/history/v1/message.proto\x1a'temporal/api/taskqueue/v1/message.proto\x1a$temporal/api/enums/v1/workflow.proto\x1a&temporal/api/workflow/v1/message.proto\x1a#temporal/api/query/v1/message.proto\x1a&temporal/api/protocol/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a#temporal/api/nexus/v1/message.proto\x1a*temporal/server/api/clock/v1/message.proto\x1a*temporal/server/api/enums/v1/cluster.proto\x1a)temporal/server/api/enums/v1/common.proto\x1a+temporal/server/api/enums/v1/workflow.proto\x1a,temporal/server/api/history/v1/message.proto\x1a.temporal/server/api/namespace/v1/message.proto\x1a3temporal/server/api/persistence/v1/executions.proto\x1a,temporal/server/api/persistence/v1/hsm.proto\x1a?temporal/server/api/persistence/v1/workflow_mutable_state.proto\x1a0temporal/server/api/replication/v1/message.proto\x1a.temporal/server/api/taskqueue/v1/message.proto\x1a*temporal/server/api/token/v1/message.proto\x1a-temporal/server/api/workflow/v1/message.proto\x1a6temporal/api/workflowservice/v1/request_response.proto\x1a:temporal/server/api/adminservice/v1/request_response.proto\x1a'temporal/server/api/common/v1/dlq.proto\"\xe0\x01\n" +
+	"<temporal/server/api/historyservice/v1/request_response.proto\x12%temporal.server.api.historyservice.v1\x1a google/protobuf/descriptor.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a&temporal/api/activity/v1/message.proto\x1a(temporal/api/deployment/v1/message.proto\x1a$temporal/api/common/v1/message.proto\x1a%temporal/api/history/v1/message.proto\x1a'temporal/api/taskqueue/v1/message.proto\x1a$temporal/api/enums/v1/workflow.proto\x1a&temporal/api/workflow/v1/message.proto\x1a#temporal/api/query/v1/message.proto\x1a&temporal/api/protocol/v1/message.proto\x1a%temporal/api/failure/v1/message.proto\x1a#temporal/api/nexus/v1/message.proto\x1a*temporal/server/api/clock/v1/message.proto\x1a*temporal/server/api/enums/v1/cluster.proto\x1a)temporal/server/api/enums/v1/common.proto\x1a+temporal/server/api/enums/v1/workflow.proto\x1a,temporal/server/api/history/v1/message.proto\x1a.temporal/server/api/namespace/v1/message.proto\x1a3temporal/server/api/persistence/v1/executions.proto\x1a,temporal/server/api/persistence/v1/hsm.proto\x1a?temporal/server/api/persistence/v1/workflow_mutable_state.proto\x1a0temporal/server/api/replication/v1/message.proto\x1a.temporal/server/api/taskqueue/v1/message.proto\x1a*temporal/server/api/token/v1/message.proto\x1a-temporal/server/api/workflow/v1/message.proto\x1a6temporal/api/workflowservice/v1/request_response.proto\x1a:temporal/server/api/adminservice/v1/request_response.proto\x1a'temporal/server/api/common/v1/dlq.proto\"\x90\x02\n" +
 	"\x0eRoutingOptions\x12\x16\n" +
 	"\x06custom\x18\x01 \x01(\bR\x06custom\x12\x19\n" +
 	"\bany_host\x18\x02 \x01(\bR\aanyHost\x12\x19\n" +
@@ -9805,7 +9814,8 @@ const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc 
 	"\n" +
 	"task_token\x18\x06 \x01(\tR\ttaskToken\x12\x1d\n" +
 	"\n" +
-	"task_infos\x18\a \x01(\tR\ttaskInfos\"\x8e\n" +
+	"task_infos\x18\a \x01(\tR\ttaskInfos\x12.\n" +
+	"\x13chasm_component_ref\x18\b \x01(\tR\x11chasmComponentRef\"\x8e\n" +
 	"\n" +
 	"\x1dStartWorkflowExecutionRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12c\n" +
@@ -10436,7 +10446,7 @@ const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc 
 	"\x10ListTasksRequest\x12V\n" +
 	"\arequest\x18\x01 \x01(\v2<.temporal.server.api.adminservice.v1.ListHistoryTasksRequestR\arequest:\x16\x92\xc4\x03\x12\x1a\x10request.shard_id\"n\n" +
 	"\x11ListTasksResponse\x12Y\n" +
-	"\bresponse\x18\x01 \x01(\v2=.temporal.server.api.adminservice.v1.ListHistoryTasksResponseR\bresponse\"\x90\x03\n" +
+	"\bresponse\x18\x01 \x01(\v2=.temporal.server.api.adminservice.v1.ListHistoryTasksResponseR\bresponse\"\xdd\x02\n" +
 	"\"CompleteNexusOperationChasmRequest\x12V\n" +
 	"\n" +
 	"completion\x18\x01 \x01(\v26.temporal.server.api.token.v1.NexusOperationCompletionR\n" +
@@ -10444,7 +10454,7 @@ const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc 
 	"\asuccess\x18\x02 \x01(\v2\x1f.temporal.api.common.v1.PayloadH\x00R\asuccess\x12<\n" +
 	"\afailure\x18\x03 \x01(\v2 .temporal.api.failure.v1.FailureH\x00R\afailure\x129\n" +
 	"\n" +
-	"close_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\tcloseTime:Q\x92\xc4\x03M\"%completion.component_ref.namespace_id*$completion.component_ref.business_idB\t\n" +
+	"close_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\tcloseTime:\x1e\x92\xc4\x03\x1aB\x18completion.component_refB\t\n" +
 	"\aoutcome\"%\n" +
 	"#CompleteNexusOperationChasmResponse\"\xe0\x03\n" +
 	"\x1dCompleteNexusOperationRequest\x12V\n" +

--- a/api/token/v1/message.pb.go
+++ b/api/token/v1/message.pb.go
@@ -573,7 +573,7 @@ type NexusOperationCompletion struct {
 	// Allows completing a started operation after a workflow has been reset.
 	RequestId string `protobuf:"bytes,5,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
 	// Reference to the CHASM component to be informed of the completion.
-	ComponentRef  *v11.ChasmComponentRef `protobuf:"bytes,6,opt,name=component_ref,json=componentRef,proto3" json:"component_ref,omitempty"`
+	ComponentRef  []byte `protobuf:"bytes,6,opt,name=component_ref,json=componentRef,proto3" json:"component_ref,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -643,7 +643,7 @@ func (x *NexusOperationCompletion) GetRequestId() string {
 	return ""
 }
 
-func (x *NexusOperationCompletion) GetComponentRef() *v11.ChasmComponentRef {
+func (x *NexusOperationCompletion) GetComponentRef() []byte {
 	if x != nil {
 		return x.ComponentRef
 	}
@@ -654,7 +654,7 @@ var File_temporal_server_api_token_v1_message_proto protoreflect.FileDescriptor
 
 const file_temporal_server_api_token_v1_message_proto_rawDesc = "" +
 	"\n" +
-	"*temporal/server/api/token/v1/message.proto\x12\x1ctemporal.server.api.token.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a*temporal/server/api/clock/v1/message.proto\x1a,temporal/server/api/history/v1/message.proto\x1a.temporal/server/api/persistence/v1/chasm.proto\x1a,temporal/server/api/persistence/v1/hsm.proto\"\xc1\x04\n" +
+	"*temporal/server/api/token/v1/message.proto\x12\x1ctemporal.server.api.token.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a*temporal/server/api/clock/v1/message.proto\x1a,temporal/server/api/history/v1/message.proto\x1a,temporal/server/api/persistence/v1/hsm.proto\"\xc1\x04\n" +
 	"\x13HistoryContinuation\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12$\n" +
 	"\x0efirst_event_id\x18\x02 \x01(\x03R\ffirstEventId\x12\"\n" +
@@ -709,7 +709,7 @@ const file_temporal_server_api_token_v1_message_proto_rawDesc = "" +
 	"\atask_id\x18\x03 \x01(\tR\x06taskId\"R\n" +
 	"\x0fHistoryEventRef\x12\x19\n" +
 	"\bevent_id\x18\x01 \x01(\x03R\aeventId\x12$\n" +
-	"\x0eevent_batch_id\x18\x02 \x01(\x03R\feventBatchId\"\xb7\x02\n" +
+	"\x0eevent_batch_id\x18\x02 \x01(\x03R\feventBatchId\"\x80\x02\n" +
 	"\x18NexusOperationCompletion\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12\x1f\n" +
 	"\vworkflow_id\x18\x02 \x01(\tR\n" +
@@ -717,8 +717,8 @@ const file_temporal_server_api_token_v1_message_proto_rawDesc = "" +
 	"\x06run_id\x18\x03 \x01(\tR\x05runId\x12E\n" +
 	"\x03ref\x18\x04 \x01(\v23.temporal.server.api.persistence.v1.StateMachineRefR\x03ref\x12\x1d\n" +
 	"\n" +
-	"request_id\x18\x05 \x01(\tR\trequestId\x12Z\n" +
-	"\rcomponent_ref\x18\x06 \x01(\v25.temporal.server.api.persistence.v1.ChasmComponentRefR\fcomponentRefB*Z(go.temporal.io/server/api/token/v1;tokenb\x06proto3"
+	"request_id\x18\x05 \x01(\tR\trequestId\x12#\n" +
+	"\rcomponent_ref\x18\x06 \x01(\fR\fcomponentRefB*Z(go.temporal.io/server/api/token/v1;tokenb\x06proto3"
 
 var (
 	file_temporal_server_api_token_v1_message_proto_rawDescOnce sync.Once
@@ -748,7 +748,6 @@ var file_temporal_server_api_token_v1_message_proto_goTypes = []any{
 	(*v12.VectorClock)(nil),              // 11: temporal.server.api.clock.v1.VectorClock
 	(*timestamppb.Timestamp)(nil),        // 12: google.protobuf.Timestamp
 	(*v11.StateMachineRef)(nil),          // 13: temporal.server.api.persistence.v1.StateMachineRef
-	(*v11.ChasmComponentRef)(nil),        // 14: temporal.server.api.persistence.v1.ChasmComponentRef
 }
 var file_temporal_server_api_token_v1_message_proto_depIdxs = []int32{
 	7,  // 0: temporal.server.api.token.v1.HistoryContinuation.transient_workflow_task:type_name -> temporal.server.api.history.v1.TransientWorkflowTaskInfo
@@ -758,12 +757,11 @@ var file_temporal_server_api_token_v1_message_proto_depIdxs = []int32{
 	11, // 4: temporal.server.api.token.v1.Task.clock:type_name -> temporal.server.api.clock.v1.VectorClock
 	12, // 5: temporal.server.api.token.v1.Task.started_time:type_name -> google.protobuf.Timestamp
 	13, // 6: temporal.server.api.token.v1.NexusOperationCompletion.ref:type_name -> temporal.server.api.persistence.v1.StateMachineRef
-	14, // 7: temporal.server.api.token.v1.NexusOperationCompletion.component_ref:type_name -> temporal.server.api.persistence.v1.ChasmComponentRef
-	8,  // [8:8] is the sub-list for method output_type
-	8,  // [8:8] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	7,  // [7:7] is the sub-list for method output_type
+	7,  // [7:7] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_api_token_v1_message_proto_init() }

--- a/chasm/engine.go
+++ b/chasm/engine.go
@@ -6,6 +6,11 @@ import (
 	"context"
 )
 
+// NoValue is a sentinel type representing no value.
+// Useful for accessing components using the engine methods (e.g., [GetComponent]) with a function that does not need to
+// return any information.
+type NoValue = *struct{}
+
 type Engine interface {
 	NewEntity(
 		context.Context,

--- a/chasm/interceptors.go
+++ b/chasm/interceptors.go
@@ -29,9 +29,9 @@ func (i *ChasmRequestInterceptor) Intercept(
 ) (resp interface{}, retError error) {
 	if strings.HasPrefix(info.FullMethod, chasmRequestPrefix) {
 		defer metrics.CapturePanic(i.logger, i.metricsHandler, &retError)
-
-		ctx = NewEngineContext(ctx, i.engine)
 	}
+
+	ctx = NewEngineContext(ctx, i.engine)
 
 	return handler(ctx, req)
 }

--- a/chasm/nexus_completion.go
+++ b/chasm/nexus_completion.go
@@ -17,7 +17,8 @@ const (
 // NexusCompletionHandler is implemented by CHASM components that want to handle
 // Nexus operation completion callbacks.
 type NexusCompletionHandler interface {
-	HandleNexusCompletion(MutableContext, *persistencespb.ChasmNexusCompletion) error
+	Component
+	HandleNexusCompletion(ctx MutableContext, completion *persistencespb.ChasmNexusCompletion) error
 }
 
 // GetNexusCallback generates a Callback message indicating a CHASM component

--- a/client/history/client_gen.go
+++ b/client/history/client_gen.go
@@ -75,7 +75,12 @@ func (c *clientImpl) CompleteNexusOperationChasm(
 	request *historyservice.CompleteNexusOperationChasmRequest,
 	opts ...grpc.CallOption,
 ) (*historyservice.CompleteNexusOperationChasmResponse, error) {
-	shardID := c.shardIDFromWorkflowID(request.GetCompletion().GetComponentRef().GetNamespaceId(), request.GetCompletion().GetComponentRef().GetBusinessId())
+	ref, err := c.tokenSerializer.DeserializeChasmComponentRef(request.GetCompletion().GetComponentRef())
+	if err != nil {
+		return nil, serviceerror.NewInvalidArgument("error deserializing component ref")
+	}
+	shardID := c.shardIDFromWorkflowID(ref.GetNamespaceId(), ref.GetBusinessId())
+	
 	var response *historyservice.CompleteNexusOperationChasmResponse
 	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
 		var err error

--- a/cmd/tools/genrpcwrappers/main.go
+++ b/cmd/tools/genrpcwrappers/main.go
@@ -233,7 +233,7 @@ func toGetter(snake string) string {
 func makeGetHistoryClient(reqType reflect.Type, routingOptions *historyservice.RoutingOptions) string {
 	t := reqType.Elem() // we know it's a pointer
 
-	if routingOptions.AnyHost && routingOptions.ShardId != "" && routingOptions.WorkflowId != "" && routingOptions.TaskToken != "" && routingOptions.TaskInfos != "" {
+	if routingOptions.AnyHost && routingOptions.ShardId != "" && routingOptions.WorkflowId != "" && routingOptions.TaskToken != "" && routingOptions.TaskInfos != "" && routingOptions.ChasmComponentRef != "" {
 		log.Fatalf("Found more than one routing directive in %s", t)
 	}
 	if routingOptions.AnyHost {
@@ -266,6 +266,15 @@ func makeGetHistoryClient(reqType reflect.Type, routingOptions *historyservice.R
 	}
 	shardID := c.shardIDFromWorkflowID(%s, taskToken.GetWorkflowId())
 `, toGetter(routingOptions.TaskToken), toGetter(namespaceIdField))
+	}
+	if routingOptions.ChasmComponentRef != "" {
+		verifyFieldExists(t, routingOptions.ChasmComponentRef)
+		return fmt.Sprintf(`ref, err := c.tokenSerializer.DeserializeChasmComponentRef(%s)
+	if err != nil {
+		return nil, serviceerror.NewInvalidArgument("error deserializing component ref")
+	}
+	shardID := c.shardIDFromWorkflowID(ref.GetNamespaceId(), ref.GetBusinessId())
+	`, toGetter(routingOptions.ChasmComponentRef))
 	}
 	if routingOptions.TaskInfos != "" {
 		verifyFieldExists(t, routingOptions.TaskInfos)

--- a/common/tasktoken/serializer.go
+++ b/common/tasktoken/serializer.go
@@ -1,6 +1,7 @@
 package tasktoken
 
 import (
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 )
 
@@ -48,4 +49,10 @@ func (s *Serializer) DeserializeNexusTaskToken(data []byte) (*tokenspb.NexusTask
 	taskToken := tokenspb.NexusTask{}
 	err := taskToken.Unmarshal(data)
 	return &taskToken, err
+}
+
+func (s *Serializer) DeserializeChasmComponentRef(data []byte) (*persistencespb.ChasmComponentRef, error) {
+	token := persistencespb.ChasmComponentRef{}
+	err := token.Unmarshal(data)
+	return &token, err
 }

--- a/components/callbacks/chasm_invocation.go
+++ b/components/callbacks/chasm_invocation.go
@@ -57,13 +57,7 @@ func (c chasmInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e 
 		return invocationResultFail{logInternalError(e.Logger, "failed to decode CHASM ComponentRef", err)}
 	}
 
-	ref := &persistencespb.ChasmComponentRef{}
-	err = proto.Unmarshal(decodedRef, ref)
-	if err != nil {
-		return invocationResultFail{logInternalError(e.Logger, "failed to unmarshal CHASM ComponentRef: %v", err)}
-	}
-
-	request, err := c.getHistoryRequest(ref)
+	request, err := c.getHistoryRequest(decodedRef)
 	if err != nil {
 		return invocationResultFail{logInternalError(e.Logger, "failed to build history request: %v", err)}
 	}
@@ -82,7 +76,7 @@ func (c chasmInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e 
 }
 
 func (c chasmInvocation) getHistoryRequest(
-	ref *persistencespb.ChasmComponentRef,
+	ref []byte,
 ) (*historyservice.CompleteNexusOperationChasmRequest, error) {
 	var req *historyservice.CompleteNexusOperationChasmRequest
 

--- a/proto/internal/buf.yaml
+++ b/proto/internal/buf.yaml
@@ -13,7 +13,7 @@ breaking:
   ignore:
     # example: - temporal/server/api/.../message.proto
     - temporal/server/api/persistence/v1/chasm.proto
-    - temporal/server/api/routing/v1/extension.proto
+    - temporal/server/api/token/v1/message.proto
 lint:
   use:
     - DEFAULT

--- a/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
@@ -58,6 +58,8 @@ message RoutingOptions {
     string task_token = 6;
     // Request will be routed by resolving the namespace ID and the workflow ID from the first task info element.
     string task_infos = 7;
+    // Request will be routed by resolving the namespace ID and the workflow ID from this chasm ref to a given shard.
+    string chasm_component_ref = 8;
 }
 
 message StartWorkflowExecutionRequest {
@@ -1145,12 +1147,8 @@ message ListTasksResponse {
 }
 
 message CompleteNexusOperationChasmRequest {
-    option (routing) = {
-        namespace_id: "completion.component_ref.namespace_id"
-        // TODO - fix after merge
-        // business_id: "completion.component_ref.business_id"
-        workflow_id: "completion.component_ref.business_id"
-    };
+    option (routing).chasm_component_ref = "completion.component_ref";
+
     // Completion token - holds information for locating an entity and the corresponding component.
     temporal.server.api.token.v1.NexusOperationCompletion completion = 1;
     oneof outcome {

--- a/proto/internal/temporal/server/api/token/v1/message.proto
+++ b/proto/internal/temporal/server/api/token/v1/message.proto
@@ -7,7 +7,6 @@ option go_package = "go.temporal.io/server/api/token/v1;token";
 import "google/protobuf/timestamp.proto";
 import "temporal/server/api/clock/v1/message.proto";
 import "temporal/server/api/history/v1/message.proto";
-import "temporal/server/api/persistence/v1/chasm.proto";
 import "temporal/server/api/persistence/v1/hsm.proto";
 
 message HistoryContinuation {
@@ -87,5 +86,5 @@ message NexusOperationCompletion {
     // Allows completing a started operation after a workflow has been reset.
     string request_id = 5;
     // Reference to the CHASM component to be informed of the completion.
-    temporal.server.api.persistence.v1.ChasmComponentRef component_ref = 6;
+    bytes component_ref = 6;
 }


### PR DESCRIPTION
## Why?

Intentionally want to keep refs opaque.

## How did you test it?
- [x] covered by existing tests
