### PR TITLE
Fix leaking and modifying history event cache objects

### DIFF
--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -14,7 +14,6 @@ import (
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service/history/api"
@@ -54,7 +53,6 @@ func Invoke(
 	shardContext historyi.ShardContext,
 	workflowConsistencyChecker api.WorkflowConsistencyChecker,
 	tokenSerializer *tasktoken.Serializer,
-	visibilityManager manager.VisibilityManager,
 	matchingClient matchingservice.MatchingServiceClient,
 	testHooks testhooks.TestHooks,
 ) (*historyservice.ExecuteMultiOperationResponse, error) {
@@ -93,7 +91,6 @@ func Invoke(
 			shardContext,
 			workflowConsistencyChecker,
 			tokenSerializer,
-			visibilityManager,
 			startReq,
 			uws.workflowLeaseCallback(ctx),
 		)

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -386,7 +386,6 @@ func (e *historyEngineImpl) StartWorkflowExecution(
 		e.shardContext,
 		e.workflowConsistencyChecker,
 		e.tokenSerializer,
-		e.persistenceVisibilityMgr,
 		startRequest,
 		api.NewWorkflowLeaseAndContext,
 	)
@@ -408,7 +407,6 @@ func (e *historyEngineImpl) ExecuteMultiOperation(
 		e.shardContext,
 		e.workflowConsistencyChecker,
 		e.tokenSerializer,
-		e.persistenceVisibilityMgr,
 		e.matchingClient,
 		e.testHooks,
 	)

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -1394,6 +1394,8 @@ func (s *engine2Suite) TestStartWorkflowExecution_BrandNew() {
 	})
 	s.Nil(err)
 	s.NotNil(resp.RunId)
+	s.True(resp.Started)
+	s.Nil(resp.EagerWorkflowTask)
 }
 
 func (s *engine2Suite) TestStartWorkflowExecution_BrandNew_SearchAttributes() {
@@ -1435,6 +1437,8 @@ func (s *engine2Suite) TestStartWorkflowExecution_BrandNew_SearchAttributes() {
 	})
 	s.Nil(err)
 	s.NotNil(resp.RunId)
