### PR TITLE
Fix migration workflow break change for cloud

### DIFF
--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -489,18 +489,16 @@ func (a *activities) ListWorkflows(ctx context.Context, request *workflowservice
 	executions := make([]*ExecutionInfo, 0, len(resp.Executions))
 	for _, e := range resp.Executions {
 		executionInfo := &ExecutionInfo{
-			executionInfoNewJSON: executionInfoNewJSON{
-				BusinessID: e.Execution.GetWorkflowId(),
-				RunID:      e.Execution.GetRunId(),
-				// Ideally we should use chasm.WorkflowArchetypeID by default,
-				// but for backward compatibility reason we need this field to be 0
-				// to avoid unmarshaling errors since the previous type returned in
-				// ListWorkflowExecutions.Executions is commonpb.WorkflowExecution
-				// which does not have ArchetypeId field.
-				//
-				// TODO: switch to chasm.WorkflowArchetypeID in release 1.31.0
-				ArchetypeID: chasm.UnspecifiedArchetypeID,
-			},
+			BusinessID: e.Execution.GetWorkflowId(),
+			RunID:      e.Execution.GetRunId(),
+			// Ideally we should use chasm.WorkflowArchetypeID by default,
+			// but for backward compatibility reason we need this field to be 0
+			// to avoid unmarshaling errors since the previous type returned in
+			// ListWorkflowExecutions.Executions is commonpb.WorkflowExecution
+			// which does not have ArchetypeId field.
+			//
+			// TODO: switch to chasm.WorkflowArchetypeID in release 1.31.0
+			ArchetypeID: chasm.UnspecifiedArchetypeID,
 		}
 
 		archetypeID, err := workercommon.ArchetypeIDFromExecutionInfo(e)

--- a/service/worker/migration/activities_test.go
+++ b/service/worker/migration/activities_test.go
@@ -68,19 +68,15 @@ const (
 
 var (
 	execution1 = &ExecutionInfo{
-		executionInfoNewJSON: executionInfoNewJSON{
-			BusinessID:  "workflow1",
-			RunID:       "run1",
-			ArchetypeID: chasm.WorkflowArchetypeID,
-		},
+		BusinessID:  "workflow1",
+		RunID:       "run1",
+		ArchetypeID: chasm.WorkflowArchetypeID,
 	}
 
 	execution2 = &ExecutionInfo{
-		executionInfoNewJSON: executionInfoNewJSON{
-			BusinessID:  "workflow2",
-			RunID:       "run2",
-			ArchetypeID: chasm.UnspecifiedArchetypeID,
-		},
+		BusinessID:  "workflow2",
+		RunID:       "run2",
+		ArchetypeID: chasm.UnspecifiedArchetypeID,
 	}
 
 	completeState = &historyservice.DescribeMutableStateResponse{

--- a/service/worker/migration/execution_info.go
+++ b/service/worker/migration/execution_info.go
@@ -5,10 +5,6 @@ import (
 )
 
 type ExecutionInfo struct {
-	executionInfoNewJSON
-}
-
-type executionInfoNewJSON struct {
 	BusinessID  string `json:"business_id,omitempty"`
 	RunID       string `json:"run_id,omitempty"`
 	ArchetypeID uint32 `json:"archetype_id,omitempty"`
@@ -21,17 +17,8 @@ type executionInfoLegacyJSON struct {
 	ArchetypeID uint32 `json:"archetype_id,omitempty"`
 }
 
-func (e *ExecutionInfo) MarshalJSON() ([]byte, error) {
-	return json.Marshal(executionInfoLegacyJSON{
-		WorkflowID:  e.BusinessID,
-		RunID:       e.RunID,
-		ArchetypeID: e.ArchetypeID,
-	})
-}
-
 func (e *ExecutionInfo) UnmarshalJSON(data []byte) error {
-	// For forward compatibility, support both workflow_id and business_id here.
-	// Then in v1.31, we can always encode using "business_id" and also support downgrade.
+	// For backward compatibility, support both workflow_id and business_id here.
 	var legacy executionInfoLegacyJSON
 	if err := json.Unmarshal(data, &legacy); err != nil {
 		return err
@@ -42,10 +29,8 @@ func (e *ExecutionInfo) UnmarshalJSON(data []byte) error {
 		businessID = legacy.BusinessID
 	}
 
-	e.executionInfoNewJSON = executionInfoNewJSON{
-		BusinessID:  businessID,
-		RunID:       legacy.RunID,
-		ArchetypeID: legacy.ArchetypeID,
-	}
+	e.BusinessID = businessID
+	e.RunID = legacy.RunID
+	e.ArchetypeID = legacy.ArchetypeID
 	return nil
 }

--- a/service/worker/migration/execution_info_test.go
+++ b/service/worker/migration/execution_info_test.go
@@ -5,33 +5,33 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/converter"
+	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/chasm"
 )
 
-func TestExecutionInfo_Marshal(t *testing.T) {
+func TestExecutionInfo_Marshal_OSS(t *testing.T) {
 	t.Parallel()
 
-	// OSS v1.29 uses *commonpb.WorkflowExecution,
-	// so validate the encoded data can still be decoded to the old definition.
-	// i.e. we can downgrade to OSS v1.29.
+	// This test validates the marshaling logic is compatible with the
+	// unmarshaling logic in OSS v1.30, i.e. we can downgrade to OSS v1.30.
+	//
+	// Since the unmarshaling logic is the same as the one in OSS v1.30.
+	// Just do a basic marshal/unmarshal test here.
 	executionInfo := &ExecutionInfo{
-		executionInfoNewJSON: executionInfoNewJSON{
-			BusinessID:  "business-id-1",
-			RunID:       "run-id-1",
-			ArchetypeID: chasm.UnspecifiedArchetypeID,
-		},
+		BusinessID:  "business-id-1",
+		RunID:       "run-id-1",
+		ArchetypeID: chasm.UnspecifiedArchetypeID,
 	}
 
 	encoded, err := json.Marshal(executionInfo)
 	require.NoError(t, err)
 
-	var workflowExecution *commonpb.WorkflowExecution
-	err = json.Unmarshal(encoded, &workflowExecution)
+	var executionInfoUnmarshaled *ExecutionInfo
+	err = json.Unmarshal(encoded, &executionInfoUnmarshaled)
 	require.NoError(t, err)
-	require.Equal(t, executionInfo.BusinessID, workflowExecution.WorkflowId)
-	require.Equal(t, executionInfo.RunID, workflowExecution.RunId)
+	require.Equal(t, executionInfo.BusinessID, executionInfoUnmarshaled.BusinessID)
+	require.Equal(t, executionInfo.RunID, executionInfoUnmarshaled.RunID)
 
 	// ExecutionInfo is not directly used as activity input/output,
 	// instead, it's used as a field in another struct.
@@ -40,11 +40,62 @@ func TestExecutionInfo_Marshal(t *testing.T) {
 		Executions: []*ExecutionInfo{
 			executionInfo,
 			{
-				executionInfoNewJSON: executionInfoNewJSON{
-					BusinessID:  "business-id-2",
-					RunID:       "run-id-2",
-					ArchetypeID: chasm.UnspecifiedArchetypeID,
-				},
+				BusinessID:  "business-id-2",
+				RunID:       "run-id-2",
+				ArchetypeID: chasm.UnspecifiedArchetypeID,
+			},
+		},
+		NextPageToken: []byte("next-page-token"),
+	}
+	dataConverter := converter.GetDefaultDataConverter()
+	payload, err := dataConverter.ToPayload(listResponse)
+	require.NoError(t, err)
+
+	listResponseUnmarshaled := struct {
+		Executions    []*ExecutionInfo
+		NextPageToken []byte
+	}{}
+	err = dataConverter.FromPayload(payload, &listResponseUnmarshaled)
+	require.NoError(t, err)
+	require.Equal(t, listResponse.NextPageToken, listResponseUnmarshaled.NextPageToken)
+	for idx := 0; idx != len(listResponse.Executions); idx++ {
+		require.Equal(t, listResponse.Executions[idx].BusinessID, listResponseUnmarshaled.Executions[idx].BusinessID)
+		require.Equal(t, listResponse.Executions[idx].RunID, listResponseUnmarshaled.Executions[idx].RunID)
+	}
+}
+
+func TestExecutionInfo_Marshal_Cloud(t *testing.T) {
+	t.Parallel()
+
+	// This test validates the marshaling logic is compatible with the
+	// unmarshaling logic in cloud/v1.30.0-149, i.e. we can downgrade to cloud/v1.30.0-149.
+
+	executionInfo := &ExecutionInfo{
+		BusinessID:  "business-id-1",
+		RunID:       "run-id-1",
+		ArchetypeID: chasm.WorkflowArchetypeID,
+	}
+
+	encoded, err := json.Marshal(executionInfo)
+	require.NoError(t, err)
+
+	// cloud/v1.30.0-149 uses *replicationspb.MigrationExecutionInfo for unmarshaling.
+	var migrationExecutionInfo *replicationspb.MigrationExecutionInfo
+	err = json.Unmarshal(encoded, &migrationExecutionInfo)
+	require.NoError(t, err)
+	require.Equal(t, executionInfo.BusinessID, migrationExecutionInfo.BusinessId)
+	require.Equal(t, executionInfo.RunID, migrationExecutionInfo.RunId)
+
+	// ExecutionInfo is not directly used as activity input/output,
+	// instead, it's used as a field in another struct.
+	// Test that case and do encoding/decoding with an actual SDK data coverter.
+	listResponse := &listWorkflowsResponse{
+		Executions: []*ExecutionInfo{
+			executionInfo,
+			{
+				BusinessID:  "business-id-2",
+				RunID:       "run-id-2",
+				ArchetypeID: chasm.WorkflowArchetypeID,
 			},
 		},
 		NextPageToken: []byte("next-page-token"),
@@ -54,50 +105,51 @@ func TestExecutionInfo_Marshal(t *testing.T) {
 	require.NoError(t, err)
 
 	listResponseLegacy := struct {
-		Executions    []commonpb.WorkflowExecution
+		Executions    []*replicationspb.MigrationExecutionInfo
 		NextPageToken []byte
 	}{}
 	err = dataConverter.FromPayload(payload, &listResponseLegacy)
 	require.NoError(t, err)
 	require.Equal(t, listResponse.NextPageToken, listResponseLegacy.NextPageToken)
 	for idx := 0; idx != len(listResponse.Executions); idx++ {
-		require.Equal(t, listResponse.Executions[idx].BusinessID, listResponseLegacy.Executions[idx].WorkflowId)
+		require.Equal(t, listResponse.Executions[idx].BusinessID, listResponseLegacy.Executions[idx].BusinessId)
 		require.Equal(t, listResponse.Executions[idx].RunID, listResponseLegacy.Executions[idx].RunId)
 	}
 }
 
-func TestExecutionInfo_Unmarshal(t *testing.T) {
+func TestExecutionInfo_Unmarshal_OSS(t *testing.T) {
 	t.Parallel()
 
-	// OSS v1.29 uses *commonpb.WorkflowExecution,
-	// so validate the encoded data can be decoded to the new definition.
-	// i.e. we can upgrade from OSS v1.29.
-	workflowExecution := &commonpb.WorkflowExecution{
-		WorkflowId: "business-id-1",
-		RunId:      "run-id-1",
+	// This test validates the unmarshaling logic is compatible with the
+	// marshaling logic in OSS v1.30, i.e. we can upgrade from OSS v1.30.
+
+	// OSS v1.30 uses executionInfoLegacyJSON for marshaling.
+	executionInfoLegacy := &executionInfoLegacyJSON{
+		WorkflowID: "business-id-1",
+		RunID:      "run-id-1",
 	}
 
-	encoded, err := json.Marshal(workflowExecution)
+	encoded, err := json.Marshal(executionInfoLegacy)
 	require.NoError(t, err)
 
 	var executionInfo *ExecutionInfo
 	err = json.Unmarshal(encoded, &executionInfo)
 	require.NoError(t, err)
-	require.Equal(t, workflowExecution.WorkflowId, executionInfo.BusinessID)
-	require.Equal(t, workflowExecution.RunId, executionInfo.RunID)
+	require.Equal(t, executionInfoLegacy.WorkflowID, executionInfo.BusinessID)
+	require.Equal(t, executionInfoLegacy.RunID, executionInfo.RunID)
 
 	// ExecutionInfo is not directly used as activity input/output,
 	// instead, it's used as a field in another struct.
 	// Test that case and do encoding/decoding with an actual SDK data coverter.
 	listResponseLegacy := struct {
-		Executions    []*commonpb.WorkflowExecution
+		Executions    []*executionInfoLegacyJSON
 		NextPageToken []byte
 	}{
-		Executions: []*commonpb.WorkflowExecution{
-			workflowExecution,
+		Executions: []*executionInfoLegacyJSON{
+			executionInfoLegacy,
 			{
-				WorkflowId: "business-id-2",
-				RunId:      "run-id-2",
+				WorkflowID: "business-id-2",
+				RunID:      "run-id-2",
 			},
 		},
 		NextPageToken: []byte("next-page-token"),
@@ -112,7 +164,60 @@ func TestExecutionInfo_Unmarshal(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, listResponseLegacy.NextPageToken, listResponse.NextPageToken)
 	for idx := 0; idx != len(listResponse.Executions); idx++ {
-		require.Equal(t, listResponseLegacy.Executions[idx].WorkflowId, listResponse.Executions[idx].BusinessID)
+		require.Equal(t, listResponseLegacy.Executions[idx].WorkflowID, listResponse.Executions[idx].BusinessID)
+		require.Equal(t, listResponseLegacy.Executions[idx].RunID, listResponse.Executions[idx].RunID)
+	}
+}
+
+func TestExecutionInfo_Unmarshal_Cloud(t *testing.T) {
+	t.Parallel()
+
+	// This test validates the unmarshaling logic is compatible with the
+	// marshaling logic in cloud/v1.30.0-149, i.e. we can upgrade from cloud/v1.30.0-149.
+
+	// cloud/v1.30.0-149 uses *replicationspb.MigrationExecutionInfo for marshaling.
+	migrationExecutionInfo := &replicationspb.MigrationExecutionInfo{
+		BusinessId:  "business-id-1",
+		RunId:       "run-id-1",
+		ArchetypeId: chasm.WorkflowArchetypeID,
+	}
+	encoded, err := json.Marshal(migrationExecutionInfo)
+	require.NoError(t, err)
+
+	var executionInfo *ExecutionInfo
+	err = json.Unmarshal(encoded, &executionInfo)
+	require.NoError(t, err)
+	require.Equal(t, migrationExecutionInfo.BusinessId, executionInfo.BusinessID)
+	require.Equal(t, migrationExecutionInfo.RunId, executionInfo.RunID)
+
+	// ExecutionInfo is not directly used as activity input/output,
+	// instead, it's used as a field in another struct.
+	// Test that case and do encoding/decoding with an actual SDK data coverter.
+	listResponseLegacy := struct {
+		Executions    []*replicationspb.MigrationExecutionInfo
+		NextPageToken []byte
+	}{
+		Executions: []*replicationspb.MigrationExecutionInfo{
+			migrationExecutionInfo,
+			{
+				BusinessId:  "business-id-2",
+				RunId:       "run-id-2",
+				ArchetypeId: chasm.WorkflowArchetypeID,
+			},
+		},
+		NextPageToken: []byte("next-page-token"),
+	}
+
+	dataConverter := converter.GetDefaultDataConverter()
+	payload, err := dataConverter.ToPayload(listResponseLegacy)
+	require.NoError(t, err)
+
+	var listResponse listWorkflowsResponse
+	err = dataConverter.FromPayload(payload, &listResponse)
+	require.NoError(t, err)
+	require.Equal(t, listResponseLegacy.NextPageToken, listResponse.NextPageToken)
+	for idx := 0; idx != len(listResponse.Executions); idx++ {
+		require.Equal(t, listResponseLegacy.Executions[idx].BusinessId, listResponse.Executions[idx].BusinessID)
 		require.Equal(t, listResponseLegacy.Executions[idx].RunId, listResponse.Executions[idx].RunID)
 	}
 }

--- a/service/worker/migration/force_replication_workflow_test.go
+++ b/service/worker/migration/force_replication_workflow_test.go
@@ -82,7 +82,7 @@ func (s *ForceReplicationWorkflowTestSuite) TestForceReplicationWorkflow() {
 		currentPageCount++
 		if currentPageCount < totalPageCount {
 			return &listWorkflowsResponse{
-				Executions:    []*ExecutionInfo{{executionInfoNewJSON{BusinessID: "wf-1"}}},
+				Executions:    []*ExecutionInfo{{BusinessID: "wf-1"}},
 				NextPageToken: []byte("fake-page-token"),
 				LastStartTime: startTime,
 				LastCloseTime: closeTime,
@@ -559,9 +559,9 @@ func (s *ForceReplicationWorkflowTestSuite) TestVerifyPerIterationExecutions() {
 	env.OnActivity(a.GetMetadata, mock.Anything, metadataRequest{Namespace: "test-ns"}).Return(&metadataResponse{ShardCount: 1, NamespaceID: namespaceID}, nil)
 
 	pages := [][]*ExecutionInfo{
-		{{executionInfoNewJSON{BusinessID: "wf-1a"}}},
-		{{executionInfoNewJSON{BusinessID: "wf-2a"}}, {executionInfoNewJSON{BusinessID: "wf-2b"}}},
-		{{executionInfoNewJSON{BusinessID: "wf-3a"}}},
+		{{BusinessID: "wf-1a"}},
+		{{BusinessID: "wf-2a"}, {BusinessID: "wf-2b"}},
+		{{BusinessID: "wf-3a"}},
 	}
 
 	totalPageCount := len(pages)


### PR DESCRIPTION
## What changed?
- Always marshal migration execution info using businessID to be compatible with the logic in cloud.
- Unmarshaling part still accepts both workflowID and businessID so that people can upgrade from OSS v1.30.
- Depends on https://github.com/temporalio/temporal/pull/9085
- This change will be part of OSS v1.31 but not v1.30.

## Why?
- Fix breaking changes for cloud

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
