### PR TITLE
Enable Chasm and CHASM callbacks by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2774,7 +2774,7 @@ that task will be sent to DLQ.`,
 
 	EnableChasm = NewNamespaceBoolSetting(
 		"history.enableChasm",
-		false,
+		true,
 		"Use real chasm tree implementation instead of the noop one",
 	)
 
@@ -2800,7 +2800,7 @@ to the CHASM (V2) implementation on active scheduler workflows.`,
 
 	EnableCHASMCallbacks = NewNamespaceBoolSetting(
 		"history.enableCHASMCallbacks",
-		false,
+		true,
 		`Controls whether new callbacks are created using the CHASM implementation
 instead of the previous HSM backed implementation.`,
 	)

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -264,6 +264,10 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_UseExisting_OnConflictOpt
 					dynamicconfig.MaxCallbacksPerWorkflow,
 					tc.MaxCallbacksPerWorkflow,
 				)
+				s.OverrideDynamicConfig(
+					dynamicconfig.MaxCHASMCallbacksPerWorkflow,
+					tc.MaxCallbacksPerWorkflow,
+				)
 			}
 
 			tv := testvars.New(s.T())

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -72,6 +72,11 @@ func (s *NexusStateReplicationSuite) SetupSuite() {
 			"Pattern": "*", "AllowInsecure": true,
 		}},
 	}
+	if !s.enableTransitionHistory {
+		// CHASM state replicates via transition history. When TH is disabled,
+		// fall back to HSM callbacks which use task-based replication.
+		s.dynamicConfigOverrides[dynamicconfig.EnableCHASMCallbacks.Key()] = false
+	}
 	s.setupSuite()
 }
 


### PR DESCRIPTION
## What changed?
WISOTT

## Why?
Supported by default now.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Minimal, we've done extensive testing.