+	s.True(resp.Started)
+	s.Nil(resp.EagerWorkflowTask)
 }
 
 func makeMockStartRequest(

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -5307,8 +5307,6 @@ func (s *engineSuite) TestReapplyEvents_ResetWorkflow() {
 func (s *engineSuite) TestEagerWorkflowStart_DoesNotCreateTransferTask() {
 	var recordedTasks []tasks.Task
 
-	s.mockVisibilityMgr.EXPECT().GetIndexName().Return("mock")
-	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes("mock", false).Return(searchattribute.NameTypeMap{}, nil)
 	s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, request *persistence.CreateWorkflowExecutionRequest) (*persistence.CreateWorkflowExecutionResponse, error) {
 		recordedTasks = request.NewWorkflowSnapshot.Tasks[tasks.CategoryTransfer]
 		persistenceResponse := persistence.CreateWorkflowExecutionResponse{NewMutableStateStats: tests.CreateWorkflowExecutionResponse.NewMutableStateStats}
@@ -5337,11 +5335,12 @@ func (s *engineSuite) TestEagerWorkflowStart_DoesNotCreateTransferTask() {
 		return response, err
 	})
 	s.NoError(err)
-	s.Equal(len(response.(*historyservice.StartWorkflowExecutionResponse).EagerWorkflowTask.History.Events), 3)
-	s.Equal(response.(*historyservice.StartWorkflowExecutionResponse).EagerWorkflowTask.History.Events[0].EventType, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED)
-	s.Equal(response.(*historyservice.StartWorkflowExecutionResponse).EagerWorkflowTask.History.Events[1].EventType, enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED)
-	s.Equal(response.(*historyservice.StartWorkflowExecutionResponse).EagerWorkflowTask.History.Events[2].EventType, enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED)
-	s.Equal(len(recordedTasks), 0)
+	startResp := response.(*historyservice.StartWorkflowExecutionResponse)
+	s.Len(startResp.EagerWorkflowTask.History.Events, 3)
+	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED, startResp.EagerWorkflowTask.History.Events[0].EventType)
+	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED, startResp.EagerWorkflowTask.History.Events[1].EventType)
+	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED, startResp.EagerWorkflowTask.History.Events[2].EventType)
+	s.Empty(recordedTasks)
 }
 
 func (s *engineSuite) TestEagerWorkflowStart_FromCron_SkipsEager() {
@@ -5381,6 +5380,53 @@ func (s *engineSuite) TestEagerWorkflowStart_FromCron_SkipsEager() {
 	s.NoError(err)
 	s.Nil(response.(*historyservice.StartWorkflowExecutionResponse).EagerWorkflowTask)
 	s.Equal(len(recordedTasks), 0)
+}
+
+func (s *engineSuite) TestEagerWorkflowStart_WithSearchAttributes() {
+	var recordedTasks []tasks.Task
+
+	s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, request *persistence.CreateWorkflowExecutionRequest) (*persistence.CreateWorkflowExecutionResponse, error) {
+		recordedTasks = request.NewWorkflowSnapshot.Tasks[tasks.CategoryTransfer]
+		persistenceResponse := persistence.CreateWorkflowExecutionResponse{NewMutableStateStats: tests.CreateWorkflowExecutionResponse.NewMutableStateStats}
+		return &persistenceResponse, nil
+	})
+
+	searchAttributes := &commonpb.SearchAttributes{
+		IndexedFields: map[string]*commonpb.Payload{
+			"Keyword01": payload.EncodeString("random-keyword"),
+		},
+	}
+	i := interceptor.NewTelemetryInterceptor(s.mockShard.GetNamespaceRegistry(),
+		s.mockShard.GetMetricsHandler(),
+		s.mockShard.Resource.Logger,
+		s.config.LogAllReqErrors,
+		s.mockErrorHandler)
+	response, err := i.UnaryIntercept(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "StartWorkflowExecution"}, func(ctx context.Context, req interface{}) (interface{}, error) {
+		response, err := s.historyEngine.StartWorkflowExecution(ctx, &historyservice.StartWorkflowExecutionRequest{
+			NamespaceId: tests.NamespaceID.String(),
+			Attempt:     1,
+			StartRequest: &workflowservice.StartWorkflowExecutionRequest{
+				WorkflowId:            "test",
+				Namespace:             tests.Namespace.String(),
+				WorkflowType:          &commonpb.WorkflowType{Name: "test"},
+				TaskQueue:             &taskqueuepb.TaskQueue{Kind: enumspb.TASK_QUEUE_KIND_NORMAL, Name: "test"},
+				Identity:              "test",
+				RequestId:             "test",
+				SearchAttributes:      searchAttributes,
+				RequestEagerExecution: true,
+			},
+		})
+		return response, err
+	})
+	s.NoError(err)
+	startResp := response.(*historyservice.StartWorkflowExecutionResponse)
+	s.Len(startResp.EagerWorkflowTask.History.Events, 3)
+	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED, startResp.EagerWorkflowTask.History.Events[0].EventType)
+	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED, startResp.EagerWorkflowTask.History.Events[1].EventType)
+	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED, startResp.EagerWorkflowTask.History.Events[2].EventType)
+	workflowStartedEventAttr := startResp.EagerWorkflowTask.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
+	s.Equal(searchAttributes.IndexedFields, workflowStartedEventAttr.GetSearchAttributes().GetIndexedFields())
+	s.Empty(recordedTasks)
 }
 
 func (s *engineSuite) TestGetHistory() {


### PR DESCRIPTION
## What changed?
Alias search attributes of WorkflowStartedEvent in the eager workflow task in the StartWorkflowResponse in frontend instead of history.

## Why?
Modifying in history modifies the object in history cache, which breaks the retry logic.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
