### PR TITLE
Add libsql persistence plugin

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"      // needed to load mysql plugin
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql" // needed to load postgresql plugin
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"     // needed to load sqlite plugin
+	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/libsql"     // needed to load libsql/Turso plugin
 	"go.temporal.io/server/temporal"
 )
 

--- a/cmd/tools/sql/main.go
+++ b/cmd/tools/sql/main.go
@@ -6,6 +6,7 @@ import (
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"      // needed to load mysql plugin
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql" // needed to load postgresql plugin
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"     // needed to load sqlite plugin
+	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/libsql"     // needed to load libsql/Turso plugin
 	"go.temporal.io/server/tools/sql"
 )
 

--- a/common/persistence/sql/sqlplugin/libsql/README.md
+++ b/common/persistence/sql/sqlplugin/libsql/README.md
@@ -1,0 +1,36 @@
+# libsql persistence plugin
+
+Persistence plugin using [go-libsql](https://github.com/tursodatabase/go-libsql) instead of `modernc.org/sqlite`. Reuses `schema/sqlite/` and behaves identically to the sqlite plugin with the following differences:
+
+- Requires `CGO_ENABLED=1` (go-libsql uses CGO). Supported on linux/darwin, amd64/arm64.
+- `IsDupEntryError` matches on SQLite extended error codes (`2067`, `1555`) with a string fallback,
+  since go-libsql doesn't expose typed errors like `modernc.org/sqlite` does.
+- Pragma-style connect attributes are not forwarded (go-libsql manages its own pragmas).
+  Only `mode` and `setup` are recognized.
+- DDL statements have double-quoted strings rewritten to single quotes. libsql is compiled
+  with `DQS=0` (double-quoted strings are identifiers, not literals), but our schema uses
+  double-quoted JSON paths in generated columns. `normalizeDQS` in `admin.go` rewrites
+  those to single-quoted so the visibility schema applies correctly.
+
+## Configuration
+
+```yaml
+persistence:
+  defaultStore: libsql-default
+  visibilityStore: libsql-visibility
+  datastores:
+    libsql-default:
+      sql:
+        pluginName: "libsql"
+        databaseName: "file:/var/temporal/default.db"
+        connectAttributes:
+          setup: "true"
+    libsql-visibility:
+      sql:
+        pluginName: "libsql"
+        databaseName: "file:/var/temporal/visibility.db"
+        connectAttributes:
+          setup: "true"
+```
+
+`databaseName` accepts `file:/path/to/db` or `:memory:`.

--- a/common/persistence/sql/sqlplugin/libsql/admin.go
+++ b/common/persistence/sql/sqlplugin/libsql/admin.go
@@ -1,0 +1,170 @@
+package libsql
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	readSchemaVersionQuery = `SELECT curr_version from schema_version where version_partition=0 and db_name=?`
+
+	writeSchemaVersionQuery = `REPLACE into schema_version(version_partition, db_name, creation_time, curr_version, min_compatible_version) VALUES (0,?,?,?,?)`
+
+	writeSchemaUpdateHistoryQuery = `INSERT into schema_update_history(version_partition, year, month, update_time, old_version, new_version, manifest_md5, description) VALUES(0,?,?,?,?,?,?,?)`
+
+	createSchemaVersionTableQuery = `CREATE TABLE schema_version(version_partition INT not null, ` +
+		`db_name VARCHAR(255) not null, ` +
+		`creation_time DATETIME(6), ` +
+		`curr_version VARCHAR(64), ` +
+		`min_compatible_version VARCHAR(64), ` +
+		`PRIMARY KEY (version_partition, db_name));`
+
+	createSchemaUpdateHistoryTableQuery = `CREATE TABLE schema_update_history(` +
+		`version_partition INT not null, ` +
+		`year int not null, ` +
+		`month int not null, ` +
+		`update_time DATETIME(6) not null, ` +
+		`description VARCHAR(255), ` +
+		`manifest_md5 VARCHAR(64), ` +
+		`new_version VARCHAR(64), ` +
+		`old_version VARCHAR(64), ` +
+		`PRIMARY KEY (version_partition, year, month, update_time));`
+
+	listTablesQuery = "SELECT name FROM sqlite_master WHERE type='table'"
+
+	dropTableQuery = "DROP TABLE %v"
+)
+
+// CreateSchemaVersionTables sets up the schema version tables
+func (mdb *db) CreateSchemaVersionTables() error {
+	if err := mdb.Exec(createSchemaVersionTableQuery); err != nil {
+		return err
+	}
+	return mdb.Exec(createSchemaUpdateHistoryTableQuery)
+}
+
+// ReadSchemaVersion returns the current schema version for the keyspace
+func (mdb *db) ReadSchemaVersion(database string) (string, error) {
+	var version string
+	err := mdb.db.Get(&version, readSchemaVersionQuery, database)
+	return version, err
+}
+
+// UpdateSchemaVersion updates the schema version for the keyspace
+func (mdb *db) UpdateSchemaVersion(database string, newVersion string, minCompatibleVersion string) error {
+	return mdb.Exec(writeSchemaVersionQuery, database, time.Now().UTC(), newVersion, minCompatibleVersion)
+}
+
+// WriteSchemaUpdateLog adds an entry to the schema update history table
+func (mdb *db) WriteSchemaUpdateLog(oldVersion string, newVersion string, manifestMD5 string, desc string) error {
+	now := time.Now().UTC()
+	return mdb.Exec(writeSchemaUpdateHistoryQuery, now.Year(), int(now.Month()), now, oldVersion, newVersion, manifestMD5, desc)
+}
+
+// Exec executes a sql statement.
+// libsql is compiled with DQS=0, so double-quoted strings in DDL are treated as
+// identifiers rather than string literals. Temporal's upstream schema uses
+// double-quoted JSON paths (e.g. "$.Foo") which need to be single-quoted.
+func (mdb *db) Exec(stmt string, args ...interface{}) error {
+	_, err := mdb.db.Exec(normalizeDQS(stmt), args...)
+	return err
+}
+
+// normalizeDQS rewrites double-quoted strings to single-quoted in DDL
+// statements. Only touches CREATE/ALTER statements to avoid mangling DML.
+func normalizeDQS(stmt string) string {
+	trimmed := strings.TrimSpace(stmt)
+	upper := strings.ToUpper(trimmed)
+	if !strings.HasPrefix(upper, "CREATE ") && !strings.HasPrefix(upper, "ALTER ") {
+		return stmt
+	}
+
+	var b strings.Builder
+	b.Grow(len(stmt))
+	for i := 0; i < len(stmt); i++ {
+		ch := stmt[i]
+		if ch == '\'' {
+			// skip single-quoted string literal
+			b.WriteByte(ch)
+			i++
+			for i < len(stmt) {
+				b.WriteByte(stmt[i])
+				if stmt[i] == '\'' {
+					if i+1 < len(stmt) && stmt[i+1] == '\'' {
+						b.WriteByte(stmt[i+1])
+						i++
+					} else {
+						break
+					}
+				}
+				i++
+			}
+		} else if ch == '"' {
+			// rewrite to single quote
+			b.WriteByte('\'')
+			i++
+			for i < len(stmt) {
+				if stmt[i] == '"' {
+					if i+1 < len(stmt) && stmt[i+1] == '"' {
+						b.WriteByte('\'')
+						b.WriteByte('\'')
+						i += 2
+					} else {
+						b.WriteByte('\'')
+						break
+					}
+				} else if stmt[i] == '\'' {
+					// escape embedded single quotes
+					b.WriteByte('\'')
+					b.WriteByte('\'')
+					i++
+				} else {
+					b.WriteByte(stmt[i])
+					i++
+				}
+			}
+		} else {
+			b.WriteByte(ch)
+		}
+	}
+	return b.String()
+}
+
+// ListTables returns a list of tables in this database
+func (mdb *db) ListTables(database string) ([]string, error) {
+	var tables []string
+	err := mdb.db.Select(&tables, listTablesQuery)
+	return tables, err
+}
+
+// DropTable drops a given table from the database
+func (mdb *db) DropTable(name string) error {
+	return mdb.Exec(fmt.Sprintf(dropTableQuery, name))
+}
+
+// DropAllTables drops all tables from this database
+func (mdb *db) DropAllTables(database string) error {
+	tables, err := mdb.ListTables(database)
+	if err != nil {
+		return err
+	}
+	for _, tab := range tables {
+		if err := mdb.DropTable(tab); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CreateDatabase creates a database if it doesn't exist
+func (mdb *db) CreateDatabase(name string) error {
+	// Embedded (file/memory) DB does not use separate create.
+	return nil
+}
+
+// DropDatabase drops a database
+func (mdb *db) DropDatabase(name string) error {
+	// Embedded DB does not use separate drop.
+	return nil
+}

--- a/common/persistence/sql/sqlplugin/libsql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/libsql/cluster_metadata.go
@@ -1,0 +1,244 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	p "go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const constMetadataPartition = 0
+const constMembershipPartition = 0
+const (
+	// ****** CLUSTER_METADATA_INFO TABLE ******
+	insertClusterMetadataQry = `INSERT INTO cluster_metadata_info (metadata_partition, cluster_name, data, data_encoding, version) VALUES(?, ?, ?, ?, ?)`
+
+	updateClusterMetadataQry = `UPDATE cluster_metadata_info SET data = ?, data_encoding = ?, version = ? WHERE metadata_partition = ? AND cluster_name = ?`
+
+	getClusterMetadataBase         = `SELECT data, data_encoding, version FROM cluster_metadata_info `
+	getClusterMetadataQry          = getClusterMetadataBase + `WHERE metadata_partition = ? AND cluster_name = ?`
+	listClusterMetadataQry         = getClusterMetadataBase + `WHERE metadata_partition = ? ORDER BY cluster_name LIMIT ?`
+	listClusterMetadataRangeQry    = getClusterMetadataBase + `WHERE metadata_partition = ? AND cluster_name > ? ORDER BY cluster_name LIMIT ?`
+	writeLockGetClusterMetadataQry = getClusterMetadataQry
+
+	deleteClusterMetadataQry = `DELETE FROM cluster_metadata_info WHERE metadata_partition = ? AND cluster_name = ?`
+
+	// ****** CLUSTER_MEMBERSHIP TABLE ******
+	templateUpsertActiveClusterMembership = `REPLACE INTO
+cluster_membership (membership_partition, host_id, rpc_address, rpc_port, role, session_start, last_heartbeat, record_expiry)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?) `
+
+	templatePruneStaleClusterMembership = `DELETE FROM
+cluster_membership 
+WHERE membership_partition = ? AND record_expiry < ?`
+
+	templateGetClusterMembership = `SELECT host_id, rpc_address, rpc_port, role, session_start, last_heartbeat, record_expiry FROM
+cluster_membership WHERE membership_partition = ?`
+
+	// ClusterMembership WHERE Suffixes
+	templateWithRoleSuffix           = ` AND role = ?`
+	templateWithHeartbeatSinceSuffix = ` AND last_heartbeat > ?`
+	templateWithRecordExpirySuffix   = ` AND record_expiry > ?`
+	templateWithRPCAddressSuffix     = ` AND rpc_address = ?`
+	templateWithHostIDSuffix         = ` AND host_id = ?`
+	templateWithHostIDGreaterSuffix  = ` AND host_id > ?`
+	templateWithSessionStartSuffix   = ` AND session_start >= ?`
+
+	// Generic SELECT Suffixes
+	templateWithLimitSuffix               = ` LIMIT ?`
+	templateWithOrderBySessionStartSuffix = ` ORDER BY membership_partition ASC, host_id ASC`
+)
+
+func (mdb *db) SaveClusterMetadata(
+	ctx context.Context,
+	row *sqlplugin.ClusterMetadataRow,
+) (sql.Result, error) {
+	if row.Version == 0 {
+		return mdb.conn.ExecContext(ctx,
+			insertClusterMetadataQry,
+			constMetadataPartition,
+			row.ClusterName,
+			row.Data,
+			row.DataEncoding,
+			1,
+		)
+	}
+	return mdb.conn.ExecContext(ctx,
+		updateClusterMetadataQry,
+		row.Data,
+		row.DataEncoding,
+		row.Version+1,
+		constMetadataPartition,
+		row.ClusterName,
+	)
+}
+
+func (mdb *db) ListClusterMetadata(
+	ctx context.Context,
+	filter *sqlplugin.ClusterMetadataFilter,
+) ([]sqlplugin.ClusterMetadataRow, error) {
+	var err error
+	var rows []sqlplugin.ClusterMetadataRow
+	switch {
+	case len(filter.ClusterName) != 0:
+		err = mdb.conn.SelectContext(ctx,
+			&rows,
+			listClusterMetadataRangeQry,
+			constMetadataPartition,
+			filter.ClusterName,
+			filter.PageSize,
+		)
+	default:
+		err = mdb.conn.SelectContext(ctx,
+			&rows,
+			listClusterMetadataQry,
+			constMetadataPartition,
+			filter.PageSize,
+		)
+	}
+	return rows, err
+}
+
+func (mdb *db) GetClusterMetadata(
+	ctx context.Context,
+	filter *sqlplugin.ClusterMetadataFilter,
+) (*sqlplugin.ClusterMetadataRow, error) {
+	var row sqlplugin.ClusterMetadataRow
+	err := mdb.conn.GetContext(ctx,
+		&row,
+		getClusterMetadataQry,
+		constMetadataPartition,
+		filter.ClusterName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, err
+}
+
+func (mdb *db) WriteLockGetClusterMetadata(
+	ctx context.Context,
+	filter *sqlplugin.ClusterMetadataFilter,
+) (*sqlplugin.ClusterMetadataRow, error) {
+	var row sqlplugin.ClusterMetadataRow
+	err := mdb.conn.GetContext(ctx,
+		&row,
+		writeLockGetClusterMetadataQry,
+		constMetadataPartition,
+		filter.ClusterName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, err
+}
+
+func (mdb *db) DeleteClusterMetadata(
+	ctx context.Context,
+	filter *sqlplugin.ClusterMetadataFilter,
+) (sql.Result, error) {
+
+	return mdb.conn.ExecContext(ctx,
+		deleteClusterMetadataQry,
+		constMetadataPartition,
+		filter.ClusterName,
+	)
+}
+
+func (mdb *db) UpsertClusterMembership(
+	ctx context.Context,
+	row *sqlplugin.ClusterMembershipRow,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		templateUpsertActiveClusterMembership,
+		constMembershipPartition,
+		row.HostID,
+		row.RPCAddress,
+		row.RPCPort,
+		row.Role,
+		mdb.converter.ToSQLiteDateTime(row.SessionStart),
+		mdb.converter.ToSQLiteDateTime(row.LastHeartbeat),
+		mdb.converter.ToSQLiteDateTime(row.RecordExpiry))
+}
+
+func (mdb *db) GetClusterMembers(
+	ctx context.Context,
+	filter *sqlplugin.ClusterMembershipFilter,
+) ([]sqlplugin.ClusterMembershipRow, error) {
+	var queryString strings.Builder
+	var operands []interface{}
+	queryString.WriteString(templateGetClusterMembership)
+	operands = append(operands, constMembershipPartition)
+
+	if filter.HostIDEquals != nil {
+		queryString.WriteString(templateWithHostIDSuffix)
+		operands = append(operands, filter.HostIDEquals)
+	}
+
+	if filter.RPCAddressEquals != "" {
+		queryString.WriteString(templateWithRPCAddressSuffix)
+		operands = append(operands, filter.RPCAddressEquals)
+	}
+
+	if filter.RoleEquals != p.All {
+		queryString.WriteString(templateWithRoleSuffix)
+		operands = append(operands, filter.RoleEquals)
+	}
+
+	if !filter.LastHeartbeatAfter.IsZero() {
+		queryString.WriteString(templateWithHeartbeatSinceSuffix)
+		operands = append(operands, filter.LastHeartbeatAfter)
+	}
+
+	if !filter.RecordExpiryAfter.IsZero() {
+		queryString.WriteString(templateWithRecordExpirySuffix)
+		operands = append(operands, filter.RecordExpiryAfter)
+	}
+
+	if !filter.SessionStartedAfter.IsZero() {
+		queryString.WriteString(templateWithSessionStartSuffix)
+		operands = append(operands, filter.SessionStartedAfter)
+	}
+
+	if filter.HostIDGreaterThan != nil {
+		queryString.WriteString(templateWithHostIDGreaterSuffix)
+		operands = append(operands, filter.HostIDGreaterThan)
+	}
+
+	queryString.WriteString(templateWithOrderBySessionStartSuffix)
+
+	if filter.MaxRecordCount > 0 {
+		queryString.WriteString(templateWithLimitSuffix)
+		operands = append(operands, filter.MaxRecordCount)
+	}
+
+	compiledQryString := queryString.String()
+
+	var rows []sqlplugin.ClusterMembershipRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		compiledQryString,
+		operands...,
+	); err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		rows[i].SessionStart = mdb.converter.FromSQLiteDateTime(rows[i].SessionStart)
+		rows[i].LastHeartbeat = mdb.converter.FromSQLiteDateTime(rows[i].LastHeartbeat)
+		rows[i].RecordExpiry = mdb.converter.FromSQLiteDateTime(rows[i].RecordExpiry)
+	}
+	return rows, nil
+}
+
+func (mdb *db) PruneClusterMembership(
+	ctx context.Context,
+	filter *sqlplugin.PruneClusterMembershipFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		templatePruneStaleClusterMembership,
+		constMembershipPartition,
+		mdb.converter.ToSQLiteDateTime(filter.PruneRecordsBefore),
+	)
+}

--- a/common/persistence/sql/sqlplugin/libsql/conn_pool.go
+++ b/common/persistence/sql/sqlplugin/libsql/conn_pool.go
@@ -1,0 +1,81 @@
+package libsql
+
+import (
+	"sync"
+
+	"github.com/jmoiron/sqlx"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/resolver"
+)
+
+// This pool properly enables support for libsql in the Temporal server.
+// Internal Temporal services are highly isolated, each will create at least a single connection to the database;
+// we share one connection (single writer) to avoid locking issues.
+type connPool struct {
+	mu   sync.Mutex
+	pool map[string]entry
+}
+
+type entry struct {
+	db       *sqlx.DB
+	refCount int
+}
+
+func newConnPool() *connPool {
+	return &connPool{
+		pool: make(map[string]entry),
+	}
+}
+
+// Allocate allocates the shared database in the pool or returns already exists instance with the same DSN. If instance
+// for such DSN already exists, it will be returned instead. Each request counts as reference until Close.
+func (cp *connPool) Allocate(
+	cfg *config.SQL,
+	resolver resolver.ServiceResolver,
+	logger log.Logger,
+	create func(*config.SQL, resolver.ServiceResolver, log.Logger) (*sqlx.DB, error),
+) (db *sqlx.DB, err error) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	dsn := buildDSN(cfg)
+
+	if e, ok := cp.pool[dsn]; ok {
+		e.refCount++
+		cp.pool[dsn] = e
+		return e.db, nil
+	}
+
+	db, err = create(cfg, resolver, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	cp.pool[dsn] = entry{db: db, refCount: 1}
+
+	return db, nil
+}
+
+// Close virtual connection to database. Only closes for real once no references left.
+func (cp *connPool) Close(cfg *config.SQL) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	dsn := buildDSN(cfg)
+
+	e, ok := cp.pool[dsn]
+	if !ok {
+		return
+	}
+
+	e.refCount--
+	cp.pool[dsn] = e
+	// todo: at the moment pool will persist a single connection to the DB for the whole duration of application
+	// temporal will start and stop DB connections multiple times, which will cause the loss of the cache
+	// and "db is closed" error
+	// if e.refCount == 0 {
+	// 	e.db.Close()
+	// 	delete(cp.pool, dsn)
+	// }
+}

--- a/common/persistence/sql/sqlplugin/libsql/db.go
+++ b/common/persistence/sql/sqlplugin/libsql/db.go
@@ -1,0 +1,125 @@
+package libsql
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/jmoiron/sqlx"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	sqliteschema "go.temporal.io/server/schema/sqlite"
+)
+
+// db represents a logical connection to a libsql database
+type db struct {
+	dbKind sqlplugin.DbKind
+	dbName string
+
+	mu      sync.RWMutex
+	onClose []func()
+
+	db        *sqlx.DB
+	tx        *sqlx.Tx
+	conn      sqlplugin.Conn
+	converter DataConverter
+	logger    log.Logger
+}
+
+var _ sqlplugin.AdminDB = (*db)(nil)
+var _ sqlplugin.DB = (*db)(nil)
+var _ sqlplugin.Tx = (*db)(nil)
+
+// newDB returns an instance of DB, which is a logical
+// connection to the underlying libsql database
+func newDB(
+	dbKind sqlplugin.DbKind,
+	dbName string,
+	xdb *sqlx.DB,
+	tx *sqlx.Tx,
+	logger log.Logger,
+) *db {
+	mdb := &db{
+		dbKind:  dbKind,
+		dbName:  dbName,
+		onClose: make([]func(), 0),
+		db:      xdb,
+		tx:      tx,
+		logger:  logger,
+	}
+	mdb.conn = xdb
+	if tx != nil {
+		mdb.conn = tx
+	}
+	mdb.converter = &converter{}
+	return mdb
+}
+
+// BeginTx starts a new transaction and returns a reference to the Tx object
+func (mdb *db) BeginTx(ctx context.Context) (sqlplugin.Tx, error) {
+	xtx, err := mdb.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return newDB(mdb.dbKind, mdb.dbName, mdb.db, xtx, mdb.logger), nil
+}
+
+// Commit commits a previously started transaction
+func (mdb *db) Commit() error {
+	return mdb.tx.Commit()
+}
+
+// Rollback triggers rollback of a previously started transaction
+func (mdb *db) Rollback() error {
+	return mdb.tx.Rollback()
+}
+
+func (mdb *db) OnClose(hook func()) {
+	mdb.mu.Lock()
+	mdb.onClose = append(mdb.onClose, hook)
+	mdb.mu.Unlock()
+}
+
+// Close closes the connection to the libsql db
+func (mdb *db) Close() error {
+	mdb.mu.RLock()
+	defer mdb.mu.RUnlock()
+
+	for _, hook := range mdb.onClose {
+		// de-registers the database from conn pool
+		hook()
+	}
+
+	// database connection will be automatically closed by the hook handler when all references are removed
+	return nil
+}
+
+// PluginName returns the name of the plugin
+func (mdb *db) PluginName() string {
+	return PluginName
+}
+
+// DbName returns the name of the database
+func (mdb *db) DbName() string {
+	return mdb.dbName
+}
+
+// ExpectedVersion returns expected version.
+func (mdb *db) ExpectedVersion() string {
+	switch mdb.dbKind {
+	case sqlplugin.DbKindMain:
+		return sqliteschema.Version
+	case sqlplugin.DbKindVisibility:
+		return sqliteschema.VisibilityVersion
+	default:
+		panic(fmt.Sprintf("unknown db kind %v", mdb.dbKind))
+	}
+}
+
+// VerifyVersion verify schema version is up to date
+func (mdb *db) VerifyVersion() error {
+	return nil
+	// TODO(jlegrone): implement this
+	// expectedVersion := mdb.ExpectedVersion()
+	// return schema.VerifyCompatibleVersion(mdb, mdb.dbName, expectedVersion)
+}

