### PR TITLE
Use s.NoError

### DIFF
--- a/common/archiver/filestore/util_test.go
+++ b/common/archiver/filestore/util_test.go
@@ -398,16 +398,16 @@ func (s *UtilSuite) TestSerializeDeserializeGetHistoryToken() {
 	}
 
 	serializedToken, err := serializeToken(token)
-	s.Nil(err)
+	s.NoError(err)
 
 	deserializedToken, err := deserializeGetHistoryToken(serializedToken)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(token, deserializedToken)
 }
 
 func (s *UtilSuite) createFile(dir string, filename string) {
 	err := os.WriteFile(filepath.Join(dir, filename), []byte("file contents"), testFileMode)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *UtilSuite) assertFileExists(filepath string) {

--- a/common/archiver/gcloud/util_test.go
+++ b/common/archiver/gcloud/util_test.go
@@ -92,10 +92,10 @@ func (s *utilSuite) TestSerializeDeserializeGetHistoryToken() {
 	}
 
 	serializedToken, err := serializeToken(token)
-	s.Nil(err)
+	s.NoError(err)
 
 	deserializedToken, err := deserializeGetHistoryToken(serializedToken)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(token, deserializedToken)
 }
 

--- a/common/archiver/history_iterator_test.go
+++ b/common/archiver/history_iterator_test.go
@@ -325,7 +325,7 @@ func (s *HistoryIteratorSuite) TestNext_Fail_IteratorDepleted() {
 	// set target history batches such that a single call to next will read all of history
 	itr := s.constructTestHistoryIterator(s.mockExecutionMgr, 16*testDefaultHistoryEventSize, nil)
 	blob, err := itr.Next(context.Background())
-	s.Nil(err)
+	s.NoError(err)
 
 	expectedIteratorState := historyIteratorState{
 		// when iteration is finished page token is not advanced

--- a/common/codec/jsonpb_test.go
+++ b/common/codec/jsonpb_test.go
@@ -55,14 +55,14 @@ func (s *jsonpbEncoderSuite) SetupSuite() {
 
 func (s *jsonpbEncoderSuite) TestEncode() {
 	json, err := s.encoder.Encode(history)
-	s.Nil(err)
+	s.NoError(err)
 	s.JSONEq(encodedHistory, string(json))
 }
 
 func (s *jsonpbEncoderSuite) TestDecode() {
 	var val historypb.History
 	err := s.encoder.Decode([]byte(encodedHistory), &val)
-	s.Nil(err)
+	s.NoError(err)
 	protoassert.ProtoEqual(s.T(), &val, history)
 }
 
@@ -73,7 +73,7 @@ func (s *jsonpbEncoderSuite) TestEncodeHistories() {
 	histories = append(histories, history)
 
 	json, err := s.encoder.EncodeHistories(histories)
-	s.Nil(err)
+	s.NoError(err)
 	s.JSONEq(fmt.Sprintf("[%[1]s,%[1]s,%[1]s]", encodedHistory), string(json))
 }
 
@@ -87,7 +87,7 @@ func (s *jsonpbEncoderSuite) TestDecodeHistories() {
 
 	decodedHistories, err := s.encoder.DecodeHistories([]byte(historyJSON))
 
-	s.Nil(err)
+	s.NoError(err)
 	protoassert.ProtoSliceEqual(s.T(), histories, decodedHistories)
 }
 
@@ -101,6 +101,6 @@ func (s *jsonpbEncoderSuite) TestDecodeOldHistories() {
 
 	decodedHistories, err := s.encoder.DecodeHistories([]byte(historyJSON))
 
-	s.Nil(err)
+	s.NoError(err)
 	protoassert.ProtoSliceEqual(s.T(), historyEvents, decodedHistories)
 }

--- a/common/collection/paging_iterator_test.go
+++ b/common/collection/paging_iterator_test.go
@@ -74,7 +74,7 @@ func (s *pagingIteratorSuite) TestIteration_NoErr() {
 	ite := NewPagingIterator(pagingFn)
 	for ite.HasNext() {
 		num, err := ite.Next()
-		s.Nil(err)
+		s.NoError(err)
 		result = append(result, num)
 	}
 	s.Equal([]int{1, 2, 3, 4, 5, 6}, result)

--- a/common/config/loader_test.go
+++ b/common/config/loader_test.go
@@ -40,7 +40,7 @@ func (s *LoaderSuite) TestBaseYaml() {
 
 	data := buildConfig(false, "", "")
 	err := os.WriteFile(path(dir, "base.yaml"), []byte(data), fileMode)
-	s.Nil(err)
+	s.NoError(err)
 
 	envs := []string{"", "prod"}
 	zones := []string{"", "us-east-1a"}
@@ -49,7 +49,7 @@ func (s *LoaderSuite) TestBaseYaml() {
 		for _, zone := range zones {
 			var cfg testConfig
 			err = Load(env, dir, zone, &cfg)
-			s.Nil(err)
+			s.NoError(err)
 			s.Equal("hello__", cfg.Items.Item1)
 			s.Equal("world__", cfg.Items.Item2)
 		}
@@ -84,7 +84,7 @@ func (s *LoaderSuite) TestHierarchy() {
 	for _, tc := range testCases {
 		var cfg testConfig
 		err := Load(tc.env, dir, tc.zone, &cfg)
-		s.Nil(err)
+		s.NoError(err)
 		s.Equal(tc.item1, cfg.Items.Item1)
 		s.Equal(tc.item2, cfg.Items.Item2)
 	}
@@ -98,7 +98,7 @@ func (s *LoaderSuite) TestInvalidPath() {
 
 func (s *LoaderSuite) createFile(dir string, file string, template bool, env string, zone string) {
 	err := os.WriteFile(path(dir, file), []byte(buildConfig(template, env, zone)), fileMode)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func buildConfig(template bool, env, zone string) string {

--- a/common/log/zap_logger_test.go
+++ b/common/log/zap_logger_test.go
@@ -52,7 +52,7 @@ func (s *LogSuite) TestNewLogger() {
 	log := BuildZapLogger(cfg)
 	s.NotNil(log)
 	_, err := os.Stat(dir + "/test.log")
-	s.Nil(err)
+	s.NoError(err)
 	log.DPanic("Development default is false; should not panic here!")
 	s.Panics(nil, func() {
 		log.Panic("Must Panic")
@@ -66,7 +66,7 @@ func (s *LogSuite) TestNewLogger() {
 	log = BuildZapLogger(cfg)
 	s.NotNil(log)
 	_, err = os.Stat(dir + "/test.log")
-	s.Nil(err)
+	s.NoError(err)
 	s.Panics(nil, func() {
 		log.DPanic("Must panic!")
 	})

--- a/common/membership/ringpop/factory_test.go
+++ b/common/membership/ringpop/factory_test.go
@@ -110,7 +110,7 @@ func (s *RingpopSuite) TearDownSuite() {
 func (s *RingpopSuite) TestHostsMode() {
 	var cfg config.Membership
 	err := yaml.Unmarshal([]byte(getHostsConfig()), &cfg)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal("1.2.3.4", cfg.BroadcastAddress)
 	s.Equal(time.Second*30, cfg.MaxJoinDuration)
 
@@ -120,7 +120,7 @@ func (s *RingpopSuite) TestHostsMode() {
 		Logger:      log.Logger(log.NewNoopLogger()),
 	}
 	f, err := newFactory(params)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(f)
 }
 

--- a/common/metrics/grpc_test.go
+++ b/common/metrics/grpc_test.go
@@ -73,7 +73,7 @@ func (s *grpcSuite) TestMetadataMetricInjection() {
 				},
 			)
 
-			s.Nil(err)
+			s.NoError(err)
 			trailers := ssts.CapturedTrailers()
 			s.Equal(1, len(trailers))
 			propagationContextBlobs := trailers[0].Get(metricsTrailerKey)
@@ -81,13 +81,13 @@ func (s *grpcSuite) TestMetadataMetricInjection() {
 			s.Equal(1, len(propagationContextBlobs))
 			baggage := &metricsspb.Baggage{}
 			err = baggage.Unmarshal(([]byte)(propagationContextBlobs[0]))
-			s.Nil(err)
+			s.NoError(err)
 			s.Equal(int64(1234), baggage.CountersInt[anyMetricName])
 			return res, err
 		},
 	)
 
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(10, res)
 	s.Assert()
 }
@@ -129,7 +129,7 @@ func (s *grpcSuite) TestMetadataMetricInjection_NoMetricPresent() {
 				},
 			)
 
-			s.Nil(err)
+			s.NoError(err)
 			trailers := ssts.CapturedTrailers()
 			s.Equal(1, len(trailers))
 			propagationContextBlobs := trailers[0].Get(metricsTrailerKey)
@@ -137,13 +137,13 @@ func (s *grpcSuite) TestMetadataMetricInjection_NoMetricPresent() {
 			s.Equal(1, len(propagationContextBlobs))
 			baggage := &metricsspb.Baggage{}
 			err = baggage.Unmarshal(([]byte)(propagationContextBlobs[0]))
-			s.Nil(err)
+			s.NoError(err)
 			s.Nil(baggage.CountersInt)
 			return res, err
 		},
 	)
 
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(10, res)
 	s.Assert()
 }

--- a/common/namespace/nsregistry/registry_test.go
+++ b/common/namespace/nsregistry/registry_test.go
@@ -174,17 +174,17 @@ func (s *registrySuite) TestListNamespace() {
 	defer s.registry.Stop()
 
 	entryByName1, err := s.registry.GetNamespace(namespace.Name(namespaceRecord1.Namespace.Info.Name))
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(entry1, entryByName1)
 	entryByID1, err := s.registry.GetNamespaceByID(namespace.ID(namespaceRecord1.Namespace.Info.Id))
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(entry1, entryByID1)
 
 	entryByName2, err := s.registry.GetNamespace(namespace.Name(namespaceRecord2.Namespace.Info.Name))
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(entry2, entryByName2)
 	entryByID2, err := s.registry.GetNamespaceByID(namespace.ID(namespaceRecord2.Namespace.Info.Id))
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(entry2, entryByID2)
 }
 

--- a/common/namespace/nsreplication/replication_task_executor_test.go
+++ b/common/namespace/nsreplication/replication_task_executor_test.go
@@ -247,7 +247,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_RegisterNamespaceTas
 		IsGlobalNamespace: true,
 	})
 	err := s.namespaceReplicator.Execute(context.Background(), task)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *namespaceReplicationTaskExecutorSuite) TestExecute_RegisterNamespaceTask_Duplicate() {
@@ -292,7 +292,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_RegisterNamespaceTas
 	}}, nil).Times(1)
 	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(nil, errors.New("test"))
 	err := s.namespaceReplicator.Execute(context.Background(), task)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_NamespaceNotExist() {
@@ -377,7 +377,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		IsGlobalNamespace: true,
 	})
 	err := s.namespaceReplicator.Execute(context.Background(), updateTask)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_UpdateConfig_UpdateActiveCluster() {
@@ -480,7 +480,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		NotificationVersion: updateFailoverVersion,
 	})
 	err := s.namespaceReplicator.Execute(context.Background(), updateTask)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_UpdateConfig_NoUpdateActiveCluster() {
@@ -574,7 +574,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		NotificationVersion: updateFailoverVersion,
 	})
 	err := s.namespaceReplicator.Execute(context.Background(), updateTask)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_NoUpdateConfig_UpdateActiveCluster() {
@@ -656,7 +656,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		NotificationVersion: updateFailoverVersion,
 	})
 	err := s.namespaceReplicator.Execute(context.Background(), updateTask)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_NoUpdateConfig_NoUpdateActiveCluster() {
@@ -726,5 +726,5 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 
 	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Times(0)
 	err := s.namespaceReplicator.Execute(context.Background(), updateTask)
-	s.Nil(err)
+	s.NoError(err)
 }

