### PR TITLE
Standalone activity error code fixes

### DIFF
--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -21,8 +21,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const StandaloneActivityDisabledError = "Standalone activity is disabled"
-
 type FrontendHandler interface {
 	StartActivityExecution(ctx context.Context, req *workflowservice.StartActivityExecutionRequest) (*workflowservice.StartActivityExecutionResponse, error)
 	DescribeActivityExecution(ctx context.Context, req *workflowservice.DescribeActivityExecutionRequest) (*workflowservice.DescribeActivityExecutionResponse, error)
@@ -34,6 +32,8 @@ type FrontendHandler interface {
 	TerminateActivityExecution(context.Context, *workflowservice.TerminateActivityExecutionRequest) (*workflowservice.TerminateActivityExecutionResponse, error)
 	IsStandaloneActivityEnabled(namespaceName string) bool
 }
+
+var ErrStandaloneActivityDisabled = serviceerror.NewUnimplemented("Standalone activity is disabled")
 
 type frontendHandler struct {
 	FrontendHandler
@@ -83,7 +83,7 @@ func (h *frontendHandler) IsStandaloneActivityEnabled(namespaceName string) bool
 // 3. Sends the request to the history activity service.
 func (h *frontendHandler) StartActivityExecution(ctx context.Context, req *workflowservice.StartActivityExecutionRequest) (*workflowservice.StartActivityExecutionResponse, error) {
 	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
+		return nil, ErrStandaloneActivityDisabled
 	}
 
 	namespaceID, err := h.namespaceRegistry.GetNamespaceID(namespace.Name(req.GetNamespace()))
@@ -111,7 +111,7 @@ func (h *frontendHandler) DescribeActivityExecution(
 	req *workflowservice.DescribeActivityExecutionRequest,
 ) (*workflowservice.DescribeActivityExecutionResponse, error) {
 	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
+		return nil, ErrStandaloneActivityDisabled
 	}
 
 	err := ValidateDescribeActivityExecutionRequest(
@@ -140,7 +140,7 @@ func (h *frontendHandler) PollActivityExecution(
 	req *workflowservice.PollActivityExecutionRequest,
 ) (*workflowservice.PollActivityExecutionResponse, error) {
 	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
+		return nil, ErrStandaloneActivityDisabled
 	}
 
 	err := ValidatePollActivityExecutionRequest(
@@ -167,7 +167,7 @@ func (h *frontendHandler) ListActivityExecutions(
 	req *workflowservice.ListActivityExecutionsRequest,
 ) (*workflowservice.ListActivityExecutionsResponse, error) {
 	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
+		return nil, ErrStandaloneActivityDisabled
 	}
 
 	pageSize := req.GetPageSize()
@@ -230,7 +230,7 @@ func (h *frontendHandler) CountActivityExecutions(
 	req *workflowservice.CountActivityExecutionsRequest,
 ) (*workflowservice.CountActivityExecutionsResponse, error) {
 	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
+		return nil, ErrStandaloneActivityDisabled
 	}
 
 	namespaceID, err := h.namespaceRegistry.GetNamespaceID(namespace.Name(req.GetNamespace()))
@@ -267,7 +267,7 @@ func (h *frontendHandler) TerminateActivityExecution(
 	req *workflowservice.TerminateActivityExecutionRequest,
 ) (*workflowservice.TerminateActivityExecutionResponse, error) {
 	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
+		return nil, ErrStandaloneActivityDisabled
 	}
 
 	namespaceName := req.GetNamespace()
@@ -315,7 +315,7 @@ func (h *frontendHandler) RequestCancelActivityExecution(
 	req *workflowservice.RequestCancelActivityExecutionRequest,
 ) (*workflowservice.RequestCancelActivityExecutionResponse, error) {
 	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
+		return nil, ErrStandaloneActivityDisabled
 	}
 
 	namespaceID, err := h.namespaceRegistry.GetNamespaceID(namespace.Name(req.GetNamespace()))

--- a/chasm/statemachine.go
+++ b/chasm/statemachine.go
@@ -1,15 +1,10 @@
 package chasm
 
 import (
-	"errors"
-	"fmt"
 	"slices"
 
 	"go.temporal.io/api/serviceerror"
 )
-
-// ErrInvalidTransition is returned from [Transition.Apply] on an invalid state transition.
-var ErrInvalidTransition = errors.New("invalid transition")
 
 // A StateMachine is anything that can get and set a comparable state S and re-generate tasks based on current state.
 // It is meant to be used with [Transition] objects to safely transition their state on a given event.
@@ -48,8 +43,7 @@ func (t Transition[S, SM, E]) Possible(sm SM) bool {
 func (t Transition[S, SM, E]) Apply(sm SM, ctx MutableContext, event E) error {
 	prevState := sm.StateMachineState()
 	if !t.Possible(sm) {
-		err := fmt.Errorf("%w from %v: %v", ErrInvalidTransition, prevState, event)
-		return serviceerror.NewFailedPrecondition(err.Error())
+		return serviceerror.NewFailedPreconditionf("invalid transition from %v: %v", prevState, event)
 	}
 
 	sm.SetStateMachineState(t.Destination)

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -1226,7 +1226,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(ctx context.Context, requ
 	namespaceName := namespaceEntry.Name().String()
 
 	if len(taskToken.GetComponentRef()) > 0 && !wh.IsStandaloneActivityEnabled(namespaceName) {
-		return nil, serviceerror.NewUnavailable(activity.StandaloneActivityDisabledError)
+		return nil, activity.ErrStandaloneActivityDisabled
 	}
 
 	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.Name().String())
@@ -1419,7 +1419,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 	namespaceName := namespaceEntry.Name().String()
 
 	if len(taskToken.GetComponentRef()) > 0 && !wh.IsStandaloneActivityEnabled(namespaceName) {
-		return nil, serviceerror.NewUnavailable(activity.StandaloneActivityDisabledError)
+		return nil, activity.ErrStandaloneActivityDisabled
 	}
 
 	if len(request.GetIdentity()) > wh.config.MaxIDLengthLimit() {
@@ -1611,7 +1611,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 	namespaceName := namespaceEntry.Name().String()
 
 	if len(taskToken.GetComponentRef()) > 0 && !wh.IsStandaloneActivityEnabled(namespaceName) {
-		return nil, serviceerror.NewUnavailable(activity.StandaloneActivityDisabledError)
+		return nil, activity.ErrStandaloneActivityDisabled
 	}
 
 	if request.GetFailure() != nil && request.GetFailure().GetApplicationFailureInfo() == nil {
@@ -1828,7 +1828,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(ctx context.Context, requ
 	namespaceName := namespaceEntry.Name().String()
 
 	if len(taskToken.GetComponentRef()) > 0 && !wh.IsStandaloneActivityEnabled(namespaceName) {
-		return nil, serviceerror.NewUnavailable(activity.StandaloneActivityDisabledError)
+		return nil, activity.ErrStandaloneActivityDisabled
 	}
 
 	if len(request.GetIdentity()) > wh.config.MaxIDLengthLimit() {


### PR DESCRIPTION
## What changed?

- Use Unimplemented for when standalone activities are disabled.
- Get rid of ErrInvalidTransition constant.

## Why?

Semantics.