### PR TITLE
Remove explicit status tracking from namespace registry

### DIFF
--- a/common/namespace/nsregistry/registry_test.go
+++ b/common/namespace/nsregistry/registry_test.go
@@ -62,7 +62,6 @@ func (s *registrySuite) SetupTest() {
 }
 
 func (s *registrySuite) TearDownTest() {
-	s.registry.Stop()
 	s.controller.Finish()
 }
 
@@ -834,6 +833,7 @@ func (s *registrySuite) TestNamespaceRename() {
 	}).MinTimes(1)
 
 	s.registry.Start()
+	defer s.registry.Stop()
 	// Register callback to detect when the rename is applied
 	refreshCompletedCh := make(chan struct{})
 	s.registry.RegisterStateChangeCallback("test", func(ns *namespace.Namespace, deletedFromDb bool) {
@@ -841,7 +841,6 @@ func (s *registrySuite) TestNamespaceRename() {
 			close(refreshCompletedCh)
 		}
 	})
-	defer s.registry.Stop()
 
 	// Verify original name works before rename
 	ns, err := s.registry.GetNamespace("original-name")


### PR DESCRIPTION
## What changed?
Remove explicit lifecycle status tracking from the namespace registry. 
Updated tests to guarantee Stop is called exactly once.

## Why?
The namespace registry is managed by fx lifecycle hooks, which guarantee Start() and Stop() are called exactly once in order. The status tracking was defensive code that duplicated guarantees already provided by fx. Other components like the Nexus endpoint registry already rely on fx without internal status tracking.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Tests call Start() and Stop() directly rather than through fx. These calls are no longer idempotent so behavior is undefined if a test misuses them. Existing tests are correct.
