### PR TITLE
Config to turn off gzip for ElasticSearch

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7.go
@@ -46,7 +46,7 @@ func newClient(cfg *Config, httpClient *http.Client, logger log.Logger) (*client
 		elastic.SetRetrier(elastic.NewBackoffRetrier(elastic.NewExponentialBackoff(128*time.Millisecond, 513*time.Millisecond))),
 		// Critical to ensure decode of int64 won't lose precision.
 		elastic.SetDecoder(&elastic.NumberDecoder{}),
-		elastic.SetGzip(!cfg.disableGzip),
+		elastic.SetGzip(!cfg.DisableGzip),
 	}
 
 	options = append(options, getLoggerOptions(cfg.LogLevel, logger)...)

--- a/common/persistence/visibility/store/elasticsearch/client/config.go
+++ b/common/persistence/visibility/store/elasticsearch/client/config.go
@@ -31,10 +31,11 @@ type (
 		EnableSniff                  bool                      `yaml:"enableSniff"`
 		EnableHealthcheck            bool                      `yaml:"enableHealthcheck"`
 		TLS                          *auth.TLS                 `yaml:"tls"`
+		// DisableGzip disables gzip compression for Elasticsearch requests.
+		// Useful in test/development environments where ES runs locally.
+		DisableGzip bool `yaml:"disableGzip"`
 		// httpClient is the awsHttpClient to be used for creating esClient.
 		httpClient *http.Client
-		// disableGzip disables gzip compression for Elasticsearch requests.
-		disableGzip bool
 	}
 
 	// ESAWSRequestSigningConfig represents configuration for signing ES requests to AWS
@@ -89,12 +90,6 @@ func (cfg *Config) GetHttpClient() *http.Client {
 		return nil
 	}
 	return cfg.httpClient
-}
-
-// SetDisableGzip is for testing purposes only.
-// It lowers memory and CPU usage significantly.
-func (cfg *Config) SetDisableGzip() {
-	cfg.disableGzip = true
 }
 
 func (cfg *Config) Validate() error {

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -257,9 +257,9 @@ func newClusterWithPersistenceTestBaseFactory(t *testing.T, clusterConfig *TestC
 				Host:   fmt.Sprintf("%s:%d", environment.GetESAddress(), environment.GetESPort()),
 				Scheme: "http",
 			},
-			Version: environment.GetESVersion(),
+			Version:     environment.GetESVersion(),
+			DisableGzip: true, // lowers memory and CPU usage significantly in tests
 		}
-		clusterConfig.ESConfig.SetDisableGzip() // lowers memory and CPU usage significantly
 
 		err := setupIndex(clusterConfig.ESConfig, logger)
 		if err != nil {


### PR DESCRIPTION
## What changed?

Add ElasticSearch config option to turn of gzip compression.

## Why?

Allow users to turn off in situations where it's not needed (ie same machine cluster) or not useful/helpful.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
