### PR TITLE
Fix search attributes Decode function

### DIFF
--- a/common/searchattribute/encode.go
+++ b/common/searchattribute/encode.go
@@ -61,12 +61,8 @@ func Decode(
 		if typeMap != nil {
 			var err error
 			saType, err = typeMap.getType(saName, customCategory|predefinedCategory)
-			if err != nil {
-				// If the search attribute name is not in typeMap but the payload has type metadata,
-				// we can still decode it (e.g., for CHASM search attributes).
-				if _, hasTypeMetadata := saPayload.Metadata[MetadataType]; !hasTypeMetadata {
-					lastErr = err
-				}
+			if err != nil && !IsChasmSearchAttribute(saName) {
+				lastErr = err
 			}
 		}
 

--- a/common/searchattribute/encode_test.go
+++ b/common/searchattribute/encode_test.go
@@ -3,13 +3,12 @@ package searchattribute
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 )
 
 func Test_Encode_Success(t *testing.T) {
-	assert := assert.New(t)
+	r := require.New(t)
 
 	sa, err := Encode(map[string]interface{}{
 		"key1": "val1",
@@ -27,26 +26,26 @@ func Test_Encode_Success(t *testing.T) {
 		"key6": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	}})
 
-	assert.NoError(err)
-	assert.Len(sa.IndexedFields, 6)
-	assert.Equal(`"val1"`, string(sa.IndexedFields["key1"].GetData()))
-	assert.Equal("Text", string(sa.IndexedFields["key1"].GetMetadata()["type"]))
-	assert.Equal("2", string(sa.IndexedFields["key2"].GetData()))
-	assert.Equal("Int", string(sa.IndexedFields["key2"].GetMetadata()["type"]))
-	assert.Equal("true", string(sa.IndexedFields["key3"].GetData()))
-	assert.Equal("Bool", string(sa.IndexedFields["key3"].GetMetadata()["type"]))
-	assert.Equal("", string(sa.IndexedFields["key4"].GetData()))
-	assert.Equal("Double", string(sa.IndexedFields["key4"].GetMetadata()["type"]))
-	assert.Equal("binary/null", string(sa.IndexedFields["key4"].GetMetadata()["encoding"]))
-	assert.Equal(`["val2","val3"]`, string(sa.IndexedFields["key5"].GetData()))
-	assert.Equal("Keyword", string(sa.IndexedFields["key5"].GetMetadata()["type"]))
-	assert.Equal("json/plain", string(sa.IndexedFields["key5"].GetMetadata()["encoding"]))
-	assert.Equal("[]", string(sa.IndexedFields["key6"].GetData()))
-	assert.Equal("Keyword", string(sa.IndexedFields["key6"].GetMetadata()["type"]))
-	assert.Equal("json/plain", string(sa.IndexedFields["key6"].GetMetadata()["encoding"]))
+	r.NoError(err)
+	r.Len(sa.IndexedFields, 6)
+	r.Equal(`"val1"`, string(sa.IndexedFields["key1"].GetData()))
+	r.Equal("Text", string(sa.IndexedFields["key1"].GetMetadata()["type"]))
+	r.Equal("2", string(sa.IndexedFields["key2"].GetData()))
+	r.Equal("Int", string(sa.IndexedFields["key2"].GetMetadata()["type"]))
+	r.Equal("true", string(sa.IndexedFields["key3"].GetData()))
+	r.Equal("Bool", string(sa.IndexedFields["key3"].GetMetadata()["type"]))
+	r.Empty(string(sa.IndexedFields["key4"].GetData()))
+	r.Equal("Double", string(sa.IndexedFields["key4"].GetMetadata()["type"]))
+	r.Equal("binary/null", string(sa.IndexedFields["key4"].GetMetadata()["encoding"]))
+	r.Equal(`["val2","val3"]`, string(sa.IndexedFields["key5"].GetData()))
+	r.Equal("Keyword", string(sa.IndexedFields["key5"].GetMetadata()["type"]))
+	r.Equal("json/plain", string(sa.IndexedFields["key5"].GetMetadata()["encoding"]))
+	r.Equal("[]", string(sa.IndexedFields["key6"].GetData()))
+	r.Equal("Keyword", string(sa.IndexedFields["key6"].GetMetadata()["type"]))
+	r.Equal("json/plain", string(sa.IndexedFields["key6"].GetMetadata()["encoding"]))
 }
 func Test_Encode_NilMap(t *testing.T) {
-	assert := assert.New(t)
+	r := require.New(t)
 
 	sa, err := Encode(map[string]interface{}{
 		"key1": "val1",
@@ -57,21 +56,21 @@ func Test_Encode_NilMap(t *testing.T) {
 		"key6": []string{},
 	}, nil)
 
-	assert.NoError(err)
-	assert.Len(sa.IndexedFields, 6)
-	assert.Equal(`"val1"`, string(sa.IndexedFields["key1"].GetData()))
-	assert.Equal("2", string(sa.IndexedFields["key2"].GetData()))
-	assert.Equal("true", string(sa.IndexedFields["key3"].GetData()))
-	assert.Equal("", string(sa.IndexedFields["key4"].GetData()))
-	assert.Equal("binary/null", string(sa.IndexedFields["key4"].GetMetadata()["encoding"]))
-	assert.Equal(`["val2","val3"]`, string(sa.IndexedFields["key5"].GetData()))
-	assert.Equal("json/plain", string(sa.IndexedFields["key5"].GetMetadata()["encoding"]))
-	assert.Equal("[]", string(sa.IndexedFields["key6"].GetData()))
-	assert.Equal("json/plain", string(sa.IndexedFields["key6"].GetMetadata()["encoding"]))
+	r.NoError(err)
+	r.Len(sa.IndexedFields, 6)
+	r.Equal(`"val1"`, string(sa.IndexedFields["key1"].GetData()))
+	r.Equal("2", string(sa.IndexedFields["key2"].GetData()))
+	r.Equal("true", string(sa.IndexedFields["key3"].GetData()))
+	r.Empty(string(sa.IndexedFields["key4"].GetData()))
+	r.Equal("binary/null", string(sa.IndexedFields["key4"].GetMetadata()["encoding"]))
+	r.Equal(`["val2","val3"]`, string(sa.IndexedFields["key5"].GetData()))
+	r.Equal("json/plain", string(sa.IndexedFields["key5"].GetMetadata()["encoding"]))
+	r.Equal("[]", string(sa.IndexedFields["key6"].GetData()))
+	r.Equal("json/plain", string(sa.IndexedFields["key6"].GetMetadata()["encoding"]))
 }
 
 func Test_Encode_Error(t *testing.T) {
-	assert := assert.New(t)
+	r := require.New(t)
 	sa, err := Encode(map[string]interface{}{
 		"key1": "val1",
 		"key2": 2,
@@ -82,18 +81,18 @@ func Test_Encode_Error(t *testing.T) {
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
 	}})
 
-	assert.Error(err)
-	assert.ErrorIs(err, ErrInvalidName)
-	assert.Len(sa.IndexedFields, 3)
-	assert.Equal(`"val1"`, string(sa.IndexedFields["key1"].GetData()))
-	assert.Equal("Text", string(sa.IndexedFields["key1"].GetMetadata()["type"]))
-	assert.Equal("2", string(sa.IndexedFields["key2"].GetData()))
-	assert.Equal("true", string(sa.IndexedFields["key3"].GetData()))
-	assert.Equal("Bool", string(sa.IndexedFields["key3"].GetMetadata()["type"]))
+	r.Error(err)
+	r.ErrorIs(err, ErrInvalidName)
+	r.Len(sa.IndexedFields, 3)
+	r.Equal(`"val1"`, string(sa.IndexedFields["key1"].GetData()))
+	r.Equal("Text", string(sa.IndexedFields["key1"].GetMetadata()["type"]))
+	r.Equal("2", string(sa.IndexedFields["key2"].GetData()))
+	r.Equal("true", string(sa.IndexedFields["key3"].GetData()))
+	r.Equal("Bool", string(sa.IndexedFields["key3"].GetMetadata()["type"]))
 }
 
 func Test_Decode_Success(t *testing.T) {
-	assert := assert.New(t)
+	r := require.New(t)
 
 	typeMap := &NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
@@ -111,17 +110,17 @@ func Test_Decode_Success(t *testing.T) {
 		"key5": []string{"val2", "val3"},
 		"key6": []string{},
 	}, typeMap)
-	assert.NoError(err)
+	r.NoError(err)
 
 	vals, err := Decode(sa, typeMap, true)
-	assert.NoError(err)
-	assert.Len(vals, 6)
-	assert.Equal("val1", vals["key1"])
-	assert.Equal(int64(2), vals["key2"])
-	assert.Equal(true, vals["key3"])
-	assert.Nil(vals["key4"])
-	assert.Equal([]string{"val2", "val3"}, vals["key5"])
-	assert.Nil(vals["key6"])
+	r.NoError(err)
+	r.Len(vals, 6)
+	r.Equal("val1", vals["key1"])
+	r.Equal(int64(2), vals["key2"])
+	r.Equal(true, vals["key3"])
+	r.Nil(vals["key4"])
+	r.Equal([]string{"val2", "val3"}, vals["key5"])
+	r.Nil(vals["key6"])
 
 	delete(sa.IndexedFields["key1"].Metadata, "type")
 	delete(sa.IndexedFields["key2"].Metadata, "type")
@@ -131,18 +130,18 @@ func Test_Decode_Success(t *testing.T) {
 	delete(sa.IndexedFields["key6"].Metadata, "type")
 
 	vals, err = Decode(sa, typeMap, true)
-	assert.NoError(err)
-	assert.Len(vals, 6)
-	assert.Equal("val1", vals["key1"])
-	assert.Equal(int64(2), vals["key2"])
-	assert.Equal(true, vals["key3"])
-	assert.Nil(vals["key4"])
-	assert.Equal([]string{"val2", "val3"}, vals["key5"])
-	assert.Nil(vals["key6"])
+	r.NoError(err)
+	r.Len(vals, 6)
+	r.Equal("val1", vals["key1"])
+	r.Equal(int64(2), vals["key2"])
+	r.Equal(true, vals["key3"])
+	r.Nil(vals["key4"])
+	r.Equal([]string{"val2", "val3"}, vals["key5"])
+	r.Nil(vals["key6"])
 }
 
 func Test_Decode_NilMap(t *testing.T) {
-	assert := assert.New(t)
+	r := require.New(t)
 	typeMap := &NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
@@ -159,21 +158,21 @@ func Test_Decode_NilMap(t *testing.T) {
 		"key5": []string{"val2", "val3"},
 		"key6": []string{},
 	}, typeMap)
-	assert.NoError(err)
+	r.NoError(err)
 
 	vals, err := Decode(sa, nil, true)
-	assert.NoError(err)
-	assert.Len(sa.IndexedFields, 6)
-	assert.Equal("val1", vals["key1"])
-	assert.Equal(int64(2), vals["key2"])
-	assert.Equal(true, vals["key3"])
-	assert.Nil(vals["key4"])
-	assert.Equal([]string{"val2", "val3"}, vals["key5"])
-	assert.Nil(vals["key6"])
+	r.NoError(err)
+	r.Len(sa.IndexedFields, 6)
+	r.Equal("val1", vals["key1"])
+	r.Equal(int64(2), vals["key2"])
+	r.Equal(true, vals["key3"])
+	r.Nil(vals["key4"])
+	r.Equal([]string{"val2", "val3"}, vals["key5"])
+	r.Nil(vals["key6"])
 }
 
 func Test_Decode_Error(t *testing.T) {
-	assert := assert.New(t)
+	r := require.New(t)
 
 	typeMap := &NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
@@ -185,7 +184,7 @@ func Test_Decode_Error(t *testing.T) {
 		"key2": 2,
 		"key3": true,
 	}, typeMap)
-	assert.NoError(err)
+	r.NoError(err)
 
 	vals, err := Decode(
 		sa,
@@ -196,21 +195,22 @@ func Test_Decode_Error(t *testing.T) {
 		}},
 		true,
 	)
