### PR TITLE
Increase max Nexus operation header size to 8K

### DIFF
--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -67,7 +67,7 @@ use as the token.`,
 
 var MaxOperationHeaderSize = dynamicconfig.NewNamespaceIntSetting(
 	"component.nexusoperations.limit.header.size",
-	4096,
+	8192,
 	`The maximum allowed header size for a Nexus Operation.
 ScheduleNexusOperation commands with a "nexus_header" field that exceeds this limit will be rejected.
 Uses Go's len() function on header keys and values to determine the total size.`,


### PR DESCRIPTION
## What changed?
Increased the default max Nexus operation header size to 8K from 4K. Dynamic config is `component.nexusoperations.limit.header.size`

## Why?
4K was too restrictive, especially for auth headers which can be long.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

