### PR TITLE
Change log level for unspecified task queue kind from Warn to Debug

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -885,7 +885,7 @@ func (wh *WorkflowHandler) PollWorkflowTaskQueue(ctx context.Context, request *w
 	}
 
 	if request.TaskQueue.GetKind() == enumspb.TASK_QUEUE_KIND_UNSPECIFIED {
-		wh.logger.Warn("Unspecified task queue kind",
+		wh.logger.Debug("Unspecified task queue kind",
 			tag.WorkflowTaskQueueName(request.TaskQueue.GetName()),
 			tag.WorkflowNamespace(namespace.Name(request.GetNamespace()).String()),
 		)


### PR DESCRIPTION
## What changed?
Demoted the log level for the message "Unspecified task queue kind" from `Warn` to `Debug` within `service/frontend/workflow_handler.go`.

## Why?
## What changed?
Demoted the log level for the message "Unspecified task queue kind" from `Warn` to `Debug` within `service/frontend/workflow_handler.go`.

## Why?
This change addresses the noise reported in #8322.

his log line currently creates significant noise in server logs, especially for users of SDKs (such as the Ruby SDK) that do not explicitly pass the `TaskQueueKind` field. Since the Temporal server is documented to default this field to `Normal` and handles the fallback correctly, a **Warn** level is unnecessarily aggressive.

In high-throughput environments, this "log chunder" obscures actual operational issues and inflates log storage costs without providing actionable insights, as the system is behaving as intended. Moving this to **Debug** keeps the information available for protocol troubleshooting without impacting production log readability.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
The risk is minimal. Developers who specifically monitor **Warn** logs to identify incomplete `gRPC` requests from custom clients will now need to enable **Debug** logging to see this specific entry. However, since the server's default behavior is functional and intended, this change does not impact system stability or data integrity.


his log line currently creates significant noise in server logs, especially for users of SDKs (such as the Ruby SDK) that do not explicitly pass the `TaskQueueKind` field. Since the Temporal server is documented to default this field to `Normal` and handles the fallback correctly, a **Warn** level is unnecessarily aggressive.

In high-throughput environments, this "log chunder" obscures actual operational issues and inflates log storage costs without providing actionable insights, as the system is behaving as intended. Moving this to **Debug** keeps the information available for protocol troubleshooting without impacting production log readability.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
The risk is minimal. Developers who specifically monitor **Warn** logs to identify incomplete `gRPC` requests from custom clients will now need to enable **Debug** logging to see this specific entry. However, since the server's default behavior is functional and intended, this change does not impact system stability or data integrity.
