### PR TITLE
fix(frontend): return error when creating duplicate search attributes

### DIFF
--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -21,7 +21,6 @@ import (
 	"go.temporal.io/server/common"
 	clustermetadata "go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
@@ -212,11 +211,7 @@ func (h *OperatorHandlerImpl) addSearchAttributesElasticsearch(
 		if !currentSearchAttributes.IsDefined(saName) {
 			customAttributesToAdd[saName] = saType
 		} else {
-			h.logger.Warn(
-				fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName),
-				tag.NewStringTag(visibilityIndexNameTagName, indexName),
-				tag.NewStringTag(visibilitySearchAttributeTagName, saName),
-			)
+			return serviceerror.NewAlreadyExist(fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName))
 		}
 	}
 
@@ -279,12 +274,7 @@ func (h *OperatorHandlerImpl) addSearchAttributesSQL(
 	for saName, saType := range request.GetSearchAttributes() {
 		// check if alias is already in use
 		if _, ok := aliasToFieldMap[saName]; ok {
-			h.logger.Warn(
-				fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName),
-				tag.NewStringTag(namespaceTagName, nsName),
-				tag.NewStringTag(visibilitySearchAttributeTagName, saName),
-			)
-			continue
+			return serviceerror.NewAlreadyExists(fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName))
 		}
 		// find the first available field for the given type
 		targetFieldName := ""

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -529,8 +529,8 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributesElasticsearch() {
 					"CustomKeywordField": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 				},
 			},
-			expectedErrMsg: "",
-		},
+			// Expect the formatted error message
+			expectedErrMsg: fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, "CustomKeywordField")},
 		{
 			name: "success: mix new and already exists search attributes",
 			request: &operatorservice.AddSearchAttributesRequest{
@@ -539,12 +539,9 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributesElasticsearch() {
 					"CustomKeywordField": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 				},
 			},
-			passValidation: true,
-			customAttributesToAdd: map[string]enumspb.IndexedValueType{
-				"CustomAttr": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			},
-			expectedErrMsg: "",
-		},
+			passValidation:        false,
+			customAttributesToAdd: nil,
+			expectedErrMsg:        fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, "CustomKeywordField")},
 
 		{
 			name: "fail: cannot add elasticsearch schema",
@@ -646,7 +643,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributesSQL() {
 			expectedErrMsg:              "",
 		},
 		{
-			name: "success: search attribute already exists",
+			name: "fail: search attribute already exists",
 			request: &operatorservice.AddSearchAttributesRequest{
 				SearchAttributes: map[string]enumspb.IndexedValueType{
 					"CustomKeywordField": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
@@ -654,7 +651,8 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributesSQL() {
 				Namespace: testNamespace,
 			},
 			describeNamespaceCalled: true,
-			expectedErrMsg:          "",
+			// expect the formatted error message
+			expectedErrMsg: fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, "CustomKeywordField"),
 		},
 		{
 			name: "success: mix new and already exists search attributes",
@@ -665,11 +663,10 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributesSQL() {
 				},
 				Namespace: testNamespace,
 			},
-			customSearchAttributesToAdd: []string{"CustomAttr"},
+			customSearchAttributesToAdd: nil,
 			describeNamespaceCalled:     true,
-			updateNamespaceCalled:       true,
-			expectedErrMsg:              "",
-		},
+			updateNamespaceCalled:       false,
+			expectedErrMsg:              fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, "CustomKeywordField")},
 
 		{
 			name: "fail: cannot get frontend client",


### PR DESCRIPTION
## What changed?
Updated AddSearchAttributes in operator_handler.go for both Elasticsearch and SQL paths, to return a serviceerror.NewAlreadyExists error immediately when a duplicate attribute is detected, inplace  of just logging a warning and returning success....
## Why?
Previously, the CLI would report "Search attributes have been added" even if the operation was skipped because the attribute existed. This silent failure caused confusion and made it difficult to detect configuration drift in CI/CD pipelines.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

