### PR TITLE
Emit error log if deregistered search attribute in chasm vis task

### DIFF
--- a/service/history/visibility_queue_task_executor.go
+++ b/service/history/visibility_queue_task_executor.go
@@ -410,9 +410,9 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 	for alias, value := range aliasedSearchAttributes {
 		fieldName, err := searchAttributesMapper.GetFieldName(alias, namespaceEntry.Name().String())
 		if err != nil {
-			// INFO: To reach here, either the search attribute has been deregistered before task execution, which is valid behavior,
-			// or the upserted search attribute is incorrectly mapped, indicating possible bug in application code.
-			t.logger.Error("Failed to get field name for alias, ignoring search attribute", tag.NewStringTag("alias", alias), tag.Error(err))
+			// To reach here, either the search attribute has been deregistered before task execution, which is valid behavior,
+			// or there are delays in propagating search attribute mappings to History.
+			t.logger.Warn("Failed to get field name for alias, ignoring search attribute", tag.NewStringTag("alias", alias), tag.Error(err))
 			continue
 		}
 		searchattributes[fieldName] = value


### PR DESCRIPTION
## What changed?
Emit warn log if deregistered search attribute in chasm vis task. 

Original thread: https://github.com/temporalio/temporal/pull/8662#discussion_r2561591969

## Current State
If user deregisters search attributes while the task is getting processed, current code leads to task failure.

In ES, if the search attribute has been deregistered, upsert SA task execution would still fail when generating the ES Doc and attempting to decode the value. 

In the SQL implementation, since these fields are constant and always attached to the NameTypeMap/ClusterMetadata, Upserting these fields would succeed, so there is a discrepancy between these stores.

## Why?

Once we have parity between ES and SQL for preallocated columns, we should not throw an error if a search attribute gets deregistered when executing the CHASM vis task and just do a best effort upsert call. User deregistering search attributes after archetype execution is a valid use case.

A valid concern is if the visibility component somehow has an incorrect search attribute (eg. field name). There was an issue the past caught because errors were thrown during translation, which showed search attribute already translated to field name before hitting the translation layer (due to application code bug). However, Error logs should be sufficient to debug.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
