### PR TITLE
Fix chasm unit tests due to merge conflict failures

### DIFF
--- a/chasm/lib/callback/executors_test.go
+++ b/chasm/lib/callback/executors_test.go
@@ -184,7 +184,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 			}
 
 			chasmRegistry := chasm.NewRegistry(logger)
-			err := chasmRegistry.Register(&Library{
+			err = chasmRegistry.Register(&Library{
 				InvocationTaskExecutor: executor,
 			})
 			require.NoError(t, err)
@@ -587,7 +587,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 			}
 
 			chasmRegistry := chasm.NewRegistry(logger)
-			err := chasmRegistry.Register(&Library{
+			err = chasmRegistry.Register(&Library{
 				InvocationTaskExecutor: executor,
 			})
 			require.NoError(t, err)


### PR DESCRIPTION
## What changed?
FIx failing golang linters due to incorrect merge.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
