### PR TITLE
Refactor searchattribute.TestNameTypeMap

### DIFF
--- a/common/archiver/filestore/visibility_archiver_test.go
+++ b/common/archiver/filestore/visibility_archiver_test.go
@@ -317,14 +317,14 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidURI() {
 		NamespaceID: testNamespaceID,
 		PageSize:    1,
 	}
-	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 	s.Error(err)
 	s.Nil(response)
 }
 
 func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidRequest() {
 	visibilityArchiver := s.newTestVisibilityArchiver()
-	response, err := visibilityArchiver.Query(context.Background(), s.testArchivalURI, &archiver.QueryVisibilityRequest{}, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), s.testArchivalURI, &archiver.QueryVisibilityRequest{}, searchattribute.TestNameTypeMap())
 	s.Error(err)
 	s.Nil(response)
 }
@@ -338,7 +338,7 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidQuery() {
 		NamespaceID: "some random namespaceID",
 		PageSize:    10,
 		Query:       "some invalid query",
-	}, searchattribute.TestNameTypeMap)
+	}, searchattribute.TestNameTypeMap())
 	s.Error(err)
 	s.Nil(response)
 }
@@ -356,7 +356,7 @@ func (s *visibilityArchiverSuite) TestQuery_Success_DirectoryNotExist() {
 		Query:       "parsed by mockParser",
 		PageSize:    1,
 	}
-	response, err := visibilityArchiver.Query(context.Background(), s.testArchivalURI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), s.testArchivalURI, request, searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.NotNil(response)
 	s.Empty(response.Executions)
@@ -377,7 +377,7 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidToken() {
 		PageSize:      1,
 		NextPageToken: []byte{1, 2, 3},
 	}
-	response, err := visibilityArchiver.Query(context.Background(), s.testArchivalURI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), s.testArchivalURI, request, searchattribute.TestNameTypeMap())
 	s.Error(err)
 	s.Nil(response)
 }
@@ -398,12 +398,12 @@ func (s *visibilityArchiverSuite) TestQuery_Success_NoNextPageToken() {
 	}
 	URI, err := archiver.NewURI("file://" + s.testQueryDirectory)
 	s.NoError(err)
-	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.NotNil(response)
 	s.Nil(response.NextPageToken)
 	s.Len(response.Executions, 1)
-	ei, err := convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err := convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, response.Executions[0])
 }
@@ -424,25 +424,25 @@ func (s *visibilityArchiverSuite) TestQuery_Success_SmallPageSize() {
 	}
 	URI, err := archiver.NewURI("file://" + s.testQueryDirectory)
 	s.NoError(err)
-	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.NotNil(response)
 	s.NotNil(response.NextPageToken)
 	s.Len(response.Executions, 2)
-	ei, err := convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err := convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, response.Executions[0])
-	ei, err = convertToExecutionInfo(s.visibilityRecords[1], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.visibilityRecords[1], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, response.Executions[1])
 
 	request.NextPageToken = response.NextPageToken
-	response, err = visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+	response, err = visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.NotNil(response)
 	s.Nil(response.NextPageToken)
 	s.Len(response.Executions, 1)
-	ei, err = convertToExecutionInfo(s.visibilityRecords[3], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.visibilityRecords[3], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, response.Executions[0])
 }
@@ -472,17 +472,17 @@ func (s *visibilityArchiverSuite) TestArchiveAndQuery() {
 	}
 	executions := []*workflowpb.WorkflowExecutionInfo{}
 	for len(executions) == 0 || request.NextPageToken != nil {
-		response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+		response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 		s.NoError(err)
 		s.NotNil(response)
 		executions = append(executions, response.Executions...)
 		request.NextPageToken = response.NextPageToken
 	}
 	s.Len(executions, 2)
-	ei, err := convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err := convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, executions[0])
-	ei, err = convertToExecutionInfo(s.visibilityRecords[1], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.visibilityRecords[1], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, executions[1])
 }
@@ -504,7 +504,7 @@ func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_InvalidNamespace() {
 		NextPageToken: nil,
 		Query:         "",
 	}
-	_, err := visibilityArchiver.Query(context.Background(), URI, req, searchattribute.TestNameTypeMap)
+	_, err := visibilityArchiver.Query(context.Background(), URI, req, searchattribute.TestNameTypeMap())
 
 	var svcErr *serviceerror.InvalidArgument
 
@@ -520,7 +520,7 @@ func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_ZeroPageSize() {
 		NextPageToken: nil,
 		Query:         "",
 	}
-	_, err := visibilityArchiver.Query(context.Background(), s.testArchivalURI, req, searchattribute.TestNameTypeMap)
+	_, err := visibilityArchiver.Query(context.Background(), s.testArchivalURI, req, searchattribute.TestNameTypeMap())
 
 	var svcErr *serviceerror.InvalidArgument
 
@@ -545,7 +545,7 @@ func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_Pagination() {
 	}
 	var executions []*workflowpb.WorkflowExecutionInfo
 	for len(executions) == 0 || request.NextPageToken != nil {
-		response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+		response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 		s.NoError(err)
 		s.NotNil(response)
 		executions = append(executions, response.Executions...)

--- a/common/archiver/gcloud/visibility_archiver_test.go
+++ b/common/archiver/gcloud/visibility_archiver_test.go
@@ -144,7 +144,7 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidVisibilityURI() {
 		Query:       "WorkflowType='type::example' AND CloseTime='2020-02-05T11:00:00Z' AND SearchPrecision='Day'",
 	}
 
-	_, err = visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap)
+	_, err = visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap())
 	s.Error(err)
 }
 
@@ -192,7 +192,7 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidQuery() {
 		NamespaceID: "some random namespaceID",
 		PageSize:    10,
 		Query:       "some invalid query",
-	}, searchattribute.TestNameTypeMap)
+	}, searchattribute.TestNameTypeMap())
 	s.Error(err)
 	s.Nil(response)
 }
@@ -221,7 +221,7 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidToken() {
 		PageSize:      1,
 		NextPageToken: []byte{1, 2, 3},
 	}
-	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 	s.Error(err)
 	s.Nil(response)
 }
@@ -255,12 +255,12 @@ func (s *visibilityArchiverSuite) TestQuery_Success_NoNextPageToken() {
 		Query:       "parsed by mockParser",
 	}
 
-	response, err := visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.NotNil(response)
 	s.Nil(response.NextPageToken)
 	s.Len(response.Executions, 1)
-	ei, err := convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err := convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.ProtoEqual(ei, response.Executions[0])
 }
@@ -298,25 +298,25 @@ func (s *visibilityArchiverSuite) TestQuery_Success_SmallPageSize() {
 		Query:       "parsed by mockParser",
 	}
 
-	response, err := visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.NotNil(response)
 	s.NotNil(response.NextPageToken)
 	s.Len(response.Executions, 2)
-	ei, err := convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err := convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.ProtoEqual(ei, response.Executions[0])
-	ei, err = convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.ProtoEqual(ei, response.Executions[1])
 
 	request.NextPageToken = response.NextPageToken
-	response, err = visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap)
+	response, err = visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.NotNil(response)
 	s.Nil(response.NextPageToken)
 	s.Len(response.Executions, 1)
-	ei, err = convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.ProtoEqual(ei, response.Executions[0])
 }
@@ -333,7 +333,7 @@ func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_InvalidNamespace() {
 		NextPageToken: nil,
 		Query:         "",
 	}
-	_, err = arc.Query(context.Background(), URI, req, searchattribute.TestNameTypeMap)
+	_, err = arc.Query(context.Background(), URI, req, searchattribute.TestNameTypeMap())
 
 	var svcErr *serviceerror.InvalidArgument
 
@@ -353,7 +353,7 @@ func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_ZeroPageSize() {
 		NextPageToken: nil,
 		Query:         "",
 	}
-	_, err = arc.Query(context.Background(), URI, req, searchattribute.TestNameTypeMap)
+	_, err = arc.Query(context.Background(), URI, req, searchattribute.TestNameTypeMap())
 
 	var svcErr *serviceerror.InvalidArgument
 
@@ -419,7 +419,7 @@ func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_Pagination() {
 			NextPageToken: response.NextPageToken,
 			Query:         "",
 		}
-		response, err = arc.Query(context.Background(), URI, req, searchattribute.TestNameTypeMap)
+		response, err = arc.Query(context.Background(), URI, req, searchattribute.TestNameTypeMap())
 		s.NoError(err)
 		s.NotNil(response)
 		s.Len(response.Executions, 1)

--- a/common/archiver/s3store/visibility_archiver_test.go
+++ b/common/archiver/s3store/visibility_archiver_test.go
@@ -217,14 +217,14 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidURI() {
 		NamespaceID: testNamespaceID,
 		PageSize:    1,
 	}
