### PR TITLE
Link to sections in docs tree

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,20 +1,20 @@
 # Temporal Server Documentation
 
-This folder contains docs for those working closely with the Temporal server. 
+This folder contains docs for those working closely with the Temporal server.
 If you are more interested in just authoring workflows, see our [Getting Started Guide](../README.md#getting-started).
 
 ## Core Documentation Sections
 
-### Architectural Diagrams (`/architecture`)
-This section contains high-level explanations of Temporal's architecture and core concepts. 
-It is designed to be useful for both server developers and those interested in understanding the technological underpinnings of Temporal. 
+### Architecture overview ([`/architecture`](./architecture))
+This section contains high-level explanations of Temporal's architecture and core concepts.
+It is designed to be useful for both server developers and those interested in understanding the technological underpinnings of Temporal.
 Detailed diagrams and descriptions can be found there.
 
-### Development Instructions (`/development`)
-Here, you'll find guides to setting up a local development environment, along with potentially more advanced topics such as adding migrations or new Remote Procedure Calls (RPCs). 
+### Development Instructions ([`/development`](./development/))
+Here, you'll find guides to setting up a local development environment, along with potentially more advanced topics such as adding migrations or new Remote Procedure Calls (RPCs).
 This section is essential for developers looking to contribute to the Temporal codebase or understand its inner workings.
 
-### Operational Guides (`/admin`)
-This section provides reference materials for administrators responsible for deploying Temporal in a production environment. 
+### Operational Guides ([`/admin`](./admin/))
+This section provides reference materials for administrators responsible for deploying Temporal in a production environment.
 It is pretty bare for now, but it is intended to covers topics like spinning up a production environment, configuring it, and monitoring it with metrics and dynamic configurations.
 For now, you can find this info on the Temporal docs website at https://docs.temporal.io/self-hosted-guide.


### PR DESCRIPTION
The top-level docs page mentioned pages without linking to them.
This change adds links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime or configuration impact.
> 
> **Overview**
> The top-level **`docs/README.md`** now links each core section heading to its folder: [`./architecture`](./architecture), [`./development/`](./development/), and [`./admin/`](./admin/). Headings were renamed slightly (e.g. “Architectural Diagrams” → “Architecture overview”) so the link text matches the section names.
> 
> Trailing whitespace on a few lines was removed; doc content is otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b6b9bd956d6d73fe04dbf0e2a702a6a7a240fab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->