### PR TITLE
CHASM: support archetypeID in admin handler

### DIFF
--- a/api/adminservice/v1/request_response.pb.go
+++ b/api/adminservice/v1/request_response.pb.go
@@ -317,8 +317,10 @@ type DescribeMutableStateRequest struct {
 	Execution       *v1.WorkflowExecution  `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
 	SkipForceReload bool                   `protobuf:"varint,3,opt,name=skip_force_reload,json=skipForceReload,proto3" json:"skip_force_reload,omitempty"`
 	Archetype       string                 `protobuf:"bytes,4,opt,name=archetype,proto3" json:"archetype,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// (-- api-linter: core::0141::forbidden-types=disabled --)
+	ArchetypeId   uint32 `protobuf:"varint,5,opt,name=archetype_id,json=archetypeId,proto3" json:"archetype_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DescribeMutableStateRequest) Reset() {
@@ -377,6 +379,13 @@ func (x *DescribeMutableStateRequest) GetArchetype() string {
 		return x.Archetype
 	}
 	return ""
+}
+
+func (x *DescribeMutableStateRequest) GetArchetypeId() uint32 {
+	if x != nil {
+		return x.ArchetypeId
+	}
+	return 0
 }
 
 type DescribeMutableStateResponse struct {
@@ -3149,10 +3158,12 @@ func (x *MergeDLQMessagesResponse) GetNextPageToken() []byte {
 }
 
 type RefreshWorkflowTasksRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	NamespaceId   string                 `protobuf:"bytes,3,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty"`
-	Execution     *v1.WorkflowExecution  `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
-	Archetype     string                 `protobuf:"bytes,4,opt,name=archetype,proto3" json:"archetype,omitempty"`
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	NamespaceId string                 `protobuf:"bytes,3,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty"`
+	Execution   *v1.WorkflowExecution  `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
+	Archetype   string                 `protobuf:"bytes,4,opt,name=archetype,proto3" json:"archetype,omitempty"`
+	// (-- api-linter: core::0141::forbidden-types=disabled --)
+	ArchetypeId   uint32 `protobuf:"varint,5,opt,name=archetype_id,json=archetypeId,proto3" json:"archetype_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3206,6 +3217,13 @@ func (x *RefreshWorkflowTasksRequest) GetArchetype() string {
 		return x.Archetype
 	}
 	return ""
