### PR TITLE
Revert "Grouping replication task by workflow Id (#8604)"

### DIFF
--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -280,12 +280,7 @@ func sequentialTaskQueueFactoryProvider(
 		if config.EnableReplicationTaskBatching() {
 			return NewSequentialBatchableTaskQueue(task, nil, logger, metricsHandler)
 		}
-		item := task.QueueID()
-		workflowKey, ok := item.(definition.WorkflowKey)
-		if !ok {
-			return NewSequentialTaskQueueWithID(item)
-		}
-		return NewSequentialTaskQueueWithID(workflowKey.NamespaceID + "_" + workflowKey.WorkflowID)
+		return NewSequentialTaskQueue(task)
 	}
 }
 


### PR DESCRIPTION
This reverts commit 3bc3b3eaf1c862e7c9974adfc13cdf9ef101cdfb.

## What changed?
Reverting for patch

## Why?
Noise

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
