### PR TITLE
Fix partition count in the functional tests

### DIFF
--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -624,7 +624,7 @@ func (s *FunctionalTestBase) RunTestWithMatchingBehavior(subtest func()) {
 						if forcePollForward {
 							s.InjectHook(testhooks.MatchingLBForceReadPartition, 5)
 						} else {
-							s.InjectHook(testhooks.MatchingLBForceReadPartition, 1)
+							s.InjectHook(testhooks.MatchingLBForceReadPartition, 0)
 						}
 						if forceAsync {
 							s.InjectHook(testhooks.MatchingDisableSyncMatch, true)


### PR DESCRIPTION
## What changed?
Making sure the num MatchingNumTaskqueueReadPartitions is always >= MatchingNumTaskqueueWritePartitions

## Why?
The code assumes so.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
None
