### PR TITLE
Add TLS support to elasticsearch-tool.

### DIFF
--- a/tools/elasticsearch/README.md
+++ b/tools/elasticsearch/README.md
@@ -24,15 +24,21 @@ COMMANDS:
    help, h         Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --endpoint value           hostname or ip address of elasticsearch server (default: "http://127.0.0.1:9200") [$ES_SERVER]
-   --user value               username for elasticsearch or aws_access_key_id if using static aws credentials [$ES_USER]
-   --password value           password for elasticsearch or aws_secret_access_key if using static aws credentials [$ES_PWD]
-   --aws-credentials value    AWS credentials provider (supported ['static', 'environment', 'aws-sdk-default']) [$AWS_CREDENTIALS]
-   --aws-session-token value  AWS sessiontoken for use with 'static' AWS credentials provider [$AWS_SESSION_TOKEN]
-   --index value              name of the visibility index [$ES_VISIBILITY_INDEX]
-   --quiet                    don't log errors to stderr (default: false)
-   --help, -h                 show help
-   --version, -v              print the version
+   --endpoint value                    hostname or ip address of elasticsearch server (default: "http://127.0.0.1:9200") [$ES_SERVER]
+   --user value                        username for elasticsearch or aws_access_key_id if using static aws credentials [$ES_USER]
+   --password value                    password for elasticsearch or aws_secret_access_key if using static aws credentials [$ES_PWD]
+   --aws-credentials value             AWS credentials provider (supported ['static', 'environment', 'aws-sdk-default']) [$AWS_CREDENTIALS]
+   --aws-session-token value           AWS sessiontoken for use with 'static' AWS credentials provider [$AWS_SESSION_TOKEN]
+   --tls                               enable TLS for elasticsearch connection [$ES_TLS]
+   --tls-cert-file value               path to TLS certificate file (tls must be enabled) [$ES_TLS_CERT_FILE]
+   --tls-key-file value                path to TLS key file (tls must be enabled) [$ES_TLS_KEY_FILE]
+   --tls-ca-file value                 path to TLS CA certificate file (tls must be enabled) [$ES_TLS_CA_FILE]
+   --tls-server-name value             TLS server name for host name verification (tls must be enabled) [$ES_TLS_SERVER_NAME]
+   --tls-disable-host-verification     disable TLS host name verification (tls must be enabled) [$ES_TLS_DISABLE_HOST_VERIFICATION]
+   --index value                       name of the visibility index [$ES_VISIBILITY_INDEX]
+   --quiet                             don't log errors to stderr (default: false)
+   --help, -h                          show help
+   --version, -v                       print the version
 ```
 
 ## For localhost development
@@ -148,6 +154,74 @@ export ES_VISIBILITY_INDEX=temporal_visibility_v1
 
 temporal-elasticsearch-tool --aws static setup-schema
 temporal-elasticsearch-tool --aws static create-index
+```
+
+### TLS Configuration
+The tool supports TLS for secure connections to Elasticsearch.
+
+#### Basic TLS with CA certificate
+```bash
+export ES_SERVER=https://elasticsearch.example.com:9200
+export ES_TLS=true
+export ES_TLS_CA_FILE=/path/to/ca.crt
+export ES_USER=elastic
+export ES_PWD=password
+
+temporal-elasticsearch-tool setup-schema
+temporal-elasticsearch-tool create-index
+```
+
+#### TLS with client certificate authentication
+```bash
+export ES_SERVER=https://elasticsearch.example.com:9200
+export ES_TLS=true
+export ES_TLS_CA_FILE=/path/to/ca.crt
+export ES_TLS_CERT_FILE=/path/to/client.crt
+export ES_TLS_KEY_FILE=/path/to/client.key
+export ES_USER=elastic
+export ES_PWD=password
+
+temporal-elasticsearch-tool setup-schema
+temporal-elasticsearch-tool create-index
+```
+
+#### TLS with custom server name
+```bash
+export ES_SERVER=https://elasticsearch.example.com:9200
+export ES_TLS=true
+export ES_TLS_CA_FILE=/path/to/ca.crt
+export ES_TLS_SERVER_NAME=elasticsearch.internal
+export ES_USER=elastic
+export ES_PWD=password
+
+temporal-elasticsearch-tool setup-schema
+```
+
+#### TLS with disabled host verification (not recommended for production)
+```bash
+export ES_SERVER=https://elasticsearch.example.com:9200
+export ES_TLS=true
+export ES_TLS_DISABLE_HOST_VERIFICATION=true
+export ES_USER=elastic
+export ES_PWD=password
+
+temporal-elasticsearch-tool setup-schema
+```
+
+#### Using command line flags
+All TLS options can also be specified as command line flags:
+
+```bash
+temporal-elasticsearch-tool \
+  --endpoint https://elasticsearch.example.com:9200 \
+  --tls \
+  --tls-ca-file /path/to/ca.crt \
+  --tls-cert-file /path/to/client.crt \
+  --tls-key-file /path/to/client.key \
+  --tls-server-name elasticsearch.internal \
+  --user elastic \
+  --password password \
+  setup-schema
 ```
 
 ### Additional Commands

