### PR TITLE
Retry NamespaceNotFound errors for nexus requests

### DIFF
--- a/service/frontend/nexus_http_handler.go
+++ b/service/frontend/nexus_http_handler.go
@@ -261,9 +261,10 @@ func (h *NexusHTTPHandler) nexusContextFromEndpoint(entry *persistencespb.NexusE
 		nsName, err := h.namespaceRegistry.GetNamespaceName(namespace.ID(v.Worker.GetNamespaceId()))
 		if err != nil {
 			h.logger.Error("failed to get namespace name by ID", tag.Error(err))
-			var notFoundErr *serviceerror.NotFound
+			var notFoundErr *serviceerror.NamespaceNotFound
 			if errors.As(err, &notFoundErr) {
-				h.writeNexusFailure(w, http.StatusBadRequest, &nexus.Failure{Message: "invalid endpoint target"})
+				w.Header().Set("nexus-request-retryable", "true")
+				h.writeNexusFailure(w, http.StatusNotFound, &nexus.Failure{Message: "invalid endpoint target"})
 			} else {
 				h.writeNexusFailure(w, http.StatusInternalServerError, &nexus.Failure{Message: "internal error"})
 			}


### PR DESCRIPTION
## What changed?

- Change the condition in `nexus_http_handler.go` to check for `NamespaceNotFound` errors instead of `NotFound` errors. The previous condition was wrong.
- Change the error from a bad request error to a retryable not found error.

## Why?

The error should be retryable as it is always considered to be temporary since namespaces cannot be deleted if they are an endpoint target.
