### PR TITLE
Fix testrunner timeout reporter

### DIFF
--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -56,7 +56,7 @@ func (a *attempt) run(ctx context.Context, args []string) (string, error) {
 	cmd := exec.CommandContext(ctx, a.runner.gotestsumPath, args...)
 	var output strings.Builder
 	cmd.Stdout = io.MultiWriter(os.Stdout, &output)
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = io.MultiWriter(os.Stderr, &output)
 	cmd.Stdin = os.Stdin
 	err := cmd.Run()
 	return output.String(), err


### PR DESCRIPTION
## What changed?

Make testrunner also capture stderr.

## Why?

To capture test timeout logs and report them correctly.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

