### PR TITLE
Make delete visibility last step in force delete

### DIFF
--- a/service/history/api/forcedeleteworkflowexecution/api.go
+++ b/service/history/api/forcedeleteworkflowexecution/api.go
@@ -84,19 +84,6 @@ func Invoke(
 		}
 	}
 
-	// NOTE: the deletion is best effort, for sql visibility implementation,
-	// we can't guarantee there's no update or record close request for this workflow since
-	// visibility queue processing is async. Operator can call this api again to delete visibility
-	// record again if this happens.
-	if err := persistenceVisibilityMgr.DeleteWorkflowExecution(ctx, &manager.VisibilityDeleteWorkflowExecutionRequest{
-		NamespaceID: namespace.ID(request.GetNamespaceId()),
-		WorkflowID:  execution.GetWorkflowId(),
-		RunID:       execution.GetRunId(),
-		TaskID:      math.MaxInt64,
-	}); err != nil {
-		return nil, err
-	}
-
 	if err := persistenceExecutionMgr.DeleteCurrentWorkflowExecution(ctx, &persistence.DeleteCurrentWorkflowExecutionRequest{
 		ShardID:     shardID,
 		NamespaceID: request.NamespaceId,
@@ -126,6 +113,19 @@ func Invoke(
 			logger.Warn(warnMsg, tag.WorkflowBranchID(string(branchToken)), tag.Error(err))
 			warnings = append(warnings, fmt.Sprintf("%s. BranchToken: %v, Error: %v", warnMsg, branchToken, err.Error()))
 		}
+	}
+
+	// NOTE: the deletion is best effort, for sql visibility implementation,
+	// we can't guarantee there's no update or record close request for this workflow since
+	// visibility queue processing is async. Operator can call this api again to delete visibility
+	// record again if this happens.
+	if err := persistenceVisibilityMgr.DeleteWorkflowExecution(ctx, &manager.VisibilityDeleteWorkflowExecutionRequest{
+		NamespaceID: namespace.ID(request.GetNamespaceId()),
+		WorkflowID:  execution.GetWorkflowId(),
+		RunID:       execution.GetRunId(),
+		TaskID:      math.MaxInt64,
+	}); err != nil {
+		return nil, err
 	}
 
 	return &historyservice.ForceDeleteWorkflowExecutionResponse{


### PR DESCRIPTION
## What changed?
- Make delete visibility the last step in force delete execution flow

## Why?
- Force delete is by namespace deletion workflow which relies on visibility to determine if an execution is deleted or not. If we delete visibility first in force delete, but fail at a later step, then namespace deletion workflow will no longer see that execution and won't retry to continue deleting it. Delete visibility last to fix that.
- Force delete logic can work regardless if execution actually exists or not, so it's ok to delete mutable state first.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
