### PR TITLE
Pass enabled in RateLimitedSchedulerOptions for outbound task queue

### DIFF
--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -198,24 +198,21 @@ func (f *outboundQueueFactory) CreateQueue(
 
 	currentClusterName := f.ClusterMetadata.GetCurrentClusterName()
 
-	scheduler := f.hostScheduler
-	if f.Config.TaskSchedulerEnableRateLimiter() {
-		scheduler = queues.NewRateLimitedScheduler(
-			f.hostScheduler,
-			queues.RateLimitedSchedulerOptions{
-				Enabled:          f.Config.TaskSchedulerEnableRateLimiter,
-				EnableShadowMode: f.Config.TaskSchedulerEnableRateLimiterShadowMode,
-				StartupDelay:     f.Config.TaskSchedulerRateLimiterStartupDelay,
-			},
-			currentClusterName,
-			f.NamespaceRegistry,
-			f.SchedulerRateLimiter,
-			f.TimeSource,
-			f.ChasmRegistry,
-			logger,
-			metricsHandler,
-		)
-	}
+	scheduler := queues.NewRateLimitedScheduler(
+		f.hostScheduler,
+		queues.RateLimitedSchedulerOptions{
+			Enabled:          f.Config.TaskSchedulerEnableRateLimiter,
+			EnableShadowMode: f.Config.TaskSchedulerEnableRateLimiterShadowMode,
+			StartupDelay:     f.Config.TaskSchedulerRateLimiterStartupDelay,
+		},
+		currentClusterName,
+		f.NamespaceRegistry,
+		f.SchedulerRateLimiter,
+		f.TimeSource,
+		f.ChasmRegistry,
+		logger,
+		metricsHandler,
+	)
 
 	rescheduler := queues.NewRescheduler(
 		scheduler,


### PR DESCRIPTION
## What changed?
Pass Enabled field in RateLimitedSchedulerOptions from outbound queue factory.

## Why?
RateLimitedScheduler expects this config to be present. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

