### PR TITLE
Fairness counter: use sliding window

### DIFF
--- a/service/matching/counter/cmsketch.go
+++ b/service/matching/counter/cmsketch.go
@@ -30,14 +30,19 @@ type (
 		params CMSketchParams
 		seed0  maphash.Seed
 		seeds  []uint64
-		// TODO: use uint32 with a sliding window
-		cells []int64
+		// cells stores offsets from base. The actual value for a cell is base + int64(cells[i]).
+		// This allows us to use uint32 for storage while supporting the full int64 range.
+		base  int64
+		cells []uint32
 
 		skips, incs int // used to calculate skip rate
 
 		topKProvider topKFunc // callback to get top-K entries on resize
 	}
 )
+
+// slideHeadroom is how much space to leave in the sliding window when we need to slide
+const slideHeadroom = math.MaxUint32 / 2
 
 var _ Counter = (*cmSketch)(nil)
 
@@ -49,7 +54,7 @@ func NewCMSketchCounter(params CMSketchParams, src rand.Source, topKProvider top
 		params:       params,
 		seed0:        maphash.MakeSeed(),
 		seeds:        makeSeeds(params.D, src),
-		cells:        make([]int64, params.W*params.D),
+		cells:        make([]uint32, params.W*params.D),
 		topKProvider: topKProvider,
 	}
 }
