### PR TITLE
Add linter rules to enforce UnixMilliseconds() in Cassandra persistence

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -38,6 +38,12 @@ linters:
           msg: "Please avoid using panic in application code"
         - pattern: time\.Now
           msg: "Using time.Now is not allowed in chasm/lib package (non-test files), use ctx.Now(component) instead"
+        - pattern: '^Unix$'
+          msg: "Do not use .Unix() for Cassandra timestamps (returns seconds). Use p.UnixMilliseconds() which returns milliseconds."
+        - pattern: '^UnixMilli$'
+          msg: "Do not use .UnixMilli() for Cassandra timestamps. Use p.UnixMilliseconds() for consistency and proper zero-time handling."
+        - pattern: '^UnixNano$'
+          msg: "Do not use .UnixNano() for Cassandra timestamps. Use p.UnixMilliseconds() which returns milliseconds."
     depguard:
       rules:
         main:
@@ -163,6 +169,16 @@ linters:
           - forbidigo
       - path: chasm/lib/.*_test\.go$
         text: "time.Now"
+        linters:
+          - forbidigo
+      # Cassandra timestamp rules only apply to cassandra persistence package
+      - path-except: common/persistence/cassandra/.*\.go$
+        text: "Unix|UnixMilli|UnixNano"
+        linters:
+          - forbidigo
+      # Allow in tests
+      - path: _test\.go$
+        text: "Unix|UnixMilli|UnixNano"
         linters:
           - forbidigo
       - path: _test\.go|tests/.+\.go|common/testing/


### PR DESCRIPTION
## Summary
- Add forbidigo linter rules to prevent direct use of `.Unix()`, `.UnixMilli()`, or `.UnixNano()` method calls in the Cassandra persistence package
- Rules enforce using `p.UnixMilliseconds()` for all CQL timestamp values

## Why?
Cassandra TIMESTAMP type has millisecond precision. Using the wrong time conversion can cause:
- **`.Unix()`**: Returns seconds, not milliseconds - timestamps would be off by 1000x
- **`.UnixNano()`**: Returns nanoseconds - precision loss when Cassandra truncates to milliseconds
- **`.UnixMilli()`**: Works but doesn't handle zero-time edge cases like `UnixMilliseconds()` does

The existing `p.UnixMilliseconds()` function (in `common/persistence/data_interfaces.go`) handles these edge cases and should be used consistently.

## What changed?
- Added 3 forbidigo patterns for `Unix`, `UnixMilli`, `UnixNano` method identifiers
- Added exclusion rules so patterns only apply to `common/persistence/cassandra/*.go`
- Tests are excluded from these rules

## Test plan
- [x] Verified linter correctly flags `.Unix()` method calls in cassandra persistence
- [x] Verified `time.Unix()` function calls are NOT flagged (no false positives)
- [x] Verified no existing violations in cassandra persistence code
- [x] Rules scoped to only cassandra persistence package

Addresses #245

🤖 Generated with [Claude Code](https://claude.ai/code)