### PR TITLE
Make EnableTransitionHistory a per-namespace flag with default true

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1564,11 +1564,10 @@ timeout timer when execution timeout is specified when starting a workflow.`,
 		`EnableUpdateWorkflowModeIgnoreCurrent controls whether to enable the new logic for updating closed workflow execution
 by mutation using UpdateWorkflowModeIgnoreCurrent`,
 	)
-	EnableTransitionHistory = NewGlobalBoolSetting(
+	EnableTransitionHistory = NewNamespaceBoolSetting(
 		"history.enableTransitionHistory",
-		false,
-		`EnableTransitionHistory controls whether to enable the new logic for recording the history for each state transition.
-This feature is still under development and should NOT be enabled.`,
+		true,
+		`EnableTransitionHistory controls whether to enable the new logic for recording the history for each state transition.`,
 	)
 	HistoryStartupMembershipJoinDelay = NewGlobalDurationSetting(
 		"history.startupMembershipJoinDelay",

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -62,7 +62,7 @@ type Config struct {
 	EnableNexus                           dynamicconfig.BoolPropertyFn
 	EnableWorkflowExecutionTimeoutTimer   dynamicconfig.BoolPropertyFn
 	EnableUpdateWorkflowModeIgnoreCurrent dynamicconfig.BoolPropertyFn
-	EnableTransitionHistory               dynamicconfig.BoolPropertyFn
+	EnableTransitionHistory               dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	MaxCallbacksPerWorkflow               dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxCHASMCallbacksPerWorkflow          dynamicconfig.IntPropertyFnWithNamespaceFilter
 	EnableRequestIdRefLinks               dynamicconfig.BoolPropertyFn

--- a/service/history/ndc/state_rebuilder_test.go
+++ b/service/history/ndc/state_rebuilder_test.go
@@ -74,7 +74,7 @@ func (s *stateRebuilderSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockTaskRefresher = workflow.NewMockTaskRefresher(s.controller)
 	config := tests.NewDynamicConfig()
-	config.EnableTransitionHistory = dynamicconfig.GetBoolPropertyFn(true)
+	config.EnableTransitionHistory = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.ExternalPayloadsEnabled = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	s.mockShard = shard.NewTestContext(
 		s.controller,

--- a/service/history/statemachine_environment_test.go
+++ b/service/history/statemachine_environment_test.go
@@ -62,7 +62,7 @@ func newStateMachineEnvTestContext(t *testing.T, enableTransitionHistory bool) *
 	s.timeSource = clock.NewEventTimeSource().Update(s.now)
 	s.controller = gomock.NewController(t)
 	config := tests.NewDynamicConfig()
-	config.EnableTransitionHistory = func() bool { return enableTransitionHistory }
+	config.EnableTransitionHistory = func(string) bool { return enableTransitionHistory }
 	s.version = s.namespaceEntry.FailoverVersion(namespace.EmptyBusinessID)
 
 	s.mockShard = shard.NewTestContextWithTimeSource(

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -164,7 +164,7 @@ func NewDynamicConfig() *configs.Config {
 	config.NamespaceCacheRefreshInterval = dynamicconfig.GetDurationPropertyFn(time.Second)
 	config.ReplicationEnableUpdateWithNewTaskMerge = dynamicconfig.GetBoolPropertyFn(true)
 	config.EnableWorkflowIdReuseStartTimeValidation = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
-	config.EnableTransitionHistory = dynamicconfig.GetBoolPropertyFn(true)
+	config.EnableTransitionHistory = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.EnableChasm = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false)
 	return config
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -342,7 +342,7 @@ func NewMutableState(
 		appliedEvents:                make(map[string]struct{}),
 		InsertTasks:                  make(map[tasks.Category][]tasks.Task),
 		BestEffortDeleteTasks:        make(map[tasks.Category][]tasks.Key),
-		transitionHistoryEnabled:     shard.GetConfig().EnableTransitionHistory(),
+		transitionHistoryEnabled:     shard.GetConfig().EnableTransitionHistory(namespaceName),
 		visibilityUpdated:            false,
 		executionStateUpdated:        false,
 		workflowTaskUpdated:          false,
@@ -6835,7 +6835,7 @@ func (ms *MutableStateImpl) StartTransaction(
 		return false, serviceerror.NewUnavailable("MutableState encountered dirty transaction")
 	}
 
-	ms.transitionHistoryEnabled = ms.config.EnableTransitionHistory()
+	ms.transitionHistoryEnabled = ms.config.EnableTransitionHistory(namespaceEntry.Name().String())
 
 	namespaceEntry, err := ms.startTransactionHandleNamespaceMigration(namespaceEntry)
 	if err != nil {

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -196,7 +196,7 @@ func (s *mutableStateSuite) SetupTest() {
 
 	s.mockConfig.MutableStateActivityFailureSizeLimitWarn = func(namespace string) int { return 1 * 1024 }
 	s.mockConfig.MutableStateActivityFailureSizeLimitError = func(namespace string) int { return 2 * 1024 }
-	s.mockConfig.EnableTransitionHistory = func() bool { return true }
+	s.mockConfig.EnableTransitionHistory = func(string) bool { return true }
 	s.mockShard.SetEventsCacheForTesting(s.mockEventsCache)
 
 	s.namespaceEntry = tests.GlobalNamespaceEntry


### PR DESCRIPTION
## What changed?
Change the EnableTransitionHistory dynamic config from a global setting
to a namespace-scoped setting, allowing it to be configured per namespace.
Also update the default value from false to true.

## Why?
To better control the feature.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
no risk.