### PR TITLE
chore: bump elasticsearch8 image to 8.5.0 (backport to v1.28.x)

### DIFF
--- a/develop/github/docker-compose.yml
+++ b/develop/github/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
 
   elasticsearch8:
-    image: elasticsearch:8.0.0
+    image: elasticsearch:8.5.0
     ports:
       - "9200:9200"
     environment:


### PR DESCRIPTION
## Summary
- Cherry-pick of #9312 (c2c7fb071ab84825617f24822889c68a57f2ab0f) into `release/v1.28.x`
- Bumps elasticsearch8 Docker image from current version to 8.5.0