### PR TITLE
fix: handle under-filled CQL pages in ListQueues with ALLOW FILTERING

### DIFF
--- a/common/persistence/cassandra/queue_v2_store.go
+++ b/common/persistence/cassandra/queue_v2_store.go
@@ -471,45 +471,60 @@ func (s *queueV2Store) ListQueues(
 	if request.PageSize <= 0 {
 		return nil, persistence.ErrNonPositiveListQueuesPageSize
 	}
-	iter := s.session.Query(
-		templateGetQueueNamesQuery,
-		request.QueueType,
-	).PageSize(request.PageSize).PageState(request.NextPageToken).WithContext(ctx).Iter()
 
+	// The ALLOW FILTERING query may return fewer rows than PageSize per CQL
+	// page because the partition key is (queue_type, queue_name) and we filter
+	// only on queue_type. Keep fetching pages until we have enough rows or
+	// exhaust the result set.
 	var queues []persistence.QueueInfo
-	for {
-		var (
-			queueName        string
-			metadataBytes    []byte
-			metadataEncoding string
-			version          int64
-		)
-		if !iter.Scan(&queueName, &metadataBytes, &metadataEncoding, &version) {
+	pageToken := request.NextPageToken
+
+	for len(queues) < request.PageSize {
+		remaining := request.PageSize - len(queues)
+		iter := s.session.Query(
+			templateGetQueueNamesQuery,
+			request.QueueType,
+		).PageSize(remaining).PageState(pageToken).WithContext(ctx).Iter()
+
+		for {
+			var (
+				queueName        string
+				metadataBytes    []byte
+				metadataEncoding string
+				version          int64
+			)
+			if !iter.Scan(&queueName, &metadataBytes, &metadataEncoding, &version) {
+				break
+			}
+			q, err := getQueueFromMetadata(request.QueueType, queueName, metadataBytes, metadataEncoding, version)
+			if err != nil {
+				return nil, err
+			}
+			partition, err := persistence.GetPartitionForQueueV2(request.QueueType, queueName, q.Metadata)
+			if err != nil {
+				return nil, err
+			}
+			messageCount, lastMessageID, err := s.getMessageCountAndLastID(ctx, request.QueueType, queueName, partition)
+			if err != nil {
+				return nil, err
+			}
+			queues = append(queues, persistence.QueueInfo{
+				QueueName:     queueName,
+				MessageCount:  messageCount,
+				LastMessageID: lastMessageID,
+			})
+		}
+		pageToken = iter.PageState()
+		if err := iter.Close(); err != nil {
+			return nil, gocql.ConvertError("QueueV2ListQueues", err)
+		}
+		if len(pageToken) == 0 {
 			break
 		}
-		q, err := getQueueFromMetadata(request.QueueType, queueName, metadataBytes, metadataEncoding, version)
-		if err != nil {
-			return nil, err
-		}
-		partition, err := persistence.GetPartitionForQueueV2(request.QueueType, queueName, q.Metadata)
-		if err != nil {
-			return nil, err
-		}
-		messageCount, lastMessageID, err := s.getMessageCountAndLastID(ctx, request.QueueType, queueName, partition)
-		if err != nil {
-			return nil, err
-		}
-		queues = append(queues, persistence.QueueInfo{
-			QueueName:     queueName,
-			MessageCount:  messageCount,
-			LastMessageID: lastMessageID,
-		})
 	}
-	if err := iter.Close(); err != nil {
-		return nil, gocql.ConvertError("QueueV2ListQueues", err)
-	}
+
 	return &persistence.InternalListQueuesResponse{
 		Queues:        queues,
-		NextPageToken: iter.PageState(),
+		NextPageToken: pageToken,
 	}, nil
 }


### PR DESCRIPTION
The queues table uses composite partition key (queue_type, queue_name). The ALLOW FILTERING query on queue_type alone may return fewer rows than PageSize per CQL page while more data remains. Accumulate results across multiple pages to guarantee the requested page size is filled.

## What changed?
This is an interesting and a slight change of behavior between ScyllaDB and Cassandra. I couldn't judge from the protocol who's right. I think it's not very very well defined.

## Why?
Tests against ScyllaDB could have failed.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
I've tested it against both Cassandra (3.11, 5.0) and ScyllaDB (2025.4, 2026.1)
