### PR TITLE
CHASM: Skip TrimHistoryBranch for non-workflows

### DIFF
--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -1046,6 +1046,13 @@ func (m *executionManagerImpl) trimHistoryNode(
 	runID string,
 	archetypeID chasm.ArchetypeID,
 ) {
+	if archetypeID != chasm.WorkflowArchetypeID {
+		// TODO: [chasm-events] remove this check when history events are supported
+		// in chasm framework.
+		// For now, we can return early and avoid unnecessary GetWorkflowExecution call.
+		return
+	}
+
 	response, err := m.GetWorkflowExecution(ctx, &GetWorkflowExecutionRequest{
 		ShardID:     shardID,
 		NamespaceID: namespaceID,
@@ -1068,6 +1075,11 @@ func (m *executionManagerImpl) trimHistoryNode(
 	if err != nil {
 		return
 	}
+	if len(branchToken) == 0 {
+		// Branch token can be empty if there is no history for chasm executions.
+		return
+	}
+
 	mutableStateLastNodeID := executionInfo.LastFirstEventId
 	mutableStateLastNodeTransactionID := executionInfo.LastFirstEventTxnId
 	if _, err := m.TrimHistoryBranch(ctx, &TrimHistoryBranchRequest{


### PR DESCRIPTION
## What changed?
- Skip TrimHistoryBranch for non-workflows

## Why?
- Chasm execution has no history and has empty branch token. Attempting TrimHistoryBranch causing an necessary mutable state load. The actual trim operation will also fail as the branch token is invalid.
- TrimHistoryBranch is only a best effort clean up operation when Update/ConflictResolveExecution fails due to a Conflict error. So even without the fix there's no real impact besides noisy error log which complains that TrimHistoryBranch has failed. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
