### PR TITLE
Fix `TestInactiveChannelDeletionRace` to not hang for 15 minutes

### DIFF
--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -523,12 +523,19 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestInactiveChannelDeletio
 			ChannelWeightFn:       func(key int) int { return s.channelKeyToWeight[key] },
 			ChannelWeightUpdateCh: s.channelWeightUpdateCh,
 			InactiveChannelDeletionDelay: func() time.Duration {
-				return 0 // Setting cleanup delay to 0 to continuously delete channels.
+				// Use a small positive delay (not 0) so that cleanupLoop blocks on the
+				// timer channel instead of spinning in a tight loop. Cleanup is triggered
+				// by advancing the fake time source below.
+				return time.Nanosecond
 			},
 		},
 		Scheduler[*testTask](s.mockFIFOScheduler),
 		log.NewTestLogger(),
 	)
+	// Use the suite's EventTimeSource so cleanup timers only fire when we
+	// explicitly advance fake time, preventing the cleanup goroutine from
+	// spinning in a tight loop with a real-time zero-duration timer.
+	s.scheduler.ts = s.ts
 	s.mockFIFOScheduler.EXPECT().Start()
 	s.scheduler.Start()
 	s.mockFIFOScheduler.EXPECT().Stop()
@@ -554,20 +561,28 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestInactiveChannelDeletio
 		taskWG.Add(1)
 		s.scheduler.Submit(mockTask0)
 		taskWG.Wait()
+		// Advance past the 1ns delay to trigger cleanup asynchronously, creating
+		// a concurrent race between cleanup and the next Submit call.
+		s.ts.Advance(2 * time.Nanosecond)
 
 		taskWG.Add(1)
 		s.scheduler.Submit(mockTask1)
 		taskWG.Wait()
+		s.ts.Advance(2 * time.Nanosecond)
 
 		taskWG.Add(1)
 		s.scheduler.Submit(mockTask2)
 		taskWG.Wait()
+		s.ts.Advance(2 * time.Nanosecond)
 
 		taskWG.Add(1)
 		s.scheduler.Submit(mockTask3)
 		taskWG.Wait()
+		s.ts.Advance(2 * time.Nanosecond)
 	}
 
+	// Trigger a final cleanup and give the cleanup goroutine time to run.
+	s.ts.Advance(2 * time.Nanosecond)
 	time.Sleep(100 * time.Millisecond) //nolint:forbidigo
 	s.Empty(s.scheduler.channels())
 }


### PR DESCRIPTION
## What changed?
The test previously used `InactiveChannelDeletionDelay: 0` with the default `RealTimeSource`, and did not assign `s.scheduler.ts = s.ts`. Two changes fix this:

1. Set `s.scheduler.ts = s.ts` to use the suite's `EventTimeSource` instead of `RealTimeSource`
2. Change `InactiveChannelDeletionDelay` from `0` to `time.Nanosecond`, and advance fake time by `2 * time.Nanosecond` after each `taskWG.Wait()` to trigger cleanup asynchronously

## Why?
With `InactiveChannelDeletionDelay: 0` and `RealTimeSource`, `cleanupLoop` called `time.NewTimer(0)` which fires instantly, infinite tight loop that continuously allocated OS timer objects and acquired the scheduler's write lock.

Dispatcher busy-wait: `numInflightTask` is manually set to 1 to force the weighted-dispatch path. This makes `hasRemainingTasks()` permanently true, so `dispatchTasksWithWeight`() never returns to the event loop's select. The dispatcher spins indefinitely.

Sample: https://github.com/temporalio/temporal/actions/runs/23311641483/job/67800610136

## How did you test it?
- [ ] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Unit test changes only
