### PR TITLE
fix(frontend): return error when creating duplicate search attributes

### DIFF
--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -21,7 +21,6 @@ import (
 	"go.temporal.io/server/common"
 	clustermetadata "go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
@@ -212,11 +211,7 @@ func (h *OperatorHandlerImpl) addSearchAttributesElasticsearch(
 		if !currentSearchAttributes.IsDefined(saName) {
 			customAttributesToAdd[saName] = saType
 		} else {
-			h.logger.Warn(
-				fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName),
-				tag.NewStringTag(visibilityIndexNameTagName, indexName),
-				tag.NewStringTag(visibilitySearchAttributeTagName, saName),
-			)
+			return serviceerror.NewAlreadyExists(fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName))
 		}
 	}
 
@@ -279,12 +274,7 @@ func (h *OperatorHandlerImpl) addSearchAttributesSQL(
 	for saName, saType := range request.GetSearchAttributes() {
 		// check if alias is already in use
 		if _, ok := aliasToFieldMap[saName]; ok {
-			h.logger.Warn(
-				fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName),
-				tag.NewStringTag(namespaceTagName, nsName),
-				tag.NewStringTag(visibilitySearchAttributeTagName, saName),
-			)
-			continue
+			return serviceerror.NewAlreadyExists(fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName))
 		}
 		// find the first available field for the given type
 		targetFieldName := ""

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -523,29 +523,26 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributesElasticsearch() {
 			expectedErrMsg: "",
 		},
 		{
-			name: "success: search attribute already exists",
+			name: "search attribute already exists",
 			request: &operatorservice.AddSearchAttributesRequest{
 				SearchAttributes: map[string]enumspb.IndexedValueType{
 					"CustomKeywordField": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 				},
 			},
-			expectedErrMsg: "",
+			passValidation: false,
+			expectedErrMsg: "Search attribute CustomKeywordField already exists",
 		},
 		{
-			name: "success: mix new and already exists search attributes",
+			name: "mix new and already exists search attributes",
 			request: &operatorservice.AddSearchAttributesRequest{
 				SearchAttributes: map[string]enumspb.IndexedValueType{
 					"CustomAttr":         enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 					"CustomKeywordField": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 				},
 			},
-			passValidation: true,
-			customAttributesToAdd: map[string]enumspb.IndexedValueType{
-				"CustomAttr": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			},
-			expectedErrMsg: "",
+			passValidation: false,
+			expectedErrMsg: "Search attribute CustomKeywordField already exists",
 		},
-
 		{
 			name: "fail: cannot add elasticsearch schema",
 			request: &operatorservice.AddSearchAttributesRequest{
@@ -646,7 +643,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributesSQL() {
 			expectedErrMsg:              "",
 		},
 		{
-			name: "success: search attribute already exists",
+			name: "search attribute already exists",
 			request: &operatorservice.AddSearchAttributesRequest{
 				SearchAttributes: map[string]enumspb.IndexedValueType{
 					"CustomKeywordField": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
@@ -654,10 +651,10 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributesSQL() {
 				Namespace: testNamespace,
 			},
 			describeNamespaceCalled: true,
-			expectedErrMsg:          "",
+			expectedErrMsg:          "Search attribute CustomKeywordField already exists",
 		},
 		{
-			name: "success: mix new and already exists search attributes",
+			name: "mix new and already exists search attributes",
 			request: &operatorservice.AddSearchAttributesRequest{
 				SearchAttributes: map[string]enumspb.IndexedValueType{
 					"CustomAttr":         enumspb.INDEXED_VALUE_TYPE_KEYWORD,
@@ -665,12 +662,9 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributesSQL() {
 				},
 				Namespace: testNamespace,
 			},
-			customSearchAttributesToAdd: []string{"CustomAttr"},
-			describeNamespaceCalled:     true,
-			updateNamespaceCalled:       true,
-			expectedErrMsg:              "",
+			describeNamespaceCalled: true,
+			expectedErrMsg:          "Search attribute CustomKeywordField already exists",
 		},
-
 		{
 			name: "fail: cannot get frontend client",
 			request: &operatorservice.AddSearchAttributesRequest{


### PR DESCRIPTION
### What's being changed:

This PR changes the behavior of `AddSearchAttributes` to return a clear error when trying to add a search attribute that already exists (Fixes #8631).

**The Issue:**
In the past, the server would log a warning and return `nil` (success) when a duplicate was found. This led clients, such as the CLI, to report "Search attributes have been added" even though no changes were made.

**The Fix:**
I updated `addSearchAttributesElasticsearch` and `addSearchAttributesSQL` to return `serviceerror.NewAlreadyExists` right away when a duplicate alias or field is detected.

**Test Coverage:**
I modified `Test_AddSearchAttributesElasticsearch` and `Test_AddSearchAttributesSQL` in `operator_handler_test.go` to expect this new error instead of the earlier success-with-warning behavior.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.