### PR TITLE
Make the enableChasm flag per-NS instead of global

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2634,7 +2634,7 @@ that task will be sent to DLQ.`,
 		"Enable generating request ID reference links",
 	)
 
-	EnableChasm = NewGlobalBoolSetting(
+	EnableChasm = NewNamespaceBoolSetting(
 		"history.enableChasm",
 		false,
 		"Use real chasm tree implementation instead of the noop one",

--- a/service/history/chasm_engine_test.go
+++ b/service/history/chasm_engine_test.go
@@ -68,7 +68,7 @@ func (s *chasmEngineSuite) SetupTest() {
 	s.mockEngine = historyi.NewMockEngine(s.controller)
 
 	s.config = tests.NewDynamicConfig()
-	s.config.EnableChasm = dynamicconfig.GetBoolPropertyFn(true)
+	s.config.EnableChasm = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 
 	s.mockShard = shard.NewTestContext(
 		s.controller,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -66,7 +66,7 @@ type Config struct {
 	MaxCallbacksPerWorkflow               dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxCHASMCallbacksPerWorkflow          dynamicconfig.IntPropertyFnWithNamespaceFilter
 	EnableRequestIdRefLinks               dynamicconfig.BoolPropertyFn
-	EnableChasm                           dynamicconfig.BoolPropertyFn
+	EnableChasm                           dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableCHASMCallbacks                  dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	ChasmMaxInMemoryPureTasks             dynamicconfig.IntPropertyFn
 	EnableCHASMSchedulerCreation          dynamicconfig.BoolPropertyFnWithNamespaceFilter

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -165,5 +165,6 @@ func NewDynamicConfig() *configs.Config {
 	config.ReplicationEnableUpdateWithNewTaskMerge = dynamicconfig.GetBoolPropertyFn(true)
 	config.EnableWorkflowIdReuseStartTimeValidation = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.EnableTransitionHistory = dynamicconfig.GetBoolPropertyFn(true)
+	config.EnableChasm = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false)
 	return config
 }

--- a/service/history/visibility_queue_task_executor_test.go
+++ b/service/history/visibility_queue_task_executor_test.go
@@ -100,7 +100,7 @@ func (s *visibilityQueueTaskExecutorSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 
 	config := tests.NewDynamicConfig()
-	config.EnableChasm = dynamicconfig.GetBoolPropertyFn(true)
+	config.EnableChasm = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	s.mockShard = shard.NewTestContext(
 		s.controller,
 		&persistencespb.ShardInfo{

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -397,7 +397,7 @@ func NewMutableState(
 
 	s.mustInitHSM()
 
-	if s.config.EnableChasm() {
+	if s.config.EnableChasm(namespaceEntry.Name().String()) {
 		s.chasmTree = chasm.NewEmptyTree(
 			shard.ChasmRegistry(),
 			shard.GetTimeSource(),
@@ -542,7 +542,7 @@ func NewMutableStateFromDB(
 		mutableState.chasmNodeSizes[key] = nodeSize
 	}
 
-	if shard.GetConfig().EnableChasm() {
+	if shard.GetConfig().EnableChasm(namespaceEntry.Name().String()) {
 		var err error
 		mutableState.chasmTree, err = chasm.NewTreeFromDB(
 			dbRecord.ChasmNodes,


### PR DESCRIPTION
## What changed?
- The `enableChasm` dynamic config flag is now applied per-namespace.

## Why?
- For this release, we only want CHASM enabled in canary codepaths, for both callbacks and scheduler.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- This reduces the risk by reducing `enableChasm`'s blast radius. However, we'll need to be wary of writing tests that rely on `enableChasm` being set to `false` (current default), since in the future it'll be enabled everywhere.
