### PR TITLE
log: add consistent, shorthand log tag constructors

### DIFF
--- a/common/log/tag/zap_tag.go
+++ b/common/log/tag/zap_tag.go
@@ -105,6 +105,12 @@ func NewUInt32(key string, value uint32) ZapTag {
 	}
 }
 
+func NewUInt64(key string, value uint64) ZapTag {
+	return ZapTag{
+		field: zap.Uint64(key, value),
+	}
+}
+
 func NewFloat64(key string, value float64) ZapTag {
 	return ZapTag{
 		field: zap.Float64(key, value),
@@ -157,4 +163,70 @@ func NewBinaryTag(key string, value []byte) ZapTag {
 	return ZapTag{
 		field: zap.Binary(key, value),
 	}
+}
+
+// Shorter helpers (aliases for the New* functions above)
+
+func String(key string, value string) ZapTag {
+	return NewStringTag(key, value)
+}
+
+func Strings(key string, value []string) ZapTag {
+	return NewStringsTag(key, value)
+}
+
+func Stringer(key string, value fmt.Stringer) ZapTag {
+	return NewStringerTag(key, value)
+}
+
+func Stringers(key string, value []fmt.Stringer) ZapTag {
+	return NewStringersTag(key, value)
+}
+
+func Int64(key string, value int64) ZapTag {
+	return NewInt64(key, value)
+}
+
+func Int(key string, value int) ZapTag {
+	return NewInt(key, value)
+}
+
+func Int32(key string, value int32) ZapTag {
+	return NewInt32(key, value)
+}
+
+func UInt32(key string, value uint32) ZapTag {
+	return NewUInt32(key, value)
+}
+
+func UInt64(key string, value uint64) ZapTag {
+	return NewUInt64(key, value)
+}
+
+func Float64(key string, value float64) ZapTag {
+	return NewFloat64(key, value)
+}
+
+func Duration(key string, value time.Duration) ZapTag {
+	return NewDurationTag(key, value)
+}
+
+func DurationPtr(key string, value *durationpb.Duration) ZapTag {
+	return NewDurationPtrTag(key, value)
+}
+
+func Time(key string, value time.Time) ZapTag {
+	return NewTimeTag(key, value)
+}
+
+func TimePtr(key string, value *timestamppb.Timestamp) ZapTag {
+	return NewTimePtrTag(key, value)
+}
+
+func Any(key string, value any) ZapTag {
+	return NewAnyTag(key, value)
+}
+
+func Binary(key string, value []byte) ZapTag {
+	return NewBinaryTag(key, value)
 }


### PR DESCRIPTION
## What changed?

This PR adds _consistent_ shorthand tag constructors for all supported zap tags.

I also added `Uint64` (and `NewUint64`) as we've wanted it in other projects.

## Why?

There are two main reasons:
- I (and others I've talked to) are lazy and dislike typing `log.New<Type><TAB>` when `log.<Type>` would have done it
- Consistency! Some tags are just the type name (`Bool`, `Error`), some have a prefix of New (`NewInt64`), and some have a prefix _and_ a suffix of Tag (`NewStringTag`).

The new constructors are entirely consistent: no prefixes and no suffixes; just the type's name.

## How did you test it?
I didn't, yet. These wrap existing APIs.

## Potential risks
None.
