### PR TITLE
Fix legacy query converter search attribute precedence

### DIFF
--- a/chasm/lib/tests/gen/testspb/v1/message.pb.go
+++ b/chasm/lib/tests/gen/testspb/v1/message.pb.go
@@ -30,6 +30,7 @@ type TestPayloadStore struct {
 	// (-- api-linter: core::0142::time-field-type=disabled --)
 	ExpirationTimes map[string]*timestamppb.Timestamp `protobuf:"bytes,3,rep,name=expiration_times,json=expirationTimes,proto3" json:"expiration_times,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Closed          bool                              `protobuf:"varint,4,opt,name=closed,proto3" json:"closed,omitempty"`
+	Canceled        bool                              `protobuf:"varint,5,opt,name=canceled,proto3" json:"canceled,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -88,6 +89,13 @@ func (x *TestPayloadStore) GetExpirationTimes() map[string]*timestamppb.Timestam
 func (x *TestPayloadStore) GetClosed() bool {
 	if x != nil {
 		return x.Closed
+	}
+	return false
+}
+
+func (x *TestPayloadStore) GetCanceled() bool {
+	if x != nil {
+		return x.Canceled
 	}
 	return false
 }
@@ -184,14 +192,15 @@ var File_temporal_server_chasm_lib_tests_proto_v1_message_proto protoreflect.Fil
 
 const file_temporal_server_chasm_lib_tests_proto_v1_message_proto_rawDesc = "" +
 	"\n" +
-	"6temporal/server/chasm/lib/tests/proto/v1/message.proto\x12(temporal.server.chasm.lib.tests.proto.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc6\x02\n" +
+	"6temporal/server/chasm/lib/tests/proto/v1/message.proto\x12(temporal.server.chasm.lib.tests.proto.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe2\x02\n" +
 	"\x10TestPayloadStore\x12\x1f\n" +
 	"\vtotal_count\x18\x01 \x01(\x03R\n" +
 	"totalCount\x12\x1d\n" +
 	"\n" +
 	"total_size\x18\x02 \x01(\x03R\ttotalSize\x12z\n" +
 	"\x10expiration_times\x18\x03 \x03(\v2O.temporal.server.chasm.lib.tests.proto.v1.TestPayloadStore.ExpirationTimesEntryR\x0fexpirationTimes\x12\x16\n" +
-	"\x06closed\x18\x04 \x01(\bR\x06closed\x1a^\n" +
+	"\x06closed\x18\x04 \x01(\bR\x06closed\x12\x1a\n" +
+	"\bcanceled\x18\x05 \x01(\bR\bcanceled\x1a^\n" +
 	"\x14ExpirationTimesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x05value:\x028\x01\"9\n" +

--- a/chasm/lib/tests/handler.go
+++ b/chasm/lib/tests/handler.go
@@ -38,6 +38,13 @@ type (
 
 	ClosePayloadStoreResponse struct{}
 
+	CancelPayloadStoreRequest struct {
+		NamespaceID namespace.ID
+		StoreID     string
+	}
+
+	CancelPayloadStoreResponse struct{}
+
 	AddPayloadRequest struct {
 		NamespaceID namespace.ID
 		StoreID     string
@@ -133,6 +140,24 @@ func ClosePayloadStoreHandler(
 		),
 		(*PayloadStore).Close,
 		nil,
+	)
+	return resp, err
+}
+
+func CancelPayloadStoreHandler(
+	ctx context.Context,
+	request CancelPayloadStoreRequest,
+) (CancelPayloadStoreResponse, error) {
+	resp, _, err := chasm.UpdateComponent(
+		ctx,
+		chasm.NewComponentRef[*PayloadStore](
+			chasm.ExecutionKey{
+				NamespaceID: request.NamespaceID.String(),
+				BusinessID:  request.StoreID,
+			},
+		),
+		(*PayloadStore).Cancel,
+		request,
 	)
 	return resp, err
 }

--- a/chasm/lib/tests/proto/v1/message.proto
+++ b/chasm/lib/tests/proto/v1/message.proto
@@ -12,6 +12,7 @@ message TestPayloadStore {
     // (-- api-linter: core::0142::time-field-type=disabled --)
     map<string, google.protobuf.Timestamp> expiration_times = 3;
     bool closed = 4;
+    bool canceled = 5;
 }
 
 message TestPayloadTTLPureTask {

--- a/common/persistence/visibility/store/query/resolve.go
+++ b/common/persistence/visibility/store/query/resolve.go
@@ -37,11 +37,11 @@ func ResolveSearchAttributeAlias(
 			saType, _ := saTypeMap.GetType(sadefs.WorkflowID)
 			return sadefs.WorkflowID, saType, nil
 		}
+	}
 
-		fieldName, fieldType = tryChasmMapper(name, chasmMapper)
-		if fieldName != "" {
-			return fieldName, fieldType, nil
-		}
+	fieldName, fieldType := tryChasmMapper(name, chasmMapper)
+	if fieldName != "" {
+		return fieldName, fieldType, nil
 	}
 
 	fieldName, fieldType, found := tryDirectAndPrefixedLookup(name, saTypeMap)

--- a/common/persistence/visibility/store/query/resolve_test.go
+++ b/common/persistence/visibility/store/query/resolve_test.go
@@ -180,6 +180,31 @@ func TestResolveSearchAttributeAlias_WithChasmMapper(t *testing.T) {
 	}
 }
 
