### PR TITLE
Limit standalone activity retention time to 1 day

### DIFF
--- a/chasm/lib/activity/library.go
+++ b/chasm/lib/activity/library.go
@@ -10,17 +10,27 @@ type componentOnlyLibrary struct {
 	chasm.UnimplementedLibrary
 }
 
+const (
+	libraryName   = "activity"
+	componentName = "activity"
+)
+
+var (
+	ArchetypeID = chasm.GenerateTypeID(chasm.FullyQualifiedName(libraryName, componentName))
+)
+
 func newComponentOnlyLibrary() *componentOnlyLibrary {
 	return &componentOnlyLibrary{}
 }
 
 func (l *componentOnlyLibrary) Name() string {
-	return "activity"
+	return libraryName
 }
 
 func (l *componentOnlyLibrary) Components() []*chasm.RegistrableComponent {
 	return []*chasm.RegistrableComponent{
-		chasm.NewRegistrableComponent[*Activity]("activity",
+		chasm.NewRegistrableComponent[*Activity](
+			componentName,
 			chasm.WithSearchAttributes(
 				TypeSearchAttribute,
 				StatusSearchAttribute,

--- a/chasm/library.go
+++ b/chasm/library.go
@@ -35,8 +35,12 @@ func (UnimplementedLibrary) Tasks() []*RegistrableTask {
 func (UnimplementedLibrary) RegisterServices(_ *grpc.Server) {
 }
 
-func (UnimplementedLibrary) mustEmbedUnimplementedLibrary() {}
-
-func fullyQualifiedName(libName, name string) string {
+// FullyQualifiedName creates a fully qualified name (FQN) by combining a library name
+// and a component or task name. The FQN is used to uniquely identify components and
+// tasks within the CHASM framework.
+// The format of the returned FQN is: "libName.name"
+func FullyQualifiedName(libName, name string) string {
 	return libName + "." + name
 }
+
+func (UnimplementedLibrary) mustEmbedUnimplementedLibrary() {}

--- a/chasm/registrable_component.go
+++ b/chasm/registrable_component.go
@@ -156,13 +156,20 @@ func (rc *RegistrableComponent) registerToLibrary(
 	rc.library = library
 
 	fqn := rc.fqType()
-	rc.componentID = generateTypeID(fqn)
+	rc.componentID = GenerateTypeID(fqn)
 	return fqn, rc.componentID, nil
 }
 
 // SearchAttributesMapper returns the search attributes mapper for this component.
 func (rc *RegistrableComponent) SearchAttributesMapper() *VisibilitySearchAttributesMapper {
 	return rc.searchAttributesMapper
+}
+
+// GenerateTypeID generates a unique 32-bit identifier from a fully qualified name (FQN).
+// The generated ID is used to uniquely identify components and tasks within the CHASM framework. The same FQN will
+// always produce the same ID.
+func GenerateTypeID(fqn string) uint32 {
+	return farm.Fingerprint32([]byte(fqn))
 }
 
 // hasBusinessIDAlias returns true if the component has a businessID alias configured
@@ -188,9 +195,5 @@ func (rc *RegistrableComponent) fqType() string {
 		// this should never happen because the component is only accessible from the library.
 		panic("component is not registered to a library")
 	}
-	return fullyQualifiedName(rc.library.Name(), rc.componentType)
-}
-
-func generateTypeID(fqn string) uint32 {
-	return farm.Fingerprint32([]byte(fqn))
+	return FullyQualifiedName(rc.library.Name(), rc.componentType)
 }

--- a/chasm/registrable_task.go
+++ b/chasm/registrable_task.go
@@ -90,7 +90,7 @@ func (rt *RegistrableTask) registerToLibrary(
 	rt.library = library
 
 	fqn := rt.fqType()
-	rt.taskTypeID = generateTypeID(fqn)
+	rt.taskTypeID = GenerateTypeID(fqn)
 	return fqn, rt.taskTypeID, nil
 }
 
@@ -107,5 +107,5 @@ func (rt *RegistrableTask) fqType() string {
 		// this should never happen because the task is only accessible from the library.
 		panic("task is not registered to a library")
 	}
-	return fullyQualifiedName(rt.library.Name(), rt.taskType)
+	return FullyQualifiedName(rt.library.Name(), rt.taskType)
 }

--- a/chasm/scheduler.go
+++ b/chasm/scheduler.go
@@ -9,6 +9,6 @@ const (
 )
 
 var (
-	SchedulerArchetype   = Archetype(fullyQualifiedName(SchedulerLibraryName, SchedulerComponentName))
-	SchedulerArchetypeID = ArchetypeID(generateTypeID(SchedulerArchetype))
+	SchedulerArchetype   = Archetype(FullyQualifiedName(SchedulerLibraryName, SchedulerComponentName))
+	SchedulerArchetypeID = ArchetypeID(GenerateTypeID(SchedulerArchetype))
 )

--- a/chasm/test_var_test.go
+++ b/chasm/test_var_test.go
@@ -13,23 +13,23 @@ const (
 )
 
 var (
-	testComponentFQN      = fullyQualifiedName(testLibraryName, testComponentName)
-	testSubComponent1FQN  = fullyQualifiedName(testLibraryName, testSubComponent1Name)
-	testSubComponent11FQN = fullyQualifiedName(testLibraryName, testSubComponent11Name)
-	testSubComponent2FQN  = fullyQualifiedName(testLibraryName, testSubComponent2Name)
+	testComponentFQN      = FullyQualifiedName(testLibraryName, testComponentName)
+	testSubComponent1FQN  = FullyQualifiedName(testLibraryName, testSubComponent1Name)
+	testSubComponent11FQN = FullyQualifiedName(testLibraryName, testSubComponent11Name)
+	testSubComponent2FQN  = FullyQualifiedName(testLibraryName, testSubComponent2Name)
 
-	testSideEffectTaskFQN         = fullyQualifiedName(testLibraryName, testSideEffectTaskName)
-	testOutboundSideEffectTaskFQN = fullyQualifiedName(testLibraryName, testOutboundSideEffectTaskName)
-	testPureTaskFQN               = fullyQualifiedName(testLibraryName, testPureTaskName)
+	testSideEffectTaskFQN         = FullyQualifiedName(testLibraryName, testSideEffectTaskName)
+	testOutboundSideEffectTaskFQN = FullyQualifiedName(testLibraryName, testOutboundSideEffectTaskName)
+	testPureTaskFQN               = FullyQualifiedName(testLibraryName, testPureTaskName)
 )
 
 var (
-	testComponentTypeID      = generateTypeID(testComponentFQN)
-	testSubComponent1TypeID  = generateTypeID(testSubComponent1FQN)
-	testSubComponent11TypeID = generateTypeID(testSubComponent11FQN)
-	testSubComponent2TypeID  = generateTypeID(testSubComponent2FQN)
+	testComponentTypeID      = GenerateTypeID(testComponentFQN)
+	testSubComponent1TypeID  = GenerateTypeID(testSubComponent1FQN)
+	testSubComponent11TypeID = GenerateTypeID(testSubComponent11FQN)
+	testSubComponent2TypeID  = GenerateTypeID(testSubComponent2FQN)
 
-	testSideEffectTaskTypeID         = generateTypeID(testSideEffectTaskFQN)
-	testOutboundSideEffectTaskTypeID = generateTypeID(testOutboundSideEffectTaskFQN)
-	testPureTaskTypeID               = generateTypeID(testPureTaskFQN)
+	testSideEffectTaskTypeID         = GenerateTypeID(testSideEffectTaskFQN)
+	testOutboundSideEffectTaskTypeID = GenerateTypeID(testOutboundSideEffectTaskFQN)
+	testPureTaskTypeID               = GenerateTypeID(testPureTaskFQN)
 )

--- a/chasm/visibility.go
+++ b/chasm/visibility.go
@@ -23,8 +23,8 @@ const (
 )
 
 var (
-	visibilityComponentTypeID = generateTypeID(visibilityComponentType)
-	visibilityTaskTypeID      = generateTypeID(visibilityTaskType)
+	visibilityComponentTypeID = GenerateTypeID(visibilityComponentType)
+	visibilityTaskTypeID      = GenerateTypeID(visibilityTaskType)
 )
 
 // VisibilitySearchAttributesProvider if implemented by the root Component,

--- a/chasm/workflow.go
+++ b/chasm/workflow.go
@@ -6,6 +6,6 @@ const (
 )
 
 var (
-	WorkflowArchetype   = Archetype(fullyQualifiedName(WorkflowLibraryName, WorkflowComponentName))
-	WorkflowArchetypeID = ArchetypeID(generateTypeID(WorkflowArchetype))
+	WorkflowArchetype   = Archetype(FullyQualifiedName(WorkflowLibraryName, WorkflowComponentName))
+	WorkflowArchetypeID = ArchetypeID(GenerateTypeID(WorkflowArchetype))
 )

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -12,6 +12,7 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/log"
@@ -273,6 +274,11 @@ func (r *TaskGeneratorImpl) GenerateWorkflowCloseTasks(
 // This method returns an error when the GetNamespaceByID call fails with anything other than
 // serviceerror.NamespaceNotFound.
 func (r *TaskGeneratorImpl) getRetention() (time.Duration, error) {
+	// For standalone activities, use 1 day retention
+	if r.mutableState.ChasmTree().ArchetypeID() == activity.ArchetypeID {
+		return 24 * time.Hour, nil
+	}
+
 	retention := defaultWorkflowRetention
 	executionInfo := r.mutableState.GetExecutionInfo()
 	namespaceEntry, err := r.namespaceRegistry.GetNamespaceByID(namespace.ID(executionInfo.NamespaceId))

--- a/service/history/workflow/task_generator_test.go
+++ b/service/history/workflow/task_generator_test.go
@@ -14,6 +14,7 @@ import (
 	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/cluster"
@@ -22,6 +23,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/components/callbacks"
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/service/history/configs"
@@ -916,4 +918,151 @@ func TestTaskGeneratorImpl_GenerateDirtySubStateMachineTasks_TrimsTimersForDelet
 
 	require.Empty(t, genTasks)
 	require.Empty(t, ms.GetExecutionInfo().StateMachineTimers) // Timer should be trimmed
+}
+
+func TestTaskGeneratorImpl_GenerateDeleteHistoryEventTask_ActivityRetention(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	closeTime := time.Unix(0, 0)
+	retentionJitterDuration := time.Second
+
+	testCases := []struct {
+		name                   string
+		archetypeID            chasm.ArchetypeID
+		namespaceRetention     time.Duration
+		expectedMinRetention   time.Duration
+		expectedMaxRetention   time.Duration
+		setupNamespaceRegistry func(*namespace.MockRegistry)
+	}{
+		{
+			name:                 "standalone activity uses 1 day retention",
+			archetypeID:          activity.ArchetypeID,
+			namespaceRetention:   90 * 24 * time.Hour, // 90 days namespace retention
+			expectedMinRetention: 24 * time.Hour,      // Activity should use 1 day
+			expectedMaxRetention: 24*time.Hour + retentionJitterDuration*2,
+			setupNamespaceRegistry: func(nr *namespace.MockRegistry) {
+				// Namespace registry should not be called for activities
+			},
+		},
+		{
+			name:                 "workflow uses namespace retention",
+			archetypeID:          chasm.WorkflowArchetypeID,
+			namespaceRetention:   7 * 24 * time.Hour, // 7 days namespace retention
+			expectedMinRetention: 7 * 24 * time.Hour,
+			expectedMaxRetention: 7*24*time.Hour + retentionJitterDuration*2,
+			setupNamespaceRegistry: func(nr *namespace.MockRegistry) {
+				namespaceConfig := &persistencespb.NamespaceConfig{
+					Retention: durationpb.New(7 * 24 * time.Hour),
+				}
+				namespaceEntry := namespace.NewGlobalNamespaceForTest(
+					&persistencespb.NamespaceInfo{Id: tests.NamespaceID.String(), Name: tests.Namespace.String()},
+					namespaceConfig,
+					&persistencespb.NamespaceReplicationConfig{
+						ActiveClusterName: cluster.TestCurrentClusterName,
+						Clusters: []string{
+							cluster.TestCurrentClusterName,
+						},
+					},
+					tests.Version,
+				)
+				nr.EXPECT().GetNamespaceByID(namespaceEntry.ID()).Return(namespaceEntry, nil).AnyTimes()
+			},
+		},
+		{
+			name:                 "scheduler uses namespace retention",
+			archetypeID:          chasm.SchedulerArchetypeID,
+			namespaceRetention:   30 * 24 * time.Hour, // 30 days namespace retention
+			expectedMinRetention: 30 * 24 * time.Hour,
+			expectedMaxRetention: 30*24*time.Hour + retentionJitterDuration*2,
+			setupNamespaceRegistry: func(nr *namespace.MockRegistry) {
+				namespaceConfig := &persistencespb.NamespaceConfig{
+					Retention: durationpb.New(30 * 24 * time.Hour),
+				}
+				namespaceEntry := namespace.NewGlobalNamespaceForTest(
+					&persistencespb.NamespaceInfo{Id: tests.NamespaceID.String(), Name: tests.Namespace.String()},
+					namespaceConfig,
+					&persistencespb.NamespaceReplicationConfig{
+						ActiveClusterName: cluster.TestCurrentClusterName,
+						Clusters: []string{
+							cluster.TestCurrentClusterName,
+						},
+					},
+					tests.Version,
+				)
+				nr.EXPECT().GetNamespaceByID(namespaceEntry.ID()).Return(namespaceEntry, nil).AnyTimes()
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			namespaceRegistry := namespace.NewMockRegistry(ctrl)
+			tc.setupNamespaceRegistry(namespaceRegistry)
+
+			mutableState := historyi.NewMockMutableState(ctrl)
+			mutableState.EXPECT().GetExecutionInfo().DoAndReturn(func() *persistencespb.WorkflowExecutionInfo {
+				return &persistencespb.WorkflowExecutionInfo{
+					NamespaceId: tests.NamespaceID.String(),
+				}
+			}).AnyTimes()
+			mutableState.EXPECT().GetWorkflowKey().Return(definition.NewWorkflowKey(
+				tests.NamespaceID.String(), tests.WorkflowID, tests.RunID,
+			)).AnyTimes()
+			mutableState.EXPECT().GetCloseVersion().Return(int64(0), nil).AnyTimes()
+			mutableState.EXPECT().GetCurrentBranchToken().Return([]byte("branch-token"), nil).AnyTimes()
+
+			// Create a mock ChasmTree that returns the specific archetype ID
+			mockChasmTree := historyi.NewMockChasmTree(ctrl)
+			mockChasmTree.EXPECT().ArchetypeID().Return(tc.archetypeID).AnyTimes()
+			mutableState.EXPECT().ChasmTree().Return(mockChasmTree).AnyTimes()
+
+			var allTasks []tasks.Task
+			mutableState.EXPECT().AddTasks(gomock.Any()).Do(func(ts ...tasks.Task) {
+				allTasks = append(allTasks, ts...)
+			}).AnyTimes()
+
+			cfg := &configs.Config{
+				RetentionTimerJitterDuration: func() time.Duration {
+					return retentionJitterDuration
+				},
+			}
+
+			taskGenerator := NewTaskGenerator(
+				namespaceRegistry,
+				mutableState,
+				cfg,
+				nil, // archivalMetadata not needed for this test
+				testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError),
+			)
+
+			err := taskGenerator.GenerateDeleteHistoryEventTask(closeTime)
+			require.NoError(t, err)
+
+			// Find the DeleteHistoryEventTask
+			var deleteHistoryEventTask *tasks.DeleteHistoryEventTask
+			for _, task := range allTasks {
+				if t, ok := task.(*tasks.DeleteHistoryEventTask); ok {
+					deleteHistoryEventTask = t
+					break
+				}
+			}
+
+			require.NotNil(t, deleteHistoryEventTask, "DeleteHistoryEventTask should be created")
+			assert.Equal(t, tests.NamespaceID.String(), deleteHistoryEventTask.NamespaceID)
+			assert.Equal(t, tests.WorkflowID, deleteHistoryEventTask.WorkflowID)
+			assert.Equal(t, tests.RunID, deleteHistoryEventTask.RunID)
+			assert.Equal(t, tc.archetypeID, deleteHistoryEventTask.ArchetypeID)
+
+			// Verify the retention time is within expected range
+			expectedDeleteTime := closeTime.Add(tc.expectedMinRetention)
+			assert.GreaterOrEqual(t, deleteHistoryEventTask.VisibilityTimestamp, expectedDeleteTime,
+				"Delete time should be at least closeTime + retention")
+			assert.LessOrEqual(t, deleteHistoryEventTask.VisibilityTimestamp, closeTime.Add(tc.expectedMaxRetention),
+				"Delete time should not exceed closeTime + retention + jitter")
+		})
+	}
 }


### PR DESCRIPTION
## What changed?
Limit standalone activity retention time to 1 day. Export chasm FullyQualifiedName and GenerateTypeID

## Why?
Agreed to limit standalone execution main persistence to one day, so as not to incur extraneous costs and over-stress storage. Exported FullyQualifiedName and GenerateTypeID so they are accessible to the chasm activity code.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

