### PR TITLE
[Pause] Reject queries when workflow is paused

### DIFF
--- a/service/history/api/queryworkflow/api.go
+++ b/service/history/api/queryworkflow/api.go
@@ -96,6 +96,16 @@ func Invoke(
 			}, nil
 		}
 	}
+	// If workflow is paused, return query rejected with PAUSED status.
+	if mutableStateStatus == enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED {
+		return &historyservice.QueryWorkflowResponse{
+			Response: &workflowservice.QueryWorkflowResponse{
+				QueryRejected: &querypb.QueryRejected{
+					Status: enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED,
+				},
+			},
+		}, nil
+	}
 
 	mutableState := workflowLease.GetMutableState()
 	if !mutableState.IsWorkflowExecutionRunning() && !mutableState.HasCompletedAnyWorkflowTask() {

--- a/tests/pause_workflow_execution_test.go
+++ b/tests/pause_workflow_execution_test.go
@@ -165,7 +165,7 @@ func (s *PauseWorkflowExecutionSuite) TestQueryWorkflowWhenPaused() {
 		}
 	}, 5*time.Second, 200*time.Millisecond)
 
-	// Issue a query with reject condition so that paused workflows return QueryRejected with PAUSED status.
+	// Issue a query to the paused workflow. It should return QueryRejected with WORKFLOW_EXECUTION_STATUS_PAUSED status.
 	queryReq := &workflowservice.QueryWorkflowRequest{
 		Namespace: s.Namespace().String(),
 		Execution: &commonpb.WorkflowExecution{
@@ -175,7 +175,6 @@ func (s *PauseWorkflowExecutionSuite) TestQueryWorkflowWhenPaused() {
 		Query: &querypb.WorkflowQuery{
 			QueryType: "__stack_trace",
 		},
-		QueryRejectCondition: enumspb.QUERY_REJECT_CONDITION_NOT_OPEN,
 	}
 	queryResp, err := s.FrontendClient().QueryWorkflow(ctx, queryReq)
 	s.NoError(err)


### PR DESCRIPTION
## What changed?
- Querying a paused workflow returns a "rejected" response.
- Added functional test.

## Why?
Executing queries on a paused workflow may not provide the updated results since the server withholds events from the worker when a workflow is paused. This breaks the current expectation of read-after-write semantics of Query API. Ex: When a client sends a signal to the workflow and follows up with a query, the expectation is that the query result includes the effect of the signal. But for a paused workflow that guarantee cannot be provided. So we are failing the queries in a paused workflow for now.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Queries against paused workflows now return QueryRejected with PAUSED status; adds a functional test to validate behavior.
> 
> - **History API**:
>   - `service/history/api/queryworkflow/api.go`: When `mutableStateStatus` is `WORKFLOW_EXECUTION_STATUS_PAUSED`, return `QueryRejected` with status `PAUSED`.
> - **Tests**:
>   - `tests/pause_workflow_execution_test.go`: Add `TestQueryWorkflowWhenPaused` to verify querying a paused workflow returns `QueryRejected` with `PAUSED` status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f9a8387b5868e289d4c0fbea7909935c1b4f5a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->