### PR TITLE
Yx/exclude health

### DIFF
--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -9,7 +9,6 @@ import (
 	"github.com/urfave/cli/v2"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
-	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/service/history/tasks"
 	"go.uber.org/multierr"
 )
@@ -68,19 +67,6 @@ func getCommands(
 			Name:        "decode",
 			Usage:       "Decode payload",
 			Subcommands: newDecodeCommands(taskBlobEncoder),
-		},
-		{
-			Name: "health-check",
-			Action: func(c *cli.Context) error {
-				adminClient := clientFactory.AdminClient(c)
-				ctx, cancel := newContext(c)
-				defer cancel()
-				_, err := adminClient.DeepHealthCheck(ctx, &adminservice.DeepHealthCheckRequest{})
-				if err != nil {
-					return err
-				}
-				return nil
-			},
 		},
 	}
 }


### PR DESCRIPTION
## What changed?
Exclude long poll API from health check signal

## Why?
Long poll APIs has higher latency which could be a noise single to health check

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