--- a/common/persistence/sql/sqlplugin/libsql/driver.go
+++ b/common/persistence/sql/sqlplugin/libsql/driver.go
@@ -1,0 +1,117 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"regexp"
+	"strings"
+
+	_ "github.com/tursodatabase/go-libsql"
+)
+
+const (
+	goSQLDriverName = "libsql_temporal"
+	innerDriverName = "libsql"
+
+	sqlTableExistsPattern  = `(?i)table .* already exists`
+	sqliteConstraintUnique = "error code = 2067" // SQLITE_CONSTRAINT_UNIQUE
+	sqliteConstraintPK     = "error code = 1555" // SQLITE_CONSTRAINT_PRIMARYKEY
+)
+
+// wrappedDriver wraps go-libsql's driver to return connections that implement
+// ResetSession() and IsValid(), preventing the SQL library from closing the
+// connection when a transaction context is canceled.
+type wrappedDriver struct {
+	inner driver.Driver
+}
+
+func (d *wrappedDriver) Open(name string) (driver.Conn, error) {
+	c, err := d.inner.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &conn{inner: c}, nil
+}
+
+// conn wraps a go-libsql connection. We can't embed driver.Conn because
+// go-libsql's conn also implements ExecerContext, QueryerContext, etc. and
+// embedding would shadow those from database/sql's type assertions.
+type conn struct {
+	inner driver.Conn
+}
+
+func (c *conn) Prepare(query string) (driver.Stmt, error) { return c.inner.Prepare(query) }
+func (c *conn) Close() error                              { return c.inner.Close() }
+func (c *conn) Begin() (driver.Tx, error)                 { return c.inner.Begin() }
+
+func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if bt, ok := c.inner.(driver.ConnBeginTx); ok {
+		return bt.BeginTx(ctx, opts)
+	}
+	return c.inner.Begin()
+}
+
+func (c *conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	if pc, ok := c.inner.(driver.ConnPrepareContext); ok {
+		return pc.PrepareContext(ctx, query)
+	}
+	return c.inner.Prepare(query)
+}
+
+func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	if ec, ok := c.inner.(driver.ExecerContext); ok {
+		return ec.ExecContext(ctx, query, args)
+	}
+	return nil, driver.ErrSkip
+}
+
+func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	if qc, ok := c.inner.(driver.QueryerContext); ok {
+		return qc.QueryContext(ctx, query, args)
+	}
+	return nil, driver.ErrSkip
+}
+
+// ResetSession does nothing. We only have one connection to the db. It should always be valid.
+// Otherwise we would have already lost the database.
+func (c *conn) ResetSession(_ context.Context) error { return nil }
+
+// IsValid always returns true. Same reasoning as ResetSession.
+func (c *conn) IsValid() bool { return true }
+
+func init() {
+	// go-libsql registers "libsql" in its own init(); grab the driver and wrap it.
+	db, err := sql.Open(innerDriverName, ":memory:")
+	if err != nil {
+		panic("libsql plugin: " + err.Error())
+	}
+	inner := db.Driver()
+	_ = db.Close()
+	sql.Register(goSQLDriverName, &wrappedDriver{inner: inner})
+}
+
+var sqlTableExistsRegex = regexp.MustCompile(sqlTableExistsPattern)
+
+// go-libsql doesn't expose typed errors, but does include the extended
+// error code in the message (e.g. "error code = 2067: UNIQUE constraint failed").
+func (*db) IsDupEntryError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	if strings.Contains(msg, sqliteConstraintUnique) || strings.Contains(msg, sqliteConstraintPK) {
+		return true
+	}
+	// fallback for forward compat if error format changes
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "unique constraint failed") ||
+		strings.Contains(lower, "primary key constraint failed")
+}
+
+func isTableExistsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return sqlTableExistsRegex.MatchString(err.Error())
+}

--- a/common/persistence/sql/sqlplugin/libsql/driver_test.go
+++ b/common/persistence/sql/sqlplugin/libsql/driver_test.go
@@ -1,0 +1,90 @@
+package libsql
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/config"
+)
+
+func TestIsDupEntryError(t *testing.T) {
+	d := &db{}
+
+	require.False(t, d.IsDupEntryError(nil))
+	require.False(t, d.IsDupEntryError(errors.New("something else")))
+
+	// error code path
+	require.True(t, d.IsDupEntryError(
+		errors.New("failed to execute query INSERT INTO ...\nerror code = 2067: UNIQUE constraint failed: executions.shard_id"),
+	))
+	require.True(t, d.IsDupEntryError(
+		errors.New("failed to execute query INSERT INTO ...\nerror code = 1555: PRIMARY KEY constraint failed"),
+	))
+
+	// string fallback
+	require.True(t, d.IsDupEntryError(errors.New("UNIQUE constraint failed: t.c")))
+	require.True(t, d.IsDupEntryError(errors.New("primary key constraint failed")))
+
+	// base constraint code should NOT match (we only want the specific extended codes)
+	require.False(t, d.IsDupEntryError(errors.New("error code = 19: SQLITE_CONSTRAINT")))
+}
+
+func TestIsTableExistsError(t *testing.T) {
+	require.False(t, isTableExistsError(nil))
+	require.False(t, isTableExistsError(errors.New("something else")))
+	require.True(t, isTableExistsError(errors.New("table executions_visibility already exists")))
+	require.True(t, isTableExistsError(errors.New("TABLE schema_version ALREADY EXISTS")))
+	require.False(t, isTableExistsError(errors.New("table not found")))
+}
+
+func TestBuildDSN(t *testing.T) {
+	require.Equal(t, ":memory:", buildDSN(&config.SQL{DatabaseName: ":memory:"}))
+	require.Equal(t, ":memory:", buildDSN(&config.SQL{
+		DatabaseName:      "ignored",
+		ConnectAttributes: map[string]string{"mode": "memory"},
+	}))
+	require.Equal(t, "file:/var/temporal/default.db", buildDSN(&config.SQL{DatabaseName: "/var/temporal/default.db"}))
+	require.Equal(t, "file:/var/temporal/default.db", buildDSN(&config.SQL{DatabaseName: "file:/var/temporal/default.db"}))
+	require.Equal(t, "file:/tmp/test.db", buildDSN(&config.SQL{DatabaseName: "/tmp/test.db"}))
+}
+
+func TestNormalizeDQS(t *testing.T) {
+	// DDL with double-quoted JSON paths should be rewritten
+	input := `CREATE TABLE t (x TEXT GENERATED ALWAYS AS (JSON_EXTRACT(data, "$.foo")))`
+	expected := `CREATE TABLE t (x TEXT GENERATED ALWAYS AS (JSON_EXTRACT(data, '$.foo')))`
+	require.Equal(t, expected, normalizeDQS(input))
+
+	// Single-quoted strings pass through unchanged
+	input = `CREATE TABLE t (x TEXT GENERATED ALWAYS AS (JSON_EXTRACT(data, '$.foo')))`
+	require.Equal(t, input, normalizeDQS(input))
+
+	// Non-DDL statements are not touched
+	input = `INSERT INTO t (name) VALUES ("hello")`
+	require.Equal(t, input, normalizeDQS(input))
+
+	// Escaped double quotes inside double-quoted string
+	input = `CREATE TABLE t (x TEXT DEFAULT "say ""hi""")`
+	expected = `CREATE TABLE t (x TEXT DEFAULT 'say ''hi''')`
+	require.Equal(t, expected, normalizeDQS(input))
+
+	// Single quotes embedded inside a double-quoted string get escaped
+	input = `CREATE TABLE t (x TEXT DEFAULT "it's")`
+	expected = `CREATE TABLE t (x TEXT DEFAULT 'it''s')`
+	require.Equal(t, expected, normalizeDQS(input))
+
+	// Mixed: single-quoted string followed by double-quoted string
+	input = `CREATE TABLE t (a TEXT DEFAULT 'keep', b TEXT DEFAULT "rewrite")`
+	expected = `CREATE TABLE t (a TEXT DEFAULT 'keep', b TEXT DEFAULT 'rewrite')`
+	require.Equal(t, expected, normalizeDQS(input))
+
+	// ALTER TABLE is also handled
+	input = `ALTER TABLE t ADD COLUMN x TEXT GENERATED ALWAYS AS (JSON_EXTRACT(data, "$.bar"))`
+	expected = `ALTER TABLE t ADD COLUMN x TEXT GENERATED ALWAYS AS (JSON_EXTRACT(data, '$.bar'))`
+	require.Equal(t, expected, normalizeDQS(input))
+
+	// STRFTIME with mixed quoting from Temporal schema
+	input = `CREATE TABLE t (ts TIMESTAMP GENERATED ALWAYS AS (STRFTIME('%Y-%m-%d', JSON_EXTRACT(data, "$.dt"))))`
+	expected = `CREATE TABLE t (ts TIMESTAMP GENERATED ALWAYS AS (STRFTIME('%Y-%m-%d', JSON_EXTRACT(data, '$.dt'))))`
+	require.Equal(t, expected, normalizeDQS(input))
+}

--- a/common/persistence/sql/sqlplugin/libsql/events.go
+++ b/common/persistence/sql/sqlplugin/libsql/events.go
@@ -1,0 +1,202 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	// below are templates for history_node table
+	replaceHistoryNodesQuery = `REPLACE INTO history_node (` +
+		`shard_id, tree_id, branch_id, node_id, prev_txn_id, txn_id, data, data_encoding) ` +
+		`VALUES (:shard_id, :tree_id, :branch_id, :node_id, :prev_txn_id, :txn_id, :data, :data_encoding) `
+
+	getHistoryNodesQuery = `SELECT node_id, prev_txn_id, txn_id, data, data_encoding FROM history_node ` +
+		`WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND ((node_id = ? AND txn_id > ?) OR node_id > ?) AND node_id < ? ` +
+		`ORDER BY shard_id, tree_id, branch_id, node_id, txn_id LIMIT ? `
+
+	getHistoryNodesReverseQuery = `SELECT node_id, prev_txn_id, txn_id, data, data_encoding FROM history_node ` +
+		`WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id >= ? AND ((node_id = ? AND txn_id < ?) OR node_id < ?) ` +
+		`ORDER BY shard_id, tree_id, branch_id DESC, node_id DESC, txn_id DESC LIMIT ? `
+
+	getHistoryNodeMetadataQuery = `SELECT node_id, prev_txn_id, txn_id FROM history_node ` +
+		`WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND ((node_id = ? AND txn_id > ?) OR node_id > ?) AND node_id < ? ` +
+		`ORDER BY shard_id, tree_id, branch_id, node_id, txn_id LIMIT ? `
+
+	deleteHistoryNodeQuery = `DELETE FROM history_node WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id = ? AND txn_id = ? `
+
+	deleteHistoryNodesQuery = `DELETE FROM history_node WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id >= ? `
+
+	// below are templates for history_tree table
+	addHistoryTreeQuery = `REPLACE INTO history_tree (` +
+		`shard_id, tree_id, branch_id, data, data_encoding) ` +
+		`VALUES (:shard_id, :tree_id, :branch_id, :data, :data_encoding) `
+
+	getHistoryTreeQuery = `SELECT branch_id, data, data_encoding FROM history_tree WHERE shard_id = ? AND tree_id = ? `
+
+	paginateBranchesQuery = `SELECT shard_id, tree_id, branch_id, data, data_encoding
+        FROM history_tree
+        WHERE (shard_id, tree_id, branch_id) > ($1, $2, $3)
+        ORDER BY shard_id, tree_id, branch_id
+        LIMIT $4`
+
+	deleteHistoryTreeQuery = `DELETE FROM history_tree WHERE shard_id = ? AND tree_id = ? AND branch_id = ? `
+)
+
+// For history_node table:
+
+// InsertIntoHistoryNode inserts a row into history_node table
+func (mdb *db) InsertIntoHistoryNode(
+	ctx context.Context,
+	row *sqlplugin.HistoryNodeRow,
+) (sql.Result, error) {
+	// NOTE: txn_id is *= -1 within DB
+	row.TxnID = -row.TxnID
+	return mdb.conn.NamedExecContext(ctx,
+		replaceHistoryNodesQuery,
+		row,
+	)
+}
+
+// DeleteFromHistoryNode delete a row from history_node table
+func (mdb *db) DeleteFromHistoryNode(
+	ctx context.Context,
+	row *sqlplugin.HistoryNodeRow,
+) (sql.Result, error) {
+	// NOTE: txn_id is *= -1 within DB
+	row.TxnID = -row.TxnID
+	return mdb.conn.ExecContext(ctx,
+		deleteHistoryNodeQuery,
+		row.ShardID,
+		row.TreeID,
+		row.BranchID,
+		row.NodeID,
+		row.TxnID,
+	)
+}
+
+// SelectFromHistoryNode reads one or more rows from history_node table
+func (mdb *db) RangeSelectFromHistoryNode(
+	ctx context.Context,
+	filter sqlplugin.HistoryNodeSelectFilter,
+) ([]sqlplugin.HistoryNodeRow, error) {
+	var query string
+	if filter.MetadataOnly {
+		query = getHistoryNodeMetadataQuery
+	} else if filter.ReverseOrder {
+		query = getHistoryNodesReverseQuery
+	} else {
+		query = getHistoryNodesQuery
+	}
+
+	var args []interface{}
+	if filter.ReverseOrder {
+		args = []interface{}{
+			filter.ShardID,
+			filter.TreeID,
+			filter.BranchID,
+			filter.MinNodeID,
+			filter.MaxTxnID,
+			-filter.MaxTxnID,
+			filter.MaxNodeID,
+			filter.PageSize,
+		}
+	} else {
+		args = []interface{}{
+			filter.ShardID,
+			filter.TreeID,
+			filter.BranchID,
+			filter.MinNodeID,
+			-filter.MinTxnID, // NOTE: transaction ID is *= -1 when stored
+			filter.MinNodeID,
+			filter.MaxNodeID,
+			filter.PageSize,
+		}
+	}
+
+	var rows []sqlplugin.HistoryNodeRow
+	if err := mdb.conn.SelectContext(ctx, &rows, query, args...); err != nil {
+		return nil, err
+	}
+
+	for index := range rows {
+		rows[index].TxnID = -rows[index].TxnID
+	}
+
+	return rows, nil
+}
+
+// DeleteFromHistoryNode deletes one or more rows from history_node table
+func (mdb *db) RangeDeleteFromHistoryNode(
+	ctx context.Context,
+	filter sqlplugin.HistoryNodeDeleteFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteHistoryNodesQuery,
+		filter.ShardID,
+		filter.TreeID,
+		filter.BranchID,
+		filter.MinNodeID,
+	)
+}
+
+// For history_tree table:
+
+// InsertIntoHistoryTree inserts a row into history_tree table
+func (mdb *db) InsertIntoHistoryTree(
+	ctx context.Context,
+	row *sqlplugin.HistoryTreeRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		addHistoryTreeQuery,
+		row,
+	)
+}
+
+// SelectFromHistoryTree reads one or more rows from history_tree table
+func (mdb *db) SelectFromHistoryTree(
+	ctx context.Context,
+	filter sqlplugin.HistoryTreeSelectFilter,
+) ([]sqlplugin.HistoryTreeRow, error) {
+	var rows []sqlplugin.HistoryTreeRow
+	err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getHistoryTreeQuery,
+		filter.ShardID,
+		filter.TreeID,
+	)
+	return rows, err
+}
+
+// PaginateBranchesFromHistoryTree reads up to page.Limit rows from the history_tree table sorted by their primary key,
+// while skipping the first page.Offset rows.
+func (mdb *db) PaginateBranchesFromHistoryTree(
+	ctx context.Context,
+	page sqlplugin.HistoryTreeBranchPage,
+) ([]sqlplugin.HistoryTreeRow, error) {
+	var rows []sqlplugin.HistoryTreeRow
+	err := mdb.conn.SelectContext(ctx,
+		&rows,
+		paginateBranchesQuery,
+		page.ShardID,
+		page.TreeID,
+		page.BranchID,
+		page.Limit,
+	)
+	return rows, err
+}
+
+// DeleteFromHistoryTree deletes one or more rows from history_tree table
+func (mdb *db) DeleteFromHistoryTree(
+	ctx context.Context,
+	filter sqlplugin.HistoryTreeDeleteFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteHistoryTreeQuery,
+		filter.ShardID,
+		filter.TreeID,
+		filter.BranchID,
+	)
+}

