### PR TITLE
Bump ServerVersion 1.30.0 to 1.30.1

### DIFF
--- a/common/headers/version_checker.go
+++ b/common/headers/version_checker.go
@@ -23,7 +23,7 @@ const (
 
 	// ServerVersion value can be changed by the create-tag Github workflow.
 	// If you change the var name or move it, be sure to update the workflow.
-	ServerVersion = "1.30.0"
+	ServerVersion = "1.30.1"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"


### PR DESCRIPTION
## Summary
- Bump `ServerVersion` from `1.30.0` to `1.30.1` in `common/headers/version_checker.go`

