### PR TITLE
Retract v1.30.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.temporal.io/server
 go 1.25.5
 
 retract (
+	v1.30.0
 	v1.26.1 // Contains retractions only.
 	v1.26.0 // Published accidentally.
 )


### PR DESCRIPTION
## What changed?
Retract v1.30.0 since the release is paused. Following up with v1.30.1 release.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
