### PR TITLE
Add NewNilLibrary to scheduler for registration-only contexts

### DIFF
--- a/chasm/lib/scheduler/library.go
+++ b/chasm/lib/scheduler/library.go
@@ -21,6 +21,12 @@ type (
 	}
 )
 
+// NewNilLibrary creates a Library with all nil executors. Useful for
+// registration-only contexts like tdbg where no task execution is needed.
+func NewNilLibrary() *Library {
+	return &Library{}
+}
+
 func NewLibrary(
 	handler *handler,
 	SchedulerIdleTaskExecutor *SchedulerIdleTaskExecutor,

--- a/tools/tdbg/chasm_registry.go
+++ b/tools/tdbg/chasm_registry.go
@@ -19,7 +19,7 @@ func newChasmRegistry(logger log.Logger) (*chasm.Registry, error) {
 		return nil, err
 	}
 
-	if err := registry.Register(chasmscheduler.NewLibrary(nil, nil, nil, nil, nil, nil, nil)); err != nil {
+	if err := registry.Register(chasmscheduler.NewNilLibrary()); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
- Adds `NewNilLibrary()` constructor to the scheduler package that returns a `Library` with all nil executors
- Updates tdbg to use `NewNilLibrary()` instead of `NewLibrary(nil, nil, ...)`, avoiding breakage when new task executors are added

## Test plan
- [x] `go build ./tools/tdbg/ ./chasm/lib/scheduler/` passes