### PR TITLE
CHASM: Remove output from StartExecution fn response

### DIFF
--- a/chasm/engine_mock.go
+++ b/chasm/engine_mock.go
@@ -92,14 +92,14 @@ func (mr *MockEngineMockRecorder) ReadComponent(arg0, arg1, arg2 any, arg3 ...an
 }
 
 // StartExecution mocks base method.
-func (m *MockEngine) StartExecution(arg0 context.Context, arg1 ComponentRef, arg2 func(MutableContext) (Component, error), arg3 ...TransitionOption) (EngineStartExecutionResult, error) {
+func (m *MockEngine) StartExecution(arg0 context.Context, arg1 ComponentRef, arg2 func(MutableContext) (Component, error), arg3 ...TransitionOption) (StartExecutionResult, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "StartExecution", varargs...)
-	ret0, _ := ret[0].(EngineStartExecutionResult)
+	ret0, _ := ret[0].(StartExecutionResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -67,20 +67,18 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 			NamespaceID: req.GetNamespaceId(),
 			BusinessID:  req.GetFrontendRequest().GetActivityId(),
 		},
-		func(mutableContext chasm.MutableContext, request *workflowservice.StartActivityExecutionRequest) (*Activity, *workflowservice.StartActivityExecutionResponse, error) {
+		func(mutableContext chasm.MutableContext, request *workflowservice.StartActivityExecutionRequest) (*Activity, error) {
 			newActivity, err := NewStandaloneActivity(mutableContext, request)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 
 			err = TransitionScheduled.Apply(newActivity, mutableContext, nil)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 
-			return newActivity, &workflowservice.StartActivityExecutionResponse{
-				// EagerTask: TODO when supported, need to call the same code that would handle the HandleStarted API
-			}, nil
+			return newActivity, nil
 		},
 		req.GetFrontendRequest(),
 		chasm.WithRequestID(req.GetFrontendRequest().GetRequestId()),
@@ -96,11 +94,12 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 		return nil, err
 	}
 
-	result.Output.RunId = result.ExecutionKey.RunID
-	result.Output.Started = result.Created
-
 	return &activitypb.StartActivityExecutionResponse{
-		FrontendResponse: result.Output,
+		FrontendResponse: &workflowservice.StartActivityExecutionResponse{
+			RunId:   result.ExecutionKey.RunID,
+			Started: result.Created,
+			// EagerTask: TODO when supported, need to call the same code that would handle the HandleStarted API
+		},
 	}, nil
 }
 

