### PR TITLE
Add automatic eviction of stale internode gRPC connections

### DIFF
--- a/common/rpc/rpc_membership_test.go
+++ b/common/rpc/rpc_membership_test.go
@@ -1,0 +1,113 @@
+package rpc
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/membership"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/primitives"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func TestRPCFactoryRemovesStaleConnectionsOnMembershipUpdate(t *testing.T) {
+	const targetAddress = "matching-host:7235"
+
+	// Setup
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockMonitor := membership.NewMockMonitor(ctrl)
+	mockResolver := membership.NewMockServiceResolver(ctrl)
+
+	listener := bufconn.Listen(1024 * 1024)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	server := grpc.NewServer()
+	t.Cleanup(server.Stop)
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	dialOptions := []grpc.DialOption{
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+	}
+
+	factory := NewFactory(
+		&config.Config{
+			Services: map[string]config.Service{
+				string(primitives.MatchingService): {
+					RPC: config.RPC{},
+				},
+			},
+		},
+		primitives.HistoryService,
+		log.NewNoopLogger(),
+		metrics.NoopMetricsHandler,
+		nil,
+		"frontend:7233",
+		"",
+		0,
+		nil,
+		dialOptions,
+		nil,
+		mockMonitor,
+	)
+
+	// Add expectations
+
+	var listenerChan chan<- *membership.ChangedEvent
+
+	mockMonitor.EXPECT().GetResolver(primitives.MatchingService).Return(mockResolver, nil).Times(1)
+	mockResolver.EXPECT().
+		AddListener(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ string, ch chan<- *membership.ChangedEvent) error {
+			listenerChan = ch
+			return nil
+		}).
+		Times(1)
+	mockResolver.EXPECT().RemoveListener(gomock.Any()).Return(nil).AnyTimes()
+
+	// Create the first connection and validate it
+
+	conn1 := factory.CreateMatchingGRPCConnection(targetAddress)
+	require.NotNil(t, conn1)
+	t.Cleanup(func() { _ = conn1.Close() })
+
+	require.NotNil(t, listenerChan, "membership listener channel not captured")
+	require.Same(t, conn1, factory.interNodeGrpcConnections.Get(targetAddress))
+
+	// Next pretend the host has been removed
+
+	listenerChan <- &membership.ChangedEvent{
+		HostsRemoved: []membership.HostInfo{membership.NewHostInfoFromAddress(targetAddress)},
+	}
+
+	// Now we expect that the first connection has been dropped
+
+	require.Eventually(t, func() bool {
+		conn := factory.interNodeGrpcConnections.Get(targetAddress)
+		return conn == nil
+	}, time.Second, 10*time.Millisecond)
+
+	mockMonitor.EXPECT().GetResolver(primitives.MatchingService).Times(0)
+	mockResolver.EXPECT().AddListener(gomock.Any(), gomock.Any()).Times(0)
+
+	// Finally create a new connection to the same address, we expect to get a new one
+
+	conn2 := factory.CreateMatchingGRPCConnection(targetAddress)
+	require.NotNil(t, conn2)
+	require.NotSame(t, conn1, conn2)
+	t.Cleanup(func() { _ = conn2.Close() })
+}


### PR DESCRIPTION
## What changed?

This PR evicts internode gRPC connections from the `interNodeGrpcConnections` cache when a node is removed from the membership ring.

It does by adding a membership listener per service, spawning a goroutine that listens for `HostsRemoved` and `HostsChanged` events and removes each host from the cache.

## Why?

We started deploying a self-hosted Temporal cluster on Kubernetes with the official Helm chart and today I noticed something strange, the different services logged a lot of warnings like this:

```
{
    "level": "warn",
    "ts": "2025-11-03T18:16:34.230Z",
    "msg": "network dial error",
    "service": "client",
    "address": "10.154.98.162:7235",
    "totalDuration": 20.000332771,
    "error": "dial tcp 10.154.98.162:7235: i/o timeout",
    "error-type": "context.DeadlineExceeded",
    "connectDuration": 20.00032146,
    "connectAddr": "10.154.98.162:7235",
    "connectErr": "dial tcp 10.154.98.162:7235: i/o timeout",
    "logging-call-at": "/home/runner/work/docker-builds/docker-builds/temporal/common/rpc/dial_tracer.go:73"
}
```

Initially I assumed there was a load issue but looking further into it I realised that this address did not exist anymore: the pod that initially had that IP address didn't exist anymore.
I confirmed that it was the case for a bunch of the warnings I was seeing for the History, Frontend and Matching services.

I validated that the membership ring didn't have stale information by looking in Cassandra and also using `tcl admin membership list_gossip`: everything was OK, it only listed IP addresses for pods that existed.

So I investigated with the help of Codex to find out when and how the Temporal could keep stale IP addresses to connect to and I found out that, as far as I understand, the `RPCFactory` has a _internode connections cache_ that is never cleaned, meaning the process `*grpc.ClientConn` is forever trying to re-dial a stale IP address.

This change then adds a internode connection eviction mechanism using the monitor and membership listener.

How it works is simple:
* if needed, start a membership listener when a connection is created
* spawn a goroutine that uses the listener to receive membership change events
* if a host is removed or changed, delete its cache entry which will in turn close the connection

I deployed and tested it on our cluster and can confirm the changes does what I intended; i tracked the `service_dial_error` and `service_dial_latency_bucket` in Grafana to visualize the effect:

<img width="2542" height="1173" alt="service_dial_errors" src="https://github.com/user-attachments/assets/ad867fe6-300a-4b98-8112-013b446bfd68" />
<img width="2544" height="1174" alt="service_dial_latency" src="https://github.com/user-attachments/assets/86d95538-7bee-4d5d-b6ca-6a50b955824f" />

I also added a unit test to validate that it works using the mock monitor and resolver.

**Disclaimer**: this was written with the help of Claude Code.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

Since it touches the internode gRPC connections the changes may be dangerous for some reason I'm not aware of, I'm not familiar with the code base so I may be missing things.