### PR TITLE
CHASM: Avoid double map lookup in registry

### DIFF
--- a/chasm/registrable_component.go
+++ b/chasm/registrable_component.go
@@ -14,9 +14,10 @@ type (
 		componentType string
 		goType        reflect.Type
 
-		// Those two fields are initialized when the component is registered to a library.
+		// Following three fields are initialized when the component is registered to a library.
 		library     namer
 		componentID uint32
+		fqn         string
 
 		ephemeral     bool
 		singleCluster bool
@@ -161,10 +162,9 @@ func (rc *RegistrableComponent) registerToLibrary(
 	}
 
 	rc.library = library
-
-	fqn := rc.fqType()
-	rc.componentID = GenerateTypeID(fqn)
-	return fqn, rc.componentID, nil
+	rc.fqn = FullyQualifiedName(rc.library.Name(), rc.componentType)
+	rc.componentID = GenerateTypeID(rc.fqn)
+	return rc.fqn, rc.componentID, nil
 }
 
 // SearchAttributesMapper returns the search attributes mapper for this component.
@@ -198,9 +198,9 @@ func (rc *RegistrableComponent) GoType() reflect.Type {
 // the library name and the component type. This is used to uniquely identify
 // the component in the registry.
 func (rc *RegistrableComponent) fqType() string {
-	if rc.library == nil {
+	if rc.fqn == "" {
 		// this should never happen because the component is only accessible from the library.
 		panic("component is not registered to a library")
 	}
-	return FullyQualifiedName(rc.library.Name(), rc.componentType)
+	return rc.fqn
 }

--- a/chasm/registry.go
+++ b/chasm/registry.go
@@ -18,14 +18,17 @@ var (
 
 type (
 	Registry struct {
-		libraries         map[string]Library                     // library name -> library
-		componentByType   map[string]*RegistrableComponent       // fully qualified type name -> component
-		componentFqnByID  map[uint32]string                      // component ID -> fully qualified type name
-		componentByGoType map[reflect.Type]*RegistrableComponent // component go type -> component
+		libraries map[string]Library // library name -> library
 
-		taskByType   map[string]*RegistrableTask       // fully qualified type name -> task
-		taskFqnByID  map[uint32]string                 // task type ID -> fully qualified type name
-		taskByGoType map[reflect.Type]*RegistrableTask // task go type -> task
+		// rc stands for RegistrableComponent.
+		rcByFqn    map[string]*RegistrableComponent       // fully qualified type name -> component
+		rcByID     map[uint32]*RegistrableComponent       // component type ID -> component
+		rcByGoType map[reflect.Type]*RegistrableComponent // component go type -> component
+
+		// rt stands for RegistrableTask.
+		rtByFqn    map[string]*RegistrableTask       // fully qualified type name -> task
+		rtByID     map[uint32]*RegistrableTask       // task type ID -> task
+		rtByGoType map[reflect.Type]*RegistrableTask // task go type -> task
 
 		logger log.Logger
 	}
@@ -33,14 +36,14 @@ type (
 
 func NewRegistry(logger log.Logger) *Registry {
 	return &Registry{
-		libraries:         make(map[string]Library),
-		componentByType:   make(map[string]*RegistrableComponent),
-		componentFqnByID:  make(map[uint32]string),
-		componentByGoType: make(map[reflect.Type]*RegistrableComponent),
-		taskByType:        make(map[string]*RegistrableTask),
-		taskFqnByID:       make(map[uint32]string),
-		taskByGoType:      make(map[reflect.Type]*RegistrableTask),
-		logger:            logger,
+		libraries:  make(map[string]Library),
+		rcByFqn:    make(map[string]*RegistrableComponent),
+		rcByID:     make(map[uint32]*RegistrableComponent),
+		rcByGoType: make(map[reflect.Type]*RegistrableComponent),
+		rtByFqn:    make(map[string]*RegistrableTask),
+		rtByID:     make(map[uint32]*RegistrableTask),
+		rtByGoType: make(map[reflect.Type]*RegistrableTask),
+		logger:     logger,
 	}
 }
 
@@ -77,15 +80,18 @@ func (r *Registry) RegisterServices(server *grpc.Server) {
 // This method should only be used by CHASM framework internal code,
 // NOT CHASM library developers.
 func (r *Registry) ComponentFqnByID(id uint32) (string, bool) {
-	fqn, ok := r.componentFqnByID[id]
-	return fqn, ok
+	rc, ok := r.rcByID[id]
+	if !ok {
+		return "", false
+	}
+	return rc.fqType(), true
 }
 
 // ComponentIDByFqn converts fully qualified component type name to component type ID.
 // This method should only be used by CHASM framework internal code,
 // NOT CHASM library developers.
 func (r *Registry) ComponentIDByFqn(fqn string) (uint32, bool) {
-	rc, ok := r.componentByType[fqn]
+	rc, ok := r.rcByFqn[fqn]
 	if !ok {
 		return 0, false
 	}
@@ -93,12 +99,11 @@ func (r *Registry) ComponentIDByFqn(fqn string) (uint32, bool) {
 }
 
 // ComponentByID returns the registrable component for a given archetype ID.
+// This method should only be used by CHASM framework internal code,
+// NOT CHASM library developers.
 func (r *Registry) ComponentByID(id uint32) (*RegistrableComponent, bool) {
-	fqn, ok := r.componentFqnByID[id]
-	if !ok {
-		return nil, false
-	}
-	return r.component(fqn)
+	rc, ok := r.rcByID[id]
+	return rc, ok
 }
 
 // ComponentIDFor converts registered component instance to component type ID.
@@ -113,16 +118,22 @@ func (r *Registry) ComponentIDFor(componentInstance any) (uint32, bool) {
 }
 
 // TaskByID returns the registrable task for a given task type ID.
+// This method should only be used by CHASM framework internal code,
+// NOT CHASM library developers.
 func (r *Registry) TaskByID(id uint32) (*RegistrableTask, bool) {
-	return r.taskByID(id)
+	rt, ok := r.rtByID[id]
+	return rt, ok
 }
 
 // TaskFqnByID converts task type ID to fully qualified task type name.
 // This method should only be used by CHASM framework internal code,
 // NOT CHASM library developers.
 func (r *Registry) TaskFqnByID(id uint32) (string, bool) {
-	fqn, ok := r.taskFqnByID[id]
-	return fqn, ok
+	rt, ok := r.rtByID[id]
+	if !ok {
+		return "", false
+	}
+	return rt.fqType(), true
 }
 
 // TaskIDFor converts registered task instance to task type ID.
@@ -136,32 +147,9 @@ func (r *Registry) TaskIDFor(taskInstance any) (uint32, bool) {
 	return rt.taskTypeID, true
 }
 
-func (r *Registry) component(fqn string) (*RegistrableComponent, bool) {
-	rc, ok := r.componentByType[fqn]
-	return rc, ok
-}
-
-func (r *Registry) task(fqn string) (*RegistrableTask, bool) {
-	rt, ok := r.taskByType[fqn]
-	return rt, ok
-}
-
-func (r *Registry) componentFor(componentInstance any) (*RegistrableComponent, bool) {
-	rc, ok := r.componentByGoType[reflect.TypeOf(componentInstance)]
-	return rc, ok
-}
-
-func (r *Registry) taskFor(taskInstance any) (*RegistrableTask, bool) {
-	rt, ok := r.taskByGoType[reflect.TypeOf(taskInstance)]
-	return rt, ok
-}
-
-func (r *Registry) componentOf(componentGoType reflect.Type) (*RegistrableComponent, bool) {
-	rc, ok := r.componentByGoType[componentGoType]
-	return rc, ok
-}
-
 // ArchetypeDisplayName returns the human-readable name for a given archetype ID.
+// This method should only be used by CHASM framework internal code,
+// NOT CHASM library developers.
 func (r *Registry) ArchetypeDisplayName(id ArchetypeID) (string, bool) {
 	rc, ok := r.ComponentByID(id)
 	if !ok {
@@ -171,27 +159,44 @@ func (r *Registry) ArchetypeDisplayName(id ArchetypeID) (string, bool) {
 }
 
 // ArchetypeIDOf returns the ArchetypeID for the given component Go type.
-// This method should only be used by CHASM framework internal,
+// This method should only be used by CHASM framework internal code,
 // NOT CHASM library developers.
 func (r *Registry) ArchetypeIDOf(componentGoType reflect.Type) (ArchetypeID, bool) {
-	rc, ok := r.componentByGoType[componentGoType]
+	rc, ok := r.rcByGoType[componentGoType]
 	if !ok {
 		return UnspecifiedArchetypeID, false
 	}
 	return rc.componentID, true
 }
 
-func (r *Registry) taskOf(taskGoType reflect.Type) (*RegistrableTask, bool) {
-	rt, ok := r.taskByGoType[taskGoType]
+func (r *Registry) component(fqn string) (*RegistrableComponent, bool) {
+	rc, ok := r.rcByFqn[fqn]
+	return rc, ok
+}
+
+func (r *Registry) task(fqn string) (*RegistrableTask, bool) {
+	rt, ok := r.rtByFqn[fqn]
 	return rt, ok
 }
 
-func (r *Registry) taskByID(id uint32) (*RegistrableTask, bool) {
-	fqn, ok := r.taskFqnByID[id]
-	if !ok {
-		return nil, false
-	}
-	return r.task(fqn)
+func (r *Registry) componentFor(componentInstance any) (*RegistrableComponent, bool) {
+	rc, ok := r.rcByGoType[reflect.TypeOf(componentInstance)]
+	return rc, ok
+}
+
+func (r *Registry) taskFor(taskInstance any) (*RegistrableTask, bool) {
+	rt, ok := r.rtByGoType[reflect.TypeOf(taskInstance)]
+	return rt, ok
+}
+
+func (r *Registry) componentOf(componentGoType reflect.Type) (*RegistrableComponent, bool) {
+	rc, ok := r.rcByGoType[componentGoType]
+	return rc, ok
+}
+
+func (r *Registry) taskOf(taskGoType reflect.Type) (*RegistrableTask, bool) {
+	rt, ok := r.rtByGoType[taskGoType]
+	return rt, ok
 }
 
 func (r *Registry) registerComponent(
@@ -207,7 +212,7 @@ func (r *Registry) registerComponent(
 		return err
 	}
 
-	if _, ok := r.componentByType[fqn]; ok {
+	if _, ok := r.rcByFqn[fqn]; ok {
 		return fmt.Errorf("component %s is already registered", fqn)
 	}
 
@@ -215,8 +220,8 @@ func (r *Registry) registerComponent(
 		return fmt.Errorf("component %s maps to a reserved archetype id %d, please use a different name", fqn, UnspecifiedArchetypeID)
 	}
 
-	if existingComponentFqn, ok := r.componentFqnByID[id]; ok {
-		return fmt.Errorf("component ID %d collision between %s and %s", id, fqn, existingComponentFqn)
+	if existingComponent, ok := r.rcByID[id]; ok {
+		return fmt.Errorf("component ID %d collision between %s and %s", id, fqn, existingComponent.fqType())
 	}
 
 	// rc.goType implements Component interface; therefore, it must be a struct.
@@ -225,14 +230,14 @@ func (r *Registry) registerComponent(
 		(rc.goType.Kind() == reflect.Ptr && rc.goType.Elem().Kind() == reflect.Struct)) {
 		return fmt.Errorf("component type %s must be struct or pointer to struct", rc.goType.String())
 	}
-	if _, ok := r.componentByGoType[rc.goType]; ok {
+	if _, ok := r.rcByGoType[rc.goType]; ok {
 		return fmt.Errorf("component type %s is already registered", rc.goType.String())
 	}
 	r.warnUnmanagedFields(fqn, rc)
 
-	r.componentByType[fqn] = rc
-	r.componentFqnByID[id] = fqn
-	r.componentByGoType[rc.goType] = rc
+	r.rcByFqn[fqn] = rc
+	r.rcByID[id] = rc
+	r.rcByGoType[rc.goType] = rc
 	return nil
 }
 
@@ -256,19 +261,19 @@ func (r *Registry) registerTask(
 		return err
 	}
 
-	if _, ok := r.taskByType[fqn]; ok {
+	if _, ok := r.rtByFqn[fqn]; ok {
 		return fmt.Errorf("task %s is already registered", fqn)
 	}
 
-	if existingTaskFqn, ok := r.taskFqnByID[id]; ok {
-		return fmt.Errorf("task type ID %d collision between %s and %s", id, fqn, existingTaskFqn)
+	if existingTask, ok := r.rtByID[id]; ok {
+		return fmt.Errorf("task type ID %d collision between %s and %s", id, fqn, existingTask.fqType())
 	}
 
 	if !(rt.goType.Kind() == reflect.Struct ||
 		(rt.goType.Kind() == reflect.Ptr && rt.goType.Elem().Kind() == reflect.Struct)) {
 		return fmt.Errorf("task type %s must be struct or pointer to struct", rt.goType.String())
 	}
-	if _, ok := r.taskByGoType[rt.goType]; ok {
+	if _, ok := r.rtByGoType[rt.goType]; ok {
 		return fmt.Errorf("task type %s is already registered", rt.goType.String())
 	}
 	if !(rt.componentGoType.Kind() == reflect.Interface ||
@@ -278,9 +283,9 @@ func (r *Registry) registerTask(
 		return fmt.Errorf("component type %s must be and interface or struct that implements Component interface", rt.componentGoType.String())
 	}
 
-	r.taskByType[fqn] = rt
-	r.taskFqnByID[id] = fqn
-	r.taskByGoType[rt.goType] = rt
+	r.rtByFqn[fqn] = rt
+	r.rtByID[id] = rt
+	r.rtByGoType[rt.goType] = rt
 	return nil
 }
 

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -1788,7 +1788,7 @@ func (n *Node) closeTransactionUpdateComponentTasks(
 func (n *Node) deserializeComponentTask(
 	componentTask *persistencespb.ChasmComponentAttributes_Task,
 ) (any, error) {
-	registableTask, ok := n.registry.taskByID(componentTask.TypeId)
+	registableTask, ok := n.registry.TaskByID(componentTask.TypeId)
 	if !ok {
 		return nil, softassert.UnexpectedInternalErr(
 			n.logger,
@@ -2975,7 +2975,7 @@ func (n *Node) ValidateSideEffectTask(
 
 	taskInfo := chasmTask.Info
 	taskTypeID := taskInfo.TypeId
-	registrableTask, ok := n.registry.taskByID(taskTypeID)
+	registrableTask, ok := n.registry.TaskByID(taskTypeID)
 	if !ok {
 		return false, softassert.UnexpectedInternalErr(
 			n.logger,
@@ -3060,7 +3060,7 @@ func (n *Node) ExecuteSideEffectTask(
 
 	taskInfo := chasmTask.Info
 	taskTypeID := taskInfo.TypeId
-	registrableTask, ok := registry.taskByID(taskTypeID)
+	registrableTask, ok := registry.TaskByID(taskTypeID)
 	if !ok {
 		return softassert.UnexpectedInternalErr(
 			n.logger,


### PR DESCRIPTION
## What changed?
- Avoid double map look up when getting registableComponent/Task by ID

## Why?
- Minor performance improvement.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