--- a/chasm/lib/scheduler/handler.go
+++ b/chasm/lib/scheduler/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/log"
@@ -28,7 +29,7 @@ func newHandler(logger log.Logger, specBuilder *legacyscheduler.SpecBuilder) *ha
 func (h *handler) CreateSchedule(ctx context.Context, req *schedulerpb.CreateScheduleRequest) (resp *schedulerpb.CreateScheduleResponse, err error) {
 	defer log.CapturePanic(h.logger, &err)
 
-	result, err := chasm.StartExecution(
+	_, err = chasm.StartExecution(
 		ctx,
 		chasm.ExecutionKey{
 			NamespaceID: req.NamespaceId,
@@ -44,7 +45,11 @@ func (h *handler) CreateSchedule(ctx context.Context, req *schedulerpb.CreateSch
 		return nil, serviceerror.NewAlreadyExistsf("schedule %q is already registered", req.FrontendRequest.ScheduleId)
 	}
 
-	return result.Output, nil
+	return &schedulerpb.CreateScheduleResponse{
+		FrontendResponse: &workflowservice.CreateScheduleResponse{
+			ConflictToken: initialSerializedConflictToken,
+		},
+	}, nil
 }
 
 func (h *handler) UpdateSchedule(ctx context.Context, req *schedulerpb.UpdateScheduleRequest) (resp *schedulerpb.UpdateScheduleResponse, err error) {

--- a/chasm/lib/scheduler/util.go
+++ b/chasm/lib/scheduler/util.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"encoding/binary"
 	"time"
 
 	"go.temporal.io/server/common/log"
@@ -21,6 +22,13 @@ func generateRequestID(scheduler *Scheduler, backfillID string, nominal, actual 
 		nominal,
 		actual,
 	)
+}
+
+// serializeConflictToken serializes a conflict token as a byte slice.
+func serializeConflictToken(conflictToken int64) []byte {
+	token := make([]byte, 8)
+	binary.LittleEndian.PutUint64(token, uint64(conflictToken))
+	return token
 }
 
 // newTaggedLogger returns a logger tagged with the Scheduler's attributes.

--- a/chasm/lib/tests/handler.go
+++ b/chasm/lib/tests/handler.go
@@ -81,9 +81,9 @@ func NewPayloadStoreHandler(
 			NamespaceID: request.NamespaceID.String(),
 			BusinessID:  request.StoreID,
 		},
-		func(mutableContext chasm.MutableContext, _ any) (*PayloadStore, any, error) {
+		func(mutableContext chasm.MutableContext, _ any) (*PayloadStore, error) {
 			store, err := NewPayloadStore(mutableContext)
-			return store, nil, err
+			return store, err
 		},
 		nil,
 		chasm.WithBusinessIDPolicy(request.IDReusePolicy, request.IDConflictPolicy),

--- a/service/history/chasm_engine.go
+++ b/service/history/chasm_engine.go
@@ -99,17 +99,17 @@ func (e *ChasmEngine) StartExecution(
 	executionRef chasm.ComponentRef,
 	startFn func(chasm.MutableContext) (chasm.Component, error),
 	opts ...chasm.TransitionOption,
-) (result chasm.EngineStartExecutionResult, retErr error) {
+) (result chasm.StartExecutionResult, retErr error) {
 	options := e.constructTransitionOptions(opts...)
 
 	shardContext, err := e.getShardContext(executionRef)
 	if err != nil {
-		return chasm.EngineStartExecutionResult{}, err
+		return chasm.StartExecutionResult{}, err
 	}
 
 	archetypeID, err := executionRef.ArchetypeID(e.registry)
 	if err != nil {
-		return chasm.EngineStartExecutionResult{}, err
+		return chasm.StartExecutionResult{}, err
 	}
 
 	currentExecutionReleaseFn, err := e.lockCurrentExecution(
@@ -120,7 +120,7 @@ func (e *ChasmEngine) StartExecution(
 		archetypeID,
 	)
 	if err != nil {
-		return chasm.EngineStartExecutionResult{}, err
+		return chasm.StartExecutionResult{}, err
 	}
 	defer func() {
 		currentExecutionReleaseFn(retErr)
@@ -135,7 +135,7 @@ func (e *ChasmEngine) StartExecution(
 		options,
 	)
 	if err != nil {
-		return chasm.EngineStartExecutionResult{}, err
+		return chasm.StartExecutionResult{}, err
 	}
 
 	currentRunInfo, hasCurrentRun, err := e.persistAsBrandNew(
@@ -147,18 +147,18 @@ func (e *ChasmEngine) StartExecution(
 		// Even though Created is false, it's not guaranteed the execution wasn't created.
 		// The persistence layer writes history events outside the main transaction, so on errors
 		// like network timeouts etc., the operation outcome is ambiguous.
-		return chasm.EngineStartExecutionResult{}, err
+		return chasm.StartExecutionResult{}, err
 	}
 	if !hasCurrentRun {
 		serializedRef, err := newExecutionParams.executionRef.Serialize(e.registry)
 		if err != nil {
 			// Created is true here because persistAsBrandNew succeeded, but we failed to serialize the ref.
-			return chasm.EngineStartExecutionResult{
+			return chasm.StartExecutionResult{
 				ExecutionKey: newExecutionParams.executionRef.ExecutionKey,
 				Created:      true,
 			}, err
 		}
-		return chasm.EngineStartExecutionResult{
+		return chasm.StartExecutionResult{
 			ExecutionKey: newExecutionParams.executionRef.ExecutionKey,
 			ExecutionRef: serializedRef,
 			Created:      true,
@@ -531,15 +531,15 @@ func (e *ChasmEngine) handleExecutionConflict(
 	newExecutionParams newExecutionParams,
 	currentRunInfo currentExecutionInfo,
 	options chasm.TransitionOptions,
-) (chasm.EngineStartExecutionResult, error) {
+) (chasm.StartExecutionResult, error) {
 	// Check if this a retried request using requestID.
 	if _, ok := currentRunInfo.RequestIDs[options.RequestID]; ok {
 		newExecutionParams.executionRef.RunID = currentRunInfo.RunID
 		serializedRef, err := newExecutionParams.executionRef.Serialize(e.registry)
 		if err != nil {
-			return chasm.EngineStartExecutionResult{}, err
+			return chasm.StartExecutionResult{}, err
 		}
-		return chasm.EngineStartExecutionResult{
+		return chasm.StartExecutionResult{
 			ExecutionKey: newExecutionParams.executionRef.ExecutionKey,
 			ExecutionRef: serializedRef,
 		}, nil
@@ -554,7 +554,7 @@ func (e *ChasmEngine) handleExecutionConflict(
 			nsEntry.IsGlobalNamespace(),
 			currentRunInfo.LastWriteVersion,
 		)
-		return chasm.EngineStartExecutionResult{}, serviceerror.NewNamespaceNotActive(
+		return chasm.StartExecutionResult{}, serviceerror.NewNamespaceNotActive(
 			nsEntry.Name().String(),
 			clusterMetadata.GetCurrentClusterName(),
 			clusterName,
@@ -567,7 +567,7 @@ func (e *ChasmEngine) handleExecutionConflict(
 	case enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED:
 		return e.handleReusePolicy(ctx, shardContext, newExecutionParams, currentRunInfo, options.ReusePolicy)
 	default:
-		return chasm.EngineStartExecutionResult{}, serviceerror.NewInternal(
+		return chasm.StartExecutionResult{}, serviceerror.NewInternal(
 			fmt.Sprintf("unexpected current run state when creating new execution: %v", currentRunInfo.State),
 		)
 	}
@@ -579,10 +579,10 @@ func (e *ChasmEngine) handleConflictPolicy(
 	newExecutionParams newExecutionParams,
 	currentRunInfo currentExecutionInfo,
 	conflictPolicy chasm.BusinessIDConflictPolicy,
-) (chasm.EngineStartExecutionResult, error) {
+) (chasm.StartExecutionResult, error) {
 	switch conflictPolicy {
 	case chasm.BusinessIDConflictPolicyFail:
-		return chasm.EngineStartExecutionResult{}, chasm.NewExecutionAlreadyStartedErr(
+		return chasm.StartExecutionResult{}, chasm.NewExecutionAlreadyStartedErr(
 			fmt.Sprintf(
 				"CHASM execution still running. BusinessID: %s, RunID: %s, ID Conflict Policy: %v",
 				newExecutionParams.executionRef.BusinessID,
@@ -603,20 +603,20 @@ func (e *ChasmEngine) handleConflictPolicy(
 		// and we may have a chain of runs all created via TerminateExisting policy, meaning
 		// replication has to replicated all of them transactionally.
 		// We need a way to break this chain into consistent pieces and replicate them one by one.
-		return chasm.EngineStartExecutionResult{}, serviceerror.NewUnimplemented("ID Conflict Policy Terminate Existing is not yet supported")
+		return chasm.StartExecutionResult{}, serviceerror.NewUnimplemented("ID Conflict Policy Terminate Existing is not yet supported")
 	case chasm.BusinessIDConflictPolicyUseExisting:
 		existingExecutionRef := newExecutionParams.executionRef
 		existingExecutionRef.RunID = currentRunInfo.RunID
 		serializedRef, err := existingExecutionRef.Serialize(e.registry)
 		if err != nil {
-			return chasm.EngineStartExecutionResult{}, err
+			return chasm.StartExecutionResult{}, err
 		}
-		return chasm.EngineStartExecutionResult{
+		return chasm.StartExecutionResult{
 			ExecutionKey: existingExecutionRef.ExecutionKey,
 			ExecutionRef: serializedRef,
 		}, nil
 	default:
-		return chasm.EngineStartExecutionResult{}, serviceerror.NewInternal(
+		return chasm.StartExecutionResult{}, serviceerror.NewInternal(
 			fmt.Sprintf("unknown business ID conflict policy: %v", conflictPolicy),
 		)
 	}
@@ -628,14 +628,14 @@ func (e *ChasmEngine) handleReusePolicy(
 	newExecutionParams newExecutionParams,
 	currentRunInfo currentExecutionInfo,
 	reusePolicy chasm.BusinessIDReusePolicy,
-) (chasm.EngineStartExecutionResult, error) {
+) (chasm.StartExecutionResult, error) {
 	switch reusePolicy {
 	case chasm.BusinessIDReusePolicyAllowDuplicate:
 		// No more check needed.
 		// Fallthrough to persist the new execution as current run.
 	case chasm.BusinessIDReusePolicyAllowDuplicateFailedOnly:
 		if _, ok := consts.FailedWorkflowStatuses[currentRunInfo.Status]; !ok {
-			return chasm.EngineStartExecutionResult{}, chasm.NewExecutionAlreadyStartedErr(
+			return chasm.StartExecutionResult{}, chasm.NewExecutionAlreadyStartedErr(
 				fmt.Sprintf(
 					"CHASM execution already completed successfully. BusinessID: %s, RunID: %s, ID Reuse Policy: %v",
 					newExecutionParams.executionRef.BusinessID,
@@ -648,7 +648,7 @@ func (e *ChasmEngine) handleReusePolicy(
 		}
 		// Fallthrough to persist the new execution as current run.
 	case chasm.BusinessIDReusePolicyRejectDuplicate:
-		return chasm.EngineStartExecutionResult{}, chasm.NewExecutionAlreadyStartedErr(
+		return chasm.StartExecutionResult{}, chasm.NewExecutionAlreadyStartedErr(
 			fmt.Sprintf(
 				"CHASM execution already finished. BusinessID: %s, RunID: %s, ID Reuse Policy: %v",
 				newExecutionParams.executionRef.BusinessID,
@@ -659,7 +659,7 @@ func (e *ChasmEngine) handleReusePolicy(
 			currentRunInfo.RunID,
 		)
 	default:
-		return chasm.EngineStartExecutionResult{}, serviceerror.NewInternal(
+		return chasm.StartExecutionResult{}, serviceerror.NewInternal(
 			fmt.Sprintf("unknown business ID reuse policy: %v", reusePolicy),
 		)
 	}
@@ -675,14 +675,14 @@ func (e *ChasmEngine) handleReusePolicy(
 		newExecutionParams.events,
 	)
 	if err != nil {
-		return chasm.EngineStartExecutionResult{}, err
+		return chasm.StartExecutionResult{}, err
 	}
 
 	serializedRef, err := newExecutionParams.executionRef.Serialize(e.registry)
 	if err != nil {
-		return chasm.EngineStartExecutionResult{ExecutionKey: newExecutionParams.executionRef.ExecutionKey, Created: true}, err
+		return chasm.StartExecutionResult{ExecutionKey: newExecutionParams.executionRef.ExecutionKey, Created: true}, err
 	}
-	return chasm.EngineStartExecutionResult{
+	return chasm.StartExecutionResult{
 		ExecutionKey: newExecutionParams.executionRef.ExecutionKey,
 		ExecutionRef: serializedRef,
 		Created:      true,


### PR DESCRIPTION
## What changed?
- Remove output from StartExecution fn response

## Why?
- When StartExecution reuses an existing execution (e.g. request deduped by requestID, or conflictPolicy is UseExisting), no new execution get created and the output from the StartFn is not persisted and may not be consistent with the existing execution. Returning output in this case doesn't really make sense and will cause confusion and bugs.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
