### PR TITLE
Propagate external payload downlod stats to history events

### DIFF
--- a/cmd/tools/getproto/files.go
+++ b/cmd/tools/getproto/files.go
@@ -75,6 +75,7 @@ func init() {
 	importMap["temporal/api/replication/v1/message.proto"] = replication.File_temporal_api_replication_v1_message_proto
 	importMap["temporal/api/rules/v1/message.proto"] = rules.File_temporal_api_rules_v1_message_proto
 	importMap["temporal/api/schedule/v1/message.proto"] = schedule.File_temporal_api_schedule_v1_message_proto
+	importMap["temporal/api/sdk/v1/external_payload_download_stats.proto"] = sdk.File_temporal_api_sdk_v1_external_payload_download_stats_proto
 	importMap["temporal/api/sdk/v1/task_complete_metadata.proto"] = sdk.File_temporal_api_sdk_v1_task_complete_metadata_proto
 	importMap["temporal/api/sdk/v1/user_metadata.proto"] = sdk.File_temporal_api_sdk_v1_user_metadata_proto
 	importMap["temporal/api/sdk/v1/worker_config.proto"] = sdk.File_temporal_api_sdk_v1_worker_config_proto

--- a/go.mod
+++ b/go.mod
@@ -170,3 +170,8 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
+
+replace (
+	go.temporal.io/api => ../api-go
+	go.temporal.io/sdk => ../sdk-go
+)

--- a/go.sum
+++ b/go.sum
@@ -390,10 +390,6 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.59.1-0.20251203230651-7773526824c5 h1:7lFIrLVM+NPVcqFMrEwv5d8D9meA7n/Xl9GtCl8Gyhc=
-go.temporal.io/api v1.59.1-0.20251203230651-7773526824c5/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
-go.temporal.io/sdk v1.35.0 h1:lRNAQ5As9rLgYa7HBvnmKyzxLcdElTuoFJ0FXM/AsLQ=
-go.temporal.io/sdk v1.35.0/go.mod h1:1q5MuLc2MEJ4lneZTHJzpVebW2oZnyxoIOWX3oFVebw=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -1043,6 +1043,7 @@ func failWorkflowTask(
 		"",
 		"",
 		0,
+		request.GetExternalPayloadStats(),
 	)
 	if err != nil {
 		return nil, common.EmptyEventID, err

--- a/service/history/api/respondworkflowtaskfailed/api.go
+++ b/service/history/api/respondworkflowtaskfailed/api.go
@@ -110,7 +110,8 @@ func Invoke(
 				request.GetBinaryChecksum(),
 				"",
 				"",
-				0); err != nil {
+				0,
+				request.GetExternalPayloadStats()); err != nil {
 				return nil, err
 			}
 

--- a/service/history/historybuilder/event_factory.go
+++ b/service/history/historybuilder/event_factory.go
@@ -142,6 +142,7 @@ func (b *EventFactory) CreateWorkflowTaskCompletedEvent(
 	deploymentName string,
 	deployment *deploymentpb.Deployment,
 	behavior enumspb.VersioningBehavior,
+	externalPayloadStats *sdkpb.ExternalPayloadDownloadStats,
 ) *historypb.HistoryEvent {
 	event := b.createHistoryEvent(enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED, b.timeSource.Now())
 	event.Attributes = &historypb.HistoryEvent_WorkflowTaskCompletedEventAttributes{
@@ -156,6 +157,7 @@ func (b *EventFactory) CreateWorkflowTaskCompletedEvent(
 			WorkerDeploymentName: deploymentName,
 			DeploymentVersion:    worker_versioning.ExternalWorkerDeploymentVersionFromDeployment(deployment),
 			VersioningBehavior:   behavior,
+			ExternalPayloadStats: externalPayloadStats,
 		},
 	}
 
@@ -189,19 +191,21 @@ func (b *EventFactory) CreateWorkflowTaskFailedEvent(
 	newRunID string,
 	forkEventVersion int64,
 	checksum string,
+	externalPayloadStats *sdkpb.ExternalPayloadDownloadStats,
 ) *historypb.HistoryEvent {
 	event := b.createHistoryEvent(enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED, b.timeSource.Now())
 	event.Attributes = &historypb.HistoryEvent_WorkflowTaskFailedEventAttributes{
 		WorkflowTaskFailedEventAttributes: &historypb.WorkflowTaskFailedEventAttributes{
-			ScheduledEventId: scheduledEventID,
-			StartedEventId:   startedEventID,
-			Cause:            cause,
-			Failure:          failure,
-			Identity:         identity,
-			BaseRunId:        baseRunID,
-			NewRunId:         newRunID,
-			ForkEventVersion: forkEventVersion,
-			BinaryChecksum:   checksum,
+			ScheduledEventId:     scheduledEventID,
+			StartedEventId:       startedEventID,
+			Cause:                cause,
+			Failure:              failure,
+			Identity:             identity,
+			BaseRunId:            baseRunID,
+			NewRunId:             newRunID,
+			ForkEventVersion:     forkEventVersion,
+			BinaryChecksum:       checksum,
+			ExternalPayloadStats: externalPayloadStats,
 		},
 	}
 	return event

--- a/service/history/historybuilder/history_builder.go
+++ b/service/history/historybuilder/history_builder.go
@@ -223,6 +223,7 @@ func (b *HistoryBuilder) AddWorkflowTaskCompletedEvent(
 	deploymentName string,
 	deployment *deploymentpb.Deployment,
 	behavior enumspb.VersioningBehavior,
+	externalPayloadStats *sdkpb.ExternalPayloadDownloadStats,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateWorkflowTaskCompletedEvent(
 		scheduledEventID,
@@ -235,6 +236,7 @@ func (b *HistoryBuilder) AddWorkflowTaskCompletedEvent(
 		deploymentName,
 		deployment,
 		behavior,
+		externalPayloadStats,
 	)
 	event, _ = b.EventStore.add(event)
 	return event
@@ -260,6 +262,7 @@ func (b *HistoryBuilder) AddWorkflowTaskFailedEvent(
 	newRunID string,
 	forkEventVersion int64,
 	checksum string,
+	externalPayloadStats *sdkpb.ExternalPayloadDownloadStats,
 ) *historypb.HistoryEvent {
 	event := b.EventFactory.CreateWorkflowTaskFailedEvent(
 		scheduledEventID,
@@ -271,6 +274,7 @@ func (b *HistoryBuilder) AddWorkflowTaskFailedEvent(
 		newRunID,
 		forkEventVersion,
 		checksum,
+		externalPayloadStats,
 	)
 	event, _ = b.EventStore.add(event)
 	return event

--- a/service/history/historybuilder/history_builder_categorization_test.go
+++ b/service/history/historybuilder/history_builder_categorization_test.go
@@ -1286,6 +1286,7 @@ func (s *sutTestingAdapter) AddWorkflowTaskFailedEvent(_ ...eventConfig) *histor
 		"new-run-1",
 		0,
 		"checksum",
+		nil,
 	)
 }
 

--- a/service/history/historybuilder/history_builder_test.go
+++ b/service/history/historybuilder/history_builder_test.go
@@ -734,6 +734,7 @@ func (s *historyBuilderSuite) TestWorkflowTaskFailed() {
 		newRunID,
 		forkEventVersion,
 		checksum,
+		nil,
 	)
 	s.Equal(event, s.flush())
 	s.Equal(&historypb.HistoryEvent{

--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -12,6 +12,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
+	sdkpb "go.temporal.io/api/sdk/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	updatepb "go.temporal.io/api/update/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
@@ -68,7 +69,7 @@ type (
 		AddCompletedWorkflowEvent(int64, *commandpb.CompleteWorkflowExecutionCommandAttributes, string) (*historypb.HistoryEvent, error)
 		AddContinueAsNewEvent(context.Context, int64, int64, namespace.Name, *commandpb.ContinueAsNewWorkflowExecutionCommandAttributes, worker_versioning.IsWFTaskQueueInVersionDetector) (*historypb.HistoryEvent, MutableState, error)
 		AddWorkflowTaskCompletedEvent(*WorkflowTaskInfo, *workflowservice.RespondWorkflowTaskCompletedRequest, WorkflowTaskCompletionLimits) (*historypb.HistoryEvent, error)
-		AddWorkflowTaskFailedEvent(workflowTask *WorkflowTaskInfo, cause enumspb.WorkflowTaskFailedCause, failure *failurepb.Failure, identity string, versioningStamp *commonpb.WorkerVersionStamp, binChecksum, baseRunID, newRunID string, forkEventVersion int64) (*historypb.HistoryEvent, error)
+		AddWorkflowTaskFailedEvent(workflowTask *WorkflowTaskInfo, cause enumspb.WorkflowTaskFailedCause, failure *failurepb.Failure, identity string, versioningStamp *commonpb.WorkerVersionStamp, binChecksum, baseRunID, newRunID string, forkEventVersion int64, externalPayloadStats *sdkpb.ExternalPayloadDownloadStats) (*historypb.HistoryEvent, error)
 		AddWorkflowTaskScheduleToStartTimeoutEvent(workflowTask *WorkflowTaskInfo) (*historypb.HistoryEvent, error)
 		AddFirstWorkflowTaskScheduled(parentClock *clockspb.VectorClock, event *historypb.HistoryEvent, bypassTaskGeneration bool) (int64, error)
 		AddWorkflowTaskScheduledEvent(bypassTaskGeneration bool, workflowTaskType enumsspb.WorkflowTaskType) (*WorkflowTaskInfo, error)

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -20,6 +20,7 @@ import (
 	enums "go.temporal.io/api/enums/v1"
 	failure "go.temporal.io/api/failure/v1"
 	history "go.temporal.io/api/history/v1"
+	sdk "go.temporal.io/api/sdk/v1"
 	taskqueue "go.temporal.io/api/taskqueue/v1"
 	update "go.temporal.io/api/update/v1"
 	workflow "go.temporal.io/api/workflow/v1"
@@ -834,18 +835,18 @@ func (mr *MockMutableStateMockRecorder) AddWorkflowTaskCompletedEvent(arg0, arg1
 }
 
 // AddWorkflowTaskFailedEvent mocks base method.
-func (m *MockMutableState) AddWorkflowTaskFailedEvent(workflowTask *WorkflowTaskInfo, cause enums.WorkflowTaskFailedCause, arg2 *failure.Failure, identity string, versioningStamp *common.WorkerVersionStamp, binChecksum, baseRunID, newRunID string, forkEventVersion int64) (*history.HistoryEvent, error) {
+func (m *MockMutableState) AddWorkflowTaskFailedEvent(workflowTask *WorkflowTaskInfo, cause enums.WorkflowTaskFailedCause, arg2 *failure.Failure, identity string, versioningStamp *common.WorkerVersionStamp, binChecksum, baseRunID, newRunID string, forkEventVersion int64, externalPayloadStats *sdk.ExternalPayloadDownloadStats) (*history.HistoryEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddWorkflowTaskFailedEvent", workflowTask, cause, arg2, identity, versioningStamp, binChecksum, baseRunID, newRunID, forkEventVersion)
+	ret := m.ctrl.Call(m, "AddWorkflowTaskFailedEvent", workflowTask, cause, arg2, identity, versioningStamp, binChecksum, baseRunID, newRunID, forkEventVersion, externalPayloadStats)
 	ret0, _ := ret[0].(*history.HistoryEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddWorkflowTaskFailedEvent indicates an expected call of AddWorkflowTaskFailedEvent.
-func (mr *MockMutableStateMockRecorder) AddWorkflowTaskFailedEvent(workflowTask, cause, arg2, identity, versioningStamp, binChecksum, baseRunID, newRunID, forkEventVersion any) *gomock.Call {
+func (mr *MockMutableStateMockRecorder) AddWorkflowTaskFailedEvent(workflowTask, cause, arg2, identity, versioningStamp, binChecksum, baseRunID, newRunID, forkEventVersion, externalPayloadStats any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowTaskFailedEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowTaskFailedEvent), workflowTask, cause, arg2, identity, versioningStamp, binChecksum, baseRunID, newRunID, forkEventVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowTaskFailedEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowTaskFailedEvent), workflowTask, cause, arg2, identity, versioningStamp, binChecksum, baseRunID, newRunID, forkEventVersion, externalPayloadStats)
 }
 
 // AddWorkflowTaskScheduleToStartTimeoutEvent mocks base method.

--- a/service/history/ndc/buffer_event_flusher_test.go
+++ b/service/history/ndc/buffer_event_flusher_test.go
@@ -157,6 +157,7 @@ func (s *bufferEventFlusherSuite) TestFlushBufferedEvents() {
 		"",
 		"",
 		int64(0),
+		nil,
 	).Return(&historypb.HistoryEvent{}, nil)
 	s.mockMutableState.EXPECT().IsWorkflowExecutionStatusPaused().Return(false)
 	s.mockMutableState.EXPECT().AddWorkflowTaskScheduledEvent(

--- a/service/history/ndc/workflow.go
+++ b/service/history/ndc/workflow.go
@@ -251,6 +251,7 @@ func (r *WorkflowImpl) failWorkflowTask() (*historypb.HistoryEvent, error) {
 		"",
 		"",
 		0,
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -543,6 +543,7 @@ func (r *workflowResetterImpl) failWorkflowTask(
 		baseRunID,
 		resetRunID,
 		baseRebuildLastEventVersion,
+		nil,
 	)
 	return err
 }

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -399,6 +399,7 @@ func (s *workflowResetterSuite) TestFailWorkflowTask_WorkflowTaskScheduled() {
 		baseRunID,
 		resetRunID,
 		baseRebuildLastEventVersion,
+		nil,
 	).Return(&historypb.HistoryEvent{}, nil)
 
 	err := s.workflowResetter.failWorkflowTask(
@@ -440,6 +441,7 @@ func (s *workflowResetterSuite) TestFailWorkflowTask_WorkflowTaskStarted() {
 		baseRunID,
 		resetRunID,
 		baseRebuildLastEventVersion,
+		nil,
 	).Return(&historypb.HistoryEvent{}, nil)
 
 	err := s.workflowResetter.failWorkflowTask(
@@ -542,6 +544,7 @@ func (s *workflowResetterSuite) TestTerminateWorkflow() {
 		"",
 		"",
 		int64(0),
+		nil,
 	).Return(&historypb.HistoryEvent{EventId: wtFailedEventID}, nil)
 	mutableState.EXPECT().FlushBufferedEvents()
 	mutableState.EXPECT().AddWorkflowExecutionTerminatedEvent(
@@ -1548,6 +1551,7 @@ func (s *workflowResetterSuite) TestWorkflowRestartAfterExecutionTimeout() {
 		s.baseRunID,
 		s.resetRunID,
 		baseRebuildLastEventVersion,
+		nil,
 	).Return(&historypb.HistoryEvent{}, nil)
 
 	resetWorkflow, err := s.workflowResetter.prepareResetWorkflow(

--- a/service/history/ndc/workflow_test.go
+++ b/service/history/ndc/workflow_test.go
@@ -262,6 +262,7 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 		"",
 		"",
 		int64(0),
+		nil,
 	).Return(&historypb.HistoryEvent{EventId: wtFailedEventID}, nil)
 	s.mockMutableState.EXPECT().FlushBufferedEvents()
 

--- a/service/history/timer_queue_standby_task_executor_test.go
+++ b/service/history/timer_queue_standby_task_executor_test.go
@@ -952,6 +952,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowTaskTimeout_Atte
 		"",
 		"",
 		0,
+		nil,
 	)
 	s.NoError(err)
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -20,6 +20,7 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
 	rulespb "go.temporal.io/api/rules/v1"
+	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	updatepb "go.temporal.io/api/update/v1"
@@ -3706,6 +3707,7 @@ func (ms *MutableStateImpl) AddWorkflowTaskFailedEvent(
 	versioningStamp *commonpb.WorkerVersionStamp,
 	binChecksum, baseRunID, newRunID string,
 	forkEventVersion int64,
+	externalPayloadStats *sdkpb.ExternalPayloadDownloadStats,
 ) (*historypb.HistoryEvent, error) {
 	opTag := tag.WorkflowActionWorkflowTaskFailed
 	if err := ms.checkMutability(opTag); err != nil {
@@ -3721,6 +3723,7 @@ func (ms *MutableStateImpl) AddWorkflowTaskFailedEvent(
 		baseRunID,
 		newRunID,
 		forkEventVersion,
+		externalPayloadStats,
 	)
 }
 

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -308,6 +308,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchApplied
 		"",
 		"",
 		0,
+		nil,
 	)
 	s.NoError(err)
 	s.Equal(0, s.mutableState.hBuilder.NumBufferedEvents())
@@ -1036,6 +1037,7 @@ func (s *mutableStateSuite) TestUnpinnedTransitionFailed() {
 		"",
 		"",
 		0,
+		nil,
 	)
 	s.NoError(err)
 	// WFT failure does not fail transition

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -40,6 +40,7 @@ func failWorkflowTask(
 		"",
 		"",
 		0,
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -11,6 +11,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
+	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	updatepb "go.temporal.io/api/update/v1"
@@ -739,6 +740,7 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskCompletedEvent(
 		//nolint:staticcheck // SA1019 deprecated Deployment will clean up later
 		worker_versioning.DeploymentOrVersion(request.Deployment, worker_versioning.DeploymentVersionFromOptions(request.DeploymentOptions)),
 		vb,
+		request.ExternalPayloadStats,
 	)
 
 	err := m.afterAddWorkflowTaskCompletedEvent(event, limits)
@@ -772,6 +774,7 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskFailedEvent(
 	baseRunID string,
 	newRunID string,
 	forkEventVersion int64,
+	externalPayloadStats *sdkpb.ExternalPayloadDownloadStats,
 ) (*historypb.HistoryEvent, error) {
 
 	// IMPORTANT: returned event can be nil under some circumstances. Specifically, if WT is transient.
@@ -814,6 +817,7 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskFailedEvent(
 			newRunID,
 			forkEventVersion,
 			binaryChecksum,
+			externalPayloadStats,
 		)
 
 		if event != nil {


### PR DESCRIPTION
## What changed?
Propagates external download stats from RespondWorkflowTaskCompletedRequest and RespondWorkflowTaskFailedRequest into corresponding history events

## Why?
We'd like to expose external payload download stats in Temporal UI, and to do so those stats needs to be recorded by SDK in RespondWorkflowTaskCompletedRequest and RespondWorkflowTaskFailedRequest and stored in corresponding history events WorkflowTaskCompletedEventAttributes and WorkflowTaskFailedEventAttributes. This PR propagates the download stats into the history events.

**This PR depends on API change https://github.com/temporalio/api/pull/691**

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

