### PR TITLE
Add a hook point to the Matching service once a task has been matched or not

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -377,6 +377,7 @@ go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
 go.temporal.io/api v1.62.2 h1:jFhIzlqNyJsJZTiCRQmTIMv6OTQ5BZ57z8gbgLGMaoo=
 go.temporal.io/api v1.62.2/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.62.3-0.20260219004129-d78c552c23d4 h1:F6uvvdLNJfEoC2MTPuZHcZVOmxUyNV0bH8jj2yau8Ug=
 go.temporal.io/api v1.62.3-0.20260219004129-d78c552c23d4/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.38.0 h1:4Bok5LEdED7YKpsSjIa3dDqram5VOq+ydBf4pyx0Wo4=
 go.temporal.io/sdk v1.38.0/go.mod h1:a+R2Ej28ObvHoILbHaxMyind7M6D+W0L7edt5UJF4SE=

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -23,6 +23,7 @@ import (
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/tqid"
+	"go.temporal.io/server/service/matching/hooks"
 	"go.temporal.io/server/service/matching/workers"
 	"go.temporal.io/server/service/worker/workerdeployment"
 	"go.uber.org/fx"
@@ -70,6 +71,7 @@ type (
 		RateLimiter                   TaskDispatchRateLimiter `optional:"true"`
 		WorkersRegistry               workers.Registry
 		Serializer                    serialization.Serializer
+		TaskHookFactories             []hooks.TaskHookFactory `group:"TaskHookFactories"`
 	}
 )
 
@@ -112,6 +114,7 @@ func NewHandler(
 			params.SearchAttributeMapperProvider,
 			params.RateLimiter,
 			params.Serializer,
+			params.TaskHookFactories,
 		),
 		namespaceRegistry: params.NamespaceRegistry,
 		workersRegistry:   params.WorkersRegistry,

--- a/service/matching/hooks/task_lifecycle_hooks.go
+++ b/service/matching/hooks/task_lifecycle_hooks.go
@@ -1,0 +1,46 @@
+package hooks
+
+import (
+	"context"
+
+	deploymentpb "go.temporal.io/api/deployment/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/tqid"
+)
+
+type (
+	// TaskQueuePartition is a simplified version of tqid.Partition that removes details
+	// the hooks should not concern themselves with
+	TaskQueuePartition interface {
+		NamespaceId() string
+		TaskQueue() *tqid.TaskQueue
+		TaskType() enumspb.TaskQueueType
+		Kind() enumspb.TaskQueueKind
+	}
+
+	TaskHookFactoryCreateDetails struct {
+		Namespace *namespace.Namespace
+		Partition TaskQueuePartition
+	}
+	TaskAddHookDetails struct {
+		DeploymentVersion *deploymentpb.WorkerDeploymentVersion
+		IsSyncMatch       bool
+	}
+
+	TaskHookFactory interface {
+		// Create returns a TaskHook instance that will be leveraged as part
+		// of the specific task queue partition (as specified in the details).
+		// This might also return nil, if no hooking into that task queue
+		// partition is desired.
+		Create(details *TaskHookFactoryCreateDetails) TaskHook
+	}
+	TaskHook interface {
+		// Start is called when the task queue partition manager for the hooks partition is started
+		Start()
+		// Stop is called when the task queue partition manager for the hooks partition is stopped
+		Stop()
+		// ProcessTaskAdd is called for each Task addition (whether sync or async matching)
+		ProcessTaskAdd(ctx context.Context, event *TaskAddHookDetails)
+	}
+)

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -60,6 +60,7 @@ import (
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/common/worker_versioning"
 	"go.temporal.io/server/service/history/api"
+	"go.temporal.io/server/service/matching/hooks"
 	"go.temporal.io/server/service/worker/workerdeployment"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -175,6 +176,8 @@ type (
 		reachabilityCache reachabilityCache
 		// Rate limiter to limit the task dispatch
 		rateLimiter TaskDispatchRateLimiter
+
+		taskHookFactories []hooks.TaskHookFactory
 	}
 )
 
