### PR TITLE
History Handler cleanup

### DIFF
--- a/chasm/interceptors.go
+++ b/chasm/interceptors.go
@@ -14,16 +14,18 @@ import (
 // ChasmVisibilityInterceptor.
 type ChasmEngineInterceptor struct {
 	engine         Engine
-	logger         log.Logger
+	logger         log.SnTaggedLogger
 	metricsHandler metrics.Handler
 }
 
 func (i *ChasmEngineInterceptor) Intercept(
 	ctx context.Context,
-	req interface{},
+	req any,
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
-) (resp interface{}, retError error) {
+) (resp any, retError error) {
+	// Capture panics for any handler method, not just CHASM-specific ones. This could have gone into a separate
+	// interceptor, but having it here avoids the overhead of adding another layer to the interceptor chain.
 	defer metrics.CapturePanic(i.logger, i.metricsHandler, &retError)
 
 	ctx = NewEngineContext(ctx, i.engine)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -1909,7 +1909,9 @@ func (h *Handler) PollWorkflowExecutionUpdate(
 
 func (h *Handler) StreamWorkflowReplicationMessages(
 	server historyservice.HistoryService_StreamWorkflowReplicationMessagesServer,
-) error {
+) (retErr error) {
+	// Note that since this is not a unary RPC, we cannot use the interceptor to capture panics.
+	metrics.CapturePanic(h.logger, h.metricsHandler, &retErr)
 	getter := headers.NewGRPCHeaderGetter(server.Context())
 	clientClusterShardID, serverClusterShardID, err := history.DecodeClusterShardMD(getter)
 	if err != nil {


### PR DESCRIPTION
## What changed?

- Remove defer metrics.CapturePanic and log.CapturePanic calls from all handler methods, that is now handled in the chasm interceptor
- Remove named return parameters (retError, retErr) from handler signatures
- Standardize error variable naming to consistently use 'err'
- Remove isStopped checks as they're redundant with graceful shutdown draining happening before stopping the handler