### PR TITLE
Added request ID transition option when creating activity entity.

### DIFF
--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -39,7 +39,9 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 				// EagerTask: TODO when supported, need to call the same code that would handle the RecordActivityTaskStarted API
 			}, nil
 		},
-		req.GetFrontendRequest())
+		req.GetFrontendRequest(),
+		chasm.WithRequestID(req.GetFrontendRequest().GetRequestId()),
+	)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What changed?
Added request ID transition option when creating activity entity.

## Why?
The requestID is set by the matching service to a UUID, allowing safe retries if the response is lost. Here we add the request ID transition option so chasm engine handles it for us under the hood. 

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

