### PR TITLE
CHASM update consistency level

### DIFF
--- a/chasm/engine.go
+++ b/chasm/engine.go
@@ -65,6 +65,25 @@ type DeleteExecutionRequest struct {
 	TerminateComponentRequest
 }
 
+// ConsistencyLevel controls how strictly a [ComponentRef] is validated
+// against the current execution state. Ordered from strongest to loosest.
+type ConsistencyLevel int
+
+const (
+	// ConsistencyLevelExecution is the default. Validates [ComponentRef.executionLastUpdateVT].
+	ConsistencyLevelExecution ConsistencyLevel = iota
+	// ConsistencyLevelComponent validates only [ComponentRef.componentInitialVT].
+	// Use when the token may have been generated before a failover changed the
+	// execution-level VT, but the component itself is still valid on the current branch.
+	ConsistencyLevelComponent
+	// ConsistencyLevelBusinessID skips all [VersionedTransition] checks and matches
+	// by [ComponentRef.componentPath] only. Falls back to the latest open run if the
+	// referenced [ComponentRef.RunID] points to a closed execution.
+	// Use when the original run may have been reset: the operation should target the
+	// same component in the new run, matched by path and deduplicated by request ID.
+	ConsistencyLevelBusinessID
+)
+
 type BusinessIDReusePolicy int
 
 const (
@@ -82,10 +101,11 @@ const (
 )
 
 type TransitionOptions struct {
-	ReusePolicy    BusinessIDReusePolicy
-	ConflictPolicy BusinessIDConflictPolicy
-	RequestID      string
-	Speculative    bool
+	ReusePolicy      BusinessIDReusePolicy
+	ConflictPolicy   BusinessIDConflictPolicy
+	RequestID        string
+	Speculative      bool
+	ConsistencyLevel ConsistencyLevel
 }
 
 type TransitionOption func(*TransitionOptions)
@@ -105,7 +125,7 @@ type TransitionOption func(*TransitionOptions)
 //   - Created: Indicates whether a new execution was actually created. When false,
 //     the execution already existed (based on the [BusinessIDReusePolicy] and
 //     [BusinessIDConflictPolicy] configured via [WithBusinessIDPolicy]), and the
-//     existing execution was returned instead.
+//     existing execution was returned instead.chasm_engine.go:234
 type StartExecutionResult struct {
 	ExecutionKey ExecutionKey
 	ExecutionRef []byte
@@ -169,6 +189,16 @@ func WithRequestID(
 ) TransitionOption {
 	return func(opts *TransitionOptions) {
 		opts.RequestID = requestID
+	}
+}
+
+// WithConsistencyLevel sets the consistency level used when resolving a component reference.
+// See [ConsistencyLevel] for details on each level.
+func WithConsistencyLevel(
+	level ConsistencyLevel,
+) TransitionOption {
+	return func(opts *TransitionOptions) {
+		opts.ConsistencyLevel = level
 	}
 }
 

--- a/chasm/field_test.go
+++ b/chasm/field_test.go
@@ -119,7 +119,7 @@ func (s *fieldSuite) TestFieldGetComponent() {
 
 	chasmContext := NewMutableContext(context.Background(), node)
 
-	c, err := node.Component(chasmContext, ComponentRef{componentPath: rootPath})
+	c, err := node.Component(chasmContext, ComponentRef{componentPath: rootPath}, ConsistencyLevelExecution)
 	s.NoError(err)
 	s.NotNil(c)
 
@@ -216,7 +216,7 @@ func (s *fieldSuite) TestDeferredPointerResolution() {
 
 	// Get components from tree to mark nodes as needing sync.
 
-	rootComponentInterface, err := rootNode.Component(ctx, ComponentRef{})
+	rootComponentInterface, err := rootNode.Component(ctx, ComponentRef{}, ConsistencyLevelExecution)
 	s.NoError(err)
 	rootComponent = rootComponentInterface.(*TestComponent)
 	sc1 = rootComponent.SubComponent1.Get(ctx)
@@ -293,7 +293,7 @@ func (s *fieldSuite) TestMixedPointerScenario() {
 	s.NoError(err)
 
 	// Get components from tree to mark nodes as needing sync.
-	rootComponentInterface, err := rootNode.Component(ctx, ComponentRef{})
+	rootComponentInterface, err := rootNode.Component(ctx, ComponentRef{}, ConsistencyLevelExecution)
 	s.NoError(err)
 	rootComponent = rootComponentInterface.(*TestComponent)
 
@@ -308,7 +308,7 @@ func (s *fieldSuite) TestMixedPointerScenario() {
 	// otherwise those nodes will not be marked as dirty.
 
 	ctx2 := NewMutableContext(context.Background(), rootNode)
-	rootComponentInterface, err = rootNode.Component(ctx2, ComponentRef{})
+	rootComponentInterface, err = rootNode.Component(ctx2, ComponentRef{}, ConsistencyLevelExecution)
 	s.NoError(err)
 
 	rootComponent = rootComponentInterface.(*TestComponent)
@@ -372,7 +372,7 @@ func (s *fieldSuite) TestUnresolvableDeferredPointerError() {
 	s.NoError(err)
 
 	// Get component from tree to mark node as needing sync.
-	rootComponentInterface, err := rootNode.Component(ctx, ComponentRef{})
+	rootComponentInterface, err := rootNode.Component(ctx, ComponentRef{}, ConsistencyLevelExecution)
 	s.NoError(err)
 	rootComponent = rootComponentInterface.(*TestComponent)
 

--- a/chasm/lib/scheduler/backfiller_tasks_test.go
+++ b/chasm/lib/scheduler/backfiller_tasks_test.go
@@ -29,7 +29,7 @@ type backfillTestCase struct {
 
 func runBackfillTestCase(t *testing.T, env *testEnv, c *backfillTestCase) {
 	ctx := env.MutableContext()
-	schedComponent, err := env.Node.Component(ctx, chasm.ComponentRef{})
+	schedComponent, err := env.Node.Component(ctx, chasm.ComponentRef{}, chasm.ConsistencyLevelExecution)
 	require.NoError(t, err)
 	sched := schedComponent.(*scheduler.Scheduler)
 	invoker := sched.Invoker.Get(ctx)
@@ -229,7 +229,7 @@ func TestBackfillTask_PartialFill(t *testing.T) {
 	}
 
 	ctx := env.MutableContext()
-	schedComponent, err := env.Node.Component(ctx, chasm.ComponentRef{})
+	schedComponent, err := env.Node.Component(ctx, chasm.ComponentRef{}, chasm.ConsistencyLevelExecution)
 	require.NoError(t, err)
 	sched := schedComponent.(*scheduler.Scheduler)
 	backfiller := sched.NewRangeBackfiller(ctx, request)
@@ -241,7 +241,7 @@ func TestBackfillTask_PartialFill(t *testing.T) {
 
 	// Backfiller should still exist (not complete).
 	ctx = env.MutableContext()
-	schedComponent, err = env.Node.Component(ctx, chasm.ComponentRef{})
+	schedComponent, err = env.Node.Component(ctx, chasm.ComponentRef{}, chasm.ConsistencyLevelExecution)
 	require.NoError(t, err)
 	sched = schedComponent.(*scheduler.Scheduler)
 	_, ok := sched.Backfillers[backfiller.BackfillId].TryGet(ctx)

--- a/chasm/ref.go
+++ b/chasm/ref.go
@@ -54,6 +54,18 @@ type ComponentRef struct {
 	validationFn func(NodeBackend, Context, Component, *Registry) error
 }
 
+// ResetToBusinessID prepares a ComponentRef for cross-run resolution by clearing all
+// versioned transition fields. After this call, the ref identifies a component solely
+// by its path within the execution tree. The RunID is also cleared so that the framework
+// will resolve the ref against the latest open execution for the business ID.
+// This is used internally when ConsistencyLevelBusinessID is in effect and the original
+// run is closed.
+func (r *ComponentRef) ResetToBusinessID() {
+	r.RunID = ""
+	r.executionLastUpdateVT = nil
+	r.componentInitialVT = nil
+}
+
 // NewComponentRef creates a new ComponentRef with a registered root component go type.
 //
 // In V1, if you don't have a ref,

--- a/chasm/ref_test.go
+++ b/chasm/ref_test.go
@@ -98,3 +98,36 @@ func (s *componentRefSuite) TestSerializeDeserialize() {
 	s.Equal(ref.ExecutionKey, deserializedRef.ExecutionKey)
 	s.Equal(ref.componentPath, deserializedRef.componentPath)
 }
+
+func (s *componentRefSuite) TestResetToBusinessID() {
+	ref := ComponentRef{
+		ExecutionKey: ExecutionKey{
+			NamespaceID: primitives.NewUUID().String(),
+			BusinessID:  primitives.NewUUID().String(),
+			RunID:       primitives.NewUUID().String(),
+		},
+		archetypeID: 42,
+		executionLastUpdateVT: &persistencespb.VersionedTransition{
+			NamespaceFailoverVersion: rand.Int63(),
+			TransitionCount:          rand.Int63(),
+		},
+		componentPath: []string{"root", "child"},
+		componentInitialVT: &persistencespb.VersionedTransition{
+			NamespaceFailoverVersion: rand.Int63(),
+			TransitionCount:          rand.Int63(),
+		},
+	}
+
+	expected := ComponentRef{
+		ExecutionKey: ExecutionKey{
+			NamespaceID: ref.NamespaceID,
+			BusinessID:  ref.BusinessID,
+		},
+		archetypeID:   42,
+		componentPath: []string{"root", "child"},
+	}
+
+	ref.ResetToBusinessID()
+
+	s.Equal(expected, ref)
+}

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -328,7 +328,7 @@ func newTreeInitSearchAttributesAndMemo(
 	registry *Registry,
 ) error {
 	immutableContext := NewContext(context.Background(), root)
-	rootComponent, err := root.Component(immutableContext, ComponentRef{})
+	rootComponent, err := root.Component(immutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	if err != nil {
 		return err
 	}
@@ -402,6 +402,7 @@ func (n *Node) setValueState(state valueState) {
 func (n *Node) Component(
 	chasmContext Context,
 	ref ComponentRef,
+	consistencyLevel ConsistencyLevel,
 ) (Component, error) {
 	// Archetype is already validated before this method is called.
 	// (when the mutable state is loaded, in chasm engine implementation)
@@ -411,11 +412,17 @@ func (n *Node) Component(
 		return nil, errComponentNotFound
 	}
 
-	if ref.componentInitialVT != nil && transitionhistory.Compare(
-		ref.componentInitialVT,
-		node.serializedNode.Metadata.InitialVersionedTransition,
-	) != 0 {
-		return nil, errComponentNotFound
+	switch consistencyLevel {
+	case ConsistencyLevelBusinessID:
+		// Loosest level: skip the initial VT check — the component
+		// is identified by path only (business-level logic handles deduplication).
+	case ConsistencyLevelComponent, ConsistencyLevelExecution:
+		if ref.componentInitialVT != nil && transitionhistory.Compare(
+			ref.componentInitialVT,
+			node.serializedNode.Metadata.InitialVersionedTransition,
+		) != 0 {
+			return nil, errComponentNotFound
+		}
 	}
 
 	validationContext := NewContext(chasmContext.goContext(), node)
@@ -1536,7 +1543,7 @@ func (n *Node) closeTransactionHandleRootLifecycleChange(
 		)
 	}
 
-	rootComponent, err := n.Component(immutableContext, ComponentRef{})
+	rootComponent, err := n.Component(immutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	if err != nil {
 		return false, err
 	}
@@ -1579,7 +1586,7 @@ func (n *Node) closeTransactionForceUpdateVisibility(
 
 	needUpdate := rootLifecycleChanged
 
-	rootComponent, err := n.Component(immutableContext, ComponentRef{})
+	rootComponent, err := n.Component(immutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	if err != nil {
 		return err
 	}
@@ -1628,7 +1635,7 @@ func (n *Node) closeTransactionForceUpdateVisibility(
 		return nil
 	}
 
-	visComponent, err := visibilityNode.Component(immutableContext, ComponentRef{})
+	visComponent, err := visibilityNode.Component(immutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	if err != nil {
 		return err
 	}
@@ -2227,7 +2234,7 @@ func (n *Node) ApplyMutation(
 	// TODO: combine this with the logic in CloseTransactionForceUpdateVisibility
 	// right that force update logic only applies to the active cluster.
 	immutableContext := NewContext(context.TODO(), n)
-	rootComponent, err := n.root().Component(immutableContext, ComponentRef{})
+	rootComponent, err := n.root().Component(immutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	if err != nil {
 		return err
 	}
@@ -2527,17 +2534,31 @@ func (n *Node) IsStateDirty() bool {
 
 func (n *Node) IsStale(
 	ref ComponentRef,
+	consistencyLevel ConsistencyLevel,
 ) error {
-	// The point of this method to access the private executionLastUpdateVT field in componentRef,
-	// and avoid exposing it in the public CHASM interface.
-	if ref.executionLastUpdateVT == nil {
+	switch consistencyLevel {
+	case ConsistencyLevelBusinessID:
+		// Loosest level: skip all VT checks, component is matched by path only.
 		return nil
+	case ConsistencyLevelComponent:
+		// Check only the component's initial VT against transition history.
+		if ref.componentInitialVT == nil {
+			return nil
+		}
+		return transitionhistory.StalenessCheck(
+			n.backend.GetExecutionInfo().TransitionHistory,
+			ref.componentInitialVT,
+		)
+	default:
+		// ConsistencyLevelExecution (strongest): check the execution last update VT.
+		if ref.executionLastUpdateVT == nil {
+			return nil
+		}
+		return transitionhistory.StalenessCheck(
+			n.backend.GetExecutionInfo().TransitionHistory,
+			ref.executionLastUpdateVT,
+		)
 	}
-
-	return transitionhistory.StalenessCheck(
-		n.backend.GetExecutionInfo().TransitionHistory,
-		ref.executionLastUpdateVT,
-	)
 }
 
 func (n *Node) Terminate(
@@ -2552,7 +2573,7 @@ func (n *Node) Terminate(
 	}
 
 	mutableContext := NewMutableContext(context.TODO(), n.root())
-	component, err := n.Component(mutableContext, ComponentRef{})
+	component, err := n.Component(mutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	if err != nil {
 		return err
 	}
@@ -2986,7 +3007,7 @@ func (n *Node) ExecutePureTask(
 	}
 
 	executionContext := NewMutableContext(progressIntentCtx, n)
-	component, err := n.Component(executionContext, ComponentRef{})
+	component, err := n.Component(executionContext, ComponentRef{}, ConsistencyLevelExecution)
 	if err != nil {
 		return false, err
 	}

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -202,7 +202,7 @@ func (s *nodeSuite) TestSerializeNode_ClearSubDataField() {
 	node := s.testComponentTree()
 
 	mutableContext := NewMutableContext(context.Background(), node)
-	component, err := node.Component(mutableContext, ComponentRef{})
+	component, err := node.Component(mutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	s.NoError(err)
 	testComponent := component.(*TestComponent)
 
@@ -490,7 +490,7 @@ func (s *nodeSuite) TestPointerAttributes() {
 		s.NoError(err)
 
 		mutableContext := NewMutableContext(context.Background(), rootNode)
-		component, err := rootNode.Component(mutableContext, ComponentRef{})
+		component, err := rootNode.Component(mutableContext, ComponentRef{}, ConsistencyLevelExecution)
 		s.NoError(err)
 		testComponent := component.(*TestComponent)
 
@@ -514,7 +514,7 @@ func (s *nodeSuite) TestPointerAttributes() {
 		s.NoError(err)
 
 		mutableContext := NewMutableContext(context.Background(), rootNode)
-		component, err := rootNode.Component(mutableContext, ComponentRef{})
+		component, err := rootNode.Component(mutableContext, ComponentRef{}, ConsistencyLevelExecution)
 		s.NoError(err)
 		testComponent := component.(*TestComponent)
 
@@ -535,7 +535,7 @@ func (s *nodeSuite) TestParentPointer_InMemory() {
 	// Additionally also test parentPtr for components inside a map.
 
 	mutableContext := NewMutableContext(context.Background(), node)
-	component, err := node.Component(mutableContext, ComponentRef{})
+	component, err := node.Component(mutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	s.NoError(err)
 	testComponent := component.(*TestComponent)
 
@@ -569,7 +569,7 @@ func (s *nodeSuite) TestParentPointer_FromDB() {
 
 func (s *nodeSuite) assertParentPointer(testComponentNode *Node) {
 	chasmContext := NewContext(context.Background(), testComponentNode)
-	component, err := testComponentNode.Component(chasmContext, ComponentRef{})
+	component, err := testComponentNode.Component(chasmContext, ComponentRef{}, ConsistencyLevelExecution)
 	s.NoError(err)
 	testComponent := component.(*TestComponent)
 
@@ -611,7 +611,7 @@ func (s *nodeSuite) TestSyncSubComponents_DeleteMiddleNode() {
 	node := s.testComponentTree()
 
 	mutableContext := NewMutableContext(context.Background(), node)
-	component, err := node.Component(mutableContext, ComponentRef{})
+	component, err := node.Component(mutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	s.NoError(err)
 	testComponent := component.(*TestComponent)
 
@@ -1638,7 +1638,7 @@ func (s *nodeSuite) TestGetComponent_DetachedNodeBypassesParentValidation() {
 	ref := ComponentRef{
 		componentPath: targetPath,
 	}
-	component, err := root.Component(ctx, ref)
+	component, err := root.Component(ctx, ref, ConsistencyLevelExecution)
 	s.NoError(err)
 	s.NotNil(component)
 }
@@ -1670,7 +1670,7 @@ func (s *nodeSuite) TestGetComponent_ClosedTargetSucceeds() {
 	ref := ComponentRef{
 		componentPath: targetPath,
 	}
-	component, err := root.Component(ctx, ref)
+	component, err := root.Component(ctx, ref, ConsistencyLevelExecution)
 	s.NoError(err)
 	s.NotNil(component)
 }
@@ -1776,7 +1776,7 @@ func (s *nodeSuite) TestGetComponent() {
 			root, err := s.newTestTree(testComponentSerializedNodes())
 			s.NoError(err)
 
-			component, err := root.Component(tc.chasmContextFn(root), tc.ref)
+			component, err := root.Component(tc.chasmContextFn(root), tc.ref, ConsistencyLevelExecution)
 			s.Equal(tc.expectedErr, err)
 
 			node, ok := root.findNode(tc.ref.componentPath)
@@ -1824,7 +1824,7 @@ func (s *nodeSuite) TestRef() {
 	s.NoError(err)
 
 	chasmContext := NewContext(context.Background(), root)
-	rootComponent, err := root.Component(chasmContext, NewComponentRef[*TestComponent](executionKey))
+	rootComponent, err := root.Component(chasmContext, NewComponentRef[*TestComponent](executionKey), ConsistencyLevelExecution)
 	s.NoError(err)
 	testComponent, ok := rootComponent.(*TestComponent)
 	s.True(ok)
@@ -1979,7 +1979,7 @@ func (s *nodeSuite) TestSerializeDeserializeTask() {
 func (s *nodeSuite) TestCloseTransaction_Success() {
 	node := s.testComponentTree()
 	chasmCtx := NewMutableContext(context.Background(), node)
-	tc, err := node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
+	tc, err := node.Component(chasmCtx, ComponentRef{componentPath: rootPath}, ConsistencyLevelExecution)
 	s.NoError(err)
 	tc.(*TestComponent).SubData1 = NewEmptyField[*protoMessageType]()
 	tc.(*TestComponent).ComponentData = &protoMessageType{CreateRequestId: primitives.NewUUID().String()}
@@ -2021,7 +2021,7 @@ func (s *nodeSuite) TestCloseTransaction_LifecycleChange() {
 	node := s.testComponentTree()
 
 	chasmCtx := NewMutableContext(context.Background(), node)
-	_, err := node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
+	_, err := node.Component(chasmCtx, ComponentRef{componentPath: rootPath}, ConsistencyLevelExecution)
 	s.NoError(err)
 	_, err = node.CloseTransaction()
 	s.NoError(err)
@@ -2029,7 +2029,7 @@ func (s *nodeSuite) TestCloseTransaction_LifecycleChange() {
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, s.nodeBackend.LastUpdateWorkflowStatus())
 
 	// Test force terminate case
-	_, err = node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
+	_, err = node.Component(chasmCtx, ComponentRef{componentPath: rootPath}, ConsistencyLevelExecution)
 	s.NoError(err)
 	node.terminated = true
 	_, err = node.CloseTransaction()
@@ -2038,7 +2038,7 @@ func (s *nodeSuite) TestCloseTransaction_LifecycleChange() {
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, s.nodeBackend.LastUpdateWorkflowStatus())
 
 	node.terminated = false
-	tc, err := node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
+	tc, err := node.Component(chasmCtx, ComponentRef{componentPath: rootPath}, ConsistencyLevelExecution)
 	s.NoError(err)
 	tc.(*TestComponent).Complete(chasmCtx)
 	_, err = node.CloseTransaction()
@@ -2046,7 +2046,7 @@ func (s *nodeSuite) TestCloseTransaction_LifecycleChange() {
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED, s.nodeBackend.LastUpdateWorkflowState())
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, s.nodeBackend.LastUpdateWorkflowStatus())
 
-	tc, err = node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
+	tc, err = node.Component(chasmCtx, ComponentRef{componentPath: rootPath}, ConsistencyLevelExecution)
 	s.NoError(err)
 	tc.(*TestComponent).Fail(chasmCtx)
 	_, err = node.CloseTransaction()
@@ -2059,7 +2059,7 @@ func (s *nodeSuite) TestCloseTransaction_ForceUpdateVisibility_RootLifecycleChan
 	node := s.testComponentTree()
 
 	chasmCtx := NewMutableContext(context.Background(), node)
-	testComponent, err := node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
+	testComponent, err := node.Component(chasmCtx, ComponentRef{componentPath: rootPath}, ConsistencyLevelExecution)
 	s.NoError(err)
 
 	nextTransitionCount := int64(1)
@@ -2082,7 +2082,7 @@ func (s *nodeSuite) TestCloseTransaction_ForceUpdateVisibility_RootLifecycleChan
 	// Change ComponentData which is used as Memo. Even though lifecycle didn't change,
 	// visibility should be updated because memo changed.
 	nextTransitionCount = 2
-	testComponent, err = node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
+	testComponent, err = node.Component(chasmCtx, ComponentRef{componentPath: rootPath}, ConsistencyLevelExecution)
 	s.NoError(err)
 	testComponent.(*TestComponent).ComponentData = &protoMessageType{
 		CreateRequestId: "some-updated-component-data",
@@ -2099,7 +2099,7 @@ func (s *nodeSuite) TestCloseTransaction_ForceUpdateVisibility_RootLifecycleChan
 	// Close the run, visibility should be force updated
 	// even if not explicitly updated.
 	nextTransitionCount = 3
-	testComponent, err = node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
+	testComponent, err = node.Component(chasmCtx, ComponentRef{componentPath: rootPath}, ConsistencyLevelExecution)
 	s.NoError(err)
 	testComponent.(*TestComponent).Complete(chasmCtx)
 	s.nodeBackend.HandleUpdateWorkflowStateStatus = func(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) (bool, error) {
@@ -2115,7 +2115,7 @@ func (s *nodeSuite) TestCloseTransaction_ForceUpdateVisibility_RootLifecycleChan
 func (s *nodeSuite) TestCloseTransaction_ForceUpdateVisibility_RootSAMemoChanged() {
 	node := s.testComponentTree()
 	chasmCtx := NewMutableContext(context.Background(), node)
-	testComponent, err := node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
+	testComponent, err := node.Component(chasmCtx, ComponentRef{componentPath: rootPath}, ConsistencyLevelExecution)
 	s.NoError(err)
 
 	nextTransitionCount := int64(1)
@@ -2137,7 +2137,7 @@ func (s *nodeSuite) TestCloseTransaction_ForceUpdateVisibility_RootSAMemoChanged
 	// Update root component state, which results in a change to the search attributes and memo.
 	// CHASM framework should automatically detect the change and generate a visibility task.
 	nextTransitionCount = 2
-	testComponent, err = node.Component(chasmCtx, ComponentRef{componentPath: rootPath})
+	testComponent, err = node.Component(chasmCtx, ComponentRef{componentPath: rootPath}, ConsistencyLevelExecution)
 	s.NoError(err)
 	testComponent.(*TestComponent).ComponentData = &protoMessageType{
 		StartTime: timestamppb.Now(),
@@ -2237,7 +2237,7 @@ func (s *nodeSuite) TestCloseTransaction_InvalidateComponentTasks() {
 
 	// The idea is to mark the node as dirty by accessing it with a mutable context.
 	mutableContext := NewMutableContext(context.Background(), root)
-	_, err = root.Component(mutableContext, ComponentRef{})
+	_, err = root.Component(mutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	s.NoError(err)
 
 	s.testLibrary.mockSideEffectTaskHandler.EXPECT().
@@ -2313,7 +2313,7 @@ func (s *nodeSuite) TestCloseTransaction_NewComponentTasks() {
 	s.NoError(err)
 
 	mutableContext := NewMutableContext(context.Background(), root)
-	c, err := root.Component(mutableContext, ComponentRef{})
+	c, err := root.Component(mutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	s.NoError(err)
 
 	// Add a valid side effect task.
@@ -2649,7 +2649,7 @@ func (s *nodeSuite) TestTerminate() {
 	s.NoError(err)
 
 	mutableContext := NewMutableContext(context.Background(), node)
-	_, err = node.Component(mutableContext, ComponentRef{})
+	_, err = node.Component(mutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	s.NoError(err)
 
 	mutations, err = node.CloseTransaction()
@@ -2739,7 +2739,7 @@ func (s *nodeSuite) testComponentTree() *Node {
 	s.IsType(&TestComponent{}, node.value)
 	s.Equal(valueStateSynced, node.valueState)
 
-	tc, err := node.Component(NewMutableContext(context.Background(), node), ComponentRef{componentPath: rootPath})
+	tc, err := node.Component(NewMutableContext(context.Background(), node), ComponentRef{componentPath: rootPath}, ConsistencyLevelExecution)
 	s.NoError(err)
 	s.Equal(valueStateNeedSyncStructure, node.valueState)
 	// Create subcomponents by assigning fields to TestComponent instance.
@@ -2763,7 +2763,7 @@ func (s *nodeSuite) TestExecuteImmediatePureTask() {
 	// Start a clean transaction.
 
 	mutableContext := NewMutableContext(context.Background(), root)
-	component, err := root.Component(mutableContext, ComponentRef{})
+	component, err := root.Component(mutableContext, ComponentRef{}, ConsistencyLevelExecution)
 	s.NoError(err)
 	testComponent := component.(*TestComponent)
 
@@ -2957,7 +2957,7 @@ func (s *nodeSuite) TestEachPureTask() {
 			[]byte("some-random-data-root"),
 		) {
 			mutableContext := NewMutableContext(context.Background(), root)
-			rootComponent, err := root.Component(mutableContext, ComponentRef{})
+			rootComponent, err := root.Component(mutableContext, ComponentRef{}, ConsistencyLevelExecution)
 			s.NoError(err)
 
 			rootComponent.(*TestComponent).SubComponent2 = NewEmptyField[*TestSubComponent2]()
@@ -2969,7 +2969,7 @@ func (s *nodeSuite) TestEachPureTask() {
 			[]byte("some-random-data-sc11-2"),
 		) {
 			mutableContext := NewMutableContext(context.Background(), root)
-			rootComponent, err := root.Component(mutableContext, ComponentRef{})
+			rootComponent, err := root.Component(mutableContext, ComponentRef{}, ConsistencyLevelExecution)
 			s.NoError(err)
 
 			rootComponent.(*TestComponent).SubComponent1 = NewEmptyField[*TestSubComponent1]()
@@ -3203,7 +3203,7 @@ func (s *nodeSuite) TestExecuteSideEffectTask() {
 				s.NotNil(ref.validationFn)
 
 				// Accessing the Component should trigger the validationFn.
-				_, err := root.Component(chasmContext, ref)
+				_, err := root.Component(chasmContext, ref, ConsistencyLevelExecution)
 				if err != nil {
 					return err
 				}
@@ -3321,7 +3321,7 @@ func (s *nodeSuite) TestExecuteSideEffectDiscardTask() {
 			_ context.Context, ref ComponentRef, _ TaskAttributes, _ *TestDiscardableSideEffectTask,
 		) error {
 			s.NotNil(ref.validationFn)
-			_, err := root.Component(chasmContext, ref)
+			_, err := root.Component(chasmContext, ref, ConsistencyLevelExecution)
 			return err
 		}).Times(1)
 
@@ -3342,7 +3342,7 @@ func (s *nodeSuite) TestExecuteSideEffectDiscardTask() {
 		).DoAndReturn(func(
 			_ context.Context, ref ComponentRef, _ TaskAttributes, _ *TestDiscardableSideEffectTask,
 		) error {
-			_, err := root.Component(chasmContext, ref)
+			_, err := root.Component(chasmContext, ref, ConsistencyLevelExecution)
 			return err
 		}).Times(1)
 
@@ -3362,7 +3362,7 @@ func (s *nodeSuite) TestExecuteSideEffectDiscardTask() {
 		).DoAndReturn(func(
 			_ context.Context, ref ComponentRef, _ TaskAttributes, _ *TestDiscardableSideEffectTask,
 		) error {
-			_, err := root.Component(chasmContext, ref)
+			_, err := root.Component(chasmContext, ref, ConsistencyLevelExecution)
 			return err
 		}).Times(1)
 
@@ -3390,7 +3390,7 @@ func (s *nodeSuite) TestExecuteSideEffectDiscardTask() {
 			_ context.Context, ref ComponentRef, _ TaskAttributes, _ *TestDiscardableSideEffectTask,
 		) error {
 			s.NotNil(ref.validationFn)
-			if _, err := root.Component(chasmContext, ref); err != nil {
+			if _, err := root.Component(chasmContext, ref, ConsistencyLevelExecution); err != nil {
 				return err
 			}
 			return discardErr
@@ -3537,6 +3537,131 @@ func (s *nodeSuite) TestAndAllChildren_PathIndependence() {
 	// because append reused the backing array at depth 3→4.
 	s.Equal([]string{"A", "B", "C", "S1"}, collected["S1"])
 	s.Equal([]string{"A", "B", "C", "S2"}, collected["S2"])
+}
+
+func (s *nodeSuite) TestIsStale_ConsistencyLevels() {
+	// Transition history: failover version 1 with transitions 1-5,
+	// then failover version 2 with transitions 6-8.
+	transitionHistory := []*persistencespb.VersionedTransition{
+		{NamespaceFailoverVersion: 1, TransitionCount: 5},
+		{NamespaceFailoverVersion: 2, TransitionCount: 8},
+	}
+	s.nodeBackend = &MockNodeBackend{
+		HandleGetExecutionInfo: func() *persistencespb.WorkflowExecutionInfo {
+			return &persistencespb.WorkflowExecutionInfo{
+				TransitionHistory: transitionHistory,
+			}
+		},
+	}
+
+	root, err := s.newTestTree(testComponentSerializedNodes())
+	s.NoError(err)
+
+	validExecVT := &persistencespb.VersionedTransition{NamespaceFailoverVersion: 2, TransitionCount: 7}
+	staleExecVT := &persistencespb.VersionedTransition{NamespaceFailoverVersion: 3, TransitionCount: 1}
+	validComponentVT := &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 3}
+	staleComponentVT := &persistencespb.VersionedTransition{NamespaceFailoverVersion: 3, TransitionCount: 1}
+
+	testCases := []struct {
+		name             string
+		consistencyLevel ConsistencyLevel
+		ref              ComponentRef
+		expectErr        bool
+	}{
+		{
+			name:             "Execution - valid exec VT",
+			consistencyLevel: ConsistencyLevelExecution,
+			ref:              ComponentRef{executionLastUpdateVT: validExecVT, componentInitialVT: validComponentVT},
+		},
+		{
+			name:             "Execution - stale exec VT",
+			consistencyLevel: ConsistencyLevelExecution,
+			ref:              ComponentRef{executionLastUpdateVT: staleExecVT, componentInitialVT: validComponentVT},
+			expectErr:        true,
+		},
+		{
+			name:             "Execution - nil exec VT",
+			consistencyLevel: ConsistencyLevelExecution,
+			ref:              ComponentRef{},
+		},
+		{
+			name:             "Component - stale exec VT but valid component VT",
+			consistencyLevel: ConsistencyLevelComponent,
+			ref:              ComponentRef{executionLastUpdateVT: staleExecVT, componentInitialVT: validComponentVT},
+		},
+		{
+			name:             "Component - stale component VT",
+			consistencyLevel: ConsistencyLevelComponent,
+			ref:              ComponentRef{executionLastUpdateVT: staleExecVT, componentInitialVT: staleComponentVT},
+			expectErr:        true,
+		},
+		{
+			name:             "Component - nil component VT",
+			consistencyLevel: ConsistencyLevelComponent,
+			ref:              ComponentRef{},
+		},
+		{
+			name:             "BusinessID - both VTs stale",
+			consistencyLevel: ConsistencyLevelBusinessID,
+			ref:              ComponentRef{executionLastUpdateVT: staleExecVT, componentInitialVT: staleComponentVT},
+		},
+		{
+			name:             "BusinessID - nil VTs",
+			consistencyLevel: ConsistencyLevelBusinessID,
+			ref:              ComponentRef{},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			err := root.IsStale(tc.ref, tc.consistencyLevel)
+			if tc.expectErr {
+				s.Error(err)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *nodeSuite) TestGetComponent_ConsistencyLevelBusinessID() {
+	root, err := s.newTestTree(testComponentSerializedNodes())
+	s.NoError(err)
+
+	chasmContext := NewMutableContext(
+		newContextWithOperationIntent(context.Background(), OperationIntentProgress),
+		root,
+	)
+
+	s.Run("matches component by path only, ignoring mismatched initial VT", func() {
+		ref := ComponentRef{
+			componentPath: []string{"SubComponent1"},
+			// Intentionally wrong VT — would fail at ConsistencyLevelExecution/Component.
+			componentInitialVT: &persistencespb.VersionedTransition{
+				NamespaceFailoverVersion: 99,
+				TransitionCount:          99,
+			},
+		}
+
+		// With ConsistencyLevelExecution, this should fail due to VT mismatch.
+		_, err := root.Component(chasmContext, ref, ConsistencyLevelExecution)
+		s.Equal(errComponentNotFound, err)
+
+		// With ConsistencyLevelBusinessID, the VT mismatch is ignored.
+		component, err := root.Component(chasmContext, ref, ConsistencyLevelBusinessID)
+		s.NoError(err)
+		s.NotNil(component)
+		_, ok := component.(*TestSubComponent1)
+		s.True(ok)
+	})
+
+	s.Run("still fails when path does not exist", func() {
+		ref := ComponentRef{
+			componentPath: []string{"nonexistent"},
+		}
+		_, err := root.Component(chasmContext, ref, ConsistencyLevelBusinessID)
+		s.Equal(errComponentNotFound, err)
+	})
 }
 
 func (s *nodeSuite) newTestTree(

--- a/service/history/chasm_engine.go
+++ b/service/history/chasm_engine.go
@@ -234,7 +234,7 @@ func (e *ChasmEngine) updateWithStartExecution(
 		return chasm.EngineUpdateWithStartExecutionResult{}, serviceerror.NewUnimplemented("setting runID is not supported for UpdateWithStartExecution")
 	}
 
-	_, executionLease, err := e.getExecutionLease(ctx, executionRef)
+	_, executionLease, err := e.getExecutionLease(ctx, &executionRef, chasm.ConsistencyLevelExecution)
 	switch err.(type) {
 	case nil:
 		defer func() {
@@ -305,7 +305,7 @@ func (e *ChasmEngine) updateExecution(
 	actualRef := executionRef
 	actualRef.RunID = workflowKey.RunID
 
-	serializedRef, err := e.applyUpdateWithLease(ctx, shardContext, executionLease, actualRef, updateFn)
+	serializedRef, err := e.applyUpdateWithLease(ctx, shardContext, executionLease, actualRef, updateFn, chasm.ConsistencyLevelExecution)
 	if err != nil {
 		return chasm.ExecutionKey{}, nil, err
 	}
@@ -352,6 +352,7 @@ func (e *ChasmEngine) applyUpdateWithLease(
 	executionLease api.WorkflowLease,
 	ref chasm.ComponentRef,
 	updateFn func(chasm.MutableContext, chasm.Component) error,
+	consistencyLevel chasm.ConsistencyLevel,
 ) ([]byte, error) {
 	mutableState := executionLease.GetMutableState()
 	chasmTree, ok := mutableState.ChasmTree().(*chasm.Node)
@@ -364,7 +365,7 @@ func (e *ChasmEngine) applyUpdateWithLease(
 	}
 
 	mutableContext := chasm.NewMutableContext(ctx, chasmTree)
-	component, err := chasmTree.Component(mutableContext, ref)
+	component, err := chasmTree.Component(mutableContext, ref, consistencyLevel)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +455,7 @@ func (e *ChasmEngine) UpdateComponent(
 	opts ...chasm.TransitionOption,
 ) ([]byte, error) {
 	options := e.constructTransitionOptions(opts...)
-	result, err := e.updateComponent(ctx, ref, updateFn)
+	result, err := e.updateComponent(ctx, ref, updateFn, options.ConsistencyLevel)
 	return result, e.convertError(err, ref, options.RequestID)
 }
 
@@ -462,8 +463,9 @@ func (e *ChasmEngine) updateComponent(
 	ctx context.Context,
 	ref chasm.ComponentRef,
 	updateFn func(chasm.MutableContext, chasm.Component) error,
+	consistencyLevel chasm.ConsistencyLevel,
 ) (updatedRef []byte, retError error) {
-	shardContext, executionLease, err := e.getExecutionLease(ctx, ref)
+	shardContext, executionLease, err := e.getExecutionLease(ctx, &ref, consistencyLevel)
 	if err != nil {
 		return nil, err
 	}
@@ -472,7 +474,7 @@ func (e *ChasmEngine) updateComponent(
 		executionLease.GetReleaseFn()(retError)
 	}()
 
-	return e.applyUpdateWithLease(ctx, shardContext, executionLease, ref, updateFn)
+	return e.applyUpdateWithLease(ctx, shardContext, executionLease, ref, updateFn, consistencyLevel)
 }
 
 // DeleteExecution deletes a CHASM execution. If the execution is still running on the active
@@ -491,7 +493,7 @@ func (e *ChasmEngine) deleteExecution(
 	ref chasm.ComponentRef,
 	request chasm.DeleteExecutionRequest,
 ) (retError error) {
-	shardContext, executionLease, err := e.getExecutionLease(ctx, ref)
+	shardContext, executionLease, err := e.getExecutionLease(ctx, &ref, chasm.ConsistencyLevelExecution)
 	if err != nil {
 		return err
 	}
@@ -562,15 +564,16 @@ func (e *ChasmEngine) ReadComponent(
 	opts ...chasm.TransitionOption,
 ) error {
 	options := e.constructTransitionOptions(opts...)
-	return e.convertError(e.readComponent(ctx, ref, readFn), ref, options.RequestID)
+	return e.convertError(e.readComponent(ctx, ref, readFn, options.ConsistencyLevel), ref, options.RequestID)
 }
 
 func (e *ChasmEngine) readComponent(
 	ctx context.Context,
 	ref chasm.ComponentRef,
 	readFn func(chasm.Context, chasm.Component) error,
+	consistencyLevel chasm.ConsistencyLevel,
 ) error {
-	_, executionLease, err := e.getExecutionLease(ctx, ref)
+	_, executionLease, err := e.getExecutionLease(ctx, &ref, consistencyLevel)
 	if err != nil {
 		return err
 	}
@@ -590,7 +593,7 @@ func (e *ChasmEngine) readComponent(
 	}
 
 	chasmContext := chasm.NewContext(ctx, chasmTree)
-	component, err := chasmTree.Component(chasmContext, ref)
+	component, err := chasmTree.Component(chasmContext, ref, consistencyLevel)
 	if err != nil {
 		return err
 	}
@@ -618,7 +621,7 @@ func (e *ChasmEngine) PollComponent(
 	opts ...chasm.TransitionOption,
 ) ([]byte, error) {
 	options := e.constructTransitionOptions(opts...)
-	result, err := e.pollComponent(ctx, requestRef, monotonicPredicate)
+	result, err := e.pollComponent(ctx, requestRef, monotonicPredicate, options.ConsistencyLevel)
 	return result, e.convertError(err, requestRef, options.RequestID)
 }
 
@@ -626,6 +629,7 @@ func (e *ChasmEngine) pollComponent(
 	ctx context.Context,
 	requestRef chasm.ComponentRef,
 	monotonicPredicate func(chasm.Context, chasm.Component) (bool, error),
+	consistencyLevel chasm.ConsistencyLevel,
 ) (retRef []byte, retError error) {
 
 	var ch <-chan struct{}
@@ -637,13 +641,13 @@ func (e *ChasmEngine) pollComponent(
 	}()
 
 	checkPredicateOrSubscribe := func() ([]byte, error) {
-		_, executionLease, err := e.getExecutionLease(ctx, requestRef)
+		_, executionLease, err := e.getExecutionLease(ctx, &requestRef, consistencyLevel)
 		if err != nil {
 			return nil, err
 		}
 		defer executionLease.GetReleaseFn()(nil) //nolint:revive
 
-		ref, err := e.predicateSatisfied(ctx, monotonicPredicate, requestRef, executionLease)
+		ref, err := e.predicateSatisfied(ctx, monotonicPredicate, requestRef, executionLease, consistencyLevel)
 		if err != nil {
 			return nil, err
 		}
@@ -685,6 +689,7 @@ func (e *ChasmEngine) predicateSatisfied(
 	predicate func(chasm.Context, chasm.Component) (bool, error),
 	ref chasm.ComponentRef,
 	executionLease api.WorkflowLease,
+	consistencyLevel chasm.ConsistencyLevel,
 ) ([]byte, error) {
 	chasmTree, ok := executionLease.GetMutableState().ChasmTree().(*chasm.Node)
 	if !ok {
@@ -696,7 +701,7 @@ func (e *ChasmEngine) predicateSatisfied(
 	}
 
 	chasmContext := chasm.NewContext(ctx, chasmTree)
-	component, err := chasmTree.Component(chasmContext, ref)
+	component, err := chasmTree.Component(chasmContext, ref, consistencyLevel)
 	if err != nil {
 		return nil, err
 	}
@@ -1083,9 +1088,10 @@ func (e *ChasmEngine) getShardContext(
 // supplied component reference.
 func (e *ChasmEngine) getExecutionLease(
 	ctx context.Context,
-	ref chasm.ComponentRef,
+	ref *chasm.ComponentRef,
+	consistencyLevel chasm.ConsistencyLevel,
 ) (historyi.ShardContext, api.WorkflowLease, error) {
-	shardContext, err := e.getShardContext(ref)
+	shardContext, err := e.getShardContext(*ref)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1114,7 +1120,7 @@ func (e *ChasmEngine) getExecutionLease(
 		ctx,
 		nil,
 		func(mutableState historyi.MutableState) bool {
-			err := mutableState.ChasmTree().IsStale(ref)
+			err := mutableState.ChasmTree().IsStale(*ref, consistencyLevel)
 			needReload = errors.Is(err, consts.ErrStaleState)
 			if !needReload {
 				// Reference itself might be stale.
@@ -1143,47 +1149,68 @@ func (e *ChasmEngine) getExecutionLease(
 		return nil, nil, predicateErr
 	}
 
-	if !needReload {
-		return shardContext, executionLease, nil
-	}
-
-	// Mutable state was previously detected as stale and got reloaded,
-	// do a final check to ensure mutable state is not stale after reload.
-	err = executionLease.GetMutableState().ChasmTree().IsStale(ref)
-	if err != nil {
-		logger := log.With(shardContext.GetLogger(),
-			tag.WorkflowNamespaceID(ref.NamespaceID),
-			tag.WorkflowID(ref.BusinessID),
-			tag.WorkflowRunID(ref.RunID),
-		)
-
-		if errors.Is(err, consts.ErrStaleState) {
-			// This could happen when there's a replication lag upon force failover,
-			// and caller is using the reference from the original cluster in the
-			// new cluster before replication catches up.
-			//
-			// This could also happen due to data loss in the database,
-			// but we can't really distinguish the two cases here, so always return
-			// a retryable error here.
-			//
-			// TODO: consider adding a clusterID field to the generated token to distinguish
-			// the two cases.
-			logger.Warn(
-				"stale state after mutable state reload, could due to force namespace failover or data loss",
-				tag.Error(err),
+	if needReload {
+		// Mutable state was previously detected as stale and got reloaded,
+		// do a final check to ensure mutable state is not stale after reload.
+		err = executionLease.GetMutableState().ChasmTree().IsStale(*ref, consistencyLevel)
+		if err != nil {
+			logger := log.With(shardContext.GetLogger(),
+				tag.WorkflowNamespaceID(ref.NamespaceID),
+				tag.WorkflowID(ref.BusinessID),
+				tag.WorkflowRunID(ref.RunID),
 			)
 
-			executionLease.GetReleaseFn()(nil)
-			return nil, nil, serviceerror.NewUnavailablef("stale state, please retry")
-		}
+			if errors.Is(err, consts.ErrStaleState) {
+				// This could happen when there's a replication lag upon force failover,
+				// and caller is using the reference from the original cluster in the
+				// new cluster before replication catches up.
+				//
+				// This could also happen due to data loss in the database,
+				// but we can't really distinguish the two cases here, so always return
+				// a retryable error here.
+				//
+				// TODO: consider adding a clusterID field to the generated token to distinguish
+				// the two cases.
+				logger.Warn(
+					"stale state after mutable state reload, could due to force namespace failover or data loss",
+					tag.Error(err),
+				)
 
-		// Stale reference case is already handled above.
+				executionLease.GetReleaseFn()(nil)
+				return nil, nil, serviceerror.NewUnavailablef("stale state, please retry")
+			}
+
+			// Stale reference case is already handled above.
+			executionLease.GetReleaseFn()(nil)
+			return nil, nil, softassert.UnexpectedInternalErr(
+				logger,
+				"Unexpected stale reference in final execution staleness check",
+				err,
+			)
+		}
+	}
+
+	// For ConsistencyLevelBusinessID: if the referenced run is closed, release its
+	// lease and fall back to the latest open execution for this business ID. The
+	// token carries the original run ID for the fast-path cache hit, but when that
+	// run turns out to be closed we strip VTs and re-resolve.
+	if consistencyLevel == chasm.ConsistencyLevelBusinessID &&
+		!executionLease.GetMutableState().IsWorkflowExecutionRunning() {
 		executionLease.GetReleaseFn()(nil)
-		return nil, nil, softassert.UnexpectedInternalErr(
-			logger,
-			"Unexpected stale reference in final execution staleness check",
-			err,
+		ref.ResetToBusinessID()
+		// ref.RunID has been cleared by ResetToBusinessID, so the consistency checker
+		// will resolve the current run via GetCurrentChasmRunID (fast CDS cache path).
+		newLease, err := consistencyChecker.GetChasmLease(
+			ctx,
+			nil,
+			definition.NewWorkflowKey(ref.NamespaceID, ref.BusinessID, ref.RunID),
+			archetypeID,
+			lockPriority,
 		)
+		if err != nil {
+			return nil, nil, err
+		}
+		return shardContext, newLease, nil
 	}
 
 	return shardContext, executionLease, nil

--- a/service/history/interfaces/chasm_tree.go
+++ b/service/history/interfaces/chasm_tree.go
@@ -47,7 +47,7 @@ type ChasmTree interface {
 		ctx context.Context,
 		task *tasks.ChasmTask,
 	) (bool, error)
-	IsStale(chasm.ComponentRef) error
-	Component(chasm.Context, chasm.ComponentRef) (chasm.Component, error)
+	IsStale(chasm.ComponentRef, chasm.ConsistencyLevel) error
+	Component(chasm.Context, chasm.ComponentRef, chasm.ConsistencyLevel) (chasm.Component, error)
 	ComponentByPath(chasm.Context, []string) (chasm.Component, error)
 }

--- a/service/history/interfaces/chasm_tree_mock.go
+++ b/service/history/interfaces/chasm_tree_mock.go
@@ -131,18 +131,18 @@ func (mr *MockChasmTreeMockRecorder) CloseTransaction() *gomock.Call {
 }
 
 // Component mocks base method.
-func (m *MockChasmTree) Component(arg0 chasm.Context, arg1 chasm.ComponentRef) (chasm.Component, error) {
+func (m *MockChasmTree) Component(arg0 chasm.Context, arg1 chasm.ComponentRef, arg2 chasm.ConsistencyLevel) (chasm.Component, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Component", arg0, arg1)
+	ret := m.ctrl.Call(m, "Component", arg0, arg1, arg2)
 	ret0, _ := ret[0].(chasm.Component)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Component indicates an expected call of Component.
-func (mr *MockChasmTreeMockRecorder) Component(arg0, arg1 any) *gomock.Call {
+func (mr *MockChasmTreeMockRecorder) Component(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Component", reflect.TypeOf((*MockChasmTree)(nil).Component), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Component", reflect.TypeOf((*MockChasmTree)(nil).Component), arg0, arg1, arg2)
 }
 
 // ComponentByPath mocks base method.
@@ -217,17 +217,17 @@ func (mr *MockChasmTreeMockRecorder) IsDirty() *gomock.Call {
 }
 
 // IsStale mocks base method.
-func (m *MockChasmTree) IsStale(arg0 chasm.ComponentRef) error {
+func (m *MockChasmTree) IsStale(arg0 chasm.ComponentRef, arg1 chasm.ConsistencyLevel) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsStale", arg0)
+	ret := m.ctrl.Call(m, "IsStale", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // IsStale indicates an expected call of IsStale.
-func (mr *MockChasmTreeMockRecorder) IsStale(arg0 any) *gomock.Call {
+func (mr *MockChasmTreeMockRecorder) IsStale(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStale", reflect.TypeOf((*MockChasmTree)(nil).IsStale), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStale", reflect.TypeOf((*MockChasmTree)(nil).IsStale), arg0, arg1)
 }
 
 // IsStateDirty mocks base method.

--- a/service/history/workflow/noop_chasm_tree.go
+++ b/service/history/workflow/noop_chasm_tree.go
@@ -68,11 +68,11 @@ func (*noopChasmTree) EachPureTask(
 	return nil
 }
 
-func (*noopChasmTree) IsStale(chasm.ComponentRef) error {
+func (*noopChasmTree) IsStale(chasm.ComponentRef, chasm.ConsistencyLevel) error {
 	return nil
 }
 
-func (*noopChasmTree) Component(chasm.Context, chasm.ComponentRef) (chasm.Component, error) {
+func (*noopChasmTree) Component(chasm.Context, chasm.ComponentRef, chasm.ConsistencyLevel) (chasm.Component, error) {
 	return nil, serviceerror.NewInternal("Component() method invoked on noop CHASM tree")
 }
 


### PR DESCRIPTION
## What changed?

Introduce a `ConsistencyLevel` parameter to control how strictly a `ComponentRef` token is validated against execution state during CHASM operations.

Three levels (strongest to loosest):
- **Execution** (default): validates `executionLastUpdateVT` — full staleness check.
- **Component**: validates only `componentInitialVT` — tolerates execution-level VT changes from failovers as long as the component itself is on the right branch.
- **BusinessID**: skips all VT checks, matches by component path only. If the referenced run is closed, falls back to the latest open execution for the same business ID.

Affected surfaces: `Node.Component()`, `Node.IsStale()`, `ChasmEngine.getExecutionLease()`, and all engine entry points (`UpdateComponent`, `ReadComponent`, `PollComponent`) via `WithConsistencyLevel()` transition option.

## Why?

Nexus callback tokens are generated when a component starts an async operation. By the time the callback arrives, the execution may have undergone a failover (invalidating the execution-level VT) or a reset (creating a new run). Without relaxed consistency levels, these legitimate callbacks would be rejected as stale.

## How did you test it?
- [x] covered by existing tests (all call sites updated to pass `ConsistencyLevelExecution`)
- [x] added new unit test(s): `TestIsStale_ConsistencyLevels`, `TestGetComponent_ConsistencyLevelBusinessID`, `TestResetToBusinessID`

## Potential risks
- `getExecutionLease` now takes `*ComponentRef` (pointer) — it may mutate the ref when `ConsistencyLevelBusinessID` triggers the closed-run fallback. All current callers use local copies, but future callers must be aware of this contract.