### PR TITLE
Publish metrics for storage drivers types in worker heartbeat

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -2,34 +2,35 @@ package metrics
 
 // Common tags for all services
 const (
-	OperationTagName            = "operation"
-	ServiceRoleTagName          = "service_role"
-	CacheTypeTagName            = "cache_type"
-	FailureTagName              = "failure"
-	FailureSourceTagName        = "failure_source"
-	TaskCategoryTagName         = "task_category"
-	TaskTypeTagName             = "task_type"
-	TaskPriorityTagName         = "task_priority"
-	QueueReaderIDTagName        = "queue_reader_id"
-	QueueActionTagName          = "queue_action"
-	QueueTypeTagName            = "queue_type"
-	visibilityPluginNameTagName = "visibility_plugin_name"
-	visibilityIndexNameTagName  = "visibility_index_name"
-	ErrorTypeTagName            = "error_type"
-	httpStatusTagName           = "http_status"
-	nexusMethodTagName          = "method"
-	nexusEndpointTagName        = "nexus_endpoint"
-	nexusServiceTagName         = "nexus_service"
-	nexusOperationTagName       = "nexus_operation"
-	outcomeTagName              = "outcome"
-	versionedTagName            = "versioned"
-	resourceExhaustedTag        = "resource_exhausted_cause"
-	resourceExhaustedScopeTag   = "resource_exhausted_scope"
-	PartitionTagName            = "partition"
-	PriorityTagName             = "priority"
-	PersistenceDBKindTagName    = "db_kind"
-	WorkerPluginNameTagName     = "worker_plugin_name"
-	headerCallsiteTagName       = "header_callsite"
+	OperationTagName               = "operation"
+	ServiceRoleTagName             = "service_role"
+	CacheTypeTagName               = "cache_type"
+	FailureTagName                 = "failure"
+	FailureSourceTagName           = "failure_source"
+	TaskCategoryTagName            = "task_category"
+	TaskTypeTagName                = "task_type"
+	TaskPriorityTagName            = "task_priority"
+	QueueReaderIDTagName           = "queue_reader_id"
+	QueueActionTagName             = "queue_action"
+	QueueTypeTagName               = "queue_type"
+	visibilityPluginNameTagName    = "visibility_plugin_name"
+	visibilityIndexNameTagName     = "visibility_index_name"
+	ErrorTypeTagName               = "error_type"
+	httpStatusTagName              = "http_status"
+	nexusMethodTagName             = "method"
+	nexusEndpointTagName           = "nexus_endpoint"
+	nexusServiceTagName            = "nexus_service"
+	nexusOperationTagName          = "nexus_operation"
+	outcomeTagName                 = "outcome"
+	versionedTagName               = "versioned"
+	resourceExhaustedTag           = "resource_exhausted_cause"
+	resourceExhaustedScopeTag      = "resource_exhausted_scope"
+	PartitionTagName               = "partition"
+	PriorityTagName                = "priority"
+	PersistenceDBKindTagName       = "db_kind"
+	WorkerPluginNameTagName        = "worker_plugin_name"
+	WorkerStorageDriverTypeTagName = "worker_storage_driver_type"
+	headerCallsiteTagName          = "header_callsite"
 )
 
 // This package should hold all the metrics and tags for temporal
@@ -1217,6 +1218,14 @@ var (
 		"worker_plugin_name",
 		WithDescription(
 			"Set if the worker was configured with a plugin. Dimensions: namespace, plugin_name"),
+	)
+
+	// ----------------------------------------------------------------------------------------------------------------
+	// Matching service: Metrics to understand storage driver adoption.
+	WorkerStorageDriverTypeMetric = NewGaugeDef(
+		"worker_storage_driver_type",
+		WithDescription(
+			"Set if the worker was configured with a storage driver. Dimensions: namespace, storage_driver_type."),
 	)
 	// ----------------------------------------------------------------------------------------------------------------
 	// Matching service: Metrics to understand poller autoscaling adoption.

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -321,6 +321,10 @@ func WorkerPluginNameTag(value string) Tag {
 	return Tag{Key: WorkerPluginNameTagName, Value: value}
 }
 
