### PR TITLE
Change dev environment to enable chasm

### DIFF
--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -55,3 +55,5 @@ history.hostLevelCacheMaxSize:
   - value: 8192
 history.enableTransitionHistory:
   - value: true
+history.enableChasm:
+  - value: true

--- a/config/dynamicconfig/development-sql.yaml
+++ b/config/dynamicconfig/development-sql.yaml
@@ -71,3 +71,5 @@ history.hostLevelCacheMaxSize:
   - value: 8192
 history.enableTransitionHistory:
   - value: true
+history.enableChasm:
+  - value: true

--- a/config/dynamicconfig/development-xdc.yaml
+++ b/config/dynamicconfig/development-xdc.yaml
@@ -47,3 +47,5 @@ history.enableTransitionHistory:
   - value: true
 history.EnableReplicationTaskTieredProcessing:
   - value: true
+history.enableChasm:
+  - value: true


### PR DESCRIPTION
## What changed?
Change dev environment to enable Chasm

## Why?
Chasm should be enabled for development by default so devs don't have to explicitly set the config.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