--- a/tools/elasticsearch/handler.go
+++ b/tools/elasticsearch/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	"github.com/urfave/cli"
+	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
@@ -117,6 +118,17 @@ func parseElasticConfig(cli *cli.Context) (*esclient.Config, error) {
 			cfg.AWSRequestSigning.Static.AccessKeyID = cfg.Username
 			cfg.AWSRequestSigning.Static.SecretAccessKey = cfg.Password
 			cfg.AWSRequestSigning.Static.Token = cli.GlobalString(CLIOptAWSToken)
+		}
+	}
+
+	if cli.GlobalBool(commonschema.CLIFlagEnableTLS) {
+		cfg.TLS = &auth.TLS{
+			Enabled:                true,
+			CertFile:               cli.GlobalString(commonschema.CLIFlagTLSCertFile),
+			KeyFile:                cli.GlobalString(commonschema.CLIFlagTLSKeyFile),
+			CaFile:                 cli.GlobalString(commonschema.CLIFlagTLSCaFile),
+			ServerName:             cli.GlobalString(commonschema.CLIFlagTLSHostName),
+			EnableHostVerification: !cli.GlobalBool(commonschema.CLIFlagTLSDisableHostVerification),
 		}
 	}
 

--- a/tools/elasticsearch/main.go
+++ b/tools/elasticsearch/main.go
@@ -82,6 +82,40 @@ func BuildCLIOptions() *cli.App {
 			Name:  commonschema.CLIOptQuiet,
 			Usage: "don't log errors to stderr",
 		},
+		cli.BoolFlag{
+			Name:   commonschema.CLIFlagEnableTLS,
+			Usage:  "enable TLS for elasticsearch connection",
+			EnvVar: "ES_TLS",
+		},
+		cli.StringFlag{
+			Name:   commonschema.CLIFlagTLSCertFile,
+			Value:  "",
+			Usage:  "path to TLS certificate file (tls must be enabled)",
+			EnvVar: "ES_TLS_CERT_FILE",
+		},
+		cli.StringFlag{
+			Name:   commonschema.CLIFlagTLSKeyFile,
+			Value:  "",
+			Usage:  "path to TLS key file (tls must be enabled)",
+			EnvVar: "ES_TLS_KEY_FILE",
+		},
+		cli.StringFlag{
+			Name:   commonschema.CLIFlagTLSCaFile,
+			Value:  "",
+			Usage:  "path to TLS CA certificate file (tls must be enabled)",
+			EnvVar: "ES_TLS_CA_FILE",
+		},
+		cli.BoolFlag{
+			Name:   commonschema.CLIFlagTLSDisableHostVerification,
+			Usage:  "disable TLS host name verification (tls must be enabled)",
+			EnvVar: "ES_TLS_DISABLE_HOST_VERIFICATION",
+		},
+		cli.StringFlag{
+			Name:   commonschema.CLIFlagTLSHostName,
+			Value:  "",
+			Usage:  "TLS server name for host name verification (tls must be enabled)",
+			EnvVar: "ES_TLS_SERVER_NAME",
+		},
 	}
 
 	app.Commands = []cli.Command{


### PR DESCRIPTION
Environment variable style taken from the SQL tool.

## What changed?
Added support for configuring TLS settings for Elasticsearch.

## Why?
Allows users to adjust their TLS config as required.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds TLS support to the Elasticsearch schema tool with CLI/env options and documentation/examples.
> 
> - **Elasticsearch Tool**:
>   - **CLI Options**: Add TLS flags `--tls`, `--tls-cert-file`, `--tls-key-file`, `--tls-ca-file`, `--tls-server-name`, `--tls-disable-host-verification` with corresponding env vars.
>   - **Client Config**: Parse TLS options and set `auth.TLS` on Elasticsearch client config when enabled.
>   - **Docs**: Update `tools/elasticsearch/README.md` with TLS configuration details and usage examples (env vars and flags).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16b95d0ec1263ecb58d738d08e83fc112d86a8b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->