### PR TITLE
Add protogetter linter

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - godox
     - iotamixing
     - testifylint
+    - protogetter
   settings:
     staticcheck:
       checks:


### PR DESCRIPTION
## What changed?

Adds [protogetter](https://github.com/ghostiam/protogetter) linter. (it also supports auto fixing!)

## Why?

Using the protomessages getters has benefits:
1. Consistent style
2. Avoids accidental NPEs (see [protogetter README](https://github.com/ghostiam/protogetter) for example)
3. Ensures compatibility with the [new Opaque API](https://go.dev/blog/protobuf-opaque).

Only downside I can see is a (likely negligible) performance penalty. I expect them to get inlined, though, and then it becomes a single extra comparison instruction per field.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Example lint error:
```
service/frontend/workflow_handler.go:389:6: avoid direct access to proto field
  request.WorkflowId, use request.GetWorkflowId() instead (protogetter)
        _ = request.WorkflowId
```