### PR TITLE
Dump container logs on functional test failure

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -539,7 +539,7 @@ jobs:
 
       - name: Dump container logs
         if: ${{ failure() && toJson(matrix.containers) != '[]' }}
-        run: docker compose -f ${{ env.DOCKER_COMPOSE_FILE }} logs --no-color --tail=200
+        run: docker compose -f ${{ env.DOCKER_COMPOSE_FILE }} logs --no-color
 
       - name: Print memory snapshot
         if: always()


### PR DESCRIPTION
## What changed?
- We now dump container logs for failing GHA runs (including for cassandra and elasticsearch).

## Why?
- Debugging some flakiness in ES8 on ARM, right now the logs for dependencies aren't available since the cluster is torn down at the end of the test.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
