### PR TITLE
Fix LRU data race

### DIFF
--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -144,8 +144,10 @@ func NewWithMetrics(maxSize int, opts *Options, handler metrics.Handler) Stoppab
 	if opts == nil {
 		opts = &Options{}
 	}
-	if opts.BackgroundEvict == nil {
-		opts.BackgroundEvict = func() dynamicconfig.CacheBackgroundEvictSettings {
+
+	backgroundEvict := opts.BackgroundEvict
+	if backgroundEvict == nil {
+		backgroundEvict = func() dynamicconfig.CacheBackgroundEvictSettings {
 			return dynamicconfig.CacheBackgroundEvictSettings{
 				Enabled: false,
 			}
@@ -170,7 +172,7 @@ func NewWithMetrics(maxSize int, opts *Options, handler metrics.Handler) Stoppab
 		onEvict:         opts.OnEvict,
 		timeSource:      timeSource,
 		metricsHandler:  handler,
-		backgroundEvict: opts.BackgroundEvict,
+		backgroundEvict: backgroundEvict,
 	}
 	if c.backgroundEvict().Enabled {
 		c.loops.Go(c.bgEvictLoop)


### PR DESCRIPTION
Fixes

```
2026-01-21T19:50:51.3542081Z ==================
2026-01-21T19:50:51.3542420Z WARNING: DATA RACE
2026-01-21T19:50:51.3542790Z Read at 0x0000093b48f0 by goroutine 16:
2026-01-21T19:50:51.3543393Z   go.temporal.io/server/common/cache.NewWithMetrics()
2026-01-21T19:50:51.3544337Z       /home/runner/work/temporal/temporal/common/cache/lru.go:147 +0x14e
2026-01-21T19:50:51.3545080Z   go.temporal.io/server/common/cache.New()
2026-01-21T19:50:51.3546113Z       /home/runner/work/temporal/temporal/common/cache/lru.go:138 +0x278
2026-01-21T19:50:51.3546976Z   go.temporal.io/server/common/namespace/nsregistry.NewRegistry()

2026-01-21T19:50:51.3620133Z Previous write at 0x0000093b48f0 by goroutine 15:
2026-01-21T19:50:51.3620523Z   go.temporal.io/server/common/cache.NewWithMetrics()
2026-01-21T19:50:51.3621050Z       /home/runner/work/temporal/temporal/common/cache/lru.go:148 +0x17b
2026-01-21T19:50:51.3621457Z   go.temporal.io/server/common/cache.New()
2026-01-21T19:50:51.3621946Z       /home/runner/work/temporal/temporal/common/cache/lru.go:138 +0x278
2026-01-21T19:50:51.3622435Z   go.temporal.io/server/common/namespace/nsregistry.NewRegistry()
```

(from [test logs](https://productionresultssa19.blob.core.windows.net/actions-results/d17507f0-b617-48e3-841f-a223b9de3a1f/workflow-job-run-7b7ecbe7-e78e-55fb-bc97-c597d98566c7/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-01-21T22%3A08%3A59Z&sig=Y1HT%2BSYgpSMNKEKe5X8L1%2FFqkNCy6rXMeRdUnM1U%2BnM%3D&ske=2026-01-21T22%3A28%3A49Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-01-21T21%3A28%3A49Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-01-21T21%3A58%3A54Z&sv=2025-11-05)) 