### PR TITLE
Add dry-run mode for XDC system workflows

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3094,6 +3094,11 @@ WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 		false,
 		`WorkerEnableHistoryRateLimiter decides whether to generate migration tasks with history length rate limiter.`,
 	)
+	WorkerDryRunMode = NewGlobalBoolSetting(
+		"worker.dryRunMode",
+		false,
+		`WorkerDryRunMode causes XDC system workflows (force-replication, namespace-handover) to complete immediately without doing real work. Use for testing.`,
+	)
 	MaxUserMetadataSummarySize = NewNamespaceIntSetting(
 		"limit.userMetadataSummarySize",
 		400,

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -114,6 +114,7 @@ type (
 		namespaceReplicationQueue        persistence.NamespaceReplicationQueue
 		generateMigrationTaskViaFrontend dynamicconfig.BoolPropertyFn
 		enableHistoryRateLimiter         dynamicconfig.BoolPropertyFn
+		dryRunMode                       dynamicconfig.BoolPropertyFn
 		workflowVerifier                 WorkflowVerifier
 		chasmRegistry                    *chasm.Registry
 	}
@@ -151,6 +152,11 @@ func (r verifyResult) isVerified() bool {
 // Using a different task queue and a dedicated worker for migration can solve the issue but requires
 // changing all existing tooling around namespace migration to start workflows & activities on the new task queue.
 // Another approach is to use separate workers for workflow tasks and activities and keep existing tooling unchanged.
+
+// IsDryRunMode returns whether the cell is in dry-run mode.
+func (a *activities) IsDryRunMode(_ context.Context) (bool, error) {
+	return a.dryRunMode(), nil
+}
 
 // GetMetadata returns history shard count and namespaceID for requested namespace.
 func (a *activities) GetMetadata(_ context.Context, request metadataRequest) (*metadataResponse, error) {

--- a/service/worker/migration/force_replication_workflow.go
+++ b/service/worker/migration/force_replication_workflow.go
@@ -134,6 +134,10 @@ func ForceReplicationWorkflow(ctx workflow.Context, params ForceReplicationParam
 		}, nil
 	})
 
+	if dryRun, _ := isDryRunMode(ctx); dryRun {
+		return nil
+	}
+
 	if err := validateAndSetForceReplicationParams(ctx, &params); err != nil {
 		return err
 	}
@@ -216,6 +220,10 @@ func ForceReplicationWorkflowV2(ctx workflow.Context, params ForceReplicationPar
 			PageTokenForRestart:                startPageToken,
 		}, nil
 	})
+
+	if dryRun, _ := isDryRunMode(ctx); dryRun {
+		return nil
+	}
 
 	if err := validateAndSetForceReplicationParams(ctx, &params); err != nil {
 		return err
@@ -335,6 +343,18 @@ func ForceTaskQueueUserDataReplicationWorkflow(ctx workflow.Context, params Task
 	}
 	err = workflow.SignalExternalWorkflow(ctx, workflow.GetInfo(ctx).ParentWorkflowExecution.ID, "", taskQueueUserDataReplicationDoneSignalType, errStr).Get(ctx, nil)
 	return err
+}
+
+func isDryRunMode(ctx workflow.Context) (bool, error) {
+	lao := workflow.LocalActivityOptions{
+		StartToCloseTimeout: 5 * time.Second,
+	}
+	var a *activities
+	var dryRun bool
+	err := workflow.ExecuteLocalActivity(
+		workflow.WithLocalActivityOptions(ctx, lao), a.IsDryRunMode,
+	).Get(ctx, &dryRun)
+	return dryRun, err
 }
 
 func validateAndSetForceReplicationParams(ctx workflow.Context, params *ForceReplicationParams) error {

--- a/service/worker/migration/fx.go
+++ b/service/worker/migration/fx.go
@@ -124,6 +124,7 @@ func (wc *replicationWorkerComponent) activities() *activities {
 		forceReplicationMetricsHandler:   wc.MetricsHandler.WithTags(metrics.WorkflowTypeTag(forceReplicationWorkflowName)),
 		generateMigrationTaskViaFrontend: dynamicconfig.WorkerGenerateMigrationTaskViaFrontend.Get(wc.DynamicCollection),
 		enableHistoryRateLimiter:         dynamicconfig.WorkerEnableHistoryRateLimiter.Get(wc.DynamicCollection),
+		dryRunMode:                       dynamicconfig.WorkerDryRunMode.Get(wc.DynamicCollection),
 		workflowVerifier:                 wc.WorkflowVerifier,
 		chasmRegistry:                    wc.ChasmRegistry,
 	}

--- a/service/worker/migration/handover_workflow.go
+++ b/service/worker/migration/handover_workflow.go
@@ -75,6 +75,11 @@ func NamespaceHandoverWorkflow(ctx workflow.Context, params NamespaceHandoverPar
 	if err := validateAndSetNamespaceHandoverParams(&params); err != nil {
 		return err
 	}
+
+	if dryRun, _ := isDryRunMode(ctx); dryRun {
+		return nil
+	}
+
 	retryPolicy := &temporal.RetryPolicy{
 		InitialInterval:    time.Second,
 		MaximumInterval:    time.Second,


### PR DESCRIPTION
## Summary
- Adds a `worker.dryRunMode` dynamic config flag that, when enabled on a cell, causes XDC system workflows (force-replication, namespace-handover) to complete immediately without doing real work
- This enables testing control plane globalization/failover/deglobalization code paths end-to-end without the time complexity of actually running force replication (which can take hours)

## Motivation
The control plane CICD MultiRegionSuite tests invoke real temporal server system workflows (force-replication, handover) on test cells. Force replication lists, replicates, and verifies all workflows between cells, taking hours.

The tradeoff with alternative approaches (e.g., mocking the data-plane client interface in the control plane) is that mock interfaces don't stay up to date as the server evolves. With this approach, all control plane code paths execute against a real temporal server with real gRPC serialization — the server just returns immediately from XDC workflows when dry-run mode is enabled.

## Changes
- `common/dynamicconfig/constants.go`: New `WorkerDryRunMode` global bool setting (default `false`)
- `service/worker/migration/activities.go`: `dryRunMode` field on activities struct + `IsDryRunMode` local activity
- `service/worker/migration/fx.go`: Wire `WorkerDryRunMode` into activities
- `service/worker/migration/force_replication_workflow.go`: `isDryRunMode` helper + skip checks in V1 and V2 (after query handler setup)
- `service/worker/migration/handover_workflow.go`: Skip check after param validation (V2 delegates to V1, so covered)

## Enabling on a cell
```bash
# Via dynamic config
{"worker.dryRunMode": [{"value": true}]}
```

## Test plan
- [x] `go test -tags test_dep ./service/worker/migration/...` passes
- [x] `go build ./...` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)