### PR TITLE
Fix panic in WorkerDeploymentSuite

### DIFF
--- a/tests/worker_deployment_test.go
+++ b/tests/worker_deployment_test.go
@@ -2084,7 +2084,7 @@ func (s *WorkerDeploymentSuite) TestConcurrentPollers_DifferentTaskQueues_SameVe
 				Version:   tvI.DeploymentVersionString(),
 			})
 			a.NoError(err)
-			a.True(proto.Equal(tvI.ExternalDeploymentVersion(), resp.GetWorkerDeploymentVersionInfo().GetDeploymentVersion()))
+			a.Equal(tvI.ExternalDeploymentVersion(), resp.GetWorkerDeploymentVersionInfo().GetDeploymentVersion())
 		}, time.Minute, time.Second)
 	}
 


### PR DESCRIPTION
## What changed?
WISOTT

## Why?
Panics after the sub test finished were causing failures and CI issues

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Test only