--- a/common/namespace/nsreplication/transmission_task_handler_test.go
+++ b/common/namespace/nsreplication/transmission_task_handler_test.go
@@ -140,7 +140,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_RegisterNamespaceTask
 		isGlobalNamespace,
 		nil,
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *transmissionTaskSuite) TestHandleTransmissionTask_RegisterNamespaceTask_NotGlobalNamespace() {
@@ -195,7 +195,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_RegisterNamespaceTask
 		isGlobalNamespace,
 		nil,
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_IsGlobalNamespace() {
@@ -283,7 +283,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_I
 		isGlobalNamespace,
 		nil,
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_NotGlobalNamespace() {
@@ -337,7 +337,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_N
 		isGlobalNamespace,
 		nil,
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_ReplicationClusterListUpdated() {
@@ -425,7 +425,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_R
 		isGlobalNamespace,
 		nil,
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	err = s.namespaceReplicator.HandleTransmissionTask(
 		context.Background(),
@@ -439,5 +439,5 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_R
 		isGlobalNamespace,
 		nil,
 	)
-	s.Nil(err)
+	s.NoError(err)
 }

--- a/common/persistence/persistence-tests/cluster_metadata_manager.go
+++ b/common/persistence/persistence-tests/cluster_metadata_manager.go
@@ -55,7 +55,7 @@ func (s *ClusterMetadataManagerSuite) TearDownSuite() {
 // TestClusterMembershipEmptyInitially verifies the GetClusterMembers() works with an initial empty table
 func (s *ClusterMetadataManagerSuite) TestClusterMembershipEmptyInitially() {
 	resp, err := s.ClusterMetadataManager.GetClusterMembers(s.ctx, &p.GetClusterMembersRequest{LastHeartbeatWithin: time.Minute * 10})
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(resp)
 	s.Empty(resp.ActiveMembers)
 }
@@ -72,11 +72,11 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipUpsertCanReadAny() {
 	}
 
 	err := s.ClusterMetadataManager.UpsertClusterMembership(s.ctx, req)
-	s.Nil(err)
+	s.NoError(err)
 
 	resp, err := s.ClusterMetadataManager.GetClusterMembers(s.ctx, &p.GetClusterMembersRequest{})
 
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(resp)
 	s.NotEmpty(resp.ActiveMembers)
 
@@ -127,7 +127,7 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipUpsertCanPageRead() {
 }
 
 func (s *ClusterMetadataManagerSuite) validateUpsert(req *p.UpsertClusterMembershipRequest, resp *p.GetClusterMembersResponse, err error) {
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(resp)
 	s.NotEmpty(resp.ActiveMembers)
 	s.Equal(len(resp.ActiveMembers), 1)
@@ -153,7 +153,7 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipReadFiltersCorrectly(
 	}
 
 	err := s.ClusterMetadataManager.UpsertClusterMembership(s.ctx, req)
-	s.Nil(err)
+	s.NoError(err)
 
 	resp, err := s.ClusterMetadataManager.GetClusterMembers(
 		s.ctx,
@@ -168,7 +168,7 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipReadFiltersCorrectly(
 		&p.GetClusterMembersRequest{LastHeartbeatWithin: time.Millisecond, HostIDEquals: req.HostID},
 	)
 
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(resp)
 	s.Empty(resp.ActiveMembers)
 
@@ -177,7 +177,7 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipReadFiltersCorrectly(
 		&p.GetClusterMembersRequest{RoleEquals: p.Matching},
 	)
 
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(resp)
 	s.Empty(resp.ActiveMembers)
 
@@ -186,7 +186,7 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipReadFiltersCorrectly(
 		&p.GetClusterMembersRequest{SessionStartedAfter: time.Now().UTC()},
 	)
 
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(resp)
 	s.Empty(resp.ActiveMembers)
 
@@ -241,7 +241,7 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipUpsertExpiresCorrectl
 func (s *ClusterMetadataManagerSuite) waitForPrune(waitFor time.Duration) {
 	s.Eventually(func() bool {
 		err := s.ClusterMetadataManager.PruneClusterMembership(s.ctx, &p.PruneClusterMembershipRequest{MaxRecordsPruned: 100})
-		s.Nil(err)
+		s.NoError(err)
 
 		resp, err := s.ClusterMetadataManager.GetClusterMembers(
 			s.ctx,
@@ -316,7 +316,7 @@ func (s *ClusterMetadataManagerSuite) TestInitImmutableMetadataReadWrite() {
 				IsConnectionEnabled:      true,
 			}})
 
-	s.Nil(err)
+	s.NoError(err)
 	s.True(initialResp) // request should be applied as this is first initialize
 
 	// Case 3 - Get, data persisted
@@ -324,7 +324,7 @@ func (s *ClusterMetadataManagerSuite) TestInitImmutableMetadataReadWrite() {
 	getResp, err = s.ClusterMetadataManager.GetClusterMetadata(s.ctx, &p.GetClusterMetadataRequest{ClusterName: clusterNameToPersist})
 
 	// Validate they match our initializations
-	s.Nil(err)
+	s.NoError(err)
 	s.True(getResp != nil)
 	s.Equal(clusterNameToPersist, getResp.ClusterName)
 	s.Equal(historyShardsToPersist, getResp.HistoryShardCount)
@@ -344,14 +344,14 @@ func (s *ClusterMetadataManagerSuite) TestInitImmutableMetadataReadWrite() {
 			HistoryShardCount: int32(77),
 		}})
 
-	s.Nil(err)
+	s.NoError(err)
 	s.False(secondResp) // Should not have applied, and should match values from first request
 
 	// Refetch persisted
 	getResp, err = s.ClusterMetadataManager.GetClusterMetadata(s.ctx, &p.GetClusterMetadataRequest{ClusterName: clusterNameToPersist})
 
 	// Validate they match our initial values
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(getResp)
 	s.Equal(clusterNameToPersist, getResp.ClusterName)
 	s.Equal(historyShardsToPersist, getResp.HistoryShardCount)
@@ -373,16 +373,16 @@ func (s *ClusterMetadataManagerSuite) TestInitImmutableMetadataReadWrite() {
 		ClusterMetadata: getResp.ClusterMetadata,
 		Version:         getResp.Version,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.True(thirdResp)
 	getResp, err = s.ClusterMetadataManager.GetClusterMetadata(s.ctx, &p.GetClusterMetadataRequest{ClusterName: clusterNameToPersist})
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(getResp)
 	s.Equal("1.0", getResp.ClusterMetadata.VersionInfo.Current.Version)
 
 	// Case 6 - Delete Cluster Metadata
 	err = s.ClusterMetadataManager.DeleteClusterMetadata(s.ctx, &p.DeleteClusterMetadataRequest{ClusterName: clusterNameToPersist})
-	s.Nil(err)
+	s.NoError(err)
 	getResp, err = s.ClusterMetadataManager.GetClusterMetadata(s.ctx, &p.GetClusterMetadataRequest{ClusterName: clusterNameToPersist})
 
 	// Validate they match our initializations
@@ -406,7 +406,7 @@ func (s *ClusterMetadataManagerSuite) TestInitImmutableMetadataReadWrite() {
 				IsGlobalNamespaceEnabled: true,
 				IsConnectionEnabled:      true,
 			}})
-	s.Nil(err)
+	s.NoError(err)
 	s.True(initialResp)
 
 	// Case 8 - Get, data persisted
@@ -414,7 +414,7 @@ func (s *ClusterMetadataManagerSuite) TestInitImmutableMetadataReadWrite() {
 	getResp, err = s.ClusterMetadataManager.GetClusterMetadata(s.ctx, &p.GetClusterMetadataRequest{ClusterName: clusterNameToPersist})
 
 	// Validate they match our initializations
-	s.Nil(err)
+	s.NoError(err)
 	s.True(getResp != nil)
 	s.Equal(clusterNameToPersist, getResp.ClusterName)
 	s.Equal(historyShardsToPersist, getResp.HistoryShardCount)

--- a/common/persistence/persistence-tests/history_v2_persistence.go
+++ b/common/persistence/persistence-tests/history_v2_persistence.go
@@ -101,7 +101,7 @@ func (s *HistoryV2PersistenceSuite) TestScanAllTrees() {
 	resp, err := s.ExecutionManager.GetAllHistoryTreeBranches(s.ctx, &p.GetAllHistoryTreeBranchesRequest{
 		PageSize: 1,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, len(resp.Branches), "some trees were leaked in other tests")
 
 	trees := map[string]bool{}
@@ -111,11 +111,11 @@ func (s *HistoryV2PersistenceSuite) TestScanAllTrees() {
 	for i := 0; i < totalTrees; i++ {
 		treeID := uuid.NewRandom().String()
 		bi, err := s.newHistoryBranch(treeID)
-		s.Nil(err)
+		s.NoError(err)
 
 		events := s.genRandomEvents([]int64{1, 2, 3}, 1)
 		err = s.appendNewBranchAndFirstNode(bi, events, 1, "branchInfo")
-		s.Nil(err)
+		s.NoError(err)
 		trees[string(treeID)] = true
 	}
 
@@ -125,7 +125,7 @@ func (s *HistoryV2PersistenceSuite) TestScanAllTrees() {
 			PageSize:      pgSize,
 			NextPageToken: pgToken,
 		})
-		s.Nil(err)
+		s.NoError(err)
 		for _, br := range resp.Branches {
 			uuidTreeId := br.BranchInfo.TreeId
 			if trees[uuidTreeId] {
@@ -152,40 +152,40 @@ func (s *HistoryV2PersistenceSuite) TestScanAllTrees() {
 func (s *HistoryV2PersistenceSuite) TestReadBranchByPagination() {
 	treeID := uuid.NewRandom().String()
 	bi, err := s.newHistoryBranch(treeID)
-	s.Nil(err)
+	s.NoError(err)
 
 	historyW := &historypb.History{}
 	events := s.genRandomEvents([]int64{1, 2, 3}, 0)
 	err = s.appendNewBranchAndFirstNode(bi, events, 1, "branchInfo")
-	s.Nil(err)
+	s.NoError(err)
 	historyW.Events = events
 
 	events = s.genRandomEvents([]int64{4}, 0)
 	err = s.appendNewNode(bi, events, 2)
-	s.Nil(err)
+	s.NoError(err)
 	historyW.Events = append(historyW.Events, events...)
 
 	events = s.genRandomEvents([]int64{5, 6, 7, 8}, 4)
 	err = s.appendNewNode(bi, events, 6)
-	s.Nil(err)
+	s.NoError(err)
 	historyW.Events = append(historyW.Events, events...)
 
 	// stale event batch
 	events = s.genRandomEvents([]int64{6, 7, 8}, 1)
 	err = s.appendNewNode(bi, events, 3)
-	s.Nil(err)
+	s.NoError(err)
 	// stale event batch
 	events = s.genRandomEvents([]int64{6, 7, 8}, 2)
 	err = s.appendNewNode(bi, events, 4)
-	s.Nil(err)
+	s.NoError(err)
 	// stale event batch
 	events = s.genRandomEvents([]int64{6, 7, 8}, 3)
 	err = s.appendNewNode(bi, events, 5)
-	s.Nil(err)
+	s.NoError(err)
 
 	events = s.genRandomEvents([]int64{9}, 4)
 	err = s.appendNewNode(bi, events, 7)
-	s.Nil(err)
+	s.NoError(err)
 	historyW.Events = append(historyW.Events, events...)
 
 	// Start to read from middle, should not return error, but the first batch should be ignored by application layer
@@ -199,53 +199,53 @@ func (s *HistoryV2PersistenceSuite) TestReadBranchByPagination() {
 	}
 	// first page
 	resp, err := s.ExecutionManager.ReadHistoryBranch(s.ctx, req)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(4, len(resp.HistoryEvents))
 	s.Equal(int64(6), resp.HistoryEvents[0].GetEventId())
 
 	events = s.genRandomEvents([]int64{10}, 4)
 	err = s.appendNewNode(bi, events, 8)
-	s.Nil(err)
+	s.NoError(err)
 	historyW.Events = append(historyW.Events, events...)
 
 	events = s.genRandomEvents([]int64{11}, 4)
 	err = s.appendNewNode(bi, events, 9)
-	s.Nil(err)
+	s.NoError(err)
 	historyW.Events = append(historyW.Events, events...)
 
 	events = s.genRandomEvents([]int64{12}, 4)
 	err = s.appendNewNode(bi, events, 10)
-	s.Nil(err)
+	s.NoError(err)
 	historyW.Events = append(historyW.Events, events...)
 
 	events = s.genRandomEvents([]int64{13, 14, 15}, 4)
 	err = s.appendNewNode(bi, events, 11)
-	s.Nil(err)
+	s.NoError(err)
 	// we don't append this batch because we will fork from 13
 	// historyW.Events = append(historyW.Events, events...)
 
 	// fork from here
 	bi2, err := s.fork(bi, 13)
-	s.Nil(err)
+	s.NoError(err)
 
 	events = s.genRandomEvents([]int64{13}, 4)
 	err = s.appendNewNode(bi2, events, 12)
-	s.Nil(err)
+	s.NoError(err)
 	historyW.Events = append(historyW.Events, events...)
 
 	events = s.genRandomEvents([]int64{14}, 4)
 	err = s.appendNewNode(bi2, events, 13)
-	s.Nil(err)
+	s.NoError(err)
 	historyW.Events = append(historyW.Events, events...)
 
 	events = s.genRandomEvents([]int64{15, 16, 17}, 4)
 	err = s.appendNewNode(bi2, events, 14)
-	s.Nil(err)
+	s.NoError(err)
 	historyW.Events = append(historyW.Events, events...)
 
 	events = s.genRandomEvents([]int64{18, 19, 20}, 4)
 	err = s.appendNewNode(bi2, events, 15)
-	s.Nil(err)
+	s.NoError(err)
 	historyW.Events = append(historyW.Events, events...)
 
 	// read branch to verify
@@ -262,7 +262,7 @@ func (s *HistoryV2PersistenceSuite) TestReadBranchByPagination() {
 
 	// first page
 	resp, err = s.ExecutionManager.ReadHistoryBranch(s.ctx, req)
-	s.Nil(err)
+	s.NoError(err)
 
 	s.Equal(8, len(resp.HistoryEvents))
 	historyR.Events = append(historyR.Events, resp.HistoryEvents...)
@@ -272,13 +272,13 @@ func (s *HistoryV2PersistenceSuite) TestReadBranchByPagination() {
 	// doe to difference in Cassandra / MySQL pagination
 	// the stale event batch may get returned
 	resp, err = s.ExecutionManager.ReadHistoryBranch(s.ctx, req)
-	s.Nil(err)
+	s.NoError(err)
 	historyR.Events = append(historyR.Events, resp.HistoryEvents...)
 	req.NextPageToken = resp.NextPageToken
 	if len(resp.HistoryEvents) == 0 {
 		// second page
 		resp, err = s.ExecutionManager.ReadHistoryBranch(s.ctx, req)
-		s.Nil(err)
+		s.NoError(err)
 		s.Equal(3, len(resp.HistoryEvents))
 		historyR.Events = append(historyR.Events, resp.HistoryEvents...)
 		req.NextPageToken = resp.NextPageToken
@@ -290,14 +290,14 @@ func (s *HistoryV2PersistenceSuite) TestReadBranchByPagination() {
 
 	// 3rd page, since we fork from nodeID=13, we can only see one batch of 12 here
 	resp, err = s.ExecutionManager.ReadHistoryBranch(s.ctx, req)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, len(resp.HistoryEvents))
 	historyR.Events = append(historyR.Events, resp.HistoryEvents...)
 	req.NextPageToken = resp.NextPageToken
 
 	// 4th page, 13~17
 	resp, err = s.ExecutionManager.ReadHistoryBranch(s.ctx, req)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(5, len(resp.HistoryEvents))
 	historyR.Events = append(historyR.Events, resp.HistoryEvents...)
 	req.NextPageToken = resp.NextPageToken
@@ -309,13 +309,13 @@ func (s *HistoryV2PersistenceSuite) TestReadBranchByPagination() {
 	// to get history again, no error and history events should be returned.
 	req.PageSize = 1
 	resp, err = s.ExecutionManager.ReadHistoryBranch(s.ctx, req)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(3, len(resp.HistoryEvents))
 	historyR.Events = append(historyR.Events, resp.HistoryEvents...)
 	req.NextPageToken = resp.NextPageToken
 	if len(resp.NextPageToken) != 0 {
 		resp, err = s.ExecutionManager.ReadHistoryBranch(s.ctx, req)
-		s.Nil(err)
+		s.NoError(err)
 		s.Equal(0, len(resp.HistoryEvents))
 	}
 
@@ -330,9 +330,9 @@ func (s *HistoryV2PersistenceSuite) TestReadBranchByPagination() {
 	s.IsType(&serviceerror.NotFound{}, err)
 
 	err = s.deleteHistoryBranch(bi2)
-	s.Nil(err)
+	s.NoError(err)
 	err = s.deleteHistoryBranch(bi)
-	s.Nil(err)
+	s.NoError(err)
 	branches := s.descTree(treeID)
 	s.Equal(0, len(branches))
 }
@@ -350,28 +350,28 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyCreateAndAppendBranches() {
 		go func(idx int) {
 			defer wg.Done()
 			bi, err := s.newHistoryBranch(treeID)
-			s.Nil(err)
+			s.NoError(err)
 			historyW := &historypb.History{}
 			m.Store(idx, bi)
 
 			events := s.genRandomEvents([]int64{1, 2, 3}, 1)
 			err = s.appendNewBranchAndFirstNode(bi, events, 1, "branchInfo")
-			s.Nil(err)
+			s.NoError(err)
 			historyW.Events = events
 
 			events = s.genRandomEvents([]int64{4}, 1)
 			err = s.appendNewNode(bi, events, 2)
-			s.Nil(err)
+			s.NoError(err)
 			historyW.Events = append(historyW.Events, events...)
 
 			events = s.genRandomEvents([]int64{5, 6, 7, 8}, 1)
 			err = s.appendNewNode(bi, events, 3)
-			s.Nil(err)
+			s.NoError(err)
 			historyW.Events = append(historyW.Events, events...)
 
 			events = s.genRandomEvents([]int64{9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1)
 			err = s.appendNewNode(bi, events, 4000)
-			s.Nil(err)
+			s.NoError(err)
 			historyW.Events = append(historyW.Events, events...)
 
 			// read branch to verify
@@ -400,7 +400,7 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyCreateAndAppendBranches() {
 			// override with smaller txn_id
 			events := s.genRandomEvents([]int64{5}, 1)
 			err := s.appendNewNode(branch, events, 0)
-			s.Nil(err)
+			s.NoError(err)
 			// it shouldn't change anything
 			events = s.read(branch, 1, 25)
 			s.Equal(20, len(events))
@@ -408,7 +408,7 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyCreateAndAppendBranches() {
 			// override with greatest txn_id
 			events = s.genRandomEvents([]int64{5}, 1)
 			err = s.appendNewNode(branch, events, 3000)
-			s.Nil(err)
+			s.NoError(err)
 
 			// read to verify override success, at this point history is corrupted, missing 6/7/8, so we should only see 5 events
 			events = s.read(branch, 1, 6)
@@ -420,7 +420,7 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyCreateAndAppendBranches() {
 			// override with even larger txn_id and same version
 			events = s.genRandomEvents([]int64{5, 6}, 1)
 			err = s.appendNewNode(branch, events, 3001)
-			s.Nil(err)
+			s.NoError(err)
 
 			// read to verify override success, at this point history is corrupted, missing 7/8, so we should only see 6 events
 			events = s.read(branch, 1, 7)
@@ -432,14 +432,14 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyCreateAndAppendBranches() {
 			// override more with larger txn_id, this would fix the corrupted hole so that we cna get 20 events again
 			events = s.genRandomEvents([]int64{7, 8}, 1)
 			err = s.appendNewNode(branch, events, 3002)
-			s.Nil(err)
+			s.NoError(err)
 
 			// read to verify override
 			events = s.read(branch, 1, 25)
 			s.Equal(20, len(events))
 			events = s.genRandomEvents([]int64{9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}, 1)
 			err = s.appendNewNode(branch, events, 4001)
-			s.Nil(err)
+			s.NoError(err)
 			events = s.read(branch, 1, 25)
 			s.Equal(23, len(events))
 		}(i)
@@ -451,7 +451,7 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyCreateAndAppendBranches() {
 		br := v.([]byte)
 		// delete old branches along with create new branches
 		err := s.deleteHistoryBranch(br)
-		s.Nil(err)
+		s.NoError(err)
 		return true
 	})
 
@@ -465,7 +465,7 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 	wg := sync.WaitGroup{}
 	concurrency := 10
 	masterBr, err := s.newHistoryBranch(treeID)
-	s.Nil(err)
+	s.NoError(err)
 	branches := s.descTree(treeID)
 	s.Equal(0, len(branches))
 
@@ -476,10 +476,10 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 	}
 	events := s.genRandomEvents(eids, 1)
 	err = s.appendNewBranchAndFirstNode(masterBr, events[0:1], 1, "masterbr")
-	s.Nil(err)
+	s.NoError(err)
 
 	readEvents := s.read(masterBr, 1, int64(concurrency)+2)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, len(readEvents))
 
 	branches = s.descTree(treeID)
@@ -498,9 +498,9 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 	}
 
 	err = s.appendOneByOne(masterBr, events[1:], reserveTxn(len(events[1:])))
-	s.Nil(err)
+	s.NoError(err)
 	events = s.read(masterBr, 1, int64(concurrency)+2)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal((concurrency)+1, len(events))
 
 	level1ID := new(sync.Map)
@@ -515,7 +515,7 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 			level1ID.Store(idx, forkNodeID)
 
 			bi, err := s.fork(masterBr, forkNodeID)
-			s.Nil(err)
+			s.NoError(err)
 			level1Br.Store(idx, bi)
 
 			// cannot append to ancestors
@@ -532,18 +532,18 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 			events = s.genRandomEvents(eids, 1)
 
 			err = s.appendNewNode(bi, events[0:1], reserveTxn(1))
-			s.Nil(err)
+			s.NoError(err)
 
 			err = s.appendOneByOne(bi, events[1:], reserveTxn(len(events[1:])))
-			s.Nil(err)
+			s.NoError(err)
 
 			events = s.read(bi, 1, int64(concurrency)*2+2)
-			s.Nil(err)
+			s.NoError(err)
 			s.Equal((concurrency)*2+1, len(events))
 
 			if idx == 0 {
 				err = s.deleteHistoryBranch(bi)
-				s.Nil(err)
+				s.NoError(err)
 			}
 
 		}(i)
@@ -572,7 +572,7 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 			}
 
 			bi, err := s.fork(forkBr, forkNodeID)
-			s.Nil(err)
+			s.NoError(err)
 			level2Br.Store(idx, bi)
 
 			// append second batch to second level
@@ -582,29 +582,29 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 			}
 			events := s.genRandomEvents(eids, 1)
 			err = s.appendNewNode(bi, events[0:1], reserveTxn(1))
-			s.Nil(err)
+			s.NoError(err)
 			err = s.appendOneByOne(bi, events[1:], reserveTxn(len(events[1:])))
-			s.Nil(err)
+			s.NoError(err)
 			events = s.read(bi, 1, int64(concurrency)*3+2)
-			s.Nil(err)
+			s.NoError(err)
 			s.Equal((concurrency)*3+1, len(events))
 
 			// try override last event
 			events = s.genRandomEvents([]int64{int64(concurrency)*3 + 1}, 1)
 			err = s.appendNewNode(bi, events, reserveTxn(1))
-			s.Nil(err)
+			s.NoError(err)
 			events = s.read(bi, 1, int64(concurrency)*3+2)
-			s.Nil(err)
+			s.NoError(err)
 			s.Equal((concurrency)*3+1, len(events))
 
 			// test fork and newBranch concurrently
 			bi, err = s.newHistoryBranch(treeID)
-			s.Nil(err)
+			s.NoError(err)
 			level2Br.Store(concurrency+idx, bi)
 
 			events = s.genRandomEvents([]int64{1}, 1)
 			err = s.appendNewBranchAndFirstNode(bi, events, reserveTxn(1), "newbr")
-			s.Nil(err)
+			s.NoError(err)
 
 		}(i)
 	}
@@ -632,7 +632,7 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 		br := v.([]byte)
 		// delete old branches along with create new branches
 		err := s.deleteHistoryBranch(br)
-		s.Nil(err)
+		s.NoError(err)
 
 		return true
 	})
@@ -640,12 +640,12 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 		br := v.([]byte)
 		// delete old branches along with create new branches
 		err := s.deleteHistoryBranch(br)
-		s.Nil(err)
+		s.NoError(err)
 
 		return true
 	})
 	err = s.deleteHistoryBranch(masterBr)
-	s.Nil(err)
+	s.NoError(err)
 
 	branches = s.descTree(treeID)
 	s.Equal(0, len(branches))
@@ -736,7 +736,7 @@ func (s *HistoryV2PersistenceSuite) descTree(treeID string) []*persistencespb.Hi
 // persistence helper
 func (s *HistoryV2PersistenceSuite) read(branch []byte, minID, maxID int64) []*historypb.HistoryEvent {
 	res, err := s.readWithError(branch, minID, maxID)
-	s.Nil(err)
+	s.NoError(err)
 	return res
 }
 

--- a/common/persistence/serialization/serializer_test.go
+++ b/common/persistence/serialization/serializer_test.go
@@ -81,39 +81,39 @@ func (s *temporalSerializerSuite) TestSerializer() {
 
 			// serialize event
 			nilEvent, err := s.serializer.SerializeEvent(nil)
-			s.Nil(err)
+			s.NoError(err)
 			s.Nil(nilEvent)
 
 			dProto, err := s.serializer.SerializeEvent(event0)
-			s.Nil(err)
+			s.NoError(err)
 			s.NotNil(dProto)
 
 			// serialize batch events
 			nilEvents, err := s.serializer.SerializeEvents(nil)
-			s.Nil(err)
+			s.NoError(err)
 			s.NotNil(nilEvents)
 
 			dsProto, err := s.serializer.SerializeEvents(history0.Events)
-			s.Nil(err)
+			s.NoError(err)
 			s.NotNil(dsProto)
 
 			// deserialize event
 			dNilEvent, err := s.serializer.DeserializeEvent(nilEvent)
-			s.Nil(err)
+			s.NoError(err)
 			s.Nil(dNilEvent)
 
 			event2, err := s.serializer.DeserializeEvent(dProto)
-			s.Nil(err)
+			s.NoError(err)
 			s.ProtoEqual(event0, event2)
 
 			// deserialize events
 			dNilEvents, err := s.serializer.DeserializeEvents(nilEvents)
-			s.Nil(err)
+			s.NoError(err)
 			s.Nil(dNilEvents)
 
 			events, err := s.serializer.DeserializeEvents(dsProto)
 			history2 := &historypb.History{Events: events}
-			s.Nil(err)
+			s.NoError(err)
 			s.ProtoEqual(history0, history2)
 		}()
 	}

--- a/common/persistence/serializer_test.go
+++ b/common/persistence/serializer_test.go
@@ -78,42 +78,42 @@ func (s *temporalSerializerSuite) TestSerializer() {
 			// serialize event
 
 			nilEvent, err := serializer.SerializeEvent(nil)
-			s.Nil(err)
+			s.NoError(err)
 			s.Nil(nilEvent)
 
 			dProto, err := serializer.SerializeEvent(event0)
-			s.Nil(err)
+			s.NoError(err)
 			s.NotNil(dProto)
 
 			// serialize batch events
 
 			nilEvents, err := serializer.SerializeEvents(nil)
-			s.Nil(err)
+			s.NoError(err)
 			s.NotNil(nilEvents)
 
 			dsProto, err := serializer.SerializeEvents(history0.Events)
-			s.Nil(err)
+			s.NoError(err)
 			s.NotNil(dsProto)
 
 			// deserialize event
 
 			dNilEvent, err := serializer.DeserializeEvent(nilEvent)
-			s.Nil(err)
+			s.NoError(err)
 			s.Nil(dNilEvent)
 
 			event2, err := serializer.DeserializeEvent(dProto)
-			s.Nil(err)
+			s.NoError(err)
 			s.ProtoEqual(event0, event2)
 
 			// deserialize events
 
 			dNilEvents, err := serializer.DeserializeEvents(nilEvents)
-			s.Nil(err)
+			s.NoError(err)
 			s.Nil(dNilEvents)
 
 			events, err := serializer.DeserializeEvents(dsProto)
 			history2 := &historypb.History{Events: events}
-			s.Nil(err)
+			s.NoError(err)
 			s.ProtoEqual(history0, history2)
 		}()
 	}

--- a/common/persistence/tests/visibility_persistence_suite.go
+++ b/common/persistence/tests/visibility_persistence_suite.go
@@ -426,7 +426,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStartTime() {
 		PageSize:    2,
 		Query:       queryStr,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, len(resp.Executions))
 	s.assertOpenExecutionEquals(openRecord2, resp.Executions[0])
 
@@ -436,7 +436,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStartTime() {
 		PageSize:    2,
 		Query:       queryStr,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(2, len(resp.Executions))
 
 	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
@@ -444,7 +444,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStartTime() {
 		PageSize:    2,
 		Query:       queryStr + ` AND WorkflowType = "visibility-workflow-1"`,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, len(resp.Executions))
 	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
 }
@@ -497,7 +497,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByType() {
 		PageSize:    2,
 		Query:       `WorkflowType = "visibility-workflow-1"`,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, len(resp.Executions))
 	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
 
@@ -534,7 +534,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByType() {
 		PageSize:    2,
 		Query:       `WorkflowType = "visibility-workflow-2"`,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, len(resp.Executions))
 	s.assertClosedExecutionEquals(closedRecord2, resp.Executions[0])
 }
@@ -587,7 +587,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByWorkflowID() {
 		PageSize:    2,
 		Query:       `WorkflowId = "visibility-filtering-test1"`,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, len(resp.Executions))
 	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
 
@@ -624,7 +624,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByWorkflowID() {
 		PageSize:    2,
 		Query:       `WorkflowId = "visibility-filtering-test2"`,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, len(resp.Executions))
 	s.assertClosedExecutionEquals(closedRecord2, resp.Executions[0])
 }
@@ -685,7 +685,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStatus() {
 		PageSize:    5,
 		Query:       `ExecutionStatus = "Failed"`,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, len(resp.Executions))
 	s.assertClosedExecutionEquals(closeRecord2, resp.Executions[0])
 }
@@ -1057,7 +1057,7 @@ func (s *VisibilityPersistenceSuite) listWithPagination(namespaceID namespace.ID
 		PageSize:    pageSize,
 		Query:       "",
 	})
-	s.Nil(err)
+	s.NoError(err)
 	executions = append(executions, resp.Executions...)
 
 	for len(resp.NextPageToken) > 0 {
@@ -1067,7 +1067,7 @@ func (s *VisibilityPersistenceSuite) listWithPagination(namespaceID namespace.ID
 			Query:         "",
 			NextPageToken: resp.NextPageToken,
 		})
-		s.Nil(err)
+		s.NoError(err)
 		executions = append(executions, resp.Executions...)
 	}
 
@@ -1095,7 +1095,7 @@ func (s *VisibilityPersistenceSuite) createClosedWorkflowRecord(
 		HistoryLength:     5,
 	}
 	err := s.VisibilityMgr.RecordWorkflowExecutionClosed(s.ctx, closeReq)
-	s.Nil(err)
+	s.NoError(err)
 	return closeReq
 }
 
@@ -1125,7 +1125,7 @@ func (s *VisibilityPersistenceSuite) createOpenWorkflowRecord(
 		},
 	}
 	err := s.VisibilityMgr.RecordWorkflowExecutionStarted(s.ctx, startReq)
-	s.Nil(err)
+	s.NoError(err)
 	return startReq
 }
 