@@ -82,8 +87,8 @@ func (s *cmSketch) SkipRate() float64 {
 func (s *cmSketch) EstimateDistinctKeys() int {
 	// TODO: improve this estimate with more math
 	count := 0
-	for _, d := range s.cells {
-		if d > 0 {
+	for _, c := range s.cells {
+		if c > 0 {
 			count++
 		}
 	}
@@ -124,7 +129,8 @@ func (s *cmSketch) maybeGrow() {
 
 	s.params.W = min(int(float64(s.params.W)*s.params.Grow.Ratio), s.params.Grow.MaxW)
 	s.seed0 = maphash.MakeSeed()
-	s.cells = make([]int64, s.params.W*s.params.D)
+	s.base = 0
+	s.cells = make([]uint32, s.params.W*s.params.D)
 	s.skips, s.incs = 0, 0
 
 	if len(topK) > 0 {
@@ -142,22 +148,58 @@ func (s *cmSketch) maybeGrow() {
 
 func (s *cmSketch) getByIndexes(indexes []int) int64 {
 	// TODO: consider using better estimator: https://dl.acm.org/doi/pdf/10.1145/3219819.3219975
-	minVal := int64(math.MaxInt64)
+	minVal := uint32(math.MaxUint32)
 	for _, idx := range indexes {
 		minVal = min(minVal, s.cells[idx])
 	}
-	return minVal
+	return s.base + int64(minVal)
 }
 
 func (s *cmSketch) ensureByIndexes(indexes []int, target int64) (skips int) {
+	offset := target - s.base
+	if offset < 0 {
+		// target is below base, all cells are already high enough
+		return len(indexes)
+	}
+	if offset > math.MaxUint32 {
+		// would overflow uint32, need to slide the base up first
+		s.slideBase(offset + slideHeadroom - math.MaxUint32)
+		offset = math.MaxUint32 - slideHeadroom
+	}
+
+	uoffset := uint32(offset)
 	for _, idx := range indexes {
-		if s.cells[idx] < target {
-			s.cells[idx] = target
+		if s.cells[idx] < uoffset {
+			s.cells[idx] = uoffset
 		} else {
 			skips++
 		}
 	}
 	return
+}
+
+// slideBase increases the base by delta, subtracting delta from all cells.
+// Cells that would go negative are clamped to 0 (those keys are "dragged up").
+func (s *cmSketch) slideBase(delta int64) {
+	if delta <= 0 {
+		return
+	}
+	s.base += delta
+	if delta >= math.MaxUint32 {
+		for i := range s.cells {
+			s.cells[i] = 0
+		}
+		return
+	}
+	// delta fits in uint32
+	udelta := uint32(delta)
+	for i := range s.cells {
+		if s.cells[i] > udelta {
+			s.cells[i] -= udelta
+		} else {
+			s.cells[i] = 0
+		}
+	}
 }
 
 func makeSeeds(d int, src rand.Source) []uint64 {

--- a/service/matching/counter/cmsketch_test.go
+++ b/service/matching/counter/cmsketch_test.go
@@ -97,3 +97,111 @@ func TestCMSketch_Grow_PreservedOnResize(t *testing.T) {
 	assert.GreaterOrEqual(t, cms.GetPass("topkey1", 0, 1), int64(9999))
 	assert.GreaterOrEqual(t, cms.GetPass("topkey2", 0, 1), int64(99999))
 }
+
+func TestCMSketch_SlideBase(t *testing.T) {
+	src := rand.NewPCG(rand.Uint64(), rand.Uint64())
+	cms := NewCMSketchCounter(CMSketchParams{W: 10, D: 3}, src, nil)
+
+	// start with a value that will require sliding when we add more
+	startBase := int64(math.MaxUint32) - 100
+	p1 := cms.GetPass("hot", startBase, 0)
+	assert.Equal(t, startBase, p1)
+	assert.Equal(t, int64(0), cms.base, "base should still be 0, value fits in uint32")
+
+	// push past MaxUint32, which should trigger a slide
+	p2 := cms.GetPass("hot", 0, 200)
+	assert.Equal(t, startBase+200, p2)
+	assert.Positive(t, cms.base, "base should have slid up")
+
+	// the value should still be correct after sliding
+	p3 := cms.GetPass("hot", 0, 0)
+	assert.Equal(t, startBase+200, p3)
+}
+
+func TestCMSketch_SlideBase_DragUp(t *testing.T) {
+	src := rand.NewPCG(rand.Uint64(), rand.Uint64())
+	cms := NewCMSketchCounter(CMSketchParams{W: 10, D: 3}, src, nil)
+
+	// set up a cold key at a low value
+	coldPass := cms.GetPass("cold", 0, 100)
+	assert.Equal(t, int64(100), coldPass)
+
+	// set up a hot key near the uint32 boundary
+	hotStart := int64(math.MaxUint32) - 50
+	cms.GetPass("hot", hotStart, 0)
+
+	// push hot key past the boundary, triggering a slide
+	cms.GetPass("hot", 0, 200)
+
+	// cold key should have been dragged up to the new base
+	coldPassAfter := cms.GetPass("cold", 0, 0)
+	assert.Greater(t, coldPassAfter, coldPass, "cold key should have been dragged up")
+	assert.Equal(t, cms.base, coldPassAfter, "cold key should be at or above base")
+}
+
+func TestCMSketch_SlideBase_Headroom(t *testing.T) {
+	src := rand.NewPCG(rand.Uint64(), rand.Uint64())
+	cms := NewCMSketchCounter(CMSketchParams{W: 10, D: 3}, src, nil)
+
+	// push a key just past MaxUint32 to trigger a slide
+	startBase := int64(math.MaxUint32) + 1
+	cms.GetPass("key", startBase, 0)
+
+	// after sliding, there should be some headroom so we can do many more increments
+	// without another slide
+	baseBeforeIncs := cms.base
+	for range 1000 {
+		cms.GetPass("key", 0, 1000)
+	}
+	assert.Equal(t, baseBeforeIncs, cms.base, "base should not have changed after moderate increments")
+}
+
+func TestCMSketch_SlideBase_TargetBelowBase(t *testing.T) {
+	src := rand.NewPCG(rand.Uint64(), rand.Uint64())
+	cms := NewCMSketchCounter(CMSketchParams{W: 10, D: 3}, src, nil)
+
+	// push past MaxUint32 to establish a high base
+	highValue := int64(math.MaxUint32) + 1000
+	cms.GetPass("key", highValue, 0)
+	assert.Positive(t, cms.base)
+
+	// try to set a value below the base, should be a no-op
+	result := cms.GetPass("key", 100, 0) // base arg of 100 is below cms.base
+	assert.Equal(t, highValue, result, "should return current value, not the low base")
+
+	// new key with a low base should get dragged up to the current base
+	newKeyResult := cms.GetPass("newkey", 100, 0)
+	assert.Equal(t, cms.base, newKeyResult, "new key should be at base")
+}
+
+func TestCMSketch_SlideBase_MultipleSlides(t *testing.T) {
+	src := rand.NewPCG(rand.Uint64(), rand.Uint64())
+	cms := NewCMSketchCounter(CMSketchParams{W: 10, D: 3}, src, nil)
+
+	// do multiple slides by repeatedly jumping past the uint32 boundary
+	const jump = int64(math.MaxUint32 * 3 / 4)
+	var lastPass int64
+	for range 5 {
+		lastPass = cms.GetPass("key", lastPass+jump, 0)
+	}
+
+	// values should still be tracked correctly
+	assert.Equal(t, 5*jump, lastPass)
+}
+
+func TestCMSketch_SlideBase_LargeDelta(t *testing.T) {
+	src := rand.NewPCG(rand.Uint64(), rand.Uint64())
+	cms := NewCMSketchCounter(CMSketchParams{W: 10, D: 3}, src, nil)
+
+	// set a cell to some value
+	cms.GetPass("key1", 1000, 0)
+
+	const delta = int64(math.MaxUint32) + 1
+	cms.slideBase(delta)
+
+	// all cells should be zero
+	for _, val := range cms.cells {
+		assert.Zero(t, val)
+	}
+	assert.Equal(t, delta, cms.base)
+}


### PR DESCRIPTION
## What changed?
Use a sliding window for count-min sketch cells.

## Why?
Use less memory, or use more cells with the same memory.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Reduced accuracy in some extreme scenarios.