### PR TITLE
Add default testhooks.NewHook impl

### DIFF
--- a/common/testing/testhooks/noop_impl.go
+++ b/common/testing/testhooks/noop_impl.go
@@ -39,6 +39,10 @@ func Call[S any](_ TestHooks, _ Key[func(), S], _ S) {}
 // Hook is an empty stub in production mode. NewHook and its methods are only available with -tags=test_dep.
 type Hook struct{}
 
+func NewHook[T any, S any](_ Key[T, S], _ T) Hook {
+	panic("testhooks.NewHook called but TestHooks are not enabled: use -tags=test_dep when running `go test`")
+}
+
 func (h Hook) Scope() ScopeType {
 	panic("testhooks.Hook used but TestHooks are not enabled: use -tags=test_dep when running `go test`")
 }


### PR DESCRIPTION
## What changed?

Add default testhooks.NewHook impl that panics.

## Why?

Only a few tests use testhooks.NewHook; by adding this default impl, the others can be run without using `-tags test_dep`. This is particularly useful with agentic coding as it reduces friction.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

