### PR TITLE
Fix flakereport

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -354,12 +354,19 @@ jobs:
           flags: unit-test
           report_type: test_results
 
+      - name: Get job ID
+        id: get_job_id
+        uses: ./.github/actions/get-job-id
+        with:
+          job_name: Unit test
+          run_id: ${{ github.run_id }}
+
       - name: Upload test results to GitHub
         # Can't pin to major because the action linter doesn't recognize the include-hidden-files flag.
         uses: actions/upload-artifact@v4.4.3
         if: ${{ !cancelled() }}
         with:
-          name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--unit-test
+          name: junit-xml--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--unit-test
           path: ./.testoutput/junit.*.xml
           include-hidden-files: true
           retention-days: 28
@@ -447,12 +454,19 @@ jobs:
           flags: integration-test
           report_type: test_results
 
+      - name: Get job ID
+        id: get_job_id
+        uses: ./.github/actions/get-job-id
+        with:
+          job_name: Integration test
+          run_id: ${{ github.run_id }}
+
       - name: Upload test results to GitHub
         # Can't pin to major because the action linter doesn't recognize the include-hidden-files flag.
         uses: actions/upload-artifact@v4.4.3
         if: ${{ !cancelled() }}
         with:
-          name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--integration-test
+          name: junit-xml--${{ github.run_id }}--${{ steps.get_job_id.outputs.job_id }}--${{ github.run_attempt }}--integration-test
           path: ./.testoutput/junit.*.xml
           include-hidden-files: true
           retention-days: 28

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dustin/go-humanize v1.0.1
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect

