### PR TITLE
Reduce load on priority activity functional test

### DIFF
--- a/tests/priority_fairness_test.go
+++ b/tests/priority_fairness_test.go
@@ -115,6 +115,7 @@ func (s *PrioritySuite) TestActivity_Basic() {
 		s.NoError(err)
 	}
 
+	// wait for activity tasks to appear in the matching backlog (from transfer queue)
 	s.Eventually(func() bool {
 		res, err := s.AdminClient().DescribeTaskQueuePartition(ctx, &adminservice.DescribeTaskQueuePartitionRequest{
 			Namespace: s.Namespace().String(),


### PR DESCRIPTION
## What changed?
Reduce the number of tasks to reduce load in CI to hopefully avoid the context timeout.

## Why?
We've observed some flakes in CI for this, this should help.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)


