### PR TITLE
Add t.Parallel() to TestEnv suites

### DIFF
--- a/tests/activity_api_pause_test.go
+++ b/tests/activity_api_pause_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestActivityApiPauseClientTestSuite(t *testing.T) {
+	t.Parallel()
 	t.Run("TestActivityPauseApi_WhileRunning", func(t *testing.T) {
 		s := testcore.NewEnv(t, testcore.WithSdkWorker())
 

--- a/tests/max_buffered_event_test.go
+++ b/tests/max_buffered_event_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestMaxBufferedEventSuite(t *testing.T) {
+	t.Parallel()
 	commonOpts := []testcore.TestOption{
 		testcore.WithSdkWorker(),
 		// Set MaximumBufferedEventsSizeInBytes high so we don't hit that limit.

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -69,6 +69,7 @@ func closeShard(s testcore.Env, wid string) {
 }
 
 func TestWorkflowUpdateSuite(t *testing.T) {
+	t.Parallel()
 	t.Run("EmptySpeculativeWorkflowTask_AcceptComplete", func(t *testing.T) {
 		testCases := []struct {
 			name     string


### PR DESCRIPTION
## What changed?

Add t.Parallel() to all TestEnv suites.

## Why?

Each test case automatically becomes parallel when using TestEnv; but the wrapper test ("suite") must still manually be marked as parallel.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
