### PR TITLE
Improve multi-cursor reader stuck monitoring

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1695,6 +1695,17 @@ NOTE: The outbound queue has a separate configuration: outboundQueuePendingTaskC
 before that task range is split into a separate slice to unblock loading for later range.
 currently only work for scheduled queues and the task range is 1s.`,
 	)
+	QueueReaderStuckLagDuration = NewGlobalDurationSetting(
+		"history.queueReaderStuckLagDuration",
+		5*time.Second,
+		`QueueReaderStuckLagDuration is the minimum time the reader watermark must lag behind current time
+before triggering the reader stuck alert.`,
+	)
+	QueueReaderStuckShadowMode = NewGlobalBoolSetting(
+		"history.queueReaderStuckShadowMode",
+		true,
+		`QueueReaderStuckShadowMode controls whether reader stuck alerts are suppressed and only logged/metriced.`,
+	)
 	QueueCriticalSlicesCount = NewGlobalIntSetting(
 		"history.queueCriticalSlicesCount",
 		50,

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -862,6 +862,7 @@ var (
 	QueueReaderCountHistogram = NewDimensionlessHistogramDef("queue_reader_count")
 	QueueSliceCountHistogram  = NewDimensionlessHistogramDef("queue_slice_count")
 	QueueActionCounter        = NewCounterDef("queue_actions")
+	QueueAlertShadowCounter   = NewCounterDef("queue_alert_shadow")
 	ActivityE2ELatency        = NewTimerDef(
 		"activity_end_to_end_latency",
 		WithDescription("DEPRECATED: Will be removed in one of the next releases. Duration of an activity attempt. Use activity_start_to_close_latency instead."),

--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -186,6 +186,8 @@ func (f *archivalQueueFactory) newScheduledQueue(shard historyi.ShardContext, ex
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,
 				ReaderStuckCriticalAttempts: f.Config.QueueReaderStuckCriticalAttempts,
+				ReaderStuckLagDuration:      f.Config.QueueReaderStuckLagDuration,
+				ReaderStuckShadowMode:       f.Config.QueueReaderStuckShadowMode,
 				SliceCountCriticalThreshold: f.Config.QueueCriticalSlicesCount,
 			},
 			MaxPollRPS:                          f.Config.ArchivalProcessorMaxPollRPS,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -100,6 +100,8 @@ type Config struct {
 
 	QueuePendingTaskCriticalCount     dynamicconfig.IntPropertyFn
 	QueueReaderStuckCriticalAttempts  dynamicconfig.IntPropertyFn
+	QueueReaderStuckLagDuration       dynamicconfig.DurationPropertyFn
+	QueueReaderStuckShadowMode        dynamicconfig.BoolPropertyFn
 	QueueCriticalSlicesCount          dynamicconfig.IntPropertyFn
 	QueuePendingTaskMaxCount          dynamicconfig.IntPropertyFn
 	QueueMaxPredicateSize             dynamicconfig.IntPropertyFn
@@ -497,6 +499,8 @@ func NewConfig(
 
 		QueuePendingTaskCriticalCount:     dynamicconfig.QueuePendingTaskCriticalCount.Get(dc),
 		QueueReaderStuckCriticalAttempts:  dynamicconfig.QueueReaderStuckCriticalAttempts.Get(dc),
+		QueueReaderStuckLagDuration:       dynamicconfig.QueueReaderStuckLagDuration.Get(dc),
+		QueueReaderStuckShadowMode:        dynamicconfig.QueueReaderStuckShadowMode.Get(dc),
 		QueueCriticalSlicesCount:          dynamicconfig.QueueCriticalSlicesCount.Get(dc),
 		QueuePendingTaskMaxCount:          dynamicconfig.QueuePendingTaskMaxCount.Get(dc),
 		QueueMaxPredicateSize:             dynamicconfig.QueueMaxPredicateSize.Get(dc),

--- a/service/history/outbound_queue_factory.go
+++ b/service/history/outbound_queue_factory.go
@@ -285,6 +285,8 @@ func (f *outboundQueueFactory) CreateQueue(
 				PendingTasksCriticalCount: f.Config.OutboundQueuePendingTaskCriticalCount,
 				// Shared configuration with other queues.
 				ReaderStuckCriticalAttempts: f.Config.QueueReaderStuckCriticalAttempts,
+				ReaderStuckLagDuration:      f.Config.QueueReaderStuckLagDuration,
+				ReaderStuckShadowMode:       f.Config.QueueReaderStuckShadowMode,
 				SliceCountCriticalThreshold: f.Config.QueueCriticalSlicesCount,
 			},
 			MaxPollRPS:                          f.Config.OutboundProcessorMaxPollRPS,

--- a/service/history/queues/action_reader_stuck.go
+++ b/service/history/queues/action_reader_stuck.go
@@ -8,6 +8,8 @@ import (
 
 var _ Action = (*actionReaderStuck)(nil)
 
+const readerStuckActionName = "reader-stuck"
+
 type (
 	actionReaderStuck struct {
 		attributes *AlertAttributesReaderStuck
@@ -26,7 +28,7 @@ func newReaderStuckAction(
 }
 
 func (a *actionReaderStuck) Name() string {
-	return "reader-stuck"
+	return readerStuckActionName
 }
 
 func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) bool {

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -132,7 +132,7 @@ func newQueueBase(
 		exclusiveReaderHighWatermark = ackLevel
 	}
 
-	monitor := newMonitor(category.Type(), shard.GetTimeSource(), &options.MonitorOptions)
+	monitor := newMonitor(category.Type(), shard.GetTimeSource(), logger, metricsHandler, &options.MonitorOptions)
 	readerRateLimiter := newShardReaderRateLimiter(
 		options.MaxPollRPS,
 		hostReaderRateLimiter,

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -59,6 +59,8 @@ var testQueueOptions = Options{
 	MonitorOptions: MonitorOptions{
 		PendingTasksCriticalCount:   dynamicconfig.GetIntPropertyFn(1000),
 		ReaderStuckCriticalAttempts: dynamicconfig.GetIntPropertyFn(5),
+		ReaderStuckLagDuration:      dynamicconfig.GetDurationPropertyFn(0),
+		ReaderStuckShadowMode:       dynamicconfig.GetBoolPropertyFn(false),
 		SliceCountCriticalThreshold: dynamicconfig.GetIntPropertyFn(50),
 	},
 	MaxPollRPS:                          dynamicconfig.GetIntPropertyFn(20),

--- a/service/history/queues/reader_test.go
+++ b/service/history/queues/reader_test.go
@@ -80,9 +80,11 @@ func (s *readerSuite) SetupTest() {
 			telemetry.NoopTracer,
 		)
 	})
-	s.monitor = newMonitor(tasks.CategoryTypeScheduled, clock.NewRealTimeSource(), &MonitorOptions{
+	s.monitor = newMonitor(tasks.CategoryTypeScheduled, clock.NewRealTimeSource(), s.logger, s.metricsHandler, &MonitorOptions{
 		PendingTasksCriticalCount:   dynamicconfig.GetIntPropertyFn(1000),
 		ReaderStuckCriticalAttempts: dynamicconfig.GetIntPropertyFn(5),
+		ReaderStuckLagDuration:      dynamicconfig.GetDurationPropertyFn(0),
+		ReaderStuckShadowMode:       dynamicconfig.GetBoolPropertyFn(false),
 		SliceCountCriticalThreshold: dynamicconfig.GetIntPropertyFn(50),
 	})
 }

--- a/service/history/queues/slice_test.go
+++ b/service/history/queues/slice_test.go
@@ -77,9 +77,11 @@ func (s *sliceSuite) SetupTest() {
 			telemetry.NoopTracer,
 		)
 	})
-	s.monitor = newMonitor(tasks.CategoryTypeScheduled, clock.NewRealTimeSource(), &MonitorOptions{
+	s.monitor = newMonitor(tasks.CategoryTypeScheduled, clock.NewRealTimeSource(), log.NewTestLogger(), metrics.NoopMetricsHandler, &MonitorOptions{
 		PendingTasksCriticalCount:   dynamicconfig.GetIntPropertyFn(1000),
 		ReaderStuckCriticalAttempts: dynamicconfig.GetIntPropertyFn(5),
+		ReaderStuckLagDuration:      dynamicconfig.GetDurationPropertyFn(0),
+		ReaderStuckShadowMode:       dynamicconfig.GetBoolPropertyFn(false),
 		SliceCountCriticalThreshold: dynamicconfig.GetIntPropertyFn(50),
 	})
 }

--- a/service/history/timer_queue_factory.go
+++ b/service/history/timer_queue_factory.go
@@ -181,6 +181,8 @@ func (f *timerQueueFactory) CreateQueue(
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,
 				ReaderStuckCriticalAttempts: f.Config.QueueReaderStuckCriticalAttempts,
+				ReaderStuckLagDuration:      f.Config.QueueReaderStuckLagDuration,
+				ReaderStuckShadowMode:       f.Config.QueueReaderStuckShadowMode,
 				SliceCountCriticalThreshold: f.Config.QueueCriticalSlicesCount,
 			},
 			MaxPollRPS:                          f.Config.TimerProcessorMaxPollRPS,

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -174,6 +174,8 @@ func (f *transferQueueFactory) CreateQueue(
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,
 				ReaderStuckCriticalAttempts: f.Config.QueueReaderStuckCriticalAttempts,
+				ReaderStuckLagDuration:      f.Config.QueueReaderStuckLagDuration,
+				ReaderStuckShadowMode:       f.Config.QueueReaderStuckShadowMode,
 				SliceCountCriticalThreshold: f.Config.QueueCriticalSlicesCount,
 			},
 			MaxPollRPS:                          f.Config.TransferProcessorMaxPollRPS,

--- a/service/history/visibility_queue_factory.go
+++ b/service/history/visibility_queue_factory.go
@@ -143,6 +143,8 @@ func (f *visibilityQueueFactory) CreateQueue(
 			MonitorOptions: queues.MonitorOptions{
 				PendingTasksCriticalCount:   f.Config.QueuePendingTaskCriticalCount,
 				ReaderStuckCriticalAttempts: f.Config.QueueReaderStuckCriticalAttempts,
+				ReaderStuckLagDuration:      f.Config.QueueReaderStuckLagDuration,
+				ReaderStuckShadowMode:       f.Config.QueueReaderStuckShadowMode,
 				SliceCountCriticalThreshold: f.Config.QueueCriticalSlicesCount,
 			},
 			MaxPollRPS:                          f.Config.VisibilityProcessorMaxPollRPS,


### PR DESCRIPTION
## What changed?
- Only trigger reader stuck action when reader is actually lagging behind
- Add a shadow mode for reader stuck

## Why?
- Previous implementation is purely based on the # of read within one second, however when a shard is actively making progress and generating new tasks, it is normal for it to do hundreds of read per second and that should not trigger reader stuck action.
- The idea in this PR is that only split a second out when we are actually lagging in task loading AND we've already loaded that second too many time.
- Also adding a shadow mode to get confidence before actually enabling it.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- Reader stuck is currently effectively disable in cloud and shadow mode is enabled by default.
