### PR TITLE
fix: use full tuple range in CQL queries for ScyllaDB compatibility

### DIFF
--- a/common/persistence/cassandra/matching_task_store_v2.go
+++ b/common/persistence/cassandra/matching_task_store_v2.go
@@ -20,24 +20,24 @@ const (
 		`WHERE namespace_id = ? ` +
 		`and task_queue_name = ? ` +
 		`and task_queue_type = ? ` +
-		`and type = ? ` +
-		`and (pass, task_id) >= (?, ?)`
+		`and (type, pass, task_id) >= (?, ?, ?) ` +
+		`and (type, pass, task_id) < (?, ?, ?)`
 
 	templateGetTasksQuery_v2_limit = `SELECT task_id, task, task_encoding ` +
 		`FROM tasks_v2 ` +
 		`WHERE namespace_id = ? ` +
 		`and task_queue_name = ? ` +
 		`and task_queue_type = ? ` +
-		`and type = ? ` +
-		`and (pass, task_id) >= (?, ?) ` +
+		`and (type, pass, task_id) >= (?, ?, ?) ` +
+		`and (type, pass, task_id) < (?, ?, ?) ` +
 		`LIMIT ?`
 
 	templateCompleteTasksLessThanQuery_v2 = `DELETE FROM tasks_v2 ` +
 		`WHERE namespace_id = ? ` +
 		`AND task_queue_name = ? ` +
 		`AND task_queue_type = ? ` +
-		`AND type = ? ` +
-		`and (pass, task_id) < (?, ?)`
+		`AND (type, pass, task_id) >= (?, ?, ?) ` +
+		`AND (type, pass, task_id) < (?, ?, ?)`
 )
 
 // matchingTaskStoreV2 is a fork of matchingTaskStoreV1 that uses a new task schema.
@@ -128,14 +128,18 @@ func (d *matchingTaskStoreV2) GetTasks(
 
 	// Reading taskqueue tasks need to be quorum level consistent, otherwise we could lose tasks
 	var query gocql.Query
+	rowType := rowTypeTaskInSubqueue(request.Subqueue)
 	if request.UseLimit {
 		query = d.Session.Query(templateGetTasksQuery_v2_limit,
 			request.NamespaceID,
 			request.TaskQueue,
 			request.TaskType,
-			rowTypeTaskInSubqueue(request.Subqueue),
+			rowType,
 			request.InclusiveMinPass,
 			request.InclusiveMinTaskID,
+			rowType,
+			int64(math.MaxInt64),
+			int64(math.MaxInt64),
 			request.PageSize,
 		)
 	} else {
@@ -143,9 +147,12 @@ func (d *matchingTaskStoreV2) GetTasks(
 			request.NamespaceID,
 			request.TaskQueue,
 			request.TaskType,
-			rowTypeTaskInSubqueue(request.Subqueue),
+			rowType,
 			request.InclusiveMinPass,
 			request.InclusiveMinTaskID,
+			rowType,
+			int64(math.MaxInt64),
+			int64(math.MaxInt64),
 		)
 	}
 	iter := query.WithContext(ctx).PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
@@ -203,12 +210,16 @@ func (d *matchingTaskStoreV2) CompleteTasksLessThan(
 		return 0, serviceerror.NewInternal("invalid CompleteTasksLessThan request on fair queue")
 	}
 
+	rowType := rowTypeTaskInSubqueue(request.Subqueue)
 	query := d.Session.Query(
 		templateCompleteTasksLessThanQuery_v2,
 		request.NamespaceID,
 		request.TaskQueueName,
 		request.TaskType,
-		rowTypeTaskInSubqueue(request.Subqueue),
+		rowType,
+		int64(0),
+		int64(0),
+		rowType,
 		request.ExclusiveMaxPass,
 		request.ExclusiveMaxTaskID,
 	).WithContext(ctx)


### PR DESCRIPTION
ScyllaDB evaluates single-column equality + partial-tuple range differently from Cassandra: it may produce incorrect results or fail when a subset of clustering columns appears in the tuple comparison.

## What changed?
Rewrite the tasks_v2 queries so every clustering column (type, pass, task_id) participates in both the >= and < tuple bounds. This makes range scans and deletes explicit and portable across both databases.

## Why?
To ensure Temporal can run well against both Cassandra and ScyllaDB.

## How did you test it?
- [x] built
- [x] run locally and tested manually - against both ScyllaDB and Cassandra.
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

