### PR TITLE
Handle nil errors in MultiOperationExecution

### DIFF
--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -382,6 +382,9 @@ func isRetryableUpdateError(err error) bool {
 	var errMultiOps *serviceerror.MultiOperationExecution
 	if errors.As(err, &errMultiOps) {
 		for _, e := range errMultiOps.OperationErrors() {
+			if e == nil {
+				continue
+			}
 			if errors.As(e, &errResourceExhausted) &&
 				(errResourceExhausted.Cause == enumspb.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT ||
 					errResourceExhausted.Cause == enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW) {


### PR DESCRIPTION
## What changed?
- There is a chance that the errors slice of a *serviceerror.MultiOperationExecution pointer contains nil errors. Right now, in the workerdeployment code, we were not handling that.

## Why?
- To fix things.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents nil error entries from breaking retry logic during multi-operation updates.
> 
> - In `service/worker/workerdeployment/util.go`, `isRetryableUpdateError` now skips `nil` items in `errMultiOps.OperationErrors()` before checking for `ResourceExhausted`, `ErrWorkflowClosing`, or `AbortedByServerErr` conditions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f8f94f136d60abd62c0a2d3c6de8d0c146c79a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->