### PR TITLE
Refactor worker registry to use WorkerMetricsConfig struct

### DIFF
--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -199,12 +199,14 @@ func WorkersRegistryProvider(
 	serviceConfig *Config,
 ) workers.Registry {
 	return workers.NewRegistry(lc, workers.RegistryParams{
-		NumBuckets:          serviceConfig.WorkerRegistryNumBuckets,
-		TTL:                 serviceConfig.WorkerRegistryEntryTTL,
-		MinEvictAge:         serviceConfig.WorkerRegistryMinEvictAge,
-		MaxItems:            serviceConfig.WorkerRegistryMaxEntries,
-		EvictionInterval:    serviceConfig.WorkerRegistryEvictionInterval,
-		MetricsHandler:      metricsHandler,
-		EnablePluginMetrics: serviceConfig.EnableWorkerPluginMetrics,
+		NumBuckets:       serviceConfig.WorkerRegistryNumBuckets,
+		TTL:              serviceConfig.WorkerRegistryEntryTTL,
+		MinEvictAge:      serviceConfig.WorkerRegistryMinEvictAge,
+		MaxItems:         serviceConfig.WorkerRegistryMaxEntries,
+		EvictionInterval: serviceConfig.WorkerRegistryEvictionInterval,
+		MetricsHandler:   metricsHandler,
+		MetricsConfig: workers.WorkerMetricsConfig{
+			EnablePluginMetrics: serviceConfig.EnableWorkerPluginMetrics,
+		},
 	})
 }

--- a/service/matching/workers/registry_impl.go
+++ b/service/matching/workers/registry_impl.go
@@ -46,27 +46,27 @@ type (
 	// It partitions the keyspace into buckets and enforces TTL and capacity.
 	// Eviction runs in the background.
 	registryImpl struct {
-		buckets                   []*bucket                        // buckets for partitioning the keyspace
-		maxItemsFn                dynamicconfig.IntPropertyFn      // dynamic config for maximum entries
-		ttlFn                     dynamicconfig.DurationPropertyFn // dynamic config for entry TTL
-		minEvictAgeFn             dynamicconfig.DurationPropertyFn // dynamic config for minimum evict age
-		evictionIntervalFn        dynamicconfig.DurationPropertyFn // dynamic config for eviction interval
-		total                     atomic.Int64                     // atomic counter of total entries
-		quit                      chan struct{}                    // channel to signal shutdown of the eviction loop
-		seed                      maphash.Seed                     // seed for the hasher, used to ensure consistent hashing
-		metricsHandler            metrics.Handler                  // metrics handler for recording registry metrics
-		enableWorkerPluginMetrics dynamicconfig.BoolPropertyFn     // dynamic config function to control plugin metrics export
+		buckets            []*bucket                        // buckets for partitioning the keyspace
+		maxItemsFn         dynamicconfig.IntPropertyFn      // dynamic config for maximum entries
+		ttlFn              dynamicconfig.DurationPropertyFn // dynamic config for entry TTL
+		minEvictAgeFn      dynamicconfig.DurationPropertyFn // dynamic config for minimum evict age
+		evictionIntervalFn dynamicconfig.DurationPropertyFn // dynamic config for eviction interval
+		total              atomic.Int64                     // atomic counter of total entries
+		quit               chan struct{}                    // channel to signal shutdown of the eviction loop
+		seed               maphash.Seed                     // seed for the hasher, used to ensure consistent hashing
+		metricsHandler     metrics.Handler                  // metrics handler for recording registry metrics
+		metricsEmitter     *workerMetricsEmitter            // emitter for heartbeat-derived metrics
 	}
 
 	// RegistryParams contains all parameters for creating a worker registry.
 	RegistryParams struct {
-		NumBuckets          dynamicconfig.IntPropertyFn
-		TTL                 dynamicconfig.DurationPropertyFn
-		MinEvictAge         dynamicconfig.DurationPropertyFn
-		MaxItems            dynamicconfig.IntPropertyFn
-		EvictionInterval    dynamicconfig.DurationPropertyFn
-		MetricsHandler      metrics.Handler
-		EnablePluginMetrics dynamicconfig.BoolPropertyFn
+		NumBuckets       dynamicconfig.IntPropertyFn
+		TTL              dynamicconfig.DurationPropertyFn
+		MinEvictAge      dynamicconfig.DurationPropertyFn
+		MaxItems         dynamicconfig.IntPropertyFn
+		EvictionInterval dynamicconfig.DurationPropertyFn
+		MetricsHandler   metrics.Handler
+		MetricsConfig    WorkerMetricsConfig
 	}
 )
 
