### PR TITLE
Update local postgres-backed start command in doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ make start-sqlite-file
 To run with Postgres:
 ```bash
 make install-schema-postgresql
-make start-postgresql
+make start-postgres
 ```
 
 To run with MySQL:


### PR DESCRIPTION
## What changed?

There is no `start-postgresql` target in Makefile, the target is `start-postgres` or `start-postgres12` per the Makefile: https://github.com/temporalio/temporal/blob/main/Makefile#L674-L677.

If reviewers prefer I can use `start-postgres12` directly.

I decided against updating the actual Makefile target in case it's used somewhere I'm not aware of.

## Why?

Keep documentation up-to-date.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
