### PR TITLE
Cherry-pick: Retract v1.30.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.temporal.io/server
 go 1.25.7
 
 retract (
+	v1.30.0
 	v1.26.1 // Contains retractions only.
 	v1.26.0 // Published accidentally.
 )


### PR DESCRIPTION
Cherry-pick of #9245 into `release/v1.30.x`.