### PR TITLE
Add ActiveInCluster api to ReplicationResolver

### DIFF
--- a/common/namespace/namespace.go
+++ b/common/namespace/namespace.go
@@ -233,15 +233,13 @@ func (ns *Namespace) NotificationVersion() int64 {
 	return ns.notificationVersion
 }
 
-// ActiveInCluster returns whether the namespace is active, i.e. non global
-// namespace or global namespace which active cluster is the provided cluster
+// ActiveInCluster returns whether the namespace is active in the given cluster.
+// A namespace is considered active if it is either a local namespace or a global
+// namespace whose active cluster matches the provided cluster.
+// Note: Do not use this to determine if a workflow is active in the cluster.
+// Use ActiveClusterName(businessID) instead.
 func (ns *Namespace) ActiveInCluster(clusterName string) bool {
-	if !ns.replicationResolver.IsGlobalNamespace() {
-		// namespace is not a global namespace, meaning namespace is always
-		// "active" within each cluster
-		return true
-	}
-	return clusterName == ns.ActiveClusterName(EmptyBusinessID)
+	return ns.replicationResolver.ActiveInCluster(clusterName)
 }
 
 // ReplicationPolicy return the derived workflow replication policy

--- a/common/namespace/replication_resolver.go
+++ b/common/namespace/replication_resolver.go
@@ -7,6 +7,7 @@ import (
 
 type ReplicationResolver interface {
 	ActiveClusterName(businessID string) string
+	ActiveInCluster(clusterName string) bool
 	ClusterNames(businessID string) []string
 	ReplicationState() enumspb.ReplicationState
 	IsGlobalNamespace() bool
@@ -49,6 +50,15 @@ func (r *defaultReplicationResolver) ActiveClusterName(businessID string) string
 		return ""
 	}
 	return r.replicationConfig.ActiveClusterName
+}
+
+func (r *defaultReplicationResolver) ActiveInCluster(clusterName string) bool {
+	if !r.IsGlobalNamespace() {
+		// namespace is not a global namespace, meaning namespace is always
+		// "active" within each cluster
+		return true
+	}
+	return r.replicationConfig.ActiveClusterName == clusterName
 }
 
 func (r *defaultReplicationResolver) ClusterNames(businessID string) []string {


### PR DESCRIPTION
## What changed?
Add ActiveInCluster api to ReplicationResolver

## Why?
To move all replication related logic to replication resolver

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
no risk