### PR TITLE
Fix nexus operation outcome when the min request timeout is reached

### DIFF
--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -453,8 +453,8 @@ func (e taskExecutor) handleStartOperationError(env hsm.Environment, node *hsm.N
 		// operation if the response's operation token is too large.
 		return handleNonRetryableStartOperationError(node, operation, callErr)
 	case errors.Is(callErr, ErrOperationTimeoutBelowMin):
-		// Operation timeout is not retryable
-		return handleNonRetryableStartOperationError(node, operation, callErr)
+		// Not enough time to execute another request, resolve the operation with a timeout.
+		return e.recordOperationTimeout(node)
 	case errors.Is(callErr, context.DeadlineExceeded) || errors.Is(callErr, context.Canceled):
 		// If timed out, we don't leak internal info to the user
 		callErr = errRequestTimedOut
@@ -513,6 +513,10 @@ func (e taskExecutor) executeBackoffTask(env hsm.Environment, node *hsm.Node, ta
 }
 
 func (e taskExecutor) executeTimeoutTask(env hsm.Environment, node *hsm.Node, task TimeoutTask) error {
+	return e.recordOperationTimeout(node)
+}
+
+func (e taskExecutor) recordOperationTimeout(node *hsm.Node) error {
 	return hsm.MachineTransition(node, func(op Operation) (hsm.TransitionOutput, error) {
 		eventID, err := hsm.EventIDFromToken(op.ScheduledEventToken)
 		if err != nil {

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -333,11 +333,11 @@ func TestProcessInvocationTask(t *testing.T) {
 			expectedMetricOutcome: "operation-timeout",
 			onStartOperation:      nil, // This should not be called if the operation has timed out.
 			checkOutcome: func(t *testing.T, op nexusoperations.Operation, events []*historypb.HistoryEvent) {
-				require.Equal(t, enumsspb.NEXUS_OPERATION_STATE_FAILED, op.State())
+				require.Equal(t, enumsspb.NEXUS_OPERATION_STATE_TIMED_OUT, op.State())
 				require.Equal(t, 1, len(events))
-				failure := events[0].GetNexusOperationFailedEventAttributes().Failure.Cause
-				require.NotNil(t, failure.GetApplicationFailureInfo())
-				require.Equal(t, "remaining operation timeout is less than required minimum", failure.Message)
+				failure := events[0].GetNexusOperationTimedOutEventAttributes().Failure.Cause
+				require.NotNil(t, failure.GetTimeoutFailureInfo())
+				require.Equal(t, "operation timed out", failure.Message)
 			},
 		},
 		{


### PR DESCRIPTION
## Why?

This fixes an issue when we realize that the operation is about to time out and we do not have enough time to issue the last start request attempt.
Resolving the operation as failed is misleading.

## How did you test it?
- [x] covered by existing tests (with adjustments to the new behavior)