### PR TITLE
[Scheduler] Emit ScheduleBufferOverrun for Generator

### DIFF
--- a/chasm/lib/scheduler/config.go
+++ b/chasm/lib/scheduler/config.go
@@ -12,6 +12,7 @@ type (
 		DefaultCatchupWindow              time.Duration // Default for catchup window
 		MinCatchupWindow                  time.Duration // Minimum for catchup window
 		MaxBufferSize                     int           // MaxBufferSize limits the number of buffered actions pending execution in total
+		GeneratorBufferReserveSize        int           // Minimum number of spaces in `BufferedStarts` reserved for automated actions.
 		CanceledTerminatedCountAsFailures bool          // Whether cancelled+terminated count for pause-on-failure
 		RecentActionCount                 int           // Number of recent actions taken (workflow execution results) recorded in the ScheduleInfo metadata.
 		MaxActionsPerExecution            int           // Limits the number of actions (startWorkflow, terminate/cancel) taken by ExecuteTask in a single iteration
@@ -54,6 +55,7 @@ var (
 		DefaultCatchupWindow:              365 * 24 * time.Hour,
 		MinCatchupWindow:                  10 * time.Second,
 		MaxBufferSize:                     1000,
+		GeneratorBufferReserveSize:        50,
 		CanceledTerminatedCountAsFailures: false,
 		RecentActionCount:                 10,
 		MaxActionsPerExecution:            5,


### PR DESCRIPTION
## What changed?
- The `ScheduleBufferOverruns` metric is emitted from the Generator when automated actions are dropped. Backfillers still never drop actions.
- A reserve space for automated actions has been added to the buffer.

## Why?
- Noticed this as I was going over runbooks; even though CHASM scheduler will never drop a backfill action (yay), automated actions could be dropped under extreme pressure (but I gave them a pretty generous reserve).

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
