### PR TITLE
Fix ContinuedFailure not cleared on null success payloads

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -855,12 +855,13 @@ func (s *scheduler) processWatcherResult(id string, f workflow.Future, long bool
 	}
 
 	// handle last completion/failure and record resulting payload sizes
-	if res.GetResult() != nil {
-		s.State.LastCompletionResult = res.GetResult()
+	if res.Status == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
 		s.State.ContinuedFailure = nil
-
-		if resultPayload, err := res.GetResult().Marshal(); err == nil {
-			s.metrics.Counter(metrics.SchedulePayloadSize.Name()).Inc(int64(len(resultPayload)))
+		if res.GetResult() != nil {
+			s.State.LastCompletionResult = res.GetResult()
+			if resultPayload, err := res.GetResult().Marshal(); err == nil {
+				s.metrics.Counter(metrics.SchedulePayloadSize.Name()).Inc(int64(len(resultPayload)))
+			}
 		}
 	} else if res.GetFailure() != nil {
 		// leave LastCompletionResult from previous run


### PR DESCRIPTION
## What changed?
- Clear ContinuedFailure when workflow completes successfully regardless of whether the result payload is null
- Previously, ContinuedFailure was only cleared when res.GetResult() != nil, causing it to persist when workflows completed successfully with null payloads
- Add test TestContinuedFailureCleared to verify the fix
- Edge cases handled:
   - COMPLETED with result payload: Works as before (clears failure + sets result)
   - COMPLETED with null payload: Now correctly clears failure (the bug fix)
   - Other statuses (FAILED, CANCELED, TERMINATED): Unchanged behavior

## Why?
Fixed a bug where ContinuedFailure persisted when scheduled workflows completed successfully with null/empty result payloads. Previously, ContinuedFailure was only cleared when res.GetResult() != nil, causing it to incorrectly propagate to subsequent scheduled actions even after a successful completion. This ensures that any successful workflow completion clears the failure state, regardless of whether a result payload is present.

Fixes #8490 

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
