### PR TITLE
 add dynamic config to trigger schedule migration to CHASM

### DIFF
--- a/service/worker/scheduler/fx.go
+++ b/service/worker/scheduler/fx.go
@@ -52,6 +52,7 @@ type (
 		specBuilder              *SpecBuilder // workflow dep
 		activityDeps             activityDeps
 		enabledForNs             dynamicconfig.BoolPropertyFnWithNamespaceFilter
+		enableCHASMMigration     dynamicconfig.BoolPropertyFnWithNamespaceFilter
 		globalNSStartWorkflowRPS dynamicconfig.TypedSubscribableWithNamespaceFilter[float64]
 		maxBlobSize              dynamicconfig.IntPropertyFnWithNamespaceFilter
 		localActivitySleepLimit  dynamicconfig.DurationPropertyFnWithNamespaceFilter
@@ -87,6 +88,7 @@ func NewResult(
 			specBuilder:              specBuilder,
 			activityDeps:             params,
 			enabledForNs:             dynamicconfig.WorkerEnableScheduler.Get(dc),
+			enableCHASMMigration:     dynamicconfig.EnableCHASMSchedulerMigration.Get(dc),
 			globalNSStartWorkflowRPS: dynamicconfig.SchedulerNamespaceStartWorkflowRPS.Subscribe(dc),
 			maxBlobSize:              dynamicconfig.BlobSizeLimitError.Get(dc),
 			localActivitySleepLimit:  dynamicconfig.SchedulerLocalActivitySleepLimit.Get(dc),
@@ -101,6 +103,8 @@ func (s *workerComponent) DedicatedWorkerOptions(ns *namespace.Namespace) *worke
 }
 
 func (s *workerComponent) Register(registry sdkworker.Registry, ns *namespace.Namespace, details workercommon.RegistrationDetails) func() {
+	CurrentTweakablePolicies.EnableCHASMMigration = s.enableCHASMMigration(ns.Name().String())
+
 	wfFunc := func(ctx workflow.Context, args *schedulespb.StartScheduleArgs) error {
 		return schedulerWorkflowWithSpecBuilder(ctx, args, s.specBuilder)
 	}

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -158,6 +158,8 @@ type (
 		Version                           SchedulerWorkflowVersion // Used to keep track of schedules version to release new features and for backward compatibility
 		// version 0 corresponds to the schedule version that comes before introducing the Version parameter
 
+		EnableCHASMMigration bool // Whether to automatically migrate this schedule to CHASM (V2)
+
 		// When introducing a new field with new workflow logic, consider generating a new
 		// history for TestReplays using generate_history.sh.
 	}
@@ -316,6 +318,9 @@ func (s *scheduler) run() error {
 			)
 		}
 
+		if s.tweakables.EnableCHASMMigration {
+			s.State.PendingMigration = true
+		}
 		if s.State.PendingMigration {
 			err := s.executeMigration()
 			if err == nil {

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -2464,3 +2464,114 @@ func (s *workflowSuite) TestMigrateFailureThenSignal() {
 	s.Require().NoError(payloads.Decode(canErr.Input, &canArgs))
 	s.True(canArgs.State.PendingMigration, "PendingMigration should be set in CAN state")
 }
+
+func (s *workflowSuite) TestMigrateDynamicConfig() {
+	// Enable migration via tweakable (simulating dynamic config).
+	prevTweakables := CurrentTweakablePolicies
+	CurrentTweakablePolicies.EnableCHASMMigration = true
+	defer func() { CurrentTweakablePolicies = prevTweakables }()
+
+	// Mock MigrateSchedule activity to succeed.
+	s.env.OnActivity(new(activities).MigrateScheduleToChasm, mock.Anything, mock.Anything).Once().Return(nil)
+
+	CurrentTweakablePolicies.IterationsBeforeContinueAsNew = 100
+	s.env.SetStartTime(baseStartTime)
+	s.env.ExecuteWorkflow(SchedulerWorkflow, &schedulespb.StartScheduleArgs{
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{{
+					Interval: durationpb.New(1 * time.Hour),
+				}},
+			},
+			Action: s.defaultAction("myid"),
+		},
+		State: &schedulespb.InternalState{
+			Namespace:     "myns",
+			NamespaceId:   "mynsid",
+			ScheduleId:    "myschedule",
+			ConflictToken: InitialConflictToken,
+		},
+	})
+
+	// Workflow should complete successfully (not CAN) after migration triggered by tweakable.
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+}
+
+func (s *workflowSuite) TestMigrateDynamicConfigFailure() {
+	// Enable migration via tweakable, but activity fails.
+	prevTweakables := CurrentTweakablePolicies
+	CurrentTweakablePolicies.EnableCHASMMigration = true
+	defer func() { CurrentTweakablePolicies = prevTweakables }()
+
+	migrateCalls := 0
+	s.env.OnActivity(new(activities).MigrateScheduleToChasm, mock.Anything, mock.Anything).Return(
+		func(context.Context, *schedulerpb.CreateFromMigrationStateRequest) error {
+			migrateCalls++
+			return errors.New("migration failed")
+		})
+
+	CurrentTweakablePolicies.IterationsBeforeContinueAsNew = 5
+	s.env.SetStartTime(baseStartTime)
+	s.env.ExecuteWorkflow(SchedulerWorkflow, &schedulespb.StartScheduleArgs{
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{{
+					Interval: durationpb.New(1 * time.Hour),
+				}},
+			},
+			Action: s.defaultAction("myid"),
+		},
+		State: &schedulespb.InternalState{
+			Namespace:     "myns",
+			NamespaceId:   "mynsid",
+			ScheduleId:    "myschedule",
+			ConflictToken: InitialConflictToken,
+		},
+	})
+
+	// Workflow should CAN after all iterations, not terminate.
+	s.True(s.env.IsWorkflowCompleted())
+	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+	// Migration attempted every iteration.
+	s.Equal(5, migrateCalls)
+
+	// PendingMigration should be preserved in CAN state.
+	var canErr *workflow.ContinueAsNewError
+	s.Require().ErrorAs(s.env.GetWorkflowError(), &canErr)
+	var canArgs schedulespb.StartScheduleArgs
+	s.Require().NoError(payloads.Decode(canErr.Input, &canArgs))
+	s.True(canArgs.State.PendingMigration, "PendingMigration should be set in CAN state")
+}
+
+func (s *workflowSuite) TestMigrateDynamicConfigDisabledNoMigration() {
+	// Ensure migration does NOT happen when EnableCHASMMigration is false (default).
+	prevTweakables := CurrentTweakablePolicies
+	CurrentTweakablePolicies.EnableCHASMMigration = false
+	defer func() { CurrentTweakablePolicies = prevTweakables }()
+
+	// No activity mock registered -- if migration is attempted, the test will fail.
+
+	CurrentTweakablePolicies.IterationsBeforeContinueAsNew = 3
+	s.env.SetStartTime(baseStartTime)
+	s.env.ExecuteWorkflow(SchedulerWorkflow, &schedulespb.StartScheduleArgs{
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{{
+					Interval: durationpb.New(1 * time.Hour),
+				}},
+			},
+			Action: s.defaultAction("myid"),
+		},
+		State: &schedulespb.InternalState{
+			Namespace:     "myns",
+			NamespaceId:   "mynsid",
+			ScheduleId:    "myschedule",
+			ConflictToken: InitialConflictToken,
+		},
+	})
+
+	// Workflow should CAN normally without attempting migration.
+	s.True(s.env.IsWorkflowCompleted())
+	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+}

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -187,6 +187,115 @@ func TestScheduleMigrationV2AlreadyExists(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestScheduleMigrationDynamicConfig(t *testing.T) {
+	env := testcore.NewEnv(
+		t,
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true),
+	)
+
+	ctx := testcore.NewContext()
+	sid := testcore.RandomizeStr("sched-migrate-dc")
+	wid := testcore.RandomizeStr("sched-migrate-dc-wf")
+	wt := testcore.RandomizeStr("sched-migrate-dc-wt")
+	tq := testcore.RandomizeStr("tq")
+
+	nsName := env.Namespace().String()
+	nsID := env.NamespaceID().String()
+	sched := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{Interval: durationpb.New(1 * time.Hour)},
+			},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   wid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: tq, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+	}
+
+	// Create the V1 (workflow-backed) scheduler directly.
+	startArgs := &schedulespb.StartScheduleArgs{
+		Schedule: sched,
+		State: &schedulespb.InternalState{
+			Namespace:     nsName,
+			NamespaceId:   nsID,
+			ScheduleId:    sid,
+			ConflictToken: scheduler.InitialConflictToken,
+		},
+	}
+	inputPayloads, err := sdk.PreferProtoDataConverter.ToPayloads(startArgs)
+	require.NoError(t, err)
+	v1WorkflowID := scheduler.WorkflowIDPrefix + sid
+	startReq := &workflowservice.StartWorkflowExecutionRequest{
+		Namespace:                nsName,
+		WorkflowId:               v1WorkflowID,
+		WorkflowType:             &commonpb.WorkflowType{Name: scheduler.WorkflowType},
+		TaskQueue:                &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue},
+		Input:                    inputPayloads,
+		Identity:                 "test",
+		RequestId:                uuid.NewString(),
+		WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
+	}
+	_, err = env.GetTestCluster().HistoryClient().StartWorkflowExecution(
+		ctx,
+		common.CreateHistoryStartWorkflowRequest(nsID, startReq, nil, nil, time.Now().UTC()),
+	)
+	require.NoError(t, err)
+
+	// Wait for the per-namespace worker to pick up the V1 workflow.
+	require.Eventually(t, func() bool {
+		desc, err := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
+			ctx,
+			&historyservice.DescribeWorkflowExecutionRequest{
+				NamespaceId: nsID,
+				Request: &workflowservice.DescribeWorkflowExecutionRequest{
+					Namespace: nsName,
+					Execution: &commonpb.WorkflowExecution{WorkflowId: v1WorkflowID},
+				},
+			},
+		)
+		if err != nil {
+			return false
+		}
+		return desc.GetWorkflowExecutionInfo().GetHistoryLength() > 3
+	}, 10*time.Second, 500*time.Millisecond)
+
+	// V1 workflow should automatically migrate due to dynamic config and complete.
+	require.Eventually(t, func() bool {
+		desc, err := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
+			ctx,
+			&historyservice.DescribeWorkflowExecutionRequest{
+				NamespaceId: nsID,
+				Request: &workflowservice.DescribeWorkflowExecutionRequest{
+					Namespace: nsName,
+					Execution: &commonpb.WorkflowExecution{WorkflowId: v1WorkflowID},
+				},
+			},
+		)
+		if err != nil {
+			return false
+		}
+		return desc.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
+	}, 30*time.Second, 500*time.Millisecond)
+
+	// V2 schedule should now exist.
+	_, err = env.GetTestCluster().SchedulerClient().DescribeSchedule(
+		ctx,
+		&schedulerpb.DescribeScheduleRequest{
+			NamespaceId:     nsID,
+			FrontendRequest: &workflowservice.DescribeScheduleRequest{Namespace: nsName, ScheduleId: sid},
+		},
+	)
+	require.NoError(t, err)
+}
+
 func TestScheduleMigrationV1ToV2(t *testing.T) {
 	env := testcore.NewEnv(
 		t,


### PR DESCRIPTION
## Summary
- Adds `EnableCHASMMigration` field to `TweakablePolicies`, wired to the existing `EnableCHASMSchedulerMigration` dynamic config via `MutableSideEffect` for NDE safety
- When enabled, the scheduler workflow sets `PendingMigration` automatically without needing a signal sent to each workflow
- The dynamic config is read in `Register` when the per-namespace worker starts. Changes to the DC take effect on worker restart, which happens on membership changes or namespace updates, but not on DC changes alone.

## Test plan
- [x] Unit tests for tweakable policies migration enablement
- [x] Functional test verifying dynamic config triggers migration end-to-end