### PR TITLE
Small refactor to addBackfiller

### DIFF
--- a/chasm/lib/scheduler/backfiller.go
+++ b/chasm/lib/scheduler/backfiller.go
@@ -27,9 +27,9 @@ const (
 	RequestTypeBackfill
 )
 
-// newBackfiller returns an initialized backfiller without a request set or tasks
-// created.
-func newBackfiller(
+// addBackfiller returns an initialized backfiller, adding it to the scheduler's
+// Backfillers.
+func addBackfiller(
 	ctx chasm.MutableContext,
 	scheduler *Scheduler,
 ) *Backfiller {
@@ -43,6 +43,11 @@ func newBackfiller(
 
 	// Immediately schedule the first backfiller task.
 	ctx.AddTask(backfiller, chasm.TaskAttributes{}, &schedulerpb.BackfillerTask{})
+
+	if scheduler.Backfillers == nil {
+		scheduler.Backfillers = make(chasm.Map[string, *Backfiller])
+	}
+	scheduler.Backfillers[id] = chasm.NewComponentField(ctx, backfiller)
 
 	return backfiller
 }

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -180,11 +180,10 @@ func (s *Scheduler) NewRangeBackfiller(
 	ctx chasm.MutableContext,
 	request *schedulepb.BackfillRequest,
 ) *Backfiller {
-	backfiller := newBackfiller(ctx, s)
+	backfiller := addBackfiller(ctx, s)
 	backfiller.Request = &schedulerpb.BackfillerState_BackfillRequest{
 		BackfillRequest: request,
 	}
-	s.Backfillers[backfiller.BackfillId] = chasm.NewComponentField(ctx, backfiller)
 	return backfiller
 }
 
@@ -194,11 +193,10 @@ func (s *Scheduler) NewImmediateBackfiller(
 	ctx chasm.MutableContext,
 	request *schedulepb.TriggerImmediatelyRequest,
 ) *Backfiller {
-	backfiller := newBackfiller(ctx, s)
+	backfiller := addBackfiller(ctx, s)
 	backfiller.Request = &schedulerpb.BackfillerState_TriggerRequest{
 		TriggerRequest: request,
 	}
-	s.Backfillers[backfiller.BackfillId] = chasm.NewComponentField(ctx, backfiller)
 	return backfiller
 }
 


### PR DESCRIPTION
## What changed?
- Moves around `newBackfiller` stuff in the CHASM scheduler.
