### PR TITLE
Fix CHASM not found errors

### DIFF
--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -119,12 +119,6 @@ func (h *handler) DescribeActivityExecution(
 		BusinessID:  req.GetFrontendRequest().GetActivityId(),
 		RunID:       req.GetFrontendRequest().GetRunId(),
 	})
-	defer func() {
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
-			err = serviceerror.NewNotFound("activity execution not found")
-		}
-	}()
 
 	// Below, we send an empty non-error response on context deadline expiry. Here we compute a
 	// deadline that causes us to send that response before the caller's own deadline (see
@@ -187,12 +181,6 @@ func (h *handler) PollActivityExecution(
 		BusinessID:  req.GetFrontendRequest().GetActivityId(),
 		RunID:       req.GetFrontendRequest().GetRunId(),
 	})
-	defer func() {
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
-			err = serviceerror.NewNotFound("activity execution not found")
-		}
-	}()
 
 	// Below, we send an empty non-error response on context deadline expiry. Here we compute a
 	// deadline that causes us to send that response before the caller's own deadline (see

--- a/chasm/registry.go
+++ b/chasm/registry.go
@@ -161,6 +161,15 @@ func (r *Registry) componentOf(componentGoType reflect.Type) (*RegistrableCompon
 	return rc, ok
 }
 
+// ArchetypeDisplayName returns the human-readable name for a given archetype ID.
+func (r *Registry) ArchetypeDisplayName(id ArchetypeID) (string, bool) {
+	rc, ok := r.ComponentByID(id)
+	if !ok {
+		return "", false
+	}
+	return rc.componentType, true
+}
+
 // ArchetypeIDOf returns the ArchetypeID for the given component Go type.
 // This method should only be used by CHASM framework internal,
 // NOT CHASM library developers.

--- a/service/history/chasm_engine_test.go
+++ b/service/history/chasm_engine_test.go
@@ -1016,7 +1016,7 @@ func (s *chasmEngineSuite) TestReadComponent_NotFound() {
 	s.Error(err)
 	var notFound *serviceerror.NotFound
 	s.ErrorAs(err, &notFound)
-	s.Equal("execution not found", notFound.Message)
+	s.Equal("test_component not found for ID: non-existent-execution", notFound.Message)
 }
 
 func (s *chasmEngineSuite) buildPersistenceMutableState(

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -283,7 +283,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityTaskQueue() {
 	require.NotNil(t, pollTaskResp.TaskToken)
 }
 
-func (s *standaloneActivityTestSuite) TestCompleted() {
+func (s *standaloneActivityTestSuite) TestComplete() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -555,7 +555,7 @@ func (s *standaloneActivityTestSuite) TestCompleted() {
 	})
 }
 
-func (s *standaloneActivityTestSuite) TestFailed() {
+func (s *standaloneActivityTestSuite) TestFail() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -853,7 +853,7 @@ func (s *standaloneActivityTestSuite) TestFailed() {
 	})
 }
 
-func (s *standaloneActivityTestSuite) TestCancellation() {
+func (s *standaloneActivityTestSuite) TestRequestCancel() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -1543,9 +1543,24 @@ func (s *standaloneActivityTestSuite) TestCancellation() {
 		require.ErrorAs(t, err, &invalidArgErr)
 		require.Equal(t, "token does not match namespace", invalidArgErr.Message)
 	})
+
+	t.Run("NonExistent", func(t *testing.T) {
+		activityID := testcore.RandomizeStr(t.Name())
+
+		_, err := s.FrontendClient().RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
+			Namespace:  s.Namespace().String(),
+			ActivityId: activityID,
+			Reason:     "Test Cancellation",
+			Identity:   "canceller",
+		})
+
+		var notFoundErr *serviceerror.NotFound
+		require.ErrorAs(t, err, &notFoundErr)
+		require.Equal(t, fmt.Sprintf("activity not found for ID: %s", activityID), notFoundErr.Message)
+	})
 }
 
