### PR TITLE
Add evicted ack cache to fairTaskReader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/temporalio/ringpop-go v0.0.0-20250130211428-b97329e994f7
 	github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb
 	github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938
+	github.com/tidwall/btree v1.8.1
 	github.com/uber-go/tally/v4 v4.1.17
 	github.com/urfave/cli v1.22.16
 	github.com/urfave/cli/v2 v2.27.5

--- a/go.sum
+++ b/go.sum
@@ -317,6 +317,8 @@ github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb/go.mod h1:143
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b/go.mod h1:c+V9Z/ZgkzAdyGvHrvC5AsXgN+M9Qwey04cBdKYzV7U=
 github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938 h1:sEJGhmDo+0FaPWM6f0v8Tjia0H5pR6/Baj6+kS78B+M=
 github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938/go.mod h1:ezRQRwu9KQXy8Wuuv1aaFFxoCNz5CeNbVOOkh3xctbY=
+github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
+github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/uber-common/bark v1.0.0/go.mod h1:g0ZuPcD7XiExKHynr93Q742G/sbrdVQkghrqLGOoFuY=

--- a/service/matching/fair_task_reader.go
+++ b/service/matching/fair_task_reader.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/emirpasic/gods/maps/treemap"
+	"github.com/tidwall/btree"
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
@@ -43,6 +44,12 @@ type (
 		ackLevel         fairLevel   // inclusive: task exactly at ackLevel _has_ been acked
 		atEnd            bool        // whether we believe outstandingTasks represents the entire queue right now
 
+		// Small cache of acked task levels that were evicted from outstandingTasks. When tasks
+		// are evicted from memory, we lose track of which ones were already acked. This cache
+		// helps avoid reprocessing tasks that we know were already acked but whose ack was
+		// evicted before it could be used to advance ackLevel.
+		evictedAcks *btree.BTreeG[fairLevel]
+
 		// Hold tasks written while a read is pending so we make sure to account for them in
 		// our read level.
 		newlyWrittenTasks []*persistencespb.AllocatedTaskInfo
@@ -68,6 +75,11 @@ const (
 	mergeWrite
 )
 
+// Max number of evicted ack levels to cache. This is a small cache to avoid
+// reprocessing tasks that were acked but whose acks were evicted before they
+// could be used to advance ackLevel.
+const evictedAcksCacheSize = 256
+
 func newFairTaskReader(
 	backlogMgr *fairBacklogManagerImpl,
 	subqueue subqueueIndex,
@@ -88,6 +100,7 @@ func newFairTaskReader(
 		outstandingTasks: *newFairLevelTreeMap(),
 		readLevel:        initialAckLevel,
 		ackLevel:         initialAckLevel,
+		evictedAcks:      btree.NewBTreeG(fairLevel.less),
 
 		// gc state
 		lastGCTime: time.Now(),
@@ -397,6 +410,9 @@ func (tr *fairTaskReader) mergeTasksLocked(tasks []*persistencespb.AllocatedTask
 			// If write/read race or we have to re-read a range, we may read something we had
 			// already added to the matcher or acked. Ignore tasks we already have.
 			continue
+		} else if _, have := tr.evictedAcks.Delete(level); have {
+			// This task was already acked but the ack was evicted. Skip it.
+			continue
 		}
 		merged.Put(level, t)
 	}
@@ -445,14 +461,19 @@ func (tr *fairTaskReader) mergeTasksLocked(tasks []*persistencespb.AllocatedTask
 	// We also have to remove any acked levels (nils) in outstandingTasks that are above our
 	// new read level (and accept reprocessing those tasks when we see them again), otherwise
 	// we may use these acks to increment our ack level across dropped ranges of tasks.
-	// TODO: we could add an additional cache to improve this
+	// Cache these evicted acks so we can skip them if we re-read them later.
 	tr.outstandingTasks.Select(func(k, v any) bool {
 		return v == nil && tr.readLevel.less(k.(fairLevel))
 	}).Each(func(k, v any) {
 		evictedAnyTasks = true
-		tr.outstandingTasks.Remove(k)
-		// TODO: metric for this?
+		level := k.(fairLevel) //nolint:revive
+		tr.outstandingTasks.Remove(level)
+		tr.evictedAcks.Set(level)
 	})
+	// Trim the cache to max size by removing highest levels.
+	for tr.evictedAcks.Len() > evictedAcksCacheSize {
+		tr.evictedAcks.PopMax()
+	}
 
 	internalTasks := make([]*internalTask, len(tasks))
 	for i, t := range tasks {


### PR DESCRIPTION
## What changed?
Add cache for evicted acks.
I'm planning to use `btree` for rewriting some more of the fairTaskReader and maybe priTaskMatcher data structures, so even though a new dependency seems like a lot for just this small feature, I wanted to start this one on it instead of the rb tree used elsewhere in matching.

## Why?
Avoid reprocessing tasks.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
