### PR TITLE
Remove NamespaceID from CHASM visibility requests and resolve via namespace registry

### DIFF
--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -175,13 +175,7 @@ func (h *frontendHandler) ListActivityExecutions(
 		pageSize = maxPageSize
 	}
 
-	namespaceID, err := h.namespaceRegistry.GetNamespaceID(namespace.Name(req.GetNamespace()))
-	if err != nil {
-		return nil, err
-	}
-
 	resp, err := chasm.ListExecutions[*Activity, *emptypb.Empty](ctx, &chasm.ListExecutionsRequest{
-		NamespaceID:   namespaceID.String(),
 		NamespaceName: req.GetNamespace(),
 		PageSize:      int(pageSize),
 		NextPageToken: req.GetNextPageToken(),
@@ -233,13 +227,7 @@ func (h *frontendHandler) CountActivityExecutions(
 		return nil, ErrStandaloneActivityDisabled
 	}
 
-	namespaceID, err := h.namespaceRegistry.GetNamespaceID(namespace.Name(req.GetNamespace()))
-	if err != nil {
-		return nil, err
-	}
-
 	resp, err := chasm.CountExecutions[*Activity](ctx, &chasm.CountExecutionsRequest{
-		NamespaceID:   namespaceID.String(),
 		NamespaceName: req.GetNamespace(),
 		Query:         req.GetQuery(),
 	})

--- a/chasm/visibility_manager.go
+++ b/chasm/visibility_manager.go
@@ -42,7 +42,6 @@ type ExecutionInfo[M proto.Message] struct {
 }
 
 type ListExecutionsRequest struct {
-	NamespaceID   string
 	NamespaceName string
 	Query         string
 	PageSize      int
@@ -55,7 +54,6 @@ type ListExecutionsResponse[M proto.Message] struct {
 }
 
 type CountExecutionsRequest struct {
-	NamespaceID   string
 	NamespaceName string
 	Query         string
 }

--- a/common/persistence/visibility/chasm_visibility_manager.go
+++ b/common/persistence/visibility/chasm_visibility_manager.go
@@ -13,6 +13,7 @@ import (
 
 type ChasmVisibilityManager struct {
 	registry      *chasm.Registry
+	nsRegistry    namespace.Registry
 	visibilityMgr manager.VisibilityManager
 }
 
@@ -20,19 +21,22 @@ var _ chasm.VisibilityManager = (*ChasmVisibilityManager)(nil)
 
 func NewChasmVisibilityManager(
 	registry *chasm.Registry,
+	nsRegistry namespace.Registry,
 	visibilityMgr manager.VisibilityManager,
 ) *ChasmVisibilityManager {
 	return &ChasmVisibilityManager{
 		registry:      registry,
+		nsRegistry:    nsRegistry,
 		visibilityMgr: visibilityMgr,
 	}
 }
 
 func ChasmVisibilityManagerProvider(
 	registry *chasm.Registry,
+	nsRegistry namespace.Registry,
 	visibilityMgr manager.VisibilityManager,
 ) chasm.VisibilityManager {
-	return NewChasmVisibilityManager(registry, visibilityMgr)
+	return NewChasmVisibilityManager(registry, nsRegistry, visibilityMgr)
 }
 
 // ListExecutions implements the Engine interface for visibility queries.
@@ -46,9 +50,14 @@ func (e *ChasmVisibilityManager) ListExecutions(
 		return nil, serviceerror.NewInternal("unknown chasm component type: " + archetypeType.String())
 	}
 
+	namespaceID, err := e.nsRegistry.GetNamespaceID(namespace.Name(request.NamespaceName))
+	if err != nil {
+		return nil, err
+	}
+
 	visReq := &manager.ListChasmExecutionsRequest{
 		ArchetypeID:   archetypeID,
-		NamespaceID:   namespace.ID(request.NamespaceID),
+		NamespaceID:   namespaceID,
 		Namespace:     namespace.Name(request.NamespaceName),
 		PageSize:      request.PageSize,
 		NextPageToken: request.NextPageToken,
@@ -69,9 +78,14 @@ func (e *ChasmVisibilityManager) CountExecutions(
 		return nil, serviceerror.NewInternal("unknown chasm component type: " + archetypeType.String())
 	}
 
+	namespaceID, err := e.nsRegistry.GetNamespaceID(namespace.Name(request.NamespaceName))
+	if err != nil {
+		return nil, err
+	}
+
 	visReq := &manager.CountChasmExecutionsRequest{
 		ArchetypeID: archetypeID,
-		NamespaceID: namespace.ID(request.NamespaceID),
+		NamespaceID: namespaceID,
 		Namespace:   namespace.Name(request.NamespaceName),
 		Query:       request.Query,
 	}

--- a/common/persistence/visibility/chasm_visibility_manager_test.go
+++ b/common/persistence/visibility/chasm_visibility_manager_test.go
@@ -26,6 +26,7 @@ type (
 		controller *gomock.Controller
 
 		registry          *chasm.Registry
+		nsRegistry        *namespace.MockRegistry
 		visibilityManager *manager.MockVisibilityManager
 		visibilityMgr     *ChasmVisibilityManager
 	}
@@ -94,8 +95,12 @@ func (s *ChasmVisibilityManagerSuite) SetupTest() {
 
 	s.visibilityManager = manager.NewMockVisibilityManager(s.controller)
 
+	s.nsRegistry = namespace.NewMockRegistry(s.controller)
+	s.nsRegistry.EXPECT().GetNamespaceID(testChasmNamespace).Return(testChasmNamespaceID, nil).AnyTimes()
+
 	s.visibilityMgr = NewChasmVisibilityManager(
 		s.registry,
+		s.nsRegistry,
 		s.visibilityManager,
 	)
 }
@@ -191,7 +196,6 @@ func (s *ChasmVisibilityManagerSuite) TestListExecutions_Success() {
 
 	// Call ListExecutions
 	request := &chasm.ListExecutionsRequest{
-		NamespaceID:   string(testChasmNamespaceID),
 		NamespaceName: string(testChasmNamespace),
 		Query:         query,
 		PageSize:      pageSize,
@@ -269,7 +273,6 @@ func (s *ChasmVisibilityManagerSuite) TestCountExecutions_Success() {
 
 	// Call CountExecutions
 	request := &chasm.CountExecutionsRequest{
-		NamespaceID:   string(testChasmNamespaceID),
 		NamespaceName: string(testChasmNamespace),
 		Query:         query,
 	}
@@ -293,7 +296,6 @@ func (s *ChasmVisibilityManagerSuite) TestListExecutions_InvalidArchetypeType() 
 	invalidType := reflect.TypeFor[struct{ Field string }]()
 
 	request := &chasm.ListExecutionsRequest{
-		NamespaceID:   string(testChasmNamespaceID),
 		NamespaceName: string(testChasmNamespace),
 		Query:         "StartTime > '2024-01-01T00:00:00Z'",
 	}
@@ -315,7 +317,6 @@ func (s *ChasmVisibilityManagerSuite) TestCountExecutions_InvalidArchetypeType()
 	invalidType := reflect.TypeFor[struct{ Field string }]()
 
 	request := &chasm.CountExecutionsRequest{
-		NamespaceID:   string(testChasmNamespaceID),
 		NamespaceName: string(testChasmNamespace),
 		Query:         "StartTime > '2024-01-01T00:00:00Z'",
 	}
@@ -348,7 +349,6 @@ func (s *ChasmVisibilityManagerSuite) TestListExecutions_VisibilityManagerError(
 		})
 
 	request := &chasm.ListExecutionsRequest{
-		NamespaceID:   string(testChasmNamespaceID),
 		NamespaceName: string(testChasmNamespace),
 		Query:         query,
 	}
@@ -382,7 +382,6 @@ func (s *ChasmVisibilityManagerSuite) TestCountExecutions_VisibilityManagerError
 		})
 
 	request := &chasm.CountExecutionsRequest{
-		NamespaceID:   string(testChasmNamespaceID),
 		NamespaceName: string(testChasmNamespace),
 		Query:         query,
 	}
@@ -431,7 +430,9 @@ func (s *ChasmVisibilityManagerSuite) TestListExecutions_WithTaskQueueSearchAttr
 	s.NoError(err)
 
 	visibilityMgr := manager.NewMockVisibilityManager(ctrl)
-	chasmVisMgr := NewChasmVisibilityManager(registry, visibilityMgr)
+	nsRegistry := namespace.NewMockRegistry(ctrl)
+	nsRegistry.EXPECT().GetNamespaceID(testChasmNamespace).Return(testChasmNamespaceID, nil).AnyTimes()
+	chasmVisMgr := NewChasmVisibilityManager(registry, nsRegistry, visibilityMgr)
 
 	ctx := context.Background()
 	query := "TaskQueue = 'my-task-queue'"
@@ -467,7 +468,6 @@ func (s *ChasmVisibilityManagerSuite) TestListExecutions_WithTaskQueueSearchAttr
 
 	// Call ListExecutions
 	request := &chasm.ListExecutionsRequest{
-		NamespaceID:   string(testChasmNamespaceID),
 		NamespaceName: string(testChasmNamespace),
 		Query:         query,
 		PageSize:      pageSize,

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -4652,11 +4652,10 @@ func (wh *WorkflowHandler) listSchedulesChasm(
 	query string,
 ) (_ *workflowservice.ListSchedulesResponse, retError error) {
 	resp, err := chasm.ListExecutions[*chasmscheduler.Scheduler, *schedulepb.ScheduleListInfo](ctx, &chasm.ListExecutionsRequest{
-		NamespaceID:   namespaceID.String(),
+		NamespaceName: namespaceName.String(),
 		PageSize:      int(request.GetMaximumPageSize()),
 		NextPageToken: request.NextPageToken,
 		Query:         query,
-		NamespaceName: namespaceName.String(),
 	})
 	if err != nil {
 		return nil, err
@@ -4783,7 +4782,6 @@ func (wh *WorkflowHandler) countSchedulesChasm(
 	query string,
 ) (*workflowservice.CountSchedulesResponse, error) {
 	resp, err := chasm.CountExecutions[*chasmscheduler.Scheduler](ctx, &chasm.CountExecutionsRequest{
-		NamespaceID:   namespaceID.String(),
 		NamespaceName: namespaceName.String(),
 		Query:         query,
 	})

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -366,10 +366,12 @@ func VisibilityManagerProvider(
 
 func ChasmVisibilityManagerProvider(
 	chasmRegistry *chasm.Registry,
+	nsRegistry namespace.Registry,
 	visibilityManager manager.VisibilityManager,
 ) chasm.VisibilityManager {
 	return visibility.NewChasmVisibilityManager(
 		chasmRegistry,
+		nsRegistry,
 		visibilityManager,
 	)
 }

--- a/tests/chasm_test.go
+++ b/tests/chasm_test.go
@@ -236,7 +236,6 @@ func (s *ChasmTestSuite) TestListExecutions() {
 	s.Eventually(
 		func() bool {
 			resp, err := chasm.ListExecutions[*tests.PayloadStore, *testspb.TestPayloadStore](ctx, &chasm.ListExecutionsRequest{
-				NamespaceID:   string(s.NamespaceID()),
 				NamespaceName: string(s.Namespace()),
 				PageSize:      10,
 				Query:         visQuery,
@@ -290,7 +289,6 @@ func (s *ChasmTestSuite) TestListExecutions() {
 	s.Eventually(
 		func() bool {
 			resp, err := chasm.ListExecutions[*tests.PayloadStore, *testspb.TestPayloadStore](ctx, &chasm.ListExecutionsRequest{
-				NamespaceID:   string(s.NamespaceID()),
 				NamespaceName: string(s.Namespace()),
 				PageSize:      10,
 				Query:         visQuery + " AND PayloadTotalCount > 0",
@@ -321,7 +319,6 @@ func (s *ChasmTestSuite) TestListExecutions() {
 	s.Eventually(
 		func() bool {
 			resp, err := chasm.ListExecutions[*tests.PayloadStore, *testspb.TestPayloadStore](ctx, &chasm.ListExecutionsRequest{
-				NamespaceID:   s.NamespaceID().String(),
 				NamespaceName: s.Namespace().String(),
 				PageSize:      10,
 				Query:         visQuery + " AND ExecutionStatus = 'Completed' AND PayloadTotalCount > 0",
@@ -402,7 +399,6 @@ func (s *ChasmTestSuite) TestCountExecutions_GroupBy() {
 			countResp, err = chasm.CountExecutions[*tests.PayloadStore](
 				ctx,
 				&chasm.CountExecutionsRequest{
-					NamespaceID:   string(s.NamespaceID()),
 					NamespaceName: s.Namespace().String(),
 					Query:         "GROUP BY `ExecutionStatus`",
 				},
@@ -432,7 +428,6 @@ func (s *ChasmTestSuite) TestCountExecutions_GroupBy() {
 	_, err = chasm.CountExecutions[*tests.PayloadStore](
 		ctx,
 		&chasm.CountExecutionsRequest{
-			NamespaceID:   string(s.NamespaceID()),
 			NamespaceName: s.Namespace().String(),
 			Query:         "GROUP BY `PayloadTotalCount`",
 		},
@@ -578,7 +573,6 @@ func (s *ChasmTestSuite) TestPayloadStoreForceDelete() {
 	s.Eventually(
 		func() bool {
 			resp, err := chasm.ListExecutions[*tests.PayloadStore, *testspb.TestPayloadStore](ctx, &chasm.ListExecutionsRequest{
-				NamespaceID:   s.NamespaceID().String(),
 				NamespaceName: s.Namespace().String(),
 				PageSize:      10,
 				Query:         visQuery,
@@ -614,7 +608,6 @@ func (s *ChasmTestSuite) TestDeletePayloadStore_RunningExecution() {
 	s.EventuallyWithT(
 		func(t *assert.CollectT) {
 			resp, err := chasm.ListExecutions[*tests.PayloadStore, *testspb.TestPayloadStore](ctx, &chasm.ListExecutionsRequest{
-				NamespaceID:   s.NamespaceID().String(),
 				NamespaceName: s.Namespace().String(),
 				PageSize:      10,
 				Query:         visQuery,
@@ -641,7 +634,6 @@ func (s *ChasmTestSuite) TestDeletePayloadStore_RunningExecution() {
 	s.EventuallyWithT(
 		func(t *assert.CollectT) {
 			resp, err := chasm.ListExecutions[*tests.PayloadStore, *testspb.TestPayloadStore](ctx, &chasm.ListExecutionsRequest{
-				NamespaceID:   s.NamespaceID().String(),
 				NamespaceName: s.Namespace().String(),
 				PageSize:      10,
 				Query:         visQuery,
@@ -680,7 +672,6 @@ func (s *ChasmTestSuite) TestListExecutions_ExecutionStatusAsAlias() {
 	s.Eventually(
 		func() bool {
 			resp, err := chasm.ListExecutions[*tests.PayloadStore, *testspb.TestPayloadStore](ctx, &chasm.ListExecutionsRequest{
-				NamespaceID:   string(s.NamespaceID()),
 				NamespaceName: string(s.Namespace()),
 				PageSize:      10,
 				Query:         visQuery,
@@ -716,7 +707,6 @@ func (s *ChasmTestSuite) TestListExecutions_ExecutionStatusAsAlias() {
 	s.Eventually(
 		func() bool {
 			resp, err := chasm.ListExecutions[*tests.PayloadStore, *testspb.TestPayloadStore](ctx, &chasm.ListExecutionsRequest{
-				NamespaceID:   string(s.NamespaceID()),
 				NamespaceName: string(s.Namespace()),
 				PageSize:      10,
 				Query:         visQueryCanceled,
@@ -756,7 +746,6 @@ func (s *ChasmTestSuite) TestTaskQueuePreallocatedSearchAttribute() {
 	s.Eventually(
 		func() bool {
 			resp, err := chasm.ListExecutions[*tests.PayloadStore, *testspb.TestPayloadStore](ctx, &chasm.ListExecutionsRequest{
-				NamespaceID:   string(s.NamespaceID()),
 				NamespaceName: string(s.Namespace()),
 				PageSize:      10,
 				Query:         visQuery,
@@ -807,7 +796,6 @@ func (s *ChasmTestSuite) TestMutableStateRebuilder() {
 	s.Eventually(
 		func() bool {
 			resp, err := chasm.ListExecutions[*tests.PayloadStore, *testspb.TestPayloadStore](ctx, &chasm.ListExecutionsRequest{
-				NamespaceID:   string(s.NamespaceID()),
 				NamespaceName: string(s.Namespace()),
 				PageSize:      10,
 				Query:         visQuery,


### PR DESCRIPTION
## What changed?

Move namespace ID resolution from callers into ChasmVisibilityManager by adding a namespace.Registry field. Callers no longer need to resolve and pass namespace IDs when constructing ListExecutionsRequest or CountExecutionsRequest.

## Why?
Easier for callers to use.