### PR TITLE
Add metadata context support to mutable state

### DIFF
--- a/common/contextutil/metadata.go
+++ b/common/contextutil/metadata.go
@@ -1,0 +1,67 @@
+package contextutil
+
+import (
+	"context"
+	"sync"
+)
+
+type (
+	metadataContextKey struct{}
+
+	// metadataContext is used to store workflow and activity metadata that can be modified in-place
+	metadataContext struct {
+		sync.Mutex
+		Metadata map[string]string
+	}
+)
+
+var metadataCtxKey = metadataContextKey{}
+
+// getMetadataContext extracts metadata context from golang context.
+func getMetadataContext(ctx context.Context) *metadataContext {
+	metadataCtx := ctx.Value(metadataCtxKey)
+	if metadataCtx == nil {
+		return nil
+	}
+	mc, ok := metadataCtx.(*metadataContext)
+	if !ok {
+		return nil
+	}
+	return mc
+}
+
+// AddMetadataContext adds a metadata context to the given context.
+func AddMetadataContext(ctx context.Context) context.Context {
+	metadataCtx := &metadataContext{
+		Metadata: make(map[string]string),
+	}
+	return context.WithValue(ctx, metadataCtxKey, metadataCtx)
+}
+
+// ContextMetadataSet sets a metadata key-value pair in the context.
+func ContextMetadataSet(ctx context.Context, key, value string) bool {
+	metadataCtx := getMetadataContext(ctx)
+	if metadataCtx == nil {
+		return false
+	}
+
+	metadataCtx.Lock()
+	defer metadataCtx.Unlock()
+
+	metadataCtx.Metadata[key] = value
+	return true
+}
+
+// ContextMetadataGet retrieves a metadata value from the context.
+func ContextMetadataGet(ctx context.Context, key string) (string, bool) {
+	metadataCtx := getMetadataContext(ctx)
+	if metadataCtx == nil {
+		return "", false
+	}
+
+	metadataCtx.Lock()
+	defer metadataCtx.Unlock()
+
+	value, ok := metadataCtx.Metadata[key]
+	return value, ok
+}