--- a/common/persistence/versionhistory/version_history_test.go
+++ b/common/persistence/versionhistory/version_history_test.go
@@ -499,17 +499,17 @@ func (s *versionHistoriesSuite) TestAddGetVersionHistory() {
 	s.Equal(int32(0), histories.CurrentVersionHistoryIndex)
 
 	currentBranchChanged, newVersionHistoryIndex, err := AddAndSwitchVersionHistory(histories, versionHistory2)
-	s.Nil(err)
+	s.NoError(err)
 	s.True(currentBranchChanged)
 	s.Equal(int32(1), newVersionHistoryIndex)
 	s.Equal(int32(1), histories.CurrentVersionHistoryIndex)
 
 	resultVersionHistory1, err := GetVersionHistory(histories, 0)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(versionHistory1, resultVersionHistory1)
 
 	resultVersionHistory2, err := GetVersionHistory(histories, 1)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(versionHistory2, resultVersionHistory2)
 }
 
@@ -529,7 +529,7 @@ func (s *versionHistoriesSuite) TestFindLCAVersionHistoryIndexAndItem_LargerEven
 
 	histories := NewVersionHistories(versionHistory1)
 	_, _, err := AddAndSwitchVersionHistory(histories, versionHistory2)
-	s.Nil(err)
+	s.NoError(err)
 
 	versionHistoryIncoming := NewVersionHistory([]byte("branch token incoming"), []*historyspb.VersionHistoryItem{
 		{EventId: 3, Version: 0},
@@ -539,7 +539,7 @@ func (s *versionHistoriesSuite) TestFindLCAVersionHistoryIndexAndItem_LargerEven
 	})
 
 	item, index, err := FindLCAVersionHistoryItemAndIndex(histories, versionHistoryIncoming)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(int32(0), index)
 	s.Equal(NewVersionHistoryItem(7, 6), item)
 }
@@ -559,7 +559,7 @@ func (s *versionHistoriesSuite) TestFindLCAVersionHistoryIndexAndItem_SameEventI
 
 	histories := NewVersionHistories(versionHistory1)
 	_, _, err := AddAndSwitchVersionHistory(histories, versionHistory2)
-	s.Nil(err)
+	s.NoError(err)
 
 	versionHistoryIncoming := NewVersionHistory([]byte("branch token incoming"), []*historyspb.VersionHistoryItem{
 		{EventId: 3, Version: 0},
@@ -569,7 +569,7 @@ func (s *versionHistoriesSuite) TestFindLCAVersionHistoryIndexAndItem_SameEventI
 	})
 
 	item, index, err := FindLCAVersionHistoryItemAndIndex(histories, versionHistoryIncoming)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(int32(1), index)
 	s.Equal(NewVersionHistoryItem(7, 6), item)
 }
@@ -589,7 +589,7 @@ func (s *versionHistoriesSuite) TestFindFirstVersionHistoryIndexByItem() {
 
 	histories := NewVersionHistories(versionHistory1)
 	_, _, err := AddAndSwitchVersionHistory(histories, versionHistory2)
-	s.Nil(err)
+	s.NoError(err)
 
 	index, err := FindFirstVersionHistoryIndexByVersionHistoryItem(histories, NewVersionHistoryItem(8, 10))
 	s.NoError(err)

--- a/common/rpc/interceptor/dc_redirection_policy_test.go
+++ b/common/rpc/interceptor/dc_redirection_policy_test.go
@@ -78,10 +78,10 @@ func (s *noopDCRedirectionPolicySuite) TestWithNamespaceRedirect() {
 	}
 
 	err := s.policy.WithNamespaceIDRedirect(context.Background(), namespaceID, apiName, callFn)
-	s.Nil(err)
+	s.NoError(err)
 
 	err = s.policy.WithNamespaceRedirect(context.Background(), namespaceName, apiName, callFn)
-	s.Nil(err)
+	s.NoError(err)
 
 	s.Equal(2, callCount)
 }
@@ -134,10 +134,10 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestWithNamespaceRedirect
 	}
 
 	err := s.policy.WithNamespaceIDRedirect(context.Background(), s.namespaceID, apiName, callFn)
-	s.Nil(err)
+	s.NoError(err)
 
 	err = s.policy.WithNamespaceRedirect(context.Background(), s.namespace, apiName, callFn)
-	s.Nil(err)
+	s.NoError(err)
 
 	s.Equal(2, callCount)
 }
@@ -154,10 +154,10 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestWithNamespaceRedirect
 	}
 
 	err := s.policy.WithNamespaceIDRedirect(context.Background(), s.namespaceID, apiName, callFn)
-	s.Nil(err)
+	s.NoError(err)
 
 	err = s.policy.WithNamespaceRedirect(context.Background(), s.namespace, apiName, callFn)
-	s.Nil(err)
+	s.NoError(err)
 
 	s.Equal(2, callCount)
 }
@@ -174,10 +174,10 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestWithNamespaceRedirect
 	}
 
 	err := s.policy.WithNamespaceIDRedirect(context.Background(), s.namespaceID, apiName, callFn)
-	s.Nil(err)
+	s.NoError(err)
 
 	err = s.policy.WithNamespaceRedirect(context.Background(), s.namespace, apiName, callFn)
-	s.Nil(err)
+	s.NoError(err)
 
 	s.Equal(2, callCount)
 }
@@ -194,10 +194,10 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestWithNamespaceRedirect
 
 	for apiName := range selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs {
 		err := s.policy.WithNamespaceIDRedirect(context.Background(), s.namespaceID, apiName, callFn)
-		s.Nil(err)
+		s.NoError(err)
 
 		err = s.policy.WithNamespaceRedirect(context.Background(), s.namespace, apiName, callFn)
-		s.Nil(err)
+		s.NoError(err)
 	}
 
 	s.Equal(2*len(selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs), callCount)
@@ -215,10 +215,10 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestGetTargetDataCenter_G
 
 	for apiName := range selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs {
 		err := s.policy.WithNamespaceIDRedirect(context.Background(), s.namespaceID, apiName, callFn)
-		s.Nil(err)
+		s.NoError(err)
 
 		err = s.policy.WithNamespaceRedirect(context.Background(), s.namespace, apiName, callFn)
-		s.Nil(err)
+		s.NoError(err)
 	}
 
 	s.Equal(2*len(selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs), callCount)
@@ -236,10 +236,10 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestGetTargetDataCenter_G
 
 	for apiName := range selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs {
 		err := s.policy.WithNamespaceIDRedirect(context.Background(), s.namespaceID, apiName, callFn)
-		s.Nil(err)
+		s.NoError(err)
 
 		err = s.policy.WithNamespaceRedirect(context.Background(), s.namespace, apiName, callFn)
-		s.Nil(err)
+		s.NoError(err)
 	}
 
 	s.Equal(2*len(selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs), callCount)
@@ -296,10 +296,10 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestGetTargetDataCenter_G
 					api = api + "_notwhitelisted"
 				}
 				err := s.policy.WithNamespaceIDRedirect(context.Background(), s.namespaceID, api, callFn)
-				s.Nil(err)
+				s.NoError(err)
 
 				err = s.policy.WithNamespaceRedirect(context.Background(), s.namespace, api, callFn)
-				s.Nil(err)
+				s.NoError(err)
 			}
 
 			s.Equal(tc.expectedCallCount, callCountByCluster)
@@ -327,10 +327,10 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestGetTargetDataCenter_G
 
 	for apiName := range selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs {
 		err := s.policy.WithNamespaceIDRedirect(context.Background(), s.namespaceID, apiName, callFn)
-		s.Nil(err)
+		s.NoError(err)
 
 		err = s.policy.WithNamespaceRedirect(context.Background(), s.namespace, apiName, callFn)
-		s.Nil(err)
+		s.NoError(err)
 	}
 
 	s.Equal(2*len(selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs), currentClustercallCount)
@@ -357,10 +357,10 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestGetTargetDataCenter_G
 
 	for apiName := range selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs {
 		err := s.policy.WithNamespaceIDRedirect(context.Background(), s.namespaceID, apiName, callFn)
-		s.Nil(err)
+		s.NoError(err)
 
 		err = s.policy.WithNamespaceRedirect(context.Background(), s.namespace, apiName, callFn)
-		s.Nil(err)
+		s.NoError(err)
 	}
 
 	s.Equal(2*len(selectedAPIsForwardingRedirectionPolicyWhitelistedAPIs), currentClustercallCount)
@@ -388,10 +388,10 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestGetTargetDataCenter_G
 
 	apiName := "NotExistRandomAPI"
 	err := s.policy.WithNamespaceIDRedirect(context.Background(), s.namespaceID, apiName, callFn)
-	s.Nil(err)
+	s.NoError(err)
 
 	err = s.policy.WithNamespaceRedirect(context.Background(), s.namespace, apiName, callFn)
-	s.Nil(err)
+	s.NoError(err)
 
 	s.Equal(2, currentClustercallCount)
 	s.Equal(2, alternativeClustercallCount)

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -177,7 +177,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 	var attr *commonpb.SearchAttributes
 
 	err := saValidator.Validate(attr, namespace)
-	s.Nil(err)
+	s.NoError(err)
 
 	intPayload, err := payload.Encode(1)
 	s.NoError(err)

--- a/common/serviceerror/service_error_with_dpanic_test.go
+++ b/common/serviceerror/service_error_with_dpanic_test.go
@@ -47,6 +47,6 @@ func (s *serviceErrorWithDPanicSuite) TestNewDPanicInDev() {
 
 	s.Panics(nil, func() {
 		err := NewInternalErrorWithDPanic(logger, "Must panic!")
-		s.Nil(err)
+		s.NoError(err)
 	})
 }

