### PR TITLE
Rename Worker to SdkWorker

### DIFF
--- a/tests/activity_api_batch_reset_test.go
+++ b/tests/activity_api_batch_reset_test.go
@@ -48,8 +48,8 @@ func (s *ActivityApiBatchResetClientTestSuite) TestActivityBatchReset_Success() 
 
 	internalWorkflow := newInternalWorkflow()
 
-	s.Worker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
-	s.Worker().RegisterActivity(internalWorkflow.ActivityFunc)
+	s.SdkWorker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
+	s.SdkWorker().RegisterActivity(internalWorkflow.ActivityFunc)
 
 	workflowRun1 := s.createWorkflow(ctx, internalWorkflow.WorkflowFunc)
 	workflowRun2 := s.createWorkflow(ctx, internalWorkflow.WorkflowFunc)
@@ -176,8 +176,8 @@ func (s *ActivityApiBatchResetClientTestSuite) TestActivityBatchReset_Success_Pr
 
 	internalWorkflow := newInternalWorkflow()
 
-	s.Worker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
-	s.Worker().RegisterActivity(internalWorkflow.ActivityFunc)
+	s.SdkWorker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
+	s.SdkWorker().RegisterActivity(internalWorkflow.ActivityFunc)
 
 	workflowRun1 := s.createWorkflow(ctx, internalWorkflow.WorkflowFunc)
 	workflowRun2 := s.createWorkflow(ctx, internalWorkflow.WorkflowFunc)
@@ -304,8 +304,8 @@ func (s *ActivityApiBatchResetClientTestSuite) TestActivityBatchReset_DontResetA
 
 	internalWorkflow := newInternalWorkflow()
 
-	s.Worker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
-	s.Worker().RegisterActivity(internalWorkflow.ActivityFunc)
+	s.SdkWorker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
+	s.SdkWorker().RegisterActivity(internalWorkflow.ActivityFunc)
 
 	workflowRun1 := s.createWorkflow(ctx, internalWorkflow.WorkflowFunc)
 	workflowRun2 := s.createWorkflow(ctx, internalWorkflow.WorkflowFunc)

--- a/tests/activity_api_batch_unpause_test.go
+++ b/tests/activity_api_batch_unpause_test.go
@@ -97,8 +97,8 @@ func (s *ActivityApiBatchUnpauseClientTestSuite) TestActivityBatchUnpause_Succes
 
 	internalWorkflow := newInternalWorkflow()
 
-	s.Worker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
-	s.Worker().RegisterActivity(internalWorkflow.ActivityFunc)
+	s.SdkWorker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
+	s.SdkWorker().RegisterActivity(internalWorkflow.ActivityFunc)
 
 	workflowRun1 := s.createWorkflow(ctx, internalWorkflow.WorkflowFunc)
 	workflowRun2 := s.createWorkflow(ctx, internalWorkflow.WorkflowFunc)

--- a/tests/activity_api_batch_update_options_test.go
+++ b/tests/activity_api_batch_update_options_test.go
@@ -51,8 +51,8 @@ func (s *ActivityApiBatchUpdateOptionsClientTestSuite) TestActivityBatchUpdateOp
 
 	internalWorkflow := newInternalWorkflow()
 
-	s.Worker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
-	s.Worker().RegisterActivity(internalWorkflow.ActivityFunc)
+	s.SdkWorker().RegisterWorkflow(internalWorkflow.WorkflowFunc)
+	s.SdkWorker().RegisterActivity(internalWorkflow.ActivityFunc)
 
 	workflowRun1 := s.createWorkflow(ctx, internalWorkflow.WorkflowFunc)
 	workflowRun2 := s.createWorkflow(ctx, internalWorkflow.WorkflowFunc)

