### PR TITLE
fix: use LoggedBatch for CAS operations in UpdateTaskQueueUserData

### DIFF
--- a/common/persistence/cassandra/matching_task_store_user_data.go
+++ b/common/persistence/cassandra/matching_task_store_user_data.go
@@ -67,7 +67,7 @@ func (d *userDataStore) UpdateTaskQueueUserData(
 	ctx context.Context,
 	request *p.InternalUpdateTaskQueueUserDataRequest,
 ) error {
-	batch := d.Session.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
+	batch := d.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 
 	for taskQueue, update := range request.Updates {
 		if update.Version == 0 {


### PR DESCRIPTION
UnloggedBatch was incorrectly used with CAS (IF/IF NOT EXISTS) queries. CAS batches use Paxos which requires Logged batches for correctness. While Cassandra ignores the batch type for Paxos in practice, using LoggedBatch is semantically correct and avoids potential issues with ScyllaDB's LWT implementation.

## What changed?
Corrected it to use a logged batch.

## Why?
It used incorrectly unlogged, while it should have been logged. Failures here could be missed.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