--- a/common/persistence/sql/sqlplugin/libsql/execution.go
+++ b/common/persistence/sql/sqlplugin/libsql/execution.go
@@ -1,0 +1,927 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	"go.temporal.io/server/common/softassert"
+)
+
+const (
+	executionsColumns = `shard_id, namespace_id, workflow_id, run_id, next_event_id, last_write_version, data, data_encoding, state, state_encoding, db_record_version`
+
+	createExecutionQuery = `INSERT INTO executions(` + executionsColumns + `)
+ VALUES(:shard_id, :namespace_id, :workflow_id, :run_id, :next_event_id, :last_write_version, :data, :data_encoding, :state, :state_encoding, :db_record_version)`
+
+	updateExecutionQuery = `UPDATE executions SET
+ db_record_version = :db_record_version, next_event_id = :next_event_id, last_write_version = :last_write_version, data = :data, data_encoding = :data_encoding, state = :state, state_encoding = :state_encoding
+ WHERE shard_id = :shard_id AND namespace_id = :namespace_id AND workflow_id = :workflow_id AND run_id = :run_id`
+
+	getExecutionQuery = `SELECT ` + executionsColumns + ` FROM executions
+ WHERE shard_id = ? AND namespace_id = ? AND workflow_id = ? AND run_id = ?`
+
+	deleteExecutionQuery = `DELETE FROM executions 
+ WHERE shard_id = ? AND namespace_id = ? AND workflow_id = ? AND run_id = ?`
+
+	lockExecutionQueryBase = `SELECT db_record_version, next_event_id FROM executions 
+ WHERE shard_id = ? AND namespace_id = ? AND workflow_id = ? AND run_id = ?`
+
+	writeLockExecutionQuery = lockExecutionQueryBase
+	readLockExecutionQuery  = lockExecutionQueryBase
+
+	createCurrentExecutionQuery = `INSERT INTO current_executions
+(shard_id, namespace_id, workflow_id, run_id, create_request_id, state, status, start_time, last_write_version, data, data_encoding) VALUES
+(:shard_id, :namespace_id, :workflow_id, :run_id, :create_request_id, :state, :status, :start_time, :last_write_version, :data, :data_encoding)`
+	createCurrentChasmExecutionQuery = `INSERT INTO current_chasm_executions
+(shard_id, namespace_id, business_id, archetype_id, run_id, create_request_id, state, status, start_time, last_write_version, data, data_encoding) VALUES
+(:shard_id, :namespace_id, :workflow_id, :archetype_id, :run_id, :create_request_id, :state, :status, :start_time, :last_write_version, :data, :data_encoding)`
+
+	deleteCurrentExecutionQuery      = "DELETE FROM current_executions WHERE shard_id = ? AND namespace_id = ? AND workflow_id = ? AND run_id = ?"
+	deleteCurrentChasmExecutionQuery = "DELETE FROM current_chasm_executions WHERE shard_id = ? AND namespace_id = ? AND business_id = ? AND archetype_id = ? AND run_id = ?"
+
+	getCurrentExecutionQuery = `SELECT
+shard_id, namespace_id, workflow_id, run_id, create_request_id, state, status, start_time, last_write_version, data, data_encoding
+FROM current_executions WHERE shard_id = ? AND namespace_id = ? AND workflow_id = ?`
+	getCurrentChasmExecutionQuery = `SELECT
+shard_id, namespace_id, business_id as workflow_id, run_id, create_request_id, state, status, start_time, last_write_version, data, data_encoding
+FROM current_chasm_executions WHERE shard_id = ? AND namespace_id = ? AND business_id = ? AND archetype_id = ?`
+
+	lockCurrentExecutionJoinExecutionsQuery = `SELECT
+ce.shard_id, ce.namespace_id, ce.workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, e.last_write_version, ce.data, ce.data_encoding
+FROM current_executions ce
+INNER JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.workflow_id AND e.run_id = ce.run_id
+WHERE ce.shard_id = ? AND ce.namespace_id = ? AND ce.workflow_id = ?`
+	lockCurrentChasmExecutionJoinExecutionsQuery = `SELECT
+ce.shard_id, ce.namespace_id, ce.business_id as workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, e.last_write_version, ce.data, ce.data_encoding
+FROM current_chasm_executions ce
+INNER JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.business_id AND e.run_id = ce.run_id
+WHERE ce.shard_id = ? AND ce.namespace_id = ? AND ce.business_id = ? AND ce.archetype_id = ?`
+
+	lockCurrentExecutionQuery      = getCurrentExecutionQuery
+	lockCurrentChasmExecutionQuery = getCurrentChasmExecutionQuery
+
+	updateCurrentExecutionsBase = ` SET
+run_id = :run_id,
+create_request_id = :create_request_id,
+state = :state,
+status = :status,
+start_time = :start_time,
+last_write_version = :last_write_version,
+data = :data,
+data_encoding = :data_encoding
+WHERE
+shard_id = :shard_id AND
+namespace_id = :namespace_id
+`
+	updateCurrentExecutionsQuery      = `UPDATE current_executions` + updateCurrentExecutionsBase + ` AND workflow_id = :workflow_id`
+	updateCurrentChasmExecutionsQuery = `UPDATE current_chasm_executions` + updateCurrentExecutionsBase + ` AND business_id = :workflow_id AND archetype_id = :archetype_id`
+
+	createHistoryImmediateTasksQuery = `INSERT INTO history_immediate_tasks(shard_id, category_id, task_id, data, data_encoding) 
+ VALUES(:shard_id, :category_id, :task_id, :data, :data_encoding)`
+
+	getHistoryImmediateTasksQuery = `SELECT task_id, data, data_encoding 
+ FROM history_immediate_tasks WHERE shard_id = ? AND category_id = ? AND task_id >= ? AND task_id < ? ORDER BY task_id LIMIT ?`
+
+	deleteHistoryImmediateTaskQuery       = `DELETE FROM history_immediate_tasks WHERE shard_id = ? AND category_id = ? AND task_id = ?`
+	rangeDeleteHistoryImmediateTasksQuery = `DELETE FROM history_immediate_tasks WHERE shard_id = ? AND category_id = ? AND task_id >= ? AND task_id < ?`
+
+	createHistoryScheduledTasksQuery = `INSERT INTO history_scheduled_tasks (shard_id, category_id, visibility_timestamp, task_id, data, data_encoding)
+  VALUES (:shard_id, :category_id, :visibility_timestamp, :task_id, :data, :data_encoding)`
+
+	getHistoryScheduledTasksQuery = `SELECT visibility_timestamp, task_id, data, data_encoding FROM history_scheduled_tasks 
+  WHERE shard_id = ? 
+  AND category_id = ? 
+  AND ((visibility_timestamp >= ? AND task_id >= ?) OR visibility_timestamp > ?) 
+  AND visibility_timestamp < ?
+  ORDER BY visibility_timestamp,task_id LIMIT ?`
+
+	deleteHistoryScheduledTaskQuery       = `DELETE FROM history_scheduled_tasks WHERE shard_id = ? AND category_id = ? AND visibility_timestamp = ? AND task_id = ?`
+	rangeDeleteHistoryScheduledTasksQuery = `DELETE FROM history_scheduled_tasks WHERE shard_id = ? AND category_id = ? AND visibility_timestamp >= ? AND visibility_timestamp < ?`
+
+	createTransferTasksQuery = `INSERT INTO transfer_tasks(shard_id, task_id, data, data_encoding) 
+ VALUES(:shard_id, :task_id, :data, :data_encoding)`
+
+	getTransferTasksQuery = `SELECT task_id, data, data_encoding 
+ FROM transfer_tasks WHERE shard_id = ? AND task_id >= ? AND task_id < ? ORDER BY task_id LIMIT ?`
+
+	deleteTransferTaskQuery      = `DELETE FROM transfer_tasks WHERE shard_id = ? AND task_id = ?`
+	rangeDeleteTransferTaskQuery = `DELETE FROM transfer_tasks WHERE shard_id = ? AND task_id >= ? AND task_id < ?`
+
+	createTimerTasksQuery = `INSERT INTO timer_tasks (shard_id, visibility_timestamp, task_id, data, data_encoding)
+  VALUES (:shard_id, :visibility_timestamp, :task_id, :data, :data_encoding)`
+
+	getTimerTasksQuery = `SELECT visibility_timestamp, task_id, data, data_encoding FROM timer_tasks 
+  WHERE shard_id = ? 
+  AND ((visibility_timestamp >= ? AND task_id >= ?) OR visibility_timestamp > ?) 
+  AND visibility_timestamp < ?
+  ORDER BY visibility_timestamp,task_id LIMIT ?`
+
+	deleteTimerTaskQuery      = `DELETE FROM timer_tasks WHERE shard_id = ? AND visibility_timestamp = ? AND task_id = ?`
+	rangeDeleteTimerTaskQuery = `DELETE FROM timer_tasks WHERE shard_id = ? AND visibility_timestamp >= ? AND visibility_timestamp < ?`
+
+	createReplicationTasksQuery = `INSERT INTO replication_tasks (shard_id, task_id, data, data_encoding) 
+  VALUES(:shard_id, :task_id, :data, :data_encoding)`
+
+	getReplicationTasksQuery = `SELECT task_id, data, data_encoding FROM replication_tasks WHERE 
+shard_id = ? AND task_id >= ? AND task_id < ? ORDER BY task_id LIMIT ?`
+
+	deleteReplicationTaskQuery      = `DELETE FROM replication_tasks WHERE shard_id = ? AND task_id = ?`
+	rangeDeleteReplicationTaskQuery = `DELETE FROM replication_tasks WHERE shard_id = ? AND task_id >= ? AND task_id < ?`
+
+	getReplicationTasksDLQQuery = `SELECT task_id, data, data_encoding FROM replication_tasks_dlq WHERE 
+source_cluster_name = ? AND
+shard_id = ? AND
+task_id >= ? AND
+task_id < ?
+ORDER BY task_id LIMIT ?`
+
+	createVisibilityTasksQuery = `INSERT INTO visibility_tasks(shard_id, task_id, data, data_encoding) 
+ VALUES(:shard_id, :task_id, :data, :data_encoding)`
+
+	getVisibilityTasksQuery = `SELECT task_id, data, data_encoding 
+ FROM visibility_tasks WHERE shard_id = ? AND task_id >= ? AND task_id < ? ORDER BY task_id LIMIT ?`
+
+	deleteVisibilityTaskQuery      = `DELETE FROM visibility_tasks WHERE shard_id = ? AND task_id = ?`
+	rangeDeleteVisibilityTaskQuery = `DELETE FROM visibility_tasks WHERE shard_id = ? AND task_id >= ? AND task_id < ?`
+
+	bufferedEventsColumns     = `shard_id, namespace_id, workflow_id, run_id, data, data_encoding`
+	createBufferedEventsQuery = `INSERT INTO buffered_events(` + bufferedEventsColumns + `)
+VALUES (:shard_id, :namespace_id, :workflow_id, :run_id, :data, :data_encoding)`
+
+	deleteBufferedEventsQuery = `DELETE FROM buffered_events WHERE shard_id=? AND namespace_id=? AND workflow_id=? AND run_id=?`
+	getBufferedEventsQuery    = `SELECT data, data_encoding FROM buffered_events WHERE
+shard_id=? AND namespace_id=? AND workflow_id=? AND run_id=? ORDER BY id`
+
+	insertReplicationTaskDLQQuery = `
+INSERT INTO replication_tasks_dlq 
+            (source_cluster_name, 
+             shard_id, 
+             task_id, 
+             data, 
+             data_encoding) 
+VALUES     (:source_cluster_name, 
+            :shard_id, 
+            :task_id, 
+            :data, 
+            :data_encoding)
+`
+	deleteReplicationTaskFromDLQQuery = `
+	DELETE FROM replication_tasks_dlq 
+		WHERE source_cluster_name = ? 
+		AND shard_id = ? 
+		AND task_id = ?`
+
+	rangeDeleteReplicationTaskFromDLQQuery = `
+	DELETE FROM replication_tasks_dlq 
+		WHERE source_cluster_name = ? 
+		AND shard_id = ? 
+		AND task_id >= ?
+		AND task_id < ?`
+)
+
+// InsertIntoExecutions inserts a row into executions table
+func (mdb *db) InsertIntoExecutions(
+	ctx context.Context,
+	row *sqlplugin.ExecutionsRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		createExecutionQuery,
+		row,
+	)
+}
+
+// UpdateExecutions updates a single row in executions table
+func (mdb *db) UpdateExecutions(
+	ctx context.Context,
+	row *sqlplugin.ExecutionsRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		updateExecutionQuery,
+		row,
+	)
+}
+
+// SelectFromExecutions reads a single row from executions table
+func (mdb *db) SelectFromExecutions(
+	ctx context.Context,
+	filter sqlplugin.ExecutionsFilter,
+) (*sqlplugin.ExecutionsRow, error) {
+	var row sqlplugin.ExecutionsRow
+	err := mdb.conn.GetContext(ctx,
+		&row, getExecutionQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, err
+}
+
+// DeleteFromExecutions deletes a single row from executions table
+func (mdb *db) DeleteFromExecutions(
+	ctx context.Context,
+	filter sqlplugin.ExecutionsFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteExecutionQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}
+
+// ReadLockExecutions acquires a write lock on a single row in executions table
+func (mdb *db) ReadLockExecutions(
+	ctx context.Context,
+	filter sqlplugin.ExecutionsFilter,
+) (int64, int64, error) {
+	var executionVersion sqlplugin.ExecutionVersion
+	err := mdb.conn.GetContext(ctx,
+		&executionVersion,
+		readLockExecutionQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+	return executionVersion.DBRecordVersion, executionVersion.NextEventID, err
+}
+
+// WriteLockExecutions acquires a write lock on a single row in executions table
+func (mdb *db) WriteLockExecutions(
+	ctx context.Context,
+	filter sqlplugin.ExecutionsFilter,
+) (int64, int64, error) {
+	var executionVersion sqlplugin.ExecutionVersion
+	err := mdb.conn.GetContext(ctx,
+		&executionVersion,
+		writeLockExecutionQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+	return executionVersion.DBRecordVersion, executionVersion.NextEventID, err
+}
+
+// InsertIntoCurrentExecutions inserts a single row into current_executions table
+func (mdb *db) InsertIntoCurrentExecutions(
+	ctx context.Context,
+	row *sqlplugin.CurrentExecutionsRow,
+) (sql.Result, error) {
+	if err := mdb.assertArchetypeIDSpecified(row.ArchetypeID); err != nil {
+		return nil, err
+	}
+
+	if row.ArchetypeID == chasm.WorkflowArchetypeID {
+		return mdb.conn.NamedExecContext(ctx,
+			createCurrentExecutionQuery,
+			row,
+		)
+	}
+
+	return mdb.conn.NamedExecContext(ctx,
+		createCurrentChasmExecutionQuery,
+		row,
+	)
+}
+
+// UpdateCurrentExecutions updates a single row in current_executions table
+func (mdb *db) UpdateCurrentExecutions(
+	ctx context.Context,
+	row *sqlplugin.CurrentExecutionsRow,
+) (sql.Result, error) {
+	if err := mdb.assertArchetypeIDSpecified(row.ArchetypeID); err != nil {
+		return nil, err
+	}
+
+	if row.ArchetypeID == chasm.WorkflowArchetypeID {
+		return mdb.conn.NamedExecContext(ctx,
+			updateCurrentExecutionsQuery,
+			row,
+		)
+	}
+
+	return mdb.conn.NamedExecContext(ctx,
+		updateCurrentChasmExecutionsQuery,
+		row,
+	)
+}
+
+// SelectFromCurrentExecutions reads one or more rows from current_executions table
+func (mdb *db) SelectFromCurrentExecutions(
+	ctx context.Context,
+	filter sqlplugin.CurrentExecutionsFilter,
+) (*sqlplugin.CurrentExecutionsRow, error) {
+	var row sqlplugin.CurrentExecutionsRow
+	var err error
+
+	if err := mdb.assertArchetypeIDSpecified(filter.ArchetypeID); err != nil {
+		return nil, err
+	}
+
+	if filter.ArchetypeID == chasm.WorkflowArchetypeID {
+		err = mdb.conn.GetContext(ctx,
+			&row,
+			getCurrentExecutionQuery,
+			filter.ShardID,
+			filter.NamespaceID,
+			filter.WorkflowID,
+		)
+	} else {
+		err = mdb.conn.GetContext(ctx,
+			&row,
+			getCurrentChasmExecutionQuery,
+			filter.ShardID,
+			filter.NamespaceID,
+			filter.WorkflowID,
+			filter.ArchetypeID,
+		)
+	}
+
+	row.ArchetypeID = filter.ArchetypeID
+	return &row, err
+}
+
+// DeleteFromCurrentExecutions deletes a single row in current_executions table
+func (mdb *db) DeleteFromCurrentExecutions(
+	ctx context.Context,
+	filter sqlplugin.CurrentExecutionsFilter,
+) (sql.Result, error) {
+	if err := mdb.assertArchetypeIDSpecified(filter.ArchetypeID); err != nil {
+		return nil, err
+	}
+
+	if filter.ArchetypeID == chasm.WorkflowArchetypeID {
+		return mdb.conn.ExecContext(ctx,
+			deleteCurrentExecutionQuery,
+			filter.ShardID,
+			filter.NamespaceID,
+			filter.WorkflowID,
+			filter.RunID,
+		)
+	}
+
+	return mdb.conn.ExecContext(ctx,
+		deleteCurrentChasmExecutionQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.ArchetypeID,
+		filter.RunID,
+	)
+}
+
+// LockCurrentExecutions acquires a write lock on a single row in current_executions table
+func (mdb *db) LockCurrentExecutions(
+	ctx context.Context,
+	filter sqlplugin.CurrentExecutionsFilter,
+) (*sqlplugin.CurrentExecutionsRow, error) {
+	var row sqlplugin.CurrentExecutionsRow
+	var err error
+
+	if err := mdb.assertArchetypeIDSpecified(filter.ArchetypeID); err != nil {
+		return nil, err
+	}
+
+	if filter.ArchetypeID == chasm.WorkflowArchetypeID {
+		err = mdb.conn.GetContext(ctx,
+			&row,
+			lockCurrentExecutionQuery,
+			filter.ShardID,
+			filter.NamespaceID,
+			filter.WorkflowID,
+		)
+	} else {
+		err = mdb.conn.GetContext(ctx,
+			&row,
+			lockCurrentChasmExecutionQuery,
+			filter.ShardID,
+			filter.NamespaceID,
+			filter.WorkflowID,
+			filter.ArchetypeID,
+		)
+	}
+
+	row.ArchetypeID = filter.ArchetypeID
+	return &row, err
+}
+
+// LockCurrentExecutionsJoinExecutions joins a row in current_executions with executions table and acquires a
+// write lock on the result
+func (mdb *db) LockCurrentExecutionsJoinExecutions(
+	ctx context.Context,
+	filter sqlplugin.CurrentExecutionsFilter,
+) (rows []sqlplugin.CurrentExecutionsRow, err error) {
+	if err := mdb.assertArchetypeIDSpecified(filter.ArchetypeID); err != nil {
+		return nil, err
+	}
+
+	if filter.ArchetypeID == chasm.WorkflowArchetypeID {
+		err = mdb.conn.SelectContext(ctx,
+			&rows,
+			lockCurrentExecutionJoinExecutionsQuery,
+			filter.ShardID,
+			filter.NamespaceID,
+			filter.WorkflowID,
+		)
+	} else {
+		err = mdb.conn.SelectContext(ctx,
+			&rows,
+			lockCurrentChasmExecutionJoinExecutionsQuery,
+			filter.ShardID,
+			filter.NamespaceID,
+			filter.WorkflowID,
+			filter.ArchetypeID,
+		)
+	}
+
+	for i := range rows {
+		rows[i].ArchetypeID = filter.ArchetypeID
+	}
+	return rows, err
+}
+
+// InsertIntoHistoryImmediateTasks inserts one or more rows into history_immediate_tasks table
+func (mdb *db) InsertIntoHistoryImmediateTasks(
+	ctx context.Context,
+	rows []sqlplugin.HistoryImmediateTasksRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		createHistoryImmediateTasksQuery,
+		rows,
+	)
+}
+
+// RangeSelectFromHistoryImmediateTasks reads one or more rows from transfer_tasks table
+func (mdb *db) RangeSelectFromHistoryImmediateTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryImmediateTasksRangeFilter,
+) ([]sqlplugin.HistoryImmediateTasksRow, error) {
+	var rows []sqlplugin.HistoryImmediateTasksRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getHistoryImmediateTasksQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.InclusiveMinTaskID,
+		filter.ExclusiveMaxTaskID,
+		filter.PageSize,
+	); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// DeleteFromHistoryImmediateTasks deletes one or more rows from transfer_tasks table
+func (mdb *db) DeleteFromHistoryImmediateTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryImmediateTasksFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteHistoryImmediateTaskQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.TaskID,
+	)
+}
+
+// RangeDeleteFromHistoryImmediateTasks deletes one or more rows from transfer_tasks table
+func (mdb *db) RangeDeleteFromHistoryImmediateTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryImmediateTasksRangeFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		rangeDeleteHistoryImmediateTasksQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.InclusiveMinTaskID,
+		filter.ExclusiveMaxTaskID,
+	)
+}
+
+// InsertIntoHistoryScheduledTasks inserts one or more rows into timer_tasks table
+func (mdb *db) InsertIntoHistoryScheduledTasks(
+	ctx context.Context,
+	rows []sqlplugin.HistoryScheduledTasksRow,
+) (sql.Result, error) {
+	for i := range rows {
+		rows[i].VisibilityTimestamp = mdb.converter.ToSQLiteDateTime(rows[i].VisibilityTimestamp)
+	}
+	return mdb.conn.NamedExecContext(
+		ctx,
+		createHistoryScheduledTasksQuery,
+		rows,
+	)
+}
+
+// RangeSelectFromHistoryScheduledTasks reads one or more rows from timer_tasks table
+func (mdb *db) RangeSelectFromHistoryScheduledTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryScheduledTasksRangeFilter,
+) ([]sqlplugin.HistoryScheduledTasksRow, error) {
+	var rows []sqlplugin.HistoryScheduledTasksRow
+	filter.InclusiveMinVisibilityTimestamp = mdb.converter.ToSQLiteDateTime(filter.InclusiveMinVisibilityTimestamp)
+	filter.ExclusiveMaxVisibilityTimestamp = mdb.converter.ToSQLiteDateTime(filter.ExclusiveMaxVisibilityTimestamp)
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getHistoryScheduledTasksQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.InclusiveMinVisibilityTimestamp,
+		filter.InclusiveMinTaskID,
+		filter.InclusiveMinVisibilityTimestamp,
+		filter.ExclusiveMaxVisibilityTimestamp,
+		filter.PageSize,
+	); err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		rows[i].VisibilityTimestamp = mdb.converter.ToSQLiteDateTime(rows[i].VisibilityTimestamp)
+	}
+	return rows, nil
+}
+
+// DeleteFromHistoryScheduledTasks deletes one or more rows from timer_tasks table
+func (mdb *db) DeleteFromHistoryScheduledTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryScheduledTasksFilter,
+) (sql.Result, error) {
+	filter.VisibilityTimestamp = mdb.converter.ToSQLiteDateTime(filter.VisibilityTimestamp)
+	return mdb.conn.ExecContext(ctx,
+		deleteHistoryScheduledTaskQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.VisibilityTimestamp,
+		filter.TaskID,
+	)
+}
+
+// RangeDeleteFromHistoryScheduledTasks deletes one or more rows from timer_tasks table
+func (mdb *db) RangeDeleteFromHistoryScheduledTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryScheduledTasksRangeFilter,
+) (sql.Result, error) {
+	filter.InclusiveMinVisibilityTimestamp = mdb.converter.ToSQLiteDateTime(filter.InclusiveMinVisibilityTimestamp)
+	filter.ExclusiveMaxVisibilityTimestamp = mdb.converter.ToSQLiteDateTime(filter.ExclusiveMaxVisibilityTimestamp)
+	return mdb.conn.ExecContext(ctx,
+		rangeDeleteHistoryScheduledTasksQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.InclusiveMinVisibilityTimestamp,
+		filter.ExclusiveMaxVisibilityTimestamp,
+	)
+}
+
+// InsertIntoTransferTasks inserts one or more rows into transfer_tasks table
+func (mdb *db) InsertIntoTransferTasks(
+	ctx context.Context,
+	rows []sqlplugin.TransferTasksRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		createTransferTasksQuery,
+		rows,
+	)
+}
+
+// RangeSelectFromTransferTasks reads one or more rows from transfer_tasks table
+func (mdb *db) RangeSelectFromTransferTasks(
+	ctx context.Context,
+	filter sqlplugin.TransferTasksRangeFilter,
+) ([]sqlplugin.TransferTasksRow, error) {
+	var rows []sqlplugin.TransferTasksRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getTransferTasksQuery,
+		filter.ShardID,
+		filter.InclusiveMinTaskID,
+		filter.ExclusiveMaxTaskID,
+		filter.PageSize,
+	); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// DeleteFromTransferTasks deletes one or more rows from transfer_tasks table
+func (mdb *db) DeleteFromTransferTasks(
+	ctx context.Context,
+	filter sqlplugin.TransferTasksFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteTransferTaskQuery,
+		filter.ShardID,
+		filter.TaskID,
+	)
+}
+
+// RangeDeleteFromTransferTasks deletes one or more rows from transfer_tasks table
+func (mdb *db) RangeDeleteFromTransferTasks(
+	ctx context.Context,
+	filter sqlplugin.TransferTasksRangeFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		rangeDeleteTransferTaskQuery,
+		filter.ShardID,
+		filter.InclusiveMinTaskID,
+		filter.ExclusiveMaxTaskID,
+	)
+}
+
+// InsertIntoTimerTasks inserts one or more rows into timer_tasks table
+func (mdb *db) InsertIntoTimerTasks(
+	ctx context.Context,
+	rows []sqlplugin.TimerTasksRow,
+) (sql.Result, error) {
+	for i := range rows {
+		rows[i].VisibilityTimestamp = mdb.converter.ToSQLiteDateTime(rows[i].VisibilityTimestamp)
+	}
+	return mdb.conn.NamedExecContext(
+		ctx,
+		createTimerTasksQuery,
+		rows,
+	)
+}
+
+// RangeSelectFromTimerTasks reads one or more rows from timer_tasks table
+func (mdb *db) RangeSelectFromTimerTasks(
+	ctx context.Context,
+	filter sqlplugin.TimerTasksRangeFilter,
+) ([]sqlplugin.TimerTasksRow, error) {
+	var rows []sqlplugin.TimerTasksRow
+	filter.InclusiveMinVisibilityTimestamp = mdb.converter.ToSQLiteDateTime(filter.InclusiveMinVisibilityTimestamp)
+	filter.ExclusiveMaxVisibilityTimestamp = mdb.converter.ToSQLiteDateTime(filter.ExclusiveMaxVisibilityTimestamp)
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getTimerTasksQuery,
+		filter.ShardID,
+		filter.InclusiveMinVisibilityTimestamp,
+		filter.InclusiveMinTaskID,
+		filter.InclusiveMinVisibilityTimestamp,
+		filter.ExclusiveMaxVisibilityTimestamp,
+		filter.PageSize,
+	); err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		rows[i].VisibilityTimestamp = mdb.converter.FromSQLiteDateTime(rows[i].VisibilityTimestamp)
+	}
+	return rows, nil
+}
+
+// DeleteFromTimerTasks deletes one or more rows from timer_tasks table
+func (mdb *db) DeleteFromTimerTasks(
+	ctx context.Context,
+	filter sqlplugin.TimerTasksFilter,
+) (sql.Result, error) {
+	filter.VisibilityTimestamp = mdb.converter.ToSQLiteDateTime(filter.VisibilityTimestamp)
+	return mdb.conn.ExecContext(ctx,
+		deleteTimerTaskQuery,
+		filter.ShardID,
+		filter.VisibilityTimestamp,
+		filter.TaskID,
+	)
+}
+
+// RangeDeleteFromTimerTasks deletes one or more rows from timer_tasks table
+func (mdb *db) RangeDeleteFromTimerTasks(
+	ctx context.Context,
+	filter sqlplugin.TimerTasksRangeFilter,
+) (sql.Result, error) {
+	filter.InclusiveMinVisibilityTimestamp = mdb.converter.ToSQLiteDateTime(filter.InclusiveMinVisibilityTimestamp)
+	filter.ExclusiveMaxVisibilityTimestamp = mdb.converter.ToSQLiteDateTime(filter.ExclusiveMaxVisibilityTimestamp)
+	return mdb.conn.ExecContext(ctx,
+		rangeDeleteTimerTaskQuery,
+		filter.ShardID,
+		filter.InclusiveMinVisibilityTimestamp,
+		filter.ExclusiveMaxVisibilityTimestamp,
+	)
+}
+
+// InsertIntoBufferedEvents inserts one or more rows into buffered_events table
+func (mdb *db) InsertIntoBufferedEvents(
+	ctx context.Context,
+	rows []sqlplugin.BufferedEventsRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		createBufferedEventsQuery,
+		rows,
+	)
+}
+
+// SelectFromBufferedEvents reads one or more rows from buffered_events table
+func (mdb *db) SelectFromBufferedEvents(
+	ctx context.Context,
+	filter sqlplugin.BufferedEventsFilter,
+) ([]sqlplugin.BufferedEventsRow, error) {
+	var rows []sqlplugin.BufferedEventsRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getBufferedEventsQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	); err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(rows); i++ {
+		rows[i].NamespaceID = filter.NamespaceID
+		rows[i].WorkflowID = filter.WorkflowID
+		rows[i].RunID = filter.RunID
+		rows[i].ShardID = filter.ShardID
+	}
+	return rows, nil
+}
+
+// DeleteFromBufferedEvents deletes one or more rows from buffered_events table
+func (mdb *db) DeleteFromBufferedEvents(
+	ctx context.Context,
+	filter sqlplugin.BufferedEventsFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteBufferedEventsQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}
+
+// InsertIntoReplicationTasks inserts one or more rows into replication_tasks table
+func (mdb *db) InsertIntoReplicationTasks(
+	ctx context.Context,
+	rows []sqlplugin.ReplicationTasksRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		createReplicationTasksQuery,
+		rows,
+	)
+}
+
+// RangeSelectFromReplicationTasks reads one or more rows from replication_tasks table
+func (mdb *db) RangeSelectFromReplicationTasks(
+	ctx context.Context,
+	filter sqlplugin.ReplicationTasksRangeFilter,
+) ([]sqlplugin.ReplicationTasksRow, error) {
+	var rows []sqlplugin.ReplicationTasksRow
+	err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getReplicationTasksQuery,
+		filter.ShardID,
+		filter.InclusiveMinTaskID,
+		filter.ExclusiveMaxTaskID,
+		filter.PageSize,
+	)
+	return rows, err
+}
+
+// DeleteFromReplicationTasks deletes one row from replication_tasks table
+func (mdb *db) DeleteFromReplicationTasks(
+	ctx context.Context,
+	filter sqlplugin.ReplicationTasksFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteReplicationTaskQuery,
+		filter.ShardID,
+		filter.TaskID,
+	)
+}
+
+// RangeDeleteFromReplicationTasks deletes multi rows from replication_tasks table
+func (mdb *db) RangeDeleteFromReplicationTasks(
+	ctx context.Context,
+	filter sqlplugin.ReplicationTasksRangeFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		rangeDeleteReplicationTaskQuery,
+		filter.ShardID,
+		filter.InclusiveMinTaskID,
+		filter.ExclusiveMaxTaskID,
+	)
+}
+
+// InsertIntoReplicationDLQTasks inserts one or more rows into replication_tasks_dlq table
+func (mdb *db) InsertIntoReplicationDLQTasks(
+	ctx context.Context,
+	rows []sqlplugin.ReplicationDLQTasksRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		insertReplicationTaskDLQQuery,
+		rows,
+	)
+}
+
+// RangeSelectFromReplicationDLQTasks reads one or more rows from replication_tasks_dlq table
+func (mdb *db) RangeSelectFromReplicationDLQTasks(
+	ctx context.Context,
+	filter sqlplugin.ReplicationDLQTasksRangeFilter,
+) ([]sqlplugin.ReplicationDLQTasksRow, error) {
+	var rows []sqlplugin.ReplicationDLQTasksRow
+	err := mdb.conn.SelectContext(ctx,
+		&rows, getReplicationTasksDLQQuery,
+		filter.SourceClusterName,
+		filter.ShardID,
+		filter.InclusiveMinTaskID,
+		filter.ExclusiveMaxTaskID,
+		filter.PageSize,
+	)
+	return rows, err
+}
+
+// DeleteFromReplicationDLQTasks deletes one row from replication_tasks_dlq table
+func (mdb *db) DeleteFromReplicationDLQTasks(
+	ctx context.Context,
+	filter sqlplugin.ReplicationDLQTasksFilter,
+) (sql.Result, error) {
+
+	return mdb.conn.ExecContext(ctx,
+		deleteReplicationTaskFromDLQQuery,
+		filter.SourceClusterName,
+		filter.ShardID,
+		filter.TaskID,
+	)
+}
+
+// RangeDeleteFromReplicationDLQTasks deletes one or more rows from replication_tasks_dlq table
+func (mdb *db) RangeDeleteFromReplicationDLQTasks(
+	ctx context.Context,
+	filter sqlplugin.ReplicationDLQTasksRangeFilter,
+) (sql.Result, error) {
+
+	return mdb.conn.ExecContext(ctx,
+		rangeDeleteReplicationTaskFromDLQQuery,
+		filter.SourceClusterName,
+		filter.ShardID,
+		filter.InclusiveMinTaskID,
+		filter.ExclusiveMaxTaskID,
+	)
+}
+
+// InsertIntoVisibilityTasks inserts one or more rows into visibility_tasks table
+func (mdb *db) InsertIntoVisibilityTasks(
+	ctx context.Context,
+	rows []sqlplugin.VisibilityTasksRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		createVisibilityTasksQuery,
+		rows,
+	)
+}
+
+// RangeSelectFromVisibilityTasks reads one or more rows from visibility_tasks table
+func (mdb *db) RangeSelectFromVisibilityTasks(
+	ctx context.Context,
+	filter sqlplugin.VisibilityTasksRangeFilter,
+) ([]sqlplugin.VisibilityTasksRow, error) {
+	var rows []sqlplugin.VisibilityTasksRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getVisibilityTasksQuery,
+		filter.ShardID,
+		filter.InclusiveMinTaskID,
+		filter.ExclusiveMaxTaskID,
+		filter.PageSize,
+	); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// DeleteFromVisibilityTasks deletes one or more rows from visibility_tasks table
+func (mdb *db) DeleteFromVisibilityTasks(
+	ctx context.Context,
+	filter sqlplugin.VisibilityTasksFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteVisibilityTaskQuery,
+		filter.ShardID,
+		filter.TaskID,
+	)
+}
+
+// RangeDeleteFromVisibilityTasks deletes one or more rows from visibility_tasks table
+func (mdb *db) RangeDeleteFromVisibilityTasks(
+	ctx context.Context,
+	filter sqlplugin.VisibilityTasksRangeFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		rangeDeleteVisibilityTaskQuery,
+		filter.ShardID,
+		filter.InclusiveMinTaskID,
+		filter.ExclusiveMaxTaskID,
+	)
+}
+
+func (mdb *db) assertArchetypeIDSpecified(archetypeID chasm.ArchetypeID) error {
+	if archetypeID == chasm.UnspecifiedArchetypeID {
+		return softassert.UnexpectedInternalErr(mdb.logger, "ArchetypeID not specified", nil)
+	}
+	return nil
+}