-	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 	s.Error(err)
 	s.Nil(response)
 }
 
 func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidRequest() {
 	visibilityArchiver := s.newTestVisibilityArchiver()
-	response, err := visibilityArchiver.Query(context.Background(), s.testArchivalURI, &archiver.QueryVisibilityRequest{}, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), s.testArchivalURI, &archiver.QueryVisibilityRequest{}, searchattribute.TestNameTypeMap())
 	s.Error(err)
 	s.Nil(response)
 }
@@ -238,7 +238,7 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidQuery() {
 		NamespaceID: "some random namespaceID",
 		PageSize:    10,
 		Query:       "some invalid query",
-	}, searchattribute.TestNameTypeMap)
+	}, searchattribute.TestNameTypeMap())
 	s.Error(err)
 	s.Nil(response)
 }
@@ -257,7 +257,7 @@ func (s *visibilityArchiverSuite) TestQuery_Success_DirectoryNotExist() {
 		Query:       "parsed by mockParser",
 		PageSize:    1,
 	}
-	response, err := visibilityArchiver.Query(context.Background(), s.testArchivalURI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), s.testArchivalURI, request, searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.NotNil(response)
 	s.Empty(response.Executions)
@@ -280,12 +280,12 @@ func (s *visibilityArchiverSuite) TestQuery_Success_NoNextPageToken() {
 	}
 	URI, err := archiver.NewURI(testBucketURI)
 	s.NoError(err)
-	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.NotNil(response)
 	s.Nil(response.NextPageToken)
 	s.Len(response.Executions, 2)
-	ei, err := convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err := convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(response.Executions[0], ei)
 }
@@ -306,25 +306,25 @@ func (s *visibilityArchiverSuite) TestQuery_Success_SmallPageSize() {
 	}
 	URI, err := archiver.NewURI(testBucketURI)
 	s.NoError(err)
-	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.NotNil(response)
 	s.NotNil(response.NextPageToken)
 	s.Len(response.Executions, 2)
-	ei, err := convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err := convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, response.Executions[0])
-	ei, err = convertToExecutionInfo(s.visibilityRecords[1], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.visibilityRecords[1], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, response.Executions[1])
 
 	request.NextPageToken = response.NextPageToken
-	response, err = visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+	response, err = visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.NotNil(response)
 	s.Nil(response.NextPageToken)
 	s.Len(response.Executions, 1)
-	ei, err = convertToExecutionInfo(s.visibilityRecords[2], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.visibilityRecords[2], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, response.Executions[0])
 }
@@ -339,7 +339,7 @@ func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_InvalidNamespace() {
 		NextPageToken: nil,
 		Query:         "",
 	}
-	_, err = arc.Query(context.Background(), uri, req, searchattribute.TestNameTypeMap)
+	_, err = arc.Query(context.Background(), uri, req, searchattribute.TestNameTypeMap())
 
 	var svcErr *serviceerror.InvalidArgument
 
@@ -358,7 +358,7 @@ func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_ZeroPageSize() {
 		NextPageToken: nil,
 		Query:         "",
 	}
-	_, err = arc.Query(context.Background(), uri, req, searchattribute.TestNameTypeMap)
+	_, err = arc.Query(context.Background(), uri, req, searchattribute.TestNameTypeMap())
 
 	var svcErr *serviceerror.InvalidArgument
 
@@ -380,7 +380,7 @@ func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_Pagination() {
 			NextPageToken: nextPageToken,
 			Query:         "",
 		}
-		response, err := arc.Query(context.Background(), uri, req, searchattribute.TestNameTypeMap)
+		response, err := arc.Query(context.Background(), uri, req, searchattribute.TestNameTypeMap())
 		s.NoError(err)
 		s.NotNil(response)
 		nextPageToken = response.NextPageToken
@@ -516,7 +516,7 @@ func (s *visibilityArchiverSuite) TestArchiveAndQueryPrecisions() {
 		}, nil).AnyTimes()
 		visibilityArchiver.queryParser = mockParser
 
-		response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+		response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 		s.NoError(err)
 		s.NotNil(response)
 		s.Len(response.Executions, 2, "Iteration ", i)
@@ -529,7 +529,7 @@ func (s *visibilityArchiverSuite) TestArchiveAndQueryPrecisions() {
 		}, nil).AnyTimes()
 		visibilityArchiver.queryParser = mockParser
 
-		response, err = visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+		response, err = visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 		s.NoError(err)
 		s.NotNil(response)
 		s.Len(response.Executions, 2, "Iteration ", i)
@@ -542,7 +542,7 @@ func (s *visibilityArchiverSuite) TestArchiveAndQueryPrecisions() {
 		}, nil).AnyTimes()
 		visibilityArchiver.queryParser = mockParser
 
-		response, err = visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+		response, err = visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 		s.NoError(err)
 		s.NotNil(response)
 		s.Len(response.Executions, 2, "Iteration ", i)
@@ -555,7 +555,7 @@ func (s *visibilityArchiverSuite) TestArchiveAndQueryPrecisions() {
 		}, nil).AnyTimes()
 		visibilityArchiver.queryParser = mockParser
 
-		response, err = visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+		response, err = visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 		s.NoError(err)
 		s.NotNil(response)
 		s.Len(response.Executions, 2, "Iteration ", i)
@@ -584,7 +584,7 @@ func (s *visibilityArchiverSuite) TestArchiveAndQuery() {
 	executions := []*workflowpb.WorkflowExecutionInfo{}
 	first := true
 	for first || request.NextPageToken != nil {
-		response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+		response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 		s.NoError(err)
 		s.NotNil(response)
 		executions = append(executions, response.Executions...)
@@ -592,13 +592,13 @@ func (s *visibilityArchiverSuite) TestArchiveAndQuery() {
 		first = false
 	}
 	s.Len(executions, 3)
-	ei, err := convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err := convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, executions[0])
-	ei, err = convertToExecutionInfo(s.visibilityRecords[1], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.visibilityRecords[1], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, executions[1])
-	ei, err = convertToExecutionInfo(s.visibilityRecords[2], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.visibilityRecords[2], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, executions[2])
 
@@ -615,7 +615,7 @@ func (s *visibilityArchiverSuite) TestArchiveAndQuery() {
 	executions = []*workflowpb.WorkflowExecutionInfo{}
 	first = true
 	for first || request.NextPageToken != nil {
-		response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+		response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap())
 		s.NoError(err)
 		s.NotNil(response)
 		executions = append(executions, response.Executions...)
@@ -623,13 +623,13 @@ func (s *visibilityArchiverSuite) TestArchiveAndQuery() {
 		first = false
 	}
 	s.Len(executions, 3)
-	ei, err = convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.visibilityRecords[0], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, executions[0])
-	ei, err = convertToExecutionInfo(s.visibilityRecords[1], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.visibilityRecords[1], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, executions[1])
-	ei, err = convertToExecutionInfo(s.visibilityRecords[2], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.visibilityRecords[2], searchattribute.TestNameTypeMap())
 	s.NoError(err)
 	s.Equal(ei, executions[2])
 }

