### PR TITLE
[CHASM] tdbg support for CHASM protobufs

### DIFF
--- a/tools/tdbg/protos.go
+++ b/tools/tdbg/protos.go
@@ -2,6 +2,7 @@ package tdbg
 
 // Import chasm lib protobuf packages for side effects (protobuf type registration).
 // This allows tdbg decode to find protobuf types from chasm/lib packages.
+//nolint:revive
 import (
 	_ "go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	_ "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"


### PR DESCRIPTION
## What changed?
- Imports the current CHASM protobufs as a side effect.

## Why?
- Enables their use through `tdbg decode`. Other existing protobufs are imported by virtue of explicit imports elsewhere in tdbg.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
