### PR TITLE
Populate blob and memo size limits for DescribeNamespace

### DIFF
--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -863,6 +863,10 @@ func (d *namespaceHandler) createResponse(
 			ReportedProblemsSearchAttribute: numConsecutiveWorkflowTaskProblemsToTriggerSearchAttribute > 0,
 			WorkerHeartbeats:                d.config.WorkerHeartbeatsEnabled(info.Name),
 		},
+		Limits: &namespacepb.NamespaceInfo_Limits{
+			BlobSizeLimitError: int64(d.config.BlobSizeLimitError(info.Name)),
+			MemoSizeLimitError: int64(d.config.MemoSizeLimitError(info.Name)),
+		},
 		SupportsSchedules: d.config.EnableSchedules(info.Name),
 	}
 

--- a/service/frontend/namespace_handler_test.go
+++ b/service/frontend/namespace_handler_test.go
@@ -358,7 +358,7 @@ func (s *namespaceHandlerCommonSuite) TestListNamespace() {
 	}
 }
 
-func (s *namespaceHandlerCommonSuite) TestCapabilities() {
+func (s *namespaceHandlerCommonSuite) TestCapabilitiesAndLimits() {
 	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), &persistence.GetNamespaceRequest{
 		Name: "ns",
 	}).Return(
@@ -384,6 +384,8 @@ func (s *namespaceHandlerCommonSuite) TestCapabilities() {
 	s.True(resp.NamespaceInfo.Capabilities.AsyncUpdate)
 	s.True(resp.NamespaceInfo.Capabilities.ReportedProblemsSearchAttribute)
 	s.True(resp.NamespaceInfo.Capabilities.WorkerHeartbeats)
+	s.Equal(int64(2*1024*1024), resp.NamespaceInfo.Limits.BlobSizeLimitError)
+	s.Equal(int64(2*1024*1024), resp.NamespaceInfo.Limits.MemoSizeLimitError)
 
 	// Second call: Override the default value of dynamic configs.
 	s.config.EnableEagerWorkflowStart = dc.GetBoolPropertyFnFilteredByNamespace(false)
@@ -391,6 +393,8 @@ func (s *namespaceHandlerCommonSuite) TestCapabilities() {
 	s.config.EnableUpdateWorkflowExecutionAsyncAccepted = dc.GetBoolPropertyFnFilteredByNamespace(false)
 	s.config.NumConsecutiveWorkflowTaskProblemsToTriggerSearchAttribute = dc.GetIntPropertyFnFilteredByNamespace(5)
 	s.config.WorkerHeartbeatsEnabled = dc.GetBoolPropertyFnFilteredByNamespace(false)
+	s.config.BlobSizeLimitError = dc.GetIntPropertyFnFilteredByNamespace(1024)
+	s.config.MemoSizeLimitError = dc.GetIntPropertyFnFilteredByNamespace(512)
 
 	resp, err = s.handler.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: "ns",
@@ -401,6 +405,8 @@ func (s *namespaceHandlerCommonSuite) TestCapabilities() {
 	s.False(resp.NamespaceInfo.Capabilities.AsyncUpdate)
 	s.True(resp.NamespaceInfo.Capabilities.ReportedProblemsSearchAttribute)
 	s.False(resp.NamespaceInfo.Capabilities.WorkerHeartbeats)
+	s.Equal(int64(1024), resp.NamespaceInfo.Limits.BlobSizeLimitError)
+	s.Equal(int64(512), resp.NamespaceInfo.Limits.MemoSizeLimitError)
 }
 
 func (s *namespaceHandlerCommonSuite) TestRegisterNamespace_WithOneCluster() {

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -89,6 +89,7 @@ type Config struct {
 	// size limit system protection
 	BlobSizeLimitError dynamicconfig.IntPropertyFnWithNamespaceFilter
 	BlobSizeLimitWarn  dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MemoSizeLimitError dynamicconfig.IntPropertyFnWithNamespaceFilter
 
 	ThrottledLogRPS dynamicconfig.IntPropertyFn
 
@@ -297,6 +298,7 @@ func NewConfig(
 		DisableListVisibilityByFilter:            dynamicconfig.DisableListVisibilityByFilter.Get(dc),
 		BlobSizeLimitError:                       dynamicconfig.BlobSizeLimitError.Get(dc),
 		BlobSizeLimitWarn:                        dynamicconfig.BlobSizeLimitWarn.Get(dc),
+		MemoSizeLimitError:                       dynamicconfig.MemoSizeLimitError.Get(dc),
 		ThrottledLogRPS:                          dynamicconfig.FrontendThrottledLogRPS.Get(dc),
 		ShutdownDrainDuration:                    dynamicconfig.FrontendShutdownDrainDuration.Get(dc),
 		ShutdownFailHealthCheckDuration:          dynamicconfig.FrontendShutdownFailHealthCheckDuration.Get(dc),


### PR DESCRIPTION
## What changed?
Populates BlobSizeLimitError and MemoSizeLimitError in the response for DescribeNamespace

## Why?
Currently the BlobSizeLimitError and MemoSizeLimitError are terminating the workflow with the check performed on the server. In order, for SDK to enforce and fail workflow task, we need to pass those to the SDK. https://github.com/temporalio/api/pull/670 is the change that added those limits to the NamespaceInfo structure.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] added new unit test(s)

## Potential risks
No risks, as those are not used yet.
