### PR TITLE
Clean stale branches

### DIFF
--- a/.github/workflows/cleanup-stale-branches.yml
+++ b/.github/workflows/cleanup-stale-branches.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: read
 
 jobs:
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
 
       # TODO: add `--delete` to actually remove branches
       - name: find stale branches


### PR DESCRIPTION
## What changed?

Adding scheduled GitHub job to delete stale branches from the repo.

## Why?

Cleanup.

## How did you test it?

Script will only list stale branches at first; will need to verify correctness before arming it.

<details><summary>Example output</summary>
<p>

```
Repo:    temporalio/temporal
Cutoff:  2025-11-21T22:13:38Z (90 days)
Dry run: true

STALE: TQConfigAttachRateLimit (2025-07-21T12:44:46-07:00)
STALE: accepted-update-blocks-termination (2025-05-01T10:59:33-07:00)
SKIP (recent): advance-time-clean (2026-02-10T16:54:44-08:00)
SKIP (open PR): advance-time-matching
SKIP (recent): ai-review (2026-02-17T17:51:51-08:00)
STALE: allow-weightness-override-wf (2025-10-29T20:14:01-07:00)
STALE: antithesis-poc (2024-12-03T22:46:39-08:00)
STALE: antithesis-poc-apply-bug (2024-11-16T16:41:11-08:00)
STALE: antithesis-poc-startedtime-bug (2024-11-16T16:45:32-08:00)
STALE: api-1.46.0 (2025-03-21T09:35:49-07:00)
STALE: arm-test-runner (2025-05-30T10:49:41-07:00)
STALE: assertion-func (2025-02-26T11:57:37-08:00)
STALE: assertion-func2 (2025-03-05T10:40:51-08:00)
STALE: assertion-func3 (2025-03-04T17:09:44-08:00)
SKIP (recent): autoshard (2026-02-06T07:48:35-08:00)
SKIP (recent): autoshard-file (2026-02-10T11:06:25-08:00)
STALE: bump-ui-version (2024-12-18T10:52:19-08:00)
SKIP (recent): catch (2025-11-22T15:16:49-08:00)
STALE: chunk-cass-tests (2025-05-30T11:44:30-07:00)
SKIP (open PR): clean-up-branches
STALE: clear-update-registry-on-shard-reload (2024-07-15T10:05:49-07:00)
STALE: codecov-badge (2025-03-13T10:13:42-07:00)
STALE: codecov-checks-off (2025-03-13T10:22:55-07:00)
STALE: codecov-demo-pr (2025-03-13T10:03:12-07:00)
SKIP (recent): crash-monitor (2026-01-21T13:50:11-08:00)
STALE: d2-protos (2025-01-08T17:14:54-08:00)
STALE: datablob-json (2025-01-30T10:06:02-08:00)
STALE: datablob-nil (2025-08-08T13:46:46-07:00)
STALE: dc-ns (2025-01-24T09:47:53-08:00)
STALE: debug-TestPerKeyRateLimit (2025-07-22T10:55:43-07:00)
STALE: debug-tests (2024-03-06T13:05:18-08:00)
STALE: disable-cyclomatic-complexity-for-tests (2024-03-04T10:47:06-08:00)
STALE: docs-concepts (2024-01-16T16:53:04-08:00)
STALE: docs-from-ground-up (2024-02-05T10:04:43-08:00)
STALE: docs-schema (2024-06-07T11:22:55-07:00)
STALE: drop-encoding-param (2025-06-18T11:47:31-07:00)
STALE: fair7 (2025-07-14T09:39:31-07:00)
STALE: fairness-dropped-task (2025-07-15T12:30:38-07:00)
STALE: fairness-schema (2025-06-03T16:12:44-07:00)
STALE: fairness-tdbg-test (2025-07-07T17:03:36-07:00)
SKIP (recent): fake-network (2026-01-26T17:31:45-08:00)
STALE: feature/fairness (2025-07-14T10:37:54-07:00)
STALE: feature/test-docker-builds (2025-07-07T18:35:22-07:00)
STALE: feature/use-poll-instead-goroutine (2024-07-09T15:54:31-07:00)
SKIP (recent): fix-GetWorkflowExecutionHistory-longpoll (2026-01-09T09:24:21-08:00)
STALE: fix-coveralls (2025-03-13T08:39:08-07:00)
STALE: fix-coveralls-2 (2025-02-10T19:58:11-08:00)
STALE: fix-coveralls-3 (2025-02-12T08:58:26-08:00)
STALE: fix-fair-taskstore-init (2025-07-15T12:28:30-07:00)
SKIP (recent): fix-feature-tests (2025-12-02T13:13:50-08:00)
STALE: fix-flaky-update-sdk-test (2024-11-15T08:05:43-08:00)
STALE: fix-json-omes (2025-04-24T12:38:38-07:00)
STALE: fix-multiops-lease (2024-11-20T18:18:36-08:00)
STALE: flaky-TestUpdateWorkflow_ValidateWorkerMessages (2025-01-22T15:53:15-08:00)
STALE: fwd-server-status (2025-05-01T17:33:38-07:00)
STALE: gomock-generics (2024-03-04T09:34:48-08:00)
SKIP (recent): goroutine-dump-2 (2026-02-11T12:58:18-08:00)
STALE: gotestsum-debug (2024-11-13T13:55:45-08:00)
STALE: gotestsum-fix (2024-11-12T16:24:09-08:00)
SKIP (recent): group-flakes (2026-01-28T17:05:29-08:00)
SKIP (recent): injecthook-ns (2026-02-11T19:48:52-08:00)
STALE: internal-assertions (2025-10-31T08:09:51-07:00)
STALE: jmbarzee/flakes/matching-data-race-optimize-imports-goland (2024-08-21T10:33:43-07:00)
STALE: longpoll-stress (2025-08-29T00:35:50Z)
SKIP (recent): lower-server-workers-in-tests (2026-02-04T12:53:16-08:00)
STALE: makefile-make-rpc-clients (2023-12-14T11:34:12-08:00)
SKIP (recent): manual-faults (2026-01-21T13:54:30-08:00)
SKIP (recent): manual-faults2 (2026-01-20T11:48:11-08:00)
SKIP (recent): manual-faults3 (2026-01-26T20:40:04-08:00)
STALE: matching-docs (2024-02-14T09:37:39-08:00)
STALE: matching-engine-gauge (2025-01-13T16:35:25-08:00)
STALE: matching-engine-pqm (2025-01-13T15:27:33-08:00)
STALE: matching-engine-qry (2025-01-13T13:07:51-08:00)
STALE: matching-engine-test-new (2025-01-14T13:15:32-08:00)
STALE: maybe-start-workflow (2024-03-22T17:12:01-07:00)
STALE: merge-poller-handlers (2024-07-05T20:19:12-07:00)
STALE: more-docs (2024-08-07T14:17:44-07:00)
STALE: move-golangci (2025-04-08T09:41:53-07:00)
STALE: multiop-require-start (2024-05-02T14:18:25-07:00)
STALE: multiops-frontend-ops-validation (2024-04-22T08:18:11-07:00)
STALE: multiops-logging (2025-05-30T17:21:11-07:00)
STALE: multiops-race (2024-11-20T17:51:35-08:00)
STALE: new-workflow-in-cache (2024-03-22T10:10:36-07:00)
SKIP (open PR): nexus-chasm-cmd
SKIP (open PR): nexus-chasm-cmd-cancel
STALE: nil-err (2025-10-29T18:23:47-07:00)
STALE: no-tag-th (2025-04-10T08:24:42-07:00)
STALE: ns-cluster (2025-01-17T16:07:16-08:00)
STALE: ns-replication (2025-01-17T15:16:39-08:00)
STALE: otel-asap (2025-11-05T08:31:46-08:00)
STALE: otel-debug (2024-08-14T12:56:30-07:00)
STALE: otel-ms (2025-01-31T15:35:54-08:00)
STALE: otel-persistence-attr (2025-01-09T16:51:36-08:00)
STALE: otel-sampler-debug-always-on (2025-02-26T13:56:13-08:00)
STALE: otel-timeout-ctx (2025-02-05T10:54:38-08:00)
STALE: otel-trace-env (2024-02-27T09:03:59-08:00)
STALE: persistence-wrapper (2025-01-09T08:30:45-08:00)
STALE: pri-metric (2025-04-24T12:15:46-07:00)
STALE: pri-taskidblock (2025-03-17T13:03:11-07:00)
STALE: priority-assert (2025-03-07T15:40:41-08:00)
SKIP (recent): proc-per-test (2026-02-10T08:37:01-08:00)
SKIP (recent): protobuf-opaque (2026-01-24T09:26:11-08:00)
SKIP (recent): protogetter (2026-02-03T08:44:39-08:00)
STALE: protovalidate-go-poc (2024-11-10T19:33:57-08:00)
STALE: query-history (2025-01-27T08:55:37-08:00)
STALE: rapid-testing (2025-03-31T14:04:37-07:00)
STALE: ratelimit-fair (2025-09-01T13:33:02-07:00)
STALE: rd/go-1.25 (2025-08-22T09:55:24-07:00)
STALE: readme-refresh (2025-04-07T14:48:56-07:00)
STALE: readme-toc (2025-03-13T11:33:28-07:00)
STALE: reapply-reset-update (2024-09-10T13:17:48-07:00)
STALE: refactor-start-workflow-tests (2024-03-04T14:21:48-08:00)
STALE: refactor-workflow-id-reuse (2024-03-05T13:48:29-08:00)
STALE: reject-update-shard-move (2024-05-23T21:05:24-07:00)
STALE: reject-update-shard-move-v2 (2024-05-24T10:44:16-07:00)
STALE: reject-update-shard-move-v3 (2024-05-24T10:43:05-07:00)
STALE: remove-generic-go-comment (2024-01-12T15:07:21-08:00)
STALE: remove-internal (2025-03-25T13:31:48-07:00)
STALE: remove-logger-field (2024-07-19T12:01:32-07:00)
SKIP (recent): remove-multi-flag (2025-12-22T13:55:51-08:00)
STALE: remove-shortcut-rpc (2025-06-27T12:20:38-07:00)
STALE: remove-simple-cache (2024-05-23T08:37:59-07:00)
STALE: remove-update-dc (2024-12-18T12:25:51-08:00)
STALE: revert-upgrade (2025-03-25T13:15:20-07:00)
SKIP (recent): serialization-refactor (2025-11-26T16:15:22-08:00)
STALE: sethistorytree-remove-ctx (2024-02-20T11:36:55-08:00)
STALE: simplify-task-poller-at-handler (2024-05-14T13:48:17-07:00)
STALE: simulate-stuck-workflow (2025-11-16T17:52:22-08:00)
STALE: single-import-for-package (2024-01-17T13:39:40-08:00)
SKIP (recent): slim-jobs-v2 (2026-02-04T13:44:17-08:00)
STALE: sofassert-static (2025-09-29T11:56:45-07:00)
STALE: softassert-internalerr (2025-10-07T11:08:10-07:00)
SKIP (recent): softassert-testhooks (2025-12-09T09:12:23-08:00)
STALE: sometimes (2025-10-31T08:09:12-07:00)
STALE: sqlite-chai (2024-07-04T12:24:43-07:00)
STALE: sqlite3-wasm (2024-07-04T12:11:16-07:00)
STALE: stale-gha (2024-03-05T08:56:52-08:00)
STALE: stamp (2025-04-29T15:43:56-07:00)
STALE: start-workflow-split (2024-03-01T10:13:11-08:00)
STALE: stats-api (2025-04-28T14:21:22-07:00)
STALE: struct-builder (2024-05-17T13:34:02-07:00)
STALE: subqueuekey-prioritykey (2025-07-30T13:51:26-07:00)
STALE: task-queue-stats-tests2 (2025-06-18T17:40:50-07:00)
STALE: test-crash-report (2025-09-04T14:38:54-07:00)
SKIP (recent): test-env-5 (2026-01-28T11:44:30-08:00)
STALE: test-start-request-builder (2024-05-16T09:22:50-07:00)
STALE: test-suite-timeout (2025-01-22T14:13:10-08:00)
STALE: test-timeout (2025-01-22T10:13:04-08:00)
STALE: test-worker-checksum (2025-04-07T09:05:13-07:00)
STALE: test-yuri-refactor (2025-01-24T12:23:07-08:00)
SKIP (recent): testenv-tqstats (2026-02-09T13:13:37-08:00)
STALE: testhook (2024-12-05T08:34:09-08:00)
SKIP (recent): testify-eventually (2026-01-27T10:30:10-08:00)
STALE: testify-replace (2025-07-24T17:13:38-07:00)
STALE: testrunner-logprefix (2025-01-14T10:25:00-08:00)
STALE: testrunner-simplify (2025-06-30T10:16:00-07:00)
SKIP (recent): tests-otel-events (2026-01-29T16:03:52-08:00)
STALE: timeout-debug (2025-07-31T14:00:58-07:00)
STALE: timeout-task (2025-02-12T15:41:13-08:00)
STALE: track-flaky-tests (2024-06-06T08:35:58-07:00)
STALE: transition-fix (2024-12-16T12:52:40-08:00)
SKIP (open PR): tweak-gofix-retry
STALE: typed-cache (2024-05-22T15:01:50-07:00)
STALE: typed-named-dc (2025-01-17T12:11:51-08:00)
SKIP (recent): umpire (2026-01-11T18:57:02-08:00)
STALE: unify-datablob (2025-08-07T10:02:13-07:00)
STALE: upd-closing-err (2025-02-06T13:28:01-08:00)
STALE: upd-namespace-tag (2025-05-30T10:23:49-07:00)
STALE: upd-protoc-gen-go-grpc (2025-03-31T12:55:05-07:00)
STALE: update-dependencies (2024-06-18T10:36:59-07:00)
STALE: update-docs-editing (2024-10-02T09:42:54-07:00)
STALE: update-handler-refactor (2024-03-04T16:12:41-08:00)
STALE: update-limit-docs-can (2025-03-06T14:55:37-08:00)
STALE: update-limit-raise (2025-02-05T07:54:20-08:00)
STALE: update-name-reserve (2025-01-15T10:40:04-08:00)
STALE: update-state-machine (2024-05-29T14:55:44-07:00)
STALE: update-state-transition-fix (2024-12-13T16:33:20-08:00)
STALE: update-tag-logger (2024-07-16T16:21:10-07:00)
STALE: update-tools (2025-03-25T11:37:48-07:00)
STALE: update-with-start (2024-01-22T14:50:58-08:00)
STALE: update-with-start-delayed (2024-08-27T13:13:46-07:00)
STALE: update-with-start-poc (2024-01-10T16:56:19-08:00)
STALE: update-with-start2 (2024-02-28T10:54:24-08:00)
STALE: update_dep_127 (2025-03-25T08:46:29-07:00)
STALE: uws-annotations (2024-12-04T19:02:31-08:00)
STALE: uws-closed-wf (2025-04-25T09:08:30-07:00)
STALE: uws-debug (2024-11-10T16:49:06-08:00)
STALE: uws-lock-fix (2024-12-19T13:56:18-08:00)
STALE: uws-notfound-test (2025-06-12T09:00:11-07:00)
STALE: uws-npe (2025-05-01T13:24:05-07:00)
STALE: uws-race-fix-test (2024-11-29T16:22:40-08:00)
STALE: uws-refactoring (2025-01-08T12:39:08-08:00)
STALE: verbose-tests-ci (2024-04-05T11:35:41-07:00)
STALE: wait-stage-metric (2025-01-22T11:09:55-08:00)
STALE: workflow-task-attempt-reset (2025-11-21T12:22:05-08:00)
STALE: xray (2024-05-15T14:36:31-07:00)
SKIP (recent): yamlfmt (2026-02-04T15:26:04-08:00)
SKIP (recent): advance-time-clean (2026-02-10T16:45:06-08:00)
SKIP (recent): byte-replication (2025-12-16T12:44:58-08:00)
SKIP (recent): cdf/pick-9300-9316 (2026-02-12T23:39:11-08:00)
SKIP (open PR): cdf/reactivation-cache-flake-fix
SKIP (recent): cdf/revert-9300 (2026-02-12T22:45:13-08:00)
STALE: cdf/trigger-publish-error (2025-04-21T14:36:33-07:00)
SKIP (recent): cg/nexus/3-cancellation (2026-01-22T12:22:47-08:00)
STALE: chasm-backfill-task (2025-08-27T17:04:01-07:00)
SKIP (recent): chasm-fix-unit-test-linter (2025-12-11T18:07:23-05:00)
STALE: chasm-generate-task (2025-08-27T17:04:10-07:00)
STALE: chasm-invoker-tasks (2025-08-27T17:02:50-07:00)
STALE: chasm-library-and-config (2025-08-27T17:03:48-07:00)
STALE: chasm-port-hsm-components (2025-08-27T17:03:37-07:00)
STALE: chasm_parent (2025-07-07T16:00:28-07:00)
STALE: codex/add-build-flag-to-disable-archiver-package (2025-06-30T16:34:15-07:00)
STALE: codex/fix-reschedule-time-update-on-submit-failure (2025-07-09T19:32:36-07:00)
STALE: codex/move-and-consolidate-blob-methods (2025-06-20T19:27:13-07:00)
STALE: correct (2025-06-17T14:02:09-07:00)
SKIP (recent): cretz/time-skipping (2026-02-18T17:34:20-06:00)
STALE: david/fairsim (2025-08-22T13:27:42-07:00)
SKIP (open PR): dependabot/go_modules/filippo.io/edwards25519-1.1.1
SKIP (recent): docs-links (2026-01-08T15:45:55-05:00)
SKIP (open PR): elasticsearch-cluster-metadata-config-override
SKIP (recent): empty-cherry-pick-cloud-v1.31.0-151 (2026-02-17T16:35:53-08:00)
SKIP (recent): empty-refs (2025-11-26T14:05:09-05:00)
SKIP (recent): esAliasMappingRegistration (2026-02-18T14:49:58-05:00)
STALE: fairness (2025-07-14T11:27:34-07:00)
SKIP (recent): fix-GetWorkflowExecutionHistory-longpoll (2026-01-09T09:24:21-08:00)
SKIP (recent): fix-allow-no-pollers-unset-current-issue (2026-02-04T14:44:10-08:00)
SKIP (recent): fix-error-message (2026-01-19T15:58:18-05:00)
SKIP (recent): fredtzeng/debug-cloud (2026-01-15T11:58:53-08:00)
SKIP (recent): fredtzeng/debug-retention (2026-01-26T11:29:43-08:00)
SKIP (recent): fredtzeng/debug-shard-ownership (2026-01-16T15:39:07-08:00)
STALE: haifengh/safinder (2025-06-16T23:00:16-07:00)
SKIP (recent): history_server_worker_heartbeat (2025-12-28T16:05:37-08:00)
SKIP (recent): implement_history_server_worker_heartbeat (2025-12-30T14:47:02-08:00)
STALE: jbarzee/elastic-search-client-no-retry (2025-03-20T16:12:17-07:00)
STALE: jbarzee/remove-migrated-cluster-handlers (2025-03-09T15:53:22-06:00)
SKIP (recent): jssmith/child-reset (2025-12-09T23:52:10-08:00)
SKIP (recent): jssmith/child-reset-v1.29.1 (2025-12-10T00:12:02-08:00)
SKIP (open PR): kannan/activity-cancel/batching
SKIP (recent): kannan/activity-cancel/control-queue-single-partition (2026-02-11T16:45:11-08:00)
SKIP (recent): kannan/activity-cancel/dispatch-logic (2026-02-17T21:51:36-08:00)
SKIP (recent): kannan/activity-cancel/persist-worker-key (2026-02-17T19:43:22-08:00)
SKIP (recent): kannan/activity-cancel/task-definition (2026-02-17T21:51:29-08:00)
SKIP (recent): kannan/activity-cancel/typed-nexus-service (2026-02-12T14:28:12-08:00)
SKIP (recent): kannan/activity-cancel/worker-registry-lookup (2026-02-10T10:41:59-08:00)
SKIP (recent): kannan/cleanup-poll-metadata-context (2026-02-04T16:07:43-08:00)
SKIP (recent): kannan/fix-outstanding-pollers-forwarding-bug (2026-02-09T16:01:53-08:00)
SKIP (open PR): kannan/shutdown-worker-poll-guard
SKIP (recent): kannan/temp_task_started_verification_timer (2026-01-22T16:41:05-08:00)
SKIP (recent): kannanr/chasm_worker_benchmark (2025-12-29T10:34:20-08:00)
SKIP (open PR): lanie/deep-health-check-impl
SKIP (open PR): mcn-data-merger
SKIP (recent): metrics-wire-q (2026-01-21T15:42:23-08:00)
SKIP (open PR): nexus-chasm-cmd
SKIP (open PR): nexus-chasm-cmd-cancel
SKIP (recent): nexus/hsm-to-chasm-migration (2026-02-18T15:24:59-08:00)
SKIP (recent): parallelize-all-the-things (2026-02-17T11:44:29-08:00)
SKIP (recent): parent-close-policy-transfer-task (2026-01-07T11:56:28-05:00)
STALE: patch-3.140-b3749347-c8fb-4504-802e-8b177a0e81a2 (2025-08-26T15:26:32Z)
SKIP (recent): patch-3.150-5148cc28-2a82-40d8-8964-ef54f22a9505 (2026-02-11T21:28:37Z)
SKIP (recent): ppv/connFix (2026-01-13T10:09:33-08:00)
SKIP (recent): ppv/connFix2 (2026-02-10T10:47:10-08:00)
SKIP (recent): ppv/nexusRL (2026-02-06T17:09:28-08:00)
STALE: ppv/sortedRescheduler2 (2025-08-27T10:16:21-07:00)
SKIP (recent): ppv/widSequentialScheduler (2026-02-18T17:26:07-08:00)
SKIP (recent): prototype_worker_chasm (2025-12-28T13:15:47-08:00)
SKIP (recent): remove-nil-search-attributes (2026-02-02T13:45:38-05:00)
SKIP (recent): reproduce-missing-deployment-version-error (2026-02-04T18:28:07-05:00)
SKIP (recent): revert-8750-RE-20 (2025-12-17T08:42:10-06:00)
SKIP (recent): revert-9304-nexus-on-by-default (2026-02-18T10:11:46-06:00)
SKIP (recent): revert-grouping-replication-task-by-workflow-id (2025-12-12T10:00:17-08:00)
SKIP (recent): rodrigozhou/del-vis-task-retention-flag (2026-02-18T13:17:34-08:00)
SKIP (recent): rodrigozhou/del-vis-task-start-time (2026-01-15T00:17:39-08:00)
SKIP (recent): rodrigozhou/vis-queue-metrics (2025-12-09T18:16:39-08:00)
SKIP (recent): sa-tests-refactor (2026-02-13T08:59:14-05:00)
SKIP (recent): saa-state-machine (2025-12-16T12:23:38-05:00)
SKIP (recent): saa-visibility-unaliased-task-queue (2025-12-11T17:20:12-05:00)
SKIP (recent): sched-future-action-coverage (2026-01-08T14:33:19-08:00)
SKIP (recent): sched-initial-update (2026-01-12T16:30:01-08:00)
SKIP (recent): sched-listexecutions (2025-12-10T19:34:08-08:00)
SKIP (recent): seandan/streaming (2025-12-22T14:04:28-05:00)
SKIP (recent): serverless (2026-02-18T16:50:11-08:00)
SKIP (recent): shahab/concurrency-test-max-deployments-error (2025-12-17T16:03:32-08:00)
SKIP (open PR): shivam/last-signaled-target-version
STALE: simple-default-claim-mapper-with-aud (2025-08-22T15:13:40-04:00)
SKIP (open PR): spk/convert-operator-suites
SKIP (recent): spk/default-test-timeout (2026-02-12T15:01:57-07:00)
SKIP (recent): spk/flaky-transient-test (2026-02-11T10:50:10-07:00)
SKIP (recent): spk/purge-count-sent-metric (2026-02-02T16:58:35-07:00)
SKIP (open PR): spk/report-failures
SKIP (recent): spk/revive-7732 (2026-02-18T16:14:27-07:00)
SKIP (recent): spk/update-aborted-err (2026-02-18T12:40:38-07:00)
SKIP (open PR): spk/update-premature-end-stream
STALE: ss/blackholing-queries (2025-07-02T14:44:39-04:00)
SKIP (recent): ss/enable-eager-activities (2026-02-06T11:11:21-05:00)
STALE: ss/fix-flake (2025-06-21T22:04:18-04:00)
SKIP (recent): ss/flake-doctor (2025-12-18T10:00:22-05:00)
SKIP (recent): ss/reject-versioning-override (2025-12-03T11:14:22-05:00)
SKIP (recent): ss/worker-versioning-RL (2026-01-30T16:32:24-05:00)
STALE: stamp (2025-07-01T11:23:16-07:00)
SKIP (recent): standalone-activity-todos (2025-12-18T17:48:24-05:00)
SKIP (open PR): stefan/ext-service
SKIP (open PR): stefan/matching-service
SKIP (recent): stefan/wci (2026-02-18T11:34:36-08:00)
SKIP (recent): task-latency-without-persistence (2026-01-30T13:52:02-05:00)
SKIP (recent): test-env-5 (2026-01-26T13:52:21-07:00)
STALE: test-salt-optimizer (2025-07-02T14:24:53-04:00)
SKIP (recent): update-deps-1.30.0-071858a3-ec3f-41a3-9b18-0764d5ca9224 (2026-01-06T19:21:57-05:00)
SKIP (recent): update-deps-1.30.0-4680c0d0-1a8d-4454-a52a-341c6605b74d (2026-01-08T01:17:30Z)
SKIP (recent): update-deps-1.30.0-871da80c-4fc2-4228-bc96-2194e297f313 (2026-01-06T19:21:57-05:00)
SKIP (recent): update-deps-1.30.0-9bc4aa33-ba5c-4c34-848c-77b571cdb995 (2026-01-06T19:21:57-05:00)
SKIP (recent): update-deps-1.30.0-cec0b4e3-a7cf-4de3-a85c-942bb93a9dce (2026-01-23T17:56:51Z)
SKIP (recent): update-deps-1.31.0-0446aa97-bd86-4487-bae3-bf5f15e87790 (2026-02-17T18:30:28-06:00)
SKIP (recent): update-deps-1.31.0-1011a6ad-1d0d-40a3-a0f2-41d7c4114849 (2026-01-31T03:32:33Z)
SKIP (recent): update-deps-1.31.0-9af3ad41-ce2c-4231-b1c2-622515e053ca (2026-01-31T03:32:33Z)
SKIP (recent): update-deps-1.31.0-9f4e47e8-6d42-4bc5-9607-9cc77e80f6b4 (2026-01-31T03:32:33Z)
SKIP (recent): update-deps-1.31.0-b1b0dec5-e44d-48a1-aa08-879a1a268905 (2026-01-31T03:32:33Z)
SKIP (recent): will/debug-historyproxy-unimplemented (2026-01-26T17:14:13-08:00)
STALE: yichao/chasm-enable-tests (2025-07-01T15:57:51-07:00)
SKIP (recent): yichao/chasm-id-space-sql (2026-01-14T17:09:19-08:00)
STALE: yichao/chasm-wire-up (2025-07-01T16:12:28-07:00)
SKIP (recent): yichao/fix-migration-breaking-change (2026-01-21T12:05:40-08:00)

Found 188 stale branches, skipped 133.
Re-run with --delete to remove them.


```

</p>
</details> 