### PR TITLE
Add docstrings to some chasm entrypoints

### DIFF
--- a/chasm/engine.go
+++ b/chasm/engine.go
@@ -176,6 +176,9 @@ func UpdateWithNewEntity[C Component, I any, O1 any, O2 any](
 //   - consider remove ComponentRef from the return value and allow components to get
 //     the ref in the transition function. There are some caveats there, check the
 //     comment of the NewRef method in MutableContext.
+//
+// UpdateComponent applies updateFn to the component identified by the supplied component reference.
+// It returns the result, along with the new component reference.
 func UpdateComponent[C any, R []byte | ComponentRef, I any, O any](
 	ctx context.Context,
 	r R,
@@ -207,6 +210,8 @@ func UpdateComponent[C any, R []byte | ComponentRef, I any, O any](
 	return output, newSerializedRef, err
 }
 
+// ReadComponent returns the result of evaluating readFn against the current state of the component
+// identified by the supplied component reference.
 func ReadComponent[C any, R []byte | ComponentRef, I any, O any](
 	ctx context.Context,
 	r R,

--- a/service/history/chasm_engine.go
+++ b/service/history/chasm_engine.go
@@ -155,6 +155,10 @@ func (e *ChasmEngine) UpdateWithNewEntity(
 	return chasm.EntityKey{}, nil, serviceerror.NewUnimplemented("UpdateWithNewEntity is not yet supported")
 }
 
+// UpdateComponent applies updateFn to the current state of the component identified by ref, and
+// returns the new component reference corresponding to this transition. An error is returned if the
+// state transition specified by the component reference is not interpretable as part of the entity
+// transition history.
 func (e *ChasmEngine) UpdateComponent(
 	ctx context.Context,
 	ref chasm.ComponentRef,
@@ -207,6 +211,9 @@ func (e *ChasmEngine) UpdateComponent(
 	return newSerializedRef, nil
 }
 
+// ReadComponent evaluates readFn against the current state of the component identified by the
+// supplied component reference. An error is returned if the state transition specified by the
+// component reference is not interpretable as part of the entity transition history.
 func (e *ChasmEngine) ReadComponent(
 	ctx context.Context,
 	ref chasm.ComponentRef,
@@ -547,6 +554,11 @@ func (e *ChasmEngine) getShardContext(
 	return e.shardController.GetShardByID(shardID)
 }
 
+// getExecutionLease returns shard context and mutable state for the entity identified by the
+// supplied component reference, with the lock held. If the state transition specified by the
+// component reference is consistent with mutable state being stale, then mutable state is reloaded
+// from persistence before returning. An error is returned if the state transition specified by the
+// component reference is not interpretable as part of mutable state transition history.
 func (e *ChasmEngine) getExecutionLease(
 	ctx context.Context,
 	ref chasm.ComponentRef,


### PR DESCRIPTION
WISOTT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add concise docstrings for `UpdateComponent`, `ReadComponent`, and `getExecutionLease` in `chasm` and `service/history` engines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db5d7f6779f41830c53601cc59093380f6be5fc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->