### PR TITLE
Fix flaky test Count GroupBy

### DIFF
--- a/tests/chasm_test.go
+++ b/tests/chasm_test.go
@@ -405,7 +405,7 @@ func (s *ChasmTestSuite) TestCountExecutions_GroupBy() {
 					Query:         "GROUP BY `PayloadExecutionStatus`",
 				},
 			)
-			return err == nil && countResp != nil && countResp.Count > 0
+			return err == nil && countResp != nil && countResp.Count >= 5
 		},
 		testcore.WaitForESToSettle,
 		100*time.Millisecond,


### PR DESCRIPTION
## What changed?
Verify when all CHASM visibility executions have completed, instead of exiting when at least one execution has completed.

## Why?
Counting CHASM executions with GroupBy filtering fails during test verification due to a non-deterministic verification. The current code assumes all 5 executions have been written to visibility, if CountExecutions call returns ANY value greater than 0.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

