### PR TITLE
improvement: use NetworkTopologyStrategy instead of SimpleStrategy for keyspa…

### DIFF
--- a/common/persistence/cassandra/helpers.go
+++ b/common/persistence/cassandra/helpers.go
@@ -21,7 +21,7 @@ func CreateCassandraKeyspace(s gocql.Session, keyspace string, replicas int, ove
 		}
 	}
 	err = s.Query(fmt.Sprintf(`CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {
-		'class' : 'SimpleStrategy', 'replication_factor' : %d}`, keyspace, replicas)).Exec()
+		'class' : 'NetworkTopologyStrategy', 'datacenter1' : %d}`, keyspace, replicas)).Exec()
 	if err != nil {
 		logger.Error("create keyspace error", tag.Error(err))
 		return

--- a/schema/cassandra/temporal/keyspace.cql
+++ b/schema/cassandra/temporal/keyspace.cql
@@ -1,1 +1,1 @@
-CREATE KEYSPACE IF NOT EXISTS temporal WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1};
+CREATE KEYSPACE IF NOT EXISTS temporal WITH replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1};

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -72,9 +72,6 @@ const (
 		`PRIMARY KEY ((year, month), update_time));`
 
 	createKeyspaceCQL = `CREATE KEYSPACE IF NOT EXISTS %v ` +
-		`WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : %v};`
-
-	createKeyspaceNetworkTopologyCQL = `CREATE KEYSPACE IF NOT EXISTS %v ` +
 		`WITH replication = { 'class' : 'NetworkTopologyStrategy', '%v' : %v};`
 )
 
@@ -143,12 +140,12 @@ func (client *cqlClient) DropDatabase(name string) error {
 
 // createKeyspace creates a cassandra Keyspace if it doesn't exist
 func (client *cqlClient) createKeyspace(name string) error {
-	if client.datacenter != "" {
-		client.logger.Info(fmt.Sprintf("Creating Keyspace %v using NetworkTopologyStrategy in Datacenter %v with RF=%v.", name, client.datacenter, client.nReplicas))
-		return client.Exec(fmt.Sprintf(createKeyspaceNetworkTopologyCQL, name, client.datacenter, client.nReplicas))
+	datacenter := client.datacenter
+	if datacenter == "" {
+		datacenter = "datacenter1"
 	}
-	client.logger.Info(fmt.Sprintf("Creating Keyspace %v using SimpleStrategy with RF=%v.", name, client.nReplicas))
-	return client.Exec(fmt.Sprintf(createKeyspaceCQL, name, client.nReplicas))
+	client.logger.Info(fmt.Sprintf("Creating Keyspace %v using NetworkTopologyStrategy in Datacenter %v with RF=%v.", name, datacenter, client.nReplicas))
+	return client.Exec(fmt.Sprintf(createKeyspaceCQL, name, datacenter, client.nReplicas))
 }
 
 // dropKeyspace drops a Keyspace


### PR DESCRIPTION
…ce creation

SimpleStrategy is not recommended for production use. Switch all keyspace creation paths to use NetworkTopologyStrategy with a default datacenter of 'datacenter1' (Cassandra's built-in default). The --datacenter flag continues to override this default when specified.

## What changed?
Switched to NetworkTopologyStrategy .

## Why?
In the future, ScyllaDB will kill Simple altogether, so let's be future-proof.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
