### PR TITLE
Optimize MySQL and PostgreSQL CI containers for test performance

### DIFF
--- a/develop/github/docker-compose.yml
+++ b/develop/github/docker-compose.yml
@@ -24,7 +24,17 @@ services:
       - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: root
-    command: --max-connections=500
+    command: >-
+      --max-connections=500
+      --innodb-flush-log-at-trx-commit=0
+      --innodb-flush-method=nosync
+      --innodb-doublewrite=0
+      --innodb-log-buffer-size=64M
+      --innodb-buffer-pool-size=512M
+      --sync-binlog=0
+      --skip-log-bin
+    tmpfs:
+      - /var/lib/mysql:size=2G
     volumes:
       - ./mysql-init:/docker-entrypoint-initdb.d
     healthcheck:
@@ -38,7 +48,18 @@ services:
     environment:
       POSTGRES_USER: temporal
       POSTGRES_PASSWORD: temporal
-    command: postgres -c max_connections=500
+    command: >-
+      postgres
+      -c max_connections=500
+      -c synchronous_commit=off
+      -c fsync=off
+      -c full_page_writes=off
+      -c wal_level=minimal
+      -c max_wal_senders=0
+      -c shared_buffers=256MB
+      -c work_mem=16MB
+    tmpfs:
+      - /var/lib/postgresql/data:size=2G
     volumes:
       - ./postgresql-init:/docker-entrypoint-initdb.d
     healthcheck:


### PR DESCRIPTION
## Summary

- Disable durability guarantees (fsync, doublewrite, binlog, full page writes) on MySQL and PostgreSQL CI containers
- Mount data directories on tmpfs to eliminate disk I/O entirely
- These settings only affect crash recovery (durability), not transaction isolation or consistency

### MySQL flags added
- `innodb-flush-log-at-trx-commit=0` - don't fsync redo log on every commit
- `innodb-flush-method=nosync` - skip fsync syscall
- `innodb-doublewrite=0` - skip doublewrite buffer
- `innodb-buffer-pool-size=512M` - larger in-memory cache (up from 128M default)
- `innodb-log-buffer-size=64M` - larger redo log buffer
- `sync-binlog=0` / `skip-log-bin` - disable binary logging
- `tmpfs` at `/var/lib/mysql` (2GB)

### PostgreSQL flags added
- `fsync=off` - skip all fsync calls
- `synchronous_commit=off` - don't wait for WAL flush on commit
- `full_page_writes=off` - skip full page images in WAL
- `wal_level=minimal` / `max_wal_senders=0` - minimal WAL overhead
- `shared_buffers=256MB` - larger shared memory cache
- `work_mem=16MB` - more memory for sorts/joins
- `tmpfs` at `/var/lib/postgresql/data` (2GB)

## Test plan

- [x] Local A/B test with smoke tests (MySQL: 75s -> 71s, PostgreSQL: 72s -> 71s — modest gains expected locally due to macOS Docker VM and fast NVMe)
- [ ] CI A/B comparison: compare this PR's job durations against recent main runs (baseline captured from runs 23058493365 and 23057581982)
- [ ] Verify no test failures introduced by the config changes


Made with [Cursor](https://cursor.com)