### PR TITLE
[Flake resolution]: Resolve flakiness on the TestTaskQueueStatsSuite 

### DIFF
--- a/tests/task_queue_stats_test.go
+++ b/tests/task_queue_stats_test.go
@@ -19,6 +19,7 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/worker_versioning"
 	"go.temporal.io/server/tests/testcore"
@@ -56,19 +57,14 @@ type (
 	TaskQueueExpectationsByType map[enumspb.TaskQueueType]TaskQueueExpectations
 )
 
-func shortRandomizedName(prefix string) string {
-	// Keep names short because they get embedded (and base64-encoded) into internal persisted task_queue_id strings
-	return fmt.Sprintf("%s-%s", prefix, uuid.NewString()[:8])
-}
-
 // TODO(pri): remove once the classic matcher is removed
 func TestTaskQueueStats_Classic_Suite(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	suite.Run(t, &TaskQueueStatsSuite{usePriMatcher: false})
 }
 
 func TestTaskQueueStats_Pri_Suite(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	suite.Run(t, &TaskQueueStatsSuite{usePriMatcher: true})
 }
 
@@ -131,7 +127,7 @@ func (s *TaskQueueStatsSuite) TestAddMultipleTasks_MultiplePartitions_ValidateSt
 	s.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
 	s.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Hour) // using a long TTL to verify caching
 
-	tqName := shortRandomizedName("backlog-counter-task-queue")
+	tqName := "tq-" + common.GenerateRandomString(5)
 	s.createDeploymentInTaskQueue(tqName)
 
 	// Enqueue all workflows.
