### PR TITLE
Fix workflow runner selection for repository forks

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -475,7 +475,7 @@ jobs:
             persistence_type: sql
             persistence_driver: postgres12_pgx
             containers: [postgresql]
-    runs-on: ${{ matrix.runs_on_override || matrix.runs-on }}
+    runs-on: ${{ (github.repository_owner == 'temporalio' && matrix.runs_on_override) || matrix.runs-on }}
     env:
       TEST_TOTAL_SHARDS: ${{ needs.set-up-single-test.outputs.total_shards }}
       TEST_SHARD_INDEX: ${{ matrix.shard_index }}
@@ -649,7 +649,7 @@ jobs:
             persistence_driver: postgres12_pgx
             parallel_flags: "-parallel=2" # reduce parallelism for postgres
             containers: [postgresql]
-    runs-on: ${{ matrix.runs_on_override || 'ubuntu-latest' }}
+    runs-on: ${{ (github.repository_owner == 'temporalio' && matrix.runs_on_override) || 'ubuntu-latest' }}
     env:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}
@@ -807,7 +807,7 @@ jobs:
             persistence_type: sql
             persistence_driver: postgres12_pgx
             containers: [postgresql]
-    runs-on: ${{ matrix.runs_on_override || 'ubuntu-latest' }}
+    runs-on: ${{ (github.repository_owner == 'temporalio' && matrix.runs_on_override) || 'ubuntu-latest' }}
     env:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}


### PR DESCRIPTION
## Summary
- Fix workflow runner selection to use custom runners only in the temporalio organization
- In forks, jobs fall back to standard runners instead of waiting 24 hours for non-existent `ubuntu-latest-8-cores`

## Test plan
- [x] `actionlint` passes
- [x] Verify workflow runs on fork without timing out (https://github.com/yiminc/temporal/actions/runs/21422096265)

Fixes #9135

🤖 Generated with [Claude Code](https://claude.com/claude-code)