### PR TITLE
Upgrade Go to 1.25.5 to fix crypto/x509 CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.temporal.io/server
 
-go 1.25.0
+go 1.25.5
 
 retract (
 	v1.26.1 // Contains retractions only.


### PR DESCRIPTION
## Summary

- Upgrades Go version from 1.25.0 to 1.25.5 to fix security vulnerabilities in `crypto/x509`

## Security Fixes

- **CVE-2025-61727**: Excluded subdomain constraint doesn't preclude wildcard SAN ([golang/go#76442](https://github.com/golang/go/issues/76442))
- **CVE-2025-61729**: Excessive resource consumption in printing error string for host certificate validation ([golang/go#76445](https://github.com/golang/go/issues/76445))

Both CVEs were fixed in Go 1.25.5 (released December 2, 2025).

## Impact

Once merged, new Docker images for both server and admin-tools will be built with Go 1.25.5, which includes the security fixes.

Fixes #8865
Fixes #8866

## Test plan

- [ ] CI passes with Go 1.25.5
- [ ] Docker images build successfully

🤖 Generated with [Claude Code](https://claude.ai/code)