### PR TITLE
Add metric to track inflight visibility tasks

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -846,7 +846,10 @@ var (
 	QueueReaderCountHistogram = NewDimensionlessHistogramDef("queue_reader_count")
 	QueueSliceCountHistogram  = NewDimensionlessHistogramDef("queue_slice_count")
 	QueueActionCounter        = NewCounterDef("queue_actions")
-	ActivityE2ELatency        = NewTimerDef(
+
+	VisibilityTaskExecutorInflightTasks = NewGaugeDef("visibility_task_executor_inflight_tasks")
+
+	ActivityE2ELatency = NewTimerDef(
 		"activity_end_to_end_latency",
 		WithDescription("DEPRECATED: Will be removed in one of the next releases. Duration of an activity attempt. Use activity_start_to_close_latency instead."),
 	)


### PR DESCRIPTION
## What changed?
Added metric to track number of inflight visibility tasks.

## Why?
Help debug bottlenecks in the visibility task flow: task queue or bulk processor.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
