### PR TITLE
CHASM: Fix force migration

### DIFF
--- a/chasm/lib/activity/library.go
+++ b/chasm/lib/activity/library.go
@@ -16,7 +16,8 @@ const (
 )
 
 var (
-	ArchetypeID = chasm.GenerateTypeID(chasm.FullyQualifiedName(libraryName, componentName))
+	Archetype   = chasm.FullyQualifiedName(libraryName, componentName)
+	ArchetypeID = chasm.GenerateTypeID(Archetype)
 )
 
 func newComponentOnlyLibrary() *componentOnlyLibrary {

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -10,9 +10,11 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/log"
@@ -757,15 +759,27 @@ func (r *TaskGeneratorImpl) GenerateMigrationTasks(targetClusters []string) ([]t
 	if err != nil {
 		return nil, 0, err
 	}
-	lastItem, err := versionhistory.GetLastVersionHistoryItem(versionHistory)
-	if err != nil {
-		return nil, 0, err
+
+	archetypeID := r.mutableState.ChasmTree().ArchetypeID()
+	isWorkflow := archetypeID == chasm.WorkflowArchetypeID
+
+	lastItem := &historyspb.VersionHistoryItem{
+		EventId: common.EmptyEventID,
+		Version: common.EmptyVersion,
 	}
+	nextEventID := common.EmptyEventID
+	if isWorkflow {
+		// version history is empty for non-workflow
+		lastItem, err = versionhistory.GetLastVersionHistoryItem(versionHistory)
+		if err != nil {
+			return nil, 0, err
+		}
+		nextEventID = lastItem.GetEventId() + 1
+	}
+
 	now := time.Now().UTC()
 	workflowKey := r.mutableState.GetWorkflowKey()
 	var taskEquivalents []tasks.Task
-	archetypeID := r.mutableState.ChasmTree().ArchetypeID()
-	isWorkflow := archetypeID == chasm.WorkflowArchetypeID
 
 	if r.mutableState.GetExecutionState().State == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
 		if isWorkflow {
@@ -791,7 +805,7 @@ func (r *TaskGeneratorImpl) GenerateMigrationTasks(targetClusters []string) ([]t
 				VersionedTransition: transitionhistory.LastVersionedTransition(transitionHistory),
 				FirstEventID:        executionInfo.LastFirstEventId,
 				FirstEventVersion:   lastItem.Version,
-				NextEventID:         lastItem.GetEventId() + 1,
+				NextEventID:         nextEventID,
 				TaskEquivalents:     taskEquivalents,
 				TargetClusters:      targetClusters,
 				IsForceReplication:  true,
@@ -813,7 +827,7 @@ func (r *TaskGeneratorImpl) GenerateMigrationTasks(targetClusters []string) ([]t
 			// TaskID, VisibilityTimestamp is set by shard
 			WorkflowKey:    workflowKey,
 			FirstEventID:   executionInfo.LastFirstEventId,
-			NextEventID:    lastItem.GetEventId() + 1,
+			NextEventID:    nextEventID,
 			Version:        lastItem.GetVersion(),
 			TargetClusters: targetClusters,
 		})
@@ -850,7 +864,7 @@ func (r *TaskGeneratorImpl) GenerateMigrationTasks(targetClusters []string) ([]t
 			VersionedTransition: transitionhistory.LastVersionedTransition(transitionHistory),
 			FirstEventID:        executionInfo.LastFirstEventId,
 			FirstEventVersion:   lastItem.GetVersion(),
-			NextEventID:         lastItem.GetEventId() + 1,
+			NextEventID:         nextEventID,
 			TaskEquivalents:     taskEquivalents,
 			TargetClusters:      targetClusters,
 			IsForceReplication:  true,

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/chasm"
+	chasmactivity "go.temporal.io/server/chasm/lib/activity"
 	serverClient "go.temporal.io/server/client"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -1056,6 +1057,13 @@ func (a *activities) archetypeIDToName(ctx context.Context, archetypeID chasm.Ar
 		// for workflows. But 0 is not a valid archetypeID in chasm.Registry, so explicitly return
 		//  WorkflowArchetype here.
 		return chasm.WorkflowArchetype, nil
+	}
+
+	// chasm activity library is not registered on worker service, so hardcoding the mapping here for now.
+	// TODO: Accept archetypeID in admin apis directly and remove this translation logic which relies on
+	// chasm registry.
+	if archetypeID == chasmactivity.ArchetypeID {
+		return chasmactivity.Archetype, nil
 	}
 
 	archetype, ok := a.chasmRegistry.ComponentFqnByID(archetypeID)


### PR DESCRIPTION
## What changed?
- Fix archetypeID translation for SAA in worker service
- Handle empty version history when generating migration task.

## Why?
- Fix force migration for CHASM executions

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
- [x] nightly migration pipeline
