### PR TITLE
chore(docker): bump alpine base to 3.23.3

### DIFF
--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -29,7 +29,7 @@ inputs:
   alpine-tag:
     description: "Alpine base image tag"
     required: false
-    default: "3.23"
+    default: "3.23.3"
   dockerhub-username:
     description: "Docker Hub username"
     required: false

--- a/.github/workflows/docker-build-manual.yml
+++ b/.github/workflows/docker-build-manual.yml
@@ -12,9 +12,9 @@ on:
         required: true
         default: "1.5.1"
       alpine-tag:
-        description: "Alpine base image tag (e.g., 3.23)"
+        description: "Alpine base image tag (e.g., 3.23.3)"
         required: true
-        default: "3.23"
+        default: "3.23.3"
       push:
         description: "Push images to Docker Hub"
         required: true

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -36,7 +36,7 @@ variable "TAG_LATEST" {
 # NOTE: We use just the tag without a digest pin because digest-pinned manifest lists
 # cause platform resolution issues in multi-arch buildx builds (InvalidBaseImagePlatform warnings).
 variable "ALPINE_TAG" {
-  default = "3.23"
+  default = "3.23.3"
 }
 
 target "admin-tools" {

--- a/docker/targets/admin-tools.Dockerfile
+++ b/docker/targets/admin-tools.Dockerfile
@@ -3,7 +3,7 @@
 # - docker/targets/server.Dockerfile (ARG ALPINE_TAG)
 # NOTE: We use just the tag without a digest pin because digest-pinned manifest lists
 # cause platform resolution issues in multi-arch buildx builds (InvalidBaseImagePlatform warnings).
-ARG ALPINE_TAG=3.23
+ARG ALPINE_TAG=3.23.3
 
 FROM alpine:${ALPINE_TAG}
 

--- a/docker/targets/server.Dockerfile
+++ b/docker/targets/server.Dockerfile
@@ -3,7 +3,7 @@
 # - docker/targets/admin-tools.Dockerfile (ARG ALPINE_TAG)
 # NOTE: We use just the tag without a digest pin because digest-pinned manifest lists
 # cause platform resolution issues in multi-arch buildx builds (InvalidBaseImagePlatform warnings).
-ARG ALPINE_TAG=3.23
+ARG ALPINE_TAG=3.23.3
 
 FROM alpine:${ALPINE_TAG}
 


### PR DESCRIPTION
## Summary
- Bump Alpine base image tag default to 3.23.3 for server/admin-tools images.
- Update defaults in docker build bake args and manual build workflows.