### PR TITLE
Inline SAA API handling in handler.go

### DIFF
--- a/service/history/api/recordactivitytaskheartbeat/api.go
+++ b/service/history/api/recordactivitytaskheartbeat/api.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/chasm"
-	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/metrics"
@@ -27,20 +25,6 @@ func Invoke(
 	token, err0 := tokenSerializer.Deserialize(request.TaskToken)
 	if err0 != nil {
 		return nil, consts.ErrDeserializingToken
-	}
-
-	// Handle as standalone activity if token has component ref.
-	if componentRef := token.GetComponentRef(); len(componentRef) > 0 {
-		response, _, err := chasm.UpdateComponent(
-			ctx,
-			componentRef,
-			(*activity.Activity).RecordHeartbeat,
-			activity.WithToken[*historyservice.RecordActivityTaskHeartbeatRequest]{
-				Token:   token,
-				Request: req,
-			},
-		)
-		return response, err
 	}
 
 	_, err := api.GetActiveNamespace(shard, namespace.ID(req.GetNamespaceId()), token.WorkflowId)

--- a/service/history/api/recordactivitytaskstarted/api.go
+++ b/service/history/api/recordactivitytaskstarted/api.go
@@ -12,8 +12,6 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/chasm"
-	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/metrics"
@@ -44,21 +42,6 @@ func Invoke(
 	workflowConsistencyChecker api.WorkflowConsistencyChecker,
 	matchingClient matchingservice.MatchingServiceClient,
 ) (resp *historyservice.RecordActivityTaskStartedResponse, retError error) {
-	if activityRefProto := request.GetComponentRef(); len(activityRefProto) > 0 {
-		response, _, err := chasm.UpdateComponent(
-			ctx,
-			activityRefProto,
-			(*activity.Activity).HandleStarted,
-			request,
-		)
-
-		if err != nil {
-			return nil, err
-		}
-
-		return response, nil
-	}
-
 	var err error
 	response := &historyservice.RecordActivityTaskStartedResponse{}
 	var rejectCode rejectCode

--- a/service/history/api/respondactivitytaskcanceled/api.go
+++ b/service/history/api/respondactivitytaskcanceled/api.go
@@ -6,8 +6,6 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/chasm"
-	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/metrics"
@@ -30,34 +28,6 @@ func Invoke(
 	token, err0 := tokenSerializer.Deserialize(request.TaskToken)
 	if err0 != nil {
 		return nil, consts.ErrDeserializingToken
-	}
-
-	// Handle standalone activity if component ref is present in the token
-	if componentRef := token.GetComponentRef(); len(componentRef) > 0 {
-		namespaceEntry, err := api.GetActiveNamespace(shard, namespace.ID(req.GetNamespaceId()), token.ActivityId)
-		if err != nil {
-			return nil, err
-		}
-		response, _, err := chasm.UpdateComponent(
-			ctx,
-			componentRef,
-			(*activity.Activity).HandleCanceled,
-			activity.RespondCancelledEvent{
-				Request: req,
-				Token:   token,
-				MetricsHandlerBuilderParams: activity.MetricsHandlerBuilderParams{
-					Handler:                     shard.GetMetricsHandler(),
-					NamespaceName:               namespaceEntry.Name().String(),
-					BreakdownMetricsByTaskQueue: shard.GetConfig().BreakdownMetricsByTaskQueue,
-				},
-			},
-		)
-
-		if err != nil {
-			return nil, err
-		}
-
-		return response, nil
 	}
 
 	namespaceEntry, err := api.GetActiveNamespace(shard, namespace.ID(req.GetNamespaceId()), token.WorkflowId)

--- a/service/history/api/respondactivitytaskcompleted/api.go
+++ b/service/history/api/respondactivitytaskcompleted/api.go
@@ -6,8 +6,6 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/chasm"
-	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/metrics"
@@ -30,34 +28,6 @@ func Invoke(
 	token, err0 := tokenSerializer.Deserialize(request.TaskToken)
 	if err0 != nil {
 		return nil, consts.ErrDeserializingToken
-	}
-
-	// Handle standalone activity if component ref is present in the token
-	if componentRef := token.GetComponentRef(); len(componentRef) > 0 {
-		namespaceEntry, err := api.GetActiveNamespace(shard, namespace.ID(req.GetNamespaceId()), token.ActivityId)
-		if err != nil {
-			return nil, err
-		}
-		response, _, err := chasm.UpdateComponent(
-			ctx,
-			componentRef,
-			(*activity.Activity).HandleCompleted,
-			activity.RespondCompletedEvent{
-				Request: req,
-				Token:   token,
-				MetricsHandlerBuilderParams: activity.MetricsHandlerBuilderParams{
-					Handler:                     shard.GetMetricsHandler(),
-					NamespaceName:               namespaceEntry.Name().String(),
-					BreakdownMetricsByTaskQueue: shard.GetConfig().BreakdownMetricsByTaskQueue,
-				},
-			},
-		)
-
-		if err != nil {
-			return nil, err
-		}
-
-		return response, nil
 	}
 
 	namespaceEntry, err := api.GetActiveNamespace(shard, namespace.ID(req.GetNamespaceId()), token.WorkflowId)

--- a/service/history/api/respondactivitytaskfailed/api.go
+++ b/service/history/api/respondactivitytaskfailed/api.go
@@ -7,8 +7,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/chasm"
-	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/metrics"
@@ -31,34 +29,6 @@ func Invoke(
 	token, err0 := tokenSerializer.Deserialize(request.TaskToken)
 	if err0 != nil {
 		return nil, consts.ErrDeserializingToken
-	}
-
-	// Handle standalone activity if component ref is present in the token
-	if componentRef := token.GetComponentRef(); len(componentRef) > 0 {
-		namespaceEntry, err := api.GetActiveNamespace(shard, namespace.ID(req.GetNamespaceId()), token.ActivityId)
-		if err != nil {
-			return nil, err
-		}
-		response, _, err := chasm.UpdateComponent(
-			ctx,
-			componentRef,
-			(*activity.Activity).HandleFailed,
-			activity.RespondFailedEvent{
-				Request: req,
-				Token:   token,
-				MetricsHandlerBuilderParams: activity.MetricsHandlerBuilderParams{
-					Handler:                     shard.GetMetricsHandler(),
-					NamespaceName:               namespaceEntry.Name().String(),
-					BreakdownMetricsByTaskQueue: shard.GetConfig().BreakdownMetricsByTaskQueue,
-				},
-			},
-		)
-
-		if err != nil {
-			return nil, err
-		}
-
-		return response, nil
 	}
 
 	namespaceEntry, err := api.GetActiveNamespace(shard, namespace.ID(req.GetNamespaceId()), token.WorkflowId)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -21,6 +21,7 @@ import (
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/client/history"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/archiver"
@@ -301,31 +302,36 @@ func (h *Handler) IsActivityTaskValid(ctx context.Context, request *historyservi
 func (h *Handler) RecordActivityTaskHeartbeat(ctx context.Context, request *historyservice.RecordActivityTaskHeartbeatRequest) (_ *historyservice.RecordActivityTaskHeartbeatResponse, retError error) {
 	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 
+	taskToken, err := h.tokenSerializer.Deserialize(request.GetHeartbeatRequest().GetTaskToken())
+	if err != nil {
+		return nil, consts.ErrDeserializingToken
+	}
+
+	if err := validateTaskToken(taskToken); err != nil {
+		return nil, h.convertError(err)
+	}
+
+	// Handle as standalone activity if token has component ref.
+	if componentRef := taskToken.GetComponentRef(); len(componentRef) > 0 {
+		response, _, err := chasm.UpdateComponent(
+			ctx,
+			componentRef,
+			(*activity.Activity).RecordHeartbeat,
+			activity.WithToken[*historyservice.RecordActivityTaskHeartbeatRequest]{
+				Token:   taskToken,
+				Request: request,
+			},
+		)
+		return response, h.convertError(err)
+	}
+
+	// Handle worklow activity (mutable state backed implementation).
 	namespaceID := namespace.ID(request.GetNamespaceId())
 	if namespaceID == "" {
 		return nil, h.convertError(errNamespaceNotSet)
 	}
 
-	heartbeatRequest := request.HeartbeatRequest
-	taskToken, err0 := h.tokenSerializer.Deserialize(heartbeatRequest.TaskToken)
-	if err0 != nil {
-		return nil, consts.ErrDeserializingToken
-	}
-
-	err0 = validateTaskToken(taskToken)
-	if err0 != nil {
-		return nil, h.convertError(err0)
-	}
-	businessID := taskToken.GetWorkflowId()
-	if businessID == "" {
-		ref, err := chasm.DeserializeComponentRef(taskToken.GetComponentRef())
-		if err != nil {
-			return nil, err
-		}
-		businessID = ref.BusinessID
-	}
-
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, businessID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, taskToken.GetWorkflowId())
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -346,22 +352,27 @@ func (h *Handler) RecordActivityTaskHeartbeat(ctx context.Context, request *hist
 func (h *Handler) RecordActivityTaskStarted(ctx context.Context, request *historyservice.RecordActivityTaskStartedRequest) (_ *historyservice.RecordActivityTaskStartedResponse, retError error) {
 	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 
-	namespaceID := namespace.ID(request.GetNamespaceId())
-	workflowExecution := request.WorkflowExecution
-	businessID := workflowExecution.GetWorkflowId()
-	if businessID == "" {
-		ref, err := chasm.DeserializeComponentRef(request.GetComponentRef())
+	// Handle as standalone activity if request has component ref.
+	if activityRefProto := request.GetComponentRef(); len(activityRefProto) > 0 {
+		response, _, err := chasm.UpdateComponent(
+			ctx,
+			activityRefProto,
+			(*activity.Activity).HandleStarted,
+			request,
+		)
 		if err != nil {
 			return nil, err
 		}
-		businessID = ref.BusinessID
+		return response, nil
 	}
 
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, businessID)
-	if request.GetNamespaceId() == "" {
+	// Handle worklow activity (mutable state backed implementation).
+	namespaceID := namespace.ID(request.GetNamespaceId())
+	if namespaceID == "" {
 		return nil, h.convertError(errNamespaceNotSet)
 	}
 
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, request.GetWorkflowExecution().GetWorkflowId())
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -426,31 +437,49 @@ func (h *Handler) RecordWorkflowTaskStarted(ctx context.Context, request *histor
 func (h *Handler) RespondActivityTaskCompleted(ctx context.Context, request *historyservice.RespondActivityTaskCompletedRequest) (_ *historyservice.RespondActivityTaskCompletedResponse, retError error) {
 	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 
+	taskToken, err := h.tokenSerializer.Deserialize(request.CompleteRequest.GetTaskToken())
+	if err != nil {
+		return nil, consts.ErrDeserializingToken
+	}
+
+	if err := validateTaskToken(taskToken); err != nil {
+		return nil, h.convertError(err)
+	}
+
+	// Handle standalone activity if component ref is present in the token.
+	if componentRef := taskToken.GetComponentRef(); len(componentRef) > 0 {
+		namespaceName, err := h.namespaceRegistry.GetNamespaceName(namespace.ID(request.GetNamespaceId()))
+		if err != nil {
+			return nil, err
+		}
+
+		response, _, err := chasm.UpdateComponent(
+			ctx,
+			componentRef,
+			(*activity.Activity).HandleCompleted,
+			activity.RespondCompletedEvent{
+				Request: request,
+				Token:   taskToken,
+				MetricsHandlerBuilderParams: activity.MetricsHandlerBuilderParams{
+					Handler:                     h.metricsHandler,
+					NamespaceName:               namespaceName.String(),
+					BreakdownMetricsByTaskQueue: h.config.BreakdownMetricsByTaskQueue,
+				},
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		return response, nil
+	}
+
+	// Handle worklow activity (mutable state backed implementation).
 	namespaceID := namespace.ID(request.GetNamespaceId())
 	if namespaceID == "" {
 		return nil, h.convertError(errNamespaceNotSet)
 	}
 
-	completeRequest := request.CompleteRequest
-	taskToken, err0 := h.tokenSerializer.Deserialize(completeRequest.TaskToken)
-	if err0 != nil {
-		return nil, consts.ErrDeserializingToken
-	}
-
-	err0 = validateTaskToken(taskToken)
-	if err0 != nil {
-		return nil, h.convertError(err0)
-	}
-	businessID := taskToken.GetWorkflowId()
-	if businessID == "" {
-		ref, err := chasm.DeserializeComponentRef(taskToken.GetComponentRef())
-		if err != nil {
-			return nil, err
-		}
-		businessID = ref.BusinessID
-	}
-
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, businessID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, taskToken.GetWorkflowId())
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -471,31 +500,49 @@ func (h *Handler) RespondActivityTaskCompleted(ctx context.Context, request *his
 func (h *Handler) RespondActivityTaskFailed(ctx context.Context, request *historyservice.RespondActivityTaskFailedRequest) (_ *historyservice.RespondActivityTaskFailedResponse, retError error) {
 	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 
+	taskToken, err := h.tokenSerializer.Deserialize(request.FailedRequest.GetTaskToken())
+	if err != nil {
+		return nil, consts.ErrDeserializingToken
+	}
+
+	if err := validateTaskToken(taskToken); err != nil {
+		return nil, h.convertError(err)
+	}
+
+	// Handle standalone activity if component ref is present in the token.
+	if componentRef := taskToken.GetComponentRef(); len(componentRef) > 0 {
+		namespaceName, err := h.namespaceRegistry.GetNamespaceName(namespace.ID(request.GetNamespaceId()))
+		if err != nil {
+			return nil, err
+		}
+
+		response, _, err := chasm.UpdateComponent(
+			ctx,
+			componentRef,
+			(*activity.Activity).HandleFailed,
+			activity.RespondFailedEvent{
+				Request: request,
+				Token:   taskToken,
+				MetricsHandlerBuilderParams: activity.MetricsHandlerBuilderParams{
+					Handler:                     h.metricsHandler,
+					NamespaceName:               namespaceName.String(),
+					BreakdownMetricsByTaskQueue: h.config.BreakdownMetricsByTaskQueue,
+				},
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		return response, nil
+	}
+
+	// Handle worklow activity (mutable state backed implementation).
 	namespaceID := namespace.ID(request.GetNamespaceId())
 	if namespaceID == "" {
 		return nil, h.convertError(errNamespaceNotSet)
 	}
 
-	failRequest := request.FailedRequest
-	taskToken, err0 := h.tokenSerializer.Deserialize(failRequest.TaskToken)
-	if err0 != nil {
-		return nil, consts.ErrDeserializingToken
-	}
-
-	err0 = validateTaskToken(taskToken)
-	if err0 != nil {
-		return nil, h.convertError(err0)
-	}
-	businessID := taskToken.GetWorkflowId()
-	if businessID == "" {
-		ref, err := chasm.DeserializeComponentRef(taskToken.GetComponentRef())
-		if err != nil {
-			return nil, err
-		}
-		businessID = ref.BusinessID
-	}
-
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, businessID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, taskToken.GetWorkflowId())
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -516,31 +563,49 @@ func (h *Handler) RespondActivityTaskFailed(ctx context.Context, request *histor
 func (h *Handler) RespondActivityTaskCanceled(ctx context.Context, request *historyservice.RespondActivityTaskCanceledRequest) (_ *historyservice.RespondActivityTaskCanceledResponse, retError error) {
 	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 
+	taskToken, err := h.tokenSerializer.Deserialize(request.CancelRequest.GetTaskToken())
+	if err != nil {
+		return nil, consts.ErrDeserializingToken
+	}
+
+	if err := validateTaskToken(taskToken); err != nil {
+		return nil, h.convertError(err)
+	}
+
+	// Handle standalone activity if component ref is present in the token.
+	if componentRef := taskToken.GetComponentRef(); len(componentRef) > 0 {
+		namespaceName, err := h.namespaceRegistry.GetNamespaceName(namespace.ID(request.GetNamespaceId()))
+		if err != nil {
+			return nil, err
+		}
+
+		response, _, err := chasm.UpdateComponent(
+			ctx,
+			componentRef,
+			(*activity.Activity).HandleCanceled,
+			activity.RespondCancelledEvent{
+				Request: request,
+				Token:   taskToken,
+				MetricsHandlerBuilderParams: activity.MetricsHandlerBuilderParams{
+					Handler:                     h.metricsHandler,
+					NamespaceName:               namespaceName.String(),
+					BreakdownMetricsByTaskQueue: h.config.BreakdownMetricsByTaskQueue,
+				},
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		return response, nil
+	}
+
+	// Handle worklow activity (mutable state backed implementation).
 	namespaceID := namespace.ID(request.GetNamespaceId())
 	if namespaceID == "" {
 		return nil, h.convertError(errNamespaceNotSet)
 	}
 
-	cancelRequest := request.CancelRequest
-	taskToken, err0 := h.tokenSerializer.Deserialize(cancelRequest.TaskToken)
-	if err0 != nil {
-		return nil, consts.ErrDeserializingToken
-	}
-
-	err0 = validateTaskToken(taskToken)
-	if err0 != nil {
-		return nil, h.convertError(err0)
-	}
-	businessID := taskToken.GetWorkflowId()
-	if businessID == "" {
-		ref, err := chasm.DeserializeComponentRef(taskToken.GetComponentRef())
-		if err != nil {
-			return nil, err
-		}
-		businessID = ref.BusinessID
-	}
-
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, businessID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, taskToken.GetWorkflowId())
 	if err != nil {
 		return nil, h.convertError(err)
 	}


### PR DESCRIPTION
Removes redundant code from the previous approach (#9041).
Note that we do not call `GetActiveNamespace`, it is deferred to the end of the transaction and should ideally be solved in the platform level and not pollute business logic.