### PR TITLE
Implement LifecycleState for chasm.Callback

### DIFF
--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -49,8 +49,14 @@ func NewCallback(
 }
 
 func (c *Callback) LifecycleState(_ chasm.Context) chasm.LifecycleState {
-	// TODO (seankane): implement lifecycle state
-	return chasm.LifecycleStateRunning
+	switch c.Status {
+	case callbackspb.CALLBACK_STATUS_SUCCEEDED:
+		return chasm.LifecycleStateCompleted
+	case callbackspb.CALLBACK_STATUS_FAILED:
+		return chasm.LifecycleStateFailed
+	default:
+		return chasm.LifecycleStateRunning
+	}
 }
 
 func (c *Callback) StateMachineState() callbackspb.CallbackStatus {


### PR DESCRIPTION
## What changed?
Implement `LifecycleState` method for chasm.Callback which was always showing Running

## Why?
Addresses a TODO

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
NA
