### PR TITLE
Standalone Activities: add activity_ prefix to id_conflict/reuse_policy

### DIFF
--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -51,14 +51,14 @@ func newHandler(config *Config, metricsHandler metrics.Handler, logger log.Logge
 func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.StartActivityExecutionRequest) (*activitypb.StartActivityExecutionResponse, error) {
 	frontendReq := req.GetFrontendRequest()
 
-	reusePolicy, ok := businessIDReusePolicyMap[frontendReq.GetIdReusePolicy()]
+	reusePolicy, ok := businessIDReusePolicyMap[frontendReq.GetActivityIdReusePolicy()]
 	if !ok {
-		return nil, serviceerror.NewInvalidArgumentf("unsupported ID reuse policy: %v", frontendReq.GetIdReusePolicy())
+		return nil, serviceerror.NewInvalidArgumentf("unsupported ID reuse policy: %v", frontendReq.GetActivityIdReusePolicy())
 	}
 
-	conflictPolicy, ok := businessIDConflictPolicyMap[frontendReq.GetIdConflictPolicy()]
+	conflictPolicy, ok := businessIDConflictPolicyMap[frontendReq.GetActivityIdConflictPolicy()]
 	if !ok {
-		return nil, serviceerror.NewInvalidArgumentf("unsupported ID conflict policy: %v", frontendReq.GetIdConflictPolicy())
+		return nil, serviceerror.NewInvalidArgumentf("unsupported ID conflict policy: %v", frontendReq.GetActivityIdConflictPolicy())
 	}
 
 	result, err := chasm.StartExecution(

--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -166,12 +166,12 @@ func normalizeAndValidateTimeouts(
 }
 
 func normalizeAndValidateIDPolicy(req *workflowservice.StartActivityExecutionRequest) error {
-	if req.GetIdReusePolicy() == enumspb.ACTIVITY_ID_REUSE_POLICY_UNSPECIFIED {
-		req.IdReusePolicy = enumspb.ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE
+	if req.GetActivityIdReusePolicy() == enumspb.ACTIVITY_ID_REUSE_POLICY_UNSPECIFIED {
+		req.ActivityIdReusePolicy = enumspb.ACTIVITY_ID_REUSE_POLICY_ALLOW_DUPLICATE
 	}
 
-	if req.GetIdConflictPolicy() == enumspb.ACTIVITY_ID_CONFLICT_POLICY_UNSPECIFIED {
-		req.IdConflictPolicy = enumspb.ACTIVITY_ID_CONFLICT_POLICY_FAIL
+	if req.GetActivityIdConflictPolicy() == enumspb.ACTIVITY_ID_CONFLICT_POLICY_UNSPECIFIED {
+		req.ActivityIdConflictPolicy = enumspb.ACTIVITY_ID_CONFLICT_POLICY_FAIL
 	}
 
 	return nil


### PR DESCRIPTION
## What changed?
_Describe what has changed in this PR._
Add `activity_` prefix to existing fields

## Why?
_Tell your future self why have you made these changes._
https://github.com/temporalio/api/pull/707

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
Should be low/none, standalone activities not yet released

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical field rename/wiring change limited to standalone activity start/validation; main risk is misrouting defaults if callers still rely on deprecated unprefixed fields.
> 
> **Overview**
> Standalone activity start now reads ID reuse/conflict policy from the new `ActivityIdReusePolicy`/`ActivityIdConflictPolicy` request fields, including updated invalid-argument errors.
> 
> Validation/normalization likewise defaults the new fields when unspecified, ensuring standalone activities honor the `activity_`-prefixed API fields consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e8a21332b99bb980a3ba3db9f8993e48a74786d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->