### PR TITLE
refactor: migrate RelayTaskTestSuite to testcore.NewEnv

### DIFF
--- a/tests/relay_task_test.go
+++ b/tests/relay_task_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/suite"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -16,16 +15,8 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-type RelayTaskTestSuite struct {
-	testcore.FunctionalTestBase
-}
-
-func TestRelayTaskTestSuite(t *testing.T) {
-	t.Parallel()
-	suite.Run(t, new(RelayTaskTestSuite))
-}
-
-func (s *RelayTaskTestSuite) TestRelayWorkflowTaskTimeout() {
+func TestRelayWorkflowTaskTimeout(t *testing.T) {
+	s := testcore.NewEnv(t)
 	id := "functional-relay-workflow-task-timeout-test"
 	wt := "functional-relay-workflow-task-timeout-test-type"
 	tl := "functional-relay-workflow-task-timeout-test-taskqueue"

--- a/tests/relay_task_test.go
+++ b/tests/relay_task_test.go
@@ -11,12 +11,21 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-func TestRelayWorkflowTaskTimeout(t *testing.T) {
-	s := testcore.NewEnv(t)
+type RelayTaskTestSuite struct {
+	parallelsuite.Suite[*RelayTaskTestSuite]
+}
+
+func TestRelayTaskTestSuite(t *testing.T) {
+	parallelsuite.Run(t, &RelayTaskTestSuite{})
+}
+
+func (s *RelayTaskTestSuite) TestRelayWorkflowTaskTimeout() {
+	env := testcore.NewEnv(s.T())
 	id := "functional-relay-workflow-task-timeout-test"
 	wt := "functional-relay-workflow-task-timeout-test-type"
 	tl := "functional-relay-workflow-task-timeout-test-taskqueue"
@@ -25,7 +34,7 @@ func TestRelayWorkflowTaskTimeout(t *testing.T) {
 	// Start workflow execution
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:           uuid.NewString(),
-		Namespace:           s.Namespace().String(),
+		Namespace:           env.Namespace().String(),
 		WorkflowId:          id,
 		WorkflowType:        &commonpb.WorkflowType{Name: wt},
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
@@ -35,9 +44,9 @@ func TestRelayWorkflowTaskTimeout(t *testing.T) {
 		Identity:            identity,
 	}
 
-	we, err0 := s.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	we, err0 := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 	s.NoError(err0)
-	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
+	env.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
 
 	workflowExecution := &commonpb.WorkflowExecution{
 		WorkflowId: id,
@@ -62,13 +71,13 @@ func TestRelayWorkflowTaskTimeout(t *testing.T) {
 	}
 
 	poller := &testcore.TaskPoller{
-		Client:              s.FrontendClient(),
-		Namespace:           s.Namespace().String(),
+		Client:              env.FrontendClient(),
+		Namespace:           env.Namespace().String(),
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		Identity:            identity,
 		WorkflowTaskHandler: wtHandler,
 		ActivityTaskHandler: nil,
-		Logger:              s.Logger,
+		Logger:              env.Logger,
 		T:                   s.T(),
 	}
 
@@ -77,7 +86,7 @@ func TestRelayWorkflowTaskTimeout(t *testing.T) {
 		testcore.WithExpectedAttemptCount(0),
 		testcore.WithRetries(3),
 		testcore.WithForceNewWorkflowTask)
-	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
+	env.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	newTask := res.NewTask
 	s.NotNil(newTask)
@@ -87,7 +96,7 @@ func TestRelayWorkflowTaskTimeout(t *testing.T) {
 	time.Sleep(time.Second * 2) // wait 2s for relay workflow task to timeout
 	workflowTaskTimeout := false
 	for range 3 {
-		events := s.GetHistory(s.Namespace().String(), workflowExecution)
+		events := env.GetHistory(env.Namespace().String(), workflowExecution)
 		if len(events) >= 8 {
 			s.EqualHistoryEvents(`
   1 WorkflowExecutionStarted
@@ -109,7 +118,7 @@ func TestRelayWorkflowTaskTimeout(t *testing.T) {
 
 	// Now complete workflow
 	_, err = poller.PollAndProcessWorkflowTask(testcore.WithDumpHistory, testcore.WithExpectedAttemptCount(2))
-	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
+	env.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	s.True(workflowComplete)


### PR DESCRIPTION
Migrate `RelayTaskTestSuite` from testify suite + `FunctionalTestBase` to `testcore.NewEnv`.