### PR TITLE
Add IS NULL / IS NOT NULL support to ListWorkers query engine

### DIFF
--- a/service/matching/workers/worker_query_engine.go
+++ b/service/matching/workers/worker_query_engine.go
@@ -64,11 +64,15 @@ Example query:
 
 Different fields can support different operators.
   - string fields (e.g., WorkerIdentity, HostName, TaskQueue, DeploymentName, BuildId, SdkName, SdkVersion):
-		starts_with, not starts_with
+		=, !=, starts_with, not starts_with, IS NULL, IS NOT NULL
   - time fields (e.g., StartTime, HeartbeatTime):
-		 =, !=, >, >=, <, <=, between
+		 =, !=, >, >=, <, <=, between, IS NULL, IS NOT NULL
   - metric fields (e.g., total_sticky_cache_hit):
 		=, !=, >, >=, <, <=
+
+For string fields, IS NULL matches workers where the field is empty, and IS NOT NULL matches
+workers where the field is non-empty. For time fields, IS NULL matches workers where the
+timestamp is not set.
 
 Returns the list of workers for which the query matches the worker heartbeat, or an error,
 Errors are:
@@ -219,7 +223,7 @@ func (w *workerQueryEngine) evaluateExpression(expr sqlparser.Expr) (bool, error
 	case *sqlparser.RangeCond:
 		return w.evaluateRange(e)
 	case *sqlparser.IsExpr:
-		return false, serviceerror.NewInvalidArgumentf("%s: 'is' expression", notSupportedErrMessage)
+		return w.evaluateIsExpr(e)
 	case *sqlparser.NotExpr:
 		return false, serviceerror.NewInvalidArgumentf("%s: 'not' expression", notSupportedErrMessage)
 	case *sqlparser.FuncExpr:
@@ -252,6 +256,42 @@ func (w *workerQueryEngine) evaluateOr(expr *sqlparser.OrExpr) (bool, error) {
 	}
 	// if left is false, then right must be evaluated
 	return w.evaluateExpression(expr.Right)
+}
+
+func (w *workerQueryEngine) evaluateIsExpr(expr *sqlparser.IsExpr) (bool, error) {
+	if expr == nil {
+		return false, serviceerror.NewInvalidArgumentf("IsExpr input expression cannot be nil")
+	}
+
+	colNameExpr, ok := expr.Expr.(*sqlparser.ColName)
+	if !ok {
+		return false, serviceerror.NewInvalidArgumentf("invalid filter name: %s", sqlparser.String(expr.Expr))
+	}
+	colName := strings.ReplaceAll(sqlparser.String(colNameExpr), "`", "")
+
+	if expr.Operator != sqlparser.IsNullStr && expr.Operator != sqlparser.IsNotNullStr {
+		return false, serviceerror.NewInvalidArgumentf(
+			"%s: 'is' operator %q is not supported; only IS NULL and IS NOT NULL are supported",
+			notSupportedErrMessage, expr.Operator)
+	}
+
+	isNull := expr.Operator == sqlparser.IsNullStr
+
+	if propertyFunc, ok := propertyMapFuncs[colName]; ok {
+		isEmpty := propertyFunc(w.currentWorker) == ""
+		return isEmpty == isNull, nil
+	}
+
+	switch colName {
+	case workerStartTimeColName, workerHeartbeatTimeColName:
+		timeValue, err := w.getTimeValue(colName)
+		if err != nil {
+			return false, err
+		}
+		return timeValue.IsZero() == isNull, nil
+	default:
+		return false, serviceerror.NewInvalidArgumentf("unknown or unsupported worker heartbeat search field: %s", colName)
+	}
 }
 
 func (w *workerQueryEngine) evaluateComparison(expr *sqlparser.ComparisonExpr) (bool, error) {

--- a/service/matching/workers/worker_query_engine_test.go
+++ b/service/matching/workers/worker_query_engine_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	workerpb "go.temporal.io/api/worker/v1"
@@ -347,4 +348,177 @@ func TestActivityInfoMatchEvaluator_SupportedTimeFields(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWorkerQueryEngine_IsNullString(t *testing.T) {
+	hbWithDeployment := &workerpb.WorkerHeartbeat{
+		TaskQueue: "task_queue",
+		DeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
+			DeploymentName: "my-deployment",
+		},
+	}
+	hbWithoutDeployment := &workerpb.WorkerHeartbeat{
+		TaskQueue: "task_queue",
+	}
+
+	engine, err := newWorkerQueryEngine("nsID", fmt.Sprintf("%s IS NULL", workerDeploymentNameColName))
+	require.NoError(t, err)
+
+	match, err := engine.EvaluateWorker(hbWithoutDeployment)
+	require.NoError(t, err)
+	assert.True(t, match, "IS NULL should match when DeploymentName is empty")
+
+	match, err = engine.EvaluateWorker(hbWithDeployment)
+	require.NoError(t, err)
+	assert.False(t, match, "IS NULL should not match when DeploymentName is set")
+}
+
+func TestWorkerQueryEngine_IsNotNullString(t *testing.T) {
+	hbWithDeployment := &workerpb.WorkerHeartbeat{
+		TaskQueue: "task_queue",
+		DeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
+			DeploymentName: "my-deployment",
+		},
+	}
+	hbWithoutDeployment := &workerpb.WorkerHeartbeat{
+		TaskQueue: "task_queue",
+	}
+
+	engine, err := newWorkerQueryEngine("nsID", fmt.Sprintf("%s IS NOT NULL", workerDeploymentNameColName))
+	require.NoError(t, err)
+
+	match, err := engine.EvaluateWorker(hbWithDeployment)
+	require.NoError(t, err)
+	assert.True(t, match, "IS NOT NULL should match when DeploymentName is set")
+
+	match, err = engine.EvaluateWorker(hbWithoutDeployment)
+	require.NoError(t, err)
+	assert.False(t, match, "IS NOT NULL should not match when DeploymentName is empty")
+}
+
+func TestWorkerQueryEngine_IsNullTime(t *testing.T) {
+	startTimeStr := "2023-10-26T14:30:00Z"
+	startTime, err := sqlquery.ConvertToTime(fmt.Sprintf("'%s'", startTimeStr))
+	require.NoError(t, err)
+
+	hbWithTime := &workerpb.WorkerHeartbeat{
+		TaskQueue:     "task_queue",
+		StartTime:     timestamppb.New(startTime),
+		HeartbeatTime: timestamppb.New(startTime),
+	}
+	hbWithoutTime := &workerpb.WorkerHeartbeat{
+		TaskQueue: "task_queue",
+	}
+
+	for _, colName := range []string{workerStartTimeColName, workerHeartbeatTimeColName} {
+		engine, err := newWorkerQueryEngine("nsID", fmt.Sprintf("%s IS NULL", colName))
+		require.NoError(t, err)
+
+		t.Run(fmt.Sprintf("%s matches when not set", colName), func(t *testing.T) {
+			match, err := engine.EvaluateWorker(hbWithoutTime)
+			require.NoError(t, err)
+			assert.True(t, match)
+		})
+
+		t.Run(fmt.Sprintf("%s does not match when set", colName), func(t *testing.T) {
+			match, err := engine.EvaluateWorker(hbWithTime)
+			require.NoError(t, err)
+			assert.False(t, match)
+		})
+	}
+}
+
+func TestWorkerQueryEngine_IsNotNullTime(t *testing.T) {
+	startTimeStr := "2023-10-26T14:30:00Z"
+	startTime, err := sqlquery.ConvertToTime(fmt.Sprintf("'%s'", startTimeStr))
+	require.NoError(t, err)
+
+	hbWithTime := &workerpb.WorkerHeartbeat{
+		TaskQueue:     "task_queue",
+		StartTime:     timestamppb.New(startTime),
+		HeartbeatTime: timestamppb.New(startTime),
+	}
+	hbWithoutTime := &workerpb.WorkerHeartbeat{
+		TaskQueue: "task_queue",
+	}
+
+	for _, colName := range []string{workerStartTimeColName, workerHeartbeatTimeColName} {
+		engine, err := newWorkerQueryEngine("nsID", fmt.Sprintf("%s IS NOT NULL", colName))
+		require.NoError(t, err)
+
+		t.Run(fmt.Sprintf("%s matches when set", colName), func(t *testing.T) {
+			match, err := engine.EvaluateWorker(hbWithTime)
+			require.NoError(t, err)
+			assert.True(t, match)
+		})
+
+		t.Run(fmt.Sprintf("%s does not match when not set", colName), func(t *testing.T) {
+			match, err := engine.EvaluateWorker(hbWithoutTime)
+			require.NoError(t, err)
+			assert.False(t, match)
+		})
+	}
+}
+
+func TestWorkerQueryEngine_IsNullComposite(t *testing.T) {
+	hb := &workerpb.WorkerHeartbeat{
+		TaskQueue: "task_queue",
+		SdkName:   "temporal-go",
+	}
+
+	tests := []struct {
+		name          string
+		query         string
+		expectedMatch bool
+	}{
+		{
+			name:          "IS NOT NULL AND equality, both match",
+			query:         fmt.Sprintf("%s IS NOT NULL AND %s = 'task_queue'", workerSdkNameColName, workerTaskQueueColName),
+			expectedMatch: true,
+		},
+		{
+			name:          "IS NULL OR equality, right matches",
+			query:         fmt.Sprintf("%s IS NULL OR %s = 'task_queue'", workerSdkNameColName, workerTaskQueueColName),
+			expectedMatch: true,
+		},
+		{
+			name:          "IS NULL AND equality, left fails",
+			query:         fmt.Sprintf("%s IS NULL AND %s = 'task_queue'", workerSdkNameColName, workerTaskQueueColName),
+			expectedMatch: false,
+		},
+		{
+			name:          "IS NULL with empty field in composite",
+			query:         fmt.Sprintf("%s IS NULL AND %s IS NOT NULL", workerDeploymentNameColName, workerSdkNameColName),
+			expectedMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine, err := newWorkerQueryEngine("nsID", tt.query)
+			require.NoError(t, err)
+			match, err := engine.EvaluateWorker(hb)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedMatch, match)
+		})
+	}
+}
+
+func TestWorkerQueryEngine_IsNullRejectsUnknownColumn(t *testing.T) {
+	hb := &workerpb.WorkerHeartbeat{TaskQueue: "task_queue"}
+	engine, err := newWorkerQueryEngine("nsID", "UnknownField IS NULL")
+	require.NoError(t, err)
+	_, err = engine.EvaluateWorker(hb)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown or unsupported")
+}
+
+// Only IS NULL and IS NOT NULL are supported; other IS operators (e.g., IS TRUE) should be rejected.
+func TestWorkerQueryEngine_IsExprRejectsUnsupportedOperators(t *testing.T) {
+	hb := &workerpb.WorkerHeartbeat{TaskQueue: "task_queue"}
+	engine, err := newWorkerQueryEngine("nsID", fmt.Sprintf("%s IS TRUE", workerTaskQueueColName))
+	require.NoError(t, err)
+	_, err = engine.EvaluateWorker(hb)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
 }


### PR DESCRIPTION
## What changed?
Added support for `IS NULL` and `IS NOT NULL` operators in the ListWorkers query engine.

- Implemented `evaluateIsExpr` in `worker_query_engine.go` to handle `IS NULL` / `IS NOT NULL` for string and time fields
- For string fields: `IS NULL` matches empty values, `IS NOT NULL` matches non-empty values
- For time fields (`StartTime`, `HeartbeatTime`): `IS NULL` matches when the timestamp is not set
- Unsupported IS operators (`IS TRUE`, etc.) return a clear error
- Updated doc comment with the new supported operators

## Why?
To enable filtering workers by whether a field is set or not (e.g., `DeploymentName IS NULL` to find workers without a deployment).

## How did you test it?
- [x] built
- [x] added new unit test(s)

New tests:
- String field IS NULL / IS NOT NULL (DeploymentName with empty and populated values)
- Time field IS NULL / IS NOT NULL (StartTime, HeartbeatTime with nil and set timestamps)
- Composite queries combining IS NULL with AND/OR
- Error cases: unknown column rejected, unsupported IS operators (e.g., IS TRUE) rejected