+}
+
+func (x *RefreshWorkflowTasksRequest) GetArchetypeId() uint32 {
+	if x != nil {
+		return x.ArchetypeId
+	}
+	return 0
 }
 
 type RefreshWorkflowTasksResponse struct {
@@ -3541,10 +3559,12 @@ func (x *GetTaskQueueTasksResponse) GetNextPageToken() []byte {
 }
 
 type DeleteWorkflowExecutionRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Namespace     string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	Execution     *v1.WorkflowExecution  `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
-	Archetype     string                 `protobuf:"bytes,3,opt,name=archetype,proto3" json:"archetype,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Namespace string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Execution *v1.WorkflowExecution  `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
+	Archetype string                 `protobuf:"bytes,3,opt,name=archetype,proto3" json:"archetype,omitempty"`
+	// (-- api-linter: core::0141::forbidden-types=disabled --)
+	ArchetypeId   uint32 `protobuf:"varint,4,opt,name=archetype_id,json=archetypeId,proto3" json:"archetype_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3598,6 +3618,13 @@ func (x *DeleteWorkflowExecutionRequest) GetArchetype() string {
 		return x.Archetype
 	}
 	return ""
+}
+
+func (x *DeleteWorkflowExecutionRequest) GetArchetypeId() uint32 {
+	if x != nil {
+		return x.ArchetypeId
+	}
+	return 0
 }
 
 type DeleteWorkflowExecutionResponse struct {
@@ -5004,8 +5031,10 @@ type GenerateLastHistoryReplicationTasksRequest struct {
 	Execution      *v1.WorkflowExecution  `protobuf:"bytes,2,opt,name=execution,proto3" json:"execution,omitempty"`
 	TargetClusters []string               `protobuf:"bytes,3,rep,name=target_clusters,json=targetClusters,proto3" json:"target_clusters,omitempty"`
 	Archetype      string                 `protobuf:"bytes,4,opt,name=archetype,proto3" json:"archetype,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// (-- api-linter: core::0141::forbidden-types=disabled --)
+	ArchetypeId   uint32 `protobuf:"varint,5,opt,name=archetype_id,json=archetypeId,proto3" json:"archetype_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GenerateLastHistoryReplicationTasksRequest) Reset() {
@@ -5064,6 +5093,13 @@ func (x *GenerateLastHistoryReplicationTasksRequest) GetArchetype() string {
 		return x.Archetype
 	}
 	return ""
+}
+
+func (x *GenerateLastHistoryReplicationTasksRequest) GetArchetypeId() uint32 {
+	if x != nil {
+		return x.ArchetypeId
+	}
+	return 0
 }
 
 type GenerateLastHistoryReplicationTasksResponse struct {
@@ -5766,12 +5802,13 @@ const file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc = 
 	"\x0fversion_history\x18\x04 \x01(\v2..temporal.server.api.history.v1.VersionHistoryR\x0eversionHistory\x12\x14\n" +
 	"\x05token\x18\x05 \x01(\fR\x05token\"7\n" +
 	"\x1fImportWorkflowExecutionResponse\x12\x14\n" +
-	"\x05token\x18\x01 \x01(\fR\x05token\"\xce\x01\n" +
+	"\x05token\x18\x01 \x01(\fR\x05token\"\xf1\x01\n" +
 	"\x1bDescribeMutableStateRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12G\n" +
 	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\x12*\n" +
 	"\x11skip_force_reload\x18\x03 \x01(\bR\x0fskipForceReload\x12\x1c\n" +
-	"\tarchetype\x18\x04 \x01(\tR\tarchetype\"\xb6\x02\n" +
+	"\tarchetype\x18\x04 \x01(\tR\tarchetype\x12!\n" +
+	"\farchetype_id\x18\x05 \x01(\rR\varchetypeId\"\xb6\x02\n" +
 	"\x1cDescribeMutableStateResponse\x12\x19\n" +
 	"\bshard_id\x18\x01 \x01(\tR\ashardId\x12!\n" +
 	"\fhistory_addr\x18\x02 \x01(\tR\vhistoryAddr\x12h\n" +
@@ -5987,11 +6024,12 @@ const file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc = 
 	"\x11maximum_page_size\x18\x05 \x01(\x05R\x0fmaximumPageSize\x12&\n" +
 	"\x0fnext_page_token\x18\x06 \x01(\fR\rnextPageToken\"B\n" +
 	"\x18MergeDLQMessagesResponse\x12&\n" +
-	"\x0fnext_page_token\x18\x01 \x01(\fR\rnextPageToken\"\xad\x01\n" +
+	"\x0fnext_page_token\x18\x01 \x01(\fR\rnextPageToken\"\xd0\x01\n" +
 	"\x1bRefreshWorkflowTasksRequest\x12!\n" +
 	"\fnamespace_id\x18\x03 \x01(\tR\vnamespaceId\x12G\n" +
 	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\x12\x1c\n" +
-	"\tarchetype\x18\x04 \x01(\tR\tarchetypeJ\x04\b\x01\x10\x02\"\x1e\n" +
+	"\tarchetype\x18\x04 \x01(\tR\tarchetype\x12!\n" +
+	"\farchetype_id\x18\x05 \x01(\rR\varchetypeIdJ\x04\b\x01\x10\x02\"\x1e\n" +
 	"\x1cRefreshWorkflowTasksResponse\"\xaf\x02\n" +
 	"\x1dResendReplicationTasksRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12\x1f\n" +
@@ -6020,11 +6058,12 @@ const file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc = 
 	"\bsubqueue\x18\b \x01(\x05R\bsubqueue\"\x90\x01\n" +
 	"\x19GetTaskQueueTasksResponse\x12K\n" +
 	"\x05tasks\x18\x01 \x03(\v25.temporal.server.api.persistence.v1.AllocatedTaskInfoR\x05tasks\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\fR\rnextPageToken\"\xa5\x01\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\fR\rnextPageToken\"\xc8\x01\n" +
 	"\x1eDeleteWorkflowExecutionRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12G\n" +
 	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\x12\x1c\n" +
-	"\tarchetype\x18\x03 \x01(\tR\tarchetype\"=\n" +
+	"\tarchetype\x18\x03 \x01(\tR\tarchetype\x12!\n" +
+	"\farchetype_id\x18\x04 \x01(\rR\varchetypeId\"=\n" +
 	"\x1fDeleteWorkflowExecutionResponse\x12\x1a\n" +
 	"\bwarnings\x18\x01 \x03(\tR\bwarnings\"\xaa\x01\n" +
 	"(StreamWorkflowReplicationMessagesRequest\x12p\n" +
@@ -6121,12 +6160,13 @@ const file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc = 
 	"\x11target_cluster_id\x18\x05 \x01(\x05R\x0ftargetClusterId\x12!\n" +
 	"\farchetype_id\x18\x06 \x01(\rR\varchetypeId\"\xb9\x01\n" +
 	"\x19SyncWorkflowStateResponse\x12\x83\x01\n" +
-	"\x1dversioned_transition_artifact\x18\x05 \x01(\v2?.temporal.server.api.replication.v1.VersionedTransitionArtifactR\x1bversionedTransitionArtifactJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05\"\xda\x01\n" +
+	"\x1dversioned_transition_artifact\x18\x05 \x01(\v2?.temporal.server.api.replication.v1.VersionedTransitionArtifactR\x1bversionedTransitionArtifactJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05\"\xfd\x01\n" +
 	"*GenerateLastHistoryReplicationTasksRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12G\n" +
 	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\x12'\n" +
 	"\x0ftarget_clusters\x18\x03 \x03(\tR\x0etargetClusters\x12\x1c\n" +
-	"\tarchetype\x18\x04 \x01(\tR\tarchetype\"\x8a\x01\n" +
+	"\tarchetype\x18\x04 \x01(\tR\tarchetype\x12!\n" +
+	"\farchetype_id\x18\x05 \x01(\rR\varchetypeId\"\x8a\x01\n" +
 	"+GenerateLastHistoryReplicationTasksResponse\x124\n" +
 	"\x16state_transition_count\x18\x01 \x01(\x03R\x14stateTransitionCount\x12%\n" +
 	"\x0ehistory_length\x18\x02 \x01(\x03R\rhistoryLength\"\xfc\x01\n" +

--- a/proto/internal/temporal/server/api/adminservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/adminservice/v1/request_response.proto
@@ -57,6 +57,8 @@ message DescribeMutableStateRequest {
   temporal.api.common.v1.WorkflowExecution execution = 2;
   bool skip_force_reload = 3;
   string archetype = 4;
+  // (-- api-linter: core::0141::forbidden-types=disabled --)
+  uint32 archetype_id = 5;
 }
 
 message DescribeMutableStateResponse {
@@ -363,6 +365,8 @@ message RefreshWorkflowTasksRequest {
   string namespace_id = 3;
   temporal.api.common.v1.WorkflowExecution execution = 2;
   string archetype = 4;
+  // (-- api-linter: core::0141::forbidden-types=disabled --)
+  uint32 archetype_id = 5;
 }
 
 message RefreshWorkflowTasksResponse {
@@ -403,6 +407,8 @@ message DeleteWorkflowExecutionRequest {
   string namespace = 1;
   temporal.api.common.v1.WorkflowExecution execution = 2;
   string archetype = 3;
+  // (-- api-linter: core::0141::forbidden-types=disabled --)
+  uint32 archetype_id = 4;
 }
 
 message DeleteWorkflowExecutionResponse {
@@ -580,6 +586,8 @@ message GenerateLastHistoryReplicationTasksRequest {
   temporal.api.common.v1.WorkflowExecution execution = 2;
   repeated string target_clusters = 3;
   string archetype = 4;
+  // (-- api-linter: core::0141::forbidden-types=disabled --)
+  uint32 archetype_id = 5;
 }
 
 message GenerateLastHistoryReplicationTasksResponse {

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -783,7 +783,7 @@ func (adh *AdminHandler) DescribeMutableState(ctx context.Context, request *admi
 		return nil, err
 	}
 
-	archetypeID, err := adh.archetypeNameToID(request.GetArchetype())
+	archetypeID, err := adh.validateAndResolveArchetypeID(request.GetArchetype(), request.GetArchetypeId())
 	if err != nil {
 		return nil, err
 	}
@@ -1560,7 +1560,7 @@ func (adh *AdminHandler) RefreshWorkflowTasks(
 		return nil, err
 	}
 
-	archetypeID, err := adh.archetypeNameToID(request.GetArchetype())
+	archetypeID, err := adh.validateAndResolveArchetypeID(request.GetArchetype(), request.GetArchetypeId())
 	if err != nil {
 		return nil, err
 	}
@@ -1848,7 +1848,7 @@ func (adh *AdminHandler) DeleteWorkflowExecution(
 		return nil, err
 	}
 
-	archetypeID, err := adh.archetypeNameToID(request.GetArchetype())
+	archetypeID, err := adh.validateAndResolveArchetypeID(request.GetArchetype(), request.GetArchetypeId())
 	if err != nil {
 		return nil, err
 	}
@@ -2313,7 +2313,7 @@ func (adh *AdminHandler) GenerateLastHistoryReplicationTasks(
 		return nil, err
 	}
 
-	archetypeID, err := adh.archetypeNameToID(request.GetArchetype())
+	archetypeID, err := adh.validateAndResolveArchetypeID(request.GetArchetype(), request.GetArchetypeId())
 	if err != nil {
 		return nil, err
 	}
@@ -2349,7 +2349,35 @@ func (adh *AdminHandler) getDLQWorkflowID(
 	)
 }
 
-func (adh *AdminHandler) archetypeNameToID(archetype chasm.Archetype) (chasm.ArchetypeID, error) {
+// validateAndResolveArchetypeID validates the archetype and archetypeID fields and returns the resolved archetype ID.
+// It performs the following checks:
+// 1. If archetypeID is specified (non-zero), validates it's registered in the chasm registry
+// 2. If both archetypeID and archetype are specified, validates they match each other
+// 3. If only archetype is specified, converts it to an ID
+func (adh *AdminHandler) validateAndResolveArchetypeID(
+	archetype chasm.Archetype,
+	archetypeID uint32,
+) (chasm.ArchetypeID, error) {
+	// If archetypeID is specified, use it
+	if archetypeID != chasm.UnspecifiedArchetypeID {
+		// Validate that the archetypeID is registered in the chasm registry
+		archetypeFqn, ok := adh.chasmRegistry.ComponentFqnByID(archetypeID)
+		if !ok {
+			return chasm.UnspecifiedArchetypeID, serviceerror.NewInvalidArgumentf(
+				"unknown archetype ID: %d", archetypeID)
+		}
+
+		// If both archetype and archetypeID are specified, validate they match
+		if len(archetype) > 0 && archetype != archetypeFqn {
+			return chasm.UnspecifiedArchetypeID, serviceerror.NewInvalidArgumentf(
+				"archetype mismatch: archetypeID (%d) does not match archetype name (%s), registered name %s",
+				archetypeID, archetype, archetypeFqn)
+		}
+
+		return chasm.ArchetypeID(archetypeID), nil
+	}
+
+	// If only archetype is specified, convert it to an ID
 	if len(archetype) == 0 {
 		// For backwards compatibility, default to Workflow
 		return chasm.WorkflowArchetypeID, nil

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -382,6 +382,7 @@ func (a *activities) generateWorkflowReplicationTask(
 				RunId:      execution.RunID,
 			},
 			Archetype:      archetype,
+			ArchetypeId:    execution.ArchetypeID,
 			TargetClusters: targetClusters,
 		})
 		if err != nil {
@@ -780,6 +781,7 @@ func (a *activities) verifySingleReplicationTask(
 			RunId:      execution.RunID,
 		},
 		Archetype:       archetype,
+		ArchetypeId:     execution.ArchetypeID,
 		SkipForceReload: true,
 	})
 	a.forceReplicationMetricsHandler.Timer(metrics.VerifyDescribeMutableStateLatency.Name()).Record(time.Since(s))

--- a/service/worker/migration/activities_test.go
+++ b/service/worker/migration/activities_test.go
@@ -181,6 +181,7 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_Success() {
 			RunId:      execution1.RunID,
 		},
 		Archetype:       chasm.WorkflowArchetype,
+		ArchetypeId:     execution1.ArchetypeID,
 		SkipForceReload: true,
 	})).Return(&adminservice.DescribeMutableStateResponse{}, nil).Times(1)
 
@@ -202,6 +203,7 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_Success() {
 				RunId:      execution2.RunID,
 			},
 			Archetype:       chasm.WorkflowArchetype,
+			ArchetypeId:     execution2.ArchetypeID,
 			SkipForceReload: true,
 		})).Return(r.resp, r.err).Times(1)
 	}
@@ -272,6 +274,7 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_SkipWorkflowExecution() {
 				RunId:      execution1.RunID,
 			},
 			Archetype:       chasm.WorkflowArchetype,
+			ArchetypeId:     execution1.ArchetypeID,
 			SkipForceReload: true,
 		})).Return(nil, serviceerror.NewNotFound("")).Times(1)
 
@@ -328,6 +331,7 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_FailedNotFound() {
 			RunId:      execution1.RunID,
 		},
 		Archetype:       chasm.WorkflowArchetype,
+		ArchetypeId:     execution1.ArchetypeID,
 		SkipForceReload: true,
 	})).Return(nil, serviceerror.NewNotFound("")).AnyTimes()
 
@@ -384,6 +388,7 @@ func (s *activitiesSuite) Test_verifySingleReplicationTask() {
 			RunId:      execution1.RunID,
 		},
 		Archetype:       chasm.WorkflowArchetype,
+		ArchetypeId:     execution1.ArchetypeID,
 		SkipForceReload: true,
 	})).Return(&adminservice.DescribeMutableStateResponse{}, nil).Times(1)
 	result, err := s.a.verifySingleReplicationTask(ctx, &request, s.mockRemoteAdminClient, &testNamespace, request.Executions[0])
@@ -398,6 +403,7 @@ func (s *activitiesSuite) Test_verifySingleReplicationTask() {
 			RunId:      execution2.RunID,
 		},
 		Archetype:       chasm.WorkflowArchetype,
+		ArchetypeId:     execution2.ArchetypeID,
 		SkipForceReload: true,
 	})).Return(&adminservice.DescribeMutableStateResponse{}, serviceerror.NewNotFound("")).Times(1)
 
@@ -446,6 +452,7 @@ Loop:
 					RunId:      execution1.RunID,
 				},
 				Archetype:       chasm.WorkflowArchetype,
+				ArchetypeId:     execution1.ArchetypeID,
 				SkipForceReload: true,
 			})).Return(&adminservice.DescribeMutableStateResponse{}, nil).Times(1)
 		case executionNotfound:
@@ -456,6 +463,7 @@ Loop:
 					RunId:      execution1.RunID,
 				},
 				Archetype:       chasm.WorkflowArchetype,
+				ArchetypeId:     execution1.ArchetypeID,
 				SkipForceReload: true,
 			})).Return(nil, serviceerror.NewNotFound("")).Times(1)
 			break Loop
@@ -467,6 +475,7 @@ Loop:
 					RunId:      execution1.RunID,
 				},
 				Archetype:       chasm.WorkflowArchetype,
+				ArchetypeId:     execution1.ArchetypeID,
 				SkipForceReload: true,
 			})).Return(nil, serviceerror.NewInternal("")).Times(1)
 		}
@@ -616,6 +625,7 @@ func (s *activitiesSuite) Test_verifyReplicationTasksNoProgress() {
 			RunId:      execution1.RunID,
 		},
 		Archetype:       chasm.WorkflowArchetype,
+		ArchetypeId:     execution1.ArchetypeID,
 		SkipForceReload: true,
 	})).Return(nil, serviceerror.NewNotFound("")).Times(1)
 
@@ -661,6 +671,7 @@ func (s *activitiesSuite) Test_verifyReplicationTasksSkipRetention() {
 				RunId:      execution1.RunID,
 			},
 			Archetype:       chasm.WorkflowArchetype,
+			ArchetypeId:     execution1.ArchetypeID,
 			SkipForceReload: true,
 		})).Return(nil, serviceerror.NewNotFound("")).Times(1)
 

--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -358,7 +358,8 @@ func describeMutableState(c *cli.Context, clientFactory ClientFactory) (*adminse
 			WorkflowId: bid,
 			RunId:      rid,
 		},
-		Archetype: getArchetypeWithDefault(c, chasm.WorkflowArchetype),
+		Archetype:   getArchetype(c),
+		ArchetypeId: chasm.ArchetypeID(c.Uint(FlagArchetypeID)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to get Mutable State: %s", err)
@@ -396,7 +397,8 @@ func AdminDeleteWorkflow(c *cli.Context, clientFactory ClientFactory, prompter *
 			WorkflowId: wid,
 			RunId:      rid,
 		},
-		Archetype: getArchetypeWithDefault(c, chasm.WorkflowArchetype),
+		Archetype:   getArchetype(c),
+		ArchetypeId: chasm.ArchetypeID(c.Uint(FlagArchetypeID)),
 	})
 	if err != nil {
 		return fmt.Errorf("unable to delete workflow execution: %s", err)
@@ -726,7 +728,8 @@ func AdminRefreshWorkflowTasks(c *cli.Context, clientFactory ClientFactory) erro
 			WorkflowId: wid,
 			RunId:      rid,
 		},
-		Archetype: getArchetypeWithDefault(c, chasm.WorkflowArchetype),
+		Archetype:   getArchetype(c),
+		ArchetypeId: chasm.ArchetypeID(c.Uint(FlagArchetypeID)),
 	})
 	if err != nil {
 		return fmt.Errorf("unable to refresh Workflow Task: %s", err)
@@ -857,7 +860,8 @@ func AdminReplicateWorkflow(
 			WorkflowId: wid,
 			RunId:      rid,
 		},
-		Archetype: getArchetypeWithDefault(c, chasm.WorkflowArchetype),
+		Archetype:   getArchetype(c),
+		ArchetypeId: chasm.ArchetypeID(c.Uint(FlagArchetypeID)),
 	})
 	if err != nil {
 		return fmt.Errorf("unable to replicate workflow: %w", err)

--- a/tools/tdbg/flags.go
+++ b/tools/tdbg/flags.go
@@ -15,6 +15,7 @@ var (
 	FlagBusinessID                 = "business-id"
 	FlagBusinessIDAlias            = []string{"bid", FlagWorkflowID, FlagWorkflowIDAlias[0]}
 	FlagArchetype                  = "archetype"
+	FlagArchetypeID                = "archetype-id"
 	FlagNumberOfShards             = "number-of-shards"
 	FlagMinEventID                 = "min-event-id"
 	FlagMaxEventID                 = "max-event-id"

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -166,6 +166,10 @@ func newAdminExecutionCommands(clientFactory ClientFactory, prompterFactory Prom
 					Usage:       "Fully qualified archetype name of the execution",
 					DefaultText: chasm.WorkflowArchetype,
 				},
+				&cli.UintFlag{
+					Name:  FlagArchetypeID,
+					Usage: "Archetype ID (optional, overrides --archetype if specified)",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				return AdminDescribeExecution(c, clientFactory)
@@ -190,6 +194,10 @@ func newAdminExecutionCommands(clientFactory ClientFactory, prompterFactory Prom
 					Name:        FlagArchetype,
 					Usage:       "Fully qualified archetype name of the execution",
 					DefaultText: chasm.WorkflowArchetype,
+				},
+				&cli.UintFlag{
+					Name:  FlagArchetypeID,
+					Usage: "Archetype ID (optional, overrides --archetype if specified)",
 				},
 				&cli.StringFlag{
 					Name:  FlagVisibilityQuery,
@@ -248,6 +256,10 @@ func newAdminExecutionCommands(clientFactory ClientFactory, prompterFactory Prom
 					Usage:       "Fully qualified archetype name of the execution",
 					DefaultText: chasm.WorkflowArchetype,
 				},
+				&cli.UintFlag{
+					Name:  FlagArchetypeID,
+					Usage: "Archetype ID (optional, overrides --archetype if specified)",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				return AdminReplicateWorkflow(c, clientFactory)
@@ -272,6 +284,10 @@ func newAdminExecutionCommands(clientFactory ClientFactory, prompterFactory Prom
 					Name:        FlagArchetype,
 					Usage:       "Fully qualified archetype name of the execution",
 					DefaultText: chasm.WorkflowArchetype,
+				},
+				&cli.UintFlag{
+					Name:  FlagArchetypeID,
+					Usage: "Archetype ID (optional, overrides --archetype if specified)",
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/tools/tdbg/util.go
+++ b/tools/tdbg/util.go
@@ -309,13 +309,14 @@ func getNamespaceID(c *cli.Context, clientFactory ClientFactory, nsName namespac
 	return namespace.ID(nsResponse.NamespaceInfo.GetId()), nil
 }
 
-func getArchetypeWithDefault(
-	c *cli.Context,
-	defaultAchetype chasm.Archetype,
-) chasm.Archetype {
+func getArchetype(c *cli.Context) chasm.Archetype {
+	if c.IsSet(FlagArchetypeID) {
+		return ""
+	}
+
 	archetype := c.String(FlagArchetype)
 	if archetype != "" {
 		return archetype
 	}
-	return defaultAchetype
+	return chasm.WorkflowArchetype
 }


### PR DESCRIPTION
## What changed?
- Accept archetypeID in admin API requests

## Why?
- With this we no longer need to register chasm components to worker service, which currently performs an archetypeID to name conversion before calling admin apis.
- For backward compatibility, we can only stop registering chasm components to worker service starting from next cloud release.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
