### PR TITLE
Fix throttled logger to not throttle panics and fatals

### DIFF
--- a/common/log/throttle_logger.go
+++ b/common/log/throttle_logger.go
@@ -5,6 +5,7 @@ import (
 	"go.temporal.io/server/common/quotas"
 )
 
+// extraSkipForThrottleLogger is the number of extra stack trace frames to skip when SkipLogger is used
 const extraSkipForThrottleLogger = 3
 
 type throttledLogger struct {
@@ -18,7 +19,7 @@ var _ Logger = (*throttledLogger)(nil)
 // log messages being emitted. The underlying implementation uses a token bucket
 // rate limiter and stops emitting logs once the bucket runs out of tokens
 //
-// Fatal/Panic logs are always emitted without any throttling
+// Fatal/Panic/DPanic logs are always emitted without any throttling
 func NewThrottledLogger(logger Logger, rps quotas.RateFn) *throttledLogger {
 	if sl, ok := logger.(SkipLogger); ok {
 		logger = sl.Skip(extraSkipForThrottleLogger)
@@ -57,15 +58,25 @@ func (tl *throttledLogger) Error(msg string, tags ...tag.Tag) {
 }
 
 func (tl *throttledLogger) DPanic(msg string, tags ...tag.Tag) {
-	tl.logger.DPanic(msg, tags...)
+	// DPanic logs are always emitted without any throttling. Call bypassRateLimit
+	// to maintain the same number of stack trace frames (see extraSkipForThrottleLogger)
+	tl.bypassRateLimit(func() {
+		tl.logger.DPanic(msg, tags...)
+	})
 }
 
 func (tl *throttledLogger) Panic(msg string, tags ...tag.Tag) {
-	tl.logger.Panic(msg, tags...)
+	// Panic logs are always emitted without any throttling
+	tl.bypassRateLimit(func() {
+		tl.logger.Panic(msg, tags...)
+	})
 }
 
 func (tl *throttledLogger) Fatal(msg string, tags ...tag.Tag) {
-	tl.logger.Fatal(msg, tags...)
+	// Fatal logs are always emitted without any throttling
+	tl.bypassRateLimit(func() {
+		tl.logger.Fatal(msg, tags...)
+	})
 }
 
 // Return a logger with the specified key-value pairs set, to be included in a subsequent normal logging call
@@ -78,7 +89,13 @@ func (tl *throttledLogger) With(tags ...tag.Tag) Logger {
 }
 
 func (tl *throttledLogger) rateLimit(f func()) {
-	if ok := tl.limiter.Allow(); ok {
+	if tl.limiter.Allow() {
 		f()
 	}
+}
+
+// bypassRateLimit bypasses the rate limit and calls the function directly. It exists to maintain the same
+// number of stack trace frames as when rateLimit is called (see extraSkipForThrottleLogger)
+func (tl *throttledLogger) bypassRateLimit(f func()) {
+	f()
 }


### PR DESCRIPTION
## What changed?
Do not throttle panics and fatals in throttled logger

## Why?
The doc block for NewThrottledLogger already says:
```
// Fatal/Panic logs are always emitted without any throttling
```
but this is not respected in the code. Changed the code to match this.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

