### PR TITLE
Move encode_value.go to sadefs

### DIFF
--- a/common/persistence/tests/visibility_persistence_suite.go
+++ b/common/persistence/tests/visibility_persistence_suite.go
@@ -1014,7 +1014,7 @@ func (s *VisibilityPersistenceSuite) TestCountGroupByWorkflowExecutions() {
 		)
 	}
 
-	runningStatusPayload, _ := searchattribute.EncodeValue(
+	runningStatusPayload, _ := sadefs.EncodeValue(
 		enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String(),
 		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	)

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -1043,7 +1043,7 @@ func (s *VisibilityStore) ParseESDoc(
 		fieldType, err := combinedTypeMap.GetType(fieldName)
 		if err != nil {
 			// Silently ignore ErrInvalidName because it indicates an unknown field in an Elasticsearch document.
-			if errors.Is(err, searchattribute.ErrInvalidName) {
+			if errors.Is(err, sadefs.ErrInvalidName) {
 				continue
 			}
 			metrics.ElasticsearchDocumentParseFailuresCount.With(s.metricsHandler).Record(1)
@@ -1190,7 +1190,7 @@ func (s *VisibilityStore) parseCountGroupByResponse(
 			if err != nil {
 				return fmt.Errorf("unable to parse value %v: %w", bucket["key"], err)
 			}
-			payload, err := searchattribute.EncodeValue(value, groupByTypes[index])
+			payload, err := sadefs.EncodeValue(value, groupByTypes[index])
 			if err != nil {
 				return fmt.Errorf("unable to encode value %v: %w", value, err)
 			}

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -86,7 +86,7 @@ var (
 )
 
 func mustEncodeValue(val any, valueType enumspb.IndexedValueType) *commonpb.Payload {
-	p, err := searchattribute.EncodeValue(val, valueType)
+	p, err := sadefs.EncodeValue(val, valueType)
 	if err != nil {
 		panic(fmt.Sprintf("failed to encode value %v: %v", val, err))
 	}

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -26,6 +26,7 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 )
 
 type (
@@ -711,7 +712,7 @@ func (s *VisibilityStore) countGroupByExecutions(
 	for _, row := range rows {
 		groupValues := make([]*commonpb.Payload, len(row.GroupValues))
 		for i, val := range row.GroupValues {
-			groupValues[i], err = searchattribute.EncodeValue(val, groupByTypes[i])
+			groupValues[i], err = sadefs.EncodeValue(val, groupByTypes[i])
 			if err != nil {
 				return nil, err
 			}
@@ -887,7 +888,7 @@ func (s *VisibilityStore) encodeRowSearchAttributes(
 	for name, value := range rowSearchAttributes {
 		tp, err := combinedTypeMap.GetType(name)
 		if err != nil {
-			if errors.Is(err, searchattribute.ErrInvalidName) {
+			if errors.Is(err, sadefs.ErrInvalidName) {
 				continue
 			}
 			return nil, err

--- a/common/searchattribute/encode.go
+++ b/common/searchattribute/encode.go
@@ -32,7 +32,7 @@ func Encode(searchAttributes map[string]any, typeMap *NameTypeMap) (*commonpb.Se
 		if typeMap != nil {
 			saType, err = typeMap.getType(saName, customCategory|predefinedCategory)
 			if err != nil {
-				if errors.Is(err, ErrInvalidName) {
+				if errors.Is(err, sadefs.ErrInvalidName) {
 					// Silently skip unknown search attributes. This can happen due to
 					// version mismatches where a newer server wrote a predefined SA
 					// that this server doesn't recognize.
@@ -72,7 +72,7 @@ func Decode(
 				if sadefs.IsChasmSearchAttribute(saName) {
 					// Chasm search attributes are not in the standard type map;
 					// allow them through with UNSPECIFIED type.
-				} else if errors.Is(err, ErrInvalidName) {
+				} else if errors.Is(err, sadefs.ErrInvalidName) {
 					// Silently skip unknown search attributes. This can happen due to
 					// version mismatches where a newer server wrote a predefined SA
 					// that this server doesn't recognize.
@@ -83,7 +83,7 @@ func Decode(
 			}
 		}
 
-		searchAttributeValue, err := DecodeValue(saPayload, saType, allowList)
+		searchAttributeValue, err := sadefs.DecodeValue(saPayload, saType, allowList)
 		if err != nil {
 			lastErr = err
 			result[saName] = nil

--- a/common/searchattribute/encode_test.go
+++ b/common/searchattribute/encode_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 )
 
 func Test_Encode_Success(t *testing.T) {
@@ -222,7 +223,7 @@ func Test_Decode_Error(t *testing.T) {
 
 	vals, err := Decode(sa, nil, true)
 	r.Error(err)
-	r.ErrorIs(err, ErrInvalidType)
+	r.ErrorIs(err, sadefs.ErrInvalidType)
 	r.Len(vals, 3)
 	r.Nil(vals["key1"])
 	r.Nil(vals["key2"])

--- a/common/searchattribute/name_type_map.go
+++ b/common/searchattribute/name_type_map.go
@@ -88,7 +88,7 @@ func (m NameTypeMap) getType(name string, cat category) (enumspb.IndexedValueTyp
 			return t, nil
 		}
 	}
-	return enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, fmt.Errorf("%w: %s", ErrInvalidName, name)
+	return enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, fmt.Errorf("%w: %s", sadefs.ErrInvalidName, name)
 }
 
 func (m NameTypeMap) IsDefined(name string) bool {

--- a/common/searchattribute/name_type_map_test.go
+++ b/common/searchattribute/name_type_map_test.go
@@ -1,15 +1,15 @@
 package searchattribute
 
 import (
-	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 )
 
 func Test_IsValid(t *testing.T) {
-	assert := assert.New(t)
+	r := require.New(t)
 	typeMap := NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
@@ -17,22 +17,22 @@ func Test_IsValid(t *testing.T) {
 	}}
 
 	isDefined := typeMap.IsDefined("RunId")
-	assert.True(isDefined)
+	r.True(isDefined)
 	isDefined = typeMap.IsDefined("TemporalChangeVersion")
-	assert.True(isDefined)
+	r.True(isDefined)
 	isDefined = typeMap.IsDefined("key1")
-	assert.True(isDefined)
+	r.True(isDefined)
 
 	isDefined = NameTypeMap{}.IsDefined("key1")
-	assert.False(isDefined)
+	r.False(isDefined)
 	isDefined = typeMap.IsDefined("key4")
-	assert.False(isDefined)
+	r.False(isDefined)
 	isDefined = typeMap.IsDefined("NamespaceId")
-	assert.False(isDefined)
+	r.False(isDefined)
 }
 
 func Test_GetType(t *testing.T) {
-	assert := assert.New(t)
+	r := require.New(t)
 	typeMap := NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
@@ -40,30 +40,30 @@ func Test_GetType(t *testing.T) {
 	}}
 
 	ivt, err := typeMap.GetType("key1")
-	assert.NoError(err)
-	assert.Equal(enumspb.INDEXED_VALUE_TYPE_TEXT, ivt)
+	r.NoError(err)
+	r.Equal(enumspb.INDEXED_VALUE_TYPE_TEXT, ivt)
 	ivt, err = typeMap.GetType("key2")
-	assert.NoError(err)
-	assert.Equal(enumspb.INDEXED_VALUE_TYPE_INT, ivt)
+	r.NoError(err)
+	r.Equal(enumspb.INDEXED_VALUE_TYPE_INT, ivt)
 	ivt, err = typeMap.GetType("key3")
-	assert.NoError(err)
-	assert.Equal(enumspb.INDEXED_VALUE_TYPE_BOOL, ivt)
+	r.NoError(err)
+	r.Equal(enumspb.INDEXED_VALUE_TYPE_BOOL, ivt)
 	ivt, err = typeMap.GetType("RunId")
-	assert.NoError(err)
-	assert.Equal(enumspb.INDEXED_VALUE_TYPE_KEYWORD, ivt)
+	r.NoError(err)
+	r.Equal(enumspb.INDEXED_VALUE_TYPE_KEYWORD, ivt)
 	ivt, err = typeMap.GetType("TemporalChangeVersion")
-	assert.NoError(err)
-	assert.Equal(enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, ivt)
+	r.NoError(err)
+	r.Equal(enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, ivt)
 	ivt, err = typeMap.GetType("NamespaceId")
-	assert.Error(err)
-	assert.Equal(enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, ivt)
+	r.Error(err)
+	r.Equal(enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, ivt)
 
 	ivt, err = NameTypeMap{}.GetType("key1")
-	assert.Error(err)
-	assert.True(errors.Is(err, ErrInvalidName))
-	assert.Equal(enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, ivt)
+	r.Error(err)
+	r.ErrorIs(err, sadefs.ErrInvalidName)
+	r.Equal(enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, ivt)
 	ivt, err = typeMap.GetType("key4")
-	assert.Error(err)
-	assert.True(errors.Is(err, ErrInvalidName))
-	assert.Equal(enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, ivt)
+	r.Error(err)
+	r.ErrorIs(err, sadefs.ErrInvalidName)
+	r.Equal(enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, ivt)
 }

--- a/common/searchattribute/sadefs/encode_value.go
+++ b/common/searchattribute/sadefs/encode_value.go
@@ -1,7 +1,6 @@
-package searchattribute
+package sadefs
 
 import (
-	"errors"
 	"fmt"
 	"time"
 	"unicode/utf8"
@@ -9,10 +8,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/payload"
-	"go.temporal.io/server/common/searchattribute/sadefs"
 )
-
-var ErrInvalidString = errors.New("SearchAttribute value is not a valid UTF-8 string")
 
 // EncodeValue encodes search attribute value and IndexedValueType to Payload.
 func EncodeValue(val any, t enumspb.IndexedValueType) (*commonpb.Payload, error) {
@@ -21,7 +17,7 @@ func EncodeValue(val any, t enumspb.IndexedValueType) (*commonpb.Payload, error)
 		return nil, err
 	}
 
-	sadefs.SetMetadataType(valPayload, t)
+	SetMetadataType(valPayload, t)
 	return valPayload, nil
 }
 
@@ -35,11 +31,10 @@ func DecodeValue(
 	allowList bool,
 ) (any, error) {
 	if t == enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED {
-		var err error
-		t, err = enumspb.IndexedValueTypeFromString(string(value.Metadata[MetadataType]))
-		if err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrInvalidType, t)
-		}
+		t = GetMetadataType(value)
+	}
+	if t == enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidType, t)
 	}
 
 	switch t {

--- a/common/searchattribute/sadefs/encode_value_test.go
+++ b/common/searchattribute/sadefs/encode_value_test.go
@@ -1,4 +1,4 @@
-package searchattribute
+package sadefs
 
 import (
 	"errors"

--- a/common/searchattribute/sadefs/errors.go
+++ b/common/searchattribute/sadefs/errors.go
@@ -1,0 +1,9 @@
+package sadefs
+
+import "errors"
+
+var (
+	ErrInvalidName   = errors.New("invalid search attribute name")
+	ErrInvalidType   = errors.New("invalid search attribute type")
+	ErrInvalidString = errors.New("SearchAttribute value is not a valid UTF-8 string")
+)

--- a/common/searchattribute/sadefs/util.go
+++ b/common/searchattribute/sadefs/util.go
@@ -11,6 +11,14 @@ const (
 	MetadataType = "type"
 )
 
+func GetMetadataType(p *commonpb.Payload) enumspb.IndexedValueType {
+	t, err := enumspb.IndexedValueTypeFromString(string(p.Metadata[MetadataType]))
+	if err != nil {
+		return enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED
+	}
+	return t
+}
+
 func SetMetadataType(p *commonpb.Payload, t enumspb.IndexedValueType) {
 	if t == enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED {
 		return
@@ -21,5 +29,5 @@ func SetMetadataType(p *commonpb.Payload, t enumspb.IndexedValueType) {
 		// nolint: forbidigo
 		panic(fmt.Sprintf("unknown index value type %v", t))
 	}
-	p.Metadata[MetadataType] = []byte(enumspb.IndexedValueType(t).String())
+	p.Metadata[MetadataType] = []byte(t.String())
 }

--- a/common/searchattribute/search_attirbute.go
+++ b/common/searchattribute/search_attirbute.go
@@ -4,7 +4,6 @@ package searchattribute
 
 import (
 	"context"
-	"errors"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -24,11 +23,6 @@ type (
 		Provider
 		SaveSearchAttributes(ctx context.Context, indexName string, newCustomSearchAttributes map[string]enumspb.IndexedValueType) error
 	}
-)
-
-var (
-	ErrInvalidName = errors.New("invalid search attribute name")
-	ErrInvalidType = errors.New("invalid search attribute type")
 )
 
 // ApplyTypeMap set type for all valid search attributes which don't have it.

--- a/common/searchattribute/stringify.go
+++ b/common/searchattribute/stringify.go
@@ -33,7 +33,7 @@ func Stringify(searchAttributes *commonpb.SearchAttributes, typeMap *NameTypeMap
 		if typeMap != nil {
 			saType, _ = typeMap.getType(saName, customCategory|predefinedCategory)
 		}
-		saValue, err := DecodeValue(saPayload, saType, true)
+		saValue, err := sadefs.DecodeValue(saPayload, saType, true)
 		if err != nil {
 			// If DecodeValue failed, save error and use raw JSON from Data field.
 			result[saName] = string(saPayload.GetData())
@@ -150,7 +150,7 @@ func parseValueTyped(valStr string, t enumspb.IndexedValueType) (any, error) {
 	case enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED:
 		val = parseValueUnspecified(valStr)
 	default:
-		err = fmt.Errorf("%w: %v", ErrInvalidType, t)
+		err = fmt.Errorf("%w: %v", sadefs.ErrInvalidType, t)
 	}
 
 	return val, err
@@ -212,6 +212,6 @@ func parseJSONArray(str string, t enumspb.IndexedValueType) (any, error) {
 		err := json.Unmarshal([]byte(str), &result)
 		return result, err
 	default:
-		return nil, fmt.Errorf("%w: %v", ErrInvalidType, t)
+		return nil, fmt.Errorf("%w: %v", sadefs.ErrInvalidType, t)
 	}
 }

--- a/common/searchattribute/stringify_test.go
+++ b/common/searchattribute/stringify_test.go
@@ -1,21 +1,25 @@
 package searchattribute
 
 import (
-	"errors"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 )
 
 type StringifySuite struct {
 	suite.Suite
+	*require.Assertions
 }
 
 func TestStringifySuite(t *testing.T) {
-	s := &StringifySuite{}
+	s := &StringifySuite{
+		Assertions: require.New(t),
+	}
 	suite.Run(t, s)
 }
 
@@ -66,7 +70,7 @@ func (s *StringifySuite) Test_Stringify() {
 	// Even w/o typeMap error is returned but string values are set with  raw JSON from GetData().
 	saStr, err = Stringify(sa, nil)
 	s.Error(err)
-	s.True(errors.Is(err, ErrInvalidType))
+	s.ErrorIs(err, sadefs.ErrInvalidType)
 	s.Len(saStr, 3)
 	s.Equal(`"val1"`, saStr["key1"])
 	s.Equal("2", saStr["key2"])
@@ -111,7 +115,7 @@ func (s *StringifySuite) Test_Stringify_Array() {
 	// Even w/o typeMap error is returned but string values are set with  raw JSON from GetData().
 	saStr, err = Stringify(sa, nil)
 	s.Error(err)
-	s.True(errors.Is(err, ErrInvalidType))
+	s.ErrorIs(err, sadefs.ErrInvalidType)
 	s.Len(saStr, 3)
 	s.Equal(`["val1","val2"]`, saStr["key1"])
 	s.Equal("[2,3,4]", saStr["key2"])

--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -96,7 +96,7 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 
 		saType, err := saTypeMap.getType(saFieldName, customCategory|predefinedCategory)
 		if err != nil {
-			if errors.Is(err, ErrInvalidName) {
+			if errors.Is(err, sadefs.ErrInvalidName) {
 				return v.validationError(
 					"search attribute %s is not defined",
 					saFieldName,
@@ -120,7 +120,7 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 				)
 			}
 		}
-		saValue, err := DecodeValue(saPayload, saType, v.allowList(namespace))
+		saValue, err := sadefs.DecodeValue(saPayload, saType, v.allowList(namespace))
 		if err != nil {
 			var invalidValue any
 			if err = payload.Decode(saPayload, &invalidValue); err != nil {

--- a/service/history/api/command_attr_validator_test.go
+++ b/service/history/api/command_attr_validator_test.go
@@ -194,7 +194,7 @@ func (s *commandAttrValidatorSuite) TestValidateUpsertWorkflowSearchAttributes()
 	s.EqualError(err, "IndexedFields is not set on UpsertWorkflowSearchAttributesCommand.")
 	s.Equal(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SEARCH_ATTRIBUTES, fc)
 
-	saPayload, err := searchattribute.EncodeValue("bytes", enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+	saPayload, err := sadefs.EncodeValue("bytes", enumspb.INDEXED_VALUE_TYPE_KEYWORD)
 	s.NoError(err)
 	attributes.SearchAttributes.IndexedFields = map[string]*commonpb.Payload{
 		"Keyword01": saPayload,
@@ -286,7 +286,7 @@ func (s *commandAttrValidatorSuite) TestValidateContinueAsNewWorkflowExecutionAt
 	s.Equal(maxWorkflowTaskStartToCloseTimeout, attributes.GetWorkflowTaskTimeout().AsDuration())
 
 	// Predefined Worker-Deployment related SA's should be rejected when they are attempted to be set during CAN
-	saPayload, _ := searchattribute.EncodeValue([]string{"a"}, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+	saPayload, _ := sadefs.EncodeValue([]string{"a"}, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
 	attributes.SearchAttributes = &commonpb.SearchAttributes{}
 
 	deploymentRestrictedAttributes := []string{

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -55,7 +55,6 @@ import (
 	"go.temporal.io/server/common/persistence/transitionhistory"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
-	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/softassert"
@@ -3320,7 +3319,7 @@ func (ms *MutableStateImpl) updateBinaryChecksumSearchAttribute() error {
 			recentBinaryChecksums = append(recentBinaryChecksums, rp.BinaryChecksum)
 		}
 	}
-	checksumsPayload, err := searchattribute.EncodeValue(recentBinaryChecksums, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
+	checksumsPayload, err := sadefs.EncodeValue(recentBinaryChecksums, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
 	if err != nil {
 		return err
 	}
@@ -3516,7 +3515,7 @@ func (ms *MutableStateImpl) loadBuildIds() ([]string, error) {
 	if !found {
 		return []string{}, nil
 	}
-	decoded, err := searchattribute.DecodeValue(saPayload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
+	decoded, err := sadefs.DecodeValue(saPayload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
 	if err != nil {
 		return nil, err
 	}
@@ -3539,7 +3538,7 @@ func (ms *MutableStateImpl) loadSearchAttributeString(saName string) (string, er
 	if !found {
 		return "", nil
 	}
-	decoded, err := searchattribute.DecodeValue(saPayload, enumspb.INDEXED_VALUE_TYPE_KEYWORD, false)
+	decoded, err := sadefs.DecodeValue(saPayload, enumspb.INDEXED_VALUE_TYPE_KEYWORD, false)
 	if err != nil {
 		return "", err
 	}
@@ -3562,7 +3561,7 @@ func (ms *MutableStateImpl) loadUsedDeploymentVersions() ([]string, error) {
 	if !found {
 		return []string{}, nil
 	}
-	decoded, err := searchattribute.DecodeValue(saPayload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
+	decoded, err := sadefs.DecodeValue(saPayload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
 	if err != nil {
 		return nil, err
 	}
@@ -3665,7 +3664,7 @@ func (ms *MutableStateImpl) saveBuildIds(buildIds []string, maxSearchAttributeVa
 		hasUnversionedOrAssigned = worker_versioning.IsUnversionedOrAssignedBuildIdSearchAttribute(buildIds[0])
 	}
 	for {
-		saPayload, err := searchattribute.EncodeValue(buildIds, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
+		saPayload, err := sadefs.EncodeValue(buildIds, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
 		if err != nil {
 			return err
 		}
@@ -3693,7 +3692,7 @@ func (ms *MutableStateImpl) saveUsedDeploymentVersions(usedDeploymentVersions []
 	}
 
 	for {
-		saPayload, err := searchattribute.EncodeValue(usedDeploymentVersions, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
+		saPayload, err := sadefs.EncodeValue(usedDeploymentVersions, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
 		if err != nil {
 			return err
 		}
@@ -3721,7 +3720,7 @@ func (ms *MutableStateImpl) saveDeploymentSearchAttributes(deployment, version, 
 	if deployment == "" {
 		saPayloads[sadefs.TemporalWorkerDeployment] = nil
 	} else {
-		deploymentPayload, err := searchattribute.EncodeValue(deployment, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+		deploymentPayload, err := sadefs.EncodeValue(deployment, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
 		if err != nil {
 			return err
 		}
@@ -3733,7 +3732,7 @@ func (ms *MutableStateImpl) saveDeploymentSearchAttributes(deployment, version, 
 		saPayloads[sadefs.TemporalWorkerDeploymentVersion] = nil
 	} else {
 		saPayloads[sadefs.TemporalWorkerDeploymentVersion] = nil
-		versionPayload, err := searchattribute.EncodeValue(version, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+		versionPayload, err := sadefs.EncodeValue(version, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
 		if err != nil {
 			return err
 		}
@@ -3744,7 +3743,7 @@ func (ms *MutableStateImpl) saveDeploymentSearchAttributes(deployment, version, 
 	if behavior == "" {
 		saPayloads[sadefs.TemporalWorkflowVersioningBehavior] = nil
 	} else {
-		behaviorPayload, err := searchattribute.EncodeValue(behavior, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+		behaviorPayload, err := sadefs.EncodeValue(behavior, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
 		if err != nil {
 			return err
 		}
@@ -6449,7 +6448,7 @@ func (ms *MutableStateImpl) buildTemporalPauseInfoEntries() []string {
 func (ms *MutableStateImpl) updatePauseInfoSearchAttribute() error {
 	allEntries := ms.buildTemporalPauseInfoEntries()
 
-	pauseInfoPayload, err := searchattribute.EncodeValue(allEntries, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
+	pauseInfoPayload, err := sadefs.EncodeValue(allEntries, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
 	if err != nil {
 		return err
 	}
@@ -6482,7 +6481,7 @@ func (ms *MutableStateImpl) UpdateReportedProblemsSearchAttribute() error {
 		}
 	}
 
-	reportedProblemsPayload, err := searchattribute.EncodeValue(reportedProblems, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
+	reportedProblemsPayload, err := sadefs.EncodeValue(reportedProblems, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
 	if err != nil {
 		return err
 	}
@@ -6492,7 +6491,7 @@ func (ms *MutableStateImpl) UpdateReportedProblemsSearchAttribute() error {
 		exeInfo.SearchAttributes = make(map[string]*commonpb.Payload, 1)
 	}
 
-	decodedA, err := searchattribute.DecodeValue(exeInfo.SearchAttributes[sadefs.TemporalReportedProblems], enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, false)
+	decodedA, err := sadefs.DecodeValue(exeInfo.SearchAttributes[sadefs.TemporalReportedProblems], enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, false)
 	if err != nil {
 		return err
 	}
@@ -6558,7 +6557,7 @@ func (ms *MutableStateImpl) decodeReportedProblems(p *commonpb.Payload) []string
 		return nil
 	}
 
-	decoded, err := searchattribute.DecodeValue(p, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, false)
+	decoded, err := sadefs.DecodeValue(p, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, false)
 	if err != nil {
 		ms.logger.Error("Failed to decode TemporalReportedProblems payload for logging",
 			tag.Error(err))

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -44,7 +44,6 @@ import (
 	"go.temporal.io/server/common/persistence/transitionhistory"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
-	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	serviceerror2 "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/testing/fakedata"
@@ -3917,7 +3916,7 @@ func (s *mutableStateSuite) getBuildIdsFromMutableState() []string {
 	if !found {
 		return []string{}
 	}
-	decoded, err := searchattribute.DecodeValue(payload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
+	decoded, err := sadefs.DecodeValue(payload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
 	s.NoError(err)
 	buildIDs, ok := decoded.([]string)
 	s.True(ok)
@@ -3929,7 +3928,7 @@ func (s *mutableStateSuite) getUsedDeploymentVersionsFromMutableState() []string
 	if !found {
 		return []string{}
 	}
-	decoded, err := searchattribute.DecodeValue(payload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
+	decoded, err := sadefs.DecodeValue(payload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
 	s.NoError(err)
 	usedDeploymentVersions, ok := decoded.([]string)
 	s.True(ok)

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -963,11 +963,11 @@ func (s *AdvancedVisibilitySuite) TestCountGroupByWorkflow() {
 	s.Equal(int64(numWorkflows), resp.GetCount())
 	s.Len(resp.Groups, 2)
 
-	runningStatusPayload, _ := searchattribute.EncodeValue(
+	runningStatusPayload, _ := sadefs.EncodeValue(
 		enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String(),
 		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	)
-	terminatedStatusPayload, _ := searchattribute.EncodeValue(
+	terminatedStatusPayload, _ := sadefs.EncodeValue(
 		enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED.String(),
 		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	)

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -37,7 +37,7 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/primitives/timestamp"
-	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/protoutils"
 	"go.temporal.io/server/common/testing/taskpoller"
 	"go.temporal.io/server/common/testing/testhooks"
@@ -4270,7 +4270,7 @@ func (s *Versioning3Suite) verifyVersioningSAs(
 			if behavior == vbPinned {
 				payload, ok := w.GetSearchAttributes().GetIndexedFields()["BuildIds"]
 				a.True(ok)
-				searchAttrAny, err := searchattribute.DecodeValue(payload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
+				searchAttrAny, err := sadefs.DecodeValue(payload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
 				a.NoError(err)
 				var searchAttr []string
 				if searchAttrAny != nil {
@@ -4285,7 +4285,7 @@ func (s *Versioning3Suite) verifyVersioningSAs(
 				// Validate TemporalUsedWorkerDeploymentVersions search attribute
 				versionPayload, ok := w.GetSearchAttributes().GetIndexedFields()["TemporalUsedWorkerDeploymentVersions"]
 				a.True(ok)
-				versionAttrAny, err := searchattribute.DecodeValue(versionPayload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
+				versionAttrAny, err := sadefs.DecodeValue(versionPayload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
 				a.NoError(err)
 				var versionAttr []string
 				if versionAttrAny != nil {

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -31,7 +31,7 @@ import (
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/dynamicconfig"
-	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/worker_versioning"
 	"go.temporal.io/server/tests/testcore"
@@ -5023,7 +5023,7 @@ func (s *VersioningIntegSuite) validateWorkflowBuildIds(
 	dw, err := s.SdkClient().DescribeWorkflowExecution(ctx, wfId, runId)
 	s.NoError(err)
 	saPayload := dw.GetWorkflowExecutionInfo().GetSearchAttributes().GetIndexedFields()["BuildIds"]
-	searchAttrAny, err := searchattribute.DecodeValue(saPayload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
+	searchAttrAny, err := sadefs.DecodeValue(saPayload, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, true)
 	var searchAttr []string
 	if searchAttrAny != nil {
 		searchAttr = searchAttrAny.([]string)


### PR DESCRIPTION
## What changed?
Move `encode_value.go` to `sadefs`.

## Why?
Use in CHASM without circular dependency.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
