### PR TITLE
CHASM: remove stack trace from archetypeID assertion

### DIFF
--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -3,7 +3,6 @@ package persistence
 import (
 	"context"
 	"errors"
-	"runtime/debug"
 	"strings"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -1187,7 +1186,6 @@ func (m *executionManagerImpl) assertAndConvertArchetypeID(
 		archetypeID != chasm.UnspecifiedArchetypeID,
 		"ArchetypeID not specified, defaulting to Workflow.",
 		tag.Operation(methodName),
-		tag.SysStackTrace(string(debug.Stack())),
 	) {
 		return chasm.WorkflowArchetypeID, true
 	}

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -4,7 +4,6 @@ package cache
 
 import (
 	"context"
-	"runtime/debug"
 	"sync/atomic"
 	"time"
 
@@ -268,7 +267,6 @@ func (c *cacheImpl) getOrCreateWorkflowExecutionInternal(
 		shardContext.GetLogger(),
 		archetypeID != chasm.UnspecifiedArchetypeID,
 		"Creating execution cache key with unspecified archetype ID",
-		tag.SysStackTrace(string(debug.Stack())),
 	) {
 		archetypeID = chasm.WorkflowArchetypeID
 	}

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"context"
-	"runtime/debug"
 	"strconv"
 
 	"go.opentelemetry.io/otel/trace"
@@ -76,7 +75,6 @@ func NewContext(
 		contextImpl.throttledLogger,
 		contextImpl.archetypeID != chasm.UnspecifiedArchetypeID,
 		"Creating execution context with unspecified archetype ID",
-		tag.SysStackTrace(string(debug.Stack())),
 	)
 
 	return contextImpl


### PR DESCRIPTION
## What changed?
- Remove stacktrace tag from archetypeID assertion

## Why?
- If assertions the error log will automatically add a stack trace
- Existing impl is taking a stack dump for every request

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
