### PR TITLE
Ignore Unimplemented error for CHASM sentinel path

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3374,9 +3374,14 @@ func (wh *WorkflowHandler) createScheduleWorkflow(
 	// fleet, so it is stable for usage here.
 	if wh.config.EnableChasm(namespaceName.String()) {
 		if err := wh.writeSchedulerCHASMSentinel(ctx, namespaceID.String(), namespaceName.String(), request.ScheduleId); err != nil {
-			// CreateSentinel succeeds idempotently if a sentinel already exists.
-			// An AlreadyExists error means a real CHASM scheduler owns this ID.
-			return nil, err
+			// Ignore unimplemented to avoid issues with mixed brain testing.
+			//
+			// We wouldn't hit this condition in prod, as we wouldn't migrate with the fleet
+			// halfway deployed to the target version.
+			var unimplErr *serviceerror.Unimplemented
+			if !errors.As(err, &unimplErr) {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
## What changed?
- Unimplemented is now ignored in the `CreateSchedule` CHASM sentinel path.

## Why?
- `CreateSentinel` is a new (internal-only) API, and is part of the `CreateSchedule` call path. For mixed brain tests, this presents a problem since the earlier version won't have the operation. 
- In production cases, Unimplemented isn't a concern, as we wouldn't be beginning migration on a half-deployed fleet (== we'd manually verify this). 

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
