### PR TITLE
Migrate workflow_memo_test.go to TestEnv

### DIFF
--- a/tests/workflow_memo_test.go
+++ b/tests/workflow_memo_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -145,8 +147,8 @@ func (s *WorkflowMemoTestSuite) startWithMemoHelper(env *testcore.TestEnv, start
 
 	// verify open visibility
 	var openExecutionInfo *workflowpb.WorkflowExecutionInfo
-	s.Eventually(
-		func() bool {
+	s.EventuallyWithT(
+		func(t *assert.CollectT) {
 			resp, err1 := env.FrontendClient().ListOpenWorkflowExecutions(testcore.NewContext(), &workflowservice.ListOpenWorkflowExecutionsRequest{
 				Namespace:       env.Namespace().String(),
 				MaximumPageSize: 100,
@@ -158,18 +160,13 @@ func (s *WorkflowMemoTestSuite) startWithMemoHelper(env *testcore.TestEnv, start
 					WorkflowId: id,
 				}},
 			})
-			s.NoError(err1)
-			if len(resp.Executions) == 1 {
-				openExecutionInfo = resp.Executions[0]
-				return true
-			}
-			env.Logger.Info("Open WorkflowExecution is not yet visible")
-			return false
+			require.NoError(t, err1)
+			require.Len(t, resp.Executions, 1)
+			openExecutionInfo = resp.Executions[0]
 		},
 		testcore.WaitForESToSettle,
 		100*time.Millisecond,
 	)
-	s.NotNil(openExecutionInfo)
 	s.ProtoEqual(memo, openExecutionInfo.Memo)
 
 	execution := &commonpb.WorkflowExecution{
@@ -202,8 +199,8 @@ func (s *WorkflowMemoTestSuite) startWithMemoHelper(env *testcore.TestEnv, start
 
 	// verify closed visibility
 	var closedExecutionInfo *workflowpb.WorkflowExecutionInfo
-	s.Eventually(
-		func() bool {
+	s.EventuallyWithT(
+		func(t *assert.CollectT) {
 			resp, err1 := env.FrontendClient().ListClosedWorkflowExecutions(testcore.NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{
 				Namespace:       env.Namespace().String(),
 				MaximumPageSize: 100,
@@ -215,18 +212,13 @@ func (s *WorkflowMemoTestSuite) startWithMemoHelper(env *testcore.TestEnv, start
 					WorkflowId: id,
 				}},
 			})
-			s.NoError(err1)
-			if len(resp.Executions) == 1 {
-				closedExecutionInfo = resp.Executions[0]
-				return true
-			}
-			env.Logger.Info("Closed WorkflowExecution is not yet visible")
-			return false
+			require.NoError(t, err1)
+			require.Len(t, resp.Executions, 1)
+			closedExecutionInfo = resp.Executions[0]
 		},
 		testcore.WaitForESToSettle,
 		100*time.Millisecond,
 	)
-	s.NotNil(closedExecutionInfo)
 	s.ProtoEqual(memo, closedExecutionInfo.Memo)
 
 	// verify DescribeWorkflowExecution result: workflow closed and close visibility task completed


### PR DESCRIPTION
## Summary
- Migrate `workflow_memo_test.go` from legacy `FunctionalTestBase` + testify suite to `testcore.NewEnv(t)` pattern
- Replace old `TaskPoller` struct with `s.TaskPoller().PollAndHandleWorkflowTask`
- Remove debug logging and unused imports

## Test plan
- [x] `go test -tags "disable_grpc_modules,test_dep" -run TestWorkflowMemoTestSuite -count=1 -v ./tests/` passes locally