### PR TITLE
refactor: migrate WorkflowTimerTestSuite to parallelsuite

### DIFF
--- a/tests/workflow_timer_test.go
+++ b/tests/workflow_timer_test.go
@@ -45,7 +45,7 @@ func (s *WorkflowTimerTestSuite) TestCancelTimer() {
 		Identity:            identity,
 	}
 
-	creatResp, err0 := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	creatResp, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
 	s.NoError(err0)
 	workflowExecution := &commonpb.WorkflowExecution{
 		WorkflowId: id,
@@ -169,7 +169,7 @@ func (s *WorkflowTimerTestSuite) TestCancelTimer_CancelFiredAndBuffered() {
 		Identity:            identity,
 	}
 
-	creatResp, err0 := env.FrontendClient().StartWorkflowExecution(testcore.NewContext(), request)
+	creatResp, err0 := env.FrontendClient().StartWorkflowExecution(env.Context(), request)
 	s.NoError(err0)
 	workflowExecution := &commonpb.WorkflowExecution{
 		WorkflowId: id,


### PR DESCRIPTION
Migrate `WorkflowTimerTestSuite` from testify suite + `FunctionalTestBase` to `parallelsuite`.