### PR TITLE
Avoid proceeding with nil target queue after matching restarts

### DIFF
--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -1102,6 +1102,9 @@ func (pm *taskQueuePartitionManagerImpl) getPhysicalQueuesForAdd(
 		targetDeploymentQueue, taskDispatchRevisionNumber, err = pm.chooseTargetQueueByFlag(
 			ctx, deployment, targetDeployment, targetDeploymentRevisionNumber, taskDirectiveRevisionNumber,
 		)
+		if err != nil {
+			return nil, nil, nil, 0, nil, err
+		}
 		targetDeploymentVersion = worker_versioning.DeploymentVersionFromDeployment(targetDeploymentQueue.QueueKey().Version().Deployment())
 
 		if forwardInfo == nil {


### PR DESCRIPTION
## What changed?
Add error check to avoid proceeding with nil target queue after matching restarts

## Why?
To avoid nil pointer

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
- [x] run with fault injection pipeline a few times

## Potential risks
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents nil-pointer scenarios during task routing when selecting a deployment queue fails.
> 
> - In `task_queue_partition_manager.go#getPhysicalQueuesForAdd`, after calling `chooseTargetQueueByFlag(...)`, immediately return the error and avoid proceeding with a nil `targetDeploymentQueue`.
> - Affects unpinned workflow routing (non-sticky) when computing target deployment and revision numbers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb92678671c1e0482986dddebae0db40e1700870. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->