### PR TITLE
Remove callback pool from dynamicconfig.Collection

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -15,16 +15,6 @@ import (
 
 var (
 	// keys for dynamic config itself
-	DynamicConfigSubscriptionCallback = NewGlobalTypedSetting(
-		"dynamicconfig.subscriptionCallback",
-		subscriptionCallbackSettings{
-			MinWorkers:   10,
-			MaxWorkers:   1e9, // effectively unlimited
-			TargetDelay:  10 * time.Millisecond,
-			ShrinkFactor: 1000, // 10 seconds
-		},
-		`Settings for dynamic config subscription dispatch. Requires server restart.`,
-	)
 	DynamicConfigSubscriptionPollInterval = NewGlobalDurationSetting(
 		"dynamicconfig.subscriptionPollInterval",
 		time.Minute,


### PR DESCRIPTION
## What changed?
Remove use of goro.AdaptivePool for dynamic config subscription callbacks and just run each one in a new goroutine instead.

## Why?
This was a questionable premature optimization that probably hurts more than it helps overall. Specifically, on a burst of a large number of callbacks, it holds subscriptionLock while deciding whether to expand the pool, which may contend with other things adding/removing callbacks.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
A burst of callbacks would create more goroutines than before, but that should be overall less impact to the system than the contention on subscriptionLock.
