### PR TITLE
Run the features test for CHASM scheduler as part of CI

### DIFF
--- a/.github/workflows/features-integration.yml
+++ b/.github/workflows/features-integration.yml
@@ -103,6 +103,8 @@ jobs:
       version-is-repo-ref: false
       docker-image-artifact-name: temporal-server-docker
       dynamic-config-values: |
+        history.enableTransitionHistory:
+          - value: true
         history.enableChasm:
           - value: true
         history.enableCHASMSchedulerCreation:


### PR DESCRIPTION
## What changed?
- Runs the Go SDK features test, with CHASM scheduler enabled, as part of CI.
- Relies on https://github.com/temporalio/features/pull/716 being merged
- Relies on pending schedule bugfix PRs #8951 #8952 to pass

## Why?
- These black-box tests have found bugs that the server functional tests don't, they should be part of regular CI until CHASM is flipped on by default.
