### PR TITLE
Avoid finalGC when ack level is zero

### DIFF
--- a/service/matching/fair_task_reader.go
+++ b/service/matching/fair_task_reader.go
@@ -680,5 +680,8 @@ func (tr *fairTaskReader) finalGC() {
 	tr.lock.Lock()
 	ackLevel := tr.ackLevel
 	tr.lock.Unlock()
+	if ackLevel.pass == 0 {
+		return
+	}
 	_, _ = tr.doGCAt(ackLevel)
 }

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -543,5 +543,8 @@ func (tr *priTaskReader) finalGC() {
 	tr.lock.Lock()
 	ackLevel := tr.ackLevel
 	tr.lock.Unlock()
+	if ackLevel == 0 {
+		return
+	}
 	_, _ = tr.doGCAt(ackLevel)
 }


### PR DESCRIPTION
## What changed?
When finishing draining, the drained queue may not have had any tasks at all. In that case don't try to do a GC. This is harmless but causes an error log.

## Why?
Misleading error logs.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
