### PR TITLE
feat: Add backend support for `CONTAINS` operator in workflow visibility queries to enable substring matching.

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/converter.go
+++ b/common/persistence/visibility/store/elasticsearch/converter.go
@@ -17,6 +17,8 @@ var allowedComparisonOperators = map[string]struct{}{
 	sqlparser.NotInStr:         {},
 	sqlparser.StartsWithStr:    {},
 	sqlparser.NotStartsWithStr: {},
+	sqlparser.ContainsStr:      {},
+	sqlparser.NotContainsStr:   {},
 }
 
 func NewQueryConverter(

--- a/common/persistence/visibility/store/query/converter.go
+++ b/common/persistence/visibility/store/query/converter.go
@@ -494,6 +494,18 @@ func (c *comparisonExprConverter) Convert(expr sqlparser.Expr) (elastic.Query, e
 			return nil, NewConverterError("right-hand side of '%v' must be a string", comparisonExpr.Operator)
 		}
 		query = elastic.NewBoolQuery().MustNot(elastic.NewPrefixQuery(colName, v))
+	case sqlparser.ContainsStr:
+		v, ok := colValues[0].(string)
+		if !ok {
+			return nil, NewConverterError("right-hand side of '%v' must be a string", comparisonExpr.Operator)
+		}
+		query = elastic.NewWildcardQuery(colName, "*"+v+"*")
+	case sqlparser.NotContainsStr:
+		v, ok := colValues[0].(string)
+		if !ok {
+			return nil, NewConverterError("right-hand side of '%v' must be a string", comparisonExpr.Operator)
+		}
+		query = elastic.NewBoolQuery().MustNot(elastic.NewWildcardQuery(colName, "*"+v+"*"))
 	}
 
 	return query, nil

--- a/common/persistence/visibility/store/sql/query_converter_test.go
+++ b/common/persistence/visibility/store/sql/query_converter_test.go
@@ -339,6 +339,44 @@ func (s *queryConverterSuite) TestConvertComparisonExpr() {
 			),
 		},
 		{
+			name:   "contains expression",
+			input:  "AliasForKeyword01 contains 'substring'",
+			output: `Keyword01 like '%substring%' escape '!'`,
+			err:    nil,
+		},
+		{
+			name:   "not contains expression",
+			input:  "AliasForKeyword01 not contains 'substring'",
+			output: `Keyword01 not like '%substring%' escape '!'`,
+			err:    nil,
+		},
+		{
+			name:   "contains expression with special chars",
+			input:  "AliasForKeyword01 contains 'foo_bar%'",
+			output: `Keyword01 like '%foo!_bar!%%' escape '!'`,
+			err:    nil,
+		},
+		{
+			name:   "contains expression error",
+			input:  "AliasForKeyword01 contains 123",
+			output: "",
+			err: query.NewConverterError(
+				"%s: right-hand side of '%s' must be a literal string (got: 123)",
+				query.InvalidExpressionErrMessage,
+				sqlparser.ContainsStr,
+			),
+		},
+		{
+			name:   "not contains expression error",
+			input:  "AliasForKeyword01 not contains 123",
+			output: "",
+			err: query.NewConverterError(
+				"%s: right-hand side of '%s' must be a literal string (got: 123)",
+				query.InvalidExpressionErrMessage,
+				sqlparser.NotContainsStr,
+			),
+		},
+		{
 			name:   "like expression",
 			input:  "AliasForKeyword01 like 'foo%'",
 			output: "",


### PR DESCRIPTION
## What changed?

Add `CONTAINS` operator support for substring matching in workflow visibility queries.

**Files modified:**
- `common/persistence/visibility/store/sql/query_converter.go` + tests
- `common/persistence/visibility/store/elasticsearch/converter.go`
- `common/persistence/visibility/store/query/converter.go`
- `go.mod` (replace directive for local sqlparser)

**Query transformation:**
```sql
WorkflowId CONTAINS "substring" 
→ SQL: LIKE '%substring%' ESCAPE '!'
→ ES: WildcardQuery("*substring*")
```

**Related PRs:** sqlparser ([link]) and UI ([link]) - all three must merge together.

## Why?

Enable substring search for WorkflowId/WorkflowType. Currently only prefix matching (`STARTS_WITH`) is available.

**Example use case:** Find workflows containing "user-service" anywhere in the name:
- `ai-agent-user-service-1` ✓
- `api-user-service-sync` ✓  
- `backend-payment-service` ✗

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s) (5 test cases)

**Manual testing:** Created test workflows, verified CONTAINS query returns correct results via CLI and UI.

## Potential risks

**Performance:** `LIKE '%value%'` cannot use indexes (leading wildcard). May be slower on large datasets. Mitigate by combining with other filters (timerange, status).

**Dependencies:** Requires sqlparser PR merged first. Remove `replace` directive in go.mod before merging.

Related PRs: sqlparser ([[link](https://github.com/temporalio/sqlparser/pull/3)]) and UI ([[link](https://github.com/temporalio/ui/pull/3008)]) - all three must merge together.
