### PR TITLE
CODEOWNERS: Update owners for default rule and components package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,10 @@
 /common/tasks/ @temporalio/oss-foundations @temporalio/cgs
 /common/persistence/ @temporalio/oss-foundations @temporalio/oss-matching @temporalio/cgs
 
+# Components
+
+/components/ @temporalio/act @temporalio/nexus
+
 # Proto Definitions
 
 /proto/internal/temporal/server/api/schedule/ @temporalio/act


### PR DESCRIPTION
## What changed?
- Add nexus team to the default rule

## Why?
- Add nexus team to the default rule

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
