### PR TITLE
External payload metrics

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1064,6 +1064,7 @@ var (
 	DynamicWorkerPoolSchedulerDequeuedTasks = NewCounterDef("dynamic_worker_pool_scheduler_dequeued_tasks")
 	DynamicWorkerPoolSchedulerRejectedTasks = NewCounterDef("dynamic_worker_pool_scheduler_rejected_tasks")
 	PausedActivitiesCounter                 = NewCounterDef("paused_activities")
+	ExternalPayloadUploadSize               = NewBytesHistogramDef("external_payload_upload_size", WithDescription("The histogram of sizes in bytes of uploaded external payloads."))
 
 	// Deadlock detector metrics
 	DDSuspectedDeadlocks                 = NewCounterDef("dd_suspected_deadlocks")

--- a/service/history/ndc/state_rebuilder.go
+++ b/service/history/ndc/state_rebuilder.go
@@ -16,6 +16,7 @@ import (
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/transitionhistory"
@@ -383,7 +384,10 @@ func (r *StateRebuilderImpl) getPaginationFn(
 
 			// Calculate and accumulate external payload size and count for this batch of history events
 			if r.shard.GetConfig().ExternalPayloadsEnabled(namespaceName) {
-				externalPayloadSize, externalPayloadCount, err := workflow.CalculateExternalPayloadSize(history.Events)
+				externalPayloadSize, externalPayloadCount, err := workflow.CalculateExternalPayloadSize(
+					history.Events,
+					metrics.NoopMetricsHandler, // don't record metrics since those are not new uploads
+				)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -30,6 +30,7 @@ import (
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
@@ -1118,7 +1119,10 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 
 			localMutableState.GetExecutionInfo().ExecutionStats.HistorySize += int64(len(historyBlob.rawHistory.Data))
 			if r.shardContext.GetConfig().ExternalPayloadsEnabled(nsName.String()) {
-				externalPayloadSize, externalPayloadCount, err := workflow.CalculateExternalPayloadSize(events)
+				externalPayloadSize, externalPayloadCount, err := workflow.CalculateExternalPayloadSize(
+					events,
+					metrics.NoopMetricsHandler, // don't record metrics since those are not new uploads
+				)
 				if err != nil {
 					return err
 				}
@@ -1184,7 +1188,10 @@ func (r *WorkflowStateReplicatorImpl) bringLocalEventsUpToSourceCurrentBranch(
 		startEventVersion = events[len(events)-1].Version
 		localMutableState.GetExecutionInfo().ExecutionStats.HistorySize += int64(len(eventBlobs[i].Data))
 		if r.shardContext.GetConfig().ExternalPayloadsEnabled(localMutableState.GetNamespaceEntry().Name().String()) {
-			externalPayloadSize, externalPayloadCount, err := workflow.CalculateExternalPayloadSize(events)
+			externalPayloadSize, externalPayloadCount, err := workflow.CalculateExternalPayloadSize(
+				events,
+				metrics.NoopMetricsHandler, // don't record metrics since those are not new uploads
+			)
 			if err != nil {
 				return newBranchToken, err
 			}

--- a/service/history/workflow/external_payload_size_test.go
+++ b/service/history/workflow/external_payload_size_test.go
@@ -8,6 +8,8 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 )
 
 func TestCalculateExternalPayloadSize_NoExternalPayloads(t *testing.T) {
@@ -28,13 +30,17 @@ func TestCalculateExternalPayloadSize_NoExternalPayloads(t *testing.T) {
 		},
 	}
 
-	size, count, err := CalculateExternalPayloadSize(events)
+	size, count, err := CalculateExternalPayloadSize(events, metrics.NoopMetricsHandler)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), size)
 	assert.Equal(t, int64(0), count)
 }
 
 func TestCalculateExternalPayloadSize_WithExternalPayloads(t *testing.T) {
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	defer metricsHandler.StopCapture(capture)
+
 	events := []*historypb.HistoryEvent{
 		{
 			EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
@@ -79,16 +85,24 @@ func TestCalculateExternalPayloadSize_WithExternalPayloads(t *testing.T) {
 		},
 	}
 
-	size, count, err := CalculateExternalPayloadSize(events)
+	size, count, err := CalculateExternalPayloadSize(events, metricsHandler)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1024+2048+512), size)
 	assert.Equal(t, int64(3), count)
+
+	snapshot := capture.Snapshot()
+
+	histogramRecs := snapshot[metrics.ExternalPayloadUploadSize.Name()]
+	require.Len(t, histogramRecs, 3)
+	assert.Equal(t, int64(1024), histogramRecs[0].Value)
+	assert.Equal(t, int64(2048), histogramRecs[1].Value)
+	assert.Equal(t, int64(512), histogramRecs[2].Value)
 }
 
 func TestCalculateExternalPayloadSize_EmptyEvents(t *testing.T) {
 	events := []*historypb.HistoryEvent{}
 
-	size, count, err := CalculateExternalPayloadSize(events)
+	size, count, err := CalculateExternalPayloadSize(events, metrics.NoopMetricsHandler)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), size)
 	assert.Equal(t, int64(0), count)

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -7678,7 +7678,7 @@ func (ms *MutableStateImpl) closeTransactionPrepareEvents(
 
 		// Calculate and add the external payload size and count for this batch
 		if ms.config.ExternalPayloadsEnabled(ms.GetNamespaceEntry().Name().String()) {
-			externalPayloadSize, externalPayloadCount, err := CalculateExternalPayloadSize(eventBatch)
+			externalPayloadSize, externalPayloadCount, err := CalculateExternalPayloadSize(eventBatch, ms.metricsHandler)
 			if err != nil {
 				return nil, nil, nil, false, err
 			}


### PR DESCRIPTION
## What changed?
Track metrics for total size and count of uploaded external payloads and the histogram of individual payloads.

## Why?
We only track the payload sizes as they appear in history, and for external payloads, it's a small size the lightweight reference occupies. We'd like to log the additional information about the number and size of uploaded external payloads, as well as the histogram of their sizes. 

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
No
