### PR TITLE
Bump Go version 1.25.0 -> 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.temporal.io/server
 
-go 1.25.0
+go 1.25.5
 
 retract (
 	v1.26.1 // Contains retractions only.


### PR DESCRIPTION
## What changed?
Bumping Go version to 1.25.5 (latest of of this date)

## Why?
Fixes issues found in older versions of stdlib
Fixes https://github.com/temporalio/temporal/issues/8698

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps the Go toolchain used by the module.
> 
> - Updates `go` directive in `go.mod` from `1.25.0` to `1.25.5`
> - No other files or dependencies changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3937eefc3634a3897096bdf1db6f6e778b82bf8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->