### PR TITLE
Fix error message

### DIFF
--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -1341,11 +1341,10 @@ func (m *workflowTaskStateMachine) emitWorkflowTaskAttemptStats(
 	namespaceName := m.ms.GetNamespaceEntry().Name().String()
 	metrics.WorkflowTaskAttempt.With(m.ms.metricsHandler).
 		Record(int64(attempt), metrics.NamespaceTag(namespaceName))
-	if attempt >= int32(m.ms.shard.GetConfig().WorkflowTaskCriticalAttempts()) {
+	threshold := int32(m.ms.shard.GetConfig().WorkflowTaskCriticalAttempts())
+	if attempt >= threshold {
 		m.ms.shard.GetThrottledLogger().Warn(
-			fmt.Sprintf(
-				"Workflow task attempt %d exceeds critical threshold (%d)",
-				attempt, m.ms.shard.GetConfig().WorkflowTaskCriticalAttempts()),
+			fmt.Sprintf("Workflow task attempt %d exceeds critical threshold (%d)", attempt, threshold),
 			tag.WorkflowNamespace(namespaceName),
 			tag.WorkflowID(m.ms.GetExecutionInfo().WorkflowId),
 			tag.WorkflowRunID(m.ms.GetExecutionState().RunId),

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -4,6 +4,7 @@ package workflow
 
 import (
 	"cmp"
+	"fmt"
 	"math"
 	"slices"
 	"time"
@@ -1341,7 +1342,10 @@ func (m *workflowTaskStateMachine) emitWorkflowTaskAttemptStats(
 	metrics.WorkflowTaskAttempt.With(m.ms.metricsHandler).
 		Record(int64(attempt), metrics.NamespaceTag(namespaceName))
 	if attempt >= int32(m.ms.shard.GetConfig().WorkflowTaskCriticalAttempts()) {
-		m.ms.shard.GetThrottledLogger().Warn("Critical attempts processing workflow task",
+		m.ms.shard.GetThrottledLogger().Warn(
+			fmt.Sprintf(
+				"Workflow task attempt %d exceeds critical threshold (%d)",
+				attempt, m.ms.shard.GetConfig().WorkflowTaskCriticalAttempts()),
 			tag.WorkflowNamespace(namespaceName),
 			tag.WorkflowID(m.ms.GetExecutionInfo().WorkflowId),
 			tag.WorkflowRunID(m.ms.GetExecutionState().RunId),


### PR DESCRIPTION
## What changed?
Clarify an error message.

## Why?
The error message wasn't written clearly.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests

I have seen the new message in local testing:
```
{
  "level": "warn",
  "ts": "2026-01-19T14:23:09.763-0500",
  "msg": "Workflow task attempt 20 exceeds critical threshold (10)",
  "shard-id": 1,
  "address": "127.0.0.1:7234",
  "wf-namespace": "default",
  "wf-id": "test-stats-minimal:019bd761-bf89-7a12-b00b-b5f6386e7458-config-driven-minimalstatstest-1",
  "wf-run-id": "55242767-89b6-4e33-97ab-93eff948149f",
  "attempt": 20,
  "logging-call-at": "/Users/dan/src/temporal-all/repos/temporal/service/history/workflow/workflow_task_state_machine.go:1345"
}
```


## Potential risks
Could panic in WFT processing if the code has a bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the warn log emitted when workflow task attempts reach the critical threshold.
> 
> - In `workflow_task_state_machine.go`, updates `emitWorkflowTaskAttemptStats` to compute `threshold` once and log a formatted message: `Workflow task attempt <attempt> exceeds critical threshold (<threshold>)`
> - Adds `fmt` import to support the new formatted log message
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 401dbd3888b2baa5dd74e85b55e325daeee5798e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->