### PR TITLE
Document high-level CHASM terminology

### DIFF
--- a/docs/architecture/chasm.md
+++ b/docs/architecture/chasm.md
@@ -10,6 +10,6 @@
 
 - A single `Execution` may consist of multiple non-overlapping runs (e.g. successive non-overlapping invocations of an `Activity` or `Workflow` that share the same `businessID`, successive non-overlapping invocations of a `Workflow` by a `Scheduler`).
 
-- An `Execution` has a tree structure in which each subtree is a `Component`. A component, and thus an execution, may comprise one node only.
+- An `Execution` has a tree structure in which each subtree is a `Component`. A component, and thus an execution, may be a tree comprising one node only.
 
-- A `ComponentRef` contains an `ExecutionKey` and a `ComponentPath` that together identify a component within an execution. The component ref contains additional information identifying (uniquely across all clusters when there is a multi-cluster configuration with failovers) a specific transition in execution history.
+- A `ComponentRef` contains an `ExecutionKey`, a `ComponentPath`, and additional information identifying (uniquely across all clusters when there is a multi-cluster configuration with failovers) a specific transition in execution history. Together these identify a component within an execution.


### PR DESCRIPTION
WISOTT [rendered](https://github.com/temporalio/temporal/blob/chasm-terminology/docs/architecture/chasm.md)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new `docs/architecture/chasm.md` page defining key CHASM terms like `Archetype`, `Execution`, `BusinessID`, `Component`, and `ComponentRef`, including multi-run execution semantics.
> 
> - **Docs**:
>   - Add `docs/architecture/chasm.md` describing CHASM terminology:
>     - Define `Archetype` (`Workflow`, `Activity`, `Scheduler`).
>     - Define `Execution` and multi-run execution semantics.
>     - Define `BusinessID` uniqueness constraints (within namespace for non-terminal executions).
>     - Define tree-structured `Component` and `ComponentPath`.
>     - Define `ComponentRef` composition (includes `ExecutionKey`, `ComponentPath`, and transition identifier for multi-cluster uniqueness).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afd6fe8ec0269072f465dfdeb5ca79a6fb830092. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->