### PR TITLE
Silence old versioning flakes

### DIFF
--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -775,6 +775,7 @@ func (s *VersioningIntegSuite) unversionedWorkflowStaysUnversioned() {
 }
 
 func (s *VersioningIntegSuite) TestFirstWorkflowTaskAssignment_Spooled() {
+	s.T().Skip("Skipping test since rules based versioning is soon to be deprecated")
 	s.RunTestWithMatchingBehavior(s.firstWorkflowTaskAssignmentSpooled)
 }
 
@@ -887,6 +888,7 @@ func (s *VersioningIntegSuite) firstWorkflowTaskAssignmentSpooled() {
 }
 
 func (s *VersioningIntegSuite) TestFirstWorkflowTaskAssignment_SyncMatch() {
+	s.T().Skip("Skipping test since rules based versioning is soon to be deprecated")
 	s.RunTestWithMatchingBehavior(s.firstWorkflowTaskAssignmentSyncMatch)
 }
 


### PR DESCRIPTION
## What changed?
- WISOTT

## Why?
- Rules based versioning (v2) is soon to be deprecated. These tests are flaky and we want to turn them off.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- Just silencing some flakes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes test execution by skipping two cases; no production code or behavior is modified.
> 
> **Overview**
> **Disables two flaky integration tests for rules-based worker versioning.**
> 
> `TestFirstWorkflowTaskAssignment_Spooled` and `TestFirstWorkflowTaskAssignment_SyncMatch` in `tests/versioning_test.go` now call `s.T().Skip(...)`, effectively removing them from CI coverage while leaving the underlying helper logic intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a7ad75194d3e6743b30c52b9e030ca910eac54b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->