--- a/common/persistence/sql/sqlplugin/libsql/execution_maps.go
+++ b/common/persistence/sql/sqlplugin/libsql/execution_maps.go
@@ -1,0 +1,703 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	deleteMapQryTemplate = `DELETE FROM %v
+WHERE
+shard_id = ? AND
+namespace_id = ? AND
+workflow_id = ? AND
+run_id = ?`
+
+	// %[2]v is the columns of the value struct (i.e. no primary key columns), comma separated
+	// %[3]v should be %[2]v with colons prepended.
+	// i.e. %[3]v = ",".join(":" + s for s in %[2]v)
+	// %[4]v should be %[2]v in the format of n=VALUES(n).
+	// i.e. %[4]v = ",".join(s + "=VALUES(" + s + ")" for s in %[2]v)
+	// So that this query can be used with BindNamed
+	// %[5]v should be the name of the key associated with the map
+	// e.g. for ActivityInfo it is "schedule_id"
+	setKeyInMapQryTemplate = `REPLACE INTO %[1]v
+(shard_id, namespace_id, workflow_id, run_id, %[5]v, %[2]v)
+VALUES
+(:shard_id, :namespace_id, :workflow_id, :run_id, :%[5]v, %[3]v);`
+
+	// %[2]v is the name of the key
+	deleteKeyInMapQryTemplate = `DELETE FROM %[1]v
+WHERE
+shard_id = ? AND
+namespace_id = ? AND
+workflow_id = ? AND
+run_id = ? AND
+%[2]v IN ( ? )`
+
+	// %[1]v is the name of the table
+	// %[2]v is the name of the key
+	// %[3]v is the value columns, separated by commas
+	getMapQryTemplate = `SELECT %[2]v, %[3]v FROM %[1]v
+WHERE
+shard_id = ? AND
+namespace_id = ? AND
+workflow_id = ? AND
+run_id = ?`
+)
+
+func stringMap(a []string, f func(string) string) []string {
+	b := make([]string, len(a))
+	for i, v := range a {
+		b[i] = f(v)
+	}
+	return b
+}
+
+func makeDeleteMapQry(tableName string) string {
+	return fmt.Sprintf(deleteMapQryTemplate, tableName)
+}
+
+func makeSetKeyInMapQry(tableName string, nonPrimaryKeyColumns []string, mapKeyName string) string {
+	return fmt.Sprintf(setKeyInMapQryTemplate,
+		tableName,
+		strings.Join(nonPrimaryKeyColumns, ","),
+		strings.Join(stringMap(nonPrimaryKeyColumns, func(x string) string {
+			return ":" + x
+		}), ","),
+		strings.Join(stringMap(nonPrimaryKeyColumns, func(x string) string {
+			return x + "=" + x
+		}), ","),
+		mapKeyName)
+}
+
+func makeDeleteKeyInMapQry(tableName string, mapKeyName string) string {
+	return fmt.Sprintf(deleteKeyInMapQryTemplate,
+		tableName,
+		mapKeyName)
+}
+
+func makeGetMapQryTemplate(tableName string, nonPrimaryKeyColumns []string, mapKeyName string) string {
+	return fmt.Sprintf(getMapQryTemplate,
+		tableName,
+		mapKeyName,
+		strings.Join(nonPrimaryKeyColumns, ","))
+}
+
+var (
+	// Omit shard_id, run_id, namespace_id, workflow_id, schedule_id since they're in the primary key
+	activityInfoColumns = []string{
+		"data",
+		"data_encoding",
+	}
+	activityInfoTableName = "activity_info_maps"
+	activityInfoKey       = "schedule_id"
+
+	deleteActivityInfoMapQry      = makeDeleteMapQry(activityInfoTableName)
+	setKeyInActivityInfoMapQry    = makeSetKeyInMapQry(activityInfoTableName, activityInfoColumns, activityInfoKey)
+	deleteKeyInActivityInfoMapQry = makeDeleteKeyInMapQry(activityInfoTableName, activityInfoKey)
+	getActivityInfoMapQry         = makeGetMapQryTemplate(activityInfoTableName, activityInfoColumns, activityInfoKey)
+)
+
+// ReplaceIntoActivityInfoMaps replaces one or more rows in activity_info_maps table
+func (mdb *db) ReplaceIntoActivityInfoMaps(
+	ctx context.Context,
+	rows []sqlplugin.ActivityInfoMapsRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		setKeyInActivityInfoMapQry,
+		rows,
+	)
+}
+
+// SelectAllFromActivityInfoMaps reads all rows from activity_info_maps table
+func (mdb *db) SelectAllFromActivityInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.ActivityInfoMapsAllFilter,
+) ([]sqlplugin.ActivityInfoMapsRow, error) {
+	var rows []sqlplugin.ActivityInfoMapsRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getActivityInfoMapQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	); err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(rows); i++ {
+		rows[i].ShardID = filter.ShardID
+		rows[i].NamespaceID = filter.NamespaceID
+		rows[i].WorkflowID = filter.WorkflowID
+		rows[i].RunID = filter.RunID
+	}
+	return rows, nil
+}
+
+// DeleteFromActivityInfoMaps deletes one or more rows from activity_info_maps table
+func (mdb *db) DeleteFromActivityInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.ActivityInfoMapsFilter,
+) (sql.Result, error) {
+	query, args, err := sqlx.In(
+		deleteKeyInActivityInfoMapQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+		filter.ScheduleIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return mdb.conn.ExecContext(ctx,
+		mdb.conn.Rebind(query),
+		args...,
+	)
+}
+
+// DeleteAllFromActivityInfoMaps deletes all rows from activity_info_maps table
+func (mdb *db) DeleteAllFromActivityInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.ActivityInfoMapsAllFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteActivityInfoMapQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}
+
+var (
+	timerInfoColumns = []string{
+		"data",
+		"data_encoding",
+	}
+	timerInfoTableName = "timer_info_maps"
+	timerInfoKey       = "timer_id"
+
+	deleteTimerInfoMapSQLQuery      = makeDeleteMapQry(timerInfoTableName)
+	setKeyInTimerInfoMapSQLQuery    = makeSetKeyInMapQry(timerInfoTableName, timerInfoColumns, timerInfoKey)
+	deleteKeyInTimerInfoMapSQLQuery = makeDeleteKeyInMapQry(timerInfoTableName, timerInfoKey)
+	getTimerInfoMapSQLQuery         = makeGetMapQryTemplate(timerInfoTableName, timerInfoColumns, timerInfoKey)
+)
+
+// ReplaceIntoTimerInfoMaps replaces one or more rows in timer_info_maps table
+func (mdb *db) ReplaceIntoTimerInfoMaps(
+	ctx context.Context,
+	rows []sqlplugin.TimerInfoMapsRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		setKeyInTimerInfoMapSQLQuery,
+		rows,
+	)
+}
+
+// SelectAllFromTimerInfoMaps reads all rows from timer_info_maps table
+func (mdb *db) SelectAllFromTimerInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.TimerInfoMapsAllFilter,
+) ([]sqlplugin.TimerInfoMapsRow, error) {
+	var rows []sqlplugin.TimerInfoMapsRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getTimerInfoMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	); err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(rows); i++ {
+		rows[i].ShardID = filter.ShardID
+		rows[i].NamespaceID = filter.NamespaceID
+		rows[i].WorkflowID = filter.WorkflowID
+		rows[i].RunID = filter.RunID
+	}
+	return rows, nil
+}
+
+// DeleteFromTimerInfoMaps deletes one or more rows from timer_info_maps table
+func (mdb *db) DeleteFromTimerInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.TimerInfoMapsFilter,
+) (sql.Result, error) {
+	query, args, err := sqlx.In(
+		deleteKeyInTimerInfoMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+		filter.TimerIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return mdb.conn.ExecContext(ctx,
+		mdb.conn.Rebind(query),
+		args...,
+	)
+}
+
+// DeleteAllFromTimerInfoMaps deletes all rows from timer_info_maps table
+func (mdb *db) DeleteAllFromTimerInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.TimerInfoMapsAllFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteTimerInfoMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}
+
+var (
+	childExecutionInfoColumns = []string{
+		"data",
+		"data_encoding",
+	}
+	childExecutionInfoTableName = "child_execution_info_maps"
+	childExecutionInfoKey       = "initiated_id"
+
+	deleteChildExecutionInfoMapQry      = makeDeleteMapQry(childExecutionInfoTableName)
+	setKeyInChildExecutionInfoMapQry    = makeSetKeyInMapQry(childExecutionInfoTableName, childExecutionInfoColumns, childExecutionInfoKey)
+	deleteKeyInChildExecutionInfoMapQry = makeDeleteKeyInMapQry(childExecutionInfoTableName, childExecutionInfoKey)
+	getChildExecutionInfoMapQry         = makeGetMapQryTemplate(childExecutionInfoTableName, childExecutionInfoColumns, childExecutionInfoKey)
+)
+
+// ReplaceIntoChildExecutionInfoMaps replaces one or more rows in child_execution_info_maps table
+func (mdb *db) ReplaceIntoChildExecutionInfoMaps(
+	ctx context.Context,
+	rows []sqlplugin.ChildExecutionInfoMapsRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		setKeyInChildExecutionInfoMapQry,
+		rows,
+	)
+}
+
+// SelectAllFromChildExecutionInfoMaps reads all rows from child_execution_info_maps table
+func (mdb *db) SelectAllFromChildExecutionInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.ChildExecutionInfoMapsAllFilter,
+) ([]sqlplugin.ChildExecutionInfoMapsRow, error) {
+	var rows []sqlplugin.ChildExecutionInfoMapsRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getChildExecutionInfoMapQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	); err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(rows); i++ {
+		rows[i].ShardID = filter.ShardID
+		rows[i].NamespaceID = filter.NamespaceID
+		rows[i].WorkflowID = filter.WorkflowID
+		rows[i].RunID = filter.RunID
+	}
+	return rows, nil
+}
+
+// DeleteFromChildExecutionInfoMaps deletes one or more rows from child_execution_info_maps table
+func (mdb *db) DeleteFromChildExecutionInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.ChildExecutionInfoMapsFilter,
+) (sql.Result, error) {
+	query, args, err := sqlx.In(
+		deleteKeyInChildExecutionInfoMapQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+		filter.InitiatedIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return mdb.conn.ExecContext(ctx,
+		mdb.conn.Rebind(query),
+		args...,
+	)
+}
+
+// DeleteAllFromChildExecutionInfoMaps deletes all rows from child_execution_info_maps table
+func (mdb *db) DeleteAllFromChildExecutionInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.ChildExecutionInfoMapsAllFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteChildExecutionInfoMapQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}
+
+var (
+	requestCancelInfoColumns = []string{
+		"data",
+		"data_encoding",
+	}
+	requestCancelInfoTableName = "request_cancel_info_maps"
+	requestCancelInfoKey       = "initiated_id"
+
+	deleteRequestCancelInfoMapQry      = makeDeleteMapQry(requestCancelInfoTableName)
+	setKeyInRequestCancelInfoMapQry    = makeSetKeyInMapQry(requestCancelInfoTableName, requestCancelInfoColumns, requestCancelInfoKey)
+	deleteKeyInRequestCancelInfoMapQry = makeDeleteKeyInMapQry(requestCancelInfoTableName, requestCancelInfoKey)
+	getRequestCancelInfoMapQry         = makeGetMapQryTemplate(requestCancelInfoTableName, requestCancelInfoColumns, requestCancelInfoKey)
+)
+
+// ReplaceIntoRequestCancelInfoMaps replaces one or more rows in request_cancel_info_maps table
+func (mdb *db) ReplaceIntoRequestCancelInfoMaps(
+	ctx context.Context,
+	rows []sqlplugin.RequestCancelInfoMapsRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		setKeyInRequestCancelInfoMapQry,
+		rows,
+	)
+}
+
+// SelectAllFromRequestCancelInfoMaps reads all rows from request_cancel_info_maps table
+func (mdb *db) SelectAllFromRequestCancelInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.RequestCancelInfoMapsAllFilter,
+) ([]sqlplugin.RequestCancelInfoMapsRow, error) {
+	var rows []sqlplugin.RequestCancelInfoMapsRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows, getRequestCancelInfoMapQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	); err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(rows); i++ {
+		rows[i].ShardID = filter.ShardID
+		rows[i].NamespaceID = filter.NamespaceID
+		rows[i].WorkflowID = filter.WorkflowID
+		rows[i].RunID = filter.RunID
+	}
+	return rows, nil
+}
+
+// DeleteFromRequestCancelInfoMaps deletes one or more rows from request_cancel_info_maps table
+func (mdb *db) DeleteFromRequestCancelInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.RequestCancelInfoMapsFilter,
+) (sql.Result, error) {
+	query, args, err := sqlx.In(
+		deleteKeyInRequestCancelInfoMapQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+		filter.InitiatedIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return mdb.conn.ExecContext(ctx,
+		mdb.conn.Rebind(query),
+		args...,
+	)
+}
+
+// DeleteAllFromRequestCancelInfoMaps deletes all rows from request_cancel_info_maps table
+func (mdb *db) DeleteAllFromRequestCancelInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.RequestCancelInfoMapsAllFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteRequestCancelInfoMapQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}
+
+var (
+	signalInfoColumns = []string{
+		"data",
+		"data_encoding",
+	}
+	signalInfoTableName = "signal_info_maps"
+	signalInfoKey       = "initiated_id"
+
+	deleteSignalInfoMapQry      = makeDeleteMapQry(signalInfoTableName)
+	setKeyInSignalInfoMapQry    = makeSetKeyInMapQry(signalInfoTableName, signalInfoColumns, signalInfoKey)
+	deleteKeyInSignalInfoMapQry = makeDeleteKeyInMapQry(signalInfoTableName, signalInfoKey)
+	getSignalInfoMapQry         = makeGetMapQryTemplate(signalInfoTableName, signalInfoColumns, signalInfoKey)
+)
+
+// ReplaceIntoSignalInfoMaps replaces one or more rows in signal_info_maps table
+func (mdb *db) ReplaceIntoSignalInfoMaps(
+	ctx context.Context,
+	rows []sqlplugin.SignalInfoMapsRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		setKeyInSignalInfoMapQry,
+		rows,
+	)
+}
+
+// SelectAllFromSignalInfoMaps reads all rows from signal_info_maps table
+func (mdb *db) SelectAllFromSignalInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.SignalInfoMapsAllFilter,
+) ([]sqlplugin.SignalInfoMapsRow, error) {
+	var rows []sqlplugin.SignalInfoMapsRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getSignalInfoMapQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	); err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(rows); i++ {
+		rows[i].ShardID = filter.ShardID
+		rows[i].NamespaceID = filter.NamespaceID
+		rows[i].WorkflowID = filter.WorkflowID
+		rows[i].RunID = filter.RunID
+	}
+	return rows, nil
+}
+
+// DeleteFromSignalInfoMaps deletes one or more rows from signal_info_maps table
+func (mdb *db) DeleteFromSignalInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.SignalInfoMapsFilter,
+) (sql.Result, error) {
+	query, args, err := sqlx.In(
+		deleteKeyInSignalInfoMapQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+		filter.InitiatedIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return mdb.conn.ExecContext(ctx,
+		mdb.conn.Rebind(query),
+		args...,
+	)
+}
+
+// DeleteAllFromSignalInfoMaps deletes all rows from signal_info_maps table
+func (mdb *db) DeleteAllFromSignalInfoMaps(
+	ctx context.Context,
+	filter sqlplugin.SignalInfoMapsAllFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteSignalInfoMapQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}
+
+const (
+	deleteAllSignalsRequestedSetQry = `DELETE FROM signals_requested_sets
+WHERE
+shard_id = ? AND
+namespace_id = ? AND
+workflow_id = ? AND
+run_id = ?
+`
+
+	replaceSignalsRequestedSetQry = `REPLACE INTO signals_requested_sets
+(shard_id, namespace_id, workflow_id, run_id, signal_id) VALUES
+(:shard_id, :namespace_id, :workflow_id, :run_id, :signal_id)`
+
+	deleteSignalsRequestedSetQry = `DELETE FROM signals_requested_sets 
+WHERE 
+shard_id = ? AND
+namespace_id = ? AND
+workflow_id = ? AND
+run_id = ? AND
+signal_id IN ( ? )`
+
+	getSignalsRequestedSetQry = `SELECT signal_id FROM signals_requested_sets
+WHERE 
+shard_id = ? AND
+namespace_id = ? AND
+workflow_id = ? AND
+run_id = ?`
+)
+
+// ReplaceIntoSignalsRequestedSets inserts one or more rows into signals_requested_sets table
+func (mdb *db) ReplaceIntoSignalsRequestedSets(
+	ctx context.Context,
+	rows []sqlplugin.SignalsRequestedSetsRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		replaceSignalsRequestedSetQry,
+		rows,
+	)
+
+}
+
+// SelectAllFromSignalsRequestedSets reads all rows from signals_requested_sets table
+func (mdb *db) SelectAllFromSignalsRequestedSets(
+	ctx context.Context,
+	filter sqlplugin.SignalsRequestedSetsAllFilter,
+) ([]sqlplugin.SignalsRequestedSetsRow, error) {
+	var rows []sqlplugin.SignalsRequestedSetsRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getSignalsRequestedSetQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	); err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(rows); i++ {
+		rows[i].ShardID = filter.ShardID
+		rows[i].NamespaceID = filter.NamespaceID
+		rows[i].WorkflowID = filter.WorkflowID
+		rows[i].RunID = filter.RunID
+	}
+	return rows, nil
+}
+
+// DeleteFromSignalsRequestedSets deletes one or more rows from signals_requested_sets table
+func (mdb *db) DeleteFromSignalsRequestedSets(
+	ctx context.Context,
+	filter sqlplugin.SignalsRequestedSetsFilter,
+) (sql.Result, error) {
+	query, args, err := sqlx.In(
+		deleteSignalsRequestedSetQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+		filter.SignalIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return mdb.conn.ExecContext(ctx,
+		mdb.conn.Rebind(query),
+		args...,
+	)
+}
+
+// DeleteAllFromSignalsRequestedSets deletes all rows from signals_requested_sets table
+func (mdb *db) DeleteAllFromSignalsRequestedSets(
+	ctx context.Context,
+	filter sqlplugin.SignalsRequestedSetsAllFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteAllSignalsRequestedSetQry,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}
+
+var (
+	chasmNodeColumns = []string{
+		"metadata",
+		"metadata_encoding",
+		"data",
+		"data_encoding",
+	}
+	chasmNodeTableName = "chasm_node_maps"
+	chasmNodeKey       = "chasm_path"
+
+	deleteChasmNodeMapSQLQuery      = makeDeleteMapQry(chasmNodeTableName)
+	setKeyInChasmNodeMapSQLQuery    = makeSetKeyInMapQry(chasmNodeTableName, chasmNodeColumns, chasmNodeKey)
+	deleteKeyInChasmNodeMapSQLQuery = makeDeleteKeyInMapQry(chasmNodeTableName, chasmNodeKey)
+	getChasmNodeMapSQLQuery         = makeGetMapQryTemplate(chasmNodeTableName, chasmNodeColumns, chasmNodeKey)
+)
+
+func (mdb *db) SelectAllFromChasmNodeMaps(
+	ctx context.Context,
+	filter sqlplugin.ChasmNodeMapsAllFilter,
+) ([]sqlplugin.ChasmNodeMapsRow, error) {
+	var rows []sqlplugin.ChasmNodeMapsRow
+
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getChasmNodeMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	); err != nil {
+		return nil, err
+	}
+
+	for i := range rows {
+		rows[i].ShardID = filter.ShardID
+		rows[i].NamespaceID = filter.NamespaceID
+		rows[i].WorkflowID = filter.WorkflowID
+		rows[i].RunID = filter.RunID
+	}
+
+	return rows, nil
+}
+
+func (mdb *db) ReplaceIntoChasmNodeMaps(
+	ctx context.Context,
+	rows []sqlplugin.ChasmNodeMapsRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		setKeyInChasmNodeMapSQLQuery,
+		rows,
+	)
+}
+
+func (mdb *db) DeleteFromChasmNodeMaps(ctx context.Context, filter sqlplugin.ChasmNodeMapsFilter) (sql.Result, error) {
+	query, args, err := sqlx.In(
+		deleteKeyInChasmNodeMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+		filter.ChasmPaths,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return mdb.conn.ExecContext(ctx,
+		mdb.conn.Rebind(query),
+		args...,
+	)
+}
+
+func (mdb *db) DeleteAllFromChasmNodeMaps(ctx context.Context, filter sqlplugin.ChasmNodeMapsAllFilter) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteChasmNodeMapSQLQuery,
+		filter.ShardID,
+		filter.NamespaceID,
+		filter.WorkflowID,
+		filter.RunID,
+	)
+}