--- a/common/rpc/interceptor/metadata_context.go
+++ b/common/rpc/interceptor/metadata_context.go
@@ -1,0 +1,27 @@
+package interceptor
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"go.temporal.io/server/common/contextutil"
+)
+
+type MetadataContextInterceptor struct{}
+
+// NewMetadataContextInterceptor creates a new MetadataContextInterceptor
+func NewMetadataContextInterceptor() *MetadataContextInterceptor {
+	return &MetadataContextInterceptor{}
+}
+
+// Intercept adds metadata context to all incoming gRPC requests
+func (m *MetadataContextInterceptor) Intercept(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (interface{}, error) {
+	ctx = contextutil.AddMetadataContext(ctx)
+	return handler(ctx, req)
+}

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -65,6 +65,7 @@ var Module = fx.Options(
 	fx.Provide(RateLimitInterceptorProvider),
 	fx.Provide(HealthSignalAggregatorProvider),
 	fx.Provide(HealthCheckInterceptorProvider),
+	fx.Provide(MetadataContextInterceptorProvider),
 	fx.Provide(chasm.ChasmEngineInterceptorProvider),
 	fx.Provide(chasm.ChasmVisibilityInterceptorProvider),
 	fx.Provide(HistoryAdditionalInterceptorsProvider),
@@ -216,12 +217,18 @@ func HealthCheckInterceptorProvider(
 	)
 }
 
+func MetadataContextInterceptorProvider() *interceptor.MetadataContextInterceptor {
+	return interceptor.NewMetadataContextInterceptor()
+}
+
 func HistoryAdditionalInterceptorsProvider(
 	healthCheckInterceptor *interceptor.HealthCheckInterceptor,
 	chasmRequestEngineInterceptor *chasm.ChasmEngineInterceptor,
 	chasmRequestVisibilityInterceptor *chasm.ChasmVisibilityInterceptor,
+	metadataContextInterceptor *interceptor.MetadataContextInterceptor,
 ) []grpc.UnaryServerInterceptor {
 	return []grpc.UnaryServerInterceptor{
+		metadataContextInterceptor.Intercept,
 		healthCheckInterceptor.UnaryIntercept,
 		chasmRequestEngineInterceptor.Intercept,
 		chasmRequestVisibilityInterceptor.Intercept,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/contextutil"
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/enums"
@@ -6943,10 +6944,33 @@ type closeTransactionResult struct {
 	chasmNodesMutation chasm.NodesMutation
 }
 
+func (ms *MutableStateImpl) setMetaDataMap(
+	ctx context.Context,
+) {
+	switch ms.chasmTree.ArchetypeID() {
+	case chasm.WorkflowArchetypeID, chasm.SchedulerArchetypeID, chasm.UnspecifiedArchetypeID:
+		// Set workflow type
+		if wfType := ms.GetWorkflowType(); wfType != nil && wfType.GetName() != "" {
+			contextutil.ContextMetadataSet(ctx, "workflow-type", wfType.GetName())
+		}
+
+		// Set workflow task queue
+		if ms.executionInfo != nil && ms.executionInfo.TaskQueue != "" {
+			contextutil.ContextMetadataSet(ctx, "workflow-task-queue", ms.executionInfo.TaskQueue)
+		}
+
+		// TODO activity-type, activity-task-queue
+	default:
+		// No metadata to set for other archetype types
+	}
+}
+
 func (ms *MutableStateImpl) closeTransaction(
-	ctx context.Context, // TODO Attach metadata map to context based on mutable state archetype
+	ctx context.Context,
 	transactionPolicy historyi.TransactionPolicy,
 ) (closeTransactionResult, error) {
+	ms.setMetaDataMap(ctx)
+
 	if err := ms.closeTransactionWithPolicyCheck(
 		transactionPolicy,
 	); err != nil {

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -3397,6 +3397,14 @@ func (s *mutableStateSuite) TestCloseTransactionUpdateTransition() {
 				namespaceEntry.FailoverVersion(),
 			).Return(cluster.TestCurrentClusterName).AnyTimes()
 			s.mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+			s.mockEventsCache.EXPECT().GetEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&historypb.HistoryEvent{
+				EventType: enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
+				Attributes: &historypb.HistoryEvent_ActivityTaskScheduledEventAttributes{
+					ActivityTaskScheduledEventAttributes: &historypb.ActivityTaskScheduledEventAttributes{
+						ActivityType: &commonpb.ActivityType{Name: "test-activity"},
+					},
+				},
+			}, nil).AnyTimes()
 			var expectedTransitionHistory []*persistencespb.VersionedTransition
 			if s.mutableState.executionInfo.TransitionHistory == nil {
 				expectedTransitionHistory = transitionhistory.CopyVersionedTransitions(s.mutableState.executionInfo.PreviousTransitionHistory)
@@ -3899,6 +3907,14 @@ func (s *mutableStateSuite) TestCloseTransactionHandleUnknownVersionedTransition
 				namespaceEntry.FailoverVersion(),
 			).Return(cluster.TestCurrentClusterName).AnyTimes()
 			s.mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+			s.mockEventsCache.EXPECT().GetEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&historypb.HistoryEvent{
+				EventType: enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
+				Attributes: &historypb.HistoryEvent_ActivityTaskScheduledEventAttributes{
+					ActivityTaskScheduledEventAttributes: &historypb.ActivityTaskScheduledEventAttributes{
+						ActivityType: &commonpb.ActivityType{Name: "test-activity"},
+					},
+				},
+			}, nil).AnyTimes()
 
 			s.NotNil(s.mutableState.executionInfo.TransitionHistory)
 			execInfo, err := tc.txFunc(s.mutableState)


### PR DESCRIPTION
## What changed?
Adds metadata context support to history service gRPC calls while setting information before finalizing any mutable state transaction.

## Why?
We want to pass mutable state metadata, such as workflow type, activity type, workflow task queue, and activity task queue, throughout the gRPC call lifecycle.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a per-request metadata context and populates it with workflow info during state transitions.
> 
> - New `contextutil` metadata store with thread-safe, in-place `ContextMetadataSet/Get`
> - New gRPC `MetadataContextInterceptor` that injects metadata context into all history requests; wired via `fx` in `fx.go`
> - `MutableStateImpl` now sets `workflow-type` and `workflow-task-queue` into the request `context` at `closeTransaction`
> - Tests updated to stub event retrieval where needed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cc1fbcb9eae8e0985e6d0163516f5b90da2a684. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->