### PR TITLE
Turn off gzip for ElasticSearch in functional tests

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7.go
@@ -46,7 +46,7 @@ func newClient(cfg *Config, httpClient *http.Client, logger log.Logger) (*client
 		elastic.SetRetrier(elastic.NewBackoffRetrier(elastic.NewExponentialBackoff(128*time.Millisecond, 513*time.Millisecond))),
 		// Critical to ensure decode of int64 won't lose precision.
 		elastic.SetDecoder(&elastic.NumberDecoder{}),
-		elastic.SetGzip(true),
+		elastic.SetGzip(!cfg.disableGzip),
 	}
 
 	options = append(options, getLoggerOptions(cfg.LogLevel, logger)...)

--- a/common/persistence/visibility/store/elasticsearch/client/config.go
+++ b/common/persistence/visibility/store/elasticsearch/client/config.go
@@ -31,8 +31,10 @@ type (
 		EnableSniff                  bool                      `yaml:"enableSniff"`
 		EnableHealthcheck            bool                      `yaml:"enableHealthcheck"`
 		TLS                          *auth.TLS                 `yaml:"tls"`
-		// httpClient is the awsHttpClient to be used for creating esClient
+		// httpClient is the awsHttpClient to be used for creating esClient.
 		httpClient *http.Client
+		// disableGzip disables gzip compression for Elasticsearch requests.
+		disableGzip bool
 	}
 
 	// ESAWSRequestSigningConfig represents configuration for signing ES requests to AWS
@@ -87,6 +89,12 @@ func (cfg *Config) GetHttpClient() *http.Client {
 		return nil
 	}
 	return cfg.httpClient
+}
+
+// SetDisableGzip is for testing purposes only.
+// It lowers memory and CPU usage significantly.
+func (cfg *Config) SetDisableGzip() {
+	cfg.disableGzip = true
 }
 
 func (cfg *Config) Validate() error {

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -259,6 +259,7 @@ func newClusterWithPersistenceTestBaseFactory(t *testing.T, clusterConfig *TestC
 			},
 			Version: environment.GetESVersion(),
 		}
+		clusterConfig.ESConfig.SetDisableGzip() // lowers memory and CPU usage significantly
 
 		err := setupIndex(clusterConfig.ESConfig, logger)
 		if err != nil {


### PR DESCRIPTION
## What changed?

Turn off gzip for ElasticSearch in functional tests.

## Why?

Looking at a Go heap from a functional test that uses the ElasticSearch client ([link](https://github.com/temporalio/temporal/actions/runs/21151275319/job/60827820596#step:10:147)), we can see that significant allocations (and likely CPU usage) are spent on compressing/decompressing.

```
Build ID: 5e6f217042f7638422b82855fafeec7bf59967d7
Type: alloc_space
Time: 2026-01-19 21:19:39 UTC
Showing nodes accounting for 28568.36MB, 69.16% of 41306.22MB total
Dropped 5182 nodes (cum <= 206.53MB)
      flat  flat%   sum%        cum   cum%
 3360.02MB  8.13%  8.13%  4099.66MB  9.93%  compress/flate.NewWriter (inline)
      ...
  712.32MB  1.72% 31.15%   712.32MB  1.72%  compress/flate.(*compressor).initDeflate (inline)
```

It turns out that this is only happening on setups with ElasticSearch. And since the tests run on a single machine, gzip has very little benefit. Turning it off reduces memory and CPU usage significantly.

The entries are completely removed from this PR's Go heap dump ([example](https://github.com/temporalio/temporal/actions/runs/21153617516/job/60834464320?pr=9078#step:10:73)).

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

`gzip` is enabled by default in test envs, staging and production; therefore still being exercised sufficiently.