### PR TITLE
rm checking-nil for doneChn in dcClient for better backward compatibi…

### DIFF
--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -76,9 +76,6 @@ func NewFileBasedClientWithReader(reader FileReader, config *FileBasedClientConf
 	if logger == nil {
 		return nil, errors.New("logger for dynamic config client is nil")
 	}
-	if doneCh == nil {
-		return nil, errors.New("done channel for dynamic config client is nil")
-	}
 	if metricsHandler == nil {
 		metricsHandler = metrics.NoopMetricsHandler
 		logger.Warn("metrics handler is nil, using noop metrics handler")

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -302,16 +302,6 @@ func (s *fileBasedClientSuite) TestValidateConfig_NilReader() {
 	s.Error(err, "file reader for dynamic config client is nil")
 }
 
-func (s *fileBasedClientSuite) TestValidateConfig_NilDoneCh() {
-	logger := log.NewNoopLogger()
-	reader := dynamicconfig.NewMockFileReader(gomock.NewController(s.T()))
-	_, err := dynamicconfig.NewFileBasedClientWithReader(reader, &dynamicconfig.FileBasedClientConfig{
-		Filepath:     "config/testConfig.yaml",
-		PollInterval: time.Second * 5,
-	}, logger, nil, metrics.NoopMetricsHandler)
-	s.Error(err, "done channel for dynamic config client is nil")
-}
-
 func (s *fileBasedClientSuite) TestValidateConfig_ShortPollInterval() {
 	logger := log.NewNoopLogger()
 	doneCh := make(chan any)


### PR DESCRIPTION
…lity

## What changed?
remove checking nil for doneChn of dcClient

## Why?
better backward compatibility

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
