### PR TITLE
Fix/scheduler trigger immediately visibility

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -1281,7 +1281,7 @@ func (s *scheduler) processBuffer() bool {
 		}
 		metricsWithTag.Counter(metrics.ScheduleActionSuccess.Name()).Inc(1)
 		nonOverlapping := start == action.NonOverlappingStart
-		s.recordAction(result, nonOverlapping)
+		s.recordAction(result, nonOverlapping, start.Manual)
 	}
 
 	// Terminate or cancel if required (terminate overrides cancel if both are present)
@@ -1310,10 +1310,10 @@ func (s *scheduler) processBuffer() bool {
 	return tryAgain
 }
 
-func (s *scheduler) recordAction(result *schedulepb.ScheduleActionResult, nonOverlapping bool) {
+func (s *scheduler) recordAction(result *schedulepb.ScheduleActionResult, nonOverlapping bool, manual bool) {
 	s.Info.ActionCount++
 	s.Info.RecentActions = util.SliceTail(append(s.Info.RecentActions, result), s.tweakables.RecentActionCount)
-	canTrack := nonOverlapping || !s.hasMinVersion(DontTrackOverlapping)
+	canTrack := nonOverlapping || manual || !s.hasMinVersion(DontTrackOverlapping)
 	if canTrack && result.StartWorkflowResult != nil {
 		s.Info.RunningWorkflows = append(s.Info.RunningWorkflows, result.StartWorkflowResult)
 	}


### PR DESCRIPTION
## What changed?
I updated the `recordAction` method in the scheduler workflow to accept a `manual` boolean flag. This flag is now passed down from `processBuffer`.

I changed the logic inside `recordAction` to guarantee that if a workflow start is `manual` (for example, through `TriggerImmediately` or Backfill), it is always added to the `RunningWorkflows` list. Before, these were often filtered out if they were seen as "overlapping," especially under `ALLOW_ALL` policies.

I also added a reproduction test case, `TestTriggerImmediatelyVisibility`, in `workflow_test`.go.

## Why?
This fixes #8833.

Users reported that workflows triggered with `triggerImmediately`: true did not show up in the scheduler's `info.runningActions` list. This occurred because the scheduler treated them as "overlapping" executions. These are hidden by default to prevent state bloat. This optimization was introduced in version 3.

Manual triggers are clear user actions and should always be visible in the API response and UI, no matter the schedule's overlap policy.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s) 
- [x] added new functional test(s) (`TestTriggerImmediatelyVisibility`)