-	require.NoError(t, err)
-	assert.Len(sa.IndexedFields, 3)
-	assert.Equal("val1", vals["key1"])
-	assert.Equal(int64(2), vals["key2"])
-	assert.Equal(true, vals["key3"])
+	r.Error(err)
+	r.ErrorIs(err, ErrInvalidName)
+	r.Len(sa.IndexedFields, 3)
+	r.Equal("val1", vals["key1"])
+	r.Equal(int64(2), vals["key2"])
+	r.Equal(true, vals["key3"])
 
 	delete(sa.IndexedFields["key1"].Metadata, "type")
 	delete(sa.IndexedFields["key2"].Metadata, "type")
 	delete(sa.IndexedFields["key3"].Metadata, "type")
 
 	vals, err = Decode(sa, nil, true)
-	assert.Error(err)
-	assert.ErrorIs(err, ErrInvalidType)
-	assert.Len(vals, 3)
-	assert.Nil(vals["key1"])
-	assert.Nil(vals["key2"])
-	assert.Nil(vals["key3"])
+	r.Error(err)
+	r.ErrorIs(err, ErrInvalidType)
+	r.Len(vals, 3)
+	r.Nil(vals["key1"])
+	r.Nil(vals["key2"])
+	r.Nil(vals["key3"])
 }


### PR DESCRIPTION
## What changed?
Fix the search attributes `Decode` function to not swallow errors when the type map is passed to the function.

## Why?
Recent PR https://github.com/temporalio/temporal/pull/8491 changed the behavior allowing search attributes with metadata to passthrough when the type map is not nil and the custom search attribute is not defined.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
