### PR TITLE
Use 8 core test runners by default

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           shards=3
           timeout=35   # update this to TEST_TIMEOUT if you update the Makefile
-          runs_on='["ubuntu-latest"]'
+          runs_on='["ubuntu-latest-8-cores"]'
           if [[ "${{ inputs.run_single_functional_test }}" == "true" || "${{ inputs.run_single_unit_test }}" == "true" ]]; then
             shards=1
             timeout=${{ inputs.timeout_minutes }}
@@ -444,15 +444,11 @@ jobs:
             persistence_driver: cassandra
             containers: [cassandra, elasticsearch]
             es_version: v7
-            # Cassandra tests need a larger instance
-            runs_on_override: ubuntu-latest-8-cores
           - name: cass_es8
             persistence_type: nosql
             persistence_driver: cassandra
             containers: [cassandra, elasticsearch8]
             es_version: v8
-            # Cassandra tests need a larger instance
-            runs_on_override: ubuntu-latest-8-cores
           - name: cass_os2
             persistence_type: nosql
             persistence_driver: cassandra
@@ -477,7 +473,8 @@ jobs:
             persistence_type: sql
             persistence_driver: postgres12_pgx
             containers: [postgresql]
-    runs-on: ${{ (github.repository_owner == 'temporalio' && matrix.runs_on_override) || matrix.runs-on }}
+    # For forks, fall back to ubuntu-latest since custom runners are not available.
+    runs-on: ${{ github.repository_owner == 'temporalio' && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     env:
       TEST_TOTAL_SHARDS: ${{ needs.set-up-single-test.outputs.total_shards }}
       TEST_SHARD_INDEX: ${{ matrix.shard_index }}
@@ -619,15 +616,11 @@ jobs:
             persistence_driver: elasticsearch
             parallel_flags: ""
             containers: [cassandra, elasticsearch]
-            # Cassandra tests need a larger instance
-            runs_on_override: ubuntu-latest-8-cores
           - name: cass_es8
             persistence_type: nosql
             persistence_driver: elasticsearch
             parallel_flags: ""
             containers: [cassandra, elasticsearch8]
-            # Cassandra tests need a larger instance
-            runs_on_override: ubuntu-latest-8-cores
           - name: cass_os2
             persistence_type: nosql
             persistence_driver: cassandra
@@ -651,7 +644,8 @@ jobs:
             persistence_driver: postgres12_pgx
             parallel_flags: "-parallel=2" # reduce parallelism for postgres
             containers: [postgresql]
-    runs-on: ${{ (github.repository_owner == 'temporalio' && matrix.runs_on_override) || 'ubuntu-latest' }}
+    # For forks, fall back to ubuntu-latest since custom runners are not available.
+    runs-on: ${{ github.repository_owner == 'temporalio' && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     env:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}
@@ -780,15 +774,11 @@ jobs:
             persistence_driver: elasticsearch
             containers: [cassandra, elasticsearch]
             es_version: v7
-            # Cassandra tests need a larger instance
-            runs_on_override: ubuntu-latest-8-cores
           - name: cass_es8
             persistence_type: nosql
             persistence_driver: elasticsearch
             containers: [cassandra, elasticsearch8]
             es_version: v8
-            # Cassandra tests need a larger instance
-            runs_on_override: ubuntu-latest-8-cores
           - name: cass_os2
             persistence_type: nosql
             persistence_driver: cassandra
@@ -809,7 +799,8 @@ jobs:
             persistence_type: sql
             persistence_driver: postgres12_pgx
             containers: [postgresql]
-    runs-on: ${{ (github.repository_owner == 'temporalio' && matrix.runs_on_override) || 'ubuntu-latest' }}
+    # For forks, fall back to ubuntu-latest since custom runners are not available.
+    runs-on: ${{ github.repository_owner == 'temporalio' && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     env:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}


### PR DESCRIPTION
## What changed?

Run tests with 8 instead of 4 core runners.

## Why?

Speed up test execution by providing more memory and CPU.

Prevent OOM kills.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
