### PR TITLE
Reduce scheduler worker counts for tests

### DIFF
--- a/tests/testcore/dynamic_config_overrides.go
+++ b/tests/testcore/dynamic_config_overrides.go
@@ -44,6 +44,15 @@ var (
 		dynamicconfig.ExecutionsScannerEnabled.Key():                            false,
 		dynamicconfig.BuildIdScavengerEnabled.Key():                             false,
 
+		// Reduce scheduler worker counts for tests (don't need production-level parallelism).
+		dynamicconfig.TimerProcessorSchedulerWorkerCount.Key():                  128,
+		dynamicconfig.TransferProcessorSchedulerWorkerCount.Key():               128,
+		dynamicconfig.VisibilityProcessorSchedulerWorkerCount.Key():             128,
+		dynamicconfig.ArchivalProcessorSchedulerWorkerCount.Key():               128,
+		dynamicconfig.ReplicationProcessorSchedulerWorkerCount.Key():            128,
+		dynamicconfig.ReplicationLowPriorityProcessorSchedulerWorkerCount.Key(): 32,
+		dynamicconfig.MemoryTimerProcessorSchedulerWorkerCount.Key():            16,
+
 		// Better to read through in tests than add artificial sleeps (which is what we previously had).
 		dynamicconfig.ForceSearchAttributesCacheRefreshOnRead.Key(): true,
 


### PR DESCRIPTION
## What changed?

Adjusted worker counts for test clusters to 1/4.

## Why?

Reduce CPU and memory usage.

## How did you test it?
- [ ] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Comparison with latest main PR checks for `sqlite` (by shard):

| `main` | branch |
|--------|--------|
| [84%](https://github.com/temporalio/temporal/actions/runs/21687402010/job/62538354752#step:10:62) | [81%](https://github.com/temporalio/temporal/actions/runs/21687993062/job/62540455363?pr=9215#step:10:73) |
| [96%](https://github.com/temporalio/temporal/actions/runs/21687402010/job/62538354760#step:10:66) | [80%](https://github.com/temporalio/temporal/actions/runs/21687993062/job/62540455381?pr=9215#step:10:59) |
| [92%](https://github.com/temporalio/temporal/actions/runs/21687402010/job/62538354770#step:10:62) | [83%](https://github.com/temporalio/temporal/actions/runs/21687993062/job/62540455441?pr=9215#step:10:60) | 