### PR TITLE
Fix poll based replication resend

### DIFF
--- a/service/history/replication/dlq_handler_test.go
+++ b/service/history/replication/dlq_handler_test.go
@@ -100,7 +100,7 @@ func (s *dlqHandlerSuite) SetupTest() {
 			return NewTaskExecutor(
 				params.RemoteCluster,
 				params.Shard,
-				params.HistoryResender,
+				params.RemoteHistoryFetcher,
 				params.DeleteManager,
 				params.WorkflowCache,
 			)

--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -108,7 +108,7 @@ func replicationTaskExecutorProvider() TaskExecutorProvider {
 		return NewTaskExecutor(
 			params.RemoteCluster,
 			params.Shard,
-			params.HistoryResender,
+			params.RemoteHistoryFetcher,
 			params.DeleteManager,
 			params.WorkflowCache,
 		)

--- a/service/history/replication/task_executor.go
+++ b/service/history/replication/task_executor.go
@@ -32,25 +32,25 @@ type (
 	}
 
 	TaskExecutorParams struct {
-		RemoteCluster   string // TODO: Remove this remote cluster from executor then it can use singleton.
-		Shard           historyi.ShardContext
-		HistoryResender eventhandler.ResendHandler
-		DeleteManager   deletemanager.DeleteManager
-		WorkflowCache   wcache.Cache
+		RemoteCluster        string // TODO: Remove this remote cluster from executor then it can use singleton.
+		Shard                historyi.ShardContext
+		RemoteHistoryFetcher eventhandler.HistoryPaginatedFetcher
+		DeleteManager        deletemanager.DeleteManager
+		WorkflowCache        wcache.Cache
 	}
 
 	TaskExecutorProvider func(params TaskExecutorParams) TaskExecutor
 
 	taskExecutorImpl struct {
-		currentCluster    string
-		remoteCluster     string
-		shardContext      historyi.ShardContext
-		namespaceRegistry namespace.Registry
-		resendHandler     eventhandler.ResendHandler
-		deleteManager     deletemanager.DeleteManager
-		workflowCache     wcache.Cache
-		metricsHandler    metrics.Handler
-		logger            log.Logger
+		currentCluster       string
+		remoteCluster        string
+		shardContext         historyi.ShardContext
+		namespaceRegistry    namespace.Registry
+		remoteHistoryFetcher eventhandler.HistoryPaginatedFetcher
+		deleteManager        deletemanager.DeleteManager
+		workflowCache        wcache.Cache
+		metricsHandler       metrics.Handler
+		logger               log.Logger
 	}
 )
 
@@ -59,20 +59,20 @@ type (
 func NewTaskExecutor(
 	remoteCluster string,
 	shardContext historyi.ShardContext,
-	resendHandler eventhandler.ResendHandler,
+	remoteHistoryFetcher eventhandler.HistoryPaginatedFetcher,
 	deleteManager deletemanager.DeleteManager,
 	workflowCache wcache.Cache,
 ) TaskExecutor {
 	return &taskExecutorImpl{
-		currentCluster:    shardContext.GetClusterMetadata().GetCurrentClusterName(),
-		remoteCluster:     remoteCluster,
-		shardContext:      shardContext,
-		namespaceRegistry: shardContext.GetNamespaceRegistry(),
-		resendHandler:     resendHandler,
-		deleteManager:     deleteManager,
-		workflowCache:     workflowCache,
-		metricsHandler:    shardContext.GetMetricsHandler(),
-		logger:            shardContext.GetLogger(),
+		currentCluster:       shardContext.GetClusterMetadata().GetCurrentClusterName(),
+		remoteCluster:        remoteCluster,
+		shardContext:         shardContext,
+		namespaceRegistry:    shardContext.GetNamespaceRegistry(),
+		remoteHistoryFetcher: remoteHistoryFetcher,
+		deleteManager:        deleteManager,
+		workflowCache:        workflowCache,
+		metricsHandler:       shardContext.GetMetricsHandler(),
+		logger:               shardContext.GetLogger(),
 	}
 }
 
@@ -170,7 +170,7 @@ func (e *taskExecutorImpl) handleActivityTask(
 			)
 		}()
 
-		resendErr := e.resendHandler.ResendHistoryEvents(
+		resendErr := e.resend(
 			ctx,
 			e.remoteCluster,
 			namespace.ID(retryErr.NamespaceId),
@@ -264,8 +264,7 @@ func (e *taskExecutorImpl) handleHistoryReplicationTask(
 				metrics.ServiceRoleTag(metrics.HistoryRoleTagValue),
 			)
 		}()
-
-		resendErr := e.resendHandler.ResendHistoryEvents(
+		resendErr := e.resend(
 			ctx,
 			e.remoteCluster,
 			namespace.ID(retryErr.NamespaceId),
@@ -330,7 +329,7 @@ func (e *taskExecutorImpl) handleSyncWorkflowStateTask(
 	case nil:
 		return nil
 	case *serviceerrors.RetryReplication:
-		resendErr := e.resendHandler.ResendHistoryEvents(
+		resendErr := e.resend(
 			ctx,
 			e.remoteCluster,
 			namespace.ID(retryErr.NamespaceId),
@@ -425,4 +424,47 @@ func (e *taskExecutorImpl) newTaskContext(
 	ctx = headers.SetCallerName(ctx, namespaceName.String())
 
 	return ctx, cancel
+}
+
+func (e *taskExecutorImpl) resend(
+	ctx context.Context,
+	remoteClusterName string,
+	namespaceID namespace.ID,
+	workflowID string,
+	runID string,
+	startEventID int64,
+	startEventVersion int64,
+	endEventID int64,
+	endEventVersion int64) error {
+	iterator := e.remoteHistoryFetcher.GetSingleWorkflowHistoryPaginatedIteratorExclusive(
+		ctx,
+		remoteClusterName,
+		namespaceID,
+		workflowID,
+		runID,
+		startEventID,
+		startEventVersion,
+		endEventID,
+		endEventVersion,
+	)
+	for iterator.HasNext() {
+		historyBatch, err := iterator.Next()
+		if err != nil {
+			return err
+		}
+		replicateRequest := &historyservice.ReplicateEventsV2Request{
+			NamespaceId: namespaceID.String(),
+			WorkflowExecution: &commonpb.WorkflowExecution{
+				WorkflowId: workflowID,
+				RunId:      runID,
+			},
+			Events:              historyBatch.RawEventBatch,
+			VersionHistoryItems: historyBatch.VersionHistory.GetItems(),
+		}
+		_, err = e.shardContext.GetHistoryClient().ReplicateEventsV2(ctx, replicateRequest)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/service/history/replication/task_executor_test.go
+++ b/service/history/replication/task_executor_test.go
@@ -19,6 +19,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/resourcetest"
@@ -39,16 +40,15 @@ type (
 		*require.Assertions
 		controller *gomock.Controller
 
-		remoteCluster      string
-		mockResource       *resourcetest.Test
-		mockShard          *shard.ContextTest
-		config             *configs.Config
-		historyClient      *historyservicemock.MockHistoryServiceClient
-		mockNamespaceCache *namespace.MockRegistry
-		clusterMetadata    *cluster.MockMetadata
-		workflowCache      *wcache.MockCache
-		nDCHistoryResender *eventhandler.MockResendHandler
-
+		remoteCluster           string
+		mockResource            *resourcetest.Test
+		mockShard               *shard.ContextTest
+		config                  *configs.Config
+		historyClient           *historyservicemock.MockHistoryServiceClient
+		mockNamespaceCache      *namespace.MockRegistry
+		clusterMetadata         *cluster.MockMetadata
+		workflowCache           *wcache.MockCache
+		remoteHistoryFetcher    *eventhandler.MockHistoryPaginatedFetcher
 		replicationTaskExecutor *taskExecutorImpl
 	}
 )
@@ -86,9 +86,10 @@ func (s *taskExecutorSuite) SetupTest() {
 	s.mockResource = s.mockShard.Resource
 	s.mockNamespaceCache = s.mockResource.NamespaceCache
 	s.clusterMetadata = s.mockResource.ClusterMetadata
-	s.nDCHistoryResender = eventhandler.NewMockResendHandler(s.controller)
+
 	s.historyClient = historyservicemock.NewMockHistoryServiceClient(s.controller)
 	s.workflowCache = wcache.NewMockCache(s.controller)
+	s.remoteHistoryFetcher = eventhandler.NewMockHistoryPaginatedFetcher(s.controller)
 
 	s.clusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockNamespaceCache.EXPECT().GetNamespaceName(gomock.Any()).Return(tests.Namespace, nil).AnyTimes()
@@ -96,7 +97,7 @@ func (s *taskExecutorSuite) SetupTest() {
 	s.replicationTaskExecutor = NewTaskExecutor(
 		s.remoteCluster,
 		s.mockShard,
-		s.nDCHistoryResender,
+		s.remoteHistoryFetcher,
 		deletemanager.NewMockDeleteManager(s.controller),
 		s.workflowCache,
 	).(*taskExecutorImpl)
@@ -263,7 +264,10 @@ func (s *taskExecutorSuite) TestProcessTaskOnce_SyncActivityReplicationTask_Rese
 		456,
 	)
 	s.historyClient.EXPECT().SyncActivity(gomock.Any(), request).Return(nil, resendErr)
-	s.nDCHistoryResender.EXPECT().ResendHistoryEvents(
+	emptyIterator := collection.NewPagingIterator(func(paginationToken []byte) ([]*eventhandler.HistoryBatch, []byte, error) {
+		return nil, nil, nil
+	})
+	s.remoteHistoryFetcher.EXPECT().GetSingleWorkflowHistoryPaginatedIteratorExclusive(
 		gomock.Any(),
 		s.remoteCluster,
 		namespaceID,
@@ -273,7 +277,7 @@ func (s *taskExecutorSuite) TestProcessTaskOnce_SyncActivityReplicationTask_Rese
 		int64(234),
 		int64(345),
 		int64(456),
-	)
+	).Return(emptyIterator)
 
 	s.historyClient.EXPECT().SyncActivity(gomock.Any(), request).Return(&historyservice.SyncActivityResponse{}, nil)
 	err := s.replicationTaskExecutor.Execute(context.Background(), task, true)
@@ -351,7 +355,10 @@ func (s *taskExecutorSuite) TestProcess_HistoryReplicationTask_Resend() {
 		456,
 	)
 	s.historyClient.EXPECT().ReplicateEventsV2(gomock.Any(), request).Return(nil, resendErr)
-	s.nDCHistoryResender.EXPECT().ResendHistoryEvents(
+	emptyIterator := collection.NewPagingIterator(func(paginationToken []byte) ([]*eventhandler.HistoryBatch, []byte, error) {
+		return nil, nil, nil
+	})
+	s.remoteHistoryFetcher.EXPECT().GetSingleWorkflowHistoryPaginatedIteratorExclusive(
 		gomock.Any(),
 		s.remoteCluster,
 		namespaceID,
@@ -361,7 +368,7 @@ func (s *taskExecutorSuite) TestProcess_HistoryReplicationTask_Resend() {
 		int64(234),
 		int64(345),
 		int64(456),
-	)
+	).Return(emptyIterator)
 
 	s.historyClient.EXPECT().ReplicateEventsV2(gomock.Any(), request).Return(&historyservice.ReplicateEventsV2Response{}, nil)
 	err := s.replicationTaskExecutor.Execute(context.Background(), task, true)


### PR DESCRIPTION
## What changed?
Fix poll based replication resend

## Why?
Poll based replication have cross shard call, so we need to use history client to resend.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
No risk.