### PR TITLE
Reduce metricstest allocations

### DIFF
--- a/common/metrics/metricstest/metricstest_test.go
+++ b/common/metrics/metricstest/metricstest_test.go
@@ -10,94 +10,111 @@ import (
 	"go.temporal.io/server/common/metrics"
 )
 
-func TestBasic(t *testing.T) {
+func TestHandler(t *testing.T) {
 	t.Parallel()
-	logger := log.NewTestLogger()
-	handler, err := NewHandler(logger, metrics.ClientConfig{})
-	require.NoError(t, err)
 
-	counterName := "counter1"
-	counterTags := []metrics.Tag{
-		metrics.StringTag("l2", "v2"),
-		metrics.StringTag("l1", "v1"),
-	}
-	expectedSystemTags := []metrics.Tag{
+	systemTags := []metrics.Tag{
 		metrics.StringTag("otel_scope_name", "temporal"),
 		metrics.StringTag("otel_scope_version", ""),
 	}
-	expectedCounterTags := append(expectedSystemTags, counterTags...)
-	counter := handler.WithTags(counterTags...).Counter(counterName)
-	counter.Record(1)
-	counter.Record(1)
 
-	s1, err := handler.Snapshot()
-	require.NoError(t, err)
+	t.Run("counter", func(t *testing.T) {
+		t.Parallel()
+		handler, err := NewHandler(log.NewTestLogger(), metrics.ClientConfig{})
+		require.NoError(t, err)
 
-	counterVal, err := s1.Counter(counterName+"_total", expectedCounterTags...)
-	require.NoError(t, err)
-	assert.Equal(t, float64(2), counterVal)
+		tags := []metrics.Tag{metrics.StringTag("k1", "v1")}
+		handler.WithTags(tags...).Counter("my_counter").Record(1)
+		handler.WithTags(tags...).Counter("my_counter").Record(1)
 
-	gaugeName := "gauge1"
-	gaugeTags := []metrics.Tag{
-		metrics.StringTag("l3", "v3"),
-		metrics.StringTag("l4", "v4"),
-	}
-	expectedGaugeTags := append(expectedSystemTags, gaugeTags...)
-	gauge := handler.WithTags(gaugeTags...).Gauge(gaugeName)
-	gauge.Record(-2)
-	gauge.Record(10)
+		snap, err := handler.Snapshot()
+		require.NoError(t, err)
 
-	s2, err := handler.Snapshot()
-	require.NoError(t, err)
+		val, err := snap.Counter("my_counter_total", append(systemTags, tags...)...)
+		require.NoError(t, err)
+		assert.InDelta(t, 2, val, 0.0001)
+	})
 
-	counterVal, err = s2.Counter(counterName+"_total", expectedCounterTags...)
-	require.NoError(t, err)
-	assert.Equal(t, float64(2), counterVal)
+	t.Run("gauge", func(t *testing.T) {
+		t.Parallel()
+		handler, err := NewHandler(log.NewTestLogger(), metrics.ClientConfig{})
+		require.NoError(t, err)
 
-	gaugeVal, err := s2.Gauge(gaugeName, expectedGaugeTags...)
-	require.NoError(t, err)
-	assert.Equal(t, float64(10), gaugeVal)
+		tags := []metrics.Tag{metrics.StringTag("k1", "v1")}
+		handler.WithTags(tags...).Gauge("my_gauge").Record(-2)
+		handler.WithTags(tags...).Gauge("my_gauge").Record(10)
+
+		snap, err := handler.Snapshot()
+		require.NoError(t, err)
+
+		val, err := snap.Gauge("my_gauge", append(systemTags, tags...)...)
+		require.NoError(t, err)
+		assert.InDelta(t, 10, val, 0.0001)
+	})
+
+	t.Run("histogram", func(t *testing.T) {
+		t.Parallel()
+		handler, err := NewHandler(log.NewTestLogger(), metrics.ClientConfig{
+			PerUnitHistogramBoundaries: map[string][]float64{
+				metrics.Dimensionless: {1, 2, 5},
+			},
+		})
+		require.NoError(t, err)
+
+		tags := []metrics.Tag{metrics.StringTag("k1", "v1")}
+		handler.WithTags(tags...).Histogram("my_histogram", metrics.Dimensionless).Record(1)
+		handler.WithTags(tags...).Histogram("my_histogram", metrics.Dimensionless).Record(3)
+
+		snap, err := handler.Snapshot()
+		require.NoError(t, err)
+
+		buckets, err := snap.Histogram("my_histogram_ratio", append(systemTags, tags...)...)
+		require.NoError(t, err)
+		assert.Equal(t, []HistogramBucket{
+			{value: 1, upperBound: 1},
+			{value: 1, upperBound: 2},
+			{value: 2, upperBound: 5},
+			{value: 2, upperBound: math.Inf(1)},
+		}, buckets)
+	})
 }
 
-func TestHistogram(t *testing.T) {
-	t.Parallel()
-	logger := log.NewTestLogger()
-	handler, err := NewHandler(logger, metrics.ClientConfig{
-		PerUnitHistogramBoundaries: map[string][]float64{
-			metrics.Dimensionless: {
-				1,
-				2,
-				5,
-			},
-		},
+func TestCaptureHandler(t *testing.T) {
+	t.Run("zero allocations when no capture active", func(t *testing.T) {
+		handler := NewCaptureHandler()
+		counter := handler.Counter("test")
+
+		allocs := testing.AllocsPerRun(1, func() {
+			counter.Record(1)
+		})
+		assert.Zero(t, allocs)
 	})
-	require.NoError(t, err)
 
-	histogramName := "histogram1"
-	histogramTags := []metrics.Tag{
-		metrics.StringTag("l2", "v2"),
-		metrics.StringTag("l1", "v1"),
-	}
-	expectedSystemTags := []metrics.Tag{
-		metrics.StringTag("otel_scope_name", "temporal"),
-		metrics.StringTag("otel_scope_version", ""),
-	}
-	expectedHistogramTags := append(expectedSystemTags, histogramTags...)
-	histogram := handler.WithTags(histogramTags...).Histogram(histogramName, metrics.Dimensionless)
-	histogram.Record(1)
-	histogram.Record(3)
+	t.Run("discards metrics when no capture active", func(t *testing.T) {
+		t.Parallel()
+		handler := NewCaptureHandler()
 
-	s1, err := handler.Snapshot()
-	require.NoError(t, err)
+		handler.Counter("test_counter").Record(1)
+		handler.Gauge("test_gauge").Record(42.0)
 
-	expectedBuckets := []HistogramBucket{
-		{value: 1, upperBound: 1},
-		{value: 1, upperBound: 2},
-		{value: 2, upperBound: 5},
-		{value: 2, upperBound: math.Inf(1)},
-	}
+		capture := handler.StartCapture()
+		defer handler.StopCapture(capture)
+		assert.Empty(t, capture.Snapshot())
+	})
 
-	histogramVal, err := s1.Histogram(histogramName+"_ratio", expectedHistogramTags...)
-	require.NoError(t, err)
-	assert.Equal(t, expectedBuckets, histogramVal)
+	t.Run("records metrics when capture active", func(t *testing.T) {
+		t.Parallel()
+		handler := NewCaptureHandler()
+
+		capture := handler.StartCapture()
+		defer handler.StopCapture(capture)
+
+		handler.Counter("test_counter").Record(1)
+		handler.Counter("test_counter").Record(2)
+		handler.Gauge("test_gauge").Record(42.0)
+
+		snapshot := capture.Snapshot()
+		assert.Len(t, snapshot["test_counter"], 2)
+		assert.Len(t, snapshot["test_gauge"], 1)
+	})
 }


### PR DESCRIPTION
## What changed?

Reduce memory allocations of metricstest helpers by discarding metrics early while no captures are active (which is the most common scenario).

## Why?

I noticed on another PR where I took a pprof snapshot that a single functional test job needlessly allocated **2.7GB** (last line in below's snippet) despite very few tests actually needing the metric snapshot.

```
File: tests.test
  Build ID: 6c0c0ed82153b3d7917d885f9dff8737065c87e2
  Type: alloc_space
  Time: 2026-01-14 17:50:33 UTC
  Showing nodes accounting for 23712.04MB, 70.46% of 33653.67MB total
  Dropped 5262 nodes (cum <= 168.27MB)
  flat  flat%   sum%        cum   cum%
  3102.64MB  9.22%  9.22%  3783.86MB 11.24%  compress/flate.NewWriter (inline)
  2708.72MB  8.05% 17.27%  2709.72MB  8.05%  go.temporal.io/server/common/metrics/metricstest.(*CaptureHandler).record
  [...]
```

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

