### PR TITLE
add support for loading svc from the env

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -138,7 +138,7 @@ func buildCLI() *cli.App {
 					Aliases: []string{"svc"},
 					Value:   cli.NewStringSlice(temporal.DefaultServices...),
 					Usage:   "service(s) to start",
-					EnvVars: []string{"SERVICES"},
+					EnvVars: []string{"TEMPORAL_SERVICES"},
 				},
 			},
 			Before: func(c *cli.Context) error {


### PR DESCRIPTION
## What changed?
Allows the service the server binary starts to be controls by the `TEMPORAL_SERVICES` environment variable.

## Why?
Allows us to remove the shell scripts from the server docker image.

**Breaking Change**: the script currently supports `:` as a list separator but this does not

## Testing
```
===  Single environment variable value ===
+ API_KEY=from-env ./flagtest
Resolved api-key: [from-env] (1 values)

=== Multiple comma-separated values in ENV ===
+ API_KEY=key1,key2,key3 ./flagtest
Resolved api-key: [key1 key2 key3] (3 values)

=== Multiple comma-separated values in CLI arg ===
+ ./flagtest --api-key=cli1,cli2,cli3
Resolved api-key: [cli1 cli2 cli3] (3 values)

=== CLI argument overrides ENV variable (single values) ===
+ API_KEY=from-env ./flagtest --api-key=from-cli
Resolved api-key: [from-cli] (1 values)

=== Multiple --api-key arguments ===
+ ./flagtest --api-key=first --api-key=second --api-key=third
Resolved api-key: [first second third] (3 values)

=== Mixed: multiple args with comma-separated values ===
+ ./flagtest --api-key=a1,a2 --api-key=b1,b2
Resolved api-key: [a1 a2 b1 b2] (4 values)
```