### PR TITLE
matching: fix data race on nexusEndpointsOwnershipLostCh

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -140,6 +140,7 @@ type (
 		visibilityManager             manager.VisibilityManager
 		nexusEndpointClient           *nexusEndpointClient
 		nexusEndpointsOwnershipLostCh chan struct{}
+		nexusEndpointsOwnershipMu     sync.RWMutex
 		saMapperProvider              searchattribute.MapperProvider
 		saProvider                    searchattribute.Provider
 		metricsHandler                metrics.Handler
@@ -2746,8 +2747,10 @@ func (e *matchingEngineImpl) ListNexusEndpoints(ctx context.Context, request *ma
 
 func (e *matchingEngineImpl) checkNexusEndpointsOwnership() (bool, <-chan struct{}, error) {
 	// Get the channel before checking the condition to prevent the channel from being closed while we're running this
-	// check.
+	// check. Use the lock to protect the read, as notifyNexusEndpointsOwnershipChange may concurrently replace it.
+	e.nexusEndpointsOwnershipMu.RLock()
 	ch := e.nexusEndpointsOwnershipLostCh
+	e.nexusEndpointsOwnershipMu.RUnlock()
 	self := e.hostInfoProvider.HostInfo().Identity()
 	owner, err := e.serviceResolver.Lookup(nexusEndpointsTablePartitionRoutingKey)
 	if err != nil {
@@ -2765,8 +2768,10 @@ func (e *matchingEngineImpl) notifyNexusEndpointsOwnershipChange() {
 		return
 	}
 	if !isOwner {
+		e.nexusEndpointsOwnershipMu.Lock()
 		close(e.nexusEndpointsOwnershipLostCh)
 		e.nexusEndpointsOwnershipLostCh = make(chan struct{})
+		e.nexusEndpointsOwnershipMu.Unlock()
 	}
 	e.nexusEndpointClient.notifyOwnershipChanged(isOwner)
 }

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3582,7 +3582,8 @@ func (s *matchingEngineSuite) TestCheckNexusEndpointsOwnership() {
 }
 
 func (s *matchingEngineSuite) TestNotifyNexusEndpointsOwnershipLost() {
-	ch := s.matchingEngine.nexusEndpointsOwnershipLostCh
+	_, ch, err := s.matchingEngine.checkNexusEndpointsOwnership()
+	s.NoError(err)
 	s.matchingEngine.notifyNexusEndpointsOwnershipChange()
 	select {
 	case <-ch:


### PR DESCRIPTION
## What changed?

Added a `sync.RWMutex` to protect concurrent access to `nexusEndpointsOwnershipLostCh` in `matchingEngineImpl`.

## Why?

Go race detector flagged a data race between two goroutines accessing the `nexusEndpointsOwnershipLostCh` field:

- **Read** path: `ListNexusEndpoints` → `checkNexusEndpointsOwnership()` reads the channel reference (called concurrently from gRPC handlers)
- **Write** path: `watchMembership` goroutine → `notifyNexusEndpointsOwnershipChange()` closes and replaces the channel

The comment at the read site ("Get the channel before checking the condition to prevent the channel from being closed while we're running this check") described the *intent* but provided no actual synchronization.

## How?

- Added `nexusEndpointsOwnershipMu sync.RWMutex` to the struct
- Use it while accessing `nexusEndpointsOwnershipLostCh`