### PR TITLE
Enable Go cache for linter jobs

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           go-version-file: "go.mod"
           check-latest: true
+          cache: true
 
       - name: lint actions
         run: |
@@ -34,6 +35,7 @@ jobs:
         with:
           go-version-file: "go.mod"
           check-latest: true
+          cache: true
 
       - uses: arduino/setup-protoc@v3
         with:
@@ -54,6 +56,7 @@ jobs:
         with:
           go-version-file: "go.mod"
           check-latest: true
+          cache: true
 
       - uses: arduino/setup-protoc@v3
         with:
@@ -74,6 +77,7 @@ jobs:
         with:
           go-version-file: "go.mod"
           check-latest: true
+          cache: true
 
       - uses: arduino/setup-protoc@v3
         with:
@@ -93,6 +97,7 @@ jobs:
         with:
           go-version-file: "go.mod"
           check-latest: true
+          cache: true
 
       - name: format golang import statements
         run: |
@@ -118,6 +123,7 @@ jobs:
         with:
           go-version-file: "go.mod"
           check-latest: true
+          cache: true
 
       - name: check yaml formatting
         run: make lint-yaml
@@ -133,6 +139,7 @@ jobs:
         with:
           go-version-file: "go.mod"
           check-latest: true
+          cache: true
 
       - name: lint code
         run: |


### PR DESCRIPTION
## What changed?

Enabled Go cache for linter jobs.

## Why?

Slightly faster ...

<img width="594" height="349" alt="Screenshot 2026-02-09 at 4 27 20 PM" src="https://github.com/user-attachments/assets/a5251dd4-a182-4f25-9ddb-f4f71e36145f" />

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

