### PR TITLE
[Elasticsearch] Combine query clauses whenever possible to avoid deep nested BoolQuery

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/query_converter_bool_query.go
+++ b/common/persistence/visibility/store/elasticsearch/query_converter_bool_query.go
@@ -1,0 +1,51 @@
+package elasticsearch
+
+import (
+	"fmt"
+
+	"github.com/olivere/elastic/v7"
+)
+
+// This is a wrapper for elastic.BoolQuery so we can access the clauses and be able to combine
+// queries and avoid nesting queries when possible.
+type boolQuery struct {
+	mustNotClauses     []elastic.Query
+	filterClauses      []elastic.Query
+	shouldClauses      []elastic.Query
+	minimumShouldMatch string
+}
+
+var _ elastic.Query = (*boolQuery)(nil)
+
+func newBoolQuery() *boolQuery {
+	return &boolQuery{}
+}
+
+func (q *boolQuery) MustNot(queries ...elastic.Query) *boolQuery {
+	q.mustNotClauses = append(q.mustNotClauses, queries...)
+	return q
+}
+
+func (q *boolQuery) Filter(filters ...elastic.Query) *boolQuery {
+	q.filterClauses = append(q.filterClauses, filters...)
+	return q
+}
+
+func (q *boolQuery) Should(queries ...elastic.Query) *boolQuery {
+	q.shouldClauses = append(q.shouldClauses, queries...)
+	return q
+}
+
+func (q *boolQuery) MinimumNumberShouldMatch(minimumNumberShouldMatch int) *boolQuery {
+	q.minimumShouldMatch = fmt.Sprintf("%d", minimumNumberShouldMatch)
+	return q
+}
+
+func (q *boolQuery) Source() (any, error) {
+	return elastic.NewBoolQuery().
+		MustNot(q.mustNotClauses...).
+		Filter(q.filterClauses...).
+		Should(q.shouldClauses...).
+		MinimumShouldMatch(q.minimumShouldMatch).
+		Source()
+}


### PR DESCRIPTION
## What changed?
Combining query clauses in Elasticsearch.

1. `AND` queries: combined multiple `AND` clause into a single `BoolQuery`. Example: `a AND b AND c`
  - Before:
    ```json
    {
      "bool": {
        "filter": [
          { ... }, // `a` clause
          {
            "bool": {
              "filter": [
                { ... }, // `b` clause
                { ... }  // `c` clause
              ]
            }
          }
        ]
      }
    }
    ```
  - After:
    ```json
    {
      "bool": {
        "filter": [
          { ... }, // `a` clause
          { ... }, // `b` clause
          { ... }  // `c` clause
        ]
      }
    }
    ```

2. `OR` queries: combined multiple `OR` clause into a single `BoolQuery` (similar to `AND` above)

3. `NOT (a OR b)`: replace `should` with `must_not`.
  - Before:
    ```json
    {
      "bool": {
        "must_not": {
          "bool": {
            "should": [
              { ... }, // `a` clause
              { ... }  // `b` clause
            ]
          }
        }
      }
    }
    ```
  - After:
    ```json
    {
      "bool": {
        "must_not": [
          { ... }, // `a` clause
          { ... }  // `b` clause
        ]
      }
    }
    ```

4. `a AND !b`: combine `filter` and `must_not` clauses into a single `BoolQuery`.
  - Before:
    ```json
    {
      "bool": {
        "filter": [
          { ... }, // `a` clause
          {
            "bool": {
              "must_not": [
                { ... } // `b` clause
              ]
            }
          }
        ]
      }
    }
    ```
  - After:
    ```json
    {
      "bool": {
        "filter": [
          { ... } // `a` clause
        ]
        "must_not": [
          { ... } // `b` clause
        ]
      }
    }
    ```

## Why?
Reduce nesting depth of bool queries.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
