### PR TITLE
Fix ListWorkers query support for BuildId and Status columns

### DIFF
--- a/service/matching/workers/worker_query_engine.go
+++ b/service/matching/workers/worker_query_engine.go
@@ -17,11 +17,15 @@ const (
 	workerHostNameColName       = "HostName"
 	workerTaskQueueColName      = "TaskQueue"
 	workerDeploymentNameColName = "DeploymentName"
+	workerBuildIDColName        = "BuildId"
 	workerSdkNameColName        = "SdkName"
 	workerSdkVersionColName     = "SdkVersion"
 	workerStartTimeColName      = "StartTime"
 	workerHeartbeatTimeColName  = "HeartbeatTime"
 	workerStatusColName         = "WorkerStatus"
+	// "Status" is a SQL reserved word, so the parser lowercases and backtick-quotes it.
+	// After stripping backticks we get "status".
+	workerStatusColNameAlias = "status"
 )
 
 const (
@@ -35,7 +39,7 @@ FilterWorkers filters the list of per-namespace worker heartbeats against the pr
 The query should be a valid SQL query without WHERE clause.
 
 Query is used to filter workers based on worker heartbeat info.
-The following worker status attributes are expected are supported as part of the query:
+The following worker attributes are supported as part of the query:
 * WorkerInstanceKey
 * WorkerIdentity
 * HostName
@@ -45,8 +49,8 @@ The following worker status attributes are expected are supported as part of the
 * SdkName
 * SdkVersion
 * StartTime
-* LastHeartbeatTime
-* Status
+* HeartbeatTime
+* WorkerStatus (or Status)
 Currently metrics are not supported as a part of ListWorkers query.
 
 Field names are case-sensitive.
@@ -56,12 +60,12 @@ The query can have conditions on multiple fields.
 Date time fields should be in RFC3339 format.
 Example query:
 
-	"TaskQueue = 'my_task_queue' AND LastHeartbeatTime < '2023-10-27T10:30:00Z' "
+	"TaskQueue = 'my_task_queue' AND HeartbeatTime < '2023-10-27T10:30:00Z' "
 
 Different fields can support different operators.
-  - string fields (e.g., WorkerIdentity, HostName, TaskQueue, DeploymentName, SdkName, SdkVersion):
+  - string fields (e.g., WorkerIdentity, HostName, TaskQueue, DeploymentName, BuildId, SdkName, SdkVersion):
 		starts_with, not starts_with
-  - time fields (e.g., StartTime, LastHeartbeatTime):
+  - time fields (e.g., StartTime, HeartbeatTime):
 		 =, !=, >, >=, <, <=, between
   - metric fields (e.g., total_sticky_cache_hit):
 		=, !=, >, >=, <, <=
@@ -111,6 +115,12 @@ var (
 			}
 			return hb.DeploymentVersion.DeploymentName
 		},
+		workerBuildIDColName: func(hb *workerpb.WorkerHeartbeat) string {
+			if hb.DeploymentVersion == nil {
+				return ""
+			}
+			return hb.DeploymentVersion.BuildId
+		},
 		workerSdkNameColName: func(hb *workerpb.WorkerHeartbeat) string {
 			return hb.SdkName
 		},
@@ -118,6 +128,9 @@ var (
 			return hb.SdkVersion
 		},
 		workerStatusColName: func(hb *workerpb.WorkerHeartbeat) string {
+			return hb.Status.String()
+		},
+		workerStatusColNameAlias: func(hb *workerpb.WorkerHeartbeat) string {
 			return hb.Status.String()
 		},
 	}