--- a/service/history/api/command_attr_validator_test.go
+++ b/service/history/api/command_attr_validator_test.go
@@ -315,7 +315,7 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_LocalToLocal(
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testTargetNamespaceID).Return(targetNamespaceEntry, nil)
 
 	err := s.validator.validateCrossNamespaceCall(s.testNamespaceID, s.testTargetNamespaceID)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_LocalToEffectiveLocal_SameCluster() {
@@ -338,7 +338,7 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_LocalToEffect
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testTargetNamespaceID).Return(targetNamespaceEntry, nil)
 
 	err := s.validator.validateCrossNamespaceCall(s.testNamespaceID, s.testTargetNamespaceID)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_LocalToEffectiveLocal_DiffCluster() {
@@ -410,7 +410,7 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_EffectiveLoca
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testTargetNamespaceID).Return(targetNamespaceEntry, nil)
 
 	err := s.validator.validateCrossNamespaceCall(s.testNamespaceID, s.testTargetNamespaceID)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_EffectiveLocalToLocal_DiffCluster() {
@@ -460,7 +460,7 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_EffectiveLoca
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testTargetNamespaceID).Return(targetNamespaceEntry, nil)
 
 	err := s.validator.validateCrossNamespaceCall(s.testNamespaceID, s.testTargetNamespaceID)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_EffectiveLocalToEffectiveLocal_DiffCluster() {
@@ -617,7 +617,7 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_GlobalToGloba
 	targetNamespaceID := s.testNamespaceID
 
 	err := s.validator.validateCrossNamespaceCall(s.testNamespaceID, targetNamespaceID)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *commandAttrValidatorSuite) TestValidateActivityRetryPolicy() {

--- a/service/history/events/cache_test.go
+++ b/service/history/events/cache_test.go
@@ -89,7 +89,7 @@ func (s *eventsCacheSuite) TestEventsCacheHitSuccess() {
 		shardID,
 		EventKey{namespaceID, workflowID, runID, eventID, common.EmptyVersion},
 		eventID, nil)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event, actualEvent)
 }
 
@@ -149,7 +149,7 @@ func (s *eventsCacheSuite) TestEventsCacheMissMultiEventsBatchV2Success() {
 		shardID,
 		EventKey{namespaceID, workflowID, runID, event6.GetEventId(), common.EmptyVersion},
 		event1.GetEventId(), []byte("store_token"))
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event6, actualEvent)
 }
 
@@ -218,7 +218,7 @@ func (s *eventsCacheSuite) TestEventsCacheDisableSuccess() {
 		shardID,
 		EventKey{namespaceID, workflowID, runID, event2.GetEventId(), common.EmptyVersion},
 		event2.GetEventId(), []byte("store_token"))
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event2, actualEvent)
 }
 

--- a/service/history/events/notifier_test.go
+++ b/service/history/events/notifier_test.go
@@ -83,7 +83,7 @@ func (s *notifierSuite) TestSingleSubscriberWatchingEvents() {
 	timerChan := time.NewTimer(time.Second * 2).C
 
 	subscriberID, channel, err := s.notifier.WatchHistoryEvent(definition.NewWorkflowKey(namespaceID, execution.GetWorkflowId(), execution.GetRunId()))
-	s.Nil(err)
+	s.NoError(err)
 
 	go func() {
 		<-timerChan
@@ -94,7 +94,7 @@ func (s *notifierSuite) TestSingleSubscriberWatchingEvents() {
 	s.Equal(historyEvent, msg)
 
 	err = s.notifier.UnwatchHistoryEvent(definition.NewWorkflowKey(namespaceID, execution.GetWorkflowId(), execution.GetRunId()), subscriberID)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *notifierSuite) TestMultipleSubscriberWatchingEvents() {
@@ -127,7 +127,7 @@ func (s *notifierSuite) TestMultipleSubscriberWatchingEvents() {
 
 	watchFunc := func() {
 		subscriberID, channel, err := s.notifier.WatchHistoryEvent(definition.NewWorkflowKey(namespaceID, execution.GetWorkflowId(), execution.GetRunId()))
-		s.Nil(err)
+		s.NoError(err)
 
 		timeourChan := time.NewTimer(time.Second * 10).C
 
@@ -138,7 +138,7 @@ func (s *notifierSuite) TestMultipleSubscriberWatchingEvents() {
 			s.Fail("subscribe to new events timeout")
 		}
 		err = s.notifier.UnwatchHistoryEvent(definition.NewWorkflowKey(namespaceID, execution.GetWorkflowId(), execution.GetRunId()), subscriberID)
-		s.Nil(err)
+		s.NoError(err)
 		waitGroup.Done()
 	}
 

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -330,7 +330,7 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled() {
 	expectedResponse.NextPageToken = nil
 
 	response, err := s.historyEngine.RecordWorkflowTaskStarted(metrics.AddMetricsContext(context.Background()), &request)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(response)
 	s.True(response.StartedTime.AsTime().After(expectedResponse.ScheduledTime.AsTime()))
 	expectedResponse.StartedTime = response.StartedTime
@@ -440,7 +440,7 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled_WithInt
 	expectedResponse.NextPageToken = nil
 
 	response, err := s.historyEngine.RecordWorkflowTaskStarted(metrics.AddMetricsContext(context.Background()), &request)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(response)
 	s.True(response.StartedTime.AsTime().After(expectedResponse.ScheduledTime.AsTime()))
 	expectedResponse.StartedTime = response.StartedTime
@@ -739,7 +739,7 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccess() {
 		},
 	})
 
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(response)
 	s.Equal("wType", response.WorkflowType.Name)
 	s.True(response.PreviousStartedEventId == 0)
@@ -841,7 +841,7 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccessWithInternalRawHistor
 		},
 	})
 
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(response)
 	s.Equal("wType", response.WorkflowType.Name)
 	s.True(response.PreviousStartedEventId == 0)
@@ -938,7 +938,7 @@ func (s *engine2Suite) TestRecordActivityTaskStartedSuccess() {
 			Identity: identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(response)
 	s.Equal(scheduledEvent, response.ScheduledEvent)
 }
@@ -970,7 +970,7 @@ func (s *engine2Suite) TestRequestCancelWorkflowExecution_Running() {
 			Identity: "identity",
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 := s.getMutableState(namespaceID, workflowExecution)
 	s.Equal(int64(4), ms2.GetNextEventID())
@@ -1003,7 +1003,7 @@ func (s *engine2Suite) TestRequestCancelWorkflowExecution_Finished() {
 			Identity: "identity",
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *engine2Suite) TestRequestCancelWorkflowExecution_NotFound() {
@@ -1197,7 +1197,7 @@ func (s *engine2Suite) TestRespondWorkflowTaskCompletedRecordMarkerCommand() {
 			Identity:  identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	ms2 := s.getMutableState(namespaceID, we)
 	s.Equal(int64(6), ms2.GetNextEventID())
 	s.Equal(int64(3), ms2.GetExecutionInfo().LastCompletedWorkflowTaskStartedEventId)
@@ -1272,7 +1272,7 @@ func (s *engine2Suite) TestRespondWorkflowTaskCompleted_StartChildWithSearchAttr
 			Identity:  identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *engine2Suite) TestRespondWorkflowTaskCompleted_StartChildWorkflow_ExceedsLimit() {
@@ -1392,7 +1392,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_BrandNew() {
 			RequestId:                requestID,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(resp.RunId)
 }
 
@@ -1433,7 +1433,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_BrandNew_SearchAttributes() {
 				"CustomKeywordField": payload.EncodeString("test"),
 			}}},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(resp.RunId)
 }
 
@@ -1896,7 +1896,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
 	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil)
 
 	resp, err := s.historyEngine.SignalWithStartWorkflowExecution(metrics.AddMetricsContext(context.Background()), sRequest)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(runID, resp.GetRunId())
 }
 
@@ -1936,7 +1936,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist() {
 	s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.CreateWorkflowExecutionResponse, nil)
 
 	resp, err := s.historyEngine.SignalWithStartWorkflowExecution(metrics.AddMetricsContext(context.Background()), sRequest)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(resp.GetRunId())
 }
 
@@ -1999,7 +1999,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotRunning()
 	s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.CreateWorkflowExecutionResponse, nil)
 
 	resp, err := s.historyEngine.SignalWithStartWorkflowExecution(metrics.AddMetricsContext(context.Background()), sRequest)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(resp.GetRunId())
 	s.NotEqual(runID, resp.GetRunId())
 }

--- a/service/history/history_engine3_eventsv2_test.go
+++ b/service/history/history_engine3_eventsv2_test.go
@@ -262,7 +262,7 @@ func (s *engine3Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled() {
 	expectedResponse.NextPageToken = nil
 
 	response, err := s.historyEngine.RecordWorkflowTaskStarted(context.Background(), &request)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(response)
 	s.True(response.StartedTime.AsTime().After(expectedResponse.ScheduledTime.AsTime()))
 	expectedResponse.StartedTime = response.StartedTime
@@ -376,7 +376,7 @@ func (s *engine3Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled_WithInt
 	expectedResponse.NextPageToken = nil
 
 	response, err := s.historyEngine.RecordWorkflowTaskStarted(context.Background(), &request)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(response)
 	s.True(response.StartedTime.AsTime().After(expectedResponse.ScheduledTime.AsTime()))
 	expectedResponse.StartedTime = response.StartedTime
@@ -413,7 +413,7 @@ func (s *engine3Suite) TestStartWorkflowExecution_BrandNew() {
 			RequestId:                requestID,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(resp.RunId)
 }
 
@@ -467,7 +467,7 @@ func (s *engine3Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
 	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil)
 
 	resp, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(runID, resp.GetRunId())
 }
 
@@ -512,6 +512,6 @@ func (s *engine3Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist() {
 	s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.CreateWorkflowExecutionResponse, nil)
 
 	resp, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(resp.GetRunId())
 }

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -266,7 +266,7 @@ func (s *engineSuite) TestGetMutableStateSync() {
 		NamespaceId: tests.NamespaceID.String(),
 		Execution:   &execution,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(int64(4), response.GetNextEventId())
 	s.Equal(tests.RunID, response.GetFirstExecutionRunId())
 }
@@ -347,7 +347,7 @@ func (s *engineSuite) TestGetMutableStateLongPoll() {
 				Identity:  identity,
 			},
 		})
-		s.Nil(err)
+		s.NoError(err)
 		waitGroup.Done()
 		// right now the next event ID is 5
 	}
@@ -358,7 +358,7 @@ func (s *engineSuite) TestGetMutableStateLongPoll() {
 		Execution:           &execution,
 		ExpectedNextEventId: 3,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(int64(4), response.NextEventId)
 
 	// long poll, new event happen before long poll timeout
@@ -370,7 +370,7 @@ func (s *engineSuite) TestGetMutableStateLongPoll() {
 		ExpectedNextEventId: 4,
 	})
 	s.True(time.Now().UTC().After(start.Add(time.Second)))
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(int64(5), pollResponse.GetNextEventId())
 	waitGroup.Wait()
 }
@@ -425,7 +425,7 @@ func (s *engineSuite) TestGetMutableStateLongPoll_CurrentBranchChanged() {
 		Execution:           execution,
 		ExpectedNextEventId: 3,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(int64(4), response0.GetNextEventId())
 
 	// long poll, new event happen before long poll timeout
@@ -437,7 +437,7 @@ func (s *engineSuite) TestGetMutableStateLongPoll_CurrentBranchChanged() {
 		ExpectedNextEventId: 10,
 	})
 	s.True(time.Now().UTC().After(start.Add(time.Second)))
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(response0.GetCurrentBranchToken(), response1.GetCurrentBranchToken())
 }
 
@@ -469,7 +469,7 @@ func (s *engineSuite) TestGetMutableStateLongPollTimeout() {
 		Execution:           &execution,
 		ExpectedNextEventId: 4,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(int64(4), response.GetNextEventId())
 }
 
@@ -2124,7 +2124,7 @@ func (s *engineSuite) TestRespondWorkflowTaskCompleted_WorkflowTaskHeartbeatNotT
 			Identity:                   identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *engineSuite) TestRespondWorkflowTaskCompleted_WorkflowTaskHeartbeatNotTimeout_ZeroOrignalScheduledTime() {
@@ -2168,7 +2168,7 @@ func (s *engineSuite) TestRespondWorkflowTaskCompleted_WorkflowTaskHeartbeatNotT
 			Identity:                   identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *engineSuite) TestRespondWorkflowTaskCompletedCompleteWorkflowSuccess() {
@@ -3396,7 +3396,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedSuccess() {
 			Identity:  identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(9), ms2.GetNextEventID())
 	s.Equal(int64(3), ms2.GetExecutionInfo().LastCompletedWorkflowTaskStartedEventId)
@@ -3460,7 +3460,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedWithHeartbeatSuccess() {
 			LastHeartbeatDetails: details,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(9), ms2.GetNextEventID())
 	s.Equal(int64(3), ms2.GetExecutionInfo().LastCompletedWorkflowTaskStartedEventId)
@@ -3523,7 +3523,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedByIdSuccess() {
 			Identity:  identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(9), ms2.GetNextEventID())
 	s.Equal(int64(3), ms2.GetExecutionInfo().LastCompletedWorkflowTaskStartedEventId)
@@ -3582,7 +3582,7 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatSuccess_NoTimer() {
 			Details:   detais,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *engineSuite) TestRecordActivityTaskHeartBeatSuccess_TimerRunning() {
@@ -3631,7 +3631,7 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatSuccess_TimerRunning() {
 			Details:   detais,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(7), ms2.GetNextEventID())
 	s.Equal(int64(3), ms2.GetExecutionInfo().LastCompletedWorkflowTaskStartedEventId)
@@ -3685,7 +3685,7 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatByIDSuccess() {
 			Details:   detais,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *engineSuite) TestRespondActivityTaskCanceled_Scheduled() {
@@ -3762,7 +3762,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceled_Started() {
 	activityScheduledEvent, _ := addActivityTaskScheduledEvent(ms, workflowTaskCompletedEvent.EventId, activityID, activityType, tl, activityInput, 100*time.Second, 10*time.Second, 1*time.Second, 1*time.Second)
 	addActivityTaskStartedEvent(ms, activityScheduledEvent.EventId, identity)
 	_, _, err := ms.AddActivityTaskCancelRequestedEvent(workflowTaskCompletedEvent.EventId, activityScheduledEvent.EventId, identity)
-	s.Nil(err)
+	s.NoError(err)
 
 	wfMs := workflow.TestCloneToProto(ms)
 	gwmsResponse := &persistence.GetWorkflowExecutionResponse{State: wfMs}
@@ -3778,7 +3778,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceled_Started() {
 			Details:   payloads.EncodeString("details"),
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(10), ms2.GetNextEventID())
 	s.Equal(int64(3), ms2.GetExecutionInfo().LastCompletedWorkflowTaskStartedEventId)
@@ -3821,7 +3821,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceledById_Started() {
 	activityScheduledEvent, _ := addActivityTaskScheduledEvent(ms, workflowTaskCompletedEvent.EventId, activityID, activityType, tl, activityInput, 100*time.Second, 10*time.Second, 1*time.Second, 1*time.Second)
 	addActivityTaskStartedEvent(ms, activityScheduledEvent.EventId, identity)
 	_, _, err := ms.AddActivityTaskCancelRequestedEvent(workflowTaskCompletedEvent.EventId, activityScheduledEvent.EventId, identity)
-	s.Nil(err)
+	s.NoError(err)
 
 	wfMs := workflow.TestCloneToProto(ms)
 	gwmsResponse := &persistence.GetWorkflowExecutionResponse{State: wfMs}
@@ -3839,7 +3839,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceledById_Started() {
 			Details:   payloads.EncodeString("details"),
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(10), ms2.GetNextEventID())
 	s.Equal(int64(3), ms2.GetExecutionInfo().LastCompletedWorkflowTaskStartedEventId)
@@ -4067,7 +4067,7 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_Scheduled()
 			Identity:  identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(12), ms2.GetNextEventID())
@@ -4132,7 +4132,7 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_Started() {
 			Identity:  identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(11), ms2.GetNextEventID())
@@ -4200,7 +4200,7 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_Completed()
 			Identity:  identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(11), ms2.GetNextEventID())
@@ -4261,7 +4261,7 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_NoHeartBeat
 			Identity:  identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(11), ms2.GetNextEventID())
@@ -4289,7 +4289,7 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_NoHeartBeat
 			Details:   payloads.EncodeString("details"),
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(hbResponse)
 	s.True(hbResponse.CancelRequested)
 
@@ -4304,7 +4304,7 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_NoHeartBeat
 			Details:   payloads.EncodeString("details"),
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 = s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(13), ms2.GetNextEventID())
@@ -4365,7 +4365,7 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_Success() {
 			Identity:  identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(11), ms2.GetNextEventID())
@@ -4393,7 +4393,7 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_Success() {
 			Details:   payloads.EncodeString("details"),
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(hbResponse)
 	s.True(hbResponse.CancelRequested)
 
@@ -4408,7 +4408,7 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_Success() {
 			Details:   payloads.EncodeString("details"),
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 = s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(13), ms2.GetNextEventID())
@@ -4500,7 +4500,7 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_SuccessWith
 			QueryResults: queryResults,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(11), ms2.GetNextEventID())
@@ -4544,7 +4544,7 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_SuccessWith
 			Details:   payloads.EncodeString("details"),
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(hbResponse)
 	s.True(hbResponse.CancelRequested)
 
@@ -4559,7 +4559,7 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_SuccessWith
 			Details:   payloads.EncodeString("details"),
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 = s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(13), ms2.GetNextEventID())
@@ -4615,7 +4615,7 @@ func (s *engineSuite) TestStarTimer_DuplicateTimerID() {
 			Identity:  identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, ms2.GetExecutionState().State)
