### PR TITLE
Bump server version to 1.31.0

### DIFF
--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -23,7 +23,7 @@ const (
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
-	ServerVersion = "1.29.0"
+	ServerVersion = "1.31.0"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"


### PR DESCRIPTION
## Summary
- Bump server version from 1.29.0 to 1.31.0

## Test plan
- CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)