### PR TITLE
Remove redunant waitForClusterSynced after failover calls.

### DIFF
--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -990,6 +990,8 @@ func (s *FunctionalClustersTestSuite) TestResetWorkflowFailover() {
 	s.NoError(err)
 	s.True(workflowComplete)
 
+	s.waitForClusterSynced()
+
 	getHistoryReq := &workflowservice.GetWorkflowExecutionHistoryRequest{
 		Namespace: namespace,
 		Execution: &commonpb.WorkflowExecution{


### PR DESCRIPTION
## What changed?
Removed redundant waitForClusterSynced calls.

## Why?
failover already calls it.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies XDC failover tests by relying on `failover(...)`'s built-in sync.
> 
> - Removed redundant `waitForClusterSynced()` after `failover(...)` in the activity heartbeat failover path of `tests/xdc/failover_test.go` to avoid double-waiting and reduce test flakiness/time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cba7865d115ec3f0a92caa672d98461f35b06a63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->