### PR TITLE
Reset workflow task attempt not activity task attempt

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -8565,7 +8565,7 @@ func (ms *MutableStateImpl) reschedulePendingWorkflowTask(invalidatePendingTasks
 		ms.executionInfo.WorkflowTaskStamp += 1
 
 		// Reset the attempt; forcing a non-transient workflow task to be scheduled.
-		ms.executionInfo.Attempt = 1
+		ms.executionInfo.WorkflowTaskAttempt = 1
 	}
 
 	return ms.taskGenerator.GenerateScheduleWorkflowTaskTasks(pendingTask.ScheduledEventID)


### PR DESCRIPTION
## What changed?

`reschedulePendingWorkflowTask` should reset the Workflow Task attempt, not the Activity Task attempt.

## Why?

Bug.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
