### PR TITLE
Forbid use of time.Now() in chasm libraries

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -36,6 +36,8 @@ linters:
           msg: "Please use require.Eventually or assert.Eventually instead unless you've no other option"
         - pattern: panic
           msg: "Please avoid using panic in application code"
+        - pattern: time\.Now
+          msg: "Using time.Now is not allowed in chasm/lib package (non-test files), use ctx.Now(component) instead"
     depguard:
       rules:
         main:
@@ -153,6 +155,14 @@ linters:
     rules:
       - path-except: _test\.go|tests/.+\.go
         text: "time.Sleep"
+        linters:
+          - forbidigo
+      - path-except: chasm/lib/.*\.go$
+        text: "time.Now"
+        linters:
+          - forbidigo
+      - path: chasm/lib/.*_test\.go$
+        text: "time.Now"
         linters:
           - forbidigo
       - path: _test\.go|tests/.+\.go|common/testing/


### PR DESCRIPTION
## What changed?

Use forbidigo to enforce `time.Now()` is not used in CHASM code.

## Why?

We want to support pause and time skipping as part of the CHASM framework, which requires that the framework provides the time.