### PR TITLE
Clone VersioningInfo in MutableStateToGetResponse

### DIFF
--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -414,7 +414,7 @@ func MutableStateToGetResponse(
 		InheritedBuildId:             mutableState.GetInheritedBuildId(),
 		MostRecentWorkerVersionStamp: mostRecentWorkerVersionStamp,
 		TransitionHistory:            transitionhistory.CopyVersionedTransitions(mutableState.GetExecutionInfo().TransitionHistory),
-		VersioningInfo:               mutableState.GetExecutionInfo().VersioningInfo,
+		VersioningInfo:               common.CloneProto(mutableState.GetExecutionInfo().VersioningInfo),
 		TransientOrSpeculativeTasks:  transientOrSpeculativeTasks,
 	}, nil
 }


### PR DESCRIPTION
## What changed?
WISOTT

## Why?
Data race was detected in a [functional test](https://github.com/temporalio/temporal/actions/runs/23487536498/job/68347191553). In the body of the `MutableStateToGetResponse` function is this comment: 
```
	// NOTE: fields of GetMutableStateResponse (returned value of this func)
	// are accessed outside of workflow lock, and, therefore,
	// ***MUST*** be copied by value from mutableState fields.
```
VersioningInfo is a proto pointer so it must be cloned, not aliased. 

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
`common.CloneProto` handles nil safety so very minimal risks
