### PR TITLE
Fix the bug fix: Don't put nil elements in the list of Worker Deployment Summaries

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3621,16 +3621,16 @@ func (wh *WorkflowHandler) ListWorkerDeployments(ctx context.Context, request *w
 		return nil, err
 	}
 
-	workerDeployments := make([]*workflowservice.ListWorkerDeploymentsResponse_WorkerDeploymentSummary, 0, len(resp))
-	for _, d := range resp {
-		workerDeployments = append(workerDeployments, &workflowservice.ListWorkerDeploymentsResponse_WorkerDeploymentSummary{
-			Name:                  d.GetName(),
-			CreateTime:            d.GetCreateTime(),
-			RoutingConfig:         d.GetRoutingConfig(),
-			LatestVersionSummary:  d.GetLatestVersionSummary(),
-			RampingVersionSummary: d.GetRampingVersionSummary(),
-			CurrentVersionSummary: d.GetCurrentVersionSummary(),
-		})
+	workerDeployments := make([]*workflowservice.ListWorkerDeploymentsResponse_WorkerDeploymentSummary, len(resp))
+	for i, d := range resp {
+		workerDeployments[i] = &workflowservice.ListWorkerDeploymentsResponse_WorkerDeploymentSummary{
+			Name:                  d.Name,
+			CreateTime:            d.CreateTime,
+			RoutingConfig:         d.RoutingConfig,
+			LatestVersionSummary:  d.LatestVersionSummary,
+			RampingVersionSummary: d.RampingVersionSummary,
+			CurrentVersionSummary: d.CurrentVersionSummary,
+		}
 	}
 
 	return &workflowservice.ListWorkerDeploymentsResponse{


### PR DESCRIPTION
## What changed?
- WISOTT

## Why?
Commit [2072e703ff65059bc7fa8caab1349dba3f910907](https://github.com/temporalio/temporal/commit/2072e703ff65059bc7fa8caab1349dba3f910907) from this morning made it so that nil objects could be in the list of deployment summaries. The consumer of this list expects no nil objects. Changing to append instead of element assignment fixes this issue.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Risk that this doesn't actually solve the issue, but we believe it does. Concurrently to this merging, @carlydf will write a test so that we don't rely on VCR to generate the racy failure case.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes `ListWorkerDeployments` resilient to missing/invalid workflow memos.
> 
> - Switches from pre-sized indexing to `append` when building `workerDeploymentSummaries`, so entries are only added when valid (prevents nil/empty slots on decode errors or race before memo upsert)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea4887ebfb9cdbb0177bf577c1a6f0b46e6d54a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->