### PR TITLE
Nexus endpoint package

### DIFF
--- a/common/nexus/nexusendpoint/endpoint_registry_test.go
+++ b/common/nexus/nexusendpoint/endpoint_registry_test.go
@@ -1,4 +1,4 @@
-package nexus
+package nexusendpoint
 
 import (
 	"context"
@@ -27,7 +27,7 @@ import (
 )
 
 type testMocks struct {
-	config         *EndpointRegistryConfig
+	config         *RegistryConfig
 	matchingClient *matchingservicemock.MockMatchingServiceClient
 	persistence    *persistence.MockNexusEndpointManager
 }
@@ -55,7 +55,7 @@ func TestGet(t *testing.T) {
 		return &matchingservice.ListNexusEndpointsResponse{TableVersion: int64(1)}, nil
 	}).AnyTimes()
 
-	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	reg := NewRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	reg.StartLifecycle()
 	defer reg.StopLifecycle()
 
@@ -100,7 +100,7 @@ func TestGetNotFound(t *testing.T) {
 	sentinelErr := errors.New("sentinel")
 	mocks.persistence.EXPECT().GetNexusEndpoint(gomock.Any(), gomock.Any()).Return(nil, sentinelErr)
 
-	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	reg := NewRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	reg.StartLifecycle()
 	defer reg.StopLifecycle()
 
@@ -143,7 +143,7 @@ func TestInitializationFallback(t *testing.T) {
 		Entries:       []*persistencespb.NexusEndpointEntry{testEndpoint},
 	}, nil)
 
-	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	reg := NewRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	reg.StartLifecycle()
 	defer reg.StopLifecycle()
 
@@ -170,7 +170,7 @@ func TestEnableDisableEnable(t *testing.T) {
 	}
 
 	// start disabled
-	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	reg := NewRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	reg.StartLifecycle()
 	defer reg.StopLifecycle()
 
@@ -296,7 +296,7 @@ func TestTableVersionErrorResetsMatchingPagination(t *testing.T) {
 		return &matchingservice.ListNexusEndpointsResponse{TableVersion: int64(1)}, nil
 	}).MaxTimes(1)
 
-	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	reg := NewRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	reg.StartLifecycle()
 	defer reg.StopLifecycle()
 
@@ -363,7 +363,7 @@ func TestTableVersionErrorResetsPersistencePagination(t *testing.T) {
 		NextPageToken: nil,
 	}, nil)
 
-	reg := NewEndpointRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
+	reg := NewRegistry(mocks.config, mocks.matchingClient, mocks.persistence, log.NewNoopLogger(), metrics.NoopMetricsHandler)
 	reg.StartLifecycle()
 	defer reg.StopLifecycle()
 