@@ -4720,7 +4720,7 @@ func (s *engineSuite) TestUserTimer_RespondWorkflowTaskCompleted() {
 			Identity:  identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(10), ms2.GetNextEventID())
@@ -4824,7 +4824,7 @@ func (s *engineSuite) TestCancelTimer_RespondWorkflowTaskCompleted_TimerFired() 
 	addWorkflowTaskStartedEvent(ms, wt2.ScheduledEventID, tl, identity)
 	addTimerFiredEvent(ms, timerID)
 	_, _, err := ms.CloseTransactionAsMutation(historyi.TransactionPolicyActive)
-	s.Nil(err)
+	s.NoError(err)
 
 	wfMs := workflow.TestCloneToProto(ms)
 	gwmsResponse := &persistence.GetWorkflowExecutionResponse{State: wfMs}
@@ -4852,7 +4852,7 @@ func (s *engineSuite) TestCancelTimer_RespondWorkflowTaskCompleted_TimerFired() 
 			Identity:  identity,
 		},
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	ms2 := s.getMutableState(tests.NamespaceID, &we)
 	s.Equal(int64(10), ms2.GetNextEventID())
@@ -4898,7 +4898,7 @@ func (s *engineSuite) TestSignalWorkflowExecution() {
 	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil)
 
 	_, err = s.historyEngine.SignalWorkflowExecution(context.Background(), signalRequest)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 // Test signal workflow task by adding request ID
@@ -4941,7 +4941,7 @@ func (s *engineSuite) TestSignalWorkflowExecution_DuplicateRequest() {
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
 
 	_, err = s.historyEngine.SignalWorkflowExecution(context.Background(), signalRequest)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 // Test signal workflow task by dedup request ID & workflow finished
@@ -4985,7 +4985,7 @@ func (s *engineSuite) TestSignalWorkflowExecution_DuplicateRequest_Completed() {
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
 
 	_, err = s.historyEngine.SignalWorkflowExecution(context.Background(), signalRequest)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *engineSuite) TestSignalWorkflowExecution_Failed() {
@@ -5087,7 +5087,7 @@ func (s *engineSuite) TestSignalWorkflowExecution_WorkflowTaskBackoff() {
 	})
 
 	_, err = s.historyEngine.SignalWorkflowExecution(context.Background(), signalRequest)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *engineSuite) TestRemoveSignalMutableState() {
@@ -5120,7 +5120,7 @@ func (s *engineSuite) TestRemoveSignalMutableState() {
 	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil)
 
 	_, err = s.historyEngine.RemoveSignalMutableState(context.Background(), removeRequest)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *engineSuite) TestReapplyEvents_ReturnSuccess() {

--- a/service/history/ndc/activity_state_replicator_test.go
+++ b/service/history/ndc/activity_state_replicator_test.go
@@ -561,7 +561,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_WorkflowNotFound() {
 	).AnyTimes()
 
 	err := s.nDCActivityStateReplicator.SyncActivityState(context.Background(), request)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *activityReplicatorStateSuite) TestSyncActivities_WorkflowNotFound() {
@@ -598,7 +598,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_WorkflowNotFound() {
 	).AnyTimes()
 
 	err := s.nDCActivityStateReplicator.SyncActivitiesState(context.Background(), request)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *activityReplicatorStateSuite) TestSyncActivity_WorkflowClosed() {
@@ -1035,7 +1035,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_Zombie() {
 	).AnyTimes()
 
 	err = s.nDCActivityStateReplicator.SyncActivityState(context.Background(), request)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityFound_Zombie() {
@@ -1141,7 +1141,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityFound_Zombie()
 	).AnyTimes()
 
 	err = s.nDCActivityStateReplicator.SyncActivitiesState(context.Background(), request)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_NonZombie() {
@@ -1243,7 +1243,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_NonZombie(
 	).AnyTimes()
 
 	err = s.nDCActivityStateReplicator.SyncActivityState(context.Background(), request)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityFound_NonZombie() {
@@ -1349,5 +1349,5 @@ func (s *activityReplicatorStateSuite) TestSyncActivities_ActivityFound_NonZombi
 	).AnyTimes()
 
 	err = s.nDCActivityStateReplicator.SyncActivitiesState(context.Background(), request)
-	s.Nil(err)
+	s.NoError(err)
 }

--- a/service/history/ndc/branch_manager_test.go
+++ b/service/history/ndc/branch_manager_test.go
@@ -130,7 +130,7 @@ func (s *branchMgrSuite) TestCreateNewBranch() {
 		})
 
 	newIndex, err := s.nDCBranchMgr.createNewBranch(context.Background(), baseBranchToken, baseBranchLCAEventID, newVersionHistory)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(int32(1), newIndex)
 
 	compareVersionHistory, err := versionhistory.CopyVersionHistoryUntilLCAVersionHistoryItem(

--- a/service/history/ndc/conflict_resolver_test.go
+++ b/service/history/ndc/conflict_resolver_test.go
@@ -174,7 +174,7 @@ func (s *conflictResolverSuite) TestGetOrRebuildCurrentMutableState_NoRebuild_No
 	)
 	versionHistories := versionhistory.NewVersionHistories(versionHistory0)
 	_, _, err := versionhistory.AddAndSwitchVersionHistory(versionHistories, versionHistory1)
-	s.Nil(err)
+	s.NoError(err)
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{VersionHistories: versionHistories}).AnyTimes()
 
 	rebuiltMutableState, isRebuilt, err := s.nDCConflictResolver.GetOrRebuildCurrentMutableState(context.Background(), 0, version0)
