### PR TITLE
Improve error when version override does not have the version present in the task queue

### DIFF
--- a/common/worker_versioning/worker_versioning.go
+++ b/common/worker_versioning/worker_versioning.go
@@ -40,6 +40,11 @@ const (
 	UnversionedSearchAttribute = buildIdSearchAttributePrefixUnversioned
 	UnversionedVersionId       = "__unversioned__"
 
+	// ErrPinnedVersionNotInTaskQueueSubstring is the key substring used to identify
+	// when a pinned version is not present in a task queue. This is used for error
+	// classification in batch operations.
+	ErrPinnedVersionNotInTaskQueueSubstring = "is not present in task queue"
+
 	// WorkerDeploymentVersionIdDelimiterV31 will be deleted once we stop supporting v31 version string fields
 	// in external and internal APIs. Until then, both delimiters are banned in deployment name. All
 	// deprecated version string fields in APIs keep using the old delimiter. Workflow SA uses new delimiter.
@@ -54,6 +59,24 @@ const (
 	WorkerDeploymentNameFieldName                = "WorkerDeploymentName"
 	WorkerDeploymentBuildIDFieldName             = "BuildID"
 )
+
+// FormatPinnedVersionNotInTaskQueueError formats the error message when a pinned version
+// is not present in a task queue.
+func FormatPinnedVersionNotInTaskQueueError(deploymentName, buildID, taskQueue string, taskQueueType enumspb.TaskQueueType) string {
+	var tqType string
+	switch taskQueueType {
+	case enumspb.TASK_QUEUE_TYPE_WORKFLOW:
+		tqType = "Workflow"
+	case enumspb.TASK_QUEUE_TYPE_ACTIVITY:
+		tqType = "Activity"
+	case enumspb.TASK_QUEUE_TYPE_NEXUS:
+		tqType = "Nexus"
+	default:
+		tqType = "Unknown"
+	}
+	return fmt.Sprintf("Pinned version '%s:%s' %s '%s' of type '%s'",
+		deploymentName, buildID, ErrPinnedVersionNotInTaskQueueSubstring, taskQueue, tqType)
+}
 
 // PinnedBuildIdSearchAttribute creates the pinned search attribute for the BuildIds list, used as a visibility optimization.
 // For pinned workflows using WorkerDeployment APIs (ms.GetEffectiveVersioningBehavior() == PINNED &&
@@ -546,8 +569,7 @@ func validatePinnedVersionInTaskQueue(ctx context.Context,
 			return nil
 		}
 		return serviceerror.NewFailedPrecondition(
-			fmt.Sprintf("Pinned version '%s:%s' is not present in task queue '%s' of type '%s'",
-				pinnedVersion.GetDeploymentName(), pinnedVersion.GetBuildId(), tq, tqType),
+			FormatPinnedVersionNotInTaskQueueError(pinnedVersion.GetDeploymentName(), pinnedVersion.GetBuildId(), tq, tqType),
 		)
 	}
 
@@ -572,8 +594,7 @@ func validatePinnedVersionInTaskQueue(ctx context.Context,
 	)
 	if !resp.GetIsMember() {
 		return serviceerror.NewFailedPrecondition(
-			fmt.Sprintf("Pinned version '%s:%s' is not present in task queue '%s' of type '%s'",
-				pinnedVersion.GetDeploymentName(), pinnedVersion.GetBuildId(), tq, tqType),
+			FormatPinnedVersionNotInTaskQueueError(pinnedVersion.GetDeploymentName(), pinnedVersion.GetBuildId(), tq, tqType),
 		)
 	}
 	return nil

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -4968,8 +4968,6 @@ func (wh *WorkflowHandler) StartBatchOperation(
 	case *workflowservice.StartBatchOperationRequest_UpdateWorkflowOptionsOperation:
 		input.BatchType = enumspb.BATCH_OPERATION_TYPE_UPDATE_EXECUTION_OPTIONS
 		identity = op.UpdateWorkflowOptionsOperation.GetIdentity()
-		// Mark pinned version not found errors as non-retryable.
-		input.NonRetryableErrors = append(input.NonRetryableErrors, "is not present in task queue")
 	case *workflowservice.StartBatchOperationRequest_UnpauseActivitiesOperation:
 		input.BatchType = enumspb.BATCH_OPERATION_TYPE_UNPAUSE_ACTIVITY
 		identity = op.UnpauseActivitiesOperation.GetIdentity()


### PR DESCRIPTION
## What changed?
- WISOTT

## Why?
- User experience.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances error clarity and batch behavior around version overrides.
> 
> - Introduces `ErrPinnedVersionNotInTaskQueueSubstring` and `FormatPinnedVersionNotInTaskQueueError` to produce detailed messages (deployment, build ID, task queue, type)
> - Replaces generic errors in `validatePinnedVersionInTaskQueue` with formatted message; updates related tests to expect new text
> - Adds operation-aware non-retryable detection in `batcher` (`isNonRetryableError`) for `BATCH_OPERATION_TYPE_UPDATE_EXECUTION_OPTIONS` using the new substring; integrates into `handleTaskResult`
> - Removes frontend-added non-retryable string for update-execution-options; responsibility moved to worker
> - Adds unit tests for new formatter and non-retryable detection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb8942394b599c09cfa641f1c987aa85c73b9a94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->