--- a/tests/activity_api_reset_test.go
+++ b/tests/activity_api_reset_test.go
@@ -115,8 +115,8 @@ func (s *ActivityApiResetClientTestSuite) TestActivityResetApi_AfterRetry() {
 
 	workflowFn := s.makeWorkflowFunc(activityFunction)
 
-	s.Worker().RegisterWorkflow(workflowFn)
-	s.Worker().RegisterActivity(activityFunction)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFunction)
 
 	wfId := testcore.RandomizeStr("wfid-" + s.T().Name())
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -183,8 +183,8 @@ func (s *ActivityApiResetClientTestSuite) TestActivityResetApi_WhileRunning() {
 
 	workflowFn := s.makeWorkflowFunc(activityFunction)
 
-	s.Worker().RegisterWorkflow(workflowFn)
-	s.Worker().RegisterActivity(activityFunction)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFunction)
 
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:        s.tv.WorkflowID(),
@@ -266,8 +266,8 @@ func (s *ActivityApiResetClientTestSuite) TestActivityResetApi_InRetry() {
 
 	workflowFn := s.makeWorkflowFunc(activityFunction)
 
-	s.Worker().RegisterWorkflow(workflowFn)
-	s.Worker().RegisterActivity(activityFunction)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFunction)
 
 	wfId := testcore.RandomizeStr("wf_id-" + s.T().Name())
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -347,8 +347,8 @@ func (s *ActivityApiResetClientTestSuite) TestActivityResetApi_KeepPaused() {
 
 	workflowFn := s.makeWorkflowFunc(activityFunction)
 
-	s.Worker().RegisterWorkflow(workflowFn)
-	s.Worker().RegisterActivity(activityFunction)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFunction)
 
 	wfId := testcore.RandomizeStr("wf_id-" + s.T().Name())
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -493,8 +493,8 @@ func (s *ActivityApiResetClientTestSuite) TestActivityReset_HeartbeatDetails() {
 		return ret, err
 	}
 
