### PR TITLE
Add RateLimitedScheduler to outbound task processor

### DIFF
--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -198,9 +198,9 @@ func (f *outboundQueueFactory) CreateQueue(
 
 	currentClusterName := f.ClusterMetadata.GetCurrentClusterName()
 
-	var shardScheduler = f.hostScheduler
+	scheduler := f.hostScheduler
 	if f.Config.TaskSchedulerEnableRateLimiter() {
-		shardScheduler = queues.NewRateLimitedScheduler(
+		scheduler = queues.NewRateLimitedScheduler(
 			f.hostScheduler,
 			queues.RateLimitedSchedulerOptions{
 				EnableShadowMode: f.Config.TaskSchedulerEnableRateLimiterShadowMode,
@@ -217,7 +217,7 @@ func (f *outboundQueueFactory) CreateQueue(
 	}
 
 	rescheduler := queues.NewRescheduler(
-		shardScheduler,
+		scheduler,
 		shardContext.GetTimeSource(),
 		logger,
 		metricsHandler,
@@ -254,7 +254,7 @@ func (f *outboundQueueFactory) CreateQueue(
 
 	factory := queues.NewExecutableFactory(
 		executor,
-		shardScheduler,
+		scheduler,
 		rescheduler,
 		queues.NewNoopPriorityAssigner(),
 		shardContext.GetTimeSource(),
@@ -274,7 +274,7 @@ func (f *outboundQueueFactory) CreateQueue(
 	return queues.NewImmediateQueue(
 		shardContext,
 		tasks.CategoryOutbound,
-		shardScheduler,
+		scheduler,
 		rescheduler,
 		&queues.Options{
 			ReaderOptions: queues.ReaderOptions{


### PR DESCRIPTION
## What changed?
Add RateLimitedScheduler to the outbound task processor.

## Why?
Add task processing queues, except the outbound task queue uses RateLimitedScheduler. Adding this helps to make sure that the rate limit is applied on the caller namespace.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

