### PR TITLE
feat: add memo to UpdateSchedule

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -754,9 +754,6 @@ func (s *Scheduler) Update(
 	}
 
 	// Update custom search attributes.
-	//
-	// TODO - we could also easily support allowing the customer to update their
-	// memo here.
 	if req.FrontendRequest.GetSearchAttributes() != nil {
 		// To preserve compatibility with V1 scheduler, we do a full replacement
 		// of search attributes, dropping any that aren't a part of the update's
@@ -776,6 +773,12 @@ func (s *Scheduler) Update(
 	// not silently lost during the migration window.
 	if s.WorkflowMigration != nil {
 		return nil, ErrMigrationPending
+	}
+
+	// Update custom memo.
+	if req.FrontendRequest.GetMemo() != nil {
+		visibility := s.Visibility.Get(ctx)
+		visibility.ReplaceCustomMemo(ctx, req.FrontendRequest.GetMemo().GetFields())
 	}
 
 	s.Schedule = req.FrontendRequest.Schedule

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -9,6 +9,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	schedulepb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/api/workflowservice/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/scheduler"
@@ -130,6 +131,113 @@ func TestCreateSchedulerFromMigration(t *testing.T) {
 	require.NoError(t, node.SetRootComponent(sched))
 	_, err = node.CloseTransaction()
 	require.NoError(t, err)
+}
+
+func TestUpdate_WithMemo(t *testing.T) {
+	sched, ctx, _ := setupSchedulerForTest(t)
+	memoValue := &commonpb.Payload{Data: []byte("test-value")}
+
+	_, err := sched.Update(ctx, &schedulerpb.UpdateScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.UpdateScheduleRequest{
+			Namespace:  namespace,
+			ScheduleId: scheduleID,
+			Schedule:   defaultSchedule(),
+			Memo: &commonpb.Memo{
+				Fields: map[string]*commonpb.Payload{"key1": memoValue},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	visibility := sched.Visibility.Get(ctx)
+	memo := visibility.CustomMemo(ctx)
+	protorequire.ProtoEqual(t, memoValue, memo["key1"])
+}
+
+func TestUpdate_WithNilMemo(t *testing.T) {
+	sched, ctx, node := setupSchedulerForTest(t)
+
+	// Set initial memo.
+	visibility := sched.Visibility.Get(ctx)
+	visibility.MergeCustomMemo(ctx, map[string]*commonpb.Payload{
+		"existing": {Data: []byte("value")},
+	})
+	_, err := node.CloseTransaction()
+	require.NoError(t, err)
+
+	// Update without memo (nil) should preserve existing memo.
+	ctx = chasm.NewMutableContext(context.Background(), node)
+	_, err = sched.Update(ctx, &schedulerpb.UpdateScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.UpdateScheduleRequest{
+			Namespace:  namespace,
+			ScheduleId: scheduleID,
+			Schedule:   defaultSchedule(),
+		},
+	})
+	require.NoError(t, err)
+
+	visibility = sched.Visibility.Get(ctx)
+	memo := visibility.CustomMemo(ctx)
+	protorequire.ProtoEqual(t, &commonpb.Payload{Data: []byte("value")}, memo["existing"])
+}
+
+func TestUpdate_MemoReplaceSemantics(t *testing.T) {
+	sched, ctx, node := setupSchedulerForTest(t)
+
+	// Set initial memo with keys A and B.
+	visibility := sched.Visibility.Get(ctx)
+	visibility.MergeCustomMemo(ctx, map[string]*commonpb.Payload{
+		"A": {Data: []byte("1")},
+		"B": {Data: []byte("2")},
+	})
+	_, err := node.CloseTransaction()
+	require.NoError(t, err)
+
+	// Update with only C: should fully replace memo (A and B are gone).
+	ctx = chasm.NewMutableContext(context.Background(), node)
+	_, err = sched.Update(ctx, &schedulerpb.UpdateScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.UpdateScheduleRequest{
+			Namespace:  namespace,
+			ScheduleId: scheduleID,
+			Schedule:   defaultSchedule(),
+			Memo: &commonpb.Memo{
+				Fields: map[string]*commonpb.Payload{
+					"C": {Data: []byte("3")},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	visibility = sched.Visibility.Get(ctx)
+	memo := visibility.CustomMemo(ctx)
+	require.Nil(t, memo["A"], "A should be gone after replace")
+	require.Nil(t, memo["B"], "B should be gone after replace")
+	protorequire.ProtoEqual(t, &commonpb.Payload{Data: []byte("3")}, memo["C"])
+
+	// Update with empty memo: should clear all memo fields.
+	_, err = node.CloseTransaction()
+	require.NoError(t, err)
+	ctx = chasm.NewMutableContext(context.Background(), node)
+	_, err = sched.Update(ctx, &schedulerpb.UpdateScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.UpdateScheduleRequest{
+			Namespace:  namespace,
+			ScheduleId: scheduleID,
+			Schedule:   defaultSchedule(),
+			Memo: &commonpb.Memo{
+				Fields: map[string]*commonpb.Payload{},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	visibility = sched.Visibility.Get(ctx)
+	memo = visibility.CustomMemo(ctx)
+	require.Empty(t, memo, "memo should be empty after replace with empty map")
 }
 
 func TestCreateSchedulerFromMigration_EmptyState(t *testing.T) {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -4533,6 +4533,11 @@ func (wh *WorkflowHandler) UpdateSchedule(
 		}
 	}
 
+	// Reject memo updates for V1 schedules.
+	if request.GetMemo() != nil {
+		return nil, serviceerror.NewFailedPrecondition("memo updates are not supported on workflow-backed schedules")
+	}
+
 	return wh.updateScheduleWorkflow(ctx, request)
 }
 
@@ -4663,8 +4668,6 @@ func (wh *WorkflowHandler) PatchSchedule(
 		return nil, err
 	}
 
-	// TODO - when V2 supports updating the scheduler memo, make sure to add that to
-	// the size validation here (like in CreateSchedule).
 	sizeLimitError := wh.config.BlobSizeLimitError(request.GetNamespace())
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(request.GetNamespace())
 	if err := common.CheckEventBlobSizeLimit(

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -77,6 +77,8 @@ func TestScheduleCHASM(t *testing.T) {
 	t.Run("TestResetWithAdditionalCallback_ChasmCallbacks", func(t *testing.T) { testResetWithAdditionalCallback(t, newContext, true) })
 	t.Run("TestMigrationCallbackAttach", func(t *testing.T) { testMigrationCallbackAttach(t, newContext) })
 	t.Run("TestCreatesWorkflowSentinel", func(t *testing.T) { testCreatesWorkflowSentinel(t, newContext) })
+	t.Run("TestUpdateScheduleMemo", func(t *testing.T) { testUpdateScheduleMemo(t, newContext) })
+	t.Run("TestUpdateScheduleMemoOnly", func(t *testing.T) { testUpdateScheduleMemoOnly(t, newContext) })
 }
 
 func TestScheduleV1(t *testing.T) {
@@ -90,6 +92,7 @@ func TestScheduleV1(t *testing.T) {
 	t.Run("TestRateLimit", func(t *testing.T) { testRateLimit(t, newContext) })
 	t.Run("TestNextTimeCache", func(t *testing.T) { testNextTimeCache(t, newContext) })
 	t.Run("TestCreatesCHASMSentinel", func(t *testing.T) { testCreatesCHASMSentinel(t, newContext) })
+	t.Run("TestUpdateScheduleMemoRejected", func(t *testing.T) { testUpdateScheduleMemoRejected(t, newContext) })
 }
 
 func runSharedScheduleTests(t *testing.T, newContext contextFactory) {
@@ -2347,4 +2350,260 @@ func assertRecentActionsNoDuplicateRunIDs(t *testing.T, actions []*schedulepb.Sc
 		}
 		seen[runID] = i
 	}
+}
+func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
+
+	sid := "sched-test-update-memo"
+	wid := "sched-test-update-memo-wf"
+	wt := "sched-test-update-memo-wt"
+
+	s.SdkWorker().RegisterWorkflowWithOptions(
+		func(ctx workflow.Context) error { return nil },
+		workflow.RegisterOptions{Name: wt},
+	)
+
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{Interval: durationpb.New(1 * time.Hour)},
+			},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   wid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+	}
+
+	memo1 := payload.EncodeString("val1")
+	memo2 := payload.EncodeString("val2")
+
+	// Create schedule with initial memo.
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+		Memo: &commonpb.Memo{
+			Fields: map[string]*commonpb.Payload{
+				"key1": memo1,
+				"key2": memo2,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Verify initial memo.
+	describeResp, err := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+	})
+	require.NoError(t, err)
+	require.Equal(t, memo1.Data, describeResp.Memo.Fields["key1"].Data)
+	require.Equal(t, memo2.Data, describeResp.Memo.Fields["key2"].Data)
+
+	// Update: replace memo with only key3 (key1 and key2 should be gone).
+	memo3 := payload.EncodeString("new")
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+		Memo: &commonpb.Memo{
+			Fields: map[string]*commonpb.Payload{
+				"key3": memo3,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Verify replaced memo.
+	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+	})
+	require.NoError(t, err)
+	require.Nil(t, describeResp.Memo.Fields["key1"], "key1 should be gone after replace")
+	require.Nil(t, describeResp.Memo.Fields["key2"], "key2 should be gone after replace")
+	require.Equal(t, memo3.Data, describeResp.Memo.Fields["key3"].Data, "key3 should be set")
+
+	// Update with nil memo (no change).
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	// Verify memo unchanged.
+	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+	})
+	require.NoError(t, err)
+	require.Equal(t, memo3.Data, describeResp.Memo.Fields["key3"].Data, "key3 should be unchanged")
+
+	// Update with empty memo (clear all).
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+		Memo: &commonpb.Memo{
+			Fields: map[string]*commonpb.Payload{},
+		},
+	})
+	require.NoError(t, err)
+
+	// Verify memo cleared.
+	describeResp, err = s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+	})
+	require.NoError(t, err)
+	require.Empty(t, describeResp.Memo.GetFields(), "memo should be empty after replace with empty map")
+}
+
+func testUpdateScheduleMemoRejected(t *testing.T, newContext contextFactory) {
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
+
+	sid := "sched-test-update-memo-rejected"
+	wid := "sched-test-update-memo-rejected-wf"
+	wt := "sched-test-update-memo-rejected-wt"
+
+	s.SdkWorker().RegisterWorkflowWithOptions(
+		func(ctx workflow.Context) error { return nil },
+		workflow.RegisterOptions{Name: wt},
+	)
+
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{Interval: durationpb.New(1 * time.Hour)},
+			},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   wid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+	}
+
+	// Create V1 schedule.
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	// Update with memo should be rejected.
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+		Memo: &commonpb.Memo{
+			Fields: map[string]*commonpb.Payload{
+				"key": payload.EncodeString("value"),
+			},
+		},
+	})
+	require.Error(t, err)
+	var failedPrecondition *serviceerror.FailedPrecondition
+	require.ErrorAs(t, err, &failedPrecondition)
+	require.Contains(t, err.Error(), "memo updates are not supported on workflow-backed schedules")
+}
+
+func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
+	// UpdateScheduleRequest uses replace semantics for the schedule field, so omitting it
+	// causes the schedule to be unset. Memo-only updates require the server to skip replacing
+	// the schedule when the field is nil, similar to how memo and search_attributes are handled.
+	t.Skip("memo-only updates not yet supported: omitting the schedule field unsets the schedule")
+
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
+
+	sid := "sched-test-update-memo-only"
+	wid := "sched-test-update-memo-only-wf"
+	wt := "sched-test-update-memo-only-wt"
+
+	s.SdkWorker().RegisterWorkflowWithOptions(
+		func(ctx workflow.Context) error { return nil },
+		workflow.RegisterOptions{Name: wt},
+	)
+
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{
+				{Interval: durationpb.New(1 * time.Hour)},
+			},
+		},
+		Action: &schedulepb.ScheduleAction{
+			Action: &schedulepb.ScheduleAction_StartWorkflow{
+				StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+					WorkflowId:   wid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+				},
+			},
+		},
+	}
+
+	// Create schedule with initial memo.
+	memo1 := payload.EncodeString("val1")
+	ctx := newContext(s.Context())
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+		Memo: &commonpb.Memo{
+			Fields: map[string]*commonpb.Payload{"key1": memo1},
+		},
+	})
+	require.NoError(t, err)
+
+	// Update only memo, without setting the schedule field.
+	memo2 := payload.EncodeString("val2")
+	_, err = s.FrontendClient().UpdateSchedule(newContext(s.Context()), &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+		Memo: &commonpb.Memo{
+			Fields: map[string]*commonpb.Payload{"key1": memo2},
+		},
+	})
+	require.NoError(t, err)
+
+	// Verify memo was updated and schedule is still intact.
+	describeResp, err := s.FrontendClient().DescribeSchedule(newContext(s.Context()), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+	})
+	require.NoError(t, err)
+	require.Equal(t, memo2.Data, describeResp.Memo.Fields["key1"].Data, "memo should be updated")
+	require.NotNil(t, describeResp.Schedule.Spec, "schedule spec should not be nil")
+	require.NotEmpty(t, describeResp.Schedule.Spec.Interval, "schedule spec intervals should be preserved")
+	require.NotNil(t, describeResp.Schedule.Action, "schedule action should be preserved")
 }


### PR DESCRIPTION
Add memo field to UpdateScheduleRequest with replace semantics. CHASM only; V1 rejects with FailedPrecondition.
