### PR TITLE
[Scheduled Actions] Move backfiller initial task into NewBackfiller

### DIFF
--- a/chasm/lib/scheduler/backfiller.go
+++ b/chasm/lib/scheduler/backfiller.go
@@ -41,6 +41,10 @@ func newBackfiller(
 		},
 		Scheduler: chasm.ComponentPointerTo(ctx, scheduler),
 	}
+
+	// Immediately schedule the first backfiller task.
+	ctx.AddTask(backfiller, chasm.TaskAttributes{}, &schedulerpb.BackfillerTask{})
+
 	return backfiller
 }
 

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -148,7 +148,7 @@ func (s *Scheduler) NewRangeBackfiller(
 	backfiller.Request = &schedulerpb.BackfillerState_BackfillRequest{
 		BackfillRequest: request,
 	}
-	s.addBackfiller(ctx, backfiller)
+	s.Backfillers[backfiller.BackfillId] = chasm.NewComponentField(ctx, backfiller)
 	return backfiller
 }
 
@@ -162,18 +162,8 @@ func (s *Scheduler) NewImmediateBackfiller(
 	backfiller.Request = &schedulerpb.BackfillerState_TriggerRequest{
 		TriggerRequest: request,
 	}
-	s.addBackfiller(ctx, backfiller)
-	return backfiller
-}
-
-// addBackfiller adds the backfiller to the scheduler tree, and adds a task to
-// kick off backfill processing.
-func (s *Scheduler) addBackfiller(
-	ctx chasm.MutableContext,
-	backfiller *Backfiller,
-) {
 	s.Backfillers[backfiller.BackfillId] = chasm.NewComponentField(ctx, backfiller)
-	ctx.AddTask(backfiller, chasm.TaskAttributes{}, &schedulerpb.BackfillerTask{})
+	return backfiller
 }
 
 // useScheduledAction returns true when the Scheduler should allow scheduled


### PR DESCRIPTION
## What changed?
- Moved where the first backfiller task is generated.

## Why?
- I think it's less leaky to have each component manage its own starter task, and this brings Backfiller in line with how Generator kicks off.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