@@ -382,7 +382,7 @@ func TestTableVersionErrorResetsPersistencePagination(t *testing.T) {
 
 func newTestMocks(t *testing.T) *testMocks {
 	ctrl := gomock.NewController(t)
-	testConfig := NewEndpointRegistryConfig(dynamicconfig.NewNoopCollection())
+	testConfig := NewRegistryConfig(dynamicconfig.NewNoopCollection())
 	testConfig.refreshEnabled = func(func(bool)) (bool, func()) {
 		return true, func() {}
 	}

--- a/common/nexus/nexustest/registry.go
+++ b/common/nexus/nexustest/registry.go
@@ -5,7 +5,7 @@ import (
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/namespace"
-	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusendpoint"
 )
 
 type FakeEndpointRegistry struct {
@@ -29,4 +29,4 @@ func (f FakeEndpointRegistry) StopLifecycle() {
 	panic("unimplemented")
 }
 
-var _ commonnexus.EndpointRegistry = FakeEndpointRegistry{}
+var _ nexusendpoint.Registry = FakeEndpointRegistry{}

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -28,6 +28,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusendpoint"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/service/history/consts"
@@ -62,7 +63,7 @@ type TaskExecutorOptions struct {
 	Logger                 log.Logger
 	CallbackTokenGenerator *commonnexus.CallbackTokenGenerator
 	ClientProvider         ClientProvider
-	EndpointRegistry       commonnexus.EndpointRegistry
+	EndpointRegistry       nexusendpoint.Registry
 	HTTPTraceProvider      commonnexus.HTTPClientTraceProvider
 	HistoryClient          resource.HistoryClient
 	ChasmRegistry          *chasm.Registry

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -560,7 +560,7 @@ func TestProcessInvocationTask(t *testing.T) {
 					metrics.FailureSourceTag("_unknown_"))
 			}
 
-			endpointReg := nexustest.FakeEndpointRegistry{
+			endpointReg := nexustest.FakeRegistry{
 				OnGetByID: func(ctx context.Context, endpointID string) (*persistencespb.NexusEndpointEntry, error) {
 					require.Equal(t, "endpoint-id", endpointID)
 					if tc.endpointNotFound {
@@ -995,7 +995,7 @@ func TestProcessCancelationTask(t *testing.T) {
 					metrics.OutcomeTag(tc.expectedMetricOutcome),
 					metrics.FailureSourceTag("_unknown_"))
 			}
-			endpointReg := nexustest.FakeEndpointRegistry{
+			endpointReg := nexustest.FakeRegistry{
 				OnGetByID: func(ctx context.Context, endpointID string) (*persistencespb.NexusEndpointEntry, error) {
 					require.Equal(t, "endpoint-id", endpointID)
 					if tc.endpointNotFound {
@@ -1102,7 +1102,7 @@ func TestProcessCancelationTask_OperationCompleted(t *testing.T) {
 			},
 		},
 		NamespaceRegistry: namespaceRegistry,
-		EndpointRegistry: nexustest.FakeEndpointRegistry{
+		EndpointRegistry: nexustest.FakeRegistry{
 			OnGetByID: func(ctx context.Context, endpointID string) (*persistencespb.NexusEndpointEntry, error) {
 				return endpointEntry, nil
 			},

--- a/components/nexusoperations/fx.go
+++ b/components/nexusoperations/fx.go
@@ -14,6 +14,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusendpoint"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/resource"
@@ -26,8 +27,8 @@ var Module = fx.Module(
 	fx.Provide(ClientProviderFactory),
 	fx.Provide(DefaultNexusTransportProvider),
 	fx.Provide(CallbackTokenGeneratorProvider),
-	fx.Provide(EndpointRegistryProvider),
-	fx.Invoke(EndpointRegistryLifetimeHooks),
+	fx.Provide(RegistryProvider),
+	fx.Invoke(RegistryLifetimeHooks),
 	fx.Invoke(RegisterStateMachines),
 	fx.Invoke(RegisterTaskSerializers),
 	fx.Invoke(RegisterEventDefinitions),
@@ -36,15 +37,15 @@ var Module = fx.Module(
 
 const NexusCallbackSourceHeader = "Nexus-Callback-Source"
 
-func EndpointRegistryProvider(
+func RegistryProvider(
 	matchingClient resource.MatchingClient,
 	endpointManager persistence.NexusEndpointManager,
 	dc *dynamicconfig.Collection,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
-) commonnexus.EndpointRegistry {
-	registryConfig := commonnexus.NewEndpointRegistryConfig(dc)
-	return commonnexus.NewEndpointRegistry(
+) nexusendpoint.Registry {
+	registryConfig := nexusendpoint.NewRegistryConfig(dc)
+	return nexusendpoint.NewRegistry(
 		registryConfig,
 		matchingClient,
 		endpointManager,
@@ -53,7 +54,7 @@ func EndpointRegistryProvider(
 	)
 }
 
-func EndpointRegistryLifetimeHooks(lc fx.Lifecycle, registry commonnexus.EndpointRegistry) {
+func RegistryLifetimeHooks(lc fx.Lifecycle, registry nexusendpoint.Registry) {
 	lc.Append(fx.StartStopHook(registry.StartLifecycle, registry.StopLifecycle))
 }
 

--- a/components/nexusoperations/workflow/commands.go
+++ b/components/nexusoperations/workflow/commands.go
@@ -16,6 +16,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusendpoint"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/service/history/hsm"
@@ -26,7 +27,7 @@ import (
 
 type commandHandler struct {
 	config           *nexusoperations.Config
-	endpointRegistry commonnexus.EndpointRegistry
+	endpointRegistry nexusendpoint.Registry
 	nexusProcessor   *chasm.NexusEndpointProcessor
 }
 
@@ -328,7 +329,7 @@ func (ch *commandHandler) HandleCancelCommand(
 func RegisterCommandHandlers(
 	reg *workflow.CommandHandlerRegistry,
 	chasmRegistry *chasm.Registry,
-	endpointRegistry commonnexus.EndpointRegistry,
+	endpointRegistry nexusendpoint.Registry,
 	config *nexusoperations.Config,
 ) error {
 	h := commandHandler{

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -24,6 +24,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusendpoint"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/visibility"
@@ -109,9 +110,9 @@ var Module = fx.Options(
 	fx.Provide(HTTPAPIServerProvider),
 	fx.Provide(NewServiceProvider),
 	fx.Provide(NexusEndpointClientProvider),
-	fx.Provide(NexusEndpointRegistryProvider),
+	fx.Provide(NexusRegistryProvider),
 	fx.Invoke(ServiceLifetimeHooks),
-	fx.Invoke(EndpointRegistryLifetimeHooks),
+	fx.Invoke(RegistryLifetimeHooks),
 	fx.Provide(schedulerpb.NewSchedulerServiceLayeredClient),
 	nexusfrontend.Module,
 	activity.FrontendModule,
@@ -837,7 +838,7 @@ func RegisterNexusHTTPHandler(
 	clusterMetadata cluster.Metadata,
 	clientCache *cluster.FrontendHTTPClientCache,
 	namespaceRegistry namespace.Registry,
-	endpointRegistry nexus.EndpointRegistry,
+	endpointRegistry nexusendpoint.Registry,
 	authInterceptor *authorization.Interceptor,
 	telemetryInterceptor *interceptor.TelemetryInterceptor,
 	requestErrorHandler *interceptor.RequestErrorHandler,
@@ -951,15 +952,15 @@ func NexusEndpointClientProvider(
 	)
 }
 
-func NexusEndpointRegistryProvider(
+func NexusRegistryProvider(
 	matchingClient resource.MatchingClient,
 	nexusEndpointManager persistence.NexusEndpointManager,
 	dc *dynamicconfig.Collection,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
-) nexus.EndpointRegistry {
-	registryConfig := nexus.NewEndpointRegistryConfig(dc)
-	return nexus.NewEndpointRegistry(
+) nexusendpoint.Registry {
+	registryConfig := nexusendpoint.NewRegistryConfig(dc)
+	return nexusendpoint.NewRegistry(
 		registryConfig,
 		matchingClient,
 		nexusEndpointManager,
@@ -968,7 +969,7 @@ func NexusEndpointRegistryProvider(
 	)
 }
 
-func EndpointRegistryLifetimeHooks(lc fx.Lifecycle, registry nexus.EndpointRegistry) {
+func RegistryLifetimeHooks(lc fx.Lifecycle, registry nexusendpoint.Registry) {
 	lc.Append(fx.StartStopHook(registry.StartLifecycle, registry.StopLifecycle))
 }
 

--- a/service/frontend/nexus_http_handler.go
+++ b/service/frontend/nexus_http_handler.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusendpoint"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/routing"
 	"go.temporal.io/server/common/rpc"
@@ -36,7 +37,7 @@ type NexusHTTPHandler struct {
 	base                                 nexusrpc.BaseHTTPHandler
 	logger                               log.Logger
 	nexusHandler                         http.Handler
-	enpointRegistry                      commonnexus.EndpointRegistry
+	enpointRegistry                      nexusendpoint.Registry
 	namespaceRegistry                    namespace.Registry
 	preprocessErrorCounter               metrics.CounterFunc
 	auth                                 *authorization.Interceptor
@@ -54,7 +55,7 @@ func NewNexusHTTPHandler(
 	clusterMetadata cluster.Metadata,
 	clientCache *cluster.FrontendHTTPClientCache,
 	namespaceRegistry namespace.Registry,
-	endpointRegistry commonnexus.EndpointRegistry,
+	endpointRegistry nexusendpoint.Registry,
 	authInterceptor *authorization.Interceptor,
 	telemetryInterceptor *interceptor.TelemetryInterceptor,
 	requestErrorHandler *interceptor.RequestErrorHandler,


### PR DESCRIPTION
## What changed?

Move Nexus endpoint-related code into `common/nexus/nexusendpoint`.

## Why?

To break dependency cycle when using `common/nexus` from `chasm`.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
