### PR TITLE
Forward original HTTP headers for Nexus CompleteOperation

### DIFF
--- a/components/nexusoperations/frontend/handler.go
+++ b/components/nexusoperations/frontend/handler.go
@@ -308,6 +308,9 @@ func (h *completionHandler) forwardCompleteOperation(ctx context.Context, r *nex
 	}
 
 	forwardReq.Header = rCtx.originalHeaders
+	if forwardReq.Header == nil {
+		forwardReq.Header = make(http.Header, 1)
+	}
 	forwardReq.Header.Set(interceptor.DCRedirectionApiHeaderName, "true")
 
 	resp, err := client.Do(forwardReq)


### PR DESCRIPTION
## What changed?
Forward originally received HTTP headers for Nexus CompleteOperation requests.

## Why?
This avoids header sanitization that occurs in the interceptors as those headers are still needed on the forwarded request.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

