### PR TITLE
Patch for standalone activity rollback (#9229)

### DIFF
--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const StandaloneActivityDisabledError = "Standalone activity is disabled"
+var ErrStandaloneActivityDisabled = serviceerror.NewUnimplemented("Standalone activity is disabled")
 
 type FrontendHandler interface {
 	StartActivityExecution(ctx context.Context, req *workflowservice.StartActivityExecutionRequest) (*workflowservice.StartActivityExecutionResponse, error)
@@ -67,11 +67,6 @@ func NewFrontendHandler(
 	}
 }
 
-// IsStandaloneActivityEnabled checks if standalone activities are enabled for the given namespace
-func (h *frontendHandler) IsStandaloneActivityEnabled(namespaceName string) bool {
-	return h.config.Enabled(namespaceName)
-}
-
 // StartActivityExecution initiates a standalone activity execution in the specified namespace.
 // It validates the request, resolves the namespace ID, applies default configurations,
 // and forwards the request to the activity service handler.
@@ -82,9 +77,7 @@ func (h *frontendHandler) IsStandaloneActivityEnabled(namespaceName string) bool
 // before mutation to preserve the original for retries.
 // 3. Sends the request to the history activity service.
 func (h *frontendHandler) StartActivityExecution(ctx context.Context, req *workflowservice.StartActivityExecutionRequest) (*workflowservice.StartActivityExecutionResponse, error) {
-	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
-	}
+	return nil, ErrStandaloneActivityDisabled //nolint:all
 
 	namespaceID, err := h.namespaceRegistry.GetNamespaceID(namespace.Name(req.GetNamespace()))
 	if err != nil {
@@ -110,9 +103,7 @@ func (h *frontendHandler) DescribeActivityExecution(
 	ctx context.Context,
 	req *workflowservice.DescribeActivityExecutionRequest,
 ) (*workflowservice.DescribeActivityExecutionResponse, error) {
-	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
-	}
+	return nil, ErrStandaloneActivityDisabled //nolint:all
 
 	err := ValidateDescribeActivityExecutionRequest(
 		req,
@@ -139,9 +130,7 @@ func (h *frontendHandler) PollActivityExecution(
 	ctx context.Context,
 	req *workflowservice.PollActivityExecutionRequest,
 ) (*workflowservice.PollActivityExecutionResponse, error) {
-	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
-	}
+	return nil, ErrStandaloneActivityDisabled //nolint:all
 
 	err := ValidatePollActivityExecutionRequest(
 		req,
@@ -166,9 +155,7 @@ func (h *frontendHandler) ListActivityExecutions(
 	ctx context.Context,
 	req *workflowservice.ListActivityExecutionsRequest,
 ) (*workflowservice.ListActivityExecutionsResponse, error) {
-	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
-	}
+	return nil, ErrStandaloneActivityDisabled //nolint:all
 
 	namespaceID, err := h.namespaceRegistry.GetNamespaceID(namespace.Name(req.GetNamespace()))
 	if err != nil {
@@ -224,9 +211,7 @@ func (h *frontendHandler) CountActivityExecutions(
 	ctx context.Context,
 	req *workflowservice.CountActivityExecutionsRequest,
 ) (*workflowservice.CountActivityExecutionsResponse, error) {
-	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
-	}
+	return nil, ErrStandaloneActivityDisabled //nolint:all
 
 	namespaceID, err := h.namespaceRegistry.GetNamespaceID(namespace.Name(req.GetNamespace()))
 	if err != nil {
@@ -261,9 +246,7 @@ func (h *frontendHandler) TerminateActivityExecution(
 	ctx context.Context,
 	req *workflowservice.TerminateActivityExecutionRequest,
 ) (*workflowservice.TerminateActivityExecutionResponse, error) {
-	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
-	}
+	return nil, ErrStandaloneActivityDisabled //nolint:all
 
 	namespaceName := req.GetNamespace()
 	namespaceID, err := h.namespaceRegistry.GetNamespaceID(namespace.Name(namespaceName))
@@ -309,9 +292,7 @@ func (h *frontendHandler) RequestCancelActivityExecution(
 	ctx context.Context,
 	req *workflowservice.RequestCancelActivityExecutionRequest,
 ) (*workflowservice.RequestCancelActivityExecutionResponse, error) {
-	if !h.config.Enabled(req.GetNamespace()) {
-		return nil, serviceerror.NewUnavailable(StandaloneActivityDisabledError)
-	}
+	return nil, ErrStandaloneActivityDisabled //nolint:all
 
 	namespaceID, err := h.namespaceRegistry.GetNamespaceID(namespace.Name(req.GetNamespace()))
 	if err != nil {

--- a/chasm/lib/activity/library.go
+++ b/chasm/lib/activity/library.go
@@ -6,6 +6,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+const archetypeID = 3332429922
+
 type componentOnlyLibrary struct {
 	chasm.UnimplementedLibrary
 }
@@ -92,4 +94,11 @@ func (l *library) Tasks() []*chasm.RegistrableTask {
 			l.heartbeatTimeoutTaskExecutor,
 		),
 	}
+}
+
+// ShouldDropStandaloneActivityTask indicates whether a task should be dropped based on whether it is a standalone
+// activity task. This is used in the event of server downgrade from a version where standalone activities was supported,
+// so that such tasks won't block queue processing.
+func ShouldDropStandaloneActivityTask(archID uint32) bool {
+	return archID == archetypeID
 }

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -1222,10 +1222,9 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(ctx context.Context, requ
 	if err != nil {
 		return nil, err
 	}
-	namespaceName := namespaceEntry.Name().String()
 
-	if len(taskToken.GetComponentRef()) > 0 && !wh.IsStandaloneActivityEnabled(namespaceName) {
-		return nil, serviceerror.NewUnavailable(activity.StandaloneActivityDisabledError)
+	if len(taskToken.GetComponentRef()) > 0 {
+		return nil, activity.ErrStandaloneActivityDisabled
 	}
 
 	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.Name().String())
@@ -1302,20 +1301,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeatById(ctx context.Context, 
 	// Else this should be a validation error.
 	var componentRef []byte
 	if workflowID == "" {
-		if !wh.IsStandaloneActivityEnabled(request.GetNamespace()) {
-			return nil, errWorkflowIDNotSet
-		}
-
-		ref := chasm.NewComponentRef[*activity.Activity](chasm.ExecutionKey{
-			NamespaceID: namespaceID.String(),
-			BusinessID:  activityID,
-			RunID:       runID,
-		})
-
-		componentRef, err = ref.Serialize(wh.registry)
-		if err != nil {
-			return nil, err
-		}
+		return nil, errWorkflowIDNotSet
 	}
 
 	taskToken := tasktoken.NewActivityTaskToken(
@@ -1417,8 +1403,8 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 	}
 	namespaceName := namespaceEntry.Name().String()
 
-	if len(taskToken.GetComponentRef()) > 0 && !wh.IsStandaloneActivityEnabled(namespaceName) {
-		return nil, serviceerror.NewUnavailable(activity.StandaloneActivityDisabledError)
+	if len(taskToken.GetComponentRef()) > 0 {
+		return nil, activity.ErrStandaloneActivityDisabled
 	}
 
 	if len(request.GetIdentity()) > wh.config.MaxIDLengthLimit() {
@@ -1497,20 +1483,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedById(ctx context.Context,
 	// Else this should be a validation error.
 	var componentRef []byte
 	if workflowID == "" {
-		if !wh.IsStandaloneActivityEnabled(request.GetNamespace()) {
-			return nil, errWorkflowIDNotSet
-		}
-
-		ref := chasm.NewComponentRef[*activity.Activity](chasm.ExecutionKey{
-			NamespaceID: namespaceID.String(),
-			BusinessID:  activityID,
-			RunID:       runID,
-		})
-
-		componentRef, err = ref.Serialize(wh.registry)
-		if err != nil {
-			return nil, err
-		}
+		return nil, errWorkflowIDNotSet
 	}
 
 	taskToken := tasktoken.NewActivityTaskToken(
@@ -1609,8 +1582,8 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 	}
 	namespaceName := namespaceEntry.Name().String()
 
-	if len(taskToken.GetComponentRef()) > 0 && !wh.IsStandaloneActivityEnabled(namespaceName) {
-		return nil, serviceerror.NewUnavailable(activity.StandaloneActivityDisabledError)
+	if len(taskToken.GetComponentRef()) > 0 {
+		return nil, activity.ErrStandaloneActivityDisabled
 	}
 
 	if request.GetFailure() != nil && request.GetFailure().GetApplicationFailureInfo() == nil {
@@ -1705,20 +1678,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedById(ctx context.Context, re
 	// Else this should be a validation error.
 	var componentRef []byte
 	if workflowID == "" {
-		if !wh.IsStandaloneActivityEnabled(request.GetNamespace()) {
-			return nil, errWorkflowIDNotSet
-		}
-
-		ref := chasm.NewComponentRef[*activity.Activity](chasm.ExecutionKey{
-			NamespaceID: namespaceID.String(),
-			BusinessID:  activityID,
-			RunID:       runID,
-		})
-
-		componentRef, err = ref.Serialize(wh.registry)
-		if err != nil {
-			return nil, err
-		}
+		return nil, errWorkflowIDNotSet
 	}
 
 	taskToken := tasktoken.NewActivityTaskToken(
@@ -1826,8 +1786,8 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(ctx context.Context, requ
 	}
 	namespaceName := namespaceEntry.Name().String()
 
-	if len(taskToken.GetComponentRef()) > 0 && !wh.IsStandaloneActivityEnabled(namespaceName) {
-		return nil, serviceerror.NewUnavailable(activity.StandaloneActivityDisabledError)
+	if len(taskToken.GetComponentRef()) > 0 {
+		return nil, activity.ErrStandaloneActivityDisabled
 	}
 
 	if len(request.GetIdentity()) > wh.config.MaxIDLengthLimit() {
@@ -1905,20 +1865,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledById(ctx context.Context, 
 	// Else this should be a validation error.
 	var componentRef []byte
 	if workflowID == "" {
-		if !wh.IsStandaloneActivityEnabled(request.GetNamespace()) {
-			return nil, errWorkflowIDNotSet
-		}
-
-		ref := chasm.NewComponentRef[*activity.Activity](chasm.ExecutionKey{
-			NamespaceID: namespaceID.String(),
-			BusinessID:  activityID,
-			RunID:       runID,
-		})
-
-		componentRef, err = ref.Serialize(wh.registry)
-		if err != nil {
-			return nil, err
-		}
+		return nil, errWorkflowIDNotSet
 	}
 
 	taskToken := tasktoken.NewActivityTaskToken(

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/server/api/matchingservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/definition"
@@ -980,6 +981,10 @@ func (t *timerQueueActiveTaskExecutor) executeChasmSideEffectTimerTask(
 	ctx context.Context,
 	task *tasks.ChasmTask,
 ) error {
+	if activity.ShouldDropStandaloneActivityTask(task.Info.ArchetypeId) {
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
 	defer cancel()
 
@@ -1020,6 +1025,10 @@ func (t *timerQueueActiveTaskExecutor) executeChasmPureTimerTask(
 	ctx context.Context,
 	task *tasks.ChasmTaskPure,
 ) error {
+	if activity.ShouldDropStandaloneActivityTask(task.ArchetypeID) {
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
 	defer cancel()
 

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -13,6 +13,7 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
@@ -123,6 +124,10 @@ func (t *timerQueueStandbyTaskExecutor) executeChasmPureTimerTask(
 	ctx context.Context,
 	task *tasks.ChasmTaskPure,
 ) error {
+	if activity.ShouldDropStandaloneActivityTask(task.ArchetypeID) {
+		return nil
+	}
+
 	actionFn := func(
 		ctx context.Context,
 		wfContext historyi.WorkflowContext,
@@ -171,6 +176,10 @@ func (t *timerQueueStandbyTaskExecutor) executeChasmSideEffectTimerTask(
 	ctx context.Context,
 	task *tasks.ChasmTask,
 ) error {
+	if activity.ShouldDropStandaloneActivityTask(task.Info.ArchetypeId) {
+		return nil
+	}
+
 	actionFn := func(
 		ctx context.Context,
 		wfContext historyi.WorkflowContext,

--- a/service/history/timer_queue_task_executor_base.go
+++ b/service/history/timer_queue_task_executor_base.go
@@ -11,6 +11,7 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -82,6 +83,10 @@ func (t *timerQueueTaskExecutorBase) executeDeleteHistoryEventTask(
 	ctx context.Context,
 	task *tasks.DeleteHistoryEventTask,
 ) (retError error) {
+	if activity.ShouldDropStandaloneActivityTask(task.ArchetypeID) {
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
 	defer cancel()
 

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -19,6 +19,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	workflowspb "go.temporal.io/server/api/workflow/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/locks"
@@ -157,6 +158,10 @@ func (t *transferQueueActiveTaskExecutor) executeChasmSideEffectTransferTask(
 	ctx context.Context,
 	task *tasks.ChasmTask,
 ) error {
+	if activity.ShouldDropStandaloneActivityTask(task.Info.ArchetypeId) {
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
 	defer cancel()
 

--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -12,6 +12,7 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
@@ -123,6 +124,10 @@ func (t *transferQueueStandbyTaskExecutor) executeChasmSideEffectTransferTask(
 	ctx context.Context,
 	task *tasks.ChasmTask,
 ) error {
+	if activity.ShouldDropStandaloneActivityTask(task.Info.ArchetypeId) {
+		return nil
+	}
+
 	actionFn := func(
 		ctx context.Context,
 		wfContext historyi.WorkflowContext,

--- a/service/history/transfer_queue_task_executor_base.go
+++ b/service/history/transfer_queue_task_executor_base.go
@@ -11,6 +11,7 @@ import (
 	"go.temporal.io/server/api/matchingservice/v1"
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/locks"
@@ -203,6 +204,10 @@ func (t *transferQueueTaskExecutorBase) processDeleteExecutionTask(
 	task *tasks.DeleteExecutionTask,
 	ensureNoPendingCloseTask bool,
 ) error {
+	if activity.ShouldDropStandaloneActivityTask(task.ArchetypeID) {
+		return nil
+	}
+
 	if task.ArchetypeID == chasm.UnspecifiedArchetypeID {
 		task.ArchetypeID = chasm.WorkflowArchetypeID
 	}

--- a/service/history/visibility_queue_task_executor.go
+++ b/service/history/visibility_queue_task_executor.go
@@ -9,6 +9,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -314,6 +315,10 @@ func (t *visibilityQueueTaskExecutor) processDeleteExecution(
 	ctx context.Context,
 	task *tasks.DeleteExecutionVisibilityTask,
 ) (retError error) {
+	if activity.ShouldDropStandaloneActivityTask(task.ArchetypeID) {
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
 	defer cancel()
 
@@ -346,6 +351,10 @@ func (t *visibilityQueueTaskExecutor) processChasmTask(
 	ctx context.Context,
 	task *tasks.ChasmTask,
 ) (retError error) {
+	if activity.ShouldDropStandaloneActivityTask(task.Info.ArchetypeId) {
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
 	defer cancel()
 

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -1,3 +1,7 @@
+//go:build ignore
+
+// All tests disabled since standalone activity is expected to be disabled for the v1.30-148 release
+
 package tests
 
 import (


### PR DESCRIPTION
## What changed?
Drop outstanding standalone activity chasm tasks. Return unimplemented error if standalone activity is disabled. Disabled standalone activity integration tests.

## Why?
In the event of a rollback for a server version where standalone activity was enabled to v1.30.0-148, we need to gracefully handle any outstanding tasks and ensure standalone APIs return unimplemented. Integration test also must be disabled since standalone activity will not function in this version.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

(cherry picked from commit fae3f7428bb1f0f16f1e7a586c5661ab09d98592)
