### PR TITLE
Add namespace filter in SQL VisibilityStore instead of query converter

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/query_converter.go
+++ b/common/persistence/sql/sqlplugin/mysql/query_converter.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/temporalio/sqlparser"
-	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/searchattribute"
@@ -130,23 +129,12 @@ func (c *queryConverter) ConvertTextComparisonExpr(
 }
 
 func (c *queryConverter) BuildSelectStmt(
-	namespaceID namespace.ID,
 	queryParams *query.QueryParams[sqlparser.Expr],
 	pageSize int,
 	token *sqlplugin.VisibilityPageToken,
 ) (string, []any) {
 	var whereClauses []string
 	var queryArgs []any
-
-	// Namespace filter
-	whereClauses = append(
-		whereClauses,
-		fmt.Sprintf(
-			"%s = '%s'",
-			searchattribute.GetSqlDbColName(searchattribute.NamespaceID),
-			namespaceID,
-		),
-	)
 
 	if queryParams.QueryExpr != nil {
 		if queryString := sqlparser.String(queryParams.QueryExpr); queryString != "" {
@@ -183,12 +171,17 @@ func (c *queryConverter) BuildSelectStmt(
 		dbFields[i] = "ev." + field
 	}
 
+	whereString := ""
+	if len(whereClauses) > 0 {
+		whereString = " WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
 	stmt := fmt.Sprintf(
-		`SELECT %s FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (%s, %s) WHERE %s ORDER BY %s DESC, %s DESC, %s LIMIT ?`,
+		`SELECT %s FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (%s, %s)%s ORDER BY %s DESC, %s DESC, %s LIMIT ?`,
 		strings.Join(dbFields, ", "),
 		searchattribute.GetSqlDbColName(searchattribute.NamespaceID),
 		searchattribute.GetSqlDbColName(searchattribute.RunID),
-		strings.Join(whereClauses, " AND "),
+		whereString,
 		sqlparser.String(c.GetCoalesceCloseTimeExpr()),
 		searchattribute.GetSqlDbColName(searchattribute.StartTime),
 		searchattribute.GetSqlDbColName(searchattribute.RunID),
@@ -199,24 +192,13 @@ func (c *queryConverter) BuildSelectStmt(
 }
 
 func (c *queryConverter) BuildCountStmt(
-	namespaceID namespace.ID,
 	queryParams *query.QueryParams[sqlparser.Expr],
 ) (string, []any) {
-	var whereClauses []string
-
-	// Namespace filter
-	whereClauses = append(
-		whereClauses,
-		fmt.Sprintf(
-			"%s = '%s'",
-			searchattribute.GetSqlDbColName(searchattribute.NamespaceID),
-			namespaceID,
-		),
-	)
-
+	whereString := ""
 	if queryParams.QueryExpr != nil {
-		if queryString := sqlparser.String(queryParams.QueryExpr); queryString != "" {
-			whereClauses = append(whereClauses, queryString)
+		whereString = sqlparser.String(queryParams.QueryExpr)
+		if whereString != "" {
+			whereString = " WHERE " + whereString
 		}
 	}
 
@@ -231,11 +213,11 @@ func (c *queryConverter) BuildCountStmt(
 	}
 
 	return fmt.Sprintf(
-		`SELECT %s FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (%s, %s) WHERE %s%s`,
+		`SELECT %s FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (%s, %s)%s%s`,
 		strings.Join(append(groupBy, "COUNT(*)"), ", "),
 		searchattribute.GetSqlDbColName(searchattribute.NamespaceID),
 		searchattribute.GetSqlDbColName(searchattribute.RunID),
-		strings.Join(whereClauses, " AND "),
+		whereString,
 		groupByClause,
 	), nil
 }

--- a/common/persistence/sql/sqlplugin/mysql/query_converter_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/query_converter_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/sqlparser"
 	enumspb "go.temporal.io/api/enums/v1"
-	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/searchattribute"
@@ -161,7 +160,6 @@ func TestQueryConverter_ConvertTextComparisonExpr(t *testing.T) {
 }
 
 func TestQueryConverter_BuildSelectStmt(t *testing.T) {
-	testNamespaceID := namespace.ID("test-namespace-id")
 	closeTime := time.Date(2025, 11, 10, 13, 34, 56, 0, time.UTC)
 	startTime := time.Date(2025, 11, 10, 12, 34, 56, 0, time.UTC)
 	runID := "test-run-id"
@@ -191,9 +189,8 @@ func TestQueryConverter_BuildSelectStmt(t *testing.T) {
 			name:     "empty",
 			pageSize: 10,
 			stmt: fmt.Sprintf(
-				"SELECT %s FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (namespace_id, run_id) WHERE namespace_id = '%s' ORDER BY coalesce(close_time, cast('9999-12-31 23:59:59' as datetime)) DESC, start_time DESC, run_id LIMIT ?",
+				"SELECT %s FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (namespace_id, run_id) ORDER BY coalesce(close_time, cast('9999-12-31 23:59:59' as datetime)) DESC, start_time DESC, run_id LIMIT ?",
 				strings.Join(dbFields, ", "),
-				testNamespaceID.String(),
 			),
 			queryArgs: []any{10},
 		},
@@ -206,9 +203,8 @@ func TestQueryConverter_BuildSelectStmt(t *testing.T) {
 			},
 			pageSize: 20,
 			stmt: fmt.Sprintf(
-				"SELECT %s FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (namespace_id, run_id) WHERE namespace_id = '%s' AND Keyword01 = 'foo' ORDER BY coalesce(close_time, cast('9999-12-31 23:59:59' as datetime)) DESC, start_time DESC, run_id LIMIT ?",
+				"SELECT %s FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (namespace_id, run_id) WHERE Keyword01 = 'foo' ORDER BY coalesce(close_time, cast('9999-12-31 23:59:59' as datetime)) DESC, start_time DESC, run_id LIMIT ?",
 				strings.Join(dbFields, ", "),
-				testNamespaceID.String(),
 			),
 			queryArgs: []any{20},
 		},
@@ -226,9 +222,8 @@ func TestQueryConverter_BuildSelectStmt(t *testing.T) {
 				RunID:     runID,
 			},
 			stmt: fmt.Sprintf(
-				"SELECT %s FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (namespace_id, run_id) WHERE namespace_id = '%s' AND Keyword01 = 'foo' AND ((coalesce(close_time, cast('9999-12-31 23:59:59' as datetime)) = ? AND start_time = ? AND run_id > ?) OR (coalesce(close_time, cast('9999-12-31 23:59:59' as datetime)) = ? AND start_time < ?) OR coalesce(close_time, cast('9999-12-31 23:59:59' as datetime)) < ?) ORDER BY coalesce(close_time, cast('9999-12-31 23:59:59' as datetime)) DESC, start_time DESC, run_id LIMIT ?",
+				"SELECT %s FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (namespace_id, run_id) WHERE Keyword01 = 'foo' AND ((coalesce(close_time, cast('9999-12-31 23:59:59' as datetime)) = ? AND start_time = ? AND run_id > ?) OR (coalesce(close_time, cast('9999-12-31 23:59:59' as datetime)) = ? AND start_time < ?) OR coalesce(close_time, cast('9999-12-31 23:59:59' as datetime)) < ?) ORDER BY coalesce(close_time, cast('9999-12-31 23:59:59' as datetime)) DESC, start_time DESC, run_id LIMIT ?",
 				strings.Join(dbFields, ", "),
-				testNamespaceID.String(),
 			),
 			queryArgs: []any{
 				closeTime,
@@ -249,7 +244,7 @@ func TestQueryConverter_BuildSelectStmt(t *testing.T) {
 			qp := &query.QueryParams[sqlparser.Expr]{
 				QueryExpr: tc.queryExpr,
 			}
-			stmt, queryArgs := qc.BuildSelectStmt(testNamespaceID, qp, tc.pageSize, tc.token)
+			stmt, queryArgs := qc.BuildSelectStmt(qp, tc.pageSize, tc.token)
 			r.Equal(tc.stmt, stmt)
 			r.Equal(tc.queryArgs, queryArgs)
 		})
@@ -257,7 +252,6 @@ func TestQueryConverter_BuildSelectStmt(t *testing.T) {
 }
 
 func TestQueryConverter_BuildCountStmt(t *testing.T) {
-	testNamespaceID := namespace.ID("test-namespace-id")
 	keywordCol := query.NewSAColumn(
 		"AliasForKeyword01",
 		"Keyword01",
@@ -272,10 +266,7 @@ func TestQueryConverter_BuildCountStmt(t *testing.T) {
 	}{
 		{
 			name: "empty",
-			stmt: fmt.Sprintf(
-				"SELECT COUNT(*) FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (namespace_id, run_id) WHERE namespace_id = '%s'",
-				testNamespaceID.String(),
-			),
+			stmt: "SELECT COUNT(*) FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (namespace_id, run_id)",
 		},
 		{
 			name: "non-empty",
@@ -284,10 +275,7 @@ func TestQueryConverter_BuildCountStmt(t *testing.T) {
 				Left:     keywordCol,
 				Right:    query.NewUnsafeSQLString("foo"),
 			},
-			stmt: fmt.Sprintf(
-				"SELECT COUNT(*) FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (namespace_id, run_id) WHERE namespace_id = '%s' AND Keyword01 = 'foo'",
-				testNamespaceID.String(),
-			),
+			stmt: "SELECT COUNT(*) FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (namespace_id, run_id) WHERE Keyword01 = 'foo'",
 		},
 		{
 			name: "group by",
@@ -299,10 +287,7 @@ func TestQueryConverter_BuildCountStmt(t *testing.T) {
 			groupBy: []*query.SAColumn{
 				query.NewSAColumn(searchattribute.ExecutionStatus, searchattribute.ExecutionStatus, enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 			},
-			stmt: fmt.Sprintf(
-				"SELECT status, COUNT(*) FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (namespace_id, run_id) WHERE namespace_id = '%s' AND Keyword01 = 'foo' GROUP BY status",
-				testNamespaceID.String(),
-			),
+			stmt: "SELECT status, COUNT(*) FROM executions_visibility ev LEFT JOIN custom_search_attributes USING (namespace_id, run_id) WHERE Keyword01 = 'foo' GROUP BY status",
 		},
 	}
 
@@ -314,7 +299,7 @@ func TestQueryConverter_BuildCountStmt(t *testing.T) {
 				QueryExpr: tc.queryExpr,
 				GroupBy:   tc.groupBy,
 			}
-			stmt, queryArgs := qc.BuildCountStmt(testNamespaceID, qp)
+			stmt, queryArgs := qc.BuildCountStmt(qp)
 			r.Equal(tc.stmt, stmt)
 			r.Nil(queryArgs)
 		})

--- a/common/persistence/sql/sqlplugin/postgresql/query_converter_test.go
+++ b/common/persistence/sql/sqlplugin/postgresql/query_converter_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/sqlparser"
 	enumspb "go.temporal.io/api/enums/v1"
-	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/searchattribute"
@@ -186,7 +185,6 @@ func TestQueryConverter_ConvertTextComparisonExpr(t *testing.T) {
 }
 
 func TestQueryConverter_BuildSelectStmt(t *testing.T) {
-	testNamespaceID := namespace.ID("test-namespace-id")
 	closeTime := time.Date(2025, 11, 10, 13, 34, 56, 0, time.UTC)
 	startTime := time.Date(2025, 11, 10, 12, 34, 56, 0, time.UTC)
 	runID := "test-run-id"
@@ -208,9 +206,8 @@ func TestQueryConverter_BuildSelectStmt(t *testing.T) {
 			name:     "empty",
 			pageSize: 10,
 			stmt: fmt.Sprintf(
-				"SELECT %s FROM executions_visibility WHERE namespace_id = '%s' ORDER BY coalesce(close_time, '9999-12-31 23:59:59') DESC, start_time DESC, run_id LIMIT ?",
+				"SELECT %s FROM executions_visibility ORDER BY coalesce(close_time, '9999-12-31 23:59:59') DESC, start_time DESC, run_id LIMIT ?",
 				strings.Join(sqlplugin.DbFields, ", "),
-				testNamespaceID.String(),
 			),
 			queryArgs: []any{10},
 		},
@@ -223,9 +220,8 @@ func TestQueryConverter_BuildSelectStmt(t *testing.T) {
 			},
 			pageSize: 20,
 			stmt: fmt.Sprintf(
-				"SELECT %s FROM executions_visibility WHERE namespace_id = '%s' AND Keyword01 = 'foo' ORDER BY coalesce(close_time, '9999-12-31 23:59:59') DESC, start_time DESC, run_id LIMIT ?",
+				"SELECT %s FROM executions_visibility WHERE Keyword01 = 'foo' ORDER BY coalesce(close_time, '9999-12-31 23:59:59') DESC, start_time DESC, run_id LIMIT ?",
 				strings.Join(sqlplugin.DbFields, ", "),
-				testNamespaceID.String(),
 			),
 			queryArgs: []any{20},
 		},
@@ -243,9 +239,8 @@ func TestQueryConverter_BuildSelectStmt(t *testing.T) {
 				RunID:     runID,
 			},
 			stmt: fmt.Sprintf(
-				"SELECT %s FROM executions_visibility WHERE namespace_id = '%s' AND Keyword01 = 'foo' AND ((coalesce(close_time, '9999-12-31 23:59:59') = ? AND start_time = ? AND run_id > ?) OR (coalesce(close_time, '9999-12-31 23:59:59') = ? AND start_time < ?) OR coalesce(close_time, '9999-12-31 23:59:59') < ?) ORDER BY coalesce(close_time, '9999-12-31 23:59:59') DESC, start_time DESC, run_id LIMIT ?",
+				"SELECT %s FROM executions_visibility WHERE Keyword01 = 'foo' AND ((coalesce(close_time, '9999-12-31 23:59:59') = ? AND start_time = ? AND run_id > ?) OR (coalesce(close_time, '9999-12-31 23:59:59') = ? AND start_time < ?) OR coalesce(close_time, '9999-12-31 23:59:59') < ?) ORDER BY coalesce(close_time, '9999-12-31 23:59:59') DESC, start_time DESC, run_id LIMIT ?",
 				strings.Join(sqlplugin.DbFields, ", "),
-				testNamespaceID.String(),
 			),
 			queryArgs: []any{
 				closeTime,
@@ -266,7 +261,7 @@ func TestQueryConverter_BuildSelectStmt(t *testing.T) {
 			qp := &query.QueryParams[sqlparser.Expr]{
 				QueryExpr: tc.queryExpr,
 			}
-			stmt, queryArgs := qc.BuildSelectStmt(testNamespaceID, qp, tc.pageSize, tc.token)
+			stmt, queryArgs := qc.BuildSelectStmt(qp, tc.pageSize, tc.token)
 			r.Equal(tc.stmt, stmt)
 			r.Equal(tc.queryArgs, queryArgs)
 		})
@@ -274,7 +269,6 @@ func TestQueryConverter_BuildSelectStmt(t *testing.T) {
 }
 
 func TestQueryConverter_BuildCountStmt(t *testing.T) {
-	testNamespaceID := namespace.ID("test-namespace-id")
 	keywordCol := query.NewSAColumn(
 		"AliasForKeyword01",
 		"Keyword01",
@@ -289,10 +283,7 @@ func TestQueryConverter_BuildCountStmt(t *testing.T) {
 	}{
 		{
 			name: "empty",
-			stmt: fmt.Sprintf(
-				"SELECT COUNT(*) FROM executions_visibility WHERE namespace_id = '%s'",
-				testNamespaceID.String(),
-			),
+			stmt: "SELECT COUNT(*) FROM executions_visibility",
 		},
 		{
 			name: "non-empty",
@@ -301,10 +292,7 @@ func TestQueryConverter_BuildCountStmt(t *testing.T) {
 				Left:     keywordCol,
 				Right:    query.NewUnsafeSQLString("foo"),
 			},
-			stmt: fmt.Sprintf(
-				"SELECT COUNT(*) FROM executions_visibility WHERE namespace_id = '%s' AND Keyword01 = 'foo'",
-				testNamespaceID.String(),
-			),
+			stmt: "SELECT COUNT(*) FROM executions_visibility WHERE Keyword01 = 'foo'",
 		},
 		{
 			name: "group by",
@@ -316,10 +304,7 @@ func TestQueryConverter_BuildCountStmt(t *testing.T) {
 			groupBy: []*query.SAColumn{
 				query.NewSAColumn(searchattribute.ExecutionStatus, searchattribute.ExecutionStatus, enumspb.INDEXED_VALUE_TYPE_KEYWORD),
 			},
-			stmt: fmt.Sprintf(
-				"SELECT status, COUNT(*) FROM executions_visibility WHERE namespace_id = '%s' AND Keyword01 = 'foo' GROUP BY status",
-				testNamespaceID.String(),
-			),
+			stmt: "SELECT status, COUNT(*) FROM executions_visibility WHERE Keyword01 = 'foo' GROUP BY status",
 		},
 	}
 
@@ -331,7 +316,7 @@ func TestQueryConverter_BuildCountStmt(t *testing.T) {
 				QueryExpr: tc.queryExpr,
 				GroupBy:   tc.groupBy,
 			}
-			stmt, queryArgs := qc.BuildCountStmt(testNamespaceID, qp)
+			stmt, queryArgs := qc.BuildCountStmt(qp)
 			r.Equal(tc.stmt, stmt)
 			r.Nil(queryArgs)
 		})

--- a/common/persistence/sql/sqlplugin/visibility_query_converter.go
+++ b/common/persistence/sql/sqlplugin/visibility_query_converter.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/temporalio/sqlparser"
-	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 )
 
@@ -49,14 +48,12 @@ type VisibilityQueryConverter interface {
 	) (sqlparser.Expr, error)
 
 	BuildSelectStmt(
-		namespaceID namespace.ID,
 		queryExpr *query.QueryParams[sqlparser.Expr],
 		pageSize int,
 		pageToken *VisibilityPageToken,
 	) (string, []any)
 
 	BuildCountStmt(
-		namespaceID namespace.ID,
 		queryExpr *query.QueryParams[sqlparser.Expr],
 	) (string, []any)
 }

--- a/common/persistence/sql/sqlplugin/visibility_query_converter_mock.go
+++ b/common/persistence/sql/sqlplugin/visibility_query_converter_mock.go
@@ -13,7 +13,6 @@ import (
 	reflect "reflect"
 
 	sqlparser "github.com/temporalio/sqlparser"
-	namespace "go.temporal.io/server/common/namespace"
 	query "go.temporal.io/server/common/persistence/visibility/store/query"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -43,33 +42,33 @@ func (m *MockVisibilityQueryConverter) EXPECT() *MockVisibilityQueryConverterMoc
 }
 
 // BuildCountStmt mocks base method.
-func (m *MockVisibilityQueryConverter) BuildCountStmt(namespaceID namespace.ID, queryExpr *query.QueryParams[sqlparser.Expr]) (string, []any) {
+func (m *MockVisibilityQueryConverter) BuildCountStmt(queryExpr *query.QueryParams[sqlparser.Expr]) (string, []any) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildCountStmt", namespaceID, queryExpr)
+	ret := m.ctrl.Call(m, "BuildCountStmt", queryExpr)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].([]any)
 	return ret0, ret1
 }
 
 // BuildCountStmt indicates an expected call of BuildCountStmt.
-func (mr *MockVisibilityQueryConverterMockRecorder) BuildCountStmt(namespaceID, queryExpr any) *gomock.Call {
+func (mr *MockVisibilityQueryConverterMockRecorder) BuildCountStmt(queryExpr any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildCountStmt", reflect.TypeOf((*MockVisibilityQueryConverter)(nil).BuildCountStmt), namespaceID, queryExpr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildCountStmt", reflect.TypeOf((*MockVisibilityQueryConverter)(nil).BuildCountStmt), queryExpr)
 }
 
 // BuildSelectStmt mocks base method.
-func (m *MockVisibilityQueryConverter) BuildSelectStmt(namespaceID namespace.ID, queryExpr *query.QueryParams[sqlparser.Expr], pageSize int, pageToken *VisibilityPageToken) (string, []any) {
+func (m *MockVisibilityQueryConverter) BuildSelectStmt(queryExpr *query.QueryParams[sqlparser.Expr], pageSize int, pageToken *VisibilityPageToken) (string, []any) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildSelectStmt", namespaceID, queryExpr, pageSize, pageToken)
+	ret := m.ctrl.Call(m, "BuildSelectStmt", queryExpr, pageSize, pageToken)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].([]any)
 	return ret0, ret1
 }
 
 // BuildSelectStmt indicates an expected call of BuildSelectStmt.
-func (mr *MockVisibilityQueryConverterMockRecorder) BuildSelectStmt(namespaceID, queryExpr, pageSize, pageToken any) *gomock.Call {
+func (mr *MockVisibilityQueryConverterMockRecorder) BuildSelectStmt(queryExpr, pageSize, pageToken any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildSelectStmt", reflect.TypeOf((*MockVisibilityQueryConverter)(nil).BuildSelectStmt), namespaceID, queryExpr, pageSize, pageToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildSelectStmt", reflect.TypeOf((*MockVisibilityQueryConverter)(nil).BuildSelectStmt), queryExpr, pageSize, pageToken)
 }
 
 // ConvertKeywordListComparisonExpr mocks base method.

--- a/common/persistence/visibility/store/query/converter.go
+++ b/common/persistence/visibility/store/query/converter.go
@@ -178,12 +178,7 @@ func (c *QueryConverter[ExprT]) Convert(
 		}
 	}
 
-	queryExpr, err := c.storeQC.BuildParenExpr(queryParams.QueryExpr)
-	if err != nil {
-		return nil, err
-	}
-
-	queryParams.QueryExpr, err = c.storeQC.BuildAndExpr(namespaceDivisionExpr, queryExpr)
+	queryParams.QueryExpr, err = c.storeQC.BuildAndExpr(namespaceDivisionExpr, queryParams.QueryExpr)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -103,11 +103,7 @@ func (c *SQLQueryConverter) BuildAndExpr(exprs ...sqlparser.Expr) (sqlparser.Exp
 	}
 	wrappedExprs := make([]sqlparser.Expr, len(exprs))
 	for i, expr := range exprs {
-		if _, ok := expr.(*sqlparser.OrExpr); ok {
-			wrappedExprs[i], _ = c.BuildParenExpr(expr)
-		} else {
-			wrappedExprs[i] = expr
-		}
+		wrappedExprs[i], _ = c.BuildParenExpr(expr)
 	}
 	return query.ReduceExprs(
 		func(left, right sqlparser.Expr) sqlparser.Expr {

--- a/common/persistence/visibility/store/sql/query_converter_test.go
+++ b/common/persistence/visibility/store/sql/query_converter_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/sqlparser"
 	enumspb "go.temporal.io/api/enums/v1"
-	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.uber.org/mock/gomock"
@@ -90,7 +89,6 @@ func (c *dummyVisQC) ConvertIsExpr(
 }
 
 func (c *dummyVisQC) BuildSelectStmt(
-	namespaceID namespace.ID,
 	queryExpr *query.QueryParams[sqlparser.Expr],
 	pageSize int,
 	pageToken *sqlplugin.VisibilityPageToken,
@@ -100,7 +98,6 @@ func (c *dummyVisQC) BuildSelectStmt(
 }
 
 func (c *dummyVisQC) BuildCountStmt(
-	namespaceID namespace.ID,
 	queryExpr *query.QueryParams[sqlparser.Expr],
 ) (string, []any) {
 	c.buildCountStmtCalls++
@@ -241,7 +238,7 @@ func TestSQLQueryConverter_BuildAndExpr(t *testing.T) {
 				parseWhereString("a = 1 and b = 'foo'"),
 				parseWhereString("c = 'bar'"),
 			},
-			out: "a = 1 and b = 'foo' and c = 'bar'",
+			out: "(a = 1 and b = 'foo') and c = 'bar'",
 		},
 		{
 			in: []sqlparser.Expr{
@@ -929,8 +926,8 @@ func TestSQLQueryConverter_SelectStmt(t *testing.T) {
 				VisibilityQueryConverter: pluginVisQCMock,
 			}
 
-			pluginVisQCMock.EXPECT().BuildSelectStmt(testNamespaceID, tc.queryParams, tc.pageSize, tc.pageToken).Return("", nil)
-			queryConverter.BuildSelectStmt(testNamespaceID, tc.queryParams, tc.pageSize, tc.pageToken)
+			pluginVisQCMock.EXPECT().BuildSelectStmt(tc.queryParams, tc.pageSize, tc.pageToken).Return("", nil)
+			queryConverter.BuildSelectStmt(tc.queryParams, tc.pageSize, tc.pageToken)
 		})
 	}
 }
@@ -961,8 +958,8 @@ func TestSQLQueryConverter_CountStmt(t *testing.T) {
 				VisibilityQueryConverter: pluginVisQCMock,
 			}
 
-			pluginVisQCMock.EXPECT().BuildCountStmt(testNamespaceID, tc.queryParams).Return("", nil)
-			queryConverter.BuildCountStmt(testNamespaceID, tc.queryParams)
+			pluginVisQCMock.EXPECT().BuildCountStmt(tc.queryParams).Return("", nil)
+			queryConverter.BuildCountStmt(tc.queryParams)
 		})
 	}
 }

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -183,7 +183,24 @@ func (s *VisibilityStore) listWorkflowExecutions(
 		return nil, err
 	}
 
-	queryParams, err := s.buildQueryParams(request.Namespace, request.Query, sqlQC)
+	saTypeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.GetIndexName(), false)
+	if err != nil {
+		return nil, err
+	}
+
+	saMapper, err := s.searchAttributesMapperProvider.GetMapper(request.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	queryParams, err := buildQueryParams(
+		request.Namespace,
+		request.NamespaceID,
+		request.Query,
+		sqlQC,
+		saTypeMap,
+		saMapper,
+	)
 	if err != nil {
 		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be
 		// only mapper errors).
@@ -199,12 +216,7 @@ func (s *VisibilityStore) listWorkflowExecutions(
 		return nil, err
 	}
 
-	queryString, queryArgs := sqlQC.BuildSelectStmt(
-		request.NamespaceID,
-		queryParams,
-		request.PageSize,
-		pageToken,
-	)
+	queryString, queryArgs := sqlQC.BuildSelectStmt(queryParams, request.PageSize, pageToken)
 	selectFilter := &sqlplugin.VisibilitySelectFilter{
 		Query:     queryString,
 		QueryArgs: queryArgs,
@@ -384,7 +396,24 @@ func (s *VisibilityStore) countWorkflowExecutions(
 		return nil, err
 	}
 
-	queryParams, err := s.buildQueryParams(request.Namespace, request.Query, sqlQC)
+	saTypeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.GetIndexName(), false)
+	if err != nil {
+		return nil, err
+	}
+
+	saMapper, err := s.searchAttributesMapperProvider.GetMapper(request.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	queryParams, err := buildQueryParams(
+		request.Namespace,
+		request.NamespaceID,
+		request.Query,
+		sqlQC,
+		saTypeMap,
+		saMapper,
+	)
 	if err != nil {
 		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be
 		// only mapper errors).
@@ -395,7 +424,7 @@ func (s *VisibilityStore) countWorkflowExecutions(
 		return nil, err
 	}
 
-	queryString, queryArgs := sqlQC.BuildCountStmt(request.NamespaceID, queryParams)
+	queryString, queryArgs := sqlQC.BuildCountStmt(queryParams)
 	groupBy := make([]string, 0, len(queryParams.GroupBy)+1)
 	for _, field := range queryParams.GroupBy {
 		groupBy = append(groupBy, field.FieldName)
@@ -464,35 +493,6 @@ func (s *VisibilityStore) countGroupByWorkflowExecutions(
 		resp.Count += row.Count
 	}
 	return resp, nil
-}
-
-func (s *VisibilityStore) buildQueryParams(
-	namespaceName namespace.Name,
-	queryString string,
-	sqlQC *SQLQueryConverter,
-) (*query.QueryParams[sqlparser.Expr], error) {
-	saTypeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.GetIndexName(), false)
-	if err != nil {
-		return nil, err
-	}
-
-	saMapper, err := s.searchAttributesMapperProvider.GetMapper(namespaceName)
-	if err != nil {
-		return nil, err
-	}
-
-	c := query.NewQueryConverter(sqlQC, namespaceName, saTypeMap, saMapper)
-	queryParams, err := c.Convert(queryString)
-	if err != nil {
-		return nil, err
-	}
-
-	// ORDER BY is not support in SQL visibility store
-	if len(queryParams.OrderBy) > 0 {
-		return nil, query.NewConverterError("%s: 'ORDER BY' clause", query.NotSupportedErrMessage)
-	}
-
-	return queryParams, nil
 }
 
 func (s *VisibilityStore) GetWorkflowExecution(
@@ -691,4 +691,40 @@ func (s *VisibilityStore) AddSearchAttributes(
 ) error {
 	// SQL Visibility does not support modifying schema to add search attributes at this moment.
 	return serviceerror.NewUnimplemented("AddSearchAttributes operation not supported in SQL visibility")
+}
+
+func buildQueryParams(
+	namespaceName namespace.Name,
+	namespaceID namespace.ID,
+	queryString string,
+	sqlQC *SQLQueryConverter,
+	saTypeMap searchattribute.NameTypeMap,
+	saMapper searchattribute.Mapper,
+) (*query.QueryParams[sqlparser.Expr], error) {
+	c := query.NewQueryConverter(sqlQC, namespaceName, saTypeMap, saMapper)
+	queryParams, err := c.Convert(queryString)
+	if err != nil {
+		return nil, err
+	}
+
+	nsFilterExpr, err := sqlQC.ConvertComparisonExpr(
+		sqlparser.EqualStr,
+		query.NamespaceIDSAColumn,
+		namespaceID.String(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	queryParams.QueryExpr, err = sqlQC.BuildAndExpr(nsFilterExpr, queryParams.QueryExpr)
+	if err != nil {
+		return nil, err
+	}
+
+	// ORDER BY is not support in SQL visibility store
+	if len(queryParams.OrderBy) > 0 {
+		return nil, query.NewConverterError("%s: 'ORDER BY' clause", query.NotSupportedErrMessage)
+	}
+
+	return queryParams, nil
 }

--- a/common/persistence/visibility/store/sql/visibility_store_test.go
+++ b/common/persistence/visibility/store/sql/visibility_store_test.go
@@ -1,0 +1,88 @@
+package sql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/sqlparser"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
+	"go.temporal.io/server/common/searchattribute"
+)
+
+var pluginNames = []string{
+	mysql.PluginName,
+	postgresql.PluginName,
+	sqlite.PluginName,
+}
+
+func TestBuildQueryParams(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		query string
+		out   string
+		err   string
+	}{
+		{
+			name:  "empty",
+			query: "",
+			out:   fmt.Sprintf("namespace_id = '%s' and TemporalNamespaceDivision is null", testNamespaceID),
+		},
+		{
+			name:  "one comparison",
+			query: "AliasForKeyword01 = 'foo'",
+			out:   fmt.Sprintf("namespace_id = '%s' and (TemporalNamespaceDivision is null and Keyword01 = 'foo')", testNamespaceID),
+		},
+		{
+			name:  "two comparisons",
+			query: "AliasForKeyword01 = 'foo' and AliasForInt01 = 123",
+			out:   fmt.Sprintf("namespace_id = '%s' and (TemporalNamespaceDivision is null and (Keyword01 = 'foo' and Int01 = 123))", testNamespaceID),
+		},
+		{
+			name:  "with TemporalNamespaceDivision",
+			query: "AliasForKeyword01 = 'foo' and TemporalNamespaceDivision = 'bar'",
+			out:   fmt.Sprintf("namespace_id = '%s' and (Keyword01 = 'foo' and TemporalNamespaceDivision = 'bar')", testNamespaceID),
+		},
+		{
+			name:  "fail invalid custom search attribute",
+			query: "AliasForFoo = 'foo'",
+			err:   "invalid expression: column name 'AliasForFoo' is not a valid search attribute",
+		},
+		{
+			name:  "fail order by not supported",
+			query: "AliasForKeyword01 = 'foo' ORDER BY WorkflowType",
+			err:   "operation is not supported: 'ORDER BY' clause",
+		},
+	}
+
+	for _, pluginName := range pluginNames {
+		for _, tc := range testCases {
+			tcName := fmt.Sprintf("%s/%s", pluginName, tc.name)
+			t.Run(tcName, func(t *testing.T) {
+				r := require.New(t)
+				sqlQC, err := NewSQLQueryConverter(pluginName)
+				r.NoError(err)
+
+				qp, err := buildQueryParams(
+					testNamespaceName,
+					testNamespaceID,
+					tc.query,
+					sqlQC,
+					searchattribute.TestNameTypeMap,
+					&searchattribute.TestMapper{},
+				)
+				if tc.err != "" {
+					r.Error(err)
+					r.ErrorContains(err, tc.err)
+				} else {
+					r.NoError(err)
+					r.Equal(tc.out, sqlparser.String(qp.QueryExpr))
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## What changed?
Move the namespace filter from the inside the unified query converter to the VisibilityStore code.

## Why?
That's a filter that needs to be added no matter the query converter implementation.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