@@ -198,9 +194,9 @@ func (s *TaskQueueStatsSuite) currentVersionAbsorbsUnversionedBacklogNoRamping(n
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	tqName := shortRandomizedName("tq-current-absorbs-unversioned")
-	deploymentName := shortRandomizedName("deployment")
-	currentBuildID := shortRandomizedName("current-build-id")
+	deploymentName := testcore.RandomizeStr("deployment")
+	tqName := "tq-" + common.GenerateRandomString(5)
+	currentBuildID := "v1"
 
 	// Register this version in the task queue
 	pollerCtx, cancelPoller := context.WithCancel(testcore.NewContext())
@@ -332,9 +328,9 @@ func (s *TaskQueueStatsSuite) currentAbsorbsUnversionedBacklogWhenRampingToUnver
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	tqName := shortRandomizedName("ramping-unversioned")
-	deploymentName := shortRandomizedName("deployment")
-	currentBuildID := shortRandomizedName(tqName + "-current-build-id")
+	deploymentName := testcore.RandomizeStr("deployment")
+	tqName := "tq-" + common.GenerateRandomString(5)
+	currentBuildID := "v1"
 
 	pollCtx, cancelPoll := context.WithCancel(ctx)
 	s.createVersionsInTaskQueue(pollCtx, tqName, deploymentName, currentBuildID)
@@ -415,9 +411,9 @@ func (s *TaskQueueStatsSuite) rampingAbsorbsUnversionedBacklogWhenCurrentIsUnver
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	tqName := shortRandomizedName("tq-ramping-from-unversioned")
-	deploymentName := shortRandomizedName(tqName + "-deployment")
-	rampingBuildID := shortRandomizedName(tqName + "-ramping-build-id")
+	deploymentName := testcore.RandomizeStr("deployment")
+	tqName := "tq-" + common.GenerateRandomString(5)
+	rampingBuildID := "v2"
 
 	pollCtx, cancelPoll := context.WithCancel(ctx)
 	s.createVersionsInTaskQueue(pollCtx, tqName, deploymentName, rampingBuildID)
@@ -483,10 +479,10 @@ func (s *TaskQueueStatsSuite) rampingAndCurrentAbsorbsUnversionedBacklog(numPart
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	tqName := shortRandomizedName("tq-ramping-and-current")
-	deploymentName := shortRandomizedName("deployment")
-	currentBuildID := shortRandomizedName("current-build-id")
-	rampingBuildID := shortRandomizedName("ramping-build-id")
+	tqName := "tq-" + common.GenerateRandomString(5)
+	deploymentName := testcore.RandomizeStr("deployment")
+	currentBuildID := "v1"
+	rampingBuildID := "v2"
 
 	pollCtx, cancelPoll := context.WithCancel(ctx)
 	s.createVersionsInTaskQueue(pollCtx, tqName, deploymentName, currentBuildID)
@@ -663,10 +659,10 @@ func (s *TaskQueueStatsSuite) inactiveVersionDoesNotAbsorbUnversionedBacklog(num
 	s.OverrideDynamicConfig(dynamicconfig.MatchingLongPollExpirationInterval, 10*time.Second)
 	s.OverrideDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 1*time.Millisecond) // zero means no TTL
 
-	tqName := shortRandomizedName("inactive-version")
-	deploymentName := shortRandomizedName(tqName + "-deployment")
-	currentBuildID := shortRandomizedName(tqName + "-current-build-id")
-	inactiveBuildID := shortRandomizedName(tqName + "-inactive-build-id")
+	tqName := "tq-" + common.GenerateRandomString(5)
+	deploymentName := testcore.RandomizeStr("deployment")
+	currentBuildID := "v1"
+	inactiveBuildID := "v2"
 
 	pollCtx, cancelPoll := context.WithCancel(testcore.NewContext())
 
@@ -858,10 +854,9 @@ func (s *TaskQueueStatsSuite) requireWDVTaskQueueStatsRelaxed(
 	validateTaskQueueStats(label, a, stats, expectation)
 }
 
-// requireLegacyTaskQueueStatsRelaxed is a relaxed version of requireLegacyTaskQueueStatsStrict
-// that allows for over-counting in multi-partition ramping scenarios.
-// The production code intentionally uses math.Ceil for both ramping and current percentage
-// calculations across partitions, which can result in slight over-counting.
+// requireLegacyTaskQueueStatsRelaxed asserts task queue statistics by allowing for over-counting in multi-partition scenarios.
+// The production code intentionally uses math.Ceil for both ramping and current percentage calculations across partitions,
+// which can result in slight over-counting.
 func (s *TaskQueueStatsSuite) requireLegacyTaskQueueStatsRelaxed(
 	ctx context.Context,
 	a *require.Assertions,
@@ -884,7 +879,7 @@ func (s *TaskQueueStatsSuite) requireLegacyTaskQueueStatsRelaxed(
 
 // Publishes versioned and unversioned entities; with one entity per priority (plus default priority). Multiplied by `sets`.
 func (s *TaskQueueStatsSuite) publishConsumeWorkflowTasksValidateStats(sets int, singlePartition bool) {
-	tqName := shortRandomizedName("backlog-counter-task-queue")
+	tqName := "tq-" + common.GenerateRandomString(5)
 	s.createDeploymentInTaskQueue(tqName)
 
 	// verify both workflow and activity backlogs are empty


### PR DESCRIPTION
## What changed?
- Tests that are testing the statistics of current/ramping versions were altered to have their checks relaxed. They were relaxed in the sense that we now allow these stats to be over-counted since it's theoretically possible for them to do so.

## Why?
- When calculating per-version stats, each partition has a very narrow view of them. An unequal distribution of tasks in each partition could lead to an aggregated count of the backlog to be more than the total number of scheduled tasks on the workflow. This is possible because each task queue partition calculates a version's stats using the `math.ceil` function (since we are okay with an overcount).

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts TaskQueueStats tests to tolerate partition-induced overcounting and stabilize flakey assertions.
> 
> - Introduces relaxed helpers `requireWDVTaskQueueStatsRelaxed` and `requireLegacyTaskQueueStatsRelaxed` that allow up to `numPartitions` extra backlog items (due to per-partition ceil) and replaces strict assertions across relevant tests
> - Passes `numPartitions` through call sites; updates test data (task queue names via `common.GenerateRandomString`, simplified build IDs/deployment names)
> - Keeps behavior validation (rates/backlog across current, ramping, inactive, and legacy modes) while allowing slight overcounts, especially in multi-partition scenarios
> - Imports `go.temporal.io/server/common` for random string generation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87b889a92636c44a81313212b56066a704ea700e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->