--- a/common/persistence/sql/sqlplugin/libsql/namespace.go
+++ b/common/persistence/sql/sqlplugin/libsql/namespace.go
@@ -1,0 +1,209 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	createNamespaceQuery = `INSERT INTO 
+ namespaces (partition_id, id, name, is_global, data, data_encoding, notification_version)
+ VALUES(?, ?, ?, ?, ?, ?, ?)`
+
+	updateNamespaceQuery = `UPDATE namespaces 
+ SET name = ?, data = ?, data_encoding = ?, is_global = ?, notification_version = ?
+ WHERE partition_id=54321 AND id = ?`
+
+	getNamespacePart = `SELECT id, name, is_global, data, data_encoding, notification_version FROM namespaces`
+
+	getNamespaceByIDQuery   = getNamespacePart + ` WHERE partition_id=? AND id = ?`
+	getNamespaceByNameQuery = getNamespacePart + ` WHERE partition_id=? AND name = ?`
+
+	listNamespacesQuery      = getNamespacePart + ` WHERE partition_id=? ORDER BY id LIMIT ?`
+	listNamespacesRangeQuery = getNamespacePart + ` WHERE partition_id=? AND id > ? ORDER BY id LIMIT ?`
+
+	deleteNamespaceByIDQuery   = `DELETE FROM namespaces WHERE partition_id=? AND id = ?`
+	deleteNamespaceByNameQuery = `DELETE FROM namespaces WHERE partition_id=? AND name = ?`
+
+	getNamespaceMetadataQuery    = `SELECT notification_version FROM namespace_metadata WHERE partition_id = 54321`
+	lockNamespaceMetadataQuery   = getNamespaceMetadataQuery
+	updateNamespaceMetadataQuery = `UPDATE namespace_metadata SET notification_version = ? WHERE notification_version = ? AND partition_id = 54321`
+)
+
+const (
+	partitionID = 54321
+)
+
+var errMissingArgs = errors.New("missing one or more args for API")
+
+// InsertIntoNamespace inserts a single row into namespaces table
+func (mdb *db) InsertIntoNamespace(
+	ctx context.Context,
+	row *sqlplugin.NamespaceRow,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		createNamespaceQuery,
+		partitionID,
+		row.ID,
+		row.Name,
+		row.IsGlobal,
+		row.Data,
+		row.DataEncoding,
+		row.NotificationVersion,
+	)
+}
+
+// UpdateNamespace updates a single row in namespaces table
+func (mdb *db) UpdateNamespace(
+	ctx context.Context,
+	row *sqlplugin.NamespaceRow,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		updateNamespaceQuery,
+		row.Name,
+		row.Data,
+		row.DataEncoding,
+		row.IsGlobal,
+		row.NotificationVersion,
+		row.ID,
+	)
+}
+
+// SelectFromNamespace reads one or more rows from namespaces table
+func (mdb *db) SelectFromNamespace(
+	ctx context.Context,
+	filter sqlplugin.NamespaceFilter,
+) ([]sqlplugin.NamespaceRow, error) {
+	switch {
+	case filter.ID != nil || filter.Name != nil:
+		if filter.ID != nil && filter.Name != nil {
+			return nil, serviceerror.NewInternal("only ID or name filter can be specified for selection")
+		}
+		return mdb.selectFromNamespace(ctx, filter)
+	case filter.PageSize != nil && *filter.PageSize > 0:
+		return mdb.selectAllFromNamespace(ctx, filter)
+	default:
+		return nil, errMissingArgs
+	}
+}
+
+func (mdb *db) selectFromNamespace(
+	ctx context.Context,
+	filter sqlplugin.NamespaceFilter,
+) ([]sqlplugin.NamespaceRow, error) {
+	var err error
+	var row sqlplugin.NamespaceRow
+	switch {
+	case filter.ID != nil:
+		err = mdb.conn.GetContext(ctx,
+			&row,
+			getNamespaceByIDQuery,
+			partitionID,
+			*filter.ID,
+		)
+	case filter.Name != nil:
+		err = mdb.conn.GetContext(ctx,
+			&row,
+			getNamespaceByNameQuery,
+			partitionID,
+			*filter.Name,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return []sqlplugin.NamespaceRow{row}, nil
+}
+
+func (mdb *db) selectAllFromNamespace(
+	ctx context.Context,
+	filter sqlplugin.NamespaceFilter,
+) ([]sqlplugin.NamespaceRow, error) {
+	var err error
+	var rows []sqlplugin.NamespaceRow
+	switch {
+	case filter.GreaterThanID != nil:
+		err = mdb.conn.SelectContext(ctx,
+			&rows,
+			listNamespacesRangeQuery,
+			partitionID,
+			*filter.GreaterThanID,
+			*filter.PageSize,
+		)
+	default:
+		err = mdb.conn.SelectContext(ctx,
+			&rows,
+			listNamespacesQuery,
+			partitionID,
+			filter.PageSize,
+		)
+	}
+	return rows, err
+}
+
+// DeleteFromNamespace deletes a single row in namespaces table
+func (mdb *db) DeleteFromNamespace(
+	ctx context.Context,
+	filter sqlplugin.NamespaceFilter,
+) (sql.Result, error) {
+	var err error
+	var result sql.Result
+	switch {
+	case filter.ID != nil:
+		result, err = mdb.conn.ExecContext(ctx,
+			deleteNamespaceByIDQuery,
+			partitionID,
+			filter.ID,
+		)
+	default:
+		result, err = mdb.conn.ExecContext(ctx,
+			deleteNamespaceByNameQuery,
+			partitionID,
+			filter.Name,
+		)
+	}
+	return result, err
+}
+
+// LockNamespaceMetadata acquires a write lock on a single row in namespace_metadata table
+func (mdb *db) LockNamespaceMetadata(
+	ctx context.Context,
+) (*sqlplugin.NamespaceMetadataRow, error) {
+	var row sqlplugin.NamespaceMetadataRow
+	err := mdb.conn.GetContext(ctx,
+		&row.NotificationVersion,
+		lockNamespaceMetadataQuery,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+// SelectFromNamespaceMetadata reads a single row in namespace_metadata table
+func (mdb *db) SelectFromNamespaceMetadata(
+	ctx context.Context,
+) (*sqlplugin.NamespaceMetadataRow, error) {
+	var row sqlplugin.NamespaceMetadataRow
+	err := mdb.conn.GetContext(ctx,
+		&row.NotificationVersion,
+		getNamespaceMetadataQuery,
+	)
+	return &row, err
+}
+
+// UpdateNamespaceMetadata updates a single row in namespace_metadata table
+func (mdb *db) UpdateNamespaceMetadata(
+	ctx context.Context,
+	row *sqlplugin.NamespaceMetadataRow,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		updateNamespaceMetadataQuery,
+		row.NotificationVersion+1,
+		row.NotificationVersion,
+	)
+}

--- a/common/persistence/sql/sqlplugin/libsql/nexus_endpoints.go
+++ b/common/persistence/sql/sqlplugin/libsql/nexus_endpoints.go
@@ -1,0 +1,92 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	createEndpointsTableVersionQry    = `INSERT INTO nexus_endpoints_partition_status(version) VALUES(1)`
+	incrementEndpointsTableVersionQry = `UPDATE nexus_endpoints_partition_status SET version = ? WHERE version = ?`
+	getEndpointsTableVersionQry       = `SELECT version FROM nexus_endpoints_partition_status`
+
+	createEndpointQry  = `INSERT INTO nexus_endpoints(id, data, data_encoding, version) VALUES (?, ?, ?, 1)`
+	updateEndpointQry  = `UPDATE nexus_endpoints SET data = ?, data_encoding = ?, version = ? WHERE id = ? AND version = ?`
+	deleteEndpointQry  = `DELETE FROM nexus_endpoints WHERE id = ?`
+	getEndpointByIdQry = `SELECT id, data, data_encoding, version FROM nexus_endpoints WHERE id = ?`
+	getEndpointsQry    = `SELECT id, data, data_encoding, version FROM nexus_endpoints WHERE id > ? LIMIT ?`
+)
+
+func (mdb *db) InitializeNexusEndpointsTableVersion(ctx context.Context) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx, createEndpointsTableVersionQry)
+}
+
+func (mdb *db) IncrementNexusEndpointsTableVersion(
+	ctx context.Context,
+	lastKnownTableVersion int64,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx, incrementEndpointsTableVersionQry, lastKnownTableVersion+1, lastKnownTableVersion)
+}
+
+func (mdb *db) GetNexusEndpointsTableVersion(ctx context.Context) (int64, error) {
+	var version int64
+	err := mdb.conn.GetContext(ctx, &version, getEndpointsTableVersionQry)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	return version, err
+}
+
+func (mdb *db) InsertIntoNexusEndpoints(
+	ctx context.Context,
+	row *sqlplugin.NexusEndpointsRow,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(
+		ctx,
+		createEndpointQry,
+		row.ID,
+		row.Data,
+		row.DataEncoding)
+}
+
+func (mdb *db) UpdateNexusEndpoint(
+	ctx context.Context,
+	row *sqlplugin.NexusEndpointsRow,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(
+		ctx,
+		updateEndpointQry,
+		row.Data,
+		row.DataEncoding,
+		row.Version+1,
+		row.ID,
+		row.Version)
+}
+
+func (mdb *db) DeleteFromNexusEndpoints(
+	ctx context.Context,
+	id []byte,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx, deleteEndpointQry, id)
+}
+
+func (mdb *db) GetNexusEndpointByID(
+	ctx context.Context,
+	id []byte,
+) (*sqlplugin.NexusEndpointsRow, error) {
+	var row sqlplugin.NexusEndpointsRow
+	err := mdb.conn.GetContext(ctx, &row, getEndpointByIdQry, id)
+	return &row, err
+}
+
+func (mdb *db) ListNexusEndpoints(
+	ctx context.Context,
+	request *sqlplugin.ListNexusEndpointsRequest,
+) ([]sqlplugin.NexusEndpointsRow, error) {
+	var rows []sqlplugin.NexusEndpointsRow
+	err := mdb.conn.SelectContext(ctx, &rows, getEndpointsQry, request.LastID, request.Limit)
+	return rows, err
+}

--- a/common/persistence/sql/sqlplugin/libsql/plugin.go
+++ b/common/persistence/sql/sqlplugin/libsql/plugin.go
@@ -1,0 +1,126 @@
+package libsql
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/iancoleman/strcase"
+	"github.com/jmoiron/sqlx"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence/sql"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	"go.temporal.io/server/common/resolver"
+	sqliteschema "go.temporal.io/server/schema/sqlite"
+)
+
+const (
+	// PluginName is the name of the plugin
+	PluginName = "libsql"
+)
+
+type plugin struct {
+	queryConverter sqlplugin.VisibilityQueryConverter
+	connPool       *connPool
+}
+
+func init() {
+	sql.RegisterPlugin(PluginName, &plugin{
+		queryConverter: &queryConverter{},
+		connPool:       newConnPool(),
+	})
+}
+
+func (p *plugin) GetVisibilityQueryConverter() sqlplugin.VisibilityQueryConverter {
+	return p.queryConverter
+}
+
+// CreateDB initialize the db object
+func (p *plugin) CreateDB(
+	dbKind sqlplugin.DbKind,
+	cfg *config.SQL,
+	r resolver.ServiceResolver,
+	logger log.Logger,
+	_ metrics.Handler,
+) (sqlplugin.GenericDB, error) {
+	conn, err := p.connPool.Allocate(cfg, r, logger, p.createDBConnection)
+	if err != nil {
+		return nil, err
+	}
+	db := newDB(dbKind, cfg.DatabaseName, conn, nil, logger)
+	db.OnClose(func() { p.connPool.Close(cfg) })
+	return db, nil
+}
+
+// createDBConnection creates a returns a reference to a logical connection to the
+// underlying SQL database. The returned object is tied to a single
+// SQL database and the object can be used to perform CRUD operations on
+// the tables in the database.
+func (p *plugin) createDBConnection(
+	cfg *config.SQL,
+	_ resolver.ServiceResolver,
+	logger log.Logger,
+) (*sqlx.DB, error) {
+	dsn := buildDSN(cfg)
+
+	db, err := sqlx.Connect(goSQLDriverName, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("libsql connect (%s): %w", dsn, err)
+	}
+
+	// Single connection to avoid "database is locked" with file-backed engines.
+	// See https://github.com/mattn/go-sqlite3#faq
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxIdleTime(0)
+
+	// Maps struct names in CamelCase to snake without need for db struct tags.
+	db.MapperFunc(strcase.ToSnake)
+
+	switch {
+	case cfg.ConnectAttributes["mode"] == "memory":
+		if err := p.setupDatabase(cfg, db, logger); err != nil {
+			_ = db.Close()
+			return nil, err
+		}
+	case cfg.ConnectAttributes["setup"] == "true":
+		if err := p.setupDatabase(cfg, db, logger); err != nil && !isTableExistsError(err) {
+			_ = db.Close()
+			return nil, err
+		}
+	}
+
+	return db, nil
+}
+
+func (p *plugin) setupDatabase(cfg *config.SQL, conn *sqlx.DB, logger log.Logger) error {
+	db := newDB(sqlplugin.DbKindUnknown, cfg.DatabaseName, conn, nil, logger)
+	defer func() { _ = db.Close() }()
+
+	err := db.CreateDatabase(cfg.DatabaseName)
+	if err != nil {
+		return err
+	}
+
+	return sqliteschema.SetupSchemaOnDB(db)
+}
+
+func buildDSN(cfg *config.SQL) string {
+	if cfg.ConnectAttributes == nil {
+		cfg.ConnectAttributes = make(map[string]string)
+	}
+
+	name := cfg.DatabaseName
+
+	if name == ":memory:" || cfg.ConnectAttributes["mode"] == "memory" {
+		return ":memory:"
+	}
+
+	// go-libsql expects file: prefix
+	if !strings.HasPrefix(name, "file:") {
+		return "file:" + name
+	}
+
+	return name
+}

