### PR TITLE
Ignore duplication of terminate requests for standalone activity

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -383,14 +383,6 @@ func (a *Activity) Terminate(
 ) (chasm.TerminateComponentResponse, error) {
 	// If already in terminated state, fail if request ID is different, else no-op
 	if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_TERMINATED {
-		newReqID := req.RequestID
-		existingReqID := a.GetTerminateState().GetRequestId()
-
-		if existingReqID != newReqID {
-			return chasm.TerminateComponentResponse{}, serviceerror.NewFailedPrecondition(
-				fmt.Sprintf("already terminated with request ID %s", existingReqID))
-		}
-
 		return chasm.TerminateComponentResponse{}, nil
 	}
 

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -1935,7 +1935,7 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 
 	})
 
-	t.Run("DuplicateRequestIDSucceeds", func(t *testing.T) {
+	t.Run("TerminateAlreadyTerminatedWithSameRequestID_Fails", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
@@ -1962,7 +1962,39 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 			Reason:     "Test Termination",
 			Identity:   "terminator",
 		})
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+	})
+
+	t.Run("TerminateAlreadyTerminatedWithNoRequestID_Fails", func(t *testing.T) {
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		runID := startResp.RunId
+		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+
+		// First terminate — succeeds
+		_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  s.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Reason:     "Test Termination",
+			Identity:   "terminator",
+		})
 		require.NoError(t, err)
+		s.eventuallyTerminated(ctx, t, activityID, runID)
+
+		// Second terminate (no requestID) — must fail with FailedPrecondition
+		_, err = s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  s.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Reason:     "Duplicate Termination",
+			Identity:   "terminator",
+		})
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
 	})
 
 	t.Run("DifferentRequestIDFails", func(t *testing.T) {
@@ -2231,6 +2263,46 @@ func (s *standaloneActivityTestSuite) TestDelete() {
 		})
 		require.NoError(t, err)
 
+		s.eventuallyDeleted(ctx, t, activityID, runID)
+	})
+
+	t.Run("DeleteTerminatedActivity_AfterFailedTerminate_Succeeds", func(t *testing.T) {
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
+		runID := startResp.RunId
+		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
+
+		// Terminate the activity
+		_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  s.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Reason:     "First termination",
+			Identity:   "terminator",
+		})
+		require.NoError(t, err)
+		s.eventuallyTerminated(ctx, t, activityID, runID)
+
+		// A second terminate would fail for the user...
+		_, secondTermErr := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
+			Namespace:  s.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+			Reason:     "Duplicate termination",
+			Identity:   "terminator",
+		})
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, secondTermErr, &failedPreconditionErr)
+
+		// ...but delete should still succeed
+		_, err = s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
+			Namespace:  s.Namespace().String(),
+			ActivityId: activityID,
+			RunId:      runID,
+		})
+		require.NoError(t, err)
 		s.eventuallyDeleted(ctx, t, activityID, runID)
 	})
 

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -2265,46 +2265,6 @@ func (s *standaloneActivityTestSuite) TestDelete() {
 		s.eventuallyDeleted(ctx, t, activityID, runID)
 	})
 
-	t.Run("DeleteTerminatedActivity_AfterFailedTerminate_Succeeds", func(t *testing.T) {
-		activityID := testcore.RandomizeStr(t.Name())
-		taskQueue := testcore.RandomizeStr(t.Name())
-
-		startResp := s.startAndValidateActivity(ctx, t, activityID, taskQueue)
-		runID := startResp.RunId
-		s.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, runID)
-
-		// Terminate the activity
-		_, err := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      runID,
-			Reason:     "First termination",
-			Identity:   "terminator",
-		})
-		require.NoError(t, err)
-		s.eventuallyTerminated(ctx, t, activityID, runID)
-
-		// A second terminate would fail for the user...
-		_, secondTermErr := s.FrontendClient().TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      runID,
-			Reason:     "Duplicate termination",
-			Identity:   "terminator",
-		})
-		var failedPreconditionErr *serviceerror.FailedPrecondition
-		require.ErrorAs(t, secondTermErr, &failedPreconditionErr)
-
-		// ...but delete should still succeed
-		_, err = s.FrontendClient().DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-			Namespace:  s.Namespace().String(),
-			ActivityId: activityID,
-			RunId:      runID,
-		})
-		require.NoError(t, err)
-		s.eventuallyDeleted(ctx, t, activityID, runID)
-	})
-
 	t.Run("DeleteCancelRequestedActivity", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())

--- a/tests/standalone_activity_test.go
+++ b/tests/standalone_activity_test.go
@@ -1935,7 +1935,7 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 
 	})
 
-	t.Run("TerminateAlreadyTerminatedWithSameRequestID_Fails", func(t *testing.T) {
+	t.Run("DuplicateRequestIDSucceeds", func(t *testing.T) {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
@@ -1962,8 +1962,7 @@ func (s *standaloneActivityTestSuite) TestTerminate() {
 			Reason:     "Test Termination",
 			Identity:   "terminator",
 		})
-		var failedPreconditionErr *serviceerror.FailedPrecondition
-		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.NoError(t, err)
 	})
 
 	t.Run("TerminateAlreadyTerminatedWithNoRequestID_Fails", func(t *testing.T) {


### PR DESCRIPTION
## What changed?
Remove duplication check on the `Activity.Terminate`, add a functional test to verify Deleting a terminated activity succeeds.

## Why?
Delete needs to ignore the terminate error.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [X] added new functional test(s)

## Potential risks
No