@@ -230,7 +230,7 @@ func (s *conflictResolverSuite) TestGetOrRebuildCurrentMutableState_Rebuild() {
 
 	versionHistories := versionhistory.NewVersionHistories(versionHistory0)
 	_, _, err := versionhistory.AddAndSwitchVersionHistory(versionHistories, versionHistory1)
-	s.Nil(err)
+	s.NoError(err)
 
 	s.mockMutableState.EXPECT().GetUpdateCondition().Return(updateCondition, dbVersion).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
@@ -327,7 +327,7 @@ func (s *conflictResolverSuite) TestGetOrRebuildMutableState_Rebuild() {
 
 	versionHistories := versionhistory.NewVersionHistories(versionHistory0)
 	_, _, err := versionhistory.AddAndSwitchVersionHistory(versionHistories, versionHistory1)
-	s.Nil(err)
+	s.NoError(err)
 
 	s.mockMutableState.EXPECT().GetUpdateCondition().Return(updateCondition, dbVersion).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{

--- a/service/history/ndc/replication_task_test.go
+++ b/service/history/ndc/replication_task_test.go
@@ -66,7 +66,7 @@ func (s *replicationTaskSuite) TestValidateEventsSlice() {
 
 	v, err := validateEventsSlice(eS1, eS2)
 	s.Equal(int64(2), v)
-	s.Nil(err)
+	s.NoError(err)
 
 	v, err = validateEventsSlice(eS1, eS3)
 	s.Equal(int64(0), v)
@@ -112,7 +112,7 @@ func (s *replicationTaskSuite) TestValidateEvents() {
 	}
 
 	v, err := validateEvents(eS1)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(int64(2), v)
 
 	v, err = validateEvents(eS2)

--- a/service/history/replication/eager_namespace_refresher_test.go
+++ b/service/history/replication/eager_namespace_refresher_test.go
@@ -115,7 +115,7 @@ func (s *EagerNamespaceRefresherSuite) TestSyncNamespaceFromSourceCluster_Create
 	s.mockNamespaceRegistry.EXPECT().GetNamespaceByID(namespaceId).Return(nil, serviceerror.NewNamespaceNotFound("namespace not found")).Times(1)
 	s.mockNamespaceRegistry.EXPECT().RefreshNamespaceById(namespaceId).Return(fromAdminClientApiResponse(nsResponse), nil).Times(1)
 	ns, err := s.eagerNamespaceRefresher.SyncNamespaceFromSourceCluster(context.Background(), namespaceId, "currentCluster")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(namespaceId, ns.ID())
 }
 
@@ -156,7 +156,7 @@ func (s *EagerNamespaceRefresherSuite) TestSyncNamespaceFromSourceCluster_Update
 	s.mockNamespaceRegistry.EXPECT().GetNamespaceByID(namespaceId).Return(nil, nil).Times(1)
 	s.mockNamespaceRegistry.EXPECT().RefreshNamespaceById(namespaceId).Return(fromAdminClientApiResponse(nsResponse), nil).Times(1)
 	ns, err := s.eagerNamespaceRefresher.SyncNamespaceFromSourceCluster(context.Background(), namespaceId, "currentCluster")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(namespaceId, ns.ID())
 }
 

--- a/service/history/replication/eventhandler/event_importer_test.go
+++ b/service/history/replication/eventhandler/event_importer_test.go
@@ -212,7 +212,7 @@ func (s *eventImporterSuite) TestImportHistoryEvents_ImportAllLocalAndCommit() {
 		7,
 		1001,
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func serializeEvents(serializer serialization.Serializer, events [][]*historypb.HistoryEvent) []*commonpb.DataBlob {

--- a/service/history/replication/eventhandler/history_events_handler_test.go
+++ b/service/history/replication/eventhandler/history_events_handler_test.go
@@ -125,7 +125,7 @@ func (s *historyEventHandlerSuite) TestHandleHistoryEvents_RemoteOnly() {
 		nil,
 		"",
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *historyEventHandlerSuite) TestHandleHistoryEvents_LocalAndRemote_HandleLocalThenRemote() {
@@ -217,7 +217,7 @@ func (s *historyEventHandlerSuite) TestHandleHistoryEvents_LocalAndRemote_Handle
 		nil,
 		"",
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *historyEventHandlerSuite) TestHandleLocalHistoryEvents_AlreadyExist() {
@@ -268,7 +268,7 @@ func (s *historyEventHandlerSuite) TestHandleLocalHistoryEvents_AlreadyExist() {
 		workflowKey,
 		versionHistory.Items,
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *historyEventHandlerSuite) TestHandleHistoryEvents_LocalOnly_ImportAllLocalAndCommit() {
@@ -325,7 +325,7 @@ func (s *historyEventHandlerSuite) TestHandleHistoryEvents_LocalOnly_ImportAllLo
 		workflowKey,
 		versionHistory.Items,
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *historyEventHandlerSuite) TestHandleHistoryEvents_LocalOnly_ExistButNotEnoughEvents_DataLose() {

--- a/service/history/replication/eventhandler/remote_history_paginated_fetcher_test.go
+++ b/service/history/replication/eventhandler/remote_history_paginated_fetcher_test.go
@@ -191,12 +191,12 @@ func (s *historyPaginatedFetcherSuite) TestGetSingleWorkflowHistoryIterator() {
 	)
 	s.True(fetcher.HasNext())
 	batch, err := fetcher.Next()
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(blob, batch.RawEventBatch)
 
 	s.True(fetcher.HasNext())
 	batch, err = fetcher.Next()
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(blob, batch.RawEventBatch)
 
 	s.False(fetcher.HasNext())
@@ -248,14 +248,14 @@ func (s *historyPaginatedFetcherSuite) TestGetHistory() {
 		pageSize,
 		false,
 	)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(token, nextTokenOut)
 	s.Equal(out[0].RawEventBatch.Data, blob)
 }
 
 func (s *historyPaginatedFetcherSuite) serializeEvents(events []*historypb.HistoryEvent) *commonpb.DataBlob {
 	blob, err := s.serializer.SerializeEvents(events)
-	s.Nil(err)
+	s.NoError(err)
 	return &commonpb.DataBlob{
 		EncodingType: enumspb.ENCODING_TYPE_PROTO3,
 		Data:         blob.Data,

--- a/service/history/replication/eventhandler/resend_handler_test.go
+++ b/service/history/replication/eventhandler/resend_handler_test.go
@@ -327,7 +327,7 @@ func (s *resendHandlerSuite) TestSendSingleWorkflowHistory_AllRemoteEvents() {
 		endEventID,
 		endEventVersion,
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *resendHandlerSuite) TestSendSingleWorkflowHistory_LocalAndRemoteEvents() {
@@ -435,7 +435,7 @@ func (s *resendHandlerSuite) TestSendSingleWorkflowHistory_LocalAndRemoteEvents(
 		endEventID,
 		endEventVersion,
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *resendHandlerSuite) TestSendSingleWorkflowHistory_MixedVersionHistory_RemoteEventsOnly() {
@@ -503,7 +503,7 @@ func (s *resendHandlerSuite) TestSendSingleWorkflowHistory_MixedVersionHistory_R
 		endEventID,
 		endEventVersion,
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *resendHandlerSuite) TestSendSingleWorkflowHistory_AllRemoteEvents_BatchTest() {
@@ -627,12 +627,12 @@ func (s *resendHandlerSuite) TestSendSingleWorkflowHistory_AllRemoteEvents_Batch
 		endEventID,
 		endEventVersion,
 	)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *resendHandlerSuite) serializeEvents(events []*historypb.HistoryEvent) *commonpb.DataBlob {
 	blob, err := s.serializer.SerializeEvents(events)
-	s.Nil(err)
+	s.NoError(err)
 	return &commonpb.DataBlob{
 		EncodingType: enumspb.ENCODING_TYPE_PROTO3,
 		Data:         blob.Data,

--- a/service/history/replication/executable_activity_state_task_test.go
+++ b/service/history/replication/executable_activity_state_task_test.go
@@ -382,7 +382,7 @@ func (s *executableActivityStateTaskSuite) TestBatchedTask_ShouldBatchTogether_A
 		ActivitiesInfo: activityTask.activityInfos,
 	})
 	err := batchResult.Execute()
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *executableActivityStateTaskSuite) TestBatchWith_InvalidBatchTask_ShouldNotBatch() {

--- a/service/history/replication/executable_task_test.go
+++ b/service/history/replication/executable_task_test.go
@@ -594,7 +594,7 @@ func (s *executableTaskSuite) TestResend_TransitionHistoryDisabled() {
 	)
 
 	doContinue, err := s.task.SyncState(context.Background(), syncStateErr, ResendAttempt)
-	s.Nil(err)
+	s.NoError(err)
 	s.False(doContinue)
 }
 
@@ -637,7 +637,7 @@ func (s *executableTaskSuite) TestSyncState_SourceMutableStateHasUnFlushedBuffer
 	).Return(nil, serviceerror.NewWorkflowNotReady("workflow not ready")).Times(1)
 
 	doContinue, err := s.task.SyncState(context.Background(), syncStateErr, ResendAttempt)
-	s.Nil(err)
+	s.NoError(err)
 	s.False(doContinue)
 }
 
@@ -1023,7 +1023,7 @@ func (s *executableTaskSuite) TestGetNamespaceInfo_NotFoundOnCurrentCluster_Sync
 		nil, errors.New("some error"))
 
 	_, toProcess, err := s.task.GetNamespaceInfo(context.Background(), namespaceID)
-	s.Nil(err)
+	s.NoError(err)
 	s.False(toProcess)
 }
 

--- a/service/history/replication/progress_cache_test.go
+++ b/service/history/replication/progress_cache_test.go
@@ -103,7 +103,7 @@ func (s *progressCacheSuite) TestProgressCache() {
 	s.Nil(cachedProgress)
 
 	err := s.progressCache.Update(s.runID, targetClusterID, versionedTransitions, versionHistoryItems)
-	s.Nil(err)
+	s.NoError(err)
 
 	// get existing progress
 	cachedProgress = s.progressCache.Get(s.runID, targetClusterID)
@@ -120,7 +120,7 @@ func (s *progressCacheSuite) TestProgressCache() {
 		versionhistory.NewVersionHistoryItem(firstEventID+1, versionedTransition.NamespaceFailoverVersion),
 	}
 	err = s.progressCache.Update(s.runID, targetClusterID, versionedTransitions2, versionHistoryItems2)
-	s.Nil(err)
+	s.NoError(err)
 
 	expected2 := &ReplicationProgress{
 		versionedTransitions:         [][]*persistencespb.VersionedTransition{versionedTransitions2},
@@ -143,7 +143,7 @@ func (s *progressCacheSuite) TestProgressCache() {
 		versionhistory.NewVersionHistoryItem(firstEventID+1, versionedTransition.NamespaceFailoverVersion+1),
 	}
 	err = s.progressCache.Update(s.runID, targetClusterID, versionedTransitions3, versionHistoryItems3)
-	s.Nil(err)
+	s.NoError(err)
 
 	expected3 := &ReplicationProgress{
 		versionedTransitions:         [][]*persistencespb.VersionedTransition{versionedTransitions2, versionedTransitions3},
@@ -156,7 +156,7 @@ func (s *progressCacheSuite) TestProgressCache() {
 
 	// noop update: versioned transition and version history are already included in the existing progress
 	err = s.progressCache.Update(s.runID, targetClusterID, versionedTransitions, versionHistoryItems)
-	s.Nil(err)
+	s.NoError(err)
 
 	cachedProgress = s.progressCache.Get(s.runID, targetClusterID)
 	s.DeepEqual(expected3, cachedProgress)

--- a/service/history/replication/stream_sender_test.go
+++ b/service/history/replication/stream_sender_test.go
@@ -691,7 +691,7 @@ func (s *streamSenderSuite) TestSendLive() {
 		channel,
 		watermark0,
 	)
-	s.Nil(err)
+	s.NoError(err)
 	s.True(!s.streamSender.IsValid())
 }
 

--- a/service/history/replication/sync_state_retriever_test.go
+++ b/service/history/replication/sync_state_retriever_test.go
@@ -881,10 +881,10 @@ func (s *syncWorkflowStateSuite) TestGetUpdatedSubStateMachine() {
 	s.NoError(err)
 	root.InternalRepr().LastUpdateVersionedTransition = &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 10}
 	child1, err := root.AddChild(hsm.Key{Type: def1.Type(), ID: "child1"}, hsmtest.NewData(hsmtest.State1))
-	s.Nil(err)
+	s.NoError(err)
 	child1.InternalRepr().LastUpdateVersionedTransition = &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 8}
 	child2, err := root.AddChild(hsm.Key{Type: def1.Type(), ID: "child2"}, hsmtest.NewData(hsmtest.State1))
-	s.Nil(err)
+	s.NoError(err)
 	child2.InternalRepr().LastUpdateVersionedTransition = &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 10}
 
 	result, err := s.syncStateRetriever.getUpdatedSubStateMachine(root, &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 9})

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -228,7 +228,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Fire() {
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -303,7 +303,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Noop() {
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -373,7 +373,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessUserTimerTimeout_WfClosed
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -440,7 +440,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessUserTimerTimeout_NoTimerA
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -493,7 +493,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessActivityTimeout_NoRetryPo
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -576,7 +576,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessActivityTimeout_NoRetryPo
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -661,7 +661,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPoli
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -749,7 +749,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPoli
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -855,7 +855,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPoli
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -936,7 +936,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPoli
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1024,7 +1024,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessActivityTimeout_Heartbeat
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1114,7 +1114,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowTaskTimeout_Fire() {
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	startedEvent := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1165,7 +1165,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowTaskTimeout_Noop() {
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	startedEvent := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1218,7 +1218,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowBackoffTimer_Fire() {
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	timerTask := &tasks.WorkflowBackoffTimerTask{
 		WorkflowKey:         workflowKey,
@@ -1264,7 +1264,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowBackoffTimer_Noop() {
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1315,7 +1315,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestActivityRetryTimer_Fire() {
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1404,7 +1404,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestActivityRetryTimer_Noop() {
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1488,7 +1488,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowRunTimeout_Fire() {
 			WorkflowExecutionExpirationTime: timestamppb.New(s.now.Add(expirationTime)),
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	startEvent := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1554,7 +1554,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowRunTimeout_Retry() {
 			WorkflowExecutionExpirationTime: timestamppb.New(s.now.Add(executionRunTimeout)),
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 	// need to override the workflow retry policy
 	executionInfo := mutableState.GetExecutionInfo()
 	executionInfo.HasRetryPolicy = true
@@ -1621,7 +1621,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowRunTimeout_Cron() {
 			WorkflowExecutionExpirationTime: timestamppb.New(s.now.Add(expirationTime)),
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 	mutableState.GetExecutionState().StartTime = timestamppb.New(s.now)
 	mutableState.GetExecutionInfo().CronSchedule = "* * * * *"
 
@@ -1679,7 +1679,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowRunTimeout_WorkflowExpir
 			WorkflowExecutionExpirationTime: timestamppb.New(s.now.Add(-1 * time.Second)),
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 	mutableState.GetExecutionState().StartTime = timestamppb.New(s.now)
 	mutableState.GetExecutionInfo().CronSchedule = "* * * * *"
 
@@ -1740,7 +1740,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowExecutionTimeout_Fire() 
 		uuid.New(),
 		firstRunID,
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	timerTask := &tasks.WorkflowExecutionTimeoutTask{
 		NamespaceID:         s.namespaceID.String(),
@@ -1809,7 +1809,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowExecutionTimeout_Noop() 
 			WorkflowExecutionExpirationTime: timestamppb.New(s.now.Add(10 * time.Second)),
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	timerTask := &tasks.WorkflowExecutionTimeoutTask{
 		NamespaceID:         s.namespaceID.String(),
@@ -1852,7 +1852,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestExecuteChasmPureTimerTask_Zombie
 			StartRequest: &workflowservice.StartWorkflowExecutionRequest{},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 	mutableState.GetExecutionState().State = enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE
 
 	// Add a valid timer task.
@@ -1888,7 +1888,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestExecuteStateMachineTimerTask_Zom
 			StartRequest: &workflowservice.StartWorkflowExecutionRequest{},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 	mutableState.GetExecutionState().State = enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE
 
 	timerTask := &tasks.StateMachineTimerTask{

--- a/service/history/timer_queue_standby_task_executor_test.go
+++ b/service/history/timer_queue_standby_task_executor_test.go
@@ -233,7 +233,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Pending
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -313,7 +313,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Success
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -376,7 +376,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Multipl
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -443,7 +443,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityTimeout_Pending(
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -523,7 +523,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityTimeout_Success(
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -593,7 +593,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityTimeout_Heartbea
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -663,7 +663,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityTimeout_Multiple
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -785,7 +785,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowTaskTimeout_Pend
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	startedEvent := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -871,7 +871,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowTaskTimeout_Succ
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -924,7 +924,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowTaskTimeout_Atte
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1003,7 +1003,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Pen
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	// Flush buffered events so real IDs get assigned
 	mutableState.FlushBufferedEvents()
@@ -1058,7 +1058,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Suc
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	// Flush buffered events so real IDs get assigned
@@ -1108,7 +1108,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowRunTimeout_Pendi
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	startEvent := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1175,7 +1175,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowRunTimeout_Succe
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1232,7 +1232,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowExecutionTimeout
 		uuid.New(),
 		firstRunID,
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	// Flush buffered events so real IDs get assigned
 	mutableState.FlushBufferedEvents()
@@ -1302,7 +1302,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowExecutionTimeout
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	// Flush buffered events so real IDs get assigned
 	mutableState.FlushBufferedEvents()
@@ -1356,7 +1356,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessRetryTimeout() {
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, startEvent.GetEventId(), startEvent.GetVersion())
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil).AnyTimes()
 	timerTask := &tasks.ActivityRetryTimerTask{
@@ -1399,7 +1399,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityRetryTimer_Noop(
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1497,7 +1497,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityRetryTimer_Activ
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1566,7 +1566,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityRetryTimer_Pendi
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1986,7 +1986,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestExecuteStateMachineTimerTask_Zo
 			StartRequest: &workflowservice.StartWorkflowExecutionRequest{},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 	mutableState.GetExecutionState().State = enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE
 
 	timerTask := &tasks.StateMachineTimerTask{

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -262,7 +262,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessActivityTask_Success()
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -391,7 +391,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessActivityTask_Duplicati
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -451,7 +451,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessActivityTask_Paused() 
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -512,7 +512,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessWorkflowTask_FirstWork
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	taskID := s.mustGenerateTaskID()
 	wt := addWorkflowTaskScheduledEvent(mutableState)
@@ -563,7 +563,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessWorkflowTask_NonFirstW
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -620,7 +620,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessWorkflowTask_Sticky_No
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -684,7 +684,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessWorkflowTask_WorkflowT
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -743,7 +743,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessWorkflowTask_Duplicati
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	taskID := s.mustGenerateTaskID()
 	wt := addWorkflowTaskScheduledEvent(mutableState)
@@ -811,7 +811,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_HasPare
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -871,7 +871,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -925,7 +925,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -991,7 +991,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 		Input:             payloads.EncodeString("random input"),
 		ParentClosePolicy: parentClosePolicy1,
 	}, "child namespace1-ID")
-	s.Nil(err)
+	s.NoError(err)
 	_, _, err = mutableState.AddStartChildWorkflowExecutionInitiatedEvent(event.GetEventId(), &commandpb.StartChildWorkflowExecutionCommandAttributes{
 		Namespace:  "child namespace2",
 		WorkflowId: "child workflow2",
@@ -1002,7 +1002,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 		Input:             payloads.EncodeString("random input"),
 		ParentClosePolicy: parentClosePolicy2,
 	}, "child namespace2-ID")
-	s.Nil(err)
+	s.NoError(err)
 	_, _, err = mutableState.AddStartChildWorkflowExecutionInitiatedEvent(event.GetEventId(), &commandpb.StartChildWorkflowExecutionCommandAttributes{
 		Namespace:  "child namespace3",
 		WorkflowId: "child workflow3",
@@ -1013,7 +1013,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 		Input:             payloads.EncodeString("random input"),
 		ParentClosePolicy: parentClosePolicy3,
 	}, "child namespace3-ID")
-	s.Nil(err)
+	s.NoError(err)
 
 	mutableState.FlushBufferedEvents()
 
@@ -1076,7 +1076,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1115,7 +1115,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 			Input:             payloads.EncodeString("random input"),
 			ParentClosePolicy: parentClosePolicy,
 		}, "child namespace1-ID")
-		s.Nil(err)
+		s.NoError(err)
 	}
 
 	mutableState.FlushBufferedEvents()
@@ -1168,7 +1168,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_ParentW
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	mutableState.GetExecutionInfo().ResetRunId = uuid.New() // indicate that the execution was reset.
 	s.mockShard.GetConfig().AllowResetWithPendingChildren = func(namespace string) bool {
@@ -1212,7 +1212,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_ParentW
 			Input:             payloads.EncodeString("random input"),
 			ParentClosePolicy: parentClosePolicy,
 		}, "child namespace1-ID")
-		s.Nil(err)
+		s.NoError(err)
 	}
 
 	mutableState.FlushBufferedEvents()
@@ -1263,7 +1263,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1302,7 +1302,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 			Input:             payloads.EncodeString("random input"),
 			ParentClosePolicy: parentClosePolicy,
 		}, "child namespace1-ID")
-		s.Nil(err)
+		s.NoError(err)
 	}
 
 	mutableState.FlushBufferedEvents()
@@ -1477,7 +1477,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_DeleteA
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1539,7 +1539,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Succes
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1598,7 +1598,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Failur
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1657,7 +1657,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Failur
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1714,7 +1714,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Duplic
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -2025,7 +2025,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Su
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -2143,7 +2143,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Re
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 	mutableState.GetExecutionInfo().OriginalExecutionRunId = originalExecutionRunID
 
 	childInitEvent, _ := addStartChildWorkflowExecutionInitiatedEvent(
@@ -2258,7 +2258,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Fa
 			ContinueAsNewInitiator: enumspb.CONTINUE_AS_NEW_INITIATOR_UNSPECIFIED,
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -2417,7 +2417,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Su
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -2518,7 +2518,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Du
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -2599,7 +2599,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessorStartChildExecution_
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())

--- a/service/history/transfer_queue_standby_task_executor_test.go
+++ b/service/history/transfer_queue_standby_task_executor_test.go
@@ -237,7 +237,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessActivityTask_Pending(
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -390,7 +390,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessActivityTask_Success(
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -453,7 +453,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessActivityTask_Paused()
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -512,7 +512,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessWorkflowTask_Pending(
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	taskID := s.mustGenerateTaskID()
 	wt := addWorkflowTaskScheduledEvent(mutableState)
@@ -573,7 +573,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessWorkflowTask_Success_
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	taskID := s.mustGenerateTaskID()
 	wt := addWorkflowTaskScheduledEvent(mutableState)
@@ -625,7 +625,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessWorkflowTask_Success_
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -700,7 +700,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessCloseExecution() {
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -824,7 +824,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessCancelExecution_Pendi
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -890,7 +890,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessCancelExecution_Succe
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -953,7 +953,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessSignalExecution_Pendi
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1021,7 +1021,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessSignalExecution_Succe
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1083,7 +1083,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessStartChildExecution_P
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -1190,7 +1190,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessStartChildExecution_S
 			ContinueAsNewInitiator: enumspb.CONTINUE_AS_NEW_INITIATOR_UNSPECIFIED,
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())

--- a/service/history/visibility_queue_task_executor_test.go
+++ b/service/history/visibility_queue_task_executor_test.go
@@ -218,7 +218,7 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessCloseExecution() {
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -304,7 +304,7 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessCloseExecutionWithWorkflow
 			},
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	wt := addWorkflowTaskScheduledEvent(mutableState)
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.New())
@@ -374,7 +374,7 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessRecordWorkflowStartedTask(
 			FirstWorkflowTaskBackoff: durationpb.New(backoff),
 		},
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	taskID := int64(59)
 	wt := addWorkflowTaskScheduledEvent(mutableState)

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -1334,7 +1334,7 @@ func (s *mutableStateSuite) TestChecksum() {
 			s.EqualValues(dbState.Checksum, s.mutableState.checksum)
 			s.mutableState.namespaceEntry = s.newNamespaceCacheEntry()
 			csum, err := tc.closeTxFunc(s.mutableState)
-			s.Nil(err)
+			s.NoError(err)
 			s.NotNil(csum.Value)
 			s.Equal(enumsspb.CHECKSUM_FLAVOR_IEEE_CRC32_OVER_PROTO3_BINARY, csum.Flavor)
 			s.Equal(mutableStateChecksumPayloadV1, csum.Version)
@@ -1348,7 +1348,7 @@ func (s *mutableStateSuite) TestChecksum() {
 
 			// generate checksum again and verify its the same
 			csum, err = tc.closeTxFunc(s.mutableState)
-			s.Nil(err)
+			s.NoError(err)
 			s.NotNil(csum.Value)
 			s.Equal(dbState.Checksum.Value, csum.Value)
 
@@ -1736,7 +1736,7 @@ func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchAppl
 		uuid.New(),
 		workflowStartEvent,
 	)
-	s.Nil(err)
+	s.NoError(err)
 
 	// setup transient workflow task
 	wt, err := s.mutableState.ApplyWorkflowTaskScheduledEvent(
@@ -1749,7 +1749,7 @@ func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchAppl
 		nil,
 		enumsspb.WORKFLOW_TASK_TYPE_NORMAL,
 	)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(wt)
 
 	wt, err = s.mutableState.ApplyWorkflowTaskStartedEvent(
@@ -1764,11 +1764,11 @@ func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchAppl
 		nil,
 		int64(0),
 	)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(wt)
 
 	err = s.mutableState.ApplyWorkflowTaskFailedEvent()
-	s.Nil(err)
+	s.NoError(err)
 
 	workflowTaskAttempt = int32(123)
 	newWorkflowTaskScheduleEvent := &historypb.HistoryEvent{
@@ -1806,7 +1806,7 @@ func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchAppl
 		nil,
 		enumsspb.WORKFLOW_TASK_TYPE_NORMAL,
 	)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(wt)
 
 	wt, err = s.mutableState.ApplyWorkflowTaskStartedEvent(
@@ -1821,7 +1821,7 @@ func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchAppl
 		nil,
 		int64(0),
 	)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(wt)
 
 	s.mutableState.SetHistoryBuilder(historybuilder.NewImmutable([]*historypb.HistoryEvent{
@@ -2345,7 +2345,7 @@ func (s *mutableStateSuite) TestSpeculativeWorkflowTaskNotPersisted() {
 
 			// Normal WT is persisted as is.
 			execInfo, err := tc.closeTxFunc(s.mutableState)
-			s.Nil(err)
+			s.NoError(err)
 			s.Equal(enumsspb.WORKFLOW_TASK_TYPE_NORMAL, execInfo.WorkflowTaskType)
 			s.NotEqual(common.EmptyEventID, execInfo.WorkflowTaskScheduledEventId)
 			s.NotEqual(common.EmptyEventID, execInfo.WorkflowTaskStartedEventId)
@@ -2354,7 +2354,7 @@ func (s *mutableStateSuite) TestSpeculativeWorkflowTaskNotPersisted() {
 
 			// Speculative WT is converted to normal.
 			execInfo, err = tc.closeTxFunc(s.mutableState)
-			s.Nil(err)
+			s.NoError(err)
 			s.Equal(enumsspb.WORKFLOW_TASK_TYPE_NORMAL, execInfo.WorkflowTaskType)
 			s.NotEqual(common.EmptyEventID, execInfo.WorkflowTaskScheduledEventId)
 			s.NotEqual(common.EmptyEventID, execInfo.WorkflowTaskStartedEventId)
@@ -2842,7 +2842,7 @@ func (s *mutableStateSuite) TestCloseTransactionUpdateTransition() {
 			}
 
 			execInfo, err := tc.txFunc(s.mutableState)
-			s.Nil(err)
+			s.NoError(err)
 
 			protorequire.ProtoSliceEqual(t, expectedTransitionHistory, execInfo.TransitionHistory)
 		})
@@ -3337,7 +3337,7 @@ func (s *mutableStateSuite) TestCloseTransactionHandleUnknownVersionedTransition
 			execInfo, err := tc.txFunc(s.mutableState)
 			s.NotNil(execInfo.PreviousTransitionHistory)
 			s.Nil(execInfo.TransitionHistory)
-			s.Nil(err)
+			s.NoError(err)
 		})
 	}
 }
@@ -4368,7 +4368,7 @@ func (s *mutableStateSuite) TestExecutionInfoClone() {
 			&info.NamespaceId,
 		}
 	})
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *mutableStateSuite) addChangesForStateReplication(state *persistencespb.WorkflowMutableState) {

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -199,7 +199,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_No
 	s.mockMutableState.EXPECT().SetHistoryTree(nil, timestamp.DurationFromSeconds(100), tests.RunID).Return(nil)
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -248,7 +248,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_Wi
 	s.mockMutableState.EXPECT().SetHistoryTree(nil, timestamp.DurationFromSeconds(100), tests.RunID).Return(nil)
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -281,7 +281,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTimedOut()
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -345,7 +345,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTimedOut_W
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	newRunStateBuilder, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), newRunEvents, newRunID)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(newRunStateBuilder)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 
@@ -382,7 +382,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTerminated
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -440,7 +440,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTerminated
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	newRunStateBuilder, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), newRunEvents, uuid.New())
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(newRunStateBuilder)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 
@@ -478,7 +478,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionFailed() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -542,7 +542,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionFailed_Wit
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	newRunStateBuilder, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), newRunEvents, newRunID)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(newRunStateBuilder)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 
@@ -580,7 +580,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCompleted(
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -643,7 +643,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCompleted_
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	newRunStateBuilder, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), newRunEvents, newRunID)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(newRunStateBuilder)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 
@@ -681,7 +681,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCanceled()
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -794,7 +794,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	newRunStateBuilder, err := s.stateRebuilder.ApplyEvents(
 		context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(continueAsNewEvent), newRunEvents, "",
 	)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(newRunStateBuilder)
 	s.Equal(continueAsNewEvent.TaskId, s.executionInfo.LastRunningClock)
 
@@ -844,7 +844,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	newRunStateBuilder, err := s.stateRebuilder.ApplyEvents(
 		context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(continueAsNewEvent), nil, "",
 	)
-	s.Nil(err)
+	s.NoError(err)
 	s.Nil(newRunStateBuilder)
 	s.Equal(continueAsNewEvent.TaskId, s.executionInfo.LastRunningClock)
 }
@@ -873,7 +873,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionSignaled()
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -901,7 +901,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCancelRequ
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -932,7 +932,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeUpsertWorkflowSearchAttribu
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -963,7 +963,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowPropertiesModified(
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -990,7 +990,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeMarkerRecorded() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1042,7 +1042,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskScheduled() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskStarted() {
@@ -1091,7 +1091,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskStarted() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1136,7 +1136,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskTimedOut() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1180,7 +1180,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskFailed() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1213,7 +1213,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskCompleted() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1258,7 +1258,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerStarted() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1289,7 +1289,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerFired() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1320,7 +1320,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerCanceled() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1378,7 +1378,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskScheduled() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1421,7 +1421,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskStarted() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(startedEvent), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(startedEvent.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1453,7 +1453,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskTimedOut() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1484,7 +1484,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskFailed() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1515,7 +1515,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskCompleted() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1543,7 +1543,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskCancelRequested
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1574,7 +1574,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskCanceled() {
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1627,7 +1627,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeStartChildWorkflowExecution
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1655,7 +1655,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeStartChildWorkflowExecution
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1683,7 +1683,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionStart
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1711,7 +1711,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionTimed
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1739,7 +1739,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionTermi
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1767,7 +1767,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionFaile
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1795,7 +1795,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionCompl
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1852,7 +1852,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeRequestCancelExternalWorkfl
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1880,7 +1880,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeRequestCancelExternalWorkfl
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1908,7 +1908,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeExternalWorkflowExecutionCa
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1936,7 +1936,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionCance
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -1999,7 +1999,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeSignalExternalWorkflowExecu
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -2027,7 +2027,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeSignalExternalWorkflowExecu
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 
@@ -2055,7 +2055,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeExternalWorkflowExecutionSi
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil, "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(event.TaskId, s.executionInfo.LastRunningClock)
 }
 

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -475,7 +475,7 @@ func (s *matchingEngineSuite) testFailAddTaskWithHistoryError(
 	if expectedError != nil {
 		s.ErrorAs(err, &expectedError)
 	} else {
-		s.Nil(err)
+		s.NoError(err)
 	}
 	wg.Wait()
 }
@@ -576,7 +576,7 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues() {
 		NextPageToken: nil,
 	}
 
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(expectedResp, resp)
 }
 
@@ -1685,7 +1685,7 @@ func (s *matchingEngineSuite) TestPollWithExpiredContext() {
 			Identity:  identity,
 		},
 	}, metrics.NoopMetricsHandler)
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(emptyPollActivityTaskQueueResponse, resp)
 }
 
@@ -1715,7 +1715,7 @@ func (s *matchingEngineSuite) TestForceUnloadTaskQueue() {
 			Identity:  identity,
 		}},
 		metrics.NoopMetricsHandler)
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(pollResp)
 
 	// Sanity check: adding a task should succeed with the queue loaded
