### PR TITLE
Improve re-usability of ringpop membership & PerNamespaceWorker

### DIFF
--- a/common/membership/ringpop/monitor.go
+++ b/common/membership/ringpop/monitor.go
@@ -458,6 +458,7 @@ var (
 	serviceNameToServiceTypeEnumMap = map[primitives.ServiceName]persistence.ServiceType{}
 )
 
+// RegisterServiceNameToServiceTypeEnum must be called from a static init().
 func RegisterServiceNameToServiceTypeEnum(serviceName primitives.ServiceName, serviceType persistence.ServiceType) {
 	serviceNameToServiceTypeEnumMap[serviceName] = serviceType
 }

--- a/service/worker/pernamespaceworker_test.go
+++ b/service/worker/pernamespaceworker_test.go
@@ -39,7 +39,7 @@ type perNsWorkerManagerSuite struct {
 	cmp1 *workercommon.MockPerNSWorkerComponent
 	cmp2 *workercommon.MockPerNSWorkerComponent
 
-	manager *perNamespaceWorkerManager
+	manager *PerNamespaceWorkerManager
 }
 
 func TestPerNsWorkerManager(t *testing.T) {
@@ -57,7 +57,7 @@ func (s *perNsWorkerManagerSuite) SetupTest() {
 	s.cmp1 = workercommon.NewMockPerNSWorkerComponent(s.controller)
 	s.cmp2 = workercommon.NewMockPerNSWorkerComponent(s.controller)
 
-	s.manager = NewPerNamespaceWorkerManager(perNamespaceWorkerManagerInitParams{
+	s.manager = PerNamespaceWorkerManagerProvider(perNamespaceWorkerManagerInitParams{
 		Logger:            s.logger,
 		SdkClientFactory:  s.cfactory,
 		NamespaceRegistry: s.registry,
@@ -558,7 +558,7 @@ func TestPerNsWorkerManagerSubscription(t *testing.T) {
 	t.Cleanup(dc.Stop)
 	config := NewConfig(dc, nil)
 
-	manager := NewPerNamespaceWorkerManager(perNamespaceWorkerManagerInitParams{
+	manager := PerNamespaceWorkerManagerProvider(perNamespaceWorkerManagerInitParams{
 		Logger:            logger,
 		SdkClientFactory:  cfactory,
 		NamespaceRegistry: registry,

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -62,7 +62,7 @@ type (
 		config           *Config
 
 		workerManager                    *workerManager
-		perNamespaceWorkerManager        *perNamespaceWorkerManager
+		perNamespaceWorkerManager        *PerNamespaceWorkerManager
 		scanner                          *scanner.Scanner
 		matchingClient                   matchingservice.MatchingServiceClient
 		namespaceReplicationTaskExecutor nsreplication.TaskExecutor
@@ -121,7 +121,7 @@ func NewService(
 	taskManager persistence.TaskManager,
 	historyClient resource.HistoryClient,
 	workerManager *workerManager,
-	perNamespaceWorkerManager *perNamespaceWorkerManager,
+	perNamespaceWorkerManager *PerNamespaceWorkerManager,
 	visibilityManager manager.VisibilityManager,
 	matchingClient resource.MatchingClient,
 	namespaceReplicationTaskExecutor nsreplication.TaskExecutor,


### PR DESCRIPTION
## What changed?
This makes the ServiceName to ServiceType mapping in the Ringpop membership implementation more extensible, and exports the worker-service's PerNamespaceWorker.

## Why?
As the code base grows, it becomes useful to enable building system services in seperate repositories (just to manage growth). 

This approach unblocks re-use of membership and PerNamespaceWorker capabilities that are more generically useful than solely inside the server.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)