### PR TITLE
OperationID, ChasmRunID and ActivityID log tags in interceptor

### DIFF
--- a/cmd/tools/genrpcserverinterceptors/main.go
+++ b/cmd/tools/genrpcserverinterceptors/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
 	"flag"
 	"fmt"
@@ -21,9 +22,12 @@ type (
 	messageData struct {
 		Type string
 
-		WorkflowIdGetter string
-		RunIdGetter      string
-		TaskTokenGetter  string
+		WorkflowIDGetter  string
+		RunIDGetter       string
+		TaskTokenGetter   string
+		ActivityIDGetter  string
+		OperationIDGetter string
+		ChasmRunIDGetter  string
 	}
 
 	grpcServerData struct {
@@ -67,12 +71,20 @@ var (
 		GetTaskToken() []byte
 	})(nil)).Elem()
 
-	workflowIdGetterT = reflect.TypeOf((*interface {
+	workflowIDGetterT = reflect.TypeOf((*interface {
 		GetWorkflowId() string
 	})(nil)).Elem()
 
-	runIdGetterT = reflect.TypeOf((*interface {
+	runIDGetterT = reflect.TypeOf((*interface {
 		GetRunId() string
+	})(nil)).Elem()
+
+	activityIDGetterT = reflect.TypeOf((*interface {
+		GetActivityId() string
+	})(nil)).Elem()
+
+	operationIDGetterT = reflect.TypeOf((*interface {
+		GetOperationId() string
 	})(nil)).Elem()
 )
 
@@ -120,11 +132,11 @@ func workflowTagGetters(messageType reflect.Type, depth int) messageData {
 
 	switch {
 	case messageType.AssignableTo(executionGetterT):
-		pd.WorkflowIdGetter = "GetExecution().GetWorkflowId()"
-		pd.RunIdGetter = "GetExecution().GetRunId()"
+		pd.WorkflowIDGetter = "GetExecution().GetWorkflowId()"
+		pd.RunIDGetter = "GetExecution().GetRunId()"
 	case messageType.AssignableTo(workflowExecutionGetterT):
-		pd.WorkflowIdGetter = "GetWorkflowExecution().GetWorkflowId()"
-		pd.RunIdGetter = "GetWorkflowExecution().GetRunId()"
+		pd.WorkflowIDGetter = "GetWorkflowExecution().GetWorkflowId()"
+		pd.RunIDGetter = "GetWorkflowExecution().GetRunId()"
 	case messageType.AssignableTo(taskTokenGetterT):
 		for _, ert := range excludeTaskTokenTypes {
 			if messageType.AssignableTo(ert) {
@@ -133,22 +145,24 @@ func workflowTagGetters(messageType reflect.Type, depth int) messageData {
 		}
 		pd.TaskTokenGetter = "GetTaskToken()"
 	default:
-		// Might be one of these, both, or neither.
-		if messageType.AssignableTo(workflowIdGetterT) {
-			pd.WorkflowIdGetter = "GetWorkflowId()"
+		// Might have any combination of these, or none.
+		if messageType.AssignableTo(workflowIDGetterT) {
+			pd.WorkflowIDGetter = "GetWorkflowId()"
 		}
-		if messageType.AssignableTo(runIdGetterT) {
-			pd.RunIdGetter = "GetRunId()"
+		if messageType.AssignableTo(runIDGetterT) {
+			pd.RunIDGetter = "GetRunId()"
+		}
+		if messageType.AssignableTo(activityIDGetterT) {
+			pd.ActivityIDGetter = "GetActivityId()"
+		}
+		if messageType.AssignableTo(operationIDGetterT) {
+			pd.OperationIDGetter = "GetOperationId()"
 		}
 	}
 
 	// Iterates over fields in order they defined in proto file, not proto index.
 	// Order is important because the first match wins.
 	for fieldNum := 0; fieldNum < messageType.Elem().NumField(); fieldNum++ {
-		if (pd.WorkflowIdGetter != "" && pd.RunIdGetter != "") || pd.TaskTokenGetter != "" {
-			break
-		}
-
 		nestedRequest := messageType.Elem().Field(fieldNum)
 		if nestedRequest.Type.Kind() != reflect.Ptr {
 			continue
@@ -162,15 +176,32 @@ func workflowTagGetters(messageType reflect.Type, depth int) messageData {
 
 		nestedRd := workflowTagGetters(nestedRequest.Type, depth+1)
 		// First match wins: if getter is already set, it won't be overwritten.
-		if pd.WorkflowIdGetter == "" && nestedRd.WorkflowIdGetter != "" {
-			pd.WorkflowIdGetter = fmt.Sprintf("Get%s().%s", nestedRequest.Name, nestedRd.WorkflowIdGetter)
+		if pd.WorkflowIDGetter == "" && nestedRd.WorkflowIDGetter != "" {
+			pd.WorkflowIDGetter = fmt.Sprintf("Get%s().%s", nestedRequest.Name, nestedRd.WorkflowIDGetter)
 		}
-		if pd.RunIdGetter == "" && nestedRd.RunIdGetter != "" {
-			pd.RunIdGetter = fmt.Sprintf("Get%s().%s", nestedRequest.Name, nestedRd.RunIdGetter)
+		if pd.RunIDGetter == "" && nestedRd.RunIDGetter != "" {
+			pd.RunIDGetter = fmt.Sprintf("Get%s().%s", nestedRequest.Name, nestedRd.RunIDGetter)
 		}
 		if pd.TaskTokenGetter == "" && nestedRd.TaskTokenGetter != "" {
 			pd.TaskTokenGetter = fmt.Sprintf("Get%s().%s", nestedRequest.Name, nestedRd.TaskTokenGetter)
 		}
+		if pd.ActivityIDGetter == "" && nestedRd.ActivityIDGetter != "" {
+			pd.ActivityIDGetter = fmt.Sprintf("Get%s().%s", nestedRequest.Name, nestedRd.ActivityIDGetter)
+		}
+		if pd.OperationIDGetter == "" && nestedRd.OperationIDGetter != "" {
+			pd.OperationIDGetter = fmt.Sprintf("Get%s().%s", nestedRequest.Name, nestedRd.OperationIDGetter)
+		}
 	}
+
+	// When a business ID (activity or operation) is present without a workflow ID,
+	// the run_id is not a workflow run ID. Only apply at the top level.
+	if depth == 0 {
+		hasChasmBusinessID := pd.WorkflowIDGetter == "" && cmp.Or(pd.ActivityIDGetter, pd.OperationIDGetter) != ""
+		if hasChasmBusinessID && pd.RunIDGetter != "" {
+			pd.ChasmRunIDGetter = pd.RunIDGetter
+			pd.RunIDGetter = ""
+		}
+	}
+
 	return pd
 }

--- a/cmd/tools/genrpcserverinterceptors/main_test.go
+++ b/cmd/tools/genrpcserverinterceptors/main_test.go
@@ -12,11 +12,14 @@ import (
 
 func TestWorkflowTagGetters(t *testing.T) {
 	testCases := []struct {
-		name             string
-		reqT             reflect.Type
-		workflowIDGetter string
-		runIDGetter      string
-		taskTokenGetter  string
+		name              string
+		reqT              reflect.Type
+		workflowIDGetter  string
+		runIDGetter       string
+		taskTokenGetter   string
+		activityIDGetter  string
+		operationIDGetter string
+		chasmRunIDGetter  string
 	}{
 		{
 			name:             "Request with only workflowID",
@@ -28,6 +31,7 @@ func TestWorkflowTagGetters(t *testing.T) {
 			reqT:             reflect.TypeOf(&workflowservice.RecordActivityTaskHeartbeatByIdRequest{}),
 			workflowIDGetter: "GetWorkflowId()",
 			runIDGetter:      "GetRunId()",
+			activityIDGetter: "GetActivityId()",
 		},
 		{
 			name:             "Request with execution",
@@ -68,20 +72,33 @@ func TestWorkflowTagGetters(t *testing.T) {
 			workflowIDGetter: "GetWorkflowState().GetExecutionInfo().GetWorkflowId()",
 			runIDGetter:      "GetWorkflowState().GetExecutionState().GetRunId()",
 		},
+		{
+			name:             "Chasm activity request with activity_id and run_id",
+			reqT:             reflect.TypeOf(&workflowservice.DescribeActivityExecutionRequest{}),
+			activityIDGetter: "GetActivityId()",
+			chasmRunIDGetter: "GetRunId()",
+		},
+		{
+			name:             "Chasm activity request with only activity_id",
+			reqT:             reflect.TypeOf(&workflowservice.StartActivityExecutionRequest{}),
+			activityIDGetter: "GetActivityId()",
+		},
+		{
+			name:              "History request with nested operation_id",
+			reqT:              reflect.TypeOf(&historyservice.CancelNexusOperationRequest{}),
+			operationIDGetter: "GetRequest().GetOperationId()",
+		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			rd := workflowTagGetters(tt.reqT, 0)
-			if tt.workflowIDGetter != "" {
-				assert.Equal(t, tt.workflowIDGetter, rd.WorkflowIdGetter)
-			}
-			if tt.runIDGetter != "" {
-				assert.Equal(t, tt.runIDGetter, rd.RunIdGetter)
-			}
-			if tt.taskTokenGetter != "" {
-				assert.Equal(t, tt.taskTokenGetter, rd.TaskTokenGetter)
-			}
+			assert.Equal(t, tt.workflowIDGetter, rd.WorkflowIDGetter, "WorkflowIDGetter")
+			assert.Equal(t, tt.runIDGetter, rd.RunIDGetter, "RunIDGetter")
+			assert.Equal(t, tt.taskTokenGetter, rd.TaskTokenGetter, "TaskTokenGetter")
+			assert.Equal(t, tt.activityIDGetter, rd.ActivityIDGetter, "ActivityIDGetter")
+			assert.Equal(t, tt.operationIDGetter, rd.OperationIDGetter, "OperationIDGetter")
+			assert.Equal(t, tt.chasmRunIDGetter, rd.ChasmRunIDGetter, "ChasmRunIDGetter")
 		})
 	}
 }

--- a/cmd/tools/genrpcserverinterceptors/server_interceptors.tmpl
+++ b/cmd/tools/genrpcserverinterceptors/server_interceptors.tmpl
@@ -14,14 +14,20 @@ func (wt *WorkflowTags) extractFrom{{.Server}}Message(message any) []tag.Tag {
 	switch r := message.(type) {
 	{{- range .Messages}}
 	case {{.Type}}:
-	{{- if or .TaskTokenGetter .WorkflowIdGetter .RunIdGetter}}
+	{{- if or .TaskTokenGetter .WorkflowIDGetter .RunIDGetter .ActivityIDGetter .OperationIDGetter .ChasmRunIDGetter}}
 		{{- if .TaskTokenGetter}}
 		return wt.fromTaskToken(r.{{ .TaskTokenGetter}})
 		{{- else}}
 		return []tag.Tag{
-		{{if .WorkflowIdGetter}}	tag.WorkflowID(r.{{.WorkflowIdGetter}}),
+		{{if .WorkflowIDGetter}}	tag.WorkflowID(r.{{.WorkflowIDGetter}}),
 		{{end -}}
-		{{if .RunIdGetter}}	tag.WorkflowRunID(r.{{.RunIdGetter}}),
+		{{if .ActivityIDGetter}}	tag.ActivityID(r.{{.ActivityIDGetter}}),
+		{{end -}}
+		{{if .OperationIDGetter}}	tag.OperationID(r.{{.OperationIDGetter}}),
+		{{end -}}
+		{{if .RunIDGetter}}	tag.WorkflowRunID(r.{{.RunIDGetter}}),
+		{{end -}}
+		{{if .ChasmRunIDGetter}}	tag.ChasmRunID(r.{{.ChasmRunIDGetter}}),
 		{{end -}}
 		}
 		{{- end}}

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -147,11 +147,6 @@ func WorkflowBinaryChecksum(cs string) ZapTag {
 	return NewStringTag("wf-binary-checksum", cs)
 }
 
-// WorkflowActivityID returns tag for WorkflowActivityID
-func WorkflowActivityID(id string) ZapTag {
-	return NewStringTag("wf-activity-id", id)
-}
-
 // WorkflowTimerID returns tag for WorkflowTimerID
 func WorkflowTimerID(id string) ZapTag {
 	return NewStringTag("wf-timer-id", id)
@@ -917,9 +912,19 @@ func ActivityInfo(activityInfo any) ZapTag {
 	return NewAnyTag("activity-info", activityInfo)
 }
 
-// ActivityID returns tag for a standalone activity ID
+// ActivityID returns tag for an activity ID
 func ActivityID(id string) ZapTag {
 	return NewStringTag("activity-id", id)
+}
+
+// OperationID returns tag for a nexus operation ID
+func OperationID(id string) ZapTag {
+	return NewStringTag("operation-id", id)
+}
+
+// ChasmRunID returns tag for an entity run ID
+func ChasmRunID(id string) ZapTag {
+	return NewStringTag("run-id", id)
 }
 
 // ActivitySize returns a tag for a standalone activity size

--- a/common/rpc/interceptor/logtags/history_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/history_service_server_gen.go
@@ -14,7 +14,9 @@ func (wt *WorkflowTags) extractFromHistoryServiceServerMessage(message any) []ta
 	case *historyservice.AddTasksResponse:
 		return nil
 	case *historyservice.CancelNexusOperationRequest:
-		return nil
+		return []tag.Tag{
+			tag.OperationID(r.GetRequest().GetOperationId()),
+		}
 	case *historyservice.CancelNexusOperationResponse:
 		return nil
 	case *historyservice.CloseShardRequest:

--- a/common/rpc/interceptor/logtags/workflow_service_server_gen.go
+++ b/common/rpc/interceptor/logtags/workflow_service_server_gen.go
@@ -31,7 +31,8 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 		return nil
 	case *workflowservice.DeleteActivityExecutionRequest:
 		return []tag.Tag{
-			tag.WorkflowRunID(r.GetRunId()),
+			tag.ActivityID(r.GetActivityId()),
+			tag.ChasmRunID(r.GetRunId()),
 		}
 	case *workflowservice.DeleteActivityExecutionResponse:
 		return nil
@@ -64,7 +65,8 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 		return nil
 	case *workflowservice.DescribeActivityExecutionRequest:
 		return []tag.Tag{
-			tag.WorkflowRunID(r.GetRunId()),
+			tag.ActivityID(r.GetActivityId()),
+			tag.ChasmRunID(r.GetRunId()),
 		}
 	case *workflowservice.DescribeActivityExecutionResponse:
 		return []tag.Tag{
@@ -243,7 +245,8 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 		return nil
 	case *workflowservice.PollActivityExecutionRequest:
 		return []tag.Tag{
-			tag.WorkflowRunID(r.GetRunId()),
+			tag.ActivityID(r.GetActivityId()),
+			tag.ChasmRunID(r.GetRunId()),
 		}
 	case *workflowservice.PollActivityExecutionResponse:
 		return []tag.Tag{
@@ -291,6 +294,7 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 	case *workflowservice.RecordActivityTaskHeartbeatByIdRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
+			tag.ActivityID(r.GetActivityId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
 	case *workflowservice.RecordActivityTaskHeartbeatByIdResponse:
@@ -305,7 +309,8 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 		return nil
 	case *workflowservice.RequestCancelActivityExecutionRequest:
 		return []tag.Tag{
-			tag.WorkflowRunID(r.GetRunId()),
+			tag.ActivityID(r.GetActivityId()),
+			tag.ChasmRunID(r.GetRunId()),
 		}
 	case *workflowservice.RequestCancelActivityExecutionResponse:
 		return nil
@@ -346,6 +351,7 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 	case *workflowservice.RespondActivityTaskCanceledByIdRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
+			tag.ActivityID(r.GetActivityId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
 	case *workflowservice.RespondActivityTaskCanceledByIdResponse:
@@ -357,6 +363,7 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 	case *workflowservice.RespondActivityTaskCompletedByIdRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
+			tag.ActivityID(r.GetActivityId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
 	case *workflowservice.RespondActivityTaskCompletedByIdResponse:
@@ -368,6 +375,7 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 	case *workflowservice.RespondActivityTaskFailedByIdRequest:
 		return []tag.Tag{
 			tag.WorkflowID(r.GetWorkflowId()),
+			tag.ActivityID(r.GetActivityId()),
 			tag.WorkflowRunID(r.GetRunId()),
 		}
 	case *workflowservice.RespondActivityTaskFailedByIdResponse:
@@ -432,7 +440,9 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 	case *workflowservice.SignalWorkflowExecutionResponse:
 		return nil
 	case *workflowservice.StartActivityExecutionRequest:
-		return nil
+		return []tag.Tag{
+			tag.ActivityID(r.GetActivityId()),
+		}
 	case *workflowservice.StartActivityExecutionResponse:
 		return []tag.Tag{
 			tag.WorkflowRunID(r.GetRunId()),
@@ -455,7 +465,8 @@ func (wt *WorkflowTags) extractFromWorkflowServiceServerMessage(message any) []t
 		return nil
 	case *workflowservice.TerminateActivityExecutionRequest:
 		return []tag.Tag{
-			tag.WorkflowRunID(r.GetRunId()),
+			tag.ActivityID(r.GetActivityId()),
+			tag.ChasmRunID(r.GetRunId()),
 		}
 	case *workflowservice.TerminateActivityExecutionResponse:
 		return nil

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4425,7 +4425,7 @@ func (ms *MutableStateImpl) AddActivityTaskCanceledEvent(
 			tag.WorkflowEventID(ms.GetNextEventID()),
 			tag.ErrorTypeInvalidHistoryAction,
 			tag.WorkflowScheduledEventID(scheduledEventID),
-			tag.WorkflowActivityID(ai.ActivityId),
+			tag.ActivityID(ai.ActivityId),
 			tag.WorkflowStartedEventID(ai.StartedEventId))
 		return nil, ms.createInternalServerError(opTag)
 	}

--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -450,7 +450,7 @@ func (s *ActivityTestSuite) TestActivityHeartBeatWorkflow_Success() {
 		s.Equal(id, task.WorkflowExecution.GetWorkflowId())
 		s.Equal(activityName, task.ActivityType.GetName())
 		for i := range 10 {
-			s.Logger.Info("Heartbeating for activity", tag.WorkflowActivityID(task.ActivityId), tag.Counter(i))
+			s.Logger.Info("Heartbeating for activity", tag.ActivityID(task.ActivityId), tag.Counter(i))
 			_, err := s.FrontendClient().RecordActivityTaskHeartbeat(testcore.NewContext(), &workflowservice.RecordActivityTaskHeartbeatRequest{
 				Namespace: s.Namespace().String(),
 				TaskToken: task.TaskToken,
@@ -986,7 +986,7 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 		s.Equal(id, task.WorkflowExecution.GetWorkflowId())
 		s.Equal(activityName, task.ActivityType.GetName())
 		for i := range 10 {
-			s.Logger.Info("Heartbeating for activity", tag.WorkflowActivityID(task.ActivityId), tag.Counter(i))
+			s.Logger.Info("Heartbeating for activity", tag.ActivityID(task.ActivityId), tag.Counter(i))
 			response, err := s.FrontendClient().RecordActivityTaskHeartbeat(testcore.NewContext(),
 				&workflowservice.RecordActivityTaskHeartbeatRequest{
 					Namespace: s.Namespace().String(),

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -1276,7 +1276,7 @@ func (s *WorkflowTestSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
 	atHandler := func(task *workflowservice.PollActivityTaskQueueResponse) (*commonpb.Payloads, bool, error) {
 		s.EqualValues(tv.WorkflowID(), task.WorkflowExecution.WorkflowId)
 		s.Equal(tv.ActivityType().Name, task.ActivityType.Name)
-		s.Logger.Info("Activity ID", tag.WorkflowActivityID(task.ActivityId))
+		s.Logger.Info("Activity ID", tag.ActivityID(task.ActivityId))
 		return payloads.EncodeString("Activity Result"), false, nil
 	}
 


### PR DESCRIPTION
## What changed?

Extend genrpcserverinterceptors to support `ActivityID` and `OperationID` and `ChasmRunID`

## Why?

Fix and improve logging.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

