### PR TITLE
Stop using BuildIds SA in Drainage

### DIFF
--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -1453,10 +1453,14 @@ func (d *ClientImpl) GetVersionDrainageStatus(
 }
 
 func makeDeploymentQuery(version string) string {
-	var statusFilter string
-	deploymentFilter := fmt.Sprintf("= '%s'", worker_versioning.PinnedBuildIdSearchAttribute(version))
-	statusFilter = "= 'Running'"
-	return fmt.Sprintf("%s %s AND %s %s", sadefs.BuildIds, deploymentFilter, sadefs.ExecutionStatus, statusFilter)
+	deploymentFilter := fmt.Sprintf("= '%s'", version)
+	statusFilter := "= 'Running'"
+	behaviorFilter := "= 'Pinned'"
+	return fmt.Sprintf("%s %s AND %s %s AND %s %s",
+		sadefs.TemporalWorkerDeploymentVersion, deploymentFilter,
+		sadefs.TemporalWorkflowVersioningBehavior, behaviorFilter,
+		sadefs.ExecutionStatus, statusFilter,
+	)
 }
 
 func (d *ClientImpl) IsVersionMissingTaskQueues(ctx context.Context, namespaceEntry *namespace.Namespace, prevCurrentVersion, newVersion string) (bool, error) {


### PR DESCRIPTION
## What changed?
The `BuildIds` search attribute is deprecated and we don't want to depend on it for drainage status calculation. updating the internal query to use `TemporalWorklfowVersioningBehavior` and `TemporalWorkerDeploymentVersion` SAs.

## Why?
remove dependency to deprecated SA.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
The new query uses there filters vs two filters in the previous one so it might be slightly less efficient.
