### PR TITLE
Add goro.KeyedSet

### DIFF
--- a/common/goro/keyed_set.go
+++ b/common/goro/keyed_set.go
@@ -1,0 +1,53 @@
+package goro
+
+import (
+	"context"
+	"sync"
+)
+
+// KeyedSet maintains a set of goroutines addressed by keys, creating new ones as necessary and
+// canceling obsolete ones. A KeyedSet may not be copied.
+type KeyedSet[K comparable] struct {
+	baseCtx context.Context
+	lock    sync.Mutex
+	cancels map[K]context.CancelFunc
+}
+
+// NewKeyedSet returns a new KeyedSet where all goroutines inherit a context from baseCtx.
+func NewKeyedSet[K comparable](baseCtx context.Context) *KeyedSet[K] {
+	return &KeyedSet[K]{
+		baseCtx: baseCtx,
+		cancels: make(map[K]context.CancelFunc),
+	}
+}
+
+// Sync cancels/starts goroutines as necessary so that the running set matches the set of keys
+// in target. To start a new goroutine, it does "go f(ctx, key)".
+// You can use Sync(nil, nil) to cancel all running goroutines.
+//
+// Note that even if f returns without its context being canceled, it will still be considered
+// "running" for future calls to Sync. In general f should not return _until_ its context is
+// canceled. If KeyedSet were to remove f from the running set when it returned, then we could
+// have a race where f decides to return, a concurrent call to Sync includes f's key, then f
+// returns and is removed, but the caller of f thinks it's now active. In other words, there
+// should be one source of truth for what should be running.
+func (s *KeyedSet[K]) Sync(target map[K]struct{}, f func(context.Context, K)) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	for key, cancel := range s.cancels {
+		if _, ok := target[key]; !ok {
+			cancel()
+			delete(s.cancels, key)
+		}
+	}
+
+	for key := range target {
+		if _, ok := s.cancels[key]; ok {
+			continue
+		}
+		ctx, cancel := context.WithCancel(s.baseCtx)
+		s.cancels[key] = cancel
+		go f(ctx, key)
+	}
+}

--- a/common/goro/keyed_set_test.go
+++ b/common/goro/keyed_set_test.go
@@ -1,0 +1,148 @@
+package goro_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/goro"
+)
+
+func TestKeyedSet_Starts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ks := goro.NewKeyedSet[int](ctx)
+
+	var running atomic.Int32
+	f := func(ctx context.Context, key int) {
+		running.Add(1)
+		<-ctx.Done()
+		running.Add(-1)
+	}
+
+	// Start with 3 goroutines
+	target := map[int]struct{}{1: {}, 2: {}, 3: {}}
+	ks.Sync(target, f)
+
+	require.Eventually(t, func() bool {
+		return running.Load() == 3
+	}, time.Second, time.Millisecond)
+}
+
+func TestKeyedSet_Cancels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ks := goro.NewKeyedSet[int](ctx)
+
+	var running atomic.Int32
+	f := func(ctx context.Context, key int) {
+		running.Add(1)
+		<-ctx.Done()
+		running.Add(-1)
+	}
+
+	target := map[int]struct{}{1: {}, 2: {}, 3: {}}
+	ks.Sync(target, f)
+
+	require.Eventually(t, func() bool {
+		return running.Load() == 3
+	}, time.Second, time.Millisecond)
+
+	// Remove key 2
+	target = map[int]struct{}{1: {}, 3: {}}
+	ks.Sync(target, f)
+
+	// Goroutine for key 2 should be canceled
+	require.Eventually(t, func() bool {
+		return running.Load() == 2
+	}, time.Second, time.Millisecond)
+}
+
+func TestKeyedSet_StartsAndCancelsTogether(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ks := goro.NewKeyedSet[string](ctx)
+
+	var running sync.Map
+	f := func(ctx context.Context, key string) {
+		running.Store(key, true)
+		<-ctx.Done()
+		running.Delete(key)
+	}
+
+	runningKeys := func() (keys []string) {
+		running.Range(func(key, _ any) bool {
+			keys = append(keys, key.(string))
+			return true
+		})
+		return keys
+	}
+
+	// Start with {"a", "b"}
+	ks.Sync(map[string]struct{}{"a": {}, "b": {}}, f)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"a", "b"}, runningKeys())
+	}, time.Second, time.Millisecond)
+
+	// Change to {"b", "c"} - should cancel "a", keep "b", start "c"
+	ks.Sync(map[string]struct{}{"b": {}, "c": {}}, f)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"b", "c"}, runningKeys())
+	}, time.Second, time.Millisecond)
+
+	// Cancel all
+	ks.Sync(nil, nil)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, runningKeys())
+	}, time.Second, time.Millisecond)
+}
+
+func TestKeyedSet_BaseContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ks := goro.NewKeyedSet[int](ctx)
+
+	var running atomic.Int32
+	f := func(ctx context.Context, key int) {
+		running.Add(1)
+		<-ctx.Done()
+		running.Add(-1)
+	}
+
+	// Start goroutines
+	ks.Sync(map[int]struct{}{1: {}, 2: {}}, f)
+	require.Eventually(t, func() bool { return running.Load() == 2 }, time.Second, time.Millisecond)
+
+	// Cancel base context
+	cancel()
+	require.Eventually(t, func() bool { return running.Load() == 0 }, time.Second, time.Millisecond)
+}
+
+func TestKeyedSet_ConcurrentSync(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ks := goro.NewKeyedSet[int](ctx)
+
+	f := func(ctx context.Context, key int) {
+		<-ctx.Done()
+	}
+
+	// Run concurrent syncs - should not panic
+	var wg sync.WaitGroup
+	for i := range 1000 {
+		wg.Go(func() {
+			target := map[int]struct{}{i % 5: {}, (i + 1) % 5: {}}
+			ks.Sync(target, f)
+		})
+	}
+	wg.Wait()
+
+	ks.Sync(nil, nil)
+}


### PR DESCRIPTION
## What changed?
Add a utility for managing a set of goroutines.

## Why?
Planning to use this in upcoming changes to simplify some code.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