-func (s *standaloneActivityTestSuite) TestTerminated() {
+func (s *standaloneActivityTestSuite) TestTerminate() {
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -1685,6 +1700,21 @@ func (s *standaloneActivityTestSuite) TestTerminated() {
 		})
 		var failedPreconditionErr *serviceerror.FailedPrecondition
 		require.ErrorAs(t, err, &failedPreconditionErr)
+	})
+
+	t.Run("NonExistent", func(t *testing.T) {
+		activityID := testcore.RandomizeStr(t.Name())
+
+		_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  s.Namespace().String(),
+			ActivityId: activityID,
+			Reason:     "Test Termination",
+			Identity:   "terminator",
+		})
+
+		var notFoundErr *serviceerror.NotFound
+		require.ErrorAs(t, err, &notFoundErr)
+		require.Equal(t, fmt.Sprintf("activity not found for ID: %s", activityID), notFoundErr.Message)
 	})
 }
 
@@ -2499,7 +2529,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution_NotFound() {
 				RunId:      existingRunID,
 			},
 			expectedErr:    notFoundErr,
-			expectedErrMsg: "activity execution not found",
+			expectedErrMsg: "activity not found for ID: non-existent-activity",
 		},
 		{
 			name: "NonExistentRunID",
@@ -2509,7 +2539,7 @@ func (s *standaloneActivityTestSuite) TestPollActivityExecution_NotFound() {
 				RunId:      "11111111-2222-3333-4444-555555555555",
 			},
 			expectedErr:    notFoundErr,
-			expectedErrMsg: "activity execution not found",
+			expectedErrMsg: fmt.Sprintf("activity not found for ID: %s", existingActivityID),
 		},
 	}
 
@@ -3069,7 +3099,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NotFound() {
 				RunId:      existingRunID,
 			},
 			expectedErr:    notFoundErr,
-			expectedErrMsg: "activity execution not found",
+			expectedErrMsg: "activity not found for ID: non-existent-activity",
 		},
 		{
 			name: "NonExistentRunID",
@@ -3079,7 +3109,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NotFound() {
 				RunId:      "11111111-2222-3333-4444-555555555555",
 			},
 			expectedErr:    notFoundErr,
-			expectedErrMsg: "activity execution not found",
+			expectedErrMsg: fmt.Sprintf("activity not found for ID: %s", existingActivityID),
 		},
 	}
 
@@ -3109,7 +3139,7 @@ func (s *standaloneActivityTestSuite) TestDescribeActivityExecution_NotFound() {
 		})
 		var notFoundErr *serviceerror.NotFound
 		require.ErrorAs(t, err, &notFoundErr)
-		require.Equal(t, "activity execution not found", notFoundErr.Message)
+		require.Equal(t, "activity not found for ID: non-existent-activity", notFoundErr.Message)
 	})
 }
 


### PR DESCRIPTION
## What changed?
- Make `ArchetypeDisplayName` available on `Registry`
- Use it to create more appropriate and helpful `NotFound` error messages

## Why?
- Fixes a bug: CHASM `<verb>Component` APIs were returning "Workflow not found for ID" messages on NotFound
- Including archetype name in error messages is helpful for users

## How did you test it?
- [x] added new functional test(s)

## Potential risks
Could break schedules and standalone activity if there's a mistake

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error conversion behavior for CHASM reads/polls and standalone activity APIs; risk is mainly compatibility for clients/tests that assert exact `NotFound` messages.
> 
> **Overview**
> Fixes CHASM `NotFound` responses to be *archetype-aware* instead of leaking generic workflow/“activity execution” wording.
> 
> The history `ChasmEngine` now converts underlying persistence `NotFound` errors into `"<archetype> not found for ID: <businessID>"` using a new `Registry.ArchetypeDisplayName` helper, and standalone activity long-poll handlers stop overriding `NotFound` messages. Tests are updated/added to assert the new messages and add coverage for non-existent cancel/terminate activity requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b88a5db09c74e9c80fb1d0f40adf53a888e99d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->