### PR TITLE
Fix nexus forwarding criteria

### DIFF
--- a/components/nexusoperations/frontend/handler.go
+++ b/components/nexusoperations/frontend/handler.go
@@ -587,6 +587,5 @@ func (c *requestContext) shouldForwardRequest(ctx context.Context, header http.H
 	return redirectAllowed &&
 		c.RedirectionInterceptor.RedirectionAllowed(ctx) &&
 		c.namespace.IsGlobalNamespace() &&
-		len(c.namespace.ClusterNames(businessID)) > 1 &&
 		c.Config.ForwardingEnabledForNamespace(c.namespace.Name().String())
 }

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -274,7 +274,6 @@ func (c *operationContext) shouldForwardRequest(ctx context.Context, header nexu
 	return redirectAllowed &&
 		c.redirectionInterceptor.RedirectionAllowed(ctx) &&
 		c.namespace.IsGlobalNamespace() &&
-		len(c.namespace.ClusterNames(namespace.EmptyBusinessID)) > 1 &&
 		c.forwardingEnabledForNamespace(c.namespaceName)
 }
 


### PR DESCRIPTION
## What changed?
Fix nexus forwarding criteria

## Why?
We don't need this criteria to decide if we should forward. If ActiveCluster is not current cluster, then we can do forward.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
no risk.