--- a/common/persistence/sql/sqlplugin/libsql/query_converter.go
+++ b/common/persistence/sql/sqlplugin/libsql/query_converter.go
@@ -1,0 +1,271 @@
+package libsql
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/temporalio/sqlparser"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	"go.temporal.io/server/common/persistence/visibility/store/query"
+	"go.temporal.io/server/common/searchattribute/sadefs"
+)
+
+var maxDatetime = time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+
+const (
+	keywordListTypeFtsTableName = "executions_visibility_fts_keyword_list"
+	textTypeFtsTableName        = "executions_visibility_fts_text"
+)
+
+type queryConverter struct{}
+
+var _ sqlplugin.VisibilityQueryConverter = (*queryConverter)(nil)
+
+func (c *queryConverter) GetDatetimeFormat() string {
+	return "2006-01-02 15:04:05.999999-07:00"
+}
+
+func (c *queryConverter) GetCoalesceCloseTimeExpr() sqlparser.Expr {
+	return query.NewFuncExpr(
+		"coalesce",
+		query.CloseTimeSAColumn,
+		query.NewUnsafeSQLString(maxDatetime.Format(c.GetDatetimeFormat())),
+	)
+}
+
+func (c *queryConverter) ConvertKeywordListComparisonExpr(
+	operator string,
+	col *query.SAColumn,
+	value sqlparser.Expr,
+) (sqlparser.Expr, error) {
+	var ftsQuery string
+	switch operator {
+	case sqlparser.EqualStr, sqlparser.NotEqualStr:
+		valueExpr, ok := value.(*query.UnsafeSQLString)
+		if !ok {
+			return nil, query.NewConverterError(
+				"%s: unexpected value type (expected string, got %s)",
+				query.InvalidExpressionErrMessage,
+				sqlparser.String(value),
+			)
+		}
+		ftsQuery = buildFtsQueryString(col.FieldName, valueExpr.Val)
+
+	case sqlparser.InStr, sqlparser.NotInStr:
+		valTupleExpr, isValTuple := value.(sqlparser.ValTuple)
+		if !isValTuple {
+			return nil, query.NewConverterError(
+				"%s: unexpected value type (expected tuple of strings, got %s)",
+				query.InvalidExpressionErrMessage,
+				sqlparser.String(value),
+			)
+		}
+		values, err := query.GetUnsafeStringTupleValues(valTupleExpr)
+		if err != nil {
+			return nil, err
+		}
+		ftsQuery = buildFtsQueryString(col.FieldName, values...)
+
+	default:
+		// this should never happen since isSupportedKeywordListOperator should already fail
+		return nil, query.NewConverterError(
+			"%s: operator '%s' not supported for KeywordList type",
+			query.InvalidExpressionErrMessage,
+			operator,
+		)
+	}
+
+	var oper string
+	switch operator {
+	case sqlparser.EqualStr, sqlparser.InStr:
+		oper = sqlparser.InStr
+	case sqlparser.NotEqualStr, sqlparser.NotInStr:
+		oper = sqlparser.NotInStr
+	default:
+		// this should never happen since isSupportedKeywordListOperator should already fail
+		return nil, query.NewConverterError(
+			"%s: operator '%s' not supported for KeywordList type",
+			query.InvalidExpressionErrMessage,
+			operator,
+		)
+	}
+
+	newExpr := sqlparser.ComparisonExpr{
+		Operator: oper,
+		Left:     query.NewColName("rowid"),
+		Right: &sqlparser.Subquery{
+			Select: buildFtsSelectStmt(keywordListTypeFtsTableName, ftsQuery),
+		},
+	}
+	return &newExpr, nil
+}
+
+func (c *queryConverter) ConvertTextComparisonExpr(
+	operator string,
+	col *query.SAColumn,
+	value sqlparser.Expr,
+) (sqlparser.Expr, error) {
+	valueExpr, ok := value.(*query.UnsafeSQLString)
+	if !ok {
+		return nil, query.NewConverterError(
+			"%s: unexpected value type (expected string, got %s)",
+			query.InvalidExpressionErrMessage,
+			sqlparser.String(value),
+		)
+	}
+	tokens := query.TokenizeTextQueryString(valueExpr.Val)
+	if len(tokens) == 0 {
+		return nil, query.NewConverterError(
+			"%s: unexpected value for Text type search attribute (no tokens found)",
+			query.InvalidExpressionErrMessage,
+		)
+	}
+
+	var oper string
+	switch operator {
+	case sqlparser.EqualStr:
+		oper = sqlparser.InStr
+	case sqlparser.NotEqualStr:
+		oper = sqlparser.NotInStr
+	default:
+		// this should never happen since isSupportedTextOperator should already fail
+		return nil, query.NewConverterError(
+			"%s: operator '%s' not supported for Text type",
+			query.InvalidExpressionErrMessage,
+			operator,
+		)
+	}
+
+	ftsQuery := buildFtsQueryString(col.FieldName, tokens...)
+	newExpr := sqlparser.ComparisonExpr{
+		Operator: oper,
+		Left:     query.NewColName("rowid"),
+		Right: &sqlparser.Subquery{
+			Select: buildFtsSelectStmt(textTypeFtsTableName, ftsQuery),
+		},
+	}
+	return &newExpr, nil
+}
+
+func (c *queryConverter) BuildSelectStmt(
+	queryParams *query.QueryParams[sqlparser.Expr],
+	pageSize int,
+	token *sqlplugin.VisibilityPageToken,
+) (string, []any) {
+	var whereClauses []string
+	var queryArgs []any
+
+	if queryParams.QueryExpr != nil {
+		if queryString := sqlparser.String(queryParams.QueryExpr); queryString != "" {
+			whereClauses = append(whereClauses, queryString)
+		}
+	}
+
+	if token != nil {
+		whereClauses = append(
+			whereClauses,
+			fmt.Sprintf(
+				"((%s = ? AND %s = ? AND %s > ?) OR (%s = ? AND %s < ?) OR %s < ?)",
+				sqlparser.String(c.GetCoalesceCloseTimeExpr()),
+				sadefs.GetSqlDbColName(sadefs.StartTime),
+				sadefs.GetSqlDbColName(sadefs.RunID),
+				sqlparser.String(c.GetCoalesceCloseTimeExpr()),
+				sadefs.GetSqlDbColName(sadefs.StartTime),
+				sqlparser.String(c.GetCoalesceCloseTimeExpr()),
+			),
+		)
+		queryArgs = append(
+			queryArgs,
+			token.CloseTime,
+			token.StartTime,
+			token.RunID,
+			token.CloseTime,
+			token.StartTime,
+			token.CloseTime,
+		)
+	}
+
+	whereString := ""
+	if len(whereClauses) > 0 {
+		whereString = " WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
+	stmt := fmt.Sprintf(
+		`SELECT %s FROM executions_visibility%s ORDER BY %s DESC, %s DESC, %s LIMIT ?`,
+		strings.Join(sqlplugin.DbFields, ", "),
+		whereString,
+		sqlparser.String(c.GetCoalesceCloseTimeExpr()),
+		sadefs.GetSqlDbColName(sadefs.StartTime),
+		sadefs.GetSqlDbColName(sadefs.RunID),
+	)
+	queryArgs = append(queryArgs, pageSize)
+
+	return stmt, queryArgs
+}
+
+func (c *queryConverter) BuildCountStmt(
+	queryParams *query.QueryParams[sqlparser.Expr],
+) (string, []any) {
+	whereString := ""
+	if queryParams.QueryExpr != nil {
+		whereString = sqlparser.String(queryParams.QueryExpr)
+		if whereString != "" {
+			whereString = " WHERE " + whereString
+		}
+	}
+
+	groupBy := make([]string, 0, len(queryParams.GroupBy)+1)
+	for _, field := range queryParams.GroupBy {
+		groupBy = append(groupBy, sadefs.GetSqlDbColName(field.FieldName))
+	}
+
+	groupByClause := ""
+	if len(queryParams.GroupBy) > 0 {
+		groupByClause = fmt.Sprintf(" GROUP BY %s", strings.Join(groupBy, ", "))
+	}
+
+	return fmt.Sprintf(
+		"SELECT %s FROM executions_visibility%s%s",
+		strings.Join(append(groupBy, "COUNT(*)"), ", "),
+		whereString,
+		groupByClause,
+	), nil
+}
+
+// buildFtsSelectStmt builds the following statement for querying FTS:
+//
+//	SELECT rowid FROM tableName WHERE tableName = '%s'
+func buildFtsSelectStmt(
+	tableName string,
+	queryString string,
+) sqlparser.SelectStatement {
+	return &sqlparser.Select{
+		SelectExprs: sqlparser.SelectExprs{
+			&sqlparser.AliasedExpr{
+				Expr: query.NewColName("rowid"),
+			},
+		},
+		From: sqlparser.TableExprs{
+			&sqlparser.AliasedTableExpr{
+				Expr: &sqlparser.TableName{
+					Name: sqlparser.NewTableIdent(tableName),
+				},
+			},
+		},
+		Where: sqlparser.NewWhere(
+			sqlparser.WhereStr,
+			&sqlparser.ComparisonExpr{
+				Operator: sqlparser.EqualStr,
+				Left:     query.NewColName(tableName),
+				Right:    query.NewUnsafeSQLString(queryString),
+			},
+		),
+	}
+}
+
+func buildFtsQueryString(fieldName string, values ...string) string {
+	// FTS query format: 'colName : ("token1" OR "token2" OR ...)'
+	colName := sadefs.GetSqlDbColName(fieldName)
+	return fmt.Sprintf(`%s : ("%s")`, colName, strings.Join(values, `" OR "`))
+}

--- a/common/persistence/sql/sqlplugin/libsql/query_converter_test.go
+++ b/common/persistence/sql/sqlplugin/libsql/query_converter_test.go
@@ -1,0 +1,342 @@
+package libsql
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/sqlparser"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	"go.temporal.io/server/common/persistence/visibility/store/query"
+	"go.temporal.io/server/common/searchattribute/sadefs"
+)
+
+func TestQueryConverter_GetCoalesceCloseTimeExpr(t *testing.T) {
+	r := require.New(t)
+	qc := &queryConverter{}
+	expr := qc.GetCoalesceCloseTimeExpr()
+	r.Equal(
+		"coalesce(close_time, '9999-12-31 23:59:59+00:00')",
+		sqlparser.String(expr),
+	)
+}
+
+func TestQueryConverter_ConvertKeywordListComparisonExpr(t *testing.T) {
+	keywordListCol := query.NewSAColumn(
+		"AliasForKeywordList01",
+		"KeywordList01",
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
+	)
+
+	testCases := []struct {
+		name     string
+		operator string
+		col      *query.SAColumn
+		value    sqlparser.Expr
+		out      string
+		err      string
+	}{
+		{
+			name:     "valid equal expression",
+			operator: sqlparser.EqualStr,
+			col:      keywordListCol,
+			value:    query.NewUnsafeSQLString("foo"),
+			out:      `rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo")')`,
+		},
+		{
+			name:     "valid not equal expression",
+			operator: sqlparser.NotEqualStr,
+			col:      keywordListCol,
+			value:    query.NewUnsafeSQLString("foo"),
+			out:      `rowid not in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo")')`,
+		},
+		{
+			name:     "valid in expression",
+			operator: sqlparser.InStr,
+			col:      keywordListCol,
+			value: sqlparser.ValTuple{
+				query.NewUnsafeSQLString("foo"),
+				query.NewUnsafeSQLString("bar"),
+			},
+			out: `rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo" OR "bar")')`,
+		},
+		{
+			name:     "valid not in expression",
+			operator: sqlparser.NotInStr,
+			col:      keywordListCol,
+			value: sqlparser.ValTuple{
+				query.NewUnsafeSQLString("foo"),
+				query.NewUnsafeSQLString("bar"),
+			},
+			out: `rowid not in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo" OR "bar")')`,
+		},
+		{
+			name:     "invalid equal expression",
+			operator: sqlparser.EqualStr,
+			col:      keywordListCol,
+			value:    sqlparser.NewIntVal([]byte("123")),
+			err: fmt.Sprintf(
+				"%s: unexpected value type (expected string, got 123)",
+				query.InvalidExpressionErrMessage,
+			),
+		},
+		{
+			name:     "invalid in expression",
+			operator: sqlparser.InStr,
+			col:      keywordListCol,
+			value:    query.NewUnsafeSQLString("foo"),
+			err: fmt.Sprintf(
+				"%s: unexpected value type (expected tuple of strings, got 'foo')",
+				query.InvalidExpressionErrMessage,
+			),
+		},
+		{
+			name:     "invalid operator",
+			operator: sqlparser.LessThanStr,
+			col:      keywordListCol,
+			value:    query.NewUnsafeSQLString("foo"),
+			err: fmt.Sprintf(
+				"%s: operator '<' not supported for KeywordList type",
+				query.InvalidExpressionErrMessage,
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			qc := &queryConverter{}
+			out, err := qc.ConvertKeywordListComparisonExpr(tc.operator, tc.col, tc.value)
+			if tc.err != "" {
+				r.Error(err)
+				r.ErrorContains(err, tc.err)
+				var expectedErr *query.ConverterError
+				r.ErrorAs(err, &expectedErr)
+			} else {
+				r.NoError(err)
+				r.Equal(tc.out, sqlparser.String(out))
+			}
+		})
+	}
+}
+
+func TestQueryConverter_ConvertTextComparisonExpr(t *testing.T) {
+	textCol := query.NewSAColumn(
+		"AliasForText01",
+		"Text01",
+		enumspb.INDEXED_VALUE_TYPE_TEXT,
+	)
+
+	tests := []struct {
+		name     string
+		operator string
+		col      *query.SAColumn
+		value    sqlparser.Expr
+		out      string
+		err      string
+	}{
+		{
+			name:     "valid equal expression",
+			operator: sqlparser.EqualStr,
+			col:      textCol,
+			value:    query.NewUnsafeSQLString("foo bar"),
+			out:      `rowid in (select rowid from executions_visibility_fts_text where executions_visibility_fts_text = 'Text01 : ("foo" OR "bar")')`,
+		},
+		{
+			name:     "valid not equal expression",
+			operator: sqlparser.NotEqualStr,
+			col:      textCol,
+			value:    query.NewUnsafeSQLString("foo bar"),
+			out:      `rowid not in (select rowid from executions_visibility_fts_text where executions_visibility_fts_text = 'Text01 : ("foo" OR "bar")')`,
+		},
+		{
+			name:     "invalid value type",
+			operator: sqlparser.EqualStr,
+			col:      textCol,
+			value:    sqlparser.NewIntVal([]byte("123")),
+			err: fmt.Sprintf(
+				"%s: unexpected value type (expected string, got 123)",
+				query.InvalidExpressionErrMessage,
+			),
+		},
+		{
+			name:     "invalid no tokens expression",
+			operator: sqlparser.EqualStr,
+			col:      textCol,
+			value:    query.NewUnsafeSQLString(""),
+			err: fmt.Sprintf(
+				"%s: unexpected value for Text type search attribute (no tokens found)",
+				query.InvalidExpressionErrMessage,
+			),
+		},
+		{
+			name:     "invalid operator",
+			operator: sqlparser.LessThanStr,
+			col:      textCol,
+			value:    query.NewUnsafeSQLString("foo"),
+			err: fmt.Sprintf(
+				"%s: operator '<' not supported for Text type",
+				query.InvalidExpressionErrMessage,
+			),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			qc := &queryConverter{}
+			out, err := qc.ConvertTextComparisonExpr(tc.operator, tc.col, tc.value)
+			if tc.err != "" {
+				r.Error(err)
+				r.ErrorContains(err, tc.err)
+				var expectedErr *query.ConverterError
+				r.ErrorAs(err, &expectedErr)
+			} else {
+				r.NoError(err)
+				r.Equal(tc.out, sqlparser.String(out))
+			}
+		})
+	}
+}
+
+func TestQueryConverter_BuildSelectStmt(t *testing.T) {
+	closeTime := time.Date(2025, 11, 10, 13, 34, 56, 0, time.UTC)
+	startTime := time.Date(2025, 11, 10, 12, 34, 56, 0, time.UTC)
+	runID := "test-run-id"
+	keywordCol := query.NewSAColumn(
+		"AliasForKeyword01",
+		"Keyword01",
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+	)
+
+	tests := []struct {
+		name      string
+		queryExpr sqlparser.Expr
+		pageSize  int
+		token     *sqlplugin.VisibilityPageToken
+		stmt      string
+		queryArgs []any
+	}{
+		{
+			name:     "empty",
+			pageSize: 10,
+			stmt: fmt.Sprintf(
+				"SELECT %s FROM executions_visibility ORDER BY coalesce(close_time, '9999-12-31 23:59:59+00:00') DESC, start_time DESC, run_id LIMIT ?",
+				strings.Join(sqlplugin.DbFields, ", "),
+			),
+			queryArgs: []any{10},
+		},
+		{
+			name: "non-empty",
+			queryExpr: &sqlparser.ComparisonExpr{
+				Operator: sqlparser.EqualStr,
+				Left:     keywordCol,
+				Right:    query.NewUnsafeSQLString("foo"),
+			},
+			pageSize: 20,
+			stmt: fmt.Sprintf(
+				"SELECT %s FROM executions_visibility WHERE Keyword01 = 'foo' ORDER BY coalesce(close_time, '9999-12-31 23:59:59+00:00') DESC, start_time DESC, run_id LIMIT ?",
+				strings.Join(sqlplugin.DbFields, ", "),
+			),
+			queryArgs: []any{20},
+		},
+		{
+			name: "token",
+			queryExpr: &sqlparser.ComparisonExpr{
+				Operator: sqlparser.EqualStr,
+				Left:     keywordCol,
+				Right:    query.NewUnsafeSQLString("foo"),
+			},
+			pageSize: 20,
+			token: &sqlplugin.VisibilityPageToken{
+				CloseTime: closeTime,
+				StartTime: startTime,
+				RunID:     runID,
+			},
+			stmt: fmt.Sprintf(
+				"SELECT %s FROM executions_visibility WHERE Keyword01 = 'foo' AND ((coalesce(close_time, '9999-12-31 23:59:59+00:00') = ? AND start_time = ? AND run_id > ?) OR (coalesce(close_time, '9999-12-31 23:59:59+00:00') = ? AND start_time < ?) OR coalesce(close_time, '9999-12-31 23:59:59+00:00') < ?) ORDER BY coalesce(close_time, '9999-12-31 23:59:59+00:00') DESC, start_time DESC, run_id LIMIT ?",
+				strings.Join(sqlplugin.DbFields, ", "),
+			),
+			queryArgs: []any{
+				closeTime,
+				startTime,
+				runID,
+				closeTime,
+				startTime,
+				closeTime,
+				20,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			qc := &queryConverter{}
+			qp := &query.QueryParams[sqlparser.Expr]{
+				QueryExpr: tc.queryExpr,
+			}
+			stmt, queryArgs := qc.BuildSelectStmt(qp, tc.pageSize, tc.token)
+			r.Equal(tc.stmt, stmt)
+			r.Equal(tc.queryArgs, queryArgs)
+		})
+	}
+}
+
+func TestQueryConverter_BuildCountStmt(t *testing.T) {
+	keywordCol := query.NewSAColumn(
+		"AliasForKeyword01",
+		"Keyword01",
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+	)
+
+	tests := []struct {
+		name      string
+		queryExpr sqlparser.Expr
+		groupBy   []*query.SAColumn
+		stmt      string
+	}{
+		{
+			name: "empty",
+			stmt: "SELECT COUNT(*) FROM executions_visibility",
+		},
+		{
+			name: "non-empty",
+			queryExpr: &sqlparser.ComparisonExpr{
+				Operator: sqlparser.EqualStr,
+				Left:     keywordCol,
+				Right:    query.NewUnsafeSQLString("foo"),
+			},
+			stmt: "SELECT COUNT(*) FROM executions_visibility WHERE Keyword01 = 'foo'",
+		},
+		{
+			name: "group by",
+			queryExpr: &sqlparser.ComparisonExpr{
+				Operator: sqlparser.EqualStr,
+				Left:     keywordCol,
+				Right:    query.NewUnsafeSQLString("foo"),
+			},
+			groupBy: []*query.SAColumn{
+				query.NewSAColumn(sadefs.ExecutionStatus, sadefs.ExecutionStatus, enumspb.INDEXED_VALUE_TYPE_KEYWORD),
+			},
+			stmt: "SELECT status, COUNT(*) FROM executions_visibility WHERE Keyword01 = 'foo' GROUP BY status",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			qc := &queryConverter{}
+			qp := &query.QueryParams[sqlparser.Expr]{
+				QueryExpr: tc.queryExpr,
+				GroupBy:   tc.groupBy,
+			}
+			stmt, queryArgs := qc.BuildCountStmt(qp)
+			r.Equal(tc.stmt, stmt)
+			r.Nil(queryArgs)
+		})
+	}
+}

