### PR TITLE
Add extension_data to namespace with replication

### DIFF
--- a/api/persistence/v1/namespaces.pb.go
+++ b/api/persistence/v1/namespaces.pb.go
@@ -11,9 +11,10 @@ import (
 	sync "sync"
 	unsafe "unsafe"
 
+	v11 "go.temporal.io/api/common/v1"
 	v1 "go.temporal.io/api/enums/v1"
-	v11 "go.temporal.io/api/namespace/v1"
-	v12 "go.temporal.io/api/rules/v1"
+	v12 "go.temporal.io/api/namespace/v1"
+	v13 "go.temporal.io/api/rules/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
@@ -128,6 +129,7 @@ type NamespaceInfo struct {
 	Description   string                 `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
 	Owner         string                 `protobuf:"bytes,5,opt,name=owner,proto3" json:"owner,omitempty"`
 	Data          map[string]string      `protobuf:"bytes,6,rep,name=data,proto3" json:"data,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ExtensionData *v11.DataBlob          `protobuf:"bytes,7,opt,name=extension_data,json=extensionData,proto3" json:"extension_data,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -204,17 +206,24 @@ func (x *NamespaceInfo) GetData() map[string]string {
 	return nil
 }
 
+func (x *NamespaceInfo) GetExtensionData() *v11.DataBlob {
+	if x != nil {
+		return x.ExtensionData
+	}
+	return nil
+}
+
 type NamespaceConfig struct {
 	state                        protoimpl.MessageState       `protogen:"open.v1"`
 	Retention                    *durationpb.Duration         `protobuf:"bytes,1,opt,name=retention,proto3" json:"retention,omitempty"`
 	ArchivalBucket               string                       `protobuf:"bytes,2,opt,name=archival_bucket,json=archivalBucket,proto3" json:"archival_bucket,omitempty"`
-	BadBinaries                  *v11.BadBinaries             `protobuf:"bytes,3,opt,name=bad_binaries,json=badBinaries,proto3" json:"bad_binaries,omitempty"`
+	BadBinaries                  *v12.BadBinaries             `protobuf:"bytes,3,opt,name=bad_binaries,json=badBinaries,proto3" json:"bad_binaries,omitempty"`
 	HistoryArchivalState         v1.ArchivalState             `protobuf:"varint,4,opt,name=history_archival_state,json=historyArchivalState,proto3,enum=temporal.api.enums.v1.ArchivalState" json:"history_archival_state,omitempty"`
 	HistoryArchivalUri           string                       `protobuf:"bytes,5,opt,name=history_archival_uri,json=historyArchivalUri,proto3" json:"history_archival_uri,omitempty"`
 	VisibilityArchivalState      v1.ArchivalState             `protobuf:"varint,6,opt,name=visibility_archival_state,json=visibilityArchivalState,proto3,enum=temporal.api.enums.v1.ArchivalState" json:"visibility_archival_state,omitempty"`
 	VisibilityArchivalUri        string                       `protobuf:"bytes,7,opt,name=visibility_archival_uri,json=visibilityArchivalUri,proto3" json:"visibility_archival_uri,omitempty"`
 	CustomSearchAttributeAliases map[string]string            `protobuf:"bytes,8,rep,name=custom_search_attribute_aliases,json=customSearchAttributeAliases,proto3" json:"custom_search_attribute_aliases,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	WorkflowRules                map[string]*v12.WorkflowRule `protobuf:"bytes,9,rep,name=workflow_rules,json=workflowRules,proto3" json:"workflow_rules,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	WorkflowRules                map[string]*v13.WorkflowRule `protobuf:"bytes,9,rep,name=workflow_rules,json=workflowRules,proto3" json:"workflow_rules,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields                protoimpl.UnknownFields
 	sizeCache                    protoimpl.SizeCache
 }
@@ -263,7 +272,7 @@ func (x *NamespaceConfig) GetArchivalBucket() string {
 	return ""
 }
 
-func (x *NamespaceConfig) GetBadBinaries() *v11.BadBinaries {
+func (x *NamespaceConfig) GetBadBinaries() *v12.BadBinaries {
 	if x != nil {
 		return x.BadBinaries
 	}
@@ -305,7 +314,7 @@ func (x *NamespaceConfig) GetCustomSearchAttributeAliases() map[string]string {
 	return nil
 }
 
-func (x *NamespaceConfig) GetWorkflowRules() map[string]*v12.WorkflowRule {
+func (x *NamespaceConfig) GetWorkflowRules() map[string]*v13.WorkflowRule {
 	if x != nil {
 		return x.WorkflowRules
 	}
@@ -437,7 +446,7 @@ var File_temporal_server_api_persistence_v1_namespaces_proto protoreflect.FileDe
 
 const file_temporal_server_api_persistence_v1_namespaces_proto_rawDesc = "" +
 	"\n" +
-	"3temporal/server/api/persistence/v1/namespaces.proto\x12\"temporal.server.api.persistence.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a%temporal/api/enums/v1/namespace.proto\x1a'temporal/api/namespace/v1/message.proto\x1a#temporal/api/rules/v1/message.proto\"\xf2\x03\n" +
+	"3temporal/server/api/persistence/v1/namespaces.proto\x12\"temporal.server.api.persistence.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a%temporal/api/enums/v1/namespace.proto\x1a'temporal/api/namespace/v1/message.proto\x1a#temporal/api/rules/v1/message.proto\x1a$temporal/api/common/v1/message.proto\"\xf2\x03\n" +
 	"\x0fNamespaceDetail\x12E\n" +
 	"\x04info\x18\x01 \x01(\v21.temporal.server.api.persistence.v1.NamespaceInfoR\x04info\x12K\n" +
 	"\x06config\x18\x02 \x01(\v23.temporal.server.api.persistence.v1.NamespaceConfigR\x06config\x12m\n" +
@@ -445,14 +454,15 @@ const file_temporal_server_api_persistence_v1_namespaces_proto_rawDesc = "" +
 	"\x0econfig_version\x18\x04 \x01(\x03R\rconfigVersion\x12B\n" +
 	"\x1dfailover_notification_version\x18\x05 \x01(\x03R\x1bfailoverNotificationVersion\x12)\n" +
 	"\x10failover_version\x18\x06 \x01(\x03R\x0ffailoverVersion\x12F\n" +
-	"\x11failover_end_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x0ffailoverEndTime\"\xb2\x02\n" +
+	"\x11failover_end_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x0ffailoverEndTime\"\xfb\x02\n" +
 	"\rNamespaceInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12;\n" +
 	"\x05state\x18\x02 \x01(\x0e2%.temporal.api.enums.v1.NamespaceStateR\x05state\x12\x12\n" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x04 \x01(\tR\vdescription\x12\x14\n" +
 	"\x05owner\x18\x05 \x01(\tR\x05owner\x12O\n" +
-	"\x04data\x18\x06 \x03(\v2;.temporal.server.api.persistence.v1.NamespaceInfo.DataEntryR\x04data\x1a7\n" +
+	"\x04data\x18\x06 \x03(\v2;.temporal.server.api.persistence.v1.NamespaceInfo.DataEntryR\x04data\x12G\n" +
+	"\x0eextension_data\x18\a \x01(\v2 .temporal.api.common.v1.DataBlobR\rextensionData\x1a7\n" +
 	"\tDataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xac\a\n" +
@@ -505,11 +515,12 @@ var file_temporal_server_api_persistence_v1_namespaces_proto_goTypes = []any{
 	nil,                                // 7: temporal.server.api.persistence.v1.NamespaceConfig.WorkflowRulesEntry
 	(*timestamppb.Timestamp)(nil),      // 8: google.protobuf.Timestamp
 	(v1.NamespaceState)(0),             // 9: temporal.api.enums.v1.NamespaceState
-	(*durationpb.Duration)(nil),        // 10: google.protobuf.Duration
-	(*v11.BadBinaries)(nil),            // 11: temporal.api.namespace.v1.BadBinaries
-	(v1.ArchivalState)(0),              // 12: temporal.api.enums.v1.ArchivalState
-	(v1.ReplicationState)(0),           // 13: temporal.api.enums.v1.ReplicationState
-	(*v12.WorkflowRule)(nil),           // 14: temporal.api.rules.v1.WorkflowRule
+	(*v11.DataBlob)(nil),               // 10: temporal.api.common.v1.DataBlob
+	(*durationpb.Duration)(nil),        // 11: google.protobuf.Duration
+	(*v12.BadBinaries)(nil),            // 12: temporal.api.namespace.v1.BadBinaries
+	(v1.ArchivalState)(0),              // 13: temporal.api.enums.v1.ArchivalState
+	(v1.ReplicationState)(0),           // 14: temporal.api.enums.v1.ReplicationState
+	(*v13.WorkflowRule)(nil),           // 15: temporal.api.rules.v1.WorkflowRule
 }
 var file_temporal_server_api_persistence_v1_namespaces_proto_depIdxs = []int32{
 	1,  // 0: temporal.server.api.persistence.v1.NamespaceDetail.info:type_name -> temporal.server.api.persistence.v1.NamespaceInfo
@@ -518,21 +529,22 @@ var file_temporal_server_api_persistence_v1_namespaces_proto_depIdxs = []int32{
 	8,  // 3: temporal.server.api.persistence.v1.NamespaceDetail.failover_end_time:type_name -> google.protobuf.Timestamp
 	9,  // 4: temporal.server.api.persistence.v1.NamespaceInfo.state:type_name -> temporal.api.enums.v1.NamespaceState
 	5,  // 5: temporal.server.api.persistence.v1.NamespaceInfo.data:type_name -> temporal.server.api.persistence.v1.NamespaceInfo.DataEntry
-	10, // 6: temporal.server.api.persistence.v1.NamespaceConfig.retention:type_name -> google.protobuf.Duration
-	11, // 7: temporal.server.api.persistence.v1.NamespaceConfig.bad_binaries:type_name -> temporal.api.namespace.v1.BadBinaries
-	12, // 8: temporal.server.api.persistence.v1.NamespaceConfig.history_archival_state:type_name -> temporal.api.enums.v1.ArchivalState
-	12, // 9: temporal.server.api.persistence.v1.NamespaceConfig.visibility_archival_state:type_name -> temporal.api.enums.v1.ArchivalState
-	6,  // 10: temporal.server.api.persistence.v1.NamespaceConfig.custom_search_attribute_aliases:type_name -> temporal.server.api.persistence.v1.NamespaceConfig.CustomSearchAttributeAliasesEntry
-	7,  // 11: temporal.server.api.persistence.v1.NamespaceConfig.workflow_rules:type_name -> temporal.server.api.persistence.v1.NamespaceConfig.WorkflowRulesEntry
-	13, // 12: temporal.server.api.persistence.v1.NamespaceReplicationConfig.state:type_name -> temporal.api.enums.v1.ReplicationState
-	4,  // 13: temporal.server.api.persistence.v1.NamespaceReplicationConfig.failover_history:type_name -> temporal.server.api.persistence.v1.FailoverStatus
-	8,  // 14: temporal.server.api.persistence.v1.FailoverStatus.failover_time:type_name -> google.protobuf.Timestamp
-	14, // 15: temporal.server.api.persistence.v1.NamespaceConfig.WorkflowRulesEntry.value:type_name -> temporal.api.rules.v1.WorkflowRule
-	16, // [16:16] is the sub-list for method output_type
-	16, // [16:16] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	10, // 6: temporal.server.api.persistence.v1.NamespaceInfo.extension_data:type_name -> temporal.api.common.v1.DataBlob
+	11, // 7: temporal.server.api.persistence.v1.NamespaceConfig.retention:type_name -> google.protobuf.Duration
+	12, // 8: temporal.server.api.persistence.v1.NamespaceConfig.bad_binaries:type_name -> temporal.api.namespace.v1.BadBinaries
+	13, // 9: temporal.server.api.persistence.v1.NamespaceConfig.history_archival_state:type_name -> temporal.api.enums.v1.ArchivalState
+	13, // 10: temporal.server.api.persistence.v1.NamespaceConfig.visibility_archival_state:type_name -> temporal.api.enums.v1.ArchivalState
+	6,  // 11: temporal.server.api.persistence.v1.NamespaceConfig.custom_search_attribute_aliases:type_name -> temporal.server.api.persistence.v1.NamespaceConfig.CustomSearchAttributeAliasesEntry
+	7,  // 12: temporal.server.api.persistence.v1.NamespaceConfig.workflow_rules:type_name -> temporal.server.api.persistence.v1.NamespaceConfig.WorkflowRulesEntry
+	14, // 13: temporal.server.api.persistence.v1.NamespaceReplicationConfig.state:type_name -> temporal.api.enums.v1.ReplicationState
+	4,  // 14: temporal.server.api.persistence.v1.NamespaceReplicationConfig.failover_history:type_name -> temporal.server.api.persistence.v1.FailoverStatus
+	8,  // 15: temporal.server.api.persistence.v1.FailoverStatus.failover_time:type_name -> google.protobuf.Timestamp
+	15, // 16: temporal.server.api.persistence.v1.NamespaceConfig.WorkflowRulesEntry.value:type_name -> temporal.api.rules.v1.WorkflowRule
+	17, // [17:17] is the sub-list for method output_type
+	17, // [17:17] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_api_persistence_v1_namespaces_proto_init() }

--- a/common/namespace/namespace.go
+++ b/common/namespace/namespace.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
 	rulespb "go.temporal.io/api/rules/v1"
@@ -259,6 +260,13 @@ func (ns *Namespace) GetCustomData(key string) string {
 		return ""
 	}
 	return ns.info.Data[key]
+}
+
+func (ns *Namespace) ExtensionData() *commonpb.DataBlob {
+	if ns.info == nil {
+		return nil
+	}
+	return ns.info.ExtensionData
 }
 
 // Retention returns retention duration for this namespace.

--- a/common/namespace/nsreplication/replication_task_executor.go
+++ b/common/namespace/nsreplication/replication_task_executor.go
@@ -137,12 +137,13 @@ func (h *taskExecutorImpl) handleNamespaceCreationReplicationTask(
 	request := &persistence.CreateNamespaceRequest{
 		Namespace: &persistencespb.NamespaceDetail{
 			Info: &persistencespb.NamespaceInfo{
-				Id:          task.GetId(),
-				Name:        task.Info.GetName(),
-				State:       task.Info.GetState(),
-				Description: task.Info.GetDescription(),
-				Owner:       task.Info.GetOwnerEmail(),
-				Data:        task.Info.Data,
+				Id:            task.GetId(),
+				Name:          task.Info.GetName(),
+				State:         task.Info.GetState(),
+				Description:   task.Info.GetDescription(),
+				Owner:         task.Info.GetOwnerEmail(),
+				Data:          task.Info.Data,
+				ExtensionData: task.Info.GetExtensionData(),
 			},
 			Config: &persistencespb.NamespaceConfig{
 				Retention:                    task.Config.GetWorkflowExecutionRetentionTtl(),
@@ -269,12 +270,13 @@ func (h *taskExecutorImpl) handleNamespaceUpdateReplicationTask(
 	if resp.Namespace.ConfigVersion < task.GetConfigVersion() {
 		recordUpdated = true
 		request.Namespace.Info = &persistencespb.NamespaceInfo{
-			Id:          task.GetId(),
-			Name:        task.Info.GetName(),
-			State:       task.Info.GetState(),
-			Description: task.Info.GetDescription(),
-			Owner:       task.Info.GetOwnerEmail(),
-			Data:        task.Info.Data,
+			Id:            task.GetId(),
+			Name:          task.Info.GetName(),
+			State:         task.Info.GetState(),
+			Description:   task.Info.GetDescription(),
+			Owner:         task.Info.GetOwnerEmail(),
+			Data:          task.Info.Data,
+			ExtensionData: task.Info.GetExtensionData(),
 		}
 		request.Namespace.Config = &persistencespb.NamespaceConfig{
 			Retention:                    task.Config.GetWorkflowExecutionRetentionTtl(),

--- a/common/namespace/nsreplication/transmission_task_handler.go
+++ b/common/namespace/nsreplication/transmission_task_handler.go
@@ -80,11 +80,12 @@ func (r *replicator) HandleTransmissionTask(
 			NamespaceOperation: namespaceOperation,
 			Id:                 info.Id,
 			Info: &namespacepb.NamespaceInfo{
-				Name:        info.Name,
-				State:       info.State,
-				Description: info.Description,
-				OwnerEmail:  info.Owner,
-				Data:        info.Data,
+				Name:          info.Name,
+				State:         info.State,
+				Description:   info.Description,
+				OwnerEmail:    info.Owner,
+				Data:          info.Data,
+				ExtensionData: info.ExtensionData,
 			},
 			Config: &namespacepb.NamespaceConfig{
 				WorkflowExecutionRetentionTtl: config.Retention,

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,8 @@ require (
 	modernc.org/sqlite v1.39.1
 )
 
+require github.com/golang/protobuf v1.5.4 // indirect
+
 require (
 	cel.dev/expr v0.20.0 // indirect
 	cloud.google.com/go v0.118.3 // indirect; indirect e
@@ -170,3 +172,5 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
+
+replace go.temporal.io/api => ../api-go

--- a/go.sum
+++ b/go.sum
@@ -390,8 +390,6 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.59.1-0.20251203230651-7773526824c5 h1:7lFIrLVM+NPVcqFMrEwv5d8D9meA7n/Xl9GtCl8Gyhc=
-go.temporal.io/api v1.59.1-0.20251203230651-7773526824c5/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.35.0 h1:lRNAQ5As9rLgYa7HBvnmKyzxLcdElTuoFJ0FXM/AsLQ=
 go.temporal.io/sdk v1.35.0/go.mod h1:1q5MuLc2MEJ4lneZTHJzpVebW2oZnyxoIOWX3oFVebw=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/proto/internal/temporal/server/api/persistence/v1/namespaces.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/namespaces.proto
@@ -9,6 +9,7 @@ import "google/protobuf/timestamp.proto";
 import "temporal/api/enums/v1/namespace.proto";
 import "temporal/api/namespace/v1/message.proto";
 import "temporal/api/rules/v1/message.proto";
+import "temporal/api/common/v1/message.proto";
 
 // detail column
 message NamespaceDetail {
@@ -28,6 +29,7 @@ message NamespaceInfo {
     string description = 4;
     string owner = 5;
     map<string, string> data = 6;
+    temporal.api.common.v1.DataBlob extension_data = 7;
 }
 
 message NamespaceConfig {

--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -182,12 +182,13 @@ func (d *namespaceHandler) RegisterNamespace(
 	}
 
 	info := &persistencespb.NamespaceInfo{
-		Id:          uuid.NewString(),
-		Name:        registerRequest.GetNamespace(),
-		State:       enumspb.NAMESPACE_STATE_REGISTERED,
-		Owner:       registerRequest.GetOwnerEmail(),
-		Description: registerRequest.GetDescription(),
-		Data:        registerRequest.Data,
+		Id:            uuid.NewString(),
+		Name:          registerRequest.GetNamespace(),
+		State:         enumspb.NAMESPACE_STATE_REGISTERED,
+		Owner:         registerRequest.GetOwnerEmail(),
+		Description:   registerRequest.GetDescription(),
+		Data:          registerRequest.Data,
+		ExtensionData: registerRequest.GetExtensionData(),
 	}
 	config := &persistencespb.NamespaceConfig{
 		Retention:                    registerRequest.GetWorkflowExecutionRetentionPeriod(),
@@ -433,6 +434,10 @@ func (d *namespaceHandler) UpdateNamespace(
 				return nil, err
 			}
 			info.State = updatedInfo.State
+		}
+		if updatedInfo.ExtensionData != nil {
+			configurationChanged = true
+			info.ExtensionData = updatedInfo.ExtensionData
 		}
 	}
 	if updateRequest.Config != nil {
@@ -849,12 +854,13 @@ func (d *namespaceHandler) createResponse(
 	numConsecutiveWorkflowTaskProblemsToTriggerSearchAttribute := d.config.NumConsecutiveWorkflowTaskProblemsToTriggerSearchAttribute(info.Name)
 
 	infoResult := &namespacepb.NamespaceInfo{
-		Name:        info.Name,
-		State:       info.State,
-		Description: info.Description,
-		OwnerEmail:  info.Owner,
-		Data:        info.Data,
-		Id:          info.Id,
+		Name:          info.Name,
+		State:         info.State,
+		Description:   info.Description,
+		OwnerEmail:    info.Owner,
+		Data:          info.Data,
+		Id:            info.Id,
+		ExtensionData: info.ExtensionData,
 
 		Capabilities: &namespacepb.NamespaceInfo_Capabilities{
 			EagerWorkflowStart:              d.config.EnableEagerWorkflowStart(info.Name),


### PR DESCRIPTION
## What changed?
Adding extension_data to namespace model

IGNORE go.mod for now as needed to work with locally built api-go which was a headache

## Why?
If we want to add/persist binary data later on

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

