### PR TITLE
Capture memory monitor report before OOM crash

### DIFF
--- a/develop/github/memory_monitor.sh
+++ b/develop/github/memory_monitor.sh
@@ -78,7 +78,7 @@ print_pprof_analysis() {
   fi
 }
 
-write_snapshot() {
+snapshot() {
   local memtotal_kb memavail_kb memused_kb memused_mb pct
   memtotal_kb="$(awk '/MemTotal/ {print $2}' /proc/meminfo)"
   memavail_kb="$(awk '/MemAvailable/ {print $2}' /proc/meminfo)"
@@ -114,6 +114,7 @@ write_snapshot() {
     HEAP_PRINTED=true
   fi
 
+  # Write snapshot to disk.
   {
     echo "Memory snapshot at $(date '+%Y-%m-%d %H:%M:%S')"
     echo ""
@@ -129,8 +130,8 @@ write_snapshot() {
   } > "$SNAPSHOT_FILE"
 }
 
-# Take snapshots every 30s until killed
+# Take snapshots every 30s until killed.
 while true; do
-  write_snapshot
+  snapshot
   sleep 30
 done


### PR DESCRIPTION
## What changed?

Follow-up to https://github.com/temporalio/temporal/pull/9027

1. Print memory stats to both file and stdout (new!)
2. Print Go heap report once a memory threshold is reached (ie close to OOM kill)
3. Add `alloc_objects` to Go heap report


See [example](https://github.com/temporalio/temporal/actions/runs/21153910359/job/60835302610?pr=9079#step:9:89):
<img width="1328" height="1197" alt="Screenshot 2026-01-19 at 4 23 28 PM" src="https://github.com/user-attachments/assets/fe910197-d813-4f63-8907-797c5f11bc90" />
(note that Go test output is buffered so they all appear mostly sequentially)

## Why?

Gain ability to capture memory usage and Go heap report **before an OOM kill**.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
