### PR TITLE
Fix replication task processing latency metrics

### DIFF
--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -285,7 +285,9 @@ func (e *ExecutableTaskImpl) MarkTaskDuplicated() {
 }
 
 func (e *ExecutableTaskImpl) MarkExecutionStart() {
-	e.taskExecuteStartTime = time.Now().UTC()
+	if e.taskExecuteStartTime.IsZero() {
+		e.taskExecuteStartTime = time.Now().UTC()
+	}
 }
 
 func (e *ExecutableTaskImpl) GetPriority() enumsspb.TaskPriority {
@@ -346,6 +348,7 @@ func (e *ExecutableTaskImpl) emitFinishMetrics(
 				tag.WorkflowRunID(e.replicationTask.RawTaskInfo.RunId),
 				tag.ReplicationTask(e.replicationTask.GetRawTaskInfo()),
 				tag.ShardID(e.Config.GetShardID(namespace.ID(e.replicationTask.RawTaskInfo.NamespaceId), e.replicationTask.RawTaskInfo.WorkflowId)),
+				tag.AttemptCount(int64(e.Attempt())),
 			)
 		}
 	}


### PR DESCRIPTION
## What changed?
Fix replication task processing latency metrics

## Why?
We want to know the entire time it takes to process a replication task instead of one attempt. With this change, it will be easier to reasoning replication latency

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
no risk.