--- a/common/persistence/visibility/store/elasticsearch/query_interceptors_test.go
+++ b/common/persistence/visibility/store/elasticsearch/query_interceptors_test.go
@@ -35,7 +35,7 @@ func (s *QueryInterceptorSuite) TearDownTest() {
 func (s *QueryInterceptorSuite) TestTimeProcessFunc() {
 	vi := NewValuesInterceptor(
 		"test-namespace",
-		searchattribute.TestNameTypeMap,
+		searchattribute.TestEsNameTypeMap(),
 	)
 
 	cases := []struct {
@@ -72,7 +72,7 @@ func (s *QueryInterceptorSuite) TestTimeProcessFunc() {
 func (s *QueryInterceptorSuite) TestStatusProcessFunc() {
 	vi := NewValuesInterceptor(
 		"test-namespace",
-		searchattribute.TestNameTypeMap,
+		searchattribute.TestEsNameTypeMap(),
 	)
 
 	cases := []struct {
@@ -115,7 +115,7 @@ func (s *QueryInterceptorSuite) TestStatusProcessFunc() {
 func (s *QueryInterceptorSuite) TestDurationProcessFunc() {
 	vi := NewValuesInterceptor(
 		"test-namespace",
-		searchattribute.TestNameTypeMap,
+		searchattribute.TestEsNameTypeMap(),
 	)
 
 	cases := []struct {
@@ -171,7 +171,7 @@ func (s *QueryInterceptorSuite) TestNameInterceptor_ScheduleIDToWorkflowID() {
 func (s *QueryInterceptorSuite) TestValuesInterceptor_ScheduleIDToWorkflowID() {
 	vi := NewValuesInterceptor(
 		"test-namespace",
-		searchattribute.TestNameTypeMap,
+		searchattribute.TestEsNameTypeMap(),
 	)
 
 	values, err := vi.Values(searchattribute.ScheduleID, searchattribute.WorkflowID, "test-schedule-id")
@@ -193,7 +193,7 @@ func (s *QueryInterceptorSuite) TestValuesInterceptor_ScheduleIDToWorkflowID() {
 func (s *QueryInterceptorSuite) TestValuesInterceptor_NoTransformation() {
 	vi := NewValuesInterceptor(
 		"test-namespace",
-		searchattribute.TestNameTypeMapWithScheduleId,
+		searchattribute.TestEsNameTypeMapWithScheduleID(),
 	)
 
 	values, err := vi.Values(searchattribute.ScheduleID, searchattribute.ScheduleID, "test-workflow-id")
@@ -214,7 +214,7 @@ func (s *QueryInterceptorSuite) TestValuesInterceptor_NoTransformation() {
 func (s *QueryInterceptorSuite) createMockNameInterceptor(mapper searchattribute.Mapper) *nameInterceptor {
 	return &nameInterceptor{
 		namespace:                      "test-namespace",
-		searchAttributesTypeMap:        searchattribute.TestNameTypeMap,
+		searchAttributesTypeMap:        searchattribute.TestEsNameTypeMap(),
 		searchAttributesMapperProvider: searchattribute.NewTestMapperProvider(mapper),
 	}
 }

--- a/common/persistence/visibility/store/query/converter_test.go
+++ b/common/persistence/visibility/store/query/converter_test.go
@@ -31,7 +31,7 @@ func TestWithSearchAttributeInterceptor(t *testing.T) {
 	c := NewQueryConverter(
 		storeQCMock,
 		testNamespaceName,
-		searchattribute.TestNameTypeMap,
+		searchattribute.TestNameTypeMap(),
 		&searchattribute.TestMapper{},
 	)
 	r.Equal(nopSearchAttributeInterceptor, c.saInterceptor)
@@ -40,7 +40,7 @@ func TestWithSearchAttributeInterceptor(t *testing.T) {
 	c = NewQueryConverter(
 		storeQCMock,
 		testNamespaceName,
-		searchattribute.TestNameTypeMap,
+		searchattribute.TestNameTypeMap(),
 		&searchattribute.TestMapper{},
 	).WithSearchAttributeInterceptor(nil)
 	r.Equal(nopSearchAttributeInterceptor, c.saInterceptor)
@@ -50,7 +50,7 @@ func TestWithSearchAttributeInterceptor(t *testing.T) {
 	c = NewQueryConverter(
 		storeQCMock,
 		testNamespaceName,
-		searchattribute.TestNameTypeMap,
+		searchattribute.TestNameTypeMap(),
 		&searchattribute.TestMapper{},
 	).WithSearchAttributeInterceptor(i)
 	r.Equal(i, c.saInterceptor)
@@ -294,7 +294,7 @@ func TestQueryConverter_Convert(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -432,7 +432,7 @@ func TestQueryConverter_ConvertWhereString(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -590,7 +590,7 @@ func TestQueryConverter_ConvertSelectStmt(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -860,7 +860,7 @@ func TestQueryConverter_ConvertWhereExpr(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -950,7 +950,7 @@ func TestQueryConverter_ConvertParenExpr(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -1030,7 +1030,7 @@ func TestQueryConverter_ConvertNotExpr(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -1139,7 +1139,7 @@ func TestQueryConverter_ConvertAndExpr(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -1248,7 +1248,7 @@ func TestQueryConverter_ConvertOrExpr(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -1370,7 +1370,7 @@ func TestQueryConverter_ConvertComparisonExprStoreQueryConverterCalled(t *testin
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 			storeQCMock.EXPECT().GetDatetimeFormat().Return(time.RFC3339Nano).AnyTimes()
@@ -1463,7 +1463,7 @@ func TestQueryConverter_ConvertComparisonExprFail(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -1558,7 +1558,7 @@ func TestQueryConverter_ConvertRangeCond(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -1695,7 +1695,7 @@ func TestQueryConverter_ConvertIsExpr(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -1812,7 +1812,7 @@ func TestQueryConverter_ConvertColName(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -1922,8 +1922,7 @@ func TestQueryConverter_ResolveSearchAttributeAlias(t *testing.T) {
 			name:                 "success custom ScheduleId",
 			in:                   "ScheduleId",
 			withCustomScheduleID: true,
-			useNoopMapper:        true,
-			outFn:                "ScheduleId",
+			outFn:                searchattribute.TestScheduleIDFieldName,
 			outFt:                enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		},
 
@@ -1931,7 +1930,6 @@ func TestQueryConverter_ResolveSearchAttributeAlias(t *testing.T) {
 			name:                 "success custom ScheduleId reserved TemporalScheduleId",
 			in:                   "TemporalScheduleId",
 			withCustomScheduleID: true,
-			useNoopMapper:        true,
 			outFn:                "WorkflowId",
 			outFt:                enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		},
@@ -1940,7 +1938,6 @@ func TestQueryConverter_ResolveSearchAttributeAlias(t *testing.T) {
 			name:                 "success noop mapper ScheduleId",
 			in:                   "ScheduleId",
 			withCustomScheduleID: false,
-			useNoopMapper:        true,
 			outFn:                "WorkflowId",
 			outFt:                enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		},
@@ -1949,7 +1946,6 @@ func TestQueryConverter_ResolveSearchAttributeAlias(t *testing.T) {
 			name:                 "success noop mapper TemporalScheduleId",
 			in:                   "TemporalScheduleId",
 			withCustomScheduleID: false,
-			useNoopMapper:        true,
 			outFn:                "WorkflowId",
 			outFt:                enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		},
@@ -1972,13 +1968,12 @@ func TestQueryConverter_ResolveSearchAttributeAlias(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
-				&searchattribute.TestMapper{},
+				searchattribute.TestNameTypeMap(),
+				&searchattribute.TestMapper{
+					WithCustomScheduleID: tc.withCustomScheduleID,
+				},
 			)
 
-			if tc.withCustomScheduleID {
-				queryConverter.saTypeMap = searchattribute.TestNameTypeMapWithScheduleId
-			}
 			if tc.useNoopMapper {
 				queryConverter.saMapper = searchattribute.NewNoopMapper()
 			}
@@ -2127,7 +2122,7 @@ func TestQueryConverter_ParseValueExpr(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 
@@ -2232,7 +2227,7 @@ func TestQueryConverter_ParseSQLVal(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 			storeQCMock.EXPECT().GetDatetimeFormat().Return(time.RFC3339Nano).AnyTimes()
@@ -2449,7 +2444,7 @@ func TestQueryConverter_ValidateValueType(t *testing.T) {
 			queryConverter := NewQueryConverter(
 				storeQCMock,
 				testNamespaceName,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 			)
 			storeQCMock.EXPECT().GetDatetimeFormat().Return(time.RFC3339Nano).AnyTimes()

--- a/common/persistence/visibility/store/query/interceptors_test.go
+++ b/common/persistence/visibility/store/query/interceptors_test.go
@@ -28,7 +28,7 @@ func TestSearchAttributeInterceptor(t *testing.T) {
 	interceptor := &testSearchAttributeInterceptor{}
 	c := NewNilQueryConverter(
 		"",
-		searchattribute.TestNameTypeMap,
+		searchattribute.TestNameTypeMap(),
 		&searchattribute.TestMapper{},
 	).WithSearchAttributeInterceptor(interceptor)
 

--- a/common/persistence/visibility/store/query/nil_converter_test.go
+++ b/common/persistence/visibility/store/query/nil_converter_test.go
@@ -95,6 +95,6 @@ func TestNilStoreQueryConverter_ConvertIsExpr(t *testing.T) {
 
 func TestNewNilQueryConverter(t *testing.T) {
 	t.Parallel()
-	c := NewNilQueryConverter("", searchattribute.TestNameTypeMap, nil)
+	c := NewNilQueryConverter("", searchattribute.TestNameTypeMap(), nil)
 	require.Equal(t, &nilStoreQueryConverter{}, c.storeQC)
 }

--- a/common/persistence/visibility/store/sql/query_converter_legacy_test.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy_test.go
@@ -48,7 +48,7 @@ func (s *queryConverterSuite) SetupTest() {
 		s.pqc,
 		testNamespaceName,
 		testNamespaceID,
-		searchattribute.TestNameTypeMap,
+		searchattribute.TestNameTypeMap(),
 		&searchattribute.TestMapper{},
 		"",
 	)
@@ -142,7 +142,7 @@ func (s *queryConverterSuite) TestConvertWhereString() {
 				s.pqc,
 				testNamespaceName,
 				testNamespaceID,
-				searchattribute.TestNameTypeMap,
+				searchattribute.TestNameTypeMap(),
 				&searchattribute.TestMapper{},
 				"",
 			)
@@ -596,7 +596,7 @@ func (s *queryConverterSuite) TestConvertColName() {
 			),
 			err: nil,
 			setup: func() {
-				s.queryConverter.saTypeMap = searchattribute.TestNameTypeMapWithScheduleId
+				s.queryConverter.saTypeMap = searchattribute.TestEsNameTypeMapWithScheduleID()
 				s.queryConverter.saMapper = newMapper(
 					func(alias, namespace string) (string, error) {
 						return alias, nil

--- a/common/searchattribute/test_provider.go
+++ b/common/searchattribute/test_provider.go
@@ -2,6 +2,7 @@ package searchattribute
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	enumspb "go.temporal.io/api/enums/v1"
@@ -9,10 +10,13 @@ import (
 )
 
 type (
-	TestProvider struct{}
+	TestProvider struct {
+		es bool
+	}
 
 	TestMapper struct {
-		Namespace string
+		Namespace            string
+		WithCustomScheduleID bool
 	}
 )
 
@@ -20,52 +24,20 @@ var _ Provider = (*TestProvider)(nil)
 var _ Mapper = (*TestMapper)(nil)
 
 var (
-	TestNameTypeMap = NameTypeMap{
-		customSearchAttributes: map[string]enumspb.IndexedValueType{
-			"CustomIntField":      enumspb.INDEXED_VALUE_TYPE_INT,
-			"CustomTextField":     enumspb.INDEXED_VALUE_TYPE_TEXT,
-			"CustomKeywordField":  enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			"CustomDatetimeField": enumspb.INDEXED_VALUE_TYPE_DATETIME,
-			"CustomDoubleField":   enumspb.INDEXED_VALUE_TYPE_DOUBLE,
-			"CustomBoolField":     enumspb.INDEXED_VALUE_TYPE_BOOL,
-
-			"Int01":         enumspb.INDEXED_VALUE_TYPE_INT,
-			"Int02":         enumspb.INDEXED_VALUE_TYPE_INT,
-			"Int03":         enumspb.INDEXED_VALUE_TYPE_INT,
-			"Text01":        enumspb.INDEXED_VALUE_TYPE_TEXT,
-			"Keyword01":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			"Keyword02":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			"Keyword03":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			"Datetime01":    enumspb.INDEXED_VALUE_TYPE_DATETIME,
-			"Double01":      enumspb.INDEXED_VALUE_TYPE_DOUBLE,
-			"Bool01":        enumspb.INDEXED_VALUE_TYPE_BOOL,
-			"KeywordList01": enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
-		},
+	esCustomSearchAttributes = map[string]enumspb.IndexedValueType{
+		"CustomIntField":      enumspb.INDEXED_VALUE_TYPE_INT,
+		"CustomTextField":     enumspb.INDEXED_VALUE_TYPE_TEXT,
+		"CustomKeywordField":  enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"CustomDatetimeField": enumspb.INDEXED_VALUE_TYPE_DATETIME,
+		"CustomDoubleField":   enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+		"CustomBoolField":     enumspb.INDEXED_VALUE_TYPE_BOOL,
 	}
 
-	TestNameTypeMapWithScheduleId = NameTypeMap{
-		customSearchAttributes: map[string]enumspb.IndexedValueType{
-			"CustomIntField":      enumspb.INDEXED_VALUE_TYPE_INT,
-			"CustomTextField":     enumspb.INDEXED_VALUE_TYPE_TEXT,
-			"CustomKeywordField":  enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			"CustomDatetimeField": enumspb.INDEXED_VALUE_TYPE_DATETIME,
-			"CustomDoubleField":   enumspb.INDEXED_VALUE_TYPE_DOUBLE,
-			"CustomBoolField":     enumspb.INDEXED_VALUE_TYPE_BOOL,
+	// default custom search attributes definition for SQL databases
+	sqlCustomSearchAttributes = GetDBIndexSearchAttributes(nil).CustomSearchAttributes
 
-			"Int01":         enumspb.INDEXED_VALUE_TYPE_INT,
-			"Int02":         enumspb.INDEXED_VALUE_TYPE_INT,
-			"Int03":         enumspb.INDEXED_VALUE_TYPE_INT,
-			"Text01":        enumspb.INDEXED_VALUE_TYPE_TEXT,
-			"Keyword01":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			"Keyword02":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			"Keyword03":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			"Datetime01":    enumspb.INDEXED_VALUE_TYPE_DATETIME,
-			"Double01":      enumspb.INDEXED_VALUE_TYPE_DOUBLE,
-			"Bool01":        enumspb.INDEXED_VALUE_TYPE_BOOL,
-			"KeywordList01": enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
-			ScheduleID:      enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-	}
+	// ScheduleId is mapped to Keyword10 for tests
+	TestScheduleIDFieldName = "Keyword10"
 
 	TestAliases = map[string]string{
 		"Int01":         "CustomIntField",
@@ -78,12 +50,41 @@ var (
 	}
 )
 
+func TestNameTypeMap() NameTypeMap {
+	csa := maps.Clone(sqlCustomSearchAttributes)
+	return NameTypeMap{
+		customSearchAttributes: csa,
+	}
+}
+
+func TestEsNameTypeMap() NameTypeMap {
+	csa := maps.Clone(esCustomSearchAttributes)
+	return NameTypeMap{
+		customSearchAttributes: csa,
+	}
+}
+
+func TestEsNameTypeMapWithScheduleID() NameTypeMap {
+	res := TestEsNameTypeMap()
+	res.customSearchAttributes[ScheduleID] = enumspb.INDEXED_VALUE_TYPE_KEYWORD
+	return res
+}
+
 func NewTestProvider() *TestProvider {
 	return &TestProvider{}
 }
 
+func NewTestEsProvider() *TestProvider {
+	return &TestProvider{
+		es: true,
+	}
+}
+
 func (s *TestProvider) GetSearchAttributes(_ string, _ bool) (NameTypeMap, error) {
-	return TestNameTypeMap, nil
+	if s.es {
+		return TestEsNameTypeMap(), nil
+	}
+	return TestNameTypeMap(), nil
 }
 
 func (t *TestMapper) GetAlias(fieldName string, namespace string) (string, error) {
@@ -99,6 +100,9 @@ func (t *TestMapper) GetAlias(fieldName string, namespace string) (string, error
 	if namespace == "test-namespace" || namespace == t.Namespace {
 		if fieldName == "pass-through" {
 			return fieldName, nil
+		}
+		if t.WithCustomScheduleID && fieldName == TestScheduleIDFieldName {
+			return ScheduleID, nil
 		}
 		return "AliasFor" + fieldName, nil
 	}
@@ -119,6 +123,9 @@ func (t *TestMapper) GetFieldName(alias string, namespace string) (string, error
 	} else if namespace == "test-namespace" || namespace == t.Namespace {
 		if alias == "pass-through" {
 			return alias, nil
+		}
+		if t.WithCustomScheduleID && alias == ScheduleID {
+			return TestScheduleIDFieldName, nil
 		}
 		if strings.HasPrefix(alias, "AliasFor") {
 			return strings.TrimPrefix(alias, "AliasFor"), nil

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -60,7 +60,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 	intPayload, err := payload.Encode(1)
 	s.NoError(err)
 	fields := map[string]*commonpb.Payload{
-		"CustomIntField": intPayload,
+		"Int01": intPayload,
 	}
 	attr = &commonpb.SearchAttributes{
 		IndexedFields: fields,
@@ -69,9 +69,9 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 	s.NoError(err)
 
 	fields = map[string]*commonpb.Payload{
-		"CustomIntField":     intPayload,
-		"CustomKeywordField": payload.EncodeString("keyword"),
-		"CustomBoolField":    payload.EncodeString("true"),
+		"Int01":     intPayload,
+		"Keyword01": payload.EncodeString("keyword"),
+		"Bool01":    payload.EncodeString("true"),
 	}
 	attr.IndexedFields = fields
 	err = saValidator.Validate(attr, namespace)
@@ -87,18 +87,18 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 	s.Equal("search attribute InvalidKey is not defined", err.Error())
 
 	fields = map[string]*commonpb.Payload{
-		"CustomTextField": payload.EncodeString("1"),
-		"CustomBoolField": payload.EncodeString("123"),
+		"Text01": payload.EncodeString("1"),
+		"Bool01": payload.EncodeString("123"),
 	}
 	attr.IndexedFields = fields
 	err = saValidator.Validate(attr, namespace)
 	s.Error(err)
-	s.Equal("invalid value for search attribute CustomBoolField of type Bool: 123", err.Error())
+	s.Equal("invalid value for search attribute Bool01 of type Bool: 123", err.Error())
 
 	intArrayPayload, err := payload.Encode([]int{1, 2})
 	s.NoError(err)
 	fields = map[string]*commonpb.Payload{
-		"CustomIntField": intArrayPayload,
+		"Int01": intArrayPayload,
 	}
 	attr.IndexedFields = fields
 	err = saValidator.Validate(attr, namespace)
@@ -182,7 +182,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 	intPayload, err := payload.Encode(1)
 	s.NoError(err)
 	fields := map[string]*commonpb.Payload{
-		"CustomIntField": intPayload,
+		"Int01": intPayload,
 	}
 	attr = &commonpb.SearchAttributes{
 		IndexedFields: fields,
@@ -191,7 +191,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 	s.NoError(err)
 
 	fields = map[string]*commonpb.Payload{
-		"CustomIntField": intPayload,
+		"Int01": intPayload,
 	}
 	attr = &commonpb.SearchAttributes{
 		IndexedFields: fields,
@@ -212,13 +212,13 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 	s.Require().EqualError(err, "Namespace error-namespace has no mapping defined for field name InvalidKey")
 
 	fields = map[string]*commonpb.Payload{
-		"CustomTextField": payload.EncodeString("1"),
-		"CustomBoolField": payload.EncodeString("123"),
+		"Text01": payload.EncodeString("1"),
+		"Bool01": payload.EncodeString("123"),
 	}
 	attr.IndexedFields = fields
 	err = saValidator.Validate(attr, namespace)
 	s.Error(err)
-	s.Equal("invalid value for search attribute AliasForCustomBoolField of type Bool: 123", err.Error())
+	s.Equal("invalid value for search attribute AliasForBool01 of type Bool: 123", err.Error())
 }
 
 func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {
@@ -240,7 +240,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {
 	namespace := "namespace"
 
 	fields := map[string]*commonpb.Payload{
-		"CustomKeywordField": payload.EncodeString("123456"),
+		"Keyword01": payload.EncodeString("123456"),
 	}
 	attr := &commonpb.SearchAttributes{
 		IndexedFields: fields,
@@ -249,16 +249,16 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {
 	attr.IndexedFields = fields
 	err := saValidator.ValidateSize(attr, namespace)
 	s.Error(err)
-	s.Equal("search attribute CustomKeywordField value size 8 exceeds size limit 5", err.Error())
+	s.Equal("search attribute Keyword01 value size 8 exceeds size limit 5", err.Error())
 
 	fields = map[string]*commonpb.Payload{
-		"CustomKeywordField": payload.EncodeString("123"),
-		"CustomTextField":    payload.EncodeString("12"),
+		"Keyword01": payload.EncodeString("123"),
+		"Text01":    payload.EncodeString("12"),
 	}
 	attr.IndexedFields = fields
 	err = saValidator.ValidateSize(attr, namespace)
 	s.Error(err)
-	s.Equal("total size of search attributes 106 exceeds size limit 20", err.Error())
+	s.Equal("total size of search attributes 88 exceeds size limit 20", err.Error())
 }
 
 func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize_Mapper() {
@@ -280,7 +280,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize_Mapper
 	namespace := "test-namespace"
 
 	fields := map[string]*commonpb.Payload{
-		"CustomKeywordField": payload.EncodeString("123456"),
+		"Keyword01": payload.EncodeString("123456"),
 	}
 	attr := &commonpb.SearchAttributes{
 		IndexedFields: fields,
@@ -289,14 +289,14 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize_Mapper
 	attr.IndexedFields = fields
 	err := saValidator.ValidateSize(attr, namespace)
 	s.Error(err)
-	s.Equal("search attribute AliasForCustomKeywordField value size 8 exceeds size limit 5", err.Error())
+	s.Equal("search attribute AliasForKeyword01 value size 8 exceeds size limit 5", err.Error())
 
 	fields = map[string]*commonpb.Payload{
-		"CustomKeywordField": payload.EncodeString("123"),
-		"CustomTextField":    payload.EncodeString("12"),
+		"Keyword01": payload.EncodeString("123"),
+		"Text01":    payload.EncodeString("12"),
 	}
 	attr.IndexedFields = fields
 	err = saValidator.ValidateSize(attr, namespace)
 	s.Error(err)
-	s.Equal("total size of search attributes 106 exceeds size limit 20", err.Error())
+	s.Equal("total size of search attributes 88 exceeds size limit 20", err.Error())
 }

--- a/service/frontend/admin_handler_test.go
+++ b/service/frontend/admin_handler_test.go
@@ -219,7 +219,7 @@ func (s *adminHandlerSuite) Test_AddSearchAttributes() {
 
 	// Elasticsearch is not configured
 	s.mockVisibilityMgr.EXPECT().GetIndexName().Return("").AnyTimes()
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestEsNameTypeMap(), nil).AnyTimes()
 	testCases3 := []test{
 		{
 			Name: "reserved key (empty index)",
@@ -250,7 +250,7 @@ func (s *adminHandlerSuite) Test_AddSearchAttributes() {
 
 	// Configure Elasticsearch: add advanced visibility store config with index name.
 	s.mockVisibilityMgr.EXPECT().GetIndexName().Return("random-index-name").AnyTimes()
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestEsNameTypeMap(), nil).AnyTimes()
 	testCases2 := []test{
 		{
 			Name: "reserved key (ES configured)",
@@ -338,7 +338,7 @@ func (s *adminHandlerSuite) Test_GetSearchAttributes_EmptyIndexName() {
 	s.mockVisibilityMgr.EXPECT().GetIndexName().Return("").AnyTimes()
 	mockSdkClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), "temporal-sys-add-search-attributes-workflow", "").Return(
 		&workflowservice.DescribeWorkflowExecutionResponse{}, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestEsNameTypeMap(), nil).AnyTimes()
 
 	resp, err = handler.GetSearchAttributes(ctx, &adminservice.GetSearchAttributesRequest{Namespace: s.namespace.String()})
 	s.NoError(err)
@@ -358,21 +358,21 @@ func (s *adminHandlerSuite) Test_GetSearchAttributes_NonEmptyIndexName() {
 
 	mockSdkClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), "temporal-sys-add-search-attributes-workflow", "").Return(
 		&workflowservice.DescribeWorkflowExecutionResponse{}, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestEsNameTypeMap(), nil).AnyTimes()
 	resp, err := handler.GetSearchAttributes(ctx, &adminservice.GetSearchAttributesRequest{})
 	s.NoError(err)
 	s.NotNil(resp)
 
 	mockSdkClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), "temporal-sys-add-search-attributes-workflow", "").Return(
 		&workflowservice.DescribeWorkflowExecutionResponse{}, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("another-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("another-index-name", true).Return(searchattribute.TestEsNameTypeMap(), nil).AnyTimes()
 	resp, err = handler.GetSearchAttributes(ctx, &adminservice.GetSearchAttributesRequest{IndexName: "another-index-name"})
 	s.NoError(err)
 	s.NotNil(resp)
 
 	mockSdkClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), "temporal-sys-add-search-attributes-workflow", "").Return(
 		nil, errors.New("random error"))
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestEsNameTypeMap(), nil).AnyTimes()
 	resp, err = handler.GetSearchAttributes(ctx, &adminservice.GetSearchAttributesRequest{Namespace: s.namespace.String()})
 	s.Error(err)
 	s.Nil(resp)
@@ -411,7 +411,7 @@ func (s *adminHandlerSuite) Test_RemoveSearchAttributes_EmptyIndexName() {
 	// Elasticsearch is not configured
 	s.mockVisibilityMgr.EXPECT().HasStoreName(elasticsearch.PersistenceName).Return(true).AnyTimes()
 	s.mockVisibilityMgr.EXPECT().GetIndexName().Return("").AnyTimes()
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestNameTypeMap(), nil).AnyTimes()
 	testCases2 := []test{
 		{
 			Name: "reserved search attribute (empty index)",
@@ -474,7 +474,7 @@ func (s *adminHandlerSuite) Test_RemoveSearchAttributes_NonEmptyIndexName() {
 	// Configure Elasticsearch: add advanced visibility store config with index name.
 	s.mockVisibilityMgr.EXPECT().HasStoreName(elasticsearch.PersistenceName).Return(true).AnyTimes()
 	s.mockVisibilityMgr.EXPECT().GetIndexName().Return("random-index-name").AnyTimes()
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestEsNameTypeMap(), nil).AnyTimes()
 	for _, testCase := range testCases {
 		s.T().Run(testCase.Name, func(t *testing.T) {
 			resp, err := handler.RemoveSearchAttributes(ctx, testCase.Request)
@@ -1883,7 +1883,7 @@ func (s *adminHandlerSuite) TestImportWorkflowExecution_WithAliasedSearchAttribu
 	}{
 		{
 			Name:        "valid SA alias",
-			SaName:      "AliasOfCustomKeywordField",
+			SaName:      "AliasOfKeyword01",
 			ExpectedErr: nil,
 		},
 		{
@@ -1939,7 +1939,7 @@ func (s *adminHandlerSuite) TestImportWorkflowExecution_WithAliasedSearchAttribu
 				return "", serviceerror.NewInvalidArgument("unknown alias")
 			}).Times(eventsWithSasCount)
 
-			s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(tv.IndexName(), gomock.Any()).Return(searchattribute.TestNameTypeMap, nil).Times(eventsWithSasCount)
+			s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(tv.IndexName(), gomock.Any()).Return(searchattribute.TestNameTypeMap(), nil).Times(eventsWithSasCount)
 
 			if subTest.ExpectedErr != nil {
 				s.mockSaMapper.EXPECT().GetAlias(gomock.Any(), tv.NamespaceName().String()).Return("", serviceerror.NewInvalidArgument(""))
@@ -1955,7 +1955,7 @@ func (s *adminHandlerSuite) TestImportWorkflowExecution_WithAliasedSearchAttribu
 							if eventHasSas {
 								s.NotNil(unaliasedSas, "search attributes must be set on every event with search_attributes field")
 								s.Len(unaliasedSas.GetIndexedFields(), 1, "only 1 search attribute must be set")
-								s.ProtoEqual(saValue, unaliasedSas.GetIndexedFields()["CustomKeywordField"])
+								s.ProtoEqual(saValue, unaliasedSas.GetIndexedFields()["Keyword01"])
 							}
 						}
 					}
@@ -2033,7 +2033,7 @@ func (s *adminHandlerSuite) TestImportWorkflowExecution_WithNonAliasedSearchAttr
 			s.mockNamespaceCache.EXPECT().GetNamespaceID(tv.NamespaceName()).Return(tv.NamespaceID(), nil)
 			s.mockVisibilityMgr.EXPECT().GetIndexName().Return(tv.IndexName()).Times(eventsWithSasCount)
 
-			s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(tv.IndexName(), gomock.Any()).Return(searchattribute.TestNameTypeMap, nil).Times(eventsWithSasCount)
+			s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(tv.IndexName(), gomock.Any()).Return(searchattribute.TestEsNameTypeMap(), nil).Times(eventsWithSasCount)
 
 			// Mock mapper returns error because field name is not an alias.
 			s.mockSaMapper.EXPECT().GetFieldName(gomock.Any(), tv.NamespaceName().String()).DoAndReturn(func(alias string, nsName string) (string, error) {

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -1974,7 +1974,7 @@ func (s *WorkflowHandlerSuite) TestGetSearchAttributes() {
 	wh := s.getWorkflowHandler(s.newConfig())
 
 	ctx := context.Background()
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil)
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap(), nil)
 	resp, err := wh.GetSearchAttributes(ctx, &workflowservice.GetSearchAttributesRequest{})
 	s.NoError(err)
 	s.NotNil(resp)
@@ -3089,7 +3089,7 @@ func (s *WorkflowHandlerSuite) TestGetWorkflowExecutionHistory_InternalRawHistor
 	newRunID := uuid.New().String()
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceID(tests.Namespace).Return(tests.NamespaceID, nil).Times(2)
-	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), gomock.Any()).Return(searchattribute.TestNameTypeMap, nil).Times(2)
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), gomock.Any()).Return(searchattribute.TestNameTypeMap(), nil).Times(2)
 
 	req := &workflowservice.GetWorkflowExecutionHistoryRequest{
 		Namespace:              tests.Namespace.String(),

--- a/service/history/api/command_attr_validator_test.go
+++ b/service/history/api/command_attr_validator_test.go
@@ -195,7 +195,7 @@ func (s *commandAttrValidatorSuite) TestValidateUpsertWorkflowSearchAttributes()
 	saPayload, err := searchattribute.EncodeValue("bytes", enumspb.INDEXED_VALUE_TYPE_KEYWORD)
 	s.NoError(err)
 	attributes.SearchAttributes.IndexedFields = map[string]*commonpb.Payload{
-		"CustomKeywordField": saPayload,
+		"Keyword01": saPayload,
 	}
 	fc, err = s.validator.ValidateUpsertWorkflowSearchAttributes(namespaceName, attributes)
 	s.NoError(err)

--- a/service/history/archival/archiver_test.go
+++ b/service/history/archival/archiver_test.go
@@ -121,7 +121,7 @@ func TestArchiver(t *testing.T) {
 			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
 				"Text01": payload.EncodeString("value"),
 			}},
-			NameTypeMap: searchattribute.TestNameTypeMap,
+			NameTypeMap: searchattribute.TestNameTypeMap(),
 
 			ExpectArchiveVisibility: true,
 		},

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -246,7 +246,7 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled() {
 				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 					SearchAttributes: &commonpb.SearchAttributes{
 						IndexedFields: map[string]*commonpb.Payload{
-							"CustomKeywordField":    payload.EncodeString("random-keyword"),
+							"Keyword01":             payload.EncodeString("random-keyword"),
 							"TemporalChangeVersion": payload.EncodeString("random-data"),
 						},
 					},
@@ -264,7 +264,7 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled() {
 		NextPageToken: []byte{},
 		Size:          1,
 	}, nil)
-	s.mockShard.Resource.SearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil)
+	s.mockShard.Resource.SearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap(), nil)
 	s.mockShard.Resource.SearchAttributesMapperProvider.EXPECT().GetMapper(tests.Namespace).
 		Return(&searchattribute.TestMapper{Namespace: tests.Namespace.String()}, nil).AnyTimes()
 
@@ -352,7 +352,7 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled_WithInt
 				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 					SearchAttributes: &commonpb.SearchAttributes{
 						IndexedFields: map[string]*commonpb.Payload{
-							"CustomKeywordField":    payload.EncodeString("random-keyword"),
+							"Keyword01":             payload.EncodeString("random-keyword"),
 							"TemporalChangeVersion": payload.EncodeString("random-data"),
 						},
 					},
@@ -670,7 +670,7 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccess() {
 				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 					SearchAttributes: &commonpb.SearchAttributes{
 						IndexedFields: map[string]*commonpb.Payload{
-							"CustomKeywordField":    payload.EncodeString("random-keyword"),
+							"Keyword01":             payload.EncodeString("random-keyword"),
 							"TemporalChangeVersion": payload.EncodeString("random-data"),
 						},
 					},
@@ -688,7 +688,7 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccess() {
 		NextPageToken: []byte{},
 		Size:          1,
 	}, nil)
-	s.mockShard.Resource.SearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil)
+	s.mockShard.Resource.SearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap(), nil)
 	s.mockShard.Resource.SearchAttributesMapperProvider.EXPECT().GetMapper(tests.Namespace).
 		Return(&searchattribute.TestMapper{Namespace: tests.Namespace.String()}, nil).AnyTimes()
 
@@ -767,7 +767,7 @@ func (s *engine2Suite) TestRecordWorkflowTaskStartedSuccessWithInternalRawHistor
 					WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 						SearchAttributes: &commonpb.SearchAttributes{
 							IndexedFields: map[string]*commonpb.Payload{
-								"CustomKeywordField":    payload.EncodeString("random-keyword"),
+								"Keyword01":             payload.EncodeString("random-keyword"),
 								"TemporalChangeVersion": payload.EncodeString("random-data"),
 							},
 						},
@@ -1236,7 +1236,7 @@ func (s *engine2Suite) TestRespondWorkflowTaskCompleted_StartChildWithSearchAttr
 			WorkflowType: &commonpb.WorkflowType{Name: "wType"},
 			TaskQueue:    &taskqueuepb.TaskQueue{Name: tl},
 			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
-				"AliasForCustomTextField": payload.EncodeString("search attribute value")},
+				"AliasForText01": payload.EncodeString("search attribute value")},
 			},
 		}},
 	}}
@@ -1256,7 +1256,7 @@ func (s *engine2Suite) TestRespondWorkflowTaskCompleted_StartChildWithSearchAttr
 		// Search attribute name was mapped and saved under field name.
 		s.ProtoEqual(
 			payload.EncodeString("search attribute value"),
-			startChildEventAttributes.GetSearchAttributes().GetIndexedFields()["CustomTextField"])
+			startChildEventAttributes.GetSearchAttributes().GetIndexedFields()["Text01"])
 		return tests.UpdateWorkflowExecutionResponse, nil
 	})
 
@@ -1413,7 +1413,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_BrandNew_SearchAttributes() {
 		// Search attribute name was mapped and saved under field name.
 		s.ProtoEqual(
 			payload.EncodeString("test"),
-			startEventAttributes.GetSearchAttributes().GetIndexedFields()["CustomKeywordField"])
+			startEventAttributes.GetSearchAttributes().GetIndexedFields()["Keyword01"])
 		return tests.CreateWorkflowExecutionResponse, nil
 	})
 
@@ -1432,7 +1432,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_BrandNew_SearchAttributes() {
 			Identity:                 identity,
 			RequestId:                requestID,
 			SearchAttributes: &commonpb.SearchAttributes{IndexedFields: map[string]*commonpb.Payload{
-				"CustomKeywordField": payload.EncodeString("test"),
+				"Keyword01": payload.EncodeString("test"),
 			}}},
 	})
 	s.Nil(err)

--- a/service/history/history_engine3_eventsv2_test.go
+++ b/service/history/history_engine3_eventsv2_test.go
@@ -174,7 +174,7 @@ func (s *engine3Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled() {
 				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 					SearchAttributes: &commonpb.SearchAttributes{
 						IndexedFields: map[string]*commonpb.Payload{
-							"CustomKeywordField":    payload.EncodeString("random-keyword"),
+							"Keyword01":             payload.EncodeString("random-keyword"),
 							"TemporalChangeVersion": payload.EncodeString("random-data"),
 						},
 					},
@@ -199,7 +199,7 @@ func (s *engine3Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled() {
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(testNamespaceEntry, nil).AnyTimes()
 	s.mockNamespaceCache.EXPECT().GetNamespace(gomock.Any()).Return(testNamespaceEntry, nil).AnyTimes()
 
-	s.mockShard.Resource.SearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil)
+	s.mockShard.Resource.SearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap(), nil)
 	s.mockShard.Resource.SearchAttributesMapperProvider.EXPECT().GetMapper(tests.Namespace).
 		Return(&searchattribute.TestMapper{Namespace: tests.Namespace.String()}, nil).AnyTimes()
 
@@ -284,7 +284,7 @@ func (s *engine3Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled_WithInt
 					WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 						SearchAttributes: &commonpb.SearchAttributes{
 							IndexedFields: map[string]*commonpb.Payload{
-								"CustomKeywordField":    payload.EncodeString("random-keyword"),
+								"Keyword01":             payload.EncodeString("random-keyword"),
 								"TemporalChangeVersion": payload.EncodeString("random-data"),
 							},
 						},

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -1740,7 +1740,7 @@ func (s *engineSuite) testRespondWorkflowTaskCompletedSignalGeneration() *histor
 	_, err := s.historyEngine.SignalWorkflowExecution(context.Background(), signalRequest)
 	s.NoError(err)
 
-	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil)
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap(), nil)
 	s.mockSearchAttributesMapperProvider.EXPECT().GetMapper(tests.Namespace).Return(&searchattribute.TestMapper{Namespace: tests.Namespace.String()}, nil).AnyTimes()
 	s.mockVisibilityMgr.EXPECT().GetIndexName().Return(esIndexName).AnyTimes()
 	s.mockExecutionMgr.EXPECT().ReadHistoryBranch(gomock.Any(), gomock.Any()).Return(&persistence.ReadHistoryBranchResponse{HistoryEvents: []*historypb.HistoryEvent{}}, nil)
@@ -1927,7 +1927,7 @@ func (s *engineSuite) TestRespondWorkflowTaskCompleted_ActivityEagerExecution_Ca
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
 	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil)
 
-	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil)
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap(), nil)
 	s.mockSearchAttributesMapperProvider.EXPECT().GetMapper(tests.Namespace).Return(&searchattribute.TestMapper{Namespace: tests.Namespace.String()}, nil).AnyTimes()
 	s.mockVisibilityMgr.EXPECT().GetIndexName().Return(esIndexName).AnyTimes()
 	s.mockExecutionMgr.EXPECT().ReadHistoryBranch(gomock.Any(), gomock.Any()).Return(&persistence.ReadHistoryBranchResponse{HistoryEvents: []*historypb.HistoryEvent{}}, nil)
@@ -5458,7 +5458,7 @@ func (s *engineSuite) TestGetHistory() {
 					WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
 						SearchAttributes: &commonpb.SearchAttributes{
 							IndexedFields: map[string]*commonpb.Payload{
-								"CustomKeywordField":    payload.EncodeString("random-keyword"),
+								"Keyword01":             payload.EncodeString("random-keyword"),
 								"TemporalChangeVersion": payload.EncodeString("random-data"),
 							},
 						},
@@ -5470,7 +5470,7 @@ func (s *engineSuite) TestGetHistory() {
 		Size:          1,
 	}, nil)
 
-	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil)
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap(), nil)
 	s.mockSearchAttributesMapperProvider.EXPECT().GetMapper(tests.Namespace).
 		Return(&searchattribute.TestMapper{Namespace: tests.Namespace.String()}, nil).AnyTimes()
 	s.mockVisibilityMgr.EXPECT().GetIndexName().Return(esIndexName).AnyTimes()
@@ -5496,7 +5496,7 @@ func (s *engineSuite) TestGetHistory() {
 	s.NotNil(history)
 	s.Equal([]byte{}, token)
 
-	s.EqualValues("Keyword", history.Events[1].GetWorkflowExecutionStartedEventAttributes().GetSearchAttributes().GetIndexedFields()["AliasForCustomKeywordField"].GetMetadata()["type"])
+	s.EqualValues("Keyword", history.Events[1].GetWorkflowExecutionStartedEventAttributes().GetSearchAttributes().GetIndexedFields()["AliasForKeyword01"].GetMetadata()["type"])
 	s.EqualValues(`"random-data"`, history.Events[1].GetWorkflowExecutionStartedEventAttributes().GetSearchAttributes().GetIndexedFields()["TemporalChangeVersion"].GetData())
 }
 
@@ -5574,7 +5574,7 @@ func (s *engineSuite) TestGetWorkflowExecutionHistory() {
 	}, nil).Times(2)
 
 	s.mockExecutionMgr.EXPECT().TrimHistoryBranch(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap(), nil).AnyTimes()
 	s.mockVisibilityMgr.EXPECT().GetIndexName().Return(esIndexName).AnyTimes()
 
 	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
@@ -5703,7 +5703,7 @@ func (s *engineSuite) TestGetWorkflowExecutionHistoryWhenInternalRawHistoryIsEna
 	}, nil).Times(1)
 
 	s.mockExecutionMgr.EXPECT().TrimHistoryBranch(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap(), nil).AnyTimes()
 	s.mockVisibilityMgr.EXPECT().GetIndexName().Return(esIndexName).AnyTimes()
 
 	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())

--- a/service/worker/scheduler/query_test.go
+++ b/service/worker/scheduler/query_test.go
@@ -20,7 +20,7 @@ func TestFieldNameAggInterceptor(t *testing.T) {
 	s := require.New(t)
 	fnInterceptor := newFieldNameAggInterceptor(
 		testNamespace,
-		searchattribute.TestNameTypeMap,
+		searchattribute.TestEsNameTypeMap(),
 		searchattribute.NewTestMapperProvider(nil),
 	)
 
@@ -165,7 +165,7 @@ func TestGetQueryFieldsLegacy(t *testing.T) {
 				s := require.New(t)
 				fields, err := getQueryFieldsLegacy(
 					testNamespace,
-					searchattribute.TestNameTypeMap,
+					searchattribute.TestEsNameTypeMap(),
 					searchattribute.NewTestMapperProvider(nil),
 					tc.input,
 				)
@@ -200,14 +200,14 @@ func TestGetQueryFields(t *testing.T) {
 		},
 		{
 			name:           "filter custom search attribute",
-			input:          "CustomKeywordField = 'foo'",
-			expectedFields: []string{"CustomKeywordField"},
+			input:          "AliasForKeyword01 = 'foo'",
+			expectedFields: []string{"AliasForKeyword01"},
 			expectedErrMsg: "",
 		},
 		{
 			name:           "filter multiple custom search attribute",
-			input:          "(CustomKeywordField = 'foo' AND CustomIntField = 123) OR CustomKeywordField = 'bar'",
-			expectedFields: []string{"CustomKeywordField", "CustomIntField"},
+			input:          "(AliasForKeyword01 = 'foo' AND AliasForInt01 = 123) OR AliasForKeyword01 = 'bar'",
+			expectedFields: []string{"AliasForKeyword01", "AliasForInt01"},
 			expectedErrMsg: "",
 		},
 		{
@@ -224,8 +224,8 @@ func TestGetQueryFields(t *testing.T) {
 		},
 		{
 			name:           "filter TemporalSchedulePaused and custom search attribute",
-			input:          "TemporalSchedulePaused = true AND CustomKeywordField = 'foo'",
-			expectedFields: []string{"TemporalSchedulePaused", "CustomKeywordField"},
+			input:          "TemporalSchedulePaused = true AND AliasForKeyword01 = 'foo'",
+			expectedFields: []string{"TemporalSchedulePaused", "AliasForKeyword01"},
 			expectedErrMsg: "",
 		},
 		{
@@ -236,7 +236,7 @@ func TestGetQueryFields(t *testing.T) {
 		},
 		{
 			name:           "invalid query filter",
-			input:          "CustomKeywordField = foo",
+			input:          "AliasForKeyword01 = foo",
 			expectedFields: nil,
 			expectedErrMsg: "invalid query",
 		},
@@ -255,8 +255,8 @@ func TestGetQueryFields(t *testing.T) {
 				s := require.New(t)
 				fields, err := getQueryFields(
 					testNamespace,
-					searchattribute.TestNameTypeMap,
-					searchattribute.NewTestMapperProvider(nil),
+					searchattribute.TestNameTypeMap(),
+					searchattribute.NewTestMapperProvider(&searchattribute.TestMapper{}),
 					tc.input,
 				)
 				if tc.expectedErrMsg == "" {
@@ -288,12 +288,12 @@ func TestValidateVisibilityQuery(t *testing.T) {
 		},
 		{
 			name:           "filter custom search attribute",
-			input:          "CustomKeywordField = 'foo'",
+			input:          "AliasForKeyword01 = 'foo'",
 			expectedErrMsg: "",
 		},
 		{
 			name:           "filter multiple custom search attribute",
-			input:          "(CustomKeywordField = 'foo' AND CustomIntField = 123) OR CustomKeywordField = 'bar'",
+			input:          "(AliasForKeyword01 = 'foo' AND AliasForInt01 = 123) OR AliasForKeyword01 = 'bar'",
 			expectedErrMsg: "",
 		},
 		{
@@ -308,7 +308,7 @@ func TestValidateVisibilityQuery(t *testing.T) {
 		},
 		{
 			name:           "filter TemporalSchedulePaused and custom search attribute",
-			input:          "TemporalSchedulePaused = true AND CustomKeywordField = 'foo'",
+			input:          "TemporalSchedulePaused = true AND AliasForKeyword01 = 'foo'",
 			expectedErrMsg: "",
 		},
 		{
@@ -318,7 +318,7 @@ func TestValidateVisibilityQuery(t *testing.T) {
 		},
 		{
 			name:           "invalid query filter",
-			input:          "CustomKeywordField = foo",
+			input:          "AliasForKeyword01 = foo",
 			expectedErrMsg: "invalid query",
 		},
 		{
@@ -335,8 +335,8 @@ func TestValidateVisibilityQuery(t *testing.T) {
 				s := require.New(t)
 				err := ValidateVisibilityQuery(
 					testNamespace,
-					searchattribute.TestNameTypeMap,
-					searchattribute.NewTestMapperProvider(nil),
+					searchattribute.TestNameTypeMap(),
+					searchattribute.NewTestMapperProvider(&searchattribute.TestMapper{}),
 					dynamicconfig.GetBoolPropertyFn(true),
 					tc.input,
 				)

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -431,19 +431,15 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_KeywordQuery() {
 	tl := "es-functional-list-workflow-keyword-query-test-taskqueue"
 	request := s.createStartWorkflowExecutionRequest(id, wt, tl)
 
-	searchAttr, err := searchattribute.Encode(
-		map[string]any{
-			"CustomKeywordField": "justice for all",
-		},
-		&searchattribute.TestNameTypeMap,
-	)
+	searchAttr := map[string]any{
+		"CustomKeywordField": "justice for all",
+	}
+	encodedSearchAttr, err := searchattribute.Encode(searchAttr, nil)
 	s.NoError(err)
 
-	request.SearchAttributes = searchAttr
+	request.SearchAttributes = encodedSearchAttr
 	we1, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
 	s.NoError(err)
-
-	time.Sleep(testcore.WaitForESToSettle) //nolint:forbidigo
 
 	// Exact match Keyword (supported)
 	var openExecution *workflowpb.WorkflowExecutionInfo
@@ -452,15 +448,16 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_KeywordQuery() {
 		PageSize:  testcore.DefaultPageSize,
 		Query:     `CustomKeywordField = "justice for all"`,
 	}
-	for i := 0; i < numOfRetry; i++ {
-		resp, err := s.FrontendClient().ListWorkflowExecutions(testcore.NewContext(), listRequest)
-		s.NoError(err)
-		if len(resp.GetExecutions()) == 1 {
+	s.EventuallyWithT(
+		func(c *assert.CollectT) {
+			resp, err := s.FrontendClient().ListWorkflowExecutions(testcore.NewContext(), listRequest)
+			require.NoError(c, err)
+			require.Len(c, resp.GetExecutions(), 1)
 			openExecution = resp.GetExecutions()[0]
-			break
-		}
-		time.Sleep(waitTimeInMs * time.Millisecond) //nolint:forbidigo
-	}
+		},
+		testcore.WaitForESToSettle,
+		100*time.Millisecond,
+	)
 	s.NotNil(openExecution)
 	s.Equal(we1.GetRunId(), openExecution.GetExecution().GetRunId())
 	s.True(!openExecution.GetExecutionTime().AsTime().Before(openExecution.GetStartTime().AsTime()))
@@ -501,7 +498,10 @@ func (s *AdvancedVisibilitySuite) TestListWorkflow_KeywordQuery() {
 	s.Len(resp.GetExecutions(), 1)
 	s.Equal(id, resp.Executions[0].GetExecution().GetWorkflowId())
 	s.Equal(wt, resp.Executions[0].GetType().GetName())
-	s.ProtoEqual(searchAttr, resp.Executions[0].GetSearchAttributes())
+
+	decodedSearchAttr, err := searchattribute.Decode(resp.Executions[0].GetSearchAttributes(), nil, false)
+	s.NoError(err)
+	s.Equal(searchAttr, decodedSearchAttr)
 
 	listRequest = &workflowservice.ListWorkflowExecutionsRequest{
 		Namespace: s.Namespace().String(),

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -246,8 +246,10 @@ func newClusterWithPersistenceTestBaseFactory(t *testing.T, clusterConfig *TestC
 	var (
 		indexName string
 		esClient  esclient.Client
+		saTypeMap searchattribute.NameTypeMap
 	)
 	if !UseSQLVisibility() {
+		saTypeMap = searchattribute.TestEsNameTypeMap()
 		clusterConfig.ESConfig = &esclient.Config{
 			Indices: map[string]string{
 				esclient.VisibilityAppName: RandomizeStr("temporal_visibility_v1_test"),
@@ -274,6 +276,7 @@ func newClusterWithPersistenceTestBaseFactory(t *testing.T, clusterConfig *TestC
 			return nil, err
 		}
 	} else {
+		saTypeMap = searchattribute.TestNameTypeMap()
 		clusterConfig.ESConfig = nil
 		storeConfig := pConfig.DataStores[pConfig.VisibilityStore]
 		if storeConfig.SQL != nil {
@@ -309,7 +312,7 @@ func newClusterWithPersistenceTestBaseFactory(t *testing.T, clusterConfig *TestC
 	err := testBase.SearchAttributesManager.SaveSearchAttributes(
 		context.Background(),
 		indexName,
-		searchattribute.TestNameTypeMap.Custom(),
+		saTypeMap.Custom(),
 	)
 	if err != nil {
 		return nil, err
@@ -444,7 +447,7 @@ func setupIndex(esConfig *esclient.Config, logger log.Logger) error {
 	logger.Info("Index created.", tag.ESIndex(esConfig.GetVisibilityIndex()))
 
 	logger.Info("Add custom search attributes for tests.")
-	_, err = esClient.PutMapping(ctx, esConfig.GetVisibilityIndex(), searchattribute.TestNameTypeMap.Custom())
+	_, err = esClient.PutMapping(ctx, esConfig.GetVisibilityIndex(), searchattribute.TestEsNameTypeMap().Custom())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What changed?
Split `searchattribute.TestNameTypeMap` in two: one for ES setup, and one for SQL DB setup.

## Why?
`searchattribute.TestNameTypeMap` is used in tests as the predefined list of custom search attributes. However, it mixes how custom search attributes work differently in Elasticsearch vs SQL databases. This PR splits the variable in two (one for each) so the tests will be a better representation of the actual system.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
