### PR TITLE
Add Noop impl of NewHook in common/testing/testhooks

### DIFF
--- a/common/testing/testhooks/noop_impl.go
+++ b/common/testing/testhooks/noop_impl.go
@@ -39,6 +39,10 @@ func Call[S any](_ TestHooks, _ Key[func(), S], _ S) {}
 // Hook is an empty stub in production mode. NewHook and its methods are only available with -tags=test_dep.
 type Hook struct{}
 
+func NewHook[T any, S any](_ Key[T, S], _ T) Hook {
+	panic("testhooks.NewHook called but TestHooks are not enabled: use -tags=test_dep when running `go test`")
+}
+
 func (h Hook) Scope() ScopeType {
 	panic("testhooks.Hook used but TestHooks are not enabled: use -tags=test_dep when running `go test`")
 }


### PR DESCRIPTION
## What changed?
WISOTT

## Why?
Shows up as not findable without the `-tags=test_dep` build tag, adding a noop impl will prevent errors with language servers. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
NA
