### PR TITLE
Set the "missing" key in ES sorter

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -427,6 +427,7 @@ jobs:
           - cass_es
           - cass_es8
           - cass_os2
+          - cass_os3
           - sqlite
           - mysql8
           - postgres12
@@ -452,6 +453,10 @@ jobs:
             persistence_type: nosql
             persistence_driver: cassandra
             containers: [cassandra, opensearch2]
+          - name: cass_os3
+            persistence_type: nosql
+            persistence_driver: cassandra
+            containers: [cassandra, opensearch3]
           - name: sqlite
             persistence_type: sql
             persistence_driver: sqlite
@@ -604,7 +609,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [cass_es, cass_es8, cass_os2, mysql8, postgres12, postgres12_pgx]
+        name: [cass_es, cass_es8, cass_os2, cass_os3, mysql8, postgres12, postgres12_pgx]
         include:
           - name: cass_es
             persistence_type: nosql
@@ -624,6 +629,10 @@ jobs:
             persistence_type: nosql
             persistence_driver: cassandra
             containers: [cassandra, opensearch2]
+          - name: cass_os3
+            persistence_type: nosql
+            persistence_driver: cassandra
+            containers: [cassandra, opensearch3]
           - name: mysql8
             persistence_type: sql
             persistence_driver: mysql8
@@ -766,6 +775,7 @@ jobs:
           - cass_es
           - cass_es8
           - cass_os2
+          - cass_os3
           - mysql8
           - postgres12
           - postgres12_pgx
@@ -788,6 +798,10 @@ jobs:
             persistence_type: nosql
             persistence_driver: cassandra
             containers: [cassandra, opensearch2]
+          - name: cass_os3
+            persistence_type: nosql
+            persistence_driver: cassandra
+            containers: [cassandra, opensearch3]
           - name: mysql8
             persistence_type: sql
             persistence_driver: mysql8

--- a/common/persistence/visibility/store/elasticsearch/converter_test.go
+++ b/common/persistence/visibility/store/elasticsearch/converter_test.go
@@ -78,15 +78,15 @@ var supportedWhereOrderCases = map[string]struct {
 }{
 	"id > 1 order by id asc, order_id desc": {
 		query:  `{"bool":{"filter":{"range":{"id":{"from":1,"include_lower":false,"include_upper":true,"to":null}}}}}`,
-		sorter: `[{"id":{"order":"asc"}},{"order_id":{"order":"desc"}}]`,
+		sorter: `[{"id":{"missing":"_last","order":"asc"}},{"order_id":{"missing":"_last","order":"desc"}}]`,
 	},
 	"id is null order by `order`.abc": {
 		query:  `{"bool":{"must_not":{"exists":{"field":"id"}}}}`,
-		sorter: `[{"order.abc":{"order":"asc"}}]`,
+		sorter: `[{"order.abc":{"missing":"_last","order":"asc"}}]`,
 	},
 	"id beTweeN 1 AnD 3 ORdeR BY random_id DESC": {
 		query:  `{"bool":{"filter":{"range":{"id":{"from":1,"include_lower":true,"include_upper":true,"to":3}}}}}`,
-		sorter: `[{"random_id":{"order":"desc"}}]`,
+		sorter: `[{"random_id":{"missing":"_last","order":"desc"}}]`,
 	},
 }
 
@@ -153,7 +153,7 @@ func TestEmptySelectWhere(t *testing.T) {
 	assert.Len(t, queryParams.Sorter, 1)
 	actualSorterMap, _ := queryParams.Sorter[0].Source()
 	actualSorterJson, _ := json.Marshal([]interface{}{actualSorterMap})
-	assert.Equal(t, `[{"Id":{"order":"desc"}}]`, string(actualSorterJson))
+	assert.JSONEq(t, `[{"Id":{"missing":"_last","order":"desc"}}]`, string(actualSorterJson))
 }
 
 func TestSupportedSelectWhereOrder(t *testing.T) {

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -106,6 +106,8 @@ var (
 			}
 			if item.missing_first {
 				fs.Missing("_first")
+			} else {
+				fs.Missing("_last")
 			}
 			ret = append(ret, fs)
 		}
@@ -749,7 +751,7 @@ func (s *VisibilityStore) convertQuery(
 				sqlparser.String(orderByExpr),
 			)
 		}
