### PR TITLE
Bump go.temporal.io/sdk to v1.41.0 and regenerate mocks

### DIFF
--- a/common/testing/mocksdk/client_mock.go
+++ b/common/testing/mocksdk/client_mock.go
@@ -100,6 +100,20 @@ func (mr *MockClientMockRecorder) CompleteActivity(ctx, taskToken, result, err a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteActivity", reflect.TypeOf((*MockClient)(nil).CompleteActivity), ctx, taskToken, result, err)
 }
 
+// CompleteActivityByActivityID mocks base method.
+func (m *MockClient) CompleteActivityByActivityID(ctx context.Context, namespace, activityID, activityRunID string, result any, err error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CompleteActivityByActivityID", ctx, namespace, activityID, activityRunID, result, err)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CompleteActivityByActivityID indicates an expected call of CompleteActivityByActivityID.
+func (mr *MockClientMockRecorder) CompleteActivityByActivityID(ctx, namespace, activityID, activityRunID, result, err any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteActivityByActivityID", reflect.TypeOf((*MockClient)(nil).CompleteActivityByActivityID), ctx, namespace, activityID, activityRunID, result, err)
+}
+
 // CompleteActivityByID mocks base method.
 func (m *MockClient) CompleteActivityByID(ctx context.Context, namespace, workflowID, runID, activityID string, result any, err error) error {
 	m.ctrl.T.Helper()
@@ -112,6 +126,21 @@ func (m *MockClient) CompleteActivityByID(ctx context.Context, namespace, workfl
 func (mr *MockClientMockRecorder) CompleteActivityByID(ctx, namespace, workflowID, runID, activityID, result, err any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteActivityByID", reflect.TypeOf((*MockClient)(nil).CompleteActivityByID), ctx, namespace, workflowID, runID, activityID, result, err)
+}
+
+// CountActivities mocks base method.
+func (m *MockClient) CountActivities(ctx context.Context, options client.CountActivitiesOptions) (*client.CountActivitiesResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountActivities", ctx, options)
+	ret0, _ := ret[0].(*client.CountActivitiesResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountActivities indicates an expected call of CountActivities.
+func (mr *MockClientMockRecorder) CountActivities(ctx, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountActivities", reflect.TypeOf((*MockClient)(nil).CountActivities), ctx, options)
 }
 
 // CountWorkflow mocks base method.
@@ -203,6 +232,26 @@ func (mr *MockClientMockRecorder) DescribeWorkflowExecution(ctx, workflowID, run
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeWorkflowExecution", reflect.TypeOf((*MockClient)(nil).DescribeWorkflowExecution), ctx, workflowID, runID)
 }
 
+// ExecuteActivity mocks base method.
+func (m *MockClient) ExecuteActivity(ctx context.Context, options client.StartActivityOptions, activity any, args ...any) (client.ActivityHandle, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, options, activity}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExecuteActivity", varargs...)
+	ret0, _ := ret[0].(client.ActivityHandle)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExecuteActivity indicates an expected call of ExecuteActivity.
+func (mr *MockClientMockRecorder) ExecuteActivity(ctx, options, activity any, args ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, options, activity}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteActivity", reflect.TypeOf((*MockClient)(nil).ExecuteActivity), varargs...)
+}
+
 // ExecuteWorkflow mocks base method.
 func (m *MockClient) ExecuteWorkflow(ctx context.Context, options client.StartWorkflowOptions, workflow any, args ...any) (client.WorkflowRun, error) {
 	m.ctrl.T.Helper()
@@ -221,6 +270,20 @@ func (mr *MockClientMockRecorder) ExecuteWorkflow(ctx, options, workflow any, ar
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, options, workflow}, args...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteWorkflow", reflect.TypeOf((*MockClient)(nil).ExecuteWorkflow), varargs...)
+}
+
+// GetActivityHandle mocks base method.
+func (m *MockClient) GetActivityHandle(options client.GetActivityHandleOptions) client.ActivityHandle {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActivityHandle", options)
+	ret0, _ := ret[0].(client.ActivityHandle)
+	return ret0
+}
+
+// GetActivityHandle indicates an expected call of GetActivityHandle.
+func (mr *MockClientMockRecorder) GetActivityHandle(options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActivityHandle", reflect.TypeOf((*MockClient)(nil).GetActivityHandle), options)
 }
 
 // GetSearchAttributes mocks base method.
@@ -323,6 +386,21 @@ func (m *MockClient) GetWorkflowUpdateHandle(ref client.GetWorkflowUpdateHandleO
 func (mr *MockClientMockRecorder) GetWorkflowUpdateHandle(ref any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowUpdateHandle", reflect.TypeOf((*MockClient)(nil).GetWorkflowUpdateHandle), ref)
+}
+
+// ListActivities mocks base method.
+func (m *MockClient) ListActivities(ctx context.Context, options client.ListActivitiesOptions) (client.ListActivitiesResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListActivities", ctx, options)
+	ret0, _ := ret[0].(client.ListActivitiesResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListActivities indicates an expected call of ListActivities.
+func (mr *MockClientMockRecorder) ListActivities(ctx, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActivities", reflect.TypeOf((*MockClient)(nil).ListActivities), ctx, options)
 }
 
 // ListArchivedWorkflow mocks base method.

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/maruel/panicparse/v2 v2.4.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/nexus-rpc/sdk-go v0.5.2-0.20260211051645-26b0b4c584e5
+	github.com/nexus-rpc/sdk-go v0.6.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/olivere/elastic/v7 v7.0.32
 	github.com/pkg/errors v0.9.1
@@ -61,7 +61,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
 	go.temporal.io/api v1.62.4
-	go.temporal.io/sdk v1.38.0
+	go.temporal.io/sdk v1.41.0
 	go.uber.org/fx v1.24.0
 	go.uber.org/mock v0.6.0
 	go.uber.org/multierr v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/nexus-rpc/sdk-go v0.5.2-0.20260211051645-26b0b4c584e5 h1:Van9KGGs8lcDgxzSNFbDhEMNeJ80TbBxwZ45f9iBk9U=
-github.com/nexus-rpc/sdk-go v0.5.2-0.20260211051645-26b0b4c584e5/go.mod h1:FHdPfVQwRuJFZFTF0Y2GOAxCrbIBNrcPna9slkGKPYk=
+github.com/nexus-rpc/sdk-go v0.6.0 h1:QRgnP2zTbxEbiyWG/aXH8uSC5LV/Mg1fqb19jb4DBlo=
+github.com/nexus-rpc/sdk-go v0.6.0/go.mod h1:FHdPfVQwRuJFZFTF0Y2GOAxCrbIBNrcPna9slkGKPYk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
@@ -378,8 +378,8 @@ go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
 go.temporal.io/api v1.62.4 h1:XxstCG0LWfAqMsQAMk8kIx92l47FtJlIOKFWF3ydOUE=
 go.temporal.io/api v1.62.4/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
-go.temporal.io/sdk v1.38.0 h1:4Bok5LEdED7YKpsSjIa3dDqram5VOq+ydBf4pyx0Wo4=
-go.temporal.io/sdk v1.38.0/go.mod h1:a+R2Ej28ObvHoILbHaxMyind7M6D+W0L7edt5UJF4SE=
+go.temporal.io/sdk v1.41.0 h1:c9tayCQJDM5ZQdrqjGmjqk5ejxUtsEScJGF94sAVYpM=
+go.temporal.io/sdk v1.41.0/go.mod h1:/InXQT5guZ6AizYzpmzr5avQ/GMgq1ZObcKlKE2AhTc=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=


### PR DESCRIPTION
Bumps go.temporal.io/sdk to v1.41.0 and github.com/nexus-rpc/sdk-go to v0.6.0. 
Regenerated client mock picks up new Client interface methods: ExecuteActivity, GetActivityHandle, ListActivities, CountActivities, and CompleteActivityByActivityID.

## What changed?
  - Bumped go.temporal.io/sdk from v1.38.0 to v1.41.0                            
  - Bumped github.com/nexus-rpc/sdk-go from v0.5.2-prerelease to v0.6.0
  - Regenerated common/testing/mocksdk/client_mock.go to include new Client interface methods added in the SDK update   

## Why?
Pick up the latest Temporal SDK which adds support for standalone activity execution (ExecuteActivity, GetActivityHandle), activity visibility APIs (ListActivities, CountActivities), and CompleteActivityByActivityID. 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
  - New SDK methods are additive only; no existing APIs changed. Low risk.       
  - Downstream code that implements the Client interface outside of this repo
  will need to add the new methods. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a dependency upgrade; while the code changes are additive and mostly test-only, updating `go.temporal.io/sdk` can introduce behavioral changes at runtime that will surface only under integration workloads.
> 
> **Overview**
> Updates dependencies to `go.temporal.io/sdk v1.41.0` (and `github.com/nexus-rpc/sdk-go v0.6.0`), with corresponding `go.sum` changes.
> 
> Regenerates the GoMock Temporal `Client` mock to match the updated SDK interface by adding new mocked methods: `ExecuteActivity`, `GetActivityHandle`, `ListActivities`, `CountActivities`, and `CompleteActivityByActivityID`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a87618fc0b58f63a107de21f64e66120b12cd3d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->