### PR TITLE
TestTooManyCancelRequests improvements

### DIFF
--- a/tests/client_misc_test.go
+++ b/tests/client_misc_test.go
@@ -257,7 +257,7 @@ func (s *ClientMiscTestSuite) TestTooManyCancelRequests() {
 		})
 		s.NoError(err)
 		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, workflowExecution.State.ExecutionState.Status)
-		s.Zero(len(workflowExecution.State.RequestCancelInfos))
+		s.Empty(workflowExecution.State.RequestCancelInfos)
 		s.NoError(s.SdkClient().CancelWorkflow(ctx, cancelerWorkflowId, ""))
 	})
 


### PR DESCRIPTION
## What changed?
Improved `TestClientMiscTestSuite/TestTooManyCancelRequests`:
* Reduced the number of target workflows from 50 -> `testcore.ClientSuiteLimit + 1` (11)
* Increased timeout when waiting for failure in `CancelAllWorkflowsAtOnce`
* Removed unnecessary 3s wait

## Why?
Reduce flakiness

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
