### PR TITLE
[Scheduler] Tag scheduler metrics with backend version

### DIFF
--- a/chasm/lib/scheduler/util.go
+++ b/chasm/lib/scheduler/util.go
@@ -51,9 +51,12 @@ func newTaggedLogger(baseLogger log.Logger, scheduler *Scheduler) log.Logger {
 	)
 }
 
-// newTaggedMetricsHandler returns a metrics handler tagged with the Scheduler's namespace.
+// newTaggedMetricsHandler returns a metrics handler tagged with the Scheduler's namespace and backend.
 func newTaggedMetricsHandler(baseHandler metrics.Handler, scheduler *Scheduler) metrics.Handler {
-	return baseHandler.WithTags(metrics.NamespaceTag(scheduler.Namespace))
+	return baseHandler.WithTags(
+		metrics.NamespaceTag(scheduler.Namespace),
+		metrics.StringTag(metrics.ScheduleBackendTag, metrics.ScheduleBackendChasm),
+	)
 }
 
 // validateTaskHighWaterMark validates a component's lastProcessedTime against a

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -598,6 +598,9 @@ const (
 const (
 	ScheduleActionTypeTag       = "schedule_action"
 	ScheduleActionStartWorkflow = "start_workflow"
+	ScheduleBackendTag          = "scheduler_backend"
+	ScheduleBackendChasm        = "chasm"
+	ScheduleBackendLegacy       = "legacy"
 )
 
 var (

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -226,8 +226,11 @@ func schedulerWorkflowWithSpecBuilder(ctx workflow.Context, args *schedulespb.St
 		ctx:               ctx,
 		a:                 nil,
 		logger:            sdklog.With(workflow.GetLogger(ctx), "wf-namespace", args.State.Namespace, "schedule-id", args.State.ScheduleId),
-		metrics:           workflow.GetMetricsHandler(ctx).WithTags(map[string]string{"namespace": args.State.Namespace}),
-		specBuilder:       specBuilder,
+		metrics: workflow.GetMetricsHandler(ctx).WithTags(map[string]string{
+			"namespace":                args.State.Namespace,
+			metrics.ScheduleBackendTag: metrics.ScheduleBackendLegacy,
+		}),
+		specBuilder: specBuilder,
 	}
 	return scheduler.run()
 }


### PR DESCRIPTION
## What changed?
- Metrics emitted from the scheduler are now tagged as from CHASM or legacy backend.

## Why?
- So we can distinguish our metrics between the two, which will help us isolate failures to a particular stack, as well as track adoption.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- Though I'm adding a new tag to existing metrics, scheduler metrics aren't particularly busy metrics to begin with, and the tag will only ever consist of two static values, so I consider it minimal risk to observability.
