### PR TITLE
[Scheduler] Adjust CHASM scheduler log levels

### DIFF
--- a/chasm/lib/scheduler/generator_tasks.go
+++ b/chasm/lib/scheduler/generator_tasks.go
@@ -75,7 +75,7 @@ func (g *GeneratorTaskExecutor) Execute(
 	t1 := generator.LastProcessedTime.AsTime()
 	t2 := ctx.Now(generator).UTC()
 	if t2.Before(t1) {
-		logger.Warn("time went backwards",
+		logger.Error("time went backwards",
 			tag.NewStringerTag("time", t1),
 			tag.NewStringerTag("time", t2))
 		t2 = t1

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -247,7 +247,7 @@ func (e *InvokerExecuteTaskExecutor) cancelWorkflows(
 			defer resultMutex.Unlock()
 
 			if err != nil {
-				logger.Error("failed to cancel workflow", tag.Error(err), tag.WorkflowID(wf.WorkflowId))
+				logger.Info("failed to cancel workflow", tag.Error(err), tag.WorkflowID(wf.WorkflowId))
 				metricsHandler.Counter(metrics.ScheduleCancelWorkflowErrors.Name()).Record(1)
 			}
 
@@ -285,7 +285,7 @@ func (e *InvokerExecuteTaskExecutor) terminateWorkflows(
 			defer resultMutex.Unlock()
 
 			if err != nil {
-				logger.Error("failed to terminate workflow", tag.Error(err), tag.WorkflowID(wf.WorkflowId))
+				logger.Info("failed to terminate workflow", tag.Error(err), tag.WorkflowID(wf.WorkflowId))
 				metricsHandler.Counter(metrics.ScheduleTerminateWorkflowErrors.Name()).Record(1)
 			}
 
@@ -342,7 +342,7 @@ func (e *InvokerExecuteTaskExecutor) startWorkflows(
 			defer resultMutex.Unlock()
 
 			if err != nil {
-				logger.Error("failed to start workflow", tag.Error(err))
+				logger.Info("failed to start workflow", tag.Error(err))
 
 				// Don't count "already started" for the error metric or retry, as it is most likely
 				// due to misconfiguration.

--- a/chasm/lib/scheduler/spec_processor.go
+++ b/chasm/lib/scheduler/spec_processor.go
@@ -131,14 +131,14 @@ func (s *SpecProcessorImpl) ProcessTimeRange(
 			// water mark, discard actions that were scheduled to kick off before the update.
 			// Skip this check for manual (backfill) actions since they explicitly request
 			// past times.
-			s.logger.Warn("ProcessBuffer skipped an action due to update time",
+			s.logger.Info("ProcessBuffer skipped an action due to update time",
 				tag.NewTimeTag("updateTime", scheduler.Info.UpdateTime.AsTime()),
 				tag.NewTimeTag("droppedActionTime", next.Next))
 			continue
 		}
 
 		if !manual && end.Sub(next.Next) > catchupWindow {
-			s.logger.Warn("Schedule missed catchup window",
+			s.logger.Info("Schedule missed catchup window",
 				tag.NewTimeTag("now", end),
 				tag.NewTimeTag("time", next.Next))
 			metricsHandler.Counter(metrics.ScheduleMissedCatchupWindow.Name()).Record(1)


### PR DESCRIPTION
## What changed?
- Log levels throughout CHASM scheduler have been adjusted.

## Why?
- Because usually these aren't errors originating from the scheduler itself; they're usually driven by rate limits, or other system resource exhaustion limits.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