+func WorkerStorageDriverTypeTag(value string) Tag {
+	return Tag{Key: WorkerStorageDriverTypeTagName, Value: value}
+}
+
 // VersionedTag represents whether a loaded task queue manager represents a specific version set or build ID or not.
 func VersionedTag(versioned string) Tag {
 	return Tag{Key: versionedTagName, Value: versioned}

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -57,6 +57,7 @@ type (
 		BreakdownMetricsByBuildID                dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 		EnableWorkerPluginMetrics                dynamicconfig.BoolPropertyFn
 		EnablePollerAutoscalingMetrics           dynamicconfig.BoolPropertyFn
+		ExternalPayloadsEnabled                  dynamicconfig.BoolPropertyFnWithNamespaceFilter
 		WorkerRegistryNumBuckets                 dynamicconfig.IntPropertyFn
 		WorkerRegistryEntryTTL                   dynamicconfig.DurationPropertyFn
 		WorkerRegistryMinEvictAge                dynamicconfig.DurationPropertyFn
@@ -296,6 +297,7 @@ func NewConfig(
 		BreakdownMetricsByBuildID:                dynamicconfig.MetricsBreakdownByBuildID.Get(dc),
 		EnableWorkerPluginMetrics:                dynamicconfig.MatchingEnableWorkerPluginMetrics.Get(dc),
 		EnablePollerAutoscalingMetrics:           dynamicconfig.MatchingEnablePollerAutoscalingMetrics.Get(dc),
+		ExternalPayloadsEnabled:                  dynamicconfig.ExternalPayloadsEnabled.Get(dc),
 		WorkerRegistryNumBuckets:                 dynamicconfig.MatchingWorkerRegistryNumBuckets.Get(dc),
 		WorkerRegistryEntryTTL:                   dynamicconfig.MatchingWorkerRegistryEntryTTL.Get(dc),
 		WorkerRegistryMinEvictAge:                dynamicconfig.MatchingWorkerRegistryMinEvictAge.Get(dc),

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -209,6 +209,7 @@ func WorkersRegistryProvider(
 			EnablePluginMetrics:            serviceConfig.EnableWorkerPluginMetrics,
 			EnablePollerAutoscalingMetrics: serviceConfig.EnablePollerAutoscalingMetrics,
 			BreakdownMetricsByTaskQueue:    serviceConfig.BreakdownMetricsByTaskQueue,
+			ExternalPayloadsEnabled:        serviceConfig.ExternalPayloadsEnabled,
 		},
 	})
 }

--- a/service/matching/workers/registry_test.go
+++ b/service/matching/workers/registry_test.go
@@ -10,6 +10,7 @@ import (
 	workerpb "go.temporal.io/api/worker/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
 )
 
@@ -20,6 +21,21 @@ const (
 	testDefaultMaxEntries       = 1_000_000
 	testDefaultEvictionInterval = 10 * time.Minute
 )