@@ -254,6 +257,7 @@ func NewEngine(
 	saMapperProvider searchattribute.MapperProvider,
 	rateLimiter TaskDispatchRateLimiter,
 	historySerializer serialization.Serializer,
+	taskHookFactories []hooks.TaskHookFactory,
 ) Engine {
 	scopedMetricsHandler := metricsHandler.WithTags(metrics.OperationTag(metrics.MatchingEngineScope))
 	e := &matchingEngineImpl{
@@ -296,6 +300,7 @@ func NewEngine(
 		namespaceReplicationQueue: namespaceReplicationQueue,
 		userDataUpdateBatchers:    collection.NewSyncMap[namespace.ID, *stream_batcher.Batcher[*userDataUpdate, error]](),
 		rateLimiter:               rateLimiter,
+		taskHookFactories:         taskHookFactories,
 	}
 	e.reachabilityCache = newReachabilityCache(
 		metrics.NoopMetricsHandler,

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/common/worker_versioning"
+	"go.temporal.io/server/service/matching/hooks"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -73,6 +74,8 @@ type (
 		metricsHandler      metrics.Handler // namespace/taskqueue tagged metric scope
 		// TODO(stephanos): move cache out of partition manager
 		cache cache.Cache // non-nil for root-partition
+
+		taskHooks []hooks.TaskHook
 
 		goroGroup goro.Group
 
@@ -118,6 +121,17 @@ func newTaskQueuePartitionManager(
 		userDataManager,
 		tqConfig,
 		partition.TaskQueue().TaskType())
+	var taskHooks []hooks.TaskHook
+	for _, hookFactory := range e.taskHookFactories {
+		taskHook := hookFactory.Create(&hooks.TaskHookFactoryCreateDetails{
+			Namespace: ns,
+			Partition: partition,
+		})
+		if taskHook != nil {
+			taskHooks = append(taskHooks, taskHook)
+		}
+	}
+
 	pm := &taskQueuePartitionManagerImpl{
 		engine:                e,
 		partition:             partition,
@@ -132,6 +146,7 @@ func newTaskQueuePartitionManager(
 		rateLimitManager:      rateLimitManager,
 		defaultQueueFuture:    future.NewFuture[physicalTaskQueueManager](),
 		autoEnableRateLimiter: quotas.NewRateLimiter(1.0/60, 1),
+		taskHooks:             taskHooks,
 	}
 	pm.initCtx, pm.initCancel = context.WithCancel(context.Background())
 
@@ -214,6 +229,10 @@ func (pm *taskQueuePartitionManagerImpl) Start() {
 	pm.loadTime = time.Now()
 	pm.engine.updateTaskQueuePartitionGauge(pm.Namespace(), pm.partition, 1)
 	pm.userDataManager.Start()
+	for _, hook := range pm.taskHooks {
+		hook.Start()
+	}
+
 	//nolint:errcheck
 	go pm.initialize()
 }
@@ -241,6 +260,10 @@ func (pm *taskQueuePartitionManagerImpl) Stop(unloadCause unloadCause) {
 		pm.emitZeroLogicalBacklogForQueue(version, vq)
 	}
 	pm.versionedQueuesLock.Unlock()
+
+	for _, hook := range pm.taskHooks {
+		hook.Stop()
+	}
 
 	// Then, stop user data manager to wrap up any reads/writes.
 	pm.userDataManager.Stop()
@@ -359,6 +382,7 @@ reredirectTask:
 	if isActive {
 		syncMatched, err = syncMatchQueue.TrySyncMatch(ctx, syncMatchTask)
 		if syncMatched && !pm.shouldBacklogSyncMatchTaskOnError(err) {
+			pm.processTaskAddHooks(ctx, targetVersion, syncMatched)
 
 			// Build ID is not returned for sync match. The returned build ID is used by History to update
 			// mutable state (and visibility) when the first workflow task is spooled.
@@ -384,7 +408,21 @@ reredirectTask:
 		assignedBuildId = spoolQueue.QueueKey().Version().BuildId()
 	}
 
-	return assignedBuildId, false, spoolQueue.SpoolTask(params.taskInfo)
+	err = spoolQueue.SpoolTask(params.taskInfo)
+	if err == nil {
+		pm.processTaskAddHooks(ctx, targetVersion, false)
+	}
+
+	return assignedBuildId, false, err
+}
+
+func (pm *taskQueuePartitionManagerImpl) processTaskAddHooks(ctx context.Context, targetVersion *deploymentspb.WorkerDeploymentVersion, syncMatched bool) {
+	for _, l := range pm.taskHooks {
+		l.ProcessTaskAdd(ctx, &hooks.TaskAddHookDetails{
+			DeploymentVersion: worker_versioning.ExternalWorkerDeploymentVersionFromVersion(targetVersion),
+			IsSyncMatch:       syncMatched,
+		})
+	}
 }
 
 func (pm *taskQueuePartitionManagerImpl) shouldBacklogSyncMatchTaskOnError(err error) bool {
@@ -996,7 +1034,7 @@ func (pm *taskQueuePartitionManagerImpl) describe(
 			unversionedCurrentShareByPriority, unversionedRampingShareByPriority =
 				splitStatsByPriorityByRampPercentage(unversionedStatsByPriority, rampPercentage)
 		} else if currentExists {
-			// If there exist no ramping version, weattribute the entire unversioned backlog to the current version.
+			// If there exist no ramping version, we attribute the entire unversioned backlog to the current version.
 			unversionedCurrentShareByPriority = cloneStatsByPriority(unversionedStatsByPriority)
 		}
 	}

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -28,6 +28,7 @@ import (
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/worker_versioning"
+	"go.temporal.io/server/service/matching/hooks"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -169,7 +170,7 @@ func (s *PartitionManagerTestSuite) TestDescribeTaskQueuePartition_MultipleBuild
 			ApproximateBacklogCount: 1,
 		},
 		TaskQueueStatsByPriorityKey: map[int32]*taskqueuepb.TaskQueueStats{
-			3: &taskqueuepb.TaskQueueStats{
+			3: {
 				ApproximateBacklogAge:   durationpb.New(0),
 				ApproximateBacklogCount: 1,
 			},
@@ -1334,6 +1335,76 @@ type testPartitionManagerConfig struct {
 	withRecentPoller bool          // Whether to register a poller to simulate recent poller activity
 }
 
+// capturingTaskMatchHook records ProcessTaskMatch calls for test assertions.
+type capturingTaskMatchHook struct {
+	mu            sync.Mutex
+	taskQueueName string
+	taskQueueType enumspb.TaskQueueType
+	calls         []capturedTaskMatchDetails
+}
+
+type capturedTaskMatchDetails struct {
+	TaskQueueName     string
+	TaskQueueType     enumspb.TaskQueueType
+	IsSyncMatch       bool
+	DeploymentVersion *deploymentpb.WorkerDeploymentVersion
+}
+
+func (h *capturingTaskMatchHook) Create(details *hooks.TaskHookFactoryCreateDetails) hooks.TaskHook {
+	h.taskQueueName = details.Partition.TaskQueue().Name()
+	h.taskQueueType = details.Partition.TaskQueue().TaskType()
+	return h
+}
+
+func (h *capturingTaskMatchHook) Start() {
+}
+
+func (h *capturingTaskMatchHook) Stop() {
+}
+
+func (h *capturingTaskMatchHook) ProcessTaskAdd(ctx context.Context, event *hooks.TaskAddHookDetails) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	details := capturedTaskMatchDetails{
+		TaskQueueName: h.taskQueueName,
+		TaskQueueType: h.taskQueueType,
+		IsSyncMatch:   event.IsSyncMatch,
+	}
+	if event.DeploymentVersion != nil {
+		details.DeploymentVersion = &deploymentpb.WorkerDeploymentVersion{
+			DeploymentName: event.DeploymentVersion.DeploymentName,
+			BuildId:        event.DeploymentVersion.BuildId,
+		}
+	}
+	h.calls = append(h.calls, details)
+}
+
+func (h *capturingTaskMatchHook) getCalls() []capturedTaskMatchDetails {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]capturedTaskMatchDetails(nil), h.calls...)
+}
+
+// setupPartitionManagerWithTaskHookFactories creates a partition manager with the given task match hooks.
+func (s *PartitionManagerTestSuite) setupPartitionManagerWithTaskHookFactories(taskHookFactories []hooks.TaskHookFactory) (*taskQueuePartitionManagerImpl, func()) {
+	f, err := tqid.NewTaskQueueFamily(namespaceID, taskQueueName)
+	s.Require().NoError(err)
+	partition := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).RootPartition()
+	tqConfig := newTaskQueueConfig(partition.TaskQueue(), s.partitionMgr.engine.config, s.partitionMgr.ns.Name())
+	s.partitionMgr.engine.taskHookFactories = taskHookFactories
+
+	pm, err := newTaskQueuePartitionManager(s.partitionMgr.engine, s.partitionMgr.ns, partition, tqConfig, s.partitionMgr.logger, s.partitionMgr.throttledLogger, metrics.NoopMetricsHandler, s.userDataMgr)
+	s.Require().NoError(err)
+	pm.Start()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	err = pm.WaitUntilInitialized(ctx)
+	cancel()
+	s.Require().NoError(err)
+
+	return pm, func() { pm.Stop(unloadCauseUnspecified) }
+}
+
 // setupPartitionManagerWithCapture creates a partition manager with a capturing metrics handler
 // and returns the manager, capture, and a cleanup function
 func (s *PartitionManagerTestSuite) setupPartitionManagerWithCapture(
@@ -1478,6 +1549,117 @@ func (s *PartitionManagerTestSuite) TestNoRecentPollerMetric_OldPartitionWithRec
 	recordings, exists := snapshot[metrics.NoRecentPollerTasksPerTaskQueueCounter.Name()]
 	s.False(exists, "No recordings should exist when there are no recent pollers")
 	s.Empty(recordings, "Metric should not be emitted when there are recent pollers")
+}
+
+func (s *PartitionManagerTestSuite) TestTaskAddHooks_AddHookSyncMatch() {
+	hook := &capturingTaskMatchHook{}
+	pm, cleanup := s.setupPartitionManagerWithTaskHookFactories([]hooks.TaskHookFactory{hook})
+	defer cleanup()
+
+	type pollResult struct {
+		task *internalTask
+		err  error
+	}
+	pollDone := make(chan pollResult, 1)
+	pollStarted := make(chan struct{})
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		close(pollStarted)
+		task, _, err := pm.PollTask(ctx, &pollMetadata{
+			workerVersionCapabilities: &commonpb.WorkerVersionCapabilities{
+				BuildId:       "",
+				UseVersioning: false,
+			},
+		})
+		pollDone <- pollResult{task: task, err: err}
+		if task != nil && task.responseC != nil {
+			close(task.responseC)
+		}
+	}()
+	s.Require().Eventually(func() bool {
+		select {
+		case <-pollStarted:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 1*time.Millisecond)
+
+	_, syncMatched, err := pm.AddTask(context.Background(), addTaskParams{
+		taskInfo: &persistencespb.TaskInfo{
+			NamespaceId: namespaceID,
+			RunId:       "run",
+			WorkflowId:  "wf",
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().True(syncMatched)
+
+	var pr pollResult
+	s.Require().Eventually(func() bool {
+		select {
+		case pr = <-pollDone:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+	s.Require().NoError(pr.err)
+	s.Require().NotNil(pr.task)
+	s.Require().NotNil(pr.task.responseC)
+
+	s.Require().Eventually(func() bool { return len(hook.getCalls()) >= 1 }, 2*time.Second, 10*time.Millisecond)
+	calls := hook.getCalls()
+	s.Require().Len(calls, 1)
+	s.Equal(taskQueueName, calls[0].TaskQueueName)
+	s.Equal(enumspb.TASK_QUEUE_TYPE_WORKFLOW, calls[0].TaskQueueType)
+	s.True(calls[0].IsSyncMatch)
+	s.Nil(calls[0].DeploymentVersion)
+}
+
+func (s *PartitionManagerTestSuite) TestTaskAddHooks_AddHookNoSyncMatch() {
+	hook := &capturingTaskMatchHook{}
+	pm, cleanup := s.setupPartitionManagerWithTaskHookFactories([]hooks.TaskHookFactory{hook})
+	defer cleanup()
+
+	_, syncMatched, err := pm.AddTask(context.Background(), addTaskParams{
+		taskInfo: &persistencespb.TaskInfo{
+			NamespaceId:      namespaceID,
+			RunId:            "run",
+			WorkflowId:       "wf",
+			VersionDirective: worker_versioning.MakeBuildIdDirective("buildXYZ"),
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().False(syncMatched)
+
+	calls := hook.getCalls()
+	s.Require().Len(calls, 1)
+	s.Equal(taskQueueName, calls[0].TaskQueueName)
+	s.Equal(enumspb.TASK_QUEUE_TYPE_WORKFLOW, calls[0].TaskQueueType)
+	s.False(calls[0].IsSyncMatch)
+}
+
+func (s *PartitionManagerTestSuite) TestTaskAddHooks_MultipleHooksInvoked() {
+	hook1 := &capturingTaskMatchHook{}
+	hook2 := &capturingTaskMatchHook{}
+	pm, cleanup := s.setupPartitionManagerWithTaskHookFactories([]hooks.TaskHookFactory{hook1, hook2})
+	defer cleanup()
+
+	_, _, err := pm.AddTask(context.Background(), addTaskParams{
+		taskInfo: &persistencespb.TaskInfo{
+			NamespaceId: namespaceID,
+			RunId:       "run",
+			WorkflowId:  "wf",
+		},
+	})
+	s.Require().NoError(err)
+
+	s.Len(hook1.getCalls(), 1)
+	s.Len(hook2.getCalls(), 1)
+	s.False(hook1.getCalls()[0].IsSyncMatch)
+	s.False(hook2.getCalls()[0].IsSyncMatch)
 }
 
 type mockUserDataManager struct {


### PR DESCRIPTION
## What changed?
This adds a hook point to the matching service once it has matched a task or decided to spool it. 

## Why?
This can be leveraged to react to task sync or no-sync match events, while keeping matching service decoupled from the event handling logic.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)