@@ -250,32 +263,26 @@ func (w *workerQueryEngine) evaluateComparison(expr *sqlparser.ComparisonExpr) (
 	if !ok {
 		return false, serviceerror.NewInvalidArgumentf("invalid filter name: %s", sqlparser.String(expr.Left))
 	}
-	colName := sqlparser.String(colNameExpr)
+	// Strip backticks added by the SQL parser for reserved words (e.g., "Status" → "`status`" → "status").
+	colName := strings.ReplaceAll(sqlparser.String(colNameExpr), "`", "")
 	valExpr, ok := expr.Right.(*sqlparser.SQLVal)
 	if !ok {
 		return false, serviceerror.NewInvalidArgumentf("invalid value: %s", sqlparser.String(expr.Right))
 	}
 	valStr := sqlparser.String(valExpr)
 
-	switch colName {
-	case workerInstanceKeyColName,
-		workerIdentityColName,
-		workerHostNameColName,
-		workerTaskQueueColName,
-		workerDeploymentNameColName,
-		workerSdkNameColName,
-		workerSdkVersionColName,
-		workerStatusColName:
-		propertyFunc, ok := propertyMapFuncs[colName]
-		if !ok {
-			return false, serviceerror.NewInvalidArgumentf("unknown or unsupported worker heartbeat search field: %s", colName)
-		}
+	// First check if the column name is a valid property function.
+	if propertyFunc, ok := propertyMapFuncs[colName]; ok {
 		val, err := sqlquery.ExtractStringValue(valStr)
 		if err != nil {
 			return false, serviceerror.NewInvalidArgumentf("invalid value for %s: %v", colName, err)
 		}
 		existingVal := propertyFunc(w.currentWorker)
 		return compareQueryString(val, existingVal, expr.Operator, colName)
+	}
+
+	// If not, then check if the column name is a valid time column.
+	switch colName {
 	case workerStartTimeColName:
 		expectedTime, err := sqlquery.ConvertToTime(valStr)
 		if err != nil {
@@ -303,7 +310,8 @@ func (w *workerQueryEngine) evaluateRange(expr *sqlparser.RangeCond) (bool, erro
 	if !ok {
 		return false, serviceerror.NewInvalidArgumentf("unknown or unsupported column name: %s", sqlparser.String(expr.Left))
 	}
-	colNameStr := sqlparser.String(colName)
+	// Strip backticks added by the SQL parser for reserved words (e.g., "Status" → "`status`" → "status").
+	colNameStr := strings.ReplaceAll(sqlparser.String(colName), "`", "")
 
 	switch colNameStr {
 	case workerStartTimeColName, workerHeartbeatTimeColName:

--- a/service/matching/workers/worker_query_engine_test.go
+++ b/service/matching/workers/worker_query_engine_test.go
@@ -141,6 +141,16 @@ func TestActivityInfoMatchEvaluator_SupportedFields(t *testing.T) {
 			expectedMatch: false,
 		},
 		{
+			name:          "BuildId, true",
+			query:         fmt.Sprintf("%s = 'build_id'", workerBuildIDColName),
+			expectedMatch: true,
+		},
+		{
+			name:          "BuildId, false",
+			query:         fmt.Sprintf("%s = 'build_id_unknown'", workerBuildIDColName),
+			expectedMatch: false,
+		},
+		{
 			name:          "SdkName, true",
 			query:         fmt.Sprintf("%s = 'sdk_name'", workerSdkNameColName),
 			expectedMatch: true,
@@ -168,6 +178,16 @@ func TestActivityInfoMatchEvaluator_SupportedFields(t *testing.T) {
 		{
 			name:          "WorkerStatus, false",
 			query:         fmt.Sprintf("%s = 'status_unknown'", workerStatusColName),
+			expectedMatch: false,
+		},
+		{
+			name:          "Status (alias), true",
+			query:         "Status = 'Running'",
+			expectedMatch: true,
+		},
+		{
+			name:          "Status (alias), false",
+			query:         "Status = 'status_unknown'",
 			expectedMatch: false,
 		},
 	}


### PR DESCRIPTION
## What changed?
- Added `BuildId` as a supported query attribute in `worker_query_engine.go` (was documented in proto but missing from implementation)
- Added `Status` query support by registering the lowercased form (`status`) that the SQL parser produces for reserved words, using `sqlparser.String()` + backtick strip consistent with the rest of the codebase
- Kept `WorkerStatus` as a backward-compatible alias
- Fixed stale comment references (`LastHeartbeatTime` → `HeartbeatTime`)

## Why?
`BuildId` and `Status` are documented as supported query attributes in `ListWorkersRequest` proto but were not working. `BuildId` was entirely missing from the property map, and `Status` is a SQL reserved word so the parser lowercases and backtick-quotes it — the old code used `WorkerStatus` which didn't match the proto docs.

## How did you test it?
- [x] built
- [x] covered by existing tests
- [x] added new unit test(s)