@@ -2137,14 +2137,14 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch() {
 	// This is only for unit test purpose
 	blm.taskAckManager.setReadLevel(blm.getDB().GetMaxReadLevel(0))
 	batch, err := blm.taskReader.getTaskBatch(context.Background())
-	s.Nil(err)
+	s.NoError(err)
 	s.EqualValues(0, len(batch.tasks))
 	s.EqualValues(blm.getDB().GetMaxReadLevel(0), batch.readLevel)
 	s.True(batch.isReadBatchDone)
 
 	blm.taskAckManager.setReadLevel(0)
 	batch, err = blm.taskReader.getTaskBatch(context.Background())
-	s.Nil(err)
+	s.NoError(err)
 	s.EqualValues(rangeSize, len(batch.tasks))
 	s.EqualValues(rangeSize, batch.readLevel)
 	s.True(batch.isReadBatchDone)
@@ -2177,7 +2177,7 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch() {
 	}
 	s.EqualValues(taskCount-rangeSize, s.taskManager.getTaskCount(dbq))
 	batch, err = blm.taskReader.getTaskBatch(context.Background())
-	s.Nil(err)
+	s.NoError(err)
 	s.True(0 < len(batch.tasks) && len(batch.tasks) <= rangeSize)
 	s.True(batch.isReadBatchDone)
 }

--- a/service/worker/scanner/history/scavenger_test.go
+++ b/service/worker/scanner/history/scavenger_test.go
@@ -156,7 +156,7 @@ func (s *ScavengerTestSuite) TestAllSkipTasksTwoPages() {
 	}, nil)
 
 	hbd, err := s.scavenger.Run(context.Background())
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(4, hbd.SkipCount)
 	s.Equal(0, hbd.SuccessCount)
 	s.Equal(0, hbd.ErrorCount)
@@ -214,7 +214,7 @@ func (s *ScavengerTestSuite) TestAllErrorSplittingTasksTwoPages() {
 	}, nil)
 
 	hbd, err := s.scavenger.Run(context.Background())
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, hbd.SkipCount)
 	s.Equal(0, hbd.SuccessCount)
 	s.Equal(4, hbd.ErrorCount)
@@ -315,7 +315,7 @@ func (s *ScavengerTestSuite) TestNoGarbageTwoPages() {
 	})).Return(ms, nil)
 
 	hbd, err := s.scavenger.Run(context.Background())
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, hbd.SkipCount)
 	s.Equal(4, hbd.SuccessCount)
 	s.Equal(0, hbd.ErrorCount)
@@ -400,32 +400,32 @@ func (s *ScavengerTestSuite) TestDeletingBranchesTwoPages() {
 		},
 	})).Return(nil, serviceerror.NewNotFound(""))
 	branchToken1, err := s.historyBranchUtil.NewHistoryBranch(uuid.New(), uuid.New(), uuid.New(), treeID1, &branchID1, []*persistencespb.HistoryBranchRange{}, 0, 0, 0)
-	s.Nil(err)
+	s.NoError(err)
 	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), protomock.Eq(&persistence.DeleteHistoryBranchRequest{
 		BranchToken: branchToken1,
 		ShardID:     common.WorkflowIDToHistoryShard("namespaceID1", "workflowID1", s.numShards),
 	})).Return(nil)
 	branchToken2, err := s.historyBranchUtil.NewHistoryBranch(uuid.New(), uuid.New(), uuid.New(), treeID2, &branchID2, []*persistencespb.HistoryBranchRange{}, 0, 0, 0)
-	s.Nil(err)
+	s.NoError(err)
 	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), protomock.Eq(&persistence.DeleteHistoryBranchRequest{
 		BranchToken: branchToken2,
 		ShardID:     common.WorkflowIDToHistoryShard("namespaceID2", "workflowID2", s.numShards),
 	})).Return(nil)
 	branchToken3, err := s.historyBranchUtil.NewHistoryBranch(uuid.New(), uuid.New(), uuid.New(), treeID3, &branchID3, []*persistencespb.HistoryBranchRange{}, 0, 0, 0)
-	s.Nil(err)
+	s.NoError(err)
 	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), protomock.Eq(&persistence.DeleteHistoryBranchRequest{
 		BranchToken: branchToken3,
 		ShardID:     common.WorkflowIDToHistoryShard("namespaceID3", "workflowID3", s.numShards),
 	})).Return(nil)
 	branchToken4, err := s.historyBranchUtil.NewHistoryBranch(uuid.New(), uuid.New(), uuid.New(), treeID4, &branchID4, []*persistencespb.HistoryBranchRange{}, 0, 0, 0)
-	s.Nil(err)
+	s.NoError(err)
 	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), protomock.Eq(&persistence.DeleteHistoryBranchRequest{
 		BranchToken: branchToken4,
 		ShardID:     common.WorkflowIDToHistoryShard("namespaceID4", "workflowID4", s.numShards),
 	})).Return(nil)
 
 	hbd, err := s.scavenger.Run(context.Background())
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, hbd.SkipCount)
 	s.Equal(4, hbd.SuccessCount)
 	s.Equal(0, hbd.ErrorCount)
@@ -533,21 +533,21 @@ func (s *ScavengerTestSuite) TestMixesTwoPages() {
 	})).Return(ms, nil)
 
 	branchToken3, err := s.historyBranchUtil.NewHistoryBranch(uuid.New(), uuid.New(), uuid.New(), treeID3, &branchID3, []*persistencespb.HistoryBranchRange{}, 0, 0, 0)
-	s.Nil(err)
+	s.NoError(err)
 	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), protomock.Eq(&persistence.DeleteHistoryBranchRequest{
 		BranchToken: branchToken3,
 		ShardID:     common.WorkflowIDToHistoryShard("namespaceID3", "workflowID3", s.numShards),
 	})).Return(nil)
 
 	branchToken4, err := s.historyBranchUtil.NewHistoryBranch(uuid.New(), uuid.New(), uuid.New(), treeID4, &branchID4, []*persistencespb.HistoryBranchRange{}, 0, 0, 0)
-	s.Nil(err)
+	s.NoError(err)
 	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), protomock.Eq(&persistence.DeleteHistoryBranchRequest{
 		BranchToken: branchToken4,
 		ShardID:     common.WorkflowIDToHistoryShard("namespaceID4", "workflowID4", s.numShards),
 	})).Return(fmt.Errorf("failed to delete history"))
 
 	hbd, err := s.scavenger.Run(context.Background())
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(1, hbd.SkipCount)
 	s.Equal(2, hbd.SuccessCount)
 	s.Equal(2, hbd.ErrorCount)
@@ -715,7 +715,7 @@ func (s *ScavengerTestSuite) TestDeleteWorkflowAfterRetention() {
 	})).Return(nil, nil).Times(1)
 
 	hbd, err := s.scavenger.Run(context.Background())
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, hbd.SkipCount)
 	s.Equal(5, hbd.SuccessCount)
 	s.Equal(0, hbd.ErrorCount)

--- a/tests/gethistory_test.go
+++ b/tests/gethistory_test.go
@@ -513,7 +513,7 @@ func (s *RawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 			WaitNewEvent:    isLongPoll,
 			NextPageToken:   token,
 		})
-		s.Nil(err)
+		s.NoError(err)
 		return responseInner.RawHistory, responseInner.NextPageToken
 	}
 
@@ -526,7 +526,7 @@ func (s *RawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 			MaximumPageSize: int32(100),
 			NextPageToken:   token,
 		})
-		s.Nil(err)
+		s.NoError(err)
 		return responseInner.RawHistory, responseInner.NextPageToken
 	}
 
@@ -675,7 +675,7 @@ func (s *RawHistoryClientSuite) TestGetHistoryReverse() {
 	s.NoError(err)
 
 	wfeResponse, err := s.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
-	s.Nil(err)
+	s.NoError(err)
 
 	eventDefaultOrder := s.GetHistory(s.Namespace().String(), wfeResponse.WorkflowExecutionInfo.Execution)
 	eventDefaultOrder = reverseSlice(eventDefaultOrder)

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -5049,7 +5049,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 					// poll update to ensure same outcome is returned
 					pollRes, err := s.pollUpdate(tv,
 						&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
-					s.Nil(err)
+					s.NoError(err)
 					s.Equal(updateRep.Outcome.String(), pollRes.Outcome.String())
 
 					s.EqualHistoryEvents(`
@@ -5139,7 +5139,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 				// poll update to ensure same outcome is returned
 				pollRes, err := s.pollUpdate(tv,
 					&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
-				s.Nil(err)
+				s.NoError(err)
 				s.Equal(updateRep.Outcome.String(), pollRes.Outcome.String())
 
 				s.EqualHistoryEvents(`
@@ -5248,7 +5248,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 				// poll update to ensure same outcome is returned
 				pollRes, err := s.pollUpdate(tv,
 					&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
-				s.Nil(err)
+				s.NoError(err)
 				s.Equal(updateRep.Outcome.String(), pollRes.Outcome.String())
 			})
 
@@ -5353,7 +5353,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 					// poll update to ensure same outcome is returned
 					pollRes, err := s.pollUpdate(tv,
 						&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
-					s.Nil(err)
+					s.NoError(err)
 					s.Equal(uwsRes1.response.Responses[1].GetUpdateWorkflow().Outcome.String(), pollRes.Outcome.String())
 				})
 			}
@@ -5458,7 +5458,7 @@ func (s *UpdateWorkflowSuite) TestUpdateWithStart() {
 			// poll update to ensure same outcome is returned
 			pollRes, err := s.pollUpdate(tv,
 				&updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED})
-			s.Nil(err)
+			s.NoError(err)
 			s.Equal(updateRep.Outcome.String(), pollRes.Outcome.String())
 		})
 

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -673,7 +673,7 @@ func (s *Versioning3Suite) TestUnpinnedWorkflow_SuccessfulUpdate_TransitionstoNe
 		Namespace: s.Namespace().String(),
 		Execution: execution,
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.NotNil(describeCall)
 
 	// Since the poller accepted the update, the Worker Deployment Version that completed the last workflow task

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -2281,7 +2281,7 @@ func (s *VersioningIntegSuite) TestRedirectWithConcurrentActivities() {
 	var maxStartedTimestamp time.Time
 	for wh.HasNext() {
 		he, err := wh.Next()
-		s.Nil(err)
+		s.NoError(err)
 		var taskStartedStamp *commonpb.WorkerVersionStamp
 		var taskRedirectCounter int64
 		var buildId string
@@ -3997,7 +3997,7 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Versioned_Reachabil
 			Namespace: s.Namespace().String(),
 			Query:     queryARunning,
 		})
-		s.Nil(err)
+		s.NoError(err)
 		return resp.GetCount() > 0
 	}, 5*time.Second, 50*time.Millisecond)
 
@@ -4065,7 +4065,7 @@ func (s *VersioningIntegSuite) TestDescribeTaskQueueEnhanced_Versioned_BasicReac
 			Namespace: s.Namespace().String(),
 			Query:     queryARunning,
 		})
-		s.Nil(err)
+		s.NoError(err)
 		return resp.GetCount() > 0
 	}, 3*time.Second, 50*time.Millisecond)
 
