### PR TITLE
Grouping replication task by workflow Id

### DIFF
--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -279,7 +279,12 @@ func sequentialTaskQueueFactoryProvider(
 		if config.EnableReplicationTaskBatching() {
 			return NewSequentialBatchableTaskQueue(task, nil, logger, metricsHandler)
 		}
-		return NewSequentialTaskQueue(task)
+		item := task.QueueID()
+		workflowKey, ok := item.(definition.WorkflowKey)
+		if !ok {
+			return NewSequentialTaskQueueWithID(item)
+		}
+		return NewSequentialTaskQueueWithID(workflowKey.NamespaceID + "_" + workflowKey.WorkflowID)
 	}
 }
 


### PR DESCRIPTION
## What changed?
Grouping replication task by workflow Id for high priority replication task
## Why?
Reduce the lock contention issue when there is a hot workflow

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
n/a