+
+func testDefaultRegistryParams(handler metrics.Handler) RegistryParams {
+	return RegistryParams{
+		NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
+		TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
+		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
+		MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
+		EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
+		MetricsHandler:   handler,
+		MetricsConfig: WorkerMetricsConfig{
+			EnablePluginMetrics:     dynamicconfig.GetBoolPropertyFn(true),
+			ExternalPayloadsEnabled: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		},
+	}
+}
 
 func TestRegistryImpl_RecordWorkerHeartbeat(t *testing.T) {
 	tests := []struct {
@@ -78,17 +94,7 @@ func TestRegistryImpl_RecordWorkerHeartbeat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := newRegistryImpl(RegistryParams{
-				NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
-				TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-				MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-				MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-				EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-				MetricsHandler:   metrics.NoopMetricsHandler,
-				MetricsConfig: WorkerMetricsConfig{
-					EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
-				},
-			})
+			r := newRegistryImpl(testDefaultRegistryParams(metrics.NoopMetricsHandler))
 			tt.setup(r)
 
 			r.RecordWorkerHeartbeats(tt.nsID, namespace.Name(tt.nsID+"_name"), []*workerpb.WorkerHeartbeat{tt.workerHeartbeat})
@@ -184,17 +190,7 @@ func TestRegistryImpl_ListWorkers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := newRegistryImpl(RegistryParams{
-				NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
-				TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-				MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-				MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-				EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-				MetricsHandler:   metrics.NoopMetricsHandler,
-				MetricsConfig: WorkerMetricsConfig{
-					EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
-				},
-			})
+			r := newRegistryImpl(testDefaultRegistryParams(metrics.NoopMetricsHandler))
 			tt.setup(r)
 
 			resp, err := r.ListWorkers(tt.nsID, ListWorkersParams{})
@@ -316,17 +312,7 @@ func TestRegistryImpl_ListWorkersWithQuery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := newRegistryImpl(RegistryParams{
-				NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
-				TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-				MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-				MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-				EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-				MetricsHandler:   metrics.NoopMetricsHandler,
-				MetricsConfig: WorkerMetricsConfig{
-					EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
-				},
-			})
+			r := newRegistryImpl(testDefaultRegistryParams(metrics.NoopMetricsHandler))
 			tt.setup(r)
 
 			resp, err := r.ListWorkers(tt.nsID, ListWorkersParams{Query: tt.query})
@@ -428,17 +414,7 @@ func TestRegistryImpl_DescribeWorker(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := newRegistryImpl(RegistryParams{
-				NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
-				TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-				MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-				MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-				EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-				MetricsHandler:   metrics.NoopMetricsHandler,
-				MetricsConfig: WorkerMetricsConfig{
-					EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
-				},
-			})
+			r := newRegistryImpl(testDefaultRegistryParams(metrics.NoopMetricsHandler))
 			tt.setup(r)
 
 			result, err := r.DescribeWorker(tt.nsID, tt.workerInstanceKey)
@@ -455,17 +431,7 @@ func TestRegistryImpl_DescribeWorker(t *testing.T) {
 }
 
 func TestRegistryImpl_ListWorkersPagination(t *testing.T) {
-	r := newRegistryImpl(RegistryParams{
-		NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
-		TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-		MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-		EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-		MetricsHandler:   metrics.NoopMetricsHandler,
-		MetricsConfig: WorkerMetricsConfig{
-			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
-		},
-	})
+	r := newRegistryImpl(testDefaultRegistryParams(metrics.NoopMetricsHandler))
 
 	// Add 5 workers in non-sorted order to verify sorting works
 	r.upsertHeartbeats("ns1", []*workerpb.WorkerHeartbeat{
@@ -561,17 +527,7 @@ func TestRegistryImpl_ListWorkersPaginationWithDeletedCursor(t *testing.T) {
 }
 
 func TestRegistryImpl_ListWorkersNoPagination(t *testing.T) {
-	r := newRegistryImpl(RegistryParams{
-		NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
-		TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-		MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-		EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-		MetricsHandler:   metrics.NoopMetricsHandler,
-		MetricsConfig: WorkerMetricsConfig{
-			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
-		},
-	})
+	r := newRegistryImpl(testDefaultRegistryParams(metrics.NoopMetricsHandler))
 
 	r.upsertHeartbeats("ns1", []*workerpb.WorkerHeartbeat{
 		{WorkerInstanceKey: "worker-a"},
@@ -587,17 +543,7 @@ func TestRegistryImpl_ListWorkersNoPagination(t *testing.T) {
 }
 
 func TestRegistryImpl_ListWorkersInvalidPageToken(t *testing.T) {
-	r := newRegistryImpl(RegistryParams{
-		NumBuckets:       dynamicconfig.GetIntPropertyFn(10),
-		TTL:              dynamicconfig.GetDurationPropertyFn(testDefaultEntryTTL),
-		MinEvictAge:      dynamicconfig.GetDurationPropertyFn(testDefaultMinEvictAge),
-		MaxItems:         dynamicconfig.GetIntPropertyFn(testDefaultMaxEntries),
-		EvictionInterval: dynamicconfig.GetDurationPropertyFn(testDefaultEvictionInterval),
-		MetricsHandler:   metrics.NoopMetricsHandler,
-		MetricsConfig: WorkerMetricsConfig{
-			EnablePluginMetrics: dynamicconfig.GetBoolPropertyFn(true),
-		},
-	})
+	r := newRegistryImpl(testDefaultRegistryParams(metrics.NoopMetricsHandler))
 
 	r.upsertHeartbeats("ns1", []*workerpb.WorkerHeartbeat{
 		{WorkerInstanceKey: "worker-a"},
@@ -606,4 +552,74 @@ func TestRegistryImpl_ListWorkersInvalidPageToken(t *testing.T) {
 	_, err := r.ListWorkers("ns1", ListWorkersParams{PageSize: 2, NextPageToken: []byte("invalid-json")})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid next_page_token")
+}
+
+func TestRegistryImpl_RecordStorageDriverMetric(t *testing.T) {
+	t.Run("disabled when ExternalPayloadsEnabled is false", func(t *testing.T) {
+		captureHandler := metricstest.NewCaptureHandler()
+		capture := captureHandler.StartCapture()
+		defer captureHandler.StopCapture(capture)
+
+		params := testDefaultRegistryParams(captureHandler)
+		r := newRegistryImpl(params)
+
+		r.metricsEmitter.emit(namespace.ID("test-ns-id"), namespace.Name("test-ns"), []*workerpb.WorkerHeartbeat{
+			{
+				WorkerInstanceKey: "worker1",
+				Drivers:           []*workerpb.StorageDriverInfo{{Type: "s3"}},
+			},
+		})
+
+		snap := capture.Snapshot()
+		assert.Empty(t, snap["worker_storage_driver_type"], "no metrics should be emitted when external payloads is disabled")
+	})
+
+	t.Run("emits storage driver type when enabled", func(t *testing.T) {
+		captureHandler := metricstest.NewCaptureHandler()
+		capture := captureHandler.StartCapture()
+		defer captureHandler.StopCapture(capture)
+
+		params := testDefaultRegistryParams(captureHandler)
+		params.MetricsConfig.ExternalPayloadsEnabled = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
+		r := newRegistryImpl(params)
+
+		r.metricsEmitter.emit(namespace.ID("test-ns-id"), namespace.Name("test-ns"), []*workerpb.WorkerHeartbeat{
+			{
+				WorkerInstanceKey: "worker1",
+				Drivers:           []*workerpb.StorageDriverInfo{{Type: "s3"}},
+			},
+		})
+
+		snap := capture.Snapshot()
+		recordings := snap["worker_storage_driver_type"]
+		require.Len(t, recordings, 1)
+		assert.Equal(t, "s3", recordings[0].Tags["worker_storage_driver_type"])
+		assert.Equal(t, "test-ns", recordings[0].Tags["namespace"])
+	})
+
+	t.Run("deduplication across heartbeats", func(t *testing.T) {
+		captureHandler := metricstest.NewCaptureHandler()
+		capture := captureHandler.StartCapture()
+		defer captureHandler.StopCapture(capture)
+
+		params := testDefaultRegistryParams(captureHandler)
+		params.MetricsConfig.ExternalPayloadsEnabled = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
+		r := newRegistryImpl(params)
+
+		r.metricsEmitter.emit(namespace.ID("test-ns-id"), namespace.Name("test-ns"), []*workerpb.WorkerHeartbeat{
+			{
+				WorkerInstanceKey: "worker1",
+				Drivers:           []*workerpb.StorageDriverInfo{{Type: "s3"}},
+			},
+			{
+				WorkerInstanceKey: "worker2",
+				Drivers:           []*workerpb.StorageDriverInfo{{Type: "s3"}},
+			},
+		})
+
+		snap := capture.Snapshot()
+		recordings := snap["worker_storage_driver_type"]
+		require.Len(t, recordings, 1, "same driver type from multiple heartbeats should produce a single metric")
+		assert.Equal(t, "s3", recordings[0].Tags["worker_storage_driver_type"])
+	})
 }

--- a/service/matching/workers/worker_metrics_emitter.go
+++ b/service/matching/workers/worker_metrics_emitter.go
@@ -14,6 +14,7 @@ type WorkerMetricsConfig struct {
 	EnablePluginMetrics            dynamicconfig.BoolPropertyFn
 	EnablePollerAutoscalingMetrics dynamicconfig.BoolPropertyFn
 	BreakdownMetricsByTaskQueue    dynamicconfig.BoolPropertyFnWithTaskQueueFilter
+	ExternalPayloadsEnabled        dynamicconfig.BoolPropertyFnWithNamespaceFilter
 }
 
 // workerMetricsEmitter encapsulates logic for emitting metrics derived from worker heartbeats.
@@ -25,8 +26,10 @@ type workerMetricsEmitter struct {
 func (e *workerMetricsEmitter) emit(nsID namespace.ID, nsName namespace.Name, heartbeats []*workerpb.WorkerHeartbeat) {
 	enablePluginMetrics := e.config.EnablePluginMetrics != nil && e.config.EnablePluginMetrics()
 	enablePollerAutoscalingMetrics := e.config.EnablePollerAutoscalingMetrics != nil && e.config.EnablePollerAutoscalingMetrics()
+	enableStorageDriverMetrics := e.config.ExternalPayloadsEnabled != nil && e.config.ExternalPayloadsEnabled(nsName.String())
 
 	recordedPlugins := make(map[string]bool)
+	recordedDrivers := make(map[string]bool)
 
 	for _, hb := range heartbeats {
 		// Activity slots metric (always enabled)
@@ -50,6 +53,19 @@ func (e *workerMetricsEmitter) emit(nsID namespace.ID, nsName namespace.Name, he
 		// Poller autoscaling metrics (if enabled)
 		if enablePollerAutoscalingMetrics {
 			e.emitPollerAutoscaling(nsID, nsName, hb)
+		}
+
+		// Storage driver metrics (if external payloads enabled)
+		if enableStorageDriverMetrics {
+			for _, driver := range hb.GetDrivers() {
+				driverType := driver.GetType()
+				if !recordedDrivers[driverType] {
+					metrics.WorkerStorageDriverTypeMetric.
+						With(e.handler).
+						Record(1, metrics.NamespaceTag(nsName.String()), metrics.WorkerStorageDriverTypeTag(driverType))
+					recordedDrivers[driverType] = true
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What changed?
Publish metrics for storage driver types that are passed from SDK through worker heartbeat. This is only enabled if ExternalPayloadsEnabled is set to true.

## Why?
SDK sends the storage driver types used for storing large external payloads. We'd like to publish them as metrics in order to gauge the usage.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
High metric cardinality for Temporal Cloud, so should be logged to Chronicle.
