### PR TITLE
Use ARM for more jobs

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read
 jobs:
   lint-actions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
         with:
@@ -24,7 +24,7 @@ jobs:
         shell: bash
 
   lint-protos:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
         with:
@@ -44,7 +44,7 @@ jobs:
           make lint-protos
 
   lint-api:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
         with:
@@ -64,7 +64,7 @@ jobs:
           make lint-api
 
   lint-workflows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
         with:
@@ -83,7 +83,7 @@ jobs:
         run: make workflowcheck
 
   fmt-imports:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
         with:
@@ -108,7 +108,7 @@ jobs:
           fi
 
   lint-yaml:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
         with:
@@ -123,7 +123,7 @@ jobs:
         run: make lint-yaml
 
   golangci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
         with:
@@ -156,7 +156,7 @@ jobs:
       - fmt-imports
       - lint-yaml
       - golangci
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: always()
     env:
       RESULTS: ${{ toJSON(needs.*.result) }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -106,7 +106,7 @@ jobs:
   misc-checks:
     name: Misc checks
     needs: [pre-build, set-up-functional-test]
-    runs-on: ${{ needs.set-up-functional-test.outputs.runner_x64 }}
+    runs-on: ${{ needs.set-up-functional-test.outputs.runner_arm }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -145,7 +145,7 @@ jobs:
   unit-test:
     name: Unit test
     needs: [pre-build, set-up-functional-test]
-    runs-on: ${{ needs.set-up-functional-test.outputs.runner_x64 }}
+    runs-on: ${{ needs.set-up-functional-test.outputs.runner_arm }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## What changed?

Changed GitHub runners to ARM for selected jobs that are run on each PR.

Note that integration tests were not converted as they require Docker containers and that didn't succeed for all of them out of the box. Future work ...

## Why?

<img width="582" height="438" alt="Screenshot 2026-02-09 at 1 14 44 PM" src="https://github.com/user-attachments/assets/b8509b12-3e14-4c50-808a-37dd1f2eaa5b" />

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

