### PR TITLE
[Scheduler] Fix missing namespace tag from metrics

### DIFF
--- a/chasm/lib/scheduler/generator_tasks.go
+++ b/chasm/lib/scheduler/generator_tasks.go
@@ -53,6 +53,7 @@ func (g *GeneratorTaskExecutor) Execute(
 ) error {
 	scheduler := generator.Scheduler.Get(ctx)
 	logger := newTaggedLogger(g.baseLogger, scheduler)
+	metricsHandler := newTaggedMetricsHandler(g.metricsHandler, scheduler)
 	invoker := scheduler.Invoker.Get(ctx)
 
 	// If we have no last processed time, this is a new schedule.
@@ -99,7 +100,7 @@ func (g *GeneratorTaskExecutor) Execute(
 	if result.DroppedCount > 0 {
 		logger.Warn("Buffer overrun, dropping actions",
 			tag.NewInt64("dropped-count", result.DroppedCount))
-		g.metricsHandler.Counter(metrics.ScheduleBufferOverruns.Name()).Record(result.DroppedCount)
+		metricsHandler.Counter(metrics.ScheduleBufferOverruns.Name()).Record(result.DroppedCount)
 		scheduler.Info.BufferDropped += result.DroppedCount
 	}
 

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -176,6 +176,7 @@ func (e *InvokerExecuteTaskExecutor) Execute(
 	}
 
 	logger := newTaggedLogger(e.baseLogger, scheduler)
+	metricsHandler := newTaggedMetricsHandler(e.metricsHandler, scheduler)
 
 	// Terminate, cancel, and start workflows. The result struct contains the
 	// complete outcome of all requests executed in a single batch.
@@ -184,9 +185,9 @@ func (e *InvokerExecuteTaskExecutor) Execute(
 	// cancel, start) at a time, so it isn't sensible to run them in parallel. The
 	// structure below is simply for code simplicity.
 	ictx := e.newInvokerTaskExecutorContext(ctx, scheduler)
-	result = result.Append(e.terminateWorkflows(ictx, logger, scheduler, invoker.GetTerminateWorkflows()))
-	result = result.Append(e.cancelWorkflows(ictx, logger, scheduler, invoker.GetCancelWorkflows()))
-	sres, startResults := e.startWorkflows(ictx, logger, scheduler, invoker, lastCompletionState, callback)
+	result = result.Append(e.terminateWorkflows(ictx, logger, metricsHandler, scheduler, invoker.GetTerminateWorkflows()))
+	result = result.Append(e.cancelWorkflows(ictx, logger, metricsHandler, scheduler, invoker.GetCancelWorkflows()))
+	sres, startResults := e.startWorkflows(ictx, logger, metricsHandler, scheduler, invoker, lastCompletionState, callback)
 	result = result.Append(sres)
 
 	// Record action results on the Invoker (internal state), as well as the
@@ -225,6 +226,7 @@ func (i *invokerTaskExecutorContext) takeNextAction() bool {
 func (e *InvokerExecuteTaskExecutor) cancelWorkflows(
 	ctx invokerTaskExecutorContext,
 	logger log.Logger,
+	metricsHandler metrics.Handler,
 	scheduler *Scheduler,
 	targets []*commonpb.WorkflowExecution,
 ) (result executeResult) {
@@ -246,7 +248,7 @@ func (e *InvokerExecuteTaskExecutor) cancelWorkflows(
 
 			if err != nil {
 				logger.Error("failed to cancel workflow", tag.Error(err), tag.WorkflowID(wf.WorkflowId))
-				e.metricsHandler.Counter(metrics.ScheduleCancelWorkflowErrors.Name()).Record(1)
+				metricsHandler.Counter(metrics.ScheduleCancelWorkflowErrors.Name()).Record(1)
 			}
 
 			// Cancels are only attempted once.
@@ -262,6 +264,7 @@ func (e *InvokerExecuteTaskExecutor) cancelWorkflows(
 func (e *InvokerExecuteTaskExecutor) terminateWorkflows(
 	ctx invokerTaskExecutorContext,
 	logger log.Logger,
+	metricsHandler metrics.Handler,
 	scheduler *Scheduler,
 	targets []*commonpb.WorkflowExecution,
 ) (result executeResult) {
@@ -283,7 +286,7 @@ func (e *InvokerExecuteTaskExecutor) terminateWorkflows(
 
 			if err != nil {
 				logger.Error("failed to terminate workflow", tag.Error(err), tag.WorkflowID(wf.WorkflowId))
-				e.metricsHandler.Counter(metrics.ScheduleTerminateWorkflowErrors.Name()).Record(1)
+				metricsHandler.Counter(metrics.ScheduleTerminateWorkflowErrors.Name()).Record(1)
 			}
 
 			// Terminates are only attempted once.
@@ -299,12 +302,13 @@ func (e *InvokerExecuteTaskExecutor) terminateWorkflows(
 func (e *InvokerExecuteTaskExecutor) startWorkflows(
 	ctx invokerTaskExecutorContext,
 	logger log.Logger,
+	metricsHandler metrics.Handler,
 	scheduler *Scheduler,
 	invoker *Invoker,
 	lastCompletionState *schedulerpb.LastCompletionResult,
 	callback *commonpb.Callback,
 ) (result executeResult, startResults []*schedulepb.ScheduleActionResult) {
-	metricsWithTag := e.metricsHandler.WithTags(
+	metricsWithTag := metricsHandler.WithTags(
 		metrics.StringTag(metrics.ScheduleActionTypeTag, metrics.ScheduleActionStartWorkflow))
 
 	var wg sync.WaitGroup
@@ -332,7 +336,7 @@ func (e *InvokerExecuteTaskExecutor) startWorkflows(
 		// Run all starts concurrently.
 		newCtx := ctx.Clone()
 		wg.Go(func() {
-			startResult, err := e.startWorkflow(newCtx, scheduler, start, lastCompletionState, callback)
+			startResult, err := e.startWorkflow(newCtx, metricsHandler, scheduler, start, lastCompletionState, callback)
 
 			resultMutex.Lock()
 			defer resultMutex.Unlock()
@@ -528,6 +532,7 @@ func (e *InvokerProcessBufferTaskExecutor) startWorkflowDeadline(
 
 func (e *InvokerExecuteTaskExecutor) startWorkflow(
 	ctx context.Context,
+	metricsHandler metrics.Handler,
 	scheduler *Scheduler,
 	start *schedulespb.BufferedStart,
 	lastCompletionState *schedulerpb.LastCompletionResult,
@@ -598,7 +603,7 @@ func (e *InvokerExecuteTaskExecutor) startWorkflow(
 
 	// Record time taken from action eligible to workflow started.
 	if !start.Manual {
-		e.metricsHandler.
+		metricsHandler.
 			Timer(metrics.ScheduleActionDelay.Name()).
 			Record(actualStartTime.Sub(start.DesiredTime.AsTime()))
 	}

--- a/chasm/lib/scheduler/spec_processor.go
+++ b/chasm/lib/scheduler/spec_processor.go
@@ -82,6 +82,7 @@ func (s *SpecProcessorImpl) ProcessTimeRange(
 	limit *int,
 ) (*ProcessedTimeRange, error) {
 	tweakables := s.config.Tweakables(scheduler.Namespace)
+	metricsHandler := newTaggedMetricsHandler(s.metricsHandler, scheduler)
 	overlapPolicy = scheduler.resolveOverlapPolicy(overlapPolicy)
 
 	s.logger.Debug("ProcessTimeRange",
@@ -140,7 +141,7 @@ func (s *SpecProcessorImpl) ProcessTimeRange(
 			s.logger.Warn("Schedule missed catchup window",
 				tag.NewTimeTag("now", end),
 				tag.NewTimeTag("time", next.Next))
-			s.metricsHandler.Counter(metrics.ScheduleMissedCatchupWindow.Name()).Record(1)
+			metricsHandler.Counter(metrics.ScheduleMissedCatchupWindow.Name()).Record(1)
 
 			scheduler.Info.MissedCatchupWindow++
 			continue

--- a/chasm/lib/scheduler/util.go
+++ b/chasm/lib/scheduler/util.go
@@ -6,6 +6,7 @@ import (
 
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -48,6 +49,11 @@ func newTaggedLogger(baseLogger log.Logger, scheduler *Scheduler) log.Logger {
 		tag.WorkflowNamespace(scheduler.Namespace),
 		tag.ScheduleID(scheduler.ScheduleId),
 	)
+}
+
+// newTaggedMetricsHandler returns a metrics handler tagged with the Scheduler's namespace.
+func newTaggedMetricsHandler(baseHandler metrics.Handler, scheduler *Scheduler) metrics.Handler {
+	return baseHandler.WithTags(metrics.NamespaceTag(scheduler.Namespace))
 }
 
 // validateTaskHighWaterMark validates a component's lastProcessedTime against a


### PR DESCRIPTION
## What changed?
- Scheduler V2 metrics were missing the namespace tag 😿
