### PR TITLE
Abridged tests on PRs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -535,7 +535,6 @@ jobs:
         env:
           TEST_TOTAL_SHARDS: ${{ matrix.total_shards }}
           TEST_SHARD_INDEX: ${{ matrix.total_shards && matrix.shard_index }} # guard with total_shards to avoid falsy eval of shard_index=0
-          TEST_SHARD_SALT: ${{ vars.TEST_SHARD_SALT || '-salt-26' }}
           TEST_ARGS: "${{ matrix.test_args }}"
 
       - name: Print memory snapshot


### PR DESCRIPTION
## What changed?

Running an abridged database coverage (unless on main/release branch or touching persistence)  

## Why?

Reduce PR failure rate by not running tests for every database setup.

Note that an earlier version of this PR also merged `xdc` and `ndc` with the other tests across shards but there were a couple of issues (e.g. xdc and ndc are not shard aware) that we'll address later.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Abridged run: https://github.com/temporalio/temporal/actions/runs/21849078475/job/63051453069
(note [smoke test](https://github.com/temporalio/temporal/actions/runs/21849078475/job/63051583242?pr=9216#step:10:99))

Full run: https://github.com/temporalio/temporal/actions/runs/21846314222/job/63043110945