### PR TITLE
Add CHASM context CloseTime API

### DIFF
--- a/chasm/context.go
+++ b/chasm/context.go
@@ -17,16 +17,14 @@ type Context interface {
 	Now(Component) time.Time
 	// ExecutionKey returns the execution key for the execution the context is operating on.
 	ExecutionKey() ExecutionKey
-
+	// ExecutionCloseTime returns the time when the execution was closed. An execution is closed when its root component reaches a terminal
+	// state in its lifecycle. If the component is still running (not yet closed), it returns a zero time.Time value.
+	ExecutionCloseTime() time.Time
 	// Intent() OperationIntent
 	// ComponentOptions(Component) []ComponentOption
 
 	structuredRef(Component) (ComponentRef, error)
 	getContext() context.Context
-
-	// CloseTime returns the time when the execution was closed. An execution is closed when its root component reaches a terminal
-	// state in its lifecycle. If the component is still running (not yet closed), it returns a zero time.Time value.
-	CloseTime() time.Time
 }
 
 type MutableContext interface {
@@ -115,7 +113,7 @@ func (c *immutableCtx) getContext() context.Context {
 	return c.ctx
 }
 
-func (c *immutableCtx) CloseTime() time.Time {
+func (c *immutableCtx) ExecutionCloseTime() time.Time {
 	closeTime := c.root.backend.GetExecutionInfo().GetCloseTime()
 	if closeTime == nil {
 		return time.Time{}

--- a/chasm/context_mock.go
+++ b/chasm/context_mock.go
@@ -8,9 +8,10 @@ import (
 
 // MockContext is a mock implementation of [Context].
 type MockContext struct {
-	HandleExecutionKey func() ExecutionKey
-	HandleNow          func(component Component) time.Time
-	HandleRef          func(component Component) ([]byte, error)
+	HandleExecutionKey       func() ExecutionKey
+	HandleNow                func(component Component) time.Time
+	HandleRef                func(component Component) ([]byte, error)
+	HandleExecutionCloseTime func() time.Time
 }
 
 func (c *MockContext) getContext() context.Context {
@@ -42,7 +43,10 @@ func (c *MockContext) ExecutionKey() ExecutionKey {
 	return ExecutionKey{}
 }
 
-func (c *MockContext) CloseTime() time.Time {
+func (c *MockContext) ExecutionCloseTime() time.Time {
+	if c.HandleExecutionCloseTime != nil {
+		return c.HandleExecutionCloseTime()
+	}
 	return time.Time{}
 }
 

--- a/service/history/chasm_engine_test.go
+++ b/service/history/chasm_engine_test.go
@@ -630,7 +630,7 @@ func (s *chasmEngineSuite) TestReadComponent_Success() {
 			s.True(ok)
 			s.Equal(expectedActivityID, tc.ActivityInfo.ActivityId)
 
-			closeTime := ctx.CloseTime()
+			closeTime := ctx.ExecutionCloseTime()
 			s.True(closeTime.IsZero(), "CloseTime should be zero when component is still running")
 			return nil
 		},
@@ -923,7 +923,7 @@ func (s *chasmEngineSuite) TestCloseTime_ReturnsNonZeroWhenCompleted() {
 			component chasm.Component,
 		) error {
 			// Verify CloseTime returns non-zero time when component is completed
-			closeTime := ctx.CloseTime()
+			closeTime := ctx.ExecutionCloseTime()
 			s.False(closeTime.IsZero(), "CloseTime should be non-zero when component is completed")
 			s.Equal(expectedCloseTime.Unix(), closeTime.Unix(), "CloseTime should match the expected close time")
 			return nil


### PR DESCRIPTION
## What changed?
Added API to chasm ctx to get the close time of a component

## Why?
Chasm library callers need a way to get the time the component transitions to a terminal state. This avoids each component managing this separately.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

