### PR TITLE
fix: make release dep check job always run on PRs

### DIFF
--- a/.github/workflows/check-release-dependencies.yml
+++ b/.github/workflows/check-release-dependencies.yml
@@ -1,16 +1,24 @@
 name: Check Release Dependencies
 on:
-  pull_request:
-    branches:
-      - release/*
-      - cloud/*
+  pull_request: {}
+
+permissions:
+  contents: read
+
 jobs:
   check-dependencies:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        if: >-
+          startsWith('release/', github.event.pull_request.base.ref) ||
+          startsWith('cloud/', github.event.pull_request.base.ref)
+
       - name: Check temporal dependencies use tagged versions
+        if: >-
+          startsWith('release/', github.event.pull_request.base.ref) ||
+          startsWith('cloud/', github.event.pull_request.base.ref)
         run: |
           echo "Checking that temporal dependencies use tagged versions..."
 


### PR DESCRIPTION
## What changed?

Always run the release dependency check job on all PRs. When the PR is not against a release branch, it gracefully degrades to a no-op.

## Why?

This will let us make the status required, so that it can actually block releases that fail the job.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
