### PR TITLE
Functional test for versioned queue unload

### DIFF
--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -5495,7 +5495,7 @@ func (s *Versioning3Suite) TestVersionedQueueUnload() {
 	// Ensure the task is backlogged by checking stats
 	s.validateBacklogCount(tv1, tqTypeWf, 1)
 
-	// Keep calling DescribeTaskQueue without asking for stats every second for 10 seconds to keep queue loaded
+	// Ensure the default queue is loaded by sending long polls for user data for 10 seconds
 	keepAliveDone := make(chan struct{})
 	go func() {
 		defer close(keepAliveDone)
@@ -5507,7 +5507,6 @@ func (s *Versioning3Suite) TestVersionedQueueUnload() {
 			case <-timeout:
 				return
 			case <-ticker.C:
-				// ensure the defaul queue is not unloaded by sending long polls for user data
 				smallCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
 				_, _ = s.GetTestCluster().MatchingClient().GetTaskQueueUserData(smallCtx, &matchingservice.GetTaskQueueUserDataRequest{
 					NamespaceId:   s.NamespaceID().String(),


### PR DESCRIPTION
## What changed?
Functional test for https://github.com/temporalio/temporal/pull/9238

## Why?
We like testing!

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

## Potential risks
None
