### PR TITLE
Add getReplicationResolver API to namespace

### DIFF
--- a/common/namespace/namespace.go
+++ b/common/namespace/namespace.go
@@ -254,6 +254,11 @@ func (ns *Namespace) ReplicationPolicy() ReplicationPolicy {
 	return ReplicationPolicyOneCluster
 }
 
+// GetReplicationResolver return the replication resolover
+func (ns *Namespace) GetReplicationResolver() ReplicationResolver {
+	return ns.replicationResolver
+}
+
 func (ns *Namespace) GetCustomData(key string) string {
 	if ns.info.Data == nil {
 		return ""


### PR DESCRIPTION
## What changed?
Add getReplicationResolver API to namespace

## Why?
To expose ReplicationResolver so it can be used by custom logic.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
no risk.
