### PR TITLE
Use serviceerror.ActivityExecutionAlreadyStarted

### DIFF
--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -5,18 +5,14 @@ import (
 	"errors"
 
 	enumspb "go.temporal.io/api/enums/v1"
-	errordetailspb "go.temporal.io/api/errordetails/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	"go.temporal.io/server/common/contextutil"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var (
@@ -94,21 +90,7 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 	if err != nil {
 		var alreadyStartedErr *chasm.ExecutionAlreadyStartedError
 		if errors.As(err, &alreadyStartedErr) {
-			details := &errordetailspb.ActivityExecutionAlreadyStartedFailure{
-				StartRequestId: alreadyStartedErr.CurrentRequestID,
-				RunId:          alreadyStartedErr.CurrentRunID,
-			}
-
-			errStatus := status.New(codes.AlreadyExists, "activity execution already started")
-
-			errStatusWithDetails, errDetail := status.New(codes.AlreadyExists, "activity execution already started").WithDetails(details)
-			if errDetail != nil {
-				h.logger.Error("Failed to add error details to ActivityExecutionAlreadyStartedFailure",
-					tag.Error(errDetail), tag.ActivityID(frontendReq.GetActivityId()))
-				return nil, errStatus.Err()
-			}
-
-			return nil, errStatusWithDetails.Err()
+			return nil, serviceerror.NewActivityExecutionAlreadyStarted("activity execution already started", alreadyStartedErr.CurrentRequestID, alreadyStartedErr.CurrentRunID)
 		}
 
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	go.opentelemetry.io/otel/trace v1.34.0
-	go.temporal.io/api v1.61.0
+	go.temporal.io/api v1.61.1-0.20260123144430-3418f5100388
 	go.temporal.io/sdk v1.38.0
 	go.uber.org/fx v1.24.0
 	go.uber.org/mock v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,8 @@ go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
-go.temporal.io/api v1.61.0 h1:gGIvUu1pRE9yVKqlirYd5FGDT5N/hvcZ0tlB4mRvVM4=
-go.temporal.io/api v1.61.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.61.1-0.20260123144430-3418f5100388 h1:Rahqpgjqalbv28RLoOtnNNZvwtnes/sQP0+cisO70Hw=
+go.temporal.io/api v1.61.1-0.20260123144430-3418f5100388/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.38.0 h1:4Bok5LEdED7YKpsSjIa3dDqram5VOq+ydBf4pyx0Wo4=
 go.temporal.io/sdk v1.38.0/go.mod h1:a+R2Ej28ObvHoILbHaxMyind7M6D+W0L7edt5UJF4SE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=


### PR DESCRIPTION
## Why?

Cleaner than creating errordetails messages and constructing status errors.