--- a/tools/flakereport/flakereport.go
+++ b/tools/flakereport/flakereport.go
@@ -259,8 +259,9 @@ func runGenerateCommand(c *cli.Context) (err error) {
 	// Count test runs by name for failure rate calculation
 	testRunCounts := countTestRuns(allTestRuns)
 
-	// Group failures by test name
+	// Group failures by test name, then remove parent entries whose subtests were observed.
 	grouped := groupFailuresByTest(allFailures)
+	filterParentTests(grouped, testRunCounts)
 	fmt.Printf("Unique tests with failures: %d\n", len(grouped))
 
 	// Classify failures

--- a/tools/flakereport/github.go
+++ b/tools/flakereport/github.go
@@ -191,20 +191,33 @@ func extractArtifactZip(zipPath, outputDir string) ([]string, error) {
 	return xmlFiles, nil
 }
 
-// parseArtifactName extracts run_id and job_id from artifact name
-// Format: {prefix}--{run_id}--{job_id}--{suffix}
-// Returns: runID, jobID (or "unknown" if not parseable)
-func parseArtifactName(artifactName string) (runID string, jobID string) {
+// parseArtifactName extracts run_id, job_id, and matrix_name from artifact name.
+// Functional tests: junit-xml--{run_id}--{job_id}--{run_attempt}--{matrix_name}--{display_name}--functional-test
+// Unit/integration:  junit-xml--{run_id}--{job_id}--{run_attempt}--unit-test
+// Returns: runID, jobID, matrixName ("unknown" for fields that are absent or unparseable)
+func parseArtifactName(artifactName string) (runID string, jobID string, matrixName string) {
 	parts := strings.Split(artifactName, "--")
-	if len(parts) >= 3 {
-		runID = parts[1]
-		jobID = parts[2]
-		if jobID == "" {
-			jobID = "unknown"
-		}
-		return runID, jobID
+	if len(parts) < 3 {
+		return "unknown", "unknown", "unknown"
 	}
-	return "unknown", "unknown"
+
+	runID = parts[1]
+
+	jobID = parts[2]
+	if jobID == "" {
+		jobID = "unknown"
+	}
+
+	// Functional test artifacts carry a matrix name (DB config) at parts[4].
+	// Unit/integration artifacts have only 5 parts where parts[4] is the test type
+	// (e.g. "unit-test"), not a matrix name. Functional artifacts have >=7 parts.
+	if len(parts) >= 6 {
+		matrixName = parts[4]
+	} else {
+		matrixName = "unknown"
+	}
+
+	return runID, jobID, matrixName
 }
 
 // buildGitHubURL constructs GitHub Actions URL from run/job IDs

--- a/tools/flakereport/parallel.go
+++ b/tools/flakereport/parallel.go
@@ -135,7 +135,8 @@ func processArtifactJob(ctx context.Context, job ArtifactJob, totalArtifacts int
 		result.Failures = append(result.Failures, failures...)
 
 		// Extract all test runs for failure rate calculation
-		testRuns := extractAllTestRuns(suites, job.RunID)
+		_, jobID, matrixName := parseArtifactName(job.Artifact.Name)
+		testRuns := extractAllTestRuns(suites, job.RunID, jobID, matrixName)
 		result.AllRuns = append(result.AllRuns, testRuns...)
 	}
 

--- a/tools/flakereport/parser.go
+++ b/tools/flakereport/parser.go
@@ -68,8 +68,8 @@ func isGoTestSuite(name string) bool {
 func extractFailures(suites *junit.Testsuites, artifactName string, runID int64, timestamp time.Time) []TestFailure {
 	var failures []TestFailure
 
-	// Parse artifact name for run_id and job_id
-	_, jobID := parseArtifactName(artifactName)
+	// Parse artifact name for run_id, job_id, and matrix_name
+	_, jobID, matrixName := parseArtifactName(artifactName)
 
 	for _, suite := range suites.Suites {
 		for _, testcase := range suite.Testcases {
@@ -82,6 +82,7 @@ func extractFailures(suites *junit.Testsuites, artifactName string, runID int64,
 					ArtifactID: artifactName,
 					RunID:      runID,
 					JobID:      jobID,
+					MatrixName: matrixName,
 					Timestamp:  timestamp,
 				}
 				failures = append(failures, failure)
@@ -94,17 +95,19 @@ func extractFailures(suites *junit.Testsuites, artifactName string, runID int64,
 
 // extractAllTestRuns extracts all test runs (including successes) from parsed JUnit data
 // Used for calculating failure rates
-func extractAllTestRuns(suites *junit.Testsuites, runID int64) []TestRun {
+func extractAllTestRuns(suites *junit.Testsuites, runID int64, jobID, matrixName string) []TestRun {
 	var runs []TestRun
 
 	for _, suite := range suites.Suites {
 		for _, testcase := range suite.Testcases {
 			run := TestRun{
-				SuiteName: topLevelTestName(testcase.Name),
-				Name:      testcase.Name,
-				Failed:    testcase.Failure != nil,
-				Skipped:   testcase.Skipped != nil,
-				RunID:     runID,
+				SuiteName:  topLevelTestName(testcase.Name),
+				Name:       testcase.Name,
+				Failed:     testcase.Failure != nil,
+				Skipped:    testcase.Skipped != nil,
+				RunID:      runID,
+				JobID:      jobID,
+				MatrixName: matrixName,
 			}
 			runs = append(runs, run)
 		}
@@ -237,6 +240,25 @@ func convertToReports(grouped map[string][]TestFailure, testRunCounts map[string
 	return reports
 }
 
+// filterParentTests removes top-level test names from grouped when subtests of
+// that parent were observed in testRunCounts. A top-level failure whose subtests
+// ran in other CI jobs is already captured (with a correct denominator) in the
+// Flaky Suites section, so including it in the per-test table produces a
+// misleading 1/1 entry.
+func filterParentTests(grouped map[string][]TestFailure, testRunCounts map[string]int) {
+	suitePrefix := make(map[string]bool, len(testRunCounts))
+	for name := range testRunCounts {
+		if idx := strings.IndexByte(name, '/'); idx >= 0 {
+			suitePrefix[name[:idx]] = true
+		}
+	}
+	for testName := range grouped {
+		if !strings.Contains(testName, "/") && suitePrefix[testName] {
+			delete(grouped, testName)
+		}
+	}
+}
+
 // isFinalRetry returns true if the test name has the "(final)" suffix,
 // indicating the test runner exhausted all retries.
 func isFinalRetry(testName string) bool {
@@ -341,23 +363,35 @@ func identifyCIBreakers(failures []TestFailure) (map[string][]TestFailure, map[s
 	return ciBreakers, ciBreakCount
 }
 
+// suiteRunKey returns a string that uniquely identifies a single (CI run × DB config) pair.
+// Each workflow run may spawn multiple matrix jobs sharing the same RunID but with distinct
+// MatrixNames (DB configs). Keying by (RunID, MatrixName) ensures shards belonging to the
+// same run+config are counted once, regardless of how many shard JobIDs they produce.
+func suiteRunKey(runID int64, matrixName string) string {
+	return fmt.Sprintf("%d:%s", runID, matrixName)
+}
+
 // generateSuiteReports creates per-suite flake breakdown from all failures and test runs.
-// Suite flake rate = % of workflow runs where the suite had at least one non-retry failure.
+// Suite flake rate = % of (CI run × DB config) pairs where the suite had at least one
+// non-retry failure.
 func generateSuiteReports(allFailures []TestFailure, allTestRuns []TestRun) []SuiteReport {
-	// Track unique workflow runs per suite (denominator)
-	suiteRuns := make(map[string]map[int64]bool)
+	// Track unique (CI run × DB config) pairs per suite (denominator).
+	// Using MatrixName avoids the inflation caused by per-shard JobIDs: suites whose
+	// test methods are spread across N shards would otherwise be counted N times per
+	// (run × DB config).
+	suiteRuns := make(map[string]map[string]bool)
 	for _, run := range allTestRuns {
 		if run.Skipped || !isGoTestSuite(run.SuiteName) {
 			continue
 		}
 		if suiteRuns[run.SuiteName] == nil {
-			suiteRuns[run.SuiteName] = make(map[int64]bool)
+			suiteRuns[run.SuiteName] = make(map[string]bool)
 		}
-		suiteRuns[run.SuiteName][run.RunID] = true
+		suiteRuns[run.SuiteName][suiteRunKey(run.RunID, run.MatrixName)] = true
 	}
 
-	// Track workflow runs with non-retry failures per suite (numerator)
-	suiteFailedRuns := make(map[string]map[int64]bool)
+	// Track (CI run × DB config) pairs with non-retry failures per suite (numerator)
+	suiteFailedRuns := make(map[string]map[string]bool)
 	suiteLastFailure := make(map[string]time.Time)
 	for _, failure := range allFailures {
 		if !isGoTestSuite(failure.SuiteName) {
@@ -368,9 +402,9 @@ func generateSuiteReports(allFailures []TestFailure, allTestRuns []TestRun) []Su
 			continue
 		}
 		if suiteFailedRuns[failure.SuiteName] == nil {
-			suiteFailedRuns[failure.SuiteName] = make(map[int64]bool)
+			suiteFailedRuns[failure.SuiteName] = make(map[string]bool)
 		}
-		suiteFailedRuns[failure.SuiteName][failure.RunID] = true
+		suiteFailedRuns[failure.SuiteName][suiteRunKey(failure.RunID, failure.MatrixName)] = true
 		if failure.Timestamp.After(suiteLastFailure[failure.SuiteName]) {
 			suiteLastFailure[failure.SuiteName] = failure.Timestamp
 		}

--- a/tools/flakereport/parser_test.go
+++ b/tools/flakereport/parser_test.go
@@ -46,36 +46,55 @@ func TestNormalizeTestName(t *testing.T) {
 
 func TestParseArtifactName(t *testing.T) {
 	tests := []struct {
-		name          string
-		artifactName  string
-		expectedRunID string
-		expectedJobID string
+		name               string
+		artifactName       string
+		expectedRunID      string
+		expectedJobID      string
+		expectedMatrixName string
 	}{
 		{
-			name:          "valid artifact name",
-			artifactName:  "test-results--12345678--87654321--junit",
-			expectedRunID: "12345678",
-			expectedJobID: "87654321",
+			name:               "functional test artifact",
+			artifactName:       "junit-xml--22373551837--64609560060--1--integration-0--Integration--functional-test",
+			expectedRunID:      "22373551837",
+			expectedJobID:      "64609560060",
+			expectedMatrixName: "integration-0",
 		},
 		{
-			name:          "artifact name with empty job id",
-			artifactName:  "test-results--12345678----junit",
-			expectedRunID: "12345678",
-			expectedJobID: "unknown",
+			name:               "unit test artifact",
+			artifactName:       "junit-xml--22373551837--64609560061--1--unit-test",
+			expectedRunID:      "22373551837",
+			expectedJobID:      "64609560061",
+			expectedMatrixName: "unknown",
 		},
 		{
-			name:          "invalid artifact name",
-			artifactName:  "test-results",
-			expectedRunID: "unknown",
-			expectedJobID: "unknown",
+			name:               "integration test artifact",
+			artifactName:       "junit-xml--22373551837--64609560062--1--integration-test",
+			expectedRunID:      "22373551837",
+			expectedJobID:      "64609560062",
+			expectedMatrixName: "unknown",
+		},
+		{
+			name:               "artifact name with empty job id",
+			artifactName:       "junit-xml--22373551837----1--unit-test",
+			expectedRunID:      "22373551837",
+			expectedJobID:      "unknown",
+			expectedMatrixName: "unknown",
+		},
+		{
+			name:               "invalid artifact name",
+			artifactName:       "test-results",
+			expectedRunID:      "unknown",
+			expectedJobID:      "unknown",
+			expectedMatrixName: "unknown",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runID, jobID := parseArtifactName(tt.artifactName)
+			runID, jobID, matrixName := parseArtifactName(tt.artifactName)
 			assert.Equal(t, tt.expectedRunID, runID)
 			assert.Equal(t, tt.expectedJobID, jobID)
+			assert.Equal(t, tt.expectedMatrixName, matrixName)
 		})
 	}
 }
@@ -157,39 +176,84 @@ func TestClassifyFailures(t *testing.T) {
 	assert.Len(t, flaky["TestNormal"], 2)
 }
 
+func TestFilterParentTests(t *testing.T) {
+	makeFailures := func(names ...string) map[string][]TestFailure {
+		m := make(map[string][]TestFailure, len(names))
+		for _, n := range names {
+			m[n] = []TestFailure{{Name: n}}
+		}
+		return m
+	}
+
+	t.Run("removes parent when subtests observed", func(t *testing.T) {
+		grouped := makeFailures("TestFooSuite", "TestFooSuite/TestBar")
+		counts := map[string]int{
+			"TestFooSuite/TestBar": 10,
+			"TestFooSuite/TestBaz": 20,
+		}
+		filterParentTests(grouped, counts)
+		require.NotContains(t, grouped, "TestFooSuite")
+		require.Contains(t, grouped, "TestFooSuite/TestBar")
+	})
+
+	t.Run("keeps parent when no subtests observed", func(t *testing.T) {
+		grouped := makeFailures("TestStandalone")
+		counts := map[string]int{"TestStandalone": 5}
+		filterParentTests(grouped, counts)
+		require.Contains(t, grouped, "TestStandalone")
+	})
+
+	t.Run("keeps subtest entry regardless", func(t *testing.T) {
+		grouped := makeFailures("TestFooSuite/TestBar")
+		counts := map[string]int{"TestFooSuite/TestBar": 10}
+		filterParentTests(grouped, counts)
+		require.Contains(t, grouped, "TestFooSuite/TestBar")
+	})
+}
+
 func TestGenerateSuiteReports(t *testing.T) {
 	now := time.Now()
 	twoDaysAgo := now.Add(-48 * time.Hour)
 	oneDayAgo := now.Add(-24 * time.Hour)
 
+	// Each CI run has 2 DB configs ("db-a" and "db-b"), and within each config
+	// the suite is spread across 2 shards (distinct JobIDs). The denominator
+	// should count unique (RunID × MatrixName) pairs, not raw JobIDs, so shards
+	// within the same run+config collapse into one entry.
 	failures := []TestFailure{
-		// SuiteA: original failure in run 1
-		{Name: "TestFoo", SuiteName: "TestFunctionalSuiteA", RunID: 1, Timestamp: twoDaysAgo},
-		// SuiteA: retry failure in run 1 (should be excluded from suite flake rate)
-		{Name: "TestFoo (retry 1)", SuiteName: "TestFunctionalSuiteA", RunID: 1, Timestamp: twoDaysAgo},
-		// SuiteA: original failure in run 2
-		{Name: "TestBar", SuiteName: "TestFunctionalSuiteA", RunID: 2, Timestamp: oneDayAgo},
-		// SuiteB: original failure in run 1
-		{Name: "TestBaz", SuiteName: "TestFunctionalSuiteB", RunID: 1, Timestamp: twoDaysAgo},
+		// SuiteA: failure in run 1, db-a (shard job 101)
+		{Name: "TestFoo", SuiteName: "TestFunctionalSuiteA", RunID: 1, JobID: "101", MatrixName: "db-a", Timestamp: twoDaysAgo},
+		// SuiteA: retry failure — should be excluded from suite flake rate
+		{Name: "TestFoo (retry 1)", SuiteName: "TestFunctionalSuiteA", RunID: 1, JobID: "101", MatrixName: "db-a", Timestamp: twoDaysAgo},
+		// SuiteA: failure in run 2, db-b (shard job 204)
+		{Name: "TestBar", SuiteName: "TestFunctionalSuiteA", RunID: 2, JobID: "204", MatrixName: "db-b", Timestamp: oneDayAgo},
+		// SuiteB: failure in run 1, db-a
+		{Name: "TestBaz", SuiteName: "TestFunctionalSuiteB", RunID: 1, JobID: "101", MatrixName: "db-a", Timestamp: twoDaysAgo},
 	}
 
 	allRuns := []TestRun{
-		// SuiteA present in runs 1, 2, 3
-		{SuiteName: "TestFunctionalSuiteA", Name: "TestFoo", RunID: 1},
-		{SuiteName: "TestFunctionalSuiteA", Name: "TestFoo (retry 1)", RunID: 1},
-		{SuiteName: "TestFunctionalSuiteA", Name: "TestBar", RunID: 2},
-		{SuiteName: "TestFunctionalSuiteA", Name: "TestFoo", RunID: 3},
-		// SuiteB present in runs 1, 2
-		{SuiteName: "TestFunctionalSuiteB", Name: "TestBaz", RunID: 1},
-		{SuiteName: "TestFunctionalSuiteB", Name: "TestBaz", RunID: 2},
+		// SuiteA: runs 1–3, each with db-a (shards 101,102) and db-b (shards 103,104 / 203,204 / 303,304)
+		// → 3 runs × 2 DB configs = 6 unique (run, config) pairs
+		{SuiteName: "TestFunctionalSuiteA", Name: "TestFoo", RunID: 1, JobID: "101", MatrixName: "db-a"},
+		{SuiteName: "TestFunctionalSuiteA", Name: "TestFoo", RunID: 1, JobID: "102", MatrixName: "db-a"}, // same (run=1, db-a) pair
+		{SuiteName: "TestFunctionalSuiteA", Name: "TestFoo (retry 1)", RunID: 1, JobID: "101", MatrixName: "db-a"},
+		{SuiteName: "TestFunctionalSuiteA", Name: "TestFoo", RunID: 1, JobID: "103", MatrixName: "db-b"},
+		{SuiteName: "TestFunctionalSuiteA", Name: "TestFoo", RunID: 1, JobID: "104", MatrixName: "db-b"}, // same (run=1, db-b) pair
+		{SuiteName: "TestFunctionalSuiteA", Name: "TestBar", RunID: 2, JobID: "203", MatrixName: "db-a"},
+		{SuiteName: "TestFunctionalSuiteA", Name: "TestBar", RunID: 2, JobID: "204", MatrixName: "db-b"},
+		{SuiteName: "TestFunctionalSuiteA", Name: "TestFoo", RunID: 3, JobID: "301", MatrixName: "db-a"},
+		{SuiteName: "TestFunctionalSuiteA", Name: "TestFoo", RunID: 3, JobID: "303", MatrixName: "db-b"},
+		// SuiteB present in runs 1, 2, single DB config each
+		{SuiteName: "TestFunctionalSuiteB", Name: "TestBaz", RunID: 1, JobID: "101", MatrixName: "db-a"},
+		{SuiteName: "TestFunctionalSuiteB", Name: "TestBaz", RunID: 2, JobID: "203", MatrixName: "db-a"},
 		// Skipped test should not count
 		{SuiteName: "TestFunctionalSuiteC", Name: "TestSkipped", RunID: 1, Skipped: true},
 		// Non-suite names should be filtered out
 		{SuiteName: "DATA RACE", Name: "DATA RACE: detected", RunID: 1},
 		{SuiteName: "TestStandalone", Name: "TestStandalone", RunID: 1},
 		// Suite with no failures should be excluded
-		{SuiteName: "TestHealthySuite", Name: "TestOk", RunID: 1},
-		{SuiteName: "TestHealthySuite", Name: "TestOk", RunID: 2},
+		{SuiteName: "TestHealthySuite", Name: "TestOk", RunID: 1, MatrixName: "db-a"},
+		{SuiteName: "TestHealthySuite", Name: "TestOk", RunID: 2, MatrixName: "db-a"},
 	}
 
 	reports := generateSuiteReports(failures, allRuns)
@@ -201,13 +265,14 @@ func TestGenerateSuiteReports(t *testing.T) {
 	require.Equal(t, "TestFunctionalSuiteA", reports[0].SuiteName)
 	require.Equal(t, "TestFunctionalSuiteB", reports[1].SuiteName)
 
-	// SuiteA: 2 failed runs (run 1 and run 2) out of 3 total runs
+	// SuiteA: 2 failed (run,config) pairs out of 6 total
+	// Failed: (run=1, db-a) and (run=2, db-b); retry on (run=1, db-a) doesn't add a new key
 	require.Equal(t, 2, reports[0].FailedRuns)
-	require.Equal(t, 3, reports[0].TotalRuns)
-	require.InDelta(t, 66.7, reports[0].FlakeRate, 0.1)
+	require.Equal(t, 6, reports[0].TotalRuns)
+	require.InDelta(t, 33.3, reports[0].FlakeRate, 0.1)
 	require.Equal(t, oneDayAgo, reports[0].LastFailure)
 
-	// SuiteB: 1 failed run (run 1) out of 2 total runs
+	// SuiteB: 1 failed (run,config) pair out of 2 total
 	require.Equal(t, 1, reports[1].FailedRuns)
 	require.Equal(t, 2, reports[1].TotalRuns)
 	require.InDelta(t, 50.0, reports[1].FlakeRate, 0.1)

--- a/tools/flakereport/report.go
+++ b/tools/flakereport/report.go
@@ -2,10 +2,21 @@ package flakereport
 
 import (
 	"fmt"
+	"math"
 	"strings"
-
-	"github.com/dustin/go-humanize"
+	"time"
 )
+
+const boldFlakeRateThreshold = 5.0
+
+// hoursAgo formats a timestamp as "Xh ago" relative to now.
+func hoursAgo(t time.Time) string {
+	h := math.Round(time.Since(t).Hours())
+	if h < 1 {
+		h = 1
+	}
+	return fmt.Sprintf("%dh ago", int(h))
+}
 
 // formatReportLines returns a plain-text bullet line per report.
 func formatReportLines(reports []TestReport) []string {
@@ -47,10 +58,13 @@ func generateSuiteBreakdownTable(suiteReports []SuiteReport) string {
 	for _, sr := range suiteReports {
 		lastFailure := "-"
 		if sr.FailedRuns > 0 && !sr.LastFailure.IsZero() {
-			lastFailure = humanize.Time(sr.LastFailure)
+			lastFailure = hoursAgo(sr.LastFailure)
 		}
-		sb.WriteString(fmt.Sprintf("| `%s` | %.1f%% (%d/%d) | %s |\n",
-			sr.SuiteName, sr.FlakeRate, sr.FailedRuns, sr.TotalRuns, lastFailure))
+		rate := fmt.Sprintf("%.1f%% (%d/%d)", sr.FlakeRate, sr.FailedRuns, sr.TotalRuns)
+		if sr.FlakeRate > boldFlakeRateThreshold {
+			rate = "**" + rate + "**"
+		}
+		sb.WriteString(fmt.Sprintf("| `%s` | %s | %s |\n", sr.SuiteName, rate, lastFailure))
 	}
 
 	return sb.String()
@@ -74,11 +88,14 @@ func generateTestReportTable(reports []TestReport, maxLinks int) string {
 		links := formatLinks(report.GitHubURLs, maxLinks)
 		lastFailure := "N/A"
 		if !report.LastFailure.IsZero() {
-			lastFailure = humanize.Time(report.LastFailure)
+			lastFailure = hoursAgo(report.LastFailure)
 		}
-		sb.WriteString(fmt.Sprintf("| `%s` | %.1f%% (%d/%d) | %s | %s |\n",
-			report.TestName, pct, report.FailureCount, report.TotalRuns,
-			lastFailure, links))
+		rate := fmt.Sprintf("%.1f%% (%d/%d)", pct, report.FailureCount, report.TotalRuns)
+		if pct > boldFlakeRateThreshold {
+			rate = "**" + rate + "**"
+		}
+		sb.WriteString(fmt.Sprintf("| `%s` | %s | %s | %s |\n",
+			report.TestName, rate, lastFailure, links))
 	}
 
 	return sb.String()
@@ -98,7 +115,7 @@ func generateCIBreakerTable(reports []TestReport, maxLinks int) string {
 		links := formatLinks(report.GitHubURLs, maxLinks)
 		lastFailure := "N/A"
 		if !report.LastFailure.IsZero() {
-			lastFailure = humanize.Time(report.LastFailure)
+			lastFailure = hoursAgo(report.LastFailure)
 		}
 		sb.WriteString(fmt.Sprintf("| `%s` | %d | %d | %s | %s |\n",
 			report.TestName, report.CIRunsBroken, report.FailureCount,

--- a/tools/flakereport/types.go
+++ b/tools/flakereport/types.go
@@ -10,16 +10,19 @@ type TestFailure struct {
 	ArtifactID string    // Artifact identifier from GitHub
 	RunID      int64     // GitHub Actions run ID
 	JobID      string    // GitHub Actions job ID (or "unknown")
+	MatrixName string    // DB config name from artifact name (e.g. "sqlite", "cassandra")
 	Timestamp  time.Time // When the workflow run was created
 }
 
 // TestRun represents a test execution (success or failure)
 type TestRun struct {
-	SuiteName string // Top-level test suite name
-	Name      string // Test name
-	Failed    bool   // Whether the test failed
-	Skipped   bool   // Whether the test was skipped
-	RunID     int64  // Workflow run ID
+	SuiteName  string // Top-level test suite name
+	Name       string // Test name
+	Failed     bool   // Whether the test failed
+	Skipped    bool   // Whether the test was skipped
+	RunID      int64  // Workflow run ID
+	JobID      string // GitHub Actions job ID (unique per matrix job/shard)
+	MatrixName string // DB config name from artifact name (e.g. "sqlite", "cassandra")
 }
 
 // TestReport represents aggregated failures for a single test
@@ -35,9 +38,9 @@ type TestReport struct {
 // SuiteReport represents aggregated flake data for a test suite
 type SuiteReport struct {
 	SuiteName   string    // Test suite name from JUnit XML
-	FlakeRate   float64   // Percentage of runs with at least one non-retry failure
-	FailedRuns  int       // Number of runs with at least one non-retry failure
-	TotalRuns   int       // Total number of workflow runs where this suite appeared
+	FlakeRate   float64   // Percentage of job executions with at least one non-retry failure
+	FailedRuns  int       // Number of job executions with at least one non-retry failure
+	TotalRuns   int       // Total number of job executions where this suite appeared
 	LastFailure time.Time // Timestamp of the most recent failure
 }
 


### PR DESCRIPTION
## What changed?

Fix issues with flakereport; see comments for details.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

<details><summary>Example</summary>
<p>

## Flaky Tests Report - 2026-02-25 11:25:50

### Overall Statistics

* **CI Success Rate**: 4/8 (50.00%)
* **Total Test Runs**: 261830
* **Total Failures**: 404
* **Overall Failure Rate**: 1.5 per 1000 tests

### Failure Categories Summary

| Category | Unique Tests |
|----------|--------------|
| CI Breakers | 1 |
| Crashes | 1 |
| Timeouts | 0 |
| Flaky Tests | 129 |

### CI Breakers (Failed All Retries)

| Test | CI Runs Broken | Total Failures | Last Failure | Links |
|------|---------------|----------------|-------------|-------|
| `TestVersionWorkflowSuite/v2/Test_DeleteVersion_QueryAfterDeletion` | 1 | 1 | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/1) |

### Crashes

| Test | Flake Rate | Last Failure | Links |
|------|------------|-------------|-------|
| `unit-test` | **100.0% (2/2)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/1) [2](https://github.com/temporalio/temporal/actions/runs/22296780641/job/1) |

### Flaky Tests

| Test | Flake Rate | Last Failure | Links |
|------|------------|-------------|-------|
| `TestClientDataConverterTestSuite` | **100.0% (1/1)** | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560060) |
| `PANIC: runtime error: index out of range [0] with length 0 [recovered, repanicked] — in go.temporal.io/server/tests.TestWorkflowUpdateSuite.func21.2` | **100.0% (1/1)** | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560060) |
| `PANIC: Fail in goroutine after TestVersioning3FunctionalSuiteV2/TestWorkflowWithPinnedOverride_NoSticky has completed — in TestVersioning3FunctionalSuiteV0/TestActivityRetryAutoUpgradeDuringBackoff` | **100.0% (1/1)** | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `PANIC: Fail in goroutine after TestVersioning3FunctionalSuiteV0/TestPinnedQuery_RollbackDrainedVersion/ForceTaskForwardNoPollForwardForceAsync has completed — in TestVersioning3FunctionalSuiteV2/TestActivityRetryAutoUpgradeDuringBackoff` | **100.0% (1/1)** | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `DATA RACE: Data race detected` | **100.0% (1/1)** | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198239) |
| `PANIC: runtime error: invalid memory address or nil pointer dereference — in go.temporal.io/server/tests.(*DeploymentVersionSuite).TestForceCAN_WithOverrideState.func1` | **100.0% (1/1)** | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068496) |
| `TestVersioning3FunctionalSuiteV0/TestTransitionDuringTransientTask_WithSignal` | **48.9% (45/92)** | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456075) [2](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456229) [3](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456270) |
| `TestVersioning3FunctionalSuiteV2/TestTransitionDuringTransientTask_WithoutSignal` | **48.9% (45/92)** | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456093) [2](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456143) [3](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456167) |
| `TestVersioning3FunctionalSuiteV2/TestTransitionDuringTransientTask_WithSignal` | **48.9% (45/92)** | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456136) [2](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456111) [3](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456112) |
| `TestVersioning3FunctionalSuiteV0/TestTransitionDuringTransientTask_WithoutSignal` | **43.4% (36/83)** | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456143) [2](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456236) [3](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456250) |
| `TestVersionWorkflowSuite/v2/Test_DeleteVersion_QueryAfterDeletion` | **42.9% (3/7)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/1) [2](https://github.com/temporalio/temporal/actions/runs/22373551837/job/1) [3](https://github.com/temporalio/temporal/actions/runs/22373551837/job/1) |
| `TestUserData_FetchesUpTree` | **16.7% (1/6)** | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/1) |
| `TestNewServerWithOTEL/with_OTEL_Collector_running` | **16.7% (1/6)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/1) |
| `TestInterleavedWeightedRoundRobinSchedulerSuite/TestInactiveChannelDeletionRace` | **16.7% (1/6)** | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/1) |
| `TestUserData_FetchesActivityToWorkflow` | **16.7% (1/6)** | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/1) |
| `TestDeploymentVersionSuiteV0/TestReactivationSignalCache_Deduplication_StartWorkflow` | **16.1% (9/56)** | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456136) [2](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456111) [3](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068532) |
| `TestNewServer` | **15.4% (2/13)** | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/1) [2](https://github.com/temporalio/temporal/actions/runs/22367698230/job/1) |
| `TestDeploymentVersionSuiteV0/TestReactivationSignalCache_Deduplication_SignalWithStart` | **11.3% (6/53)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512764) [2](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198239) [3](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198192) |
| `TestDeploymentVersionSuiteV0/TestStartWorkflowExecution_ReactivateVersionOnPinned_WithConflictPolicy` | **9.6% (5/52)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512848) [2](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198189) [3](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068462) |
| `TestDeploymentVersionSuiteV2/TestVersionScavenger_DeleteOnAdd` | **9.6% (5/52)** | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456111) [2](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512818) [3](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198207) |
| `TestDeploymentVersionSuiteV0/TestStartWorkflowExecution_ReactivateVersionOnPinned` | **9.3% (5/54)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512766) [2](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198202) [3](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068483) |
| `TestDeploymentVersionSuiteV0/TestSignalWithStartWorkflowExecution_ReactivateVersionOnPinned` | **7.8% (4/51)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512865) [2](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512840) [3](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512870) |
| `TestFairnessAutoEnableSuite/Test_Activity_Basic` | **7.7% (4/52)** | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456112) [2](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512799) [3](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068532) |
| `TestDeploymentVersionSuiteV2/TestReactivationSignalCache_Deduplication_UpdateOptions` | **7.7% (4/52)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512837) [2](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) [3](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestActivityClientTestSuite/TestActivityScheduleToClose_FiredDuringBackoff` | **7.5% (4/53)** | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456152) [2](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512837) [3](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198228) |
| `TestDeploymentVersionSuiteV0/TestReactivationSignalCache_Deduplication_Reset` | **6.0% (3/50)** | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068487) [2](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560087) [3](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114101) |
| `TestDeploymentVersionSuiteV0/TestResetWorkflowExecution_ReactivateVersionOnPinned` | **6.0% (3/50)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512828) [2](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198239) [3](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068520) |
| `TestDeploymentVersionSuiteV2/TestVersionMissingTaskQueues_ValidSetRampingVersion` | **6.0% (3/50)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512818) [2](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198207) [3](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114123) |
| `TestTaskQueueStats_Pri_Suite/TestRampingAndCurrentAbsorbUnversionedBacklog/ForceTaskForwardForcePollForwardAllowSync` | **5.9% (3/51)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512818) [2](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068532) [3](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114123) |
| `TestWorkerDeploymentSuiteV0/TestSetCurrentVersion_Concurrent_DifferentVersions_NoUnexpectedErrors` | **5.9% (3/51)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512837) [2](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198193) [3](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestDeploymentVersionSuiteV0/TestUpdateWorkflowExecutionOptions_ReactivateVersionOnPinned` | **5.9% (3/51)** | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456393) [2](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512824) [3](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestCronTestClientSuite/TestCronWorkflowCompletionStates` | **5.8% (3/52)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512824) [2](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512861) [3](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestCallbacksSuiteCHASM/TestWorkflowNexusCallbacks_CarriedOver/ContinueAsNew` | **5.8% (3/52)** | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456103) [2](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068523) [3](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestStandaloneActivityTestSuite/TestHeartbeat/HeartbeatKeepsActivityAlive` | **5.8% (3/52)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512824) [2](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198210) [3](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198202) |
| `TestCallbacksSuiteCHASM/TestWorkflowNexusCallbacks_CarriedOver/WorkflowRunTimeout` | **5.8% (3/52)** | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456103) [2](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068523) [3](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestWorkerDeploymentSuiteV0/TestDescribeWorkerDeployment_SetCurrentVersion` | **5.8% (3/52)** | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512837) [2](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512837) [3](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198228) |
| `TestDeploymentVersionSuiteV0/TestReactivationSignalCache_Deduplication_UpdateOptions` | 4.1% (2/49) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456093) [2](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560043) |
| `TestTaskQueueStats_Classic_Suite/TestAddMultipleTasks_ValidateStats_Cached` | 4.0% (2/50) | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512837) [2](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestTaskQueueStats_Pri_Suite/TestInactiveVersionDoesNotAbsorbUnversionedBacklog/NoTaskForwardNoPollForwardAllowSync` | 4.0% (2/50) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456111) [2](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198189) |
| `TestTaskQueueStats_Pri_Suite/TestMultipleTasks_WithMatchingBehavior_ValidateStats/ForceTaskForwardForcePollForwardAllowSync` | 4.0% (2/50) | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512821) [2](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestWorkerDeploymentSuiteV0/TestSetRampingVersion_AfterDrained` | 4.0% (2/50) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068420) [2](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestWorkerDeploymentSuiteV2/TestDrainRollbackedVersion` | 4.0% (2/50) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068525) [2](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestFuncClustersTestSuite/EnableTransitionHistory/TestForceMigration_ResetWorkflow` | 4.0% (2/50) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456146) [2](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068440) |
| `TestDeploymentVersionSuiteV0/TestVersionScavenger_DeleteOnAdd` | 4.0% (2/50) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068551) [2](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestWorkerDeploymentSuiteV2/TestSetCurrentVersion_Concurrent_DifferentVersions_NoUnexpectedErrors` | 4.0% (2/50) | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512837) [2](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560090) |
| `TestPrioritySuite/TestSubqueue_Migration` | 3.9% (2/51) | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512837) [2](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestCallbacksSuiteCHASM/TestWorkflowNexusCallbacks_CarriedOver/WorkflowFailureRetry` | 3.9% (2/51) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456152) [2](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560001) |
| `TestWorkerDeploymentSuiteV0/TestDrainRollbackedVersion` | 3.9% (2/51) | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198228) [2](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068512) |
| `TestVersioning3FunctionalSuiteV0/TestPinnedTask_NoProperPoller/NoTaskForwardNoPollForwardForceAsync` | 2.1% (1/48) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068483) |
| `TestVersioning3FunctionalSuiteV2/TestPinnedCaN_UpgradeOnCaN_NormalWFT_WithSuggest/ForceTaskForwardNoPollForwardForceAsync` | 2.1% (1/48) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114123) |
| `TestDeploymentVersionSuiteV0/TestUpdateWorkflowExecutionOptions_SetImpliedPinnedSuccess` | 2.1% (1/48) | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512818) |
| `TestGetHistoryFunctionalSuite/DisableTransitionHistory/TestGetWorkflowExecutionHistory_All` | 2.1% (1/48) | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198239) |
| `TestVersioning3FunctionalSuiteV2/TestUnpinnedCaN` | 2.1% (1/48) | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198239) |
| `TestVersioningFunctionalSuite/TestWorkflowTaskRedirectInRetryNonFirstTask/NoTaskForwardForcePollForwardAllowSync` | 2.1% (1/48) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456112) |
| `TestWorkerDeploymentSuiteV0/TestListWorkerDeployments_TwoVersions_SameDeployment_OneCurrent_OneRamping` | 2.1% (1/48) | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198239) |
| `TestTaskQueueStats_Classic_Suite/TestMultipleTasks_WithMatchingBehavior_ValidateStats/ForceTaskForwardNoPollForwardForceAsync` | 2.1% (1/48) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456212) |
| `TestVersioning3FunctionalSuiteV2/TestWorkflowWithPinnedOverride_NoSticky/ForceTaskForwardForcePollForwardForceAsync` | 2.1% (1/48) | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestAdvancedVisibilitySuiteLegacy/TestListWorkflow_StringQuery` | 2.1% (1/48) | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198239) |
| `TestVersioning3FunctionalSuiteV0/TestChildWorkflowInheritance_ParentPinnedByOverride` | 2.1% (1/48) | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198284) |
| `TestStandaloneActivityTestSuite/TestRequestCancel/MismatchedTokenComponentRef` | 2.1% (1/48) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456111) |
| `TestDeploymentVersionSuiteV2/TestVersionMissingTaskQueues_ValidSetCurrentVersion` | 2.1% (1/48) | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512837) |
| `TestVersioning3FunctionalSuiteV0/TestPinnedQuery_DrainedVersion_PollersAbsent/ForceTaskForwardNoPollForwardAllowSync` | 2.1% (1/48) | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198239) |
| `TestVersioning3FunctionalSuiteV0/TestPinnedWorkflowWithLateActivityPoller/ForceTaskForwardNoPollForwardAllowSync` | 2.1% (1/48) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114104) |
| `TestTaskQueueStats_Classic_Suite/TestMultipleTasks_WithMatchingBehavior_ValidateStats/ForceTaskForwardForcePollForwardAllowSync` | 2.1% (1/48) | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512839) |
| `TestDeploymentVersionSuiteV2/TestStartWorkflowExecution_ReactivateVersionOnPinned_WithConflictPolicy` | 2.1% (1/48) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456111) |
| `TestDeploymentVersionSuiteV2/TestSignalWithStartWorkflowExecution_ReactivateVersionOnPinned` | 2.1% (1/48) | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198239) |
| `TestVersioningFunctionalSuite/TestDispatchQueryOld/ForceTaskForwardNoPollForwardAllowSync` | 2.1% (1/48) | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198239) |
| `TestVersioningFunctionalSuite/TestWorkflowTaskRedirectInRetryFirstTask/ForceTaskForwardForcePollForwardForceAsync` | 2.1% (1/48) | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestTaskQueueStats_Pri_Suite/TestMultipleTasks_WithMatchingBehavior_ValidateStats/ForceTaskForwardForcePollForwardForceAsync` | 2.1% (1/48) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068525) |
| `TestWorkerDeploymentSuiteV0/TestDescribeWorkerDeployment_MultipleVersions_Sorted` | 2.0% (1/49) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068496) |
| `TestDeploymentVersionSuiteV2/TestDrainageStatus_SetCurrentVersion_YesOpenWFs` | 2.0% (1/49) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068496) |
| `TestVersioning3FunctionalSuiteV0/TestAutoUpgradeCaN_UpgradeOnCaN/ForceTaskForwardNoPollForwardAllowSync` | 2.0% (1/49) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068496) |
| `TestWorkerDeploymentSuiteV2/TestSetCurrentVersion_Batching` | 2.0% (1/49) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068420) |
| `TestTaskQueueStats_Classic_Suite/TestCurrentAbsorbsUnversionedBacklog_WhenRampingToUnversioned/NoTaskForwardForcePollForwardForceAsync` | 2.0% (1/49) | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560082) |
| `TestTaskQueueSuite/TestTaskQueueRateLimit_UpdateFromWorkerConfigAndAPI` | 2.0% (1/49) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456111) |
| `TestVersioning3FunctionalSuiteV0/TestPinnedQuery_RollbackDrainedVersion/ForceTaskForwardNoPollForwardForceAsync` | 2.0% (1/49) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestWorkflowUpdateSuite/StickySpeculativeWorkflowTask_AcceptComplete_StickyWorkerUnavailable` | 2.0% (1/49) | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560060) |
| `TestWorkerDeploymentSuiteV2/TestResourceExhaustedErrors_Converted_To_ReadableMessage` | 2.0% (1/49) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114116) |
| `TestVersioning3FunctionalSuiteV0/TestPinnedCaN_UpgradeOnCaN_TransientWFT_WithSuggest/ForceTaskForwardForcePollForwardForceAsync` | 2.0% (1/49) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456152) |
| `TestVersioning3FunctionalSuiteV2/TestPinnedCaN_UpgradeOnCaN_NormalWFT_PinnedOverride_WithSuggest/NoTaskForwardForcePollForwardAllowSync` | 2.0% (1/49) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068496) |
| `TestTaskQueueStats_Pri_Suite/TestMultipleTasks_WithMatchingBehavior_ValidateStats/ForceTaskForwardNoPollForwardForceAsync` | 2.0% (1/49) | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestChildWorkflowSuite/TestCronChildWorkflowExecution` | 2.0% (1/49) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114114) |
| `TestNexusStateReplicationTestSuite/DisableTransitionHistory/TestNexusCallbackReplicated` | 2.0% (1/49) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456192) |
| `TestWorkerDeploymentSuiteV0/TestSetWorkerDeploymentRampingVersion_WithCurrent_Unset_Ramp` | 2.0% (1/49) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestFuncClustersTestSuite/EnableTransitionHistory/TestForceMigration_ClosedWorkflow` | 2.0% (1/49) | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198205) |
| `TestTaskQueueStats_Classic_Suite/TestCurrentVersionAbsorbsUnversionedBacklog_NoRamping/ForceTaskForwardNoPollForwardForceAsync` | 2.0% (1/49) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114074) |
| `TestWorkflowUpdateSuite/SpeculativeWorkflowTask_ScheduleToStartTimeoutOnNormalTaskQueue` | 2.0% (1/49) | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560060) |
| `TestStandaloneActivityTestSuite/TestRequestCancel/StaleAttemptToken` | 2.0% (1/49) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068496) |
| `TestTaskQueueStats_Classic_Suite/TestCurrentVersionAbsorbsUnversionedBacklog_NoRamping/NoTaskForwardForcePollForwardAllowSync` | 2.0% (1/49) | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198284) |
| `TestVersioning3FunctionalSuiteV2/TestUnpinnedQuery_NoSticky/ForceTaskForwardForcePollForwardForceAsync` | 2.0% (1/49) | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512861) |
| `TestTaskQueueStats_Classic_Suite/TestRampingAbsorbsUnversionedBacklog_WhenCurrentIsUnversioned/NoTaskForwardForcePollForwardForceAsync` | 2.0% (1/49) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestTaskQueueStats_Pri_Suite/TestCurrentVersionAbsorbsUnversionedBacklog_NoRamping/NoTaskForwardNoPollForwardAllowSync` | 2.0% (1/49) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456212) |
| `TestTaskQueueStats_Pri_Suite/TestRampingAndCurrentAbsorbUnversionedBacklog/NoTaskForwardNoPollForwardAllowSync` | 2.0% (1/49) | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560089) |
| `TestFuncClustersTestSuite/DisableTransitionHistory/TestForceMigration_ClosedWorkflow` | 2.0% (1/49) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114115) |
| `TestWorkerDeploymentSuiteV0/TestSetRampingVersion_Concurrent_DifferentVersions_NoUnexpectedErrors` | 2.0% (1/49) | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512837) |
| `TestTaskQueueStats_Classic_Suite/TestMultipleTasks_WithMatchingBehavior_ValidateStats/NoTaskForwardNoPollForwardAllowSync` | 2.0% (1/49) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068496) |
| `TestVersioning3FunctionalSuiteV0/TestPinnedQuery_RollbackDrainedVersion/NoTaskForwardForcePollForwardAllowSync` | 2.0% (1/49) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestVersioning3FunctionalSuiteV2/TestUnpinnedQuery_NoSticky/NoTaskForwardForcePollForwardAllowSync` | 2.0% (1/49) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068523) |
| `TestDeploymentVersionSuiteV0/TestForceCAN_WithOverrideState` | 2.0% (1/49) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068496) |
| `TestVersioningFunctionalSuite/TestDispatchActivityFailCrossTq/NoTaskForwardForcePollForwardAllowSync` | 2.0% (1/49) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068496) |
| `TestVersioning3FunctionalSuiteV0/TestPinnedCaN_UpgradeOnCaN_TransientWFT_WithSuggest/ForceTaskForwardNoPollForwardForceAsync` | 2.0% (1/49) | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestWorkerDeploymentSuiteV0/TestSetWorkerDeploymentRampingVersion_Batching` | 2.0% (1/49) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestDeploymentVersionSuiteV0/TestDrainageStatus_SetCurrentVersion_NoOpenWFs` | 2.0% (1/50) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068523) |
| `TestScheduleFunctionalSuite/TestNextTimeCache` | 2.0% (1/50) | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512837) |
| `TestVersioning3FunctionalSuiteV2/TestUnpinnedQuery_NoSticky/ForceTaskForwardNoPollForwardAllowSync` | 2.0% (1/50) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestPollerScalingFunctionalSuite/TestPollerScalingDecisionsAreSeenProbabilistically` | 2.0% (1/50) | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestFairnessSuite/TestMigration_FromFair` | 2.0% (1/50) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114116) |
| `TestFairnessAutoEnableSuite/TestMigration_FromClassic` | 2.0% (1/50) | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560075) |
| `TestTaskQueueStats_Pri_Suite/TestMultipleTasks_WithMatchingBehavior_ValidateStats/ForceTaskForwardNoPollForwardAllowSync` | 2.0% (1/50) | 23h ago | [1](https://github.com/temporalio/temporal/actions/runs/22367698230/job/64738198193) |
| `TestWorkflowTaskTestSuite/TestWorkflowTaskHeartbeatingWithEmptyResult` | 2.0% (1/50) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114142) |
| `TestAdvancedVisibilitySuite/TestWorkerTaskReachability_Unversioned_InTaskQueue` | 2.0% (1/50) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestDeploymentVersionSuiteV2/TestDeleteVersion_DeleteRampedVersion` | 2.0% (1/50) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456152) |
| `TestWorkerDeploymentSuiteV0/TestDeploymentVersionLimits` | 2.0% (1/50) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114116) |
| `TestVersioning3FunctionalSuiteV2/TestPinnedQuery_RollbackDrainedVersion/ForceTaskForwardForcePollForwardForceAsync` | 2.0% (1/50) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456152) |
| `TestVersioning3FunctionalSuiteV2/TestUnpinnedQuery_NoSticky/NoTaskForwardNoPollForwardAllowSync` | 2.0% (1/50) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068512) |
| `TestDeploymentVersionSuiteV2/TestDeleteVersion_Drained_But_Pollers_Exist` | 2.0% (1/50) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456152) |
| `TestVersioning3FunctionalSuiteV2/TestQueryWithPinnedOverride_Sticky/ForceTaskForwardForcePollForwardAllowSync` | 2.0% (1/50) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068512) |
| `TestFairnessAutoEnableSuite/TestMigration_FromFair` | 2.0% (1/50) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456152) |
| `TestVersioning3FunctionalSuiteV0/TestPinnedCaN_UpgradeOnCaN_SpeculativeWFT_NoSuggest/NoTaskForwardNoPollForwardAllowSync` | 2.0% (1/50) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068525) |
| `TestWorkerDeploymentSuiteV0/TestDescribeWorkerDeployment_TwoVersions_Sorted` | 2.0% (1/50) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068512) |
| `TestDeploymentVersionSuiteV2/TestDrainageStatus_SetCurrentVersion_NoOpenWFs` | 2.0% (1/50) | 1h ago | [1](https://github.com/temporalio/temporal/actions/runs/22410112796/job/64881456152) |
| `TestDeploymentVersionSuiteV2/TestDeleteVersion_ValidDelete` | 2.0% (1/50) | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512833) |
| `TestScheduleFunctionalSuite/TestListSchedulesReturnsWorkflowStatus` | 2.0% (1/50) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068523) |
| `TestVersioningFunctionalSuite/TestWorkflowTaskRedirectInRetryFirstTask/ForceTaskForwardForcePollForwardAllowSync` | 2.0% (1/50) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestCronTestSuite/TestCronWorkflow` | 2.0% (1/50) | 44h ago | [1](https://github.com/temporalio/temporal/actions/runs/22329840058/job/64609560092) |
| `TestVersioning3FunctionalSuiteV0/TestPinnedCaN_UpgradeOnCaN_NormalWFT_WithSuggest/ForceTaskForwardNoPollForwardForceAsync` | 2.0% (1/50) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068420) |
| `TestVersioning3FunctionalSuiteV2/TestAutoUpgradeCaN_UpgradeOnCaN/ForceTaskForwardForcePollForwardAllowSync` | 2.0% (1/50) | 38h ago | [1](https://github.com/temporalio/temporal/actions/runs/22337683305/job/64634068472) |
| `TestDeploymentVersionSuiteV2/TestReactivationSignalCache_Deduplication_SignalWithStart` | 2.0% (1/50) | 60h ago | [1](https://github.com/temporalio/temporal/actions/runs/22296780641/job/64495114191) |
| `TestVersioning3FunctionalSuiteV2/TestPinnedQuery_DrainedVersion_PollersAbsent/ForceTaskForwardNoPollForwardAllowSync` | 2.0% (1/50) | 21h ago | [1](https://github.com/temporalio/temporal/actions/runs/22373551837/job/64758512837) |

### Flaky Suites

| Suite | Flake Rate | Last Failure |
|-------|------------|-------------|
| `TestAcquireShard_DeadlineExceededErrorSuite` | 2.1% (1/47) | 38h ago |
| `TestAcquireShard_OwnershipLostErrorSuite` | 2.1% (1/48) | 44h ago |
| `TestActivityClientTestSuite` | **8.3% (4/48)** | 1h ago |
| `TestActivityTestSuite` | 2.1% (1/48) | 44h ago |
| `TestAdminTestSuite` | 2.1% (1/48) | 44h ago |
| `TestAdvancedVisibilitySuite` | 4.2% (2/48) | 44h ago |
| `TestAdvancedVisibilitySuiteLegacy` | 2.1% (1/48) | 23h ago |
| `TestCallbacksSuiteCHASM` | **8.3% (4/48)** | 1h ago |
| `TestChasmTestSuiteLegacy` | 2.1% (1/48) | 44h ago |
| `TestChildWorkflowSuite` | 2.1% (1/48) | 60h ago |
| `TestClientDataConverterTestSuite` | **100.0% (1/1)** | 44h ago |
| `TestClientMiscTestSuite` | 2.1% (1/48) | 44h ago |
| `TestCronTestClientSuite` | **6.2% (3/48)** | 21h ago |
| `TestCronTestSuite` | 2.1% (1/48) | 44h ago |
| `TestDLQSuite` | 4.2% (2/48) | 44h ago |
| `TestDeploymentVersionSuiteV0` | **62.5% (30/48)** | 1h ago |
| `TestDeploymentVersionSuiteV2` | **22.9% (11/48)** | 1h ago |
| `TestFairnessAutoEnableSuite` | **8.3% (4/48)** | 1h ago |
| `TestFairnessSuite` | 2.1% (1/48) | 60h ago |
| `TestFuncClustersTestSuite` | **8.3% (4/48)** | 1h ago |
| `TestGetHistoryFunctionalSuite` | 2.1% (1/48) | 23h ago |
| `TestNamespaceInterceptorTestSuite` | **6.2% (3/48)** | 38h ago |
| `TestNamespaceSuite` | 1.9% (1/53) | 44h ago |
| `TestNexusApiTestSuiteWithTemporalFailures` | 2.1% (1/48) | 44h ago |
| `TestNexusStateReplicationTestSuite` | 2.1% (1/48) | 1h ago |
| `TestNexusWorkflowTestSuite` | 2.1% (1/48) | 44h ago |
| `TestPollerScalingFunctionalSuite` | 2.1% (1/48) | 44h ago |
| `TestPrioritySuite` | 4.2% (2/48) | 21h ago |
| `TestPurgeDLQTasksSuite` | 2.1% (1/48) | 44h ago |
| `TestQueryWorkflowSuite` | 2.1% (1/48) | 38h ago |
| `TestRawHistoryClientSuite` | 2.1% (1/48) | 44h ago |
| `TestRelayTaskTestSuite` | 2.1% (1/47) | 44h ago |
| `TestResetWorkflowTestSuite` | 2.1% (1/48) | 44h ago |
| `TestScheduleFunctionalSuite` | **6.2% (3/48)** | 21h ago |
| `TestStandaloneActivityTestSuite` | **10.4% (5/48)** | 1h ago |
| `TestTLSFunctionalSuite` | 2.1% (1/48) | 44h ago |
| `TestTaskQueueStats_Classic_Suite` | **18.8% (9/48)** | 1h ago |
| `TestTaskQueueStats_Pri_Suite` | **25.0% (12/48)** | 1h ago |
| `TestTaskQueueSuite` | 4.2% (2/48) | 1h ago |
| `TestTransientTaskSuite` | 2.1% (1/48) | 44h ago |
| `TestUpdateWorkflowSdkSuite` | 2.1% (1/48) | 44h ago |
| `TestUserMetadataSuite` | 2.1% (1/47) | 44h ago |
| `TestUserTimersTestSuite` | 2.1% (1/47) | 44h ago |
| `TestVersionWorkflowSuite` | **20.0% (1/5)** | 21h ago |
| `TestVersioning3FunctionalSuiteV0` | **100.0% (48/48)** | 1h ago |
| `TestVersioning3FunctionalSuiteV2` | **100.0% (48/48)** | 1h ago |
| `TestVersioningFunctionalSuite` | **10.4% (5/48)** | 1h ago |
| `TestWorkerDeploymentSuiteV0` | **16.7% (8/48)** | 21h ago |
| `TestWorkerDeploymentSuiteV2` | **12.5% (6/48)** | 21h ago |
| `TestWorkflowMemoTestSuite` | 2.1% (1/48) | 44h ago |
| `TestWorkflowTaskTestSuite` | 4.2% (2/48) | 38h ago |
| `TestWorkflowUpdateSuite` | 2.1% (1/48) | 44h ago |



</p>
</details> 
