### PR TITLE
Removing duplicated DestinationDownError

### DIFF
--- a/components/callbacks/nexus_invocation.go
+++ b/components/callbacks/nexus_invocation.go
@@ -20,7 +20,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
-	"go.temporal.io/server/service/history/queues"
 	queuescommon "go.temporal.io/server/service/history/queues/common"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
 )
@@ -57,7 +56,7 @@ func outcomeTag(callCtx context.Context, response *http.Response, callErr error)
 
 func (n nexusInvocation) WrapError(result invocationResult, err error) error {
 	if failure, ok := result.(invocationResultRetry); ok {
-		return queues.NewDestinationDownError(failure.err.Error(), err)
+		return queueserrors.NewDestinationDownError(failure.err.Error(), err)
 	}
 	return err
 }

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -27,7 +27,6 @@ import (
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/hsm"
-	"go.temporal.io/server/service/history/queues"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
 	"go.uber.org/fx"
 )
@@ -298,7 +297,7 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 	err = e.saveResult(ctx, env, ref, result, callErr)
 
 	if callErr != nil && isDestinationDown(callErr) {
-		err = queues.NewDestinationDownError(callErr.Error(), err)
+		err = queueserrors.NewDestinationDownError(callErr.Error(), err)
 	}
 
 	return err
@@ -643,7 +642,7 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 	err = e.saveCancelationResult(ctx, env, ref, callErr, args.scheduledEventID)
 
 	if callErr != nil && isDestinationDown(callErr) {
-		err = queues.NewDestinationDownError(callErr.Error(), err)
+		err = queueserrors.NewDestinationDownError(callErr.Error(), err)
 	}
 
 	return err

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -32,7 +32,7 @@ import (
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/hsm"
 	"go.temporal.io/server/service/history/hsm/hsmtest"
-	"go.temporal.io/server/service/history/queues"
+	queueserrors "go.temporal.io/server/service/history/queues/errors"
 	"go.uber.org/mock/gomock"
 )
 
@@ -534,7 +534,7 @@ func TestProcessInvocationTask(t *testing.T) {
 				nexusoperations.InvocationTask{EndpointName: "endpoint-id"},
 			)
 			if tc.destinationDown {
-				var destinationDownErr *queues.DestinationDownError
+				var destinationDownErr *queueserrors.DestinationDownError
 				require.ErrorAs(t, err, &destinationDownErr)
 			} else {
 				require.NoError(t, err)
@@ -848,7 +848,8 @@ func TestProcessCancelationTask(t *testing.T) {
 				nexusoperations.CancelationTask{EndpointName: "endpoint-id"},
 			)
 			if tc.destinationDown {
-				require.IsType(t, &queues.DestinationDownError{}, err)
+				var destinationDownErr *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destinationDownErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/service/history/outbound_queue_standby_task_executor.go
+++ b/service/history/outbound_queue_standby_task_executor.go
@@ -153,7 +153,7 @@ func (e *outboundQueueStandbyTaskExecutor) executeStateMachineTask(
 		// Assuming the dynamic config OutboundStandbyTaskMissingEventsDiscardDelay is long enough,
 		// it should give enough time for the active side to execute the task successfully, and the
 		// standby side to process it as well without discarding the task.
-		err = queues.NewDestinationDownError(
+		err = queueserrors.NewDestinationDownError(
 			"standby task executor returned retryable error",
 			err,
 		)


### PR DESCRIPTION
## What changed?
Remove duplicated `DestinationDownError`

## Why?
Proper error handling

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
NA