### PR TITLE
Avoid softassert failure in ephemeralDataChanged during init

### DIFF
--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -1123,6 +1123,8 @@ func (pm *taskQueuePartitionManagerImpl) ephemeralDataChanged(data *taskqueuespb
 	// for now, only sticky partitions act on ephemeral data, normal partitions ignore it.
 	if pm.partition.Kind() != enumspb.TASK_QUEUE_KIND_STICKY {
 		return
+	} else if !pm.defaultQueueFuture.Ready() {
+		return // not initialized yet
 	}
 
 	// transpose map to more useful form


### PR DESCRIPTION
## What changed?
ephemeralDataChanged might be called during sticky partition initialization. It's a no-op in this case but it was calling pm.defaultQueue which asserts in that situation. Exit early to avoid the assert.

## Why?
avoid misleading assertion failures

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
