### PR TITLE
Print goroutine profile in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -239,7 +239,11 @@ jobs:
 
       - name: Run unit tests
         timeout-minutes: 20
-        run: TEST_TIMEOUT=15m make unit-test-coverage
+        run: TEST_TIMEOUT=15m ./develop/github/monitor_test.sh make unit-test-coverage
+
+      - name: Print memory snapshot
+        if: always()
+        run: if [ -f /tmp/memory_snapshot.txt ]; then cat /tmp/memory_snapshot.txt; fi
 
       - name: Generate crash report
         if: failure() # if the tests failed, we would expect one JUnit XML report per attempt; otherwise it must have crashed
@@ -322,7 +326,11 @@ jobs:
 
       - name: Run integration test
         timeout-minutes: 15
-        run: make integration-test-coverage
+        run: ./develop/github/monitor_test.sh make integration-test-coverage
+
+      - name: Print memory snapshot
+        if: always()
+        run: if [ -f /tmp/memory_snapshot.txt ]; then cat /tmp/memory_snapshot.txt; fi
 
       - name: Generate crash report
         if: failure() # if the tests failed, we would expect one JUnit XML report per attempt; otherwise it must have crashed


### PR DESCRIPTION
## What changed?

1. Extended existing Go test memory monitor to include goroutine profile.
2. Changed snapshot to be of moment with _highest_ memory usage (instead of latest).
3. Unified report into a single one (both printing and disk snapshot).
4. (bonus) added monitor to unit and integration test jobs.

## Why?

Inspect where high goroutine count comes from.

## How did you test it?

Example: https://github.com/temporalio/temporal/actions/runs/21695994550/job/62566409323?pr=9162#step:10:17
