### PR TITLE
Export OTEL_EXPORTER_OTLP_ENDPOINT=json in OTEL=true path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ ifeq ($(OTEL),true)
 	export OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
 	export OTEL_TRACES_EXPORTER=otlp
 	export TEMPORAL_OTEL_DEBUG=true
+	export TEMPORAL_TEST_DATA_ENCODING=json
 endif
 
 MODULE_ROOT := $(lastword $(shell grep -e "^module " go.mod))


### PR DESCRIPTION
## What changed?

Export OTEL_EXPORTER_OTLP_ENDPOINT=json when OTEL=true in Makefile, per [this comment](https://github.com/temporalio/xray/pull/152#discussion_r2990118942) from @stephanos on https://github.com/temporalio/xray/pull/152

> I think we should instead add `TEMPORAL_TEST_DATA_ENCODING=json` to `OTEL=true` in the Makefile as it's a good option to default to for local dev.
> 
> It would just be great to great to reduce the instructions effectively to run `xray` and `make OTEL=true start`.



## Why?

To allow xray to work against locally built Temporal server without having to explicitly export env vars.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

