### PR TITLE
Add a throttled priority for live replication.

### DIFF
--- a/api/enums/v1/task.go-helpers.pb.go
+++ b/api/enums/v1/task.go-helpers.pb.go
@@ -75,6 +75,7 @@ var (
 	TaskPriority_shorthandValue = map[string]int32{
 		"Unspecified": 0,
 		"High":        1,
+		"Throttled":   2,
 		"Low":         10,
 	}
 )

--- a/api/enums/v1/task.pb.go
+++ b/api/enums/v1/task.pb.go
@@ -237,13 +237,14 @@ func (x TaskType) String() string {
 	case TASK_TYPE_USER_TIMER:
 		return "UserTimer"
 
-		// gap between index can be used for future priority levels if needed
+		// TASK_PRIORITY_THROTTLED is assigned by the sender to tasks that would normally be HIGH
+		// priority but whose namespace is currently reported as throttled by the receiver.
+		// The receiver continues to run these tasks through the namespace throttler so the
+		// namespace can recover and be promoted back to HIGH priority.
 	case TASK_TYPE_WORKFLOW_RUN_TIMEOUT:
 		return "WorkflowRunTimeout"
 	case TASK_TYPE_DELETE_HISTORY_EVENT:
 		return "DeleteHistoryEvent"
-
-		// Enum value maps for TaskPriority.
 	case TASK_TYPE_ACTIVITY_RETRY_TIMER:
 		return "ActivityRetryTimer"
 	case TASK_TYPE_WORKFLOW_BACKOFF_TIMER:
@@ -252,9 +253,13 @@ func (x TaskType) String() string {
 		return "VisibilityStartExecution"
 	case TASK_TYPE_VISIBILITY_UPSERT_EXECUTION:
 		return "VisibilityUpsertExecution"
+
+		// gap between index can be used for future priority levels if needed
 	case TASK_TYPE_VISIBILITY_CLOSE_EXECUTION:
 		return "VisibilityCloseExecution"
 	case TASK_TYPE_VISIBILITY_DELETE_EXECUTION:
+
+		// Enum value maps for TaskPriority.
 		return "VisibilityDeleteExecution"
 	case TASK_TYPE_TRANSFER_DELETE_EXECUTION:
 		return "TransferDeleteExecution"
@@ -270,8 +275,6 @@ func (x TaskType) String() string {
 		return "WorkflowExecutionTimeout"
 	case TASK_TYPE_REPLICATION_SYNC_HSM:
 		return "ReplicationSyncHsm"
-
-		// Deprecated: Use TaskPriority.Descriptor instead.
 	case TASK_TYPE_REPLICATION_SYNC_VERSIONED_TRANSITION:
 		return "ReplicationSyncVersionedTransition"
 	case TASK_TYPE_CHASM_PURE:
@@ -306,6 +309,8 @@ const (
 	TASK_PRIORITY_UNSPECIFIED TaskPriority = 0
 	TASK_PRIORITY_HIGH        TaskPriority = 1
 
+	TASK_PRIORITY_THROTTLED TaskPriority = 2
+
 	TASK_PRIORITY_LOW TaskPriority = 10
 )
 
@@ -313,11 +318,13 @@ var (
 	TaskPriority_name = map[int32]string{
 		0:  "TASK_PRIORITY_UNSPECIFIED",
 		1:  "TASK_PRIORITY_HIGH",
+		2:  "TASK_PRIORITY_THROTTLED",
 		10: "TASK_PRIORITY_LOW",
 	}
 	TaskPriority_value = map[string]int32{
 		"TASK_PRIORITY_UNSPECIFIED": 0,
 		"TASK_PRIORITY_HIGH":        1,
+		"TASK_PRIORITY_THROTTLED":   2,
 		"TASK_PRIORITY_LOW":         10,
 	}
 )
@@ -334,6 +341,8 @@ func (x TaskPriority) String() string {
 		return "Unspecified"
 	case TASK_PRIORITY_HIGH:
 		return "High"
+	case TASK_PRIORITY_THROTTLED:
+		return "Throttled"
 	case TASK_PRIORITY_LOW:
 		return "Low"
 	default:
@@ -354,6 +363,7 @@ func (x TaskPriority) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
+// Deprecated: Use TaskPriority.Descriptor instead.
 func (TaskPriority) EnumDescriptor() ([]byte, []int) {
 	return file_temporal_server_api_enums_v1_task_proto_rawDescGZIP(), []int{2}
 }
@@ -400,10 +410,11 @@ const file_temporal_server_api_enums_v1_task_proto_rawDesc = "" +
 	"\x1eTASK_TYPE_REPLICATION_SYNC_HSM\x10\x1e\x123\n" +
 	"/TASK_TYPE_REPLICATION_SYNC_VERSIONED_TRANSITION\x10\x1f\x12\x18\n" +
 	"\x14TASK_TYPE_CHASM_PURE\x10 \x12\x13\n" +
-	"\x0fTASK_TYPE_CHASM\x10!\"\x04\b\t\x10\t\"\x04\b\v\x10\v\"\x04\b\x17\x10\x17*\\\n" +
+	"\x0fTASK_TYPE_CHASM\x10!\"\x04\b\t\x10\t\"\x04\b\v\x10\v\"\x04\b\x17\x10\x17*y\n" +
 	"\fTaskPriority\x12\x1d\n" +
 	"\x19TASK_PRIORITY_UNSPECIFIED\x10\x00\x12\x16\n" +
-	"\x12TASK_PRIORITY_HIGH\x10\x01\x12\x15\n" +
+	"\x12TASK_PRIORITY_HIGH\x10\x01\x12\x1b\n" +
+	"\x17TASK_PRIORITY_THROTTLED\x10\x02\x12\x15\n" +
 	"\x11TASK_PRIORITY_LOW\x10\n" +
 	"B*Z(go.temporal.io/server/api/enums/v1;enumsb\x06proto3"
 

--- a/api/replication/v1/message.pb.go
+++ b/api/replication/v1/message.pb.go
@@ -424,8 +424,13 @@ type SyncReplicationState struct {
 	InclusiveLowWatermarkTime *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=inclusive_low_watermark_time,json=inclusiveLowWatermarkTime,proto3" json:"inclusive_low_watermark_time,omitempty"`
 	HighPriorityState         *ReplicationState      `protobuf:"bytes,3,opt,name=high_priority_state,json=highPriorityState,proto3" json:"high_priority_state,omitempty"`
 	LowPriorityState          *ReplicationState      `protobuf:"bytes,4,opt,name=low_priority_state,json=lowPriorityState,proto3" json:"low_priority_state,omitempty"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	// flow control state for the THROTTLED priority lane; watermark is factored into high_priority_state
+	// on the receiver so the sender does not need to track it separately
+	ThrottledPriorityState *ReplicationState `protobuf:"bytes,5,opt,name=throttled_priority_state,json=throttledPriorityState,proto3" json:"throttled_priority_state,omitempty"`
+	// namespace IDs currently throttled by the receiver; sender should demote these to throttled priority
+	ThrottledNamespaceIds []string `protobuf:"bytes,6,rep,name=throttled_namespace_ids,json=throttledNamespaceIds,proto3" json:"throttled_namespace_ids,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *SyncReplicationState) Reset() {
@@ -482,6 +487,20 @@ func (x *SyncReplicationState) GetHighPriorityState() *ReplicationState {
 func (x *SyncReplicationState) GetLowPriorityState() *ReplicationState {
 	if x != nil {
 		return x.LowPriorityState
+	}
+	return nil
+}
+
+func (x *SyncReplicationState) GetThrottledPriorityState() *ReplicationState {
+	if x != nil {
+		return x.ThrottledPriorityState
+	}
+	return nil
+}
+
+func (x *SyncReplicationState) GetThrottledNamespaceIds() []string {
+	if x != nil {
+		return x.ThrottledNamespaceIds
 	}
 	return nil
 }
@@ -2146,12 +2165,14 @@ const file_temporal_server_api_replication_v1_message_proto_rawDesc = "" +
 	"\x1elast_processed_visibility_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x1blastProcessedVisibilityTime\"N\n" +
 	"\x0fSyncShardStatus\x12;\n" +
 	"\vstatus_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"statusTime\"\xf5\x02\n" +
+	"statusTime\"\x9d\x04\n" +
 	"\x14SyncReplicationState\x126\n" +
 	"\x17inclusive_low_watermark\x18\x01 \x01(\x03R\x15inclusiveLowWatermark\x12[\n" +
 	"\x1cinclusive_low_watermark_time\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x19inclusiveLowWatermarkTime\x12d\n" +
 	"\x13high_priority_state\x18\x03 \x01(\v24.temporal.server.api.replication.v1.ReplicationStateR\x11highPriorityState\x12b\n" +
-	"\x12low_priority_state\x18\x04 \x01(\v24.temporal.server.api.replication.v1.ReplicationStateR\x10lowPriorityState\"\x96\x02\n" +
+	"\x12low_priority_state\x18\x04 \x01(\v24.temporal.server.api.replication.v1.ReplicationStateR\x10lowPriorityState\x12n\n" +
+	"\x18throttled_priority_state\x18\x05 \x01(\v24.temporal.server.api.replication.v1.ReplicationStateR\x16throttledPriorityState\x126\n" +
+	"\x17throttled_namespace_ids\x18\x06 \x03(\tR\x15throttledNamespaceIds\"\x96\x02\n" +
 	"\x10ReplicationState\x126\n" +
 	"\x17inclusive_low_watermark\x18\x01 \x01(\x03R\x15inclusiveLowWatermark\x12[\n" +
 	"\x1cinclusive_low_watermark_time\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x19inclusiveLowWatermarkTime\x12m\n" +
@@ -2385,59 +2406,60 @@ var file_temporal_server_api_replication_v1_message_proto_depIdxs = []int32{
 	25, // 18: temporal.server.api.replication.v1.SyncReplicationState.inclusive_low_watermark_time:type_name -> google.protobuf.Timestamp
 	4,  // 19: temporal.server.api.replication.v1.SyncReplicationState.high_priority_state:type_name -> temporal.server.api.replication.v1.ReplicationState
 	4,  // 20: temporal.server.api.replication.v1.SyncReplicationState.low_priority_state:type_name -> temporal.server.api.replication.v1.ReplicationState
-	25, // 21: temporal.server.api.replication.v1.ReplicationState.inclusive_low_watermark_time:type_name -> google.protobuf.Timestamp
-	29, // 22: temporal.server.api.replication.v1.ReplicationState.flow_control_command:type_name -> temporal.server.api.enums.v1.ReplicationFlowControlCommand
-	0,  // 23: temporal.server.api.replication.v1.ReplicationMessages.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
-	2,  // 24: temporal.server.api.replication.v1.ReplicationMessages.sync_shard_status:type_name -> temporal.server.api.replication.v1.SyncShardStatus
-	0,  // 25: temporal.server.api.replication.v1.WorkflowReplicationMessages.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
-	25, // 26: temporal.server.api.replication.v1.WorkflowReplicationMessages.exclusive_high_watermark_time:type_name -> google.protobuf.Timestamp
-	26, // 27: temporal.server.api.replication.v1.WorkflowReplicationMessages.priority:type_name -> temporal.server.api.enums.v1.TaskPriority
-	30, // 28: temporal.server.api.replication.v1.ReplicationTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
-	26, // 29: temporal.server.api.replication.v1.ReplicationTaskInfo.priority:type_name -> temporal.server.api.enums.v1.TaskPriority
-	31, // 30: temporal.server.api.replication.v1.NamespaceTaskAttributes.namespace_operation:type_name -> temporal.server.api.enums.v1.NamespaceOperation
-	32, // 31: temporal.server.api.replication.v1.NamespaceTaskAttributes.info:type_name -> temporal.api.namespace.v1.NamespaceInfo
-	33, // 32: temporal.server.api.replication.v1.NamespaceTaskAttributes.config:type_name -> temporal.api.namespace.v1.NamespaceConfig
-	34, // 33: temporal.server.api.replication.v1.NamespaceTaskAttributes.replication_config:type_name -> temporal.api.replication.v1.NamespaceReplicationConfig
-	35, // 34: temporal.server.api.replication.v1.NamespaceTaskAttributes.failover_history:type_name -> temporal.api.replication.v1.FailoverStatus
-	25, // 35: temporal.server.api.replication.v1.SyncShardStatusTaskAttributes.status_time:type_name -> google.protobuf.Timestamp
-	25, // 36: temporal.server.api.replication.v1.SyncActivityTaskAttributes.scheduled_time:type_name -> google.protobuf.Timestamp
-	25, // 37: temporal.server.api.replication.v1.SyncActivityTaskAttributes.started_time:type_name -> google.protobuf.Timestamp
-	25, // 38: temporal.server.api.replication.v1.SyncActivityTaskAttributes.last_heartbeat_time:type_name -> google.protobuf.Timestamp
-	36, // 39: temporal.server.api.replication.v1.SyncActivityTaskAttributes.details:type_name -> temporal.api.common.v1.Payloads
-	37, // 40: temporal.server.api.replication.v1.SyncActivityTaskAttributes.last_failure:type_name -> temporal.api.failure.v1.Failure
-	38, // 41: temporal.server.api.replication.v1.SyncActivityTaskAttributes.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
-	39, // 42: temporal.server.api.replication.v1.SyncActivityTaskAttributes.base_execution_info:type_name -> temporal.server.api.workflow.v1.BaseExecutionInfo
-	25, // 43: temporal.server.api.replication.v1.SyncActivityTaskAttributes.first_scheduled_time:type_name -> google.protobuf.Timestamp
-	25, // 44: temporal.server.api.replication.v1.SyncActivityTaskAttributes.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
-	40, // 45: temporal.server.api.replication.v1.SyncActivityTaskAttributes.retry_initial_interval:type_name -> google.protobuf.Duration
-	40, // 46: temporal.server.api.replication.v1.SyncActivityTaskAttributes.retry_maximum_interval:type_name -> google.protobuf.Duration
-	41, // 47: temporal.server.api.replication.v1.HistoryTaskAttributes.version_history_items:type_name -> temporal.server.api.history.v1.VersionHistoryItem
-	24, // 48: temporal.server.api.replication.v1.HistoryTaskAttributes.events:type_name -> temporal.api.common.v1.DataBlob
-	24, // 49: temporal.server.api.replication.v1.HistoryTaskAttributes.new_run_events:type_name -> temporal.api.common.v1.DataBlob
-	39, // 50: temporal.server.api.replication.v1.HistoryTaskAttributes.base_execution_info:type_name -> temporal.server.api.workflow.v1.BaseExecutionInfo
-	24, // 51: temporal.server.api.replication.v1.HistoryTaskAttributes.events_batches:type_name -> temporal.api.common.v1.DataBlob
-	42, // 52: temporal.server.api.replication.v1.SyncWorkflowStateTaskAttributes.workflow_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
-	43, // 53: temporal.server.api.replication.v1.TaskQueueUserDataAttributes.user_data:type_name -> temporal.server.api.persistence.v1.TaskQueueUserData
-	38, // 54: temporal.server.api.replication.v1.SyncHSMAttributes.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
-	44, // 55: temporal.server.api.replication.v1.SyncHSMAttributes.state_machine_node:type_name -> temporal.server.api.persistence.v1.StateMachineNode
-	41, // 56: temporal.server.api.replication.v1.BackfillHistoryTaskAttributes.event_version_history:type_name -> temporal.server.api.history.v1.VersionHistoryItem
-	24, // 57: temporal.server.api.replication.v1.BackfillHistoryTaskAttributes.event_batches:type_name -> temporal.api.common.v1.DataBlob
-	16, // 58: temporal.server.api.replication.v1.BackfillHistoryTaskAttributes.new_run_info:type_name -> temporal.server.api.replication.v1.NewRunInfo
-	24, // 59: temporal.server.api.replication.v1.NewRunInfo.event_batch:type_name -> temporal.api.common.v1.DataBlob
-	27, // 60: temporal.server.api.replication.v1.SyncWorkflowStateMutationAttributes.exclusive_start_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	45, // 61: temporal.server.api.replication.v1.SyncWorkflowStateMutationAttributes.state_mutation:type_name -> temporal.server.api.persistence.v1.WorkflowMutableStateMutation
-	42, // 62: temporal.server.api.replication.v1.SyncWorkflowStateSnapshotAttributes.state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
-	41, // 63: temporal.server.api.replication.v1.VerifyVersionedTransitionTaskAttributes.event_version_history:type_name -> temporal.server.api.history.v1.VersionHistoryItem
-	21, // 64: temporal.server.api.replication.v1.SyncVersionedTransitionTaskAttributes.versioned_transition_artifact:type_name -> temporal.server.api.replication.v1.VersionedTransitionArtifact
-	17, // 65: temporal.server.api.replication.v1.VersionedTransitionArtifact.sync_workflow_state_mutation_attributes:type_name -> temporal.server.api.replication.v1.SyncWorkflowStateMutationAttributes
-	18, // 66: temporal.server.api.replication.v1.VersionedTransitionArtifact.sync_workflow_state_snapshot_attributes:type_name -> temporal.server.api.replication.v1.SyncWorkflowStateSnapshotAttributes
-	24, // 67: temporal.server.api.replication.v1.VersionedTransitionArtifact.event_batches:type_name -> temporal.api.common.v1.DataBlob
-	16, // 68: temporal.server.api.replication.v1.VersionedTransitionArtifact.new_run_info:type_name -> temporal.server.api.replication.v1.NewRunInfo
-	69, // [69:69] is the sub-list for method output_type
-	69, // [69:69] is the sub-list for method input_type
-	69, // [69:69] is the sub-list for extension type_name
-	69, // [69:69] is the sub-list for extension extendee
-	0,  // [0:69] is the sub-list for field type_name
+	4,  // 21: temporal.server.api.replication.v1.SyncReplicationState.throttled_priority_state:type_name -> temporal.server.api.replication.v1.ReplicationState
+	25, // 22: temporal.server.api.replication.v1.ReplicationState.inclusive_low_watermark_time:type_name -> google.protobuf.Timestamp
+	29, // 23: temporal.server.api.replication.v1.ReplicationState.flow_control_command:type_name -> temporal.server.api.enums.v1.ReplicationFlowControlCommand
+	0,  // 24: temporal.server.api.replication.v1.ReplicationMessages.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
+	2,  // 25: temporal.server.api.replication.v1.ReplicationMessages.sync_shard_status:type_name -> temporal.server.api.replication.v1.SyncShardStatus
+	0,  // 26: temporal.server.api.replication.v1.WorkflowReplicationMessages.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
+	25, // 27: temporal.server.api.replication.v1.WorkflowReplicationMessages.exclusive_high_watermark_time:type_name -> google.protobuf.Timestamp
+	26, // 28: temporal.server.api.replication.v1.WorkflowReplicationMessages.priority:type_name -> temporal.server.api.enums.v1.TaskPriority
+	30, // 29: temporal.server.api.replication.v1.ReplicationTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
+	26, // 30: temporal.server.api.replication.v1.ReplicationTaskInfo.priority:type_name -> temporal.server.api.enums.v1.TaskPriority
+	31, // 31: temporal.server.api.replication.v1.NamespaceTaskAttributes.namespace_operation:type_name -> temporal.server.api.enums.v1.NamespaceOperation
+	32, // 32: temporal.server.api.replication.v1.NamespaceTaskAttributes.info:type_name -> temporal.api.namespace.v1.NamespaceInfo
+	33, // 33: temporal.server.api.replication.v1.NamespaceTaskAttributes.config:type_name -> temporal.api.namespace.v1.NamespaceConfig
+	34, // 34: temporal.server.api.replication.v1.NamespaceTaskAttributes.replication_config:type_name -> temporal.api.replication.v1.NamespaceReplicationConfig
+	35, // 35: temporal.server.api.replication.v1.NamespaceTaskAttributes.failover_history:type_name -> temporal.api.replication.v1.FailoverStatus
+	25, // 36: temporal.server.api.replication.v1.SyncShardStatusTaskAttributes.status_time:type_name -> google.protobuf.Timestamp
+	25, // 37: temporal.server.api.replication.v1.SyncActivityTaskAttributes.scheduled_time:type_name -> google.protobuf.Timestamp
+	25, // 38: temporal.server.api.replication.v1.SyncActivityTaskAttributes.started_time:type_name -> google.protobuf.Timestamp
+	25, // 39: temporal.server.api.replication.v1.SyncActivityTaskAttributes.last_heartbeat_time:type_name -> google.protobuf.Timestamp
+	36, // 40: temporal.server.api.replication.v1.SyncActivityTaskAttributes.details:type_name -> temporal.api.common.v1.Payloads
+	37, // 41: temporal.server.api.replication.v1.SyncActivityTaskAttributes.last_failure:type_name -> temporal.api.failure.v1.Failure
+	38, // 42: temporal.server.api.replication.v1.SyncActivityTaskAttributes.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
+	39, // 43: temporal.server.api.replication.v1.SyncActivityTaskAttributes.base_execution_info:type_name -> temporal.server.api.workflow.v1.BaseExecutionInfo
+	25, // 44: temporal.server.api.replication.v1.SyncActivityTaskAttributes.first_scheduled_time:type_name -> google.protobuf.Timestamp
+	25, // 45: temporal.server.api.replication.v1.SyncActivityTaskAttributes.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
+	40, // 46: temporal.server.api.replication.v1.SyncActivityTaskAttributes.retry_initial_interval:type_name -> google.protobuf.Duration
+	40, // 47: temporal.server.api.replication.v1.SyncActivityTaskAttributes.retry_maximum_interval:type_name -> google.protobuf.Duration
+	41, // 48: temporal.server.api.replication.v1.HistoryTaskAttributes.version_history_items:type_name -> temporal.server.api.history.v1.VersionHistoryItem
+	24, // 49: temporal.server.api.replication.v1.HistoryTaskAttributes.events:type_name -> temporal.api.common.v1.DataBlob
+	24, // 50: temporal.server.api.replication.v1.HistoryTaskAttributes.new_run_events:type_name -> temporal.api.common.v1.DataBlob
+	39, // 51: temporal.server.api.replication.v1.HistoryTaskAttributes.base_execution_info:type_name -> temporal.server.api.workflow.v1.BaseExecutionInfo
+	24, // 52: temporal.server.api.replication.v1.HistoryTaskAttributes.events_batches:type_name -> temporal.api.common.v1.DataBlob
+	42, // 53: temporal.server.api.replication.v1.SyncWorkflowStateTaskAttributes.workflow_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
+	43, // 54: temporal.server.api.replication.v1.TaskQueueUserDataAttributes.user_data:type_name -> temporal.server.api.persistence.v1.TaskQueueUserData
+	38, // 55: temporal.server.api.replication.v1.SyncHSMAttributes.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
+	44, // 56: temporal.server.api.replication.v1.SyncHSMAttributes.state_machine_node:type_name -> temporal.server.api.persistence.v1.StateMachineNode
+	41, // 57: temporal.server.api.replication.v1.BackfillHistoryTaskAttributes.event_version_history:type_name -> temporal.server.api.history.v1.VersionHistoryItem
+	24, // 58: temporal.server.api.replication.v1.BackfillHistoryTaskAttributes.event_batches:type_name -> temporal.api.common.v1.DataBlob
+	16, // 59: temporal.server.api.replication.v1.BackfillHistoryTaskAttributes.new_run_info:type_name -> temporal.server.api.replication.v1.NewRunInfo
+	24, // 60: temporal.server.api.replication.v1.NewRunInfo.event_batch:type_name -> temporal.api.common.v1.DataBlob
+	27, // 61: temporal.server.api.replication.v1.SyncWorkflowStateMutationAttributes.exclusive_start_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	45, // 62: temporal.server.api.replication.v1.SyncWorkflowStateMutationAttributes.state_mutation:type_name -> temporal.server.api.persistence.v1.WorkflowMutableStateMutation
+	42, // 63: temporal.server.api.replication.v1.SyncWorkflowStateSnapshotAttributes.state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
+	41, // 64: temporal.server.api.replication.v1.VerifyVersionedTransitionTaskAttributes.event_version_history:type_name -> temporal.server.api.history.v1.VersionHistoryItem
+	21, // 65: temporal.server.api.replication.v1.SyncVersionedTransitionTaskAttributes.versioned_transition_artifact:type_name -> temporal.server.api.replication.v1.VersionedTransitionArtifact
+	17, // 66: temporal.server.api.replication.v1.VersionedTransitionArtifact.sync_workflow_state_mutation_attributes:type_name -> temporal.server.api.replication.v1.SyncWorkflowStateMutationAttributes
+	18, // 67: temporal.server.api.replication.v1.VersionedTransitionArtifact.sync_workflow_state_snapshot_attributes:type_name -> temporal.server.api.replication.v1.SyncWorkflowStateSnapshotAttributes
+	24, // 68: temporal.server.api.replication.v1.VersionedTransitionArtifact.event_batches:type_name -> temporal.api.common.v1.DataBlob
+	16, // 69: temporal.server.api.replication.v1.VersionedTransitionArtifact.new_run_info:type_name -> temporal.server.api.replication.v1.NewRunInfo
+	70, // [70:70] is the sub-list for method output_type
+	70, // [70:70] is the sub-list for method input_type
+	70, // [70:70] is the sub-list for extension type_name
+	70, // [70:70] is the sub-list for extension extendee
+	0,  // [0:70] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_api_replication_v1_message_proto_init() }

--- a/proto/internal/temporal/server/api/enums/v1/task.proto
+++ b/proto/internal/temporal/server/api/enums/v1/task.proto
@@ -65,6 +65,11 @@ enum TaskType {
 enum TaskPriority {
     TASK_PRIORITY_UNSPECIFIED = 0;
     TASK_PRIORITY_HIGH = 1;
+    // TASK_PRIORITY_THROTTLED is assigned by the sender to tasks that would normally be HIGH
+    // priority but whose namespace is currently reported as throttled by the receiver.
+    // The receiver continues to run these tasks through the namespace throttler so the
+    // namespace can recover and be promoted back to HIGH priority.
+    TASK_PRIORITY_THROTTLED = 2;
     // gap between index can be used for future priority levels if needed
     TASK_PRIORITY_LOW = 10;
 }

--- a/proto/internal/temporal/server/api/replication/v1/message.proto
+++ b/proto/internal/temporal/server/api/replication/v1/message.proto
@@ -69,6 +69,11 @@ message SyncReplicationState {
     google.protobuf.Timestamp  inclusive_low_watermark_time = 2;
     ReplicationState high_priority_state = 3;
     ReplicationState low_priority_state = 4;
+    // flow control state for the THROTTLED priority lane; watermark is factored into high_priority_state
+    // on the receiver so the sender does not need to track it separately
+    ReplicationState throttled_priority_state = 5;
+    // namespace IDs currently throttled by the receiver; sender should demote these to throttled priority
+    repeated string throttled_namespace_ids = 6;
 }
 message ReplicationState {
     int64 inclusive_low_watermark = 1;

--- a/service/history/replication/executable_activity_state_task.go
+++ b/service/history/replication/executable_activity_state_task.go
@@ -128,7 +128,7 @@ func (e *ExecutableActivityStateTask) Execute() error {
 	}
 	e.MarkExecutionStart()
 
-	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+	callerInfo := getReplicationCallerInfo(e.GetPriority())
 	namespaceName, apply, nsError := e.GetNamespaceInfo(headers.SetCallerInfo(
 		context.Background(),
 		callerInfo,
@@ -190,7 +190,7 @@ func (e *ExecutableActivityStateTask) HandleErr(err error) error {
 	case nil, *serviceerror.NotFound:
 		return nil
 	case *serviceerrors.RetryReplication:
-		callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+		callerInfo := getReplicationCallerInfo(e.GetPriority())
 		namespaceName, _, nsError := e.GetNamespaceInfo(headers.SetCallerInfo(
 			context.Background(),
 			callerInfo,

--- a/service/history/replication/executable_backfill_history_events_task.go
+++ b/service/history/replication/executable_backfill_history_events_task.go
@@ -76,7 +76,7 @@ func (e *ExecutableBackfillHistoryEventsTask) Execute() error {
 	}
 	e.MarkExecutionStart()
 
-	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+	callerInfo := getReplicationCallerInfo(e.GetPriority())
 	namespaceName, apply, nsError := e.GetNamespaceInfo(headers.SetCallerInfo(
 		context.Background(),
 		callerInfo,
@@ -149,7 +149,7 @@ func (e *ExecutableBackfillHistoryEventsTask) HandleErr(err error) error {
 		tag.TaskID(e.ExecutableTask.TaskID()),
 		tag.Error(err),
 	)
-	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+	callerInfo := getReplicationCallerInfo(e.GetPriority())
 	switch taskErr := err.(type) {
 	case nil, *serviceerror.NotFound:
 		return nil

--- a/service/history/replication/executable_history_task.go
+++ b/service/history/replication/executable_history_task.go
@@ -100,7 +100,7 @@ func (e *ExecutableHistoryTask) Execute() error {
 	}
 	e.MarkExecutionStart()
 
-	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+	callerInfo := getReplicationCallerInfo(e.GetPriority())
 	namespaceName, apply, nsError := e.GetNamespaceInfo(headers.SetCallerInfo(
 		context.Background(),
 		callerInfo,
@@ -156,7 +156,7 @@ func (e *ExecutableHistoryTask) HandleErr(err error) error {
 	case nil, *serviceerror.NotFound:
 		return nil
 	case *serviceerrors.RetryReplication:
-		callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+		callerInfo := getReplicationCallerInfo(e.GetPriority())
 		namespaceName, _, nsError := e.GetNamespaceInfo(headers.SetCallerInfo(
 			context.Background(),
 			callerInfo,

--- a/service/history/replication/executable_sync_hsm_task.go
+++ b/service/history/replication/executable_sync_hsm_task.go
@@ -78,7 +78,7 @@ func (e *ExecutableSyncHSMTask) Execute() error {
 	}
 	e.MarkExecutionStart()
 
-	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+	callerInfo := getReplicationCallerInfo(e.GetPriority())
 	namespaceName, apply, nsError := e.GetNamespaceInfo(headers.SetCallerInfo(
 		context.Background(),
 		callerInfo,
@@ -132,7 +132,7 @@ func (e *ExecutableSyncHSMTask) HandleErr(err error) error {
 		e.MarkTaskDuplicated()
 		return nil
 	}
-	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+	callerInfo := getReplicationCallerInfo(e.GetPriority())
 	switch retryErr := err.(type) {
 	case nil, *serviceerror.NotFound:
 		return nil

--- a/service/history/replication/executable_sync_versioned_transition_task.go
+++ b/service/history/replication/executable_sync_versioned_transition_task.go
@@ -74,7 +74,7 @@ func (e *ExecutableSyncVersionedTransitionTask) Execute() error {
 	}
 	e.MarkExecutionStart()
 
-	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+	callerInfo := getReplicationCallerInfo(e.GetPriority())
 	namespaceName, apply, nsError := e.GetNamespaceInfo(headers.SetCallerInfo(
 		context.Background(),
 		callerInfo,
@@ -135,7 +135,7 @@ func (e *ExecutableSyncVersionedTransitionTask) HandleErr(err error) error {
 		tag.TaskID(e.ExecutableTask.TaskID()),
 		tag.Error(err),
 	)
-	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+	callerInfo := getReplicationCallerInfo(e.GetPriority())
 	switch taskErr := err.(type) {
 	case *serviceerrors.SyncState:
 		namespaceName, _, nsError := e.GetNamespaceInfo(headers.SetCallerInfo(

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -897,7 +897,7 @@ func newTaskContext(
 	return context.WithTimeout(ctx, timeout)
 }
 
-func getReplicaitonCallerInfo(priority enumsspb.TaskPriority) headers.CallerInfo {
+func getReplicationCallerInfo(priority enumsspb.TaskPriority) headers.CallerInfo {
 	switch priority {
 	case enumsspb.TASK_PRIORITY_LOW:
 		return headers.SystemPreemptableCallerInfo

--- a/service/history/replication/executable_task_tool_box.go
+++ b/service/history/replication/executable_task_tool_box.go
@@ -37,5 +37,6 @@ type (
 		HistoryEventsHandler     eventhandler.HistoryEventsHandler
 		WorkflowCache            wcache.Cache
 		RemoteHistoryFetcher     eventhandler.HistoryPaginatedFetcher
+		NamespaceThrottler       NamespaceThrottler
 	}
 )

--- a/service/history/replication/executable_verify_versioned_transition_task.go
+++ b/service/history/replication/executable_verify_versioned_transition_task.go
@@ -81,7 +81,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) Execute() error {
 	}
 	e.MarkExecutionStart()
 
-	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+	callerInfo := getReplicationCallerInfo(e.GetPriority())
 	namespaceName, apply, nsError := e.GetNamespaceInfo(headers.SetCallerInfo(
 		context.Background(),
 		callerInfo,
@@ -271,7 +271,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) HandleErr(err error) error {
 	)
 	switch taskErr := err.(type) {
 	case *serviceerrors.SyncState:
-		callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+		callerInfo := getReplicationCallerInfo(e.GetPriority())
 		namespaceName, _, nsError := e.GetNamespaceInfo(headers.SetCallerInfo(
 			context.Background(),
 			callerInfo,
@@ -307,7 +307,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) HandleErr(err error) error {
 			tag.WorkflowID(e.WorkflowID),
 			tag.WorkflowRunID(e.RunID),
 		)
-		callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+		callerInfo := getReplicationCallerInfo(e.GetPriority())
 		// workflow is not found in source cluster, cleanup workflow in target cluster
 		ctx, cancel := newTaskContext(e.NamespaceName(), e.Config.ReplicationTaskApplyTimeout(), callerInfo)
 		defer cancel()

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -81,7 +81,7 @@ func (e *ExecutableWorkflowStateTask) Execute() error {
 	}
 	e.MarkExecutionStart()
 
-	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+	callerInfo := getReplicationCallerInfo(e.GetPriority())
 	namespaceName, apply, err := e.GetNamespaceInfo(headers.SetCallerInfo(
 		context.Background(),
 		callerInfo,
@@ -130,7 +130,7 @@ func (e *ExecutableWorkflowStateTask) HandleErr(err error) error {
 		e.MarkTaskDuplicated()
 		return nil
 	}
-	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
+	callerInfo := getReplicationCallerInfo(e.GetPriority())
 	switch retryErr := err.(type) {
 	case *serviceerrors.SyncState:
 		namespaceName, _, nsError := e.GetNamespaceInfo(headers.SetCallerInfo(

--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -41,6 +41,9 @@ type (
 
 var Module = fx.Provide(
 	NewTaskFetcherFactory,
+	func() NamespaceThrottler {
+		return NoopNamespaceReplicationThrottler{}
+	},
 	func(m persistence.ExecutionManager) ExecutionManager {
 		return m
 	},

--- a/service/history/replication/namespace_throttler.go
+++ b/service/history/replication/namespace_throttler.go
@@ -1,0 +1,22 @@
+package replication
+
+// NamespaceReplicationThrottler tracks per-namespace replication rate limits on the receiver side.
+// When a namespace exceeds its allowed rate, it is considered throttled and its ID is included
+// in SyncReplicationState ACKs so the sender can demote it to low priority.
+
+type NamespaceThrottler interface {
+	// Allow records an incoming task for the given namespace and reports whether it is within
+	// its rate limit. It must be called for every incoming task — including tasks already at
+	// THROTTLED priority — so the throttler can track the current load and determine when a
+	// namespace has recovered enough to be promoted back to HIGH priority.
+	// Returns true if the namespace is within its limit (not throttled).
+	Allow(namespaceID string) bool
+	// ThrottledNamespaceIDs returns the set of namespace IDs that are currently throttled.
+	ThrottledNamespaceIDs() []string
+}
+
+// NoopNamespaceReplicationThrottler is the default implementation which never throttles.
+type NoopNamespaceReplicationThrottler struct{}
+
+func (NoopNamespaceReplicationThrottler) Allow(_ string) bool             { return true }
+func (NoopNamespaceReplicationThrottler) ThrottledNamespaceIDs() []string { return nil }

--- a/service/history/replication/raw_task_converter.go
+++ b/service/history/replication/raw_task_converter.go
@@ -98,7 +98,7 @@ func (c *SourceTaskConverterImpl) Convert(
 	if namespaceEntry != nil {
 		nsName = namespaceEntry.Name().String()
 	}
-	callerInfo := getReplicaitonCallerInfo(priority)
+	callerInfo := getReplicationCallerInfo(priority)
 	ctx, cancel = newTaskContext(nsName, c.config.ReplicationTaskApplyTimeout(), callerInfo)
 	defer cancel()
 	replicationTask, err := c.historyEngine.ConvertReplicationTask(ctx, task, targetClusterID)

--- a/service/history/replication/stream_receiver.go
+++ b/service/history/replication/stream_receiver.go
@@ -39,18 +39,19 @@ type (
 	StreamReceiverImpl struct {
 		ProcessToolBox
 
-		status                  int32
-		clientShardKey          ClusterShardKey
-		serverShardKey          ClusterShardKey
-		highPriorityTaskTracker ExecutableTaskTracker
-		lowPriorityTaskTracker  ExecutableTaskTracker
-		shutdownChan            channel.ShutdownOnce
-		logger                  log.Logger
-		stream                  Stream
-		taskConverter           ExecutableTaskConverter
-		receiverMode            ReceiverMode
-		flowController          ReceiverFlowController
-		recvSignalChan          chan struct{}
+		status                       int32
+		clientShardKey               ClusterShardKey
+		serverShardKey               ClusterShardKey
+		highPriorityTaskTracker      ExecutableTaskTracker
+		throttledPriorityTaskTracker ExecutableTaskTracker
+		lowPriorityTaskTracker       ExecutableTaskTracker
+		shutdownChan                 channel.ShutdownOnce
+		logger                       log.Logger
+		stream                       Stream
+		taskConverter                ExecutableTaskConverter
+		receiverMode                 ReceiverMode
+		flowController               ReceiverFlowController
+		recvSignalChan               chan struct{}
 
 		slowSubmissionMu         sync.RWMutex
 		slowSubmissionTimestamps map[enumsspb.TaskPriority]time.Time
@@ -81,17 +82,19 @@ func NewStreamReceiver(
 		tag.Operation("replication-stream-receiver"),
 	)
 	highPriorityTaskTracker := NewExecutableTaskTracker(logger, processToolBox.MetricsHandler)
+	throttledPriorityTaskTracker := NewExecutableTaskTracker(logger, processToolBox.MetricsHandler)
 	lowPriorityTaskTracker := NewExecutableTaskTracker(logger, processToolBox.MetricsHandler)
 	receiver := &StreamReceiverImpl{
 		ProcessToolBox: processToolBox,
 
-		status:                  common.DaemonStatusInitialized,
-		clientShardKey:          clientShardKey,
-		serverShardKey:          serverShardKey,
-		highPriorityTaskTracker: highPriorityTaskTracker,
-		lowPriorityTaskTracker:  lowPriorityTaskTracker,
-		shutdownChan:            channel.NewShutdownOnce(),
-		logger:                  logger,
+		status:                       common.DaemonStatusInitialized,
+		clientShardKey:               clientShardKey,
+		serverShardKey:               serverShardKey,
+		highPriorityTaskTracker:      highPriorityTaskTracker,
+		throttledPriorityTaskTracker: throttledPriorityTaskTracker,
+		lowPriorityTaskTracker:       lowPriorityTaskTracker,
+		shutdownChan:                 channel.NewShutdownOnce(),
+		logger:                       logger,
 		stream: newStream(
 			processToolBox,
 			clientShardKey,
@@ -107,6 +110,12 @@ func NewStreamReceiver(
 		return &FlowControlSignal{
 			taskTrackingCount:  highPriorityTaskTracker.Size(),
 			lastSlowSubmission: receiver.getLastSlowSubmissionTimestamp(enumsspb.TASK_PRIORITY_HIGH),
+		}
+	}
+	taskTrackerMap[enumsspb.TASK_PRIORITY_THROTTLED] = func() *FlowControlSignal {
+		return &FlowControlSignal{
+			taskTrackingCount:  throttledPriorityTaskTracker.Size(),
+			lastSlowSubmission: receiver.getLastSlowSubmissionTimestamp(enumsspb.TASK_PRIORITY_THROTTLED),
 		}
 	}
 	taskTrackerMap[enumsspb.TASK_PRIORITY_LOW] = func() *FlowControlSignal {
@@ -223,10 +232,11 @@ func (r *StreamReceiverImpl) ackMessage(
 	stream Stream,
 ) (int64, error) {
 	highPriorityWaterMarkInfo := r.highPriorityTaskTracker.LowWatermark()
+	throttledPriorityWaterMarkInfo := r.throttledPriorityTaskTracker.LowWatermark()
 	lowPriorityWaterMarkInfo := r.lowPriorityTaskTracker.LowWatermark()
-	size := r.highPriorityTaskTracker.Size() + r.lowPriorityTaskTracker.Size()
+	size := r.highPriorityTaskTracker.Size() + r.throttledPriorityTaskTracker.Size() + r.lowPriorityTaskTracker.Size()
 
-	var highPriorityWatermark, lowPriorityWatermark *replicationspb.ReplicationState
+	var highPriorityWatermark, throttledPriorityWatermark, lowPriorityWatermark *replicationspb.ReplicationState
 	inclusiveLowWaterMark := int64(-1)
 	var inclusiveLowWaterMarkTime time.Time
 
@@ -244,15 +254,37 @@ func (r *StreamReceiverImpl) ackMessage(
 			r.logger.Warn("Tiered stack mode. Have to wait for both high and low priority tracker received at least one batch of tasks before acking.")
 			return 0, nil
 		}
+
+		// Synthetic effective HIGH watermark: min of HIGH and THROTTLED trackers.
+		// THROTTLED tasks originate from the HIGH reader on the sender, so their
+		// watermarks are interleaved with HIGH task IDs. The sender uses HighPriorityState
+		// to advance the HIGH reader position, so we must not report a watermark that
+		// skips over unprocessed THROTTLED tasks.
+		effectiveHighWaterMarkInfo := highPriorityWaterMarkInfo
+		if throttledPriorityWaterMarkInfo != nil && throttledPriorityWaterMarkInfo.Watermark < highPriorityWaterMarkInfo.Watermark {
+			effectiveHighWaterMarkInfo = throttledPriorityWaterMarkInfo
+		}
+
 		highPriorityFlowControlInfo := r.flowController.GetFlowControlInfo(enumsspb.TASK_PRIORITY_HIGH)
 		if highPriorityFlowControlInfo.Command == enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_PAUSE {
 			r.logger.Warn(fmt.Sprintf("pausing High Priority Tasks: %s", highPriorityFlowControlInfo.Cause))
 		}
 		highPriorityWatermark = &replicationspb.ReplicationState{
-			InclusiveLowWatermark:     highPriorityWaterMarkInfo.Watermark,
-			InclusiveLowWatermarkTime: timestamppb.New(highPriorityWaterMarkInfo.Timestamp),
+			InclusiveLowWatermark:     effectiveHighWaterMarkInfo.Watermark,
+			InclusiveLowWatermarkTime: timestamppb.New(effectiveHighWaterMarkInfo.Timestamp),
 			FlowControlCommand:        highPriorityFlowControlInfo.Command,
 		}
+
+		throttledFlowControlInfo := r.flowController.GetFlowControlInfo(enumsspb.TASK_PRIORITY_THROTTLED)
+		if throttledFlowControlInfo.Command == enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_PAUSE {
+			r.logger.Warn(fmt.Sprintf("pausing Throttled Priority Tasks: %s", throttledFlowControlInfo.Cause))
+		}
+		// Watermark is already factored into highPriorityWatermark above; this field carries
+		// only the flow control command back to the sender.
+		throttledPriorityWatermark = &replicationspb.ReplicationState{
+			FlowControlCommand: throttledFlowControlInfo.Command,
+		}
+
 		lowPriorityFlowControlInfo := r.flowController.GetFlowControlInfo(enumsspb.TASK_PRIORITY_LOW)
 		if lowPriorityFlowControlInfo.Command == enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_PAUSE {
 			r.logger.Warn(fmt.Sprintf("pausing Low Priority Tasks: %s", lowPriorityFlowControlInfo.Cause))
@@ -262,9 +294,9 @@ func (r *StreamReceiverImpl) ackMessage(
 			InclusiveLowWatermarkTime: timestamppb.New(lowPriorityWaterMarkInfo.Timestamp),
 			FlowControlCommand:        lowPriorityFlowControlInfo.Command,
 		}
-		if highPriorityWaterMarkInfo.Watermark <= lowPriorityWaterMarkInfo.Watermark {
-			inclusiveLowWaterMark = highPriorityWaterMarkInfo.Watermark
-			inclusiveLowWaterMarkTime = highPriorityWaterMarkInfo.Timestamp
+		if effectiveHighWaterMarkInfo.Watermark <= lowPriorityWaterMarkInfo.Watermark {
+			inclusiveLowWaterMark = effectiveHighWaterMarkInfo.Watermark
+			inclusiveLowWaterMarkTime = effectiveHighWaterMarkInfo.Timestamp
 		} else {
 			inclusiveLowWaterMark = lowPriorityWaterMarkInfo.Watermark
 			inclusiveLowWaterMarkTime = lowPriorityWaterMarkInfo.Timestamp
@@ -283,14 +315,19 @@ func (r *StreamReceiverImpl) ackMessage(
 		return 0, NewStreamError("InclusiveLowWaterMark is not set", serviceerror.NewInternal("Invalid inclusive low watermark"))
 	}
 
+	syncState := &replicationspb.SyncReplicationState{
+		InclusiveLowWatermark:     inclusiveLowWaterMark,
+		InclusiveLowWatermarkTime: timestamppb.New(inclusiveLowWaterMarkTime),
+		HighPriorityState:         highPriorityWatermark,
+		ThrottledPriorityState:    throttledPriorityWatermark,
+		LowPriorityState:          lowPriorityWatermark,
+	}
+	if receiverMode == ReceiverModeTieredStack {
+		syncState.ThrottledNamespaceIds = r.NamespaceThrottler.ThrottledNamespaceIDs()
+	}
 	if err := stream.Send(&adminservice.StreamWorkflowReplicationMessagesRequest{
 		Attributes: &adminservice.StreamWorkflowReplicationMessagesRequest_SyncReplicationState{
-			SyncReplicationState: &replicationspb.SyncReplicationState{
-				InclusiveLowWatermark:     inclusiveLowWaterMark,
-				InclusiveLowWatermarkTime: timestamppb.New(inclusiveLowWaterMarkTime),
-				HighPriorityState:         highPriorityWatermark,
-				LowPriorityState:          lowPriorityWatermark,
-			},
+			SyncReplicationState: syncState,
 		},
 	}); err != nil {
 		return 0, NewStreamError("stream_receiver failed to send", err)
@@ -339,6 +376,7 @@ func (r *StreamReceiverImpl) processMessages(
 			// sender mode changed, exit loop and let stream reconnect to retry
 			return NewStreamError("ReplicationTask wrong receiver mode", err)
 		}
+		receiverMode := ReceiverMode(atomic.LoadInt32((*int32)(&r.receiverMode)))
 
 		if err = ValidateTasksHaveSamePriority(priority, messages.ReplicationTasks...); err != nil {
 			// This should not happen because source side is sending task 1 by 1. Validate here just in case.
@@ -368,6 +406,19 @@ func (r *StreamReceiverImpl) processMessages(
 			schedulerPriority, err := r.getTaskSchedulerPriority(priority, task)
 			if err != nil {
 				return err
+			}
+			if receiverMode == ReceiverModeTieredStack &&
+				(schedulerPriority == enumsspb.TASK_PRIORITY_HIGH || schedulerPriority == enumsspb.TASK_PRIORITY_THROTTLED) {
+				nsID := task.ReplicationTask().GetRawTaskInfo().GetNamespaceId()
+				if !r.NamespaceThrottler.Allow(nsID) {
+					if schedulerPriority == enumsspb.TASK_PRIORITY_HIGH {
+						schedulerPriority = enumsspb.TASK_PRIORITY_THROTTLED
+						r.ThrottledLogger.Warn("Replication namespace throttled, demoting task to throttled priority",
+							tag.WorkflowNamespaceID(nsID),
+						)
+					}
+					// Already THROTTLED and still over limit — no change needed; Allow() updated throttled state.
+				}
 			}
 			scheduler, err := r.getTaskScheduler(schedulerPriority)
 			if err != nil {
@@ -405,6 +456,8 @@ func (r *StreamReceiverImpl) getTaskTracker(priority enumsspb.TaskPriority) (Exe
 		return r.highPriorityTaskTracker, nil
 	case enumsspb.TASK_PRIORITY_LOW:
 		return r.lowPriorityTaskTracker, nil
+	case enumsspb.TASK_PRIORITY_THROTTLED:
+		return r.throttledPriorityTaskTracker, nil
 	default:
 		return nil, serviceerror.NewInvalidArgumentf("Unknown task priority: %v", priority)
 	}
@@ -421,7 +474,7 @@ func (r *StreamReceiverImpl) getTaskSchedulerPriority(priority enumsspb.TaskPrio
 			return enumsspb.TASK_PRIORITY_LOW, nil
 		}
 		return enumsspb.TASK_PRIORITY_HIGH, nil
-	case enumsspb.TASK_PRIORITY_HIGH, enumsspb.TASK_PRIORITY_LOW:
+	case enumsspb.TASK_PRIORITY_HIGH, enumsspb.TASK_PRIORITY_LOW, enumsspb.TASK_PRIORITY_THROTTLED:
 		return priority, nil
 	default:
 		return 0, serviceerror.NewInvalidArgumentf("Unknown task priority: %v", priority)
@@ -432,7 +485,9 @@ func (r *StreamReceiverImpl) getTaskScheduler(priority enumsspb.TaskPriority) (c
 	switch priority {
 	case enumsspb.TASK_PRIORITY_HIGH:
 		return r.ProcessToolBox.HighPriorityTaskScheduler, nil
-	case enumsspb.TASK_PRIORITY_LOW:
+	case enumsspb.TASK_PRIORITY_LOW, enumsspb.TASK_PRIORITY_THROTTLED:
+		// THROTTLED shares the LOW scheduler so throttled-namespace backpressure cannot
+		// block the HIGH scheduler lane.
 		return r.ProcessToolBox.LowPriorityTaskScheduler, nil
 	default:
 		return nil, serviceerror.NewInvalidArgumentf("Unknown task scheduler priority: %v", priority)
@@ -467,7 +522,7 @@ func (r *StreamReceiverImpl) setReceiverMode(priority enumsspb.TaskPriority) {
 	switch priority {
 	case enumsspb.TASK_PRIORITY_UNSPECIFIED:
 		atomic.StoreInt32((*int32)(&r.receiverMode), int32(ReceiverModeSingleStack))
-	case enumsspb.TASK_PRIORITY_HIGH, enumsspb.TASK_PRIORITY_LOW:
+	case enumsspb.TASK_PRIORITY_HIGH, enumsspb.TASK_PRIORITY_LOW, enumsspb.TASK_PRIORITY_THROTTLED:
 		atomic.StoreInt32((*int32)(&r.receiverMode), int32(ReceiverModeTieredStack))
 	}
 }

--- a/service/history/replication/stream_receiver_test.go
+++ b/service/history/replication/stream_receiver_test.go
@@ -88,7 +88,7 @@ func (s *streamReceiverSuite) SetupTest() {
 		MetricsHandler:            metrics.NoopMetricsHandler,
 		Logger:                    testLogger,
 		ThrottledLogger:           testLogger,
-		NamespaceThrottler:    NoopNamespaceReplicationThrottler{},
+		NamespaceThrottler:        NoopNamespaceReplicationThrottler{},
 		DLQWriter:                 NoopDLQWriter{},
 	}
 	processToolBox.Config.ReplicationStreamSyncStatusDuration = dynamicconfig.GetDurationPropertyFn(5 * time.Millisecond)

--- a/service/history/replication/stream_receiver_test.go
+++ b/service/history/replication/stream_receiver_test.go
@@ -2,6 +2,7 @@ package replication
 
 import (
 	"math/rand"
+	"sort"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/adminservice/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -26,12 +28,13 @@ type (
 		suite.Suite
 		*require.Assertions
 
-		controller              *gomock.Controller
-		clusterMetadata         *cluster.MockMetadata
-		highPriorityTaskTracker *MockExecutableTaskTracker
-		lowPriorityTaskTracker  *MockExecutableTaskTracker
-		stream                  *mockStream
-		taskScheduler           *mockScheduler
+		controller                   *gomock.Controller
+		clusterMetadata              *cluster.MockMetadata
+		highPriorityTaskTracker      *MockExecutableTaskTracker
+		throttledPriorityTaskTracker *MockExecutableTaskTracker
+		lowPriorityTaskTracker       *MockExecutableTaskTracker
+		stream                       *mockStream
+		taskScheduler                *mockScheduler
 
 		streamReceiver         *StreamReceiverImpl
 		receiverFlowController *MockReceiverFlowController
@@ -66,6 +69,7 @@ func (s *streamReceiverSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.clusterMetadata = cluster.NewMockMetadata(s.controller)
 	s.highPriorityTaskTracker = NewMockExecutableTaskTracker(s.controller)
+	s.throttledPriorityTaskTracker = NewMockExecutableTaskTracker(s.controller)
 	s.lowPriorityTaskTracker = NewMockExecutableTaskTracker(s.controller)
 	s.stream = &mockStream{
 		requests: nil,
@@ -75,13 +79,16 @@ func (s *streamReceiverSuite) SetupTest() {
 		tasks: nil,
 	}
 
+	testLogger := log.NewTestLogger()
 	processToolBox := ProcessToolBox{
 		ClusterMetadata:           s.clusterMetadata,
 		Config:                    tests.NewDynamicConfig(),
 		HighPriorityTaskScheduler: s.taskScheduler,
 		LowPriorityTaskScheduler:  s.taskScheduler,
 		MetricsHandler:            metrics.NoopMetricsHandler,
-		Logger:                    log.NewTestLogger(),
+		Logger:                    testLogger,
+		ThrottledLogger:           testLogger,
+		NamespaceThrottler:    NoopNamespaceReplicationThrottler{},
 		DLQWriter:                 NoopDLQWriter{},
 	}
 	processToolBox.Config.ReplicationStreamSyncStatusDuration = dynamicconfig.GetDurationPropertyFn(5 * time.Millisecond)
@@ -105,6 +112,7 @@ func (s *streamReceiverSuite) SetupTest() {
 		},
 	).AnyTimes()
 	s.streamReceiver.highPriorityTaskTracker = s.highPriorityTaskTracker
+	s.streamReceiver.throttledPriorityTaskTracker = s.throttledPriorityTaskTracker
 	s.streamReceiver.lowPriorityTaskTracker = s.lowPriorityTaskTracker
 	s.stream.requests = []*adminservice.StreamWorkflowReplicationMessagesRequest{}
 	s.receiverFlowController = NewMockReceiverFlowController(s.controller)
@@ -117,8 +125,10 @@ func (s *streamReceiverSuite) TearDownTest() {
 
 func (s *streamReceiverSuite) TestAckMessage_Noop() {
 	s.highPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
+	s.throttledPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
 	s.lowPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
 	s.highPriorityTaskTracker.EXPECT().Size().Return(0)
+	s.throttledPriorityTaskTracker.EXPECT().Size().Return(0)
 	s.lowPriorityTaskTracker.EXPECT().Size().Return(0)
 
 	s.streamReceiver.ackMessage(s.stream)
@@ -129,8 +139,10 @@ func (s *streamReceiverSuite) TestAckMessage_Noop() {
 func (s *streamReceiverSuite) TestAckMessage_SyncStatus_ReceiverModeUnset() {
 	s.streamReceiver.receiverMode = ReceiverModeUnset // when stream receiver is in unset mode, means no task received yet, so no ACK should be sent
 	s.highPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
+	s.throttledPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
 	s.lowPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
 	s.highPriorityTaskTracker.EXPECT().Size().Return(0)
+	s.throttledPriorityTaskTracker.EXPECT().Size().Return(0)
 	s.lowPriorityTaskTracker.EXPECT().Size().Return(0)
 	_, err := s.streamReceiver.ackMessage(s.stream)
 	s.Equal(0, len(s.stream.requests))
@@ -145,8 +157,10 @@ func (s *streamReceiverSuite) TestAckMessage_SyncStatus_ReceiverModeSingleStack(
 
 	s.streamReceiver.receiverMode = ReceiverModeSingleStack
 	s.highPriorityTaskTracker.EXPECT().LowWatermark().Return(watermarkInfo)
+	s.throttledPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
 	s.lowPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
 	s.highPriorityTaskTracker.EXPECT().Size().Return(0)
+	s.throttledPriorityTaskTracker.EXPECT().Size().Return(0)
 	s.lowPriorityTaskTracker.EXPECT().Size().Return(0)
 
 	_, err := s.streamReceiver.ackMessage(s.stream)
@@ -170,8 +184,10 @@ func (s *streamReceiverSuite) TestAckMessage_SyncStatus_ReceiverModeSingleStack_
 
 	s.streamReceiver.receiverMode = ReceiverModeSingleStack
 	s.highPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
+	s.throttledPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
 	s.lowPriorityTaskTracker.EXPECT().LowWatermark().Return(watermarkInfo)
 	s.highPriorityTaskTracker.EXPECT().Size().Return(0)
+	s.throttledPriorityTaskTracker.EXPECT().Size().Return(0)
 	s.lowPriorityTaskTracker.EXPECT().Size().Return(0)
 
 	_, err := s.streamReceiver.ackMessage(s.stream)
@@ -187,8 +203,10 @@ func (s *streamReceiverSuite) TestAckMessage_SyncStatus_ReceiverModeSingleStack_
 
 	s.streamReceiver.receiverMode = ReceiverModeSingleStack
 	s.highPriorityTaskTracker.EXPECT().LowWatermark().Return(watermarkInfo)
+	s.throttledPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
 	s.lowPriorityTaskTracker.EXPECT().LowWatermark().Return(watermarkInfo)
 	s.highPriorityTaskTracker.EXPECT().Size().Return(0)
+	s.throttledPriorityTaskTracker.EXPECT().Size().Return(0)
 	s.lowPriorityTaskTracker.EXPECT().Size().Return(0)
 
 	_, err := s.streamReceiver.ackMessage(s.stream)
@@ -203,8 +221,10 @@ func (s *streamReceiverSuite) TestAckMessage_SyncStatus_ReceiverModeTieredStack_
 		Timestamp: time.Unix(0, rand.Int63()),
 	}
 	s.highPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
+	s.throttledPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
 	s.lowPriorityTaskTracker.EXPECT().LowWatermark().Return(watermarkInfo)
 	s.highPriorityTaskTracker.EXPECT().Size().Return(0)
+	s.throttledPriorityTaskTracker.EXPECT().Size().Return(0)
 	s.lowPriorityTaskTracker.EXPECT().Size().Return(0)
 	_, err := s.streamReceiver.ackMessage(s.stream)
 	s.Equal(0, len(s.stream.requests))
@@ -218,8 +238,10 @@ func (s *streamReceiverSuite) TestAckMessage_SyncStatus_ReceiverModeTieredStack_
 		Timestamp: time.Unix(0, rand.Int63()),
 	}
 	s.highPriorityTaskTracker.EXPECT().LowWatermark().Return(watermarkInfo)
+	s.throttledPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
 	s.lowPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
 	s.highPriorityTaskTracker.EXPECT().Size().Return(0)
+	s.throttledPriorityTaskTracker.EXPECT().Size().Return(0)
 	s.lowPriorityTaskTracker.EXPECT().Size().Return(0)
 	_, err := s.streamReceiver.ackMessage(s.stream)
 	s.Equal(0, len(s.stream.requests))
@@ -237,10 +259,13 @@ func (s *streamReceiverSuite) TestAckMessage_SyncStatus_ReceiverModeTieredStack(
 		Timestamp: time.Unix(0, rand.Int63()),
 	}
 	s.highPriorityTaskTracker.EXPECT().LowWatermark().Return(highWatermarkInfo)
+	s.throttledPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
 	s.lowPriorityTaskTracker.EXPECT().LowWatermark().Return(lowWatermarkInfo)
 	s.receiverFlowController.EXPECT().GetFlowControlInfo(enumsspb.TASK_PRIORITY_HIGH).Return(FlowControlInfo{Command: enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_RESUME})
+	s.receiverFlowController.EXPECT().GetFlowControlInfo(enumsspb.TASK_PRIORITY_THROTTLED).Return(FlowControlInfo{Command: enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_RESUME})
 	s.receiverFlowController.EXPECT().GetFlowControlInfo(enumsspb.TASK_PRIORITY_LOW).Return(FlowControlInfo{Command: enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_PAUSE, Cause: "test cause"})
 	s.highPriorityTaskTracker.EXPECT().Size().Return(0).AnyTimes()
+	s.throttledPriorityTaskTracker.EXPECT().Size().Return(0).AnyTimes()
 	s.lowPriorityTaskTracker.EXPECT().Size().Return(0).AnyTimes()
 	_, err := s.streamReceiver.ackMessage(s.stream)
 	s.NoError(err)
@@ -253,6 +278,9 @@ func (s *streamReceiverSuite) TestAckMessage_SyncStatus_ReceiverModeTieredStack(
 					InclusiveLowWatermark:     highWatermarkInfo.Watermark,
 					InclusiveLowWatermarkTime: timestamppb.New(highWatermarkInfo.Timestamp),
 					FlowControlCommand:        enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_RESUME,
+				},
+				ThrottledPriorityState: &replicationspb.ReplicationState{
+					FlowControlCommand: enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_RESUME,
 				},
 				LowPriorityState: &replicationspb.ReplicationState{
 					InclusiveLowWatermark:     lowWatermarkInfo.Watermark,
@@ -509,6 +537,87 @@ func (s *streamReceiverSuite) TestRecvEventLoop_Panic_Captured() {
 	s.streamReceiver.recvEventLoop() // should not cause panic
 }
 
+func (s *streamReceiverSuite) TestProcessMessage_TrackSubmit_TieredStack_ThrottledNamespace() {
+	// A HIGH-priority task whose namespace is throttled must be demoted to THROTTLED priority
+	// and routed to the low-priority scheduler.
+	const throttledNS = "throttled-ns-id"
+	throttler := &mockNamespaceReplicationThrottler{
+		throttledIDs: map[string]struct{}{throttledNS: {}},
+	}
+	s.streamReceiver.NamespaceThrottler = throttler
+	s.streamReceiver.receiverMode = ReceiverModeTieredStack
+
+	rawTaskInfo := &persistencespb.ReplicationTaskInfo{NamespaceId: throttledNS}
+	replicationTask := &replicationspb.ReplicationTask{
+		TaskType:       enumsspb.ReplicationTaskType(-1),
+		SourceTaskId:   rand.Int63(),
+		VisibilityTime: timestamppb.New(time.Unix(0, rand.Int63())),
+		Priority:       enumsspb.TASK_PRIORITY_HIGH,
+		RawTaskInfo:    rawTaskInfo,
+	}
+	streamResp := StreamResp[*adminservice.StreamWorkflowReplicationMessagesResponse]{
+		Resp: &adminservice.StreamWorkflowReplicationMessagesResponse{
+			Attributes: &adminservice.StreamWorkflowReplicationMessagesResponse_Messages{
+				Messages: &replicationspb.WorkflowReplicationMessages{
+					ReplicationTasks:           []*replicationspb.ReplicationTask{replicationTask},
+					ExclusiveHighWatermark:     rand.Int63(),
+					ExclusiveHighWatermarkTime: timestamppb.New(time.Unix(0, rand.Int63())),
+					Priority:                   enumsspb.TASK_PRIORITY_HIGH,
+				},
+			},
+		},
+	}
+	s.stream.respChan <- streamResp
+	close(s.stream.respChan)
+
+	highScheduler := &mockScheduler{}
+	lowScheduler := &mockScheduler{}
+	s.streamReceiver.HighPriorityTaskScheduler = highScheduler
+	s.streamReceiver.LowPriorityTaskScheduler = lowScheduler
+
+	trackedTask := NewMockTrackableExecutableTask(s.controller)
+	trackedTask.EXPECT().ReplicationTask().Return(replicationTask).AnyTimes()
+	s.highPriorityTaskTracker.EXPECT().TrackTasks(gomock.Any(), gomock.Any()).Return([]TrackableExecutableTask{trackedTask})
+
+	err := s.streamReceiver.processMessages(s.stream)
+	s.NoError(err)
+	s.Empty(highScheduler.tasks, "throttled namespace task must NOT go to high priority scheduler")
+	s.Len(lowScheduler.tasks, 1, "throttled namespace task must go to low priority scheduler")
+}
+
+func (s *streamReceiverSuite) TestAckMessage_TieredStack_IncludesThrottledNamespaceIDs() {
+	const throttledNS = "throttled-ns-id"
+	s.streamReceiver.NamespaceThrottler = &mockNamespaceReplicationThrottler{
+		throttledIDs: map[string]struct{}{throttledNS: {}},
+	}
+	s.streamReceiver.receiverMode = ReceiverModeTieredStack
+
+	highWatermarkInfo := &WatermarkInfo{
+		Watermark: rand.Int63(),
+		Timestamp: time.Unix(0, rand.Int63()),
+	}
+	lowWatermarkInfo := &WatermarkInfo{
+		Watermark: highWatermarkInfo.Watermark - 10,
+		Timestamp: time.Unix(0, rand.Int63()),
+	}
+	s.highPriorityTaskTracker.EXPECT().LowWatermark().Return(highWatermarkInfo)
+	s.throttledPriorityTaskTracker.EXPECT().LowWatermark().Return(nil)
+	s.lowPriorityTaskTracker.EXPECT().LowWatermark().Return(lowWatermarkInfo)
+	s.highPriorityTaskTracker.EXPECT().Size().Return(0)
+	s.throttledPriorityTaskTracker.EXPECT().Size().Return(0)
+	s.lowPriorityTaskTracker.EXPECT().Size().Return(0)
+	s.receiverFlowController.EXPECT().GetFlowControlInfo(enumsspb.TASK_PRIORITY_HIGH).Return(FlowControlInfo{Command: enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_RESUME})
+	s.receiverFlowController.EXPECT().GetFlowControlInfo(enumsspb.TASK_PRIORITY_THROTTLED).Return(FlowControlInfo{Command: enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_RESUME})
+	s.receiverFlowController.EXPECT().GetFlowControlInfo(enumsspb.TASK_PRIORITY_LOW).Return(FlowControlInfo{Command: enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_RESUME})
+
+	_, err := s.streamReceiver.ackMessage(s.stream)
+	s.NoError(err)
+	s.Require().Len(s.stream.requests, 1)
+	syncState := s.stream.requests[0].GetSyncReplicationState()
+	s.NotNil(syncState)
+	s.Equal([]string{throttledNS}, syncState.ThrottledNamespaceIds)
+}
+
 func (s *streamReceiverSuite) TestLivenessMonitor() {
 	s.streamReceiver.recvSignalChan <- struct{}{}
 	livenessMonitor(
@@ -552,3 +661,21 @@ func (s *mockScheduler) TrySubmit(task TrackableExecutableTask) bool {
 
 func (s *mockScheduler) Start() {}
 func (s *mockScheduler) Stop()  {}
+
+type mockNamespaceReplicationThrottler struct {
+	throttledIDs map[string]struct{}
+}
+
+func (m *mockNamespaceReplicationThrottler) Allow(namespaceID string) bool {
+	_, throttled := m.throttledIDs[namespaceID]
+	return !throttled
+}
+
+func (m *mockNamespaceReplicationThrottler) ThrottledNamespaceIDs() []string {
+	ids := make([]string, 0, len(m.throttledIDs))
+	for id := range m.throttledIDs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -66,6 +66,15 @@ type (
 		// throttledNamespaceIDs stores a map[string]struct{} of namespace IDs that the
 		// receiver has reported as throttled; updated on each SyncReplicationState ACK.
 		throttledNamespaceIDs atomic.Value
+		// throttledCatchupStart is the task ID of the first THROTTLED task skipped during a
+		// flow control pause. Non-zero means a catchup is pending. Only accessed by the HIGH
+		// sender goroutine so no synchronization is needed.
+		throttledCatchupStart      int64
+		// throttledCatchupNamespaces is the snapshot of throttled namespace IDs taken when
+		// throttledCatchupStart was first set. The catchup must only re-send tasks from these
+		// namespaces — tasks for other namespaces were sent normally as HIGH and must not be
+		// duplicated. The atomic.Value stores an immutable map so the snapshot is safe to hold.
+		throttledCatchupNamespaces map[string]struct{}
 	}
 )
 
@@ -445,6 +454,15 @@ func (s *StreamSenderImpl) sendLive(
 			return err
 		}
 		beginInclusiveWatermark = endExclusiveWatermark
+		// If THROTTLED tasks were skipped during a pause, run a catchup once the lane
+		// resumes so those tasks are delivered before the HIGH reader advances further.
+		if priority == enumsspb.TASK_PRIORITY_HIGH &&
+			s.throttledCatchupStart > 0 &&
+			!s.flowController.IsPaused(enumsspb.TASK_PRIORITY_THROTTLED) {
+			if err := s.sendThrottledCatchup(s.throttledCatchupStart, beginInclusiveWatermark); err != nil {
+				return err
+			}
+		}
 		if !syncStatusTimer.Stop() {
 			select {
 			case <-syncStatusTimer.C:
@@ -557,6 +575,28 @@ Loop:
 			}
 		}
 		if !s.shouldProcessTask(item) {
+			continue Loop
+		}
+		// Non-blocking THROTTLED skip: if this task has been demoted to THROTTLED and the
+		// THROTTLED flow control lane is currently paused, skip it so the HIGH goroutine
+		// is not blocked. On the first skip, send an anchor beacon so the receiver's
+		// THROTTLED tracker holds the synthetic HIGH watermark back to this task ID —
+		// preventing the sender from reading past it on reconnect. A catchup pass will
+		// re-send the skipped tasks once the lane resumes.
+		if s.isTieredStackEnabled &&
+			taskPriority == enumsspb.TASK_PRIORITY_THROTTLED &&
+			s.flowController.IsPaused(enumsspb.TASK_PRIORITY_THROTTLED) {
+			if s.throttledCatchupStart == 0 {
+				s.throttledCatchupStart = item.GetTaskID()
+				// Snapshot the throttled namespace set so the catchup re-sends only
+				// tasks that were actually skipped. Tasks for other namespaces were
+				// already sent as HIGH and must not be duplicated.
+				m, _ := s.throttledNamespaceIDs.Load().(map[string]struct{})
+				s.throttledCatchupNamespaces = m
+				if err := s.sendThrottledAnchor(item.GetTaskID(), item.GetVisibilityTime()); err != nil {
+					return err
+				}
+			}
 			continue Loop
 		}
 		metrics.ReplicationTaskLoadLatency.With(s.metrics).Record(
@@ -687,6 +727,138 @@ Loop:
 			},
 		},
 	})
+}
+
+// sendThrottledAnchor sends an empty THROTTLED-priority batch with ExclusiveHighWatermark=taskID
+// to the receiver. This anchors the receiver's THROTTLED tracker so the synthetic HIGH watermark
+// (min of HIGH and THROTTLED trackers) does not advance past unacknowledged THROTTLED tasks.
+func (s *StreamSenderImpl) sendThrottledAnchor(taskID int64, visibilityTime time.Time) error {
+	return s.sendToStream(&historyservice.StreamWorkflowReplicationMessagesResponse{
+		Attributes: &historyservice.StreamWorkflowReplicationMessagesResponse_Messages{
+			Messages: &replicationspb.WorkflowReplicationMessages{
+				ExclusiveHighWatermark:     taskID,
+				ExclusiveHighWatermarkTime: timestamppb.New(visibilityTime),
+				Priority:                   enumsspb.TASK_PRIORITY_THROTTLED,
+			},
+		},
+	})
+}
+
+// sendThrottledCatchup re-reads tasks in [start, end) and sends originally-HIGH tasks
+// as THROTTLED priority to fill the gap left by skipping them during a THROTTLED pause.
+// It uses non-blocking pause checks so a re-pause mid-catchup updates throttledCatchupStart
+// and returns immediately without blocking the HIGH sender goroutine. On full completion it
+// clears throttledCatchupStart.
+func (s *StreamSenderImpl) sendThrottledCatchup(start, end int64) error {
+	if start >= end {
+		s.throttledCatchupStart = 0
+		s.throttledCatchupNamespaces = nil
+		return nil
+	}
+	s.logger.Info("starting THROTTLED catchup", tag.NewInt64("start", start), tag.NewInt64("end", end))
+
+	callerInfo := getReplicaitonCallerInfo(enumsspb.TASK_PRIORITY_THROTTLED)
+	ctx := headers.SetCallerInfo(s.server.Context(), callerInfo)
+	iter, err := s.historyEngine.GetReplicationTasksIter(ctx, string(s.clientShardKey.ClusterID), start, end)
+	if err != nil {
+		return err
+	}
+
+	for iter.HasNext() {
+		if s.shutdownChan.IsShutdown() {
+			return nil
+		}
+		item, err := iter.Next()
+		if err != nil {
+			return fmt.Errorf("sendThrottledCatchup unable to get next replication task: %w", err)
+		}
+		// Only re-send tasks that (a) are originally HIGH priority and (b) belong to a
+		// namespace that was throttled when the skip occurred. Tasks for other namespaces
+		// were sent normally as HIGH during the pause and must not be duplicated.
+		// Always-LOW tasks (e.g. SyncWorkflowStateTask) are served by the LOW reader.
+		if s.getTaskPriority(item) != enumsspb.TASK_PRIORITY_HIGH {
+			continue
+		}
+		if _, wasThrottled := s.throttledCatchupNamespaces[item.GetNamespaceID()]; !wasThrottled {
+			continue
+		}
+		if !s.shouldProcessTask(item) {
+			continue
+		}
+		// Non-blocking re-pause check: if THROTTLED paused again, update the catchup start
+		// and send a new anchor beacon so the synthetic HIGH watermark stays correct,
+		// then return so the HIGH goroutine is not blocked.
+		if s.flowController.IsPaused(enumsspb.TASK_PRIORITY_THROTTLED) {
+			if s.throttledCatchupStart != item.GetTaskID() {
+				s.throttledCatchupStart = item.GetTaskID()
+				if err := s.sendThrottledAnchor(item.GetTaskID(), item.GetVisibilityTime()); err != nil {
+					return err
+				}
+			}
+			s.logger.Info("THROTTLED catchup interrupted by re-pause", tag.NewInt64("taskID", item.GetTaskID()))
+			return nil
+		}
+
+		var attempt int64
+		operation := func() error {
+			attempt++
+			startTime := time.Now().UTC()
+			defer func() {
+				metrics.ReplicationTaskGenerationLatency.With(s.metrics).Record(
+					time.Since(startTime),
+					metrics.FromClusterIDTag(s.serverShardKey.ClusterID),
+					metrics.ToClusterIDTag(s.clientShardKey.ClusterID),
+					metrics.OperationTag(TaskOperationTagFromTask(item.GetType())),
+					metrics.ReplicationTaskPriorityTag(enumsspb.TASK_PRIORITY_THROTTLED),
+				)
+			}()
+			task, err := s.taskConverter.Convert(item, s.clientShardKey.ClusterID, enumsspb.TASK_PRIORITY_THROTTLED)
+			if err != nil {
+				return err
+			}
+			if task == nil {
+				return nil
+			}
+			task.Priority = enumsspb.TASK_PRIORITY_THROTTLED
+			if err := s.flowController.Wait(s.server.Context(), enumsspb.TASK_PRIORITY_THROTTLED); err != nil {
+				if errors.Is(err, context.Canceled) {
+					return err
+				}
+			}
+			return s.sendToStream(&historyservice.StreamWorkflowReplicationMessagesResponse{
+				Attributes: &historyservice.StreamWorkflowReplicationMessagesResponse_Messages{
+					Messages: &replicationspb.WorkflowReplicationMessages{
+						ReplicationTasks:           []*replicationspb.ReplicationTask{task},
+						ExclusiveHighWatermark:     task.SourceTaskId + 1,
+						ExclusiveHighWatermarkTime: task.VisibilityTime,
+						Priority:                   enumsspb.TASK_PRIORITY_THROTTLED,
+					},
+				},
+			})
+		}
+
+		retryPolicy := backoff.NewExponentialRetryPolicy(s.config.ReplicationStreamSenderErrorRetryWait()).
+			WithBackoffCoefficient(s.config.ReplicationStreamSenderErrorRetryBackoffCoefficient()).
+			WithMaximumInterval(s.config.ReplicationStreamSenderErrorRetryMaxInterval()).
+			WithMaximumAttempts(s.config.ReplicationStreamSenderErrorRetryMaxAttempts()).
+			WithExpirationInterval(s.config.ReplicationStreamSenderErrorRetryExpiration())
+		err = backoff.ThrottleRetry(operation, retryPolicy, isRetryableError)
+		metrics.ReplicationTaskSendAttempt.With(s.metrics).Record(
+			attempt,
+			metrics.FromClusterIDTag(s.serverShardKey.ClusterID),
+			metrics.ToClusterIDTag(s.clientShardKey.ClusterID),
+			metrics.OperationTag(TaskOperationTagFromTask(item.GetType())),
+			metrics.ReplicationTaskPriorityTag(enumsspb.TASK_PRIORITY_THROTTLED),
+		)
+		if err != nil {
+			return fmt.Errorf("sendThrottledCatchup failed to send task: %v, cause: %w", item, err)
+		}
+	}
+
+	s.logger.Info("THROTTLED catchup complete", tag.NewInt64("start", start), tag.NewInt64("end", end))
+	s.throttledCatchupStart = 0
+	s.throttledCatchupNamespaces = nil
+	return nil
 }
 
 func (s *StreamSenderImpl) sendToStream(payload *historyservice.StreamWorkflowReplicationMessagesResponse) error {

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -66,15 +66,6 @@ type (
 		// throttledNamespaceIDs stores a map[string]struct{} of namespace IDs that the
 		// receiver has reported as throttled; updated on each SyncReplicationState ACK.
 		throttledNamespaceIDs atomic.Value
-		// throttledCatchupStart is the task ID of the first THROTTLED task skipped during a
-		// flow control pause. Non-zero means a catchup is pending. Only accessed by the HIGH
-		// sender goroutine so no synchronization is needed.
-		throttledCatchupStart      int64
-		// throttledCatchupNamespaces is the snapshot of throttled namespace IDs taken when
-		// throttledCatchupStart was first set. The catchup must only re-send tasks from these
-		// namespaces — tasks for other namespaces were sent normally as HIGH and must not be
-		// duplicated. The atomic.Value stores an immutable map so the snapshot is safe to hold.
-		throttledCatchupNamespaces map[string]struct{}
 	}
 )
 
@@ -133,10 +124,12 @@ func (s *StreamSenderImpl) Start() {
 	}
 
 	if s.isTieredStackEnabled {
-		// High Priority sender is used for live traffic
-		// Low Priority sender is used for force replication closed workflow
+		// High Priority sender is used for live traffic.
+		// Low Priority sender is used for force replication of closed workflows.
+		// Throttled Priority sender handles tasks for namespaces the receiver has back-pressured.
 		go WrapEventLoop(s.server.Context(), getSenderEventLoop(enumsspb.TASK_PRIORITY_HIGH), s.Stop, s.logger, s.metrics, s.clientShardKey, s.serverShardKey, s.config)
 		go WrapEventLoop(s.server.Context(), getSenderEventLoop(enumsspb.TASK_PRIORITY_LOW), s.Stop, s.logger, s.metrics, s.clientShardKey, s.serverShardKey, s.config)
+		go WrapEventLoop(s.server.Context(), getSenderEventLoop(enumsspb.TASK_PRIORITY_THROTTLED), s.Stop, s.logger, s.metrics, s.clientShardKey, s.serverShardKey, s.config)
 	} else {
 		go WrapEventLoop(s.server.Context(), getSenderEventLoop(enumsspb.TASK_PRIORITY_UNSPECIFIED), s.Stop, s.logger, s.metrics, s.clientShardKey, s.serverShardKey, s.config)
 	}
@@ -262,53 +255,22 @@ func (s *StreamSenderImpl) recvSyncReplicationState(
 		if attr.HighPriorityState == nil || attr.LowPriorityState == nil {
 			return NewStreamError("streamSender encountered unsupported SyncReplicationState", nil)
 		}
+		// Throttled watermark falls back to the high watermark when the receiver has not
+		// yet sent a ThrottledPriorityState (e.g. older receiver versions or first connect).
+		throttledWatermark := attr.GetHighPriorityState().GetInclusiveLowWatermark()
+		if tp := attr.GetThrottledPriorityState(); tp != nil {
+			throttledWatermark = tp.GetInclusiveLowWatermark()
+		}
 		readerState = &persistencespb.QueueReaderState{
 			Scopes: []*persistencespb.QueueSliceScope{
-				// index 0 is for overall low watermark. In tiered stack it is Min(LowWatermark-high priority, LowWatermark-low priority)
-				{
-					Range: &persistencespb.QueueSliceRange{
-						InclusiveMin: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(attr.GetInclusiveLowWatermark()),
-						),
-						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(math.MaxInt64),
-						),
-					},
-					Predicate: &persistencespb.Predicate{
-						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-					},
-				},
-				// index 1 is for high priority
-				{
-					Range: &persistencespb.QueueSliceRange{
-						InclusiveMin: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(attr.GetHighPriorityState().GetInclusiveLowWatermark()),
-						),
-						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(math.MaxInt64),
-						),
-					},
-					Predicate: &persistencespb.Predicate{
-						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-					},
-				},
-				// index 2 is for low priority
-				{
-					Range: &persistencespb.QueueSliceRange{
-						InclusiveMin: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(attr.GetLowPriorityState().GetInclusiveLowWatermark()),
-						),
-						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(math.MaxInt64),
-						),
-					},
-					Predicate: &persistencespb.Predicate{
-						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-					},
-				},
+				// index 0: overall low watermark — Min(high, low, throttled) in tiered stack
+				makeUniversalQueueSliceScope(attr.GetInclusiveLowWatermark()),
+				// index 1: high priority
+				makeUniversalQueueSliceScope(attr.GetHighPriorityState().GetInclusiveLowWatermark()),
+				// index 2: low priority
+				makeUniversalQueueSliceScope(attr.GetLowPriorityState().GetInclusiveLowWatermark()),
+				// index 3: throttled priority
+				makeUniversalQueueSliceScope(throttledWatermark),
 			},
 		}
 	case false:
@@ -317,21 +279,8 @@ func (s *StreamSenderImpl) recvSyncReplicationState(
 		}
 		readerState = &persistencespb.QueueReaderState{
 			Scopes: []*persistencespb.QueueSliceScope{
-				// in single stack, index 0 is for overall low watermark
-				{
-					Range: &persistencespb.QueueSliceRange{
-						InclusiveMin: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(attr.GetInclusiveLowWatermark()),
-						),
-						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(math.MaxInt64),
-						),
-					},
-					Predicate: &persistencespb.Predicate{
-						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-					},
-				},
+				// index 0: overall low watermark (single stack)
+				makeUniversalQueueSliceScope(attr.GetInclusiveLowWatermark()),
 			},
 		}
 	}
@@ -411,26 +360,29 @@ func (s *StreamSenderImpl) sendCatchUp(priority enumsspb.TaskPriority) (int64, e
 }
 
 func (s *StreamSenderImpl) getSendCatchupBeginInclusiveWatermark(readerState *persistencespb.QueueReaderState, priority enumsspb.TaskPriority) int64 {
+	// Scope layout: [0]=overall, [1]=high, [2]=low, [3]=throttled.
+	// Older reader states may have fewer scopes (e.g. single-stack has only [0], the
+	// previous tiered format had [0,1,2]). Fall back to index 0 (overall watermark)
+	// when the expected scope does not exist — it is always Min of all per-lane watermarks
+	// so it is a safe, conservative starting point.
 	getReaderScopesIndex := func(priority enumsspb.TaskPriority) int {
 		switch priority {
 		case enumsspb.TASK_PRIORITY_HIGH:
-			/*
-				this is to handle the case when switch from single stack to tiered stack, the reader state is still in old format.
-				In this case, it is safe to use the overall low watermark as the beginInclusiveWatermark, as long as we always guarantee
-				the overall low watermark is Min(lowPriorityLowWatermark, highPriorityLowWatermark)
-			*/
-			if len(readerState.Scopes) != 3 {
+			if len(readerState.Scopes) < 2 {
 				return 0
 			}
 			return 1
 		case enumsspb.TASK_PRIORITY_LOW:
-			if len(readerState.Scopes) != 3 {
+			if len(readerState.Scopes) < 3 {
 				return 0
 			}
 			return 2
-		case enumsspb.TASK_PRIORITY_UNSPECIFIED:
-			return 0
-		default:
+		case enumsspb.TASK_PRIORITY_THROTTLED:
+			if len(readerState.Scopes) < 4 {
+				return 0
+			}
+			return 3
+		default: // UNSPECIFIED and anything else
 			return 0
 		}
 	}
@@ -454,15 +406,6 @@ func (s *StreamSenderImpl) sendLive(
 			return err
 		}
 		beginInclusiveWatermark = endExclusiveWatermark
-		// If THROTTLED tasks were skipped during a pause, run a catchup once the lane
-		// resumes so those tasks are delivered before the HIGH reader advances further.
-		if priority == enumsspb.TASK_PRIORITY_HIGH &&
-			s.throttledCatchupStart > 0 &&
-			!s.flowController.IsPaused(enumsspb.TASK_PRIORITY_THROTTLED) {
-			if err := s.sendThrottledCatchup(s.throttledCatchupStart, beginInclusiveWatermark); err != nil {
-				return err
-			}
-		}
 		if !syncStatusTimer.Stop() {
 			select {
 			case <-syncStatusTimer.C:
@@ -514,7 +457,7 @@ func (s *StreamSenderImpl) sendTasks(
 		})
 	}
 
-	callerInfo := getReplicaitonCallerInfo(priority)
+	callerInfo := getReplicationCallerInfo(priority)
 	ctx := headers.SetCallerInfo(s.server.Context(), callerInfo)
 	iter, err := s.historyEngine.GetReplicationTasksIter(
 		ctx,
@@ -555,48 +498,11 @@ Loop:
 			}
 			skipCount = 0
 		}
-		// In tiered-stack mode, resolve the effective priority for this task.
-		// The HIGH loop handles both HIGH and THROTTLED tasks (THROTTLED tasks originate from
-		// the HIGH task reader). The LOW loop handles only always-LOW tasks.
-		// In single-stack mode (UNSPECIFIED), priority is passed through unchanged.
-		taskPriority := priority
-		if priority != enumsspb.TASK_PRIORITY_UNSPECIFIED {
-			taskPriority = s.getEffectiveTaskPriority(item)
-			// HIGH loop: skip only always-LOW tasks (e.g. SyncWorkflowStateTask); THROTTLED tasks
-			// originate from the HIGH reader and are intentionally sent within this loop at reduced
-			// priority, so they are NOT skipped here.
-			if priority == enumsspb.TASK_PRIORITY_HIGH && taskPriority == enumsspb.TASK_PRIORITY_LOW {
-				continue Loop
-			}
-			// LOW loop: skip anything that isn't always-LOW (including THROTTLED, which the HIGH
-			// loop handles so the LOW reader doesn't double-send it).
-			if priority == enumsspb.TASK_PRIORITY_LOW && taskPriority != enumsspb.TASK_PRIORITY_LOW {
-				continue Loop
-			}
-		}
-		if !s.shouldProcessTask(item) {
+		taskPriority, skip := s.resolveTaskPriorityForLoop(priority, item)
+		if skip {
 			continue Loop
 		}
-		// Non-blocking THROTTLED skip: if this task has been demoted to THROTTLED and the
-		// THROTTLED flow control lane is currently paused, skip it so the HIGH goroutine
-		// is not blocked. On the first skip, send an anchor beacon so the receiver's
-		// THROTTLED tracker holds the synthetic HIGH watermark back to this task ID —
-		// preventing the sender from reading past it on reconnect. A catchup pass will
-		// re-send the skipped tasks once the lane resumes.
-		if s.isTieredStackEnabled &&
-			taskPriority == enumsspb.TASK_PRIORITY_THROTTLED &&
-			s.flowController.IsPaused(enumsspb.TASK_PRIORITY_THROTTLED) {
-			if s.throttledCatchupStart == 0 {
-				s.throttledCatchupStart = item.GetTaskID()
-				// Snapshot the throttled namespace set so the catchup re-sends only
-				// tasks that were actually skipped. Tasks for other namespaces were
-				// already sent as HIGH and must not be duplicated.
-				m, _ := s.throttledNamespaceIDs.Load().(map[string]struct{})
-				s.throttledCatchupNamespaces = m
-				if err := s.sendThrottledAnchor(item.GetTaskID(), item.GetVisibilityTime()); err != nil {
-					return err
-				}
-			}
+		if !s.shouldProcessTask(item) {
 			continue Loop
 		}
 		metrics.ReplicationTaskLoadLatency.With(s.metrics).Record(
@@ -631,11 +537,7 @@ Loop:
 			if s.isTieredStackEnabled {
 				// THROTTLED tasks use the THROTTLED flow control lane so backpressure
 				// from throttled-namespace backlogs does not affect the HIGH lane.
-				waitPriority := priority
-				if taskPriority == enumsspb.TASK_PRIORITY_THROTTLED {
-					waitPriority = enumsspb.TASK_PRIORITY_THROTTLED
-				}
-				if err := s.flowController.Wait(s.server.Context(), waitPriority); err != nil {
+				if err := s.flowController.Wait(s.server.Context(), taskPriority); err != nil {
 					if errors.Is(err, context.Canceled) {
 						return err
 					}
@@ -685,13 +587,7 @@ Loop:
 			return nil
 		}
 
-		retryPolicy := backoff.NewExponentialRetryPolicy(s.config.ReplicationStreamSenderErrorRetryWait()).
-			WithBackoffCoefficient(s.config.ReplicationStreamSenderErrorRetryBackoffCoefficient()).
-			WithMaximumInterval(s.config.ReplicationStreamSenderErrorRetryMaxInterval()).
-			WithMaximumAttempts(s.config.ReplicationStreamSenderErrorRetryMaxAttempts()).
-			WithExpirationInterval(s.config.ReplicationStreamSenderErrorRetryExpiration())
-
-		err = backoff.ThrottleRetry(operation, retryPolicy, isRetryableError)
+		err = backoff.ThrottleRetry(operation, s.newSendRetryPolicy(), isRetryableError)
 		metrics.ReplicationTaskSendAttempt.With(s.metrics).Record(
 			attempt,
 			metrics.FromClusterIDTag(s.serverShardKey.ClusterID),
@@ -727,138 +623,6 @@ Loop:
 			},
 		},
 	})
-}
-
-// sendThrottledAnchor sends an empty THROTTLED-priority batch with ExclusiveHighWatermark=taskID
-// to the receiver. This anchors the receiver's THROTTLED tracker so the synthetic HIGH watermark
-// (min of HIGH and THROTTLED trackers) does not advance past unacknowledged THROTTLED tasks.
-func (s *StreamSenderImpl) sendThrottledAnchor(taskID int64, visibilityTime time.Time) error {
-	return s.sendToStream(&historyservice.StreamWorkflowReplicationMessagesResponse{
-		Attributes: &historyservice.StreamWorkflowReplicationMessagesResponse_Messages{
-			Messages: &replicationspb.WorkflowReplicationMessages{
-				ExclusiveHighWatermark:     taskID,
-				ExclusiveHighWatermarkTime: timestamppb.New(visibilityTime),
-				Priority:                   enumsspb.TASK_PRIORITY_THROTTLED,
-			},
-		},
-	})
-}
-
-// sendThrottledCatchup re-reads tasks in [start, end) and sends originally-HIGH tasks
-// as THROTTLED priority to fill the gap left by skipping them during a THROTTLED pause.
-// It uses non-blocking pause checks so a re-pause mid-catchup updates throttledCatchupStart
-// and returns immediately without blocking the HIGH sender goroutine. On full completion it
-// clears throttledCatchupStart.
-func (s *StreamSenderImpl) sendThrottledCatchup(start, end int64) error {
-	if start >= end {
-		s.throttledCatchupStart = 0
-		s.throttledCatchupNamespaces = nil
-		return nil
-	}
-	s.logger.Info("starting THROTTLED catchup", tag.NewInt64("start", start), tag.NewInt64("end", end))
-
-	callerInfo := getReplicaitonCallerInfo(enumsspb.TASK_PRIORITY_THROTTLED)
-	ctx := headers.SetCallerInfo(s.server.Context(), callerInfo)
-	iter, err := s.historyEngine.GetReplicationTasksIter(ctx, string(s.clientShardKey.ClusterID), start, end)
-	if err != nil {
-		return err
-	}
-
-	for iter.HasNext() {
-		if s.shutdownChan.IsShutdown() {
-			return nil
-		}
-		item, err := iter.Next()
-		if err != nil {
-			return fmt.Errorf("sendThrottledCatchup unable to get next replication task: %w", err)
-		}
-		// Only re-send tasks that (a) are originally HIGH priority and (b) belong to a
-		// namespace that was throttled when the skip occurred. Tasks for other namespaces
-		// were sent normally as HIGH during the pause and must not be duplicated.
-		// Always-LOW tasks (e.g. SyncWorkflowStateTask) are served by the LOW reader.
-		if s.getTaskPriority(item) != enumsspb.TASK_PRIORITY_HIGH {
-			continue
-		}
-		if _, wasThrottled := s.throttledCatchupNamespaces[item.GetNamespaceID()]; !wasThrottled {
-			continue
-		}
-		if !s.shouldProcessTask(item) {
-			continue
-		}
-		// Non-blocking re-pause check: if THROTTLED paused again, update the catchup start
-		// and send a new anchor beacon so the synthetic HIGH watermark stays correct,
-		// then return so the HIGH goroutine is not blocked.
-		if s.flowController.IsPaused(enumsspb.TASK_PRIORITY_THROTTLED) {
-			if s.throttledCatchupStart != item.GetTaskID() {
-				s.throttledCatchupStart = item.GetTaskID()
-				if err := s.sendThrottledAnchor(item.GetTaskID(), item.GetVisibilityTime()); err != nil {
-					return err
-				}
-			}
-			s.logger.Info("THROTTLED catchup interrupted by re-pause", tag.NewInt64("taskID", item.GetTaskID()))
-			return nil
-		}
-
-		var attempt int64
-		operation := func() error {
-			attempt++
-			startTime := time.Now().UTC()
-			defer func() {
-				metrics.ReplicationTaskGenerationLatency.With(s.metrics).Record(
-					time.Since(startTime),
-					metrics.FromClusterIDTag(s.serverShardKey.ClusterID),
-					metrics.ToClusterIDTag(s.clientShardKey.ClusterID),
-					metrics.OperationTag(TaskOperationTagFromTask(item.GetType())),
-					metrics.ReplicationTaskPriorityTag(enumsspb.TASK_PRIORITY_THROTTLED),
-				)
-			}()
-			task, err := s.taskConverter.Convert(item, s.clientShardKey.ClusterID, enumsspb.TASK_PRIORITY_THROTTLED)
-			if err != nil {
-				return err
-			}
-			if task == nil {
-				return nil
-			}
-			task.Priority = enumsspb.TASK_PRIORITY_THROTTLED
-			if err := s.flowController.Wait(s.server.Context(), enumsspb.TASK_PRIORITY_THROTTLED); err != nil {
-				if errors.Is(err, context.Canceled) {
-					return err
-				}
-			}
-			return s.sendToStream(&historyservice.StreamWorkflowReplicationMessagesResponse{
-				Attributes: &historyservice.StreamWorkflowReplicationMessagesResponse_Messages{
-					Messages: &replicationspb.WorkflowReplicationMessages{
-						ReplicationTasks:           []*replicationspb.ReplicationTask{task},
-						ExclusiveHighWatermark:     task.SourceTaskId + 1,
-						ExclusiveHighWatermarkTime: task.VisibilityTime,
-						Priority:                   enumsspb.TASK_PRIORITY_THROTTLED,
-					},
-				},
-			})
-		}
-
-		retryPolicy := backoff.NewExponentialRetryPolicy(s.config.ReplicationStreamSenderErrorRetryWait()).
-			WithBackoffCoefficient(s.config.ReplicationStreamSenderErrorRetryBackoffCoefficient()).
-			WithMaximumInterval(s.config.ReplicationStreamSenderErrorRetryMaxInterval()).
-			WithMaximumAttempts(s.config.ReplicationStreamSenderErrorRetryMaxAttempts()).
-			WithExpirationInterval(s.config.ReplicationStreamSenderErrorRetryExpiration())
-		err = backoff.ThrottleRetry(operation, retryPolicy, isRetryableError)
-		metrics.ReplicationTaskSendAttempt.With(s.metrics).Record(
-			attempt,
-			metrics.FromClusterIDTag(s.serverShardKey.ClusterID),
-			metrics.ToClusterIDTag(s.clientShardKey.ClusterID),
-			metrics.OperationTag(TaskOperationTagFromTask(item.GetType())),
-			metrics.ReplicationTaskPriorityTag(enumsspb.TASK_PRIORITY_THROTTLED),
-		)
-		if err != nil {
-			return fmt.Errorf("sendThrottledCatchup failed to send task: %v, cause: %w", item, err)
-		}
-	}
-
-	s.logger.Info("THROTTLED catchup complete", tag.NewInt64("start", start), tag.NewInt64("end", end))
-	s.throttledCatchupStart = 0
-	s.throttledCatchupNamespaces = nil
-	return nil
 }
 
 func (s *StreamSenderImpl) sendToStream(payload *historyservice.StreamWorkflowReplicationMessagesResponse) error {
@@ -931,6 +695,53 @@ func (s *StreamSenderImpl) getEffectiveTaskPriority(task tasks.Task) enumsspb.Ta
 		}
 	}
 	return p
+}
+
+// resolveTaskPriorityForLoop returns the effective priority for item and whether
+// the task should be skipped in a loop running at loopPriority.
+//   - HIGH loop:      sends only HIGH tasks; skips LOW and THROTTLED (each has its own goroutine).
+//   - LOW loop:       sends only always-LOW tasks (e.g. SyncWorkflowStateTask); skips everything else.
+//   - THROTTLED loop: sends tasks whose effective priority is THROTTLED (HIGH-base tasks for
+//     namespaces the receiver has back-pressured); idles when no namespaces are throttled.
+//   - UNSPECIFIED loop (single-stack): sends all tasks unchanged.
+func (s *StreamSenderImpl) resolveTaskPriorityForLoop(loopPriority enumsspb.TaskPriority, item tasks.Task) (enumsspb.TaskPriority, bool) {
+	if loopPriority == enumsspb.TASK_PRIORITY_UNSPECIFIED {
+		return loopPriority, false
+	}
+	effective := s.getEffectiveTaskPriority(item)
+	switch loopPriority {
+	case enumsspb.TASK_PRIORITY_HIGH:
+		return effective, effective != enumsspb.TASK_PRIORITY_HIGH
+	case enumsspb.TASK_PRIORITY_LOW:
+		return effective, effective != enumsspb.TASK_PRIORITY_LOW
+	case enumsspb.TASK_PRIORITY_THROTTLED:
+		return effective, effective != enumsspb.TASK_PRIORITY_THROTTLED
+	default:
+		return effective, false
+	}
+}
+
+func (s *StreamSenderImpl) newSendRetryPolicy() backoff.RetryPolicy {
+	return backoff.NewExponentialRetryPolicy(s.config.ReplicationStreamSenderErrorRetryWait()).
+		WithBackoffCoefficient(s.config.ReplicationStreamSenderErrorRetryBackoffCoefficient()).
+		WithMaximumInterval(s.config.ReplicationStreamSenderErrorRetryMaxInterval()).
+		WithMaximumAttempts(s.config.ReplicationStreamSenderErrorRetryMaxAttempts()).
+		WithExpirationInterval(s.config.ReplicationStreamSenderErrorRetryExpiration())
+}
+
+// makeUniversalQueueSliceScope returns a QueueSliceScope that covers [watermark, MaxInt64)
+// with a universal predicate (matches all task types).
+func makeUniversalQueueSliceScope(watermark int64) *persistencespb.QueueSliceScope {
+	return &persistencespb.QueueSliceScope{
+		Range: &persistencespb.QueueSliceRange{
+			InclusiveMin: shard.ConvertToPersistenceTaskKey(tasks.NewImmediateKey(watermark)),
+			ExclusiveMax: shard.ConvertToPersistenceTaskKey(tasks.NewImmediateKey(math.MaxInt64)),
+		},
+		Predicate: &persistencespb.Predicate{
+			PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+			Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+		},
+	}
 }
 
 func (s *StreamSenderImpl) getTaskTargetCluster(task tasks.Task) []string {

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -63,6 +63,9 @@ type (
 		flowController          SenderFlowController
 		sendLock                sync.Mutex
 		ssRateLimiter           ServerSchedulerRateLimiter
+		// throttledNamespaceIDs stores a map[string]struct{} of namespace IDs that the
+		// receiver has reported as throttled; updated on each SyncReplicationState ACK.
+		throttledNamespaceIDs atomic.Value
 	}
 )
 
@@ -333,6 +336,11 @@ func (s *StreamSenderImpl) recvSyncReplicationState(
 	)
 	if s.isTieredStackEnabled {
 		s.flowController.RefreshReceiverFlowControlInfo(attr)
+		throttled := make(map[string]struct{}, len(attr.GetThrottledNamespaceIds()))
+		for _, id := range attr.GetThrottledNamespaceIds() {
+			throttled[id] = struct{}{}
+		}
+		s.throttledNamespaceIDs.Store(throttled)
 	}
 
 	if err := s.shardContext.UpdateReplicationQueueReaderState(
@@ -529,9 +537,24 @@ Loop:
 			}
 			skipCount = 0
 		}
-		if priority != enumsspb.TASK_PRIORITY_UNSPECIFIED && // case: skip priority check. When priority is unspecified, send all tasks
-			priority != s.getTaskPriority(item) { // case: skip task with different priority than this loop
-			continue Loop
+		// In tiered-stack mode, resolve the effective priority for this task.
+		// The HIGH loop handles both HIGH and THROTTLED tasks (THROTTLED tasks originate from
+		// the HIGH task reader). The LOW loop handles only always-LOW tasks.
+		// In single-stack mode (UNSPECIFIED), priority is passed through unchanged.
+		taskPriority := priority
+		if priority != enumsspb.TASK_PRIORITY_UNSPECIFIED {
+			taskPriority = s.getEffectiveTaskPriority(item)
+			// HIGH loop: skip only always-LOW tasks (e.g. SyncWorkflowStateTask); THROTTLED tasks
+			// originate from the HIGH reader and are intentionally sent within this loop at reduced
+			// priority, so they are NOT skipped here.
+			if priority == enumsspb.TASK_PRIORITY_HIGH && taskPriority == enumsspb.TASK_PRIORITY_LOW {
+				continue Loop
+			}
+			// LOW loop: skip anything that isn't always-LOW (including THROTTLED, which the HIGH
+			// loop handles so the LOW reader doesn't double-send it).
+			if priority == enumsspb.TASK_PRIORITY_LOW && taskPriority != enumsspb.TASK_PRIORITY_LOW {
+				continue Loop
+			}
 		}
 		if !s.shouldProcessTask(item) {
 			continue Loop
@@ -541,7 +564,7 @@ Loop:
 			metrics.FromClusterIDTag(s.serverShardKey.ClusterID),
 			metrics.ToClusterIDTag(s.clientShardKey.ClusterID),
 			metrics.OperationTag(TaskOperationTagFromTask(item.GetType())),
-			metrics.ReplicationTaskPriorityTag(priority),
+			metrics.ReplicationTaskPriorityTag(taskPriority),
 		)
 
 		var attempt int64
@@ -554,19 +577,25 @@ Loop:
 					metrics.FromClusterIDTag(s.serverShardKey.ClusterID),
 					metrics.ToClusterIDTag(s.clientShardKey.ClusterID),
 					metrics.OperationTag(TaskOperationTagFromTask(item.GetType())),
-					metrics.ReplicationTaskPriorityTag(priority),
+					metrics.ReplicationTaskPriorityTag(taskPriority),
 				)
 			}()
-			task, err := s.taskConverter.Convert(item, s.clientShardKey.ClusterID, priority)
+			task, err := s.taskConverter.Convert(item, s.clientShardKey.ClusterID, taskPriority)
 			if err != nil {
 				return err
 			}
 			if task == nil {
 				return nil
 			}
-			task.Priority = priority
+			task.Priority = taskPriority
 			if s.isTieredStackEnabled {
-				if err := s.flowController.Wait(s.server.Context(), priority); err != nil {
+				// THROTTLED tasks use the THROTTLED flow control lane so backpressure
+				// from throttled-namespace backlogs does not affect the HIGH lane.
+				waitPriority := priority
+				if taskPriority == enumsspb.TASK_PRIORITY_THROTTLED {
+					waitPriority = enumsspb.TASK_PRIORITY_THROTTLED
+				}
+				if err := s.flowController.Wait(s.server.Context(), waitPriority); err != nil {
 					if errors.Is(err, context.Canceled) {
 						return err
 					}
@@ -600,7 +629,7 @@ Loop:
 						ReplicationTasks:           []*replicationspb.ReplicationTask{task},
 						ExclusiveHighWatermark:     task.SourceTaskId + 1,
 						ExclusiveHighWatermarkTime: task.VisibilityTime,
-						Priority:                   priority,
+						Priority:                   taskPriority,
 					},
 				},
 			}); err != nil {
@@ -713,6 +742,23 @@ func (s *StreamSenderImpl) getTaskPriority(task tasks.Task) enumsspb.TaskPriorit
 	default:
 		return enumsspb.TASK_PRIORITY_HIGH
 	}
+}
+
+// getEffectiveTaskPriority returns the task priority to use for routing decisions.
+// In tiered-stack mode, HIGH-priority tasks whose namespace is currently reported as
+// throttled by the receiver are sent with THROTTLED priority. The receiver continues
+// to run THROTTLED tasks through the namespace rate limiter so the namespace can
+// recover and be promoted back to HIGH priority.
+func (s *StreamSenderImpl) getEffectiveTaskPriority(task tasks.Task) enumsspb.TaskPriority {
+	p := s.getTaskPriority(task)
+	if p == enumsspb.TASK_PRIORITY_HIGH && s.isTieredStackEnabled {
+		if m, ok := s.throttledNamespaceIDs.Load().(map[string]struct{}); ok {
+			if _, throttled := m[task.GetNamespaceID()]; throttled {
+				return enumsspb.TASK_PRIORITY_THROTTLED
+			}
+		}
+	}
+	return p
 }
 
 func (s *StreamSenderImpl) getTaskTargetCluster(task tasks.Task) []string {

--- a/service/history/replication/stream_sender_flow_controller.go
+++ b/service/history/replication/stream_sender_flow_controller.go
@@ -26,6 +26,8 @@ type (
 	SenderFlowController interface {
 		// Wait will block go routine until the sender is allowed to send a task
 		Wait(ctx context.Context, priority enumsspb.TaskPriority) error
+		// IsPaused returns true if the given priority lane is currently paused, without blocking.
+		IsPaused(priority enumsspb.TaskPriority) bool
 		RefreshReceiverFlowControlInfo(syncState *replicationspb.SyncReplicationState)
 	}
 	SenderFlowControllerImpl struct {
@@ -96,6 +98,16 @@ func (s *SenderFlowControllerImpl) setState(state *flowControlState, flowControl
 		defer state.mu.Unlock()
 		state.resume = false
 	}
+}
+
+func (s *SenderFlowControllerImpl) IsPaused(priority enumsspb.TaskPriority) bool {
+	state, ok := s.flowControlStates[priority]
+	if !ok {
+		return false
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return !state.resume
 }
 
 func (s *SenderFlowControllerImpl) Wait(ctx context.Context, priority enumsspb.TaskPriority) error {

--- a/service/history/replication/stream_sender_flow_controller.go
+++ b/service/history/replication/stream_sender_flow_controller.go
@@ -52,7 +52,16 @@ func NewSenderFlowController(config *configs.Config, logger log.Logger) *SenderF
 	lowPriorityState.rateLimiter = quotas.NewDefaultOutgoingRateLimiter(func() float64 {
 		return float64(config.ReplicationStreamSenderLowPriorityQPS())
 	})
+	throttledPriorityState := &flowControlState{
+		resume: true,
+	}
+	throttledPriorityState.cond = sync.NewCond(&throttledPriorityState.mu)
+	throttledPriorityState.rateLimiter = quotas.NewDefaultOutgoingRateLimiter(func() float64 {
+		return float64(config.ReplicationStreamSenderLowPriorityQPS())
+	})
+
 	flowControlStates[enumsspb.TASK_PRIORITY_HIGH] = highPriorityState
+	flowControlStates[enumsspb.TASK_PRIORITY_THROTTLED] = throttledPriorityState
 	flowControlStates[enumsspb.TASK_PRIORITY_LOW] = lowPriorityState
 	return &SenderFlowControllerImpl{
 		flowControlStates:  flowControlStates,
@@ -64,6 +73,9 @@ func NewSenderFlowController(config *configs.Config, logger log.Logger) *SenderF
 func (s *SenderFlowControllerImpl) RefreshReceiverFlowControlInfo(syncState *replicationspb.SyncReplicationState) {
 	if syncState.GetHighPriorityState() != nil {
 		s.setState(s.flowControlStates[enumsspb.TASK_PRIORITY_HIGH], syncState.GetHighPriorityState().GetFlowControlCommand())
+	}
+	if syncState.GetThrottledPriorityState() != nil {
+		s.setState(s.flowControlStates[enumsspb.TASK_PRIORITY_THROTTLED], syncState.GetThrottledPriorityState().GetFlowControlCommand())
 	}
 	if syncState.GetLowPriorityState() != nil {
 		s.setState(s.flowControlStates[enumsspb.TASK_PRIORITY_LOW], syncState.GetLowPriorityState().GetFlowControlCommand())

--- a/service/history/replication/stream_sender_flow_controller_mock.go
+++ b/service/history/replication/stream_sender_flow_controller_mock.go
@@ -54,6 +54,20 @@ func (mr *MockSenderFlowControllerMockRecorder) RefreshReceiverFlowControlInfo(s
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshReceiverFlowControlInfo", reflect.TypeOf((*MockSenderFlowController)(nil).RefreshReceiverFlowControlInfo), syncState)
 }
 
+// IsPaused mocks base method.
+func (m *MockSenderFlowController) IsPaused(priority enums.TaskPriority) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPaused", priority)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsPaused indicates an expected call of IsPaused.
+func (mr *MockSenderFlowControllerMockRecorder) IsPaused(priority any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPaused", reflect.TypeOf((*MockSenderFlowController)(nil).IsPaused), priority)
+}
+
 // Wait mocks base method.
 func (m *MockSenderFlowController) Wait(ctx context.Context, priority enums.TaskPriority) error {
 	m.ctrl.T.Helper()

--- a/service/history/replication/stream_sender_test.go
+++ b/service/history/replication/stream_sender_test.go
@@ -1048,6 +1048,104 @@ func (s *streamSenderSuite) TestRecvEventLoop_RpcError_ShouldReturnStreamError()
 	s.IsType(&StreamError{}, err)
 }
 
+func (s *streamSenderSuite) TestGetEffectiveTaskPriority_NotTieredStack_ReturnsBase() {
+	s.streamSender.isTieredStackEnabled = false
+	task := tasks.NewMockTask(s.controller)
+	// GetNamespaceID must not be called; the throttle check is gated on isTieredStackEnabled.
+	s.Equal(enumsspb.TASK_PRIORITY_HIGH, s.streamSender.getEffectiveTaskPriority(task))
+}
+
+func (s *streamSenderSuite) TestGetEffectiveTaskPriority_TieredStack_NotThrottled_ReturnsHigh() {
+	s.streamSender.isTieredStackEnabled = true
+	task := tasks.NewMockTask(s.controller)
+	task.EXPECT().GetNamespaceID().Return("ns-1").AnyTimes()
+	s.streamSender.throttledNamespaceIDs.Store(map[string]struct{}{})
+	s.Equal(enumsspb.TASK_PRIORITY_HIGH, s.streamSender.getEffectiveTaskPriority(task))
+}
+
+func (s *streamSenderSuite) TestGetEffectiveTaskPriority_TieredStack_Throttled_DemotesToThrottled() {
+	s.streamSender.isTieredStackEnabled = true
+	task := tasks.NewMockTask(s.controller)
+	task.EXPECT().GetNamespaceID().Return("ns-1").AnyTimes()
+	s.streamSender.throttledNamespaceIDs.Store(map[string]struct{}{"ns-1": {}})
+	s.Equal(enumsspb.TASK_PRIORITY_THROTTLED, s.streamSender.getEffectiveTaskPriority(task))
+}
+
+func (s *streamSenderSuite) TestGetEffectiveTaskPriority_TieredStack_LowTaskNotAffected() {
+	s.streamSender.isTieredStackEnabled = true
+	// SyncWorkflowStateTask is inherently LOW priority; throttle map must not flip it further.
+	task := &tasks.SyncWorkflowStateTask{}
+	s.Equal(enumsspb.TASK_PRIORITY_LOW, s.streamSender.getEffectiveTaskPriority(task))
+}
+
+func (s *streamSenderSuite) TestRecvSyncReplicationState_TieredStack_StoresThrottledNamespaceIDs() {
+	s.streamSender.isTieredStackEnabled = true
+	readerID := shard.ReplicationReaderIDFromClusterShardID(
+		int64(s.clientShardKey.ClusterID),
+		s.clientShardKey.ShardID,
+	)
+	ts := timestamppb.New(time.Now())
+	replicationState := &replicationspb.SyncReplicationState{
+		InclusiveLowWatermark:     100,
+		InclusiveLowWatermarkTime: ts,
+		HighPriorityState: &replicationspb.ReplicationState{
+			InclusiveLowWatermark:     110,
+			InclusiveLowWatermarkTime: ts,
+		},
+		LowPriorityState: &replicationspb.ReplicationState{
+			InclusiveLowWatermark:     100,
+			InclusiveLowWatermarkTime: ts,
+		},
+		ThrottledNamespaceIds: []string{"ns-a", "ns-b"},
+	}
+	s.senderFlowController.EXPECT().RefreshReceiverFlowControlInfo(replicationState).Times(1)
+	s.shardContext.EXPECT().UpdateReplicationQueueReaderState(readerID, gomock.Any()).Return(nil)
+	s.shardContext.EXPECT().UpdateRemoteReaderInfo(readerID, gomock.Any(), gomock.Any()).Return(nil)
+
+	err := s.streamSender.recvSyncReplicationState(replicationState)
+	s.NoError(err)
+
+	m, ok := s.streamSender.throttledNamespaceIDs.Load().(map[string]struct{})
+	s.True(ok)
+	s.Contains(m, "ns-a")
+	s.Contains(m, "ns-b")
+	s.Len(m, 2)
+}
+
+func (s *streamSenderSuite) TestRecvSyncReplicationState_TieredStack_ClearsThrottledNamespaceIDs() {
+	s.streamSender.isTieredStackEnabled = true
+	// Pre-populate with some throttled namespaces.
+	s.streamSender.throttledNamespaceIDs.Store(map[string]struct{}{"old-ns": {}})
+	readerID := shard.ReplicationReaderIDFromClusterShardID(
+		int64(s.clientShardKey.ClusterID),
+		s.clientShardKey.ShardID,
+	)
+	ts := timestamppb.New(time.Now())
+	replicationState := &replicationspb.SyncReplicationState{
+		InclusiveLowWatermark:     100,
+		InclusiveLowWatermarkTime: ts,
+		HighPriorityState: &replicationspb.ReplicationState{
+			InclusiveLowWatermark:     110,
+			InclusiveLowWatermarkTime: ts,
+		},
+		LowPriorityState: &replicationspb.ReplicationState{
+			InclusiveLowWatermark:     100,
+			InclusiveLowWatermarkTime: ts,
+		},
+		// No throttled namespace IDs — receiver cleared them.
+	}
+	s.senderFlowController.EXPECT().RefreshReceiverFlowControlInfo(replicationState).Times(1)
+	s.shardContext.EXPECT().UpdateReplicationQueueReaderState(readerID, gomock.Any()).Return(nil)
+	s.shardContext.EXPECT().UpdateRemoteReaderInfo(readerID, gomock.Any(), gomock.Any()).Return(nil)
+
+	err := s.streamSender.recvSyncReplicationState(replicationState)
+	s.NoError(err)
+
+	m, ok := s.streamSender.throttledNamespaceIDs.Load().(map[string]struct{})
+	s.True(ok)
+	s.Empty(m)
+}
+
 func (s *streamSenderSuite) TestLivenessMonitor() {
 	s.streamSender.recvSignalChan <- struct{}{}
 	livenessMonitor(

--- a/service/history/replication/stream_sender_test.go
+++ b/service/history/replication/stream_sender_test.go
@@ -207,52 +207,15 @@ func (s *streamSenderSuite) TestRecvSyncReplicationState_TieredStack_Success() {
 	}
 	s.senderFlowController.EXPECT().RefreshReceiverFlowControlInfo(replicationState).Return().Times(1)
 
+	// ThrottledPriorityState is nil so throttled watermark falls back to high watermark.
 	s.shardContext.EXPECT().UpdateReplicationQueueReaderState(
 		readerID,
 		&persistencespb.QueueReaderState{
 			Scopes: []*persistencespb.QueueSliceScope{
-				{
-					Range: &persistencespb.QueueSliceRange{
-						InclusiveMin: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(replicationState.InclusiveLowWatermark),
-						),
-						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(math.MaxInt64),
-						),
-					},
-					Predicate: &persistencespb.Predicate{
-						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-					},
-				},
-				{
-					Range: &persistencespb.QueueSliceRange{
-						InclusiveMin: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(replicationState.HighPriorityState.InclusiveLowWatermark),
-						),
-						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(math.MaxInt64),
-						),
-					},
-					Predicate: &persistencespb.Predicate{
-						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-					},
-				},
-				{
-					Range: &persistencespb.QueueSliceRange{
-						InclusiveMin: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(replicationState.LowPriorityState.InclusiveLowWatermark),
-						),
-						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(math.MaxInt64),
-						),
-					},
-					Predicate: &persistencespb.Predicate{
-						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-					},
-				},
+				makeUniversalQueueSliceScope(replicationState.InclusiveLowWatermark),
+				makeUniversalQueueSliceScope(replicationState.HighPriorityState.InclusiveLowWatermark),
+				makeUniversalQueueSliceScope(replicationState.LowPriorityState.InclusiveLowWatermark),
+				makeUniversalQueueSliceScope(replicationState.HighPriorityState.InclusiveLowWatermark), // throttled fallback
 			},
 		},
 	).Return(nil)
@@ -295,52 +258,15 @@ func (s *streamSenderSuite) TestRecvSyncReplicationState_TieredStack_Error() {
 	}
 	s.senderFlowController.EXPECT().RefreshReceiverFlowControlInfo(replicationState).Return().Times(1)
 
+	// ThrottledPriorityState is nil so throttled watermark falls back to high watermark.
 	s.shardContext.EXPECT().UpdateReplicationQueueReaderState(
 		readerID,
 		&persistencespb.QueueReaderState{
 			Scopes: []*persistencespb.QueueSliceScope{
-				{
-					Range: &persistencespb.QueueSliceRange{
-						InclusiveMin: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(replicationState.InclusiveLowWatermark),
-						),
-						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(math.MaxInt64),
-						),
-					},
-					Predicate: &persistencespb.Predicate{
-						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-					},
-				},
-				{
-					Range: &persistencespb.QueueSliceRange{
-						InclusiveMin: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(replicationState.HighPriorityState.InclusiveLowWatermark),
-						),
-						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(math.MaxInt64),
-						),
-					},
-					Predicate: &persistencespb.Predicate{
-						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-					},
-				},
-				{
-					Range: &persistencespb.QueueSliceRange{
-						InclusiveMin: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(replicationState.LowPriorityState.InclusiveLowWatermark),
-						),
-						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
-							tasks.NewImmediateKey(math.MaxInt64),
-						),
-					},
-					Predicate: &persistencespb.Predicate{
-						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
-						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
-					},
-				},
+				makeUniversalQueueSliceScope(replicationState.InclusiveLowWatermark),
+				makeUniversalQueueSliceScope(replicationState.HighPriorityState.InclusiveLowWatermark),
+				makeUniversalQueueSliceScope(replicationState.LowPriorityState.InclusiveLowWatermark),
+				makeUniversalQueueSliceScope(replicationState.HighPriorityState.InclusiveLowWatermark), // throttled fallback
 			},
 		},
 	).Return(ownershipLost)
@@ -1146,13 +1072,12 @@ func (s *streamSenderSuite) TestRecvSyncReplicationState_TieredStack_ClearsThrot
 	s.Empty(m)
 }
 
-// TestSendTasks_TieredStack_ThrottledPaused_SkipsAndAnchors verifies that when a THROTTLED
-// task is encountered while the THROTTLED flow control lane is paused, the task is skipped
-// (no blocking), an anchor beacon is sent to hold the receiver's THROTTLED tracker, and
-// throttledCatchupStart is set to the task ID. Subsequent HIGH tasks are sent normally.
-func (s *streamSenderSuite) TestSendTasks_TieredStack_ThrottledPaused_SkipsAndAnchors() {
+// TestSendTasks_TieredStack_HighLoopSkipsThrottledTasks verifies that the HIGH loop skips
+// tasks whose effective priority is THROTTLED (namespace is back-pressured by receiver).
+// Those tasks are handled by the dedicated THROTTLED goroutine; the HIGH loop never sees them.
+func (s *streamSenderSuite) TestSendTasks_TieredStack_HighLoopSkipsThrottledTasks() {
 	s.streamSender.isTieredStackEnabled = true
-	s.streamSender.clientClusterShardCount = 1 // all workflow IDs map to shard 1
+	s.streamSender.clientClusterShardCount = 1
 	s.streamSender.throttledNamespaceIDs.Store(map[string]struct{}{"throttled-ns": {}})
 
 	beginInclusiveWatermark := int64(100)
@@ -1161,7 +1086,7 @@ func (s *streamSenderSuite) TestSendTasks_TieredStack_ThrottledPaused_SkipsAndAn
 	throttledTask := &tasks.SyncWorkflowStateTask{
 		WorkflowKey: definition.WorkflowKey{NamespaceID: "throttled-ns", WorkflowID: "w1"},
 		TaskID:      110,
-		Priority:    enumsspb.TASK_PRIORITY_HIGH, // will be demoted to THROTTLED
+		Priority:    enumsspb.TASK_PRIORITY_HIGH, // effective priority → THROTTLED
 	}
 	highTask := &tasks.SyncWorkflowStateTask{
 		WorkflowKey: definition.WorkflowKey{NamespaceID: "normal-ns", WorkflowID: "w2"},
@@ -1188,22 +1113,12 @@ func (s *streamSenderSuite) TestSendTasks_TieredStack_ThrottledPaused_SkipsAndAn
 	)
 	s.historyEngine.EXPECT().GetReplicationTasksIter(gomock.Any(), string(s.clientShardKey.ClusterID), beginInclusiveWatermark, endExclusiveWatermark).Return(iter, nil)
 
-	// THROTTLED is paused: non-blocking check for the throttled task.
-	s.senderFlowController.EXPECT().IsPaused(enumsspb.TASK_PRIORITY_THROTTLED).Return(true).Times(1)
-	// The high task is not THROTTLED so IsPaused is not called for it; normal Wait is used.
+	// No IsPaused calls: the HIGH loop skips THROTTLED tasks purely via resolveTaskPriorityForLoop.
 	s.senderFlowController.EXPECT().Wait(gomock.Any(), enumsspb.TASK_PRIORITY_HIGH).Return(nil).Times(1)
 	s.taskConverter.EXPECT().Convert(highTask, s.clientShardKey.ClusterID, enumsspb.TASK_PRIORITY_HIGH).Return(convertedHighTask, nil)
 
 	gomock.InOrder(
-		// Anchor beacon for the skipped THROTTLED task.
-		s.server.EXPECT().Send(gomock.Any()).DoAndReturn(func(resp *historyservice.StreamWorkflowReplicationMessagesResponse) error {
-			msgs := resp.GetMessages()
-			s.Equal(enumsspb.TASK_PRIORITY_THROTTLED, msgs.Priority)
-			s.Equal(int64(110), msgs.ExclusiveHighWatermark)
-			s.Empty(msgs.ReplicationTasks)
-			return nil
-		}),
-		// The HIGH task after the skipped one is sent normally.
+		// throttledTask is silently skipped; highTask is sent.
 		s.server.EXPECT().Send(gomock.Any()).DoAndReturn(func(resp *historyservice.StreamWorkflowReplicationMessagesResponse) error {
 			msgs := resp.GetMessages()
 			s.Equal(enumsspb.TASK_PRIORITY_HIGH, msgs.Priority)
@@ -1216,31 +1131,31 @@ func (s *streamSenderSuite) TestSendTasks_TieredStack_ThrottledPaused_SkipsAndAn
 
 	err := s.streamSender.sendTasks(enumsspb.TASK_PRIORITY_HIGH, beginInclusiveWatermark, endExclusiveWatermark)
 	s.NoError(err)
-	s.Equal(int64(110), s.streamSender.throttledCatchupStart, "catchup start must be set to the first skipped task ID")
 }
 
-// TestSendThrottledCatchup_SendsSkippedTasks verifies that sendThrottledCatchup re-reads
-// the gap range, sends originally-HIGH tasks as THROTTLED, and clears throttledCatchupStart.
-func (s *streamSenderSuite) TestSendThrottledCatchup_SendsSkippedTasks() {
+// TestSendTasks_TieredStack_ThrottledLoopSendsThrottledTasks verifies that the THROTTLED loop
+// sends tasks whose effective priority is THROTTLED and skips tasks for non-throttled namespaces.
+func (s *streamSenderSuite) TestSendTasks_TieredStack_ThrottledLoopSendsThrottledTasks() {
 	s.streamSender.isTieredStackEnabled = true
 	s.streamSender.clientClusterShardCount = 1
 	s.streamSender.throttledNamespaceIDs.Store(map[string]struct{}{"throttled-ns": {}})
-	s.streamSender.throttledCatchupStart = 110
-	s.streamSender.throttledCatchupNamespaces = map[string]struct{}{"throttled-ns": {}}
+
+	beginInclusiveWatermark := int64(100)
+	endExclusiveWatermark := int64(200)
 
 	throttledTask := &tasks.SyncWorkflowStateTask{
 		WorkflowKey: definition.WorkflowKey{NamespaceID: "throttled-ns", WorkflowID: "w1"},
 		TaskID:      110,
-		Priority:    enumsspb.TASK_PRIORITY_HIGH,
+		Priority:    enumsspb.TASK_PRIORITY_HIGH, // effective priority → THROTTLED
 	}
-	// This task belongs to a non-throttled namespace — it was already sent as HIGH during
-	// the pause and must not be re-sent by the catchup.
-	normalTask := &tasks.SyncWorkflowStateTask{
+	// This task has a non-throttled namespace; its effective priority is HIGH, so the
+	// THROTTLED loop skips it (it is handled by the HIGH goroutine).
+	highTask := &tasks.SyncWorkflowStateTask{
 		WorkflowKey: definition.WorkflowKey{NamespaceID: "normal-ns", WorkflowID: "w2"},
-		TaskID:      130,
+		TaskID:      120,
 		Priority:    enumsspb.TASK_PRIORITY_HIGH,
 	}
-	convertedTask := &replicationspb.ReplicationTask{
+	convertedThrottledTask := &replicationspb.ReplicationTask{
 		SourceTaskId:   110,
 		VisibilityTime: timestamppb.New(time.Unix(0, 1)),
 		Priority:       enumsspb.TASK_PRIORITY_THROTTLED,
@@ -1255,97 +1170,29 @@ func (s *streamSenderSuite) TestSendThrottledCatchup_SendsSkippedTasks() {
 
 	iter := collection.NewPagingIterator[tasks.Task](
 		func(paginationToken []byte) ([]tasks.Task, []byte, error) {
-			return []tasks.Task{throttledTask, normalTask}, nil, nil
+			return []tasks.Task{throttledTask, highTask}, nil, nil
 		},
 	)
-	s.historyEngine.EXPECT().GetReplicationTasksIter(gomock.Any(), string(s.clientShardKey.ClusterID), int64(110), int64(200)).Return(iter, nil)
+	s.historyEngine.EXPECT().GetReplicationTasksIter(gomock.Any(), string(s.clientShardKey.ClusterID), beginInclusiveWatermark, endExclusiveWatermark).Return(iter, nil)
 
-	// THROTTLED is not paused during catchup.
-	s.senderFlowController.EXPECT().IsPaused(enumsspb.TASK_PRIORITY_THROTTLED).Return(false).Times(1)
+	// THROTTLED goroutine blocks freely on Wait — no IsPaused needed.
 	s.senderFlowController.EXPECT().Wait(gomock.Any(), enumsspb.TASK_PRIORITY_THROTTLED).Return(nil).Times(1)
-	s.taskConverter.EXPECT().Convert(throttledTask, s.clientShardKey.ClusterID, enumsspb.TASK_PRIORITY_THROTTLED).Return(convertedTask, nil)
-
-	s.server.EXPECT().Send(gomock.Any()).DoAndReturn(func(resp *historyservice.StreamWorkflowReplicationMessagesResponse) error {
-		msgs := resp.GetMessages()
-		s.Equal(enumsspb.TASK_PRIORITY_THROTTLED, msgs.Priority)
-		s.Len(msgs.ReplicationTasks, 1)
-		return nil
-	})
-
-	err := s.streamSender.sendThrottledCatchup(110, 200)
-	s.NoError(err)
-	s.Zero(s.streamSender.throttledCatchupStart, "catchup start must be cleared on completion")
-}
-
-// TestSendThrottledCatchup_RepauseMidCatchup verifies that if THROTTLED pauses again during
-// catchup, sendThrottledCatchup stops immediately, updates throttledCatchupStart to the
-// current task ID, and sends a new anchor beacon.
-func (s *streamSenderSuite) TestSendThrottledCatchup_RepauseMidCatchup() {
-	s.streamSender.isTieredStackEnabled = true
-	s.streamSender.clientClusterShardCount = 1
-	s.streamSender.throttledCatchupStart = 110
-	s.streamSender.throttledCatchupNamespaces = map[string]struct{}{"throttled-ns": {}}
-
-	task1 := &tasks.SyncWorkflowStateTask{
-		WorkflowKey: definition.WorkflowKey{NamespaceID: "throttled-ns", WorkflowID: "w1"},
-		TaskID:      110,
-		Priority:    enumsspb.TASK_PRIORITY_HIGH,
-	}
-	task2 := &tasks.SyncWorkflowStateTask{
-		WorkflowKey: definition.WorkflowKey{NamespaceID: "throttled-ns", WorkflowID: "w2"},
-		TaskID:      150,
-		Priority:    enumsspb.TASK_PRIORITY_HIGH,
-	}
-	converted1 := &replicationspb.ReplicationTask{
-		SourceTaskId:   110,
-		VisibilityTime: timestamppb.New(time.Unix(0, 1)),
-		Priority:       enumsspb.TASK_PRIORITY_THROTTLED,
-	}
-
-	mockRegistry := namespace.NewMockRegistry(s.controller)
-	mockRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(namespace.NewGlobalNamespaceForTest(
-		nil, nil, &persistencespb.NamespaceReplicationConfig{
-			Clusters: []string{"source_cluster", "target_cluster"},
-		}, 100), nil).AnyTimes()
-	s.shardContext.EXPECT().GetNamespaceRegistry().Return(mockRegistry).AnyTimes()
-
-	iter := collection.NewPagingIterator[tasks.Task](
-		func(paginationToken []byte) ([]tasks.Task, []byte, error) {
-			return []tasks.Task{task1, task2}, nil, nil
-		},
-	)
-	s.historyEngine.EXPECT().GetReplicationTasksIter(gomock.Any(), string(s.clientShardKey.ClusterID), int64(110), int64(200)).Return(iter, nil)
+	s.taskConverter.EXPECT().Convert(throttledTask, s.clientShardKey.ClusterID, enumsspb.TASK_PRIORITY_THROTTLED).Return(convertedThrottledTask, nil)
 
 	gomock.InOrder(
-		// task1: THROTTLED not paused — send it.
-		s.senderFlowController.EXPECT().IsPaused(enumsspb.TASK_PRIORITY_THROTTLED).Return(false),
-		// task2: THROTTLED re-paused — stop catchup.
-		s.senderFlowController.EXPECT().IsPaused(enumsspb.TASK_PRIORITY_THROTTLED).Return(true),
-	)
-	s.senderFlowController.EXPECT().Wait(gomock.Any(), enumsspb.TASK_PRIORITY_THROTTLED).Return(nil).Times(1)
-	s.taskConverter.EXPECT().Convert(task1, s.clientShardKey.ClusterID, enumsspb.TASK_PRIORITY_THROTTLED).Return(converted1, nil)
-
-	gomock.InOrder(
-		// task1 sent.
+		// highTask is silently skipped; throttledTask is sent as THROTTLED priority.
 		s.server.EXPECT().Send(gomock.Any()).DoAndReturn(func(resp *historyservice.StreamWorkflowReplicationMessagesResponse) error {
 			msgs := resp.GetMessages()
 			s.Equal(enumsspb.TASK_PRIORITY_THROTTLED, msgs.Priority)
 			s.Len(msgs.ReplicationTasks, 1)
 			return nil
 		}),
-		// New anchor beacon for task2 (re-pause point).
-		s.server.EXPECT().Send(gomock.Any()).DoAndReturn(func(resp *historyservice.StreamWorkflowReplicationMessagesResponse) error {
-			msgs := resp.GetMessages()
-			s.Equal(enumsspb.TASK_PRIORITY_THROTTLED, msgs.Priority)
-			s.Equal(int64(150), msgs.ExclusiveHighWatermark)
-			s.Empty(msgs.ReplicationTasks)
-			return nil
-		}),
+		// End-of-batch watermark beacon.
+		s.server.EXPECT().Send(gomock.Any()).Return(nil),
 	)
 
-	err := s.streamSender.sendThrottledCatchup(110, 200)
+	err := s.streamSender.sendTasks(enumsspb.TASK_PRIORITY_THROTTLED, beginInclusiveWatermark, endExclusiveWatermark)
 	s.NoError(err)
-	s.Equal(int64(150), s.streamSender.throttledCatchupStart, "catchup start must be updated to the re-pause task ID")
 }
 
 func (s *streamSenderSuite) TestLivenessMonitor() {

--- a/service/history/replication/stream_sender_test.go
+++ b/service/history/replication/stream_sender_test.go
@@ -1146,6 +1146,208 @@ func (s *streamSenderSuite) TestRecvSyncReplicationState_TieredStack_ClearsThrot
 	s.Empty(m)
 }
 
+// TestSendTasks_TieredStack_ThrottledPaused_SkipsAndAnchors verifies that when a THROTTLED
+// task is encountered while the THROTTLED flow control lane is paused, the task is skipped
+// (no blocking), an anchor beacon is sent to hold the receiver's THROTTLED tracker, and
+// throttledCatchupStart is set to the task ID. Subsequent HIGH tasks are sent normally.
+func (s *streamSenderSuite) TestSendTasks_TieredStack_ThrottledPaused_SkipsAndAnchors() {
+	s.streamSender.isTieredStackEnabled = true
+	s.streamSender.clientClusterShardCount = 1 // all workflow IDs map to shard 1
+	s.streamSender.throttledNamespaceIDs.Store(map[string]struct{}{"throttled-ns": {}})
+
+	beginInclusiveWatermark := int64(100)
+	endExclusiveWatermark := int64(200)
+
+	throttledTask := &tasks.SyncWorkflowStateTask{
+		WorkflowKey: definition.WorkflowKey{NamespaceID: "throttled-ns", WorkflowID: "w1"},
+		TaskID:      110,
+		Priority:    enumsspb.TASK_PRIORITY_HIGH, // will be demoted to THROTTLED
+	}
+	highTask := &tasks.SyncWorkflowStateTask{
+		WorkflowKey: definition.WorkflowKey{NamespaceID: "normal-ns", WorkflowID: "w2"},
+		TaskID:      120,
+		Priority:    enumsspb.TASK_PRIORITY_HIGH,
+	}
+	convertedHighTask := &replicationspb.ReplicationTask{
+		SourceTaskId:   120,
+		VisibilityTime: timestamppb.New(time.Unix(0, 1)),
+		Priority:       enumsspb.TASK_PRIORITY_HIGH,
+	}
+
+	mockRegistry := namespace.NewMockRegistry(s.controller)
+	mockRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(namespace.NewGlobalNamespaceForTest(
+		nil, nil, &persistencespb.NamespaceReplicationConfig{
+			Clusters: []string{"source_cluster", "target_cluster"},
+		}, 100), nil).AnyTimes()
+	s.shardContext.EXPECT().GetNamespaceRegistry().Return(mockRegistry).AnyTimes()
+
+	iter := collection.NewPagingIterator[tasks.Task](
+		func(paginationToken []byte) ([]tasks.Task, []byte, error) {
+			return []tasks.Task{throttledTask, highTask}, nil, nil
+		},
+	)
+	s.historyEngine.EXPECT().GetReplicationTasksIter(gomock.Any(), string(s.clientShardKey.ClusterID), beginInclusiveWatermark, endExclusiveWatermark).Return(iter, nil)
+
+	// THROTTLED is paused: non-blocking check for the throttled task.
+	s.senderFlowController.EXPECT().IsPaused(enumsspb.TASK_PRIORITY_THROTTLED).Return(true).Times(1)
+	// The high task is not THROTTLED so IsPaused is not called for it; normal Wait is used.
+	s.senderFlowController.EXPECT().Wait(gomock.Any(), enumsspb.TASK_PRIORITY_HIGH).Return(nil).Times(1)
+	s.taskConverter.EXPECT().Convert(highTask, s.clientShardKey.ClusterID, enumsspb.TASK_PRIORITY_HIGH).Return(convertedHighTask, nil)
+
+	gomock.InOrder(
+		// Anchor beacon for the skipped THROTTLED task.
+		s.server.EXPECT().Send(gomock.Any()).DoAndReturn(func(resp *historyservice.StreamWorkflowReplicationMessagesResponse) error {
+			msgs := resp.GetMessages()
+			s.Equal(enumsspb.TASK_PRIORITY_THROTTLED, msgs.Priority)
+			s.Equal(int64(110), msgs.ExclusiveHighWatermark)
+			s.Empty(msgs.ReplicationTasks)
+			return nil
+		}),
+		// The HIGH task after the skipped one is sent normally.
+		s.server.EXPECT().Send(gomock.Any()).DoAndReturn(func(resp *historyservice.StreamWorkflowReplicationMessagesResponse) error {
+			msgs := resp.GetMessages()
+			s.Equal(enumsspb.TASK_PRIORITY_HIGH, msgs.Priority)
+			s.Len(msgs.ReplicationTasks, 1)
+			return nil
+		}),
+		// End-of-batch watermark beacon.
+		s.server.EXPECT().Send(gomock.Any()).Return(nil),
+	)
+
+	err := s.streamSender.sendTasks(enumsspb.TASK_PRIORITY_HIGH, beginInclusiveWatermark, endExclusiveWatermark)
+	s.NoError(err)
+	s.Equal(int64(110), s.streamSender.throttledCatchupStart, "catchup start must be set to the first skipped task ID")
+}
+
+// TestSendThrottledCatchup_SendsSkippedTasks verifies that sendThrottledCatchup re-reads
+// the gap range, sends originally-HIGH tasks as THROTTLED, and clears throttledCatchupStart.
+func (s *streamSenderSuite) TestSendThrottledCatchup_SendsSkippedTasks() {
+	s.streamSender.isTieredStackEnabled = true
+	s.streamSender.clientClusterShardCount = 1
+	s.streamSender.throttledNamespaceIDs.Store(map[string]struct{}{"throttled-ns": {}})
+	s.streamSender.throttledCatchupStart = 110
+	s.streamSender.throttledCatchupNamespaces = map[string]struct{}{"throttled-ns": {}}
+
+	throttledTask := &tasks.SyncWorkflowStateTask{
+		WorkflowKey: definition.WorkflowKey{NamespaceID: "throttled-ns", WorkflowID: "w1"},
+		TaskID:      110,
+		Priority:    enumsspb.TASK_PRIORITY_HIGH,
+	}
+	// This task belongs to a non-throttled namespace — it was already sent as HIGH during
+	// the pause and must not be re-sent by the catchup.
+	normalTask := &tasks.SyncWorkflowStateTask{
+		WorkflowKey: definition.WorkflowKey{NamespaceID: "normal-ns", WorkflowID: "w2"},
+		TaskID:      130,
+		Priority:    enumsspb.TASK_PRIORITY_HIGH,
+	}
+	convertedTask := &replicationspb.ReplicationTask{
+		SourceTaskId:   110,
+		VisibilityTime: timestamppb.New(time.Unix(0, 1)),
+		Priority:       enumsspb.TASK_PRIORITY_THROTTLED,
+	}
+
+	mockRegistry := namespace.NewMockRegistry(s.controller)
+	mockRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(namespace.NewGlobalNamespaceForTest(
+		nil, nil, &persistencespb.NamespaceReplicationConfig{
+			Clusters: []string{"source_cluster", "target_cluster"},
+		}, 100), nil).AnyTimes()
+	s.shardContext.EXPECT().GetNamespaceRegistry().Return(mockRegistry).AnyTimes()
+
+	iter := collection.NewPagingIterator[tasks.Task](
+		func(paginationToken []byte) ([]tasks.Task, []byte, error) {
+			return []tasks.Task{throttledTask, normalTask}, nil, nil
+		},
+	)
+	s.historyEngine.EXPECT().GetReplicationTasksIter(gomock.Any(), string(s.clientShardKey.ClusterID), int64(110), int64(200)).Return(iter, nil)
+
+	// THROTTLED is not paused during catchup.
+	s.senderFlowController.EXPECT().IsPaused(enumsspb.TASK_PRIORITY_THROTTLED).Return(false).Times(1)
+	s.senderFlowController.EXPECT().Wait(gomock.Any(), enumsspb.TASK_PRIORITY_THROTTLED).Return(nil).Times(1)
+	s.taskConverter.EXPECT().Convert(throttledTask, s.clientShardKey.ClusterID, enumsspb.TASK_PRIORITY_THROTTLED).Return(convertedTask, nil)
+
+	s.server.EXPECT().Send(gomock.Any()).DoAndReturn(func(resp *historyservice.StreamWorkflowReplicationMessagesResponse) error {
+		msgs := resp.GetMessages()
+		s.Equal(enumsspb.TASK_PRIORITY_THROTTLED, msgs.Priority)
+		s.Len(msgs.ReplicationTasks, 1)
+		return nil
+	})
+
+	err := s.streamSender.sendThrottledCatchup(110, 200)
+	s.NoError(err)
+	s.Zero(s.streamSender.throttledCatchupStart, "catchup start must be cleared on completion")
+}
+
+// TestSendThrottledCatchup_RepauseMidCatchup verifies that if THROTTLED pauses again during
+// catchup, sendThrottledCatchup stops immediately, updates throttledCatchupStart to the
+// current task ID, and sends a new anchor beacon.
+func (s *streamSenderSuite) TestSendThrottledCatchup_RepauseMidCatchup() {
+	s.streamSender.isTieredStackEnabled = true
+	s.streamSender.clientClusterShardCount = 1
+	s.streamSender.throttledCatchupStart = 110
+	s.streamSender.throttledCatchupNamespaces = map[string]struct{}{"throttled-ns": {}}
+
+	task1 := &tasks.SyncWorkflowStateTask{
+		WorkflowKey: definition.WorkflowKey{NamespaceID: "throttled-ns", WorkflowID: "w1"},
+		TaskID:      110,
+		Priority:    enumsspb.TASK_PRIORITY_HIGH,
+	}
+	task2 := &tasks.SyncWorkflowStateTask{
+		WorkflowKey: definition.WorkflowKey{NamespaceID: "throttled-ns", WorkflowID: "w2"},
+		TaskID:      150,
+		Priority:    enumsspb.TASK_PRIORITY_HIGH,
+	}
+	converted1 := &replicationspb.ReplicationTask{
+		SourceTaskId:   110,
+		VisibilityTime: timestamppb.New(time.Unix(0, 1)),
+		Priority:       enumsspb.TASK_PRIORITY_THROTTLED,
+	}
+
+	mockRegistry := namespace.NewMockRegistry(s.controller)
+	mockRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(namespace.NewGlobalNamespaceForTest(
+		nil, nil, &persistencespb.NamespaceReplicationConfig{
+			Clusters: []string{"source_cluster", "target_cluster"},
+		}, 100), nil).AnyTimes()
+	s.shardContext.EXPECT().GetNamespaceRegistry().Return(mockRegistry).AnyTimes()
+
+	iter := collection.NewPagingIterator[tasks.Task](
+		func(paginationToken []byte) ([]tasks.Task, []byte, error) {
+			return []tasks.Task{task1, task2}, nil, nil
+		},
+	)
+	s.historyEngine.EXPECT().GetReplicationTasksIter(gomock.Any(), string(s.clientShardKey.ClusterID), int64(110), int64(200)).Return(iter, nil)
+
+	gomock.InOrder(
+		// task1: THROTTLED not paused — send it.
+		s.senderFlowController.EXPECT().IsPaused(enumsspb.TASK_PRIORITY_THROTTLED).Return(false),
+		// task2: THROTTLED re-paused — stop catchup.
+		s.senderFlowController.EXPECT().IsPaused(enumsspb.TASK_PRIORITY_THROTTLED).Return(true),
+	)
+	s.senderFlowController.EXPECT().Wait(gomock.Any(), enumsspb.TASK_PRIORITY_THROTTLED).Return(nil).Times(1)
+	s.taskConverter.EXPECT().Convert(task1, s.clientShardKey.ClusterID, enumsspb.TASK_PRIORITY_THROTTLED).Return(converted1, nil)
+
+	gomock.InOrder(
+		// task1 sent.
+		s.server.EXPECT().Send(gomock.Any()).DoAndReturn(func(resp *historyservice.StreamWorkflowReplicationMessagesResponse) error {
+			msgs := resp.GetMessages()
+			s.Equal(enumsspb.TASK_PRIORITY_THROTTLED, msgs.Priority)
+			s.Len(msgs.ReplicationTasks, 1)
+			return nil
+		}),
+		// New anchor beacon for task2 (re-pause point).
+		s.server.EXPECT().Send(gomock.Any()).DoAndReturn(func(resp *historyservice.StreamWorkflowReplicationMessagesResponse) error {
+			msgs := resp.GetMessages()
+			s.Equal(enumsspb.TASK_PRIORITY_THROTTLED, msgs.Priority)
+			s.Equal(int64(150), msgs.ExclusiveHighWatermark)
+			s.Empty(msgs.ReplicationTasks)
+			return nil
+		}),
+	)
+
+	err := s.streamSender.sendThrottledCatchup(110, 200)
+	s.NoError(err)
+	s.Equal(int64(150), s.streamSender.throttledCatchupStart, "catchup start must be updated to the re-pause task ID")
+}
+
 func (s *streamSenderSuite) TestLivenessMonitor() {
 	s.streamSender.recvSignalChan <- struct{}{}
 	livenessMonitor(


### PR DESCRIPTION
This provides namespace isolation for live replication. High watermark and shard ack level will be held back by throttled tasks, as they are live traffic.

Flow control is added so that throttled stream can pause/resume separately from high/low.

## What changed?
_Describe what has changed in this PR._

## Why?
_Tell your future self why have you made these changes._

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
