### PR TITLE
Nexus endpoint rate limiter

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -561,10 +561,10 @@ is currently processing a task.
 		`NexusEndpointListMaxPageSize is the maximum page size for listing Nexus endpoints.`,
 	)
 
-	FrontendGlobalNexusEndpointRPS = NewDestinationIntSetting(
-		"frontend.globalNexusEndpointRPS",
+	FrontendNexusEndpointRPS = NewDestinationIntSetting(
+		"frontend.nexusEndpointRPS",
 		0,
-		`FrontendGlobalNexusEndpointRPS is a per-endpoint, cluster-wide rate limit for Nexus
+		`FrontendNexusEndpointRPS is a per-endpoint, cluster-wide rate limit for Nexus
 dispatch requests, divided across frontend instances. 0 means unlimited. Configurable per
 endpoint using the "destination" constraint.`,
 	)

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -561,6 +561,14 @@ is currently processing a task.
 		`NexusEndpointListMaxPageSize is the maximum page size for listing Nexus endpoints.`,
 	)
 
+	FrontendGlobalNexusEndpointRPS = NewDestinationIntSetting(
+		"frontend.globalNexusEndpointRPS",
+		0,
+		`FrontendGlobalNexusEndpointRPS is a per-endpoint, cluster-wide rate limit for Nexus
+dispatch requests, divided across frontend instances. 0 means unlimited. Configurable per
+endpoint using the "destination" constraint.`,
+	)
+
 	RemovableBuildIdDurationSinceDefault = NewGlobalDurationSetting(
 		"worker.removableBuildIdDurationSinceDefault",
 		time.Hour,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -564,9 +564,17 @@ is currently processing a task.
 	FrontendNexusEndpointRPS = NewDestinationIntSetting(
 		"frontend.nexusEndpointRPS",
 		0,
-		`FrontendNexusEndpointRPS is a per-endpoint, cluster-wide rate limit for Nexus
+		`FrontendNexusEndpointRPS is a per-caller-per-endpoint, cluster-wide rate limit for Nexus
 dispatch requests, divided across frontend instances. 0 means unlimited. Configurable per
-endpoint using the "destination" constraint.`,
+caller namespace using the "namespace" constraint and per endpoint using the "destination" constraint.`,
+	)
+
+	FrontendNexusEndpointRPSBurstRatio = NewDestinationFloatSetting(
+		"frontend.nexusEndpointRPSBurstRatio",
+		2.0,
+		`FrontendNexusEndpointRPSBurstRatio is the burst ratio for the per-caller-per-endpoint Nexus rate limiter.
+Burst size is calculated as rate * ratio. Configurable per caller namespace using the "namespace" constraint
+and per endpoint using the "destination" constraint.`,
 	)
 
 	RemovableBuildIdDurationSinceDefault = NewGlobalDurationSetting(

--- a/common/quotas/request.go
+++ b/common/quotas/request.go
@@ -8,6 +8,7 @@ type (
 		CallerType    string
 		CallerSegment int32
 		Initiation    string
+		Destination   string
 	}
 )
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -854,6 +854,7 @@ func RegisterNexusHTTPHandler(
 	endpointRateLimiter := configs.NewNexusEndpointRateLimiter(
 		frontendServiceResolver,
 		serviceConfig.NexusEndpointRPS,
+		serviceConfig.NexusEndpointRPSBurstRatio,
 	)
 	h := NewNexusHTTPHandler(
 		serviceConfig,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -854,7 +854,6 @@ func RegisterNexusHTTPHandler(
 	endpointRateLimiter := configs.NewNexusEndpointRateLimiter(
 		frontendServiceResolver,
 		serviceConfig.NexusEndpointRPS,
-		logger,
 	)
 	h := NewNexusHTTPHandler(
 		serviceConfig,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -854,6 +854,7 @@ func RegisterNexusHTTPHandler(
 	endpointRateLimiter := configs.NewNexusEndpointRateLimiter(
 		frontendServiceResolver,
 		serviceConfig.NexusEndpointRPS,
+		logger,
 	)
 	h := NewNexusHTTPHandler(
 		serviceConfig,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -853,7 +853,7 @@ func RegisterNexusHTTPHandler(
 ) {
 	endpointRateLimiter := configs.NewNexusEndpointRateLimiter(
 		frontendServiceResolver,
-		serviceConfig.GlobalNexusEndpointRPS,
+		serviceConfig.NexusEndpointRPS,
 	)
 	h := NewNexusHTTPHandler(
 		serviceConfig,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -846,10 +846,15 @@ func RegisterNexusHTTPHandler(
 	namespaceCountLimiterInterceptor *interceptor.ConcurrentRequestLimitInterceptor,
 	namespaceValidatorInterceptor *interceptor.NamespaceValidatorInterceptor,
 	rateLimitInterceptor *interceptor.RateLimitInterceptor,
+	frontendServiceResolver membership.ServiceResolver,
 	logger log.Logger,
 	router *mux.Router,
 	httpTraceProvider nexus.HTTPClientTraceProvider,
 ) {
+	endpointRateLimiter := configs.NewNexusEndpointRateLimiter(
+		frontendServiceResolver,
+		serviceConfig.GlobalNexusEndpointRPS,
+	)
 	h := NewNexusHTTPHandler(
 		serviceConfig,
 		matchingClient,
@@ -866,6 +871,7 @@ func RegisterNexusHTTPHandler(
 		namespaceRateLimiterInterceptor,
 		namespaceCountLimiterInterceptor,
 		rateLimitInterceptor,
+		endpointRateLimiter,
 		logger,
 		httpTraceProvider,
 	)

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -235,14 +235,12 @@ func (c *operationContext) interceptRequest(
 	}
 
 	if c.endpointName != "" && c.endpointRateLimiter != nil {
-		if !c.endpointRateLimiter.Allow(time.Now().UTC(), quotas.NewRequest(
-			c.apiName,
-			1,
-			c.endpointName,
-			"",
-			0,
-			"",
-		)) {
+		if !c.endpointRateLimiter.Allow(time.Now().UTC(), quotas.Request{
+			API:         c.apiName,
+			Token:       1,
+			Caller:      c.namespaceName,
+			Destination: c.endpointName,
+		}) {
 			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("endpoint_rate_limited"))
 			return commonnexus.ConvertGRPCError(errNexusEndpointRateLimitBusy, true)
 		}

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -46,7 +46,7 @@ const (
 
 var errNexusEndpointRateLimitBusy = &serviceerror.ResourceExhausted{
 	Cause:   enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT,
-	Scope:   enumspb.RESOURCE_EXHAUSTED_SCOPE_SYSTEM,
+	Scope:   enumspb.RESOURCE_EXHAUSTED_SCOPE_NAMESPACE,
 	Message: "nexus endpoint rate limit exceeded",
 }
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -204,6 +204,7 @@ type Config struct {
 	NexusForwardRequestUseEndpoint dynamicconfig.BoolPropertyFn
 	NexusOperationsMetricTagConfig dynamicconfig.TypedPropertyFn[chasmnexus.NexusMetricTagConfig]
 	NexusEndpointRPS               dynamicconfig.TypedPropertyFnWithDestinationFilter[int]
+	NexusEndpointRPSBurstRatio     dynamicconfig.FloatPropertyFnWithDestinationFilter
 
 	LinkMaxSize        dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxLinksPerRequest dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -373,6 +374,7 @@ func NewConfig(
 		NexusForwardRequestUseEndpoint: dynamicconfig.FrontendNexusForwardRequestUseEndpointDispatch.Get(dc),
 		NexusOperationsMetricTagConfig: nexusoperations.MetricTagConfiguration.Get(dc),
 		NexusEndpointRPS:               dynamicconfig.FrontendNexusEndpointRPS.Get(dc),
+		NexusEndpointRPSBurstRatio:     dynamicconfig.FrontendNexusEndpointRPSBurstRatio.Get(dc),
 
 		LinkMaxSize:        dynamicconfig.FrontendLinkMaxSize.Get(dc),
 		MaxLinksPerRequest: dynamicconfig.FrontendMaxLinksPerRequest.Get(dc),

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -203,6 +203,7 @@ type Config struct {
 	NexusRequestHeadersBlacklist   dynamicconfig.TypedPropertyFn[*regexp.Regexp]
 	NexusForwardRequestUseEndpoint dynamicconfig.BoolPropertyFn
 	NexusOperationsMetricTagConfig dynamicconfig.TypedPropertyFn[chasmnexus.NexusMetricTagConfig]
+	GlobalNexusEndpointRPS         dynamicconfig.TypedPropertyFnWithDestinationFilter[int]
 
 	LinkMaxSize        dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxLinksPerRequest dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -371,6 +372,7 @@ func NewConfig(
 		NexusRequestHeadersBlacklist:   dynamicconfig.FrontendNexusRequestHeadersBlacklist.Get(dc),
 		NexusForwardRequestUseEndpoint: dynamicconfig.FrontendNexusForwardRequestUseEndpointDispatch.Get(dc),
 		NexusOperationsMetricTagConfig: nexusoperations.MetricTagConfiguration.Get(dc),
+		GlobalNexusEndpointRPS:         dynamicconfig.FrontendGlobalNexusEndpointRPS.Get(dc),
 
 		LinkMaxSize:        dynamicconfig.FrontendLinkMaxSize.Get(dc),
 		MaxLinksPerRequest: dynamicconfig.FrontendMaxLinksPerRequest.Get(dc),

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -203,7 +203,7 @@ type Config struct {
 	NexusRequestHeadersBlacklist   dynamicconfig.TypedPropertyFn[*regexp.Regexp]
 	NexusForwardRequestUseEndpoint dynamicconfig.BoolPropertyFn
 	NexusOperationsMetricTagConfig dynamicconfig.TypedPropertyFn[chasmnexus.NexusMetricTagConfig]
-	GlobalNexusEndpointRPS         dynamicconfig.TypedPropertyFnWithDestinationFilter[int]
+	NexusEndpointRPS               dynamicconfig.TypedPropertyFnWithDestinationFilter[int]
 
 	LinkMaxSize        dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxLinksPerRequest dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -372,7 +372,7 @@ func NewConfig(
 		NexusRequestHeadersBlacklist:   dynamicconfig.FrontendNexusRequestHeadersBlacklist.Get(dc),
 		NexusForwardRequestUseEndpoint: dynamicconfig.FrontendNexusForwardRequestUseEndpointDispatch.Get(dc),
 		NexusOperationsMetricTagConfig: nexusoperations.MetricTagConfiguration.Get(dc),
-		GlobalNexusEndpointRPS:         dynamicconfig.FrontendGlobalNexusEndpointRPS.Get(dc),
+		NexusEndpointRPS:               dynamicconfig.FrontendNexusEndpointRPS.Get(dc),
 
 		LinkMaxSize:        dynamicconfig.FrontendLinkMaxSize.Get(dc),
 		MaxLinksPerRequest: dynamicconfig.FrontendMaxLinksPerRequest.Get(dc),


### PR DESCRIPTION
## What changed?
Added a per-caller per-endpoint rate limiter for Nexus dispatch requests. A new dynamic config frontend.nexusEndpointRPS (type DestinationIntSetting, default 0 = unlimited) controls the limit.

## Why?
To control the total traffic processed by an endpoint from a caller. Existing rate limiters operate at namespace or global level and don't account for the caller level traffic on endpoints.

## How did you test it?
- [x] built
- [x] added new unit test(s)