@@ -213,15 +213,18 @@ func NewRegistry(lc fx.Lifecycle, params RegistryParams) Registry {
 
 func newRegistryImpl(params RegistryParams) *registryImpl {
 	m := &registryImpl{
-		buckets:                   make([]*bucket, params.NumBuckets()),
-		maxItemsFn:                params.MaxItems,
-		ttlFn:                     params.TTL,
-		minEvictAgeFn:             params.MinEvictAge,
-		evictionIntervalFn:        params.EvictionInterval,
-		seed:                      maphash.MakeSeed(),
-		quit:                      make(chan struct{}),
-		metricsHandler:            params.MetricsHandler,
-		enableWorkerPluginMetrics: params.EnablePluginMetrics,
+		buckets:            make([]*bucket, params.NumBuckets()),
+		maxItemsFn:         params.MaxItems,
+		ttlFn:              params.TTL,
+		minEvictAgeFn:      params.MinEvictAge,
+		evictionIntervalFn: params.EvictionInterval,
+		seed:               maphash.MakeSeed(),
+		quit:               make(chan struct{}),
+		metricsHandler:     params.MetricsHandler,
+		metricsEmitter: &workerMetricsEmitter{
+			handler: params.MetricsHandler,
+			config:  params.MetricsConfig,
+		},
 	}
 
 	for i := range m.buckets {
@@ -273,33 +276,6 @@ func (m *registryImpl) recordEvictionMetric() {
 	} else {
 		// Back under capacity - clear the issue
 		metrics.WorkerRegistryEvictionBlockedByAgeMetric.With(m.metricsHandler).Record(0)
-	}
-}
-
-// recordPluginMetric sets a value of 1 for each unique plugin name present in the heartbeats.
-func (m *registryImpl) recordPluginMetric(nsName namespace.Name, heartbeats []*workerpb.WorkerHeartbeat) {
-	// Check if plugin metrics are enabled via dynamic config
-	if !m.enableWorkerPluginMetrics() {
-		return
-	}
-
-	// Track which plugins we've already recorded
-	recordedPlugins := make(map[string]bool)
-
-	for _, hb := range heartbeats {
-		for _, pluginInfo := range hb.Plugins {
-			pluginName := pluginInfo.Name
-			if !recordedPlugins[pluginName] {
-				metrics.WorkerPluginNameMetric.
-					With(m.metricsHandler).
-					Record(
-						1,
-						metrics.NamespaceIDTag(nsName.String()),
-						metrics.WorkerPluginNameTag(pluginName),
-					)
-				recordedPlugins[pluginName] = true
-			}
-		}
 	}
 }
 
@@ -388,17 +364,7 @@ func (m *registryImpl) Stop() {
 
 func (m *registryImpl) RecordWorkerHeartbeats(nsID namespace.ID, nsName namespace.Name, workerHeartbeat []*workerpb.WorkerHeartbeat) {
 	m.upsertHeartbeats(nsID, workerHeartbeat)
-	m.recordPluginMetric(nsName, workerHeartbeat)
-	m.recordActivitySlotsMetric(workerHeartbeat)
-}
-
-// recordActivitySlotsMetric records the distribution of activity slots in use across workers.
-func (m *registryImpl) recordActivitySlotsMetric(heartbeats []*workerpb.WorkerHeartbeat) {
-	for _, hb := range heartbeats {
-		if hb.ActivityTaskSlotsInfo != nil {
-			metrics.WorkerRegistryActivitySlotsUsed.With(m.metricsHandler).Record(int64(hb.ActivityTaskSlotsInfo.CurrentUsedSlots))
-		}
-	}
+	m.metricsEmitter.emit(nsName, workerHeartbeat)
 }
 
 func (m *registryImpl) ListWorkers(nsID namespace.ID, params ListWorkersParams) (ListWorkersResponse, error) {

--- a/service/matching/workers/registry_impl_test.go
+++ b/service/matching/workers/registry_impl_test.go
@@ -27,13 +27,15 @@ func TestUpdateAndListNamespace(t *testing.T) {
 	defer captureHandler.StopCapture(capture)
 
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(2),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(0),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(10),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      captureHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(2),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(0),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(10),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   captureHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 
@@ -74,13 +76,15 @@ func TestShutdownStatusRemovesWorker(t *testing.T) {
 	defer captureHandler.StopCapture(capture)
 
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(1),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(0),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(10),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      captureHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(1),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(0),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(10),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   captureHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 
@@ -120,13 +124,15 @@ func TestShutdownStatusRemovesWorker(t *testing.T) {
 
 func TestShutdownStatusForNonExistentWorker(t *testing.T) {
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(1),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(0),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(10),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      metrics.NoopMetricsHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(1),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(0),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(10),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   metrics.NoopMetricsHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 
@@ -142,13 +148,15 @@ func TestShutdownStatusForNonExistentWorker(t *testing.T) {
 
 func TestListNamespacePredicate(t *testing.T) {
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(1),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(0),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(10),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      metrics.NoopMetricsHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(1),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(0),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(10),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   metrics.NoopMetricsHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 
@@ -185,13 +193,15 @@ func TestEvictByTTL(t *testing.T) {
 	defer captureHandler.StopCapture(capture)
 
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(1),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(1 * time.Second),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(0),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(10),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      captureHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(1),
+		TTL:              dynamicconfig.GetDurationPropertyFn(1 * time.Second),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(0),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(10),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   captureHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 
@@ -228,13 +238,15 @@ func TestEvictByCapacity(t *testing.T) {
 	defer captureHandler.StopCapture(capture)
 
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(1),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(0),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(maxItems),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      captureHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(1),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(0),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(maxItems),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   captureHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 
@@ -284,13 +296,15 @@ func TestEvictByCapacityWithMinAgeProtection(t *testing.T) {
 	defer captureHandler.StopCapture(capture)
 
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(1),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(minEvictAge),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(maxItems),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      captureHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(1),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(minEvictAge),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(maxItems),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   captureHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 
@@ -334,13 +348,15 @@ func TestEvictByCapacityAfterMinAge(t *testing.T) {
 
 		// Uses real time.NewTicker - synctest provides virtual time control
 		m := newRegistryImpl(RegistryParams{
-			NumBuckets:          dynamicconfig.GetIntPropertyFn(1),
-			TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-			MinEvictAge:         dynamicconfig.GetDurationPropertyFn(minEvictAge),
-			MaxItems:            dynamicconfig.GetIntPropertyFn(maxItems),
-			EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-			MetricsHandler:      captureHandler,
-			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+			NumBuckets:       dynamicconfig.GetIntPropertyFn(1),
+			TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+			MinEvictAge:      dynamicconfig.GetDurationPropertyFn(minEvictAge),
+			MaxItems:         dynamicconfig.GetIntPropertyFn(maxItems),
+			EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+			MetricsHandler:   captureHandler,
+			MetricsConfig: WorkerMetricsConfig{
+				EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+			},
 		})
 		defer m.Stop()
 
@@ -380,13 +396,15 @@ func TestMultipleNamespaces(t *testing.T) {
 	defer captureHandler.StopCapture(capture)
 
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(2),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(0),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(maxItems),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      captureHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(2),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(0),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(maxItems),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   captureHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 
@@ -446,13 +464,15 @@ func TestEvictLoopRecordsUtilizationMetric(t *testing.T) {
 		defer captureHandler.StopCapture(capture)
 
 		m := newRegistryImpl(RegistryParams{
-			NumBuckets:          dynamicconfig.GetIntPropertyFn(1),
-			TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-			MinEvictAge:         dynamicconfig.GetDurationPropertyFn(0),
-			MaxItems:            dynamicconfig.GetIntPropertyFn(maxItems),
-			EvictionInterval:    dynamicconfig.GetDurationPropertyFn(evictionInterval),
-			MetricsHandler:      captureHandler,
-			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+			NumBuckets:       dynamicconfig.GetIntPropertyFn(1),
+			TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+			MinEvictAge:      dynamicconfig.GetDurationPropertyFn(0),
+			MaxItems:         dynamicconfig.GetIntPropertyFn(maxItems),
+			EvictionInterval: dynamicconfig.GetDurationPropertyFn(evictionInterval),
+			MetricsHandler:   captureHandler,
+			MetricsConfig: WorkerMetricsConfig{
+				EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+			},
 		})
 
 		// Add some entries to create utilization
@@ -489,13 +509,15 @@ func TestEvictLoopRecordsUtilizationMetric(t *testing.T) {
 
 func BenchmarkUpdate(b *testing.B) {
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(16),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(time.Minute),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(b.N),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      metrics.NoopMetricsHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(16),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(time.Minute),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(b.N),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   metrics.NoopMetricsHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 	hb := &workerpb.WorkerHeartbeat{WorkerInstanceKey: "benchWorker"}
@@ -507,13 +529,15 @@ func BenchmarkUpdate(b *testing.B) {
 
 func BenchmarkListNamespace(b *testing.B) {
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(16),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(time.Minute),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(1000),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      metrics.NoopMetricsHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(16),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(time.Minute),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(1000),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   metrics.NoopMetricsHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 	// Pre-populate with entries
@@ -533,13 +557,15 @@ func BenchmarkRandomUpdate(b *testing.B) {
 	namespaces := []namespace.ID{"ns1", "ns2", "ns3"}
 	totalHeartbeats := 30 // Total heartbeats per namespace
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(len(namespaces)),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(time.Minute),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(b.N),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      metrics.NoopMetricsHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(len(namespaces)),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(time.Minute),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(b.N),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   metrics.NoopMetricsHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 
@@ -576,13 +602,15 @@ func TestActivitySlotsMetric(t *testing.T) {
 	defer captureHandler.StopCapture(capture)
 
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(1),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(0),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(10),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      captureHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(1),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(0),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(10),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   captureHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 
@@ -643,13 +671,15 @@ func TestPluginMetricsExported(t *testing.T) {
 	defer captureHandler.StopCapture(capture)
 
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(2),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(0),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(10),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      captureHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(2),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(0),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(10),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   captureHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 	defer m.Stop()
 
@@ -721,13 +751,15 @@ func TestPluginMetricsDisabled(t *testing.T) {
 	defer captureHandler.StopCapture(capture)
 
 	m := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(2),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(0),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(10),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(time.Hour),
-		MetricsHandler:      captureHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(false),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(2),
+		TTL:              dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(0),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(10),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(time.Hour),
+		MetricsHandler:   captureHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(false),
+		},
 	})
 	defer m.Stop()
 

--- a/service/matching/workers/registry_test.go
+++ b/service/matching/workers/registry_test.go
@@ -79,13 +79,15 @@ func TestRegistryImpl_RecordWorkerHeartbeat(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newRegistryImpl(RegistryParams{
-				NumBuckets:          dynamicconfig.GetIntPropertyFn(10),
-				TTL:                 dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-				MinEvictAge:         dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-				MaxItems:            dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-				EvictionInterval:    dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-				MetricsHandler:      metrics.NoopMetricsHandler,
-				EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+				NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
+				TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
+				MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
+				MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
+				EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
+				MetricsHandler:   metrics.NoopMetricsHandler,
+				MetricsConfig: WorkerMetricsConfig{
+					EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+				},
 			})
 			tt.setup(r)
 
@@ -183,13 +185,15 @@ func TestRegistryImpl_ListWorkers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newRegistryImpl(RegistryParams{
-				NumBuckets:          dynamicconfig.GetIntPropertyFn(10),
-				TTL:                 dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-				MinEvictAge:         dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-				MaxItems:            dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-				EvictionInterval:    dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-				MetricsHandler:      metrics.NoopMetricsHandler,
-				EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+				NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
+				TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
+				MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
+				MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
+				EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
+				MetricsHandler:   metrics.NoopMetricsHandler,
+				MetricsConfig: WorkerMetricsConfig{
+					EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+				},
 			})
 			tt.setup(r)
 
@@ -313,13 +317,15 @@ func TestRegistryImpl_ListWorkersWithQuery(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newRegistryImpl(RegistryParams{
-				NumBuckets:          dynamicconfig.GetIntPropertyFn(10),
-				TTL:                 dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-				MinEvictAge:         dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-				MaxItems:            dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-				EvictionInterval:    dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-				MetricsHandler:      metrics.NoopMetricsHandler,
-				EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+				NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
+				TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
+				MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
+				MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
+				EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
+				MetricsHandler:   metrics.NoopMetricsHandler,
+				MetricsConfig: WorkerMetricsConfig{
+					EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+				},
 			})
 			tt.setup(r)
 
@@ -423,13 +429,15 @@ func TestRegistryImpl_DescribeWorker(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newRegistryImpl(RegistryParams{
-				NumBuckets:          dynamicconfig.GetIntPropertyFn(10),
-				TTL:                 dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-				MinEvictAge:         dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-				MaxItems:            dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-				EvictionInterval:    dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-				MetricsHandler:      metrics.NoopMetricsHandler,
-				EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+				NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
+				TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
+				MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
+				MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
+				EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
+				MetricsHandler:   metrics.NoopMetricsHandler,
+				MetricsConfig: WorkerMetricsConfig{
+					EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+				},
 			})
 			tt.setup(r)
 
@@ -448,13 +456,15 @@ func TestRegistryImpl_DescribeWorker(t *testing.T) {
 
 func TestRegistryImpl_ListWorkersPagination(t *testing.T) {
 	r := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(10),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-		MetricsHandler:      metrics.NoopMetricsHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
+		TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
+		MetricsHandler:   metrics.NoopMetricsHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 
 	// Add 5 workers in non-sorted order to verify sorting works
@@ -552,13 +562,15 @@ func TestRegistryImpl_ListWorkersPaginationWithDeletedCursor(t *testing.T) {
 
 func TestRegistryImpl_ListWorkersNoPagination(t *testing.T) {
 	r := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(10),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-		MetricsHandler:      metrics.NoopMetricsHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
+		TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
+		MetricsHandler:   metrics.NoopMetricsHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 
 	r.upsertHeartbeats("ns1", []*workerpb.WorkerHeartbeat{
@@ -576,13 +588,15 @@ func TestRegistryImpl_ListWorkersNoPagination(t *testing.T) {
 
 func TestRegistryImpl_ListWorkersInvalidPageToken(t *testing.T) {
 	r := newRegistryImpl(RegistryParams{
-		NumBuckets:          dynamicconfig.GetIntPropertyFn(10),
-		TTL:                 dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-		MinEvictAge:         dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-		MaxItems:            dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-		EvictionInterval:    dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-		MetricsHandler:      metrics.NoopMetricsHandler,
-		EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
+		TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
+		MetricsHandler:   metrics.NoopMetricsHandler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
+		},
 	})
 
 	r.upsertHeartbeats("ns1", []*workerpb.WorkerHeartbeat{

--- a/service/matching/workers/worker_metrics_emitter.go
+++ b/service/matching/workers/worker_metrics_emitter.go
@@ -1,0 +1,45 @@
+package workers
+
+import (
+	workerpb "go.temporal.io/api/worker/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+)
+
+// WorkerMetricsConfig contains dynamic config flags for worker-related metrics.
+type WorkerMetricsConfig struct {
+	EnablePluginMetrics dynamicconfig.BoolPropertyFn
+}
+
+// workerMetricsEmitter encapsulates logic for emitting metrics derived from worker heartbeats.
+type workerMetricsEmitter struct {
+	handler metrics.Handler
+	config  WorkerMetricsConfig
+}
+
+func (e *workerMetricsEmitter) emit(nsName namespace.Name, heartbeats []*workerpb.WorkerHeartbeat) {
+	enablePluginMetrics := e.config.EnablePluginMetrics != nil && e.config.EnablePluginMetrics()
+
+	recordedPlugins := make(map[string]bool)
+
+	for _, hb := range heartbeats {
+		// Activity slots metric (always enabled)
+		if hb.ActivityTaskSlotsInfo != nil {
+			metrics.WorkerRegistryActivitySlotsUsed.With(e.handler).Record(int64(hb.ActivityTaskSlotsInfo.CurrentUsedSlots))
+		}
+
+		// Plugin metrics (if enabled)
+		if enablePluginMetrics {
+			for _, pluginInfo := range hb.Plugins {
+				pluginName := pluginInfo.Name
+				if !recordedPlugins[pluginName] {
+					metrics.WorkerPluginNameMetric.
+						With(e.handler).
+						Record(1, metrics.NamespaceIDTag(nsName.String()), metrics.WorkerPluginNameTag(pluginName))
+					recordedPlugins[pluginName] = true
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What changed?
- Introduces `WorkerMetricsConfig` struct to encapsulate metric enable flags
- Extracts heartbeat metrics logic into `workerMetricsEmitter` in a separate file
- Consolidates metric recording into a single `emit()` method

## Why?
Makes it easier to add new heartbeat-derived metrics without changing `RegistryParams`. The `workerMetricsEmitter` abstraction provides better separation of concerns between registry logic and metrics emission.

## How did you test it?
- [x] built
- [x] covered by existing tests

## Potential risks
None - pure refactoring with no behavioral changes.