### PR TITLE
tentative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@
 
 # Ignoring AI agent files
 .agents/
+**/spec.md
+**/CLAUDE.md


### PR DESCRIPTION
## What changed?
git-ignore
spec.md is not skill.md which describes an action while spec.md is to give clues of the context of complex projects

## Why?
encourage local AI related experiments while won't impact the repo for now
before we decide to make some official AI guide files

---> 
I feel a possible goal is we have official spec.md and claude.md and every pr-merge will update the specs to keep them updated. In this way, cc can naturally work fast. Vibe checking this target myself.
