### PR TITLE
Move ForceLoadAllChildPartitions into partition manager

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -431,26 +431,12 @@ func (e *matchingEngineImpl) getTaskQueuePartitionManager(
 	create bool,
 	loadCause loadCause,
 ) (retPM taskQueuePartitionManager, retCreated bool, retErr error) {
-	var newPM *taskQueuePartitionManagerImpl
-
 	defer func() {
 		if retErr != nil || retPM == nil {
 			return
 		}
-
 		if retErr = retPM.WaitUntilInitialized(ctx); retErr != nil {
 			e.unloadTaskQueuePartition(retPM, unloadCauseInitError)
-			return
-		}
-
-		if retCreated {
-			// Whenever a root partition is loaded, we need to force all child partitions to load.
-			// If there is a backlog of tasks on any child partitions, force loading will ensure
-			// that they can forward their tasks the poller which caused the root partition to be
-			// loaded. These partitions could be managed by this matchingEngineImpl, but are most
-			// likely not. We skip checking and just make gRPC requests to force loading them all.
-			// Note that if retCreated is true, retPM must be newPM, so we can use newPM here.
-			newPM.ForceLoadAllChildPartitions()
 		}
 	}()
 
@@ -471,6 +457,7 @@ func (e *matchingEngineImpl) getTaskQueuePartitionManager(
 		return nil, false, err
 	}
 
+	var newPM *taskQueuePartitionManagerImpl
 	tqConfig := newTaskQueueConfig(partition.TaskQueue(), e.config, namespaceEntry.Name())
 	tqConfig.loadCause = loadCause
 	logger, throttledLogger, metricsHandler := e.loggerAndMetricsForPartition(namespaceEntry, partition, tqConfig)

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -145,7 +145,9 @@ func newTaskQueuePartitionManager(
 }
 
 func (pm *taskQueuePartitionManagerImpl) initialize() (retErr error) {
+	defer pm.initCancel()
 	defer func() { pm.defaultQueueFuture.SetIfNotReady(nil, retErr) }()
+
 	unload := func(bool) {
 		pm.unloadFromEngine(unloadCauseConfigChange)
 	}
@@ -199,6 +201,15 @@ func (pm *taskQueuePartitionManagerImpl) initialize() (retErr error) {
 	defaultQ.Start()
 	pm.goroGroup.Go(pm.updateEphemeralData)
 	pm.goroGroup.Go(pm.emitLogicalBacklogMetrics)
+
+	// Whenever a root partition is loaded, we need to force all child partitions to load.
+	// If there is a backlog of tasks on any child partitions, force loading will ensure
+	// that they can forward their tasks the poller which caused the root partition to be
+	// loaded. We're in a separate goroutine in initialize() so we can do it here.
+	if defaultQ.WaitUntilInitialized(pm.initCtx) == nil {
+		pm.ForceLoadAllChildPartitions()
+	}
+
 	return nil
 }
 
@@ -1174,7 +1185,7 @@ func (pm *taskQueuePartitionManagerImpl) emitLogicalBacklogMetrics(ctx context.C
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(interval):
+		case <-time.After(backoff.Jitter(interval, 0.05)):
 			pm.fetchAndEmitLogicalBacklogMetrics(ctx)
 		}
 	}
@@ -1469,38 +1480,33 @@ func (pm *taskQueuePartitionManagerImpl) callerInfoContext(ctx context.Context) 
 	return headers.SetCallerInfo(ctx, headers.NewBackgroundHighCallerInfo(pm.ns.Name().String()))
 }
 
-// ForceLoadAllChildPartitions spins off go routines which make RPC calls to all the
+// ForceLoadAllChildPartitions force-loads known child (read) partitions in new goroutines.
 func (pm *taskQueuePartitionManagerImpl) ForceLoadAllChildPartitions() {
 	if !pm.partition.IsRoot() {
 		return
 	}
 
-	partition := pm.partition
-	taskQueue := partition.TaskQueue()
+	partitions := int32(pm.config.NumReadPartitions())
+	if partitions <= 1 {
+		return
+	}
 
-	namespaceId := partition.NamespaceId()
-	taskQueueName := taskQueue.Name()
-	taskQueueType := taskQueue.TaskType()
-	partitionTotal := pm.config.NumReadPartitions()
+	// record total-1 as we won't try to load the root partition.
+	pm.metricsHandler.Counter(metrics.ForceLoadedTaskQueuePartitions.Name()).Record(int64(partitions) - 1)
 
-	// record total - 1 as we won't try to forceLoad the Root partition.
-	pm.metricsHandler.Counter(metrics.ForceLoadedTaskQueuePartitions.Name()).Record(int64(partitionTotal) - 1)
-
-	for partitionId := 1; partitionId < partitionTotal; partitionId++ {
-
+	for id := int32(1); id < partitions; id++ {
 		go func() {
 			ctx := pm.callerInfoContext(context.Background())
 			resp, err := pm.matchingClient.ForceLoadTaskQueuePartition(ctx, &matchingservice.ForceLoadTaskQueuePartitionRequest{
-				NamespaceId: namespaceId,
+				NamespaceId: pm.partition.NamespaceId(),
 				TaskQueuePartition: &taskqueuespb.TaskQueuePartition{
-					TaskQueue:     taskQueueName,
-					TaskQueueType: taskQueueType,
-					PartitionId:   &taskqueuespb.TaskQueuePartition_NormalPartitionId{NormalPartitionId: int32(partitionId)},
+					TaskQueue:     pm.partition.TaskQueue().Name(),
+					TaskQueueType: pm.partition.TaskQueue().TaskType(),
+					PartitionId:   &taskqueuespb.TaskQueuePartition_NormalPartitionId{NormalPartitionId: id},
 				},
 			})
 			if err != nil {
-				pm.logger.Error("Failed to force load non-root partition after root partition was loaded",
-					tag.Error(err))
+				pm.logger.Error("failed to load child partition after root partition was loaded", tag.Error(err))
 				return
 			}
 

--- a/service/matching/task_queue_partition_manager_test.go
+++ b/service/matching/task_queue_partition_manager_test.go
@@ -84,6 +84,8 @@ func (s *PartitionManagerTestSuite) SetupTest() {
 	}
 
 	s.matchingClient = matchingservicemock.NewMockMatchingServiceClient(s.controller)
+	s.matchingClient.EXPECT().ForceLoadTaskQueuePartition(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&matchingservice.ForceLoadTaskQueuePartitionResponse{}, nil).AnyTimes()
 	engine := createTestMatchingEngine(logger, s.controller, config, s.matchingClient, registry)
 
 	f, err := tqid.NewTaskQueueFamily(namespaceID, taskQueueName)


### PR DESCRIPTION
## What changed?
Just rearrange some code: responsibility for force-loading child partitions is moved into task queue partition manager.

## Why?
It makes more sense to keep it here, and will make it easier to move it into the partition scale manager after that's merged.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
