### PR TITLE
Support file scheme for JWT key provider

### DIFF
--- a/common/authorization/default_token_key_provider.go
+++ b/common/authorization/default_token_key_provider.go
@@ -4,8 +4,12 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -15,7 +19,6 @@ import (
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
-	"go.uber.org/multierr"
 )
 
 // Default token key provider
@@ -138,17 +141,16 @@ func (a *defaultTokenKeyProvider) updateKeysFromURI(
 	ecKeys map[string]*ecdsa.PublicKey,
 ) (err error) {
 
-	resp, err := http.Get(uri)
+	resp, err := a.openURI(uri)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		err = multierr.Combine(err, resp.Body.Close())
+		err = errors.Join(err, resp.Close())
 	}()
 
 	jwks := jose.JSONWebKeySet{}
-	err = json.NewDecoder(resp.Body).Decode(&jwks)
-	if err != nil {
+	if err := json.NewDecoder(resp).Decode(&jwks); err != nil {
 		return err
 	}
 
@@ -163,6 +165,25 @@ func (a *defaultTokenKeyProvider) updateKeysFromURI(
 		}
 	}
 	return nil
+}
+
+// openURI returns a ReadCloser for the given URI. Supports http://, https://, and file:// schemes.
+func (a *defaultTokenKeyProvider) openURI(uri string) (io.ReadCloser, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme == "file" {
+		if u.Host != "" && u.Host != "localhost" {
+			return nil, fmt.Errorf("file URI with remote host is not supported: %s", uri)
+		}
+		return os.Open(u.Path)
+	}
+	resp, err := http.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
 }
 
 func (a *defaultTokenKeyProvider) HmacKey(alg string, kid string) ([]byte, error) {

--- a/common/authorization/default_token_key_provider_test.go
+++ b/common/authorization/default_token_key_provider_test.go
@@ -1,0 +1,51 @@
+package authorization
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+)
+
+func TestOpenURI_FileScheme(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"keys":[]}`), 0644))
+
+	provider := &defaultTokenKeyProvider{logger: log.NewNoopLogger()}
+
+	r, err := provider.openURI("file://" + path)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+}
+
+func TestOpenURI_FileScheme_Localhost(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"keys":[]}`), 0644))
+
+	provider := &defaultTokenKeyProvider{logger: log.NewNoopLogger()}
+
+	r, err := provider.openURI("file://localhost" + path)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+}
+
+func TestOpenURI_FileScheme_RemoteHost(t *testing.T) {
+	provider := &defaultTokenKeyProvider{logger: log.NewNoopLogger()}
+
+	_, err := provider.openURI("file://remotehost/tmp/test.json")
+	require.ErrorContains(t, err, "remote host")
+}
+
+func TestOpenURI_FileScheme_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.json")
+
+	provider := &defaultTokenKeyProvider{logger: log.NewNoopLogger()}
+
+	_, err := provider.openURI("file://" + path)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What changed?
Add `file://` URI support to `jwtKeyProvider.keySourceURIs`, so JWKS can be loaded directly from disk without running an HTTP server.

## Why?
Easier to test JWT key provider locally, when you don't need to spin up a sidecar HTTP server.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Safe, as this is an additive change and http.Get would have failed on file:// schema with `unsupported protocol scheme "file"`. 
