### PR TITLE
WorkerDeployment Read API's to have their own Rate Limiters!

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -737,6 +737,39 @@ If this is set, it overwrites the per instance limit configured with
 "frontend.namespaceRPS.namespaceReplicationInducingAPIs".
 This config is EXPERIMENTAL and may be changed or removed in a later release.`,
 	)
+	FrontendWorkerDeploymentReadAPIsRPS = NewGlobalIntSetting(
+		"frontend.rps.workerDeploymentReadAPIs",
+		10,
+		`FrontendWorkerDeploymentReadAPIsRPS limits the per second request rate for worker deployment read APIs
+(e.g. DescribeWorkerDeploymentVersion, DescribeWorkerDeployment).
+This config is EXPERIMENTAL and may be changed or removed in a later release.`,
+	)
+	FrontendMaxNamespaceWorkerDeploymentReadAPIsRPSPerInstance = NewNamespaceIntSetting(
+		"frontend.namespaceRPS.workerDeploymentReadAPIs",
+		10,
+		`FrontendMaxNamespaceWorkerDeploymentReadAPIsRPSPerInstance is a per host/per namespace RPS limit for
+worker deployment read APIs (e.g. DescribeWorkerDeploymentVersion, DescribeWorkerDeployment).
+This config is EXPERIMENTAL and may be changed or removed in a later release.`,
+	)
+	FrontendMaxNamespaceWorkerDeploymentReadAPIsBurstRatioPerInstance = NewNamespaceFloatSetting(
+		"frontend.namespaceBurstRatio.workerDeploymentReadAPIs",
+		10,
+		`FrontendMaxNamespaceWorkerDeploymentReadAPIsBurstRatioPerInstance is a per host/per namespace burst limit for
+worker deployment read APIs (e.g. DescribeWorkerDeploymentVersion, DescribeWorkerDeployment)
+as a ratio of namespace WorkerDeploymentReadAPIs RPS. The RPS used here will be the effective RPS from global and
+per-instance limits. This config is EXPERIMENTAL and may be changed or removed in a later release. The value must
+be 1 or higher.`,
+	)
+	FrontendGlobalNamespaceWorkerDeploymentReadAPIsRPS = NewNamespaceIntSetting(
+		"frontend.globalNamespaceRPS.workerDeploymentReadAPIs",
+		0,
+		`FrontendGlobalNamespaceWorkerDeploymentReadAPIsRPS is a cluster global, per namespace RPS limit for
+worker deployment read APIs (e.g. DescribeWorkerDeploymentVersion, DescribeWorkerDeployment).
+The limit is evenly distributed among available frontend service instances.
+If this is set, it overwrites the per instance limit configured with
+"frontend.namespaceRPS.workerDeploymentReadAPIs".
+This config is EXPERIMENTAL and may be changed or removed in a later release.`,
+	)
 	InternalFrontendGlobalNamespaceVisibilityRPS = NewNamespaceIntSetting(
 		"internal-frontend.globalNamespaceRPS.visibility",
 		0,

--- a/common/log/tag/values.go
+++ b/common/log/tag/values.go
@@ -127,6 +127,7 @@ var (
 	ComponentLongPollHandler           = component("long-poll-handler")
 	ComponentVisibilityHandler         = component("visibility-handler")
 	ComponentNamespaceReplication      = component("namespace-replication")
+	ComponentWorkerVersioning          = component("worker-versioning")
 	ComponentPersistence               = component("persistence")
 	ComponentWorkflowUpdate            = component("workflow-update")
 	ComponentTaskScheduler             = component("task-scheduler")

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -70,6 +70,10 @@ type Config struct {
 	GlobalNamespaceVisibilityRPS                                      dynamicconfig.IntPropertyFnWithNamespaceFilter
 	InternalFEGlobalNamespaceVisibilityRPS                            dynamicconfig.IntPropertyFnWithNamespaceFilter
 	GlobalNamespaceNamespaceReplicationInducingAPIsRPS                dynamicconfig.IntPropertyFnWithNamespaceFilter
+	WorkerDeploymentReadAPIsRPS                                       dynamicconfig.IntPropertyFn
+	MaxNamespaceWorkerDeploymentReadAPIsRPSPerInstance                dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxNamespaceWorkerDeploymentReadAPIsBurstRatioPerInstance         dynamicconfig.FloatPropertyFnWithNamespaceFilter
+	GlobalNamespaceWorkerDeploymentReadAPIsRPS                        dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxIDLengthLimit                                                  dynamicconfig.IntPropertyFn
 	WorkerBuildIdSizeLimit                                            dynamicconfig.IntPropertyFn
 	ReachabilityTaskQueueScanLimit                                    dynamicconfig.IntPropertyFn
@@ -294,6 +298,11 @@ func NewConfig(
 		InternalFEGlobalNamespaceVisibilityRPS: dynamicconfig.InternalFrontendGlobalNamespaceVisibilityRPS.Get(dc),
 		// Overshoot since these low rate limits don't work well in an uncoordinated global limiter.
 		GlobalNamespaceNamespaceReplicationInducingAPIsRPS: dynamicconfig.FrontendGlobalNamespaceNamespaceReplicationInducingAPIsRPS.Get(dc),
+
+		WorkerDeploymentReadAPIsRPS:                               dynamicconfig.FrontendWorkerDeploymentReadAPIsRPS.Get(dc),
+		MaxNamespaceWorkerDeploymentReadAPIsRPSPerInstance:        dynamicconfig.FrontendMaxNamespaceWorkerDeploymentReadAPIsRPSPerInstance.Get(dc),
+		MaxNamespaceWorkerDeploymentReadAPIsBurstRatioPerInstance: dynamicconfig.FrontendMaxNamespaceWorkerDeploymentReadAPIsBurstRatioPerInstance.Get(dc),
+		GlobalNamespaceWorkerDeploymentReadAPIsRPS:                dynamicconfig.FrontendGlobalNamespaceWorkerDeploymentReadAPIsRPS.Get(dc),
 
 		MaxIDLengthLimit:                         dynamicconfig.MaxIDLengthLimit.Get(dc),
 		WorkerBuildIdSizeLimit:                   dynamicconfig.WorkerBuildIdSizeLimit.Get(dc),


### PR DESCRIPTION
## What changed?
- WISOTT, mainly
- Also changed the grouping of the ListWorkerDeployments API to the Visibility API's, which seem to have a limit of 10 RPS.

## Why?
- Moreover, we noticed that a lot of folks were calling read WorkerDeployment API's (like DescribeDeploymentVersion) at 200 RPS. This is.....quite a lot.
- Right now, I noticed that there was no real way to change the rate limits for these specific API's unless I added a new RL for these. So I went ahead and did that. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- This is my first time working on RL stuff; would love a thorough review given that I did use a lot of existing code as my template.
