### PR TITLE
Add RegisteredName to dynamicconfig.Key

### DIFF
--- a/cmd/tools/gendynamicconfig/dynamic_config.tmpl
+++ b/cmd/tools/gendynamicconfig/dynamic_config.tmpl
@@ -39,7 +39,7 @@ func New{{$P.Name}}TypedSetting[T any](key string, def T, description string) {{
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -52,7 +52,7 @@ func New{{$P.Name}}TypedSettingWithConverter[T any](key string, convert func(any
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -65,7 +65,7 @@ func New{{$P.Name}}TypedSettingWithConstrainedDefault[T any](key string, convert
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 

--- a/common/dynamicconfig/collection_test.go
+++ b/common/dynamicconfig/collection_test.go
@@ -428,6 +428,15 @@ func (s *collectionSuite) TestGetTypedProtoEnum() {
 	})
 }
 
+func (s *collectionSuite) TestRegisteredName() {
+	setting := dynamicconfig.NewGlobalIntSetting("settingWithUppercaseLetters", 10, "")
+	// For a registered setting, RegisteredName will return the original name.
+	s.Equal("settingWithUppercaseLetters", setting.Key().RegisteredName())
+
+	// For a key that has not been registered, it will return the empty string.
+	s.Empty(dynamicconfig.MakeKey("settingDoesNotExist").RegisteredName())
+}
+
 // someEnum is an example type for DynamicConfigParseHook.
 type someEnum int32
 

--- a/common/dynamicconfig/key.go
+++ b/common/dynamicconfig/key.go
@@ -19,3 +19,13 @@ func MakeKey(s string) Key {
 func (k Key) String() string {
 	return k.handle.Value()
 }
+
+// RegisteredName returns the original name that the setting with this key was registered with.
+// Note that it only works on registered settings (i.e. New{Scope}{Type}Setting). If called on
+// a key that does not correspond to a registered setting, it will return the empty string.
+func (k Key) RegisteredName() string {
+	if name, ok := getRegisteredName(k); ok {
+		return name
+	}
+	return ""
+}

--- a/common/dynamicconfig/registry.go
+++ b/common/dynamicconfig/registry.go
@@ -8,6 +8,7 @@ import (
 type (
 	registry struct {
 		settings map[Key]GenericSetting
+		regNames map[Key]string
 		queried  atomic.Bool
 	}
 )
@@ -16,18 +17,20 @@ var (
 	globalRegistry registry
 )
 
-func register(s GenericSetting) {
+func register(s GenericSetting, regName string) {
 	if globalRegistry.queried.Load() {
 		panic("dynamicconfig.New*Setting must only be called from static initializers")
 	}
 	if globalRegistry.settings == nil {
 		globalRegistry.settings = make(map[Key]GenericSetting)
+		globalRegistry.regNames = make(map[Key]string)
 	}
 	if globalRegistry.settings[s.Key()] != nil {
 		// nolint:forbidigo // only called during static initialization
 		panic(fmt.Sprintf("duplicate registration of dynamic config key: %q", s.Key().String()))
 	}
 	globalRegistry.settings[s.Key()] = s
+	globalRegistry.regNames[s.Key()] = regName
 }
 
 func queryRegistry(k Key) GenericSetting {
@@ -37,8 +40,17 @@ func queryRegistry(k Key) GenericSetting {
 	return globalRegistry.settings[k]
 }
 
+func getRegisteredName(k Key) (string, bool) {
+	if !globalRegistry.queried.Load() {
+		globalRegistry.queried.Store(true)
+	}
+	name, ok := globalRegistry.regNames[k]
+	return name, ok
+}
+
 // For testing only; do not call from regular code!
 func ResetRegistryForTest() {
 	globalRegistry.settings = nil
+	globalRegistry.regNames = nil
 	globalRegistry.queried.Store(false)
 }

--- a/common/dynamicconfig/setting_gen.go
+++ b/common/dynamicconfig/setting_gen.go
@@ -753,7 +753,7 @@ func NewGlobalTypedSetting[T any](key string, def T, description string) GlobalT
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -765,7 +765,7 @@ func NewGlobalTypedSettingWithConverter[T any](key string, convert func(any) (T,
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -777,7 +777,7 @@ func NewGlobalTypedSettingWithConstrainedDefault[T any](key string, convert func
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -889,7 +889,7 @@ func NewNamespaceTypedSetting[T any](key string, def T, description string) Name
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -901,7 +901,7 @@ func NewNamespaceTypedSettingWithConverter[T any](key string, convert func(any) 
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -913,7 +913,7 @@ func NewNamespaceTypedSettingWithConstrainedDefault[T any](key string, convert f
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1025,7 +1025,7 @@ func NewNamespaceIDTypedSetting[T any](key string, def T, description string) Na
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1037,7 +1037,7 @@ func NewNamespaceIDTypedSettingWithConverter[T any](key string, convert func(any
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1049,7 +1049,7 @@ func NewNamespaceIDTypedSettingWithConstrainedDefault[T any](key string, convert
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1161,7 +1161,7 @@ func NewTaskQueueTypedSetting[T any](key string, def T, description string) Task
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1173,7 +1173,7 @@ func NewTaskQueueTypedSettingWithConverter[T any](key string, convert func(any) 
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1185,7 +1185,7 @@ func NewTaskQueueTypedSettingWithConstrainedDefault[T any](key string, convert f
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1321,7 +1321,7 @@ func NewShardIDTypedSetting[T any](key string, def T, description string) ShardI
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1333,7 +1333,7 @@ func NewShardIDTypedSettingWithConverter[T any](key string, convert func(any) (T
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1345,7 +1345,7 @@ func NewShardIDTypedSettingWithConstrainedDefault[T any](key string, convert fun
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1457,7 +1457,7 @@ func NewTaskTypeTypedSetting[T any](key string, def T, description string) TaskT
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1469,7 +1469,7 @@ func NewTaskTypeTypedSettingWithConverter[T any](key string, convert func(any) (
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1481,7 +1481,7 @@ func NewTaskTypeTypedSettingWithConstrainedDefault[T any](key string, convert fu
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1593,7 +1593,7 @@ func NewDestinationTypedSetting[T any](key string, def T, description string) De
 		convert:     ConvertStructure[T](def),
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1605,7 +1605,7 @@ func NewDestinationTypedSettingWithConverter[T any](key string, convert func(any
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 
@@ -1617,7 +1617,7 @@ func NewDestinationTypedSettingWithConstrainedDefault[T any](key string, convert
 		convert:     convert,
 		description: description,
 	}
-	register(s)
+	register(s, key)
 	return s
 }
 


### PR DESCRIPTION
## What changed?
Add a RegisteredName method to get the original key name string that a setting was registered with.

## Why?
This is convenient for things using the server dynamicconfig package as a library.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
