### PR TITLE
Improve TestEnv

### DIFF
--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -9,10 +9,8 @@ import (
 	"maps"
 	"os"
 	"regexp"
-	"strconv"
 	"time"
 
-	"github.com/dgryski/go-farm"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -346,30 +344,7 @@ func (s *FunctionalTestBase) initAssertions() {
 
 // checkTestShard supports test sharding based on environment variables.
 func (s *FunctionalTestBase) checkTestShard() {
-	totalStr := os.Getenv("TEST_TOTAL_SHARDS")
-	indexStr := os.Getenv("TEST_SHARD_INDEX")
-	if totalStr == "" || indexStr == "" {
-		return
-	}
-	total, err := strconv.Atoi(totalStr)
-	if err != nil || total < 1 {
-		s.T().Fatal("Couldn't convert TEST_TOTAL_SHARDS")
-	}
-	index, err := strconv.Atoi(indexStr)
-	if err != nil || index < 0 || index >= total {
-		s.T().Fatal("Couldn't convert TEST_SHARD_INDEX")
-	}
-
-	salt := os.Getenv("TEST_SHARD_SALT")
-	if salt == "" {
-		s.T().Fatal("TEST_SHARD_SALT must be set when sharding is enabled")
-	}
-	nameToHash := s.T().Name() + salt
-	testIndex := int(farm.Fingerprint32([]byte(nameToHash))) % total
-	if testIndex != index {
-		s.T().Skipf("Skipping %s in test shard %d/%d (it runs in %d)", s.T().Name(), index+1, total, testIndex+1)
-	}
-	s.T().Logf("Running %s in test shard %d/%d", s.T().Name(), index+1, total)
+	checkTestShard(s.T())
 }
 
 func ApplyTestClusterOptions(options []TestClusterOption) TestClusterParams {

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -2,10 +2,13 @@ package testcore
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/dgryski/go-farm"
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -18,13 +21,14 @@ import (
 )
 
 var (
-	_                Env = (*testEnv)(nil)
-	sequentialSuites sync.Map
+	_                Env      = (*testEnv)(nil)
+	sequentialSuites sync.Map // map[string]*sequentialSuite
 )
 
 type Env interface {
 	T() *testing.T
 	Namespace() namespace.Name
+	NamespaceID() namespace.ID
 	FrontendClient() workflowservice.WorkflowServiceClient
 	GetTestCluster() *TestCluster
 	CloseShard(namespaceID string, workflowID string)
@@ -40,6 +44,7 @@ type testEnv struct {
 
 	cluster    *TestCluster
 	nsName     namespace.Name
+	nsID       namespace.ID
 	taskPoller *taskpoller.TaskPoller
 	t          *testing.T
 	tv         *testvars.TestVars
@@ -80,9 +85,16 @@ func WithDynamicConfig(setting dynamicconfig.GenericSetting, value any) TestOpti
 	}
 }
 
+// sequentialSuite holds state for a suite marked with MustRunSequential.
+// It manages a single dedicated cluster shared by all tests in the suite.
+type sequentialSuite struct {
+	cluster *FunctionalTestBase
+}
+
 // MustRunSequential marks a test suite to run its tests sequentially instead
 // of in parallel. Call this at the start of your test suite before any
-// subtests are created.
+// subtests are created. A single dedicated cluster will be created for this
+// suite and torn down when the suite completes.
 func MustRunSequential(t *testing.T, reason string) {
 	if strings.Contains(t.Name(), "/") {
 		panic("MustRunSequential must be called from a top-level test, not a subtest")
@@ -90,18 +102,37 @@ func MustRunSequential(t *testing.T, reason string) {
 	if reason == "" {
 		panic("MustRunSequential requires a reason")
 	}
-	sequentialSuites.Store(t.Name(), true)
+
+	// Create a dedicated cluster for this suite.
+	suite := &sequentialSuite{
+		cluster: testClusterPool.createCluster(t, nil, false),
+	}
+	sequentialSuites.Store(t.Name(), suite)
+
+	// Register cleanup to tear down the suite's cluster when the parent test completes.
+	t.Cleanup(func() {
+		sequentialSuites.Delete(t.Name())
+		if err := suite.cluster.testCluster.TearDownCluster(); err != nil {
+			t.Logf("Failed to tear down sequential suite cluster: %v", err)
+		}
+	})
 }
 
 // NewEnv creates a new test environment with access to a Temporal cluster.
-// Tests are run in parallel - use MustRunSequential to run suite sequentially.
+//
+// By default, tests are marked as parallel. Use MustRunSequential on the
+// test's parent `testing.T` to run them sequentially instead.
 func NewEnv(t *testing.T, opts ...TestOption) *testEnv {
+	// Check test sharding early, before any expensive operations.
+	checkTestShard(t)
+
 	// Check if this is a sequential suite by looking up the parent test name.
 	suiteName := t.Name()
 	if idx := strings.Index(suiteName, "/"); idx != -1 {
 		suiteName = suiteName[:idx]
 	}
-	if _, sequential := sequentialSuites.Load(suiteName); !sequential {
+	suiteVal, sequential := sequentialSuites.Load(suiteName)
+	if !sequential {
 		t.Parallel()
 	}
 
@@ -110,28 +141,37 @@ func NewEnv(t *testing.T, opts ...TestOption) *testEnv {
 		opt(&options)
 	}
 
-	// For dedicated clusters, pass all dynamic config settings at cluster creation.
-	var startupConfig map[dynamicconfig.Key]any
-	if options.dedicatedCluster && len(options.dynamicConfigSettings) > 0 {
-		startupConfig = make(map[dynamicconfig.Key]any, len(options.dynamicConfigSettings))
-		for _, override := range options.dynamicConfigSettings {
-			startupConfig[override.setting.Key()] = override.value
+	var base *FunctionalTestBase
+	if sequential {
+		// Sequential suites use a single dedicated cluster for all tests.
+		suite := suiteVal.(*sequentialSuite)
+		base = suite.cluster
+		base.SetT(t)
+	} else {
+		// For dedicated clusters, pass all dynamic config settings at cluster creation.
+		var startupConfig map[dynamicconfig.Key]any
+		if options.dedicatedCluster && len(options.dynamicConfigSettings) > 0 {
+			startupConfig = make(map[dynamicconfig.Key]any, len(options.dynamicConfigSettings))
+			for _, override := range options.dynamicConfigSettings {
+				startupConfig[override.setting.Key()] = override.value
+			}
 		}
-	}
 
-	// Obtain the test cluster from the pool.
-	base := testClusterPool.get(t, options.dedicatedCluster, startupConfig)
+		// Obtain the test cluster from the pool.
+		base = testClusterPool.get(t, options.dedicatedCluster, startupConfig)
+	}
 	cluster := base.GetTestCluster()
 
 	// Create a dedicated namespace for the test to help with test isolation.
 	ns := namespace.Name(RandomizeStr(t.Name()))
-	if _, err := base.RegisterNamespace(
+	nsID, err := base.RegisterNamespace(
 		ns,
 		1, // 1 day retention
 		enumspb.ARCHIVAL_STATE_DISABLED,
 		"",
 		"",
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatalf("Failed to register namespace: %v", err)
 	}
 
@@ -141,6 +181,7 @@ func NewEnv(t *testing.T, opts ...TestOption) *testEnv {
 		HistoryRequire:     historyrequire.New(t),
 		cluster:            cluster,
 		nsName:             ns,
+		nsID:               nsID,
 		Logger:             base.Logger,
 		taskPoller:         taskpoller.New(t, cluster.FrontendClient(), ns.String()),
 		t:                  t,
@@ -160,6 +201,10 @@ func NewEnv(t *testing.T, opts ...TestOption) *testEnv {
 // Use test env-specific namespace here for test isolation.
 func (e *testEnv) Namespace() namespace.Name {
 	return e.nsName
+}
+
+func (e *testEnv) NamespaceID() namespace.ID {
+	return e.nsID
 }
 
 func (e *testEnv) TaskPoller() *taskpoller.TaskPoller {
@@ -211,4 +256,33 @@ func canBeNamespaceScoped(p dynamicconfig.Precedence) bool {
 	default:
 		return false
 	}
+}
+
+// checkTestShard supports test sharding based on environment variables.
+// This distributes tests across multiple CI shards for parallel execution.
+func checkTestShard(t *testing.T) {
+	totalStr := os.Getenv("TEST_TOTAL_SHARDS")
+	indexStr := os.Getenv("TEST_SHARD_INDEX")
+	if totalStr == "" || indexStr == "" {
+		return
+	}
+	total, err := strconv.Atoi(totalStr)
+	if err != nil || total < 1 {
+		t.Fatal("Couldn't convert TEST_TOTAL_SHARDS")
+	}
+	index, err := strconv.Atoi(indexStr)
+	if err != nil || index < 0 || index >= total {
+		t.Fatal("Couldn't convert TEST_SHARD_INDEX")
+	}
+
+	salt := os.Getenv("TEST_SHARD_SALT")
+	if salt == "" {
+		t.Fatal("TEST_SHARD_SALT must be set when sharding is enabled")
+	}
+	nameToHash := t.Name() + salt
+	testIndex := int(farm.Fingerprint32([]byte(nameToHash))) % total
+	if testIndex != index {
+		t.Skipf("Skipping %s in test shard %d/%d (it runs in %d)", t.Name(), index+1, total, testIndex+1)
+	}
+	t.Logf("Running %s in test shard %d/%d", t.Name(), index+1, total)
 }


### PR DESCRIPTION
## What changed?

Improved TestEnv:

1. When using `MustRunSequential`, ensures the cluster is only used by _that_ suite
2. Makes namespace ID available, too (not just name)
3. Applies test sharding

## Why?

Make TestEnv behave like testify suites while we migrate suites over.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

This PR was extracted from a suite migration where this is used: https://github.com/temporalio/temporal/pull/9191