### PR TITLE
Export TestEnv 

### DIFF
--- a/tests/testcore/context.go
+++ b/tests/testcore/context.go
@@ -15,7 +15,7 @@ import (
 //
 // NOTE: If you're using testcore.NewEnv, you can use env.Context() directly - it already
 // includes RPC headers. This function is primarily for legacy tests or creating standalone
-// contexts outside of the testEnv framework.
+// contexts outside of the TestEnv framework.
 //
 // If a parent context is provided, the returned context will be canceled when
 // either the timeout expires OR the parent is canceled.

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -35,7 +35,7 @@ import (
 var shardSalt string
 
 var (
-	_                  Env = (*testEnv)(nil)
+	_                  Env = (*TestEnv)(nil)
 	sequentialSuites   sync.Map
 	defaultTestTimeout = 90 * time.Second * debug.TimeoutMultiplier
 )
@@ -52,7 +52,7 @@ type Env interface {
 	InjectHook(hook testhooks.Hook) (cleanup func())
 }
 
-type testEnv struct {
+type TestEnv struct {
 	*FunctionalTestBase
 	*require.Assertions
 	historyrequire.HistoryRequire
@@ -163,7 +163,7 @@ func MustRunSequential(t *testing.T, reason string) {
 //
 // By default, tests are marked as parallel. Use MustRunSequential on the
 // test's parent `testing.T` to run them sequentially instead.
-func NewEnv(t *testing.T, opts ...TestOption) *testEnv {
+func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	// Check test sharding early, before any expensive operations.
 	checkTestShard(t)
 
@@ -216,7 +216,7 @@ func NewEnv(t *testing.T, opts ...TestOption) *testEnv {
 		t.Fatalf("Failed to register namespace: %v", err)
 	}
 
-	env := &testEnv{
+	env := &TestEnv{
 		FunctionalTestBase: base,
 		Assertions:         require.New(t),
 		HistoryRequire:     historyrequire.New(t),
@@ -245,11 +245,11 @@ func NewEnv(t *testing.T, opts ...TestOption) *testEnv {
 }
 
 // Use test env-specific namespace here for test isolation.
-func (e *testEnv) Namespace() namespace.Name {
+func (e *TestEnv) Namespace() namespace.Name {
 	return e.nsName
 }
 
-func (e *testEnv) NamespaceID() namespace.ID {
+func (e *TestEnv) NamespaceID() namespace.ID {
 	return e.nsID
 }
 
@@ -258,7 +258,7 @@ func (e *testEnv) NamespaceID() namespace.ID {
 // It auto-detects the scope from the hook:
 // - For namespace-scoped hooks: scopes it to the test's namespace
 // - For global hooks: requires a dedicated cluster (fails early if used on shared cluster)
-func (e *testEnv) InjectHook(hook testhooks.Hook) (cleanup func()) {
+func (e *TestEnv) InjectHook(hook testhooks.Hook) (cleanup func()) {
 	var scope any
 	switch hook.Scope() {
 	case testhooks.ScopeNamespace:
@@ -274,15 +274,15 @@ func (e *testEnv) InjectHook(hook testhooks.Hook) (cleanup func()) {
 	return e.cluster.host.injectHook(e.t, hook, scope)
 }
 
-func (e *testEnv) TaskPoller() *taskpoller.TaskPoller {
+func (e *TestEnv) TaskPoller() *taskpoller.TaskPoller {
 	return e.taskPoller
 }
 
-func (e *testEnv) T() *testing.T {
+func (e *TestEnv) T() *testing.T {
 	return e.t
 }
 
-func (e *testEnv) Tv() *testvars.TestVars {
+func (e *TestEnv) Tv() *testvars.TestVars {
 	return e.tv
 }
 
@@ -294,13 +294,13 @@ func (e *testEnv) Tv() *testvars.TestVars {
 //
 //	ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
 //	defer cancel()
-func (e *testEnv) Context() context.Context {
+func (e *TestEnv) Context() context.Context {
 	return e.ctx
 }
 
 // SdkClient returns the SDK client created by WithSdkWorker.
 // Panics if WithSdkWorker was not passed to NewEnv.
-func (e *testEnv) SdkClient() sdkclient.Client {
+func (e *TestEnv) SdkClient() sdkclient.Client {
 	if e.sdkClient == nil {
 		panic("SdkClient() requires WithSdkWorker option to be passed to NewEnv")
 	}
@@ -309,7 +309,7 @@ func (e *testEnv) SdkClient() sdkclient.Client {
 
 // SdkWorker returns the SDK worker created by WithSdkWorker.
 // Panics if WithSdkWorker was not passed to NewEnv.
-func (e *testEnv) SdkWorker() sdkworker.Worker {
+func (e *TestEnv) SdkWorker() sdkworker.Worker {
 	if e.worker == nil {
 		panic("SdkWorker() requires WithSdkWorker option to be passed to NewEnv")
 	}
@@ -318,14 +318,14 @@ func (e *testEnv) SdkWorker() sdkworker.Worker {
 
 // WorkerTaskQueue returns the task queue name used by the SDK Worker.
 // Panics if WithSdkWorker was not passed to NewEnv.
-func (e *testEnv) WorkerTaskQueue() string {
+func (e *TestEnv) WorkerTaskQueue() string {
 	if e.workerTaskQueue == "" {
 		panic("WorkerTaskQueue() requires WithSdkWorker option to be passed to NewEnv")
 	}
 	return e.workerTaskQueue
 }
 
-func (e *testEnv) setupSdk() {
+func (e *TestEnv) setupSdk() {
 	clientOptions := sdkclient.Options{
 		HostPort:  e.FrontendGRPCAddress(),
 		Namespace: e.nsName.String(),
@@ -361,7 +361,7 @@ func (e *testEnv) setupSdk() {
 // OverrideDynamicConfig overrides a dynamic config setting for the duration of this test.
 // For settings that can be namespace-scoped, a namespace constraint is applied.
 // All others cannot be applied to a shared cluster and require `WithDedicatedCluster`.
-func (e *testEnv) OverrideDynamicConfig(setting dynamicconfig.GenericSetting, value any) (cleanup func()) {
+func (e *TestEnv) OverrideDynamicConfig(setting dynamicconfig.GenericSetting, value any) (cleanup func()) {
 	if e.isShared {
 		if !canBeNamespaceScoped(setting.Precedence()) {
 			e.t.Fatalf("OverrideDynamicConfig for setting %s (precedence %v) cannot be called on a shared cluster; use testcore.WithDedicatedCluster()", setting.Key(), setting.Precedence())


### PR DESCRIPTION
## What changed?

Export `testEnv`.

## Why?

While there is an `Env` interface, it doesn't cover all that `TestEnv` does; in particular the testify assertions cannot be supported as they don't have an interface. 

Eventually we'll delete the `Env` interface once all test suites are converted. Right now the purpose it serves is allowing test helpers to allow taking in either `testEnv` or `FunctionalTestEnv`.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
