### PR TITLE
Make TestTransientWorkflowTaskHistorySize less flaky

### DIFF
--- a/tests/transient_task_test.go
+++ b/tests/transient_task_test.go
@@ -134,7 +134,7 @@ func (s *TransientTaskSuite) TestTransientWorkflowTaskHistorySize() {
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Input:               nil,
 		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
-		WorkflowTaskTimeout: durationpb.New(4 * time.Second), // use a higher timeout as this test uses with large payloads.
+		WorkflowTaskTimeout: durationpb.New(4 * time.Second), // use a higher timeout as this test uses large payloads.
 		Identity:            identity,
 	}
 


### PR DESCRIPTION
## What changed?
- Increase workflow task timeout in TestTransientWorkflowTaskHistorySize to 4s.

## Why?
- Since this tests uses large payload (2 1MB payloads), sometimes 2s is not enough for the workflow task to process  in CI causing the test to fail. (e.g. history has workflowTaskTimedout instead of workflowTaskCompleted, or respondWorkflowTaskCompleted returns not found as the task already timed out) 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
