### PR TITLE
Add diagnostic metrics for worker registry

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1160,6 +1160,18 @@ var (
 		"worker_registry_capacity_utilization",
 		WithDescription("Tracks the ratio of total entries to maxItems."),
 	)
+	WorkerRegistryWorkersAdded = NewCounterDef(
+		"worker_registry_workers_added",
+		WithDescription("Count of new workers registered in the worker registry."),
+	)
+	WorkerRegistryWorkersRemoved = NewCounterDef(
+		"worker_registry_workers_removed",
+		WithDescription("Count of workers removed from the worker registry."),
+	)
+	WorkerRegistryActivitySlotsUsed = NewDimensionlessHistogramDef(
+		"worker_registry_activity_slots_used",
+		WithDescription("Number of activity slots in use per worker."),
+	)
 	// ----------------------------------------------------------------------------------------------------------------
 	// Matching service: Metrics to understand plugin adoption.
 	WorkerPluginNameMetric = NewGaugeDef(


### PR DESCRIPTION
## What changed?
- worker_registry_workers_added: count of new workers registered
- worker_registry_workers_removed: count of workers removed
- worker_registry_activity_slots_used: histogram of activity slots in use per worker

## Why?
To better understand the scaling aspects of worker heartbeat

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
No cardinality concerns as these are container level metrics. Not per namespace.