-	s.Worker().RegisterActivity(activityFn)
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	wfId := "functional-test-heartbeat-details-after-reset"
 	workflowOptions := sdkclient.StartWorkflowOptions{

--- a/tests/activity_api_rules_test.go
+++ b/tests/activity_api_rules_test.go
@@ -277,8 +277,8 @@ func (s *ActivityApiRulesClientTestSuite) TestActivityRulesApi_RetryActivity() {
 	defer cancel()
 
 	testWorkflow := newInternalRulesTestWorkflow(ctx, &s.FunctionalTestBase, s.Logger)
-	s.Worker().RegisterWorkflow(testWorkflow.WorkflowFuncForRetryActivity)
-	s.Worker().RegisterActivity(testWorkflow.ActivityFuncForRetryActivity)
+	s.SdkWorker().RegisterWorkflow(testWorkflow.WorkflowFuncForRetryActivity)
+	s.SdkWorker().RegisterActivity(testWorkflow.ActivityFuncForRetryActivity)
 
 	workflowRun := s.createWorkflow(ctx, testWorkflow.WorkflowFuncForRetryActivity)
 
@@ -411,8 +411,8 @@ func (s *ActivityApiRulesClientTestSuite) TestActivityRulesApi_RetryTask() {
 	s.initialRetryInterval = 4 * time.Second
 	s.activityRetryPolicy.InitialInterval = s.initialRetryInterval
 
-	s.Worker().RegisterWorkflow(testRetryTaskWorkflow.WorkflowFuncForRetryTask)
-	s.Worker().RegisterActivity(testRetryTaskWorkflow.ActivityFuncForRetryTask)
+	s.SdkWorker().RegisterWorkflow(testRetryTaskWorkflow.WorkflowFuncForRetryTask)
+	s.SdkWorker().RegisterActivity(testRetryTaskWorkflow.ActivityFuncForRetryTask)
 
 	// 1. Start workflow
 	workflowRun := s.createWorkflow(ctx, testRetryTaskWorkflow.WorkflowFuncForRetryTask)
@@ -543,8 +543,8 @@ func (s *ActivityApiRulesClientTestSuite) TestActivityRulesApi_PrePause() {
 
 	testRetryTaskWorkflow := newInternalRulesTestWorkflow(ctx, &s.FunctionalTestBase, s.Logger)
 
-	s.Worker().RegisterWorkflow(testRetryTaskWorkflow.WorkflowFuncForPrePause)
-	s.Worker().RegisterActivity(testRetryTaskWorkflow.ActivityFuncForPrePause)
+	s.SdkWorker().RegisterWorkflow(testRetryTaskWorkflow.WorkflowFuncForPrePause)
+	s.SdkWorker().RegisterActivity(testRetryTaskWorkflow.ActivityFuncForPrePause)
 
 	// 1. Create rule to pause activity
 	ruleID := "pause-activity"

--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -89,8 +89,8 @@ func (s *ActivityClientTestSuite) TestActivityScheduleToClose_FiredDuringBackoff
 		return "done!", err
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
-	s.Worker().RegisterActivity(activityFunction)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFunction)
 
 	wfId := "functional-test-gethistoryreverse"
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -159,8 +159,8 @@ func (s *ActivityClientTestSuite) TestActivityScheduleToClose_FiredDuringActivit
 		return "done!", err
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
-	s.Worker().RegisterActivity(activityFunction)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFunction)
 
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:        s.T().Name(),
@@ -298,8 +298,8 @@ func (s *ActivityClientTestSuite) Test_ActivityTimeouts() {
 		return nil
 	}
 
-	s.Worker().RegisterActivity(activityFn)
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:                 "functional-test-activity-timeouts",
@@ -1231,8 +1231,8 @@ func (s *ActivityClientTestSuite) TestActivityHeartbeatDetailsDuringRetry() {
 		return nil
 	}
 
-	s.Worker().RegisterActivity(activityFn)
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	wfId := "functional-test-heartbeat-details-during-retry"
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -1525,8 +1525,8 @@ func (s *ActivityClientTestSuite) TestActivity_AttemptsExceeded() {
 		return err
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
-	s.Worker().RegisterActivity(activityFunction)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFunction)
 
 	wfID := testcore.RandomizeStr(s.T().Name())
 	workflowOptions := sdkclient.StartWorkflowOptions{

--- a/tests/admin_batch_refresh_workflow_tasks_test.go
+++ b/tests/admin_batch_refresh_workflow_tasks_test.go
@@ -60,7 +60,7 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_R
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	s.Worker().RegisterWorkflow(s.simpleWorkflow)
+	s.SdkWorker().RegisterWorkflow(s.simpleWorkflow)
 
 	// Create two workflows
 	workflowRun1 := s.createWorkflow(ctx, s.simpleWorkflow)
@@ -95,7 +95,7 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_R
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	s.Worker().RegisterWorkflow(s.simpleWorkflow)
+	s.SdkWorker().RegisterWorkflow(s.simpleWorkflow)
 
 	// Create workflows
 	workflowRun1 := s.createWorkflow(ctx, s.simpleWorkflow)
@@ -212,7 +212,7 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_0
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	s.Worker().RegisterWorkflow(s.simpleWorkflow)
+	s.SdkWorker().RegisterWorkflow(s.simpleWorkflow)
 
 	s.OverrideDynamicConfig(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, 1)
 	s.OverrideDynamicConfig(dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace, 1)

--- a/tests/admin_test.go
+++ b/tests/admin_test.go
@@ -65,7 +65,7 @@ func rebuildMutableStateWorkflowHelper(s *AdminTestSuite, testWithChasm bool) {
 		return nil
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	workflowID := tv.Any().String()
 	workflowOptions := sdkclient.StartWorkflowOptions{

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -1675,8 +1675,8 @@ func (s *AdvancedVisibilitySuite) TestChildWorkflow_ParentWorkflow() {
 			Get(ctx, nil)
 	}
 
-	s.Worker().RegisterWorkflowWithOptions(wf, workflow.RegisterOptions{Name: wfType})
-	s.Worker().RegisterWorkflowWithOptions(childWf, workflow.RegisterOptions{Name: childWfType})
+	s.SdkWorker().RegisterWorkflowWithOptions(wf, workflow.RegisterOptions{Name: wfType})
+	s.SdkWorker().RegisterWorkflowWithOptions(childWf, workflow.RegisterOptions{Name: childWfType})
 
 	startOptions := sdkclient.StartWorkflowOptions{
 		ID:        wfID,

--- a/tests/client_data_converter_test.go
+++ b/tests/client_data_converter_test.go
@@ -153,8 +153,8 @@ func (s *ClientDataConverterTestSuite) TestClientDataConverter() {
 	}
 	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(time.Minute)
 	defer cancel()
-	s.Worker().RegisterWorkflow(testDataConverterWorkflow)
-	s.Worker().RegisterActivity(testActivity)
+	s.SdkWorker().RegisterWorkflow(testDataConverterWorkflow)
+	s.SdkWorker().RegisterActivity(testActivity)
 	we, err := s.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testDataConverterWorkflow, tl)
 	s.NoError(err)
 	s.NotNil(we)
@@ -189,8 +189,8 @@ func (s *ClientDataConverterTestSuite) TestClientDataConverterFailed() {
 	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(time.Minute)
 	defer cancel()
 
-	s.Worker().RegisterWorkflow(testDataConverterWorkflow)
-	s.Worker().RegisterActivity(testActivity)
+	s.SdkWorker().RegisterWorkflow(testDataConverterWorkflow)
+	s.SdkWorker().RegisterActivity(testActivity)
 	we, err := s.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testDataConverterWorkflow, tl)
 	s.NoError(err)
 	s.NotNil(we)
@@ -237,8 +237,8 @@ func (s *ClientDataConverterTestSuite) TestClientDataConverterWithChild() {
 	}
 	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(time.Minute)
 	defer cancel()
-	s.Worker().RegisterWorkflow(testParentWorkflow)
-	s.Worker().RegisterWorkflow(testChildWorkflow)
+	s.SdkWorker().RegisterWorkflow(testParentWorkflow)
+	s.SdkWorker().RegisterWorkflow(testChildWorkflow)
 
 	we, err := s.SdkClient().ExecuteWorkflow(ctx, workflowOptions, testParentWorkflow)
 	s.NoError(err)

--- a/tests/client_misc_test.go
+++ b/tests/client_misc_test.go
@@ -79,9 +79,9 @@ func (s *ClientMiscTestSuite) TestTooManyChildWorkflows() {
 	}
 
 	// register all the workflows
-	s.Worker().RegisterWorkflow(blockingChildWorkflow)
-	s.Worker().RegisterWorkflow(childWorkflow)
-	s.Worker().RegisterWorkflow(parentWorkflow)
+	s.SdkWorker().RegisterWorkflow(blockingChildWorkflow)
+	s.SdkWorker().RegisterWorkflow(childWorkflow)
+	s.SdkWorker().RegisterWorkflow(parentWorkflow)
 
 	// start the parent workflow
 	timeout := time.Minute * 5
@@ -130,11 +130,11 @@ func (s *ClientMiscTestSuite) TestTooManyPendingActivities() {
 		pendingActivities <- activity.GetInfo(ctx)
 		return activity.ErrResultPending
 	}
-	s.Worker().RegisterActivity(pendingActivity)
+	s.SdkWorker().RegisterActivity(pendingActivity)
 	lastActivity := func(ctx context.Context) error {
 		return nil
 	}
-	s.Worker().RegisterActivity(lastActivity)
+	s.SdkWorker().RegisterActivity(lastActivity)
 
 	readyToScheduleLastActivity := "ready-to-schedule-last-activity"
 	myWorkflow := func(ctx workflow.Context) error {
@@ -152,7 +152,7 @@ func (s *ClientMiscTestSuite) TestTooManyPendingActivities() {
 			ActivityID:          "last-activity",
 		}), lastActivity).Get(ctx, nil)
 	}
-	s.Worker().RegisterWorkflow(myWorkflow)
+	s.SdkWorker().RegisterWorkflow(myWorkflow)
 
 	workflowID := uuid.NewString()
 	workflowRun, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
@@ -204,7 +204,7 @@ func (s *ClientMiscTestSuite) TestTooManyCancelRequests() {
 			return false
 		})
 	}
-	s.Worker().RegisterWorkflow(targetWorkflow)
+	s.SdkWorker().RegisterWorkflow(targetWorkflow)
 	for i := range numTargetWorkflows {
 		_, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
 			ID:        fmt.Sprintf("workflow-%d", i),
@@ -227,7 +227,7 @@ func (s *ClientMiscTestSuite) TestTooManyCancelRequests() {
 		}
 		return nil
 	}
-	s.Worker().RegisterWorkflow(cancelWorkflowsInRange)
+	s.SdkWorker().RegisterWorkflow(cancelWorkflowsInRange)
 
 	// try to cancel all the workflows at once and verify that we can't because of the limit violation
 	s.Run("CancelAllWorkflowsAtOnce", func() {
@@ -298,7 +298,7 @@ func (s *ClientMiscTestSuite) TestTooManyPendingSignals() {
 		}
 		return errs
 	}
-	s.Worker().RegisterWorkflow(sender)
+	s.SdkWorker().RegisterWorkflow(sender)
 
 	receiver := func(ctx workflow.Context) error {
 		channel := workflow.GetSignalChannel(ctx, signalName)
@@ -306,7 +306,7 @@ func (s *ClientMiscTestSuite) TestTooManyPendingSignals() {
 			channel.Receive(ctx, nil)
 		}
 	}
-	s.Worker().RegisterWorkflow(receiver)
+	s.SdkWorker().RegisterWorkflow(receiver)
 	_, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
 		TaskQueue: s.TaskQueue(),
 		ID:        receiverId,
@@ -366,7 +366,7 @@ func continueAsNewTightLoop(ctx workflow.Context, currCount, maxCount int) (int,
 func (s *ClientMiscTestSuite) TestContinueAsNewTightLoop() {
 	// Simulate continue as new tight loop, and verify server throttle the rate.
 	workflowId := "continue_as_new_tight_loop"
-	s.Worker().RegisterWorkflow(continueAsNewTightLoop)
+	s.SdkWorker().RegisterWorkflow(continueAsNewTightLoop)
 
 	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(time.Minute)
 	defer cancel()
@@ -402,7 +402,7 @@ func (s *ClientMiscTestSuite) TestStickyAutoReset() {
 		return msg, nil
 	}
 
-	s.Worker().RegisterWorkflow(wfFn)
+	s.SdkWorker().RegisterWorkflow(wfFn)
 
 	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(time.Minute)
 	defer cancel()
@@ -432,7 +432,7 @@ func (s *ClientMiscTestSuite) TestStickyAutoReset() {
 	}, 5*time.Second, 200*time.Millisecond)
 
 	// stop worker
-	s.Worker().Stop()
+	s.SdkWorker().Stop()
 	//nolint:forbidigo
 	time.Sleep(time.Second * 11) // wait 11s (longer than 10s timeout), after this time, matching will detect StickyWorkerUnavailable
 	resp, err := s.FrontendClient().DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
@@ -517,7 +517,7 @@ func (s *ClientMiscTestSuite) TestWorkflowCanBeCompletedDespiteAdmittedUpdate() 
 		return workflow.ExecuteLocalActivity(laCtx, localActivityFn).Get(laCtx, nil)
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	workflowRun, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
 		ID:                  tv.WorkflowID(),
@@ -612,7 +612,7 @@ func (s *ClientMiscTestSuite) Test_CancelActivityAndTimerBeforeComplete() {
 		return nil
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	id := s.T().Name()
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -656,9 +656,9 @@ func (s *ClientMiscTestSuite) Test_FinishWorkflowWithDeferredCommands() {
 		return nil
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
-	s.Worker().RegisterWorkflow(childWorkflowFn)
-	s.Worker().RegisterActivity(activityFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(childWorkflowFn)
+	s.SdkWorker().RegisterActivity(activityFn)
 
 	id := "functional-test-finish-workflow-with-deffered-commands"
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -738,8 +738,8 @@ func (s *ClientMiscTestSuite) TestInvalidCommandAttribute() {
 		return workflow.ExecuteActivity(ctx, activityFn).Get(ctx, nil)
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
-	s.Worker().RegisterActivity(activityFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFn)
 
 	id := "functional-test-invalid-command-attributes"
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -810,7 +810,7 @@ func (s *ClientMiscTestSuite) Test_BufferedQuery() {
 		return multierr.Combine(err1, workflow.Sleep(ctx, 5*time.Second))
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	id := "functional-test-buffered-query"
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -918,7 +918,7 @@ func (s *ClientMiscTestSuite) TestBufferedSignalCausesUnhandledCommandAndSchedul
 		return nil
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:        tv.WorkflowID(),
@@ -1088,7 +1088,7 @@ func (s *ClientMiscTestSuite) TestBatchSignal() {
 		workflow.GetSignalChannel(ctx, "my-signal").Receive(ctx, &receivedData)
 		return receivedData, nil
 	}
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	workflowRun, err := s.SdkClient().ExecuteWorkflow(context.Background(), sdkclient.StartWorkflowOptions{
 		ID:                       uuid.NewString(),
@@ -1150,8 +1150,8 @@ func (s *ClientMiscTestSuite) TestBatchReset() {
 		err := workflow.ExecuteActivity(ctx, activityFn).Get(ctx, &result)
 		return result, err
 	}
-	s.Worker().RegisterWorkflow(workflowFn)
-	s.Worker().RegisterActivity(activityFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFn)
 
 	workflowRun, err := s.SdkClient().ExecuteWorkflow(context.Background(), sdkclient.StartWorkflowOptions{
 		ID:                       uuid.NewString(),

--- a/tests/cron_test.go
+++ b/tests/cron_test.go
@@ -422,7 +422,7 @@ func (s *CronTestClientSuite) TestCronWorkflowCompletionStates() {
 		panic("shouldn't get here")
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	// Because of rounding in GetBackoffForNextSchedule, we'll tend to stay aligned to whatever
 	// phase we start in relative to second boundaries, but drift slightly later within the second

--- a/tests/dlq_test.go
+++ b/tests/dlq_test.go
@@ -142,7 +142,7 @@ func myWorkflow(workflow.Context) (string, error) {
 func (s *DLQSuite) SetupTest() {
 	s.FunctionalTestBase.SetupTest()
 
-	s.Worker().RegisterWorkflow(myWorkflow)
+	s.SdkWorker().RegisterWorkflow(myWorkflow)
 
 	s.deleteBlockCh = make(chan any)
 	close(s.deleteBlockCh)

--- a/tests/gethistory_test.go
+++ b/tests/gethistory_test.go
@@ -655,8 +655,8 @@ func (s *RawHistoryClientSuite) TestGetHistoryReverse() {
 		return nil
 	}
 
-	s.Worker().RegisterActivity(activityFn)
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	wfId := "functional-test-gethistoryreverse"
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -730,8 +730,8 @@ func (s *RawHistoryClientSuite) TestGetHistoryReverse_MultipleBranches() {
 		return nil
 	}
 
-	s.Worker().RegisterActivity(activityFn)
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterActivity(activityFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	wfId := "functional-test-wf-gethistory-reverse-multiple-branches"
 	workflowOptions := sdkclient.StartWorkflowOptions{

--- a/tests/http_api_test.go
+++ b/tests/http_api_test.go
@@ -80,7 +80,7 @@ func (s *HttpApiTestSuite) runHTTPAPIBasicsTest(
 		}
 		return arg, nil
 	}
-	s.Worker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: "http-basic-workflow"})
+	s.SdkWorker().RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: "http-basic-workflow"})
 
 	// Capture metrics
 	capture := s.GetTestCluster().Host().CaptureMetricsHandler().StartCapture()

--- a/tests/pause_workflow_execution_test.go
+++ b/tests/pause_workflow_execution_test.go
@@ -101,14 +101,14 @@ func (s *PauseWorkflowExecutionSuite) SetupTest() {
 		return "activity", nil
 	}
 
-	s.Worker().RegisterWorkflow(s.workflowFn)
-	s.Worker().RegisterWorkflow(s.childWorkflowFn)
-	s.Worker().RegisterActivity(s.activityFn)
+	s.SdkWorker().RegisterWorkflow(s.workflowFn)
+	s.SdkWorker().RegisterWorkflow(s.childWorkflowFn)
+	s.SdkWorker().RegisterActivity(s.activityFn)
 
 	// Setup for TestPauseWorkflowAndActivity
 	s.activityShouldSucceed.Store(false)
-	s.Worker().RegisterWorkflow(s.workflowWithFailingActivity)
-	s.Worker().RegisterActivity(s.failingActivity)
+	s.SdkWorker().RegisterWorkflow(s.workflowWithFailingActivity)
+	s.SdkWorker().RegisterActivity(s.failingActivity)
 }
 
 // failingActivity is an activity that fails until activityShouldSucceed is set to true.

--- a/tests/query_workflow_test.go
+++ b/tests/query_workflow_test.go
@@ -57,7 +57,7 @@ func (s *QueryWorkflowSuite) TestQueryWorkflow_Sticky() {
 		return msg, nil
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	id := "test-query-sticky"
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -107,7 +107,7 @@ func (s *QueryWorkflowSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 		}
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	id := "test-query-consistent"
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -149,7 +149,7 @@ func (s *QueryWorkflowSuite) TestQueryWorkflow_QueryWhileBackoff() {
 		})
 		return nil
 	}
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	testCases := []struct {
 		testName       string
@@ -207,7 +207,7 @@ func (s *QueryWorkflowSuite) TestQueryWorkflow_QueryWhileBackoff() {
 
 func (s *QueryWorkflowSuite) TestQueryWorkflow_QueryBeforeStart() {
 	// stop the worker, so the workflow won't be started before query
-	s.Worker().Stop()
+	s.SdkWorker().Stop()
 
 	workflowFn := func(ctx workflow.Context) (string, error) {
 		status := "initialized"
@@ -286,7 +286,7 @@ func (s *QueryWorkflowSuite) TestQueryWorkflow_QueryFailedWorkflowTask() {
 		panic("Workflow failed")
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	id := "test-query-failed-workflow-task"
 	workflowOptions := sdkclient.StartWorkflowOptions{
@@ -344,7 +344,7 @@ func (s *QueryWorkflowSuite) TestQueryWorkflow_WithRawHistoryBytesToMatchingServ
 	s.OverrideDynamicConfig(dynamicconfig.SendRawHistoryBytesToMatchingService, true)
 
 	// Stop the default worker, so we can control sticky behavior
-	s.Worker().Stop()
+	s.SdkWorker().Stop()
 
 	workflowFn := func(ctx workflow.Context) (string, error) {
 		status := "initialized"

--- a/tests/reset_workflow_test.go
+++ b/tests/reset_workflow_test.go
@@ -950,7 +950,7 @@ func (s *ResetWorkflowTestSuite) TestResetWorkflow_ResetAfterContinueAsNew() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	s.Worker().RegisterWorkflow(CaNOnceWorkflow)
+	s.SdkWorker().RegisterWorkflow(CaNOnceWorkflow)
 	run, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{TaskQueue: s.TaskQueue()}, CaNOnceWorkflow, "")
 	s.NoError(err)
 

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -79,7 +79,7 @@ type (
 
 		// Fields used by SDK based tests.
 		sdkClient sdkclient.Client
-		worker    sdkworker.Worker
+		sdkWorker sdkworker.Worker
 		taskQueue string
 
 		// TODO (alex): replace with v2
@@ -211,8 +211,8 @@ func (s *FunctionalTestBase) WorkerGRPCAddress() string {
 	return s.GetTestCluster().WorkerGRPCAddress()
 }
 
-func (s *FunctionalTestBase) Worker() sdkworker.Worker {
-	return s.worker
+func (s *FunctionalTestBase) SdkWorker() sdkworker.Worker {
+	return s.sdkWorker
 }
 
 func (s *FunctionalTestBase) SdkClient() sdkclient.Client {
@@ -387,8 +387,8 @@ func (s *FunctionalTestBase) setupSdk() {
 	s.taskQueue = RandomizeStr("tq")
 
 	workerOptions := sdkworker.Options{}
-	s.worker = sdkworker.New(s.sdkClient, s.taskQueue, workerOptions)
-	err = s.worker.Start()
+	s.sdkWorker = sdkworker.New(s.sdkClient, s.taskQueue, workerOptions)
+	err = s.sdkWorker.Start()
 	s.NoError(err)
 }
 
@@ -432,8 +432,8 @@ func (s *FunctionalTestBase) TearDownSubTest() {
 }
 
 func (s *FunctionalTestBase) tearDownSdk() {
-	if s.worker != nil {
-		s.worker.Stop()
+	if s.sdkWorker != nil {
+		s.sdkWorker.Stop()
 	}
 	if s.sdkClient != nil {
 		s.sdkClient.Close()

--- a/tests/update_workflow_sdk_test.go
+++ b/tests/update_workflow_sdk_test.go
@@ -53,7 +53,7 @@ func (s *UpdateWorkflowSdkSuite) TestTerminateWorkflowAfterUpdateAdmitted() {
 	run := s.startWorkflow(ctx, tv, workflowFn)
 	s.updateWorkflowWaitAdmitted(ctx, tv, "update-arg")
 
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	s.NoError(s.SdkClient().TerminateWorkflow(ctx, tv.WorkflowID(), run.GetRunID(), "reason"))
 
@@ -89,7 +89,7 @@ func (s *UpdateWorkflowSdkSuite) TestTimeoutWorkflowAfterUpdateAccepted() {
 		return unreachableErr
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	wfRun, err := s.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
 		ID:                       tv.WorkflowID(),
@@ -153,7 +153,7 @@ func (s *UpdateWorkflowSdkSuite) TestTerminateWorkflowAfterUpdateAccepted() {
 		return unreachableErr
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 	wfRun := s.startWorkflow(ctx, tv, workflowFn)
 
 	// Wait for the first WFT to complete.
@@ -234,9 +234,9 @@ func (s *UpdateWorkflowSdkSuite) TestContinueAsNewAfterUpdateAdmitted() {
 		return workflow.NewContinueAsNewError(ctx, workflowFn2)
 	}
 
-	s.Worker().RegisterWorkflow(workflowFn1)
-	s.Worker().RegisterWorkflow(workflowFn2)
-	s.Worker().RegisterActivity(sendUpdateActivityFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn1)
+	s.SdkWorker().RegisterWorkflow(workflowFn2)
+	s.SdkWorker().RegisterActivity(sendUpdateActivityFn)
 
 	var firstRun sdkclient.WorkflowRun
 	firstRun = s.startWorkflow(rootCtx, tv, workflowFn1)
@@ -322,7 +322,7 @@ func (s *UpdateWorkflowSdkSuite) TestTimeoutWithRetryAfterUpdateAdmitted() {
 	s.ErrorAs(err, &canErr)
 
 	// "start" worker for workflowFn.
-	s.Worker().RegisterWorkflow(workflowFn)
+	s.SdkWorker().RegisterWorkflow(workflowFn)
 
 	var secondRunID string
 	s.Eventually(func() bool {

--- a/tests/workflow_alias_search_attribute_test.go
+++ b/tests/workflow_alias_search_attribute_test.go
@@ -36,7 +36,7 @@ func TestWorkflowAliasSearchAttributeTestSuite(t *testing.T) {
 func (s *WorkflowAliasSearchAttributeTestSuite) SetupTest() {
 	s.FunctionalTestBase.SetupTest()
 
-	s.Worker().RegisterWorkflow(s.workflowFunc)
+	s.SdkWorker().RegisterWorkflow(s.workflowFunc)
 }
 
 func (s *WorkflowAliasSearchAttributeTestSuite) workflowFunc(ctx workflow.Context) (string, error) {

--- a/tests/workflow_reset_with_child_test.go
+++ b/tests/workflow_reset_with_child_test.go
@@ -49,12 +49,12 @@ func TestWorkflowResetWithChildTestSuite(t *testing.T) {
 
 func (s *WorkflowResetWithChildSuite) SetupTest() {
 	s.FunctionalTestBase.SetupTest()
-	s.Worker().RegisterWorkflow(s.WorkflowWithChildren)
-	s.Worker().RegisterWorkflow(s.WorkflowWithWaitingChild)
-	s.Worker().RegisterWorkflow(child)
-	s.Worker().RegisterWorkflow(s.waitingChild)
-	s.Worker().RegisterActivity(simpleActivity)
-	err := s.Worker().Start()
+	s.SdkWorker().RegisterWorkflow(s.WorkflowWithChildren)
+	s.SdkWorker().RegisterWorkflow(s.WorkflowWithWaitingChild)
+	s.SdkWorker().RegisterWorkflow(child)
+	s.SdkWorker().RegisterWorkflow(s.waitingChild)
+	s.SdkWorker().RegisterActivity(simpleActivity)
+	err := s.SdkWorker().Start()
 	s.NoError(err)
 }
 

--- a/tests/workflow_task_reported_problems_test.go
+++ b/tests/workflow_task_reported_problems_test.go
@@ -84,7 +84,7 @@ func (s *WFTFailureReportedProblemsTestSuite) TestWFTFailureReportedProblems_Set
 
 	s.shouldFail.Store(true)
 
-	s.Worker().RegisterWorkflow(s.simpleWorkflowWithShouldFail)
+	s.SdkWorker().RegisterWorkflow(s.simpleWorkflowWithShouldFail)
 
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:        testcore.RandomizeStr("wf_id-" + s.T().Name()),
@@ -126,7 +126,7 @@ func (s *WFTFailureReportedProblemsTestSuite) TestWFTFailureReportedProblems_Not
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	s.Worker().RegisterWorkflow(s.workflowWithSignalsThatFails)
+	s.SdkWorker().RegisterWorkflow(s.workflowWithSignalsThatFails)
 
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:        testcore.RandomizeStr("wf_id-" + s.T().Name()),
@@ -193,8 +193,8 @@ func (s *WFTFailureReportedProblemsTestSuite) TestWFTFailureReportedProblems_Set
 
 	s.shouldFail.Store(true)
 
-	s.Worker().RegisterWorkflow(s.workflowWithActivity)
-	s.Worker().RegisterActivity(s.simpleActivity)
+	s.SdkWorker().RegisterWorkflow(s.workflowWithActivity)
+	s.SdkWorker().RegisterActivity(s.simpleActivity)
 
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:        testcore.RandomizeStr("wf_id-" + s.T().Name()),
@@ -237,7 +237,7 @@ func (s *WFTFailureReportedProblemsTestSuite) TestWFTFailureReportedProblems_Dyn
 	defer cleanup()
 	s.shouldFail.Store(true)
 
-	s.Worker().RegisterWorkflow(s.simpleWorkflowWithShouldFail)
+	s.SdkWorker().RegisterWorkflow(s.simpleWorkflowWithShouldFail)
 
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:        testcore.RandomizeStr("wf_id-" + s.T().Name()),


### PR DESCRIPTION
## What changed?

Rename `FunctionalTestBase`'s `Worker` to `SdkWorker`.

## Why?

The new TestEnv uses `SdkClient/SdkWorker`; with this change the diff on individual suite migrations is greatly reduced.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
