### PR TITLE
wrap matching_engine gauge checks in eventually

### DIFF
--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -2989,10 +2989,12 @@ func (s *matchingEngineSuite) TaskQueueMetricValidator(capture *metricstest.Capt
 
 func (s *matchingEngineSuite) PhysicalQueueMetricValidator(capture *metricstest.Capture, physicalTaskQueueLength int, physicalTaskQueueCounter float64) {
 	// checks the metrics according to the values passed in the parameters
-	snapshot := capture.Snapshot()
-	physicalTaskQueueRecordings := snapshot[metrics.LoadedPhysicalTaskQueueGauge.Name()]
-	s.Len(physicalTaskQueueRecordings, physicalTaskQueueLength)
-	s.Equal(physicalTaskQueueCounter, physicalTaskQueueRecordings[physicalTaskQueueLength-1].Value.(float64))
+	s.Eventually(func() bool {
+		snapshot := capture.Snapshot()
+		physicalTaskQueueRecordings := snapshot[metrics.LoadedPhysicalTaskQueueGauge.Name()]
+		return len(physicalTaskQueueRecordings) == physicalTaskQueueLength &&
+			physicalTaskQueueCounter == physicalTaskQueueRecordings[physicalTaskQueueLength-1].Value.(float64)
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
 func (s *matchingEngineSuite) TestUpdateTaskQueuePartitionGauge_RootPartitionWorkflowType() {


### PR DESCRIPTION
These are checking the metrics for the TaskQueueStarted counter, however even with WaitUntilInitialized on physicalTaskQueManagerImpl it doesn't gurantee that the metrics has been emitted as the WaitUntilInitialized just waits for the backlog manager.

## What changed?
wrap matching_engine gauge checks in eventually

## Why?
These are checking the metrics for the TaskQueueStarted counter, however even with WaitUntilInitialized on physicalTaskQueManagerImpl it doesn't gurantee that the metrics has been emitted as the WaitUntilInitialized just waits for the backlog manager.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
