### PR TITLE
Add Omes timeout to Mixed Brain

### DIFF
--- a/tests/mixedbrain/mixed_brain_test.go
+++ b/tests/mixedbrain/mixed_brain_test.go
@@ -156,6 +156,7 @@ func runOmes(t *testing.T, binary, serverAddr, logPath string, duration time.Dur
 
 		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 		require.NoError(t, err)
+
 		var buf bytes.Buffer
 		cmd := exec.CommandContext(t.Context(), binary,
 			"run-scenario-with-worker",
@@ -163,6 +164,7 @@ func runOmes(t *testing.T, binary, serverAddr, logPath string, duration time.Dur
 			"--language", "go",
 			"--server-address", serverAddr,
 			"--duration", remaining.String(),
+			"--timeout", (remaining + 2*time.Minute).String(), // with grace period to complete
 			"--run-id", runID,
 			"--max-concurrent", "5",
 			"--option", "internal-iterations=10",


### PR DESCRIPTION
## What changed?

Add timeout to Omes in Mixed Brain test.

## Why?

In [this run](https://github.com/temporalio/temporal/actions/runs/22877745566/job/66373674464?pr=9288) it took 18m for the error to surface. No need to wait that long.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

