### PR TITLE
refactor: migrate UserTimersTestSuite to testcore.NewEnv

### DIFF
--- a/tests/user_timers_test.go
+++ b/tests/user_timers_test.go
@@ -19,15 +19,9 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-func TestUserTimersTestSuite(t *testing.T) {
-	t.Parallel()
-	t.Run("TestUserTimers_Sequential", func(t *testing.T) {
-		s := testcore.NewEnv(t)
-		testUserTimersSequential(s)
-	})
-}
+func TestUserTimersSequential(t *testing.T) {
+	s := testcore.NewEnv(t)
 
-func testUserTimersSequential(s *testcore.TestEnv) {
 	id := "functional-user-timers-sequential-test"
 	wt := "functional-user-timers-sequential-test-type"
 	tl := "functional-user-timers-sequential-test-taskqueue"

--- a/tests/user_timers_test.go
+++ b/tests/user_timers_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/suite"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -20,16 +19,15 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-type UserTimersTestSuite struct {
-	testcore.FunctionalTestBase
-}
-
 func TestUserTimersTestSuite(t *testing.T) {
 	t.Parallel()
-	suite.Run(t, new(UserTimersTestSuite))
+	t.Run("TestUserTimers_Sequential", func(t *testing.T) {
+		s := testcore.NewEnv(t)
+		testUserTimersSequential(s)
+	})
 }
 
-func (s *UserTimersTestSuite) TestUserTimers_Sequential() {
+func testUserTimersSequential(s *testcore.TestEnv) {
 	id := "functional-user-timers-sequential-test"
 	wt := "functional-user-timers-sequential-test-type"
 	tl := "functional-user-timers-sequential-test-taskqueue"

--- a/tests/user_timers_test.go
+++ b/tests/user_timers_test.go
@@ -15,12 +15,21 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-func TestUserTimersSequential(t *testing.T) {
-	s := testcore.NewEnv(t)
+type UserTimersTestSuite struct {
+	parallelsuite.Suite[*UserTimersTestSuite]
+}
+
+func TestUserTimersTestSuite(t *testing.T) {
+	parallelsuite.Run(t, &UserTimersTestSuite{})
+}
+
+func (s *UserTimersTestSuite) TestUserTimersSequential() {
+	env := testcore.NewEnv(s.T())
 
 	id := "functional-user-timers-sequential-test"
 	wt := "functional-user-timers-sequential-test-type"
@@ -29,7 +38,7 @@ func TestUserTimersSequential(t *testing.T) {
 
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
-		Namespace:           s.Namespace().String(),
+		Namespace:           env.Namespace().String(),
 		WorkflowId:          id,
 		WorkflowType:        &commonpb.WorkflowType{Name: wt},
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -39,10 +48,10 @@ func TestUserTimersSequential(t *testing.T) {
 		Identity:            identity,
 	}
 
-	we, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
 	s.NoError(err0)
 
-	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
+	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
 	workflowComplete := false
 	timerCount := int32(4)
@@ -71,19 +80,19 @@ func TestUserTimersSequential(t *testing.T) {
 	}
 
 	poller := &testcore.TaskPoller{
-		Client:              s.FrontendClient(),
-		Namespace:           s.Namespace().String(),
+		Client:              env.FrontendClient(),
+		Namespace:           env.Namespace().String(),
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
 		WorkflowTaskHandler: wtHandler,
 		ActivityTaskHandler: nil,
-		Logger:              s.Logger,
+		Logger:              env.Logger,
 		T:                   s.T(),
 	}
 
 	for range 4 {
 		_, err := poller.PollAndProcessWorkflowTask()
-		s.Logger.Info("PollAndProcessWorkflowTask: completed")
+		env.Logger.Info("PollAndProcessWorkflowTask: completed")
 		s.NoError(err)
 	}
 


### PR DESCRIPTION
Migrate `UserTimersTestSuite` from testify suite + `FunctionalTestBase` to `testcore.NewEnv`.