### PR TITLE
Avoid resetting activity info TimerTaskStatus for each retry

### DIFF
--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -723,7 +723,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPoli
 	s.Equal(scheduledEvent.GetEventId(), activityInfo.ScheduledEventId)
 	s.Equal(common.EmptyEventID, activityInfo.StartedEventId)
 	// only a schedule to start timer will be created, apart from the retry timer
-	s.Equal(int32(workflow.TimerTaskStatusCreatedScheduleToStart), activityInfo.TimerTaskStatus)
+	s.Equal(int32(workflow.TimerTaskStatusCreatedScheduleToStart|workflow.TimerTaskStatusCreatedHeartbeat), activityInfo.TimerTaskStatus)
 }
 
 func (s *timerQueueActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_RetryTimeout() {

--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -67,7 +67,7 @@ func UpdateActivityInfoForRetries(
 	failure *failurepb.Failure,
 	nextScheduledTime *timestamppb.Timestamp,
 	isActivityRetryStampIncrementEnabled bool,
-) *persistencespb.ActivityInfo {
+) {
 	previousAttempt := ai.Attempt
 	ai.Attempt = attempt
 	ai.Version = version
@@ -76,7 +76,8 @@ func UpdateActivityInfoForRetries(
 	ai.StartVersion = common.EmptyVersion
 	ai.RequestId = ""
 	ai.StartedTime = nil
-	ai.TimerTaskStatus = TimerTaskStatusNone
+	// Mark per-attempt timers for recreation.
+	ai.TimerTaskStatus ^= TimerTaskStatusCreatedHeartbeat | TimerTaskStatusCreatedStartToClose | TimerTaskStatusCreatedScheduleToStart
 	ai.RetryLastWorkerIdentity = ai.StartedIdentity
 	ai.RetryLastFailure = failure
 	// this flag means the user resets the activity with "--reset-heartbeat" flag
@@ -93,8 +94,6 @@ func UpdateActivityInfoForRetries(
 	if isActivityRetryStampIncrementEnabled && attempt > previousAttempt {
 		ai.Stamp++
 	}
-
-	return ai
 }
 
 func GetPendingActivityInfo(


### PR DESCRIPTION
## What changed?

In PR description.

## Why?

Avoid creating extra timers where unnecessary.

## How did you test it?

Should be covered by existing tests.