+func TestResolveSearchAttributeAlias_ChasmOverridesSystemAttribute(t *testing.T) {
+	ns := namespace.Name("test-namespace")
+	saTypeMap := searchattribute.NewNameTypeMapStub(map[string]enumspb.IndexedValueType{
+		"ExecutionStatus": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+	})
+	mapper := customMapper{
+		fieldToAlias: map[string]string{},
+		aliasToField: map[string]string{},
+	}
+
+	chasmMapper := chasm.NewTestVisibilitySearchAttributesMapper(
+		map[string]string{
+			"TemporalLowCardinalityKeyword01": "ExecutionStatus",
+		},
+		map[string]enumspb.IndexedValueType{
+			"TemporalLowCardinalityKeyword01": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+	)
+
+	fieldName, fieldType, err := ResolveSearchAttributeAlias("ExecutionStatus", ns, mapper, saTypeMap, chasmMapper)
+	require.NoError(t, err)
+	require.Equal(t, "TemporalLowCardinalityKeyword01", fieldName)
+	require.Equal(t, enumspb.INDEXED_VALUE_TYPE_KEYWORD, fieldType)
+}
+
 func TestResolveSearchAttributeAlias_ChasmPriority(t *testing.T) {
 	ns := namespace.Name("test-namespace")
 	saTypeMap := searchattribute.NewNameTypeMapStub(map[string]enumspb.IndexedValueType{

--- a/tests/chasm_test.go
+++ b/tests/chasm_test.go
@@ -638,25 +638,23 @@ func (s *ChasmTestSuite) TestListExecutions_ExecutionStatusAsAlias() {
 	s.True(ok)
 	s.Equal("Running", executionStatus)
 
-	// Close the store and verify the status changes
-	_, err = tests.ClosePayloadStoreHandler(
+	_, err = tests.CancelPayloadStoreHandler(
 		ctx,
-		tests.ClosePayloadStoreRequest{
+		tests.CancelPayloadStoreRequest{
 			NamespaceID: s.NamespaceID(),
 			StoreID:     storeID,
 		},
 	)
 	s.NoError(err)
 
-	// Query for Completed status using ExecutionStatus as CHASM alias
-	visQueryCompleted := fmt.Sprintf("TemporalNamespaceDivision = '%d' AND ExecutionStatus = 'Completed'", archetypeID)
+	visQueryCanceled := fmt.Sprintf("TemporalNamespaceDivision = '%d' AND ExecutionStatus = 'Canceled' AND PayloadStoreId = '%s'", archetypeID, storeID)
 	s.Eventually(
 		func() bool {
 			resp, err := chasm.ListExecutions[*tests.PayloadStore, *testspb.TestPayloadStore](ctx, &chasm.ListExecutionsRequest{
 				NamespaceID:   string(s.NamespaceID()),
 				NamespaceName: string(s.Namespace()),
 				PageSize:      10,
-				Query:         visQueryCompleted + fmt.Sprintf(" AND PayloadStoreId = '%s'", storeID),
+				Query:         visQueryCanceled,
 			})
 			s.NoError(err)
 			return len(resp.Executions) == 1


### PR DESCRIPTION
## What changed?
Fix legacy query converter search attribute precedence.

## Why?
For conflicting search attribute aliases, custom search attributes should take precedence, then chasm, then system/predefined search attributes. Legacy converter incorrectly resolves system search attribute before chasm.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)
