### PR TITLE
Cherry-pick: Avoid softassert failure in ephemeralDataChanged during init

### DIFF
--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -1114,6 +1114,8 @@ func (pm *taskQueuePartitionManagerImpl) ephemeralDataChanged(data *taskqueuespb
 	// for now, only sticky partitions act on ephemeral data, normal partitions ignore it.
 	if pm.partition.Kind() != enumspb.TASK_QUEUE_KIND_STICKY {
 		return
+	} else if !pm.defaultQueueFuture.Ready() {
+		return // not initialized yet
 	}
 
 	// transpose map to more useful form


### PR DESCRIPTION
Cherry-pick of #9071 (commit 4841747cc754bb79eaa20e54abc555764309c1b7) into release/v1.30.x