### PR TITLE
Fix CHASM Scheduler memo provider

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -54,6 +54,11 @@ type Scheduler struct {
 	compiledSpec       *scheduler.CompiledSpec // compiledSpec is only ever replaced whole, not mutated.
 }
 
+var (
+	_ (chasm.VisibilitySearchAttributesProvider) = (*Scheduler)(nil)
+	_ (chasm.VisibilityMemoProvider)             = (*Scheduler)(nil)
+)
+
 const (
 	// How many recent actions to keep on the Info.RecentActions list.
 	recentActionCount = 10
@@ -697,19 +702,8 @@ func (s *Scheduler) SearchAttributes(chasm.Context) []chasm.SearchAttributeKeyVa
 // Memo returns the scheduler's info block for visibility.
 func (s *Scheduler) Memo(
 	ctx chasm.Context,
-) map[string]chasm.VisibilityValue {
-	newInfo := s.ListInfo(ctx)
-
-	infoPayload, err := proto.MarshalOptions{
-		Deterministic: true,
-	}.Marshal(newInfo)
-	if err != nil {
-		return nil
-	}
-
-	return map[string]chasm.VisibilityValue{
-		visibilityMemoFieldInfo: chasm.VisibilityValueByteSlice(infoPayload),
-	}
+) proto.Message {
+	return s.ListInfo(ctx)
 }
 
 // ListInfo returns the ScheduleListInfo, used as the visibility memo, and to


### PR DESCRIPTION
## What changed?
Fix CHASM `Scheduler` implementation of `VisibilityMemoProvider`.

## Why?
`VisibilityMemoProvider` interface changed in a previous PR, and this was missed.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
