### PR TITLE
Capture NotFound when trying to Delete workflow on replication stack

### DIFF
--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -785,6 +785,10 @@ func (e *ExecutableTaskImpl) DeleteWorkflow(
 		},
 		ClosedWorkflowOnly: false,
 	})
+	var notFoundErr *serviceerror.NotFound
+	if errors.As(err, &notFoundErr) {
+		return nil
+	}
 	return err
 }
 


### PR DESCRIPTION
## What changed?
Capture NotFound when trying to Delete workflow on replication stack

## Why?
If NotFound is returned, we can ack this task, instead of keep retrying

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
no risk.