### PR TITLE
Add completed_by_worker_shutdown field in poll responses

### DIFF
--- a/api/matchingservice/v1/request_response.pb.go
+++ b/api/matchingservice/v1/request_response.pb.go
@@ -145,9 +145,12 @@ type PollWorkflowTaskQueueResponse struct {
 	PollerScalingDecision *v14.PollerScalingDecision `protobuf:"bytes,21,opt,name=poller_scaling_decision,json=pollerScalingDecision,proto3" json:"poller_scaling_decision,omitempty"`
 	// Raw history bytes sent from matching service when history.sendRawHistoryBetweenInternalServices is enabled.
 	// Matching client will deserialize this to History when it receives the response.
-	RawHistory    *v16.History `protobuf:"bytes,22,opt,name=raw_history,json=rawHistory,proto3" json:"raw_history,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	RawHistory *v16.History `protobuf:"bytes,22,opt,name=raw_history,json=rawHistory,proto3" json:"raw_history,omitempty"`
+	// When true, this empty response was caused by the server completing the poll
+	// because the worker has been shut down via the ShutdownWorker API.
+	CompletedByWorkerShutdown bool `protobuf:"varint,23,opt,name=completed_by_worker_shutdown,json=completedByWorkerShutdown,proto3" json:"completed_by_worker_shutdown,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
 }
 
 func (x *PollWorkflowTaskQueueResponse) Reset() {
@@ -327,6 +330,13 @@ func (x *PollWorkflowTaskQueueResponse) GetRawHistory() *v16.History {
 	return nil
 }
 
+func (x *PollWorkflowTaskQueueResponse) GetCompletedByWorkerShutdown() bool {
+	if x != nil {
+		return x.CompletedByWorkerShutdown
+	}
+	return false
+}
+
 // PollWorkflowTaskQueueResponseWithRawHistory is wire-compatible with PollWorkflowTaskQueueResponse.
 //
 // WIRE COMPATIBILITY PATTERN:
@@ -374,9 +384,12 @@ type PollWorkflowTaskQueueResponseWithRawHistory struct {
 	// Raw history bytes. Each element is a proto-encoded batch of history events.
 	// When matching client deserializes this to PollWorkflowTaskQueueResponse, this field
 	// will be automatically deserialized to the raw_history field as History.
-	RawHistory    [][]byte `protobuf:"bytes,22,rep,name=raw_history,json=rawHistory,proto3" json:"raw_history,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	RawHistory [][]byte `protobuf:"bytes,22,rep,name=raw_history,json=rawHistory,proto3" json:"raw_history,omitempty"`
+	// When true, this empty response was caused by the server completing the poll
+	// because the worker has been shut down via the ShutdownWorker API.
+	CompletedByWorkerShutdown bool `protobuf:"varint,23,opt,name=completed_by_worker_shutdown,json=completedByWorkerShutdown,proto3" json:"completed_by_worker_shutdown,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
 }
 
 func (x *PollWorkflowTaskQueueResponseWithRawHistory) Reset() {
@@ -556,6 +569,13 @@ func (x *PollWorkflowTaskQueueResponseWithRawHistory) GetRawHistory() [][]byte {
 	return nil
 }
 
+func (x *PollWorkflowTaskQueueResponseWithRawHistory) GetCompletedByWorkerShutdown() bool {
+	if x != nil {
+		return x.CompletedByWorkerShutdown
+	}
+	return false
+}
+
 type PollActivityTaskQueueRequest struct {
 	state           protoimpl.MessageState           `protogen:"open.v1"`
 	NamespaceId     string                           `protobuf:"bytes,1,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty"`
@@ -662,8 +682,11 @@ type PollActivityTaskQueueResponse struct {
 	RetryPolicy                 *v11.RetryPolicy           `protobuf:"bytes,19,opt,name=retry_policy,json=retryPolicy,proto3" json:"retry_policy,omitempty"`
 	// ID of the activity run (applicable for standalone activities only)
 	ActivityRunId string `protobuf:"bytes,20,opt,name=activity_run_id,json=activityRunId,proto3" json:"activity_run_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// When true, this empty response was caused by the server completing the poll
+	// because the worker has been shut down via the ShutdownWorker API.
+	CompletedByWorkerShutdown bool `protobuf:"varint,21,opt,name=completed_by_worker_shutdown,json=completedByWorkerShutdown,proto3" json:"completed_by_worker_shutdown,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
 }
 
 func (x *PollActivityTaskQueueResponse) Reset() {
@@ -834,6 +857,13 @@ func (x *PollActivityTaskQueueResponse) GetActivityRunId() string {
 		return x.ActivityRunId
 	}
 	return ""
+}
+
+func (x *PollActivityTaskQueueResponse) GetCompletedByWorkerShutdown() bool {
+	if x != nil {
+		return x.CompletedByWorkerShutdown
+	}
+	return false
 }
 
 type AddWorkflowTaskRequest struct {
@@ -4087,9 +4117,12 @@ func (x *PollNexusTaskQueueRequest) GetConditions() *PollConditions {
 type PollNexusTaskQueueResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Response that should be delivered to the worker containing a request from DispatchNexusTaskRequest.
-	Response      *v1.PollNexusTaskQueueResponse `protobuf:"bytes,1,opt,name=response,proto3" json:"response,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Response *v1.PollNexusTaskQueueResponse `protobuf:"bytes,1,opt,name=response,proto3" json:"response,omitempty"`
+	// When true, this empty response was caused by the server completing the poll
+	// because the worker has been shut down via the ShutdownWorker API.
+	CompletedByWorkerShutdown bool `protobuf:"varint,2,opt,name=completed_by_worker_shutdown,json=completedByWorkerShutdown,proto3" json:"completed_by_worker_shutdown,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
 }
 
 func (x *PollNexusTaskQueueResponse) Reset() {
@@ -4127,6 +4160,13 @@ func (x *PollNexusTaskQueueResponse) GetResponse() *v1.PollNexusTaskQueueRespons
 		return x.Response
 	}
 	return nil
+}
+
+func (x *PollNexusTaskQueueResponse) GetCompletedByWorkerShutdown() bool {
+	if x != nil {
+		return x.CompletedByWorkerShutdown
+	}
+	return false
 }
 
 type RespondNexusTaskCompletedRequest struct {
@@ -5749,7 +5789,7 @@ const file_temporal_server_api_matchingservice_v1_request_response_proto_rawDesc
 	"\x10forwarded_source\x18\x04 \x01(\tR\x0fforwardedSource\x12V\n" +
 	"\n" +
 	"conditions\x18\x05 \x01(\v26.temporal.server.api.matchingservice.v1.PollConditionsR\n" +
-	"conditions\"\xd1\v\n" +
+	"conditions\"\x92\f\n" +
 	"\x1dPollWorkflowTaskQueueResponse\x12\x1d\n" +
 	"\n" +
 	"task_token\x18\x01 \x01(\fR\ttaskToken\x12X\n" +
@@ -5774,10 +5814,11 @@ const file_temporal_server_api_matchingservice_v1_request_response_proto_rawDesc
 	"\x0fnext_page_token\x18\x14 \x01(\fR\rnextPageToken\x12h\n" +
 	"\x17poller_scaling_decision\x18\x15 \x01(\v20.temporal.api.taskqueue.v1.PollerScalingDecisionR\x15pollerScalingDecision\x12A\n" +
 	"\vraw_history\x18\x16 \x01(\v2 .temporal.api.history.v1.HistoryR\n" +
-	"rawHistory\x1a`\n" +
+	"rawHistory\x12?\n" +
+	"\x1ccompleted_by_worker_shutdown\x18\x17 \x01(\bR\x19completedByWorkerShutdown\x1a`\n" +
 	"\fQueriesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12:\n" +
-	"\x05value\x18\x02 \x01(\v2$.temporal.api.query.v1.WorkflowQueryR\x05value:\x028\x01J\x04\b\r\x10\x0e\"\xcb\v\n" +
+	"\x05value\x18\x02 \x01(\v2$.temporal.api.query.v1.WorkflowQueryR\x05value:\x028\x01J\x04\b\r\x10\x0e\"\x8c\f\n" +
 	"+PollWorkflowTaskQueueResponseWithRawHistory\x12\x1d\n" +
 	"\n" +
 	"task_token\x18\x01 \x01(\fR\ttaskToken\x12X\n" +
@@ -5802,7 +5843,8 @@ const file_temporal_server_api_matchingservice_v1_request_response_proto_rawDesc
 	"\x0fnext_page_token\x18\x14 \x01(\fR\rnextPageToken\x12h\n" +
 	"\x17poller_scaling_decision\x18\x15 \x01(\v20.temporal.api.taskqueue.v1.PollerScalingDecisionR\x15pollerScalingDecision\x12\x1f\n" +
 	"\vraw_history\x18\x16 \x03(\fR\n" +
-	"rawHistory\x1a`\n" +
+	"rawHistory\x12?\n" +
+	"\x1ccompleted_by_worker_shutdown\x18\x17 \x01(\bR\x19completedByWorkerShutdown\x1a`\n" +
 	"\fQueriesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12:\n" +
 	"\x05value\x18\x02 \x01(\v2$.temporal.api.query.v1.WorkflowQueryR\x05value:\x028\x01J\x04\b\r\x10\x0e\"\xc3\x02\n" +
@@ -5813,8 +5855,7 @@ const file_temporal_server_api_matchingservice_v1_request_response_proto_rawDesc
 	"\x10forwarded_source\x18\x04 \x01(\tR\x0fforwardedSource\x12V\n" +
 	"\n" +
 	"conditions\x18\x05 \x01(\v26.temporal.server.api.matchingservice.v1.PollConditionsR\n" +
-	"conditions\"\xc0\n" +
-	"\n" +
+	"conditions\"\x81\v\n" +
 	"\x1dPollActivityTaskQueueResponse\x12\x1d\n" +
 	"\n" +
 	"task_token\x18\x01 \x01(\fR\ttaskToken\x12X\n" +
@@ -5838,7 +5879,8 @@ const file_temporal_server_api_matchingservice_v1_request_response_proto_rawDesc
 	"\x17poller_scaling_decision\x18\x11 \x01(\v20.temporal.api.taskqueue.v1.PollerScalingDecisionR\x15pollerScalingDecision\x12<\n" +
 	"\bpriority\x18\x12 \x01(\v2 .temporal.api.common.v1.PriorityR\bpriority\x12F\n" +
 	"\fretry_policy\x18\x13 \x01(\v2#.temporal.api.common.v1.RetryPolicyR\vretryPolicy\x12&\n" +
-	"\x0factivity_run_id\x18\x14 \x01(\tR\ractivityRunId\"\x9d\x05\n" +
+	"\x0factivity_run_id\x18\x14 \x01(\tR\ractivityRunId\x12?\n" +
+	"\x1ccompleted_by_worker_shutdown\x18\x15 \x01(\bR\x19completedByWorkerShutdown\"\x9d\x05\n" +
 	"\x16AddWorkflowTaskRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12G\n" +
 	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\x12C\n" +
@@ -6087,9 +6129,10 @@ const file_temporal_server_api_matchingservice_v1_request_response_proto_rawDesc
 	"\x10forwarded_source\x18\x04 \x01(\tR\x0fforwardedSource\x12V\n" +
 	"\n" +
 	"conditions\x18\x05 \x01(\v26.temporal.server.api.matchingservice.v1.PollConditionsR\n" +
-	"conditions\"u\n" +
+	"conditions\"\xb6\x01\n" +
 	"\x1aPollNexusTaskQueueResponse\x12W\n" +
-	"\bresponse\x18\x01 \x01(\v2;.temporal.api.workflowservice.v1.PollNexusTaskQueueResponseR\bresponse\"\x80\x02\n" +
+	"\bresponse\x18\x01 \x01(\v2;.temporal.api.workflowservice.v1.PollNexusTaskQueueResponseR\bresponse\x12?\n" +
+	"\x1ccompleted_by_worker_shutdown\x18\x02 \x01(\bR\x19completedByWorkerShutdown\"\x80\x02\n" +
 	" RespondNexusTaskCompletedRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12C\n" +
 	"\n" +

--- a/proto/internal/temporal/server/api/matchingservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/matchingservice/v1/request_response.proto
@@ -62,6 +62,9 @@ message PollWorkflowTaskQueueResponse {
   // Raw history bytes sent from matching service when history.sendRawHistoryBetweenInternalServices is enabled.
   // Matching client will deserialize this to History when it receives the response.
   temporal.api.history.v1.History raw_history = 22;
+  // When true, this empty response was caused by the server completing the poll
+  // because the worker has been shut down via the ShutdownWorker API.
+  bool completed_by_worker_shutdown = 23;
 }
 
 // PollWorkflowTaskQueueResponseWithRawHistory is wire-compatible with PollWorkflowTaskQueueResponse.
@@ -112,6 +115,9 @@ message PollWorkflowTaskQueueResponseWithRawHistory {
   // When matching client deserializes this to PollWorkflowTaskQueueResponse, this field
   // will be automatically deserialized to the raw_history field as History.
   repeated bytes raw_history = 22;
+  // When true, this empty response was caused by the server completing the poll
+  // because the worker has been shut down via the ShutdownWorker API.
+  bool completed_by_worker_shutdown = 23;
 }
 
 message PollActivityTaskQueueRequest {
@@ -149,6 +155,9 @@ message PollActivityTaskQueueResponse {
   temporal.api.common.v1.RetryPolicy retry_policy = 19;
   // ID of the activity run (applicable for standalone activities only)
   string activity_run_id = 20;
+  // When true, this empty response was caused by the server completing the poll
+  // because the worker has been shut down via the ShutdownWorker API.
+  bool completed_by_worker_shutdown = 21;
 }
 
 message AddWorkflowTaskRequest {
@@ -579,6 +588,9 @@ message PollNexusTaskQueueRequest {
 message PollNexusTaskQueueResponse {
   // Response that should be delivered to the worker containing a request from DispatchNexusTaskRequest.
   temporal.api.workflowservice.v1.PollNexusTaskQueueResponse response = 1;
+  // When true, this empty response was caused by the server completing the poll
+  // because the worker has been shut down via the ShutdownWorker API.
+  bool completed_by_worker_shutdown = 2;
 }
 
 message RespondNexusTaskCompletedRequest {

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -109,6 +109,12 @@ type (
 		workerControlTaskQueue    string
 	}
 
+	pollResult struct {
+		task             *internalTask
+		versionSetUsed   bool
+		completedByShutdown bool
+	}
+
 	userDataUpdate struct {
 		taskQueue string
 		update    persistence.SingleTaskQueueUserDataUpdate
@@ -694,13 +700,19 @@ pollLoop:
 			workerInstanceKey:         request.WorkerInstanceKey,
 			workerControlTaskQueue:    request.WorkerControlTaskQueue,
 		}
-		task, versionSetUsed, err := e.pollTask(pollerCtx, partition, pollMetadata)
+		result, err := e.pollTask(pollerCtx, partition, pollMetadata)
 		if err != nil {
 			if errors.Is(err, errNoTasks) {
+				if result.completedByShutdown {
+					return &matchingservice.PollWorkflowTaskQueueResponseWithRawHistory{
+						CompletedByWorkerShutdown: true,
+					}, nil
+				}
 				return emptyPollWorkflowTaskQueueResponse, nil
 			}
 			return nil, err
 		}
+		task := result.task
 		if task.isStarted() {
 			// tasks received from remote are already started. So, simply forward the response
 			// no need to emit task dispatch latency metric because the parent partition already did it.
@@ -757,7 +769,7 @@ pollLoop:
 		}
 
 		requestClone := request
-		if versionSetUsed {
+		if result.versionSetUsed {
 			// We remove build ID from workerVersionCapabilities so History can differentiate between
 			// old and new versioning in Record*TaskStart.
 			// TODO: remove this block after old versioning cleanup. [cleanup-old-wv]
@@ -967,20 +979,26 @@ pollLoop:
 			workerInstanceKey:         request.WorkerInstanceKey,
 			workerControlTaskQueue:    request.WorkerControlTaskQueue,
 		}
-		task, versionSetUsed, err := e.pollTask(pollerCtx, partition, pollMetadata)
+		result, err := e.pollTask(pollerCtx, partition, pollMetadata)
 		if err != nil {
 			if errors.Is(err, errNoTasks) {
+				if result.completedByShutdown {
+					return &matchingservice.PollActivityTaskQueueResponse{
+						CompletedByWorkerShutdown: true,
+					}, nil
+				}
 				return emptyPollActivityTaskQueueResponse, nil
 			}
 			return nil, err
 		}
 
+		task := result.task
 		if task.isStarted() {
 			// tasks received from remote are already started. So, simply forward the response
 			return task.pollActivityTaskQueueResponse(), nil
 		}
 		requestClone := request
-		if versionSetUsed {
+		if result.versionSetUsed {
 			// We remove build ID from workerVersionCapabilities so History can differentiate between
 			// old and new versioning in Record*TaskStart.
 			// TODO: remove this block after old versioning cleanup. [cleanup-old-wv]
@@ -2565,14 +2583,20 @@ pollLoop:
 			conditions:                req.Conditions,
 			workerInstanceKey:         request.WorkerInstanceKey,
 		}
-		task, _, err := e.pollTask(pollerCtx, partition, pollMetadata)
+		result, err := e.pollTask(pollerCtx, partition, pollMetadata)
 		if err != nil {
 			if errors.Is(err, errNoTasks) {
+				if result.completedByShutdown {
+					return &matchingservice.PollNexusTaskQueueResponse{
+						CompletedByWorkerShutdown: true,
+					}, nil
+				}
 				return &matchingservice.PollNexusTaskQueueResponse{}, nil
 			}
 			return nil, err
 		}
 
+		task := result.task
 		if task.isStarted() {
 			// tasks received from remote are already started. So, simply forward the response
 			return task.pollNexusTaskQueueResponse(), nil
@@ -2822,10 +2846,10 @@ func (e *matchingEngineImpl) pollTask(
 	ctx context.Context,
 	partition tqid.Partition,
 	pollMetadata *pollMetadata,
-) (*internalTask, bool, error) {
+) (pollResult, error) {
 	pm, _, err := e.getTaskQueuePartitionManager(ctx, partition, true, loadCausePoll)
 	if err != nil {
-		return nil, false, err
+		return pollResult{}, err
 	}
 
 	pollMetadata.localPollStartTime = e.timeSource.Now()
@@ -2842,7 +2866,7 @@ func (e *matchingEngineImpl) pollTask(
 			tag.WorkflowTaskQueueType(partition.TaskType()),
 			tag.NewStringTag("worker-instance-key", workerInstanceKey),
 		)
-		return nil, false, errNoTasks
+		return pollResult{completedByShutdown: true}, errNoTasks
 	}
 
 	ctx, cancel := contextutil.WithDeadlineBuffer(ctx, pm.LongPollExpirationInterval(), returnEmptyTaskTimeBudget)
@@ -2865,7 +2889,8 @@ func (e *matchingEngineImpl) pollTask(
 			}
 		}()
 	}
-	return pm.PollTask(ctx, pollMetadata)
+	task, versionSetUsed, err := pm.PollTask(ctx, pollMetadata)
+	return pollResult{task: task, versionSetUsed: versionSetUsed}, err
 }
 
 // emitTaskDispatchLatency emits latency metrics for a task dispatched to a worker.

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -265,6 +265,8 @@ func newMatchingEngine(
 		timeSource:          clock.NewRealTimeSource(),
 		visibilityManager:   mockVisibilityManager,
 		nexusEndpointClient: newEndpointClient(config.NexusEndpointsRefreshInterval, nexusEndpointManager),
+		workerInstancePollers: workerPollerTracker{pollers: make(map[string]map[string]context.CancelFunc)},
+		shutdownWorkers:       cache.New(shutdownWorkersCacheMaxSize, &cache.Options{TTL: shutdownWorkersCacheTTL}),
 	}
 	e.nexusEndpointsOwnershipLostCh.Store(make(chan struct{}))
 	return e
@@ -276,6 +278,86 @@ func (s *matchingEngineSuite) newPartitionManager(prtn tqid.Partition, config *C
 	pm, err := newTaskQueuePartitionManager(s.matchingEngine, s.ns, prtn, tqConfig, logger, logger, metricsHandler, &mockUserDataManager{})
 	s.Require().NoError(err)
 	return pm
+}
+
+func (s *matchingEngineSuite) TestPollWorkflowTaskQueue_CompletedByWorkerShutdown() {
+	namespaceID := uuid.NewString()
+	tl := "shutdown-test-tq"
+	workerKey := "test-worker-instance"
+
+	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(time.Minute)
+
+	// Shut down the worker so subsequent polls are rejected.
+	_, err := s.matchingEngine.CancelOutstandingWorkerPolls(context.Background(),
+		&matchingservice.CancelOutstandingWorkerPollsRequest{
+			WorkerInstanceKey: workerKey,
+		})
+	s.NoError(err)
+
+	resp, err := s.matchingEngine.PollWorkflowTaskQueue(context.Background(), &matchingservice.PollWorkflowTaskQueueRequest{
+		NamespaceId: namespaceID,
+		PollRequest: &workflowservice.PollWorkflowTaskQueueRequest{
+			TaskQueue:         &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:          "test-identity",
+			WorkerInstanceKey: workerKey,
+		},
+	}, metrics.NoopMetricsHandler)
+	s.NoError(err)
+	s.True(resp.GetCompletedByWorkerShutdown(), "response should have CompletedByWorkerShutdown set")
+	s.Empty(resp.GetTaskToken(), "response should have no task token")
+}
+
+func (s *matchingEngineSuite) TestPollActivityTaskQueue_CompletedByWorkerShutdown() {
+	namespaceID := uuid.NewString()
+	tl := "shutdown-test-tq"
+	workerKey := "test-worker-instance"
+
+	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(time.Minute)
+
+	// Shut down the worker so subsequent polls are rejected.
+	_, err := s.matchingEngine.CancelOutstandingWorkerPolls(context.Background(),
+		&matchingservice.CancelOutstandingWorkerPollsRequest{
+			WorkerInstanceKey: workerKey,
+		})
+	s.NoError(err)
+
+	resp, err := s.matchingEngine.PollActivityTaskQueue(context.Background(), &matchingservice.PollActivityTaskQueueRequest{
+		NamespaceId: namespaceID,
+		PollRequest: &workflowservice.PollActivityTaskQueueRequest{
+			TaskQueue:         &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:          "test-identity",
+			WorkerInstanceKey: workerKey,
+		},
+	}, metrics.NoopMetricsHandler)
+	s.NoError(err)
+	s.True(resp.GetCompletedByWorkerShutdown(), "response should have CompletedByWorkerShutdown set")
+	s.Empty(resp.GetTaskToken(), "response should have no task token")
+}
+
+func (s *matchingEngineSuite) TestPollNexusTaskQueue_CompletedByWorkerShutdown() {
+	namespaceID := uuid.NewString()
+	tl := "shutdown-test-tq"
+	workerKey := "test-worker-instance"
+
+	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueue(time.Minute)
+
+	// Shut down the worker so subsequent polls are rejected.
+	_, err := s.matchingEngine.CancelOutstandingWorkerPolls(context.Background(),
+		&matchingservice.CancelOutstandingWorkerPollsRequest{
+			WorkerInstanceKey: workerKey,
+		})
+	s.NoError(err)
+
+	resp, err := s.matchingEngine.PollNexusTaskQueue(context.Background(), &matchingservice.PollNexusTaskQueueRequest{
+		NamespaceId: namespaceID,
+		Request: &workflowservice.PollNexusTaskQueueRequest{
+			TaskQueue:         &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:          "test-identity",
+			WorkerInstanceKey: workerKey,
+		},
+	}, metrics.NoopMetricsHandler)
+	s.NoError(err)
+	s.True(resp.GetCompletedByWorkerShutdown(), "response should have CompletedByWorkerShutdown set")
 }
 
 func (s *matchingEngineSuite) TestPollActivityTaskQueuesEmptyResult() {
@@ -328,6 +410,7 @@ func (s *matchingEngineSuite) PollForTasksEmptyResultTest(callContext context.Co
 			}, metrics.NoopMetricsHandler)
 			s.NoError(err)
 			s.Equal(emptyPollActivityTaskQueueResponse, pollResp)
+			s.False(pollResp.GetCompletedByWorkerShutdown())
 
 			taskQueueType = enumspb.TASK_QUEUE_TYPE_ACTIVITY
 		} else {
@@ -340,6 +423,7 @@ func (s *matchingEngineSuite) PollForTasksEmptyResultTest(callContext context.Co
 			}, metrics.NoopMetricsHandler)
 			s.NoError(err)
 			s.Equal(emptyPollWorkflowTaskQueueResponse, resp)
+			s.False(resp.GetCompletedByWorkerShutdown())
 
 			taskQueueType = enumspb.TASK_QUEUE_TYPE_WORKFLOW
 		}
@@ -545,6 +629,7 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues() {
 	}, metrics.NoopMetricsHandler)
 	s.NoError(err)
 	s.Equal(emptyPollWorkflowTaskQueueResponse, resp)
+	s.False(resp.GetCompletedByWorkerShutdown())
 
 	// add task to sticky queue again, this time it should pass
 	_, _, err = s.matchingEngine.AddWorkflowTask(context.Background(), &addRequest)
@@ -585,6 +670,7 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues() {
 
 	s.Nil(err)
 	s.Equal(expectedResp, resp)
+	s.False(resp.GetCompletedByWorkerShutdown())
 }
 
 func (s *matchingEngineSuite) TestPollWorkflowTaskQueues_NamespaceHandover() {
@@ -1776,6 +1862,7 @@ func (s *matchingEngineSuite) TestPollWithExpiredContext() {
 	}, metrics.NoopMetricsHandler)
 	s.Nil(err)
 	s.Equal(emptyPollActivityTaskQueueResponse, resp)
+	s.False(resp.GetCompletedByWorkerShutdown())
 }
 
 func (s *matchingEngineSuite) TestForceUnloadTaskQueue() {
@@ -2154,14 +2241,16 @@ func (s *matchingEngineSuite) TestAddTaskAfterStartFailure() {
 	s.NoError(err)
 	s.EqualValues(1, s.taskManager.getTaskCount(dbq))
 
-	task1, _, err := s.matchingEngine.pollTask(context.Background(), dbq.partition, &pollMetadata{})
+	result1, err := s.matchingEngine.pollTask(context.Background(), dbq.partition, &pollMetadata{})
 	s.NoError(err)
+	task1 := result1.task
 
 	task1.finish(serviceerror.NewInternal("test error"), true)
 	s.EqualValues(1, s.taskManager.getTaskCount(dbq))
 
-	task2, _, err := s.matchingEngine.pollTask(context.Background(), dbq.partition, &pollMetadata{})
+	result2, err := s.matchingEngine.pollTask(context.Background(), dbq.partition, &pollMetadata{})
 	s.NoError(err)
+	task2 := result2.task
 	protoassert.ProtoEqual(s.T(), task1.event.Data, task2.event.Data)
 	s.NotEqual(task1.event.GetTaskId(), task2.event.GetTaskId(), "IDs should not match")
 
@@ -2800,16 +2889,16 @@ func (s *matchingEngineSuite) TestUnknownBuildId_Match() {
 
 	go func() {
 		prtn := newRootPartition(namespaceID, tq, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
-		task, _, err := s.matchingEngine.pollTask(ctx, prtn, &pollMetadata{
+		result, err := s.matchingEngine.pollTask(ctx, prtn, &pollMetadata{
 			workerVersionCapabilities: &commonpb.WorkerVersionCapabilities{
 				BuildId:       "unknown",
 				UseVersioning: true,
 			},
 		})
 		s.NoError(err)
-		s.Equal("wf", task.event.Data.WorkflowId)
-		s.Equal(int64(123), task.event.Data.ScheduledEventId)
-		task.finish(nil, true)
+		s.Equal("wf", result.task.event.Data.WorkflowId)
+		s.Equal(int64(123), result.task.event.Data.ScheduledEventId)
+		result.task.finish(nil, true)
 		wg.Done()
 	}()
 
@@ -2909,16 +2998,16 @@ func (s *matchingEngineSuite) TestDemotedMatch() {
 	s.NoError(err)
 
 	// now poll for the task
-	task, _, err := s.matchingEngine.pollTask(ctx, prtn, &pollMetadata{
+	result, err := s.matchingEngine.pollTask(ctx, prtn, &pollMetadata{
 		workerVersionCapabilities: &commonpb.WorkerVersionCapabilities{
 			BuildId:       build1,
 			UseVersioning: true,
 		},
 	})
 	s.Require().NoError(err)
-	s.Equal("wf", task.event.Data.WorkflowId)
-	s.Equal(int64(123), task.event.Data.ScheduledEventId)
-	task.finish(nil, true)
+	s.Equal("wf", result.task.event.Data.WorkflowId)
+	s.Equal(int64(123), result.task.event.Data.ScheduledEventId)
+	result.task.finish(nil, true)
 }
 
 type mockRoutingMatchingClient struct {
@@ -5988,3 +6077,4 @@ func TestAutoEnableV2ConfigChange_NoUnloadWhenEffectiveConfigUnchanged(t *testin
 		}
 	}, 100*time.Millisecond, 10*time.Millisecond, "physical queue should NOT be stopped when effective config does not change")
 }
+

--- a/tests/task_queue_test.go
+++ b/tests/task_queue_test.go
@@ -1496,10 +1496,6 @@ func (s *TaskQueueSuite) TestShutdownWorkerCancelsOutstandingPolls() {
 	s.NoError(err)
 	s.NotNil(rePollResp)
 	s.Empty(rePollResp.GetTaskToken(), "re-poll from shutdown worker should return empty response")
-	// TODO: Replace timing assertion with an explicit poll response field indicating
-	// shutdown rejection, so we don't rely on timing to distinguish cache rejection
-	// from natural poll timeout. Requires adding a field to PollWorkflowTaskQueueResponse
-	// and PollActivityTaskQueueResponse in the public API proto.
 	s.Less(time.Since(wfStart), 2*time.Minute, "workflow re-poll should be rejected quickly, not wait for timeout")
 
 	// Activity poll should also be rejected immediately.


### PR DESCRIPTION
## What
Add `completed_by_worker_shutdown` bool field to matching-internal poll response protos. When matching detects a poll from a shut-down worker, it sets this field in the response. The field is not propagated to the public API — it's for internal debugging of the frontend-to-matching RPCs.

## Why
Gives us visibility into whether matching is correctly rejecting re-polls from shut-down workers, without changing the public API.

## How did you test it?
- Unit tests  verify `completedByShutdown` behavior.