### PR TITLE
Run TestTaskQueueStats suites in parallel

### DIFF
--- a/tests/task_queue_stats_test.go
+++ b/tests/task_queue_stats_test.go
@@ -61,13 +61,11 @@ func newTaskQueueStatsSuite(t *testing.T, env testcore.Env, usePriMatcher bool) 
 
 // TODO(pri): remove once the classic matcher is removed
 func TestTaskQueueStats_Classic_Suite(t *testing.T) {
-	testcore.MustRunSequential(t, "tests flake when run in parallel")
 	t.Parallel()
 	runTaskQueueStatsTests(t, false) // usePriMatcher = false
 }
 
 func TestTaskQueueStats_Pri_Suite(t *testing.T) {
-	testcore.MustRunSequential(t, "tests flake when run in parallel")
 	t.Parallel()
 	runTaskQueueStatsTests(t, true) // usePriMatcher = true
 }

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -965,7 +965,7 @@ func sdkClientFactoryProvider(
 }
 
 func (c *TemporalImpl) overrideDynamicConfig(t *testing.T, name dynamicconfig.Key, value any) func() {
-	cleanup := c.dcClient.OverrideValue(name, value)
+	cleanup := c.dcClient.PartialOverrideValue(name, value)
 	t.Cleanup(cleanup)
 	return cleanup
 }


### PR DESCRIPTION
## Why?

Run faster.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Ran it 3x locally and they passed 3x (wasn't the case before https://github.com/temporalio/temporal/pull/9390)