### PR TITLE
Skip time in UpdateWorkflowSuite [WiP]

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -38,11 +38,19 @@ linters:
           msg: "Please avoid using panic in application code"
         - pattern: time\.Now
           msg: "Using time.Now is not allowed in chasm/lib package (non-test files), use ctx.Now(component) instead"
-        - pattern: '^Unix$'
+        - pattern: time\.NewTimer
+          msg: "Do not use time.NewTimer directly in history/matching services. Use TimeSource.NewTimer() for testability with fake time."
+        - pattern: time\.AfterFunc
+          msg: "Do not use time.AfterFunc directly in history/matching services. Use TimeSource.AfterFunc() for testability with fake time."
+        - pattern: time\.NewTicker
+          msg: "Do not use time.NewTicker directly in history/matching services. Use TimeSource.NewTicker() for testability with fake time."
+        - pattern: time\.After\(
+          msg: "Do not use time.After directly in history/matching services. Use TimeSource.NewTimer() for testability with fake time."
+        - pattern: "^Unix$"
           msg: "Do not use .Unix() for Cassandra timestamps (returns seconds). Use p.UnixMilliseconds() which returns milliseconds."
-        - pattern: '^UnixMilli$'
+        - pattern: "^UnixMilli$"
           msg: "Do not use .UnixMilli() for Cassandra timestamps. Use p.UnixMilliseconds() for consistency and proper zero-time handling."
-        - pattern: '^UnixNano$'
+        - pattern: "^UnixNano$"
           msg: "Do not use .UnixNano() for Cassandra timestamps. Use p.UnixMilliseconds() which returns milliseconds."
     depguard:
       rules:
@@ -179,6 +187,21 @@ linters:
       # Allow in tests
       - path: _test\.go$
         text: "Unix|UnixMilli|UnixNano"
+        linters:
+          - forbidigo
+      # time.NewTimer/AfterFunc/NewTicker/After rules only apply to history and matching services
+      - path-except: service/(history|matching)/.*\.go$
+        text: "time.NewTimer|time.AfterFunc|time.NewTicker|time.After"
+        linters:
+          - forbidigo
+      # Allow in tests
+      - path: _test\.go$
+        text: "time.NewTimer|time.AfterFunc|time.NewTicker|time.After"
+        linters:
+          - forbidigo
+      # Allow in workers subpackage (worker registry is not timing-critical for task dispatching)
+      - path: service/matching/workers/.*\.go$
+        text: "time.NewTimer|time.AfterFunc|time.NewTicker|time.After"
         linters:
           - forbidigo
       - path: _test\.go|tests/.+\.go|common/testing/

--- a/common/clock/time_source.go
+++ b/common/clock/time_source.go
@@ -6,12 +6,18 @@ import (
 )
 
 type (
+	// Ticker represents a ticker that can be stopped.
+	Ticker interface {
+		Stop()
+	}
+
 	// TimeSource is an interface to make it easier to test code that uses time.
 	TimeSource interface {
 		Now() time.Time
 		Since(t time.Time) time.Duration
 		AfterFunc(d time.Duration, f func()) Timer
 		NewTimer(d time.Duration) (<-chan time.Time, Timer)
+		NewTicker(d time.Duration) (<-chan time.Time, Ticker)
 	}
 	// Timer is a timer returned by TimeSource.AfterFunc. Unlike the timers returned by [time.NewTimer] or time.Ticker,
 	// this timer does not have a channel. That is because the callback already reacts to the timer firing.
@@ -52,5 +58,11 @@ func (ts RealTimeSource) AfterFunc(d time.Duration, f func()) Timer {
 // NewTimer is a pass-through to time.NewTimer.
 func (ts RealTimeSource) NewTimer(d time.Duration) (<-chan time.Time, Timer) {
 	t := time.NewTimer(d)
+	return t.C, t
+}
+
+// NewTicker is a pass-through to time.NewTicker.
+func (ts RealTimeSource) NewTicker(d time.Duration) (<-chan time.Time, Ticker) {
+	t := time.NewTicker(d)
 	return t.C, t
 }

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -81,7 +81,8 @@ type (
 		nextForceNewSliceTime          time.Time
 
 		checkpointRetrier backoff.Retrier
-		checkpointTimer   *time.Timer
+		checkpointTimerCh <-chan time.Time
+		checkpointTimer   clock.Timer
 
 		alertCh <-chan *Alert
 	}
@@ -232,7 +233,7 @@ func (p *queueBase) Start() {
 	p.rescheduler.Start()
 	p.readerGroup.Start()
 
-	p.checkpointTimer = time.NewTimer(backoff.Jitter(
+	p.checkpointTimerCh, p.checkpointTimer = p.timeSource.NewTimer(backoff.Jitter(
 		p.options.CheckpointInterval(),
 		p.options.CheckpointIntervalJitterCoefficient(),
 	))

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -227,7 +227,7 @@ func (s *queueBaseSuite) TestStartStop() {
 	base.processNewRange()
 
 	<-doneCh
-	<-base.checkpointTimer.C
+	<-base.checkpointTimerCh
 
 	s.mockRescheduler.EXPECT().Stop().Times(1)
 	base.Stop()
@@ -303,7 +303,7 @@ func (s *queueBaseSuite) TestCheckPoint_WithPendingTasks_PerformRangeCompletion(
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 
 	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
-	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
+	base.checkpointTimerCh, base.checkpointTimer = base.timeSource.NewTimer(s.options.CheckpointInterval())
 
 	s.True(scopeMinKey.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
 
@@ -372,7 +372,7 @@ func (s *queueBaseSuite) TestCheckPoint_WithPendingTasks_SkipRangeCompletion() {
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 
 	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
-	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
+	base.checkpointTimerCh, base.checkpointTimer = base.timeSource.NewTimer(s.options.CheckpointInterval())
 
 	s.True(scopeMinKey.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
 
@@ -415,7 +415,7 @@ func (s *queueBaseSuite) TestCheckPoint_NoPendingTasks() {
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 
 	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
-	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
+	base.checkpointTimerCh, base.checkpointTimer = base.timeSource.NewTimer(s.options.CheckpointInterval())
 
 	s.True(exclusiveReaderHighWatermark.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
 
@@ -490,7 +490,7 @@ func (s *queueBaseSuite) TestCheckPoint_SlicePredicateAction() {
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 
 	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
-	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
+	base.checkpointTimerCh, base.checkpointTimer = base.timeSource.NewTimer(s.options.CheckpointInterval())
 	s.True(scopes[0].Range.InclusiveMin.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
 
 	// set to a smaller value so that delete will be triggered
@@ -539,7 +539,7 @@ func (s *queueBaseSuite) TestCheckPoint_MoveTaskGroupAction() {
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 
 	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
-	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
+	base.checkpointTimerCh, base.checkpointTimer = base.timeSource.NewTimer(s.options.CheckpointInterval())
 
 	// set to a smaller value so that delete will be triggered
 	base.exclusiveDeletionHighWatermark = tasks.MinimumKey

--- a/service/history/queues/queue_scheduled.go
+++ b/service/history/queues/queue_scheduled.go
@@ -192,7 +192,7 @@ func (p *scheduledQueue) processEventLoop() {
 			p.lookAheadTask()
 		case <-p.timerGate.FireCh():
 			p.processNewRange()
-		case <-p.checkpointTimer.C:
+		case <-p.checkpointTimerCh:
 			p.checkpoint()
 		case alert := <-p.alertCh:
 			p.handleAlert(alert)

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -77,7 +77,7 @@ type (
 		nextReadSlice *list.Element
 		notifyCh      chan struct{}
 
-		throttleTimer *time.Timer
+		throttleTimer clock.Timer
 		retrier       backoff.Retrier
 
 		rateLimitContext       context.Context
@@ -392,7 +392,7 @@ func (r *ReaderImpl) pauseLocked(duration time.Duration) {
 		r.throttleTimer.Stop()
 	}
 
-	r.throttleTimer = time.AfterFunc(duration, func() {
+	r.throttleTimer = r.timeSource.AfterFunc(duration, func() {
 		r.Lock()
 		defer r.Unlock()
 

--- a/service/history/queues/rescheduler.go
+++ b/service/history/queues/rescheduler.go
@@ -181,7 +181,7 @@ func (r *reschedulerImpl) Len() int {
 func (r *reschedulerImpl) rescheduleLoop() {
 	defer r.shutdownWG.Done()
 
-	cleanupTimer := time.NewTimer(backoff.Jitter(
+	cleanupTimerCh, cleanupTimer := r.timeSource.NewTimer(backoff.Jitter(
 		reschedulerPQCleanupDuration,
 		reschedulerPQCleanupJitterCoefficient,
 	))
@@ -194,7 +194,7 @@ func (r *reschedulerImpl) rescheduleLoop() {
 			return
 		case <-r.timerGate.FireCh():
 			r.reschedule()
-		case <-cleanupTimer.C:
+		case <-cleanupTimerCh:
 			r.cleanupPQ()
 			cleanupTimer.Reset(backoff.Jitter(
 				reschedulerPQCleanupDuration,

--- a/service/history/queues/scheduler_monitor.go
+++ b/service/history/queues/scheduler_monitor.go
@@ -116,14 +116,14 @@ func (m *schedulerMonitor) RecordStart(executable Executable) {
 }
 
 func (m *schedulerMonitor) metricEmissionLoop() {
-	emissionTicker := time.NewTicker(m.options.aggregationDuration)
+	emissionTickerCh, emissionTicker := m.timeSource.NewTicker(m.options.aggregationDuration)
 	defer emissionTicker.Stop()
 
 	for {
 		select {
 		case <-m.shutdownCh:
 			return
-		case <-emissionTicker.C:
+		case <-emissionTickerCh:
 			m.Lock()
 
 			now := m.timeSource.Now()

--- a/service/history/replication/executable_task_tool_box.go
+++ b/service/history/replication/executable_task_tool_box.go
@@ -2,6 +2,7 @@ package replication
 
 import (
 	"go.temporal.io/server/client"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -31,6 +32,7 @@ type (
 		LowPriorityTaskScheduler ctasks.Scheduler[TrackableExecutableTask] `name:"LowPriorityTaskScheduler"`
 		MetricsHandler           metrics.Handler
 		Logger                   log.Logger
+		TimeSource               clock.TimeSource
 		Serializer               serialization.Serializer
 		DLQWriter                DLQWriter
 		HistoryEventsHandler     eventhandler.HistoryEventsHandler

--- a/service/history/replication/stream_receiver.go
+++ b/service/history/replication/stream_receiver.go
@@ -138,6 +138,7 @@ func (r *StreamReceiverImpl) Start() {
 		r.shutdownChan,
 		r.Stop,
 		r.logger,
+		r.TimeSource,
 	)
 	r.logger.Info("StreamReceiver started.")
 }
@@ -180,14 +181,14 @@ func (r *StreamReceiverImpl) sendEventLoop() error {
 	}()
 	defer log.CapturePanic(r.logger, &panicErr)
 
-	timer := time.NewTicker(r.Config.ReplicationStreamSyncStatusDuration())
+	timerC, timer := r.TimeSource.NewTicker(r.Config.ReplicationStreamSyncStatusDuration())
 	defer timer.Stop()
 
 	var inclusiveLowWatermark int64
 
 	for {
 		select {
-		case <-timer.C:
+		case <-timerC:
 			watermark, err := r.ackMessage(r.stream)
 			if err != nil {
 				return err

--- a/service/history/replication/stream_receiver_monitor.go
+++ b/service/history/replication/stream_receiver_monitor.go
@@ -126,7 +126,7 @@ func (m *StreamReceiverMonitorImpl) RegisterInboundStream(
 
 func (m *StreamReceiverMonitorImpl) eventLoop() {
 	defer m.Stop()
-	ticker := time.NewTicker(streamReceiverMonitorInterval)
+	tickerC, ticker := m.TimeSource.NewTicker(streamReceiverMonitorInterval)
 	defer ticker.Stop()
 
 	clusterMetadataChangeChan := make(chan struct{}, 1)
@@ -145,7 +145,7 @@ Loop:
 		case <-clusterMetadataChangeChan:
 			m.reconcileInboundStreams()
 			m.reconcileOutboundStreams()
-		case <-ticker.C:
+		case <-tickerC:
 			m.reconcileInboundStreams()
 			m.reconcileOutboundStreams()
 		case <-m.shutdownOnce.Channel():
@@ -291,12 +291,12 @@ func (m *StreamReceiverMonitorImpl) doReconcileOutboundStreams(
 }
 
 func (m *StreamReceiverMonitorImpl) statusMonitorLoop() {
-	ticker := time.NewTicker(5 * time.Minute)
+	tickerC, ticker := m.TimeSource.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-ticker.C:
+		case <-tickerC:
 			m.monitorStreamStatus()
 		case <-m.shutdownOnce.Channel():
 			return

--- a/service/history/replication/stream_receiver_test.go
+++ b/service/history/replication/stream_receiver_test.go
@@ -12,6 +12,7 @@ import (
 	"go.temporal.io/server/api/adminservice/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -82,6 +83,7 @@ func (s *streamReceiverSuite) SetupTest() {
 		LowPriorityTaskScheduler:  s.taskScheduler,
 		MetricsHandler:            metrics.NoopMetricsHandler,
 		Logger:                    log.NewTestLogger(),
+		TimeSource:                clock.NewRealTimeSource(),
 		DLQWriter:                 NoopDLQWriter{},
 	}
 	processToolBox.Config.ReplicationStreamSyncStatusDuration = dynamicconfig.GetDurationPropertyFn(5 * time.Millisecond)
@@ -518,6 +520,7 @@ func (s *streamReceiverSuite) TestLivenessMonitor() {
 		s.streamReceiver.shutdownChan,
 		s.streamReceiver.Stop,
 		s.streamReceiver.logger,
+		s.streamReceiver.TimeSource,
 	)
 	s.False(s.streamReceiver.IsValid())
 }

--- a/service/history/replication/stream_sender_test.go
+++ b/service/history/replication/stream_sender_test.go
@@ -15,6 +15,7 @@ import (
 	"go.temporal.io/server/api/historyservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -79,6 +80,7 @@ func (s *streamSenderSuite) SetupTest() {
 	s.shardContext.EXPECT().GetEngine(gomock.Any()).Return(s.historyEngine, nil).AnyTimes()
 	s.shardContext.EXPECT().GetMetricsHandler().Return(metrics.NoopMetricsHandler).AnyTimes()
 	s.shardContext.EXPECT().GetLogger().Return(log.NewNoopLogger()).AnyTimes()
+	s.shardContext.EXPECT().GetTimeSource().Return(clock.NewRealTimeSource()).AnyTimes()
 
 	s.streamSender = NewStreamSender(
 		s.server,
@@ -1057,6 +1059,7 @@ func (s *streamSenderSuite) TestLivenessMonitor() {
 		s.streamSender.shutdownChan,
 		s.streamSender.Stop,
 		s.streamSender.logger,
+		s.streamSender.shardContext.GetTimeSource(),
 	)
 	s.False(s.streamSender.IsValid())
 }

--- a/service/history/replication/task_fetcher_test.go
+++ b/service/history/replication/task_fetcher_test.go
@@ -11,6 +11,7 @@ import (
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/api/adminservicemock/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -71,6 +72,7 @@ func (s *taskFetcherSuite) SetupTest() {
 		cluster.TestCurrentClusterName,
 		s.config,
 		s.mockResource.ClientBean,
+		clock.NewRealTimeSource(),
 	)
 }
 
@@ -282,6 +284,7 @@ func (s *taskFetcherSuite) TestConcurrentFetchAndProcess_Success() {
 		cluster.TestCurrentClusterName,
 		s.config,
 		s.mockResource.ClientBean,
+		clock.NewRealTimeSource(),
 	)
 
 	s.frontendClient.EXPECT().GetReplicationMessages(
@@ -326,6 +329,7 @@ func (s *taskFetcherSuite) TestConcurrentFetchAndProcess_Error() {
 		cluster.TestCurrentClusterName,
 		s.config,
 		s.mockResource.ClientBean,
+		clock.NewRealTimeSource(),
 	)
 
 	s.frontendClient.EXPECT().GetReplicationMessages(

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1213,7 +1213,7 @@ func (s *ContextImpl) renewRangeLocked(isStealing bool) error {
 }
 
 func (s *ContextImpl) monitorQueueMetrics() {
-	timer := time.NewTimer(queueMetricUpdateInterval)
+	timerC, timer := s.GetTimeSource().NewTimer(queueMetricUpdateInterval)
 	defer timer.Stop()
 
 	done := s.lifecycleCtx.Done()
@@ -1221,7 +1221,7 @@ func (s *ContextImpl) monitorQueueMetrics() {
 		select {
 		case <-done:
 			return
-		case <-timer.C:
+		case <-timerC:
 			s.emitShardInfoMetricsLogs()
 			// We reset the timer (rather than using a ticker) so that delays in grabbing the shard lock
 			// don't cause us to pile up

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -10,6 +10,7 @@ import (
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/future"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
@@ -74,6 +75,7 @@ func ControllerProvider(
 	metricsHandler metrics.Handler,
 	hostInfoProvider membership.HostInfoProvider,
 	contextFactory ContextFactory,
+	timeSource clock.TimeSource,
 ) *ControllerImpl {
 	hostIdentity := hostInfoProvider.HostInfo().Identity()
 	contextTaggedLogger := log.With(logger, tag.ComponentShardController, tag.Address(hostIdentity))
@@ -85,6 +87,7 @@ func ControllerProvider(
 		hostInfoProvider,
 		contextTaggedLogger,
 		taggedMetricsHandler,
+		timeSource,
 	)
 
 	c := &ControllerImpl{

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -99,6 +99,7 @@ func NewTestController(
 		metricsTestHandler,
 		resource.GetHostInfoProvider(),
 		contextFactory,
+		resource.GetTimeSource(),
 	)
 }
 

--- a/service/history/shard/ownership_test.go
+++ b/service/history/shard/ownership_test.go
@@ -54,6 +54,7 @@ func (s *ownershipSuite) newController(contextFactory ContextFactory) *Controlle
 		s.resource.GetMetricsHandler(),
 		s.resource.GetHostInfoProvider(),
 		contextFactory,
+		s.resource.GetTimeSource(),
 	)
 }
 

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -16,6 +16,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -79,6 +80,7 @@ func (s *BacklogManagerTestSuite) SetupTest() {
 	s.ptqMgr.EXPECT().QueueKey().Return(queue).AnyTimes()
 	s.ptqMgr.EXPECT().ProcessSpooledTask(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	s.ptqMgr.EXPECT().GetFairnessWeightOverrides().AnyTimes().Return(fairnessWeightOverrides{ /* To avoid deadlock with gomock method */ })
+	s.ptqMgr.EXPECT().TimeSource().Return(clock.NewRealTimeSource()).AnyTimes()
 
 	var ctx context.Context
 	ctx, s.cancelCtx = context.WithCancel(context.Background())

--- a/service/matching/fair_backlog_manager.go
+++ b/service/matching/fair_backlog_manager.go
@@ -206,11 +206,14 @@ func (c *fairBacklogManagerImpl) getSubqueueForPriority(priority priorityKey) su
 }
 
 func (c *fairBacklogManagerImpl) periodicSync() {
+	tickerC, ticker := c.pqMgr.TimeSource().NewTicker(c.config.UpdateAckInterval())
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-c.tqCtx.Done():
 			return
-		case <-time.After(c.config.UpdateAckInterval()):
+		case <-tickerC:
 			ctx, cancel := context.WithTimeout(c.tqCtx, ioTimeout)
 			err := c.db.SyncState(ctx)
 			cancel()

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -11,6 +11,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/membership"
@@ -70,6 +71,7 @@ type (
 		RateLimiter                   TaskDispatchRateLimiter `optional:"true"`
 		WorkersRegistry               workers.Registry
 		Serializer                    serialization.Serializer
+		TimeSource                    clock.TimeSource
 	}
 )
 
@@ -112,6 +114,7 @@ func NewHandler(
 			params.SearchAttributeMapperProvider,
 			params.RateLimiter,
 			params.Serializer,
+			params.TimeSource,
 		),
 		namespaceRegistry: params.NamespaceRegistry,
 		workersRegistry:   params.WorkersRegistry,

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -20,6 +20,7 @@ import (
 	"go.temporal.io/server/api/matchingservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payloads"
@@ -83,11 +84,11 @@ func (t *MatcherTestSuite) SetupTest() {
 	t.childConfig = tlCfg
 	t.fwdr, err = newForwarder(&t.childConfig.forwarderConfig, t.queue, t.client)
 	t.Assert().NoError(err)
-	t.childMatcher = newTaskMatcher(tlCfg, t.fwdr, metrics.NoopMetricsHandler, t.newDefaultRateLimiter())
+	t.childMatcher = newTaskMatcher(tlCfg, t.fwdr, metrics.NoopMetricsHandler, t.newDefaultRateLimiter(), clock.NewRealTimeSource())
 	t.childMatcher.Start()
 
 	t.rootConfig = newTaskQueueConfig(prtn.TaskQueue(), cfg, "test-namespace")
-	t.rootMatcher = newTaskMatcher(t.rootConfig, nil, metrics.NoopMetricsHandler, t.newDefaultRateLimiter())
+	t.rootMatcher = newTaskMatcher(t.rootConfig, nil, metrics.NoopMetricsHandler, t.newDefaultRateLimiter(), clock.NewRealTimeSource())
 	t.rootMatcher.Start()
 }
 

--- a/service/matching/physical_task_queue_manager_interface.go
+++ b/service/matching/physical_task_queue_manager_interface.go
@@ -10,6 +10,7 @@ import (
 	"go.temporal.io/server/api/matchingservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
+	"go.temporal.io/server/common/clock"
 )
 
 type (
@@ -58,5 +59,6 @@ type (
 		// GetFairnessWeightOverrides returns current fairness weight overrides for this queue.
 		GetFairnessWeightOverrides() fairnessWeightOverrides
 		UpdateRemotePriorityBacklogs(remotePriorityBacklogSet)
+		TimeSource() clock.TimeSource
 	}
 )

--- a/service/matching/physical_task_queue_manager_mock.go
+++ b/service/matching/physical_task_queue_manager_mock.go
@@ -18,6 +18,7 @@ import (
 	matchingservice "go.temporal.io/server/api/matchingservice/v1"
 	persistence "go.temporal.io/server/api/persistence/v1"
 	taskqueue0 "go.temporal.io/server/api/taskqueue/v1"
+	clock "go.temporal.io/server/common/clock"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -316,6 +317,20 @@ func (m *MockphysicalTaskQueueManager) Stop(arg0 unloadCause) {
 func (mr *MockphysicalTaskQueueManagerMockRecorder) Stop(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).Stop), arg0)
+}
+
+// TimeSource mocks base method.
+func (m *MockphysicalTaskQueueManager) TimeSource() clock.TimeSource {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TimeSource")
+	ret0, _ := ret[0].(clock.TimeSource)
+	return ret0
+}
+
+// TimeSource indicates an expected call of TimeSource.
+func (mr *MockphysicalTaskQueueManagerMockRecorder) TimeSource() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TimeSource", reflect.TypeOf((*MockphysicalTaskQueueManager)(nil).TimeSource))
 }
 
 // TrySyncMatch mocks base method.

--- a/service/matching/poller_history.go
+++ b/service/matching/poller_history.go
@@ -5,6 +5,7 @@ import (
 
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/server/common/cache"
+	"go.temporal.io/server/common/clock"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -27,10 +28,11 @@ type pollerHistory struct {
 	history cache.Cache
 }
 
-func newPollerHistory(pollerHistoryTTL time.Duration) *pollerHistory {
+func newPollerHistory(pollerHistoryTTL time.Duration, timeSource clock.TimeSource) *pollerHistory {
 	opts := &cache.Options{
-		TTL: pollerHistoryTTL,
-		Pin: false,
+		TTL:        pollerHistoryTTL,
+		Pin:        false,
+		TimeSource: timeSource,
 	}
 
 	return &pollerHistory{

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -221,11 +221,14 @@ func (c *priBacklogManagerImpl) getSubqueueForPriority(priority priorityKey) sub
 }
 
 func (c *priBacklogManagerImpl) periodicSync() {
+	tickerC, ticker := c.pqMgr.TimeSource().NewTicker(c.config.UpdateAckInterval())
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-c.tqCtx.Done():
 			return
-		case <-time.After(c.config.UpdateAckInterval()):
+		case <-tickerC:
 			ctx, cancel := context.WithTimeout(c.tqCtx, ioTimeout)
 			err := c.db.SyncState(ctx)
 			cancel()

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -28,6 +28,7 @@ import (
 	"go.temporal.io/server/api/adminservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -101,6 +102,7 @@ type (
 		FaultInjectionConfig   *config.FaultInjection
 		NumHistoryShards       int32
 		SharedCluster          bool
+		TimeSource             clock.TimeSource
 	}
 	TestClusterOption func(params *TestClusterParams)
 )
@@ -166,6 +168,14 @@ func WithNumHistoryShards(n int32) TestClusterOption {
 func WithSharedCluster() TestClusterOption {
 	return func(params *TestClusterParams) {
 		params.SharedCluster = true
+	}
+}
+
+// withTimeSource sets a custom TimeSource for the cluster.
+// This enables tests to control time by using EventTimeSource.
+func withTimeSource(ts clock.TimeSource) TestClusterOption {
+	return func(params *TestClusterParams) {
+		params.TimeSource = ts
 	}
 }
 
@@ -275,6 +285,7 @@ func (s *FunctionalTestBase) setupCluster(options ...TestClusterOption) {
 		EnableMetricsCapture:   true,
 		EnableArchival:         params.ArchivalEnabled,
 		EnableMTLS:             params.EnableMTLS,
+		TimeSource:             params.TimeSource,
 	}
 
 	// Apply configuration for shared clusters.

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -24,6 +24,7 @@ import (
 	"go.temporal.io/server/common/archiver/filestore"
 	"go.temporal.io/server/common/archiver/provider"
 	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -88,6 +89,8 @@ type (
 		SpanExporters          map[telemetry.SpanExporterType]sdktrace.SpanExporter
 		// ServiceFxOptions can be populated using WithFxOptionsForService.
 		ServiceFxOptions map[primitives.ServiceName][]fx.Option
+		// TimeSource is an optional custom time source for the cluster.
+		TimeSource clock.TimeSource
 	}
 
 	TestClusterFactory interface {
@@ -329,6 +332,7 @@ func newClusterWithPersistenceTestBaseFactory(t *testing.T, clusterConfig *TestC
 		TaskCategoryRegistry:             temporal.TaskCategoryRegistryProvider(archiverBase.metadata),
 		HostsByProtocolByService:         hostsByProtocolByService,
 		SpanExporters:                    clusterConfig.SpanExporters,
+		TimeSource:                       clusterConfig.TimeSource,
 	}
 
 	if clusterConfig.EnableMetricsCapture {


### PR DESCRIPTION
## What changed?

Replaced all "real time" `time` package uses with `clock.TimeSource` across History and Matching.

## Why?

To replace `time.Sleep`s with `s.Advance` in `UpdateWorkflowSuite` to skip time; one for History, one for Matching.

**Before**: TBD
**After**: TBD

## How did you test it?

Tests were run 10x locally without issues.

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
