### PR TITLE
Fix uuid usage

### DIFF
--- a/tests/pause_workflow_execution_test.go
+++ b/tests/pause_workflow_execution_test.go
@@ -170,7 +170,7 @@ func (s *PauseWorkflowExecutionSuite) TestQueryWorkflowWhenPaused() {
 		RunId:      runID,
 		Identity:   s.pauseIdentity,
 		Reason:     s.pauseReason,
-		RequestId:  uuid.New(),
+		RequestId:  uuid.NewString(),
 	}
 	pauseResp, err := s.FrontendClient().PauseWorkflowExecution(ctx, pauseRequest)
 	s.NoError(err)


### PR DESCRIPTION
## What changed?
Fixed uuid usage (`uuid.NewString()`)

## Why?
Because `uuid.New()` doesn't exist

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace uuid.New() with uuid.NewString() for RequestId in pause workflow execution tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e8e7d443caf67a39cb7e51e8f2db1bd6a30e43f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->