### PR TITLE
fix bug: MySQL CPU utilization spiked to 100%

### DIFF
--- a/common/persistence/visibility/store/sql/query_converter_legacy_mysql.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy_mysql.go
@@ -282,15 +282,9 @@ func (c *mysqlQueryConverter) buildCountStmt(
 	return fmt.Sprintf(
 		`SELECT %s
 		FROM executions_visibility ev
-		LEFT JOIN custom_search_attributes USING (%s, %s)
-		LEFT JOIN chasm_search_attributes USING (%s, %s)
 		WHERE %s
 		%s`,
 		strings.Join(append(groupBy, "COUNT(*)"), ", "),
-		sadefs.GetSqlDbColName(sadefs.NamespaceID),
-		sadefs.GetSqlDbColName(sadefs.RunID),
-		sadefs.GetSqlDbColName(sadefs.NamespaceID),
-		sadefs.GetSqlDbColName(sadefs.RunID),
 		strings.Join(whereClauses, " AND "),
 		groupByClause,
 	), queryArgs

--- a/schema/mysql/v8/visibility/schema.sql
+++ b/schema/mysql/v8/visibility/schema.sql
@@ -69,6 +69,7 @@ CREATE INDEX by_parent_workflow_id      ON executions_visibility (namespace_id, 
 CREATE INDEX by_parent_run_id           ON executions_visibility (namespace_id, parent_run_id,          (COALESCE(close_time, CAST('9999-12-31 23:59:59' AS DATETIME))) DESC, start_time DESC, run_id);
 CREATE INDEX by_root_workflow_id        ON executions_visibility (namespace_id, root_workflow_id,       (COALESCE(close_time, CAST('9999-12-31 23:59:59' AS DATETIME))) DESC, start_time DESC, run_id);
 CREATE INDEX by_root_run_id             ON executions_visibility (namespace_id, root_run_id,            (COALESCE(close_time, CAST('9999-12-31 23:59:59' AS DATETIME))) DESC, start_time DESC, run_id);
+CREATE INDEX by_status_group            ON executions_visibility (namespace_id, TemporalNamespaceDivision, status);
 
 -- Indexes for the predefined search attributes
 CREATE INDEX by_temporal_change_version       ON executions_visibility (namespace_id, (CAST(TemporalChangeVersion AS CHAR(255) ARRAY)), (COALESCE(close_time, CAST('9999-12-31 23:59:59' AS DATETIME))) DESC, start_time DESC, run_id);


### PR DESCRIPTION
## What changed?
Removing unnecessary left joins serves no purpose other than wasting MySQL's CPU.
Adding an index to a FOR GROUP statement
## Why?
Solve sql
```
SELECT STATUS , COUNT ( * ) FROM executions_visibility ev LEFT JOIN custom_search_attributes  USING ( namespace_id, run_id ) WHERE ( namespace_id= "32049b68-7872-4094-8e63-d0dd59896a83" ) AND TemporalNamespaceDivision IS NULL GROUP BY STATUS
```
mysql cpu occupied 100%


Why is the left join meaningless here?

1. COUNT(*) only counts the left table （executions_visibility）.
2. The filter condition 'TemporalNamespaceDivision IS NULL' also applies to the left table.
3. All connection keys are PK（namespace_id, run_id）, and there is no 1:N relationship.



## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
