### PR TITLE
[Scheduler] Set an initial UpdateTime

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -88,14 +88,10 @@ func NewScheduler(
 	input *schedulepb.Schedule,
 	patch *schedulepb.SchedulePatch,
 ) *Scheduler {
-	var zero time.Time
-
 	sched := &Scheduler{
 		SchedulerState: &schedulerpb.SchedulerState{
-			Schedule: input,
-			Info: &schedulepb.ScheduleInfo{
-				UpdateTime: timestamppb.New(zero),
-			},
+			Schedule:      input,
+			Info:          &schedulepb.ScheduleInfo{},
 			Namespace:     namespace,
 			NamespaceId:   namespaceID,
 			ScheduleId:    scheduleID,
@@ -107,6 +103,7 @@ func NewScheduler(
 	}
 	sched.setNullableFields()
 	sched.Info.CreateTime = timestamppb.New(ctx.Now(sched))
+	sched.Info.UpdateTime = sched.Info.CreateTime
 
 	invoker := NewInvoker(ctx)
 	sched.Invoker = chasm.NewComponentField(ctx, invoker)

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -8,6 +8,13 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+func TestNewScheduler_UpdateTimeEqualsCreateTime(t *testing.T) {
+	scheduler, _, _ := setupSchedulerForTest(t)
+
+	protorequire.ProtoEqual(t, scheduler.Info.CreateTime, scheduler.Info.UpdateTime)
+	require.False(t, scheduler.Info.UpdateTime.AsTime().IsZero())
+}
+
 func TestListInfo(t *testing.T) {
 	scheduler, ctx, _ := setupSchedulerForTest(t)
 

--- a/chasm/lib/scheduler/spec_processor_test.go
+++ b/chasm/lib/scheduler/spec_processor_test.go
@@ -60,7 +60,7 @@ func newTestSpecProcessor(ctrl *gomock.Controller) *testSpecProcessor {
 
 func (s *specProcessorSuite) TestProcessTimeRange_LimitedActions() {
 	ctx := chasm.NewMutableContext(context.Background(), s.node)
-	sched := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, defaultSchedule(), nil)
+	sched := s.newSchedulerForTest(ctx, defaultSchedule())
 	end := time.Now()
 	start := end.Add(-defaultInterval)
 
@@ -93,7 +93,7 @@ func (s *specProcessorSuite) TestProcessTimeRange_LimitedActions() {
 
 func (s *specProcessorSuite) TestProcessTimeRange_UpdateAfterHighWatermark() {
 	ctx := chasm.NewMutableContext(context.Background(), s.node)
-	sched := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, defaultSchedule(), nil)
+	sched := s.newSchedulerForTest(ctx, defaultSchedule())
 
 	// Below window would give 6 actions, but the update time halves that.
 	base := time.Now()
@@ -120,7 +120,7 @@ func (s *specProcessorSuite) TestProcessTimeRange_UpdateBetweenNominalAndJitter(
 		}},
 		Jitter: durationpb.New(1 * time.Hour),
 	}
-	sched := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, schedule, nil)
+	sched := s.newSchedulerForTest(ctx, schedule)
 
 	// Generate a start with a long jitter period.
 	base := time.Date(2025, 03, 31, 1, 0, 0, 0, time.UTC)
@@ -145,7 +145,7 @@ func (s *specProcessorSuite) TestProcessTimeRange_UpdateBetweenNominalAndJitter(
 
 func (s *specProcessorSuite) TestProcessTimeRange_CatchupWindow() {
 	ctx := chasm.NewMutableContext(context.Background(), s.node)
-	sched := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, defaultSchedule(), nil)
+	sched := s.newSchedulerForTest(ctx, defaultSchedule())
 
 	// When an action would fall outside of the schedule's catchup window, it should
 	// be dropped.
@@ -159,7 +159,7 @@ func (s *specProcessorSuite) TestProcessTimeRange_CatchupWindow() {
 
 func (s *specProcessorSuite) TestProcessTimeRange_Limit() {
 	ctx := chasm.NewMutableContext(context.Background(), s.node)
-	sched := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, defaultSchedule(), nil)
+	sched := s.newSchedulerForTest(ctx, defaultSchedule())
 	end := time.Now()
 	start := end.Add(-defaultInterval * 5)
 
@@ -176,7 +176,7 @@ func (s *specProcessorSuite) TestProcessTimeRange_Limit() {
 
 func (s *specProcessorSuite) TestProcessTimeRange_OverlapPolicy() {
 	ctx := chasm.NewMutableContext(context.Background(), s.node)
-	sched := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, defaultSchedule(), nil)
+	sched := s.newSchedulerForTest(ctx, defaultSchedule())
 	end := time.Now()
 	start := end.Add(-defaultInterval * 5)
 
@@ -204,7 +204,7 @@ func (s *specProcessorSuite) TestProcessTimeRange_OverlapPolicy() {
 
 func (s *specProcessorSuite) TestProcessTimeRange_Basic() {
 	ctx := chasm.NewMutableContext(context.Background(), s.node)
-	sched := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, defaultSchedule(), nil)
+	sched := s.newSchedulerForTest(ctx, defaultSchedule())
 	end := time.Now()
 	start := end.Add(-defaultInterval * 5)
 

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -253,6 +253,7 @@ func (s *scheduler) run() error {
 		s.State.LastProcessedTime = timestamppb.New(s.now())
 		s.State.ConflictToken = InitialConflictToken
 		s.Info.CreateTime = s.State.LastProcessedTime
+		s.Info.UpdateTime = s.Info.CreateTime
 
 		s.recordActionPayloadMetrics()
 	}

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -278,7 +278,7 @@ func (s *scheduleFunctionalSuiteBase) TestBasics() {
 
 	// GreaterOrEqual is used as we may have had other runs start while waiting for visibility
 	s.DurationNear(describeResp.Info.CreateTime.AsTime().Sub(createTime), 0, 3*time.Second)
-	s.Equal(describeResp.Info.CreateTime.AsTime(), describeResp.Info.UpdateTime.AsTime())
+	s.Equal(describeResp.Info.CreateTime.AsTime().Truncate(time.Second), describeResp.Info.UpdateTime.AsTime().Truncate(time.Second))
 	s.GreaterOrEqual(describeResp.Info.ActionCount, int64(2))
 	s.EqualValues(0, describeResp.Info.MissedCatchupWindow)
 	s.EqualValues(0, describeResp.Info.OverlapSkipped)

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -278,6 +278,7 @@ func (s *scheduleFunctionalSuiteBase) TestBasics() {
 
 	// GreaterOrEqual is used as we may have had other runs start while waiting for visibility
 	s.DurationNear(describeResp.Info.CreateTime.AsTime().Sub(createTime), 0, 3*time.Second)
+	s.Equal(describeResp.Info.CreateTime.AsTime(), describeResp.Info.UpdateTime.AsTime())
 	s.GreaterOrEqual(describeResp.Info.ActionCount, int64(2))
 	s.EqualValues(0, describeResp.Info.MissedCatchupWindow)
 	s.EqualValues(0, describeResp.Info.OverlapSkipped)


### PR DESCRIPTION
*V1 doesn't do this, so we're going to hold off on making this change until we're completely migrated. draft for now*

## What changed?
- Sets `UpdateTime` to `CreateTime` on schedule create.

## Why?
- Looks weird if it's just set to 1970.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)
