### PR TITLE
Rename predefinedWhiteList to predefinedAllowList in search attributes

### DIFF
--- a/common/searchattribute/sadefs/constants.go
+++ b/common/searchattribute/sadefs/constants.go
@@ -142,16 +142,16 @@ var (
 		RootRunID:            enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	}
 
-	// predefinedWhiteList contains a subset of predefined Search Attributes (SAs)
+	// predefinedAllowList contains a subset of predefined Search Attributes (SAs)
 	// that are currently allowed for use in production environments. These attributes
 	// are internal and were not originally intended for end-user usage, but may be
 	// in active use by users at the moment.
 	//
 	// The long-term plan is to deprecate and disallow the use of these attributes
 	// once it is confirmed that they are no longer being relied upon in any
-	// production workflows. Until then, this whitelist acts as a temporary allowance
+	// production workflows. Until then, this allow list acts as a temporary allowance
 	// to ensure backward compatibility and avoid breaking existing use cases.
-	predefinedWhiteList = map[string]enumspb.IndexedValueType{
+	predefinedAllowList = map[string]enumspb.IndexedValueType{
 		TemporalChangeVersion:      enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
 		BinaryChecksums:            enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
 		BuildIds:                   enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
@@ -166,7 +166,7 @@ var (
 	}
 
 	// predefined are internal search attributes which are passed and stored in SearchAttributes object together with custom search attributes.
-	// Attributes listed here but not in predefinedWhiteList are considered internal-only and are banned from user-facing usage.
+	// Attributes listed here but not in predefinedAllowList are considered internal-only and are banned from user-facing usage.
 	predefined = map[string]enumspb.IndexedValueType{
 		TemporalChangeVersion: enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
 		BinaryChecksums:       enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
@@ -263,9 +263,9 @@ func Predefined() map[string]enumspb.IndexedValueType {
 	return maps.Clone(predefined)
 }
 
-// PredefinedWhiteList returns a clone of the predefined whitelist search attributes map.
-func PredefinedWhiteList() map[string]enumspb.IndexedValueType {
-	return maps.Clone(predefinedWhiteList)
+// PredefinedAllowList returns a clone of the predefined allow list search attributes map.
+func PredefinedAllowList() map[string]enumspb.IndexedValueType {
+	return maps.Clone(predefinedAllowList)
 }
 
 // Reserved returns a clone of the reserved field names map.

--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -110,11 +110,11 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 			)
 		}
 
-		// Don't allow those SA's that are in predefined but not in predefinedWhiteList to be set by a user
+		// Don't allow those SA's that are in predefined but not in predefinedAllowList to be set by a user
 		predefined := sadefs.Predefined()
 		if _, ok := predefined[saFieldName]; ok {
-			predefinedWhiteList := sadefs.PredefinedWhiteList()
-			if _, ok = predefinedWhiteList[saFieldName]; !ok {
+			predefinedAllowList := sadefs.PredefinedAllowList()
+			if _, ok = predefinedAllowList[saFieldName]; !ok {
 				return serviceerror.NewInvalidArgumentf(
 					"%s attribute can't be set in SearchAttributes", saFieldName,
 				)

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -1708,8 +1708,8 @@ func (s *WorkflowTestSuite) TestStartWorkflowExecution_Invalid_DeploymentSearchA
 		s.ErrorAs(err, &invalidArgument)
 	})
 
-	// These are currently allowed since they are in the predefinedWhiteList. Once it's confirmed that they are not being used,
-	// we can remove them from the predefinedWhiteList.
+	// These are currently allowed since they are in the predefinedAllowList. Once it's confirmed that they are not being used,
+	// we can remove them from the predefinedAllowList.
 	s.Run(sadefs.BatcherUser, func() {
 		request := makeRequest(sadefs.BatcherUser)
 		_, err := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)


### PR DESCRIPTION
## What changed?

- Renamed `predefinedWhiteList` to `predefinedAllowList` in search attributes, updated references

## Why?
- internal discussion, related: https://www.theshelf.com/industry-news/allowlisting-vs-whitelisting/

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure rename of the predefined search-attribute “whitelist” symbol/API to “allow list”, with no functional behavior changes beyond updating call sites and tests.
> 
> **Overview**
> Renames the predefined search-attribute gating map and accessor from `predefinedWhiteList`/`PredefinedWhiteList()` to `predefinedAllowList`/`PredefinedAllowList()`.
> 
> Updates validation logic (`validator.go`) and the workflow tests to use the new naming, keeping the same rule: predefined attributes not in the allow list remain user-settable-blocked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ee18d03d17e44b656a2cab3d14460dca50545b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->