### PR TITLE
Change timeout type to schedule-to-close on attempt timeout when not enough time to schedule next attempt

### DIFF
--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -309,7 +309,7 @@ func (t *timerQueueActiveTaskExecutor) processSingleActivityTimeoutTask(
 	// always resolved as failed.
 	if retryState == enumspb.RETRY_STATE_TIMEOUT && timerSequenceID.TimerType != enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START {
 		timeoutFailure = failure.NewTimeoutFailure(
-			"not enough time to schedule next retry before activity schedule-to-close timeout, giving up retrying",
+			"Not enough time to schedule next retry before activity ScheduleToClose timeout, giving up retrying",
 			enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
 		)
 	}

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -817,7 +817,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPoli
 			s.Equal(enumspb.EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT, timeoutEvent.GetEventType())
 			timeoutAttributes := timeoutEvent.GetActivityTaskTimedOutEventAttributes()
 			s.Equal(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, timeoutAttributes.Failure.GetTimeoutFailureInfo().GetTimeoutType())
-			s.Contains(timeoutAttributes.Failure.Message, enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE.String())
+			s.Contains(timeoutAttributes.Failure.Message, "Not enough time to schedule next retry before activity ScheduleToClose timeout")
 			s.Equal(enumspb.RETRY_STATE_TIMEOUT, timeoutAttributes.RetryState)
 			return tests.UpdateWorkflowExecutionResponse, nil
 		})

--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -363,7 +363,7 @@ func (s *ActivityClientTestSuite) Test_ActivityTimeouts() {
 	timeoutErr, ok = activityErr.Unwrap().(*temporal.TimeoutError)
 	s.True(ok)
 	s.Equal(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, timeoutErr.TimeoutType())
-	s.Equal("not enough time to schedule next retry before activity schedule-to-close timeout, giving up retrying (type: ScheduleToClose)", timeoutErr.Error())
+	s.Equal("Not enough time to schedule next retry before activity ScheduleToClose timeout, giving up retrying (type: ScheduleToClose)", timeoutErr.Error())
 	s.True(timeoutErr.HasLastHeartbeatDetails())
 	v = 0
 	s.NoError(timeoutErr.LastHeartbeatDetails(&v))
@@ -374,7 +374,7 @@ func (s *ActivityClientTestSuite) Test_ActivityTimeouts() {
 	timeoutErr, ok = activityErr.Unwrap().(*temporal.TimeoutError)
 	s.True(ok)
 	s.Equal(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, timeoutErr.TimeoutType())
-	s.Equal("not enough time to schedule next retry before activity schedule-to-close timeout, giving up retrying (type: ScheduleToClose)", timeoutErr.Error())
+	s.Equal("Not enough time to schedule next retry before activity ScheduleToClose timeout, giving up retrying (type: ScheduleToClose)", timeoutErr.Error())
 }
 
 func (s *ActivityTestSuite) TestActivityHeartBeatWorkflow_Success() {


### PR DESCRIPTION
## What changed?

When an activity attempt times out and there is not enough time to schedule the next attempt, record `ActivityTaskTimedOut` with schedule-to-close timeout type and provide a clear message. 

## Why?

Noticed a regression of the behavior while running Java SDK tests with server 150. This change fixes the regression.
I added tests in the repo for this:
https://github.com/bergundy/temporal/blob/e747980e0edb0edc9ac8a90cc925edd68d9ef9f2/tests/activity_test.go#L361-L377

Verified that these added tests fail since https://github.com/temporalio/temporal/pull/9132. This PR reverts the behavior and adds a bit more information in the error message.

## How did you test it?
- [x] added new functional test(s)