-		fieldSort := elastic.NewFieldSort(colName.FieldName)
+		fieldSort := elastic.NewFieldSort(colName.FieldName).Missing("_last")
 		if orderByExpr.Direction == sqlparser.DescScr {
 			fieldSort = fieldSort.Desc()
 		}

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -261,7 +261,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 		SearchAfter: nil,
 		PageSize:    testPageSize,
 		Sorter: []elastic.Sorter{
-			elastic.NewFieldSort(sadefs.WorkflowID).Asc(),
+			elastic.NewFieldSort(sadefs.WorkflowID).Asc().Missing("_last"),
 			elastic.NewFieldSort(sadefs.RunID).Desc(),
 		},
 	}, p)
@@ -355,7 +355,7 @@ func (s *ESVisibilitySuite) Test_convertQueryLegacy() {
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
 	s.NoError(err)
 	s.Equal(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":{"term":{"WorkflowId":"wid"}}}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
-	s.Equal(`[{"StartTime":{"order":"desc"}}]`, s.sorterToJSON(queryParams.Sorter))
+	s.JSONEq(`[{"StartTime":{"missing":"_last","order":"desc"}}]`, s.sorterToJSON(queryParams.Sorter))
 
 	query = `WorkflowId = 'wid' and CloseTime is null`
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
@@ -373,7 +373,7 @@ func (s *ESVisibilitySuite) Test_convertQueryLegacy() {
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
 	s.NoError(err)
 	s.Equal(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"must_not":{"exists":{"field":"CloseTime"}}}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
-	s.Equal(`[{"CloseTime":{"order":"desc"}}]`, s.sorterToJSON(queryParams.Sorter))
+	s.JSONEq(`[{"CloseTime":{"missing":"_last","order":"desc"}}]`, s.sorterToJSON(queryParams.Sorter))
 
 	query = `StartTime = "2018-06-07T15:04:05.123456789-08:00"`
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
@@ -409,13 +409,13 @@ func (s *ESVisibilitySuite) Test_convertQueryLegacy() {
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
 	s.NoError(err)
 	s.Equal(`{"bool":{"filter":{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
-	s.Equal(`[{"ExecutionTime":{"order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
+	s.JSONEq(`[{"ExecutionTime":{"missing":"_last","order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
 
 	query = `order by StartTime desc, CloseTime asc`
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
 	s.NoError(err)
 	s.Equal(`{"bool":{"filter":{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
-	s.Equal(`[{"StartTime":{"order":"desc"}},{"CloseTime":{"order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
+	s.JSONEq(`[{"StartTime":{"missing":"_last","order":"desc"}},{"CloseTime":{"missing":"_last","order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
 
 	query = `order by CustomTextField desc`
 	_, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
@@ -427,7 +427,7 @@ func (s *ESVisibilitySuite) Test_convertQueryLegacy() {
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
 	s.NoError(err)
 	s.Equal(`{"bool":{"filter":{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
-	s.Equal(`[{"CustomIntField":{"order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
+	s.JSONEq(`[{"CustomIntField":{"missing":"_last","order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
 
 	query = `ExecutionTime < "unable to parse"`
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
@@ -479,13 +479,13 @@ func (s *ESVisibilitySuite) Test_convertQueryLegacy_Mapper() {
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
 	s.NoError(err)
 	s.Equal(`{"bool":{"filter":{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
-	s.Equal(`[{"ExecutionTime":{"order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
+	s.JSONEq(`[{"ExecutionTime":{"missing":"_last","order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
 
 	query = `order by AliasForCustomKeywordField asc`
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
 	s.NoError(err)
 	s.Equal(`{"bool":{"filter":{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
-	s.Equal(`[{"CustomKeywordField":{"order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
+	s.JSONEq(`[{"CustomKeywordField":{"missing":"_last","order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
 
 	query = `order by CustomKeywordField asc`
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
@@ -519,7 +519,7 @@ func (s *ESVisibilitySuite) Test_convertQueryLegacy_Mapper_Error() {
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
 	s.NoError(err)
 	s.Equal(`{"bool":{"filter":{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
-	s.Equal(`[{"ExecutionTime":{"order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
+	s.JSONEq(`[{"ExecutionTime":{"missing":"_last","order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
 
 	s.visibilityStore.searchAttributesMapperProvider = nil
 }
@@ -571,7 +571,7 @@ func (s *ESVisibilitySuite) Test_convertQuery() {
 						elastic.NewTermQuery(sadefs.WorkflowID, "wid"),
 					),
 				),
-				Sorter:  []elastic.Sorter{elastic.NewFieldSort(sadefs.WorkflowID)},
+				Sorter:  []elastic.Sorter{elastic.NewFieldSort(sadefs.WorkflowID).Missing("_last")},
 				GroupBy: []string{},
 			},
 		},
@@ -609,7 +609,7 @@ func (s *ESVisibilitySuite) Test_convertQuery() {
 							MinimumNumberShouldMatch(1),
 					),
 				),
-				Sorter:  []elastic.Sorter{elastic.NewFieldSort("CustomKeywordField")},
+				Sorter:  []elastic.Sorter{elastic.NewFieldSort("CustomKeywordField").Missing("_last")},
 				GroupBy: []string{},
 			},
 		},
@@ -1957,7 +1957,7 @@ func (s *ESVisibilitySuite) Test_convertQueryLegacy_ChasmMapper() {
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, queryStr, chasmMapper, chasm.UnspecifiedArchetypeID)
 	s.NoError(err)
 	s.JSONEq(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":{"match":{"TemporalBool01":{"query":true}}}}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
-	s.JSONEq(`[{"TemporalKeyword01":{"order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
+	s.JSONEq(`[{"TemporalKeyword01":{"missing":"_last","order":"asc"}}]`, s.sorterToJSON(queryParams.Sorter))
 
 	queryStr = `ChasmStatus = 'active' and WorkflowId = 'wid'`
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, queryStr, chasmMapper, chasm.UnspecifiedArchetypeID)
@@ -2051,7 +2051,7 @@ func (s *ESVisibilitySuite) Test_convertQuery_ChasmMapper() {
 						elastic.NewTermQuery("TemporalBool01", true),
 					),
 				),
-				Sorter:  []elastic.Sorter{elastic.NewFieldSort("TemporalKeyword01")},
+				Sorter:  []elastic.Sorter{elastic.NewFieldSort("TemporalKeyword01").Missing("_last")},
 				GroupBy: []string{},
 			},
 		},
@@ -2166,7 +2166,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2_ChasmMapper() {
 		SearchAfter: nil,
 		PageSize:    testPageSize,
 		Sorter: []elastic.Sorter{
-			elastic.NewFieldSort("TemporalKeyword01").Asc(),
+			elastic.NewFieldSort("TemporalKeyword01").Asc().Missing("_last"),
 			elastic.NewFieldSort(sadefs.RunID).Desc(),
 		},
 	}, p)

--- a/common/persistence/visibility/store/query/converter_legacy.go
+++ b/common/persistence/visibility/store/query/converter_legacy.go
@@ -244,7 +244,7 @@ func (c *ConverterLegacy) convertSelect(sel *sqlparser.Select) (*QueryParamsLega
 		if err != nil {
 			return nil, wrapConverterError("unable to convert 'order by' column name", err)
 		}
-		fieldSort := elastic.NewFieldSort(colName)
+		fieldSort := elastic.NewFieldSort(colName).Missing("_last")
 		if orderByExpr.Direction == sqlparser.DescScr {
 			fieldSort = fieldSort.Desc()
 		}

--- a/common/persistence/visibility/store/query/interceptors_legacy_test.go
+++ b/common/persistence/visibility/store/query/interceptors_legacy_test.go
@@ -60,7 +60,7 @@ func TestNameInterceptor(t *testing.T) {
 	}
 	//nolint:staticcheck
 	actualSorterJson, _ := json.Marshal(actualSorterMaps)
-	require.JSONEq(t, `[{"StartTime1":{"order":"asc"}}]`, string(actualSorterJson))
+	require.JSONEq(t, `[{"StartTime1":{"missing":"_last","order":"asc"}}]`, string(actualSorterJson))
 
 	_, err = c.ConvertWhereOrderBy("error='Running' order by StartTime")
 	require.Error(t, err)

--- a/develop/github/docker-compose.yml
+++ b/develop/github/docker-compose.yml
@@ -53,7 +53,20 @@ services:
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
 
   opensearch2:
-    image: opensearchproject/opensearch:2.7.0
+    image: opensearchproject/opensearch:2
+    ports:
+      - "9200:9200"
+    environment:
+      - cluster.routing.allocation.disk.threshold_enabled=true
+      - cluster.routing.allocation.disk.watermark.low=512mb
+      - cluster.routing.allocation.disk.watermark.high=256mb
+      - cluster.routing.allocation.disk.watermark.flood_stage=128mb
+      - discovery.type=single-node
+      - DISABLE_SECURITY_PLUGIN=true
+      - OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g
+
+  opensearch3:
+    image: opensearchproject/opensearch:3
     ports:
       - "9200:9200"
     environment:


### PR DESCRIPTION
## What changed?
Explicitly set the `"missing"` key in ES sorter. This is to address pagination bug in OpenSearch 2.8.0+ (see https://github.com/opensearch-project/OpenSearch/issues/8212#issuecomment-1615325095).

Run CI tests with latest version of OpenSearch 2 and OpenSearch 3.

## Why?
Full support of OpenSearch as visibility store.
Issue: https://github.com/temporalio/temporal/issues/5680

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
