### PR TITLE
Fix race in fairTaskReader

### DIFF
--- a/service/matching/fair_task_reader.go
+++ b/service/matching/fair_task_reader.go
@@ -237,6 +237,10 @@ func (tr *fairTaskReader) readTasksImpl() {
 		tr.advanceAckLevelLocked()
 	}
 
+	// If a backoff timer fired while readPending was still true, its maybeReadTasksLocked call
+	// was a no-op. Re-check now that readPending is false to avoid getting stuck.
+	tr.maybeReadTasksLocked()
+
 	// unlock before calling addTaskToMatcher
 	tr.lock.Unlock()
 


### PR DESCRIPTION
## What changed?
Do another call to `tr.maybeReadTasksLocked()` here (after setting `tr.readPending = false`) in case the backoff timer runs before the rest of `tr.readTasksImpl` runs.

## Why?
There's a race between the backoff timer and the rest of `readTasksImpl`: if the backoff timer runs first it'll think there's still a read pending and give up. So we can do a final check if we should read tasks before finishing `readTasksImpl`. Note that if it does decide to read then, the next read will be in another goroutine.

## How did you test it?
- [ ] built
- [x] run locally and tested manually (tested with manual hook and fault injection)
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
