### PR TITLE
support setting metricHandler after initialization

### DIFF
--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -51,8 +51,8 @@ type (
 	}
 )
 
-// An explicit way to create a file based client without metrics.Handler,
-// and update later with SetMetricsHandler. This is useful when the metricsHandler is not available
+// NewFileBasedClientWithoutMetrics creates a file based client without a metrics.Handler,
+// which can be set later with SetMetricsHandler. This is useful when the metricsHandler is not available
 // at the time of initialization like in cases of circular dependencies.
 func NewFileBasedClientWithoutMetrics(config *FileBasedClientConfig, logger log.Logger, doneCh <-chan any) (*fileBasedClient, error) {
 	return NewFileBasedClient(config, logger, doneCh, nil)

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -75,6 +75,23 @@ func (s *fileBasedClientSuite) TestGetValue_NonExistKey() {
 	s.Equal(defaultValue, v)
 }
 
+func (s *fileBasedClientSuite) TestNewFileBasedClientWithoutMetrics() {
+	dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 0, "")
+	logger := log.NewNoopLogger()
+	doneCh := make(chan any)
+	defer close(doneCh)
+
+	client, err := dynamicconfig.NewFileBasedClientWithoutMetrics(
+		&dynamicconfig.FileBasedClientConfig{
+			Filepath:     "config/testConfig.yaml",
+			PollInterval: time.Minute * 5,
+		}, logger, doneCh)
+	s.NoError(err)
+
+	client.SetMetricsHandler(metrics.NoopMetricsHandler)
+	s.NoError(client.Update())
+}
+
 func (s *fileBasedClientSuite) TestGetValue_CaseInsensitie() {
 	cvs := s.client.GetValue(dynamicconfig.MakeKey(testCaseInsensitivePropertyKey))
 	s.Equal(1, len(cvs))
@@ -965,22 +982,4 @@ testGetBoolPropertyKey:
 		}
 	}
 	s.Equal(3, found)
-}
-
-func (s *fileBasedClientSuite) TestNewFileBasedClientWithoutMetrics() {
-	dynamicconfig.NewGlobalIntSetting(testGetIntPropertyKey, 0, "")
-
-	logger := log.NewNoopLogger()
-	doneCh := make(chan any)
-	defer close(doneCh)
-
-	client, err := dynamicconfig.NewFileBasedClientWithoutMetrics(
-		&dynamicconfig.FileBasedClientConfig{
-			Filepath:     "anyValue",
-			PollInterval: time.Minute * 5,
-		}, logger, doneCh)
-	s.NoError(err)
-
-	client.SetMetricsHandler(metrics.NoopMetricsHandler)
-	s.NoError(client.Update())
 }


### PR DESCRIPTION
## What changed?
allowing nil metricHandler for dc 

## Why?
more flexible for initialization

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

