### PR TITLE
[Scheduler] CHASM Schedules moved to a distinct ID space

### DIFF
--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -1190,11 +1190,6 @@ func (m *executionManagerImpl) assertAndConvertArchetypeID(
 		return chasm.WorkflowArchetypeID, true
 	}
 
-	// This is a temporary exception to allow Schedules run in the same ID space as workflows.
-	if archetypeID == chasm.SchedulerArchetypeID {
-		return chasm.WorkflowArchetypeID, true
-	}
-
 	return archetypeID, false
 }
 


### PR DESCRIPTION
## What changed?
CHASM schedules have moved to their own distinct ID space in advance of launch, as the migration plan accounts for the possibility of ID space collision situations.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- not launched yet, nor any data written in cloud
