### PR TITLE
Trying to fix broken unit tests on main

### DIFF
--- a/service/matching/user_data_manager.go
+++ b/service/matching/user_data_manager.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dgryski/go-farm"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/matchingservice/v1"
@@ -250,11 +249,7 @@ func (m *userDataManagerImpl) userDataFetchSource() (*tqid.NormalPartition, erro
 		}
 		// sticky queue can only be of workflow type as of now. but to be future-proof, we make sure
 		// change to workflow task queue here
-		wfTQ := normalQ.Family().TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW)
-		// use hash of the sticky queue name to pick a consistent "parent"
-		partitions := m.config.NumReadPartitions()
-		partition := int(farm.Fingerprint32([]byte(m.partition.RpcName()))) % partitions
-		return wfTQ.NormalPartition(partition), nil
+		return normalQ.Family().TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).RootPartition(), nil
 	}
 
 }


### PR DESCRIPTION
This reverts commit b55fbfcea48eaa67a606c51dca6b0d38f6b18e4d.

## What changed?
- Just reverting the above commit.

## Why?
- This commit, I think, was causing existing unit-tests to timeout consistently. Reverting this should unblock the team from merging things in the temporal repo. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- Not risky

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sticky task queues now fetch user data from the workflow root partition instead of a hashed normal partition; removes hashing logic and farm dependency.
> 
> - **Matching / user data fetching**:
>   - Sticky task queues now query user data from `workflow` `RootPartition()` instead of selecting a normal partition via hashing.
>   - Removed consistent-partition hashing logic and the `go-farm` dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d4ec7e8c320bcde3e85335916b6c756cb4caaec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->