### PR TITLE
Verify during force to address flakiness

### DIFF
--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -2347,8 +2347,10 @@ func (s *FunctionalClustersTestSuite) TestLocalNamespaceMigration() {
 		TaskQueue:          primitives.DefaultWorkerTaskQueue,
 		WorkflowRunTimeout: time.Second * 30,
 	}, "force-replication", migration.ForceReplicationParams{
-		Namespace:  namespace,
-		OverallRps: 10,
+		Namespace:          namespace,
+		OverallRps:         10,
+		EnableVerification: true,
+		TargetClusterName:  s.clusters[1].ClusterName(),
 	})
 
 	s.NoError(err)
@@ -2488,8 +2490,10 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
 		TaskQueue:          primitives.DefaultWorkerTaskQueue,
 		WorkflowRunTimeout: time.Second * 30,
 	}, "force-replication", migration.ForceReplicationParams{
-		Namespace:  namespace,
-		OverallRps: 10,
+		Namespace:          namespace,
+		OverallRps:         10,
+		EnableVerification: true,
+		TargetClusterName:  s.clusters[1].ClusterName(),
 	})
 	s.NoError(err)
 	err = sysWfRun.Get(testCtx, nil)
@@ -2595,8 +2599,10 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
 		TaskQueue:          primitives.DefaultWorkerTaskQueue,
 		WorkflowRunTimeout: time.Second * 30,
 	}, "force-replication", migration.ForceReplicationParams{
-		Namespace:  namespace,
-		OverallRps: 10,
+		Namespace:          namespace,
+		OverallRps:         10,
+		EnableVerification: true,
+		TargetClusterName:  s.clusters[1].ClusterName(),
 	})
 	s.NoError(err)
 	err = sysWfRun.Get(testCtx, nil)


### PR DESCRIPTION
## What changed?
Addressing flakiness during force replication:

The core issue is that we issue force replication workflow, then IMMEDIATELY attempt to verify that the workflow has been replicated, which is racey as force replication workflow must generate the event on active and then will async replicate and apply it on passive. 

This can be addressed by asking force replication workflow to verify, which is an optional step where it explicitly waits/polls the target cluster for the workflows that we are expecting - this way the test will actually block until force replication finishes.

## Why?
Flakiness

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
