### PR TITLE
Activity/nexus task queues get userdata from their parent

### DIFF
--- a/service/matching/user_data_manager_test.go
+++ b/service/matching/user_data_manager_test.go
@@ -355,7 +355,7 @@ func TestUserData_FetchesAndFetchesAgain(t *testing.T) {
 		&matchingservice.GetTaskQueueUserDataRequest{
 			NamespaceId:              defaultNamespaceId,
 			TaskQueue:                defaultRootTqID,
-			TaskQueueType:            enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+			TaskQueueType:            enumspb.TASK_QUEUE_TYPE_ACTIVITY,
 			LastKnownUserDataVersion: 0,
 			WaitNewData:              false, // first is not long poll
 		}).
@@ -368,7 +368,7 @@ func TestUserData_FetchesAndFetchesAgain(t *testing.T) {
 		&matchingservice.GetTaskQueueUserDataRequest{
 			NamespaceId:              defaultNamespaceId,
 			TaskQueue:                defaultRootTqID,
-			TaskQueueType:            enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+			TaskQueueType:            enumspb.TASK_QUEUE_TYPE_ACTIVITY,
 			LastKnownUserDataVersion: 1,
 			WaitNewData:              true, // second is long poll
 		}).
@@ -381,7 +381,7 @@ func TestUserData_FetchesAndFetchesAgain(t *testing.T) {
 		&matchingservice.GetTaskQueueUserDataRequest{
 			NamespaceId:              defaultNamespaceId,
 			TaskQueue:                defaultRootTqID,
-			TaskQueueType:            enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+			TaskQueueType:            enumspb.TASK_QUEUE_TYPE_ACTIVITY,
 			LastKnownUserDataVersion: 2,
 			WaitNewData:              true,
 		}).


### PR DESCRIPTION
## What changed?
This changes the topology of user data propagation to be separate per type instead of jumping over to the workflow type immediately. Now each type follows its tree structure, and the root activity/nexus task queue fetch from the root workflow partition.

## Why?
We want to propagate additional data in this path, but the new data is per-type, so this structure makes more sense.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
The downside is one additional hop for non-root activity/nexus partitions, which increases propagation latency slightly.
