### PR TITLE
remove errr check in chasm unit test

### DIFF
--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -562,14 +562,12 @@ func (s *nodeSuite) assertParentPointer(testComponentNode *Node) {
 	_, found := testComponent.ParentPtr.TryGet(chasmContext)
 	s.False(found)
 
-	subComponent1, err := testComponent.SubComponent1.Get(chasmContext)
-	s.NoError(err)
+	subComponent1 := testComponent.SubComponent1.Get(chasmContext)
 	testComponentFromPtr := subComponent1.ParentPtr.Get(chasmContext)
 	// Asserting they actually point to the same testComponent object.
 	s.Same(testComponent, testComponentFromPtr)
 
-	subComponent11, err := subComponent1.SubComponent11.Get(chasmContext)
-	s.NoError(err)
+	subComponent11 := subComponent1.SubComponent11.Get(chasmContext)
 	testSubComponent1FromPtr := subComponent11.ParentPtr.Get(chasmContext)
 	// Asserting they actually point to the same testSubComponent1 object.
 	s.Same(subComponent1, testSubComponent1FromPtr)


### PR DESCRIPTION
## What changed?
- The chasm.Field.Get method recently changed to not return an error per [this](https://github.com/temporalio/temporal/pull/8669) 
- Thus, we don't (and can't) check an error in the unit-test. Moreover, if there were to be an error, the test would simply panic with the error message.

## Why?
- Correctness

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- None, this is a unit test that I am fixing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update tree tests to remove error handling and use the new non-error Field.Get() signature in parent pointer assertions.
> 
> - **Tests**:
>   - Update `chasm/tree_test.go` `assertParentPointer` to use `Field.Get(ctx)` without error returns; remove related `s.NoError(err)` checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b32e6874290217789361a09f11056e450bd40b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->