### PR TITLE
Record the cause when pausing a stream.

### DIFF
--- a/service/history/replication/stream_receiver.go
+++ b/service/history/replication/stream_receiver.go
@@ -244,23 +244,23 @@ func (r *StreamReceiverImpl) ackMessage(
 			r.logger.Warn("Tiered stack mode. Have to wait for both high and low priority tracker received at least one batch of tasks before acking.")
 			return 0, nil
 		}
-		highPriorityFlowControlCommand := r.flowController.GetFlowControlInfo(enumsspb.TASK_PRIORITY_HIGH)
-		if highPriorityFlowControlCommand == enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_PAUSE {
-			r.logger.Warn(fmt.Sprintf("pausing High Priority Tasks, current size: %v, lowWatermark: %v", r.highPriorityTaskTracker.Size(), highPriorityWaterMarkInfo.Watermark))
+		highPriorityFlowControlInfo := r.flowController.GetFlowControlInfo(enumsspb.TASK_PRIORITY_HIGH)
+		if highPriorityFlowControlInfo.Command == enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_PAUSE {
+			r.logger.Warn(fmt.Sprintf("pausing High Priority Tasks: %s", highPriorityFlowControlInfo.Cause))
 		}
 		highPriorityWatermark = &replicationspb.ReplicationState{
 			InclusiveLowWatermark:     highPriorityWaterMarkInfo.Watermark,
 			InclusiveLowWatermarkTime: timestamppb.New(highPriorityWaterMarkInfo.Timestamp),
-			FlowControlCommand:        highPriorityFlowControlCommand,
+			FlowControlCommand:        highPriorityFlowControlInfo.Command,
 		}
-		lowPriorityFlowControlCommand := r.flowController.GetFlowControlInfo(enumsspb.TASK_PRIORITY_LOW)
-		if lowPriorityFlowControlCommand == enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_PAUSE {
-			r.logger.Warn(fmt.Sprintf("pausing Low Priority Tasks, current size: %v, lowWatermark: %v", r.lowPriorityTaskTracker.Size(), lowPriorityWaterMarkInfo.Watermark))
+		lowPriorityFlowControlInfo := r.flowController.GetFlowControlInfo(enumsspb.TASK_PRIORITY_LOW)
+		if lowPriorityFlowControlInfo.Command == enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_PAUSE {
+			r.logger.Warn(fmt.Sprintf("pausing Low Priority Tasks: %s", lowPriorityFlowControlInfo.Cause))
 		}
 		lowPriorityWatermark = &replicationspb.ReplicationState{
 			InclusiveLowWatermark:     lowPriorityWaterMarkInfo.Watermark,
 			InclusiveLowWatermarkTime: timestamppb.New(lowPriorityWaterMarkInfo.Timestamp),
-			FlowControlCommand:        lowPriorityFlowControlCommand,
+			FlowControlCommand:        lowPriorityFlowControlInfo.Command,
 		}
 		if highPriorityWaterMarkInfo.Watermark <= lowPriorityWaterMarkInfo.Watermark {
 			inclusiveLowWaterMark = highPriorityWaterMarkInfo.Watermark

--- a/service/history/replication/stream_receiver_flow_controller_mock.go
+++ b/service/history/replication/stream_receiver_flow_controller_mock.go
@@ -41,10 +41,10 @@ func (m *MockReceiverFlowController) EXPECT() *MockReceiverFlowControllerMockRec
 }
 
 // GetFlowControlInfo mocks base method.
-func (m *MockReceiverFlowController) GetFlowControlInfo(priority enums.TaskPriority) enums.ReplicationFlowControlCommand {
+func (m *MockReceiverFlowController) GetFlowControlInfo(priority enums.TaskPriority) FlowControlInfo {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFlowControlInfo", priority)
-	ret0, _ := ret[0].(enums.ReplicationFlowControlCommand)
+	ret0, _ := ret[0].(FlowControlInfo)
 	return ret0
 }
 

--- a/service/history/replication/stream_receiver_test.go
+++ b/service/history/replication/stream_receiver_test.go
@@ -238,8 +238,8 @@ func (s *streamReceiverSuite) TestAckMessage_SyncStatus_ReceiverModeTieredStack(
 	}
 	s.highPriorityTaskTracker.EXPECT().LowWatermark().Return(highWatermarkInfo)
 	s.lowPriorityTaskTracker.EXPECT().LowWatermark().Return(lowWatermarkInfo)
-	s.receiverFlowController.EXPECT().GetFlowControlInfo(enumsspb.TASK_PRIORITY_HIGH).Return(enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_RESUME)
-	s.receiverFlowController.EXPECT().GetFlowControlInfo(enumsspb.TASK_PRIORITY_LOW).Return(enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_PAUSE)
+	s.receiverFlowController.EXPECT().GetFlowControlInfo(enumsspb.TASK_PRIORITY_HIGH).Return(FlowControlInfo{Command: enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_RESUME})
+	s.receiverFlowController.EXPECT().GetFlowControlInfo(enumsspb.TASK_PRIORITY_LOW).Return(FlowControlInfo{Command: enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_PAUSE, Cause: "test cause"})
 	s.highPriorityTaskTracker.EXPECT().Size().Return(0).AnyTimes()
 	s.lowPriorityTaskTracker.EXPECT().Size().Return(0).AnyTimes()
 	_, err := s.streamReceiver.ackMessage(s.stream)


### PR DESCRIPTION
## What changed?
Add a cause to flow info.

## Why?
Allows accurate logging of the reason for a pause, now that we have multiple.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is largely unchanged (still pauses/resumes under the same conditions) and the change is confined to flow-control plumbing plus logging/test updates.
> 
> **Overview**
> Enhances replication stream receiver flow control to return a structured `FlowControlInfo` containing both the pause/resume command and a human-readable *cause* when pausing (e.g., outstanding task count over limit or recent slow submissions).
> 
> Updates `ackMessage` to log pause events using this cause while still sending only the `FlowControlCommand` in replication state, and adjusts mocks/tests to assert on the new return type and cause content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77cdfec8ee3bd159eb5c3462b854ae73826a8493. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->