### PR TITLE
lock before reading subqueues in emitZeroBacklogGauges

### DIFF
--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -816,8 +816,8 @@ func (db *taskQueueDB) emitZeroBacklogGauges() {
 		return
 	}
 
-	db.Lock()
 	priorities := make(map[int32]struct{})
+	db.Lock()
 	for _, s := range db.subqueues {
 		priorities[s.Key.Priority] = struct{}{}
 	}


### PR DESCRIPTION
## What changed?
We changed the approximateBacklogCount metric to be tagged with priority, this also meant adding that tag in emitZeroBacklogGauges. However now that we're reading the priority off the subqueues, we need to take the lock here before reading.

## Why?
Fix a race found in the functional tests.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
