### PR TITLE
Remove redundant calls in worker service Start()

### DIFF
--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -222,9 +222,6 @@ func (s *Service) Start() {
 
 	metrics.RestartCount.With(s.metricsHandler).Record(1)
 
-	s.clusterMetadata.Start()
-	s.namespaceRegistry.Start()
-
 	s.membershipMonitor.Start()
 
 	s.ensureSystemNamespaceExists(context.TODO())
@@ -256,8 +253,6 @@ func (s *Service) Stop() {
 	s.scanner.Stop()
 	s.perNamespaceWorkerManager.Stop()
 	s.workerManager.Stop()
-	s.namespaceRegistry.Stop()
-	s.clusterMetadata.Stop()
 	s.visibilityManager.Close()
 
 	s.logger.Info(


### PR DESCRIPTION
## What changed?
Remove calls to cluster metadata and namespace registry lifecycle from worker's Start()

## Why?
These are managed by fx

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
