### PR TITLE
Flake fixer: pass assert.TestingT to nested functions 

### DIFF
--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -2983,7 +2983,8 @@ func (s *Versioning3Suite) verifyWorkflowVersioning(
 			},
 		},
 	)
-	if !assert.NoError(t, err) {
+	if err != nil {
+		assert.Fail(t, "DescribeWorkflowExecution failed", "error: %v", err)
 		return
 	}
 
@@ -2993,7 +2994,9 @@ func (s *Versioning3Suite) verifyWorkflowVersioning(
 	if versioningInfo.GetVersion() != "" { //nolint:staticcheck // SA1019: worker versioning v0.31
 		//nolint:staticcheck // SA1019: worker versioning v0.31
 		v, err = worker_versioning.WorkerDeploymentVersionFromStringV31(versioningInfo.GetVersion())
-		if !assert.NoError(t, err) {
+		if err != nil {
+			//nolint:staticcheck // SA1019: worker versioning v0.31
+			assert.Fail(t, "WorkerDeploymentVersionFromStringV31 failed", "version: %q, error: %v", versioningInfo.GetVersion(), err)
 			return
 		}
 		// make sure we are always populating this whenever Version string is populated


### PR DESCRIPTION
## What changed?
- Pass in assert.TestingT to a helper function that is nested inside EventuallyWithT.

## Why?
- Now that life is async in versioning, our tests need to realize that propagation is eventually consistent. 
- This helper method was not respecting the above requirement.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- no risk. Improvement in tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Plumbs assert.TestingT through versioning tests by changing verifyWorkflowVersioning signature and migrating its internals and all call sites to assertion-based checks compatible with EventuallyWithT.
> 
> - **Tests (versioning_3_test.go)**:
>   - Change `verifyWorkflowVersioning` to accept `assert.TestingT` and use `assert.*` (with `assert.Fail` on errors) instead of suite assertions; add safer nil checks for `deployment` and `transition` comparisons.
>   - Update all invocations to pass `s.T()` (or `t` within `EventuallyWithT`) and adjust assertions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ae8995c5bef00425c509a00e8518be34ee04016. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->