--- a/common/persistence/sql/sqlplugin/libsql/queue.go
+++ b/common/persistence/sql/sqlplugin/libsql/queue.go
@@ -1,0 +1,156 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	templateEnqueueMessageQuery      = `INSERT INTO queue (queue_type, message_id, message_payload, message_encoding) VALUES(:queue_type, :message_id, :message_payload, :message_encoding)`
+	templateGetMessageQuery          = `SELECT message_id, message_payload, message_encoding FROM queue WHERE queue_type = ? and message_id = ?`
+	templateGetMessagesQuery         = `SELECT message_id, message_payload, message_encoding FROM queue WHERE queue_type = ? and message_id > ? and message_id <= ? ORDER BY message_id ASC LIMIT ?`
+	templateDeleteMessageQuery       = `DELETE FROM queue WHERE queue_type = ? and message_id = ?`
+	templateRangeDeleteMessagesQuery = `DELETE FROM queue WHERE queue_type = ? and message_id > ? and message_id <= ?`
+
+	templateGetLastMessageIDQuery = `SELECT message_id FROM queue WHERE message_id >= (SELECT message_id FROM queue WHERE queue_type=? ORDER BY message_id DESC LIMIT 1)`
+
+	templateCreateQueueMetadataQuery = `INSERT INTO queue_metadata (queue_type, data, data_encoding, version) VALUES(:queue_type, :data, :data_encoding, :version)`
+	templateUpdateQueueMetadataQuery = `UPDATE queue_metadata SET data = :data, data_encoding = :data_encoding, version = :version+1 WHERE queue_type = :queue_type and version = :version`
+	templateGetQueueMetadataQuery    = `SELECT data, data_encoding, version from queue_metadata WHERE queue_type = ?`
+	templateLockQueueMetadataQuery   = templateGetQueueMetadataQuery
+)
+
+// InsertIntoMessages inserts a new row into queue table
+func (mdb *db) InsertIntoMessages(
+	ctx context.Context,
+	row []sqlplugin.QueueMessageRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		templateEnqueueMessageQuery,
+		row,
+	)
+}
+
+func (mdb *db) SelectFromMessages(
+	ctx context.Context,
+	filter sqlplugin.QueueMessagesFilter,
+) ([]sqlplugin.QueueMessageRow, error) {
+	var rows []sqlplugin.QueueMessageRow
+	err := mdb.conn.SelectContext(ctx,
+		&rows,
+		templateGetMessageQuery,
+		filter.QueueType,
+		filter.MessageID,
+	)
+	return rows, err
+}
+
+func (mdb *db) RangeSelectFromMessages(
+	ctx context.Context,
+	filter sqlplugin.QueueMessagesRangeFilter,
+) ([]sqlplugin.QueueMessageRow, error) {
+	var rows []sqlplugin.QueueMessageRow
+	err := mdb.conn.SelectContext(ctx,
+		&rows,
+		templateGetMessagesQuery,
+		filter.QueueType,
+		filter.MinMessageID,
+		filter.MaxMessageID,
+		filter.PageSize,
+	)
+	return rows, err
+}
+
+// DeleteFromMessages deletes message with a messageID from the queue
+func (mdb *db) DeleteFromMessages(
+	ctx context.Context,
+	filter sqlplugin.QueueMessagesFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		templateDeleteMessageQuery,
+		filter.QueueType,
+		filter.MessageID,
+	)
+}
+
+// RangeDeleteFromMessages deletes messages before messageID from the queue
+func (mdb *db) RangeDeleteFromMessages(
+	ctx context.Context,
+	filter sqlplugin.QueueMessagesRangeFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		templateRangeDeleteMessagesQuery,
+		filter.QueueType,
+		filter.MinMessageID,
+		filter.MaxMessageID,
+	)
+}
+
+// GetLastEnqueuedMessageIDForUpdate returns the last enqueued message ID
+func (mdb *db) GetLastEnqueuedMessageIDForUpdate(
+	ctx context.Context,
+	queueType persistence.QueueType,
+) (int64, error) {
+	var lastMessageID int64
+	err := mdb.conn.GetContext(ctx,
+		&lastMessageID,
+		templateGetLastMessageIDQuery,
+		queueType,
+	)
+	return lastMessageID, err
+}
+
+func (mdb *db) InsertIntoQueueMetadata(
+	ctx context.Context,
+	row *sqlplugin.QueueMetadataRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		templateCreateQueueMetadataQuery,
+		row,
+	)
+}
+
+func (mdb *db) UpdateQueueMetadata(
+	ctx context.Context,
+	row *sqlplugin.QueueMetadataRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		templateUpdateQueueMetadataQuery,
+		row,
+	)
+}
+
+func (mdb *db) SelectFromQueueMetadata(
+	ctx context.Context,
+	filter sqlplugin.QueueMetadataFilter,
+) (*sqlplugin.QueueMetadataRow, error) {
+	var row sqlplugin.QueueMetadataRow
+	err := mdb.conn.GetContext(ctx,
+		&row,
+		templateGetQueueMetadataQuery,
+		filter.QueueType,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (mdb *db) LockQueueMetadata(
+	ctx context.Context,
+	filter sqlplugin.QueueMetadataFilter,
+) (*sqlplugin.QueueMetadataRow, error) {
+	var row sqlplugin.QueueMetadataRow
+	err := mdb.conn.GetContext(ctx,
+		&row,
+		templateLockQueueMetadataQuery,
+		filter.QueueType,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}

--- a/common/persistence/sql/sqlplugin/libsql/queue_v2.go
+++ b/common/persistence/sql/sqlplugin/libsql/queue_v2.go
@@ -1,0 +1,104 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	templateEnqueueMessageQueryV2      = `INSERT INTO queue_messages (queue_type, queue_name, queue_partition, message_id, message_payload, message_encoding) VALUES(:queue_type, :queue_name, :queue_partition, :message_id, :message_payload, :message_encoding)`
+	templateGetMessagesQueryV2         = `SELECT message_id, message_payload, message_encoding FROM queue_messages WHERE queue_type = ? and queue_name = ? and queue_partition = ? and message_id >= ? ORDER BY message_id ASC LIMIT ?`
+	templateRangeDeleteMessagesQueryV2 = `DELETE FROM queue_messages WHERE queue_type = ? and queue_name = ? and queue_partition = ? and message_id >= ? and message_id <= ?`
+	templateGetLastMessageIDQueryV2    = `SELECT message_id FROM queue_messages WHERE queue_type=? and queue_name=? and queue_partition=? ORDER BY message_id DESC LIMIT 1`
+	templateCreateQueueMetadataQueryV2 = `INSERT INTO queues (queue_type, queue_name, metadata_payload, metadata_encoding) VALUES(:queue_type, :queue_name, :metadata_payload, :metadata_encoding)`
+	templateUpdateQueueMetadataQueryV2 = `UPDATE queues SET metadata_payload = :metadata_payload, metadata_encoding = :metadata_encoding WHERE queue_type = :queue_type and queue_name = :queue_name`
+	templateGetQueueMetadataQueryV2    = `SELECT metadata_payload, metadata_encoding from queues WHERE queue_type=? and queue_name=?`
+	templateGetNameFromQueueMetadataV2 = `SELECT queue_type, queue_name, metadata_payload, metadata_encoding from queues WHERE queue_type=? LIMIT ? OFFSET ?`
+)
+
+func (sdb *db) InsertIntoQueueV2Metadata(ctx context.Context, row *sqlplugin.QueueV2MetadataRow) (sql.Result, error) {
+	return sdb.conn.NamedExecContext(ctx,
+		templateCreateQueueMetadataQueryV2,
+		row,
+	)
+}
+func (sdb *db) UpdateQueueV2Metadata(ctx context.Context, row *sqlplugin.QueueV2MetadataRow) (sql.Result, error) {
+	return sdb.conn.NamedExecContext(ctx,
+		templateUpdateQueueMetadataQueryV2,
+		row,
+	)
+}
+func (sdb *db) SelectFromQueueV2Metadata(ctx context.Context, filter sqlplugin.QueueV2MetadataFilter) (*sqlplugin.QueueV2MetadataRow, error) {
+	var row sqlplugin.QueueV2MetadataRow
+	err := sdb.conn.GetContext(ctx,
+		&row,
+		templateGetQueueMetadataQueryV2,
+		filter.QueueType,
+		filter.QueueName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+func (sdb *db) SelectFromQueueV2MetadataForUpdate(ctx context.Context, filter sqlplugin.QueueV2MetadataFilter) (*sqlplugin.QueueV2MetadataRow, error) {
+	// SQLite-compatible engines do not support FOR UPDATE; use plain select.
+	return sdb.SelectFromQueueV2Metadata(ctx, filter)
+}
+func (sdb *db) SelectNameFromQueueV2Metadata(ctx context.Context, filter sqlplugin.QueueV2MetadataTypeFilter) ([]sqlplugin.QueueV2MetadataRow, error) {
+	var rows []sqlplugin.QueueV2MetadataRow
+	err := sdb.conn.SelectContext(ctx,
+		&rows,
+		templateGetNameFromQueueMetadataV2,
+		filter.QueueType,
+		filter.PageSize,
+		filter.PageOffset,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+func (sdb *db) InsertIntoQueueV2Messages(ctx context.Context, row []sqlplugin.QueueV2MessageRow) (sql.Result, error) {
+	return sdb.conn.NamedExecContext(ctx,
+		templateEnqueueMessageQueryV2,
+		row,
+	)
+}
+func (sdb *db) RangeSelectFromQueueV2Messages(ctx context.Context, filter sqlplugin.QueueV2MessagesFilter) ([]sqlplugin.QueueV2MessageRow, error) {
+	var rows []sqlplugin.QueueV2MessageRow
+	err := sdb.conn.SelectContext(ctx,
+		&rows,
+		templateGetMessagesQueryV2,
+		filter.QueueType,
+		filter.QueueName,
+		filter.Partition,
+		filter.MinMessageID,
+		filter.PageSize,
+	)
+	return rows, err
+}
+func (sdb *db) RangeDeleteFromQueueV2Messages(ctx context.Context, filter sqlplugin.QueueV2MessagesFilter) (sql.Result, error) {
+	return sdb.conn.ExecContext(ctx,
+		templateRangeDeleteMessagesQueryV2,
+		filter.QueueType,
+		filter.QueueName,
+		filter.Partition,
+		filter.MinMessageID,
+		filter.MaxMessageID,
+	)
+}
+
+func (sdb *db) GetLastEnqueuedMessageIDForUpdateV2(ctx context.Context, filter sqlplugin.QueueV2Filter) (int64, error) {
+	var lastMessageID int64
+	err := sdb.conn.GetContext(ctx,
+		&lastMessageID,
+		templateGetLastMessageIDQueryV2,
+		filter.QueueType,
+		filter.QueueName,
+		filter.Partition,
+	)
+	return lastMessageID, err
+}

--- a/common/persistence/sql/sqlplugin/libsql/shard.go
+++ b/common/persistence/sql/sqlplugin/libsql/shard.go
@@ -1,0 +1,97 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	createShardQry = `INSERT INTO
+ shards (shard_id, range_id, data, data_encoding) VALUES (?, ?, ?, ?)`
+
+	getShardQry = `SELECT
+ shard_id, range_id, data, data_encoding
+ FROM shards WHERE shard_id = ?`
+
+	updateShardQry = `UPDATE shards 
+ SET range_id = ?, data = ?, data_encoding = ? 
+ WHERE shard_id = ?`
+
+	lockShardQry     = `SELECT range_id FROM shards WHERE shard_id = ?`
+	readLockShardQry = lockShardQry
+)
+
+// InsertIntoShards inserts one or more rows into shards table
+func (mdb *db) InsertIntoShards(
+	ctx context.Context,
+	row *sqlplugin.ShardsRow,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		createShardQry,
+		row.ShardID,
+		row.RangeID,
+		row.Data,
+		row.DataEncoding,
+	)
+}
+
+// UpdateShards updates one or more rows into shards table
+func (mdb *db) UpdateShards(
+	ctx context.Context,
+	row *sqlplugin.ShardsRow,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		updateShardQry,
+		row.RangeID,
+		row.Data,
+		row.DataEncoding,
+		row.ShardID,
+	)
+}
+
+// SelectFromShards reads one or more rows from shards table
+func (mdb *db) SelectFromShards(
+	ctx context.Context,
+	filter sqlplugin.ShardsFilter,
+) (*sqlplugin.ShardsRow, error) {
+	var row sqlplugin.ShardsRow
+	err := mdb.conn.GetContext(ctx,
+		&row,
+		getShardQry,
+		filter.ShardID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, err
+}
+
+// ReadLockShards acquires a read lock on a single row in shards table
+func (mdb *db) ReadLockShards(
+	ctx context.Context,
+	filter sqlplugin.ShardsFilter,
+) (int64, error) {
+	var rangeID int64
+	err := mdb.conn.GetContext(ctx,
+		&rangeID,
+		readLockShardQry,
+		filter.ShardID,
+	)
+	return rangeID, err
+}
+
+// WriteLockShards acquires a write lock on a single row in shards table
+func (mdb *db) WriteLockShards(
+	ctx context.Context,
+	filter sqlplugin.ShardsFilter,
+) (int64, error) {
+	var rangeID int64
+	err := mdb.conn.GetContext(ctx,
+		&rangeID,
+		lockShardQry,
+		filter.ShardID,
+	)
+	return rangeID, err
+}

--- a/common/persistence/sql/sqlplugin/libsql/task_queues.go
+++ b/common/persistence/sql/sqlplugin/libsql/task_queues.go
@@ -1,0 +1,171 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	taskQueueCreatePart = `INTO task_queues_v2 (range_hash, task_queue_id, range_id, data, data_encoding) ` +
+		`VALUES (:range_hash, :task_queue_id, :range_id, :data, :data_encoding)`
+
+	// (default range ID: initialRangeID == 1)
+	createTaskQueueQry = `INSERT ` + taskQueueCreatePart
+
+	updateTaskQueueQry = `UPDATE task_queues_v2 SET
+	range_id = :range_id,
+	data = :data,
+	data_encoding = :data_encoding
+	WHERE
+	range_hash = :range_hash AND
+	task_queue_id = :task_queue_id
+	`
+
+	listTaskQueueRowSelect = `SELECT range_hash, task_queue_id, range_id, data, data_encoding FROM task_queues_v2 `
+
+	listTaskQueueWithHashRangeQry = listTaskQueueRowSelect +
+		`WHERE range_hash >= ? AND range_hash <= ? AND task_queue_id > ? ORDER BY task_queue_id ASC LIMIT ?`
+
+	listTaskQueueQry = listTaskQueueRowSelect +
+		`WHERE range_hash = ? AND task_queue_id > ? ORDER BY task_queue_id ASC LIMIT ?`
+
+	getTaskQueueQry = listTaskQueueRowSelect +
+		`WHERE range_hash = ? AND task_queue_id = ?`
+
+	deleteTaskQueueQry = `DELETE FROM task_queues_v2 WHERE range_hash=? AND task_queue_id=? AND range_id=?`
+
+	lockTaskQueueQry = `SELECT range_id FROM task_queues_v2 ` +
+		`WHERE range_hash = ? AND task_queue_id = ?`
+)
+
+// InsertIntoTaskQueues inserts one or more rows into task_queues[_v2] table
+func (mdb *db) InsertIntoTaskQueues(
+	ctx context.Context,
+	row *sqlplugin.TaskQueuesRow,
+	v sqlplugin.MatchingTaskVersion,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		sqlplugin.SwitchTaskQueuesTable(createTaskQueueQry, v),
+		row,
+	)
+}
+
+// UpdateTaskQueues updates a row in task_queues[_v2] table
+func (mdb *db) UpdateTaskQueues(
+	ctx context.Context,
+	row *sqlplugin.TaskQueuesRow,
+	v sqlplugin.MatchingTaskVersion,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		sqlplugin.SwitchTaskQueuesTable(updateTaskQueueQry, v),
+		row,
+	)
+}
+
+// SelectFromTaskQueues reads one or more rows from task_queues[_v2] table
+func (mdb *db) SelectFromTaskQueues(
+	ctx context.Context,
+	filter sqlplugin.TaskQueuesFilter,
+	v sqlplugin.MatchingTaskVersion,
+) ([]sqlplugin.TaskQueuesRow, error) {
+	switch {
+	case filter.TaskQueueID != nil:
+		if filter.RangeHashLessThanEqualTo != 0 || filter.RangeHashGreaterThanEqualTo != 0 {
+			return nil, serviceerror.NewInternal("range of hashes not supported for specific selection")
+		}
+		return mdb.selectFromTaskQueues(ctx, filter, v)
+	case filter.RangeHashLessThanEqualTo != 0 && filter.PageSize != nil:
+		if filter.RangeHashLessThanEqualTo < filter.RangeHashGreaterThanEqualTo {
+			return nil, serviceerror.NewInternal("range of hashes bound is invalid")
+		}
+		return mdb.rangeSelectFromTaskQueues(ctx, filter, v)
+	case filter.TaskQueueIDGreaterThan != nil && filter.PageSize != nil:
+		return mdb.rangeSelectFromTaskQueues(ctx, filter, v)
+	default:
+		return nil, serviceerror.NewInternal("invalid set of query filter params")
+	}
+}
+
+func (mdb *db) selectFromTaskQueues(
+	ctx context.Context,
+	filter sqlplugin.TaskQueuesFilter,
+	v sqlplugin.MatchingTaskVersion,
+) ([]sqlplugin.TaskQueuesRow, error) {
+	var err error
+	var row sqlplugin.TaskQueuesRow
+	err = mdb.conn.GetContext(ctx,
+		&row,
+		sqlplugin.SwitchTaskQueuesTable(getTaskQueueQry, v),
+		filter.RangeHash,
+		filter.TaskQueueID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return []sqlplugin.TaskQueuesRow{row}, nil
+}
+
+func (mdb *db) rangeSelectFromTaskQueues(
+	ctx context.Context,
+	filter sqlplugin.TaskQueuesFilter,
+	v sqlplugin.MatchingTaskVersion,
+) ([]sqlplugin.TaskQueuesRow, error) {
+	var err error
+	var rows []sqlplugin.TaskQueuesRow
+
+	if filter.RangeHashLessThanEqualTo != 0 {
+		err = mdb.conn.SelectContext(ctx,
+			&rows,
+			sqlplugin.SwitchTaskQueuesTable(listTaskQueueWithHashRangeQry, v),
+			filter.RangeHashGreaterThanEqualTo,
+			filter.RangeHashLessThanEqualTo,
+			filter.TaskQueueIDGreaterThan,
+			*filter.PageSize,
+		)
+	} else {
+		err = mdb.conn.SelectContext(ctx,
+			&rows,
+			sqlplugin.SwitchTaskQueuesTable(listTaskQueueQry, v),
+			filter.RangeHash,
+			filter.TaskQueueIDGreaterThan,
+			*filter.PageSize,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// DeleteFromTaskQueues deletes a row from task_queues[_v2] table
+func (mdb *db) DeleteFromTaskQueues(
+	ctx context.Context,
+	filter sqlplugin.TaskQueuesFilter,
+	v sqlplugin.MatchingTaskVersion,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		sqlplugin.SwitchTaskQueuesTable(deleteTaskQueueQry, v),
+		filter.RangeHash,
+		filter.TaskQueueID,
+		*filter.RangeID,
+	)
+}
+
+// LockTaskQueues locks a row in task_queues[_v2] table
+func (mdb *db) LockTaskQueues(
+	ctx context.Context,
+	filter sqlplugin.TaskQueuesFilter,
+	v sqlplugin.MatchingTaskVersion,
+) (int64, error) {
+	var rangeID int64
+	err := mdb.conn.GetContext(ctx,
+		&rangeID,
+		sqlplugin.SwitchTaskQueuesTable(lockTaskQueueQry, v),
+		filter.RangeHash,
+		filter.TaskQueueID,
+	)
+	return rangeID, err
+}

--- a/common/persistence/sql/sqlplugin/libsql/task_user_data.go
+++ b/common/persistence/sql/sqlplugin/libsql/task_user_data.go
@@ -1,0 +1,127 @@
+package libsql
+
+import (
+	"context"
+	"strings"
+
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	getTaskQueueUserDataQry = `SELECT data, data_encoding, version FROM task_queue_user_data ` +
+		`WHERE namespace_id = ? AND task_queue_name = ?`
+
+	updateTaskQueueUserDataQry = `UPDATE task_queue_user_data SET ` +
+		`data = ?, ` +
+		`data_encoding = ?, ` +
+		`version = ? ` +
+		`WHERE namespace_id = ? ` +
+		`AND task_queue_name = ? ` +
+		`AND version = ?`
+
+	insertTaskQueueUserDataQry = `INSERT INTO task_queue_user_data` +
+		`(namespace_id, task_queue_name, data, data_encoding, version) ` +
+		`VALUES (?, ?, ?, ?, 1)`
+
+	listTaskQueueUserDataQry = `SELECT task_queue_name, data, data_encoding, version FROM task_queue_user_data WHERE namespace_id = ? AND task_queue_name > ? LIMIT ?`
+
+	addBuildIdToTaskQueueMappingQry    = `INSERT INTO build_id_to_task_queue (namespace_id, build_id, task_queue_name) VALUES `
+	removeBuildIdToTaskQueueMappingQry = `DELETE FROM build_id_to_task_queue WHERE namespace_id = ? AND task_queue_name = ? AND build_id IN (`
+	listTaskQueuesByBuildIdQry         = `SELECT task_queue_name FROM build_id_to_task_queue WHERE namespace_id = ? AND build_id = ?`
+	countTaskQueuesByBuildIdQry        = `SELECT COUNT(*) FROM build_id_to_task_queue WHERE namespace_id = ? AND build_id = ?`
+)
+
+func (mdb *db) GetTaskQueueUserData(ctx context.Context, request *sqlplugin.GetTaskQueueUserDataRequest) (*sqlplugin.VersionedBlob, error) {
+	var row sqlplugin.VersionedBlob
+	err := mdb.conn.GetContext(ctx, &row, getTaskQueueUserDataQry, request.NamespaceID, request.TaskQueueName)
+	return &row, err
+}
+
+func (mdb *db) UpdateTaskQueueUserData(ctx context.Context, request *sqlplugin.UpdateTaskQueueDataRequest) error {
+	if request.Version == 0 {
+		_, err := mdb.conn.ExecContext(
+			ctx,
+			insertTaskQueueUserDataQry,
+			request.NamespaceID,
+			request.TaskQueueName,
+			request.Data,
+			request.DataEncoding)
+		return err
+	}
+	result, err := mdb.conn.ExecContext(
+		ctx,
+		updateTaskQueueUserDataQry,
+		request.Data,
+		request.DataEncoding,
+		request.Version+1,
+		request.NamespaceID,
+		request.TaskQueueName,
+		request.Version)
+	if err != nil {
+		return err
+	}
+	numRows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if numRows != 1 {
+		return &persistence.ConditionFailedError{Msg: "Expected exactly one row to be updated"}
+	}
+	return nil
+}
+
+func (mdb *db) ListTaskQueueUserDataEntries(ctx context.Context, request *sqlplugin.ListTaskQueueUserDataEntriesRequest) ([]sqlplugin.TaskQueueUserDataEntry, error) {
+	var rows []sqlplugin.TaskQueueUserDataEntry
+	err := mdb.conn.SelectContext(ctx, &rows, listTaskQueueUserDataQry, request.NamespaceID, request.LastTaskQueueName, request.Limit)
+	return rows, err
+}
+
+func (mdb *db) AddToBuildIdToTaskQueueMapping(ctx context.Context, request sqlplugin.AddToBuildIdToTaskQueueMapping) error {
+	query := addBuildIdToTaskQueueMappingQry
+	var params []any
+	for idx, buildId := range request.BuildIds {
+		if idx == len(request.BuildIds)-1 {
+			query += "(?, ?, ?)"
+		} else {
+			query += "(?, ?, ?), "
+		}
+		params = append(params, request.NamespaceID, buildId, request.TaskQueueName)
+	}
+
+	_, err := mdb.conn.ExecContext(ctx, query, params...)
+	return err
+}
+
+func (mdb *db) RemoveFromBuildIdToTaskQueueMapping(ctx context.Context, request sqlplugin.RemoveFromBuildIdToTaskQueueMapping) error {
+	query := removeBuildIdToTaskQueueMappingQry + strings.Repeat("?, ", len(request.BuildIds)-1) + "?)"
+	// Golang doesn't support appending a string slice to an any slice which is essentially what we're doing here.
+	params := make([]any, len(request.BuildIds)+2)
+	params[0] = request.NamespaceID
+	params[1] = request.TaskQueueName
+	for i, buildId := range request.BuildIds {
+		params[i+2] = buildId
+	}
+
+	_, err := mdb.conn.ExecContext(ctx, query, params...)
+	return err
+}
+
+func (mdb *db) GetTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.GetTaskQueuesByBuildIdRequest) ([]string, error) {
+	var rows []struct {
+		TaskQueueName string
+	}
+
+	err := mdb.conn.SelectContext(ctx, &rows, listTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
+	taskQueues := make([]string, len(rows))
+	for i, row := range rows {
+		taskQueues[i] = row.TaskQueueName
+	}
+	return taskQueues, err
+}
+
+func (mdb *db) CountTaskQueuesByBuildId(ctx context.Context, request *sqlplugin.CountTaskQueuesByBuildIdRequest) (int, error) {
+	var count int
+	err := mdb.conn.GetContext(ctx, &count, countTaskQueuesByBuildIdQry, request.NamespaceID, request.BuildID)
+	return count, err
+}

--- a/common/persistence/sql/sqlplugin/libsql/task_v1.go
+++ b/common/persistence/sql/sqlplugin/libsql/task_v1.go
@@ -1,0 +1,97 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	getTaskMinMaxQry = `SELECT task_id, data, data_encoding ` +
+		`FROM tasks ` +
+		`WHERE range_hash = ? AND task_queue_id = ? AND task_id >= ? AND task_id < ? ` +
+		` ORDER BY task_id LIMIT ?`
+
+	getTaskMinQry = `SELECT task_id, data, data_encoding ` +
+		`FROM tasks ` +
+		`WHERE range_hash = ? AND task_queue_id = ? AND task_id >= ? ORDER BY task_id LIMIT ?`
+
+	createTaskQry = `INSERT INTO ` +
+		`tasks(range_hash, task_queue_id, task_id, data, data_encoding) ` +
+		`VALUES(:range_hash, :task_queue_id, :task_id, :data, :data_encoding)`
+
+	// deleteTaskQry = `DELETE FROM tasks ` +
+	// 	`WHERE range_hash = ? AND task_queue_id = ? AND task_id = ?`
+
+	rangeDeleteTaskQry = `DELETE FROM tasks ` +
+		`WHERE range_hash = ? AND task_queue_id = ? AND task_id IN (SELECT task_id FROM
+		 tasks WHERE range_hash = ? AND task_queue_id = ? AND task_id < ? ` +
+		`ORDER BY task_queue_id,task_id LIMIT ? ) `
+)
+
+// InsertIntoTasks inserts one or more rows into tasks table
+func (mdb *db) InsertIntoTasks(
+	ctx context.Context,
+	rows []sqlplugin.TasksRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		createTaskQry,
+		rows,
+	)
+}
+
+// SelectFromTasks reads one or more rows from tasks table
+func (mdb *db) SelectFromTasks(
+	ctx context.Context,
+	filter sqlplugin.TasksFilter,
+) ([]sqlplugin.TasksRow, error) {
+	var err error
+	var rows []sqlplugin.TasksRow
+	switch {
+	case filter.ExclusiveMaxTaskID != nil:
+		err = mdb.conn.SelectContext(ctx,
+			&rows, getTaskMinMaxQry,
+			filter.RangeHash,
+			filter.TaskQueueID,
+			*filter.InclusiveMinTaskID,
+			*filter.ExclusiveMaxTaskID,
+			*filter.PageSize,
+		)
+	default:
+		err = mdb.conn.SelectContext(ctx,
+			&rows, getTaskMinQry,
+			filter.RangeHash,
+			filter.TaskQueueID,
+			*filter.ExclusiveMaxTaskID,
+			*filter.PageSize,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// DeleteFromTasks deletes one or more rows from tasks table
+func (mdb *db) DeleteFromTasks(
+	ctx context.Context,
+	filter sqlplugin.TasksFilter,
+) (sql.Result, error) {
+	if filter.ExclusiveMaxTaskID == nil {
+		return nil, serviceerror.NewInternal("missing ExclusiveMaxTaskID parameter")
+	}
+	if filter.Limit == nil || *filter.Limit == 0 {
+		return nil, serviceerror.NewInternal("missing limit parameter")
+	}
+	return mdb.conn.ExecContext(ctx,
+		rangeDeleteTaskQry,
+		filter.RangeHash,
+		filter.TaskQueueID,
+		filter.RangeHash,
+		filter.TaskQueueID,
+		*filter.ExclusiveMaxTaskID,
+		*filter.Limit,
+	)
+}

--- a/common/persistence/sql/sqlplugin/libsql/task_v2.go
+++ b/common/persistence/sql/sqlplugin/libsql/task_v2.go
@@ -1,0 +1,98 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+const (
+	getTaskV2Qry = `SELECT task_id, data, data_encoding ` +
+		`FROM tasks_v2 ` +
+		`WHERE range_hash = ? ` +
+		`AND task_queue_id = ? ` +
+		`AND (pass, task_id) >= (?, ?) ` +
+		`ORDER BY pass, task_id`
+
+	getTaskV2QryWithLimit = getTaskV2Qry + ` LIMIT ?`
+
+	createTaskV2Qry = `INSERT INTO ` +
+		`tasks_v2 ( range_hash,  task_queue_id,  task_id,       pass,  data,  data_encoding) ` +
+		`VALUES   (:range_hash, :task_queue_id, :task_id, :task_pass, :data, :data_encoding)`
+
+	rangeDeleteTaskV2Qry = `DELETE FROM tasks_v2 ` +
+		`WHERE range_hash = ? AND task_queue_id = ? AND task_id IN (SELECT task_id FROM ` +
+		`tasks_v2 WHERE range_hash = ? AND task_queue_id = ? AND (pass, task_id) < (?, ?) ` +
+		`ORDER BY task_queue_id, pass, task_id LIMIT ? ) `
+)
+
+// InsertIntoTasks inserts one or more rows into tasks_v2 table
+func (mdb *db) InsertIntoTasksV2(
+	ctx context.Context,
+	rows []sqlplugin.TasksRowV2,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		createTaskV2Qry,
+		rows,
+	)
+}
+
+// SelectFromTasks reads one or more rows from tasks_v2 table
+func (mdb *db) SelectFromTasksV2(
+	ctx context.Context,
+	filter sqlplugin.TasksFilterV2,
+) ([]sqlplugin.TasksRowV2, error) {
+	if filter.InclusiveMinLevel == nil {
+		return nil, serviceerror.NewInternal("missing InclusiveMinLevel")
+	}
+	var err error
+	var rows []sqlplugin.TasksRowV2
+	switch {
+	case filter.PageSize != nil:
+		err = mdb.conn.SelectContext(ctx,
+			&rows, getTaskV2QryWithLimit,
+			filter.RangeHash,
+			filter.TaskQueueID,
+			filter.InclusiveMinLevel.TaskPass,
+			filter.InclusiveMinLevel.TaskID,
+			*filter.PageSize,
+		)
+	default:
+		err = mdb.conn.SelectContext(ctx,
+			&rows, getTaskV2Qry,
+			filter.RangeHash,
+			filter.TaskQueueID,
+			filter.InclusiveMinLevel.TaskPass,
+			filter.InclusiveMinLevel.TaskID,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// DeleteFromTasks deletes one or more rows from tasks_v2 table
+func (mdb *db) DeleteFromTasksV2(
+	ctx context.Context,
+	filter sqlplugin.TasksFilterV2,
+) (sql.Result, error) {
+	if filter.ExclusiveMaxLevel == nil {
+		return nil, serviceerror.NewInternal("missing ExclusiveMaxTaskLevel")
+	}
+	if filter.Limit == nil || *filter.Limit == 0 {
+		return nil, serviceerror.NewInternal("missing limit parameter")
+	}
+	return mdb.conn.ExecContext(ctx,
+		rangeDeleteTaskV2Qry,
+		filter.RangeHash,
+		filter.TaskQueueID,
+		filter.RangeHash,
+		filter.TaskQueueID,
+		filter.ExclusiveMaxLevel.TaskPass,
+		filter.ExclusiveMaxLevel.TaskID,
+		*filter.Limit,
+	)
+}

--- a/common/persistence/sql/sqlplugin/libsql/typeconv.go
+++ b/common/persistence/sql/sqlplugin/libsql/typeconv.go
@@ -1,0 +1,41 @@
+package libsql
+
+import "time"
+
+var (
+	minSQLiteDateTime = getMinSQLiteDateTime()
+)
+
+type (
+	// DataConverter defines the API for conversions to/from
+	// Go types and database column types (SQLite-compatible datetime).
+	DataConverter interface {
+		ToSQLiteDateTime(t time.Time) time.Time
+		FromSQLiteDateTime(t time.Time) time.Time
+	}
+	converter struct{}
+)
+
+// ToSQLiteDateTime converts Go time to database datetime (SQLite-compatible format).
+func (c *converter) ToSQLiteDateTime(t time.Time) time.Time {
+	if t.IsZero() {
+		return minSQLiteDateTime
+	}
+	return t.UTC().Truncate(time.Microsecond)
+}
+
+// FromSQLiteDateTime converts database datetime back to Go time.
+func (c *converter) FromSQLiteDateTime(t time.Time) time.Time {
+	if t.Equal(minSQLiteDateTime) {
+		return time.Time{}.UTC()
+	}
+	return t.UTC()
+}
+
+func getMinSQLiteDateTime() time.Time {
+	t, err := time.Parse(time.RFC3339, "1000-01-01T00:00:00Z")
+	if err != nil {
+		return time.Unix(0, 0).UTC()
+	}
+	return t.UTC()
+}

--- a/common/persistence/sql/sqlplugin/libsql/visibility.go
+++ b/common/persistence/sql/sqlplugin/libsql/visibility.go
@@ -1,0 +1,207 @@
+package libsql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+)
+
+var (
+	keywordListSeparator = "♡"
+
+	templateInsertWorkflowExecution = fmt.Sprintf(
+		`INSERT INTO executions_visibility (%s)
+		VALUES (%s)
+		ON CONFLICT (namespace_id, run_id) DO NOTHING`,
+		strings.Join(sqlplugin.DbFields, ", "),
+		sqlplugin.BuildNamedPlaceholder(sqlplugin.DbFields...),
+	)
+
+	templateUpsertWorkflowExecution = fmt.Sprintf(
+		`INSERT INTO executions_visibility (%s)
+		VALUES (%s)
+		%s`,
+		strings.Join(sqlplugin.DbFields, ", "),
+		sqlplugin.BuildNamedPlaceholder(sqlplugin.DbFields...),
+		buildOnDuplicateKeyUpdate(sqlplugin.DbFields...),
+	)
+
+	templateDeleteWorkflowExecution = `
+		DELETE FROM executions_visibility
+		WHERE namespace_id = :namespace_id AND run_id = :run_id`
+
+	templateGetWorkflowExecution = fmt.Sprintf(
+		`SELECT %s FROM executions_visibility
+		WHERE namespace_id = :namespace_id AND run_id = :run_id`,
+		strings.Join(sqlplugin.DbFields, ", "),
+	)
+)
+
+func buildOnDuplicateKeyUpdate(fields ...string) string {
+	items := make([]string, len(fields))
+	for i, field := range fields {
+		items[i] = fmt.Sprintf("%s = excluded.%s", field, field)
+	}
+	return fmt.Sprintf(
+		// The WHERE clause ensures that no update occurs if the version is behind the saved version.
+		"ON CONFLICT (namespace_id, run_id) DO UPDATE SET %s WHERE executions_visibility.%s < EXCLUDED.%s",
+		strings.Join(items, ", "), sqlplugin.VersionColumnName, sqlplugin.VersionColumnName,
+	)
+}
+
+// InsertIntoVisibility inserts a row into visibility table. If an row already exist,
+// its left as such and no update will be made
+func (mdb *db) InsertIntoVisibility(
+	ctx context.Context,
+	row *sqlplugin.VisibilityRow,
+) (sql.Result, error) {
+	finalRow := mdb.prepareRowForDB(row)
+	return mdb.conn.NamedExecContext(ctx, templateInsertWorkflowExecution, finalRow)
+}
+
+// ReplaceIntoVisibility replaces an existing row if it exist or creates a new row in visibility table
+func (mdb *db) ReplaceIntoVisibility(
+	ctx context.Context,
+	row *sqlplugin.VisibilityRow,
+) (sql.Result, error) {
+	finalRow := mdb.prepareRowForDB(row)
+	return mdb.conn.NamedExecContext(ctx, templateUpsertWorkflowExecution, finalRow)
+}
+
+// DeleteFromVisibility deletes a row from visibility table if it exist
+func (mdb *db) DeleteFromVisibility(
+	ctx context.Context,
+	filter sqlplugin.VisibilityDeleteFilter,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx, templateDeleteWorkflowExecution, filter)
+}
+
+// SelectFromVisibility reads one or more rows from visibility table
+func (mdb *db) SelectFromVisibility(
+	ctx context.Context,
+	filter sqlplugin.VisibilitySelectFilter,
+) ([]sqlplugin.VisibilityRow, error) {
+	if len(filter.Query) == 0 {
+		// backward compatibility for existing tests
+		err := sqlplugin.GenerateSelectQuery(&filter, mdb.converter.ToSQLiteDateTime)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var rows []sqlplugin.VisibilityRow
+	err := mdb.conn.SelectContext(ctx, &rows, filter.Query, filter.QueryArgs...)
+	if err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		err = mdb.processRowFromDB(&rows[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return rows, nil
+}
+
+// GetFromVisibility reads one row from visibility table
+func (mdb *db) GetFromVisibility(
+	ctx context.Context,
+	filter sqlplugin.VisibilityGetFilter,
+) (*sqlplugin.VisibilityRow, error) {
+	var row sqlplugin.VisibilityRow
+	stmt, err := mdb.conn.PrepareNamedContext(ctx, templateGetWorkflowExecution)
+	if err != nil {
+		return nil, err
+	}
+	err = stmt.GetContext(ctx, &row, filter)
+	if err != nil {
+		return nil, err
+	}
+	err = mdb.processRowFromDB(&row)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (mdb *db) CountFromVisibility(
+	ctx context.Context,
+	filter sqlplugin.VisibilitySelectFilter,
+) (int64, error) {
+	var count int64
+	err := mdb.conn.GetContext(ctx, &count, filter.Query, filter.QueryArgs...)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (mdb *db) CountGroupByFromVisibility(
+	ctx context.Context,
+	filter sqlplugin.VisibilitySelectFilter,
+) ([]sqlplugin.VisibilityCountRow, error) {
+	rows, err := mdb.db.QueryContext(ctx, filter.Query, filter.QueryArgs...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return sqlplugin.ParseCountGroupByRows(rows, filter.GroupBy)
+}
+
+func (mdb *db) prepareRowForDB(row *sqlplugin.VisibilityRow) *sqlplugin.VisibilityRow {
+	if row == nil {
+		return nil
+	}
+	finalRow := *row
+	finalRow.StartTime = mdb.converter.ToSQLiteDateTime(finalRow.StartTime)
+	finalRow.ExecutionTime = mdb.converter.ToSQLiteDateTime(finalRow.ExecutionTime)
+	if finalRow.CloseTime != nil {
+		*finalRow.CloseTime = mdb.converter.ToSQLiteDateTime(*finalRow.CloseTime)
+	}
+	if finalRow.SearchAttributes != nil {
+		finalSearchAttributes := sqlplugin.VisibilitySearchAttributes{}
+		for name, value := range *finalRow.SearchAttributes {
+			switch v := value.(type) {
+			case []string:
+				finalSearchAttributes[name] = strings.Join(v, keywordListSeparator)
+			case time.Time:
+				finalSearchAttributes[name] = v.Format(time.RFC3339Nano)
+			default:
+				finalSearchAttributes[name] = v
+			}
+		}
+		finalRow.SearchAttributes = &finalSearchAttributes
+	}
+	return &finalRow
+}
+
+func (mdb *db) processRowFromDB(row *sqlplugin.VisibilityRow) error {
+	if row == nil {
+		return nil
+	}
+	row.StartTime = mdb.converter.FromSQLiteDateTime(row.StartTime)
+	row.ExecutionTime = mdb.converter.FromSQLiteDateTime(row.ExecutionTime)
+	if row.CloseTime != nil {
+		closeTime := mdb.converter.FromSQLiteDateTime(*row.CloseTime)
+		row.CloseTime = &closeTime
+	}
+	if row.SearchAttributes != nil {
+		for saName, saValue := range *row.SearchAttributes {
+			switch typedSaValue := saValue.(type) {
+			case string:
+				if strings.Contains(typedSaValue, keywordListSeparator) {
+					// If the string contains the keywordListSeparator, then we need to split it
+					// into a list of keywords.
+					(*row.SearchAttributes)[saName] = strings.Split(typedSaValue, keywordListSeparator)
+				}
+			default:
+				// no-op
+			}
+		}
+	}
+	return nil
+}

--- a/config/development-libsql.yaml
+++ b/config/development-libsql.yaml
@@ -1,0 +1,136 @@
+log:
+  stdout: true
+  level: info
+
+persistence:
+  defaultStore: libsql-default
+  visibilityStore: libsql-visibility
+  numHistoryShards: 1
+  datastores:
+    libsql-default:
+      sql:
+        user: ""
+        password: ""
+        pluginName: "libsql"
+        databaseName: "default"
+        connectAddr: "localhost"
+        connectProtocol: "tcp"
+        connectAttributes:
+          mode: "memory"
+        maxConns: 1
+        maxIdleConns: 1
+        maxConnLifetime: "1h"
+        tls:
+          enabled: false
+          caFile: ""
+          certFile: ""
+          keyFile: ""
+          enableHostVerification: false
+          serverName: ""
+
+    libsql-visibility:
+      sql:
+        user: ""
+        password: ""
+        pluginName: "libsql"
+        databaseName: "default"
+        connectAddr: "localhost"
+        connectProtocol: "tcp"
+        connectAttributes:
+          mode: "memory"
+        maxConns: 1
+        maxIdleConns: 1
+        maxConnLifetime: "1h"
+        tls:
+          enabled: false
+          caFile: ""
+          certFile: ""
+          keyFile: ""
+          enableHostVerification: false
+          serverName: ""
+global:
+  membership:
+    maxJoinDuration: 30s
+    broadcastAddress: "127.0.0.1"
+  pprof:
+    port: 7936
+  metrics:
+    prometheus:
+      # specify framework to use new approach for initializing metrics and/or use opentelemetry
+      # framework: "opentelemetry"
+      framework: "tally"
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
+
+services:
+  frontend:
+    rpc:
+      grpcPort: 7233
+      membershipPort: 6933
+      bindOnLocalHost: true
+      httpPort: 7243
+
+  matching:
+    rpc:
+      grpcPort: 7235
+      membershipPort: 6935
+      bindOnLocalHost: true
+
+  history:
+    rpc:
+      grpcPort: 7234
+      membershipPort: 6934
+      bindOnLocalHost: true
+
+  worker:
+    rpc:
+      grpcPort: 7239
+      membershipPort: 6939
+      bindOnLocalHost: true
+
+clusterMetadata:
+  enableGlobalNamespace: false
+  failoverVersionIncrement: 10
+  masterClusterName: "active"
+  currentClusterName: "active"
+  clusterInformation:
+    active:
+      enabled: true
+      initialFailoverVersion: 1
+      rpcName: "frontend"
+      rpcAddress: "localhost:7233"
+      httpAddress: "localhost:7243"
+
+dcRedirectionPolicy:
+  policy: "noop"
+
+archival:
+  history:
+    state: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+      gstorage:
+        credentialsPath: "/tmp/gcloud/keyfile.json"
+  visibility:
+    state: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+
+namespaceDefaults:
+  archival:
+    history:
+      state: "disabled"
+      URI: "file:///tmp/temporal_archival/development"
+    visibility:
+      state: "disabled"
+      URI: "file:///tmp/temporal_vis_archival/development"
+
+dynamicConfigClient:
+  filepath: "config/dynamicconfig/development-sql.yaml"
+  pollInterval: "10s"

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb
 	github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938
 	github.com/tidwall/btree v1.8.1
+	github.com/tursodatabase/go-libsql v0.0.0-20251219133454-43644db490ff
 	github.com/uber-go/tally/v4 v4.1.17
 	github.com/urfave/cli v1.22.16
 	github.com/urfave/cli/v2 v2.27.5
@@ -79,7 +80,11 @@ require (
 	modernc.org/sqlite v1.44.3
 )
 
-require github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 // indirect
+require (
+	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 // indirect
+	github.com/libsql/sqlite-antlr4-parser v0.0.0-20240327125255-dbf53b6cbf06 // indirect
+)
 
 require (
 	cel.dev/expr v0.23.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
+github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apache/thrift v0.21.0 h1:tdPmh/ptjE1IJnhbhrcl2++TauVjy242rkV/UzJChnE=
 github.com/apache/thrift v0.21.0/go.mod h1:W1H8aR/QRtYNvrPeFXBtobyRkd0/YVhTc6i07XIAgDw=
@@ -208,6 +210,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/libsql/sqlite-antlr4-parser v0.0.0-20240327125255-dbf53b6cbf06 h1:JLvn7D+wXjH9g4Jsjo+VqmzTUpl/LX7vfr6VOfSWTdM=
+github.com/libsql/sqlite-antlr4-parser v0.0.0-20240327125255-dbf53b6cbf06/go.mod h1:FUkZ5OHjlGPjnM2UyGJz9TypXQFgYqw6AFNO1UiROTM=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/maruel/panicparse/v2 v2.4.0 h1:yQKMIbQ0DKfinzVkTkcUzQyQ60UCiNnYfR7PWwTs2VI=
@@ -319,6 +323,8 @@ github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938 h1:sEJGh
 github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938/go.mod h1:ezRQRwu9KQXy8Wuuv1aaFFxoCNz5CeNbVOOkh3xctbY=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
 github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
+github.com/tursodatabase/go-libsql v0.0.0-20251219133454-43644db490ff h1:Hvxz9W8fWpSg9xkiq8/q+3cVJo+MmLMfkjdS/u4nWFY=
+github.com/tursodatabase/go-libsql v0.0.0-20251219133454-43644db490ff/go.mod h1:TjsB2miB8RW2Sse8sdxzVTdeGlx74GloD5zJYUC38d8=
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/uber-common/bark v1.0.0/go.mod h1:g0ZuPcD7XiExKHynr93Q742G/sbrdVQkghrqLGOoFuY=
@@ -544,6 +550,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 modernc.org/cc/v4 v4.27.1 h1:9W30zRlYrefrDV2JE2O8VDtJ1yPGownxciz5rrbQZis=
 modernc.org/cc/v4 v4.27.1/go.mod h1:uVtb5OGqUKpoLWhqwNQo/8LwvoiEBLvZXIQ/SmO6mL0=


### PR DESCRIPTION
Turso is basically SQLite under the hood, so this is a straightforward extension: same schema, same config shape, just swap in [go-libsql](https://github.com/tursodatabase/go-libsql) instead of modernc.org/sqlite. When they ship multithreading it could be a drop-in performance boost for anyone using SQLite today.

Couple of fixes that came up:
- **DQS=0** — libsql treats double-quoted strings as identifiers. Our visibility schema uses `"$.Foo"` in generated columns and was failing. Plugin rewrites those to single-quoted when applying schema.
- **Dup detection** — go-libsql has no typed errors, so we match on SQLite codes 2067/1555 and the error string.

Requires CGO. Config: `pluginName: "libsql"`, `databaseName` is a file path or `:memory:`. Example in `config/development-libsql.yaml`.