@@ -5083,7 +5083,7 @@ func (s *VersioningIntegSuite) validateWorkflowEventsVersionStamps(
 	checkedInheritedBuildId := false
 	for wh.HasNext() {
 		he, err := wh.Next()
-		s.Nil(err)
+		s.NoError(err)
 		if !checkedInheritedBuildId {
 			// first event
 			checkedInheritedBuildId = true

--- a/tests/worker_deployment_test.go
+++ b/tests/worker_deployment_test.go
@@ -387,7 +387,7 @@ func (s *WorkerDeploymentSuite) TestConflictToken_Describe_SetCurrent_SetRamping
 		Version:        firstVersion.DeploymentVersionString(),
 		ConflictToken:  cT,
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		a := require.New(t)
@@ -411,7 +411,7 @@ func (s *WorkerDeploymentSuite) TestConflictToken_Describe_SetCurrent_SetRamping
 		ConflictToken:           cT,
 		IgnoreMissingTaskQueues: true, // here until we have 'has version started' safeguard in place
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	s.EventuallyWithT(func(t *assert.CollectT) {
 		a := require.New(t)
@@ -1302,7 +1302,7 @@ func (s *WorkerDeploymentSuite) TestSetWorkerDeploymentRampingVersion_Batching()
 		Namespace:      s.Namespace().String(),
 		DeploymentName: tv.DeploymentSeries(),
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(tv.DeploymentVersionString(), resp.GetWorkerDeploymentInfo().GetRoutingConfig().GetRampingVersion())
 
 	s.verifyDescribeWorkerDeployment(resp, &workflowservice.DescribeWorkerDeploymentResponse{
@@ -1374,7 +1374,7 @@ func (s *WorkerDeploymentSuite) TestSetWorkerDeploymentRampingVersion_Unversione
 		Namespace:      s.Namespace().String(),
 		DeploymentName: tv.DeploymentSeries(),
 	})
-	s.Nil(err)
+	s.NoError(err)
 	// nolint:staticcheck // SA1019: old worker versioning
 	s.Equal(worker_versioning.UnversionedVersionId, resp.GetWorkerDeploymentInfo().GetRoutingConfig().GetRampingVersion())
 
@@ -1554,7 +1554,7 @@ func (s *WorkerDeploymentSuite) TestSetCurrentVersion_Batching() {
 		Namespace:      s.Namespace().String(),
 		DeploymentName: tv.DeploymentSeries(),
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	s.verifyDescribeWorkerDeployment(resp, &workflowservice.DescribeWorkerDeploymentResponse{
 		WorkerDeploymentInfo: &deploymentpb.WorkerDeploymentInfo{
@@ -1698,7 +1698,7 @@ func (s *WorkerDeploymentSuite) TestSetCurrentVersion_Unversioned_NoRamp() {
 		Namespace:      s.Namespace().String(),
 		DeploymentName: currentVars.DeploymentSeries(),
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.verifyDescribeWorkerDeployment(resp, &workflowservice.DescribeWorkerDeploymentResponse{
 		WorkerDeploymentInfo: &deploymentpb.WorkerDeploymentInfo{
 			Name:       currentVars.DeploymentSeries(),
@@ -2089,7 +2089,7 @@ func (s *WorkerDeploymentSuite) TestSetWorkerDeploymentRampingVersion_Unversione
 		Namespace:      s.Namespace().String(),
 		DeploymentName: tv.DeploymentSeries(),
 	})
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(worker_versioning.UnversionedVersionId, resp.GetWorkerDeploymentInfo().GetRoutingConfig().GetRampingVersion())
 
 	// check that the current version's task queues have ramping version == __unversioned__
@@ -2849,7 +2849,7 @@ func (s *WorkerDeploymentSuite) TestDeleteWorkerDeployment_ValidDelete() {
 	}
 
 	err = s.SendSignal(s.Namespace().String(), workflowExecution, workerdeployment.SyncDrainageSignalName, signalPayload, tv1.ClientIdentity())
-	s.Nil(err)
+	s.NoError(err)
 
 	// Wait for pollers going away
 	s.EventuallyWithT(func(t *assert.CollectT) {
@@ -2885,7 +2885,7 @@ func (s *WorkerDeploymentSuite) TestDeleteWorkerDeployment_ValidDelete() {
 		DeploymentName: tv1.DeploymentSeries(),
 		Identity:       tv1.ClientIdentity(),
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	// Describe Worker Deployment should give not found
 	s.EventuallyWithT(func(t *assert.CollectT) {
@@ -2978,7 +2978,7 @@ func (s *WorkerDeploymentSuite) tryDeleteVersion(
 		Identity:  tv.ClientIdentity(),
 	})
 	if expectedError == "" {
-		s.Nil(err)
+		s.NoError(err)
 	} else {
 		s.Error(err)
 		s.Contains(err.Error(), expectedError)

--- a/tests/worker_deployment_version_test.go
+++ b/tests/worker_deployment_version_test.go
@@ -317,7 +317,7 @@ func (s *DeploymentVersionSuite) TestDrainageStatus_SetCurrentVersion_NoOpenWFs(
 
 	// SetCurrent tv1
 	err := s.setCurrent(tv1, true)
-	s.Nil(err)
+	s.NoError(err)
 
 	// Both versions have no drainage info and tv1 has it's status updated to current
 	s.checkVersionDrainageAndVersionStatus(ctx, tv1, &deploymentpb.VersionDrainageInfo{}, enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT, false, false)
@@ -326,7 +326,7 @@ func (s *DeploymentVersionSuite) TestDrainageStatus_SetCurrentVersion_NoOpenWFs(
 	baseTime := time.Now()
 	// SetCurrent tv2 --> tv1 starts the child drainage workflow
 	err = s.setCurrent(tv2, true)
-	s.Nil(err)
+	s.NoError(err)
 
 	changed1, checked1 := s.checkVersionDrainageAndVersionStatus(ctx, tv1, &deploymentpb.VersionDrainageInfo{
 		Status: enumspb.VERSION_DRAINAGE_STATUS_DRAINING,
@@ -360,7 +360,7 @@ func (s *DeploymentVersionSuite) TestDrainageStatus_SetCurrentVersion_YesOpenWFs
 
 	// SetCurrent tv1
 	err := s.setCurrent(tv1, true)
-	s.Nil(err)
+	s.NoError(err)
 
 	// both versions have no drainage info and tv1 has it's status updated to current
 	s.checkVersionDrainageAndVersionStatus(ctx, tv1, &deploymentpb.VersionDrainageInfo{}, enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT, false, false)
@@ -372,7 +372,7 @@ func (s *DeploymentVersionSuite) TestDrainageStatus_SetCurrentVersion_YesOpenWFs
 	baseTime := time.Now()
 	// SetCurrent tv2 --> tv1 starts the child drainage workflow
 	err = s.setCurrent(tv2, true)
-	s.Nil(err)
+	s.NoError(err)
 
 	// tv1 should now be "draining" for visibilityGracePeriod duration
 	changed1, checked1 := s.checkVersionDrainageAndVersionStatus(ctx, tv1, &deploymentpb.VersionDrainageInfo{
@@ -405,7 +405,7 @@ func (s *DeploymentVersionSuite) TestDrainageStatus_SetCurrentVersion_YesOpenWFs
 		Reason:   "test",
 		Identity: tv1.ClientIdentity(),
 	})
-	s.Nil(err)
+	s.NoError(err)
 
 	// tv1 should now be "drained"
 	changed4, checked4 := s.checkVersionDrainageAndVersionStatus(ctx, tv1, &deploymentpb.VersionDrainageInfo{
@@ -452,7 +452,7 @@ func (s *DeploymentVersionSuite) TestVersionIgnoresDrainageSignalWhenCurrentOrRa
 
 	// Make it current
 	err := s.setCurrent(tv1, false)
-	s.Nil(err)
+	s.NoError(err)
 
 	// Signal it to be drained. Only do this in tests.
 	versionWorkflowID := worker_versioning.GenerateVersionWorkflowID(tv1.DeploymentSeries(), tv1.BuildID())
@@ -477,7 +477,7 @@ func (s *DeploymentVersionSuite) TestVersionIgnoresDrainageSignalWhenCurrentOrRa
 		},
 	}
 	err = s.SendSignal(s.Namespace().String(), workflowExecution, workerdeployment.SyncDrainageSignalName, signalPayload, tv1.ClientIdentity())
-	s.Nil(err)
+	s.NoError(err)
 
 	// describe version and confirm that it is not drained
 	// add a 3s time requirement so that it does not succeed immediately
@@ -506,7 +506,7 @@ func (s *DeploymentVersionSuite) TestDeleteVersion_DeleteCurrentVersion() {
 
 	// Set version as current
 	err := s.setCurrent(tv1, false)
-	s.Nil(err)
+	s.NoError(err)
 
 	// Deleting this version should fail since the version is current
 	s.tryDeleteVersion(ctx, tv1, workerdeployment.ErrVersionIsCurrentOrRamping, false)
@@ -536,7 +536,7 @@ func (s *DeploymentVersionSuite) TestDeleteVersion_DeleteRampedVersion() {
 
 	// Set version as ramping
 	err := s.setRamping(tv1, 0)
-	s.Nil(err)
+	s.NoError(err)
 
 	// Deleting this version should fail since the version is ramping
 	s.tryDeleteVersion(ctx, tv1, workerdeployment.ErrVersionIsCurrentOrRamping, false)
@@ -598,7 +598,7 @@ func (s *DeploymentVersionSuite) TestDeleteVersion_DrainingVersion() {
 
 	// Make the version current
 	err := s.setCurrent(tv1, false)
-	s.Nil(err)
+	s.NoError(err)
 
 	// Start another version workflow
 	tv2 := testvars.New(s).WithBuildIDNumber(2)
@@ -606,7 +606,7 @@ func (s *DeploymentVersionSuite) TestDeleteVersion_DrainingVersion() {
 
 	// Setting this version to current should start the drainage workflow for version1 and make it draining
 	err = s.setCurrent(tv2, true)
-	s.Nil(err)
+	s.NoError(err)
 
 	// Version should be draining
 	s.checkVersionDrainageAndVersionStatus(ctx, tv1, &deploymentpb.VersionDrainageInfo{
@@ -630,7 +630,7 @@ func (s *DeploymentVersionSuite) TestDeleteVersion_Drained_But_Pollers_Exist() {
 
 	// Make the version current
 	err := s.setCurrent(tv1, false)
-	s.Nil(err)
+	s.NoError(err)
 
 	// Start another version workflow
 	tv2 := testvars.New(s).WithBuildIDNumber(2)
@@ -638,7 +638,7 @@ func (s *DeploymentVersionSuite) TestDeleteVersion_Drained_But_Pollers_Exist() {
 
 	// Setting this version to current should start the drainage workflow for version1
 	err = s.setCurrent(tv2, true)
-	s.Nil(err)
+	s.NoError(err)
 
 	// Signal the first version to be drained. Only do this in tests.
 	s.signalAndWaitForDrained(ctx, tv1)
@@ -670,7 +670,7 @@ func (s *DeploymentVersionSuite) signalAndWaitForDrained(ctx context.Context, tv
 		},
 	}
 	err = s.SendSignal(s.Namespace().String(), workflowExecution, workerdeployment.SyncDrainageSignalName, signalPayload, tv.ClientIdentity())
-	s.Nil(err)
+	s.NoError(err)
 
 	// wait for drained
 	s.EventuallyWithT(func(t *assert.CollectT) {
@@ -710,10 +710,10 @@ func (s *DeploymentVersionSuite) TestVersionScavenger_DeleteOnAdd() {
 
 	// Make tvs[0] current
 	err := s.setCurrent(tvs[0], false)
-	s.Nil(err)
+	s.NoError(err)
 	// Make tvs[1] current, hence tvs[0] should go to draining
 	err = s.setCurrent(tvs[1], false)
-	s.Nil(err)
+	s.NoError(err)
 
 	// stuff above can take a long time, sending some fresh polls to ensure that deletion logic sees them.
 	for i := 0; i < testMaxVersionsInDeployment; i++ {
@@ -913,7 +913,7 @@ func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_InvalidSetCurrentV
 
 	// SetCurrent so that the task queue puts the version in its versions info
 	err := s.setCurrent(tv1, false)
-	s.Nil(err)
+	s.NoError(err)
 
 	// new version with a different registered task-queue
 	tv2 := testvars.New(s).WithBuildIDNumber(2).WithTaskQueue(testvars.New(s.T()).Any().String())
@@ -943,7 +943,7 @@ func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_ValidSetCurrentVer
 
 	// SetCurrent so that the task queue puts the version in its versions info
 	err := s.setCurrent(tv1, false)
-	s.Nil(err)
+	s.NoError(err)
 
 	// new version with a different registered task-queue
 	tv2 := tv.WithBuildIDNumber(2).WithTaskQueue(tv.Any().String())
@@ -953,7 +953,7 @@ func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_ValidSetCurrentVer
 	err = s.setCurrent(tv2, false)
 
 	// SetCurrent tv2 should succeed as task_queue_1, despite missing from the new current version, has no backlogged tasks/add-rate > 0
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_InvalidSetRampingVersion() {
@@ -971,7 +971,7 @@ func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_InvalidSetRampingV
 
 	// SetCurrent so that the task queue puts the version in its versions info
 	err := s.setCurrent(tv1, false)
-	s.Nil(err)
+	s.NoError(err)
 
 	// new version with a different registered task-queue
 	tv2 := tv.WithBuildIDNumber(2).WithTaskQueue(tv.Any().String())
@@ -1002,7 +1002,7 @@ func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_ValidSetRampingVer
 
 	// SetCurrent so that the task queue puts the version in its versions info
 	err := s.setCurrent(tv1, false)
-	s.Nil(err)
+	s.NoError(err)
 
 	// new version with a different registered task-queue
 	tv2 := tv.WithBuildIDNumber(2).WithTaskQueue(tv.Any().String())
@@ -1012,7 +1012,7 @@ func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_ValidSetRampingVer
 	err = s.setRamping(tv2, 0)
 
 	// SetRampingVersion to tv2 should succeed as task_queue_1, despite missing from the new current version, has no backlogged tasks/add-rate > 0
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *DeploymentVersionSuite) TestUpdateVersionMetadata() {
@@ -1246,7 +1246,7 @@ func (s *DeploymentVersionSuite) tryDeleteVersion(
 	}
 	_, err := s.FrontendClient().DeleteWorkerDeploymentVersion(ctx, req)
 	if expectedError == "" {
-		s.Nil(err)
+		s.NoError(err)
 	} else {
 		s.EqualErrorf(err, expectedError, err.Error())
 	}

--- a/tools/cassandra/cqlclient_tests.go
+++ b/tools/cassandra/cqlclient_tests.go
@@ -38,7 +38,7 @@ func (s *CQLClientTestSuite) TestParseCQLFile() {
 
 func (s *CQLClientTestSuite) TestCQLClient() {
 	client, err := newTestCQLClient(s.DBName)
-	s.Nil(err)
+	s.NoError(err)
 	s.RunCreateTest(client)
 	s.RunUpdateTest(client)
 	s.RunDropTest(client)

--- a/tools/cassandra/handler_test.go
+++ b/tools/cassandra/handler_test.go
@@ -57,7 +57,7 @@ func (s *HandlerTestSuite) TestDropKeyspaceError() {
 	args := []string{"./tool", "drop-keyspace", "-f", "--keyspace", ""}
 	app := buildCLIOptions()
 	err := app.Run(args)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *HandlerTestSuite) TestCreateKeyspaceError() {
@@ -70,5 +70,5 @@ func (s *HandlerTestSuite) TestCreateKeyspaceError() {
 	args := []string{"./tool", "create-keyspace", "--keyspace", ""}
 	app := buildCLIOptions()
 	err := app.Run(args)
-	s.Nil(err)
+	s.NoError(err)
 }

--- a/tools/cassandra/setup_task_tests.go
+++ b/tools/cassandra/setup_task_tests.go
@@ -28,11 +28,11 @@ func (s *SetupSchemaTestSuite) TearDownSuite() {
 func (s *SetupSchemaTestSuite) TestCreateKeyspace() {
 	s.Nil(RunTool([]string{"./tool", "create", "-k", "foobar123", "--rf", "1"}))
 	err := s.client.dropKeyspace("foobar123")
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *SetupSchemaTestSuite) TestSetupSchema() {
 	client, err := newTestCQLClient(s.DBName)
-	s.Nil(err)
+	s.NoError(err)
 	s.RunSetupTest(buildCLIOptions(), client, "-k", createTestCQLFileContent(), []string{"tasks", "events"})
 }

--- a/tools/cassandra/update_task_tests.go
+++ b/tools/cassandra/update_task_tests.go
@@ -24,14 +24,14 @@ func (s *UpdateSchemaTestSuite) TearDownSuite() {
 
 func (s *UpdateSchemaTestSuite) TestUpdateSchema() {
 	client, err := newTestCQLClient(s.DBName)
-	s.Nil(err)
+	s.NoError(err)
 	defer client.Close()
 	s.RunUpdateSchemaTest(buildCLIOptions(), client, "-k", createTestCQLFileContent(), []string{"events", "tasks"})
 }
 
 func (s *UpdateSchemaTestSuite) TestDryrun() {
 	client, err := newTestCQLClient(s.DBName)
-	s.Nil(err)
+	s.NoError(err)
 	defer client.Close()
 	dir := "../../schema/cassandra/temporal/versioned"
 	s.RunDryrunTest(buildCLIOptions(), client, "-k", dir, cassandra.Version)

--- a/tools/common/schema/handler_test.go
+++ b/tools/common/schema/handler_test.go
@@ -102,7 +102,7 @@ func (s *HandlerTestSuite) TestValidateUpdateConfig() {
 
 func (s *HandlerTestSuite) assertValidateSetupSucceeds(input *SetupConfig, db DB) {
 	err := validateSetupConfig(input, db)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *HandlerTestSuite) assertValidateSetupFails(input *SetupConfig, db DB) {
@@ -114,7 +114,7 @@ func (s *HandlerTestSuite) assertValidateSetupFails(input *SetupConfig, db DB) {
 
 func (s *HandlerTestSuite) assertValidateUpdateSucceeds(input *UpdateConfig, db DB) {
 	err := validateUpdateConfig(input, db)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *HandlerTestSuite) assertValidateUpdateFails(input *UpdateConfig, db DB) {

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -206,7 +206,7 @@ func (s *UpdateTaskTestSuite) runReadManifestTest(
 
 	file := dir + "/manifest.json"
 	err := os.WriteFile(file, []byte(input), os.FileMode(0644))
-	s.Nil(err)
+	s.NoError(err)
 
 	m, err := readManifest(os.DirFS(dir), ".")
 	if isErr {

--- a/tools/elasticsearch/main_test.go
+++ b/tools/elasticsearch/main_test.go
@@ -33,7 +33,7 @@ func (s *MainTestSuite) TestSetupSchemaError() {
 	args := []string{"./tool", "setup-schema"}
 	app := BuildCLIOptions()
 	err := app.Run(args)
-	s.Nil(err)
+	s.NoError(err)
 }
 
 func (s *MainTestSuite) TestPingError() {
@@ -46,5 +46,5 @@ func (s *MainTestSuite) TestPingError() {
 	args := []string{"./tool", "--endpoint", "http://nonexistent:9200", "ping"}
 	app := BuildCLIOptions()
 	err := app.Run(args)
-	s.Nil(err)
+	s.NoError(err)
 }

--- a/tools/sql/clitest/conn_tests.go
+++ b/tools/sql/clitest/conn_tests.go
@@ -72,7 +72,7 @@ func (s *SQLConnTestSuite) TestParseCQLFile() {
 // TestSQLConn test
 func (s *SQLConnTestSuite) TestSQLConn() {
 	conn, err := newTestConn(s.DBName, s.host, s.port, s.pluginName)
-	s.Nil(err)
+	s.NoError(err)
 	s.RunCreateTest(conn)
 	s.RunUpdateTest(conn)
 	s.RunDropTest(conn)

--- a/tools/sql/clitest/update_task_tests.go
+++ b/tools/sql/clitest/update_task_tests.go
@@ -61,7 +61,7 @@ func (s *UpdateSchemaTestSuite) TearDownSuite() {
 // TestUpdateSchema test
 func (s *UpdateSchemaTestSuite) TestUpdateSchema() {
 	conn, err := newTestConn(s.DBName, s.host, s.port, s.pluginName)
-	s.Nil(err)
+	s.NoError(err)
 	defer conn.Close()
 	s.RunUpdateSchemaTest(sql.BuildCLIOptions(), conn, "--db", s.sqlQuery, []string{"executions", "current_executions"})
 }


### PR DESCRIPTION
## What changed?

Replace use of `s.Nil` with `s.NoError`.

## Why?

Happy linter.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

