### PR TITLE
Make Nexus work OOTB with token-based callback routing

### DIFF
--- a/chasm/lib/callback/fx.go
+++ b/chasm/lib/callback/fx.go
@@ -9,6 +9,8 @@ import (
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
 	queuescommon "go.temporal.io/server/service/history/queues/common"
 	"go.uber.org/fx"
 )
@@ -23,6 +25,7 @@ func register(
 // httpCallerProviderProvider provides an HTTPCallerProvider for CHASM callbacks.
 func httpCallerProviderProvider(
 	clusterMetadata cluster.Metadata,
+	namespaceRegistry namespace.Registry,
 	rpcFactory common.RPCFactory,
 	httpClientCache *cluster.FrontendHTTPClientCache,
 	logger log.Logger,
@@ -32,12 +35,15 @@ func httpCallerProviderProvider(
 		return nil, fmt.Errorf("cannot create local frontend HTTP client: %w", err)
 	}
 	defaultClient := &http.Client{}
+	callbackTokenGenerator := commonnexus.NewCallbackTokenGenerator()
 
 	m := collection.NewOnceMap(func(queuescommon.NamespaceIDAndDestination) HTTPCaller {
 		return func(r *http.Request) (*http.Response, error) {
 			return routeRequest(r,
 				clusterMetadata,
+				namespaceRegistry,
 				httpClientCache,
+				callbackTokenGenerator,
 				defaultClient,
 				localClient,
 				logger,

--- a/chasm/lib/callback/request.go
+++ b/chasm/lib/callback/request.go
@@ -1,29 +1,98 @@
 package callback
 
 import (
+	"errors"
 	"net/http"
 
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
-	"go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
 )
 
 // Header key used to identify callbacks that originate from and target the same cluster.
 // Note: this is the nexusoperations.NexusCallbackSourceHeader stripped of Nexus-Callback-
 const callbackSourceHeader = "source"
 
+// routeSystemCallbackRequest routes a system callback request to the appropriate frontend client
+// based on the callback token's namespace and active cluster.
+func routeSystemCallbackRequest(
+	r *http.Request,
+	clusterMetadata cluster.Metadata,
+	namespaceRegistry namespace.Registry,
+	httpClientCache *cluster.FrontendHTTPClientCache,
+	callbackTokenGenerator *commonnexus.CallbackTokenGenerator,
+	localClient *common.FrontendHTTPClient,
+	logger log.Logger,
+) (*http.Response, error) {
+	var frontendClient *common.FrontendHTTPClient
+	if r.Header != nil {
+		token, err := commonnexus.DecodeCallbackToken(r.Header.Get(commonnexus.CallbackTokenHeader))
+		if err != nil {
+			logger.Error("failed to decode callback token", tag.Error(err))
+			return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid callback token")
+		}
+
+		completion, err := callbackTokenGenerator.DecodeCompletion(token)
+		if err != nil {
+			logger.Error("failed to decode completion from token", tag.Error(err))
+			return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid callback token")
+		}
+		ns, err := namespaceRegistry.GetNamespaceByID(namespace.ID(completion.NamespaceId))
+		if err != nil {
+			logger.Error("failed to get namespace for nexus completion request", tag.WorkflowNamespaceID(completion.NamespaceId), tag.Error(err))
+			var nfe *serviceerror.NamespaceNotFound
+			if errors.As(err, &nfe) {
+				return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeNotFound, "namespace %q not found", completion.NamespaceId)
+			}
+			return nil, commonnexus.ConvertGRPCError(err, false)
+		}
+		clusterName := ns.ActiveClusterName(completion.GetWorkflowId())
+		if clusterMetadata.GetCurrentClusterName() == clusterName {
+			frontendClient = localClient
+		} else {
+			fec, err := httpClientCache.Get(clusterName)
+			if err != nil {
+				logger.Warn(
+					"HTTPCallerProvider unable to get FrontendHTTPClient for callback target cluster. Using local HTTP Client.",
+					tag.SourceCluster(clusterMetadata.GetCurrentClusterName()),
+					tag.TargetCluster(clusterName),
+					tag.Error(err),
+				)
+				frontendClient = localClient
+			} else {
+				frontendClient = fec
+			}
+		}
+	} else {
+		frontendClient = localClient
+	}
+	r.URL.Path = commonnexus.PathCompletionCallbackNoIdentifier
+	r.URL.Scheme = frontendClient.Scheme
+	r.URL.Host = frontendClient.Address
+	r.Host = frontendClient.Address
+	return frontendClient.Do(r)
+}
+
 func routeRequest(
 	r *http.Request,
 	clusterMetadata cluster.Metadata,
+	namespaceRegistry namespace.Registry,
 	httpClientCache *cluster.FrontendHTTPClientCache,
+	callbackTokenGenerator *commonnexus.CallbackTokenGenerator,
 	defaultClient *http.Client,
 	localClient *common.FrontendHTTPClient,
 	logger log.Logger,
 ) (*http.Response, error) {
+	if r.URL.String() == commonnexus.SystemCallbackURL {
+		return routeSystemCallbackRequest(r, clusterMetadata, namespaceRegistry, httpClientCache, callbackTokenGenerator, localClient, logger)
+	}
 	// This source header is populated in nexusoperations/executors (via the ClientProvider) for worker targets
-	// if this header is not populated then we assume it's and external target.
+	// if this header is not populated then we assume it's an external target.
 	if r.Header == nil || r.Header.Get(callbackSourceHeader) == "" {
 		return defaultClient.Do(r)
 	}
@@ -61,9 +130,6 @@ func routeRequest(
 		frontendClient = localClient
 	}
 
-	if r.URL.String() == nexus.SystemCallbackURL {
-		r.URL.Path = nexus.PathCompletionCallbackNoIdentifier
-	}
 	r.URL.Scheme = frontendClient.Scheme
 	r.URL.Host = frontendClient.Address
 	r.Host = frontendClient.Address

--- a/chasm/lib/callback/request_test.go
+++ b/chasm/lib/callback/request_test.go
@@ -1,0 +1,324 @@
+package callback
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"go.uber.org/mock/gomock"
+)
+
+func newTestFrontendHTTPClient(ts *httptest.Server) *common.FrontendHTTPClient {
+	u, _ := url.Parse(ts.URL)
+	return &common.FrontendHTTPClient{
+		Client:  *ts.Client(),
+		Address: u.Host,
+		Scheme:  u.Scheme,
+	}
+}
+
+func TestRouteRequest_ExternalTarget(t *testing.T) {
+	// When no source header is set, the request should be sent via the default client.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	ctrl := gomock.NewController(t)
+	clusterMeta := cluster.NewMockMetadata(ctrl)
+
+	r, err := http.NewRequest(http.MethodPost, ts.URL+"/some/path", nil)
+	require.NoError(t, err)
+
+	resp, err := routeRequest(
+		r,
+		clusterMeta,
+		nil, // namespaceRegistry not needed for external targets
+		nil, // httpClientCache not needed for external targets
+		nil, // callbackTokenGenerator not needed for external targets
+		ts.Client(),
+		nil, // localClient not needed for external targets
+		log.NewNoopLogger(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRouteRequest_SourceHeaderLocal(t *testing.T) {
+	// When the source header matches the local cluster, the request should be routed to the local client.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ts.Close()
+
+	ctrl := gomock.NewController(t)
+	clusterMeta := cluster.NewMockMetadata(ctrl)
+	clusterMeta.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
+		"cluster-A": {ClusterID: "cluster-id-A"},
+	})
+	clusterMeta.EXPECT().GetCurrentClusterName().Return("cluster-A")
+
+	localClient := newTestFrontendHTTPClient(ts)
+
+	r, err := http.NewRequest(http.MethodPost, "http://original-host/some/path", nil)
+	require.NoError(t, err)
+	r.Header.Set(callbackSourceHeader, "cluster-id-A")
+
+	resp, err := routeRequest(
+		r,
+		clusterMeta,
+		nil, // namespaceRegistry
+		nil, // httpClientCache - not used since it's the local cluster
+		nil, // callbackTokenGenerator
+		&http.Client{},
+		localClient,
+		log.NewNoopLogger(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+}
+
+func TestRouteRequest_SourceHeaderUnknownCluster(t *testing.T) {
+	// When the source header doesn't match any known cluster, falls back to local client.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ts.Close()
+
+	ctrl := gomock.NewController(t)
+	clusterMeta := cluster.NewMockMetadata(ctrl)
+	clusterMeta.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
+		"cluster-A": {ClusterID: "cluster-id-A"},
+	})
+	clusterMeta.EXPECT().GetCurrentClusterName().Return("cluster-A")
+
+	localClient := newTestFrontendHTTPClient(ts)
+
+	r, err := http.NewRequest(http.MethodPost, "http://original-host/some/path", nil)
+	require.NoError(t, err)
+	r.Header.Set(callbackSourceHeader, "unknown-cluster-id")
+
+	resp, err := routeRequest(
+		r,
+		clusterMeta,
+		nil,
+		nil,
+		nil,
+		&http.Client{},
+		localClient,
+		log.NewNoopLogger(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+}
+
+func TestRouteSystemCallbackRequest_NilHeaders(t *testing.T) {
+	// When the request has nil headers, it should fall back to the local client.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, commonnexus.PathCompletionCallbackNoIdentifier, r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	localClient := newTestFrontendHTTPClient(ts)
+
+	r := &http.Request{
+		Method: http.MethodPost,
+		URL:    &url.URL{Path: "/"},
+		Header: nil,
+	}
+
+	resp, err := routeSystemCallbackRequest(
+		r,
+		nil, // clusterMetadata - not needed for nil headers path
+		nil, // namespaceRegistry
+		nil, // httpClientCache
+		nil, // callbackTokenGenerator
+		localClient,
+		log.NewNoopLogger(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRouteSystemCallbackRequest_InvalidToken(t *testing.T) {
+	r, err := http.NewRequest(http.MethodPost, commonnexus.SystemCallbackURL, nil)
+	require.NoError(t, err)
+	r.Header.Set(commonnexus.CallbackTokenHeader, "not-valid-json")
+
+	_, err = routeSystemCallbackRequest(
+		r,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		log.NewNoopLogger(),
+	)
+	require.Error(t, err)
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+	require.Contains(t, handlerErr.Error(), "invalid callback token")
+}
+
+func TestRouteSystemCallbackRequest_InvalidTokenData(t *testing.T) {
+	// Valid token structure but invalid data field.
+	r, err := http.NewRequest(http.MethodPost, commonnexus.SystemCallbackURL, nil)
+	require.NoError(t, err)
+	r.Header.Set(commonnexus.CallbackTokenHeader, `{"v":1,"d":"!!!invalid-base64"}`)
+
+	tokenGen := commonnexus.NewCallbackTokenGenerator()
+
+	_, err = routeSystemCallbackRequest(
+		r,
+		nil,
+		nil,
+		nil,
+		tokenGen,
+		nil,
+		log.NewNoopLogger(),
+	)
+	require.Error(t, err)
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+}
+
+func TestRouteSystemCallbackRequest_NamespaceNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	nsRegistry := namespace.NewMockRegistry(ctrl)
+
+	tokenGen := commonnexus.NewCallbackTokenGenerator()
+	tokenStr, err := tokenGen.Tokenize(&tokenspb.NexusOperationCompletion{
+		NamespaceId: "ns-id-1",
+		WorkflowId:  "wf-1",
+	})
+	require.NoError(t, err)
+
+	nsRegistry.EXPECT().GetNamespaceByID(namespace.ID("ns-id-1")).Return(
+		nil, serviceerror.NewNamespaceNotFound("ns-id-1"),
+	)
+
+	r, err := http.NewRequest(http.MethodPost, commonnexus.SystemCallbackURL, nil)
+	require.NoError(t, err)
+	r.Header.Set(commonnexus.CallbackTokenHeader, tokenStr)
+
+	_, err = routeSystemCallbackRequest(
+		r,
+		nil,
+		nsRegistry,
+		nil,
+		tokenGen,
+		nil,
+		log.NewNoopLogger(),
+	)
+	require.Error(t, err)
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeNotFound, handlerErr.Type)
+}
+
+func TestRouteSystemCallbackRequest_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, commonnexus.PathCompletionCallbackNoIdentifier, r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	ctrl := gomock.NewController(t)
+	clusterMeta := cluster.NewMockMetadata(ctrl)
+	nsRegistry := namespace.NewMockRegistry(ctrl)
+
+	tokenGen := commonnexus.NewCallbackTokenGenerator()
+	tokenStr, err := tokenGen.Tokenize(&tokenspb.NexusOperationCompletion{
+		NamespaceId: "ns-id-1",
+		WorkflowId:  "wf-1",
+	})
+	require.NoError(t, err)
+
+	testNS := namespace.NewLocalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Id: "ns-id-1", Name: "test-ns"},
+		nil,
+		"cluster-A",
+	)
+	nsRegistry.EXPECT().GetNamespaceByID(namespace.ID("ns-id-1")).Return(testNS, nil)
+
+	// httpClientCache.Get will fail for "cluster-A", so it falls back to localClient.
+	clusterMeta.EXPECT().GetCurrentClusterName().Return("cluster-A").AnyTimes()
+	clusterMeta.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{}).AnyTimes()
+	clusterMeta.EXPECT().RegisterMetadataChangeCallback(gomock.Any(), gomock.Any())
+
+	localClient := newTestFrontendHTTPClient(ts)
+
+	// Create a cache that will fail for the requested cluster since we don't set up metadata fully.
+	httpClientCache := cluster.NewFrontendHTTPClientCache(clusterMeta, nil)
+
+	r, err := http.NewRequest(http.MethodPost, commonnexus.SystemCallbackURL, nil)
+	require.NoError(t, err)
+	r.Header.Set(commonnexus.CallbackTokenHeader, tokenStr)
+
+	resp, err := routeSystemCallbackRequest(
+		r,
+		clusterMeta,
+		nsRegistry,
+		httpClientCache,
+		tokenGen,
+		localClient,
+		log.NewNoopLogger(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRouteRequest_SystemCallback(t *testing.T) {
+	// Verify that routeRequest delegates to routeSystemCallbackRequest for system callback URLs.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, commonnexus.PathCompletionCallbackNoIdentifier, r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	localClient := newTestFrontendHTTPClient(ts)
+
+	// Use nil headers to take the simplest path through routeSystemCallbackRequest.
+	r := &http.Request{
+		Method: http.MethodPost,
+		URL: &url.URL{
+			Scheme: "temporal",
+			Host:   "system",
+		},
+		Header: nil,
+	}
+
+	resp, err := routeRequest(
+		r,
+		nil,
+		nil,
+		nil,
+		nil,
+		&http.Client{},
+		localClient,
+		log.NewNoopLogger(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/components/callbacks/fx.go
+++ b/components/callbacks/fx.go
@@ -8,6 +8,8 @@ import (
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
 	queuescommon "go.temporal.io/server/service/history/queues/common"
 	"go.uber.org/fx"
 )
@@ -23,6 +25,7 @@ var Module = fx.Module(
 
 func HTTPCallerProviderProvider(
 	clusterMetadata cluster.Metadata,
+	namespaceRegistry namespace.Registry,
 	rpcFactory common.RPCFactory,
 	httpClientCache *cluster.FrontendHTTPClientCache,
 	logger log.Logger,
@@ -32,17 +35,19 @@ func HTTPCallerProviderProvider(
 		return nil, fmt.Errorf("cannot create local frontend HTTP client: %w", err)
 	}
 	defaultClient := &http.Client{}
+	callbackTokenGenerator := commonnexus.NewCallbackTokenGenerator()
 
 	m := collection.NewOnceMap(func(queuescommon.NamespaceIDAndDestination) HTTPCaller {
 		return func(r *http.Request) (*http.Response, error) {
 			return routeRequest(r,
 				clusterMetadata,
+				namespaceRegistry,
 				httpClientCache,
+				callbackTokenGenerator,
 				defaultClient,
 				localClient,
 				logger,
 			)
-
 		}
 	})
 	return m.Get, nil

--- a/components/callbacks/request.go
+++ b/components/callbacks/request.go
@@ -1,29 +1,98 @@
 package callbacks
 
 import (
+	"errors"
 	"net/http"
 
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
-	"go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
 )
 
 // Header key used to identify callbacks that originate from and target the same cluster.
 // Note: this is the nexusoperations.NexusCallbackSourceHeader stripped of Nexus-Callback-
 const callbackSourceHeader = "source"
 
+// routeSystemCallbackRequest routes a system callback request to the appropriate frontend client
+// based on the callback token's namespace and active cluster.
+func routeSystemCallbackRequest(
+	r *http.Request,
+	clusterMetadata cluster.Metadata,
+	namespaceRegistry namespace.Registry,
+	httpClientCache *cluster.FrontendHTTPClientCache,
+	callbackTokenGenerator *commonnexus.CallbackTokenGenerator,
+	localClient *common.FrontendHTTPClient,
+	logger log.Logger,
+) (*http.Response, error) {
+	var frontendClient *common.FrontendHTTPClient
+	if r.Header != nil {
+		token, err := commonnexus.DecodeCallbackToken(r.Header.Get(commonnexus.CallbackTokenHeader))
+		if err != nil {
+			logger.Error("failed to decode callback token", tag.Error(err))
+			return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid callback token")
+		}
+
+		completion, err := callbackTokenGenerator.DecodeCompletion(token)
+		if err != nil {
+			logger.Error("failed to decode completion from token", tag.Error(err))
+			return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid callback token")
+		}
+		ns, err := namespaceRegistry.GetNamespaceByID(namespace.ID(completion.NamespaceId))
+		if err != nil {
+			logger.Error("failed to get namespace for nexus completion request", tag.WorkflowNamespaceID(completion.NamespaceId), tag.Error(err))
+			var nfe *serviceerror.NamespaceNotFound
+			if errors.As(err, &nfe) {
+				return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeNotFound, "namespace %q not found", completion.NamespaceId)
+			}
+			return nil, commonnexus.ConvertGRPCError(err, false)
+		}
+		clusterName := ns.ActiveClusterName(completion.GetWorkflowId())
+		if clusterMetadata.GetCurrentClusterName() == clusterName {
+			frontendClient = localClient
+		} else {
+			fec, err := httpClientCache.Get(clusterName)
+			if err != nil {
+				logger.Warn(
+					"HTTPCallerProvider unable to get FrontendHTTPClient for callback target cluster. Using local HTTP Client.",
+					tag.SourceCluster(clusterMetadata.GetCurrentClusterName()),
+					tag.TargetCluster(clusterName),
+					tag.Error(err),
+				)
+				frontendClient = localClient
+			} else {
+				frontendClient = fec
+			}
+		}
+	} else {
+		frontendClient = localClient
+	}
+	r.URL.Path = commonnexus.PathCompletionCallbackNoIdentifier
+	r.URL.Scheme = frontendClient.Scheme
+	r.URL.Host = frontendClient.Address
+	r.Host = frontendClient.Address
+	return frontendClient.Do(r)
+}
+
 func routeRequest(
 	r *http.Request,
 	clusterMetadata cluster.Metadata,
+	namespaceRegistry namespace.Registry,
 	httpClientCache *cluster.FrontendHTTPClientCache,
+	callbackTokenGenerator *commonnexus.CallbackTokenGenerator,
 	defaultClient *http.Client,
 	localClient *common.FrontendHTTPClient,
 	logger log.Logger,
 ) (*http.Response, error) {
+	if r.URL.String() == commonnexus.SystemCallbackURL {
+		return routeSystemCallbackRequest(r, clusterMetadata, namespaceRegistry, httpClientCache, callbackTokenGenerator, localClient, logger)
+	}
 	// This source header is populated in nexusoperations/executors (via the ClientProvider) for worker targets
-	// if this header is not populated then we assume it's and external target.
+	// if this header is not populated then we assume it's an external target.
 	if r.Header == nil || r.Header.Get(callbackSourceHeader) == "" {
 		return defaultClient.Do(r)
 	}
@@ -61,9 +130,6 @@ func routeRequest(
 		frontendClient = localClient
 	}
 
-	if r.URL.String() == nexus.SystemCallbackURL {
-		r.URL.Path = nexus.PathCompletionCallbackNoIdentifier
-	}
 	r.URL.Scheme = frontendClient.Scheme
 	r.URL.Host = frontendClient.Address
 	r.Host = frontendClient.Address

--- a/components/callbacks/request_test.go
+++ b/components/callbacks/request_test.go
@@ -1,0 +1,324 @@
+package callbacks
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"go.uber.org/mock/gomock"
+)
+
+func newTestFrontendHTTPClient(ts *httptest.Server) *common.FrontendHTTPClient {
+	u, _ := url.Parse(ts.URL)
+	return &common.FrontendHTTPClient{
+		Client:  *ts.Client(),
+		Address: u.Host,
+		Scheme:  u.Scheme,
+	}
+}
+
+func TestRouteRequest_ExternalTarget(t *testing.T) {
+	// When no source header is set, the request should be sent via the default client.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	ctrl := gomock.NewController(t)
+	clusterMeta := cluster.NewMockMetadata(ctrl)
+
+	r, err := http.NewRequest(http.MethodPost, ts.URL+"/some/path", nil)
+	require.NoError(t, err)
+
+	resp, err := routeRequest(
+		r,
+		clusterMeta,
+		nil, // namespaceRegistry not needed for external targets
+		nil, // httpClientCache not needed for external targets
+		nil, // callbackTokenGenerator not needed for external targets
+		ts.Client(),
+		nil, // localClient not needed for external targets
+		log.NewNoopLogger(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRouteRequest_SourceHeaderLocal(t *testing.T) {
+	// When the source header matches the local cluster, the request should be routed to the local client.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ts.Close()
+
+	ctrl := gomock.NewController(t)
+	clusterMeta := cluster.NewMockMetadata(ctrl)
+	clusterMeta.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
+		"cluster-A": {ClusterID: "cluster-id-A"},
+	})
+	clusterMeta.EXPECT().GetCurrentClusterName().Return("cluster-A")
+
+	localClient := newTestFrontendHTTPClient(ts)
+
+	r, err := http.NewRequest(http.MethodPost, "http://original-host/some/path", nil)
+	require.NoError(t, err)
+	r.Header.Set(callbackSourceHeader, "cluster-id-A")
+
+	resp, err := routeRequest(
+		r,
+		clusterMeta,
+		nil, // namespaceRegistry
+		nil, // httpClientCache - not used since it's the local cluster
+		nil, // callbackTokenGenerator
+		&http.Client{},
+		localClient,
+		log.NewNoopLogger(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+}
+
+func TestRouteRequest_SourceHeaderUnknownCluster(t *testing.T) {
+	// When the source header doesn't match any known cluster, falls back to local client.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ts.Close()
+
+	ctrl := gomock.NewController(t)
+	clusterMeta := cluster.NewMockMetadata(ctrl)
+	clusterMeta.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
+		"cluster-A": {ClusterID: "cluster-id-A"},
+	})
+	clusterMeta.EXPECT().GetCurrentClusterName().Return("cluster-A")
+
+	localClient := newTestFrontendHTTPClient(ts)
+
+	r, err := http.NewRequest(http.MethodPost, "http://original-host/some/path", nil)
+	require.NoError(t, err)
+	r.Header.Set(callbackSourceHeader, "unknown-cluster-id")
+
+	resp, err := routeRequest(
+		r,
+		clusterMeta,
+		nil,
+		nil,
+		nil,
+		&http.Client{},
+		localClient,
+		log.NewNoopLogger(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+}
+
+func TestRouteSystemCallbackRequest_NilHeaders(t *testing.T) {
+	// When the request has nil headers, it should fall back to the local client.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, commonnexus.PathCompletionCallbackNoIdentifier, r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	localClient := newTestFrontendHTTPClient(ts)
+
+	r := &http.Request{
+		Method: http.MethodPost,
+		URL:    &url.URL{Path: "/"},
+		Header: nil,
+	}
+
+	resp, err := routeSystemCallbackRequest(
+		r,
+		nil, // clusterMetadata - not needed for nil headers path
+		nil, // namespaceRegistry
+		nil, // httpClientCache
+		nil, // callbackTokenGenerator
+		localClient,
+		log.NewNoopLogger(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRouteSystemCallbackRequest_InvalidToken(t *testing.T) {
+	r, err := http.NewRequest(http.MethodPost, commonnexus.SystemCallbackURL, nil)
+	require.NoError(t, err)
+	r.Header.Set(commonnexus.CallbackTokenHeader, "not-valid-json")
+
+	_, err = routeSystemCallbackRequest(
+		r,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		log.NewNoopLogger(),
+	)
+	require.Error(t, err)
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+	require.Contains(t, handlerErr.Error(), "invalid callback token")
+}
+
+func TestRouteSystemCallbackRequest_InvalidTokenData(t *testing.T) {
+	// Valid token structure but invalid data field.
+	r, err := http.NewRequest(http.MethodPost, commonnexus.SystemCallbackURL, nil)
+	require.NoError(t, err)
+	r.Header.Set(commonnexus.CallbackTokenHeader, `{"v":1,"d":"!!!invalid-base64"}`)
+
+	tokenGen := commonnexus.NewCallbackTokenGenerator()
+
+	_, err = routeSystemCallbackRequest(
+		r,
+		nil,
+		nil,
+		nil,
+		tokenGen,
+		nil,
+		log.NewNoopLogger(),
+	)
+	require.Error(t, err)
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+}
+
+func TestRouteSystemCallbackRequest_NamespaceNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	nsRegistry := namespace.NewMockRegistry(ctrl)
+
+	tokenGen := commonnexus.NewCallbackTokenGenerator()
+	tokenStr, err := tokenGen.Tokenize(&tokenspb.NexusOperationCompletion{
+		NamespaceId: "ns-id-1",
+		WorkflowId:  "wf-1",
+	})
+	require.NoError(t, err)
+
+	nsRegistry.EXPECT().GetNamespaceByID(namespace.ID("ns-id-1")).Return(
+		nil, serviceerror.NewNamespaceNotFound("ns-id-1"),
+	)
+
+	r, err := http.NewRequest(http.MethodPost, commonnexus.SystemCallbackURL, nil)
+	require.NoError(t, err)
+	r.Header.Set(commonnexus.CallbackTokenHeader, tokenStr)
+
+	_, err = routeSystemCallbackRequest(
+		r,
+		nil,
+		nsRegistry,
+		nil,
+		tokenGen,
+		nil,
+		log.NewNoopLogger(),
+	)
+	require.Error(t, err)
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeNotFound, handlerErr.Type)
+}
+
+func TestRouteSystemCallbackRequest_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, commonnexus.PathCompletionCallbackNoIdentifier, r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	ctrl := gomock.NewController(t)
+	clusterMeta := cluster.NewMockMetadata(ctrl)
+	nsRegistry := namespace.NewMockRegistry(ctrl)
+
+	tokenGen := commonnexus.NewCallbackTokenGenerator()
+	tokenStr, err := tokenGen.Tokenize(&tokenspb.NexusOperationCompletion{
+		NamespaceId: "ns-id-1",
+		WorkflowId:  "wf-1",
+	})
+	require.NoError(t, err)
+
+	testNS := namespace.NewLocalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Id: "ns-id-1", Name: "test-ns"},
+		nil,
+		"cluster-A",
+	)
+	nsRegistry.EXPECT().GetNamespaceByID(namespace.ID("ns-id-1")).Return(testNS, nil)
+
+	// httpClientCache.Get will fail for "cluster-A", so it falls back to localClient.
+	clusterMeta.EXPECT().GetCurrentClusterName().Return("cluster-A").AnyTimes()
+	clusterMeta.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{}).AnyTimes()
+	clusterMeta.EXPECT().RegisterMetadataChangeCallback(gomock.Any(), gomock.Any())
+
+	localClient := newTestFrontendHTTPClient(ts)
+
+	// Create a cache that will fail for the requested cluster since we don't set up metadata fully.
+	httpClientCache := cluster.NewFrontendHTTPClientCache(clusterMeta, nil)
+
+	r, err := http.NewRequest(http.MethodPost, commonnexus.SystemCallbackURL, nil)
+	require.NoError(t, err)
+	r.Header.Set(commonnexus.CallbackTokenHeader, tokenStr)
+
+	resp, err := routeSystemCallbackRequest(
+		r,
+		clusterMeta,
+		nsRegistry,
+		httpClientCache,
+		tokenGen,
+		localClient,
+		log.NewNoopLogger(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRouteRequest_SystemCallback(t *testing.T) {
+	// Verify that routeRequest delegates to routeSystemCallbackRequest for system callback URLs.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, commonnexus.PathCompletionCallbackNoIdentifier, r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	localClient := newTestFrontendHTTPClient(ts)
+
+	// Use nil headers to take the simplest path through routeSystemCallbackRequest.
+	r := &http.Request{
+		Method: http.MethodPost,
+		URL: &url.URL{
+			Scheme: "temporal",
+			Host:   "system",
+		},
+		Header: nil,
+	}
+
+	resp, err := routeRequest(
+		r,
+		nil,
+		nil,
+		nil,
+		nil,
+		&http.Client{},
+		localClient,
+		log.NewNoopLogger(),
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -77,14 +77,14 @@ Uses Go's len() function on header keys and values to determine the total size.`
 
 var UseSystemCallbackURL = dynamicconfig.NewGlobalBoolSetting(
 	"component.nexusoperations.useSystemCallbackURL",
-	false,
+	true,
 	`UseSystemCallbackURL is a global feature toggle that controls how the executor generates
 	callback URLs for worker targets in Nexus Operations.When set to true,
 	the executor will use the fixed system callback URL ("temporal://system") for all worker targets,
 	instead of generating URLs from the callback URL template.
 	This simplifies configuration and improves reliability for worker callbacks.
-	- false (default): The executor uses the callback URL template to generate callback URLs for worker targets.
-	- true: The executor uses the fixed system callback URL ("temporal://system") for worker targets.
+	- false: The executor uses the callback URL template to generate callback URLs for worker targets.
+	- true (default): The executor uses the fixed system callback URL ("temporal://system") for worker targets.
 	Note: The default will switch to true in future releases.`,
 )
 


### PR DESCRIPTION
## Summary
- Use the system callback URL by default now that the previous minor supports it (1.30)
- Extract system callback URL handling from `routeRequest` into a dedicated `routeSystemCallbackRequest` function that routes based on callback token namespace and active cluster
- Update both `components/callbacks` and `chasm/lib/callback` packages to use namespace registry and callback token generator for routing decisions
- Add unit tests for `routeRequest` and `routeSystemCallbackRequest` covering external targets, local/unknown cluster routing, nil headers, invalid tokens, namespace not found, and success paths

## Test plan
- [x] Unit tests added for both `components/callbacks` and `chasm/lib/callback` packages
- [x] All 18 tests pass (9 per package)
- [x] `make lint` passes with no new issues